### PR TITLE
Fix issue 1321.

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -93,6 +93,7 @@ def __cacheit(func):
             k = args + tuple(items)
         else:
             k = args
+        k = k + tuple(map(lambda x: type(x), k))
         try:
             return func_cache_it_cache[k]
         except KeyError:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -570,7 +570,8 @@ class Mul(AssocOp):
         # handle (w*3).matches('x*5') -> {w: x*5/3}
         coeff, terms = self.as_coeff_mul()
         if len(terms) == 1:
-            return terms[0].matches(expr/coeff, repl_dict)
+            newexpr = self.__class__._combine_inverse(expr, coeff)
+            return terms[0].matches(newexpr, repl_dict)
         return
 
     def matches(self, expr, repl_dict={}, evaluate=False):
@@ -654,6 +655,12 @@ class Mul(AssocOp):
         """
         if lhs == rhs:
             return S.One
+        def check(l, r):
+            if l.is_Real and r.is_comparable:
+                return Add(l, 0) == Add(r.evalf(), 0)
+            return False
+        if check(lhs, rhs) or check(rhs, lhs):
+           return S.One
         if lhs.is_Mul and rhs.is_Mul:
             a = list(lhs.args)
             b = [1]

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -254,3 +254,12 @@ def test_doit():
     d = Derivative(f, x)
     assert d.doit() == 12
     assert d.doit(deep = False) == d
+
+def test_evalf_default():
+    from sympy.functions.special.gamma_functions import polygamma
+    assert type(sin(4.0)) == Real
+    assert type(re(sin(I + 1.0))) == Real
+    assert type(im(sin(I + 1.0))) == Real
+    assert type(sin(4)) == sin
+    assert type(polygamma(2,4.0)) == Real
+    assert type(sin(Rational(1,4))) == sin

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -300,7 +300,7 @@ def test_exclude():
 def test_floats():
     a,b = map(Wild, 'ab')
 
-    e = cos(0.12345)**2
+    e = cos(0.12345, evaluate=False)**2
     r = e.match(a*cos(b)**2)
     assert r == {a: 1, b: Real(0.12345)}
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -382,7 +382,7 @@ class log(Function):
         else:
             abs = C.Abs(self.args[0])
             arg = C.arg(self.args[0])
-        if hints['log']: # Expand the log
+        if hints.get('log', False): # Expand the log
             hints['complex'] = False
             return (log(abs).expand(deep, **hints), arg)
         else:


### PR DESCRIPTION
This fixes issue 1321.
All tests passed.

Mul._combine_inverse now uses mpmath.almosteq to treat floats. This is to only way I could manage to get the unit test test_match_float to work. Consider

```
  >>> l = cos(0.123,evaluate=False)**2
  >>> r = cos(0.123,evaluate=False).evalf()**2
  >>> l.evalf() == r
  False
  >>> l.evalf()._prec
  53
 >>> r._prec
 53
  >>> l.evalf()._mpf_
  (0, 141945842586699671, -57, 57)
  >>> r._mpf_
  (0, 8871615161668729, -53, 53)
  # the tuples are different so == returns False, although "for all intents and purposes"
  # these numbers are the same
```

If there is a better way to figure out that l/r should be 1, please let me know.

Note: _combine_inverse always tries lhs == rhs to test if it should return one. This sometimes works for floats, since in our case r == l internally does l.evalf(). In particular:
     >>> cos(0.123,evaluate=False) == cos(0.123)
     False   # Function.__eq__ returns false when applied to Real's
     >>> cos(0.123) == cos(0.123,evaluate=False)
     True    # Real.**eq** evalf()s the function and returns True.

Hence == is not symmetric with the current implementation!

Changelog:

```
  sympy/core/cache.py:
    (__cacheit.wrapper) Make argument types part of tuple to be hashed.

  sympy/core/function.py:
    (__new__): evalf() if desired, using ...
    (should_evalf): New classmethod.

  sympy/core/mul.py:
    (_matches_simple): Use _combine_inverse instead of division.
    (_combine_inverse): Use almosteq comparison for floats.

  sympy/core/tests/test_functions.py
    (test_evalf_default) New test.

  sympy/core/tests/test_match.py
    (test_match_float) Adapt test to new default evalf.

  sympy/functions/elementary/exponential.py
    (log.as_real_imag) Bugfix.
```
