### PR TITLE
fix ordered_iter for python < 2.6

### DIFF
--- a/examples/intermediate/mplot2d.py
+++ b/examples/intermediate/mplot2d.py
@@ -6,6 +6,7 @@ Demonstrates plotting with matplotlib.
 
 from sample import sample
 from sympy import Basic, log, pi, sqrt, sin, Symbol
+from sympy.core.compatibility import ordered_iter
 
 def mplot2d(f, var, show=True):
     """
@@ -20,7 +21,7 @@ def mplot2d(f, var, show=True):
     except ImportError:
         raise ImportError("Matplotlib is required to use mplot2d.")
 
-    if not isinstance(f, (tuple, list)):
+    if not ordered_iter(f):
         f = [f,]
 
     for f_i in f:

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -1,6 +1,7 @@
 """Gosper's algorithm for hypergeometric summation. """
 
 from sympy.core import S, Dummy, symbols
+from sympy.core.compatibility import ordered_iter
 from sympy.polys import Poly, parallel_poly_from_expr, factor
 from sympy.solvers import solve
 from sympy.simplify import hypersimp
@@ -181,7 +182,7 @@ def gosper_sum(f, k):
     """
     indefinite = False
 
-    if isinstance(k, tuple):
+    if ordered_iter(k):
         k, a, b = k
     else:
         indefinite = True

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -1,4 +1,5 @@
 from sympy.core import Expr, S, C, Mul, sympify
+from sympy.core.compatibility import ordered_iter
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp
 
@@ -29,7 +30,7 @@ class Product(Expr):
                 k = symbol.lhs
                 a = symbol.rhs.start
                 n = symbol.rhs.end
-            elif isinstance(symbol, (tuple, list)):
+            elif ordered_iter(symbol):
                 k, a, n = symbol
             else:
                 raise ValueError("Invalid arguments")

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -4,7 +4,7 @@ from assumptions import AssumeMeths, make__get_assumption
 from cache import cacheit
 from core import BasicMeta, BasicType, C
 from sympify import _sympify, sympify, SympifyError
-from compatibility import any
+from compatibility import any, iterable
 from sympy.core.decorators import deprecated
 
 
@@ -548,7 +548,7 @@ class Basic(AssumeMeths):
                                     result.add(expr)
 
                 iter = expr.iter_basic_args()
-            elif isinstance(expr, (tuple, list)):
+            elif iterable(expr):
                 iter = expr.__iter__()
             else:
                 iter = []
@@ -726,7 +726,7 @@ class Basic(AssumeMeths):
             sequence = args[0]
             if isinstance(sequence, dict):
                 return self._subs_dict(sequence)
-            elif hasattr(sequence, '__iter__') or hasattr(sequence, '__getitem__'):
+            elif iterable(sequence):
                 return self._subs_list(sequence)
             else:
                 raise TypeError("Not an iterable container")
@@ -1165,7 +1165,7 @@ class Basic(AssumeMeths):
             if not pattern:
                 return self._eval_rewrite(None, rule, **hints)
             else:
-                if isinstance(pattern[0], (tuple, list)):
+                if iterable(pattern[0]):
                     pattern = pattern[0]
 
                 pattern = [ p.__class__ for p in pattern if self.has(p) ]

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -119,3 +119,73 @@ except ImportError:
                 return True
         return False
 
+def iterable(i, exclude=(str, dict)):
+    """
+    Return a boolean indicating whether i is an iterable in the sympy sense.
+
+    When sympy is working with iterables, it is almost always assuming
+    that the iterable is not a string or a mapping, so those are excluded
+    by default. If you want a pure python definition, make exclude=None. To
+    exclude multiple items, pass them as a tuple.
+
+    See also: ordered_iter
+
+    Examples:
+
+    >>> from sympy.utilities.iterables import iterable
+    >>> from sympy import Tuple
+    >>> things = [[1], (1,), set([1]), Tuple(1), (j for j in [1, 2]), {1:2}, '1', 1]
+    >>> for i in things:
+    ...     print iterable(i), type(i)
+    True <type 'list'>
+    True <type 'tuple'>
+    True <type 'set'>
+    True <class 'sympy.core.containers.Tuple'>
+    True <type 'generator'>
+    False <type 'dict'>
+    False <type 'str'>
+    False <type 'int'>
+
+    >>> iterable({}, exclude=None)
+    True
+    >>> iterable({}, exclude=str)
+    True
+    >>> iterable("no", exclude=str)
+    False
+
+    """
+    try:
+        iter(i)
+    except TypeError:
+        return False
+    if exclude:
+        return not isinstance(i, exclude)
+    return True
+
+def ordered_iter(i, include=None):
+    """
+    Return a boolean indicating whether i is an ordered iterable in the sympy
+    sense. If anything is iterable but doesn't have an index attribute, it
+    can be included in what is considered iterable by using the 'include'
+    keyword. If multiple items are to be included, pass them as a tuple.
+
+    See also: iterable
+
+    Examples:
+
+    >>> from sympy.utilities.iterables import ordered_iter
+    >>> from sympy import Tuple
+    >>> ordered_iter([])
+    True
+    >>> ordered_iter(set())
+    False
+    >>> ordered_iter(Tuple())
+    False
+    >>> ordered_iter(Tuple(), include=Tuple)
+    True
+
+    """
+    return (hasattr(i, '__getitem__') and
+            iterable(i) or
+            bool(include) and
+            isinstance(i, include))

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -179,9 +179,9 @@ def ordered_iter(i, include=None):
     True
     >>> ordered_iter(set())
     False
-    >>> ordered_iter(Tuple())
+    >>> ordered_iter('abc')
     False
-    >>> ordered_iter(Tuple(), include=Tuple)
+    >>> ordered_iter('abc', include=str)
     True
 
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -39,6 +39,7 @@ from numbers import Rational
 from sympy.core.containers import Tuple
 from sympy.core.decorators import deprecated
 from sympy.utilities import all, any, default_sort_key
+from sympy.core.compatibility import iterable
 
 from sympy import mpmath
 
@@ -1293,7 +1294,7 @@ def count_ops(expr, visual=False):
     elif type(expr) is dict:
         ops = [count_ops(k, visual=visual) +
                count_ops(v, visual=visual) for k, v in expr.iteritems()]
-    elif hasattr(expr, '__iter__'):
+    elif iterable(expr):
         ops = [count_ops(i, visual=visual) for i in expr]
     elif not isinstance(expr, Basic):
         ops = []

--- a/sympy/core/logic.py
+++ b/sympy/core/logic.py
@@ -6,6 +6,7 @@ NOTE
 at present this is mainly needed for facts.py , feel free however to improve
 this stuff for general purpose.
 """
