### PR TITLE
Add more emulation of tuple in Tuple, and use it in FockState

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -35,11 +35,40 @@ class Tuple(Basic):
     def __len__(self):
         return len(self.args)
 
-    def __contains__(self,item):
+    def __contains__(self, item):
         return item in self.args
 
     def __iter__(self):
         return iter(self.args)
+
+    def __add__(self, other):
+        if isinstance(other, Tuple):
+            return Tuple(*(self.args + other.args))
+        elif isinstance(other, tuple):
+            return Tuple(*(self.args + other))
+        else:
+            return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, Tuple):
+            return Tuple(*(other.args + self.args))
+        elif isinstance(other, tuple):
+            return Tuple(*(other + self.args))
+        else:
+            return NotImplemented
+
+    def __eq__(self, other):
+        if isinstance(other, Basic):
+            return super(Tuple, self).__eq__(other)
+        return self.args == other
+
+    def __ne__(self, other):
+        if isinstance(other, Basic):
+            return super(Tuple, self).__ne__(other)
+        return self.args != other
+
+    def __hash__(self):
+        return hash(self.args)
 
 
 def tuple_wrapper(method):

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,5 +1,6 @@
 from sympy import Tuple, symbols
 from sympy.core.containers import tuple_wrapper
+from sympy.utilities.pytest import raises
 
 def test_Tuple():
     t = (1, 2, 3, 4)
@@ -15,6 +16,36 @@ def test_Tuple():
     st2 = Tuple(*t2)
     assert st2.atoms() == set(t2)
     assert st == st2.subs({p:1, q:2, r:3, s:4})
+
+def test_Tuple_contains():
+    t1, t2 = Tuple(1), Tuple(2)
+    assert t1 in Tuple(1, 2, 3, t1, Tuple(t2))
+    assert t2 not in Tuple(1, 2, 3, t1, Tuple(t2))
+
+def test_Tuple_concatenation():
+    assert Tuple(1, 2) + Tuple(3, 4) == Tuple(1, 2, 3, 4)
+    assert (1, 2) + Tuple(3, 4) == Tuple(1, 2, 3, 4)
+    assert Tuple(1, 2) + (3, 4) == Tuple(1, 2, 3, 4)
+    raises(TypeError, 'Tuple(1, 2) + 3')
+    raises(TypeError, '1 + Tuple(2, 3)')
+
+    #the Tuple case in __radd__ is only reached when a subclass is involved
+    class Tuple2(Tuple):
+        def __radd__(self, other):
+            return Tuple.__radd__(self, other + other)
+    assert Tuple(1, 2) + Tuple2(3, 4) == Tuple(1, 2, 1, 2, 3, 4)
+    assert Tuple2(1, 2) + Tuple(3, 4) == Tuple(1, 2, 3, 4)
+
+def test_Tuple_equality():
+    assert Tuple(1, 2) is not (1, 2)
+    assert (Tuple(1, 2) == (1, 2)) is True
+    assert (Tuple(1, 2) != (1, 2)) is False
+    assert (Tuple(1, 2) == (1, 3)) is False
+    assert (Tuple(1, 2) != (1, 3)) is True
+    assert (Tuple(1, 2) == Tuple(1, 2)) is True
+    assert (Tuple(1, 2) != Tuple(1, 2)) is False
+    assert (Tuple(1, 2) == Tuple(1, 3)) is False
+    assert (Tuple(1, 2) != Tuple(1, 3)) is True
 
 def test_tuple_wrapper():
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1107,8 +1107,8 @@ class FockState(Expr):
           Element 0 is the state that was occupied first, element i
           is the i'th occupied state.
         """
-        o = map(sympify, occupations)
-        obj = Basic.__new__(cls, tuple(o), commutative=False)
+        occupations = map(sympify, occupations)
+        obj = Basic.__new__(cls, Tuple(*occupations), commutative=False)
         return obj
 
     def _eval_subs(self, old, new):
@@ -1212,7 +1212,7 @@ class FermionState(FockState):
         >>> p = Symbol('p')
 
         >>> FKet([]).up(a)
-        FockStateFermionKet((a,))
+        FockStateFermionKet(Tuple(a))
 
         A creator acting on vacuum below fermi vanishes
         >>> FKet([]).up(i)
@@ -1264,7 +1264,7 @@ class FermionState(FockState):
         >>> FKet([]).down(i)
         0
         >>> FKet([],4).down(i)
-        FockStateFermionKet((i,))
+        FockStateFermionKet(Tuple(i))
 
         """
         present = i in self.args[0]


### PR DESCRIPTION
FockState should the last subclass of Basic that still had a tuple in its .args. Converting it to Tuple required implementing Tuple concatenation. I've also allowed Tuples to be compared with tuples in the obvious way and added tests to get full coverage of the class. This fixes issue 2237.
