### PR TITLE
Fix Gruntz

### DIFF
--- a/doc/src/modules/series.txt
+++ b/doc/src/modules/series.txt
@@ -3,19 +3,132 @@ Series Expansions
 
 .. module:: sympy.series
 
-The series module implements series expansions as a function. This is achieved 
+The series module implements series expansions as a function and many related
+functions.
+
+Limits
+------
+
+The main purpose of this module is the computation of limits.
+
+.. autofunction:: sympy.series.limits.limit
+
+As is explained above, the workhorse for limit computations is the
+function gruntz() which implements Gruntz' algorithm for computing limits.
+
+The Gruntz Algorithm
+^^^^^^^^^^^^^^^^^^^^
+
+This section explains the basics of the algorithm used for computing limits.
+Most of the time the limit() function should just work. However it is still
+useful to keep in mind how it is implemented in case something does not work
+as expected.
+
+First we define an ordering on functions. Suppose $f(x)$ and $g(x)$ are two
+real-valued functions such that $\lim_{x \to \infty} f(x) = \infty$ and
+similarly $\lim_{x \to \infty} g(x) = \infty$. We shall say that $f(x)$
+*dominates*
+$g(x)$, written $f(x) \succ g(x)$, if for all $a, b \in \mathbb{R}_{>0}$ we have
+$\lim_{x \to \infty} \frac{f(x)^a}{g(x)^b} = \infty$.
+We also say that $f(x)$ and
+$g(x)$ are *of the same comparability class* if neither $f(x) \succ g(x)$ nor
+$g(x) \succ f(x)$ and shall denote it as $f(x) \asymp g(x)$.
+
+Note that whenever $a, b \in \mathbb{R}_{>0}$ then
+$a f(x)^b \asymp f(x)$, and we shall use this to extend the definition of
+$\succ$ to all functions which tend to $0$ or $\pm \infty$ as $x \to \infty$.
+Thus we declare that $f(x) \asymp 1/f(x)$ and $f(x) \asymp -f(x)$.
+
+It is easy to show the following examples:
+
+* $e^x \succ x^m$
+* $e^{x^2} \succ e^{mx}$
+* $e^{e^x} \succ e^{x^m}$
+* $x^m \asymp x^n$
+* $e^{x + \frac{1}{x}} \asymp e^{x + \log{x}} \asymp e^x$.
+
+From the above definition, it is possible to prove the following property:
+
+    Suppose $\omega$, $g_1, g_2, \dots$ are functions of $x$,
+    $\lim_{x \to \infty} \omega = 0$ and $\omega \succ g_i$ for
+    all $i$. Let $c_1, c_2, \dots \in \mathbb{R}$ with $c_1 < c_2 < \dots$.
+
+    Then $\lim_{x \to \infty} \sum_i g_i \omega^{c_i} = \lim_{x \to \infty} g_1 \omega^{c_1}$.
+
+For $g_1 = g$ and $\omega$ as above we also have the following easy result:
+
+    * $\lim_{x \to \infty} g \omega^c = 0$ for $c > 0$
+    * $\lim_{x \to \infty} g \omega^c = \pm \infty$ for $c < 0$,
+      where the sign is determined by the (eventual) sign of $g$
+    * $\lim_{x \to \infty} g \omega^0 = \lim_{x \to \infty} g$.
+
+
+Using these results yields the following strategy for computing
+$\lim_{x \to \infty} f(x)$:
+
+1. Find the set of *most rapidly varying subexpressions* (MRV set) of $f(x)$.
+   That is, from the set of all subexpressions of $f(x)$, find the elements that
+   are maximal under the relation $\succ$.
+2. Choose a function $\omega$ that is in the same comparability class as
+   the elements in the MRV set, such that $\lim_{x \to \infty} \omega = 0$.
+3. Expand $f(x)$ as a series in $\omega$ in such a way that the antecedents of
+   the above theorem are satisfied.
+4. Apply the theorem and conclude the computation of
+   $\lim_{x \to \infty} f(x)$, possibly by recursively working on $g_1(x)$.
+
+
+Notes
+"""""
+
+This exposition glossed over several details. Many are described in the file
+gruntz.py, and all can be found in Gruntz' very readable thesis. The most
+important points that have not been explained are:
+
+1. Given f(x) and g(x), how do we determine if $f(x) \succ g(x)$,
+   $g(x) \succ f(x)$ or $g(x) \asymp f(x)$?
+2. How do we find the MRV set of an expression?
+3. How do we compute series expansions?
+4. Why does the algorithm terminate?
+
+If you are interested, be sure to take a look at
+`Gruntz Thesis <http://www.cybertester.com/data/gruntz.pdf>`_.
+
+
+More Intuitive Series Expansion
+-------------------------------
+
+This is achieved 
 by creating a wrapper around Basic.series(). This allows for the use of 
 series(x*cos(x),x), which is possibly more intuative than (x*cos(x)).series(x).
 
 Examples
---------
+^^^^^^^^
     >>> from sympy import Symbol, cos, series
     >>> x = Symbol('x')
     >>> series(cos(x),x)
     1 - x**2/2 + x**4/24 + O(x**6)
 
+Order Terms
+-----------
 
-TODO and Bugs
--------------
-The series expansion about a point other than x=0 does not work. This is a bug in Basic.series() (issue 1334). When fixed there, the bug will 
-also be automatically fixed here.
+This module also implements automatic keeping track of the order of your
+expansion.
+
+Examples
+^^^^^^^^
+     >>> from sympy import Symbol, Order
+     >>> x = Symbol('x')
+     >>> Order(x) + x**2
+     O(x)
+     >>> Order(x) + 1
+     1 + O(x)
+
+Series Acceleration
+-------------------
+
+TODO
+
+Residues
+--------
+
+TODO

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -397,7 +397,7 @@ class Add(AssocOp):
 
     def _eval_as_leading_term(self, x):
         # TODO this does not need to call nseries!
-        coeff, terms = self.as_coeff_add(x)
+        coeff, terms = self.collect(x).as_coeff_add(x)
         has_unbounded = bool([f for f in self.args if f.is_unbounded])
         if has_unbounded:
             if isinstance(terms, Basic):
@@ -408,7 +408,7 @@ class Add(AssocOp):
         else:
             o = C.Order(terms[0]*x,x)
         n = 1
-        s = self.nseries(x, n=n)
+        s = self.nseries(x, n=n).collect(x) # could be 1/x + 1/(y*x)
         while s.is_Order:
             n +=1
             s = self.nseries(x, n=n)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -215,8 +215,8 @@ class Add(AssocOp):
     def _eval_derivative(self, s):
         return Add(*[f.diff(s) for f in self.args])
 
-    def _eval_nseries(self, x, n):
-        terms = [t.nseries(x, n=n) for t in self.args]
+    def _eval_nseries(self, x, n, logx):
+        terms = [t.nseries(x, n=n, logx=logx) for t in self.args]
         return Add(*terms)
 
     def _matches_simple(self, expr, repl_dict):
@@ -396,6 +396,7 @@ class Add(AssocOp):
         return (self.new(*re_part), self.new(*im_part))
 
     def _eval_as_leading_term(self, x):
+        # TODO this does not need to call nseries!
         coeff, terms = self.as_coeff_add(x)
         has_unbounded = bool([f for f in self.args if f.is_unbounded])
         if has_unbounded:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1249,7 +1249,7 @@ class Expr(Basic, EvalfMixin):
         # from here on it's x0=0 and dir='+' handling
 
         if n != None: # nseries handling
-            s1 = self._eval_nseries(x, n=n)
+            s1 = self._eval_nseries(x, n=n, logx=None)
             o = s1.getO() or S.Zero
             if o:
                 # make sure the requested order is returned
@@ -1264,11 +1264,11 @@ class Expr(Basic, EvalfMixin):
                     # is different than the original order and then predict how
                     # many additional terms are needed
                     for more in range(1, 9):
-                        s1 = self._eval_nseries(x, n=n + more)
+                        s1 = self._eval_nseries(x, n=n + more, logx=None)
                         newn = s1.getn()
                         if newn != ngot:
                             ndo = n + (n - ngot)*more/(newn - ngot)
-                            s1 = self._eval_nseries(x, n=ndo)
+                            s1 = self._eval_nseries(x, n=ndo, logx=None)
                             # if this assertion fails then our ndo calculation
                             # needs modification
                             assert s1.getn() == n
@@ -1342,7 +1342,7 @@ class Expr(Basic, EvalfMixin):
         # override this method and implement much more efficient yielding of
         # terms.
         n = 0
-        series = self._eval_nseries(x, n=n)
+        series = self._eval_nseries(x, n=n, logx=None)
         if not series.is_Order:
             if series.is_Add:
                 yield series.removeO()
@@ -1352,19 +1352,19 @@ class Expr(Basic, EvalfMixin):
 
         while series.is_Order:
             n += 1
-            series = self._eval_nseries(x, n=n)
+            series = self._eval_nseries(x, n=n, logx=None)
         e = series.removeO()
         yield e
         while 1:
             while 1:
                 n += 1
-                series = self._eval_nseries(x, n=n).removeO()
+                series = self._eval_nseries(x, n=n, logx=None).removeO()
                 if e != series:
                     break
             yield series - e
             e = series
 
-    def nseries(self, x=None, x0=0, n=6, dir='+'):
+    def nseries(self, x=None, x0=0, n=6, dir='+',logx=None):
         """
         Wrapper to _eval_nseries if assumptions allow, else to series.
 
@@ -1389,11 +1389,12 @@ class Expr(Basic, EvalfMixin):
         if x and not self.has(x):
             return self
         if x is None or x0 or dir != '+':#{see XPOS above} or (x.is_positive == x.is_negative == None):
+            assert logx == None
             return self.series(x, x0, n, dir)
         else:
-            return self._eval_nseries(x, n=n)
+            return self._eval_nseries(x, n=n, logx=logx)
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         """
         Return terms of series for self up to O(x**n) at x=0
         from the positive direction.
@@ -1410,8 +1411,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.series.limits import limit
         return limit(self, x, xlim, dir)
 
-    @cacheit
-    def compute_leading_term(self, x, skip_abs=False, skip_log=False):
+    def compute_leading_term(self, x, skip_abs=False, logx=None):
         """ as_leading_term is only allowed for results of .series()
             This is a wrapper to compute a series first.
             If skip_abs is true, the absolute term is assumed to be zero.
@@ -1425,13 +1425,15 @@ class Expr(Basic, EvalfMixin):
         from sympy import cancel, expand_mul
         if self.removeO() == 0:
             return self
