### PR TITLE
1379: No longer import test and doctest with from sympy import *.

### DIFF
--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -63,9 +63,10 @@ def make_report(source_dir, report_dir, use_cache=False):
     else:
         cov.erase()
         cov.start()
-        import sympy
-        sympy.test(source_dir)
-        #sympy.doctest()        #coverage doesn't play well with doctests
+        from sympy.utilities.runtests import test
+        test(source_dir)
+        #from sympy.utilities.runtests import doctest
+        #doctest()        #coverage doesn't play well with doctests
         cov.stop()
         cov.save()
 

--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -63,9 +63,9 @@ def make_report(source_dir, report_dir, use_cache=False):
     else:
         cov.erase()
         cov.start()
-        import sympy
-        sympy.test(source_dir)
-        #sympy.doctest()        #coverage doesn't play well with doctests
+        from sympy.utilities.runtests import test, doctest
+        test(source_dir)
+        #doctest()        #coverage doesn't play well with doctests
         cov.stop()
         cov.save()
 

--- a/bin/doctest
+++ b/bin/doctest
@@ -16,7 +16,7 @@ from optparse import OptionParser
 
 from get_sympy import path_hack
 path_hack()
-import sympy
+from sympy.utilities.runtests import doctest
 
 parser = OptionParser()
 parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
@@ -34,7 +34,7 @@ parser.epilog = '"options" are any of the options above.  "files" are 0 or more 
 
 options, args = parser.parse_args()
 
-ok = sympy.doctest(*args, **{"verbose": options.verbose,
+ok = doctest(*args, **{"verbose": options.verbose,
     "blacklist": blacklist, "normal": options.normal})
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -3,8 +3,9 @@
 """
 Program to execute tests using the py.test like interface.
 
-The advantage over py.test is that it only depends on sympy and should just
-work in any circumstances. See "sympy.test?" for documentation.
+The advantage over py.test is that it only depends on sympy and should
+just work in any circumstances. See the docstring of test in
+sympy/utilities/runtests.py for documentation.
 """
 
 import sys
@@ -13,7 +14,7 @@ from optparse import OptionParser
 
 from get_sympy import path_hack
 path_hack()
-import sympy
+from sympy.utilities.runtests import test
 
 parser = OptionParser()
 parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
@@ -34,7 +35,7 @@ parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = '"options" are any of the options above.  "tests" are 0 or more glob strings of tests to run.  If no test arguments are given, all tests will be run.'
 options, args = parser.parse_args()
 
-ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
+ok = test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
     "sort": options.sort})
 if ok:

--- a/bin/test
+++ b/bin/test
@@ -34,7 +34,9 @@ parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = '"options" are any of the options above.  "tests" are 0 or more glob strings of tests to run.  If no test arguments are given, all tests will be run.'
 options, args = parser.parse_args()
 
-ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
+from sympy.utilities.runtests import test
+
+ok = test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
     "sort": options.sort})
 if ok:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ from distutils.core import Command
 import sys
 
 import sympy
+from sympy.utilities.runtests import test, doctest
 
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (2,4):
@@ -155,10 +156,10 @@ class test_sympy(Command):
         pass
 
     def run(self):
-        if sympy.test():
+        if test():
             # all regular tests run successfuly, so let's also run doctests
             # (if some regular test fails, the doctests are not run)
-            sympy.doctest()
+            doctest()
 
 
 class run_benchmarks(Command):

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,7 +1,7 @@
 from sympy import Lambda, Symbol, Function, WildFunction, Derivative, sqrt, \
         log, exp, Rational, Real, sign, Basic, sin, cos, diff, I, re, im, \
-        oo, zoo, nan, E, expand, pi, raises, O, Sum
-from sympy.utilities.pytest import XFAIL
+        oo, zoo, nan, E, expand, pi, O, Sum
+from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y
 from sympy.core.function import PoleError
 

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,8 +1,10 @@
 from sympy import (
     Symbol, Set, Union, Interval, oo, S,
-    Inequality, max_, min_, raises, And, Or
+    Inequality, max_, min_, And, Or
 )
 from sympy.mpmath import mpi
+
+from sympy.utilities.pytest import raises
 
 def test_interval_arguments():
     assert Interval(0, oo) == Interval(0, oo, False, True)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,7 +1,8 @@
 from sympy import (
     Symbol, Set, Union, Interval, oo, S,
-    Inequality, max_, min_, raises, And, Or
+    Inequality, max_, min_, And, Or
 )
+from sympy.utilities.pytest import raises
 from sympy.mpmath import mpi
 
 def test_interval_arguments():

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,6 +1,7 @@
-from sympy import Symbol, Wild, Inequality, StrictInequality, pi, I, Rational, \
-        sympify, raises, symbols
+from sympy import (Symbol, Wild, Inequality, StrictInequality, pi, I, Rational,
+    sympify, symbols)
 
