### PR TITLE
Refactor ask()

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -152,31 +152,14 @@ def ask_direct(expr, key=Q.is_true, assumptions=True, context=global_assumptions
     Method for inferring properties about objects.
 
     """
-    expr = sympify(expr)
-    if isinstance(key, basestring):
-        key = getattr(Q, str(key))
     assumptions = And(assumptions, And(*context))
 
-    if assumptions is True:
-        return
-
-    if not expr.is_Atom:
-        return
-
     assumptions = eliminate_assume(assumptions, expr)
-    if assumptions is None or assumptions is True:
-        return
 
-    # Failing all else, we do a full logical inference
-    # If it's not consistent with the assumptions, then it can't be true
     if not satisfiable(And(known_facts_cnf, assumptions, key)):
         return False
-
-    # If the negation is unsatisfiable, it is entailed
     if not satisfiable(And(known_facts_cnf, assumptions, Not(key))):
         return True
-
-    # Otherwise, we don't have enough information to conclude one way or the other
     return None
 
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -135,16 +135,7 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
             return False
 
     # Failing all else, we do a full logical inference
-    # If it's not consistent with the assumptions, then it can't be true
-    if not satisfiable(And(known_facts_cnf, assumptions, key)):
-        return False
-
-    # If the negation is unsatisfiable, it is entailed
-    if not satisfiable(And(known_facts_cnf, assumptions, Not(key))):
-        return True
-
-    # Otherwise, we don't have enough information to conclude one way or the other
-    return None
+    return ask_direct(key, assumptions)
 
 
 def ask_direct(proposition, hypothesis):

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -147,13 +147,11 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
     return None
 
 
-def ask_direct(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
+def ask_direct(expr, key=Q.is_true, assumptions=True):
     """
     Method for inferring properties about objects.
 
     """
-    assumptions = And(assumptions, And(*context))
-
     assumptions = eliminate_assume(assumptions, expr)
 
     if not satisfiable(And(known_facts_cnf, assumptions, key)):

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -106,8 +106,6 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
 
     """
     expr = sympify(expr)
-    if isinstance(key, basestring):
-        key = getattr(Q, str(key))
     assumptions = And(assumptions, And(*context))
 
     # direct resolution method, no logic
@@ -169,16 +167,16 @@ def register_handler(key, handler):
     """Register a handler in the ask system. key must be a string and handler a
     class inheriting from AskHandler.
 
-        >>> from sympy.assumptions import register_handler, ask
+        >>> from sympy.assumptions import register_handler, ask, Q
         >>> from sympy.assumptions.handlers import AskHandler
         >>> class MersenneHandler(AskHandler):
         ...     # Mersenne numbers are in the form 2**n + 1, n integer
         ...     @staticmethod
         ...     def Integer(expr, assumptions):
         ...         import math
-        ...         return ask(math.log(expr + 1, 2), 'integer')
+        ...         return ask(math.log(expr + 1, 2), Q.integer)
         >>> register_handler('mersenne', MersenneHandler)
-        >>> ask(7, 'mersenne')
+        >>> ask(7, Q.mersenne)
         True
 
     """

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -79,14 +79,9 @@ def eliminate_assume(expr, symbol=None):
         Not(Q.positive)
 
     """
-    if symbol is not None:
-        props = expr.atoms(AppliedPredicate)
-        if props and symbol not in [prop.arg for prop in props]:
-            return
-    if expr.__class__ is AppliedPredicate:
-        if symbol is not None:
-            if not expr.arg.has(symbol):
-                return
+    if symbol is not None and not expr.has(symbol):
+        return None
+    if isinstance(expr, AppliedPredicate):
         return expr.func
     return expr.func(*filter(lambda x: x is not None,
                 [eliminate_assume(arg, symbol) for arg in expr.args]))

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -65,15 +65,14 @@ def _extract_facts(expr, symbol):
     """
     Helper for ask().
 
-    Extracts the facts relevant to the symbol from an assumption.
-    Returns None if there is nothing to extract.
+    Extracts the facts relevant to the symbol from an assumption in CNF.
+    Returns True (the tautological fact) if there is nothing to extract.
     """
     if not expr.has(symbol):
-        return None
+        return True
     if isinstance(expr, AppliedPredicate):
         return expr.func
-    return expr.func(*filter(lambda x: x is not None,
-                [_extract_facts(arg, symbol) for arg in expr.args]))
+    return expr.func(*[_extract_facts(arg, symbol) for arg in expr.args])
 
 def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
     """
@@ -119,8 +118,8 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
     if not expr.is_Atom:
         return
 
-    local_facts = _extract_facts(assumptions, expr)
-    if local_facts is None or local_facts is True:
+    local_facts = _extract_facts(to_cnf(assumptions), expr)
+    if local_facts is True:
         return
 
     # See if there's a straight-forward conclusion we can make for the inference

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -61,7 +61,7 @@ def eval_predicate(predicate, expr, assumptions=True):
     return res
 
 
-def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disable_preprocessing=False):
+def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
     """
     Method for inferring properties about objects.
 
@@ -97,10 +97,9 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disab
     assumptions = And(assumptions, And(*context))
 
     # direct resolution method, no logic
-    if not disable_preprocessing:
-        res = eval_predicate(key, expr, assumptions)
-        if res is not None:
-            return res
+    res = eval_predicate(key, expr, assumptions)
+    if res is not None:
+        return res
 
     if assumptions is True:
         return
@@ -113,28 +112,27 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disab
         return
 
     # See if there's a straight-forward conclusion we can make for the inference
-    if not disable_preprocessing:
-        if assumptions.is_Atom:
-            if key in known_facts_dict[assumptions]:
-                return True
-            if Not(key) in known_facts_dict[assumptions]:
-                return False
-        elif assumptions.func is And:
-            for assum in assumptions.args:
-                if assum.is_Atom:
-                    if key in known_facts_dict[assum]:
-                        return True
-                    if Not(key) in known_facts_dict[assum]:
-                        return False
-                elif assum.func is Not and assum.args[0].is_Atom:
-                    if key in known_facts_dict[assum]:
-                        return False
-                    if Not(key) in known_facts_dict[assum]:
-                        return True
-        elif (isinstance(key, Predicate) and
-                assumptions.func is Not and assumptions.args[0].is_Atom):
-            if assumptions.args[0] in known_facts_dict[key]:
-                return False
+    if assumptions.is_Atom:
+        if key in known_facts_dict[assumptions]:
+            return True
+        if Not(key) in known_facts_dict[assumptions]:
+            return False
+    elif assumptions.func is And:
+        for assum in assumptions.args:
+            if assum.is_Atom:
+                if key in known_facts_dict[assum]:
+                    return True
+                if Not(key) in known_facts_dict[assum]:
+                    return False
+            elif assum.func is Not and assum.args[0].is_Atom:
+                if key in known_facts_dict[assum]:
+                    return False
+                if Not(key) in known_facts_dict[assum]:
+                    return True
+    elif (isinstance(key, Predicate) and
+            assumptions.func is Not and assumptions.args[0].is_Atom):
+        if assumptions.args[0] in known_facts_dict[key]:
+            return False
 
     # Failing all else, we do a full logical inference
     # If it's not consistent with the assumptions, then it can't be true
@@ -147,6 +145,41 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions, disab
 
     # Otherwise, we don't have enough information to conclude one way or the other
     return None
+
+
+def ask_direct(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
+    """
+    Method for inferring properties about objects.
+
+    """
+    expr = sympify(expr)
+    if isinstance(key, basestring):
+        key = getattr(Q, str(key))
+    assumptions = And(assumptions, And(*context))
+
+    if assumptions is True:
+        return
+
+    if not expr.is_Atom:
+        return
+
+    assumptions = eliminate_assume(assumptions, expr)
+    if assumptions is None or assumptions is True:
+        return
+
+    # Failing all else, we do a full logical inference
+    # If it's not consistent with the assumptions, then it can't be true
+    if not satisfiable(And(known_facts_cnf, assumptions, key)):
+        return False
+
+    # If the negation is unsatisfiable, it is entailed
+    if not satisfiable(And(known_facts_cnf, assumptions, Not(key))):
+        return True
+
+    # Otherwise, we don't have enough information to conclude one way or the other
+    return None
+
+
 
 def register_handler(key, handler):
     """Register a handler in the ask system. key must be a string and handler a