+from sympy.core.compatibility import iterable
 
 def fuzzy_bool(x):
     """Return True, False or None according to x.
@@ -22,7 +23,7 @@ def fuzzy_and(*args):
 
     If `a` is an iterable it must have more than one element."""
 
-    if (len(args) == 1 and hasattr(args[0], '__iter__') or
+    if (len(args) == 1 and iterable(args[0]) or
         len(args) > 2):
         if len(args) == 1:
             args = args[0]

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -4,6 +4,7 @@ from types import NoneType
 from inspect import getmro
 
 from core import all_classes as sympy_classes
+from sympy.core.compatibility import iterable
 
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
@@ -107,7 +108,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     if strict:
         raise SympifyError(a)
 
-    if isinstance(a, (list, tuple, set)):
+    if iterable(a):
         return type(a)([sympify(x, locals=locals, convert_xor=convert_xor, rational=rational) for x in a])
 
     # At this point we were given an arbitrary expression

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -55,7 +55,7 @@ def test_subs():
 
     assert b21.subs({b1: b2, b2: b1}) == Basic(b2, b2)
 
-    raises(ValueError, "b21.subs('bad arg')")
+    raises(TypeError, "b21.subs('bad arg')")
     raises(TypeError, "b21.subs(b1, b2, b3)")
 
 def test_atoms():

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,6 +1,7 @@
-from sympy import Tuple, symbols
+from sympy import Matrix, Tuple, symbols
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import all, ordered_iter, iterable
 
 def test_Tuple():
     t = (1, 2, 3, 4)
@@ -57,3 +58,13 @@ def test_tuple_wrapper():
     assert wrap_tuples_and_return(p, 1) == (p, 1)
     assert wrap_tuples_and_return((p, 1)) == (Tuple(p, 1),)
     assert wrap_tuples_and_return(1, (p, 2), 3) == (1, Tuple(p, 2), 3)
+
+def test_iterable_ordered_iter():
+    ordered = [list(), tuple(), Tuple(), Matrix([[]])]
+    unordered = [set()]
+    not_sympy_iterable = [{}, '']
+    assert all(ordered_iter(i) for i in ordered)
+    assert all(not ordered_iter(i) for i in unordered)
+    assert all(iterable(i) for i in ordered + unordered)
+    assert all(not iterable(i) for i in not_sympy_iterable)
+    assert all(iterable(i, exclude=None) for i in not_sympy_iterable)

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -7,6 +7,7 @@ Curve
 """
 
 from sympy.core import sympify, C, Symbol
+from sympy.core.compatibility import ordered_iter
 from sympy.geometry.exceptions import GeometryError
 from sympy.geometry.point import Point
 from entity import GeometryEntity
@@ -54,9 +55,9 @@ class Curve(GeometryEntity):
 
     def __new__(cls, function, limits):
         fun = sympify(function)
-        if not isinstance(fun, (list, tuple)) or len(fun) != 2:
+        if not ordered_iter(fun) or len(fun) != 2:
             raise ValueError("Function argument should be (x(t), y(t)) but got %s" % str(function))
-        if not isinstance(limits, (list, tuple)) or len(limits) != 3:
+        if not ordered_iter(limits) or len(limits) != 3:
             raise ValueError("Limit argument should be (t, tmin, tmax) but got %s" % str(limits))
         return GeometryEntity.__new__(cls, tuple(sympify(fun)), tuple(sympify(limits)))
 

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -7,6 +7,7 @@ Point
 """
 
 from sympy.core import S, sympify
+from sympy.core.compatibility import iterable
 from sympy.simplify import simplify
 from sympy.geometry.exceptions import GeometryError
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -51,7 +52,7 @@ class Point(GeometryEntity):
 
     """
     def __new__(cls, *args, **kwargs):
-        if isinstance(args[0], (tuple, list, set)):
+        if iterable(args[0]):
             coords = tuple([sympify(x) for x in args[0]])
         else:
             coords = tuple([sympify(x) for x in args])

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -2,6 +2,7 @@ from sympy.core import (Basic, Expr, S, C, Symbol, Wild, Add, sympify, diff,
                         oo, Tuple, Dummy, Equality, Interval)
 
 from sympy.core.symbol import Dummy
+from sympy.core.compatibility import ordered_iter
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.deltafunctions import deltaintegrate
 from sympy.integrals.rationaltools import ratint
@@ -54,7 +55,7 @@ def _process_limits(*symbols):
         if isinstance(V, Symbol):
             limits.append(Tuple(V))
             continue
-        elif isinstance(V, (tuple, list, Tuple)):
+        elif ordered_iter(V, Tuple):
             V = sympify(flatten(V))
             if V[0].is_Symbol:
                 newsymbol = V[0]
@@ -868,8 +869,8 @@ def line_integrate(field, curve, vars):
         raise ValueError("Expecting function specifying field as first argument.")
     if not isinstance(curve, Curve):
         raise ValueError("Expecting Curve entity as second argument.")
-    if not isinstance(vars, (list, tuple)):
-        raise ValueError("Expecting list/tuple for variables.")
+    if not ordered_iter(vars):
+        raise ValueError("Expecting ordered iterable for variables.")
     if len(curve.functions) != len(vars):
         raise ValueError("Field variable size does not match curve dimension.")
 

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -17,6 +17,7 @@ import random
 
 from sympy import Mul, Pow, Integer, Matrix, Rational, Tuple, I, sqrt, Add
 from sympy.core.numbers import Number
+from sympy.core.compatibility import ordered_iter
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.utilities.iterables import all
 
@@ -314,7 +315,7 @@ class CGate(Gate):
         # _eval_args has the right logic for the controls argument.
         controls = args[0]
         gate = args[1]
-        if not isinstance(controls, (list, tuple, Tuple)):
+        if not ordered_iter(controls):
             controls = (controls,)
         controls = UnitaryOperator._eval_args(controls)
         _validate_targets_controls(chain(controls,gate.targets))
@@ -442,7 +443,7 @@ class UGate(Gate):
     @classmethod
     def _eval_args(cls, args):
         targets = args[0]
-        if not isinstance(targets, (list, tuple, Tuple)):
+        if not ordered_iter(targets):
             targets = (targets,)
         targets = Gate._eval_args(targets)
         _validate_targets_controls(targets)

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -2,6 +2,7 @@
 from sympy import Expr, sympify, Symbol, Matrix
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.core.containers import Tuple
+from sympy.core.compatibility import ordered_iter
 
 from sympy.physics.quantum.matrixutils import (
     numpy_ndarray, scipy_sparse_matrix,
@@ -54,7 +55,7 @@ def __qsympify_sequence_helper(seq):
        This function does the actual work.
     """
     #base case. If not a list, do Sympification
-    if not isinstance(seq, (list, tuple, Tuple)):
+    if not ordered_iter(seq):
         if isinstance(seq, Matrix):
             return seq
         elif isinstance(seq, basestring):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1,4 +1,5 @@
 from sympy import Integer
+from sympy.core.compatibility import ordered_iter
 
 from threading import RLock
 
@@ -290,7 +291,7 @@ class Plot(object):
         if isinstance(args, PlotObject):
             f = args
         else:
-            if (not isinstance(args, (list, tuple))) or isinstance(args, GeometryEntity):
+            if (not ordered_iter(args)) or isinstance(args, GeometryEntity):
                 args = [args]
             if len(args) == 0:
                 return # no arguments given

--- a/sympy/plotting/plot_axes.py
+++ b/sympy/plotting/plot_axes.py
@@ -6,6 +6,7 @@ from util import strided_range, billboard_matrix
 from util import get_direction_vectors
 from util import dot_product, vec_sub, vec_mag
 from sympy.core import S
+from sympy.core.compatibility import ordered_iter
 
 class PlotAxes(PlotObject):
 
@@ -32,7 +33,7 @@ class PlotAxes(PlotObject):
         stride = kwargs.pop('stride', 0.25)
         try: stride = eval(stride)
         except: pass
-        if isinstance(stride, (list, tuple)):
+        if ordered_iter(stride):
             assert len(stride) == 3
             self._stride = stride
         else:

--- a/sympy/plotting/plot_mode.py
+++ b/sympy/plotting/plot_mode.py
@@ -3,6 +3,7 @@ from plot_interval import PlotInterval
 from plot_object import PlotObject
 from util import parse_option_string
 from sympy.geometry.entity import GeometryEntity
+from sympy.core.compatibility import ordered_iter
 
 class PlotMode(PlotObject):
     """
@@ -362,7 +363,7 @@ class PlotMode(PlotObject):
                     else:
                         intervals.append(i)
                 else:
-                    if isinstance(a, (str, list, tuple)):
+                    if ordered_iter(a, include=str):
                         raise ValueError(interpret_error % (str(a)))
                     try:
                         f = sympify(a)

--- a/sympy/plotting/plot_mode_base.py
+++ b/sympy/plotting/plot_mode_base.py
@@ -3,6 +3,7 @@ from plot_mode import PlotMode
 from threading import Thread, Event, RLock
 from color_scheme import ColorScheme
 from sympy.core import S
+from sympy.core.compatibility import ordered_iter
 from time import sleep
 
 class PlotModeBase(PlotMode):
@@ -323,7 +324,7 @@ class PlotModeBase(PlotMode):
     def _set_color(self, v):
         try:
             if v is not None:
-                if isinstance(v, (list, tuple)):
+                if ordered_iter(v):
                     v = ColorScheme(*v)
                 else: v = ColorScheme(v)
             if repr(v) == repr(self._color): return

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4,6 +4,7 @@ from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     Derivative, Wild, Symbol, sympify, expand, expand_mul, expand_func,
     Function, Equality, Dummy, Atom, count_ops)
 
+from sympy.core.compatibility import iterable
 from sympy.core.numbers import igcd
 from sympy.core.function import expand_log
 from sympy.core.compatibility import minkey
@@ -916,7 +917,7 @@ def posify(eq):
     ([_x, _x + 1], {_x: x})
     """
     eq = sympify(eq)
-    if type(eq) in (list, set, tuple):
+    if iterable(eq):
         f = type(eq)
         eq = list(eq)
         syms = set()

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -202,7 +202,7 @@ anything is broken, one of those tests will surely fail.
 
 """
 from sympy.core import Add, Basic, C, S, Mul, Pow, oo
-from sympy.core.compatibility import any, all, minkey
+from sympy.core.compatibility import any, all, minkey, iterable
 from sympy.core.function import Derivative, diff, expand_mul
 from sympy.core.multidimensional import vectorize
 from sympy.core.relational import Equality, Eq
@@ -1191,7 +1191,7 @@ def ode_sol_simplicity(sol, func, trysolving=True):
     # See the docstring for the coercion rules.  We check easier (faster)
     # things here first, to save time.
 
-    if type(sol) in (list, tuple):
+    if iterable(sol):
         # See if there are Integrals
         for i in sol:
             if ode_sol_simplicity(i, func, trysolving=trysolving) == oo:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -13,6 +13,7 @@
 
 """
 
+from sympy.core.compatibility import iterable
 from sympy.core.sympify import sympify
 from sympy.core import S, Mul, Add, Pow, Symbol, Wild, Equality, Dummy, Basic
 from sympy.core.numbers import ilcm
@@ -291,7 +292,7 @@ def _solve(f, *symbols, **flags):
     # make f and symbols into lists of sympified quantities
     # keeping track of how f was passed since if it is a list
     # a dictionary of results will be returned.
-    bare_f = not isinstance(f, (list, tuple, set))
+    bare_f = not iterable(f)
     f, symbols = (sympified_list(w) for w in [f, symbols])
 
     for i, fi in enumerate(f):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -106,6 +106,7 @@
 #      - Idx with step determined by function call
 
 from sympy.core import Expr, Basic, Tuple, Symbol, Integer, sympify, S
+from sympy.core.compatibility import ordered_iter
 
 class IndexException(Exception):
     pass
@@ -168,7 +169,7 @@ class IndexedBase(Expr):
             label = Symbol(label)
 
         obj = Expr.__new__(cls, label, **kw_args)
-        if isinstance(shape, (tuple, list)):
+        if ordered_iter(shape):
             obj._shape = Tuple(*shape)
         else:
             obj._shape = shape
@@ -185,7 +186,7 @@ class IndexedBase(Expr):
         return Expr._hashable_content(self) + (self._shape,)
 
     def __getitem__(self, indices, **kw_args):
-        if isinstance(indices, (tuple, list, Tuple)):
+        if ordered_iter(indices):
             # Special case needed because M[*my_tuple] is a syntax error.
             if self.shape and len(self.shape) != len(indices):
                 raise IndexException("Rank mismatch")
@@ -373,7 +374,7 @@ class Idx(Expr):
         if not label.is_integer:
             raise TypeError("Idx object requires an integer label")
 
-        elif isinstance(range, (tuple, list, Tuple)):
+        elif ordered_iter(range):
             assert len(range) == 2, "Idx got range tuple with wrong length"
             for bound in range:
                 if not (bound.is_integer or abs(bound) is S.Infinity):
@@ -384,7 +385,7 @@ class Idx(Expr):
                 raise TypeError("Idx object requires an integer dimension")
             args = label, Tuple(S.Zero, range-S.One)
         elif range:
-            raise TypeError("range must be  tuple or integer sympy expression")
+            raise TypeError("range must be ordered iterable or integer sympy expression")
         else:
             args = label,
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -77,6 +77,7 @@ from StringIO import StringIO
 
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function
+from sympy.core.compatibility import ordered_iter
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
 from sympy.printing.fcode import fcode, FCodePrinter
@@ -138,7 +139,7 @@ class Routine(object):
         """
         arg_list = []
 
-        if isinstance(expr, (list, tuple)):
+        if ordered_iter(expr):
             if not expr:
                 raise ValueError("No expression given")
             expressions = Tuple(*expr)

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,5 +1,6 @@
 from sympy.core import Basic, C
 from sympy.core.compatibility import minkey, iff, all, any #for backwards compatibility
+from sympy.core.compatibility import ordered_iter, iterable #logically, they belong here
 
 import random
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -5,6 +5,7 @@ lambda functions which can be used to calculate numerical values very fast.
 
 from __future__ import division
 from sympy.core.sympify import sympify
+from sympy.core.compatibility import ordered_iter
 
 import inspect
 
@@ -308,7 +309,7 @@ def _imp_namespace(expr, namespace=None):
     if namespace is None:
         namespace = {}
     # tuples, lists, dicts are valid expressions
-    if isinstance(expr, (list, tuple)):
+    if ordered_iter(expr):
         for arg in expr:
             _imp_namespace(arg, namespace)
         return namespace


### PR DESCRIPTION
I couldn't find the reopen for 363 so I made a new pull request.
