### PR TITLE
A few random improvements related to roots()

### DIFF
--- a/sympy/polys/__init__.py
+++ b/sympy/polys/__init__.py
@@ -23,6 +23,7 @@ from polytools import (
     factor_list, factor,
     intervals, refine_root, count_roots,
     real_roots, nroots, ground_roots,
+    nth_power_roots_poly,
     cancel,
     reduced, groebner,
 )
@@ -101,3 +102,4 @@ from partfrac import (
 
 from polyoptions import Options
 import polycontext as ctx
+

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -31,6 +31,7 @@ from sympy.polys.densearith import (
     dup_add, dmp_add,
     dup_sub, dmp_sub,
     dup_mul, dmp_mul,
+    dup_sqr, dmp_sqr,
     dup_pow, dmp_pow,
     dup_div, dmp_div,
     dup_rem, dmp_rem,
@@ -38,6 +39,7 @@ from sympy.polys.densearith import (
     dup_expand, dmp_expand,
     dup_add_mul, dmp_add_mul,
     dup_sub_mul, dmp_sub_mul,
+    dup_lshift, dup_rshift,
     dup_max_norm, dmp_max_norm,
     dup_l1_norm, dmp_l1_norm,
     dup_mul_ground, dmp_mul_ground,
@@ -52,7 +54,7 @@ from sympy.polys.densetools import (
     dup_eval, dmp_eval_tail,
     dmp_eval_in, dmp_diff_eval_in,
     dup_compose, dmp_compose,
-    dup_shift)
+    dup_shift, dup_mirror)
 
 from sympy.polys.euclidtools import (
     dmp_primitive,
@@ -327,6 +329,75 @@ def dup_zz_irreducible_p(f, K):
         for p in e_ff.iterkeys():
             if (lc % p) and (tc % p**2):
                 return True
+
+@cythonized("n,i")
+def dup_zz_cyclotomic_p(f, K, irreducible=False):
+    """
+    Efficiently test if ``f`` is a cyclotomic polnomial.
+
+    **Examples**
+
+    >>> from sympy.polys.factortools import dup_zz_cyclotomic_p
+    >>> from sympy.polys.domains import ZZ
+
+    >>> f = [1, 0, 1, 0, 0, 0,-1, 0, 1, 0,-1, 0, 0, 0, 1, 0, 1]
+    >>> dup_zz_cyclotomic_p(f, ZZ)
+    False
+
+    >>> g = [1, 0, 1, 0, 0, 0,-1, 0,-1, 0,-1, 0, 0, 0, 1, 0, 1]
+    >>> dup_zz_cyclotomic_p(g, ZZ)
+    True
+
+    """
+    if not K.is_ZZ:
+        return False
+
+    lc = dup_LC(f, K)
+    tc = dup_TC(f, K)
+
+    if lc != 1 or (tc != -1 and tc != 1):
+        return False
+
+    if not irreducible:
+        coeff, factors = dup_factor_list(f, K)
+
+        if coeff != K.one or factors != [(f, 1)]:
+            return False
+
+    n = dup_degree(f)
+    g, h = [], []
+
+    for i in xrange(n, -1, -2):
+        g.insert(0, f[i])
+
+    for i in xrange(n-1, -1, -2):
+        h.insert(0, f[i])
+
+    g = dup_sqr(dup_strip(g), K)
+    h = dup_sqr(dup_strip(h), K)
+
+    F = dup_sub(g, dup_lshift(h, 1, K), K)
+
+    if K.is_negative(dup_LC(F, K)):
+        F = dup_neg(F, K)
+
+    if F == f:
+        return True
+
+    g = dup_mirror(f, K)
+
+    if K.is_negative(dup_LC(g, K)):
+        g = dup_neg(g, K)
+
+    if F == g and dup_zz_cyclotomic_p(g, K):
+        return True
+
+    G = dup_sqf_part(F, K)
+
+    if dup_sqr(G, K) == F and dup_zz_cyclotomic_p(G, K):
+        return True
+
+    return False
 
 @cythonized("n,p,k")
 def dup_zz_cyclotomic_poly(n, K):

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -70,7 +70,7 @@ from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query
 
 from sympy.polys.polyerrors import (
-    ExtraneousFactors, DomainError, EvaluationFailed)
+    ExtraneousFactors, DomainError, CoercionFailed, EvaluationFailed)
 
 from sympy.ntheory import nextprime, isprime, factorint
 from sympy.utilities import any, all, subsets, cythonized
@@ -349,7 +349,13 @@ def dup_zz_cyclotomic_p(f, K, irreducible=False):
     True
 
     """
-    if not K.is_ZZ:
+    if K.is_QQ:
+        try:
+            K0, K = K, K.get_ring()
+            f = dup_convert(f, K0, K)
+        except CoercionFailed:
+            return False
+    elif not K.is_ZZ:
         return False
 
     lc = dup_LC(f, K)

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -114,6 +114,7 @@ from sympy.polys.sqfreetools import (
     dmp_sqf_list, dmp_sqf_list_include)
 
 from sympy.polys.factortools import (
+    dup_zz_cyclotomic_p,
     dup_factor_list, dup_factor_list_include,
     dmp_factor_list, dmp_factor_list_include)
 
@@ -741,6 +742,14 @@ class DMP(object):
     def is_homogeneous(f):
         """Returns `True` if `f` has zero trailing coefficient. """
         return f.dom.is_zero(dmp_ground_TC(f.rep, f.lev, f.dom))
+
+    @property
+    def is_cyclotomic(f):
+        """Returns ``True`` if ``f`` is a cyclotomic polnomial. """
+        if not f.lev:
+            return dup_zz_cyclotomic_p(f.rep, f.dom)
+        else:
+            return False
 
     def __abs__(f):
         return f.abs()

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -429,7 +429,10 @@ def roots(f, *gens, **flags):
 
         result = {}
 
-        if f.degree() == 1:
+        if not f.get_domain().is_Exact:
+            for r in f.nroots():
+                _update_dict(result, r, 1)
+        elif f.degree() == 1:
             result[roots_linear(f)[0]] = 1
         elif f.degree() == 2:
             for r in roots_quadratic(f):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -1,18 +1,23 @@
+"""Algorithms for computing symbolic roots of polynomials. """
+
 from sympy.core.symbol import Dummy
 from sympy.core.add import Add
 from sympy.core.mul import Mul
-from sympy.core import S
+from sympy.core import S, I
 from sympy.core.sympify import sympify
-from sympy.core.numbers import Rational
+from sympy.core.numbers import Rational, igcd
 
-from sympy.ntheory import divisors
+from sympy.ntheory import divisors, isprime, nextprime
 from sympy.functions import exp, sqrt, re, im
 
 from sympy.polys.polytools import Poly, cancel, factor
+from sympy.polys.specialpolys import cyclotomic_poly
 from sympy.polys.polyerrors import PolynomialError, GeneratorsNeeded
 
 from sympy.simplify import simplify
 from sympy.utilities import all
+
+import math
 
 def roots_linear(f):
     """Returns a list of roots of a linear polynomial."""
@@ -238,6 +243,75 @@ def roots_binomial(f):
 
     return roots
 
+def _inv_totient_estimate(m):
+    """
+    Find ``(L, U)`` such that ``L <= phi^-1(m) <= U``.
+
+    **Examples**
+
+    >>> from sympy.polys.polyroots import _inv_totient_estimate
+
+    >>> _inv_totient_estimate(192)
+    (192, 840)
+    >>> _inv_totient_estimate(400)
+    (400, 1750)
+
+    """
+    primes = [ d + 1 for d in divisors(m) if isprime(d + 1) ]
+
+    a, b = 1, 1
+
+    for p in primes:
+        a *= p
+        b *= p - 1
+
+    L = m
+    U = int(math.ceil(m*(float(a)/b)))
+
+    P = p = 2
+    primes = []
+
+    while P <= U:
+        p = nextprime(p)
+        primes.append(p)
+        P *= p
+
+    P //= p
+    b = 1
+
+    for p in primes[:-1]:
+        b *= p - 1
+
+    U = int(math.ceil(m*(float(P)/b)))
+
+    return L, U
+
+def roots_cyclotomic(f, factor=False):
+    """Compute roots of cyclotomic polynomials. """
+    L, U = _inv_totient_estimate(f.degree())
+
+    for n in xrange(L, U+1):
+        g = cyclotomic_poly(n, f.gen, polys=True)
+
+        if f == g:
+            break
+    else: # pragma: no cover
+        raise RuntimeError("failed to find index of a cyclotomic polynomial")
+
+    roots = []
+
+    if not factor:
+        for k in xrange(1, n+1):
+            if igcd(k, n) == 1:
+                roots.append(exp(2*k*S.Pi*I/n).expand(complex=True))
+    else:
+        g = Poly(f, extension=(-1)**Rational(1, n))
+
+        for h, _ in g.factor_list()[1]:
+            roots.append(-h.TC())
+
+    return roots
+
 def roots_rational(f):
     """Returns a list of rational roots of a polynomial."""
     domain = f.get_domain()
@@ -404,6 +478,8 @@ def roots(f, *gens, **flags):
             result += map(cancel, roots_linear(f))
         elif n == 2:
             result += map(cancel, roots_quadratic(f))
+        elif f.is_cyclotomic:
+            result += roots_cyclotomic(f)
         elif n == 3 and cubics:
             result += roots_cubic(f)
         elif n == 4 and quartics:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -87,11 +87,11 @@ class Poly(Expr):
         if 'order' in opt:
             raise NotImplementedError("'order' keyword is not implemented yet")
 
-        if isinstance(rep, (dict, list)):
+        if hasattr(rep, '__iter__'):
             if isinstance(rep, dict):
                 return cls._from_dict(rep, opt)
             else:
-                return cls._from_list(rep, opt)
+                return cls._from_list(list(rep), opt)
         else:
             rep = sympify(rep)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3058,6 +3058,29 @@ class Poly(Expr):
         """
         return len(f.gens) != 1
 
+    @property
+    def is_cyclotomic(f):
+        """
+        Returns ``True`` if ``f`` is a cyclotomic polnomial.
+
+        **Examples**
+
+        >>> from sympy import Poly
+        >>> from sympy.abc import x
+
+        >>> f = x**16 + x**14 - x**10 + x**8 - x**6 + x**2 + 1
+
+        >>> Poly(f).is_cyclotomic
+        False
+
+        >>> g = x**16 + x**14 - x**10 - x**8 - x**6 + x**2 + 1
+
+        >>> Poly(g).is_cyclotomic
+        True
+
+        """
+        return f.rep.is_cyclotomic
+
     def __abs__(f):
         return f.abs()
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1,7 +1,7 @@
 """User-friendly public interface to polynomial functions. """
 
 from sympy.core import (
-    S, Basic, Expr, I, Integer, Add, Mul,
+    S, Basic, Expr, I, Integer, Add, Mul, Dummy,
 )
 
 from sympy.core.sympify import (
@@ -2748,6 +2748,44 @@ class Poly(Expr):
 
         return roots
 
+    def nth_power_roots_poly(f, n):
+        """
+        Construct a polynomial with n-th powers of roots of ``f``.
+
+        **Examples**
+
+        >>> from sympy import Poly
+        >>> from sympy.abc import x
+
+        >>> f = Poly(x**4 - x**2 + 1)
+
+        >>> f.nth_power_roots_poly(2)
+        Poly(x**4 - 2*x**3 + 3*x**2 - 2*x + 1, x, domain='ZZ')
+        >>> f.nth_power_roots_poly(3)
+        Poly(x**4 + 2*x**2 + 1, x, domain='ZZ')
+        >>> f.nth_power_roots_poly(4)
+        Poly(x**4 + 2*x**3 + 3*x**2 + 2*x + 1, x, domain='ZZ')
+        >>> f.nth_power_roots_poly(12)
+        Poly(x**4 - 4*x**3 + 6*x**2 - 4*x + 1, x, domain='ZZ')
+
+        """
+        if f.is_multivariate:
+            raise MultivariatePolynomialError("must be a univariate polynomial")
+
+        N = sympify(n)
+
+        if N.is_Integer and N >= 1:
+            n = int(N)
+        else:
+            raise ValueError("'n' must an integer and n >= 1, got %s" % n)
+
+        x = f.gen
+        t = Dummy('t')
+
+        r = f.resultant(f.__class__.from_expr(x**n - t, x, t))
+
+        return r.replace(t, x)
+
     def cancel(f, g):
         """
         Cancel common factors in a rational function ``f/g``.
@@ -4777,6 +4815,42 @@ def ground_roots(f, *gens, **args):
         raise ComputationFailed('ground_roots', 1, exc)
 
     return F.ground_roots()
+
+def nth_power_roots_poly(f, n, *gens, **args):
+    """
+    Construct a polynomial with n-th powers of roots of ``f``.
+
+    **Examples**
+
+    >>> from sympy import nth_power_roots_poly, factor, roots
+    >>> from sympy.abc import x
+
+    >>> f = x**4 - x**2 + 1
+    >>> g = factor(nth_power_roots_poly(f, 2))
+
+    >>> g
+    (1 - x + x**2)**2
+
+    >>> R_f = [ (r**2).expand() for r in roots(f) ]
+    >>> R_g = roots(g).keys()
+
+    >>> set(R_f) == set(R_g)
+    True
+
+    """
+    options.allowed_flags(args, [])
+
+    try:
+        F, opt = poly_from_expr(f, *gens, **args)
+    except PolificationFailed, exc:
+        raise ComputationFailed('nth_power_roots_poly', 1, exc)
+
+    result = F.nth_power_roots_poly(n)
+
+    if not opt.polys:
+        return result.as_expr()
+    else:
+        return result
 
 def cancel(f, *gens, **args):
     """

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -29,7 +29,7 @@ from sympy.polys.factortools import (
     dmp_zz_wang_lead_coeffs,
     dmp_zz_wang_hensel_lifting,
     dup_zz_diophantine, dmp_zz_diophantine,
-    dup_zz_cyclotomic_poly, dup_zz_cyclotomic_factor,
+    dup_zz_cyclotomic_p, dup_zz_cyclotomic_poly, dup_zz_cyclotomic_factor,
     dup_zz_factor, dup_zz_factor_sqf, dmp_zz_factor,
     dup_ext_factor, dmp_ext_factor,
     dup_factor_list, dmp_factor_list,
@@ -97,6 +97,30 @@ def test_dup_zz_irreducible_p():
 
     assert dup_zz_irreducible_p([3, 2, 6, 8, 10], ZZ) == True
     assert dup_zz_irreducible_p([3, 2, 6, 8, 14], ZZ) == True
+
+def test_dup_zz_cyclotomic_p():
+    assert dup_zz_cyclotomic_p([1,-1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,1,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,0,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,1,1,1,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,-1,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,1,1,1,1,1,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,0,0,0,1], ZZ) == True
+    assert dup_zz_cyclotomic_p([1,0,0,1,0,0,1], ZZ) == True
+
+    assert dup_zz_cyclotomic_p([], ZZ) == False
+    assert dup_zz_cyclotomic_p([1], ZZ) == False
+    assert dup_zz_cyclotomic_p([1, 0], ZZ) == False
+    assert dup_zz_cyclotomic_p([1, 2], ZZ) == False
+    assert dup_zz_cyclotomic_p([3, 1], ZZ) == False
+    assert dup_zz_cyclotomic_p([1, 0, -1], ZZ) == False
+
+    f = [1, 0, 1, 0, 0, 0,-1, 0, 1, 0,-1, 0, 0, 0, 1, 0, 1]
+    assert dup_zz_cyclotomic_p(f, ZZ) == False
+
+    g = [1, 0, 1, 0, 0, 0,-1, 0,-1, 0,-1, 0, 0, 0, 1, 0, 1]
+    assert dup_zz_cyclotomic_p(g, ZZ) == True
 
 def test_dup_zz_cyclotomic_poly():
     assert dup_zz_cyclotomic_poly(1, ZZ) == [1,-1]

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -122,6 +122,9 @@ def test_dup_zz_cyclotomic_p():
     g = [1, 0, 1, 0, 0, 0,-1, 0,-1, 0,-1, 0, 0, 0, 1, 0, 1]
     assert dup_zz_cyclotomic_p(g, ZZ) == True
 
+    assert dup_zz_cyclotomic_p([QQ(1),QQ(1),QQ(1)], QQ) == True
+    assert dup_zz_cyclotomic_p([QQ(1,2),QQ(1),QQ(1)], QQ) == False
+
 def test_dup_zz_cyclotomic_poly():
     assert dup_zz_cyclotomic_poly(1, ZZ) == [1,-1]
     assert dup_zz_cyclotomic_poly(2, ZZ) == [1,1]

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -128,11 +128,6 @@ def test_roots():
     assert roots(x**6-4*x**4+4*x**3-x**2, x) == \
         {S.One: 2, -1 - sqrt(2): 1, S.Zero: 2, -1 + sqrt(2): 1}
 
-    R1 = sorted([ r.evalf() for r in roots(x**2 + x + 1,   x) ])
-    R2 = sorted([ r         for r in roots(x**2 + x + 1.0, x) ])
-
-    assert R1 == R2
-
     assert roots(x**8-1, x) == {
          2**S.Half/2 + I*2**S.Half/2: 1,
          2**S.Half/2 - I*2**S.Half/2: 1,
@@ -141,9 +136,9 @@ def test_roots():
         S.One: 1, -S.One: 1, I: 1, -I: 1
     }
 
-    assert roots(-2016*x**2 - 5616*x**3 - 2056*x**4 + 3324*x**5 + 2176*x**6 \
-        - 224*x**7 - 384*x**8 - 64*x**9, x) == {S(0): 2, -S(2): 2, S(2): 1, -S(7)/2: 1,\
-                                            -S(3)/2: 1, -S(1)/2: 1, S(3)/2: 1}
+    f = -2016*x**2 - 5616*x**3 - 2056*x**4 + 3324*x**5 + 2176*x**6 - 224*x**7 - 384*x**8 - 64*x**9
+
+    assert roots(f) == {S(0): 2, -S(2): 2, S(2): 1, -S(7)/2: 1, -S(3)/2: 1, -S(1)/2: 1, S(3)/2: 1}
 
     assert roots((a+b+c)*x - (a+b+c+d), x) == {(a+b+c+d)/(a+b+c): 1}
 
@@ -234,6 +229,19 @@ def test_roots2():
     e2 = (zz-k)*yx*yx + zx*(yy-k)*zx + zy*zy*(xx-k)
 
     assert roots(e1 - e2, k).values() == [1, 1, 1]
+
+def test_roots_inexact():
+    R1 = sorted([ r.evalf() for r in roots(x**2 + x + 1,   x) ])
+    R2 = sorted([ r         for r in roots(x**2 + x + 1.0, x) ])
+
+    for r1, r2 in zip(R1, R2):
+        assert abs(r1 - r2) < 1e-12
+
+    f = x**4 + 3.0*sqrt(2.0)*x**3 - (78.0 + 24.0*sqrt(3.0))*x**2 + 144.0*(2*sqrt(3.0) + 9.0)
+    R = [-12.7530479110482, -3.85012393732929, 4.89897948556636, 7.46155167569183]
+
+    for r1, r2 in zip(roots(f, multiple=True), R):
+        assert abs(r1 - r2) < 1e-12
 
 def test_root_factors():
     assert root_factors(Poly(1, x)) == [Poly(1, x)]

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -238,9 +238,11 @@ def test_roots_inexact():
         assert abs(r1 - r2) < 1e-12
 
     f = x**4 + 3.0*sqrt(2.0)*x**3 - (78.0 + 24.0*sqrt(3.0))*x**2 + 144.0*(2*sqrt(3.0) + 9.0)
-    R = [-12.7530479110482, -3.85012393732929, 4.89897948556636, 7.46155167569183]
 
-    for r1, r2 in zip(roots(f, multiple=True), R):
+    R1 = sorted(roots(f, multiple=True))
+    R2 = sorted([-12.7530479110482, -3.85012393732929, 4.89897948556636, 7.46155167569183])
+
+    for r1, r2 in zip(R1, R2):
         assert abs(r1 - r2) < 1e-12
 
 def test_root_factors():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -22,6 +22,7 @@ from sympy.polys.polytools import (
     factor_list, factor,
     intervals, refine_root, count_roots,
     real_roots, nroots, ground_roots,
+    nth_power_roots_poly,
     cancel,
     reduced, groebner)
 
@@ -2083,6 +2084,26 @@ def test_ground_roots():
 
     assert Poly(f).ground_roots() == {S(1): 2, S(0): 2}
     assert ground_roots(f) == {S(1): 2, S(0): 2}
+
+def test_nth_power_roots_poly():
+    f = x**4 - x**2 + 1
+
+    f_2 = (x**2 - x + 1)**2
+    f_3 = (x**2 + 1)**2
+    f_4 = (x**2 + x + 1)**2
+    f_12 = (x - 1)**4
+
+    nth_power_roots_poly(f, 1) == f
+
+    raises(ValueError, "nth_power_roots_poly(f, 0)")
+    raises(ValueError, "nth_power_roots_poly(f, x)")
+
+    factor(nth_power_roots_poly(f, 2)) == f_2
+    factor(nth_power_roots_poly(f, 3)) == f_3
+    factor(nth_power_roots_poly(f, 4)) == f_4
+    factor(nth_power_roots_poly(f, 12)) == f_12
+
+    raises(MultivariatePolynomialError, "nth_power_roots_poly(x + y, 2, x, y)")
 
 def test_cancel():
     assert cancel(0) == 0

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -597,6 +597,9 @@ def test_Poly_properties():
     assert Poly(x*y).is_multivariate == True
     assert Poly(x).is_multivariate == False
 
+    assert Poly(x**16 + x**14 - x**10 + x**8 - x**6 + x**2 + 1).is_cyclotomic == False
+    assert Poly(x**16 + x**14 - x**10 - x**8 - x**6 + x**2 + 1).is_cyclotomic == True
+
 @XFAIL
 def test_Poly_is_irreducible():
     # when this passes, check the polytools is_irreducible docstring, too.

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -232,8 +232,16 @@ def test_Poly__new__():
 
     raises(GeneratorsNeeded, "Poly({1: 2, 0: 1})")
     raises(GeneratorsNeeded, "Poly([2, 1])")
+    raises(GeneratorsNeeded, "Poly((2, 1))")
 
     raises(GeneratorsNeeded, "Poly(1)")
+
+    f = a*x**2 + b*x + c
+
+    assert Poly({2: a, 1: b, 0: c}, x) == f
+    assert Poly(iter([a, b, c]), x) == f
+    assert Poly([a, b, c], x) == f
+    assert Poly((a, b, c), x) == f
 
     assert Poly(Poly(a*x + b*y, x, y), x) == Poly(a*x + b*y, x)
 

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -39,6 +39,8 @@ def test_solve_poly_system():
     assert solve_poly_system([x**2 - y**2, x - 1], x, y) == solution
     assert solve_poly_system([x**2 - y**2, x - 1]) == solution
 
+    assert solve_poly_system([x + x*y - 3, y + x*y - 4], x, y) == [(-3, -2), (1, 2)]
+
     raises(NotImplementedError, "solve_poly_system([x**3-y**3], x, y)")
 
 def test_solve_biquadratic():
@@ -90,3 +92,4 @@ def test_solve_triangualted():
 
     assert solve_triangulated([f_1, f_2, f_3], x, y, z, domain=dom) == \
         [(a, a, a), (0, 0, 1), (0, 1, 0), (b, b, b), (1, 0, 0)]
+


### PR DESCRIPTION
The most important improvement is support for cyclotomic polynomials in roots(). For now quite simple (i.e. solutions are often returned in terms of trigonometric functions), but is a basis for future developments. Also added tests for issues #1868 and #2087.

Example:

<pre>
In [1]: f = cyclotomic_poly(14, x)

In [2]: f
Out[2]: 
         2    3    4    5    6
1 - x + x  - x  + x  - x  + x 

In [3]: Poly(f).is_cyclotomic
Out[3]: True

In [4]: key = lambda r: (re(r), im(r))

In [5]: roots(f)
Out[5]: 
⎧     ⎛2⋅π⎞        ⎛2⋅π⎞          ⎛π⎞      ⎛π⎞            ⎛π⎞      ⎛π⎞          ⎛2⋅π⎞        ⎛2⋅π⎞          ⎛3⋅π⎞      ⎛3⋅π⎞            ⎛3⋅π⎞      ⎛3⋅π
⎨- cos⎜───⎟ + ⅈ⋅sin⎜───⎟: 1, ⅈ⋅sin⎜─⎟ + cos⎜─⎟: 1, - ⅈ⋅sin⎜─⎟ + cos⎜─⎟: 1, - cos⎜───⎟ - ⅈ⋅sin⎜───⎟: 1, ⅈ⋅sin⎜───⎟ + cos⎜───⎟: 1, - ⅈ⋅sin⎜───⎟ + cos⎜───
⎩     ⎝ 7 ⎠        ⎝ 7 ⎠          ⎝7⎠      ⎝7⎠            ⎝7⎠      ⎝7⎠          ⎝ 7 ⎠        ⎝ 7 ⎠          ⎝ 7 ⎠      ⎝ 7 ⎠            ⎝ 7 ⎠      ⎝ 7 

⎞   ⎫
⎟: 1⎬
⎠   ⎭

In [6]: sorted([ N(r) for r in _.keys() ], key=key)
Out[6]: 
[-0.623489801858733 - 0.78183148246803⋅ⅈ, -0.623489801858733 + 0.78183148246803⋅ⅈ, 0.222520933956314 - 0.974927912181824⋅ⅈ, 0.222520933956314 + 0.97492
7912181824⋅ⅈ, 0.900968867902419 - 0.433883739117558⋅ⅈ, 0.900968867902419 + 0.433883739117558⋅ⅈ]

In [7]: sorted(nroots(f), key=key)
Out[7]: 
[-0.623489801858733 - 0.78183148246803⋅ⅈ, -0.623489801858733 + 0.78183148246803⋅ⅈ, 0.222520933956314 - 0.974927912181824⋅ⅈ, 0.222520933956314 + 0.97492
7912181824⋅ⅈ, 0.900968867902419 - 0.433883739117558⋅ⅈ, 0.900968867902419 + 0.433883739117558⋅ⅈ]
</pre>
