### PR TITLE
1694 solver related change pertaining to issue 2397: log expansion changes

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -965,18 +965,6 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     >>> x, y = symbols('x,y', positive=True)
     >>> log(x**2*y).expand(log=True)
     2*log(x) + log(y)
-    >>> log(4)
-    2*log(2)
-    >>> log(4*3)
-    log(12)
-    >>> _.expand()
-    log(3) + 2*log(2)
-    >>> log(12).expand(factor_limit=0) # don't do numerical expansion
-    log(12)
-    >>> log(2147909653)
-    log(2147909653)
-    >>> _.expand(factor_limit=oo) # default limit is 2**15; oo forces full factorization
-    log(32771) + log(65543)
 
     trig - Do trigonometric expansions.
     >>> cos(x + y).expand(trig=True)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -957,7 +957,7 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     into sums of logs.  Note that these only work if the arguments of the log
     function have the proper assumptions: the arguments must be positive and the
     exponents must be real or else the force hint must be True.
-    >>> from sympy import log, symbols
+    >>> from sympy import log, symbols, oo
     >>> log(x**2*y).expand(log=True)
     log(x**2*y)
     >>> log(x**2*y).expand(log=True, force=True)
@@ -965,6 +965,18 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     >>> x, y = symbols('x,y', positive=True)
     >>> log(x**2*y).expand(log=True)
     2*log(x) + log(y)
+    >>> log(4)
+    2*log(2)
+    >>> log(4*3)
+    log(12)
+    >>> _.expand()
+    log(3) + 2*log(2)
+    >>> log(12).expand(limit=0) # don't do numerical expansion
+    log(12)
+    >>> log(2147909653)
+    log(2147909653)
+    >>> _.expand(limit=oo) # default limit is 2**15; oo forces full factorization
+    log(32771) + log(65543)
 
     trig - Do trigonometric expansions.
     >>> cos(x + y).expand(trig=True)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -919,7 +919,10 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     recursively expanded.  Use deep=False to only expand on the top
     level.
 
-    Also see expand_log, expand_mul, expand_complex, expand_trig,
+    If the 'force' hint is used, assumptions about variables will be ignored
+    in making the expansion.
+
+    Also see expand_log, expand_mul, separate, expand_complex, expand_trig,
     and expand_func, which are wrappers around those expansion methods.
 
     >>> from sympy import cos, exp
@@ -930,18 +933,19 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     x*y + y*z
 
     complex - Split an expression into real and imaginary parts.
-    >>> (x+y).expand(complex=True)
+    >>> (x + y).expand(complex=True)
     I*im(x) + I*im(y) + re(x) + re(y)
     >>> cos(x).expand(complex=True)
     -I*sin(re(x))*sinh(im(x)) + cos(re(x))*cosh(im(x))
 
     power_exp - Expand addition in exponents into multiplied bases.
-    >>> exp(x+y).expand(power_exp=True)
+    >>> exp(x + y).expand(power_exp=True)
     exp(x)*exp(y)
-    >>> (2**(x+y)).expand(power_exp=True)
+    >>> (2**(x + y)).expand(power_exp=True)
     2**x*2**y
 
-    power_base - Split powers of multiplied bases if assumptions allow.
+    power_base - Split powers of multiplied bases if assumptions allow
+    or if the 'force' hint is used.
     >>> ((x*y)**z).expand(power_base=True)
     (x*y)**z
     >>> ((x*y)**z).expand(power_base=True, force=True)
@@ -952,39 +956,41 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     log - Pull out power of an argument as a coefficient and split logs products
     into sums of logs.  Note that these only work if the arguments of the log
     function have the proper assumptions: the arguments must be positive and the
-    exponents must be real.
+    exponents must be real or else the force hint must be True.
     >>> from sympy import log, symbols
     >>> log(x**2*y).expand(log=True)
     log(x**2*y)
+    >>> log(x**2*y).expand(log=True, force=True)
+    2*log(x) + log(y)
     >>> x, y = symbols('x,y', positive=True)
     >>> log(x**2*y).expand(log=True)
     2*log(x) + log(y)
 
     trig - Do trigonometric expansions.
-    >>> cos(x+y).expand(trig=True)
+    >>> cos(x + y).expand(trig=True)
     -sin(x)*sin(y) + cos(x)*cos(y)
 
     func - Expand other functions.
     >>> from sympy import gamma
