### PR TITLE
Fix issue 1779: series for atan2

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -284,22 +284,26 @@ class Function(Application, Expr):
         return self, S.One
 
     def _eval_nseries(self, x, n):
-        if self.func.nargs != 1:
-            raise NotImplementedError('series for user-defined and \
-multi-arg functions are not supported.')
-        arg = self.args[0]
-        arg0 = arg.limit(x, 0)
+        """
+        This function does compute series for multivariate functions,
+        but the expansion is always in terms of *one* variable.
+        """
+        if self.func.nargs is None:
+            raise NotImplementedError('series for user-defined \
+functions are not supported.')
+        args = self.args
+        args0 = [t.limit(x, 0) for t in args]
         from sympy import oo
-        if arg0 == S.NaN or arg0.is_bounded == False:
-            raise PoleError("Cannot expand %s around 0" % (arg))
-        if arg0:
+        if any([(t == S.NaN) or (t.is_bounded == False) for t in args0]):
+            raise PoleError("Cannot expand %s around 0" % (args))
+        if (self.func.nargs == 1 and args0[0]) or self.func.nargs > 1:
             e = self
             e1 = e.expand()
             if e == e1:
                 #for example when e = sin(x+1) or e = sin(cos(x))
                 #let's try the general algorithm
                 term = e.subs(x, S.Zero)
-                if arg0 == S.NaN or term.is_bounded == False:
+                if term.is_bounded == False:
                     raise PoleError("Cannot expand %s around 0" % (self))
                 series = term
                 fact = S.One
@@ -318,6 +322,7 @@ multi-arg functions are not supported.')
                     series += term
                 return series + C.Order(x**n, x)
             return e1.nseries(x, n=n)
+        arg = self.args[0]
         l = []
         g = None
         for i in xrange(n+2):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -287,6 +287,14 @@ class Function(Application, Expr):
         """
         This function does compute series for multivariate functions,
         but the expansion is always in terms of *one* variable.
+        Examples:
+
+        >>> from sympy import atan2, O
+        >>> from sympy.abc import x, y
+        >>> atan2(x, y).series(x, n=2)
+        atan2(0, y) + x/y + O(x**2)
+        >>> atan2(x, y).series(y, n=2)
+        atan2(x, 0) - y/x + O(y**2)
         """
         if self.func.nargs is None:
             raise NotImplementedError('series for user-defined \

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,8 +1,8 @@
 from sympy import Lambda, Symbol, Function, Derivative, sqrt, \
         log, exp, Rational, Real, sin, cos, acos, diff, I, re, im, \
-        oo, zoo, nan, E, expand, pi, O, Sum, S
+        oo, zoo, nan, E, expand, pi, O, Sum, S, polygamma
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.abc import x, y
+from sympy.abc import x, y, n
 from sympy.core.function import PoleError
 
 def test_f_expand_complex():
@@ -251,6 +251,8 @@ def test_function__eval_nseries():
     assert sin(x+1)._eval_nseries(x,2) == x*cos(1) + sin(1) + O(x**2)
     assert sin(pi*(1-x))._eval_nseries(x,2) == pi*x + O(x**2)
     assert acos(1-x**2)._eval_nseries(x,2) == sqrt(2)*x + O(x**2)
+    assert polygamma(n,x+1)._eval_nseries(x,2) == \
+                   polygamma(n,1) + polygamma(n+1,1)*x + O(x**2)
     raises(PoleError, 'sin(1/x)._eval_nseries(x,2)')
     raises(PoleError, 'acos(1-x)._eval_nseries(x,2)')
     raises(PoleError, 'acos(1+x)._eval_nseries(x,2)')

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1,6 +1,6 @@
 from sympy import symbols, Symbol, nan, oo, I, sinh, sin, acot, pi, atan, \
         acos, Rational, sqrt, asin, acot, cot, coth, E, S, tan, tanh, cos, \
-        cosh, atan2, exp, asinh, acoth, atanh, O
+        cosh, atan2, exp, asinh, acoth, atanh, O, cancel, Matrix
 
 def test_sin():
     x, y = symbols('x,y')
@@ -483,3 +483,15 @@ def test_as_leading_term_issue2173():
     assert acos(x).as_leading_term(x) == x
     assert atan(x).as_leading_term(x) == x
     assert acot(x).as_leading_term(x) == x
+
+def test_atan2_expansion():
+    x, y = symbols("x,y")
+    assert cancel(atan2(x+1,x**2).diff(x) - atan((x+1)/x**2).diff(x)) == 0
+    assert cancel(atan(x/y).series(x, 0, 5) - atan2(x, y).series(x, 0, 5) \
+                  + atan2(0, y) - atan(0)) == O(x**5)
+    assert cancel(atan(x/y).series(y, 1, 4) - atan2(x, y).series(y, 1, 4)  \
+                  + atan2(x, 1) - atan(x)) == O(y**4)
+    assert cancel(atan((x+y)/y).series(y, 1, 3) - atan2(x+y, y).series(y, 1, 3) \
+                  + atan2(1+x, 1) - atan(1+x)) == O(y**3)
+    assert Matrix([atan2(x, y)]).jacobian([x, y]) \
+                  == Matrix([[y/(x**2+y**2), -x/(x**2+y**2)]])

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1173,6 +1173,15 @@ class atan2(Function):
     def _eval_is_real(self):
         return self.args[0].is_real and self.args[1].is_real
 
+    def fdiff(self, argindex):
+        x, y = self.args
+        if argindex == 1:
+            return y/(x**2 + y**2)
+        elif argindex == 2:
+            return -x/(x**2 + y**2)
+        else:
+            raise ArgumentIndexError(self, argindex)
+
     def _sage_(self):
         import sage.all as sage
         return sage.atan2(self.args[0]._sage_(), self.args[1]._sage_())


### PR DESCRIPTION
The first commit extends Function._eval_nseries to multivariate functions.
The second commit adds differentiation of atan2. Combined this yields, series and jacobians for atan2, fixing issue 1779.

All tests still pass.

Changelog:

sympy/core/function.py:
  (_eval_nseries) Allow self.func.nargs > 1, always using the
                  "general algorithm" in this case.

sympy/core/tests/test_functions.py:
  (test_function__eval_nseries) Test multivariate expansion using
                                polygamma.

sympy/functions/elementary/trigonometric.py:
  (atan2.fdiff) New method.

sympy/functions/elementary/tests/test_trigonometric.py:
  (test_atan2_expansion) New test.

sympy/core/function.py:
  (_eval_nseries) Use atan2 for docstring example.
