### PR TITLE
Remove as_coeff_Mul (issue 2307)

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -205,12 +205,17 @@ class Add(AssocOp):
             return coeff, notrat + self.args[1:]
         return S.Zero, self.args
 
-    @cacheit
-    def as_coeff_mul(self, *deps):
+#    @cacheit
+    def as_coeff_mul(self, *deps, **kwargs):
         # -2 + 2 * a -> -1, 2-2*a
+        args = kwargs.pop('args', True)
+        if kwargs:
+            raise TypeError("as_coeff_mul() got unexpected keyword arguments %s" % kwargs)
         if self.args[0].is_Rational and self.args[0].is_negative:
+            if not args:
+                return S.NegativeOne, -self
             return S.NegativeOne, (-self,)
-        return Expr.as_coeff_mul(self, *deps)
+        return Expr.as_coeff_mul(self, *deps, **{'args':args})
 
     def _eval_derivative(self, s):
         return Add(*[f.diff(s) for f in self.args])

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -398,7 +398,7 @@ class Basic(AssumeMeths):
                 return head(self), (1, args), number(S.One), S.One
         else:
             try:
-                coeff, expr = self.as_coeff_Mul()
+                coeff, expr = self.as_coeff_mul(args=False)
             except AttributeError:
                 return head(self), (len(self.args), self.args), number(S.One), S.One
             else:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -495,7 +495,10 @@ class Mul(AssocOp):
             return args[0], self._new_rawargs(*args[1:])
 
     @cacheit
-    def as_coeff_mul(self, *deps):
+    def as_coeff_mul(self, *deps, **kwargs):
+        args = kwargs.pop('args', True)
+        if kwargs:
+            raise TypeError("as_coeff_mul() got unexpected keyword arguments %s" % kwargs)
         if deps:
             l1 = []
             l2 = []
@@ -504,10 +507,16 @@ class Mul(AssocOp):
                     l2.append(f)
                 else:
                     l1.append(f)
+            if not args:
+                return self._new_rawargs(*l1), self._new_rawargs(*l2)
             return self._new_rawargs(*l1), tuple(l2)
         coeff, notrat = self.args[0].as_coeff_mul()
         if not coeff is S.One:
+            if not args:
+                return coeff, self._new_rawargs(*(notrat + self.args[1:]))
             return coeff, notrat + self.args[1:]
+        if not args:
+            return S.One, self
         return S.One, self.args
 
     @staticmethod
@@ -772,18 +781,6 @@ class Mul(AssocOp):
             numers.append(n)
             denoms.append(d)
         return Mul(*numers), Mul(*denoms)
-
-    def as_coeff_Mul(self):
-        """Efficiently extract the coefficient of a product. """
-        coeff, args = self.args[0], self.args[1:]
-
-        if coeff.is_Number:
-            if len(args) == 1:
-                return coeff, args[0]
-            else:
-                return coeff, self._new_rawargs(*args)
-        else:
-            return S.One, self
 
     def _eval_is_polynomial(self, syms):
         for term in self.args:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -201,12 +201,22 @@ class Number(AtomicExpr):
     def is_number(self):
         return True
 
-    def as_coeff_mul(self, *deps):
+    def as_coeff_mul(self, *deps, **kwargs):
         # a -> c * t
+        args = kwargs.pop('args', True)
+        if kwargs:
+            raise TypeError("as_coeff_mul() got unexpected keyword arguments %s" % kwargs)
+
         if self.is_Rational:
+            if not args:
+                return self, S.One
             return self, tuple()
         elif self.is_negative:
+            if not args:
+                return S.NegativeOne, -self
             return S.NegativeOne, (-self,)
+        if not args:
+            return S.One, self
         return S.One, (self,)
 
     def as_coeff_add(self, *deps):
@@ -229,10 +239,6 @@ class Number(AtomicExpr):
         """Compute GCD and cofactors of input arguments. """
         other = _sympify(other)
         return S.One, self, other
