### PR TITLE
Implemented EPath for expression manipulation

### DIFF
--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -13,3 +13,5 @@ from sqrtdenest import sqrtdenest
 from cse_main import cse
 
 from traversaltools import use
+
+from epathtools import epath, EPath

--- a/sympy/simplify/epathtools.py
+++ b/sympy/simplify/epathtools.py
@@ -1,0 +1,305 @@
+"""Tools for manipulation of expressions using paths. """
+
+from sympy.core import Basic
+
+class EPath(object):
+    """
+    Manipulate expressions using paths.
+
+    EPath grammar in EBNF notation::
+
+        literal   ::= /[A-Za-z_][A-Za-z_0-9]*/
+        number    ::= /-?\d+/
+        type      ::= literal
+        attribute ::= literal "?"
+        all       ::= "*"
+        slice     ::= "[" number? (":" number? (":" number?)?)? "]"
+        range     ::= all | slice
+        query     ::= (type | attribute) ("|" (type | attribute))*
+        selector  ::= range | query range?
+        path      ::= "/" selector ("/" selector)*
+
+    """
+
+    __slots__ = ["_path", "_epath"]
+
+    def __new__(cls, path):
+        """Construct new EPath. """
+        if isinstance(path, EPath):
+            return path
+
+        if not path:
+            raise ValueError("empty EPath")
+
+        _path = path
+
+        if path[0] == '/':
+            path = path[1:]
+        else:
+            raise NotImplementedError("non-root EPath")
+
+        epath = []
+
+        for selector in path.split('/'):
+            selector = selector.strip()
+
+            if not selector:
+                raise ValueError("empty selector")
+
+            index = 0
+
+            for c in selector:
+                if c.isalnum() or c == '_' or c == '|' or c == '?':
+                    index += 1
+                else:
+                    break
+
+            attrs = []
+            types = []
+
+            if index:
+                elements = selector[:index]
+                selector = selector[index:]
+
+                for element in elements.split('|'):
+                    element = element.strip()
+
+                    if not element:
+                        raise ValueError("empty element")
+
+                    if element.endswith('?'):
+                        attrs.append(element[:-1])
+                    else:
+                        types.append(element)
+
+            span = None
+
+            if selector == '*':
+                pass
+            else:
+                if selector.startswith('['):
+                    try:
+                        i = selector.index(']')
+                    except ValueError:
+                        raise ValueError("expected ']', got EOL")
+
+                    _span, span = selector[1:i], []
+
+                    if ':' not in _span:
+                        span = int(_span)
+                    else:
+                        for elt in _span.split(':', 3):
+                            if not elt:
+                                span.append(None)
+                            else:
+                                span.append(int(elt))
+
+                        span = slice(*span)
+
+                    selector = selector[i+1:]
+
+                if selector:
+                    raise ValueError("trailing characters in selector")
+
+            epath.append((attrs, types, span))
+
+        obj = object.__new__(cls)
+
+        obj._path = _path
+        obj._epath = epath
+
+        return obj
+
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__.__name__, self._path)
+
+    def _hasattrs(self, expr, attrs):
+        """Check if ``expr`` has any of ``attrs``. """
+        for attr in attrs:
+            if not hasattr(expr, attr):
+                return False
+
+        return True
+
+    def _hastypes(self, expr, types):
+        """Check if ``expr`` is any of ``types``. """
+        _types = [ cls.__name__ for cls in expr.__class__.mro() ]
+        return bool(set(_types).intersection(types))
+
+    def _has(self, expr, attrs, types):
+        """Apply ``_hasattrs`` and ``_hastypes`` to ``expr``. """
+        if not (attrs or types):
+            return True
+
+        if attrs and self._hasattrs(expr, attrs):
+            return True
+
+        if types and self._hastypes(expr, types):
+            return True
+
+        return False
+
+    def apply(self, expr, func, args=None, kwargs=None):
+        """
+        Modify parts of an expression selected by a path.
+
+        **Examples**
+
+        >>> from sympy.simplify.epathtools import EPath
+        >>> from sympy.abc import x, y, z
+
+        >>> path = EPath("/*/[0]/Symbol")
+        >>> expr = [((x, 1), 2), ((3, y), z)]
+
+        >>> path.apply(expr, lambda expr: expr**2)
+        [((x**2, 1), 2), ((3, y**2), z)]
+
+        """
+        def _apply(path, expr, func):
+            if not path:
+                return func(expr)
+            else:
+                selector, path = path[0], path[1:]
+                attrs, types, span = selector
+
+                if isinstance(expr, Basic):
+                    args, basic = expr.args, True
+                elif hasattr(expr, '__iter__'):
+                    args, basic = expr, False
+                else:
+                    return expr
+
+                args = list(args)
+
+                if span is not None:
+                    if type(span) == slice:
+                        indices = range(*span.indices(len(args)))
+                    else:
+                        indices = [span]
+                else:
+                    indices = xrange(len(args))
+
+                for i in indices:
+                    try:
+                        arg = args[i]
+                    except IndexError:
+                        continue
+
+                    if self._has(arg, attrs, types):
+                        args[i] = _apply(path, arg, func)
+
+                if basic:
+                    return expr.func(*args)
+                else:
+                    return expr.__class__(args)
+
+        _args, _kwargs = args or (), kwargs or {}
+        _func = lambda expr: func(expr, *_args, **_kwargs)
+
+        return _apply(self._epath, expr, _func)
+
+    def select(self, expr):
+        """
+        Retrieve parts of an expression selected by a path.
+
+        **Examples**
+
+        >>> from sympy.simplify.epathtools import EPath
+        >>> from sympy.abc import x, y, z
+
+        >>> path = EPath("/*/[0]/Symbol")
+        >>> expr = [((x, 1), 2), ((3, y), z)]
+
+        >>> path.select(expr)
+        [x, y]
+
+        """
+        result = []
+
+        def _select(path, expr):
+            if not path:
+                result.append(expr)
+            else:
+                selector, path = path[0], path[1:]
+                attrs, types, span = selector
+
+                if isinstance(expr, Basic):
+                    args = expr.args
+                elif hasattr(expr, '__iter__'):
+                    args = expr
+                else:
+                    return
+
+                if span is not None:
+                    if type(span) == slice:
+                        args = args[span]
+                    else:
+                        try:
+                            args = [args[span]]
+                        except IndexError:
+                            return
+
+                for arg in args:
+                    if self._has(arg, attrs, types):
+                        _select(path, arg)
+
+        _select(self._epath, expr)
+        return result
+
+def epath(path, expr=None, func=None, args=None, kwargs=None):
+    """
+    Manipulate parts of an expression selected by a path.
+
+    This function allows to manipulate large nested expressions in single
+    line of code, utilizing techniques to those applied in XML processing
+    standards (e.g. XPath).
+
+    If ``func`` is ``None``, :func:`epath` retrieves elements selected by
+    the ``path``. Otherwise it applies ``func`` to each matching element.
+
+    **Syntax**
+
+    select all : "/*"
+        Equivalent of ``for arg in args:``.
+    select slice : "/[0]" | "/[1:5]" | "/[1:5:2]"
+        Supports standard Python's slice syntax.
+    select by type : "/list" | "/list|tuple"
+        Emulates :func:`isinstance`.
+    select by attribute : "/__iter__?"
+        Emulates :func:`hasattr`.
+
+    **Parameters**
+
+    path : str | EPath
+        A path as a string or a compiled EPath.
+    expr : Basic | iterable
+        An expression or a container of expressions.
+    func : callable (optional)
+        A callable that will be applied to matching parts.
+    args : tuple (optional)
+        Additional positional arguments to ``func``.
+    kwargs : dict (optional)
+        Additional keyword arguments to ``func``.
+
+    **Examples**
+
+    >>> from sympy.simplify.epathtools import epath
+    >>> from sympy.abc import x, y, z
+
+    >>> path = "/*/[0]/Symbol"
+    >>> expr = [((x, 1), 2), ((3, y), z)]
+
+    >>> epath(path, expr)
+    [x, y]
+    >>> epath(path, expr, lambda expr: expr**2)
+    [((x**2, 1), 2), ((3, y**2), z)]
+
+    """
+    _epath = EPath(path)
+
+    if expr is None:
+        return _epath
+    if func is None:
+        return _epath.select(expr)
+    else:
+        return _epath.apply(expr, func, args, kwargs)

