### PR TITLE
Issue 2305: rename Integer.sqrt to Integer.isqrt

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1214,7 +1214,7 @@ class Integer(Rational):
         """Compute factorial of `a`. """
         return Integer(ifactorial(int(a)))
 
-    def sqrt(a):
+    def isqrt(a):
         """Compute integer square root of `a`. """
         return Integer(mlib.isqrt(int(a)))
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -604,9 +604,9 @@ def test_Integer_methods():
     assert Integer(1).factorial() == Integer(1)
     assert Integer(10).factorial() == Integer(3628800)
 
-    assert Integer(100).sqrt() == Integer(10)
-    assert Integer(110).sqrt() == Integer(10)
-    assert Integer(121).sqrt() == Integer(11)
+    assert Integer(100).isqrt() == Integer(10)
+    assert Integer(110).isqrt() == Integer(10)
+    assert Integer(121).isqrt() == Integer(11)
 
     assert Integer(100).half_gcdex(2004) == \
         (Integer(-20), Integer(4))

--- a/sympy/polys/domains/sympyintegerring.py
+++ b/sympy/polys/domains/sympyintegerring.py
@@ -96,7 +96,7 @@ class SymPyIntegerRing(IntegerRing):
 
     def sqrt(self, a):
         """Compute square root of `a`. """
-        return a.sqrt()
+        return a.isqrt()
 
     def factorial(self, a):
         """Compute factorial of `a`. """


### PR DESCRIPTION
Incorrectly named method has been renamed to avoid confusion.
