### PR TITLE
Sysfix: Keep sys from being imported into the global namespace

### DIFF
--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -22,3 +22,4 @@ from pytest import raises
 
 from cythonutils import cythonized
 
+del sys


### PR DESCRIPTION
While fixing [issue 2135](http://code.google.com/p/sympy/issues/detail?id=2135), I noticed that `sys` was being imported into the global namespace because it was being imported in `utilities/__init__.py` to check the Python version (to see if it needs to import any/all for Python 2.4), and it wasn't being deleted.  The result was that `sys` is imported into the namespace with every `from sympy import *`.  

Here is a trivial fix.  
