### PR TITLE
2501: use a letter in dummy argument names of unknown functions.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -513,8 +513,8 @@ functions are not supported.')
             if not (1<=argindex<=nargs):
                 raise ArgumentIndexError(self, argindex)
         if not self.args[argindex-1].is_Symbol:
-            # See issue 1525 and issue 1620
-            arg_dummy = C.Dummy('%i' % argindex)
+            # See issue 1525 and issue 1620 and issue 2501
+            arg_dummy = C.Dummy('xi_%i' % argindex)
             return Subs(Derivative(
                 self.subs(self.args[argindex-1], arg_dummy),
                 arg_dummy), arg_dummy, self.args[argindex-1])


### PR DESCRIPTION
Now it's clearer when pretty printing that the derivatives are taken
with respect to a dummy symbol, not a number:

```
>>> f(g(x)).diff(x)
d        ⎛ d        ⎞│
──(g(x))⋅⎜───(f(ξ₁))⎟│
dx       ⎝dξ₁       ⎠│ξ₁=g(x)
```
