### PR TITLE
Exppower

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -134,17 +134,16 @@ class Mul(AssocOp):
                     b2,e2 = o.as_base_exp()
                     new_exp = e1 + e2
                     # Only allow powers to combine if the new exponent is
-                    # not an Add or if e1 and e2 are commutative.
-                    if b1==b2 and\
-                        ((e1.is_commutative and e2.is_commutative) or\
-                         (not new_exp.is_Add)):
+                    # not an Add. This allow things like a**2*b**3 == a**5
+                    # if a.is_commutative == False, but prohibits
+                    # a**x*a**y and x**a*x**b from combining (x,y commute).
+                    if b1==b2 and (not new_exp.is_Add):
                         o12 = b1 ** new_exp
 
                         # now o12 could be a commutative object
                         if o12.is_commutative:
                             seq.append(o12)
                             continue
-
                         else:
                             nc_seq.insert(0, o12)
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -132,8 +132,13 @@ class Mul(AssocOp):
                     o1 = nc_part.pop()
                     b1,e1 = o1.as_base_exp()
                     b2,e2 = o.as_base_exp()
-                    if b1==b2 and e1.is_commutative and e2.is_commutative:
-                        o12 = b1 ** (e1 + e2)
+                    new_exp = e1 + e2
+                    # Only allow powers to combine if the new exponent is
+                    # not an Add or if e1 and e2 are commutative.
+                    if b1==b2 and\
+                        ((e1.is_commutative and e2.is_commutative) or\
+                         (not new_exp.is_Add)):
+                        o12 = b1 ** new_exp
 
                         # now o12 could be a commutative object
                         if o12.is_commutative:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -132,7 +132,7 @@ class Mul(AssocOp):
                     o1 = nc_part.pop()
                     b1,e1 = o1.as_base_exp()
                     b2,e2 = o.as_base_exp()
-                    if b1==b2:
+                    if b1==b2 and e1.is_commutative and e2.is_commutative:
                         o12 = b1 ** (e1 + e2)
 
                         # now o12 could be a commutative object

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -249,7 +249,7 @@ class Pow(Expr):
         else:
             b = self.base
             e = self.exp
-        if e.is_Add:
+        if e.is_Add and e.is_commutative:
             expr = 1
             for x in e.args:
                 if deep:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -217,8 +217,8 @@ def test_power_expand():
 
     A = Symbol('A', commutative=False)
     B = Symbol('B', commutative=False)
-    p = 2**(A+B)
-    assert p.expand() == 2**(A+B)
+    assert (2**(A+B)).expand() == 2**(A+B)
+    assert (A**(a+b)).expand() != A**(a+b)
 
 def test_real_mul():
     Real(0) * pi * x == Real(0)
@@ -256,6 +256,8 @@ def test_ncmul():
 def test_ncpow():
     x = Symbol('x', commutative=False)
     y = Symbol('y', commutative=False)
+    a = Symbol('a')
+    b = Symbol('b')
 
     assert (x**2)*(y**2) != (y**2)*(x**2)
     assert (x**-2)*y != y*(x**2)
@@ -263,6 +265,9 @@ def test_ncpow():
     assert 2**x*2**(2*x) == 2**(3*x)
     assert exp(x)*exp(y) != exp(y)*exp(x)
     assert exp(x)*exp(y) != exp(x+y)
+    assert x**a*x**b != x**(a+b)
+    assert x**3*x**4 == x**7
+    assert x**a*x**(4*a) == x**(5*a)
 
 def test_powerbug():
     x=Symbol("x")

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -260,6 +260,7 @@ def test_ncpow():
     assert (x**2)*(y**2) != (y**2)*(x**2)
     assert (x**-2)*y != y*(x**2)
     assert 2**x*2**y != 2**(x+y)
+    assert 2**x*2**(2*x) == 2**(3*x)
     assert exp(x)*exp(y) != exp(y)*exp(x)
     assert exp(x)*exp(y) != exp(x+y)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -256,18 +256,26 @@ def test_ncmul():
 def test_ncpow():
     x = Symbol('x', commutative=False)
     y = Symbol('y', commutative=False)
+    z = Symbol('z', commutative=False)
     a = Symbol('a')
     b = Symbol('b')
+    c = Symbol('c')
 
     assert (x**2)*(y**2) != (y**2)*(x**2)
     assert (x**-2)*y != y*(x**2)
     assert 2**x*2**y != 2**(x+y)
+    assert 2**x*2**y*2**z != 2**(x+y+z)
     assert 2**x*2**(2*x) == 2**(3*x)
+    assert 2**x*2**(2*x)*2**x == 2**(4*x)
     assert exp(x)*exp(y) != exp(y)*exp(x)
-    assert exp(x)*exp(y) != exp(x+y)
+    assert exp(x)*exp(y)*exp(z) != exp(y)*exp(x)*exp(z)
+    assert exp(x)*exp(y)*exp(z) != exp(x+y+z)
     assert x**a*x**b != x**(a+b)
