### PR TITLE
Improve residue_ntheory.py functions

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1,5 +1,6 @@
 from sympy.core.numbers import igcd
 from primetest import isprime
+from factor_ import factorint
 
 def totient_(n):
     """returns the number of integers less than n
@@ -17,11 +18,20 @@ def n_order(a,n):
     Order of a modulo n is the smallest integer
     k such that a^k leaves a remainder of 1 with n.
     """
-    assert igcd(a,n)==1
-    if a>n : a=a%n
-    for x in xrange(1,totient_(n)+1):
-        if (a**x)%n==1:
-            return x
+    assert igcd(a,n)==1,"The two numbers should be relatively prime"
+    group_order=totient_(n)
+    factors=factorint(group_order)
+    order=1
+    if a>n:
+        a=a%n
+    for p, e in factors.iteritems():
+        exponent=group_order
+        for f in xrange(0,e+1):
+            if (a**(exponent))%n!=1:
+                order*=p**(e-f+1)
+                break
+            exponent=exponent//p
+    return order
 
 def is_primitive_root(a,p):
     """

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -55,9 +55,14 @@ def is_quad_residue(a,p):
     assert igcd(a,p)==1,"The two numbers should be relatively prime"
     if a>p:
         a=a%p
-    rem=(a**((p-1)//2))%p    # a^(p-1 / 2) % p
-    if rem==1: return True
-    else : return False
+    def square_and_multiply(a,n,p):
+        if n==0: return 1
+        if n==1: return a
+        if n%2==1:
+            return (square_and_multiply(a,n//2,p)**2 * a)%p
+        else:
+            return (square_and_multiply(a,n//2,p)**2)%p
+    return (square_and_multiply(a,(p-1)//2,p)%p)==1
 
 def legendre_symbol(a,p):
     """

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -2,83 +2,94 @@ from sympy.core.numbers import igcd
 from primetest import isprime
 from factor_ import factorint
 
+
 def totient_(n):
     """returns the number of integers less than n
     and relatively prime to n"""
     if n < 1:
         raise ValueError("n must be a positive integer")
-    tot=0
-    for x in xrange(1,n):
-        if igcd(x,n)==1:
-            tot+=1
+    tot = 0
+    for x in xrange(1, n):
+        if igcd(x, n) == 1:
+            tot += 1
     return tot
 
-def n_order(a,n):
+
+def n_order(a, n):
     """ returns the order of a modulo n
     Order of a modulo n is the smallest integer
     k such that a^k leaves a remainder of 1 with n.
     """
-    if igcd(a,n)!=1:
+    if igcd(a, n) != 1:
         raise ValueError("The two numbers should be relatively prime")
-    group_order=totient_(n)
-    factors=factorint(group_order)
-    order=1
-    if a>n:
-        a=a%n
+    group_order = totient_(n)
+    factors = factorint(group_order)
+    order = 1
+    if a > n:
+        a = a % n
     for p, e in factors.iteritems():
-        exponent=group_order
-        for f in xrange(0,e+1):
-            if (a**(exponent))%n!=1:
-                order*=p**(e-f+1)
+        exponent = group_order
+        for f in xrange(0, e + 1):
+            if (a ** (exponent)) % n != 1:
+                order *= p ** (e - f + 1)
                 break
-            exponent=exponent//p
+            exponent = exponent // p
     return order
 
-def is_primitive_root(a,p):
+
+def is_primitive_root(a, p):
     """
     returns True if a is a primitive root of p
     """
-    if igcd(a,p)!=1:
+    if igcd(a, p) != 1:
         raise ValueError("The two numbers should be relatively prime")
-    if a>p:
-        a=a%p
-    if n_order(a,p)==totient_(p):
+    if a > p:
+        a = a % p
+    if n_order(a, p) == totient_(p):
         return True
     else:
         return False
 
-def is_quad_residue(a,p):
+
+def is_quad_residue(a, p):
     """
     returns True if a is a quadratic residue of p
     p should be a prime and a should be relatively
     prime to p
     """
