### PR TITLE
Issue 101: tests on the wiki documentation

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -28,11 +28,16 @@ parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
 # when the user enters -h or --help, print the `help` text
 parser.add_option("-n", "--normal", action="store_true", dest="normal",
         help="run normal doctests; do not require explicit imports", default=False)
+parser.add_option("--no-colors", action="store_false", dest="colors",
+        default=True, help="Do not report colored [OK] and [FAIL]")
 parser.add_option('-t', '--types', dest='types', action='store',
         default=None, choices=['gmpy', 'python', 'sympy'],
         help='setup ground types: gmpy | python | sympy')
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
+parser.add_option("-f", "--firstonly", action="store_true", dest="first_only",
+        help="Report details only about the first failure or exception [default: %default]",
+        default=False)
 
 parser.set_usage("test [options ...] [files ...]")
 parser.epilog = """\

--- a/bin/doctest
+++ b/bin/doctest
@@ -33,6 +33,7 @@ parser.add_option('-t', '--types', dest='types', action='store',
         help='setup ground types: gmpy | python | sympy')
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
+
 parser.set_usage("test [options ...] [files ...]")
 parser.epilog = """\
 "options" are any of the options above. "files" are 0 or more glob strings of \
@@ -50,8 +51,9 @@ if options.types:
 
 import sympy
 
-ok = sympy.doctest(*args, **{"verbose": options.verbose,
-    "blacklist": blacklist, "normal": options.normal})
+dictargs = {"blacklist": blacklist}
+dictargs.update(options.__dict__)
+ok = sympy.doctest(*args, **dictargs)
 
 if ok:
     sys.exit(0)

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -61,8 +61,13 @@ parser.add_option("-n", "--normal", action="store_true", dest="normal",
         help="run normal wikitests; do not require explicit imports", default=False)
 parser.add_option("--no-colors", action="store_false", dest="colors",
         default=True, help="Do not report colored [OK] and [FAIL]")
+parser.add_option('-t', '--types', dest='types', action='store',
+        default=None, choices=['gmpy', 'python', 'sympy'],
+        help='setup ground types: gmpy | python | sympy')
+parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
+        default=True, help='disable caching mechanism')
 parser.add_option("-f", "--firstonly", action="store_true", dest="first_only",
-        help="Report only first failure for every file [default: %default]",
+        help="Report details only about the first failure or exception [default: %default]",
         default=False)
 
 
@@ -81,6 +86,11 @@ parser.epilog = '"options" are any of the options above.  "files" are 0 or more 
 
 
 options, args = parser.parse_args()
+
+if not options.cache:
+    os.environ['SYMPY_USE_CACHE'] = 'no'
+if options.types:
+    os.environ['SYMPY_GROUND_TYPES'] = options.types
 
 againstlist = options.against.split(",")
 dictargs = {"blacklist": blacklist, "againstlist": againstlist}

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -46,7 +46,10 @@ Additional #doctest:+<...> options, which applied for tested examples lines:
     RELEASE_ONLY - test only for release only. Usually when
         deprecated syntax of sympy  is used or test has deprecated output.
 
-    PRETTY - for define what the output of test is expected.
+    PRETTY - for define that the output of test is expected, like sympy's pretty
+        printer do.
+
+    USE_UNICODE - use unicode in tests's output
 
 
 All those doctests options have their global analog:

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -47,6 +47,11 @@ Additional #doctest:+<...> options, which applied for tested examples lines:
         deprecated syntax of sympy  is used or test has deprecated output.
 
     PRETTY - for define what the output of test is expected.
+
+
+All those doctests options have their global analog:
+    <!-- wikitest (future_only, pretty_print) -->
+
 """
 
 # files listed here can be in unix forward slash format with paths

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -78,7 +78,7 @@ parser.add_option("-a", "--against", type="string", dest="against",
         help="SymPy version. What do the tests must be relative [master | release | master,release] [default: %default]",
         default="master")
 parser.add_option("--all", action="store_true", dest="all_pages",
-        help="Test all wiki pages in directory, that is inspire of pages's directive. [default: %default]",
+        help="Test all the pages in the directory, regardless of the directive in the pages. [default: %default]",
         default=False)
 parser.add_option("-w", "--wiki-dir", type="string", dest="wiki_dir",
         help="The path to the wiki pages directory", default=None)

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+"""
+This procedure test wiki pages against master or release
+ repositories.
+
+Assuming that wiki.sympy and release version are placed near
+master repository. E.g.
+
+    ./sympy/
+    ./wiki.sympy/
+    ./sympy-0.7.1/
+
+If the directories are not the same, then they can be tuned by
+those options:
+
+    -a AGAINST, --against=AGAINST
+                    What do the tests must be relative [master | release |
+                    master,release] [default: master]
+    -w WIKI_DIR, --wiki-dir=WIKI_DIR
+                    The path to the wiki pages directory
+    -m MASTER_DIR, --master-dir=MASTER_DIR
+                    The path to the sympy master repository
+    -r RELEASE_DIR, --release-dir=RELEASE_DIR
+                    The path to the sympy release directory
+
+The files are to be passing through the test contain the special directives.
+For reStructedText comments is shaped as:
+
+    .. wikitest release
+
+For markdown:
+
+    <!-- wikitest release -->
+
+"wikitest release" directive means that tests for current wiki-page have to be
+passed against release version only.
+"wikitest master" - against master.
+"wikitest master,release" - against master and release version
+"""
+
+# files listed here can be in unix forward slash format with paths
+# listed relative to sympy (which contains bin, etc...)
+blacklist = []
+
+import sys
+from os import getcwd
+from os.path import normpath, abspath, isdir, dirname, join
+from optparse import OptionParser
+import imp
+
+parser = OptionParser()
+parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
+        default=False)
+
+# if you don't see a -n `default=False`;
+# if you do see a -n `store_true` means to store a True value for it;
+# dest is where in options to put it, options.normal will hold the bool;
+# when the user enters -h or --help, print the `help` text
+parser.add_option("-n", "--normal", action="store_true", dest="normal",
+        help="run normal wikitests; do not require explicit imports", default=False)
+parser.add_option("--no-colors", action="store_false", dest="colors",
+        default=True, help="Do not report colored [OK] and [FAIL]")
+parser.add_option("-f", "--firstonly", action="store_true", dest="first_only",
+        help="Report only first failure for every file [default: %default]",
+        default=False)
+
+
+parser.add_option("-a", "--against", type="string", dest="against",
+        help="What do the tests must be relative [master | release | master,release] [default: %default]",
+        default="master")
+parser.add_option("-w", "--wiki-dir", type="string", dest="wiki_dir",
+        help="The path to the wiki pages directory", default=None)
+parser.add_option("-m", "--master-dir", type="string", dest="master_dir",
+        help="The path to the sympy master repository", default=None)
+parser.add_option("-r", "--release-dir", type="string", dest="release_dir",
+        help="The path to the sympy release directory", default=None)
+
+parser.set_usage("wikitest [options ...] [files ...]")
+parser.epilog = '"options" are any of the options above.  "files" are 0 or more glob strings of files to run wikitests on.  If no file arguments are given, all wikitests will be run.'
+
+
+options, args = parser.parse_args()
+
+againstlist = options.against.split(",")
+dictargs = {"blacklist": blacklist, "againstlist": againstlist}
+dictargs.update(options.__dict__)
+
+# check paths
+
+def calcpath(path, default):
+    """
+    If path specified then it computes relative current directory
+    if no, then default path computes relative
+    """
+    if path:
+        res = join(getcwd(), normpath(path))
+    else:
+        res = join(dirname(__file__), normpath(default))
+    res = abspath(res)
+    return res
+
+dictargs["wiki_dir"] = calcpath(options.wiki_dir, "../../sympy.wiki")
+if not isdir(dictargs["wiki_dir"]):
+    parser.error("Directory of wiki pages '%s' is not found " % dictargs["wiki_dir"])
+for against in againstlist:
+    if not against in ["master", "release"]:
+        parser.error("The 'against' option must be in the set [master,release]")
+    elif against == "master":
+        dictargs["master_dir"] = calcpath(options.master_dir, "../")
+        if not isdir(dictargs["master_dir"]):
+            parser.error("Master repository '%s' is not found " % dictargs["master_dir"])
+    elif against == "release":
+        dictargs["release_dir"] = calcpath(options.release_dir, "../../sympy-0.7.1")
+        if not isdir(dictargs["release_dir"]):
+            parser.error("SymPy's release directory '%s' is not found " % dictargs["release_dir"])
+
+# Manually load modules, passing out sympy
+fn_runtests = join(dirname(__file__), "../sympy/utilities/runtests.py")
+runtests = imp.load_source("runtests", fn_runtests)
+
+ok = runtests.wikitest(*args, **dictargs)
+if ok:
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -4,11 +4,11 @@
 This procedure test wiki pages against master or release
  repositories.
 
-Assuming that wiki.sympy and release version are placed near
+Assuming that sympy.wiki and release version are placed near
 master repository. E.g.
 
     ./sympy/
-    ./wiki.sympy/
+    ./sympy.wiki/
     ./sympy-0.7.1/
 
 If the directories are not the same, then they can be tuned by

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -37,6 +37,9 @@ For markdown:
 passed against release version only.
 "wikitest master" - against master.
 "wikitest master,release" - against master and release version
+
+
+
 """
 
 # files listed here can be in unix forward slash format with paths
