### PR TITLE
Importfix

### DIFF
--- a/sympy/physics/quantum/matrixcache.py
+++ b/sympy/physics/quantum/matrixcache.py
@@ -32,16 +32,17 @@ class MatrixCache(object):
         """
         try:
             self._sympy_matrix(name, m)
-        except:
-            raise
+        except ImportError:
+            pass
         try:
             self._numpy_matrix(name, m)
-        except:
-            raise
+        except ImportError:
+            pass
         try:
             self._scipy_sparse_matrix(name, m)
-        except:
-            raise
+        except ImportError:
+            pass
+
 
     def get_matrix(self, name, format):
         """Get a cached matrix by name and format.


### PR DESCRIPTION
This fixes a silly bug that was causing the test suite to fail if scipy or numpy as not installed.  There were a few spots in matrixcache that were not protecting against ImportErrors.  These are not fixed.
