### PR TITLE
1978

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -14,7 +14,7 @@ class Add(AssocOp):
     # cyclic import, so defined in numbers.py
 
     @classmethod
-    def flatten(cls, seq):
+    def flatten(cls, seq, **kwargs):
         """
         Takes the sequence "seq" of nested Adds and returns a flatten list.
 
@@ -62,6 +62,11 @@ class Add(AssocOp):
                 if c.is_Number:
                     if c is S.One:
                         s = o
+                    elif (len(o.args) == 2 and
+                          o.args[1].is_Add and
+                          o.args[1].is_commutative):
+                        seq.extend([c*si for si in o.args[1].args])
+                        continue
                     else:
                         s = o.as_two_terms()[1]
 
@@ -110,7 +115,8 @@ class Add(AssocOp):
 
                 else:
                     # alternatively we have to call all Mul's machinery (slow)
-                    newseq.append(Mul(c,s))
+                    term = Mul(c, s)
+                    newseq.append(term)
 
             noncommutative = noncommutative or not s.is_commutative
 

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -119,6 +119,7 @@ C = ClassRegistry()
 class BasicMeta(BasicType):
 
     keep_sign = False
+    keep_coeff = False
 
     def __init__(cls, *args, **kws):
         setattr(C, cls.__name__, cls)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -27,7 +27,7 @@ class Mul(AssocOp):
     @classmethod
     def flatten(cls, seq, **kwargs):
         """Return the sequence of items to be multiplied in canonical form.
-        If kwargs['keep_coeff']=False (default) then a numerical constant will not be
+        If Basic.keep_coeff=False (default) then a numerical constant will be
         distributed into a single Add, e.g. 2*(1 + x) won't become 2 + 2*x.
         """
 
@@ -306,9 +306,9 @@ class Mul(AssocOp):
             # there are failures in recurr.py if this is not here; the biggest
             # one is rsolve_hyper([n**2-2, -2*n-1, 1], 0, n) giving 0 rather
             # than something like C0*rf(sqrt(2), n) + C1*rf(-sqrt(2), n).
-            #   To allow the 2-arg behavior to be overidden the keyword
-            # keep_coeff=False can be used, e.g. Mul(2, 1+x, keep_coeff=False) -> 2*(1 + x)
-            if (not kwargs.get('keep_coeff', False) and
+            #   To allow the 2-arg behavior to be overidden, Basic.keep_coeff=False can be set.
+            # e.g. Basic.keep_coeff = True; Mul(2, 1+x) -> 2*(1 + x)
+            if (not Basic.keep_coeff and
                 len(c_part)==2 and
                 c_part[0].is_Number and
                 c_part[1].is_Add):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -38,7 +38,7 @@ class AssocOp(Expr):
             obj = Expr.__new__(cls, *args, **assumptions)
             obj.is_commutative = all(arg.is_commutative for arg in args)
             return obj
-        c_part, nc_part, order_symbols = cls.flatten(args)
+        c_part, nc_part, order_symbols = cls.flatten(args, **assumptions)
         if len(c_part) + len(nc_part) <= 1:
             if c_part:
                 obj = c_part[0]

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -70,11 +70,13 @@ class AssocOp(Expr):
            x*y
 
         """
-        if len(args) == 1:
-            obj = args[0]
-        else:
+        if len(args) > 1:
             obj = Expr.__new__(type(self), *args)  # NB no assumptions for Add/Mul
             obj.is_commutative = self.is_commutative
+        elif len(args) == 1:
+            obj = args[0]
+        else:
+            obj = self.identity
 
         return obj
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -769,10 +769,14 @@ def test_as_powers_dict():
 
 def test_new_rawargs():
     x = Symbol('x')
-    assert 2*x == Mul._new_rawargs(3*x, *[S(2), x])
-    assert 2 + x == Add._new_rawargs(3 + x, *[S(2), x])
-    assert x == Mul._new_rawargs(3*x, *[x])
-    assert x == Add._new_rawargs(3 + x, *[x])
+    m = 3*x
+    a = 3 + x
+    assert 2*x == m._new_rawargs(*[S(2), x])
+    assert 2 + x == a._new_rawargs(*[S(2), x])
+    assert x == m._new_rawargs(*[x])
+    assert x == a._new_rawargs(*[x])
+    assert 1 == m._new_rawargs(*[])
+    assert 0 == a._new_rawargs(*[])
 
 def test_2127():
     assert Add(evaluate=False) == 0

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -782,3 +782,9 @@ def test_2127():
     assert Add(evaluate=False) == 0
     assert Mul(evaluate=False) == 1
     assert Mul(x+y, evaluate=False).is_Add
+
+def test_keep_coeff():
+    m = Mul(2, 1 + x, keep_coeff=True)
+    assert m == Mul(2, 1 + x, evaluate=False)
+    assert 1 + m == 3 + 2*x
+    assert 2*m == 4 + 4*x

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -784,7 +784,11 @@ def test_2127():
     assert Mul(x+y, evaluate=False).is_Add
 
 def test_keep_coeff():
-    m = Mul(2, 1 + x, keep_coeff=True)
-    assert m == Mul(2, 1 + x, evaluate=False)
+    was  = Basic.keep_coeff
+    if not was:
+        Basic.keep_coeff = True
+    m = Mul(2, 1 + x)
+    assert m == Mul(2, 1 + x)
+    Basic.keep_coeff = was
     assert 1 + m == 3 + 2*x
     assert 2*m == 4 + 4*x


### PR DESCRIPTION
This commit allows one to skip the distribution of a constant over an Add (so `2*(1+x)` can be returned rather than `2+2*x`). This commit does not use the evaluate=False approach.
