### PR TITLE
The fix for this issue is a bit tedious. It would be much simpler

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,6 +1,6 @@
 from sympy import (S, symbols, integrate, Integral, Derivative, exp, oo, Symbol,
         Function, Rational, log, sin, cos, pi, E, I, Poly, LambertW, diff,
-        Matrix, sympify, sqrt, atan, asin, acos, atan, DiracDelta, Heaviside,
+        Matrix, sympify, sqrt, atan, asin, asinh, acos, atan, DiracDelta, Heaviside,
         Lambda, sstr, Add)
 from sympy.utilities.pytest import XFAIL, skip, raises
 from sympy.physics.units import m, s
@@ -534,3 +534,7 @@ def test_series():
     i = Integral(cos(x))
     e = i.lseries(x)
     assert i.nseries(x, n=8).removeO() == Add(*[e.next() for j in range(4)])
+
+def test_issue_1304():
+    z = Symbol('z', positive=True)
+    assert integrate(sqrt(x**2 + z**2),x) == z**2*asinh(x/z)/2 + x*(x**2 + z**2)**(S(1)/2)/2


### PR DESCRIPTION
if the heuristic in risch.py did not make the implicit assumption
that the coefficient in the expression will be an integer. We can
bypass this assumption if the integral is expressed in the form
prescribed by [1]

[1] Number 30 in integral-table.com