+from sympy.utilities.pytest import raises
 
 def test_Symbol():
     a = Symbol("a")

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, Wild, Inequality, StrictInequality, pi, I, Rational, \
-        sympify, raises, symbols
-
+        sympify, symbols
+from sympy.utilities.pytest import raises
 
 def test_Symbol():
     a = Symbol("a")

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,8 +1,9 @@
 from sympy import Symbol, exp, Integer, Real, sin, cos, log, Poly, Lambda, \
-        Function, I, S, sqrt,  raises, srepr, Rational
+        Function, I, S, sqrt, srepr, Rational
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
 from sympy.core.decorators import _sympifyit
+from sympy.utilities.pytest import raises
 
 def test_439():
     v = sympify("exp(x)")

--- a/sympy/core/tests/test_var.py
+++ b/sympy/core/tests/test_var.py
@@ -1,6 +1,7 @@
 # Tests for var are in their own file, because var pollutes global namespace.
 
-from sympy import Symbol, var, raises
+from sympy import Symbol, var
+from sympy.utilities.pytest import raises
 
 # make z1 with call-depth = 1
 def make_z1():

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1,7 +1,6 @@
 from sympy import diff, Integral, integrate, log, oo, Piecewise, \
-    piecewise_fold, raises, symbols, pi, solve, Rational, Interval, \
-    lambdify, expand
-from sympy.utilities.pytest import XFAIL
+    piecewise_fold, symbols, pi, solve, Rational, Interval, lambdify, expand
+from sympy.utilities.pytest import XFAIL, raises
 
 x,y = symbols('xy')
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1,7 +1,7 @@
-from sympy import diff, Integral, integrate, log, oo, Piecewise, \
-    piecewise_fold, raises, symbols, pi, solve, Rational, Interval, \
-    lambdify, expand
-from sympy.utilities.pytest import XFAIL
+from sympy import (diff, Integral, integrate, log, oo, Piecewise,
+    piecewise_fold, symbols, pi, solve, Rational, Interval,
+    lambdify, expand)
+from sympy.utilities.pytest import XFAIL, raises
 
 x,y = symbols('xy')
 

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -1,5 +1,6 @@
-from sympy import jn, yn, symbols, sin, cos, pi, S, jn_zeros, raises
+from sympy import jn, yn, symbols, sin, cos, pi, S, jn_zeros
 from sympy.functions.special.bessel import fn
+from sympy.utilities.pytest import raises
 
 def test_fn():
     x, z = symbols("x z")

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,7 +1,8 @@
-from sympy import Symbol, Rational, sqrt, pi, cos, oo, simplify, Real, raises
-from sympy.geometry import Point, Polygon, convex_hull, Segment, \
-        RegularPolygon, Circle, Ellipse, GeometryError, Line, intersection, \
-        Ray, Triangle, are_similar, Curve
+from sympy import Symbol, Rational, sqrt, pi, cos, oo, simplify, Real
+from sympy.geometry import (Point, Polygon, convex_hull, Segment,
+    RegularPolygon, Circle, Ellipse, GeometryError, Line, intersection, Ray,
+    Triangle, are_similar, Curve)
+from sympy.utilities.pytest import raises
 
 x = Symbol('x', real=True)
 y = Symbol('y', real=True)

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,7 +1,8 @@
-from sympy import Symbol, Rational, sqrt, pi, cos, oo, simplify, Real, raises
+from sympy import Symbol, Rational, sqrt, pi, cos, oo, simplify, Real
 from sympy.geometry import Point, Polygon, convex_hull, Segment, \
         RegularPolygon, Circle, Ellipse, GeometryError, Line, intersection, \
         Ray, Triangle, are_similar, Curve
+from sympy.utilities.pytest import raises
 
 x = Symbol('x', real=True)
 y = Symbol('y', real=True)
@@ -407,19 +408,3 @@ def test_concyclic_doctest_bug():
     p3,p4 = Point(0, 1), Point(-1, 2)
     assert Point.is_concyclic(p1, p2, p3)
     assert not Point.is_concyclic(p1, p2, p3, p4)
-
-if __name__ == "__main__":
-    from sys import modules,stderr,exc_info,excepthook
-    import hotshot, hotshot.stats
-    curr_module = modules[__name__]
-    for member in dir(curr_module):
-        if member.startswith("test_"):
-            try:
-                sys.stderr.write("Testing %s..." % member)
-                curr_module.__dict__[member]()
-                sys.stderr.write("SUCCESS!\n")
-            except AssertionError, e:
-                sys.stderr.write("FAILED!\n")
-                sys.stderr.write('-' * 25 + '\n')
-                excepthook(*exc_info())
-                sys.stderr.write('-' * 25 + '\n')

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,8 +1,8 @@
 from sympy import (S, symbols, integrate, Integral, Derivative, exp, oo, Symbol,
         Function, Rational, log, sin, cos, pi, E, I, Poly, LambertW, diff,
         Matrix, sympify, sqrt, atan, asin, acos, atan, DiracDelta, Heaviside,
-        raises, Lambda, sstr)
-from sympy.utilities.pytest import XFAIL, skip
+        Lambda, sstr)
+from sympy.utilities.pytest import XFAIL, skip, raises
 from sympy.physics.units import m, s
 
 x,y,a,t = symbols('xyat')

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,8 +1,9 @@
 from sympy import symbols, Matrix, eye, I, Symbol, Rational, wronskian, cos, \
         sin, exp, hessian, sqrt, zeros, ones, randMatrix, Poly, S, pi, \
