### PR TITLE
Use ~Q.real(x) instead of Assume(x, 'real', False)

### DIFF
--- a/doc/src/modules/assumptions.txt
+++ b/doc/src/modules/assumptions.txt
@@ -14,9 +14,9 @@ Querying
 ask's optional second argument should be a boolean
 expression involving assumptions about objects in expr. Valid values include:
 
-    * Assume(x, Q.integer)
-    * Assume(x, Q.positive)
-    * Assume(x, Q.integer) & Assume(x, Q.positive)
+    * Q.integer(x)
+    * Q.positive(x)
+    * Q.integer(x) & Q.positive(x)
     * etc.
 
 Q is a class in sympy.assumptions holding valid assumptions.
@@ -31,7 +31,7 @@ clean_global_assumptions()
 
      >>> from sympy import *
      >>> x = Symbol('x')
-     >>> global_assumptions.add(Assume(x, Q.positive))
+     >>> global_assumptions.add(Q.positive(x))
      >>> ask(x, Q.positive)
      True
      >>> global_assumptions.clear()
@@ -52,7 +52,7 @@ Examples::
     >>> x = Symbol('x')
     >>> ask(exp(x), Q.bounded)
     False
-    >>> ask(exp(x), Q.bounded , Assume(x, Q.bounded))
+    >>> ask(exp(x), Q.bounded , Q.bounded(x))
     True
     >>> ask(sin(x), Q.bounded)
     True
@@ -70,9 +70,9 @@ Examples::
     >>> x, y = symbols('x,y')
     >>> ask(x, Q.commutative)
     True
-    >>> ask(x, Q.commutative, Assume(x, Q.commutative, False))
+    >>> ask(x, Q.commutative, ~Q.commutative(x))
     False
-    >>> ask(x*y, Q.commutative, Assume(x, Q.commutative, False))
+    >>> ask(x*y, Q.commutative, ~Q.commutative(x))
     False
 
 
@@ -89,7 +89,7 @@ Examples::
     >>> ask(I, Q.complex)
     True
     >>> x, y = symbols('x,y')
-    >>> ask(x+I*y, Q.complex, Assume(x, Q.real) & Assume(y, Q.real))
+    >>> ask(x+I*y, Q.complex, Q.real(x) & Q.real(y))
     True
 
 
@@ -105,7 +105,7 @@ Examples::
     >>> ask(2, Q.even)
     True
     >>> n = Symbol('n')
-    >>> ask(2*n, Q.even, Assume(n, Q.integer))
+    >>> ask(2*n, Q.even, Q.integer(n))
     True
 
 
@@ -122,7 +122,7 @@ Examples::
     True
     >>> ask(2, Q.extended_real)
     True
-    >>> ask(x, Q.extended_real, Assume(x, Q.real))
+    >>> ask(x, Q.extended_real, Q.real(x))
     True
 
 
@@ -138,7 +138,7 @@ Examples::
     >>> ask(2*I, Q.imaginary)
     True
     >>> x = Symbol('x')
-    >>> ask(x*I, Q.imaginary, Assume(x, Q.real))
+    >>> ask(x*I, Q.imaginary, Q.real(x))
     True
 
 
@@ -153,9 +153,9 @@ Examples::
     >>> ask(1/oo, Q.infinitesimal)
     True
     >>> x, y = symbols('x,y')
-    >>> ask(2*x, Q.infinitesimal, Assume(x, Q.infinitesimal))
+    >>> ask(2*x, Q.infinitesimal, Q.infinitesimal(x))
     True
-    >>> ask(x*y, Q.infinitesimal, Assume(x, Q.infinitesimal) & Assume(y, Q.bounded))
+    >>> ask(x*y, Q.infinitesimal, Q.infinitesimal(x) & Q.bounded(y))
     True
 
 
@@ -172,7 +172,7 @@ Examples::
     >>> ask(sqrt(2), Q.integer)
     False
     >>> x = Symbol('x')
-    >>> ask(x/2, Q.integer, Assume(x, Q.even))
+    >>> ask(x/2, Q.integer, Q.even(x))
     True
 
 
@@ -188,7 +188,7 @@ Examples::
      True
      >>> ask(sqrt(2), Q.irrational)
      True
-     >>> ask(x*sqrt(2), Q.irrational, Assume(x, Q.rational))
+     >>> ask(x*sqrt(2), Q.irrational, Q.rational(x))
      True
 
 
@@ -203,9 +203,9 @@ Examples::
      >>> ask(Rational(3, 4), Q.rational)
      True
      >>> x, y = symbols('x,y')
-     >>> ask(x/2, Q.rational, Assume(x, Q.integer))
+     >>> ask(x/2, Q.rational, Q.integer(x))
      True
-     >>> ask(x/y, Q.rational, Assume(x, Q.integer) & Assume(y, Q.integer))
+     >>> ask(x/y, Q.rational, Q.integer(x) & Q.integer(y))
      True
 
 
@@ -220,7 +220,7 @@ Examples::
      >>> ask(0.3, Q.negative)
      False
      >>> x = Symbol('x')
-     >>> ask(-x, Q.negative, Assume(x, Q.positive))
+     >>> ask(-x, Q.negative, Q.positive(x))
      True
 
 Remarks
@@ -241,7 +241,7 @@ Examples::
      >>> ask(0.3, Q.positive)
      True
      >>> x = Symbol('x')
-     >>> ask(-x, Q.positive, Assume(x, Q.negative))
+     >>> ask(-x, Q.positive, Q.negative(x))
      True
 
 Remarks
@@ -274,7 +274,7 @@ Examples::
     >>> ask(sqrt(2), Q.real)
     True
     >>> x, y = symbols('x,y')
-    >>> ask(x*y, Q.real, Assume(x, Q.real) & Assume(y, Q.real))
+    >>> ask(x*y, Q.real, Q.real(x) & Q.real(y))
     True
 
 
@@ -289,7 +289,7 @@ Examples::
     >>> ask(3, Q.odd)
     True
     >>> n = Symbol('n')
-    >>> ask(2*n + 1, Q.odd, Assume(n, Q.integer))
+    >>> ask(2*n + 1, Q.odd, Q.integer(n))
     True
 
 
@@ -302,7 +302,7 @@ Examples::
 
      >>> from sympy import *
      >>> x = Symbol('x')
-     >>> ask(x, Q.nonzero, Assume(x, Q.positive) | Assume(x, Q.negative))
+     >>> ask(x, Q.nonzero, Q.positive(x) | Q.negative(x))
      True
 
 

--- a/sympy/assumptions/__init__.py
+++ b/sympy/assumptions/__init__.py
@@ -1,3 +1,3 @@
-from assume import Assume, global_assumptions, Predicate, AssumptionsContext
+from assume import AppliedPredicate, global_assumptions, Predicate, AssumptionsContext
 from ask import Q, ask, register_handler, remove_handler
 from refine import refine

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -59,7 +59,7 @@ def eval_predicate(predicate, expr, assumptions=True):
     return res
 
 
-def ask(expr, key, assumptions=True, context=global_assumptions, disable_preprocessing=False):
+def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disable_preprocessing=False):
     """
     Method for inferring properties about objects.
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -36,6 +36,8 @@ def eval_predicate(predicate, expr, assumptions=True):
 
     This uses only direct resolution methods, not logical inference.
     """
+    if not isinstance(predicate, Predicate):
+        return eval_predicate(Q.is_true, predicate(expr), assumptions)
     res, _res = None, None
     mro = inspect.getmro(type(expr))
     for handler in predicate.handlers:
@@ -90,7 +92,7 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disab
 
     """
     expr = sympify(expr)
-    if type(key) is not Predicate:
+    if isinstance(key, basestring):
         key = getattr(Q, str(key))
     assumptions = And(assumptions, And(*context))
 
@@ -129,7 +131,8 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disab
                         return False
                     if Not(key) in known_facts_dict[assum]:
                         return True
-        elif assumptions.func is Not and assumptions.args[0].is_Atom:
+        elif (isinstance(key, Predicate) and
+                assumptions.func is Not and assumptions.args[0].is_Atom):
             if assumptions.args[0] in known_facts_dict[key]:
                 return False
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -2,7 +2,7 @@
 import inspect
 from sympy.core import sympify
 from sympy.utilities.source import get_class
-from sympy.assumptions import global_assumptions, Assume, Predicate
+from sympy.assumptions import global_assumptions, Predicate
 from sympy.assumptions.assume import eliminate_assume
 from sympy.logic.boolalg import to_cnf, And, Not, Or, Implies, Equivalent
 from sympy.logic.inference import satisfiable
@@ -72,19 +72,19 @@ def ask(expr, key, assumptions=True, context=global_assumptions, disable_preproc
             where expression is any SymPy expression
 
     **Examples**
-        >>> from sympy import ask, Q, Assume, pi
+        >>> from sympy import ask, Q, pi
         >>> from sympy.abc import x, y
         >>> ask(pi, Q.rational)
         False
-        >>> ask(x*y, Q.even, Assume(x, Q.even) & Assume(y, Q.integer))
+        >>> ask(x*y, Q.even, Q.even(x) & Q.integer(y))
         True
-        >>> ask(x*y, Q.prime, Assume(x, Q.integer) &  Assume(y, Q.integer))
+        >>> ask(x*y, Q.prime, Q.integer(x) &  Q.integer(y))
         False
 
     **Remarks**
         Relations in assumptions are not implemented (yet), so the following
         will not give a meaningful result.
-        >> ask(x, positive=True, Assume(x>0))
+        >> ask(x, Q.positive, Q.is_true(x > 0))
         It is however a work in progress and should be available before
         the official release
 
@@ -193,7 +193,7 @@ def compute_known_facts():
         mapping[key] = set([key])
         for other_key in known_facts_keys:
             if other_key != key:
-                if ask(x, other_key, Assume(x, key, True), disable_preprocessing=True):
+                if ask(x, other_key, key(x), disable_preprocessing=True):
                     mapping[key].add(other_key)
     fact_string += "\n# -{ Known facts in compressed sets }-\n"
     fact_string += "known_facts_dict = {\n    "

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -44,20 +44,8 @@ class Assume(Boolean):
     Q.is_true(1 < x)
 
     """
-    def __new__(cls, expr, predicate=None, value=True):
-        from sympy import Q
-        if predicate is None:
-            predicate = Q.is_true
-        elif not isinstance(predicate, Predicate):
-            key = str(predicate)
-            try:
-                predicate = getattr(Q, key)
-            except AttributeError:
-                predicate = Predicate(key)
-        if value:
-            return Boolean.__new__(cls, expr, predicate)
-        else:
-            return Not(Boolean.__new__(cls, expr, predicate))
+    def __new__(cls, expr, predicate):
+        return Boolean.__new__(cls, expr, predicate)
 
     is_Atom = True # do not attempt to decompose this
 
@@ -148,7 +136,7 @@ class Predicate(Boolean):
         return (self.name,)
 
     def __call__(self, expr):
-        return Assume(expr, self.name)
+        return Assume(expr, self)
 
     def add_handler(self, handler):
         self.handlers.append(handler)

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -13,10 +13,10 @@ class AssumptionsContext(set):
         >>> global_assumptions
         AssumptionsContext()
         >>> from sympy.abc import x
-        >>> global_assumptions.add(Assume(x, Q.real))
+        >>> global_assumptions.add(Q.real(x))
         >>> global_assumptions
         AssumptionsContext([Assume(x, Q.real)])
-        >>> global_assumptions.remove(Assume(x, Q.real))
+        >>> global_assumptions.remove(Q.real(x))
         >>> global_assumptions
         AssumptionsContext()
         >>> global_assumptions.clear()
@@ -34,13 +34,13 @@ global_assumptions = AssumptionsContext()
 class Assume(Boolean):
     """New-style assumptions.
 
-    >>> from sympy import Assume, Q
+    >>> from sympy import Q
     >>> from sympy.abc import x
-    >>> Assume(x, Q.integer)
+    >>> Q.integer(x)
     Assume(x, Q.integer)
-    >>> Assume(x, Q.integer, False)
+    >>> ~Q.integer(x)
     Not(Assume(x, Q.integer))
-    >>> Assume( x > 1 )
+    >>> Q.is_true(x > 1)
     Assume(1 < x, Q.is_true)
 
     """
