### PR TITLE
2220 matrix fixes

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1202,22 +1202,22 @@ class Matrix(object):
         return self.rows == self.cols
 
     def is_upper(self):
-        for i in range(self.cols):
-            for j in range(self.rows):
+        for i in range(self.rows):
+            for j in range(self.cols):
                 if i > j and self[i,j] != 0:
                     return False
         return True
 
     def is_lower(self):
-        for i in range(self.cols):
-            for j in range(self.rows):
+        for i in range(self.rows):
+            for j in range(self.cols):
                 if i < j and self[i, j] != 0:
                     return False
         return True
 
     def is_symbolic(self):
-        for i in range(self.cols):
-            for j in range(self.rows):
+        for i in range(self.rows):
+            for j in range(self.cols):
                 if self[i,j].has(Symbol):
                     return True
         return False

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1023,6 +1023,26 @@ def test_is_symbolic():
     assert a.is_symbolic() == False
     a = Matrix([[1,x],[3,4]])
     assert a.is_symbolic() == True
+    a = Matrix([[1,x,3]])
+    assert a.is_symbolic() == True
+    a = Matrix([[1,2,3]])
+    assert a.is_symbolic() == False
+    a = Matrix([[1],[x],[3]])
+    assert a.is_symbolic() == True
+    a = Matrix([[1],[2],[3]])
+    assert a.is_symbolic() == False
+
+def test_is_upper():
+    a = Matrix([[1,2,3]])
+    assert a.is_upper() == True
+    a = Matrix([[1],[2],[3]])
+    assert a.is_upper() == False
+
+def test_is_lower():
+    a = Matrix([[1,2,3]])
+    assert a.is_lower() == False
+    a = Matrix([[1],[2],[3]])
+    assert a.is_lower() == True
 
 def test_zeros_ones_fill():
     n, m = 3, 5
@@ -1220,6 +1240,3 @@ def test_SMatrix_transpose():
 def test_SMatrix_CL_RL():
     assert SMatrix((1,2),(3,4)).row_list() == [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
     assert SMatrix((1,2),(3,4)).col_list() ==[(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
-
-
-


### PR DESCRIPTION
The indexing of the matrices is [row,col], but the functions were iterating over [col,row]. Simply swapping these fixes this, and tests are implemented to validate that this works.
http://code.google.com/p/sympy/issues/detail?id=2220
