### PR TITLE
Swapped meaning of quo() and exquo()

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -121,7 +121,7 @@ def ratint_ratpart(f, g, x):
     A = Poly(A_coeffs, x, domain=ZZ[C_coeffs])
     B = Poly(B_coeffs, x, domain=ZZ[C_coeffs])
 
-    H = f - A.diff()*v + A*(u.diff()*v).exquo(u) - B*u
+    H = f - A.diff()*v + A*(u.diff()*v).quo(u) - B*u
 
     result = solve(H.coeffs(), C_coeffs)
 
@@ -182,7 +182,7 @@ def ratint_logpart(f, g, x, t=None):
             _include_sign(c, h_lc_sqf)
 
             for a, j in h_lc_sqf:
-                h = h.exquo(Poly(a.gcd(q)**j, x))
+                h = h.quo(Poly(a.gcd(q)**j, x))
 
             inv, coeffs = h_lc.invert(q), [S(1)]
 
@@ -219,7 +219,7 @@ def log_to_atan(f, g):
         return 2*atan(p.as_expr())
     else:
         s, t, h = g.gcdex(-f)
-        u = (f*s+g*t).exquo(h)
+        u = (f*s+g*t).quo(h)
         A = 2*atan(u.as_expr())
 
         return A + log_to_atan(s, t)

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -313,13 +313,17 @@ def dup_quo_ground(f, c, K):
 
     **Examples**
 
-    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.domains import ZZ, QQ
     >>> from sympy.polys.densearith import dup_quo_ground
 
-    >>> f = QQ.map([1, 0, 2])
+    >>> f = ZZ.map([3, 0, 2])
+    >>> g = QQ.map([3, 0, 2])
 
-    >>> dup_quo_ground(f, QQ(2), QQ)
-    [1/2, 0/1, 1/1]
+    >>> dup_quo_ground(f, ZZ(2), ZZ)
+    [1, 0, 1]
+
+    >>> dup_quo_ground(g, QQ(2), QQ)
+    [3/2, 0/1, 1/1]
 
     """
     if not c:
@@ -327,7 +331,10 @@ def dup_quo_ground(f, c, K):
     if not f:
         return f
 
-    return [ K.quo(cf, c) for cf in f ]
+    if K.has_Field or not K.is_Exact:
+        return [ K.quo(cf, c) for cf in f ]
+    else:
+        return [ cf // c for cf in f ]
 
 @cythonized("u,v")
 def dmp_quo_ground(f, c, u, K):
@@ -336,13 +343,17 @@ def dmp_quo_ground(f, c, u, K):
 
     **Examples**
 
-    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.domains import ZZ, QQ
     >>> from sympy.polys.densearith import dmp_quo_ground
 
-    >>> f = QQ.map([[1, 0], [2], []])
+    >>> f = ZZ.map([[2, 0], [3], []])
+    >>> g = QQ.map([[2, 0], [3], []])
 
-    >>> dmp_quo_ground(f, QQ(2), 1, QQ)
-    [[1/2, 0/1], [1/1], []]
+    >>> dmp_quo_ground(f, ZZ(2), 1, ZZ)
+    [[1, 0], [1], []]
+
+    >>> dmp_quo_ground(g, QQ(2), 1, QQ)
+    [[1/1, 0/1], [3/2], []]
 
     """
     if not u:
@@ -361,14 +372,10 @@ def dup_exquo_ground(f, c, K):
     >>> from sympy.polys.domains import ZZ, QQ
     >>> from sympy.polys.densearith import dup_exquo_ground
 
-    >>> f = ZZ.map([3, 0, 2])
-    >>> g = QQ.map([3, 0, 2])
+    >>> f = QQ.map([1, 0, 2])
 
-    >>> dup_exquo_ground(f, ZZ(2), ZZ)
-    [1, 0, 1]
-
-    >>> dup_exquo_ground(g, QQ(2), QQ)
-    [3/2, 0/1, 1/1]
+    >>> dup_exquo_ground(f, QQ(2), QQ)
+    [1/2, 0/1, 1/1]
 
     """
     if not c:
@@ -376,10 +383,7 @@ def dup_exquo_ground(f, c, K):
     if not f:
         return f
 
-    if K.has_Field or not K.is_Exact:
-        return [ K.quo(cf, c) for cf in f ]
-    else:
-        return [ cf // c for cf in f ]
+    return [ K.exquo(cf, c) for cf in f ]
 
 @cythonized("u,v")
 def dmp_exquo_ground(f, c, u, K):
@@ -391,14 +395,10 @@ def dmp_exquo_ground(f, c, u, K):
     >>> from sympy.polys.domains import ZZ, QQ
     >>> from sympy.polys.densearith import dmp_exquo_ground
 
-    >>> f = ZZ.map([[2, 0], [3], []])
-    >>> g = QQ.map([[2, 0], [3], []])
+    >>> f = QQ.map([[1, 0], [2], []])
 
-    >>> dmp_exquo_ground(f, ZZ(2), 1, ZZ)
-    [[1, 0], [1], []]
-
-    >>> dmp_exquo_ground(g, QQ(2), 1, QQ)
-    [[1/1, 0/1], [3/2], []]
+    >>> dmp_exquo_ground(f, QQ(2), 1, QQ)
+    [[1/2, 0/1], [1/1], []]
 
     """
     if not u:
@@ -1121,7 +1121,7 @@ def dup_prem(f, g, K):
 
 def dup_pquo(f, g, K):
     """
-    Polynomial pseudo-quotient in ``K[x]``.
+    Polynomial exact pseudo-quotient in ``K[X]``.
 
     **Examples**
 
@@ -1138,21 +1138,14 @@ def dup_pquo(f, g, K):
     >>> g = ZZ.map([2, -4])
 
     >>> dup_pquo(f, g, ZZ)
-    Traceback (most recent call last):
-    ...
-    ExactQuotientFailed: [2, -4] does not divide [1, 0, 1]
+    [2, 4]
 
     """
-    q, r = dup_pdiv(f, g, K)
-
-    if not r:
-        return q
-    else:
-        raise ExactQuotientFailed(f, g)
+    return dup_pdiv(f, g, K)[0]
 
 def dup_pexquo(f, g, K):
     """
-    Polynomial exact pseudo-quotient in ``K[X]``.
+    Polynomial pseudo-quotient in ``K[x]``.
 
     **Examples**
 
@@ -1169,10 +1162,17 @@ def dup_pexquo(f, g, K):
     >>> g = ZZ.map([2, -4])
 
     >>> dup_pexquo(f, g, ZZ)
-    [2, 4]
+    Traceback (most recent call last):
+    ...
+    ExactQuotientFailed: [2, -4] does not divide [1, 0, 1]
 
     """
-    return dup_pdiv(f, g, K)[0]
+    q, r = dup_pdiv(f, g, K)
+
+    if not r:
+        return q
+    else:
+        raise ExactQuotientFailed(f, g)
 
 @cythonized("u,df,dg,dr,N,j")
 def dmp_pdiv(f, g, u, K):
@@ -1284,7 +1284,7 @@ def dmp_prem(f, g, u, K):
 
 def dmp_pquo(f, g, u, K):
     """
-    Polynomial pseudo-quotient in ``K[X]``.
+    Polynomial exact pseudo-quotient in ``K[X]``.
 
     **Examples**
 
@@ -1299,21 +1299,14 @@ def dmp_pquo(f, g, u, K):
     [[2], []]
 
     >>> dmp_pquo(f, h, 1, ZZ)
-    Traceback (most recent call last):
-    ...
-    ExactQuotientFailed: [[2], [2]] does not divide [[1], [1, 0], []]
+    [[2], [2, -2]]
 
     """
-    q, r = dmp_pdiv(f, g, u, K)
-
-    if dmp_zero_p(r, u):
-        return q
-    else:
-        raise ExactQuotientFailed(f, g)
+    return dmp_pdiv(f, g, u, K)[0]
 
 def dmp_pexquo(f, g, u, K):
     """
-    Polynomial exact pseudo-quotient in ``K[X]``.
+    Polynomial pseudo-quotient in ``K[X]``.
 
     **Examples**
 
@@ -1328,10 +1321,17 @@ def dmp_pexquo(f, g, u, K):
     [[2], []]
 
     >>> dmp_pexquo(f, h, 1, ZZ)
-    [[2], [2, -2]]
+    Traceback (most recent call last):
+    ...
+    ExactQuotientFailed: [[2], [2]] does not divide [[1], [1, 0], []]
 
     """
