### PR TITLE
A simpler fix for Issue 2059: Don't wrap indices as Idx

### DIFF
--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -22,8 +22,8 @@
     properties are implemented in these Base objects, but implicit contraction
     of repeated indices is supported.
 
-    Note that the support for complex (i.e. non-atomic) integer expressions as
-    indices is limited.  (This should be improved in future releases.)
+    Note that the support for complicated (i.e. non-atomic) integer expressions
+    as indices is limited.  (This should be improved in future releases.)
 
     Examples
     ========
@@ -278,7 +278,7 @@ class Indexed(Expr):
     def ranges(self):
         """returns a list of tuples with lower and upper range of each index
 
-        If an index does not define data menbers upper and lower, the
+        If an index does not define the data members upper and lower, the
         corresponding slot in the list contains ``None'' instead of a tuple.
         """
         ranges = []

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -65,14 +65,14 @@
     >>> M[i, j].shape
     Tuple(m, n)
     >>> M[i, j].ranges
-    [(0, -1 + m), (0, -1 + n)]
+    [Tuple(0, -1 + m), Tuple(0, -1 + n)]
 
     The above can be compared with the following:
 
     >>> A[i, 2, j].shape
     Tuple(dim1, 2*dim1, dim2)
     >>> A[i, 2, j].ranges
-    [(0, -1 + m), None, (0, -1 + n)]
+    [Tuple(0, -1 + m), None, Tuple(0, -1 + n)]
 
     To analyze the structure of indexed expressions, you can use the methods
     get_indices() and get_contraction_structure():
@@ -284,7 +284,7 @@ class Indexed(Expr):
         ranges = []
         for i in self.indices:
             try:
-                ranges.append((i.lower, i.upper))
+                ranges.append(Tuple(i.lower, i.upper))
             except AttributeError:
                 ranges.append(None)
         return ranges

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -22,6 +22,9 @@
     properties are implemented in these Base objects, but implicit contraction
     of repeated indices is supported.
 
+    Note that the support for complex (i.e. non-atomic) integer expressions as
+    indices is limited.  (This should be improved in future releases.)
+
     Examples
     ========
 
@@ -64,12 +67,12 @@
     >>> M[i, j].ranges
     [(0, -1 + m), (0, -1 + n)]
 
-    The above is can be contrasted with the following:
+    The above can be compared with the following:
 
     >>> A[i, 2, j].shape
     Tuple(dim1, 2*dim1, dim2)
     >>> A[i, 2, j].ranges
-    [(0, -1 + m), (None, None), (0, -1 + n)]
+    [(0, -1 + m), None, (0, -1 + n)]
 
     To analyze the structure of indexed expressions, you can use the methods
     get_indices() and get_contraction_structure():
@@ -202,12 +205,6 @@ class IndexedBase(Expr):
     def _sympystr(self, p):
         return p.doprint(self.label)
 
-#FIXME only needed for 2.4 compatibility
-def _ensure_Idx(arg):
-    if isinstance(arg, Idx):
-        return arg
-    else:
-        return Idx(arg)
 
 class Indexed(Expr):
     """Represents a mathematical object with indices.
@@ -233,9 +230,6 @@ class Indexed(Expr):
             base = IndexedBase(base)
         elif not isinstance(base, IndexedBase):
             raise TypeError("Indexed expects string, Symbol or IndexedBase as base")
-        # FIXME: 2.4 compatibility
-        args = map(_ensure_Idx, args)
-        # args = tuple([ a if isinstance(a, Idx) else Idx(a) for a in args ])
         return Expr.__new__(cls, base, *args, **kw_args)
 
     @property
@@ -253,20 +247,47 @@ class Indexed(Expr):
 
     @property
     def shape(self):
-        """returns a list with dimensions of each index"""
+        """returns a list with dimensions of each index.
+
+        Dimensions is a property of the array, not of the indices.  Still, if
+        the IndexedBase does not define a shape attribute, it is assumed that
+        the ranges of the indices correspond to the shape of the array.
+
+        >>> from sympy.tensor.indexed import IndexedBase, Idx
+        >>> from sympy import symbols
+        >>> n, m = symbols('n m', integer=True)
+        >>> i = Idx('i', m)
+        >>> j = Idx('j', m)
+        >>> A = IndexedBase('A', shape=(n, n))
+        >>> B = IndexedBase('B')
+        >>> A[i, j].shape
+        Tuple(n, n)
+        >>> B[i, j].shape
+        Tuple(m, m)
+        """
         if self.base.shape:
             return self.base.shape
         try:
             return Tuple(*[i.upper - i.lower + 1 for i in self.indices])
+        except AttributeError:
+            raise IndexException("Range is not defined for all indices in: %s" % self)
         except TypeError:
-            # Let's return a more meaningful error
-            raise IndexException("Shape is not defined for all indices")
+            raise IndexException("Shape cannot be inferred from Idx with undefined range: %s"%self)
 
     @property
     def ranges(self):
         """returns a list of tuples with lower and upper range of each index
