### PR TITLE
Abs: Rename abs() to Abs()

### DIFF
--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -6,20 +6,20 @@ Functions Module
 Elementary
 ==========
 
-This module implements elementary functions (abs, max, etc.)
+This module implements elementary functions, as well as functions like abs, max, etc.
 
 
-abs
+Abs
 ---
 
 Returns the absolute value of the argument.
 
 Examples::
-    >>> from sympy.functions import abs
-    >>> abs(-1)
+    >>> from sympy.functions import Abs
+    >>> Abs(-1)
     1
 
-.. autoclass:: sympy.functions.elementary.abs
+.. autoclass:: sympy.functions.elementary.Abs
 
 
 arg

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -19,7 +19,7 @@ Examples::
     >>> Abs(-1)
     1
 
-.. autoclass:: sympy.functions.elementary.Abs
+.. autoclass:: sympy.functions.elementary.complexes.Abs
 
 
 arg
@@ -38,7 +38,7 @@ Examples::
     >>> arg(sqrt(2) + I*sqrt(2))
     pi/4
 
-.. autoclass:: sympy.functions.elementary.arg
+.. autoclass:: sympy.functions.elementary.complexes.arg
 
 conjugate
 ---------
@@ -61,7 +61,7 @@ Examples::
     >>> conjugate(I)
     -I
 
-.. autoclass:: sympy.functions.elementary.conjugate
+.. autoclass:: sympy.functions.elementary.complexes.conjugate
 
 
 min_
@@ -80,7 +80,7 @@ Examples::
 
 It is named min_ and not min to avoid conflicts with built-in function min.
 
-.. autoclass:: sympy.functions.elementary.min_
+.. autoclass:: sympy.functions.elementary.miscellaneous.min_
 
 
 max_
@@ -90,7 +90,7 @@ Returns the maximum of two (comparable) expressions
 
 It is named max_ and not max to avoid conflicts with built-in function min.
 
-.. autoclass:: sympy.functions.elementary.max_
+.. autoclass:: sympy.functions.elementary.miscellaneous.max_
 
 
 re
@@ -104,7 +104,7 @@ Examples::
     >>> re(2+3*I)
     2
 
-.. autoclass:: sympy.functions.elementary.re
+.. autoclass:: sympy.functions.elementary.complexes.re
 
 
 sqrt