-        s = cancel(calculate_series(self, x, skip_abs, skip_log))
-        logx = Dummy('l')
-        if skip_log:
-            s = s.subs(C.log(x), logx)
+        if logx is None:
+            d = C.Dummy('logx')
+            s = calculate_series(self, x, skip_abs, d).subs(d, C.log(x))
+        else:
+            s = calculate_series(self, x, skip_abs, logx)
+        s = cancel(s)
         if skip_abs:
             s = expand_mul(s).as_independent(x)[1]
-        return s.as_leading_term(x).subs(logx, C.log(x))
+        return s.as_leading_term(x)
 
     @cacheit
     def as_leading_term(self, *symbols):
@@ -1703,7 +1705,7 @@ class AtomicExpr(Atom, Expr):
     def is_number(self):
         return True
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         return self
 
 from mul import Mul

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -530,6 +530,7 @@ functions are not supported.')
 
     def _eval_as_leading_term(self, x):
         """General method for the leading term"""
+        # XXX This seems broken to me!
         arg = self.args[0].as_leading_term(x)
 
         if C.Order(1,x).contains(arg):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1111,9 +1111,9 @@ class Mul(AssocOp):
             margs = [Pow(new, cdid)] + margs
         return Mul(*margs)*Mul(*nc)
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         from sympy import powsimp
-        terms = [t.nseries(x, n=n) for t in self.args]
+        terms = [t.nseries(x, n=n, logx=logx) for t in self.args]
         return powsimp(Mul(*terms).expand(), combine='exp', deep=True)
 
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -617,6 +617,13 @@ class Pow(Expr):
         return d
 
     def _eval_nseries(self, x, n):
+        # NOTE! This function is an important part of the gruntz algorithm
+        #       for computing limits. It has to return a generalised power series
+        #       with coefficients in C(log, log(x)). In more detail:
+        # It has to return an expression
+        #     c_0*x**e_0 + c_1*x**e_1 + ... (finitely many terms)
+        # where e_i are numbers (not necessarily integers) and c_i are expression
+        # involving only numbers, the log function, and log(x).
         from sympy import powsimp, collect, exp, log, O, ceiling
 
         b, e = self.args
@@ -649,6 +656,10 @@ class Pow(Expr):
                         p = p._eval_nseries(y, n=n)
                         p = p.subs(y, -1/log(x))
                         return p
+                if b.has(log(x)):
+                    y = Dummy("y")
+                    p = 1/b.subs(log(x),y)
+                    return p._eval_nseries(x, n=n).subs(y, log(x))
                 prefactor = b.as_leading_term(x)
                 # express "rest" as: rest = 1 + k*x**l + ... + O(x**n)
                 rest = ((b - prefactor)/prefactor)._eval_expand_mul()
@@ -697,7 +708,7 @@ class Pow(Expr):
                 # now we have a type 1/f(x), that we know how to expand
                 return (1/denominator)._eval_nseries(x, n=n)
 
-        if e.has(x):
+        if e.has(Symbol):
             return exp(e*log(b))._eval_nseries(x, n=n)
 
         if b == x:
@@ -749,7 +760,7 @@ class Pow(Expr):
                 raise ValueError('expecting numerical exponent but got %s' % ei)
 
             nuse = n - ei
-            lt = b.as_leading_term(x)
+            lt = b.compute_leading_term(x) # arg = sin(x); lt = x
             #  XXX o is not used -- was this to be used as o and o2 below to compute a new e?
             o = order*lt**(1 - e)
             bs = b._eval_nseries(x, n=nuse)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -625,8 +625,6 @@ class Pow(Expr):
         # where e_i are numbers (not necessarily integers) and c_i are expression
         # involving only numbers, the log function, and log(x).
         from sympy import powsimp, collect, exp, log, O, ceiling
-        if logx is None:
-            logx = log(x)
         b, e = self.args
         if e.is_Integer:
             if e > 0:
@@ -636,31 +634,10 @@ class Pow(Expr):
                            )._eval_expand_multinomial(deep = False)
             elif e is S.NegativeOne:
                 # this is also easy to expand using the formula:
-                # 1/(1 + x) = 1 + x + x**2 + x**3 ...
+                # 1/(1 + x) = 1 - x + x**2 - x**3 ...
                 # so we need to rewrite base to the form "1+x"
-                if b.has(log(x)):
-                    # we need to handle the log(x) singularity:
-                    y = Dummy("y")
-                    p = self.subs(log(x), -1/y)
-                    if not p.has(x):
-                        p = p._eval_nseries(y, n=n, logx=logx)
-                        p = p.subs(y, -1/log(x))
-                        return p
 
                 b = b._eval_nseries(x, n=n, logx=logx)
-                if b.has(log(x)):
-                    # we need to handle the log(x) singularity:
-                    y = Dummy("y")
-                    self0 = 1/b
-                    p = self0.subs(log(x), -1/y)
-                    if not p.has(x):
-                        p = p._eval_nseries(y, n=n, logx=logx)
-                        p = p.subs(y, -1/logx)
-                        return p
-                if b.has(log(x)):
-                    y = Dummy("y")
-                    p = 1/b.subs(log(x),y)
-                    return p._eval_nseries(x, n=n, logx=logx).subs(y, logx)
                 prefactor = b.as_leading_term(x)
                 # express "rest" as: rest = 1 + k*x**l + ... + O(x**n)
                 rest = ((b - prefactor)/prefactor)._eval_expand_mul()
@@ -673,13 +650,11 @@ class Pow(Expr):
                 n2 = rest.getn()
                 if n2 is not None:
                     n = n2
+                    # remove the O - powering this is slow
+                    if logx is not None:
+                        rest = rest.removeO()
 
-                term2 = collect(rest.as_leading_term(x), x)
-                k, l = Wild("k"), Wild("l")
-                r = term2.match(k*x**l)
-                # if term2 is NaN then r will not contain l
-                k = r.get(k, S.One)
-                l = r.get(l, S.Zero)
+                k, l = rest.leadterm(x)
                 if l.is_Rational and l > 0:
                     pass
                 elif l.is_number and l > 0:
@@ -695,8 +670,9 @@ class Pow(Expr):
                     else:
                         new_term = new_term._eval_expand_mul(deep = False)
                     terms.append(new_term)
-                if n2 is None:
-                    # Append O(...) because it is not included in "r"
+
+                # Append O(...), we know the order.
+                if n2 is None or logx is not None:
                     terms.append(O(x**n))
                 return powsimp(Add(*terms), deep=True, combine='exp')
             else:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -657,7 +657,7 @@ class Pow(Expr):
                     # factor the w**4 out using collect:
                     return 1/collect(prefactor, x)
                 if rest.is_Order:
-                    return (1 + rest)/prefactor
+                    return 1/prefactor + rest/prefactor
                 n2 = rest.getn()
                 if n2 is not None:
                     n = n2

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -326,12 +326,12 @@ def test_Add_Mul_is_bounded():
     assert sin(x).is_bounded == True
     assert (x*sin(x)).is_bounded == False
     assert (1024*sin(x)).is_bounded == True
-    assert (sin(x)*exp(x)).is_bounded == False
+    assert (sin(x)*exp(x)).is_bounded is not True
     assert (sin(x)*cos(x)).is_bounded == True
-    assert (x*sin(x)*exp(x)).is_bounded == False
+    assert (x*sin(x)*exp(x)).is_bounded is not True
 
     assert (sin(x)-67).is_bounded == True
-    assert (sin(x)+exp(x)).is_bounded == False
+    assert (sin(x)+exp(x)).is_bounded is not True
 
 def test_Mul_is_even_odd():
     x = Symbol('x', integer=True)
@@ -889,7 +889,7 @@ def test_Pow_is_bounded():
     assert (sin(x)**x).is_bounded == None
     assert (sin(x)**exp(x)).is_bounded == None
     assert (1/sin(x)).is_bounded == None # if zero, no, otherwise yes
-    assert (1/exp(x)).is_bounded == False
+    assert (1/exp(x)).is_bounded == None # x could be -oo
 
 def test_Pow_is_even_odd():
     x = Symbol('x')

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -209,7 +209,7 @@ def test_as_leading_term2():
 
 def test_as_leading_term3():
     assert (2+pi+x).as_leading_term(x) == 2 + pi
-    assert (2*x+pi*x+x**2).as_leading_term(x) == 2*x + pi*x
+    assert (2*x+pi*x+x**2).as_leading_term(x) == (2+pi)*x
 
 def test_atoms():
     assert sorted(list(x.atoms())) == [x]

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,6 +1,6 @@
 from sympy import Lambda, Symbol, Function, Derivative, sqrt, \
         log, exp, Rational, Real, sin, cos, acos, diff, I, re, im, \
-        oo, zoo, nan, E, expand, pi, O, Sum, S, polygamma
+        oo, zoo, nan, E, expand, pi, O, Sum, S, polygamma, loggamma
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y, n
 from sympy.core.function import PoleError
@@ -256,6 +256,7 @@ def test_function__eval_nseries():
     raises(PoleError, 'sin(1/x)._eval_nseries(x,2)')
     raises(PoleError, 'acos(1-x)._eval_nseries(x,2)')
     raises(PoleError, 'acos(1+x)._eval_nseries(x,2)')
+    assert loggamma(1/x)._eval_nseries(x,0) == log(x)/2 - log(x)/x - 1/x + O(1, x)
 
 def test_doit():
     n = Symbol('n', integer = True)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -247,16 +247,17 @@ def test_function_non_commutative():
 
 def test_function__eval_nseries():
     x = Symbol('x')
-    assert sin(x)._eval_nseries(x,2) == x + O(x**2)
-    assert sin(x+1)._eval_nseries(x,2) == x*cos(1) + sin(1) + O(x**2)
-    assert sin(pi*(1-x))._eval_nseries(x,2) == pi*x + O(x**2)
-    assert acos(1-x**2)._eval_nseries(x,2) == sqrt(2)*x + O(x**2)
-    assert polygamma(n,x+1)._eval_nseries(x,2) == \
+    assert sin(x)._eval_nseries(x,2,None) == x + O(x**2)
+    assert sin(x+1)._eval_nseries(x,2,None) == x*cos(1) + sin(1) + O(x**2)
+    assert sin(pi*(1-x))._eval_nseries(x,2,None) == pi*x + O(x**2)
+    assert acos(1-x**2)._eval_nseries(x,2,None) == sqrt(2)*x + O(x**2)
+    assert polygamma(n,x+1)._eval_nseries(x,2,None) == \
                    polygamma(n,1) + polygamma(n+1,1)*x + O(x**2)
