### PR TITLE
1274: delete bad XFAIL test

### DIFF
--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -549,16 +549,6 @@ def test_logcombine_1():
         force=True) == log(x**2)+3*I*log(x) + \
         Integral((sin(x**2)+cos(x**3))/x, x)
 
-@XFAIL
-def test_logcombine_2():
-    # The same as one of the tests above, but with Rational(a, b) replaced with a/b.
-    # This fails because of a bug in matches.  See issue 1274.
-    x, y = symbols("x,y")
-    assert logcombine((x*y+sqrt(x**4+y**4)+log(x)-log(y))/(pi*x**(2/3)*y**(3/2)), \
-        force=True) == log(x**(1/(pi*x**(2/3)*y**(3/2)))*y**(-1/\
-        (pi*x**(2/3)*y**(3/2)))) + (x**4 + y**4)**(1/2)/(pi*x**(2/3)*y**(3/2)) + \
-        x**(1/3)/(pi*y**(1/2))
-
 def test_posify():
     from sympy import posify, Symbol, log
     from sympy.abc import x


### PR DESCRIPTION
```
There is no way the test could ever succeed since it is basically doing

assert 2*(2/3 + 3/4) == 2*(8+9)/12
       --------------   ---------------------------
       purposefully     output entered incorrectly
       bad input        with values that the correct
                        input would have given

Only fortuitous cancellation of errors would ever make this work, e.g.
assert 2*(1/2 + 1/3) == 2*(2 + 3)/6 would work.
```
