### PR TITLE
Sympify fractions

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -465,13 +465,6 @@ class Rational(Number):
         if q is None:
             if isinstance(p, Rational):
                return p
-            try:
-                # fractions only available for python 2.6+
-                import fractions
-                if isinstance(p, fractions.Fraction):
-                    return Rational(p.numerator, p.denominator)
-            except ImportError:
-                pass
             if isinstance(p, basestring):
                 try:
                     # we might have a Real

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -465,6 +465,13 @@ class Rational(Number):
         if q is None:
             if isinstance(p, Rational):
                return p
+            try:
+                # fractions only available for python 2.6+
+                import fractions
+                if isinstance(p, fractions.Fraction):
+                    return Rational(p.numerator, p.denominator)
+            except ImportError:
+                pass
             if isinstance(p, basestring):
                 try:
                     # we might have a Real
@@ -1808,7 +1815,17 @@ class ImaginaryUnit(AtomicExpr):
     def _sage_(self):
         import sage.all as sage
         return sage.I
+
 I = S.ImaginaryUnit
+
+try:
+    # fractions is only available for python 2.6+
+    import fractions
+    def sympify_fractions(f):
+        return Rational(f.numerator, f.denominator)
+    converter[fractions.Fraction] = sympify_fractions
+except ImportError:
+    pass
 
 def sympify_complex(a):
     real, imag = map(sympify, (a.real, a.imag))

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -130,6 +130,13 @@ def test_Rational_new():
     assert Rational(19, 25).limit_denominator(4) == n3_4
     assert Rational('19/25').limit_denominator(4) == n3_4
 
+    # handle fractions.Fraction instances
+    try:
+        import fractions
+        assert Rational(fractions.Fraction(1, 2)) == Rational(1, 2)
+    except ImportError:
+        pass
+
 def test_Rational_cmp():
     n1 = Rational(1,4)
     n2 = Rational(1,3)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -47,6 +47,13 @@ def test_sympify1():
     # ... or from high precision reals
     assert sympify('.1234567890123456', rational=1) == Rational(19290123283179,  156250000000000)
 
+    # sympify fractions.Fraction instances
+    try:
+        import fractions
+        assert sympify(fractions.Fraction(1, 2)) == Rational(1, 2)
+    except ImportError:
+        pass
+
 def test_sympify2():
     class A:
         def _sympy_(self):


### PR DESCRIPTION
This patch allows sympy to handle fractions.Fraction instances as Rational rather than float.