-    return dmp_pdiv(f, g, u, K)[0]
+    q, r = dmp_pdiv(f, g, u, K)
+
+    if dmp_zero_p(r, u):
+        return q
+    else:
+        raise ExactQuotientFailed(f, g)
 
 @cythonized("df,dg,dr,j")
 def dup_rr_div(f, g, K):
@@ -1596,23 +1596,47 @@ def dup_rem(f, g, K):
 
 def dup_quo(f, g, K):
     """
-    Returns polynomial quotient in ``K[x]``.
+    Returns exact polynomial quotient in ``K[x]``.
 
     **Examples**
 
-    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.domains import ZZ, QQ
     >>> from sympy.polys.densearith import dup_quo
-
-    >>> f = ZZ.map([1, 0, -1])
-    >>> g = ZZ.map([1, -1])
-
-    >>> dup_quo(f, g, ZZ)
-    [1, 1]
 
     >>> f = ZZ.map([1, 0, 1])
     >>> g = ZZ.map([2, -4])
 
     >>> dup_quo(f, g, ZZ)
+    []
+
+    >>> f = QQ.map([1, 0, 1])
+    >>> g = QQ.map([2, -4])
+
+    >>> dup_quo(f, g, QQ)
+    [1/2, 1/1]
+
+    """
+    return dup_div(f, g, K)[0]
+
+def dup_exquo(f, g, K):
+    """
+    Returns polynomial quotient in ``K[x]``.
+
+    **Examples**
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densearith import dup_exquo
+
+    >>> f = ZZ.map([1, 0, -1])
+    >>> g = ZZ.map([1, -1])
+
+    >>> dup_exquo(f, g, ZZ)
+    [1, 1]
+
+    >>> f = ZZ.map([1, 0, 1])
+    >>> g = ZZ.map([2, -4])
+
+    >>> dup_exquo(f, g, ZZ)
     Traceback (most recent call last):
     ...
     ExactQuotientFailed: [2, -4] does not divide [1, 0, 1]
@@ -1624,30 +1648,6 @@ def dup_quo(f, g, K):
         return q
     else:
         raise ExactQuotientFailed(f, g)
-
-def dup_exquo(f, g, K):
-    """
-    Returns exact polynomial quotient in ``K[x]``.
-
-    **Examples**
-
-    >>> from sympy.polys.domains import ZZ, QQ
-    >>> from sympy.polys.densearith import dup_exquo
-
-    >>> f = ZZ.map([1, 0, 1])
-    >>> g = ZZ.map([2, -4])
-
-    >>> dup_exquo(f, g, ZZ)
-    []
-
-    >>> f = QQ.map([1, 0, 1])
-    >>> g = QQ.map([2, -4])
-
-    >>> dup_exquo(f, g, QQ)
-    [1/2, 1/1]
-
-    """
-    return dup_div(f, g, K)[0]
 
 @cythonized("u")
 def dmp_div(f, g, u, K):
@@ -1705,21 +1705,46 @@ def dmp_rem(f, g, u, K):
 @cythonized("u")
 def dmp_quo(f, g, u, K):
     """
+    Returns exact polynomial quotient in ``K[X]``.
+
+    **Examples**
+
+    >>> from sympy.polys.domains import ZZ, QQ
+    >>> from sympy.polys.densearith import dmp_quo
+
+    >>> f = ZZ.map([[1], [1, 0], []])
+    >>> g = ZZ.map([[2], [2]])
+
+    >>> dmp_quo(f, g, 1, ZZ)
+    [[]]
+
+    >>> f = QQ.map([[1], [1, 0], []])
+    >>> g = QQ.map([[2], [2]])
+
+    >>> dmp_quo(f, g, 1, QQ)
+    [[1/2], [1/2, -1/2]]
+
+    """
+    return dmp_div(f, g, u, K)[0]
+
+@cythonized("u")
+def dmp_exquo(f, g, u, K):
+    """
     Returns polynomial quotient in ``K[X]``.
 
     **Examples**
 
     >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.densearith import dmp_quo
+    >>> from sympy.polys.densearith import dmp_exquo
 
     >>> f = ZZ.map([[1], [1, 0], []])
     >>> g = ZZ.map([[1], [1, 0]])
     >>> h = ZZ.map([[2], [2]])
 
-    >>> dmp_quo(f, g, 1, ZZ)
+    >>> dmp_exquo(f, g, 1, ZZ)
     [[1], []]
 
-    >>> dmp_quo(f, h, 1, ZZ)
+    >>> dmp_exquo(f, h, 1, ZZ)
     Traceback (most recent call last):
     ...
     ExactQuotientFailed: [[2], [2]] does not divide [[1], [1, 0], []]
@@ -1731,31 +1756,6 @@ def dmp_quo(f, g, u, K):
         return q
     else:
         raise ExactQuotientFailed(f, g)
-
-@cythonized("u")
-def dmp_exquo(f, g, u, K):
-    """
-    Returns exact polynomial quotient in ``K[X]``.
-
-    **Examples**
-
-    >>> from sympy.polys.domains import ZZ, QQ
-    >>> from sympy.polys.densearith import dmp_exquo
-
-    >>> f = ZZ.map([[1], [1, 0], []])
-    >>> g = ZZ.map([[2], [2]])
-
-    >>> dmp_exquo(f, g, 1, ZZ)
-    [[]]
-
-    >>> f = QQ.map([[1], [1, 0], []])
-    >>> g = QQ.map([[2], [2]])
-
-    >>> dmp_exquo(f, g, 1, QQ)
-    [[1/2], [1/2, -1/2]]
-
-    """
-    return dmp_div(f, g, u, K)[0]
 
 def dup_max_norm(f, K):
     """

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -30,7 +30,6 @@ from sympy.polys.densearith import (
     dup_div, dmp_div,
     dup_rem, dmp_rem,
     dup_quo, dmp_quo,
-    dup_exquo, dmp_exquo,
     dup_prem, dmp_prem,
     dup_expand, dmp_expand,
     dup_add_mul, dup_sub_mul,
@@ -82,7 +81,7 @@ def dup_integrate(f, m, K):
         for j in xrange(1, m):
             n *= i+j+1
 
-        g.insert(0, K.exquo(c, K(n)))
+        g.insert(0, K.quo(c, K(n)))
 
     return g
 
@@ -534,7 +533,7 @@ def dup_monic(f, K):
     if K.is_one(lc):
         return f
     else:
-        return dup_quo_ground(f, lc, K)
+        return dup_exquo_ground(f, lc, K)
 
 @cythonized("u")
 def dmp_ground_monic(f, u, K):
@@ -567,7 +566,7 @@ def dmp_ground_monic(f, u, K):
     if K.is_one(lc):
         return f
     else:
-        return dmp_quo_ground(f, lc, u, K)
+        return dmp_exquo_ground(f, lc, u, K)
 
 def dup_content(f, K):
     """
@@ -661,7 +660,7 @@ def dup_primitive(f, K):
     if K.is_one(cont):
         return cont, f
     else:
-        return cont, dup_exquo_ground(f, cont, K)
+        return cont, dup_quo_ground(f, cont, K)
 
 @cythonized("u")
 def dmp_ground_primitive(f, u, K):
@@ -693,7 +692,7 @@ def dmp_ground_primitive(f, u, K):
     if K.is_one(cont):
         return cont, f
     else:
