### PR TITLE
Issue 1548: Fixed integration of DiracDelta(-(x-a)) and added tests.

### DIFF
--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -104,6 +104,7 @@ def deltaintegrate(f, x):
                     fh = sympy.integrals.integrate(rest_mult,x)
                     return fh
             else:
+                dg = dg.simplify(x)
                 point = solve(dg.args[0],x)[0]
                 return (rest_mult.subs(x,point)*Heaviside(dg.args[0]))
     return None

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -334,6 +334,8 @@ def test_integrate_DiracDelta():
     assert integrate(DiracDelta(x),x) == Heaviside(x)
     assert integrate(DiracDelta(x) * f(x),x) == f(0) * Heaviside(x)
     assert integrate(DiracDelta(x) * f(x),(x,-oo,oo)) == f(0)
+    assert integrate(DiracDelta(-x) * f(x),(x,-oo,oo)) == f(0)
+    assert integrate(DiracDelta(-(x-1)) * f(x),(x,-oo,oo)) == f(1)
     assert integrate(DiracDelta(x) * f(x),(x,0,oo)) == f(0)/2
     assert integrate(DiracDelta(x**2+x-2),x) - \
            (Heaviside(-1 + x)/3 + Heaviside(2 + x)/3) == 0


### PR DESCRIPTION
This fixes [Issue 1548](http://code.google.com/p/sympy/issues/detail?id=1548). The patch was sitting there since 2009, unreviewed. All tests pass for me.