-    raises(PoleError, 'sin(1/x)._eval_nseries(x,2)')
-    raises(PoleError, 'acos(1-x)._eval_nseries(x,2)')
-    raises(PoleError, 'acos(1+x)._eval_nseries(x,2)')
-    assert loggamma(1/x)._eval_nseries(x,0) == log(x)/2 - log(x)/x - 1/x + O(1, x)
+    raises(PoleError, 'sin(1/x)._eval_nseries(x,2,None)')
+    raises(PoleError, 'acos(1-x)._eval_nseries(x,2,None)')
+    raises(PoleError, 'acos(1+x)._eval_nseries(x,2,None)')
+    assert loggamma(1/x)._eval_nseries(x,0,None) \
+           == log(x)/2 - log(x)/x - 1/x + O(1, x)
 
 def test_doit():
     n = Symbol('n', integer = True)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -258,6 +258,8 @@ def test_function__eval_nseries():
     raises(PoleError, 'acos(1+x)._eval_nseries(x,2,None)')
     assert loggamma(1/x)._eval_nseries(x,0,None) \
            == log(x)/2 - log(x)/x - 1/x + O(1, x)
+    l = Symbol('l')
+    assert loggamma(log(1/x)).nseries(x,n=1,logx=y) == loggamma(-y)
 
 def test_doit():
     n = Symbol('n', integer = True)

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -28,7 +28,8 @@ from elementary.integers import floor, ceiling
 from elementary.piecewise import Piecewise, piecewise_fold
 
 from special.error_functions import erf
-from special.gamma_functions import gamma, lowergamma, uppergamma, polygamma, loggamma
+from special.gamma_functions import gamma, lowergamma, uppergamma, polygamma, \
+         loggamma, digamma, trigamma
 from special.zeta_functions import dirichlet_eta, zeta
 from special.spherical_harmonics import Ylm, Zlm
 from special.tensor_functions import Dij, Eijk

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -277,9 +277,9 @@ class Abs(Function):
                 return self.args[0]**other
         return
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         direction = self.args[0].leadterm(x)[0]
-        s = self.args[0]._eval_nseries(x, n=n)
+        s = self.args[0]._eval_nseries(x, n=n, logx=logx)
         when = Eq(direction, 0)
         return Piecewise(
                          ((s.subs(direction, 0)), when),

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -104,7 +104,7 @@ class floor(RoundFunction):
         if arg.is_NumberSymbol:
             return arg.approximation_interval(C.Integer)[0]
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         r = self.subs(x, 0)
         args = self.args[0]
         args0 = args.subs(x, 0)
@@ -153,7 +153,7 @@ class ceiling(RoundFunction):
         if arg.is_NumberSymbol:
             return arg.approximation_interval(C.Integer)[1]
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         r = self.subs(x, 0)
         args = self.args[0]
         args0 = args.subs(x, 0)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -25,6 +25,10 @@ class ExprCondPair(Function):
         return self.args[1]
 
     @property
+    def is_commutative(self):
+        return self.expr.is_commutative
+
+    @property
     def free_symbols(self):
         # Overload Basic.free_symbols because self.args[1] may contain non-Basic
         result = self.expr.free_symbols
@@ -249,6 +253,11 @@ class Piecewise(Function):
             else:
                 new_args.append((e._eval_subs(old, new), c._eval_subs(old, new)))
         return Piecewise( *new_args )
+
+    def _eval_nseries(self, x, n, logx):
+        args = map(lambda ec: (ec.expr._eval_nseries(x, n, logx), ec.cond), \
+                   self.args)
+        return self.func(*args)
 
     @classmethod
     def __eval_cond(cls, cond):

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -71,6 +71,9 @@ def test_piecewise():
     p = Piecewise((x, x < -10),(x**2, x <= -1),(x, 1 < x))
     raises(ValueError, "integrate(p,(x,-2,2))")
 
+    # Test commutativity
+    assert p.is_commutative is True
+
 def test_piecewise_free_symbols():
     a = symbols('a')
     f = Piecewise((x , a<0), (y, True))
@@ -193,3 +196,9 @@ def test_piecewise_lambdify():
     assert f(0.5) == 0.5
     assert f(2.0) == 0.0
 
+
+def test_piecewise_series():
+    from sympy import sin, cos, O
+    p1 = Piecewise((sin(x), x<0),(cos(x),x>0))
+    p2 = Piecewise((x+O(x**2), x<0),(1+O(x**2),x>0))
+    assert p1.nseries(x,n=2) == p2

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -536,3 +536,12 @@ def test_atan2_expansion():
                   + atan2(1+x, 1) - atan(1+x)) == O(y**3)
     assert Matrix([atan2(x, y)]).jacobian([x, y]) \
                   == Matrix([[y/(x**2+y**2), -x/(x**2+y**2)]])
+
+def test_aseries():
+    x = Symbol('x')
+    def t(n, v, d, e):
+        assert abs(n(1/v).evalf() - n(1/x).series(x, dir=d).removeO().subs(x, v)) < e
+    t(atan, 0.1, '+', 1e-5)
+    t(atan, -0.1, '-', 1e-5)
+    t(acot, 0.1, '+', 1e-5)
+    t(acot, -0.1, '-', 1e-5)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -579,11 +579,11 @@ class tan(Function):
 
             return (-1)**a * b*(b-1) * B/F * x**n
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         i = self.args[0].limit(x, 0)*2/S.Pi
         if i and i.is_Integer:
-            return self.rewrite(cos)._eval_nseries(x, n=n)
-        return Function._eval_nseries(self, x, n=n)
+            return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
+        return Function._eval_nseries(self, x, n=n, logx=logx)
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -747,11 +747,11 @@ class cot(Function):
 
             return (-1)**((n+1)//2) * 2**(n+1) * B/F * x**n
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         i = self.args[0].limit(x, 0)/S.Pi
         if i and i.is_Integer:
-            return self.rewrite(cos)._eval_nseries(x, n=n)
-        return Function._eval_nseries(self, x, n=n)
+            return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
+        return Function._eval_nseries(self, x, n=n, logx=logx)
 
     def _eval_conjugate(self):
         assert len(self.args) == 1
@@ -1096,13 +1096,13 @@ class atan(Function):
         return S.ImaginaryUnit/2 * \
                (C.log((S(1) - S.ImaginaryUnit * x)/(S(1) + S.ImaginaryUnit * x)))
 
-    def _eval_aseries(self, n, args0, x):
+    def _eval_aseries(self, n, args0, x, logx):
         if args0[0] == S.Infinity:
             return S.Pi/2 - atan(1/self.args[0])
         elif args0[0] == S.NegativeInfinity:
             return -S.Pi/2 - atan(1/self.args[0])
         else:
-            return super(atan, self)._eval_aseries(n, args0, x)
+            return super(atan, self)._eval_aseries(n, args0, x, logx)
 
     def _sage_(self):
         import sage.all as sage
@@ -1191,13 +1191,13 @@ class acot(Function):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_aseries(self, n, args0, x):
+    def _eval_aseries(self, n, args0, x, logx):
         if args0[0] == S.Infinity:
             return S.Pi/2 - acot(1/self.args[0])
         elif args0[0] == S.NegativeInfinity:
             return 3*S.Pi/2 - acot(1/self.args[0])
         else:
-            return super(atan, self)._eval_aseries(n, args0, x)
+            return super(atan, self)._eval_aseries(n, args0, x, logx)
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1096,6 +1096,14 @@ class atan(Function):
         return S.ImaginaryUnit/2 * \
                (C.log((S(1) - S.ImaginaryUnit * x)/(S(1) + S.ImaginaryUnit * x)))
 
+    def _eval_aseries(self, n, args0, x):
+        if args0[0] == S.Infinity:
+            return S.Pi/2 - atan(1/self.args[0])
+        elif args0[0] == S.NegativeInfinity:
+            return -S.Pi/2 - atan(1/self.args[0])
+        else:
+            return super(atan, self)._eval_aseries(n, args0, x)
+
     def _sage_(self):
         import sage.all as sage
         return sage.atan(self.args[0]._sage_())
@@ -1182,6 +1190,14 @@ class acot(Function):
 
     def _eval_is_real(self):
         return self.args[0].is_real
+
+    def _eval_aseries(self, n, args0, x):
+        if args0[0] == S.Infinity:
+            return S.Pi/2 - acot(1/self.args[0])
+        elif args0[0] == S.NegativeInfinity:
+            return 3*S.Pi/2 - acot(1/self.args[0])
+        else:
+            return super(atan, self)._eval_aseries(n, args0, x)
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -1,9 +1,10 @@
-from sympy.core import Add, S, C, sympify
+from sympy.core import Add, S, C, sympify, oo, pi
 from sympy.core.function import Function, ArgumentIndexError
 from zeta_functions import zeta
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.combinatorial.numbers import bernoulli
 
 ###############################################################################
 ############################ COMPLETE GAMMA FUNCTION ##########################
@@ -218,3 +219,20 @@ class polygamma(Function):
 class loggamma(Function):
 
     nargs = 1
+
+    def _eval_aseries(self, n, args0, x):
+        if args0[0] != oo:
+            return super(loggamma, self)._eval_aseries(n, args0, x)
+        z = self.args[0]
+        n = min(n, C.ceiling((n+S(1))/2))
+        r = log(z)*(z-S(1)/2) - z + log(2*pi)/2
+        l = [bernoulli(2*k) / (2*k*(2*k-1)*z**(2*k-1)) for k in range(1, n)]
+        o = None
+        if n == 0:
+            o = C.Order(1, x)
+        else:
+            o = C.Order(1/z**(2*n-1), x)
+        # It is very inefficient to first add the order and then do the nseries
+        return (r + Add(*l))._eval_nseries(x, n) + o
+
+from sympy import expand

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -170,10 +170,10 @@ class polygamma(Function):
     def _eval_is_real(self):
         return self.args[0].is_real
 
-    def _eval_aseries(self, n, args0, x):
+    def _eval_aseries(self, n, args0, x, logx):
         if args0[1] != oo or not \
            (self.args[0].is_Integer and self.args[0].is_nonnegative):
-            return super(polygamma, self)._eval_aseries(n, args0, x)
+            return super(polygamma, self)._eval_aseries(n, args0, x, logx)
         z = self.args[1]
         N = self.args[0]
 
@@ -189,7 +189,7 @@ class polygamma(Function):
                 l = [bernoulli(2*k) / (2*k*z**(2*k)) for k in range(1, m)]
                 r -= Add(*l)
                 o = C.Order(1/z**(2*m), x)
-            return r._eval_nseries(x, n) + o
+            return r._eval_nseries(x, n, logx) + o
         else:
             # proper polygamma function
             # Abramowitz & Stegun, p. 260, 6.4.10
@@ -207,7 +207,7 @@ class polygamma(Function):
                 o = C.Order(1/z, x)
             elif n == 1:
                 o = C.Order(1/z**2, x)
-            r = e0._eval_nseries(z, n=n) + o
+            r = e0._eval_nseries(z, n, logx) + o
             return -1 * (-1/z)**N * r
 
     @classmethod
@@ -274,9 +274,9 @@ class loggamma(Function):
 
     nargs = 1
 
-    def _eval_aseries(self, n, args0, x):
+    def _eval_aseries(self, n, args0, x, logx):
         if args0[0] != oo:
-            return super(loggamma, self)._eval_aseries(n, args0, x)
+            return super(loggamma, self)._eval_aseries(n, args0, x, logx)
         z = self.args[0]
         m = min(n, C.ceiling((n+S(1))/2))
         r = log(z)*(z-S(1)/2) - z + log(2*pi)/2
@@ -287,7 +287,7 @@ class loggamma(Function):
         else:
             o = C.Order(1/z**(2*m-1), x)
         # It is very inefficient to first add the order and then do the nseries
-        return (r + Add(*l))._eval_nseries(x, n) + o
+        return (r + Add(*l))._eval_nseries(x, n, logx) + o
 
     def _eval_rewrite_as_intractable(self, z):
         return log(gamma(z))

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -81,6 +81,9 @@ class gamma(Function):
     def _eval_is_real(self):
         return self.args[0].is_real
 
+    def _eval_rewrite_as_tractable(self, z):
+        return C.exp(loggamma(z))
+
 
 ###############################################################################
 ################## LOWER and UPPER INCOMPLETE GAMMA FUNCTIONS #################
@@ -234,5 +237,11 @@ class loggamma(Function):
             o = C.Order(1/z**(2*n-1), x)
         # It is very inefficient to first add the order and then do the nseries
         return (r + Add(*l))._eval_nseries(x, n) + o
+
+    def _eval_rewrite_as_intractable(self, z):
+        return log(gamma(z))
+
+    def _eval_is_real(self):
+        return self.args[0].is_real
 
 from sympy import expand

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -1,5 +1,6 @@
 from sympy import Symbol, gamma, oo, nan, zoo, factorial, sqrt, Rational, log,\
-        polygamma, EulerGamma, pi, uppergamma, S, expand_func
+        polygamma, EulerGamma, pi, uppergamma, S, expand_func, loggamma, sin, cos, \
+        O, cancel
 
 x = Symbol('x')
 y = Symbol('y')
@@ -120,4 +121,19 @@ def test_polygamma_expand_func():
     assert e.expand(func = True, basic = False) == e
 
 def test_loggamma():
-    pass
+    s1 = loggamma(1/(x+sin(x))+cos(x)).nseries(x,n=4)
+    s2 = (-log(2*x)-1)/(2*x) - log(x/pi)/2 + (4-log(2*x))*x/24 + O(x**2)
+    assert cancel(s1 - s2).removeO() == 0
+    s1 = loggamma(1/x).series(x)
+    s2 = (1/x-S(1)/2)*log(1/x) - 1/x  + log(2*pi)/2 + \
+         x/12 - x**3/360 + x**5/1260 +  O(x**7)
+    assert cancel(s1 - s2).removeO() == 0
+
+    def tN(N, M):
+        assert loggamma(1/x)._eval_nseries(x,n=N).getn() == M
+    tN(0, 0)
+    tN(1, 1)
+    tN(2, 3)
+    tN(3, 3)
+    tN(4, 5)
+    tN(5, 5)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -130,7 +130,7 @@ def test_loggamma():
     assert cancel(s1 - s2).removeO() == 0
 
     def tN(N, M):
-        assert loggamma(1/x)._eval_nseries(x,n=N).getn() == M
+        assert loggamma(1/x)._eval_nseries(x,n=N,logx=None).getn() == M
     tN(0, 0)
     tN(1, 1)
     tN(2, 3)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -137,3 +137,12 @@ def test_loggamma():
     tN(3, 3)
     tN(4, 5)
     tN(5, 5)
+
+def test_polygamma_expansion():
+    # A. & S., pa. 259 and 260
+    assert polygamma(0, 1/x).nseries(x, n=3) \
+           == -log(x) - x/2 - x**2/12 + O(x**4)
+    assert polygamma(1, 1/x).series(x, n=5) \
+           == x + x**2/2 + x**3/6 + O(x**5)
+    assert polygamma(3, 1/x).nseries(x, n=8) \
+           == 2*x**3 + 3*x**4 + 2*x**5 - x**7 + 4*x**9/3 + O(x**11)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -626,8 +626,8 @@ class Integral(Expr):
         for term in self.function.lseries(x):
             yield integrate(term, *self.limits)
 
-    def _eval_nseries(self, x, n):
-        terms, order = self.function.nseries(x, n=n).as_coeff_add(C.Order)
+    def _eval_nseries(self, x, n, logx):
+        terms, order = self.function.nseries(x, n=n, logx=logx).as_coeff_add(C.Order)
         return integrate(terms, *self.limits) + Add(*order)*x
 
     def _eval_subs(self, old, new):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -353,20 +353,24 @@ def subexp(e, sub):
     return e.subs(sub, C.Dummy('u')) != e
 
 @debug
-def calculate_series(e, x):
+def calculate_series(e, x, skip_abs=False, skip_log=False):
     """ Calculates at least one term of the series of "e" in "x".
 
     This is a place that fails most often, so it is in its own function.
     """
 
+    logx = Dummy('l')
     f = e
     for n in [2, 4, 6, 8]:
         series = f.nseries(x, n=n).removeO()
         if series:
-            break
+            if skip_log:
+                series = series.subs(log(x), logx)
+            if (not skip_abs) or series.has(x):
+                break
     else:
-        assert ValueError('(%s).series(%s, n=8) gave no terms.' % (f, x))
-    return series
+        raise ValueError('(%s).series(%s, n=8) gave no terms.' % (f, x))
+    return series.subs(logx, log(x))
 
 @debug
 def mrv_leadterm(e, x, Omega=[]):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -417,7 +417,7 @@ def sign(e, x):
        for x sufficiently large. [If e is constant, of course, this is just
        the same thing as the sign of e.]
     """
-    ## from sympy import sign as _sign
+    from sympy import sign as _sign
     assert isinstance(e, Basic)
 
     if e.is_positive:
@@ -434,11 +434,7 @@ def sign(e, x):
         else:
             return -1
     elif not e.has(x):
-        # if we can't resolve the sign just return
-        # the value; another option would be an
-        # unevaluated sign
-        ## return _sign(e)
-        return e
+        return _sign(e)
     elif e == x:
         return 1
     elif e.is_Mul:

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -483,29 +483,26 @@ def moveup(l, x):
 
 
 @debug
-def calculate_series(e, x, skip_abs=False, skip_log=False):
+def calculate_series(e, x, skip_abs=False, logx=None):
     """ Calculates at least one term of the series of "e" in "x".
 
     This is a place that fails most often, so it is in its own function.
     """
 
-    logx = Dummy('l')
     f = e
     for n in [2, 4, 6, 8]:
-        series = f.nseries(x, n=n)
+        series = f.nseries(x, n=n, logx=logx)
         if not series.has(O):
             # The series expansion is locally exact.
             return series
 
         series = series.removeO()
         if series:
-            if skip_log:
-                series = series.subs(log(x), logx)
             if (not skip_abs) or series.has(x):
                 break
     else:
         raise ValueError('(%s).series(%s, n=8) gave no terms.' % (f, x))
-    return series.subs(logx, log(x))
+    return series
 
 @debug
 def mrv_leadterm(e, x, Omega=SubsSet(), exps=None):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -343,6 +343,9 @@ def sign(e, x):
 @debug
 def limitinf(e, x):
     """Limit e(x) for x-> oo"""
+    #rewrite e in terms of tractable functions only
+    e = e.rewrite('tractable', deep=True)
+
     if not e.has(x):
         return e #e is a constant
     if not x.is_positive:
@@ -503,10 +506,11 @@ def gruntz(e, z, z0, dir="+"):
         raise NotImplementedError("Second argument must be a Symbol")
 
     #convert all limits to the limit z->oo; sign of z is handled in limitinf
+    r = None
     if z0 == oo:
-        return limitinf(e, z)
+        r = limitinf(e, z)
     elif z0 == -oo:
-        return limitinf(e.subs(z, -z), z)
+        r = limitinf(e.subs(z, -z), z)
     else:
         if dir == "-":
             e0 = e.subs(z, z0 - 1/z)
@@ -514,4 +518,10 @@ def gruntz(e, z, z0, dir="+"):
             e0 = e.subs(z, z0 + 1/z)
         else:
             raise NotImplementedError("dir must be '+' or '-'")
-        return limitinf(e0, z)
+        r = limitinf(e0, z)
+
+    # This is a bit of a heuristic for nice results... we always rewrite
+    # tractable functions in terms of familiar intractable ones.
+    # It might be nicer to rewrite the exactly to what they were initially,
+    # but that would take some work to implement.
+    return r.rewrite('intractable', deep=True)

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -174,6 +174,11 @@ def maketree(f, *args, **kw):
     tmp = []
     iter += 1
 
+    # If there is a bug and the algorithm enters an infinite loop, enable the
+    # following line. It will print the names and parameters of all major functions
+    # that are called, *before* they are called
+    #print "%s%s %s%s" % (iter, reduce(lambda x, y: x + y,map(lambda x: '-',range(1,2+iter))), f.func_name, args)
+
     r = f(*args, **kw)
 
     iter -= 1
@@ -189,7 +194,14 @@ def maketree(f, *args, **kw):
 
 def compare(a, b, x):
     """Returns "<" if a<b, "=" for a == b, ">" for a>b"""
-    c = limitinf(log(a)/log(b), x)
+    # log(exp(...)) must always be simplified here for termination
+    la, lb = log(a), log(b)
+    if isinstance(a, Basic) and a.func is exp:
+        la = a.args[0]
+    if isinstance(b, Basic) and b.func is exp:
+        lb = b.args[0]
+
+    c = limitinf(la/lb, x)
     if c == 0:
         return "<"
     elif c in [oo, -oo]:
@@ -226,6 +238,10 @@ def mrv(e, x):
     elif e.func is log:
         return mrv(e.args[0], x)
     elif e.func is exp:
+        # We know from the theory of this algorithm that exp(log(...)) may always
+        # be simplified here, and doing so is vital for termination.
+        if e.args[0].func is log:
+            return mrv(e.args[0].args[0], x)
         if limitinf(e.args[0], x).is_unbounded:
             return mrv_max(set([e]), mrv(e.args[0], x), x)
         else:
@@ -268,13 +284,27 @@ def mrv_max(f, g, x):
 def sign(e, x):
     """Returns a sign of an expression e(x) for x->oo.
 
-        e >  0 ...  1
-        e == 0 ...  0
-        e <  0 ... -1
+        e >  0 for x sufficiently large ...  1
+        e == 0 for x sufficiently large ...  0
+        e <  0 for x sufficiently large ... -1
+
+        The result of this function is currently undefined if e changes sign
+        arbitarily often for arbitrarily large x (e.g. sin(x)).
+
+       Note that this returns zero only if e is *constantly* zero
+       for x sufficiently large. [If e is constant, of course, this is just
+       the same thing as the sign of e.]
     """
     ## from sympy import sign as _sign
     assert isinstance(e, Basic)
+
+    if e.is_positive:
+        return 1
+    elif e.is_negative:
+        return -1
+
     if e.is_Rational or e.is_Real:
+        assert not e is S.NaN
         if e == 0:
             return 0
         elif e.evalf() > 0:
@@ -282,16 +312,11 @@ def sign(e, x):
         else:
             return -1
     elif not e.has(x):
-        if e.is_positive:
-            return 1
-        elif e.is_negative:
-            return -1
-        else:
-            # if we can't resolve the sign just return
-            # the value; another option would be an
-            # unevaluated sign
-            ## return _sign(e)
-            return e
+        # if we can't resolve the sign just return
+        # the value; another option would be an
+        # unevaluated sign
+        ## return _sign(e)
+        return e
     elif e == x:
         return 1
     elif e.is_Mul:
@@ -303,15 +328,17 @@ def sign(e, x):
     elif e.func is exp:
         return 1
     elif e.is_Pow:
-        if sign(e.base, x) == 1:
+        s = sign(e.base, x)
+        if s == 1:
             return 1
+        if e.exp.is_Integer:
+            return s**e.exp
     elif e.func is log:
         return sign(e.args[0] -1, x)
-    elif e.is_Add:
-        return sign(limitinf(e, x), x)
-    elif e.is_Function and hasattr(e, 'nargs'): # XXX is this how to detect cos(x) vs f(x)?
-        return sign(e.func(*[limitinf(a, x) for a in e.args]), x)
-    raise ValueError("Don't know how to determine the sign of %s" % e)
+
+    # if all else fails, do it the hard way
+    c0, e0 = mrv_leadterm(e, x)
+    return sign(c0, x)
 
 @debug
 def limitinf(e, x):
@@ -362,7 +389,12 @@ def calculate_series(e, x, skip_abs=False, skip_log=False):
     logx = Dummy('l')
     f = e
     for n in [2, 4, 6, 8]:
-        series = f.nseries(x, n=n).removeO()
+        series = f.nseries(x, n=n)
+        if not series.has(O):
+            # The series expansion is locally exact.
+            return series
+
+        series = series.removeO()
         if series:
             if skip_log:
                 series = series.subs(log(x), logx)
@@ -434,10 +466,8 @@ def rewrite(e, Omega, x, wsym):
     #O2 is a list, which results by rewriting each item in Omega using "w"
     O2 = []
     for f in Omega:
-        c = mrv_leadterm(f.args[0]/g.args[0], x)
-        #the c is a constant, because both f and g are from Omega:
-        assert c[1] == 0
-        O2.append(exp((f.args[0] - c[0]*g.args[0]).expand())*wsym**c[0])
+        c = limitinf(f.args[0]/g.args[0], x)
+        O2.append(exp((f.args[0] - c*g.args[0]).expand())*wsym**c)
 
     #Remember that Omega contains subexpressions of "e". So now we find
     #them in "e" and substitute them for our rewriting, stored in O2

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -132,8 +132,6 @@ class Order(Expr):
         return obj
 
     def _hashable_content(self):
-        if self.args[0].is_number:
-            return (self.args[0],)
         return self.args
 
     def oseries(self, order):

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -180,6 +180,19 @@ class Order(Expr):
         Return None if the inclusion relation cannot be determined
         (e.g. when self and expr have different symbols).
         """
+        # NOTE: when multiplying out series a lot of queries like
+        #       O(...).contains(a*x**b) with many a and few b are made.
+        #       Separating out the independent part allows for better caching.
+        c, m = expr.as_coeff_mul(*self.variables)
+        if m != ():
+            return self._contains(Mul(*m))
+        else:
+            # Mul(*m) == 1, and O(1) treatment is somewhat peculiar ...
+            # some day this else should not be necessary
+            return self._contains(expr)
+
+    @cacheit
+    def _contains(self, expr):
         from sympy import powsimp, limit
         if expr is S.Zero:
             return True

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -137,7 +137,7 @@ class Order(Expr):
     def oseries(self, order):
         return self
 
-    def _eval_nseries(self, x, n):
+    def _eval_nseries(self, x, n, logx):
         return self
 
     @property

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -116,7 +116,13 @@ class Order(Expr):
                 lst = expr.extract_leading_order(*symbols)
                 expr = Add(*[f.expr for (e,f) in lst])
             elif expr:
-                expr = expr.as_leading_term(*symbols)
+                if len(symbols) > 1:
+                    # TODO
+                    # We cannot use compute_leading_term because that only
+                    # works in one symbol.
+                    expr = expr.as_leading_term(*symbols)
+                else:
+                    expr = expr.compute_leading_term(symbols[0])
                 coeff, terms = expr.as_coeff_mul()
                 expr = Mul(*[t for t in terms if t.has(*symbols)])
 

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -1,5 +1,5 @@
 from sympy import Symbol, exp, log, oo, Rational, I, sin, gamma, loggamma, S, \
-    atan, acot, pi, cancel, E
+    atan, acot, pi, cancel, E, erf, sqrt, zeta, cos, digamma
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
 from sympy.utilities.pytest import XFAIL, skip
@@ -17,6 +17,93 @@ correctly.
 
 x = Symbol('x', real=True)
 m = Symbol('m', real=True)
+
+
+runslow = False
+def sskip():
+    if not runslow: skip("slow")
+
+def test_gruntz_evaluation():
+    # Gruntz' thesis pp. 122 to 123
+    assert gruntz(exp(x)*(exp(1/x-exp(-x))-exp(1/x)), x, oo) == -1
+    assert gruntz((x*log(x)*(log(x*exp(x)-x**2))**2)
+                  / (log(log(x**2+2*exp(exp(3*x**3*log(x)))))), x, oo) == S(1)/3
+    assert gruntz((3**x + 5**x)**(1/x), x, oo) == 5
+    assert gruntz(exp(exp(S(5)/2*x**(-S(5)/7)+ S(21)/8*x**(S(6)/11)
+                          +2*x**(-8)+S(54)/17*x**(S(49)/45) ))**8
+                  / log(log(-log(S(4)/3*x**(-S(5)/14))))**(S(7)/6), x, oo) == oo
+    assert gruntz(exp(x*exp(-x)/(exp(-x)+exp(-2*x**2/(x+1))))/exp(x), x, oo) \
+           == 1
+    assert gruntz(log(x)*(log(log(x)+log(log(x))) - log(log(x)))
+                  / (log(log(x)+log(log(log(x))))), x, oo) == 1
+    assert gruntz(x/log(x**(log(x**(log(2)/log(x))))), x, oo) == oo
+    assert gruntz(x/log(x**(log(x**(log(2)/log(x))))), x, oo) == oo
+    assert gruntz(log(x)**2 * exp(sqrt(log(x))*(log(log(x)))**2
+                  * exp(sqrt(log(log(x))) * (log(log(log(x))))**3)) / sqrt(x),
+                  x, oo) == 0
+    assert gruntz(exp((log(log(x+exp(log(x)*log(log(x))))))
+                  / (log(log(log(exp(x)+x+log(x)))))), x, oo) == E
+    assert gruntz(exp(x)*(exp(1/x+exp(-x)+exp(-x**2)) \
+                  - exp(1/x-exp(-exp(x)))), x, oo) == 1
+    assert gruntz((exp(4*x*exp(-x)/(1/exp(x)+1/exp(2*x**2/(x+1)))) - exp(x))
+                  / exp(x)**4, x, oo) == 1
+    assert gruntz(exp(exp(x-exp(-x))/(1-1/x)) - exp(exp(x)), x, oo) == oo
+    assert gruntz(exp(exp(2*log(x**5+x)*log(log(x))))
+                  / exp(exp(10*log(x)*log(log(x)))), x, oo) == oo
+    assert gruntz((exp(x*exp(-x)/(exp(-x)+exp(-2*x**2/(x+1)))) - exp(x))/x,
+                  x, oo) == -exp(2)
+    assert gruntz(exp(exp(x)) / exp(exp(x-exp(-exp(exp(x))))), x, oo) == 1
+    assert gruntz(exp(exp(exp(x+exp(-x)))) / exp(exp(exp(x))), x, oo) == oo
+    assert gruntz(exp(exp(exp(x+exp(-x)))) / exp(exp(exp(x))), x, oo) == oo
+    assert gruntz(exp(exp(exp(x))) / exp(exp(exp(x-exp(-exp(exp(x)))))),
+                  x, oo) == 1
+
+def test_gruntz_evaluation_slow():
+    sskip()
+    assert gruntz((exp(exp(-x/(1+exp(-x))))*exp(-x/(1+exp(-x/(1+exp(-x)))))
+                   *exp(exp(-x+exp(-x/(1+exp(-x))))))
+                  / (exp(-x/(1+exp(-x))))**2 - exp(x) + x, x, oo) == 2
+    assert gruntz(exp(exp(exp(x)/(1-1/x)))
+                  - exp(exp(exp(x)/(1-1/x-log(x)**(-log(x))))), x, oo) == -oo
+
+def test_gruntz_eval_special():
+    # Gruntz, p. 126
+    assert gruntz(exp(x)*(sin(1/x+exp(-x))-sin(1/x+exp(-x**2))), x, oo) == 1
+    assert gruntz((erf(x-exp(-exp(x))) - erf(x)) * exp(exp(x)) * exp(x**2),
+                  x, oo) == -2/sqrt(pi)
+    assert gruntz(exp(exp(x)) * (exp(sin(1/x+exp(-exp(x)))) - exp(sin(1/x))),
+                  x, oo) == 1
+    assert gruntz(exp(x)*(gamma(x+exp(-x)) - gamma(x)), x, oo) == oo
+    assert gruntz(exp(exp(digamma(digamma(x))))/x,x,oo) == exp(-S(1)/2)
+    assert gruntz(exp(exp(digamma(log(x))))/x,x,oo) == exp(-S(1)/2)
+    assert gruntz(digamma(digamma(digamma(x))),x,oo) == oo
+    assert gruntz(loggamma(loggamma(x)), x, oo) == oo
+    assert gruntz(((gamma(x+1/gamma(x)) - gamma(x))/log(x) - cos(1/x))
+                  * x*log(x), x, oo) == -S(1)/2
+    assert gruntz(x * (gamma(x-1/gamma(x)) - gamma(x) + log(x)), x, oo) \
+           == S(1)/2
+    assert gruntz((gamma(x+1/gamma(x)) - gamma(x)) / log(x), x, oo) == 1
+
+def test_gruntz_eval_special_slow():
+    sskip()
+    assert gruntz(gamma(x+1)/sqrt(2*pi)
+                  - exp(-x)*(x**(x+S(1)/2) + x**(x-S(1)/2)/12), x, oo) == oo
+    assert gruntz(exp(exp(exp(digamma(digamma(digamma(x))))))/x, x, oo) == 0
+    # XXX This sometimes fails!!!
+    assert gruntz(exp(gamma(x-exp(-x))*exp(1/x)) - exp(gamma(x)), x, oo) == oo
+
+
+@XFAIL
+def test_gruntz_eval_special_fail():
+    # TODO exponential integral Ei
+    # assert gruntz((Ei(x-exp(-exp(x))) - Ei(x)) *exp(-x)*exp(exp(x))*x,
+    #               x, oo) == -1
+
+    # TODO zeta function series
+    assert gruntz(exp((log(2)+1)*x) * (zeta(x+exp(-x)) - zeta(x)), x, oo) \
+           == -log(2)
+
+    # TODO 8.35 - 8.37 (bessel, max-min)
 
 
 def test_compare1():
@@ -199,9 +286,7 @@ def test_limit3():
     assert gruntz(exp(x)/(1+exp(x)), x, oo) == 1
     assert gruntz(exp(x)/(a+exp(x)), x, oo) == 1
 
-@XFAIL
 def test_limit4():
-    skip("Takes too long")
     #issue 364
     assert gruntz((3**x+5**x)**(1/x), x, oo) == 5
     #issue 364
@@ -245,7 +330,3 @@ def test_exp_log_series():
 
 def test_issue545():
     assert gruntz(((x**7+x+1)/(2**x+x**2))**(-1/x), x, oo) == 2
-
-def test_slow():
-    skip("This is very slow.")
-    assert gruntz(loggamma(loggamma(x)), x, oo) == oo

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -74,7 +74,7 @@ def test_sign1():
     assert sign(-exp(x), x) == -1
     assert sign(3-1/x, x) == 1
     assert sign(-3-1/x, x) == -1
-    assert sign(sin(1/x), x) == 0
+    assert sign(sin(1/x), x) == 1
 
 def test_sign2():
     assert sign(x, x) == 1

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -86,68 +86,71 @@ def test_sign2():
     assert sign(y*x, x) == 1
     assert sign(-y*x, x) == -1
 
+def mmrv(a, b): return set(mrv(a, b)[0].keys())
+
 def test_mrv1():
-    assert mrv(x, x) == set([x])
-    assert mrv(x+1/x, x) == set([x])
-    assert mrv(x**2, x) == set([x])
-    assert mrv(log(x), x) == set([x])
-    assert mrv(exp(x), x) == set([exp(x)])
-    assert mrv(exp(-x), x) == set([exp(-x)])
-    assert mrv(exp(x**2), x) == set([exp(x**2)])
-    assert mrv(-exp(1/x), x) == set([x])
-    assert mrv(exp(x+1/x), x) == set([exp(x+1/x)])
+    assert mmrv(x, x) == set([x])
+    assert mmrv(x+1/x, x) == set([x])
+    assert mmrv(x**2, x) == set([x])
+    assert mmrv(log(x), x) == set([x])
+    assert mmrv(exp(x), x) == set([exp(x)])
+    assert mmrv(exp(-x), x) == set([exp(-x)])
+    assert mmrv(exp(x**2), x) == set([exp(x**2)])
+    assert mmrv(-exp(1/x), x) == set([x])
+    assert mmrv(exp(x+1/x), x) == set([exp(x+1/x)])
 
 def test_mrv2a():
-    assert mrv(exp(x+exp(-exp(x))), x) == set([exp(-exp(x))])
-    assert mrv(exp(x+exp(-x)), x) == set([exp(x+exp(-x)), exp(-x)])
-    assert mrv(exp(1/x+exp(-x)), x) == set([exp(-x)])
+    assert mmrv(exp(x+exp(-exp(x))), x) == set([exp(-exp(x))])
+    assert mmrv(exp(x+exp(-x)), x) == set([exp(x+exp(-x)), exp(-x)])
+    assert mmrv(exp(1/x+exp(-x)), x) == set([exp(-x)])
 
 #sometimes infinite recursion due to log(exp(x**2)) not simplifying
 def test_mrv2b():
-    assert mrv(exp(x+exp(-x**2)), x) == set([exp(-x**2)])
+    assert mmrv(exp(x+exp(-x**2)), x) == set([exp(-x**2)])
 
 #sometimes infinite recursion due to log(exp(x**2)) not simplifying
 def test_mrv2c():
-    assert mrv(exp(-x+1/x**2)-exp(x+1/x), x) == set([exp(x+1/x), exp(1/x**2-x)])
+    assert mmrv(exp(-x+1/x**2)-exp(x+1/x), x) == set([exp(x+1/x), exp(1/x**2-x)])
 
 #sometimes infinite recursion due to log(exp(x**2)) not simplifying
 def test_mrv3():
-    assert mrv(exp(x**2)+x*exp(x)+log(x)**x/x, x) == set([exp(x**2)])
-    assert mrv(exp(x)*(exp(1/x+exp(-x))-exp(1/x)), x) == set([exp(x), exp(-x)])
-    assert mrv(log(x**2+2*exp(exp(3*x**3*log(x)))), x) == set([exp(exp(3*x**3*log(x)))])
-    assert mrv(log(x-log(x))/log(x), x) == set([x])
-    assert mrv((exp(1/x-exp(-x))-exp(1/x))*exp(x), x) == set([exp(x), exp(-x)])
-    assert mrv(1/exp(-x+exp(-x))-exp(x), x) == set([exp(x), exp(-x), exp(x-exp(-x))])
-    assert mrv(log(log(x*exp(x*exp(x))+1)), x) == set([exp(x*exp(x))])
-    assert mrv(exp(exp(log(log(x)+1/x))), x) == set([x])
+    assert mmrv(exp(x**2)+x*exp(x)+log(x)**x/x, x) == set([exp(x**2)])
+    assert mmrv(exp(x)*(exp(1/x+exp(-x))-exp(1/x)), x) == set([exp(x), exp(-x)])
+    assert mmrv(log(x**2+2*exp(exp(3*x**3*log(x)))), x) == set([exp(exp(3*x**3*log(x)))])
+    assert mmrv(log(x-log(x))/log(x), x) == set([x])
+    assert mmrv((exp(1/x-exp(-x))-exp(1/x))*exp(x), x) == set([exp(x), exp(-x)])
+    assert mmrv(1/exp(-x+exp(-x))-exp(x), x) == set([exp(x), exp(-x), exp(x-exp(-x))])
+    assert mmrv(log(log(x*exp(x*exp(x))+1)), x) == set([exp(x*exp(x))])
+    assert mmrv(exp(exp(log(log(x)+1/x))), x) == set([x])
 
 def test_mrv4():
     ln = log
-    assert mrv((ln(ln(x)+ln(ln(x)))-ln(ln(x)))/ln(ln(x)+ln(ln(ln(x))))*ln(x),
+    assert mmrv((ln(ln(x)+ln(ln(x)))-ln(ln(x)))/ln(ln(x)+ln(ln(ln(x))))*ln(x),
             x) == set([x])
-    assert mrv(log(log(x*exp(x*exp(x))+1)) - exp(exp(log(log(x)+1/x))), x) == \
+    assert mmrv(log(log(x*exp(x*exp(x))+1)) - exp(exp(log(log(x)+1/x))), x) == \
         set([exp(x*exp(x))])
 
+def mrewrite(a, b, c): return rewrite(a[1], a[0], b, c)
 def test_rewrite1():
     e = exp(x)
-    assert rewrite(e, mrv(e, x), x, m) == (1/m, -x)
+    assert mrewrite(mrv(e, x), x, m) == (1/m, -x)
     e = exp(x**2)
-    assert rewrite(e, mrv(e, x), x, m) == (1/m, -x**2)
+    assert mrewrite(mrv(e, x), x, m) == (1/m, -x**2)
     e = exp(x+1/x)
-    assert rewrite(e, mrv(e, x), x, m) == (1/m, -x-1/x)
+    assert mrewrite(mrv(e, x), x, m) == (1/m, -x-1/x)
     e = 1/exp(-x+exp(-x))-exp(x)
-    assert rewrite(e, mrv(e, x), x, m) == (1/(m*exp(m))-1/m, -x)
+    assert mrewrite(mrv(e, x), x, m) == (1/(m*exp(m))-1/m, -x)
 
 def test_rewrite2():
     e = exp(x)*log(log(exp(x)))
-    assert mrv(e, x) == set([exp(x)])
-    assert rewrite(e, mrv(e, x), x, m) == (1/m*log(x), -x)
+    assert mmrv(e, x) == set([exp(x)])
+    assert mrewrite(mrv(e, x), x, m) == (1/m*log(x), -x)
 
 #sometimes infinite recursion due to log(exp(x**2)) not simplifying
 def test_rewrite3():
     e = exp(-x+1/x**2)-exp(x+1/x)
     #both of these are correct and should be equivalent:
-    assert rewrite(e, mrv(e, x), x, m) in [(-1/m + m*exp(1/x+1/x**2), -x-1/x), (m - 1/m*exp(1/x + x**(-2)), x**(-2) - x)]
+    assert mrewrite(mrv(e, x), x, m) in [(-1/m + m*exp(1/x+1/x**2), -x-1/x), (m - 1/m*exp(1/x + x**(-2)), x**(-2) - x)]
 
 def test_mrv_leadterm1():
     assert mrv_leadterm(-exp(1/x), x) == (-1, 0)
@@ -161,7 +164,7 @@ def test_mrv_leadterm2():
 
 def test_mrv_leadterm3():
     #Gruntz: p56, 3.27
-    assert mrv(exp(-x+exp(-x)*exp(-x*log(x))), x) == set([exp(-x-x*log(x))])
+    assert mmrv(exp(-x+exp(-x)*exp(-x*log(x))), x) == set([exp(-x-x*log(x))])
     assert mrv_leadterm(exp(-x+exp(-x)*exp(-x*log(x))), x) == (exp(-x), 0)
 
 def test_limit1():

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -1,4 +1,5 @@
-from sympy import Symbol, exp, log, oo, Rational, I, sin, gamma, loggamma, E, S
+from sympy import Symbol, exp, log, oo, Rational, I, sin, gamma, loggamma, S, \
+    atan, acot, pi, cancel, E
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
 from sympy.utilities.pytest import XFAIL, skip
@@ -230,6 +231,11 @@ def test_intractable():
     assert gruntz(gamma(S(1)/7+1/x), x, oo) == gamma(S(1)/7)
     assert gruntz(log(x**x)/log(gamma(x)), x, oo) == 1
     assert gruntz(log(gamma(gamma(x)))/exp(x), x, oo) == oo
+
+def test_aseries_trig():
+    assert cancel(gruntz(1/log(atan(x)), x, oo) \
+           - 1/(log(pi) + log(S(1)/2))) == 0
+    assert gruntz(1/acot(x), x, -oo) == -oo
 
 def test_exp_log_series():
     assert gruntz(x/log(log(x*exp(x))), x, oo) == oo

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, exp, log, oo, Rational, I, sin, E
+from sympy import Symbol, exp, log, oo, Rational, I, sin, gamma, loggamma, E, S
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
 from sympy.utilities.pytest import XFAIL, skip
@@ -220,3 +220,23 @@ def test_I():
 
 def test_issue1715():
     assert gruntz((x + 1)**(1/log(x + 1)), x, oo) == E
+
+def test_intractable():
+    assert gruntz(1/gamma(x), x, oo) == 0
+    assert gruntz(1/loggamma(x), x, oo) == 0
+    assert gruntz(gamma(x)/loggamma(x), x, oo) == oo
+    assert gruntz(exp(gamma(x))/gamma(x), x, oo) == oo
+    assert gruntz(gamma(x), x, 3) == 2
+    assert gruntz(gamma(S(1)/7+1/x), x, oo) == gamma(S(1)/7)
+    assert gruntz(log(x**x)/log(gamma(x)), x, oo) == 1
+    assert gruntz(log(gamma(gamma(x)))/exp(x), x, oo) == oo
+
+def test_exp_log_series():
+    assert gruntz(x/log(log(x*exp(x))), x, oo) == oo
+
+def test_issue545():
+    assert gruntz(((x**7+x+1)/(2**x+x**2))**(-1/x), x, oo) == 2
+
+def test_slow():
+    skip("This is very slow.")
+    assert gruntz(loggamma(loggamma(x)), x, oo) == oo

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,6 +1,6 @@
 from sympy import (limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
                    atan, gamma, Symbol, S, pi, Integral, cot, Rational, I, zoo,
-                   tan, cot, integrate, Sum)
+                   tan, cot, integrate, Sum, sign)
 
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import XFAIL, raises
@@ -25,7 +25,7 @@ def test_basic1():
     assert limit((1 + x)**oo, x, 0, dir='-') == 0
     assert limit((1 + x + y)**oo, x, 0, dir='-') == (1 + y)**(oo)
     assert limit(y/x/log(x), x, 0) == -y*oo
-    assert limit(cos(x + y)/x, x, 0) == cos(y)*oo
+    assert limit(cos(x + y)/x, x, 0) == sign(cos(y))*oo
     raises(NotImplementedError, 'limit(Sum(1/x, (x, 1, y)) - log(y), y, oo)')
     assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))
     assert limit(gamma(1/x + 3), x, oo) == 2

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -260,3 +260,6 @@ def test_issue1447():
 def test_issue835():
     assert limit((1 + x**log(3))**(1/x), x, 0) == 1
     assert limit((5**(1/x) + 3**(1/x))**x, x, 0) == 5