-        return cont, dmp_exquo_ground(f, cont, u, K)
+        return cont, dmp_quo_ground(f, cont, u, K)
 
 def dup_extract(f, g, K):
     """
@@ -717,8 +716,8 @@ def dup_extract(f, g, K):
     gcd = K.gcd(fc, gc)
 
     if not K.is_one(gcd):
-        f = dup_exquo_ground(f, gcd, K)
-        g = dup_exquo_ground(g, gcd, K)
+        f = dup_quo_ground(f, gcd, K)
+        g = dup_quo_ground(g, gcd, K)
 
     return gcd, f, g
 
@@ -745,8 +744,8 @@ def dmp_ground_extract(f, g, u, K):
     gcd = K.gcd(fc, gc)
 
     if not K.is_one(gcd):
-        f = dmp_exquo_ground(f, gcd, u, K)
-        g = dmp_exquo_ground(g, gcd, u, K)
+        f = dmp_quo_ground(f, gcd, u, K)
+        g = dmp_quo_ground(g, gcd, u, K)
 
     return gcd, f, g
 
@@ -978,7 +977,7 @@ def _dup_right_decompose(f, s, K):
             fc, gc = f[n+j-i], g[s-j]
             coeff += (i - r*j)*fc*gc
 
-        g[s-i] = K.exquo(coeff, i*r*lc)
+        g[s-i] = K.quo(coeff, i*r*lc)
 
     return dup_from_raw_dict(g, K)
 

--- a/sympy/polys/domains/ring.py
+++ b/sympy/polys/domains/ring.py
@@ -14,14 +14,14 @@ class Ring(Domain):
 
     def exquo(self, a, b):
         """Exact quotient of `a` and `b`, implies `__floordiv__`.  """
-        return a // b
-
-    def quo(self, a, b):
-        """Quotient of `a` and `b`, implies `__floordiv__`. """
         if a % b:
             raise ExactQuotientFailed(a, b, self)
         else:
             return a // b
+
+    def quo(self, a, b):
+        """Quotient of `a` and `b`, implies `__floordiv__`. """
+        return a // b
 
     def rem(self, a, b):
         """Remainder of `a` and `b`, implies `__mod__`.  """

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -20,11 +20,11 @@ from sympy.polys.densearith import (
     dup_pow, dmp_pow,
     dup_div, dmp_div,
     dup_rem, dmp_rem,
-    dup_exquo, dmp_exquo,
+    dup_quo, dmp_quo,
     dup_prem, dmp_prem,
     dup_mul_ground, dmp_mul_ground,
     dup_mul_term, dmp_mul_term,
-    dup_exquo_ground, dmp_exquo_ground,
+    dup_quo_ground, dmp_quo_ground,
     dup_max_norm, dmp_max_norm)
 
 from sympy.polys.densetools import (
@@ -80,7 +80,7 @@ def dup_half_gcdex(f, g, K):
         f, g = g, r
         a, b = b, dup_sub_mul(a, q, b, K)
 
-    a = dup_exquo_ground(a, dup_LC(f, K), K)
+    a = dup_quo_ground(a, dup_LC(f, K), K)
     f = dup_monic(f, K)
 
     return a, f
@@ -121,7 +121,7 @@ def dup_gcdex(f, g, K):
     s, h = dup_half_gcdex(f, g, K)
 
     F = dup_sub_mul(h, s, f, K)
-    t = dup_exquo(F, g, K)
+    t = dup_quo(F, g, K)
 
     return s, t, h
 
@@ -344,7 +344,7 @@ def dup_inner_subresultants(f, g, K):
         else:
             q = c**(d-1)
 
-        c = K.exquo((-lc)**d, q)
+        c = K.quo((-lc)**d, q)
         b = -lc * c**(m-k)
 
         f, g, m, d = g, h, k, m-k
@@ -353,7 +353,7 @@ def dup_inner_subresultants(f, g, K):
         D.append(d)
 
         h = dup_prem(f, g, K)
-        h = dup_exquo_ground(h, b, K)
+        h = dup_quo_ground(h, b, K)
 
     return R, B, D
 
@@ -424,7 +424,7 @@ def dup_prs_resultant(f, g, K):
     i = dup_degree(R[-2])
 
     res = dup_LC(R[-1], K)**i
-    res = K.exquo(res*p, q)
+    res = K.quo(res*p, q)
 
     return res, R
 
@@ -508,7 +508,7 @@ def dmp_inner_subresultants(f, g, u, K):
         else:
             q = dmp_pow(c, d-1, v, K)
 
-        c = dmp_exquo(p, q, v, K)
+        c = dmp_quo(p, q, v, K)
         b = dmp_mul(dmp_neg(lc, v, K),
                     dmp_pow(c, m-k, v, K), v, K)
 
@@ -518,7 +518,7 @@ def dmp_inner_subresultants(f, g, u, K):
         D.append(d)
 
         h = dmp_prem(f, g, u, K)
-        h = [ dmp_exquo(ch, b, v, K) for ch in h ]
+        h = [ dmp_quo(ch, b, v, K) for ch in h ]
 
     return R, B, D
 
@@ -604,7 +604,7 @@ def dmp_prs_resultant(f, g, u, K):
     i = dmp_degree(R[-2], u)
 
     res = dmp_pow(dmp_LC(R[-1], K), i, v, K)
-    res = dmp_exquo(dmp_mul(res, p, v, K), q, v, K)
+    res = dmp_quo(dmp_mul(res, p, v, K), q, v, K)
 
     return res, R
 
@@ -778,7 +778,7 @@ def dmp_qq_collins_resultant(f, g, u, K0):
 
     c = K0.convert(cf**m * cg**n, K1)
 
-    return dmp_exquo_ground(r, c, u-1, K0)
+    return dmp_quo_ground(r, c, u-1, K0)
 
 @cythonized("u")
 def dmp_resultant(f, g, u, K):
@@ -833,7 +833,7 @@ def dup_discriminant(f, K):
 
         r = dup_resultant(f, dup_diff(f, 1, K), K)
 
-        return K.exquo(r, c*K(s))
+        return K.quo(r, c*K(s))
 
 @cythonized("u,v,d,s")
 def dmp_discriminant(f, u, K):
@@ -865,7 +865,7 @@ def dmp_discriminant(f, u, K):
         r = dmp_resultant(f, dmp_diff(f, 1, u, K), u, K)
         c = dmp_mul_ground(c, K(s), v, K)
 
-        return dmp_exquo(r, c, v, K)
+        return dmp_quo(r, c, v, K)
 
 def _dup_rr_trivial_gcd(f, g, K):
     """Handle trivial cases in GCD algorithm over a ring. """
@@ -962,8 +962,8 @@ def _dmp_simplify_gcd(f, g, u, K):
     v = u - 1
     h = dmp_gcd(F, G, v, K)
 
-    cff = [ dmp_exquo(cf, h, v, K) for cf in f ]
-    cfg = [ dmp_exquo(cg, h, v, K) for cg in g ]
+    cff = [ dmp_quo(cf, h, v, K) for cf in f ]
+    cfg = [ dmp_quo(cg, h, v, K) for cg in g ]
 
     return [h], cff, cfg
 
@@ -1004,8 +1004,8 @@ def dup_rr_prs_gcd(f, g, K):
 
     h = dup_mul_ground(h, c, K)
 
-    cff = dup_exquo(f, h, K)
-    cfg = dup_exquo(g, h, K)
+    cff = dup_quo(f, h, K)
+    cfg = dup_quo(g, h, K)
 
     return h, cff, cfg
 
@@ -1036,8 +1036,8 @@ def dup_ff_prs_gcd(f, g, K):
     h = dup_subresultants(f, g, K)[-1]
     h = dup_monic(h, K)
 
-    cff = dup_exquo(f, h, K)
-    cfg = dup_exquo(g, h, K)
+    cff = dup_quo(f, h, K)
+    cfg = dup_quo(g, h, K)
 
     return h, cff, cfg
 
@@ -1081,8 +1081,8 @@ def dmp_rr_prs_gcd(f, g, u, K):
     _, h = dmp_primitive(h, u, K)
     h = dmp_mul_term(h, c, 0, u, K)
 
-    cff = dmp_exquo(f, h, u, K)
-    cfg = dmp_exquo(g, h, u, K)
+    cff = dmp_quo(f, h, u, K)
+    cfg = dmp_quo(g, h, u, K)
 
     return h, cff, cfg
 
@@ -1124,8 +1124,8 @@ def dmp_ff_prs_gcd(f, g, u, K):
     h = dmp_mul_term(h, c, 0, u, K)
     h = dmp_ground_monic(h, u, K)
 
-    cff = dmp_exquo(f, h, u, K)
-    cfg = dmp_exquo(g, h, u, K)
+    cff = dmp_quo(f, h, u, K)
+    cfg = dmp_quo(g, h, u, K)
 
     return h, cff, cfg
 
@@ -1263,7 +1263,7 @@ def _dmp_zz_gcd_interpolate(h, x, v, K):
         f.insert(0, g)
 
         h = dmp_sub(h, g, v, K)
-        h = dmp_exquo_ground(h, x, v, K)
+        h = dmp_quo_ground(h, x, v, K)
 
     if K.is_negative(dmp_ground_LC(f, v+1, K)):
         return dmp_neg(f, v+1, K)
@@ -1617,8 +1617,8 @@ def dup_rr_lcm(f, g, K):
 
     c = K.lcm(fc, gc)
 
-    h = dup_exquo(dup_mul(f, g, K),
-                  dup_gcd(f, g, K), K)
+    h = dup_quo(dup_mul(f, g, K),
+                dup_gcd(f, g, K), K)
 
     return dup_mul_ground(h, c, K)
 
@@ -1638,8 +1638,8 @@ def dup_ff_lcm(f, g, K):
     [1/1, 7/2, 3/1, 0/1]
 
     """
