### PR TITLE
Move @wraps and @deprecated to the core

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -7,6 +7,7 @@ CACHE = []  # [] of
             #    (item, {} or tuple of {})
 
 from sympy.core.logic import fuzzy_bool
+from sympy.core.decorators import wraps
 
 def print_cache():
     """print cache content"""
@@ -72,6 +73,7 @@ def __cacheit(func):
     func._cache_it_cache = func_cache_it_cache = {}
     CACHE.append((func, func_cache_it_cache))
 
+    @wraps(func)
     def wrapper(*args, **kw_args):
         """
         Assemble the args and kw_args to compute the hash.
@@ -100,16 +102,13 @@ def __cacheit(func):
             pass
         func_cache_it_cache[k] = r = func(*args, **kw_args)
         return r
-
-    wrapper.__doc__ = func.__doc__
-    wrapper.__name__ = func.__name__
-
     return wrapper
 
 def __cacheit_debug(func):
     """cacheit + code to check cache consistency"""
     cfunc = __cacheit(func)
 
+    @wraps(func)
     def wrapper(*args, **kw_args):
         # always call function itself and compare it with cached version
         r1 = func (*args, **kw_args)
@@ -130,10 +129,6 @@ def __cacheit_debug(func):
         assert r1 == r2
 
         return r1
-
-    wrapper.__doc__ = func.__doc__
-    wrapper.__name__ = func.__name__
-
     return wrapper
 
 class MemoizerArg:
@@ -244,6 +239,7 @@ class Memoizer:
         value_cache = {}
         CACHE.append((func, (cache, value_cache)))
 
+        @wraps(func)
         def wrapper(*args, **kw_args):
             kw_items = tuple(kw_args.items())
             try:
@@ -280,6 +276,7 @@ class Memoizer_nocache(Memoizer):
     def __call__(self, func):
         # XXX I would be happy just to return func, but we need to provide
         # argument convertion, and it is really needed for e.g. Real("0.5")
+        @wraps(func)
         def wrapper(*args, **kw_args):
             kw_items = tuple(kw_args.items())
             self.fix_allowed_types()

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -7,15 +7,18 @@ dependencies, so that they can be easily imported anywhere in sympy/core.
 from sympify import SympifyError, sympify
 import warnings
 
-def wraps(old_func):
-    """Copy private data from ``old_func`` to ``new_func``. """
-    def decorate(new_func):
-        new_func.__dict__.update(old_func.__dict__)
-        new_func.__module__ = old_func.__module__
-        new_func.__name__   = old_func.__name__
-        new_func.__doc__    = old_func.__doc__
-        return new_func
-    return decorate
+try:
+    from functools import wraps
+except ImportError:
+    def wraps(old_func):
+        """Copy private data from ``old_func`` to ``new_func``. """
+        def decorate(new_func):
+            new_func.__dict__.update(old_func.__dict__)
+            new_func.__module__ = old_func.__module__
+            new_func.__name__   = old_func.__name__
+            new_func.__doc__    = old_func.__doc__
+            return new_func
+        return decorate
 
 def deprecated(func):
     """This is a decorator which can be used to mark functions

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -4,8 +4,31 @@ SymPy core decorators.
 The purpose of this module is to expose decorators without any other
 dependencies, so that they can be easily imported anywhere in sympy/core.
 """
-
 from sympify import SympifyError, sympify
+import warnings
+
+def wraps(old_func):
+    """Copy private data from ``old_func`` to ``new_func``. """
+    def decorate(new_func):
+        new_func.__dict__.update(old_func.__dict__)
+        new_func.__module__ = old_func.__module__
+        new_func.__name__   = old_func.__name__
+        new_func.__doc__    = old_func.__doc__
+        return new_func
+    return decorate
+
+def deprecated(func):
+    """This is a decorator which can be used to mark functions
+    as deprecated. It will result in a warning being emitted
+    when the function is used."""
+    def new_func(*args, **kwargs):
+        warnings.warn("Call to deprecated function %s." % func.__name__,
+                      category=DeprecationWarning)
+        return func(*args, **kwargs)
+    new_func.__name__ = func.__name__
+    new_func.__doc__ = func.__doc__
+    new_func.__dict__.update(func.__dict__)
+    return new_func
 
 def _sympifyit(arg, retval=None):
     """decorator to smartly _sympify function arguments

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -24,13 +24,11 @@ def deprecated(func):
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted
     when the function is used."""
+    @wraps(func)
     def new_func(*args, **kwargs):
         warnings.warn("Call to deprecated function %s." % func.__name__,
                       category=DeprecationWarning)
         return func(*args, **kwargs)
-    new_func.__name__ = func.__name__
-    new_func.__doc__ = func.__doc__
-    new_func.__dict__.update(func.__dict__)
     return new_func
 
 def _sympifyit(arg, retval=None):
@@ -66,10 +64,12 @@ def __sympifyit(func, arg, retval=None):
     assert func.func_code.co_varnames[1] == arg
 
     if retval is None:
+        @wraps(func)
         def __sympifyit_wrapper(a, b):
             return func(a, sympify(b, strict=True))
 
     else:
+        @wraps(func)
         def __sympifyit_wrapper(a, b):
             try:
                 return func(a, sympify(b, strict=True))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -29,7 +29,6 @@ Example:
     (x,)
 
 """