@@ -72,8 +75,11 @@ parser.add_option("-f", "--firstonly", action="store_true", dest="first_only",
 
 
 parser.add_option("-a", "--against", type="string", dest="against",
-        help="What do the tests must be relative [master | release | master,release] [default: %default]",
+        help="SymPy version. What do the tests must be relative [master | release | master,release] [default: %default]",
         default="master")
+parser.add_option("--all", action="store_true", dest="all_pages",
+        help="Test all wiki pages in directory, that is inspire of pages's directive. [default: %default]",
+        default=False)
 parser.add_option("-w", "--wiki-dir", type="string", dest="wiki_dir",
         help="The path to the wiki pages directory", default=None)
 parser.add_option("-m", "--master-dir", type="string", dest="master_dir",

--- a/bin/wikitest
+++ b/bin/wikitest
@@ -1,18 +1,16 @@
 #!/usr/bin/env python
 
 """
-This procedure test wiki pages against master or release
- repositories.
+This procedure test wiki pages against master or release repositories.
 
-Assuming that sympy.wiki and release version are placed near
-master repository. E.g.
+Assuming that sympy.wiki and release version are placed near master repository.
+E.g.
 
     ./sympy/
     ./sympy.wiki/
     ./sympy-0.7.1/
 
-If the directories are not the same, then they can be tuned by
-those options:
+If the directories are not the same, then they can be tuned by those options:
 
     -a AGAINST, --against=AGAINST
                     What do the tests must be relative [master | release |
@@ -24,22 +22,31 @@ those options:
     -r RELEASE_DIR, --release-dir=RELEASE_DIR
                     The path to the sympy release directory
 
-The files are to be passing through the test contain the special directives.
-For reStructedText comments is shaped as:
+Wiki pages can contain the special directives. For reStructedText comments they
+are shaped as:
 
-    .. wikitest release
+    .. wikitest skip
 
-For markdown:
+or for Markdown or Mediawiki the syntax is shaped as:
 
-    <!-- wikitest release -->
+    <!-- wikitest skip -->
 
-"wikitest release" directive means that tests for current wiki-page have to be
-passed against release version only.
-"wikitest master" - against master.
-"wikitest master,release" - against master and release version
+The directive "skip" means, that this page will not to be tested unless '--all'
+is used for ./wikitest script conrtol.
 
+If the directive is 'wikitest (pretty_print)' then test's
+output of this page will be expected as pretty print mode by default. See also
+#doctest: +/- PRETTY option.
 
+Additional #doctest:+<...> options, which applied for tested examples lines:
 
+    FUTURE_ONLY  - skip test if the release sympy's version is used
+        as interpreter.
+
+    RELEASE_ONLY - test only for release only. Usually when
+        deprecated syntax of sympy  is used or test has deprecated output.
+
+    PRETTY - for define what the output of test is expected.
 """
 
 # files listed here can be in unix forward slash format with paths
@@ -77,8 +84,11 @@ parser.add_option("-f", "--firstonly", action="store_true", dest="first_only",
 parser.add_option("-a", "--against", type="string", dest="against",
         help="SymPy version. What do the tests must be relative [master | release | master,release] [default: %default]",
         default="master")
-parser.add_option("--all", action="store_true", dest="all_pages",
-        help="Test all the pages in the directory, regardless of the directive in the pages. [default: %default]",
+parser.add_option("-s", "--skipped", action="store_true", dest="all_tests",
+        help="Test all tests in the pages, regardless of the directives FUTURE_ONLY | RELEASE_ONLY. [default: %default]",
+        default=False)
+parser.add_option("-A", "--all", action="store_true", dest="all_pages",
+        help="Test all the wiki pages, regardless if the <wikitest skip> directive in the page [default: %default]",
         default=False)
 parser.add_option("-w", "--wiki-dir", type="string", dest="wiki_dir",
         help="The path to the wiki pages directory", default=None)
@@ -87,8 +97,10 @@ parser.add_option("-m", "--master-dir", type="string", dest="master_dir",
 parser.add_option("-r", "--release-dir", type="string", dest="release_dir",
         help="The path to the sympy release directory", default=None)
 
-parser.set_usage("wikitest [options ...] [files ...]")
-parser.epilog = '"options" are any of the options above.  "files" are 0 or more glob strings of files to run wikitests on.  If no file arguments are given, all wikitests will be run.'
+
+description = '"options" are any of the options below.  "files" are 0 or more glob strings of files to run wikitests on. If no file arguments are given, all wikitests will be run.'
+
+parser.set_usage("\n\n\t%prog [options ...] [files ...]\n\n" + description + "\n" + __doc__)
 
 
 options, args = parser.parse_args()

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -343,3 +343,58 @@ except NameError: # Python 2.5
             x >>= 1
             pass
         return '0b' + ''.join(reversed(out))
+
+
+# since Python 2.6
+import os.path
+def relpath(path, start=os.path.curdir):
+    _relpath = None
+    try:
+        _relpath = os.path.relpath
+    except:
+        pass
+    if _relpath:
+        return _relpath(path, start)
+
+    # to be sure that the tests utilities, which use this functions fo reporting
+    # do not craching on the other platforms and interpreter's versions.
+    # when Python 2.5 is used, calculate it manually
+    if not path:
+        raise ValueError("no path specified")
+
+    start_list = [x for x in os.path.abspath(start).split(os.path.sep) if x]
+    path_list = [x for x in os.path.abspath(path).split(os.path.sep) if x]
+
+    # fix for windows platform
+    start_list = [sys_normcase(p) for p in start_list]
+    path_list = [sys_normcase(p) for p in path_list]
+
+    # Work out how much of the filepath is shared by start and path.
+    i = len(os.path.commonprefix([start_list, path_list]))
+
+    rel_list = [os.path.pardir] * (len(start_list)-i) + path_list[i:]
+    if not rel_list:
+        return os.path.curdir
+    return os.path.join(*rel_list)
+
+# Those next two procedures are needed for relpath()  when Python 2.5 is used
+def sys_normcase(f):
+    if sys_case_insensitive:
+        return f.lower()
+    return f
+
+def check_sys_case_insensitive():
+    """
+    Returns the root sympy directory and set the global value
+    indicating whether the system is case sensitive or not.
+    """
+    global sys_case_insensitive
+
+    this_file = os.path.abspath(__file__)
+    sympy_dir = os.path.join(os.path.dirname(this_file), "..", "..")
+    sympy_dir = os.path.normpath(sympy_dir)
+    sys_case_insensitive = (os.path.isdir(sympy_dir) and
+                        os.path.isdir(sympy_dir.lower()) and
+                        os.path.isdir(sympy_dir.upper()))
+
+check_sys_case_insensitive()

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1187,7 +1187,7 @@ class SymPyTextTestParser(DocTestParser):
                 if len(examples):
                     doctest = pdoctest.DocTest(examples, globs, name, filename,
                         0,
-                        string.join(examples_fullsource, ""))
+                        "".join(examples_fullsource))
                     doctests.append(doctest)
                     examples = []
                     examples_fullsource = []
@@ -1488,7 +1488,7 @@ class SymPyDocTestRunner(DocTestRunner):
             if compileflags ==0:
                 compileflags = pdoctest._extract_future_flags(test.globs)
 
-            # If REPORT_ONLY_FIRST_FAILURE is set, then supress
+            # If REPORT_ONLY_FIRST_FAILURE is set, then suppress
             # reporting after the first failure.
             quiet = (self.optionflags & REPORT_ONLY_FIRST_FAILURE and
                      failures > 0)
@@ -1551,10 +1551,9 @@ class SymPyDocTestRunner(DocTestRunner):
 
             # The example raised an exception:  check if it was expected.
             else:
-                exc_info = sys.exc_info()   # XXX: duplicated calling of sys.exc_info() ?
-                exc_msg = traceback.format_exception_only(*exc_info[:2])[-1]
+                exc_msg = traceback.format_exception_only(*exception[:2])[-1]
                 if not quiet:
-                    got += _exception_traceback(exc_info)
+                    got += _exception_traceback(exception)
 
                 # If `example.exc_msg` is None, then we weren't expecting
                 # an exception.
@@ -1584,7 +1583,7 @@ class SymPyDocTestRunner(DocTestRunner):
             elif outcome is BOOM:
                 if not quiet:
                     self.report_unexpected_exception(out, test, example,
-                                                     exc_info)
+                                                     exception)
                 failures += 1
             else:
                 assert False, ("unknown outcome", outcome)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1975,12 +1975,17 @@ def relpath(path, start=os.path.curdir):
         pass
     if _relpath:
         return _relpath(path, start)
-    # when Python 2.5
+
+    # when Python 2.5 is used, calculate it manually
     if not path:
         raise ValueError("no path specified")
 
     start_list = [x for x in os.path.abspath(start).split(os.path.sep) if x]
     path_list = [x for x in os.path.abspath(path).split(os.path.sep) if x]
+
+    # fix for windows platform
+    start_list = [sys_normcase(p) for p in start_list]
+    path_list = [sys_normcase(p) for p in path_list]
 
     # Work out how much of the filepath is shared by start and path.
     i = len(os.path.commonprefix([start_list, path_list]))

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1563,9 +1563,9 @@ class SymPyDocTestRunner(DocTestRunner):
 
                 # Another chance if they didn't care about the detail.
                 elif self.optionflags & IGNORE_EXCEPTION_DETAIL:
-                    m1 = re.match(r'[^:]*:', example.exc_msg)
-                    m2 = re.match(r'[^:]*:', exc_msg)
-                    if m1 and m2 and check(m1.group(0), m2.group(0),
+                    m1 = re.match(r'(?:[^:]*\.)?([^:]*:)', example.exc_msg)
+                    m2 = re.match(r'(?:[^:]*\.)?([^:]*:)', exc_msg)
+                    if m1 and m2 and check(m1.group(1), m2.group(1),
                                            self.optionflags):
                         outcome = SUCCESS
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -474,9 +474,9 @@ def wikitest(*paths, **kwargs):
             r.start()
             failed = not t.test_text_files()
             r.finish()
+            if failed:
+                failed_total = True
 
-        if failed:
-            failed_total = True
     return not failed_total
 
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1802,7 +1802,7 @@ class PyTestReporter(Reporter):
         if seed is not None:
             self.write("random seed:  %d\n" % seed)
         if self._sympy_dir <> None:
-            self.write("sympy:        %s\n" % self._sympy_dir)
+            self.write("sympy:        %s\n" % relpath(self._sympy_dir))
         self.write('\n')
         self._t_start = clock()
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1073,8 +1073,8 @@ class SymPyWikiTester(SymPyDocTester):
         self._reporter.root_dir(dir_for_reporter)
 
         re_directives = []
-        re_directives.append(re.compile(r"<!--\s+wikitest\s+(?P<against>[\w,]+)(\s+\((?P<options>[\w,]+)\))?\s+-->", re.M))
-        re_directives.append(re.compile(r"\.\.\s+wikitest\s+(?P<against>[\w,]+)(\s+\((?P<options>[\w,]+)\))?\s+$", re.M))
+        re_directives.append(re.compile(r"<!--\s+wikitest(\s+(?P<skip>[\w,]+))?(\s+\((?P<options>[\w,]+)\))?\s+-->", re.M))
+        re_directives.append(re.compile(r"\.\.\s+wikitest(\s+(?P<skip>[\w,]+))?(\s+\((?P<options>[\w,]+)\))?\s+$", re.M))
         self.re_directives = re_directives
 
     def set_against(self, against, against_dir):
@@ -1126,8 +1126,8 @@ class SymPyWikiTester(SymPyDocTester):
             for re_directive in self.re_directives:
                 m = re_directive.search(s)
                 if m:
-                    against_permitted = m.group("against").split(",")
-                    if "skip" in against_permitted:
+                    skip = m.group("skip")
+                    if "skip" == skip:
                         return True
         return False
 
@@ -1138,13 +1138,11 @@ class SymPyWikiTester(SymPyDocTester):
             for re_directive in self.re_directives:
                 m = re_directive.search(s)
                 if m:
-                    against_permitted = m.group("against").split(",")
-                    if self.against in against_permitted:
-                        options = m.group("options")
-                        if options:
-                            options = options.split(",")
-                            for op in options:
-                                res[op] = True
+                    options = m.group("options")
+                    if options:
+                        options = options.split(",")
+                        for op in options:
+                            res[op] = True
         return res
 
     def pre_options(self, fn):
@@ -1152,8 +1150,11 @@ class SymPyWikiTester(SymPyDocTester):
         pretty_print = directive_options.get("pretty_print", False)
         if pretty_print:
             self.optionflags |= PRETTY
-
         print_manager.setup_pprint(pretty_print, hard=True)
+        if directive_options.get("future_only", False):
+            self.optionflags |= FUTURE_ONLY
+        if directive_options.get("RELEASE_only", False):
+            self.optionflags |= RELEASE_ONLY
 
     def load_sympy_version(self):
         """

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -444,6 +444,7 @@ def wikitest(*paths, **kwargs):
     verbose = kwargs.get("verbose", False)
     colors = kwargs.get("colors", True)
     first_only = kwargs.get("first_only", False)
+    all_pages = kwargs.get("all_pages", False)
 
     againstlist = kwargs.get("againstlist", ["master"])
     blacklist = kwargs.get("blacklist", [])
@@ -464,7 +465,7 @@ def wikitest(*paths, **kwargs):
         t.load_sympy_version()
         t.load_sympy_modules()
 
-        test_files = t.get_test_files(wiki_dir, pat=r"^.*\.(md|rest|mediawiki)$",init_only=False)
+        test_files = t.get_test_files(wiki_dir, pat=r"^.*\.(md|rest|mediawiki)$",init_only=False, all_pages = all_pages)
 
         matched = t.filter_files(test_files, blacklist, paths)
         t._testfiles = matched
@@ -1065,7 +1066,7 @@ class SymPyWikiTester(SymPyDocTester):
         self.against = against
         self.against_dir = against_dir
 
-    def get_test_files(self, dir, pat=r'^.*\.md$', init_only=True):
+    def get_test_files(self, dir, pat=r'^.*\.md$', init_only=True, all_pages = False):
         """
         Returns the list of wiki-pages (default) from which docstrings
         will be tested which are at or below directory `dir`.
@@ -1082,7 +1083,7 @@ class SymPyWikiTester(SymPyDocTester):
         g = []
         for path, folders, files in os.walk(dir):
             g.extend([os.path.join(path, f) for f in files
-                      if _fnmatch(f) and self.has_directive(path, f)])
+                      if _fnmatch(f) and (all_pages or self.has_directive(path, f))])
         return [sys_normcase(gi) for gi in g]
 
     def has_directive(self, pathdir, fn):

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -2,6 +2,7 @@
 This is our testing framework.
 
 Goals:
+======
 
 * it should be compatible with py.test and operate very similarly (or
 identically)
@@ -10,7 +11,53 @@ identically)
 * no magic, just import the test file and execute the test functions, that's it
 * portable
 
+
+The code structure.
+===================
+
+Modules loading:
+----------------
+
+* Load standard modules
+* Tune standard doctest module (utf8 encoding, indent)
+
+Entering points:
+----------------
+
+* test()      - Run all tests in `test_*.py` files, test code quality and so on.
+* doctest()   - Run all doctests in `*.py` files, and run tests in `doc/src/*/*.txt` files.
+* wikitest()  - Run test in wiki pages.
+
+Tester classes:
+---------------
+
+* SymPyTesterBase                 - base tester class
+* SymPyTester(SymPyTesterBase)    - find and test 'test_*.py' files
+* SymPyDocTester(SymPyTesterBase) - find and test docstrings and *.txt files
+* SymPyWikiTester(SymPyDocTester) - find and test wiki pages
+
+
+Finder, Parser, Runner classes:
+-------------------------------
+* SymPyTextTestParser(DocTestParser) - Parser to find tests in the *txt files
+    and in the wiki page
+    It extends "get_doctest" to group examples to blocks (tests)
+
+* SymPyDocTestFinder(DocTestFinder)
+
+* SymPyDocTestRunner(DocTestRunner)
+    Modified from the doctest version to not reset the sys.displayhook
+
+Reporter Class:
+---------------
+
+* PyTestReporter
+
 """
+
+#
+# Load standard modules
+#
 import os
 import sys
 import inspect
@@ -21,18 +68,28 @@ import linecache
 from fnmatch import fnmatch
 from timeit import default_timer as clock
 import doctest as pdoctest # avoid clashing with our doctest() function
-from doctest import DocTestFinder, DocTestRunner
+from doctest import DocTestFinder, DocTestRunner, DocTestParser
 import re as pre
 import random
 import subprocess
+import imp
 
-from sympy.core.cache import clear_cache
+from StringIO import StringIO
+import string
+import codecs
+
+
+#
+# Tune standard doctest module (utf8 encoding, indent)
+#
 
 # Use sys.stdout encoding for ouput.
 # This was only added to Python's doctest in Python 2.6, so we must duplicate
 # it here to make utf8 files work in Python 2.5.
 pdoctest._encoding = getattr(sys.__stdout__, 'encoding', None) or 'utf-8'
 
+# There is the same function in pdoctest already,
+# but we must sure to be independed from python version
 def _indent(s, indent=4):
     """
     Add the given number of space characters to the beginning of
@@ -48,6 +105,32 @@ def _indent(s, indent=4):
     return re.sub('(?m)^(?!$)', indent*' ', s)
 
 pdoctest._indent = _indent
+
+# Take some classes from the pdoctest
+
+_exception_traceback = pdoctest._exception_traceback
+Example = pdoctest.Example
+
+# The Python 2.5 doctest runner uses a tuple, but in 2.6+, it uses a namedtuple
+# (which doesn't exist in 2.5-)
+if sys.version_info[:2] > (2,5):
+    from collections import namedtuple
+    SymPyTestResults = namedtuple('TestResults', 'failed attempted')
+else:
+    SymPyTestResults = lambda a, b: (a, b)
+
+# Take some constants from the pdoctest. And define the new ones.
+
+REPORT_ONLY_FIRST_FAILURE = pdoctest.REPORT_ONLY_FIRST_FAILURE
+SKIP = pdoctest.SKIP
+IGNORE_EXCEPTION_DETAIL = pdoctest.IGNORE_EXCEPTION_DETAIL
+PRETTY = pdoctest.register_optionflag('PRETTY')
+pdoctest.PRETTY = PRETTY
+
+################################################################################
+####                           Utilities                                    ####
+################################################################################
+
 
 def sys_normcase(f):
     if sys_case_insensitive:
@@ -103,14 +186,44 @@ def isgeneratorfunction(object):
         return True
     return False
 
-def setup_pprint():
-    from sympy import pprint_use_unicode, init_printing
+class PrintManager(object):
+    """
+    Class for manage test's output printer methods (pprint or strprinter).
+    """
+    def __init__(self):
+        self._pprint_status = None
 
-    # force pprint to be in ascii mode in doctests
-    pprint_use_unicode(False)
+    def save_displayhook(self):
+        self._displayhook = sys.displayhook
 
-    # hook our nice, hash-stable strprinter
-    init_printing(pretty_print=False)
+    def restore_displayhook(self):
+        sys.displayhook = self._displayhook
+
+    def setup_pprint(self, pretty_print = False, hard=False):
+        """
+        Load and set printer according the options.
+        """
+        if (self._pprint_status <> pretty_print) or hard:
+            self._setup_pprint(pretty_print)
+            self._pprint_status = pretty_print
+
+    def _setup_pprint(self, pretty_print = False):
+
+        from sympy import pprint_use_unicode, init_printing
+
+        # force pprint to be in ascii mode in doctests
+        pprint_use_unicode(False)
+
+        # hook our nice, hash-stable strprinter
+        init_printing(pretty_print=pretty_print)
+
+print_manager = PrintManager()
+
+sympy_dir = get_sympy_dir()
+
+################################################################################
+####                           Entering points                              ####
+################################################################################
 
 def test(*paths, **kwargs):
     """
@@ -170,16 +283,12 @@ def test(*paths, **kwargs):
     seed = kwargs.get("seed", None)
     if seed is None:
         seed = random.randrange(100000000)
-    r = PyTestReporter(verbose, tb, colors)
-    t = SymPyTests(r, kw, post_mortem, seed)
 
-    # Disable warnings for external modules
-    import sympy.external
-    sympy.external.importtools.WARN_OLD_VERSION = False
-    sympy.external.importtools.WARN_NOT_INSTALLED = False
+    r = PyTestReporter(verbose, tb, colors)
+    t = SymPyTester(r, kw, post_mortem, seed)
+    t.load_sympy_modules()
 
     test_files = t.get_test_files('sympy')
-
     if len(paths) == 0:
         t._testfiles.extend(test_files)
     else:
@@ -195,10 +304,13 @@ def test(*paths, **kwargs):
 
     return t.test(sort=sort)
 
+
 def doctest(*paths, **kwargs):
     """
-    Runs doctests in all *py files in the sympy directory which match
+    Runs doctests in all *.py files in the sympy directory which match
     any of the given strings in `paths` or all tests if paths=[].
+
+    Also run doctests in all *.txt files in the sympy/doc/src directory.
 
     Note:
        o paths can be entered in native system format or in unix,
@@ -226,6 +338,8 @@ def doctest(*paths, **kwargs):
     """
     normal = kwargs.get("normal", False)
     verbose = kwargs.get("verbose", False)
+    colors = kwargs.get("colors", True)
+    first_only = kwargs.get("first_only", True)
     blacklist = kwargs.get("blacklist", [])
     blacklist.extend([
                     "doc/src/modules/mpmath", # needs to be fixed upstream
@@ -246,252 +360,244 @@ def doctest(*paths, **kwargs):
                     ])
     blacklist = convert_to_native_paths(blacklist)
 
-    # Disable warnings for external modules
-    import sympy.external
-    sympy.external.importtools.WARN_OLD_VERSION = False
-    sympy.external.importtools.WARN_NOT_INSTALLED = False
+    r = PyTestReporter(verbose, colors=colors, first_only=first_only)
+    t = SymPyDocTester(r, normal)
+    t.load_sympy_modules()
+    t.parser = SymPyTextTestParser()
+    if first_only:
+        t.optionflags |= pdoctest.REPORT_ONLY_FIRST_FAILURE
 
-    r = PyTestReporter(verbose)
-    t = SymPyDocTests(r, normal)
-
+    # Step 1
+    #
+    # Here we test doctests in all *py files
+    #
     test_files = t.get_test_files('sympy')
+
     test_files.extend(t.get_test_files('examples', init_only=False))
 
-    not_blacklisted = [f for f in test_files
-                         if not any(b in f for b in blacklist)]
-    if len(paths) == 0:
-        t._testfiles.extend(not_blacklisted)
-    else:
-        # take only what was requested...but not blacklisted items
-        # and allow for partial match anywhere or fnmatch of name
-        paths = convert_to_native_paths(paths)
-        matched = []
-        for f in not_blacklisted:
-            basename = os.path.basename(f)
-            for p in paths:
-                if p in f or fnmatch(basename, p):
-                    matched.append(f)
-                    break
-        t._testfiles.extend(matched)
+    matched = t.filter_files(test_files, blacklist, paths)
+    t._testfiles.extend(matched)
+
+    # setup prtinter
+    print_manager.setup_pprint(False, hard=True)
+
 
     # run the tests and record the result for this *py portion of the tests
     if t._testfiles:
-        failed = not t.test()
+        failed = not t.test_docstrings()
     else:
         failed = False
 
-    # N.B.
-    # --------------------------------------------------------------------
+
+    # Step 2
+    #
     # Here we test *.txt files at or below doc/src. Code from these must
     # be self supporting in terms of imports since there is no importing
     # of necessary modules by doctest.testfile. If you try to pass *.py
     # files through this they might fail because they will lack the needed
     # imports and smarter parsing that can be done with source code.
     #
+    failed_2 = False
     test_files = t.get_test_files('doc/src', '*.txt', init_only=False)
     test_files.sort()
 
-    not_blacklisted = [f for f in test_files
-                            if not any(b in f for b in blacklist)]
+    matched = t.filter_files(test_files, blacklist, paths)
+    t._testfiles = matched
+    t.pprint_status = None
+    print_manager.setup_pprint(False, hard=True)
 
-    if len(paths) == 0:
-        matched = not_blacklisted
-    else:
-        # Take only what was requested as long as it's not on the blacklist.
-        # Paths were already made native in *py tests so don't repeat here.
-        # There's no chance of having a *py file slip through since we
-        # only have *txt files in test_files.
-        matched =  []
-        for f in not_blacklisted:
-            basename = os.path.basename(f)
-            for p in paths:
-                if p in f or fnmatch(basename, p):
-                    matched.append(f)
-                    break
+    if t._testfiles:
+        failed_2 = not t.test_text_files()
 
-    setup_pprint()
-    first_report = True
-    for txt_file in matched:
-        if not os.path.isfile(txt_file):
-            continue
-        old_displayhook = sys.displayhook
+    return not (failed or failed_2)
+
+def wikitest(*paths, **kwargs):
+    """
+    Runs wikitest in files in the wiki_dir directory.
+
+    The files are to be passing throu the test contain the special directives.
+    For reStructedText comments is shaped as:
+        .. wikitest release
+    For markdown:
+        <!-- wikitest release -->
+
+    "wikitest release" directive means that tests for current wiki-page have
+    to be passed against release version only.
+    "wikitest master" - against master.
+    "wikitest master,release" - against master and release version
+
+    To run tests  only for a few files, `paths` is used. If paths=[] then all
+    files with directives tests.
+
+    Note:
+       o paths can be entered in native system format or in unix,
+         forward-slash format.
+       o files that are on the blacklist can be tested by providing
+         their path; they are only excluded if no paths are given.
+
+    Examples:
+
+    >> from sympy.utilities.runtests import wikitest
+
+    Run all tests:
+
+    >> wikitest()
+
+    """
+    normal = kwargs.get("normal", False)
+    verbose = kwargs.get("verbose", False)
+    colors = kwargs.get("colors", True)
+    first_only = kwargs["first_only"]
+    againstlist = kwargs.get("againstlist", ["master"])
+    blacklist = kwargs.get("blacklist", [])
+    blacklist.extend([])
+    blacklist = convert_to_native_paths(blacklist)
+    wiki_dir = kwargs["wiki_dir"]
+
+    r = PyTestReporter(verbose, colors=colors, first_only=first_only)
+    t = SymPyWikiTester(r, normal, wiki_dir)
+    t.parser = SymPyTextTestParser()
+    if first_only:
+        t.optionflags |= pdoctest.REPORT_ONLY_FIRST_FAILURE
+
+    failed_total = False
+
+    for against in againstlist:
+        t.set_against_dir(against, kwargs["%s_dir" % against])
+        t.load_sympy_version()
+        t.load_sympy_modules()
+
+        test_files = t.get_test_files(wiki_dir, pat=r"^.*\.(md|rest|mediawiki)$",init_only=False)
+
+        matched = t.filter_files(test_files, blacklist, paths)
+        t._testfiles = matched
+        t.pprint_status = None
+        print_manager.setup_pprint(False, hard=True)
+        if t._testfiles:
+            failed = not t.test_text_files()
+
+        if failed:
+            failed_total = True
+    return not failed_total
+
+
+
+################################################################################
+####                           Tester classes                               ####
+################################################################################
+
+
+
+#    Hierarchy:
+#
+#
+#    SymPyTesterBase
+#              // base tester class
+#        methods:
+#         - filter_files()      // Filter files by blacklist
+#         - load_sympy_modules() // load sympy modules
+#         - clear_cache()
+#
+#
+#    SymPyTester(SymPyTesterBase)
+#               // find and test 'test_*.py' files
+#        methods:
+#        - get_test_files()     // find 'test_*.py'
+#        - test()               // test them
+#        - test_python_file()   // test a 'test_*.py' file
+#
+#
+#
+#    SymPyDocTester(SymPyTesterBase)
+#              // find and test docstrings and *.txt files
+#        methods:
+#        - get_test_files()          // find `*.py' or `*.txt` files
+#        - test_docstrings()         // test docstrings in the files founded out
+#        - test_docstrings_in_file() // test docstrings in the '*.py' file
+#        - test_text_files()         // test examples in the files founded out
+#        - test_text_file()          // test examples in the '*.txt' file and in the wiki page
+#
+#
+#
+#    SymPyWikiTester(SymPyDocTester)
+#               // find and test wiki pages
+#       methods:
+#        - get_test_files()       // find `*.rst` and `*.md` files
+#        - load_sympy_version()   // load right SymPy's version.
+#
+
+class SymPyTesterBase(object):
+    """
+    Base tester class.
+
+    """
+    def __init__(self):
+        self.pprint_status = None
+
+    def load_sympy_modules(self):
+        """
+        Manually load SymPy modules.
+
+        E.g. clear_cache() function, without loading of the sympy itself because another
+        release can be tested) It is needed for wikitest, wehere test passed against
+        another release of SymPy so the modules only of that release must be loaded.
+        """
+        #fn_core_cache  = os.path.join(os.path.dirname(__file__), "../core/cache.py")
+        #module_core_cache = imp.load_source("cache", fn_core_cache)
+        #clear_cache = module_core_cache.clear_cache
+
+        from sympy.core.cache import clear_cache
+        self._clear_cache = clear_cache
+
+        # Disable warnings for external modules
+        import sympy.external
+        sympy.external.importtools.WARN_OLD_VERSION = False
+        sympy.external.importtools.WARN_NOT_INSTALLED = False
+
+        global ARCH
+        from sympy.utilities.misc import ARCH
+        global USE_CACHE
         try:
-            # out = pdoctest.testfile(txt_file, module_relative=False, encoding='utf-8',
-            #    optionflags=pdoctest.ELLIPSIS | pdoctest.NORMALIZE_WHITESPACE)
-            out = sympytestfile(txt_file, module_relative=False, encoding='utf-8',
-                optionflags=pdoctest.ELLIPSIS | pdoctest.NORMALIZE_WHITESPACE \
-                            | pdoctest.IGNORE_EXCEPTION_DETAIL)
-        finally:
-            # make sure we return to the original displayhook in case some
-            # doctest has changed that
-            sys.displayhook = old_displayhook
+            from sympy.core.cache import USE_CACHE
+        except:
+            USE_CACHE = "unknown"
+        global GROUND_TYPES
+        from sympy.polys.domains import GROUND_TYPES
 
-        txtfailed, tested = out
-        if tested:
-            failed = txtfailed or failed
-            if first_report:
-                first_report = False
-                msg = 'txt doctests start'
-                lhead = '='*((r.terminal_width - len(msg))//2 - 1)
-                rhead = '='*(r.terminal_width - 1 - len(msg) - len(lhead) - 1)
-                print ' '.join([lhead, msg, rhead])
-                print
-            # use as the id, everything past the first 'sympy'
-            file_id = txt_file[txt_file.find('sympy') + len('sympy') + 1:]
-            print file_id, # get at least the name out so it is know who is being tested
-            wid = r.terminal_width - len(file_id) - 1 #update width
-            test_file = '[%s]' % (tested)
-            report = '[%s]' % (txtfailed or 'OK')
-            print ''.join([test_file,' '*(wid-len(test_file)-len(report)), report])
+    def clear_cache(self):
+        self._clear_cache()
 
-    # the doctests for *py will have printed this message already if there was
-    # a failure, so now only print it if there was intervening reporting by
-    # testing the *txt as evidenced by first_report no longer being True.
-    if not first_report and failed:
-        print
-        print("DO *NOT* COMMIT!")
+    def filter_files(self, test_files, blacklist, argument_paths):
+        """
+        Filter files by blacklist and/or by argument of command.
+        """
+        not_blacklisted = [f for f in test_files
+                             if not any(b in f for b in blacklist)]
+        if len(argument_paths) == 0:
+            matched = not_blacklisted
+        else:
+            # Take only what was requested as long as it's not on the blacklist.
+            # Paths were already made native in *py tests so don't repeat here.
+            # There's no chance of having a *py file slip through since we
+            # only have *txt files in test_files.
+            matched =  []
+            for f in not_blacklisted:
+                basename = os.path.basename(f)
+                for p in argument_paths:
+                    if p in f or fnmatch(basename, p):
+                        matched.append(f)
+                        break
+        return matched
 
-    return not failed
-
-# The Python 2.5 doctest runner uses a tuple, but in 2.6+, it uses a namedtuple
-# (which doesn't exist in 2.5-)
-if sys.version_info[:2] > (2,5):
-    from collections import namedtuple
-    SymPyTestResults = namedtuple('TestResults', 'failed attempted')
-else:
-    SymPyTestResults = lambda a, b: (a, b)
-
-def sympytestfile(filename, module_relative=True, name=None, package=None,
-             globs=None, verbose=None, report=True, optionflags=0,
-             extraglobs=None, raise_on_error=False,
-             parser=pdoctest.DocTestParser(), encoding=None):
+class SymPyTester(SymPyTesterBase):
     """
