### PR TITLE
2186- Make X, Y, and Z gates Hermitian (also added tests)

### DIFF
--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -24,7 +24,7 @@ from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.qexpr import QuantumError
 from sympy.physics.quantum.hilbert import ComplexSpace
-from sympy.physics.quantum.operator import UnitaryOperator, Operator
+from sympy.physics.quantum.operator import UnitaryOperator, Operator, HermitianOperator
 from sympy.physics.quantum.matrixutils import (
     matrix_tensor_product, matrix_eye
 )
@@ -608,7 +608,7 @@ class HadamardGate(OneQubitGate):
         return sqrt(2)*IdentityGate(self.targets[0])
 
 
-class XGate(OneQubitGate):
+class XGate(OneQubitGate, HermitianOperator):
     """The single qubit X, or NOT, gate.
 
     Parameters
@@ -645,7 +645,7 @@ class XGate(OneQubitGate):
 
 
 
-class YGate(OneQubitGate):
+class YGate(OneQubitGate, HermitianOperator):
     """The single qubit Y gate.
 
     Parameters
@@ -673,7 +673,7 @@ class YGate(OneQubitGate):
         return Integer(0)
 
 
-class ZGate(OneQubitGate):
+class ZGate(OneQubitGate, HermitianOperator):
     """The single qubit Z gate.
 
     Parameters

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -608,7 +608,7 @@ class HadamardGate(OneQubitGate):
         return sqrt(2)*IdentityGate(self.targets[0])
 
 
-class XGate(OneQubitGate, HermitianOperator):
+class XGate(HermitianOperator, OneQubitGate):
     """The single qubit X, or NOT, gate.
 
     Parameters
@@ -645,7 +645,7 @@ class XGate(OneQubitGate, HermitianOperator):
 
 
 
-class YGate(OneQubitGate, HermitianOperator):
+class YGate(HermitianOperator, OneQubitGate):
     """The single qubit Y gate.
 
     Parameters
@@ -673,7 +673,7 @@ class YGate(OneQubitGate, HermitianOperator):
         return Integer(0)
 
 
-class ZGate(OneQubitGate, HermitianOperator):
+class ZGate(HermitianOperator, OneQubitGate):
     """The single qubit Z gate.
 
     Parameters

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -194,6 +194,22 @@ class HermitianOperator(Operator):
     def _eval_dagger(self):
         return self
 
+    def _eval_inverse(self):
+        if isinstance(self, UnitaryOperator):
+            return self
+        else:
+            return Operator._eval_inverse(self)
+
+    def _eval_power(self, exp):
+        if isinstance(self, UnitaryOperator):
+            if exp == -1:
+                return Operator._eval_power(self, exp)
+            elif abs(exp) % 2 == 0:
+                return self*(Operator._eval_inverse(self))
+            else:
+                return self
+        else:
+            return Operator._eval_power(self, exp)
 
 class UnitaryOperator(Operator):
     """A unitary operator that satisfies U*Dagger(U) == 1.

--- a/sympy/physics/quantum/tests/test_gate.py
+++ b/sympy/physics/quantum/tests/test_gate.py
@@ -212,7 +212,6 @@ def test_swap_gate():
             assert represent(SwapGate(i,j), nqubits=nqubits) ==\
                 represent(SwapGate(i,j).decompose(), nqubits=nqubits)
 
-
 def test_one_qubit_commutators():
     """Test single qubit gate commutation relations."""
     for g1 in (IdentityGate, X, Y, Z, H, T, S):
@@ -275,3 +274,21 @@ def test_hermitian_ZGate():
     z_dagger = Dagger(z)
 
     assert (z == z_dagger)
+
+def test_unitary_XGate():
+    x = XGate(1, 2)
+    x_dagger = Dagger(x)
+
+    assert (x*x_dagger == 1)
+
+def test_unitary_YGate():
+    y = YGate(1, 2)
+    y_dagger = Dagger(y)
+
+    assert (y*y_dagger == 1)
+
+def test_unitary_ZGate():
+    z = ZGate(1, 2)
+    z_dagger = Dagger(z)
+
+    assert (z*z_dagger == 1)

--- a/sympy/physics/quantum/tests/test_gate.py
+++ b/sympy/physics/quantum/tests/test_gate.py
@@ -9,7 +9,7 @@ from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import Qubit, IntQubit, qubit_to_matrix,\
      matrix_to_qubit
 from sympy.physics.quantum.matrixutils import matrix_to_zero
-
+from sympy.physics.quantum import Dagger
 
 def test_gate():
     """Test a basic gate."""
@@ -258,3 +258,20 @@ def test_random_circuit():
     assert m.shape == (8,8)
     assert isinstance(m, Matrix)
 
+def test_hermitian_XGate():
+    x = XGate(1, 2)
+    x_dagger = Dagger(x)
+
+    assert (x == x_dagger)
+
+def test_hermitian_YGate():
+    y = YGate(1, 2)
+    y_dagger = Dagger(y)
+
+    assert (y == y_dagger)
+
+def test_hermitian_ZGate():
+    z = ZGate(1, 2)
+    z_dagger = Dagger(z)
+
+    assert (z == z_dagger)


### PR DESCRIPTION
XGate, YGate, and ZGate now inherit from both HermitianOperator and OneQubitGate. Also added tests in test_gate.py to ensure that this isn't broken in the future. 

http://code.google.com/p/sympy/issues/detail?id=2186&q=label%3Aquantum&colspec=ID%20Type%20Status%20Priority%20Milestone%20Owner%20Summary%20Stars
