### PR TITLE
gcd_terms keeps coefficient

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -377,5 +377,8 @@ def gcd_terms(terms):
     y*(x + 1)*(x + y + 1)
 
     """
+    from sympy.polys.polytools import _keep_coeff
+
     cont, numer, denom = _gcd_terms(sympify(terms))
-    return cont*(numer/denom)
+    coeff, factors = cont.as_coeff_Mul()
+    return _keep_coeff(coeff, factors*numer/denom)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -3,7 +3,7 @@
 from sympy.core.exprtools import (
     decompose_power, Factors, Term, _gcd_terms, gcd_terms)
 
-from sympy import S, Add, sin
+from sympy import S, Add, sin, Mul
 from sympy.abc import x, y, z, t
 
 def test_decompose_power():
@@ -85,3 +85,4 @@ def test_gcd_terms():
     assert gcd_terms(0) == 0
     assert gcd_terms(1) == 1
     assert gcd_terms(x) == x
+    assert gcd_terms(2 + 2*x) == Mul(2, 1 + x, evaluate=False)

--- a/sympy/polys/tests/test_rationaltools.py
+++ b/sympy/polys/tests/test_rationaltools.py
@@ -2,7 +2,7 @@
 
 from sympy.polys.rationaltools import together
 
-from sympy import S, symbols, Rational, sin, exp, Eq, Integral
+from sympy import S, symbols, Rational, sin, exp, Eq, Integral, Mul
 from sympy.abc import x, y, z
 
 A, B = symbols('A,B', commutative=False)
@@ -21,7 +21,7 @@ def test_together():
     assert together(1/x + x) == (x**2 + 1)/x
 
     assert together(1/x + Rational(1, 2)) == (x + 2)/(2*x)
-    assert together(Rational(1, 2) + x/2) == (x + 1)/2
+    assert together(Rational(1, 2) + x/2) == Mul(S.Half, x + 1, evaluate=False)
 
     assert together(1/x + 2/y) == (2*x + y)/(y*x)
     assert together(1/(1 + 1/x)) == x/(1 + x)


### PR DESCRIPTION
This allows gcd_terms(2+2_x) to return 2_(x + 1) rather than having the coefficient reabsorbed by the Add.
