### PR TITLE
Issue1394. Added integration by parts with condition

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -572,7 +572,22 @@ class Integral(Expr):
             if h is not None:
                 parts.append(coeff * h)
             else:
-                return None
+                # integral(f1*f2,x) = f1 * integrate(f2, x) - integrate(f1.diff(x) * integrate(f2,x), x)
+                # We will use the above technique to solve integration.
+                # Since we are putting the following condition
+                #         len (args_m) >= len(Mul.make_args(f1.diff(x) * f2_inte))
+                # the process is terminating even though its recursive.
+                args_m = Mul.make_args(f)
+                if len(args_m)>1:
+                    f1 = args_m[0]
+                    f2 = Mul(*args_m[1:])
+                    f2_inte = integrate(f2,x)
+                    if len (args_m) >= len(Mul.make_args(f1.diff(x) * f2_inte)):
+                        return f1 * f2_inte - integrate(f1.diff(x) * f2_inte ,x)
+                    else :
+                        return None
+                else:
+                    return None
 
         return Add(*parts)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1,5 +1,5 @@
 from sympy.core import (Basic, Expr, S, C, Symbol, Wild, Add, sympify, diff,
-                        oo, Tuple, Dummy)
+                        oo, Tuple, Dummy, Mul)
 
 from sympy.core.symbol import Dummy
 from sympy.integrals.trigonometry import trigintegrate


### PR DESCRIPTION
With reference to Issue1394, I added code so as to enable sympy/integrals/integrals.py to integrate  some more function when everything previously existing method fails. Obviously, it doesn't cover the whole of integration but it covers the integrations which were solvable by integration by parts.

At the present it show two error in test file. Two errors are -

---

_______ sympy/solvers/tests/test_ode.py:test_1st_homogeneous_coeff_ode3 ________
  File "/home/hector/Workstation/sympy/sympy/solvers/tests/test_ode.py", line 524, in test_1st_homogeneous_coeff_ode3
    assert str(dsolve(eq, f(x), hint='1st_homogeneous_coeff_subs_indep_div_dep')) == solstr
AssertionError

When I solved the assertion explicitly, the result is - 

```
In [1]: eq = f(x)**2+(x*sqrt(f(x)**2-x**2)-x*f(x))*f(x).diff(x)

In [2]: str(dsolve(eq, f(x), hint='1st_homogeneous_coeff_subs_indep_div_dep'))  
Out[2]: f(x) == C1*exp(-Integral(1/((1 - _u2**2)**(1/2)*_u2), (_u2, x/f(x))))

In [3]: solstr = "f(x) == C1*exp(Integral(-1/((1 - _u2**2)**(1/2)*_u2), (_u2, x/f(x))))"

In [4]: Out[2] == solstr
Out[4]: False
```

Please notice that its only difference is -Integral(1/(something) ) and  Integral(-1/(something)). Rest is identical. I don't think it is a serious threat. 

---

______________ sympy/solvers/tests/test_solvers.py:test_tsolve_1 _______________
  File "/home/hector/Workstation/sympy/sympy/solvers/tests/test_solvers.py", line 231, in test_tsolve_1
    [-((4_log(7) + 5_LambertW(-7_2__Rational(4,5)_6*_Rational(1,5)_log(7)/10))/(3*log(7)))]]
AssertionError

 This error is present in master branch and at present level, there is nothing I can do about it.
