### PR TITLE
Enabled preprocessing algorithm in roots()

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -128,11 +128,9 @@ def _construct_composite(coeffs, opt):
                 fractions = True
                 break
 
-    result = []
+    coeffs = set([])
 
     if not fractions:
-        coeffs = set([])
-
         for numer, denom in zip(numers, denoms):
             denom = denom[zeros]
 
@@ -140,24 +138,31 @@ def _construct_composite(coeffs, opt):
                 coeff /= denom
                 coeffs.add(coeff)
                 numer[monom] = coeff
+    else:
+        for numer, denom in zip(numers, denoms):
+            coeffs.update(numer.values())
+            coeffs.update(denom.values())
 
-        rationals, reals = False, False
+    rationals, reals = False, False
 
-        for coeff in coeffs:
-            if coeff.is_Rational:
-                if not coeff.is_Integer:
-                    rationals = True
-            elif coeff.is_Real:
-                reals = True
-                break
+    for coeff in coeffs:
+        if coeff.is_Rational:
+            if not coeff.is_Integer:
+                rationals = True
+        elif coeff.is_Real:
+            reals = True
+            break
 
-        if reals:
-            ground = RR
-        elif rationals:
-            ground = QQ
-        else:
-            ground = ZZ
+    if reals:
+        ground = RR
+    elif rationals:
+        ground = QQ
+    else:
+        ground = ZZ
 
+    result = []
+
+    if not fractions:
         domain = ground.poly_ring(*gens)
 
         for numer in numers:
@@ -166,14 +171,14 @@ def _construct_composite(coeffs, opt):
 
             result.append(domain(numer))
     else:
-        domain = ZZ.frac_field(*gens)
+        domain = ground.frac_field(*gens)
 
         for numer, denom in zip(numers, denoms):
             for monom, coeff in numer.iteritems():
-                numer[monom] = ZZ.from_sympy(coeff)
+                numer[monom] = ground.from_sympy(coeff)
 
             for monom, coeff in denom.iteritems():
-                denom[monom] = ZZ.from_sympy(coeff)
+                denom[monom] = ground.from_sympy(coeff)
 
             result.append(domain((numer, denom)))
 

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -921,7 +921,7 @@ def dmp_from_dict(f, u, K):
     return dmp_strip(h, u)
 
 @cythonized("n,k")
-def dup_to_dict(f):
+def dup_to_dict(f, K=None, zero=False):
     """
     Convert ``K[x]`` polynomial to a ``dict``.
 
@@ -935,6 +935,9 @@ def dup_to_dict(f):
     {}
 
     """
+    if not f and zero:
+        return {(0,): K.zero}
+
     n, result = dup_degree(f), {}
 
     for k in xrange(0, n+1):
@@ -944,7 +947,7 @@ def dup_to_dict(f):
     return result
 
 @cythonized("n,k")
-def dup_to_raw_dict(f):
+def dup_to_raw_dict(f, K=None, zero=False):
     """
     Convert ``K[x]`` polynomial to a raw ``dict``.
 
@@ -956,6 +959,9 @@ def dup_to_raw_dict(f):
     {0: 7, 2: 5, 4: 1}
 
     """
+    if not f and zero:
+        return {0: K.zero}
+
     n, result = dup_degree(f), {}
 
     for k in xrange(0, n+1):
@@ -965,7 +971,7 @@ def dup_to_raw_dict(f):
     return result
 
 @cythonized("u,v,n,k")
-def dmp_to_dict(f, u):
+def dmp_to_dict(f, u, K=None, zero=False):
     """
     Convert ``K[X]`` polynomial to a ``dict````.
 
@@ -980,7 +986,10 @@ def dmp_to_dict(f, u):
 
     """
     if not u:
-        return dup_to_dict(f)
+        return dup_to_dict(f, K, zero=zero)
+
+    if dmp_zero_p(f, u) and zero:
+        return {(0,)*(u + 1): K.zero}
 
     n, v, result = dmp_degree(f, u), u-1, {}
 

--- a/sympy/polys/domains/realdomain.py
+++ b/sympy/polys/domains/realdomain.py
@@ -102,4 +102,11 @@ class RealDomain(CharacteristicZero, SimpleDomain): # XXX: should be a field
 
     def div(self, a, b):
         """Division of `a` and `b`, implies `__div__`. """
