### PR TITLE
Fix for the compute_known_facts function (issue 2299)

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -182,8 +182,8 @@ def compute_known_facts():
     # Compute the known facts in CNF form for logical inference
     fact_string = " -{ Known facts in CNF }-\n"
     cnf = to_cnf(known_facts)
-    fact_string += "known_facts_cnf = And( \\\n   ",
-    fact_string += ", \\\n    ".join(map(str, cnf.args))
+    fact_string += "known_facts_cnf = And(\n    "
+    fact_string += ",\n    ".join(map(str, cnf.args))
     fact_string += "\n)\n"
 
     # Compute the quick lookup for single facts
@@ -193,11 +193,11 @@ def compute_known_facts():
         mapping[key] = set([key])
         for other_key in known_facts_keys:
             if other_key != key:
-                if ask(x, other_key, Assume(x, key, False), disable_preprocessing=True):
-                    mapping[key].add(Not(other_key))
+                if ask(x, other_key, Assume(x, key, True), disable_preprocessing=True):
+                    mapping[key].add(other_key)
     fact_string += "\n\n -{ Known facts in compressed sets }-\n"
-    fact_string += "known_facts_dict = { \\\n   ",
-    fact_string += ", \\\n    ".join(["%s: %s" % item for item in mapping.items()])
+    fact_string += "known_facts_dict = {\n    "
+    fact_string += ",\n    ".join(["%s: %s" % item for item in mapping.items()])
     fact_string += "\n}\n"
     return fact_string
 


### PR DESCRIPTION
For some reason, the latest version of compute_known_facts wasn't put into the master. This commit fixes the following issues:
- Two syntax errors where an extra comma was added
- Two formatting errors that displayed the data structures incorrectly
- Two errors that cause the known_facts_dict to be built improperly
  
  This pull request is related to [issue 2299](http://code.google.com/p/sympy/issues/detail?id=2299).
