### PR TITLE
Small change to fix some problems with limits.

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -81,7 +81,7 @@ def limit(e, z, z0, dir="+"):
 
 def heuristics(e, z, z0, dir):
     if z0 == oo:
-        return heuristics(e.subs(z, 1/z), z, sympify(0), "+")
+        return limit(e.subs(z, 1/z), z, sympify(0), "+")
     elif e.is_Mul:
         r = []
         for a in e.args:
@@ -95,7 +95,7 @@ def heuristics(e, z, z0, dir):
             r.append(a.limit(z, z0, dir))
         return Add(*r)
     elif e.is_Function:
-        return e.subs(e.args[0], heuristics(e.args[0], z, z0, dir))
+        return e.subs(e.args[0], limit(e.args[0], z, z0, dir))
     msg = "Don't know how to calculate the limit(%s, %s, %s, dir=%s), sorry."
     raise PoleError(msg % (e, z, z0, dir))
 

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,5 +1,5 @@
 from sympy import limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling, \
-        atan, Symbol, S, pi, Integral, cot
+        atan, gamma, Symbol, S, pi, Integral, cot
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import XFAIL
 
@@ -173,3 +173,13 @@ def test_issue2065():
     assert limit(x**0.5, x, 0) == 0
     assert limit(x**(-0.5), x, oo) == 0
     assert limit(x**(-0.5), x, 4) == S(4)**(-0.5)
+
+def test_issue2085():
+    assert limit(sin(x)/x, x, oo) == 0
+    assert limit(atan(x), x, oo) == pi/2
+    assert limit(gamma(x), x, oo) == oo
+
+@XFAIL
+def test_issue2085_unresolved():
+    assert limit(cos(x)/x, x, oo) == 0 # Raises ZeroDivisionError
+    assert limit(gamma(x), x, 1/2) == sqrt(pi) # Raises AssertionError


### PR DESCRIPTION
Fixes a majority of the issues in [2085](http://code.google.com/p/sympy/issues/detail?id=2085). ./setup.py test says the limit portion passes.

```
In [1]: limit(sin(x)/x, x, oo)
Out[1]: 0

In [2]: limit(gamma(x), x, oo)
Out[2]: ∞

In [3]: limit(atan(x), x, oo)
Out[3]: 
π
─
2
```

However, `gamma(x)` with `x` approaching `1/2` still gives the `AssertionError`, and now `cos(x)/x` with `x` approaching `oo` yields a `ZeroDivisionError` (but it gave a `PoleError` previously), so there's probably some deeper issues.

Put the changes on a different branch and explained the fix as per asmeurer's request.
