### PR TITLE
Doctest

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -73,7 +73,7 @@ def smoothness_p(n, m=-1, power=0, visual=None):
         >>> factorint(17*9)
         {3: 2, 17: 1}
         >>> smoothness_p(_)
-        'p**i=3**2 has p-1 B=2, B-pow=2\np**i=17**1 has p-1 B=2, B-pow=16
+        'p**i=3**2 has p-1 B=2, B-pow=2\\np**i=17**1 has p-1 B=2, B-pow=16'
         >>> smoothness_p(_)
         {3: 2, 17: 1}
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -575,6 +575,8 @@ class SymPyDocTestFinder(DocTestFinder):
                         try:
                             valname = '%s.%s' % (name, rawname)
                             self._find(tests, val, valname, module, source_lines, globs, seen)
+                        except ValueError, msg:
+                            raise
                         except:
                             pass
 


### PR DESCRIPTION
Doctests that had bad formatting (i.e. were not triple quote or blank line terminated) now flag an error during doctests. This identified a problem with an existing doctest that was corrected.
