### PR TITLE
1462: NumberSymbol lacks __int__ method

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1622,6 +1622,9 @@ class NumberSymbol(AtomicExpr):
     def __ge__(self, other):
         return (-self) <= (-other)
 
+    def __int__(self):
+        return int(self.evalf(0))
+
     def __hash__(self):
         return super(NumberSymbol, self).__hash__()
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -401,6 +401,9 @@ def test_int():
     a = Rational(9, 10)
     assert int(a) == int(-a) == 0
     assert 1/(-1)**Rational(2, 3) == -(-1)**Rational(1, 3)
+    assert int(pi) == 3
+    assert int(E) == 2
+    assert int(GoldenRatio) == 1
 
 def test_real_bug():
     x = Symbol("x")


### PR DESCRIPTION
I have added **int** to NumberSymbol and used evalf(0) to avoid calculating decimal places.
