### PR TITLE
Issue 2011 : less self-confident simplify

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1093,10 +1093,16 @@ class Matrix(object):
         return Matrix([row.mat for row in reversed(x)])
 
     # Utility functions
-    def simplify(self):
-        """Simplify the elements of a matrix in place."""
+    def simplify(self, ratio=1.7):
+        """Simplify the elements of a matrix in place.
+
+        If (result length)/(input length) > ratio, then input is returned
+        unmodified. If 'ratio=oo', then simplify() is applied anyway.
+
+        See also simplify().
+        """
         for i in xrange(len(self.mat)):
-            self.mat[i] = simplify(self.mat[i])
+            self.mat[i] = simplify(self.mat[i], ratio=ratio)
 
     #def evaluate(self):    # no more eval() so should be removed
     #    for i in range(self.rows):
@@ -1223,10 +1229,14 @@ class Matrix(object):
                     return True
         return False
 
-    def is_symmetric(self):
+    def is_symmetric(self, simplify=True):
         """
         Check if matrix is symmetric matrix,
         that is square matrix and is equal to its transpose.
+
+        By default, simplifications occur before testing symmetry.
+        They can be skipped using 'simplify=False'; while speeding things a bit,
+        this may however induce false negatives.
 
         Example:
 
@@ -1261,12 +1271,23 @@ class Matrix(object):
         >>> m.is_symmetric()
         True
 
+        If the matrix is already simplified, you may speed-up is_symmetric()
+        test by using 'simplify=False'.
+
+        >>> m.is_symmetric(simplify=False)
+        False
+        >>> m1 = m.expand()
+        >>> m1.is_symmetric(simplify=False)
+        True
         """
         if not self.is_square:
             return False
-        delta = self - self.transpose()
-        delta.simplify()
-        return delta == self.zeros((self.rows, self.cols))
+        if simplify:
+            delta = self - self.transpose()
+            delta.simplify()
+            return delta == self.zeros((self.rows, self.cols))
+        else:
+            return self == self.transpose()
 
     def is_diagonal(self):
         """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1264,9 +1264,9 @@ class Matrix(object):
         """
         if not self.is_square:
             return False
-        m = self.clone()
-        m.simplify()
-        return (m == m.transpose())
+        delta = self - self.transpose()
+        delta.simplify()
+        return delta == self.zeros((self.rows, self.cols))
 
     def is_diagonal(self):
         """
@@ -2631,4 +2631,3 @@ def symarray(prefix, shape):
     for index in np.ndindex(shape):
         arr[index] = Symbol('%s_%s' % (prefix, '_'.join(map(str, index))))
     return arr
-

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -874,6 +874,11 @@ def test_simplify():
     M.simplify()
     assert M ==  Matrix([[(x + y)/(x * y),               1 + y           ],
                          [   1 + y,       (2 - 2*cos(pi*n))/(pi*n) ]])
+    M = Matrix([[(1 + x)**2]])
+    M.simplify()
+    assert M == Matrix([[(1 + x)**2]])
+    M.simplify(ratio=oo)
+    assert M == Matrix([[1 + 2*x + x**2]])
 
 def test_transpose():
     M = Matrix([[1,2,3,4,5,6,7,8,9,0],
@@ -1250,6 +1255,7 @@ def test_diagonal_symmetrical():
     m = Matrix(2,2,[0, 1, 1, 0])
     assert not m.is_diagonal()
     assert m.is_symmetric()
+    assert m.is_symmetric(simplify=False)
 
     m = Matrix(2,2,[1, 0, 0, 1])
     assert m.is_diagonal()
@@ -1267,6 +1273,8 @@ def test_diagonal_symmetrical():
     x, y = symbols('x','y')
     m = Matrix(3,3,[1, x**2 + 2*x + 1, y, (x + 1)**2 , 2, 0, y, 0, 3])
     assert m.is_symmetric()
+    assert not m.is_symmetric(simplify=False)
+    assert m.expand().is_symmetric(simplify=False)
 
 
 def test_diagonalization():
@@ -1405,4 +1413,3 @@ def test_SMatrix_transpose():
 def test_SMatrix_CL_RL():
     assert SMatrix((1,2),(3,4)).row_list() == [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
     assert SMatrix((1,2),(3,4)).col_list() == [(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
-

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1578,28 +1578,34 @@ def simplify(expr, ratio=1.7):
        function directly, because those are well defined and thus your algorithm
        will be robust.
 
-       In some cases, applying simplify() may actually result in some more
+       In some cases, applying :func:`simplify` may actually result in some more
        complicated expression.
-       By default 'ratio=1.7' prevents more extreme cases:
+       By default ``ratio=1.7`` prevents more extreme cases:
        if (result length)/(input length) > ratio, then input is returned
-       unmodified (count_ops() is used to measure length).
+       unmodified (:func:`count_ops` is used to measure length).
+
+       ::
 
            >>> from sympy import S, simplify, count_ops, oo
            >>> root = S("(5/2 + 21**(1/2)/2)**(1/3)*(1/2 - I*3**(1/2)/2) \
                         + 1/((1/2 - I*3**(1/2)/2)*(5/2 + 21**(1/2)/2)**(1/3))")
 
-       Since simplify(root) result in a much longer expression, root is returned
-       inchanged instead.
+       Since ``simplify(root)`` results in a much longer expression, root is
+       returned inchanged instead::
+
            >>> simplify(root) is root
            True
 
-       If 'ratio=oo', simplify will be applied anyway.
+       If ``ratio=oo``, simplify will be applied anyway::
+
            >>> count_ops(simplify(root, ratio=oo)) > 1.5*count_ops(root)
            True
-
     """
     if isinstance(expr, Atom):
         return expr
