### PR TITLE
Github docs

### DIFF
--- a/bin/test_pure
+++ b/bin/test_pure
@@ -22,7 +22,7 @@
 
 apt-get -y install git-core python2.4
 cd /tmp
-git clone git://git.sympy.org/sympy.git
+git clone git://github.com/sympy/sympy.git
 cd sympy
 python2.4 setup.py sdist
 cd dist

--- a/bin/test_pure_plotting
+++ b/bin/test_pure_plotting
@@ -23,7 +23,7 @@
 apt-get -y install git-core python2.4 python-codespeak-lib python-ctypes
 apt-get -y install libgl1-mesa-dev libglu1-mesa-dev libfreetype6-dev libfontconfig1-dev
 cd /tmp
-git clone git://git.sympy.org/sympy.git
+git clone git://github.com/sympy/sympy.git
 cd sympy
 python2.4 setup.py sdist
 cd dist

--- a/doc/src/aboutus.txt
+++ b/doc/src/aboutus.txt
@@ -108,7 +108,7 @@ want to be mentioned here, so see our repository history for a full list).
 
 
 Up-to-date list in the order of the first contribution is given in the `AUTHORS
-<http://git.sympy.org/?p=sympy.git;f=AUTHORS;hb=HEAD>`_ file.
+<https://github.com/sympy/sympy/blob/master/AUTHORS>`_ file.
 
 You can find a brief history of SymPy in the README.
 

--- a/doc/src/guide.txt
+++ b/doc/src/guide.txt
@@ -292,7 +292,7 @@ should return either some simplified instance of some other class or if the
 class should be unmodified, return ``None`` (see ``core/function.py`` in
 ``Function.__new__`` for implementation details). See also tests in
 `sympy/functions/elementary/tests/test_interface.py
-<http://git.sympy.org/?p=sympy.git;a=blob;f=sympy/functions/elementary/tests/test_interface.py>`_,
+<https://github.com/sympy/sympy/blob/master/sympy/functions/elementary/tests/test_interface.py>`_,
 that test this interface and you can use them to create your own new functions.
 
 The applied function ``sign(x)`` is constructed using

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -14,7 +14,7 @@ Printer Class
 
 The main class responsible for printing is ``Printer`` (see also its
 `source code
-<http://git.sympy.org/?p=sympy.git;a=blob;f=sympy/printing/printer.py>`_):
+<https://github.com/sympy/sympy/blob/master/sympy/printing/printer.py>`_):
 
 .. autoclass:: Printer
     :members: doprint, _print

--- a/doc/src/sympy-patches-tutorial.txt
+++ b/doc/src/sympy-patches-tutorial.txt
@@ -1079,7 +1079,7 @@ Download the latest SymPy git and fix something:
 
 .. parsed-literal::
 
-    $ :input:`git clone git://git.sympy.org/sympy.git`
+    $ :input:`git clone git://github.com/sympy/sympy.git`
     Initialized empty Git repository in /tmp/abb/sympy/.git/
     remote: Counting objects: 15421, done.
     remote: Compressing objects: 100% (4171/4171), done.

--- a/doc/src/tutorial.txt
+++ b/doc/src/tutorial.txt
@@ -20,7 +20,7 @@ to know more, read the
 :ref:`SymPy User's Guide <guide>`,
 :ref:`SymPy Modules Reference <module-docs>`.
 or the `sources
-<http://git.sympy.org/?p=sympy.git;a=tree;hb=HEAD>`_ directly.
+<https://github.com/sympy/sympy/>`_ directly.
 
 First Steps with SymPy
 ======================
@@ -292,7 +292,7 @@ you can also calculate the limit at infinity::
 
 for some non-trivial examples on limits, you can read the test file
 `test_demidovich.py
-<http://git.sympy.org/?p=sympy.git;a=blob;f=sympy/series/tests/test_demidovich.py>`_
+<https://github.com/sympy/sympy/blob/master/sympy/series/tests/test_demidovich.py>`_
 
 .. index:: differentiation, diff
 


### PR DESCRIPTION
Replace all instances of git.sympy.org with github in the docs.  See [issue 1959](http://code.google.com/p/sympy/issues/detail?id=1959).
