### PR TITLE
Raises prints more informative message

### DIFF
--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -39,7 +39,7 @@ def raises(ExpectedException, code):
 
     """
     if not isinstance(code, str):
-        raise ValueError('raises() expects a code string for the 2nd argument.')
+        raise TypeError('raises() expects a code string for the 2nd argument.')
     frame = sys._getframe(1)
     loc = frame.f_locals.copy()
     try:

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -38,7 +38,8 @@ def raises(ExpectedException, code):
     AssertionError: DID NOT RAISE
 
     """
-    assert isinstance(code, str)
+    if not isinstance(code, str):
+        raise ValueError('raises() expects a code string for the 2nd argument.')
     frame = sys._getframe(1)
     loc = frame.f_locals.copy()
     try:

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -19,4 +19,4 @@ def test_raises():
     except My2, e:
         assert str(e) == "my text123"
 
-    raises(ValueError, 'raises("oops", ValueError)')
+    raises(TypeError, 'raises("oops", ValueError)')

--- a/sympy/utilities/tests/test_pytest.py
+++ b/sympy/utilities/tests/test_pytest.py
@@ -18,3 +18,5 @@ def test_raises():
         assert False
     except My2, e:
         assert str(e) == "my text123"
+
+    raises(ValueError, 'raises("oops", ValueError)')


### PR DESCRIPTION
Instead of this:
    h[1] >>> raises('1/0', ValueError)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "sympy\utilities\pytest.py", line 41, in raises
        assert isinstance(code, str)
    AssertionError

we now get

```
ValueError: raises() expects a code string for the 2nd argument.
```
