### PR TITLE
1694 related -- 2400: use deep in simplify's call to together

### DIFF
--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -615,16 +615,16 @@ def test_issue_1100():
     assert integrate(exp(-I*2*pi*y*x)*x, (x, -oo, oo)) is S.NaN
 
 def test_issue_841():
-    from sympy import simplify
-    a = Symbol('a', positive = True)
-    b = Symbol('b')
-    c = Symbol('c')
-    d = Symbol('d', positive = True)
+    from sympy import factor
+    a,b,c,d = symbols('a:d', positive=True, bounded=True)
     assert integrate(exp(-x**2 + I*c*x), x) == sqrt(pi)*erf(x - I*c/2)*exp(-c**S(2)/4)/2
     assert integrate(exp(a*x**2 + b*x + c), x) == \
           I*sqrt(pi)*erf(-I*x*sqrt(a) - I*b/(2*sqrt(a)))*exp(c)*exp(-b**2/(4*a))/(2*sqrt(a))
-    assert simplify(integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo))) == sqrt(pi)*(1 + erf(oo - d/sqrt(a))) \
-           *exp(d**2/a)/(2*sqrt(a))
+    a,b,c,d = symbols('a:d', positive=True)
+    i = integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo))
+    ans = sqrt(pi)*exp(d**2/a)*(1 + erf(oo - d/sqrt(a)))/(2*sqrt(a))
+    n, d = i.as_numer_denom()
+    assert factor(n, expand=False)/d == ans
 
 def test_issue_2314():
     # Note that this is not the same as testing ratint() becuase integrate()

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1633,7 +1633,7 @@ def simplify(expr, ratio=1.7):
     if expr.is_commutative is False:
         return together(powsimp(expr))
 
-    expr = together(cancel(powsimp(expr)).expand())
+    expr = together(cancel(powsimp(expr)).expand(), deep=True)
 
     if not isinstance(expr, Basic): # XXX: temporary hack
         return expr


### PR DESCRIPTION
Since together has a deep option, it makes sense to use it when trying to simplify an expression, otherwise you will have less than optimally simplified expressions within functions.

An interesting problem was encountered with one of the tests that failed after this. An integral could not be done when variables were bounded and positive, only when they were positive. But without the bounded assumption, the infiinity they were being subtracted from didn't absorb them so when together was applied to `oo - d/sqrt(a)` where a and d were the positive quantitites, a value of nan was obtained -- and that caused to whole integral result to collapse to nan when simplified.

```
>>> from sympy.abc import *
>>> from sympy import *
>>> var('a,d',positive=1,bounded=True)
(a, d)
>>> (integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo)))
Integral(exp(2*d*x - a*x**2), (x, -oo, oo))
>>> (oo-d/sqrt(a))
oo
>>> var('a,d',positive=1)
(a, d)
>>> (integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo)))
pi**(1/2)*exp(d**2/a)/(2*a**(1/2)) + pi**(1/2)*erf(oo - d/a**(1/2))*exp(d**2/a)/
(2*a**(1/2))
>>> (oo-d/sqrt(a))
oo - d/a**(1/2)
>>> together(_)
nan
```