-
 from core import BasicMeta, C
 from basic import Basic
 from singleton import S
@@ -38,7 +37,7 @@ from expr import Expr, AtomicExpr
 from cache import cacheit
 #from numbers import Rational, Integer
 #from symbol import Symbol, Dummy
-from sympy.utilities.decorator import deprecated
+from sympy.core.decorators import deprecated
 from sympy.utilities import all, any
 
 from sympy import mpmath

--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -3,14 +3,7 @@ Provides functionality for multidimensional usage of scalar-functions.
 
 Read the vectorize docstring for more details.
 """
-try:
-    # functools is not available in Python 2.4
-    import functools
-except ImportError:
-    has_functools = False
-else:
-    has_functools = True
-
+from sympy.core.decorators import wraps
 
 def apply_on_element(f, args, kwargs, n):
     """
@@ -61,8 +54,6 @@ def structure_copy(structure):
         return structure.copy()
     return iter_copy(structure)
 
-#FIXME: Is it possible to use the decorator function from the decorator module
-#       to make help(vectorized_funciton) give the original signature?
 class vectorize:
     """
     Generalizes a function taking scalars to accept multidimensional arguments.
@@ -102,6 +93,7 @@ class vectorize:
         Returns a wrapper for the one-dimensional function that can handle
         multidimensional arguments.
         """
+        @wraps(f)
         def wrapper(*args, **kwargs):
             # Get arguments that should be treated multidimensional
             if self.mdargs:
@@ -134,8 +126,4 @@ class vectorize:
                     result = apply_on_element(wrapper, args, kwargs, n)
                     return result
             return f(*args, **kwargs)
-        wrapper.__doc__ = f.__doc__
-        wrapper.__name__ = f.__name__
-        if has_functools:
-            wrapper = functools.update_wrapper(wrapper, f)
         return wrapper

--- a/sympy/functions/elementary/tests/test_interface.py
+++ b/sympy/functions/elementary/tests/test_interface.py
@@ -1,9 +1,7 @@
 # This test file tests the SymPy function interface, that people use to create
 # their own new functions. It should be as easy as possible.
-
 from sympy import Function, sympify, sin, cos, limit, tanh
 from sympy.abc import x
-from sympy.utilities.decorator import deprecated
 
 def test_function_series1():
     """Create our new "sin" function."""