-    if isprime(p)==False or p==2:
+    if not isprime(p) or p == 2:
         raise ValueError("p should be an odd prime")
-    if igcd(a,p)!=1:
+    if igcd(a, p) != 1:
         raise ValueError("The two numbers should be relatively prime")
-    if a>p:
-        a=a%p
-    def square_and_multiply(a,n,p):
-        if n==0: return 1
-        if n==1: return a
-        if n%2==1:
-            return (square_and_multiply(a,n//2,p)**2 * a)%p
-        else:
-            return (square_and_multiply(a,n//2,p)**2)%p
-    return (square_and_multiply(a,(p-1)//2,p)%p)==1
+    if a > p:
+        a = a % p
 
-def legendre_symbol(a,p):
+    def square_and_multiply(a, n, p):
+        if n == 0:
+            return 1
+        elif n == 1:
+            return a
+        elif n % 2 == 1:
+            return ((square_and_multiply(a, n // 2, p) ** 2) * a) % p
+        else:
+            return (square_and_multiply(a, n // 2, p) ** 2) % p
+
+    return (square_and_multiply(a, (p - 1) // 2, p) % p) == 1
+
+
+def legendre_symbol(a, p):
     """
     return 1 if a is a quadratic residue of p
     else return -1
     p should be an odd prime by definition
     """
-    if isprime(p)==False or p==2:
+    if not isprime(p) or p == 2:
         raise ValueError("p should be an odd prime")
-    if igcd(a,p)!=1:
+    if igcd(a, p) != 1:
         raise ValueError("The two numbers should be relatively prime")
-    if a>p:
-        a=a%p
-    if is_quad_residue(a,p)==True: return 1
-    else : return -1
+    if a > p:
+        a = a % p
+    if is_quad_residue(a, p):
+        return 1
+    else:
+        return -1

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -18,7 +18,8 @@ def n_order(a,n):
     Order of a modulo n is the smallest integer
     k such that a^k leaves a remainder of 1 with n.
     """
-    assert igcd(a,n)==1,"The two numbers should be relatively prime"
+    if igcd(a,n)!=1:
+        raise ValueError("The two numbers should be relatively prime")
     group_order=totient_(n)
     factors=factorint(group_order)
     order=1
@@ -37,7 +38,8 @@ def is_primitive_root(a,p):
     """
     returns True if a is a primitive root of p
     """
-    assert igcd(a,p) == 1,"The two numbers should be relatively prime"
+    if igcd(a,p)!=1:
+        raise ValueError("The two numbers should be relatively prime")
     if a>p:
         a=a%p
     if n_order(a,p)==totient_(p):
@@ -51,8 +53,10 @@ def is_quad_residue(a,p):
     p should be a prime and a should be relatively
     prime to p
     """
-    assert isprime(p) and p!=2,"p should be an odd prime"
-    assert igcd(a,p)==1,"The two numbers should be relatively prime"
+    if isprime(p)==False or p==2:
+        raise ValueError("p should be an odd prime")
+    if igcd(a,p)!=1:
+        raise ValueError("The two numbers should be relatively prime")
     if a>p:
         a=a%p
     def square_and_multiply(a,n,p):
@@ -70,8 +74,10 @@ def legendre_symbol(a,p):
     else return -1
     p should be an odd prime by definition
     """
-    assert isprime(p) and p!=2,"p should be an odd prime"
-    assert igcd(a,p)==1,"The two numbers should be relatively prime"
+    if isprime(p)==False or p==2:
+        raise ValueError("p should be an odd prime")
+    if igcd(a,p)!=1:
+        raise ValueError("The two numbers should be relatively prime")
     if a>p:
         a=a%p
     if is_quad_residue(a,p)==True: return 1


### PR DESCRIPTION
Modify the functions `n_order` and `is_quad_residue` in order to improve performance.

`n_order` now uses factorint of `n` but the old code would similarly fail for large numbers.

`is_quad_residue` is just square and multiply modulo `p`.
