### PR TITLE
Coherent "symbols guessing" in diff() and integrate() (#527)

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -591,8 +591,12 @@ class Derivative(Expr):
 
     def __new__(cls, expr, *symbols, **assumptions):
         expr = sympify(expr)
+
         if not symbols:
-            return expr
+            symbols = expr.free_symbols
+
+            if len(symbols) != 1:
+                raise ValueError("specify differentiation variables to differentiate %s" % expr)
 
         # standardize symbols
         symbols = list(sympify(symbols))
@@ -869,7 +873,8 @@ def diff(f, *symbols, **kwargs):
     that if there are 0 symbols (such as diff(f(x), x, 0), then the result will
     be the function (the zeroth derivative), even if evaluate=False.
 
-    Examples:
+    **Examples**
+
     >>> from sympy import sin, cos, Function, diff
     >>> from sympy.abc import x, y
     >>> f = Function('f')
@@ -891,6 +896,16 @@ def diff(f, *symbols, **kwargs):
     sin
     >>> type(diff(sin(x), x, 0, evaluate=False))
     sin
+
+    >>> diff(sin(x))
+    cos(x)
+    >>> diff(sin(x*y))
+    Traceback (most recent call last):
+    ...
+    ValueError: specify differentiation variables to differentiate sin(x*y)
+
+    Note that ``diff(sin(x))`` syntax is meant only for convenience
+    in interactive sessions and should be avoided in library code.
 
     See Also
     http://documents.wolfram.com/v5/Built-inFunctions/AlgebraicComputation/Calculus/D.html

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -276,8 +276,8 @@ def test_issue2300():
     args = [x, y, S(2), S.Half]
     def ok(a):
         """Return True if the input args for diff are ok"""
-        if not a:return True
-        if a[0].is_Symbol is False:return False
+        if not a: return False
+        if a[0].is_Symbol is False: return False
         s_at = [i for i in range(len(a)) if a[i].is_Symbol]
         n_at = [i for i in range(len(a)) if not a[i].is_Symbol]
         # every symbol is followed by symbol or int

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -104,15 +104,14 @@ class Integral(Expr):
         else:
             # no symbols provided -- let's compute full anti-derivative
             limits, sign = [Tuple(s) for s in function.free_symbols], 1
-            if not limits:
-                raise ValueError('An integration variable is required.')
 
+            if len(limits) != 1:
+                raise ValueError("specify integration variables to integrate %s" % function)
 
         while isinstance(function, Integral):
             # denest the integrand
             limits = list(function.limits) + limits
             function = function.function
-
 
         obj = Expr.__new__(cls, **assumptions)
         arglist = [sign*function]
@@ -812,7 +811,7 @@ def integrate(*args, **kwargs):
        Also, if no var is specified at all, then the full anti-derivative of f is
        returned. This is equivalent to integrating f over all its variables.
 
-       Examples
+       **Examples**
 
        >>> from sympy import integrate, log
        >>> from sympy.abc import a, x, y
@@ -830,7 +829,12 @@ def integrate(*args, **kwargs):
        x**2/2
 
        >>> integrate(x*y)
-       x**2*y**2/4
+       Traceback (most recent call last):
+       ...
+       ValueError: specify integration variables to integrate x*y
+
+       Note that ``integrate(x)`` syntax is meant only for convenience
+       in interactive sessions and should be avoided in library code.
 
        See also the doctest of Integral._eval_integral(), which explains
        thoroughly the strategy that SymPy uses for integration.

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -153,9 +153,11 @@ def test_integrate_poly_defined():
 
 def test_integrate_omit_var():
     y = Symbol('y')
+
+    assert integrate(x) == x**2/2
+
     raises(ValueError, "integrate(2)")
-    assert integrate(x)     == x**2/2
-    assert integrate(x*y)   == x**2*y**2/4
+    raises(ValueError, "integrate(x*y)")
 
 def test_integrate_poly_accurately():
     y = Symbol('y')


### PR DESCRIPTION
This pull request finalizes issue #527 by unifying behaviour of diff() and integrate(), e.g.:

In [1]: diff(x**2)
Out[1]: 2⋅x

In [2]: diff(x**2_y)
(...)
ValueError: specify differentiation variables to differentiate y_x**2

In [3]: integrate(x**2)
Out[3]:
 3
x
──
3

In [4]: integrate(x**2_y)
(...)
ValueError: specify integration variables to integrate y_x**2

No tests/doctests where changed other than those directly testing the behaviour. Doctests and comments about usage of the syntax were added (as per comment #7 in #527). 
