### PR TITLE
Finalized implementation of Gosper's algorithm (#2386)

### DIFF
--- a/sympy/concrete/__init__.py
+++ b/sympy/concrete/__init__.py
@@ -1,3 +1,2 @@
 from products import product, Product
 from summations import summation, Sum
-from gosper import normal, gosper

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -1,100 +1,200 @@
-from sympy.core.singleton import S
-from sympy.core.symbol import Dummy
-from sympy.core.mul import Mul
-from sympy.core import sympify
+"""Gosper's algorithm for hypergeometric summation. """
 
-from sympy.polys import gcd, quo, roots, resultant
+from sympy.core import S, Dummy, sympify, symbols
+from sympy.polys import Poly, parallel_poly_from_expr, factor
+from sympy.solvers import solve
+from sympy.simplify import hypersimp
 
-def normal(f, g, n=None):
-    """Given relatively prime univariate polynomials 'f' and 'g',
-       rewrite their quotient to a normal form defined as follows:
+def gosper_normal(f, g, n, polys=True):
+    r"""
+    Compute the Gosper's normal form of ``f`` and ``g``.
 
-                       f(n)       A(n) C(n+1)
-                       ----  =  Z -----------
-                       g(n)       B(n)  C(n)
+    Given relatively prime univariate polynomials ``f`` and ``g``,
+    rewrite their quotient to a normal form defined as follows::
 
-       where Z is arbitrary constant and A, B, C are monic
-       polynomials in 'n' with following properties:
+    .. math::
 
-           (1) gcd(A(n), B(n+h)) = 1 for all 'h' in N
-           (2) gcd(B(n), C(n+1)) = 1
-           (3) gcd(A(n), C(n)) = 1
+        \frac{f(n)}{g(n)} = Z \cdot \frac{A(n) C(n+1)}{B(n) C(n)}
 
-       This normal form, or rational factorization in other words,
-       is crucial step in Gosper's algorithm and in difference
-       equations solving. It can be also used to decide if two
-       hypergeometric are similar or not.
+    where ``Z`` is an arbitrary constant and ``A``, ``B``, ``C`` are
+    monic polynomials in ``n`` with the following properties:
 
-       This procedure will return a tuple containing elements
-       of this factorization in the form (Z*A, B, C). For example:
+    1. $\gcd(A(n), B(n+h)) = 1 \forall h \in \mathbb{N}$
+    2. $\gcd(B(n), C(n+1)) = 1$
+    3. $\gcd(A(n), C(n)) = 1$
 
-       >>> from sympy import Symbol, normal
-       >>> n = Symbol('n', integer=True)
+    This normal form, or rational factorization in other words, is a
+    crucial step in Gosper's algorithm and in solving of difference
+    equations. It can be also used to decide if two hypergeometric
+    terms are similar or not.
 
