### PR TITLE
Issue 2318: fixed doctest utility. Also use 'warn' in the geometry/polygo

### DIFF
--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -6,6 +6,7 @@ from point import Point
 from ellipse import Circle
 from line import Line, Segment, Ray
 
+import warnings
 
 class Polygon(GeometryEntity):
     """A two-dimensional polygon.
@@ -370,7 +371,7 @@ class Polygon(GeometryEntity):
                 e2_max_radius = r
         center_dist = Point.distance(e1_center, e2_center)
         if center_dist <= e1_max_radius + e2_max_radius:
-            print("Warning: Polygons may intersect producing erroneous output")
+            warnings.warn("Polygons may intersect producing erroneous output")
 
         '''
         Find the upper rightmost vertex of e1 and the lowest leftmost vertex of e2

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -274,7 +274,9 @@ def doctest(*paths, **kwargs):
                 continue
             old_displayhook = sys.displayhook
             try:
-                out = pdoctest.testfile(txt_file, module_relative=False, encoding='utf-8',
+                # out = pdoctest.testfile(txt_file, module_relative=False, encoding='utf-8',
+                #    optionflags=pdoctest.ELLIPSIS | pdoctest.NORMALIZE_WHITESPACE)
+                out = sympytestfile(txt_file, module_relative=False, encoding='utf-8',
                     optionflags=pdoctest.ELLIPSIS | pdoctest.NORMALIZE_WHITESPACE)
             finally:
                 # make sure we return to the original displayhook in case some


### PR DESCRIPTION
Issue 2318: fixed doctest utility. Also use 'warn' in the geometry/polygone.

There was some doctests failed in the master branch after poly12 added.
See issue 2318 [1] for details.

It was due to the aplying standard doctest.testfile() instead of
sympytestfile() procedure.

Also replaced "print" with "warning.warn" in the "sympy/geometry/polygon.py"
module.

[1] http://code.google.com/p/sympy/issues/detail?id=2318
