### PR TITLE
2137: Fix a bug in as_real_imag()

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -464,11 +464,11 @@ class Pow(Expr):
             # Terms with even b powers will be real
             r = [i for i in expr.terms() if not i[0][1] % 2]
             re_part = Add(*[cc*a**aa*b**bb for (aa, bb), cc in r])
-            # Terms odd b powers will be imaginary
+            # Terms with odd b powers will be imaginary
             r = [i for i in expr.terms() if i[0][1] % 4 == 1]
             im_part1 = Add(*[cc*a**aa*b**bb for (aa, bb), cc in r])
             r = [i for i in expr.terms() if i[0][1] % 4 == 3]
-            im_part3 = Add(*[cc*a**a*b**bb for (aa, bb), cc in r])
+            im_part3 = Add(*[cc*a**aa*b**bb for (aa, bb), cc in r])
 
             return (re_part.subs({a: re, b: S.ImaginaryUnit*im}),
             im_part1.subs({a: re, b: im}) + im_part3.subs({a: re, b: -im}))

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -131,4 +131,5 @@ def test_issue_1985():
     assert ((x + x*I)/(1 + I)).as_real_imag() == (re((x + I*x)/(1 + I)), im((x + I*x)/(1 + I)))
 
 def test_issue_2137():
-    assert (cos(1+I)**3).as_real_imag() == (-3*sin(1)**2*sinh(1)**2*cos(1)*cosh(1) + cos(1)**3*cosh(1)**3, -3*cos(1)**2*cosh(1)**2*sin(1)*sinh(1) + sin(1)**3*sinh(1)**3)
+    assert (cos(1+I)**3).as_real_imag() == (-3*sin(1)**2*sinh(1)**2*cos(1)*cosh(1) +
+        cos(1)**3*cosh(1)**3, -3*cos(1)**2*cosh(1)**2*sin(1)*sinh(1) + sin(1)**3*sinh(1)**3)

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -129,3 +129,6 @@ def test_re_im1652():
 def test_issue_1985():
     x = Symbol('x')
     assert ((x + x*I)/(1 + I)).as_real_imag() == (re((x + I*x)/(1 + I)), im((x + I*x)/(1 + I)))
+
+def test_issue_2137():
+    assert (cos(1+I)**3).as_real_imag() == (-3*sin(1)**2*sinh(1)**2*cos(1)*cosh(1) + cos(1)**3*cosh(1)**3, -3*cos(1)**2*cosh(1)**2*sin(1)*sinh(1) + sin(1)**3*sinh(1)**3)


### PR DESCRIPTION
See the issue page.  The bug was with `(cos(1+I)**3).as_real_imag()`.
