### PR TITLE
Field.gcd() and Field.lcm() give non-trivial results

### DIFF
--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -583,7 +583,7 @@ def dup_content(f, K):
     >>> dup_content(f, ZZ)
     2
     >>> dup_content(g, QQ)
-    1/1
+    2/1
 
     """
     if not f:
@@ -615,7 +615,7 @@ def dmp_ground_content(f, u, K):
     >>> dmp_ground_content(f, 1, ZZ)
     2
     >>> dmp_ground_content(g, 1, QQ)
-    1/1
+    2/1
 
     """
     if not u:
@@ -649,7 +649,7 @@ def dup_primitive(f, K):
     >>> dup_primitive(f, ZZ)
     (2, [3, 4, 6])
     >>> dup_primitive(g, QQ)
-    (1/1, [6/1, 8/1, 12/1])
+    (2/1, [3/1, 4/1, 6/1])
 
     """
     if not f:
@@ -678,7 +678,7 @@ def dmp_ground_primitive(f, u, K):
     >>> dmp_ground_primitive(f, 1, ZZ)
     (2, [[1, 3], [2, 6]])
     >>> dmp_ground_primitive(g, 1, QQ)
-    (1/1, [[2/1, 6/1], [4/1, 12/1]])
+    (2/1, [[1/1, 3/1], [2/1, 6/1]])
 
     """
     if not u:

--- a/sympy/polys/domains/field.py
+++ b/sympy/polys/domains/field.py
@@ -34,11 +34,27 @@ class Field(Ring):
 
     def gcd(self, a, b):
         """Returns GCD of `a` and `b`. """
-        return self.one
+        try:
+            ring = self.get_ring()
+        except DomainError:
+            return self.one
+
+        p = ring.gcd(self.numer(a), self.numer(b))
+        q = ring.lcm(self.denom(a), self.denom(b))
+
+        return self.convert(p, ring)/q
 
     def lcm(self, a, b):
         """Returns LCM of `a` and `b`. """
-        return a*b
+        try:
+            ring = self.get_ring()
+        except DomainError:
+            return a*b
+
+        p = ring.lcm(self.numer(a), self.numer(b))
+        q = ring.gcd(self.denom(a), self.denom(b))
+
+        return self.convert(p, ring)/q
 
     def revert(self, a):
         """Returns `a**(-1)` if possible. """

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -278,7 +278,8 @@ def test_dup_content():
     assert dup_content([1,2,1], ZZ) == ZZ(1)
     assert dup_content([2,4,2], ZZ) == ZZ(2)
 
-    assert dup_content([QQ(2,3),QQ(4,5)], QQ) == QQ(1)
+    assert dup_content([QQ(2,3),QQ(4,9)], QQ) == QQ(2,9)
+    assert dup_content([QQ(2,3),QQ(4,5)], QQ) == QQ(2,15)
 
 def test_dmp_ground_content():
     assert dmp_ground_content([[]], 1, ZZ) == ZZ(0)
@@ -290,7 +291,8 @@ def test_dmp_ground_content():
     assert dmp_ground_content([[1],[2],[1]], 1, ZZ) == ZZ(1)
     assert dmp_ground_content([[2],[4],[2]], 1, ZZ) == ZZ(2)
 
-    assert dmp_ground_content([[QQ(2,3)],[QQ(4,5)]], 1, QQ) == QQ(1)
+    assert dmp_ground_content([[QQ(2,3)],[QQ(4,9)]], 1, QQ) == QQ(2,9)
+    assert dmp_ground_content([[QQ(2,3)],[QQ(4,5)]], 1, QQ) == QQ(2,15)
 
     assert dmp_ground_content(f_0, 2, ZZ) == ZZ(1)
     assert dmp_ground_content(dmp_mul_ground(f_0, ZZ(2), 2, ZZ), 2, ZZ) == ZZ(2)
