### PR TITLE
Spin x/y/z bases representation

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -7,16 +7,20 @@ TODO:
 * Implement rewrite logic for everything.
 * Test
 """
-from sympy import I, Symbol, S, Integer, Rational, Matrix, sqrt, sympify
-from sympy import exp, cos, sin, diff, factorial
-from sympy.printing.pretty.stringpict import prettyForm, stringPict
-from sympy.matrices.matrices import zeros
 
+from sympy import (
+        binomial, cos, diff, exp, factorial, I, Integer, Matrix, N, pi,
+        Rational, S, sin, sqrt, Symbol, sympify, simplify
+)
+from sympy.matrices.matrices import zeros
+from sympy.printing.pretty.stringpict import prettyForm, stringPict
+
+from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.operator import (
     HermitianOperator, Operator, UnitaryOperator
 )
-from sympy.physics.quantum.state import State, Ket, Bra
+from sympy.physics.quantum.state import Bra, Ket, State
 from sympy.physics.quantum.kronecker import KroneckerDelta
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.hilbert import ComplexSpace
@@ -299,7 +303,53 @@ class J2Op(SpinOpBase, HermitianOperator):
 
 
 class Rotation(UnitaryOperator):
-    """Wigner D operator in terms of Euler angles."""
+    """Wigner D operator in terms of Euler angles.
+
+    Defines the rotation operator in terms of the Euler angles defined by
+    the z-y-z convention for a passive transformation. That is the coordinate
+    axes are rotated first about the z-axis, giving the new x'-y'-z' axes. Then
+    this new coordinate system is rotated about the new y'-axis, giving new
+    x''-y''-z'' axes. Then this new coordinate system is rotated about the
+    z''-axis. Conventions follow those laid out in [1].
+
+    See the Wigner D-function, Rotation.D, and the Wigner small-d matrix for
+    the evaluation of the rotation operator on spin states.
+
+    Parameters
+    ==========
+
+    alpha : Number, Symbol
+        First Euler Angle
+    beta : Number, Symbol
+        Second Euler angle
+    gamma : Number, Symbol
+        Third Euler angle
+
+    Examples
+    ========
+
+    A simple example rotation operator:
+
+        >>> from sympy import pi
+        >>> from sympy.physics.quantum.spin import Rotation
+        >>> Rotation(pi, 0, pi/2)
+        'R'(pi,0,pi/2)
+
+    With symbolic Euler angles and calculating the inverse rotation operator:
+
+        >>> from sympy import symbols
+        >>> a, b, c = symbols('a b c')
+        >>> Rotation(a, b, c)
+        'R'(a,b,c)
+        >>> Rotation(a, b, c).inverse()
+        'R'(-c,-b,-a)
+
+
+    References
+    ==========
+
+    [1] Varshalovich, D A, Quantum Theory of Angular Momentum. 1988.
+    """
 
     @classmethod
     def _eval_args(cls, args):
@@ -332,43 +382,131 @@ class Rotation(UnitaryOperator):
         return prettyForm(u"\u211B" + u" ")
 
     def _eval_inverse(self):
-        return Rotation((-self.gamma, -self.beta, -self.alpha))
+        return Rotation(-self.gamma, -self.beta, -self.alpha)
 
     @classmethod
     def D(cls, j, m, mp, alpha, beta, gamma):
-        """Wigner-D function."""
+        """Wigner D-function.
+
+        The Wigner D-function gives the matrix elements of the rotation
+        operator in the jm-representation. For the Euler angles alpha, beta,
+        gamma, the the D-function is defined such that:
+        <j,m| R(alpha,beta,gamma) |j',m'> = delta_jj' * D(j, m, m', alpha, beta, gamma)
+        Where the rotation operator is as defined by the Rotation class.
+
+        The Wigner D-function defined in this way gives:
+        D(j, m, m', alpha, beta, gamma) = exp(-i*m*alpha) * d(j, m, m', beta) * exp(-i*m'*gamma)
+        Where d is the Wigner small-d function, which is given by Rotation.d.
+
+        Note that to evaluate the D-function, the j, m and mp parameters must
+        be integer or half integer numbers.
+
+        Parameters
+        ==========
+
+        j : Number
+            Total angular momentum
+        m : Number
+            Eigenvalue of angular momentum along axis after rotation
+        mp : Number
+            Eigenvalue of angular momentum along rotated axis
+        alpha : Number, Symbol
+            First Euler angle of rotation
+        beta : Number, Symbol
+            Second Euler angle of rotation
+        gamma : Number, Symbol
+            Third Euler angle of rotation
+
+        Examples
+        ========
+
+        Evaluate the matrix elements of a simple rotation:
+
+            >>> from sympy.physics.quantum.spin import Rotation
+            >>> from sympy import pi
+            >>> Rotation.D(1, 1, 0, pi, pi/2, 0)
+            2**(1/2)/2
+
+        References
+        ==========
+
+        [1] Varshalovich, D A, Quantum Theory of Angular Momentum. 1988.
+        """
         result = exp(-I*m*alpha)*exp(-I*mp*gamma)
         result *= cls.d(j, m, mp, beta)
         return result
 
     @classmethod
     def d(cls, j, m, mp, beta):
-        """Wigner's lowercase d function."""
-        # TODO: This does not do a good job of simplifying the trig functions.
-        # The Jacobi Polynomial expansion is probably best as it is a simple
-        # sum. But, this version does give correct answers and uses
-        # Eq. 7 in Section 4.3.2 of Varshalovich.
+        """Wigner small-d function.
+
+        The Wigner small-d function gives the component of the Wigner
+        D-function that is determined by the second Euler angle. That is the
+        Wigner D-function is:
+        D(j, m, m', alpha, beta, gamma) = exp(-i*m*alpha) * d(j, m, m', beta) * exp(-i*m'*gamma)
+        Where d is the small-d function. The Wigner D-function is given by
+        Rotation.D.
+
+        Parameters
+        ==========
+
+        j : Number
+            Total angular momentum
+        m : Number
+            Eigenvalue of angular momentum along axis after rotation
+        mp : Number
+            Eigenvalue of angular momentum along rotated axis
+        beta : Number, Symbol
+            Second Euler angle of rotation
+
+        Examples
+        ========
+
+        Evaluate the matrix elements of a simple rotation
+
+            >>> from sympy.physics.quantum.spin import Rotation
+            >>> from sympy import pi
+            >>> Rotation.d(1, 1, 0, pi/2)
+            -2**(1/2)/2
+
+        References
+        ==========
+
+        [1] Varshalovich, D A, Quantum Theory of Angular Momentum. 1988.
+        """
         j = sympify(j)
-        cosbeta = Symbol('cosbeta')
-        x = 1-cosbeta
-        y = 1+cosbeta
-        jmmp = j-mp
-        jpm = j+m
-        jpmp = j+mp
-        jmm = j-m
-        mpmm2 = (mp-m)//2
-        mpmp2 = (m+mp)//2
-        result = (-1)**jmmp
-        result *= 2**(-j)
-        result *= sqrt(factorial(jpm)/(factorial(jmm)*factorial(jpmp)*factorial(jmmp)))
-        result *= (x**mpmm2)*(y**(-mpmp2))
-        result *= diff((x**jmmp)*(y**jpmp), cosbeta, jmm)
-        if (2*j).is_Integer and not j.is_Integer:
-            result = result.subs(1+cosbeta, 2*cos(beta/2)**2)
-            result = result.subs(1-cosbeta, 2*sin(beta/2)**2)
+        m = sympify(m)
+        mp = sympify(mp)
+        beta = sympify(beta)
+        r = 0
+        if beta == pi/2:
+            # Varshalovich Equation (5), Section 4.16, page 113, setting
+            # alpha=gamma=0.
+            for k in range(2*j+1):
+                if k > j+mp or k > j-m or k < mp-m:
+                    continue
+                r += (-S(1))**k * binomial(j+mp, k) * binomial(j-mp, k+m-mp)
+            r *= (-S(1))**(m-mp) / 2**j * sqrt(factorial(j+m) * \
+                    factorial(j-m) / (factorial(j+mp) * factorial(j-mp)))
         else:
-            result = result.subs(cosbeta, cos(beta))
-        return result
+            # Varshalovich Equation(5), Section 4.7.2, page 87, where we set
+            # beta1=beta2=pi/2, and we get alpha=gamma=pi/2 and beta=phi+pi,
+            # then we use the Eq. (1), Section 4.4. page 79, to simplify:
+            # d(j, m, mp, beta+pi) = (-1)**(j-mp) * d(j, m, -mp, beta)
+            # This happens to be almost the same as in Eq.(10), Section 4.16,
+            # except that we need to substitute -mp for mp.
+            size, mvals = m_values(j)
+            for mpp in mvals:
+                r += Rotation.d(j, m, mpp, pi/2) * (cos(-mpp*beta)+I*sin(-mpp*beta)) * \
+                    Rotation.d(j, mpp, -mp, pi/2)
+            # Empirical normalization factor so results match Varshalovich
+            # Tables 4.3-4.12
+            # Note that this exact normalization does not follow from the
+            # above equations
+            r = r * I**(2*j-m-mp) * (-1)**(2*m)
+            # Finally, simplify the whole expression
+            r = simplify(r)
+        return r
 
     def matrix_element(self, j, m, jp, mp):
         result = self.__class__.D(
@@ -424,14 +562,187 @@ class SpinState(State):
     def _eval_hilbert_space(cls, label):
         return ComplexSpace(2*label[0]+1)
 
+    def _represent_base(self, **options):
+        j = self.j
+        alpha = options.get('alpha', 0)
+        beta = options.get('beta', 0)
+        gamma = options.get('gamma', 0)
+        size, mvals = m_values(j)
+        result = zeros((size,1))
+        for p in range(size):
+            result[p,0] = Rotation.D(self.j, mvals[p], self.m, alpha, beta, gamma)
+        return result
 
-class JzKet(SpinState, Ket):
-    """Eigenket of Jz."""
+    def _eval_rewrite_as_Jx(self, *args):
+        if isinstance(self,Bra):
+            return self._rewrite_basis(Jx, JxBra, *args)
+        return self._rewrite_basis(Jx, JxKet, *args)
+
+    def _eval_rewrite_as_Jy(self, *args):
+        if isinstance(self,Bra):
+            return self._rewrite_basis(Jy, JyBra, *args)
+        return self._rewrite_basis(Jy, JyKet, *args)
+
+    def _eval_rewrite_as_Jz(self, *args):
+        return self._rewrite_basis(Jz, JzKet, *args)
+
+    def _rewrite_basis(self, basis, evect_cls, *args):
+        j = self.j
+        size, mvals = m_values(j)
+        result = 0
+        vect = represent(self, basis=basis)
+        for p in range(size):
+            me = vect[p]
+            me *= evect_cls.__new__(evect_cls, j, mvals[p])
+            result += me
+        return result
+
+    def _eval_innerproduct_JxBra(self, bra, **hints):
+        result = KroneckerDelta(self.j, bra.j)
+        if not isinstance(bra, self.__class__):
+            result *= self._represent_JxOp(None)[bra.j-bra.m]
+        else:
+            result *= KroneckerDelta(self.m, bra.m)
+        return result
+
+    def _eval_innerproduct_JyBra(self, bra, **hints):
+        result = KroneckerDelta(self.j, bra.j)
+        if not isinstance(bra, self.__class__):
+            result *= self._represent_JyOp(None)[bra.j-bra.m]
+        else:
+            result *= KroneckerDelta(self.m, bra.m)
+        return result
 
     def _eval_innerproduct_JzBra(self, bra, **hints):
-        d1 = KroneckerDelta(self.j, bra.j)
-        d2 = KroneckerDelta(self.m, bra.m)
-        return d1*d2
+        result = KroneckerDelta(self.j, bra.j)
+        if not issubclass(bra.dual_class, self.__class__):
+            result *= self._represent_JzOp(None)[bra.j-bra.m]
+        else:
+            result *= KroneckerDelta(self.m, bra.m)
+        return result
+
+
+class JxKet(SpinState, Ket):
+    """Eigenket of Jx.
+
+    See JzKet for the usage of spin eigenstates.
+    """
+
+    @property
+    def dual_class(self):
+        return JxBra
+
+    def _represent_default_basis(self, **options):
+        return self._represent_JzOp(None, **options)
+
+    def _represent_JxOp(self, basis, **options):
+        return self._represent_base()
+
+    def _represent_JyOp(self, basis, **options):
+        return self._represent_base(alpha=3*pi/2)
+
+    def _represent_JzOp(self, basis, **options):
+        return self._represent_base(beta=pi/2)
+
+
+class JxBra(SpinState, Bra):
+    """Eigenbra of Jx.
+
+    See JzKet for the usage of spin eigenstates.
+    """
+
+    @property
+    def dual_class(self):
+        return JxKet
+
+
+class JyKet(SpinState, Ket):
+    """Eigenket of Jy.
+
+    See JzKet for the usage of spin eigenstates.
+    """
+
+    @property
+    def dual_class(self):
+        return JyBra
+
+    def _represent_default_basis(self, **options):
+        return self._represent_JzOp(None, **options)
+
+    def _represent_JxOp(self, basis, **options):
+        return self._represent_base(gamma=pi/2)
+
+    def _represent_JyOp(self, basis, **options):
+        return self._represent_base()
+
+    def _represent_JzOp(self, basis, **options):
+        return self._represent_base(alpha=3*pi/2,beta=-pi/2,gamma=pi/2)
+
+
+class JyBra(SpinState, Bra):
+    """Eigenbra of Jy.
+
+    See JzKet for the usage of spin eigenstates.
+    """
+
+    @property
+    def dual_class(self):
+        return JyKet
+
+
+class JzKet(SpinState, Ket):
+    """Eigenket of Jz.
+
+    Spin state which is an eigenstate of the Jz operator
+
+    Parameters
+    ==========
+
+    j : Number, Symbol
+        Total spin angular momentum
+    m : Number, Symbol
+        Eigenvalue of the Jz spin operator
+
+    Examples
+    ========
+
+    Defining simple spin states, both numerical and symbolic:
+
+        >>> from sympy.physics.quantum.spin import JzKet
+        >>> from sympy import symbols
+        >>> JzKet(1, 0)
+        |1,0>
+        >>> j, m = symbols('j m')
+        >>> JzKet(j, m)
+        |j,m>
+
+    Rewriting the JzKet in terms of eigenkets of the Jx operator:
+    Note: that the resulting eigenstates are JxKet's
+
+        >>> JzKet(1,1).rewrite("Jx")
+        |1,-1>/2 - 2**(1/2)*|1,0>/2 + |1,1>/2
+
+    Get the vector representation of a state in terms of the basis elements
+    of the Jx operator:
+
+        >>> from sympy.physics.quantum.represent import represent
+        >>> from sympy.physics.quantum.spin import Jx
+        >>> represent(JzKet(1,-1), basis=Jx)
+        [       1/2]
+        [2**(1/2)/2]
+        [       1/2]
+
+    Apply innerproducts between states:
+
+        >>> from sympy.physics.quantum.innerproduct import InnerProduct
+        >>> from sympy.physics.quantum.spin import JxBra
+        >>> i = InnerProduct(JxBra(1,1), JzKet(1,1))
+        >>> i
+        <1,1|1,1>
+        >>> i.doit()
+        1/2
+
+    """
 
     @property
     def dual_class(self):
@@ -440,79 +751,22 @@ class JzKet(SpinState, Ket):
     def _represent_default_basis(self, **options):
         return self._represent_JzOp(None, **options)
 
+    def _represent_JxOp(self, basis, **options):
+        return self._represent_base(beta=3*pi/2)
+
+    def _represent_JyOp(self, basis, **options):
+        return self._represent_base(alpha=3*pi/2,beta=pi/2,gamma=pi/2)
+
     def _represent_JzOp(self, basis, **options):
-        if self.j == Rational(1,2):
-            if self.m == Rational(1,2):
-                return Matrix([1,0])
-            elif self.m == -Rational(1,2):
-                return Matrix([0,1])
+        return self._represent_base()
 
 
 class JzBra(SpinState, Bra):
-    """Eigenbra of Jz."""
+    """Eigenbra of Jz.
+
+    See the JzKet for the usage of spin eigenstates.
+    """
 
     @property
     def dual_class(self):
         return JzKet
-
-
-class JxKet(SpinState, Ket):
-    """Eigenket of Jx."""
-
-    @property
-    def dual_class(self):
-        return JxBra
-
-    def _eval_innerproduct_JxBra(self, bra, **hints):
-        d1 = KroneckerDelta(self.j, bra.j)
-        d2 = KroneckerDelta(self.m, bra.m)
-        return d1*d2
-
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
-
-    def _represent_JzOp(self, basis, **options):
-        if self.j == Rational(1,2):
-            if self.m == Rational(1,2):
-                return Matrix([1,1])/sqrt(2)
-            elif self.m == -Rational(1,2):
-                return Matrix([1,-1])/sqrt(2)
-
-
-class JxBra(SpinState, Bra):
-    """Eigenbra of Jx."""
-
-    @property
-    def dual_class(self):
-        return JxKet
-
-
-class JyKet(SpinState, Ket):
-    """Eigenket of Jy."""
-
-    @property
-    def dual_class(self):
-        return JyBra
-
-    def _eval_innerproduct_JyBar(self, bra, **hints):
-        d1 = KroneckerDelta(self.s, bra.s)
-        d2 = KroneckerDelta(self.ms, bra.ms)
-        return d1*d2
-
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
-
-    def _represent_JzOp(self, basis, **options):
-        if self.j == Rational(1,2):
-            if self.m == Rational(1,2):
-                return Matrix([1,I])/sqrt(2)
-            elif self.m == -Rational(1,2):
-                return Matrix([1,-I])/sqrt(2)
-
-
-class JyBra(SpinState, Bra):
-    """Eigenbra of Jy."""
-
-    @property
-    def dual_class(self):
-        return JyKet

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -1,14 +1,405 @@
-from sympy import I, Matrix, symbols
+from __future__ import division
+from sympy import cos, exp, I, Matrix, pi, S, sin, sqrt, symbols
 
-from sympy.physics.quantum import hbar, represent, Commutator
+from sympy.physics.quantum import hbar, represent, Commutator, InnerProduct
 from sympy.physics.quantum import qapply
-from sympy.physics.quantum.spin import (J2, Rotation, Jplus, JzKet, Jminus,
-        Jx, Jy, Jz)
+from sympy.physics.quantum.spin import (
+    Rotation, Jx, Jy, Jz, Jplus, Jminus, J2,
+    JxBra, JyBra, JzBra,
+    JxKet, JyKet, JzKet
+)
+
+from sympy.utilities.pytest import XFAIL
 
 
 def test_represent():
+    # Spin operators
+    assert represent(Jx) == hbar*Matrix([[0,1],[1,0]])/2
+    assert represent(Jx, j=1) == hbar*sqrt(2)*Matrix([[0,1,0],[1,0,1],[0,1,0]])/2
+    assert represent(Jy) == hbar*I*Matrix([[0,-1],[1,0]])/2
+    assert represent(Jy, j=1) == hbar*I*sqrt(2)*Matrix([[0,-1,0],[1,0,-1],[0,1,0]])/2
     assert represent(Jz) == hbar*Matrix([[1,0],[0,-1]])/2
     assert represent(Jz, j=1) == hbar*Matrix([[1,0,0],[0,0,0],[0,0,-1]])
+    # Spin states
+    # Jx basis
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jx) == Matrix([1,0])
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jx) == Matrix([0,1])
+    assert represent(JxKet(1,1), basis=Jx) == Matrix([1,0,0])
+    assert represent(JxKet(1,0), basis=Jx) == Matrix([0,1,0])
+    assert represent(JxKet(1,-1), basis=Jx) == Matrix([0,0,1])
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jx) == Matrix([exp(-I*pi/4),0])
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jx) == Matrix([0,exp(I*pi/4)])
+    assert represent(JyKet(1,1), basis=Jx) == Matrix([-I,0,0])
+    assert represent(JyKet(1,0), basis=Jx) == Matrix([0,1,0])
+    assert represent(JyKet(1,-1), basis=Jx) == Matrix([0,0,I])
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jx) == sqrt(2)*Matrix([-1,1])/2
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jx) == sqrt(2)*Matrix([-1,-1])/2
+    assert represent(JzKet(1,1), basis=Jx) == Matrix([1,-sqrt(2),1])/2
+    assert represent(JzKet(1,0), basis=Jx) == sqrt(2)*Matrix([1,0,-1])/2
+    assert represent(JzKet(1,-1), basis=Jx) == Matrix([1,sqrt(2),1])/2
+    # Jy basis
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jy) == Matrix([exp(-3*I*pi/4),0])
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jy) == Matrix([0,exp(3*I*pi/4)])
+    assert represent(JxKet(1,1), basis=Jy) == Matrix([I,0,0])
+    assert represent(JxKet(1,0), basis=Jy) == Matrix([0,1,0])
+    assert represent(JxKet(1,-1), basis=Jy) == Matrix([0,0,-I])
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jy) == Matrix([1,0])
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jy) == Matrix([0,1])
+    assert represent(JyKet(1,1), basis=Jy) == Matrix([1,0,0])
+    assert represent(JyKet(1,0), basis=Jy) == Matrix([0,1,0])
+    assert represent(JyKet(1,-1), basis=Jy) == Matrix([0,0,1])
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jy) == sqrt(2)*Matrix([-1,I])/2
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jy) == sqrt(2)*Matrix([I,-1])/2
+    assert represent(JzKet(1,1), basis=Jy) == Matrix([1,-I*sqrt(2),-1])/2
+    assert represent(JzKet(1,0), basis=Jy) == Matrix([-sqrt(2)*I,0,-sqrt(2)*I])/2
+    assert represent(JzKet(1,-1), basis=Jy) == Matrix([-1,-sqrt(2)*I,1])/2
+    # Jz basis
+    assert represent(JxKet(S(1)/2,S(1)/2)) == sqrt(2)*Matrix([1,1])/2
+    assert represent(JxKet(S(1)/2,-S(1)/2)) == sqrt(2)*Matrix([-1,1])/2
+    assert represent(JxKet(1,1)) == Matrix([1,sqrt(2),1])/2
+    assert represent(JxKet(1,0)) == sqrt(2)*Matrix([-1,0,1])/2
+    assert represent(JxKet(1,-1)) == Matrix([1,-sqrt(2),1])/2
+    assert represent(JyKet(S(1)/2,S(1)/2)) == sqrt(2)*Matrix([-1,-I])/2
+    assert represent(JyKet(S(1)/2,-S(1)/2)) == sqrt(2)*Matrix([-I,-1])/2
+    assert represent(JyKet(1,1)) == Matrix([1,sqrt(2)*I,-1])/2
+    assert represent(JyKet(1,0)) == sqrt(2)*Matrix([I,0,I])/2
+    assert represent(JyKet(1,-1)) == Matrix([-1,sqrt(2)*I,1])/2
+    assert represent(JzKet(S(1)/2,S(1)/2)) == Matrix([1,0])
+    assert represent(JzKet(S(1)/2,-S(1)/2)) == Matrix([0,1])
+    assert represent(JzKet(1,1)) == Matrix([1,0,0])
+    assert represent(JzKet(1,0)) == Matrix([0,1,0])
+    assert represent(JzKet(1,-1)) == Matrix([0,0,1])
+
+def test_rewrite():
+    # Rewrite to same basis
+    assert JxBra(1,1).rewrite('Jx') == JxBra(1,1)
+    assert JxKet(1,1).rewrite('Jx') == JxKet(1,1)
+    # Rewriting to different basis
+    assert JxKet(1,1).rewrite('Jy') == I*JyKet(1,1)
+    assert JxKet(1,0).rewrite('Jy') == JyKet(1,0)
+    assert JxKet(1,-1).rewrite('Jy') == -I*JyKet(1,-1)
+    assert JxKet(1,1).rewrite('Jz') == JzKet(1,1)/2+JzKet(1,0)/sqrt(2)+JzKet(1,-1)/2
+    assert JxKet(1,0).rewrite('Jz') == -sqrt(2)*JzKet(1,1)/2+sqrt(2)*JzKet(1,-1)/2
+    assert JxKet(1,-1).rewrite('Jz') == JzKet(1,1)/2-JzKet(1,0)/sqrt(2)+JzKet(1,-1)/2
+    assert JyKet(1,1).rewrite('Jx') == -I*JxKet(1,1)
+    assert JyKet(1,0).rewrite('Jx') == JxKet(1,0)
+    assert JyKet(1,-1).rewrite('Jx') == I*JxKet(1,-1)
+    assert JyKet(1,1).rewrite('Jz') == JzKet(1,1)/2+sqrt(2)*I*JzKet(1,0)/2-JzKet(1,-1)/2
+    assert JyKet(1,0).rewrite('Jz') == sqrt(2)*I*JzKet(1,1)/2+sqrt(2)*I*JzKet(1,-1)/2
+    assert JyKet(1,-1).rewrite('Jz') == -JzKet(1,1)/2+sqrt(2)*I*JzKet(1,0)/2+JzKet(1,-1)/2
+    assert JzKet(1,1).rewrite('Jx') == JxKet(1,1)/2-sqrt(2)*JxKet(1,0)/2+JxKet(1,-1)/2
+    assert JzKet(1,0).rewrite('Jx') == sqrt(2)*JxKet(1,1)/2-sqrt(2)*JxKet(1,-1)/2
+    assert JzKet(1,-1).rewrite('Jx') == JxKet(1,1)/2+sqrt(2)*JxKet(1,0)/2+JxKet(1,-1)/2
+    assert JzKet(1,1).rewrite('Jy') == JyKet(1,1)/2-sqrt(2)*I*JyKet(1,0)/2-JyKet(1,-1)/2
+    assert JzKet(1,0).rewrite('Jy') == -sqrt(2)*I*JyKet(1,1)/2-sqrt(2)*I*JyKet(1,-1)/2
+    assert JzKet(1,-1).rewrite('Jy') == -JyKet(1,1)/2-sqrt(2)*I*JyKet(1,0)/2+JyKet(1,-1)/2
+    # Innerproducts of rewritten states
+    assert qapply(JxBra(1,1)*JxKet(1,1).rewrite('Jy')).doit() == 1
+    assert qapply(JxBra(1,0)*JxKet(1,0).rewrite('Jy')).doit() == 1
+    assert qapply(JxBra(1,-1)*JxKet(1,-1).rewrite('Jy')).doit() == 1
+    assert qapply(JxBra(1,1)*JxKet(1,1).rewrite('Jz')).doit() == 1
+    assert qapply(JxBra(1,0)*JxKet(1,0).rewrite('Jz')).doit() == 1
+    assert qapply(JxBra(1,-1)*JxKet(1,-1).rewrite('Jz')).doit() == 1
+    assert qapply(JyBra(1,1)*JyKet(1,1).rewrite('Jx')).doit() == 1
+    assert qapply(JyBra(1,0)*JyKet(1,0).rewrite('Jx')).doit() == 1
+    assert qapply(JyBra(1,-1)*JyKet(1,-1).rewrite('Jx')).doit() == 1
+    assert qapply(JyBra(1,1)*JyKet(1,1).rewrite('Jz')).doit() == 1
+    assert qapply(JyBra(1,0)*JyKet(1,0).rewrite('Jz')).doit() == 1
+    assert qapply(JyBra(1,-1)*JyKet(1,-1).rewrite('Jz')).doit() == 1
+    assert qapply(JyBra(1,1)*JyKet(1,1).rewrite('Jz')).doit() == 1
+    assert qapply(JyBra(1,0)*JyKet(1,0).rewrite('Jz')).doit() == 1
+    assert qapply(JyBra(1,-1)*JyKet(1,-1).rewrite('Jz')).doit() == 1
+    assert qapply(JzBra(1,1)*JzKet(1,1).rewrite('Jy')).doit() == 1
+    assert qapply(JzBra(1,0)*JzKet(1,0).rewrite('Jy')).doit() == 1
+    assert qapply(JzBra(1,-1)*JzKet(1,-1).rewrite('Jy')).doit() == 1
+    assert qapply(JxBra(1,1)*JxKet(1,0).rewrite('Jy')).doit() == 0
+    assert qapply(JxBra(1,1)*JxKet(1,-1).rewrite('Jy')) == 0
+    assert qapply(JxBra(1,1)*JxKet(1,0).rewrite('Jz')).doit() == 0
+    assert qapply(JxBra(1,1)*JxKet(1,-1).rewrite('Jz')) == 0
+    assert qapply(JyBra(1,1)*JyKet(1,0).rewrite('Jx')).doit() == 0
+    assert qapply(JyBra(1,1)*JyKet(1,-1).rewrite('Jx')) == 0
+    assert qapply(JyBra(1,1)*JyKet(1,0).rewrite('Jz')).doit() == 0
+    assert qapply(JyBra(1,1)*JyKet(1,-1).rewrite('Jz')) == 0
+    assert qapply(JzBra(1,1)*JzKet(1,0).rewrite('Jx')).doit() == 0
+    assert qapply(JzBra(1,1)*JzKet(1,-1).rewrite('Jx')) == 0
+    assert qapply(JzBra(1,1)*JzKet(1,0).rewrite('Jy')).doit() == 0
+    assert qapply(JzBra(1,1)*JzKet(1,-1).rewrite('Jy')) == 0
+    assert qapply(JxBra(1,0)*JxKet(1,1).rewrite('Jy')) == 0
+    assert qapply(JxBra(1,0)*JxKet(1,-1).rewrite('Jy')) == 0
+    assert qapply(JxBra(1,0)*JxKet(1,1).rewrite('Jz')) == 0
+    assert qapply(JxBra(1,0)*JxKet(1,-1).rewrite('Jz')) == 0
+    assert qapply(JyBra(1,0)*JyKet(1,1).rewrite('Jx')) == 0
+    assert qapply(JyBra(1,0)*JyKet(1,-1).rewrite('Jx')) == 0
+    assert qapply(JyBra(1,0)*JyKet(1,1).rewrite('Jz')) == 0
+    assert qapply(JyBra(1,0)*JyKet(1,-1).rewrite('Jz')) == 0
+    assert qapply(JzBra(1,0)*JzKet(1,1).rewrite('Jx')) == 0
+    assert qapply(JzBra(1,0)*JzKet(1,-1).rewrite('Jx')) == 0
+    assert qapply(JzBra(1,0)*JzKet(1,1).rewrite('Jy')) == 0
+    assert qapply(JzBra(1,0)*JzKet(1,-1).rewrite('Jy')) == 0
+    assert qapply(JxBra(1,-1)*JxKet(1,1).rewrite('Jy')) == 0
+    assert qapply(JxBra(1,-1)*JxKet(1,0).rewrite('Jy')).doit() == 0
+    assert qapply(JxBra(1,-1)*JxKet(1,1).rewrite('Jz')) == 0
+    assert qapply(JxBra(1,-1)*JxKet(1,0).rewrite('Jz')).doit() == 0
+    assert qapply(JyBra(1,-1)*JyKet(1,1).rewrite('Jx')) == 0
+    assert qapply(JyBra(1,-1)*JyKet(1,0).rewrite('Jx')).doit() == 0
+    assert qapply(JyBra(1,-1)*JyKet(1,1).rewrite('Jz')) == 0
+    assert qapply(JyBra(1,-1)*JyKet(1,0).rewrite('Jz')).doit() == 0
+    assert qapply(JzBra(1,-1)*JzKet(1,1).rewrite('Jx')) == 0
+    assert qapply(JzBra(1,-1)*JzKet(1,0).rewrite('Jx')).doit() == 0
+    assert qapply(JzBra(1,-1)*JzKet(1,1).rewrite('Jy')) == 0
+    assert qapply(JzBra(1,-1)*JzKet(1,0).rewrite('Jy')).doit() == 0
+
+def test_innerproduct():
+    j,m = symbols("j m")
+    assert InnerProduct(JzBra(1,1), JzKet(1,1)).doit() == 1
+    assert InnerProduct(JzBra(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2)).doit() == 0
+    assert InnerProduct(JzBra(j,m), JzKet(j,m)).doit() == 1
+    assert InnerProduct(JzBra(1,0), JyKet(1,1)).doit() == I/sqrt(2)
+    assert InnerProduct(JxBra(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)).doit() == -sqrt(2)/2
+    assert InnerProduct(JyBra(1,1), JzKet(1,1)).doit() == S(1)/2
+    assert InnerProduct(JxBra(1,-1), JyKet(1,1)).doit() == 0
+
+def test_rotation_small_d():
+    # Symbolic tests
+    beta = symbols('beta')
+    # j = 1/2
+    assert Rotation.d(S(1)/2,S(1)/2,S(1)/2,beta) == cos(beta/2)
+    assert Rotation.d(S(1)/2,S(1)/2,-S(1)/2,beta) == -sin(beta/2)
+    assert Rotation.d(S(1)/2,-S(1)/2,S(1)/2,beta) == sin(beta/2)
+    assert Rotation.d(S(1)/2,-S(1)/2,-S(1)/2,beta) == cos(beta/2)
+    # j = 1
+    assert Rotation.d(1,1,1,beta) == (1+cos(beta))/2
+    assert Rotation.d(1,1,0,beta) == -sin(beta)/sqrt(2)
+    assert Rotation.d(1,1,-1,beta) == (1-cos(beta))/2
+    assert Rotation.d(1,0,1,beta) == sin(beta)/sqrt(2)
+    assert Rotation.d(1,0,0,beta) == cos(beta)
+    assert Rotation.d(1,0,-1,beta) == -sin(beta)/sqrt(2)
+    assert Rotation.d(1,-1,1,beta) == (1-cos(beta))/2
+    assert Rotation.d(1,-1,0,beta) == sin(beta)/sqrt(2)
+    assert Rotation.d(1,-1,-1,beta) == (1+cos(beta))/2
+    # j = 3/2
+    assert Rotation.d(S(3)/2,S(3)/2,S(3)/2,beta) == (3*cos(beta/2)+cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(3)/2,S(1)/2,beta) == sqrt(3)*(-sin(beta/2)-sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(3)/2,-S(1)/2,beta) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(3)/2,-S(3)/2,beta) == (-3*sin(beta/2)+sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(1)/2,S(3)/2,beta) == sqrt(3)*(sin(beta/2)+sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(1)/2,S(1)/2,beta) == (cos(beta/2)+3*cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(1)/2,-S(1)/2,beta) == (sin(beta/2)-3*sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,S(1)/2,-S(3)/2,beta) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(1)/2,S(3)/2,beta) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(1)/2,S(1)/2,beta) == (-sin(beta/2)+3*sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(1)/2,-S(1)/2,beta) == (cos(beta/2)+3*cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(1)/2,-S(3)/2,beta) == sqrt(3)*(-sin(beta/2)-sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(3)/2,S(3)/2,beta) == (3*sin(beta/2)-sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(3)/2,S(1)/2,beta) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(3)/2,-S(1)/2,beta) == sqrt(3)*(sin(beta/2)+sin(3*beta/2))/4
+    assert Rotation.d(S(3)/2,-S(3)/2,-S(3)/2,beta) == (3*cos(beta/2)+cos(3*beta/2))/4
+    # j = 2
+    assert Rotation.d(2,2,2,beta) == (3+4*cos(beta)+cos(2*beta))/8
+    assert Rotation.d(2,2,1,beta) == (-2*sin(beta)-sin(2*beta))/4
+    assert Rotation.d(2,2,0,beta) == sqrt(6)*(1-cos(2*beta))/8
+    assert Rotation.d(2,2,-1,beta) == (-2*sin(beta)+sin(2*beta))/4
+    assert Rotation.d(2,2,-2,beta) == (3-4*cos(beta)+cos(2*beta))/8
+    assert Rotation.d(2,1,2,beta) == (2*sin(beta)+sin(2*beta))/4
+    assert Rotation.d(2,1,1,beta) == (cos(beta)+cos(2*beta))/2
+    assert Rotation.d(2,1,0,beta) == -sqrt(6)*sin(2*beta)/4
+    assert Rotation.d(2,1,-1,beta) == (cos(beta)-cos(2*beta))/2
+    assert Rotation.d(2,1,-2,beta) == (-2*sin(beta)+sin(2*beta))/4
+    assert Rotation.d(2,0,2,beta) == sqrt(6)*(1-cos(2*beta))/8
+    assert Rotation.d(2,0,1,beta) == sqrt(6)*sin(2*beta)/4
+    assert Rotation.d(2,0,0,beta) == (1+3*cos(2*beta))/4
+    assert Rotation.d(2,0,-1,beta) == -sqrt(6)*sin(2*beta)/4
+    assert Rotation.d(2,0,-2,beta) == sqrt(6)*(1-cos(2*beta))/8
+    assert Rotation.d(2,-1,2,beta) == (2*sin(beta)-sin(2*beta))/4
+    assert Rotation.d(2,-1,1,beta) == (cos(beta)-cos(2*beta))/2
+    assert Rotation.d(2,-1,0,beta) == sqrt(6)*sin(2*beta)/4
+    assert Rotation.d(2,-1,-1,beta) == (cos(beta)+cos(2*beta))/2
+    assert Rotation.d(2,-1,-2,beta) == (-2*sin(beta)-sin(2*beta))/4
+    assert Rotation.d(2,-2,2,beta) == (3-4*cos(beta)+cos(2*beta))/8
+    assert Rotation.d(2,-2,1,beta) == (2*sin(beta)-sin(2*beta))/4
+    assert Rotation.d(2,-2,0,beta) == sqrt(6)*(1-cos(2*beta))/8
+    assert Rotation.d(2,-2,-1,beta) == (2*sin(beta)+sin(2*beta))/4
+    assert Rotation.d(2,-2,-2,beta) == (3+4*cos(beta)+cos(2*beta))/8
+    # Numerical tests
+    # j = 1/2
+    assert Rotation.d(S(1)/2,S(1)/2,S(1)/2,pi/2) == sqrt(2)/2
+    assert Rotation.d(S(1)/2,S(1)/2,-S(1)/2,pi/2) == -sqrt(2)/2
+    assert Rotation.d(S(1)/2,-S(1)/2,S(1)/2,pi/2) == sqrt(2)/2
+    assert Rotation.d(S(1)/2,-S(1)/2,-S(1)/2,pi/2) == sqrt(2)/2
+    # j = 1
+    assert Rotation.d(1,1,1,pi/2) == 1/2
+    assert Rotation.d(1,1,0,pi/2) == -sqrt(2)/2
+    assert Rotation.d(1,1,-1,pi/2) == 1/2
+    assert Rotation.d(1,0,1,pi/2) == sqrt(2)/2
+    assert Rotation.d(1,0,0,pi/2) == 0
+    assert Rotation.d(1,0,-1,pi/2) == -sqrt(2)/2
+    assert Rotation.d(1,-1,1,pi/2) == 1/2
+    assert Rotation.d(1,-1,0,pi/2) == sqrt(2)/2
+    assert Rotation.d(1,-1,-1,pi/2) == 1/2
+    # j = 3/2
+    assert Rotation.d(S(3)/2,S(3)/2,S(3)/2,pi/2) == sqrt(2)/4
+    assert Rotation.d(S(3)/2,S(3)/2,S(1)/2,pi/2) == -sqrt(6)/4
+    assert Rotation.d(S(3)/2,S(3)/2,-S(1)/2,pi/2) == sqrt(6)/4
+    assert Rotation.d(S(3)/2,S(3)/2,-S(3)/2,pi/2) == -sqrt(2)/4
+    assert Rotation.d(S(3)/2,S(1)/2,S(3)/2,pi/2) == sqrt(6)/4
+    assert Rotation.d(S(3)/2,S(1)/2,S(1)/2,pi/2) == -sqrt(2)/4
+    assert Rotation.d(S(3)/2,S(1)/2,-S(1)/2,pi/2) == -sqrt(2)/4
+    assert Rotation.d(S(3)/2,S(1)/2,-S(3)/2,pi/2) == sqrt(6)/4
+    assert Rotation.d(S(3)/2,-S(1)/2,S(3)/2,pi/2) == sqrt(6)/4
+    assert Rotation.d(S(3)/2,-S(1)/2,S(1)/2,pi/2) == sqrt(2)/4
+    assert Rotation.d(S(3)/2,-S(1)/2,-S(1)/2,pi/2) == -sqrt(2)/4
+    assert Rotation.d(S(3)/2,-S(1)/2,-S(3)/2,pi/2) == -sqrt(6)/4
+    assert Rotation.d(S(3)/2,-S(3)/2,S(3)/2,pi/2) == sqrt(2)/4
+    assert Rotation.d(S(3)/2,-S(3)/2,S(1)/2,pi/2) == sqrt(6)/4
+    assert Rotation.d(S(3)/2,-S(3)/2,-S(1)/2,pi/2) == sqrt(6)/4
+    assert Rotation.d(S(3)/2,-S(3)/2,-S(3)/2,pi/2) == sqrt(2)/4
+    # j = 2
+    assert Rotation.d(2,2,2,pi/2) == 1/4
+    assert Rotation.d(2,2,1,pi/2) == -1/2
+    assert Rotation.d(2,2,0,pi/2) == sqrt(6)/4
+    assert Rotation.d(2,2,-1,pi/2) == -1/2
+    assert Rotation.d(2,2,-2,pi/2) == 1/4
+    assert Rotation.d(2,1,2,pi/2) == 1/2
+    assert Rotation.d(2,1,1,pi/2) == -1/2
+    assert Rotation.d(2,1,0,pi/2) == 0
+    assert Rotation.d(2,1,-1,pi/2) == 1/2
+    assert Rotation.d(2,1,-2,pi/2) == -1/2
+    assert Rotation.d(2,0,2,pi/2) == sqrt(6)/4
+    assert Rotation.d(2,0,1,pi/2) == 0
+    assert Rotation.d(2,0,0,pi/2) == -1/2
+    assert Rotation.d(2,0,-1,pi/2) == 0
+    assert Rotation.d(2,0,-2,pi/2) == sqrt(6)/4
+    assert Rotation.d(2,-1,2,pi/2) == 1/2
+    assert Rotation.d(2,-1,1,pi/2) == 1/2
+    assert Rotation.d(2,-1,0,pi/2) == 0
+    assert Rotation.d(2,-1,-1,pi/2) == -1/2
+    assert Rotation.d(2,-1,-2,pi/2) == -1/2
+    assert Rotation.d(2,-2,2,pi/2) == 1/4
+    assert Rotation.d(2,-2,1,pi/2) == 1/2
+    assert Rotation.d(2,-2,0,pi/2) == sqrt(6)/4
+    assert Rotation.d(2,-2,-1,pi/2) == 1/2
+    assert Rotation.d(2,-2,-2,pi/2) == 1/4
+
+def test_rotation_d():
+    # Symbolic tests
+    alpha, beta, gamma = symbols('alpha beta gamma')
+    # j = 1/2
+    assert Rotation.D(S(1)/2,S(1)/2,S(1)/2,alpha,beta,gamma) == cos(beta/2)*exp(-I*alpha/2)*exp(-I*gamma/2)
+    assert Rotation.D(S(1)/2,S(1)/2,-S(1)/2,alpha,beta,gamma) == -sin(beta/2)*exp(-I*alpha/2)*exp(I*gamma/2)
+    assert Rotation.D(S(1)/2,-S(1)/2,S(1)/2,alpha,beta,gamma) == sin(beta/2)*exp(I*alpha/2)*exp(-I*gamma/2)
+    assert Rotation.D(S(1)/2,-S(1)/2,-S(1)/2,alpha,beta,gamma) == cos(beta/2)*exp(I*alpha/2)*exp(I*gamma/2)
+    # j = 1
+    assert Rotation.D(1,1,1,alpha,beta,gamma) == (1+cos(beta))/2*exp(-I*alpha)*exp(-I*gamma)
+    assert Rotation.D(1,1,0,alpha,beta,gamma) == -sin(beta)/sqrt(2)*exp(-I*alpha)
+    assert Rotation.D(1,1,-1,alpha,beta,gamma) == (1-cos(beta))/2*exp(-I*alpha)*exp(I*gamma)
+    assert Rotation.D(1,0,1,alpha,beta,gamma) == sin(beta)/sqrt(2)*exp(-I*gamma)
+    assert Rotation.D(1,0,0,alpha,beta,gamma) == cos(beta)
+    assert Rotation.D(1,0,-1,alpha,beta,gamma) == -sin(beta)/sqrt(2)*exp(I*gamma)
+    assert Rotation.D(1,-1,1,alpha,beta,gamma) == (1-cos(beta))/2*exp(I*alpha)*exp(-I*gamma)
+    assert Rotation.D(1,-1,0,alpha,beta,gamma) == sin(beta)/sqrt(2)*exp(I*alpha)
+    assert Rotation.D(1,-1,-1,alpha,beta,gamma) == (1+cos(beta))/2*exp(I*alpha)*exp(I*gamma)
+    # j = 3/2
+    assert Rotation.D(S(3)/2,S(3)/2,S(3)/2,alpha,beta,gamma) == (3*cos(beta/2)+cos(3*beta/2))/4*exp(-3*I*alpha/2)*exp(-3*I*gamma/2)
+    assert Rotation.D(S(3)/2,S(3)/2,S(1)/2,alpha,beta,gamma) == sqrt(3)*(-sin(beta/2)-sin(3*beta/2))/4*exp(-3*I*alpha/2)*exp(-I*gamma/2)
+    assert Rotation.D(S(3)/2,S(3)/2,-S(1)/2,alpha,beta,gamma) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4*exp(-3*I*alpha/2)*exp(I*gamma/2)
+    assert Rotation.D(S(3)/2,S(3)/2,-S(3)/2,alpha,beta,gamma) == (-3*sin(beta/2)+sin(3*beta/2))/4*exp(-3*I*alpha/2)*exp(3*I*gamma/2)
+    assert Rotation.D(S(3)/2,S(1)/2,S(3)/2,alpha,beta,gamma) == sqrt(3)*(sin(beta/2)+sin(3*beta/2))/4*exp(-I*alpha/2)*exp(-3*I*gamma/2)
+    assert Rotation.D(S(3)/2,S(1)/2,S(1)/2,alpha,beta,gamma) == (cos(beta/2)+3*cos(3*beta/2))/4*exp(-I*alpha/2)*exp(-I*gamma/2)
+    assert Rotation.D(S(3)/2,S(1)/2,-S(1)/2,alpha,beta,gamma) == (sin(beta/2)-3*sin(3*beta/2))/4*exp(-I*alpha/2)*exp(I*gamma/2)
+    assert Rotation.D(S(3)/2,S(1)/2,-S(3)/2,alpha,beta,gamma) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4*exp(-I*alpha/2)*exp(3*I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(1)/2,S(3)/2,alpha,beta,gamma) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4*exp(I*alpha/2)*exp(-3*I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(1)/2,S(1)/2,alpha,beta,gamma) == (-sin(beta/2)+3*sin(3*beta/2))/4*exp(I*alpha/2)*exp(-I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(1)/2,-S(1)/2,alpha,beta,gamma) == (cos(beta/2)+3*cos(3*beta/2))/4*exp(I*alpha/2)*exp(I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(1)/2,-S(3)/2,alpha,beta,gamma) == sqrt(3)*(-sin(beta/2)-sin(3*beta/2))/4*exp(I*alpha/2)*exp(3*I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(3)/2,S(3)/2,alpha,beta,gamma) == (3*sin(beta/2)-sin(3*beta/2))/4*exp(3*I*alpha/2)*exp(-3*I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(3)/2,S(1)/2,alpha,beta,gamma) == sqrt(3)*(cos(beta/2)-cos(3*beta/2))/4*exp(3*I*alpha/2)*exp(-I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(3)/2,-S(1)/2,alpha,beta,gamma) == sqrt(3)*(sin(beta/2)+sin(3*beta/2))/4*exp(3*I*alpha/2)*exp(I*gamma/2)
+    assert Rotation.D(S(3)/2,-S(3)/2,-S(3)/2,alpha,beta,gamma) == (3*cos(beta/2)+cos(3*beta/2))/4*exp(3*I*alpha/2)*exp(3*I*gamma/2)
+    # j = 2
+    assert Rotation.D(2,2,2,alpha,beta,gamma) == (3+4*cos(beta)+cos(2*beta))/8*exp(-2*I*alpha)*exp(-2*I*gamma)
+    assert Rotation.D(2,2,1,alpha,beta,gamma) == (-2*sin(beta)-sin(2*beta))/4*exp(-2*I*alpha)*exp(-I*gamma)
+    assert Rotation.D(2,2,0,alpha,beta,gamma) == sqrt(6)*(1-cos(2*beta))/8*exp(-2*I*alpha)
+    assert Rotation.D(2,2,-1,alpha,beta,gamma) == (-2*sin(beta)+sin(2*beta))/4*exp(-2*I*alpha)*exp(I*gamma)
+    assert Rotation.D(2,2,-2,alpha,beta,gamma) == (3-4*cos(beta)+cos(2*beta))/8*exp(-2*I*alpha)*exp(2*I*gamma)
+    assert Rotation.D(2,1,2,alpha,beta,gamma) == (2*sin(beta)+sin(2*beta))/4*exp(-I*alpha)*exp(-2*I*gamma)
+    assert Rotation.D(2,1,1,alpha,beta,gamma) == (cos(beta)+cos(2*beta))/2*exp(-I*alpha)*exp(-I*gamma)
+    assert Rotation.D(2,1,0,alpha,beta,gamma) == -sqrt(6)*sin(2*beta)/4*exp(-I*alpha)
+    assert Rotation.D(2,1,-1,alpha,beta,gamma) == (cos(beta)-cos(2*beta))/2*exp(-I*alpha)*exp(I*gamma)
+    assert Rotation.D(2,1,-2,alpha,beta,gamma) == (-2*sin(beta)+sin(2*beta))/4*exp(-I*alpha)*exp(2*I*gamma)
+    assert Rotation.D(2,0,2,alpha,beta,gamma) == sqrt(6)*(1-cos(2*beta))/8*exp(-2*I*gamma)
+    assert Rotation.D(2,0,1,alpha,beta,gamma) == sqrt(6)*sin(2*beta)/4*exp(-I*gamma)
+    assert Rotation.D(2,0,0,alpha,beta,gamma) == (1+3*cos(2*beta))/4
+    assert Rotation.D(2,0,-1,alpha,beta,gamma) == -sqrt(6)*sin(2*beta)/4*exp(I*gamma)
+    assert Rotation.D(2,0,-2,alpha,beta,gamma) == sqrt(6)*(1-cos(2*beta))/8*exp(2*I*gamma)
+    assert Rotation.D(2,-1,2,alpha,beta,gamma) == (2*sin(beta)-sin(2*beta))/4*exp(I*alpha)*exp(-2*I*gamma)
+    assert Rotation.D(2,-1,1,alpha,beta,gamma) == (cos(beta)-cos(2*beta))/2*exp(I*alpha)*exp(-I*gamma)
+    assert Rotation.D(2,-1,0,alpha,beta,gamma) == sqrt(6)*sin(2*beta)/4*exp(I*alpha)
+    assert Rotation.D(2,-1,-1,alpha,beta,gamma) == (cos(beta)+cos(2*beta))/2*exp(I*alpha)*exp(I*gamma)
+    assert Rotation.D(2,-1,-2,alpha,beta,gamma) == (-2*sin(beta)-sin(2*beta))/4*exp(I*alpha)*exp(2*I*gamma)
+    assert Rotation.D(2,-2,2,alpha,beta,gamma) == (3-4*cos(beta)+cos(2*beta))/8*exp(2*I*alpha)*exp(-2*I*gamma)
+    assert Rotation.D(2,-2,1,alpha,beta,gamma) == (2*sin(beta)-sin(2*beta))/4*exp(2*I*alpha)*exp(-I*gamma)
+    assert Rotation.D(2,-2,0,alpha,beta,gamma) == sqrt(6)*(1-cos(2*beta))/8*exp(2*I*alpha)
+    assert Rotation.D(2,-2,-1,alpha,beta,gamma) == (2*sin(beta)+sin(2*beta))/4*exp(2*I*alpha)*exp(I*gamma)
+    assert Rotation.D(2,-2,-2,alpha,beta,gamma) == (3+4*cos(beta)+cos(2*beta))/8*exp(2*I*alpha)*exp(2*I*gamma)
+    # Numerical tests
+    # j = 1/2
+    assert Rotation.D(S(1)/2,S(1)/2,S(1)/2,pi/2,pi/2,pi/2) == -I*sqrt(2)/2
+    assert Rotation.D(S(1)/2,S(1)/2,-S(1)/2,pi/2,pi/2,pi/2) == -sqrt(2)/2
+    assert Rotation.D(S(1)/2,-S(1)/2,S(1)/2,pi/2,pi/2,pi/2) == sqrt(2)/2
+    assert Rotation.D(S(1)/2,-S(1)/2,-S(1)/2,pi/2,pi/2,pi/2) == I*sqrt(2)/2
+    # j = 1
+    assert Rotation.D(1,1,1,pi/2,pi/2,pi/2) == -1/2
+    assert Rotation.D(1,1,0,pi/2,pi/2,pi/2) == I*sqrt(2)/2
+    assert Rotation.D(1,1,-1,pi/2,pi/2,pi/2) == 1/2
+    assert Rotation.D(1,0,1,pi/2,pi/2,pi/2) == -I*sqrt(2)/2
+    assert Rotation.D(1,0,0,pi/2,pi/2,pi/2) == 0
+    assert Rotation.D(1,0,-1,pi/2,pi/2,pi/2) == -I*sqrt(2)/2
+    assert Rotation.D(1,-1,1,pi/2,pi/2,pi/2) == 1/2
+    assert Rotation.D(1,-1,0,pi/2,pi/2,pi/2) == I*sqrt(2)/2
+    assert Rotation.D(1,-1,-1,pi/2,pi/2,pi/2) == -1/2
+    # j = 3/2
+    assert Rotation.D(S(3)/2,S(3)/2,S(3)/2,pi/2,pi/2,pi/2) == I*sqrt(2)/4
+    assert Rotation.D(S(3)/2,S(3)/2,S(1)/2,pi/2,pi/2,pi/2) == sqrt(6)/4
+    assert Rotation.D(S(3)/2,S(3)/2,-S(1)/2,pi/2,pi/2,pi/2) == -I*sqrt(6)/4
+    assert Rotation.D(S(3)/2,S(3)/2,-S(3)/2,pi/2,pi/2,pi/2) == -sqrt(2)/4
+    assert Rotation.D(S(3)/2,S(1)/2,S(3)/2,pi/2,pi/2,pi/2) == -sqrt(6)/4
+    assert Rotation.D(S(3)/2,S(1)/2,S(1)/2,pi/2,pi/2,pi/2) == I*sqrt(2)/4
+    assert Rotation.D(S(3)/2,S(1)/2,-S(1)/2,pi/2,pi/2,pi/2) == -sqrt(2)/4
+    assert Rotation.D(S(3)/2,S(1)/2,-S(3)/2,pi/2,pi/2,pi/2) == I*sqrt(6)/4
+    assert Rotation.D(S(3)/2,-S(1)/2,S(3)/2,pi/2,pi/2,pi/2) == -I*sqrt(6)/4
+    assert Rotation.D(S(3)/2,-S(1)/2,S(1)/2,pi/2,pi/2,pi/2) == sqrt(2)/4
+    assert Rotation.D(S(3)/2,-S(1)/2,-S(1)/2,pi/2,pi/2,pi/2) == -I*sqrt(2)/4
+    assert Rotation.D(S(3)/2,-S(1)/2,-S(3)/2,pi/2,pi/2,pi/2) == sqrt(6)/4
+    assert Rotation.D(S(3)/2,-S(3)/2,S(3)/2,pi/2,pi/2,pi/2) == sqrt(2)/4
+    assert Rotation.D(S(3)/2,-S(3)/2,S(1)/2,pi/2,pi/2,pi/2) == I*sqrt(6)/4
+    assert Rotation.D(S(3)/2,-S(3)/2,-S(1)/2,pi/2,pi/2,pi/2) == -sqrt(6)/4
+    assert Rotation.D(S(3)/2,-S(3)/2,-S(3)/2,pi/2,pi/2,pi/2) == -I*sqrt(2)/4
+    # j = 2
+    assert Rotation.D(2,2,2,pi/2,pi/2,pi/2) == 1/4
+    assert Rotation.D(2,2,1,pi/2,pi/2,pi/2) == -I/2
+    assert Rotation.D(2,2,0,pi/2,pi/2,pi/2) == -sqrt(6)/4
+    assert Rotation.D(2,2,-1,pi/2,pi/2,pi/2) == I/2
+    assert Rotation.D(2,2,-2,pi/2,pi/2,pi/2) == 1/4
+    assert Rotation.D(2,1,2,pi/2,pi/2,pi/2) == I/2
+    assert Rotation.D(2,1,1,pi/2,pi/2,pi/2) == 1/2
+    assert Rotation.D(2,1,0,pi/2,pi/2,pi/2) == 0
+    assert Rotation.D(2,1,-1,pi/2,pi/2,pi/2) == 1/2
+    assert Rotation.D(2,1,-2,pi/2,pi/2,pi/2) == -I/2
+    assert Rotation.D(2,0,2,pi/2,pi/2,pi/2) == -sqrt(6)/4
+    assert Rotation.D(2,0,1,pi/2,pi/2,pi/2) == 0
+    assert Rotation.D(2,0,0,pi/2,pi/2,pi/2) == -1/2
+    assert Rotation.D(2,0,-1,pi/2,pi/2,pi/2) == 0
+    assert Rotation.D(2,0,-2,pi/2,pi/2,pi/2) == -sqrt(6)/4
+    assert Rotation.D(2,-1,2,pi/2,pi/2,pi/2) == -I/2
+    assert Rotation.D(2,-1,1,pi/2,pi/2,pi/2) == 1/2
+    assert Rotation.D(2,-1,0,pi/2,pi/2,pi/2) == 0
+    assert Rotation.D(2,-1,-1,pi/2,pi/2,pi/2) == 1/2
+    assert Rotation.D(2,-1,-2,pi/2,pi/2,pi/2) == I/2
+    assert Rotation.D(2,-2,2,pi/2,pi/2,pi/2) == 1/4
+    assert Rotation.D(2,-2,1,pi/2,pi/2,pi/2) == I/2
+    assert Rotation.D(2,-2,0,pi/2,pi/2,pi/2) == -sqrt(6)/4
+    assert Rotation.D(2,-2,-1,pi/2,pi/2,pi/2) == -I/2
+    assert Rotation.D(2,-2,-2,pi/2,pi/2,pi/2) == 1/4
 
 def test_jplus():
     assert Commutator(Jplus, Jminus).doit() == 2*hbar*Jz
