### PR TITLE
Copyright: Update the copyright to 2011

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006, 2007, 2008, 2009, 2010 SymPy Development Team
+Copyright (c) 2006, 2007, 2008, 2009, 2010, 2011 SymPy Development Team
 
 All rights reserved.
 

--- a/README
+++ b/README
@@ -106,7 +106,7 @@ For people that don't want to be listed there, see the git history.
 
 To cite SymPy in publications use::
 
-  SymPy Development Team (2010). SymPy: Python library for symbolic mathematics
+  SymPy Development Team (2011). SymPy: Python library for symbolic mathematics
   URL http://www.sympy.org.
 
 A BibTeX entry for LaTeX users is::
@@ -114,7 +114,7 @@ A BibTeX entry for LaTeX users is::
   @Manual{,
     title = {SymPy: Python library for symbolic mathematics},
     author = {{SymPy Development Team}},
-    year = {2010},
+    year = {2011},
     url = {http://www.sympy.org},
   }
 

--- a/data/TeXmacs/LICENSE
+++ b/data/TeXmacs/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006, 2007 SymPy developers
+Copyright (c) 2006, 2007, 2008, 2009, 2010, 2011 SymPy developers
 
 All rights reserved.
 

--- a/doc/api/conf.py
+++ b/doc/api/conf.py
@@ -34,15 +34,15 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'SymPy'
-copyright = '2008, SymPy Development Team'
+copyright = '2011, SymPy Development Team'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 #
 # The short X.Y version.
-version = '0.5.13'
+version = '0.6.7'
 # The full version, including alpha/beta/rc tags.
-release = '0.5.13'
+release = '0.6.7-git'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/man/isympy.xml
+++ b/doc/man/isympy.xml
@@ -66,8 +66,8 @@ this will generate isympy.1 in the current directory. -->
 			</author>
 		</authorgroup>
 		<copyright>
-			<year>2007</year>
-			<holder>Ondrej Certik</holder>
+			<year>2011</year>
+			<holder>SymPy Development Team</holder>
 		</copyright>
 		<legalnotice>
 			<para>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</para>

--- a/doc/src/aboutus.txt
+++ b/doc/src/aboutus.txt
@@ -70,7 +70,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. Kaifeng Zhu: factorint() fix
 #. Ted Horst: Basic.__call__() fix, pretty printing fix
 #. Akshay Srinivasan: Printing fix, improvements to integration
-#. Aaron Meurer: ODE solvers (GSoC 2009), other fixes, project leader
+#. Aaron Meurer: ODE solvers (GSoC 2009), The Risch Algorithm for integration (GSoC 2010), other fixes, project leader as of Jan 4, 2011
 #. Barry Wardell: implement series as function, several tests added
 #. Tomasz Buchert: ccode printing fixes, code quality concerning exceptions, documentation
 #. Vinay Kumar: polygamma tests


### PR DESCRIPTION
This changes the copyright year everywhere to 2011, including a place where it hasn't been changed in a while.

I am adding this here instead of just pushing it in for bookkeeping reasons.  

By the way, what's up with the `conf.py` file in `doc/`?  It still has 0.5.13 as the SymPy version.  Is this file even being used?
