### PR TITLE
rename ordered_iter to is_sequence

### DIFF
--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -1,7 +1,7 @@
 """Gosper's algorithm for hypergeometric summation. """
 
 from sympy.core import S, Dummy, symbols
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from sympy.polys import Poly, parallel_poly_from_expr, factor
 from sympy.solvers import solve
 from sympy.simplify import hypersimp
@@ -182,7 +182,7 @@ def gosper_sum(f, k):
     """
     indefinite = False
 
-    if ordered_iter(k):
+    if is_sequence(k):
         k, a, b = k
     else:
         indefinite = True

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -1,5 +1,5 @@
 from sympy.core import Expr, S, C, Mul, sympify
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp
 
@@ -30,7 +30,7 @@ class Product(Expr):
                 k = symbol.lhs
                 a = symbol.rhs.start
                 n = symbol.rhs.end
-            elif ordered_iter(symbol):
+            elif is_sequence(symbol):
                 k, a, n = symbol
             else:
                 raise ValueError("Invalid arguments")

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -128,7 +128,7 @@ def iterable(i, exclude=(basestring, dict)):
     by default. If you want a pure python definition, make exclude=None. To
     exclude multiple items, pass them as a tuple.
 
-    See also: ordered_iter
+    See also: is_sequence
 
     Examples:
 
@@ -162,26 +162,36 @@ def iterable(i, exclude=(basestring, dict)):
         return not isinstance(i, exclude)
     return True
 
-def ordered_iter(i, include=None):
+def is_sequence(i, include=None):
     """
-    Return a boolean indicating whether i is an ordered iterable in the sympy
-    sense. If anything is iterable but doesn't have an index attribute, it
-    can be included in what is considered iterable by using the 'include'
-    keyword. If multiple items are to be included, pass them as a tuple.
+    Return a boolean indicating whether i is a sequence in the sympy
+    sense. If anything that fails the test below should be included as
+    being a sequence for your application, set 'include' to that object's
+    type; multiple types should be passed as a tuple of types.
+
+    Note: although generators can generate a sequence, they often need special
+    handling to make sure their elements are captured before the generator is
+    exhausted, so these are not included by default in the definition of a
+    sequence.
 
     See also: iterable
 
     Examples:
 
-    >>> from sympy.utilities.iterables import ordered_iter
-    >>> from sympy import Tuple
-    >>> ordered_iter([])
+    >>> from sympy.utilities.iterables import is_sequence
+    >>> from types import GeneratorType
+    >>> is_sequence([])
     True
-    >>> ordered_iter(set())
+    >>> is_sequence(set())
     False
-    >>> ordered_iter('abc')
+    >>> is_sequence('abc')
     False
-    >>> ordered_iter('abc', include=str)
+    >>> is_sequence('abc', include=str)
+    True
+    >>> generator = (c for c in 'abc')
+    >>> is_sequence(generator)
+    False
+    >>> is_sequence(generator, include=(str, GeneratorType))
     True
 
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -39,7 +39,7 @@ from numbers import Rational
 from sympy.core.containers import Tuple
 from sympy.core.decorators import deprecated
 from sympy.utilities import all, any, default_sort_key
-from sympy.core.compatibility import iterable, ordered_iter
+from sympy.core.compatibility import iterable, is_sequence
 from sympy.utilities.iterables import uniq
 
 from sympy import mpmath