-    h = dup_exquo(dup_mul(f, g, K),
-                  dup_gcd(f, g, K), K)
+    h = dup_quo(dup_mul(f, g, K),
+                dup_gcd(f, g, K), K)
 
     return dup_monic(h, K)
 
@@ -1686,8 +1686,8 @@ def dmp_rr_lcm(f, g, u, K):
 
     c = K.lcm(fc, gc)
 
-    h = dmp_exquo(dmp_mul(f, g, u, K),
-                  dmp_gcd(f, g, u, K), u, K)
+    h = dmp_quo(dmp_mul(f, g, u, K),
+                dmp_gcd(f, g, u, K), u, K)
 
     return dmp_mul_ground(h, c, u, K)
 
@@ -1708,8 +1708,8 @@ def dmp_ff_lcm(f, g, u, K):
     [[1/1], [4/1, 0/1], [4/1, 0/1, 0/1], []]
 
     """
-    h = dmp_exquo(dmp_mul(f, g, u, K),
-                  dmp_gcd(f, g, u, K), u, K)
+    h = dmp_quo(dmp_mul(f, g, u, K),
+                dmp_gcd(f, g, u, K), u, K)
 
     return dmp_ground_monic(h, u, K)
 
@@ -1791,7 +1791,7 @@ def dmp_primitive(f, u, K):
     if dmp_zero_p(f, u) or dmp_one_p(cont, v, K):
         return cont, f
     else:
-        return cont, [ dmp_exquo(c, cont, v, K) for c in f ]
+        return cont, [ dmp_quo(c, cont, v, K) for c in f ]
 
 def dup_cancel(f, g, K, include=True):
     """

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -35,7 +35,7 @@ from sympy.polys.densearith import (
     dup_pow, dmp_pow,
     dup_div, dmp_div,
     dup_rem, dmp_rem,
-    dup_exquo, dmp_exquo,
+    dup_quo, dmp_quo,
     dup_expand, dmp_expand,
     dup_add_mul, dmp_add_mul,
     dup_sub_mul, dmp_sub_mul,
@@ -43,7 +43,7 @@ from sympy.polys.densearith import (
     dup_max_norm, dmp_max_norm,
     dup_l1_norm, dmp_l1_norm,
     dup_mul_ground, dmp_mul_ground,
-    dup_exquo_ground, dmp_exquo_ground)
+    dup_quo_ground, dmp_quo_ground)
 
 from sympy.polys.densetools import (
     dup_clear_denoms, dmp_clear_denoms,
@@ -411,7 +411,7 @@ def dup_zz_cyclotomic_poly(n, K):
     h = [K.one,-K.one]
 
     for p, k in factorint(n).iteritems():
-        h = dup_exquo(dup_inflate(h, p, K), h, K)
+        h = dup_quo(dup_inflate(h, p, K), h, K)
         h = dup_inflate(h, p**(k-1), K)
 
     return h
@@ -421,7 +421,7 @@ def _dup_cyclotomic_decompose(n, K):
     H = [[K.one,-K.one]]
 
     for p, k in factorint(n).iteritems():
-        Q = [ dup_exquo(dup_inflate(h, p, K), h, K) for h in H ]
+        Q = [ dup_quo(dup_inflate(h, p, K), h, K) for h in H ]
         H.extend(Q)
 
         for i in xrange(1, k):
@@ -756,7 +756,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
         B, G = [], []
 
         for f in F:
-            B.append(dmp_exquo(e, f, u, K))
+            B.append(dmp_quo(e, f, u, K))
             G.append(dmp_eval_in(f, a, n, u, K))
 
         C = dmp_eval_in(c, a, n, u, K)
@@ -782,7 +782,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
             C = dmp_diff_eval_in(c, k+1, a, n, u, K)
 
             if not dmp_zero_p(C, v):
-                C = dmp_exquo_ground(C, K.factorial(k+1), v, K)
+                C = dmp_quo_ground(C, K.factorial(k+1), v, K)
                 T = dmp_zz_diophantine(G, C, A, d, p, v, K)
 
                 for i, t in enumerate(T):
@@ -837,7 +837,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
             C = dmp_diff_eval_in(c, k+1, a, w, w, K)
 
             if not dmp_zero_p(C, w-1):
-                C = dmp_exquo_ground(C, K.factorial(k+1), w-1, K)
+                C = dmp_quo_ground(C, K.factorial(k+1), w-1, K)
                 T = dmp_zz_diophantine(G, C, I, d, p, w-1, K)
 
                 for i, (h, t) in enumerate(zip(H, T)):

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -418,16 +418,16 @@ def gf_mul_ground(f, a, p, K):
     else:
         return [ (a*b) % p for b in f ]
 
-def gf_exquo_ground(f, a, p, K):
+def gf_quo_ground(f, a, p, K):
     """
     Compute ``f/a`` where ``f`` in ``GF(p)[x]`` and ``a`` in ``GF(p)``.
 
     **Examples**
 
     >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.galoistools import gf_exquo_ground
+    >>> from sympy.polys.galoistools import gf_quo_ground
 
-    >>> gf_exquo_ground([3, 2, 4], 2, 5, ZZ)
+    >>> gf_quo_ground([3, 2, 4], 2, 5, ZZ)
     [4, 1, 2]
 
     """
@@ -695,44 +695,19 @@ def gf_rem(f, g, p, K):
     """
     return gf_div(f, g, p, K)[1]
 
-def gf_quo(f, g, p, K):
-    """
-    Compute polynomial quotient in ``GF(p)[x]``.
-
-    **Examples**
-
-    >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.galoistools import gf_quo
-
-    >>> gf_quo([1, 0, 3, 2, 3], [2, 2, 2], 5, ZZ)
-    [3, 2, 4]
-
-    >>> gf_quo([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
-    Traceback (most recent call last):
-    ...
-    ExactQuotientFailed: [1, 1, 0] does not divide [1, 0, 1, 1]
-
-    """
-    q, r = gf_div(f, g, p, K)
-
-    if not r:
-        return q
-    else:
-        raise ExactQuotientFailed(f, g)
-
 @cythonized("df,dg,dq,dr,i,j")
-def gf_exquo(f, g, p, K):
+def gf_quo(f, g, p, K):
     """
     Compute exact quotient in ``GF(p)[x]``.
 
     **Examples**
 
     >>> from sympy.polys.domains import ZZ
-    >>> from sympy.polys.galoistools import gf_exquo
+    >>> from sympy.polys.galoistools import gf_quo
 
-    >>> gf_exquo([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
+    >>> gf_quo([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
     [1, 1]
-    >>> gf_exquo([1, 0, 3, 2, 3], [2, 2, 2], 5, ZZ)
+    >>> gf_quo([1, 0, 3, 2, 3], [2, 2, 2], 5, ZZ)
     [3, 2, 4]
 
     """
@@ -757,6 +732,31 @@ def gf_exquo(f, g, p, K):
         h[i] = (coeff * inv) % p
 
     return h[:dq+1]
+
+def gf_exquo(f, g, p, K):
+    """
+    Compute polynomial quotient in ``GF(p)[x]``.
+
+    **Examples**
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.galoistools import gf_exquo
+
+    >>> gf_exquo([1, 0, 3, 2, 3], [2, 2, 2], 5, ZZ)
+    [3, 2, 4]
+
+    >>> gf_exquo([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
+    Traceback (most recent call last):
+    ...
+    ExactQuotientFailed: [1, 1, 0] does not divide [1, 0, 1, 1]
+
+    """
+    q, r = gf_div(f, g, p, K)
+
+    if not r:
+        return q
+    else:
+        raise ExactQuotientFailed(f, g)
 
 @cythonized("n")
 def gf_lshift(f, n, K):
@@ -912,8 +912,8 @@ def gf_lcm(f, g, p, K):
     if not f or not g:
         return []
 
-    h = gf_exquo(gf_mul(f, g, p, K),
-                 gf_gcd(f, g, p, K), p, K)
+    h = gf_quo(gf_mul(f, g, p, K),
+               gf_gcd(f, g, p, K), p, K)
 
     return gf_monic(h, p, K)[1]
 
@@ -935,8 +935,8 @@ def gf_cofactors(f, g, p, K):
 
     h = gf_gcd(f, g, p, K)
 
-    return (h, gf_exquo(f, h, p, K),
-               gf_exquo(g, h, p, K))
+    return (h, gf_quo(f, h, p, K),
+               gf_quo(g, h, p, K))
 
 def gf_gcdex(f, g, p, K):
     """
@@ -1023,7 +1023,7 @@ def gf_monic(f, p, K):
         if K.is_one(lc):
             return lc, list(f)
         else:
-            return lc, gf_exquo_ground(f, lc, p, K)
+            return lc, gf_quo_ground(f, lc, p, K)
 
 @cythonized("df,n")
 def gf_diff(f, p, K):
@@ -1434,18 +1434,18 @@ def gf_sqf_list(f, p, K, all=False):
 
         if F != []:
             g = gf_gcd(f, F, p, K)
-            h = gf_exquo(f, g, p, K)
+            h = gf_quo(f, g, p, K)
 
             i = 1
 
             while h != [K.one]:
                 G = gf_gcd(g, h, p, K)
-                H = gf_exquo(h, G, p, K)
+                H = gf_quo(h, G, p, K)
 
                 if gf_degree(H) > 0:
                     factors.append((H, i*n))
 
-                g, h, i = gf_exquo(g, G, p, K), G, i+1
+                g, h, i = gf_quo(g, G, p, K), G, i+1
 
             if g == [K.one]:
                 sqf = True
@@ -1600,7 +1600,7 @@ def gf_berlekamp(f, p, K):
                 if h != [K.one] and h != f:
                     factors.remove(f)
 
-                    f = gf_exquo(f, h, p, K)
+                    f = gf_quo(f, h, p, K)
                     factors.extend([f, h])
 
                 if len(factors) == len(V):
@@ -1654,7 +1654,7 @@ def gf_ddf_zassenhaus(f, p, K):
         if h != [K.one]:
             factors.append((h, i))
 
-            f = gf_exquo(f, h, p, K)
+            f = gf_quo(f, h, p, K)
             g = gf_rem(g, f, p, K)
 
         i += 1
@@ -1713,7 +1713,7 @@ def gf_edf_zassenhaus(f, n, p, K):
 
         if g != [K.one] and g != f:
             factors = gf_edf_zassenhaus(g, n, p, K) \
-                    + gf_edf_zassenhaus(gf_exquo(f, g, p, K), n, p, K)
+                    + gf_edf_zassenhaus(gf_quo(f, g, p, K), n, p, K)
 
     return _sort_factors(factors, multiple=False)
 
@@ -1775,7 +1775,7 @@ def gf_ddf_shoup(f, p, K):
             h = gf_rem(h, f, p, K)
 
         g = gf_gcd(f, h, p, K)
-        f = gf_exquo(f, g, p, K)
+        f = gf_quo(f, g, p, K)
 
         for u in reversed(U):
             h = gf_sub(v, u, p, K)
@@ -1784,7 +1784,7 @@ def gf_ddf_shoup(f, p, K):
             if F != [K.one]:
                 factors.append((F, k*(i+1)-j))
 
-            g, j = gf_exquo(g, F, p, K), j-1
+            g, j = gf_quo(g, F, p, K), j-1
 
     if f != [K.one]:
         factors.append((f, gf_degree(f)))
@@ -1834,7 +1834,7 @@ def gf_edf_shoup(f, n, p, K):
 
     if p == 2:
         h1 = gf_gcd(f, H, p, K)
-        h2 = gf_exquo(f, h1, p, K)
+        h2 = gf_quo(f, h1, p, K)
 
         factors = gf_edf_shoup(h1, n, p, K) \
                 + gf_edf_shoup(h2, n, p, K)
@@ -1843,7 +1843,7 @@ def gf_edf_shoup(f, n, p, K):
 
         h1 = gf_gcd(f, h, p, K)
         h2 = gf_gcd(f, gf_sub_ground(h, K.one, p, K), p, K)
-        h3 = gf_exquo(f, gf_mul(h1, h2, p, K), p, K)
+        h3 = gf_quo(f, gf_mul(h1, h2, p, K), p, K)
 
         factors = gf_edf_shoup(h1, n, p, K) \
                 + gf_edf_shoup(h2, n, p, K) \

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -331,7 +331,7 @@ def sdp_primitive(f, K):
         if K.is_one(cont):
             return cont, f
         else:
-            return cont, [ (m, K.exquo(c, cont)) for m, c in f ]
+            return cont, [ (m, K.quo(c, cont)) for m, c in f ]
 
 def _term_rr_div(a, b, K):
     """Division of two terms in over a ring. """
@@ -341,7 +341,7 @@ def _term_rr_div(a, b, K):
     monom = monomial_div(a_lm, b_lm)
 
     if not (monom is None or a_lc % b_lc):
-        return monom, K.exquo(a_lc, b_lc)
+        return monom, K.quo(a_lc, b_lc)
     else:
         return None
 
@@ -353,7 +353,7 @@ def _term_ff_div(a, b, K):
     monom = monomial_div(a_lm, b_lm)
 
     if monom is not None:
-        return monom, K.exquo(a_lc, b_lc)
+        return monom, K.quo(a_lc, b_lc)
     else:
         return None
 
@@ -399,17 +399,17 @@ def sdp_rem(f, g, u, O, K):
     return sdp_div(f, g, u, O, K)[1]
 
 def sdp_quo(f, g, u, O, K):
-    """Returns polynomial quotient in `K[X]`. """
+    """Returns polynomial quotient in `K[x]`. """
+    return sdp_div(f, g, u, O, K)[0]
+
+def sdp_exquo(f, g, u, O, K):
+    """Returns exact polynomial quotient in `K[X]`. """
     q, r = sdp_div(f, g, u, O, K)
 
     if not r:
         return q
     else:
         raise ExactQuotientFailed(f, g)
-
-def sdp_exquo(f, g, u, O, K):
-    """Returns exact polynomial quotient in `K[x]`. """
-    return sdp_div(f, g, u, O, K)[0]
 
 def sdp_lcm(f, g, u, O, K):
     """

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -68,7 +68,7 @@ def apart_undetermined_coeffs(P, Q):
         n, q = f.degree(), Q
 
         for i in xrange(1, k+1):
-            coeffs, q = take(X, n), q.exquo(f)
+            coeffs, q = take(X, n), q.quo(f)
             partial.append((coeffs, q, f, i))
             symbols.extend(coeffs)
 
@@ -146,10 +146,10 @@ def apart_full_decomposition(P, Q):
             Q = Poly(Q, x)
 
             G = P.gcd(d)
-            D = d.exquo(G)
+            D = d.quo(G)
 
             B, g = Q.half_gcdex(D)
-            b = (P * B.exquo(g)).rem(D)
+            b = (P * B.quo(g)).rem(D)
 
             numer = b.as_expr()
             denom = (x-a)**(n-j)

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -848,10 +848,10 @@ class DMP(object):
 
     def __floordiv__(f, g):
         if isinstance(g, DMP):
-            return f.exquo(g)
+            return f.quo(g)
         else:
             try:
-                return f.exquo_ground(g)
+                return f.quo_ground(g)
             except TypeError:
                 return NotImplemented
 
@@ -1221,10 +1221,10 @@ class DMF(object):
 
     def __div__(f, g):
         if isinstance(g, (DMP, DMF)):
-            return f.exquo(g)
+            return f.quo(g)
 
         try:
-            return f.exquo(f.half_per(g))
+            return f.quo(f.half_per(g))
         except TypeError:
             return NotImplemented
 
@@ -1491,10 +1491,10 @@ class ANP(object):
 
     def __div__(f, g):
         if isinstance(g, ANP):
-            return f.exquo(g)
+            return f.quo(g)
         else:
             try:
-                return f.exquo(f.per(g))
+                return f.quo(f.per(g))
             except TypeError:
                 return NotImplemented
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -565,7 +565,7 @@ def roots(f, *gens, **flags):
 
         for i in [-1, 1]:
             if not f.eval(i):
-                f = f.exquo(Poly(f.gen - i, f.gen))
+                f = f.quo(Poly(f.gen - i, f.gen))
                 result.append(i)
                 break
 
@@ -699,7 +699,7 @@ def root_factors(f, *gens, **args):
 
         if N < F.degree():
             G = reduce(lambda p,q: p*q, factors)
-            factors.append(F.exquo(G))
+            factors.append(F.quo(G))
 
     if not isinstance(f, Poly):
         return [ f.as_expr() for f in factors ]

--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -13,7 +13,7 @@ from sympy.polys.densearith import (
     dup_neg, dmp_neg,
     dup_sub, dmp_sub,
     dup_mul, dmp_mul,
-    dup_exquo, dmp_exquo,
+    dup_quo, dmp_quo,
     dup_mul_ground, dmp_mul_ground)
 
 from sympy.polys.densetools import (
@@ -204,7 +204,7 @@ def dup_sqf_part(f, K):
         f = dup_neg(f, K)
 
     gcd = dup_gcd(f, dup_diff(f, 1, K), K)
-    sqf = dup_exquo(f, gcd, K)
+    sqf = dup_quo(f, gcd, K)
 
     if K.has_Field or not K.is_Exact:
         return dup_monic(sqf, K)
@@ -240,7 +240,7 @@ def dmp_sqf_part(f, u, K):
         f = dmp_neg(f, u, K)
 
     gcd = dmp_gcd(f, dmp_diff(f, 1, u, K), u, K)
-    sqf = dmp_exquo(f, gcd, u, K)
+    sqf = dmp_quo(f, gcd, u, K)
 
     if K.has_Field or not K.is_Exact:
         return dmp_ground_monic(sqf, u, K)
@@ -468,7 +468,7 @@ def dup_gff_list(f, K):
             g = dup_mul(g, dup_shift(h, -K(k), K), K)
             H[i] = (h, k + 1)
 
-        f = dup_exquo(f, g, K)
+        f = dup_quo(f, g, K)
 
         if not dup_degree(f):
             return H

--- a/sympy/polys/tests/test_densearith.py
+++ b/sympy/polys/tests/test_densearith.py
@@ -182,7 +182,6 @@ def test_dmp_mul_ground():
 
 def test_dup_quo_ground():
     raises(ZeroDivisionError, 'dup_quo_ground(dup_normal([1,2,3], ZZ), ZZ(0), ZZ)')
-    raises(ExactQuotientFailed, 'dup_quo_ground(dup_normal([1,2,3], ZZ), ZZ(3), ZZ)')
 
     f = dup_normal([], ZZ)
 
@@ -193,6 +192,8 @@ def test_dup_quo_ground():
     assert dup_quo_ground(f, ZZ(1), ZZ) == f
     assert dup_quo_ground(f, ZZ(2), ZZ) == dup_normal([3,1,4], ZZ)
 
+    assert dup_quo_ground(f, ZZ(3), ZZ) == dup_normal([2,0,2], ZZ)
+
     f = dup_normal([6,2,8], QQ)
 
     assert dup_quo_ground(f, QQ(1), QQ) == f
@@ -201,17 +202,16 @@ def test_dup_quo_ground():
 
 def test_dup_exquo_ground():
     raises(ZeroDivisionError, 'dup_exquo_ground(dup_normal([1,2,3], ZZ), ZZ(0), ZZ)')
+    raises(ExactQuotientFailed, 'dup_exquo_ground(dup_normal([1,2,3], ZZ), ZZ(3), ZZ)')
 
     f = dup_normal([], ZZ)
 
-    assert dup_quo_ground(f, ZZ(3), ZZ) == dup_normal([], ZZ)
+    assert dup_exquo_ground(f, ZZ(3), ZZ) == dup_normal([], ZZ)
 
     f = dup_normal([6,2,8], ZZ)
 
     assert dup_exquo_ground(f, ZZ(1), ZZ) == f
     assert dup_exquo_ground(f, ZZ(2), ZZ) == dup_normal([3,1,4], ZZ)
-
-    assert dup_exquo_ground(f, ZZ(3), ZZ) == dup_normal([2,0,2], ZZ)
 
     f = dup_normal([6,2,8], QQ)
 
@@ -225,13 +225,13 @@ def test_dmp_quo_ground():
     assert dmp_quo_ground(f, ZZ(1), 1, ZZ) == f
     assert dmp_quo_ground(f, ZZ(2), 1, ZZ) == dmp_normal([[3],[1],[4]], 1, ZZ)
 
+    assert dmp_normal(dmp_quo_ground(f, ZZ(3), 1, ZZ), 1, ZZ) == dmp_normal([[2],[],[2]], 1, ZZ)
+
 def test_dmp_exquo_ground():
     f = dmp_normal([[6],[2],[8]], 1, ZZ)
 
     assert dmp_exquo_ground(f, ZZ(1), 1, ZZ) == f
     assert dmp_exquo_ground(f, ZZ(2), 1, ZZ) == dmp_normal([[3],[1],[4]], 1, ZZ)
-
-    assert dmp_normal(dmp_exquo_ground(f, ZZ(3), 1, ZZ), 1, ZZ) == dmp_normal([[2],[],[2]], 1, ZZ)
 
 def test_dup_lshift():
     assert dup_lshift([], 3, ZZ) == []
@@ -524,10 +524,10 @@ def test_dup_pdiv():
     r = dup_normal([52, 111], ZZ)
 
     assert dup_pdiv(f, g, ZZ) == (q, r)
-    assert dup_pexquo(f, g, ZZ) == q
+    assert dup_pquo(f, g, ZZ) == q
     assert dup_prem(f, g, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dup_pquo(f, g, ZZ)')
+    raises(ExactQuotientFailed, 'dup_pexquo(f, g, ZZ)')
 
     f = dup_normal([3,1,1,5], QQ)
     g = dup_normal([5,-3,1], QQ)
@@ -536,10 +536,10 @@ def test_dup_pdiv():
     r = dup_normal([52, 111], QQ)
 
     assert dup_pdiv(f, g, QQ) == (q, r)
-    assert dup_pexquo(f, g, QQ) == q
+    assert dup_pquo(f, g, QQ) == q
     assert dup_prem(f, g, QQ) == r
 
-    raises(ExactQuotientFailed, 'dup_pquo(f, g, QQ)')
+    raises(ExactQuotientFailed, 'dup_pexquo(f, g, QQ)')
 
 def test_dmp_pdiv():
     f = dmp_normal([[1], [], [1,0,0]], 1, ZZ)
@@ -549,10 +549,10 @@ def test_dmp_pdiv():
     r = dmp_normal([[2, 0, 0]], 1, ZZ)
 
     assert dmp_pdiv(f, g, 1, ZZ) == (q, r)
-    assert dmp_pexquo(f, g, 1, ZZ) == q
+    assert dmp_pquo(f, g, 1, ZZ) == q
     assert dmp_prem(f, g, 1, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dmp_pquo(f, g, 1, ZZ)')
+    raises(ExactQuotientFailed, 'dmp_pexquo(f, g, 1, ZZ)')
 
     f = dmp_normal([[1], [], [1,0,0]], 1, ZZ)
     g = dmp_normal([[2], [-2,0]], 1, ZZ)
@@ -561,10 +561,10 @@ def test_dmp_pdiv():
     r = dmp_normal([[8, 0, 0]], 1, ZZ)
 
     assert dmp_pdiv(f, g, 1, ZZ) == (q, r)
-    assert dmp_pexquo(f, g, 1, ZZ) == q
+    assert dmp_pquo(f, g, 1, ZZ) == q
     assert dmp_prem(f, g, 1, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dmp_pquo(f, g, 1, ZZ)')
+    raises(ExactQuotientFailed, 'dmp_pexquo(f, g, 1, ZZ)')
 
 def test_dup_rr_div():
     raises(ZeroDivisionError, "dup_rr_div([1,2,3], [], ZZ)")
@@ -644,35 +644,35 @@ def test_dup_div():
     f, g, q, r = [5,4,3,2,1], [1,2,3], [5,-6,0], [20,1]
 
     assert dup_div(f, g, ZZ) == (q, r)
-    assert dup_exquo(f, g, ZZ) == q
+    assert dup_quo(f, g, ZZ) == q
     assert dup_rem(f, g, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dup_quo(f, g, ZZ)')
+    raises(ExactQuotientFailed, 'dup_exquo(f, g, ZZ)')
 
     f, g, q, r = [5,4,3,2,1,0], [1,2,0,0,9], [5,-6], [15,2,-44,54]
 
     assert dup_div(f, g, ZZ) == (q, r)
-    assert dup_exquo(f, g, ZZ) == q
+    assert dup_quo(f, g, ZZ) == q
     assert dup_rem(f, g, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dup_quo(f, g, ZZ)')
+    raises(ExactQuotientFailed, 'dup_exquo(f, g, ZZ)')
 
 def test_dmp_div():
     f, g, q, r = [5,4,3,2,1], [1,2,3], [5,-6,0], [20,1]
 
     assert dmp_div(f, g, 0, ZZ) == (q, r)
-    assert dmp_exquo(f, g, 0, ZZ) == q
+    assert dmp_quo(f, g, 0, ZZ) == q
     assert dmp_rem(f, g, 0, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dmp_quo(f, g, 0, ZZ)')
+    raises(ExactQuotientFailed, 'dmp_exquo(f, g, 0, ZZ)')
 
     f, g, q, r = [[[1]]], [[[2]],[1]], [[[]]], [[[1]]]
 
     assert dmp_div(f, g, 2, ZZ) == (q, r)
-    assert dmp_exquo(f, g, 2, ZZ) == q
+    assert dmp_quo(f, g, 2, ZZ) == q
     assert dmp_rem(f, g, 2, ZZ) == r
 
-    raises(ExactQuotientFailed, 'dmp_quo(f, g, 2, ZZ)')
+    raises(ExactQuotientFailed, 'dmp_exquo(f, g, 2, ZZ)')
 
 def test_dup_max_norm():
     assert dup_max_norm([], ZZ) == 0

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -4,7 +4,7 @@ from sympy.polys.galoistools import (
     gf_degree, gf_strip, gf_trunc, gf_normal,
     gf_from_dict, gf_to_dict,
     gf_from_int_poly, gf_to_int_poly,
-    gf_neg, gf_add_ground, gf_sub_ground, gf_mul_ground, gf_exquo_ground,
+    gf_neg, gf_add_ground, gf_sub_ground, gf_mul_ground, gf_quo_ground,
     gf_add, gf_sub, gf_add_mul, gf_sub_mul, gf_mul, gf_sqr,
     gf_div, gf_rem, gf_quo, gf_exquo,
     gf_lshift, gf_rshift, gf_expand,
@@ -209,27 +209,27 @@ def test_gf_division():
     raises(ZeroDivisionError, "gf_div([1,2,3], [], 11, ZZ)")
     raises(ZeroDivisionError, "gf_rem([1,2,3], [], 11, ZZ)")
     raises(ZeroDivisionError, "gf_quo([1,2,3], [], 11, ZZ)")
-    raises(ZeroDivisionError, "gf_exquo([1,2,3], [], 11, ZZ)")
+    raises(ZeroDivisionError, "gf_quo([1,2,3], [], 11, ZZ)")
 
     assert gf_div([1], [1,2,3], 7, ZZ) == ([], [1])
-    assert gf_exquo([1], [1,2,3], 7, ZZ) == []
     assert gf_rem([1], [1,2,3], 7, ZZ) == [1]
+    assert gf_quo([1], [1,2,3], 7, ZZ) == []
 
     f, g, q, r = [5,4,3,2,1,0], [1,2,3], [5,1,0,6], [3,3]
 
     assert gf_div(f, g, 7, ZZ) == (q, r)
-    assert gf_exquo(f, g, 7, ZZ) == q
     assert gf_rem(f, g, 7, ZZ) == r
+    assert gf_quo(f, g, 7, ZZ) == q
 
-    raises(ExactQuotientFailed, "gf_quo(f, g, 7, ZZ)")
+    raises(ExactQuotientFailed, "gf_exquo(f, g, 7, ZZ)")
 
     f, g, q, r = [5,4,3,2,1,0], [1,2,3,0], [5,1,0], [6,1,0]
 
     assert gf_div(f, g, 7, ZZ) == (q, r)
-    assert gf_exquo(f, g, 7, ZZ) == q
     assert gf_rem(f, g, 7, ZZ) == r
+    assert gf_quo(f, g, 7, ZZ) == q
 
-    raises(ExactQuotientFailed, "gf_quo(f, g, 7, ZZ)")
+    raises(ExactQuotientFailed, "gf_exquo(f, g, 7, ZZ)")
 
     assert gf_quo([1,2,1], [1,1], 11, ZZ) == [1,1]
 

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -81,9 +81,9 @@ def test_DMP_arithmetics():
     f = DMP([[2],[2,0]], ZZ)
 
     assert f.mul_ground(2) == DMP([[4],[4,0]], ZZ)
-    assert f.exquo_ground(2) == DMP([[1],[1,0]], ZZ)
+    assert f.quo_ground(2) == DMP([[1],[1,0]], ZZ)
 
-    raises(ExactQuotientFailed, 'f.quo_ground(3)')
+    raises(ExactQuotientFailed, 'f.exquo_ground(3)')
 
     f = DMP([[-5]], ZZ)
     g = DMP([[5]], ZZ)
@@ -133,10 +133,10 @@ def test_DMP_arithmetics():
     r = DMP([[8,0,0]], ZZ)
 
     assert f.pdiv(g) == (q, r)
-    assert f.pexquo(g) == q
+    assert f.pquo(g) == q
     assert f.prem(g) == r
 
-    raises(ExactQuotientFailed, 'f.pquo(g)')
+    raises(ExactQuotientFailed, 'f.pexquo(g)')
 
     f = DMP([[1],[],[1,0,0]], ZZ)
     g = DMP([[1],[-1,0]], ZZ)
@@ -145,14 +145,14 @@ def test_DMP_arithmetics():
     r = DMP([[2,0,0]], ZZ)
 
     assert f.div(g) == (q, r)
-    assert f.exquo(g) == q
+    assert f.quo(g) == q
     assert f.rem(g) == r
 
     assert divmod(f, g) == (q, r)
     assert f // g == q
     assert f % g == r
 
-    raises(ExactQuotientFailed, 'f.quo(g)')
+    raises(ExactQuotientFailed, 'f.exquo(g)')
 
 def test_DMP_functionality():
     f = DMP([[1],[2,0],[1,0,0]], ZZ)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -434,11 +434,11 @@ def test_Poly_mul_ground():
 
 def test_Poly_quo_ground():
     assert Poly(2*x + 4).quo_ground(2) == Poly(x + 2)
-    raises(ExactQuotientFailed, "Poly(2*x + 3).quo_ground(2)")
+    assert Poly(2*x + 3).quo_ground(2) == Poly(x + 1)
 
 def test_Poly_exquo_ground():
     assert Poly(2*x + 4).exquo_ground(2) == Poly(x + 2)
-    assert Poly(2*x + 3).exquo_ground(2) == Poly(x + 1)
+    raises(ExactQuotientFailed, "Poly(2*x + 3).exquo_ground(2)")
 
 def test_Poly_abs():
     assert Poly(-x+1, x).abs() == abs(Poly(-x+1, x)) == Poly(x+1, x)
@@ -1185,44 +1185,44 @@ def test_pdiv():
     F, G, Q, R = [ Poly(h, x, y) for h in (f, g, q, r) ]
 
     assert F.pdiv(G) == (Q, R)
-    assert F.pexquo(G) == Q
-    assert F.pquo(G) == Q
     assert F.prem(G) == R
+    assert F.pquo(G) == Q
+    assert F.pexquo(G) == Q
 
     assert pdiv(f, g) == (q, r)
-    assert pexquo(f, g) == q
-    assert pquo(f, g) == q
     assert prem(f, g) == r
+    assert pquo(f, g) == q
+    assert pexquo(f, g) == q
 
     assert pdiv(f, g, x, y) == (q, r)
-    assert pexquo(f, g, x, y) == q
-    assert pquo(f, g, x, y) == q
     assert prem(f, g, x, y) == r
+    assert pquo(f, g, x, y) == q
+    assert pexquo(f, g, x, y) == q
 
     assert pdiv(f, g, (x,y)) == (q, r)
-    assert pexquo(f, g, (x,y)) == q
-    assert pquo(f, g, (x,y)) == q
     assert prem(f, g, (x,y)) == r
+    assert pquo(f, g, (x,y)) == q
+    assert pexquo(f, g, (x,y)) == q
 
     assert pdiv(F, G) == (Q, R)
-    assert pexquo(F, G) == Q
-    assert pquo(F, G) == Q
     assert prem(F, G) == R
+    assert pquo(F, G) == Q
+    assert pexquo(F, G) == Q
 
     assert pdiv(f, g, polys=True) == (Q, R)
-    assert pexquo(f, g, polys=True) == Q
-    assert pquo(f, g, polys=True) == Q
     assert prem(f, g, polys=True) == R
+    assert pquo(f, g, polys=True) == Q
+    assert pexquo(f, g, polys=True) == Q
 
     assert pdiv(F, G, polys=False) == (q, r)
-    assert pexquo(F, G, polys=False) == q
-    assert pquo(F, G, polys=False) == q
     assert prem(F, G, polys=False) == r
+    assert pquo(F, G, polys=False) == q
+    assert pexquo(F, G, polys=False) == q
 
     raises(ComputationFailed, "pdiv(4, 2)")
-    raises(ComputationFailed, "pexquo(4, 2)")
-    raises(ComputationFailed, "pquo(4, 2)")
     raises(ComputationFailed, "prem(4, 2)")
+    raises(ComputationFailed, "pquo(4, 2)")
+    raises(ComputationFailed, "pexquo(4, 2)")
 
 def test_div():
     f, g = x**2 - y**2, x - y
@@ -1231,44 +1231,44 @@ def test_div():
     F, G, Q, R = [ Poly(h, x, y) for h in (f, g, q, r) ]
 
     assert F.div(G) == (Q, R)
-    assert F.exquo(G) == Q
-    assert F.quo(G) == Q
     assert F.rem(G) == R
+    assert F.quo(G) == Q
+    assert F.exquo(G) == Q
 
     assert div(f, g) == (q, r)
-    assert exquo(f, g) == q
-    assert quo(f, g) == q
     assert rem(f, g) == r
+    assert quo(f, g) == q
+    assert exquo(f, g) == q
 
     assert div(f, g, x, y) == (q, r)
-    assert exquo(f, g, x, y) == q
-    assert quo(f, g, x, y) == q
     assert rem(f, g, x, y) == r
+    assert quo(f, g, x, y) == q
+    assert exquo(f, g, x, y) == q
 
     assert div(f, g, (x,y)) == (q, r)
-    assert exquo(f, g, (x,y)) == q
-    assert quo(f, g, (x,y)) == q
     assert rem(f, g, (x,y)) == r
+    assert quo(f, g, (x,y)) == q
+    assert exquo(f, g, (x,y)) == q
 
     assert div(F, G) == (Q, R)
-    assert exquo(F, G) == Q
-    assert quo(F, G) == Q
     assert rem(F, G) == R
+    assert quo(F, G) == Q
+    assert exquo(F, G) == Q
 
     assert div(f, g, polys=True) == (Q, R)
-    assert exquo(f, g, polys=True) == Q
-    assert quo(f, g, polys=True) == Q
     assert rem(f, g, polys=True) == R
+    assert quo(f, g, polys=True) == Q
+    assert exquo(f, g, polys=True) == Q
 
     assert div(F, G, polys=False) == (q, r)
-    assert exquo(F, G, polys=False) == q
-    assert quo(F, G, polys=False) == q
     assert rem(F, G, polys=False) == r
+    assert quo(F, G, polys=False) == q
+    assert exquo(F, G, polys=False) == q
 
     raises(ComputationFailed, "div(4, 2)")
-    raises(ComputationFailed, "exquo(4, 2)")
-    raises(ComputationFailed, "quo(4, 2)")
     raises(ComputationFailed, "rem(4, 2)")
+    raises(ComputationFailed, "quo(4, 2)")
+    raises(ComputationFailed, "exquo(4, 2)")
 
     f, g = x**2 + 1, 2*x - 4
 
@@ -1295,27 +1295,27 @@ def test_div():
     assert rem(f, g, domain=QQ, auto=True) == rq
     assert rem(f, g, domain=QQ, auto=False) == rq
 
-    assert exquo(f, g) == qq
-    assert exquo(f, g, auto=True) == qq
-    assert exquo(f, g, auto=False) == qz
-    assert exquo(f, g, domain=ZZ) == qz
-    assert exquo(f, g, domain=QQ) == qq
-    assert exquo(f, g, domain=ZZ, auto=True) == qq
-    assert exquo(f, g, domain=ZZ, auto=False) == qz
-    assert exquo(f, g, domain=QQ, auto=True) == qq
-    assert exquo(f, g, domain=QQ, auto=False) == qq
+    assert quo(f, g) == qq
+    assert quo(f, g, auto=True) == qq
+    assert quo(f, g, auto=False) == qz
+    assert quo(f, g, domain=ZZ) == qz
+    assert quo(f, g, domain=QQ) == qq
+    assert quo(f, g, domain=ZZ, auto=True) == qq
+    assert quo(f, g, domain=ZZ, auto=False) == qz
+    assert quo(f, g, domain=QQ, auto=True) == qq
+    assert quo(f, g, domain=QQ, auto=False) == qq
 
     f, g, q = x**2, 2*x, x/2
 
-    assert quo(f, g) == q
-    assert quo(f, g, auto=True) == q
-    raises(ExactQuotientFailed, "quo(f, g, auto=False)")
-    raises(ExactQuotientFailed, "quo(f, g, domain=ZZ)")
-    assert quo(f, g, domain=QQ) == q
-    assert quo(f, g, domain=ZZ, auto=True) == q
-    raises(ExactQuotientFailed, "quo(f, g, domain=ZZ, auto=False)")
-    assert quo(f, g, domain=QQ, auto=True) == q
-    assert quo(f, g, domain=QQ, auto=False) == q
+    assert exquo(f, g) == q
+    assert exquo(f, g, auto=True) == q
+    raises(ExactQuotientFailed, "exquo(f, g, auto=False)")
+    raises(ExactQuotientFailed, "exquo(f, g, domain=ZZ)")
+    assert exquo(f, g, domain=QQ) == q
+    assert exquo(f, g, domain=ZZ, auto=True) == q
+    raises(ExactQuotientFailed, "exquo(f, g, domain=ZZ, auto=False)")
+    assert exquo(f, g, domain=QQ, auto=True) == q
+    assert exquo(f, g, domain=QQ, auto=False) == q
 
     f, g = Poly(x**2), Poly(x)
 

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -53,7 +53,7 @@ from sympy.core import sympify
 
 from sympy.simplify import simplify, hypersimp, hypersimilar
 from sympy.solvers import solve, solve_undetermined_coeffs
-from sympy.polys import Poly, exquo, gcd, lcm, roots, resultant
+from sympy.polys import Poly, quo, gcd, lcm, roots, resultant
 from sympy.functions import binomial, FallingFactorial
 from sympy.matrices import Matrix, casoratian
 from sympy.concrete import product
@@ -387,7 +387,7 @@ def rsolve_ratio(coeffs, f, n, **hints):
 
     if not res.is_polynomial(h):
         p, q = res.as_numer_denom()
-        res = exquo(p, q, h)
+        res = quo(p, q, h)
 
     nni_roots = roots(res, h, filter='Z',
         predicate=lambda r: r >= 0).keys()
@@ -400,8 +400,8 @@ def rsolve_ratio(coeffs, f, n, **hints):
         for i in xrange(int(max(nni_roots)), -1, -1):
             d = gcd(A, B.subs(n, n+i), n)
 
-            A = exquo(A, d, n)
-            B = exquo(B, d.subs(n, n-i), n)
+            A = quo(A, d, n)
+            B = quo(B, d.subs(n, n-i), n)
 
             C *= Mul(*[ d.subs(n, n-j) for j in xrange(0, i+1) ])
 
@@ -410,8 +410,8 @@ def rsolve_ratio(coeffs, f, n, **hints):
         for i in range(0, r+1):
             g = gcd(coeffs[i], denoms[i], n)
 
-            numers[i] = exquo(coeffs[i], g, n)
-            denoms[i] = exquo(denoms[i], g, n)
+            numers[i] = quo(coeffs[i], g, n)
+            denoms[i] = quo(denoms[i], g, n)
 
         for i in xrange(0, r+1):
             numers[i] *= Mul(*(denoms[:i] + denoms[i+1:]))
@@ -554,7 +554,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
             a = Mul(*[ A.subs(n, n+j) for j in xrange(0, i) ])
             b = Mul(*[ B.subs(n, n+j) for j in xrange(i, r) ])
 
-            poly = exquo(coeffs[i]*a*b, D, n)
+            poly = quo(coeffs[i]*a*b, D, n)
             polys.append(poly.as_poly(n))
 
             if not poly.is_zero:
@@ -696,9 +696,9 @@ def rsolve(f, y, init=None):
     if common is not S.One:
         for k, coeff in h_part.iteritems():
             numer, denom = coeff.as_numer_denom()
-            h_part[k] = numer*exquo(common, denom, n)
+            h_part[k] = numer*quo(common, denom, n)
 
-        i_part = i_numer*exquo(common, i_denom, n)
+        i_part = i_numer*quo(common, i_denom, n)
 
     K_min = min(h_part.keys())
 


### PR DESCRIPTION
Now `quo(f, g)` means `div(f, g)[0]` (the implementation may be more efficient and skip computation of the remainder) and `exquo(f, g)` means `quo(f, g)` and a check if the remainder is zero (otherwise `ExactQuotientFailed` is raised).

<pre>
In [1]: quo(2*x + 1, 2*x)
Out[1]: 1

In [2]: exquo(2*x + 1, 2*x)
(...)
ExactQuotientFailed: 2*x does not divide 2*x + 1
</pre>
