### PR TITLE
t Symbol

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -8,8 +8,8 @@
 
        >>> from __future__ import division
        >>> from sympy import *
-       >>> x, y, z, t = symbols("x,y,z,t")
-       >>> k, m, n = symbols("k,m,n", integer=True)
+       >>> x, y, z, t = symbols("x y z t")
+       >>> k, m, n = symbols("k m n", integer=True)
        >>> f, g, h = map(Function, 'fgh')
 
    So starting 'isympy' is equivalent to starting Python (or IPython)

--- a/doc/src/gotchas.txt
+++ b/doc/src/gotchas.txt
@@ -190,8 +190,8 @@ giving you some default Symbols and Functions.
 
     >>> from __future__ import division
     >>> from sympy import *
-    >>> x, y, z, t = symbols('x,y,z,t')
-    >>> k, m, n = symbols('k,m,n', integer=True)
+    >>> x, y, z, t = symbols('x y z t')
+    >>> k, m, n = symbols('k m n', integer=True)
     >>> f, g, h = map(Function, 'fgh')
 
 You can also import common symbol names from :mod:`sympy.abc`.

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -5,9 +5,9 @@ from sympy.interactive.printing import init_printing
 preexec_source = """\
 from __future__ import division
 from sympy import *
-x, y, z = symbols('x,y,z')
-k, m, n = symbols('k,m,n', integer=True)
-f, g, h = symbols('f,g,h', cls=Function)
+x, y, z, t = symbols('x y z t')
+k, m, n = symbols('k m n', integer=True)
+f, g, h = symbols('f g h', cls=Function)
 """
 
 verbose_message = """\


### PR DESCRIPTION
Add t to the list of default symbols in isympy

This was done before, but it seems it was undone by the polys12 merge.
