### PR TITLE
make_args

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -9,6 +9,10 @@ class Add(AssocOp):
     is_Add = True
 
     @classmethod
+    def identity(cls):
+        return S.Zero
+
+    @classmethod
     def flatten(cls, seq):
         """
         Takes the sequence "seq" of nested Adds and returns a flatten list.

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -8,9 +8,8 @@ class Add(AssocOp):
 
     is_Add = True
 
-    @classmethod
-    def identity(cls):
-        return S.Zero
+    #identity = S.Zero
+    # cyclic import, so defined in numbers.py
 
     @classmethod
     def flatten(cls, seq):

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -503,9 +503,6 @@ class Add(AssocOp):
             s += x._sage_()
         return s
 
-    def as_Add(self):
-        """Returns `self` as it was `Add` instance. """
-        return list(self.args)
 
 from mul import Mul
 from symbol import Symbol

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -608,7 +608,6 @@ class Expr(Basic, EvalfMixin):
            True
 
         """
-        from sympy.utilities.iterables import make_list
         negative_self = -self
         self_has_minus = (self.extract_multiplicatively(-1) != None)
         negative_self_has_minus = ((negative_self).extract_multiplicatively(-1) != None)
@@ -627,7 +626,7 @@ class Expr(Basic, EvalfMixin):
             elif self.is_Mul:
                 # We choose the one with an odd number of minus signs
                 num, den = self.as_numer_denom()
-                args = (make_list(num, Mul)) + (make_list(den, Mul))
+                args = Mul.make_args(num) + Mul.make_args(den)
                 arg_signs = [arg.could_extract_minus_sign() for arg in args]
                 negative_args = filter(None, arg_signs)
                 return len(negative_args) % 2 == 1
@@ -820,14 +819,6 @@ class Expr(Basic, EvalfMixin):
         if not c.has(x):
             return c,e
         raise ValueError("cannot compute leadterm(%s, %s), got c=%s" % (self, x, c))
-
-    def as_Add(self):
-        """Returns `self` as it was `Add` instance. """
-        return [self]
-
-    def as_Mul(self):
-        """Returns `self` as it was `Mul` instance. """
-        return [self]
 
     def as_Pow(self):
         """Returns `self` as it was `Pow` instance. """

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -20,9 +20,8 @@ class Mul(AssocOp):
 
     is_Mul = True
 
-    @classmethod
-    def identity(cls):
-        return S.One
+    #identity = S.One
+    # cyclic import, so defined in numbers.py
 
     @classmethod
     def flatten(cls, seq):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -21,6 +21,10 @@ class Mul(AssocOp):
     is_Mul = True
 
     @classmethod
+    def identity(cls):
+        return S.One
+
+    @classmethod
     def flatten(cls, seq):
 
         # apply associativity, separate commutative part of seq

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -425,8 +425,6 @@ class Mul(AssocOp):
 
         sums must be a list of instances of Basic.
         """
-        from sympy.utilities.iterables import make_list
-
         L = len(sums)
         if L == 1:
             return sums[0].args
@@ -436,7 +434,7 @@ class Mul(AssocOp):
 
         terms = [Mul(a, b) for a in left for b in right]
         added = Add(*terms)
-        return make_list(added, Add) #it may have collapsed down to one term
+        return Add.make_args(added) #it may have collapsed down to one term
 
     def _eval_expand_basic(self, deep=True, **hints):
         sargs, terms = self.args, []
@@ -960,10 +958,6 @@ class Mul(AssocOp):
         for x in self.args:
             s *= x._sage_()
         return s
-
-    def as_Mul(self):
-        """Returns `self` as it was `Mul` instance. """
-        return list(self.args)
 
 from power import Pow
 from numbers import Real, Integer, Rational

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1800,3 +1800,6 @@ Basic.singleton['Catalan'] = Catalan
 from function import FunctionClass
 from power import Pow, integer_nthroot
 from mul import Mul
+Mul.identity = One()
+from add import Add
+Add.identity = Zero()

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -15,6 +15,9 @@ class AssocOp(Expr):
     (a op b) op c == a op (b op c) == a op b op c.
 
     Base class for Add and Mul.
+
+    This is an abstract base class, concrete derived classes must define
+    the attribute `identity`.
     """
 
     # for performance reason, we don't let is_commutative go to assumptions,
