### PR TITLE
Added support for Add and Mul to Basic.__contains__ (#2283)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -905,18 +905,59 @@ class Basic(AssumeMeths):
 
         return self._subs_list(subst)
 
+    def __contains__(self, subexpr):
+        """Check if ``subexpr`` is a part of ``self``. """
+        def _ncsplit(expr):
+            if expr.is_Add or expr.is_Mul:
+                cpart, ncpart = [], []
 
-    def __contains__(self, obj):
-        if self == obj:
-            return True
-        for arg in self.args:
-            try:
-                if obj in arg:
+                for arg in expr.args:
+                    if arg.is_commutative:
+                        cpart.append(arg)
+                    else:
+                        ncpart.append(arg)
+            elif expr.is_commutative:
+                cpart, ncpart = [expr], []
+            else:
+                cpart, ncpart = [], [expr]
+
+            return set(cpart), ncpart
+
+        def _contains(expr, subexpr, iterative, c, nc):
+            if expr == subexpr:
+                return True
+            elif not isinstance(expr, Basic):
+                if not hasattr(expr, '__iter__'):
+                    return False
+            elif iterative and (expr.is_Add or expr.is_Mul):
+                _c, _nc = _ncsplit(expr)
+
+                if (c & _c) == c:
+                    if not nc:
+                        return True
+                    elif len(nc) <= len(_nc):
+                        for i in xrange(len(_nc) - len(nc)):
+                            if _nc[i:i+len(nc)] == nc:
+                                return True
+
+            if isinstance(expr, Basic):
+                args = expr.args
+            else:
+                args = expr
+
+            for arg in args:
+                if _contains(arg, subexpr, iterative, c, nc):
                     return True
-            except TypeError:
-                if obj == arg:
-                    return True
-        return False
+
+            return False
+
+        expr, subexpr = self, sympify(subexpr)
+        iterative, c, nc = False, None, None
+
+        if subexpr.is_Add or subexpr.is_Mul:
+            iterative, (c, nc) = True, _ncsplit(subexpr)
+
+        return _contains(expr, subexpr, iterative, c, nc)
 
     @cacheit
     def has(self, *patterns):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -3,7 +3,7 @@ from sympy import Add, Basic, S, Symbol, Wild,  Real, Integer, Rational, I, \
     WildFunction, Poly, Function, Derivative, Number, pi, var, \
     NumberSymbol, zoo, Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, \
     radsimp, powsimp, simplify, together, separate, collect, \
-    apart, combsimp, factor, refine, cancel, invert, Tuple
+    apart, combsimp, factor, refine, cancel, invert, Tuple, gamma
 from sympy.physics.secondquant import FockState
 
 from sympy.core.cache import clear_cache
@@ -834,7 +834,8 @@ def test_contains():
     f = (x*y + 3/y)**(3 + 2)
     g = Function('g')
     h = Function('h')
-    p = Piecewise( (g, x<-1), (1, x<=1), (f, True))
+    p = Piecewise((g, x < -1), (1, x <= 1), (f, True))
+
     assert x in p
     assert y in p
     assert not z in p
@@ -844,6 +845,36 @@ def test_contains():
     assert f in p
     assert g in p
     assert not h in p
+
+    A, B, C = symbols('A,B,C', commutative=False)
+    f = x*gamma(x)*sin(x)*exp(x*y)*A*B*C*cos(x*A*B)
+
+    assert (x in f) == True
+    assert (x*y in f) == True
+    assert (x*sin(x) in f) == True
+    assert (x*sin(y) in f) == False
+    assert (x*A in f) == True
+    assert (x*A*B in f) == True
+    assert (x*A*C in f) == False
+    assert (x*A*B*C in f) == True
+    assert (x*A*C*B in f) == False
+    assert (x*sin(x)*A*B*C in f) == True
+    assert (x*sin(x)*A*C*B in f) == False
+    assert (x*sin(y)*A*B*C in f) == False
+    assert (x*gamma(x) in f) == True
+
+    f = Integral(x**2 + sin(x*y*z), (x, 0, x + y + z))
+
+    assert (x + y in f) == True
+    assert (x + z in f) == True
+    assert (y + z in f) == True
+
+    assert (x*y in f) == True
+    assert (x*z in f) == True
+    assert (y*z in f) == True
+
+    assert (2*x + y in f) == False
+    assert (2*x*y in f) == False
 
 def test_as_base_exp():
     assert x.as_base_exp() == (x, S.One)


### PR DESCRIPTION
This is implementation of algorithm from issue #2283, but without .find(), so it should be slightly faster (early exit if sub-expression was found).

Examples:

In [1]: var('A,B,C', commutative=False)
Out[1]: (A, B, C)

In [2]: f = x_gamma(x)_sin(x)_exp(x_y)_A_B_C_cot(x_A_B)

In [3]: x*gamma(x) in f
Out[3]: True

In [4]: x_gamma(x)_sin(x) in f
Out[4]: True

In [5]: x_gamma(x)_sin(y) in f
Out[5]: False

In [6]: 2_x_gamma(x)*sin(x) in f
Out[6]: False

In [7]: exp(x_y)_A*B in f
Out[7]: True

In [8]: exp(x_y)_B*A in f
Out[8]: False

Unfortunately a pair of test and doctest fail in ode module (test_1st_homogeneous_coeff_ode3). Aaron, can you look into this because it's an isolated failure so the new implementation may have discovered a bug in the module.
