### PR TITLE
Fixed dmp_ff_prs_gcd() for the non-trivial content case

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1114,10 +1114,10 @@ def dmp_ff_prs_gcd(f, g, u, K):
     if result is not None:
         return result
 
-    fc, f = dmp_primitive(f, u, K)
-    gc, g = dmp_primitive(g, u, K)
+    fc, F = dmp_primitive(f, u, K)
+    gc, G = dmp_primitive(g, u, K)
 
-    h = dmp_subresultants(f, g, u, K)[-1]
+    h = dmp_subresultants(F, G, u, K)[-1]
     c, _, _ = dmp_ff_prs_gcd(fc, gc, u-1, K)
 
     _, h = dmp_primitive(h, u, K)

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -38,7 +38,7 @@ from sympy.polys.specialpolys import (
     dmp_fateman_poly_F_2,
     dmp_fateman_poly_F_3)
 
-from sympy.polys.domains import ZZ, QQ
+from sympy.polys.domains import ZZ, QQ, RR
 
 def test_dup_gcdex():
     f = dup_normal([1,-2,-6,12,15], QQ)
@@ -516,6 +516,12 @@ def test_dmp_gcd():
 
     assert dmp_qq_heu_gcd(f, g, 1, QQ) == (h, g, [[QQ(1,2)]])
     assert dmp_ff_prs_gcd(f, g, 1, QQ) == (h, g, [[QQ(1,2)]])
+
+    f = [[RR(2.1), RR(-2.2), RR(2.1)], []]
+    g = [[RR(1.0)], [], [], []]
+
+    assert dmp_ff_prs_gcd(f, g, 1, RR) == \
+        ([[RR(1.0)], []], [[RR(2.1), RR(-2.2), RR(2.1)]], [[RR(1.0)], [], []])
 
 def test_dup_lcm():
     assert dup_lcm([2], [6], ZZ) == [6]


### PR DESCRIPTION
<pre>
In [1]: f = (2.1*x*y**2 - 2.2*x*y + 2.1*x)/x**3

In [2]: f
Out[2]:
       2
2.1⋅x⋅y  - 2.2⋅x⋅y + 2.1⋅x
──────────────────────────
             3
            x

In [3]: cancel(_)
Out[3]:
    ⎛     2              ⎞
1.0⋅⎝2.1⋅y  - 2.2⋅y + 2.1⎠
──────────────────────────
             2
            x
</pre>

Previously the numerator was equal to `2.1`. Printing is a little strange, so I started an issue for this (#2422).
