### PR TITLE
Bessel functions, and randomised testing

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -31,13 +31,16 @@ parser.add_option("--tb", dest="tb",
         metavar="TBSTYLE", default="short")
 parser.add_option("--random", action="store_false", dest="sort", default=True,
         help="Run tests in random order instead of sorting them")
+parser.add_option("--seed", dest="seed", type="int",
+        help="use this seed for randomised tests",
+        metavar="SEED")
 parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = '"options" are any of the options above.  "tests" are 0 or more glob strings of tests to run.  If no test arguments are given, all tests will be run.'
 options, args = parser.parse_args()
 
 ok = test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
-    "sort": options.sort})
+    "sort": options.sort, "seed": options.seed})
 if ok:
     sys.exit(0)
 else:

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -198,3 +198,14 @@ polygamma
 uppergamma
 ----------
 .. autoclass:: sympy.functions.special.gamma_functions.uppergamma
+
+Bessel Type Functions
+---------------------
+.. autoclass:: sympy.functions.special.bessel.besselj
+.. autoclass:: sympy.functions.special.bessel.bessely
+.. autoclass:: sympy.functions.special.bessel.besseli
+.. autoclass:: sympy.functions.special.bessel.besselk
+.. autoclass:: sympy.functions.special.bessel.hankel1
+.. autoclass:: sympy.functions.special.bessel.hankel2
+.. autoclass:: sympy.functions.special.bessel.jn
+.. autoclass:: sympy.functions.special.bessel.yn

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -210,12 +210,9 @@ class Add(AssocOp):
             return coeff, notrat + self.args[1:]
         return S.Zero, self.args
 
-    @cacheit
-    def as_coeff_mul(self, *deps):
-        # -2 + 2 * a -> -1, 2-2*a
-        if self.args[0].is_Rational and self.args[0].is_negative:
-            return S.NegativeOne, (-self,)
-        return Expr.as_coeff_mul(self, *deps)
+    # Note, we intentionally do not implement Add.as_coeff_mul().  Rather, we
+    # let Expr.as_coeff_mul() just always return (S.One, self) for an Add.  See
+    # issue 2425.
 
     def _eval_derivative(self, s):
         return Add(*[f.diff(s) for f in self.args])

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -237,7 +237,7 @@ class Pow(Expr):
         return Pow(self.base._eval_subs(old, new), self.exp._eval_subs(old, new))
 
     def as_base_exp(self):
-        if self.base.is_Rational and self.base.p==1:
+        if self.base.is_Rational and self.base.p==1 and self.base != S.Infinity:
             return 1/self.base, -self.exp
         return self.base, self.exp
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -237,7 +237,7 @@ class Pow(Expr):
         return Pow(self.base._eval_subs(old, new), self.exp._eval_subs(old, new))
 
     def as_base_exp(self):
-        if self.base.is_Rational and self.base.p==1 and self.base != S.Infinity:
+        if self.base.is_Rational and self.base.p==1 and self.base is not S.Infinity:
             return 1/self.base, -self.exp
         return self.base, self.exp
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1118,22 +1118,23 @@ def test_suppressed_evaluation():
 
 
 def test_Add_as_coeff_mul():
-    assert (x+1).as_coeff_mul()   == ( 1, (x+1,) )
-    assert (x+2).as_coeff_mul()   == ( 1, (x+2,) )
-    assert (x+3).as_coeff_mul()   == ( 1, (x+3,) )
+    # Issue 2425.  These should all be (1, self)
+    assert (x + 1).as_coeff_mul()   == (1, (x + 1,) )
+    assert (x + 2).as_coeff_mul()   == (1, (x + 2,) )
+    assert (x + 3).as_coeff_mul()   == (1, (x + 3,) )
 
-    assert (x-1).as_coeff_mul()   == (-1, (1-x,) )
-    assert (x-2).as_coeff_mul()   == (-1, (2-x,) )
-    assert (x-3).as_coeff_mul()   == (-1, (3-x,) )
+    assert (x - 1).as_coeff_mul()   == (1, (x - 1,) )
+    assert (x - 2).as_coeff_mul()   == (1, (x - 2,) )
+    assert (x - 3).as_coeff_mul()   == (1, (x - 3,) )
 
     n = Symbol('n', integer=True)