@@ -67,9 +67,9 @@ class Assume(Boolean):
         Return the expression used by this assumption.
 
         Examples:
-            >>> from sympy import Assume, Q
+            >>> from sympy import Q
             >>> from sympy.abc import x
-            >>> a = Assume(x+1, Q.integer)
+            >>> a = Q.integer(x + 1)
             >>> a.expr
             1 + x
 
@@ -83,9 +83,9 @@ class Assume(Boolean):
         It is a string, e.g. 'integer', 'rational', etc.
 
         Examples:
-            >>> from sympy import Assume, Q
+            >>> from sympy import Q
             >>> from sympy.abc import x
-            >>> a = Assume(x, Q.integer)
+            >>> a = Q.integer(x)
             >>> a.key
             Q.integer
 
@@ -105,16 +105,16 @@ def eliminate_assume(expr, symbol=None):
     Convert an expression with assumptions to an equivalent with all assumptions
     replaced by symbols.
 
-    Assume(x, integer=True) --> integer
-    Assume(x, integer=False) --> ~integer
+    Q.integer(x) --> Q.integer
+    ~Q.integer(x) --> ~Q.integer
 
     Examples:
         >>> from sympy.assumptions.assume import eliminate_assume
-        >>> from sympy import Assume, Q
+        >>> from sympy import Q
         >>> from sympy.abc import x
-        >>> eliminate_assume(Assume(x, Q.positive))
+        >>> eliminate_assume(Q.positive(x))
         Q.positive
-        >>> eliminate_assume(Assume(x, Q.positive, False))
+        >>> eliminate_assume(~Q.positive(x))
         Not(Q.positive)
 
     """

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -1,4 +1,3 @@
-# doctests are disabled because of issue #1521
 from sympy.logic.boolalg import Boolean, Not
 
 class AssumptionsContext(set):
@@ -31,12 +30,14 @@ class AssumptionsContext(set):
 global_assumptions = AssumptionsContext()
 
 class AppliedPredicate(Boolean):
-    """New-style assumptions.
+    """The class of expressions resulting from applying a Predicate.
 
-    >>> from sympy import Q
-    >>> from sympy.abc import x
+    >>> from sympy import Q, Symbol
+    >>> x = Symbol('x')
     >>> Q.integer(x)
     Q.integer(x)
+    >>> type(Q.integer(x))
+    <class 'sympy.assumptions.assume.AppliedPredicate'>
 
     """
     __slots__ = []
@@ -52,8 +53,8 @@ class AppliedPredicate(Boolean):
         Return the expression used by this assumption.
 
         Examples:
-            >>> from sympy import Q
-            >>> from sympy.abc import x
+            >>> from sympy import Q, Symbol
+            >>> x = Symbol('x')
             >>> a = Q.integer(x + 1)
             >>> a.arg
             1 + x
@@ -112,15 +113,21 @@ class Predicate(Boolean):
 
     Predicates merely wrap their argument and remain unevaluated:
 
-        >>> from sympy import Q, ask
+        >>> from sympy import Q, ask, Symbol
+        >>> x = Symbol('x')
         >>> Q.prime(7)
         Q.prime(7)
 
     To obtain the truth value of an expression containing predicates, use
-    the function `ask` and the special predicate Q.is_true:
+    the function `ask`:
 
-        >>> ask(Q.prime(7), Q.is_true)
+        >>> ask(Q.prime(7))
         True
+
+    The tautological predicate `Q.is_true` can be used to wrap other objects:
+
+        >>> Q.is_true(x > 1)
+        Q.is_true(1 < x)
 
     """
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -15,7 +15,7 @@ class AssumptionsContext(set):
         >>> from sympy.abc import x
         >>> global_assumptions.add(Q.real(x))
         >>> global_assumptions
-        AssumptionsContext([Assume(x, Q.real)])
+        AssumptionsContext([Q.real(x)])
         >>> global_assumptions.remove(Q.real(x))
         >>> global_assumptions
         AssumptionsContext()
@@ -37,11 +37,11 @@ class Assume(Boolean):
     >>> from sympy import Q
     >>> from sympy.abc import x
     >>> Q.integer(x)
-    Assume(x, Q.integer)
+    Q.integer(x)
     >>> ~Q.integer(x)
-    Not(Assume(x, Q.integer))
+    Not(Q.integer(x))
     >>> Q.is_true(x > 1)
-    Assume(1 < x, Q.is_true)
+    Q.is_true(1 < x)
 
     """
     def __new__(cls, expr, predicate=None, value=True):

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -120,6 +120,21 @@ def eliminate_assume(expr, symbol=None):
     return expr.func(*filter(lambda x: x is not None, [eliminate_assume(arg, symbol) for arg in expr.args]))
 
 class Predicate(Boolean):
+    """A predicate is a function that returns a boolean value.
+
+    Predicates merely wrap their argument and remain unevaluated:
+
+        >>> from sympy import Q, ask
+        >>> Q.prime(7)
+        Q.prime(7)
+
+    To obtain the truth value of an expression containing predicates, use
+    the function `ask` and the special predicate Q.is_true:
+
+        >>> ask(Q.prime(7), Q.is_true)
+        True
+
+    """
 
     is_Atom = True
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -95,6 +95,10 @@ def eliminate_assume(expr, symbol=None):
         Not(Q.positive)
 
     """
+    if symbol is not None:
+        props = expr.atoms(AppliedPredicate)
+        if props and symbol not in [prop.arg for prop in props]:
+            return
     if expr.__class__ is AppliedPredicate:
         if symbol is not None:
             if not expr.arg.has(symbol):

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -26,7 +26,6 @@ class AssumptionsContext(set):
     def add(self, *assumptions):
         """Add an assumption."""
         for a in assumptions:
-            assert isinstance(a, AppliedPredicate), 'can only store instances of AppliedPredicate'
             super(AssumptionsContext, self).add(a)
 
 global_assumptions = AssumptionsContext()

--- a/sympy/assumptions/handlers/__init__.py
+++ b/sympy/assumptions/handlers/__init__.py
@@ -50,8 +50,8 @@ class TautologicalHandler(AskHandler):
         return expr
 
     @staticmethod
-    def Assume(expr, assumptions):
-        return ask(expr.expr, expr.key, assumptions)
+    def AppliedPredicate(expr, assumptions):
+        return ask(expr.arg, expr.func, assumptions)
 
     @staticmethod
     def Not(expr, assumptions):

--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -3,7 +3,7 @@ This module contains query handlers responsible for calculus queries:
 infinitesimal, bounded, etc.
 """
 from sympy.logic.boolalg import conjuncts
-from sympy.assumptions import Q, ask, Assume
+from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler
 
 class AskInfinitesimalHandler(CommonHandler):
@@ -61,13 +61,13 @@ class AskBoundedHandler(CommonHandler):
 
     Example of usage:
 
-    >>> from sympy import Symbol, Assume, Q
+    >>> from sympy import Symbol, Q
     >>> from sympy.assumptions.handlers.calculus import AskBoundedHandler
     >>> from sympy.abc import x
     >>> a = AskBoundedHandler()
-    >>> a.Symbol(x, Assume(x, Q.positive))
+    >>> a.Symbol(x, Q.positive(x))
     False
-    >>> a.Symbol(x, Assume(x, Q.bounded))
+    >>> a.Symbol(x, Q.bounded(x))
     True
 
     """
@@ -79,17 +79,17 @@ class AskBoundedHandler(CommonHandler):
 
         Example:
 
-        >>> from sympy import Symbol, Assume, Q
+        >>> from sympy import Symbol, Q
         >>> from sympy.assumptions.handlers.calculus import AskBoundedHandler
         >>> from sympy.abc import x
         >>> a = AskBoundedHandler()
-        >>> a.Symbol(x, Assume(x, Q.positive))
+        >>> a.Symbol(x, Q.positive(x))
         False
-        >>> a.Symbol(x, Assume(x, Q.bounded))
+        >>> a.Symbol(x, Q.bounded(x))
         True
 
         """
-        if Assume(expr, 'bounded') in conjuncts(assumptions):
+        if Q.bounded(expr) in conjuncts(assumptions):
             return True
         return False
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -12,11 +12,11 @@ def refine(expr, assumptions=True):
 
     Examples::
 
-        >>> from sympy import refine, sqrt, Assume, Q
+        >>> from sympy import refine, sqrt, Q
         >>> from sympy.abc import x
-        >>> refine(sqrt(x**2), Assume(x, Q.real))
+        >>> refine(sqrt(x**2), Q.real(x))
         Abs(x)
-        >>> refine(sqrt(x**2), Assume(x, Q.positive))
+        >>> refine(sqrt(x**2), Q.positive(x))
         x
 
     """
@@ -38,13 +38,13 @@ def refine_abs(expr, assumptions):
 
     Examples::
 
-    >>> from sympy import Symbol, Assume, Q, refine, Abs
+    >>> from sympy import Symbol, Q, refine, Abs
     >>> from sympy.assumptions.refine import refine_abs
     >>> from sympy.abc import x
-    >>> refine_abs(Abs(x), Assume(x, Q.real))
-    >>> refine_abs(Abs(x), Assume(x, Q.positive))
+    >>> refine_abs(Abs(x), Q.real(x))
+    >>> refine_abs(Abs(x), Q.positive(x))
     x
-    >>> refine_abs(Abs(x), Assume(x, Q.negative))
+    >>> refine_abs(Abs(x), Q.negative(x))
     -x
 
     """
@@ -60,22 +60,22 @@ def refine_Pow(expr, assumptions):
     """
     Handler for instances of Pow.
 
-    >>> from sympy import Symbol, Assume, Q
+    >>> from sympy import Symbol, Q
     >>> from sympy.assumptions.refine import refine_Pow
     >>> from sympy.abc import x,y,z
-    >>> refine_Pow((-1)**x, Assume(x, Q.real))
-    >>> refine_Pow((-1)**x, Assume(x, Q.even))
+    >>> refine_Pow((-1)**x, Q.real(x))
+    >>> refine_Pow((-1)**x, Q.even(x))
     1
-    >>> refine_Pow((-1)**x, Assume(x, Q.odd))
+    >>> refine_Pow((-1)**x, Q.odd(x))
     -1
 
     For powers of -1, even parts of the exponent can be simplified:
 
-    >>> refine_Pow((-1)**(x+y), Assume(x, Q.even))
+    >>> refine_Pow((-1)**(x+y), Q.even(x))
     (-1)**y
-    >>> refine_Pow((-1)**(x+y+z), Assume(x, Q.odd) & Assume(z, Q.odd))
+    >>> refine_Pow((-1)**(x+y+z), Q.odd(x) & Q.odd(z))
     (-1)**y
-    >>> refine_Pow((-1)**(x+y+2), Assume(x, Q.odd))
+    >>> refine_Pow((-1)**(x+y+2), Q.odd(x))
     (-1)**(1 + y)
     >>> refine_Pow((-1)**(x+3), True)
     (-1)**(1 + x)
@@ -132,11 +132,11 @@ def refine_exp(expr, assumptions):
     """
     Handler for exponential function.
 
-    >>> from sympy import Symbol, Assume, Q, exp, I, pi
+    >>> from sympy import Symbol, Q, exp, I, pi
     >>> from sympy.assumptions.refine import refine_exp
     >>> from sympy.abc import x