--- a/sympy/utilities/__init__.py
+++ b/sympy/utilities/__init__.py
@@ -8,7 +8,7 @@ from iterables import (iff, flatten, group, take, subsets,
 from lambdify import lambdify
 from source import source
 
-from decorator import threaded, xthreaded, deprecated, wraps
+from decorator import threaded, xthreaded
 
 from cythonutils import cythonized
 from timeutils import timed

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -5,7 +5,8 @@ def threaded_factory(func, use_add):
     from sympy.core import sympify, Add
     from sympy.matrices import Matrix
 
-    def threaded_decorator(expr, *args, **kwargs):
+    @wraps(func)
+    def threaded_func(expr, *args, **kwargs):
         if isinstance(expr, Matrix):
             return expr.applyfunc(lambda f: func(f, *args, **kwargs))
         elif hasattr(expr, '__iter__'):
@@ -21,7 +22,7 @@ def threaded_factory(func, use_add):
             else:
                 return func(expr, *args, **kwargs)
 
-    return threaded_decorator
+    return threaded_func
 
 def threaded(func):
     """Apply ``func`` to sub--elements of an object, including :class:`Add`.
@@ -40,7 +41,7 @@ def threaded(func):
           def function(expr, *args, **kwargs):
 
     """
-    return wraps(func, threaded_factory(func, True))
+    return threaded_factory(func, True)
 
 def xthreaded(func):
     """Apply ``func`` to sub--elements of an object, excluding :class:`Add`.
@@ -59,7 +60,7 @@ def xthreaded(func):
           def function(expr, *args, **kwargs):
 
     """
-    return wraps(func, threaded_factory(func, False))
+    return threaded_factory(func, False)
 
 def deprecated(func):
     """This is a decorator which can be used to mark functions
@@ -74,12 +75,12 @@ def deprecated(func):
     new_func.__dict__.update(func.__dict__)
     return new_func
 
-def wraps(old_func, new_func):
+def wraps(old_func):
     """Copy private data from ``old_func`` to ``new_func``. """
-    new_func.__dict__.update(old_func.__dict__)
-
-    new_func.__module__ = old_func.__module__
-    new_func.__name__   = old_func.__name__
-    new_func.__doc__    = old_func.__doc__
-
-    return new_func
+    def decorate(new_func):
+        new_func.__dict__.update(old_func.__dict__)
+        new_func.__module__ = old_func.__module__
+        new_func.__name__   = old_func.__name__
+        new_func.__doc__    = old_func.__doc__
+        return new_func
+    return decorate

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -1,4 +1,5 @@
-import warnings
+from sympy.core.decorators import wraps
+
 
 def threaded_factory(func, use_add):
     """A factory for ``threaded`` decorators. """
@@ -61,26 +62,3 @@ def xthreaded(func):
 
     """
     return threaded_factory(func, False)
-
-def deprecated(func):
-    """This is a decorator which can be used to mark functions
-    as deprecated. It will result in a warning being emitted
-    when the function is used."""
-    def new_func(*args, **kwargs):
-        warnings.warn("Call to deprecated function %s." % func.__name__,
-                      category=DeprecationWarning)
-        return func(*args, **kwargs)
-    new_func.__name__ = func.__name__
-    new_func.__doc__ = func.__doc__
-    new_func.__dict__.update(func.__dict__)
-    return new_func
-
-def wraps(old_func):
-    """Copy private data from ``old_func`` to ``new_func``. """
-    def decorate(new_func):
-        new_func.__dict__.update(old_func.__dict__)
-        new_func.__module__ = old_func.__module__
-        new_func.__name__   = old_func.__name__
-        new_func.__doc__    = old_func.__doc__
-        return new_func
-    return decorate

--- a/sympy/utilities/tests/test_decorator.py
+++ b/sympy/utilities/tests/test_decorator.py
@@ -1,8 +1,9 @@
-from sympy.utilities.decorator import threaded, xthreaded, wraps
+from sympy.utilities.decorator import threaded, xthreaded
 
 from sympy import symbols, Eq, Matrix
 
 from sympy.abc import x, y
+from sympy.core.decorators import wraps
 
 def test_threaded():
     @threaded

--- a/sympy/utilities/tests/test_decorator.py
+++ b/sympy/utilities/tests/test_decorator.py
@@ -40,7 +40,7 @@ def test_wraps():
     my_func.is_my_func = True
 
     new_my_func = threaded(my_func)
-    new_my_func = wraps(my_func, new_my_func)
+    new_my_func = wraps(my_func)(new_my_func)
 
     assert new_my_func.__name__ == 'my_func'
     assert new_my_func.__doc__ == 'My function. '


### PR DESCRIPTION
This makes `@wraps` compatible with `functools.wraps`, moves it and `@deprecated` to the core and uses it where it's needed. Fixes [issue 1998](http://code.google.com/p/sympy/issues/detail?id=1998) and [issue 2379](http://code.google.com/p/sympy/issues/detail?id=2379).
