### PR TITLE
Don't use 'is' to test integer equality

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -161,10 +161,10 @@ class Application(Basic):
             return new
         elif old.is_Function and new.is_Function:
             if old == self.func:
-                if self.nargs is new.nargs or not new.nargs:
+                if self.nargs == new.nargs or not new.nargs:
                     return new(*self.args)
                 # Written down as an elif to avoid a super-long line
-                elif isinstance(new.nargs,tuple) and self.nargs in new.nargs:
+                elif isinstance(new.nargs, tuple) and self.nargs in new.nargs:
                     return new(*self.args)
         return Basic._seq_subs(self, old, new)
 

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -396,7 +396,7 @@ def test_convex_hull():
 
     #more than 3 collinear points
     another_p = [Point(-45, -85), Point(-45, 85), Point(-45,26),Point(-45,-24)]
-    ch2 = Segment(another_p[0],another_p[1]);
+    ch2 = Segment(another_p[0],another_p[1])
 
     assert convex_hull(another_p) == ch2
     assert convex_hull(p) == ch

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -36,7 +36,8 @@ def intersection(*entities):
     from entity import GeometryEntity
 
     entities = GeometryEntity.extract_entities(entities, False)
-    if len(entities) <= 1: return []
+    if len(entities) <= 1:
+        return []
 
     res = GeometryEntity.do_intersection(entities[0], entities[1])
     for entity in entities[2:]:
@@ -71,51 +72,39 @@ def convex_hull(*args):
     from polygon import Polygon
 
     def uniquify(a):
-        ret = {}
         # not order preserving
-        map(ret.__setitem__, a, [])
-        return ret.keys()
+        return list(set(a))
 
     p = args[0]
     if isinstance(p, Point):
         p = uniquify(args)
 
-    if len(p) is 1:
+    if len(p) == 1:
         return p[0]
-    else:
-        if len(p) is 2:
-            return Segment(p[0],p[1])
+    elif len(p) == 2:
+        return Segment(p[0], p[1])
 
-
-
-    def orientation(p,q,r):
+    def orientation(p, q, r):
         '''Return positive if p-q-r are clockwise, neg if ccw, zero if colinear.'''
         return (q[1]-p[1])*(r[0]-p[0]) - (q[0]-p[0])*(r[1]-p[1])
-
 
     '''scan to find upper and lower convex hulls of a set of 2d points.'''
     U = []
     L = []
-    #print "[graham] points:",Points
     p.sort()
     for p_i in p:
-        while len(U) > 1 and orientation(U[-2],U[-1],p_i) <= 0: U.pop()
-        while len(L) > 1 and orientation(L[-2],L[-1],p_i) >= 0: L.pop()
+        while len(U) > 1 and orientation(U[-2], U[-1], p_i) <= 0:
+            U.pop()
+        while len(L) > 1 and orientation(L[-2], L[-1], p_i) >= 0:
+            L.pop()
         U.append(p_i)
-        L.append(p_i)        #print "[graham] result:", U,L
+        L.append(p_i)
     U.reverse()
-    convexHull = tuple(L+U[1:-1])
+    convexHull = tuple(L + U[1:-1])
 
-    #convexHull = uniquify(convexHull)
-    #print "U:",U.reverse()
-    #print "L:",L
-    #print "ch(",len(convexHull),"):",convexHull
-    if len(convexHull) is 2:
-        return Segment(convexHull[0],convexHull[1])
+    if len(convexHull) == 2:
+        return Segment(convexHull[0], convexHull[1])
     return Polygon(convexHull)
-
-
-
 
 
 def are_similar(e1, e2):
@@ -127,7 +116,8 @@ def are_similar(e1, e2):
     ======
         - If the two objects are equal then they are always similar.
     """
-    if e1 == e2: return True
+    if e1 == e2:
+        return True
     try:
         return e1.is_similar(e2)
     except AttributeError:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -499,7 +499,7 @@ class SymPyTests(object):
             # Sorting of XFAILed functions isn't fixed yet :-(
             funcs.sort(key=lambda x: inspect.getsourcelines(x)[1])
             i = 0
-            while i is not len(funcs):
+            while i < len(funcs):
                 if isgeneratorfunction(funcs[i]):
                 # some tests can be generators, that return the actual
                 # test functions. We unpack it below:


### PR DESCRIPTION
These simple fixes allow PyPy to run the test suite. A lot more work will be required to make it pass, but at least it's a start.