-       >>> normal(4*n+5, 2*(4*n+1)*(2*n+3), n)
-       (1/4, 3/2 + n, 1/4 + n)
+    This procedure will return a tuple containing elements of this
+    factorization in the form ``(Z*A, B, C)``.
+
+    **Examples**
+
+    >>> from sympy.concrete.gosper import gosper_normal
+    >>> from sympy.abc import n
+
+    >>> gosper_normal(4*n+5, 2*(4*n+1)*(2*n+3), n, polys=False)
+    (1/4, 3/2 + n, 1/4 + n)
 
     """
-    f, g = map(sympify, (f, g))
+    (p, q), opt = parallel_poly_from_expr((f, g), n, field=True)
 
-    p = f.as_poly(n, field=True)
-    q = g.as_poly(n, field=True)
+    a, A = p.LC(), p.monic()
+    b, B = q.LC(), q.monic()
 
-    a, p = p.LC(), p.monic()
-    b, q = q.LC(), q.monic()
-
-    A = p.as_expr()
-    B = q.as_expr()
-
-    C, Z = S.One, a / b
-
+    C, Z = A.one, a/b
     h = Dummy('h')
 
-    res = resultant(A, B.subs(n, n+h), n)
+    D = Poly(n + h, n, h, domain=opt.domain)
 
-    nni_roots = roots(res, h, filter='Z',
-        predicate=lambda r: r >= 0).keys()
+    R = A.resultant(B.compose(D))
+    roots = set(R.ground_roots().keys())
 
-    if not nni_roots:
-        return (f, g, S.One)
+    for r in set(roots):
+        if not r.is_Integer or r < 0:
+            roots.remove(r)
+
+    for i in sorted(roots):
+        d = A.gcd(B.shift(+i))
+
+        A = A.quo(d)
+        B = B.quo(d.shift(-i))
+
+        for j in xrange(1, i+1):
+            C *= d.shift(-j)
+
+    A = A.mul_ground(Z)
+
+    if not polys:
+        A = A.as_expr()
+        B = B.as_expr()
+        C = C.as_expr()
+
+    return A, B, C
+
+def gosper_term(f, n):
+    """
+    Compute Gosper's hypergeometric term for ``f``.
+
+    Suppose ``f`` is a hypergeometric term such that::
+
+    .. math::
+
+        s_n = \sum_{k=0}^{n-1} f_k
+
+    and $f_k$ doesn't depend on $n$. Returns a hypergeometric
+    term $g_n$ such that $g_{n+1} - g_n = f_n$.
+
+    **Examples**
+
+    >>> from sympy.concrete.gosper import gosper_term
+    >>> from sympy.functions import factorial
+    >>> from sympy.abc import n
+
+    >>> gosper_term((4*n + 1)*factorial(n)/factorial(2*n + 1), n)
+    (-1/2 - n)/(1/4 + n)
+
+    """
+    r = hypersimp(f, n)
+
+    if r is None:
+        return None    # 'f' is *not* a hypergeometric term
+
+    p, q = r.as_numer_denom()
+
+    A, B, C = gosper_normal(p, q, n)
+    B = B.shift(-1)
+
+    N = S(A.degree())
+    M = S(B.degree())
+    K = S(C.degree())
+
+    if (N != M) or (A.LC() != B.LC()):
+        D = set([K - max(N, M)])
+    elif not N:
+        D = set([K - N + 1, S(0)])
     else:
-        for i in sorted(nni_roots):
-            d = gcd(A, B.subs(n, n+i), n)
+        D = set([K - N + 1, (B.nth(N - 1) - A.nth(N - 1))/A.LC()])
 
-            A = quo(A, d, n)
-            B = quo(B, d.subs(n, n-i), n)
+    for d in set(D):
+        if not d.is_Integer or d < 0:
+            D.remove(d)
 
-            C *= Mul(*[ d.subs(n, n-j) for j in xrange(1, i+1) ])
+    if not D:
+        return None    # 'f(n)' is *not* Gosper-summable
 
-        return (Z*A, B, C)
+    d = max(D)
 
-def gosper(term, k, a, n):
-    from sympy.solvers import rsolve_poly
+    coeffs = symbols('c:%s' % (d + 1), cls=Dummy)
+    domain = A.get_domain().inject(*coeffs)
 
-    if not term:
+    x = Poly(coeffs, n, domain=domain)
+    H = A*x.shift(1) - B*x - C
+
+    solution = solve(H.coeffs(), coeffs)
+
+    if solution is None:
+        return None    # 'f(n)' is *not* Gosper-summable
+
+    for coeff in coeffs:
+        if coeff not in solution:
+            solution[coeff] = S(0)
+
+    x = x.as_expr().subs(solution)
+
+    if x is S.Zero:
+        return None    # 'f(n)' is *not* Gosper-summable
+    else:
+        return B*x/C
+
+def gosper_sum(f, k):
+    """
+    Gosper's hypergeometric summation algorithm.
+
+    Given a hypergeometric term ``f`` such that::
+
+    .. math::
+
+        s_n = \sum_{k=0}^{n-1} f_k
+
+    and $f(n)$ doesn't depend on $n$, returns $g_{n} - g(0)$ where
+    $g_{n+1} - g_n = f_n$, or ``None`` if $s_n$ can not be expressed
+    in closed form as a sum of hypergeometric terms.
+
+    **Examples**
+
+    >>> from sympy.concrete.gosper import gosper_sum
+    >>> from sympy.functions import factorial
+    >>> from sympy.abc import n, k
+
+    >>> gosper_sum((4*k + 1)*factorial(k)/factorial(2*k + 1), (k, 0, n))
+    (-n! + 2*(1 + 2*n)!)/(1 + 2*n)!
+
+    **References**
+
+    .. [1] Marko Petkovsek, Herbert S. Wilf, Doron Zeilberger, A = B,
+           AK Peters, Ltd., Wellesley, MA, USA, 1997, pp. 73--100
+
+    """
+    indefinite = False
+
+    if isinstance(k, tuple):
+        k, a, b = k
+    else:
+        indefinite = True
+
+    g = gosper_term(f, k)
+
+    if g is None:
         return None
+
+    if indefinite:
+        result = f*g
     else:
-        p, q = term.as_numer_denom()
-        A, B, C = normal(p, q, k)
+        result = (f*(g+1)).subs(k, b) - (f*g).subs(k, a)
 
-        B = B.subs(k, k-1)
-
-        R = rsolve_poly([-B, A], C, k)
-        symbol = []
-
-        if not (R is None  or  R is S.Zero):
-            if symbol != []:
-                symbol = symbol[0]
-
-                W = R.subs(symbol, S.Zero)
-
-                if W is S.Zero:
-                    R = R.subs(symbol, S.One)
-                else:
-                    R = W
-
-            Z = B*R*term/C
-            return simplify(Z.subs(k, n+1) - Z.subs(k, a))
-        else:
-            return None
+    return factor(result)
 

--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -1,8 +1,61 @@
-from sympy import Symbol, normal
-from sympy.abc import n
+"""Tests for Gosper's algorithm for hypergeometric summation. """
 
