### PR TITLE
Issues 2203: Replace some "In [n]:/Out[n]:" with ">>>" in doctests.

### DIFF
--- a/doc/src/guide.txt
+++ b/doc/src/guide.txt
@@ -156,13 +156,14 @@ write by hand - so for example ``b*a + -4 + b + a*b + 4 + (a+b)**2`` becomes
 Whenever you construct an expression, for example ``Add(x, x)``, the
 ``Add.__new__()`` is called and it determines what to return. In this case::
 
-    In [1]: e = Add(x, x)
+    >>> from sympy import Add
+    >>> from sympy.abc import x
+    >>> e = Add(x, x)
+    >>> e
+    2*x
 
-    In [2]: e
-    Out[2]: 2*x
-
-    In [3]: type(e)
-    Out[3]: <class 'sympy.core.mul.Mul'>
+    >>> type(e)
+    <class 'sympy.core.mul.Mul'>
 
 ``e`` is actually an instance of ``Mul(2, x)``, because ``Add.__new__()``
 retuned ``Mul``.
@@ -172,11 +173,12 @@ Comparisons
 
 Expressions can be compared using a regular python syntax::
 
-    In [1]: x+y == y+x
-    Out[1]: True
+    >>> from sympy.abc import x, y
+    >>> x+y == y+x
+    True
 
-    In [2]: x+y == y-x
-    Out[2]: False
+    >>> x+y == y-x
+    False
 
 We made the following decision in SymPy: ``a=Symbol("x")`` and another
 ``b=Symbol("x")`` (with the same string "x") is the same thing, i.e ``a==b`` is
@@ -189,11 +191,12 @@ some calculation, which is going to be substituted for something else at the
 end anyway. This is achieved using ``Dummy("x")``. So, to sum it
 up::
 
-    In [1]: Symbol("x") == Symbol("x")
-    Out[1]: True
+    >>> from  sympy import Symbol, Dummy
+    >>> Symbol("x") == Symbol("x")
+    True
 
-    In [2]: Dummy("x") == Dummy("x")
-    Out[2]: False
+    >>> Dummy("x") == Dummy("x")
+    False
 
 
 Debugging
@@ -416,32 +419,30 @@ Please use the same way as is shown below all across SymPy.
 
 **accessing parameters**::
 
+    >>> from sympy import sign, sin
+    >>> from sympy.abc import x, y, z
+    
     In [1]: e = sign(x**2)
-
     In [2]: e.args
-    Out[2]:
-    ⎛ 2⎞
-    ⎝x ⎠
+    Out[2]: x**2
 
     In [3]: e.args[0]
-    Out[3]:
-     2
+    Out[3]: x**2
+
+    >>> (x+y*z).args
+    (y*z, x)
+
+    >>> (x+y*z).args[0]
+    y*z
+
+    >>> (x+y*z).args[1]
     x
 
-    In [4]: (x+y*z).args
-    Out[4]: (y*z, x)
+    >>> (y*z).args
+    (y, z)
 
-    In [5]: (x+y*z).args[0]
-    Out[5]: y*z
-
-    In [6]: (x+y*z).args[1]
-    Out[6]: x
-
-    In [7]: (y*z).args
-    Out[7]: (y, z)
-
-    In [8]: sin(y*z).args
-    Out[8]: (y*z)
+    >>> sin(y*z).args
+    (y*z,)
 
 Never use internal methods or variables, prefixed with "``_``" (example: don't
 use ``_args``, use ``.args`` instead).
@@ -450,38 +451,40 @@ use ``_args``, use ``.args`` instead).
 
 Applied functions::
 
-    In [1]: e = sign(x**2)
+    >>> from sympy import sign, exp, Function
+    >>> e = sign(x**2)
 
-    In [4]: isinstance(e, sign)
-    Out[4]: True
+    >>> isinstance(e, sign)
+    True
 
-    In [5]: isinstance(e, exp)
-    Out[5]: False
+    >>> isinstance(e, exp)
+    False
 
-    In [2]: isinstance(e, Function)
-    Out[2]: True
+    >>> isinstance(e, Function)
+    True
 
 So ``e`` is a ``sign(z)`` function, but not ``exp(z)`` function.
 
 Unapplied functions::
 
-    In [1]: e = sign
+    >>> from sympy import sign, exp, FunctionClass
+    >>> e = sign
 
-    In [2]: f = exp
+    >>> f = exp
 
-    In [3]: g = Add
+    >>> g = Add
 
-    In [4]: isinstance(e, FunctionClass)
-    Out[4]: True
+    >>> isinstance(e, FunctionClass)
+    True
 
-    In [5]: isinstance(f, FunctionClass)
-    Out[5]: True
+    >>> isinstance(f, FunctionClass)
+    True
 
