### PR TITLE
Summation: Rename sum() to summation()

### DIFF
--- a/sympy/concrete/__init__.py
+++ b/sympy/concrete/__init__.py
@@ -1,4 +1,4 @@
 from products import product, Product
-from summations import sum, Sum
+from summations import summation, Sum
 from sums_products import Sum2
 from gosper import normal, gosper

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -79,7 +79,7 @@ class Product(Expr):
             return self
 
     def _eval_product(self, a, n, term):
-        from sympy import sum, Sum
+        from sympy import summation, Sum
         k = self.index
 
         if not term.has(k):
@@ -125,7 +125,7 @@ class Product(Expr):
                 return A * Product(B, (k, a, n))
         elif term.is_Pow:
             if not term.base.has(k):
-                s = sum(term.exp, (k, a, n))
+                s = summation(term.exp, (k, a, n))
 
                 if not isinstance(s, Sum):
                     return term.base**s

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1,8 +1,8 @@
-from sympy import abs, Catalan, cos, Derivative, E, EulerGamma, exp, factorial,\
-                  Function, GoldenRatio, I, Integer, Integral, Interval, Lambda,\
-                  Limit, log, Matrix, nan, O, oo, pi, Rational, Real, Rel, S,\
-                  sin, SMatrix, sqrt, sum, Sum, Sum2, Symbol, symbols, Wild,\
-                  WildFunction, zeta, zoo, raises
+from sympy import (abs, Catalan, cos, Derivative, E, EulerGamma, exp, factorial,
+    Function, GoldenRatio, I, Integer, Integral, Interval, Lambda, Limit, log,
+    Matrix, nan, O, oo, pi, Rational, Real, Rel, S, sin, SMatrix, sqrt,
+    summation, Sum, Sum2, Symbol, symbols, Wild, WildFunction, zeta, zoo,
+    raises)
 from sympy.core import Expr
 from sympy.physics.units import second
 from sympy.polys import Poly, RootsOf, RootOf, RootSum
@@ -310,7 +310,7 @@ def test_SMatrix():
     assert str(M) == sstr(M) == "[x,     1]\n[y, x + y]"
 
 def test_Sum():
-    assert str(sum(cos(3*z), (z, x, y))) == "Sum(cos(3*z), (z, x, y))"
+    assert str(summation(cos(3*z), (z, x, y))) == "Sum(cos(3*z), (z, x, y))"
     assert str(Sum(x*y**2, (x, -2, 2), (y, -5, 5))) == \
         "Sum(x*y**2, (x, -2, 2), (y, -5, 5))"
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -398,7 +398,7 @@ from sympy.concrete.sums_products import Sum2, _BigOperator
 
 def test_concrete():
     x = Symbol("x")
-    for c in (Product, Product(1,2), Sum, Sum(1), Sum2, Sum2(x,(x,2,4)),
+    for c in (Product, Product(1,2), Sum, Sum(x, (x, 2, 4)), Sum2, Sum2(x,(x,2,4)),
               _BigOperator):
         check(c)
 


### PR DESCRIPTION
Rename sum() to summation()

This is because it conflicts with the builtin sum().  See issue 1376 and
issue 1727.

I also took the opportunity to fix Sum() so that it always remains
unevaluated by default and so that it and summation always require at
least symbols argument.  I have also written a docstring for
summation().

I fixed a test in test_pickling.py that I am not entirely sure if the
fix was correct (it was using the now defunct Sum(2) syntax).

There is a class called Sum2 that seems to duplicate summation/Sum.  I
did not look into it here.

See [issue 1727](http://code.google.com/p/sympy/issues/detail?id=1727), [issue 1376](http://code.google.com/p/sympy/issues/detail?id=1376), and [this mailing list thread](http://groups.google.com/group/sympy/browse_thread/thread/4f022d07f4111493). 
