### PR TITLE
2387 again

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1066,6 +1066,8 @@ class EvalfMixin(object):
         try:
             re, im, _, _ = evalf(self, prec, {})
             if im:
+                if not re:
+                    re = fzero
                 return make_mpc((re, im))
             else:
                 return make_mpf(re)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -233,3 +233,7 @@ def test_evalf_relational():
 
 def test_issue_2387():
     assert not cos(sqrt(0.5 + I)).n().is_Function
+
+def test_issue_2387_bug():
+    from sympy import I, Expr
+    assert abs(Expr._from_mpmath(I._to_mpmath(15), 15) - I) < 1.0e-15


### PR DESCRIPTION
My last pull request concerning issue 2387 contained an error that was not caught by tests :/. This hopefully fixes it.

sympy/core/evalf.py:
  (_to_mpmath) evalf() can return None ...

sympy/core/tests/test_eval.py:
  (test_issue_2387_bug) Test this.