-    >>> refine_exp(exp(pi*I*2*x), Assume(x, Q.real))
-    >>> refine_exp(exp(pi*I*2*x), Assume(x, Q.integer))
+    >>> refine_exp(exp(pi*I*2*x), Q.real(x))
+    >>> refine_exp(exp(pi*I*2*x), Q.integer(x))
     1
 
     """

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -4,6 +4,7 @@ from sympy.assumptions import AppliedPredicate, global_assumptions, Predicate
 from sympy.assumptions.assume import eliminate_assume
 from sympy.printing import pretty
 from sympy.assumptions.ask import Q
+from sympy.logic.boolalg import Or
 from sympy.utilities.pytest import XFAIL
 
 def test_equal():
@@ -42,3 +43,9 @@ def test_global():
     global_assumptions.clear()
     assert not Q.is_true(x > 0) in global_assumptions
     assert not Q.is_true(y > 0) in global_assumptions
+
+def test_composite_predicates():
+    x = symbols('x')
+    pred = Q.integer | ~Q.positive
+    assert type(pred(x)) is Or
+    assert pred(x) == Q.integer(x) | ~Q.positive(x)

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -6,12 +6,6 @@ from sympy.printing import pretty
 from sympy.assumptions.ask import Q
 from sympy.utilities.pytest import XFAIL
 
-def test_assume():
-    x = symbols('x')
-    assump = Assume(x, 'integer')
-    assert assump.expr == x
-    assert assump.key == Q.integer
-
 def test_Predicate_wraps_Assume():
     x = symbols('x')
     integer = Predicate('integer')
@@ -19,12 +13,6 @@ def test_Predicate_wraps_Assume():
     assert (assump.expr, assump.key) == (x, integer)
     assump = Assume(x, integer)
     assert (assump.expr, assump.key) == (x, integer)
-
-def test_False():
-    """Test Assume object with False keys"""
-    x = symbols('x')
-    assump = Assume(x, 'integer', False)
-    assert assump == ~Assume(x, 'integer')
 
 
 def test_equal():

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -29,6 +29,11 @@ def test_eliminate_assumptions():
     assert eliminate_assume(a(x) | b(x)) == a | b
     assert eliminate_assume(a(x) | ~b(x)) == a | ~b
 
+def test_eliminate_composite_assumptions():
+    a, b = map(Predicate, symbols('a b'))
+    x, y = symbols('x y')
+    assert eliminate_assume(~a(y), x) == None
+
 def test_global():
     """Test for global assumptions"""
     x, y = symbols('x,y')

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -34,7 +34,6 @@ def test_equal():
     assert Q.positive(x)  != ~Q.positive(x)
     assert ~Q.positive(x) == ~Q.positive(x)
 
-@XFAIL #TODO: handle printing
 def test_pretty():
     x = symbols('x')
     assert pretty(Q.positive(x)) == "Q.positive(x)"

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -1,19 +1,10 @@
 """rename this to test_assumptions.py when the old assumptions system is deleted"""
 from sympy.core import symbols
-from sympy.assumptions import Assume, global_assumptions, Predicate
+from sympy.assumptions import AppliedPredicate, global_assumptions, Predicate
 from sympy.assumptions.assume import eliminate_assume
 from sympy.printing import pretty
 from sympy.assumptions.ask import Q
 from sympy.utilities.pytest import XFAIL
-
-def test_Predicate_wraps_Assume():
-    x = symbols('x')
-    integer = Predicate('integer')
-    assump = integer(x)
-    assert (assump.expr, assump.key) == (x, integer)
-    assump = Assume(x, integer)
-    assert (assump.expr, assump.key) == (x, integer)
-
 
 def test_equal():
     """Test for equality"""

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -30,37 +30,37 @@ def test_False():
 def test_equal():
     """Test for equality"""
     x = symbols('x')
-    assert Assume(x, 'positive', True)  == Assume(x, 'positive', True)
-    assert Assume(x, 'positive', True)  != Assume(x, 'positive', False)
-    assert Assume(x, 'positive', False) == Assume(x, 'positive', False)
+    assert Q.positive(x)  == Q.positive(x)
+    assert Q.positive(x)  != ~Q.positive(x)
+    assert ~Q.positive(x) == ~Q.positive(x)
 
 @XFAIL #TODO: handle printing
 def test_pretty():
     x = symbols('x')
-    assert pretty(Assume(x, 'positive')) == "Assume(x, 'positive')"
+    assert pretty(Q.positive(x)) == "Q.positive(x)"
 
 def test_eliminate_assumptions():
-    a, b = map(Predicate, symbols('a,b'))
-    x, y = symbols('x,y')
-    assert eliminate_assume(Assume(x, a))  == a
-    assert eliminate_assume(Assume(x, a), symbol=x)  == a
-    assert eliminate_assume(Assume(x, a), symbol=y)  == None
-    assert eliminate_assume(Assume(x, a, False)) == ~a
-    assert eliminate_assume(Assume(x, a), symbol=y) == None
-    assert eliminate_assume(Assume(x, a) | Assume(x, b)) == a | b
-    assert eliminate_assume(Assume(x, a) | Assume(x, b, False)) == a | ~b
+    a, b = symbols('a b', cls=Predicate)
+    x, y = symbols('x y')
+    assert eliminate_assume(a(x))  == a
+    assert eliminate_assume(a(x), symbol=x)  == a
+    assert eliminate_assume(a(x), symbol=y)  == None
+    assert eliminate_assume(~a(x)) == ~a
+    assert eliminate_assume(a(x), symbol=y) == None
+    assert eliminate_assume(a(x) | b(x)) == a | b
+    assert eliminate_assume(a(x) | ~b(x)) == a | ~b
 
 def test_global():
     """Test for global assumptions"""
     x, y = symbols('x,y')
-    global_assumptions.add(Assume(x>0))
-    assert Assume(x>0) in global_assumptions
-    global_assumptions.remove(Assume(x>0))
-    assert not Assume(x>0) in global_assumptions
+    global_assumptions.add(Q.is_true(x > 0))
+    assert Q.is_true(x > 0) in global_assumptions
+    global_assumptions.remove(Q.is_true(x > 0))
+    assert not Q.is_true(x > 0) in global_assumptions
     # same with multiple of assumptions
-    global_assumptions.add(Assume(x>0), Assume(y>0))
-    assert Assume(x>0) in global_assumptions
-    assert Assume(y>0) in global_assumptions
+    global_assumptions.add(Q.is_true(x > 0), Q.is_true(y > 0))
+    assert Q.is_true(x > 0) in global_assumptions
+    assert Q.is_true(y > 0) in global_assumptions
     global_assumptions.clear()
-    assert not Assume(x>0) in global_assumptions
-    assert not Assume(y>0) in global_assumptions
+    assert not Q.is_true(x > 0) in global_assumptions
+    assert not Q.is_true(y > 0) in global_assumptions

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -929,6 +929,10 @@ def test_functions_in_assumptions():
     assert ask(x, Q.negative, Equivalent(Q.real(x), Q.positive(x))) is False
     assert ask(x, Q.negative, Xor(Q.real(x), Q.negative(x))) is False
 
+def test_composite_ask_key():
+    x = symbols('x')
+    assert ask(x, Q.negative & Q.integer, Q.real(x) >> Q.positive(x)) is False
+
 def test_is_true():
     from sympy.logic.boolalg import Equivalent, Implies
     x = symbols('x')

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2,7 +2,7 @@ from sympy.utilities.pytest import raises, XFAIL
 
 from sympy.core import Symbol, symbols, S, Rational, Integer, I, pi, oo
 from sympy.functions import exp, log, sin, cos, sign, re, im, sqrt, Abs
-from sympy.assumptions import (Assume, global_assumptions, Q, ask,
+from sympy.assumptions import (global_assumptions, Q, ask,
     register_handler, remove_handler, AssumptionsContext)
 from sympy.assumptions.handlers import AskHandler
 from sympy.assumptions.ask import (compute_known_facts,
@@ -379,47 +379,45 @@ def test_I():
 def test_bounded():
     x, y = symbols('x,y')
     assert ask(x, Q.bounded) == False
-    assert ask(x, Q.bounded, Assume(x, Q.bounded)) == True
-    assert ask(x, Q.bounded, Assume(y, Q.bounded)) == False
-    assert ask(x, Q.bounded, Assume(x, Q.complex)) == False
+    assert ask(x, Q.bounded, Q.bounded(x)) == True
+    assert ask(x, Q.bounded, Q.bounded(y)) == False
+    assert ask(x, Q.bounded, Q.complex(x)) == False
 
     assert ask(x+1, Q.bounded) == False
-    assert ask(x+1, Q.bounded, Assume(x, Q.bounded)) == True
+    assert ask(x+1, Q.bounded, Q.bounded(x)) == True
     assert ask(x+y, Q.bounded) == None
-    assert ask(x+y, Q.bounded, Assume(x, Q.bounded)) == False
-    assert ask(x+1, Q.bounded, Assume(x, Q.bounded) & \
-                Assume(y, Q.bounded)) == True
+    assert ask(x+y, Q.bounded, Q.bounded(x)) == False
+    assert ask(x+1, Q.bounded, Q.bounded(x) & Q.bounded(y)) == True
 
     assert ask(2*x, Q.bounded) == False
-    assert ask(2*x, Q.bounded, Assume(x, Q.bounded)) == True
+    assert ask(2*x, Q.bounded, Q.bounded(x)) == True
     assert ask(x*y, Q.bounded) == None
-    assert ask(x*y, Q.bounded, Assume(x, Q.bounded)) == False
-    assert ask(x*y, Q.bounded, Assume(x, Q.bounded) & \
-                Assume(y, Q.bounded)) == True
+    assert ask(x*y, Q.bounded, Q.bounded(x)) == False
+    assert ask(x*y, Q.bounded, Q.bounded(x) & Q.bounded(y)) == True
 
     assert ask(x**2, Q.bounded) == False
     assert ask(2**x, Q.bounded) == False
-    assert ask(2**x, Q.bounded, Assume(x, Q.bounded)) == True
+    assert ask(2**x, Q.bounded, Q.bounded(x)) == True
     assert ask(x**x, Q.bounded) == False
     assert ask(Rational(1,2) ** x, Q.bounded) == True
     assert ask(x ** Rational(1,2), Q.bounded) == False
 
     # sign function
     assert ask(sign(x), Q.bounded) == True
-    assert ask(sign(x), Q.bounded, Assume(x, Q.bounded, False)) == True
+    assert ask(sign(x), Q.bounded, ~Q.bounded(x)) == True
 
     # exponential functions
     assert ask(log(x), Q.bounded) == False
-    assert ask(log(x), Q.bounded, Assume(x, Q.bounded)) == True
+    assert ask(log(x), Q.bounded, Q.bounded(x)) == True
     assert ask(exp(x), Q.bounded) == False
-    assert ask(exp(x), Q.bounded, Assume(x, Q.bounded)) == True
+    assert ask(exp(x), Q.bounded, Q.bounded(x)) == True
     assert ask(exp(2), Q.bounded) == True
 
     # trigonometric functions
     assert ask(sin(x), Q.bounded) == True
-    assert ask(sin(x), Q.bounded, Assume(x, Q.bounded, False)) == True
+    assert ask(sin(x), Q.bounded, ~Q.bounded(x)) == True
     assert ask(cos(x), Q.bounded) == True
-    assert ask(cos(x), Q.bounded, Assume(x, Q.bounded, False)) == True
+    assert ask(cos(x), Q.bounded, ~Q.bounded(x)) == True
     assert ask(2*sin(x), Q.bounded) == True
     assert ask(sin(x)**2, Q.bounded) == True
     assert ask(cos(x)**2, Q.bounded) == True
@@ -438,83 +436,82 @@ def test_commutative():
     for both key=True and key=False"""
     x, y = symbols('x,y')
     assert ask(x, Q.commutative) == True
-    assert ask(x, Q.commutative, Assume(x, Q.commutative, False)) == False
-    assert ask(x, Q.commutative, Assume(x, Q.complex)) == True
-    assert ask(x, Q.commutative, Assume(x, Q.imaginary)) == True
-    assert ask(x, Q.commutative, Assume(x, Q.real)) == True
-    assert ask(x, Q.commutative, Assume(x, Q.positive)) == True
-    assert ask(x, Q.commutative, Assume(y, Q.commutative, False))  == True
+    assert ask(x, Q.commutative, ~Q.commutative(x)) == False
+    assert ask(x, Q.commutative, Q.complex(x)) == True
+    assert ask(x, Q.commutative, Q.imaginary(x)) == True
+    assert ask(x, Q.commutative, Q.real(x)) == True
+    assert ask(x, Q.commutative, Q.positive(x)) == True
+    assert ask(x, Q.commutative, ~Q.commutative(y))  == True
 
     assert ask(2*x, Q.commutative) == True
-    assert ask(2*x, Q.commutative, Assume(x, Q.commutative, False)) == False
+    assert ask(2*x, Q.commutative, ~Q.commutative(x)) == False
 
     assert ask(x + 1, Q.commutative) == True
-    assert ask(x + 1, Q.commutative, Assume(x, Q.commutative, False)) == False
+    assert ask(x + 1, Q.commutative, ~Q.commutative(x)) == False
 
     assert ask(x**2, Q.commutative) == True
