### PR TITLE
2361: Add.flatten watches for unevaluated Mul

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -75,6 +75,11 @@ class Add(AssocOp):
 
                 # 3*...
                 if c.is_Number:
+                    # unevaluated 2-arg Mul
+                    if len(o.args) == 2 and o.args[1].is_Add and o.args[1].is_commutative:
+                        seq.extend([c*a for a in o.args[1].args])
+                        continue
+
                     if c is S.One:
                         s = o
                     else:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1168,3 +1168,11 @@ def test_Add_primitive():
 
     (2*x/3 + 4*y/9).primitive() == (2/9, 3*x + 2*y)
     (2*x/3 + 4.1*y).primitive() == (1, 2*x/3 + 4.1*y)
+
+def test_issue2361():
+    u = Mul(2, (1 + x), evaluate=False)
+    assert 2 + u == 4 + 2*x
+    n = Symbol('n', commutative=False)
+    u = 2*(1 + n)
+    assert u.is_Mul
+    assert (2 + u).args == (S(2), u)


### PR DESCRIPTION
```
If the unevaluated Mul is not intercepted, it may end up being
distributed later when the terms are rebuilt resulting in something
like 2 + 2 + 2*x rather than 4 + 2*x.
```
