### PR TITLE
Don't transform automatically x >> y into ~x | y

### DIFF
--- a/doc/src/modules/logic.txt
+++ b/doc/src/modules/logic.txt
@@ -24,13 +24,12 @@ You can build boolean expressions with the standard python operators & (And),
     >>> ~x
     Not(x)
 
-You can also form implications with >>, <<, and class Equivalent, which are
-compiled away into their logical equivalents:
+You can also form implications with >> and <<:
 
     >>> x >> y
-    Or(Not(x), y)
+    Implies(x, y)
     >>> x << y
-    Or(Not(y), x)
+    Implies(y, x)
 
 Like most types in SymPy, Boolean expressions inherit from sympy.core.Basic:
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -129,10 +129,14 @@ class Implies(BooleanFunction):
     """
     @classmethod
     def eval(cls, *args):
-        if len(args) != 2:
-            raise ValueError, "%d operand(s) used for an Implies (pairs are required): %s" % (len(args), str(args))
+        try:
+            A, B = args
+        except ValueError:
+            raise ValueError("%d operand(s) used for an Implies (pairs are required): %s" % (len(args), str(args)))
+        if A is True or A is False or B is True or B is False:
+            return Or(Not(A), B)
         else:
-            return Or(Not(args[0]), args[1])
+            return Basic.__new__(cls, *args)
 
 class Equivalent(BooleanFunction):
     """Equivalence relation.


### PR DESCRIPTION
Implies(...) creates now instances of Implies, except in the trivial
cases where one of the arguments is True or False.

This fixes part of [issue 1894](http://code.google.com/p/sympy/issues/detail?id=1894)