@@ -29,7 +32,7 @@ class AssocOp(Expr):
             obj.is_commutative = all(arg.is_commutative for arg in args)
             return obj
         if len(args)==0:
-            return cls.identity()
+            return cls.identity
         if len(args)==1:
             return _sympify(args[0])
         c_part, nc_part, order_symbols = cls.flatten(map(_sympify, args))
@@ -39,7 +42,7 @@ class AssocOp(Expr):
             elif nc_part:
                 obj = nc_part[0]
             else:
-                obj = cls.identity()
+                obj = cls.identity
         else:
             obj = Expr.__new__(cls, *(c_part + nc_part), **assumptions)
             obj.is_commutative = not nc_part
@@ -69,9 +72,6 @@ class AssocOp(Expr):
 
         return obj
 
-    @classmethod
-    def identity(cls):
-        raise NotImplementedError("identity not defined for class %r" % (cls.__name__))
 
     @classmethod
     def flatten(cls, seq):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -199,6 +199,27 @@ class AssocOp(Expr):
 
     _eval_evalf = Expr._seq_eval_evalf
 
+    @classmethod
+    def make_args(cls, expr):
+        """
+        Return a sequence of elements `args` such that cls(*args) == expr
+
+        >>> from sympy import Symbol, Mul, Add
+        >>> x, y = map(Symbol, 'xy')
+
+        >>> Mul.make_args(x*y)
+        (x, y)
+        >>> Add.make_args(x*y)
+        (x*y,)
+        >>> set(Add.make_args(x*y + y)) == set([y, x*y])
+        True
+
+        """
+        if isinstance(expr, cls):
+            return list(expr.args)
+        else:
+            return [expr]
+
 class ShortCircuit(Exception):
     pass
 
@@ -264,6 +285,29 @@ class LatticeOp(AssocOp):
                     yield x
             else:
                 yield arg