+    # TODO: Apply different strategies, considering expression pattern:
+    # is it a purely rational function? Is there any trigonometric function?...
+    # See also https://github.com/sympy/sympy/pull/185.
 
     original_expr = expr
     expr = together(cancel(powsimp(expr)).expand())

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2,7 +2,7 @@ from sympy import SYMPY_DEBUG
 
 from sympy.core import Basic, S, C, Add, Mul, Pow, Rational, Integer, \
         Derivative, Wild, Symbol, sympify, expand, expand_mul, expand_func, \
-        Function, Equality, Dummy, count_ops
+        Function, Equality, Dummy, Atom, count_ops
 
 from sympy.core.numbers import igcd
 from sympy.core.relational import Equality
@@ -1598,6 +1598,9 @@ def simplify(expr, ratio=1.7):
            True
 
     """
+    if isinstance(expr, Atom):
+        return expr
+
     original_expr = expr
     expr = together(cancel(powsimp(expr)).expand())
     expr = powsimp(expr, combine='exp', deep=True)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -3,7 +3,7 @@ from sympy import Symbol, symbols, together, hypersimp, factorial, binomial, \
         simplify, trigsimp, cos, tan, cot, log, ratsimp, Matrix, pi, integrate, \
         solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative, \
         S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, \
-        separatevars, \
+        separatevars, count_ops, \
         numer, \
         denom, \
         Wild
@@ -149,6 +149,19 @@ def test_simplify():
 
     assert simplify(solutions[y]) == \
         (a*i+c*d+f*g-a*f-c*g-d*i)/(a*e*i+b*f*g+c*d*h-a*f*h-b*d*i-c*e*g)
+
+def test_simplify_ratio():
+    # roots of x**3-3*x+5
+    roots = ['(5/2 + 21**(1/2)/2)**(1/3)*(1/2 - I*3**(1/2)/2)'
+             ' + 1/((1/2 - I*3**(1/2)/2)*(5/2 + 21**(1/2)/2)**(1/3))',
+             '(5/2 + 21**(1/2)/2)**(1/3)*(1/2 + I*3**(1/2)/2)'
+             ' + 1/((1/2 + I*3**(1/2)/2)*(5/2 + 21**(1/2)/2)**(1/3))',
+             '-1/(5/2 + 21**(1/2)/2)**(1/3) - (5/2 + 21**(1/2)/2)**(1/3)']
+    for r in roots:
+        r = S(r)
+        assert count_ops(simplify(r, ratio=1)) <= count_ops(r)
+        # If ratio=oo, simplify() is always applied:
+        assert simplify(r, ratio=oo) is not r
 
 def test_simplify_issue_1308():
     assert simplify(exp(-Rational(1, 2)) + exp(-Rational(3, 2))) == \

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -353,12 +353,13 @@ def test_separable5():
     eq19 = (1 - x)*f(x).diff(x) - x*(f(x) + 1)
     eq20 = f(x)*diff(f(x), x) + x - 3*x*f(x)**2
     eq21 = f(x).diff(x) - exp(x + f(x))
-    sol15 = Eq(f(x), (C1 - exp(x**2/2))*exp(-x**2/2))
-    #sol15 = Eq(f(x), -1 + exp(C1 - x**2/2))
+    #sol15 = Eq(f(x), (C1 - exp(x**2/2))*exp(-x**2/2))
+    sol15 = Eq(f(x), -1 + exp(C1 - x**2/2))
     sol16 = Eq(-exp(-f(x)**2)/2, C1 - x - x**2/2)
     sol17 = Eq(f(x), exp(C1 - x))
     sol18 = Eq(-log(1 - sin(2*f(x))**2)/4, C1 + log(1 - sin(x)**2)/2)
     sol19 = Eq(f(x), -(1 - x - exp(C1 - x))/(1 - x))
+    sol19_bis = Eq(f(x), -1 + exp(C1 - x)/(1 - x))
     sol19_64bit = Eq(f(x), (C1*(1 - x) + x*(-x*exp(x) + exp(x))- exp(x) + x*exp(x))/
                         ((1 - x)*(-x*exp(x) + exp(x))))
     sol19_32bit = Eq(f(x), (C1*(1 - x) - x*(-x*exp(x) + exp(x)) -
@@ -370,6 +371,7 @@ def test_separable5():
     assert dsolve(eq17, f(x), hint='separable') == sol17
     assert dsolve(eq18, f(x), hint='separable') == sol18
     assert dsolve(eq19, f(x), hint='separable') in [sol19,
+                                                    sol19_bis,
                                                     sol19_32bit,
                                                     sol19_64bit]
     assert dsolve(eq20, f(x), hint='separable') == sol20

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -190,7 +190,7 @@ def test_linear_systemLU():
 # Note: multiple solutions exist for some of these equations, so the tests
 # should be expected to break if the implementation of the solver changes
 # in such a way that a different branch is chosen
-def test_tsolve_1():
+def test_tsolve():
     a, b = symbols('ab')
     x, y, z = symbols('xyz')
     assert solve(exp(x)-3, x) == [log(3)]
@@ -227,10 +227,11 @@ def test_tsolve_1():
     assert solve(exp(x)+1, x) == [pi*I]
     assert solve(x**2 - 2**x, x) == [2]
     assert solve(x**3 - 3**x, x) == [-3/log(3)*LambertW(-log(3)/3)]
-    assert solve(2*(3*x+4)**5 - 6*7**(3*x+9), x) in \
-        [[Rational(-4,3) - 5/log(7)/3*LambertW(-7*2**Rational(4,5)*6**Rational(1,5)*log(7)/10)],\
-         [(-5*LambertW(-7*2**(Rational(4, 5))*6**(Rational(1, 5))*log(7)/10) - 4*log(7))/(3*log(7))], \
-         [-((4*log(7) + 5*LambertW(-7*2**Rational(4,5)*6**Rational(1,5)*log(7)/10))/(3*log(7)))]]
+    assert solve(2*(3*x+4)**5 - 6*7**(3*x+9), x) in [
+         [Rational(-4,3) - 5/log(7)/3*LambertW(-7*2**Rational(4,5)*6**Rational(1,5)*log(7)/10)],
+         [(-5*LambertW(-7*2**(Rational(4, 5))*6**(Rational(1, 5))*log(7)/10) - 4*log(7))/(3*log(7))],
+         [-((4*log(7) + 5*LambertW(-7*2**Rational(4, 5)*6**Rational(1, 5)*log(7)/10))/(3*log(7)))],
+         [-((4*log(7) + 5*LambertW(-7*3**Rational(1, 5)*log(7)/5))/(3*log(7)))]]
 
     assert solve(z*cos(x)-y, x)      == [acos(y/z)]
     assert solve(z*cos(2*x)-y, x)    == [acos(y/z)/2]
@@ -244,15 +245,11 @@ def test_tsolve_1():
     # issue #1408
     assert solve(y-b/(1+a*x),x) == [(b - y)/(a*y)]
     # issue #1407
-    assert solve(y-a*x**b , x) == [y**(1/b)*(1/a)**(1/b)]
+    assert solve(y-a*x**b , x) == [(y/a)**(1/b)]
     # issue #1406
     assert solve(z**x - y, x) == [log(y)/log(z)]
     # issue #1405
     assert solve(2**x - 10, x) == [log(10)/log(2)]
-
-def test_tsolve_2():
-    x, y, a, b = symbols('xyab')
-    assert solve(y-a*x**b, x) == [y**(1/b)*(1/a)**(1/b)]
 
 def test_solve_for_functions_derivatives():
     t = Symbol('t')


### PR DESCRIPTION
Simplify() is now less confident: 'ratio' option added (issue 2011).

In some cases, simplify() result may be more complicated than
initial expression.
To prevent most extreme cases, a 'ratio' argument has been added:
if count_ops(result)/count_ops(input) exceeds ratio,
the initial expression is returned instead of the modified expression.

By default, ratio has been set to 1.7 (with a smaller value,
some simplify tests failed).

Some tests where rewritten : new results were obviously better
than previous ones.

Matrix.is_symmetric() has been also improved a bit for all matrices tests to pass.

See also http://code.google.com/p/sympy/issues/detail?id=2011