-def test_normal():
-    assert normal(4*n+5, 2*(4*n+1)*(2*n+3), n)
+from sympy.concrete.gosper import gosper_normal, gosper_term, gosper_sum
+from sympy import S, Poly, symbols, factorial, binomial, gamma
 
-def test_gosper():
-    pass
+n, m, k, i, j = symbols('n,m,k,i,j', integer=True)
+
+def test_gosper_normal():
+    assert gosper_normal(4*n + 5, 2*(4*n + 1)*(2*n + 3), n) == \
+        (Poly(S(1)/4, n), Poly(n + S(3)/2), Poly(n + S(1)/4))
+
+def test_gosper_term():
+    assert gosper_term((4*k + 1)*factorial(k)/factorial(2*k + 1), k) == (-k - S(1)/2)/(k + S(1)/4)
+
+def test_gosper_sum():
+    assert gosper_sum(1, (k, 0, n)) == 1 + n
+    assert gosper_sum(k, (k, 0, n)) == n*(1 + n)/2
+    assert gosper_sum(k**2, (k, 0, n)) == n*(1 + n)*(1 + 2*n)/6
+    assert gosper_sum(k**3, (k, 0, n)) == n**2*(1 + n)**2/4
+
+    assert gosper_sum(2**k, (k, 0, n)) == 2*2**n - 1
+
+    assert gosper_sum(factorial(k), (k, 0, n)) is None
+    assert gosper_sum(binomial(n, k), (k, 0, n)) is None
+
+    assert gosper_sum(factorial(k)/k**2, (k, 0, n)) is None
+    assert gosper_sum((k - 3)*factorial(k), (k, 0, n)) is None
+
+    assert gosper_sum(k*factorial(k), k) == factorial(k)
+    assert gosper_sum(k*factorial(k), (k, 0, n)) == n*factorial(n) + factorial(n) - 1
+
+    assert gosper_sum((-1)**k*binomial(n, k), (k, 0, n)) == 0
+    assert gosper_sum((-1)**k*binomial(n, k), (k, 0, m)) == -(-1)**m*(m - n)*binomial(n, m)/n
+
+    assert gosper_sum((4*k + 1)*factorial(k)/factorial(2*k + 1), (k, 0, n)) == \
+        (2*factorial(2*n + 1) - factorial(n))/factorial(2*n + 1)
+
+def test_gosper_sum_indefinite():
+    assert gosper_sum(k, k) == k*(k - 1)/2
+    assert gosper_sum(k**2, k) == k*(k - 1)*(2*k - 1)/6
+
+    assert gosper_sum(1/(k*(k + 1)), k) == -1/k
+    assert gosper_sum(-(27*k**4 + 158*k**3 + 430*k**2 + 678*k + 445)*gamma(2*k + 4)/(3*(3*k + 7)*gamma(3*k + 6)), k) == \
+        (3*k + 5)*(k**2 + 2*k + 5)*gamma(2*k + 4)/gamma(3*k + 6)
+
+def test_gosper_sum_parametric():
+    assert gosper_sum(binomial(S(1)/2, m - j + 1)*binomial(S(1)/2, m + j), (j, 1, n)) == \
+        n*(1 + m - n)*(-1 + 2*m + 2*n)*binomial(S(1)/2, 1 + m - n)*binomial(S(1)/2, m + n)/(m*(1 + 2*m))
+
+def test_gosper_sum_iterated():
+    f1 = binomial(2*k, k)/4**k
+    f2 = (1 + 2*n)*binomial(2*n, n)/4**n
+    f3 = (1 + 2*n)*(3 + 2*n)*binomial(2*n, n)/(3*4**n)
+    f4 = (1 + 2*n)*(3 + 2*n)*(5 + 2*n)*binomial(2*n, n)/(15*4**n)
+    f5 = (1 + 2*n)*(3 + 2*n)*(5 + 2*n)*(7 + 2*n)*binomial(2*n, n)/(105*4**n)
+
+    assert gosper_sum(f1, (k, 0, n)) == f2
+    assert gosper_sum(f2, (n, 0, n)) == f3
+    assert gosper_sum(f3, (n, 0, n)) == f4
+    assert gosper_sum(f4, (n, 0, n)) == f5
+

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -47,6 +47,9 @@ def test_composite_sums():
     B = s.subs(a,-3).subs(b,4)
     assert A == B
 
