### PR TITLE
Fixed SMatrix transpose

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2038,6 +2038,72 @@ class SMatrix(Matrix):
                     c.append(0)
         return Matrix(l)
 
+    def row_list(self):
+        """
+        Returns a Row-sorted list of non-zero elements of the matrix.
+
+        >>> from sympy.matrices import SMatrix
+        >>> a=SMatrix((1,2),(3,4))
+        >>> a
+        [1, 2]
+        [3, 4]
+        >>> a.RL
+        [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
+        """
+
+        new=[]
+        for i in range(self.rows):
+            for j in range(self.cols):
+                value = self[(i, j)]
+                if value!=0:
+                    new.append((i, j, value))
+        return new
+
+    RL = property(row_list, None, None, "Row-sorted list of non-zero elements of the matrix")
+
+    def col_list(self):
+        """
+        Returns a Column-sorted list of non-zero elements of the matrix.
+        >>> from sympy.matrices import SMatrix
+        >>> a=SMatrix((1,2),(3,4))
+        >>> a
+        [1, 2]
+        [3, 4]
+        >>> a.CL
+        [(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
+        """
+        new=[]
+        for j in range(self.cols):
+            for i in range(self.rows):
+                value = self[(i, j)]
+                if value!=0:
+                    new.append((i, j, value))
+        return new
+
+    CL = property(col_list, None, None, "Column-sorted list of non-zero elements of the matrix")
+
+    def transpose(self):
+        """
+        Returns the transposed SMatrix of this SMatrix
+        >>> from sympy.matrices import SMatrix
+        >>> a = SMatrix((1,2),(3,4))
+        >>> a
+        [1, 2]
+        [3, 4]
+        >>> a.T
+        [1, 3]
+        [2, 4]
+        """
+        tran = SMatrix(self.cols, self.rows, {})
+        for key, value in self.mat.iteritems():
+            tran.mat[key[1], key[0]] = value
+        return tran
+
+    T = property(transpose, None, None, "SMatrix transposition.")
+
+
+
+
     # from here to end all functions are same as in matrices.py
     # with Matrix replaced with SMatrix
     def copyin_list(self, key, value):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,4 +1,4 @@
-from sympy import (symbols, Matrix, eye, I, Symbol, Rational, wronskian, cos,
+from sympy import (symbols, Matrix, SMatrix, eye, I, Symbol, Rational, wronskian, cos,
     sin, exp, hessian, sqrt, zeros, ones, randMatrix, Poly, S, pi,
     oo, trigsimp, Integer, block_diag, N)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
@@ -1202,3 +1202,13 @@ def test_creation_args():
     assert eye(3.) == eye(3)
     assert ones((3L, Integer(4))) == ones((3, 4))
     raises(TypeError, 'Matrix(1, 2)')
+
+
+def test_SMatrix_transpose():
+    assert SMatrix((1,2),(3,4)).transpose() == SMatrix((1,3),(2,4))
+def test_SMatrix_CL_RL():
+    assert SMatrix((1,2),(3,4)).row_list() == [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
+    assert SMatrix((1,2),(3,4)).col_list() == [(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
+
+
+


### PR DESCRIPTION
Added functions transpose,fastR,fastC, and their respective property variables.
fastR is an alternate representation of SparseMatrices, which is essentially a list of non-zero elements sorted by Row. Similarly for fastC.
The order for transpose is O(L) where L is the number of non-zero elements, as opposed to the naive representations's O(n**2)
Thanks
