### PR TITLE
Fix issue 649

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -898,7 +898,9 @@ class Integer(Rational):
             return Integer(-self.p)
 
     def __mod__(self, other):
-        return Integer(self.p % other)
+        if isinstance(other, Integer) or not isinstance(other, Rational):
+            return Integer(self.p % other)
+        return Rational.__mod__(self, other)
 
     def __rmod__(self, other):
         return Integer(other % self.p)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -38,6 +38,7 @@ def test_mod():
     b = Integer(4)
 
     assert type(a % b) == Integer
+    assert Integer(1) % Rational(2, 3) == Rational(1, 3)
 
 def test_divmod():
     assert divmod(S(12), S(8)) == (1, 4)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -75,6 +75,46 @@ def test_sin():
 
     assert sin(r).is_real == True
 
+def test_trig_symmetry():
+    x = Symbol('x')
+    y = Symbol('y')
+    k = Symbol('k', integer=True)
+
+    assert sin(-x) == -sin(x)
+    assert cos(-x) == cos(x)
+    assert tan(-x) == -tan(x)
+    assert cot(-x) == -cot(x)
+    assert sin(x+pi) == -sin(x)
+    assert sin(x+2*pi) == sin(x)
+    assert sin(x+3*pi) == -sin(x)
+    assert sin(x+4*pi) == sin(x)
+    assert sin(x-5*pi) == -sin(x)
+    assert cos(x+pi) == -cos(x)
+    assert cos(x+2*pi) == cos(x)
+    assert cos(x+3*pi) == -cos(x)
+    assert cos(x+4*pi) == cos(x)
+    assert cos(x-5*pi) == -cos(x)
+    assert tan(x+pi) == tan(x)
+    assert tan(x-3*pi) == tan(x)
+    assert cot(x+pi) == cot(x)
+    assert cot(x-3*pi) == cot(x)
+    assert sin(pi/2-x) == cos(x)
+    assert sin(3*pi/2-x) == -cos(x)
+    assert sin(5*pi/2-x) == cos(x)
+    assert cos(pi/2-x) == sin(x)
+    assert cos(3*pi/2-x) == -sin(x)
+    assert cos(5*pi/2-x) == sin(x)
+    assert tan(pi/2-x) == cot(x)
+    assert tan(3*pi/2-x) == cot(x)
+    assert tan(5*pi/2-x) == cot(x)
+    assert cot(pi/2-x) == tan(x)
+    assert cot(3*pi/2-x) == tan(x)
+    assert cot(5*pi/2-x) == tan(x)
+    assert sin(pi/2+x) == cos(x)
+    assert cos(pi/2+x) == -sin(x)
+    assert tan(pi/2+x) == -cot(x)
+    assert cot(pi/2+x) == -tan(x)
+
 
 def test_cos():
     x, y = symbols('xy')

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -3,11 +3,42 @@ from sympy.core.mul import Mul
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.function import Function
+from sympy.core.symbol import Wild
 from miscellaneous import sqrt
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################
 ###############################################################################
+
+def _peeloff_pi(arg):
+    """
+    Split ARG into two parts, a "rest" and a multiple of pi/2.
+    This assumes ARG to be an Add.
+    The multiple of pi returned in the second position is always a Rational.
+
+    Examples:
+    >>> from sympy.functions.elementary.trigonometric import _peeloff_pi as peel
+    >>> from sympy import pi
+    >>> from sympy.abc import x, y
+    >>> peel(x + pi/2)
+    (x, pi/2)
+    >>> peel(x + 2*pi/3 + pi*y)
+    (x + pi/6 + pi*y, pi/2)
+    """
+    for a in Add.make_args(arg):
+        if a is S.Pi:
+            K = S.One
+            break
+        elif a.is_Mul:
+            K, p = a.as_two_terms()
+            if p is S.Pi and K.is_Rational:
+                break
+    else:
+        return arg, 0
+
+    m1 = (K % S.Half) * S.Pi
+    m2 = K*S.Pi - m1
+    return arg - m2, m2
 
 class sin(Function):
     """
@@ -115,8 +146,8 @@ class sin(Function):
                     return result
 
         if arg.is_Add:
-            x, m = arg.as_independent(S.Pi)
-            if m in [-S.Pi, -S.Pi/2, S.Pi/2, S.Pi]:
+            x, m = _peeloff_pi(arg)
+            if m:
                 return sin(m)*cos(x)+cos(m)*sin(x)
 
         if arg.func is asin:
@@ -325,8 +356,8 @@ class cos(Function):
                     return result
 
         if arg.is_Add:
-            x, m = arg.as_independent(S.Pi)
-            if m in [-S.Pi, -S.Pi/2, S.Pi/2, S.Pi]:
+            x, m = _peeloff_pi(arg)
+            if m:
                 return cos(m)*cos(x)-sin(m)*sin(x)
 
         if arg.func is acos:
@@ -509,6 +540,14 @@ class tan(Function):
                 except KeyError:
                     pass
 
+        if arg.is_Add:
+            x, m = _peeloff_pi(arg)
+            if m:
+                if (m*2/S.Pi) % 2 == 0:
+                    return tan(x)
+                else:
+                    return -cot(x)
+
         if arg.func is atan:
             return arg.args[0]
 
@@ -663,6 +702,14 @@ class cot(Function):
                         return result
                 except KeyError:
                     pass
+
+        if arg.is_Add:
+            x, m = _peeloff_pi(arg)
+            if m:
+                if (m*2/S.Pi) % 2 == 0:
+                    return cot(x)
+                else:
+                    return -tan(x)
 
         if arg.func is acot:
             return arg.args[0]


### PR DESCRIPTION
This fixes issue 649. Included is a fix for issue 2255 [new], should I make this a separate pull request?

```
Fix issue 649.

sympy/functions/elementary/trigonometric.py:
  (sin) Remove multiples of pi/2 from argument.
  (cos) Likewise.
  (tan) Likewise.
  (cot) Likewise.

sympy/functions/elementary/tests/test_trigonometric.py
  (test_trig_symmetry) New test, imported from sympycore.
```

Issue 2255:

```
Implement Integer % Rational.

sympy/core/numbers.py
  (Integer.__mod__): Use Rational.__mod__ if other is not integer.

sympy/core/tests/test_numbers.py
  (test_mod): Test this.
```
