### PR TITLE
UndefinedFunction cleanup

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -102,11 +102,12 @@ class Application(Basic):
     @cacheit
     def __new__(cls, *args, **options):
         args = map(sympify, args)
+
         # these lines should be refactored
         for opt in ["nargs", "dummy", "comparable", "noncommutative", "commutative"]:
             if opt in options:
                 del options[opt]
-        # up to here.
+
         if not options.pop('evaluate', True):
             return super(Application, cls).__new__(cls, *args, **options)
         evaluated = cls.eval(*args)
@@ -155,10 +156,9 @@ class Application(Basic):
             return new
         elif old.is_Function and new.is_Function:
             if old == self.func:
-                if self.nargs == new.nargs or not new.nargs:
-                    return new(*self.args)
-                # Written down as an elif to avoid a super-long line
-                elif isinstance(new.nargs, tuple) and self.nargs in new.nargs:
+                nargs = len(self.args)
+                if (nargs == new.nargs or new.nargs is None or
+                        (isinstance(new.nargs, tuple) and nargs in new.nargs)):
                     return new(*self.args)
         return self.func(*[s.subs(old, new) for s in self.args])
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -75,9 +75,7 @@ class UndefinedFunction(FunctionClass):
     The (meta)class of undefined functions.
     """
     def __new__(mcl, name):
-        attrdict = {'undefined_Function': True}
-        bases = (Function,)
-        return BasicMeta.__new__(mcl, name, bases, attrdict)
+        return BasicMeta.__new__(mcl, name, (Function,), {})
 
 class Application(Basic):
     """
@@ -121,8 +119,8 @@ class Application(Basic):
         evaluated = cls.eval(*args)
         if evaluated is not None:
             return evaluated
-        # Just undefined functions have nargs == None
-        if not cls.nargs and hasattr(cls, 'undefined_Function'):
+
+        if isinstance(cls, UndefinedFunction):
             r = super(Application, cls).__new__(cls, *args, **options)
             r.nargs = len(args)
             return r

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -28,7 +28,7 @@ def test_bug1():
     assert e.subs(log(w),-x) == sqrt(5*x)
 
 def test_general_function():
-    nu = Function('nu', nargs=1)
+    nu = Function('nu')
     x = Symbol("x")
     y = Symbol("y")
 
@@ -44,17 +44,10 @@ def test_general_function():
     assert edxdx == diff(diff(nu(x), x), x)
     assert edxdy == 0
 
-def test_function_nargs():
-    f = Function('f')
-    x = Symbol('x')
-    assert f.nargs == None
-    assert f(x).nargs == 1
-    assert f(x, x, x, x).nargs == 4
-
 def test_derivative_subs_bug():
     x = Symbol("x y")
-    l = Function('l', nargs=1)
-    n = Function('n', nargs=1)
+    l = Function('l')
+    n = Function('n')
 
     e = diff(n(x), x)
     assert e.subs(n(x), l(x)) != e
@@ -73,7 +66,7 @@ def test_derivative_subs_self_bug():
 def test_derivative_linearity():
     x = Symbol("x")
     y = Symbol("y")
-    n = Function('n', nargs=1)
+    n = Function('n')
 
     assert diff(-n(x), x) == -diff(n(x), x)
     assert diff(8*n(x), x) == 8*diff(n(x), x)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -135,15 +135,6 @@ class Piecewise(Function):
         if len(non_false_ecpairs) != len(args) or piecewise_again:
             return Piecewise(*non_false_ecpairs)
 
-        # Count number of arguments.
-        nargs = 0
-        for expr, cond in args:
-            if hasattr(expr, 'nargs'):
-                nargs = max(nargs, expr.nargs)
-            elif hasattr(expr, 'args'):
-                nargs = max(nargs, len(expr.args))
-        if nargs:
-            cls.narg = nargs
         return None
 
     def doit(self, **hints):

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -38,7 +38,7 @@ class ReprPrinter(Printer):
         return "Add(%s)"%", ".join(args)
 
     def _print_Function(self, expr):
-        r = '%s(%r)' % (expr.func.__base__.__name__, expr.func.__name__)
+        r = self._print(expr.func)
         r+= '(%s)' % ', '.join([self._print(a) for a in expr.args])
         return r
 


### PR DESCRIPTION
Solves two of the problems reported in issue 2205:
- Identifying "undefined functions" was only possible by setting an `undefinedFunction` attribute and checking for its presence. This should be replaced with `isinstance()`.
- The constructor takes a `signature` argument that is unused.