-        oo, raises, trigsimp, Integer, block_diag, N
+        oo, trigsimp, Integer, block_diag, N
 from sympy.matrices.matrices import ShapeError, MatrixError, \
         matrix_multiply_elementwise
+from sympy.utilities.pytest import raises
 
 def test_division():
     x, y, z = symbols('x','y','z')

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,8 +1,9 @@
-from sympy import symbols, Matrix, eye, I, Symbol, Rational, wronskian, cos, \
-        sin, exp, hessian, sqrt, zeros, ones, randMatrix, Poly, S, pi, \
-        oo, raises, trigsimp, Integer, block_diag, N
-from sympy.matrices.matrices import ShapeError, MatrixError, \
-        matrix_multiply_elementwise
+from sympy import (symbols, Matrix, eye, I, Symbol, Rational, wronskian, cos,
+    sin, exp, hessian, sqrt, zeros, ones, randMatrix, Poly, S, pi,
+    oo, trigsimp, Integer, block_diag, N)
+from sympy.matrices.matrices import (ShapeError, MatrixError,
+    matrix_multiply_elementwise)
+from sympy.utilities.pytest import raises
 
 def test_division():
     x, y, z = symbols('x','y','z')

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -1,14 +1,15 @@
 from sympy import Sieve, binomial_coefficients, binomial_coefficients_list, \
-        multinomial_coefficients, raises, Mul, S, Pow
+        multinomial_coefficients, Mul, S, Pow
+from sympy import factorial as fac
+
 from sympy.ntheory import isprime, n_order, is_primitive_root, \
     is_quad_residue, legendre_symbol, npartitions, totient, \
     factorint, primefactors, divisors, randprime, nextprime, prevprime, \
     primerange, primepi, prime, pollard_rho, perfect_power, multiplicity, \
     trailing, divisor_count
 from sympy.ntheory.bbp_pi import pi_hex_digits
-from sympy import factorial as fac
-
 from sympy.ntheory.modular import crt, crt1, crt2
+from sympy.utilities.pytest import raises
 
 def test_trailing():
     assert trailing(0) == 0

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -1,5 +1,5 @@
 from sympy import Sieve, binomial_coefficients, binomial_coefficients_list, \
-        multinomial_coefficients, raises, Mul, S, Pow
+        multinomial_coefficients, Mul, S, Pow
 from sympy.ntheory import isprime, n_order, is_primitive_root, \
     is_quad_residue, legendre_symbol, npartitions, totient, \
     factorint, primefactors, divisors, randprime, nextprime, prevprime, \

--- a/sympy/physics/tests/test_hydrogen.py
+++ b/sympy/physics/tests/test_hydrogen.py
@@ -1,5 +1,6 @@
-from sympy import var, sqrt, exp, simplify, S, integrate, oo, Symbol, raises
+from sympy import var, sqrt, exp, simplify, S, integrate, oo, Symbol
 from sympy.physics.hydrogen import R_nl, E_nl, E_nl_dirac
+from sympy.utilities.pytest import raises
 
 var("r Z")
 

--- a/sympy/polys/tests/test_algebratools.py
+++ b/sympy/polys/tests/test_algebratools.py
@@ -10,9 +10,11 @@ from sympy.polys.polyerrors import (
     DomainError,
 )
 
-from sympy import S, sqrt, sin, oo, raises
+from sympy import S, sqrt, sin, oo
 
 from sympy.abc import x, y
+
+from sympy.utilities.pytest import raises
 
 ALG = QQ.algebraic_field(sqrt(2)+sqrt(3))
 

--- a/sympy/polys/tests/test_algebratools.py
+++ b/sympy/polys/tests/test_algebratools.py
@@ -1,18 +1,12 @@
 """Tests for classes defining properties of ground domains, e.g. ZZ, QQ, ZZ[x] ... """
 
-from sympy.polys.algebratools import (
-    ZZ, QQ, RR, PolynomialRing, FractionField, EX
-)
+from sympy.polys.algebratools import ZZ, QQ, RR, PolynomialRing, FractionField, EX
+from sympy.polys.polyerrors import (UnificationFailed, GeneratorsNeeded,
+    DomainError,)
 
-from sympy.polys.polyerrors import (
-    UnificationFailed,
-    GeneratorsNeeded,
-    DomainError,
-)
-
-from sympy import S, sqrt, sin, oo, raises
-
+from sympy import S, sqrt, sin, oo
 from sympy.abc import x, y
