### PR TITLE
Issue 2098: solve() must checks assumptions on symbols, to filter solutio

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -217,7 +217,7 @@ def check_assumptions(expr, **assumptions):
                                             A boolean is expected.' %(key, expected)
         if hasattr(Q, key):
             test = ask(getattr(Q, key)(expr))
-            if test == expected:
+            if test is expected:
                 continue
             elif test is not None:
                 return False
@@ -573,7 +573,7 @@ def solve(f, *symbols, **flags):
     # XXX: Currently, there are some cases which are not handled,
     # see issue 2098 comment 13: http://code.google.com/p/sympy/issues/detail?id=2098#c13.
     if type(solution) is list and solution:
-        if type(solution[0]) is tuple and len(solution[0]) == len(symbols):
+        if type(solution[0]) is tuple:
             filtered = []
             for s in solution:
                 if all(check_assumptions(val, **symb.assumptions0) is not False
@@ -583,7 +583,7 @@ def solve(f, *symbols, **flags):
         elif len(symbols) == 1:
             solution = [s for s in solution if check_assumptions(s, **symbols[0].assumptions0) is not False]
     elif type(solution) is dict:
-        for symb, val in solution.copy().iteritems():
+        for symb, val in solution.iteritems():
             if check_assumptions(val, **symb.assumptions0) is False: # not None nor True
                 solution = None
                 break

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -580,8 +580,12 @@ def solve(f, *symbols, **flags):
                        for symb, val in zip(symbols, s)):
                    filtered.append(s)
             solution = filtered