@@ -196,7 +229,7 @@ def compute_known_facts():
         mapping[key] = set([key])
         for other_key in known_facts_keys:
             if other_key != key:
-                if ask(x, other_key, key(x), disable_preprocessing=True):
+                if ask(x, other_key, key(x)):
                     mapping[key].add(other_key)
     fact_string += "\n# -{ Known facts in compressed sets }-\n"
     fact_string += "known_facts_dict = {\n    "

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -147,16 +147,14 @@ def ask(expr, key=Q.is_true, assumptions=True, context=global_assumptions):
     return None
 
 
-def ask_direct(expr, key=Q.is_true, assumptions=True):
+def ask_direct(proposition, hypothesis):
     """
     Method for inferring properties about objects.
 
     """
-    assumptions = eliminate_assume(assumptions, expr)
-
-    if not satisfiable(And(known_facts_cnf, assumptions, key)):
+    if not satisfiable(And(known_facts_cnf, hypothesis, proposition)):
         return False
-    if not satisfiable(And(known_facts_cnf, assumptions, Not(key))):
+    if not satisfiable(And(known_facts_cnf, hypothesis, Not(proposition))):
         return True
     return None
 
@@ -204,13 +202,12 @@ def compute_known_facts():
     fact_string += "\n)\n"
 
     # Compute the quick lookup for single facts