+    assert x**a*x**b*x**c != x**(a+b+c)
     assert x**3*x**4 == x**7
+    assert x**3*x**4*x**2 == x**9
     assert x**a*x**(4*a) == x**(5*a)
+    assert x**a*x**(4*a)*x**a == x**(6*a)
 
 def test_powerbug():
     x=Symbol("x")

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -212,6 +212,14 @@ def test_power_expand():
     p = (1+2*(1+a))**2
     assert p.expand() == 9 + 4*(a**2) + 12*a
 
+    p = 2**(a+b)
+    assert p.expand() == 2**a*2**b
+
+    A = Symbol('A', commutative=False)
+    B = Symbol('B', commutative=False)
+    p = 2**(A+B)
+    assert p.expand() == 2**(A+B)
+
 def test_real_mul():
     Real(0) * pi * x == Real(0)
     Real(1) * pi * x == pi * x
@@ -251,6 +259,9 @@ def test_ncpow():
 
     assert (x**2)*(y**2) != (y**2)*(x**2)
     assert (x**-2)*y != y*(x**2)
+    assert 2**x*2**y != 2**(x+y)
+    assert exp(x)*exp(y) != exp(y)*exp(x)
+    assert exp(x)*exp(y) != exp(x+y)
 
 def test_powerbug():
     x=Symbol("x")

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -232,7 +232,7 @@ class exp(Function):
             arg = self.args[0].expand(deep=deep, **hints)
         else:
             arg = self.args[0]
-        if arg.is_Add:
+        if arg.is_Add and arg.is_commutative:
             expr = 1
             for x in arg.args:
                 if deep:

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -171,3 +171,9 @@ def test_infinity():
     assert exp(I*oo) == nan
     assert exp(y*I*oo) == nan
 
+def test_exp_expand():
+    A,B = symbols('AB', commutative=False)
+    x,y = symbols('xy')
+
+    assert exp(A+B).expand() == exp(A+B)
+    assert exp(x+y).expand() == exp(x)*exp(y)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -172,8 +172,10 @@ def test_infinity():
     assert exp(y*I*oo) == nan
 
 def test_exp_expand():
-    A,B = symbols('AB', commutative=False)
-    x,y = symbols('xy')
+    A,B,C = symbols('ABC', commutative=False)
+    x,y,z = symbols('xyz')
 
     assert exp(A+B).expand() == exp(A+B)
+    assert exp(A+B+C).expand() == exp(A+B+C)
     assert exp(x+y).expand() == exp(x)*exp(y)
+    assert exp(x+y+z).expand() == exp(x)*exp(y)*exp(z)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1391,7 +1391,8 @@ def powsimp(expr, deep=False, combine='all'):
                 if term.is_Add and deep:
                     newexpr *= powsimp(term, deep, combine)
                 else:
-                    if term.is_commutative:
+                    if (term.is_commutative or
+                        term.is_Pow and term.exp.is_commutative):
                         b, e = term.as_base_exp()
                         if deep:
                             b, e = powsimp(b, deep, combine), powsimp(e, deep, combine)
@@ -1425,7 +1426,8 @@ def powsimp(expr, deep=False, combine='all'):
                 c_powers = []
                 nc_part = []
                 for term in expr.args:
-                    if term.is_commutative:
+                    if (term.is_commutative or
+                        term.is_Pow and term.exp.is_commutative):
                         c_powers.append(list(term.as_base_exp()))
                     else:
                         nc_part.append(term)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1399,16 +1399,15 @@ def powsimp(expr, deep=False, combine='all'):
                     else:
                         # This is the logic that combines exponents for equal,
                         # but non-commutative bases: A**x*A**y == A**(x+y).
-                        if len(nc_part) > 0:
-                            last = nc_part.pop()
-                            b1, e1 = last.as_base_exp()
+                        if nc_part:
+                            b1, e1 = nc_part[-1].as_base_exp()
                             b2, e2 = term.as_base_exp()
-                            if b1 == b2 and e1.is_commutative and e2.is_commutative:
-                                nc_part.append(b1**(e1+e2))
-                            else:
-                                nc_part.extend([last, term])
-                        else:
-                            nc_part.append(term)
+                            if (b1 == b2 and
+                                e1.is_commutative and e2.is_commutative):
+                                nc_part[-1] = Pow(b1, Add(e1,e2))
+                                continue
+                        nc_part.append(term)
+
             newexpr = Mul(newexpr, Mul(*[Pow(b,e) for b, e in c_powers.items()]))
             if combine is 'exp':
                 return Mul(newexpr, Mul(*nc_part))
@@ -1442,17 +1441,13 @@ def powsimp(expr, deep=False, combine='all'):
                         # This is the logic that combines bases that are
                         # different and non-commutative, but with equal and
                         # commutative exponents: A**x*B**x == (A*B)**x.
-                        if len(nc_part) > 0:
-                            last = nc_part.pop()
-                            b1, e1 = last.as_base_exp()
+                        if nc_part:
+                            b1, e1 = nc_part[-1].as_base_exp()
                             b2, e2 = term.as_base_exp()
