### PR TITLE
Fix Rotation.d function

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -349,6 +349,7 @@ class Rotation(UnitaryOperator):
         # The Jacobi Polynomial expansion is probably best as it is a simple
         # sum. But, this version does give correct answers and uses
         # Eq. 7 in Section 4.3.2 of Varshalovich.
+        j=sympify(j)
         cosbeta = Symbol('cosbeta')
         x = 1-cosbeta
         y = 1+cosbeta

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -349,7 +349,7 @@ class Rotation(UnitaryOperator):
         # The Jacobi Polynomial expansion is probably best as it is a simple
         # sum. But, this version does give correct answers and uses
         # Eq. 7 in Section 4.3.2 of Varshalovich.
-        j=sympify(j)
+        j = sympify(j)
         cosbeta = Symbol('cosbeta')
         x = 1-cosbeta
         y = 1+cosbeta

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -14,3 +14,6 @@ def test_jplus():
     assert apply_operators(Jplus*JzKet(1,1)) == 0
     assert Jplus.matrix_element(1,1,1,1) == 0
     assert Jplus.rewrite('xyz') == Jx + I*Jy
+
+def test_rotation():
+    assert Rotation.d(1,1,1,0) == 1


### PR DESCRIPTION
Fixes a bug in Rotation class which would cause an AttributeErrors to be thrown if the arguments to the d function were ints, eg Rotation.d(1,1,1,0)
