### PR TITLE
(x**x).subs(x, 0) -> nan and sorted([S(0), S(1)]) -> [0, 1]

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -262,17 +262,20 @@ class Basic(AssumeMeths):
         if not isinstance(a, Order) and isinstance(b, Order):
             return -1
 
-        # FIXME this produces wrong ordering for 1 and 0
-        # e.g. the ordering will be 1 0 2 3 4 ...
-        # because 1 = x^0, but 0 2 3 4 ... = x^1
-        from sympy.core.symbol import Wild
-        p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
-        r_a = a.match(p1 * p2**p3)
-        r_b = b.match(p1 * p2**p3)
-        if r_a is not None and r_b is not None:
-            c = Basic.compare(r_a[p3], r_b[p3])
-            if c!=0:
-                return c
+        if a.is_Rational and b.is_Rational:
+            return cmp(a.p*b.q, b.p*a.q)
+        else:
+            from sympy.core.symbol import Wild
+            p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
+            r_a = a.match(p1 * p2**p3)
+            if r_a and p3 in r_a:
+                a3 = r_a[p3]
+                r_b = b.match(p1 * p2**p3)
+                if r_b and p3 in r_b:
+                    b3 = r_b[p3]
+                    c = Basic.compare(a3, b3)
+                    if c != 0:
+                        return c
 
         return Basic.compare(a,b)
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -217,7 +217,7 @@ class Pow(Expr):
                 if pow.is_Integer or self.base.is_commutative:
                     return Pow(new, pow) # (x**(2*y)).subs(x**(3*y),z) -> z**(2/3)
         b, e = self.base._eval_subs(old, new), self.exp._eval_subs(old, new)
-        if not b and e.is_negative: # don't let subs create an infinity
+        if not b and not e.is_positive: # don't let subs create an infinity
             return S.NaN
         return Pow(b, e)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -157,6 +157,9 @@ def test_pow2():
 def test_pow_issue417():
     assert 4**Rational(1, 4) == 2**Rational(1, 2)
 
+def test_pow_issue2260():
+    assert (a**a).subs(a, 0) is S.NaN
+
 def test_pow3():
     assert 2**(Rational(3)/2) == 2 * 2**Rational(1, 2)
     assert 2**(Rational(3)/2) == sqrt(8)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -247,11 +247,11 @@ def roots(f, *gens, **flags):
            >>> from sympy.abc import x, y
 
            >>> roots(x**2 - 1, x)
-           {1: 1, -1: 1}
+           {-1: 1, 1: 1}
 
            >>> p = Poly(x**2-1, x)
            >>> roots(p)
-           {1: 1, -1: 1}
+           {-1: 1, 1: 1}
 
            >>> p = Poly(x**2-y, x, y)
 
@@ -262,7 +262,7 @@ def roots(f, *gens, **flags):
            {y**(1/2): 1, -y**(1/2): 1}
 
            >>> roots([1, 0, -1])
-           {1: 1, -1: 1}
+           {-1: 1, 1: 1}
 
     """
     multiple = flags.get('multiple', False)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2164,7 +2164,7 @@ def _nth_linear_match(eq, func, order):
         >>> _nth_linear_match(f(x).diff(x, 3) + 2*f(x).diff(x) +
         ... x*f(x).diff(x, 2) + cos(x)*f(x).diff(x) + x - f(x) -
         ... sin(x), f(x), 3)
-        {1: 2 + cos(x), 0: -1, -1: x - sin(x), 2: x, 3: 1}
+        {-1: x - sin(x), 0: -1, 1: 2 + cos(x), 2: x, 3: 1}
         >>> _nth_linear_match(f(x).diff(x, 3) + 2*f(x).diff(x) +
         ... x*f(x).diff(x, 2) + cos(x)*f(x).diff(x) + x - f(x) -
         ... sin(f(x)), f(x), 3) == None

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -324,7 +324,7 @@ def sift(expr, keyfunc):
     >>> from sympy import sqrt, exp
 
     >>> sift(range(5), lambda x: x%2)
-    {1: [1, 3], 0: [0, 2, 4]}
+    {0: [0, 2, 4], 1: [1, 3]}
 
     It is possible that some keys are not present, in which case you should
     used dict's .get() method:


### PR DESCRIPTION
```
The disallowing of subs to create 1 from 0**0 (which is what
python incorrectly does) is now enforced. Ideally, 0**0 would
return nan but many errors ensue, including A/A being A**0
for non-commutatives rather than 1.

Making this change made the _compare_pretty routine start to
fail because the match did not always contain the p3 term
so while changing that, a modification was also made to
catch and properly sort Rationals.
```