-    >>> gamma(x+1).expand(func=True)
+    >>> gamma(x + 1).expand(func=True)
     x*gamma(x)
 
     multinomial - Expand (x + y + ...)**n where n is a positive integer.
-    >>> ((x+y+z)**2).expand(multinomial=True)
+    >>> ((x + y + z)**2).expand(multinomial=True)
     x**2 + 2*x*y + 2*x*z + y**2 + 2*y*z + z**2
 
     You can shut off methods that you don't want.
-    >>> (exp(x+y)*(x+y)).expand()
+    >>> (exp(x + y)*(x + y)).expand()
     x*exp(x)*exp(y) + y*exp(x)*exp(y)
-    >>> (exp(x+y)*(x+y)).expand(power_exp=False)
+    >>> (exp(x + y)*(x + y)).expand(power_exp=False)
     x*exp(x + y) + y*exp(x + y)
-    >>> (exp(x+y)*(x+y)).expand(mul=False)
+    >>> (exp(x + y)*(x + y)).expand(mul=False)
     (x + y)*exp(x)*exp(y)
 
     Use deep=False to only expand on the top level.
-    >>> exp(x+exp(x+y)).expand()
+    >>> exp(x + exp(x + y)).expand()
     exp(x)*exp(exp(x)*exp(y))
-    >>> exp(x+exp(x+y)).expand(deep=False)
+    >>> exp(x + exp(x + y)).expand(deep=False)
     exp(x)*exp(exp(x + y))
 
     Note: because hints are applied in arbitrary order, some hints may
@@ -998,30 +1004,30 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     >>> from sympy import expand_log, expand, expand_mul
     >>> x, y, z = symbols('x,y,z', positive=True)
 
-    >> expand(log(x*(y+z))) # could be either one below
+    >> expand(log(x*(y + z))) # could be either one below
     log(x*y + x*z)
     log(x) + log(y + z)
 
-    >>> expand_log(log(x*y+x*z))
+    >>> expand_log(log(x*y + x*z))
     log(x*y + x*z)
 
-    >> expand(log(x*(y+z)), mul=False)
+    >> expand(log(x*(y + z)), mul=False)
     log(x) + log(y + z)
 
 
-    >> expand((x*(y+z))**x) # could be either one below
+    >> expand((x*(y + z))**x) # could be either one below
     (x*y + x*z)**x
     x**x*(y + z)**x
 
-    >>> expand((x*(y+z))**x, mul=False)
+    >>> expand((x*(y + z))**x, mul=False)
     x**x*(y + z)**x
 
 
-    >> expand(x*(y+z)**2) # could be either one below
+    >> expand(x*(y + z)**2) # could be either one below
     2*x*y*z + x*y**2 + x*z**2
     x*(y + z)**2
 
-    >>> expand(x*(y+z)**2, mul=False)
+    >>> expand(x*(y + z)**2, mul=False)
     x*(y**2 + 2*y*z + z**2)
 
     >>> expand_mul(_)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -971,11 +971,11 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     log(12)
     >>> _.expand()
     log(3) + 2*log(2)
-    >>> log(12).expand(limit=0) # don't do numerical expansion
+    >>> log(12).expand(factor_limit=0) # don't do numerical expansion
     log(12)
     >>> log(2147909653)
     log(2147909653)
-    >>> _.expand(limit=oo) # default limit is 2**15; oo forces full factorization
+    >>> _.expand(factor_limit=oo) # default limit is 2**15; oo forces full factorization
     log(32771) + log(65543)
 
     trig - Do trigonometric expansions.

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -796,13 +796,26 @@ class Rational(Number):
     def __hash__(self):
         return super(Rational, self).__hash__()
 
