### PR TITLE
2018 as_coeff_ (terms/factors) now (mul/add)

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -1,7 +1,7 @@
 from core import Symbol
 
 _latin = list('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
-# COSINEQ should not be imported as they clash
+# COSINEQ should not be imported as they clash; gamma, pi and zeta clash, too
 _greek = 'alpha beta gamma delta epsilon zeta eta theta iota kappa '\
   'mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega'.split(' ')
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -104,7 +104,7 @@ def refine_Pow(expr, assumptions):
                 #  - a single odd term + 1
                 #  - A numerical constant N can be replaced with mod(N,2)
 
-                coeff, terms = expr.exp.as_coeff_factors()
+                coeff, terms = expr.exp.as_coeff_add()
                 terms = set(terms)
                 even_terms = set([])
                 odd_terms = set([])

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -167,12 +167,10 @@ def summation(f, *symbols, **kwargs):
     i.e.,
 
                                 b
-                              -----
-                              \
-    summation(f, (i, a, b)) =  \    f
-                               /
-                              /
-                              -----
+                              ____
+                              \   `
+    summation(f, (i, a, b)) =  )    f
+                              /___,
                               i = a
 
 
@@ -193,10 +191,6 @@ def summation(f, *symbols, **kwargs):
 
     """
     return Sum(f, *symbols, **kwargs).doit(deep=False)
-
-def getab(expr):
-    cls = expr.func
-    return cls(expr.args[0]), cls(*expr.args[1:])
 
 def telescopic_direct(L, R, n, (i, a, b)):
     """Returns the direct summation of the terms of a telescopic sum
@@ -276,7 +270,7 @@ def eval_sum_symbolic(f, (i, a, b)):
         return f*(b-a+1)
     # Linearity
     if f.is_Mul:
-        L, R = getab(f)
+        L, R = f.as_two_terms()
         if not L.has(i):
             sR = eval_sum_symbolic(R, (i, a, b))
             if sR: return L*sR
@@ -284,7 +278,7 @@ def eval_sum_symbolic(f, (i, a, b)):
             sL = eval_sum_symbolic(L, (i, a, b))
             if sL: return R*sL
     if f.is_Add:
-        L, R = getab(f)
+        L, R = f.as_two_terms()
         lrsum = telescopic(L, R, (i, a, b))
         if lrsum: return lrsum
         lsum = eval_sum_symbolic(L, (i, a, b))

--- a/sympy/concrete/sums_products.py
+++ b/sympy/concrete/sums_products.py
@@ -7,10 +7,6 @@ from sympy.core import Basic, C, Rational, Pow, Symbol, Wild, oo, sympify
 def ispoly(expr, var):
     return False
 
-def getab(expr):
-    cls = expr.__class__
-    return cls(expr.args[0]), cls(*expr.args[1:])
-
 def indexsymbol(a):
     if isinstance(a, Symbol):
         return Symbol(a.name, integer=True)
@@ -55,11 +51,11 @@ class Sum2(_BigOperator):
         if not f.has(i):
             return f*(b-a+1)
         if f.is_Mul:
-            L, R = getab(f)
+            L, R = f.as_two_terms()
             if not L.has(i): return L*Sum2(R, (i, a, b))
             if not R.has(i): return R*Sum2(L, (i, a, b))
         if f.is_Add:
-            L, R = getab(f)
+            L, R = f.as_two_terms()
             lsum = Sum2(L, (i,a,b))
             rsum = Sum2(R, (i,a,b))
             if not isinstance(lsum, Sum2) and not isinstance(rsum, Sum2):
@@ -131,7 +127,7 @@ class Product(_BigOperator):
             return f**(b-a+1)
 
         if f.is_Mul:
-            L, R = getab(f)
+            L, R = f.as_two_terms()
             lp = Product(L, (i, a, b))
             rp = Product(R, (i, a, b))
             if not (isinstance(lp, Product) and isinstance(rp, Product)):

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,7 +1,6 @@
 from sympy import (Symbol, Sum, oo, Real, Rational, summation, pi, cos, zeta,
     Catalan, exp, log, factorial, sqrt, E, sympify, binomial, EulerGamma,
     Function, Integral, Product, product, Tuple, Eq, Interval, nan)
-from sympy.concrete.summations import getab
 from sympy.concrete.sums_products import Sum2
 from sympy.utilities.pytest import XFAIL, raises
 

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -162,7 +162,7 @@ class Add(AssocOp):
 
 
     @cacheit
-    def as_coeff_factors(self, x=None):
+    def as_coeff_add(self, x=None):
         if x is not None:
             l1 = []
             l2 = []
@@ -186,9 +186,9 @@ class Add(AssocOp):
 
     def _matches_simple(self, expr, repl_dict):
         # handle (w+3).matches('x+5') -> {w: x+2}
-        coeff, factors = self.as_coeff_factors()
-        if len(factors)==1:
-            return factors[0].matches(expr - coeff, repl_dict)
+        coeff, terms = self.as_coeff_add()
+        if len(terms)==1:
+            return terms[0].matches(expr - coeff, repl_dict)
         return
 
     matches = AssocOp._matches_commutative
@@ -292,7 +292,7 @@ class Add(AssocOp):
         if c.is_nonnegative and r.is_nonnegative:
             return False
 
-    def as_coeff_terms(self, x=None):
+    def as_coeff_mul(self, x=None):
         # -2 + 2 * a -> -1, 2-2*a
         if self.args[0].is_Number and self.args[0].is_negative:
             return -S.One,(-self,)
@@ -304,14 +304,14 @@ class Add(AssocOp):
         from function import FunctionClass
         if isinstance(old, FunctionClass):
             return self.__class__(*[s._eval_subs(old, new) for s in self.args ])
-        coeff_self, factors_self = self.as_coeff_factors()
-        coeff_old, factors_old = old.as_coeff_factors()
-        if factors_self == factors_old: # (2+a).subs(3+a,y) -> 2-3+y
+        coeff_self, terms_self = self.as_coeff_add()
+        coeff_old, terms_old = old.as_coeff_add()
+        if terms_self == terms_old: # (2+a).subs(3+a,y) -> 2-3+y
             return Add(new, coeff_self, -coeff_old)
         if old.is_Add:
-            if len(factors_old) < len(factors_self): # (a+b+c+d).subs(b+c,x) -> a+x+d
-                self_set = set(factors_self)
-                old_set = set(factors_old)
+            if len(terms_old) < len(terms_self): # (a+b+c+d).subs(b+c,x) -> a+x+d
+                self_set = set(terms_self)
+                old_set = set(terms_old)
                 if old_set < self_set:
                     ret_set = self_set - old_set
                     return Add(new, coeff_self, -coeff_old, *[s._eval_subs(old, new) for s in ret_set])
@@ -360,16 +360,16 @@ class Add(AssocOp):
         return (self.new(*re_part), self.new(*im_part))
 
     def _eval_as_leading_term(self, x):
-        coeff, factors = self.as_coeff_factors(x)
+        coeff, terms = self.as_coeff_add(x)
         has_unbounded = bool([f for f in self.args if f.is_unbounded])
         if has_unbounded:
-            if isinstance(factors, Basic):
-                factors = factors.args
-            factors = [f for f in factors if not f.is_bounded]
+            if isinstance(terms, Basic):
+                terms = terms.args
+            terms = [f for f in terms if not f.is_bounded]
         if coeff is not S.Zero:
             o = C.Order(x)
         else:
-            o = C.Order(factors[0]*x,x)
+            o = C.Order(terms[0]*x,x)
         n = 1
         s = self.nseries(x, 0, n)
         while s.is_Order:
@@ -386,13 +386,13 @@ class Add(AssocOp):
         #         n          n          n
         # (-3 + y)   ->  (-1)  * (3 - y)
         #
-        # At present, as_coeff_terms return +/-1 but the
+        # At present, as_coeff_mul return +/-1 but the
         # following should work even if that changes.
         if Basic.keep_sign:
             return None
 
         rv = None
-        c, t = self.as_coeff_terms()
+        c, t = self.as_coeff_mul()
         if c.is_negative and not other.is_integer:
             if c is not S.NegativeOne and self.is_positive:
                 coeff = C.Pow(-c, other)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -252,8 +252,7 @@ class Add(AssocOp):
         return False
 
     def _eval_is_positive(self):
-        c = self.args[0]
-        r = self._new_rawargs(*self.args[1:])
+        c, r = self.as_two_terms()
         if c.is_positive and r.is_positive:
             return True
         if c.is_unbounded:
@@ -272,8 +271,7 @@ class Add(AssocOp):
             return False
 
     def _eval_is_negative(self):
-        c = self.args[0]
-        r = self._new_rawargs(*self.args[1:])
+        c, r = self.as_two_terms()
         if c.is_negative and r.is_negative:
             return True
         if c.is_unbounded:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -206,8 +206,6 @@ class Add(AssocOp):
 
     @cacheit
     def as_two_terms(self):
-        if len(self.args) == 1:
-            return S.Zero, self
         return self.args[0], self._new_rawargs(*self.args[1:])
 
     def as_numer_denom(self):
@@ -216,7 +214,8 @@ class Add(AssocOp):
             numers.append(n)
             denoms.append(d)
         r = xrange(len(numers))
-        return Add(*[Mul(*(denoms[:i]+[numers[i]]+denoms[i+1:])) for i in r]),Mul(*denoms)
+        return Add(*[Mul(*(denoms[:i]+[numers[i]]+denoms[i+1:]))
+                     for i in r]), Mul(*denoms)
 
     def count_ops(self, symbolic=True):
         if symbolic:
@@ -295,13 +294,12 @@ class Add(AssocOp):
     def as_coeff_mul(self, x=None):
         # -2 + 2 * a -> -1, 2-2*a
         if self.args[0].is_Number and self.args[0].is_negative:
-            return -S.One,(-self,)
-        return S.One,(self,)
+            return S.NegativeOne, (-self,)
+        return S.One, (self,)
 
     def _eval_subs(self, old, new):
         if self == old:
             return new
-        from function import FunctionClass
         if isinstance(old, FunctionClass):
             return self.__class__(*[s._eval_subs(old, new) for s in self.args ])
         coeff_self, terms_self = self.as_coeff_add()
@@ -512,5 +510,6 @@ class Add(AssocOp):
         return s
 
 
+from function import FunctionClass
 from mul import Mul
 from symbol import Symbol

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -397,7 +397,7 @@ class Basic(AssumeMeths):
 
            >>> from sympy import I, pi, sin
            >>> from sympy.abc import x, y
-           >>> set((1+x+2*sin(y+I*pi)).atoms())
+           >>> (1 + x + 2*sin(y + I*pi)).atoms()
            set([1, 2, pi, x, y, I])
 
            If one or more types are given, the results will contain only
@@ -406,16 +406,16 @@ class Basic(AssumeMeths):
            Examples::
 
            >>> from sympy import Number, NumberSymbol, Symbol
-           >>> (1+x+2*sin(y+I*pi)).atoms(Symbol)
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(Symbol)
            set([x, y])
 
-           >>> (1+x+2*sin(y+I*pi)).atoms(Number)
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(Number)
            set([1, 2])
 
-           >>> (1+x+2*sin(y+I*pi)).atoms(Number, NumberSymbol)
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(Number, NumberSymbol)
            set([1, 2, pi])
 
-           >>> (1+x+2*sin(y+I*pi)).atoms(Number, NumberSymbol, I)
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(Number, NumberSymbol, I)
            set([1, 2, pi, I])
 
            Note that I (imaginary unit) and zoo (complex infinity) are special
@@ -423,7 +423,7 @@ class Basic(AssumeMeths):
 
            The type can be given implicitly, too::
 
-           >>> (1+x+2*sin(y+I*pi)).atoms(x) # x is a Symbol
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(x) # x is a Symbol
            set([x, y])
 
            Be careful to check your assumptions when using the implicit option
@@ -432,10 +432,10 @@ class Basic(AssumeMeths):
            integers in an expression::
 
            >>> from sympy import S
-           >>> (1+x+2*sin(y+I*pi)).atoms(S(1))
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(S(1))
            set([1])
 
-           >>> (1+x+2*sin(y+I*pi)).atoms(S(2))
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(S(2))
            set([1, 2])
 
            Finally, arguments to atoms() can select more than atomic atoms: any
@@ -444,15 +444,14 @@ class Basic(AssumeMeths):
            expression recursively::
 
            >>> from sympy import Function, Mul
-           >>> (1+x+2*sin(y+I*pi)).atoms(Function)
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(Function)
            set([sin(y + pi*I)])
 
-           >>> (1+x+2*sin(y+I*pi)).atoms(Mul)
+           >>> (1 + x + 2*sin(y + I*pi)).atoms(Mul)
            set([2*sin(y + pi*I), pi*I])
 
 
         """
-
 
         def _atoms(expr, typ):
             """Helper function for recursively denesting atoms"""
@@ -507,13 +506,11 @@ class Basic(AssumeMeths):
            True
 
         """
-        result = False
-        for obj in self.iter_basic_args():
-            if obj.is_number:
-                result = True
-            else:
-                return False
-        return result
+        from sympy.utilities import all
+
+        if not self.args:
+            return False
+        return all(obj.is_number for obj in self.iter_basic_args())
 
     @property
     def func(self):
@@ -655,21 +652,15 @@ class Basic(AssumeMeths):
             return None
 
     def as_basic(self):
-        """Converts polynomial to a valid sympy expression.
+        """A method to be subclassed to return an object in basic form.
 
-           >>> from sympy import sin
-           >>> from sympy.abc import x, y
-
-           >>> p = (x**2 + x*y).as_poly(x, y)
-
-           >>> p.as_basic()
-           x*y + x**2
-
-           >>> f = sin(x)
-
-           >>> f.as_basic()
-           sin(x)
-
+        Example:
+        >>> from sympy import Poly
+        >>> from sympy.abc import x
+        >>> Poly(x)
+        Poly(x, x, domain='ZZ')
+        >>> _.as_basic()
+        x
         """
         return self
 
@@ -785,6 +776,7 @@ class Basic(AssumeMeths):
             else:
                 subst.append(pattern)
         subst.reverse()
+
         return self._subs_list(subst)
 
     def _seq_subs(self, old, new):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -232,9 +232,10 @@ class Expr(Basic, EvalfMixin):
         if x.is_Integer:
             return
 
+        result = self
         if expand:
-            self = self.expand() # collect expects its arguments in expanded form
-        result = collect(self, x, evaluate=False, exact=True)
+            result = result.expand() # collect expects its arguments in expanded form
+        result = collect(result, x, evaluate=False, exact=True)
         if x in result:
             return result[x]
         else:
@@ -788,11 +789,11 @@ class Expr(Basic, EvalfMixin):
         we = Wild('we')
         p  = wc*x**we
         from sympy import collect
-        self = collect(self, x)
-        d = self.match(p)
+        s = collect(self, x)
+        d = s.match(p)
         if d is not None and we in d:
             return d[wc], d[we]
-        return self, S.Zero
+        return s, S.Zero
 
     def leadterm(self, x):
         """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -5,7 +5,6 @@ from evalf import EvalfMixin
 from decorators import _sympifyit, call_highest_priority
 from cache import cacheit
 
-
 def call_other(self, other):
     if hasattr(other, '_op_priority'):
         if other._op_priority > self._op_priority:
@@ -232,7 +231,7 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy import collect
         x = sympify(x)
-        const = x.as_coeff_terms()[0] # constant multiplying x
+        const = x.as_coeff_mul()[0] # constant multiplying x
         if const != S.One: # get rid of constants
             result = self.coeff(x/const)
             if result is not None:
@@ -367,14 +366,24 @@ class Expr(Basic, EvalfMixin):
         return self, S.One
 
     def as_coeff_terms(self, x=None):
+        import warnings
+        warnings.warn("\nuse as_coeff_mul() instead of as_coeff_terms().",
+                      DeprecationWarning)
+
+    def as_coeff_factors(self, x=None):
+        import warnings
+        warnings.warn("\nuse as_coeff_add() instead of as_coeff_factors().",
+                      DeprecationWarning)
+
+    def as_coeff_mul(self, x=None):
         # a -> c * t
         if x is not None:
             if not self.has(x):
                 return self, tuple()
         return S.One, (self,)
 
-    def as_coeff_factors(self, x=None):
-        # a -> c + f
+    def as_coeff_add(self, x=None):
+        # a -> c + t
         if x is not None:
             if not self.has(x):
                 return self, tuple()
@@ -399,7 +408,7 @@ class Expr(Basic, EvalfMixin):
         #               n.subs({l: 0, r: -1})), d.subs({l: 1, r: 1})
 
         base, exp = self.as_base_exp()
-        coeff, terms = exp.as_coeff_terms()
+        coeff, terms = exp.as_coeff_mul()
         if coeff.is_negative:
             # b**-e -> 1, b**e
             return S.One, base ** (-exp)
@@ -584,9 +593,9 @@ class Expr(Basic, EvalfMixin):
                 if subs1 != None:
                     return subs1 + terms[0]
         elif self.is_Mul:
-            self_coeff, self_terms = self.as_coeff_terms()
+            self_coeff, self_terms = self.as_coeff_mul()
             if c.is_Mul:
-                c_coeff, c_terms = c.as_coeff_terms()
+                c_coeff, c_terms = c.as_coeff_mul()
                 if c_terms == self_terms:
                     new_coeff = self_coeff.extract_additively(c_coeff)
                     if new_coeff != None:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -140,7 +140,7 @@ class Application(Basic):
             if arg.is_positive: return S.One
             if arg.is_negative: return S.NegativeOne
             if isinstance(arg, C.Mul):
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
                 if coeff is not S.One:
                     return cls(coeff) * cls(C.Mul(*terms))
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -486,7 +486,7 @@ class WildFunction(Function, AtomicExpr):
     def __new__(cls, name=None, **assumptions):
         if name is None:
             name = 'Wf%s' % (C.Symbol.dummycount + 1) # XXX refactor dummy counting
-            Symbol.dummycount += 1
+            C.Symbol.dummycount += 1
         obj = Function.__new__(cls, name, **assumptions)
         obj.name = name
         return obj

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -150,7 +150,7 @@ class Mul(AssocOp):
         # We do want a combined exponent if it would not be an Add, such as
         #  y    2y     3y
         # x  * x   -> x
-        # We determine this if two exponents have the same term in as_coeff_terms
+        # We determine this if two exponents have the same term in as_coeff_mul
         #
         # Unfortunately, this isn't smart enough to consider combining into
         # exponents that might already be adds, so things like:
@@ -162,7 +162,7 @@ class Mul(AssocOp):
 
         # First gather exponents of common bases
         for b, e in c_powers:
-            co = e.as_coeff_terms()
+            co = e.as_coeff_mul()
             if b in common_b:
                 if  co[1] in common_b[b]:
                     common_b[b][co[1]] += co[0]
@@ -180,7 +180,7 @@ class Mul(AssocOp):
         new_num_exp = []
         common_b = {} # b:e
         for b, e in num_exp:
-            co = e.as_coeff_terms()
+            co = e.as_coeff_mul()
             if b in common_b:
                 if  co[1] in common_b[b]:
                     common_b[b][co[1]] += co[0]
@@ -321,7 +321,7 @@ class Mul(AssocOp):
                     return Mul(*[s**e for s in b.args])
 
                 if e.is_rational:
-                    coeff, rest = b.as_coeff_terms()
+                    coeff, rest = b.as_coeff_mul()
                     unk=[]
                     nonneg=[]
                     neg=[]
@@ -362,18 +362,18 @@ class Mul(AssocOp):
                        Pow(Mul(*unk), e)
 
 
-                coeff, rest = b.as_coeff_terms()
+                coeff, rest = b.as_coeff_mul()
                 if coeff is not S.One:
                     # (2*a)**3 -> 2**3 * a**3
                     return Mul(Pow(coeff, e), Mul(*[s**e for s in rest]))
             elif e.is_Integer:
-                coeff, rest = b.as_coeff_terms()
+                coeff, rest = b.as_coeff_mul()
                 if coeff == S.One:
                     return
                 else:
                     return Mul(Pow(coeff, e), Pow(Mul(*rest), e))
 
-        c, t = b.as_coeff_terms()
+        c, t = b.as_coeff_mul()
         if e.is_even and c.is_Number and c < 0:
             return Pow((Mul(-c, Mul(*t))), e)
 
@@ -396,7 +396,7 @@ class Mul(AssocOp):
             return args[0], self._new_rawargs(*args[1:])
 
     @cacheit
-    def as_coeff_terms(self, x=None):
+    def as_coeff_mul(self, x=None):
         if x is not None:
             l1 = []
             l2 = []
@@ -551,7 +551,7 @@ class Mul(AssocOp):
 
     def _matches_simple(self, expr, repl_dict):
         # handle (w*3).matches('x*5') -> {w: x*5/3}
-        coeff, terms = self.as_coeff_terms()
+        coeff, terms = self.as_coeff_mul()
         if len(terms)==1:
             return terms[0].matches(expr / coeff, repl_dict)
         return
@@ -825,8 +825,8 @@ class Mul(AssocOp):
             return self.__class__(*[s._eval_subs(old, new) for s in self.args ])
 
         # break up self and old into terms
-        coeff_self,terms_self = self.as_coeff_terms()
-        coeff_old,terms_old = old.as_coeff_terms()
+        coeff_self,terms_self = self.as_coeff_mul()
+        coeff_old,terms_old = old.as_coeff_mul()
 
         # NEW - implementation of strict substitution
         # if the coefficients are not the same, do not substitute.

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -816,130 +816,247 @@ class Mul(AssocOp):
             return False
 
     def _eval_subs(self, old, new):
-        # base cases
-        # simplest
+
+        from __builtin__ import min as pymin
+
+        from sympy import sign
+        from sympy.simplify.simplify import powdenest
+        from sympy.utilities.iterables import any
+
         if self == old:
             return new
-        # pass it off to its own class
-        if isinstance(old, FunctionClass):
-            return self.__class__(*[s._eval_subs(old, new) for s in self.args ])
 
-        # break up self and old into terms
-        coeff_self,terms_self = self.as_coeff_mul()
-        coeff_old,terms_old = old.as_coeff_mul()
+        def fallback():
+            """Return this value when partial subs has failed."""
 
-        # NEW - implementation of strict substitution
-        # if the coefficients are not the same, do not substitute.
-        # the only exception is if old has a coefficient of 1, then always to the sub.
-        if coeff_self != coeff_old and coeff_old != 1:
-            return self.__class__(*[s._eval_subs(old, new) for s in self.args])
+            return self.__class__(*[s._eval_subs(old, new) for s in
+                                  self.args])
 
-        # break up powers, i.e., x**2 -> x*x
-        def breakup(terms):
-            temp = []
-            for t in terms:
-                if isinstance(t,Pow) and isinstance(t.exp, Integer):
-                    if t.exp.is_positive:
-                        temp.extend([t.base]*int(t.exp))
-                    elif t.exp.is_negative:
-                        temp.extend([1/t.base]*int(abs(t.exp)))
-                else:
-                    temp.append(t)
-            return temp
-        terms_old = breakup(terms_old)
-        terms_self = breakup(terms_self)
+        def breakup(eq):
+            """break up powers assuming (not checking) that eq is a Mul:
+                   b**(Rational*e) -> b**e, Rational
+                commutatives come back as a dictionary {b**e: Rational}
+                noncommutatives come back as a list [(b**e, Rational)]
+            """
 
-        # break up old and self terms into commutative and noncommutative lists
-        comm_old = []; noncomm_old = []
-        comm_self = []; noncomm_self = []
-        for o in terms_old:
-            if o.is_commutative:
-                comm_old.append(o)
-            else:
-                noncomm_old.append(o)
-        for s in terms_self:
-            if s.is_commutative:
-                comm_self.append(s)
-            else:
-                noncomm_self.append(s)
-        comm_old_len, noncomm_old_len = len(comm_old), len(noncomm_old)
-        comm_self_len, noncomm_self_len = len(comm_self), len(noncomm_self)
-
-        # if the noncommutative part of the 'to-be-replaced' expression is
-        # smaller than the noncommutative part of the whole expression, scan
-        # to see if the whole thing is there
-        if noncomm_old_len <= noncomm_self_len and noncomm_old_len > 0:
-            for i in range(noncomm_self_len):
-                if noncomm_self[i] == noncomm_old[0]:
-                    for j in range(noncomm_old_len):
-                        # make sure each noncommutative term matches in order
-                        if (i+j) < noncomm_self_len and \
-                           noncomm_self[i+j] == noncomm_old[j]:
-                            # we only care once we've reached the end of old's
-                            # noncommutative part.
-                            if j == noncomm_old_len-1:
-                                # get rid of noncommutative terms and
-                                # substitute new expression into total
-                                # expression
-                                noncomms_final = noncomm_self[:i] + \
-                                                 noncomm_self[i+j+1:]
-                                noncomms_final.insert(i,new)
-
-                                myFlag = True
-                                comms_final = comm_self[:]
-                                # check commutative terms
-                                for ele in comm_old:
-                                    # flag to make sure all the commutative
-                                    # terms in old are in self
-                                    if ele not in comm_self:
-                                        myFlag = False
-                                    # collect commutative terms
-                                    else:
-                                        comms_final.remove(ele)
-
-                                # continue only if all commutative terms in
-                                # old are present
-                                if myFlag == True:
-                                    expr = comms_final+noncomms_final
-                                    return Mul(coeff_self/coeff_old,
-                                               Mul(*expr)._eval_subs(old,new))
-                                               #*[e._eval_subs(old,new) for e in expr])
-
-            return self.__class__(*[s._eval_subs(old, new) for s in self.args])
-
-        # but what if the noncommutative lists subexpression and the whole
-        # expression are both empty
-        elif noncomm_old_len == noncomm_self_len == 0:
-            # just check commutative parts then.
-            if comm_old_len > 0 and comm_old_len<=comm_self_len:
-                if comm_self == comm_old:
-                    return Mul(coeff_self/coeff_old*new)
-                myFlag = True
-                comms_final = comm_self[:]
-                # check commutative terms
-                for ele in comm_old:
-                    # flag to make sure all the commutative terms in old are
-                    # in self
-                    if ele not in comm_self:
-                        myFlag = False
-                    # collect commutative terms
+            (c, nc) = (dict(), list())
+            for (i, a) in enumerate(Mul.make_args(eq) or [eq]): # remove or [eq] after 2114 accepted
+                a = powdenest(a)
+                (b, e) = a.as_base_exp()
+                if not e is S.One:
+                    (co, _) = e.as_coeff_mul()
+                    b = Pow(b, e/co)
+                    e = co
+                if a.is_commutative:
+                    if b in c: # handle I and -1 like things where b, e for I is -1, 1/2
+                        c[b] += e
                     else:
-                        # needed if old has an element to an integer power
-                        if ele in comms_final:
-                            comms_final.remove(ele)
-                        else:
-                            myFlag = False
-
-                # continue only if all commutative terms in old are present
-                if myFlag == True:
-                    return Mul(coeff_self/coeff_old, new,
-                               Mul(*comms_final)._eval_subs(old,new))#*[c._eval_subs(old,new) for c in comms_final])
+                        c[b] = e
                 else:
-                    return self.__class__(*[s._eval_subs(old, new) for
-                                            s in self.args])
+                    nc.append([b, e])
+            return (c, nc)
 
-        # else the subexpression isn't in the totaly expression
-        return self.__class__(*[s._eval_subs(old, new) for s in self.args])
+        def rejoin(b, co):
+            """
+            Put rational back with exponent; in general this is not ok, but
+            since we took it from the exponent for analysis, it's ok to put
+            it back.
+            """
+
+            (b, e) = b.as_base_exp()
+            return Pow(b, e*co)
+
+        def ndiv(a, b):
+            """if b divides a in an extractive way (like 1/4 divides 1/2
+            but not vice versa, and 2/5 does not divide 1/3) then return
+            the integer number of times it divides, else return 0.
+            """
+
+            if not b.q % a.q or not a.q % b.q:
+                return int(a/b)
+            return 0
+
+        if not old.is_Mul:
+            return fallback()
+
+        # handle the leading coefficient and use it to decide if anything
+        # should even be started; we always know where to find the Rational
+        # so it's a quick test
+
+        coeff = S.One
+        co_self = self.args[0]
+        co_old = old.args[0]
+        if co_old.is_Rational and co_self.is_Rational:
+            co_xmul = co_self.extract_multiplicatively(co_old)
+        elif co_old.is_Rational:
+            co_xmul = None
+        else:
+            co_xmul = True
+
+        if not co_xmul:
+            return fallback()
+
+        (c, nc) = breakup(self)
+        (old_c, old_nc) = breakup(old)
+
+        # update the coefficients if we had an extraction
+
+        if getattr(co_xmul, 'is_Rational', False):
+            c.pop(co_self)
+            c[co_xmul] = S.One
+            old_c.pop(co_old)
+
+        # do quick tests to see if we can't succeed
+
+        ok = True
+        if (\
+            # more non-commutative terms
+            len(old_nc) > len(nc)):
+            ok = False
+        elif (\
+            # more commutative terms
+            len(old_c) > len(c)):
+            ok = False
+        elif (\
+            # unmatched non-commutative bases
+            set(_[0] for _ in  old_nc).difference(set(_[0] for _ in nc))):
+            ok = False
+        elif (\
+            # unmatched commutative terms
+            set(old_c).difference(set(c))):
+            ok = False
+        elif (\
+            # differences in sign
+            any(sign(c[b]) != sign(old_c[b]) for b in old_c)):
+            ok = False
+        if not ok:
+            return fallback()
+
+        if not old_c:
+            cdid = None
+        else:
+            rat = []
+            for (b, old_e) in old_c.items():
+                c_e = c[b]
+                rat.append(ndiv(c_e, old_e))
+            cdid = pymin(rat)
+
+        if not old_nc:
+            ncdid = None
+            for i in range(len(nc)):
+                nc[i] = rejoin(*nc[i])
+        else:
+            ncdid = 0  # number of nc replacements we did
+            take = len(old_nc)  # how much to look at each time
+            limit = cdid or S.Infinity  # max number to take
+            failed = []  # failed terms will need subs if other terms pass
+            i = 0
+            while limit and i + take <= len(nc):
+                hit = False
+
+                # the bases must be equivalent in succession, and
+                # the powers must be extractively compatible on the
+                # first and last factor but equal inbetween.
+
+                rat = []
+                for j in range(take):
+                    if nc[i + j][0] != old_nc[j][0]:
+                        break
+                    elif j == 0:
+                        rat.append(ndiv(nc[i + j][1], old_nc[j][1]))
+                    elif j == take - 1:
+                        rat.append(ndiv(nc[i + j][1], old_nc[j][1]))
+                    elif nc[i + j][1] != old_nc[j][1]:
+                        break
+                    else:
+                        rat.append(1)
+                    j += 1
+                else:
+                    ndo = pymin(rat)
+                    if ndo:
+                        if take == 1:
+                            if cdid:
+                                ndo = pymin(cdid, ndo)
+                            nc[i] = Pow(new, ndo)*rejoin(nc[i][0],
+                                    nc[i][1] - ndo*old_nc[0][1])
+                        else:
+                            ndo = 1
+
+                            # the left residual
+
+                            l = rejoin(nc[i][0], nc[i][1] - ndo*
+                                    old_nc[0][1])
+
+                            # eliminate all middle terms
+
+                            mid = new
+
+                            # the right residual (which may be the same as the middle if take == 2)
+
+                            ir = i + take - 1
+                            r = (nc[ir][0], nc[ir][1] - ndo*
+                                 old_nc[-1][1])
+                            if r[1]:
+                                if i + take < len(nc):
+                                    nc[i:i + take] = [l*mid, r]
+                                else:
+                                    r = rejoin(*r)
+                                    nc[i:i + take] = [l*mid*r]
+                            else:
+
+                                # there was nothing left on the right
+
+                                nc[i:i + take] = [l*mid]
+
+                        limit -= ndo
+                        ncdid += ndo
+                        hit = True
+                if not hit:
+
+                    # do the subs on this failing factor
+
+                    failed.append(i)
+                i += 1
+            else:
+
+                if not ncdid:
+                    return fallback()
+
+                # although we didn't fail, certain nc terms may have
+                # failed so we rebuild them after attempting a partial
+                # subs on them
+
+                failed.extend(range(i, len(nc)))
+                for i in failed:
+                    nc[i] = rejoin(*nc[i]).subs(old, new)
+
+        # rebuild the expression
+
+        if cdid is None:
+            do = ncdid
+        elif ncdid is None:
+            do = cdid
+        else:
+            do = pymin(ncdid, cdid)
+
+        margs = []
+        for b in c:
+            if b in old_c:
+
+                # calculate the new exponent
+
+                e = c[b] - old_c[b]*do
+                margs.append(rejoin(b, e))
+            else:
+                margs.append(rejoin(b.subs(old, new), c[b]))
+        if cdid and not ncdid:
+
+            # in case we are replacing commutative with non-commutative,
+            # we want the new term to come at the front just like the
+            # rest of this routine
+
+            margs = [Pow(new, cdid)] + margs
+        return Mul(*margs)*Mul(*nc)
 
     def _eval_nseries(self, x, x0, n):
         from sympy import powsimp
@@ -964,4 +1081,3 @@ from numbers import Real, Integer, Rational
 from function import FunctionClass
 from sympify import sympify
 from add import Add
-

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -907,23 +907,23 @@ class Mul(AssocOp):
         # do quick tests to see if we can't succeed
 
         ok = True
-        if (\
+        if (
             # more non-commutative terms
             len(old_nc) > len(nc)):
             ok = False
-        elif (\
+        elif (
             # more commutative terms
             len(old_c) > len(c)):
             ok = False
-        elif (\
+        elif (
             # unmatched non-commutative bases
             set(_[0] for _ in  old_nc).difference(set(_[0] for _ in nc))):
             ok = False
-        elif (\
+        elif (
             # unmatched commutative terms
             set(old_c).difference(set(c))):
             ok = False
-        elif (\
+        elif (
             # differences in sign
             any(sign(c[b]) != sign(old_c[b]) for b in old_c)):
             ok = False

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1792,18 +1792,18 @@ class ImaginaryUnit(AtomicExpr):
         if isinstance(e, Number):
             if isinstance(e, Integer):
                 e = e.p % 4
-                if e==0:
+                if e == 0:
                     return S.One
-                if e==1:
+                if e == 1:
                     return S.ImaginaryUnit
-                if e==2:
+                if e == 2:
                     return -S.One
                 return -S.ImaginaryUnit
-            return (-S.One) ** (e * S.Half)
+            return (S.NegativeOne) ** (e * S.Half)
         return
 
     def as_base_exp(self):
-        return -S.One, S.Half
+        return S.NegativeOne, S.Half
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -182,7 +182,7 @@ class Number(AtomicExpr):
     def __hash__(self):
         return super(Number, self).__hash__()
 
-    def as_coeff_terms(self, x=None):
+    def as_coeff_mul(self, x=None):
         # a -> c * t
         return self, tuple()
 
@@ -662,7 +662,7 @@ class Rational(Number):
                 else:
                     return (-1)**e * (-b)**e
 
-        c,t = b.as_coeff_terms()
+        c,t = b.as_coeff_mul()
         if e.is_even and isinstance(c, Number) and c < 0:
             return (-c * Mul(*t)) ** e
 
@@ -1017,7 +1017,7 @@ class Integer(Rational):
         if not isinstance(e, Number):
             # simplify when exp is even
             # (-2) ** k --> 2 ** k
-            c, t = b.as_coeff_terms()
+            c, t = b.as_coeff_mul()
             if e.is_even and isinstance(c, Number) and c < 0:
                 return (-c*Mul(*t))**e
         if not isinstance(e, Rational):
@@ -1224,7 +1224,7 @@ class Zero(IntegerConstant):
             if d.is_negative:
                 return S.Infinity
             return b
-        coeff, terms = e.as_coeff_terms()
+        coeff, terms = e.as_coeff_mul()
         if coeff.is_negative:
             return S.Infinity ** Mul(*terms)
         if coeff is not S.One:

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -27,16 +27,18 @@ class AssocOp(Expr):
 
     @cacheit
     def __new__(cls, *args, **assumptions):
+        if len(args) == 0:
+            return cls.identity
+
+        args = map(_sympify, args)
+        if len(args) == 1:
+            return args[0]
+
         if assumptions.get('evaluate') is False:
-            args = map(_sympify, args)
             obj = Expr.__new__(cls, *args, **assumptions)
             obj.is_commutative = all(arg.is_commutative for arg in args)
             return obj
-        if len(args)==0:
-            return cls.identity
-        if len(args)==1:
-            return _sympify(args[0])
-        c_part, nc_part, order_symbols = cls.flatten(map(_sympify, args))
+        c_part, nc_part, order_symbols = cls.flatten(args)
         if len(c_part) + len(nc_part) <= 1:
             if c_part:
                 obj = c_part[0]

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -59,7 +59,7 @@ class AssocOp(Expr):
 
            This is handy when we want to optimize things, e.g.
 
-           >>> from sympy import Mul, symbols
+           >>> from sympy import Mul, symbols, S
            >>> from sympy.abc import x, y
            >>> e = Mul(3,x,y)
            >>> e.args
@@ -68,6 +68,29 @@ class AssocOp(Expr):
            x*y
            >>> e._new_rawargs(*e.args[1:])  # the same as above, but faster
            x*y
+
+           The commutivity of the result will match that of e:
+
+           >>> _.is_commutative
+           True
+           >>> n = symbols('n', commutative=False)
+           >>> (x*n)._new_rawargs(*e.args[1:])
+           x*y
+           >>> _.is_commutative
+           False
+
+           Note: use this with caution. There is no checking of arguments at
+           all. This is best used when you are rebuilding an Add or Mul after
+           simply removing a term. If, for example, you include values of 1
+           in the list of args they will not show up in the result but a Mul
+           will be returned nonetheless:
+
+           >>> m = (x*y)._new_rawargs(S.One, x); m
+           x
+           >>> m == x
+           False
+           >>> m.is_Mul
+           True
 
         """
         if len(args) == 1:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -205,14 +205,16 @@ class Pow(Expr):
         if self == old:
             return new
         if old.func is self.func and self.base == old.base:
-            coeff1, terms1 = self.exp.as_coeff_terms()
-            coeff2, terms2 = old.exp.as_coeff_terms()
-            if terms1==terms2: return new ** (coeff1/coeff2) # (x**(2*y)).subs(x**(3*y),z) -> z**(2/3)
+            coeff1, terms1 = self.exp.as_coeff_mul()
+            coeff2, terms2 = old.exp.as_coeff_mul()
+            if terms1 == terms2:
+                return new**(coeff1/coeff2) # (x**(2*y)).subs(x**(3*y),z) -> z**(2/3)
         if old.func is C.exp:
-            coeff1, terms1 = old.args[0].as_coeff_terms()
-            coeff2, terms2 = (self.exp*C.log(self.base)).as_coeff_terms()
-            if terms1==terms2: return new**(coeff2/coeff1) # (x**(2*y)).subs(exp(3*y*log(x)),z) -> z**(2/3)
-        return self.base._eval_subs(old, new) ** self.exp._eval_subs(old, new)
+            coeff1, terms1 = old.args[0].as_coeff_mul()
+            coeff2, terms2 = (self.exp*C.log(self.base)).as_coeff_mul()
+            if terms1 == terms2:
+                return new**(coeff2/coeff1) # (x**(2*y)).subs(exp(3*y*log(x)),z) -> z**(2/3)
+        return self.base._eval_subs(old, new)**self.exp._eval_subs(old, new)
 
     def as_powers_dict(self):
         return { self.base : self.exp }

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1049,26 +1049,26 @@ def test_suppressed_evaluation():
     assert c.args == (3,2)
 
 
-def test_Add_as_coeff_terms():
-    assert (x+1).as_coeff_terms()   == ( 1, (x+1,) )
-    assert (x+2).as_coeff_terms()   == ( 1, (x+2,) )
-    assert (x+3).as_coeff_terms()   == ( 1, (x+3,) )
+def test_Add_as_coeff_mul():
+    assert (x+1).as_coeff_mul()   == ( 1, (x+1,) )
+    assert (x+2).as_coeff_mul()   == ( 1, (x+2,) )
+    assert (x+3).as_coeff_mul()   == ( 1, (x+3,) )
 
-    assert (x-1).as_coeff_terms()   == (-1, (1-x,) )
-    assert (x-2).as_coeff_terms()   == (-1, (2-x,) )
-    assert (x-3).as_coeff_terms()   == (-1, (3-x,) )
+    assert (x-1).as_coeff_mul()   == (-1, (1-x,) )
+    assert (x-2).as_coeff_mul()   == (-1, (2-x,) )
+    assert (x-3).as_coeff_mul()   == (-1, (3-x,) )
 
     n = Symbol('n', integer=True)
-    assert (n+1).as_coeff_terms()   == ( 1, (n+1,) )
-    assert (n+2).as_coeff_terms()   == ( 1, (n+2,) )
-    assert (n+3).as_coeff_terms()   == ( 1, (n+3,) )
+    assert (n+1).as_coeff_mul()   == ( 1, (n+1,) )
+    assert (n+2).as_coeff_mul()   == ( 1, (n+2,) )
+    assert (n+3).as_coeff_mul()   == ( 1, (n+3,) )
 
-    assert (n-1).as_coeff_terms()   == (-1, (1-n,) )
-    assert (n-2).as_coeff_terms()   == (-1, (2-n,) )
-    assert (n-3).as_coeff_terms()   == (-1, (3-n,) )
+    assert (n-1).as_coeff_mul()   == (-1, (1-n,) )
+    assert (n-2).as_coeff_mul()   == (-1, (2-n,) )
+    assert (n-3).as_coeff_mul()   == (-1, (3-n,) )
 
-def test_Pow_as_coeff_terms_doesnt_expand():
-    assert exp(x + y).as_coeff_terms() == (1, (exp(x + y),))
+def test_Pow_as_coeff_mul_doesnt_expand():
+    assert exp(x + y).as_coeff_mul() == (1, (exp(x + y),))
     assert exp(x + exp(x + y)) != exp(x + exp(x)*exp(y))
 
 def test_issue974():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -588,14 +588,14 @@ def test_is_number():
     assert a.is_number == False
 
 
-# TODO write more tests for as_coeff_factors
-def test_as_coeff_factors():
+# TODO write more tests for as_coeff_add
+def test_as_coeff_add():
     x = Symbol('x')
 
-    assert     x .as_coeff_factors() == ( 0, (x,))
-    assert (-1+x).as_coeff_factors() == (-1, (x,))
-    assert ( 2+x).as_coeff_factors() == ( 2, (x,))
-    assert ( 1+x).as_coeff_factors() == ( 1, (x,))
+    assert     x .as_coeff_add() == ( 0, (x,))
+    assert (-1+x).as_coeff_add() == (-1, (x,))
+    assert ( 2+x).as_coeff_add() == ( 2, (x,))
+    assert ( 1+x).as_coeff_add() == ( 1, (x,))
 
 
 def test_as_coeff_exponent():
@@ -727,13 +727,13 @@ def test_as_base_exp():
 def test_Basic_keep_sign():
     Basic.keep_sign = True
     assert Mul(x - 1, x + 1) == (x - 1)*(x + 1)
-    assert (1/(x - 1)).as_coeff_terms()[0] == +1
+    assert (1/(x - 1)).as_coeff_mul()[0] == +1
 
     clear_cache()
 
     Basic.keep_sign = False
     assert Mul(x - 1, x + 1) == -(1 - x)*(1 + x)
-    assert (1/(x - 1)).as_coeff_terms()[0] == -1
+    assert (1/(x - 1)).as_coeff_mul()[0] == -1
 
 def test_issue1864():
     assert hasattr(Mul(x, y), "is_commutative")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -207,40 +207,36 @@ def test_as_leading_term3():
     assert (2*x+pi*x+x**2).as_leading_term(x) == 2*x + pi*x
 
 def test_atoms():
-   assert sorted(list(x.atoms())) == [x]
-   assert sorted(list((1+x).atoms())) == sorted([1, x])
+    assert sorted(list(x.atoms())) == [x]
+    assert sorted(list((1+x).atoms())) == sorted([1, x])
 
-   assert sorted(list((1+2*cos(x)).atoms(Symbol))) == [x]
-   assert sorted(list((1+2*cos(x)).atoms(Symbol,Number))) == sorted([1, 2, x])
+    assert sorted(list((1+2*cos(x)).atoms(Symbol))) == [x]
+    assert sorted(list((1+2*cos(x)).atoms(Symbol,Number))) == sorted([1, 2, x])
 
-   assert sorted(list((2*(x**(y**x))).atoms())) == sorted([2, x, y])
+    assert sorted(list((2*(x**(y**x))).atoms())) == sorted([2, x, y])
 
-   assert sorted(list(Rational(1,2).atoms())) == [S.Half]
-   assert sorted(list(Rational(1,2).atoms(Symbol))) == []
+    assert sorted(list(Rational(1,2).atoms())) == [S.Half]
+    assert sorted(list(Rational(1,2).atoms(Symbol))) == []
 
-   assert sorted(list(sin(oo).atoms(oo))) == [oo]
+    assert sorted(list(sin(oo).atoms(oo))) == [oo]
 
-   assert sorted(list(Poly(0, x).atoms())) == [S.Zero]
-   assert sorted(list(Poly(1, x).atoms())) == [S.One]
+    assert sorted(list(Poly(0, x).atoms())) == [S.Zero]
+    assert sorted(list(Poly(1, x).atoms())) == [S.One]
 
-   assert sorted(list(Poly(x, x).atoms())) == [x]
-   assert sorted(list(Poly(x, x, y).atoms())) == [x]
-   assert sorted(list(Poly(x + y, x, y).atoms())) == sorted([x, y])
-   assert sorted(list(Poly(x + y, x, y, z).atoms())) == sorted([x, y])
-   assert sorted(list(Poly(x + y*t, x, y, z).atoms())) == sorted([t, x, y])
+    assert sorted(list(Poly(x, x).atoms())) == [x]
+    assert sorted(list(Poly(x, x, y).atoms())) == [x]
+    assert sorted(list(Poly(x + y, x, y).atoms())) == sorted([x, y])
+    assert sorted(list(Poly(x + y, x, y, z).atoms())) == sorted([x, y])
+    assert sorted(list(Poly(x + y*t, x, y, z).atoms())) == sorted([t, x, y])
 
-   I = S.ImaginaryUnit
-   assert list((I*pi).atoms(NumberSymbol)) == [pi]
-   assert sorted((I*pi).atoms(NumberSymbol, I)) == \
-          sorted((I*pi).atoms(I,NumberSymbol)) == [pi, I]
+    I = S.ImaginaryUnit
+    assert list((I*pi).atoms(NumberSymbol)) == [pi]
+    assert sorted((I*pi).atoms(NumberSymbol, I)) == \
+           sorted((I*pi).atoms(I,NumberSymbol)) == [pi, I]
 
-   I = S.ImaginaryUnit
-   assert list((I*pi).atoms(NumberSymbol)) == [pi]
-   assert sorted((I*pi).atoms(NumberSymbol, I)) == \
-          sorted((I*pi).atoms(I,NumberSymbol)) == [pi, I]
 
-   assert exp(exp(x)).atoms(exp) == set([exp(exp(x)), exp(x)])
-   assert (1 + x*(2 + y)+exp(3 + z)).atoms(Add) == set(
+    assert exp(exp(x)).atoms(exp) == set([exp(exp(x)), exp(x)])
+    assert (1 + x*(2 + y)+exp(3 + z)).atoms(Add) == set(
                                                    [1 + x*(2 + y)+exp(3 + z),
                                                     2 + y,
                                                     3 + z])
@@ -587,7 +583,6 @@ def test_is_number():
     a = A()
     assert a.is_number == False
 
-
 # TODO write more tests for as_coeff_add
 def test_as_coeff_add():
     x = Symbol('x')
@@ -596,7 +591,6 @@ def test_as_coeff_add():
     assert (-1+x).as_coeff_add() == (-1, (x,))
     assert ( 2+x).as_coeff_add() == ( 2, (x,))
     assert ( 1+x).as_coeff_add() == ( 1, (x,))
-
 
 def test_as_coeff_exponent():
     x, y = symbols("xy")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -770,3 +770,8 @@ def test_new_rawargs():
     assert 2 + x == Add._new_rawargs(3 + x, *[S(2), x])
     assert x == Mul._new_rawargs(3*x, *[x])
     assert x == Add._new_rawargs(3 + x, *[x])
+
+def test_2127():
+    assert Add(evaluate=False) == 0
+    assert Mul(evaluate=False) == 1
+    assert Mul(x+y, evaluate=False).is_Add

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -147,15 +147,43 @@ def test_subs_dict2():
     assert e.subs(r) == 3 * sin(4*x) / 4
 
 def test_mul():
-    x, y, z, a = map(Symbol, 'xyza')
-    assert (x*y*z).subs(z*x,y) == y**2
-    assert (z*x).subs(1/x,z) == z*x
-    assert (x*y/z).subs(1/z,a) == a*x*y
-    assert (x*y/z).subs(x/z,a) == a*y
-    assert (x*y/z).subs(y/z,a) == a*x
-    assert (x*y/z).subs(x/z,1/a) == y/a
-    assert (x*y/z).subs(x,1/a) == y/(z*a)
-    assert (2*x*y).subs(5*x*y,z) != 2*z/5
+    x, y, z, a, b, c = symbols('xyzabc')
+    A, B, C = symbols('A B C', commutative=0)
+    assert (x*y*z).subs(z*x, y) == y**2
+    assert (z*x).subs(1/x, z) == z*x
+    assert (x*y/z).subs(1/z, a) == a*x*y
+    assert (x*y/z).subs(x/z, a) == a*y
+    assert (x*y/z).subs(y/z, a) == a*x
+    assert (x*y/z).subs(x/z, 1/a) == y/a
+    assert (x*y/z).subs(x, 1/a) == y/(z*a)
+    assert (2*x*y).subs(5*x*y, z) != 2*z/5
+    assert (x*y*A).subs(x*y, a) == a*A
+    assert (x**2*y**(3*x/2)).subs(x*y**(x/2), 2) == 4*y**(x/2)
+    assert (x*exp(x*2)).subs(x*exp(x), 2) == 2*exp(x)
+    assert ((x**(2*y))**3).subs(x**y, 2) == 64
+    assert (x*A*B).subs(x*A, y) == y*B
+    assert (x*y*(1 + x)*(1 + x*y)).subs(x*y, 2) == 6*(1 + x)
+    assert ((1 + A*B)*A*B).subs(A*B, x*A*B)
+    assert (x*a/z).subs(x/z, A) == a*A
+    assert (x**3*A).subs(x**2*A, a) == a*x
+    assert (x**2*A*B).subs(x**2*B, a) == a*A
+    assert (x**2*A*B).subs(x**2*A, a) == a*B
+    assert (b*A**3/(a**3*c**3)).subs(a**4*c**3*A**3/b**4, z) == \
+            b*A**3/(a**3*c**3)
+    assert (6*x).subs(2*x, y) == 3*y
+    assert (y*exp(3*x/2)).subs(y*exp(x), 2) == 2*exp(x/2)
+    assert (y*exp(3*x/2)).subs(y*exp(x), 2) == 2*exp(x/2)
+    assert (A**2*B*A**2*B*A**2).subs(A*B*A, C) == \
+            A*C**2*A
+    assert (x*A**3).subs(x*A, y) == y*A**2
+    assert (x**2*A**3).subs(x*A, y) == y**2*A
+    assert (x*A**3).subs(x*A, B) == B*A**2
+    assert (x*A*B*A*exp(x*A*B)).subs(x*A, B) == B**2*A*exp(B*B)
+    assert (x**2*A*B*A*exp(x*A*B)).subs(x*A, B) == B**3*exp(B**2)
+    assert (x**3*A*exp(x*A*B)*A*exp(x*A*B)).subs(x*A, B) == \
+            x*B*exp(B**2)*B*exp(B**2)
+    assert (x*A*B*C*A*B).subs(x*A*B, C) == C**2*A*B
+    assert (-I*a*b).subs(a*b, 2) == -2*I
 
 def test_subs_simple():
     # Define symbols
@@ -283,7 +311,6 @@ def test_division():
     assert (   1/x**2 ).subs(x,z)  == 1/z**2
     assert (   1/x**2 ).subs(x,-2) == Rational(1,4)
     assert ( -(1/x**2)).subs(x,-2) == -Rational(1,4)
-
 
 def test_add():
     a, b, c, d, x = abc.a, abc.b, abc.c, abc.d, abc.x

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -7,7 +7,7 @@ Factorials, binomial coefficients and related functions are located in
 the separate 'factorials' module.
 """
 
-from sympy import Function, S, Symbol, Rational, oo, Integer, C
+from sympy import Function, S, Symbol, Rational, oo, Integer, C, Add
 
 from sympy.mpmath import bernfrac
 
@@ -257,7 +257,7 @@ class bernoulli(Function):
                     n, result = int(n), []
                     for k in xrange(n + 1):
                         result.append(C.Binomial(n, k)*cls(k)*sym**(n-k))
-                    return C.Add(*result)
+                    return Add(*result)
             else:
                 raise ValueError("Bernoulli numbers are defined only"
                                  " for nonnegative integer indices.")

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -175,7 +175,7 @@ class sign(Function):
         if arg.is_Function:
             if arg.func is sign: return arg
         if arg.is_Mul:
-            c, args = arg.as_coeff_terms()
+            c, args = arg.as_coeff_mul()
             unk = []
             is_neg = c.is_negative
             for ai in args:
@@ -249,7 +249,7 @@ class Abs(Function):
         if arg.is_zero:     return arg
         if arg.is_positive: return arg
         if arg.is_negative: return -arg
-        coeff, terms = arg.as_coeff_terms()
+        coeff, terms = arg.as_coeff_mul()
         if coeff is not S.One:
             return cls(coeff) * cls(C.Mul(*terms))
         if arg.is_real is False:

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1,6 +1,6 @@
 from sympy.core import S, C, Function, Derivative
 from sympy.functions.elementary.miscellaneous import sqrt
-
+from sympy.core import Add, Mul
 from sympy.utilities.iterables import iff
 
 ###############################################################################
@@ -45,7 +45,7 @@ class re(Function):
         else:
 
             included, reverted, excluded = [], [], []
-            arg = C.Add.make_args(arg)
+            arg = Add.make_args(arg)
             for term in arg:
                 coeff = term.as_coefficient(S.ImaginaryUnit)
 
@@ -58,7 +58,7 @@ class re(Function):
                     included.append(term)
 
             if len(arg) != len(included):
-                a, b, c = map(lambda xs: C.Add(*xs),
+                a, b, c = map(lambda xs: Add(*xs),
                     [included, reverted, excluded])
 
                 return cls(a) - im(b) + c
@@ -118,7 +118,7 @@ class im(Function):
             return -im(arg.args[0])
         else:
             included, reverted, excluded = [], [], []
-            arg = C.Add.make_args(arg)
+            arg = Add.make_args(arg)
             for term in arg:
                 coeff = term.as_coefficient(S.ImaginaryUnit)
 
@@ -131,7 +131,7 @@ class im(Function):
                     included.append(term)
 
             if len(arg) != len(included):
-                a, b, c = map(lambda xs: C.Add(*xs),
+                a, b, c = map(lambda xs: Add(*xs),
                     [included, reverted, excluded])
 
                 return cls(a) + re(b) + c
@@ -185,7 +185,7 @@ class sign(Function):
                     is_neg = not is_neg
             if c is S.One and len(unk) == len(args):
                 return None
-            return iff(is_neg, S.NegativeOne, S.One) * cls(C.Mul(*unk))
+            return iff(is_neg, S.NegativeOne, S.One) * cls(Mul(*unk))
 
     is_bounded = True
 
@@ -251,7 +251,7 @@ class Abs(Function):
         if arg.is_negative: return -arg
         coeff, terms = arg.as_coeff_mul()
         if coeff is not S.One:
-            return cls(coeff) * cls(C.Mul(*terms))
+            return cls(coeff) * cls(Mul(*terms))
         if arg.is_real is False:
             return sqrt( (arg * arg.conjugate()).expand() )
         if arg.is_Pow:

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -63,7 +63,7 @@ class exp(Function):
             coeff, terms = arg.as_coeff_mul()
 
             if coeff is S.Infinity:
-                excluded.append(coeff**C.Mul(*terms))
+                excluded.append(coeff**Mul(*terms))
             else:
                 coeffs, log_term = [coeff], None
 
@@ -81,12 +81,12 @@ class exp(Function):
                         break
 
                 if log_term is not None:
-                    excluded.append(log_term**C.Mul(*coeffs))
+                    excluded.append(log_term**Mul(*coeffs))
                 else:
                     included.append(arg)
 
         if excluded:
-            return C.Mul(*(excluded+[cls(C.Add(*included))]))
+            return Mul(*(excluded+[cls(Add(*included))]))
 
     @staticmethod
     @cacheit
@@ -116,7 +116,7 @@ class exp(Function):
         return self.func(self.args[0].conjugate())
 
     def as_base_exp(self):
-        return S.Exp1, C.Mul(*self.args)
+        return S.Exp1, Mul(*self.args)
 
     def as_coeff_mul(self, x=None):
         arg = self.args[0]
@@ -154,8 +154,8 @@ class exp(Function):
                     else:
                         old_al.append(a._eval_subs(old, new))
                 if new_l:
-                    new_l.append(self.func(C.Add(*old_al)))
-                    r = C.Mul(*new_l)
+                    new_l.append(self.func(Add(*old_al)))
+                    r = Mul(*new_l)
                     return r
         old = o
         return Function._eval_subs(self, old, new)
@@ -215,12 +215,12 @@ class exp(Function):
             g = self.taylor_term(i, self.args[0], g)
             g = g.nseries(x, x0, n)
             l.append(g)
-        return C.Add(*l) + C.Order(x**n, x)
+        return Add(*l) + C.Order(x**n, x)
 
     def _eval_as_leading_term(self, x):
         arg = self.args[0]
         if arg.is_Add:
-            return C.Mul(*[exp(f).as_leading_term(x) for f in arg.args])
+            return Mul(*[exp(f).as_leading_term(x) for f in arg.args])
         arg = self.args[0].as_leading_term(x)
         if C.Order(1,x).contains(arg):
             return S.One
@@ -311,7 +311,7 @@ class log(Function):
         #        arg.exp.is_number:
         #        return arg.exp * self(arg.base)
         #elif arg.is_Mul and arg.is_real:
-        #    return C.Add(*[self(a) for a in arg])
+        #    return Add(*[self(a) for a in arg])
         elif not arg.is_Add:
             coeff = arg.as_coefficient(S.ImaginaryUnit)
 
@@ -474,7 +474,7 @@ class log(Function):
                 g = ln.taylor_term(i, z, g)
                 g = g.nseries(x, x0, n)
                 l.append(g)
-            obj = C.Add(*l) + ln(arg0)
+            obj = Add(*l) + ln(arg0)
         obj2 = expand_log(powsimp(obj, deep=True, combine='exp'))
         if obj2 != obj:
             r = obj2.nseries(x, x0, n)
@@ -522,7 +522,7 @@ class LambertW(Function):
     def eval(cls, x):
         if x == S.Zero: return S.Zero
         if x == S.Exp1: return S.One
-        if x == -1/S.Exp1: return -S.One
+        if x == -1/S.Exp1: return S.NegativeOne
         if x == -log(2)/2: return -log(2)
         if x == S.Infinity: return S.Infinity
 
@@ -532,3 +532,4 @@ class LambertW(Function):
             return LambertW(x)/(x*(1+LambertW(x)))
         else:
             raise ArgumentIndexError(self, argindex)
+

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -60,7 +60,7 @@ class exp(Function):
         included, excluded = [], []
 
         for arg in args:
-            coeff, terms = arg.as_coeff_terms()
+            coeff, terms = arg.as_coeff_mul()
 
             if coeff is S.Infinity:
                 excluded.append(coeff**C.Mul(*terms))
@@ -118,11 +118,11 @@ class exp(Function):
     def as_base_exp(self):
         return S.Exp1, C.Mul(*self.args)
 
-    def as_coeff_terms(self, x=None):
+    def as_coeff_mul(self, x=None):
         arg = self.args[0]
         if x is not None:
-            c,f = arg.as_coeff_factors(x)
-            return self.func(c), tuple( self.func(a) for a in f )
+            c, t = arg.as_coeff_add(x)
+            return self.func(c), tuple( self.func(a) for a in t )
         return S.One,(self,)
 
     def _eval_subs(self, old, new):
@@ -133,8 +133,8 @@ class exp(Function):
             old = exp(old.exp * log(old.base))
         if old.func is exp:
             # exp(a*expr) .subs( exp(b*expr), y )  ->  y ** (a/b)
-            a, expr_terms = self.args[0].as_coeff_terms()
-            b, expr_terms_= old .args[0].as_coeff_terms()
+            a, expr_terms = self.args[0].as_coeff_mul()
+            b, expr_terms_= old .args[0].as_coeff_mul()
 
             if expr_terms == expr_terms_:
                 return new ** (a/b)
@@ -145,10 +145,10 @@ class exp(Function):
                 oarg = old.args[0]
                 new_l = []
                 old_al = []
-                coeff2,terms2 = oarg.as_coeff_terms()
+                coeff2,terms2 = oarg.as_coeff_mul()
                 for a in arg.args:
                     a = a._eval_subs(old, new)
-                    coeff1,terms1 = a.as_coeff_terms()
+                    coeff1,terms1 = a.as_coeff_mul()
                     if terms1==terms2:
                         new_l.append(new**(coeff1/coeff2))
                     else:

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -44,7 +44,7 @@ class sinh(Function):
             if i_coeff is not None:
                 return S.ImaginaryUnit * C.sin(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return -cls(-arg)
@@ -166,7 +166,7 @@ class cosh(Function):
             if i_coeff is not None:
                 return C.cos(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return cls(-arg)
@@ -287,7 +287,7 @@ class tanh(Function):
             if i_coeff is not None:
                 return S.ImaginaryUnit * C.tan(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return -cls(-arg)
@@ -410,7 +410,7 @@ class coth(Function):
             if i_coeff is not None:
                 return -S.ImaginaryUnit * C.cot(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return -cls(-arg)
@@ -519,7 +519,7 @@ class asinh(Function):
             if i_coeff is not None:
                 return S.ImaginaryUnit * C.asin(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return -cls(-arg)
@@ -663,7 +663,7 @@ class atanh(Function):
             if i_coeff is not None:
                 return S.ImaginaryUnit * C.atan(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return -cls(-arg)
@@ -728,7 +728,7 @@ class acoth(Function):
             if i_coeff is not None:
                 return -S.ImaginaryUnit * C.acot(i_coeff)
             else:
-                coeff, terms = arg.as_coeff_terms()
+                coeff, terms = arg.as_coeff_mul()
 
                 if coeff.is_negative:
                     return -cls(-arg)

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -1,4 +1,7 @@
-from sympy.core import S, C, Function
+from sympy.core.basic import C
+from sympy.core.singleton import S
+from sympy.core.function import Function
+from sympy.core import Add
 from sympy.core.evalf import get_integer_part, PrecisionExhausted
 
 ###############################################################################
@@ -24,10 +27,7 @@ class RoundFunction(Function):
         ipart = npart = spart = S.Zero
 
         # Extract integral (or complex integral) terms
-        if arg.is_Add:
-            terms = arg.args
-        else:
-            terms = [arg]
+        terms = Add.make_args(arg)
 
         for t in terms:
             if t.is_integer or (t.is_imaginary and C.im(t).is_integer):
@@ -164,3 +164,4 @@ class ceiling(RoundFunction):
                 return r
         else:
             return r
+

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -188,7 +188,7 @@ class sin(Function):
         if arg.is_Add: # TODO, implement more if deep stuff here
             x, y = arg.as_two_terms()
         else:
-            coeff, terms = arg.as_coeff_terms()
+            coeff, terms = arg.as_coeff_mul()
             if not (coeff is S.One) and coeff.is_Integer and terms:
                 x = C.Mul(*terms)
                 y = (coeff-1)*x
@@ -400,7 +400,7 @@ class cos(Function):
             x, y = arg.as_two_terms()
             return (cos(x)*cos(y) - sin(y)*sin(x)).expand(trig=True)
         else:
-            coeff, terms = arg.as_coeff_terms()
+            coeff, terms = arg.as_coeff_mul()
             if not (coeff is S.One) and coeff.is_Integer and terms:
                 x = C.Mul(*terms)
                 return C.chebyshevt(coeff, cos(x))

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,4 +1,9 @@
-from sympy.core import S, C, sympify, Function, cacheit
+from sympy.core.cache import cacheit
+from sympy.core.add import Add
+from sympy.core.mul import Mul
+from sympy.core.basic import C, sympify
+from sympy.core.singleton import S
+from sympy.core.function import Function
 from miscellaneous import sqrt
 
 ###############################################################################
@@ -190,7 +195,7 @@ class sin(Function):
         else:
             coeff, terms = arg.as_coeff_mul()
             if not (coeff is S.One) and coeff.is_Integer and terms:
-                x = C.Mul(*terms)
+                x = Mul(*terms)
                 y = (coeff-1)*x
         if x is not None:
             return (sin(x)*cos(y) + sin(y)*cos(x)).expand(trig=True)
@@ -402,7 +407,7 @@ class cos(Function):
         else:
             coeff, terms = arg.as_coeff_mul()
             if not (coeff is S.One) and coeff.is_Integer and terms:
-                x = C.Mul(*terms)
+                x = Mul(*terms)
                 return C.chebyshevt(coeff, cos(x))
         return cos(arg)
 
@@ -606,7 +611,7 @@ class cot(Function):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return -S.One - self**2
+            return S.NegativeOne - self**2
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -29,7 +29,7 @@ class erf(Function):
             elif arg.is_negative:
                 return -cls(-arg)
         elif arg.is_Mul:
-            coeff, terms = arg.as_coeff_terms()
+            coeff, terms = arg.as_coeff_mul()
 
             if coeff.is_negative:
                 return -cls(-arg)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -197,8 +197,8 @@ class polygamma(Function):
 
         if n.is_Integer and n.is_nonnegative:
             if z.is_Add:
-                coeff, factors = z.as_coeff_factors()
-                if coeff and coeff.is_Integer:
+                coeff = z.args[0]
+                if coeff.is_Integer:
                     e = -(n + 1)
                     if coeff > 0:
                         tail = Add(*[C.Pow(z - i, e)  for i in xrange(1, int(coeff) + 1)])
@@ -207,9 +207,8 @@ class polygamma(Function):
                     return polygamma(n, z - coeff) + (-1)**n*C.Factorial(n)*tail
 
             elif z.is_Mul:
-                coeff, terms = z.as_coeff_terms()
-                if coeff != 1 and coeff.is_Integer and coeff.is_positive:
-                    z = z._new_rawargs(*terms)
+                coeff, z = z.as_two_terms()
+                if coeff.is_Integer and coeff.is_positive:
                     tail = [ polygamma(n, z + C.Rational(i, coeff)) for i in xrange(0, int(coeff)) ]
                     if n == 0:
                         return Add(*tail)/coeff + log(coeff)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -69,7 +69,7 @@ class gamma(Function):
         if arg.is_Add:
             for i, coeff in enumerate(arg.args):
                 if arg.args[i].is_Number:
-                    terms = C.Add(*(arg.args[:i] + arg.args[i+1:]))
+                    terms = Add(*(arg.args[:i] + arg.args[i+1:]))
 
                     if coeff.is_Rational:
                         if coeff.q != 1:

--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -400,7 +400,7 @@ class LatexPrinter(Printer):
         tex = str(self._print(expr.args[0]))
 
         for term in expr.args[1:]:
-            coeff = term.as_coeff_terms()[0]
+            coeff = term.as_coeff_mul()[0]
 
             if coeff.is_negative:
                 tex += r" %s" % self._print(term)
@@ -410,7 +410,7 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_Mul(self, expr):
-        coeff, terms = expr.as_coeff_terms()
+        coeff, terms = expr.as_coeff_mul()
 
         if not coeff.is_negative:
             tex = ""

--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -6,7 +6,7 @@ import sys
 
 import os,types,StringIO
 
-from sympy.core import S, C, Basic, Symbol
+from sympy.core import S, C, Basic, Symbol, Mul
 from sympy.printing.printer import Printer
 from sympy.simplify import fraction
 import re as regrep
@@ -418,7 +418,7 @@ class LatexPrinter(Printer):
             coeff = -coeff
             tex = "- "
 
-        numer, denom = fraction(C.Mul(*terms))
+        numer, denom = fraction(Mul(*terms))
 
         def convert(terms):
             product = []

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -386,7 +386,7 @@ class Integral(Expr):
             else:
                 return None
 
-        return C.Add(*parts)
+        return Add(*parts)
 
     def _eval_lseries(self, x, x0):
         arg = self.args[0]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -404,12 +404,13 @@ class Matrix(object):
             if n < 0:
                 return self.inv() ** -n   # A**-2 = (A**-1)**2
             a = eye(self.cols)
+            s = self
             while n:
-                if n % 2:
-                    a = a * self
+                if n%2:
+                    a *= s
                     n -= 1
-                self = self * self
-                n = n // 2
+                s *= s
+                n //= 2
             return a
         raise NotImplementedError('Can only raise to the power of an integer for now')
 

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -173,9 +173,9 @@ def isprime(n):
     =============
     >>> from sympy.ntheory import isprime
     >>> isprime(13)
-        True
-        >>> isprime(15)
-        False
+    True
+    >>> isprime(15)
+    False
 
     """
     n = int(n)

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -339,7 +339,7 @@ class KroneckerDelta(Function):
             return cls(j,i)
         diff = i-j
         if diff == 0:
-            return Integer(1)
+            return S.One
         elif diff.is_number:
             return S.Zero
 
@@ -1097,7 +1097,7 @@ class FockState(Expr):
     """
     Many particle Fock state with a sequence of occupation numbers.
 
-    Anywhere you can have a FockState, you can also have Integer(0).
+    Anywhere you can have a FockState, you can also have S.Zero.
     All code must check for this!
     """
 
@@ -1147,16 +1147,16 @@ class BosonState(FockState):
     def up(self, i):
         i = int(i)
         new_occs = list(self.args[0])
-        new_occs[i] = new_occs[i]+Integer(1)
+        new_occs[i] = new_occs[i]+S.One
         return self.__class__(new_occs)
 
     def down(self, i):
         i = int(i)
         new_occs = list(self.args[0])
-        if new_occs[i]==Integer(0):
-            return Integer(0)
+        if new_occs[i]==S.Zero:
+            return S.Zero
         else:
-            new_occs[i] = new_occs[i]-Integer(1)
+            new_occs[i] = new_occs[i]-S.One
             return self.__class__(new_occs)
 
 
@@ -1499,7 +1499,7 @@ class InnerProduct(Basic):
 
     @classmethod
     def eval(cls, bra, ket):
-        result = Integer(1)
+        result = S.One
         for i,j in zip(bra.args[0], ket.args[0]):
             result *= KroneckerDelta(i,j)
             if result == 0: break

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2108,7 +2108,9 @@ class NO(Expr):
         NO(AnnihilateFermion(p)*AnnihilateFermion(r))
 
         """
-        mul = Mul(*(self.args[0].args[0:i] + self.args[0].args[i+1:]))
+        arg0 = self.args[0] # it's a Mul by definition of how it's created
+        mul = Mul._new_rawargs(arg0, Mul._new_rawargs(arg0, arg0.args[:i]),
+                                     Mul._new_rawargs(arg0, arg0.args[i + 1:]))
         return NO(mul)
 
     def _latex(self,printer):

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -173,17 +173,6 @@ class AntiSymmetricTensor(TensorSymbol):
         try:
             upper, signu = _sort_anticommuting_fermions(upper, key=cls._sortkey)
             lower, signl = _sort_anticommuting_fermions(lower, key=cls._sortkey)
-            sign = 1
-            if signu:
-                upper = Tuple(*upper)
-                if signu %2:
-                    sign = -sign
-            if signl:
-                lower = Tuple(*lower)
-                if signl %2:
-                    sign = -sign
-            if signl or signu:
-                return sign*cls(symbol, upper, lower)
 
         except ViolationOfPauliPrinciple:
             return S.Zero

--- a/sympy/polys/algebratools.py
+++ b/sympy/polys/algebratools.py
@@ -2122,19 +2122,19 @@ class ExpressionDomain(Field):
 
     def is_positive(self, a):
         """Returns True if `a` is positive. """
-        return a.ex.as_coeff_terms()[0].is_positive
+        return a.ex.as_coeff_mul()[0].is_positive
 
     def is_negative(self, a):
         """Returns True if `a` is negative. """
-        return a.ex.as_coeff_terms()[0].is_negative
+        return a.ex.as_coeff_mul()[0].is_negative
 
     def is_nonpositive(self, a):
         """Returns True if `a` is non-positive. """
-        return a.ex.as_coeff_terms()[0].is_nonpositive
+        return a.ex.as_coeff_mul()[0].is_nonpositive
 
     def is_nonnegative(self, a):
         """Returns True if `a` is non-negative. """
-        return a.ex.as_coeff_terms()[0].is_nonnegative
+        return a.ex.as_coeff_mul()[0].is_nonnegative
 
     def numer(self, a):
         """Returns numerator of `a`. """

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -50,7 +50,7 @@ def minimal_polynomial(ex, x=None, **args):
         elif ex.is_Pow:
             if ex.exp.is_Rational:
                 if ex.exp < 0 and ex.base.is_Add:
-                    coeff, terms = ex.base.as_coeff_factors()
+                    coeff, terms = ex.base.as_coeff_add()
                     elt, _ = primitive_element(terms, polys=True)
 
                     alg = ex.base - coeff

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -95,10 +95,10 @@ def _construct_domain(rep, **args):
                 if coeff.is_Rational:
                     coeff = (None, 0, QQ.from_sympy(coeff))
                 else:
-                    a, _ = coeff.as_coeff_factors()
+                    a, _ = coeff.as_coeff_add()
                     coeff -= a
 
-                    b, _ = coeff.as_coeff_terms()
+                    b, _ = coeff.as_coeff_mul()
                     coeff /= b
 
                     exts.add(coeff)

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -122,7 +122,7 @@ def _analyze_power(base, exp):
         else:
             base, exp = Pow(base, exp), 1
     else:
-        exp, tail = exp.as_coeff_terms()
+        exp, tail = exp.as_coeff_mul()
 
         if exp.is_Number:
             if exp.is_Rational:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -1,4 +1,4 @@
-from sympy.core import S, C
+from sympy.core import S, C, Add
 from sympy.printing.str import StrPrinter
 from sympy.tensor import get_indices, get_contraction_structure
 
@@ -25,7 +25,7 @@ class CodePrinter(StrPrinter):
 
         # terms with no summations first
         if None in d:
-            text = CodePrinter.doprint(self, C.Add(*d[None]))
+            text = CodePrinter.doprint(self, Add(*d[None]))
         else:
             # If all terms have summations we must initialize array to Zero
             text = CodePrinter.doprint(self, 0)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -18,7 +18,7 @@ responsibility for generating properly cased Fortran code to the user.
 """
 
 
-from sympy.core import S, C
+from sympy.core import S, C, Add
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence
 from sympy.functions import sin, cos, tan, asin, acos, atan, atan2, sinh, \
@@ -166,7 +166,7 @@ class FCodePrinter(CodePrinter):
         if len(pure_imaginary) > 0:
             if len(mixed) > 0:
                 PREC = precedence(expr)
-                term = C.Add(*mixed)
+                term = Add(*mixed)
                 t = self._print(term)
                 if t.startswith('-'):
                     sign = "-"
@@ -177,14 +177,14 @@ class FCodePrinter(CodePrinter):
                     t = "(%s)" % t
 
                 return "cmplx(%s,%s) %s %s" % (
-                    self._print(C.Add(*pure_real)),
-                    self._print(-S.ImaginaryUnit*C.Add(*pure_imaginary)),
+                    self._print(Add(*pure_real)),
+                    self._print(-S.ImaginaryUnit*Add(*pure_imaginary)),
                     sign, t,
                 )
             else:
                 return "cmplx(%s,%s)" % (
-                    self._print(C.Add(*pure_real)),
-                    self._print(-S.ImaginaryUnit*C.Add(*pure_imaginary)),
+                    self._print(Add(*pure_real)),
+                    self._print(-S.ImaginaryUnit*Add(*pure_imaginary)),
                 )
         else:
             return CodePrinter._print_Add(self, expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2,7 +2,7 @@
 A Printer which converts an expression into its LaTeX equivalent.
 """
 
-from sympy.core import S, C, Basic, Add, Wild, var
+from sympy.core import S, C, Basic, Add, Mul, Wild, var
 from printer import Printer
 from conventions import split_super_sub
 from sympy.simplify import fraction
@@ -204,7 +204,7 @@ class LatexPrinter(Printer):
             coeff = -coeff
             tex = "- "
 
-        numer, denom = fraction(C.Mul(*terms))
+        numer, denom = fraction(Mul(*terms))
         seperator = self._settings['mul_symbol_latex']
 
         def convert(terms):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -161,7 +161,7 @@ class LatexPrinter(Printer):
         tex = str(self._print(args[0]))
 
         for term in args[1:]:
-            coeff = term.as_coeff_terms()[0]
+            coeff = term.as_coeff_mul()[0]
 
             if coeff.is_negative:
                 tex += r" %s" % self._print(term)
@@ -196,7 +196,7 @@ class LatexPrinter(Printer):
             return str_real
 
     def _print_Mul(self, expr):
-        coeff, terms = expr.as_coeff_terms()
+        coeff, terms = expr.as_coeff_mul()
 
         if not coeff.is_negative:
             tex = ""

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -70,7 +70,7 @@ class MathMLPrinter(Printer):
         return n.lower()
 
     def _print_Mul(self, expr):
-        coeff, terms  = expr.as_coeff_terms()
+        coeff, terms  = expr.as_coeff_mul()
 
         if coeff.is_negative:
             x = self.dom.createElement('apply')
@@ -107,7 +107,7 @@ class MathMLPrinter(Printer):
         plusNodes = list()
         for i in range(0,len(args)):
             arg = args[i]
-            coeff, terms = arg.as_coeff_terms()
+            coeff, terms = arg.as_coeff_mul()
             if(coeff.is_negative):
                 #use minus
                 x = self.dom.createElement('apply')

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -33,7 +33,7 @@ PRECEDENCE_VALUES = {
 
 # Precedence functions
 def precedence_Mul(item):
-    coeff, rest = item.as_coeff_terms()
+    coeff, rest = item.as_coeff_mul()
     if coeff.is_negative:
         return PRECEDENCE["Add"]
     return PRECEDENCE["Mul"]

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -414,7 +414,7 @@ class PrettyPrinter(Printer):
         pforms = []
 
         for term in terms:
-            if term.is_Mul and term.as_coeff_terms()[0] < 0:
+            if term.is_Mul and term.as_coeff_mul()[0] < 0:
                 pform1 = self._print(-term)
 
                 if len(pforms) == 0:

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -159,7 +159,7 @@ class StrPrinter(Printer):
         return expr.name
 
     def _print_Mul(self, expr):
-        coeff, terms = expr.as_coeff_terms()
+        coeff, terms = expr.as_coeff_mul()
         if coeff.is_negative:
             coeff = -coeff
             if coeff is not S.One:

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -63,7 +63,7 @@ def test_ccode_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert ccode(g(A[i]), assign_to=A[i]) == (
             "for (int i=0; i<n; i++){\n"
-            "   A[i] = A[i]*(1 + A[i])*(2 + A[i]);\n"
+            "   A[i] = (1 + A[i])*(2 + A[i])*A[i];\n"
             "}"
             )
 

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -114,7 +114,7 @@ def test_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert fcode(g(A[i]), assign_to=A[i]) == (
             "      do i = 1, n\n"
-            "         A(i) = A(i)*(1 + A(i))*(2 + A(i))\n"
+            "         A(i) = (1 + A(i))*(2 + A(i))*A(i)\n"
             "      end do"
             )
 

--- a/sympy/series/acceleration.py
+++ b/sympy/series/acceleration.py
@@ -9,7 +9,7 @@ Springer 1999. (Shanks transformation: pp. 368-375, Richardson
 extrapolation: pp. 375-377.)
 """
 
-from sympy import factorial, Integer
+from sympy import factorial, Integer, S
 
 
 def richardson(A, k, n, N):
@@ -56,7 +56,7 @@ def richardson(A, k, n, N):
         1.6449340668
 
     """
-    s = Integer(0)
+    s = S.Zero
     for j in range(0, N+1):
         s += A.subs(k, Integer(n+j)) * (n+j)**N * (-1)**(j+N) / \
             (factorial(j) * factorial(N-j))

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -153,7 +153,7 @@ class Order(Expr):
                     expr = C.Add(*[f.expr for (e,f) in lst])
                 else:
                     expr = expr.as_leading_term(*symbols)
-                    coeff, terms = expr.as_coeff_terms()
+                    coeff, terms = expr.as_coeff_mul()
                     if coeff is S.Zero:
                         return coeff
                     expr = C.Mul(*[t for t in terms if t.has(*symbols)])

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -1,4 +1,5 @@
 from sympy.core import Basic, S, C, sympify, Expr, oo, Rational, Symbol
+from sympy.core import Add, Mul
 from sympy.core.cache import cacheit
 
 def solve4linearsymbol(eqn, rhs, symbols = None):
@@ -11,7 +12,6 @@ def solve4linearsymbol(eqn, rhs, symbols = None):
     if eqn.is_Symbol:
         return (eqn, rhs)
     if symbols is None:
-        # TODO: Need test that calls this branch
         symbols = eqn.atoms(Symbol)
     if symbols:
         # find  symbol
@@ -150,13 +150,13 @@ class Order(Expr):
             else:
                 if expr.is_Add:
                     lst = expr.extract_leading_order(*symbols)
-                    expr = C.Add(*[f.expr for (e,f) in lst])
+                    expr = Add(*[f.expr for (e,f) in lst])
                 else:
                     expr = expr.as_leading_term(*symbols)
                     coeff, terms = expr.as_coeff_mul()
                     if coeff is S.Zero:
                         return coeff
-                    expr = C.Mul(*[t for t in terms if t.has(*symbols)])
+                    expr = Mul(*[t for t in terms if t.has(*symbols)])
 
         elif expr is not S.Zero:
             expr = S.One

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -6,7 +6,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 """
 from simplify import collect, separate, together, radsimp, ratsimp, fraction, \
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars
+    logcombine, separatevars, powdenest, posify
 
 from rewrite import apart
 

--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -47,12 +47,13 @@ def sub_pre(e):
             positives = []
             negatives = []
             for arg in node.args:
-                if (assumed(arg, 'is_Mul') and
-                    assumed(arg.args[0], 'is_number') and
-                    assumed(arg.args[0], 'is_negative')):
-                    negatives.append(Mul(-arg.args[0], *arg.args[1:]))
-                else:
-                    positives.append(arg)
+                if assumed(arg, 'is_Mul'):
+                    a, b = arg.as_two_terms()
+                    if (assumed(a, 'is_number') and
+                        assumed(a, 'is_negative')):
+                        negatives.append(Mul(-a, b))
+                        continue
+                positives.append(arg)
             if len(negatives) > 0:
                 replacement = Sub(Add(*positives), Add(*negatives))
                 replacements.append((node, replacement))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -252,7 +252,7 @@ def together(expr, deep=False):
                         if term.exp.is_Rational:
                             term, expo = term.base, term.exp
                         elif term.exp.is_Mul:
-                            coeff, tail = term.exp.as_coeff_terms()
+                            coeff, tail = term.exp.as_coeff_mul()
                             if coeff.is_Rational:
                                 tail = C.Mul(*tail)
                                 term, expo = Pow(term.base, tail), coeff
@@ -261,7 +261,7 @@ def together(expr, deep=False):
                         if term.args[0].is_Rational:
                             term, expo = S.Exp1, term.args[0]
                         elif term.args[0].is_Mul:
-                            coeff, tail = term.args[0].as_coeff_terms()
+                            coeff, tail = term.args[0].as_coeff_mul()
                             if coeff.is_Rational:
                                 tail = C.Mul(*tail)
                                 term, expo = C.exp(tail), coeff
@@ -539,7 +539,7 @@ def collect(expr, syms, evaluate=True, exact=False):
             if expr.exp.is_Rational:
                 rat_expo = expr.exp
             elif expr.exp.is_Mul:
-                coeff, tail = expr.exp.as_coeff_terms()
+                coeff, tail = expr.exp.as_coeff_mul()
 
                 if coeff.is_Rational:
                     rat_expo, sym_expo = coeff, C.Mul(*tail)
@@ -551,7 +551,7 @@ def collect(expr, syms, evaluate=True, exact=False):
             if expr.args[0].is_Rational:
                 sexpr, rat_expo = S.Exp1, expr.args[0]
             elif expr.args[0].is_Mul:
-                coeff, tail = expr.args[0].as_coeff_terms()
+                coeff, tail = expr.args[0].as_coeff_mul()
 
                 if coeff.is_Rational:
                     sexpr, rat_expo = C.exp(C.Mul(*tail)), coeff
@@ -1200,7 +1200,7 @@ def powsimp(expr, deep=False, combine='all'):
             # e.g., 2**(2*x) => 4**x
             for i in xrange(len(c_powers)):
                 b, e = c_powers[i]
-                exp_c, exp_t = e.as_coeff_terms()
+                exp_c, exp_t = e.as_coeff_mul()
                 if not (exp_c is S.One) and exp_t:
                     c_powers[i] = [C.Pow(b, exp_c), C.Mul(*exp_t)]
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -76,7 +76,7 @@ def fraction(expr, exact=False):
                 else:
                     denom.append(Pow(term.base, -term.exp))
             elif not exact and term.exp.is_Mul:
-                coeff, tail = term.exp.args[0], term.exp._new_rawargs(*term.exp.args[1:])#term.exp.getab()
+                coeff, tail = term.exp.as_two_terms()
 
                 if coeff.is_Rational and coeff.is_negative:
                     denom.append(Pow(term.base, -term.exp))
@@ -88,7 +88,7 @@ def fraction(expr, exact=False):
             if term.args[0].is_negative:
                 denom.append(C.exp(-term.args[0]))
             elif not exact and term.args[0].is_Mul:
-                coeff, tail = term.args[0], term.args[0]._new_rawargs(*term.args[1:])#term.args.getab()
+                coeff, tail = term.args[0].as_two_terms()
 
                 if coeff.is_Rational and coeff.is_negative:
                     denom.append(C.exp(-term.args[0]))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -164,7 +164,7 @@ def separate(expr, deep=False):
 
         if expr.base.is_Mul:
             t = [separate(C.Pow(t,expo), deep) for t in expr.base.args]
-            return C.Mul(*t)
+            return Mul(*t)
         elif expr.base.func is C.exp:
             if deep == True:
                 return C.exp(separate(expr.base[0], deep)*expo)
@@ -254,7 +254,7 @@ def together(expr, deep=False):
                         elif term.exp.is_Mul:
                             coeff, tail = term.exp.as_coeff_mul()
                             if coeff.is_Rational:
-                                tail = C.Mul(*tail)
+                                tail = Mul(*tail)
                                 term, expo = Pow(term.base, tail), coeff
                         coeff = S.One
                     elif term.func is C.exp:
@@ -263,7 +263,7 @@ def together(expr, deep=False):
                         elif term.args[0].is_Mul:
                             coeff, tail = term.args[0].as_coeff_mul()
                             if coeff.is_Rational:
-                                tail = C.Mul(*tail)
+                                tail = Mul(*tail)
                                 term, expo = C.exp(tail), coeff
                         coeff = S.One
                     elif term.is_Rational:
@@ -542,7 +542,7 @@ def collect(expr, syms, evaluate=True, exact=False):
                 coeff, tail = expr.exp.as_coeff_mul()
 
                 if coeff.is_Rational:
-                    rat_expo, sym_expo = coeff, C.Mul(*tail)
+                    rat_expo, sym_expo = coeff, Mul(*tail)
                 else:
                     sym_expo = expr.exp
             else:
@@ -554,7 +554,7 @@ def collect(expr, syms, evaluate=True, exact=False):
                 coeff, tail = expr.args[0].as_coeff_mul()
 
                 if coeff.is_Rational:
-                    sexpr, rat_expo = C.exp(C.Mul(*tail)), coeff
+                    sexpr, rat_expo = C.exp(Mul(*tail)), coeff
         elif isinstance(expr, Derivative):
             sexpr, deriv = parse_derivative(expr)
 
@@ -886,6 +886,7 @@ def trigsimp(expr, deep=False, recursive=False):
 
     deep:
     - Apply trigsimp inside functions
+
     recursive:
     - Use common subexpression elimination (cse()) and apply
     trigsimp recursively (recursively==True is quite expensive
@@ -1373,7 +1374,7 @@ def powsimp(expr, deep=False, combine='all'):
         else:
             return expr
     elif expr.is_Add:
-        return C.Add(*[powsimp(t, deep, combine) for t in expr.args])
+        return Add(*[powsimp(t, deep, combine) for t in expr.args])
 
     elif expr.is_Mul:
         if combine in ('exp', 'all'):
@@ -1436,7 +1437,7 @@ def powsimp(expr, deep=False, combine='all'):
                 b, e = c_powers[i]
                 exp_c, exp_t = e.as_coeff_mul()
                 if not (exp_c is S.One) and exp_t:
-                    c_powers[i] = [C.Pow(b, exp_c), C.Mul(*exp_t)]
+                    c_powers[i] = [C.Pow(b, exp_c), Mul(*exp_t)]
 
 
             # Combine bases whenever they have the same exponent
@@ -1477,7 +1478,8 @@ def powsimp(expr, deep=False, combine='all'):
                     if not in_c_powers:
                         c_powers.append([new_base, simpe])
             c_part = [C.Pow(b,e) for b,e in c_powers]
-            return C.Mul(*(c_part + nc_part))
+            return Mul(*(c_part + nc_part))
+
     else:
         return expr
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -475,38 +475,38 @@ def test_logcombine_1():
     z, w = symbols("zw", positive=True)
     b = Symbol("b", real=True)
     assert logcombine(log(x)+2*log(y)) == log(x) + 2*log(y)
-    assert logcombine(log(x)+2*log(y), assume_pos_real=True) == log(x*y**2)
+    assert logcombine(log(x)+2*log(y), force=True) == log(x*y**2)
     assert logcombine(a*log(w)+log(z)) == a*log(w) + log(z)
     assert logcombine(b*log(z)+b*log(x)) == log(z**b) + b*log(x)
     assert logcombine(b*log(z)-log(w)) == log(z**b/w)
     assert logcombine(log(x)*log(z)) == log(x)*log(z)
     assert logcombine(log(w)*log(x)) == log(w)*log(x)
     assert logcombine(cos(-2*log(z)+b*log(w))) == cos(log(w**b/z**2))
-    assert logcombine(log(log(x)-log(y))-log(z), assume_pos_real=True) == \
+    assert logcombine(log(log(x)-log(y))-log(z), force=True) == \
         log(log((x/y)**(1/z)))
-    assert logcombine((2+I)*log(x), assume_pos_real=True) == I*log(x)+log(x**2)
-    assert logcombine((x**2+log(x)-log(y))/(x*y), assume_pos_real=True) == \
+    assert logcombine((2+I)*log(x), force=True) == I*log(x)+log(x**2)
+    assert logcombine((x**2+log(x)-log(y))/(x*y), force=True) == \
         log(x**(1/(x*y))*y**(-1/(x*y)))+x/y
-    assert logcombine(log(x)*2*log(y)+log(z), assume_pos_real=True) == \
+    assert logcombine(log(x)*2*log(y)+log(z), force=True) == \
         log(z*y**log(x**2))
     assert logcombine((x*y+sqrt(x**4+y**4)+log(x)-log(y))/(pi*x**Rational(2, 3)*\
-        y**Rational(3, 2)), assume_pos_real=True) == \
+        y**Rational(3, 2)), force=True) == \
         log(x**(1/(pi*x**Rational(2, 3)*y**Rational(3, 2)))*y**(-1/(pi*\
         x**Rational(2, 3)*y**Rational(3, 2)))) + (x**4 + y**4)**Rational(1, 2)/(pi*\
         x**Rational(2, 3)*y**Rational(3, 2)) + x**Rational(1, 3)/(pi*y**Rational(1, 2))
-    assert logcombine(Eq(log(x), -2*log(y)), assume_pos_real=True) == \
+    assert logcombine(Eq(log(x), -2*log(y)), force=True) == \
         Eq(log(x*y**2), Integer(0))
-    assert logcombine(Eq(y, x*acos(-log(x/y))), assume_pos_real=True) == \
+    assert logcombine(Eq(y, x*acos(-log(x/y))), force=True) == \
         Eq(y, x*acos(log(y/x)))
-    assert logcombine(gamma(-log(x/y))*acos(-log(x/y)), assume_pos_real=True) == \
+    assert logcombine(gamma(-log(x/y))*acos(-log(x/y)), force=True) == \
         acos(log(y/x))*gamma(log(y/x))
-    assert logcombine((2+3*I)*log(x), assume_pos_real=True) == \
+    assert logcombine((2+3*I)*log(x), force=True) == \
         log(x**2)+3*I*log(x)
-    assert logcombine(Eq(y, -log(x)), assume_pos_real=True) == Eq(y, log(1/x))
-    assert logcombine(Integral((sin(x**2)+cos(x**3))/x, x), assume_pos_real=True) == \
+    assert logcombine(Eq(y, -log(x)), force=True) == Eq(y, log(1/x))
+    assert logcombine(Integral((sin(x**2)+cos(x**3))/x, x), force=True) == \
         Integral((sin(x**2)+cos(x**3))/x, x)
     assert logcombine(Integral((sin(x**2)+cos(x**3))/x, x)+ (2+3*I)*log(x), \
-        assume_pos_real=True) == log(x**2)+3*I*log(x) + \
+        force=True) == log(x**2)+3*I*log(x) + \
         Integral((sin(x**2)+cos(x**3))/x, x)
 
 @XFAIL
@@ -515,7 +515,45 @@ def test_logcombine_2():
     # This fails because of a bug in matches.  See issue 1274.
     x, y = symbols("xy")
     assert logcombine((x*y+sqrt(x**4+y**4)+log(x)-log(y))/(pi*x**(2/3)*y**(3/2)), \
-        assume_pos_real=True) == log(x**(1/(pi*x**(2/3)*y**(3/2)))*y**(-1/\
+        force=True) == log(x**(1/(pi*x**(2/3)*y**(3/2)))*y**(-1/\
         (pi*x**(2/3)*y**(3/2)))) + (x**4 + y**4)**(1/2)/(pi*x**(2/3)*y**(3/2)) + \
         x**(1/3)/(pi*y**(1/2))
 
+def test_posify():
+    from sympy import posify, Symbol, log
+    from sympy.abc import x
+
+    assert str(posify(
+        x +
+        Symbol('p', positive=True) +
+        Symbol('n', negative=True))) == '(n + p + _x, {_x: x})'
+
+    # log(1/x).expand() should be log(1/x) but it comes back as -log(x)
+    # when it is corrected, posify will allow the change to be made:
+    eq, rep = posify(1/x)
+    assert log(eq).expand().subs(rep) == -log(x)
+    assert str(posify([x, 1 + x])) == '([_x, 1 + _x], {_x: x})'
+
+def test_powdenest():
+    from sympy import powdenest
+    from sympy.abc import x, y, z, a, b
+    assert powdenest(x) == x
+    assert powdenest(x + 2*(x**(2*a/3))**(3*x)) == x + 2*(x**(a/3))**(6*x)
+    assert powdenest((exp(2*a/3))**(3*x)) == (exp(a/3))**(6*x)
+    assert powdenest((x**(2*a/3))**(3*x)) == (x**(a/3))**(6*x)
+    assert powdenest(exp(3*x*log(2))) == 2**(3*x)
+    p = symbols('p', positive=True)
+    assert powdenest(sqrt(p**2)) == p
+    i, j = symbols('ij', integer=1)
+    assert powdenest((x**x)**(i + j)) # -X-> (x**x)**i*(x**x)**j == x**(x*(i + j))
+    assert powdenest(exp(3*y*log(x))) == x**(3*y)
+    assert powdenest(exp(y*(log(a) + log(b)))) == (a*b)**y
+    assert powdenest(exp(3*(log(a) + log(b)))) == a**3*b**3
+    i = Symbol('i', integer=True)
+    p = Symbol('p', positive=True)
+    assert powdenest(((x**(2*i))**(3*y))**x) == ((x**(2*i))**(3*y))**x
+    assert powdenest(((x**(2*i))**(3*y))**x, force=1) == x**(6*i*x*y)
+    assert powdenest(((x**(2*a/3))**(3*y/i))**x) == ((x**(a/3))**(y/i))**(6*x)
+    assert powdenest((x**(2*i)*y**(4*i))**z,1) == (x*y**2)**(2*i*z)
+    assert powdenest((((x**2*y**4)**a)**(x*y))**3) == (x**2*y**4)**(3*a*x*y)
+    assert powdenest((((x**2*y**4)**a)**(x*y)), force=1) == (x**2*y**4)**(a*x*y)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -894,7 +894,7 @@ def odesimp(eq, func, order, hint):
         # special simplification of the lhs.
         if hint.startswith("1st_homogeneous_coeff"):
             for j, eqi in enumerate(eq):
-                newi = logcombine(eqi, assume_pos_real=True)
+                newi = logcombine(eqi, force=True)
                 if newi.lhs.is_Function and newi.lhs.func is log and newi.rhs == 0:
                     newi = Eq(newi.lhs.args[0]/C1, C1)
                 eq[j] = newi
@@ -1704,7 +1704,7 @@ def ode_1st_homogeneous_coeff_subs_dep_div_indep(eq, func, order, match):
     C1 = Symbol('C1')
     int = C.Integral((-r[r['e']]/(r[r['d']]+u1*r[r['e']])).subs({x:1, r['y']:u1}),
         (u1, None, f(x)/x))
-    sol = logcombine(Eq(log(x), int + log(C1)), assume_pos_real=True)
+    sol = logcombine(Eq(log(x), int + log(C1)), force=True)
     return sol
 
 def ode_1st_homogeneous_coeff_subs_indep_div_dep(eq, func, order, match):
@@ -1785,7 +1785,7 @@ def ode_1st_homogeneous_coeff_subs_indep_div_dep(eq, func, order, match):
     C1 = Symbol('C1')
     int = C.Integral((-r[r['d']]/(r[r['e']]+u2*r[r['d']])).subs({x:u2, r['y']:1}),
         (u2, None, x/f(x)))
-    sol = logcombine(Eq(log(f(x)), int + log(C1)), assume_pos_real=True)
+    sol = logcombine(Eq(log(f(x)), int + log(C1)), force=True)
     return sol
 
 # XXX: Should this function maybe go somewhere else?
@@ -1829,7 +1829,7 @@ def homogeneous_order(eq, *symbols):
 
     """
     if eq.has(log):
-        eq = logcombine(eq, assume_pos_real=True)
+        eq = logcombine(eq, force=True)
     return _homogeneous_order(eq, *symbols)
 
 def _homogeneous_order(eq, *symbols):

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -54,7 +54,7 @@ def _get_indices_Mul(expr, return_dummies=False):
 
     """
 
-    junk, factors = expr.as_coeff_terms()
+    junk, factors = expr.as_coeff_mul()
     inds = map(get_indices, factors)
     inds, syms = zip(*inds)
 

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -381,6 +381,7 @@ def numbered_symbols(prefix='x', function=None, start=0, *args, **assumptions):
     sym : Symbol
         The subscripted symbols.
     """
+
     if function is None:
         function = C.Symbol
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1035,7 +1035,7 @@ def test_inline_function():
             'REAL*8, intent(out), dimension(1:m) :: y\n'
             'INTEGER*4 :: i\n'
             'do i = 1, m\n'
-            '   y(i) = x(i)*(1 + x(i))\n'
+            '   y(i) = (1 + x(i))*x(i)\n'
             'end do\n'
             'end subroutine\n'
         )


### PR DESCRIPTION
I'm not sure how to decorate with @deprecated (I was unable to successfully import this from utilities) so I raised a NotImplementedError with instructions on what to use instead.

All tests and doctests still pass.
