### PR TITLE
Print the architecture when running tests and iSymPy

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -26,6 +26,7 @@ def _make_message(ipython=True, quiet=False, source=None):
     """Create a banner for an interactive session. """
     from sympy import __version__ as sympy_version
     from sympy.polys.domains import GROUND_TYPES
+    from sympy.utilities.misc import ARCH
 
     import sys
     import os
@@ -44,8 +45,8 @@ def _make_message(ipython=True, quiet=False, source=None):
     if cache is not None and cache.lower() == 'no':
         info.append('cache: off')
 
-    args = shell_name, sympy_version, python_version, ', '.join(info)
-    message = "%s console for SymPy %s (Python %s) (%s)\n" % args
+    args = shell_name, sympy_version, python_version, ARCH, ', '.join(info)
+    message = "%s console for SymPy %s (Python %s-%s) (%s)\n" % args
 
     if not quiet:
         if source is None:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -42,3 +42,12 @@ def default_sort_key(item):
     # [1, x, x**2]
 
     return sympify(item).sort_key()
+
+import sys
+size = getattr(sys, "maxint", None)
+if size is None: #Python 3 doesn't have maxint
+    size = sys.maxsize
+if size > 2**32:
+    ARCH = "64-bit"
+else:
+    ARCH = "32-bit"

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1030,6 +1030,8 @@ class PyTestReporter(Reporter):
         v = tuple(sys.version_info)
         python_version = "%s.%s.%s-%s-%s" % v
         self.write("executable:   %s  (%s)\n" % (executable, python_version))
+        from .misc import ARCH
+        self.write("architecture: %s\n" % ARCH)
         from sympy.polys.domains import GROUND_TYPES
         self.write("ground types: %s\n\n" % GROUND_TYPES)
         self._t_start = clock()


### PR DESCRIPTION
Checks the architecture by comparing sys.maxint (not available in py3k)
or sys.maxsize (not available in py25) with 2**32. Adds this information
as a constant ARCH in utilities/misc.

Solves issue http://code.google.com/p/sympy/issues/detail?id=2473
