### PR TITLE
Fixing ZeroDivisionError in cos(x)

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -273,6 +273,8 @@ class cos(Function):
                 return S.NaN
             elif arg is S.Zero:
                 return S.One
+            elif arg is S.Infinity:
+                return
 
         if arg.could_extract_minus_sign():
             return cls(-arg)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -178,8 +178,8 @@ def test_issue2085():
     assert limit(sin(x)/x, x, oo) == 0
     assert limit(atan(x), x, oo) == pi/2
     assert limit(gamma(x), x, oo) == oo
+    assert limit(cos(x)/x, x, oo) == 0
 
 @XFAIL
 def test_issue2085_unresolved():
-    assert limit(cos(x)/x, x, oo) == 0 # Raises ZeroDivisionError
     assert limit(gamma(x), x, 1/2) == sqrt(pi) # Raises AssertionError


### PR DESCRIPTION
I just marked down the commit message:

Fixes the ZeroDivisionError from issue [2085](http://code.google.com/p/sympy/issues/detail?id=2085) which occurs when calling `cos(oo)`. The remedy was simply to add a special case for when the argument is `oo`, as done in `sin`.

Since `limit(cos(x)/x, x, oo)` now yields 0 as expected, this was added to the relevant limit tests.

As a note, all trigonometric tests and (modified) limit tests pass.