-    assert ask(x**2, Q.commutative, Assume(x, Q.commutative, False)) == False
+    assert ask(x**2, Q.commutative, ~Q.commutative(x)) == False
 
     assert ask(log(x), Q.commutative) == True
 
 def test_complex():
     x, y = symbols('x,y')
     assert ask(x, Q.complex) == None
-    assert ask(x, Q.complex, Assume(x, Q.complex)) == True
-    assert ask(x, Q.complex, Assume(y, Q.complex)) == None
-    assert ask(x, Q.complex, Assume(x, Q.complex, False)) == False
-    assert ask(x, Q.complex, Assume(x, Q.real)) == True
-    assert ask(x, Q.complex, Assume(x, Q.real, False)) == None
-    assert ask(x, Q.complex, Assume(x, Q.rational)) == True
-    assert ask(x, Q.complex, Assume(x, Q.irrational)) == True
-    assert ask(x, Q.complex, Assume(x, Q.positive)) == True
-    assert ask(x, Q.complex, Assume(x, Q.imaginary)) == True
+    assert ask(x, Q.complex, Q.complex(x)) == True
+    assert ask(x, Q.complex, Q.complex(y)) == None
+    assert ask(x, Q.complex, ~Q.complex(x)) == False
+    assert ask(x, Q.complex, Q.real(x)) == True
+    assert ask(x, Q.complex, ~Q.real(x)) == None
+    assert ask(x, Q.complex, Q.rational(x)) == True
+    assert ask(x, Q.complex, Q.irrational(x)) == True
+    assert ask(x, Q.complex, Q.positive(x)) == True
+    assert ask(x, Q.complex, Q.imaginary(x)) == True
 
     # a+b
-    assert ask(x+1, Q.complex, Assume(x, Q.complex)) == True
-    assert ask(x+1, Q.complex, Assume(x, Q.real)) == True
-    assert ask(x+1, Q.complex, Assume(x, Q.rational)) == True
-    assert ask(x+1, Q.complex, Assume(x, Q.irrational)) == True
-    assert ask(x+1, Q.complex, Assume(x, Q.imaginary)) == True
-    assert ask(x+1, Q.complex, Assume(x, Q.integer))  == True
-    assert ask(x+1, Q.complex, Assume(x, Q.even))  == True
-    assert ask(x+1, Q.complex, Assume(x, Q.odd))  == True
-    assert ask(x+y, Q.complex, Assume(x, Q.complex) & Assume(y, Q.complex)) == True
-    assert ask(x+y, Q.complex, Assume(x, Q.real) & Assume(y, Q.imaginary)) == True
+    assert ask(x+1, Q.complex, Q.complex(x)) == True
+    assert ask(x+1, Q.complex, Q.real(x)) == True
+    assert ask(x+1, Q.complex, Q.rational(x)) == True
+    assert ask(x+1, Q.complex, Q.irrational(x)) == True
+    assert ask(x+1, Q.complex, Q.imaginary(x)) == True
+    assert ask(x+1, Q.complex, Q.integer(x))  == True
+    assert ask(x+1, Q.complex, Q.even(x))  == True
+    assert ask(x+1, Q.complex, Q.odd(x))  == True
+    assert ask(x+y, Q.complex, Q.complex(x) & Q.complex(y)) == True
+    assert ask(x+y, Q.complex, Q.real(x) & Q.imaginary(y)) == True
 
     # a*x +b
-    assert ask(2*x+1, Q.complex, Assume(x, Q.complex)) == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.real)) == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.positive)) == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.rational)) == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.irrational)) == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.imaginary)) == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.integer))  == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.even))  == True
-    assert ask(2*x+1, Q.complex, Assume(x, Q.odd))  == True
+    assert ask(2*x+1, Q.complex, Q.complex(x)) == True
+    assert ask(2*x+1, Q.complex, Q.real(x)) == True
+    assert ask(2*x+1, Q.complex, Q.positive(x)) == True
+    assert ask(2*x+1, Q.complex, Q.rational(x)) == True
+    assert ask(2*x+1, Q.complex, Q.irrational(x)) == True
+    assert ask(2*x+1, Q.complex, Q.imaginary(x)) == True
+    assert ask(2*x+1, Q.complex, Q.integer(x))  == True
+    assert ask(2*x+1, Q.complex, Q.even(x))  == True
+    assert ask(2*x+1, Q.complex, Q.odd(x))  == True
 
     # x**2
-    assert ask(x**2, Q.complex, Assume(x, Q.complex)) == True
-    assert ask(x**2, Q.complex, Assume(x, Q.real)) == True
-    assert ask(x**2, Q.complex, Assume(x, Q.positive)) == True
-    assert ask(x**2, Q.complex, Assume(x, Q.rational)) == True
-    assert ask(x**2, Q.complex, Assume(x, Q.irrational)) == True
-    assert ask(x**2, Q.complex, Assume(x, Q.imaginary)) == True
-    assert ask(x**2, Q.complex, Assume(x, Q.integer))  == True
-    assert ask(x**2, Q.complex, Assume(x, Q.even))  == True
-    assert ask(x**2, Q.complex, Assume(x, Q.odd))  == True
+    assert ask(x**2, Q.complex, Q.complex(x)) == True
+    assert ask(x**2, Q.complex, Q.real(x)) == True
+    assert ask(x**2, Q.complex, Q.positive(x)) == True
+    assert ask(x**2, Q.complex, Q.rational(x)) == True
+    assert ask(x**2, Q.complex, Q.irrational(x)) == True
+    assert ask(x**2, Q.complex, Q.imaginary(x)) == True
+    assert ask(x**2, Q.complex, Q.integer(x))  == True
+    assert ask(x**2, Q.complex, Q.even(x))  == True
+    assert ask(x**2, Q.complex, Q.odd(x))  == True
 
     # 2**x
-    assert ask(2**x, Q.complex, Assume(x, Q.complex)) == True
-    assert ask(2**x, Q.complex, Assume(x, Q.real)) == True
-    assert ask(2**x, Q.complex, Assume(x, Q.positive)) == True
-    assert ask(2**x, Q.complex, Assume(x, Q.rational)) == True
-    assert ask(2**x, Q.complex, Assume(x, Q.irrational)) == True
-    assert ask(2**x, Q.complex, Assume(x, Q.imaginary)) == True
-    assert ask(2**x, Q.complex, Assume(x, Q.integer))  == True
-    assert ask(2**x, Q.complex, Assume(x, Q.even))  == True
-    assert ask(2**x, Q.complex, Assume(x, Q.odd))  == True
-    assert ask(x**y, Q.complex, Assume(x, Q.complex) & \
-                     Assume(y, Q.complex)) == True
+    assert ask(2**x, Q.complex, Q.complex(x)) == True
+    assert ask(2**x, Q.complex, Q.real(x)) == True
+    assert ask(2**x, Q.complex, Q.positive(x)) == True
+    assert ask(2**x, Q.complex, Q.rational(x)) == True
+    assert ask(2**x, Q.complex, Q.irrational(x)) == True
+    assert ask(2**x, Q.complex, Q.imaginary(x)) == True
+    assert ask(2**x, Q.complex, Q.integer(x))  == True
+    assert ask(2**x, Q.complex, Q.even(x))  == True
+    assert ask(2**x, Q.complex, Q.odd(x))  == True
+    assert ask(x**y, Q.complex, Q.complex(x) & Q.complex(y)) == True
 
     # trigonometric expressions
     assert ask(sin(x), Q.complex) == True
@@ -534,377 +531,346 @@ def test_complex():
 def test_even():
     x, y, z, t = symbols('x,y,z,t')
     assert ask(x, Q.even) == None
-    assert ask(x, Q.even, Assume(x, Q.integer)) == None
-    assert ask(x, Q.even, Assume(x, Q.integer, False)) == False
-    assert ask(x, Q.even, Assume(x, Q.rational)) == None
-    assert ask(x, Q.even, Assume(x, Q.positive)) == None
+    assert ask(x, Q.even, Q.integer(x)) == None
+    assert ask(x, Q.even, ~Q.integer(x)) == False
+    assert ask(x, Q.even, Q.rational(x)) == None
+    assert ask(x, Q.even, Q.positive(x)) == None
 
     assert ask(2*x, Q.even) == None
-    assert ask(2*x, Q.even, Assume(x, Q.integer)) == True
-    assert ask(2*x, Q.even, Assume(x, Q.even)) == True
-    assert ask(2*x, Q.even, Assume(x, Q.irrational)) == False
-    assert ask(2*x, Q.even, Assume(x, Q.odd)) == True
-    assert ask(2*x, Q.even, Assume(x, Q.integer, False)) == None
-    assert ask(3*x, Q.even, Assume(x, Q.integer)) == None
-    assert ask(3*x, Q.even, Assume(x, Q.even)) == True
-    assert ask(3*x, Q.even, Assume(x, Q.odd)) == False
+    assert ask(2*x, Q.even, Q.integer(x)) == True
+    assert ask(2*x, Q.even, Q.even(x)) == True
+    assert ask(2*x, Q.even, Q.irrational(x)) == False
+    assert ask(2*x, Q.even, Q.odd(x)) == True
+    assert ask(2*x, Q.even, ~Q.integer(x)) == None
+    assert ask(3*x, Q.even, Q.integer(x)) == None
+    assert ask(3*x, Q.even, Q.even(x)) == True
+    assert ask(3*x, Q.even, Q.odd(x)) == False
 
-    assert ask(x+1, Q.even, Assume(x, Q.odd)) == True
-    assert ask(x+1, Q.even, Assume(x, Q.even)) == False
-    assert ask(x+2, Q.even, Assume(x, Q.odd)) == False
-    assert ask(x+2, Q.even, Assume(x, Q.even)) == True
-    assert ask(7-x, Q.even, Assume(x, Q.odd)) == True
-    assert ask(7+x, Q.even, Assume(x, Q.odd)) == True
-    assert ask(x+y, Q.even, Assume(x, Q.odd) & Assume(y, Q.odd)) == True
-    assert ask(x+y, Q.even, Assume(x, Q.odd) & Assume(y, Q.even)) == False
-    assert ask(x+y, Q.even, Assume(x, Q.even) & Assume(y, Q.even)) == True
+    assert ask(x+1, Q.even, Q.odd(x)) == True
+    assert ask(x+1, Q.even, Q.even(x)) == False
+    assert ask(x+2, Q.even, Q.odd(x)) == False
+    assert ask(x+2, Q.even, Q.even(x)) == True
+    assert ask(7-x, Q.even, Q.odd(x)) == True
+    assert ask(7+x, Q.even, Q.odd(x)) == True
+    assert ask(x+y, Q.even, Q.odd(x) & Q.odd(y)) == True
+    assert ask(x+y, Q.even, Q.odd(x) & Q.even(y)) == False
+    assert ask(x+y, Q.even, Q.even(x) & Q.even(y)) == True
 
-    assert ask(2*x + 1, Q.even, Assume(x, Q.integer)) == False
-    assert ask(2*x*y, Q.even, Assume(x, Q.rational) & Assume(x, Q.rational)) == None
-    assert ask(2*x*y, Q.even, Assume(x, Q.irrational) & Assume(x, Q.irrational)) == None
+    assert ask(2*x + 1, Q.even, Q.integer(x)) == False
+    assert ask(2*x*y, Q.even, Q.rational(x) & Q.rational(x)) == None
+    assert ask(2*x*y, Q.even, Q.irrational(x) & Q.irrational(x)) == None
 
-    assert ask(x+y+z, Q.even, Assume(x, Q.odd) & Assume(y, Q.odd) & \
-                     Assume(z, Q.even)) == True
-    assert ask(x+y+z+t, Q.even, Assume(x, Q.odd) & Assume(y, Q.odd) & \
-                     Assume(z, Q.even) & Assume(t, Q.integer)) == None
+    assert ask(x+y+z, Q.even, Q.odd(x) & Q.odd(y) & Q.even(z)) == True
+    assert ask(x+y+z+t, Q.even,
+               Q.odd(x) & Q.odd(y) & Q.even(z) & Q.integer(t)) == None
 
