### PR TITLE
Funcderiv

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -20,6 +20,11 @@ class Expr(Basic, EvalfMixin):
         temporarily converts the non-Symbol vars in Symbols when performing
         the differentiation.
 
+        Note, see the docstring of Derivative for how this should work
+        mathematically.  In particular, note that expr.subs(yourclass, Symbol)
+        should be well-defined on a structural level, or this will lead to
+        inconsistent results.
+
         Examples
         ========
 
@@ -27,6 +32,11 @@ class Expr(Basic, EvalfMixin):
             >>> e = Expr()
             >>> e._diff_wrt
             False
+            >>> class MyClass(Expr):
+            ...     _diff_wrt = True
+            ...
+            >>> (2*MyClass()).diff(MyClass())
+            2
         """
         return False
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,6 +9,11 @@ from compatibility import reduce
 class Expr(Basic, EvalfMixin):
     __slots__ = []
 
+    # This determines if it is allowed to take derivatives wrt this type of
+    # object. Subclasses such as Symbol should set this to True to enable
+    # derivatives wrt them.
+    _diff_wrt = False
+
     def sort_key(self, order=None):
         # XXX: The order argument does not actually work
         from sympy.core import S

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -10,8 +10,11 @@ class Expr(Basic, EvalfMixin):
     __slots__ = []
 
     # This determines if it is allowed to take derivatives wrt this type of
-    # object. Subclasses such as Symbol should set this to True to enable
-    # derivatives wrt them.
+    # object. Subclasses such as Symbol, Function and Derivative should set
+    # this to True to enable derivatives wrt them. The implementation in
+    # Derivative separates the Symbol and non-Symbol diff_wrt=True variables
+    # and temporarily converts the non-Symbol vars in Symbols when performing
+    # the differentiation.
     _diff_wrt = False
 
     def sort_key(self, order=None):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,13 +9,26 @@ from compatibility import reduce
 class Expr(Basic, EvalfMixin):
     __slots__ = []
 
-    # This determines if it is allowed to take derivatives wrt this type of
-    # object. Subclasses such as Symbol, Function and Derivative should set
-    # this to True to enable derivatives wrt them. The implementation in
-    # Derivative separates the Symbol and non-Symbol diff_wrt=True variables
-    # and temporarily converts the non-Symbol vars in Symbols when performing
-    # the differentiation.
-    _diff_wrt = False
+    @property
+    def _diff_wrt(self):
+        """Is it allowed to take derivative wrt to this instance.
+
+        This determines if it is allowed to take derivatives wrt this object.
+        Subclasses such as Symbol, Function and Derivative should return True
+        to enable derivatives wrt them. The implementation in Derivative
+        separates the Symbol and non-Symbol _diff_wrt=True variables and
+        temporarily converts the non-Symbol vars in Symbols when performing
+        the differentiation.
+
+        Examples
+        ========
+
+            >>> from sympy import Expr
+            >>> e = Expr()
+            >>> e._diff_wrt
+            False
+        """
+        return False
 
     def sort_key(self, order=None):
         # XXX: The order argument does not actually work

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -622,7 +622,7 @@ class Derivative(Expr):
 
     This class also allows derivatives wrt non-Symbols that have _diff_wrt
     set to True, such as Function and Derivative. When a derivative wrt a non-
-    Symbol is attempts, the non-Symbol is termporarily converted to a Symbol
+    Symbol is attempted, the non-Symbol is termporarily converted to a Symbol
     while the differentiation is performed.
 
     Examples

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -862,7 +862,10 @@ class Derivative(Expr):
     def _eval_subs(self, old, new):
         if self==old:
             return new
-        if old in self.variables and not new.is_Symbol:
+        # Subs should only be used in situations where new is not a valid
+        # variable for differentiating wrt. Previously, Subs was used for
+        # anything that was not a Symbol, but that was too broad.
+        if old in self.variables and not new._diff_wrt:
             # Issue 1620
             return Subs(self, old, new)
         return Derivative(*map(lambda x: x._eval_subs(old, new), self.args))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -628,9 +628,18 @@ class Derivative(Expr):
     method internally (not _eval_derivative); Derivative should be the only
     one to call _eval_derivative.
 
+    Ordering of variables
+    ---------------------
+
     If evaluate is set to True and the expression can not be evaluated, the
     list of differentiation symbols will be sorted, that is, the expression is
-    assumed to have continuous derivatives up to the order asked.
+    assumed to have continuous derivatives up to the order asked. This sorting
+    assumes that derivatives wrt Symbols commute, derivatives wrt non-Symbols
+    commute, but Symbol and non-Symbol derivatives don't commute with each
+    other.
+
+    Derivative wrt non-Symbols
+    --------------------------
 
     This class also allows derivatives wrt non-Symbols that have _diff_wrt
     set to True, such as Function and Derivative. When a derivative wrt a non-

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -620,12 +620,37 @@ class Derivative(Expr):
     list of differentiation symbols will be sorted, that is, the expression is
     assumed to have continuous derivatives up to the order asked.
 
-    Examples:
+    This class also allows derivatives wrt non-Symbols that have _diff_wrt
+    set to True, such as Function and Derivative. When a derivative wrt a non-
+    Symbol is attempts, the non-Symbol is termporarily converted to a Symbol
+    while the differentiation is performed.
 
-    Derivative(Derivative(expr, x), y) -> Derivative(expr, x, y)
-    Derivative(expr, x, 3)  -> Derivative(expr, x, x, x)
-    Derivative(f(x, y), y, x, evaluate=True) -> Derivative(f(x, y), x, y)
+    Examples
+    ========
 
+    Some basic examples:
+
+        >>> from sympy import Derivative, Symbol, Function
+        >>> f = Function('f')
+        >>> g = Function('g')
+        >>> x = Symbol('x')
+        >>> y = Symbol('y')
+
+        >>> Derivative(x**2, x, evaluate=True)
+        2*x
+        >>> Derivative(Derivative(f(x,y), x), y)
+        Derivative(f(x, y), x, y)
+        >>> Derivative(f(x), x, 3)
+        Derivative(f(x), x, x, x)
+        >>> Derivative(f(x, y), y, x, evaluate=True)
+        Derivative(f(x, y), x, y)
+
+    Now some derivatives wrt functions:
+
+        >>> Derivative(f(x)**2, f(x), evaluate=True)
+        2*f(x)
+        >>> Derivative(f(g(x)), x, evaluate=True)
+        Derivative(f(g(x)), g(x))*Derivative(g(x), x)
     """
 
     is_Derivative   = True

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -156,8 +156,20 @@ class Function(Application, Expr):
 
     """
 
-    # Allow derivatives wrt functions.
-    _diff_wrt = True
+    @property
+    def _diff_wrt(self):
+        """Allow derivatives wrt functions.
+
+        Examples
+        ========
+
+            >>> from sympy import Function, Symbol
+            >>> f = Function('f')
+            >>> x = Symbol('x')
+            >>> f(x)._diff_wrt
+            True
+        """
+        return True
 
     @cacheit
     def __new__(cls, *args, **options):
@@ -622,7 +634,7 @@ class Derivative(Expr):
 
     This class also allows derivatives wrt non-Symbols that have _diff_wrt
     set to True, such as Function and Derivative. When a derivative wrt a non-
-    Symbol is attempted, the non-Symbol is termporarily converted to a Symbol
+    Symbol is attempted, the non-Symbol is temporarily converted to a Symbol
     while the differentiation is performed.
 
     Examples
@@ -655,8 +667,25 @@ class Derivative(Expr):
 
     is_Derivative   = True
 
-    # Allow derivatives wrt derivatives.
-    _diff_wrt = True
+    @property
+    def _diff_wrt(self):
+        """Allow derivatives wrt Derivatives if it contains a function.
+
+        Examples
+        ========
+
+            >>> from sympy import Function, Symbol, Derivative
+            >>> f = Function('f')
+            >>> x = Symbol('x')
+            >>> Derivative(f(x),x)._diff_wrt
+            True
+            >>> Derivative(x**2,x)._diff_wrt
+            False
+        """
+        if self.expr.is_Function:
+            return True
+        else:
+            return False
 
     def __new__(cls, expr, *symbols, **assumptions):
         expr = sympify(expr)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -31,6 +31,9 @@ class Symbol(AtomicExpr, Boolean):
 
     is_Symbol = True
 
+    # Allow derivatives wrt symbols.
+    _diff_wrt = True
+
     def __new__(cls, name, commutative=True, **assumptions):
         """Symbols are identified by name and assumptions::
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -31,8 +31,19 @@ class Symbol(AtomicExpr, Boolean):
 
     is_Symbol = True
 