-        return a / b, self.zero
+
+    def gcd(self, a, b):
+        """Returns GCD of `a` and `b`. """
+        return self.one
+
+    def lcm(self, a, b):
+        """Returns LCM of `a` and `b`. """
+        return a*b

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -768,11 +768,6 @@ class DMP(object):
         return f.dom.is_one(dmp_ground_content(f.rep, f.lev, f.dom))
 
     @property
-    def is_ground(f):
-        """Returns `True` if `f` is an element of the ground domain. """
-        return all(d <= 0 for d in dmp_degree_list(f.rep, f.lev))
-
-    @property
     def is_linear(f):
         """Returns `True` if `f` is linear in all its variables. """
         return all([ sum(monom) <= 1 for monom in dmp_to_dict(f.rep, f.lev).keys() ])
@@ -781,6 +776,11 @@ class DMP(object):
     def is_quadratic(f):
         """Returns `True` if `f` is quadratic in all its variables. """
         return all([ sum(monom) <= 2 for monom in dmp_to_dict(f.rep, f.lev).keys() ])
+
+    @property
+    def is_monomial(f):
+        """Returns `True` if `f` is zero or has only one term. """
+        return len(f.to_dict()) <= 1
 
     @property
     def is_homogeneous(f):

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -226,13 +226,13 @@ class DMP(object):
         """Create an instance of `cls` given a list of SymPy coefficients. """
         return cls(dmp_from_sympy(rep, lev, dom), dom, lev)
 
-    def to_dict(f):
+    def to_dict(f, zero=False):
         """Convert `f` to a dict representation with native coefficients. """
-        return dmp_to_dict(f.rep, f.lev)
+        return dmp_to_dict(f.rep, f.lev, f.dom, zero=zero)
 
-    def to_sympy_dict(f):
+    def to_sympy_dict(f, zero=False):
         """Convert `f` to a dict representation with SymPy coefficients. """
-        rep = dmp_to_dict(f.rep, f.lev)
+        rep = dmp_to_dict(f.rep, f.lev, f.dom, zero=zero)
 
         for k, v in rep.iteritems():
             rep[k] = f.dom.to_sympy(v)
@@ -770,12 +770,12 @@ class DMP(object):
     @property
     def is_linear(f):
         """Returns `True` if `f` is linear in all its variables. """
-        return all([ sum(monom) <= 1 for monom in dmp_to_dict(f.rep, f.lev).keys() ])
+        return all([ sum(monom) <= 1 for monom in dmp_to_dict(f.rep, f.lev, f.dom).keys() ])
 
     @property
     def is_quadratic(f):
         """Returns `True` if `f` is quadratic in all its variables. """
-        return all([ sum(monom) <= 2 for monom in dmp_to_dict(f.rep, f.lev).keys() ])
+        return all([ sum(monom) <= 2 for monom in dmp_to_dict(f.rep, f.lev, f.dom).keys() ])
 
     @property
     def is_monomial(f):
@@ -1354,11 +1354,11 @@ class ANP(object):
 
     def to_dict(f):
         """Convert `f` to a dict representation with native coefficients. """
-        return dmp_to_dict(f.rep, 0)
+        return dmp_to_dict(f.rep, 0, f.dom)
 
     def to_sympy_dict(f):
         """Convert `f` to a dict representation with SymPy coefficients. """
-        rep = dmp_to_dict(f.rep, 0)
+        rep = dmp_to_dict(f.rep, 0, f.dom)
 
         for k, v in rep.iteritems():
             rep[k] = f.dom.to_sympy(v)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -389,7 +389,7 @@ def preprocess_roots(poly):
     poly = poly.primitive()[1]
     poly = poly.retract()
 
-    if poly.get_domain().is_Poly:
+    if poly.get_domain().is_Poly and all(c.is_monomial for c in poly.rep.coeffs()):
         poly = poly.inject()
 
         strips = zip(*poly.monoms())

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -647,7 +647,7 @@ class Poly(Expr):
         Poly(x**2 + 1, x, domain='QQ')
 
         """
-        dom, rep = construct_domain(f.as_dict(), field=field)
+        dom, rep = construct_domain(f.as_dict(zero=True), field=field)
         return f.from_dict(rep, f.gens, domain=dom)
 
     def slice(f, x, m, n=None):
@@ -805,7 +805,7 @@ class Poly(Expr):
         """
         return len(f.as_dict())
 
-    def as_dict(f, native=False):
+    def as_dict(f, native=False, zero=False):
         """
         Switch to a ``dict`` representation.
 
@@ -819,9 +819,9 @@ class Poly(Expr):
 
         """
         if native:
