### PR TITLE
Python24: Issue a warning when using Python 2.4

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -11,6 +11,14 @@ See the webpage for more information and documentation:
 
 __version__ = "0.6.7-git"
 
+import sys
+import warnings
+
+if sys.version_info[1] == 4:
+    warnings.warn("Support for Python 2.4 in SymPy is deprecated.")
+
+del sys
+del warnings
 
 def __sympy_debug():
     # helper function so we don't import os globally

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -15,7 +15,8 @@ import sys
 import warnings
 
 if sys.version_info[1] == 4:
-    warnings.warn("Support for Python 2.4 in SymPy is deprecated.")
+    warnings.warn("Support for Python 2.4 in SymPy is deprecated.",
+        DeprecationWarning)
 
 del sys
 del warnings


### PR DESCRIPTION
See [issue 2135](http://code.google.com/p/sympy/issues/detail?id=2135).  This adds a warning to `sympy/__init__.py`, so that any time you run Python 2.4 and import sympy, you see:

```
Python 2.4.4 (#1, Oct 18 2006, 10:34:39) 
[GCC 4.0.1 (Apple Computer, Inc. build 5341)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sympy
sympy/__init__.py:18: UserWarning: Support for Python 2.4 in SymPy is deprecated.
  warnings.warn("Support for Python 2.4 in SymPy is deprecated.")
>>>
```

and ditto for isympy:

```
$python2.4 bin/isympy 
sympy/__init__.py:18: UserWarning: Support for Python 2.4 in SymPy is deprecated.
  warnings.warn("Support for Python 2.4 in SymPy is deprecated.")
Couldn't locate IPython. Having IPython installed is greatly recommended.
See http://ipython.scipy.org for more details.  If you use Debian/Ubuntu,
just install the 'ipython' package and start isympy again.

Python console for SymPy 0.6.7-git (Python 2.4.4)

These commands were executed:
>>> from __future__ import division
>>> from sympy import *
>>> x, y, z = symbols('xyz')
>>> k, m, n = symbols('kmn', integer=True)
>>> f, g, h = map(Function, 'fgh')

Documentation can be found at http://sympy.org/

>>> 
```

The warning prints pretty much instantly after running `import sympy`, indicating to me that importing sys and warnings do not add very much time to the import time at all.  

By the way, the plan is to drop support soon after releasing 0.7.0, so this needs to go in before the release.  Then, after we release, I will (gladly!) create a patch removing all the Python 2.4 nonsense.  
