### PR TITLE
Fix for issue #2489; Can now integrate over multiple simple delta functions

### DIFF
--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -110,12 +110,6 @@ def deltaintegrate(f, x):
             else:
                 dg = dg.simplify(x)
                 point = solve(dg.args[0],x)[0]
-                delta_args = dg.args[0].args
-                heav = None
-                if -x in delta_args:
-                    heav = x-delta_args[0]
-                else:
-                    heav = dg.args[0]
-                return (rest_mult.subs(x,point)*Heaviside(heav))
+                return (rest_mult.subs(x,point)*Heaviside(x-point))
     return None
 

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -110,6 +110,6 @@ def deltaintegrate(f, x):
             else:
                 dg = dg.simplify(x)
                 point = solve(dg.args[0],x)[0]
-                return (rest_mult.subs(x,point)*Heaviside(x-point))
+                return (rest_mult.subs(x,point)*Heaviside(x - point))
     return None
 

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -36,7 +36,10 @@ def change_mul(node,x):
     for arg in node.args:
         if arg.func == DiracDelta and arg.is_simple(x) \
                 and (len(arg.args) <= 1 or arg.args[1]==0):
-            dirac = arg
+            if dirac is None:
+                dirac = arg
+            else:
+                new_args.append(arg)
         else:
             new_args.append(change_mul(arg,x))
     if not dirac:#we didn't find any simple dirac
@@ -99,6 +102,7 @@ def deltaintegrate(f, x):
                 return fh
         else:#no expansion performed, try to extract a simple DiracDelta term
             dg, rest_mult = change_mul(f,x)
+
             if not dg:
                 if rest_mult:
                     fh = sympy.integrals.integrate(rest_mult,x)
@@ -106,6 +110,12 @@ def deltaintegrate(f, x):
             else:
                 dg = dg.simplify(x)
                 point = solve(dg.args[0],x)[0]
-                return (rest_mult.subs(x,point)*Heaviside(dg.args[0]))
+                delta_args = dg.args[0].args
+                heav = None
+                if -x in delta_args:
+                    heav = x-delta_args[0]
+                else:
+                    heav = dg.args[0]
+                return (rest_mult.subs(x,point)*Heaviside(heav))
     return None
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -5,7 +5,7 @@ from sympy import (S, symbols, integrate, Integral, Derivative, exp, erf, oo, Sy
 from sympy.utilities.pytest import XFAIL, skip, raises
 from sympy.physics.units import m, s
 
-x,y,a,t = symbols('x,y,a,t')
+x,y,a,t,x_1,x_2,z = symbols('x,y,a,t,x_1,x_2,z')
 n = Symbol('n', integer=True)
 f = Function('f')
 
@@ -342,7 +342,10 @@ def test_integrate_DiracDelta():
     assert integrate(cos(x)*(DiracDelta(x)+DiracDelta(x**2-1))*sin(x)*(x-pi),x) - \
            (-pi*(cos(1)*Heaviside(-1 + x)*sin(1)/2 - cos(1)*Heaviside(1 + x)*sin(1)/2) + \
            cos(1)*Heaviside(1 + x)*sin(1)/2 + cos(1)*Heaviside(-1 + x)*sin(1)/2) == 0
-
+    assert integrate(x_2 * DiracDelta(x-x_2) * DiracDelta(x_2-x_1), (x_2, -oo, oo)) == \
+           x*DiracDelta(x-x_1)
+    assert integrate(x*y**2*z*DiracDelta(y-x)*DiracDelta(y-z)*DiracDelta(x-z), (y, -oo, oo)) \
+           == x**3*z*DiracDelta(x-z)**2
 
 def test_subs1():
     e = Integral(exp(x-y), x)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -342,10 +342,10 @@ def test_integrate_DiracDelta():
     assert integrate(cos(x)*(DiracDelta(x)+DiracDelta(x**2-1))*sin(x)*(x-pi),x) - \
            (-pi*(cos(1)*Heaviside(-1 + x)*sin(1)/2 - cos(1)*Heaviside(1 + x)*sin(1)/2) + \
            cos(1)*Heaviside(1 + x)*sin(1)/2 + cos(1)*Heaviside(-1 + x)*sin(1)/2) == 0
-    assert integrate(x_2 * DiracDelta(x-x_2) * DiracDelta(x_2-x_1), (x_2, -oo, oo)) == \
-           x*DiracDelta(x-x_1)
-    assert integrate(x*y**2*z*DiracDelta(y-x)*DiracDelta(y-z)*DiracDelta(x-z), (y, -oo, oo)) \
-           == x**3*z*DiracDelta(x-z)**2
+    assert integrate(x_2*DiracDelta(x - x_2)*DiracDelta(x_2 - x_1), (x_2, -oo, oo)) == \
+           x*DiracDelta(x - x_1)
+    assert integrate(x*y**2*z*DiracDelta(y - x)*DiracDelta(y - z)*DiracDelta(x - z), (y, -oo, oo)) \
+           == x**3*z*DiracDelta(x - z)**2
 
 def test_subs1():
     e = Integral(exp(x-y), x)


### PR DESCRIPTION
A fix for issue #2489: http://code.google.com/p/sympy/issues/detail?id=2489

The problem was in change_mul, which improperly dealt with multiple Deltas in the same Mul. This change makes it take the first Delta it finds with the variable in question and collapse that function, keeping the other deltas in rest_mult and substituting the variable into them. 

Keeping the other deltas wasn't enough alone, though, because I found that there would be a sign error depending on where the variable was in the delta (either (x-c) or (c-x)), so that's why the argument reversal happens at the end. 

At least on my machine, no tests fail after the change. I have also added a couple tests to ensure this fix isn't broken in the future. 
