### PR TITLE
python2.4-doctest: Fix doctests in Python2.4

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -576,7 +576,11 @@ class SymPyDocTestFinder(DocTestFinder):
                             valname = '%s.%s' % (name, rawname)
                             self._find(tests, val, valname, module, source_lines, globs, seen)
                         except ValueError, msg:
-                            raise
+                            if "invalid option" in msg.args[0]:
+                                # +SKIP raises ValueError in Python 2.4
+                                pass
+                            else:
+                                raise
                         except:
                             pass
 


### PR DESCRIPTION
The commit from [pull request 49](https://github.com/sympy/sympy/pull/49) created some doctest failures in Python 2.4:

```
________________________________________________________________________________
 /users/aaronmeurer/documents/python/sympy/sympy/sympy/tensor/index_methods.py _
  File "/Library/Frameworks/Python.framework/Versions/2.4//lib/python2.4/doctest.py", line 850, in find
    self._find(tests, obj, name, module, source_lines, globs, {})
  File "/Users/aaronmeurer/Documents/Python/sympy/sympy/sympy/utilities/runtests.py", line 577, in _find
    self._find(tests, val, valname, module, source_lines, globs, seen)
  File "/Users/aaronmeurer/Documents/Python/sympy/sympy/sympy/utilities/runtests.py", line 558, in _find
    test = self._get_test(obj, name, module, globs, source_lines)
  File "/Users/aaronmeurer/Documents/Python/sympy/sympy/sympy/utilities/runtests.py", line 676, in _get_test
    filename, lineno)
  File "/Library/Frameworks/Python.framework/Versions/2.4//lib/python2.4/doctest.py", line 601, in get_doctest
    return DocTest(self.get_examples(string, name), globs,
  File "/Library/Frameworks/Python.framework/Versions/2.4//lib/python2.4/doctest.py", line 615, in get_examples
    return [x for x in self.parse(string, name)
  File "/Library/Frameworks/Python.framework/Versions/2.4//lib/python2.4/doctest.py", line 576, in parse
    (source, options, want, exc_msg) = \
  File "/Library/Frameworks/Python.framework/Versions/2.4//lib/python2.4/doctest.py", line 658, in _parse_example
    options = self._find_options(source, name, lineno)
  File "/Library/Frameworks/Python.framework/Versions/2.4//lib/python2.4/doctest.py", line 687, in _find_options
    raise ValueError('line %r of the doctest for %s '
ValueError: line 31 of the doctest for sympy.tensor.index_methods.get_indices has an invalid option: '+SKIP'
```

and I didn't notice it before pushing it in because I was running the tests with `setup.py test` and the test failure in Python 2.4 in polyroots was preventing the doctests from running (Oops!).  

So here is a fix.  We need to special case the ValueErrors that are for bad options apparently.  We should probably revert this commit after we drop Python 2.4 support.