@@ -902,7 +902,7 @@ class Subs(Expr):
 
     """
     def __new__(cls, expr, variables, point, **assumptions):
-        if not ordered_iter(variables, Tuple):
+        if not is_sequence(variables, Tuple):
             variables = [variables]
         variables = Tuple(*sympify(variables))
 
@@ -912,7 +912,7 @@ class Subs(Expr):
             raise ValueError('cannot substitute expressions %s more than '
                              'once.' % repeated)
 
-        if not ordered_iter(point, Tuple):
+        if not is_sequence(point, Tuple):
             point = [point]
         point = Tuple(*sympify(point))
 

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,7 +1,7 @@
 from sympy import Matrix, Tuple, symbols
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
-from sympy.core.compatibility import all, ordered_iter, iterable
+from sympy.core.compatibility import all, is_sequence, iterable
 
 def test_Tuple():
     t = (1, 2, 3, 4)
@@ -59,12 +59,12 @@ def test_tuple_wrapper():
     assert wrap_tuples_and_return((p, 1)) == (Tuple(p, 1),)
     assert wrap_tuples_and_return(1, (p, 2), 3) == (1, Tuple(p, 2), 3)
 
-def test_iterable_ordered_iter():
+def test_iterable_is_sequence():
     ordered = [list(), tuple(), Tuple(), Matrix([[]])]
     unordered = [set()]
     not_sympy_iterable = [{}, '', u'']
-    assert all(ordered_iter(i) for i in ordered)
-    assert all(not ordered_iter(i) for i in unordered)
+    assert all(is_sequence(i) for i in ordered)
+    assert all(not is_sequence(i) for i in unordered)
     assert all(iterable(i) for i in ordered + unordered)
     assert all(not iterable(i) for i in not_sympy_iterable)
     assert all(iterable(i, exclude=None) for i in not_sympy_iterable)

--- a/sympy/geometry/curve.py
+++ b/sympy/geometry/curve.py
@@ -7,7 +7,7 @@ Curve
 """
 
 from sympy.core import sympify, C, Symbol
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from sympy.geometry.exceptions import GeometryError
 from sympy.geometry.point import Point
 from entity import GeometryEntity
@@ -55,9 +55,9 @@ class Curve(GeometryEntity):
 
     def __new__(cls, function, limits):
         fun = sympify(function)
-        if not ordered_iter(fun) or len(fun) != 2:
+        if not is_sequence(fun) or len(fun) != 2:
             raise ValueError("Function argument should be (x(t), y(t)) but got %s" % str(function))
-        if not ordered_iter(limits) or len(limits) != 3:
+        if not is_sequence(limits) or len(limits) != 3:
             raise ValueError("Limit argument should be (t, tmin, tmax) but got %s" % str(limits))
         return GeometryEntity.__new__(cls, tuple(sympify(fun)), tuple(sympify(limits)))
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -2,7 +2,7 @@ from sympy.core import (Basic, Expr, S, C, Symbol, Wild, Add, sympify, diff,
                         oo, Tuple, Dummy, Equality, Interval)
 
 from sympy.core.symbol import Dummy
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.deltafunctions import deltaintegrate
 from sympy.integrals.rationaltools import ratint
@@ -55,7 +55,7 @@ def _process_limits(*symbols):
         if isinstance(V, Symbol):
             limits.append(Tuple(V))
             continue
-        elif ordered_iter(V, Tuple):
+        elif is_sequence(V, Tuple):
             V = sympify(flatten(V))
             if V[0].is_Symbol:
                 newsymbol = V[0]
@@ -869,7 +869,7 @@ def line_integrate(field, curve, vars):
         raise ValueError("Expecting function specifying field as first argument.")
     if not isinstance(curve, Curve):
         raise ValueError("Expecting Curve entity as second argument.")
-    if not ordered_iter(vars):
+    if not is_sequence(vars):
         raise ValueError("Expecting ordered iterable for variables.")
     if len(curve.functions) != len(vars):
         raise ValueError("Field variable size does not match curve dimension.")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,7 +1,7 @@
 from sympy import Basic, Symbol, Integer, C, S, Dummy, Rational, Add, Pow
 from sympy.core.numbers import Zero
 from sympy.core.sympify import sympify, converter, SympifyError
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 from sympy.polys import Poly, roots, cancel
 from sympy.simplify import simplify as sympy_simplify
@@ -96,7 +96,7 @@ class Matrix(object):
             for i in range(self.rows):
                 for j in range(self.cols):
                     self.mat.append(sympify(operation(i, j)))
-        elif len(args)==3 and ordered_iter(args[2]):
+        elif len(args)==3 and is_sequence(args[2]):
             self.rows=args[0]
             self.cols=args[1]
             mat = args[2]
@@ -127,7 +127,7 @@ class Matrix(object):
                     return
                 else:
                     raise NotImplementedError("Sympy supports just 1D and 2D matrices")
-            elif not ordered_iter(mat, include=Matrix):
+            elif not is_sequence(mat, include=Matrix):
                 raise TypeError("Matrix constructor doesn't accept %s as input" % str(type(mat)))
             mat = []
             for row in args[0]:
@@ -137,7 +137,7 @@ class Matrix(object):
                     mat.append(row)
             self.rows = len(mat)
             if len(mat) != 0:
-                if not ordered_iter(mat[0]):
+                if not is_sequence(mat[0]):
                     self.cols = 1
                     self.mat = map(lambda i: sympify(i), mat)
                     return
@@ -160,7 +160,7 @@ class Matrix(object):
 
     def key2ij(self,key):
         """Converts key=(4,6) to 4,6 and ensures the key is correct."""
-        if not (ordered_iter(key) and len(key) == 2):
+        if not (is_sequence(key) and len(key) == 2):
             raise TypeError("wrong syntax: a[%s]. Use a[i,j] or a[(i,j)]"
                     %repr(key))
         i,j=key
@@ -293,7 +293,7 @@ class Matrix(object):
                 if isinstance(value, Matrix):
                     self.copyin_matrix(key, value)
                     return
-                if ordered_iter(value):
+                if is_sequence(value):
                     self.copyin_list(key, value)
                     return
             else:
@@ -371,7 +371,7 @@ class Matrix(object):
                 self[i+rlo, j+clo] = sympify(value[i,j])
 
     def copyin_list(self, key, value):
-        if not ordered_iter(value):
+        if not is_sequence(value):
             raise TypeError("`value` must be an ordered iterable, not %s." % type(value))
         self.copyin_matrix(key, Matrix(value))
 
@@ -1397,7 +1397,7 @@ class Matrix(object):
     #            self[i,j] = self[i,j].eval()
 
     def cross(self, b):
-        if not ordered_iter(b, include=Matrix):
+        if not is_sequence(b, include=Matrix):
             raise TypeError("`b` must be an ordered iterable or Matrix, not %s." %
                 type(b))
         if not (self.rows == 1 and self.cols == 3 or \
@@ -1411,7 +1411,7 @@ class Matrix(object):
                                (self[0]*b[1] - self[1]*b[0])))
 
     def dot(self, b):
-        if not ordered_iter(b, include=Matrix):
+        if not is_sequence(b, include=Matrix):
             raise TypeError("`b` must be an ordered iterable or Matrix, not %s." %
                 type(b))
         m = len(b)
@@ -2715,7 +2715,7 @@ def hessian(f, varlist):
     see: http://en.wikipedia.org/wiki/Hessian_matrix
     """
     # f is the expression representing a function f, return regular matrix
-    if ordered_iter(varlist):
+    if is_sequence(varlist):
         m = len(varlist)
         if not m:
             raise ShapeError("`len(varlist)` must not be zero.")
@@ -2841,7 +2841,7 @@ class SparseMatrix(Matrix):
                     if value != 0:
                         self.mat[(i,j)] = value
         elif len(args)==3 and isinstance(args[0],int) and \
-                isinstance(args[1],int) and ordered_iter(args[2]):
+                isinstance(args[1],int) and is_sequence(args[2]):
             self.rows = args[0]
             self.cols = args[1]
             mat = args[2]
@@ -2864,7 +2864,7 @@ class SparseMatrix(Matrix):
                 mat = args[0]
             else:
                 mat = args
-            if not ordered_iter(mat[0]):
+            if not is_sequence(mat[0]):
                 mat = [ [element] for element in mat ]
             self.rows = len(mat)
             self.cols = len(mat[0])
@@ -2925,7 +2925,7 @@ class SparseMatrix(Matrix):
         if isinstance(key[0], slice) or isinstance(key[1], slice):
             if isinstance(value, Matrix):
                 self.copyin_matrix(key, value)
-            if ordered_iter(value):
+            if is_sequence(value):
                 self.copyin_list(key, value)
         else:
             i,j=self.key2ij(key)
@@ -3100,7 +3100,7 @@ class SparseMatrix(Matrix):
     # from here to end all functions are same as in matrices.py
     # with Matrix replaced with SparseMatrix
     def copyin_list(self, key, value):
-        if not ordered_iter(value):
+        if not is_sequence(value):
             raise TypeError("`value` must be of type list or tuple.")
         self.copyin_matrix(key, SparseMatrix(value))
 
@@ -3141,7 +3141,7 @@ class SparseMatrix(Matrix):
         return SparseMatrix(_rows, _cols, newD)
 
     def cross(self, b):
-        if not ordered_iter(b, include=Matrix):
+        if not is_sequence(b, include=Matrix):
             raise TypeError("`b` must be an ordered iterable or Matrix, not %s." %
                 type(b))
         if not (self.rows == 1 and self.cols == 3 or \

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -17,7 +17,7 @@ import random
 
 from sympy import Mul, Pow, Integer, Matrix, Rational, Tuple, I, sqrt, Add
 from sympy.core.numbers import Number
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.utilities.iterables import all
 
@@ -315,7 +315,7 @@ class CGate(Gate):
         # _eval_args has the right logic for the controls argument.
         controls = args[0]
         gate = args[1]
-        if not ordered_iter(controls):
+        if not is_sequence(controls):
             controls = (controls,)
         controls = UnitaryOperator._eval_args(controls)
         _validate_targets_controls(chain(controls,gate.targets))
@@ -443,7 +443,7 @@ class UGate(Gate):
     @classmethod
     def _eval_args(cls, args):
         targets = args[0]
-        if not ordered_iter(targets):
+        if not is_sequence(targets):
             targets = (targets,)
         targets = Gate._eval_args(targets)
         _validate_targets_controls(targets)

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -2,7 +2,7 @@
 from sympy import Expr, sympify, Symbol, Matrix
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.core.containers import Tuple
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 from sympy.physics.quantum.matrixutils import (
     numpy_ndarray, scipy_sparse_matrix,
@@ -55,7 +55,7 @@ def __qsympify_sequence_helper(seq):
        This function does the actual work.
     """
     #base case. If not a list, do Sympification