-    # Allow derivatives wrt symbols.
-    _diff_wrt = True
+    @property
+    def _diff_wrt(self):
+        """Allow derivatives wrt Symbols.
+
+        Examples
+        ========
+
+            >>> from sympy import Symbol
+            >>> x = Symbol('x')
+            >>> x._diff_wrt
+            True
+        """
+        return True
 
     def __new__(cls, name, commutative=True, **assumptions):
         """Symbols are identified by name and assumptions::

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -247,8 +247,8 @@ def test_deriv1():
     g = Function('g')
     x = Symbol('x')
 
-    assert f(g(x)).diff(x) == Derivative(g(x), x)*Subs(Derivative(f(x), x),
-            Tuple(x), Tuple(g(x)))
+    # assert f(g(x)).diff(x) == Derivative(g(x), x)*Subs(Derivative(f(x), x),
+    #         Tuple(x), Tuple(g(x)))
     assert f(2*x).diff(x) == 2*Subs(Derivative(f(x), x), Tuple(x), Tuple(2*x))
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
     assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Subs(Derivative(f(x), x), Tuple(x),
@@ -257,8 +257,8 @@ def test_deriv1():
     assert f(2+x).diff(x) == Subs(Derivative(f(x), x), Tuple(x), Tuple(x + 2))
     assert f(2+3*x).diff(x) == 3*Subs(Derivative(f(x), x), Tuple(x),
             Tuple(3*x + 2))
-    assert f(sin(x)).diff(x) == cos(x)*Subs(Derivative(f(x), x), Tuple(x),
-            Tuple(sin(x)))
+    # assert f(sin(x)).diff(x) == cos(x)*Subs(Derivative(f(x), x), Tuple(x),
+    #         Tuple(sin(x)))
     assert f(3*sin(x)).diff(x) == 3*cos(x)*Subs(Derivative(f(x), x),
             Tuple(x), Tuple(3*sin(x)))
 

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -385,3 +385,29 @@ def test_fdiff_argument_index_error():
     mf = myfunc(x)
     assert mf.diff(x) == Derivative(mf, x)
     raises(ValueError, 'myfunc(x, x)')
+
+def test_functional_deriv():
+    t = Symbol('t')
+    xfunc = Function('x')
+    yfunc = Function('y')
+    x = xfunc(t)
+    xd = diff(x, t)
+    xdd = diff(xd, t)
+    y = yfunc(t)
+    yd = diff(y, t)
+    ydd = diff(yd, t)
+    assert diff(x, t) == xd
+    assert diff(2 * x + 4, t) == 2 * xd
+    assert diff(2 * x + 4 + y, t) == 2 * xd + yd
+    assert diff(2 * x + 4 + y * x, t) == 2 * xd + x * yd + xd * y
+    assert diff(2 * x + 4 + y * x, x) == 2 + y
+    assert (diff(4 * x**2 + 3 * x + x * y, t) == 3 * xd + x * yd + xd * y +
+            8 * x * xd)
+    assert (diff(4 * x**2 + 3 * xd + x * y, t) ==  3 * xdd + x * yd + xd * y +
+            8 * x * xd)
+    assert diff(4 * x**2 + 3 * xd + x * y, xd) == 3
+    assert diff(4 * x**2 + 3 * xd + x * y, xdd) == 0
+    assert diff(sin(x), t) == xd * cos(x)
+    assert diff(exp(x), t) == xd * exp(x)
+    assert diff(sqrt(x), t) == xd / (2 * sqrt(x))
+

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -162,6 +162,7 @@ def test_Subs():
     y = Symbol('y')
     z = Symbol('z')
     f = Function('f')
+    g = Function('g')
 
     assert Subs(f(x), x, 0).doit() == f(0)
     assert Subs(f(x**2), x**2, 0).doit() == f(0)
@@ -204,6 +205,8 @@ def test_Subs():
     assert e1 + e2 == 2*e1
     assert e1.__hash__() == e2.__hash__()
     assert Subs(z*f(x+1), x, 1) not in [ e1, e2 ]
+    assert Derivative(f(x),x).subs(x,g(x)) == Derivative(f(g(x)),g(x))
+
 
 @XFAIL
 def test_Subs2():
@@ -440,6 +443,8 @@ def test_diff_wrt():
         Derivative(f(g(x), h(x)), g(x))*Derivative(g(x), x) +\
         Derivative(f(g(x), h(x)), h(x))*Derivative(h(x), x)
     assert f(sin(x)).diff(x) == Derivative(f(sin(x)),sin(x))*cos(x)
+
+    assert diff(f(g(x)),g(x)) == Derivative(f(g(x)),g(x))
 
 def test_klein_gordon_lagrangian():
     x = Symbol('x')

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -462,3 +462,11 @@ def test_sho_lagrangian():
     eqna = Eq(diff(L,x), diff(L,diff(x,t),t))
     eqnb = Eq(-k*x, m*diff(x,t,t))
     assert eqna == eqnb
+
+def test_straight_line():
+    x = Symbol('x')
+    f = Function('f')(x)
+
+    L = sqrt(1 + diff(f,x)**2)
+    assert diff(L,f) == 0
+    assert diff(L, diff(f,x)) == diff(f,x)/sqrt(1 + diff(f,x)**2)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -450,7 +450,7 @@ def test_diff_wrt():
 def test_diff_wrt_not_allowed():
     x = Symbol('x')
     y = Symbol('y')
-    
+
     assert diff(sin(x**2),x**2) == cos(x**2)
     assert diff(exp(x*y)),x*y == exp(x*y)
     assert diff(1+x,1+x) == 1

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -446,6 +446,15 @@ def test_diff_wrt():
 
     assert diff(f(g(x)),g(x)) == Derivative(f(g(x)),g(x))
 
+@XFAIL
+def test_diff_wrt_not_allowed():
+    x = Symbol('x')
+    y = Symbol('y')
+    
+    assert diff(sin(x**2),x**2) == cos(x**2)
+    assert diff(exp(x*y)),x*y == exp(x*y)
+    assert diff(1+x,1+x) == 1
+
 def test_klein_gordon_lagrangian():
     x = Symbol('x')
     t = Symbol('t')

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -446,14 +446,13 @@ def test_diff_wrt():
 
     assert diff(f(g(x)),g(x)) == Derivative(f(g(x)),g(x))
 
-@XFAIL
 def test_diff_wrt_not_allowed():
     x = Symbol('x')
     y = Symbol('y')
 
-    assert diff(sin(x**2),x**2) == cos(x**2)
-    assert diff(exp(x*y)),x*y == exp(x*y)
-    assert diff(1+x,1+x) == 1
+    raises(ValueError, 'diff(sin(x**2),x**2)')
+    raises(ValueError, 'diff(exp(x*y)),x*y')
+    raises(ValueError, 'diff(1+x,1+x)')
 
 def test_klein_gordon_lagrangian():
     x = Symbol('x')

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,7 +1,7 @@
 from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         oo, zoo, nan, E, expand, pi, O, Sum, S, polygamma, loggamma,
-        Tuple, Dummy, Eq)
+        Tuple, Dummy, Eq, Expr)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import x, y, n
 from sympy.core.function import PoleError
@@ -411,6 +411,16 @@ def test_deriv_wrt_function():
     assert diff(exp(x), t) == xd * exp(x)
     assert diff(sqrt(x), t) == xd / (2 * sqrt(x))
 
+def test_diff_wrt_value():
+    x = Symbol('x')
+    f = Function('f')
+
+    assert Expr()._diff_wrt == False
+    assert x._diff_wrt == True
+    assert f(x)._diff_wrt == True
+    assert Derivative(f(x),x)._diff_wrt == True
+    assert Derivative(x**2,x)._diff_wrt == False
+
 def test_diff_wrt():
     x = Symbol('x')
     f = Function('f')
@@ -435,6 +445,8 @@ def test_diff_wrt():
 
     assert diff(f(x), x).diff(f(x)) == 0
     assert (sin(f(x)) - cos(diff(f(x), x))).diff(f(x)) == cos(f(x))
+
+    assert diff(sin(fx), fx, x) == diff(sin(fx), x, fx)
 
     # Chain rule cases
     assert f(g(x)).diff(x) ==\

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -247,8 +247,6 @@ def test_deriv1():
     g = Function('g')
     x = Symbol('x')
 
-    # assert f(g(x)).diff(x) == Derivative(g(x), x)*Subs(Derivative(f(x), x),
-    #         Tuple(x), Tuple(g(x)))
     assert f(2*x).diff(x) == 2*Subs(Derivative(f(x), x), Tuple(x), Tuple(2*x))
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
     assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Subs(Derivative(f(x), x), Tuple(x),
@@ -257,8 +255,6 @@ def test_deriv1():
     assert f(2+x).diff(x) == Subs(Derivative(f(x), x), Tuple(x), Tuple(x + 2))
     assert f(2+3*x).diff(x) == 3*Subs(Derivative(f(x), x), Tuple(x),
             Tuple(3*x + 2))
-    # assert f(sin(x)).diff(x) == cos(x)*Subs(Derivative(f(x), x), Tuple(x),
-    #         Tuple(sin(x)))
     assert f(3*sin(x)).diff(x) == 3*cos(x)*Subs(Derivative(f(x), x),
             Tuple(x), Tuple(3*sin(x)))
 
@@ -386,7 +382,7 @@ def test_fdiff_argument_index_error():
     assert mf.diff(x) == Derivative(mf, x)
     raises(ValueError, 'myfunc(x, x)')
 
-def test_functional_deriv():
+def test_deriv_wrt_function():
     t = Symbol('t')
     xfunc = Function('x')
     yfunc = Function('y')
@@ -396,6 +392,7 @@ def test_functional_deriv():
     y = yfunc(t)
     yd = diff(y, t)
     ydd = diff(yd, t)
+
     assert diff(x, t) == xd
     assert diff(2 * x + 4, t) == 2 * xd
     assert diff(2 * x + 4 + y, t) == 2 * xd + yd
@@ -410,4 +407,15 @@ def test_functional_deriv():
     assert diff(sin(x), t) == xd * cos(x)
     assert diff(exp(x), t) == xd * exp(x)
     assert diff(sqrt(x), t) == xd / (2 * sqrt(x))
+
+def test_diff_wrt():
+    x = Symbol('x')
+    f = Function('f')
+    g = Function('g')
+
+    assert diff(f(x), x).diff(f(x)) == 0
+    assert (sin(f(x)) - cos(diff(f(x), x))).diff(f(x)) == cos(f(x))
+    assert f(g(x)).diff(x) == \
+        Derivative(f(g(x)),g(x))*Derivative(g(x),x)
+    assert f(sin(x)).diff(x) == Derivative(f(sin(x)),sin(x))*cos(x)
 


### PR DESCRIPTION
This branch enables Derivative to compute derivatives with respect to non-Symbols, such as functions and general expressions.  The following now works:

```
In [2]: fd = diff(f(t),t)
In [3]: diff(sin(fd),fd)
Out[3]: cos(Derivative(f(t), t))

In [7]: diff(2*x**3, x**3)
Out[7]: 2

```

This is accomplished by modifying `Derivative.__new__` to do the following:
- Find the list of symbols and their counts. In this context, the symbols are the things you are differentiating with respect to.
- For symbols that are not `Symbol`, create a temporary `Symbol` and sub it into the expression.
- Carry out the derivative with respect to the temporary `Symbol`.
- Substitute the original "symbol" back.

There still some issues that have to be worked out:

First, combining functional derivatives with plain derivatives does not work.  For example:

```
In [4]: diff(sin(fd),fd, t)  # should not be 0!
Out[4]: 0
```

This can be done in two steps though:

```

In [8]: diff(sin(fd),fd)
Out[8]: cos(Derivative(f(t), t))

In [9]: diff(_8, t)
Out[9]: -sin(Derivative(f(t), t))*Derivative(f(t), t, t)
```

But this should work in a single step.

Second, `Subs` is getting in the way of this working in some cases:

```
In [10]: diff(f(g(x)), x)
Out[10]: Derivative(g(x), x)*Subs(Derivative(f(_xi_1), _xi_1), Tuple(_xi_1), Tuple(g(x)))
```

While this is not incorrect per-se, it would be nice to actually have the result in terms of:

```
Derivative(f(g(x)), g(x))
```

I know that `Subs` was added to allow derivatives to be evaluated at points, but I think there is currently some cases it is handling that we don't need it to.  

The other aspect of Subs is that `Subs` is getting in the way of doing the back substitution after the derivatives are done.
