### PR TITLE
2114

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -820,10 +820,6 @@ class Expr(Basic, EvalfMixin):
             return c,e
         raise ValueError("cannot compute leadterm(%s, %s), got c=%s" % (self, x, c))
 
-    def as_Pow(self):
-        """Returns `self` as it was `Pow` instance. """
-        return (self, S.One)
-
     ###################################################################################
     ##################### DERIVATIVE, INTEGRAL, FUNCTIONAL METHODS ####################
     ###################################################################################

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -217,8 +217,6 @@ class AssocOp(Expr):
         """
         if isinstance(expr, cls):
             return expr.args
-        elif expr == cls.identity:
-            return ()
         else:
             return (expr,)
 
@@ -306,8 +304,6 @@ class LatticeOp(AssocOp):
         """
         if isinstance(expr, cls):
             return expr._argset
-        elif expr == cls.identity:
-            return frozenset()
         else:
             return frozenset([expr])
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -802,10 +802,6 @@ class Pow(Expr):
     def _sage_(self):
         return self.args[0]._sage_() ** self.args[1]._sage_()
 
-    def as_Pow(self):
-        """Returns `self` as it was `Pow` instance. """
-        return (self.base, self.exp)
-
 from add import Add
 from numbers import Integer
 from mul import Mul

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -720,12 +720,11 @@ def test_contains():
     assert g in p
     assert not h in p
 
-def test_as_Pow():
-    assert x.as_Pow() == (x, S.One)
-    assert (x*y*z).as_Pow() == (x*y*z, S.One)
-    assert (x+y+z).as_Pow() == (x+y+z, S.One)
-    assert ((x+y)**z).as_Pow() == (x+y, z)
-
+def test_as_base_exp():
+    assert x.as_base_exp() == (x, S.One)
+    assert (x*y*z).as_base_exp() == (x*y*z, S.One)
+    assert (x+y+z).as_base_exp() == (x+y+z, S.One)
+    assert ((x+y)**z).as_base_exp() == (x+y, z)
 
 def test_Basic_keep_sign():
     Basic.keep_sign = True

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -29,5 +29,5 @@ def test_lattice_print():
 
 def test_lattice_make_args():
     assert join.make_args(0) == set([0])
-    assert join.make_args(1) == set()
+    assert join.make_args(1) == set([1])
     assert join.make_args(join(2, 3, 4)) == set([S(2), S(3), S(4)])

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -254,9 +254,6 @@ class exp(Function):
         import sage.all as sage
         return sage.exp(self.args[0]._sage_())
 
-    def as_Pow(self):
-        return S.Exp1, self.args[0]
-
 class log(Function):
 
     nargs = (1,2)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -35,8 +35,8 @@ def test_exp():
     assert exp(x*log(x)) != x**x
     assert exp(sin(x)*log(x)) != x
 
-    assert exp(x).as_Pow() == (E, x)
-    assert exp(-x).as_Pow() == (E, -x)
+    assert exp(x).as_base_exp() == (E, x)
+    assert exp(-x).as_base_exp() == (E, -x)
 
 def test_log():
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -183,7 +183,7 @@ def test_conjuncts():
     assert conjuncts(A & B & C) == set([A, B, C])
     assert conjuncts((A | B) & C) == set([A | B, C])
     assert conjuncts(A) == set([A])
-    assert conjuncts(True) == set()
+    assert conjuncts(True) == set([True])
     assert conjuncts(False) == set([False])
 
 def test_disjuncts():
@@ -192,7 +192,7 @@ def test_disjuncts():
     assert disjuncts((A | B) & C) == set([(A | B) & C])
     assert disjuncts(A) == set([A])
     assert disjuncts(True) == set([True])
-    assert disjuncts(False) == set([])
+    assert disjuncts(False) == set([False])
 
 def test_distribute():
     A, B, C = map(Boolean, symbols('ABC'))

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -159,7 +159,7 @@ def _dict_from_basic_if_gens(ex, gens, **args):
                 coeff.append(factor)
             else:
                 try:
-                    base, exp = _analyze_power(*factor.as_Pow())
+                    base, exp = _analyze_power(*factor.as_base_exp())
                     monom[indices[base]] = exp
                 except KeyError:
                     if not factor.has(*gens):
@@ -208,7 +208,7 @@ def _dict_from_basic_no_gens(ex, **args):
             if factor.is_Number or _is_coeff(factor):
                 coeff.append(factor)
             else:
-                base, exp = _analyze_power(*factor.as_Pow())
+                base, exp = _analyze_power(*factor.as_base_exp())
 
                 elements[base] = exp
                 gens.add(base)

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -259,7 +259,7 @@ class Printer(object):
                     if factor.is_Number:
                         coeff.append(factor)
                     else:
-                        base, exp = _analyze_power(*factor.as_Pow())
+                        base, exp = _analyze_power(*factor.as_base_exp())
 
                         cpart[base] = exp
                         gens.add(base)


### PR DESCRIPTION
WIth this commit, 1) foo.make_args() will always return the args of the expression and not return the null tuple when the expression is the class identity. 2) as_Pow has been replaced with as_base_exp.
