### PR TITLE
Revert "fix fdiff to use dummies"

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -493,13 +493,7 @@ functions are not supported.')
                 nargs = self.nargs
             if not (1<=argindex<=nargs):
                 raise ArgumentIndexError(self, argindex)
-        u = self.args[argindex - 1]
-        if u.is_Symbol:
-            uself = self
-        else:
-            u = C.Dummy('u')
-            uself = self.func(u)
-        return Derivative(uself, u, evaluate=False)
+        return Derivative(self,self.args[argindex-1],evaluate=False)
 
     def _eval_as_leading_term(self, x):
         """General method for the leading term"""
@@ -575,10 +569,7 @@ class Derivative(Expr):
     Carries out differentiation of the given expression with respect to symbols.
 
     expr must define ._eval_derivative(symbol) method that returns
-    the differentiation result. This function only needs to consider the
-    non-trivial case where expr contains symbol and it should call the diff()
-    method interally (not _eval_derivative); Derivative should be the only
-    one to call _eval_derivative.
+    the differentiation result or None.
 
     Examples:
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -572,7 +572,10 @@ class Derivative(Expr):
     Carries out differentiation of the given expression with respect to symbols.
 
     expr must define ._eval_derivative(symbol) method that returns
-    the differentiation result or None.
+    the differentiation result. This function only needs to consider the
+    non-trivial case where expr contains symbol and it should call the diff()
+    method interally (not _eval_derivative); Derivative should be the only
+    one to call _eval_derivative.
 
     Examples:
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -493,6 +493,9 @@ functions are not supported.')
                 nargs = self.nargs
             if not (1<=argindex<=nargs):
                 raise ArgumentIndexError(self, argindex)
+        if not self.args[argindex-1].is_Symbol:
+            # See issue 1525 and issue 1620
+            raise NotImplementedError("Cannot express derivatives evaluated at a point")
         return Derivative(self,self.args[argindex-1],evaluate=False)
 
     def _eval_as_leading_term(self, x):

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -182,17 +182,23 @@ def test_function_comparable():
     assert sin(zoo).is_comparable   == False
     assert sin(nan).is_comparable   == False
 
+@XFAIL
 def test_deriv1():
+    # This requires derivatives evaluated at a point.  This is written in such
+    # a way that it will XPASS when that is implemented.  When it is, fix this
+    # and test_deriv2() below.
     f=Function('f')
     g=Function('g')
     x = Symbol('x')
-    assert f(g(x)).diff(x) == Derivative(f(g(x)), g(x)) * Derivative(g(x), x)
+    f(g(x)).diff(x)
 
+@XFAIL
 def test_deriv2():
+    # These all requre derivatives evaluated at a point (issue 1620) to work.
+    # See issue 1525
     f = Function('f')
     x = Symbol('x')
 
-    assert f(x).diff(x) == Derivative(f(x), x)
     assert f(2*x).diff(x) == 2*Derivative(f(2*x), 2*x)
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
     assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Derivative(f(2*x), 2*x)
@@ -212,6 +218,12 @@ def test_deriv3():
     assert diff(x**3, x) == 3*x**2
     assert diff(x**3, x, evaluate=False) != 3*x**2
     assert diff(x**3, x, evaluate=False) == Derivative(x**3, x)
+
+def test_func_deriv():
+    f = Function('f')
+    x = Symbol('x')
+
+    assert f(x).diff(x) == Derivative(f(x), x)
 
 def test_suppressed_evaluation():
     a = sin(0, evaluate=False)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -186,22 +186,21 @@ def test_deriv1():
     f=Function('f')
     g=Function('g')
     x = Symbol('x')
-    # this is a place where the polys12 Pure() symbol could be used rather than unique dummies
-    assert str(f(g(x)).diff(x)) == 'D(f(_u), _u)*D(g(x), x)'
+    assert f(g(x)).diff(x) == Derivative(f(g(x)), g(x)) * Derivative(g(x), x)
 
 def test_deriv2():
     f = Function('f')
     x = Symbol('x')
 
     assert f(x).diff(x) == Derivative(f(x), x)
