### PR TITLE
Issue 2125: adding Integer.__index__() method

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -981,6 +981,9 @@ class Integer(Rational):
     def __hash__(self):
         return super(Integer, self).__hash__()
 
+    def __index__(self):
+        return self.p
+
     ########################################
 
     def _eval_is_odd(self):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -170,7 +170,11 @@ def test_relational_noncommutative():
 def test_basic_nostr():
     for obj in basic_objs:
         for op in ['+','-','*','/','**']:
-            raises(TypeError, "obj %s '1'" % op)
+            if obj == 2 and op == '*':
+                if hasattr(int, '__index__'): # Python 2.5+ (PEP 357)
+                    assert obj * '1' == '11'
+            else:
+                raises(TypeError, "obj %s '1'" % op)
 
 def test_leadterm():
     assert (3+2*x**(log(3)/log(2)-1)).leadterm(x) == (3,0)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -397,7 +397,7 @@ def test_dont_accept_str():
 
 def test_int():
     a = Rational(5)
-    assert int(a)==5
+    assert int(a) == 5
     a = Rational(9, 10)
     assert int(a) == int(-a) == 0
     assert 1/(-1)**Rational(2, 3) == -(-1)**Rational(1, 3)
@@ -595,3 +595,7 @@ def test_relational():
     x = pi
     assert (x != cos) is True
     assert (x == cos) is False
+
+def test_Integer_as_index():
+    if hasattr(int, '__index__'): # Python 2.5+ (PEP 357)
+        assert 'hello'[Integer(2):] == 'llo'


### PR DESCRIPTION
Just add an Integer.**index**() method, and test it.

Integer can then be used everywhere python int does.

```
>>> a = Integer(2)
>>> "hello"[a:]
'llo'
```

Discussion is here: http://code.google.com/p/sympy/issues/detail?id=2125
