### PR TITLE
issue 821: implement multiple arguments for Max and Min

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,4 +1,8 @@
-from sympy.core import S, C, sympify, Function
+from sympy.core import S, C, sympify
+from sympy.core.basic import Basic
+from sympy.core.operations import LatticeOp, ShortCircuit
+from sympy.core.function import Application
+from sympy.core.expr import Expr
 
 ###############################################################################
 ############################# SQUARE ROOT FUNCTION ############################
@@ -12,53 +16,276 @@ def sqrt(arg):
 ############################# MINIMUM and MAXIMUM #############################
 ###############################################################################
 
-class Max(Function):
+class MinMaxBase(LatticeOp):
+    def __new__(cls, *args, **assumptions):
+        if not args:
+            raise ValueError("The Max/Min functions must have arguments.")
 
-    nargs = 2
+        args = (sympify(arg) for arg in args)
+
+        # first standard filter, for cls.zero and cls.identity
+        # also reshape Max(a, Max(b, c)) to Max(a, b, c)
+        try:
+            _args = frozenset(cls._new_args_filter(args))
+        except ShortCircuit:
+            return cls.zero
+
+        # second filter
+        # variant I: remove ones which can be removed
+        # args = cls._collapse_arguments(set(_args), **assumptions)
+
+        # variant II: find local zeros
+        args = cls._find_localzeros(set(_args), **assumptions)
+
+        _args = frozenset(args)
+
+        if not _args:
+            return cls.identity
+        elif len(_args) == 1:
+            return set(_args).pop()
+        else:
+            # base creation
+            obj = Expr.__new__(cls, _args, **assumptions)
+            obj._argset = _args
+            return obj
 
     @classmethod
-    def eval(cls, x, y):
-        """Return, if possible, the value from (a, b) that is >= the other.
-
-        >>> from sympy import Max, Symbol
-        >>> from sympy.abc import x
-        >>> Max(x, -2)
-        Max(x, -2)
-        >>> _.subs(x, 3)
-        3
-
-        Assumptions are used to make the decision:
-
-        >>> p = Symbol('p', positive=True)
-        >>> Max(p, -2)
-        p
+    def _new_args_filter(cls, arg_sequence):
         """
+        Generator filtering args.
 
-        if x == y:
-            return x
+        first standard filter, for cls.zero and cls.identity.
+        Also reshape Max(a, Max(b, c)) to Max(a, b, c),
+        and check arguments for comparability
+        """
+        for arg in arg_sequence:
+
+            # pre-filter, checking comparability of arguments
+            if (arg.is_real == False) or (arg is S.ComplexInfinity):
+                raise ValueError("The argument '%s' is not comparable." % arg)
+
+            if arg == cls.zero:
+                raise ShortCircuit(arg)
+            elif arg == cls.identity:
+                continue
+            elif arg.func == cls:
+                for x in arg.iter_basic_args():
+                    yield x
+            else:
+                yield arg
+
+    @classmethod
+    def _find_localzeros(cls, values, **options):
+        """
+        Sequentially allocate values to localzeros.
+
+        If value is greter than all of the localzeros, then it is new localzero
+        and it is apending to them.
+
+        if value is greter than one of the localzeros,
+        then update localzero's set.
+        """
+        localzeros = set()
+        for v in values:
+            is_newzero = True
+            for z in localzeros:
+                if id(v) == id(z):
+                    is_newzero = False
+                elif cls._is_connected(v, z):
+                    is_newzero = False
+                    if cls._is_asneeded(v, z):
+                        localzeros.remove(z)
+                        localzeros.update([v])
+                        break
+            if is_newzero:
+                localzeros.update([v])
+        return localzeros
+
+    @classmethod
+    def _is_connected(cls, x, y):
+        """
+        Check if x and y are connected somehow.
+        """
+        if (x == y) or isinstance(x > y, bool) or isinstance(x < y, bool):
+            return True
         if x.is_Number and y.is_Number:
-            return max(x, y)
-        xy = x > y
+            return True
+        return False
+
+    @classmethod
+    def _is_asneeded(cls, x, y):
+        """
+        Check if x and y satisfy relation condition.
+
+        The relation condition for Max function is x > y,
+        for Min function is x < y. They are defined in children Max and Min
+        classes through the method _rel(cls, x, y)
+        """
+        if (x == y):
+            return False
+        if x.is_Number and y.is_Number:
+            if cls._rel(x, y):
+                return True
+        xy = cls._rel(x, y)
         if isinstance(xy, bool):
             if xy:
-                return x
-            return y
-        yx = y > x
+                return True
+            return False
+        yx = cls._rel_inversed(x, y)
         if isinstance(yx, bool):
             if yx:
-                return y # never occurs?
-            return x
+                return False # never occurs?
+            return True
+        return False
 
+class Max(MinMaxBase, Application, Basic):
+    """
+    Return, if possible, the maximum value of the list.
 
