### PR TITLE
2005: y**(2*x).subs(exp(3*x*log(y)), z) -> z**(2/3), not z**(3/2)

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -206,11 +206,11 @@ class Pow(Expr):
         if old.func is self.func and self.base == old.base:
             coeff1, terms1 = self.exp.as_coeff_terms()
             coeff2, terms2 = old.exp.as_coeff_terms()
-            if terms1==terms2: return new ** (coeff1/coeff2) # (x**(2*y)).subs(x**(3*y),z) -> z**(2/3*y)
+            if terms1==terms2: return new ** (coeff1/coeff2) # (x**(2*y)).subs(x**(3*y),z) -> z**(2/3)
         if old.func is C.exp:
-            coeff1,terms1 = old.args[0].as_coeff_terms()
-            coeff2,terms2 = (self.exp * C.log(self.base)).as_coeff_terms()
-            if terms1==terms2: return new ** (coeff1/coeff2) # (x**(2*y)).subs(exp(3*y*log(x)),z) -> z**(2/3*y)
+            coeff1, terms1 = old.args[0].as_coeff_terms()
+            coeff2, terms2 = (self.exp*C.log(self.base)).as_coeff_terms()
+            if terms1==terms2: return new**(coeff2/coeff1) # (x**(2*y)).subs(exp(3*y*log(x)),z) -> z**(2/3)
         return self.base._eval_subs(old, new) ** self.exp._eval_subs(old, new)
 
     def as_powers_dict(self):

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -240,6 +240,8 @@ def test_subs_basic_funcs():
     assert (a*exp(x*y-w*z)+b*exp(x*y+w*z)).subs(z,0) == a*exp(x*y)+b*exp(x*y)
     assert ((a-b)/(c*d-a*b)).subs(c*d-a*b,K) == (a-b)/K
     assert (w*exp(a*b-c)*x*y/4).subs(x*y,L) == w*exp(a*b-c)*L/4
+    assert (x**(2*y)).subs(exp(3*y*log(x)), z) == \
+           (x**(2*y)).subs(x**(3*y), z) == z**Rational(2, 3)
     #assert (a/(b*c)).subs(b*c,K) == a/K,'Failed'; print '.' #FAILS DIVISION
 
 def test_subs_wild():


### PR DESCRIPTION
Small correction of a logical error. By roundtripping the complex substitution you can see the error manifested:

In master:
    h[1] >>> (x**(2_y)).subs(exp(3_y*log(x)), z)
    z**(3/2)
    h[2] >>> _.subs(z, exp(3_y_log(x)))
    exp(9_y_log(x)/2)
    h[3] >>> _.subs({x:3,y:5})
    31381059609_3__(1/2)
    h[4] >>> (x__(2_y))
    x**(2*y)
    h[5] >>> _.subs({x:3,y:5})
    59049
After commit:
    h[3] >>> (x**(2_y)).subs(exp(3_y_log(x)), z)
    z__(2/3)
    h[4] >>> _.subs(z, exp(3_y_log(x)))
    exp(2_y_log(x))
    h[5] >>> _.subs({x:3,y:5})
    59049
    h[6] >>> (x__(2_y))
    x*_(2_y)
    h[7] >>> _.subs({x:3,y:5})
    59049
