### PR TITLE
Fix issue 1715.

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -374,6 +374,12 @@ def mrv_leadterm(e, x, Omega=[]):
     Omega = [t for t in Omega if subexp(e, t)]
     if Omega == []:
         Omega = mrv(e, x)
+    if not Omega:
+        # e really does not depend on x after simplification
+        series = calculate_series(e, x)
+        c0, e0 = series.leadterm(x)
+        assert e0 == 0
+        return c0, e0
     if x in set(Omega):
         #move the whole omega up (exponentiate each term):
         Omega_up = set(moveup(Omega, x))

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, exp, log, oo, Rational, I, sin
+from sympy import Symbol, exp, log, oo, Rational, I, sin, E
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
 from sympy.utilities.pytest import XFAIL, skip
@@ -217,3 +217,6 @@ def test_I():
     assert gruntz(y*I*x, x, oo) == y*I*oo
     assert gruntz(y*3*I*x, x, oo) == y*I*oo
     assert gruntz(y*3*sin(I)*x, x, oo) == y*I*oo
+
+def test_issue1715():
+    assert gruntz((x + 1)**(1/log(x + 1)), x, oo) == E


### PR DESCRIPTION
All tests still pass.

```
 sympy/series/gruntz.py
   (mrv_leadterm) If mrv returns set([]), do not rewrite.
 sympy/series/tests/test_gruntz.py
   (test_issue1715) Add test for the issue that triggered this.
```

Note:
The problem in mrv_leadterm is that the function mrv does more
simplifications, so even though mrv_leadterm may not have concluded
that the expression is independent of x, mrv may, and then return an
empty set. mrv_leadterm needs to handle this.
The example in question is (x + 1)**(1/log(x + 1)), which is actually
constantly E for positive x.
