### PR TITLE
Free symbols failed for (-Integral(x, (x, 1, y))

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -500,7 +500,8 @@ class Basic(AssumeMeths):
 
         Any other method that uses bound variables should implement a symbols
         method."""
-        return self.atoms(C.Symbol)
+        union = set.union
+        return reduce(union, [arg.free_symbols for arg in self.args], set())
 
     def is_hypergeometric(self, k):
         from sympy.simplify import hypersimp

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -91,6 +91,10 @@ class Symbol(AtomicExpr, Boolean):
     def is_number(self):
         return False
 
+    @property
+    def free_symbols(self):
+        return set([self])
+
 class Dummy(Symbol):
     """Dummy symbols are each unique, identified by an internal count index ::
 

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -62,6 +62,9 @@ def test_subs():
 def test_atoms():
     assert b21.atoms() == set()
 
+def test_free_symbols_empty():
+    assert b21.free_symbols == set()
+
 def test_doit():
     assert b21.doit() == b21
     assert b21.doit(deep=False) == b21

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -823,8 +823,10 @@ def test_2127():
 
 def test_symbols():
     # symbols should return the free symbols of an object
+    assert S(1).free_symbols == set()
     assert (x).free_symbols == set([x])
     assert Integral(x, (x, 1, y)).free_symbols == set([y])
+    assert (-Integral(x, (x, 1, y))).free_symbols == set([y])
 
 def test_issue2201():
     x = Symbol('x', commutative=False)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -24,6 +24,11 @@ class ExprCondPair(Function):
     def cond(self):
         return self.args[1]
 
+    @property
+    def free_symbols(self):
+        # Overload Basic.free_symbols because self.args[1] may contain non-Basic
+        return self.expr.free_symbols
+
     def __iter__(self):
         yield self.expr
         yield self.cond

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -27,7 +27,10 @@ class ExprCondPair(Function):
     @property
     def free_symbols(self):
         # Overload Basic.free_symbols because self.args[1] may contain non-Basic
-        return self.expr.free_symbols
+        result = self.expr.free_symbols
+        if hasattr(self.cond, 'free_symbols'):
+            result |= self.cond.free_symbols
+        return result
 
     def __iter__(self):
         yield self.expr

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -71,6 +71,11 @@ def test_piecewise():
     p = Piecewise((x, x < -10),(x**2, x <= -1),(x, 1 < x))
     raises(ValueError, "integrate(p,(x,-2,2))")
 
+def test_piecewise_free_symbols():
+    a = symbols('a')
+    f = Piecewise((x , a<0), (y, True))
+    assert f.free_symbols == set([x,y,a])
+
 def test_piecewise_integrate():
     # XXX Use '<=' here! '>=' is not yet implemented ..
     f = Piecewise(((x - 2)**2, 0 <= x), (1, True))


### PR DESCRIPTION
This small patch fixes the issue.