--- a/sympy/simplify/tests/test_epathtools.py
+++ b/sympy/simplify/tests/test_epathtools.py
@@ -3,6 +3,7 @@
 from sympy.simplify.epathtools import epath, EPath
 from sympy.utilities.pytest import raises
 
+from sympy import sin, cos, E
 from sympy.abc import x, y, z, t
 
 def test_epath_select():
@@ -43,7 +44,8 @@ def test_epath_select():
     assert epath("/*/[0]/int[1:]", expr) == [1, 4]
     assert epath("/*/[0]/Symbol[1:]", expr) == [t, y]
 
-    assert set(epath("/Symbol", x + y + z + 1)) == set([x, y, z])
+    assert epath("/Symbol", x + y + z + 1) == [x, y, z]
+    assert epath("/*/*/Symbol", t + sin(x + 1) + cos(x + y + E)) == [x, x, y]
 
 def test_epath_apply():
     expr = [((x, 1, t), 2), ((3, y, 4), z)]
@@ -61,6 +63,8 @@ def test_epath_apply():
     assert epath("/*/[0]/Symbol[1:]", expr, func) == [((x, 1, t**2), 2), ((3, y**2, 4), z)]
 
     assert epath("/Symbol", x + y + z + 1, func) == x**2 + y**2 + z**2 + 1
