### PR TITLE
2092 solve4linear symbol -> solve_linear

### DIFF
--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -87,6 +87,7 @@ class Order(Expr):
 
     @cacheit
     def __new__(cls, expr, *symbols, **assumptions):
+
         expr = sympify(expr).expand()
         if expr is S.NaN:
             return S.NaN

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -113,18 +113,15 @@ class Order(Expr):
             if expr.is_Add:
                 lst = expr.extract_leading_order(*symbols)
                 expr = Add(*[f.expr for (e,f) in lst])
-            else:
+            elif expr:
                 expr = expr.as_leading_term(*symbols)
                 coeff, terms = expr.as_coeff_mul()
-                if coeff is S.Zero:
-                    return coeff
                 expr = Mul(*[t for t in terms if t.has(*symbols)])
-
-        elif expr is not S.Zero:
-            expr = S.One
 
         if expr is S.Zero:
             return expr
+        elif not expr.has(*symbols):
+            expr = S.One
 
         # create Order instance:
         symbols.sort(Basic.compare)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -20,6 +20,8 @@ def test_simple_1():
     assert Order(x*exp(1/x)).expr == x*exp(1/x)
     assert Order(x**(o/3)).expr == x**(o/3)
     assert Order(x**(5*o/3)).expr == x**(5*o/3)
+    assert Order(x**2 + x + y, x) == \
+           Order(x**2 + x + y, y) == O(1)
     raises(NotImplementedError, 'Order(x, 2 - x)')
 
 def test_simple_2():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, Rational, Order, C, exp, ln, log, O, var, nan, pi, S, symbols
+from sympy import Symbol, Rational, Order, C, exp, ln, log, O, var, nan, pi, S
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import w, x, y, z
 
@@ -8,7 +8,6 @@ def test_caching_bug():
     e = O(w)
     #and test that this won't raise an exception
     f = O(w**(-1/x/log(3)*log(5)), w)
-
 
 def test_simple_1():
     o = Rational(0)
@@ -21,6 +20,7 @@ def test_simple_1():
     assert Order(x*exp(1/x)).expr == x*exp(1/x)
     assert Order(x**(o/3)).expr == x**(o/3)
     assert Order(x**(5*o/3)).expr == x**(5*o/3)
+    raises(NotImplementedError, 'Order(x, 2 - x)')
 
 def test_simple_2():
     assert Order(2*x)*x == Order(x**2)

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -4,7 +4,7 @@ In [3]: solve(x**5+5*x**4+10*x**3+10*x**2+5*x+1,x)
 Out[3]: [-1]
 """
 from solvers import solve, solve_linear_system, solve_linear_system_LU, \
-    solve_undetermined_coeffs, tsolve, msolve, nsolve
+    solve_undetermined_coeffs, tsolve, msolve, nsolve, solve_linear
 
 from recurr import rsolve, rsolve_poly, rsolve_ratio, rsolve_hyper
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1,6 +1,6 @@
 from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
     sqrt, oo, LambertW, pi, I, sin, asin, Function, diff, Derivative, symbols,
-    S, sympify, var, simplify, Integral, sstr)
+    S, sympify, var, simplify, Integral, sstr, Wild, solve_linear)
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve
@@ -297,3 +297,19 @@ def test_issue626():
     F = x**2 + f(x)**2 - 4*x - 1
     e = F.diff(x)
     assert solve(e, f(x).diff(x)) == [(2-x)/f(x)]
+
+def test_solve_linear():
+    x, y = symbols('xy')
+    w = Wild('w')
+    assert solve_linear(x, x) == (0, 1)
+    assert solve_linear(x, y - 2*x) in [(x, y/3), (y, 3*x)]
+    assert solve_linear(x, y - 2*x, exclude=[x]) ==(y, 3*x)
+    assert solve_linear(3*x - y, 0) in [(x, y/3), (y, 3*x)]
+    assert solve_linear(3*x - y, 0, [x]) == (x, y/3)
+    assert solve_linear(3*x - y, 0, [y]) == (y, 3*x)
+    assert solve_linear(x**2/y, 1) == (y, x**2)
+    assert solve_linear(w, x) in [(w, x), (x, w)]
+    assert solve_linear(cos(x)**2 + sin(x)**2 + 2 + y) == \
+           (y, -2 - cos(x)**2 - sin(x)**2)
+    assert solve_linear(cos(x)**2 + sin(x)**2 + 2 + y, x=[x]) == \
+           (2 + y + cos(x)**2 + sin(x)**2, 1)


### PR DESCRIPTION
Reopening. This is blocking 1694 and is to be reviewed here, not there.

Unused (and unsupported code) in Order was removed and the routine there to solve an expression for a linear symbol was re-written and moved to solvers.py where it will be of use.