-    assert (n+1).as_coeff_mul()   == ( 1, (n+1,) )
-    assert (n+2).as_coeff_mul()   == ( 1, (n+2,) )
-    assert (n+3).as_coeff_mul()   == ( 1, (n+3,) )
+    assert (n + 1).as_coeff_mul()   == (1, (n + 1,) )
+    assert (n + 2).as_coeff_mul()   == (1, (n + 2,) )
+    assert (n + 3).as_coeff_mul()   == (1, (n + 3,) )
 
-    assert (n-1).as_coeff_mul()   == (-1, (1-n,) )
-    assert (n-2).as_coeff_mul()   == (-1, (2-n,) )
-    assert (n-3).as_coeff_mul()   == (-1, (3-n,) )
+    assert (n - 1).as_coeff_mul()   == (1, (n - 1,) )
+    assert (n - 2).as_coeff_mul()   == (1, (n - 2,) )
+    assert (n - 3).as_coeff_mul()   == (1, (n - 3,) )
 
 def test_Pow_as_coeff_mul_doesnt_expand():
     assert exp(x + y).as_coeff_mul() == (1, (exp(x + y),))

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -156,6 +156,11 @@ def test_zero():
     assert 0**x != 0
     assert 0**(2*x) == 0**x
     assert (0**(2 - x)).as_base_exp() == (0, 2 - x)
-    assert 0**(x - 2) == S.Infinity**(2 - x)
+    assert 0**(x - 2) != S.Infinity**(2 - x)
     assert 0**(2*x*y) == 0**(x*y)
     assert 0**(-2*x*y) == S.Infinity**(x*y)
+
+def test_pow_as_base_exp():
+    x = Symbol('x')
+    assert (S.Infinity**(2 - x)).as_base_exp() == (S.Infinity, 2 - x)
+    assert (S.Infinity**(x - 2)).as_base_exp() == (S.Infinity, x - 2)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -286,7 +286,7 @@ def test_evalf_default():
     assert type(re(sin(I + 1.0))) == Float
     assert type(im(sin(I + 1.0))) == Float
     assert type(sin(4)) == sin
-    assert type(polygamma(2,4.0)) == Float
+    assert type(polygamma(2.0,4.0)) == Float
     assert type(sin(Rational(1,4))) == sin
 
 def test_issue2300():
@@ -310,3 +310,8 @@ def test_issue2300():
                 noraise = eq.diff(*v)
             else:
                 raises(ValueError, 'eq.diff(*v)')
+
+def test_derivative_numerically():
+    from random import random
+    z0 = random() + I*random()
+    assert abs(Derivative(sin(x), x).doit_numerically(z0) - cos(z0)) < 1e-15

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -35,6 +35,7 @@ from special.spherical_harmonics import Ylm, Zlm
 from special.tensor_functions import Dij, Eijk
 from special.delta_functions import DiracDelta, Heaviside
 from special.bsplines import bspline_basis, bspline_basis_set
-from special.bessel import jn, yn, jn_zeros
+from special.bessel import besselj, bessely, besseli, besselk, hankel1, \
+                           hankel2, jn, yn, jn_zeros
 
 ln = log

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -1,96 +1,374 @@
-from math import pi
+"""Bessel type functions"""
 
+from sympy import S, pi
 from sympy.core import sympify
+from sympy.core.function import Function, ArgumentIndexError
 from sympy.functions.elementary.trigonometric import sin, cos
+from sympy.functions.elementary.miscellaneous import sqrt
 
