### PR TITLE
Remove Atom.as_numer_denom()

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1268,10 +1268,6 @@ class Atom(Basic):
         else:
             return self
 
-    def as_numer_denom(self):
-        from sympy.core import S
-        return self, S.One
-
     def doit(self, **hints):
         return self
 


### PR DESCRIPTION
This method is only defined in Expr, so it should only be overridden in
AtomicExpr, but not defined in Atom.