-    from sympy.abc import x
     mapping = {}
     for key in known_facts_keys:
         mapping[key] = set([key])
         for other_key in known_facts_keys:
             if other_key != key:
-                if ask(x, other_key, key(x)):
+                if ask_direct(other_key, key):
                     mapping[key].add(other_key)
     fact_string += "\n# -{ Known facts in compressed sets }-\n"
     fact_string += "known_facts_dict = {\n    "

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -78,36 +78,6 @@ class AppliedPredicate(Boolean):
     def __hash__(self):
         return super(AppliedPredicate, self).__hash__()
 
-def eliminate_assume(expr, symbol=None):
-    """
-    Convert an expression with assumptions to an equivalent with all assumptions
-    replaced by symbols.
-
-    Q.integer(x) --> Q.integer
-    ~Q.integer(x) --> ~Q.integer
-
-    Examples:
-        >>> from sympy.assumptions.assume import eliminate_assume
-        >>> from sympy import Q
-        >>> from sympy.abc import x
-        >>> eliminate_assume(Q.positive(x))
-        Q.positive
-        >>> eliminate_assume(~Q.positive(x))
-        Not(Q.positive)
-
-    """
-    if symbol is not None:
-        props = expr.atoms(AppliedPredicate)
-        if props and symbol not in [prop.arg for prop in props]:
-            return
-    if expr.__class__ is AppliedPredicate:
-        if symbol is not None:
-            if not expr.arg.has(symbol):
-                return
-        return expr.func
-    return expr.func(*filter(lambda x: x is not None,
-                [eliminate_assume(arg, symbol) for arg in expr.args]))
-
 class Predicate(Boolean):
     """A predicate is a function that returns a boolean value.
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -1,12 +1,12 @@
 """
-Handlers for keys related to set membership: integer, rational, etc.
+Handlers for predicates related to set membership: integer, rational, etc.
 """
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler
 
 class AskIntegerHandler(CommonHandler):
     """
-    Handler for key 'integer'
+    Handler for Q.integer
     Test that an expression belongs to the field of integer numbers
     """
 
@@ -26,7 +26,7 @@ class AskIntegerHandler(CommonHandler):
         """
         if expr.is_number:
             return AskIntegerHandler._number(expr, assumptions)
-        return test_closed_group(expr, assumptions, 'integer')
+        return test_closed_group(expr, assumptions, Q.integer)
 
     @staticmethod
     def Mul(expr, assumptions):
@@ -102,7 +102,7 @@ class AskIntegerHandler(CommonHandler):
 
 class AskRationalHandler(CommonHandler):
     """
-    Handler for key 'rational'
+    Handler for Q.rational
     Test that an expression belongs to the field of rational numbers
     """
 
