### PR TITLE
1847: powsimp doesn't always pull integers from exponent

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -950,9 +950,13 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     >>> (2**(x+y)).expand(power_exp=True)
     2**x*2**y
 
-    power_base - Split powers of multiplied bases.
+    power_base - Split powers of multiplied bases if assumptions allow.
     >>> ((x*y)**z).expand(power_base=True)
+    (x*y)**z
+    >>> ((x*y)**z).expand(power_base=True, force=True)
     x**z*y**z
+    >>> ((2*y)**z).expand(power_base=True)
+    2**z*y**z
 
     log - Pull out power of an argument as a coefficient and split logs products
     into sums of logs.  Note that these only work if the arguments of the log

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -192,6 +192,19 @@ def test_expand():
     assert e.expand(power_exp=False, power_base=False, deep=False) == x*(x*(y + z))**(x*(y + z)) + y*(x*(y + z))**(x*(y + z))
     e = (x*(y+z))**z
     assert e.expand(power_base=True, mul=True, deep=True) in [x**z*(y + z)**z, (x*y + x*z)**z]
+    assert ((2*y)**z).expand() == 2**z*y**z
+    p=Symbol('p', positive=True)
+    assert sqrt(-x).expand().is_Pow
+    assert sqrt(-x).expand(force=True) == I*sqrt(x)
+    assert ((2*y*p)**z).expand() == 2**z*p**z*y**z
+    assert ((2*y*p*x)**z).expand() == 2**z*p**z*(x*y)**z
+    assert ((2*y*p*x)**z).expand(force=True) == 2**z*p**z*x**z*y**z
+    assert ((2*y*p*-pi)**z).expand() ==  2**z*pi**z*p**z*(-y)**z
+    assert ((2*y*p*-pi*x)**z).expand() == 2**z*pi**z*p**z*(-x*y)**z
+    n=Symbol('n', negative=True)
+    m=Symbol('m', negative=True)
+    assert ((-2*x*y*n)**z).expand() == 2**z*(-n)**z*(x*y)**z
+    assert ((-2*x*y*n*m)**z).expand() == 2**z*(-m)**z*(-n)**z*(-x*y)**z
 
     # Check that this isn't too slow
     x = Symbol('x')

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -205,6 +205,8 @@ def test_expand():
     m=Symbol('m', negative=True)
     assert ((-2*x*y*n)**z).expand() == 2**z*(-n)**z*(x*y)**z
     assert ((-2*x*y*n*m)**z).expand() == 2**z*(-m)**z*(-n)**z*(-x*y)**z
+    # issue 2383
+    assert sqrt(-2*x*n) == sqrt(2)*sqrt(-n)*sqrt(x)
 
     # Check that this isn't too slow
     x = Symbol('x')

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -201,6 +201,9 @@ def test_log_expand():
     assert log(x**log(x**2)).expand(deep=False) == log(x)*log(x**2)
     assert log(x**log(x**2)).expand() == 2*log(x)**2
     assert (log(x*(y+z))*(x+y)),expand(mul=True, log=True) == y*log(x) + y*log(y + z) + z*log(x) + z*log(y + z)
+    x, y = symbols('x,y')
+    assert log(x*y).expand(force=True) == log(x) + log(y)
+    assert log(x**y).expand(force=True) == y*log(x)
 
 def test_log_simplify():
     x = Symbol("x", positive=True)

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -478,10 +478,9 @@ def test_polygon():
     assert t1.incenter == Point(ic, ic)
 
     # Inradius
-    assert t1.inradius == 5 - 5*2**(S(1)/2)/2
-    assert t2.inradius == 5*3**(S(1)/2)/6
-    t3_inradius = (2*x1**2*Abs(x1) - 2**(S(1)/2)*x1**2*Abs(x1))/(2*x1**2)
-    assert simplify((t3.inradius - t3_inradius)) == 0
+    assert t1.inradius == 5 - 5*sqrt(2)/2
+    assert t2.inradius == 5*sqrt(3)/6
+    assert t3.inradius == x1**2/((2 + sqrt(2))*Abs(x1))
 
     # Medians + Centroid
     m = t1.medians

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -384,7 +384,7 @@ def heurisch(f, x, **kwargs):
 
         h = F - derivation(candidate) / denom
 
-        numer = h.as_numer_denom()[0].expand()
+        numer = h.as_numer_denom()[0].expand(force=True)
 
         equations = {}
 
@@ -421,7 +421,7 @@ def heurisch(f, x, **kwargs):
                 antideriv = antideriv.subs(coeff, S.Zero)
 
         antideriv = antideriv.subs(rev_mapping)
-        antideriv = cancel(antideriv).expand()
+        antideriv = cancel(antideriv).expand(force=True)
 
         if antideriv.is_Add:
             antideriv = antideriv.as_independent(x)[1]

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1285,10 +1285,12 @@ def powsimp(expr, deep=False, combine='all', force=False):
                                 continue
                         nc_part.append(term)
 
-            # Pull out numerical coefficients from exponent
+            # Pull out numerical coefficients from exponent if assumptions allow
             # e.g., 2**(2*x) => 4**x
             for i in xrange(len(c_powers)):
                 b, e = c_powers[i]
+                if not (b.is_nonnegative or e.is_integer or force):
+                    continue
                 exp_c, exp_t = e.as_coeff_mul()
                 if not (exp_c is S.One) and exp_t:
                     c_powers[i] = [Pow(b, exp_c), e._new_rawargs(*exp_t)]

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -272,6 +272,15 @@ def test_powsimp():
     assert powsimp((1/x)**log(2)/x) == (1/x)**(1 + log(2))
     assert powsimp((1/p)**log(2)/p) == p**(-1 - log(2))
 
+    # coefficient of exponent can only be simplified for positive bases
+    assert powsimp(2**(2*x)) == 4**x
+    assert powsimp((-1)**(2*x)) == (-1)**(2*x)
+    i = symbols('i', integer=True)
+    assert powsimp((-1)**(2*i)) == 1
+    assert powsimp((-1)**(-x)) != (-1)**x  # could be 1/((-1)**x), but is not
+    # force=True overrides assumptions
+    assert powsimp((-1)**(2*x), force=True) == 1
+
 def test_powsimp_nc():
     x, y, z = symbols('x,y,z')
     A, B, C = symbols('A B C', commutative=False)


### PR DESCRIPTION
```
powsimp((-2)**(2*x)) should not become 4**x unless x is an integer but
powsimp(2**(2*x)) is always 4**x; if the base is non-negative or the
exponent is an integer then the Integer can be combined with the
base.
```