-        elif len(symbols) == 1:
-            solution = [s for s in solution if check_assumptions(s, **symbols[0].assumptions0) is not False]
+        else:
+            if len(symbols) != 1: # find which one was solved for
+                symbols = list(f.free_symbols - set.union(*(s.free_symbols for s in solution)))
+            if len(symbols) == 1:
+                solution = [s for s in solution
+                              if check_assumptions(s, **symbols[0].assumptions0) is not False]
     elif type(solution) is dict:
         for symb, val in solution.iteritems():
             if check_assumptions(val, **symb.assumptions0) is False: # not None nor True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -207,8 +207,7 @@ def check_assumptions(expr, **assumptions):
        >>> z = Symbol('z')
        >>> check_assumptions(z, real=True)
     """
-    if not isinstance(expr, Basic):
-        expr = sympify(expr)
+    expr = sympify(expr)
 
     result = True
     for key, expected in assumptions.iteritems():
@@ -225,7 +224,7 @@ def check_assumptions(expr, **assumptions):
         # ask() can not conclude. Try using old assumption system.
         # XXX: remove this once transition to new assumption system is finished.
         test = getattr(expr, 'is_' + key, None)
-        if test == expected:
+        if test is expected:
             continue
         elif test is not None:
             return False

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -34,6 +34,8 @@ from sympy.solvers.inequalities import reduce_inequalities
 
 from sympy.core.compatibility import reduce
 
+from sympy.assumptions import Q, ask
+
 from warnings import warn
 from types import GeneratorType
 
@@ -172,6 +174,63 @@ def checksol(f, symbol, sol=None, **flags):
         print("Warning: could not verify solution %s." % sol)
     # returns None if it can't conclude
     # TODO: improve solution testing
+
+def check_assumptions(expr, **assumptions):
+    """Checks whether expression `expr` satisfies all assumptions.
+
+    `assumptions` is a dict of assumptions: {'assumption': True|False, ...}.
+
+    Examples:
+    ---------
+
+       >>> from sympy import Symbol, pi, I, exp
+       >>> from sympy.solvers.solvers import check_assumptions
+
+       >>> check_assumptions(-5, integer=True)
+       True
+       >>> check_assumptions(pi, real=True, integer=False)
+       True
+       >>> check_assumptions(pi, real=True, negative=True)
+       False
+       >>> check_assumptions(exp(I*pi/7), real=False)
+       True
+
+       >>> x = Symbol('x', real=True, positive=True)
+       >>> check_assumptions(2*x + 1, real=True, positive=True)
+       True
+       >>> check_assumptions(-2*x - 5, real=True, positive=True)
+       False
+
+       `None` is returned if check_assumptions() could not conclude.
+
+       >>> check_assumptions(2*x - 1, real=True, positive=True)
+       >>> z = Symbol('z')
+       >>> check_assumptions(z, real=True)
+    """
+    if not isinstance(expr, Basic):
+        expr = sympify(expr)
+
+    result = True
+    for key, expected in assumptions.iteritems():
+        if expected is None:
+            continue
+        assert isinstance(expected, bool), 'Argument %s=%s is incorrect. \
+                                            A boolean is expected.' %(key, expected)
+        if hasattr(Q, key):
+            test = ask(getattr(Q, key)(expr))
+            if test == expected:
+                continue
+            elif test is not None:
+                return False
+        # ask() can not conclude. Try using old assumption system.
+        # XXX: remove this once transition to new assumption system is finished.
+        test = getattr(expr, 'is_' + key, None)
+        if test == expected:
+            continue
+        elif test is not None:
+            return False
+        result = None # Can not conclude, unless an other test fails.
+    return result
 
 # Codes for guess solve strategy
 GS_POLY = 0
@@ -509,9 +568,31 @@ def solve(f, *symbols, **flags):
                '\n\tgiven as a list so as to avoid ambiguity in the results.' +
                '\n\tsolve sorted the symbols as %s')
         print msg % str(bool(symbol_swapped) and list(zip(*swap_dict)[0]) or symbols)
+
+    # Get assumptions about symbols, to filter solutions.
+    # Note that if assumptions about a solution can't be verified, it is still returned.
+    # XXX: Currently, there are some cases which are not handled,
+    # see issue 2098 comment 13: http://code.google.com/p/sympy/issues/detail?id=2098#c13.
+    if type(solution) is list and solution:
+        if type(solution[0]) is tuple and len(solution[0]) == len(symbols):
+            filtered = []
+            for s in solution:
+                if all(check_assumptions(val, **symb.assumptions0) is not False
+                       for symb, val in zip(symbols, s)):
+                   filtered.append(s)
+            solution = filtered
+        elif len(symbols) == 1:
+            solution = [s for s in solution if check_assumptions(s, **symbols[0].assumptions0) is not False]
+    elif type(solution) is dict:
+        for symb, val in solution.copy().iteritems():
+            if check_assumptions(val, **symb.assumptions0) is False: # not None nor True
+                solution = None
+                break
+
     #
     # done
     ###########################################################################
+
     return solution
 
 def _solve(f, *symbols, **flags):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -227,14 +227,14 @@ def check_assumptions(expr, **assumptions):
                 continue
             elif test is not None:
                 return False
-        # ask() can not conclude. Try using old assumption system.
+        # ask() can't conclude. Try using old assumption system.
         # XXX: remove this once transition to new assumption system is finished.
         test = getattr(expr, 'is_' + key, None)
         if test is expected:
             continue
         elif test is not None:
             return False
-        result = None # Can not conclude, unless an other test fails.
+        result = None # Can't conclude, unless an other test fails.
     return result
 
 # Codes for guess solve strategy
@@ -346,7 +346,7 @@ def solve(f, *symbols, **flags):
                                   order 3 or greater)
                 - ``warning``, when True, will warn every time a solution can
                                not be checked, or assumptions about a variable
-                               can not be verified for a solution.
+                               can't be verified for a solution.
 
         The output varies according to the input and can be seen by example:
 
@@ -467,12 +467,15 @@ def solve(f, *symbols, **flags):
                     [(2, -4)]
 
                 If two variables (or more) don't appear in the result, the assumptions
-                can not be checked.
+                can't be checked.
                     >>> solve(z**2*x**2 - z**2*y**2/exp(x), x, y, z, warning=True)
                     <BLANKLINE>
-                        Warning: assumptions can not be checked
-                        (can not find for which variable equation was solved).
+                        Warning: assumptions can't be checked
+                        (can't find for which variable equation was solved).
                     [x*exp(x/2), -x*exp(x/2)]
+
+                Presently, assumptions aren't checked either when `solve()` input
+                involves relationals or bools.
 
        See also:
           rsolve() for solving recurrence relationships
@@ -621,10 +624,10 @@ def solve(f, *symbols, **flags):
                     solution = filtered
                 else:
                     if warn:
-                        print("\n\tWarning: assumptions can not be checked "
-                              "\n\t(can not find for which variable equation was solved).")
+                        print("\n\tWarning: assumptions can't be checked "
+                              "\n\t(cannot find for which variable equation was solved).")
             if warn and unchecked:
-                print('\n\tWarning: assumptions concerning following solution(s) can not be checked:'\
+                print("\n\tWarning: assumptions concerning following solution(s) can't be checked:"
                       + '\n\t' + ', '.join(str(s) for s in unchecked))
 
     elif type(solution) is dict:
@@ -638,7 +641,7 @@ def solve(f, *symbols, **flags):
                 break
 
         if warn and not full_check:
-            print("\n\tWarning: assumptions concerning solution can not be checked.")
+            print("\n\tWarning: assumptions concerning solution can't be checked.")
     elif isinstance(solution, (Relational, And, Or)):
         assert len(symbols) == 1
         if warn and symbols[0].assumptions0:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -402,3 +402,6 @@ def test_issue_2098():
     assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) is None
     assert solve((x + y)*n - y**2 + 2, x, y) == [(2**(S(1)/2), -2**(S(1)/2))]
     # This solution must not appear: (-2**(1/2), 2**(1/2))
+    y = Symbol('y', positive=True)
+    assert solve(x**2 - y**2/exp(x), x, y) == [x*exp(x/2)]
+    # This solution must not appear: -x*exp(x/2)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -121,9 +121,9 @@ def test_solve_polynomial1():
 
     solution = {y: S.Zero, x: S.Zero}
 
-    assert solve((x-y, x+y),  x, y ) == solution
-    assert solve((x-y, x+y), (x, y)) == solution
-    assert solve((x-y, x+y), [x, y]) == solution
+    assert solve((x - y, x+y),  x, y ) == solution
+    assert solve((x - y, x+y), (x, y)) == solution
+    assert solve((x - y, x+y), [x, y]) == solution
 
     assert solve( x**3 - 15*x - 4, x) == [-2 + 3**Rational(1,2),
                                            4,
@@ -176,12 +176,12 @@ def test_solve_rational():
 def test_linear_system():
     x, y, z, t, n, a = symbols('x,y,z,t,n,a')
 
-    assert solve([x-1, x-y, x-2*y, y-1], [x,y]) is None
+    assert solve([x - 1, x - y, x - 2*y, y - 1], [x,y]) is None
 
-    assert solve([x-1, x-y, x-2*y, x-1], [x,y]) is None
-    assert solve([x-1, x-1, x-y, x-2*y], [x,y]) is None
+    assert solve([x - 1, x - y, x - 2*y, x - 1], [x,y]) is None
+    assert solve([x - 1, x - 1, x - y, x - 2*y], [x,y]) is None
 
-    assert solve([x+5*y-2, -3*x+6*y-15], x, y) == {x: -3, y: 1}
+    assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) == {x: -3, y: 1}
 
     M = Matrix([[0,0,n*(n+1),(n+1)**2,0],
                 [n+1,n+1,-2*n-1,-(n+1),0],
@@ -190,7 +190,7 @@ def test_linear_system():
     assert solve_linear_system(M, x, y, z, t) == \
            {y: 0, z: t*(-n - 1)/n, x: t*(-n - 1)/n}
 
-    assert solve([x + y + z + t, -z-t], x, y, z, t) == {x: -y, z: -t}
+    assert solve([x + y + z + t, -z - t], x, y, z, t) == {x: -y, z: -t}
 
     assert solve([a(0, 0) + a(0, 1) + a(1, 0) + a(1, 1), -a(1, 0) - a(1, 1)],
         a(0, 0), a(0, 1), a(1, 0), a(1, 1)) == {a(1, 0): -a(1, 1), a(0, 0): -a(0, 1)}
@@ -391,3 +391,14 @@ def test_issue_1694():
     assert solve((3 - 5*x/f(x))*f(x), f(x)) == [5*x/3]
     # 1398
     #assert solve(1/(5 + x)**(S(1)/5) - 9, x) == [-295244/S(59049)]
+
+def test_issue_2098():
+    x = Symbol('x', real=True)
+    assert solve(x**2 + 1, x) == []
+    n = Symbol('n', integer=True, positive=True)
+    assert solve((n - 1)*(n + 2)*(2*n - 1), n) == [1]
+    x = Symbol('x', positive=True)
+    y = Symbol('y')
+    assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) is None
+    assert solve((x + y)*n - y**2 + 2, x, y) == [(2**(S(1)/2), -2**(S(1)/2))]
+    # This solution must not appear: (-2**(1/2), 2**(1/2))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -405,3 +405,12 @@ def test_issue_2098():
     y = Symbol('y', positive=True)
     assert solve(x**2 - y**2/exp(x), x, y) == [x*exp(x/2)]
     # This solution must not appear: -x*exp(x/2)
+
+@XFAIL
+def test_2098_ambiguous():
+    # this is a case where the solution is univariate and which variable
+    # was solved for cannot easily be determined by inspection of the free
+    # symbols alone. solve should return an unambiguous result like
+    # [{y: x*exp(x/2)}, {y: -x*exp(x/2)}]
+    x, y, z = symbols('x y z', positive=True)
+    assert solve(z**2*x**2 - z**2*y**2/exp(x), x, y, z) == [x*exp(x/2)]


### PR DESCRIPTION
Issue 2098: solve() must checks assumptions on symbols, to filter solutions.

For example, if x = Symbol('x', real=True), solve(x**2 + 1, x) should not
return any solution.

See issue 2098: http://code.google.com/p/sympy/issues/detail?id=2098
