### PR TITLE
Python 2.4 compatibility fixes

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4,6 +4,7 @@ from singleton import S
 from evalf import EvalfMixin
 from decorators import _sympifyit, call_highest_priority
 from cache import cacheit
+from sympy.core.compatibility import all
 
 class Expr(Basic, EvalfMixin):
     __slots__ = []

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1408,8 +1408,8 @@ def test_SMatrix_CL_RL():
 
 def test_SMatrix_add():
     assert SMatrix(((1,0), (0,1))) + SMatrix(((0,1), (1,0))) == SMatrix(((1,1), (1,1)))
-    a = SMatrix(100, 100, lambda i, j : 1 if j != 0 and i % j == 0 else 0)
-    b = SMatrix(100, 100, lambda i, j : 1 if i != 0 and j % i == 0 else 0)
+    a = SMatrix(100, 100, lambda i, j : int(j != 0 and i % j == 0))
+    b = SMatrix(100, 100, lambda i, j : int(i != 0 and j % i == 0))
     assert (len(a.mat) + len(b.mat) - len((a+b).mat) > 0)
 
 def test_has():

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -2,7 +2,7 @@
 
 from sympy import Matrix, I, Expr, Integer
 from sympy.matrices import matrices
-
+from sympy.core.compatibility import all
 
 __all__ = [
     'numpy_ndarray',

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -395,7 +395,7 @@ def matrix_to_qubit(matrix):
         if element != 0.0:
             # Form Qubit array; 0 in bit-locations where i is 0, 1 in
             # bit-locations where i is 1
-            qubit_array = [1 if i&(1<<x) else 0 for x in range(nqubits)]
+            qubit_array = [int(i & (1<<x) != 0) for x in range(nqubits)]
             qubit_array.reverse()
             result = result + element*cls(*qubit_array)
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -1,6 +1,7 @@
 from sympy.core import Basic, S, C, sympify, Expr, oo, Rational, Symbol, Dummy
 from sympy.core import Add, Mul
 from sympy.core.cache import cacheit
+from sympy.core.compatibility import all
 
 class Order(Expr):
     """

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1060,7 +1060,7 @@ def test_check_case_false_positive():
     x2 = symbols('x', my_assumption=True)
     try:
         codegen(('test', x1*x2), 'f95', 'prefix')
-    except CodeGenError as e:
+    except CodeGenError, e:
         if e.args[0][0:21] == "Fortran ignores case.":
             raise AssertionError("This exception should not be raised!")
 


### PR DESCRIPTION
- all isn't a builtin in 2.4, so has to be imported from sympy.core.compatibility
- ternary if expressions are invalid
- 'except Exception as e:' is a syntax error (in 2.4 and 2.5)