-    assert str(f(2*x).diff(x)) == '2*D(f(_u), _u)'
+    assert f(2*x).diff(x) == 2*Derivative(f(2*x), 2*x)
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
-    assert str((f(2*x)**3).diff(x)) == '6*f(2*x)**2*D(f(_u), _u)'
+    assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Derivative(f(2*x), 2*x)
 
-    assert str(f(2+x).diff(x)) == 'D(f(_u), _u)'
-    assert str(f(2+3*x).diff(x)) == '3*D(f(_u), _u)'
-    assert str(f(sin(x)).diff(x)) == 'D(f(_u), _u)*cos(x)'
-    assert str(f(3*sin(x)).diff(x)) == '3*D(f(_u), _u)*cos(x)'
+    assert f(2+x).diff(x) == Derivative(f(2+x), 2+x)
+    assert f(2+3*x).diff(x) == 3*Derivative(f(2+3*x), 2+3*x)
+    assert f(sin(x)).diff(x) == Derivative(f(sin(x)), sin(x)) * cos(x)
+    assert f(3*sin(x)).diff(x) == 3*Derivative(f(3*sin(x)), 3*sin(x)) * cos(x)
 
 def test_deriv3():
     x = Symbol('x')

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -681,9 +681,14 @@ def classify_ode(eq, func, dict=False):
             r['y'] = y
             r[d] = r[d].subs(f(x),y)
             r[e] = r[e].subs(f(x),y)
-            if r[d] != 0 and simplify(r[d].diff(y)) == simplify(r[e].diff(x)):
-                matching_hints["1st_exact"] = r
-                matching_hints["1st_exact_Integral"] = r
+            try:
+                if r[d] != 0 and simplify(r[d].diff(y)) == simplify(r[e].diff(x)):
+                    matching_hints["1st_exact"] = r
+                    matching_hints["1st_exact_Integral"] = r
+            except NotImplementedError:
+                # Differentiating the coefficients might fail because of things
+                # like f(2*x).diff(x).  See issue 1525 and issue 1620.
+                pass
 
         # This match is used for several cases below; we now collect on
         # f(x) so the matching works.
@@ -1662,7 +1667,7 @@ def ode_1st_homogeneous_coeff_subs_dep_div_indep(eq, func, order, match):
     If the coefficients P and Q in the  differential equation above are
     homogeneous functions of the same order, then it can be shown that
     the substitution y = u1*x (u1 = y/x) will turn the differential
-    equation into an equation separable in the variables x and u.  if
+    equation into an equation separable in the variables x and u.  If
     h(u1) is the function that results from making the substitution
     u1 = f(x)/x on P(x, f(x)) and g(u2) is the function that results
     from the substitution on Q(x, f(x)) in the differential equation
@@ -1743,7 +1748,7 @@ def ode_1st_homogeneous_coeff_subs_indep_div_dep(eq, func, order, match):
     If the coefficients P and Q in the  differential equation above are
     homogeneous functions of the same order, then it can be shown that
     the substitution x = u2*y (u2 = x/y) will turn the differential
-    equation into an equation separable in the variables y and u2.  if
+    equation into an equation separable in the variables y and u2.  If
     h(u2) is the function that results from making the substitution
     u2 = x/f(x) on P(x, f(x)) and g(u2) is the function that results
     from the substitution on Q(x, f(x)) in the differential equation


### PR DESCRIPTION
This reverts commit c20062e78c34a39096157de7c294db49dccc318b.

This change was just plain wrong.  See issue 1525, starting at comment 3: http://code.google.com/p/sympy/issues/detail?id=1525#c3

Conflicts:

```
sympy/core/function.py
```

I am still running the tests.  If there are any failures, I will fix them and update.

@smichr, you better take a look at this.
