### PR TITLE
Fix issue 360. Make zoo behave sensibly.

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -124,6 +124,10 @@ class Add(AssocOp):
         elif (coeff is S.Infinity) or (coeff is S.NegativeInfinity):
             newseq = [f for f in newseq if not f.is_real]
 
+        # zoo
+        elif coeff == S.ComplexInfinity:
+            newseq = [f for f in newseq if not (f.is_real or f.is_imaginary)]
+
 
         # process O(x)
         if order_factors:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -281,6 +281,16 @@ class Mul(AssocOp):
             nc_part = new_nc_part
             coeff *= coeff_sign
 
+        # zoo
+        if coeff is S.ComplexInfinity:
+            new_c_part = [f for f in c_part if not (f.is_Number \
+                                                    or f == S.ImaginaryUnit)]
+            new_nc_part = [f for f in nc_part if not (f.is_Number \
+                                                      or f == S.ImaginaryUnit)]
+            c_part = new_c_part
+            nc_part = new_nc_part
+
+
         # 0, nan
         elif (coeff is S.Zero) or (coeff is S.NaN):
             # we know for sure the result will be the same as coeff (0 or nan)
@@ -306,7 +316,12 @@ class Mul(AssocOp):
         if len(c_part)==2 and c_part[0].is_Number and c_part[1].is_Add:
             # 2*(1+a) -> 2 + 2 * a
             coeff = c_part[0]
-            c_part = [Add(*[coeff*f for f in c_part[1].args])]
+            if coeff is S.ComplexInfinity:
+                re, im = c_part[1].as_real_imag()
+                if re.is_Number and im.is_Number and c_part[1] != 0:
+                    c_part = [S.ComplexInfinity]
+            else:
+                c_part = [Add(*[coeff*f for f in c_part[1].args])]
 
         if reeval:
             c_part, _, _ = Mul.flatten(c_part)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1,5 +1,5 @@
 from sympy import Rational, Symbol, Real, I, sqrt, oo, nan, pi, E, Integer, \
-        S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp, Number
+        S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp, Number, zoo
 from sympy.core.power import integer_nthroot
 
 from sympy.core.numbers import igcd, ilcm, igcdex, ifactorial, seterr, _intcache
@@ -297,6 +297,48 @@ def test_Infinity_inequations():
     assert oo > pi
     assert not (oo < pi)
     assert exp(-3) < oo
+
+def test_ComplexInfinity():
+    assert zoo == zoo
+    assert zoo != oo
+    assert 1*zoo == zoo
+    assert 2*zoo == zoo
+    assert 1 != zoo
+    assert zoo != 1
+    assert zoo != Symbol("x")**3
+    assert zoo + 1 == zoo + 1
+    assert zoo + 1 == zoo
+    assert 2 + zoo == zoo
+    assert 3*zoo + 2 == zoo
+    assert 1/zoo == 0
+
+    x = Symbol('x')
+
+    assert zoo + zoo == nan
+    assert zoo - zoo == nan
+    assert zoo + oo == nan
+    assert zoo - oo == nan
+
+    assert zoo + I == zoo
+    assert zoo * I == zoo
+    assert zoo + x + 2 + 3*I == zoo + x
+    assert zoo * x * 2 * 3*I * -oo == zoo * x
+
+    assert zoo * (1+I) == zoo
+    assert zoo * (4+I+x) != zoo
+
+    assert zoo * 0 == nan
+    assert zoo * nan == nan
+    assert 0 * zoo == nan
+    assert nan * zoo == nan
+    assert zoo + nan == nan
+
+    assert zoo**zoo == nan
+    assert zoo**0   == 1
+    assert zoo**2   == zoo
+    assert zoo**(-1) == 0
+
+    assert abs(zoo) == oo
 
 def test_NaN():
     assert nan == nan


### PR DESCRIPTION
This patch fixes issue 360. All tests pass.
It should be considered a temporary solution, to be replaced when issue 2200 is sorted out.

This makes ComplexInfinity a subclass of Number and implements the required methods.

sympy/core/numbers.py:
  (ComlexInfinity) Derive from Number, not AtomicExpr.
  (ComlexInfinity.is_bounded) New attribute.
  (ComlexInfinity.is_finite) Likewise.
  (ComlexInfinity.is_infinitesimal) Likewise.
  (ComlexInfinity.is_integer) Likewise.
  (ComlexInfinity.is_rational) Likewise.
  (ComlexInfinity.is_odd) Likewise.
  (ComlexInfinity._op_priority) Likewise.

  (ComlexInfinity.**add**) New method.
  (ComlexInfinity.**radd**) Likewise.
  (ComlexInfinity.**mul**) Likewise.
  (ComlexInfinity.**rmul**) Likewise.
  (ComlexInfinity.**eq**) Likewise.
  (ComlexInfinity.**ne**) Likewise.

sympy/core/tests/test_numbers.py
  (test_ComplexInfinity) New unit test.