-    if not ordered_iter(seq):
+    if not is_sequence(seq):
         if isinstance(seq, Matrix):
             return seq
         elif isinstance(seq, basestring):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1,5 +1,5 @@
 from sympy import Integer
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 from threading import RLock
 
@@ -291,7 +291,7 @@ class Plot(object):
         if isinstance(args, PlotObject):
             f = args
         else:
-            if (not ordered_iter(args)) or isinstance(args, GeometryEntity):
+            if (not is_sequence(args)) or isinstance(args, GeometryEntity):
                 args = [args]
             if len(args) == 0:
                 return # no arguments given

--- a/sympy/plotting/plot_axes.py
+++ b/sympy/plotting/plot_axes.py
@@ -6,7 +6,7 @@ from util import strided_range, billboard_matrix
 from util import get_direction_vectors
 from util import dot_product, vec_sub, vec_mag
 from sympy.core import S
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 class PlotAxes(PlotObject):
 
@@ -33,7 +33,7 @@ class PlotAxes(PlotObject):
         stride = kwargs.pop('stride', 0.25)
         try: stride = eval(stride)
         except: pass
-        if ordered_iter(stride):
+        if is_sequence(stride):
             assert len(stride) == 3
             self._stride = stride
         else:

--- a/sympy/plotting/plot_mode.py
+++ b/sympy/plotting/plot_mode.py
@@ -3,7 +3,7 @@ from plot_interval import PlotInterval
 from plot_object import PlotObject
 from util import parse_option_string
 from sympy.geometry.entity import GeometryEntity
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 class PlotMode(PlotObject):
     """
@@ -363,7 +363,7 @@ class PlotMode(PlotObject):
                     else:
                         intervals.append(i)
                 else:
-                    if ordered_iter(a, include=str):
+                    if is_sequence(a, include=str):
                         raise ValueError(interpret_error % (str(a)))
                     try:
                         f = sympify(a)

--- a/sympy/plotting/plot_mode_base.py
+++ b/sympy/plotting/plot_mode_base.py
@@ -3,7 +3,7 @@ from plot_mode import PlotMode
 from threading import Thread, Event, RLock
 from color_scheme import ColorScheme
 from sympy.core import S
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from time import sleep
 
 from sympy.core.compatibility import callable
@@ -326,7 +326,7 @@ class PlotModeBase(PlotMode):
     def _set_color(self, v):
         try:
             if v is not None:
-                if ordered_iter(v):
+                if is_sequence(v):
                     v = ColorScheme(*v)
                 else: v = ColorScheme(v)
             if repr(v) == repr(self._color): return

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -13,7 +13,7 @@
 
 """
 
