### PR TITLE
Issue 2059: Don't wrap indices as Idx

### DIFF
--- a/sympy/tensor/tests/test_index_methods.py
+++ b/sympy/tensor/tests/test_index_methods.py
@@ -21,6 +21,10 @@ def test_get_indices_Indexed():
     assert get_indices(x[i, j]) == (set([i, j]), {})
     assert get_indices(x[j, i]) == (set([j, i]), {})
 
+    m, n = symbols('m n', integer=True)
+    assert get_indices(y[m]*x[m, n]) == (set([m, n]), {})
+    assert get_indices(y[m]*x[m, i]) == (set([m, i]), {})
+
 def test_get_indices_Idx():
     f = Function('f')
     i, j = Idx('i'), Idx('j')
@@ -80,6 +84,10 @@ def test_get_contraction_structure_basic():
     assert get_contraction_structure(x[i]*y[i]) == {(i,): set([x[i]*y[i]])}
     assert get_contraction_structure(1 + x[i]*y[i]) == {None: set([S.One]), (i,): set([x[i]*y[i]])}
     assert get_contraction_structure(x[i]**y[i]) == {None: set([x[i]**y[i]])}
+
+    m, n = symbols('m n', integer=True)
+    assert get_contraction_structure(y[m]*x[m, n]) == {None: set([y[m]*x[m, n]])}
+    assert get_contraction_structure(y[m]*x[m, i]) == {None: set([y[m]*x[m, i]])}
 
 def test_get_contraction_structure_complex():
     x = IndexedBase('x')

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -128,9 +128,9 @@ def test_Indexed_properties():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, j)
     assert A.rank == 2
-    assert A.indices == tuple(map(Idx, (i, j)))
+    assert A.indices == (i, j)
     assert A.base == IndexedBase('A')
-    assert A.ranges == [(None, None), (None, None)]
+    assert A.ranges == [None, None]
     raises(IndexException, 'A.shape')
 
     n, m = symbols('n m', integer=True)
@@ -148,3 +148,9 @@ def test_Indexed_shape_precedence():
     assert Indexed(a, Idx(i, m), Idx(j, n)).shape == Tuple(o, p)
     assert Indexed(a, Idx(i, m), Idx(j)).ranges == [(0, m - 1), (None, None)]
     assert Indexed(a, Idx(i, m), Idx(j)).shape == Tuple(o, p)
+
+def test_complex_indices():
+    i, j = symbols('i j', integer=True)
+    A = Indexed('A', i, i + j)
+    assert A.rank == 2
+    assert A.indices == (i, i + j)


### PR DESCRIPTION
These patches fixes <a href="http://code.google.com/p/sympy/issues/detail?id=2059">Issue 2059</a>.

The fix also opens the door for indexed expressions without implicit summation.  The second patch makes sure that this behavior is available, simply by using another class than Idx for the indices, e.g. Symbol.  I followed the steps that were discussed on the <a href="http://groups.google.com/group/sympy/browse_thread/thread/f6839aa93acf37ca">mailinglist</a>.
