### PR TITLE
_sage_ method for sign function

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -196,6 +196,10 @@ class sign(Function):
     def _eval_is_zero(self):
         return (self.args[0] is S.Zero)
 
+    def _sage_(self):
+        import sage.all as sage
+        return sage.sgn(self.args[0]._sage_())
+
 class abs(Function):
     """Return the absolute value of the argument. This is an extension of the built-in
     function abs to accept symbolic values

--- a/sympy/test_external/test_sage.py
+++ b/sympy/test_external/test_sage.py
@@ -123,6 +123,7 @@ def test_functions():
     check_expression("exp(x)", "x")
     check_expression("log(x)", "x")
     check_expression("abs(x)", "x")
+    check_expression("sign(x)", "x")
 
 def test_issue924():
     sage.var("a x")


### PR DESCRIPTION
This implements the _sage_ method of sign function as proposed here:
http://code.google.com/p/sympy/issues/detail?id=345

I filled a parallel bug to Sage using their notebook form (http://wiki.sagemath.org/support/ReportingBugs), since Sage needs a _sympy_ converter to their sgn function too.
