### PR TITLE
1858b (1811) separatevars modifications and noncommutative factoring

### DIFF
--- a/doc/src/modules/physics/mechanics/examples.txt
+++ b/doc/src/modules/physics/mechanics/examples.txt
@@ -171,9 +171,9 @@ represent the constraint forces in those directions. ::
   [                                          -2*u1*u3/3]
   [                             (-2*u2 + u3*tan(q2))*u1]
   >>> mprint(KM.auxiliary_eqs, order=None)
-  [                                                        -m*(r*u1*u3 + r*u2') + f1]
-  [     m*(-r*(u3*q3' - u1') - r*u2*u3)*cos(q2) - m*(r*u1**2 + r*u2**2)*sin(q2) + f2]
-  [-g*m + m*(r*(u1**2 + u2**2)*cos(q2) + (-r*(u3*q3' - u1') - r*u2*u3)*sin(q2)) + f3]
+  [                                                   -m*(r*u1*u3 + r*u2') + f1]
+  [-m*((r*(u3*q3' - u1') + r*u2*u3)*cos(q2) + (r*u1**2 + r*u2**2)*sin(q2)) + f2]
+  [-g*m + m*(r*(u1**2 + u2**2)*cos(q2) - r*(u2*u3 + u3*q3' - u1')*sin(q2)) + f3]
 
 The Bicycle
 ===========

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -24,7 +24,7 @@ from function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
 from sets import Set, Interval, Union, EmptySet, FiniteSet, ProductSet
 from evalf import PrecisionExhausted, N
 from containers import Tuple, Dict
-from exprtools import gcd_terms, factor_terms
+from exprtools import gcd_terms, factor_terms, factor_nc
 
 # expose singletons
 Catalan = S.Catalan

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -6,12 +6,16 @@ from sympy.core.mul import Mul, _keep_coeff
 from sympy.core.power import Pow
 from sympy.core.basic import Basic
 from sympy.core.expr import Expr
+from sympy.core.function import expand_mul
 from sympy.core.sympify import sympify
 from sympy.core.numbers import Rational, Integer
 from sympy.core.singleton import S
 from sympy.core.symbol import Dummy
 from sympy.core.coreerrors import NonCommutativeExpression
 from sympy.core.containers import Tuple
+from sympy.utilities import default_sort_key
+from sympy.utilities.iterables import (common_prefix, common_suffix,
+                                       preorder_traversal, variations)
 
 def decompose_power(expr):
     """
@@ -507,3 +511,230 @@ def factor_terms(expr, radical=False, clear=False):
     p = Add._from_args(list_args) # gcd_terms will fix up ordering
     p = gcd_terms(p, isprimitive=True, clear=clear)
     return _keep_coeff(cont, p, clear=clear)
+
+def _mask_nc(eq):
+    """Return ``eq`` with non-commutative objects replaced with dummy
+    symbols. A dictionary that can be used to restore the original
+    values is returned: if it is None, the expression is
+    noncommutative and cannot be made commutative. The third value
+    returned is a list of any non-commutative symbols that appeared
+    in the equation.
+
+    Notes
+    =====
+    All commutative objects (other than Symbol) will be replaced;
+    if the only non-commutative obects are Symbols, if there is only
+    1 Symbol, it will be replaced; if there are more than one then
+    they will not be replaced; the calling routine should handle
+    replacements in this case since some care must be taken to keep
+    track of the ordering of symbols when they occur within Muls.
+
+    Examples
+    ========
+    >>> from sympy.physics.secondquant import Commutator, NO, F, Fd
+    >>> from sympy import Dummy, symbols
+    >>> from sympy.abc import x, y
+    >>> from sympy.core.exprtools import _mask_nc
+    >>> A, B, C = symbols('A,B,C', commutative=False)
+    >>> Dummy._count = 0 # reset for doctest purposes
+    >>> _mask_nc(A**2 - x**2)
+    (_0**2 - x**2, {_0: A}, [])
+    >>> _mask_nc(A**2 - B**2)
+    (A**2 - B**2, None, [B, A])
+    >>> _mask_nc(1 + x*Commutator(A, B) + Commutator(A, C))
+    (_1*x + _2 + 1, {_1: Commutator(A, B), _2: Commutator(A, C)}, [C, B, A])
+    >>> _mask_nc(NO(Fd(x)*F(y)))
+    (_3, {_3: NO(CreateFermion(x)*AnnihilateFermion(y))}, [])
+
+    """
+    expr = eq
+    if expr.is_commutative:
+        return eq, {}, []
+    # if there is only one nc symbol, it can be factored regularly but
+    # polys is going to complain, so replace it with a dummy
+    rep = []
+    nc_syms = [s for s in expr.free_symbols if not s.is_commutative]
+    if len(nc_syms) == 1:
+        nc = Dummy()
+        rep.append((nc_syms.pop(), nc))
+        expr = expr.subs(rep)
+    # even though the noncommutative symbol may be gone, the expression
+    # might still appear noncommutative; if it's a non-elementary object
+    # we will replace it, but if it is a Symbol, Add, Mul, Pow we leave
+    # it alone.
+    if nc_syms or not expr.is_commutative:
+        pot = preorder_traversal(expr)
+        for i, a in enumerate(pot):
+            if any(a == r[0] for r in rep):
+                pass
+            elif (
+                not a.is_commutative and
+                not (a.is_Symbol or a.is_Add or a.is_Mul or a.is_Pow)
+                ):
+                rep.append((a, Dummy()))
+            else:
+                continue # don't skip
+            pot.skip() # don't go any further
+        expr = expr.subs(rep)
+    return expr, dict([(v, k) for k, v in rep]) or None, nc_syms
+
+def factor_nc(expr):
+    """Return the factored form of ``expr`` while handling non-commutative
+    expressions.
+
+    **examples**
+    >>> from sympy.core.exprtools import factor_nc
+    >>> from sympy import Symbol
+    >>> from sympy.abc import x
+    >>> A = Symbol('A', commutative=False)
+    >>> B = Symbol('B', commutative=False)
+    >>> factor_nc((x**2 + 2*A*x + A**2).expand())
+    (x + A)**2
+    >>> factor_nc(((x + A)*(x + B)).expand())
+    (x + A)*(x + B)
+    """
+    from sympy.simplify.simplify import _mexpand
+    from sympy.polys import gcd, factor
+
+    expr = sympify(expr)
+    if not isinstance(expr, Expr) or not expr.args:
+        return expr
+    if not expr.is_Add:
+        return expr.func(*[factor_nc(a) for a in expr.args])
+
+    expr, rep, nc_symbols = _mask_nc(expr)
+    if rep:
+        return factor(expr).subs(rep)
+    else:
+        args = [a.args_cnc() for a in Add.make_args(expr)]
+        c = g = l = r = S.One
+        hit = False
+        # find any commutative gcd term
+        for i, a in enumerate(args):
+            if i == 0:
+                c = Mul._from_args(a[0])
+            elif a[0]:
+                c = gcd(c, Mul._from_args(a[0]))
+            else:
+                c = S.One
+        if c is not S.One:
+            hit = True
+            c, g = c.as_coeff_Mul()
+            for i, (cc, _) in enumerate(args):
+                cc = list(Mul.make_args(Mul._from_args(list(cc))/g))
+                args[i][0] = cc
+        # find any noncommutative common prefix
+        for i, a in enumerate(args):
+            if i == 0:
+                n = a[1][:]
+            else:
+                n = common_prefix(n, a[1])
+            if not n:
+                # is there a power that can be extracted?
+                if not args[0][1]:
+                    break
+                b, e = args[0][1][0].as_base_exp()
+                ok = False
+                if e.is_Integer:
+                    for t in args:
+                        if not t[1]:
+                            break
+                        bt, et = t[1][0].as_base_exp()
+                        if et.is_Integer and bt == b:
+                            e = min(e, et)
+                        else:
+                            break
+                    else:
+                        ok = hit = True
+                        l = b**e
+                        il = b**-e
+                        for i, a in enumerate(args):
+                            args[i][1][0] = il*args[i][1][0]
+                        break
+                if not ok:
+                    break
+        else:
+            hit = True
+            lenn = len(n)
+            l = Mul(*n)
+            for i, a in enumerate(args):
+                args[i][1] = args[i][1][lenn:]
+        # find any noncommutative common suffix
+        for i, a in enumerate(args):
+            if i == 0:
+                n = a[1][:]
+            else:
+                n = common_suffix(n, a[1])
+            if not n:
+                # is there a power that can be extracted?
+                if not args[0][1]:
+                    break
+                b, e = args[0][1][-1].as_base_exp()
+                ok = False
+                if e.is_Integer:
+                    for t in args:
+                        if not t[1]:
+                            break
+                        bt, et = t[1][-1].as_base_exp()
+                        if et.is_Integer and bt == b:
+                            e = min(e, et)
+                        else:
+                            break
+                    else:
+                        ok = hit = True
+                        r = b**e
+                        il = b**-e
+                        for i, a in enumerate(args):
+                            args[i][1][-1] = args[i][1][-1]*il
+                        break
+                if not ok:
+                    break
+        else:
+            hit = True
+            lenn = len(n)
+            r = Mul(*n)
+            for i, a in enumerate(args):
+                args[i][1] = a[1][:len(a[1]) - lenn]
+        if hit:
+            mid = Add(*[Mul(*cc)*Mul(*nc) for cc, nc in args])
+        else:
+            mid = expr
+
+        # sort the symbols so the Dummys would appear in the same
+        # order as the original symbols, otherwise you may introduce
+        # a factor of -1, e.g. A**2 - B**2) -- {A:y, B:x} --> y**2 - x**2
+        # and the former factors into two terms, (A - B)*(A + B) while the
+        # latter factors into 3 terms, (-1)*(x - y)*(x + y)
+        rep1 = [(n, Dummy()) for n in sorted(nc_symbols, key=default_sort_key)]
+        unrep1 = [(v, k) for k, v in rep1]
+        unrep1.reverse()
+        new_mid, r2, _ = _mask_nc(mid.subs(rep1))
+        new_mid = factor(new_mid)
+
+        new_mid = new_mid.subs(r2).subs(unrep1)
+
+        if new_mid.is_Pow:
+            return _keep_coeff(c, g*l*new_mid*r)
+
+        if new_mid.is_Mul:
+            # XXX TODO there should be a way to inspect what order the terms
+            # must be in and just select the plausible ordering without
+            # checking permutations
+            cfac = []
+            ncfac = []
+            for f in new_mid.args:
+                if f.is_commutative:
+                    cfac.append(f)
+                else:
+                    b, e = f.as_base_exp()
+                    assert e.is_Integer
+                    ncfac.extend([b]*e)
+            pre_mid = g*Mul(*cfac)*l
+            target = _mexpand(expr/c)
+            for s in variations(ncfac, len(ncfac)):
+                ok = pre_mid*Mul(*s)*r
+                if _mexpand(ok) == target:
+                    return _keep_coeff(c, ok)
+
+        # mid was an Add that didn't factor successfully
+        return _keep_coeff(c, g*l*mid*r)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,6 +1,7 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
-from sympy import S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, Interval
+from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple,
+                   Interval, O, symbols, simplify, collect)
 from sympy.abc import a, b, t, x, y, z
 from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
                                   gcd_terms, factor_terms)
@@ -90,6 +91,13 @@ def test_gcd_terms():
     garg = 2*x*(x + 2*y)
     assert gcd_terms(arg) == garg
     assert gcd_terms(sin(arg)) == sin(garg)
+
+    # issue 3040-like
+    alpha, alpha1, alpha2, alpha3 = symbols('alpha:4')
+    a = alpha**2 - alpha*x**2 + alpha + x**3 - x*(alpha + 1)
+    rep = (alpha, (1 + sqrt(5))/2 + alpha1*x + alpha2*x**2 + alpha3*x**3)
+    s = (a/(x - alpha)).subs(*rep).series(x, 0, 1)
+    assert simplify(collect(s, x)) == -sqrt(5)/2 - S(3)/2 + O(x)
 
 def test_factor_terms():
     A = Symbol('A', commutative=False)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,10 +1,10 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
 from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple,
-                   Interval, O, symbols, simplify, collect)
+                   Interval, O, symbols, simplify, collect, Sum)
 from sympy.abc import a, b, t, x, y, z
 from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
-                                  gcd_terms, factor_terms)
+                                  gcd_terms, factor_terms, factor_nc)
 from sympy.core.mul import _keep_coeff as _keep_coeff
 
 def test_decompose_power():
@@ -136,3 +136,45 @@ def test_xreplace():
     e = Mul(2, 1 + x, evaluate=False)
     assert e.xreplace({}) == e
     assert e.xreplace({y: x}) == e
+
+def test_factor_nc():
+    x, y = symbols('x,y')
+    n, m, o = symbols('n,m,o', commutative=False)
+
+    # mul and multinomial expansion is needed
+    from sympy.simplify.simplify import _mexpand
+    e = x*(1 + y)**2
+    assert _mexpand(e) == x + x*2*y + x*y**2
+
+    def factor_nc_test(e):
+        ex = _mexpand(e)
+        assert ex.is_Add
+        f = factor_nc(ex)
+        assert not f.is_Add and _mexpand(f) == ex
+
+    factor_nc_test(x*(1 + y))
+    factor_nc_test(n*(x + 1))
+    factor_nc_test(n*(x + m))
+    factor_nc_test((x + m)*n)
+    factor_nc_test(n*m*(x*o + n*o*m)*n)
+    s = Sum(x, (x, 1, 2))
+    factor_nc_test(x*(1 + s))
+    factor_nc_test(x*(1 + s)*s)
+    factor_nc_test(x*(1 + sin(s)))
+    factor_nc_test((1 + n)**2)
+
+    factor_nc_test((x + n)*(x + m)*(x+y))
+    factor_nc_test(x*(n*m + 1))
+    factor_nc_test(x*(n*m + x))
+    factor_nc_test(x*(x*n*m + 1))
+    factor_nc_test(x*n*(x*m + 1))
+    factor_nc_test(x*(m*n + x*n*m))
+    factor_nc_test(n*(1 - m)*n**2)
+
+    factor_nc_test((n + m)**2)
+    factor_nc_test((n - m)*(n + m)**2)
+    factor_nc_test((n + m)**2*(n - m))
+    factor_nc_test((m - n)*(n + m)**2*(n - m))
+
+    assert factor_nc(n*(n + n*m)) == n**2*(1 + m)
+    assert factor_nc(m*(m*n + n*m*n**2)) == m*(m + n*m*n)*n

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,5 +1,6 @@
 from sympy import (Symbol, symbols, factorial, factorial2, binomial,
-    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan, oo)
+    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan, oo, simplify)
+from sympy.utilities.pytest import XFAIL
 
 def test_rf_eval_apply():
     x, y = symbols('x,y')
@@ -140,3 +141,10 @@ def test_binomial_rewrite():
 
     assert binomial(n, k).rewrite(factorial) == factorial(n)/(factorial(k)*factorial(n - k))
     assert binomial(n, k).rewrite(gamma) == gamma(n + 1)/(gamma(k + 1)*gamma(n - k + 1))
+
+@XFAIL
+def test_factorial_simplify_fail():
+    # simplify(factorial(x + 1).diff(x) - ((x + 1)*factorial(x)).diff(x))) == 0
+    from sympy.abc import x
+    assert simplify(x*polygamma(0, x + 1) - x*polygamma(0, x + 2) +
+    polygamma(0, x + 1) - polygamma(0, x + 2) + 1) == 0

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5248,7 +5248,14 @@ def factor(f, *gens, **args):
     (x + 2)**20000000*(x**2 + 1)
 
     """
-    return _generic_factor(f, gens, args, method='factor')
+    try:
+        return _generic_factor(f, gens, args, method='factor')
+    except PolynomialError, msg:
+        if not f.is_commutative:
+            from sympy.core.exprtools import factor_nc
+            return factor_nc(f)
+        else:
+            raise PolynomialError(msg)
 
 def intervals(F, all=False, eps=None, inf=None, sup=None, strict=False, fast=False, sqf=False):
     """

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -7,7 +7,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 from simplify import (collect, rcollect, separate, radsimp, ratsimp, fraction,
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify,
     logcombine, separatevars, numer, denom, powdenest, posify, polarify,
-    unpolarify, collect_const, factor_nc)
+    unpolarify, collect_const)
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -4,10 +4,10 @@ for example:
 the expression E**(pi*I) will be converted into -1
 the expression (x+x)**2 will be converted into 4*x**2
 """
-from simplify import collect, rcollect, separate, radsimp, ratsimp, fraction, \
-    simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars, numer, denom, powdenest, posify, polarify, \
-    unpolarify, collect_const
+from simplify import (collect, rcollect, separate, radsimp, ratsimp, fraction,
+    simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify,
+    logcombine, separatevars, numer, denom, powdenest, posify, polarify,
+    unpolarify, collect_const, factor_nc)
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -644,7 +644,8 @@ def separatevars(expr, symbols=[], dict=False, force=False):
         return _separatevars(expr, force)
 
 def _separatevars(expr, force):
-
+    if len(expr.free_symbols) == 1:
+        return expr
     # don't destroy a Mul since much of the work may already be done
     if expr.is_Mul:
         args = list(expr.args)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -808,9 +808,9 @@ def factor_nc(expr, **kwargs):
         # find any commutative gcd term
         for i, a in enumerate(args):
             if i == 0:
-                c = Mul._from_args(list(a[0]))
+                c = Mul._from_args(a[0])
             elif a[0]:
-                c = gcd(c, Mul._from_args(list(a[0])))
+                c = gcd(c, Mul._from_args(a[0]))
             else:
                 c = S.One
         if c is not S.One:
@@ -826,7 +826,29 @@ def factor_nc(expr, **kwargs):
             else:
                 n = common_prefix(n, a[1])
             if not n:
-                break
+                # is there a power that can be extracted?
+                if not args[0][1]:
+                    break
+                b, e = args[0][1][0].as_base_exp()
+                ok = False
+                if e.is_Integer:
+                    for t in args:
+                        if not t[1]:
+                            break
+                        bt, et = t[1][0].as_base_exp()
+                        if et.is_Integer and bt == b:
+                            e = min(e, et)
+                        else:
+                            break
+                    else:
+                        ok = hit = True
+                        l = b**e
+                        il = b**-e
+                        for i, a in enumerate(args):
+                            args[i][1][0] = il*args[i][1][0]
+                        break
+                if not ok:
+                    break
         else:
             hit = True
             lenn = len(n)
@@ -840,7 +862,29 @@ def factor_nc(expr, **kwargs):
             else:
                 n = common_suffix(n, a[1])
             if not n:
-                break
+                # is there a power that can be extracted?
+                if not args[0][1]:
+                    break
+                b, e = args[0][1][-1].as_base_exp()
+                ok = False
+                if e.is_Integer:
+                    for t in args:
+                        if not t[1]:
+                            break
+                        bt, et = t[1][-1].as_base_exp()
+                        if et.is_Integer and bt == b:
+                            e = min(e, et)
+                        else:
+                            break
+                    else:
+                        ok = hit = True
+                        r = b**e
+                        il = b**-e
+                        for i, a in enumerate(args):
+                            args[i][1][-1] = args[i][1][-1]*il
+                        break
+                if not ok:
+                    break
         else:
             hit = True
             lenn = len(n)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -13,8 +13,10 @@ from sympy.core.function import expand_log, count_ops
 from sympy.core.mul import _keep_coeff
 from sympy.core.rules import Transform
 
-from sympy.utilities import flatten, default_sort_key
 from sympy.functions import gamma, exp, sqrt, log, root, exp_polar
+from sympy.utilities import flatten, default_sort_key
+from sympy.utilities.iterables import (common_prefix, common_suffix,
+                                       preorder_traversal, variations)
 
 from sympy.simplify.cse_main import cse
 from sympy.simplify.sqrtdenest import sqrtdenest
@@ -728,6 +730,161 @@ def _separatevars_dict(expr, symbols):
         ret[k] = Mul(*v)
 
     return ret
+
+def _mask_nc(eq):
+    """Return ``eq`` with non-commutative objects replaced with dummy symbols.
+    A dictionary that can be used to restore the original values is
+    returned: if it is None, the expression is noncommutative and cannot
+    be made commutative. The third value returned is a list of any
+    non-commutative symbols that appeared in the equation.
+
+    >>> from sympy.physics.secondquant import Commutator, NO, F, Fd
+    >>> from sympy import Dummy, symbols
+    >>> from sympy.abc import x, y
+    >>> from sympy.simplify.simplify import _mask_nc
+    >>> A, B = symbols('A,B', commutative=False)
+    >>> Dummy._count = 0 # reset for doctest purposes
+    >>> _mask_nc(1 + x + Commutator(A, B))
+    (_0 + x + 1, {_0: Commutator(A, B)}, [B, A])
+    >>> _mask_nc(NO(Fd(x)*F(y)))
+    (_1, {_1: NO(CreateFermion(x)*AnnihilateFermion(y))}, [])
+
+    """
+    expr = eq
+    if expr.is_commutative:
+        return eq, {}, []
+    # if there is only one nc symbol, it can be factored regularly but
+    # polys is going to complain, so replace it with a dummy
+    rep = []
+    nc_syms = [s for s in expr.free_symbols if not s.is_commutative]
+    if len(nc_syms) == 1:
+        nc = Dummy()
+        rep.append((nc_syms.pop(), nc))
+        expr = expr.subs(rep)
+    # even though the noncommutative symbol may be gone, the expression
+    # might still appear noncommutative; if it's a non-elementary object
+    # we will replace it, but if it is a Symbol, Add, Mul, Pow we leave
+    # it alone. Symbols (past the first one) are not replaced unless the
+    # ``all`` flag is set since any factoring that is done must keep
+    # track of nc ordering within Muls
+    if nc_syms or not expr.is_commutative:
+        pot = preorder_traversal(expr)
+        for i, a in enumerate(pot):
+            if a in [r[0] for r in rep]:
+                pass
+            elif (
+                not a.is_commutative and
+                not (a.is_Symbol or a.is_Add or a.is_Mul or a.is_Pow)
+                ):
+                rep.append((a, Dummy()))
+            else:
+                continue # don't skip
+            pot.skip() # don't go any further
+        expr = expr.subs(rep)
+    return expr, dict([(v, k) for k, v in rep]) or None, nc_syms
+
+def factor_nc(expr, **kwargs):
+    """Return the factored form of ``expr`` while handling non-commutative
+    expressions.
+
+    **examples**
+    >>> from sympy.simplify.simplify import factor_nc
+    >>> from sympy import Symbol
+    >>> from sympy.abc import x
+    >>> A = Symbol('A', commutative=False)
+    >>> B = Symbol('B', commutative=False)
+    >>> factor_nc((x**2 + 2*A*x + A**2).expand())
+    (x + A)**2
+    >>> factor_nc(((x + A)*(x + B)).expand())
+    (x + A)*(x + B)
+    """
+    expr, rep, nc_symbols = _mask_nc(expr)
+    if rep is not None:
+        return factor(expr, **kwargs).subs(rep)
+    else:
+        args = [a.args_cnc() for a in Add.make_args(expr)]
+        c = g = l = r = S.One
+        hit = False
+        # find any commutative gcd term
+        for i, a in enumerate(args):
+            if i == 0:
+                c = Mul._from_args(list(a[0]))
+            elif a[0]:
+                c = gcd(c, Mul._from_args(list(a[0])))
+            else:
+                c = S.One
+        if c is not S.One:
+            hit = True
+            c, g = c.as_coeff_Mul()
+            for i, (cc, _) in enumerate(args):
+                cc = list(Mul.make_args(Mul._from_args(list(cc))/g))
+                args[i][0] = cc
+        # find any noncommutative common prefix
+        for i, a in enumerate(args):
+            if i == 0:
+                n = a[1][:]
+            else:
+                n = common_prefix(n, a[1])
+            if not n:
+                break
+        else:
+            hit = True
+            lenn = len(n)
+            l = Mul(*n)
+            for i, a in enumerate(args):
+                args[i][1] = args[i][1][lenn:]
+        # find any noncommutative common suffix
+        for i, a in enumerate(args):
+            if i == 0:
+                n = a[1][:]
+            else:
+                n = common_suffix(n, a[1])
+            if not n:
+                break
+        else:
+            hit = True
+            lenn = len(n)
+            r = Mul(*n)
+            for i, a in enumerate(args):
+                args[i][1] = a[1][:len(a[1]) - lenn]
+        if hit:
+            args = [Add(*[Mul(*cc)*Mul(*nc) for cc, nc in args])]
+        else:
+            args = list(Mul.make_args(expr))
+
+        rep1 = [(n, Dummy()) for n in nc_symbols]
+        unrep1 = [(v, k) for k, v in rep1]
+        unrep1.reverse()
+        for ia, a in enumerate(args):
+            if not a.is_Add:
+                continue
+            new_expr, r2, _ = _mask_nc(a.subs(rep1))
+            if r2 is not None:
+                newa = factor(new_expr)
+                if newa.is_Mul and all(ai.is_Add for ai in newa.args):
+                    args[ia] = newa.subs(r2).subs(unrep1)
+        mid = Mul(*args)
+        if mid.is_Mul:
+            # XXX TODO there should be a way to inspect what order the terms
+            # must be in and just select the plausible ordering without
+            # checking permutations
+            cfac = []
+            ncfac = []
+            for f in mid.args:
+                if f.is_commutative:
+                    cfac.append(f)
+                else:
+                    ncfac.append(f)
+            easy = g*Mul(*cfac)*l
+            target = expand_mul(expr/c)
+            for s in variations(ncfac, len(ncfac)):
+                ok = easy*Mul(*s)*r
+                if expand_mul(ok) == target:
+                    new_expr = ok
+                    break
+        else:
+            new_expr = g*l*mid*r
+        return _keep_coeff(c, new_expr)
 
 def ratsimp(expr):
     """

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -644,6 +644,18 @@ def separatevars(expr, symbols=[], dict=False, force=False):
         return _separatevars(expr, force)
 
 def _separatevars(expr, force):
+
+    # don't destroy a Mul since much of the work may already be done
+    if expr.is_Mul:
+        args = list(expr.args)
+        changed = False
+        for i, a in enumerate(args):
+            args[i] = separatevars(a, force)
+            changed = changed or args[i] != a
+        if changed:
+            expr = Mul(*args)
+        return expr
+
     # get a Pow ready for expansion
     if expr.is_Pow:
         expr = Pow(separatevars(expr.base, force=force), expr.exp)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -612,14 +612,14 @@ def separatevars(expr, symbols=[], dict=False, force=False):
     >>> separatevars((x*y)**y, force=True)
     x**y*y**y
     >>> separatevars(2*x**2*z*sin(y)+2*z*x**2)
-    2*x**2*z*(sin(y) + 1)
+    x**2*z*(2*sin(y) + 2)
 
     >>> separatevars(2*x+y*sin(x))
     2*x + y*sin(x)
     >>> separatevars(2*x**2*z*sin(y)+2*z*x**2, symbols=(x, y), dict=True)
-    {'coeff': 2*z, x: x**2, y: sin(y) + 1}
+    {'coeff': z, x: x**2, y: 2*sin(y) + 2}
     >>> separatevars(2*x**2*z*sin(y)+2*z*x**2, [x, y, alpha], dict=True)
-    {'coeff': 2*z, alpha: 1, x: x**2, y: sin(y) + 1}
+    {'coeff': z, alpha: 1, x: x**2, y: 2*sin(y) + 2}
 
     If the expression is not really separable, or is only partially
     separable, separatevars will do the best it can to separate it.
@@ -690,7 +690,7 @@ def _separatevars(expr, force):
     if not nonsepar:
         return commonc
     else:
-        if nonsepar.is_commutative: # factor fails for nc
+        if nonsepar.is_commutative and len(nonsepar.free_symbols) > 1: # factor fails for nc
             _expr = nonsepar
             if not force:
                 # factor will expand bases so we mask them off now

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,8 +4,7 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add, Float, radsimp, collect_const, polygamma,
-    factor_nc, Sum, hyper)
+    factor, Mul, O, hyper, Add, Float, radsimp, collect_const, hyper)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
@@ -1032,38 +1031,3 @@ def test_unpolarify():
 def test_issue_2998():
     collect(a*y**(2.0*x)+b*y**(2.0*x),y**(x)) == y**(2.0*x)*(a + b)
     collect(a*2**(2.0*x)+b*2**(2.0*x),2**(x)) == 2**(2.0*x)*(a + b)
-
-@XFAIL
-def test_factorial_simplify():
-    # simplify(factorial(x + 1).diff(x) - ((x + 1)*factorial(x)).diff(x))) == 0
-    assert simplify(x*polygamma(0, x + 1) - x*polygamma(0, x + 2) +
-    polygamma(0, x + 1) - polygamma(0, x + 2) + 1) == 0
-
-def test_factor_nc():
-    x, y = symbols('x,y')
-    n, m, o = symbols('n,m,o', commutative=False)
-    assert factor_nc(x + x*y) == x*(1 + y)
-    assert factor_nc(x*n + n) == n*(x + 1)
-    assert factor_nc(x*n + n*m) == n*(x + m)
-    assert factor_nc(x*n + m*n) == (x + m)*n
-    assert factor_nc(x*n*m*o*n + n*m*n*o*m*n) == n*m*(x*o + n*o*m)*n
-    s = Sum(x, (x, 1, 2))
-    assert factor_nc(x*s + x) == x*(1 + s)
-    assert factor_nc(x*s**2 + x*s) == x*(1 + s)*s
-    assert factor_nc(x*sin(s) + x) == x*(1 + sin(s))
-    assert factor_nc(n**2 + 2*n + 1) == (1 + n)**2
-
-    eq = (x + n)*(x + m)*(x+y)
-    assert factor_nc(eq.expand()) == eq
-    eq = (x + x*n*m)
-    assert factor_nc(eq.expand()) == x*(n*m + 1)
-    eq = (x**2 + x*n*m)
-    assert factor_nc(eq.expand()) == x*(n*m + x)
-    eq = (x + x**2*n*m)
-    assert factor_nc(eq.expand()) == x*(x*n*m + 1)
-    eq = (x*n + x**2*n*m)
-    assert factor_nc(eq.expand()) == x*n*(x*m + 1)
-    eq = (x*m*n + x**2*n*m)
-    assert factor_nc(eq.expand()) == x*(m*n + x*n*m)
-    eq = (n**3 - n*m*n**2)
-    assert factor_nc(eq) == n*(1 - m)*n**2

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1065,3 +1065,5 @@ def test_factor_nc():
     assert factor_nc(eq.expand()) == x*n*(x*m + 1)
     eq = (x*m*n + x**2*n*m)
     assert factor_nc(eq.expand()) == x*(m*n + x*n*m)
+    eq = (n**3 - n*m*n**2)
+    assert factor_nc(eq) == n*(1 - m)*n**2

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -553,6 +553,10 @@ def test_separatevars():
     assert separatevars(2*x+y, dict=True, symbols=()) is None
     assert separatevars(2*x+y, dict=True) is None
     assert separatevars(2*x+y, dict=True, symbols=None) == {'coeff': 2*x + y}
+    # 1709
+    n, m = symbols('n,m', commutative=False)
+    assert separatevars(m + n*m) == m + n*m
+    assert separatevars(x + x*n) == x*(1 + n)
 
 def test_separatevars_advanced_factor():
     x,y,z = symbols('x,y,z')

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,7 +4,8 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add, Float, radsimp, collect_const, polygamma)
+    factor, Mul, O, hyper, Add, Float, radsimp, collect_const, polygamma,
+    factor_nc, Sum, hyper)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
@@ -557,11 +558,14 @@ def test_separatevars():
     assert separatevars(2*x+y, dict=True, symbols=None) == {'coeff': 2*x + y}
     # 1709
     n, m = symbols('n,m', commutative=False)
-    assert separatevars(m + n*m) == m + n*m
+    assert separatevars(m + n*m) == (1 + n)*m
     assert separatevars(x + x*n) == x*(1 + n)
     # 1811
     f = Function('f')
     assert separatevars(f(x) + x*f(x)) == f(x) + x*f(x)
+    # a noncommutable object present
+    eq = x*(1 + hyper((), (), y*z))
+    assert separatevars(eq) == eq
 
 def test_separatevars_advanced_factor():
     x,y,z = symbols('x,y,z')
@@ -1034,3 +1038,30 @@ def test_factorial_simplify():
     # simplify(factorial(x + 1).diff(x) - ((x + 1)*factorial(x)).diff(x))) == 0
     assert simplify(x*polygamma(0, x + 1) - x*polygamma(0, x + 2) +
     polygamma(0, x + 1) - polygamma(0, x + 2) + 1) == 0
+
+def test_factor_nc():
+    x, y = symbols('x,y')
+    n, m, o = symbols('n,m,o', commutative=False)
+    assert factor_nc(x + x*y) == x*(1 + y)
+    assert factor_nc(x*n + n) == n*(x + 1)
+    assert factor_nc(x*n + n*m) == n*(x + m)
+    assert factor_nc(x*n + m*n) == (x + m)*n
+    assert factor_nc(x*n*m*o*n + n*m*n*o*m*n) == n*m*(x*o + n*o*m)*n
+    s = Sum(x, (x, 1, 2))
+    assert factor_nc(x*s + x) == x*(1 + s)
+    assert factor_nc(x*s**2 + x*s) == x*(1 + s)*s
+    assert factor_nc(x*sin(s) + x) == x*(1 + sin(s))
+    assert factor_nc(n**2 + 2*n + 1) == (1 + n)**2
+
+    eq = (x + n)*(x + m)*(x+y)
+    assert factor_nc(eq.expand()) == eq
+    eq = (x + x*n*m)
+    assert factor_nc(eq.expand()) == x*(n*m + 1)
+    eq = (x**2 + x*n*m)
+    assert factor_nc(eq.expand()) == x*(n*m + x)
+    eq = (x + x**2*n*m)
+    assert factor_nc(eq.expand()) == x*(x*n*m + 1)
+    eq = (x*n + x**2*n*m)
+    assert factor_nc(eq.expand()) == x*n*(x*m + 1)
+    eq = (x*m*n + x**2*n*m)
+    assert factor_nc(eq.expand()) == x*(m*n + x*n*m)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -533,6 +533,7 @@ def test_separatevars():
     assert separatevars((x*(y+1))**z).is_Pow # != x**z*(1 + y)**z
     assert separatevars(1+x+y+x*y) == (x+1)*(y+1)
     assert separatevars(y / pi * exp(-(z - x) / cos(n))) == y * exp((x - z) / cos(n)) / pi
+    assert separatevars((x + y)*(x - y) + y**2 + 2*x + 1) == (x + 1)**2
     # 1759
     p=Symbol('p',positive=True)
     assert separatevars(sqrt(p**2 + x*p**2)) == p*sqrt(1 + x)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -488,7 +488,7 @@ def test_collect_Wild():
     assert collect(a*(x + 1)**y + (x + 1)**y, w1**w2) == (1 + a)*(x + 1)**y
 
 def test_collect_func():
-    f = expand((x + a + 1)**3)
+    f = ((x + a + 1)**3).expand()
 
     assert collect(f, x) == a**3 + 3*a**2 + 3*a + x**3 + x**2*(3*a + 3) + x*(3*a**2 + 6*a + 3) + 1
     assert collect(f, x, factor) == x**3 + 3*x**2*(a + 1) + 3*x*(a + 1)**2 + (a + 1)**3
@@ -532,7 +532,7 @@ def test_separatevars():
     assert separatevars(x*exp(x+y)+x*exp(x)) == x*(1 + exp(y))*exp(x)
     assert separatevars((x*(y+1))**z).is_Pow # != x**z*(1 + y)**z
     assert separatevars(1+x+y+x*y) == (x+1)*(y+1)
-    assert separatevars(y / pi * exp(-(z - x) / cos(n))) == y * exp((x - z) / cos(n)) / pi
+    assert separatevars(y/pi*exp(-(z - x)/cos(n))) == y*exp(x/cos(n))*exp(-z/cos(n))/pi
     assert separatevars((x + y)*(x - y) + y**2 + 2*x + 1) == (x + 1)**2
     # 1759
     p=Symbol('p',positive=True)
@@ -544,12 +544,14 @@ def test_separatevars():
     assert separatevars(sqrt(x*y), force=True) == sqrt(x)*sqrt(y)
     # 1858
     # any type sequence for symbols is fine
-    assert separatevars(((2*x+2)*y), dict=True, symbols=()) == {'coeff': 2, x: x + 1, y: y}
+    assert separatevars(((2*x+2)*y), dict=True, symbols=()) == {'coeff': 1, x: 2*x + 2, y: y}
     # separable
-    assert separatevars(((2*x+2)*y), dict=True, symbols=[]) == {'coeff': 2, x: x + 1, y: y}
-    assert separatevars(((2*x+2)*y), dict=True) == {'coeff': 2, x: x + 1, y: y}
-    assert separatevars(((2*x+2)*y), dict=True, symbols=None) == {'coeff': 2*y*(x + 1)}
+    assert separatevars(((2*x+2)*y), dict=True, symbols=[x]) == {'coeff': y, x: 2*x + 2}
+    assert separatevars(((2*x+2)*y), dict=True, symbols=[]) == {'coeff': 1, x: 2*x + 2, y: y}
+    assert separatevars(((2*x+2)*y), dict=True) == {'coeff': 1, x: 2*x + 2, y: y}
+    assert separatevars(((2*x+2)*y), dict=True, symbols=None) == {'coeff': y*(2*x + 2)}
     # not separable
+    assert separatevars(3, dict=True) is None
     assert separatevars(2*x+y, dict=True, symbols=()) is None
     assert separatevars(2*x+y, dict=True) is None
     assert separatevars(2*x+y, dict=True, symbols=None) == {'coeff': 2*x + y}

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -557,6 +557,9 @@ def test_separatevars():
     n, m = symbols('n,m', commutative=False)
     assert separatevars(m + n*m) == m + n*m
     assert separatevars(x + x*n) == x*(1 + n)
+    # 1811
+    f = Function('f')
+    assert separatevars(f(x) + x*f(x)) == f(x) + x*f(x)
 
 def test_separatevars_advanced_factor():
     x,y,z = symbols('x,y,z')

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -367,7 +367,7 @@ def test_separable2():
     # solve() messes this one up a little bit, so lets test _Integral here
     # We have to test strings with _Integral because y is a dummy variable.
     sol6str = "Integral((_y - 2)/_y**3, (_y, f(x))) == C1 + Integral(x**(-2), x)"
-    sol7 = Eq(log(-1 + f(x)**2)/2, C1 + log(-2 - x))
+    sol7 = Eq(-log(-1 + f(x)**2)/2, C1 - log(x + 2))
     sol8 = Eq(asinh(f(x)), C1 - log(log(x)))
     # integrate cannot handle the integral on the lhs (cos/tan)
     sol9str = "Integral(cos(_y)/tan(_y), (_y, f(x))) == C1 + Integral(-E*exp(x), x)"
@@ -420,7 +420,7 @@ def test_separable5():
                         ((1 - x)*(-x*exp(x) + exp(x))))
     sol19e = Eq(f(x), (C1*(1 - x) - x*(-x*exp(x) + exp(x)) -
                             x*exp(x) + exp(x))/((1 - x)*(-exp(x) + x*exp(x))))
-    sol20 = Eq(-log(-1 + 3*f(x)**2)/6, C1 - x**2/2)
+    sol20 = Eq(log(-1 + 3*f(x)**2)/6, C1 + x**2/2)
     sol21 = Eq(-exp(-f(x)), C1 + exp(x))
     assert dsolve(eq15, hint='separable') == sol15
     assert dsolve(eq16, hint='separable', simplify=False) == sol16
@@ -429,7 +429,7 @@ def test_separable5():
     assert dsolve(eq19, hint='separable') in [sol19a, sol19b, sol19c,
                                                     sol19d, sol19e]
     assert dsolve(eq20, hint='separable', simplify=False) == sol20
-    assert dsolve(eq21, hint='separable') == sol21
+    assert dsolve(eq21, hint='separable', simplify=False) == sol21
     assert checkodesol(eq15, sol15, order=1, solve_for_func=False)[0]
     assert checkodesol(eq16, sol16, order=1, solve_for_func=False)[0]
     assert checkodesol(eq17, sol17, order=1, solve_for_func=False)[0]

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -367,11 +367,11 @@ def test_separable2():
     # solve() messes this one up a little bit, so lets test _Integral here
     # We have to test strings with _Integral because y is a dummy variable.
     sol6str = "Integral((_y - 2)/_y**3, (_y, f(x))) == C1 + Integral(x**(-2), x)"
-    sol7 = Eq(-log(-1 + f(x)**2)/2, C1 - log(2 + x))
+    sol7 = Eq(log(-1 + f(x)**2)/2, C1 + log(-2 - x))
     sol8 = Eq(asinh(f(x)), C1 - log(log(x)))
     # integrate cannot handle the integral on the lhs (cos/tan)
     sol9str = "Integral(cos(_y)/tan(_y), (_y, f(x))) == C1 + Integral(-E*exp(x), x)"
-    sol10 = Eq(log(-1 + sin(f(x))**2)/2, C1 + log(x**2 - a**2)/2)
+    sol10 = Eq(-log(-1 + sin(f(x))**2)/2, C1 - log(x**2 - a**2)/2)
     assert str(dsolve(eq6, hint='separable_Integral')) == sol6str
     assert dsolve(eq7, hint='separable', simplify=False) == sol7
     assert dsolve(eq8, hint='separable', simplify=False) == sol8

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -371,7 +371,7 @@ def test_separable2():
     sol8 = Eq(asinh(f(x)), C1 - log(log(x)))
     # integrate cannot handle the integral on the lhs (cos/tan)
     sol9str = "Integral(cos(_y)/tan(_y), (_y, f(x))) == C1 + Integral(-E*exp(x), x)"
-    sol10 = Eq(-log(-1 + sin(f(x))**2)/2, C1 - log(x**2 - a**2)/2)
+    sol10 = Eq(log(-1 + sin(f(x))**2)/2, C1 + log(x**2 - a**2)/2)
     assert str(dsolve(eq6, hint='separable_Integral')) == sol6str
     assert dsolve(eq7, hint='separable', simplify=False) == sol7
     assert dsolve(eq8, hint='separable', simplify=False) == sol8

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -420,8 +420,8 @@ def test_separable5():
                         ((1 - x)*(-x*exp(x) + exp(x))))
     sol19e = Eq(f(x), (C1*(1 - x) - x*(-x*exp(x) + exp(x)) -
                             x*exp(x) + exp(x))/((1 - x)*(-exp(x) + x*exp(x))))
-    sol20 = Eq(log(-1 + 3*f(x)**2)/6, C1 + x**2/2)
-    sol21 = Eq(f(x), log(-1/(C1 + exp(x))))
+    sol20 = Eq(-log(-1 + 3*f(x)**2)/6, C1 - x**2/2)
+    sol21 = Eq(-exp(-f(x)), C1 + exp(x))
     assert dsolve(eq15, hint='separable') == sol15
     assert dsolve(eq16, hint='separable', simplify=False) == sol16
     assert dsolve(eq17, hint='separable') == sol17

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -516,6 +516,60 @@ def dict_merge(*dicts):
 
     return merged
 
+def common_prefix(*seqs):
+    """Return the subsequence that is a common start of sequences in ``seqs``.
+
+    >>> from sympy.utilities.iterables import common_prefix
+    >>> common_prefix(range(3))
+    [0, 1, 2]
+    >>> common_prefix(range(3), range(4))
+    [0, 1, 2]
+    >>> common_prefix([1, 2, 3], [1, 2, 5])
+    [1, 2]
+    >>> common_prefix([1, 2, 3], [1, 3, 5])
+    [1]
+    """
+    if any(not s for s in seqs):
+        return []
+    elif len(seqs) == 1:
+        return seqs[0]
+    i = 0
+    for i in range(min(len(s) for s in seqs)):
+        if not all(seqs[j][i] == seqs[0][i] for j in xrange(len(seqs))):
+            break
+    else:
+        i += 1
+    return seqs[0][:i]
+
+def common_suffix(*seqs):
+    """Return the subsequence that is a common ending of sequences in ``seqs``.
+
+    >>> from sympy.utilities.iterables import common_suffix
+    >>> common_suffix(range(3))
+    [0, 1, 2]
+    >>> common_suffix(range(3), range(4))
+    []
+    >>> common_suffix([1, 2, 3], [9, 2, 3])
+    [2, 3]
+    >>> common_suffix([1, 2, 3], [9, 7, 3])
+    [3]
+    """
+
+    if any(not s for s in seqs):
+        return []
+    elif len(seqs) == 1:
+        return seqs[0]
+    i = 0
+    for i in range(-1, -min(len(s) for s in seqs) - 1, -1):
+        if not all(seqs[j][i] == seqs[0][i] for j in xrange(len(seqs))):
+            break
+    else:
+        i -= 1
+    if i == -1:
+        return []
+    else:
+        return seqs[0][i + 1:]
+
 def prefixes(seq):
     """
     Generate all prefixes of a sequence.

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -4,7 +4,8 @@ from sympy.utilities.iterables import (postorder_traversal, preorder_traversal,
     dict_merge, prefixes, postfixes, sift, topological_sort, rotate_left,
     rotate_right, multiset_partitions, partitions, binary_partitions,
     generate_bell, generate_involutions, generate_derangements,
-    unrestricted_necklace, generate_oriented_forest, unflatten)
+    unrestricted_necklace, generate_oriented_forest, unflatten,
+    common_prefix, common_suffix)
 
 from sympy.core.singleton import S
 from sympy.functions.elementary.piecewise import Piecewise, ExprCondPair
@@ -324,3 +325,17 @@ def test_unflatten():
     assert unflatten(r, 5) == [tuple(r[:5]), tuple(r[5:])]
     raises(ValueError, "unflatten(range(10), 3)")
     raises(ValueError, "unflatten(range(10), -2)")
+
+def test_common_prefix_suffix():
+    assert common_prefix([], [1]) == []
+    assert common_prefix(range(3)) == [0, 1, 2]
+    assert common_prefix(range(3), range(4)) == [0, 1, 2]
+    assert common_prefix([1, 2, 3], [1, 2, 5]) == [1, 2]
+    assert common_prefix([1, 2, 3], [1, 3, 5]) == [1]
+
+    assert common_suffix([], [1]) == []
+    assert common_suffix(range(3)) == [0, 1, 2]
+    assert common_suffix(range(3), range(3)) == [0, 1, 2]
+    assert common_suffix(range(3), range(4)) == []
+    assert common_suffix([1, 2, 3], [9, 2, 3]) == [2, 3]
+    assert common_suffix([1, 2, 3], [9, 7, 3]) == [3]


### PR DESCRIPTION
Changes basically following those described at http://code.google.com/p/sympy/issues/detail?id=1811 are contained in these commits. In addition, iterable functions common_prefix and common_suffix are added to handle identification of extractable sequences in noncommutative terms and are used in a noncommutative factoring routine.

I've left these as a series of individual commits hoping that this might help in the review process (to keep the individual changes per commit small).

After committing, search issues for this pull request number (e.g. put "422" in the search box to see which might have been related to this issue.)
