### PR TITLE
1766a separatevars obeys power rules

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1718,7 +1718,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.simplify import nsimplify
         return nsimplify(self, constants, tolerance, full)
 
-    def separate(self, deep=False):
+    def separate(self, deep=False, force=True):
         """See the separate function in sympy.simplify"""
         from sympy.simplify import separate
         return separate(self, deep)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1718,7 +1718,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.simplify import nsimplify
         return nsimplify(self, constants, tolerance, full)
 
-    def separate(self, deep=False, force=True):
+    def separate(self, deep=False, force=False):
         """See the separate function in sympy.simplify"""
         from sympy.simplify import separate
         return separate(self, deep)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -640,29 +640,19 @@ def _separatevars(expr, force):
 def _separatevars_dict(expr, *symbols):
     if symbols:
         assert all((t.is_Atom for t in symbols)), "symbols must be Atoms."
-    ret = dict(((i,sympify(1)) for i in symbols))
-    ret['coeff'] = sympify(1)
-    if expr.is_Mul:
-        for i in expr.args:
-            expsym = i.atoms(Symbol)
-            intersection = set(symbols).intersection(expsym)
-            if len(intersection) > 1:
-                return None
-            if len(intersection) == 0:
-                # There are no symbols, so it is part of the coefficient
-                ret['coeff'] *= i
-            else:
-                ret[intersection.pop()] *= i
-    else:
-        expsym = expr.atoms(Symbol)
+
+    ret = dict(((i, S.One) for i in symbols + ('coeff',)))
+
+    for i in Mul.make_args(expr):
+        expsym = i.free_symbols
         intersection = set(symbols).intersection(expsym)
         if len(intersection) > 1:
             return None
         if len(intersection) == 0:
             # There are no symbols, so it is part of the coefficient
-            ret['coeff'] *= expr
+            ret['coeff'] *= i
         else:
-            ret[intersection.pop()] *= expr
+            ret[intersection.pop()] *= i
 
     return ret
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -110,15 +110,15 @@ def denom_expand(expr):
     return a / b.expand()
 
 def separate(expr, deep=False, force=True):
-    """A wrapper to expand(power_base=True, force=True) which separates a power with a
-       base that is a Mul into a product of powers without performing any other
-       expansions and without regard to assumptions on variables.
+    """A wrapper to expand(power_base=True, force=True) which separates a power
+       with a base that is a Mul into a product of powers without performing
+       any other expansions and without regard to assumptions on variables.
 
-       deep=True will do separations inside functions.
+       deep=True (default is False) will do separations inside functions.
 
-       force=False will cause assumptions regarding the sign of base or type
-       of exponent to be regarded and will prevent separations of bases having
-       no assumptions regarding sign.
+       force=True (default) will cause the expansion to ignore assumptions
+       about the base and exponent. When False, the expansion will only happen
+       if the base is non-negative or the exponent is an integer.
 
        >>> from sympy.abc import x, y, z
        >>> from sympy import separate, sin, cos, exp

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -109,14 +109,15 @@ def denom_expand(expr):
     a, b = fraction(expr)
     return a / b.expand()
 
-def separate(expr, deep=False, force=True):
-    """A wrapper to expand(power_base=True, force=True) which separates a power
-       with a base that is a Mul into a product of powers without performing
-       any other expansions and without regard to assumptions on variables.
+def separate(expr, deep=False, force=False):
+    """A wrapper to expand(power_base=True) which separates a power
+       with a base that is a Mul into a product of powers, without performing
+       any other expansions, provided that assumptions about the power's base
+       and exponent allow.
 
        deep=True (default is False) will do separations inside functions.
 
-       force=True (default) will cause the expansion to ignore assumptions
+       force=True (default is False) will cause the expansion to ignore assumptions
        about the base and exponent. When False, the expansion will only happen
        if the base is non-negative or the exponent is an integer.
 
@@ -129,14 +130,14 @@ def separate(expr, deep=False, force=True):
        >>> separate((x*(y*z)**3)**2)
        x**2*y**6*z**6
 
-       >>> separate((x*sin(x))**y + (x*cos(x))**y)
-       x**y*sin(x)**y + x**y*cos(x)**y
+       >>> separate((2*sin(x))**y + (2*cos(x))**y)
+       2**y*sin(x)**y + 2**y*cos(x)**y
 
-       >>> separate((exp(x)*exp(y))**x)
-       exp(x**2)*exp(x*y)
+       >>> separate((2*exp(y))**x)
+       2**x*exp(x*y)
 
