### PR TITLE
core/function: fix Lambda.__hash__ method to be compatible with equality comparison.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -816,6 +816,9 @@ class Lambda(Expr):
     def __hash__(self):
         return super(Lambda, self).__hash__()
 
+    def _hashable_content(self):
+        return (self.nargs, ) + tuple(sorted(self.free_symbols))
+
     @property
     def is_identity(self):
         """Return ``True`` if this ``Lambda`` is an identity function. """

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -133,6 +133,9 @@ def test_Lambda():
     p = x, y, z, t
     assert Lambda(p, t*(x+y+z))(*p) == t * (x + y + z)
 
+    assert Lambda(x, 2*x) + Lambda(y, 2*y) == 2*Lambda(x, 2*x)
+    assert Lambda(x, 2*x) not in [ Lambda(x, x) ]
+
 def test_IdentityFunction():
     assert Lambda(x, x) is Lambda(y, y) is S.IdentityFunction
     assert Lambda(x, 2*x) is not S.IdentityFunction


### PR DESCRIPTION
This allows different instances of the same lambda to be treated as
such:

```
>>> Lambda(x, 2*x) + Lambda(y, 2*y)
2*Lambda(_x, 2*_x)
```
