### PR TITLE
2130 use limit in limit if necessary, not only subs

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,4 +1,4 @@
-from sympy.core import S, Add, sympify, Expr, PoleError, Mul, oo
+from sympy.core import S, Add, sympify, Expr, PoleError, Mul, oo, C
 from gruntz import gruntz
 
 def limit(e, z, z0, dir="+"):
@@ -59,6 +59,9 @@ def limit(e, z, z0, dir="+"):
         finite = []
         for term in e.args:
             result = term.subs(z, z0)
+            if not result.is_unbounded:
+                # check with more robust limit
+                result = limit(term, z, z0, dir)
             if result.is_unbounded or result is S.NaN:
                 unbounded.append(term)
                 unbounded_result.append(result)
@@ -72,6 +75,10 @@ def limit(e, z, z0, dir="+"):
                 return Add(*finite) + limit(Add(*unbounded), z, z0, dir)
         else:
             return Add(*finite)
+
+    if e.is_Order:
+        args = e.args
+        return C.Order(limit(args[0], z, z0), *args[1:])
 
     try:
         r = gruntz(e, z, z0, dir)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -182,4 +182,8 @@ def test_issue2085():
 
 @XFAIL
 def test_issue2085_unresolved():
-    assert limit(gamma(x), x, 1/2) == sqrt(pi) # Raises AssertionError
+    assert limit(gamma(x), x, Rational(1, 2)) == sqrt(pi) # Raises AssertionError
+
+def test_issue2130():
+    assert limit((1+y)**(1/y) - S.Exp1, y, 0) == 0
+    assert limit(cos(x)/x, x, oo) == 0


### PR DESCRIPTION
see [ http://code.google.com/p/sympy/issues/detail?id=2130 ]

```
>>> limit((1+y)**(1/y), y, 0)
E
>>> limit((1+y)**(1/y) - E, y, 0) # used to be 1 - E
0
```
