### PR TITLE
Call deprecated: Deprecated the __call__ shortcut to subs in Basic (issue 1927)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,5 +1,7 @@
 """Base class for all objects in sympy"""
 
+import warnings
+
 from decorators import _sympifyit
 from assumptions import AssumeMeths, make__get_assumption
 from cache import cacheit
@@ -1086,6 +1088,8 @@ class Basic(AssumeMeths):
 
     def __call__(self, subsdict):
         """Use call as a shortcut for subs, but only support the dictionary version"""
+        # See issue 1927
+        warnings.warn("__call__ as a shortcut to subs is deprecated.", DeprecationWarning)
         if not isinstance(subsdict, dict):
             raise TypeError("argument must be a dictionary")
         return self.subs(subsdict)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1,3 +1,5 @@
+import warnings
+
 from sympy import Add, Basic, S, Symbol, Wild,  Real, Integer, Rational,  \
     sin, cos, exp, log, oo, sqrt, symbols, Integral, sympify, \
     WildFunction, Poly, Function, Derivative, Number, pi, var, \
@@ -440,6 +442,8 @@ def test_subs_list():
     assert (x+y)._subs_list([(y, x**2), (x, 3)]) == 12
 
 def test_call():
+    # This is deprecated.
+    warnings.filterwarnings("ignore", r"__call__ as a shortcut to subs is deprecated\.")
     a,b,c,d,e = symbols('abcde')
 
     assert sin(x)({ x : 1, sin(x) : 2}) == 2

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,3 +1,5 @@
+import warnings
+
 from sympy import Symbol, Wild, Inequality, StrictInequality, pi, I, Rational, \
         sympify, raises, symbols
 
@@ -106,5 +108,7 @@ def test_symbols():
 def test_call():
     f = Symbol('f')
     assert f(2)
+    # This is deprecated.
+    warnings.filterwarnings("ignore", r"__call__ as a shortcut to subs is deprecated\.")
     f = Wild('f')
     assert f({})


### PR DESCRIPTION
Note that this pull request is mutually exclusive with [pull request 72](https://github.com/sympy/sympy/pull/72).  Please review one or the other, whether you think the `__call__` behavior should be deprecated or just removed.  This one is for deprecation.