-                            if e1 == e1 and b1 != b2 and\
-                                e1.is_commutative and e2.is_commutative:
-                                nc_part.append((b1*b2)**e1)
-                            else:
-                                nc_part.extend([last, term])
-                        else:
-                            nc_part.append(term)
+                            if (e1 == e2 and e2.is_commutative):
+                                nc_part[-1] = Pow(Mul(b1, b2), e1)
+                                continue
+                        nc_part.append(term)
 
             # Pull out numerical coefficients from exponent
             # e.g., 2**(2*x) => 4**x

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -265,9 +265,20 @@ def test_powsimp():
     assert powsimp(x*y**(z**x*z**y), deep=True) == x*y**(z**(x + y))
     assert powsimp((z**x*z**y)**x, deep=True) == (z**(x + y))**x
     assert powsimp(x*(z**x*z**y)**x, deep=True) == x*(z**(x + y))**x
-    n, m = symbols('n m', commutative=False)
-    assert powsimp(n**x*n**y) == n**(x+y)
-    assert powsimp(n**x*m**x) == (n*m)**x
+
+def test_powsimp_nc():
+    x, y = symbols('xy')
+    A, B = symbols('A B', commutative=False)
+    assert powsimp(A**x*A**y, combine='all') == A**(x+y)
+    assert powsimp(A**x*A**y, combine='base') == A**x*A**y
+    assert powsimp(A**x*A**y, combine='exp') == A**(x+y)
+    assert powsimp(A**x*B**x, combine='all') == (A*B)**x
+    assert powsimp(A**x*B**x, combine='base') == (A*B)**x
+    assert powsimp(A**x*B**x, combine='exp') == A**x*B**x
+    assert powsimp(B**x*A**x, combine='all') == (B*A)**x
+    assert powsimp(B**x*A**x, combine='base') == (B*A)**x
+    assert powsimp(B**x*A**x, combine='exp') == B**x*A**x
+
 
 def test_collect_1():
     """Collect with respect to a Symbol"""

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -265,6 +265,9 @@ def test_powsimp():
     assert powsimp(x*y**(z**x*z**y), deep=True) == x*y**(z**(x + y))
     assert powsimp((z**x*z**y)**x, deep=True) == (z**(x + y))**x
     assert powsimp(x*(z**x*z**y)**x, deep=True) == x*(z**(x + y))**x
+    n, m = symbols('n m', commutative=False)
+    assert powsimp(n**x*n**y) == n**(x+y)
+    assert powsimp(n**x*m**x) == (n*m)**x
 
 def test_collect_1():
     """Collect with respect to a Symbol"""

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -267,18 +267,32 @@ def test_powsimp():
     assert powsimp(x*(z**x*z**y)**x, deep=True) == x*(z**(x + y))**x
 
 def test_powsimp_nc():
-    x, y = symbols('xy')
-    A, B = symbols('A B', commutative=False)
+    x, y, z = symbols('xyz')
+    A, B, C = symbols('A B C', commutative=False)
+
     assert powsimp(A**x*A**y, combine='all') == A**(x+y)
     assert powsimp(A**x*A**y, combine='base') == A**x*A**y
     assert powsimp(A**x*A**y, combine='exp') == A**(x+y)
+
     assert powsimp(A**x*B**x, combine='all') == (A*B)**x
     assert powsimp(A**x*B**x, combine='base') == (A*B)**x
     assert powsimp(A**x*B**x, combine='exp') == A**x*B**x
+
     assert powsimp(B**x*A**x, combine='all') == (B*A)**x
     assert powsimp(B**x*A**x, combine='base') == (B*A)**x
     assert powsimp(B**x*A**x, combine='exp') == B**x*A**x
 
+    assert powsimp(A**x*A**y*A**z, combine='all') == A**(x+y+z)
+    assert powsimp(A**x*A**y*A**z, combine='base') == A**x*A**y*A**z
+    assert powsimp(A**x*A**y*A**z, combine='exp') == A**(x+y+z)
+
+    assert powsimp(A**x*B**x*C**x, combine='all') == (A*B*C)**x
+    assert powsimp(A**x*B**x*C**x, combine='base') == (A*B*C)**x
+    assert powsimp(A**x*B**x*C**x, combine='exp') == A**x*B**x*C**x
+
+    assert powsimp(B**x*A**x*C**x, combine='all') == (B*A*C)**x
+    assert powsimp(B**x*A**x*C**x, combine='base') == (B*A*C)**x
+    assert powsimp(B**x*A**x*C**x, combine='exp') == B**x*A**x*C**x
 
 def test_collect_1():
     """Collect with respect to a Symbol"""


### PR DESCRIPTION
This branch fixes non-commutative exponentiation rules in sympy.  Previously:

exp(A)*exp(B) == exp(A+B) for non commutative A and B in sympy.  Now:

exp(A)*exp(B) != exp(A+B).  Tests have been added.
