### PR TITLE
Fixed exponentiation of content in gcd_terms() (#2457)

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -230,11 +230,7 @@ class Term(object):
 
                 if base.is_Add:
                     cont, base = base.primitive()
-
-                    if exp > 0:
-                        coeff *= cont
-                    else:
-                        coeff /= cont
+                    coeff *= cont**exp
 
                 if exp > 0:
                     numer[base] = exp

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -68,6 +68,9 @@ def test_Term():
 
     assert a.mul(b) == Term(8, Factors({x: 4, y: 7, t: 4}), Factors({z: 1}))
 
+    assert Term((2*x + 2)**3) == Term(8, Factors({x + 1: 3}), Factors({}))
+    assert Term((2*x + 2)*(3*x + 6)**2) == Term(18, Factors({x + 1: 1, x + 2: 2}), Factors({}))
+
 def test_gcd_terms():
     f = 2*(x + 1)*(x + 4)/(5*x**2 + 5) + (2*x + 2)*(x + 5)/(x**2 + 1)/5 + (2*x + 2)*(x + 6)/(5*x**2 + 5)
 
@@ -76,6 +79,8 @@ def test_gcd_terms():
 
     assert gcd_terms(f) == (S(6)/5)*((1 + x)*(5 + x)/(1 + x**2))
     assert gcd_terms(Add.make_args(f)) == (S(6)/5)*((1 + x)*(5 + x)/(1 + x**2))
+
+    assert gcd_terms((2*x + 2)**3 + (2*x + 2)**2) == 4*(x + 1)**2*(2*x + 3)
 
     assert gcd_terms(0) == 0
     assert gcd_terms(1) == 1

--- a/sympy/polys/tests/test_rationaltools.py
+++ b/sympy/polys/tests/test_rationaltools.py
@@ -40,6 +40,7 @@ def test_together():
     assert together(1 + 1/(x + 1)**2) == (1 + (x + 1)**2)/(x + 1)**2
     assert together(1 + 1/(x*(1 + x))) == (1 + x*(1 + x))/(x*(1 + x))
     assert together(1/(x*(x + 1)) + 1/(x*(x + 2))) == (3 + 2*x)/(x*(1 + x)*(2 + x))
+    assert together(1 + 1/(2*x + 2)**2) == (4*(x + 1)**2 + 1)/(4*(x + 1)**2)
 
     assert together(sin(1/x + 1/y)) == sin(1/x + 1/y)
     assert together(sin(1/x + 1/y), deep=True) == sin((x + y)/(x*y))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -227,6 +227,7 @@ def test_tsolve():
         [Rational(-5, 3) + LambertW(log(2**(-10240*2**(Rational(1, 3))/3)))/(5*log(2))],
         [-Rational(5,3) + LambertW(-10240*2**Rational(1,3)*log(2)/3)/(5*log(2))],
         [(-25*log(2) + 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2))],
+        [-((25*log(2) - 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3)))/(15*log(2))],
         ]
     assert solve(5*x-1+3*exp(2-7*x), x) == \
         [Rational(1,5) + LambertW(-21*exp(Rational(3,5))/5)/7]


### PR DESCRIPTION
This fixes issue #2457, e.g.:

In [1]: together(1 + 1/(2_x + 2)_*2)
Out[1]:
         2
4⋅(x + 1)  + 1
──────────────
           2
  4⋅(x + 1)

There is one test failure in test_solvers.py (#229), but it also exists in master.
