### PR TITLE
Call remove: Remove the __call__ shortcut to subs in Basic (issue 1927)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1084,12 +1084,6 @@ class Basic(AssumeMeths):
                 else:
                     return self
 
-    def __call__(self, subsdict):
-        """Use call as a shortcut for subs, but only support the dictionary version"""
-        if not isinstance(subsdict, dict):
-            raise TypeError("argument must be a dictionary")
-        return self.subs(subsdict)
-
 class Atom(Basic):
     """
     A parent class for atomic things. An atom is an expression with no subexpressions.

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -440,6 +440,8 @@ def test_subs_list():
     assert (x+y)._subs_list([(y, x**2), (x, 3)]) == 12
 
 def test_call():
+    # Unlike what used to be the case, the following should NOT work.
+    # See issue 1927.
     a,b,c,d,e = symbols('abcde')
 
     raises(TypeError, "sin(x)({ x : 1, sin(x) : 2})")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -442,7 +442,6 @@ def test_subs_list():
 def test_call():
     # Unlike what used to be the case, the following should NOT work.
     # See issue 1927.
-    a,b,c,d,e = symbols('abcde')
 
     raises(TypeError, "sin(x)({ x : 1, sin(x) : 2})")
     raises(TypeError, "sin(x)(1)")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -442,11 +442,8 @@ def test_subs_list():
 def test_call():
     a,b,c,d,e = symbols('abcde')
 
-    assert sin(x)({ x : 1, sin(x) : 2}) == 2
-
-    expr = sqrt(sin(2*x))*sin(exp(x)*x)*cos(2*x) + sin(2*x)
-
-    assert expr({ sqrt(sin(2*x)) : a, cos(2*x) : b, sin(2*x) : c, x : d, exp(x) : e}) == c + a*b*sin(d*e)
+    raises(TypeError, "sin(x)({ x : 1, sin(x) : 2})")
+    raises(TypeError, "sin(x)(1)")
 
 def test_has():
     x, y = symbols("xy")

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -106,5 +106,3 @@ def test_symbols():
 def test_call():
     f = Symbol('f')
     assert f(2)
-    f = Wild('f')
-    assert f({})


### PR DESCRIPTION
Note that this pull request is mutually exclusive with [pull request 71](https://github.com/sympy/sympy/pull/71).  Please review one or the other, whether you think the `__call__` behavior should be deprecated or just removed.  This one is for removal.
