### PR TITLE
Use more robust hashing in polyclasses (DMP and friends)

### DIFF
--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -406,6 +406,48 @@ def dmp_copy(f, u):
 
     return [ dmp_copy(c, v) for c in f ]
 
+def dup_to_tuple(f):
+    """
+    Convert `f` into a tuple.
+
+    This is needed for hashing. This is similar to dup_copy().
+        **Examples**
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densebasic import dup_copy
+
+    >>> f = ZZ.map([1, 2, 3, 0])
+
+    >>> dup_copy([1, 2, 3, 0])
+    [1, 2, 3, 0]
+
+    """
+    return tuple(f)
+
+@cythonized("u,v")
+def dmp_to_tuple(f, u):
+    """
+    Convert `f` into a nested tuple of tuples.
+
+    This is needed for hashing.  This is similar to dmp_copy().
+
+    **Examples**
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.densebasic import dmp_to_tuple
+
+    >>> f = ZZ.map([[1], [1, 2]])
+
+    >>> dmp_to_tuple(f, 1)
+    ((1,), (1, 2))
+
+    """
+    if not u:
+        return tuple(f)
+    v = u - 1
+
+    return tuple(dmp_to_tuple(c, v) for c in f)
+
 def dup_normal(f, K):
     """
     Normalize univariate polynomial in the given domain.

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -51,7 +51,8 @@ from sympy.polys.densebasic import (
     dmp_inject, dmp_eject,
     dup_terms_gcd, dmp_terms_gcd,
     dmp_list_terms, dmp_exclude,
-    dmp_slice_in, dmp_permute)
+    dmp_slice_in, dmp_permute,
+    dmp_to_tuple,)
 
 from sympy.polys.densearith import (
     dup_add_term, dmp_add_term,
@@ -159,7 +160,7 @@ class DMP(object):
         return "%s(%s, %s)" % (f.__class__.__name__, f.rep, f.dom)
 
     def __hash__(f):
-        return hash((f.__class__.__name__, repr(f.rep), f.lev, f.dom))
+        return hash((f.__class__.__name__, f.to_tuple(), f.lev, f.dom))
 
     def __getstate__(self):
         return (self.rep, self.lev, self.dom)
@@ -238,6 +239,14 @@ class DMP(object):
             rep[k] = f.dom.to_sympy(v)
 
         return rep
+
+    def to_tuple(f):
+        """
+        Convert `f` to a tuple representation with native coefficients.
+
+        This is needed for hashing.
+        """
+        return dmp_to_tuple(f.rep, f.lev)
 
     @classmethod
     def from_dict(cls, rep, lev, dom):
@@ -975,7 +984,8 @@ class DMF(object):
         return "%s((%s, %s), %s)" % (f.__class__.__name__, f.num, f.den, f.dom)
 
     def __hash__(f):
-        return hash((f.__class__.__name__, repr(f.num), repr(f.den), f.lev, f.dom))
+        return hash((f.__class__.__name__, dmp_to_tuple(f.num, f.lev),
+            dmp_to_tuple(f.den, f.lev), f.lev, f.dom))
 
     def __getstate__(self):
         return (self.num, self.den, self.lev, self.dom)
@@ -1299,7 +1309,7 @@ class ANP(object):
         return "%s(%s, %s, %s)" % (f.__class__.__name__, f.rep, f.mod, f.dom)
 
     def __hash__(f):
-        return hash((f.__class__.__name__, repr(f.rep), f.mod, f.dom))
+        return hash((f.__class__.__name__, f.to_tuple(), dmp_to_tuple(f.mod, 0), f.dom))
 
     def __getstate__(self):
         return (self.rep, self.mod, self.dom)
@@ -1372,6 +1382,14 @@ class ANP(object):
     def to_sympy_list(f):
         """Convert `f` to a list representation with SymPy coefficients. """
         return [ f.dom.to_sympy(c) for c in f.rep ]
+
+    def to_tuple(f):
+        """
+        Convert `f` to a tuple representation with native coefficients.
+
+        This is needed for hashing.
+        """
+        return dmp_to_tuple(f.rep, 0)
 
     @classmethod
     def from_list(cls, rep, mod, dom):

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -488,3 +488,12 @@ def test_ANP_arithmetics():
 
     assert a.quo(a) == a.mul(a.pow(-1)) == a*a**(-1) == ANP(1, mod, QQ)
 
+def test___hash__():
+    # Issue 2472
+    # Make sure int vs. long doesn't affect hashing with Python ground types
+    assert DMP([[1, 2], [3]], ZZ) == DMP([[1l, 2l], [3l]], ZZ)
+    assert hash(DMP([[1, 2], [3]], ZZ)) == hash(DMP([[1l, 2l], [3l]], ZZ))
+    assert DMF(([[1, 2], [3]], [[1]]), ZZ) == DMF(([[1L, 2L], [3L]], [[1L]]), ZZ)
+    assert hash(DMF(([[1, 2], [3]], [[1]]), ZZ)) == hash(DMF(([[1L, 2L], [3L]], [[1L]]), ZZ))
+    assert ANP([1, 1], [1, 0, 1], ZZ) == ANP([1l, 1l], [1l, 0l, 1l], ZZ)
+    assert hash(ANP([1, 1], [1, 0, 1], ZZ)) == hash(ANP([1l, 1l], [1l, 0l, 1l], ZZ))

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -183,6 +183,8 @@ def test_RootSum___new__():
 
     assert RootSum((x - 7)*f**3, g) == log(7*x) + 3*RootSum(f, g)
     assert RootSum((x - 7)*f**3, g).doit() == log(7*x) + 3*rootofs
+    # Issue 2472
+    assert hash(RootSum((x - 7)*f**3, g)) == hash(log(7*x) + 3*RootSum(f, g))
 
     raises(MultivariatePolynomialError, "RootSum(x**3 + x + y)")
     raises(ValueError, "RootSum(x**2 + 3, lambda x: x)")


### PR DESCRIPTION
This fixes issue 2472.  Previously, it would hash the repr of self.rep.
But this caused problems when long versions of small integers slipped
in, because repr(int(1)) != repr(long(1l)).

It now converts the nested list of lists representation to a nested
tuple of tuples.  A new dmp_to_tuple() function was added to do this,
similar to dmp_copy(), and methods to_tuple() were added to DMP and ANP.

@vperic, I need you to verify that this fixes the issue that only you seemed to be able to reproduce.