@@ -117,7 +117,7 @@ Returns the square root of an expression. It is equivalent to raise to Rational(
     >>> sqrt(2) == 2**Rational(1,2)
     True
 
-.. autoclass:: sympy.functions.elementary.sqrt
+.. autoclass:: sympy.functions.elementary.miscellaneous.sqrt
 
 
 sign
@@ -134,7 +134,7 @@ Returns the sign of an expression, that is:
      >>> sign(0)
      0
 
-.. autoclass:: sympy.functions.elementary.sign
+.. autoclass:: sympy.functions.elementary.complexes.sign
 
 
 Combinatorial

--- a/examples/advanced/gibbs_phenomenon.py
+++ b/examples/advanced/gibbs_phenomenon.py
@@ -13,7 +13,7 @@ See:
  * http://en.wikipedia.org/wiki/Gibbs_phenomena
 """
 
-from sympy import var, sqrt, integrate, conjugate, seterr, abs, pprint, I, pi,\
+from sympy import var, sqrt, integrate, conjugate, seterr, Abs, pprint, I, pi,\
         sin, cos, sign, Plot, msolve, lambdify, Integral, S
 
 #seterr(True)
@@ -35,7 +35,7 @@ def l2_norm(f, lim):
     1/3*6**(1/2)
 
     """
-    return sqrt(integrate(abs(f)**2, lim))
+    return sqrt(integrate(Abs(f)**2, lim))
 
 def l2_inner_product(a, b, lim):
     """

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -187,7 +187,7 @@ class AskEvenHandler(CommonHandler):
         return False
 
     @staticmethod
-    def abs(expr, assumptions):
+    def Abs(expr, assumptions):
         if ask(expr.args[0], Q.real, assumptions):
             return ask(expr.args[0], Q.even, assumptions)
 

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -84,7 +84,7 @@ class AskNegativeHandler(CommonHandler):
         return False
 
     @staticmethod
-    def abs(expr, assumptions):
+    def Abs(expr, assumptions):
         return False
 
 class AskNonZeroHandler(CommonHandler):
@@ -122,7 +122,7 @@ class AskNonZeroHandler(CommonHandler):
         return True
 
     @staticmethod
-    def abs(expr, assumptions):
+    def Abs(expr, assumptions):
         return ask(expr.args[0], Q.nonzero, assumptions)
 
 class AskPositiveHandler(CommonHandler):
@@ -186,5 +186,5 @@ class AskPositiveHandler(CommonHandler):
         return False
 
     @staticmethod
-    def abs(expr, assumptions):
+    def Abs(expr, assumptions):
         return ask(expr, Q.nonzero, assumptions)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -97,7 +97,7 @@ class AskIntegerHandler(CommonHandler):
         return False
 
     @staticmethod
-    def abs(expr, assumptions):
+    def Abs(expr, assumptions):
         return ask(expr.args[0], Q.integer, assumptions)
 
 class AskRationalHandler(CommonHandler):
@@ -252,7 +252,7 @@ class AskRealHandler(CommonHandler):
         return True
 
     @staticmethod
-    def abs(expr, assumptions):
+    def Abs(expr, assumptions):
         return True
 
     @staticmethod
@@ -322,7 +322,7 @@ class AskComplexHandler(CommonHandler):
         return True
 
     @staticmethod
-    def abs(expr, assumptions):
+    def _complex(expr, assumptions):
         return True
 
     @staticmethod
@@ -337,7 +337,7 @@ class AskComplexHandler(CommonHandler):
     def NegativeInfinity(expr, assumptions):
         return False
 
-    sin, cos, exp, re, im = [abs]*5 # they are all complex functions
+    sin, cos, exp, re, im, Abs = [_complex]*6 # they are all complex functions
 
 class AskImaginaryHandler(CommonHandler):
     """

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -322,7 +322,7 @@ class AskComplexHandler(CommonHandler):
         return True
 
     @staticmethod
-    def _complex(expr, assumptions):
+    def Abs(expr, assumptions):
         return True
 
     @staticmethod
@@ -337,7 +337,7 @@ class AskComplexHandler(CommonHandler):
     def NegativeInfinity(expr, assumptions):
         return False
 
-    sin, cos, exp, re, im, Abs = [_complex]*6 # they are all complex functions
+    sin, cos, exp, re, im = [Abs]*5 # they are all complex functions
 
 class AskImaginaryHandler(CommonHandler):
     """

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -16,7 +16,7 @@ def refine(expr, assumptions=True):
         >>> from sympy import refine, sqrt, Assume, Q
         >>> from sympy.abc import x
         >>> refine(sqrt(x**2), Assume(x, Q.real))
-        abs(x)
+        Abs(x)
         >>> refine(sqrt(x**2), Assume(x, Q.positive))
         x
 
@@ -39,13 +39,13 @@ def refine_abs(expr, assumptions):
 
     Examples::
 
-    >>> from sympy import Symbol, Assume, Q, refine
+    >>> from sympy import Symbol, Assume, Q, refine, Abs
     >>> from sympy.assumptions.refine import refine_abs
     >>> from sympy.abc import x
-    >>> refine_abs(abs(x), Assume(x, Q.real))
-    >>> refine_abs(abs(x), Assume(x, Q.positive))
+    >>> refine_abs(Abs(x), Assume(x, Q.real))
+    >>> refine_abs(Abs(x), Assume(x, Q.positive))
     x
-    >>> refine_abs(abs(x), Assume(x, Q.negative))
+    >>> refine_abs(Abs(x), Assume(x, Q.negative))
     -x
 
     """
@@ -156,7 +156,7 @@ def refine_exp(expr, assumptions):
                     return S.ImaginaryUnit
 
 handlers_dict = {
-    'abs'        : refine_abs,
+    'Abs'        : refine_abs,
     'Pow'        : refine_Pow,
     'exp'        : refine_exp,
 }

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,5 +1,5 @@
 from sympy.core import Symbol, symbols, S, Rational, Integer, I, pi, oo
-from sympy.functions import exp, log, sin, cos, sign, re, im, sqrt
+from sympy.functions import exp, log, sin, cos, sign, re, im, sqrt, Abs
 from sympy.assumptions import (Assume, global_assumptions, Q, ask,
     register_handler, remove_handler, AssumptionsContext)
 from sympy.assumptions.handlers import AskHandler
@@ -524,7 +524,7 @@ def test_complex():
     assert ask(exp(x), Q.complex) == True
 
     # Q.complexes
-    assert ask(abs(x), Q.complex) == True
+    assert ask(Abs(x), Q.complex) == True
     assert ask(re(x),  Q.complex) == True
     assert ask(im(x),  Q.complex) == True
 
@@ -565,8 +565,8 @@ def test_even():
     assert ask(x+y+z+t, Q.even, Assume(x, Q.odd) & Assume(y, Q.odd) & \
                      Assume(z, Q.even) & Assume(t, Q.integer)) == None
 
-    assert ask(abs(x), Q.even, Assume(x, Q.even)) == True
-    assert ask(abs(x), Q.even, Assume(x, Q.even, False)) == None
+    assert ask(Abs(x), Q.even, Assume(x, Q.even)) == True
+    assert ask(Abs(x), Q.even, Assume(x, Q.even, False)) == None
     assert ask(re(x),  Q.even, Assume(x, Q.even)) == True
     assert ask(re(x),  Q.even, Assume(x, Q.even, False)) == None
     assert ask(im(x),  Q.even, Assume(x, Q.even)) == True
@@ -734,7 +734,7 @@ def test_negative():
     assert ask(x**y, Q.negative, Assume(x, Q.positive) & \
                      Assume(y, Q.integer)) == False
 
-    assert ask(abs(x), Q.negative) == False
+    assert ask(Abs(x), Q.negative) == False
 
 def test_nonzero():
     x, y = symbols('xy')
@@ -755,8 +755,8 @@ def test_nonzero():
     assert ask(x*y, Q.nonzero, Assume(x, Q.nonzero)) == None
     assert ask(x*y, Q.nonzero, Assume(x, Q.nonzero) & Assume(y, Q.nonzero)) == True
 
-    assert ask(abs(x), Q.nonzero) == None
-    assert ask(abs(x), Q.nonzero, Assume(x, Q.nonzero)) == True
+    assert ask(Abs(x), Q.nonzero) == None
+    assert ask(Abs(x), Q.nonzero, Assume(x, Q.nonzero)) == True
 
 def test_odd():
     x, y, z, t = symbols('x y z t')
@@ -805,7 +805,7 @@ def test_odd():
     assert ask(2*x*y, Q.odd, Assume(x, Q.rational) & Assume(x, Q.rational)) == None
     assert ask(2*x*y, Q.odd, Assume(x, Q.irrational) & Assume(x, Q.irrational)) == None
 
-    assert ask(abs(x), Q.odd, Assume(x, Q.odd)) == True
+    assert ask(Abs(x), Q.odd, Assume(x, Q.odd)) == True
 
 def test_prime():
     x, y = symbols('x y')
@@ -854,8 +854,8 @@ def test_positive():
     assert ask(x + exp(x), Q.positive, Assume(x, Q.real)) == None
 
     #absolute value
-    assert ask(abs(x), Q.positive) == None # abs(0) = 0
-    assert ask(abs(x), Q.positive, Assume(x, Q.positive)) == True
+    assert ask(Abs(x), Q.positive) == None # Abs(0) = 0
+    assert ask(Abs(x), Q.positive, Assume(x, Q.positive)) == True
 
 @XFAIL
 def test_positive_xfail():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,15 +1,15 @@
-from sympy import S, symbols, Assume, exp, pi, sqrt, Rational, I, Q, refine
+from sympy import S, symbols, Assume, exp, pi, sqrt, Rational, I, Q, refine, Abs
 from sympy.utilities.pytest import XFAIL
 
-def test_abs():
+def test_Abs():
     x = symbols('x')
-    assert refine(abs(x), Assume(x, Q.positive)) == x
-    assert refine(1+abs(x), Assume(x, Q.positive)) == 1+x
-    assert refine(abs(x), Assume(x, Q.negative)) == -x
-    assert refine(1+abs(x), Assume(x, Q.negative)) == 1-x
+    assert refine(Abs(x), Assume(x, Q.positive)) == x
+    assert refine(1+Abs(x), Assume(x, Q.positive)) == 1+x
+    assert refine(Abs(x), Assume(x, Q.negative)) == -x
+    assert refine(1+Abs(x), Assume(x, Q.negative)) == 1-x
 
-    assert refine(abs(x**2)) != x**2
-    assert refine(abs(x**2), Assume(x, Q.real)) == x**2
+    assert refine(Abs(x**2)) != x**2
+    assert refine(Abs(x**2), Assume(x, Q.real)) == x**2
 
 def test_pow():
     x, y, z = symbols('x y z')
@@ -18,9 +18,9 @@ def test_pow():
     assert refine((-2)**x, Assume(x, Q.even)) == 2**x
 
     # nested powers
-    assert refine(sqrt(x**2)) != abs(x)
-    assert refine(sqrt(x**2), Assume(x, Q.complex)) != abs(x)
-    assert refine(sqrt(x**2), Assume(x, Q.real)) == abs(x)
+    assert refine(sqrt(x**2)) != Abs(x)
+    assert refine(sqrt(x**2), Assume(x, Q.complex)) != Abs(x)
+    assert refine(sqrt(x**2), Assume(x, Q.real)) == Abs(x)
     assert refine(sqrt(x**2), Assume(x, Q.positive)) == x
     assert refine((x**3)**(S(1)/3)) != x
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -109,7 +109,7 @@ class Sum(Expr):
             >>> s
             -log(a) + log(b) + 1/(2*a) + 1/(2*b)
             >>> e
-            abs(-1/(12*b**2) + 1/(12*a**2))
+            Abs(-1/(12*b**2) + 1/(12*a**2))
 
         If the function is a polynomial of degree at most 2n+1, the
         Euler-Maclaurin formula becomes exact (and e = 0 is returned):

--- a/sympy/concrete/sums_products.py
+++ b/sympy/concrete/sums_products.py
@@ -1,5 +1,4 @@
-from sympy.core import Basic, C, Rational, Pow, Symbol, Wild, oo
-from sympy.core import sympify
+from sympy.core import Basic, C, Rational, Pow, Symbol, Wild, oo, sympify
 #from sympy.specfun import rising_factorial, factorial, factorial_simplify
 #from sympy.specfun.factorials import unfac
 #from sympy.specfun import bernoulli

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -583,7 +583,7 @@ def evalf_log(expr, prec, options):
 
     if xim:
         # XXX: use get_abs etc instead
-        re = evalf_log(C.log(C.abs(arg, evaluate=False), evaluate=False), prec, options)
+        re = evalf_log(C.log(C.Abs(arg, evaluate=False), evaluate=False), prec, options)
         im = mpf_atan2(xim, xre or fzero, prec)
         return re[0], im, re[2], prec
 
@@ -952,7 +952,7 @@ def _create_evalf_table():
 
     C.log : evalf_log,
     C.atan : evalf_atan,
-    C.abs : evalf_abs,
+    C.Abs : evalf_abs,
 
     C.re : evalf_re,
     C.im : evalf_im,

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -32,7 +32,7 @@ class Expr(Basic, EvalfMixin):
     def __neg__(self):
         return Mul(S.NegativeOne, self)
     def __abs__(self):
-        return C.abs(self)
+        return C.Abs(self)
 
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__radd__')

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -20,7 +20,7 @@ from combinatorial.factorials import Binomial, Factorial2
 from combinatorial.numbers import fibonacci, lucas, harmonic, bernoulli, bell
 
 from elementary.miscellaneous import sqrt, min_, max_
-from elementary.complexes import re, im, sign, abs, conjugate, arg
+from elementary.complexes import re, im, sign, Abs, conjugate, arg
 from elementary.trigonometric import acot, cot, tan, cos, sin, asin, acos, atan, atan2
 from elementary.exponential import exp, log, LambertW
 from elementary.hyperbolic import sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -209,7 +209,7 @@ class Abs(Function):
 
     Examples
 
-        >>> from sympy import Abs, Symbol
+        >>> from sympy import Abs, Symbol, S
         >>> Abs(-1)
         1
         >>> x = Symbol('x', real=True)
@@ -219,6 +219,16 @@ class Abs(Function):
         x**2
         >>> abs(-x) # The Python built-in
         Abs(x)
+
+    Note that the Python built-in will return either an Expr or int depending on
+    the argument::
+
+        >>> type(abs(-1))
+        <type 'int'>
+        >>> type(abs(S.NegativeOne))
+        <class 'sympy.core.numbers.One'>
+
+    Abs will always return a sympy object.
 
     """
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -200,20 +200,25 @@ class sign(Function):
         import sage.all as sage
         return sage.sgn(self.args[0]._sage_())
 
-class abs(Function):
-    """Return the absolute value of the argument. This is an extension of the built-in
-    function abs to accept symbolic values
+class Abs(Function):
+    """Return the absolute value of the argument.
+
+    This is an extension of the built-in function abs() to accept symbolic
+    values.  If you pass a SymPy expression to the built-in abs(), it will
+    pass it automatically to Abs().
 
     Examples
 
-        >>> from sympy import abs, Symbol
-        >>> abs(-1)
+        >>> from sympy import Abs, Symbol
+        >>> Abs(-1)
         1
         >>> x = Symbol('x', real=True)
-        >>> abs(-x)
-        abs(x)
-        >>> abs(x**2)
+        >>> Abs(-x)
+        Abs(x)
+        >>> Abs(x**2)
         x**2
+        >>> abs(-x) # The Python built-in
+        Abs(x)
 
     """
 
@@ -276,7 +281,7 @@ class abs(Function):
             return Derivative(self.args[0], x, **{'evaluate': True}) * sign(self.args[0])
         return (re(self.args[0]) * re(Derivative(self.args[0], x,
             **{'evaluate': True})) + im(self.args[0]) * im(Derivative(self.args[0],
-                x, **{'evaluate': True}))) / abs(self.args[0])
+                x, **{'evaluate': True}))) / Abs(self.args[0])
 
 class arg(Function):
     """Returns the argument (in radians) of a complex number"""