+
+def test_newissue():
+    assert limit(exp(1/sin(x))/exp(cot(x)), x, 0) == 1

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -256,7 +256,6 @@ def test_issue1447():
             else:
                 assert None
 
-@XFAIL
 def test_issue835():
     assert limit((1 + x**log(3))**(1/x), x, 0) == 1
     assert limit((5**(1/x) + 3**(1/x))**x, x, 0) == 5

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -136,7 +136,7 @@ def test_exp2():
     x = Symbol("x")
     w = Symbol("w")
     e = w**(1-log(x)/(log(2) + log(x)))
-    assert e.nseries(w,0,1) == e
+    assert e.nseries(w,0,1) == w*exp(-log(w)*log(x)/(log(2) + log(x)))
 
 def test_bug3():
     x = Symbol("x")
@@ -185,21 +185,21 @@ def test_seriesbug2b():
 def test_seriesbug2d():
     w = Symbol("w", real=True)
     e = log(sin(2*w)/w)
-    assert e.nseries(w, n=5) == log(2) - 2*w**2/3 - 4*w**4/45 + O(w**5)
+    assert e.series(w, n=5) == log(2) - 2*w**2/3 - 4*w**4/45 + O(w**5)
 
 def test_seriesbug2c():
     w = Symbol("w", real=True)
     #more complicated case, but sin(x)~x, so the result is the same as in (1)
     e=(sin(2*w)/w)**(1+w)