+    assert epath("/*/*/Symbol", t + sin(x + 1) + cos(x + y + E), func) == \
+        t + sin(x**2 + 1) + cos(x**2 + y**2 + E)
 
 def test_EPath():
     assert EPath("/*/[0]")._path == "/*/[0]"

--- a/sympy/simplify/tests/test_epathtools.py
+++ b/sympy/simplify/tests/test_epathtools.py
@@ -1,0 +1,78 @@
+"""Tests for tools for manipulation of expressions using paths. """
+
+from sympy.simplify.epathtools import epath, EPath
+from sympy.utilities.pytest import raises
+
+from sympy.abc import x, y, z, t
+
+def test_epath_select():
+    expr = [((x, 1, t), 2), ((3, y, 4), z)]
+
+    assert epath("/*", expr) == [((x, 1, t), 2), ((3, y, 4), z)]
+    assert epath("/*/*", expr) == [(x, 1, t), 2, (3, y, 4), z]
+    assert epath("/*/*/*", expr) == [x, 1, t, 3, y, 4]
+    assert epath("/*/*/*/*", expr) == []
+
+    assert epath("/[:]", expr) == [((x, 1, t), 2), ((3, y, 4), z)]
+    assert epath("/[:]/[:]", expr) == [(x, 1, t), 2, (3, y, 4), z]
+    assert epath("/[:]/[:]/[:]", expr) == [x, 1, t, 3, y, 4]
+    assert epath("/[:]/[:]/[:]/[:]", expr) == []
+
+    assert epath("/*/[:]", expr) == [(x, 1, t), 2, (3, y, 4), z]
+
+    assert epath("/*/[0]", expr) == [(x, 1, t), (3, y, 4)]
+    assert epath("/*/[1]", expr) == [2, z]
+    assert epath("/*/[2]", expr) == []
+
+    assert epath("/*/int", expr) == [2]
+    assert epath("/*/Symbol", expr) == [z]
+    assert epath("/*/tuple", expr) == [(x, 1, t), (3, y, 4)]
+    assert epath("/*/__iter__?", expr) == [(x, 1, t), (3, y, 4)]
+
+    assert epath("/*/int|tuple", expr) == [(x, 1, t), 2, (3, y, 4)]
+    assert epath("/*/Symbol|tuple", expr) == [(x, 1, t), (3, y, 4), z]
+    assert epath("/*/int|Symbol|tuple", expr) == [(x, 1, t), 2, (3, y, 4), z]
+
+    assert epath("/*/int|__iter__?", expr) == [(x, 1, t), 2, (3, y, 4)]
+    assert epath("/*/Symbol|__iter__?", expr) == [(x, 1, t), (3, y, 4), z]
+    assert epath("/*/int|Symbol|__iter__?", expr) == [(x, 1, t), 2, (3, y, 4), z]
+
+    assert epath("/*/[0]/int", expr) == [1, 3, 4]
+    assert epath("/*/[0]/Symbol", expr) == [x, t, y]
+
+    assert epath("/*/[0]/int[1:]", expr) == [1, 4]
+    assert epath("/*/[0]/Symbol[1:]", expr) == [t, y]
+
+    assert set(epath("/Symbol", x + y + z + 1)) == set([x, y, z])
+
+def test_epath_apply():
+    expr = [((x, 1, t), 2), ((3, y, 4), z)]
+    func = lambda expr: expr**2
+
+    assert epath("/*", expr, list) == [[(x, 1, t), 2], [(3, y, 4), z]]
+
+    assert epath("/*/[0]", expr, list) == [([x, 1, t], 2), ([3, y, 4], z)]
+    assert epath("/*/[1]", expr, func) == [((x, 1, t), 4), ((3, y, 4), z**2)]
+    assert epath("/*/[2]", expr, list) == expr
+
+    assert epath("/*/[0]/int", expr, func) == [((x, 1, t), 2), ((9, y, 16), z)]
+    assert epath("/*/[0]/Symbol", expr, func) == [((x**2, 1, t**2), 2), ((3, y**2, 4), z)]
+    assert epath("/*/[0]/int[1:]", expr, func) == [((x, 1, t), 2), ((3, y, 16), z)]
+    assert epath("/*/[0]/Symbol[1:]", expr, func) == [((x, 1, t**2), 2), ((3, y**2, 4), z)]
+
+    assert epath("/Symbol", x + y + z + 1, func) == x**2 + y**2 + z**2 + 1
+
+def test_EPath():
+    assert EPath("/*/[0]")._path == "/*/[0]"
+    assert EPath(EPath("/*/[0]"))._path == "/*/[0]"
+    assert isinstance(epath("/*/[0]"), EPath) is True
+
+    assert repr(EPath("/*/[0]")) == "EPath('/*/[0]')"
+
+    raises(ValueError, 'EPath("")')
+    raises(ValueError, 'EPath("/")')
+    raises(ValueError, 'EPath("/|x")')
+    raises(ValueError, 'EPath("/[")')
+    raises(ValueError, 'EPath("/[0]%")')
+
+    raises(NotImplementedError, 'EPath("Symbol")')


### PR DESCRIPTION
EPath is modeled after XPath and useful for writing expression
manipulation and retrieval code in interactive sessions with
SymPy.

Example:

Suppose we compute isolating intervals of roots of polynomial
`x**2 - 2` and we want to quickly obtain numerical approximations
of ends of those intervals:

<pre>
In [1]: intervals(x**2 - 2, eps=0.1)
Out[1]: [((-10/7, -7/5), 1), ((7/5, 10/7), 1)]

In [2]: epath("/*/[0]/*", _, N)
Out[2]: [((-1.42857142857143, -1.4), 1), ((1.4, 1.42857142857143), 1)]
</pre>
