### PR TITLE
Fixed Issue 1077

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -119,6 +119,7 @@ class Number(AtomicExpr):
     is_comparable = True
     is_bounded = True
     is_finite = True
+    is_algebraic = True
 
     __slots__ = []
 
@@ -1541,6 +1542,7 @@ class NumberSymbol(AtomicExpr):
     is_comparable = True
     is_bounded = True
     is_finite = True
+    is_algebraic = True
 
     __slots__ = []
 
@@ -1636,6 +1638,7 @@ class Exp1(NumberSymbol):
     is_positive = True
     is_negative = False # XXX Forces is_negative/is_nonnegative
     is_irrational = True
+    is_algebraic = False
 
     __slots__ = []
 
@@ -1668,6 +1671,7 @@ class Pi(NumberSymbol):
     is_positive = True
     is_negative = False
     is_irrational = True
+    is_algebraic = False
 
     __slots__ = []
 
@@ -1722,6 +1726,7 @@ class EulerGamma(NumberSymbol):
     is_positive = True
     is_negative = False
     is_irrational = None
+    is_algebraic = False
 
     __slots__ = []
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -612,3 +612,12 @@ def test_relational():
 def test_Integer_as_index():
     if hasattr(int, '__index__'): # Python 2.5+ (PEP 357)
         assert 'hello'[Integer(2):] == 'llo'
+
+def test_is_algebraic():
+    assert not pi.is_algebraic
+    assert Integer(1).is_algebraic
+    assert sqrt(2).is_algebraic
+    assert not EulerGamma.is_algebraic
+    assert not Exp1.is_algebraic
+    assert (1+I).is_algebraic
+


### PR DESCRIPTION
 All subclasses of Number and NumberSymbol have is_algebraic = True other than Pi, Exp1 and EulerGamma. 
