### PR TITLE
Updated examples in docstrings for symarray in matrices.py, changed >> to

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2647,15 +2647,9 @@ def symarray(prefix, shape):
 
     Examples
     --------
-    Note: as of 04/09/11 the output of the examples is correct, however the
-    doctests are skipped because they require Numpy to be installed. A way
-    to get the doctests to work even without Numpy installed is discussed in
-    http://code.google.com/p/sympy/issues/detail?id=2252 but is too convoluted
-    and makes the examples hard to read.
-
     >>> from sympy import symarray
-    >>> symarray('', 3) #doctest: +SKIP
-    array([_0, _1, _2], dtype=object)
+    >>> symarray('', 3) #doctest: +SKIP (requires numpy)
+    [_0, _1, _2]
 
     If you want multiple symarrays to contain distinct symbols, you *must*
     provide unique prefixes:
@@ -2671,20 +2665,20 @@ def symarray(prefix, shape):
 
     Creating symarrays with a prefix:
     >>> symarray('a', 3) #doctest: +SKIP
-    array([a_0, a_1, a_2], dtype=object)
+    [a_0, a_1, a_2]
 
     For more than one dimension, the shape must be given as a tuple:
     >>> symarray('a', (2, 3)) #doctest: +SKIP
-    array([[a_0_0, a_0_1, a_0_2],
-           [a_1_0, a_1_1, a_1_2]], dtype=object)
+    [[a_0_0, a_0_1, a_0_2],
+     [a_1_0, a_1_1, a_1_2]]
     >>> symarray('a', (2, 3, 2)) #doctest: +SKIP
-    array([[[a_0_0_0, a_0_0_1],
-            [a_0_1_0, a_0_1_1],
-            [a_0_2_0, a_0_2_1]],
+    [[[a_0_0_0, a_0_0_1],
+      [a_0_1_0, a_0_1_1],
+      [a_0_2_0, a_0_2_1]],
     <BLANKLINE>
-           [[a_1_0_0, a_1_0_1],
-            [a_1_1_0, a_1_1_1],
-            [a_1_2_0, a_1_2_1]]], dtype=object)
+     [[a_1_0_0, a_1_0_1],
+      [a_1_1_0, a_1_1_1],
+      [a_1_2_0, a_1_2_1]]]
 
     """
     try:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2674,10 +2674,10 @@ def symarray(prefix, shape):
     array([a_0, a_1, a_2], dtype=object)
 
     For more than one dimension, the shape must be given as a tuple:
-    >>> symarray('a', (2,3)) #doctest: +SKIP
+    >>> symarray('a', (2, 3)) #doctest: +SKIP
     array([[a_0_0, a_0_1, a_0_2],
            [a_1_0, a_1_1, a_1_2]], dtype=object)
-    >>> symarray('a', (2,3,2)) #doctest: +SKIP
+    >>> symarray('a', (2, 3, 2)) #doctest: +SKIP
     array([[[a_0_0_0, a_0_0_1],
             [a_0_1_0, a_0_1_1],
             [a_0_2_0, a_0_2_1]],

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2647,39 +2647,44 @@ def symarray(prefix, shape):
 
     Examples
     --------
+    Note: as of 04/09/11 the output of the examples is correct, however the
+    doctests are skipped because they require Numpy to be installed. A way
+    to get the doctests to work even without Numpy installed is discussed in
+    http://code.google.com/p/sympy/issues/detail?id=2252 but is too convoluted
+    and makes the examples hard to read.
 
-    >> from sympy import symarray
-    >> symarray('', 3)
-    [_0 _1 _2]
+    >>> from sympy import symarray
+    >>> symarray('', 3) #doctest: +SKIP
+    array([_0, _1, _2], dtype=object)
 
     If you want multiple symarrays to contain distinct symbols, you *must*
     provide unique prefixes:
 
-    >> a = symarray('', 3)
-    >> b = symarray('', 3)
-    >> a[0] is b[0]
+    >>> a = symarray('', 3) #doctest: +SKIP
+    >>> b = symarray('', 3) #doctest: +SKIP
+    >>> a[0] is b[0] #doctest: +SKIP
     True
-    >> a = symarray('a', 3)
-    >> b = symarray('b', 3)
-    >> a[0] is b[0]
+    >>> a = symarray('a', 3) #doctest: +SKIP
+    >>> b = symarray('b', 3) #doctest: +SKIP
+    >>> a[0] is b[0] #doctest: +SKIP
     False
 
     Creating symarrays with a prefix:
-    >> symarray('a', 3)
-    [a_0 a_1 a_2]
+    >>> symarray('a', 3) #doctest: +SKIP
+    array([a_0, a_1, a_2], dtype=object)
 
     For more than one dimension, the shape must be given as a tuple:
-    >> symarray('a', (2,3))
-    [[a_0_0 a_0_1 a_0_2]
-    [a_1_0 a_1_1 a_1_2]]
-    >> symarray('a', (2,3,2))
-    [[[a_0_0_0 a_0_0_1]
-      [a_0_1_0 a_0_1_1]
-      [a_0_2_0 a_0_2_1]]
+    >>> symarray('a', (2,3)) #doctest: +SKIP
+    array([[a_0_0, a_0_1, a_0_2],
+           [a_1_0, a_1_1, a_1_2]], dtype=object)
+    >>> symarray('a', (2,3,2)) #doctest: +SKIP
+    array([[[a_0_0_0, a_0_0_1],
+            [a_0_1_0, a_0_1_1],
+            [a_0_2_0, a_0_2_1]],
     <BLANKLINE>
-     [[a_1_0_0 a_1_0_1]
-      [a_1_1_0 a_1_1_1]
-      [a_1_2_0 a_1_2_1]]]
+           [[a_1_0_0, a_1_0_1],
+            [a_1_1_0, a_1_1_1],
+            [a_1_2_0, a_1_2_1]]], dtype=object)
 
     """
     try:


### PR DESCRIPTION
Updated examples in docstrings for symarray in matrices.py, changed >> to >>>.

The examples will pass under doctest but they are skipped since it symarray
requires numpy to work. Issue 2252 has some discussion on how to get the
examples to work with or without numpy but they are too convoluted and make
the examples hard to read. Since they are examples I consider it is more
important for them to be readable than to pass under doctest on a pure python
env.
