### PR TITLE
Potential fix for issue #2509; sort arguments of mul in change_mul

### DIFF
--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -1,6 +1,7 @@
 import sympy
 from sympy.functions import DiracDelta, Heaviside
 from sympy.solvers import solve
+from sympy.utilities.misc import default_sort_key
 
 def change_mul(node,x):
     """change_mul(node,x)
@@ -33,7 +34,10 @@ def change_mul(node,x):
         return node
     new_args = []
     dirac = None
-    for arg in node.args:
+    sorted_args = list(node.args)
+    sorted_args.sort(key=default_sort_key)
+
+    for arg in sorted_args:
         if arg.func == DiracDelta and arg.is_simple(x) \
                 and (len(arg.args) <= 1 or arg.args[1]==0):
             if dirac is None:
@@ -44,12 +48,12 @@ def change_mul(node,x):
             new_args.append(change_mul(arg,x))
     if not dirac:#we didn't find any simple dirac
         new_args = []
-        for arg in node.args:
+        for arg in sorted_args:
             if arg.func == DiracDelta:
                 new_args.append(arg.simplify(x))
             else:
                 new_args.append(change_mul(arg,x))
-        if tuple(new_args) != node.args:
+        if tuple(new_args) != sorted_args:
             nnode = node.__class__(*new_args).expand()
         else:#if the node didn't change there is nothing to do
             nnode = None


### PR DESCRIPTION
This is a fix for issue #2509: http://code.google.com/p/sympy/issues/detail?id=2509

It seems some people are experiencing test failures in master related to one of the tests I added in another recent pull request fixing issue 2489. These seem to be related to the sorting of the args of the Mul which goes into change_mul, because it just takes the first delta it finds to simplify. On my system, this test doesn't fail, so it's difficult for me to debug this myself. It would be great if someone who had the test failing could check this out and see if it is fixed.