-    In [6]: isinstance(g, FunctionClass)
-    Out[6]: False
+    >>> isinstance(g, FunctionClass)
+    False
 
-    In [10]: g is Add
-    Out[10]: True
+    >>> g is Add
+    True
 
 So ``e`` and ``f`` are functions, ``g`` is not a function.
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -77,15 +77,15 @@ class Ellipse(GeometryEntity):
 
     Plotting example
     ----------------
-    In [1]: c1 = Circle(Point(0,0), 1)
-    In [2]: Plot(c1)
-    Out[2]: [0]: cos(t), sin(t), 'mode=parametric'
-    In [3]: p = Plot()
-    In [4]: p[0] = c1
-    In [5]: radius = Segment(c1.center, c1.random_point())
-    In [6]: p[1] = radius
-    In [7]: p
-    Out[7]:
+    >>> from sympy import Circle, Plot, Segment
+    >>> c1 = Circle(Point(0,0), 1)
+    >>> Plot(c1)                                # doctest: +SKIP
+    [0]: cos(t), sin(t), 'mode=parametric'
+    >>> p = Plot()                              # doctest: +SKIP
+    >>> p[0] = c1                               # doctest: +SKIP
+    >>> radius = Segment(c1.center, c1.random_point())  # doctest: +SKIP
+    >>> p[1] = radius                           # doctest: +SKIP
+    >>> p                                       # doctest: +SKIP
     [0]: cos(t), sin(t), 'mode=parametric'
     [1]: t*cos(1.546086215036205357975518382),
     t*sin(1.546086215036205357975518382), 'mode=parametric'

--- a/sympy/integrals/__init__.py
+++ b/sympy/integrals/__init__.py
@@ -1,8 +1,12 @@
 """Integration functions that integrates a sympy expression.
 
-In [3]: integrate(1/x,x)
-Out[3]: log(x)
-In [4]: integrate(sin(x),x)
-Out[4]: -cos(x)
+    Examples
+    --------
+    >>> from sympy import integrate, sin
+    >>> from sympy.abc import x
+    >>> integrate(1/x,x)
+    log(x)
+    >>> integrate(sin(x),x)
+    -cos(x)
 """
 from integrals import integrate, Integral, line_integrate

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -61,20 +61,19 @@ def print_tree(node):
     """
     Prints a tree representation of "node".
 
-    In [1]: print_tree(x**2)
+    >>> from sympy.printing import print_tree
+    >>> from sympy.abc import x
+    >>> print_tree(x**2) # doctest: +SKIP
     Pow: x**2
     +-Symbol: x
     | comparable: False
-    | noncommutative: False
-    | commutative: True
     +-Integer: 2
       real: True
+      nonzero: True
       comparable: True
       commutative: True
       infinitesimal: False
-      nonzero: True
       unbounded: False
-      noncommutative: False
       noninteger: False
       zero: False
       complex: True
@@ -84,7 +83,7 @@ def print_tree(node):
       imaginary: False
       finite: True
       irrational: False
-
+    <BLANKLINE>
 
     See also: tree()
     """

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -1,7 +1,11 @@
 """A module for solving all kinds of equations.
 
-In [3]: solve(x**5+5*x**4+10*x**3+10*x**2+5*x+1,x)
-Out[3]: [-1]
+    Examples
+    --------
+    >>> from sympy.solvers import solve
+    >>> from sympy.abc import x
+    >>> solve(x**5+5*x**4+10*x**3+10*x**2+5*x+1,x)
+    [-1]
 """
 from solvers import solve, solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs, tsolve, msolve, nsolve, solve_linear


### PR DESCRIPTION
These doctests was replaced as far as possible.

Turned on:
 ./sympy/solvers/__init__.py: `solve(x**5+5*x**4+10*x**3+10*x**2+5*x+1,x)`
 ./sympy/integrals/__init__.py: integrate(1/x,x) and so on
 ./doc/src/guide.txt:    In [1]: e = Add(x, x) and so on
 ./doc/src/guide.txt:    In [4]: (x+y*z).args and so on

Leaved without changes:
   (commad `grep  -A 1 --directories=recurse --include=*.* 'In \[' ./`)

by those reasons:
  ./sympy/printing/tree.py  - as order involved, then +SKIP option added.
  ./sympy/geometry/ellipse.py - plotting, +SKIP option added.
  ./sympy/series/gruntz.py  - it is example of debugging.
  ./doc/src/gotchas.txt     - this example of help in IPython (help(), "?").
  ./doc/src/guide.txt       - user's function usage, pretty_printer usage.
! ./doc/src/guide.txt       -  `sign(x**2).args`
      **AttributeError: 'sign' object has no attribute 'agrs'**
  ./doc/src/spt-patches/xobj-fix-even-height.patch - do not know what it is.
  ./doc/src/tutorial.txt    - pretty_printer widly usage here.