@@ -331,5 +336,5 @@ class conjugate(Function):
 
 # /cyclic/
 from sympy.core import basic as _
-_.abs_ = abs
+_.abs_ = Abs
 del _

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -378,10 +378,10 @@ class log(Function):
 
     def as_real_imag(self, deep=True, **hints):
         if deep:
-            abs = C.abs(self.args[0].expand(deep, **hints))
+            abs = C.Abs(self.args[0].expand(deep, **hints))
             arg = C.arg(self.args[0].expand(deep, **hints))
         else:
-            abs = C.abs(self.args[0])
+            abs = C.Abs(self.args[0])
             arg = C.arg(self.args[0])
         if hints['log']: # Expand the log
             hints['complex'] = False

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,5 +1,5 @@
 from sympy import symbols, Symbol, sqrt, oo, re, nan, im, sign, I, E, log, \
-        pi, arg, conjugate, expand, exp, sin, cos, Function
+        pi, arg, conjugate, expand, exp, sin, cos, Function, Abs
 from sympy.utilities.pytest import XFAIL
 
 
@@ -99,42 +99,43 @@ def test_sign():
     assert sign(x).is_zero == True
 
 
-def test_abs():
+def test_Abs():
     x, y = symbols('xy')
-    assert abs(0) == 0
-    assert abs(1) == 1
-    assert abs(-1)== 1
+    assert Abs(0) == 0
+    assert Abs(1) == 1
+    assert Abs(-1)== 1
     x = Symbol('x',real=True)
     n = Symbol('n',integer=True)
