### PR TITLE
Untitled

### DIFF
--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -2,6 +2,7 @@ from sympy.mpmath import mnorm, mpf
 from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
 from sympy import Symbol, Matrix, sqrt, Eq
+from sympy.utilities.pytest import raises
 
 def test_nsolve():
     # onedimensional
@@ -9,6 +10,9 @@ def test_nsolve():
     x = Symbol('x')
     assert nsolve(sin(x), 2) - pi.evalf() < 1e-16
     assert nsolve(Eq(2*x, 2), x, -10) == nsolve(2*x - 2, -10)
+    # Testing checks on number of inputs
+    raises(TypeError, "nsolve(Eq(2*x,2))")
+    raises(TypeError, "nsolve(Eq(2*x,2),x,1,2)")
     # Issue 1730
     assert nsolve(x**2/(1-x)/(1-2*x)**2-100, x, 0) # doesn't fail
     # multidimensional


### PR DESCRIPTION
I added two tests to test_numeric.py to check that the proper errors are thrown when too many or two few inputs are given.  It increased the reported test coverage 1% for solvers.py.  
