### PR TITLE
Dummy via cls=Dummy

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -212,15 +212,10 @@ def symbols(*names, **kwargs):
     True
 
     """
+    func = Symbol
     # when polys12 is in place remove from here...
-    if 'cls' in kwargs:
-        if isinstance(names[0], str) and len(names) == 1:
-         names = names[0]
-        kwargs.pop('cls')
-        rv = []
-        for c in names.replace(',', ' ').split():
-            rv.append(Dummy(c, **kwargs))
-        return rv
+    if 'cls' in kwargs and kwargs.pop('cls') is Dummy:
+        func = Dummy
     # ... to here when polys12 is in place
     # use new behavior if space or comma in string
     if not 'each_char' in kwargs and len(names) == 1 and \
@@ -236,7 +231,7 @@ def symbols(*names, **kwargs):
             # skip empty strings
             if not t:
                 continue
-            sym = Symbol(t, **kwargs)
+            sym = func(t, **kwargs)
             res.append(sym)
         res = tuple(res)
         if len(res) == 0:   # var('')
@@ -248,9 +243,9 @@ def symbols(*names, **kwargs):
     else:
         # this is the old, deprecated behavior:
         if len(names) == 1:
-            result = [ Symbol(name, **kwargs) for name in names[0] ]
+            result = [ func(name, **kwargs) for name in names[0] ]
         else:
-            result = [ Symbol(name, **kwargs) for name in names ]
+            result = [ func(name, **kwargs) for name in names ]
         if len(result) == 1:
             return result[0]
         else:

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -18,6 +18,11 @@ def test_Symbol():
 
     assert Symbol("x") == Symbol("x")
     assert Dummy("x") != Dummy("x")
+    d = symbols('d', cls=Dummy)
+    assert isinstance(d, Dummy)
+    c,d = symbols('c,d', cls=Dummy)
+    assert isinstance(c, Dummy)
+    assert isinstance(d, Dummy)
     raises(TypeError, 'Symbol()')
 
 def test_Dummy():

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -383,14 +383,22 @@ def numbered_symbols(prefix='x', function=None, start=0, *args, **assumptions):
     """
 
     if function is None:
-        if 'dummy' in assumptions and assumptions.pop('dummy'):
+        # XXX should this backdoor creation of dummies with this assumption be allowed?
+        # XXX no other class has this privilege
+        dummy_a = 'dummy' in assumptions
+        if assumptions.pop('dummy', False):
+            dummy_a = True
             function = C.Dummy
         else:
             function = C.Symbol
 
     #remove from here...when polys12 is in place
-    if 'cls' in assumptions and assumptions['cls'] == C.Dummy:
-        assumptions.pop('cls')
+    # cls=Dummy is the only pre-polys12 function being honored
+    if assumptions.pop('cls', None) is C.Dummy:
+        if dummy_a:
+            import warnings
+            warnings.warn('Use either cls=Dummy or dummy=True', SyntaxWarning)
+        function = C.Dummy
     #to here...when polys12 is in place
     while True:
         name = '%s%s' % (prefix, start)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -124,3 +124,8 @@ def test_cartes():
            [[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5]]
     assert list(cartes()) == [[]]
 
+def test_numbered_symbols():
+    s = numbered_symbols(dummy=True)
+    assert isinstance(s.next(), Dummy)
+    s = numbered_symbols(cls=Dummy)
+    assert isinstance(s.next(), Dummy)


### PR DESCRIPTION
The current instantiation of dummies using the workaround fix for anticipated polys12 behavior doesn't work properly:

```
h[1] >>> x=symbols('x', cls=Dummy)
h[1] >>> type(x)
<type 'list'>
h[2] >>> x
[_x]
```

This commit fixes this and tests are added. Should we also allow other classes beside Dummy so, for example, `f = symbols('f', cls=Function)` would work or just wait until polys12 for that?

```
h[1] >>> x=symbols('x', cls=Dummy)
h[1] >>> type(x)
<class 'sympy.core.symbol.Dummy'>
```