+
+    @classmethod
+    def make_args(cls, expr):
+        """
+        Return a sequence of elements `args` such that cls(*args) == expr
+
+        >>> from sympy import Symbol, Mul, Add
+        >>> x, y = map(Symbol, 'xy')
+
+        >>> Mul.make_args(x*y)
+        (x, y)
+        >>> Add.make_args(x*y)
+        (x*y,)
+        >>> set(Add.make_args(x*y + y)) == set([y, x*y])
+        True
+
+        """
+        if isinstance(expr, cls):
+            return expr._argset
+        elif expr == cls.identity:
+            return frozenset()
+        else:
+            return frozenset([expr])
 
     @property
     def args(self):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -216,9 +216,11 @@ class AssocOp(Expr):
 
         """
         if isinstance(expr, cls):
-            return list(expr.args)
+            return expr.args
+        elif expr == cls.identity:
+            return ()
         else:
-            return [expr]
+            return (expr,)
 
 class ShortCircuit(Exception):
     pass

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -34,9 +34,12 @@ class AssocOp(Expr):
             return _sympify(args[0])
         c_part, nc_part, order_symbols = cls.flatten(map(_sympify, args))
         if len(c_part) + len(nc_part) <= 1:
-            if c_part: obj = c_part[0]
-            elif nc_part: obj = nc_part[0]
-            else: obj = cls.identity()
+            if c_part:
+                obj = c_part[0]
+            elif nc_part:
+                obj = nc_part[0]
+            else:
+                obj = cls.identity()
         else:
             obj = Expr.__new__(cls, *(c_part + nc_part), **assumptions)
             obj.is_commutative = not nc_part
@@ -68,14 +71,6 @@ class AssocOp(Expr):
 
     @classmethod
     def identity(cls):
-        from mul import Mul
-        from add import Add
-        if cls is Mul: return S.One
-        if cls is Add: return S.Zero
-        if cls is C.Composition:
-            from symbol import Symbol
-            s = Symbol('x',dummy=True)
-            return Lambda(s,s)
         raise NotImplementedError("identity not defined for class %r" % (cls.__name__))
 
     @classmethod

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -315,7 +315,7 @@ class Pow(Expr):
                 else:
                     radical, result = Pow(base, exp - n), []
 
-                    for term in Pow(base, n)._eval_expand_multinomial(deep=False).as_Add():
+                    for term in Add.make_args(Pow(base, n)._eval_expand_multinomial(deep=False)):
                         result.append(term*radical)
 
                     return Add(*result)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1080,3 +1080,16 @@ def test_issue415():
     assert sqrt(6)/2*sqrt(2) == sqrt(3)
     assert sqrt(6)*sqrt(2)/2 == sqrt(3)
 
+
+def test_make_args():
+    assert Add.make_args(x) == (x,)
+    assert Mul.make_args(x) == (x,)
+
+    assert Add.make_args(x*y*z) == (x*y*z,)
+    assert Mul.make_args(x*y*z) == (x*y*z).args
+
+    assert Add.make_args(x+y+z) == (x+y+z).args
+    assert Mul.make_args(x+y+z) == (x+y+z,)
+
+    assert Add.make_args((x+y)**z) == ((x+y)**z,)
+    assert Mul.make_args((x+y)**z) == ((x+y)**z,)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -720,22 +720,12 @@ def test_contains():
     assert g in p
     assert not h in p
 
-def test_as_Something():
-    assert x.as_Add() == [x]
-    assert x.as_Mul() == [x]
+def test_as_Pow():
     assert x.as_Pow() == (x, S.One)
-
-    assert (x*y*z).as_Add() == [x*y*z]
-    assert sorted((x*y*z).as_Mul()) == [x, y, z]
     assert (x*y*z).as_Pow() == (x*y*z, S.One)
-
-    assert sorted((x+y+z).as_Add()) == [x, y, z]
-    assert (x+y+z).as_Mul() == [x+y+z]
     assert (x+y+z).as_Pow() == (x+y+z, S.One)
-
-    assert ((x+y)**z).as_Add() == [(x+y)**z]
-    assert ((x+y)**z).as_Mul() == [(x+y)**z]
     assert ((x+y)**z).as_Pow() == (x+y, z)
+
 
 def test_Basic_keep_sign():
     Basic.keep_sign = True

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -1,4 +1,4 @@
-from sympy import Integer
+from sympy import Integer, S
 from sympy.core.operations import LatticeOp
 from sympy.utilities.pytest import raises
 from sympy.core.sympify import SympifyError
@@ -26,3 +26,8 @@ def test_lattice_shortcircuit():
 
 def test_lattice_print():
     assert str(join(5, 4, 3, 2)) == 'join(2, 3, 4, 5)'
+
+def test_lattice_make_args():
+    assert join.make_args(0) == set([0])
+    assert join.make_args(1) == set()
+    assert join.make_args(join(2, 3, 4)) == set([S(2), S(3), S(4)])

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -2,7 +2,7 @@ from sympy.core.basic import S, C
 from sympy.core.function import Function, Derivative
 from sympy.functions.elementary.miscellaneous import sqrt
 
-from sympy.utilities.iterables import make_list, iff
+from sympy.utilities.iterables import iff
 
 ###############################################################################
 ######################### REAL and IMAGINARY PARTS ############################
@@ -46,7 +46,7 @@ class re(Function):
         else:
 
             included, reverted, excluded = [], [], []
-            arg = make_list(arg, C.Add)
+            arg = C.Add.make_args(arg)
             for term in arg:
                 coeff = term.as_coefficient(S.ImaginaryUnit)
 
@@ -119,7 +119,7 @@ class im(Function):
             return -im(arg.args[0])
         else:
             included, reverted, excluded = [], [], []
-            arg = make_list(arg, C.Add)
+            arg = C.Add.make_args(arg)
             for term in arg:
                 coeff = term.as_coefficient(S.ImaginaryUnit)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -5,7 +5,6 @@ from sympy.integrals.deltafunctions import deltaintegrate
 from sympy.integrals.rationaltools import ratint
 from sympy.integrals.risch import heurisch
 from sympy.utilities import threaded, flatten
-from sympy.utilities.iterables import make_list
 from sympy.polys import Poly
 from sympy.solvers import solve
 from sympy.functions import Piecewise
@@ -296,7 +295,7 @@ class Integral(Expr):
         # we are going to handle Add terms separately,
         # if `f` is not Add -- we only have one term
         parts = []
-        args = make_list(f, Add)
+        args = Add.make_args(f)
         for g in args:
             coeff, g = g.as_independent(x)
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -15,8 +15,6 @@ from sympy.polys import quo, gcd, lcm, \
     monomials, factor, cancel, PolynomialError
 from sympy.polys.polyroots import root_factors
 
-from sympy.utilities.iterables import make_list
-
 def components(f, x):
     """Returns a set of all functional components of the given expression
        which includes symbols, function applications and compositions and