@@ -16,8 +407,10 @@ def test_jplus():
     assert Jplus.matrix_element(1,1,1,1) == 0
     assert Jplus.rewrite('xyz') == Jx + I*Jy
 
-def test_rotation():
-    assert Rotation.d(1,1,1,0) == 1
+def test_jminus():
+    assert qapply(Jminus*JzKet(1,-1)) == 0
+    assert Jminus.matrix_element(1,0,1,1) == sqrt(2)*hbar
+    assert Jminus.rewrite('xyz') == Jx - I*Jy
 
 def test_j2():
     j, m = symbols('j m')
@@ -26,3 +419,19 @@ def test_j2():
     assert qapply(J2*JzKet(j,m)) == j**2*hbar**2*JzKet(j,m)+j*hbar**2*JzKet(j,m)
     assert J2.matrix_element(1,1,1,1) == 2*hbar**2
 
+def test_jx():
+    assert Commutator(Jx, Jz).doit() == -I*hbar*Jy
+    assert qapply(Jx*JzKet(1,1)) == sqrt(2)*hbar*JzKet(1,0)/2
+    assert Jx.rewrite('plusminus') == (Jminus + Jplus)/2
+    assert represent(Jx, basis=Jz, j=1) == (represent(Jplus, basis=Jz, j=1)+represent(Jminus, basis=Jz, j=1))/2
+
+def test_jy():
+    assert Commutator(Jy, Jz).doit() == I*hbar*Jx
+    assert qapply(Jy*JzKet(1,1)) == I*sqrt(2)*hbar*JzKet(1,0)/2
+    assert Jy.rewrite('plusminus') == (Jplus - Jminus)/(2*I)
+    assert represent(Jy, basis=Jz) == (represent(Jplus, basis=Jz) - represent(Jminus, basis=Jz))/(2*I)
+
+def test_jz():
+    assert Commutator(Jz, Jminus).doit() == -hbar*Jminus
+    assert qapply(Jz*JzKet(2,1)) == hbar*JzKet(2,1)
+    assert Jz.rewrite('plusminus')


### PR DESCRIPTION
Provides improved functionality in moving between Jx, Jy and Jz spin bases. Implements logic for using represent, rewrite and InnerProducts between arbitrary states in any basis. See the docstrings for usage. Also implements some tests and documentation for things in the spin module. Let me know if you have any questions or comments.

Note that there are still bugs in the Rotation.d function that will effect results from this work, see [1]. Some of the cases that need to be resolved are in an XFAIL test.

[1] http://code.google.com/p/sympy/issues/detail?id=2423
