### PR TITLE
jn_zeros: added method='mpmath'

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -118,6 +118,10 @@ def jn_zeros(n, k, method="sympy"):
         from scipy.special import sph_jn
         from scipy.optimize import newton
         f  = lambda x: sph_jn(n, x)[0][-1]
+    elif method == 'mpmath':
+        # this needs a recent version of mpmath, newer than in sympy
+        from mpmath import besseljzero
+        return [besseljzero(n + 0.5, k) for k in xrange(1, k + 1)]
     else:
         raise NotImplementedError("Unknown method.")
     def solver(f, x):

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -48,3 +48,15 @@ def test_jn_zeros():
     assert eq(jn_zeros(3, 4), [6.987932, 10.417118, 13.698023, 16.923621])
     assert eq(jn_zeros(4, 4), [8.182561, 11.704907, 15.039664, 18.301255])
 
+def test_jn_zeros_mpmath():
+    try:
+        from mpmath import besseljzero
+    except ImportError:
+        return
+    zeros = lambda n, k: jn_zeros(n, k, method='mpmath')
+    assert eq(zeros(0, 4), [3.141592, 6.283185, 9.424777, 12.566370])
+    assert eq(zeros(1, 4), [4.493409, 7.725251, 10.904121, 14.066193])
+    assert eq(zeros(2, 4), [5.763459, 9.095011, 12.322940, 15.514603])
+    assert eq(zeros(3, 4), [6.987932, 10.417118, 13.698023, 16.923621])
+    assert eq(zeros(4, 4), [8.182561, 11.704907, 15.039664, 18.301255])
+


### PR DESCRIPTION
This uses a "better" method for calculating roots of the spherical bessel function, relying on mpmath's native tools. It should replace method='sympy', when mpmath in sympy gets upgraded.
