### PR TITLE
Integration3 backport

### DIFF
--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -94,6 +94,9 @@ class Domain(object):
                 if type(a) is long:
                     return K1(a)
 
+                if K1.is_Numerical and getattr(a, 'is_ground', False):
+                    return K1.convert(a.LC())
+
                 a = sympify(a)
 
                 if isinstance(a, Basic):

--- a/sympy/polys/domains/sympyintegerring.py
+++ b/sympy/polys/domains/sympyintegerring.py
@@ -16,6 +16,26 @@ class SymPyIntegerRing(IntegerRing):
     def __init__(self):
         """Allow instantiation of this domain. """
 
+    def of_type(self, a):
+        """
+        Check if `a` is of type `dtype` (`sympy`).
+
+        **Example**
+
+        >>> from sympy import S, Integer, Rational
+        >>> from sympy.polys.domains import ZZ_sympy
+
+        >>> ZZ_sympy().of_type(S.One)
+        True
+        >>> ZZ_sympy().of_type(Integer(3))
+        True
+        >>> ZZ_sympy().of_type(Rational(3, 2))
+        False
+
+        """
+        return type(a) in [type(self.one), type(self.zero),
+            type(self.dtype(-1)), type(self.dtype(2))]
+
     def to_sympy(self, a):
         """Convert `a` to a SymPy object. """
         return a

--- a/sympy/polys/domains/sympyrationalfield.py
+++ b/sympy/polys/domains/sympyrationalfield.py
@@ -6,6 +6,11 @@ from sympy.polys.domains.groundtypes import SymPyRationalType
 
 from sympy.polys.polyerrors import CoercionFailed
 
+from sympy import (
+    Integer as sympy_int,
+    Rational as sympy_rat,
+)
+
 class SymPyRationalField(RationalField):
     """Rational field based on SymPy Rational class. """
 
@@ -16,6 +21,24 @@ class SymPyRationalField(RationalField):
 
     def __init__(self):
         pass
+
+    def of_type(self, a):
+        """
+        Check if ``a`` is of type ``Rational``.
+
+        Example
+        =======
+
+        >>> from sympy import Rational, Real
+        >>> from sympy.polys.domains import QQ_sympy
+        >>> QQ_sympy().of_type(Rational(3, 2))
+        True
+        >>> QQ_sympy().of_type(2)
+        False
+        """
+        return type(a) in [type(self.one), type(self.zero), type(sympy_rat(-1)),
+                           type(sympy_rat(2)), type(sympy_rat(1, 2)),
+                           type(sympy_rat(3, 2))]
 
     def to_sympy(self, a):
         """Convert `a` to a SymPy object. """

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1793,7 +1793,7 @@ def dmp_primitive(f, u, K):
     else:
         return cont, [ dmp_exquo(c, cont, v, K) for c in f ]
 
-def dup_cancel(f, g, K, multout=True):
+def dup_cancel(f, g, K, include=True):
     """
     Cancel common factors in a rational function ``f/g``.
 
@@ -1809,9 +1809,9 @@ def dup_cancel(f, g, K, multout=True):
     ([2, 2], [1, -1])
 
     """
-    return dmp_cancel(f, g, 0, K, multout=multout)
+    return dmp_cancel(f, g, 0, K, include=include)
 
-def dmp_cancel(f, g, u, K, multout=True):
+def dmp_cancel(f, g, u, K, include=True):
     """
     Cancel common factors in a rational function ``f/g``.
 
@@ -1828,7 +1828,7 @@ def dmp_cancel(f, g, u, K, multout=True):
 
     """
     if dmp_zero_p(f, u) or dmp_zero_p(g, u):
-        if multout:
+        if include:
             return f, g
         else:
             return K.one, K.one, f, g
@@ -1861,7 +1861,7 @@ def dmp_cancel(f, g, u, K, multout=True):
     elif q_neg:
         cp, q = -cp, dmp_neg(q, u, K)
 
-    if not multout:
+    if not include:
         return cp, cq, p, q
 
     p = dmp_mul_ground(p, cp, u, K)

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -611,18 +611,18 @@ class DMP(object):
         lev, dom, per, F, G = f.unify(g)
         return per(dmp_lcm(F, G, lev, dom))
 