-    assert ask(Abs(x), Q.even, Assume(x, Q.even)) == True
-    assert ask(Abs(x), Q.even, Assume(x, Q.even, False)) == None
-    assert ask(re(x),  Q.even, Assume(x, Q.even)) == True
-    assert ask(re(x),  Q.even, Assume(x, Q.even, False)) == None
-    assert ask(im(x),  Q.even, Assume(x, Q.even)) == True
-    assert ask(im(x),  Q.even, Assume(x, Q.real)) == True
+    assert ask(Abs(x), Q.even, Q.even(x)) == True
+    assert ask(Abs(x), Q.even, ~Q.even(x)) == None
+    assert ask(re(x),  Q.even, Q.even(x)) == True
+    assert ask(re(x),  Q.even, ~Q.even(x)) == None
+    assert ask(im(x),  Q.even, Q.even(x)) == True
+    assert ask(im(x),  Q.even, Q.real(x)) == True
 
 def test_extended_real():
     x = symbols('x')
-    assert ask(x, Q.extended_real, Assume(x, Q.positive)) == True
-    assert ask(-x, Q.extended_real, Assume(x, Q.positive)) == True
-    assert ask(-x, Q.extended_real, Assume(x, Q.negative)) == True
+    assert ask(x, Q.extended_real, Q.positive(x)) == True
+    assert ask(-x, Q.extended_real, Q.positive(x)) == True
+    assert ask(-x, Q.extended_real, Q.negative(x)) == True
 
-    assert ask(x+S.Infinity, Q.extended_real, Assume(x, Q.real)) == True
+    assert ask(x+S.Infinity, Q.extended_real, Q.real(x)) == True
 
 def test_rational():
     x, y = symbols('x,y')
-    assert ask(x, Q.rational, Assume(x, Q.integer)) == True
-    assert ask(x, Q.rational, Assume(x, Q.irrational)) == False
-    assert ask(x, Q.rational, Assume(x, Q.real)) == None
-    assert ask(x, Q.rational, Assume(x, Q.positive)) == None
-    assert ask(x, Q.rational, Assume(x, Q.negative)) == None
-    assert ask(x, Q.rational, Assume(x, Q.nonzero)) == None
+    assert ask(x, Q.rational, Q.integer(x)) == True
+    assert ask(x, Q.rational, Q.irrational(x)) == False
+    assert ask(x, Q.rational, Q.real(x)) == None
+    assert ask(x, Q.rational, Q.positive(x)) == None
+    assert ask(x, Q.rational, Q.negative(x)) == None
+    assert ask(x, Q.rational, Q.nonzero(x)) == None
 
-    assert ask(2*x, Q.rational, Assume(x, Q.rational)) == True
-    assert ask(2*x, Q.rational, Assume(x, Q.integer)) == True
-    assert ask(2*x, Q.rational, Assume(x, Q.even)) == True
-    assert ask(2*x, Q.rational, Assume(x, Q.odd)) == True
-    assert ask(2*x, Q.rational, Assume(x, Q.irrational)) == False
+    assert ask(2*x, Q.rational, Q.rational(x)) == True
+    assert ask(2*x, Q.rational, Q.integer(x)) == True
+    assert ask(2*x, Q.rational, Q.even(x)) == True
+    assert ask(2*x, Q.rational, Q.odd(x)) == True
+    assert ask(2*x, Q.rational, Q.irrational(x)) == False
 
-    assert ask(x/2, Q.rational, Assume(x, Q.rational)) == True
-    assert ask(x/2, Q.rational, Assume(x, Q.integer)) == True
-    assert ask(x/2, Q.rational, Assume(x, Q.even)) == True
-    assert ask(x/2, Q.rational, Assume(x, Q.odd)) == True
-    assert ask(x/2, Q.rational, Assume(x, Q.irrational)) == False
+    assert ask(x/2, Q.rational, Q.rational(x)) == True
+    assert ask(x/2, Q.rational, Q.integer(x)) == True
+    assert ask(x/2, Q.rational, Q.even(x)) == True
+    assert ask(x/2, Q.rational, Q.odd(x)) == True
+    assert ask(x/2, Q.rational, Q.irrational(x)) == False
 
-    assert ask(1/x, Q.rational, Assume(x, Q.rational)) == True
-    assert ask(1/x, Q.rational, Assume(x, Q.integer)) == True
-    assert ask(1/x, Q.rational, Assume(x, Q.even)) == True
-    assert ask(1/x, Q.rational, Assume(x, Q.odd)) == True
-    assert ask(1/x, Q.rational, Assume(x, Q.irrational)) == False
+    assert ask(1/x, Q.rational, Q.rational(x)) == True
+    assert ask(1/x, Q.rational, Q.integer(x)) == True
+    assert ask(1/x, Q.rational, Q.even(x)) == True
+    assert ask(1/x, Q.rational, Q.odd(x)) == True
+    assert ask(1/x, Q.rational, Q.irrational(x)) == False
 
-    assert ask(2/x, Q.rational, Assume(x, Q.rational)) == True
-    assert ask(2/x, Q.rational, Assume(x, Q.integer)) == True
-    assert ask(2/x, Q.rational, Assume(x, Q.even)) == True
-    assert ask(2/x, Q.rational, Assume(x, Q.odd)) == True
-    assert ask(2/x, Q.rational, Assume(x, Q.irrational)) == False
+    assert ask(2/x, Q.rational, Q.rational(x)) == True
+    assert ask(2/x, Q.rational, Q.integer(x)) == True
+    assert ask(2/x, Q.rational, Q.even(x)) == True
+    assert ask(2/x, Q.rational, Q.odd(x)) == True
+    assert ask(2/x, Q.rational, Q.irrational(x)) == False
 
     # with multiple symbols
-    assert ask(x*y, Q.rational, Assume(x, Q.irrational) & \
-        Assume(y, Q.irrational)) == None
-    assert ask(y/x, Q.rational, Assume(x, Q.rational) & \
-        Assume(y, Q.rational)) == True
-    assert ask(y/x, Q.rational, Assume(x, Q.integer) & \
-        Assume(y, Q.rational)) == True
-    assert ask(y/x, Q.rational, Assume(x, Q.even) & \
-        Assume(y, Q.rational)) == True
-    assert ask(y/x, Q.rational, Assume(x, Q.odd) & \
-        Assume(y, Q.rational)) == True
-    assert ask(y/x, Q.rational, Assume(x, Q.irrational) & \
-        Assume(y, Q.rational)) == False
+    assert ask(x*y, Q.rational, Q.irrational(x) & Q.irrational(y)) == None
+    assert ask(y/x, Q.rational, Q.rational(x) & Q.rational(y)) == True
+    assert ask(y/x, Q.rational, Q.integer(x) & Q.rational(y)) == True
+    assert ask(y/x, Q.rational, Q.even(x) & Q.rational(y)) == True
+    assert ask(y/x, Q.rational, Q.odd(x) & Q.rational(y)) == True
+    assert ask(y/x, Q.rational, Q.irrational(x) & Q.rational(y)) == False
 
 def test_imaginary():
     x, y, z = symbols('x,y,z')
     I = S.ImaginaryUnit
     assert ask(x, Q.imaginary) == None
-    assert ask(x, Q.imaginary, Assume(x, Q.real)) == False
-    assert ask(x, Q.imaginary, Assume(x, Q.prime)) == False
+    assert ask(x, Q.imaginary, Q.real(x)) == False
+    assert ask(x, Q.imaginary, Q.prime(x)) == False
 
-    assert ask(x+1, Q.imaginary, Assume(x, Q.real)) == False
-    assert ask(x+1, Q.imaginary, Assume(x, Q.imaginary)) == False
-    assert ask(x+I, Q.imaginary, Assume(x, Q.real)) == False
-    assert ask(x+I, Q.imaginary, Assume(x, Q.imaginary)) == True
-    assert ask(x+y, Q.imaginary, Assume(x, Q.imaginary) & \
-                     Assume(y, Q.imaginary)) == True
-    assert ask(x+y, Q.imaginary, Assume(x, Q.real) & \
-                     Assume(y, Q.real)) == False
-    assert ask(x+y, Q.imaginary, Assume(x, Q.imaginary) & \
-                     Assume(y, Q.real)) == False
-    assert ask(x+y, Q.imaginary, Assume(x, Q.complex) & \
-                     Assume(y, Q.real)) == None
+    assert ask(x+1, Q.imaginary, Q.real(x)) == False
+    assert ask(x+1, Q.imaginary, Q.imaginary(x)) == False
+    assert ask(x+I, Q.imaginary, Q.real(x)) == False
+    assert ask(x+I, Q.imaginary, Q.imaginary(x)) == True
+    assert ask(x+y, Q.imaginary, Q.imaginary(x) & Q.imaginary(y)) == True
+    assert ask(x+y, Q.imaginary, Q.real(x) & Q.real(y)) == False
+    assert ask(x+y, Q.imaginary, Q.imaginary(x) & Q.real(y)) == False
+    assert ask(x+y, Q.imaginary, Q.complex(x) & Q.real(y)) == None
 
-    assert ask(I*x, Q.imaginary, Assume(x, Q.real)) == True
-    assert ask(I*x, Q.imaginary, Assume(x, Q.imaginary)) == False
-    assert ask(I*x, Q.imaginary, Assume(x, Q.complex)) == None
-    assert ask(x*y, Q.imaginary, Assume(x, Q.imaginary) & \
-                 Assume(y, Q.real)) == True
+    assert ask(I*x, Q.imaginary, Q.real(x)) == True
+    assert ask(I*x, Q.imaginary, Q.imaginary(x)) == False
+    assert ask(I*x, Q.imaginary, Q.complex(x)) == None
+    assert ask(x*y, Q.imaginary, Q.imaginary(x) & Q.real(y)) == True
 
-    assert ask(x+y+z, Q.imaginary, Assume(x, Q.real) & \
-                     Assume(y, Q.real) & Assume(z, Q.real)) == False
-    assert ask(x+y+z, Q.imaginary, Assume(x, Q.real) & \
-                     Assume(y, Q.real) & Assume(z, Q.imaginary)) == None
-    assert ask(x+y+z, Q.imaginary, Assume(x, Q.real) & \
-                     Assume(y, Q.imaginary) & Assume(z, Q.imaginary)) == False
+    assert ask(x+y+z, Q.imaginary, Q.real(x) & Q.real(y) & Q.real(z)) == False
+    assert ask(x+y+z, Q.imaginary, Q.real(x) & Q.real(y) & Q.imaginary(z)) == None
+    assert ask(x+y+z, Q.imaginary, Q.real(x) & Q.imaginary(y) & Q.imaginary(z)) == False
 
 def test_infinitesimal():
     x, y = symbols('x,y')
     assert ask(x, Q.infinitesimal) == None
-    assert ask(x, Q.infinitesimal, Assume(x, Q.infinitesimal)) == True
+    assert ask(x, Q.infinitesimal, Q.infinitesimal(x)) == True
 
-    assert ask(2*x, Q.infinitesimal, Assume(x, Q.infinitesimal)) == True
-    assert ask(x*y, Q.infinitesimal, Assume(x, Q.infinitesimal)) == None
-    assert ask(x*y, Q.infinitesimal, Assume(x, Q.infinitesimal) & \
-                     Assume(y, Q.infinitesimal)) == True
-    assert ask(x*y, Q.infinitesimal, Assume(x, Q.infinitesimal) & \
-                     Assume(y, Q.bounded)) == True
+    assert ask(2*x, Q.infinitesimal, Q.infinitesimal(x)) == True
+    assert ask(x*y, Q.infinitesimal, Q.infinitesimal(x)) == None
+    assert ask(x*y, Q.infinitesimal, Q.infinitesimal(x) & Q.infinitesimal(y)) == True
+    assert ask(x*y, Q.infinitesimal, Q.infinitesimal(x) & Q.bounded(y)) == True
 
-    assert ask(x**2, Q.infinitesimal, Assume(x, Q.infinitesimal)) == True
+    assert ask(x**2, Q.infinitesimal, Q.infinitesimal(x)) == True
 
 def test_integer():
     x = symbols('x')
     assert ask(x, Q.integer) == None
