### PR TITLE
Bugfix for issue 905

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -715,8 +715,6 @@ class Pow(Expr):
                     except TypeError:
                         pass # hope that base allows this to be resolved
                 n = _sympify(n)
-                if n.is_Integer:
-                    assert n.is_nonnegative
             return n, unbounded
 
         order = O(x**n, x)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,5 +1,5 @@
 from sympy import Lambda, Symbol, Function, Derivative, sqrt, \
-        log, exp, Rational, Real, sin, cos, diff, I, re, im, \
+        log, exp, Rational, Real, sin, cos, acos, diff, I, re, im, \
         oo, zoo, nan, E, expand, pi, O, Sum, S
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y
@@ -245,7 +245,10 @@ def test_function__eval_nseries():
     assert sin(x)._eval_nseries(x,2) == x + O(x**2)
     assert sin(x+1)._eval_nseries(x,2) == x*cos(1) + sin(1) + O(x**2)
     assert sin(pi*(1-x))._eval_nseries(x,2) == pi*x + O(x**2)
+    assert acos(1-x**2)._eval_nseries(x,2) == sqrt(2)*x + O(x**2)
     raises(PoleError, 'sin(1/x)._eval_nseries(x,2)')
+    raises(PoleError, 'acos(1-x)._eval_nseries(x,2)')
+    raises(PoleError, 'acos(1+x)._eval_nseries(x,2)')
 
 def test_doit():
     n = Symbol('n', integer = True)


### PR DESCRIPTION
This fixes issue 905 (error in acos(1-x**2).series(x)).

The problem is that Function._eval_nseries assumes that values of functions can always be computed by substitution; this is wrong since sometimes we may need a limit. However always computing a limit is slow and moreover breaks a lot, since gruntz relies on the series code to actually evaluate the limits. My solution is to only compute a limit if substitution returns NaN, hopefully this should ensure forward progress.

My changelog is this:

commit 345212fd8dd19403c5e29ee7b7f5ac7ab65d15e7
Author: Tom Bachmann e_mc_h2@web.de
Date:   Fri Mar 25 10:08:30 2011 +0000

```
Fix issue 905.

sympy/core/function.py:
  (Function._eval_nseries) Try to evaluate a limit if we get NaN at intermediate stages.
sympy/core/tests/test_functions.py:
  (test_function__eval_nseries) Add tests to illustrate this.

Bugfix along the way:
sympy/core/power.py
  (Power._eval_nseries.e2int) Remove spurious assert.
```

Regards,
Tom
