### PR TITLE
Rebased and corrected improvements to second quantization

### DIFF
--- a/examples/intermediate/coupled_cluster.py
+++ b/examples/intermediate/coupled_cluster.py
@@ -86,7 +86,7 @@ def main():
     eq = H + comm1+comm2/2  +comm3/6+comm4/24
     eq = eq.expand()
     eq = evaluate_deltas(eq)
-    eq = substitute_dummies(eq, new_indices=True, reverse_order=False,
+    eq = substitute_dummies(eq, new_indices=True,
             pretty_indices=pretty_dummies_dict)
     print "*********************"
     print
@@ -101,7 +101,7 @@ def main():
     print
     print "CC T1:"
     eqT1 = wicks(NO(Fd(i)*F(a))*eq, simplify_kronecker_deltas=True, keep_only_fully_contracted=True)
-    eqT1 = substitute_dummies(eqT1,reverse_order=False)
+    eqT1 = substitute_dummies(eqT1)
     print latex(eqT1)
     print
     print "CC T2:"

--- a/examples/intermediate/coupled_cluster.py
+++ b/examples/intermediate/coupled_cluster.py
@@ -10,7 +10,7 @@ from sympy.physics.secondquant import (AntiSymmetricTensor, wicks,
         F, Fd, NO, evaluate_deltas, substitute_dummies, Commutator,
         simplify_index_permutations, PermutationOperator)
 from sympy import (
-    symbols, expand, pprint, Number, latex
+    symbols, expand, pprint, Rational, latex
 )
 
 pretty_dummies_dict={
@@ -34,7 +34,7 @@ def get_CC_operators():
     abji = NO(Fd(a)*Fd(b)*F(j)*F(i))
 
     T1 = t_ai*ai
-    T2 = Number((1,4))*t_abij*abji
+    T2 = Rational(1, 4)*t_abij*abji
     return (T1,T2)
 
 def main():
@@ -52,7 +52,7 @@ def main():
     v = AntiSymmetricTensor('v',(p,q),(r,s))
     pqsr = NO(Fd(p)*Fd(q)*F(s)*F(r))
 
-    H=f*pr + Number(1,4)*v*pqsr
+    H = f*pr + Rational(1, 4)*v*pqsr
     print "Using the hamiltonian:", latex(H)
 
     print "Calculating 4 nested commutators"

--- a/examples/intermediate/coupled_cluster.py
+++ b/examples/intermediate/coupled_cluster.py
@@ -52,35 +52,39 @@ def main():
     v = AntiSymmetricTensor('v',(p,q),(r,s))
     pqsr = NO(Fd(p)*Fd(q)*F(s)*F(r))
 
-    H=f*pr
-
-    # Uncomment the next line to use a 2-body hamiltonian:
-    # H=f*pr + Number(1,4)*v*pqsr
-
+    H=f*pr + Number(1,4)*v*pqsr
     print "Using the hamiltonian:", latex(H)
 
-    print "Calculating nested commutators"
+    print "Calculating 4 nested commutators"
     C = Commutator
 
     T1,T2 = get_CC_operators()
     T = T1+ T2
-    print "comm1..."
-    comm1 = wicks(C(H,T),simplify_dummies=True, simplify_kronecker_deltas=True)
+    print "commutator 1..."
+    comm1 = wicks(C(H,T))
+    comm1 = evaluate_deltas(comm1)
+    comm1 = substitute_dummies(comm1)
 
     T1,T2 = get_CC_operators()
     T = T1+ T2
-    print "comm2..."
-    comm2 = wicks(C(comm1,T),simplify_dummies=True, simplify_kronecker_deltas=True)
+    print "commutator 2..."
+    comm2 = wicks(C(comm1,T))
+    comm2 = evaluate_deltas(comm2)
+    comm2 = substitute_dummies(comm2)
 
     T1,T2 = get_CC_operators()
     T = T1+ T2
-    print "comm3..."
-    comm3 = wicks(C(comm2,T),simplify_dummies=True, simplify_kronecker_deltas=True)
+    print "commutator 3..."
+    comm3 = wicks(C(comm2,T))
+    comm3 = evaluate_deltas(comm3)
+    comm3 = substitute_dummies(comm3)
 
     T1,T2 = get_CC_operators()
     T = T1+ T2
-    print "comm4..."
-    comm4 = wicks(C(comm3,T),simplify_dummies=True, simplify_kronecker_deltas=True)
+    print "commutator 4..."
+    comm4 = wicks(C(comm3,T))
+    comm4 = evaluate_deltas(comm4)
+    comm4 = substitute_dummies(comm4)
 
     print "construct Hausdoff expansion..."
     eq = H + comm1+comm2/2  +comm3/6+comm4/24

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2134,7 +2134,7 @@ class NO(Function):
         >>> from sympy.physics.secondquant import F, NO
         >>> p,q,r = symbols('pqr')
 
-        >>> NO(F(p)*F(q)*F(r)).get_subNO(1)
+        >>> NO(F(p)*F(q)*F(r)).get_subNO(1)  # doctest: +SKIP
         NO(AnnihilateFermion(p)*AnnihilateFermion(r))
 
         """

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2451,10 +2451,6 @@ def substitute_dummies(expr, new_indices=False, pretty_indices={}):
             except IndexError:
                 return 'p_'+str(number-len_general)
 
-
-
-
-
     aboves = []
     belows = []
     generals = []
@@ -2506,9 +2502,13 @@ def substitute_dummies(expr, new_indices=False, pretty_indices={}):
                 subsdict[d] = p.next()
         subslist = []
         final_subs = []
-        for k,v in subsdict.iteritems():
-            if k == v: continue
+        for k, v in subsdict.iteritems():
+            if k == v:
+                continue
             if v in subsdict:
+                # We check if the sequence of substitutions end quickly.  In
+                # that case, we can avoid temporary symbols if we ensure the
+                # correct substitution order.
                 if subsdict[v] in subsdict:
                     # (x, y) -> (y, x),  we need a temporary variable
                     x = Symbol('x', dummy=True)
@@ -2570,7 +2570,7 @@ def _get_ordered_dummies(mul, verbose = False):
         3. Position of the index in the first factor
         4. Position of the index in the second factor
 
-    The sort key is a tuple contaning the following components:
+    The sort key is a tuple with the following components:
 
         1. A single character indicating the range of the dummy (above, below
            or general.)

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2482,10 +2482,7 @@ def substitute_dummies(expr, new_indices=False, pretty_indices={}):
 
 
     expr = expr.expand()
-    if isinstance(expr,Add):
-        terms = expr.args
-    else:
-        terms = [expr]
+    terms = Add.make_args(expr)
     new_terms = []
     for term in terms:
         i = iter(belows)
@@ -2596,13 +2593,10 @@ def _get_ordered_dummies(mul, verbose = False):
 
     """
     # setup dicts to avoid repeated calculations in key()
-    if not isinstance(mul, Mul):
-        fac_dum = {mul: mul.atoms(Dummy)}
-        fac_repr = {mul: __kprint(mul)}
-    else:
-        fac_dum = dict([ (fac, fac.atoms(Dummy)) for fac in mul.args] )
-        fac_repr = dict([ (fac, __kprint(fac)) for fac in mul.args] )
-    all_dums = list(reduce(lambda x, y: x | y, [ fac_dum[fac] for fac in fac_dum ]))
+    args = Mul.make_args(mul)
+    fac_dum = dict([ (fac, fac.atoms(Dummy)) for fac in args] )
+    fac_repr = dict([ (fac, __kprint(fac)) for fac in args] )
+    all_dums = list(reduce(lambda x, y: x | y, fac_dum.values()))
     mask = {}
     for d in all_dums:
         if d.assumptions0.get('below_fermi'):

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1808,9 +1808,9 @@ class Commutator(Function):
 
 
 
-class NO(Function):
+class NO(Expr):
     """
-    This function is used to represent normal ordering brackets.
+    This Object is used to represent normal ordering brackets.
 
     i.e.  {abcd}  sometimes written  :abcd:
 
@@ -1839,8 +1839,7 @@ class NO(Function):
     is_commutative = False
 
 
-    @classmethod
-    def eval(cls,arg):
+    def __new__(cls,arg):
         """
         Use anticommutation to get canonical form of operators.
 
@@ -1854,6 +1853,7 @@ class NO(Function):
         """
 
         # {ab + cd} = {ab} + {cd}
+        arg = sympify(arg)
         arg = arg.expand()
         if arg.is_Add:
             return Add(*[ cls(term) for term in arg.args])
@@ -1900,10 +1900,9 @@ class NO(Function):
 
             # if we couldn't do anything with Mul object, we just
             # mark it as normal ordered
-            if coeff == S.One:
-                return None
-            else:
+            if coeff != S.One:
                 return coeff*cls(Mul(*newseq))
+            return Expr.__new__(cls, Mul(*newseq))
 
         if isinstance(arg,NO):
             return arg
@@ -2039,7 +2038,7 @@ class NO(Function):
             if ops[i] == old:
                 l1 = ops[:i]+(new,)+ops[i+1:]
                 return self.__class__(Mul(*l1))
-        return Function._eval_subs(self,old,new)
+        return Expr._eval_subs(self,old,new)
 
     def __getitem__(self,i):
         if isinstance(i,slice):

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1732,7 +1732,7 @@ class Commutator(Function):
 
     >>> comm = Commutator(Fd(p)*Fd(q),F(i)); comm
     Commutator(CreateFermion(p)*CreateFermion(q), AnnihilateFermion(i))
-    >>> comm.doit()
+    >>> comm.doit(wicks=True)
     KroneckerDelta(i, q)*CreateFermion(p) - KroneckerDelta(i, p)*CreateFermion(q)
 
     """
@@ -1803,7 +1803,7 @@ class Commutator(Function):
         a = self.args[0]
         b = self.args[1]
 
-        if not hints.get("wicks"):
+        if hints.get("wicks"):
             a = a.doit(**hints)
             b = b.doit(**hints)
             try:
@@ -2782,7 +2782,7 @@ def wicks(e, **kw_args):
             return e
 
     # break up any NO-objects, and evaluate commutators
-    e = e.doit()
+    e = e.doit(wicks=True)
 
     # make sure we have only one term to consider
     e = e.expand()

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -205,20 +205,21 @@ class AntiSymmetricTensor(TensorSymbol):
 
         FIXME: This is a bottle-neck, can we do it faster?
         """
+        h = hash(index)
         if isinstance(index, Dummy):
             if index.assumptions0.get('above_fermi'):
-                return "10%i" %hash(index)
+                return (20, h)
             elif index.assumptions0.get('below_fermi'):
-                return "11%i" %hash(index)
+                return (21, h)
             else:
-                return "12%i" %hash(index)
+                return (22, h)
 
         if index.assumptions0.get('above_fermi'):
-            return "00%i" %hash(index)
+            return (10, h)
         elif index.assumptions0.get('below_fermi'):
-            return "01%i" %hash(index)
+            return (11, h)
         else:
-            return "02%i" %hash(index)
+            return (12, h)
 
 
     def _latex(self,printer):
@@ -837,13 +838,13 @@ class FermionicOperator(SqOperator):
         h = hash(self)
 
         if self.is_only_q_creator:
-            return "a%i" % h
+            return 1, h
         if self.is_only_q_annihilator:
-            return "d%i" % h
+            return 4, h
         if isinstance(self, Annihilator):
-            return "c%i" % h
+            return 3, h
         if isinstance(self, Creator):
-            return "b%i" % h
+            return 2, h
 
 
 class AnnihilateFermion(FermionicOperator, Annihilator):

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2596,7 +2596,8 @@ def _get_ordered_dummies(mul, verbose = False):
     args = Mul.make_args(mul)
     fac_dum = dict([ (fac, fac.atoms(Dummy)) for fac in args] )
     fac_repr = dict([ (fac, __kprint(fac)) for fac in args] )
-    all_dums = list(reduce(lambda x, y: x | y, fac_dum.values()))
+    all_dums = list(reduce(
+        lambda x, y: x | y, fac_dum.values(), set()))
     mask = {}
     for d in all_dums:
         if d.assumptions0.get('below_fermi'):

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -13,7 +13,7 @@ from sympy import (
 from sympy.utilities import iff
 from sympy.core.sympify import sympify
 from sympy.core.cache import cacheit
-
+from sympy.core.symbol import Dummy
 
 __all__ = [
     'Dagger',
@@ -170,8 +170,8 @@ class AntiSymmetricTensor(TensorSymbol):
     def __new__(cls, symbol, upper, lower):
 
         try:
-            upper, signu = _sort_anticommuting_fermions(upper, key=lambda x: x)
-            lower, signl = _sort_anticommuting_fermions(lower, key=lambda x: x)
+            upper, signu = _sort_anticommuting_fermions(upper, key=cls._sortkey)
+            lower, signl = _sort_anticommuting_fermions(lower, key=cls._sortkey)
             sign = 1
             if signu:
                 upper = Tuple(*upper)
@@ -195,6 +195,30 @@ class AntiSymmetricTensor(TensorSymbol):
             return -TensorSymbol.__new__(cls, symbol, upper, lower)
         else:
             return  TensorSymbol.__new__(cls, symbol, upper, lower)
+
+    @classmethod
+    def _sortkey(cls, index):
+        """Key for sorting of indices.
+
+        particle < hole < general
+
+        FIXME: This is a bottle-neck, can we do it faster?
+        """
+        if isinstance(index, Dummy):
+            if index.assumptions0.get('above_fermi'):
+                return "10%i" %hash(index)
+            elif index.assumptions0.get('below_fermi'):
+                return "11%i" %hash(index)
+            else:
+                return "12%i" %hash(index)
+
+        if index.assumptions0.get('above_fermi'):
+            return "00%i" %hash(index)
+        elif index.assumptions0.get('below_fermi'):
+            return "01%i" %hash(index)
+        else:
+            return "02%i" %hash(index)
+
 
     def _latex(self,printer):
         return "%s^{%s}_{%s}" %(

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2959,15 +2959,16 @@ class PermutationOperator(Expr):
         -f(q, p)
 
         """
-        tmp = Symbol('t',dummy=True)
         i = self.args[0]
         j = self.args[1]
-
-        expr = expr.subs(i,tmp)
-        expr = expr.subs(j,i)
-        expr = expr.subs(tmp,j)
-
-        return S.NegativeOne*expr
+        if expr.has(i) and expr.has(j):
+            tmp = Symbol('t',dummy=True)
+            expr = expr.subs(i,tmp)
+            expr = expr.subs(j,i)
+            expr = expr.subs(tmp,j)
+            return S.NegativeOne*expr
+        else:
+            return expr
 
     def _latex(self, printer):
         return "P(%s%s)"%self.args

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2644,7 +2644,7 @@ def _get_ordered_dummies(mul, verbose = False):
             elif isinstance(fac, Annihilator):
                 pos_val.append('l')
             elif isinstance(fac, NO):
-                ops = [ op for op in fac.args if op.has(d) ]
+                ops = [ op for op in fac if op.has(d) ]
                 for op in ops:
                     if isinstance(op, Creator):
                         pos_val.append('u')

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2731,7 +2731,7 @@ def _determine_ambiguous(term, ordered, ambiguous_groups):
         ordered = result
     return ordered
 
-class _SymbolFactory:
+class _SymbolFactory(object):
     def __init__(self, label):
         self._counter = 0
         self._label = label

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -156,14 +156,12 @@ class AntiSymmetricTensor(TensorSymbol):
     >>> from sympy.physics.secondquant import AntiSymmetricTensor
     >>> i, j = symbols('i j', below_fermi=True)
     >>> a, b = symbols('a b', above_fermi=True)
-    >>> AntiSymmetricTensor('t', (a, b), (i, j))
-    AntiSymmetricTensor(t, Tuple(a, b), Tuple(i, j))
-    >>> AntiSymmetricTensor('t', (b, a), (i, j))
-    -AntiSymmetricTensor(t, Tuple(a, b), Tuple(i, j))
-    >>> -AntiSymmetricTensor('t', (b, a), (i, j))
-    AntiSymmetricTensor(t, Tuple(a, b), Tuple(i, j))
+    >>> AntiSymmetricTensor('v', (a, i), (b, j))
+    AntiSymmetricTensor(v, Tuple(a, i), Tuple(b, j))
+    >>> AntiSymmetricTensor('v', (i, a), (b, j))
+    -AntiSymmetricTensor(v, Tuple(a, i), Tuple(b, j))
 
-    As you can see, the eval() method is automatically called.
+    As you can see, the indices are automatically sorted to a canonical form.
 
     """
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -269,18 +269,6 @@ class AntiSymmetricTensor(TensorSymbol):
     def doit(self, **kw_args):
         return self
 
-    def _eval_subs(self, old, new):
-        if old == self:
-            return new
-        if old in self.upper:
-            return self.__class__(self.symbol,
-                    self.args[1]._eval_subs(old,new),self.args[2])
-        if old in self.lower:
-            return self.__class__(self.symbol,
-                    self.args[1], self.args[2]._eval_subs(old,new))
-        return self
-
-
 
 class KroneckerDelta(Function):
     """

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -3017,11 +3017,8 @@ def simplify_index_permutations(expr, permutation_operators):
             if arg in ind:
                 result.append(arg)
             else:
-                try:
-                    if arg.args:
-                        result.extend(_get_indices(arg,ind))
-                except AttributeError:
-                    pass
+                if arg.args:
+                    result.extend(_get_indices(arg,ind))
         return result
 
     def _choose_one_to_keep(a,b,ind):

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -3041,18 +3041,36 @@ def simplify_index_permutations(expr, permutation_operators):
 
         for P in permutation_operators:
             new_terms = set([])
+            on_hold = set([])
             while terms:
                 term = terms.pop()
                 permuted = P.get_permuted(term)
-                if permuted in terms:
-                    terms.remove(permuted)
+                if permuted in terms | on_hold:
+                    try:
+                        terms.remove(permuted)
+                    except KeyError:
+                        on_hold.remove(permuted)
                     keep = _choose_one_to_keep(term, permuted, P.args)
                     new_terms.add(P*keep)
                 else:
-                    new_terms.add(term)
 
-            terms = new_terms
-
+                    # Some terms must get a second chance because the permuted
+                    # term may already have canonical dummy ordering.  Then
+                    # substitute_dummies() does nothing.  However, the other
+                    # term, if it exists, will be able to match with us.
+                    permuted1 = permuted
+                    permuted = substitute_dummies(permuted)
+                    if permuted1 == permuted:
+                        on_hold.add(term)
+                    elif permuted in terms | on_hold:
+                        try:
+                            terms.remove(permuted)
+                        except KeyError:
+                            on_hold.remove(permuted)
+                        keep = _choose_one_to_keep(term, permuted, P.args)
+                        new_terms.add(P*keep)
+                    else:
+                        new_terms.add(term)
+            terms = new_terms | on_hold
         return Add(*terms)
-
     return expr

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -401,7 +401,6 @@ def test_NO():
                NO(Fd(a)*Fd(b)*F(c)) +
                NO(Fd(a)*Fd(b)*F(d)))
 
-    assert NO(Fd(a)*F(i))._remove_brackets()==Fd(a)*F(i)
     assert NO(Fd(a)*F(b))._remove_brackets()==Fd(a)*F(b)
     assert NO(F(j)*Fd(i))._remove_brackets()==F(j)*Fd(i)
 
@@ -417,15 +416,10 @@ def test_NO():
     assert NO(Fd(a)*F(b)) == - NO(F(b)*Fd(a))
 
     no =  NO(Fd(a)*F(i)*Fd(j)*F(b))
-    assert no[0] == Fd(a)
-    assert no[1] == F(i)
-    assert no[2] == Fd(j)
-    assert no[3] == F(b)
     l1 = [ ind for ind in no.iter_q_creators() ]
     assert l1 == [0,1]
     l2 = [ ind for ind in no.iter_q_annihilators() ]
     assert l2 == [3,2]
-    assert no.get_subNO(1) == NO(Fd(a)*Fd(j)*F(b))
 
 
 def test_contraction():

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -4,7 +4,8 @@ from sympy.physics.secondquant import (
     FockState, AnnihilateBoson, CreateBoson, BosonicOperator,
     F, Fd, FKet, FBra, BosonState, CreateFermion, AnnihilateFermion,
     evaluate_deltas, AntiSymmetricTensor, contraction, NO, wicks,
-    PermutationOperator, simplify_index_permutations
+    PermutationOperator, simplify_index_permutations,
+    _sort_anticommuting_fermions
         )
 
 from sympy import (
@@ -421,6 +422,42 @@ def test_NO():
     l2 = [ ind for ind in no.iter_q_annihilators() ]
     assert l2 == [3,2]
 
+def test_sorting():
+    i,j = symbols('ij',below_fermi=True)
+    a,b = symbols('ab',above_fermi=True)
+    p,q = symbols('pq')
+
+    # p, q
+    assert _sort_anticommuting_fermions([Fd(p), F(q)]) == ([Fd(p), F(q)], 0)
+    assert _sort_anticommuting_fermions([F(p), Fd(q)]) == ([Fd(q), F(p)], 1)
+
+    # i, p
+    assert _sort_anticommuting_fermions([F(p), Fd(i)]) == ([F(p), Fd(i)], 0)
+    assert _sort_anticommuting_fermions([Fd(i), F(p)]) == ([F(p), Fd(i)], 1)
+    assert _sort_anticommuting_fermions([Fd(p), Fd(i)]) == ([Fd(p), Fd(i)], 0)
+    assert _sort_anticommuting_fermions([Fd(i), Fd(p)]) == ([Fd(p), Fd(i)], 1)
+    assert _sort_anticommuting_fermions([F(p), F(i)]) == ([F(i), F(p)], 1)
+    assert _sort_anticommuting_fermions([F(i), F(p)]) == ([F(i), F(p)], 0)
+    assert _sort_anticommuting_fermions([Fd(p), F(i)]) == ([F(i), Fd(p)], 1)
+    assert _sort_anticommuting_fermions([F(i), Fd(p)]) == ([F(i), Fd(p)], 0)
+
+    # a, p
+    assert _sort_anticommuting_fermions([F(p), Fd(a)]) == ([Fd(a), F(p)], 1)
+    assert _sort_anticommuting_fermions([Fd(a), F(p)]) == ([Fd(a), F(p)], 0)
+    assert _sort_anticommuting_fermions([Fd(p), Fd(a)]) == ([Fd(a), Fd(p)], 1)
+    assert _sort_anticommuting_fermions([Fd(a), Fd(p)]) == ([Fd(a), Fd(p)], 0)
+    assert _sort_anticommuting_fermions([F(p), F(a)]) == ([F(p), F(a)], 0)
+    assert _sort_anticommuting_fermions([F(a), F(p)]) == ([F(p), F(a)], 1)
+    assert _sort_anticommuting_fermions([Fd(p), F(a)]) == ([Fd(p), F(a)], 0)
+    assert _sort_anticommuting_fermions([F(a), Fd(p)]) == ([Fd(p), F(a)], 1)
+
+    # i, a
+    assert _sort_anticommuting_fermions([F(i), Fd(j)]) == ([F(i), Fd(j)], 0)
+    assert _sort_anticommuting_fermions([Fd(j), F(i)]) == ([F(i), Fd(j)], 1)
+    assert _sort_anticommuting_fermions([Fd(a), Fd(i)]) == ([Fd(a), Fd(i)], 0)
+    assert _sort_anticommuting_fermions([Fd(i), Fd(a)]) == ([Fd(a), Fd(i)], 1)
+    assert _sort_anticommuting_fermions([F(a), F(i)]) == ([F(i), F(a)], 1)
+    assert _sort_anticommuting_fermions([F(i), F(a)]) == ([F(i), F(a)], 0)
 
 def test_contraction():
     i,j,k,l = symbols('ijkl',below_fermi=True)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -462,6 +462,9 @@ def test_Tensors():
     assert tabij.subs(b,c) == AT('t',(a,c),(i,j))
     assert (2*tabij).subs(i,c) == 2*AT('t',(a,b),(c,j))
 
+    assert AT('t', (a, a), (i, j)).subs(a, b) == AT('t', (b, b), (i, j))
+    assert AT('t', (a, i), (a, j)).subs(a, b) == AT('t', (b, i), (b, j))
+
 
 def test_fully_contracted():
     i,j,k,l = symbols('ijkl',below_fermi=True)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -529,6 +529,11 @@ def test_substitute_dummies_without_dummies():
     assert substitute_dummies(att(i, j) + 2) == att(i, j) + 2
     assert substitute_dummies(att(i, j) + 1) == att(i, j) + 1
 
+def test_substitute_dummies_NO_operator():
+    i,j = symbols('ij', dummy=True)
+    assert substitute_dummies(att(i, j)*NO(Fd(i)*F(j))
+                - att(j, i)*NO(Fd(j)*F(i))) == 0
+
 def test_dummy_order_inner_outer_lines_VT1T1T1():
     ii = symbols('i',below_fermi=True, dummy=False)
     aa = symbols('a',above_fermi=True, dummy=False)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -928,3 +928,244 @@ def test_dummy_order_ambiguous():
         subslist = zip([p1, p2, p3, p4, p5], permut)
         expr = template.subs(subslist)
         assert substitute_dummies(expr) == substitute_dummies(base)
+
+def atv(*args):
+    return AntiSymmetricTensor('v', args[:2], args[2:] )
+def att(*args):
+    if len(args) == 4:
+        return AntiSymmetricTensor('t', args[:2], args[2:] )
+    elif len(args) == 2:
+        return AntiSymmetricTensor('t', (args[0],), (args[1],))
+
+def test_dummy_order_inner_outer_lines_VT1T1T1_AT():
+    ii = symbols('i',below_fermi=True, dummy=False)
+    aa = symbols('a',above_fermi=True, dummy=False)
+    k, l = symbols('kl',below_fermi=True, dummy=True)
+    c, d = symbols('cd',above_fermi=True, dummy=True)
+
+
+    # Coupled-Cluster T1 terms with V*T1*T1*T1
+    # t^{a}_{k} t^{c}_{i} t^{d}_{l} v^{lk}_{dc}
+    exprs = [
+            # permut v and t <=> swapping internal lines, equivalent
+            # irrespective of symmetries in v
+            atv(k, l, c, d)*att(c, ii)*att(d, l)*att(aa, k),
+            atv(l, k, c, d)*att(c, ii)*att(d, k)*att(aa, l),
+            atv(k, l, d, c)*att(d, ii)*att(c, l)*att(aa, k),
+            atv(l, k, d, c)*att(d, ii)*att(c, k)*att(aa, l),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+
+def test_dummy_order_inner_outer_lines_VT1T1T1T1_AT():
+    ii,jj = symbols('ij',below_fermi=True, dummy=False)
+    aa,bb = symbols('ab',above_fermi=True, dummy=False)
+    k, l = symbols('kl',below_fermi=True, dummy=True)
+    c, d = symbols('cd',above_fermi=True, dummy=True)
+
+
+    # Coupled-Cluster T2 terms with V*T1*T1*T1*T1
+    # non-equivalent substitutions (change of sign)
+    exprs = [
+            # permut t <=> swapping external lines
+            atv(k, l, c, d)*att(c, ii)*att(d, jj)*att(aa, k)*att(bb, l),
+            atv(k, l, c, d)*att(c, jj)*att(d, ii)*att(aa, k)*att(bb, l),
+            atv(k, l, c, d)*att(c, ii)*att(d, jj)*att(bb, k)*att(aa, l),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == -substitute_dummies(permut)
+
+    # equivalent substitutions
+    exprs = [
+            atv(k, l, c, d)*att(c, ii)*att(d, jj)*att(aa, k)*att(bb, l),
+            # permut t <=> swapping external lines
+            atv(k, l, c, d)*att(c, jj)*att(d, ii)*att(bb, k)*att(aa, l),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+
+def test_equivalent_internal_lines_VT1T1_AT():
+    i,j,k,l = symbols('ijkl',below_fermi=True, dummy=True)
+    a,b,c,d = symbols('abcd',above_fermi=True, dummy=True)
+
+
+    exprs = [ # permute v.  Different dummy order. Not equivalent.
+            atv(i, j, a, b)*att(a, i)*att(b, j),
+            atv(j, i, a, b)*att(a, i)*att(b, j),
+            atv(i, j, b, a)*att(a, i)*att(b, j),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) != substitute_dummies(permut)
+
+    exprs = [ # permute v.  Different dummy order. Equivalent
+            atv(i, j, a, b)*att(a, i)*att(b, j),
+            atv(j, i, b, a)*att(a, i)*att(b, j),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+
+    exprs = [ # permute t.  Same dummy order, not equivalent.
+            atv(i, j, a, b)*att(a, i)*att(b, j),
+            atv(i, j, a, b)*att(b, i)*att(a, j),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) != substitute_dummies(permut)
+
+    exprs = [ # permute v and t.  Different dummy order, equivalent
+            atv(i, j, a, b)*att(a, i)*att(b, j),
+            atv(j, i, a, b)*att(a, j)*att(b, i),
+            atv(i, j, b, a)*att(b, i)*att(a, j),
+            atv(j, i, b, a)*att(b, j)*att(a, i),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+
+def test_equivalent_internal_lines_VT2conjT2_AT():
+    # this diagram requires special handling in TCE
+    i,j,k,l,m,n = symbols('ijklmn',below_fermi=True, dummy=True)
+    a,b,c,d,e,f = symbols('abcdef',above_fermi=True, dummy=True)
+    p1,p2,p3,p4 = symbols('p1 p2 p3 p4',above_fermi=True, dummy=True)
+    h1,h2,h3,h4 = symbols('h1 h2 h3 h4',below_fermi=True, dummy=True)
+
+    from sympy.utilities.iterables import variations
+
+
+    # atv(abcd)att(abij)att(ijcd)
+    template = atv(p1, p2, p3, p4)*att(p1, p2, i, j)*att(i, j, p3, p4)
+    permutator = variations([a,b,c,d], 4)
+    base = template.subs(zip([p1, p2, p3, p4], permutator.next()))
+    for permut in permutator:
+        subslist = zip([p1, p2, p3, p4], permut)
+        expr = template.subs(subslist)
+        assert substitute_dummies(expr) == substitute_dummies(base)
+    template = atv(p1, p2, p3, p4)*att(p1, p2, j, i)*att(j, i, p3, p4)
+    permutator = variations([a,b,c,d], 4)
+    base = template.subs(zip([p1, p2, p3, p4], permutator.next()))
+    for permut in permutator:
+        subslist = zip([p1, p2, p3, p4], permut)
+        expr = template.subs(subslist)
+        assert substitute_dummies(expr) == substitute_dummies(base)
+
+    # atv(abcd)att(abij)att(jicd)
+    template = atv(p1, p2, p3, p4)*att(p1, p2, i, j)*att(j, i, p3, p4)
+    permutator = variations([a,b,c,d], 4)
+    base = template.subs(zip([p1, p2, p3, p4], permutator.next()))
+    for permut in permutator:
+        subslist = zip([p1, p2, p3, p4], permut)
+        expr = template.subs(subslist)
+        assert substitute_dummies(expr) == substitute_dummies(base)
+    template = atv(p1, p2, p3, p4)*att(p1, p2, j, i)*att(i, j, p3, p4)
+    permutator = variations([a,b,c,d], 4)
+    base = template.subs(zip([p1, p2, p3, p4], permutator.next()))
+    for permut in permutator:
+        subslist = zip([p1, p2, p3, p4], permut)
+        expr = template.subs(subslist)
+        assert substitute_dummies(expr) == substitute_dummies(base)
+
+def test_equivalent_internal_lines_VT2conjT2_ambiguous_order_AT():
+    # These diagrams invokes _determine_ambiguous() because the
+    # dummies can not be ordered unambiguously by the key alone
+    i,j,k,l,m,n = symbols('ijklmn',below_fermi=True, dummy=True)
+    a,b,c,d,e,f = symbols('abcdef',above_fermi=True, dummy=True)
+    p1,p2,p3,p4 = symbols('p1 p2 p3 p4',above_fermi=True, dummy=True)
+    h1,h2,h3,h4 = symbols('h1 h2 h3 h4',below_fermi=True, dummy=True)
+
+    from sympy.utilities.iterables import variations
+
+
+    # atv(abcd)att(abij)att(cdij)
+    template = atv(p1, p2, p3, p4)*att(p1, p2, i, j)*att(p3, p4, i, j)
+    permutator = variations([a,b,c,d], 4)
+    base = template.subs(zip([p1, p2, p3, p4], permutator.next()))
+    for permut in permutator:
+        subslist = zip([p1, p2, p3, p4], permut)
+        expr = template.subs(subslist)
+        assert substitute_dummies(expr) == substitute_dummies(base)
+    template = atv(p1, p2, p3, p4)*att(p1, p2, j, i)*att(p3, p4, i, j)
+    permutator = variations([a,b,c,d], 4)
+    base = template.subs(zip([p1, p2, p3, p4], permutator.next()))
+    for permut in permutator:
+        subslist = zip([p1, p2, p3, p4], permut)
+        expr = template.subs(subslist)
+        assert substitute_dummies(expr) == substitute_dummies(base)
+
+def test_equivalent_internal_lines_VT2_AT():
+    i,j,k,l = symbols('ijkl',below_fermi=True, dummy=True)
+    a,b,c,d = symbols('abcd',above_fermi=True, dummy=True)
+
+    exprs = [
+            # permute v. Same dummy order, not equivalent.
+            atv(i, j, a, b)*att(a, b, i, j),
+            atv(j, i, a, b)*att(a, b, i, j),
+            atv(i, j, b, a)*att(a, b, i, j),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) != substitute_dummies(permut)
+
+    exprs = [
+            # permute t.
+            atv(i, j, a, b)*att(a, b, i, j),
+            atv(i, j, a, b)*att(b, a, i, j),
+            atv(i, j, a, b)*att(a, b, j, i),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) != substitute_dummies(permut)
+
+    exprs = [ # permute v and t.  Relabelling of dummies should be equivalent.
+            atv(i, j, a, b)*att(a, b, i, j),
+            atv(j, i, a, b)*att(a, b, j, i),
+            atv(i, j, b, a)*att(b, a, i, j),
+            atv(j, i, b, a)*att(b, a, j, i),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+
+def test_internal_external_VT2T2_AT():
+    ii, jj = symbols('ij',below_fermi=True, dummy=False)
+    aa, bb = symbols('ab',above_fermi=True, dummy=False)
+    k, l = symbols('kl'  ,below_fermi=True, dummy=True)
+    c, d = symbols('cd'  ,above_fermi=True, dummy=True)
+
+    dums = _get_ordered_dummies
+
+    exprs = [
+            atv(k,l,c,d)*att(aa, c, ii, k)*att(bb, d, jj, l),
+            atv(l,k,c,d)*att(aa, c, ii, l)*att(bb, d, jj, k),
+            atv(k,l,d,c)*att(aa, d, ii, k)*att(bb, c, jj, l),
+            atv(l,k,d,c)*att(aa, d, ii, l)*att(bb, c, jj, k),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+    exprs = [
+            atv(k,l,c,d)*att(aa, c, ii, k)*att(d, bb, jj, l),
+            atv(l,k,c,d)*att(aa, c, ii, l)*att(d, bb, jj, k),
+            atv(k,l,d,c)*att(aa, d, ii, k)*att(c, bb, jj, l),
+            atv(l,k,d,c)*att(aa, d, ii, l)*att(c, bb, jj, k),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+    exprs = [
+            atv(k,l,c,d)*att(c, aa, ii, k)*att(bb, d, jj, l),
+            atv(l,k,c,d)*att(c, aa, ii, l)*att(bb, d, jj, k),
+            atv(k,l,d,c)*att(d, aa, ii, k)*att(bb, c, jj, l),
+            atv(l,k,d,c)*att(d, aa, ii, l)*att(bb, c, jj, k),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+
+def test_internal_external_pqrs_AT():
+    ii, jj = symbols('ij', dummy=False)
+    aa, bb = symbols('ab', dummy=False)
+    k, l = symbols('kl'  , dummy=True)
+    c, d = symbols('cd'  , dummy=True)
+
+
+    exprs = [
+            atv(k,l,c,d)*att(aa, c, ii, k)*att(bb, d, jj, l),
+            atv(l,k,c,d)*att(aa, c, ii, l)*att(bb, d, jj, k),
+            atv(k,l,d,c)*att(aa, d, ii, k)*att(bb, c, jj, l),
+            atv(l,k,d,c)*att(aa, d, ii, l)*att(bb, c, jj, k),
+            ]
+    for permut in exprs[1:]:
+        assert substitute_dummies(exprs[0]) == substitute_dummies(permut)
+

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -20,8 +20,9 @@ def test_PermutationOperator():
     p,q,r,s = symbols('pqrs')
     f,g,h,i = map(Function, 'fghi')
     P = PermutationOperator
-    assert (P(p,q).get_permuted(f(p)*g(q)) ==
-            -f(q)*g(p))
+    assert P(p,q).get_permuted(f(p)*g(q)) == -f(q)*g(p)
+    assert P(p,q).get_permuted(f(p, q)) == -f(q, p)
+    assert P(p,q).get_permuted(f(p)) == f(p)
     expr = (f(p)*g(q)*h(r)*i(s)
         - f(q)*g(p)*h(r)*i(s)
         - f(p)*g(q)*h(s)*i(r)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -524,6 +524,11 @@ def test_fully_contracted():
             simplify_kronecker_deltas=True)
     assert Vabij==AntiSymmetricTensor('v',(a,b),(i,j))
 
+def test_substitute_dummies_without_dummies():
+    i,j = symbols('ij')
+    assert substitute_dummies(att(i, j) + 2) == att(i, j) + 2
+    assert substitute_dummies(att(i, j) + 1) == att(i, j) + 1
+
 def test_dummy_order_inner_outer_lines_VT1T1T1():
     ii = symbols('i',below_fermi=True, dummy=False)
     aa = symbols('a',above_fermi=True, dummy=False)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -266,8 +266,8 @@ def test_commutation():
     D=KroneckerDelta
 
     assert C(Fd(a),F(i)) == -2*NO(F(i)*Fd(a))
-    assert C(Fd(j),NO(Fd(a)*F(i))).doit() == -D(j,i)*Fd(a)
-    assert C(Fd(a)*F(i),Fd(b)*F(j)).doit() == 0
+    assert C(Fd(j),NO(Fd(a)*F(i))).doit(wicks=True) == -D(j,i)*Fd(a)
+    assert C(Fd(a)*F(i),Fd(b)*F(j)).doit(wicks=True) == 0
 
 def test_create_f():
     i, j, n, m = symbols('i j n m')

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -111,7 +111,7 @@ def preview(expr, output='png', viewer=None, euler=True):
     tmp = tempfile.mktemp()
 
     tex = open(tmp + ".tex", "w")
-    tex.write(format % latex(expr, inline=True))
+    tex.write(format % latex(expr, mode='inline'))
     tex.close()
 
     cwd = os.getcwd()


### PR DESCRIPTION
These patches are my response to Ronan and Ondrej's comments  in pull request https://github.com/sympy/sympy/pull/32

I have however NOT adressed the following of Ronan's remarks:
- wicks() should not accept any of the keywords used in the old coupled-cluster example :
  While I agree to this, I haven't touched wicks() otherwise, so this concern does not apply to this particular set of patches.
- I was not able to run bin/test_coverage on my computer so I don't see exactly what tests are missing, and I thought the new functionality was very well tested.  Could someone post the output from bin/coverage_report sympy/physics/secondquant.py?   edit: I got it running, will add some more tests.