-    def factors(self, limit=None, verbose=False):
+    def factors(self, limit=None, use_trial=True,
+                                  use_rho=False,
+                                  use_pm1=False,
+                                  verbose=False):
         """A wrapper to factorint which return factors of self that are
-        smaller than limit (or cheap to compute)."""
+        smaller than limit (or cheap to compute). Special methods of
+        factoring are disabled by default so that only trial division is used.
+        """
         from sympy.ntheory import factorint
 
-        f = factorint(self.p, limit=limit, verbose=verbose).copy()
-        for p, e in factorint(self.q, limit=limit, verbose=verbose).items():
+        f = factorint(self.p, limit=limit,
+                              use_trial=use_trial,
+                              use_rho=use_rho,
+                              use_pm1=use_pm1,
+                              verbose=verbose).copy()
+        for p, e in factorint(self.q, limit=limit,
+                              use_trial=use_trial,
+                              use_rho=use_rho,
+                              use_pm1=use_pm1,
+                              verbose=verbose).items():
             try: f[p] += -e
             except KeyError: f[p] = -e
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -7,7 +7,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.core.mul import Mul
 
-from sympy.ntheory import multiplicity, perfect_power
+from sympy.ntheory import multiplicity, perfect_power, factorint
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -403,7 +403,7 @@ class log(Function):
                 if limit_ != S.Infinity:
                     dict = arg.factors(limit=limit_)
                 else:
-                    dict = arg.factors()
+                    dict = factorint(arg)
                 if len(dict) > 1:
                     terms = []
                     for b, e in dict.iteritems():

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -325,22 +325,15 @@ class log(Function):
                 return S.NaN
             elif arg.is_negative:
                 return S.Pi * S.ImaginaryUnit + cls(-arg)
+            elif arg.is_Rational and arg.q != 1:
+                return cls(arg.p) - cls(arg.q)
         elif arg is S.ComplexInfinity:
             return S.ComplexInfinity
         elif arg is S.Exp1:
             return S.One
-        #this doesn't work due to caching: :(
-        #elif arg.func is exp and arg.args[0].is_real:
-        #using this one instead:
         elif arg.func is exp and arg.args[0].is_real:
             return arg.args[0]
-        #this shouldn't happen automatically (see the issue 252):
-        #elif arg.is_Pow:
-        #    if arg.exp.is_Number or arg.exp.is_NumberSymbol or \
-        #        arg.exp.is_number:
-        #        return arg.exp * self(arg.base)
-        #elif arg.is_Mul and arg.is_real:
-        #    return Add(*[self(a) for a in arg])
+        #don't autoexpand Pow or Mul (see the issue 252):
         elif not arg.is_Add:
             coeff = arg.as_coefficient(S.ImaginaryUnit)
 
@@ -443,12 +436,6 @@ class log(Function):
             return self.args[0].expand() is S.One
         elif self.args[0].is_negative:
             return False
-
-    def as_numer_denom(self):
-        n, d = self.args[0].as_numer_denom()
-        if d is S.One:
-            return self.func(n), d
-        return (self.func(n) - self.func(d)).as_numer_denom()
 
     def _eval_nseries(self, x, n, logx):
         # NOTE Please see the comment at the beginning of this file, labelled

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -398,7 +398,7 @@ class log(Function):
                 return e * self.func(b)._eval_expand_log(deep=deep,\
                 **hints)
         elif arg.is_Integer:
-            limit_ = hints.get('limit', 2**15)
+            limit_ = hints.get('factor_limit', 2**15)
             if limit_:
                 if limit_ != S.Infinity:
                     dict = arg.factors(limit=limit_)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -7,7 +7,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.core.mul import Mul
 
-from sympy.ntheory import multiplicity, perfect_power, factorint
+from sympy.ntheory import multiplicity, perfect_power
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -397,18 +397,6 @@ class log(Function):
                     e = arg.exp
                 return e * self.func(b)._eval_expand_log(deep=deep,\
                 **hints)
-        elif arg.is_Integer:
-            limit_ = hints.get('factor_limit', 2**15)
-            if limit_:
-                if limit_ != S.Infinity:
-                    dict = arg.factors(limit=limit_)
-                else:
-                    dict = factorint(arg)
-                if len(dict) > 1:
-                    terms = []
-                    for b, e in dict.iteritems():
-                        terms.append(e*self.func(b))
-                    return Add(*terms)
 
         return self.func(arg)
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -399,20 +399,16 @@ class log(Function):
                 **hints)
         elif arg.is_Integer:
             limit_ = hints.get('limit', 2**15)
-            if limit_ != S.Infinity:
-                dict = arg.factors(limit=limit_)
-            else:
-                dict = arg.factors()
-            if any(e != 1 for e in dict.values()):
-                lump = 1
-                terms = []
-                for b, e in dict.iteritems():
-                    if e == 1:
-                        lump *= b
-                    else:
+            if limit_:
+                if limit_ != S.Infinity:
+                    dict = arg.factors(limit=limit_)
+                else:
+                    dict = arg.factors()
+                if len(dict) > 1:
+                    terms = []
+                    for b, e in dict.iteritems():
                         terms.append(e*self.func(b))
-                if terms:
-                    return self.func(lump) + Add(*terms)
+                    return Add(*terms)
 
         return self.func(arg)
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, log, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
-        LambertW, sqrt, Rational, sin, expand_log, S, sign)
+        LambertW, sqrt, Rational, sin, expand_log, S, sign, nextprime)
 from sympy.utilities.pytest import XFAIL
 
 def test_exp_values():
@@ -108,7 +108,7 @@ def test_log_values():
 
     assert log(S.Half) == -log(2)
     assert log(2*3).func is log
-    assert log(2*3**2) == 2*log(3) + log(2)
+    assert log(2*3**2).func is log
 
 def test_log_base():
     assert log(1, 2) == 0
@@ -211,6 +211,13 @@ def test_log_expand():
     x, y = symbols('x,y')
     assert log(x*y).expand(force=True) == log(x) + log(y)
     assert log(x**y).expand(force=True) == y*log(x)
+
+    assert log(2*3**2).expand() == 2*log(3) + log(2)
+    p = nextprime(2**15)
+    q = nextprime(2*p)
+    assert log(p*q).expand() == log(2147909653)
+    assert log(p*q).expand(limit=oo) == log(32771) + log(65543)
+    assert log(2*3).expand(limit=0) == log(6)
 
 def test_log_simplify():
     x = Symbol("x", positive=True)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -106,6 +106,8 @@ def test_log_values():
 
     assert exp(-log(3))**(-1) == 3
 
+    assert log(S.Half) == -log(2)
+
 def test_log_base():
     assert log(1, 2) == 0
     assert log(2, 2) == 1
@@ -122,9 +124,12 @@ def test_log_symbolic():
     assert log(x, exp(1)) == log(x)
     assert log(exp(x)) != x
 
-    assert log(x) == log(x)
     assert log(x, exp(1)) == log(x)
     assert log(x*y) != log(x) + log(y)
+    assert log(x/y).expand() != log(x) - log(y)
+    assert log(x/y).expand(force=True) == log(x) - log(y)
+    assert log(x**y).expand() != y*log(x)
+    assert log(x**y).expand(force=True) == y*log(x)
 
     assert log(x, 2) == log(x)/log(2)
     assert log(E, 2) == 1/log(2)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -107,6 +107,8 @@ def test_log_values():
     assert exp(-log(3))**(-1) == 3
 
     assert log(S.Half) == -log(2)
+    assert log(2*3).func is log
+    assert log(2*3**2) == 2*log(3) + log(2)
 
 def test_log_base():
     assert log(1, 2) == 0

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -212,12 +212,10 @@ def test_log_expand():
     assert log(x*y).expand(force=True) == log(x) + log(y)
     assert log(x**y).expand(force=True) == y*log(x)
 
-    assert log(2*3**2).expand() == 2*log(3) + log(2)
-    p = nextprime(2**15)
-    q = nextprime(2*p)
-    assert log(p*q).expand() == log(2147909653)
-    assert log(p*q).expand(factor_limit=oo) == log(32771) + log(65543)
-    assert log(2*3).expand(factor_limit=0) == log(6)
+    # there's generally no need to expand out logs since this requires
+    # factoring and if simplification is sought, it's cheaper to put
+    # logs together than it is to take them apart.
+    assert log(2*3**2).expand() != 2*log(3) + log(2)
 
 def test_log_simplify():
     x = Symbol("x", positive=True)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -216,8 +216,8 @@ def test_log_expand():
     p = nextprime(2**15)
     q = nextprime(2*p)
     assert log(p*q).expand() == log(2147909653)
-    assert log(p*q).expand(limit=oo) == log(32771) + log(65543)
-    assert log(2*3).expand(limit=0) == log(6)
+    assert log(p*q).expand(factor_limit=oo) == log(32771) + log(65543)
+    assert log(2*3).expand(factor_limit=0) == log(6)
 
 def test_log_simplify():
     x = Symbol("x", positive=True)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, gamma, oo, nan, zoo, factorial, sqrt, Rational, log,\
         polygamma, EulerGamma, pi, uppergamma, S, expand_func, loggamma, sin, cos, \
-        O, cancel
+        O
 
 x = Symbol('x')
 y = Symbol('y')
@@ -126,11 +126,11 @@ def test_polygamma_expand_func():
 def test_loggamma():
     s1 = loggamma(1/(x+sin(x))+cos(x)).nseries(x,n=4)
     s2 = (-log(2*x)-1)/(2*x) - log(x/pi)/2 + (4-log(2*x))*x/24 + O(x**2)
-    assert cancel(s1 - s2).removeO() == 0
+    assert (s1 - s2).expand(force=True).removeO() == 0
     s1 = loggamma(1/x).series(x)
     s2 = (1/x-S(1)/2)*log(1/x) - 1/x  + log(2*pi)/2 + \
          x/12 - x**3/360 + x**5/1260 +  O(x**7)
-    assert cancel(s1 - s2).removeO() == 0
+    assert ((s1 - s2).expand(force=True)).removeO() == 0
 
     def tN(N, M):
         assert loggamma(1/x)._eval_nseries(x,n=N,logx=None).getn() == M
@@ -149,4 +149,3 @@ def test_polygamma_expansion():
            == x + x**2/2 + x**3/6 + O(x**5)
     assert polygamma(3, 1/x).nseries(x, n=8) \
            == 2*x**3 + 3*x**4 + 2*x**5 - x**7 + 4*x**9/3 + O(x**11)
-

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -201,19 +201,21 @@ def multiplicity(p, n):
 
 def perfect_power(n, candidates=None, big=True, factor=True):
     """