-def fn(n, z):
+# TODO
+# o Airy Ai and Bi functions
+# o Scorer functions G1 and G2
+# o Asymptotic expansions
+#   These are possible, e.g. for fixed order, but since the bessel type
+#   functions are oscillatory they are not actually tractable at
+#   infinity, so this is not particularly useful right now.
+# o Series Expansions for functions of the second kind about zero
+# o Nicer series expansions.
+# o More rewriting.
+
+class BesselBase(Function):
     """
-    Coefficients for the spherical Bessel functions.
+    Abstract base class for bessel-type functions.
 
-    Those are only needed in the jn() function.
+    This class is meant to reduce code duplication.
+    All bessel type functions can 1) be differentiated, and the derivatives
+    expressed in terms of similar functions and 2) be rewritten in terms
+    of other bessel-type functions.
 
-    The coefficients are calculated from:
+    Here "bessel-type functions" are assumed to have one complex parameter.
 
-    fn(0, z) = 1/z
-    fn(1, z) = 1/z**2
-    fn(n-1, z) + fn(n+1, z) == (2*n+1)/z * fn(n, z)
+    To use this base class, define class attributes _a and _b such that
+        2F_n' = -_a*F_{n+1} b*F_{n-1}.
+    """
+
+    nargs = 2
+
+    @property
+    def order(self):
+        """ The order of the bessel-type function. """
+        return self.args[0]
+
+    @property
+    def argument(self):
+        """ The argument of the bessel-type function. """
+        return self.args[1]
+
+    def fdiff(self, argindex=2):
+        if argindex != 2:
+            raise ArgumentIndexError(self, argindex)
+        return self._b/2 * self.__class__(self.order - 1, self.argument) \
+             - self._a/2 * self.__class__(self.order + 1, self.argument) \
+
+class besselj(BesselBase):
+    r"""
+    Bessel function of the first kind.
+
+    The Bessel J function of order :math:`\nu` is defined to be the function
+    satisfying Bessel's differential equation
+
+    .. math ::
+        z^2 \frac{\mathrm{d}^2 w}{\mathrm{d}z^2}
+        + z \frac{\mathrm{d}w}{\mathrm{d}z} + (z^2 - \nu^2) w = 0,
+
+    with Laurent expansion
+
+    .. math ::
+        J_\nu(z) = z^\nu \left(\frac{1}{\Gamma(\nu + 1) 2^\nu} + O(z^2) \right),
+
+    if :math:`\nu` is not a negative integer. If :math:`\nu` *is* a negative
+    integer, then the definition is
+
+    .. math ::
+        J_{-n}(z) = (-1)^n J_n(z).
 
     Examples:
 
-    >>> from sympy.functions.special.bessel import fn
-    >>> from sympy import Symbol
-    >>> z = Symbol("z")
-    >>> fn(1, z)
-    z**(-2)
-    >>> fn(2, z)
-    -1/z + 3/z**3
-    >>> fn(3, z)
-    -6/z**2 + 15/z**4
-    >>> fn(4, z)
-    1/z - 45/z**3 + 105/z**5
+    Create a bessel function object:
 
+    >>> from sympy import besselj, jn
+    >>> from sympy.abc import z, n
+    >>> b = besselj(n, z)
+
+    Differentiate it:
+
+    >>> b.diff(z)
+    besselj(n - 1, z)/2 - besselj(n + 1, z)/2
+
+    Rewrite in terms of spherical bessel functions:
+
+    >>> b.rewrite(jn)
+    2**(1/2)*z**(1/2)*jn(n - 1/2, z)/pi**(1/2)
+
+    Access the parameter and argument
+
+    >>> b.order
+    n
+    >>> b.argument
+    z
+
+    References:
+
+    - Abramowitz, Milton; Stegun, Irene A., eds. (1965), "Chapter 9",
+      Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical
+      Tables
+    - Luke, Y. L. (1969), The Special Functions and Their Approximations,
+      Volume 1
+    - http://en.wikipedia.org/wiki/Bessel_function
     """
-    n = sympify(n)
-    if not n.is_Integer:
-        raise TypeError("'n' must be an Integer")
-    if n == 0:
-        return 1/z
-    elif n == 1:
-        return 1/z**2
-    elif n > 1:
-        return ((2*n-1)/z * fn(n-1, z)).expand() - fn(n-2, z)
-    elif n < 0:
-        return ((2*n+3)/z * fn(n+1, z)).expand() - fn(n+2, z)
 
+    _a = S.One
+    _b = S.One
 
-def jn(n, z):
+    def _eval_rewrite_as_jn(self, nu, z):
+        return sqrt(2*z/pi) * jn(nu - S('1/2'), self.argument)
+
+class bessely(BesselBase):
+    r"""
+    Bessel function of the second kind.
+
+    The Bessel Y function of order :math:`\nu` is defined as
+
+    .. math ::
+        Y_\nu(z) = \lim_{\mu \to \nu} \frac{J_\mu(z) \cos(\pi \mu)
+                                            - J_{-\mu}(z)}{\sin(\pi \mu)}.
+
+    It is a solution to Bessel's equation, and linearly independent from
+    :math:`J_\nu`.
+
+    Examples:
+
+    >>> from sympy import bessely, yn
+    >>> from sympy.abc import z, n
+    >>> b = bessely(n, z)
+    >>> b.diff(z)
+    bessely(n - 1, z)/2 - bessely(n + 1, z)/2
+    >>> b.rewrite(yn)
+    2**(1/2)*z**(1/2)*yn(n - 1/2, z)/pi**(1/2)
+
+    See also: :class:`besselj`
     """
