### PR TITLE
Pretty-print Lambda (issue 2401)

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -588,6 +588,20 @@ class PrettyPrinter(Printer):
 
         return pform
 
+    def _print_Lambda(self, e):
+        vars, expr = e.args
+        if self._use_unicode:
+            arrow = u' \u21a6 '
+        else:
+            arrow = ' -> '
+        if len(vars) == 1:
+            var_form = self._print(vars[0])
+        else:
+            var_form = self._print(tuple(vars))
+
+        return prettyForm(*stringPict.next(var_form, arrow, self._print(expr)), binding=8)
+
+
     def _print_gamma(self, e):
         if self._use_unicode:
             pform = self._print(e.args[0])

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1251,6 +1251,32 @@ u"""\
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+def test_Lambda():
+    expr = Lambda(x, x+1)
+    assert pretty(expr) == "x -> x + 1"
+    assert upretty(expr) == u"x ↦ x + 1"
+
+    expr = Lambda(x, x**2)**2
+    ascii_str = \
+"""\
+         2
+/      2\\ \n\
+\\x -> x / \
+"""
+    ucode_str = \
+u"""\
+        2
+⎛     2⎞ \n\
+⎝x ↦ x ⎠ \
+"""
+
+
+    # S.IdentityFunction is a special case
+    expr = Lambda(y, y)
+    assert pretty(expr) == "x -> x"
+    assert upretty(expr) == u"x ↦ x"
+
+
 
 def test_pretty_sqrt():
     expr = sqrt(2)
@@ -2054,18 +2080,20 @@ RootSum⎝x  + 11⋅x - 2⎠\
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = RootSum(x**5 + 11*x - 2, Lambda(z, z**2))
+    expr = RootSum(x**5 + 11*x - 2, Lambda(z, exp(z)))
 
     ascii_str = \
 """\
-       / 5                   /    2\\\\\n\
-RootSum\\x  + 11*x - 2, Lambda\\z, z //\
+       / 5                   z\\
+RootSum\\x  + 11*x - 2, z -> e /\
 """
     ucode_str = \
 u"""\
-       ⎛ 5              ⎛    2⎞⎞\n\
-RootSum⎝x  + 11⋅x - 2, Λ⎝z, z ⎠⎠\
+       ⎛ 5                  z⎞
+RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠\
 """
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
 
 def test_pretty_Boolean():
     expr = Not(x, evaluate=False)


### PR DESCRIPTION
TODO: rebase
Print Lambda using the `\mapsto` equivalent \u21A6: ↦. It looks rather small in a fixed-width font, but I didn't find any reasonable way of simulating it in Unicode-art.

This fixes issue 2401 and is an alternate proposal for #388.

Here's what it looks like:

```
In [1]: Lambda((x, y), x*y)+1
Out[1]: 1 + ((x, y) ↦ x⋅y)

In [2]: Lambda(x, x**2)**2
Out[2]:
        2
⎛     2⎞
⎝x ↦ x ⎠

In [3]: RootSum(x**5 + 11*x - 2, Lambda(z, exp(z)))
Out[3]:
       ⎛ 5                  z⎞
RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠
```