+from sympy.utilities.pytest import raises
 
 ALG = QQ.algebraic_field(sqrt(2)+sqrt(3))
 

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -39,7 +39,7 @@ from sympy.polys.polyerrors import (
 from sympy.polys.specialpolys import f_0
 from sympy.polys.algebratools import ZZ, QQ
 
-from sympy import raises
+from sympy.utilities.pytest import raises
 
 F_0 = dmp_mul_ground(dmp_normal(f_0, 2, QQ), QQ(1,7), 2, QQ)
 

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -43,7 +43,7 @@ from sympy.polys.polyclasses import (
 
 from sympy.polys.algebratools import ZZ, QQ
 
-from sympy import raises
+from sympy.utilities.pytest import raises
 
 def test_dup_LC():
     assert dup_LC([], ZZ) == 0

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -73,7 +73,9 @@ from sympy.polys.specialpolys import (
 
 from sympy.polys.algebratools import ZZ, QQ, EX
 
-from sympy import raises, I
+from sympy import I
+
+from sympy.utilities.pytest import raises
 
 def test_dup_ground_to_ring():
     assert dup_ground_to_ring([], QQ, ZZ) == (ZZ(1), [])

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -73,7 +73,8 @@ from sympy.polys.specialpolys import (
 
 from sympy.polys.algebratools import ZZ, QQ, EX
 
-from sympy import raises, I
+from sympy import I
+from sympy.utilities.pytest import raises
 
 def test_dup_ground_to_ring():
     assert dup_ground_to_ring([], QQ, ZZ) == (ZZ(1), [])

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -45,7 +45,8 @@ from sympy.polys.polyclasses import DMP, DMF, ANP
 
 from sympy.polys.algebratools import ZZ, QQ, RR, EX
 
-from sympy import raises, nextprime, sin, sqrt, I
+from sympy import nextprime, sin, sqrt, I
+from sympy.utilities.pytest import raises
 
 def test_dup_trial_division():
     assert dup_trial_division([1,8,25,38,28,8],

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -45,7 +45,9 @@ from sympy.polys.polyclasses import DMP, DMF, ANP
 
 from sympy.polys.algebratools import ZZ, QQ, RR, EX
 
-from sympy import raises, nextprime, sin, sqrt, I
+from sympy import nextprime, sin, sqrt, I
+
+from sympy.utilities.pytest import raises
 
 def test_dup_trial_division():
     assert dup_trial_division([1,8,25,38,28,8],

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -30,7 +30,8 @@ from sympy.polys.polyerrors import (
 )
 
 from sympy.polys.algebratools import ZZ
-from sympy import pi, nextprime, raises
+from sympy import pi, nextprime
+from sympy.utilities.pytest import raises
 
 def test_gf_crt():
     U = [49, 76, 65]

--- a/sympy/polys/tests/test_groebnertools.py
+++ b/sympy/polys/tests/test_groebnertools.py
@@ -24,7 +24,7 @@ from sympy.polys.monomialtools import (
 
 from sympy.polys.algebratools import ZZ, QQ
 
-from sympy import raises
+from sympy.utilities.pytest import raises
 
 def test_sdp_LC():
     assert sdp_LC([], QQ) == QQ(0)

--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -7,7 +7,7 @@ from sympy.polys.monomialtools import (
 )
 
 from sympy.abc import x, y
-from sympy import raises
+from sympy.utilities.pytest import raises
 
 def test_monomials():
     assert sorted(monomials([], 0)) == [1]

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -1,6 +1,6 @@
 """Tests for computational algebraic number field theory. """
 
-from sympy import S, Rational, Symbol, Poly, raises, sin, sqrt, I, oo
+from sympy import S, Rational, Symbol, Poly, sin, sqrt, I, oo
 
 from sympy.polys.numberfields import (
     minimal_polynomial,
@@ -21,6 +21,8 @@ from sympy.polys.polyclasses import DMP
 from sympy.polys.algebratools import QQ
 
 from sympy.abc import x, y
+
+from sympy.utilities.pytest import raises
 
 Q = Rational
 

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -1,6 +1,7 @@
 """Tests for computational algebraic number field theory. """
 
-from sympy import S, Rational, Symbol, Poly, raises, sin, sqrt, I, oo
+from sympy import S, Rational, Symbol, Poly, sin, sqrt, I, oo
+from sympy.utilities.pytest import raises
 
 from sympy.polys.numberfields import (
     minimal_polynomial,

--- a/sympy/polys/tests/test_orthopolys.py
+++ b/sympy/polys/tests/test_orthopolys.py
@@ -1,6 +1,7 @@
 """Tests for efficient functions for generating orthogonal polynomials. """
 
-from sympy import Poly, raises, Rational as Q
+from sympy import Poly, Rational as Q
+from sympy.utilities.pytest import raises
 
 from sympy.polys.orthopolys import (
     chebyshevt_poly,

--- a/sympy/polys/tests/test_orthopolys.py
+++ b/sympy/polys/tests/test_orthopolys.py
@@ -1,6 +1,6 @@
 """Tests for efficient functions for generating orthogonal polynomials. """
 
-from sympy import Poly, raises, Rational as Q
+from sympy import Poly, Rational as Q
 
 from sympy.polys.orthopolys import (
     chebyshevt_poly,
@@ -11,6 +11,8 @@ from sympy.polys.orthopolys import (
 )
 
 from sympy.abc import x
+
+from sympy.utilities.pytest import raises
 
 def test_chebyshevt_poly():
     raises(ValueError, "chebyshevt_poly(-1, x)")

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -16,7 +16,7 @@ from sympy.polys.polyerrors import (
     ExactQuotientFailed,
 )
 
-from sympy import raises
+from sympy.utilities.pytest import raises
 
 def test_DUP___init__():
     f = DUP([0,0,1,2,3], ZZ)

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -1,6 +1,7 @@
 
 from sympy import S, symbols, Symbol, Integer, Rational, \
-    sqrt, I, raises, powsimp, Lambda
+    sqrt, I, powsimp, Lambda
+from sympy.utilities.pytest import raises
 
 from sympy.polys import Poly
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -1,12 +1,13 @@
-
 from sympy import S, symbols, Symbol, Integer, Rational, \
-    sqrt, I, raises, powsimp, Lambda
+    sqrt, I, powsimp, Lambda
 
 from sympy.polys import Poly
 
 from sympy.polys.polyroots import root_factors, roots_linear,  \
     roots_quadratic, roots_cubic, roots_quartic, roots_binomial, \
     roots_rational, roots, number_of_real_roots, RootOf, RootsOf, RootSum
+
+from sympy.utilities.pytest import raises
 
 a, b, c, d, t, x, y, z = symbols('a,b,c,d,t,x,y,z')
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -45,7 +45,8 @@ from sympy.polys.polyclasses import GFP, DMP, DMF
 
 from sympy.polys.algebratools import ZZ, QQ, RR, EX
 
-from sympy import S, Integer, Rational, Mul, symbols, sqrt, exp, sin, expand, raises, oo, I
+from sympy import S, Integer, Rational, Mul, symbols, sqrt, exp, sin, expand, oo, I
+from sympy.utilities.pytest import raises
 
 x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e = symbols('x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e')
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -45,7 +45,9 @@ from sympy.polys.polyclasses import GFP, DMP, DMF
 
 from sympy.polys.algebratools import ZZ, QQ, RR, EX
 
-from sympy import S, Integer, Rational, Mul, symbols, sqrt, exp, sin, expand, raises, oo, I
+from sympy import S, Integer, Rational, Mul, symbols, sqrt, exp, sin, expand, oo, I
+
+from sympy.utilities.pytest import raises
 
 x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e = symbols('x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e')
 

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -1,6 +1,6 @@
 """Tests for useful utilities for higher level polynomial classes. """
 
-from sympy import S, I, Integer, sqrt, symbols, raises, pi
+from sympy import S, I, Integer, sqrt, symbols, pi
 
 from sympy.polys.polyutils import (
     _sort_gens,
@@ -20,6 +20,8 @@ from sympy.polys.polyerrors import (
 )
 
 from sympy.polys.algebratools import ZZ, QQ, EX
+
+from sympy.utilities.pytest import raises
 
 x,y,z,p,q,r,s,t,u,v,w = symbols('x,y,z,p,q,r,s,t,u,v,w')
 

--- a/sympy/polys/tests/test_polyutils.py
+++ b/sympy/polys/tests/test_polyutils.py
@@ -1,6 +1,7 @@
 """Tests for useful utilities for higher level polynomial classes. """
 
-from sympy import S, I, Integer, sqrt, symbols, raises, pi
+from sympy import S, I, Integer, sqrt, symbols, pi
+from sympy.utilities.pytest import raises
 
 from sympy.polys.polyutils import (
     _sort_gens,

--- a/sympy/polys/tests/test_specialpolys.py
+++ b/sympy/polys/tests/test_specialpolys.py
@@ -1,6 +1,6 @@
 """Tests for functions for generating interesting polynomials. """
 
-from sympy import Poly, ZZ, raises
+from sympy import Poly, ZZ
 
 from sympy.polys.specialpolys import (
     swinnerton_dyer_poly,
@@ -15,6 +15,8 @@ from sympy.polys.specialpolys import (
 )
 
 from sympy.abc import x, y, z
+
+from sympy.utilities.pytest import raises
 
 def test_swinnerton_dyer_poly():
     raises(ValueError, "swinnerton_dyer_poly(0, x)")

--- a/sympy/polys/tests/test_specialpolys.py
+++ b/sympy/polys/tests/test_specialpolys.py
@@ -1,6 +1,7 @@
 """Tests for functions for generating interesting polynomials. """
 
-from sympy import Poly, ZZ, raises
+from sympy import Poly, ZZ
+from sympy.utilities.pytest import raises
 
 from sympy.polys.specialpolys import (
     swinnerton_dyer_poly,

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-from sympy import Matrix, Piecewise, Ne, symbols, sqrt, Function, raises, \
+from sympy import Matrix, Piecewise, Ne, symbols, sqrt, Function, \
     Rational, conjugate, Derivative, tan, Function, log, floor, Symbol, \
     pprint, sqrt, factorial, pi, sin, ceiling, pprint_use_unicode, I, S, \
     Limit, oo, cos, Pow, Integral, exp, Eq, Lt, Gt, Ge, Le, gamma
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
+
+from sympy.utilities.pytest import raises
 
 x, y, k = symbols('xyk')
 th  = Symbol('theta')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from sympy import Matrix, Piecewise, Ne, symbols, sqrt, Function, raises, \
+from sympy import Matrix, Piecewise, Ne, symbols, sqrt, Function, \
     Rational, conjugate, Derivative, tan, Function, log, floor, Symbol, \
     pprint, sqrt, factorial, pi, sin, ceiling, pprint_use_unicode, I, S, \
     Limit, oo, cos, Pow, Integral, exp, Eq, Lt, Gt, Ge, Le, gamma
+from sympy.utilities.pytest import raises
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -1,11 +1,13 @@
 from sympy import sin, cos, atan2, gamma, conjugate, sqrt, Factorial, \
-    Integral, Piecewise, Add, diff, symbols, S, raises, Real
+    Integral, Piecewise, Add, diff, symbols, S, Real
 from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
+
+from sympy.utilities.pytest import raises
 
 
 def test_printmethod():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -1,11 +1,12 @@
 from sympy import sin, cos, atan2, gamma, conjugate, sqrt, Factorial, \
-    Integral, Piecewise, Add, diff, symbols, S, raises, Real
+    Integral, Piecewise, Add, diff, symbols, S, Real
 from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
+from sympy.utilities.pytest import raises
 
 
 def test_printmethod():

--- a/sympy/printing/tests/test_gtk.py
+++ b/sympy/printing/tests/test_gtk.py
@@ -1,5 +1,5 @@
-from sympy import print_gtk, sin, raises
-from sympy.utilities.pytest import XFAIL
+from sympy import print_gtk, sin
+from sympy.utilities.pytest import XFAIL, raises
 
 # this test fails if python-libxml2 isn't installed. We don't want to depend on
 # anything with SymPy

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -1,4 +1,6 @@
-from sympy import symbols, sin, Matrix, raises, Interval, Piecewise
+from sympy import symbols, sin, Matrix, Interval, Piecewise
+from sympy.utilities.pytest import raises
+
 from sympy.printing.lambdarepr import lambdarepr
 x,y,z = symbols("xyz")
 

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -1,5 +1,7 @@
-from sympy import symbols, sin, Matrix, raises, Interval, Piecewise
+from sympy import symbols, sin, Matrix, Interval, Piecewise
 from sympy.printing.lambdarepr import lambdarepr
+from sympy.utilities.pytest import raises
+
 x,y,z = symbols("xyz")
 
 def test_basic():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,10 +1,10 @@
 from sympy import symbols, Rational, Symbol, Integral, log, diff, sin, exp, \
         Function, factorial, floor, ceiling, abs, re, im, conjugate, gamma, \
         Order, Piecewise, Matrix, asin, Interval, EmptySet, Union, S, Sum, \
-        Limit, oo, Poly, raises
+        Limit, oo, Poly
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 from sympy.functions import DiracDelta
 
 x,y = symbols('xy')

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,8 +1,10 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
-    pi, GoldenRatio, EulerGamma, raises, Sum
+    pi, GoldenRatio, EulerGamma, Sum
 from sympy.printing.mathml import mathml, MathMLPrinter
 from xml.dom.minidom import parseString
+
+from sympy.utilities.pytest import raises
 
 x = Symbol('x')
 mp = MathMLPrinter()

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -1,6 +1,8 @@
 from sympy import diff, Integral, Limit, sin, Symbol, Integer, Rational, cos, \
     tan, asin, acos, atan, sinh, cosh, tanh, asinh, acosh, atanh, E, I, oo, \
-    pi, GoldenRatio, EulerGamma, raises
+    pi, GoldenRatio, EulerGamma
+from sympy.utilities.pytest import raises
+
 from sympy.printing.mathml import mathml, MathMLPrinter
 from xml.dom.minidom import parseString
 

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from sympy import Symbol, symbols, oo, limit, Rational, Integral, Derivative, \
-    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne, raises
+    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne
+from sympy.utilities.pytest import raises
 
 from sympy.printing.python import python
 

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from sympy import Symbol, symbols, oo, limit, Rational, Integral, Derivative, \
-    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne, raises
+    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne
 
 from sympy.printing.python import python
+
+from sympy.utilities.pytest import raises
 
 x, y = symbols('xy')
 th  = Symbol('theta')

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,6 @@
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 from sympy import Symbol, symbols, Function, Integer, Matrix, nan, oo, abs, \
-    Rational, Real, S, WildFunction, raises
+    Rational, Real, S, WildFunction
 from sympy.geometry import Point, Circle, Ellipse
 from sympy.printing import srepr
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -2,13 +2,13 @@ from sympy import abs, Catalan, cos, Derivative, E, EulerGamma, exp, factorial,\
                   Function, GoldenRatio, I, Integer, Integral, Interval, Lambda,\
                   Limit, log, Matrix, nan, O, oo, pi, Rational, Real, Rel, S,\
                   sin, SMatrix, sqrt, sum, Sum, Sum2, Symbol, symbols, Wild,\
-                  WildFunction, zeta, zoo, raises
+                  WildFunction, zeta, zoo
 from sympy.core import Expr
 from sympy.physics.units import second
 from sympy.polys import Poly, RootsOf, RootOf, RootSum
 from sympy.statistics.distributions import Normal, Sample, Uniform
 from sympy.geometry import Point, Circle
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 from sympy.printing import sstr, sstrrepr, StrPrinter
 

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -1,6 +1,7 @@
 from sympy import Symbol, Rational, ln, exp, log, sqrt, E, O, pi, I, sinh, \
         sin, cosh, cos, tanh, coth, asinh, acosh, atanh, acoth, tan, Integer, \
-        PoleError, floor, ceiling, raises, asin, symbols
+        PoleError, floor, ceiling, asin, symbols
+from sympy.utilities.pytest import raises
 from sympy.abc import x, y, z
 
 def test_simple_1():

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -1,7 +1,9 @@
-from sympy import Symbol, Rational, ln, exp, log, sqrt, E, O, pi, I, sinh, \
-        sin, cosh, cos, tanh, coth, asinh, acosh, atanh, acoth, tan, Integer, \
-        PoleError, floor, ceiling, raises, asin, symbols
+from sympy import (Symbol, Rational, ln, exp, log, sqrt, E, O, pi, I, sinh,
+    sin, cosh, cos, tanh, coth, asinh, acosh, atanh, acoth, tan, Integer,
+    PoleError, floor, ceiling, asin, symbols)
 from sympy.abc import x, y, z
+
+from sympy.utilities.pytest import raises
 
 def test_simple_1():
     assert x.nseries(x, 0, 5) == x

--- a/sympy/simplify/tests/test_rewrite.py
+++ b/sympy/simplify/tests/test_rewrite.py
@@ -1,7 +1,8 @@
-from sympy import sin, cos, exp, cot, sqrt, S, I, E, pi, symbols, Function, Matrix, Eq, RootSum, Lambda, raises
+from sympy import sin, cos, exp, cot, sqrt, S, I, E, pi, symbols, Function, \
+    Matrix, Eq, RootSum, Lambda
 from sympy.simplify import apart, together
 from sympy.integrals import integrate
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 x,y,z,n = symbols('xyzn')
 

--- a/sympy/simplify/tests/test_rewrite.py
+++ b/sympy/simplify/tests/test_rewrite.py
@@ -1,7 +1,8 @@
-from sympy import sin, cos, exp, cot, sqrt, S, I, E, pi, symbols, Function, Matrix, Eq, RootSum, Lambda, raises
+from sympy import (sin, cos, exp, cot, sqrt, S, I, E, pi, symbols, Function,
+    Matrix, Eq, RootSum, Lambda)
 from sympy.simplify import apart, together
 from sympy.integrals import integrate
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 x,y,z,n = symbols('xyzn')
 

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -1,6 +1,7 @@
 from sympy.solvers.pde import pde_separate_add, pde_separate_mul, _separate
-from sympy import Eq, exp, Function, raises, Symbol, symbols
+from sympy import Eq, exp, Function, Symbol, symbols
 from sympy import Derivative as D
+from sympy.utilities.pytest import raises
 
 def test_pde_separate_add():
     x, y, z, t = symbols("xyzt")

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -1,6 +1,6 @@
 
-from sympy import S, symbols, Integer, Rational, \
-    sqrt, I, solve_poly_system, raises, Poly
+from sympy import S, symbols, Integer, Rational, sqrt, I, solve_poly_system, Poly
+from sympy.utilities.pytest import raises
 
 x, y, z = symbols('xyz')
 

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -1,6 +1,6 @@
+from sympy import S, symbols, Integer, Rational, sqrt, I, solve_poly_system, Poly
 
-from sympy import S, symbols, Integer, Rational, \
-    sqrt, I, solve_poly_system, raises, Poly
+from sympy.utilities.pytest import raises
 
 x, y, z = symbols('xyz')
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1,6 +1,6 @@
 from sympy import Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq, \
         sqrt, oo, LambertW, pi, I, sin, asin, Function, diff, Derivative, \
-        symbols, S, raises, sympify, var, simplify, Integral, sstr
+        symbols, S, sympify, var, simplify, Integral, sstr
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve
@@ -8,7 +8,7 @@ from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
 from sympy.solvers.solvers import guess_solve_strategy, GS_POLY, GS_POLY_CV_1, GS_POLY_CV_2,\
     GS_TRANSCENDENTAL, GS_RATIONAL, GS_RATIONAL_CV_1
 
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 def NS(e, n=15, **options):
     return sstr(sympify(e).evalf(n, **options), full_prec=True)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1,6 +1,6 @@
-from sympy import Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq, \
-        sqrt, oo, LambertW, pi, I, sin, asin, Function, diff, Derivative, \
-        symbols, S, raises, sympify, var, simplify, Integral, sstr
+from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
+    sqrt, oo, LambertW, pi, I, sin, asin, Function, diff, Derivative, symbols,
+    S, sympify, var, simplify, Integral, sstr)
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve
@@ -8,7 +8,7 @@ from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
 from sympy.solvers.solvers import guess_solve_strategy, GS_POLY, GS_POLY_CV_1, GS_POLY_CV_2,\
     GS_TRANSCENDENTAL, GS_RATIONAL, GS_RATIONAL_CV_1
 
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 def NS(e, n=15, **options):
     return sstr(sympify(e).evalf(n, **options), full_prec=True)

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -16,8 +16,6 @@ from source import source
 
 from decorator import threaded, deprecated
 
-from runtests import test, doctest
-
 from pytest import raises
 
 from cythonutils import cythonized

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -15,9 +15,5 @@ from source import source
 
 from decorator import threaded, deprecated
 
-from runtests import test, doctest
-
-from pytest import raises
-
 from cythonutils import cythonized
 

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -16,7 +16,5 @@ from source import source
 
 from decorator import threaded, deprecated
 
-from pytest import raises
-
 from cythonutils import cythonized
 

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -30,7 +30,7 @@ def raises(ExpectedException, code):
 
     Example:
 
-    >>> from sympy import raises
+    >>> from sympy.utilities.pytest import raises
     >>> raises(ZeroDivisionError, "1/0")
     >>> raises(ZeroDivisionError, "1/2")
     Traceback (most recent call last):

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -100,20 +100,20 @@ def test(*paths, **kwargs):
 
     Examples:
 
-    >> import sympy
+    >> from sympy.utilities.runtests import test
 
     Run all tests:
-    >> sympy.test()
+    >> test()
 
     Run one file:
-    >> sympy.test("sympy/core/tests/test_basic.py")
-    >> sympy.test("_basic")
+    >> test("sympy/core/tests/test_basic.py")
+    >> test("_basic")
 
     Run all tests in sympy/functions/ and some particular file:
-    >> sympy.test("sympy/core/tests/test_basic.py", "sympy/functions")
+    >> test("sympy/core/tests/test_basic.py", "sympy/functions")
 
     Run all tests in sympy/core and sympy/utilities:
-    >> sympy.test("/core", "/util")
+    >> test("/core", "/util")
     """
     verbose = kwargs.get("verbose", False)
     tb = kwargs.get("tb", "short")
@@ -153,21 +153,21 @@ def doctest(*paths, **kwargs):
 
     Examples:
 
-    >> import sympy
+    >> froms sympy.utilities.runtests import doctest
 
     Run all tests:
-    >> sympy.doctest()
+    >> doctest()
 
     Run one file:
-    >> sympy.doctest("sympy/core/basic.py")
-    >> sympy.doctest("polynomial.txt")
+    >> doctest("sympy/core/basic.py")
+    >> doctest("polynomial.txt")
 
     Run all tests in sympy/functions/ and some particular file:
-    >> sympy.doctest("/functions", "basic.py")
+    >> doctest("/functions", "basic.py")
 
     Run any file having polynomial in its name, doc/src/modules/polynomial.txt,
     sympy\functions\special\polynomials.py, and sympy\polys\polynomial.py:
-    >> sympy.doctest("polynomial")
+    >> doctest("polynomial")
     """
     normal = kwargs.get("normal", False)
     verbose = kwargs.get("verbose", False)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,4 +1,6 @@
-from sympy import symbols, Integral, raises
+from sympy import symbols, Integral
+from sympy.utilities.pytest import raises
+
 from sympy.utilities.iterables import postorder_traversal, \
     preorder_traversal, flatten, subsets, variations, cartes
 from sympy.functions.elementary.piecewise import Piecewise, ExprCondPair

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,7 +1,8 @@
-from sympy import symbols, Integral, raises, Tuple
+from sympy import symbols, Integral, Tuple
 from sympy.utilities.iterables import postorder_traversal, \
     preorder_traversal, flatten, subsets, variations, cartes
 from sympy.functions.elementary.piecewise import Piecewise, ExprCondPair
+from sympy.utilities.pytest import raises
 
 w,x,y,z= symbols('wxyz')
 


### PR DESCRIPTION
See [the issue page](http://code.google.com/p/sympy/issues/detail?id=1379).

Should we also keep importing raises?  I noticed that there too in `utilities/__init__.py`.
