### PR TITLE
Allow to specify speed of light for relativistic Hydrogen energies

### DIFF
--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -104,7 +104,7 @@ def E_nl(n, Z=1):
         raise ValueError("'n' must be positive integer")
     return -Z**2/(2*n**2)
 
-def E_nl_dirac(n, l, spin_up=True, Z=1):
+def E_nl_dirac(n, l, spin_up=True, Z=1, c=Real("137.035999037")):
     """
     Returns the relativistic energy of the state (n, l, spin) in Hartree atomic
     units.
@@ -115,6 +115,8 @@ def E_nl_dirac(n, l, spin_up=True, Z=1):
     n, l ...... quantum numbers 'n' and 'l'
     spin_up ... True if the electron spin is up (default), otherwise down
     Z    ...... atomic number (1 for Hydrogen, 2 for Helium, ...)
+    c    ...... speed of light in atomic units. Default value is 137.035999037,
+                taken from: http://arxiv.org/abs/1012.3627
 
     Examples::
 
@@ -153,6 +155,6 @@ def E_nl_dirac(n, l, spin_up=True, Z=1):
         skappa = -l - 1
     else:
         skappa = -l
-    c = Real("137.03599911")
+    c = S(c)
     beta = sqrt(skappa**2 - Z**2/c**2)
     return c**2/sqrt(1+Z**2/(n + skappa + beta)**2/c**2) - c**2

--- a/sympy/physics/tests/test_hydrogen.py
+++ b/sympy/physics/tests/test_hydrogen.py
@@ -65,6 +65,24 @@ def test_hydrogen_energies():
     raises(ValueError, "E_nl(0)")
 
 def test_hydrogen_energies_relat():
+    # First test exact formulas for small "c" so that we get nice expressions:
+    assert E_nl_dirac(2, 0, Z=1, c=1) == 1/sqrt(2) - 1
+    assert simplify(E_nl_dirac(2, 0, Z=1, c=2) - ( (8*sqrt(3) + 16) \
+                / sqrt(16*sqrt(3) + 32) - 4)) == 0
+    assert simplify(E_nl_dirac(2, 0, Z=1, c=3) - ( (54*sqrt(2) + 81) \
+                / sqrt(108*sqrt(2) + 162) - 9)) == 0
+
+    # Now test for almost the correct speed of light, without floating point
+    # numbers:
+    assert simplify(E_nl_dirac(2, 0, Z=1, c=137) - ( (352275361 + 10285412 * \
+                sqrt(1173)) / sqrt(704550722 + 20570824 * sqrt(1173)) - \
+                18769)) == 0
+    assert simplify(E_nl_dirac(2, 0, Z=82, c=137) - ( (352275361 + \
+            2571353*sqrt(12045)) / sqrt(704550722 + 5142706*sqrt(12045)) \
+            - 18769)) == 0
+
+    # Test using exact speed of light, and compare against the nonrelativistic
+    # energies:
     for n in range(1, 5):
         for l in range(n):
             assert feq(E_nl_dirac(n, l), E_nl(n), 1e-5, 1e-5)
@@ -85,6 +103,8 @@ def test_hydrogen_energies_relat():
             if l > 0:
                 assert feq(E_nl_dirac(n, l, False, Z), E_nl(n, Z), 1e-3, 1e-3)
 
+
+    # Test the exceptions:
     raises(ValueError, "E_nl_dirac(0, 0)")
     raises(ValueError, "E_nl_dirac(1, -1)")
     raises(ValueError, "E_nl_dirac(1, 0, False)")


### PR DESCRIPTION
This makes it possible to set the constant to the exact value used in some electronic structure code, so that exact numbers can be compared. As a side effect, by setting it to integers, exact expressions can be tested to make sure the relativistic formula is implemented correctly.
