### PR TITLE
S(srepr(singleton)) == singleton

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -49,6 +49,21 @@ class ReprPrinter(Printer):
         # GeometryEntity is special -- its base is tuple
         return type(expr).__name__ + srepr(tuple(expr))
 
+    def _print_Half(self, expr):
+        return 'Rational(1, 2)'
+
+    def _print_RationalConstant(self, expr):
+        return str(expr)
+
+    def _print_AtomicExpr(self, expr):
+        return str(expr)
+
+    def _print_NumberSymbol(self, expr):
+        return str(expr)
+
+    def _print_Integer(self, expr):
+        return 'Integer(%i)' % expr.p
+
     def _print_list(self, expr):
         return "[%s]"%self.reprify(expr, ", ")
 
@@ -61,16 +76,7 @@ class ReprPrinter(Printer):
         return '%s(%s)' % (expr.__class__.__name__, self._print(l))
 
     def _print_NaN(self, expr):
-        return "S.NaN"
-
-    def _print_Infinity(self, expr):
-        return 'S.Infinity'
-
-    def _print_NegativeInfinity(self, expr):
-        return "S.NegativeInfinity"
-
-    def _print_Integer(self, expr):
-        return 'Integer(%s)' % self._print(expr.p)
+        return "nan"
 
     def _print_Rational(self, expr):
         return 'Rational(%s, %s)' % (self._print(expr.p), self._print(expr.q))

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -10,12 +10,6 @@ x, y = symbols('x,y')
 # environment is the scope of "from sympy import *" for most cases.
 ENV = {}
 exec "from sympy import *" in ENV
-# These classes have to be added separately:
-ENV["Infinity"] = S.Infinity
-ENV["NegativeInfinity"] = S.NegativeInfinity
-ENV["NegativeOne"] = S.NegativeOne
-ENV["One"] = S.One
-ENV["Zero"] = S.Zero
 
 def sT(expr, string):
     """
@@ -50,8 +44,21 @@ def test_Geometry():
     sT(Ellipse(Point(0, 0), 5, 1),  "Ellipse(Point(Integer(0), Integer(0)), Integer(5), Integer(1))")
     # TODO more tests
 
-def test_Infinity():
-    sT(oo, "S.Infinity")
+def test_Singletons():
+    sT(S.Catalan, 'Catalan')
+    sT(S.ComplexInfinity, 'zoo')
+    sT(S.EulerGamma, 'EulerGamma')
+    sT(S.Exp1, 'E')
+    sT(S.GoldenRatio, 'GoldenRatio')
+    sT(S.Half, 'Rational(1, 2)')
+    sT(S.ImaginaryUnit, 'I')
+    sT(S.Infinity, 'oo')
+    sT(S.NaN, 'nan')
+    sT(S.NegativeInfinity, '-oo')
+    sT(S.NegativeOne, 'Integer(-1)')
+    sT(S.One, 'Integer(1)')
+    sT(S.Pi, 'pi')
+    sT(S.Zero, 'Integer(0)')
 
 def test_Integer():
     sT(Integer(4), "Integer(4)")
@@ -64,17 +71,7 @@ def test_Matrix():
        "Matrix([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])")
     sT(Matrix(), "Matrix([])")
 
-def test_NaN():
-    sT(nan, "S.NaN")
-
-def test_NegativeInfinity():
-    sT(-oo, "S.NegativeInfinity")
-
-def test_NegativeOne():
-    sT(-Integer(1), "Integer(-1)")
-
-def test_One():
-    sT(S.One, "Integer(1)")
+    sT(Matrix([[x**+1, 1], [y, x+y]]), "Matrix([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])")
 
 def test_Rational():
     sT(Rational(1,3), "Rational(1, 3)")
@@ -96,9 +93,6 @@ def test_tuple():
 
 def test_WildFunction():
     sT(WildFunction('w'), "WildFunction('w')")
-
-def test_Zero():
-    sT(S.Zero, "Integer(0)")
 
 def test_settins():
     raises(TypeError, 'srepr(x, method="garbage")')

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -199,7 +199,6 @@ def test_geometry():
               Polygon, Polygon(p1,p2,p3,p4), RegularPolygon, RegularPolygon(p1,4,5),
               Triangle, Triangle(p1,p2,p3)):
         check(c, check_attr = False)
-        pass
 
 #================== integrals ====================
 from sympy.integrals.integrals import Integral


### PR DESCRIPTION
```
All singleton objects can now be rebuilt from the srepr-representation.
Previously, for example, srepr(S.Half) -> Half(1, 2) and srepr(S.One) ->
One and neither of those strings could be rebuilt with S(str).

Now, for example, srepr(S.Half) -> Rational(1, 2) and srepr(S.One) ->
Integer(1).
```

see also issue 1348
