### PR TITLE
2436: python prints Derivatives as 'Derivative'.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -890,7 +890,7 @@ class Subs(Expr):
     >>> f = Function('f')
     >>> e = Subs(f(x).diff(x), x, y)
     >>> e.subs(y, 0)
-    Subs(D(f(_x), _x), Tuple(_x), Tuple(0))
+    Subs(Derivative(f(_x), _x), Tuple(_x), Tuple(0))
     >>> e.subs(f, sin).doit()
     cos(y)
 
@@ -1034,9 +1034,9 @@ def diff(f, *symbols, **kwargs):
     >>> diff(sin(x), x)
     cos(x)
     >>> diff(f(x), x, x, x)
-    D(f(x), x, x, x)
+    Derivative(f(x), x, x, x)
     >>> diff(f(x), x, 3)
-    D(f(x), x, x, x)
+    Derivative(f(x), x, x, x)
     >>> diff(sin(x)*cos(y), x, 2, y, 2)
     sin(x)*cos(y)
 

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -21,7 +21,7 @@ def idiff(eq, y, x, dep=None):
     >>> idiff(x + a + y, y, x)
     -1
     >>> idiff(x + a + y, y, x, [a])
-    -D(a, x) - 1
+    -Derivative(a, x) - 1
 
     """
     if not dep:

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -73,7 +73,7 @@ class StrPrinter(Printer):
         return 'zoo'
 
     def _print_Derivative(self, expr):
-        return 'D(%s)'%", ".join(map(self._print, expr.args))
+        return 'Derivative(%s)'%", ".join(map(self._print, expr.args))
 
     def _print_dict(self, expr):
         keys = expr.keys()

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -100,10 +100,10 @@ def test_python_functions():
 def test_python_derivatives():
     # Simple
     f_1 = Derivative(log(x), x, evaluate=False)
-    assert python(f_1) == "x = Symbol('x')\ne = D(log(x), x)"
+    assert python(f_1) == "x = Symbol('x')\ne = Derivative(log(x), x)"
 
     f_2 = Derivative(log(x), x, evaluate=False) + x
-    assert python(f_2) == "x = Symbol('x')\ne = x + D(log(x), x)"
+    assert python(f_2) == "x = Symbol('x')\ne = x + Derivative(log(x), x)"
 
     # Multiple symbols
     f_3 = Derivative(log(x) + x**2, x, y, evaluate=False)
@@ -111,8 +111,8 @@ def test_python_derivatives():
 
     f_4 = Derivative(2*x*y, y, x, evaluate=False) + x**2
     assert python(f_4) in [
-            "x = Symbol('x')\ny = Symbol('y')\ne = x**2 + D(2*x*y, y, x)",
-            "x = Symbol('x')\ny = Symbol('y')\ne = D(2*x*y, y, x) + x**2"]
+            "x = Symbol('x')\ny = Symbol('y')\ne = x**2 + Derivative(2*x*y, y, x)",
+            "x = Symbol('x')\ny = Symbol('y')\ne = Derivative(2*x*y, y, x) + x**2"]
 
 def test_python_integrals():
     # Simple

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -53,9 +53,9 @@ def test_ComplexInfinity():
     assert str(zoo) == "zoo"
 
 def test_Derivative():
-    assert str(Derivative(x, y)) == "D(x, y)"
-    assert str(Derivative(x**2, x, evaluate=False)) == "D(x**2, x)"
-    assert str(Derivative(x**2/y, x, y, evaluate=False)) == "D(x**2/y, x, y)"
+    assert str(Derivative(x, y)) == "Derivative(x, y)"
+    assert str(Derivative(x**2, x, evaluate=False)) == "Derivative(x**2, x)"
+    assert str(Derivative(x**2/y, x, y, evaluate=False)) == "Derivative(x**2/y, x, y)"
 
 def test_dict():
     assert str({1: 1+x}) == sstr({1: 1+x}) == "{1: x + 1}"

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -278,21 +278,21 @@ def collect(expr, syms, evaluate=True, exact=False):
         >>> f = Function('f') (x)
 
         >>> collect(a*D(f,x) + b*D(f,x), D(f,x))
-        (a + b)*D(f(x), x)
+        (a + b)*Derivative(f(x), x)
 
         >>> collect(a*D(D(f,x),x) + b*D(D(f,x),x), f)
-        (a + b)*D(f(x), x, x)
+        (a + b)*Derivative(f(x), x, x)
 
         >>> collect(a*D(D(f,x),x) + b*D(D(f,x),x), D(f,x), exact=True)
-        a*D(f(x), x, x) + b*D(f(x), x, x)
+        a*Derivative(f(x), x, x) + b*Derivative(f(x), x, x)
 
         >>> collect(a*D(f,x) + b*D(f,x) + a*f + b*f, f,x)
-        (a + b)*f(x) + (a + b)*D(f(x), x)
+        (a + b)*f(x) + (a + b)*Derivative(f(x), x)
 
         Or you can even match both derivative order and exponent at time::
 
         >>> collect(a*D(D(f,x),x)**2 + b*D(D(f,x),x)**2, D(f,x))
-        (a + b)*D(f(x), x, x)**2
+        (a + b)*Derivative(f(x), x, x)**2
 
 
     == Notes ==

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -97,7 +97,7 @@ def pde_separate_add(eq, fun, sep):
 
     >>> eq = Eq(D(u(x, t), x), E**(u(x, t))*D(u(x, t), t))
     >>> pde_separate_add(eq, u(x, t), [X(x), T(t)])
-    [exp(-X(x))*D(X(x), x), exp(T(t))*D(T(t), t)]
+    [exp(-X(x))*Derivative(X(x), x), exp(T(t))*Derivative(T(t), t)]
 
     """
     return pde_separate(eq, fun, sep, strategy='add')
@@ -120,7 +120,7 @@ def pde_separate_mul(eq, fun, sep):
 
     >>> eq = Eq(D(u(x, y), x, 2), D(u(x, y), y, 2))
     >>> pde_separate_mul(eq, u(x, y), [X(x), Y(y)])
-    [D(X(x), x, x)/X(x), D(Y(y), y, y)/Y(y)]
+    [Derivative(X(x), x, x)/X(x), Derivative(Y(y), y, y)/Y(y)]
 
     """
     return pde_separate(eq, fun, sep, strategy='mul')


### PR DESCRIPTION
The new representation is longer and less pretty, but it's correct:

```
>>> str(Derivative(f(x), x))
'Derivative(f(x), x)'
>>> eval(_)
Derivative(f(x), x)
```
