### PR TITLE
Fix trivial mistake in test_ode.

### DIFF
--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -146,6 +146,7 @@ def test_classify_ode():
         ('Bernoulli', 'Bernoulli_Integral')
     raises(ValueError, "classify_ode(x + f(x, y).diff(x).diff(y), f(x, y))")
     # 2077
+    k = Symbol('k')
     assert classify_ode(f(x).diff(x)/(k*f(x) + k*x*f(x)) +
                  2*f(x)/(k*f(x) + k*x*f(x)) +
                  x*f(x).diff(x)/(k*f(x) + k*x*f(x))


### PR DESCRIPTION
Commit f1ca3763716e909ceb12 introduced a test that has an undefined variable k, so test_ode is broken in master now.
