### PR TITLE
1170: sorted([S(0), S(1)]) -> [0, 1]

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -268,17 +268,20 @@ class Basic(AssumeMeths):
         if not isinstance(a, Order) and isinstance(b, Order):
             return -1
 
-        # FIXME this produces wrong ordering for 1 and 0
-        # e.g. the ordering will be 1 0 2 3 4 ...
-        # because 1 = x^0, but 0 2 3 4 ... = x^1
-        from sympy.core.symbol import Wild
-        p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
-        r_a = a.match(p1 * p2**p3)
-        r_b = b.match(p1 * p2**p3)
-        if r_a is not None and r_b is not None:
-            c = Basic.compare(r_a[p3], r_b[p3])
-            if c!=0:
-                return c
+        if a.is_Rational and b.is_Rational:
+            return cmp(a.p*b.q, b.p*a.q)
+        else:
+            from sympy.core.symbol import Wild
+            p1, p2, p3 = Wild("p1"), Wild("p2"), Wild("p3")
+            r_a = a.match(p1 * p2**p3)
+            if r_a and p3 in r_a:
+                a3 = r_a[p3]
+                r_b = b.match(p1 * p2**p3)
+                if r_b and p3 in r_b:
+                    b3 = r_b[p3]
+                    c = Basic.compare(a3, b3)
+                    if c != 0:
+                        return c
 
         return Basic.compare(a,b)
 
@@ -302,12 +305,16 @@ class Basic(AssumeMeths):
         Example:
 
         >>> from sympy.abc import x
-        >>> from sympy import Basic
+        >>> from sympy import Basic, Number
         >>> Basic._compare_pretty(x, x**2)
         -1
         >>> Basic._compare_pretty(x**2, x**2)
         0
         >>> Basic._compare_pretty(x**3, x**2)
+        1
+        >>> Basic._compare_pretty(Number(1, 2), Number(1, 3))
+        1
+        >>> Basic._compare_pretty(Number(0), Number(-1))
         1
 
         """

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -297,11 +297,11 @@ def roots(f, *gens, **flags):
     >>> from sympy.abc import x, y
 
     >>> roots(x**2 - 1, x)
-    {1: 1, -1: 1}
+    {-1: 1, 1: 1}
 
     >>> p = Poly(x**2-1, x)
     >>> roots(p)
-    {1: 1, -1: 1}
+    {-1: 1, 1: 1}
 
     >>> p = Poly(x**2-y, x, y)
 
@@ -312,7 +312,7 @@ def roots(f, *gens, **flags):
     {y**(1/2): 1, -y**(1/2): 1}
 
     >>> roots([1, 0, -1])
-    {1: 1, -1: 1}
+    {-1: 1, 1: 1}
 
     """
     flags = dict(flags)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2733,7 +2733,7 @@ class Poly(Expr):
         >>> from sympy.abc import x
 
         >>> Poly(x**6 - 4*x**4 + 4*x**3 - x**2).ground_roots()
-        {1: 2, 0: 2}
+        {0: 2, 1: 2}
 
         """
         if f.is_multivariate:
@@ -4766,7 +4766,7 @@ def ground_roots(f, *gens, **args):
     >>> from sympy.abc import x
 
     >>> ground_roots(x**6 - 4*x**4 + 4*x**3 - x**2)
-    {1: 2, 0: 2}
+    {0: 2, 1: 2}
 
     """
     options.allowed_flags(args, [])

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2181,7 +2181,7 @@ def _nth_linear_match(eq, func, order):
         >>> _nth_linear_match(f(x).diff(x, 3) + 2*f(x).diff(x) +
         ... x*f(x).diff(x, 2) + cos(x)*f(x).diff(x) + x - f(x) -
         ... sin(x), f(x), 3)
-        {1: 2 + cos(x), 0: -1, -1: x - sin(x), 2: x, 3: 1}
+        {-1: x - sin(x), 0: -1, 1: 2 + cos(x), 2: x, 3: 1}
         >>> _nth_linear_match(f(x).diff(x, 3) + 2*f(x).diff(x) +
         ... x*f(x).diff(x, 2) + cos(x)*f(x).diff(x) + x - f(x) -
         ... sin(f(x)), f(x), 3) == None

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -506,7 +506,7 @@ def sift(expr, keyfunc):
     >>> from sympy import sqrt, exp
 
     >>> sift(range(5), lambda x: x%2)
-    {1: [1, 3], 0: [0, 2, 4]}
+    {0: [0, 2, 4], 1: [1, 3]}
 
     It is possible that some keys are not present, in which case you should
     used dict's .get() method:


### PR DESCRIPTION
```
The _compare_pretty routine was modified to consider the
case when p3 may not appear as a key and to properly sort
rationals.
```