@@ -324,11 +326,12 @@ def test_dup_primitive():
     assert dup_primitive([], QQ) == (QQ(0), [])
     assert dup_primitive([QQ(1)], QQ) == (QQ(1), [QQ(1)])
     assert dup_primitive([QQ(1),QQ(1)], QQ) == (QQ(1), [QQ(1),QQ(1)])
-    assert dup_primitive([QQ(2),QQ(2)], QQ) == (QQ(1), [QQ(2),QQ(2)])
+    assert dup_primitive([QQ(2),QQ(2)], QQ) == (QQ(2), [QQ(1),QQ(1)])
     assert dup_primitive([QQ(1),QQ(2),QQ(1)], QQ) == (QQ(1), [QQ(1),QQ(2),QQ(1)])
-    assert dup_primitive([QQ(2),QQ(4),QQ(2)], QQ) == (QQ(1), [QQ(2),QQ(4),QQ(2)])
+    assert dup_primitive([QQ(2),QQ(4),QQ(2)], QQ) == (QQ(2), [QQ(1),QQ(2),QQ(1)])
 
-    assert dup_primitive([QQ(2,3),QQ(4,5)], QQ) == (QQ(1), [QQ(2,3),QQ(4,5)])
+    assert dup_primitive([QQ(2,3),QQ(4,9)], QQ) == (QQ(2,9), [QQ(3),QQ(2)])
+    assert dup_primitive([QQ(2,3),QQ(4,5)], QQ) == (QQ(2,15), [QQ(5),QQ(6)])
 
 def test_dmp_ground_primitive():
     assert dmp_ground_primitive([[]], 1, ZZ) == (ZZ(0), [[]])
@@ -355,7 +358,10 @@ def test_dmp_ground_primitive():
     assert dmp_ground_primitive(dmp_mul_ground(f_6, ZZ(8), 3, ZZ), 3, ZZ) == (ZZ(8), f_6)
 
     assert dmp_ground_primitive([[ZZ(2)]], 1, ZZ) == (ZZ(2), [[ZZ(1)]])
-    assert dmp_ground_primitive([[QQ(2)]], 1, QQ) == (QQ(1), [[QQ(2)]])
+    assert dmp_ground_primitive([[QQ(2)]], 1, QQ) == (QQ(2), [[QQ(1)]])
+
+    assert dmp_ground_primitive([[QQ(2,3)], [QQ(4,9)]], 1, QQ) == (QQ(2,9), [[QQ(3)], [QQ(2)]])
+    assert dmp_ground_primitive([[QQ(2,3)], [QQ(4,5)]], 1, QQ) == (QQ(2,15), [[QQ(5)], [QQ(6)]])
 
 def test_dup_extract():
     f = dup_normal([2930944, 0, 2198208, 0, 549552, 0, 45796], ZZ)


### PR DESCRIPTION
This makes sympy.polys algebraic framework coherent with implementation
of gcd() and lcm() in the core, e.g.:

<pre>
In [1]: Rational(2, 3).gcd(Rational(4, 9))
Out[1]: 2/9

In [2]: Rational(2, 3).lcm(Rational(4, 9))
Out[2]: 4/3

In [3]: QQ.gcd(QQ(2, 3), QQ(4, 9))
Out[3]: 2/9

In [4]: QQ.lcm(QQ(2, 3), QQ(4, 9))
Out[4]: 4/3

In [5]: primitive(2*x/3 + S(4)/9)
Out[5]: (2/9, 3⋅x + 2)
</pre>

The advantage of the new implementation of gcd() and lcm() in Field
is that primitive() now returns a polynomial with denominators cleared
and content removed, no matter if the initial domain was a ring or
a field. Some domains, like RR, don't support non-trivial gcd() and
lcm() operations, so primitive() may not return any useful results
in this case.

btw. Composite domains are also supported:

<pre>
In [1]: f = x/y * z + x**3/y**2

In [2]: primitive(f, z)
Out[2]: 
⎛x    2      ⎞
⎜──, x  + y⋅z⎟
⎜ 2          ⎟
⎝y           ⎠
</pre>

See also: http://groups.google.com/group/sympy/browse_thread/thread/db0dae1fd895d94c
