### PR TITLE
Qfix - fix quantum pretty tests

### DIFF
--- a/sympy/physics/quantum/tests/test_innerproduct.py
+++ b/sympy/physics/quantum/tests/test_innerproduct.py
@@ -73,5 +73,5 @@ def test_doit():
 def test_printing():
     psi = Ket('psi')
     ip = Dagger(psi)*psi
-    assert pretty(ip) == u'\u27e8\u03c8\u2758\u03c8\u27e9'
+    assert pretty(ip, use_unicode=True) == u'\u27e8\u03c8\u2758\u03c8\u27e9'
     assert latex(ip) == r"\left\langle \psi \right. {\left|\psi\right\rangle }"

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -129,7 +129,7 @@ def test_bra_ket_dagger():
 
 def test_printing():
     psi = Ket('psi')
-    assert pretty(psi) == u'\u2758\u03c8\u27e9'
-    assert pretty(Dagger(psi)) == u'\u27e8\u03c8\u2758'
+    assert pretty(psi, use_unicode=True) == u'\u2758\u03c8\u27e9'
+    assert pretty(Dagger(psi), use_unicode=True) == u'\u27e8\u03c8\u2758'
     assert latex(psi) == r"{\left|\psi\right\rangle }"
     assert latex(Dagger(psi)) == r"{\left\langle \psi\right|}"


### PR DESCRIPTION
When unicode is not being used, tests with an unqualified pretty test may fail. The two failing tests now pass with the changes of this commit.
