### PR TITLE
Issue 828: geometry docstrings

### DIFF
--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -18,7 +18,7 @@ class Curve(GeometryEntity):
 
     Parameters
     ----------
-    functions : list of
+    function : list of functions
     limits : 3-tuple
         Function parameter and lower and upper bounds.
 

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -14,7 +14,7 @@ class Curve(GeometryEntity):
     """A curve in space.
 
     A curve is defined by parametric functions for the coordinates, a
-    parameter and the lower and upper bounds for the parametr value.
+    parameter and the lower and upper bounds for the parameter value.
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ class Curve(GeometryEntity):
 
         Returns
         -------
-        functions : list of parametrised coordinate functions.
+        functions : list of parameterized coordinate functions.
 
         Examples
         --------

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -1,45 +1,118 @@
+"""Curves in 2-dimensional Euclidean space.
+
+Contains
+--------
+Curve
+
+"""
+
 from sympy.core import sympify
 from sympy.geometry.exceptions import GeometryError
 from entity import GeometryEntity
 
 class Curve(GeometryEntity):
-    """
-    A curve in space.
+    """A curve in space.
 
-    Example:
-    ========
-        >>> from sympy import sin, cos, Symbol
-        >>> from sympy.abc import t
-        >>> from sympy.geometry import Curve
-        >>> C = Curve([sin(t), cos(t)], (t, 0, 2))
-        >>> C.functions
-        [sin(t), cos(t)]
-        >>> C.limits
-        (t, 0, 2)
-        >>> C.parameter
-        t
+    A curve is defined by parametric functions for the coordinates, a
+    parameter and the lower and upper bounds for the parametr value.
+
+    Parameters
+    ----------
+    functions : list of
+    limits : 3-tuple
+        Function parameter and lower and upper bounds.
+
+    Attributes
+    ----------
+    functions
+    parameter
+    limits
+
+    Raises
+    ------
+    GeometryError
+        When `functions`
+    ValueError
+        When `limits` are specified incorrectly.
+
+
+    Examples
+    --------
+    >>> from sympy import sin, cos, Symbol
+    >>> from sympy.abc import t
+    >>> from sympy.geometry import Curve
+    >>> C = Curve([sin(t), cos(t)], (t, 0, 2))
+    >>> C.functions
+    [sin(t), cos(t)]
+    >>> C.limits
+    (t, 0, 2)
+    >>> C.parameter
+    t
 
     """
 
     def __new__(cls, function, limits):
         fun = sympify(function)
         if not fun:
-            raise GeometryError("%s.__new__ don't know how to handle" % cls.__name__);
+            raise GeometryError("%s.__new__ don't know how to handle" % cls.__name__)
         if not isinstance(limits, (list, tuple)) or len(limits) != 3:
-            raise ValueError("Limits argument has wrong syntax");
+            raise ValueError("Limits argument has wrong syntax")
         return GeometryEntity.__new__(cls, fun, limits)
 
     @property
     def functions(self):
-        """The functions specifying the curve."""
+        """The functions specifying the curve.
+
+        Returns
+        -------
+        functions : list of parametrised coordinate functions.
+
+        Examples
+        --------
+        >>> from sympy.abc import t
+        >>> from sympy.geometry import Curve
+        >>> C = Curve([t, t**2], (t, 0, 2))
+        >>> C.functions
+        [t, t**2]
+
+        """
         return self.__getitem__(0)
 
     @property
     def parameter(self):
-        """The curve function variable."""
+        """The curve function variable.
+
+        Returns
+        -------
+        parameter : sympy symbol
+
+        Examples
+        --------
+        >>> from sympy.abc import t
+        >>> from sympy.geometry import Curve
+        >>> C = Curve([t, t**2], (t, 0, 2))
+        >>> C.parameter
+        t
+
+        """
         return self.__getitem__(1)[0]
 
     @property
     def limits(self):
-        """The limits for the curve."""
+        """The limits for the curve.
+
+        Returns
+        -------
+        limits : tuple
+            Contains parameter and lower and upper limits.
+
+        Examples
+        --------
+        >>> from sympy.abc import t
+        >>> from sympy.geometry import Curve
+        >>> C = Curve([t, t**3], (t, -2, 2))
+        >>> C.limits
+        (t, -2, 2)
+
+        """
         return self.__getitem__(1)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -378,7 +378,7 @@ class Ellipse(GeometryEntity):
         >>> # This will plot an ellipse together with a tangent line.
         >>> from sympy import Point, Ellipse, Plot
         >>> e = Ellipse(Point(0,0), 3, 2)
-        >>> t = e.tangent_line(e.random_point())
+        >>> t = e.tangent_line(e.random_point()) # doctest: +SKIP
         >>> p = Plot() # doctest: +SKIP
         >>> p[0] = e # doctest: +SKIP
         >>> p[1] = t # doctest: +SKIP
@@ -505,13 +505,23 @@ class Ellipse(GeometryEntity):
         See Also
         --------
         Point
+        
+        Note
+        ----
+        A random point may not appear to be on the ellipse, ie, `p in e` may
+        return False. This is because the coordinates of the point will be
+        floating point values, and when these values are substituted into the 
+        equation for the ellipse the result may not be zero because of floating
+        point rounding error.
 
         Examples
         --------
         >>> from sympy import Point, Ellipse
         >>> e1 = Ellipse(Point(0, 0), 3, 2)
         >>> p1 = e1.random_point()
-        >>> p1 in e1
+        >>> # a random point may not appear to be on the ellipse because of
+        >>> # floating point rounding error
+        >>> p1 in e1 # doctest: +SKIP
         True
         >>> p1 # doctest +ELLIPSIS
         Point(...)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -505,12 +505,12 @@ class Ellipse(GeometryEntity):
         See Also
         --------
         Point
-        
+
         Note
         ----
         A random point may not appear to be on the ellipse, ie, `p in e` may
         return False. This is because the coordinates of the point will be
-        floating point values, and when these values are substituted into the 
+        floating point values, and when these values are substituted into the
         equation for the ellipse the result may not be zero because of floating
         point rounding error.
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1,3 +1,12 @@
+"""Elliptical geometrical entities.
+
+Contains
+--------
+Ellipse
+Circle
+
+"""
+
 from sympy.core import S, C, sympify, symbol
 from sympy.simplify import simplify, trigsimp
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -11,43 +20,76 @@ from line import LinearEntity, Line
 from sympy.abc import x
 
 class Ellipse(GeometryEntity):
-    """
-    An ellipse in space. Constructed from a center and two radii, the
-    first being the horizontal radius (along the x-axis) and the second
-    being the vertical radius (along the y-axis).
+    """An elliptical GeometryEntity.
 
-    Notes:
-    ======
-        - Rotation is currently not supported since an ellipse is defined
-          on horizontal/vertical radii
+    Parameters
+    ----------
+    center : Point, optional
+        Default value is Point(0, 0)
+    hradius : number or sympy expression, optional
+    vradius : number or sympy expression, optional
+    eccentricity : number or sympy expression, optional
+        Two of `hradius`, `vradius` and `eccentricity` must be supplied to
+        create an Ellipse. The third is derived from the two supplied.
 
-    Example:
-    ========
-        >>> from sympy.geometry import Ellipse, Point
-        >>> e = Ellipse(Point(0, 0), 5, 1)
-        >>> e.hradius, e.vradius
-        (5, 1)
+    Attributes
+    ----------
+    center
+    hradius
+    vradius
+    area
+    circumference
+    eccentricity
+    periapsis
+    apoapsis
+    focus_distance
+    foci
+
+    Raises
+    ------
+    GeometryError
+        When `hradius`, `vradius` and `eccentricity` are incorrectly supplied as
+        parameters.
+    TypeError
+        When `center` is not a Point.
+
+    See Also
+    --------
+    Point
+
+    Notes
+    -----
+    Constructed from a center and two radii, the first being the horizontal
+    radius (along the x-axis) and the second being the vertical radius (along
+    the y-axis).
+    Rotation is currently not supported since an ellipse is defined
+    on horizontal/vertical radii
+
+    Examples
+    --------
+    >>> from sympy import Ellipse, Point, Rational
+    >>> e1 = Ellipse(Point(0, 0), 5, 1)
+    >>> e1.hradius, e1.vradius
+    (5, 1)
+    >>> e2 = Ellipse(Point(3, 1), hradius=3, eccentricity=Rational(4, 5))
+    >>> e2
+    Ellipse(Point(3, 1), 3, 9/5)
 
     Plotting example
     ----------------
     In [1]: c1 = Circle(Point(0,0), 1)
-
     In [2]: Plot(c1)
     Out[2]: [0]: cos(t), sin(t), 'mode=parametric'
-
     In [3]: p = Plot()
-
     In [4]: p[0] = c1
-
     In [5]: radius = Segment(c1.center, c1.random_point())
-
     In [6]: p[1] = radius
-
     In [7]: p
     Out[7]:
     [0]: cos(t), sin(t), 'mode=parametric'
     [1]: t*cos(1.546086215036205357975518382),
     t*sin(1.546086215036205357975518382), 'mode=parametric'
+
     """
 
     def __new__(cls, center=None, hradius=None, vradius=None, eccentricity=None,
@@ -82,99 +124,265 @@ class Ellipse(GeometryEntity):
 
     @property
     def center(self):
-        """The center of the ellipse."""
+        """The center of the ellipse.
+
+        Returns
+        -------
+        center : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.center
+        Point(0, 0)
+
+        """
         return self.__getitem__(0)
 
     @property
     def hradius(self):
-        """The horizontal radius of the ellipse."""
+        """The horizontal radius of the ellipse.
+
+        Returns
+        -------
+        hradius : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.hradius
+        3
+
+        """
         return self.__getitem__(1)
 
     @property
     def vradius(self):
-        """The vertical radius of the ellipse."""
+        """The vertical radius of the ellipse.
+
+        Returns
+        -------
+        vradius : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.vradius
+        1
+
+        """
         return self.__getitem__(2)
 
     @property
     def area(self):
-        """The area of the ellipse."""
+        """The area of the ellipse.
+
+        Returns
+        -------
+        area : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.area
+        3*pi
+
+        """
         return simplify(S.Pi * self.hradius * self.vradius)
 
     @property
     def circumference(self):
-        """The circumference of the ellipse."""
+        """The circumference of the ellipse.
+
+        Notes
+        -----
+        This property hasn't been implemented.
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.circumference
+        12*Integral(((1 - 8*x**2/9)/(1 - x**2))**(1/2), (x, 0, 1))
+
+        """
         if self.eccentricity == 1:
             return 2*pi*self.hradius
         else:
             return 4 * self.hradius * \
-                   C.Integral(sqrt((1 - (self.eccentricity*x)**2)/(1 - x**2)), \
+                   C.Integral(sqrt((1 - (self.eccentricity*x)**2)/(1 - x**2)),
                               (x, 0, 1))
 
     @property
     def eccentricity(self):
-        """The eccentricity of the ellipse."""
+        """The eccentricity of the ellipse.
 
+        Returns
+        -------
+        eccentricity : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse, sqrt
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, sqrt(2))
+        >>> e1.eccentricity
+        7**(1/2)/3
+
+        """
         return self.focus_distance / self.hradius
 
     @property
     def periapsis(self):
         """The periapsis of the ellipse.
 
-        It's the shortest distance between the focus and the contour."""
+        The shortest distance between the focus and the contour.
 
+        Returns
+        -------
+        periapsis : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.periapsis
+        3 - 2*2**(1/2)
+
+        """
         return self.hradius * (1 - self.eccentricity)
 
     @property
     def apoapsis(self):
         """The periapsis of the ellipse.
 
-        It's the greatest distance between the focus and the contour."""
+        The greatest distance between the focus and the contour.
 
+        Returns
+        -------
+        apoapsis : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.apoapsis
+        3 + 2*2**(1/2)
+
+        """
         return self.hradius * (1 + self.eccentricity)
 
     @property
     def focus_distance(self):
         """The focale distance of the ellipse.
 
-        It's distance between the center and one focus."""
+        The distance between the center and one focus.
 
