### PR TITLE
2490: add Mod class for modulo operations on symbolic expressions.

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -12,6 +12,7 @@ from numbers import Number, Float, Rational, Integer, NumberSymbol,\
 from power import Pow, integer_nthroot
 from mul import Mul
 from add import Add
+from mod import Mod
 from relational import Rel, Eq, Ne, Lt, Le, Gt, Ge, \
     Equality, Inequality, Unequality, StrictInequality
 from multidimensional import vectorize

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -120,6 +120,14 @@ class Expr(Basic, EvalfMixin):
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
 
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rmod__')
+    def __mod__(self, other):
+        return Mod(self, other)
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__mod__')
+    def __rmod__(self, other):
+        return Mod(other, self)
 
     def __float__(self):
         result = self.evalf()
@@ -2018,6 +2026,7 @@ class AtomicExpr(Atom, Expr):
 from mul import Mul
 from add import Add
 from power import Pow
+from mod import Mod
 from function import Derivative
 from sympify import sympify
 from symbol import Wild

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,0 +1,30 @@
+from cache import cacheit
+from expr import Expr
+from sympify import sympify
+
+class Mod(Expr):
+    '''Represents a modulo operation on symbolic expressions.
+
+    Receives two arguments, dividend and divisor. If both are Numbers, the
+    result is evaluated immediately.
+
+    The convention used is the same as python's: the remainder always has the
+    same sign as the divisor.
+
+    Examples:
+    >>> from sympy.abc import x, y
+    >>> x**2 % y
+    Mod(x**2, y)
+    >>> _.subs({x: 5, y: 6})
+    1
+
+    '''
+    @cacheit
+    def __new__(cls, *args, **options):
+        if len(args) != 2:
+            raise TypeError("Mod receives two arguments, only %s passed" %
+                    len(args))
+        dividend, divisor = map(sympify, args)
+        if dividend.is_Number and divisor.is_Number:
+            return dividend % divisor
+        return Expr.__new__(cls, *args)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 from sympy import Symbol, sin, cos, exp, O, sqrt, Rational, Float, re, pi, \
-        sympify, sqrt, Add, Mul, Pow, I, log, S
+        sympify, sqrt, Add, Mul, Pow, Mod, I, log, S
 from sympy.utilities.pytest import XFAIL
 
 x = Symbol('x')
@@ -1194,3 +1194,13 @@ def test_issue2361():
     u = 2*(1 + n)
     assert u.is_Mul
     assert (2 + u).args == (S(2), u)
+
+def test_Mod():
+    assert Mod(5, 3) == 2
+    assert Mod(-5, 3) == 1
+    assert Mod(5, -3) == -1
+    assert Mod(-5, -3) == -2
+    assert 5 % x == Mod(5, x)
+    assert x % 5 == Mod(x, 5)
+    assert x % y == Mod(x, y)
+    assert (x % y).subs({x: 5, y: 3}) == 2


### PR DESCRIPTION
Now we are able to use:

```
>>> x % 3
Mod(x, 3)
>>> _.subs(x, 10)
1
```
