### PR TITLE
Fix monomial_grevlex_key (Issue 2434)

### DIFF
--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1607,7 +1607,7 @@ def dmp_list_terms(f, u, K, order=None):
     >>> dmp_list_terms(f, 1, ZZ)
     [((1, 1), 1), ((1, 0), 1), ((0, 1), 2), ((0, 0), 3)]
     >>> dmp_list_terms(f, 1, ZZ, order='grevlex')
-    [((1, 1), 1), ((0, 1), 2), ((1, 0), 1), ((0, 0), 3)]
+    [((1, 1), 1), ((1, 0), 1), ((0, 1), 2), ((0, 0), 3)]
 
     """
     terms = _rec_list_terms(f, u, ())

--- a/sympy/polys/monomialtools.py
+++ b/sympy/polys/monomialtools.py
@@ -92,7 +92,7 @@ def monomial_grlex_key(monom):
 
 def monomial_grevlex_key(monom):
     """Key function for sorting monomials in reversed graded lexicographic order. """
-    return (sum(monom), tuple(reversed(monom)))
+    return (sum(monom), tuple(reversed([-m for m in monom])))
 
 _monomial_key = {
     'lex'     : monomial_lex_key,

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5064,7 +5064,7 @@ def groebner(F, *gens, **args):
     >>> groebner([x*y - 2*y, 2*y**2 - x**2], order='grlex')
     [y**3 - 2*y, x**2 - 2*y**2, x*y - 2*y]
     >>> groebner([x*y - 2*y, 2*y**2 - x**2], order='grevlex')
-    [x**3 - 2*x**2, -x**2 + 2*y**2, x*y - 2*y]
+    [y**3 - 2*y, x**2 - 2*y**2, x*y - 2*y]
 
     **References**
 

--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -42,7 +42,7 @@ def test_monomial_grlex_key():
     assert monomial_grlex_key((1,2,3)) == (6, (1,2,3))
 
 def test_monomial_grevlex_key():
-    assert monomial_grevlex_key((1,2,3)) == (6, (3,2,1))
+    assert monomial_grevlex_key((1,2,3)) == (6, (-3,-2,-1))
 
 def test_monomial_key():
     assert monomial_key() == monomial_lex_key

--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -99,6 +99,10 @@ def test_monomial_grevlex_cmp():
     assert monomial_grevlex_cmp((0,2,3), (1,2,2)) == -1
     assert monomial_grevlex_cmp((1,1,3), (1,2,2)) == -1
 
+    assert monomial_grevlex_cmp((0,1,1), (0,0,2)) == 1
+    assert monomial_grevlex_cmp((0,3,1), (2,2,1)) == -1
+
+
 def test_monomial_cmp():
     assert monomial_cmp('lex') == monomial_lex_cmp
     assert monomial_cmp('grlex') == monomial_grlex_cmp

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2302,9 +2302,9 @@ def test_groebner():
     F = [x*y - 2*y, 2*y**2 - x**2]
 
     assert groebner(F, order='grevlex') == \
-        [-2*x**2 + x**3, -x**2 + 2*y**2, -2*y + x*y]
+        [y**3 - 2*y, x**2 - 2*y**2, x*y - 2*y]
     assert groebner(F, order='grevlex', field=True) == \
-        [-2*x**2 + x**3, -x**2/2 + y**2, -2*y + x*y]
+        [y**3 - 2*y, x**2 - 2*y**2, x*y - 2*y]
 
     assert groebner([1], x) == [1]
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2301,8 +2301,10 @@ def test_groebner():
 
     F = [x*y - 2*y, 2*y**2 - x**2]
 
-    assert groebner(F, order='grevlex') == \
+    assert groebner(F, x, y, order='grevlex') == \
         [y**3 - 2*y, x**2 - 2*y**2, x*y - 2*y]
+    assert groebner(F, y, x, order='grevlex') == \
+        [x**3 - 2*x**2, -x**2 + 2*y**2, x*y - 2*y]
     assert groebner(F, order='grevlex', field=True) == \
         [y**3 - 2*y, x**2 - 2*y**2, x*y - 2*y]
 


### PR DESCRIPTION
[Issue 2434](http://code.google.com/p/sympy/issues/detail?id=2434)

`monomial_grevlex_key(monom)` used to return `(sum(monom), tuple(reversed(monom)))`. If I wanted to compare two monomials `m1`, `m2` an ordinary cmp would be applied to the above, i.e.

`cmp((sum(m1), tuple(reversed(m1))), (sum(m2), tuple(reversed(m2))))`, 

however for grevlex, you actually have to compute

`cmp((sum(m1), tuple(reversed(**m2**))), (sum(m2), tuple(reversed(**m1**))))`.

Here's a cheap fix: Simply change the sign of `tuple(reversed(monom))`. This works because `m1` <_lex `m2` iff `-m1` >_lex `-m2`.
