### PR TITLE
Fix issue 2326.

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -472,7 +472,7 @@ def limitinf(e, x):
         # We make sure that x.is_positive is True so we
         # get all the correct mathematical bechavior from the expression.
         # We need a fresh variable.
-        p = Dummy('p', positive=True)
+        p = Dummy('p', positive=True, bounded=True)
         e = e.subs(x, p)
         x = p
     c0, e0 = mrv_leadterm(e, x)
@@ -556,7 +556,7 @@ def mrv_leadterm(e, x):
     # For limits of complex functions, the algorithm would have to be
     # improved, or just find limits of Re and Im components separately.
     #
-    w = Dummy("w", real=True, positive=True)
+    w = Dummy("w", real=True, positive=True, bounded=True)
     f, logw = rewrite(exps, Omega, x, w)
     series = calculate_series(f, w, logx=logw)
     series = series.subs(log(w), logw) # this should not be necessary

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -112,7 +112,7 @@ def limit(e, z, z0, dir="+"):
         if e.is_Mul:
             # weed out the z-independent terms
             i, d = e.as_independent(z)
-            if i is not S.One:
+            if i is not S.One and i.is_bounded:
                 return i*limit(d, z, z0, dir)
         else:
             i, d = S.One, e
@@ -145,7 +145,7 @@ def limit(e, z, z0, dir="+"):
         finite = []; unknown = []
         ok = True
         for term in e.args:
-            if not term.has(z):
+            if not term.has(z) and not term.is_unbounded:
                 finite.append(term)
                 continue
             result = term.subs(z, z0)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -262,3 +262,19 @@ def test_issue835():
 
 def test_newissue():
     assert limit(exp(1/sin(x))/exp(cot(x)), x, 0) == 1
+
+def test_extended_real_line():
+    assert limit(x - oo, x, oo) == -oo
+    assert limit(oo - x, x, -oo) == oo
+    assert limit(x**2/(x-5) - oo, x, oo) == -oo
+    assert limit(1/(x+sin(x)) - oo, x, 0) == -oo
+    assert limit(x - oo + 1/x, x, oo) == -oo
+    assert limit(x - oo + 1/x, x, 0) == -oo
+    assert limit(oo/x, x, oo) == oo
+
+@XFAIL
+def test_order_oo():
+    from sympy import C
+    x = Symbol('x', positive=True, bounded=True)
+    assert C.Order(x)*oo != C.Order(1, x)
+    assert limit(oo/(x**2 - 4), x, oo) == oo


### PR DESCRIPTION
This takes care of limits in the extended real line, e.g.
limit(x-oo, x, oo) == -oo since for every _finite_ x, x-oo == -oo.

One limit this code cannot do is limit(oo/(x*_2-4), x, oo). This is basically because there is no sensible series expansion for this. When x is bounded, oo_O(x) becomes O(1). When x is not assumed bounded it becomes O(x). In either case it is not really what we want ^^.

At any rate I think these changes are good because we get at least some of the limits right. Computing all limits in the extended real line requires a different algorithm, I think.

Changelog follows.

sympy/series/gruntz.py:
  (limitinf) Use a bounded dummy.
  (mrv_leadterm) Likewise.

sympy/series/limits.py:
  (limit) Take care of the fact that terms in the expression the limit is taken
          of can be unbounded.

sympy/series/tests/test_limits.py:
  (test_extended_real_line) Test this.
  (test_order_oo) New XFAILing test.
