### PR TITLE
2307: remove as_coeff_Mul

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -377,30 +377,47 @@ class Basic(AssumeMeths):
                 return head(self), (1, args), number(S.One), S.One
         else:
             try:
-                coeff, expr = self.as_coeff_Mul()
+                coeff, args = self.as_coeff_mul()
             except AttributeError:
                 return head(self), (len(self.args), self.args), number(S.One), S.One
             else:
-                if expr.is_Pow:
-                    expr, exp = expr.args
-                else:
-                    expr, exp = expr, S.One
 
-                if expr.is_Atom:
-                    if expr.is_Symbol:
-                        args = (str(expr),)
+                # include any Real
+                if args:
+                    if args[0].is_Number:
+                        coeff *= args[0]
+                        args = args[1:]
+                args = args or (S.One,)
+
+                if len(args) == 1:
+                    expr = args[0]
+
+                    if expr.is_Pow:
+                        expr, exp = expr.args
+                    elif expr.is_Add and coeff is S.NegativeOne:
+                        # put back the sign removed from the Add
+                        coeff = S.One
+                        expr, exp = -expr, S.One
                     else:
-                        args = (expr,)
-                else:
-                    if expr.is_Add:
-                        args = expr.as_ordered_terms(order=order)
+                        expr, exp = expr, S.One
+
+                    if expr.is_Atom:
+                        if expr.is_Symbol:
+                            args = (str(expr),)
+                        else:
+                            args = (expr,)
                     else:
-                        args = expr.args
+                        if expr.is_Add:
+                            args = expr.as_ordered_terms(order=order)
+                        else:
+                            args = expr.args
 
-                    args = rmap(args)
+                        args = rmap(args)
 
-                    if expr.is_Mul:
-                        args = sorted(args)
+                else:
+                    expr = self._new_rawargs(*args)
+                    exp = S.One
+                    args = sorted(rmap(args))
 
                 args = (len(args), args)
                 exp = exp.as_tuple_tree(order=order)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -283,28 +283,27 @@ class Expr(Basic, EvalfMixin):
         gens, terms = set([]), []
 
         for term in Add.make_args(self):
-            coeff, _term = term.as_coeff_Mul()
+            coeff, mul = term.as_coeff_mul()
 
             coeff = complex(coeff)
             cpart, ncpart = {}, []
 
-            if _term is not S.One:
-                for factor in Mul.make_args(_term):
-                    if factor.is_number:
-                        try:
-                            coeff *= complex(factor)
-                        except ValueError:
-                            pass
-                        else:
-                            continue
-
-                    if factor.is_commutative:
-                        base, exp = decompose_power(factor)
-
-                        cpart[base] = exp
-                        gens.add(base)
+            for factor in mul:
+                if factor.is_number:
+                    try:
+                        coeff *= complex(factor)
+                    except ValueError:
+                        pass
                     else:
-                        ncpart.append(factor)
+                        continue
+
+                if factor.is_commutative:
+                    base, exp = decompose_power(factor)
+
+                    cpart[base] = exp
+                    gens.add(base)
+                else:
+                    ncpart.append(factor)
 
             coeff = coeff.real, coeff.imag
             ncpart = tuple(ncpart)
@@ -1638,10 +1637,6 @@ class Expr(Basic, EvalfMixin):
         if not c.has(x):
             return c, e
         raise ValueError("cannot compute leadterm(%s, %s), got c=%s" % (self, x, c))
-
-    def as_coeff_Mul(self):
-        """Efficiently extract the coefficient of a product. """
-        return S.One, self
 
     ###################################################################################
     ##################### DERIVATIVE, INTEGRAL, FUNCTIONAL METHODS ####################

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -772,18 +772,6 @@ class Mul(AssocOp):
             denoms.append(d)
         return Mul(*numers), Mul(*denoms)
 
-    def as_coeff_Mul(self):
-        """Efficiently extract the coefficient of a product. """
-        coeff, args = self.args[0], self.args[1:]
-
-        if coeff.is_Number:
-            if len(args) == 1:
-                return coeff, args[0]
-            else:
-                return coeff, self._new_rawargs(*args)
-        else:
-            return S.One, self
-
     def _eval_is_polynomial(self, syms):
         for term in self.args:
             if not term._eval_is_polynomial(syms):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -217,10 +217,6 @@ class Number(AtomicExpr):
         other = _sympify(other)
         return S.One, self, other
 