-    Return ``(a, b)`` such that ``n`` == ``a**b`` if ``n`` is a
+    Return ``(b, e)`` such that ``n`` == ``b**e`` if ``n`` is a
     perfect power; otherwise return ``False``.
 
     By default, the base is recursively decomposed and the exponents
-    collected so the largest possible ``b`` is sought. If ``big=False``
-    then the smallest possible ``b`` (thus prime) will  be chosen.
+    collected so the largest possible ``e`` is sought. If ``big=False``
+    then the smallest possible ``e`` (thus prime) will  be chosen.
 
-    If ``candidates`` are given, they are assumed to be sorted and
-    the first one that is larger than the computed maximum will signal
+    If ``candidates`` for exponents are given, they are assumed to be sorted
+    and the first one that is larger than the computed maximum will signal
     failure for the routine.
 
     If ``factor=True`` then simultaneous factorization of n is attempted
-    since finding a factor indicates the only possible root for n.
+    since finding a factor indicates the only possible root for n. This
+    is True by default since only a few small factors will be tested in
+    the course of searching for the perfect power.
     """
 
     n = int(n)
@@ -226,11 +228,11 @@ def perfect_power(n, candidates=None, big=True, factor=True):
         candidates = primerange(2 + not_square, max_possible)
 
     afactor = 2 + n % 2
-    for b in candidates:
-        if b < 3:
-            if b == 1 or b == 2 and not_square:
+    for e in candidates:
+        if e < 3:
+            if e == 1 or e == 2 and not_square:
                 continue
-        if b > max_possible:
+        if e > max_possible:
             return False
 
         # see if there is a factor present
@@ -238,57 +240,57 @@ def perfect_power(n, candidates=None, big=True, factor=True):
             if n % afactor == 0:
                 # find what the potential power is
                 if afactor == 2:
-                    b = trailing(n)
+                    e = trailing(n)
                 else:
-                    b = multiplicity(afactor, n)
+                    e = multiplicity(afactor, n)
                 # if it's a trivial power we are done
-                if b == 1:
+                if e == 1:
                     return False
 
                 # maybe the bth root of n is exact
-                r, exact = integer_nthroot(n, b)
+                r, exact = integer_nthroot(n, e)
                 if not exact:
                     # then remove this factor and check to see if
-                    # any of b's factors are a common exponent; if
+                    # any of e's factors are a common exponent; if
                     # not then it's not a perfect power
-                    n //= afactor**b
-                    m = perfect_power(n, candidates=primefactors(b), big=big)
+                    n //= afactor**e
+                    m = perfect_power(n, candidates=primefactors(e), big=big)
                     if m is False:
                         return False
                     else:
                         r, m = m
                         # adjust the two exponents so the bases can
                         # be combined
-                        g = igcd(m, b)
+                        g = igcd(m, e)
                         if g == 1:
                             return False
                         m //= g
-                        b //= g
-                        r, b = r**m*afactor**b, g
+                        e //= g
+                        r, e = r**m*afactor**e, g
                 if not big:
-                    b0 = primefactors(b)
-                    if len(b0) > 1 or b0[0] != b:
-                        b0 = b0[0]
-                        r, b = r**(b//b0), b0
-                return r, b
+                    e0 = primefactors(e)
+                    if len(e0) > 1 or e0[0] != e:
+                        e0 = e0[0]
+                        r, e = r**(e//e0), e0
+                return r, e
             else:
                 # get the next factor ready for the next pass through the loop
                 afactor = nextprime(afactor)
 
         # Weed out downright impossible candidates
-        if logn/b < 40:
-            a = 2.0**(logn/b)
-            if abs(int(a + 0.5) - a) > 0.01:
+        if logn/e < 40:
+            b = 2.0**(logn/e)
+            if abs(int(b + 0.5) - b) > 0.01:
                 continue
 
-        # now see if the plausible b makes a perfect power
-        r, exact = integer_nthroot(n, b)
+        # now see if the plausible e makes a perfect power
+        r, exact = integer_nthroot(n, e)
         if exact:
             if big:
                 m = perfect_power(r, big=big, factor=factor)
                 if m is not False:
-                    r, b = m[0], b*m[1]
-            return int(r), b
+                    r, e = m[0], e*m[1]
+            return int(r), e
     else:
         return False
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -5,6 +5,8 @@ from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     Function, Equality, Dummy, Atom, count_ops)
 
 from sympy.core.numbers import igcd
+from sympy.core.function import expand_log
+from sympy.core.compatibility import minkey
 
 from sympy.utilities import all, any, flatten
 from sympy.functions import gamma, exp, sqrt, log
@@ -1611,6 +1613,10 @@ def simplify(expr, ratio=1.7):
 
     if expr.has(C.TrigonometricFunction):
         expr = trigsimp(expr)
+
+    if expr.has(C.log):
+        expr = minkey([expand_log(expr, deep=True), logcombine(expr)],
+                       key=count_ops)
 
     if expr.has(C.CombinatorialFunction, gamma):
         expr = combsimp(expr)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -163,6 +163,9 @@ def test_simplify():
 
     assert simplify(A*B - B*A) == A*B - B*A
 
+    assert simplify(log(2) + log(3)) == log(6)
+    assert simplify(log(2*x) - log(2)) == log(x)
+
 def test_simplify_other():
     assert simplify(sin(x)**2 + cos(x)**2) == 1
     assert simplify(gamma(x + 1)/gamma(x)) == x

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -703,7 +703,7 @@ def tsolve(eq, sym):
         >>> from sympy.abc import x
 
         >>> tsolve(3**(2*x+5)-4, x)
-        [(-5*log(3) + log(4))/(2*log(3))]
+        [(-5*log(3) + 2*log(2))/(2*log(3))]
 
         >>> tsolve(log(x) + 2*x, x)
         [LambertW(2)/2]

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1060,7 +1060,7 @@ def test_Liouville_ODE():
     sol2 = Eq(C1 + C2/x - exp(-f(x)), 0) # This is equivalent to sol1
     sol3 = [Eq(f(x), -sqrt(2)*sqrt(C1 + C2*log(x))), Eq(f(x), sqrt(2)*sqrt(C1 + C2*log(x)))]
     sol4 = [Eq(f(x), -sqrt(2)*sqrt(C1 + C2*exp(-x))), Eq(f(x), sqrt(2)*sqrt(C1 + C2*exp(-x)))]
-    sol5 = Eq(f(x), -log(x) + log(C1 + C2*x))
+    sol5 = Eq(f(x), log(C1 + C2/x))
     sol1s = constant_renumber(sol1, 'C', 1, 2)
     sol2s = constant_renumber(sol2, 'C', 1, 2)
     sol3s = constant_renumber(sol3, 'C', 1, 2)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -211,8 +211,8 @@ def test_tsolve():
     raises(NotImplementedError, "solve(Eq(cos(x), sin(x)), x)")
 
     assert solve(exp(x) + exp(-x) - y, x) in [
-     [-log(4) + log(2*y + 2*sqrt(-4 + y**2)),
-      -log(4) + log(2*y - 2*sqrt(-4 + y**2))],
+     [-2*log(2) + log(2*y + 2*sqrt(-4 + y**2)),
+      -2*log(2) + log(2*y - 2*sqrt(-4 + y**2))],
      [log(y/2 + sqrt(-4 + y**2)/2), log(y/2 - sqrt(-4 + y**2)/2)]
      ]
     assert solve(exp(x)-3, x) == [log(3)]
@@ -221,7 +221,7 @@ def test_tsolve():
     assert solve(sqrt(3*x)-4, x) == [Rational(16,3)]
     assert solve(3**(x+2), x) == [zoo]
     assert solve(3**(2-x), x) == [zoo]
-    assert solve(4*3**(5*x+2)-7, x) == [(-log(4) - 2*log(3) + log(7))/(5*log(3))]
+    assert solve(4*3**(5*x+2)-7, x) == [(-2*log(2) - 2*log(3) + log(7))/(5*log(3))]
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
     assert solve(3*x+5+2**(-5*x+3), x) in \
         [[-Rational(5,3) + LambertW(-10240*2**Rational(1,3)*log(2)/3)/(5*log(2))],\

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -221,7 +221,7 @@ def test_tsolve():
     assert solve(sqrt(3*x)-4, x) == [Rational(16,3)]
     assert solve(3**(x+2), x) == [zoo]
     assert solve(3**(2-x), x) == [zoo]
-    assert solve(4*3**(5*x+2)-7, x) == [(-2*log(2) - 2*log(3) + log(7))/(5*log(3))]
+    assert solve(4*3**(5*x+2)-7, x) == [(-2*log(3) - 2*log(2) + log(7))/(5*log(3))]
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
     assert solve(3*x+5+2**(-5*x+3), x) in [
         [Rational(-5, 3) + LambertW(log(2**(-10240*2**(Rational(1, 3))/3)))/(5*log(2))],
@@ -242,7 +242,7 @@ def test_tsolve():
     assert solve(2*log(3*x+4)-3, x) == [(exp(Rational(3,2))-4)/3]
     assert solve(exp(x)+1, x) == [pi*I]
     assert solve(x**2 - 2**x, x) == [2]
-    assert solve(x**3 - 3**x, x) == [-3/log(3)*LambertW(-log(3)/3)]
+    assert solve(x**3 - 3**x, x) == [-3*LambertW(-log(3)/3)/log(3)]
 
     A = -7*2**Rational(4, 5)*6**Rational(1, 5)*log(7)/10
     B = -7*3**Rational(1, 5)*log(7)/5
@@ -270,7 +270,7 @@ def test_tsolve():
     # issue #1406
     assert solve(z**x - y, x) == [log(y)/log(z)]
     # issue #1405
-    assert solve(2**x - 10, x) == [(log(2) + log(5))/log(2)]
+    assert solve(2**x - 10, x) == [log(10)/log(2)]
 
 def test_solve_for_functions_derivatives():
     t = Symbol('t')

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -223,17 +223,22 @@ def test_tsolve():
     assert solve(3**(2-x), x) == [zoo]
     assert solve(4*3**(5*x+2)-7, x) == [(-2*log(2) - 2*log(3) + log(7))/(5*log(3))]
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
-    assert solve(3*x+5+2**(-5*x+3), x) in \
-        [[-Rational(5,3) + LambertW(-10240*2**Rational(1,3)*log(2)/3)/(5*log(2))],\
-        [(-25*log(2) + 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2))]]
+    assert solve(3*x+5+2**(-5*x+3), x) in [
+        [Rational(-5, 3) + LambertW(log(2**(-10240*2**(Rational(1, 3))/3)))/(5*log(2))],
+        [-Rational(5,3) + LambertW(-10240*2**Rational(1,3)*log(2)/3)/(5*log(2))],
+        [(-25*log(2) + 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2))],
+        ]
     assert solve(5*x-1+3*exp(2-7*x), x) == \
         [Rational(1,5) + LambertW(-21*exp(Rational(3,5))/5)/7]
     assert solve(2*x+5+log(3*x-2), x) == \
         [Rational(2,3) + LambertW(2*exp(-Rational(19,3))/3)/2]
     assert solve(3*x+log(4*x), x) == [LambertW(Rational(3,4))/3]
     assert solve((2*x+8)*(8+exp(x)), x) == [-4, log(8) + pi*I]
-    assert solve(2*exp(3*x+4)-3, x) in [ [-Rational(4,3)+log(Rational(3,2))/3],\
-                                         [Rational(-4, 3) - log(2)/3 + log(3)/3]]
+    assert solve(2*exp(3*x+4)-3, x) in [
+        [Rational(-4, 3) + log(2**(Rational(2, 3))*3**(Rational(1, 3))/2)],
+        [-Rational(4,3)+log(Rational(3,2))/3],
+        [Rational(-4, 3) - log(2)/3 + log(3)/3],
+        ]
     assert solve(2*log(3*x+4)-3, x) == [(exp(Rational(3,2))-4)/3]
     assert solve(exp(x)+1, x) == [pi*I]
     assert solve(x**2 - 2**x, x) == [2]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -210,11 +210,11 @@ def test_tsolve():
     assert solve(2*cos(x)-y,x)== [acos(y/2)]
     raises(NotImplementedError, "solve(Eq(cos(x), sin(x)), x)")
 
-    # XXX in the following test, log(2*y + 2*...) should -> log(2) + log(y +...)
-    assert solve(exp(x) + exp(-x) - y, x)    == [
-        -log(4) + log(2*y + 2*(-4 + y**2)**Rational(1,2)),
-        -log(4) + log(2*y - 2*(-4 + y**2)**Rational(1,2))
-                                                ]
+    assert solve(exp(x) + exp(-x) - y, x) in [
+     [-log(4) + log(2*y + 2*sqrt(-4 + y**2)),
+      -log(4) + log(2*y - 2*sqrt(-4 + y**2))],
+     [log(y/2 + sqrt(-4 + y**2)/2), log(y/2 - sqrt(-4 + y**2)/2)]
+     ]
     assert solve(exp(x)-3, x) == [log(3)]
     assert solve(Eq(exp(x), 3), x) == [log(3)]
     assert solve(log(x)-3, x) == [exp(3)]
@@ -257,7 +257,7 @@ def test_tsolve():
 
     # issue #1409
     assert solve(y - b*x/(a+x), x) in [[-a*y/(y - b)], [a*y/(b - y)]]
-    assert solve(y - b*exp(a/x), x) == [a/(-log(b) + log(y))]
+    assert solve(y - b*exp(a/x), x) == [a/log(y/b)]
     # issue #1408
     assert solve(y-b/(1+a*x), x) in [[(b - y)/(a*y)], [-((y - b)/(a*y))]]
     # issue #1407
@@ -348,4 +348,3 @@ def test_solve_inequalities():
                And(Lt(1, re(x)), Lt(re(x), sqrt(2)))), Eq(im(x), 0))
     assert solve(system, assume=Q.real(x)) == \
         Or(And(Lt(-sqrt(2), x), Lt(x, -1)), And(Lt(1, x), Lt(x, sqrt(2))))
-

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -265,7 +265,7 @@ def test_tsolve():
     # issue #1406
     assert solve(z**x - y, x) == [log(y)/log(z)]
     # issue #1405
-    assert solve(2**x - 10, x) == [log(10)/log(2)]
+    assert solve(2**x - 10, x) == [(log(2) + log(5))/log(2)]
 
 def test_solve_for_functions_derivatives():
     t = Symbol('t')


### PR DESCRIPTION
```
Expansion of a log was being done in an as_numer_denom method;
it should be done in _eval_expand_log where rules are followed
concerning when the expansion shold be allowed. When this is
handled there, the as_numer_denom method is no longer needed
for log. But then tests fail because Rationals don't automatically
expand, e.g. log(1/2) doesn't become -log(2). They also fail when
simplifications that relied on that forced expansion of log(x/y)
into log(x) - log(y) no longer can do the expansion so the
force keyword was introduced to the log_expand method.

A few failing solver tests needed tweaking.

The expand docstring was PEP8'ed and edited a little.
```
