### PR TITLE
Property doctests: Fix the bug where @property methods' docstrings are not doctested (issue 1947)

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -89,7 +89,7 @@ class Assume(Boolean):
             >>> from sympy.abc import x
             >>> a = Assume(x, Q.integer)
             >>> a.key
-            'integer'
+            Q.integer
 
         """
         return self._args[1]

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -57,7 +57,7 @@ class Set(Basic):
 
         As a shortcut it is possible to use the '~' or '-' operators:
 
-        >>> ##
+        >>> from sympy import Interval
 
         >>> Interval(0, 1).complement
         Union((-oo, 0), (1, oo))
@@ -78,7 +78,7 @@ class Set(Basic):
         """
         The infimum of 'self'.
 
-        >>> ##
+        >>> from sympy import Interval, Union
 
         >>> Interval(0, 1).inf
         0
@@ -96,7 +96,7 @@ class Set(Basic):
     def sup(self):
         """ The supremum of 'self'.
 
-        >>> ##
+        >>> from sympy import Interval, Union
 
         >>> Interval(0, 1).sup
         1
@@ -151,7 +151,7 @@ class Set(Basic):
         """
         The (Lebesgue) measure of 'self'.
 
-        >>> ##
+        >>> from sympy import Interval, Union
 
         >>> Interval(0, 1).measure
         1
@@ -263,7 +263,7 @@ class Interval(Set, EvalfMixin):
         The left end point of 'self'. This property takes the same value as the
         'inf' property.
 
-        >>> ##
+        >>> from sympy import Interval
 
         >>> Interval(0, 1).start
         0
@@ -279,7 +279,7 @@ class Interval(Set, EvalfMixin):
         The right end point of 'self'. This property takes the same value as the
         'sup' property.
 
-        >>> ##
+        >>> from sympy import Interval
 
         >>> Interval(0, 1).end
         1
@@ -294,7 +294,7 @@ class Interval(Set, EvalfMixin):
         """
         True if 'self' is left-open.
 
-        >>> ##
+        >>> from sympy import Interval
 
         >>> Interval(0, 1, left_open=True).left_open
         True
@@ -309,7 +309,7 @@ class Interval(Set, EvalfMixin):
         """
         True if 'self' is right-open.
 
-        >>> ##
+        >>> from sympy import Interval
 
         >>> Interval(0, 1, right_open=True).right_open
         True

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -359,6 +359,8 @@ class Triangle(Polygon):
 
         Example:
         ========
+            >>> from sympy.geometry import Point, Triangle
+
             >>> p1,p2,p3 = Point(0,0), Point(1,0), Point(0,1)
             >>> t = Triangle(p1, p2, p3)
             >>> t.altitudes[p1]
@@ -401,6 +403,8 @@ class Triangle(Polygon):
 
         Example:
         ========
+            >>> from sympy.geometry import Point, Triangle, Segment
+
             >>> p1,p2,p3 = Point(0,0), Point(1,0), Point(0,1)
             >>> t = Triangle(p1, p2, p3)
 
@@ -446,6 +450,8 @@ class Triangle(Polygon):
 
         Example:
         ========
+            >>> from sympy.geometry import Point, Triangle
+
             >>> p1,p2,p3 = Point(0,0), Point(1,0), Point(0,1)
             >>> t = Triangle(p1, p2, p3)
             >>> t.medians[p1]

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -644,8 +644,16 @@ class SymPyDocTestFinder(DocTestFinder):
         lineno = self._find_lineno(obj, source_lines)
 
         if lineno is None:
-            # if None, then it wasn't really in this source
-            return None
+            # if None, then _find_lineno couldn't find the docstring.
+            # But IT IS STILL THERE.  Likely it was decorated or something
+            # (i.e., @property docstrings have lineno == None)
+            # TODO: Write our own _find_lineno that is smarter in this regard
+            # Until then, just give it a dummy lineno.  This is just used for
+            # sorting the tests, so the only bad effect is that they will appear
+            # last instead of the order that they really are in the file.
+            # lineno is also used to report the offending line of a failing
+            # doctest, which is another reason to fix this.  See issue 1947.
+            lineno = 0
 
         # Don't bother if the docstring is empty.
         if self._exclude_empty and not docstring:


### PR DESCRIPTION
See the [issue page](http://code.google.com/p/sympy/issues/detail?id=1947) for more information on the fix.
