### PR TITLE
2027: don't combine negative bases under vanilla x

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -94,10 +94,11 @@ class Mul(AssocOp):
                 # 3
                 if o.is_Pow and b.is_Number:
                     # get all the factors with numeric base so they can be
-                    # combined below
-                    num_exp.append((b,e))
-                    continue
-
+                    # combined below, but don't combine negatives unless
+                    # the exponent is an integer
+                    if b.is_positive or e.is_integer:
+                        num_exp.append((b, e))
+                        continue
 
                 #         n          n          n
                 # (-3 + y)   ->  (-1)  * (3 - y)
@@ -155,6 +156,7 @@ class Mul(AssocOp):
                     else:
                         nc_part.append(o1)
                         nc_part.append(o)
+
         # We do want a combined exponent if it would not be an Add, such as
         #  y    2y     3y
         # x  * x   -> x

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -146,13 +146,13 @@ def test_pow():
     assert (-2)**k == 2**k
     assert (-1)**k == 1
 
-@XFAIL
 def test_pow2():
-    # XXX These fail - they are maybe discutable,
-    # let's see SAGE and similar.
-    assert ((-x)**2)**Rational(1,3) == ((-x)**Rational(1,3))**2
-    assert (-x)**Rational(2,3) == x**Rational(2,3)
-    assert (-x)**Rational(5,7) == -x**Rational(5,7)
+    # x**(2*y) is always (x**y)**2 but is only (x**2)**y if
+    #                                  x.is_positive or y.is_integer
+    # let x = 1 to see why the following are not true.
+    assert ((-x)**2)**Rational(1,3) != ((-x)**Rational(1,3))**2
+    assert (-x)**Rational(2,3) != x**Rational(2,3)
+    assert (-x)**Rational(5,7) != -x**Rational(5,7)
 
 def test_pow_issue417():
     assert 4**Rational(1, 4) == 2**Rational(1, 2)
@@ -1093,3 +1093,8 @@ def test_make_args():
 
     assert Add.make_args((x+y)**z) == ((x+y)**z,)
     assert Mul.make_args((x+y)**z) == ((x+y)**z,)
+
+def test_issue2027():
+    assert (-2)**x*(-3)**x != 6**x
+    i = Symbol('i', integer=1)
+    assert (-2)**i*(-3)**i == 6**i

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -309,8 +309,8 @@ def test_powers_Integer():
     assert (2)  ** (S(-3)/2) == sqrt(2) / 4
     assert (81) ** (S(2)/3)  == 9 * (S(3) ** (S(2)/3))
     assert (-81) ** (S(2)/3)  == 9 * (S(-3) ** (S(2)/3))
-    assert (-3) ** Rational(-7, 3) == -(-3) ** Rational(2, 3) / 27
-    assert (-3) ** Rational(-2, 3) == -(-3) ** Rational(1, 3) / 3
+    assert (-3) ** Rational(-7, 3) == -(-1)**Rational(2, 3)*3**Rational(2, 3)/27
+    assert (-3) ** Rational(-2, 3) == -(-1)**Rational(1, 3)*3**Rational(1, 3)/3
 
     # join roots
     assert sqrt(6) + sqrt(24) == 3*sqrt(6)
@@ -326,8 +326,8 @@ def test_powers_Integer():
     assert (2**64+1) ** Rational(17,25)
 
     # negative rational power and negative base
-    assert (-3) ** Rational(-7, 3) == -(-3) ** Rational(2, 3) / 27
-    assert (-3) ** Rational(-2, 3) == -(-3) ** (S(1) / 3) / 3
+    assert (-3) ** Rational(-7, 3) == -(-1)**Rational(2, 3)*3**Rational(2, 3)/27
+    assert (-3) ** Rational(-2, 3) == -(-1)**Rational(1, 3)*3**Rational(1, 3)/3
 
     assert S(1234).factors() == {617: 1, 2: 1}
     assert Rational(2*3, 3*5*7).factors() == {2: 1, 5: -1, 7: -1}
@@ -370,9 +370,9 @@ def test_powers_Rational():
     assert Rational(1,2)  ** Rational(1,2) == sqrt(2) / 2
     assert Rational(-4,7) ** Rational(1,2) == I * Rational(4,7) ** Rational(1,2)
     assert Rational(-3, 2)**Rational(-7, 3) == \
-           -4 * (-3) ** Rational(2, 3)*2 ** Rational(1, 3)/27
+           -4*(-1)**Rational(2, 3)*2**Rational(1, 3)*3**Rational(2, 3)/27
     assert Rational(-3, 2)**Rational(-2, 3) == \
-           -(-3) ** (S(1) / 3) * 2 ** (S(2) / 3) / 3
+           -(-1)**Rational(1, 3)*2**Rational(2, 3)*3**Rational(1, 3)/3
 
     # negative integer power and negative rational base
     assert Rational(-2, 3) ** Rational(-2, 1) == Rational(9, 4)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -266,7 +266,6 @@ def test_powsimp():
     assert powsimp((z**x*z**y)**x, deep=True) == (z**(x + y))**x
     assert powsimp(x*(z**x*z**y)**x, deep=True) == x*(z**(x + y))**x
 
-
 def test_collect_1():
     """Collect with respect to a Symbol"""
     x, y, z, n = symbols('xyzn')


### PR DESCRIPTION
In a product of bases raised to the same power, `a**x*b**x *…`,
you can only combine bases that are positive if x is not an integer.

Also, `a**(2*x) == (a**x)**2` but not vice versa unless a is positive
or x is an integer. Consider `(-1)**(2*1/2) = (sqrt(-1))**2 = I**2 = -1`
but `sqrt((-1)**2) = sqrt(1) = 1`. For that reason, the debate in test_pow2
was removed. None of those expressions should ever be true if the base is not
known to be positive.