-class Min(Function):
+    When number of arguments is equal one, then
+    return this argument.
 
-    nargs = 2
+    When number of arguments is equal two, then
+    return, if possible, the value from (a, b) that is >= the other.
+
+    In common case, when the length of list greater than 2, the task
+    is more complicated. Return only the arguments, which are greater
+    than others, if it is possible to determine directional relation.
+
+    If is not possible to determine such a relation, return a partially
+    evaluated result.
+
+    Assumptions are used to make the decision too.
+
+    Also, only comparable arguments are permitted.
+
+    Example
+    -------
+
+    >>> from sympy import Max, Symbol, oo
+    >>> from sympy.abc import x, y
+    >>> p = Symbol('p', positive=True)
+    >>> n = Symbol('n', negative=True)
+
+    >>> Max(x, -2)                  #doctest: +SKIP
+    Max(x, -2)
+
+    >>> Max(x, -2).subs(x, 3)
+    3
+
+    >>> Max(p, -2)
+    p
+
+    >>> Max(x, y)                   #doctest: +SKIP
+    Max(x, y)
+
+    >>> Max(x, y) == Max(y, x)
+    True
+
+    >>> Max(x, Max(y, z))           #doctest: +SKIP
+    Max(x, y, z)
+
+    >>> Max(n, 8, p, 7, -oo)        #doctest: +SKIP
+    Max(8, p)
+
+    >>> Max (1, x, oo)
+    oo
+
+    Algorithm
+    ---------
+    The task can be considered as searching of supremums in the
+    directed complete partial orders [1]_.
+
+    The source values are sequentially allocated by the isolated subsets
+    in which supremums are searched and result as Max arguments.
+
+    If the resulted supremum is single, then it is returned.
+
+    The isolated subsets are the sets of values which are only the comparable
+    with each other in the current set. E.g. natural numbers are comparable with
+    each other, but not comparable with the `x` symbol. Another example: the
+    symbol `x` with negative assumption is comparable with a natural number.
+
+    Also there are "least" elements, which are comparable with all others,
+    and have a zero property (maximum or minimum for all elements). E.g. `oo`.
+    In case of it the allocation operation is terminated and only this value is
+    returned.
+
+    Assumption:
+       - if A > B > C then A > C
+       - if A==B then B can be removed
+
+    [1] http://en.wikipedia.org/wiki/Directed_complete_partial_order
+    [2] http://en.wikipedia.org/wiki/Lattice_(order)
+
+    See Also
+    --------
+    Min() : find minimum values
+
+    """
+    zero = S.Infinity
+    identity = S.NegativeInfinity
 
     @classmethod
-    def eval(cls, x, y):
-        """Return, if possible, the value from (a, b) that is <= the other."""
-        rv = Max(x, y)
-        if rv == x:
-            return y
-        elif rv == y:
-            return x
+    def _rel(cls, x, y):
+        """
+        Check if x > y.
+        """
+        return (x > y)
+
+    @classmethod
+    def _rel_inversed(cls, x, y):
+        """
+        Check if x < y.
+        """
+        return (x < y)
+
+
+class Min(MinMaxBase, Application, Basic):
+    """
+    Return, if possible, the minimum value of the list.
+
+    Example
+    -------
+
+    >>> from sympy import Min, Symbol, oo
+    >>> from sympy.abc import x, y
+    >>> p = Symbol('p', positive=True)
+    >>> n = Symbol('n', negative=True)
+
+    >>> Min(x, -2)                  #doctest: +SKIP
+    Min(x, -2)
+
+    >>> Min(x, -2).subs(x, 3)
+    -2
+
+    >>> Min(p, -3)
+    -3
+
+    >>> Min(x, y)                   #doctest: +SKIP
+    Min(x, y)
+
+    >>> Min(n, 8, p, -7, p, oo)     #doctest: +SKIP
+    Min(n, -7)
+
+    See Also
+    --------
+    Max() : find maximum values
+    """
+    zero = S.NegativeInfinity
+    identity = S.Infinity
+
+    @classmethod
+    def _rel(cls, x, y):
+        """
+        Check if x < y.
+        """
+        return (x < y)
+
+    @classmethod
+    def _rel_inversed(cls, x, y):
+        """
+        Check if x > y.
+        """
+        return (x > y)
+

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -1,8 +1,11 @@
-from sympy import oo
+from sympy import S
 from sympy.core.symbol import Symbol
+from sympy.utilities.pytest import raises
 from sympy.functions.elementary.miscellaneous import Min, Max
+from sympy import I, cos, sin, oo
 
 def test_Min():
+    from sympy.abc import x, y, z
     n = Symbol('n', negative=True)
     n_ = Symbol('n_', negative=True)
     nn = Symbol('nn', nonnegative=True)
@@ -11,8 +14,8 @@ def test_Min():
     p_ = Symbol('p_', positive=True)
     np = Symbol('np', nonpositive=True)
     np_ = Symbol('np_', nonpositive=True)
-    assert Min(5, 4) == 4
 
+    assert Min(5, 4) == 4
     assert Min(-oo, -oo) == -oo
     assert Min(-oo, n) == -oo
     assert Min(n, -oo) == -oo
@@ -68,5 +71,61 @@ def test_Min():
     assert Min(np, np_).func is Min
     assert Min(p, p_).func is Min
 
+    # lists
+    raises(ValueError, 'Min()')
+    assert Min(x, y) == Min(y, x)
+    assert Min(x, y, z) == Min(z, y, x)
+    assert Min(x, Min(y, z)) == Min(z, y, x)
+    assert Min(x, Max(y, -oo)) == Min(x, y)
+    assert Min(p, oo, n,  p, p, p_) == n
+    assert Min(n, oo, -7, p,  p, 2) == Min(n, -7)
+    assert Min(2, x, p, n, oo, n_,  p, 2, -2, -2) == Min(-2, x, n, n_)
+    assert Min(0, x, 1, y) == Min(0, x, y)
+    assert Min(1000, 100, -100, x, p, n) == Min(n, x, -100)
+    assert Min(cos(x), sin(x)) == Min(cos(x), sin(x))
+    assert Min(cos(x), sin(x)).subs(x, 1) == cos(1)
+    assert Min(cos(x), sin(x)).subs(x, S(1)/2) == sin(S(1)/2)
+    raises(ValueError, 'Min(cos(x), sin(x)).subs(x, I)')
+    raises(ValueError, 'Min(I)')
+    raises(ValueError, 'Min(I, x)')
+    raises(ValueError, 'Min(S.ComplexInfinity, x)')
+
+
 def test_Max():
+    from sympy.abc import x, y, z
+    n = Symbol('n', negative=True)
+    n_ = Symbol('n_', negative=True)
+    nn = Symbol('nn', nonnegative=True)
+    nn_ = Symbol('nn_', nonnegative=True)
+    p = Symbol('p', positive=True)
+    p_ = Symbol('p_', positive=True)
+    np = Symbol('np', nonpositive=True)
+    np_ = Symbol('np_', nonpositive=True)
+
     assert Max(5, 4) == 5
+
+    # lists
+
+    raises(ValueError, 'Max()')
+    assert Max(x, y) == Max(y, x)
+    assert Max(x, y, z) == Max(z, y, x)
+    assert Max(x, Max(y, z)) == Max(z, y, x)
+    assert Max(x, Min(y, oo)) == Max(x, y)
+    assert Max(n, -oo, n_,  p, 2) == Max(p, 2)
+    assert Max(n, -oo, n_,  p) == p
+    assert Max(2, x, p, n, -oo, S.NegativeInfinity, n_,  p, 2) == Max(2, x, p)
+    assert Max(0, x, 1, y) == Max(1, x, y)
+    assert Max(x, x + 1, x - 1) == 1 + x
+    assert Max(1000, 100, -100, x, p, n) == Max(p, x, 1000)
+    assert Max(cos(x), sin(x)) == Max(sin(x), cos(x))
+    assert Max(cos(x), sin(x)).subs(x, 1) == sin(1)
+    assert Max(cos(x), sin(x)).subs(x, S(1)/2) == cos(S(1)/2)
+    raises(ValueError, 'Max(cos(x), sin(x)).subs(x, I)')
+    raises(ValueError, 'Max(I)')
+    raises(ValueError, 'Max(I, x)')
+    raises(ValueError, 'Max(S.ComplexInfinity, 1)')
+    # interesting:
+    # Max(n, -oo, n_,  p, 2) == Max(p, 2)
+    # True
+    # Max(n, -oo, n_,  p, 1000) == Max(p, 1000)
+    # False

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -149,8 +149,8 @@ from sympy.functions import (Piecewise, lowergamma, acosh,
         arg, asin, DiracDelta, re, rf, Abs, uppergamma, binomial, sinh, Ylm,
         cos, cot, acos, acot, gamma, bell, hermite, harmonic,
         LambertW, zeta, log, Factorial, asinh, acoth, Zlm,
-        cosh, dirichlet_eta, Eijk, loggamma, erf, Max, ceiling, im, fibonacci,
-        conjugate, tan, chebyshevu_root, floor, atanh, sqrt, Min,
+        cosh, dirichlet_eta, Eijk, loggamma, erf, ceiling, im, fibonacci,
+        conjugate, tan, chebyshevu_root, floor, atanh, sqrt,
         RisingFactorial, sin, atan, ff, FallingFactorial, lucas, atan2,
         polygamma, exp)
 from sympy.core import pi, oo, nan, zoo, E, I
@@ -162,8 +162,8 @@ def test_functions():
             gamma, bell, harmonic, LambertW, zeta, log, Factorial, asinh,
             acoth, cosh, dirichlet_eta, loggamma, erf, ceiling, im, fibonacci,
             conjugate, tan, floor, atanh, sin, atan, lucas, exp)
-    two_var = (rf, ff, lowergamma, chebyshevu, chebyshevt, binomial, Max,
-            Min, atan2, polygamma, hermite, legendre, uppergamma)
+    two_var = (rf, ff, lowergamma, chebyshevu, chebyshevt, binomial,
+            atan2, polygamma, hermite, legendre, uppergamma)
     x, y, z = symbols("x,y,z")
     others = (chebyshevt_root, chebyshevu_root, Eijk(x, y, z),
             Piecewise( (0, x<-1), (x**2, x<=1), (x**3, True)),


### PR DESCRIPTION
When number of arguments is equal one, then
return this argument.

When number of arguments is equal two, then
return, if possible, the value from (a, b) that is >= the other.

In common case, when the length of list greater than 2, the task
is more complicated. Return only the arguments, which are greater
than others, if it is possible to determine directional relation.

See also docstring of the class Max about the algorithm.
