### PR TITLE
Matrices: Changed __eq__, and __ne__ methods.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -464,16 +464,20 @@ class Matrix(object):
     def __eq__(self, a):
         if not isinstance(a, (Matrix, Basic)):
             a = sympify(a)
-        if isinstance(a, Matrix):
-            return self.hash() == a.hash()
+        if isinstance(a, Matrix) and self.shape == a.shape:
+            return all(self[i, j] == a[i, j]
+                for i in xrange(self.rows)
+                for j in xrange(self.cols))
         else:
             return False
 
-    def __ne__(self,a):
+    def __ne__(self, a):
         if not isinstance(a, (Matrix, Basic)):
             a = sympify(a)
-        if isinstance(a, Matrix):
-            return self.hash() != a.hash()
+        if isinstance(a, Matrix) and self.shape == a.shape:
+            return any(self[i, j] != a[i, j]
+                for i in xrange(self.rows)
+                for j in xrange(self.cols))
         else:
             return True
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1761,3 +1761,20 @@ def test_len():
     assert len(Matrix([[0, 1, 2], [3, 4, 5]])) == 6
     assert Matrix([1])
     assert not Matrix()
+
+def test_equality():
+    A = Matrix(((1,2,3),(4,5,6),(7,8,9)))
+    B = Matrix(((9,8,7),(6,5,4),(3,2,1)))
+    assert A == A[:, :]
+    assert not A != A[:, :]
+    assert not A == B
+    assert A != B
+    assert A != 10
+    assert not A == 10
+
+    # A SparseMatrix can be equal to a Matrix
+    C = SparseMatrix(((1,0,0),(0,1,0),(0,0,1)))
+    D = Matrix(((1,0,0),(0,1,0),(0,0,1)))
+    assert C == D
+    assert not C != D
+    


### PR DESCRIPTION
Methods **eq** and **ne** now compare element-wise and do not use hashes.
