### PR TITLE
refine() should rebuild expression with .func

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -23,7 +23,7 @@ def refine(expr, assumptions=True):
     if not expr.is_Atom:
         args = [refine(arg, assumptions) for arg in expr.args]
         # TODO: this will probably not work with Integral or Polynomial
-        expr = type(expr)(*args)
+        expr = expr.func(*args)
     name = expr.__class__.__name__
     handler = handlers_dict.get(name, None)
     if handler is None: return expr

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -44,3 +44,24 @@ def test_exp():
     assert refine(exp(pi*I*2*(x+Rational(1,2))), Q.integer(x)) == -1
     assert refine(exp(pi*I*2*(x+Rational(1,4))), Q.integer(x)) == I
     assert refine(exp(pi*I*2*(x+Rational(3,4))), Q.integer(x)) == -I
+
+
+def test_func_args():
+    from sympy.core import Expr
+    class MyClass(Expr):
+        # A class with nontrivial .func
+
+        def __init__(self, *args):
+            self.my_member = ""
+
+        @property
+        def func(self):
+            def my_func(*args):
+                obj = MyClass(*args)
+                obj.my_member = self.my_member
+                return obj
+            return my_func
+
+    x = MyClass()
+    x.my_member = "A very important value"
+    assert x.my_member == refine(x).my_member


### PR DESCRIPTION
The patch contains the trivial fix and a regression test.