@@ -116,7 +116,7 @@ class AskRationalHandler(CommonHandler):
         if expr.is_number:
             if expr.as_real_imag()[1]:
                 return False
-        return test_closed_group(expr, assumptions, 'rational')
+        return test_closed_group(expr, assumptions, Q.rational)
 
     Mul = Add
 
@@ -175,7 +175,7 @@ class AskIrrationalHandler(CommonHandler):
 
 class AskRealHandler(CommonHandler):
     """
-    Handler for key 'real'
+    Handler for Q.real
     Test that an expression belongs to the field of real numbers
     """
 
@@ -191,7 +191,7 @@ class AskRealHandler(CommonHandler):
         """
         if expr.is_number:
             return AskRealHandler._number(expr, assumptions)
-        return test_closed_group(expr, assumptions, 'real')
+        return test_closed_group(expr, assumptions, Q.real)
 
     @staticmethod
     def Mul(expr, assumptions):
@@ -282,14 +282,14 @@ class AskRealHandler(CommonHandler):
 
 class AskExtendedRealHandler(AskRealHandler):
     """
-    Handler for key 'extended_real'
+    Handler for Q.extended_real
     Test that an expression belongs to the field of extended real numbers,
     that is real numbers union {Infinity, -Infinity}
     """
 
     @staticmethod
     def Add(expr, assumptions):
-        return test_closed_group(expr, assumptions, 'extended_real')
+        return test_closed_group(expr, assumptions, Q.extended_real)
 
     Mul, Pow = Add, Add
 
@@ -303,13 +303,13 @@ class AskExtendedRealHandler(AskRealHandler):
 
 class AskComplexHandler(CommonHandler):
     """
-    Handler for key 'complex'
+    Handler for Q.complex
     Test that an expression belongs to the field of complex numbers
     """
 
     @staticmethod
     def Add(expr, assumptions):
-        return test_closed_group(expr, assumptions, 'complex')
+        return test_closed_group(expr, assumptions, Q.complex)
 
     Mul, Pow = Add, Add
 
@@ -341,7 +341,7 @@ class AskComplexHandler(CommonHandler):
 
 class AskImaginaryHandler(CommonHandler):
     """