+def test_hypergeometric_sums():
+    assert summation(binomial(2*k, k)/4**k, (k, 0, n)) == (1 + 2*n)*binomial(2*n, n)/4**n
+
 fac = factorial
 
 def NS(e, n=15, **options):

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -126,12 +126,8 @@ class Factorial(Function):
 
                     return C.Integer(result)
 
-        if n.is_integer:
-            if n.is_negative:
-                return S.Zero
-        else:
-            return C.gamma(n+1)
-
+        if n.is_negative:
+            return S.Zero
 
     @classmethod    # ?
     def _eval_rewrite_as_gamma(self, arg):
@@ -419,18 +415,13 @@ class Binomial(Function):
 
                         return result
 
-        if k.is_integer:
-            if k.is_negative:
-                return S.Zero
-        else:
-            return C.gamma(r+1)/(C.gamma(r-k+1)*C.gamma(k+1))
-
+        if k.is_negative:
+            return S.Zero
 
     def _eval_rewrite_as_gamma(self, r, k):
         return C.gamma(r+1) / (C.gamma(r-k+1)*C.gamma(k+1))
 
     def _eval_is_integer(self):
         return self.args[0].is_integer and self.args[1].is_integer
-
 
 binomial = Binomial

--- a/sympy/polys/domains/compositedomain.py
+++ b/sympy/polys/domains/compositedomain.py
@@ -1,8 +1,16 @@
 """Implementation of :class:`CompositeDomain` class. """
 
 from sympy.polys.domains.domain import Domain
+from sympy.polys.polyerrors import GeneratorsError
 
 class CompositeDomain(Domain):
-    """Base class for composite domains, e.g. ZZ[x]. """
+    """Base class for composite domains, e.g. ZZ[x], ZZ(X). """
 
     is_Composite = True
+
+    def inject(self, *gens):
+        """Inject generators into this domain. """
+        if not (set(self.gens) & set(gens)):
+            return self.__class__(self.dom, *(self.gens + gens))
+        else:
+            raise GeneratorsError("common generators in %s and %s" % (self.gens, gens))

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -5,7 +5,7 @@ from sympy.polys.domains.compositedomain import CompositeDomain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 
 from sympy.polys.polyclasses import DMP
-from sympy.polys.polyerrors import GeneratorsNeeded, GeneratorsError, PolynomialError, CoercionFailed
+from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError, CoercionFailed
 from sympy.polys.polyutils import dict_from_basic, basic_from_dict, _dict_reorder
 
 class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