-    assert e.nseries(w,0,1) == 2 + O(w)
-    assert e.nseries(w,0,3) == 2-Rational(4,3)*w**2+w**2*log(2)**2+2*w*log(2)+O(w**3, w)
-    assert e.nseries(w,0,2).subs(w,0) == 2
+    assert e.series(w,0,1) == 2 + O(w)
+    assert e.series(w,0,3) == 2-Rational(4,3)*w**2+w**2*log(2)**2+2*w*log(2)+O(w**3, w)
+    assert e.series(w,0,2).subs(w,0) == 2
 
 def test_expbug4():
     x = Symbol("x", real=True)
-    assert (log(sin(2*x)/x)*(1+x)).nseries(x,0,2) == log(2) + x*log(2) + O(x**2, x)
+    assert (log(sin(2*x)/x)*(1+x)).series(x,0,2) == log(2) + x*log(2) + O(x**2, x)
     #assert exp(log(2)+O(x)).nseries(x,0,2) == 2 +O(x**2, x)
-    assert exp(log(sin(2*x)/x)*(1+x)).nseries(x,0,2) == 2 + 2*x*log(2) + O(x**2)
+    assert exp(log(sin(2*x)/x)*(1+x)).series(x,0,2) == 2 + 2*x*log(2) + O(x**2)
     #assert ((2+O(x))**(1+x)).nseries(x,0,2) == 2 + O(x**2, x)
 
 def test_logbug4():
