### PR TITLE
2061 as_coeff_* defines coefficient as leading Rational

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -173,10 +173,17 @@ class Add(AssocOp):
                 else:
                     l1.append(f)
             return self._new_rawargs(*l1), tuple(l2)
-        coeff = self.args[0]
-        if coeff.is_Number:
-            return coeff, self.args[1:]
+        coeff, notrat = self.args[0].as_coeff_add()
+        if not coeff is S.Zero:
+            return coeff, notrat + self.args[1:]
         return S.Zero, self.args
+
+    @cacheit
+    def as_coeff_mul(self, *deps):
+        # -2 + 2 * a -> -1, 2-2*a
+        if self.args[0].is_Rational and self.args[0].is_negative:
+            return S.NegativeOne, (-self,)
+        return Expr.as_coeff_mul(self, *deps)
 
     def _eval_derivative(self, s):
         return Add(*[f.diff(s) for f in self.args])
@@ -307,12 +314,6 @@ class Add(AssocOp):
             return True
         if c.is_nonnegative and r.is_nonnegative:
             return False
-
-    def as_coeff_mul(self, *deps):
-        # -2 + 2 * a -> -1, 2-2*a
-        if self.args[0].is_Number and self.args[0].is_negative:
-            return S.NegativeOne, (-self,)
-        return Expr.as_coeff_mul(self, *deps)
 
     def _eval_subs(self, old, new):
         if self == old:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -426,7 +426,7 @@ class Expr(Basic, EvalfMixin):
     def as_coeff_mul(self, *deps):
         """Return the tuple (c, args) where self is written as a Mul, `m`.
 
-        c should contain Numbers and any terms of the Mul that are
+        c should be a Rational multiplied by any terms of the Mul that are
         independent of deps.
 
         args should be a tuple of all other terms of m; args is empty
@@ -461,7 +461,7 @@ class Expr(Basic, EvalfMixin):
     def as_coeff_add(self, *deps):
         """Return the tuple (c, args) where self is written as an Add, `a`.
 
-        c should contain Numbers and any terms of the Mul that are
+        c should be a Rational added to any terms of the Add that are
         independent of deps.
 
         args should be a tuple of all other terms of `a`; args is empty

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -422,9 +422,9 @@ class Mul(AssocOp):
                 else:
                     l1.append(f)
             return self._new_rawargs(*l1), tuple(l2)
-        coeff = self.args[0]
-        if coeff.is_Number:
-            return coeff, self.args[1:]
+        coeff, notrat = self.args[0].as_coeff_mul()
+        if not coeff is S.One:
+            return coeff, notrat + self.args[1:]
         return S.One, self.args
 
     @staticmethod

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -184,11 +184,17 @@ class Number(AtomicExpr):
 
     def as_coeff_mul(self, *deps):
         # a -> c * t
-        return self, tuple()
+        if self.is_Rational:
+            return self, tuple()
+        elif self.is_negative:
+            return S.NegativeOne, (-self,)
+        return S.One, (self,)
 
     def as_coeff_add(self, *deps):
         # a -> c + t
-        return self, tuple()
+        if self.is_Rational:
+            return self, tuple()
+        return S.Zero, (self,)
 
 class Real(Number):
     """

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -569,6 +569,8 @@ def test_as_coeff_add():
     y = Symbol('y')
 
     assert S(2).as_coeff_add() == (2, ())
+    assert S(3.0).as_coeff_add() == (0, (S(3.0),))
+    assert S(-3.0).as_coeff_add() == (0, (S(-3.0),))
     assert     x .as_coeff_add() == ( 0, (x,))
     assert (-1+x).as_coeff_add() == (-1, (x,))
     assert ( 2+x).as_coeff_add() == ( 2, (x,))
@@ -584,6 +586,8 @@ def test_as_coeff_mul():
     y = Symbol('y')
 
     assert S(2).as_coeff_mul() == (2, ())
+    assert S(3.0).as_coeff_mul() == (1, (S(3.0),))
+    assert S(-3.0).as_coeff_mul() == (-1, (S(3.0),))
     assert     x .as_coeff_mul() == ( 1, (x,))
     assert (-x).as_coeff_mul() == (-1, (x,))
     assert (2*x).as_coeff_mul() == (2, (x,))
@@ -812,3 +816,6 @@ def test_symbols():
 def test_issue2201():
     x = Symbol('x', commutative=False)
     assert x*sqrt(2)/sqrt(6) == x*sqrt(3)/3
+
+def test_issue_2061():
+    assert sqrt(-1.0*x) == I*sqrt(x)


### PR DESCRIPTION
Issue 2061 identified a problem inherent in how Reals are treated differently than NumberSymbols. Whereas `(pi*x).as_coeff_mul()` gives `1, (pi, x)` `(3.0*x).as_coeff_mul()` gave `3.0, (x,)`. This is a problem because (based on no failing tests after the change) sympy is not ever expecting to pull out anything but a Rational with `as_coeff_*`.

Number now checks to see if the coeff is a Rational and if not, only extracts the sign of the Number as occurs with expressions like `pi*x` and `pi + x` which would return 1 and 0 from as_coeff_mul and as _coeff_add, respectively.