@@ -146,13 +146,6 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
     def frac_field(self, *gens):
         """Returns a fraction field, i.e. `K(X)`. """
         raise NotImplementedError('nested domains not allowed')
-
-    def inject(self, *gens):
-        """Inject generators into this domain. """
-        if not (set(self.gens) & set(gens)):
-            return self.__class__(self.dom, *(self.gens + gens))
-        else:
-            raise GeneratorsError("common generators in %s and %s" % (self.gens, gens))
 
     def is_positive(self, a):
         """Returns True if `LC(a)` is positive. """

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -93,6 +93,7 @@ from sympy.polys.densetools import (
     dup_monic, dmp_ground_monic,
     dup_compose, dmp_compose,
     dup_decompose,
+    dup_shift,
     dmp_lift)
 
 from sympy.polys.euclidtools import (
@@ -616,6 +617,13 @@ class DMP(object):
         """Computes functional decomposition of `f`. """
         if not f.lev:
             return map(f.per, dup_decompose(f.rep, f.dom))
+        else:
+            raise ValueError('univariate polynomial expected')
+
+    def shift(f, a):
+        """Efficiently compute Taylor shift ``f(x + a)``. """
+        if not f.lev:
+            return f.per(dup_shift(f.rep, f.dom.convert(a), f.dom))
         else:
             raise ValueError('univariate polynomial expected')
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2343,6 +2343,26 @@ class Poly(Expr):
 
         return map(f.per, result)
 
+    def shift(f, a):
+        """
+        Efficiently compute Taylor shift ``f(x + a)``.
+
+        **Examples**
+
+        >>> from sympy import Poly
+        >>> from sympy.abc import x
+
+        >>> Poly(x**2 - 2*x + 1, x).shift(2)
+        Poly(x**2 + 2*x + 1, x, domain='ZZ')
+
+        """
+        if hasattr(f.rep, 'shift'):
+            result = f.rep.shift(a)
+        else: # pragma: no cover
+            raise OperationNotSupported(f, 'shift')
+
+        return f.per(result)
+
     def sturm(f, auto=True):
         """
         Computes the Sturm sequence of ``f``.

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -391,6 +391,7 @@ def test_FractionField__init():
 def test_inject():
     assert ZZ.inject(x, y, z) == ZZ[x, y, z]
     assert ZZ[x].inject(y, z) == ZZ[x, y, z]
+    assert ZZ.frac_field(x).inject(y, z) == ZZ.frac_field(x, y, z)
     raises(GeneratorsError, "ZZ[x].inject(x)")
 
 def test_Domain_map():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1664,6 +1664,9 @@ def test_compose():
     assert compose(x**2 - y**2, x - y, x, y) ==  x**2 - 2*x*y
     assert compose(x**2 - y**2, x - y, y, x) == -y**2 + 2*x*y
 
+def test_shift():
+    assert Poly(x**2 - 2*x + 1, x).shift(2) == Poly(x**2 + 2*x + 1, x)
+
 def test_sturm():
     f, F = x, Poly(x, domain='QQ')
     g, G = 1, Poly(1, x, domain='QQ')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -85,6 +85,22 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.right('!'))
         return pform
 
+    def _print_Binomial(self, e):
+        n, k = e.args
+
+        n_pform = self._print(n)
+        k_pform = self._print(k)
+
+        bar = ' '*max(n_pform.width(), k_pform.width())
+
+        pform = prettyForm(*k_pform.above(bar))
+        pform = prettyForm(*pform.above(n_pform))
+        pform = prettyForm(*pform.parens('(', ')'))
+
+        pform.baseline = (pform.baseline + 1)//2
+
+        return pform
+
     def _print_Relational(self, e):
         op = prettyForm(' ' + xsym(e.rel_op) + ' ')
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from sympy import (Matrix, Piecewise, Ne, symbols, sqrt, Function,
     Rational, conjugate, Derivative, tan, Function, log, floor, Symbol,
-    pprint, sqrt, factorial, pi, sin, ceiling, pprint_use_unicode, I, S,
-    Limit, oo, cos, Pow, Integral, exp, Eq, Lt, Gt, Ge, Le, gamma, Abs, RootOf,
-    RootSum, Lambda, Not, And, Or, Xor, Nand, Nor, Implies, Equivalent,
+    pprint, sqrt, factorial, binomial, pi, sin, ceiling, pprint_use_unicode,
+    I, S, Limit, oo, cos, Pow, Integral, exp, Eq, Lt, Gt, Ge, Le, gamma, Abs,
+    RootOf, RootSum, Lambda, Not, And, Or, Xor, Nand, Nor, Implies, Equivalent,
     FF, ZZ, QQ, RR, O)
 
 from sympy.printing.pretty import pretty as xpretty
@@ -960,6 +960,59 @@ u"""\
 """
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
+
+    expr = 2*binomial(n, k)
+    ascii_str = \
+"""\
+  /n\\\n\
+2*| |\n\
+  \k/\
+"""
+    ucode_str = \
+u"""\
+  ⎛n⎞\n\
+2⋅⎜ ⎟\n\
+  ⎝k⎠\
+"""
+
+    assert  pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = 2*binomial(2*n, k)
+    ascii_str = \
+"""\
+  /2*n\\\n\
+2*|   |\n\
+  \ k /\
+"""
+    ucode_str = \
+u"""\
+  ⎛2⋅n⎞\n\
+2⋅⎜   ⎟\n\
+  ⎝ k ⎠\
+"""
+
+    assert  pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = 2*binomial(n**2, k)
+    ascii_str = \
+"""\
+  / 2\\\n\
+  |n |\n\
+2*|  |\n\
+  \k /\
+"""
+    ucode_str = \
+u"""\
+  ⎛ 2⎞\n\
+  ⎜n ⎟\n\
+2⋅⎜  ⎟\n\
+  ⎝k ⎠\
+"""
+
+    assert  pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
 
     expr = conjugate(x)
     ascii_str = \

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -625,10 +625,10 @@ def rsolve(f, y, init=None):
        >>> f = (n-1)*y(n+2) - (n**2+3*n-2)*y(n+1) + 2*n*(n+1)*y(n)
 
        >>> rsolve(f, y(n))
-       C0*gamma(1 + n) + C1*2**n
+       C0*n! + C1*2**n
 
        >>> rsolve(f, y(n), { y(0):0, y(1):3 })
-       -3*gamma(1 + n) + 3*2**n
+       -3*n! + 3*2**n
 
     """
     if isinstance(f, Equality):

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1,11 +1,10 @@
-from sympy import Function, dsolve, Symbol, sin, cos, sinh, acos, tan, cosh, \
-        I, exp, log, simplify, normal, together, powsimp, \
-        fraction, radsimp, Eq, sqrt, pi, erf,  diff, Rational, asinh, trigsimp, \
-        S, RootOf, Poly, Integral, atan, Equality, solve, O, LambertW, Dummy, \
-        pure
+from sympy import (Function, dsolve, Symbol, sin, cos, sinh, acos, tan, cosh,
+    I, exp, log, simplify, together, powsimp, fraction, radsimp, Eq, sqrt, pi,
+    erf,  diff, Rational, asinh, trigsimp, S, RootOf, Poly, Integral, atan,
+    Equality, solve, O, LambertW, Dummy, pure)
 from sympy.abc import x, y, z
 from sympy.solvers.ode import ode_order, homogeneous_order, \
-        _undetermined_coefficients_match, classify_ode, checkodesol, constant_renumber
+    _undetermined_coefficients_match, classify_ode, checkodesol, constant_renumber
 from sympy.utilities.pytest import XFAIL, skip, raises
 
 C1 = Symbol('C1')


### PR DESCRIPTION
Now we can work with hypergeometric summations, e.g.:

<pre>
In [1]: summation(binomial(2*k, k)/4**k, (k, 0, n))
Out[1]: 
 -n                           
4  ⋅(1 + 2⋅n)⋅Binomial(2⋅n, n)
</pre>

The algorithm itself is implemented in `gosper_sum` in `sympy.concrete.gosper`. Added tests, doctests and preliminary documentation. All tests and doctests pass. To make results from `gosper_sum` look better I disabled automatic rewriting of `factorial()` and `binomial()` in terms of `gamma()` function (no tests failed due to this change).