+
+    _a = S.One
+    _b = S.One
+
+    def _eval_rewrite_as_yn(self, nu, z):
+        return sqrt(2*z/pi) * yn(nu - S('1/2'), self.argument)
+
+class besseli(BesselBase):
+    r"""
+    Modified Bessel function of the first kind.
+
+    The Bessel I function is a solution to the modified Bessel equation
+
+    .. math ::
+        z^2 \frac{\mathrm{d}^2 w}{\mathrm{d}z^2}
+        + z \frac{\mathrm{d}w}{\mathrm{d}z} + (z^2 + \nu)^2 w = 0.
+
+    It can be defined as
+
+    .. math ::
+        I_\nu(z) = i^{-\nu} J_\nu(iz).
+
+    Examples:
+
+    >>> from sympy import besseli
+    >>> from sympy.abc import z, n
+    >>> besseli(n, z).diff(z)
+    besseli(n - 1, z)/2 + besseli(n + 1, z)/2
+
+    See also: :class:`besselj`
+    """
+
+    _a = -S.One
+    _b = S.One
+
+class besselk(BesselBase):
+    r"""
+    Modified Bessel function of the second kind.
+
+    The Bessel K function of order :math:`nu` is defined as
+
+    .. math ::
+        K_\nu(z) = \lim_{\mu \to \nu} \frac{\pi}{2}
+                   \frac{I_{-\mu}(z) -I_\mu(z)}{\sin(\pi \mu)}.
+
+    It is a solution of the modified Bessel equation, and linearly independent
+    from :math:`I_\nu`.
+
+    Examples:
+
+    >>> from sympy import besselk
+    >>> from sympy.abc import z, n
+    >>> besselk(n, z).diff(z)
+    -besselk(n - 1, z)/2 - besselk(n + 1, z)/2
+
+    See also: :class:`besselj`
+    """
+
+    _a = S.One
+    _b = -S.One
+
+class hankel1(BesselBase):
+    r"""
+    Hankel function of the first kind.
+
+    This function is defined as
+
+    .. math ::
+        H_\nu^{(1)} = J_\nu(z) + iY_\nu(z).
+
+    It is a solution to Bessel's equation.
+
+    Examples:
+
+    >>> from sympy import hankel1
+    >>> from sympy.abc import z, n
+    >>> hankel1(n, z).diff(z)
+    hankel1(n - 1, z)/2 - hankel1(n + 1, z)/2
+
+    See also: :class:`besselj`
+    """
+
+    _a = S.One
+    _b = S.One
+
+class hankel2(BesselBase):
+    r"""
+    Hankel function of the second kind.
+
+    This function is defined as
+
+    .. math ::
+        H_\nu^{(2)} = J_\nu(z) - iY_\nu(z).
+
+    It is a solution to Bessel's equation, and linearly independent from
+    :math:`H_\nu^{(1)}`.
+
+    Examples:
+
+    >>> from sympy import hankel2
+    >>> from sympy.abc import z, n
+    >>> hankel2(n, z).diff(z)
+    hankel2(n - 1, z)/2 - hankel2(n + 1, z)/2
+
+    See also: :class:`besselj`
+    """
+
+    _a = S.One
+    _b = S.One
+
+from sympy.polys.orthopolys import spherical_bessel_fn as fn
+
+class SphericalBesselBase(BesselBase):
+    """
+    Base class for spherical bessel functions.
+
+    These are thin wrappers around ordinary bessel functions,
+    since spherical bessel functions differ from the ordinary
+    ones just by a slight change in order.
+
+    To use this class, define the _rewrite and _expand methods.
+    """
+
+    def _expand(self):
+        """ Expand self into a polynomial. Nu is guaranteed to be Integer. """
+        raise NotImplementedError('expansion')
+
+    def _rewrite(self):
+        """ Rewrite self in terms of ordinary bessel functions. """
+        raise NotImplementedError('rewriting')
+
+    def _eval_expand_func(self, deep=False, **hints):
+        if self.order.is_Integer:
+            return self._expand()
+
+    def _eval_evalf(self, prec):
+        return self._rewrite()._eval_evalf(prec)
+
+    def fdiff(self, argindex=2):
+        if argindex != 2:
+            raise ArgumentIndexError(self, argindex)
+        return self.__class__(self.order - 1, self.argument) - \
+               self * (self.order + 1)/self.argument
+
+
+class jn(SphericalBesselBase):
+    r"""
     Spherical Bessel function of the first kind.
 
+    This function is a solution to the spherical bessel equation
+
+    .. math ::
+        z^2 \frac{\mathrm{d}^2 w}{\mathrm{d}z^2}
+          + 2z \frac{\mathrm{d}w}{\mathrm{d}z} + (z^2 - \nu(\nu + 1)) w = 0.
+
+    It can be defined as
+
+    .. math ::
+        j_\nu(z) = \sqrt{\frac{\pi}{2z}} J_{\nu + \frac{1}{2}}(z).
+
     Examples:
 
-        >>> from sympy import Symbol, jn, sin, cos
+        >>> from sympy import Symbol, jn, sin, cos, expand_func
         >>> z = Symbol("z")
-        >>> print jn(0, z)
+        >>> print jn(0, z).expand(func=True)
         sin(z)/z
-        >>> jn(1, z) == sin(z)/z**2 - cos(z)/z
+        >>> jn(1, z).expand(func=True) == sin(z)/z**2 - cos(z)/z
         True
-        >>> jn(3, z) ==(1/z - 15/z**3)*cos(z) + (15/z**4 - 6/z**2)*sin(z)
-        True
+        >>> expand_func(jn(3, z))
+        (-6/z**2 + 15/z**4)*sin(z) + (1/z - 15/z**3)*cos(z)
 
-    The spherical Bessel functions are calculated using the formula:
+    The spherical Bessel functions of integral order
+    are calculated using the formula:
 
     jn(n, z) == fn(n, z) * sin(z) + (-1)**(n+1) * fn(-n-1, z) * cos(z)
 
     where fn(n, z) are the coefficients, see fn()'s sourcecode for more
     information.
+
+    See also: :class:`besselj`
     """
 
