### PR TITLE
Integral commutivity is now set

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -6,7 +6,7 @@ from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.deltafunctions import deltaintegrate
 from sympy.integrals.rationaltools import ratint
 from sympy.integrals.risch import heurisch
-from sympy.utilities import threaded, flatten, any
+from sympy.utilities import threaded, flatten, any, all
 from sympy.polys import Poly
 from sympy.solvers import solve
 from sympy.functions import Piecewise, sign
@@ -16,6 +16,8 @@ from sympy.series import limit
 
 class Integral(Expr):
     """Represents unevaluated integral."""
+
+    __slots__ = ['is_commutative']
 
     def __new__(cls, function, *symbols, **assumptions):
         # Any embedded piecewise functions need to be brought out to the
@@ -69,6 +71,7 @@ class Integral(Expr):
         arglist = [function]
         arglist.extend(limits)
         obj._args = tuple(arglist)
+        obj.is_commutative = all(s.is_commutative for s in obj.free_symbols)
 
         return obj
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -60,6 +60,11 @@ def test_basics():
     # sum integral of terms
     assert integrate(y + x + exp(x), x) == x*y + x**2/2 + exp(x)
 
+    assert Integral(x).is_commutative
+    n = Symbol('n', commutative=False)
+    assert Integral(x, (x, n)).is_commutative is False
+    assert Integral(n + x, x).is_commutative is False
+
 def test_basics_multiple():
 
     assert diff_test(Integral(x, (x, 3*x, 5*y), (y, x, 2*x))) == set([x])

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1011,7 +1011,7 @@ def test_nth_linear_constant_coeff_variation_of_parameters():
     sol8 = Eq(f(x), C1*exp(x) + (S(5)/36 + x/6)*exp(-x) + C2*exp(2*x))
     sol9 = Eq(f(x), (C1 + C2*x + C3*x**2 + x**3/6)*exp(x))
     sol10 = Eq(f(x), (C1 - x*(C2 - log(x)))*exp(-x))
-    sol11 = Eq(f(x), cos(x)*(C1 - Integral(1/cos(x), x)) + sin(x)*(C2 + \
+    sol11 = Eq(f(x), cos(x)*(C2 - Integral(1/cos(x), x)) + sin(x)*(C1 + \
         Integral(1/sin(x), x)))
     sol12 = Eq(f(x), C1 + C2*x - x**3*(C3 - log(x)/6) + C4*x**2)
     sol1s = constant_renumber(sol1, 'C', 1, 3)


### PR DESCRIPTION
The commutivity of integrals is None right now. This will cause a problem with polys12 later and would be ok to fix now. This commit sets the commutivity based on the commutivity of the free_symbols of the Integral.