-            return f.rep.to_dict()
+            return f.rep.to_dict(zero=zero)
         else:
-            return f.rep.to_sympy_dict()
+            return f.rep.to_sympy_dict(zero=zero)
 
     def as_list(f, native=False):
         """Switch to a ``list`` representation. """

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5084,7 +5084,7 @@ def groebner(F, *gens, **args):
     if domain.has_assoc_Field:
         opt.domain = domain.get_field()
     else:
-        raise DomainError("can't compute a Groebner basis over %s" % K)
+        raise DomainError("can't compute a Groebner basis over %s" % domain)
 
     for i, poly in enumerate(polys):
         poly = poly.set_domain(opt.domain).rep.to_dict()

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3064,7 +3064,7 @@ class Poly(Expr):
         False
 
         """
-        return f.length() <= 1
+        return f.rep.is_monomial
 
     @property
     def is_homogeneous(f):

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -71,6 +71,16 @@ def test_construct_domain():
     assert construct_domain([2/x, 3*y]) == \
         (dom, [dom.convert(2/x), dom.convert(3*y)])
 
+    dom = RR.frac_field(x)
+
+    assert construct_domain([2/x, 3.5]) == \
+        (dom, [dom.convert(2/x), dom.convert(3.5)])
+
+    dom = RR.frac_field(x,y)
+
+    assert construct_domain([2/x, 3.5*y]) == \
+        (dom, [dom.convert(2/x), dom.convert(3.5*y)])
+
     assert construct_domain(2) == (ZZ, ZZ(2))
     assert construct_domain(S(2)/3) == (QQ, QQ(2, 3))
 

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -337,6 +337,9 @@ def test_dup_from_to_dict():
     assert dup_to_raw_dict([]) == {}
     assert dup_to_dict([]) == {}
 
+    assert dup_to_raw_dict([], ZZ, zero=True) == {0: ZZ(0)}
+    assert dup_to_dict([], ZZ, zero=True) == {(0,): ZZ(0)}
+
     f = [3,0,0,2,0,0,0,0,8]
     g = {8: 3, 5: 2, 0: 8}
     h = {(8,): 3, (5,): 2, (0,): 8}
@@ -362,6 +365,9 @@ def test_dup_from_to_dict():
 def test_dmp_from_to_dict():
     assert dmp_from_dict({}, 1, ZZ) == [[]]
     assert dmp_to_dict([[]], 1) == {}
+
+    assert dmp_to_dict([], 0, ZZ, zero=True) == {(0,): ZZ(0)}
+    assert dmp_to_dict([[]], 1, ZZ, zero=True) == {(0,0): ZZ(0)}
 
     f = [[3],[],[],[2],[],[],[],[],[8]]
     g = {(8,0): 3, (5,0): 2, (0,0): 8}

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -357,24 +357,22 @@ def test_Domain_get_field():
     assert EX.has_assoc_Field == True
     assert ZZ.has_assoc_Field == True
     assert QQ.has_assoc_Field == True
+    assert RR.has_assoc_Field == False
     assert ALG.has_assoc_Field == True
     assert ZZ[x].has_assoc_Field == True
     assert QQ[x].has_assoc_Field == True
     assert ZZ[x,y].has_assoc_Field == True
     assert QQ[x,y].has_assoc_Field == True
 
-    assert RR.has_assoc_Field == False
-
     assert EX.get_field() == EX
     assert ZZ.get_field() == QQ
     assert QQ.get_field() == QQ
+    raises(DomainError, "RR.get_field()")
     assert ALG.get_field() == ALG
     assert ZZ[x].get_field() == ZZ.frac_field(x)
     assert QQ[x].get_field() == QQ.frac_field(x)
     assert ZZ[x,y].get_field() == ZZ.frac_field(x,y)
     assert QQ[x,y].get_field() == QQ.frac_field(x,y)
-
-    raises(DomainError, "RR.get_field()")
 
 def test_Domain_get_exact():
     assert EX.get_exact() == EX

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -142,6 +142,13 @@ def test_roots_rational():
     assert roots_rational(Poly(t*x**2-x, x)) == []
 
 def test_roots_preprocessing():
+    f = a*y*x**2 + y - b
+
+    coeff, poly = preprocess_roots(Poly(f, x))
+
+    assert coeff == 1
+    assert poly == Poly(a*y*x**2 + y - b, x)
+
     f = c**3*x**3 + c**2*x**2 + c*x + a
 
     coeff, poly = preprocess_roots(Poly(f, x))

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -8,7 +8,7 @@ from sympy.polys import Poly, cyclotomic_poly
 
 from sympy.polys.polyroots import (root_factors, roots_linear,
     roots_quadratic, roots_cubic, roots_quartic, roots_cyclotomic,
-    roots_binomial, roots_rational, roots)
+    roots_binomial, roots_rational, preprocess_roots, roots)
 
 from sympy.utilities import all
 
@@ -140,6 +140,53 @@ def test_roots_rational():
     assert roots_rational(Poly(2*x**2-x, x)) == [S.Zero]
 
     assert roots_rational(Poly(t*x**2-x, x)) == []
+
+def test_roots_preprocessing():
+    f = c**3*x**3 + c**2*x**2 + c*x + a
+
+    coeff, poly = preprocess_roots(Poly(f, x))
+
+    assert coeff == 1/c
+    assert poly == Poly(x**3 + x**2 + x + a, x)
+
+    f = c**3*x**3 + c**2*x**2 + a
+
+    coeff, poly = preprocess_roots(Poly(f, x))
+
+    assert coeff == 1/c
+    assert poly == Poly(x**3 + x**2 + a, x)
+
+    f = c**3*x**3 + c*x + a
+
+    coeff, poly = preprocess_roots(Poly(f, x))
+
+    assert coeff == 1/c
+    assert poly == Poly(x**3 + x + a, x)
+
+    f = c**3*x**3 + a
+
+    coeff, poly = preprocess_roots(Poly(f, x))
+
+    assert coeff == 1/c
+    assert poly == Poly(x**3 + a, x)
+
+    E, F, J, L = symbols("E,F,J,L")
+
+    f = -21601054687500000000*E**8*J**8/L**16 + \
+         508232812500000000*F*x*E**7*J**7/L**14 - \
+         4269543750000000*E**6*F**2*J**6*x**2/L**12 + \
+         16194716250000*E**5*F**3*J**5*x**3/L**10 - \
+         27633173750*E**4*F**4*J**4*x**4/L**8 + \
+         14840215*E**3*F**5*J**3*x**5/L**6 + \
+         54794*E**2*F**6*J**2*x**6/(5*L**4) - \
+         1153*E*J*F**7*x**7/(80*L**2) + \
+         633*F**8*x**8/160000
+
+    coeff, poly = preprocess_roots(Poly(f, x))
+
+    assert coeff == 20*E*J/(F*L**2)
+    assert poly == 633*x**8 - 115300*x**7 + 4383520*x**6 + 296804300*x**5 - 27633173750*x**4 + \
+        809735812500*x**3 - 10673859375000*x**2 + 63529101562500*x - 135006591796875
 
 def test_roots():
     assert roots(1, x) == {}

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2307,6 +2307,8 @@ def test_groebner():
         [-2*x**2 + x**3, -x**2/2 + y**2, -2*y + x*y]
 
     assert groebner([1], x) == [1]
+
+    raises(DomainError, "groebner([x**2 + 2.0*y], x, y)")
     raises(ComputationFailed, "groebner([1])")
 
 def test_poly():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1639,8 +1639,10 @@ def test_primitive():
     raises(ComputationFailed, "primitive(4)")
 
     f = Poly(2*x, modulus=3)
+    g = Poly(2.0*x, domain=RR)
 
     assert f.primitive() == (1, f)
+    assert g.primitive() == (1.0, g)
 
 def test_compose():
     f = x**12+20*x**10+150*x**8+500*x**6+625*x**4-2*x**3-10*x+9

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -691,6 +691,8 @@ def test_Poly_retract():
     assert f.retract() == Poly(x**2 + 1, x, domain='ZZ')
     assert f.retract(field=True) == Poly(x**2 + 1, x, domain='QQ')
 
+    assert Poly(0, x, y).retract() == Poly(0, x, y)
+
 def test_Poly_slice():
     f = Poly(x**3 + 2*x**2 + 3*x + 4)
 

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -1,10 +1,7 @@
 """Tests for the implementation of RootOf class and related tools. """
 
 from sympy.polys.polytools import Poly
-
-from sympy.polys.rootoftools import (
-    RootOf, RootSum, _rootof_preprocess,
-)
+from sympy.polys.rootoftools import RootOf, RootSum
 
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -153,53 +150,6 @@ def test_RootOf_evalf():
 
     assert re.epsilon_eq( Real("0.60670583138111481707"))
     assert im.epsilon_eq(-Real("1.45061224918844152650"))
-
-def test_RootOf_preprocessing():
-    f = c**3*x**3 + c**2*x**2 + c*x + a
-
-    coeff, poly = _rootof_preprocess(Poly(f, x))
-
-    assert coeff == 1/c
-    assert poly == Poly(x**3 + x**2 + x + a, x)
-
-    f = c**3*x**3 + c**2*x**2 + a
-
-    coeff, poly = _rootof_preprocess(Poly(f, x))
-
-    assert coeff == 1/c
-    assert poly == Poly(x**3 + x**2 + a, x)
-
-    f = c**3*x**3 + c*x + a
-
-    coeff, poly = _rootof_preprocess(Poly(f, x))
-
-    assert coeff == 1/c
-    assert poly == Poly(x**3 + x + a, x)
-
-    f = c**3*x**3 + a
-
-    coeff, poly = _rootof_preprocess(Poly(f, x))
-
-    assert coeff == 1/c
-    assert poly == Poly(x**3 + a, x)
-
-    E, F, J, L = symbols("E,F,J,L")
-
-    f = -21601054687500000000*E**8*J**8/L**16 + \
-         508232812500000000*F*x*E**7*J**7/L**14 - \
-         4269543750000000*E**6*F**2*J**6*x**2/L**12 + \
-         16194716250000*E**5*F**3*J**5*x**3/L**10 - \
-         27633173750*E**4*F**4*J**4*x**4/L**8 + \
-         14840215*E**3*F**5*J**3*x**5/L**6 + \
-         54794*E**2*F**6*J**2*x**6/(5*L**4) - \
-         1153*E*J*F**7*x**7/(80*L**2) + \
-         633*F**8*x**8/160000
-
-    coeff, poly = _rootof_preprocess(Poly(f, x))
-
-    assert coeff == 20*E*J/(F*L**2)
-    assert poly == 633*x**8 - 115300*x**7 + 4383520*x**6 + 296804300*x**5 - 27633173750*x**4 + \
-        809735812500*x**3 - 10673859375000*x**2 + 63529101562500*x - 135006591796875
 
 def test_RootSum___new__():
     f = x**3 + x + 3

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -309,7 +309,7 @@ def test_issue626():
     f = Function("f")
     F = x**2 + f(x)**2 - 4*x - 1
     e = F.diff(x)
-    assert solve(e, f(x).diff(x)) == [-((x - 2)/f(x))]
+    assert solve(e, f(x).diff(x)) in [[(2 - x)/f(x)], [-((x - 2)/f(x))]]
 
 def test_solve_linear():
     x, y = symbols('x y')


### PR DESCRIPTION
This allows to find roots of the following polynomial (fixes issue #1868):

<pre>
    In [1]: var('J,L,E,F')
    Out[1]: (J, L, E, F)
    
    In [2]: f = -21601054687500000000*E**8*J**8/L**16 + \
       ...:     508232812500000000*F*x*E**7*J**7/L**14 - \
       ...:     4269543750000000*E**6*F**2*J**6*x**2/L**12 + \
       ...:     16194716250000*E**5*F**3*J**5*x**3/L**10 - \
       ...:     27633173750*E**4*F**4*J**4*x**4/L**8 + \
       ...:     14840215*E**3*F**5*J**3*x**5/L**6 + \
       ...:     54794*E**2*F**6*J**2*x**6/(5*L**4) - \
       ...:     1153*E*J*F**7*x**7/(80*L**2) + \
       ...:     633*F**8*x**8/160000
    
    In [3]: roots(f.evalf(), x)
    Out[3]:
    ⎧97.1168816800648⋅E⋅J     791.549343830097⋅E⋅J     1273.16678129348⋅E⋅J
    ⎪────────────────────: 1, ────────────────────: 1, ────────────────────: 1,
    ⎨           2                        2                        2
    ⎪        F⋅L                      F⋅L                      F⋅L
    ⎩
    
     503.441004174773⋅E⋅J     186.946430171876⋅E⋅J     1850.10650616851⋅E⋅J
     ────────────────────: 1, ────────────────────: 1, ────────────────────: 1,
                2                        2                        2
             F⋅L                      F⋅L                      F⋅L
    
     245.526792947065⋅E⋅J     -1304.88375606366⋅E⋅J   ⎫
     ────────────────────: 1, ─────────────────────: 1⎪
                2                         2           ⎬
             F⋅L                       F⋅L            ⎪
                                                      ⎭
</pre>