@@ -287,9 +287,9 @@ def test_issue407():
 
 def test_issue409():
     x = Symbol("x", real=True)
-    assert log(sin(x)).nseries(x, n=5) == log(x) - x**2/6 - x**4/180 + O(x**5)
+    assert log(sin(x)).series(x, n=5) == log(x) - x**2/6 - x**4/180 + O(x**5)
     e = -log(x) + x*(-log(x) + log(sin(2*x))) + log(sin(2*x))
-    assert e.nseries(x, n=5) == log(2)+log(2)*x-2*x**2/3-2*x**3/3-4*x**4/45+O(x**5)
+    assert e.series(x, n=5) == log(2)+log(2)*x-2*x**2/3-2*x**3/3-4*x**4/45+O(x**5)
 
 def test_issue408():
     x = Symbol("x")
@@ -335,9 +335,9 @@ def test_bug5():
     e = (-log(w) + log(1 + w*log(x)))**(-2)*w**(-2)*((-log(w) + log(1 + \
         x*w))*(-log(w) + log(1 + w*log(x)))*w - x*(-log(w) + log(1 + \
             w*log(x)))*w)
-    assert e.nseries(w, n=1) == x/w/log(w) + 1/w + O(1/log(w))
+    assert e.nseries(w, n=1) == x/w/log(w) + 1/w + O(log(w)**2)
     assert e.nseries(w, n=2) == x/w/log(w) + 1/w - x/log(w) + 1/log(w)*log(x)\
-            + x*log(x)/log(w)**2 + O(w/log(w))
+            + x*log(x)/log(w)**2 + O(w*log(w)**2)
 
 
 def test_issue1016():

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -62,7 +62,7 @@ def test_power_x_x2():
             1+x*log(x)+x**2*log(x)**2/2+x**3*log(x)**3/6 + O(x**4*log(x)**4)
 
 def test_log_singular1():
-    assert log(1+1/x).nseries(x, n=5) == x + log(1/x) - x**2/2 + x**3/3 - \
+    assert log(1+1/x).nseries(x, n=5) == x - log(x) - x**2/2 + x**3/3 - \
             x**4/4 + O(x**5)
 
 def test_log_power1():
@@ -136,7 +136,8 @@ def test_exp2():
     x = Symbol("x")
     w = Symbol("w")
     e = w**(1-log(x)/(log(2) + log(x)))
-    assert e.nseries(w,0,1) == w*exp(-log(w)*log(x)/(log(2) + log(x)))
+    logw = Symbol("logw")
+    assert e.nseries(w,0,1,logx=logw) == exp(logw - logw*log(x)/(log(2) + log(x)))
 
 def test_bug3():
     x = Symbol("x")
@@ -235,8 +236,8 @@ def test_issue364():
     x = Symbol("x")
     e = 1/x*(-log(w**(1 + 1/log(3)*log(5))) + log(w + w**(1/log(3)*log(5))))
     e_ser = -log(5)*log(w)/(x*log(3)) + w**(log(5)/log(3) - 1)/x - \
