### PR TITLE
2265 cse watches for exact Mul and Add sub-expressions

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -1,9 +1,10 @@
 """ Tools for doing common subexpression elimination.
 """
 import bisect
+import difflib
 
-from sympy import Basic
-from sympy.utilities.iterables import preorder_traversal, numbered_symbols
+from sympy import Basic, Mul, Add
+from sympy.utilities.iterables import preorder_traversal, numbered_symbols, any
 
 import cse_opts
 
@@ -98,6 +99,8 @@ def cse(exprs, symbols=None, optimizations=None):
         # an actual iterator.
         symbols = iter(symbols)
     seen_subexp = set()
+    muls = set()
+    adds = set()
     to_eliminate = []
     to_eliminate_ops_count = []
 
@@ -113,22 +116,103 @@ def cse(exprs, symbols=None, optimizations=None):
     exprs = [preprocess_for_cse(e, optimizations) for e in exprs]
 
     # Find all of the repeated subexpressions.
+    def insert(subtree):
+        '''This helper will insert the subtree into to_eliminate while
+        maintaining the ordering by op count and will skip the insertion
+        if subtree is already present.'''
+        ops_count = subtree.count_ops()
+        index_to_insert = bisect.bisect(to_eliminate_ops_count, ops_count)
+        # all i up to this index have op count <= the current op count
+        # so check that subtree is not yet present from this index down
+        # (if necessary) to zero.
+        for i in xrange(index_to_insert - 1, -1, -1):
+            if to_eliminate_ops_count[i] == ops_count and \
+               subtree == to_eliminate[i]:
+                return # already have it
+        to_eliminate_ops_count.insert(index_to_insert, ops_count)
+        to_eliminate.insert(index_to_insert, subtree)
+
     for expr in exprs:
         pt = preorder_traversal(expr)
         for subtree in pt:
             if subtree.is_Atom:
                 # Exclude atoms, since there is no point in renaming them.
                 continue
-            elif subtree in seen_subexp:
-                if subtree not in to_eliminate:
-                    ops_count = subtree.count_ops()
-                    index_to_insert = bisect.bisect(to_eliminate_ops_count, ops_count)
 
-                    to_eliminate_ops_count.insert(index_to_insert, ops_count)
-                    to_eliminate.insert(index_to_insert, subtree)
+            if subtree in seen_subexp:
+                insert(subtree)
                 pt.skip()
+                continue
+
+            if subtree.is_Mul:
+                muls.add(subtree)
+            elif subtree.is_Add:
+                adds.add(subtree)
+
+            seen_subexp.add(subtree)
+
+    # process adds - any adds that weren't repeated might contain
+    # subpatterns that are repeated, e.g. x+y+z and x+y have x+y in common
+    adds = [set(a.args) for a in adds]
+    for i in xrange(len(adds)):
+        for j in xrange(i + 1, len(adds)):
+            com = adds[i].intersection(adds[j])
+            if len(com) > 1:
+                insert(Add(*com))
+
+                # remove this set of symbols so it doesn't appear again
+                adds[i] = adds[i].difference(com)
+                adds[j] = adds[j].difference(com)
+                for k in xrange(j + 1, len(adds)):
+                    if not com.difference(adds[k]):
+                        adds[k] = adds[k].difference(com)
+
+    # process muls - any muls that weren't repeated might contain
+    # subpatterns that are repeated, e.g. x*y*z and x*y have x*y in common
+
+    # use SequenceMatcher on the nc part to find the longest common expression
+    # in common between the two nc parts
+    sm = difflib.SequenceMatcher()
+
+    muls = [a.args_cnc() for a in muls]
+    for i in xrange(len(muls)):
+        if muls[i][1]:
+            sm.set_seq1(muls[i][1])
+        for j in xrange(i + 1, len(muls)):
+            # the commutative part in common
+            ccom = muls[i][0].intersection(muls[j][0])
+
+            # the non-commutative part in common
+            if muls[i][1] and muls[j][1]:
+                # see if there is any chance of an nc match
+                ncom = set(muls[i][1]).intersection(set(muls[j][1]))
+                if len(ccom) + len(ncom) < 2:
+                    continue
+
+                # now work harder to find the match
+                sm.set_seq2(muls[j][1])
+                i1, _, n = sm.find_longest_match(0, len(muls[i][1]),
+                                                 0, len(muls[j][1]))
+                ncom = muls[i][1][i1:i1 + n]
             else:
-                seen_subexp.add(subtree)
+                ncom = []
+
+            com = list(ccom) + ncom
+            if len(com) < 2:
+                continue
+
+            insert(Mul(*com))
+
+            # remove ccom from all if there was no ncom; to update the nc part
+            # would require finding the subexpr and then replacing it with a
+            # dummy to keep bounding nc symbols from being identified as a
+            # subexpr, e.g. removing B*C from A*B*C*D might allow A*D to be
+            # identified as a subexpr which would not be right.
+            if not ncom:
+                muls[i][0] = muls[i][0].difference(ccom)
+                for k in xrange(j, len(muls)):
+                    if not ccom.difference(muls[k][0]):
+                        muls[k][0] = muls[k][0].difference(ccom)
 
     # Substitute symbols for all of the repeated subexpressions.
     replacements = []
@@ -140,8 +224,6 @@ def cse(exprs, symbols=None, optimizations=None):
         for j, expr in enumerate(reduced_exprs):
             reduced_exprs[j] = expr.subs(subtree, sym)
         # Make the substitution in all of the subsequent substitutions.
-        # WARNING: modifying iterated list in-place! I think it's fine,
-        # but there might be clearer alternatives.
         for j in range(i+1, len(to_eliminate)):
             to_eliminate[j] = to_eliminate[j].subs(subtree, sym)
 

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -2,6 +2,7 @@ import itertools
 
 from sympy import Add, Mul, Pow, Symbol, exp, sqrt, symbols, sympify, cse
 from sympy.simplify import cse_main, cse_opts
+from sympy.utilities.pytest import XFAIL
 
 w,x,y,z = symbols('wxyz')
 x0,x1,x2 = list(itertools.islice(cse_main.numbered_symbols(), 0, 3))
@@ -70,7 +71,7 @@ def test_subtraction_opt():
     # Make sure subtraction is optimized.
     e = (x-y)*(z-y) + exp((x-y)*(z-y))
     substs, reduced = cse([e], optimizations=[(cse_opts.sub_pre,cse_opts.sub_post)])
-    assert substs == [(x0, (x-y)*(z-y))]
+    assert substs == [(x0, (x - y)*(z - y))]
     assert reduced == [x0 + exp(x0)]
 
 def test_multiple_expressions():
@@ -79,3 +80,33 @@ def test_multiple_expressions():
     substs, reduced = cse([e1, e2], optimizations=[])
     assert substs == [(x0, x+y)]
     assert reduced == [x0*z, x0*w]
+    l = [w*x*y + z, w*y]
+    substs, reduced = cse(l)
+    rsubsts, _ = cse(reversed(l))
+    assert substs == rsubsts
+    assert reduced == [z + x*x0, x0]
+    l = [w*x*y, w*x*y + z, w*y]
+    substs, reduced = cse(l)
+    rsubsts, _ = cse(reversed(l))
+    assert substs == rsubsts
+    assert reduced == [x1, x1 + z, x0]
+    l = [(x - z)*(y - z), x - z, y - z]
+    substs, reduced = cse(l)
+    rsubsts, _ = cse(reversed(l))
+    assert substs == rsubsts
+    assert reduced == [x0*x1, x0, x1]
+    l = [w*y + w + x + y + z, w*x*y]
+    assert cse(l) == ([(x0, w*y)], [w + x + x0 + y + z, x*x0])
+    assert cse([x + y, x + y + z]) == ([(x0, x + y)], [x0, z + x0])
+    assert cse([x + y, x + z]) == ([], [x + y, x + z])
+    assert cse([x*y, x + x*y , x*y*z + 3]) == \
+           ([(x0, x*y)], [x0, x + x0, 3 + x0*z])
+    A, B, C = symbols('A B C', commutative=False)
+    l = [A*B*C, A*C]
+    assert cse(l) == ([], l)
+    l = [A*B*C, A*B]
+    assert cse(l) == ([(x0, A*B)], [x0*C, x0])
+
+@XFAIL
+def test_powers():
+    assert cse(x*y**2 + x*y) == ([(x0, x*y)], [x0*y + x0])


### PR DESCRIPTION
```
Adds and Muls that were not repeated subexpressions may still
contain subexpresions that are repeated, e.g. x+y+z and x+y
have x+y in common, but the cse process misses these.

Now all such expressions are stored and processed after the
main processing. set intersection of the args of all Adds are
tested for repeated subexpressions. For Muls, intersection of
the commutative args and longest sub-expression for the non-commutative
args are sought.

Since cse is working with exact sub-expressions, a subexpression
like x + y will not be removed from x + 2*y, nor will x*y be removed
from x*y**2.

An insert function was added which has a dual purpose of checking to
see if subtree has already been recorded and to keep the to_eliminate
list sorted.
```

cf [ http://code.google.com/p/sympy/issues/detail?id=2265&sort=-id ]
