### PR TITLE
Fix issue 2315 (integrate(1/(x**2 + n**2), x) fails, where n is an intege

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -209,6 +209,9 @@ def log_to_atan(f, g):
     if f.degree() < g.degree():
         f, g = -g, f
 
+    f = f.to_field()
+    g = g.to_field()
+
     p, q = f.div(g)
 
     if q.is_zero:

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -96,3 +96,5 @@ def test_ratint_logpart():
     assert ratint_logpart(x**2, x**3-5, x, t) == \
         [(Poly(x**3 - 5, x), Poly(-3*t + 1, t))]
 
+def test_issue_2315():
+    assert ratint(1/(x**2 + 16), x) == atan(x/4)/4


### PR DESCRIPTION
Fix issue 2315 (integrate(1/(x**2 + n**2), x) fails, where n is an integer)

log_to_atan() in integrals/rationaltools.py was failing because the
domains of the Polys weren't set properly.  Made the fix suggested by
Mateusz in the issue page, and added a test.