-    Handler for key 'imaginary'
+    Handler for Q.imaginary
     Test that an expression belongs to the field of imaginary numbers,
     that is, numbers in the form x*I, where x is real
     """
@@ -408,19 +408,19 @@ class AskImaginaryHandler(CommonHandler):
         return True
 
 class AskAlgebraicHandler(CommonHandler):
-    """Handler for 'algebraic' key. """
+    """Handler for Q.algebraic key. """
 
     @staticmethod
     def Add(expr, assumptions):
-        return test_closed_group(expr, assumptions, 'algebraic')
+        return test_closed_group(expr, assumptions, Q.algebraic)
 
     @staticmethod
     def Mul(expr, assumptions):
-        return test_closed_group(expr, assumptions, 'algebraic')
+        return test_closed_group(expr, assumptions, Q.algebraic)
 
     @staticmethod
     def Pow(expr, assumptions):
-        return expr.exp.is_Rational and ask(expr.base, 'algebraic', assumptions)
+        return expr.exp.is_Rational and ask(expr.base, Q.algebraic, assumptions)
 
     @staticmethod
     def Number(expr, assumptions):

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -22,11 +22,15 @@ def test_extract_facts():
     a, b = symbols('a b', cls=Predicate)
     x, y = symbols('x y')
     assert _extract_facts(a(x), x)  == a
-    assert _extract_facts(a(x), y)  == None
+    assert _extract_facts(a(x), y)  == True
     assert _extract_facts(~a(x), x) == ~a
-    assert _extract_facts(~a(x), y) == None
+    assert _extract_facts(~a(x), y) == True
     assert _extract_facts(a(x) | b(x), x) == a | b
     assert _extract_facts(a(x) | ~b(x), x) == a | ~b
+    assert _extract_facts(a(x) & b(y), x) == a
+    assert _extract_facts(a(x) & b(y), y) == b
+    assert _extract_facts(a(x) | b(y), x) == True
+    assert _extract_facts(~(a(x)|b(y)), x) == ~a
 
 def test_global():
     """Test for global assumptions"""

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -1,7 +1,7 @@
 """rename this to test_assumptions.py when the old assumptions system is deleted"""
 from sympy.core import symbols
 from sympy.assumptions import AppliedPredicate, global_assumptions, Predicate
-from sympy.assumptions.assume import eliminate_assume
+from sympy.assumptions.ask import eliminate_assume
 from sympy.printing import pretty
 from sympy.assumptions.ask import Q
 from sympy.logic.boolalg import Or

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -1,7 +1,7 @@
 """rename this to test_assumptions.py when the old assumptions system is deleted"""
 from sympy.core import symbols
 from sympy.assumptions import AppliedPredicate, global_assumptions, Predicate
-from sympy.assumptions.ask import eliminate_assume
+from sympy.assumptions.ask import _extract_facts
 from sympy.printing import pretty
 from sympy.assumptions.ask import Q
 from sympy.logic.boolalg import Or
@@ -18,21 +18,15 @@ def test_pretty():
     x = symbols('x')
     assert pretty(Q.positive(x)) == "Q.positive(x)"
 
-def test_eliminate_assumptions():
+def test_extract_facts():
     a, b = symbols('a b', cls=Predicate)
     x, y = symbols('x y')
-    assert eliminate_assume(a(x))  == a
-    assert eliminate_assume(a(x), symbol=x)  == a
-    assert eliminate_assume(a(x), symbol=y)  == None
-    assert eliminate_assume(~a(x)) == ~a
-    assert eliminate_assume(a(x), symbol=y) == None
-    assert eliminate_assume(a(x) | b(x)) == a | b
-    assert eliminate_assume(a(x) | ~b(x)) == a | ~b
-
-def test_eliminate_composite_assumptions():
-    a, b = map(Predicate, symbols('a b'))
-    x, y = symbols('x y')
-    assert eliminate_assume(~a(y), x) == None
+    assert _extract_facts(a(x), x)  == a
+    assert _extract_facts(a(x), y)  == None
+    assert _extract_facts(~a(x), x) == ~a
+    assert _extract_facts(~a(x), y) == None
+    assert _extract_facts(a(x) | b(x), x) == a | b
+    assert _extract_facts(a(x) | ~b(x), x) == a | ~b
 
 def test_global():
     """Test for global assumptions"""

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -933,6 +933,12 @@ def test_composite_ask_key():
     x = symbols('x')
     assert ask(x, Q.negative & Q.integer, Q.real(x) >> Q.positive(x)) is False
 
+def test_multiple_symbols():
+    x, y = symbols('x, y')
+    assert ask(Q.real(x), assumptions=Q.real(x) & Q.real(y)) is True
+    assert ask(Q.real(x), assumptions=Q.real(x) | Q.real(y)) is None
+    assert ask(Q.real(x), assumptions= ~(Q.real(x) >> Q.real(y))) is True
+
 def test_is_true():
     from sympy.logic.boolalg import Equivalent, Implies
     x = symbols('x')

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -879,30 +879,30 @@ def test_real():
 def test_algebraic():
     x, y = symbols('x,y')
 
-    assert ask(x, 'algebraic') == None
+    assert ask(x, Q.algebraic) == None
 
-    assert ask(I, 'algebraic') == True
-    assert ask(2*I, 'algebraic') == True
-    assert ask(I/3, 'algebraic') == True
+    assert ask(I, Q.algebraic) == True
+    assert ask(2*I, Q.algebraic) == True
+    assert ask(I/3, Q.algebraic) == True
 
-    assert ask(sqrt(7), 'algebraic') == True
-    assert ask(2*sqrt(7), 'algebraic') == True
-    assert ask(sqrt(7)/3, 'algebraic') == True
+    assert ask(sqrt(7), Q.algebraic) == True
+    assert ask(2*sqrt(7), Q.algebraic) == True
+    assert ask(sqrt(7)/3, Q.algebraic) == True
 
-    assert ask(I*sqrt(3), 'algebraic') == True
-    assert ask(sqrt(1+I*sqrt(3)), 'algebraic') == True
+    assert ask(I*sqrt(3), Q.algebraic) == True
+    assert ask(sqrt(1+I*sqrt(3)), Q.algebraic) == True
 
-    assert ask((1+I*sqrt(3)**(S(17)/31)), 'algebraic') == True
-    assert ask((1+I*sqrt(3)**(S(17)/pi)), 'algebraic') == False
+    assert ask((1+I*sqrt(3)**(S(17)/31)), Q.algebraic) == True
+    assert ask((1+I*sqrt(3)**(S(17)/pi)), Q.algebraic) == False
 
-    assert ask(sin(7), 'algebraic') == None
-    assert ask(sqrt(sin(7)), 'algebraic') == None
-    assert ask(sqrt(y+I*sqrt(7)), 'algebraic') == None
+    assert ask(sin(7), Q.algebraic) == None
+    assert ask(sqrt(sin(7)), Q.algebraic) == None
+    assert ask(sqrt(y+I*sqrt(7)), Q.algebraic) == None
 
-    assert ask(oo, 'algebraic') == False
-    assert ask(-oo, 'algebraic') == False
+    assert ask(oo, Q.algebraic) == False
+    assert ask(-oo, Q.algebraic) == False
 
-    assert ask(2.47, 'algebraic') == False
+    assert ask(2.47, Q.algebraic) == False
 
 def test_global():
     """Test ask with global assumptions"""
@@ -972,15 +972,15 @@ def test_incompatible_resolutors():
 def test_key_extensibility():
     """test that you can add keys to the ask system at runtime"""
     x = Symbol('x')
-    # make sure thie key is not defined
-    raises(AttributeError, "ask(x, 'my_key')")
+    # make sure the key is not defined
+    raises(AttributeError, "ask(x, Q.my_key)")
     class MyAskHandler(AskHandler):
         @staticmethod
         def Symbol(expr, assumptions):
             return True
     register_handler('my_key', MyAskHandler)
-    assert ask(x, 'my_key') == True
-    assert ask(x+1, 'my_key') == None
+    assert ask(x, Q.my_key) == True
+    assert ask(x+1, Q.my_key) == None
     remove_handler('my_key', MyAskHandler)
 
 def test_type_extensibility():

--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -3,7 +3,7 @@
 from sympy.polys.polyutils import parallel_dict_from_basic
 from sympy.polys.polyoptions import build_options
 from sympy.polys.domains import ZZ, QQ, RR, EX
-from sympy.assumptions import ask
+from sympy.assumptions import ask, Q
 from sympy.core import S, sympify
 from sympy.utilities import any
 
@@ -12,7 +12,7 @@ def _construct_simple(coeffs, opt):
     result, rationals, reals, algebraics = {}, False, False, False
 
     if opt.extension is True:
-        is_algebraic = lambda coeff: ask(coeff, 'algebraic')
+        is_algebraic = lambda coeff: ask(coeff, Q.algebraic)
     else:
         is_algebraic = lambda coeff: False
 

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -6,7 +6,7 @@ from sympy.polys.polyoptions import build_options
 from sympy.core.exprtools import decompose_power
 
 from sympy.core import S, Add, Mul, Pow
-from sympy.assumptions import ask
+from sympy.assumptions import ask, Q
 from sympy.utilities import any
 
 import re
@@ -177,7 +177,7 @@ def _parallel_dict_from_expr_no_gens(exprs, opt):
             return factor in opt.domain
     elif opt.extension is True:
         def _is_coeff(factor):
-            return ask(factor, 'algebraic')
+            return ask(factor, Q.algebraic)
     elif opt.greedy is not False:
         def _is_coeff(factor):
             return False


### PR DESCRIPTION
TODO: rework and rebase
This branch contains a few refactorings related to ask():
- Extract the version of ask() used in compute_known_facts into a simple function called `ask_direct` (@haz: any idea for a better name?) and use it inside ask().
- Move `eliminate_assume` to `ask.py` and rename it `_extract_facts`, cf. discussion in #289.
- Disallow specifying the "key" as a string, cf. [issue 2338](http://code.google.com/p/sympy/issues/detail?id=2338)
- Handle correctly assumptions of the form `P(x) | Q(y)`.
