### PR TITLE
Fixed test_integers_cache for multiple test runs (#1946)

### DIFF
--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -11,7 +11,7 @@ def test_integers_cache():
     python_int = 2**65 + 3175259
 
     while python_int in _intcache or hash(python_int) in _intcache:
-        value += 1
+        python_int += 1
 
     sympy_int = Integer(python_int)
 


### PR DESCRIPTION
This allows to run `test_integers_cache` multiple times:

<pre>
In [1]: from sympy.utilities.runtests import test

In [2]: test("sympy/core/tests/test_numbers.py")
============================= test process starts ==============================
executable:   /usr/bin/python2.6  (2.6.6-final-0)
ground types: gmpy

sympy/core/tests/test_numbers.py[46] ...........................................
...                                                                         [OK]

================== tests finished: 46 passed, in 0.61 seconds ==================
Out[2]: True

In [3]: test("sympy/core/tests/test_numbers.py")
============================= test process starts ==============================
executable:   /usr/bin/python2.6  (2.6.6-final-0)
ground types: gmpy

sympy/core/tests/test_numbers.py[46] ...........................................
...                                                                         [OK]

================== tests finished: 46 passed, in 0.53 seconds ==================
Out[3]: True
</pre>
