### PR TITLE
Patch for issue 2212.

### DIFF
--- a/doc/src/modules/matrices.txt
+++ b/doc/src/modules/matrices.txt
@@ -17,10 +17,23 @@ import and declare our first Matrix object:
     [1  0]
     [    ]
     [0  1]
+    >>> Matrix((
+    ...   Matrix((
+    ...     (1, 0, 0),
+    ...     (0, 0, 0)
+    ...   )),
+    ...   (0, 0, -1)
+    ... ))
+    [1  0  0 ]
+    [        ]
+    [0  0  0 ]
+    [        ]
+    [0  0  -1]
 
 This is the standard manner one creates a matrix, i.e. with a list of
-appropriately-sizes lists. SymPy also supports more advanced methods of matrix
-creation including a single list of values and dimension inputs:
+appropriately-sizes lists and/or matrices. SymPy also supports more advanced
+methods of matrix creation including a single list of values and dimension
+inputs:
 
     >>> Matrix(2, 3, [1, 2, 3, 4, 5, 6])
     [1  2  3]

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -126,8 +126,14 @@ class Matrix(object):
                     return
                 else:
                     raise NotImplementedError("Sympy supports just 1D and 2D matrices")
-            elif not isinstance(mat, (list, tuple)):
+            elif not isinstance(mat, (list, tuple, Matrix)):
                 raise TypeError("Matrix constructor doesn't accept %s as input" % str(type(mat)))
+            mat = []
+            for row in args[0]:
+                if isinstance(row, Matrix):
+                    mat.extend(row.tolist())
+                else:
+                    mat.append(row)
             self.rows = len(mat)
             if len(mat) != 0:
                 if not isinstance(mat[0], (list, tuple)):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -96,6 +96,17 @@ def test_creation():
 
     assert Matrix(b) == b
 
+    c = Matrix((
+          Matrix((
+            (1, 2, 3),
+            (4, 5, 6)
+          )),
+          (7, 8, 9)
+    ))
+    assert c.cols == 3
+    assert c.rows == 3
+    assert c[:] == [1,2,3,4,5,6,7,8,9]
+
 def test_tolist():
     x, y, z = symbols('xyz')
     lst = [[S.One,S.Half,x*y,S.Zero],[x,y,z,x**2],[y,-S.One,z*x,3]]


### PR DESCRIPTION
This patch is supposed to fix issue 2212 by accepting Matrix objects in the constructor of sympy.matrices.Matrix.
