### PR TITLE
Rename 'Real' to 'Float' (see issue #1721).

### DIFF
--- a/doc/src/gotchas.txt
+++ b/doc/src/gotchas.txt
@@ -278,10 +278,10 @@ to a Python expression.  Use the :func:`sympify` function, or just
     6.2000000000000002
     >>> type(6.2)
     <type 'float'>
-    >>> S(6.2) # SymPy Real has no such problems because of arbitrary precision.
+    >>> S(6.2) # SymPy Float has no such problems because of arbitrary precision.
     6.20000000000000
     >>> type(S(6.2))
-    <class 'sympy.core.numbers.Real'>
+    <class 'sympy.core.numbers.Float'>
 
 If you include numbers in a SymPy expression, they will be sympified
 automatically, but there is one gotcha you should be aware of.  If you

--- a/doc/src/guide.txt
+++ b/doc/src/guide.txt
@@ -114,8 +114,8 @@ Basics
 
 All symbolic things are implemented using subclasses of the ``Basic`` class.
 First, you need to create symbols using ``Symbol("x")`` or numbers using
-``Integer(5)`` or ``Real(34.3)``. Then you construct the expression using any
-class from SymPy.  For example ``Add(Symbol("a"),Symbol("b"))`` gives an
+``Integer(5)`` or ``Float(34.3)``. Then you construct the expression using any
+class from SymPy.  For example ``Add(Symbol("a"), Symbol("b"))`` gives an
 instance of the ``Add`` class.  You can call all methods, which the particular
 class supports.
 

--- a/doc/src/modules/evalf.txt
+++ b/doc/src/modules/evalf.txt
@@ -75,22 +75,22 @@ significantly speed up computations such as the one above.
 Floating-point numbers
 ----------------------
 
-Floating-point numbers in SymPy are instances of the class ``Real``. A ``Real``
+Floating-point numbers in SymPy are instances of the class ``Float``. A ``Float``
 can be created with a custom precision as second argument:
 
-    >>> Real(0.1)
+    >>> Float(0.1)
     0.100000000000000
-    >>> Real(0.1, 10)
+    >>> Float(0.1, 10)
     0.1000000000
-    >>> Real(0.1, 30)
+    >>> Float(0.1, 30)
     0.100000000000000005551115123126
 
 
 As the last example shows, Python floats are only accurate to about 15 digits as
-inputs. To create a ``Real`` from a high-precision decimal number, it is better
+inputs. To create a ``Float`` from a high-precision decimal number, it is better
 to pass a string or ``evalf`` a ``Rational``:
 
-    >>> Real('0.1', 30)
+    >>> Float('0.1', 30)
     0.100000000000000000000000000000
     >>> Rational(1,10).evalf(30)
     0.100000000000000000000000000000
@@ -357,7 +357,7 @@ and a minimum numerical tolerance. Here are some elementary examples:
 
 Here are several more advanced examples:
 
-    >>> nsimplify(Real('0.130198866629986772369127970337',30), [pi, E])
+    >>> nsimplify(Float('0.130198866629986772369127970337',30), [pi, E])
         1
     ----------
           5*pi

--- a/doc/src/tutorial.txt
+++ b/doc/src/tutorial.txt
@@ -123,7 +123,7 @@ Documentation can be found at http://www.sympy.org
 Using SymPy as a calculator
 ---------------------------
 
-Sympy has three built-in numeric types: Real, Rational and Integer.
+Sympy has three built-in numeric types: Float, Rational and Integer.
 
 The Rational class represents a rational number as a pair of two Integers: the numerator and the denominator, so Rational(1,2) represents 1/2, Rational(5,2) 5/2 and so on.
 

--- a/examples/beginner/substitution.py
+++ b/examples/beginner/substitution.py
@@ -20,7 +20,7 @@ def main():
     pprint(e.subs(sympy.cos(x), y).subs(y, x**2))
 
     e = 1/sympy.log(x)
-    e = e.subs(x, sympy.Real("2.71828"))
+    e = e.subs(x, sympy.Float("2.71828"))
     print '\n'
     pprint(e)
     print '\n'

--- a/examples/intermediate/sample.py
+++ b/examples/intermediate/sample.py
@@ -6,7 +6,7 @@ graphing functions using matplotlib.
 """
 
 from numpy import repeat, arange, empty, ndarray, array
-from sympy import Symbol, Basic, Real, Rational, I, sympify
+from sympy import Symbol, Basic, Rational, I, sympify
 
 def sample2d(f, x_args):
     """
@@ -52,7 +52,7 @@ def sample3d(f, x_args, y_args):
     try:
         f = sympify(f)
     except:
-        raise ValueError("f could not be interpretted as a SymPy function")
+        raise ValueError("f could not be interpreted as a SymPy function")
     try:
         x, x_min, x_max, x_n = x_args
         y, y_min, y_max, y_n = y_args

--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -58,7 +58,7 @@ class AskPrimeHandler(CommonHandler):
         return False
 
     @staticmethod
-    def Real(expr, assumptions):
+    def Float(expr, assumptions):
         return AskPrimeHandler._number(expr, assumptions)
 
     @staticmethod
@@ -167,7 +167,7 @@ class AskEvenHandler(CommonHandler):
         return False
 
     @staticmethod
-    def Real(expr, assumptions):
+    def Float(expr, assumptions):
         return expr % 2 == 0
 
     @staticmethod

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -73,7 +73,7 @@ class AskIntegerHandler(CommonHandler):
         return False
 
     @staticmethod
-    def Real(expr, assumptions):
+    def Float(expr, assumptions):
         return int(expr) == expr
 
     @staticmethod
@@ -138,7 +138,7 @@ class AskRationalHandler(CommonHandler):
         return True
 
     @staticmethod
-    def Real(expr, assumptions):
+    def Float(expr, assumptions):
         # it's finite-precission
         return True
 
@@ -240,7 +240,7 @@ class AskRealHandler(CommonHandler):
         return True
 
     @staticmethod
-    def Real(expr, assumptions):
+    def Float(expr, assumptions):
         return True
 
     @staticmethod

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,4 +1,4 @@
-from sympy import (S, Symbol, Sum, oo, Real, Rational, summation, pi, cos,
+from sympy import (S, Symbol, Sum, oo, Float, Rational, summation, pi, cos,
     zeta, exp, log, factorial, sqrt, E, sympify, binomial, harmonic, Catalan,
     EulerGamma, Function, Integral, Product, product, nan, diff, Derivative)
 from sympy.concrete.summations import telescopic

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -7,7 +7,7 @@ from basic import Basic, Atom, C
 from singleton import S
 from expr import Expr, AtomicExpr
 from symbol import Symbol, Wild, Dummy, symbols, var, Pure
-from numbers import Number, Real, Rational, Integer, NumberSymbol,\
+from numbers import Number, Float, Rational, Integer, NumberSymbol,\
         RealNumber, igcd, ilcm, seterr, E, I, nan, oo, pi, zoo
 from power import Pow, integer_nthroot
 from mul import Mul

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -8,7 +8,7 @@ from singleton import S
 from expr import Expr, AtomicExpr
 from symbol import Symbol, Wild, Dummy, symbols, var, Pure
 from numbers import Number, Float, Rational, Integer, NumberSymbol,\
-        RealNumber, igcd, ilcm, seterr, E, I, nan, oo, pi, zoo
+        RealNumber, Real, igcd, ilcm, seterr, E, I, nan, oo, pi, zoo
 from power import Pow, integer_nthroot
 from mul import Mul
 from add import Add

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -59,7 +59,7 @@ class Basic(AssumeMeths):
     is_Mul = False
     is_Pow = False
     is_Number = False
-    is_Real = False
+    is_Float = False
     is_Rational = False
     is_Integer = False
     is_NumberSymbol = False

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -5,6 +5,7 @@ from cache import cacheit
 from core import BasicMeta, BasicType, C
 from sympify import _sympify, sympify, SympifyError
 from compatibility import any
+from sympy.core.decorators import deprecated
 
 
 class Basic(AssumeMeths):
@@ -72,6 +73,12 @@ class Basic(AssumeMeths):
     is_Equality = False
     is_Boolean = False
     is_Not = False
+
+    @property
+    @deprecated
+    def is_Real(self):  # pragma: no cover
+        """Deprecated alias for is_Float"""
+        return self.is_Float
 
     def __new__(cls, *args, **assumptions):
         obj = object.__new__(cls)

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -275,7 +275,7 @@ class Memoizer_nocache(Memoizer):
 
     def __call__(self, func):
         # XXX I would be happy just to return func, but we need to provide
-        # argument convertion, and it is really needed for e.g. Real("0.5")
+        # argument convertion, and it is really needed for e.g. Float("0.5")
         @wraps(func)
         def wrapper(*args, **kw_args):
             kw_items = tuple(kw_args.items())

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -9,7 +9,7 @@ ordering_of_classes = [
     # singleton numbers
     'Zero', 'One','Half','Infinity','NaN','NegativeOne','NegativeInfinity',
     # numbers
-    'Integer','Rational','Real',
+    'Integer','Rational','Float',
     # singleton symbols
     'Exp1','Pi','ImaginaryUnit',
     # symbols

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -617,7 +617,7 @@ def evalf_piecewise(expr, prec, options):
         if hasattr(expr,'func'):
             return evalf(expr, prec, options)
         if type(expr) == float:
-            return evalf(C.Real(expr), prec, options)
+            return evalf(C.Float(expr), prec, options)
         if type(expr) == int:
             return evalf(C.Integer(expr), prec, options)
 
@@ -866,7 +866,7 @@ def evalf_sum(expr, prec, options):
         return v, None, min(prec, delta), None
     except NotImplementedError:
         # Euler-Maclaurin summation for general series
-        eps = C.Real(2.0)**(-prec)
+        eps = C.Float(2.0)**(-prec)
         for i in range(1, 5):
             m = n = 2**i * prec
             s, err = expr.euler_maclaurin(m=m, n=n, eps=eps, \
@@ -911,7 +911,7 @@ def _create_evalf_table():
     evalf_table = {
     C.Symbol : evalf_symbol,
     C.Dummy : evalf_symbol,
-    C.Real : lambda x, prec, options: (x._mpf_, None, prec, None),
+    C.Float : lambda x, prec, options: (x._mpf_, None, prec, None),
     C.Rational : lambda x, prec, options: (from_rational(x.p, x.q, prec), None, prec, None),
     C.Integer : lambda x, prec, options: (from_int(x.p, prec), None, prec, None),
     C.Zero : lambda x, prec, options: (None, None, prec, None),
@@ -1035,13 +1035,13 @@ class EvalfMixin(object):
         if re:
             p = max(min(prec, re_acc), 1)
             #re = mpf_pos(re, p, round_nearest)
-            re = C.Real._new(re, p)
+            re = C.Float._new(re, p)
         else:
             re = S.Zero
         if im:
             p = max(min(prec, im_acc), 1)
             #im = mpf_pos(im, p, round_nearest)
-            im = C.Real._new(im, p)
+            im = C.Float._new(im, p)
             return re + im*S.ImaginaryUnit
         else:
             return re
@@ -1066,19 +1066,19 @@ class EvalfMixin(object):
         v = self._eval_evalf(prec)
         if v is None:
             raise ValueError(errmsg)
-        if v.is_Real:
+        if v.is_Float:
             return make_mpf(v._mpf_)
         # Number + Number*I is also fine
         re, im = v.as_real_imag()
         if allow_ints and re.is_Integer:
             re = from_int(re.p)
-        elif re.is_Real:
+        elif re.is_Float:
             re = re._mpf_
         else:
             raise ValueError(errmsg)
         if allow_ints and im.is_Integer:
             im = from_int(im.p)
-        elif im.is_Real:
+        elif im.is_Float:
             im = im._mpf_
         else:
             raise ValueError(errmsg)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -106,11 +106,11 @@ class Expr(Basic, EvalfMixin):
     @staticmethod
     def _from_mpmath(x, prec):
         if hasattr(x, "_mpf_"):
-            return C.Real._new(x._mpf_, prec)
+            return C.Float._new(x._mpf_, prec)
         elif hasattr(x, "_mpc_"):
             re, im = x._mpc_
-            re = C.Real._new(re, prec)
-            im = C.Real._new(im, prec)*S.ImaginaryUnit
+            re = C.Float._new(re, prec)
+            im = C.Float._new(im, prec)*S.ImaginaryUnit
             return re+im
         else:
             raise TypeError("expected mpmath number (mpf or mpc)")
@@ -1038,8 +1038,8 @@ class Expr(Basic, EvalfMixin):
                     return None
                 else:
                     return quotient
-            elif self.is_Real:
-                if not quotient.is_Real:
+            elif self.is_Float:
+                if not quotient.is_Float:
                     return None
                 elif self.is_positive and quotient.is_negative:
                     return None
@@ -1127,8 +1127,8 @@ class Expr(Basic, EvalfMixin):
                     return None
                 else:
                     return sub
-            elif self.is_Real:
-                if not sub.is_Real:
+            elif self.is_Float:
+                if not sub.is_Float:
                     return None
                 elif self.is_positive and sub.is_negative:
                     return None

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -178,12 +178,12 @@ class Function(Application, Expr):
         ARG is a floating point number.
         This function is used by __new__.
         """
-        if arg.is_Real:
+        if arg.is_Float:
             return True
         if not arg.is_Add:
             return False
         re, im = arg.as_real_imag()
-        return re.is_Real or im.is_Real
+        return re.is_Float or im.is_Float
 
     @property
     def is_commutative(self):
@@ -207,7 +207,7 @@ class Function(Application, Expr):
             func = getattr(mpmath, fname)
         except (AttributeError, KeyError):
             try:
-                return C.Real(self._imp_(*self.args), prec)
+                return C.Float(self._imp_(*self.args), prec)
             except (AttributeError, TypeError):
                 return
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -741,7 +741,7 @@ class Mul(AssocOp):
         if lhs == rhs:
             return S.One
         def check(l, r):
-            if l.is_Real and r.is_comparable:
+            if l.is_Float and r.is_comparable:
                 return Add(l, 0) == Add(r.evalf(), 0)
             return False
         if check(lhs, rhs) or check(rhs, lhs):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3,7 +3,7 @@ from sympify import converter, sympify, _sympify, SympifyError
 from basic import Basic
 from singleton import S, Singleton
 from expr import Expr, AtomicExpr
-from decorators import _sympifyit
+from decorators import _sympifyit, deprecated
 from cache import cacheit, clear_cache
 import sympy.mpmath as mpmath
 import sympy.mpmath.libmp as mlib
@@ -439,6 +439,11 @@ converter[float] = converter[decimal.Decimal] = Float
 
 # this is here to work nicely in Sage
 RealNumber = Float
+
+@deprecated
+def Real(*args, **kwargs):  # pragma: no cover
+    """Deprecated alias for the Float constructor."""
+    return Float(*args, **kwargs)
 
 class Rational(Number):
     """Represents integers and rational numbers (p/q) of any size.

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -106,7 +106,7 @@ class Number(AtomicExpr):
     """
     Represents any kind of number in sympy.
 
-    Floating point numbers are represented by the Real class.
+    Floating point numbers are represented by the Float class.
     Integer numbers (of any size), together with rational numbers (again, there
     is no limit on their size) are represented by the Rational class.
 
@@ -134,7 +134,7 @@ class Number(AtomicExpr):
         if isinstance(obj, tuple) and len(obj) == 2:
             return Rational(*obj)
         if isinstance(obj, (float, mpmath.mpf, decimal.Decimal)):
-            return Real(obj)
+            return Float(obj)
         if isinstance(obj, str):
             val = sympify(obj)
             if isinstance(val, Number):
@@ -151,7 +151,7 @@ class Number(AtomicExpr):
             (self.__class__.__name__))
 
     def _eval_evalf(self, prec):
-        return Real._new(self._as_mpf_val(prec), prec)
+        return Float._new(self._as_mpf_val(prec), prec)
 
     def _as_mpf_op(self, prec):
         prec = max(prec, self._prec)
@@ -221,22 +221,22 @@ class Number(AtomicExpr):
         """Efficiently extract the coefficient of a product. """
         return self, S.One
 
-class Real(Number):
+class Float(Number):
     """
     Represents a floating point number. It is capable of representing
     arbitrary-precision floating-point numbers
 
     Usage:
     ======
-        Real(3.5)   .... 3.5 (the 3.5 was converted from a python float)
-        Real("3.0000000000000005")
+        Float(3.5)   .... 3.5 (the 3.5 was converted from a python float)
+        Float("3.0000000000000005")
 
-        Real((1,3,0,2)) # mpmath tuple: (-1)**1 * 3 * 2**0; 3 has 2 bits
+        Float((1,3,0,2)) # mpmath tuple: (-1)**1 * 3 * 2**0; 3 has 2 bits
         -3.00000000000000
 
     Notes:
     ======
-        - Real(x) with x being a Python int/long will return Integer(x)
+        - Float(x) with x being a Python int/long will return Integer(x)
     """
     is_real = True
     is_irrational = False
@@ -259,7 +259,7 @@ class Real(Number):
         self._mpf_ = _mpf_
         Expr.__setstate__(self, d)
 
-    is_Real = True
+    is_Float = True
 
     def floor(self):
         return C.Integer(int(mlib.to_int(mlib.mpf_floor(self._mpf_, self._prec))))
@@ -321,20 +321,20 @@ class Real(Number):
         return self.num < 0
 
     def __neg__(self):
-        return Real._new(mlib.mpf_neg(self._mpf_), self._prec)
+        return Float._new(mlib.mpf_neg(self._mpf_), self._prec)
 
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
         if isinstance(other, Number):
             rhs, prec = other._as_mpf_op(self._prec)
-            return Real._new(mlib.mpf_mul(self._mpf_, rhs, prec, rnd), prec)
+            return Float._new(mlib.mpf_mul(self._mpf_, rhs, prec, rnd), prec)
         return Number.__mul__(self, other)
 
     @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
         if isinstance(other, Number):
             rhs, prec = other._as_mpf_op(self._prec)
-            return Real._new(mlib.mpf_mod(self._mpf_, rhs, prec, rnd), prec)
+            return Float._new(mlib.mpf_mod(self._mpf_, rhs, prec, rnd), prec)
         return Number.__mod__(self, other)
 
     @_sympifyit('other', NotImplemented)
@@ -343,12 +343,11 @@ class Real(Number):
             return S.NaN
         if isinstance(other, Number):
             rhs, prec = other._as_mpf_op(self._prec)
-            return Real._new(mlib.mpf_add(self._mpf_, rhs, prec, rnd), prec)
+            return Float._new(mlib.mpf_add(self._mpf_, rhs, prec, rnd), prec)
         return Number.__add__(self, other)
 
-    def _eval_power(b, e):
+    def _eval_power(self, e):
         """
-        b is Real but not equal to rationals, integers, 0.5, oo, -oo, nan
         e is symbolic object but not equal to 0, 1
 
         (-p) ** r -> exp(r * log(-p)) -> exp(r * (log(p) + I*Pi)) ->
@@ -356,19 +355,19 @@ class Real(Number):
         """
         if isinstance(e, Number):
             if isinstance(e, Integer):
-                prec = b._prec
-                return Real._new(mlib.mpf_pow_int(b._mpf_, e.p, prec, rnd), prec)
-            e, prec = e._as_mpf_op(b._prec)
-            b = b._mpf_
+                prec = self._prec
+                return Float._new(mlib.mpf_pow_int(self._mpf_, e.p, prec, rnd), prec)
+            e, prec = e._as_mpf_op(self._prec)
+            b = self._mpf_
             try:
                 y = mpf_pow(b, e, prec, rnd)
-                return Real._new(y, prec)
+                return Float._new(y, prec)
             except mlib.ComplexResult:
                 re, im = mlib.mpc_pow((b, mlib.fzero), (e, mlib.fzero), prec, rnd)
-                return Real._new(re, prec) + Real._new(im, prec) * S.ImaginaryUnit
+                return Float._new(re, prec) + Float._new(im, prec) * S.ImaginaryUnit
 
     def __abs__(self):
-        return Real._new(mlib.mpf_abs(self._mpf_), self._prec)
+        return Float._new(mlib.mpf_abs(self._mpf_), self._prec)
 
     def __int__(self):
         return int(mlib.to_int(self._mpf_))
@@ -385,7 +384,7 @@ class Real(Number):
             return False
         if isinstance(other, Number):
             return bool(mlib.mpf_eq(self._mpf_, other._as_mpf_val(self._prec)))
-        return False    # Real != non-Number
+        return False    # Float != non-Number
 
     def __ne__(self, other):
         try:
@@ -399,7 +398,7 @@ class Real(Number):
             return True
         if isinstance(other, Number):
             return bool(not mlib.mpf_eq(self._mpf_, other._as_mpf_val(self._prec)))
-        return True     # Real != non-Number
+        return True     # Float != non-Number
 
     def __lt__(self, other):
         try:
@@ -426,20 +425,20 @@ class Real(Number):
         return Expr.__le__(self, other)
 
     def __hash__(self):
-        return super(Real, self).__hash__()
+        return super(Float, self).__hash__()
 
     def epsilon_eq(self, other, epsilon="10e-16"):
-        return abs(self - other) < Real(epsilon)
+        return abs(self - other) < Float(epsilon)
 
     def _sage_(self):
         import sage.all as sage
         return sage.RealNumber(str(self))
 
 # Add sympify converters
-converter[float] = converter[decimal.Decimal] = Real
+converter[float] = converter[decimal.Decimal] = Float
 
 # this is here to work nicely in Sage
-RealNumber = Real
+RealNumber = Float
 
 class Rational(Number):
     """Represents integers and rational numbers (p/q) of any size.
@@ -500,7 +499,7 @@ class Rational(Number):
                return p
             if isinstance(p, basestring):
                 try:
-                    # we might have a Real
+                    # we might have a Float
                     neg_pow, digits, expt = decimal.Decimal(p).as_tuple()
                     p = [1, -1][neg_pow] * int("".join(str(x) for x in digits))
                     if expt > 0:
@@ -624,7 +623,7 @@ class Rational(Number):
     def __mul__(self, other):
         if (other is S.NaN) or (self is S.NaN):
             return S.NaN
-        if isinstance(other, Real):
+        if isinstance(other, Float):
             return other * self
         if isinstance(other, Rational):
             return Rational(self.p * other.p, self.q * other.q)
@@ -635,7 +634,7 @@ class Rational(Number):
         if isinstance(other, Rational):
             n = (self.p*other.q) // (other.p*self.q)
             return Rational(self.p*other.q - n*other.p*self.q, self.q*other.q)
-        if isinstance(other, Real):
+        if isinstance(other, Float):
             return self.evalf() % other
         return Number.__mod__(self, other)
 
@@ -644,7 +643,7 @@ class Rational(Number):
     def __add__(self, other):
         if (other is S.NaN) or (self is S.NaN):
             return S.NaN
-        if isinstance(other, Real):
+        if isinstance(other, Float):
             return other + self
         if isinstance(other, Rational):
             if self.is_unbounded:
@@ -661,7 +660,7 @@ class Rational(Number):
     def _eval_power(b, e):
         if (e is S.NaN): return S.NaN
         if isinstance(e, Number):
-            if isinstance(e, Real):
+            if isinstance(e, Float):
                 return b._eval_evalf(e._prec) ** e
             if e.is_negative:
                 # (3/4)**-2 -> (4/3)**2
@@ -726,7 +725,7 @@ class Rational(Number):
         if other.is_comparable and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
-            if isinstance(other, Real):
+            if isinstance(other, Float):
                 return bool(mlib.mpf_eq(self._as_mpf_val(other._prec), other._mpf_))
             return bool(self.p==other.p and self.q==other.q)
 
@@ -745,7 +744,7 @@ class Rational(Number):
         if other.is_comparable and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
-            if isinstance(other, Real):
+            if isinstance(other, Float):
                 return bool(not mlib.mpf_eq(self._as_mpf_val(other._prec), other._mpf_))
             return bool(self.p!=other.p or self.q!=other.q)
 
@@ -761,7 +760,7 @@ class Rational(Number):
         if other.is_comparable and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
-            if isinstance(other, Real):
+            if isinstance(other, Float):
                 return bool(mlib.mpf_lt(self._as_mpf_val(other._prec), other._mpf_))
             return bool(self.p * other.q < self.q * other.p)
         return Expr.__lt__(self, other)
@@ -776,7 +775,7 @@ class Rational(Number):
         if other.is_comparable and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
-            if isinstance(other, Real):
+            if isinstance(other, Float):
                 return bool(mlib.mpf_le(self._as_mpf_val(other._prec), other._mpf_))
             return bool(self.p * other.q <= self.q * other.p)
         return Expr.__le__(self, other)
@@ -1372,8 +1371,8 @@ class NegativeOne(IntegerConstant):
         if e.is_odd: return S.NegativeOne
         if e.is_even: return S.One
         if isinstance(e, Number):
-            if isinstance(e, Real):
-                return Real(-1.0) ** e
+            if isinstance(e, Float):
+                return Float(-1.0) ** e
             if e is S.NaN:
                 return S.NaN
             if e is S.Infinity  or  e is S.NegativeInfinity:
@@ -1383,7 +1382,7 @@ class NegativeOne(IntegerConstant):
             if isinstance(e, Rational):
                 if e.q == 2:
                     return S.ImaginaryUnit ** Integer(e.p)
-                q = Real(e).floor()
+                q = Float(e).floor()
                 if q:
                     q = Integer(q)
                     return b ** q * b ** (e - q)
@@ -1631,7 +1630,7 @@ class NumberSymbol(AtomicExpr):
         """
 
     def _eval_evalf(self, prec):
-        return Real._new(self._as_mpf_val(prec), prec)
+        return Float._new(self._as_mpf_val(prec), prec)
 
     def __eq__(self, other):
         try:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -629,7 +629,7 @@ class Pow(Expr):
             c, t = exp.as_coeff_mul()
             if c.is_negative:
                 return 1, base**-exp
-        # unprocessed Real and NumberSymbol
+        # unprocessed Float and NumberSymbol
         return self, S.One
 
     def matches(self, expr, repl_dict={}, evaluate=False):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1,7 +1,7 @@
 from basic import Basic
 from singleton import Singleton, S
 from evalf import EvalfMixin
-from numbers import Real
+from numbers import Float
 from sympify import _sympify
 from sympy.mpmath import mpi, mpf
 
@@ -409,12 +409,12 @@ class Interval(Set, EvalfMixin):
     @property
     def is_left_unbounded(self):
         """Return ``True`` if the left endpoint is negative infinity. """
-        return self.left is S.NegativeInfinity or self.left == Real("-inf")
+        return self.left is S.NegativeInfinity or self.left == Float("-inf")
 
     @property
     def is_right_unbounded(self):
         """Return ``True`` if the right endpoint is positive infinity. """
-        return self.right is S.Infinity or self.right == Real("+inf")
+        return self.right is S.Infinity or self.right == Float("+inf")
 
     def as_relational(self, symbol):
         """Rewrite an interval in terms of inequalities and logic operators. """
@@ -437,7 +437,7 @@ class Interval(Set, EvalfMixin):
                     right = Le(symbol, self.right)
 
             if self.is_left_unbounded and self.is_right_unbounded:
-                return True # XXX: Contained(symbol, Reals)
+                return True # XXX: Contained(symbol, Floats)
             elif self.is_left_unbounded:
                 return right
             elif self.is_right_unbounded:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -23,7 +23,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     Converts an arbitrary expression to a type that can be used inside sympy.
 
     For example, it will convert python ints into instance of sympy.Rational,
-    floats into instances of sympy.Real, etc. It is also able to coerce symbolic
+    floats into instances of sympy.Float, etc. It is also able to coerce symbolic
     expressions which inherit from Basic. This can be useful in cooperation
     with SAGE.
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, sin, cos, exp, O, sqrt, Rational, Real, re, pi, \
+from sympy import Symbol, sin, cos, exp, O, sqrt, Rational, Float, re, pi, \
         sympify, sqrt, Add, Mul, Pow, I, log, S
 from sympy.utilities.pytest import XFAIL
 
@@ -236,9 +236,9 @@ def test_power_expand():
     assert (A**(a+b)).expand() != A**(a+b)
 
 def test_real_mul():
-    Real(0) * pi * x == Real(0)
-    Real(1) * pi * x == pi * x
-    len((Real(2) * pi * x).args) == 3
+    Float(0) * pi * x == Float(0)
+    Float(1) * pi * x == pi * x
+    len((Float(2) * pi * x).args) == 3
 
 def test_ncmul():
     A = Symbol("A", commutative=False)

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -1,4 +1,4 @@
-from sympy.core import Rational, Symbol, Basic, S, Real, Integer
+from sympy.core import Rational, Symbol, Basic, S, Float, Integer
 from sympy.functions.elementary.miscellaneous import sqrt
 
 def test_rational():
@@ -21,7 +21,7 @@ def test_negative_real():
     def feq(a,b):
         return abs(a - b) < 1E-10
 
-    assert feq(S.One / Real(-0.5), -Integer(2))
+    assert feq(S.One / Float(-0.5), -Integer(2))
 
 def test_expand():
     x = Symbol('x')

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1,4 +1,4 @@
-from sympy import Add, Basic, S, Symbol, Wild,  Real, Integer, Rational, I, \
+from sympy import Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I, \
     sin, cos, tan, exp, log, oo, sqrt, symbols, Integral, sympify, \
     WildFunction, Poly, Function, Derivative, Number, pi, var, \
     NumberSymbol, zoo, Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, \
@@ -104,7 +104,7 @@ f1_1 = F1_1()
 # basic sympy objects
 basic_objs = [
     Rational(2),
-    Real("1.3"),
+    Float("1.3"),
     x,
     y,
     pow(x,y)*y,
@@ -622,7 +622,7 @@ def test_nonzero():
     assert bool(x*0)    == False
 
 def test_is_number():
-    assert Real(3.14).is_number == True
+    assert Float(3.14).is_number == True
     assert Integer(737).is_number == True
     assert Rational(3, 2).is_number == True
     assert Rational(8).is_number == True
@@ -947,15 +947,15 @@ def test_issue_2061():
 def test_as_coeff_Mul():
     Integer(3).as_coeff_Mul() == (Integer(3), Integer(1))
     Rational(3, 4).as_coeff_Mul() == (Rational(3, 4), Integer(1))
-    Real(5.0).as_coeff_Mul() == (Real(5.0), Integer(1))
+    Float(5.0).as_coeff_Mul() == (Float(5.0), Integer(1))
 
     (Integer(3)*x).as_coeff_Mul() == (Integer(3), x)
     (Rational(3, 4)*x).as_coeff_Mul() == (Rational(3, 4), x)
-    (Real(5.0)*x).as_coeff_Mul() == (Real(5.0), x)
+    (Float(5.0)*x).as_coeff_Mul() == (Float(5.0), x)
 
     (Integer(3)*x*y).as_coeff_Mul() == (Integer(3), x*y)
     (Rational(3, 4)*x*y).as_coeff_Mul() == (Rational(3, 4), x*y)
-    (Real(5.0)*x*y).as_coeff_Mul() == (Real(5.0), x*y)
+    (Float(5.0)*x*y).as_coeff_Mul() == (Float(5.0), x*y)
 
     (x).as_coeff_Mul() == (S.One, x)
     (x*y).as_coeff_Mul() == (S.One, x*y)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,5 +1,5 @@
 from sympy import Lambda, Symbol, Function, Derivative, sqrt, \
-        log, exp, Rational, Real, sin, cos, acos, diff, I, re, im, \
+        log, exp, Rational, Float, sin, cos, acos, diff, I, re, im, \
         oo, zoo, nan, E, expand, pi, O, Sum, S, polygamma, loggamma
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y, n
@@ -166,8 +166,8 @@ def test_function_comparable():
     assert sin(x).is_comparable == False
     assert cos(x).is_comparable == False
 
-    assert sin(Real('0.1')).is_comparable   == True
-    assert cos(Real('0.1')).is_comparable   == True
+    assert sin(Float('0.1')).is_comparable   == True
+    assert cos(Float('0.1')).is_comparable   == True
 
     assert sin(E).is_comparable     == True
     assert cos(E).is_comparable     == True
@@ -234,13 +234,13 @@ def test_suppressed_evaluation():
 def test_function_evalf():
     def eq(a,b,eps):
         return abs(a-b) < eps
-    assert eq(sin(1).evalf(15), Real("0.841470984807897"), 1e-13)
-    assert eq(sin(2).evalf(25), Real("0.9092974268256816953960199",25), 1e-23)
-    assert eq(sin(1+I).evalf(15), Real("1.29845758141598") + Real("0.634963914784736")*I, 1e-13)
-    assert eq(exp(1+I).evalf(15), Real("1.46869393991588") + Real("2.28735528717884239")*I, 1e-13)
-    assert eq(exp(-0.5+1.5*I).evalf(15), Real("0.0429042815937374") + Real("0.605011292285002")*I, 1e-13)
-    assert eq(log(pi+sqrt(2)*I).evalf(15), Real("1.23699044022052") + Real("0.422985442737893")*I, 1e-13)
-    assert eq(cos(100).evalf(15), Real("0.86231887228768"), 1e-13)
+    assert eq(sin(1).evalf(15), Float("0.841470984807897"), 1e-13)
+    assert eq(sin(2).evalf(25), Float("0.9092974268256816953960199",25), 1e-23)
+    assert eq(sin(1+I).evalf(15), Float("1.29845758141598") + Float("0.634963914784736")*I, 1e-13)
+    assert eq(exp(1+I).evalf(15), Float("1.46869393991588") + Float("2.28735528717884239")*I, 1e-13)
+    assert eq(exp(-0.5+1.5*I).evalf(15), Float("0.0429042815937374") + Float("0.605011292285002")*I, 1e-13)
+    assert eq(log(pi+sqrt(2)*I).evalf(15), Float("1.23699044022052") + Float("0.422985442737893")*I, 1e-13)
+    assert eq(cos(100).evalf(15), Float("0.86231887228768"), 1e-13)
 
 def test_extensibility_eval():
     class MyFunc(Function):
@@ -282,11 +282,11 @@ def test_doit():
 
 def test_evalf_default():
     from sympy.functions.special.gamma_functions import polygamma
-    assert type(sin(4.0)) == Real
-    assert type(re(sin(I + 1.0))) == Real
-    assert type(im(sin(I + 1.0))) == Real
+    assert type(sin(4.0)) == Float
+    assert type(re(sin(I + 1.0))) == Float
+    assert type(im(sin(I + 1.0))) == Float
     assert type(sin(4)) == sin
-    assert type(polygamma(2,4.0)) == Real
+    assert type(polygamma(2,4.0)) == Float
     assert type(sin(Rational(1,4))) == sin
 
 def test_issue2300():

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,4 +1,4 @@
-from sympy import abc, Function, Symbol, Wild, Derivative, sin, cos, Real, \
+from sympy import abc, Function, Symbol, Wild, Derivative, sin, cos, Float, \
         Rational, exp, I, Integer, diff, Mul, var, oo, S, Add, Poly
 from sympy.utilities.pytest import XFAIL
 
@@ -302,7 +302,7 @@ def test_floats():
 
     e = cos(0.12345, evaluate=False)**2
     r = e.match(a*cos(b)**2)
-    assert r == {a: 1, b: Real(0.12345)}
+    assert r == {a: 1, b: Float(0.12345)}
 
 def test_Derivative_bug1():
     f = Function("f")

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1,4 +1,4 @@
-from sympy import (Rational, Symbol, Real, I, sqrt, oo, nan, pi, E, Integer,
+from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow)
 from sympy.core.power import integer_nthroot
@@ -52,12 +52,12 @@ def test_mod():
     assert z % y == 5/S(18043)
     assert z % z == 0
 
-    a = Real('2.6')
+    a = Float('2.6')
 
-    assert round(a % Real('0.2'), 15) == 0.2
+    assert round(a % Float('0.2'), 15) == 0.2
     assert round(a % 2, 15) == 0.6
     assert round(a % 0.5, 15) == 0.1
-    assert Rational(3,4) % Real(1.1) == 0.75
+    assert Rational(3,4) % Float(1.1) == 0.75
 
     a = Integer(7)
     b = Integer(4)
@@ -180,12 +180,12 @@ def test_Number_new():
     assert Number(2).__class__ is Integer
     assert Number(-622).__class__ is Integer
     assert Number(5,3).__class__ is Rational
-    assert Number(5.3).__class__ is Real
+    assert Number(5.3).__class__ is Float
     assert Number('1') is S.One
     assert Number('2').__class__ is Integer
     assert Number('-622').__class__ is Integer
     assert Number('5/3').__class__ is Rational
-    assert Number('5.3').__class__ is Real
+    assert Number('5.3').__class__ is Float
     raises(ValueError, "Number('cos')")
     raises(TypeError, "Number(cos)")
     a = Rational(3,5)
@@ -218,27 +218,27 @@ def test_Rational_cmp():
     assert Rational(-1) < 0
 
 
-def test_Real():
+def test_Float():
     def eq(a, b):
-        t = Real("1.0E-15")
+        t = Float("1.0E-15")
         return (-t < a-b < t)
 
-    a = Real(2) ** Real(3)
-    assert eq(a.evalf(), Real(8))
-    assert eq((pi ** -1).evalf(), Real("0.31830988618379067"))
-    a = Real(2) ** Real(4)
-    assert eq(a.evalf(), Real(16))
+    a = Float(2) ** Float(3)
+    assert eq(a.evalf(), Float(8))
+    assert eq((pi ** -1).evalf(), Float("0.31830988618379067"))
+    a = Float(2) ** Float(4)
+    assert eq(a.evalf(), Float(16))
     assert (S(.3) == S(.5)) is False
-    x_str = Real((0, '13333333333333L', -52, 53))
-    x2_str = Real((0, '26666666666666L', -53, 53))
-    x_hex = Real((0, 0x13333333333333L, -52, 53))
-    x_dec = Real((0, 5404319552844595L, -52, 53))
-    x2_hex = Real((0, 0x13333333333333L*2, -53, 53))
-    assert x_str == x_hex == x_dec == x2_hex == Real(1.2)
+    x_str = Float((0, '13333333333333L', -52, 53))
+    x2_str = Float((0, '26666666666666L', -53, 53))
+    x_hex = Float((0, 0x13333333333333L, -52, 53))
+    x_dec = Float((0, 5404319552844595L, -52, 53))
+    x2_hex = Float((0, 0x13333333333333L*2, -53, 53))
+    assert x_str == x_hex == x_dec == x2_hex == Float(1.2)
     # x2_str and 1.2 are superficially the same
-    assert str(x2_str) == str(Real(1.2))
+    assert str(x2_str) == str(Float(1.2))
     # but are different at the mpf level
-    assert Real(1.2)._mpf_ == (0, 5404319552844595L, -52, 53)
+    assert Float(1.2)._mpf_ == (0, 5404319552844595L, -52, 53)
     assert x2_str._mpf_ == (0, 10808639105689190L, -53, 53)
 
     # do not automatically evalf
@@ -252,12 +252,12 @@ def test_Real():
     teq(2*pi)
     teq(cos(0.1, evaluate=False))
 
-    assert Real(1) is S.One
-    assert Real(0) is S.Zero
+    assert Float(1) is S.One
+    assert Float(0) is S.Zero
 
-def test_Real_eval():
-    a = Real(3.2)
-    assert (a**2).is_Real
+def test_Float_eval():
+    a = Float(3.2)
+    assert (a**2).is_Float
 
 def test_Infinity():
     assert oo != 1
@@ -475,11 +475,11 @@ def test_abs1():
     assert abs(Rational(1,6)) == abs(Rational(-1,6))
 
 def test_accept_int():
-    assert Real(4) == 4
+    assert Float(4) == 4
 
 def test_dont_accept_str():
-    assert      Real("0.2") != "0.2"
-    assert not (Real("0.2") == "0.2")
+    assert      Float("0.2") != "0.2"
+    assert not (Float("0.2") == "0.2")
 
 def test_int():
     a = Rational(5)
@@ -667,22 +667,22 @@ def test_Rational_gcd_lcm_cofactors():
     assert Integer(4).cofactors(2) == (Integer(2), Integer(2), Integer(1))
     assert Integer(4).cofactors(Integer(2)) == (Integer(2), Integer(2), Integer(1))
 
-    assert Integer(4).gcd(Real(2.0)) == S.One
-    assert Integer(4).lcm(Real(2.0)) == Real(8.0)
-    assert Integer(4).cofactors(Real(2.0)) == (S.One, Integer(4), Real(2.0))
+    assert Integer(4).gcd(Float(2.0)) == S.One
+    assert Integer(4).lcm(Float(2.0)) == Float(8.0)
+    assert Integer(4).cofactors(Float(2.0)) == (S.One, Integer(4), Float(2.0))
 
-    assert Rational(1,2).gcd(Real(2.0)) == S.One
-    assert Rational(1,2).lcm(Real(2.0)) == Real(1.0)
-    assert Rational(1,2).cofactors(Real(2.0)) == (S.One, Rational(1,2), Real(2.0))
+    assert Rational(1,2).gcd(Float(2.0)) == S.One
+    assert Rational(1,2).lcm(Float(2.0)) == Float(1.0)
+    assert Rational(1,2).cofactors(Float(2.0)) == (S.One, Rational(1,2), Float(2.0))
 
-def test_Real_gcd_lcm_cofactors():
-    assert Real(2.0).gcd(Integer(4)) == S.One
-    assert Real(2.0).lcm(Integer(4)) == Real(8.0)
-    assert Real(2.0).cofactors(Integer(4)) == (S.One, Real(2.0), Integer(4))
+def test_Float_gcd_lcm_cofactors():
+    assert Float(2.0).gcd(Integer(4)) == S.One
+    assert Float(2.0).lcm(Integer(4)) == Float(8.0)
+    assert Float(2.0).cofactors(Integer(4)) == (S.One, Float(2.0), Integer(4))
 
-    assert Real(2.0).gcd(Rational(1,2)) == S.One
-    assert Real(2.0).lcm(Rational(1,2)) == Real(1.0)
-    assert Real(2.0).cofactors(Rational(1,2)) == (S.One, Real(2.0), Rational(1,2))
+    assert Float(2.0).gcd(Rational(1,2)) == S.One
+    assert Float(2.0).lcm(Rational(1,2)) == Float(1.0)
+    assert Float(2.0).cofactors(Rational(1,2)) == (S.One, Float(2.0), Rational(1,2))
 
 def test_issue1512():
     assert abs(pi._evalf(50) - 3.14159265358979) < 1e-10
@@ -700,7 +700,7 @@ def test_issue1512():
 def test_conversion_to_mpmath():
     assert mpmath.mpmathify(Integer(1)) == mpmath.mpf(1)
     assert mpmath.mpmathify(Rational(1, 2)) == mpmath.mpf(0.5)
-    assert mpmath.mpmathify(Real('1.23')) == mpmath.mpf('1.23')
+    assert mpmath.mpmathify(Float('1.23')) == mpmath.mpf('1.23')
 
 def test_relational():
     # real

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,6 +1,6 @@
 from sympy import (
     Symbol, Set, Union, Interval, oo, S,
-    Inequality, Max, Min, And, Or, Eq, Le, Lt, Real,
+    Inequality, Max, Min, And, Or, Eq, Le, Lt, Float,
 )
 from sympy.mpmath import mpi
 
@@ -193,12 +193,12 @@ def test_Interval_is_point():
 def test_Interval_is_left_unbounded():
     assert Interval(3, 4).is_left_unbounded == False
     assert Interval(-oo, 3).is_left_unbounded == True
-    assert Interval(Real("-inf"), 3).is_left_unbounded == True
+    assert Interval(Float("-inf"), 3).is_left_unbounded == True
 
 def test_Interval_is_right_unbounded():
     assert Interval(3, 4).is_right_unbounded == False
     assert Interval(3, oo).is_right_unbounded == True
-    assert Interval(3, Real("+inf")).is_right_unbounded == True
+    assert Interval(3, Float("+inf")).is_right_unbounded == True
 
 def test_Interval_as_relational():
     x = Symbol('x')

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, Wild, sin, cos, exp, sqrt, pi, Function, Derivative,
-        abc, Integer, Eq, symbols, Add, I, Real, log, Rational, Lambda, atan2,
+        abc, Integer, Eq, symbols, Add, I, Float, log, Rational, Lambda, atan2,
         cse, cot, tan, S, Tuple)
 
 def test_subs():
@@ -61,20 +61,20 @@ def test_logexppow():   # no eval()
     assert e.subs(exp(x*log(Rational(2))), w) != e
 
 def test_bug():
-    x1=Symbol("x1")
-    x2=Symbol("x2")
-    y=x1*x2
-    y.subs(x1,Real(3.0))
+    x1 = Symbol("x1")
+    x2 = Symbol("x2")
+    y = x1*x2
+    y.subs(x1, Float(3.0))
 
 def test_subbug1():
-    x=Symbol("x")
-    e=(x**x).subs(x,1)
-    e=(x**x).subs(x,1.0)
+    x = Symbol("x")
+    e = (x**x).subs(x,1)
+    e = (x**x).subs(x,1.0)
 
 def test_subbug2():
     # Ensure this does not cause infinite recursion
     x = Symbol('x')
-    assert Real(7.7).epsilon_eq(abs(x).subs(x, -7.7))
+    assert Float(7.7).epsilon_eq(abs(x).subs(x, -7.7))
 
 def test_dict():
     x = Symbol('x')

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, exp, Integer, Real, sin, cos, log, Poly, Lambda, \
+from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
         Function, I, S, sqrt, srepr, Rational
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
@@ -154,7 +154,7 @@ def test__sympify():
     assert _sympify(x)      is x
     assert _sympify(f)      is f
     assert _sympify(1)      == Integer(1)
-    assert _sympify(0.5)    == Real("0.5")
+    assert _sympify(0.5)    == Float("0.5")
     assert _sympify(1+1j)   == 1.0 + I*1.0
 
     class A:
@@ -177,20 +177,20 @@ def test_sympifyit():
     def add(a, b):
         return a+b
 
-    assert add(x, 1)    == x+1
-    assert add(x, 0.5)  == x+Real('0.5')
-    assert add(x, y)    == x+y
+    assert add(x, 1) == x + 1
+    assert add(x, 0.5) == x + Float('0.5')
+    assert add(x, y) == x + y
 
-    assert add(x, '1')  == NotImplemented
+    assert add(x, '1') == NotImplemented
 
 
     @_sympifyit('b')
     def add_raises(a, b):
         return a+b
 
-    assert add_raises(x, 1)     == x+1
-    assert add_raises(x, 0.5)   == x+Real('0.5')
-    assert add_raises(x, y)     == x+y
+    assert add_raises(x, 1) == x + 1
+    assert add_raises(x, 0.5) == x + Float('0.5')
+    assert add_raises(x, y) == x + y
 
     raises(SympifyError, "add_raises(x, '1')")
 
@@ -220,7 +220,7 @@ def test_int_float():
             return 1
 
         def _sympy_(self):
-            return Real(1.1)
+            return Float(1.1)
 
     class I5(object):
         def __int__(self):
@@ -229,7 +229,7 @@ def test_int_float():
     class I5b(object):
         """
         This class implements both __int__() and __float__(), so it will be
-        treated as Real in SymPy. One could change this behavior, by using
+        treated as Float in SymPy. One could change this behavior, by using
         float(a) == int(a), but deciding that integer-valued floats represent
         exact numbers is arbitrary and often not correct, so we do not do it.
         If, in the future, we decide to do it anyway, the tests for I5b need to
@@ -264,7 +264,7 @@ def test_int_float():
     assert sympify(i5) == 5
     assert isinstance(sympify(i5), Integer)
     assert sympify(i5b) == 5
-    assert isinstance(sympify(i5b), Real)
+    assert isinstance(sympify(i5b), Float)
     assert sympify(i5c) == 5
     assert isinstance(sympify(i5c), Integer)
     assert abs(sympify(f1_1) - 1.1) < 1e-5
@@ -274,7 +274,7 @@ def test_int_float():
     assert _sympify(i5) == 5
     assert isinstance(_sympify(i5), Integer)
     assert _sympify(i5b) == 5
-    assert isinstance(_sympify(i5b), Real)
+    assert isinstance(_sympify(i5b), Float)
     assert _sympify(i5c) == 5
     assert isinstance(_sympify(i5c), Integer)
     assert abs(_sympify(f1_1) - 1.1) < 1e-5
@@ -289,18 +289,18 @@ def test_issue1034():
     assert a.is_Integer
 
 def test_issue883():
-    a = [3,2.0]
-    assert sympify(a) == [Integer(3), Real(2.0)]
-    assert sympify(tuple(a)) == (Integer(3), Real(2.0))
-    assert sympify(set(a)) == set([Integer(3), Real(2.0)])
+    a = [3, 2.0]
+    assert sympify(a) == [Integer(3), Float(2.0)]
+    assert sympify(tuple(a)) == (Integer(3), Float(2.0))
+    assert sympify(set(a)) == set([Integer(3), Float(2.0)])
 
 def test_S_sympify():
     assert S(1)/2 == sympify(1)/2
     assert (-2)**(S(1)/2) == sqrt(2)*I
 
 def test_issue1689():
-    assert srepr(S(1.0+0J)) == srepr(S(1.0)) == srepr(Real(1.0))
-    assert srepr(Real(1)) != srepr(Real(1.0))
+    assert srepr(S(1.0+0J)) == srepr(S(1.0)) == srepr(Float(1.0))
+    assert srepr(Float(1)) != srepr(Float(1.0))
 
 def test_issue1699_None():
     assert S(None) == None

--- a/sympy/core/tests/test_truediv.py
+++ b/sympy/core/tests/test_truediv.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 #this module tests that sympy works with true division turned on
 
-from sympy import Rational, Symbol, Real
+from sympy import Rational, Symbol, Float
 
 def test_truediv():
     assert 1/2 != 0
@@ -13,7 +13,7 @@ def dotest(s):
     y = Symbol("y")
     l = [
     Rational(2),
-    Real("1.3"),
+    Float("1.3"),
     x,
     y,
     pow(x,y)*y,

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -77,14 +77,14 @@ class floor(RoundFunction):
     More information can be found in "Concrete mathematics" by Graham,
     pp. 87 or visit http://mathworld.wolfram.com/FloorFunction.html.
 
-        >>> from sympy import floor, E, I, Real, Rational
+        >>> from sympy import floor, E, I, Float, Rational
         >>> floor(17)
         17
         >>> floor(Rational(23, 10))
         2
         >>> floor(2*E)
         5
-        >>> floor(-Real(0.567))
+        >>> floor(-Float(0.567))
         -1
         >>> floor(-I/2)
         -I
@@ -99,7 +99,7 @@ class floor(RoundFunction):
                 if not arg.q:
                     return arg
                 return C.Integer(arg.p // arg.q)
-            elif arg.is_Real:
+            elif arg.is_Float:
                 return C.Integer(int(arg.floor()))
         if arg.is_NumberSymbol:
             return arg.approximation_interval(C.Integer)[0]
@@ -126,14 +126,14 @@ class ceiling(RoundFunction):
     More information can be found in "Concrete mathematics" by Graham,
     pp. 87 or visit http://mathworld.wolfram.com/CeilingFunction.html.
 
-        >>> from sympy import ceiling, E, I, Real, Rational
+        >>> from sympy import ceiling, E, I, Float, Rational
         >>> ceiling(17)
         17
         >>> ceiling(Rational(23, 10))
         3
         >>> ceiling(2*E)
         6
-        >>> ceiling(-Real(0.567))
+        >>> ceiling(-Float(0.567))
         0
         >>> ceiling(I/2)
         I
@@ -148,7 +148,7 @@ class ceiling(RoundFunction):
                 if not arg.q:
                     return arg
                 return -C.Integer(-arg.p // arg.q)
-            elif arg.is_Real:
+            elif arg.is_Float:
                 return C.Integer(int(arg.ceiling()))
         if arg.is_NumberSymbol:
             return arg.approximation_interval(C.Integer)[1]

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,4 +1,4 @@
-from sympy import (symbols, log, Real, nan, oo, zoo, I, pi, E, exp, Symbol,
+from sympy import (symbols, log, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
         LambertW, sqrt, Rational, sin, expand_log, S, sign)
 from sympy.utilities.pytest import XFAIL
 
@@ -189,7 +189,7 @@ def test_log_expand_complex():
 
 def test_log_apply_evalf():
     value = (log(3)/log(2)-1).evalf()
-    assert value.epsilon_eq(Real("0.58496250072115618145373"))
+    assert value.epsilon_eq(Float("0.58496250072115618145373"))
 
 def test_log_expand():
     w = Symbol("w", positive=True)
@@ -220,7 +220,7 @@ def test_lambertw():
     assert LambertW(oo) == oo
     assert LambertW(x**2).diff(x) == 2*LambertW(x**2)/x/(1+LambertW(x**2))
     assert LambertW(sqrt(2)).evalf(30).epsilon_eq(
-        Real("0.701338383413663009202120278965",30),1e-29)
+        Float("0.701338383413663009202120278965",30),1e-29)
 
 def test_exp_expand():
     A,B,C = symbols('A,B,C', commutative=False)

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -1,5 +1,5 @@
 from sympy import Symbol, floor, nan, oo, E, symbols, ceiling, pi, Rational, \
-        Real, I, sin, exp, log, factorial
+        Float, I, sin, exp, log, factorial
 
 from sympy.utilities.pytest import XFAIL
 
@@ -34,11 +34,11 @@ def test_floor():
     assert floor(Rational(7, 3)) == 2
     assert floor(-Rational(7, 3)) == -3
 
-    assert floor(Real(17.0)) == 17
-    assert floor(-Real(17.0)) == -17
+    assert floor(Float(17.0)) == 17
+    assert floor(-Float(17.0)) == -17
 
-    assert floor(Real(7.69)) == 7
-    assert floor(-Real(7.69)) == -8
+    assert floor(Float(7.69)) == 7
+    assert floor(-Float(7.69)) == -8
 
     assert floor(I) == I
     assert floor(-I) == -I
@@ -132,11 +132,11 @@ def test_ceiling():
     assert ceiling(Rational(7, 3)) == 3
     assert ceiling(-Rational(7, 3)) == -2
 
-    assert ceiling(Real(17.0)) == 17
-    assert ceiling(-Real(17.0)) == -17
+    assert ceiling(Float(17.0)) == 17
+    assert ceiling(-Float(17.0)) == -17
 
-    assert ceiling(Real(7.69)) == 8
-    assert ceiling(-Real(7.69)) == -7
+    assert ceiling(Float(7.69)) == 8
+    assert ceiling(-Float(7.69)) == -7
 
     assert ceiling(I) == I
     assert ceiling(-I) == -I

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,5 +1,5 @@
 from sympy.core.add import Add
-from sympy.core.numbers import Rational, Real
+from sympy.core.numbers import Rational, Float
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.function import Function, ArgumentIndexError
@@ -81,10 +81,10 @@ def _pi_coeff(arg, cycles=1):
         cx = arg.coeff(S.Pi)
         if cx:
             c, x = cx.as_coeff_Mul() # pi is not included as coeff
-            if c.is_Real:
+            if c.is_Float:
                 # recast exact binary fractions to Rationals
                 m = int(c*2)
-                if Real(float(m)/2) == c:
+                if Float(float(m)/2) == c:
                     c = Rational(m, 2)
             if x is not S.One or not (c.is_Rational and c.q != 1):
                 if x.is_integer:

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -1,4 +1,4 @@
-from sympy import symbols, DiracDelta, Heaviside, nan, oo, Real, sqrt, pi
+from sympy import symbols, DiracDelta, Heaviside, nan, oo, sqrt, pi
 x = symbols('x')
 
 def test_DiracDelta():

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,4 +1,4 @@
-from sympy import symbols, erf, nan, oo, Real, sqrt, pi, O
+from sympy import symbols, erf, nan, oo, Float, sqrt, pi, O
 
 x, y = symbols('x,y')
 
@@ -18,4 +18,4 @@ def test_erf_series():
         2*x**3/3/sqrt(pi) + x**5/5/sqrt(pi) + O(x**7)
 
 def test_erf_evalf():
-    assert abs( erf(Real(2.0)) - 0.995322265 )  <  1E-8  # XXX
+    assert abs( erf(Float(2.0)) - 0.995322265 )  <  1E-8  # XXX

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, zeta, nan, Rational, Real, pi, dirichlet_eta, log, zoo
+from sympy import Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log, zoo
 
 x = Symbol('x')
 
@@ -52,7 +52,7 @@ def test_zeta():
     assert zeta(0, 2) == -Rational(3, 2)
     assert zeta(0, -2) == Rational(3, 2)
 
-    assert zeta(3).evalf(20).epsilon_eq(Real("1.2020569031595942854",20), 1e-19)
+    assert zeta(3).evalf(20).epsilon_eq(Float("1.2020569031595942854",20), 1e-19)
 
 def test_dirichlet_eta():
 

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -10,7 +10,7 @@ Segment
 """
 from sympy.core import S, C, sympify, Dummy
 from sympy.functions.elementary.trigonometric import _pi_coeff as pi_coeff
-from sympy.core.numbers import Real, Rational
+from sympy.core.numbers import Float, Rational
 from sympy.simplify import simplify
 from sympy.solvers import solve
 from sympy.geometry.exceptions import GeometryError

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,4 +1,4 @@
-from sympy import (Abs, C, Dummy, Max, Min, Rational, Real, S, Symbol, cos, oo,
+from sympy import (Abs, C, Dummy, Max, Min, Rational, Float, S, Symbol, cos, oo,
                    pi, simplify, sqrt, symbols)
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment, Triangle,
@@ -16,7 +16,7 @@ half = Rational(1,2)
 
 def feq(a, b):
     """Test if two floating point values are 'equal'."""
-    t = Real("1.0E-10")
+    t = Float("1.0E-10")
     return -t < a-b < t
 
 def test_curve():
@@ -476,16 +476,16 @@ def test_polygon():
     # Angles
     #
     angles = p4.angles
-    assert feq(angles[Point(0, 0)].evalf(), Real("0.7853981633974483"))
-    assert feq(angles[Point(4, 4)].evalf(), Real("1.2490457723982544"))
-    assert feq(angles[Point(5, 2)].evalf(), Real("1.8925468811915388"))
-    assert feq(angles[Point(3, 0)].evalf(), Real("2.3561944901923449"))
+    assert feq(angles[Point(0, 0)].evalf(), Float("0.7853981633974483"))
+    assert feq(angles[Point(4, 4)].evalf(), Float("1.2490457723982544"))
+    assert feq(angles[Point(5, 2)].evalf(), Float("1.8925468811915388"))
+    assert feq(angles[Point(3, 0)].evalf(), Float("2.3561944901923449"))
 
     angles = p3.angles
-    assert feq(angles[Point(0, 0)].evalf(), Real("0.7853981633974483"))
-    assert feq(angles[Point(4, 4)].evalf(), Real("1.2490457723982544"))
-    assert feq(angles[Point(5, 2)].evalf(), Real("1.8925468811915388"))
-    assert feq(angles[Point(3, 0)].evalf(), Real("2.3561944901923449"))
+    assert feq(angles[Point(0, 0)].evalf(), Float("0.7853981633974483"))
+    assert feq(angles[Point(4, 4)].evalf(), Float("1.2490457723982544"))
+    assert feq(angles[Point(5, 2)].evalf(), Float("1.8925468811915388"))
+    assert feq(angles[Point(3, 0)].evalf(), Float("2.3561944901923449"))
 
     #
     # Triangle

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2211,14 +2211,14 @@ class Matrix(object):
         Test whether any subexpression matches any of the patterns.
 
         Examples:
-        >>> from sympy import Matrix, Real
+        >>> from sympy import Matrix, Float
         >>> from sympy.abc import x, y
         >>> A = Matrix(((1, x), (0.2, 3)))
         >>> A.has(x)
         True
         >>> A.has(y)
         False
-        >>> A.has(Real)
+        >>> A.has(Float)
         True
         """
         return any(a.has(*patterns) for a in self.mat)

--- a/sympy/parsing/ast_parser.py
+++ b/sympy/parsing/ast_parser.py
@@ -47,7 +47,7 @@ if ast_enabled:
                 return fix_missing_locations(Call(Name('Integer', Load()),
                         [node], [], None, None))
             elif isinstance(node.n, float):
-                return fix_missing_locations(Call(Name('Real', Load()),
+                return fix_missing_locations(Call(Name('Float', Load()),
                     [node], [], None, None))
             return node
 

--- a/sympy/parsing/ast_parser_python24.py
+++ b/sympy/parsing/ast_parser_python24.py
@@ -32,7 +32,7 @@ class SymPyTransformer(Transformer):
             n = Const(complex(number), lineno)
             return CallFunc(Name('sympify'), [n])
         n = Const(number, lineno)
-        return CallFunc(Name('Real'), [n])
+        return CallFunc(Name('Float'), [n])
 
     def atom_name(self, nodelist):
         name, lineno = nodelist[0][1:]

--- a/sympy/physics/hydrogen.py
+++ b/sympy/physics/hydrogen.py
@@ -1,4 +1,4 @@
-from sympy import factorial, sqrt, exp, S, laguerre_l, Real
+from sympy import factorial, sqrt, exp, S, laguerre_l, Float
 
 def R_nl(n, l, r, Z=1):
     """
@@ -104,7 +104,7 @@ def E_nl(n, Z=1):
         raise ValueError("'n' must be positive integer")
     return -Z**2/(2*n**2)
 
-def E_nl_dirac(n, l, spin_up=True, Z=1, c=Real("137.035999037")):
+def E_nl_dirac(n, l, spin_up=True, Z=1, c=Float("137.035999037")):
     """
     Returns the relativistic energy of the state (n, l, spin) in Hartree atomic
     units.

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -28,7 +28,7 @@ def _sympy_to_scalar(e):
     if isinstance(e, Expr):
         if e.is_Integer:
             return int(e)
-        elif e.is_Real:
+        elif e.is_Float:
             return float(e)
         elif e.is_Rational:
             return float(e)

--- a/sympy/physics/quantum/tests/test_constants.py
+++ b/sympy/physics/quantum/tests/test_constants.py
@@ -1,4 +1,4 @@
-from sympy import Real
+from sympy import Float
 
 from sympy.physics.quantum.constants import hbar
 
@@ -9,4 +9,4 @@ def test_hbar():
     assert hbar.is_negative == False
     assert hbar.is_irrational == True
 
-    assert hbar.evalf() == Real(1.05457162e-34)
+    assert hbar.evalf() == Float(1.05457162e-34)

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -1,4 +1,4 @@
-from sympy import Matrix, I, Real, Integer
+from sympy import Matrix, I, Float, Integer
 
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.represent import represent
@@ -95,7 +95,7 @@ def test_format_sympy():
 
 def test_scalar_sympy():
     assert represent(Integer(1)) == Integer(1)
-    assert represent(Real(1.0)) == Real(1.0)
+    assert represent(Float(1.0)) == Float(1.0)
     assert represent(1.0+I) == 1.0+I
 
 
@@ -115,7 +115,7 @@ else:
 
     def test_scalar_numpy():
         assert represent(Integer(1), format='numpy') == 1
-        assert represent(Real(1.0), format='numpy') == 1.0
+        assert represent(Float(1.0), format='numpy') == 1.0
         assert represent(1.0+I, format='numpy') == 1.0+1.0j
 
 
@@ -136,5 +136,5 @@ else:
 
     def test_scalar_scipy_sparse():
         assert represent(Integer(1), format='scipy.sparse') == 1
-        assert represent(Real(1.0), format='scipy.sparse') == 1.0
+        assert represent(Float(1.0), format='scipy.sparse') == 1.0
         assert represent(1.0+I, format='scipy.sparse') == 1.0+1.0j

--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -21,7 +21,7 @@ def _construct_simple(coeffs, opt):
         if coeff.is_Rational:
             if not coeff.is_Integer:
                 rationals = True
-        elif coeff.is_Real:
+        elif coeff.is_Float:
             if not algebraics:
                 reals = True
             else:
@@ -147,7 +147,7 @@ def _construct_composite(coeffs, opt):
             if coeff.is_Rational:
                 if not coeff.is_Integer:
                     rationals = True
-            elif coeff.is_Real:
+            elif coeff.is_Float:
                 reals = True
                 break
 

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -107,7 +107,7 @@ class AlgebraicField(Field, CharacteristicZero, SimpleDomain):
         return K1(K1.dom.convert(a, K0))
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return K1(K1.dom.convert(a, K0))
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -161,7 +161,7 @@ class Domain(object):
         return None
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return None
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -144,7 +144,7 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         return K1(K0.to_sympy(a))
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return K1(K0.to_sympy(a))
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -61,7 +61,7 @@ class FiniteField(Field, SimpleDomain):
         """Convert SymPy's Integer to SymPy's `Integer`. """
         if a.is_Integer:
             return self.dtype(self.dom.dtype(int(a)))
-        elif a.is_Real and int(a) == a:
+        elif a.is_Float and int(a) == a:
             return self.dtype(self.dom.dtype(int(a)))
         else:
             raise CoercionFailed("expected an integer, got %s" % a)
@@ -106,7 +106,7 @@ class FiniteField(Field, SimpleDomain):
             return K1.from_ZZ_gmpy(a.numer())
 
     def from_RR_sympy(K1, a, K0=None):
-        """Convert SymPy's `Real` to `dtype`. """
+        """Convert SymPy's `Float` to `dtype`. """
         p, q = K0.as_integer_ratio(a)
 
         if q == 1:

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -92,7 +92,7 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
         return K1(K1.dom.convert(a, K0))
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return K1(K1.dom.convert(a, K0))
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/gmpyintegerring.py
+++ b/sympy/polys/domains/gmpyintegerring.py
@@ -29,7 +29,7 @@ class GMPYIntegerRing(IntegerRing):
         """Convert SymPy's Integer to `dtype`. """
         if a.is_Integer:
             return GMPYIntegerType(a.p)
-        elif a.is_Real and int(a) == a:
+        elif a.is_Float and int(a) == a:
             return GMPYIntegerType(int(a))
         else:
             raise CoercionFailed("expected an integer, got %s" % a)
@@ -74,7 +74,7 @@ class GMPYIntegerRing(IntegerRing):
             return a.numer()
 
     def from_RR_sympy(K1, a, K0):
-        """Convert SymPy's `Real` to GMPY's `mpz`. """
+        """Convert SymPy's `Float` to GMPY's `mpz`. """
         p, q = K0.as_integer_ratio(a)
 
         if q == 1:

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -30,7 +30,7 @@ class GMPYRationalField(RationalField):
         """Convert SymPy's Integer to `dtype`. """
         if a.is_Rational and a.q != 0:
             return GMPYRationalType(a.p, a.q)
-        elif a.is_Real:
+        elif a.is_Float:
             from sympy.polys.domains import RR
             return GMPYRationalType(*RR.as_integer_ratio(a))
         else:
@@ -61,7 +61,7 @@ class GMPYRationalField(RationalField):
         return a
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return GMPYRationalType(*K0.as_integer_ratio(a))
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -33,7 +33,7 @@ from sympy.core.numbers import (
 )
 
 from sympy import (
-    Real     as SymPyRealType,
+    Float     as SymPyRealType,
     Integer  as SymPyIntegerType,
     Rational as SymPyRationalType,
 )

--- a/sympy/polys/domains/mpmathrealdomain.py
+++ b/sympy/polys/domains/mpmathrealdomain.py
@@ -27,7 +27,7 @@ class MPmathRealDomain(RealDomain):
         """Convert SymPy's Integer to `dtype`. """
         b = a.evalf()
 
-        if b.is_Real and b not in [S.Infinity, S.NegativeInfinity]:
+        if b.is_Float and b not in [S.Infinity, S.NegativeInfinity]:
             return MPmathRealType(b)
         else:
             raise CoercionFailed("expected Real object, got %s" % a)
@@ -57,7 +57,7 @@ class MPmathRealDomain(RealDomain):
         return MPmathRealType(int(a.numer())) / int(a.denom())
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return MPmathRealType(a)
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/pythoncomplexdomain.py
+++ b/sympy/polys/domains/pythoncomplexdomain.py
@@ -25,10 +25,10 @@ class PythonComplexDomain(RealDomain): # XXX: tmp solution
         """Convert SymPy's Integer to `dtype`. """
         b = a.evalf()
 
-        if b.is_Real and b not in [S.Infinity, S.NegativeInfinity]:
+        if b.is_Float and b not in [S.Infinity, S.NegativeInfinity]:
             return float(b)
         else:
-            raise CoercionFailed("expected Real object, got %s" % a)
+            raise CoercionFailed("expected Float object, got %s" % a)
 
     def from_ZZ_python(K1, a, K0):
         """Convert a Python `int` object to `dtype`. """
@@ -55,7 +55,7 @@ class PythonComplexDomain(RealDomain): # XXX: tmp solution
         return K1.dtype(int(a.numer())) / int(a.denom)
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return K1.dtype(a)
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/pythonintegerring.py
+++ b/sympy/polys/domains/pythonintegerring.py
@@ -28,7 +28,7 @@ class PythonIntegerRing(IntegerRing):
         """Convert SymPy's Integer to `dtype`. """
         if a.is_Integer:
             return PythonIntegerType(a.p)
-        elif a.is_Real and int(a) == a:
+        elif a.is_Float and int(a) == a:
             return PythonIntegerType(int(a))
         else:
             raise CoercionFailed("expected an integer, got %s" % a)
@@ -73,7 +73,7 @@ class PythonIntegerRing(IntegerRing):
             return PythonIntegerType(a.numer())
 
     def from_RR_sympy(K1, a, K0):
-        """Convert SymPy's `Real` to Python's `int`. """
+        """Convert SymPy's `Float` to Python's `int`. """
         p, q = K0.as_integer_ratio(a)
 
         if q == 1:

--- a/sympy/polys/domains/pythonrationalfield.py
+++ b/sympy/polys/domains/pythonrationalfield.py
@@ -27,7 +27,7 @@ class PythonRationalField(RationalField):
         """Convert SymPy's Rational to `dtype`. """
         if a.is_Rational and a.q != 0:
             return PythonRationalType(a.p, a.q)
-        elif a.is_Real:
+        elif a.is_Float:
             from sympy.polys.domains import RR
             return PythonRationalType(*RR.as_integer_ratio(a))
         else:
@@ -59,7 +59,7 @@ class PythonRationalField(RationalField):
                                   PythonIntegerType(a.denom()))
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return PythonRationalType(*K0.as_integer_ratio(a))
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/pythonrealdomain.py
+++ b/sympy/polys/domains/pythonrealdomain.py
@@ -34,10 +34,10 @@ class PythonRealDomain(RealDomain): # XXX: tmp solution
         """Convert SymPy's Integer to `dtype`. """
         b = a.evalf()
 
-        if b.is_Real and b not in [S.Infinity, S.NegativeInfinity]:
+        if b.is_Float and b not in [S.Infinity, S.NegativeInfinity]:
             return float(b)
         else:
-            raise CoercionFailed("expected Real object, got %s" % a)
+            raise CoercionFailed("expected Float object, got %s" % a)
 
     def from_ZZ_python(K1, a, K0):
         """Convert a Python `int` object to `dtype`. """
@@ -64,7 +64,7 @@ class PythonRealDomain(RealDomain): # XXX: tmp solution
         return K1.dtype(int(a.numer())) / int(a.denom)
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return K1.dtype(a)
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/sympyintegerring.py
+++ b/sympy/polys/domains/sympyintegerring.py
@@ -24,7 +24,7 @@ class SymPyIntegerRing(IntegerRing):
         """Convert SymPy's Integer to SymPy's `Integer`. """
         if a.is_Integer:
             return a
-        elif a.is_Real and int(a) == a:
+        elif a.is_Float and int(a) == a:
             return SymPyIntegerType(int(a))
         else:
             raise CoercionFailed("expected an integer, got %s" % a)
@@ -69,7 +69,7 @@ class SymPyIntegerRing(IntegerRing):
             return SymPyIntegerType(int(a.numer()))
 
     def from_RR_sympy(K1, a, K0):
-        """Convert SymPy's `Real` to SymPy's `Integer`. """
+        """Convert SymPy's `Float` to SymPy's `Integer`. """
         p, q = K0.as_integer_ratio(a)
 
         if q == 1:

--- a/sympy/polys/domains/sympyrationalfield.py
+++ b/sympy/polys/domains/sympyrationalfield.py
@@ -25,7 +25,7 @@ class SymPyRationalField(RationalField):
         """Convert SymPy's Rational to `dtype`. """
         if a.is_Rational and a.q != 0:
             return a
-        elif a.is_Real:
+        elif a.is_Float:
             from sympy.polys.domains import RR
             return SymPyRationalType(*RR.as_integer_ratio(a))
         else:
@@ -57,7 +57,7 @@ class SymPyRationalField(RationalField):
                                  int(a.denom()))
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return SymPyRationalType(*K0.as_integer_ratio(a))
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/domains/sympyrealdomain.py
+++ b/sympy/polys/domains/sympyrealdomain.py
@@ -6,7 +6,7 @@ from sympy.polys.domains.groundtypes import SymPyRealType
 from sympy.core import S
 
 class SymPyRealDomain(RealDomain):
-    """Domain for real numbers based on SymPy Real type. """
+    """Domain for real numbers based on SymPy Float type. """
 
     dtype = SymPyRealType
     zero  = dtype(0)
@@ -24,10 +24,10 @@ class SymPyRealDomain(RealDomain):
         """Convert SymPy's Integer to `dtype`. """
         b = a.evalf()
 
-        if b.is_Real and b not in [S.Infinity, S.NegativeInfinity]:
+        if b.is_Float and b not in [S.Infinity, S.NegativeInfinity]:
             return b
         else:
-            raise CoercionFailed("expected Real object, got %s" % a)
+            raise CoercionFailed("expected Float object, got %s" % a)
 
     def from_ZZ_python(K1, a, K0):
         """Convert a Python `int` object to `dtype`. """
@@ -54,7 +54,7 @@ class SymPyRealDomain(RealDomain):
         return SymPyRealType(int(a.numer())) / int(a.denom())
 
     def from_RR_sympy(K1, a, K0):
-        """Convert a SymPy `Real` object to `dtype`. """
+        """Convert a SymPy `Float` object to `dtype`. """
         return a
 
     def from_RR_mpmath(K1, a, K0):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -1,7 +1,7 @@
 """Computational algebraic number field theory. """
 
 from sympy import (
-    S, Expr, I, Integer, Rational, Real,
+    S, Expr, I, Integer, Rational, Float,
     Symbol, Add, Mul, sympify, Q, ask, Dummy,
 )
 

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1,7 +1,7 @@
 """Implementation of RootOf class and related tools. """
 
 from sympy.core import (
-    S, Basic, Expr, Integer, Real, I, Add, Lambda, symbols,
+    S, Basic, Expr, Integer, Float, I, Add, Lambda, symbols,
 )
 
 from sympy.polys.polytools import Poly, gcd_list, factor
@@ -550,7 +550,7 @@ class RootOf(Expr):
         finally:
             mp.prec = _prec
 
-        return Real._new(root.real._mpf_, prec) + I*Real._new(root.imag._mpf_, prec)
+        return Float._new(root.real._mpf_, prec) + I*Float._new(root.imag._mpf_, prec)
 
 class RootSum(Expr):
     """Represents a sum of all roots of a univariate polynomial. """

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -13,7 +13,7 @@ from sympy.polys.polyerrors import (
 )
 
 from sympy import (
-    S, symbols, sqrt, I, Rational, Real, Lambda, log, exp, tan,
+    S, symbols, sqrt, I, Rational, Float, Lambda, log, exp, tan,
 )
 
 from sympy.utilities.pytest import raises
@@ -142,17 +142,17 @@ def test_RootOf_subs():
 def test_RootOf_evalf():
     real = RootOf(x**3 + x + 3, 0).evalf(n=20)
 
-    assert real.epsilon_eq(Real("-1.2134116627622296341"))
+    assert real.epsilon_eq(Float("-1.2134116627622296341"))
 
     re, im = RootOf(x**3 + x + 3, 1).evalf(n=20).as_real_imag()
 
-    assert re.epsilon_eq(Real("0.60670583138111481707"))
-    assert im.epsilon_eq(Real("1.45061224918844152650"))
+    assert re.epsilon_eq(Float("0.60670583138111481707"))
+    assert im.epsilon_eq(Float("1.45061224918844152650"))
 
     re, im = RootOf(x**3 + x + 3, 2).evalf(n=20).as_real_imag()
 
-    assert re.epsilon_eq( Real("0.60670583138111481707"))
-    assert im.epsilon_eq(-Real("1.45061224918844152650"))
+    assert re.epsilon_eq( Float("0.60670583138111481707"))
+    assert im.epsilon_eq(-Float("1.45061224918844152650"))
 
 def test_RootOf_preprocessing():
     f = c**3*x**3 + c**2*x**2 + c*x + a

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -245,8 +245,8 @@ class FCodePrinter(CodePrinter):
         p, q = int(expr.p), int(expr.q)
         return "%d.0d0/%d.0d0" % (p, q)
 
-    def _print_Real(self, expr):
-        printed = CodePrinter._print_Real(self, expr)
+    def _print_Float(self, expr):
+        printed = CodePrinter._print_Float(self, expr)
         e = printed.find('e')
         if e > -1:
             return "%sd%s" % (printed[:e], printed[e+1:])

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -136,7 +136,7 @@ class LatexPrinter(Printer):
 
         return tex
 
-    def _print_Real(self, expr):
+    def _print_Float(self, expr):
         # Based off of that in StrPrinter
         dps = prec_to_dps(expr._prec)
         str_real = mlib.to_str(expr._mpf_, dps, strip_zeros=True)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -56,8 +56,8 @@ class PrettyPrinter(Printer):
 
         return prettyForm(symb)
 
-    def _print_Real(self, e):
-        # we will use StrPrinter's Real printer, but we need to handle the
+    def _print_Float(self, e):
+        # we will use StrPrinter's Float printer, but we need to handle the
         # full_prec ourselves, according to the self._print_level
         full_prec = self._settings["full_prec"]
         if  full_prec == "auto":

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -205,7 +205,7 @@ class Printer(object):
                         raise TypeError("Unknown setting '%s'." % key)
 
         # _print_level is the number of times self._print() was recursively
-        # called. See StrPrinter._print_Real() for an example of usage
+        # called. See StrPrinter._print_Float() for an example of usage
         self._print_level = 0
 
     @classmethod

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -84,7 +84,7 @@ class ReprPrinter(Printer):
     def _print_Fraction(self, expr):
         return 'Fraction(%s, %s)' % (self._print(expr.numerator), self._print(expr.denominator))
 
-    def _print_Real(self, expr):
+    def _print_Float(self, expr):
         dps = prec_to_dps(expr._prec)
         r = mlib.to_str(expr._mpf_, repr_dps(expr._prec))
         return "%s('%s', prec=%i)" % (expr.__class__.__name__, r, dps)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -329,7 +329,7 @@ class StrPrinter(Printer):
     def _print_mpq(self, expr):
         return '%s/%s' % (expr.numer(), expr.denom())
 
-    def _print_Real(self, expr):
+    def _print_Float(self, expr):
         prec = expr._prec
         if prec < 5:
             dps = 0

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, atan2, gamma, conjugate, sqrt, factorial, \
-    Integral, Piecewise, Add, diff, symbols, S, Real, Dummy
+    Integral, Piecewise, Add, diff, symbols, S, Float, Dummy
 from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
@@ -40,9 +40,9 @@ def test_fcode_Integer():
     assert fcode(Integer(67)) == "      67"
     assert fcode(Integer(-1)) == "      -1"
 
-def test_fcode_Real():
-    assert fcode(Real(42.0)) == "      42.0000000000000d0"
-    assert fcode(Real(-1e20)) == "      -1.00000000000000d+20"
+def test_fcode_Float():
+    assert fcode(Float(42.0)) == "      42.0000000000000d0"
+    assert fcode(Float(-1e20)) == "      -1.00000000000000d+20"
 
 def test_fcode_functions():
     x, y = symbols('x,y')

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
         Function, factorial, floor, ceiling, Abs, re, im, conjugate, gamma,
         Order, Piecewise, Matrix, asin, Interval, EmptySet, Union, S, Sum,
-        Limit, oo, Poly, Real)
+        Limit, oo, Poly, Float)
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
 from sympy.utilities.pytest import XFAIL, raises
@@ -41,10 +41,10 @@ def test_latex_basic():
     assert latex(1.5e20*x) == r"1.5 \times 10^{20} x"
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
 
-def test_latex_Real():
-    assert latex(Real(1.0e100)) == r"1.0 \times 10^{100}"
-    assert latex(Real(1.0e-100)) == r"1.0 \times 10^{-100}"
-    latex(Real(1.0e-100), mul_symbol="dot") == r"1.0 \cdot 10^{-100}"
+def test_latex_Float():
+    assert latex(Float(1.0e100)) == r"1.0 \times 10^{100}"
+    assert latex(Float(1.0e-100)) == r"1.0 \times 10^{-100}"
+    latex(Float(1.0e-100), mul_symbol="dot") == r"1.0 \cdot 10^{-100}"
     assert latex(1.0*oo) == r"\infty"
     assert latex(-1.0*oo) == r"- \infty"
 

--- a/sympy/printing/tests/test_precedence.py
+++ b/sympy/printing/tests/test_precedence.py
@@ -1,7 +1,7 @@
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
 from sympy.core.function import Derivative
-from sympy.core.numbers import Integer, Rational, Real
+from sympy.core.numbers import Integer, Rational, Float
 from sympy.core.relational import Rel
 from sympy.core.symbol import symbols
 from sympy.functions import sin
@@ -34,8 +34,8 @@ def test_Number():
     assert precedence(Integer(10)) == PRECEDENCE["Atom"]
     assert precedence(Rational(5,2)) == PRECEDENCE["Mul"]
     assert precedence(Rational(-5,2)) == PRECEDENCE["Add"]
-    assert precedence(Real(5)) == PRECEDENCE["Atom"]
-    assert precedence(Real(-5)) == PRECEDENCE["Add"]
+    assert precedence(Float(5)) == PRECEDENCE["Atom"]
+    assert precedence(Float(-5)) == PRECEDENCE["Add"]
 
 def test_Order():
     assert precedence(Order(x)) == PRECEDENCE["Atom"]

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import Symbol, symbols, Function, Integer, Matrix, nan, oo, Abs, \
-    Rational, Real, S, WildFunction
+    Rational, Float, S, WildFunction
 from sympy.geometry import Point, Circle, Ellipse
 from sympy.printing import srepr
 
@@ -77,11 +77,11 @@ def test_Rational():
     sT(Rational(1,3), "Rational(1, 3)")
     sT(Rational(-1,3), "Rational(-1, 3)")
 
-def test_Real():
-    sT(Real('1.23', prec=3), "Real('1.22998', prec=3)")
-    sT(Real('1.23456789', prec=9), "Real('1.23456788994', prec=9)")
-    sT(Real('1.234567890123456789', prec=19), "Real('1.234567890123456789013', prec=19)")
-    sT(Real('0.60038617995049726', 15), "Real('0.60038617995049726', prec=15)")
+def test_Float():
+    sT(Float('1.23', prec=3), "Float('1.22998', prec=3)")
+    sT(Float('1.23456789', prec=9), "Float('1.23456788994', prec=9)")
+    sT(Float('1.234567890123456789', prec=19), "Float('1.234567890123456789013', prec=19)")
+    sT(Float('0.60038617995049726', 15), "Float('0.60038617995049726', prec=15)")
 
 def test_Symbol():
     sT(x, "Symbol('x')")

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1,6 +1,6 @@
 from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp, factorial,
     Function, GoldenRatio, I, Integer, Integral, Interval, Lambda, Limit, log,
-    Matrix, nan, O, oo, pi, Rational, Real, Rel, S, sin, SMatrix, sqrt,
+    Matrix, nan, O, oo, pi, Rational, Float, Rel, S, sin, SMatrix, sqrt,
     summation, Sum, Symbol, symbols, Wild, WildFunction, zeta, zoo,
     Dummy)
 from sympy.core import Expr
@@ -158,7 +158,7 @@ def test_Mul():
     cc2 = CustomClass2(commutative=True)
     assert str(Rational(2)*cc1) == '2*CustomClass1()'
     assert str(cc1*Rational(2)) == '2*CustomClass1()'
-    assert str(cc1*Real("1.5")) == '1.5*CustomClass1()'
+    assert str(cc1*Float("1.5")) == '1.5*CustomClass1()'
     assert str(cc2*Rational(2)) == '2*CustomClass2()'
     assert str(cc2*Rational(2)*cc1) == '2*CustomClass1()*CustomClass2()'
     assert str(cc1*Rational(2)*cc2) == '2*CustomClass1()*CustomClass2()'
@@ -268,11 +268,11 @@ def test_Rational():
     assert str((-4)**Rational(1,2)) == str(2*I)
     assert str(2**Rational(1,10**10)) == "2**(1/10000000000)"
 
-def test_Real():
+def test_Float():
     # NOTE prec is the whole number of decimal digits
-    assert str(Real('1.23', prec=1+2))    == '1.23'
-    assert str(Real('1.23456789', prec=1+8))  == '1.23456789'
-    assert str(Real('1.234567890123456789', prec=1+18))    == '1.234567890123456789'
+    assert str(Float('1.23', prec=1+2))    == '1.23'
+    assert str(Float('1.23456789', prec=1+8))  == '1.23456789'
+    assert str(Float('1.234567890123456789', prec=1+18))    == '1.234567890123456789'
     assert str(pi.evalf(1+2))   == '3.14'
     assert str(pi.evalf(1+14))  == '3.14159265358979'
     assert str(pi.evalf(1+64))  == '3.1415926535897932384626433832795028841971693993751058209749445923'

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -425,7 +425,7 @@ def sign(e, x):
     elif e.is_negative:
         return -1
 
-    if e.is_Rational or e.is_Real:
+    if e.is_Rational or e.is_Float:
         assert not e is S.NaN
         if e == 0:
             return 0

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1653,7 +1653,7 @@ def _real_to_rational(expr):
     19/25 + x**(1/2)/10
     """
     p = sympify(expr)
-    for r in p.atoms(C.Real):
+    for r in p.atoms(C.Float):
         newr = nsimplify(r)
         if not newr.is_Rational or \
            r.is_finite and not newr.is_finite:
@@ -1713,7 +1713,7 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=False):
     for constant in constants:
         constant = sympify(constant)
         v = constant.evalf(prec)
-        if not v.is_Real:
+        if not v.is_Float:
             raise ValueError("constants must be real-valued")
         constants_dict[str(constant)] = v._to_mpmath(bprec)
 
@@ -1721,7 +1721,7 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=False):
     re, im = exprval.as_real_imag()
 
     # Must be numerical
-    if not ((re.is_Real or re.is_Integer) and (im.is_Real or im.is_Integer)):
+    if not ((re.is_Float or re.is_Integer) and (im.is_Float or im.is_Integer)):
         return expr
 
     def nsimplify_real(x):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1891,7 +1891,7 @@ def _homogeneous_order(eq, *symbols):
 
     # These are all constants
     if type(eq) in (int, float) or eq.is_Number or eq.is_Integer or \
-    eq.is_Rational or eq.is_NumberSymbol or eq.is_Real:
+    eq.is_Rational or eq.is_NumberSymbol or eq.is_Float:
         return sympify(0)
 
     # Break the equation into additive parts

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -5,7 +5,7 @@ from sympy.utilities.pytest import raises
 
 def test_pde_separate_add():
     x, y, z, t = symbols("x,y,z,t")
-    c = Symbol("C", Real=True)
+    c = Symbol("C", real=True)
     F, T, X, Y, Z, u = map(Function, 'FTXYZu')
 
     eq = Eq(D(u(x, t), x), D(u(x, t), t)*exp(u(x, t)))
@@ -14,7 +14,7 @@ def test_pde_separate_add():
 
 def test_pde_separate_mul():
     x, y, z, t = symbols("x,y,z,t")
-    c = Symbol("C", Real=True)
+    c = Symbol("C", real=True)
     Phi = Function('Phi')
     F, R, T, X, Y, Z, u = map(Function, 'FRTXYZu')
     r, theta, z = symbols('r,theta,z')

--- a/sympy/statistics/distributions.py
+++ b/sympy/statistics/distributions.py
@@ -1,4 +1,4 @@
-from sympy.core import sympify, Lambda, Dummy, Integer, Rational, oo, Real, pi
+from sympy.core import sympify, Lambda, Dummy, Integer, Rational, oo, Float, pi
 from sympy.functions import sqrt, exp, erf
 from sympy.printing import sstr
 import random
@@ -139,7 +139,7 @@ class Normal(ContinuousProbability):
 
         # calculate y = ierf(p) by solving erf(y) - p = 0
         y = erfinv(mpf(p))
-        t = Real(str(mpf(float(s.sigma)) * mpf(2)**0.5 * y))
+        t = Float(str(mpf(float(s.sigma)) * mpf(2)**0.5 * y))
         mu = s.mu.evalf()
         return (mu-t, mu+t)
 
@@ -191,7 +191,7 @@ class Uniform(ContinuousProbability):
         return (x-s.a)/(s.b-s.a)
 
     def _random(s):
-        return Real(random.uniform(float(s.a), float(s.b)))
+        return Float(random.uniform(float(s.a), float(s.b)))
 
     def confidence(s, p):
         """Generate a symmetric (p*100)% confidence interval.

--- a/sympy/test_external/test_numpy.py
+++ b/sympy/test_external/test_numpy.py
@@ -13,7 +13,7 @@ except ImportError:
     disabled = True
 
 
-from sympy import (Rational, Symbol, list2numpy, sin, Real, Matrix, lambdify,
+from sympy import (Rational, Symbol, list2numpy, sin, Float, Matrix, lambdify,
         symarray, symbols)
 import sympy
 
@@ -40,7 +40,7 @@ def test_systematic_basic():
     y = Symbol("y")
     sympy_objs = [
             Rational(2),
-            Real("1.3"),
+            Float("1.3"),
             x,
             y,
             pow(x,y)*y,
@@ -189,9 +189,9 @@ def test_Matrix_array():
 def test_issue629():
     x = Symbol("x")
     assert (Rational(1,2)*array([2*x, 0]) == array([x, 0])).all()
-    assert (Rational(1,2)+array([2*x, 0]) == array([2*x+Rational(1,2), Rational(1,2)])).all()
-    assert (Real("0.5")*array([2*x, 0]) == array([Real("1.0")*x, 0])).all()
-    assert (Real("0.5")+array([2*x, 0]) == array([2*x+Real("0.5"), Real("0.5")])).all()
+    assert (Rational(1,2) + array([2*x, 0]) == array([2*x + Rational(1,2), Rational(1,2)])).all()
+    assert (Float("0.5")*array([2*x, 0]) == array([Float("1.0")*x, 0])).all()
+    assert (Float("0.5") + array([2*x, 0]) == array([2*x + Float("0.5"), Float("0.5")])).all()
 
 def test_lambdify():
     x = Symbol("x")

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,5 +1,5 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import (symbols, lambdify, sqrt, sin, cos, pi, atan, Rational, Real,
+from sympy import (symbols, lambdify, sqrt, sin, cos, pi, atan, Rational, Float,
         Matrix, Lambda, exp, Integral, oo)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy import mpmath
@@ -76,7 +76,7 @@ def test_sympy_lambda():
     f = lambdify(x, sin(x), "sympy")
     assert f(x) is sin(x)
     prec = 1e-15
-    assert -prec < f(Rational(1,5)).evalf() - Real(str(sin02)) < prec
+    assert -prec < f(Rational(1,5)).evalf() - Float(str(sin02)) < prec
     try:
         # arctan is in numpy module and should not be available
         f = lambdify(x, arctan(x), "sympy")

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -11,7 +11,7 @@ from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.numbers import Catalan, ComplexInfinity, EulerGamma, Exp1,\
         GoldenRatio, Half, ImaginaryUnit, Infinity, Integer, NaN,\
         NegativeInfinity,  NegativeOne, Number, NumberSymbol, One, Pi,\
-        Rational, Real, Zero
+        Rational, Float, Zero
 from sympy.core.relational import Equality, Inequality, Relational,\
         StrictInequality, Unequality
 from sympy.core.add import Add
@@ -82,7 +82,7 @@ def test_core_numbers():
               Integer, Integer(2), NaN, NaN(), NegativeInfinity,
               NegativeInfinity(), NegativeOne, NegativeOne(), Number, Number(15),
               NumberSymbol, NumberSymbol(), One, One(), Pi, Pi(), Rational,
-              Rational(1,2), Real, Real("1.2"), Zero, Zero()):
+              Rational(1,2), Float, Float("1.2"), Zero, Zero()):
         check(c)
 
 def test_core_relational():


### PR DESCRIPTION
This makes it clear that there is a fundamental difference between
infinitely precise, symbolically described real numbers like pi or
atan(1/7), and floating-point numbers.