-    assert x**(2*n) == abs(x)**(2*n)
-    assert abs(x).diff(x) == sign(x)
+    assert x**(2*n) == Abs(x)**(2*n)
+    assert Abs(x).diff(x) == sign(x)
+    assert abs(x) == Abs(x) # Python built-in
 
 def test_abs_real():
     # test some properties of abs that only apply
     # to real numbers
     x = Symbol('x', complex=True)
-    assert sqrt(x**2) != abs(x)
-    assert abs(x**2) != x**2
+    assert sqrt(x**2) != Abs(x)
+    assert Abs(x**2) != x**2
 
     x = Symbol('x', real=True)
-    assert sqrt(x**2) == abs(x)
-    assert abs(x**2) == x**2
+    assert sqrt(x**2) == Abs(x)
+    assert Abs(x**2) == x**2
 
 def test_abs_properties():
     x = Symbol('x')
-    assert abs(x).is_real == True
-    assert abs(x).is_positive == None
-    assert abs(x).is_nonnegative == True
+    assert Abs(x).is_real == True
+    assert Abs(x).is_positive == None
+    assert Abs(x).is_nonnegative == True
 
     w = Symbol('w', complex=True, zero=False)
-    assert abs(w).is_real == True
-    assert abs(w).is_positive == True
-    assert abs(w).is_zero == False
+    assert Abs(w).is_real == True
+    assert Abs(w).is_positive == True
+    assert Abs(w).is_zero == False
 
     q = Symbol('q', positive=True)