+        Returns
+        -------
+        focus_distance : number
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.focus_distance
+        2*2**(1/2)
+
+        """
         return Point.distance(self.center, self.foci[0])
 
     @property
     def foci(self):
-        """The foci of the ellipse, if the radii are numerical."""
+        """The foci of the ellipse.
+
+        Notes
+        -----
+        The foci can only be calculated if the radii are numerical.
+
+        Raises
+        ------
+        ValueError
+            When the radii aren't numerical
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> p1 = Point(0, 0)
+        >>> e1 = Ellipse(p1, 3, 1)
+        >>> e1.foci
+        (Point(-2*2**(1/2), 0), Point(2*2**(1/2), 0))
+
+        """
         c = self.center
         if self.hradius == self.vradius:
             return (c, c)
 
         hr, vr = self.hradius, self.vradius
 
-        # calculate focus distance (manually, since focus_distance calls this routine)
+        # calculate focus distance manually, since focus_distance calls this routine
         h = sqrt(abs(vr**2 - hr**2))
         if hr < vr:
-            return (c+Point(0, -h), c+Point(0, h))
+            return (c + Point(0, -h), c + Point(0, h))
         else:
-            return (c+Point(-h, 0), c+Point(h, 0))
+            return (c + Point(-h, 0), c + Point(h, 0))
 
     def tangent_line(self, p):
-        """
-        If p is on the ellipse, returns the tangent line through point p.
-        Otherwise, returns the tangent line(s) from p to the ellipse, or
-        None if no tangent line is possible (e.g., p inside ellipse).
+        """Tangent lines between `p` and the ellipse.
 
-        Example:
+        If `p` is on the ellipse, returns the tangent line through point `p`.
+        Otherwise, returns the tangent line(s) from `p` to the ellipse, or
+        None if no tangent line is possible (e.g., `p` inside ellipse).
 
-        In [1]: e = Ellipse(Point(0,0), 3, 2)
+        Parameters
+        ----------
+        p : Point
 
-        In [2]: t = e.tangent_line(e.random_point())
+        Returns
+        -------
+        tangent_line : Line
 
-        In [3]: p = Plot()
+        Raises
+        ------
+        NotImplementedError
+            Can only find tangent lines for a point, `p`, on the ellipse.
 
-        In [4]: p[0] = e
+        See Also
+        --------
+        Point
+        Line
 
-        In [5]: p[1] = t
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> e1 = Ellipse(Point(0, 0), 3, 2)
+        >>> e1.tangent_line(Point(3, 0))
+        Line(Point(3, 0), Point(3, -12))
 
-        The above will plot an ellipse together with a tangent line.
+        >>> # This will plot an ellipse together with a tangent line.
+        >>> from sympy import Point, Ellipse, Plot
+        >>> e = Ellipse(Point(0,0), 3, 2)
+        >>> t = e.tangent_line(e.random_point())
+        >>> p = Plot() # doctest: +SKIP
+        >>> p[0] = e # doctest: +SKIP
+        >>> p[1] = t # doctest: +SKIP
+
         """
         if p in self:
             rise = (self.vradius ** 2)*(self.center[0] - p[0])
@@ -188,15 +396,42 @@ class Ellipse(GeometryEntity):
             raise NotImplementedError("Cannot find tangent lines when p is not on the ellipse")
 
     def is_tangent(self, o):
-        """Returns True if o is tangent to the ellipse, False otherwise."""
+        """Is `o` tangent to the ellipse?
+
+        Parameters
+        ----------
+        o : GeometryEntity
+            An Ellipse, LinearEntity or Polygon
+
+        Raises
+        ------
+        NotImplementedError
+            When the wrong type of argument is supplied.
+
+        Returns
+        -------
+        is_tangent: boolean
+            True if o is tangent to the ellipse, False otherwise.
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse, Line
+        >>> p0, p1, p2 = Point(0, 0), Point(3, 0), Point(3, 3)
+        >>> e1 = Ellipse(p0, 3, 2)
+        >>> l1 = Line(p1, p2)
+        >>> e1.is_tangent(l1)
+        True
+
+        """
         inter = None
         if isinstance(o, Ellipse):
             inter = self.intersection(o)
-            return (inter is not None and isinstance(inter[0], Point) and len(inter) == 1)
+            return (inter is not None and isinstance(inter[0], Point)
+                    and len(inter) == 1)
         elif isinstance(o, LinearEntity):
             inter = self._do_line_intersection(o)
-            if (inter is not None) and len(inter) == 1:
-                return (inter[0] in o)
+            if inter is not None and len(inter) == 1:
+                return inter[0] in o
             else:
                 return False
         elif isinstance(o, Polygon):
@@ -204,24 +439,84 @@ class Ellipse(GeometryEntity):
             for seg in o.sides:
                 inter = self._do_line_intersection(seg)
                 c += len([True for point in inter if point in seg])
-            return (c == 1)
+            return c == 1
         else:
             raise NotImplementedError("Unknown argument type")
 
     def arbitrary_point(self, parameter_name='t'):
-        """Returns a symbolic point that is on the ellipse."""
+        """A parametric point on the ellipse.
+
+        Parameters
+        ----------
+        parameter_name : str, optional
+            Default value is 't'.
+
+        Returns
+        -------
+        arbitrary_point : Point
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> e1 = Ellipse(Point(0, 0), 3, 2)
+        >>> e1.arbitrary_point()
+        Point(3*cos(t), 2*sin(t))
+
+        """
         t = C.Symbol(parameter_name, real=True)
