### PR TITLE
Pretty print iterated derivatives in a concise way

### DIFF
--- a/doc/src/tutorial.txt
+++ b/doc/src/tutorial.txt
@@ -607,14 +607,14 @@ Differential Equations
 In ``isympy``::
 
     >>> f(x).diff(x, x) + f(x)
-              2
-             d
-    f(x) + -----(f(x))
-           dx dx
+            2
+           d
+    f(x) + ---(f(x))
+             2
+           dx
 
     >>> dsolve(f(x).diff(x, x) + f(x), f(x))
     f(x) = C1*cos(x) + C2*sin(x)
-
 
 .. index:: equations; algebraic, solve
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1440,7 +1440,8 @@ dx            \
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
-    expr = Derivative(log(x) + x**2, x, y, evaluate=False)
+    # Multiple symbols
+    expr = Derivative(log(x) + x**2, x, y)
     ascii_str_1 = \
 """\
    2              \n\
@@ -1472,8 +1473,7 @@ dy dx             \
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
-    # Multiple symbols
-    expr = Derivative(2*x*y, y, x, evaluate=False) + x**2
+    expr = Derivative(2*x*y, y, x) + x**2
     ascii_str_1 = \
 """\
    2             \n\
@@ -1505,6 +1505,66 @@ x  + ─────(2⋅x⋅y)\n\
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
+    expr = Derivative(2*x*y, x, x)
+    ascii_str = \
+"""\
+  2       \n\
+ d        \n\
+---(2*x*y)\n\
+  2       \n\
+dx        \
+"""
+    ucode_str = \
+u"""\
+  2       \n\
+ d        \n\
+───(2⋅x⋅y)\n\
+  2       \n\
+dx        \
+"""
+    assert  pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = Derivative(2*x*y, x, 17)
+    ascii_str = \
+"""\
+ 17        \n\
+d          \n\
+----(2*x*y)\n\
+  17       \n\
+dx         \
+"""
+    ucode_str = \
+u"""\
+ 17        \n\
+d          \n\
+────(2⋅x⋅y)\n\
+  17       \n\
+dx         \
+"""
+    assert  pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = Derivative(2*x*y, x, x, y)
+    ascii_str = \
+"""\
+   3         \n\
+  d          \n\
+------(2*x*y)\n\
+     2       \n\
+dy dx        \
+"""
+    ucode_str = \
+u"""\
+   3         \n\
+  d          \n\
+──────(2⋅x⋅y)\n\
+     2       \n\
+dy dx        \
+"""
+    assert  pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
     # Greek letters
     alpha = Symbol('alpha')
     beta  = Function('beta')
@@ -1523,7 +1583,6 @@ dα      \
 """
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
-
 
 def test_pretty_integrals():
     expr = Integral(log(x), x)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2107,10 +2107,11 @@ def ode_Liouville(eq, func, order, match):
         >>> genform = Eq(diff(f(x),x,x) + g(f(x))*diff(f(x),x)**2 +
         ... h(x)*diff(f(x),x), 0)
         >>> pprint(genform)
-                        2                      2
-                d                d            d
-        g(f(x))*--(f(x))  + h(x)*--(f(x)) + -----(f(x)) = 0
-                dx               dx         dx dx
+                        2                    2
+                d                d          d
+        g(f(x))*--(f(x))  + h(x)*--(f(x)) + ---(f(x)) = 0
+                dx               dx           2
+                                            dx
         >>> pprint(dsolve(genform, f(x), hint='Liouville_Integral'))
                                           f(x)
                   /                     /


### PR DESCRIPTION
This makes iterated derivatives more pleasant to read, e.g.:

<pre>
In [1]: zeta(x).series(x, 0, 5)
Out[1]:
                            ⎛  2      ⎞│         ⎛  3      ⎞│         ⎛  4      ⎞│
                          2 ⎜ d       ⎟│       3 ⎜ d       ⎟│       4 ⎜ d       ⎟│
                         x ⋅⎜───(ζ(x))⎟│      x ⋅⎜───(ζ(x))⎟│      x ⋅⎜───(ζ(x))⎟│
                            ⎜  2      ⎟│         ⎜  3      ⎟│         ⎜  4      ⎟│
  1     ⎛d       ⎞│         ⎝dx       ⎠│x=0      ⎝dx       ⎠│x=0      ⎝dx       ⎠│x=0
- ─ + x⋅⎜──(ζ(x))⎟│    + ────────────────── + ────────────────── + ────────────────── + O(x**5)
  2     ⎝dx      ⎠│x=0           2                    6                    24
</pre>

This is just a proposal, but in my opinion it looks much better than it was previously (imagine printing 50 terms of series of `zeta(x)`).
