### PR TITLE
Fixed Expr.as_ordered_terms() for non-lex term orderings (#2498)

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -257,10 +257,21 @@ class Expr(Basic, EvalfMixin):
 
         monom_key = monomial_key(order)
 
+        def neg(monom):
+            result = []
+
+            for m in monom:
+                if isinstance(m, tuple):
+                    result.append(neg(m))
+                else:
+                    result.append(-m)
+
+            return tuple(result)
+
         def key(term):
             _, ((re, im), monom, ncpart) = term
 
-            monom = [ -m for m in monom_key(monom) ]
+            monom = neg(monom_key(monom))
             ncpart = tuple([ e.sort_key(order=order) for e in ncpart ])
             coeff = ((bool(im), im), (re, im))
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1023,6 +1023,13 @@ def test_as_ordered_terms():
     assert ( 4 - 3*I).as_ordered_terms() == [ 4, -3*I]
     assert (-4 - 3*I).as_ordered_terms() == [-4, -3*I]
 
+    f = x**2*y**2 + x*y**4 + y + 2
+
+    assert f.as_ordered_terms(order="lex") == [x**2*y**2, x*y**4, y, 2]
+    assert f.as_ordered_terms(order="grlex") == [x*y**4, x**2*y**2, y, 2]
+    assert f.as_ordered_terms(order="rev-lex") == [2, y, x*y**4, x**2*y**2]
+    assert f.as_ordered_terms(order="rev-grlex") == [2, y, x**2*y**2, x*y**4]
+
 def test_issue_1100():
     # first subs and limit gives NaN
     a = x/y


### PR DESCRIPTION
This fixes issue #2498:

<pre>
In [1]: f = x**2*y**2 + x*y**4 + y + 2

In [2]: f
Out[2]:
 2  2      4
x ⋅y  + x⋅y  + y + 2

In [3]: f.as_ordered_terms(order="lex")
Out[3]:
⎡ 2  2     4      ⎤
⎣x ⋅y , x⋅y , y, 2⎦

In [4]: f.as_ordered_terms(order="grlex")
Out[4]:
⎡   4   2  2      ⎤
⎣x⋅y , x ⋅y , y, 2⎦

In [5]: f.as_ordered_terms(order="rev-lex")
Out[5]:
⎡         4   2  2⎤
⎣2, y, x⋅y , x ⋅y ⎦

In [6]: f.as_ordered_terms(order="rev-grlex")
Out[6]:
⎡       2  2     4⎤
⎣2, y, x ⋅y , x⋅y ⎦
</pre>