-    Test examples in the given file.  Return (#failures, #tests).
-
-    Optional keyword arg "module_relative" specifies how filenames
-    should be interpreted:
-
-      - If "module_relative" is True (the default), then "filename"
-         specifies a module-relative path.  By default, this path is
-         relative to the calling module's directory; but if the
-         "package" argument is specified, then it is relative to that
-         package.  To ensure os-independence, "filename" should use
-         "/" characters to separate path segments, and should not
-         be an absolute path (i.e., it may not begin with "/").
-
-      - If "module_relative" is False, then "filename" specifies an
-        os-specific path.  The path may be absolute or relative (to
-        the current working directory).
-
-    Optional keyword arg "name" gives the name of the test; by default
-    use the file's basename.
-
-    Optional keyword argument "package" is a Python package or the
-    name of a Python package whose directory should be used as the
-    base directory for a module relative filename.  If no package is
-    specified, then the calling module's directory is used as the base
-    directory for module relative filenames.  It is an error to
-    specify "package" if "module_relative" is False.
-
-    Optional keyword arg "globs" gives a dict to be used as the globals
-    when executing examples; by default, use {}.  A copy of this dict
-    is actually used for each docstring, so that each docstring's
-    examples start with a clean slate.
-
-    Optional keyword arg "extraglobs" gives a dictionary that should be
-    merged into the globals that are used to execute examples.  By
-    default, no extra globals are used.
-
-    Optional keyword arg "verbose" prints lots of stuff if true, prints
-    only failures if false; by default, it's true iff "-v" is in sys.argv.
-
-    Optional keyword arg "report" prints a summary at the end when true,
-    else prints nothing at the end.  In verbose mode, the summary is
-    detailed, else very brief (in fact, empty if all tests passed).
-
-    Optional keyword arg "optionflags" or's together module constants,
-    and defaults to 0.  Possible values (see the docs for details):
-
-        DONT_ACCEPT_TRUE_FOR_1
-        DONT_ACCEPT_BLANKLINE
-        NORMALIZE_WHITESPACE
-        ELLIPSIS
-        SKIP
-        IGNORE_EXCEPTION_DETAIL
-        REPORT_UDIFF
-        REPORT_CDIFF
-        REPORT_NDIFF
-        REPORT_ONLY_FIRST_FAILURE
-
-    Optional keyword arg "raise_on_error" raises an exception on the
-    first unexpected exception or failure. This allows failures to be
-    post-mortem debugged.
-
-    Optional keyword arg "parser" specifies a DocTestParser (or
-    subclass) that should be used to extract tests from the files.
-
-    Optional keyword arg "encoding" specifies an encoding that should
-    be used to convert the file to unicode.
-
-    Advanced tomfoolery:  testmod runs methods of a local instance of
-    class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
-    can be called directly too, if you want to do something unusual.
-    Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
-    when you're done fiddling.
+    Class for the testing if `test_*.py` files.
     """
-    if package and not module_relative:
-        raise ValueError("Package may only be specified for module-"
-                         "relative paths.")
-
-    # Relativize the path
-    if sys.version_info[0] < 3:
-        text, filename = pdoctest._load_testfile(filename, package, module_relative)
-    else:
-        encoding = None
-        text, filename = pdoctest._load_testfile(filename, package, module_relative, encoding)
-
-    # If no name was given, then use the file's name.
-    if name is None:
-        name = os.path.basename(filename)
-
-    # Assemble the globals.
-    if globs is None:
-        globs = {}
-    else:
-        globs = globs.copy()
-    if extraglobs is not None:
-        globs.update(extraglobs)
-    if '__name__' not in globs:
-        globs['__name__'] = '__main__'
-
-    if raise_on_error:
-        runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
-    else:
-        runner = SymPyDocTestRunner(verbose=verbose, optionflags=optionflags)
-
-    if encoding is not None:
-        text = text.decode(encoding)
-
-    # Read the file, convert it to a test, and run it.
-    test = parser.get_doctest(text, globs, name, filename, 0)
-    runner.run(test)
-
-    if report:
-        runner.summarize()
-
-    if pdoctest.master is None:
-        pdoctest.master = runner
-    else:
-        pdoctest.master.merge(runner)
-
-    return SymPyTestResults(runner.failures, runner.tries)
-
-class SymPyTests(object):
 
     def __init__(self, reporter, kw="", post_mortem=False,
-                 seed=random.random()):
+                seed=random.random()):
+        SymPyTesterBase.__init__(self)
+
         self._post_mortem = post_mortem
         self._kw = kw
         self._count = 0
@@ -500,6 +606,19 @@ class SymPyTests(object):
         self._reporter.root_dir(self._root_dir)
         self._testfiles = []
         self._seed = seed
+
+    def get_test_files(self, dir, pat = 'test_*.py'):
+        """
+        Returns the list of test_*.py (default) files at or below directory
+        `dir` relative to the sympy home directory.
+        """
+        dir = os.path.join(self._root_dir, convert_to_native_paths([dir])[0])
+
+        g = []
+        for path, folders, files in os.walk(dir):
+            g.extend([os.path.join(path, f) for f in files if fnmatch(f, pat)])
+
+        return [sys_normcase(gi) for gi in g]
 
     def test(self, sort=False):
         """
@@ -516,17 +635,23 @@ class SymPyTests(object):
         self._reporter.start(self._seed)
         for f in self._testfiles:
             try:
-                self.test_file(f)
+                self.test_python_file(f)
             except KeyboardInterrupt:
                 print " interrupted by user"
                 break
         return self._reporter.finish()
 
-    def test_file(self, filename):
-        clear_cache()
+    def test_python_file(self, filename):
+        """
+        Test the tests in the "test___.py" file.
+        """
+        # Clear cache for every file tested
+        self.clear_cache()
+
         self._count += 1
         gl = {'__file__':filename}
         random.seed(self._seed)
+
         try:
             execfile(filename, gl)
         except (SystemExit, KeyboardInterrupt):
@@ -607,22 +732,17 @@ class SymPyTests(object):
             return True
         return x.__name__.find(self._kw) != -1
 
-    def get_test_files(self, dir, pat = 'test_*.py'):
-        """
-        Returns the list of test_*.py (default) files at or below directory
-        `dir` relative to the sympy home directory.
-        """
-        dir = os.path.join(self._root_dir, convert_to_native_paths([dir])[0])
 
-        g = []
-        for path, folders, files in os.walk(dir):
-            g.extend([os.path.join(path, f) for f in files if fnmatch(f, pat)])
+class SymPyDocTester(SymPyTesterBase):
+    """
+    Class for the testing of docstring and examples in the documentation.
 
-        return [sys_normcase(gi) for gi in g]
-
-class SymPyDocTests(object):
-
+    It tests examples in the docstrings of the `*.py` files, also it tests
+    the examples in the `doc/*.txt` files.
+    """
     def __init__(self, reporter, normal):
+        SymPyTesterBase.__init__(self)
+
         self._count = 0
         self._root_dir = sympy_dir
         self._reporter = reporter
@@ -630,84 +750,8 @@ class SymPyDocTests(object):
         self._normal = normal
 
         self._testfiles = []
-
-    def test(self):
-        """
-        Runs the tests and returns True if all tests pass, otherwise False.
-        """
-        self._reporter.start()
-        for f in self._testfiles:
-            try:
-                self.test_file(f)
-            except KeyboardInterrupt:
-                print " interrupted by user"
-                break
-        return self._reporter.finish()
-
-    def test_file(self, filename):
-        clear_cache()
-
-        import unittest
-        from StringIO import StringIO
-
-        rel_name = filename[len(self._root_dir)+1:]
-        dirname, file = os.path.split(filename)
-        module = rel_name.replace(os.sep, '.')[:-3]
-
-        if rel_name.startswith("examples"):
-            # Example files do not have __init__.py files,
-            # So we have to temporarily extend sys.path to import them
-            sys.path.insert(0, dirname)
-            module = file[:-3] # remove ".py"
-        setup_pprint()
-        try:
-            module = pdoctest._normalize_module(module)
-            tests = SymPyDocTestFinder().find(module)
-        except:
-            self._reporter.import_error(filename, sys.exc_info())
-            return
-        finally:
-            if rel_name.startswith("examples"):
-                del sys.path[0]
-
-        tests = [test for test in tests if len(test.examples) > 0]
-        # By default tests are sorted by alphabetical order by function name.
-        # We sort by line number so one can edit the file sequentially from
-        # bottom to top. However, if there are decorated functions, their line
-        # numbers will be too large and for now one must just search for these
-        # by text and function name.
-        tests.sort(key=lambda x: -x.lineno)
-
-        if not tests:
-            return
-        self._reporter.entering_filename(filename, len(tests))
-        for test in tests:
-            assert len(test.examples) != 0
-            runner = SymPyDocTestRunner(optionflags=pdoctest.ELLIPSIS | \
-                    pdoctest.NORMALIZE_WHITESPACE | pdoctest.IGNORE_EXCEPTION_DETAIL)
-            old = sys.stdout
-            new = StringIO()
-            sys.stdout = new
-            # If the testing is normal, the doctests get importing magic to
-            # provide the global namespace. If not normal (the default) then
-            # then must run on their own; all imports must be explicit within
-            # a function's docstring. Once imported that import will be
-            # available to the rest of the tests in a given function's
-            # docstring (unless clear_globs=True below).
-            if not self._normal:
-                test.globs = {}
-                # if this is uncommented then all the test would get is what
-                # comes by default with a "from sympy import *"
-                #exec('from sympy import *') in test.globs
-            try:
-                f, t = runner.run(test, out=new.write, clear_globs=False)
-            finally:
-                sys.stdout = old
-            if f > 0:
-                self._reporter.doctest_fail(test.name, new.getvalue())
-            else:
-                self._reporter.test_pass()
-        self._reporter.leaving_filename()
+        self.optionflags = pdoctest.ELLIPSIS | pdoctest.NORMALIZE_WHITESPACE | \
+            pdoctest.DONT_ACCEPT_TRUE_FOR_1 | pdoctest.IGNORE_EXCEPTION_DETAIL
 
     def get_test_files(self, dir, pat='*.py', init_only=True):
         """
@@ -741,6 +785,456 @@ class SymPyDocTests(object):
             g = [x for x in g if importable(x)]
 
         return [sys_normcase(gi) for gi in g]
+
+    def test_docstrings(self):
+        """
+        Runs the tests and returns True if all tests pass, otherwise False.
+        """
+        self._reporter.start()
+        for f in self._testfiles:
+            try:
+                self.test_docstrings_in_file(f)
+            except KeyboardInterrupt:
+                print " interrupted by user"
+                break
+        return self._reporter.finish()
+
+    def test_docstrings_in_file(self, filename):
+        """
+        Test docstrings in the *.py file.
+        """
+        # Clear cache for every file tested
+        self.clear_cache()
+        rel_name = filename[len(self._root_dir)+1:]
+        dirname, file = os.path.split(filename)
+        module = rel_name.replace(os.sep, '.')[:-3]
+
+        if rel_name.startswith("examples"):
+            # Example files do not have __init__.py files,
+            # So we have to temporarily extend sys.path to import them
+            sys.path.insert(0, dirname)
+            module = file[:-3] # remove ".py"
+
+        print_manager.setup_pprint(False, hard=True)
+
+        try:
+            module = pdoctest._normalize_module(module)
+            tests = SymPyDocTestFinder().find(module)
+        except (SystemExit, KeyboardInterrupt):
+            raise
+        except:
+            self._reporter.import_error(filename, sys.exc_info())
+            return
+
+        finally:
+            if rel_name.startswith("examples"):
+                del sys.path[0]
+
+        tests = [test for test in tests if len(test.examples) > 0]
+        # By default tests are sorted by alphabetical order by function name.
+        # We sort by line number so one can edit the file sequentially from
+        # bottom to top. However, if there are decorated functions, their line
+        # numbers will be too large and for now one must just search for these
+        # by text and function name.
+        tests.sort(key=lambda x: -x.lineno)
+
+        if not tests:
+            return
+        self._reporter.entering_filename(filename, len(tests))
+        for test in tests:
+            assert len(test.examples) != 0
+            runner = SymPyDocTestRunner(optionflags=pdoctest.ELLIPSIS | \
+                    pdoctest.NORMALIZE_WHITESPACE | \
+                    pdoctest.IGNORE_EXCEPTION_DETAIL)
+
+            old = sys.stdout
+            new = StringIO()
+            sys.stdout = new
+            # If the testing is normal, the doctests get importing magic to
+            # provide the global namespace. If not normal (the default) then
+            # then must run on their own; all imports must be explicit within
+            # a function's docstring. Once imported that import will be
+            # available to the rest of the tests in a given function's
+            # docstring (unless clear_globs=True below).
+            if not self._normal:
+                test.globs = {}
+                # if this is uncommented then all the test would get is what
+                # comes by default with a "from sympy import *"
+                #exec('from sympy import *') in test.globs
+            try:
+                f, t = runner.run(test, out=new.write, clear_globs=False)
+            finally:
+                sys.stdout = old
+            if f > 0:
+                self._reporter.doctest_fail(test.name, new.getvalue())
+            else:
+                self._reporter.test_pass()
+        self._reporter.leaving_filename()
+
+    def test_text_files(self):
+        """
+        Runs the tests and returns True if all tests pass, otherwise False.
+        """
+        self._reporter.start()
+        for f in self._testfiles:
+            # make sure we return to the original displayhook in case some
+            # doctest has changed that
+            old_displayhook = sys.displayhook
+            old_optionflags = self.optionflags
+            self.pre_options(f)
+
+            try:
+                self.test_text_file(f, module_relative=False,
+                    optionflags=self.optionflags,
+                    parser=self.parser, encoding='utf-8')
+                sys.displayhook = old_displayhook
+            except KeyboardInterrupt:
+                sys.displayhook = old_displayhook
+                print " interrupted by user"
+                break
+            finally:
+                sys.displayhook = old_displayhook
+                self.optionflags = old_optionflags
+
+        return self._reporter.finish()
+
+    def test_text_file(self, filename, module_relative=True, name=None, package=None,
+                 globs=None, verbose=None, report=True, optionflags=0,
+                 extraglobs=None, raise_on_error=False,
+                 parser=DocTestParser, encoding=None):
+        """
+        Test examples in the given (*.txt) file.
+
+        Return (#failures, #tests).
+
+        Optional keyword arg "module_relative" specifies how filenames
+        should be interpreted:
+
+          - If "module_relative" is True (the default), then "filename"
+             specifies a module-relative path.  By default, this path is
+             relative to the calling module's directory; but if the
+             "package" argument is specified, then it is relative to that
+             package.  To ensure os-independence, "filename" should use
+             "/" characters to separate path segments, and should not
+             be an absolute path (i.e., it may not begin with "/").
+
+          - If "module_relative" is False, then "filename" specifies an
+            os-specific path.  The path may be absolute or relative (to
+            the current working directory).
+
+        Optional keyword arg "name" gives the name of the test; by default
+        use the file's basename.
+
+        Optional keyword argument "package" is a Python package or the
+        name of a Python package whose directory should be used as the
+        base directory for a module relative filename.  If no package is
+        specified, then the calling module's directory is used as the base
+        directory for module relative filenames.  It is an error to
+        specify "package" if "module_relative" is False.
+
+        Optional keyword arg "globs" gives a dict to be used as the globals
+        when executing examples; by default, use {}.  A copy of this dict
+        is actually used for each docstring, so that each docstring's
+        examples start with a clean slate.
+
+        Optional keyword arg "extraglobs" gives a dictionary that should be
+        merged into the globals that are used to execute examples.  By
+        default, no extra globals are used.
+
+        Optional keyword arg "verbose" prints lots of stuff if true, prints
+        only failures if false; by default, it's true iff "-v" is in sys.argv.
+
+        Optional keyword arg "report" prints a summary at the end when true,
+        else prints nothing at the end.  In verbose mode, the summary is
+        detailed, else very brief (in fact, empty if all tests passed).
+
+        Optional keyword arg "optionflags" or's together module constants,
+        and defaults to 0.  Possible values (see the docs for details):
+
+            DONT_ACCEPT_TRUE_FOR_1
+            DONT_ACCEPT_BLANKLINE
+            NORMALIZE_WHITESPACE
+            ELLIPSIS
+            SKIP
+            IGNORE_EXCEPTION_DETAIL
+            REPORT_UDIFF
+            REPORT_CDIFF
+            REPORT_NDIFF
+            REPORT_ONLY_FIRST_FAILURE
+
+        Optional keyword arg "raise_on_error" raises an exception on the
+        first unexpected exception or failure. This allows failures to be
+        post-mortem debugged.
+
+        Optional keyword arg "parser" specifies a DocTestParser (or
+        subclass) that should be used to extract tests from the files.
+
+        Optional keyword arg "encoding" specifies an encoding that should
+        be used to convert the file to unicode.
+
+        Advanced tomfoolery:  testmod runs methods of a local instance of
+        class doctest.Tester, then merges the results into (or creates)
+        global Tester instance doctest.master.  Methods of doctest.master
+        can be called directly too, if you want to do something unusual.
+        Passing report=0 to testmod is especially useful then, to delay
+        displaying a summary.  Invoke doctest.master.summarize(verbose)
+        when you're done fiddling.
+        """
+        if package and not module_relative:
+            raise ValueError("Package may only be specified for module-"
+                             "relative paths.")
+
+        # Relativize the path
+        if sys.version_info[0] < 3:
+            # Fix doctest runner for Python 3
+            text, filename = pdoctest._load_testfile(filename, package, module_relative)
+        else:
+            encoding = None
+            text, filename = pdoctest._load_testfile(filename, package, module_relative, encoding)
+
+        # If no name was given, then use the file's name.
+        if name is None:
+            name = os.path.basename(filename)
+
+        # Assemble the globals.
+        if globs is None:
+            globs = {}
+        else:
+            globs = globs.copy()
+        if extraglobs is not None:
+            globs.update(extraglobs)
+        if '__name__' not in globs:
+            globs['__name__'] = '__main__'
+
+        if raise_on_error:
+            runner = pdoctest.DebugRunner(verbose=verbose, optionflags=optionflags)
+        else:
+            runner = SymPyDocTestRunner(verbose=verbose, optionflags=optionflags)
+
+        if encoding is not None:
+            text = text.decode(encoding)
+
+        # Read the file, convert it to a test, and run it.
+        tests = parser.get_doctests(text, globs, name, filename, 0)
+
+        if len(tests):
+            self._reporter.entering_filename(filename, len(tests))
+            for test in tests:
+                test.globs = globs
+                old = sys.stdout
+                new = StringIO()
+                sys.stdout = new
+                try:
+                    f, t = runner.run(test, out=new.write, clear_globs=False)
+                finally:
+                    sys.stdout = old
+                globs.update(test.globs)
+                if f > 0:
+                    self._reporter.doctest_fail(test.name, new.getvalue())
+                else:
+                    self._reporter.test_pass()
+            self._reporter.leaving_filename()
+
+    def pre_options(self, fn):
+        pass
+
+
+class SymPyWikiTester(SymPyDocTester):
+    """
+    Class for the testing examples in the wiki pages.
+    """
+
+    def __init__(self, reporter, normal, root_dir):
+        SymPyDocTester.__init__(self, reporter, normal)
+
+        self._count = 0
+        self._root_dir = root_dir
+        self._reporter = reporter
+        self._reporter.root_dir(self._root_dir)
+        self._normal = normal
+
+        self._testfiles = []
+        re_directives = []
+        re_directives.append(re.compile(r"<!--\s+wikitest\s+(?P<against>[\w,]+)(\s+\((?P<options>[\w,]+)\))?\s+-->", re.M))
+        re_directives.append(re.compile(r"\.\.\s+wikitest\s+(?P<against>[\w,]+)(\s+\((?P<options>[\w,]+)\))?\s+$", re.M))
+        self.re_directives = re_directives
+
+    def set_against_dir(self, against, against_dir):
+        """Set against dir.
+
+        While testing this dir will be injected into the test for catching right
+        version of SymPy (release, or master)
+        """
+        self.against = against
+        self.against_dir = against_dir
+
+    def get_test_files(self, dir, pat=r'^.*\.md$', init_only=True):
+        """
+        Returns the list of wiki-pages (default) from which docstrings
+        will be tested which are at or below directory `dir`.
+        """
+        re_filename = re.compile(pat)
+
+        def _fnmatch(fn):
+            if re_filename.match(fn):
+                return True
+            return False
+        #dir = os.path.join(self._root_dir, convert_to_native_paths([dir])[0])
+        dir = os.path.join("/", convert_to_native_paths([dir])[0])
+
+        g = []
+        for path, folders, files in os.walk(dir):
+            g.extend([os.path.join(path, f) for f in files
+                      if _fnmatch(f) and self.has_directive(path, f)])
+        return [sys_normcase(gi) for gi in g]
+
+    def has_directive(self, pathdir, fn):
+        """
+        Checks if file contain the directive.
+        """
+        fn = os.path.join(pathdir, fn)
+        f = codecs.open(fn, mode="r", encoding="utf8")
+        s = f.read()
+        f.close()
+        for re_directive in self.re_directives:
+            m = re_directive.search(s)
+            if m:
+                against_permitted = m.group("against").split(",")
+                if self.against in against_permitted:
+                    return True
+        return False
+
+    def get_directive_options(self, filename):
+        res = {}
+        f = codecs.open(filename, mode="r", encoding="utf8")
+        s = f.read()
+        f.close()
+        for re_directive in self.re_directives:
+            m = re_directive.search(s)
+            if m:
+                against_permitted = m.group("against").split(",")
+                if self.against in against_permitted:
+                    options = m.group("options")
+                    if options:
+                        options = options.split(",")
+                        for op in options:
+                            res[op] = True
+        return res
+
+    def pre_options(self, fn):
+        directive_options = self.get_directive_options(fn)
+        pretty_print = directive_options.get("pretty_print", False)
+        if pretty_print:
+            self.optionflags |= PRETTY
+
+        print_manager.setup_pprint(pretty_print, hard=True)
+
+    def load_sympy_version(self):
+        """
+        Load right SymPy's version.
+        And unload previous if it's needed
+        """
+        for _key in sys.modules.keys():
+            if len(_key.split("sympy")) > 1:
+                del sys.modules[_key]
+        sys.path.insert(0, self.against_dir)
+
+
+################################################################################
+####           Finder, Parser, Runner classes                                ####
+################################################################################
+
+class SymPyTextTestParser(DocTestParser):
+    """
+    Parser to find tests in the wiki page.
+
+    It extend standard DocTestParser to catch Markdown code-block syntax with
+    pigment like ```py   >>> x = Symbol('x')```
+    """
+    _EXAMPLE_RE = re.compile(r'''
+        # Source consists of a PS1 line followed by zero or more PS2 lines.
+        (?P<source>
+            (?:^(?P<indent> [ ]*) >>>    .*)    # PS1 line
+            (?:\n           [ ]*  \.\.\. .*)*)  # PS2 lines
+        \n?
+        # Want consists of any non-blank lines that do not start with PS1.
+        (?P<want> (?:(?![ ]*$)    # Not a blank line
+                     (?![ ]*>>>)  # Not a line starting with PS1
+                     (?![ ]*```)  # Not a ```
+                     .*$\n?       # But any other line
+                  )*)
+        ''', re.MULTILINE | re.VERBOSE)
+
+    def get_doctests(self, text, globs, name, filename, lineno):
+        """
+        Parse text, and extract examples grouped by tests.
+
+        It extends "get_doctest" to group examples to blocks (tests).
+        """
+
+        doctests = []
+        splitted_examples = self.parse_ext(text, name)
+        examples = []
+        examples_fullsource = []
+        for x in splitted_examples:
+            if isinstance(x, Example):
+                examples.append(x)
+                examples_fullsource.append(x._fullsource)
+            elif self._IS_BLANK_OR_COMMENT(x):
+                examples_fullsource.append(x)
+            else:
+                # form DocTest
+                if len(examples):
+                    doctest = pdoctest.DocTest(examples, globs, name, filename,
+                        0,
+                        string.join(examples_fullsource, ""))
+                    doctests.append(doctest)
+                    examples = []
+                    examples_fullsource = []
+        return doctests
+
+    def parse_ext(self, string, name='<string>'):
+        """
+        Parse text, and extract examples grouped by tests.
+
+        It extends "get_doctest" to group examples to blocks (tests).
+        The code is based on the DocTestParser.parse() method and extend it
+        by only adding aditional info for examples ("_fullsource").
+        """
+        string = string.expandtabs()
+        # If all lines begin with the same indentation, then strip it.
+        min_indent = self._min_indent(string)
+        if min_indent > 0:
+            string = '\n'.join([l[min_indent:] for l in string.split('\n')])
+
+        output = []
+        charno, lineno = 0, 0
+        # Find all doctest examples in the string:
+        for m in self._EXAMPLE_RE.finditer(string):
+            # Add the pre-example text to `output`.
+            output.append(string[charno:m.start()])
+            # Update lineno (lines before this example)
+            lineno += string.count('\n', charno, m.start())
+            # Extract info from the regexp match.
+            (source, options, want, exc_msg) = \
+                     self._parse_example(m, name, lineno)
+            # Create an Example, and add it to the list.
+            if not self._IS_BLANK_OR_COMMENT(source):
+                example = Example(source, want, exc_msg,
+                                    lineno=lineno,
+                                    indent=min_indent+len(m.group('indent')),
+                                    options=options)
+                example._fullsource = string[m.start():m.end()]
+                output.append(example)
+
+            # Update lineno (lines inside this example)
+            lineno += string.count('\n', m.start(), m.end())
+            # Update charno.
+            charno = m.end()
+        # Add any remaining post-example text to `output`.
+        output.append(string[charno:])
+        return output
+
 
 class SymPyDocTestFinder(DocTestFinder):
     """
@@ -893,6 +1387,7 @@ class SymPyDocTestFinder(DocTestFinder):
         return self._parser.get_doctest(docstring, globs, name,
                                         filename, lineno)
 
+
 class SymPyDocTestRunner(DocTestRunner):
     """
     A class used to run DocTest test cases, and accumulate statistics.
@@ -960,12 +1455,158 @@ class SymPyDocTestRunner(DocTestRunner):
             if clear_globs:
                 test.globs.clear()
 
+    # this method have gotten from original doctest module
+    # except
+    #    (a) the checking of `PRETTY` option for every example.
+    #    (b) updating compileflags for every example
+    #        to handle properly  with "from __future__ import division".
+    def __run(self, test, compileflags, out):
+        """
+        Run the examples in `test`.  Write the outcome of each example
+        with one of the `DocTestRunner.report_*` methods, using the
+        writer function `out`.  `compileflags` is the set of compiler
+        flags that should be used to execute examples.  Return a tuple
+        `(f, t)`, where `t` is the number of examples tried, and `f`
+        is the number of examples that failed.  The examples are run
+        in the namespace `test.globs`.
+        """
+        # Keep track of the number of failures and tries.
+        failures = tries = 0
+
+        # Save the option flags (since option directives can be used
+        # to modify them).
+        original_optionflags = self.optionflags
+
+        SUCCESS, FAILURE, BOOM = range(3) # `outcome` state
+
+        check = self._checker.check_output
+
+        # Process each example.
+        for examplenum, example in enumerate(test.examples):
+
+            # (b) updating compileflags for every example.
+            if compileflags ==0:
+                compileflags = pdoctest._extract_future_flags(test.globs)
+
+            # If REPORT_ONLY_FIRST_FAILURE is set, then supress
+            # reporting after the first failure.
+            quiet = (self.optionflags & REPORT_ONLY_FIRST_FAILURE and
+                     failures > 0)
+
+            # Merge in the example's options.
+            self.optionflags = original_optionflags
+            if example.options:
+                for (optionflag, val) in example.options.items():
+                    if val:
+                        self.optionflags |= optionflag
+                    else:
+                        self.optionflags &= ~optionflag
+
+            # If 'SKIP' is set, then skip this example.
+            if self.optionflags & SKIP:
+                continue
+
+            # Record that we started this example.
+            tries += 1
+            if not quiet:
+                self.report_start(out, test, example)
+
+            # Use a special filename for compile(), so we can retrieve
+            # the source code during interactive debugging (see
+            # __patched_linecache_getlines).
+            filename = '<doctest %s[%d]>' % (test.name, examplenum)
+
+            # (a) the checking of `PRETTY` option for every example.
+            # Set printer
+            if self.optionflags & PRETTY:
+                print_manager.setup_pprint(True)
+            else:
+                print_manager.setup_pprint(False)
+
+
+            # Run the example in the given context (globs), and record
+            # any exception that gets raised.  (But don't intercept
+            # keyboard interrupts.)
+            try:
+                # Don't blink!  This is where the user's code gets run.
+                exec compile(example.source, filename, "single",
+                             compileflags, 1) in test.globs
+                self.debugger.set_continue() # ==== Example Finished ====
+                exception = None
+            except KeyboardInterrupt:
+                raise
+            except:
+                exception = sys.exc_info()
+                self.debugger.set_continue() # ==== Example Finished ====
+
+            got = self._fakeout.getvalue()  # the actual output
+            self._fakeout.truncate(0)
+            outcome = FAILURE   # guilty until proved innocent or insane
+
+            # If the example executed without raising any exceptions,
+            # verify its output.
+            if exception is None:
+                if check(example.want, got, self.optionflags):
+                    outcome = SUCCESS
+
+            # The example raised an exception:  check if it was expected.
+            else:
+                exc_info = sys.exc_info()   # XXX: duplicated calling of sys.exc_info() ?
+                exc_msg = traceback.format_exception_only(*exc_info[:2])[-1]
+                if not quiet:
+                    got += _exception_traceback(exc_info)
+
+                # If `example.exc_msg` is None, then we weren't expecting
+                # an exception.
+                if example.exc_msg is None:
+                    outcome = BOOM
+
+                # We expected an exception:  see whether it matches.
+                elif check(example.exc_msg, exc_msg, self.optionflags):
+                    outcome = SUCCESS
+
+                # Another chance if they didn't care about the detail.
+                elif self.optionflags & IGNORE_EXCEPTION_DETAIL:
+                    m1 = re.match(r'[^:]*:', example.exc_msg)
+                    m2 = re.match(r'[^:]*:', exc_msg)
+                    if m1 and m2 and check(m1.group(0), m2.group(0),
+                                           self.optionflags):
+                        outcome = SUCCESS
+
+            # Report the outcome.
+            if outcome is SUCCESS:
+                if not quiet:
+                    self.report_success(out, test, example, got)
+            elif outcome is FAILURE:
+                if not quiet:
+                    self.report_failure(out, test, example, got)
+                failures += 1
+            elif outcome is BOOM:
+                if not quiet:
+                    self.report_unexpected_exception(out, test, example,
+                                                     exc_info)
+                failures += 1
+            else:
+                assert False, ("unknown outcome", outcome)
+
+        # Restore the option flags (in case they were modified)
+        self.optionflags = original_optionflags
+
+        # Record and return the number of failures and tries.
+        self.__record_outcome(test, failures, tries)
+        return SymPyTestResults(failures, tries)
+
 # We have to override the name mangled methods.
 SymPyDocTestRunner._SymPyDocTestRunner__patched_linecache_getlines = \
     DocTestRunner._DocTestRunner__patched_linecache_getlines
-SymPyDocTestRunner._SymPyDocTestRunner__run = DocTestRunner._DocTestRunner__run
+#SymPyDocTestRunner._SymPyDocTestRunner__run = DocTestRunner._DocTestRunner__run
 SymPyDocTestRunner._SymPyDocTestRunner__record_outcome = \
     DocTestRunner._DocTestRunner__record_outcome
+
+################################################################################
+####                           Reporter Class                               ####
+################################################################################
+
 
 class Reporter(object):
     """
@@ -978,10 +1619,11 @@ class PyTestReporter(Reporter):
     Py.test like reporter. Should produce output identical to py.test.
     """
 
-    def __init__(self, verbose=False, tb="short", colors=True):
+    def __init__(self, verbose=False, tb="short", colors=True, first_only=False):
         self._verbose = verbose
         self._tb_style = tb
         self._colors = colors
+        self._first_only = first_only
         self._xfailed = 0
         self._xpassed = []
         self._failed = []
@@ -996,6 +1638,7 @@ class PyTestReporter(Reporter):
         # things on the screen), without the need for any readline library:
         self._write_pos = 0
         self._line_wrap = False
+
 
     def root_dir(self, dir):
         self._root_dir = dir
@@ -1063,6 +1706,7 @@ class PyTestReporter(Reporter):
 
         return width
 
+
     def write(self, text, color="", align="left", width=None):
         """
         Prints a text on the screen.
@@ -1121,8 +1765,7 @@ class PyTestReporter(Reporter):
         if self._line_wrap:
             if text[0] != "\n":
                 sys.stdout.write("\n")
-
-        if color == "":
+        if not self._colors or (color == ""):
             sys.stdout.write(text)
         else:
             sys.stdout.write("%s%s%s" % (c_color % colors[color], text, c_normal))
@@ -1158,11 +1801,8 @@ class PyTestReporter(Reporter):
         v = tuple(sys.version_info)
         python_version = "%s.%s.%s-%s-%s" % v
         self.write("executable:   %s  (%s)\n" % (executable, python_version))
-        from .misc import ARCH
         self.write("architecture: %s\n" % ARCH)
-        from sympy.core.cache import USE_CACHE
         self.write("cache:        %s\n" % USE_CACHE)
-        from sympy.polys.domains import GROUND_TYPES
         self.write("ground types: %s\n" % GROUND_TYPES)
         if seed is not None:
             self.write("random seed:  %d\n" % seed)
@@ -1234,13 +1874,15 @@ class PyTestReporter(Reporter):
                 self.write_center("", "_")
                 self.write_center("%s" % filename, "_")
                 self.write(msg)
+                if self._first_only:
+                    break
             self.write("\n")
 
         self.write_center(text)
         ok = len(self._failed) == 0 and len(self._exceptions) == 0 and \
                 len(self._failed_doctest) == 0
         if not ok:
-            self.write("DO *NOT* COMMIT!\n")
+            self.write("DO *NOT* COMMIT!\n", "Red")
         return ok
 
     def entering_filename(self, filename, n):
@@ -1251,12 +1893,11 @@ class PyTestReporter(Reporter):
         self.write("[%d] " % n)
 
     def leaving_filename(self):
-        if self._colors:
-            self.write(" ")
-            if self._active_file_error:
-                self.write("[FAIL]", "Red", align="right")
-            else:
-                self.write("[OK]", "Green", align="right")
+        self.write(" ")
+        if self._active_file_error:
+            self.write("[FAIL]", "Red", align="right")
+        else:
+            self.write("[OK]", "Green", align="right")
         self.write("\n")
         if self._verbose:
             self.write("\n")
@@ -1318,10 +1959,6 @@ class PyTestReporter(Reporter):
         rel_name = filename[len(self._root_dir)+1:]
         self.write(rel_name)
         self.write("[?]   Failed to import", "Red")
-        if self._colors:
-            self.write(" ")
-            self.write("[FAIL]", "Red", align="right")
+        self.write(" ")
+        self.write("[FAIL]", "Red", align="right")
         self.write("\n")
-
-sympy_dir = get_sympy_dir()
-


### PR DESCRIPTION
TODO: test, and wait for 0.7.2 release out.
Added ./bin/wikitest

This procedure test wiki pages against master or release
repositories.

Asuming that wiki.sympy and release version are placed near
master repositary. E.g.

```
./sympy/
./sympy.wiki/
./sympy-0.6.7/
```

If the directories are not the same, then they can be tuned by those options:

```
-a AGAINST, --against=AGAINST
                    What do the tests must be relative [master | release |
                    master,release] [default: master]
-w WIKI_DIR, --wiki-dir=WIKI_DIR
                    The path to the wiki pages directory
-m MASTER_DIR, --master-dir=MASTER_DIR
                    The path to the sympy master repository
-r RELEASE_DIR, --release-dir=RELEASE_DIR
                    The path to the sympy release directory
```

 The files are to be passing throu the test contain the special directives.
 For reStructedText comments is shaped as:

```
.. wikitest release
```

For markdown:

```
<!-- wikitest release -->
```
- "wikitest release" directive means that tests for current wiki-page have
  to be passed against release version only.
- "wikitest master" - against master.
- "wikitest master,release" - against master and release version

Now this directives are is inserted only into a few pages.
