### PR TITLE
Made isympy verbose about wrong parameter values (#2354)

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -8,9 +8,9 @@
 
        >>> from __future__ import division
        >>> from sympy import *
-       >>> x, y, z, t = symbols("x y z t")
-       >>> k, m, n = symbols("k m n", integer=True)
-       >>> f, g, h = map(Function, 'fgh')
+       >>> x, y, z, t = symbols('x y z t')
+       >>> k, m, n = symbols('k m n', integer=True)
+       >>> f, g, h = symbols('f g h', cls=Function)
 
    So starting 'isympy' is equivalent to starting Python (or IPython)
    and executing the above commands by hand.  It is intended for easy
@@ -58,14 +58,6 @@ sympy_dir  = os.path.join(sympy_top, 'sympy')  # ../sympy/
 if os.path.isdir(sympy_dir):
     sys.path.insert(0, sympy_top)
 
-no_ipython = """\
-Couldn't locate IPython. Having IPython installed is greatly recommended.
-See http://ipython.scipy.org for more details.  If you use Debian/Ubuntu,
-just install the 'ipython' package and start isympy again.
-"""
-
-from sympy.interactive import init_session
-
 def main():
     from optparse import OptionParser
 
@@ -77,27 +69,31 @@ def main():
         dest='console',
         action='store',
         default=None,
-        help='select type of interactive session: IPython | Python')
+        choices=['ipython', 'python'],
+        help='select type of interactive session: ipython | python')
 
     parser.add_option(
         '-p', '--pretty',
         dest='pretty',
         action='store',
-        default="any",
-        help='setup pretty printing: Unicode | ASCII | any | no')
+        default=None,
+        choices=['unicode', 'ascii', 'no'],
+        help='setup pretty printing: unicode | ascii | no')
 
     parser.add_option(
         '-t', '--types',
         dest='types',
         action='store',
         default=None,
-        help='setup ground types: auto | gmpy | sympy | python')
+        choices=['gmpy', 'python', 'sympy'],
+        help='setup ground types: gmpy | python | sympy')
 
     parser.add_option(
         '-o', '--order',
         dest='order',
         action='store',
         default=None,
+        choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old'],
         help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old')
 
     parser.add_option(
@@ -123,10 +119,10 @@ def main():
 
     (options, ipy_args) = parser.parse_args()
 
-    if options.cache is False:
+    if not options.cache:
         os.environ['SYMPY_USE_CACHE'] = 'no'
 
-    if options.types is not None:
+    if options.types:
         os.environ['SYMPY_GROUND_TYPES'] = options.types
 
     if options.doctest:
@@ -136,40 +132,26 @@ def main():
     session = options.console
 
     if session is not None:
-        _session = session.lower()
-
-        if _session in ['ipython', 'python']:
-            ipython = (_session == 'ipython')
-        else:
-            raise RuntimeError('invalid session type: %s' % session)
+        ipython = session == 'ipython'
     else:
         ipython = None
 
     args = {
-        'argv'         : ipy_args,
         'pretty_print' : True,
         'use_unicode'  : None,
         'order'        : None,
+        'argv'         : ipy_args,
     }
 
-    pretty = options.pretty.lower()
-
-    if pretty != 'any':
-        if pretty == 'unicode':
-            args['use_unicode'] = True
-        else:
-            args['use_unicode'] = False
-
-            if pretty != 'ascii':
-                if pretty == 'no':
-                    args['pretty_print'] = False
-                else:
-                    raise ValueError("Unknown pretty" \
-                        " printing setup: " + options.pretty)
+    if options.pretty == 'unicode':
+        args['use_unicode'] = True
+    elif options.pretty == 'ascii':
+        args['use_unicode'] = False
+    elif options.pretty == 'no':
+        args['pretty_print'] = False
 
     if options.order is not None:
-        order = options.order.lower()
-        args['order'] = order
+        args['order'] = options.order
 
     args['quiet'] = options.quiet
 
@@ -178,4 +160,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
This fixes issue #2354, e.g.:

<pre>
$ bin/isympy -q -o grlex
IPython console for SymPy 0.6.7-git (Python 2.6.5) (ground types: gmpy)

In [1]: 
Do you really want to exit ([y]/n)? 
Exiting ...
$ bin/isympy -q -o other
Usage: isympy [options] -- [ipython options]

isympy: error: option -o: invalid choice: 'other' (choose from 'lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old')
$ 
</pre>
