### PR TITLE
Fix 2446: Symbol.as_dummy() now handles symbols with assumptions.

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -73,7 +73,9 @@ class Symbol(AtomicExpr, Boolean):
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One
 
     def as_dummy(self):
-        return Dummy(self.name, self.is_commutative, **self.assumptions0)
+        assumptions = self.assumptions0.copy()
+        assumptions.pop('commutative', None)
+        return Dummy(self.name, self.is_commutative, **assumptions)
 
     def __call__(self, *args):
         from function import Function

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -45,6 +45,10 @@ def test_as_dummy_nondummy():
     assert x1.is_commutative == False
     # assert x == x1.as_nondummy()
 
+    # issue 2446
+    x = Symbol('x', real=True, commutative=False)
+    assert x.as_dummy().assumptions0 == x.assumptions0
+
 def test_lt_gt():
     x, y = Symbol('x'), Symbol('y')
 


### PR DESCRIPTION
This fails in master:

```
>>> x = Symbol('x', real=True)
>>> x.as_dummy()
TypeError: __new__() got multiple values for keyword argument 'commutative'
```
