### PR TITLE
Added support for gmpy's and mpmath's types to sympify() (#2441)

### DIFF
--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2205,22 +2205,35 @@ def test_nroots():
 
     assert Poly(0.2*x + 0.1).nroots() == [-0.5]
 
-    roots = Poly(x**5 + x + 1).nroots()
-    eps = Float("10e-12")
+    roots = nroots(x**5 + x + 1, n=5)
+    eps = Float("1e-5")
 
-    assert re(roots[0]).epsilon_eq(-0.754877666246693, eps) and roots[0].is_real
-    # XXX: assert im(roots[0]).epsilon_eq(-0.000000000000000, eps) -> 'Zero' object has no attribute 'epsilon_eq'
-    assert re(roots[1]).epsilon_eq(-0.500000000000000, eps)
-    assert im(roots[1]).epsilon_eq(-0.866025403784439, eps)
-    assert re(roots[2]).epsilon_eq(-0.500000000000000, eps)
-    assert im(roots[2]).epsilon_eq(+0.866025403784439, eps)
-    assert re(roots[3]).epsilon_eq(+0.877438833123346, eps)
-    assert im(roots[3]).epsilon_eq(-0.744861766619744, eps)
-    assert re(roots[4]).epsilon_eq(+0.877438833123346, eps)
-    assert im(roots[4]).epsilon_eq(+0.744861766619744, eps)
+    assert re(roots[0]).epsilon_eq(-0.75487, eps) is True
+    assert im(roots[0]) ==  0.0
+    assert re(roots[1]) == -0.5
+    assert im(roots[1]).epsilon_eq(-0.86602, eps) is True
+    assert re(roots[2]) == -0.5
+    assert im(roots[2]).epsilon_eq(+0.86602, eps) is True
+    assert re(roots[3]).epsilon_eq(+0.87743, eps) is True
+    assert im(roots[3]).epsilon_eq(-0.74486, eps) is True
+    assert re(roots[4]).epsilon_eq(+0.87743, eps) is True
+    assert im(roots[4]).epsilon_eq(+0.74486, eps) is True
 
-    raises(DomainError, "Poly(x+y, x).nroots()")
-    raises(MultivariatePolynomialError, "Poly(x+y).nroots()")
+    eps = Float("1e-6")
+
+    assert re(roots[0]).epsilon_eq(-0.75487, eps) is False
+    assert im(roots[0]) ==  0.0
+    assert re(roots[1]) == -0.5
+    assert im(roots[1]).epsilon_eq(-0.86602, eps) is False
+    assert re(roots[2]) == -0.5
+    assert im(roots[2]).epsilon_eq(+0.86602, eps) is False
+    assert re(roots[3]).epsilon_eq(+0.87743, eps) is False
+    assert im(roots[3]).epsilon_eq(-0.74486, eps) is False
+    assert re(roots[4]).epsilon_eq(+0.87743, eps) is False
+    assert im(roots[4]).epsilon_eq(+0.74486, eps) is False
+
+    raises(DomainError, "Poly(x + y, x).nroots()")
+    raises(MultivariatePolynomialError, "Poly(x + y).nroots()")
 
     assert nroots(x**2 - 1) == [-1.0, 1.0]
 


### PR DESCRIPTION
In [1]: from gmpy import mpz, mpq

In [2]: sympify(mpz(1000001))
Out[2]: 1000001

In [3]: type(_)
Out[3]: <class 'sympy.core.numbers.Integer'>

In [4]: sympify(mpq(101, 127))
Out[4]:
101
───
127

In [5]: type(_)
Out[5]: <class 'sympy.core.numbers.Rational'>

In [6]: from sympy.mpmath import mpf, mpc

In [7]: sympify(mpf(1.1))
Out[7]: 1.10000000000000

In [8]: type(_)
Out[8]: <class 'sympy.core.numbers.Float'>

In [9]: sympify(mpc(1.1 + 2.2j))
Out[9]: 1.1 + 2.2⋅ⅈ

In [10]: type(_)
Out[10]: <class 'sympy.core.add.Add'>