-from sympy.core.compatibility import iterable, ordered_iter
+from sympy.core.compatibility import iterable, is_sequence
 from sympy.core.sympify import sympify
 from sympy.core import S, Mul, Add, Pow, Symbol, Wild, Equality, Dummy, Basic
 from sympy.core.numbers import ilcm
@@ -414,7 +414,7 @@ def solve(f, *symbols, **flags):
     ordered_symbols = (symbols and
                        symbols[0] and
                        (isinstance(symbols[0], Symbol) or
-                        ordered_iter(symbols[0], include=GeneratorType)
+                        is_sequence(symbols[0], include=GeneratorType)
                        )
                       )
     f, symbols = (sympified_list(w) for w in [f, symbols])
@@ -502,9 +502,13 @@ def solve(f, *symbols, **flags):
     # see issue 2405 for logic in how Polys chooses ordering and
     # for discussion of what to return see http://groups.google.com/group/sympy
     #                           Apr 18, 2011 posting 'using results from solve'
-    elif (not ordered_symbols and len(symbols) > 1 and solution and
-          ordered_iter(solution) and ordered_iter(solution[0]) and
-          any(len(set(s)) > 1 for s in solution)):
+    elif (not ordered_symbols and
+          len(symbols) > 1 and
+          solution and
+          is_sequence(solution) and
+          is_sequence(solution[0]) and
+          any(len(set(s)) > 1 for s in solution)
+         ):
         msg = ('\n\tFor nonlinear systems of equations, symbols should be' +
                '\n\tgiven as a list so as to avoid ambiguity in the results.' +
                '\n\tsolve sorted the symbols as %s')

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -106,7 +106,7 @@
 #      - Idx with step determined by function call
 
 from sympy.core import Expr, Basic, Tuple, Symbol, Integer, sympify, S
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 class IndexException(Exception):
     pass
@@ -169,7 +169,7 @@ class IndexedBase(Expr):
             label = Symbol(label)
 
         obj = Expr.__new__(cls, label, **kw_args)
-        if ordered_iter(shape):
+        if is_sequence(shape):
             obj._shape = Tuple(*shape)
         else:
             obj._shape = shape
@@ -186,7 +186,7 @@ class IndexedBase(Expr):
         return Expr._hashable_content(self) + (self._shape,)
 
     def __getitem__(self, indices, **kw_args):
-        if ordered_iter(indices):
+        if is_sequence(indices):
             # Special case needed because M[*my_tuple] is a syntax error.
             if self.shape and len(self.shape) != len(indices):
                 raise IndexException("Rank mismatch")
@@ -374,7 +374,7 @@ class Idx(Expr):
         if not label.is_integer:
             raise TypeError("Idx object requires an integer label")
 
-        elif ordered_iter(range):
+        elif is_sequence(range):
             assert len(range) == 2, "Idx got range tuple with wrong length"
             for bound in range:
                 if not (bound.is_integer or abs(bound) is S.Infinity):

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -77,7 +77,7 @@ from StringIO import StringIO
 
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
 from sympy.printing.fcode import fcode, FCodePrinter
@@ -139,7 +139,7 @@ class Routine(object):
         """
         arg_list = []
 
-        if ordered_iter(expr):
+        if is_sequence(expr):
             if not expr:
                 raise ValueError("No expression given")
             expressions = Tuple(*expr)

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,6 +1,6 @@
 from sympy.core import Basic, C
 from sympy.core.compatibility import minkey, iff, all, any #for backwards compatibility
-from sympy.core.compatibility import ordered_iter, iterable #logically, they belong here
+from sympy.core.compatibility import is_sequence, iterable #logically, they belong here
 
 import random
 

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -5,7 +5,7 @@ lambda functions which can be used to calculate numerical values very fast.
 
 from __future__ import division
 from sympy.core.sympify import sympify
-from sympy.core.compatibility import ordered_iter
+from sympy.core.compatibility import is_sequence
 
 import inspect
 
@@ -309,7 +309,7 @@ def _imp_namespace(expr, namespace=None):
     if namespace is None:
         namespace = {}
     # tuples, lists, dicts are valid expressions
-    if ordered_iter(expr):
+    if is_sequence(expr):
         for arg in expr:
             _imp_namespace(arg, namespace)
         return namespace


### PR DESCRIPTION
docstring of ordered_iter is updated to reflect the fact that generators are not included (but demonstrates how they can be) and the name is globally changed to is_sequence