-        return Point(
-                self.center[0] + self.hradius*C.cos(t),
+        return Point(self.center[0] + self.hradius*C.cos(t),
                 self.center[1] + self.vradius*C.sin(t))
 
     def plot_interval(self, parameter_name='t'):
-        """Returns a typical plot interval used by the plotting module."""
+        """The plot interval for the default geometric plot of the Ellipse.
+
+        Parameters
+        ----------
+        parameter_name : str, optional
+            Default value is 't'.
+
+        Returns
+        -------
+        plot_interval : list
+            [parameter, lower_bound, upper_bound]
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> e1 = Ellipse(Point(0, 0), 3, 2)
+        >>> e1.plot_interval()
+        [t, -pi, pi]
+
+        """
         t = C.Symbol(parameter_name, real=True)
         return [t, -S.Pi, S.Pi]
 
     def random_point(self):
-        """Returns a random point on the ellipse."""
+        """A random point on the ellipse.
+
+        Returns
+        -------
+        point : Point
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> e1 = Ellipse(Point(0, 0), 3, 2)
+        >>> p1 = e1.random_point()
+        >>> p1 in e1
+        True
+        >>> p1 # doctest +ELLIPSIS
+        Point(...)
+
+        """
         from random import random
         t = C.Symbol('t', real=True)
         p = self.arbitrary_point('t')
@@ -230,11 +525,26 @@ class Ellipse(GeometryEntity):
         return Point(p[0].subs(t, subs_val), p[1].subs(t, subs_val))
 
     def equation(self, x='x', y='y'):
-        """
-        Returns the equation of the ellipse.
+        """The equation of the ellipse.
 
-        Optional parameters x and y can be used to specify symbols, or the
-        names of the symbols used in the equation.
+        Parameters
+        ----------
+        x : str, optional
+            Label for the x-axis. Default value is 'x'.
+        y : str, optional
+            Label for the y-axis. Default value is 'y'.
+
+        Returns
+        -------
+        equation : sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse
+        >>> e1 = Ellipse(Point(1, 0), 3, 2)
+        >>> e1.equation()
+        -1 + (1/3 - x/3)**2 + y**2/4
+
         """
         if isinstance(x, basestring):   x = C.Symbol(x, real=True)
         if isinstance(y, basestring):   y = C.Symbol(y, real=True)
@@ -243,11 +553,16 @@ class Ellipse(GeometryEntity):
         return t1 + t2 - 1
 
     def _do_line_intersection(self, o):
-        """
-        Find the intersection of a LinearEntity and the ellipse. Makes no
-        regards to what the LinearEntity is because it assumes a Line. To
-        ensure correct intersection results one must invoke intersection()
-        to remove bad results.
+        """The intersection of a LinearEntity and the ellipse.
+
+        Private helper method for `intersection`.
+
+        Notes
+        -----
+        Makes no regards to what the LinearEntity is because it assumes a
+        Line. To ensure correct intersection results one must invoke
+        `intersection` to remove bad results.
+
         """
         def dot(p1, p2):
             sum = 0
@@ -272,7 +587,7 @@ class Ellipse(GeometryEntity):
         result = []
         if det == 0:
             t = -b / a
-            result.append( lp[0] + (lp[1] - lp[0]) * t )
+            result.append(lp[0] + (lp[1] - lp[0]) * t)
         else:
             is_good = True
             try:
@@ -284,13 +599,15 @@ class Ellipse(GeometryEntity):
                 root = sqrt(det)
                 t_a = (-b - root) / a
                 t_b = (-b + root) / a
-                result.append( lp[0] + (lp[1] - lp[0]) * t_a )
-                result.append( lp[0] + (lp[1] - lp[0]) * t_b )
+                result.append(lp[0] + (lp[1] - lp[0]) * t_a)
+                result.append(lp[0] + (lp[1] - lp[0]) * t_b)
         return result
 
     def _do_circle_intersection(self, o):
-        """
-        Find intersection of an Ellipse and a Circle.
+        """The intersection of an Ellipse and a Circle.
+
+        Private helper methode for `intersection`.
+
         """
         variables = self.equation().atoms(C.Symbol)
         if len(variables) > 2:
@@ -299,7 +616,8 @@ class Ellipse(GeometryEntity):
             a, b, r = o.hradius, o.vradius, self.radius
             x = a*sqrt(simplify((r**2 - b**2)/(a**2 - b**2)))
             y = b*sqrt(simplify((a**2 - r**2)/(a**2 - b**2)))
-            return list(set([Point(x,y), Point(x,-y), Point(-x,y), Point(-x,-y)]))
+            return list(set([Point(x, y), Point(x, -y), Point(-x, y),
+                             Point(-x, -y)]))
         else:
             x, y = variables
             xx = solve(self.equation(), x)
@@ -311,8 +629,10 @@ class Ellipse(GeometryEntity):
             return list(set(intersect))
 
     def _do_ellipse_intersection(self, o):
-        """
-        Find the intersection of two ellipses.
+        """The intersection of two ellipses.
+
+        Private helper method for `intersection`.
+
         """
         seq = self.equation()
         variables = self.equation().atoms(C.Symbol)
@@ -331,36 +651,49 @@ class Ellipse(GeometryEntity):
         raise NotImplementedError("Off-axis Ellipse intersection not supported.")
 
     def intersection(self, o):
-        """
-        Find points than both lie on current ellipse and object 'o'.
-        Currently supported intersections between Ellipse and:
-        Point, Line (including Segment and Ray), Ellipse and Circle.
+        """The intersection of this ellipse and another geometrical entity
+        `o`.
 
-        Example:
-        ========
+        Parameters
+        ----------
+        o : GeometryEntity
+
+        Returns
+        -------
+        intersection : list of GeometryEntities
+
+        Notes
+        -----
+        Currently supports intersections with Point, Line, Segment, Ray,
+        Circle and Ellipse types.
+
+        Example
+        -------
         >>> from sympy import Ellipse, Point, Line, sqrt
         >>> e = Ellipse(Point(0, 0), 5, 7)
-        >>> print e.intersection(Point(0, 0))
+        >>> e.intersection(Point(0, 0))
         []
-        >>> print map(tuple, e.intersection(Point(5, 0)))
-        [(5, 0)]
-        >>> print map(tuple, e.intersection(Line(Point(0,0), Point(0, 1))))
-        [(0, -7), (0, 7)]
-        >>> print map(tuple, e.intersection(Line(Point(5,0), Point(5, 1))))
-        [(5, 0)]
-        >>> print e.intersection(Line(Point(6,0), Point(6, 1)))
+        >>> e.intersection(Point(5, 0))
+        [Point(5, 0)]
+        >>> e.intersection(Line(Point(0,0), Point(0, 1)))
+        [Point(0, -7), Point(0, 7)]
+        >>> e.intersection(Line(Point(5,0), Point(5, 1)))
+        [Point(5, 0)]
+        >>> e.intersection(Line(Point(6,0), Point(6, 1)))
         []
         >>> e = Ellipse(Point(-1, 0), 4, 3)
-        >>> print map(tuple, e.intersection(Ellipse(Point(1, 0), 4, 3)))
-        [(0, -3*15**(1/2)/4), (0, 3*15**(1/2)/4)]
-        >>> print map(tuple, e.intersection(Ellipse(Point(5, 0), 4, 3)))
-        [(2, -3*7**(1/2)/4), (2, 3*7**(1/2)/4)]
-        >>> print map(tuple, e.intersection(Ellipse(Point(100500, 0), 4, 3)))
+        >>> e.intersection(Ellipse(Point(1, 0), 4, 3))
+        [Point(0, -3*15**(1/2)/4), Point(0, 3*15**(1/2)/4)]
+        >>> e.intersection(Ellipse(Point(5, 0), 4, 3))
+        [Point(2, -3*7**(1/2)/4), Point(2, 3*7**(1/2)/4)]
+        >>> e.intersection(Ellipse(Point(100500, 0), 4, 3))
         []
-        >>> print map(tuple, e.intersection(Ellipse(Point(0, 0), 3, 4)))
-        [(-363/175, -48*111**(1/2)/175), (-363/175, 48*111**(1/2)/175), (3, 0)]
-        >>> print map(tuple, e.intersection(Ellipse(Point(-1, 0), 3, 4)))
-        [(-17/5, -12/5), (-17/5, 12/5), (7/5, -12/5), (7/5, 12/5)]
+        >>> e.intersection(Ellipse(Point(0, 0), 3, 4))
+        [Point(-363/175, -48*111**(1/2)/175), Point(-363/175, 48*111**(1/2)/175),
+        Point(3, 0)]
+        >>> e.intersection(Ellipse(Point(-1, 0), 3, 4))
+        [Point(-17/5, -12/5), Point(-17/5, 12/5), Point(7/5, -12/5),
+        Point(7/5, 12/5)]
         """
         if isinstance(o, Point):
             if o in self:
@@ -372,7 +705,7 @@ class Ellipse(GeometryEntity):
             # of intersection for coincidence first
             result = self._do_line_intersection(o)
             if result is not None:
-                for ind in xrange(len(result)-1, -1, -1):
+                for ind in xrange(len(result) - 1, -1, -1):
                     if result[ind] not in o:
                         del result[ind]
             return result
@@ -387,15 +720,33 @@ class Ellipse(GeometryEntity):
         raise NotImplementedError()
 
     def distance_to_center(self, t):
+        """The distance from an point on the ellipse to the center.
 
+        Parameters
+        ----------
+        t : number
+            Parameter in range [0, 2*pi)
+
+        Examples
+        --------
+        >>> from sympy import Point, Ellipse, S
+        >>> e1 = Ellipse(Point(0, 0), 3, 2)
+        >>> # horizontal distance to center
+        >>> e1.distance_to_center(0)
+        3
+        >>> # vertical distance to center
+        >>> e1.distance_to_center(S.Pi/2)
+        2
+
+        """
         seg = Point.distance(self.center, self.arbitrary_point())
 
         return seg.subs('t', t)
 
     def __eq__(self, o):
-        return ((self.center == o.center) \
-                    and (self.hradius == o.hradius) \
-                    and (self.vradius == o.vradius))
+        """Is the other GeometryEntity the same as this ellipse?"""
+        return (self.center == o.center and self.hradius == o.hradius
+                and self.vradius == o.vradius)
 
     def __hash__(self):
         return super(Ellipse, self).__hash__()
@@ -408,24 +759,52 @@ class Ellipse(GeometryEntity):
             res = self.equation(x, y).subs({x: o[0], y: o[1]})
             return trigsimp(simplify(res)) is S.Zero
         elif isinstance(o, Ellipse):
-            return (self == o)
+            return self == o
         return False
 
 
 class Circle(Ellipse):
-    """
-    A circle in space. Constructed simply from a center and a radius, or
-    from three non-collinear points.
+    """A circle in space.
 
-    Example:
-    ========
-        >>> from sympy.geometry import Point, Circle
-        >>> c1 = Circle(Point(0, 0), 5)
-        >>> c1.hradius, c1.vradius, c1.radius
-        (5, 5, 5)
-        >>> c2 = Circle(Point(0, 0), Point(1, 1), Point(1, 0))
-        >>> c2.hradius, c2.vradius, c2.radius, c2.center
-        (2**(1/2)/2, 2**(1/2)/2, 2**(1/2)/2, Point(1/2, 1/2))
+    Constructed simply from a center and a radius, or from three
+    non-collinear points.
+
+    Parameters
+    ----------
+    center : Point
+    radius : number or sympy expression
+    points : sequence of three Points
+
+    Attributes
+    ----------
+    hradius
+    vradius
+    radius
+    circumference
+    equation
+
+    Raises
+    ------
+    GeometryError
+        When trying to construct circle from three collinear points.
+        When trying to construct circle from incorrect parameters.
+
+    See Also
+    --------
+    Point
+
+    Examples
+    --------
+    >>> from sympy.geometry import Point, Circle
+    >>> # a circle constructed from a center and radius
+    >>> c1 = Circle(Point(0, 0), 5)
+    >>> c1.hradius, c1.vradius, c1.radius
+    (5, 5, 5)
+
+    >>> # a circle costructed from three points
+    >>> c2 = Circle(Point(0, 0), Point(1, 1), Point(1, 0))
+    >>> c2.hradius, c2.vradius, c2.radius, c2.center
+    (2**(1/2)/2, 2**(1/2)/2, 2**(1/2)/2, Point(1/2, 1/2))
 
     """
     def __new__(cls, *args, **kwargs):
@@ -449,45 +828,140 @@ class Circle(Ellipse):
 
     @property
     def hradius(self):
-        """The horizontal radius of the ellipse."""
+        """The horizontal radius of the circle.
+
+        Returns
+        -------
+        hradius : number or sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Circle
+        >>> c1 = Circle(Point(3, 4), 6)
+        >>> c1.hradius
+        6
+
+        """
         return self.__getitem__(1)
 
     @property
     def vradius(self):
-        """The vertical radius of the ellipse."""
+        """The vertical radius of the circle.
+
+        Returns
+        -------
+        vradius : number or sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Circle
+        >>> c1 = Circle(Point(3, 4), 6)
+        >>> c1.vradius
+        6
+
+        """
         return self.__getitem__(1)
 
     @property
     def radius(self):
-        """The radius of the circle."""
+        """The radius of the circle.
+
+        Returns
+        -------
+        radius : number or sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Circle
+        >>> c1 = Circle(Point(3, 4), 6)
+        >>> c1.radius
+        6
+
+        """
         return self.__getitem__(1)
 
     @property
     def circumference(self):
-        """The circumference of the circle."""
+        """The circumference of the circle.
+
+        Returns
+        -------
+        circumference : number or sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Circle
+        >>> c1 = Circle(Point(3, 4), 6)
+        >>> c1.circumference
+        12*pi
+
+        """
         return 2 * S.Pi * self.radius
 
     def equation(self, x='x', y='y'):
-        """
-        Returns the equation of the circle.
+        """The equation of the circle.
 
-        Optional parameters x and y can be used to specify symbols, or the
-        names of the symbols used in the equation.
+        Parameters
+        ----------
+        x : str or Symbol, optional
+            Default value is 'x'.
+        y : str or Symbol, optional
+            Default value is 'y'.
+
+        Returns
+        -------
+        equation : sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Circle
+        >>> c1 = Circle(Point(0, 0), 5)
+        >>> c1.equation()
+        -25 + x**2 + y**2
+
         """
-        if isinstance(x, basestring):   x = C.Symbol(x, real=True)
-        if isinstance(y, basestring):   y = C.Symbol(y, real=True)
+        if isinstance(x, basestring):
+            x = C.Symbol(x, real=True)
+        if isinstance(y, basestring):
+            y = C.Symbol(y, real=True)
         t1 = (x - self.center[0])**2
         t2 = (y - self.center[1])**2
         return t1 + t2 - self.hradius**2
 
     def intersection(self, o):
+        """The intersection of this circle with another geometrical entity.
+
+        Parameters
+        ----------
+        o : GeometryEntity
+
+        Returns
+        -------
+        intersection : list of GeometryEntities
+
+        Examples
+        --------
+        >>> from sympy import Point, Circle, Line, Ray
+        >>> p1, p2, p3 = Point(0, 0), Point(5, 5), Point(6, 0)
+        >>> p4 = Point(5, 0)
+        >>> c1 = Circle(p1, 5)
+        >>> c1.intersection(p2)
+        []
+        >>> c1.intersection(p4)
+        [Point(5, 0)]
+        >>> c1.intersection(Ray(p1, p2))
+        [Point(5*2**(1/2)/2, 5*2**(1/2)/2)]
+        >>> c1.intersection(Line(p2, p3))
+        []
+
+        """
         if isinstance(o, Circle):
             if o.center == self.center:
                 if o.radius == self.radius:
                     return o
                 return []
             dx,dy = o.center - self.center
-            d = sqrt( simplify(dy**2 + dx**2) )
+            d = sqrt(simplify(dy**2 + dx**2))
             R = o.radius + self.radius
             if d > R or d < abs(self.radius - o.radius):
                 return []
@@ -497,9 +971,9 @@ class Circle(Ellipse):
             x2 = self.center[0] + (dx * a/d)
             y2 = self.center[1] + (dy * a/d)
 
-            h = sqrt( simplify(self.radius**2 - a**2) )
+            h = sqrt(simplify(self.radius**2 - a**2))
             rx = -dy * (h/d)
-            ry =  dx * (h/d)
+            ry = dx * (h/d)
 
             xi_1 = simplify(x2 + rx)
             xi_2 = simplify(x2 - rx)

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -202,10 +202,6 @@ class Ellipse(GeometryEntity):
     def circumference(self):
         """The circumference of the ellipse.
 
-        Notes
-        -----
-        This property hasn't been implemented.
-
         Examples
         --------
         >>> from sympy import Point, Ellipse

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -1,5 +1,5 @@
 """The definition of the base geometrical entity with attributes common to all
-geometrical entities from which all.
+derived geometrical entities.
 
 Contains
 --------
@@ -71,8 +71,8 @@ class GeometryEntity(tuple):
     def is_similar(self, other):
         """Is this geometrical entity similar to another geometrical entity?
 
-        Two entities are similar if a uniform scaling (enlarging or shrinking)
-        of one of the entities will allow one to obtain the other.
+        Two entities are similar if a uniform scaling (enlarging or
+        shrinking) of one of the entities will allow one to obtain the other.
 
         Notes
         -----
@@ -143,6 +143,7 @@ class GeometryEntity(tuple):
         return tuple(ret)
 
     def __ne__(self, o):
+        """Test inequality of two geometrical entities."""
         return not self.__eq__(o)
 
     def __radd__(self, a):
@@ -158,13 +159,17 @@ class GeometryEntity(tuple):
         return a.__div__(self)
 
     def __str__(self):
+        """String representation of a GeometryEntity."""
         from sympy.printing import sstr
         return type(self).__name__ + sstr(tuple(self))
 
     def __repr__(self):
+        """String representation of a GeometryEntity that can be evaluated
+        by sympy."""
         return type(self).__name__ + repr(tuple(self))
 
     def __cmp__(self, other):
+        """Comparison of two GeometryEntities."""
         n1 = self.__class__.__name__
         n2 = other.__class__.__name__
         c = cmp(n1, n2)

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -1,3 +1,12 @@
+"""The definition of the base geometrical entity with attributes common to all
+geometrical entities from which all.
+
+Contains
+--------
+GeometryEntity
+
+"""
+
 # How entities are ordered; used by __cmp__ in GeometryEntity
 ordering_of_classes = [
     "Point",
@@ -13,7 +22,12 @@ ordering_of_classes = [
 ]
 
 class GeometryEntity(tuple):
-    """The base class for any geometrical entity."""
+    """The base class for all geometrical entities.
+
+    This class doesn't represent any particular geometric entity, it only
+    provides the implementation of some methods common to all subclasses.
+
+    """
 
     def __new__(cls, *args, **kwargs):
         return tuple.__new__(cls, args)
@@ -23,9 +37,24 @@ class GeometryEntity(tuple):
 
     @staticmethod
     def do_intersection(e1, e2):
-        """
-        Determines the intersection between two geometrical entities. Returns
-        a list of all of the intersections.
+        """The intersection of two geometrical entities.
+
+        Parameters
+        ----------
+        e1 : GeometryEntity
+        e2 : GeometryEntity
+
+        Returns
+        -------
+        entities : list
+            A list of GeometryEntity instances.
+
+        Notes
+        -----
+        This method delegates to the `intersection` methods of `e1` and `e2`.
+        First, the `intersection` method of `e1` is called. If this fails to
+        find the intersection, then the `intersection` method of `e2` is called.
+
         """
         try:
             return e1.intersection(e2)
@@ -35,57 +64,65 @@ class GeometryEntity(tuple):
         try:
             return e2.intersection(e1)
         except NotImplementedError:
-            n1,n2 = type(e1).__name__, type(e2).__name__
-            raise NotImplementedError("Unable to determine intersection between '%s' and '%s'" % (n1, n2))
+            n1, n2 = type(e1).__name__, type(e2).__name__
+            msg = "Unable to determine intersection between '%s' and '%s'"
+            raise NotImplementedError(msg % (n1, n2))
 
     def is_similar(self, other):
-        """
-        Return True if self and other are similar. Two entities are similar
-        if a uniform scaling (enlarging or shrinking) of one of the entities
-        will allow one to obtain the other.
+        """Is this geometrical entity similar to another geometrical entity?
 
-        Notes:
-        ======
-            - This method is not intended to be used directly but rather
-              through the are_similar() method found in util.py.
-            - An entity is not required to implement this method.
-            - If two different types of entities can be similar, it is only
-              required that one of them be able to determine this.
+        Two entities are similar if a uniform scaling (enlarging or shrinking)
+        of one of the entities will allow one to obtain the other.
+
+        Notes
+        -----
+        This method is not intended to be used directly but rather
+        through the `are_similar` function found in util.py.
+        An entity is not required to implement this method.
+        If two different types of entities can be similar, it is only
+        required that one of them be able to determine this.
+
         """
         raise NotImplementedError()
 
     def intersection(self, o):
-        """
-        Returns a list of all of the intersections of this entity and another
-        entity.
+        """The intersection of two GeometryEntity instances.
 
-        Notes:
-        ======
-            - This method is not intended to be used directly but rather
-              through the intersection() method found in util.py.
-            - An entity is not required to implement this method.
-            - If two different types of entities can intersect, it is only
-              required that one of them be able to determine this.
+        Notes
+        -----
+        This method is not intended to be used directly but rather
+        through the `intersection` function found in util.py.
+        An entity is not required to implement this method.
+        If two different types of entities can intersect, it is only
+        required that one of them be able to determine this.
+
         """
         raise NotImplementedError()
 
 
     @staticmethod
     def extract_entities(args, remove_duplicates=True):
-        """
-        Takes a set of arguments and extracts all of the GeometryEntity
-        instances (recursively). Returns a tuple of all of the instances
-        found.
+        """Extract all GeometryEntity instances from a sequence of objects.
 
-        Notes:
-        ======
-            - Duplicates of entities are removed if the remove_duplicates
-              argument is set to True, otherwise duplicates remain.
-              The default is True.
-            - Anything that is not a GeometryEntity instance is simply
-              ignored.
-            - Ordering of arguments is always maintained. If duplicates
-              are removed then the entry with the lowest index is kept.
+        Parameters
+        ----------
+        args : a (possibly nested) sequence of objects
+        remove_duplicates : boolean, optional
+            Duplicate entities are removed from the result (default is True).
+
+        Returns
+        -------
+        entities : tuple of GeometryEntity.
+
+        Notes
+        -----
+        The extraction is performed recursively - a GeometryEntity in a
+        sub-sequences will be added to the result.
+        Anything that is not a GeometryEntity instance is excluded from the
+        return value.
+        Ordering of arguments is always maintained. If duplicates
+        are removed then the entry with the lowest index is kept.
+
         """
         ret = list()
         for arg in args:
@@ -96,7 +133,7 @@ class GeometryEntity(tuple):
         if remove_duplicates:
             temp = set(ret)
             ind, n = 0, len(ret)
-            for counter in xrange(0, n):
+            for counter in xrange(n):
                 x = ret[ind]
                 if x in temp:
                     temp.remove(x)
@@ -122,7 +159,7 @@ class GeometryEntity(tuple):
 
     def __str__(self):
         from sympy.printing import sstr
-        return type(self).__name__ + sstr (tuple(self))
+        return type(self).__name__ + sstr(tuple(self))
 
     def __repr__(self):
         return type(self).__name__ + repr(tuple(self))
@@ -131,7 +168,8 @@ class GeometryEntity(tuple):
         n1 = self.__class__.__name__
         n2 = other.__class__.__name__
         c = cmp(n1, n2)
-        if not c: return 0
+        if not c:
+            return 0
 
         i1 = -1
         for cls in self.__class__.__mro__:
@@ -140,7 +178,8 @@ class GeometryEntity(tuple):
                 break
             except ValueError:
                 i1 = -1
-        if i1 == -1: return c
+        if i1 == -1:
+            return c
 
         i2 = -1
         for cls in other.__class__.__mro__:
@@ -149,6 +188,7 @@ class GeometryEntity(tuple):
                 break
             except ValueError:
                 i2 = -1
-        if i2 == -1: return c
+        if i2 == -1:
+            return c
 
         return cmp(i1, i2)

--- a/sympy/geometry/exceptions.py
+++ b/sympy/geometry/exceptions.py
@@ -1,3 +1,5 @@
+"""Geometry Errors."""
+
 class GeometryError(ValueError):
     """An exception raised by classes in the geometry module."""
     pass

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1,3 +1,13 @@
+"""Line-like geometrical entities.
+
+Contains
+--------
+LinearEntity
+Line
+Ray
+Segment
+
+"""
 from sympy.core import S, C
 from sympy.simplify import simplify
 from sympy.geometry.exceptions import GeometryError
@@ -5,14 +15,26 @@ from entity import GeometryEntity
 from point import Point
 
 class LinearEntity(GeometryEntity):
-    """
-    A linear entity (line, ray, segment, etc) in space.
+    """An abstract base class for all linear entities (line, ray and segment)
+    in a 2-dimensional Euclidean space.
 
+    Attributes
+    ----------
+    p1
+    p2
+    coefficients
+    slope
+    points
+
+    Notes
+    -----
     This is an abstract class and is not meant to be instantiated.
     Subclasses should implement the following methods:
         __eq__
         __contains__
+
     """
+
     def __new__(cls, p1, p2, **kwargs):
         if not isinstance(p1, Point) or not isinstance(p2, Point):
             raise TypeError("%s.__new__ requires Point instances" % cls.__name__)
@@ -23,35 +45,102 @@ class LinearEntity(GeometryEntity):
 
     @property
     def p1(self):
-        """One of the defining points of a linear entity."""
+        """The first defining point of a linear entity.
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(5, 3)
+        >>> l = Line(p1, p2)
+        >>> l.p1
+        Point(0, 0)
+
+        """
         return self.__getitem__(0)
 
     @property
     def p2(self):
-        """One of the defining points of a linear entity."""
+        """The second defining point of a linear entity.
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(5, 3)
+        >>> l = Line(p1, p2)
+        >>> l.p2
+        Point(5, 3)
+
+        """
         return self.__getitem__(1)
 
     @property
     def coefficients(self):
-        """The coefficients (a,b,c) for equation ax+by+c=0"""
-        return (self.p1[1]-self.p2[1],
-                self.p2[0]-self.p1[0],
+        """The coefficients (a, b, c) for the linear equation
+        ax + by + c = 0.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> from sympy.abc import x, y
+        >>> p1, p2 = Point(0, 0), Point(5, 3)
+        >>> l = Line(p1, p2)
+        >>> l.coefficients
+        (-3, 5, 0)
+
+        >>> p3 = Point(x, y)
+        >>> l2 = Line(p1, p3)
+        >>> l2.coefficients
+        (-y, x, 0)
+
+        """
+        return (self.p1[1] - self.p2[1], self.p2[0] - self.p1[0],
                 self.p1[0]*self.p2[1] - self.p1[1]*self.p2[0])
 
     def is_concurrent(*lines):
-        """
-        Returns True if the set of linear entities are concurrent, False
-        otherwise. Two or more linear entities are concurrent if they all
+        """Is a sequence of linear entities concurrent?
+
+        Two or more linear entities are concurrent if they all
         intersect at a single point.
 
-        Description of Method Used:
-        ===========================
-            Simply take the first two lines and find their intersection.
-            If there is no intersection, then the first two lines were
-            parallel and had no intersection so concurrency is impossible
-            amongst the whole set. Otherwise, check to see if the
-            intersection point of the first two lines is a member on
-            the rest of the lines. If so, the lines are concurrent.
+        Parameters
+        ----------
+        lines : a sequence of linear entities.
+
+        Returns
+        -------
+        True if the set of linear entities are concurrent, False
+        otherwise.
+
+        Notes
+        -----
+        Simply take the first two lines and find their intersection.
+        If there is no intersection, then the first two lines were
+        parallel and had no intersection so concurrency is impossible
+        amongst the whole set. Otherwise, check to see if the
+        intersection point of the first two lines is a member on
+        the rest of the lines. If so, the lines are concurrent.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(3, 5)
+        >>> p3, p4 = Point(-2, -2), Point(0, 2)
+        >>> l1, l2, l3 = Line(p1, p2), Line(p1, p3), Line(p1, p4)
+        >>> l1.is_concurrent(l2, l3)
+        True
+
+        >>> l4 = Line(p2, p3)
+        >>> l4.is_concurrent(l2, l3)
+        False
+
         """
         _lines = lines
         lines = GeometryEntity.extract_entities(lines)
@@ -75,53 +164,157 @@ class LinearEntity(GeometryEntity):
             return False
 
     def is_parallel(l1, l2):
-        """Returns True if l1 and l2 are parallel, False otherwise"""
+        """Are two linear entities parallel?
+
+        Parameters
+        ----------
+        l1 : LinearEntity
+        l2 : LinearEntity
+
+        Returns
+        -------
+        True if l1 and l2 are parallel, False otherwise.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(1, 1)
+        >>> p3, p4 = Point(3, 4), Point(6, 7)
+        >>> l1, l2 = Line(p1, p2), Line(p3, p4)
+        >>> Line.is_parallel(l1, l2)
+        True
+
+        >>> p5 = Point(6, 6)
+        >>> l3 = Line(p3, p5)
+        >>> Line.is_parallel(l1, l3)
+        False
+
+        """
         try:
-            a1,b1,c1 = l1.coefficients
-            a2,b2,c2 = l2.coefficients
+            a1, b1, c1 = l1.coefficients
+            a2, b2, c2 = l2.coefficients
             return bool(simplify(a1*b2 - b1*a2) == 0)
         except AttributeError:
             return False
 
     def is_perpendicular(l1, l2):
-        """Returns True if l1 and l2 are perpendicular, False otherwise"""
+        """Are two linear entities parallel?
+
+        Parameters
+        ----------
+        l1 : LinearEntity
+        l2 : LinearEntity
+
+        Returns
+        -------
+        True if l1 and l2 are perpendicular, False otherwise.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(-1, 1)
+        >>> l1, l2 = Line(p1, p2), Line(p1, p3)
+        >>> l1.is_perpendicular(l2)
+        True
+
+        >>> p4 = Point(5, 3)
+        >>> l3 = Line(p1, p4)
+        >>> l1.is_perpendicular(l3)
+        False
+
+        """
         try:
-            a1,b1,c1 = l1.coefficients
-            a2,b2,c2 = l2.coefficients
+            a1, b1, c1 = l1.coefficients
+            a2, b2, c2 = l2.coefficients
             return bool(simplify(a1*a2 + b1*b2) == 0)
         except AttributeError:
             return False
 
     def angle_between(l1, l2):
-        """
-        Returns an angle formed between the two linear entities.
+        """The angle formed between the two linear entities.
 
-        Description of Method Used:
-        ===========================
-            From the dot product of vectors v1 and v2 it is known that:
-                dot(v1, v2) = |v1|*|v2|*cos(A)
-            where A is the angle formed between the two vectors. We can
-            get the directional vectors of the two lines and readily
-            find the angle between the two using the above formula.
+        Parameters
+        ----------
+        l1 : LinearEntity
+        l2 : LinearEntity
+
+        Returns
+        -------
+        angle : angle in radians
+
+        Notes
+        -----
+        From the dot product of vectors v1 and v2 it is known that:
+            dot(v1, v2) = |v1|*|v2|*cos(A)
+        where A is the angle formed between the two vectors. We can
+        get the directional vectors of the two lines and readily
+        find the angle between the two using the above formula.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2, p3 = Point(0, 0), Point(0, 4), Point(2, 0)
+        >>> l1, l2 = Line(p1, p2), Line(p1, p3)
+        >>> l1.angle_between(l2)
+        pi/2
+
         """
         v1 = l1.p2 - l1.p1
         v2 = l2.p2 - l2.p1
-        return C.acos( (v1[0]*v2[0]+v1[1]*v2[1]) / (abs(v1)*abs(v2)) )
+        return C.acos((v1[0]*v2[0] + v1[1]*v2[1]) / (abs(v1)*abs(v2)))
 
     def parallel_line(self, p):
-        """
-        Returns a new Line which is parallel to this linear entity and passes
-        through the specified point.
+        """Create a new Line parallel to this linear entity which passes
+        through the point `p`.
+
+        Parameters
+        ----------
+        p : Point
+
+        Returns
+        -------
+        line : Line
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2, p3 = Point(0, 0), Point(2, 3), Point(-2, 2)
+        >>> l1 = Line(p1, p2)
+        >>> l2 = l1.parallel_line(p3)
+        >>> p3 in l2
+        True
+        >>> l1.is_parallel(l2)
+        True
+
         """
         d = self.p1 - self.p2
         return Line(p, p + d)
 
     def perpendicular_line(self, p):
+        """Create a new Line perpendicular to this linear entity which passes
+        through the point `p`.
+
+        Parameters
+        ----------
+        p : Point
+
+        Returns
+        -------
+        line : Line
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2, p3 = Point(0, 0), Point(2, 3), Point(-2, 2)
+        >>> l1 = Line(p1, p2)
+        >>> l2 = l1.perpendicular_line(p3)
+        >>> p3 in l2
+        True
+        >>> l1.is_perpendicular(l2)
+        True
+
         """
-        Returns a new Line which is perpendicular to this linear entity and
-        passes through the specified point.
-        """
-        d1,d2 = self.p1 - self.p2
+        d1, d2 = self.p1 - self.p2
         if d2 == 0: # If an horizontal line
             if p[1] == self.p1[1]: # if p is on this linear entity
                 p2 = Point(p[0], p[1] + 1)
@@ -134,10 +327,31 @@ class LinearEntity(GeometryEntity):
             return Line(p, p2)
 
     def perpendicular_segment(self, p):
-        """
-        Returns a new Segment which connects p to a point on this linear
-        entity and is also perpendicular to this line. Returns p itself
-        if p is on this linear entity.
+        """Create a perpendicular line segment from `p` to this line.
+
+        Parameters
+        ----------
+        p : Point
+
+        Returns
+        -------
+        segment : Segment
+
+        Notes
+        -----
+        Returns `p` itself if `p` is on this linear entity.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(0, 2)
+        >>> l1 = Line(p1, p2)
+        >>> s1 = l1.perpendicular_segment(p3)
+        >>> l1.is_perpendicular(s1)
+        True
+        >>> p3 in s1
+        True
+
         """
         if p in self:
             return p
@@ -147,40 +361,106 @@ class LinearEntity(GeometryEntity):
 
     @property
     def slope(self):
+        """The slope of this linear entity, or infinity if vertical.
+
+        Returns
+        -------
+        slope : number or sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(3, 5)
+        >>> l1 = Line(p1, p2)
+        >>> l1.slope
+        5/3
+
+        >>> p3 = Point(0, 4)
+        >>> l2 = Line(p1, p3)
+        >>> l2.slope
+        oo
+
         """
-        The slope of this linear entity, or infinity if vertical.
-        """
-        d1,d2 = self.p1 - self.p2
+        d1, d2 = self.p1 - self.p2
         if d1 == 0:
             return S.Infinity
         return simplify(d2/d1)
 
     @property
     def points(self):
-        """The two points used to define this linear entity."""
+        """The two points used to define this linear entity.
+
+        Returns
+        -------
+        points : tuple of Points
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(5, 11)
+        >>> l1 = Line(p1, p2)
+        >>> l1.points
+        (Point(0, 0), Point(5, 11))
+
+        """
         return (self.p1, self.p2)
 
     def projection(self, o):
-        """
-        Project a point, line, ray, or segment onto this linear entity.
-        If projection cannot be performed then a GeometryError is raised.
+        """Project a point, line, ray, or segment onto this linear entity.
 
-        Notes:
-        ======
-            - A projection involves taking the two points that define
-              the linear entity and projecting those points onto a
-              Line and then reforming the linear entity using these
-              projections.
-            - A point P is projected onto a line L by finding the point
-              on L that is closest to P. This is done by creating a
-              perpendicular line through P and L and finding its
-              intersection with L.
+        Parameters
+        ----------
+        other : Point or LinearEntity (Line, Ray, Segment)
+
+        Returns
+        -------
+        projection : Point or LinearEntity (Line, Ray, Segment)
+            The return type matches the type of the parameter `other`.
+
+        Raises
+        ------
+        GeometryError
+            When method is unable to perform projection.
+
+        See Also
+        --------
+        Point
+
+        Notes
+        -----
+        A projection involves taking the two points that define
+        the linear entity and projecting those points onto a
+        Line and then reforming the linear entity using these
+        projections.
+        A point P is projected onto a line L by finding the point
+        on L that is closest to P. This is done by creating a
+        perpendicular line through P and L and finding its
+        intersection with L.
+
+        Examples
+        --------
+        >>> from sympy import Point, Line, Segment, Rational
+        >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(Rational(1, 2), 0)
+        >>> l1 = Line(p1, p2)
+        >>> l1.projection(p3)
+        Point(1/4, 1/4)
+
+        >>> p4, p5 = Point(10, 0), Point(12, 1)
+        >>> s1 = Segment(p4, p5)
+        >>> l1.projection(s1)
+        Segment(Point(5, 5), Point(13/2, 13/2))
+
         """
         tline = Line(self.p1, self.p2)
 
         def project(p):
             """Project a point onto the line representing self."""
-            if p in tline: return p
+            if p in tline:
+                return p
             l1 = tline.perpendicular_line(p)
             return tline.intersection(l1)[0]
 
@@ -204,14 +484,43 @@ class LinearEntity(GeometryEntity):
         return GeometryEntity.do_intersection(self, projected)[0]
 
     def intersection(self, o):
+        """The intersection with another geometrical entity.
+
+        Parameters
+        ----------
+        o : Point or LinearEntity
+
+        Returns
+        -------
+        intersection : list of geometrical entities
+
+        Examples
+        --------
+        >>> from sympy import Point, Line, Segment
+        >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(7, 7)
+        >>> l1 = Line(p1, p2)
+        >>> l1.intersection(p3)
+        [Point(7, 7)]
+
+        >>> p4, p5 = Point(5, 0), Point(0, 3)
+        >>> l2 = Line(p4, p5)
+        >>> l1.intersection(l2)
+        [Point(15/8, 15/8)]
+
+        >>> p6, p7 = Point(0, 5), Point(2, 6)
+        >>> s1 = Segment(p6, p7)
+        >>> l1.intersection(s1)
+        []
+
+        """
         if isinstance(o, Point):
             if o in self:
                 return [o]
             else:
                 return []
         elif isinstance(o, LinearEntity):
-            a1,b1,c1 = self.coefficients
-            a2,b2,c2 = o.coefficients
+            a1, b1, c1 = self.coefficients
+            a2, b2, c2 = o.coefficients
             t = simplify(a1*b2 - a2*b1)
             if t == 0: # are parallel?
                 if isinstance(self, Line):
@@ -284,18 +593,41 @@ class LinearEntity(GeometryEntity):
             px = simplify((b1*c2 - c1*b2) / t)
             py = simplify((a2*c1 - a1*c2) / t)
             inter = Point(px, py)
-            if (inter in self) and (inter in o):
+            if inter in self and inter in o:
                 return [inter]
             return []
         raise NotImplementedError()
 
     def random_point(self):
-        """Returns a random point on this Ray."""
+        """A random point on a LinearEntity.
+
+        Returns
+        -------
+        point : Point
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(5, 3)
+        >>> l1 = Line(p1, p2)
+        >>> p3 = l1.random_point()
+        >>> # random point - don't know its coords in advance
+        >>> p3 # doctest: +ELLIPSIS
+        Point(...)
+        >>> # point should belong to the line
+        >>> p3 in l1
+        True
+
+        """
         from random import randint
         from sys import maxint
 
         # The lower and upper
-        lower, upper = -maxint-1, maxint
+        lower, upper = -maxint - 1, maxint
 
         if self.slope is S.Infinity:
             if isinstance(self, Ray):
@@ -319,64 +651,128 @@ class LinearEntity(GeometryEntity):
                 lower = self.p1[0]
                 upper = self.p2[0]
 
-            a,b,c = self.coefficients
+            a, b, c = self.coefficients
             x = randint(lower, upper)
-            y = simplify( (-c - a*x) / b )
+            y = simplify((-c - a*x) / b)
         return Point(x, y)
 
     def __eq__(self, other):
+        """Subclasses should implement this method."""
         raise NotImplementedError()
 
     def __hash__(self):
         return super(LinearEntity, self).__hash__()
 
     def __contains__(self, other):
+        """Subclasses should implement this method."""
         raise NotImplementedError()
 
 
 class Line(LinearEntity):
-    """A line in space.
+    """An infinite line in space.
 
-    A line is declared with two distinct points.
+    Parameters
+    ----------
+    p1 : Point
+    p2 : Point
 
-    Note:
-    At the moment only lines in a 2D space can be declared, because
-    Points can be defined only for 2D spaces.
+    See Also
+    --------
+    Point
 
-    *Example*
+    Examples
+    --------
+    >>> from sympy import Point, Line
+    >>> l = Line(Point(2,3), Point(3,5))
+    >>> l
+    Line(Point(2, 3), Point(3, 5))
+    >>> l.points
+    (Point(2, 3), Point(3, 5))
+    >>> l.equation()
+    1 + y - 2*x
+    >>> l.coefficients
+    (-2, 1, 1)
 
-        >>> import sympy
-        >>> from sympy import Point
-        >>> from sympy.abc import L
-        >>> from sympy.geometry import Line
-        >>> L = Line(Point(2,3), Point(3,5))
-        >>> L
-        Line(Point(2, 3), Point(3, 5))
-        >>> L.points
-        (Point(2, 3), Point(3, 5))
-        >>> L.equation()
-        1 + y - 2*x
-        >>> L.coefficients
-        (-2, 1, 1)
     """
 
     def arbitrary_point(self, parameter_name='t'):
-        """Returns a symbolic point that is on this line."""
+        """A parametrised point on the Line.
+
+        Parameters
+        ----------
+        parameter_name : str, optional
+            The name of the parameter which will be used for the parametric
+            point. The default value is 't'.
+
+        Returns
+        -------
+        point : Point
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(1, 0), Point(5, 3)
+        >>> l1 = Line(p1, p2)
+        >>> l1.arbitrary_point()
+        Point(1 + 4*t, 3*t)
+
+        """
         t = C.Symbol(parameter_name, real=True)
         x = simplify(self.p1[0] + t*(self.p2[0] - self.p1[0]))
         y = simplify(self.p1[1] + t*(self.p2[1] - self.p1[1]))
         return Point(x, y)
 
     def plot_interval(self, parameter_name='t'):
-        """Returns the plot interval for the default geometric plot of line"""
+        """The plot interval for the default geometric plot of line.
+
+        Parameters
+        ----------
+        parameter_name : str, optional
+            Default value is 't'.
+
+        Returns
+        -------
+        plot_interval : list (plot interval)
+            [parameter, lower_bound, upper_bound]
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(0, 0), Point(5, 3)
+        >>> l1 = Line(p1, p2)
+        >>> l1.plot_interval()
+        [t, -5, 5]
+
+        """
         t = C.Symbol(parameter_name, real=True)
         return [t, -5, 5]
 
     def equation(self, xaxis_name='x', yaxis_name='y'):
-        """
-        Returns the equation for this line. Optional parameters xaxis_name
-        and yaxis_name can be used to specify the names of the symbols used
-        for the equation.
+        """The equation of the line: ax + by + c.
+
+        Parameters
+        ----------
+        xaxis_name : str, optional
+            The name to use for the x-axis, default value is 'x'.
+        yaxis_name : str, optional
+            The name to use for the y-axis, default value is 'y'.
+
+        Returns
+        -------
+        equation : sympy expression
+
+        Examples
+        --------
+        >>> from sympy import Point, Line
+        >>> p1, p2 = Point(1, 0), Point(5, 3)
+        >>> l1 = Line(p1, p2)
+        >>> l1.equation()
+        3 - 3*x + 4*y
+
         """
         x = C.Symbol(xaxis_name, real=True)
         y = C.Symbol(yaxis_name, real=True)
@@ -384,7 +780,7 @@ class Line(LinearEntity):
         return simplify(a*x + b*y + c)
 
     def __contains__(self, o):
-        """Return True if o is on this Line, or False otherwise."""
+        """Is `o` on the Line."""
         if isinstance(o, Line):
             return self.__eq__(o)
         elif isinstance(o, Point):
@@ -397,8 +793,9 @@ class Line(LinearEntity):
             return False
 
     def __eq__(self, other):
-        """Return True if other is equal to this Line, or False otherwise."""
-        if not isinstance(other, Line): return False
+        """Is the other Line equal to this Line."""
+        if not isinstance(other, Line):
+            return False
         return Point.is_collinear(self.p1, self.p2, other.p1, other.p2)
 
     def __hash__(self):
@@ -406,51 +803,86 @@ class Line(LinearEntity):
 
 
 class Ray(LinearEntity):
-    """
-    A ray is a semi-line in the space. It starts at one point and
-    propagates in one unique direction.
+    """A Ray is a semi-line in the space with a source point and a direction.
 
-    A ray is declared with two distinct points: the first point is the source,
-    whereas the second point lies on the semi-line. Therefore, the second
-    point determines the direction to which the semi-line propagates.
+    Paramaters
+    ----------
+    p1 : Point
+        The source of the Ray
+    p2 : Point
+        This point determines the direction in which the Ray propagates.
 
-    Note:
+    Attributes
+    ----------
+    source
+    xdirection
+    ydirection
+
+    See Also
+    --------
+    Point
+
+    Notes
+    -----
     At the moment only rays in a 2D space can be declared, because
     Points can be defined only for 2D spaces.
 
-    *Example*
+    Examples
+    --------
+    >>> import sympy
+    >>> from sympy import Point
+    >>> from sympy.abc import r
+    >>> from sympy.geometry import Ray
+    >>> r = Ray(Point(2, 3), Point(3, 5))
+    >>> r = Ray(Point(2, 3), Point(3, 5))
+    >>> r
+    Ray(Point(2, 3), Point(3, 5))
+    >>> r.points
+    (Point(2, 3), Point(3, 5))
+    >>> r.source
+    Point(2, 3)
+    >>> r.xdirection
+    oo
+    >>> r.ydirection
+    oo
+    >>> r.slope
+    2
 
-        >>> import sympy
-        >>> from sympy import Point
-        >>> from sympy.abc import r
-        >>> from sympy.geometry import Ray
-        >>> r = Ray(Point(2, 3), Point(3, 5))
-        >>> r = Ray(Point(2, 3), Point(3, 5))
-        >>> r
-        Ray(Point(2, 3), Point(3, 5))
-        >>> r.points
-        (Point(2, 3), Point(3, 5))
-        >>> r.source
-        Point(2, 3)
-        >>> r.xdirection
-        oo
-        >>> r.ydirection
-        oo
-        >>> r.slope
-        2
     """
 
     @property
     def source(self):
-        """The point from which the ray emanates."""
+        """The point from which the ray emanates.
+
+        Examples
+        --------
+        >>> from sympy import Point, Ray
+        >>> p1, p2 = Point(0, 0), Point(4, 1)
+        >>> r1 = Ray(p1, p2)
+        >>> r1.source
+        Point(0, 0)
+
+        """
         return self.p1
 
     @property
     def xdirection(self):
-        """
-        The x direction of the ray. Positive infinity if the ray points in
-        the positive x direction, negative infinity if the ray points
-        in the negative x direction, or 0 if the ray is vertical.
+        """The x direction of the ray.
+
+        Positive infinity if the ray points in the positive x direction,
+        negative infinity if the ray points in the negative x direction,
+        or 0 if the ray is vertical.
+
+        Examples
+        --------
+        >>> from sympy import Point, Ray
+        >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(0, -1)
+        >>> r1, r2 = Ray(p1, p2), Ray(p1, p3)
+        >>> r1.xdirection
+        oo
+        >>> r2.xdirection
+        0
+
         """
         if self.p1[0] < self.p2[0]:
             return S.Infinity
@@ -461,10 +893,22 @@ class Ray(LinearEntity):
 
     @property
     def ydirection(self):
-        """
-        The y direction of the ray. Positive infinity if the ray points in
-        the positive y direction, negative infinity if the ray points
-        in the negative y direction, or 0 if the ray is horizontal.
+        """The y direction of the ray.
+
+        Positive infinity if the ray points in the positive y direction,
+        negative infinity if the ray points in the negative y direction,
+        or 0 if the ray is horizontal.
+
+        Examples
+        --------
+        >>> from sympy import Point, Ray
+        >>> p1, p2, p3 = Point(0, 0), Point(-1, -1), Point(-1, 0)
+        >>> r1, r2 = Ray(p1, p2), Ray(p1, p3)
+        >>> r1.ydirection
+        -oo
+        >>> r2.ydirection
+        0
+
         """
         if self.p1[1] < self.p2[1]:
             return S.Infinity
@@ -474,27 +918,27 @@ class Ray(LinearEntity):
             return S.NegativeInfinity
 
     def __eq__(self, other):
-        """Return True if other is equal to this Ray, or False otherwise."""
+        """Is the other GeometryEntity equal to this Ray?"""
         if not isinstance(other, Ray):
             return False
-        return ((self.source == other.source) and (other.p2 in self))
+        return (self.source == other.source) and (other.p2 in self)
 
     def __hash__(self):
         return super(Ray, self).__hash__()
 
     def __contains__(self, o):
-        """Return True if o is on this Ray, or False otherwise."""
+        """Is other GeometryEntity contained in this Ray?"""
         if isinstance(o, Ray):
             d = o.p2 - o.p1
-            return Point.is_collinear(self.p1, self.p2, o.p1, o.p2) \
-                    and (self.xdirection == o.xdirection) \
-                    and (self.ydirection == o.ydirection)
+            return (Point.is_collinear(self.p1, self.p2, o.p1, o.p2)
+                    and (self.xdirection == o.xdirection)
+                    and (self.ydirection == o.ydirection))
         elif isinstance(o, Segment):
-            return ((o.p1 in self) and (o.p2 in self))
+            return (o.p1 in self) and (o.p2 in self)
         elif isinstance(o, Point):
             if Point.is_collinear(self.p1, self.p2, o):
-                if (not self.p1[0].has(C.Symbol)) and (not self.p1[1].has(C.Symbol)) \
-                        and (not self.p2[0].has(C.Symbol)) and (not self.p2[1].has(C.Symbol)):
+                if (not self.p1[0].has(C.Symbol) and not self.p1[1].has(C.Symbol)
+                        and not self.p2[0].has(C.Symbol) and not self.p2[1].has(C.Symbol)):
                     if self.xdirection is S.Infinity:
                         return o[0] >= self.source[0]
                     elif self.xdirection is S.NegativeInfinity:
@@ -518,29 +962,43 @@ class Ray(LinearEntity):
 class Segment(LinearEntity):
     """An undirected line segment in space.
 
-    A segment is declared with two distinct points.
+    Parameters
+    ----------
+    p1 : Point
+    p2 : Point
 
-    Note:
+    Attributes
+    ----------
+    length : number or sympy expression
+    midpoint : Point
+
+    See Also
+    --------
+    Point
+
+    Notes
+    -----
     At the moment only segments in a 2D space can be declared, because
     Points can be defined only for 2D spaces.
 
-    *Example*
+    Examples
+    --------
+    >>> import sympy
+    >>> from sympy import Point
+    >>> from sympy.abc import s
+    >>> from sympy.geometry import Segment
+    >>> s = Segment(Point(4, 3), Point(1, 1))
+    >>> s
+    Segment(Point(1, 1), Point(4, 3))
+    >>> s.points
+    (Point(1, 1), Point(4, 3))
+    >>> s.slope
+    2/3
+    >>> s.length
+    13**(1/2)
+    >>> s.midpoint
+    Point(5/2, 2)
 
-        >>> import sympy
-        >>> from sympy import Point
-        >>> from sympy.abc import s
-        >>> from sympy.geometry import Segment
-        >>> s = Segment(Point(4, 3), Point(1, 1))
-        >>> s
-        Segment(Point(1, 1), Point(4, 3))
-        >>> s.points
-        (Point(1, 1), Point(4, 3))
-        >>> s.slope
-        2/3
-        >>> s.length
-        13**(1/2)
-        >>> s.midpoint
-        Point(5/2, 2)
     """
 
     def __new__(cls, p1, p2, **kwargs):
@@ -554,23 +1012,88 @@ class Segment(LinearEntity):
         return LinearEntity.__new__(cls, p1, p2, **kwargs)
 
     def arbitrary_point(self, parameter_name='t'):
-        """Returns a symbolic point that is on this line segment."""
+        """A parametrised point on the Segment.
+
+        Parameters
+        ----------
+        parameter_name : str, optional
+            The name of the parameter which will be used for the parametric
+            point. The default value is 't'.
+
+        Returns
+        -------
+        point : Point
+
+        See Also
+        --------
+        Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Segment
+        >>> p1, p2 = Point(1, 0), Point(5, 3)
+        >>> s1 = Segment(p1, p2)
+        >>> s1.arbitrary_point()
+        Point(1 + 4*t, 3*t)
+
+        """
         t = C.Symbol(parameter_name, real=True)
         x = simplify(self.p1[0] + t*(self.p2[0] - self.p1[0]))
         y = simplify(self.p1[1] + t*(self.p2[1] - self.p1[1]))
         return Point(x, y)
 
     def plot_interval(self, parameter_name='t'):
+        """The plot interval for the default geometric plot of the Segment.
+
+        Parameters
+        ----------
+        parameter_name : str, optional
+            Default value is 't'.
+
+        Returns
+        -------
+        plot_interval : list
+            [parameter, lower_bound, upper_bound]
+
+        Examples
+        --------
+        >>> from sympy import Point, Segment
+        >>> p1, p2 = Point(0, 0), Point(5, 3)
+        >>> s1 = Segment(p1, p2)
+        >>> s1.plot_interval()
+        [t, 0, 1]
+
+        """
         t = C.Symbol(parameter_name, real=True)
         return [t, 0, 1]
 
     def perpendicular_bisector(self, p=None):
-        """
-        Returns the perpendicular bisector of this segment. If no point is
-        specified or the point specified is not on the bisector then the
-        bisector is returned as a Line. Otherwise a Segment is returned
-        that joins the point specified and the intersection of the bisector
-        and the segment.
+        """The perpendicular bisector of this segment.
+
+        If no point is specified or the point specified is not on the
+        bisector then the bisector is returned as a Line. Otherwise a
+        Segment is returned that joins the point specified and the
+        intersection of the bisector and the segment.
+
+        Parameters
+        ----------
+        p : Point
+
+        Returns
+        -------
+        bisector : Line or Segment
+
+        Examples
+        --------
+        >>> from sympy import Point, Segment
+        >>> p1, p2, p3 = Point(0, 0), Point(6, 6), Point(5, 1)
+        >>> s1 = Segment(p1, p2)
+        >>> s1.perpendicular_bisector()
+        Line(Point(3, 3), Point(9, -3))
+
+        >>> s1.perpendicular_bisector(p3)
+        Segment(Point(3, 3), Point(5, 1))
+
         """
         l = LinearEntity.perpendicular_line(self, self.midpoint)
         if p is None or p not in l:
@@ -580,12 +1103,32 @@ class Segment(LinearEntity):
 
     @property
     def length(self):
-        """The length of the segment."""
+        """The length of the line segment.
+
+        Examples
+        --------
+        >>> from sympy import Point, Segment
+        >>> p1, p2 = Point(0, 0), Point(4, 3)
+        >>> s1 = Segment(p1, p2)
+        >>> s1.length
+        5
+
+        """
         return Point.distance(self.p1, self.p2)
 
     @property
     def midpoint(self):
-        """The midpoint of the segment."""
+        """The midpoint of the line segment.
+
+        Examples
+        --------
+        >>> from sympy import Point, Segment
+        >>> p1, p2 = Point(0, 0), Point(4, 3)
+        >>> s1 = Segment(p1, p2)
+        >>> s1.midpoint
+        Point(2, 3/2)
+
+        """
         return Point.midpoint(self.p1, self.p2)
 
     def distance(self, o):
@@ -608,22 +1151,22 @@ class Segment(LinearEntity):
         return distance
 
     def __eq__(self, other):
-        """Return True if other is equal to this Line, or False otherwise."""
+        """Is the other GeometryEntity equal to this Ray?"""
         if not isinstance(other, Segment):
             return False
-        return ((self.p1 == other.p1) and (self.p2 == other.p2))
+        return (self.p1 == other.p1) and (self.p2 == other.p2)
 
     def __hash__(self):
         return super(Segment, self).__hash__()
 
     def __contains__(self, o):
-        """Return True if o is on this Segment, or False otherwise."""
+        """Is the other GeometryEntity contained within this Ray?"""
         if isinstance(o, Segment):
-            return ((o.p1 in self) and (o.p2 in self))
+            return o.p1 in self and o.p2 in self
         elif isinstance(o, Point):
             if Point.is_collinear(self.p1, self.p2, o):
                 d = self.length
-                if (Point.distance(self.p1,o) <= d) and (Point.distance(self.p2,o) <= d):
+                if Point.distance(self.p1,o) <= d and Point.distance(self.p2,o) <= d:
                     return True
 
         # No other known entity can be contained in a Ray

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -1,3 +1,11 @@
+"""Geometrical Points.
+
+Contains
+--------
+Point
+
+"""
+
 from sympy.core import S, sympify
 from sympy.simplify import simplify
 from sympy.geometry.exceptions import GeometryError
@@ -6,21 +14,41 @@ from entity import GeometryEntity
 
 
 class Point(GeometryEntity):
-    """
-    A point in Euclidean N-space defined by a sequence of values. Can be
-    constructed from a sequence of points or a list of points.
+    """A point in a 2-dimensional Euclidean space.
 
-    Examples:
-    ======
-        >>> from sympy.geometry import Point
-        >>> Point(1, 2)
-        Point(1, 2)
-        >>> Point([1, 2])
-        Point(1, 2)
+    Parameters
+    ----------
+    coords : sequence of 2 coordinate values.
 
-    Notes:
-    ======
-        - Currently only 2-dimensional points are supported.
+    Attributes
+    ----------
+    coordinates : 2-tuple of numbers or sympy objects.
+        Stored in `self`. That is self[0] is the first coordinate value, and
+        self[1] is the second coordinate value.
+
+    Raises
+    ------
+    NotImplementedError
+        When trying to create a point with more than two dimensions.
+        When `intersection` is called with object other than a Point.
+    TypeError
+        When trying to add or subtract points with different dimensions.
+
+    Notes
+    -----
+    Currently only 2-dimensional points are supported.
+
+    Examples
+    --------
+    >>> from sympy.geometry import Point
+    >>> from sympy.abc import x
+    >>> Point(1, 2)
+    Point(1, 2)
+    >>> Point([1, 2])
+    Point(1, 2)
+    >>> Point(0, x)
+    Point(0, x)
+
     """
     def __new__(cls, *args, **kwargs):
         if isinstance(args[0], (tuple, list, set)):
@@ -34,38 +62,48 @@ class Point(GeometryEntity):
         return GeometryEntity.__new__(cls, *coords)
 
     def is_collinear(*points):
-        """
+        """Is a sequence of points collinear?
+
         Test whether or not a set of points are collinear. Returns True if
         the set of points are collinear, or False otherwise.
 
-        Examples:
-        =========
-            >>> from sympy import Point
-            >>> from sympy.abc import x
-            >>> p1,p2 = Point(0, 0), Point(1, 1)
-            >>> p3,p4,p5 = Point(2, 2), Point(x, x), Point(1, 2)
-            >>> Point.is_collinear(p1, p2, p3, p4)
-            True
-            >>> Point.is_collinear(p1, p2, p3, p5)
-            False
+        Parameters
+        ----------
+        points : sequence of Point
 
-        Description of method used:
-        ===========================
-            Slope is preserved everywhere on a line, so the slope between
-            any two points on the line should be the same. Take the first
-            two points, p1 and p2, and create a translated point v1
-            with p1 as the origin. Now for every other point we create
-            a translated point, vi with p1 also as the origin. Note that
-            these translations preserve slope since everything is
-            consistently translated to a new origin of p1. Since slope
-            is preserved then we have the following equality:
-                    v1_slope = vi_slope
-              =>    v1.y/v1.x = vi.y/vi.x (due to translation)
-              =>    v1.y*vi.x = vi.y*v1.x
-              =>    v1.y*vi.x - vi.y*v1.x = 0           (*)
-            Hence, if we have a vi such that the equality in (*) is False
-            then the points are not collinear. We do this test for every
-            point in the list, and if all pass then they are collinear.
+        Returns
+        -------
+        is_collinear : boolean
+
+        Notes
+        --------------------------
+        Slope is preserved everywhere on a line, so the slope between
+        any two points on the line should be the same. Take the first
+        two points, p1 and p2, and create a translated point v1
+        with p1 as the origin. Now for every other point we create
+        a translated point, vi with p1 also as the origin. Note that
+        these translations preserve slope since everything is
+        consistently translated to a new origin of p1. Since slope
+        is preserved then we have the following equality:
+                v1_slope = vi_slope
+          =>    v1.y/v1.x = vi.y/vi.x (due to translation)
+          =>    v1.y*vi.x = vi.y*v1.x
+          =>    v1.y*vi.x - vi.y*v1.x = 0           (*)
+        Hence, if we have a vi such that the equality in (*) is False
+        then the points are not collinear. We do this test for every
+        point in the list, and if all pass then they are collinear.
+
+        Examples
+        --------
+        >>> from sympy import Point
+        >>> from sympy.abc import x
+        >>> p1, p2 = Point(0, 0), Point(1, 1)
+        >>> p3, p4, p5 = Point(2, 2), Point(x, x), Point(1, 2)
+        >>> Point.is_collinear(p1, p2, p3, p4)
+        True
+        >>> Point.is_collinear(p1, p2, p3, p5)
+        False
+
         """
         points = GeometryEntity.extract_entities(points)
         if len(points) == 0: return False
@@ -85,36 +123,47 @@ class Point(GeometryEntity):
         return True
 
     def is_concyclic(*points):
-        """
-        Test whether or not a set of points are concyclic (i.e., on the same
-        circle). Returns True if they are concyclic, or False otherwise.
+        """Is a sequence of points concyclic?
 
-        Example:
-        ========
-            >>> from sympy.geometry import Point
-            >>> p1,p2 = Point(-1, 0), Point(1, 0)
-            >>> p3,p4 = Point(0, 1), Point(-1, 2)
-            >>> Point.is_concyclic(p1, p2, p3)
-            True
-            >>> Point.is_concyclic(p1, p2, p3, p4)
-            False
+        Test whether or not a sequence of points are concyclic (i.e., they lie
+        on a circle).
 
-        Description of method used:
-        ===========================
-            No points are not considered to be concyclic. One or two points
-            are definitely concyclic and three points are conyclic iff they
-            are not collinear.
+        Parameters
+        ----------
+        points : sequence of Points
 
-            For more than three points, we pick the first three points and
-            attempt to create a circle. If the circle cannot be created
-            (i.e., they are collinear) then all of the points cannot be
-            concyclic. If the circle is created successfully then simply
-            check all of the other points for containment in the circle.
+        Returns
+        -------
+        is_concyclic : boolean
+            True if points are concyclic, False otherwise.
+
+        Notes
+        -----
+        No points are not considered to be concyclic. One or two points
+        are definitely concyclic and three points are conyclic iff they
+        are not collinear.
+
+        For more than three points, create a circle from the first three
+        points. If the circle cannot be created (i.e., they are collinear)
+        then all of the points cannot be concyclic. If the circle is created
+        successfully then simply check the remaining points for containment
+        in the circle.
+
+        Examples
+        --------
+        >>> from sympy.geometry import Point
+        >>> p1, p2 = Point(-1, 0), Point(1, 0)
+        >>> p3, p4 = Point(0, 1), Point(-1, 2)
+        >>> Point.is_concyclic(p1, p2, p3)
+        True
+        >>> Point.is_concyclic(p1, p2, p3, p4)
+        False
+
         """
         points = GeometryEntity.extract_entities(points)
         if len(points) == 0: return False
         if len(points) <= 2: return True
-        if len(points) == 3: return (not Point.is_collinear(*points))
+        if len(points) == 3: return not Point.is_collinear(*points)
 
         try:
             from ellipse import Circle
@@ -123,7 +172,7 @@ class Point(GeometryEntity):
                 if point not in c:
                     return False
             return True
-        except GeometryError,e:
+        except GeometryError, e:
             # Circle could not be created, because of collinearity of the
             # three points passed in, hence they are not concyclic.
             return False
@@ -152,48 +201,103 @@ class Point(GeometryEntity):
 
     @staticmethod
     def distance(p1, p2):
-        """
-        Get the Euclidean distance between two points.
+        """The Euclidean distance between two points.
 
-        Example:
-        ========
-            >>> from sympy.geometry import Point
-            >>> p1,p2 = Point(1, 1), Point(4, 5)
-            >>> Point.distance(p1, p2)
-            5
+        Parameters
+        ----------
+        p1 : Point
+        p2 : Point
+
+        Returns
+        -------
+        distance : number or symbolic expression.
+
+        Examples
+        --------
+        >>> from sympy.geometry import Point
+        >>> p1, p2 = Point(1, 1), Point(4, 5)
+        >>> Point.distance(p1, p2)
+        5
+
+        >>> from sympy.abc import x, y
+        >>> p3 = Point(x, y)
+        >>> Point.distance(Point(0, 0), p3)
+        (x**2 + y**2)**(1/2)
 
         """
-        return sqrt( sum([(a-b)**2 for a,b in zip(p1,p2)]) )
+        return sqrt(sum([(a - b)**2 for a, b in zip(p1, p2)]))
 
     @staticmethod
     def midpoint(p1, p2):
-        """
-        Get the midpoint of two points.
+        """The midpoint between points p1 and p2.
 
-        Example:
-        ========
-            >>> from sympy.geometry import Point
-            >>> p1,p2 = Point(1, 1), Point(13, 5)
-            >>> Point.midpoint(p1, p2)
-            Point(7, 3)
+        Parameters
+        ----------
+        p1 : Point
+        p2 : Point
+
+        Returns
+        -------
+        midpoint : Point
+
+        Examples
+        --------
+        >>> from sympy.geometry import Point
+        >>> p1, p2 = Point(1, 1), Point(13, 5)
+        >>> Point.midpoint(p1, p2)
+        Point(7, 3)
 
         """
-        return Point( [simplify((a + b)*S.Half) for a,b in zip(p1,p2)] )
+        return Point([simplify((a + b)*S.Half) for a, b in zip(p1, p2)])
 
     def evalf(self):
-        """
-        Evaluate and return a Point where every coordinate is evaluated to
-        a floating point number.
+        """Evaluate the coordinates of the point.
 
-        Example:
-        ========
-            >>> from sympy import Point, Rational
-            >>> Point(Rational(1,2), Rational(3,2)).evalf()
-            Point(0.5, 1.5)
+        This method will, where possible, create and return a new Point
+        where the coordinates are evaluated as floating point numbers.
+
+        Returns
+        -------
+        point : Point
+
+        Examples
+        --------
+        >>> from sympy import Point, Rational
+        >>> p1 = Point(Rational(1, 2), Rational(3, 2))
+        >>> p1
+        Point(1/2, 3/2)
+        >>> p1.evalf()
+        Point(0.5, 1.5)
+
         """
         return Point([x.evalf() for x in self])
 
     def intersection(self, o):
+        """The intersection between this point and another point.
+
+        Parameters
+        ----------
+        other : Point
+
+        Returns
+        -------
+        intersection : list of Points
+
+        Notes
+        -----
+        The return value will either be an empty list if there is no
+        intersection, otherwise it will contain this point.
+
+        Examples
+        --------
+        >>> from sympy import Point
+        >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(0, 0)
+        >>> p1.intersection(p2)
+        []
+        >>> p1.intersection(p3)
+        [Point(0, 0)]
+
+        """
         if isinstance(o, Point):
             if self == o:
                 return [self]
@@ -201,49 +305,36 @@ class Point(GeometryEntity):
         raise NotImplementedError()
 
     def __add__(self, other):
-        """
-        Create a new point where each coordinate in this point is
-        increased by the corresponding coordinate in other.
-        """
+        """Add two points, or add a factor to this point's coordinates."""
         if isinstance(other, Point):
             if len(other) == len(self):
-                return Point( [simplify(a+b) for a,b in zip(self, other)] )
+                return Point([simplify(a + b) for a, b in zip(self, other)])
             else:
                 raise TypeError("Points must have the same number of dimensions")
         else:
             other = sympify(other)
-            return Point( [simplify(a+other) for a in self] )
+            return Point([simplify(a + other) for a in self])
 
     def __sub__(self, other):
-        """
-        Create a new point where each coordinate in this point is
-        decreased by the corresponding coordinate in other.
-        """
+        """Subtract two points, or subtract a factor from this point's
+        coordinates."""
         return self + (-other)
 
     def __mul__(self, factor):
-        """
-        Create a new point where each coordinate in this point is
-        multiplied by factor.
-        """
+        """Multiply point's coordinates by a factor."""
         factor = sympify(factor)
-        return Point( [x*factor for x in self] )
+        return Point([x*factor for x in self])
 
     def __div__(self, divisor):
-        """
-        Create a new point where each coordinate in this point is
-        divided by factor.
-        """
+        """Divide point's coordinates by a factor."""
         divisor = sympify(divisor)
-        return Point( [x/divisor for x in self] )
+        return Point([x/divisor for x in self])
 
     def __neg__(self):
-        """
-        Create a new point where each coordinate in this point is negated.
-        """
-        return Point( [-x for x in self] )
+        """Negate the point."""
+        return Point([-x for x in self])
 
     def __abs__(self):
-        """Returns the distance between this point and the origin."""
+        """The distance from the origin."""
         origin = Point([0] * len(self))
         return Point.distance(origin, self)

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1179,11 +1179,12 @@ class Triangle(Polygon):
         --------
         >>> from sympy import Symbol
         >>> from sympy.geometry import Point, Triangle
-        >>> a = Symbol('a')
+        >>> a = Symbol('a', real=True)
         >>> p1, p2, p3 = Point(0, 0), Point(a, 0), Point(0, a)
         >>> t = Triangle(p1, p2, p3)
-        >>> t.inradius
-        (4*a**2*(a**2)**(1/2) - 2*2**(1/2)*a**2*(a**2)**(1/2))/(8*a**2)
+        >>> # Use expand to simplify the result
+        >>> t.inradius.expand()
+        Abs(a)/2 - 2**(1/2)*Abs(a)/4
 
         """
         return simplify(self.area / self.perimeter)

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1180,11 +1180,11 @@ class Triangle(Polygon):
         >>> from sympy import Symbol
         >>> from sympy.geometry import Point, Triangle
         >>> a = Symbol('a', real=True)
-        >>> p1, p2, p3 = Point(0, 0), Point(a, 0), Point(0, a)
+        >>> p1, p2, p3 = Point(0, 0), Point(4, 0), Point(0, 3)
         >>> t = Triangle(p1, p2, p3)
         >>> # Use expand to simplify the result
-        >>> t.inradius.expand()
-        Abs(a)/2 - 2**(1/2)*Abs(a)/4
+        >>> t.inradius
+        1/2
 
         """
         return simplify(self.area / self.perimeter)

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -1,37 +1,58 @@
+"""Utility functions for geometrical entities.
+
+Contains
+--------
+intersection
+convex_hull
+are_similar
+
+"""
+
 def intersection(*entities):
-    """
-    Finds the intersection between a list GeometryEntity instances. Returns a
-    list of all the intersections, Will raise a NotImplementedError exception
-    if unable to calculate the intersection.
+    """The intersection of a collection of GeometryEntity instances.
 
-    Examples:
-    =========
-        >>> from sympy.geometry import Point, Line, Circle, intersection
-        >>> p1,p2,p3 = Point(0,0), Point(1,1), Point(-1, 5)
-        >>> l1, l2 = Line(p1, p2), Line(p3, p2)
-        >>> c = Circle(p2, 1)
-        >>> intersection(l1, p2)
-        [Point(1, 1)]
-        >>> intersection(l1, l2)
-        [Point(1, 1)]
-        >>> intersection(c, p2)
-        []
-        >>> intersection(c, Point(1, 0))
-        [Point(1, 0)]
-        >>> intersection(c, l2)
-        [Point(1 - 5**(1/2)/5, 1 + 2*5**(1/2)/5), Point(1 + 5**(1/2)/5, 1 - 2*5**(1/2)/5)]
+    Parameters
+    ----------
+    entities : sequence of GeometryEntity
 
-    Notes:
-    ======
-        - The intersection of any geometrical entity with itself should return
-          a list with one item: the entity in question.
-        - An intersection requires two or more entities. If only a single
-          entity is given then one will receive an empty intersection list.
-        - It is possible for intersection() to miss intersections that one
-          knows exists because the required quantities were not fully
-          simplified internally.
-        - Reals should be converted to Rationals, e.g. Rational(str(real_num))
-          or else failures due to floating point issues may result.
+    Returns
+    -------
+    intersection : list of GeometryEntity
+
+    Raises
+    ------
+    NotImplementedError
+        When unable to calculate intersection.
+
+    Notes
+    -----
+    The intersection of any geometrical entity with itself should return
+    a list with one item: the entity in question.
+    An intersection requires two or more entities. If only a single
+    entity is given then the function will return an empty list.
+    It is possible for `intersection` to miss intersections that one
+    knows exists because the required quantities were not fully
+    simplified internally.
+    Reals should be converted to Rationals, e.g. Rational(str(real_num))
+    or else failures due to floating point issues may result.
+
+    Examples
+    --------
+    >>> from sympy.geometry import Point, Line, Circle, intersection
+    >>> p1, p2, p3 = Point(0, 0), Point(1, 1), Point(-1, 5)
+    >>> l1, l2 = Line(p1, p2), Line(p3, p2)
+    >>> c = Circle(p2, 1)
+    >>> intersection(l1, p2)
+    [Point(1, 1)]
+    >>> intersection(l1, l2)
+    [Point(1, 1)]
+    >>> intersection(c, p2)
+    []
+    >>> intersection(c, Point(1, 0))
+    [Point(1, 0)]
+    >>> intersection(c, l2)
+    [Point(1 - 5**(1/2)/5, 1 + 2*5**(1/2)/5), Point(1 + 5**(1/2)/5, 1 - 2*5**(1/2)/5)]
+
     """
     from entity import GeometryEntity
 
@@ -43,29 +64,41 @@ def intersection(*entities):
     for entity in entities[2:]:
         newres = []
         for x in res:
-            newres.extend( GeometryEntity.do_intersection(x, entity) )
+            newres.extend(GeometryEntity.do_intersection(x, entity))
         res = newres
     return res
 
 
 def convex_hull(*args):
-    """
-    Returns a Polygon representing the convex hull of a set of 2D points.
+    """The convex hull of a collection of 2-dimensional points.
 
-    Notes:
-    ======
-        This can only be performed on a set of non-symbolic points.
+    Parameters
+    ----------
+    args : a collection of Points
 
-    Example:
-    ========
-        >>> from sympy.geometry import Point, convex_hull
-        >>> points = [ Point(x) for x in [(1,1), (1,2), (3,1), (-5,2), (15,4)] ]
-        >>> convex_hull(points)
-        Polygon(Point(-5, 2), Point(1, 1), Point(3, 1), Point(15, 4))
+    Returns
+    -------
+    convex_hull : Polygon
 
-    Description of method used:
-    ===========================
-        See http://en.wikipedia.org/wiki/Graham_scan.
+    Notes
+    -----
+    This can only be performed on a set of non-symbolic points.
+
+    See Also
+    --------
+    Point
+
+    References
+    ----------
+    http://en.wikipedia.org/wiki/Graham_scan
+
+    Examples
+    --------
+    >>> from sympy.geometry import Point, convex_hull
+    >>> points = [Point(x) for x in [(1, 1), (1, 2), (3, 1), (-5, 2), (15, 4)]]
+    >>> convex_hull(points)
+    Polygon(Point(-5, 2), Point(1, 1), Point(3, 1), Point(15, 4))
+
     """
     from point import Point
     from line import Segment
@@ -85,10 +118,11 @@ def convex_hull(*args):
         return Segment(p[0], p[1])
 
     def orientation(p, q, r):
-        '''Return positive if p-q-r are clockwise, neg if ccw, zero if colinear.'''
-        return (q[1]-p[1])*(r[0]-p[0]) - (q[0]-p[0])*(r[1]-p[1])
+        '''Return positive if p-q-r are clockwise, neg if ccw, zero if
+        collinear.'''
+        return (q[1] - p[1])*(r[0] - p[0]) - (q[0] - p[0])*(r[1] - p[1])
 
-    '''scan to find upper and lower convex hulls of a set of 2d points.'''
+    # scan to find upper and lower convex hulls of a set of 2d points.
     U = []
     L = []
     p.sort()
@@ -108,13 +142,40 @@ def convex_hull(*args):
 
 
 def are_similar(e1, e2):
-    """
-    Returns True if e1 and e2 are similar (one can be uniformly scaled to
-    the other) or False otherwise.
+    """Are two geometrical entities similar.
 
-    Notes:
-    ======
-        - If the two objects are equal then they are always similar.
+    Can one geometrical entity be uniformly scaled to the other?
+
+    Parameters
+    ----------
+    e1 : GeometryEntity
+    e2 : GeometryEntity
+
+    Returns
+    -------
+    are_similar : boolean
+
+    Raises
+    ------
+    GeometryError
+        When `e1` and `e2` cannot be compared.
+
+    Notes
+    -----
+    If the two objects are equal then they are similar.
+
+    Examples
+    --------
+    >>> from sympy import Point, Circle, Triangle, are_similar
+    >>> c1, c2 = Circle(Point(0, 0), 4), Circle(Point(1, 4), 3)
+    >>> t1 = Triangle(Point(0, 0), Point(1, 0), Point(0, 1))
+    >>> t2 = Triangle(Point(0, 0), Point(2, 0), Point(0, 2))
+    >>> t3 = Triangle(Point(0, 0), Point(3, 0), Point(0, 1))
+    >>> are_similar(t1, t2)
+    True
+    >>> are_similar(t1, t3)
+    False
+
     """
     if e1 == e2:
         return True


### PR DESCRIPTION
Updated all docstrings in geometry (polygon.py docstrings updated in previous pull request.)

Tested on Windows XP with py2.4 and py2.7.

bin/strip_whitespace: no problems.

One issue with a doctest: I don't know why my version of sympy is not absorbing the minus sign into the expression in the brackets.
    ___________________ sympy.geometry.polygon.Triangle.inradius _________________

```
File "c:\Documents and Settings\gdk\My Documents\computing\__git__\sympy\sympy\
geometry\polygon.py", line 18, in sympy.geometry.polygon.Triangle.inradius
Failed example:
    t.inradius
Expected:
    (4*a**2*(a**2)**(1/2) - 2*2**(1/2)*a**2*(a**2)**(1/2))/(8*a**2)
Got:
    -(-4*a**2*(a**2)**(1/2) + 2*2**(1/2)*a**2*(a**2)**(1/2))/(8*a**2)
```