-    def cancel(f, g, multout=True):
+    def cancel(f, g, include=True):
         """Cancel common factors in a rational function ``f/g``. """
         lev, dom, per, F, G = f.unify(g)
 
-        if multout:
-                    F, G = dmp_cancel(F, G, lev, dom, multout=True)
+        if include:
+                    F, G = dmp_cancel(F, G, lev, dom, include=True)
         else:
-            cF, cG, F, G = dmp_cancel(F, G, lev, dom, multout=False)
+            cF, cG, F, G = dmp_cancel(F, G, lev, dom, include=False)
 
         F, G = per(F), per(G)
 
-        if multout:
+        if include:
             return F, G
         else:
             return cF, cG, F, G

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -50,7 +50,7 @@ from sympy.polys.densebasic import (
     dup_deflate, dmp_deflate,
     dmp_inject, dmp_eject,
     dup_terms_gcd, dmp_terms_gcd,
-    dmp_list_terms,
+    dmp_list_terms, dmp_exclude,
     dmp_slice_in)
 
 from sympy.polys.densearith import (
@@ -335,6 +335,24 @@ class DMP(object):
         """Eject selected generators into the ground domain. """
         F = dmp_eject(f.rep, f.lev, dom, front=front)
         return f.__class__(F, dom, f.lev - len(dom.gens))
+
+    def exclude(f):
+        r"""
+        Remove useless generators from ``f``.
+
+        Returns the removed generators and the new excluded ``f``.
+
+        **Example**
+
+        >>> from sympy.polys.polyclasses import DMP
+        >>> from sympy.polys.domains import ZZ
+
+        >>> DMP([[[ZZ(1)]], [[ZZ(1)], [ZZ(2)]]], ZZ).exclude()
+        ([2], DMP([[1], [1, 2]], ZZ))
+
+        """
+        J, F, u = dmp_exclude(f.rep, f.lev, f.dom)
+        return J, f.__class__(F, f.dom, u)
 
     def terms_gcd(f):
         """Remove GCD of terms from the polynomial `f`. """

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -51,7 +51,7 @@ from sympy.polys.densebasic import (
     dmp_inject, dmp_eject,
     dup_terms_gcd, dmp_terms_gcd,
     dmp_list_terms, dmp_exclude,
-    dmp_slice_in)
+    dmp_slice_in, dmp_permute)
 
 from sympy.polys.densearith import (
     dup_add_term, dmp_add_term,
@@ -353,6 +353,24 @@ class DMP(object):
         """
         J, F, u = dmp_exclude(f.rep, f.lev, f.dom)
         return J, f.__class__(F, f.dom, u)
+
+    def permute(f, P):
+        r"""
+        Returns a polynomial in ``K[x_{P(1)}, ..., x_{P(n)}]``.
+
+        **Example**
+
+        >>> from sympy.polys.polyclasses import DMP
+        >>> from sympy.polys.domains import ZZ
+
+        >>> DMP([[[ZZ(2)], [ZZ(1), ZZ(0)]], [[]]], ZZ).permute([1, 0, 2])
+        DMP([[[2], []], [[1, 0], []]], ZZ)
+
+        >>> DMP([[[ZZ(2)], [ZZ(1), ZZ(0)]], [[]]], ZZ).permute([1, 2, 0])
+        DMP([[[1], []], [[2, 0], []]], ZZ)
+
+        """
+        return f.per(dmp_permute(f.rep, P, f.lev, f.dom))
 
     def terms_gcd(f):
         """Remove GCD of terms from the polynomial `f`. """
@@ -879,7 +897,7 @@ class DMP(object):
         return not dmp_zero_p(f.rep, f.lev)
 
 def init_normal_DMF(num, den, lev, dom):
-    return DFP(dmp_normal(num, lev, dom),
+    return DMF(dmp_normal(num, lev, dom),
                dmp_normal(den, lev, dom), dom, lev)
 
 class DMF(object):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2517,19 +2517,23 @@ class Poly(Expr):
 
         **Examples**
 
-        >>> from sympy import Poly
+        >>> from sympy import Poly, expand
         >>> from sympy.abc import x
 
-        >>> f = 2*x**5 + 16*x**4 + 50*x**3 + 76*x**2 + 56*x + 16
+        >>> f = expand(2*(x + 1)**3*x**4)
+        >>> f
+        2*x**7 + 6*x**6 + 6*x**5 + 2*x**4
 
         >>> Poly(f).sqf_list_include()
-        [(Poly(2*x + 2, x, domain='ZZ'), 2),
-         (Poly(x + 2, x, domain='ZZ'), 3)]
+        [(Poly(2, x, domain='ZZ'), 1),
+         (Poly(x + 1, x, domain='ZZ'), 3),
+         (Poly(x, x, domain='ZZ'), 4)]
 
         >>> Poly(f).sqf_list_include(all=True)
         [(Poly(2, x, domain='ZZ'), 1),
-         (Poly(x + 1, x, domain='ZZ'), 2),
-         (Poly(x + 2, x, domain='ZZ'), 3)]
+         (Poly(1, x, domain='ZZ'), 2),
+         (Poly(x + 1, x, domain='ZZ'), 3),
+         (Poly(x, x, domain='ZZ'), 4)]
 
         """
         if hasattr(f.rep, 'sqf_list_include'):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2862,7 +2862,7 @@ class Poly(Expr):
 
         return r.replace(t, x)
 
-    def cancel(f, g):
+    def cancel(f, g, include=False):
         """
         Cancel common factors in a rational function ``f/g``.
 
@@ -2874,21 +2874,29 @@ class Poly(Expr):
         >>> Poly(2*x**2 - 2, x).cancel(Poly(x**2 - 2*x + 1, x))
         (1, Poly(2*x + 2, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'))
 
+        >>> Poly(2*x**2 - 2, x).cancel(Poly(x**2 - 2*x + 1, x), include=True)
+        (Poly(2*x + 2, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'))
+
         """
         dom, per, F, G = f._unify(g)
 
         if hasattr(F, 'cancel'):
-            cp, cq, p, q = F.cancel(G, multout=False)
+            result = F.cancel(G, include=include)
         else: # pragma: no cover
             raise OperationNotSupported(f, 'cancel')
 
-        if dom.has_assoc_Ring:
-            dom = dom.get_ring()
+        if not include:
+            if dom.has_assoc_Ring:
+                dom = dom.get_ring()
 
-        cp = dom.to_sympy(cp)
-        cq = dom.to_sympy(cq)
+            cp, cq, p, q = result
 
-        return cp/cq, per(p), per(q)
+            cp = dom.to_sympy(cp)
+            cq = dom.to_sympy(cq)
+
+            return cp/cq, per(p), per(q)
+        else:
+            return tuple(map(per, result))
 
     @property
     def is_zero(f):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -428,6 +428,28 @@ class Poly(Expr):
 
         return f.as_expr().subs(old, new)
 
+    def exclude(f):
+        """
+        Remove unnecessary generators from ``f``.
+
+        **Example**
+
+        >>> from sympy import Poly
+        >>> from sympy.abc import a, b, c, d, x
+
+        >>> Poly(a + x, a, b, c, d, x).exclude()
+        Poly(a + x, a, x, domain='ZZ')
+
+        """
+        J, new = f.rep.exclude()
+        gens = []
+
+        for j in range(len(f.gens)):
+            if j not in J:
+                gens.append(f.gens[j])
+
+        return f.per(new, gens=gens)
+
     def replace(f, x, y=None):
         """
         Replace ``x`` with ``y`` in generators list.

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -332,7 +332,7 @@ def dup_sqf_list_include(f, K, all=False):
     >>> f = ZZ.map([2, 16, 50, 76, 56, 16])
 
     >>> dup_sqf_list_include(f, ZZ)
-    [([2, 2], 2), ([1, 2], 3)]
+    [([2], 1), ([1, 1], 2), ([1, 2], 3)]
 
     >>> dup_sqf_list_include(f, ZZ, all=True)
     [([2], 1), ([1, 1], 2), ([1, 2], 3)]
@@ -340,11 +340,12 @@ def dup_sqf_list_include(f, K, all=False):
     """
     coeff, factors = dup_sqf_list(f, K, all=all)
 
-    if not factors:
-        return [(dup_strip([coeff]), 1)]
-    else:
+    if factors and factors[0][1] == 1:
         g = dup_mul_ground(factors[0][0], coeff, K)
-        return [(g, factors[0][1])] + factors[1:]
+        return [(g, 1)] + factors[1:]
+    else:
+        g = dup_strip([coeff])
+        return [(g, 1)] + factors
 
 @cythonized("u,i")
 def dmp_sqf_list(f, u, K, all=False):
@@ -419,7 +420,7 @@ def dmp_sqf_list_include(f, u, K, all=False):
     >>> f = ZZ.map([[1], [2, 0], [1, 0, 0], [], [], []])
 
     >>> dmp_sqf_list_include(f, 1, ZZ)
-    [([[1], [1, 0]], 2), ([[1], []], 3)]
+    [([[1]], 1), ([[1], [1, 0]], 2), ([[1], []], 3)]
 
     >>> dmp_sqf_list_include(f, 1, ZZ, all=True)
     [([[1]], 1), ([[1], [1, 0]], 2), ([[1], []], 3)]
@@ -430,11 +431,12 @@ def dmp_sqf_list_include(f, u, K, all=False):
 
     coeff, factors = dmp_sqf_list(f, u, K, all=all)
 
-    if not factors:
-        return [(dmp_ground(coeff, u), 1)]
-    else:
+    if factors and factors[0][1] == 1:
         g = dmp_mul_ground(factors[0][0], coeff, u, K)
-        return [(g, factors[0][1])] + factors[1:]
+        return [(g, 1)] + factors[1:]
+    else:
+        g = dmp_ground(coeff, u)
+        return [(g, 1)] + factors
 
 def dup_gff_list(f, K):
     """

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -397,6 +397,13 @@ def test_Domain_convert():
 def test_PolynomialRing__init():
     raises(GeneratorsNeeded, "ZZ.poly_ring()")
 
+def test_PolynomialRing_from_FractionField():
+    x = DMF(([1, 0, 1], [1, 1]), ZZ)
+    y = DMF(([1, 0, 1], [1]), ZZ)
+
+    assert ZZ['x'].from_FractionField(x, ZZ['x']) is None
+    assert ZZ['x'].from_FractionField(y, ZZ['x']) == DMP([ZZ(1), ZZ(0), ZZ(1)], ZZ)
+
 def test_FractionField__init():
     raises(GeneratorsNeeded, "ZZ.frac_field()")
 

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -393,6 +393,7 @@ def test_Domain_get_exact():
 
 def test_Domain_convert():
     assert QQ.convert(10e-52) != QQ(0)
+    assert ZZ.convert(DMP([[ZZ(1)]], ZZ)) == ZZ(1)
 
 def test_PolynomialRing__init():
     raises(GeneratorsNeeded, "ZZ.poly_ring()")

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -1,11 +1,11 @@
 """Tests for classes defining properties of ground domains, e.g. ZZ, QQ, ZZ[x] ... """
 
-from sympy import S, sqrt, sin, oo, all, pure, Poly
+from sympy import S, sqrt, sin, oo, all, pure, Poly, Integer, Rational
 from sympy.abc import x, y, z
 
 from sympy.polys.domains import (
     ZZ, QQ, RR, PolynomialRing, FractionField, EX,
-    PythonRationalType as Q,
+    PythonRationalType as Q, ZZ_sympy, QQ_sympy
 )
 from sympy.polys.polyerrors import (
     UnificationFailed,
@@ -581,3 +581,16 @@ def test_PythonRationalType__lt_le_gt_ge__():
     assert (Q(1, 4) <= Q(1, 2)) is True
     assert (Q(1, 4) >  Q(1, 2)) is False
     assert (Q(1, 4) >= Q(1, 2)) is False
+
+def test_sympy_of_type():
+    assert ZZ_sympy().of_type(Integer(1))
+    assert ZZ_sympy().of_type(Integer(0))
+    assert ZZ_sympy().of_type(Integer(-1))
+    assert ZZ_sympy().of_type(Integer(2))
+    assert not ZZ_sympy().of_type(Rational(1, 2))
+    assert QQ_sympy().of_type(Rational(1))
+    assert QQ_sympy().of_type(Rational(-1))
+    assert QQ_sympy().of_type(Rational(0))
+    assert QQ_sympy().of_type(Rational(2))
+    assert QQ_sympy().of_type(Rational(1, 2))
+    assert QQ_sympy().of_type(Rational(3, 2))

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -601,3 +601,7 @@ def test_sympy_of_type():
     assert QQ_sympy().of_type(Rational(2))
     assert QQ_sympy().of_type(Rational(1, 2))
     assert QQ_sympy().of_type(Rational(3, 2))
+
+def test___eq__():
+    assert not QQ['x'] == ZZ['x']
+    assert not QQ.frac_field(x) == ZZ.frac_field(x)

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -593,7 +593,7 @@ def test_dup_cancel():
     q = [ZZ(1), -ZZ(1)]
 
     assert dup_cancel(f, g, ZZ) == (p, q)
-    assert dup_cancel(f, g, ZZ, multout=False) == (ZZ(1), ZZ(1), p, q)
+    assert dup_cancel(f, g, ZZ, include=False) == (ZZ(1), ZZ(1), p, q)
 
     f = [-ZZ(1),-ZZ(2)]
     g = [ ZZ(3),-ZZ(4)]
@@ -612,4 +612,4 @@ def test_dmp_cancel():
     q = [[ZZ(1)], [-ZZ(1)]]
 
     assert dmp_cancel(f, g, 1, ZZ) == (p, q)
-    assert dmp_cancel(f, g, 1, ZZ, multout=False) == (ZZ(1), ZZ(1), p, q)
+    assert dmp_cancel(f, g, 1, ZZ, include=False) == (ZZ(1), ZZ(1), p, q)

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -252,6 +252,13 @@ def test_DMP_functionality():
     raises(ValueError, "f.decompose()")
     raises(ValueError, "f.sturm()")
 
+def test_DMP_exclude():
+    f = [[[[[[[[[[[[[[[[[[[[[[[[[[1]], [[]]]]]]]]]]]]]]]]]]]]]]]]]]
+    J = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25]
+
+    assert DMP(f, ZZ).exclude() == (J, DMP([1, 0], ZZ))
+    assert DMP([[1], [1, 0]], ZZ).exclude() == ([], DMP([[1], [1, 0]], ZZ))
+
 def test_DMF__init__():
     f = DMF(([[0],[],[0,1,2],[3]], [[1,2,3]]), ZZ)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1152,6 +1152,7 @@ def test_poly_cancel():
     a = Poly(y, y, domain='ZZ(x)')
     b = Poly(1, y, domain='ZZ[x]')
     assert a.cancel(b) == (1, Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
+    assert a.cancel(b, include=True) == (Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
 
 def test_parallel_poly_from_expr():
     assert parallel_poly_from_expr([x-1, x**2-1], x)[0] == [Poly(x-1, x), Poly(x**2-1, x)]

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -859,6 +859,11 @@ def test_Poly_eject():
     raises(DomainError, "Poly(x*y, x, y, domain=ZZ[z]).eject(y)")
     raises(NotImplementedError, "Poly(x*y, x, y, z).eject(y)")
 
+def test_Poly_exclude():
+    assert Poly(x, x, y).exclude() == Poly(x, x)
+    assert Poly(x*y, x, y).exclude() == Poly(x*y, x, y)
+    assert Poly(1, x, y).exclude() == Poly(1, x, y)
+
 def test_Poly__gen_to_level():
     assert Poly(1, x, y)._gen_to_level(-2) == 0
     assert Poly(1, x, y)._gen_to_level(-1) == 1

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1148,6 +1148,11 @@ def test_Poly_eval():
 
     raises(DomainError, "Poly(x+1, domain='ZZ').eval(S(1)/2, auto=False)")
 
+def test_poly_cancel():
+    a = Poly(y, y, domain='ZZ(x)')
+    b = Poly(1, y, domain='ZZ[x]')
+    assert a.cancel(b) == (1, Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
+
 def test_parallel_poly_from_expr():
     assert parallel_poly_from_expr([x-1, x**2-1], x)[0] == [Poly(x-1, x), Poly(x**2-1, x)]
     assert parallel_poly_from_expr([Poly(x-1, x), x**2-1], x)[0] == [Poly(x-1, x), Poly(x**2-1, x)]

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1148,12 +1148,6 @@ def test_Poly_eval():
 
     raises(DomainError, "Poly(x+1, domain='ZZ').eval(S(1)/2, auto=False)")
 
-def test_poly_cancel():
-    a = Poly(y, y, domain='ZZ(x)')
-    b = Poly(1, y, domain='ZZ[x]')
-    assert a.cancel(b) == (1, Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
-    assert a.cancel(b, include=True) == (Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
-
 def test_parallel_poly_from_expr():
     assert parallel_poly_from_expr([x-1, x**2-1], x)[0] == [Poly(x-1, x), Poly(x**2-1, x)]
     assert parallel_poly_from_expr([Poly(x-1, x), x**2-1], x)[0] == [Poly(x-1, x), Poly(x**2-1, x)]
@@ -2243,6 +2237,17 @@ def test_cancel():
     g = Poly(-x**9 + x**8 + x**6 - x**5 + 2*x**2 - 3*x + 1, x)
 
     assert cancel((f, g)) == (1, -f, -g)
+
+    f = Poly(y, y, domain='ZZ(x)')
+    g = Poly(1, y, domain='ZZ[x]')
+
+    assert f.cancel(g) == (1, Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
+    assert f.cancel(g, include=True) == (Poly(y, y, domain='ZZ(x)'), Poly(1, y, domain='ZZ(x)'))
+
+    f = Poly(5*x*y + x, y, domain='ZZ(x)')
+    g = Poly(2*x**2*y, y, domain='ZZ(x)')
+
+    assert f.cancel(g, include=True) == (Poly(5*y + 1, y, domain='ZZ(x)'), Poly(2*x*y, y, domain='ZZ(x)'))
 
 def test_reduced():
     f = 2*x**4 + y**2 - x**2 + y**3

--- a/sympy/polys/tests/test_sqfreetools.py
+++ b/sympy/polys/tests/test_sqfreetools.py
@@ -17,6 +17,10 @@ from sympy.polys.densearith import (
 from sympy.polys.densetools import (
     dmp_diff)
 
+from sympy.polys.polyclasses import (
+    DMP
+)
+
 from sympy.polys.polyerrors import (
     DomainError)
 
@@ -24,6 +28,8 @@ from sympy.polys.specialpolys import (
     f_0, f_1, f_2, f_3, f_4, f_5, f_6)
 
 from sympy.polys.domains import FF, ZZ, QQ
+
+from sympy.abc import x
 
 from sympy.utilities.pytest import raises
 
@@ -98,6 +104,9 @@ def test_dup_sqf():
 
     assert dup_sqf_list(res, ZZ) == (45796, [([4,0,1], 3)])
 
+    assert dup_sqf_list_include([DMP([1, 0, 0, 0], ZZ), DMP([], ZZ), DMP([], ZZ)], ZZ[x]) == \
+        [([DMP([1, 0, 0, 0], ZZ)], 1), ([DMP([1], ZZ), DMP([], ZZ)], 2)]
+
 def test_dmp_sqf():
     assert dmp_sqf_part([[]], 1, ZZ) == [[]]
     assert dmp_sqf_p([[]], 1, ZZ) == True
@@ -144,6 +153,11 @@ def test_dmp_sqf():
         [([[-1],[-1],[-1],[-1]], 1), ([[1],[-1]], 2)]
 
     K = FF(2)
+
+    f = [[-1], [2], [-1]]
+
+    assert dmp_sqf_list_include(f, 1, ZZ) == \
+        [([[-1]], 1), ([[1], [-1]], 2)]
 
     raises(DomainError, "dmp_sqf_list([[K(1), K(0), K(1)]], 1, K)")
 


### PR DESCRIPTION
This is basically the same as https://github.com/sympy/sympy/pull/131, but first two commits were removed and other fixed or refactored (e.g. to use `dmp_ground()` instead of `for _ in ...`). The two removed commits were related to "style" rather than functionality, so it won't cause any problems with future integration3 merge.
