### PR TITLE
2380: fix as_independent for non-symbol type args

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -439,10 +439,13 @@ def test_as_independent():
     assert (n1*n2*n1).as_independent(n2) == (n1, n2*n1)
     assert (n1*n2*n1).as_independent(n1) == (1, n1*n2*n1)
 
-    assert (3*x).as_independent(x, as_Add=1) == (0, 3*x)
-    assert (3*x).as_independent(x, as_Add=0) == (3, x)
-    assert (3+x).as_independent(x, as_Add=1) == (3, x)
-    assert (3+x).as_independent(x, as_Add=0) == (1, 3 + x)
+    assert (3*x).as_independent(x, as_Add=True) == (0, 3*x)
+    assert (3*x).as_independent(x, as_Add=False) == (3, x)
+    assert (3+x).as_independent(x, as_Add=True) == (3, x)
+    assert (3+x).as_independent(x, as_Add=False) == (1, 3 + x)
+
+    # issue 2380
+    assert (3*x).as_independent(Symbol) == (3, x)
 
 def test_subs_dict():
     a,b,c,d,e = symbols('a,b,c,d,e')


### PR DESCRIPTION
```
(3*x).as_independent(Symbol) now gives (3, x)

Sifting was done on the basis of commutivity, but things like
Symbol don't return a True or False when requesting that attribute so
getattr is now used as the keyfunc for sift (in case there are things
that don't have that attribute) and anything that gives an answer that
is not False is considered True, e.g. Symbol.is_commutative returns
neither True nor False, but <member 'is_commutative' of 'Symbol' objects>;
such things are mapped to True through the use of bool().

A general cleanup of the function was also performed.
```