-    n = sympify(n)
-    z = sympify(z)
-    return fn(n, z) * sin(z) + (-1)**(n+1) * fn(-n-1, z) * cos(z)
+    def _rewrite(self):
+        return self._eval_rewrite_as_besselj(self.order, self.argument)
 
-def yn(n, z):
-    """
+    def _eval_rewrite_as_besselj(self, nu, z):
+        return sqrt(pi/(2*z)) * besselj(nu + S('1/2'), z)
+
+    def _expand(self):
+        n = self.order
+        z = self.argument
+        return fn(n, z) * sin(z) + (-1)**(n+1) * fn(-n-1, z) * cos(z)
+
+class yn(SphericalBesselBase):
+    r"""
     Spherical Bessel function of the second kind.
+
+    This function is another solution to the spherical bessel equation, and
+    linearly independent from :math:`j_n`. It can be defined as
+
+    .. math ::
+        j_\nu(z) = \sqrt{\frac{\pi}{2z}} Y_{\nu + \frac{1}{2}}(z).
 
     Examples:
 
-        >>> from sympy import Symbol, yn, sin, cos
+        >>> from sympy import Symbol, yn, sin, cos, expand_func
         >>> z = Symbol("z")
-        >>> print yn(0, z)
+        >>> print expand_func(yn(0, z))
         -cos(z)/z
-        >>> yn(1, z) == -cos(z)/z**2-sin(z)/z
+        >>> expand_func(yn(1, z)) == -cos(z)/z**2-sin(z)/z
         True
 
-    yn is calculated using the formula:
+    For integral orders :math:`n`, yn is calculated using the formula:
 
     yn(n, z) == (-1)**(n+1) * jn(-n-1, z)
+
+    See also: :class:`besselj`, :class:`bessely`, :class:`jn`
     """
 
-    n = sympify(n)
-    z = sympify(z)
-    return (-1)**(n+1) * jn(-n-1, z)
+    def _rewrite(self):
+        return self._eval_rewrite_as_bessely(self.order, self.argument)
+
+    def _eval_rewrite_as_bessely(self, nu, z):
+        return sqrt(pi/(2*z)) * bessely(nu + S('1/2'), z)
+
+    def _expand(self):
+        n = self.order
+        z = self.argument
+        return (-1)**(n+1) * \
+               (fn(-n-1, z) * sin(z) + (-1)**(-n) * fn(n, z) * cos(z))
+
 
 def jn_zeros(n, k, method="sympy"):
     """