-    assert ask(x, Q.integer, Assume(x, Q.integer)) == True
-    assert ask(x, Q.integer, Assume(x, Q.integer, False)) == False
-    assert ask(x, Q.integer, Assume(x, Q.real, False)) == False
-    assert ask(x, Q.integer, Assume(x, Q.positive, False)) == None
-    assert ask(x, Q.integer, Assume(x, Q.even) | Assume(x, Q.odd)) == True
+    assert ask(x, Q.integer, Q.integer(x)) == True
+    assert ask(x, Q.integer, ~Q.integer(x)) == False
+    assert ask(x, Q.integer, ~Q.real(x)) == False
+    assert ask(x, Q.integer, ~Q.positive(x)) == None
+    assert ask(x, Q.integer, Q.even(x) | Q.odd(x)) == True
 
-    assert ask(2*x, Q.integer, Assume(x, Q.integer)) == True
-    assert ask(2*x, Q.integer, Assume(x, Q.even)) == True
-    assert ask(2*x, Q.integer, Assume(x, Q.prime)) == True
-    assert ask(2*x, Q.integer, Assume(x, Q.rational)) == None
-    assert ask(2*x, Q.integer, Assume(x, Q.real)) == None
-    assert ask(sqrt(2)*x, Q.integer, Assume(x, Q.integer)) == False
+    assert ask(2*x, Q.integer, Q.integer(x)) == True
+    assert ask(2*x, Q.integer, Q.even(x)) == True
+    assert ask(2*x, Q.integer, Q.prime(x)) == True
+    assert ask(2*x, Q.integer, Q.rational(x)) == None
+    assert ask(2*x, Q.integer, Q.real(x)) == None
+    assert ask(sqrt(2)*x, Q.integer, Q.integer(x)) == False
 
-    assert ask(x/2, Q.integer, Assume(x, Q.odd)) == False
-    assert ask(x/2, Q.integer, Assume(x, Q.even)) == True
-    assert ask(x/3, Q.integer, Assume(x, Q.odd)) == None
-    assert ask(x/3, Q.integer, Assume(x, Q.even)) == None
+    assert ask(x/2, Q.integer, Q.odd(x)) == False
+    assert ask(x/2, Q.integer, Q.even(x)) == True
+    assert ask(x/3, Q.integer, Q.odd(x)) == None
+    assert ask(x/3, Q.integer, Q.even(x)) == None
 
 def test_negative():
     x, y = symbols('x,y')
-    assert ask(x, Q.negative, Assume(x, Q.negative)) == True
-    assert ask(x, Q.negative, Assume(x, Q.positive)) == False
-    assert ask(x, Q.negative, Assume(x, Q.real, False)) == False
-    assert ask(x, Q.negative, Assume(x, Q.prime)) == False
-    assert ask(x, Q.negative, Assume(x, Q.prime, False)) == None
+    assert ask(x, Q.negative, Q.negative(x)) == True
+    assert ask(x, Q.negative, Q.positive(x)) == False
+    assert ask(x, Q.negative, ~Q.real(x)) == False
+    assert ask(x, Q.negative, Q.prime(x)) == False
+    assert ask(x, Q.negative, ~Q.prime(x)) == None
 
-    assert ask(-x, Q.negative, Assume(x, Q.positive)) == True
-    assert ask(-x, Q.negative, Assume(x, Q.positive, False)) == None
-    assert ask(-x, Q.negative, Assume(x, Q.negative)) == False
-    assert ask(-x, Q.negative, Assume(x, Q.positive)) == True
+    assert ask(-x, Q.negative, Q.positive(x)) == True
+    assert ask(-x, Q.negative, ~Q.positive(x)) == None
+    assert ask(-x, Q.negative, Q.negative(x)) == False
+    assert ask(-x, Q.negative, Q.positive(x)) == True
 
-    assert ask(x-1, Q.negative, Assume(x, Q.negative)) == True
+    assert ask(x-1, Q.negative, Q.negative(x)) == True
     assert ask(x+y, Q.negative) == None
-    assert ask(x+y, Q.negative, Assume(x, Q.negative)) == None
-    assert ask(x+y, Q.negative, Assume(x, Q.negative) &\
-                     Assume(y, Q.negative)) == True
+    assert ask(x+y, Q.negative, Q.negative(x)) == None
+    assert ask(x+y, Q.negative, Q.negative(x) & Q.negative(y)) == True
 
     assert ask(x**2, Q.negative) == None
-    assert ask(x**2, Q.negative, Assume(x, Q.real)) == False
-    assert ask(x**1.4, Q.negative, Assume(x, Q.real)) == None
+    assert ask(x**2, Q.negative, Q.real(x)) == False
+    assert ask(x**1.4, Q.negative, Q.real(x)) == None
 
     assert ask(x*y, Q.negative) == None
-    assert ask(x*y, Q.negative, Assume(x, Q.positive) & \
-                     Assume(y, Q.positive)) == False
-    assert ask(x*y, Q.negative, Assume(x, Q.positive) & \
-                     Assume(y, Q.negative)) == True
-    assert ask(x*y, Q.negative, Assume(x, Q.complex) & \
-                     Assume(y, Q.complex)) == None
+    assert ask(x*y, Q.negative, Q.positive(x) & Q.positive(y)) == False
+    assert ask(x*y, Q.negative, Q.positive(x) & Q.negative(y)) == True
+    assert ask(x*y, Q.negative, Q.complex(x) & Q.complex(y)) == None
 
     assert ask(x**y, Q.negative) == None
-    assert ask(x**y, Q.negative, Assume(x, Q.negative) & \
-                     Assume(y, Q.even)) == False
-    assert ask(x**y, Q.negative, Assume(x, Q.negative) & \
-                     Assume(y, Q.odd)) == True
-    assert ask(x**y, Q.negative, Assume(x, Q.positive) & \
-                     Assume(y, Q.integer)) == False
+    assert ask(x**y, Q.negative, Q.negative(x) & Q.even(y)) == False
+    assert ask(x**y, Q.negative, Q.negative(x) & Q.odd(y)) == True
+    assert ask(x**y, Q.negative, Q.positive(x) & Q.integer(y)) == False
 
     assert ask(Abs(x), Q.negative) == False
 
 def test_nonzero():
     x, y = symbols('x,y')
     assert ask(x, Q.nonzero) == None
-    assert ask(x, Q.nonzero, Assume(x, Q.real)) == None
-    assert ask(x, Q.nonzero, Assume(x, Q.positive)) == True
-    assert ask(x, Q.nonzero, Assume(x, Q.negative)) == True
-    assert ask(x, Q.nonzero, Assume(x, Q.negative) | Assume(x, Q.positive)) == True
+    assert ask(x, Q.nonzero, Q.real(x)) == None
+    assert ask(x, Q.nonzero, Q.positive(x)) == True
+    assert ask(x, Q.nonzero, Q.negative(x)) == True
+    assert ask(x, Q.nonzero, Q.negative(x) | Q.positive(x)) == True
 
     assert ask(x+y, Q.nonzero) == None
-    assert ask(x+y, Q.nonzero, Assume(x, Q.positive) & Assume(y, Q.positive)) == True
-    assert ask(x+y, Q.nonzero, Assume(x, Q.positive) & Assume(y, Q.negative)) == None
-    assert ask(x+y, Q.nonzero, Assume(x, Q.negative) & Assume(y, Q.negative)) == True
+    assert ask(x+y, Q.nonzero, Q.positive(x) & Q.positive(y)) == True
+    assert ask(x+y, Q.nonzero, Q.positive(x) & Q.negative(y)) == None
+    assert ask(x+y, Q.nonzero, Q.negative(x) & Q.negative(y)) == True
 
     assert ask(2*x, Q.nonzero) == None
-    assert ask(2*x, Q.nonzero, Assume(x, Q.positive)) == True
-    assert ask(2*x, Q.nonzero, Assume(x, Q.negative)) == True
-    assert ask(x*y, Q.nonzero, Assume(x, Q.nonzero)) == None
-    assert ask(x*y, Q.nonzero, Assume(x, Q.nonzero) & Assume(y, Q.nonzero)) == True
+    assert ask(2*x, Q.nonzero, Q.positive(x)) == True
+    assert ask(2*x, Q.nonzero, Q.negative(x)) == True
+    assert ask(x*y, Q.nonzero, Q.nonzero(x)) == None
+    assert ask(x*y, Q.nonzero, Q.nonzero(x) & Q.nonzero(y)) == True
 
     assert ask(Abs(x), Q.nonzero) == None
-    assert ask(Abs(x), Q.nonzero, Assume(x, Q.nonzero)) == True
+    assert ask(Abs(x), Q.nonzero, Q.nonzero(x)) == True
 
 def test_odd():
     x, y, z, t = symbols('x,y,z,t')
     assert ask(x, Q.odd) == None
-    assert ask(x, Q.odd, Assume(x, Q.odd)) == True
-    assert ask(x, Q.odd, Assume(x, Q.integer)) == None
-    assert ask(x, Q.odd, Assume(x, Q.integer, False)) == False
-    assert ask(x, Q.odd, Assume(x, Q.rational)) == None
-    assert ask(x, Q.odd, Assume(x, Q.positive)) == None
+    assert ask(x, Q.odd, Q.odd(x)) == True
+    assert ask(x, Q.odd, Q.integer(x)) == None
+    assert ask(x, Q.odd, ~Q.integer(x)) == False
+    assert ask(x, Q.odd, Q.rational(x)) == None
+    assert ask(x, Q.odd, Q.positive(x)) == None
 
-    assert ask(-x, Q.odd, Assume(x, Q.odd)) == True
+    assert ask(-x, Q.odd, Q.odd(x)) == True
 
     assert ask(2*x, Q.odd) == None
-    assert ask(2*x, Q.odd, Assume(x, Q.integer)) == False
-    assert ask(2*x, Q.odd, Assume(x, Q.odd)) == False
-    assert ask(2*x, Q.odd, Assume(x, Q.irrational)) == False
-    assert ask(2*x, Q.odd, Assume(x, Q.integer, False)) == None
-    assert ask(3*x, Q.odd, Assume(x, Q.integer)) == None
+    assert ask(2*x, Q.odd, Q.integer(x)) == False
+    assert ask(2*x, Q.odd, Q.odd(x)) == False
+    assert ask(2*x, Q.odd, Q.irrational(x)) == False
+    assert ask(2*x, Q.odd, ~Q.integer(x)) == None
+    assert ask(3*x, Q.odd, Q.integer(x)) == None
 
-    assert ask(x/3, Q.odd, Assume(x, Q.odd)) == None
-    assert ask(x/3, Q.odd, Assume(x, Q.even)) == None
+    assert ask(x/3, Q.odd, Q.odd(x)) == None
+    assert ask(x/3, Q.odd, Q.even(x)) == None
 
-    assert ask(x+1, Q.odd, Assume(x, Q.even)) == True
-    assert ask(x+2, Q.odd, Assume(x, Q.even)) == False
-    assert ask(x+2, Q.odd, Assume(x, Q.odd))  == True
-    assert ask(3-x, Q.odd, Assume(x, Q.odd))  == False
-    assert ask(3-x, Q.odd, Assume(x, Q.even))  == True
-    assert ask(3+x, Q.odd, Assume(x, Q.odd))  == False
-    assert ask(3+x, Q.odd, Assume(x, Q.even))  == True
-    assert ask(x+y, Q.odd, Assume(x, Q.odd) & Assume(y, Q.odd)) == False
-    assert ask(x+y, Q.odd, Assume(x, Q.odd) & Assume(y, Q.even)) == True
-    assert ask(x-y, Q.odd, Assume(x, Q.even) & Assume(y, Q.odd)) == True
-    assert ask(x-y, Q.odd, Assume(x, Q.odd) & Assume(y, Q.odd)) == False
+    assert ask(x+1, Q.odd, Q.even(x)) == True
+    assert ask(x+2, Q.odd, Q.even(x)) == False
+    assert ask(x+2, Q.odd, Q.odd(x))  == True
+    assert ask(3-x, Q.odd, Q.odd(x))  == False
+    assert ask(3-x, Q.odd, Q.even(x))  == True
+    assert ask(3+x, Q.odd, Q.odd(x))  == False
+    assert ask(3+x, Q.odd, Q.even(x))  == True
+    assert ask(x+y, Q.odd, Q.odd(x) & Q.odd(y)) == False
+    assert ask(x+y, Q.odd, Q.odd(x) & Q.even(y)) == True
+    assert ask(x-y, Q.odd, Q.even(x) & Q.odd(y)) == True
+    assert ask(x-y, Q.odd, Q.odd(x) & Q.odd(y)) == False
 