+
+        If an index does not define data menbers upper and lower, the
+        corresponding slot in the list contains ``None'' instead of a tuple.
         """
-        return [ (i.lower, i.upper) for i in self.indices ]
+        ranges = []
+        for i in self.indices:
+            try:
+                ranges.append((i.lower, i.upper))
+            except AttributeError:
+                ranges.append(None)
+        return ranges
 
     def _sympystr(self, p):
         indices = map(p.doprint, self.indices)

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -134,7 +134,7 @@ def test_Indexed_properties():
     raises(IndexException, 'A.shape')
 
     n, m = symbols('n m', integer=True)
-    assert Indexed('A', Idx(i, m), Idx(j, n)).ranges == [(0, m - 1), (0, n - 1)]
+    assert Indexed('A', Idx(i, m), Idx(j, n)).ranges == [Tuple(0, m - 1), Tuple(0, n - 1)]
     assert Indexed('A', Idx(i, m), Idx(j, n)).shape == Tuple(m, n)
     raises(IndexException, 'Indexed("A", Idx(i, m), Idx(j)).shape')
 
@@ -144,9 +144,9 @@ def test_Indexed_shape_precedence():
     n, m = symbols('n m', integer=True)
     a = IndexedBase('a', shape=(o, p))
     assert a.shape == Tuple(o, p)
-    assert Indexed(a, Idx(i, m), Idx(j, n)).ranges == [(0, m - 1), (0, n - 1)]
+    assert Indexed(a, Idx(i, m), Idx(j, n)).ranges == [Tuple(0, m - 1), Tuple(0, n - 1)]
     assert Indexed(a, Idx(i, m), Idx(j, n)).shape == Tuple(o, p)
-    assert Indexed(a, Idx(i, m), Idx(j)).ranges == [(0, m - 1), (None, None)]
+    assert Indexed(a, Idx(i, m), Idx(j)).ranges == [Tuple(0, m - 1), Tuple(None, None)]
     assert Indexed(a, Idx(i, m), Idx(j)).shape == Tuple(o, p)
 
 def test_complex_indices():

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -128,9 +128,9 @@ def test_Indexed_properties():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, j)
     assert A.rank == 2
-    assert A.indices == tuple(map(Idx, (i, j)))
+    assert A.indices == (i, j)
     assert A.base == IndexedBase('A')
-    assert A.ranges == [(None, None), (None, None)]
+    assert A.ranges == [None, None]
     raises(IndexException, 'A.shape')
 
     n, m = symbols('n m', integer=True)
@@ -148,3 +148,9 @@ def test_Indexed_shape_precedence():
     assert Indexed(a, Idx(i, m), Idx(j, n)).shape == Tuple(o, p)
     assert Indexed(a, Idx(i, m), Idx(j)).ranges == [(0, m - 1), (None, None)]
     assert Indexed(a, Idx(i, m), Idx(j)).shape == Tuple(o, p)
+
+def test_complex_indices():
+    i, j = symbols('i j', integer=True)
+    A = Indexed('A', i, i + j)
+    assert A.rank == 2
+    assert A.indices == (i, i + j)


### PR DESCRIPTION
This patch fixes Issue 2059, and nothing more.

The practical benefit is that, in order to use Idx objects as indices, they must be constructed explicitly.  Before, an integer symbol would be silently converted to Idx by the Indexed constructor, but this is problematic as discussed in the issue.

It would be great to get this into 7.0 so that people don't start relying on the silent conversion.
