### PR TITLE
update factor docstring with factorint reference

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1764,7 +1764,7 @@ class Expr(Basic, EvalfMixin):
         return combsimp(self)
 
     def factor(self, *gens, **args):
-        """See the factor function in sympy.simplify"""
+        """See the factor function in sympy.polys.polytools"""
         from sympy.polys import factor
         return factor(self, *gens, **args)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1764,7 +1764,7 @@ class Expr(Basic, EvalfMixin):
         return combsimp(self)
 
     def factor(self, *gens, **args):
-        """See the factor function in sympy.polys.polytools"""
+        """See the factor() function in sympy.polys.polytools"""
         from sympy.polys import factor
         return factor(self, *gens, **args)
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4726,7 +4726,8 @@ def factor_list(f, *gens, **args):
 
 def factor(f, *gens, **args):
     """
-    Compute the factorization of ``f`` into irreducibles.
+    Compute the factorization of ``f`` into irreducibles. (Use factorint to
+    factor an integer.)
 
     There two modes implemented: symbolic and formal. If ``f`` is not an
     instance of :class:`Poly` and generators are not specified, then the


### PR DESCRIPTION
```
also updated the factor methods reference.
```

The user who can read the docstring of factor will now see quickly that factorint should be used if they are trying to factor integers.
