### PR TITLE
heurisch: Removed double quotes to remove formatting errors in emacs

### DIFF
--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -76,7 +76,7 @@ def heurisch(f, x, **kwargs):
 
        This is a heuristic approach to indefinite integration in finite
        terms using the extended heuristic (parallel) Risch algorithm, based
-       on Manuel Bronstein's "Poor Man's Integrator".
+       on Manuel Bronstein's 'Poor Man's Integrator'.
 
        The algorithm supports various classes of functions including
        transcendental elementary or special functions like Airy,
@@ -118,7 +118,7 @@ def heurisch(f, x, **kwargs):
        >>> heurisch(y*tan(x), x)
        y*log(1 + tan(x)**2)/2
 
-       See Manuel Bronstein's "Poor Man's Integrator":
+       See Manuel Bronstein's 'Poor Man's Integrator':
 
        [1] http://www-sop.inria.fr/cafe/Manuel.Bronstein/pmint/index.html
 


### PR DESCRIPTION
Can this be done all over Sympy? Emacs formatting gets screwed up if there are double quotes in docstrings. This also implies that all emacs-python magic is rendered useless.