-    assert ask(x+y+z, Q.odd, Assume(x, Q.odd) & Assume(y, Q.odd) & \
-                     Assume(z, Q.even)) == False
-    assert ask(x+y+z+t, Q.odd, Assume(x, Q.odd) & Assume(y, Q.odd) & \
-                     Assume(z, Q.even) & Assume(t, Q.integer)) == None
+    assert ask(x+y+z, Q.odd, Q.odd(x) & Q.odd(y) & Q.even(z)) == False
+    assert ask(x+y+z+t, Q.odd,
+               Q.odd(x) & Q.odd(y) & Q.even(z) & Q.integer(t)) == None
 
-    assert ask(2*x + 1, Q.odd, Assume(x, Q.integer)) == True
-    assert ask(2*x + y, Q.odd, Assume(x, Q.integer) & Assume(y, Q.odd)) == True
-    assert ask(2*x + y, Q.odd, Assume(x, Q.integer) & Assume(y, Q.even)) == False
-    assert ask(2*x + y, Q.odd, Assume(x, Q.integer) & Assume(y, Q.integer)) == None
-    assert ask(x*y,   Q.odd, Assume(x, Q.odd) & Assume(y, Q.even)) == False
-    assert ask(x*y,   Q.odd, Assume(x, Q.odd) & Assume(y, Q.odd)) == True
-    assert ask(2*x*y, Q.odd, Assume(x, Q.rational) & Assume(x, Q.rational)) == None
-    assert ask(2*x*y, Q.odd, Assume(x, Q.irrational) & Assume(x, Q.irrational)) == None
+    assert ask(2*x + 1, Q.odd, Q.integer(x)) == True
+    assert ask(2*x + y, Q.odd, Q.integer(x) & Q.odd(y)) == True
+    assert ask(2*x + y, Q.odd, Q.integer(x) & Q.even(y)) == False
+    assert ask(2*x + y, Q.odd, Q.integer(x) & Q.integer(y)) == None
+    assert ask(x*y,   Q.odd, Q.odd(x) & Q.even(y)) == False
+    assert ask(x*y,   Q.odd, Q.odd(x) & Q.odd(y)) == True
+    assert ask(2*x*y, Q.odd, Q.rational(x) & Q.rational(x)) == None
+    assert ask(2*x*y, Q.odd, Q.irrational(x) & Q.irrational(x)) == None
 
-    assert ask(Abs(x), Q.odd, Assume(x, Q.odd)) == True
+    assert ask(Abs(x), Q.odd, Q.odd(x)) == True
 
 def test_prime():
     x, y = symbols('x,y')
-    assert ask(x, Q.prime, Assume(x, Q.prime)) == True
-    assert ask(x, Q.prime, Assume(x, Q.prime, False)) == False
-    assert ask(x, Q.prime, Assume(x, Q.integer)) == None
-    assert ask(x, Q.prime, Assume(x, Q.integer, False)) == False
+    assert ask(x, Q.prime, Q.prime(x)) == True
+    assert ask(x, Q.prime, ~Q.prime(x)) == False
+    assert ask(x, Q.prime, Q.integer(x)) == None
+    assert ask(x, Q.prime, ~Q.integer(x)) == False
 
-    assert ask(2*x, Q.prime, Assume(x, Q.integer)) == False
+    assert ask(2*x, Q.prime, Q.integer(x)) == False
     assert ask(x*y, Q.prime) == None
-    assert ask(x*y, Q.prime, Assume(x, Q.prime)) == None
-    assert ask(x*y, Q.prime, Assume(x, Q.integer) & \
-                     Assume(y, Q.integer)) == False
+    assert ask(x*y, Q.prime, Q.prime(x)) == None
+    assert ask(x*y, Q.prime, Q.integer(x) & Q.integer(y)) == False
 
-    assert ask(x**2, Q.prime, Assume(x, Q.integer)) == False
-    assert ask(x**2, Q.prime, Assume(x, Q.prime)) == False
-    assert ask(x**y, Q.prime, Assume(x, Q.integer) & \
-                     Assume(y, Q.integer)) == False
+    assert ask(x**2, Q.prime, Q.integer(x)) == False
+    assert ask(x**2, Q.prime, Q.prime(x)) == False
+    assert ask(x**y, Q.prime, Q.integer(x) & Q.integer(y)) == False
 
 def test_positive():
     x, y, z, w = symbols('x,y,z,w')
-    assert ask(x, Q.positive, Assume(x, Q.positive)) == True
-    assert ask(x, Q.positive, Assume(x, Q.negative)) == False
-    assert ask(x, Q.positive, Assume(x, Q.nonzero)) == None
+    assert ask(x, Q.positive, Q.positive(x)) == True
+    assert ask(x, Q.positive, Q.negative(x)) == False
+    assert ask(x, Q.positive, Q.nonzero(x)) == None
 
-    assert ask(-x, Q.positive, Assume(x, Q.positive)) == False
-    assert ask(-x, Q.positive, Assume(x, Q.negative)) == True
+    assert ask(-x, Q.positive, Q.positive(x)) == False
+    assert ask(-x, Q.positive, Q.negative(x)) == True
 
-    assert ask(x+y, Q.positive, Assume(x, Q.positive) & \
-                     Assume(y, Q.positive)) == True
-    assert ask(x+y, Q.positive, Assume(x, Q.positive) & \
-                     Assume(y, Q.negative)) == None
+    assert ask(x+y, Q.positive, Q.positive(x) & Q.positive(y)) == True
+    assert ask(x+y, Q.positive, Q.positive(x) & Q.negative(y)) == None
 
-    assert ask(2*x,  Q.positive, Assume(x, Q.positive)) == True
-    assumptions =  Assume(x, Q.positive) & Assume(y, Q.negative) & \
-                    Assume(z, Q.negative) & Assume(w, Q.positive)
+    assert ask(2*x,  Q.positive, Q.positive(x)) == True
+    assumptions =  Q.positive(x) & Q.negative(y) & Q.negative(z) & Q.positive(w)
     assert ask(x*y*z,  Q.positive)  == None
     assert ask(x*y*z,  Q.positive, assumptions) == True
     assert ask(-x*y*z, Q.positive, assumptions) == False
 
-    assert ask(x**2, Q.positive, Assume(x, Q.positive)) == True
-    assert ask(x**2, Q.positive, Assume(x, Q.negative)) == True
+    assert ask(x**2, Q.positive, Q.positive(x)) == True
+    assert ask(x**2, Q.positive, Q.negative(x)) == True
 
     #exponential
-    assert ask(exp(x),     Q.positive, Assume(x, Q.real)) == True
-    assert ask(x + exp(x), Q.positive, Assume(x, Q.real)) == None
+    assert ask(exp(x),     Q.positive, Q.real(x)) == True
+    assert ask(x + exp(x), Q.positive, Q.real(x)) == None
 
     #absolute value
     assert ask(Abs(x), Q.positive) == None # Abs(0) = 0
-    assert ask(Abs(x), Q.positive, Assume(x, Q.positive)) == True
+    assert ask(Abs(x), Q.positive, Q.positive(x)) == True
 
 @XFAIL
 def test_positive_xfail():
-    assert ask(1/(1 + x**2), Q.positive, Assume(x, Q.real)) == True
+    assert ask(1/(1 + x**2), Q.positive, Q.real(x)) == True
 
 def test_real():
     x, y = symbols('x,y')
     assert ask(x, Q.real) == None
-    assert ask(x, Q.real, Assume(x, Q.real)) == True
-    assert ask(x, Q.real, Assume(x, Q.nonzero)) == True
-    assert ask(x, Q.real, Assume(x, Q.positive)) == True
-    assert ask(x, Q.real, Assume(x, Q.negative)) == True
-    assert ask(x, Q.real, Assume(x, Q.integer)) == True
-    assert ask(x, Q.real, Assume(x, Q.even)) == True
-    assert ask(x, Q.real, Assume(x, Q.prime)) == True
+    assert ask(x, Q.real, Q.real(x)) == True
+    assert ask(x, Q.real, Q.nonzero(x)) == True
+    assert ask(x, Q.real, Q.positive(x)) == True
+    assert ask(x, Q.real, Q.negative(x)) == True
+    assert ask(x, Q.real, Q.integer(x)) == True
+    assert ask(x, Q.real, Q.even(x)) == True
+    assert ask(x, Q.real, Q.prime(x)) == True
 
-    assert ask(x/sqrt(2), Q.real, Assume(x, Q.real)) == True
-    assert ask(x/sqrt(-2), Q.real, Assume(x, Q.real)) == False
+    assert ask(x/sqrt(2), Q.real, Q.real(x)) == True
+    assert ask(x/sqrt(-2), Q.real, Q.real(x)) == False
 
     I = S.ImaginaryUnit
-    assert ask(x+1, Q.real, Assume(x, Q.real)) == True
-    assert ask(x+I, Q.real, Assume(x, Q.real)) == False
-    assert ask(x+I, Q.real, Assume(x, Q.complex)) == None
+    assert ask(x+1, Q.real, Q.real(x)) == True
+    assert ask(x+I, Q.real, Q.real(x)) == False
+    assert ask(x+I, Q.real, Q.complex(x)) == None
 
-    assert ask(2*x, Q.real, Assume(x, Q.real)) == True
-    assert ask(I*x, Q.real, Assume(x, Q.real)) == False
-    assert ask(I*x, Q.real, Assume(x, Q.imaginary)) == True
-    assert ask(I*x, Q.real, Assume(x, Q.complex)) == None
+    assert ask(2*x, Q.real, Q.real(x)) == True
+    assert ask(I*x, Q.real, Q.real(x)) == False
+    assert ask(I*x, Q.real, Q.imaginary(x)) == True
+    assert ask(I*x, Q.real, Q.complex(x)) == None
 
-    assert ask(x**2, Q.real, Assume(x, Q.real)) == True
-    assert ask(sqrt(x), Q.real, Assume(x, Q.negative)) == False
-    assert ask(x**y, Q.real, Assume(x, Q.real) & Assume(y, Q.integer)) == True
-    assert ask(x**y, Q.real, Assume(x, Q.real) & Assume(y, Q.real)) == None
-    assert ask(x**y, Q.real, Assume(x, Q.positive) & \
-                     Assume(y, Q.real)) == True
+    assert ask(x**2, Q.real, Q.real(x)) == True
+    assert ask(sqrt(x), Q.real, Q.negative(x)) == False
+    assert ask(x**y, Q.real, Q.real(x) & Q.integer(y)) == True
+    assert ask(x**y, Q.real, Q.real(x) & Q.real(y)) == None
+    assert ask(x**y, Q.real, Q.positive(x) & Q.real(y)) == True
 
     # trigonometric functions
     assert ask(sin(x), Q.real) == None
     assert ask(cos(x), Q.real) == None
-    assert ask(sin(x), Q.real, Assume(x, Q.real)) == True
-    assert ask(cos(x), Q.real, Assume(x, Q.real)) == True
+    assert ask(sin(x), Q.real, Q.real(x)) == True
+    assert ask(cos(x), Q.real, Q.real(x)) == True
 
     # exponential function
     assert ask(exp(x), Q.real) == None
-    assert ask(exp(x), Q.real, Assume(x, Q.real)) == True
-    assert ask(x + exp(x), Q.real, Assume(x, Q.real)) == True
+    assert ask(exp(x), Q.real, Q.real(x)) == True
+    assert ask(x + exp(x), Q.real, Q.real(x)) == True
 
     # Q.complexes
     assert ask(re(x), Q.real) == True
@@ -942,7 +908,7 @@ def test_global():
     """Test ask with global assumptions"""
     x = symbols('x')
     assert ask(x, Q.integer) == None
-    global_assumptions.add(Assume(x, Q.integer))
+    global_assumptions.add(Q.integer(x))
     assert ask(x, Q.integer) == True
     global_assumptions.clear()
     assert ask(x, Q.integer) == None
@@ -952,7 +918,7 @@ def test_custom_context():
     x = symbols('x')
     assert ask(x, Q.integer) == None
     local_context = AssumptionsContext()
