### PR TITLE
[Issue1000] Changing definition of limits

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -204,7 +204,7 @@ class exp(Function):
         arg_series = arg._eval_nseries(x, n=n)
         if arg_series.is_Order:
             return 1 + arg_series
-        arg0 = limit(arg_series.removeO(), x, 0)
+        arg0 = limit(arg_series.removeO(), x, 0,dir = "+")
         if arg0 in [-oo, oo]:
             return self
         t = Dummy("t")

--- a/sympy/functions/elementary/tests/test_interface.py
+++ b/sympy/functions/elementary/tests/test_interface.py
@@ -22,7 +22,7 @@ def test_function_series1():
 
     #Test that the taylor series is correct
     assert my_function(x).series(x, 0, 10) == sin(x).series(x, 0, 10)
-    assert limit(my_function(x)/x, x, 0) == 1
+    assert limit(my_function(x)/x, x, 0,dir="+") == 1
 
 def test_function_series2():
     """Create our new "cos" function."""

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -277,7 +277,7 @@ class Integral(Expr):
             wok = inverse_mapping.subs(x, a)
             if not wok is S.NaN:
                 return wok
-            return limit(sign(b)*inverse_mapping, x, a)
+            return limit(sign(b)*inverse_mapping, x, a, dir ="+")
         newlimits = []
         for xab in limits:
             sym = xab[0]

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -167,13 +167,13 @@ def heuristics(e, z, z0, dir):
         r = []
         for a in e.args:
             if not a.is_bounded:
-                r.append(a.limit_eval(z, z0, dir))
+                r.append(a.limit(z, z0, dir))
         if r:
             return Mul(*r)
     elif e.is_Add:
         r = []
         for a in e.args:
-            r.append(a.limit_eval(z, z0, dir))
+            r.append(a.limit(z, z0, dir))
         return Add(*r)
     elif e.is_Function:
         return e.subs(e.args[0], limit_eval(e.args[0], z, z0, dir))

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -2,7 +2,7 @@ from sympy.core import S, Add, sympify, Expr, PoleError, Mul, oo, C
 from gruntz import gruntz
 from sympy.functions import sign, tan, cot
 
-def limit(e, z, z0, dir="+"):
+def limit(e, z, z0, dir="r"):
     """
     Compute the limit of e(z) at the point z0.
 
@@ -31,6 +31,15 @@ def limit(e, z, z0, dir="+"):
     "x**2" and similar, so that it's fast. For all other cases, we use the
     Gruntz algorithm (see the gruntz() function).
     """
+
+    if dir == 'r':
+        limit_right = limit(e, z, z0, dir="+")
+        limit_left = limit(e, z, z0, dir="-")
+        if  limit_right == limit_left:
+            return limit_right
+        else:
+            return 'Limit does not exist.'
+            
     from sympy import Wild, log
 
     e = sympify(e)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -31,14 +31,15 @@ def limit(e, z, z0, dir="r"):
     "x**2" and similar, so that it's fast. For all other cases, we use the
     Gruntz algorithm (see the gruntz() function).
     """
-
     if dir == 'r':
         limit_right = limit(e, z, z0, dir="+")
         limit_left = limit(e, z, z0, dir="-")
         if  limit_right == limit_left:
             return limit_right
         else:
-            return 'Limit does not exist.'
+            msg = "Limit (%s, %s, %s, dir=%s) does not exist"
+            raise PoleError(msg % (e, z, z0, dir))
+    
 
     from sympy import Wild, log
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -39,7 +39,7 @@ def limit(e, z, z0, dir="r"):
         else:
             msg = "Limit (%s, %s, %s, dir=%s) does not exist"
             raise PoleError(msg % (e, z, z0, dir))
-    
+
 
     from sympy import Wild, log
 

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -39,7 +39,7 @@ def limit(e, z, z0, dir="r"):
             return limit_right
         else:
             return 'Limit does not exist.'
-            
+
     from sympy import Wild, log
 
     e = sympify(e)

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -215,6 +215,7 @@ class Order(Expr):
         (e.g. when self and expr have different symbols).
         """
         from sympy import powsimp, limit
+        from sympy.series.limits import limit_eval
         if expr is S.Zero:
             return True
         if expr is S.NaN:
@@ -232,7 +233,7 @@ class Order(Expr):
                 return None
             r = None
             for s in common_symbols:
-                l = limit(powsimp(self.expr/expr.expr, deep=True,\
+                l = limit_eval(powsimp(self.expr/expr.expr, deep=True,\
                 combine='exp'), s, 0) != 0
                 if r is None:
                     r = l

--- a/sympy/series/tests/test_demidovich.py
+++ b/sympy/series/tests/test_demidovich.py
@@ -52,7 +52,7 @@ def test_Limits_simple_3b():
     assert limit((sqrt(x)-1)/(x-1),x,1)==Rational(1)/2  #199
     assert limit((sqrt(x)-8)/(sqrt3(x)-4),x,64)==3  #200
     assert limit((sqrt3(x)-1)/(sqrt4(x)-1),x,1)==Rational(4)/3  #201
-    # Because of changed defination of limit, following limit does not exist. 
+    # Because of changed defination of limit, following limit does not exist.
     # assert limit((sqrt3(x**2)-2*sqrt3(x)+1)/(x-1)**2,x,1)==Rational(1)/9  #202
 
 def test_Limits_simple_4a():

--- a/sympy/series/tests/test_demidovich.py
+++ b/sympy/series/tests/test_demidovich.py
@@ -52,7 +52,8 @@ def test_Limits_simple_3b():
     assert limit((sqrt(x)-1)/(x-1),x,1)==Rational(1)/2  #199
     assert limit((sqrt(x)-8)/(sqrt3(x)-4),x,64)==3  #200
     assert limit((sqrt3(x)-1)/(sqrt4(x)-1),x,1)==Rational(4)/3  #201
-    assert limit((sqrt3(x**2)-2*sqrt3(x)+1)/(x-1)**2,x,1)==Rational(1)/9  #202
+    # Because of changed defination of limit, following limit does not exist. 
+    # assert limit((sqrt3(x**2)-2*sqrt3(x)+1)/(x-1)**2,x,1)==Rational(1)/9  #202
 
 def test_Limits_simple_4a():
     a = Symbol('a')

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -26,7 +26,7 @@ def test_basic1():
     assert limit((1 + x)**oo, x, 0, dir='-') == 0
     assert limit((1 + x + y)**oo, x, 0, dir='-') == (1 + y)**(oo)
     assert limit(y/x/log(x), x, 0) == -y*oo
-    assert limit(cos(x + y)/x, x, 0) == cos(y)*oo
+    assert limit(cos(x + y)/x, x, 0) == 'Limit does not exist.'
     raises(NotImplementedError, 'limit(Sum(1/x, (x, 1, y)) - log(y), y, oo)')
     assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))
     assert limit(gamma(1/x + 3), x, oo) == 2

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,7 +1,7 @@
 from sympy import (limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
                    atan, gamma, Symbol, S, pi, Integral, cot, Rational, I, zoo,
                    tan, cot, integrate, Sum)
-
+from sympy.core import PoleError
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.iterables import cartes
@@ -22,18 +22,16 @@ def test_basic1():
     assert limit(x - x**2, x, oo) == -oo
     assert limit((1 + x)**(1 + sqrt(2)),x,0) == 1
     assert limit((1 + cos(x))**oo, x, 0) == oo
-    assert limit((1 + x)**oo, x, 0) == oo
     assert limit((1 + x)**oo, x, 0, dir='-') == 0
     assert limit((1 + x + y)**oo, x, 0, dir='-') == (1 + y)**(oo)
     assert limit(y/x/log(x), x, 0) == -y*oo
-    assert limit(cos(x + y)/x, x, 0) == 'Limit does not exist.'
     raises(NotImplementedError, 'limit(Sum(1/x, (x, 1, y)) - log(y), y, oo)')
     assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))
     assert limit(gamma(1/x + 3), x, oo) == 2
 
     # approaching 0
     # from dir="+"
-    assert limit(1 + 1/x, x, 0) == oo
+    assert limit(1 + 1/x, x, 0, dir='+') == oo
     # from dir='-'
     # Add
     assert limit(1 + 1/x, x, 0, dir='-') == -oo
@@ -65,6 +63,13 @@ def test_basic4():
     assert limit(2*x**8 + y*x**(-3), x, -2) == 512 - y/8
     assert limit(sqrt(x + 1) - sqrt(x), x, oo)==0
     assert integrate(1/(x**3+1),(x,0,oo)) == 2*pi*sqrt(3)/9
+
+@XFAIL
+def test_changed_definition():
+    assert limit(abs(x)/x,x,0) == 1
+    assert limit((1 + x)**oo, x, 0) == oo
+    assert limit(cos(x + y)/x, x, 0) == 1
+    assert limit(1 + 1/x, x, 0) == oo
 
 def test_issue786():
     assert limit(x*y + x*z, z, 2) == x*y+2*x


### PR DESCRIPTION
http://code.google.com/p/sympy/issues/detail?id=1000

In this pull request, I made elementary changes where it only checks whether the right limit and left limit is same or not. This changes the definition of limit in SymPy ( limit exists iff limit_right == limit_left ) and hence for lots of expressions where limit used to exists before, doesn't exist now.

Although I have changed test in test_limits, because of previous definition of limits, I need to modify following test files also  -
- sympy/functions/elementary/tests/test_interface.py[3] 
  
  test_function_series1 E
- sympy/integrals/tests/test_integrals.py[56]
  
  test_transform E
- sympy/series/tests/test_demidovich.py[17] 
  
  test_Limits_simple_3b F
- sympy/series/tests/test_nseries.py[64]
  
  test_exp_1 E
- sympy/solvers/tests/test_solvers.py[18] 
  
  test_tsolve_1 F
- sympy/test_external/test_autowrap.py[10]
  
  test_wrap_twice_c_cython E

If people agree on changing this definition of limit, I can proceed further for other changes.
