### PR TITLE
2199 Rawargs should watch for []

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -70,11 +70,13 @@ class AssocOp(Expr):
            x*y
 
         """
-        if len(args) == 1:
-            obj = args[0]
-        else:
+        if len(args) > 1:
             obj = Expr.__new__(type(self), *args)  # NB no assumptions for Add/Mul
             obj.is_commutative = self.is_commutative
+        elif len(args) == 1:
+            obj = args[0]
+        else:
+            obj = self.identity
 
         return obj
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -769,10 +769,14 @@ def test_as_powers_dict():
 
 def test_new_rawargs():
     x = Symbol('x')
-    assert 2*x == Mul._new_rawargs(3*x, *[S(2), x])
-    assert 2 + x == Add._new_rawargs(3 + x, *[S(2), x])
-    assert x == Mul._new_rawargs(3*x, *[x])
-    assert x == Add._new_rawargs(3 + x, *[x])
+    m = 3*x
+    a = 3 + x
+    assert 2*x == m._new_rawargs(*[S(2), x])
+    assert 2 + x == a._new_rawargs(*[S(2), x])
+    assert x == m._new_rawargs(*[x])
+    assert x == a._new_rawargs(*[x])
+    assert 1 == m._new_rawargs(*[])
+    assert 0 == a._new_rawargs(*[])
 
 def test_2127():
     assert Add(evaluate=False) == 0


### PR DESCRIPTION
```
new_rawargs should watch for [] args

    The most anticipated case (len(args) > 1) is now put first
    in _new_rawargs. In addition, the case of no args is now
    handled. Tests were added.
```