@@ -111,6 +389,8 @@ def jn_zeros(n, k, method="sympy"):
         [5.76345919689, 9.09501133048, 12.3229409706, 15.5146030109]
 
     """
+    from math import pi
+
     if method == "sympy":
         from sympy.mpmath import findroot
         f = lambda x: jn(n, x).n()

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -1,6 +1,46 @@
-from sympy import jn, yn, symbols, sin, cos, pi, S, jn_zeros
+from sympy import jn, yn, symbols, sin, cos, pi, S, jn_zeros, besselj, \
+                  bessely, besseli, besselk, hankel1, hankel2, expand_func, \
+                  latex, sqrt
 from sympy.functions.special.bessel import fn
 from sympy.utilities.pytest import raises
+from sympy.utilities.randtest import \
+        random_complex_number as randcplx, \
+        test_numerically as tn, \
+        test_derivative_numerically as td
+from sympy.abc import z, n, k
+
+def test_bessel_rand():
+    assert td(besselj(randcplx(), z), z)
+    assert td(bessely(randcplx(), z), z)
+    assert td(besseli(randcplx(), z), z)
+    assert td(besselk(randcplx(), z), z)
+    assert td(hankel1(randcplx(), z), z)
+    assert td(hankel2(randcplx(), z), z)
+    assert td(jn(randcplx(), z), z)
+    assert td(yn(randcplx(), z), z)
+
+def test_diff():
+    assert besselj(n, z).diff(z) == besselj(n-1, z)/2 - besselj(n+1, z)/2
+    assert bessely(n, z).diff(z) == bessely(n-1, z)/2 - bessely(n+1, z)/2
+    assert besseli(n, z).diff(z) == besseli(n-1, z)/2 + besseli(n+1, z)/2
+    assert besselk(n, z).diff(z) == -besselk(n-1, z)/2 - besselk(n+1, z)/2
+    assert hankel1(n, z).diff(z) == hankel1(n-1, z)/2 - hankel1(n+1, z)/2
+    assert hankel2(n, z).diff(z) == hankel2(n-1, z)/2 - hankel2(n+1, z)/2
+
+def test_rewrite():
+    assert besselj(n, z).rewrite(jn) == sqrt(2*z/pi)*jn(n - S(1)/2, z)
+    assert bessely(n, z).rewrite(yn) == sqrt(2*z/pi)*yn(n - S(1)/2, z)
+
+def test_latex():
+    assert latex(besselj(n, z**2)**k) == r'J^{k}_{n}\left(z^{2}\right)'
+    assert latex(bessely(n, z)) == r'Y_{n}\left(z\right)'
+    assert latex(besseli(n, z)) == r'I_{n}\left(z\right)'
+    assert latex(besselk(n, z)) == r'K_{n}\left(z\right)'
+    assert latex(hankel1(n, z**2)**2) == \
+              r'\left(H^{(1)}_{n}\left(z^{2}\right)\right)^{2}'
+    assert latex(hankel2(n, z)) == r'H^{(2)}_{n}\left(z\right)'
+    assert latex(jn(n, z)) == r'j_{n}\left(z\right)'
+    assert latex(yn(n, z)) == r'y_{n}\left(z\right)'
 
 def test_fn():
     x, z = symbols("x z")
@@ -13,28 +53,31 @@ def test_fn():
     raises(TypeError, "fn(1.5, z)")
     raises(TypeError, "fn(S(1)/2, z)")
 
+def mjn(n, z): return expand_func(jn(n,z))
+def myn(n, z): return expand_func(yn(n,z))
+
 def test_jn():
     z = symbols("z")
-    assert jn(0, z) == sin(z)/z
-    assert jn(1, z) == sin(z)/z**2 - cos(z)/z
-    assert jn(2, z) == (3/z**3-1/z)*sin(z) - (3/z**2) * cos(z)
-    assert jn(3, z) == (15/z**4 - 6/z**2)*sin(z) + (1/z - 15/z**3)*cos(z)
-    assert jn(4, z) == (1/z + 105/z**5 - 45/z**3)*sin(z) + \
+    assert mjn(0, z) == sin(z)/z
+    assert mjn(1, z) == sin(z)/z**2 - cos(z)/z
+    assert mjn(2, z) == (3/z**3-1/z)*sin(z) - (3/z**2) * cos(z)
+    assert mjn(3, z) == (15/z**4 - 6/z**2)*sin(z) + (1/z - 15/z**3)*cos(z)
+    assert mjn(4, z) == (1/z + 105/z**5 - 45/z**3)*sin(z) + \
                 (-105/z**4 + 10/z**2)*cos(z)
-    assert jn(5, z) == (945/z**6 - 420/z**4 + 15/z**2)*sin(z) + \
+    assert mjn(5, z) == (945/z**6 - 420/z**4 + 15/z**2)*sin(z) + \
                 (-1/z - 945/z**5 + 105/z**3)*cos(z)
-    assert jn(6, z) == (-1/z + 10395/z**7 - 4725/z**5 + 210/z**3)*sin(z) + \
+    assert mjn(6, z) == (-1/z + 10395/z**7 - 4725/z**5 + 210/z**3)*sin(z) + \
                 (-10395/z**6 + 1260/z**4 - 21/z**2)*cos(z)
 
 def test_yn():
     z = symbols("z")
-    assert yn(0, z) == -cos(z)/z
-    assert yn(1, z) == -cos(z)/z**2-sin(z)/z
-    assert yn(2, z) == -((3/z**3-1/z)*cos(z)+(3/z**2)*sin(z))
+    assert myn(0, z) == -cos(z)/z
+    assert myn(1, z) == -cos(z)/z**2-sin(z)/z
+    assert myn(2, z) == -((3/z**3-1/z)*cos(z)+(3/z**2)*sin(z))
 
 def test_sympify_yn():
-    assert S(15) in yn(3, pi).atoms()
-    assert yn(3, pi) == 15/pi**4 - 6/pi**2
+    assert S(15) in myn(3, pi).atoms()
+    assert myn(3, pi) == 15/pi**4 - 6/pi**2
 
 def eq(a, b, tol=1e-6):
     for x, y in zip(a, b):

--- a/sympy/polys/orthopolys.py
+++ b/sympy/polys/orthopolys.py
@@ -167,3 +167,71 @@ def laguerre_poly(n, x=None, alpha=None, **args):
     else:
         return poly
 
+@cythonized("n,i")
+def dup_spherical_bessel_fn(n, K):
+    """ Low-level implementation of fn(n, x) """
+    seq = [[K.one], [K.one, K.zero]]
+
+    for i in xrange(2, n+1):
+        a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2*i-1), K)
+        seq.append(dup_sub(a, seq[-2], K))
+
+    return dup_lshift(seq[n], 1, K)
+
+@cythonized("n,i")
+def dup_spherical_bessel_fn_minus(n, K):
+    """ Low-level implementation of fn(-n, x) """
+    seq = [[K.one, K.zero], [K.zero]]
+
+    for i in xrange(2, n+1):
+        a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(3 - 2*i), K)
+        seq.append(dup_sub(a, seq[-2], K))
+
+    return seq[n]
+
+def spherical_bessel_fn(n, x=None, **args):
+    """
+    Coefficients for the spherical Bessel functions.
+
+    Those are only needed in the jn() function.
+
+    The coefficients are calculated from:
+
+    fn(0, z) = 1/z
+    fn(1, z) = 1/z**2
+    fn(n-1, z) + fn(n+1, z) == (2*n+1)/z * fn(n, z)
+
+    Examples:
+
+    >>> from sympy.polys.orthopolys import spherical_bessel_fn as fn
+    >>> from sympy import Symbol
+    >>> z = Symbol("z")
+    >>> fn(1, z)
+    z**(-2)
+    >>> fn(2, z)
+    -1/z + 3/z**3
+    >>> fn(3, z)
+    -6/z**2 + 15/z**4
+    >>> fn(4, z)
+    1/z - 45/z**3 + 105/z**5
+
+    """
+    n = sympify(n)
+    if not n.is_Integer:
+        raise TypeError("'n' must be an Integer")
+
+    if x is not None:
+        x = sympify(x)
+    else:
+        x = Dummy('x')
+    if n < 0:
+        dup = dup_spherical_bessel_fn_minus(-int(n), ZZ)
+    else:
+        dup = dup_spherical_bessel_fn(int(n), ZZ)
+
+    poly = Poly.new(DMP(dup, ZZ), 1/x)
+
+    if not args.get('polys', False):
+        return poly.as_expr()
+    else:
+        return poly

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -523,6 +523,48 @@ class LatexPrinter(Printer):
 
         return self._do_exponent(tex, exp)
 
+    def _hprint_BesselBase(self, expr, exp, sym):
+        tex = r"%s" % (sym)
+
+        need_exp = False
+        if exp is not None:
+            if tex.find('^') == -1:
+                tex = r"%s^{%s}" % (tex, self._print(exp))
+            else:
+                need_exp = True
+
+        tex = r"%s_{%s}\left(%s\right)" % (tex, self._print(expr.order),
+                                           self._print(expr.argument))
+
+        if need_exp:
+            tex = self._do_exponent(tex, exp)
+
+        return tex
+
+    def _print_besselj(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'J')
+
+    def _print_besseli(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'I')
+
+    def _print_besselk(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'K')
+
+    def _print_bessely(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'Y')
+
+    def _print_yn(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'y')
+
+    def _print_jn(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'j')
+
+    def _print_hankel1(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'H^{(1)}')
+
+    def _print_hankel2(self, expr, exp=None):
+        return self._hprint_BesselBase(expr, exp, 'H^{(2)}')
+
     def _print_Rational(self, expr):
         if expr.q != 1:
             sign = ""

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -39,6 +39,7 @@ x/y
 (1+x)*y  #3
 -5*x/(x+10)  # correct placement of negative sign
 1 - Rational(3,2)*(x+1)
+-(-x + 5)*(-x - 2*2**(1/S(2)) + 5) - (-y + 5)*(-y + 5) # Issue 2425
 
 
 ORDERING:
@@ -606,6 +607,19 @@ u"""\
 """
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+def test_issue_2425():
+    assert pretty(-(-x + 5)*(-x - 2*2**(1/S(2)) + 5) - (-y + 5)*(-y + 5)) == \
+"""\
+        /         ___    \\           2\n\
+(x - 5)*\\-x - 2*\\/ 2  + 5/ - (-y + 5) \
+"""
+
+    assert upretty(-(-x + 5)*(-x - 2*2**(1/S(2)) + 5) - (-y + 5)*(-y + 5)) == \
+u"""\
+        ⎛         ⎽⎽⎽    ⎞           2\n\
+(x - 5)⋅⎝-x - 2⋅╲╱ 2  + 5⎠ - (-y + 5) \
+"""
 
 def test_pretty_ordering():
     assert pretty(x**2 + x + 1, order='lex') == \

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -1,0 +1,46 @@
+""" Helpers for randomised testing """
+
+from sympy import I
+from random import uniform
+
+def random_complex_number():
+    """
+    Return a random complex number.
+
+    To reduce chance of hitting branch cuts or anything, we guarantee
+    -1 <= Im z <= 1, 2 <= Re z <= 3
+    """
+    return uniform(2, 3) + I*uniform(-1, 1)
+
+def test_numerically(f, g, z, tol=1.0e-6):
+    """
+    Test numerically that f and g agree when evaluated in the argument z.
+
+    Examples:
+
+    >>> from sympy import sin, cos, S
+    >>> from sympy.abc import x
+    >>> from sympy.utilities.randtest import test_numerically as tn
+    >>> tn(sin(x)**2 + cos(x)**2, S(1), x)
+    True
+    """
+    z0 = random_complex_number()
+    return abs((f.subs(z, z0) - g.subs(z, z0)).n()) <= tol
+
+def test_derivative_numerically(f, z, tol=1.0e-6):
+    """
+    Test numerically that the symbolically computed derivative of f
+    with respect to z is correct.
+
+    Examples:
+    >>> from sympy import sin, cos
+    >>> from sympy.abc import x
+    >>> from sympy.utilities.randtest import test_derivative_numerically as td
+    >>> td(sin(x), x)
+    True
+    """
+    from sympy.core.function import Derivative
+    z0 = random_complex_number()
+    f1 = f.diff(z).subs(z, z0)
+    f2 = Derivative(f, z).doit_numerically(z0)
+    return abs((f1 - f2).n()) <= tol


### PR DESCRIPTION
This branch re-organises the bessel functions, and adds support for randomised testing.

**The first commit** implements numerical differentiation of sympy expressions. The commit message has a TODO, but I think doing what is suggested there (higher order derivatives and partial derivatives) is probably not worth the effort. I had quite some struggle with the doit_numerically method to get the precisions right, so that probably warrants a good look.

**The second commit** implements randomised testing, as per issue 2281.

**The third commit** finally does the proposed reorganisation of the bessel functions. It also adds randomised tests in addition to symbolic ones for the new functionality. This commit message also has two possible TODOs worthy of discussion:
- should dup_fn and dup_fn_minus, and possibly even fn, be moved inside the polys module (@mattpap, others?)
- should the `.z` and `.nu` properties of bessel-type functions be renamed to `.argument` and `.order`?

There is also a TODO statement at the top of the file, but this is not something I plan on doing any time soon.
