### PR TITLE
Issue 760: property is_number fixed

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -528,9 +528,8 @@ class Basic(AssumeMeths):
            True
 
         """
-        if not self.args:
-            return False
-        return all(obj.is_number for obj in self.iter_basic_args())
+        # should be overriden by subclasses
+        return False
 
     @property
     def func(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -128,6 +128,29 @@ class Expr(Basic, EvalfMixin):
         else:
             raise TypeError("expected mpmath number (mpf or mpc)")
 
+    @property
+    def is_number(self):
+        """Returns True if 'self' is a number.
+
+           >>> from sympy import log, Integral
+           >>> from sympy.abc import x, y
+
+           >>> x.is_number
+           False
+           >>> (2*x).is_number
+           False
+           >>> (2 + log(2)).is_number
+           True
+           >>> (2 + Integral(2, x)).is_number
+           False
+           >>> (2 + Integral(2, (x, 1, 2))).is_number
+           True
+
+        """
+        if not self.args:
+            return False
+        return all(obj.is_number for obj in self.iter_basic_args())
+
 
     def _eval_interval(self, x, a, b):
         """

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -185,6 +185,10 @@ class Number(AtomicExpr):
     def __hash__(self):
         return super(Number, self).__hash__()
 
+    @property
+    def is_number(self):
+        return True
+
     def as_coeff_mul(self, *deps):
         # a -> c * t
         if self.is_Rational:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -3,7 +3,7 @@ from sympy import Add, Basic, S, Symbol, Wild,  Real, Integer, Rational, I, \
     WildFunction, Poly, Function, Derivative, Number, pi, var, \
     NumberSymbol, zoo, Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, \
     radsimp, powsimp, simplify, together, separate, collect, \
-    apart, combsimp, factor, refine, cancel, invert
+    apart, combsimp, factor, refine, cancel, invert, Tuple
 from sympy.physics.secondquant import FockState
 
 from sympy.core.cache import clear_cache
@@ -555,8 +555,6 @@ def test_nonzero():
     assert bool(x*0)    == False
 
 def test_is_number():
-    g = WildFunction('g')
-
     assert Real(3.14).is_number == True
     assert Integer(737).is_number == True
     assert Rational(3, 2).is_number == True
@@ -570,8 +568,16 @@ def test_is_number():
     assert (8+log(2)).is_number == True
     assert (2 + log(x)).is_number == False
     assert (8+log(2)+x).is_number == False
-    assert (2*g).is_number == False
     assert (1+x**2/x-x).is_number == True
+    assert Tuple(Integer(1)).is_number == False
+    assert Add(2, x).is_number == False
+    assert Mul(3, 4).is_number == True
+    assert Pow(log(2), 2).is_number == True
+    assert oo.is_number == True
+    g = WildFunction('g')
+    assert g.is_number == False
+    assert (2*g).is_number == False
+    assert (x**2).subs(x, 3).is_number == True
 
     # test extensibility of .is_number
     # on subinstances of Basic


### PR DESCRIPTION
Issue 760: http://code.google.com/p/sympy/issues/detail?id=760#c11

Implementation of Basic.is_number was moved to Expr.is_number.
Basic.is_number return False.
Number.is_number return True.
