### PR TITLE
make Rational literal regex stronger

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -479,12 +479,11 @@ class Rational(Number):
                     return Rational(p, Pow(10, -expt))
                 except decimal.InvalidOperation:
                     import re
-                    f = re.match(' *([-+]? *[0-9]+)( */ *)([0-9]+)', p)
+                    f = re.match('^([-+]?[0-9]+)/([0-9]+)$', ''.join(p.split()))
                     if f:
-                        p, _, q = f.groups()
-                        return Rational(int(p), int(q))
-                    else:
-                        raise ValueError('invalid literal: %s' % p)
+                        n, d = f.groups()
+                        return Rational(int(n), int(d))
+                    raise ValueError('invalid literal: %s' % p)
             elif not isinstance(p, Basic):
                 return Rational(S(p))
             q = S.One

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -164,7 +164,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
         for r in repeated:
             sym, pre, pre_d, post_d, repetend = r
             zeros = '0'*len(post_d)
-            rep = '%s(%s+%s*1/1%s+%s*1/%s%s)' % (pre, pre_d or '0', post_d or '0', zeros, repetend, '9'*len(repetend), zeros)
+            repetends = repetend.lstrip('0')
+            rep = '%s(%s+%s*1/1%s+%s*1/%s%s)' % (pre, pre_d or '0', post_d or '0', zeros, repetends, '9'*len(repetend), zeros)
             a = a.replace(sym, M, 1)
             reps.append(rep)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -129,6 +129,7 @@ def test_Rational_new():
     assert Rational('.76').limit_denominator(4) == n3_4
     assert Rational(19, 25).limit_denominator(4) == n3_4
     assert Rational('19/25').limit_denominator(4) == n3_4
+    raises(ValueError, "Rational('1/2 + 2/3')")
 
     # handle fractions.Fraction instances
     try:

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -25,6 +25,8 @@ def test_sympify1():
     assert sympify('.[3]') == Rational(1, 3)
     assert sympify('+.[3]') == Rational(1, 3)
     assert sympify('+0.[3]*10**-2') == Rational(1, 300)
+    assert sympify('.[052631578947368421]') == Rational(1, 19)
+    assert sympify('.0[526315789473684210]') == Rational(1, 19)
     # options to make reals into rationals
     assert sympify('1.22[345]', rational=1) == \
            1 + Rational(22, 100) + Rational(345, 99900)


### PR DESCRIPTION
```
The string literal passed to Rational should be nothing more than
space interspersed (perhaps) with a signed literal number or fraction.

The regex was tightened up to check for anything after the expected
literal and a test was added.
```

{Hey Github, I appreciate the pull request upgrade!}
