### PR TITLE
2406: Tuple arguments are sympified; sympify() converts iterables to Tuples and add Basic.fromiter() method.

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -328,6 +328,22 @@ class Basic(AssumeMeths):
         # now both objects are from SymPy, so we can proceed to usual comparison
         return cmp(a.sort_key(), b.sort_key())
 
+    @classmethod
+    def fromiter(cls, args, **assumptions):
+        """
+        Create a new object from an iterable.
+
+        This is a convenience function that allows one to create objects from
+        any iterable, without having to convert to a list or tuple first.
+
+        Example:
+
+        >>> from sympy import Tuple
+        >>> Tuple.fromiter(i for i in xrange(5))
+        (0, 1, 2, 3, 4)
+
+        """
+        return cls(*tuple(args), **assumptions)
 
     @classmethod
     def class_key(cls):

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -7,6 +7,7 @@
 """
 
 from basic import Basic
+from sympify import sympify
 
 class Tuple(Basic):
     """
@@ -25,6 +26,11 @@ class Tuple(Basic):
     (d, b, c)
 
     """
+
+    def __new__(cls, *args, **assumptions):
+        args = [ sympify(arg) for arg in args ]
+        obj = Basic.__new__(cls, *args, **assumptions)
+        return obj
 
     def __getitem__(self,i):
         if isinstance(i,slice):

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -8,6 +8,7 @@ from sympy.core.sympify import sympify
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.coreerrors import NonCommutativeExpression
+from sympy.core.containers import Tuple
 
 def decompose_power(expr):
     """
@@ -324,7 +325,7 @@ class Term(object):
 
 def _gcd_terms(terms):
     """Helper function for :func:`gcd_terms`. """
-    if isinstance(terms, Basic):
+    if isinstance(terms, Basic) and not isinstance(terms, Tuple):
         terms = Add.make_args(terms)
 
     if len(terms) <= 1:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -85,6 +85,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     >>> converter[GeometryEntity] = lambda x: x
 
     """
+    from containers import Tuple
+
     try:
         cls = a.__class__
     except AttributeError:  #a is probably an old-style class object
@@ -121,8 +123,12 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     if strict:
         raise SympifyError(a)
 
+    if isinstance(a, tuple):
+        return Tuple(*[sympify(x, locals=locals, convert_xor=convert_xor,
+            rational=rational) for x in a])
     if iterable(a):
-        return type(a)([sympify(x, locals=locals, convert_xor=convert_xor, rational=rational) for x in a])
+        return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
+            rational=rational) for x in a])
 
     # At this point we were given an arbitrary expression
     # which does not inherit from Basic and doesn't implement

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -32,6 +32,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
        - standard numeric python types: int, long, float, Decimal
        - strings (like "0.09" or "2e-19")
        - booleans, including `None` (will leave them unchanged)
+       - lists, sets or tuples containing any of the above
 
     If the argument is already a type that sympy understands, it will do
     nothing but return that value. This can be used at the beginning of a
@@ -69,6 +70,19 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: True
+
+    To extend `sympify` to convert custom objects (not derived from `Basic`),
+    the static dictionary `convert` is provided. The custom converters are
+    usually added at import time, and will apply to all objects of the given
+    class or its derived classes.
+
+    For example, all geometry objects derive from `GeometryEntity` class, and
+    should not be altered by the converter, so we add the following after
+    defining that class:
+
+    >>> from sympy.core.sympify import converter
+    >>> from sympy.geometry.entity import GeometryEntity
+    >>> converter[GeometryEntity] = lambda x: x
 
     """
     try:

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -22,6 +22,10 @@ def test_Tuple():
     assert Tuple(p, 1).subs(p, 0) == Tuple(0, 1)
     assert Tuple(p, Tuple(p, 1)).subs(p, 0) == Tuple(0, Tuple(0, 1))
 
+    assert Tuple.fromiter(t2) == Tuple(*t2)
+    assert Tuple.fromiter(x for x in xrange(4)) == Tuple(0, 1, 2, 3)
+    assert st2.fromiter(st2.args) == st2
+
 def test_Tuple_contains():
     t1, t2 = Tuple(1), Tuple(2)
     assert t1 in Tuple(1, 2, 3, t1, Tuple(t2))

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -22,6 +22,7 @@ def test_Tuple():
     assert Tuple(p, 1).subs(p, 0) == Tuple(0, 1)
     assert Tuple(p, Tuple(p, 1)).subs(p, 0) == Tuple(0, Tuple(0, 1))
 
+    assert Tuple(t2) == Tuple(Tuple(*t2))
     assert Tuple.fromiter(t2) == Tuple(*t2)
     assert Tuple.fromiter(x for x in xrange(4)) == Tuple(0, 1, 2, 3)
     assert st2.fromiter(st2.args) == st2

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,4 +1,4 @@
-from sympy import Matrix, Tuple, symbols
+from sympy import Matrix, Tuple, symbols, sympify, Basic
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import all, ordered_iter, iterable
@@ -6,9 +6,9 @@ from sympy.core.compatibility import all, ordered_iter, iterable
 def test_Tuple():
     t = (1, 2, 3, 4)
     st =  Tuple(*t)
