### PR TITLE
A more gentle deprecation of Symbol('x', dummy=True)

### DIFF
--- a/doc/src/guide.txt
+++ b/doc/src/guide.txt
@@ -187,13 +187,13 @@ so we chose to have ``exp(x)==exp(x)`` even for different instances of ``x``.
 
 Sometimes, you need to have a unique symbol, for example as a temporary one in
 some calculation, which is going to be substituted for something else at the
-end anyway. This is achieved using ``Symbol("x", dummy=True)``. So, to sum it
+end anyway. This is achieved using ``Dummy("x")``. So, to sum it
 up::
 
     In [1]: Symbol("x") == Symbol("x")
     Out[1]: True
 
-    In [2]: Symbol("x", dummy=True) == Symbol("x", dummy=True)
+    In [2]: Dummy("x") == Dummy("x")
     Out[2]: False
 
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -44,8 +44,13 @@ class Symbol(AtomicExpr, Boolean):
 
         if 'dummy' in assumptions:
             import warnings
-            warnings.warn("\nuse Dummy() or symbols() to create dummy symbols.",
-                          DeprecationWarning)
+            warnings.warn(
+                    "\nThe syntax Symbol('x', dummy=True) is deprecated and will"
+                    "\nbe dropped in a future version of Sympy. Please use Dummy()"
+                    "\nor symbols(..., cls=Dummy) to create dummy symbols.",
+                    DeprecationWarning)
+            if assumptions.pop('dummy'):
+                return Dummy(name, commutative, **assumptions)
         return Symbol.__xnew_cached_(cls, name, commutative, **assumptions)
 
     def __new_stage2__(cls, name, commutative=True, **assumptions):


### PR DESCRIPTION
Until yesterday the recommended way to use the Dummy class was with Symbol('x', dummy=True).  While I agree that the new syntax is better, we should take a more cautious approach in removing the old syntax.  According to git blame, it has been described in the user guide since 2008 and Dummy was not even in the sympy namespace before yesterday.  I don't think I am the only one with broken scripts today.

These patches replace the removal with a deprecation warning, and also update the user guide.
