### PR TITLE
Issue 604: write tests for p = x**3+2*x**2+8; r = roots(p, x);

### DIFF
--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -226,9 +226,6 @@ def test_evaluate_false():
     assert Pow(y, 2, evaluate=True) - Pow(y, 2, evaluate=True) == 0
 
 def test_roots_evalf():
-    """Just test that substitution of roots to initial polynomial returns 0
-    (or tiny value according to precision)
-    """
     from sympy.polys import roots
     p = x**3 + 2*x**2 + 8
     r = roots(p, x)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -224,3 +224,18 @@ def test_evaluate_false():
         assert Mul(3, 2, evaluate=no).is_Mul
         assert Pow(3, 2, evaluate=no).is_Pow
     assert Pow(y, 2, evaluate=True) - Pow(y, 2, evaluate=True) == 0
+
+def test_roots_evalf():
+    """Just test that substitution of roots to initial polynomial returns 0
+    (or tiny value according to precision)
+    """
+    from sympy.polys import roots
+    p = x**3 + 2*x**2 + 8
+    r = roots(p, x)
+    for i in r.keys():
+        # test direct substitution
+        assert abs(p.subs(x, i.evalf(20)).evalf(20)) < 1E-20
+        # test Mul._eval_evalf() and Pow._eval_evalf()
+        x1 = Pow(i, 3)._eval_evalf(80)
+        x2 = Mul(2, Pow(i, 2)._eval_evalf(80))._eval_evalf(80)
+        assert abs((x1 + x2 + 8).evalf(20)) < 1E-20


### PR DESCRIPTION
Issue info: http://code.google.com/p/sympy/issues/detail?id=604
First of all I'm not absolutely sure that this is what exactly was needed in this issue. 

I wrote test for  p = x**3+2*x**2+8; r = roots(p, x) with accounting precision. 
I also wrote tests for _eval_evalf() method in Mul and Pow as it suggested here: http://groups.google.com/group/sympy-patches/browse_thread/thread/963d69047c0e0c9c