-    assert abs(q).is_real == True
-    assert abs(q).is_positive == True
-    assert abs(q).is_zero == False
+    assert Abs(q).is_real == True
+    assert Abs(q).is_positive == True
+    assert Abs(q).is_zero == False
 
 def test_arg():
     assert arg(0) == nan
@@ -167,7 +168,7 @@ def test_conjugate():
 
 def test_issue936():
     x = Symbol('x')
-    assert abs(x).expand(trig=True)     == abs(x)
+    assert Abs(x).expand(trig=True)     == Abs(x)
     assert sign(x).expand(trig=True)    == sign(x)
     assert arg(x).expand(trig=True)     == arg(x)
 
@@ -183,5 +184,5 @@ def test_derivatives_issue1658():
     assert im(f(x)).diff(x) == im(f(x).diff(x))
 
     x = Symbol('x', real=True)
-    assert abs(f(x)).diff(x).subs(f(x), 1+I*x).doit() == x/sqrt(1 + x**2)
+    assert Abs(f(x)).diff(x).subs(f(x), 1+I*x).doit() == x/sqrt(1 + x**2)
     assert arg(f(x)).diff(x).subs(f(x), 1+I*x**2).doit() == 2*x/(1+x**4)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1077,7 +1077,7 @@ class atan2(Function):
             if sign_y.is_Number:
                 return sign_y * S.Pi/2
         else:
-            abs_yx = C.abs(y/x)
+            abs_yx = C.Abs(y/x)
             if sign_y.is_Number and abs_yx.is_number:
                 phi = C.atan(abs_yx)
                 if x.is_positive:

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -67,9 +67,9 @@ class DiracDelta(Function):
            >>> from sympy.abc import x, y
 
            >>> DiracDelta(x*y).simplify(x)
-           DiracDelta(x)/abs(y)
+           DiracDelta(x)/Abs(y)
            >>> DiracDelta(x*y).simplify(y)
-           DiracDelta(y)/abs(x)
+           DiracDelta(y)/Abs(x)
 
            >>> DiracDelta(x**2+x-2).simplify(x)
            DiracDelta(-1 + x)/3 + DiracDelta(2 + x)/3

--- a/sympy/galgebra/GA.py
+++ b/sympy/galgebra/GA.py
@@ -28,7 +28,7 @@ HALF = sympy.Rational(1,2)
 
 from sympy.core import Symbol as sym_type
 from sympy.core import Pow as pow_type
-from sympy import abs as abs_type
+from sympy import Abs as abs_type
 from sympy.core import Mul as mul_type
 from sympy.core import Add as add_type
 
@@ -55,7 +55,7 @@ def is_quasi_unit_numpy_array(array):
                 if array[ix][iy] != ZERO:
                     return(False)
                 iy += 1
-            if sympy.abs(array[ix][ix]) != ONE:
+            if sympy.Abs(array[ix][ix]) != ONE:
                 return(False)
             ix += 1
         return(True)

--- a/sympy/parsing/tests/test_maxima.py
+++ b/sympy/parsing/tests/test_maxima.py
@@ -1,12 +1,12 @@
 from sympy.parsing.maxima import parse_maxima