-
-    def as_coeff_Mul(self):
-        """Efficiently extract the coefficient of a product. """
-        return self, S.One
 
 class Real(Number):
     """

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -683,6 +683,8 @@ def test_as_coeff_mul():
     e = 2**(x + y)
     assert e.as_coeff_mul(y) == (1, (e,))
 
+    raises(TypeError, 'x.as_coeff_mul(notarealkwarg=False)')
+
 def test_as_coeff_exponent():
     assert (3*x**4).as_coeff_exponent(x) == (3, 4)
     assert (2*x**3).as_coeff_exponent(x) == (2, 3)
@@ -939,21 +941,21 @@ def test_issue_2061():
     assert sqrt(-1.0*x) == 1.0*I*sqrt(x)
     assert sqrt(1.0*x) == 1.0*sqrt(x)
 
-def test_as_coeff_Mul():
-    Integer(3).as_coeff_Mul() == (Integer(3), Integer(1))
-    Rational(3, 4).as_coeff_Mul() == (Rational(3, 4), Integer(1))
-    Real(5.0).as_coeff_Mul() == (Real(5.0), Integer(1))
+def test_as_coeff_mul_args_False():
+    Integer(3).as_coeff_mul(args=False) == (Integer(3), Integer(1))
+    Rational(3, 4).as_coeff_mul(args=False) == (Rational(3, 4), Integer(1))
+    Real(5.0).as_coeff_mul(args=False) == (Real(5.0), Integer(1))
 
-    (Integer(3)*x).as_coeff_Mul() == (Integer(3), x)
-    (Rational(3, 4)*x).as_coeff_Mul() == (Rational(3, 4), x)
-    (Real(5.0)*x).as_coeff_Mul() == (Real(5.0), x)
+    (Integer(3)*x).as_coeff_mul(args=False) == (Integer(3), x)
+    (Rational(3, 4)*x).as_coeff_mul(args=False) == (Rational(3, 4), x)
+    (Real(5.0)*x).as_coeff_mul(args=False) == (Real(5.0), x)
 
-    (Integer(3)*x*y).as_coeff_Mul() == (Integer(3), x*y)
-    (Rational(3, 4)*x*y).as_coeff_Mul() == (Rational(3, 4), x*y)
-    (Real(5.0)*x*y).as_coeff_Mul() == (Real(5.0), x*y)
+    (Integer(3)*x*y).as_coeff_mul(args=False) == (Integer(3), x*y)
+    (Rational(3, 4)*x*y).as_coeff_mul(args=False) == (Rational(3, 4), x*y)
+    (Real(5.0)*x*y).as_coeff_mul(args=False) == (Real(5.0), x*y)
 
-    (x).as_coeff_Mul() == (S.One, x)
-    (x*y).as_coeff_Mul() == (S.One, x*y)
+    (x).as_coeff_mul(args=False) == (S.One, x)
+    (x*y).as_coeff_mul(args=False) == (S.One, x*y)
 
 def test_expr_sorting():
     f, g = symbols('f,g', cls=Function)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -54,24 +54,24 @@ def _pi_coeff(arg, cycles=1):
     as 2.
 
     Examples:
-    >>> from sympy.functions.elementary.trigonometric import _pi_coeff as coeff
+    >>> from sympy.functions.elementary.trigonometric import _pi_coeff
     >>> from sympy import pi
     >>> from sympy.abc import x, y
-    >>> coeff(3*x*pi)
+    >>> _pi_coeff(3*x*pi)
     3*x
-    >>> coeff(11*pi/7)
+    >>> _pi_coeff(11*pi/7)
     11/7
-    >>> coeff(-11*pi/7)
+    >>> _pi_coeff(-11*pi/7)
     3/7
-    >>> coeff(4*pi)
+    >>> _pi_coeff(4*pi)
     0
-    >>> coeff(5*pi)
+    >>> _pi_coeff(5*pi)
     1
-    >>> coeff(5.0*pi)
+    >>> _pi_coeff(5.0*pi)
     1
-    >>> coeff(5.5*pi)
+    >>> _pi_coeff(5.5*pi)
     3/2
-    >>> coeff(2 + pi)
+    >>> _pi_coeff(2 + pi)
 
     """
     arg = sympify(arg)
@@ -82,7 +82,7 @@ def _pi_coeff(arg, cycles=1):
     elif arg.is_Mul:
         cx = arg.coeff(S.Pi)
         if cx:
-            c, x = cx.as_coeff_Mul() # pi is not included as coeff
+            c, x = cx.as_coeff_mul(args=False) # pi is not included as coeff
             if c.is_Real:
                 # recast exact binary fractions to Rationals
                 m = int(c*2)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -84,7 +84,12 @@ def _pi_coeff(arg, cycles=1):
         if cx:
             # We want the Number coefficient (but not pi). as_coeff_mul()
             # doesn't include Real coefficients, so do this instead.
-            x, c = cx.as_independent(Number)
+            if cx.is_Mul:
+                c, x = cx.as_two_terms()
+            else:
+                c, x = cx, S.One
+            if not c.is_Number:
+                c, x = S.One, cx
 
             if c.is_Real:
                 # recast exact binary fractions to Rationals

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,6 +1,6 @@
 from sympy.core.add import Add
 from sympy.core.mul import Mul
-from sympy.core.numbers import Rational, Real
+from sympy.core.numbers import Rational, Real, Number
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.function import Function, ArgumentIndexError
@@ -84,11 +84,7 @@ def _pi_coeff(arg, cycles=1):
         if cx:
             # We want the Number coefficient (but not pi). as_coeff_mul()
             # doesn't include Real coefficients, so do this instead.
-            args = Mul.make_args(cx)
-            if args[0].is_Number:
-                c, x = args[0], Mul(*args[1:])
-            else:
-                c, x = S.One, cx
+            x, c = cx.as_independent(Number)
 
             if c.is_Real:
                 # recast exact binary fractions to Rationals

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -82,7 +82,14 @@ def _pi_coeff(arg, cycles=1):
     elif arg.is_Mul:
         cx = arg.coeff(S.Pi)
         if cx:
-            c, x = cx.as_coeff_mul(args=False) # pi is not included as coeff
+            # We want the Number coefficient (but not pi). as_coeff_mul()
+            # doesn't include Real coefficients, so do this instead.
+            args = Mul.make_args(cx)
+            if args[0].is_Number:
+                c, x = args[0], Mul(*args[1:])
+            else:
+                c, x = S.One, cx
+
             if c.is_Real:
                 # recast exact binary fractions to Rationals
                 m = int(c*2)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -162,7 +162,7 @@ class LatexPrinter(Printer):
             return str_real
 
     def _print_Mul(self, expr):
-        coeff, tail = expr.as_coeff_Mul()
+        coeff, tail = expr.as_coeff_mul(args=False)
 
         if not coeff.is_negative:
             tex = ""


### PR DESCRIPTION
.as_coeff_Mul was converted to .as_coeff_mul(args=False).  See the issue for more information.