@@ -353,7 +351,7 @@ def heurisch(f, x, **kwargs):
 
         equations = {}
 
-        for term in make_list(numer, Add):
+        for term in Add.make_args(numer):
             coeff, dependent = term.as_independent(*V)
 
             if dependent in equations:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -175,9 +175,9 @@ def conjuncts(expr):
     >>> from sympy.logic.boolalg import conjuncts
     >>> from sympy.abc import A, B
     >>> conjuncts(A & B)
-    (A, B)
+    frozenset([A, B])
     >>> conjuncts(A | B)
-    (Or(A, B),)
+    frozenset([Or(A, B)])
 
     """
     return And.make_args(expr)
@@ -187,9 +187,9 @@ def disjuncts(expr):
     >>> from sympy.logic.boolalg import disjuncts
     >>> from sympy.abc import A, B
     >>> disjuncts(A | B)
-    (A, B)
+    frozenset([A, B])
     >>> disjuncts(A & B)
-    (And(A, B),)
+    frozenset([And(A, B)])
 
     """
     return Or.make_args(expr)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -180,8 +180,7 @@ def conjuncts(expr):
     [Or(A, B)]
 
     """
-    from sympy.utilities import make_list
-    return make_list(expr, And)
+    return And.make_args(expr)
 
 def disjuncts(expr):
     """Return a list of the disjuncts in the sentence s.
@@ -193,8 +192,7 @@ def disjuncts(expr):
     [And(A, B)]
 
     """
-    from sympy.utilities import make_list
-    return make_list(expr, Or)
+    return Or.make_args(expr)
 
 def distribute_and_over_or(expr):
     """
@@ -337,6 +335,5 @@ def to_int_repr(clauses, symbols):
         else:
             return symbols.index(arg)+1
 
