### PR TITLE
Fix issue 2337.

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -223,7 +223,7 @@ def compare(a, b, x):
     c = limitinf(la/lb, x)
     if c == 0:
         return "<"
-    elif c in [oo, -oo]:
+    elif c.is_unbounded:
         return ">"
     else:
         return "="
@@ -618,9 +618,11 @@ def rewrite(e, Omega, x, wsym):
     Omega.sort(key=lambda x: nodes[x[1]].ht(), reverse=True)
 
     g, _ = Omega[-1] #g is going to be the "w" - the simplest one in the mrv set
-    sig = (sign(g.args[0], x) == 1)
-    if sig:
+    sig = sign(g.args[0], x)
+    if sig == 1:
         wsym = 1/wsym #if g goes to oo, substitute 1/w
+    elif sig != -1:
+        raise NotImplementedError('Result depends on the sign of %s' % sig)
     #O2 is a list, which results by rewriting each item in Omega using "w"
     O2 = []
     for f, var in Omega:
@@ -646,7 +648,7 @@ def rewrite(e, Omega, x, wsym):
 
     #finally compute the logarithm of w (logw).
     logw = g.args[0]
-    if sig:
+    if sig == 1:
         logw = -logw     #log(w)->log(1/w)=-log(w)
 
     return f, logw

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -262,3 +262,7 @@ def test_issue835():
 
 def test_newissue():
     assert limit(exp(1/sin(x))/exp(cot(x)), x, 0) == 1
+
+def test_issue2337():
+    raises(NotImplementedError, 'limit(exp(x*y), x, oo)')
+    raises(NotImplementedError, 'limit(exp(-x*y), x, oo)')


### PR DESCRIPTION
This fixes an issue reported on irc.

Ideally we would of course want to return a cases expression, but this would require a lot more work.

sympy/series/gruntz.py:
  (rewrite) If we cannot determine if w->oo or w->0, raise a NotImplementedError.
  (compare) Test for unboundedness, not just +-oo (consider sign(y)*oo).
sympy/series/tests/test_limits.py:
  (test_issue_2337) Test this.