-    local_context.add(Assume(x, Q.integer))
+    local_context.add(Q.integer(x))
     assert ask(x, Q.integer, context = local_context) == True
     assert ask(x, Q.integer) == None
 

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,46 +1,46 @@
-from sympy import S, symbols, Assume, exp, pi, sqrt, Rational, I, Q, refine, Abs
+from sympy import S, symbols, exp, pi, sqrt, Rational, I, Q, refine, Abs
 from sympy.utilities.pytest import XFAIL
 
 def test_Abs():
     x = symbols('x')
-    assert refine(Abs(x), Assume(x, Q.positive)) == x
-    assert refine(1+Abs(x), Assume(x, Q.positive)) == 1+x
-    assert refine(Abs(x), Assume(x, Q.negative)) == -x
-    assert refine(1+Abs(x), Assume(x, Q.negative)) == 1-x
+    assert refine(Abs(x), Q.positive(x)) == x
+    assert refine(1+Abs(x), Q.positive(x)) == 1+x
+    assert refine(Abs(x), Q.negative(x)) == -x
+    assert refine(1+Abs(x), Q.negative(x)) == 1-x
 
     assert refine(Abs(x**2)) != x**2
-    assert refine(Abs(x**2), Assume(x, Q.real)) == x**2
+    assert refine(Abs(x**2), Q.real(x)) == x**2
 
 def test_pow():
     x, y, z = symbols('x,y,z')
-    assert refine((-1)**x, Assume(x, Q.even)) == 1
-    assert refine((-1)**x, Assume(x, Q.odd)) == -1
-    assert refine((-2)**x, Assume(x, Q.even)) == 2**x
+    assert refine((-1)**x, Q.even(x)) == 1
+    assert refine((-1)**x, Q.odd(x)) == -1
+    assert refine((-2)**x, Q.even(x)) == 2**x
 
     # nested powers
     assert refine(sqrt(x**2)) != Abs(x)
-    assert refine(sqrt(x**2), Assume(x, Q.complex)) != Abs(x)
-    assert refine(sqrt(x**2), Assume(x, Q.real)) == Abs(x)
-    assert refine(sqrt(x**2), Assume(x, Q.positive)) == x
+    assert refine(sqrt(x**2), Q.complex(x)) != Abs(x)
+    assert refine(sqrt(x**2), Q.real(x)) == Abs(x)
+    assert refine(sqrt(x**2), Q.positive(x)) == x
     assert refine((x**3)**(S(1)/3)) != x
 
-    assert refine((x**3)**(S(1)/3), Assume(x, Q.real)) != x
-    assert refine((x**3)**(S(1)/3), Assume(x, Q.positive)) == x
+    assert refine((x**3)**(S(1)/3), Q.real(x)) != x
+    assert refine((x**3)**(S(1)/3), Q.positive(x)) == x
 
-    assert refine(sqrt(1/x), Assume(x, Q.real)) != 1/sqrt(x)
-    assert refine(sqrt(1/x), Assume(x, Q.positive)) == 1/sqrt(x)
+    assert refine(sqrt(1/x), Q.real(x)) != 1/sqrt(x)
+    assert refine(sqrt(1/x), Q.positive(x)) == 1/sqrt(x)
 
     # powers of (-1)
-    assert refine((-1)**(x+y), Assume(x, Q.even)) == (-1)**y
-    assert refine((-1)**(x+y+z), Assume(x, Q.odd)&Assume(z, Q.odd))==(-1)**y
-    assert refine((-1)**(x+y+1), Assume(x, Q.odd))==(-1)**y
-    assert refine((-1)**(x+y+2), Assume(x, Q.odd))==(-1)**(y+1)
+    assert refine((-1)**(x+y), Q.even(x)) == (-1)**y
+    assert refine((-1)**(x+y+z), Q.odd(x) & Q.odd(z))==(-1)**y
+    assert refine((-1)**(x+y+1), Q.odd(x))==(-1)**y
+    assert refine((-1)**(x+y+2), Q.odd(x))==(-1)**(y+1)
     assert refine((-1)**(x+3)) == (-1)**(x+1)
 
 
 def test_exp():
     x = symbols('x')
-    assert refine(exp(pi*I*2*x), Assume(x, Q.integer)) == 1
-    assert refine(exp(pi*I*2*(x+Rational(1,2))), Assume(x, Q.integer)) == -1
-    assert refine(exp(pi*I*2*(x+Rational(1,4))), Assume(x, Q.integer)) == I
-    assert refine(exp(pi*I*2*(x+Rational(3,4))), Assume(x, Q.integer)) == -I
+    assert refine(exp(pi*I*2*x), Q.integer(x)) == 1
+    assert refine(exp(pi*I*2*(x+Rational(1,2))), Q.integer(x)) == -1
+    assert refine(exp(pi*I*2*(x+Rational(1,4))), Q.integer(x)) == I
+    assert refine(exp(pi*I*2*(x+Rational(3,4))), Q.integer(x)) == -I

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -38,6 +38,9 @@ class BooleanFunction(Application, Boolean):
     """
     is_Boolean = True
 
+    def __call__(self, *args):
+        return self.func(*[arg(*args) for arg in self.args])
+
 class And(LatticeOp, BooleanFunction):
     """
     Logical AND function.

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -99,6 +99,9 @@ class ReprPrinter(Printer):
     def _print_Predicate(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))
 
+    def _print_AppliedPredicate(self, expr):
+        return "%s(%s, %s)" % (expr.__class__.__name__, expr.func, expr.arg)
+
     def _print_str(self, expr):
         return repr(expr)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -60,7 +60,7 @@ class StrPrinter(Printer):
         return sign + ' '.join(l)
 
     def _print_Assume(self, expr):
-        return 'Assume(%s, %r)' % (expr.expr, expr.key)
+        return '%s(%s)' % (expr.key, expr.expr)
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -59,8 +59,8 @@ class StrPrinter(Printer):
             sign = ""
         return sign + ' '.join(l)
 
-    def _print_Assume(self, expr):
-        return '%s(%s)' % (expr.key, expr.expr)
+    def _print_AppliedPredicate(self, expr):
+        return '%s(%s)' % (expr.func, expr.arg)
 
     def _print_Basic(self, expr):
         l = [self._print(o) for o in expr.args]

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -3,7 +3,7 @@
 from sympy.core import Symbol, Interval, Union
 from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.core.singleton import S
-from sympy.assumptions import ask, Assume
+from sympy.assumptions import ask, AppliedPredicate
 from sympy.functions import re, im, Abs
 from sympy.logic import And, Or
 from sympy.polys import Poly
@@ -236,7 +236,7 @@ def reduce_inequalities(inequalities, assume=True):
             else:
                 continue
 
-        if isinstance(inequality, Assume):
+        if isinstance(inequality, AppliedPredicate):
             extra_assume.append(inequality)
             continue
 

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -4,21 +4,17 @@ from sympy.solvers.inequalities import (
     reduce_poly_inequalities,
     reduce_inequalities)
 
-from sympy import (
-    S, Symbol, Interval, Eq, Ne, Lt, Le, Gt, Ge, Or, And, pi, oo,
-    sqrt, Q, Assume, global_assumptions, re, im, sin)
+from sympy import (S, Symbol, Interval, Eq, Ne, Lt, Le, Gt, Ge, Or, And, pi, oo,
+    sqrt, Q, global_assumptions, re, im, sin)
 
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y
 
 inf = oo.evalf()
 
-x_assume = Assume(x, Q.real)
-y_assume = Assume(y, Q.real)
-
 def test_reduce_poly_inequalities_real_interval():
-    global_assumptions.add(x_assume)
-    global_assumptions.add(y_assume)
+    global_assumptions.add(Q.real(x))
+    global_assumptions.add(Q.real(y))
 
     assert reduce_poly_inequalities([[Eq(x**2, 0)]], x, relational=False) == [Interval(0, 0)]
     assert reduce_poly_inequalities([[Le(x**2, 0)]], x, relational=False) == [Interval(0, 0)]
@@ -51,12 +47,12 @@ def test_reduce_poly_inequalities_real_interval():
     assert reduce_poly_inequalities([[Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == [Interval(-s, -1, True, True), Interval(1, s, True, True)]
     assert reduce_poly_inequalities([[Lt(x**2 - 2, 0), Ne(x**2 - 1, 0)]], x, relational=False) == [Interval(-s, -1, True, True), Interval(-1, 1, True, True), Interval(1, s, True, True)]
 
-    global_assumptions.remove(x_assume)
-    global_assumptions.remove(y_assume)
+    global_assumptions.remove(Q.real(x))
+    global_assumptions.remove(Q.real(y))
 
 def test_reduce_poly_inequalities_real_relational():
-    global_assumptions.add(x_assume)
-    global_assumptions.add(y_assume)
+    global_assumptions.add(Q.real(x))
+    global_assumptions.add(Q.real(y))
 
     assert reduce_poly_inequalities([[Eq(x**2, 0)]], x, relational=True) == Eq(x, 0)
     assert reduce_poly_inequalities([[Le(x**2, 0)]], x, relational=True) == Eq(x, 0)
@@ -79,8 +75,8 @@ def test_reduce_poly_inequalities_real_relational():
     assert reduce_poly_inequalities([[Gt(x**2, 1.0)]], x, relational=True) == Or(Lt(x, -1.0), Lt(1.0, x))
     assert reduce_poly_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == Or(Lt(x, -1.0), And(Lt(-1.0, x), Lt(x, 1.0)), Lt(1.0, x))
 
-    global_assumptions.remove(x_assume)
-    global_assumptions.remove(y_assume)
+    global_assumptions.remove(Q.real(x))
+    global_assumptions.remove(Q.real(y))
 
 def test_reduce_poly_inequalities_complex_relational():
     cond = Eq(im(x), 0)
@@ -107,7 +103,7 @@ def test_reduce_poly_inequalities_complex_relational():
     assert reduce_poly_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == And(Or(Lt(re(x), -1.0), And(Lt(-1.0, re(x)), Lt(re(x), 1.0)), Lt(1.0, re(x))), cond)
 
 def test_reduce_abs_inequalities():
-    real = Assume(x, Q.real)
+    real = Q.real(x)
 
     assert reduce_inequalities(abs(x - 5) < 3, assume=real) == And(Gt(x, 2), Lt(x, 8))
     assert reduce_inequalities(abs(2*x + 3) >= 8, assume=real) == Or(Le(x, -S(11)/2), Ge(x, S(5)/2))
@@ -121,8 +117,8 @@ def test_reduce_inequalities_boolean():
     assert reduce_inequalities([Eq(x**2, 0), False]) == False
 
 def test_reduce_inequalities_assume():
-    assert reduce_inequalities([Le(x**2, 1), Assume(x, Q.real)]) == And(Le(-1, x), Le(x, 1))
-    assert reduce_inequalities([Le(x**2, 1)], Assume(x, Q.real)) == And(Le(-1, x), Le(x, 1))
+    assert reduce_inequalities([Le(x**2, 1), Q.real(x)]) == And(Le(-1, x), Le(x, 1))
+    assert reduce_inequalities([Le(x**2, 1)], Q.real(x)) == And(Le(-1, x), Le(x, 1))
 
 def test_reduce_inequalities_multivariate():
     assert reduce_inequalities([Ge(x**2, 1), Ge(y**2, 1)]) == \

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1,7 +1,7 @@
 from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
     sqrt, oo, LambertW, pi, I, sin, asin, Function, diff, Derivative, symbols,
     S, sympify, var, simplify, Integral, sstr, Wild, solve_linear, Interval,
-    And, Or, Lt, Gt, Assume, Q, re, im, expand, zoo)
+    And, Or, Lt, Gt, Q, re, im, expand, zoo)
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve, solve_undetermined_coeffs
@@ -341,6 +341,6 @@ def test_solve_inequalities():
     assert solve(system) == \
         And(Or(And(Lt(-sqrt(2), re(x)), Lt(re(x), -1)),
                And(Lt(1, re(x)), Lt(re(x), sqrt(2)))), Eq(im(x), 0))
-    assert solve(system, assume=Assume(x, Q.real)) == \
+    assert solve(system, assume=Q.real(x)) == \
         Or(And(Lt(-sqrt(2), x), Lt(x, -1)), And(Lt(1, x), Lt(x, sqrt(2))))
 


### PR DESCRIPTION
This PR deprecates and then removes completely the Assume syntax. The new model for this is to use only predicates and propositions.

Cf. [issue 2338](http://code.google.com/p/sympy/issues/detail?id=2338).