-    assert set(t) == set(st)
+    assert set(sympify(t)) == set(st)
     assert len(t) == len(st)
-    assert set(t[:2]) == set(st[:2])
+    assert set(sympify(t[:2])) == set(st[:2])
     assert isinstance(st[:], Tuple)
     assert st == Tuple(1, 2, 3, 4)
     assert st.func(*st.args) == st
@@ -17,6 +17,10 @@ def test_Tuple():
     st2 = Tuple(*t2)
     assert st2.atoms() == set(t2)
     assert st == st2.subs({p:1, q:2, r:3, s:4})
+    # issue 2406
+    assert all([ isinstance(arg, Basic) for arg in st.args ])
+    assert Tuple(p, 1).subs(p, 0) == Tuple(0, 1)
+    assert Tuple(p, Tuple(p, 1)).subs(p, 0) == Tuple(0, Tuple(0, 1))
 
 def test_Tuple_contains():
     t1, t2 = Tuple(1), Tuple(2)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,5 +1,5 @@
 from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
-    Function, I, S, sqrt, srepr, Rational
+    Function, I, S, sqrt, srepr, Rational, Tuple
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
 from sympy.core.decorators import _sympifyit
@@ -131,7 +131,8 @@ def test_sympyify_iterables():
     ans = [Rational(3, 10), Rational(1, 5)]
     assert sympify(['.3', '.2'], rational=1) == ans
     assert sympify(set(['.3', '.2']), rational=1) == set(ans)
-    assert sympify(tuple(['.3', '.2']), rational=1) == tuple(ans)
+    assert sympify(tuple(['.3', '.2']), rational=1) == Tuple(*ans)
+    assert sympify(['1', '2', ['3', '4']]) == [S(1), S(2), [S(3), S(4)]]
 
 def test_sympify4():
     class A:
@@ -337,7 +338,7 @@ def test_issue1034():
 def test_issue883():
     a = [3, 2.0]
     assert sympify(a) == [Integer(3), Float(2.0)]
-    assert sympify(tuple(a)) == (Integer(3), Float(2.0))
+    assert sympify(tuple(a)) == Tuple(Integer(3), Float(2.0))
     assert sympify(set(a)) == set([Integer(3), Float(2.0)])
 
 def test_S_sympify():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -4,6 +4,7 @@ from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
 from sympy.core.decorators import _sympifyit
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.geometry import Point, Line
 
 from sympy import mpmath
 
@@ -359,3 +360,9 @@ def test_issue1889_builtins():
 
     exp2 = sympify('C', vars)
     assert exp2 == C # Make sure it did not get mixed up with sympy.C
+
+def test_geometry():
+    p = sympify(Point(0, 1))
+    assert p == Point(0, 1) and type(p) == Point
+    L = sympify(Line(p, (1, 0)))
+    assert L == Line((0, 1), (1, 0)) and type(L) == Line

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -278,3 +278,6 @@ class GeometryEntity(tuple):
         if type(self) == type(other):
             return self == other
         raise NotImplementedError()
+
+from sympy.core.sympify import converter
+converter[GeometryEntity] = lambda x: x

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -2,7 +2,7 @@
 
 from sympy import (
     S, Expr, I, Integer, Rational, Float,
-    Symbol, Add, Mul, sympify, Q, ask, Dummy,
+    Symbol, Add, Mul, sympify, Q, ask, Dummy, Tuple
 )
 
 from sympy.polys.polytools import (
@@ -400,7 +400,7 @@ class AlgebraicNumber(Expr):
         """Construct a new algebraic number. """
         expr = sympify(expr)
 
-        if type(expr) is tuple:
+        if isinstance(expr, (tuple, Tuple)):
             minpoly, root = expr
 
             if not minpoly.is_Poly:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1,7 +1,7 @@
 """User-friendly public interface to polynomial functions. """
 
 from sympy.core import (
-    S, Basic, Expr, I, Integer, Add, Mul, Dummy,
+    S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple
 )
 
 from sympy.core.sympify import (
@@ -2904,7 +2904,8 @@ class Poly(Expr):
 
         """
         if f.is_multivariate:
-            raise MultivariatePolynomialError("can't compute numerical roots of %s" % f)
+            raise MultivariatePolynomialError("can't compute numerical roots "
+                                              "of %s" % f)
 
         if f.degree() <= 0:
             return []
@@ -5200,7 +5201,7 @@ def cancel(f, *gens, **args):
 
     f = sympify(f)
 
-    if type(f) is not tuple:
+    if not isinstance(f, (tuple, Tuple)):
         if f.is_Number:
             return f
         else:
@@ -5211,14 +5212,14 @@ def cancel(f, *gens, **args):
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
     except PolificationFailed, exc:
-        if type(f) is not tuple:
+        if not isinstance(f, (tuple, Tuple)):
             return f
         else:
             return S.One, p, q
 
     c, P, Q = F.cancel(G)
 
-    if type(f) is not tuple:
+    if not isinstance(f, (tuple, Tuple)):
         return c*(P.as_expr()/Q.as_expr())
     else:
         if not opt.polys:


### PR DESCRIPTION
This is a rebased version of [pull request 352](https://github.com/sympy/sympy/pull/352), addressing issue 2406.
