### PR TITLE
Fix issue #880: Matrix.hash vs Matrix.__hash__

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -463,7 +463,7 @@ class Matrix(object):
             return True
 
     def __hash__(self):
-        return super(Matrix, self).__hash__()
+        return self.hash()
 
     def _format_str(self, strfunc, rowsep='\n'):
         # Build table of string representations of the elements

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1217,12 +1217,12 @@ def test_creation_args():
 
 def test_SMatrix_transpose():
     assert SMatrix((1,2),(3,4)).transpose() == SMatrix((1,3),(2,4))
+
 def test_SMatrix_CL_RL():
     assert SMatrix((1,2),(3,4)).row_list() == [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
-    assert SMatrix((1,2),(3,4)).col_list() ==[(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
+    assert SMatrix((1,2),(3,4)).col_list() == [(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
 
 def test_hash():
-    
-  a = Matrix ([[1, 2], [3, 0]])
-  assert hash(a) == a.hash()
+    a = Matrix ([[1, 2],[3, 0]])
+    assert a.hash() == hash(a)
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1221,5 +1221,8 @@ def test_SMatrix_CL_RL():
     assert SMatrix((1,2),(3,4)).row_list() == [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
     assert SMatrix((1,2),(3,4)).col_list() ==[(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
 
-
+def test_hash():
+    
+  a = Matrix ([[1, 2], [3, 0]])
+  assert hash(a) == a.hash()
 


### PR DESCRIPTION
**hash** is now implemented in terms of hash, so they return the same value.