-from sympy import Rational, abs, Symbol, sin, cos, E, oo, log, factorial
+from sympy import Rational, Abs, Symbol, sin, cos, E, oo, log, factorial
 from sympy.abc import x
 
 n = Symbol('n', integer=True)
 
 
 def test_parser():
-    assert abs(parse_maxima('float(1/3)') - 0.333333333) < 10**(-5)
+    assert Abs(parse_maxima('float(1/3)') - 0.333333333) < 10**(-5)
     assert parse_maxima('13^26') == 91733330193268616658399616009
     assert parse_maxima('sin(%pi/2) + cos(%pi/3)') == Rational(3,2)
     assert parse_maxima('log(%e)') == 1
@@ -35,4 +35,4 @@ def test_maxima_functions():
                 )
             )  == factorial(n)
     assert parse_maxima('ratsimp((x^2-1)/(x+1))') == x-1
-    assert abs( parse_maxima('float(sec(%pi/3) + csc(%pi/3))') - 3.154700538379252) < 10**(-5)
+    assert Abs( parse_maxima('float(sec(%pi/3) + csc(%pi/3))') - 3.154700538379252) < 10**(-5)

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -18,7 +18,7 @@ from sympy.printing.precedence import precedence
 # Used in CCodePrinter._print_Function(self)
 known_functions = {
         "ceiling": [(lambda x: True, "ceil")],
-        "abs": [(lambda x: not x.is_integer, "fabs")],
+        "Abs": [(lambda x: not x.is_integer, "fabs")],
         }
 
 class CCodePrinter(CodePrinter):

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -22,11 +22,11 @@ from sympy.core import S, C
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence
 from sympy.functions import sin, cos, tan, asin, acos, atan, atan2, sinh, \
-    cosh, tanh, sqrt, log, exp, abs, sign, conjugate, Piecewise
+    cosh, tanh, sqrt, log, exp, Abs, sign, conjugate, Piecewise
 
 implicit_functions = set([
     sin, cos, tan, asin, acos, atan, atan2, sinh, cosh, tanh, sqrt, log, exp,
-    abs, sign, conjugate
+    Abs, sign, conjugate
 ])
 
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -474,7 +474,7 @@ class LatexPrinter(Printer):
         else:
             return tex
 
-    def _print_abs(self, expr, exp=None):
+    def _print_Abs(self, expr, exp=None):
         tex = r"\lvert{%s}\rvert" % self._print(expr.args[0])
 
         if exp is not None:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -82,7 +82,7 @@ class PrettyPrinter(Printer):
         pform = self._print(e.args[0])
         return prettyForm( *pform.above( hobj('_',pform.width())) )
 
-    def _print_abs(self, e):
+    def _print_Abs(self, e):
         pform = self._print(e.args[0])
         pform = prettyForm(*pform.parens('|', '|'))
         return pform

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from sympy import Matrix, Piecewise, Ne, symbols, sqrt, Function, raises, \
-    Rational, conjugate, Derivative, tan, Function, log, floor, Symbol, \
-    pprint, sqrt, factorial, pi, sin, ceiling, pprint_use_unicode, I, S, \
-    Limit, oo, cos, Pow, Integral, exp, Eq, Lt, Gt, Ge, Le, gamma
+from sympy import (Matrix, Piecewise, Ne, symbols, sqrt, Function, raises,
+    Rational, conjugate, Derivative, tan, Function, log, floor, Symbol,
+    pprint, sqrt, factorial, pi, sin, ceiling, pprint_use_unicode, I, S,
+    Limit, oo, cos, Pow, Integral, exp, Eq, Lt, Gt, Ge, Le, gamma, Abs)
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
@@ -66,9 +66,9 @@ sin(x)**3/tan(x)**2
 FUNCTIONS (ABS, CONJ, EXP, FUNCTION BRACES, FACTORIAL, FLOOR, CEILING):
 
 (2*x + exp(x))  #
-abs(x)
-abs(x/(x**2+1)) #
-abs(1 / (y - abs(x)))
+Abs(x)
+Abs(x/(x**2+1)) #
+Abs(1 / (y - Abs(x)))
 factorial(n)
 factorial(2*n)
 factorial(factorial(factorial(n)))
@@ -751,7 +751,7 @@ tan (x)\
 
 
 def test_pretty_functions():