-            w**(2*log(5)/log(3) - 2)/(2*x) + O(w)
-    assert e.nseries(w, n=1) == e_ser
+            w**(2*log(5)/log(3) - 2)/(2*x) + O(w**(-3+3*log(5)/log(3)))
+    assert e.nseries(w, n=3) == e_ser
 
 def test_sin():
     x = Symbol("x")

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -70,18 +70,18 @@ def test_log_power1():
     assert e.nseries(x, n=5) == x - x**(2 + log(3)/log(2)) + O(x**5)
 
 def test_log_series():
+    l = Symbol('l')
     e = 1/(1-log(x))
-    assert e.nseries(x, n=5) == -1/log(x) - log(x)**(-2) - log(x)**(-3) - \
-            log(x)**(-4) + O(log(x)**(-5))
+    assert e.nseries(x, n=5, logx=l) == 1/(1-l)
 
 def test_log2():
     e = log(-1/x)
     assert e.nseries(x, n=5) == -log(x) + log(-1)
 
 def test_log3():
+    l = Symbol('l')
     e = 1/log(-1/x)
-    assert e.nseries(x, n=4) == -1/log(x) - pi*I*log(x)**(-2) + \
-        pi**2*log(x)**(-3) + O(log(x)**(-4))
+    assert e.nseries(x, n=4, logx=l) == 1/(-l + log(-1))
 
 def test_series1():
     x = Symbol("x")
@@ -333,12 +333,13 @@ def test_bug4():
 def test_bug5():
     w = Symbol("w")
     x = Symbol("x")
+    l = Symbol('l')
     e = (-log(w) + log(1 + w*log(x)))**(-2)*w**(-2)*((-log(w) + log(1 + \
         x*w))*(-log(w) + log(1 + w*log(x)))*w - x*(-log(w) + log(1 + \
             w*log(x)))*w)
-    assert e.nseries(w, n=1) == x/w/log(w) + 1/w + O(log(w)**2)
-    assert e.nseries(w, n=2) == x/w/log(w) + 1/w - x/log(w) + 1/log(w)*log(x)\
-            + x*log(x)/log(w)**2 + O(w*log(w)**2)
+    assert e.nseries(w, n=1, logx=l) == x/w/l + 1/w + O(1, w)
+    assert e.nseries(w, n=2, logx=l) == x/w/l + 1/w - x/l + 1/l*log(x)\
+            + x*log(x)/l**2 + O(w)
 
 
 def test_issue1016():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -204,3 +204,7 @@ def test_getO():
     assert (z + O(x) + O(y)).getO() == O(x) + O(y)
     assert (z + O(x) + O(y)).removeO() == z
     raises(NotImplementedError, '(O(x)+O(y)).getn()')
+
+def test_leading_term():
+    from sympy import digamma
+    assert O(1/digamma(1/x)) == O(1/log(x))

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -20,8 +20,8 @@ def test_simple_1():
     assert Order(x*exp(1/x)).expr == x*exp(1/x)
     assert Order(x**(o/3)).expr == x**(o/3)
     assert Order(x**(5*o/3)).expr == x**(5*o/3)
-    assert Order(x**2 + x + y, x) == \
-           Order(x**2 + x + y, y) == O(1)
+    assert Order(x**2 + x + y, x) == O(1, x)
+    assert Order(x**2 + x + y, y) == O(1, y)
     raises(NotImplementedError, 'Order(x, 2 - x)')
 
 def test_simple_2():
@@ -182,10 +182,8 @@ def test_nan():
     assert not O(x).contains(nan)
 
 def test_O1():
-    assert O(1) == O(1, x)
-    assert O(1) == O(1, y)
-    assert hash(O(1)) == hash(O(1, x))
-    assert hash(O(1)) == hash(O(1, y))
+    assert O(1, x) * x == O(x)
+    assert O(1, y) * x == O(1, y)
 
 def test_getn():
     # other lines are tested incidentally by the suite

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -53,7 +53,7 @@ def test_2124():
     assert (1 + x).getn() == None
 
     assert ((1/sin(x))**oo).series() == oo
-    assert ((sin(x))**y).series(x) == 0**y
+    assert ((sin(x))**y).series(x, n=1) == exp(y*log(x)) + O(x*exp(y*log(x)), x)
 
     raises(NotImplementedError, 'series(Function("f")(x))')
 

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -53,7 +53,9 @@ def test_2124():
     assert (1 + x).getn() == None
 
     assert ((1/sin(x))**oo).series() == oo
-    assert ((sin(x))**y).series(x, n=1) == exp(y*log(x)) + O(x*exp(y*log(x)), x)
+    logx = Symbol('logx')
+    assert ((sin(x))**y).nseries(x, n=1, logx = logx) \
+           == exp(y*logx) + O(x*exp(y*logx), x)
 
     raises(NotImplementedError, 'series(Function("f")(x))')
 


### PR DESCRIPTION
This branch essentially fixes issue 2278. It is basically a big collection of fixes to gruntz. In some places I this amounted to almost rewriting the code, I did my best to preserve structure.

The principal aim of this branch is to add the "evaluation" tests from Gruntz' thesis (pp. 122-123 and 126) and make them work (at least for those functions that are in sympy). In the course of this I had to fix a number of shortcomings. In order to facilitate review, I have again numbered my commit messages, this time using roman numerals. Commits I-V implement the major functionality, VI adds the (now working) new tests, commits C1-C5 do various cleanups (note that C1-C3 are necessary to make the code work, i.e. without them the evaluation tests don't work). Details follow.

**I)** Implements the asymptotic polygamma series. There is nothing controversial here, this is just needed by the fixed gruntz algorithm (it does slightly more verbose computations).

**II)** Implements careful substitution in gruntz. In a sense this is really the meat of this series of patches. Basically subs is (getting) too smart for the kind of controlled substitution gruntz needs. Consider:

```
 >>> _p,_w = symbols('pw',positive=True)
 >>> Omega=[exp(exp(_p - exp(-_p))/(1 - 1/_p)), exp(exp(_p))]
 >>> O2=[exp(-exp(_p) + exp(-exp(-_p))*exp(_p)/(1 - 1/_p))/_w, 1/_w]
 >>> e = exp(exp(_p - exp(-_p))/(1 - 1/_p)) - exp(exp(_p))
 >>> e.subs(Omega[0],O2[0]).subs(Omega[1],O2[1])
 -1/w + exp(exp(p)*exp(-exp(-p))/(1 - 1/p))
```

The second substitution undoes the first! Moreover, there does not seem to be an easy way around this. Since some simplifications are done automatically in sympy, it is in particular not enough to just have a "be_dumb" paremeter for subs. So I decided to go the hard way, and have the mrv computation algorithm keep track of all required substitutions. This basically creates a ton of dummies and an explicit dictionary of substitutions. In the tests I have done this is not actually any slower than the old code. But see commit (V).

**III)** Implements careful propagation of log(x) in series expansions. This is likely to be the most controversial commit. The gruntz algorithm has some unique requirements for series expansions. In particular we are actually doing a series expansion in two variables, w and p, where log(w) is some specific function of p and should not be treated as depending on w. The gruntz algorithm code (and _eval_nseries in pow, exp, log) try quite hard to hide this (by substituting log(x) back and forth, so that each function accepts things with log(x) and returns things with log(x), but internally replaces log(x) by logx), but in the end it's just messy.

What this commit does is to pass an additional parameter logx to eval_nseries that contains the desired substitution. This obviously touches a lot of files. Not much is changed for the user, expansions "usually" work if logx=None is passed. Sometimes this can result in an exception (look at the changed test). There are three ways around this: 1) pass a log(x) parameter, possibly a dummy. 2) Fix the code that causes the exception. 3) Change nseries to always pass a dummy if it receives logx=None, and substitute back log(x) for the dummy in the end. I didn't do (3) because for Gruntz, O(x*log(x)) = O(x), but some users may consider this a failure. It should be noted that the problem only occurs in sufficiently esoteric cases, where in particular there is no ordinary taylor series.

**IV)** Fixes function series for logarithmic singularities.  This fixes a minor incompliance with the gruntz algorithm requirements that can hardly be seen for limits simpler than loggamma(loggamma(loggamma(x))). ^^

**C1)** Adds some series expansion for piecewise functions, this is needed to make the next commit pass tests. This code is quite incomplete, simply because orders, gruntz etc don't play along very nicely with piecewise functions.

**C2)** Makes order use compute_leading_term. There does seem to be some sort of confusion about what as_leading_term is supposed to do (according to expr it only works on series expansions, I have no idea what the code in Function supposedly does, and e.g. sin does implement proper leading term in this function...). In the previous branch I added compute_leading_term which can always be used, and this commit changes Order to use it as well, if possible (compute_leading_term only works in one variable). The need for this can be seen e.g. in O(1/digamma(1/x)).

**C3)** Is a minor fix for add._eval_as_leading_term, which didn't use to return an expression with coefficients collected, but expr.leadterm expects this.

**V)** Adds two performance improvements. (1) calculate_series now tries to compute only one term on the first try (used to be two terms). (2) rewrite doesn't have to re-compute MRV sets, since all the information (tree structure) we need is already in the SubsSet. Note that both of these would not have been possible before: (1) used to break the code (this indicates bugs), and (2) relies on the explicit substitution.

I'm not entirely satisfied with the speed, but I don't really see how to improve it further. I have created a callgraph (using cProfile and gprof2dot) [2]. This is somewhat hard to read since the algorithm is highly recursive. But we do see that a lot of time is apparently spent in powsimp and expand. Powsimp is indeed called a lot in gruntz, these calls can be moved around but I didn't achieve any speedup. Expand is mostly called from mul._eval_nseries, maybe a faster routine can be used here?

To give an example of the speed that we are at now, the slowest limit I currently have is this: `gruntz(exp(gamma(x-exp(-x))*exp(1/x)) - exp(gamma(x)), x, oo)` (it happens to tend to infinity). Sympy on my machine requires about 13 seconds to evaluate it. Maxima takes >40 seconds. I'm not sure if this means we are fast or maxima is slow. Can anyone test other CASs?

**VI)** Finally adds the new tests.

**C4)** Fixes the behaviour of unevaluated signs. gruntz used to return things like (1+y)oo instead of sign(1+y)oo which sometimes results in nans where there really shouldn't be any [sorry I lost my specific example].

**C5)** Removes XFAIL from a test that now works: apparently issue 835 has been fixed as a side effect. There is another Xpass in test_ode: test_1st_homogeneous_coeff_ode4_explicit. I don't understand what has happened here (@asmeurer ?).

[1] https://github.com/sympy/sympy/pull/216

[2] http://people.pwf.cam.ac.uk/tb401/stat.png
