### PR TITLE
2325: Fix inradius test.

### DIFF
--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -416,10 +416,9 @@ def test_polygon():
     assert t1.incenter == Point(ic, ic)
 
     # Inradius
-    assert t1.inradius == 5 - 5*2**(S(1)/2)/2
-    assert t2.inradius == 5*3**(S(1)/2)/6
-    t3_inradius = (2*x1**2*Abs(x1) - 2**(S(1)/2)*x1**2*Abs(x1))/(2*x1**2)
-    assert simplify((t3.inradius - t3_inradius)) == 0
+    assert t1.inradius == 5 - 5*sqrt(2)/2
+    assert t2.inradius == 5*sqrt(3)/6
+    assert t3.inradius == x1**2/((2 + sqrt(2))*Abs(x1))
 
     # Medians + Centroid
     m = t1.medians


### PR DESCRIPTION
Also, use sqrt in tests rather than the cumbersome **(S(1)/2).

This fixes [issue 2325](http://code.google.com/p/sympy/issues/detail?id=2325).