-    """Tests for abs, conjugate, exp, function braces, and factorial."""
+    """Tests for Abs, conjugate, exp, function braces, and factorial."""
     expr = (2*x + exp(x))
     ascii_str_1 = \
 """\
@@ -776,7 +776,7 @@ u"""\
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
-    expr = abs(x)
+    expr = Abs(x)
     ascii_str = \
 """\
 |x|\
@@ -788,7 +788,7 @@ u"""\
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = abs(x/(x**2+1))
+    expr = Abs(x/(x**2+1))
     ascii_str_1 = \
 """\
 |  x   |\n\
@@ -820,7 +820,7 @@ u"""\
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
-    expr = abs(1 / (y - abs(x)))
+    expr = Abs(1 / (y - Abs(x)))
     ascii_str = \
 """\
 |   1   |\n\

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,5 +1,5 @@
 from sympy.core import pi, oo, symbols, Function, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda
-from sympy.functions import Piecewise, sin, cos, abs, exp, ceiling, sqrt
+from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.printing.ccode import CCodePrinter
 from sympy.utilities.lambdify import implemented_function
@@ -12,7 +12,7 @@ x, y, z = symbols('xyz')
 g = Function('g')
 
 def test_printmethod():
-    class fabs(abs):
+    class fabs(Abs):
         def _ccode(self, printer):
             return "fabs(%s)" % printer._print(self.args[0])
     assert ccode(fabs(x)) == "fabs(x)"
@@ -69,7 +69,7 @@ def test_ccode_inline_function():
 
 def test_ccode_exceptions():
     assert ccode(ceiling(x)) == "ceil(x)"
-    assert ccode(abs(x)) == "fabs(x)"
+    assert ccode(Abs(x)) == "fabs(x)"
 
 def test_ccode_boolean():
     assert ccode(x&y) == "x&&y"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,5 +1,5 @@
 from sympy import symbols, Rational, Symbol, Integral, log, diff, sin, exp, \
-        Function, factorial, floor, ceiling, abs, re, im, conjugate, gamma, \
+        Function, factorial, floor, ceiling, Abs, re, im, conjugate, gamma, \
         Order, Piecewise, Matrix, asin, Interval, EmptySet, Union, S, Sum, \
         Limit, oo, Poly, raises
 from sympy.abc import mu, tau
@@ -11,11 +11,11 @@ x,y = symbols('xy')
 k,n = symbols('kn', integer=True)
 
 def test_printmethod():
-    class R(abs):
+    class R(Abs):
         def _latex(self, printer):
             return "foo(%s)" % printer._print(self.args[0])
     assert latex(R(x)) == "foo(x)"
-    class R(abs):
+    class R(Abs):
         def _latex(self, printer):
             return "foo"
     assert latex(R(x)) == "foo"
@@ -87,7 +87,7 @@ def test_latex_functions():
 
     assert latex(floor(x)) == r"\lfloor{x}\rfloor"
     assert latex(ceiling(x)) == r"\lceil{x}\rceil"
-    assert latex(abs(x)) == r"\lvert{x}\rvert"
+    assert latex(Abs(x)) == r"\lvert{x}\rvert"
     assert latex(re(x)) == r"\Re{x}"
     assert latex(im(x)) == r"\Im{x}"
     assert latex(conjugate(x)) == r"\overline{x}"

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from sympy import Symbol, symbols, oo, limit, Rational, Integral, Derivative, \
-    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne, raises
+from sympy import (Symbol, symbols, oo, limit, Rational, Integral, Derivative,
+    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne, raises, Abs)
 
 from sympy.printing.python import python
 
@@ -70,9 +70,9 @@ def test_python_functions():
     assert python((2*x + exp(x))) in "x = Symbol('x')\ne = 2*x + exp(x)"
     assert python(sqrt(2)) == 'e = 2**(Half(1, 2))'
     assert python(sqrt(2+pi)) == 'e = (2 + pi)**(Half(1, 2))'
-    assert python(abs(x)) == "x = Symbol('x')\ne = abs(x)"
-    assert python(abs(x/(x**2+1))) in ["x = Symbol('x')\ne = abs(x/(1 + x**2))",
-            "x = Symbol('x')\ne = abs(x/(x**2 + 1))"]
+    assert python(Abs(x)) == "x = Symbol('x')\ne = Abs(x)"
+    assert python(Abs(x/(x**2+1))) in ["x = Symbol('x')\ne = Abs(x/(1 + x**2))",
+            "x = Symbol('x')\ne = Abs(x/(x**2 + 1))"]
 
     # Univariate/Multivariate functions
     f = Function('f')

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,5 +1,5 @@
 from sympy.utilities.pytest import XFAIL
-from sympy import Symbol, symbols, Function, Integer, Matrix, nan, oo, abs, \
+from sympy import Symbol, symbols, Function, Integer, Matrix, nan, oo, Abs, \
     Rational, Real, S, WildFunction, raises
 from sympy.geometry import Point, Circle, Ellipse
 from sympy.printing import srepr
@@ -32,7 +32,7 @@ def test_printmethod():
         def _sympyrepr(self, printer):
             return "foo"
     assert srepr(R()) == "foo"
-    class R(abs):
+    class R(Abs):
         def _sympyrepr(self, printer):
             return "foo(%s)" % printer._print(self.args[0])
     assert srepr(R(x)) == "foo(Symbol('x'))"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1,4 +1,4 @@
-from sympy import abs, Catalan, cos, Derivative, E, EulerGamma, exp, factorial,\
+from sympy import Abs, Catalan, cos, Derivative, E, EulerGamma, exp, factorial,\
                   Function, GoldenRatio, I, Integer, Integral, Interval, Lambda,\
                   Limit, log, Matrix, nan, O, oo, pi, Rational, Real, Rel, S,\
                   sin, SMatrix, sqrt, sum, Sum, Sum2, Symbol, symbols, Wild,\
@@ -16,19 +16,19 @@ x, y, z, w = symbols('xyzw')
 d = Symbol('d', dummy=True)
 
 def test_printmethod():
-    class R(abs):
+    class R(Abs):
         def _sympystr(self, printer):
             return "foo(%s)" % printer._print(self.args[0])
     assert sstr(R(x)) == "foo(x)"
-    class R(abs):
+    class R(Abs):
         def _sympystr(self, printer):
             return "foo"
     assert sstr(R(x)) == "foo"
 
-def test_abs():
-    assert str(abs(x)) == "abs(x)"
-    assert str(abs(Rational(1,6))) == "1/6"
-    assert str(abs(Rational(-1,6))) == "1/6"
+def test_Abs():
+    assert str(Abs(x)) == "Abs(x)"
+    assert str(Abs(Rational(1,6))) == "1/6"
+    assert str(Abs(Rational(-1,6))) == "1/6"
 
 def test_Add():
     assert str(x+y) == "x + y"

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -14,7 +14,7 @@ SYMPY = {}
 
 # Mappings between sympy and other modules function names.
 MATH_TRANSLATIONS = {
-    "abs":"fabs",
+    "Abs":"fabs",
     "ceiling":"ceil",
     "E":"e",
     "ln":"log",

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -166,11 +166,11 @@ def test_no_results_c():
 
 def test_ansi_math1_codegen():
     # not included: log10
-    from sympy import acos, asin, atan, ceiling, cos, cosh, floor, log, ln, \
-        sin, sinh, sqrt, tan, tanh, N
+    from sympy import (acos, asin, atan, ceiling, cos, cosh, floor, log, ln,
+        sin, sinh, sqrt, tan, tanh, N, Abs)
     x = symbols('x')
     name_expr = [
-        ("test_fabs", abs(x)),
+        ("test_fabs", Abs(x)),
         ("test_acos", acos(x)),
         ("test_asin", asin(x)),
         ("test_atan", atan(x)),
@@ -556,11 +556,11 @@ def test_no_results_f():
 
 def test_intrinsic_math_codegen():
     # not included: log10
-    from sympy import acos, asin, atan, ceiling, cos, cosh, floor, log, ln, \
-            sin, sinh, sqrt, tan, tanh, N
+    from sympy import (acos, asin, atan, ceiling, cos, cosh, floor, log, ln,
+            sin, sinh, sqrt, tan, tanh, N, Abs)
     x = symbols('x')
     name_expr = [
-            ("test_abs", abs(x)),
+            ("test_abs", Abs(x)),
             ("test_acos", acos(x)),
             ("test_asin", asin(x)),
             ("test_atan", atan(x)),
@@ -582,7 +582,7 @@ def test_intrinsic_math_codegen():
             'REAL*8 function test_abs(x)\n'
             'implicit none\n'
             'REAL*8, intent(in) :: x\n'
-            'test_abs = abs(x)\n'
+            'test_abs = Abs(x)\n'
             'end function\n'
             'REAL*8 function test_acos(x)\n'
             'implicit none\n'

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -145,7 +145,7 @@ def test_core_cache():
 from sympy.functions import (Piecewise, lowergamma, acosh,
         chebyshevu, chebyshevt, ln, chebyshevt_root, Binomial, legendre,
         Heaviside, Dij, factorial, bernoulli, coth, tanh, assoc_legendre, sign,
-        arg, asin, DiracDelta, re, rf, abs, uppergamma, binomial, sinh, Ylm,
+        arg, asin, DiracDelta, re, rf, Abs, uppergamma, binomial, sinh, Ylm,
         oo, cos, cot, acos, acot, gamma, bell, hermite, harmonic,
         LambertW, zeta, log, Factorial, pi, asinh, acoth, Zlm,
         cosh, dirichlet_eta, Eijk, loggamma, erf, max_, ceiling, im, fibonacci,
@@ -156,7 +156,7 @@ from sympy.functions import (Piecewise, lowergamma, acosh,
 def test_functions():
     zero_var = (pi, oo, nan, zoo, E, I)
     one_var = (acosh, ln, Heaviside, Dij, factorial, bernoulli, coth, tanh,
-            sign, arg, asin, DiracDelta, re, abs, sinh, cos, cot, acos, acot,
+            sign, arg, asin, DiracDelta, re, Abs, sinh, cos, cot, acos, acot,
             gamma, bell, harmonic, LambertW, zeta, log, Factorial, asinh,
             acoth, cosh, dirichlet_eta, loggamma, erf, ceiling, im, fibonacci,
             conjugate, tan, floor, atanh, sin, atan, lucas, exp)


### PR DESCRIPTION
See the [issue page](http://code.google.com/p/sympy/issues/detail?id=1727).
