### PR TITLE
Default deriv action

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -165,9 +165,6 @@ class Expr(Basic, EvalfMixin):
     def _eval_power(self, other):
         return None
 
-    def _eval_derivative(self, s):
-        return
-
     def _eval_conjugate(self):
         if self.is_real:
             return self
@@ -744,7 +741,7 @@ class Expr(Basic, EvalfMixin):
         all the terms at once when n != None.
 
         Note: when n != None, if an O() term is returned then the x in the
-        in it and the entire expression reprsents x - x0, the displacement
+        in it and the entire expression represents x - x0, the displacement
         from x0. (If there is no O() term then the series was exact and x has
         it's normal meaning.) This is currently necessary since sympy's O()
         can only represent terms at x0=0. So instead of
@@ -1112,11 +1109,9 @@ class Expr(Basic, EvalfMixin):
     ###################################################################################
 
     def diff(self, *symbols, **assumptions):
-        new_symbols = map(sympify, symbols)
-        if not "evaluate" in assumptions:
-            assumptions["evaluate"] = True
-        ret = Derivative(self, *new_symbols, **assumptions)
-        return ret
+        new_symbols = map(sympify, symbols) # e.g. x, 2, y, z
+        assumptions.setdefault("evaluate", True)
+        return Derivative(self, *new_symbols, **assumptions)
 
     def fdiff(self, *indices):
         # FIXME FApply -> ?
@@ -1271,7 +1266,8 @@ class AtomicExpr(Atom, Expr):
     __slots__ = []
 
     def _eval_derivative(self, s):
-        if self==s: return S.One
+        if self == s:
+            return S.One
         return S.Zero
 
     def as_numer_denom(self):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -39,7 +39,7 @@ from itertools import repeat
 #from numbers import Rational, Integer
 #from symbol import Symbol, Dummy
 from sympy.utilities.decorator import deprecated
-from sympy.utilities import all
+from sympy.utilities import all, any
 
 from sympy import mpmath
 
@@ -494,63 +494,67 @@ class Derivative(Expr):
 
     is_Derivative   = True
 
-    @staticmethod
-    def _symbolgen(*symbols):
-        """
-        Generator of all symbols in the argument of the Derivative.
-
-        Example:
-        >> ._symbolgen(x, 3, y)
-        (x, x, x, y)
-        >> ._symbolgen(x, 10**6)
-        (x, x, x, x, x, x, x, ...)
-
-        The second example shows why we don't return a list, but a generator,
-        so that the code that calls _symbolgen can return earlier for special
-        cases, like x.diff(x, 10**6).
-
-        """
-        last_s = sympify(symbols[len(symbols)-1])
-        for i in xrange(len(symbols)):
-            s = sympify(symbols[i])
-            next_s = None
-            if s != last_s:
-                next_s = sympify(symbols[i+1])
-
-            if isinstance(s, Integer):
-                continue
-            elif isinstance(s, C.Symbol):
-                # handle cases like (x, 3)
-                if isinstance(next_s, Integer):
-                    # yield (x, x, x)
-                    for copy_s in repeat(s,int(next_s)):
-                        yield copy_s
-                else:
-                    yield s
-            else:
-                yield s
-
     def __new__(cls, expr, *symbols, **assumptions):
         expr = sympify(expr)
         if not symbols:
             return expr
-        symbols = Derivative._symbolgen(*symbols)
+
+        # standardize symbols
+        symbols = list(sympify(symbols))
+        if not symbols[-1].is_Integer:
+            symbols.append(S.One)
+        symbol_count = []
+        allZero = True
+        i = 0
+        while i < len(symbols) - 1: # process up to final Integer
+            s, count = symbols[i: i+2]
+            iwas = i
+            if s.is_Symbol:
+                if count.is_Symbol:
+                    count = 1
+                    i += 1
+                elif count.is_Integer:
+                    count = int(count)
+                    i += 2
+
+            if i == iwas: # didn't get an update because of bad input
+                raise ValueError('Derivative expects Symbol [, Integer] args but got %s, %s' % (s, count))
+
+            symbol_count.append((s, count))
+            if allZero and not count == 0:
+                allZero = False
+
+        # We make a special case for 0th derivative, because there
+        # is no good way to unambiguously print this.
+        if allZero:
+            return expr
+
+        evaluate = assumptions.pop('evaluate', False)
+
+        # look for a quick exit if there are symbols that are not in the free symbols
+        if evaluate:
+            if set([sc[0] for sc in symbol_count]
+                  ).difference(expr.free_symbols):
+                return S.Zero
+
+        # We make a generator so as to only generate a symbol when necessary.
+        # If a high order of derivative is requested and the expr becomes 0
+        # after a few differentiations, then we won't need the other symbols
+        symbolgen = (s for s, count in symbol_count for i in xrange(count))
+
         if expr.is_commutative:
             assumptions['commutative'] = True
-        evaluate = assumptions.pop('evaluate', False)
-        if not evaluate and not isinstance(expr, Derivative):
-            symbols = list(symbols)
-            if len(symbols) == 0:
-                # We make a special case for 0th derivative, because there
-                # is no good way to unambiguously print this.
-                return expr
+
+        if (not (hasattr(expr, '_eval_derivative') and
+                 evaluate) and
+            not isinstance(expr, Derivative)):
+            symbols = list(symbolgen)
             obj = Expr.__new__(cls, expr, *symbols, **assumptions)
             return obj
+
+        # compute the derivative now
         unevaluated_symbols = []
-        for s in symbols:
-            s = sympify(s)
-            if not isinstance(s, C.Symbol):
-                raise ValueError('Invalid literal: %s is not a valid variable' % s)
+        for s in symbolgen:
             obj = expr._eval_derivative(s)
             if obj is None:
                 unevaluated_symbols.append(s)
@@ -561,6 +565,7 @@ class Derivative(Expr):
 
         if not unevaluated_symbols:
             return expr
+
         return Expr.__new__(cls, expr, *unevaluated_symbols, **assumptions)
 
     def _eval_derivative(self, s):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -427,7 +427,13 @@ multi-arg functions are not supported.')
                 nargs = self.nargs
             if not (1<=argindex<=nargs):
                 raise TypeError("argument index %r is out of range [1,%s]" % (argindex,nargs))
-        return Derivative(self,self.args[argindex-1],evaluate=False)
+        u = self.args[argindex - 1]
+        if u.is_Symbol:
+            uself = self
+        else:
+            u = C.Dummy('u')
+            uself = self.func(u)
+        return Derivative(uself, u, evaluate=False)
 
     def _eval_as_leading_term(self, x):
         """General method for the leading term"""
@@ -483,7 +489,10 @@ class Derivative(Expr):
     Carries out differentiation of the given expression with respect to symbols.
 
     expr must define ._eval_derivative(symbol) method that returns
-    the differentiation result or None.
+    the differentiation result. This function need only consider the
+    non-trivial case where expr contains symbol and it should call the diff()
+    method interally (not _eval_derivative); Derivative should be the only
+    one to call _eval_derivative.
 
     Examples:
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -155,9 +155,6 @@ class Number(AtomicExpr):
     def __float__(self):
         return mlib.to_float(self._as_mpf_val(53))
 
-    def _eval_derivative(self, s):
-        return S.Zero
-
     def _eval_conjugate(self):
         return self
 
@@ -1555,9 +1552,6 @@ class NumberSymbol(AtomicExpr):
     def _eval_evalf(self, prec):
         return Real._new(self._as_mpf_val(prec), prec)
 
-    def _eval_derivative(self, s):
-        return S.Zero
-
     def __eq__(self, other):
         try:
             other = _sympify(other)
@@ -1778,9 +1772,6 @@ class ImaginaryUnit(AtomicExpr):
 
     def _eval_conjugate(self):
         return -S.ImaginaryUnit
-
-    def _eval_derivative(self, s):
-        return S.Zero
 
     def _eval_power(b, e):
         """

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -1,6 +1,16 @@
-from sympy import Symbol, Rational, cos, sin, tan, cot, exp, log, Function
+from sympy import Symbol, Rational, cos, sin, tan, cot, exp, log, Function, \
+                  Derivative, Expr, symbols, pi, I, S
+from sympy.utilities.pytest import raises
 
 def test_diff():
+    x = Symbol('x')
+    assert Rational(1, 3).diff(x) is S.Zero
+    assert I.diff(x) is S.Zero
+    assert pi.diff(x) is S.Zero
+    assert x.diff(x, 0) == x
+    assert (x**2).diff(x, 2, x) == 0
+    raises(ValueError, 'x.diff(1, x)')
+
     a = Symbol("a")
     b = Symbol("b")
     c = Symbol("c")
@@ -57,6 +67,17 @@ def test_diff3():
     e = (Rational(2)**a/log(Rational(2)))
     assert e == 2**a*log(Rational(2))**(-1)
     assert e.diff(a) == 2**a
+
+def test_diff_no_eval_derivative():
+    class My(Expr):
+        def __new__(cls, x):
+            return Expr.__new__(cls, x)
+
+    x, y = symbols('x y')
+    # My doesn't have its own _eval_derivative method
+    My(x).diff(x).func is Derivative
+    # it doesn't have y so it shouldn't need a method for this case
+    My(x).diff(y) == 0
 
 def test_speed():
     # this should return in 0.0s. If it takes forever, it's wrong.

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -181,21 +181,22 @@ def test_deriv1():
     f=Function('f')
     g=Function('g')
     x = Symbol('x')
-    assert f(g(x)).diff(x) == Derivative(f(g(x)), g(x)) * Derivative(g(x), x)
+    # this is a place where the polys12 Pure() symbol could be used rather than unique dummies
+    assert str(f(g(x)).diff(x)) == 'D(f(_u), _u)*D(g(x), x)'
 
 def test_deriv2():
     f = Function('f')
     x = Symbol('x')
 
     assert f(x).diff(x) == Derivative(f(x), x)
-    assert f(2*x).diff(x) == 2*Derivative(f(2*x), 2*x)
+    assert str(f(2*x).diff(x)) == '2*D(f(_u), _u)'
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
-    assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Derivative(f(2*x), 2*x)
+    assert str((f(2*x)**3).diff(x)) == '6*f(2*x)**2*D(f(_u), _u)'
 
-    assert f(2+x).diff(x) == Derivative(f(2+x), 2+x)
-    assert f(2+3*x).diff(x) == 3*Derivative(f(2+3*x), 2+3*x)
-    assert f(sin(x)).diff(x) == Derivative(f(sin(x)), sin(x)) * cos(x)
-    assert f(3*sin(x)).diff(x) == 3*Derivative(f(3*sin(x)), 3*sin(x)) * cos(x)
+    assert str(f(2+x).diff(x)) == 'D(f(_u), _u)'
+    assert str(f(2+3*x).diff(x)) == '3*D(f(_u), _u)'
+    assert str(f(sin(x)).diff(x)) == 'D(f(_u), _u)*cos(x)'
+    assert str(f(3*sin(x)).diff(x)) == '3*D(f(_u), _u)*cos(x)'
 
 def test_deriv3():
     x = Symbol('x')

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -78,8 +78,6 @@ class re(Function):
         return self.args[0].as_real_imag()[0]
 
     def _eval_derivative(self, x):
-        if not self.has(x):
-            return S.Zero
         return re(Derivative(self.args[0], x, **{'evaluate': True}))
 
 class im(Function):
@@ -150,8 +148,6 @@ class im(Function):
         return self.args[0].as_real_imag()[1]
 
     def _eval_derivative(self, x):
-        if not self.has(x):
-            return S.Zero
         return im(Derivative(self.args[0], x, **{'evaluate': True}))
 
 ###############################################################################
@@ -291,8 +287,6 @@ class Abs(Function):
         return sage.abs_symbolic(self.args[0]._sage_())
 
     def _eval_derivative(self, x):
-        if not self.has(x):
-            return S.Zero
         if self.args[0].is_real:
             return Derivative(self.args[0], x, **{'evaluate': True}) * sign(self.args[0])
         return (re(self.args[0]) * re(Derivative(self.args[0], x,
@@ -319,8 +313,6 @@ class arg(Function):
 
     def _eval_derivative(self, t):
         x, y = re(self.args[0]), im(self.args[0])
-        if not self.has(t):
-            return S.Zero
         return (x * Derivative(y, t, **{'evaluate': True}) - y *
                 Derivative(x, t, **{'evaluate': True})) / (x**2 + y**2)
 
@@ -346,8 +338,6 @@ class conjugate(Function):
         return self.args[0]
 
     def _eval_derivative(self, x):
-        if not self.has(x):
-            return S.Zero
         return conjugate(Derivative(self.args[0], x, **{'evaluate': True}))
 
 # /cyclic/

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -358,13 +358,9 @@ class Integral(Expr):
             flatten(*self.limits))
 
     def _eval_derivative(self, sym):
-        """Evaluate the derivative of the current Integral object.
-        We follow these steps:
-
-        (1) If sym will not be present in the evaluated integral return 0.
-
-        (2) Differentiate under the integral sign [1], using the
-            Fundamental Theorem of Calculus [2] when possible.
+        """Evaluate the derivative of the current Integral object by
+        differentiating under the integral sign [1], using the Fundamental
+        Theorem of Calculus [2] when possible.
 
         Whenever an Integral is encountered that is equivalent to zero or
         has an integrand that is independent of the variable of integration
@@ -392,9 +388,6 @@ class Integral(Expr):
         -1/6 - x/2 + 2*x**3/3
 
         """
-
-        if sym not in self.free_symbols:
-            return S.Zero
 
         # differentiate under the integral sign; we do not
         # check for regularity conditions (TODO), see issue 1116


### PR DESCRIPTION
If a symbol does not appear in the free symbols of an expression doesn't have a variable of differentiation, the derivative should evaluate to 0; this shouldn't require an `_eval_derivative` method to do this, it should just be part of the default behavior. Redundant _eval_derivative methods were removed and tests were added.

A typo in order.py was corrected.
