### PR TITLE
2213 Sum.diff() mods and unification of Sum and Integral limits

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1,5 +1,5 @@
 from sympy.core import (Expr, S, C, Symbol, Equality, Interval, sympify, Wild,
-                        Tuple, Dummy)
+                        Tuple, Dummy, Derivative)
 from sympy.solvers import solve
 from sympy.utilities import flatten
 
@@ -122,6 +122,13 @@ class Sum(Expr):
 
     def _eval_summation(self, f, x):
         return
+
+    def _eval_derivative(self, x):
+        if not self.has(x):
+            return S.Zero
+
+        if not self.args[1].has(x):
+            return Sum(Derivative(self.args[0], x, **{'evaluate': True}), self.args[1])
 
     def euler_maclaurin(self, m=0, n=0, eps=0, eval_integral=True):
         """

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Sum, oo, Real, Rational, summation, pi, cos, zeta,
     Catalan, exp, log, factorial, sqrt, E, sympify, binomial, EulerGamma,
-    Function, Integral, Product, product, Tuple, Eq, Interval, nan)
+    Function, Integral, Product, product, Tuple, Eq, Interval, nan, diff)
 from sympy.concrete.sums_products import Sum2
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -222,3 +222,6 @@ def test_Sum_interface():
     assert Sum(nan, (n, 0, oo)).doit() == nan
     raises(ValueError, "Sum(1)")
     raises(ValueError, "summation(1)")
+
+def test_eval_diff():
+    assert diff(Sum(n*a**2, (n, 0, 2)), a) == Sum(2*n*a, (n, 0, 2))

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,10 +1,10 @@
 from sympy import (Symbol, Sum, oo, Real, Rational, summation, pi, cos, zeta,
     Catalan, exp, log, factorial, sqrt, E, sympify, binomial, EulerGamma,
-    Function, Integral, Product, product, Tuple, Eq, Interval, nan, diff)
+    Function, Integral, Product, product, nan, diff, Derivative, S, cos)
 from sympy.concrete.sums_products import Sum2
 from sympy.utilities.pytest import XFAIL, raises
 
-a, b, c, d, m, k = map(Symbol, 'abcdmk')
+a, b, c, d, m, k, x, y = map(Symbol, 'abcdmkxy')
 n = Symbol('n', integer=True)
 
 def test_arithmetic_sums():
@@ -169,6 +169,8 @@ def test_telescopic_sums():
 def test_sum_reconstruct():
     s = Sum(n**2, (n, -1, 1))
     assert s == Sum(*s.args)
+    raises(ValueError, 'Sum(x, x)')
+    raises(ValueError, 'Sum(x, (x, 1))')
 
 def test_Sum_limit_subs():
     assert Sum(a*exp(a), (a, -2, 2)) == Sum(a*exp(a), (a, -b, b)).subs(b, 2)
@@ -184,21 +186,6 @@ def test_Sum2():
     y = Symbol('y')
     assert Sum2(x**y, (x, 1, 3)) == 1 + 2**y + 3**y
 
-def test_sum_constructor():
-    s1 = Sum(n,n)
-    assert s1.limits == (Tuple(n),)
-    s2 = Sum(n,(n,))
-    assert s2.limits == (Tuple(n),)
-    s3 = Sum(n,((n,)))
-    assert s3.limits == (Tuple(n),)
-    s4 = Sum(n,(Tuple(n,)))
-    assert s4.limits == (Tuple(n),)
-
-    s5 = Sum(n,Eq(n,1))
-    assert s5.limits == (Tuple(n,1),)
-    s6 = Sum(n,Eq(n,Interval(1,2)))
-    assert s6.limits == (Tuple(n,1,2),)
-
 def test_Sum_doit():
     assert Sum(n*Integral(a**2), (n, 0, 2)).doit() == a**3
     assert Sum(n*Integral(a**2), (n, 0, 2)).doit(deep = False) == \
@@ -213,15 +200,20 @@ def test_Product_doit():
 
 def test_Sum_interface():
     assert isinstance(Sum(0, (n, 0, 2)), Sum)
-    assert isinstance(Sum(nan, (n, 0, 2)), Sum)
+    assert Sum(nan, (n, 0, 2)) is nan
+    assert Sum(nan, (n, 0, oo)) is nan
     assert Sum(0, (n, 0, 2)).doit() == 0
-    assert Sum(nan, (n, 0, 2)).doit() == nan
     assert isinstance(Sum(0, (n, 0, oo)), Sum)
-    assert isinstance(Sum(nan, (n, 0, oo)), Sum)
     assert Sum(0, (n, 0, oo)).doit() == 0
-    assert Sum(nan, (n, 0, oo)).doit() == nan
     raises(ValueError, "Sum(1)")
     raises(ValueError, "summation(1)")
 
 def test_eval_diff():
-    assert diff(Sum(n*a**2, (n, 0, 2)), a) == Sum(2*n*a, (n, 0, 2))
+    assert Sum(x, (x, 1, 2)).diff(x) == 0
+    assert Sum(x*y, (x, 1, 2)).diff(x) == 0
+    assert Sum(x*y, (y, 1, 2)).diff(x) == Sum(y, (y, 1, 2))
+    e = Sum(x*y, (x, 1, a))
+    assert e.diff(a) == Derivative(e, a)
+    assert Sum(x*y, (x, 1, 3), (a, 2, 5)).diff(y) == \
+           Sum(x*y, (x, 1, 3), (a, 2, 5)).doit().diff(y) == \
+           24

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -252,4 +252,4 @@ def test_doit():
     f = Sum(2 * n * x, (n, 1, 3))
     d = Derivative(f, x)
     assert d.doit() == 12
-    assert d.doit(deep = False) == d
+    assert d.doit(deep = False) == Sum(2*n, (n, 1, 3))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,7 +1,7 @@
 from sympy import (S, symbols, integrate, Integral, Derivative, exp, oo, Symbol,
         Function, Rational, log, sin, cos, pi, E, I, Poly, LambertW, diff,
         Matrix, sympify, sqrt, atan, asin, acos, atan, DiracDelta, Heaviside,
-        Lambda, sstr, Add)
+        Lambda, sstr, Add, Tuple, Eq, Interval, Sum)
 from sympy.utilities.pytest import XFAIL, skip, raises
 from sympy.physics.units import m, s
 
@@ -21,6 +21,21 @@ def diff_test(i):
 def test_improper_integral():
     assert integrate(log(x), (x, 0, 1)) == -1
     assert integrate(x**(-2), (x, 1, oo)) == 1
+
+def test_constructor():
+    # this is shared by Sum, so testing Integral's constructor
+    # is equivalent to testing Sum's
+    s1 = Integral(n, n)
+    assert s1.limits == (Tuple(n),)
+    s2 = Integral(n, (n,))
+    assert s2.limits == (Tuple(n),)
+    s3 = Integral(Sum(x, (x, 1, y)))
+    assert s3.limits == (Tuple(y),)
+    s4 = Integral(n, Tuple(n,))
+    assert s4.limits == (Tuple(n),)
+
+    s5 = Integral(n, (n, Interval(1, 2)))
+    assert s5.limits == (Tuple(n, 1, 2),)
 
 def test_basics():
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -361,10 +361,13 @@ class StrPrinter(Printer):
         return self._print(expr.toMatrix())
 
     def _print_Sum(self, expr):
-        limits = str.join(', ', \
-            tuple([ '(%s)' % self.stringify(l, ', ') for l in expr.limits ]))
-
-        return 'Sum(%s, %s)' % (self._print(expr.function), limits)
+        def _xab_tostr(xab):
+            if len(xab) == 1:
+                return self._print(xab[0])
+            else:
+                return self._print((xab[0],) + tuple(xab[1:]))
+        L = ', '.join([_xab_tostr(l) for l in expr.limits])
+        return 'Sum(%s, %s)' % (self._print(expr.function), L)
 
     def _print_Sum2(self, expr):
         return "Sum2(%r, (%r, %r, %r))" % (expr.f, expr.i, expr.a, expr.b)


### PR DESCRIPTION
This is blocked by [ https://github.com/sympy/sympy/pull/132 ]. 

Sums, like Integrals, share a common structure of their limits. The processing of limits has been factored out of Integral's instantiation and stored in a private function in integrals.py

Sum(NaN, ...) is, like Integral, automatically evaluated to NaN.

foo in baz.free_symbols is used in a few places rather than baz.has(foo)

Printing of Sum now uses the same logic as Integral so Sum(x, x) and Integral(x, x) look the same except for the class name.