-    def as_coeff_Mul(self):
-        """Efficiently extract the coefficient of a product. """
-        return self, S.One
-
 class Real(Number):
     """
     Represents a floating point number. It is capable of representing

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -939,22 +939,6 @@ def test_issue_2061():
     assert sqrt(-1.0*x) == 1.0*I*sqrt(x)
     assert sqrt(1.0*x) == 1.0*sqrt(x)
 
-def test_as_coeff_Mul():
-    Integer(3).as_coeff_Mul() == (Integer(3), Integer(1))
-    Rational(3, 4).as_coeff_Mul() == (Rational(3, 4), Integer(1))
-    Real(5.0).as_coeff_Mul() == (Real(5.0), Integer(1))
-
-    (Integer(3)*x).as_coeff_Mul() == (Integer(3), x)
-    (Rational(3, 4)*x).as_coeff_Mul() == (Rational(3, 4), x)
-    (Real(5.0)*x).as_coeff_Mul() == (Real(5.0), x)
-
-    (Integer(3)*x*y).as_coeff_Mul() == (Integer(3), x*y)
-    (Rational(3, 4)*x*y).as_coeff_Mul() == (Rational(3, 4), x*y)
-    (Real(5.0)*x*y).as_coeff_Mul() == (Real(5.0), x*y)
-
-    (x).as_coeff_Mul() == (S.One, x)
-    (x*y).as_coeff_Mul() == (S.One, x*y)
-
 def test_expr_sorting():
     f, g = symbols('f,g', cls=Function)
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -82,7 +82,14 @@ def _pi_coeff(arg, cycles=1):
     elif arg.is_Mul:
         cx = arg.coeff(S.Pi)
         if cx:
-            c, x = cx.as_coeff_Mul() # pi is not included as coeff
+            # split cx into Number, c, and the rest, x
+            if cx.is_Mul:
+                c, x = cx.as_two_terms()
+            else:
+                c, x = cx, S.One
+            if not c.is_Number:
+                c, x = S.One, cx
+
             if c.is_Real:
                 # recast exact binary fractions to Rationals
                 m = int(c*2)

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -422,8 +422,8 @@ def test_ellipse_random_point():
     for ind in xrange(0, 5):
         r = e3.random_point()
         # substitution should give zero*y1**2
-        assert e3.equation(rx, ry).subs(zip((rx, ry), r.args)
-                                        ).n(3).as_coeff_Mul()[0] < 1e-10
+        ans = e3.equation(rx, ry).subs(zip((rx, ry), r.args)).n(3)
+        assert not ans or ans.as_two_terms()[0] < 1e-10
 
 def test_polygon():
     t = Triangle(Point(0, 0), Point(2, 0), Point(3, 3))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -162,7 +162,9 @@ class LatexPrinter(Printer):
             return str_real
 
     def _print_Mul(self, expr):
-        coeff, tail = expr.as_coeff_Mul()
+        coeff, tail = expr.as_two_terms()
+        if not coeff.is_Number:
+            coeff, tail = S.One, expr
 
         if not coeff.is_negative:
             tex = ""


### PR DESCRIPTION
```
If these are ever really deemed necessary the following could
be used:

    >>> def as_coeff0_mul(eq):
    ...  if eq.is_Mul:
    ...    c, x = eq.as_two_terms()
    ...    if c.is_Number:
    ...      return c, x
    ...  elif eq.is_Number:
    ...    return eq, S.One
    ...  return S.One, eq
    ...
    >>> def as_coeff0_add(eq):
    ...  if eq.is_Add:
    ...    c, x = eq.as_two_terms()
    ...    if c.is_Number:
    ...      return c, x
    ...  elif eq.is_Number:
    ...    return eq, S.Zero
    ...  return S.Zero, eq
```

If more than just Numbers are to be collected then all arguments have to be searched since a number (as opposed to Number) might appear anywhere, e.g.

```
>>> 3*x*(1+sqrt(2))
3*x*(1 + 2**(1/2))
```

The number that is the Add appears as the last argument above. The find the number portion of an expression, e.as_independent(Symbol) could be used which, for the above, gives (3 + 3_2_*(1/2), x).