-       >>> separate((sin(x)*cos(x))**y)
-       sin(x)**y*cos(x)**y
+       >>> separate((2*cos(x))**y)
+       2**y*cos(x)**y
 
        Notice that summations are left untouched. If this is not the
        requested behavior, apply 'expand' to input expression before:
@@ -144,8 +145,8 @@ def separate(expr, deep=False, force=True):
        >>> separate(((x+y)*z)**2)
        z**2*(x + y)**2
 
-       >>> separate((x*y)**(1+z))
-       x**(z + 1)*y**(z + 1)
+       >>> separate((2*y)**(1+z))
+       2**(z + 1)*y**(z + 1)
 
     """
     return sympify(expr).expand(deep=deep, mul=False, power_exp=False,\

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -117,18 +117,29 @@ def separate(expr, deep=False, force=False):
 
        deep=True (default is False) will do separations inside functions.
 
-       force=True (default is False) will cause the expansion to ignore assumptions
-       about the base and exponent. When False, the expansion will only happen
-       if the base is non-negative or the exponent is an integer.
+       force=True (default is False) will cause the expansion to ignore
+       assumptions about the base and exponent. When False, the expansion will
+       only happen if the base is non-negative or the exponent is an integer.
 
        >>> from sympy.abc import x, y, z
        >>> from sympy import separate, sin, cos, exp
 
-       >>> separate((x*y)**2)
+       >>> (x*y)**2
        x**2*y**2
 
-       >>> separate((x*(y*z)**3)**2)
-       x**2*y**6*z**6
+       >>> (2*x)**y
+       (2*x)**y
+       >>> separate(_)
+       2**y*x**y
+
+       >>> separate((x*y)**z)
+       (x*y)**z
+       >>> separate((x*y)**z, force=True)
+       x**z*y**z
+       >>> separate(sin((x*y)**z))
+       sin((x*y)**z)
+       >>> separate(sin((x*y)**z), deep=True, force=True)
+       sin(x**z*y**z)
 
        >>> separate((2*sin(x))**y + (2*cos(x))**y)
        2**y*sin(x)**y + 2**y*cos(x)**y
@@ -140,13 +151,17 @@ def separate(expr, deep=False, force=False):
        2**y*cos(x)**y
 
        Notice that summations are left untouched. If this is not the
-       requested behavior, apply 'expand' to input expression before:
+       desired behavior, apply 'expand' to the expression:
 
        >>> separate(((x+y)*z)**2)
        z**2*(x + y)**2
+       >>> (((x+y)*z)**2).expand()
+       x**2*z**2 + 2*x*y*z**2 + y**2*z**2
 
        >>> separate((2*y)**(1+z))
        2**(z + 1)*y**(z + 1)
+       >>> ((2*y)**(1+z)).expand()
+       2*2**z*y*y**z
 
     """
     return sympify(expr).expand(deep=deep, mul=False, power_exp=False,\
@@ -542,12 +557,18 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     other symbols or non-symbols will be returned keyed to the
     string 'coeff'.
 
+    If force=True, then power bases will only be separated if assumptions allow.
+
     Note: the order of the factors is determined by Mul, so that the
     separated expressions may not necessarily be grouped together.
 
     Examples:
     >>> from sympy.abc import x, y, z, alpha
     >>> from sympy import separatevars, sin
+    >>> separatevars((x*y)**y)
+    (x*y)**y
+    >>> separatevars((x*y)**y, force=True)
+    x**y*y**y
     >>> separatevars(2*x**2*z*sin(y)+2*z*x**2)
     2*x**2*z*(sin(y) + 1)
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -109,9 +109,16 @@ def denom_expand(expr):
     a, b = fraction(expr)
     return a / b.expand()
 
-def separate(expr, deep=False):
-    """Rewrite or separate a power of product to a product of powers
-       but without any expanding, i.e., rewriting products to summations.
+def separate(expr, deep=False, force=True):
+    """A wrapper to expand(power_base=True, force=True) which separates a power with a
+       base that is a Mul into a product of powers without performing any other
+       expansions and without regard to assumptions on variables.
+
+       deep=True will do separations inside functions.
+
+       force=False will cause assumptions regarding the sign of base or type
+       of exponent to be regarded and will prevent separations of bases having
+       no assumptions regarding sign.
 
        >>> from sympy.abc import x, y, z
        >>> from sympy import separate, sin, cos, exp
@@ -141,27 +148,8 @@ def separate(expr, deep=False):
        x**(z + 1)*y**(z + 1)
 
     """
-    expr = sympify(expr)
-
-    if expr.is_Pow:
-        terms, expo = [], separate(expr.exp, deep)
-
-        if expr.base.is_Mul:
-            t = [separate(Pow(t,expo), deep) for t in expr.base.args]
-            return Mul(*t)
-        elif expr.base.func is C.exp:
-            if deep == True:
-                return C.exp(separate(expr.base[0], deep)*expo)
-            else:
-                return C.exp(expr.base[0]*expo)
-        else:
-            return Pow(separate(expr.base, deep), expo)
-    elif expr.is_Add or expr.is_Mul:
-        return type(expr)(*[separate(t, deep) for t in expr.args])
-    elif expr.is_Function and deep:
-        return expr.func(*[separate(t) for t in expr.args])
-    else:
-        return expr
+    return sympify(expr).expand(deep=deep, mul=False, power_exp=False,\
+    power_base=True, basic=False, multinomial=False, log=False, force=force)
 
 def collect(expr, syms, evaluate=True, exact=False):
     """
@@ -1897,4 +1885,3 @@ def _logcombine(expr, force=False):
         _logcombine(expr.args[1], force)
 
     return expr
-

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -435,7 +435,16 @@ def test_separatevars():
     # 1759
     p=Symbol('p',positive=True)
     assert separatevars(sqrt(p**2 + x*p**2)) == p*sqrt(1 + x)
-    assert separatevars(sqrt(y*(p**2 + x*p**2))) == p*sqrt(y)*sqrt(1 + x)
+    assert separatevars(sqrt(y*(p**2 + x*p**2))) == p*sqrt(y*(1 + x))
+    assert separatevars(sqrt(y*(p**2 + x*p**2)), force=True) == p*sqrt(y)*sqrt(1 + x)
+    # 1766
+    assert separatevars(sqrt(x*y)).is_Pow
+    assert separatevars(sqrt(x*y), force=True) == sqrt(x)*sqrt(y)
+
+@XFAIL
+def test_separation_by_factor():
+    x,y = symbols('x,y')
+    assert factor(sqrt(x*y), expand=False).is_Pow
 
 def test_separatevars_advanced_factor():
     x,y,z = symbols('x,y,z')

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -219,21 +219,22 @@ def test_separate():
     x, y, z = symbols('x,y,z')
 
     assert separate((x*y*z)**4) == x**4*y**4*z**4
-    assert separate((x*y*z)**x) == x**x*y**x*z**x
+    assert separate((x*y*z)**x).is_Pow
+    assert separate((x*y*z)**x, force=True) == x**x*y**x*z**x
     assert separate((x*(y*z)**2)**3) == x**3*y**6*z**6
 
-    assert separate((sin((x*y)**2)*y)**z) == sin((x*y)**2)**z*y**z
-    assert separate((sin((x*y)**2)*y)**z, deep=True) == sin(x**2*y**2)**z*y**z
+    assert separate((sin((x*y)**2)*y)**z).is_Pow
+    assert separate((sin((x*y)**2)*y)**z, force=True) == sin((x*y)**2)**z*y**z
+    assert separate((sin((x*y)**2)*y)**z, deep=True) == (sin(x**2*y**2)*y)**z
 
     assert separate(exp(x)**2) == exp(2*x)
     assert separate((exp(x)*exp(y))**2) == exp(2*x)*exp(2*y)
 
     assert separate((exp((x*y)**z)*exp(y))**2) == exp(2*(x*y)**z)*exp(2*y)
-    assert separate((exp((x*y)**z)*exp(y))**2, deep=True) == exp(2*x**z*y**z)*exp(2*y)
+    assert separate((exp((x*y)**z)*exp(y))**2, deep=True, force=True) == exp(2*x**z*y**z)*exp(2*y)
 
-def test_separate_X1():
-    x, y, z = map(Symbol, 'xyz')
-    assert separate((exp(x)*exp(y))**z) == exp(x*z)*exp(y*z)
+    assert separate((exp(x)*exp(y))**z).is_Pow
+    assert separate((exp(x)*exp(y))**z, force=True) == exp(x*z)*exp(y*z)
 
 def test_powsimp():
     x, y, z, n = symbols('x,y,z,n')


### PR DESCRIPTION
and separate is now a wrapper to the power_base expansion with force=True.

A cleanup of _separatevars_dict was done, too.

Longer comments at issue 1766.
