### PR TITLE
mr (Miller-Rabin primality testing function) should not be in __init__.py

### DIFF
--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -4,7 +4,7 @@ Number theory module (primes, etc)
 
 from generate import nextprime, prevprime, prime, primepi, primerange,\
 randprime, Sieve, sieve, primorial, cycle_length
-from primetest import isprime, mr
+from primetest import isprime
 from factor_ import divisors, factorint, multiplicity, perfect_power,\
 pollard_pm1, pollard_rho, primefactors, totient, trailing, divisor_count
 from partitions_ import npartitions


### PR DESCRIPTION
mr (Miller-Rabin primality testing function) should not be in **init**.py

Use isprime() instead, which uses this function internally.
