### PR TITLE
Add composite option to Poly, fixing issues 1576, 1793, 1892, 2150, and 2314

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -29,7 +29,7 @@ def ratint(f, x, **flags):
     else:
         p, q = f
 
-    p, q = Poly(p, x), Poly(q, x)
+    p, q = Poly(p, x, composite=False), Poly(q, x, composite=False)
 
     coeff, p, q = p.cancel(q)
     poly, p = p.div(q)
@@ -153,7 +153,8 @@ def ratint_logpart(f, g, x, t=None):
     a, b = g, f - g.diff()*Poly(t, x)
 
     R = subresultants(a, b)
-    res = Poly(resultant(a, b), t)
+
+    res = Poly(resultant(a, b), t, composite=False)
 
     R_map, H = {}, []
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,7 +1,7 @@
 from sympy import (S, symbols, integrate, Integral, Derivative, exp, erf, oo, Symbol,
         Function, Rational, log, sin, cos, pi, E, I, Poly, LambertW, diff,
         Matrix, sympify, sqrt, atan, asin, acos, asinh, acosh, DiracDelta, Heaviside,
-        Lambda, sstr, Add, Tuple, Eq, Interval, Sum, cancel)
+        Lambda, sstr, Add, Tuple, Eq, Interval, Sum, factor, trigsimp)
 from sympy.utilities.pytest import XFAIL, skip, raises
 from sympy.physics.units import m, s
 
@@ -634,4 +634,4 @@ def test_issue_1793b():
     # 8*cos(y)**2)/(2*(3 - cos(y)))) + x**2*sin(y)/2 + 2*x*cos(y)
 
     expr = (sin(y)*x**3 + 2*cos(y)*x**2 + 12)/(x**2 + 2)
-    assert cancel(integrate(expr, x).diff(x)) == expr
+    assert trigsimp(factor(integrate(expr, x).diff(x) - expr)) == 0

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -1,4 +1,4 @@
-from sympy import symbols, S, I, atan, log, Poly
+from sympy import symbols, S, I, atan, log, Poly, sqrt
 
 from sympy.integrals.rationaltools import ratint, \
     ratint_ratpart, ratint_logpart, log_to_atan, log_to_real
@@ -84,8 +84,11 @@ def test_ratint():
         (-S(1)/6 + I*3**half/6)*log(-half + x + I*3**half/2) + \
         (-S(1)/6 - I*3**half/6)*log(-half + x - I*3**half/2)
 
+    # Issue 1892
     assert ratint(1/(x*(a+b*x)**3), x) == \
-        (3*a + 2*b*x)/(2*a**2*b**2*x**2 + 4*b*x*a**3 + 2*a**4) + (log(x) - log(x + a/b))/a**3
+        (sqrt(a**(-6))*log(x + (a - a**4*sqrt(a**(-6)))/(2*b)) +
+        (3*a + 2*b*x)/(2*a**2*b**2*x**2 + 4*b*x*a**3 + 2*a**4) -
+        sqrt(a**(-6))*log(x + (a + a**4*sqrt(a**(-6)))/(2*b)))
 
     assert ratint(x/(1 - x**2), x) == -log(x**2 - 1)/2
     assert ratint(-x/(1 - x**2), x) == log(x**2 - 1)/2
@@ -98,3 +101,8 @@ def test_ratint_logpart():
 
 def test_issue_2315():
     assert ratint(1/(x**2 + 16), x) == atan(x/4)/4
+
+def test_issue_2150():
+    assert ratint(1/(x**2 + a**2), x) == \
+        sqrt(-1/a**2)*log(x + a**2*sqrt(-1/a**2))/2 - sqrt(-1/a**2)*log(x -
+        a**2*sqrt(-1/a**2))/2

--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -209,7 +209,10 @@ def construct_domain(obj, **args):
         else:
             domain, coeffs = _construct_expression(coeffs, opt)
     else:
-        result = _construct_composite(coeffs, opt)
+        if opt.composite:
+            result = _construct_composite(coeffs, opt)
+        else:
+            result = None
 
         if result is not None:
             domain, coeffs = result

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -345,10 +345,23 @@ class Field(BooleanOption):
 
 class Greedy(BooleanOption):
     """``greedy`` option to polynomial manipulation functions. """
-
     __metaclass__ = OptionType
 
     option = 'greedy'
+
+    requires = []
+    excludes = ['domain', 'split', 'gaussian', 'extension', 'modulus', 'symmetric']
+
+class Composite(BooleanOption):
+    """ """
+
+    __metaclass__ = OptionType
+
+    option = 'composite'
+
+    @classmethod
+    def default(cls):
+        return True
 
     requires = []
     excludes = ['domain', 'split', 'gaussian', 'extension', 'modulus', 'symmetric']

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -3,7 +3,7 @@
 from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import ZZ, QQ, RR, EX
 
-from sympy import S, sqrt
+from sympy import S, sqrt, sin
 from sympy.abc import x, y
 
 def test_construct_domain():
@@ -73,3 +73,16 @@ def test_construct_domain():
 
     assert construct_domain(2) == (ZZ, ZZ(2))
     assert construct_domain(S(2)/3) == (QQ, QQ(2, 3))
+
+def test_composite_option():
+    assert construct_domain({(1,): sin(y)}, composite=False) == \
+        (EX, {(1,): EX(sin(y))})
+
+    assert construct_domain({(1,): y}, composite=False) == \
+        (EX, {(1,): EX(y)})
+
+    assert construct_domain({(1, 1): 1}, composite=False) == \
+        (ZZ, {(1, 1): 1})
+
+    assert construct_domain({(1, 0): y}, composite=False) == \
+        (EX, {(1, 0): EX(y)})


### PR DESCRIPTION
Add composite option to Poly, fixing issues 1576, 1793, 1892, 2150, and 2314

composite=False will avoid returning polynomial rings or fraction fields
over symbolic coefficients, using the EX domain instead.

In [3]: Poly(x_sin(y), x)
Out[3]: Poly(sin(y)_x, x, domain='ZZ[sin(y)]')

In [4]: Poly(x_sin(y), x, composite=False)
Out[4]: Poly(sin(y)_x, x, domain='EX')

Selective use of this in rationaltools.py fixes the above issues.  Tests
for these issues were added.  I also added tests for the composite
option.  The integral from issue 1892 was already working, but it was
untested, so I added a test.  The output is a little more complicated
than it was due to this commit, but is still correct (see the issue
page).

This commit was cherry-picked from commit
f7e24f3b43af5cc9319ee21a9b1547ef2b980ccd from my integration3 branch.

Conflicts:

```
sympy/integrals/tests/test_integrals.py
sympy/integrals/tests/test_rationaltools.py
sympy/polys/polyoptions.py
sympy/polys/polytools.py
sympy/polys/tests/test_polytools.py
```

See also the corresponding issue pages.  @mattpap should probably look at this.