-    from sympy.utilities import make_list
-    return [set(append_symbol(arg, symbols) for arg in make_list(c, Or)) \
+    return [set(append_symbol(arg, symbols) for arg in Or.make_args(c)) \
                                                             for c in clauses]

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -175,9 +175,9 @@ def conjuncts(expr):
     >>> from sympy.logic.boolalg import conjuncts
     >>> from sympy.abc import A, B
     >>> conjuncts(A & B)
-    [A, B]
+    (A, B)
     >>> conjuncts(A | B)
-    [Or(A, B)]
+    (Or(A, B),)
 
     """
     return And.make_args(expr)
@@ -187,9 +187,9 @@ def disjuncts(expr):
     >>> from sympy.logic.boolalg import disjuncts
     >>> from sympy.abc import A, B
     >>> disjuncts(A | B)
-    [A, B]
+    (A, B)
     >>> disjuncts(A & B)
-    [And(A, B)]
+    (And(A, B),)
 
     """
     return Or.make_args(expr)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -183,7 +183,7 @@ def test_conjuncts():
     assert set(conjuncts(A & B & C)) == set([A, B, C])
     assert set(conjuncts((A | B) & C)) == set([A | B, C])
     assert conjuncts(A) == [A]
-    assert conjuncts(True) == [True]
+    assert conjuncts(True) == []
     assert conjuncts(False) == [False]
 
 def test_disjuncts():
@@ -192,7 +192,7 @@ def test_disjuncts():
     assert disjuncts((A | B) & C) == [(A | B) & C]
     assert disjuncts(A) == [A]
     assert disjuncts(True) == [True]
-    assert disjuncts(False) == [False]
+    assert disjuncts(False) == []
 
 def test_distribute():
     A, B, C = map(Boolean, symbols('ABC'))

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -180,19 +180,19 @@ def test_eliminate_implications():
 
 def test_conjuncts():
     A, B, C = map(Boolean, symbols('ABC'))
-    assert set(conjuncts(A & B & C)) == set([A, B, C])
-    assert set(conjuncts((A | B) & C)) == set([A | B, C])
-    assert conjuncts(A) == [A]
-    assert conjuncts(True) == []
-    assert conjuncts(False) == [False]
+    assert conjuncts(A & B & C) == set([A, B, C])
+    assert conjuncts((A | B) & C) == set([A | B, C])
+    assert conjuncts(A) == set([A])
+    assert conjuncts(True) == set()
+    assert conjuncts(False) == set([False])
 
 def test_disjuncts():
     A, B, C = map(Boolean, symbols('ABC'))
-    assert set(disjuncts(A | B | C)) == set([A, B, C])
-    assert disjuncts((A | B) & C) == [(A | B) & C]
-    assert disjuncts(A) == [A]
-    assert disjuncts(True) == [True]
-    assert disjuncts(False) == []
+    assert disjuncts(A | B | C) == set([A, B, C])
+    assert disjuncts((A | B) & C) == set([(A | B) & C])
+    assert disjuncts(A) == set([A])
+    assert disjuncts(True) == set([True])
+    assert disjuncts(False) == set([])
 
 def test_distribute():
     A, B, C = map(Boolean, symbols('ABC'))

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2478,10 +2478,10 @@ def poly(expr, **args):
 
     terms, poly_terms = [], []
 
-    for term in expr.as_Add():
+    for term in Add.make_args(expr):
         factors, poly_factors = [], []
 
-        for factor in term.as_Mul():
+        for factor in Mul.make_args(term):
             if factor.is_Add:
                 poly_factors.append(poly(factor))
             elif factor.is_Pow and factor.base.is_Add and factor.exp.is_Integer:

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -151,10 +151,10 @@ def _dict_from_basic_if_gens(ex, gens, **args):
 
     result = {}
 
-    for term in ex.as_Add():
+    for term in Add.make_args(ex):
         coeff, monom = [], [0]*k
 
-        for factor in term.as_Mul():
+        for factor in Mul.make_args(term):
             if factor.is_Number:
                 coeff.append(factor)
             else:
@@ -201,10 +201,10 @@ def _dict_from_basic_no_gens(ex, **args):
 
     gens, terms = set([]), []
 
-    for term in ex.as_Add():
+    for term in Add.make_args(ex):
         coeff, elements = [], {}
 
-        for factor in term.as_Mul():
+        for factor in Mul.make_args(term):
             if factor.is_Number or _is_coeff(factor):
                 coeff.append(factor)
             else:

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -65,7 +65,7 @@ Some more information how the single concepts work and who should use which:
     not defined in the Printer subclass this will be the same as str(expr)
 """
 
-from sympy import Basic, Mul
+from sympy import Basic, Mul, Add
 
 from sympy.polys.polyutils import _analyze_power
 from sympy.polys.monomialtools import monomial_cmp
@@ -249,10 +249,10 @@ class Printer(object):
         """Rewrite an expression as sorted list of terms. """
         gens, terms = set([]), []
 
-        for term in expr.as_Add():
+        for term in Add.make_args(expr):
             coeff, cpart, ncpart = [], {}, []
 
-            for factor in term.as_Mul():
+            for factor in Mul.make_args(term):
                 if not factor.is_commutative:
                     ncpart.append(factor)
                 else:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -7,7 +7,7 @@ from sympy.core import Basic, S, C, Add, Mul, Pow, Rational, Integer, \
 from sympy.core.numbers import igcd
 from sympy.core.relational import Equality
 
-from sympy.utilities import make_list, all, any, flatten
+from sympy.utilities import all, any, flatten
 from sympy.functions import gamma, exp, sqrt, log
 
 from sympy.simplify.cse_main import cse
@@ -68,7 +68,7 @@ def fraction(expr, exact=False):
 
     numer, denom = [], []
 
-    for term in make_list(expr, Mul):
+    for term in Mul.make_args(expr):
         if term.is_Pow:
             if term.exp.is_negative:
                 if term.exp is S.NegativeOne:
@@ -244,7 +244,7 @@ def together(expr, deep=False):
 
                 denom = {}
 
-                for term in make_list(q.expand(), Mul):
+                for term in Mul.make_args(q.expand()) or [S.One]:
                     expo = S.One
                     coeff = S.One
 
@@ -565,7 +565,7 @@ def collect(expr, syms, evaluate=True, exact=False):
         terms is a list of tuples as returned by parse_terms
         pattern is an expression
         """
-        pattern = make_list(pattern, Mul)
+        pattern = Mul.make_args(pattern)
 
         if len(terms) < len(pattern):
             # pattern is longer than  matched product
@@ -637,7 +637,7 @@ def collect(expr, syms, evaluate=True, exact=False):
             b = collect(expr.base, syms, True, exact)
             return C.Pow(b, expr.exp)
 
-    summa = [separate(i) for i in make_list(sympify(expr), Add)]
+    summa = [separate(i) for i in Add.make_args(sympify(expr))]
 
     if isinstance(syms, list):
         syms = [separate(s) for s in syms]
@@ -647,7 +647,7 @@ def collect(expr, syms, evaluate=True, exact=False):
     collected, disliked = {}, S.Zero
 
     for product in summa:
-        terms = [parse_term(i) for i in make_list(product, Mul)]
+        terms = [parse_term(i) for i in Mul.make_args(product)]
 
         for symbol in syms:
             if SYMPY_DEBUG:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -301,7 +301,7 @@ def together(expr, deep=False):
                     else:
                         denominator.append(Pow(term, maxi))
 
-            if all([c.is_integer for c in coeffs]):
+            if coeffs and all([c.is_integer for c in coeffs]):
                 gcds = lambda x, y: igcd(int(x), int(y))
                 common = Rational(reduce(gcds, coeffs))
             else:

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -216,7 +216,7 @@ from sympy.simplify import collect, logcombine, powsimp, separatevars, \
     simplify, trigsimp
 from sympy.solvers import solve
 
-from sympy.utilities import numbered_symbols, all, any, make_list
+from sympy.utilities import numbered_symbols, all, any
 from sympy.utilities.iterables import minkey
 
 # This is a list of hints in the order that they should be applied.  That means
@@ -1897,7 +1897,7 @@ def _homogeneous_order(eq, *symbols):
         if eq.func is log:
             # The only possibility to pull a t out of a function is a power in
             # a logarithm.  This is very likely due to calling of logcombine().
-            args = make_list(eq.args[0], Mul)
+            args = Mul.make_args(eq.args[0])
             if all(i.is_Pow for i in args):
                 base = 1
                 expos = set()
@@ -2151,12 +2151,10 @@ def _nth_linear_match(eq, func, order):
         True
 
     """
-    from sympy import S
-
     x = func.args[0]
     one_x = set([x])
     terms = dict([(i, S.Zero) for i in range(-1, order+1)])
-    for i in make_list(eq, Add):
+    for i in Add.make_args(eq):
         if not i.has(func):
             terms[-1] += i
         else:
@@ -2449,7 +2447,7 @@ def _solve_undetermined_coefficients(eq, func, order, match):
     # term, in which case it must be a derivative term and so will be inhomogeneous
     eqs = expand_mul(eqs)
 
-    for i in make_list(eqs, Add):
+    for i in Add.make_args(eqs):
         s = separatevars(i, dict=True, symbols=[x])
         coeffsdict[s[x]] += s['coeff']
 

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -2,7 +2,7 @@
 """
 import sys
 
-from iterables import iff, make_list, flatten, subsets, variations, numbered_symbols
+from iterables import iff, flatten, subsets, variations, numbered_symbols
 
 if sys.version_info[0] <= 2 and sys.version_info[1] < 5:
     from iterables import any, all

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -109,29 +109,6 @@ def any(iterable):
             return True
     return False
 
-def make_list(expr, kind):
-    """
-    Returns a list of elements taken from specified expression
-    when it is of sequence type (Add or Mul) or singleton list
-    otherwise (Rational, Pow etc.).
-
-    >>> from sympy import Symbol, make_list, Mul, Add
-    >>> x, y = map(Symbol, 'xy')
-
-    >>> make_list(x*y, Mul)
-    [x, y]
-    >>> make_list(x*y, Add)
-    [x*y]
-    >>> set(make_list(x*y + y, Add)) == set([y, x*y])
-    True
-
-    """
-    if isinstance(expr, kind):
-        return list(expr.args)
-    else:
-        return [expr]
-
-
 def flatten(iterable, cls=None):
     """
     Recursively denest iterable containers.


### PR DESCRIPTION
This replaces make_list and Expr.as_Add, Expr.as_Mul methods by make_args classmethods defined for al operations. See [issue 1915](http://code.google.com/p/sympy/issues/detail?id=1915) for previous discussions.
