### PR TITLE
Bug fix for evaluating J2 on a Jz ket

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -266,7 +266,7 @@ class J2Op(SpinOpBase, HermitianOperator):
 
     def _apply_operator_JzKet(self, ket, **options):
         j = ket.j
-        return hbar**2**j*(j+1)*ket
+        return hbar**2*j*(j+1)*ket
 
     def matrix_element(self, j, m, jp, mp):
         result = (hbar**2)*j*(j+1)

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -266,7 +266,7 @@ class J2Op(SpinOpBase, HermitianOperator):
 
     def _apply_operator_JzKet(self, ket, **options):
         j = ket.j
-        return hbar**2**j(j+1)*ket
+        return hbar**2**j*(j+1)*ket
 
     def matrix_element(self, j, m, jp, mp):
         result = (hbar**2)*j*(j+1)

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -1,4 +1,4 @@
-from sympy import I, Matrix
+from sympy import I, Matrix, symbols
 
 from sympy.physics.quantum import hbar, represent, Commutator
 from sympy.physics.quantum import qapply
@@ -16,6 +16,8 @@ def test_jplus():
     assert Jplus.rewrite('xyz') == Jx + I*Jy
 
 def test_j2():
+    j, m = symbols('j m')
     assert Commutator(J2, Jz).doit() == 0
     assert qapply(J2*JzKet(1,1)) == 2*hbar**2*JzKet(1,1)
+    assert qapply(J2*JzKet(j,m)) == j**2*hbar**2*JzKet(j,m)+j*hbar**2*JzKet(j,m)
     assert J2.matrix_element(1,1,1,1) == 2*hbar**2

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -14,3 +14,8 @@ def test_jplus():
     assert qapply(Jplus*JzKet(1,1)) == 0
     assert Jplus.matrix_element(1,1,1,1) == 0
     assert Jplus.rewrite('xyz') == Jx + I*Jy
+
+def test_j2():
+    assert Commutator(J2, Jz).doit() == 0
+    assert qapply(J2*JzKet(1,1)) == 2*hbar**2*JzKet(1,1)
+    assert J2.matrix_element(1,1,1,1) == 2*hbar**2


### PR DESCRIPTION
Evaluating J2 applied to a Jz eigenket, e.g. qapply(J2*JzKet(1,1)), would return a TypeError. This fixes the error and adds some tests for the J2 operator. The second test is the one applicable to this error.
