### PR TITLE
Changes to representations in sympy.physics.quantum

### DIFF
--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -5,7 +5,7 @@ from sympy import exp
 from sympy import Interval, DiracDelta
 from sympy import Symbol
 
-from sympy.physics.quantum.operator import HermitianOperator
+from sympy.physics.quantum.operator import HermitianOperator, DifferentialOperator
 from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.hilbert import L2
@@ -40,6 +40,21 @@ class XOp(HermitianOperator):
     def _apply_operator_XKet(self, ket):
         return ket.position*ket
 
+    def _represent_PxKet(self, basis, **options):
+        mom = basis.momentum
+        if "index" in options:
+            index = options["index"]
+        else:
+            index = 1
+
+        symbol1 = Symbol(str(mom) + "_" + str(index))
+        symbol2 = Symbol(str(mom) + "_" + str(index+1))
+
+        d = DifferentialOperator(symbol1)
+        delta = DiracDelta(symbol1 - symbol2)
+
+        return I*hbar*(d*delta)
+
 
 class PxOp(HermitianOperator):
     """1D cartesian momentum operator."""
@@ -55,6 +70,20 @@ class PxOp(HermitianOperator):
     def _apply_operator_PxKet(self, ket):
         return ket.momentum*ket
 
+    def _represent_XKet(self, basis, **options):
+        pos = basis.position
+        if "index" in options:
+            index = options["index"]
+        else:
+            index = 1
+
+        symbol1 = Symbol(str(pos) + "_" + str(index))
+        symbol2 = Symbol(str(pos) + "_" + str(index+1))
+
+        d = DifferentialOperator(symbol1)
+        delta = DiracDelta(symbol1 - symbol2)
+
+        return -I*hbar*(d*delta)
 
 X = XOp('X')
 Px = PxOp('Px')
@@ -135,13 +164,6 @@ class PxKet(Ket):
 
     def _eval_innerproduct_PxBra(self, bra, **hints):
         return DiracDelta(self.momentum-bra.momentum)
-
-    def _represent_default_basis(self, **options):
-        return self._represent_PxOp(None, **options)
-
-    def _represent_PxOp(self, basis, **options):
-        return self.momentum
-
 
 class PxBra(Bra):
     """1D cartesian momentum eigenbra."""

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -49,6 +49,10 @@ class PxOp(HermitianOperator):
     """1D cartesian momentum operator."""
 
     @classmethod
+    def default_label(self):
+        return "Px"
+
+    @classmethod
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
@@ -107,6 +111,10 @@ class XBra(Bra):
 
 class PxKet(Ket):
     """1D cartesian momentum eigenket."""
+
+    @classmethod
+    def basis_op(self):
+        return PxOp
 
     @property
     def dual_class(self):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -41,17 +41,13 @@ class XOp(HermitianOperator):
         return ket.position*ket
 
     def _represent_PxKet(self, basis, **options):
-        mom = basis.momentum
-        if "index" in options:
-            index = options["index"]
-        else:
-            index = 1
+        index = options.pop("index", 1)
 
-        symbol1 = Symbol(str(mom) + "_" + str(index))
-        symbol2 = Symbol(str(mom) + "_" + str(index+1))
-
-        d = DifferentialOperator(symbol1)
-        delta = DiracDelta(symbol1 - symbol2)
+        states = basis._enumerate_state(2, start_index = index)
+        coord1 = states[0].momentum
+        coord2 = states[1].momentum
+        d = DifferentialOperator(coord1)
+        delta = DiracDelta(coord1 - coord2)
 
         return I*hbar*(d*delta)
 
@@ -71,17 +67,13 @@ class PxOp(HermitianOperator):
         return ket.momentum*ket
 
     def _represent_XKet(self, basis, **options):
-        pos = basis.position
-        if "index" in options:
-            index = options["index"]
-        else:
-            index = 1
+        index = options.pop("index", 1)
 
-        symbol1 = Symbol(str(pos) + "_" + str(index))
-        symbol2 = Symbol(str(pos) + "_" + str(index+1))
-
-        d = DifferentialOperator(symbol1)
-        delta = DiracDelta(symbol1 - symbol2)
+        states = basis._enumerate_state(2, start_index = index)
+        coord1 = states[0].position
+        coord2 = states[1].position
+        d = DifferentialOperator(coord1)
+        delta = DiracDelta(coord1 - coord2)
 
         return -I*hbar*(d*delta)
 

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -19,8 +19,12 @@ from sympy.physics.quantum.hilbert import L2
 
 __all__ = [
     'XOp',
+    'YOp',
+    'ZOp',
     'PxOp',
     'X',
+    'Y',
+    'Z',
     'Px',
     'XKet',
     'XBra',
@@ -137,11 +141,11 @@ class XKet(Ket):
 
     @classmethod
     def _operators_to_state(self, op, **options):
-        return self.__new__(self, *_lowercase_labels(op.label), **options)
+        return self.__new__(self, *_lowercase_labels(op), **options)
 
     def _state_to_operators(self, op_class, **options):
         return op_class.__new__(op_class, \
-                                *_uppercase_labels(self.label), **options)
+                                *_uppercase_labels(self), **options)
 
     @classmethod
     def default_args(self):
@@ -186,11 +190,11 @@ class PositionState3D(State):
 
     @classmethod
     def _operators_to_state(self, op, **options):
-        return self.__new__(self, *_lowercase_labels(op.label), **options)
+        return self.__new__(self, *_lowercase_labels(op), **options)
 
     def _state_to_operators(self, op_class, **options):
         return op_class.__new__(op_class, \
-                                *_uppercase_labels(self.label), **options)
+                                *_uppercase_labels(self), **options)
 
     @classmethod
     def default_args(self):
@@ -241,11 +245,11 @@ class PxKet(Ket):
 
     @classmethod
     def _operators_to_state(self, op, **options):
-        return self.__new__(self, *_lowercase_labels(op.label), **options)
+        return self.__new__(self, *_lowercase_labels(op), **options)
 
     def _state_to_operators(self, op_class, **options):
         return op_class.__new__(op_class, \
-                                *_uppercase_labels(self.label), **options)
+                                *_uppercase_labels(self), **options)
 
     @classmethod
     def default_args(self):
@@ -307,12 +311,17 @@ def _enumerate_continuous_1D(*args, **options):
 
     return enum_states
 
-def _lowercase_labels(label):
-    new_args = [str(arg).lower() for arg in label]
+def _lowercase_labels(ops):
+    if not isinstance(ops, set):
+        ops = [ops]
 
-    return new_args
+    return [str(arg.label[0]).lower() for arg in ops]
 
-def _uppercase_labels(label):
-    new_args = [str(arg)[0].upper() + str(arg)[1:] for arg in label]
+def _uppercase_labels(ops):
+    if not isinstance(ops, set):
+        ops = [ops]
+
+    new_args = [str(arg.label[0])[0].upper() + \
+                str(arg.label[0])[1:] for arg in ops]
 
     return new_args

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -105,10 +105,6 @@ class XBra(Bra):
         """The position of the state."""
         return self.label[0]
 
-    #def _eval_innerproduct_XKet(self, bra, **hints):
-        #return DiracDelta(self.position-bra.position)
-
-
 class PxKet(Ket):
     """1D cartesian momentum eigenket."""
 

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -68,8 +68,8 @@ class XKet(Ket):
     """1D cartesian position eigenket."""
 
     @classmethod
-    def basis_op(self):
-        return XOp
+    def default_args(self):
+        return ("x",)
 
     @property
     def dual_class(self):
@@ -97,8 +97,8 @@ class XBra(Bra):
     """1D cartesian position eigenbra."""
 
     @classmethod
-    def basis_op(self):
-        return XOp
+    def default_args(self):
+        return ("x",)
 
     @property
     def dual_class(self):
@@ -113,8 +113,8 @@ class PxKet(Ket):
     """1D cartesian momentum eigenket."""
 
     @classmethod
-    def basis_op(self):
-        return PxOp
+    def default_args(self):
+        return ("px",)
 
     @property
     def dual_class(self):
@@ -140,6 +140,10 @@ class PxKet(Ket):
 
 class PxBra(Bra):
     """1D cartesian momentum eigenbra."""
+
+    @classmethod
+    def default_args(self):
+        return ("px",)
 
     @property
     def dual_class(self):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -82,15 +82,19 @@ class XKet(Ket):
     def _eval_innerproduct_PxBra(self, bra, **hints):
         return exp(-I*self.position*bra.momentum/hbar)/sqrt(2*pi*hbar)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_XOp(None, **options)
+    #def _represent_default_basis(self, **options):
+        #return self._represent_XOp(None, **options)
 
-    def _represent_XOp(self, basis, **options):
-        return self.position
+    #def _represent_XOp(self, basis, **options):
+        #return self.position
 
 
 class XBra(Bra):
     """1D cartesian position eigenbra."""
+
+    @classmethod
+    def basis_op(self):
+        return XOp
 
     @property
     def dual_class(self):
@@ -100,6 +104,9 @@ class XBra(Bra):
     def position(self):
         """The position of the state."""
         return self.label[0]
+
+    #def _eval_innerproduct_XKet(self, bra, **hints):
+        #return DiracDelta(self.position-bra.position)
 
 
 class PxKet(Ket):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -27,8 +27,8 @@ class XOp(HermitianOperator):
     """1D cartesian position operator."""
 
     @classmethod
-    def default_label(self):
-        return "X"
+    def default_args(self):
+        return ("X",)
 
     @classmethod
     def basis_ket(self):
@@ -49,8 +49,8 @@ class PxOp(HermitianOperator):
     """1D cartesian momentum operator."""
 
     @classmethod
-    def default_label(self):
-        return "Px"
+    def default_args(self):
+        return ("Px",)
 
     @classmethod
     def _eval_hilbert_space(self, args):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -64,6 +64,13 @@ class XKet(Ket):
     """1D cartesian position eigenket."""
 
     @classmethod
+    def _operators_to_state(self, op, **options):
+        return self.__new__(self, str(op.label[0]).lower(), **options)
+
+    def _state_to_operators(self, op_class, **options):
+        return op_class.__new__(op_class, str(self.label[0]).upper(), **options)
+
+    @classmethod
     def default_args(self):
         return ("x",)
 
@@ -100,6 +107,15 @@ class XBra(Bra):
 
 class PxKet(Ket):
     """1D cartesian momentum eigenket."""
+
+    @classmethod
+    def _operators_to_state(self, op, **options):
+        return self.__new__(self, str(op.label[0]).lower(), **options)
+
+    def _state_to_operators(self, op_class, **options):
+        lab = str(self.label[0])
+        lab = lab[0].upper() + lab[1:]
+        return op_class.__new__(op_class, lab, **options)
 
     @classmethod
     def default_args(self):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -74,7 +74,7 @@ class XKet(Ket):
     def default_args(self):
         return ("x",)
 
-    @property
+    @classmethod
     def dual_class(self):
         return XBra
 
@@ -96,7 +96,7 @@ class XBra(Bra):
     def default_args(self):
         return ("x",)
 
-    @property
+    @classmethod
     def dual_class(self):
         return XKet
 
@@ -121,7 +121,7 @@ class PxKet(Ket):
     def default_args(self):
         return ("px",)
 
-    @property
+    @classmethod
     def dual_class(self):
         return PxBra
 
@@ -150,7 +150,7 @@ class PxBra(Bra):
     def default_args(self):
         return ("px",)
 
-    @property
+    @classmethod
     def dual_class(self):
         return PxKet
 

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -63,6 +63,10 @@ Px = PxOp('Px')
 class XKet(Ket):
     """1D cartesian position eigenket."""
 
+    @classmethod
+    def default_args(self):
+        return ("x",)
+
     @property
     def dual_class(self):
         return XBra
@@ -78,15 +82,12 @@ class XKet(Ket):
     def _eval_innerproduct_PxBra(self, bra, **hints):
         return exp(-I*self.position*bra.momentum/hbar)/sqrt(2*pi*hbar)
 
-    #def _represent_default_basis(self, **options):
-        #return self._represent_XOp(None, **options)
-
-    #def _represent_XOp(self, basis, **options):
-        #return self.position
-
-
 class XBra(Bra):
     """1D cartesian position eigenbra."""
+
+    @classmethod
+    def default_args(self):
+        return ("x",)
 
     @property
     def dual_class(self):
@@ -99,6 +100,10 @@ class XBra(Bra):
 
 class PxKet(Ket):
     """1D cartesian momentum eigenket."""
+
+    @classmethod
+    def default_args(self):
+        return ("px",)
 
     @property
     def dual_class(self):
@@ -124,6 +129,10 @@ class PxKet(Ket):
 
 class PxBra(Bra):
     """1D cartesian momentum eigenbra."""
+
+    @classmethod
+    def default_args(self):
+        return ("px",)
 
     @property
     def dual_class(self):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -26,11 +26,11 @@ __all__ = [
 class XOp(HermitianOperator):
     """1D cartesian position operator."""
 
-    @property
+    @classmethod
     def default_label(self):
         return "X"
 
-    @property
+    @classmethod
     def basis_ket(self):
         return XKet
 
@@ -63,7 +63,7 @@ Px = PxOp('Px')
 class XKet(Ket):
     """1D cartesian position eigenket."""
 
-    @property
+    @classmethod
     def basis_op(self):
         return XOp
 

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -3,11 +3,13 @@
 from sympy import I, S, sqrt, pi
 from sympy import exp
 from sympy import Interval, DiracDelta
+from sympy import Symbol
 
 from sympy.physics.quantum.operator import HermitianOperator
 from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.hilbert import L2
+
 
 
 __all__ = [
@@ -23,6 +25,14 @@ __all__ = [
 
 class XOp(HermitianOperator):
     """1D cartesian position operator."""
+
+    @property
+    def default_label(self):
+        return "X"
+
+    @property
+    def basis_ket(self):
+        return XKet
 
     @classmethod
     def _eval_hilbert_space(self, args):
@@ -52,6 +62,10 @@ Px = PxOp('Px')
 
 class XKet(Ket):
     """1D cartesian position eigenket."""
+
+    @property
+    def basis_op(self):
+        return XOp
 
     @property
     def dual_class(self):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -112,6 +112,9 @@ class XKet(Ket):
         """The position of the state."""
         return self.label[0]
 
+    def _enumerate_state(self, num_states, **options):
+        return _enumerate_continuous_1D(self, num_states, **options)
+
     def _eval_innerproduct_XBra(self, bra, **hints):
         return DiracDelta(self.position-bra.position)
 
@@ -159,6 +162,9 @@ class PxKet(Ket):
         """The momentum of the state."""
         return self.label[0]
 
+    def _enumerate_state(self, *args, **options):
+        return _enumerate_continuous_1D(self, *args, **options)
+
     def _eval_innerproduct_XBra(self, bra, **hints):
         return exp(I*self.momentum*bra.position/hbar)/sqrt(2*pi*hbar)
 
@@ -180,3 +186,21 @@ class PxBra(Bra):
     def momentum(self):
         """The momentum of the state."""
         return self.label[0]
+
+def _enumerate_continuous_1D(*args, **options):
+    state = args[0]
+    num_states = args[1]
+    state_class = state.__class__
+    index_list = options.pop('index_list', [])
+
+    if len(index_list) == 0:
+        start_index = options.pop('start_index', 1)
+        index_list = range(start_index, start_index + num_states)
+
+    enum_states = [0 for i in range(len(index_list))]
+
+    for i, ind in enumerate(index_list):
+        label = state.args[0]
+        enum_states[i] = state_class(str(label) + "_" + str(ind), **options)
+
+    return enum_states

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -31,10 +31,6 @@ class XOp(HermitianOperator):
         return ("X",)
 
     @classmethod
-    def basis_ket(self):
-        return XKet
-
-    @classmethod
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
@@ -67,10 +63,6 @@ Px = PxOp('Px')
 class XKet(Ket):
     """1D cartesian position eigenket."""
 
-    @classmethod
-    def default_args(self):
-        return ("x",)
-
     @property
     def dual_class(self):
         return XBra
@@ -96,10 +88,6 @@ class XKet(Ket):
 class XBra(Bra):
     """1D cartesian position eigenbra."""
 
-    @classmethod
-    def default_args(self):
-        return ("x",)
-
     @property
     def dual_class(self):
         return XKet
@@ -111,10 +99,6 @@ class XBra(Bra):
 
 class PxKet(Ket):
     """1D cartesian momentum eigenket."""
-
-    @classmethod
-    def default_args(self):
-        return ("px",)
 
     @property
     def dual_class(self):
@@ -140,10 +124,6 @@ class PxKet(Ket):
 
 class PxBra(Bra):
     """1D cartesian momentum eigenbra."""
-
-    @classmethod
-    def default_args(self):
-        return ("px",)
 
     @property
     def dual_class(self):

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -14,7 +14,6 @@ from itertools import count
 from sympy import Expr, Symbol, diff
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.state import Wavefunction
 
 from sympy.physics.quantum.qexpr import (
     QExpr, dispatch_method
@@ -377,6 +376,7 @@ class DifferentialOperator(Operator):
 
     def _apply_operator_Wavefunction(self, func):
         #TODO: Generalize to more complex operators
+        from sympy.physics.quantum.state import Wavefunction
 
         var = self.args[0]
         wf_vars = func.args[1:]

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -9,7 +9,9 @@ TODO:
   AntiCommutator, represent, apply_operators.
 """
 
-from sympy import Expr
+from itertools import count
+
+from sympy import Expr, Symbol
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
 
@@ -190,6 +192,27 @@ class HermitianOperator(Operator):
     >>> Dagger(H)
     H
     """
+
+    @property
+    def basis_ket(self):
+        """Return the class corresponding to the basis ket of this operator. """
+        return None
+
+    @property
+    def basis_set(self):
+        """ Return a generator for the basis kets of this operator """
+        return (self.basis_ket(self.default_label.lower() + "_" + str(i)) for i in count(1))
+
+    def _get_basis_kets(self, num):
+        ct = 0
+        basis_kets = [0 for i in range(num)]
+        for state in self.basis_set:
+            if ct == num:
+                break
+            basis_kets[ct] = state
+            ct+=1
+
+        return basis_kets
 
     def _eval_dagger(self):
         return self

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -207,13 +207,21 @@ class HermitianOperator(Operator):
         else:
             return None
 
-    def _get_basis_kets(self, start, num):
+    def _get_basis_kets(self, *args):
         if self.basis_ket() is None:
             return None
 
+        index_list = []
+        if len(args) == 1:
+            index_list = args[0]
+        elif len(args) == 2:
+            index_list = range(args[0], args[0]+args[1])
+        else:
+            raise NotImplementedError("Wrong number of arguments!")
+
         ct = 0
-        basis_kets = [0 for i in range(num)]
-        for i in range(start, start+num):
+        basis_kets = [0 for i in range(len(index_list))]
+        for i in index_list:
             basis_kets[ct] = self.basis_ket()(str(self.label[0]).lower() + "_" + str(i))
             ct+=1
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -305,7 +305,7 @@ class OuterProduct(Operator):
             raise TypeError('KetBase subclass expected, got: %r' % ket)
         if not isinstance(bra, BraBase):
             raise TypeError('BraBase subclass expected, got: %r' % ket)
-        if not ket.dual_class == bra.__class__:
+        if not ket.dual_class() == bra.__class__:
             raise TypeError(
                 'ket and bra are not dual classes: %r, %r' % \
                 (ket.__class__, bra.__class__)

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -207,15 +207,14 @@ class HermitianOperator(Operator):
         else:
             return None
 
-    def _get_basis_kets(self, num):
+    def _get_basis_kets(self, start, num):
         if self.basis_ket() is None:
             return None
+
         ct = 0
         basis_kets = [0 for i in range(num)]
-        for state in self.basis_set:
-            if ct == num:
-                break
-            basis_kets[ct] = state
+        for i in range(start, start+num):
+            basis_kets[ct] = self.basis_ket()(str(self.label[0]).lower() + "_" + str(i))
             ct+=1
 
         return basis_kets

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -392,7 +392,7 @@ class DifferentialOperator(Operator):
     >>> L = 1
     >>> n = 1
     >>> g = Piecewise((0, x < 0), (0, x > L), (sqrt(2/L)*sin(n*pi*x/L), True))
-    >>> f = Wavefunction(x, g)
+    >>> f = Wavefunction(g, x)
     >>> d = DifferentialOperator(x)
     >>> qapply(d*f)
     Piecewise((0, x < 0), (0, 1 < x), (2**(1/2)*pi*cos(pi*x), True))

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -357,10 +357,29 @@ class DifferentialOperator(Operator):
     """
     An operator for representing the differential operator, i.e. d/dx
 
+    It is initialized by passing two arguments. The first is an
+    arbitrary expression that involves a function, such as
+    Derivative(f(x), x). The second is the function (e.g. f(x)) which
+    we are to replace with the Wavefunction that this
+    DifferentialOperator is applied to.
+
+    Parameters
+    ==========
+
+    expr : Expr
+           The arbitrary expression which the appropriate Wavefunction
+           is to be substituted into
+
+    func : Expr
+           A function (e.g. f(x)) which is to be replaced with the
+           appropriate Wavefunction when this DifferentialOperator is applied
+
     Examples
     ========
 
-    You can define a completely arbitrary expression and specify where the Wavefunction is to be substituted
+    You can define a completely arbitrary expression and specify where
+    the Wavefunction is to be substituted
+
     >>> from sympy import Derivative, Function, Symbol
     >>> from sympy.physics.quantum.operator import DifferentialOperator
     >>> from sympy.physics.quantum.state import Wavefunction
@@ -372,7 +391,7 @@ class DifferentialOperator(Operator):
     >>> d.function
     f(x)
     >>> d.variables
-    set([x])
+    (x,)
     >>> qapply(d*w)
     Wavefunction(2, x)
 
@@ -393,10 +412,15 @@ class DifferentialOperator(Operator):
         >>> f = Function('f')
         >>> d = DifferentialOperator(1/x*Derivative(f(x), x), f(x))
         >>> d.variables
-        set([x])
+        (x,)
+        >>> y = Symbol('y')
+        >>> d = DifferentialOperator(Derivative(f(x, y), x) + \
+                                     Derivative(f(x, y), y), f(x, y))
+        >>> d.variables
+        (x, y)
         """
 
-        return self.args[-1].free_symbols
+        return self.args[-1].args
 
     @property
     def function(self):
@@ -413,7 +437,11 @@ class DifferentialOperator(Operator):
         >>> d = DifferentialOperator(Derivative(f(x), x), f(x))
         >>> d.function
         f(x)
-
+        >>> y = Symbol('y')
+        >>> d = DifferentialOperator(Derivative(f(x, y), x) + \
+                                     Derivative(f(x, y), y), f(x, y))
+        >>> d.function
+        f(x, y)
         """
 
         return self.args[-1]
@@ -434,7 +462,11 @@ class DifferentialOperator(Operator):
         >>> d = DifferentialOperator(Derivative(f(x), x), f(x))
         >>> d.expr
         Derivative(f(x), x)
-
+        >>> y = Symbol('y')
+        >>> d = DifferentialOperator(Derivative(f(x, y), x) + \
+                                     Derivative(f(x, y), y), f(x, y))
+        >>> d.expr
+        Derivative(f(x, y), x) + Derivative(f(x, y), y)
         """
 
         return self.args[0]
@@ -480,8 +512,3 @@ class DifferentialOperator(Operator):
         )
         pform = prettyForm(*pform.right((label_pform)))
         return pform
-
-    def _print_contents_latex(self, printer, *args):
-        return '\\frac\{d\}\{%s\}' % (
-            self._print_label_latex(printer, *args)
-        )

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -370,7 +370,8 @@ class DifferentialOperator(Operator):
     >>> d = DifferentialOperator(x)
     >>> qapply(d*f)
     Piecewise((0, x < 0), (0, 1 < x), (2**(1/2)*pi*cos(pi*x), True))
-
+    >>> d.is_commutative
+    False
     """
 
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -96,6 +96,9 @@ class Operator(QExpr):
     [2] http://en.wikipedia.org/wiki/Observable
     """
 
+    @classmethod
+    def default_args(self):
+        return ("O",)
     #-------------------------------------------------------------------------
     # Printing
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -209,7 +209,6 @@ class HermitianOperator(Operator):
     def _get_basis_kets(self, num):
         if self.basis_ket() is None:
             return None
-        
         ct = 0
         basis_kets = [0 for i in range(num)]
         for state in self.basis_set:

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -406,6 +406,31 @@ class DifferentialOperator(Operator):
 
     """
 
+    #-------------------------------------------------------------------------
+    # Printing
+    #-------------------------------------------------------------------------
+
+
+    def _print_contents(self, printer, *args):
+        return '%s(%s)' % (
+            self._print_operator_name(printer, *args),
+            self._print_label(printer, *args)
+          )
+
+    def _print_contents_pretty(self, printer, *args):
+        pform = self._print_operator_name_pretty(printer, *args)
+        label_pform = self._print_label_pretty(printer, *args)
+        label_pform = prettyForm(
+            *label_pform.parens(left='(', right=')')
+        )
+        pform = prettyForm(*pform.right((label_pform)))
+        return pform
+
+    def _print_contents_latex(self, printer, *args):
+        return '\\frac\{d\}\{%s\}' % (
+            self._print_label_latex(printer, *args)
+        )
+
     def _apply_operator_Wavefunction(self, func):
         var = self.args[0]
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -194,39 +194,6 @@ class HermitianOperator(Operator):
     H
     """
 
-    @classmethod
-    def basis_ket(self):
-        """Return the class corresponding to the basis ket of this operator. """
-        return None
-
-    @property
-    def basis_set(self):
-        """ Return a generator for the basis kets of this operator """
-        if self.basis_ket() is not None:
-            return (self.basis_ket()(str(self.label[0]).lower() + "_" + str(i)) for i in count(1))
-        else:
-            return None
-
-    def _get_basis_kets(self, *args):
-        if self.basis_ket() is None:
-            return None
-
-        index_list = []
-        if len(args) == 1:
-            index_list = args[0]
-        elif len(args) == 2:
-            index_list = range(args[0], args[0]+args[1])
-        else:
-            raise NotImplementedError("Wrong number of arguments!")
-
-        ct = 0
-        basis_kets = [0 for i in range(len(index_list))]
-        for i in index_list:
-            basis_kets[ct] = self.basis_ket()(str(self.label[0]).lower() + "_" + str(i))
-            ct+=1
-
-        return basis_kets
-
     def _eval_dagger(self):
         return self
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -11,7 +11,7 @@ TODO:
 
 from itertools import count
 
-from sympy import Expr, Symbol
+from sympy import Expr, Symbol, diff
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
 
@@ -23,7 +23,8 @@ __all__ = [
     'Operator',
     'HermitianOperator',
     'UnitaryOperator',
-    'OuterProduct'
+    'OuterProduct',
+    'DifferentialOperator'
 ]
 
 #-----------------------------------------------------------------------------
@@ -373,3 +374,32 @@ class OuterProduct(Operator):
         k = self.ket._represent(**options)
         b = self.bra._represent(**options)
         return k*b
+
+class DifferentialOperator(Operator):
+    """ An operator for representing the differential operator, i.e. d/dx
+
+    TODO: Update printing functions to override those in operator
+
+    Examples
+    ==========
+
+    >>> from sympy import Symbol, Piecewise, pi
+    >>> from sympy.functions import sqrt, sin
+    >>> from sympy.physics.quantum.state import Wavefunction
+    >>> from sympy.physics.quantum.operator import DifferentialOperator
+    >>> from sympy.physics.quantum.qapply import qapply
+    >>> x = Symbol('x')
+    >>> L = 1
+    >>> n = 1
+    >>> g = Piecewise((0, x < 0), (0, x > L), (sqrt(2/L)*sin(n*pi*x/L), True))
+    >>> f = Wavefunction(x, g)
+    >>> d = DifferentialOperator(x)
+    >>> qapply(d*f)
+    Piecewise((0, x < 0), (0, 1 < x), (2**(1/2)*pi*cos(pi*x), True))
+
+    """
+
+    def _apply_operator_Wavefunction(self, func):
+        var = self.args[0]
+
+        return diff(func(var), var)

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -193,20 +193,20 @@ class HermitianOperator(Operator):
     H
     """
 
-    @property
+    @classmethod
     def basis_ket(self):
         """Return the class corresponding to the basis ket of this operator. """
         return None
 
-    @property
+    @classmethod
     def basis_set(self):
         """ Return a generator for the basis kets of this operator """
-        return (self.basis_ket(self.default_label.lower() + "_" + str(i)) for i in count(1))
+        return (self.basis_ket()(self.default_label().lower() + "_" + str(i)) for i in count(1))
 
     def _get_basis_kets(self, num):
         ct = 0
         basis_kets = [0 for i in range(num)]
-        for state in self.basis_set:
+        for state in self.basis_set():
             if ct == num:
                 break
             basis_kets[ct] = state

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -198,15 +198,21 @@ class HermitianOperator(Operator):
         """Return the class corresponding to the basis ket of this operator. """
         return None
 
-    @classmethod
+    @property
     def basis_set(self):
         """ Return a generator for the basis kets of this operator """
-        return (self.basis_ket()(self.default_label().lower() + "_" + str(i)) for i in count(1))
+        if self.basis_ket() is not None:
+            return (self.basis_ket()(str(self.label[0]).lower() + "_" + str(i)) for i in count(1))
+        else:
+            return None
 
     def _get_basis_kets(self, num):
+        if self.basis_ket() is None:
+            return None
+        
         ct = 0
         basis_kets = [0 for i in range(num)]
-        for state in self.basis_set():
+        for state in self.basis_set:
             if ct == num:
                 break
             basis_kets[ct] = state

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -15,7 +15,10 @@ TODO List:
 """
 
 
-from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
+from sympy.physics.quantum.cartesian import (
+    XOp, YOp, ZOp, XKet, PxOp, PxKet, PositionKet3D
+)
+
 from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.state import (
     StateBase, KetBase, BraBase, Ket, Bra
@@ -35,13 +38,13 @@ __all__ = [
 #classes are written! Entries are of the form PxKet : PxOp or
 #something like 3DKet : (ROp, ThetaOp, PhiOp)
 
-# TODO: Update dict with full list of state : operator pairs
-# (including spin)
-
+#frozenset is used so that the reverse mapping can be made
+#(regular sets are not hashable because they are mutable
 state_mapping = { JxKet : frozenset((J2Op, JxOp)),
                   JyKet : frozenset((J2Op, JyOp)),
                   JzKet : frozenset((J2Op, JzOp)),
                   Ket : Operator,
+                  PositionKet3D : frozenset((XOp, YOp, ZOp)),
                   PxKet : PxOp,
                   XKet : XOp }
 
@@ -119,7 +122,7 @@ def operators_to_state(operators, **options):
             #operators...if this fails, return the class
             try:
                 op_instances = [op() for op in ops]
-                ret = _get_state(op_mapping[ops], op_instances, **options)
+                ret = _get_state(op_mapping[ops], set(op_instances), **options)
             except NotImplementedError:
                 ret = op_mapping[ops]
 

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -3,8 +3,8 @@ from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.state import StateBase, KetBase, BraBase
 
 __all__ = [
-    'operator_to_state',
-    'state_to_operator'
+    'operators_to_state',
+    'state_to_operators'
 ]
 
 #state_mapping stores the mappings between states and their associated operators or tuples
@@ -18,8 +18,8 @@ state_mapping = { PxKet : PxOp,
 
 rev_mapping = dict((v,k) for k,v in state_mapping.iteritems())
 
-def operator_to_state(arg, **options):
-    """ operator_to_state
+def operators_to_state(arg, **options):
+    """ operators_to_state
 
     A global function for mapping operator classes to their associated states.
     It takes either an Operator or a set of operators and returns the state associated
@@ -37,14 +37,14 @@ def operator_to_state(arg, **options):
     Examples
     ===========
     >>> from sympy.physics.quantum.cartesian import XOp, PxOp
-    >>> from sympy.physics.quantum.operatorset import operator_to_state
-    >>> operator_to_state(XOp)
+    >>> from sympy.physics.quantum.operatorset import operators_to_state
+    >>> operators_to_state(XOp)
     <class 'sympy.physics.quantum.cartesian.XKet'>
-    >>> operator_to_state(XOp())
+    >>> operators_to_state(XOp())
     <class 'sympy.physics.quantum.cartesian.XKet'>
-    >>> operator_to_state(PxOp)
+    >>> operators_to_state(PxOp)
     <class 'sympy.physics.quantum.cartesian.PxKet'>
-    >>> operator_to_state(PxOp())
+    >>> operators_to_state(PxOp())
     <class 'sympy.physics.quantum.cartesian.PxKet'>
     """
 
@@ -76,8 +76,8 @@ def operator_to_state(arg, **options):
         else:
             return None
 
-def state_to_operator(arg, **options):
-    """ state_to_operator
+def state_to_operators(arg, **options):
+    """ state_to_operators
 
     A global function for mapping state classes to their associated operators or sets of operators.
     It takes either a state class or instance.
@@ -94,14 +94,14 @@ def state_to_operator(arg, **options):
     Examples
     ===========
     >>> from sympy.physics.quantum.cartesian import XKet, PxKet
-    >>> from sympy.physics.quantum.operatorset import state_to_operator
-    >>> state_to_operator(XKet)
+    >>> from sympy.physics.quantum.operatorset import state_to_operators
+    >>> state_to_operators(XKet)
     <class 'sympy.physics.quantum.cartesian.XOp'>
-    >>> state_to_operator(XKet())
+    >>> state_to_operators(XKet())
     <class 'sympy.physics.quantum.cartesian.XOp'>
-    >>> state_to_operator(PxKet)
+    >>> state_to_operators(PxKet)
     <class 'sympy.physics.quantum.cartesian.PxOp'>
-    >>> state_to_operator(PxKet())
+    >>> state_to_operators(PxKet())
     <class 'sympy.physics.quantum.cartesian.PxOp'>
     """
 

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -155,8 +155,8 @@ def state_to_operators(state, **options):
             ret = state_mapping[state]
     elif type(state) in state_mapping:
         ret = _get_ops(state, _tuple_to_set(state_mapping[type(state)]), **options)
-    elif isinstance(state, BraBase) and state.dual_class in state_mapping:
-        ret = _get_ops(state, _tuple_to_set(state_mapping[state.dual_class]))
+    elif (isinstance(state, BraBase) or issubclass(state, BraBase)) and state.dual_class() in state_mapping:
+        ret = _get_ops(state, _tuple_to_set(state_mapping[state.dual_class()]))
     else:
         ret = None
 

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -1,55 +1,85 @@
+""" A module for mapping operators to their corresponding eigenstates
+and vice versa
+
+It contains a global dictionary with eigenstate-operator pairings.
+If a new state-operator pair is created, this dictionary should be
+updated as well.
+
+It also contains functions operators_to_state and state_to_operators
+for mapping between the two. These can handle both classes and
+instances of operators and states. See the individual function
+descriptions for details.
+
+TODO List:
+- Update the dictionary with a complete list of state-operator pairs
+"""
+
+
 from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
 from sympy.physics.quantum.operator import Operator
-from sympy.physics.quantum.state import StateBase, KetBase, BraBase
+from sympy.physics.quantum.state import (
+    StateBase, KetBase, BraBase, Ket, Bra
+)
 
 __all__ = [
     'operators_to_state',
     'state_to_operators'
 ]
 
-#state_mapping stores the mappings between states and their associated operators or tuples
-#of operators. This should be updated when new classes are written! Entries are of the form
-# PxKet : PxOp or something like 3DKet : (ROp, ThetaOp, PhiOp)
+#state_mapping stores the mappings between states and their associated
+#operators or tuples of operators. This should be updated when new
+#classes are written! Entries are of the form PxKet : PxOp or
+#something like 3DKet : (ROp, ThetaOp, PhiOp)
 
 # TODO: Update dict with full list of state : operator pairs
+# (including spin)
 
-state_mapping = { PxKet : PxOp,
+state_mapping = { Ket : Operator,
+                  PxKet : PxOp,
                   XKet : XOp }
 
 rev_mapping = dict((v,k) for k,v in state_mapping.iteritems())
 
 def operators_to_state(operators, **options):
-    """ operators_to_state
+    """ Returns the eigenstate of the given operator or set of operators
 
-    A global function for mapping operator classes to their associated states.
-    It takes either an Operator or a set of operators and returns the state associated
-    with these.
+    A global function for mapping operator classes to their associated
+    states. It takes either an Operator or a set of operators and
+    returns the state associated with these.
 
-    This function can handle both instances of a given operator or just the class itself
-    (i.e. both XOp() and XOp)
+    This function can handle both instances of a given operator or
+    just the class itself (i.e. both XOp() and XOp)
 
     There are multiple use cases to consider:
 
-    1) A class or set of classes is passed: First, we try to instantiate default instances for these operators. If this fails,
-    then the class is simply returned. If we succeed in instantiating default instances, then we try to call
-    state._operators_to_state on the operator instances. If this fails, the class is returned. Otherwise, the instance returned
-    by _operators_to_state is returned.
+    1) A class or set of classes is passed: First, we try to
+    instantiate default instances for these operators. If this fails,
+    then the class is simply returned. If we succeed in instantiating
+    default instances, then we try to call state._operators_to_state
+    on the operator instances. If this fails, the class is returned.
+    Otherwise, the instance returned by _operators_to_state is returned.
 
-    2) An instance or set of instances is passed: In this case, state._operators_to_state is called on the instances passed. If
-    this fails, a state class is returned. If the method returns an instance, that instance is returned.
+    2) An instance or set of instances is passed: In this case,
+    state._operators_to_state is called on the instances passed. If
+    this fails, a state class is returned. If the method returns an
+    instance, that instance is returned.
 
-    In both cases, if the operator class or set does not exist in the state_mapping dictionary, None is returned.
+    In both cases, if the operator class or set does not exist in the
+    state_mapping dictionary, None is returned.
 
     Parameters
-    ===========
+    ==========
 
     arg: Operator or set
-         The class or instance of the operator or set of operators to be mapped to a state
+         The class or instance of the operator or set of operators
+         to be mapped to a state
 
     Examples
-    ===========
+    ========
+
     >>> from sympy.physics.quantum.cartesian import XOp, PxOp
     >>> from sympy.physics.quantum.operatorset import operators_to_state
+    >>> from sympy.physics.quantum.operator import Operator
     >>> operators_to_state(XOp)
     |x>
     >>> operators_to_state(XOp())
@@ -58,20 +88,27 @@ def operators_to_state(operators, **options):
     |px>
     >>> operators_to_state(PxOp())
     |px>
+    >>> operators_to_state(Operator)
+    |psi>
+    >>> operators_to_state(Operator())
+    |psi>
     """
 
-    if not (isinstance(operators, Operator) or issubclass(operators, Operator) or isinstance(operators, set)):
+    if not (isinstance(operators, Operator) \
+            or issubclass(operators, Operator) or isinstance(operators, set)):
         raise NotImplementedError("Argument is not an Operator or a set!")
 
     if isinstance(operators, set):
         for s in operators:
-            if not isinstance(operators, Operator) or issubclass(operators, Operator):
-                raise NotImplementedError("Members of given set are not all Operators!")
+            if not isinstance(operators, Operator) \
+                   or issubclass(operators, Operator):
+                raise NotImplementedError("Set is not all Operators!")
 
         ops = tuple(operators)
 
         if ops in rev_mapping: #ops is a list of classes in this case
-            #Try to get an object from default instances of the operators...if this fails, return the class
+            #Try to get an object from default instances of the
+            #operators...if this fails, return the class
             try:
                 op_instances = [op() for op in ops]
                 ret = _get_state(rev_mapping[ops], op_instances, **options)
@@ -104,36 +141,46 @@ def operators_to_state(operators, **options):
             return None
 
 def state_to_operators(state, **options):
-    """ state_to_operators
+    """ Returns the operator or set of operators corresponding to the
+    given eigenstate
 
-    A global function for mapping state classes to their associated operators or sets of operators.
-    It takes either a state class or instance.
+    A global function for mapping state classes to their associated
+    operators or sets of operators. It takes either a state class
+    or instance.
 
-    This function can handle both instances of a given state or just the class itself
-    (i.e. both XKet() and XKet)
+    This function can handle both instances of a given state or just
+    the class itself (i.e. both XKet() and XKet)
 
     There are multiple use cases to consider:
 
-    1) A state class is passed: In this case, we first try instantiating a default instance of the class. If this succeeds,
-    then we try to call state._state_to_operators on that instance. If the creation of the default instance or if the calling of
-    _state_to_operators fails, then either an operator class or set of operator classes is returned. Otherwise, the appropriate
+    1) A state class is passed: In this case, we first try
+    instantiating a default instance of the class. If this succeeds,
+    then we try to call state._state_to_operators on that instance.
+    If the creation of the default instance or if the calling of
+    _state_to_operators fails, then either an operator class or set of
+    operator classes is returned. Otherwise, the appropriate
     operator instances are returned.
 
-    2) A state instance is returned: Here, state._state_to_operators is called for the instance. If this fails, then a class
-    or set of operator classes is returned. Otherwise, the instances are returned.
+    2) A state instance is returned: Here, state._state_to_operators
+    is called for the instance. If this fails, then a class or set of
+    operator classes is returned. Otherwise, the instances are returned.
 
-    In either case, if the state's class does not exist in state_mapping, None is returned.
+    In either case, if the state's class does not exist in
+    state_mapping, None is returned.
 
     Parameters
-    ===========
+    ==========
 
     arg: StateBase class or instance (or subclasses)
-         The class or instance of the state to be mapped to an operator or set of operators
+         The class or instance of the state to be mapped to an
+         operator or set of operators
 
     Examples
-    ===========
-    >>> from sympy.physics.quantum.cartesian import XKet, PxKet
+    ========
+
+    >>> from sympy.physics.quantum.cartesian import XKet, PxKet, XBra, PxBra
     >>> from sympy.physics.quantum.operatorset import state_to_operators
+    >>> from sympy.physics.quantum.state import Ket, Bra
     >>> state_to_operators(XKet)
     X
     >>> state_to_operators(XKet())
@@ -142,41 +189,75 @@ def state_to_operators(state, **options):
     Px
     >>> state_to_operators(PxKet())
     Px
+    >>> state_to_operators(PxBra)
+    Px
+    >>> state_to_operators(XBra)
+    X
+    >>> state_to_operators(Ket)
+    O
+    >>> state_to_operators(Bra)
+    O
     """
 
     if not (isinstance(state, StateBase) or issubclass(state, StateBase)):
         raise NotImplementedError("Argument is not a state!")
 
     if state in state_mapping: #state is a class
+        state_inst = _make_default(state)
         try:
-            state_inst = state()
-            ret = _get_ops(state_inst, _tuple_to_set(state_mapping[state]), **options)
-        except NotImplementedError:
+            ret = _get_ops(state_inst, \
+                           _tuple_to_set(state_mapping[state]), **options)
+        except (NotImplementedError, TypeError):
             ret = state_mapping[state]
     elif type(state) in state_mapping:
-        ret = _get_ops(state, _tuple_to_set(state_mapping[type(state)]), **options)
-    elif (isinstance(state, BraBase) or issubclass(state, BraBase)) and state.dual_class() in state_mapping:
-        ret = _get_ops(state, _tuple_to_set(state_mapping[state.dual_class()]))
+        ret = _get_ops(state, \
+                       _tuple_to_set(state_mapping[type(state)]), **options)
+    elif isinstance(state, BraBase) and state.dual_class() in state_mapping:
+        ret = _get_ops(state, \
+                       _tuple_to_set(state_mapping[state.dual_class()]))
+    elif issubclass(state, BraBase) and state.dual_class() in state_mapping:
+        state_inst = _make_default(state)
+        try:
+            ret = _get_ops(state_inst, \
+                           _tuple_to_set(state_mapping[state.dual_class()]))
+        except (NotImplementedError, TypeError):
+            ret = state_mapping[state.dual_class()]
     else:
         ret = None
 
     return _tuple_to_set(ret)
 
+def _make_default(expr):
+    try:
+        ret = expr()
+    except Exception:
+        ret = expr
+
+    return ret
+
 def _get_state(state_class, ops, **options):
-    #Try to get a state instance from the operator INSTANCES. If this fails, get the class
+    # Try to get a state instance from the operator INSTANCES.
+    # If this fails, get the class
     try:
         ret = state_class._operators_to_state(ops, **options)
     except NotImplementedError:
-        ret = state_class
+        ret = _make_default(state_class)
 
     return ret
 
 def _get_ops(state_inst, op_classes, **options):
-    #Try to get operator instances from the state INSTANCE. If this fails, just return the classes
+    # Try to get operator instances from the state INSTANCE.
+    # If this fails, just return the classes
     try:
         ret = state_inst._state_to_operators(op_classes, **options)
     except NotImplementedError:
-        ret = op_classes
+        if isinstance(op_classes, (set, tuple)):
+            ret = map(lambda x: _make_default(x), op_classes)
+        else:
+            ret = _make_default(op_classes)
+
+    if isinstance(ret, set) and len(ret) == 1:
+        return ret[0]
 
     return ret
 

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -51,13 +51,13 @@ def operators_to_state(operators, **options):
     >>> from sympy.physics.quantum.cartesian import XOp, PxOp
     >>> from sympy.physics.quantum.operatorset import operators_to_state
     >>> operators_to_state(XOp)
-    <class 'sympy.physics.quantum.cartesian.XKet'>
+    |x>
     >>> operators_to_state(XOp())
-    <class 'sympy.physics.quantum.cartesian.XKet'>
+    |x>
     >>> operators_to_state(PxOp)
-    <class 'sympy.physics.quantum.cartesian.PxKet'>
+    |px>
     >>> operators_to_state(PxOp())
-    <class 'sympy.physics.quantum.cartesian.PxKet'>
+    |px>
     """
 
     if not (isinstance(operators, Operator) or issubclass(operators, Operator) or isinstance(operators, set)):
@@ -135,13 +135,13 @@ def state_to_operators(state, **options):
     >>> from sympy.physics.quantum.cartesian import XKet, PxKet
     >>> from sympy.physics.quantum.operatorset import state_to_operators
     >>> state_to_operators(XKet)
-    <class 'sympy.physics.quantum.cartesian.XOp'>
+    X
     >>> state_to_operators(XKet())
-    <class 'sympy.physics.quantum.cartesian.XOp'>
+    X
     >>> state_to_operators(PxKet)
-    <class 'sympy.physics.quantum.cartesian.PxOp'>
+    Px
     >>> state_to_operators(PxKet())
-    <class 'sympy.physics.quantum.cartesian.PxOp'>
+    Px
     """
 
     if not (isinstance(state, StateBase) or issubclass(state, StateBase)):

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -18,7 +18,7 @@ state_mapping = { PxKet : PxOp,
 
 rev_mapping = dict((v,k) for k,v in state_mapping.iteritems())
 
-def operators_to_state(arg, **options):
+def operators_to_state(operators, **options):
     """ operators_to_state
 
     A global function for mapping operator classes to their associated states.
@@ -27,6 +27,18 @@ def operators_to_state(arg, **options):
 
     This function can handle both instances of a given operator or just the class itself
     (i.e. both XOp() and XOp)
+
+    There are multiple use cases to consider:
+
+    1) A class or set of classes is passed: First, we try to instantiate default instances for these operators. If this fails,
+    then the class is simply returned. If we succeed in instantiating default instances, then we try to call
+    state._operators_to_state on the operator instances. If this fails, the class is returned. Otherwise, the instance returned
+    by _operators_to_state is returned.
+
+    2) An instance or set of instances is passed: In this case, state._operators_to_state is called on the instances passed. If
+    this fails, a state class is returned. If the method returns an instance, that instance is returned.
+
+    In both cases, if the operator class or set does not exist in the state_mapping dictionary, None is returned.
 
     Parameters
     ===========
@@ -48,35 +60,50 @@ def operators_to_state(arg, **options):
     <class 'sympy.physics.quantum.cartesian.PxKet'>
     """
 
-    if not (isinstance(arg, Operator) or issubclass(arg, Operator) or isinstance(arg, set)):
+    if not (isinstance(operators, Operator) or issubclass(operators, Operator) or isinstance(operators, set)):
         raise NotImplementedError("Argument is not an Operator or a set!")
 
-    if isinstance(arg, set):
-        for s in arg:
-            if not isinstance(arg, Operator) or issubclass(arg, Operator):
+    if isinstance(operators, set):
+        for s in operators:
+            if not isinstance(operators, Operator) or issubclass(operators, Operator):
                 raise NotImplementedError("Members of given set are not all Operators!")
 
-        ops = tuple(arg)
+        ops = tuple(operators)
 
-        if ops in rev_mapping:
-            return rev_mapping[ops]
+        if ops in rev_mapping: #ops is a list of classes in this case
+            #Try to get an object from default instances of the operators...if this fails, return the class
+            try:
+                op_instances = [op() for op in ops]
+                ret = _get_state(rev_mapping[ops], op_instances, **options)
+            except NotImplementedError:
+                ret = rev_mapping[ops]
+
+            return ret
         else:
             tmp = [type(o) for o in ops]
             classes = tuple(tmp)
 
             if classes in rev_mapping:
-                return rev_mapping[classes]
+                ret = _get_state(rev_mapping[classes], ops, **options)
             else:
-                return None
+                ret = None
+
+            return ret
     else:
-        if arg in rev_mapping:
-            return rev_mapping[arg]
-        elif type(arg) in rev_mapping:
-            return rev_mapping[type(arg)]
+        if operators in rev_mapping:
+            try:
+                op_instance = operators()
+                ret = _get_state(rev_mapping[operators], op_instance, **options)
+            except NotImplementedError:
+                ret = rev_mapping[operators]
+
+            return ret
+        elif type(operators) in rev_mapping:
+            return _get_state(rev_mapping[type(operators)], operators, **options)
         else:
             return None
 
-def state_to_operators(arg, **options):
+def state_to_operators(state, **options):
     """ state_to_operators
 
     A global function for mapping state classes to their associated operators or sets of operators.
@@ -84,6 +111,18 @@ def state_to_operators(arg, **options):
 
     This function can handle both instances of a given state or just the class itself
     (i.e. both XKet() and XKet)
+
+    There are multiple use cases to consider:
+
+    1) A state class is passed: In this case, we first try instantiating a default instance of the class. If this succeeds,
+    then we try to call state._state_to_operators on that instance. If the creation of the default instance or if the calling of
+    _state_to_operators fails, then either an operator class or set of operator classes is returned. Otherwise, the appropriate
+    operator instances are returned.
+
+    2) A state instance is returned: Here, state._state_to_operators is called for the instance. If this fails, then a class
+    or set of operator classes is returned. Otherwise, the instances are returned.
+
+    In either case, if the state's class does not exist in state_mapping, None is returned.
 
     Parameters
     ===========
@@ -105,19 +144,44 @@ def state_to_operators(arg, **options):
     <class 'sympy.physics.quantum.cartesian.PxOp'>
     """
 
-    if not (isinstance(arg, StateBase) or issubclass(arg, StateBase)):
+    if not (isinstance(state, StateBase) or issubclass(state, StateBase)):
         raise NotImplementedError("Argument is not a state!")
 
-    if arg in state_mapping:
-        ret = state_mapping[arg]
-    elif type(arg) in state_mapping:
-        ret = state_mapping[type(arg)]
-    elif isinstance(arg, BraBase) and arg.dual_class in state_mapping:
-        ret = state_mapping[arg.dual_class]
+    if state in state_mapping: #state is a class
+        try:
+            state_inst = state()
+            ret = _get_ops(state_inst, _tuple_to_set(state_mapping[state]), **options)
+        except NotImplementedError:
+            ret = state_mapping[state]
+    elif type(state) in state_mapping:
+        ret = _get_ops(state, _tuple_to_set(state_mapping[type(state)]), **options)
+    elif isinstance(state, BraBase) and state.dual_class in state_mapping:
+        ret = _get_ops(state, _tuple_to_set(state_mapping[state.dual_class]))
     else:
         ret = None
 
-    if isinstance(ret, tuple):
-        return set(ret)
+    return _tuple_to_set(ret)
+
+def _get_state(state_class, ops, **options):
+    #Try to get a state instance from the operator INSTANCES. If this fails, get the class
+    try:
+        ret = state_class._operators_to_state(ops, **options)
+    except NotImplementedError:
+        ret = state_class
+
+    return ret
+
+def _get_ops(state_inst, op_classes, **options):
+    #Try to get operator instances from the state INSTANCE. If this fails, just return the classes
+    try:
+        ret = state_inst._state_to_operators(op_classes, **options)
+    except NotImplementedError:
+        ret = op_classes
+
+    return ret
+
+def _tuple_to_set(ops):
+    if isinstance(ops, tuple):
+        return set(ops)
     else:
-        return ret
+        return ops

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -1,0 +1,113 @@
+from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
+from sympy.physics.quantum.operator import Operator
+from sympy.physics.quantum.state import StateBase
+
+#state_mapping stores the mappings between states and their associated operators or sets
+#of operators. This should be updated when new classes are written!
+
+state_mapping = { PxKet : PxOp,
+                  XKet : XOp }
+
+rev_mapping = dict((v,k) for k,v in state_mapping.iteritems())
+
+def operator_to_state(arg, **options):
+    """ operator_to_state
+    
+    A global function for mapping operator classes to their associated states.
+    It takes either an Operator or a set of operators and returns the state associated
+    with these.
+
+    This function can handle both instances of a given operator or just the class itself
+    (i.e. both XOp() and XOp)
+
+    Parameters
+    ===========
+
+    arg: Operator or set
+         The class or instance of the operator or set of operators to be mapped to a state
+
+    Examples
+    ===========
+    >>> from sympy.physics.quantum.cartesian import XOp, PxOp
+    >>> from sympy.physics.quantum.operatorset import operator_to_state
+    >>> operator_to_state(XOp)
+    <class 'sympy.physics.quantum.cartesian.XKet'>
+    >>> operator_to_state(XOp())
+    <class 'sympy.physics.quantum.cartesian.XKet'>
+    >>> operator_to_state(PxOp)
+    <class 'sympy.physics.quantum.cartesian.PxKet'>
+    >>> operator_to_state(PxOp())
+    <class 'sympy.physics.quantum.cartesian.PxKet'>
+    """
+    
+    if not (isinstance(arg, Operator) or issubclass(arg, Operator) or isinstance(arg, set)):
+        raise NotImplementedError("Argument is not an Operator or a set!")
+
+    if isinstance(arg, set):
+        for s in arg:
+            if not isinstance(arg, Operator) or issubclass(arg, Operator):
+                raise NotImplementedError("Members of given set are not all Operators!")
+
+        ops = tuple(arg)
+
+        if ops in rev_mapping:
+            return rev_mapping[ops]
+        else:
+            tmp = [type(o) for o in ops]
+            classes = tuple(tmp)
+
+            if classes in rev_mapping:
+                return rev_mapping[classes]
+            else:
+                return None
+    else:
+        if arg in rev_mapping:
+            return rev_mapping[arg]
+        elif type(arg) in rev_mapping:
+            return rev_mapping[type(arg)]
+        else:
+            return None
+
+def state_to_operator(arg, **options):
+    """ state_to_operator
+    
+    A global function for mapping state classes to their associated operators or sets of operators.
+    It takes either a state class or instance. 
+
+    This function can handle both instances of a given state or just the class itself
+    (i.e. both XKet() and XKet)
+
+    Parameters
+    ===========
+
+    arg: StateBase class or instance (or subclasses)
+         The class or instance of the state to be mapped to an operator or set of operators
+
+    Examples
+    ===========
+    >>> from sympy.physics.quantum.cartesian import XKet, PxKet
+    >>> from sympy.physics.quantum.operatorset import state_to_operator
+    >>> state_to_operator(XKet)
+    <class 'sympy.physics.quantum.cartesian.XOp'>
+    >>> state_to_operator(XKet())
+    <class 'sympy.physics.quantum.cartesian.XOp'>
+    >>> state_to_operator(PxKet)
+    <class 'sympy.physics.quantum.cartesian.PxOp'>
+    >>> state_to_operator(PxKet())
+    <class 'sympy.physics.quantum.cartesian.PxOp'>
+    """
+    
+    if not (isinstance(arg, StateBase) or issubclass(arg, StateBase)):
+        raise NotImplementedError("Argument is not a state!")
+
+    if arg in state_mapping:
+        ret = state_mapping[arg]
+    elif type(arg) in state_mapping:
+        ret = state_mapping[type(arg)]
+    else:
+        ret = None
+
+    if isinstance(ret, tuple):
+        return set(ret)
+    else:
+        return ret

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -1,9 +1,17 @@
 from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
 from sympy.physics.quantum.operator import Operator
-from sympy.physics.quantum.state import StateBase
+from sympy.physics.quantum.state import StateBase, KetBase, BraBase
 
-#state_mapping stores the mappings between states and their associated operators or sets
-#of operators. This should be updated when new classes are written!
+__all__ = [
+    'operator_to_state',
+    'state_to_operator'
+]
+
+#state_mapping stores the mappings between states and their associated operators or tuples
+#of operators. This should be updated when new classes are written! Entries are of the form
+# PxKet : PxOp or something like 3DKet : (ROp, ThetaOp, PhiOp)
+
+# TODO: Update dict with full list of state : operator pairs
 
 state_mapping = { PxKet : PxOp,
                   XKet : XOp }
@@ -12,7 +20,7 @@ rev_mapping = dict((v,k) for k,v in state_mapping.iteritems())
 
 def operator_to_state(arg, **options):
     """ operator_to_state
-    
+
     A global function for mapping operator classes to their associated states.
     It takes either an Operator or a set of operators and returns the state associated
     with these.
@@ -39,7 +47,7 @@ def operator_to_state(arg, **options):
     >>> operator_to_state(PxOp())
     <class 'sympy.physics.quantum.cartesian.PxKet'>
     """
-    
+
     if not (isinstance(arg, Operator) or issubclass(arg, Operator) or isinstance(arg, set)):
         raise NotImplementedError("Argument is not an Operator or a set!")
 
@@ -70,9 +78,9 @@ def operator_to_state(arg, **options):
 
 def state_to_operator(arg, **options):
     """ state_to_operator
-    
+
     A global function for mapping state classes to their associated operators or sets of operators.
-    It takes either a state class or instance. 
+    It takes either a state class or instance.
 
     This function can handle both instances of a given state or just the class itself
     (i.e. both XKet() and XKet)
@@ -96,7 +104,7 @@ def state_to_operator(arg, **options):
     >>> state_to_operator(PxKet())
     <class 'sympy.physics.quantum.cartesian.PxOp'>
     """
-    
+
     if not (isinstance(arg, StateBase) or issubclass(arg, StateBase)):
         raise NotImplementedError("Argument is not a state!")
 
@@ -104,6 +112,8 @@ def state_to_operator(arg, **options):
         ret = state_mapping[arg]
     elif type(arg) in state_mapping:
         ret = state_mapping[type(arg)]
+    elif isinstance(arg, BraBase) and arg.dual_class in state_mapping:
+        ret = state_mapping[arg.dual_class]
     else:
         ret = None
 

--- a/sympy/physics/quantum/piab.py
+++ b/sympy/physics/quantum/piab.py
@@ -38,7 +38,7 @@ class PIABKet(Ket):
     def _eval_hilbert_space(cls, args):
         return L2(Interval(S.NegativeInfinity,S.Infinity))
 
-    @property
+    @classmethod
     def dual_class(self):
         return PIABBra
 
@@ -62,7 +62,7 @@ class PIABBra(Bra):
     def _eval_hilbert_space(cls, label):
         return L2(Interval(S.NegativeInfinity,S.Infinity))
 
-    @property
+    @classmethod
     def dual_class(self):
         return PIABKet
 

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -12,7 +12,7 @@ from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.operator import OuterProduct
-from sympy.physics.quantum.state import KetBase, BraBase
+from sympy.physics.quantum.state import KetBase, BraBase, Wavefunction
 from sympy.physics.quantum.tensorproduct import TensorProduct
 
 
@@ -109,7 +109,8 @@ def qapply_Mul(e, **options):
     lhs = args.pop()
 
     # Make sure we have two non-commutative objects before proceeding.
-    if rhs.is_commutative or lhs.is_commutative:
+    if (rhs.is_commutative and not isinstance(rhs, Wavefunction)) or \
+           (lhs.is_commutative and not isinstance(lhs, Wavefunction)):
         return e
 
     # For a Pow with an integer exponent, apply one of them and reduce the

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -116,7 +116,7 @@ class QExpr(Expr):
         # First compute args and call Expr.__new__ to create the instance
         args = cls._eval_args(args)
         if len(args) == 0:
-            args = cls._eval_args(list(cls.default_args()))
+            args = cls._eval_args(tuple(cls.default_args()))
         inst = Expr.__new__(cls, *args, **{'commutative':False})
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)
@@ -163,10 +163,10 @@ class QExpr(Expr):
     def default_args(self):
         """If no arguments are specified, then this will return a default set of arguments to be run through the constructor.
 
-        Should be a tuple of arguments.
+        NOTE: Any classes that override this MUST return a tuple of arguments.
         Should be overidden by subclasses to specify the default arguments for kets and operators
         """
-        return (None,)
+        raise NotImplementedError("No default arguments for this class!")
 
     #-------------------------------------------------------------------------
     # _eval_* methods

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -346,21 +346,23 @@ class QExpr(Expr):
         if basis is None:
             result = self._represent_default_basis(**options)
         else:
-            #try:
             result = dispatch_method(self, '_represent', basis, **options)
-            #except NotImplementedError:
-            #    if isinstance(self, State):
 
         # If we get a matrix representation, convert it to the right format.
         format = options.get('format', 'sympy')
-        if format == 'sympy' and not isinstance(result, Matrix):
-            result = to_sympy(result)
-        elif format == 'numpy' and not isinstance(result, numpy_ndarray):
-            result = to_numpy(result)
-        elif format == 'scipy.sparse' and\
-            not isinstance(result, scipy_sparse_matrix):
-            result = to_scipy_sparse(result)
+        result = self.format_represent(result, format)
+        
         return result
+
+    def _format_represent(self, result, format):
+        if format == 'sympy' and not isinstance(result, Matrix):
+            return to_sympy(result)
+        elif format == 'numpy' and not isinstance(result, numpy_ndarray):
+            return to_numpy(result)
+        elif format == 'scipy.sparse' and\
+        not isinstance(result, scipy_sparse_matrix):
+            return to_scipy_sparse(result)
+            
 
 
 def split_commutative_parts(e):

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -149,7 +149,7 @@ class QExpr(Expr):
         This must be a tuple, rather than a Tuple.
         """
         if len(self.args) == 0: # If there is no label specified, return the default
-            return self.default_label
+            return self._eval_args([self.default_label])
         else:
             return self.args
 
@@ -161,10 +161,11 @@ class QExpr(Expr):
     def default_label(self):
         """If no label is specified, then this will be set to be the default value.
 
+        Should be a string. Will be qsympified upon evaluation of label.
+        Convention should be capital letter for operators.
         Should be overidden by subclasses to specify the default labels for kets and operators
         """
-
-        return None
+        return ""
 
     #-------------------------------------------------------------------------
     # _eval_* methods

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -288,7 +288,7 @@ class QExpr(Expr):
         # than str(). See L1072 of basic.py.
         # This will call self.rule(*self.args) for rewriting.
         if hints.get('deep', False):
-            args = [ a._eval_rewrite(pattern, rule, **hints) for a in self ]
+            args = [ a._eval_rewrite(pattern, rule, **hints) for a in self.args ]
         else:
             args = self.args
 

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -116,7 +116,7 @@ class QExpr(Expr):
         # First compute args and call Expr.__new__ to create the instance
         args = cls._eval_args(args)
         if len(args) == 0:
-            args = cls._eval_args([cls.default_label()])
+            args = cls._eval_args(list(cls.default_args()))
         inst = Expr.__new__(cls, *args, **{'commutative':False})
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)
@@ -151,7 +151,7 @@ class QExpr(Expr):
         This must be a tuple, rather than a Tuple.
         """
         if len(self.args) == 0: # If there is no label specified, return the default
-            return self._eval_args([self.default_label()])
+            return self._eval_args(list(self.default_args()))
         else:
             return self.args
 
@@ -160,14 +160,13 @@ class QExpr(Expr):
         return True
 
     @classmethod
-    def default_label(self):
-        """If no label is specified, then this will be set to be the default value.
+    def default_args(self):
+        """If no arguments are specified, then this will return a default set of arguments to be run through the constructor.
 
-        Should be a string. Will be qsympified upon evaluation of label.
-        Convention should be capital letter for operators.
-        Should be overidden by subclasses to specify the default labels for kets and operators
+        Should be a tuple of arguments.
+        Should be overidden by subclasses to specify the default arguments for kets and operators
         """
-        return ""
+        return (None,)
 
     #-------------------------------------------------------------------------
     # _eval_* methods

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -350,8 +350,7 @@ class QExpr(Expr):
 
         # If we get a matrix representation, convert it to the right format.
         format = options.get('format', 'sympy')
-        result = self.format_represent(result, format)
-        
+        result = self._format_represent(result, format)
         return result
 
     def _format_represent(self, result, format):
@@ -362,8 +361,8 @@ class QExpr(Expr):
         elif format == 'scipy.sparse' and\
         not isinstance(result, scipy_sparse_matrix):
             return to_scipy_sparse(result)
-            
 
+        return result
 
 def split_commutative_parts(e):
     """Split into commutative and non-commutative parts."""

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -115,6 +115,8 @@ class QExpr(Expr):
 
         # First compute args and call Expr.__new__ to create the instance
         args = cls._eval_args(args)
+        if len(args) == 0:
+            args = cls._eval_args([cls.default_label()])
         inst = Expr.__new__(cls, *args, **{'commutative':False})
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)
@@ -149,7 +151,7 @@ class QExpr(Expr):
         This must be a tuple, rather than a Tuple.
         """
         if len(self.args) == 0: # If there is no label specified, return the default
-            return self._eval_args([self.default_label])
+            return self._eval_args([self.default_label()])
         else:
             return self.args
 
@@ -157,7 +159,7 @@ class QExpr(Expr):
     def is_symbolic(self):
         return True
 
-    @property
+    @classmethod
     def default_label(self):
         """If no label is specified, then this will be set to be the default value.
 
@@ -344,7 +346,10 @@ class QExpr(Expr):
         if basis is None:
             result = self._represent_default_basis(**options)
         else:
+            #try:
             result = dispatch_method(self, '_represent', basis, **options)
+            #except NotImplementedError:
+            #    if isinstance(self, State):
 
         # If we get a matrix representation, convert it to the right format.
         format = options.get('format', 'sympy')

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -148,11 +148,23 @@ class QExpr(Expr):
 
         This must be a tuple, rather than a Tuple.
         """
-        return self.args
+        if len(self.args) == 0: # If there is no label specified, return the default
+            return self.default_label
+        else:
+            return self.args
 
     @property
     def is_symbolic(self):
         return True
+
+    @property
+    def default_label(self):
+        """If no label is specified, then this will be set to be the default value.
+
+        Should be overidden by subclasses to specify the default labels for kets and operators
+        """
+
+        return None
 
     #-------------------------------------------------------------------------
     # _eval_* methods

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -169,7 +169,7 @@ class Qubit(QubitState, Ket):
     """
 
 
-    @property
+    @classmethod
     def dual_class(self):
         return QubitBra
 
@@ -219,7 +219,7 @@ class QubitBra(QubitState, Bra):
     See ``Qubit`` for examples.
 
     """
-    @property
+    @classmethod
     def dual_class(self):
         return Qubit
 
@@ -317,7 +317,7 @@ class IntQubit(IntQubitState, Qubit):
         >>> Qubit(q)
         |101>
     """
-    @property
+    @classmethod
     def dual_class(self):
         return IntQubitBra
 
@@ -325,7 +325,7 @@ class IntQubit(IntQubitState, Qubit):
 class IntQubitBra(IntQubitState, QubitBra):
     """A qubit bra that store integers as binary numbers in qubit values."""
 
-    @property
+    @classmethod
     def dual_class(self):
         return IntQubit
 

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -374,6 +374,35 @@ def get_basis(expr, **options):
         return None
 
 def enumerate_states(*args, **options):
+    """
+    Handles indexing of states passed to it.
+
+    Operates in two different modes:
+
+    1) Two arguments are passed to it. The first is the base state which is to be indexed, and the
+    second argument is a list of indices to append.
+
+    2) Three arguments are passed. The first is again the base state to be indexed. The second is the
+    start index for counting. The final argument is the number of kets you wish to receive.
+
+    Parameters
+    =============
+
+    args: list
+    See list of operation mode above for explanation
+
+    Examples
+    =============
+    >>> from sympy.physics.quantum.cartesian import XBra, XKet
+    >>> from sympy.physics.quantum.represent import enumerate_states
+    >>> test = XKet('foo')
+    >>> enumerate_states(test, 1, 3)
+    [|foo_1>, |foo_2>, |foo_3>]
+    >>> test2 = XBra('bar')
+    >>> enumerate_states(test2, [4, 5, 10])
+    [<bar_4|, <bar_5|, <bar_10|]
+    """
+
     state = args[0]
 
     if not isinstance(state, StateBase):
@@ -391,7 +420,7 @@ def enumerate_states(*args, **options):
     enum_states = [0 for i in range(len(index_list))]
     ct = 0
     for i in index_list:
-        label = state.label
+        label = state.args
         new_label = [str(lab) + "_" + str(i) for lab in label]
         enum_states[ct] = state_class(*new_label, **options)
         ct+=1

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -110,6 +110,15 @@ def represent(expr, **options):
         >>> represent(up, basis=sz)
         [1]
         [0]
+
+        >>> from sympy.physics.quantum.cartesian import XOp, XKet, XBra
+        >>> X = XOp()
+        >>> x = XKet()
+        >>> y = XBra('y')
+        >>> represent(X*x)
+        x*DiracDelta(x - x_2)
+        >>> represent(X*x*y)
+        x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
     """
     format = options.get('format', 'sympy')
     if isinstance(expr, QExpr):
@@ -186,8 +195,6 @@ def represent(expr, **options):
         result = represent(arg, **options)*result
         last_arg = arg
 
-    #TODO: Collapse DiracDelta functions
-
     # All three matrix formats create 1 by 1 matrices when inner products of
     # vectors are taken. In these cases, we simply return a scalar.
     result = flatten_scalar(result)
@@ -201,6 +208,7 @@ def represent(expr, **options):
 
     # If the result is expressed in a continuous basis, then we need to integrate over any unities
     # that were inserted. As a start to this, we should collapse all of the delta functions by hand
+    # TODO: Integrate any remaining unities after delta functions are collapsed?
     result = collapse_deltas(result, **options)
 
     return result

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -188,7 +188,7 @@ def rep_innerproduct(expr, **options):
         else:
             bra = (basis_kets[1].dual if basis_kets[0] == expr else basis_kets[0].dual)
             ket = expr
-        
+
         prod = InnerProduct(bra, ket)
         result = prod.doit()
 

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -331,7 +331,7 @@ def integrate_result(orig_expr, result, **options):
 
     Examples
     ==========
-    >>> from sympy import symbols
+    >>> from sympy import symbols, DiracDelta
     >>> from sympy.physics.quantum.represent import integrate_result
     >>> from sympy.physics.quantum.cartesian import XOp, XKet
     >>> x_ket = XKet()
@@ -405,7 +405,7 @@ def get_basis(expr, **options):
     Examples:
     ===========
     >>> from sympy.physics.quantum.represent import get_basis
-    >>> from sympy.physics.quantum.cartesian import XOp, XKet
+    >>> from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
     >>> x = XKet()
     >>> X = XOp()
     >>> get_basis(x)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -239,7 +239,7 @@ def rep_innerproduct(expr, **options):
         raise TypeError("expr passed is not a Bra or Ket")
 
     #If the basis is not specified, simply use default states of the same class as expr
-    basis = options.pop('basis', (expr.__class__() if isinstance(expr, KetBase) else expr.dual_class()))
+    basis = options.pop('basis', (expr.__class__() if isinstance(expr, KetBase) else (expr.dual_class())()))
 
     if isinstance(basis, BraBase):
         basis = basis.dual
@@ -427,7 +427,7 @@ def get_basis(expr, **options):
         if isinstance(expr, KetBase):
             return expr.__class__()
         elif isinstance(expr, BraBase):
-            return expr.dual_class()
+            return (expr.dual_class())()
         elif isinstance(expr, Operator):
             state_inst = operators_to_state(expr)
             return (state_inst if state_inst is not None else None)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -186,7 +186,7 @@ def rep_innerproduct(expr, **options):
 
     #Once we know the basis, try to get the basis kets and form an inner product
     if basis.basis_set is not None:
-        basis_kets = basis._get_basis_kets(2)
+        basis_kets = basis._get_basis_kets(1, 2)
 
         if isinstance(expr, BraBase):
             bra = expr
@@ -216,7 +216,7 @@ def rep_expectation(expr, **options):
     if basis is None and expr.basis_ket() is None:
         raise NotImplementedError("Could not get basis kets for this operator")
     elif basis is None:
-        basis_kets = expr._get_basis_kets(2)
+        basis_kets = expr._get_basis_kets(1, 2)
 
     bra = basis_kets[1].dual
     ket = basis_kets[0]

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -18,7 +18,7 @@ from sympy.physics.quantum.matrixutils import flatten_scalar
 from sympy.physics.quantum.state import KetBase, BraBase, StateBase
 from sympy.physics.quantum.operator import Operator, HermitianOperator
 from sympy.physics.quantum.qapply import qapply
-from sympy.physics.quantum.operatorset import operator_to_state, state_to_operator
+from sympy.physics.quantum.operatorset import operators_to_state, state_to_operators
 
 __all__ = [
     'represent',
@@ -244,7 +244,7 @@ def rep_innerproduct(expr, **options):
     if isinstance(basis, BraBase):
         basis = basis.dual
     elif isinstance(basis, Operator):
-        basis = (operator_to_state(basis))()
+        basis = (operators_to_state(basis))()
 
     if not "index" in options:
         options["index"] = 1
@@ -296,14 +296,14 @@ def rep_expectation(expr, **options):
     if not isinstance(expr, Operator):
         raise TypeError("The passed expression is not an operator")
 
-    if basis is None and operator_to_state(expr) is None:
+    if basis is None and operators_to_state(expr) is None:
         raise NotImplementedError("Could not get basis kets for this operator")
     elif basis is None:
-        basis_state = operator_to_state(expr)
+        basis_state = operators_to_state(expr)
         basis_kets = enumerate_states(basis_state(), options["index"], 2)
     else:
         if isinstance(basis, Operator):
-            basis = (operator_to_state(basis))()
+            basis = (operators_to_state(basis))()
         basis_kets = enumerate_states(basis, options["index"], 2)
 
     bra = basis_kets[1].dual
@@ -350,7 +350,7 @@ def integrate_result(orig_expr, result, **options):
         if (isinstance(arg, KetBase) or isinstance (arg, BraBase)):
             options["basis"] = (arg.__class__)()
         elif isinstance(arg, Operator):
-            state_class = operator_to_state(arg)
+            state_class = operators_to_state(arg)
             options["basis"] = (state_class() if state_class is not None else None)
 
     basis = options.pop("basis", None)
@@ -369,7 +369,7 @@ def integrate_result(orig_expr, result, **options):
     for coord in coords:
         if coord in result.free_symbols:
             #TODO: Add support for sets of operators
-            basis_op = (state_to_operator(basis))()
+            basis_op = (state_to_operators(basis))()
             start = basis_op.hilbert_space.interval.start
             end = basis_op.hilbert_space.interval.end
             result = integrate(result, (coord, start, end))
@@ -424,13 +424,13 @@ def get_basis(expr, **options):
         if isinstance(expr, StateBase):
             return expr.__class__()
         elif isinstance(expr, Operator):
-            state_class = operator_to_state(expr)
+            state_class = operators_to_state(expr)
             return (state_class() if state_class is not None else None)
         else:
             return None
     elif (isinstance(basis, Operator) or \
           (not isinstance(basis, StateBase) and issubclass(basis, Operator))):
-        state_class = operator_to_state(basis)
+        state_class = operators_to_state(basis)
         return (state_class() if state_class is not None else None)
     elif isinstance(basis, StateBase):
         return basis

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -347,11 +347,7 @@ def integrate_result(orig_expr, result, **options):
 
     if not "basis" in options:
         arg = orig_expr.args[-1]
-        if (isinstance(arg, KetBase) or isinstance (arg, BraBase)):
-            options["basis"] = (arg.__class__)()
-        elif isinstance(arg, Operator):
-            state_class = operators_to_state(arg)
-            options["basis"] = (state_class() if state_class is not None else None)
+        options["basis"] = get_basis(arg, **options)
 
     basis = options.pop("basis", None)
 
@@ -421,8 +417,10 @@ def get_basis(expr, **options):
     basis = options.pop("basis", None)
 
     if basis is None:
-        if isinstance(expr, StateBase):
+        if isinstance(expr, KetBase):
             return expr.__class__()
+        elif isinstance(expr, BraBase):
+            return expr.dual_class()
         elif isinstance(expr, Operator):
             state_class = operators_to_state(expr)
             return (state_class() if state_class is not None else None)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -484,6 +484,8 @@ def enumerate_states(*args, **options):
     2) Three arguments are passed. The first is again the base state to be indexed. The second is the
     start index for counting. The final argument is the number of kets you wish to receive.
 
+    Tries to call state._enumerate_state. If this fails, returns an empty list
+
     Parameters
     =============
 
@@ -504,24 +506,22 @@ def enumerate_states(*args, **options):
 
     state = args[0]
 
+    if not (len(args) == 2 or len(args) == 3):
+        raise NotImplementedError("Wrong number of arguments!")
+
     if not isinstance(state, StateBase):
         raise TypeError("First argument is not a state!")
 
-    state_class = state.__class__
-    index_list = []
-    if len(args) == 2:
-        index_list = args[1]
-    elif len(args) == 3:
-        index_list = range(args[1], args[1]+args[2])
+    if len(args) == 3:
+        num_states = args[2]
+        options['start_index'] = args[1]
     else:
-        raise NotImplementedError("Wrong number of arguments!")
+        num_states = len(args[1])
+        options['index_list'] = args[1]
 
-    enum_states = [0 for i in range(len(index_list))]
-    ct = 0
-    for i in index_list:
-        label = state.args
-        new_label = [str(lab) + "_" + str(i) for lab in label]
-        enum_states[ct] = state_class(*new_label, **options)
-        ct+=1
+    try:
+        ret = state._enumerate_state(num_states, **options)
+    except NotImplementedError:
+        ret = []
 
-    return enum_states
+    return ret

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -107,19 +107,17 @@ def represent(expr, **options):
     """
     format = options.get('format', 'sympy')
     if isinstance(expr, QExpr):
-        result = None
         try:
-            result = expr._represent(**options)
+            return expr._represent(**options)
         except NotImplementedError as strerr:
             if isinstance(expr, (KetBase, BraBase)):
                 try:
-                    result = rep_innerproduct(expr, **options)
+                    return rep_innerproduct(expr, **options)
                 except NotImplementedError:
                     raise NotImplementedError(strerr)
             else:
                 raise NotImplementedError(strerr)
 
-        return result
     elif isinstance(expr, Add):
         result = represent(expr.args[0], **options)
         for args in expr.args[1:]:
@@ -166,10 +164,10 @@ def represent(expr, **options):
 def rep_innerproduct(expr, **options):
     """ Attempts to calculate inner product with a bra from the specified basis and if this fails
         resorts to the standard represent specified in QExpr"""
-        
+
     basis = options.pop('basis', None)
     superobj = super(type(expr), expr)
-    
+
     if basis is None:
         superobj._represent(**options)
     else:
@@ -181,15 +179,14 @@ def rep_innerproduct(expr, **options):
                 bra = basis_kets[1].dual
             else:
                 bra = basis_kets[0].dual
-            
+
             prod = InnerProduct(bra, expr)
             try:
                 result = prod.doit()
             except NotImplementedError:
                 return superobj._represent(**options)
-        
+
             format = options.get('format', 'sympy')
             return expr._format_represent(result, format)
         else:
             return superobj._represent(**options)
-

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -203,6 +203,8 @@ def represent(expr, **options):
             options["index"] += 1
         elif isinstance(last_arg, KetBase) and isinstance(arg, Operator):
             options["unities"].append(options["index"])
+        elif isinstance(last_arg, KetBase) and isinstance(arg, BraBase):
+            options["unities"].append(options["index"])
 
         result = represent(arg, **options)*result
         last_arg = arg
@@ -364,6 +366,8 @@ def integrate_result(orig_expr, result, **options):
     if not "basis" in options:
         arg = orig_expr.args[-1]
         options["basis"] = get_basis(arg, **options)
+    elif not isinstance(options["basis"], StateBase):
+        options["basis"] = get_basis(orig_expr, **options)
 
     basis = options.pop("basis", None)
 

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -743,7 +743,7 @@ class SpinState(State):
 
     def _eval_innerproduct_JzBra(self, bra, **hints):
         result = KroneckerDelta(self.j, bra.j)
-        if not issubclass(bra.dual_class, self.__class__):
+        if not issubclass(bra.dual_class(), self.__class__):
             result *= self._represent_JzOp(None)[bra.j-bra.m]
         else:
             result *= KroneckerDelta(self.m, bra.m)
@@ -756,7 +756,7 @@ class JxKet(SpinState, Ket):
     See JzKet for the usage of spin eigenstates.
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return JxBra
 
@@ -779,7 +779,7 @@ class JxBra(SpinState, Bra):
     See JzKet for the usage of spin eigenstates.
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return JxKet
 
@@ -790,7 +790,7 @@ class JyKet(SpinState, Ket):
     See JzKet for the usage of spin eigenstates.
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return JyBra
 
@@ -813,7 +813,7 @@ class JyBra(SpinState, Bra):
     See JzKet for the usage of spin eigenstates.
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return JyKet
 
@@ -872,7 +872,7 @@ class JzKet(SpinState, Ket):
 
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return JzBra
 
@@ -895,6 +895,6 @@ class JzBra(SpinState, Bra):
     See the JzKet for the usage of spin eigenstates.
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return JzKet

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -7,7 +7,6 @@ from sympy import (
 from sympy.matrices.matrices import zeros
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
-from sympy.physics.quantum.represent import represent
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.operator import (
     HermitianOperator, Operator, UnitaryOperator
@@ -715,6 +714,7 @@ class SpinState(State):
         return self._rewrite_basis(Jz, JzKet, *args)
 
     def _rewrite_basis(self, basis, evect_cls, *args):
+        from sympy.physics.quantum.represent import represent
         j = self.j
         size, mvals = m_values(j)
         result = 0

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -57,18 +57,18 @@ class StateBase(QExpr):
     instead use State.
     """
 
-    @property
+    @classmethod
     def basis_op(self):
         """Return the operator that this state is an eigenstate of; to be overidden in subclasses"""
         return None
 
-    @property
+    @classmethod
     def default_label(self):
-        if self.basis_op is None:
+        if self.basis_op() is None:
             return None
         else:
             #
-            return ((self.basis_op()).default_label.lower() + "_1")
+            return (self.basis_op().default_label().lower() + "_1")
 
     #-------------------------------------------------------------------------
     # Dagger/dual

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -69,7 +69,7 @@ class StateBase(QExpr):
             return None
         else:
             #Returns a default label corresponding to the labeling of its basis operator
-            return (self.basis_op().default_label().lower() + "_1")
+            return (self.basis_op().default_label().lower())
 
     def _represent_default_basis(self, **options):
         return self._represent(basis=(self.basis_op())())

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -74,7 +74,7 @@ class StateBase(QExpr):
         return state_to_operators(self)
 
     def _represent_default_basis(self, **options):
-        return self._represent(basis=(self.operators)())
+        return self._represent(basis=self.operators)
 
     #-------------------------------------------------------------------------
     # Dagger/dual

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -1,7 +1,7 @@
 """Dirac notation for states."""
 
 
-from sympy import Expr, Symbol, Function, integrate
+from sympy import Expr, Symbol, Function, integrate, Expr
 from sympy import Lambda, oo, conjugate, Tuple, sqrt
 from sympy.printing.pretty.stringpict import prettyForm
 
@@ -569,6 +569,8 @@ class Wavefunction(Function):
     1
     >>> f(L+1)
     0
+    >>> f(L-1)
+    2**(1/2)*(1/L)**(1/2)*sin(pi*n*(L - 1)/L)
     >>> f(-1)
     0
     >>> f(0.85)
@@ -604,8 +606,15 @@ class Wavefunction(Function):
         #If the passed value is outside the specified bounds, return 0
         for v in var:
             lower,upper = self.limits[v]
+
+            #Do the comparison to limits only if the passed symbol is actually
+            #a symbol present in the limits; Had problems with a comparison of x > L
+            if isinstance(args[ct], Expr) and not (lower in args[ct].free_symbols or upper in args[ct].free_symbols):
+                continue
+
             if args[ct] < lower or args[ct] > upper:
                 return 0
+
             ct+=1
 
         expr = self.expr

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -65,12 +65,12 @@ class StateBase(QExpr):
         return None
 
     @classmethod
-    def default_label(self):
+    def default_args(self):
         """Returns a default label corresponding to the labeling of its basis operator"""
         if self.basis_op() is None:
             return None
         else:
-            return (self.basis_op().default_label().lower())
+            return tuple([str(arg).lower() for arg in self.basis_op().default_args()])
 
     def _represent_default_basis(self, **options):
         return self._represent(basis=(self.basis_op())())

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -83,9 +83,9 @@ class StateBase(QExpr):
     @property
     def dual(self):
         """Return the dual state of this one."""
-        return self.dual_class._new_rawargs(self.hilbert_space, *self.args)
+        return self.dual_class()._new_rawargs(self.hilbert_space, *self.args)
 
-    @property
+    @classmethod
     def dual_class(self):
         """Return the class used to construt the dual."""
         raise NotImplementedError(
@@ -133,7 +133,7 @@ class KetBase(StateBase):
     lbracket_latex = r'\left|'
     rbracket_latex = r'\right\rangle '
 
-    @property
+    @classmethod
     def dual_class(self):
         return BraBase
 
@@ -206,7 +206,19 @@ class BraBase(StateBase):
     lbracket_latex = r'\left\langle '
     rbracket_latex = r'\right|'
 
-    @property
+    @classmethod
+    def _operators_to_state(self, ops, **options):
+        state = self.dual_class().operators_to_state(ops, **options)
+        return state.dual
+
+    def _state_to_operators(self, op_classes, **options):
+        return self.dual._state_to_operators(op_classes, **options)
+
+    @classmethod
+    def default_args(self):
+        return self.dual_class().default_args()
+
+    @classmethod
     def dual_class(self):
         return KetBase
 
@@ -274,7 +286,7 @@ class Ket(State, KetBase):
 
         >>> k.dual
         <psi|
-        >>> k.dual_class
+        >>> k.dual_class()
         <class 'sympy.physics.quantum.state.Bra'>
 
     Take a linear combination of two kets::
@@ -297,7 +309,7 @@ class Ket(State, KetBase):
     [1] http://en.wikipedia.org/wiki/Bra-ket_notation
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return Bra
 
@@ -334,7 +346,7 @@ class Bra(State, BraBase):
 
         >>> b.dual
         |psi>
-        >>> b.dual_class
+        >>> b.dual_class()
         <class 'sympy.physics.quantum.state.Ket'>
 
     Like Kets, Bras can have compound labels and be manipulated in a similar
@@ -356,7 +368,7 @@ class Bra(State, BraBase):
     [1] http://en.wikipedia.org/wiki/Bra-ket_notation
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return Ket
 
@@ -475,11 +487,11 @@ class TimeDepKet(TimeDepState, KetBase):
 
         >>> k.dual
         <psi;t|
-        >>> k.dual_class
+        >>> k.dual_class()
         <class 'sympy.physics.quantum.state.TimeDepBra'>
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return TimeDepBra
 
@@ -516,7 +528,7 @@ class TimeDepBra(TimeDepState, BraBase):
         |psi;t>
     """
 
-    @property
+    @classmethod
     def dual_class(self):
         return TimeDepKet
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -73,6 +73,9 @@ class StateBase(QExpr):
         from operatorset import state_to_operators #import internally to avoid circular import errors
         return state_to_operators(self)
 
+    def _enumerate_state(self, num_states, **options):
+        raise NotImplementedError("Cannot enumerate this state!")
+
     def _represent_default_basis(self, **options):
         return self._represent(basis=self.operators)
 
@@ -217,6 +220,10 @@ class BraBase(StateBase):
 
     def _state_to_operators(self, op_classes, **options):
         return self.dual._state_to_operators(op_classes, **options)
+
+    def _enumerate_state(self, num_states, **options):
+        dual_states = self.dual._enumerate_state(num_states, **options)
+        return map(lambda x: x.dual, dual_states)
 
     @classmethod
     def default_args(self):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -62,9 +62,29 @@ class StateBase(QExpr):
 
     @classmethod
     def _operators_to_state(self, ops, **options):
+        """ Returns the eigenstate instance for the passed operators.
+
+        This method should be overridden in subclasses. It will handle
+        being passed either an Operator instance or set of Operator
+        instances. It should return the corresponding state INSTANCE
+        or simply raise a NotImplementedError. See cartesian.py for an
+        example.
+        """
+
         raise NotImplementedError("Cannot map operators to states in this class. Method not implemented!")
 
     def _state_to_operators(self, op_classes, **options):
+        """ Returns the operators which this state instance is an
+        eigenstate of.
+
+        This method should be overridden in subclasses. It will be
+        called on state instances and be passed the operator classes
+        that we wish to make into instances. The state instance will
+        then transform the classes appropriately, or raise a
+        NotImplementedError if it cannot return operator
+        instances. See cartesian.py for examples,
+        """
+
         raise NotImplementedError("Cannot map this state to operators. Method not implemented!")
 
     @property

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -633,7 +633,7 @@ class Wavefunction(Function):
     def variables(self):
         """
         Return the free coordinates which were passed to the constructor
-        
+
         Examples
         =========
         >>> from sympy.physics.quantum.state import Wavefunction

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -1,7 +1,7 @@
 """Dirac notation for states."""
 
 
-from sympy import Expr
+from sympy import Expr, Symbol
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import (
@@ -67,7 +67,8 @@ class StateBase(QExpr):
         if self.basis_op is None:
             return None
         else:
-            return Symbol(str(self.basis_op.default_label) + "_1")
+            #
+            return ((self.basis_op()).default_label.lower() + "_1")
 
     #-------------------------------------------------------------------------
     # Dagger/dual

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -57,6 +57,18 @@ class StateBase(QExpr):
     instead use State.
     """
 
+    @property
+    def basis_op(self):
+        """Return the operator that this state is an eigenstate of; to be overidden in subclasses"""
+        return None
+
+    @property
+    def default_label(self):
+        if self.basis_op is None:
+            return None
+        else:
+            return Symbol(str(self.basis_op.default_label) + "_1")
+
     #-------------------------------------------------------------------------
     # Dagger/dual
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -134,6 +134,10 @@ class KetBase(StateBase):
     rbracket_latex = r'\right\rangle '
 
     @classmethod
+    def default_args(self):
+        return ("psi",)
+
+    @classmethod
     def dual_class(self):
         return BraBase
 
@@ -396,6 +400,10 @@ class TimeDepState(StateBase):
     #-------------------------------------------------------------------------
     # Initialization
     #-------------------------------------------------------------------------
+
+    @classmethod
+    def default_args(self):
+        return ("psi", "t")
 
     #-------------------------------------------------------------------------
     # Properties

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -70,11 +70,32 @@ class StateBase(QExpr):
         """
         Returns a default label corresponding to the labeling of its basis operator
 
-        To be overidden in subclasses
+        Uses the default labels of the basis operators to determine its own labeling
+        Note that since this is a classmethod, many times state_to_operators will return classes rather than instances.
+        But, since the operators' default_args will also be a classmethod, this won't make a difference for our implementation.
         """
 
-        return None
+        from operatorset import state_to_operators
+        ops = state_to_operators(self)
 
+        if ops is None:
+            return None
+        else:
+            if isinstance(ops, set):
+                new_args = []
+                #Loop accounts for the fact that each operator may have multiple default labels
+                for op in ops:
+                    def_args = op.default_args()
+                    if len(def_args) != 1:
+                        arg = tuple([str(arg).lower() for arg in def_args])
+                    else:
+                        arg = str(def_args[0]).lower()
+
+                    new_args.append(arg)
+
+                return tuple(new_args)
+            else:
+                return tuple([str(arg).lower() for arg in ops.default_args()])
 
     def _represent_default_basis(self, **options):
         return self._represent(basis=(self.operators)())

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -67,8 +67,11 @@ class StateBase(QExpr):
         if self.basis_op() is None:
             return None
         else:
-            #
+            #Returns a default label corresponding to the labeling of its basis operator
             return (self.basis_op().default_label().lower() + "_1")
+
+    def _represent_default_basis(self, **options):
+        return self._represent(basis=(self.basis_op())())
 
     #-------------------------------------------------------------------------
     # Dagger/dual

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -575,6 +575,8 @@ class Wavefunction(Function):
     2**(1/2)*(1/L)**(1/2)*sin(0.85*pi*n/L)
     >> f(0.85, n=1, L=1)
     2**(1/2)*sin(0.85*pi)
+    >> f.is_commutative
+    False
     """
 
     #Any passed tuples for coordinates and their bounds need to be converted to Tuples
@@ -588,6 +590,8 @@ class Wavefunction(Function):
                 new_args[ct] = Tuple(*arg)
             else:
                 new_args[ct] = arg
+
+            setattr(new_args[ct], 'is_commutative', False)
             ct+=1
 
         return super(Function, cls).__new__(cls, *new_args, **options)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -518,7 +518,7 @@ class TimeDepBra(TimeDepState, BraBase):
     def dual_class(self):
         return TimeDepKet
 
-class Wavefunction(Lambda, Function):
+class Wavefunction(Function):
     """Class for representations in continuous bases
 
     Note: Just a demonstration for functions of one variable. Will need to be generalized.
@@ -539,7 +539,7 @@ class Wavefunction(Lambda, Function):
     >> n = 1
     >> L = 1
     >> g = Piecewise((0, x < 0), (0, x > L), (sqrt(2/L)*sin(n*pi*x/L), True))
-    >> f = Wavefunction(x, g)
+    >> f = Wavefunction(g, x)
     >> f.norm_constant
     1
     >> f.is_normalized
@@ -557,6 +557,26 @@ class Wavefunction(Lambda, Function):
     0.412214747707527
     """
 
+    def __call__(self, *args):
+        var = self.variables
+
+        if len(args) != len(var):
+            raise NotImplementedError("Incorrect number of arguments to function!")
+
+        return self.expr.subs(tuple(zip(var, args)))
+
+    @classmethod
+    def eval(self, *args):
+        return None
+
+    @property
+    def variables(self):
+        return tuple(self._args[1:])
+
+    @property
+    def expr(self):
+        return self._args[0]
+
     @property
     def is_normalized(self):
         return (self.norm_constant == 1.0)
@@ -564,7 +584,7 @@ class Wavefunction(Lambda, Function):
     @property
     def norm_constant(self):
         #NOTE: Only works with one variable right now; will have to be changed!
-        return 1/integrate(self.expr*conjugate(self.expr), (self.variables, -oo, oo))
+        return 1/integrate(self.expr*conjugate(self.expr), (self.variables[0], -oo, oo))
 
     def prob(self):
-        return Lambda(self.variables, self.expr*conjugate(self.expr))
+        return Wavefunction(self.expr*conjugate(self.expr), *self.variables)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -4,6 +4,7 @@
 from sympy import Expr, Symbol, Function, integrate, Expr
 from sympy import Lambda, oo, conjugate, Tuple, sqrt
 from sympy.printing.pretty.stringpict import prettyForm
+from sympy.physics.quantum.operator import Operator
 
 from sympy.physics.quantum.qexpr import (
     QExpr, dispatch_method
@@ -59,43 +60,18 @@ class StateBase(QExpr):
     instead use State.
     """
 
+    @classmethod
+    def _operators_to_state(self, ops, **options):
+        raise NotImplementedError("Cannot map operators to states in this class. Method not implemented!")
+
+    def _state_to_operators(self, op_classes, **options):
+        raise NotImplementedError("Cannot map this state to operators. Method not implemented!")
+
     @property
     def operators(self):
         """Return the operator(s) that this state is an eigenstate of"""
         from operatorset import state_to_operators #import internally to avoid circular import errors
         return state_to_operators(self)
-
-    @classmethod
-    def default_args(self):
-        """
-        Returns a default label corresponding to the labeling of its basis operator
-
-        Uses the default labels of the basis operators to determine its own labeling
-        Note that since this is a classmethod, many times state_to_operators will return classes rather than instances.
-        But, since the operators' default_args will also be a classmethod, this won't make a difference for our implementation.
-        """
-
-        from operatorset import state_to_operators
-        ops = state_to_operators(self)
-
-        if ops is None:
-            return None
-        else:
-            if isinstance(ops, set):
-                new_args = []
-                #Loop accounts for the fact that each operator may have multiple default labels
-                for op in ops:
-                    def_args = op.default_args()
-                    if len(def_args) != 1:
-                        arg = tuple([str(arg).lower() for arg in def_args])
-                    else:
-                        arg = str(def_args[0]).lower()
-
-                    new_args.append(arg)
-
-                return tuple(new_args)
-            else:
-                return tuple([str(arg).lower() for arg in ops.default_args()])
 
     def _represent_default_basis(self, **options):
         return self._represent(basis=(self.operators)())

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -66,10 +66,10 @@ class StateBase(QExpr):
 
     @classmethod
     def default_label(self):
+        """Returns a default label corresponding to the labeling of its basis operator"""
         if self.basis_op() is None:
             return None
         else:
-            #Returns a default label corresponding to the labeling of its basis operator
             return (self.basis_op().default_label().lower())
 
     def _represent_default_basis(self, **options):
@@ -533,49 +533,49 @@ class Wavefunction(Function):
     Examples
     ==============
     Particle in a box
-    >> from sympy import Symbol, Piecewise, pi
-    >> from sympy.functions import sqrt, sin
-    >> from sympy.physics.quantum.state import Wavefunction
-    >> x = Symbol('x')
-    >> n = 1
-    >> L = 1
-    >> g = Piecewise((0, x < 0), (0, x > L), (sqrt(2/L)*sin(n*pi*x/L), True))
-    >> f = Wavefunction(g, x)
-    >> f.norm_constant
+    >>> from sympy import Symbol, Piecewise, pi
+    >>> from sympy.functions import sqrt, sin
+    >>> from sympy.physics.quantum.state import Wavefunction
+    >>> x = Symbol('x')
+    >>> n = 1
+    >>> L = 1
+    >>> g = Piecewise((0, x < 0), (0, x > L), (sqrt(2/L)*sin(n*pi*x/L), True))
+    >>> f = Wavefunction(g, x)
+    >>> f.norm_constant
     1
-    >> f.is_normalized
+    >>> f.is_normalized
     True
-    >> p = f.prob()
-    >> p(0)
+    >>> p = f.prob()
+    >>> p(0)
     0
-    >> p(L)
+    >>> p(L)
     0
-    >> p(0.5)
+    >>> p(0.5)
     0
-    >> p(0.85*L)
+    >>> p(0.85*L)
     2*sin(0.85*pi)**2
-    >> N(p(0.85*L))
+    >>> N(p(0.85*L))
     0.412214747707527
 
     Additionally, you can specify the bounds of the function and the indices in a different way.
-    >> from sympy import symbols, pi
-    >> from sympy.functions import sqrt, sin
-    >> from sympy.physics.quantum.state import Wavefunction
-    >> x, L = symbols('x,L', real=True)
-    >> n = symbols('n', integer=True)
-    >> g = sqrt(2/L)*sin(n*pi*x/L)
-    >> f = Wavefunction(g, (x, 0, L))
-    >> f.norm_constant
+    >>> from sympy import symbols, pi
+    >>> from sympy.functions import sqrt, sin
+    >>> from sympy.physics.quantum.state import Wavefunction
+    >>> x, L = symbols('x,L', real=True)
+    >>> n = symbols('n', integer=True)
+    >>> g = sqrt(2/L)*sin(n*pi*x/L)
+    >>> f = Wavefunction(g, (x, 0, L))
+    >>> f.norm_constant
     1
-    >> f(L+1)
+    >>> f(L+1)
     0
-    >> f(-1)
+    >>> f(-1)
     0
-    >> f(0.85)
+    >>> f(0.85)
     2**(1/2)*(1/L)**(1/2)*sin(0.85*pi*n/L)
-    >> f(0.85, n=1, L=1)
+    >>> f(0.85, n=1, L=1)
     2**(1/2)*sin(0.85*pi)
-    >> f.is_commutative
+    >>> f.is_commutative
     False
     """
 
@@ -631,25 +631,109 @@ class Wavefunction(Function):
 
     @property
     def variables(self):
+        """
+        Return the free coordinates which were passed to the constructor
+        
+        Examples
+        =========
+        >>> from sympy.physics.quantum.state import Wavefunction
+        >>> from sympy import symbols
+        >>> x,y = symbols('x,y')
+        >>> f = Wavefunction(x*y, x, y)
+        >>> f.variables
+        (x, y)
+        >>> g = Wavefunction(x*y, x)
+        >>> g.variables
+        (x,)
+        """
         var = [g[0] if isinstance(g, Tuple) else g for g in self._args[1:]]
         return tuple(var)
 
     @property
     def limits(self):
+        """
+        Return the limits of the coordinates passed to the constructor.
+        If no limits are specified, defaults to (-oo, oo)
+
+        Examples
+        =========
+        >>> from sympy.physics.quantum.state import Wavefunction
+        >>> from sympy import symbols
+        >>> x, y = symbols('x, y')
+        >>> f = Wavefunction(x**2, (x, 0, 1))
+        >>> f.limits
+        {x: (0, 1)}
+        >>> f = Wavefunction(x**2, x)
+        >>> f.limits
+        {x: (-oo, oo)}
+        >>> f = Wavefunction(x**2 + y**2, x, (y, -1, 2))
+        {x: (-oo, oo), y: (-1, 2)}
+        """
         limits = [(g[1], g[2]) if isinstance(g, Tuple) else (-oo, oo) \
                   for g in self._args[1:]]
         return dict(zip(self.variables, tuple(limits)))
 
     @property
     def expr(self):
+        """
+        Return the functional form of the Wavefunction
+
+        Examples
+        =========
+        >>> from sympy.physics.quantum.state import Wavefunction
+        >>> from sympy import symbols
+        >>> x, y = symbols('x, y')
+        >>> f = Wavefunction(x**2, x)
+        >>> f.expr
+        x**2
+        """
         return self._args[0]
 
     @property
     def is_normalized(self):
+        """
+        Returns true if the Wavefunction is properly normalized
+
+        Examples
+        =========
+        >>> from sympy import symbols, pi
+        >>> from sympy.functions import sqrt, sin
+        >>> from sympy.physics.quantum.state import Wavefunction
+        >>> x, L = symbols('x,L', real=True)
+        >>> n = symbols('n', integer=True)
+        >>> g = sqrt(2/L)*sin(n*pi*x/L)
+        >>> f = Wavefunction(g, (x, 0, L))
+        >>> f.is_normalized
+        True
+        """
+
         return (self.norm_constant == 1.0)
 
     @property
     def norm_constant(self):
+        """
+        Return the normalization of the specified functional form.
+
+        This function integrates over the coordinates passed to the constructor of the Wavefunction,
+        with the bounds specified.
+
+        Examples
+        =========
+        >>> from sympy import symbols, pi
+        >>> from sympy.functions import sqrt, sin
+        >>> from sympy.physics.quantum.state import Wavefunction
+        >>> x, L = symbols('x,L', real=True)
+        >>> n = symbols('n', integer=True)
+        >>> g = sqrt(2/L)*sin(n*pi*x/L)
+        >>> f = Wavefunction(g, (x, 0, L))
+        >>> f.norm_constant
+        1
+        >>> g = sin(n*pi*x/L)
+        >>> f = Wavefunction(g, (x, 0, L))
+        >>> f.norm_constant
+        2**(1/2)*(1/L)**(1/2)
+        """
+
         exp = self.expr*conjugate(self.expr)
         var = self.variables
         limits = self.limits
@@ -661,4 +745,20 @@ class Wavefunction(Function):
         return sqrt(1/exp)
 
     def prob(self):
+        """
+        Return the absolute magnitude of the functional form |psi(x)|^2
+
+        Examples
+        =========
+        >>> from sympy import symbols, pi
+        >>> from sympy.functions import sqrt, sin
+        >>> from sympy.physics.quantum.state import Wavefunction
+        >>> x, L = symbols('x,L', real=True)
+        >>> n = symbols('n', integer=True)
+        >>> g = sin(n*pi*x/L)
+        >>> f = Wavefunction(g, (x, 0, L))
+        >>> f.prob()
+        Wavefunction(sin(pi*n*x/L)**2, x)
+        """
+
         return Wavefunction(self.expr*conjugate(self.expr), *self.variables)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -290,11 +290,11 @@ class Ket(State, KetBase):
 
     [1] http://en.wikipedia.org/wiki/Bra-ket_notation
     """
-    
+
     @property
     def dual_class(self):
         return Bra
-    
+
 class Bra(State, BraBase):
     """A general time-independent Bra in quantum mechanics.
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -533,7 +533,7 @@ class Wavefunction(Function):
     Examples
     ==============
     Particle in a box
-    >>> from sympy import Symbol, Piecewise, pi
+    >>> from sympy import Symbol, Piecewise, pi, N
     >>> from sympy.functions import sqrt, sin
     >>> from sympy.physics.quantum.state import Wavefunction
     >>> x = Symbol('x')
@@ -551,7 +551,7 @@ class Wavefunction(Function):
     >>> p(L)
     0
     >>> p(0.5)
-    0
+    2
     >>> p(0.85*L)
     2*sin(0.85*pi)**2
     >>> N(p(0.85*L))
@@ -667,6 +667,7 @@ class Wavefunction(Function):
         >>> f.limits
         {x: (-oo, oo)}
         >>> f = Wavefunction(x**2 + y**2, x, (y, -1, 2))
+        >>> f.limits
         {x: (-oo, oo), y: (-1, 2)}
         """
         limits = [(g[1], g[2]) if isinstance(g, Tuple) else (-oo, oo) \

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -185,7 +185,6 @@ class KetBase(StateBase):
         """
         return dispatch_method(self, '_apply_operator', op, **options)
 
-
 class BraBase(StateBase):
     """Base class for Bras.
 
@@ -291,12 +290,11 @@ class Ket(State, KetBase):
 
     [1] http://en.wikipedia.org/wiki/Bra-ket_notation
     """
-
+    
     @property
     def dual_class(self):
         return Bra
-
-
+    
 class Bra(State, BraBase):
     """A general time-independent Bra in quantum mechanics.
 

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -581,8 +581,8 @@ class Wavefunction(Function):
            The expression representing the functional form of the w.f.
 
     coords : Symbol or tuple
-           The coordinates to be integrated over, and their bounds  
-    
+           The coordinates to be integrated over, and their bounds
+
     Examples
     ========
 
@@ -782,7 +782,6 @@ class Wavefunction(Function):
         """
         Return the expression which is the functional form of the
         Wavefunction
-    
 
         Examples
         ========

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -1,7 +1,7 @@
 """Dirac notation for states."""
 
 
-from sympy import Expr, Symbol, Function, integrate, Lambda, oo, conjugate, Tuple
+from sympy import Expr, Symbol, Function, integrate, Lambda, oo, conjugate, Tuple, sqrt
 from sympy.printing.pretty.stringpict import prettyForm
 
 from sympy.physics.quantum.qexpr import (
@@ -613,7 +613,7 @@ class Wavefunction(Function):
             curr_limits = limits[v]
             exp = integrate(exp, (v, curr_limits[0], curr_limits[1]))
 
-        return 1/exp
+        return sqrt(1.0/exp)
 
     def prob(self):
         return Wavefunction(self.expr*conjugate(self.expr), *self.variables)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -59,21 +59,25 @@ class StateBase(QExpr):
     instead use State.
     """
 
-    @classmethod
-    def basis_op(self):
-        """Return the operator that this state is an eigenstate of; to be overidden in subclasses"""
-        return None
+    @property
+    def operators(self):
+        """Return the operator(s) that this state is an eigenstate of"""
+        from operatorset import state_to_operators #import internally to avoid circular import errors
+        return state_to_operators(self)
 
     @classmethod
     def default_args(self):
-        """Returns a default label corresponding to the labeling of its basis operator"""
-        if self.basis_op() is None:
-            return None
-        else:
-            return tuple([str(arg).lower() for arg in self.basis_op().default_args()])
+        """
+        Returns a default label corresponding to the labeling of its basis operator
+
+        To be overidden in subclasses
+        """
+
+        return None
+
 
     def _represent_default_basis(self, **options):
-        return self._represent(basis=(self.basis_op())())
+        return self._represent(basis=(self.operators)())
 
     #-------------------------------------------------------------------------
     # Dagger/dual

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -590,8 +590,6 @@ class Wavefunction(Function):
                 new_args[ct] = Tuple(*arg)
             else:
                 new_args[ct] = arg
-
-            setattr(new_args[ct], 'is_commutative', False)
             ct+=1
 
         return super(Function, cls).__new__(cls, *new_args, **options)
@@ -619,6 +617,13 @@ class Wavefunction(Function):
                 expr = expr.subs(symbol, val)
 
         return expr.subs(tuple(zip(var, args)))
+
+    @property
+    def is_commutative(self):
+        """
+        Override Function's is_commutative so that order is preserved in represented expressions
+        """
+        return False
 
     @classmethod
     def eval(self, *args):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -570,13 +570,25 @@ class TimeDepBra(TimeDepState, BraBase):
 class Wavefunction(Function):
     """Class for representations in continuous bases
 
+    This class takes an expression and coordinates in its
+    constructor. It can be used to easily calculate normalizations and
+    probabilities.
+
     Parameters
     ==========
 
+    expr : Expr
+           The expression representing the functional form of the w.f.
+
+    coords : Symbol or tuple
+           The coordinates to be integrated over, and their bounds  
+    
     Examples
     ========
 
-    Particle in a box
+    Particle in a box, specifying bounds in the more primitive way of
+    using Piecewise
+
     >>> from sympy import Symbol, Piecewise, pi, N
     >>> from sympy.functions import sqrt, sin
     >>> from sympy.physics.quantum.state import Wavefunction
@@ -602,7 +614,8 @@ class Wavefunction(Function):
     0.412214747707527
 
     Additionally, you can specify the bounds of the function and the
-    indices in a different way.
+    indices in a more compact way.
+
     >>> from sympy import symbols, pi, diff
     >>> from sympy.functions import sqrt, sin
     >>> from sympy.physics.quantum.state import Wavefunction
@@ -706,7 +719,8 @@ class Wavefunction(Function):
     @property
     def is_commutative(self):
         """
-        Override Function's is_commutative so that order is preserved in represented expressions
+        Override Function's is_commutative so that order is preserved
+        in represented expressions
         """
         return False
 
@@ -717,7 +731,7 @@ class Wavefunction(Function):
     @property
     def variables(self):
         """
-        Return the free coordinates which were passed to the constructor
+        Return the coordinates which the wavefunction depends on
 
         Examples
         ========
@@ -739,7 +753,7 @@ class Wavefunction(Function):
     @property
     def limits(self):
         """
-        Return the limits of the coordinates passed to the constructor.
+        Return the limits of the coordinates which the w.f. depends on
         If no limits are specified, defaults to (-oo, oo)
 
         Examples
@@ -766,7 +780,9 @@ class Wavefunction(Function):
     @property
     def expr(self):
         """
-        Return the functional form of the Wavefunction
+        Return the expression which is the functional form of the
+        Wavefunction
+    
 
         Examples
         ========
@@ -809,7 +825,7 @@ class Wavefunction(Function):
         """
         Return the normalization of the specified functional form.
 
-        This function integrates over the coordinates passed to the constructor of the Wavefunction,
+        This function integrates over the coordinates of the Wavefunction,
         with the bounds specified.
 
         Examples
@@ -843,7 +859,7 @@ class Wavefunction(Function):
 
     def normalize(self):
         """
-        Return the normalized wavefunction
+        Return a normalized version of the Wavefunction
 
         Examples
         ========
@@ -868,7 +884,7 @@ class Wavefunction(Function):
 
     def prob(self):
         """
-        Return the absolute magnitude of the functional form |psi(x)|^2
+        Return the absolute magnitude of the w.f., |psi(x)|^2
 
         Examples
         ========

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -871,7 +871,7 @@ class Wavefunction(Function):
         >>> g = sin(n*pi*x/L)
         >>> f = Wavefunction(g, (x, 0, L))
         >>> f.normalize()
-        Wavefunction(2**(1/2)*sin(pi*n*x/L)/L**(1/2), Tuple(x, 0, L))
+        Wavefunction(2**(1/2)*sin(pi*n*x/L)/L**(1/2), (x, 0, L))
 
         """
         const = self.norm

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -8,7 +8,7 @@ from sympy.physics.quantum.cartesian import (
     XOp, PxOp, X, Px, XKet, XBra, PxKet, PxBra
 )
 
-x, y, x_1 = symbols('x,y,x_1')
+x, y, x_1, x_2, x_3 = symbols('x,y,x_1,x_2,x_3')
 px, py = symbols('px py')
 
 
@@ -24,6 +24,8 @@ def test_x():
     assert represent(XKet(x)) == DiracDelta(x-x_1)
     assert represent(XBra(x)) == DiracDelta(-x + x_1)
     assert XBra(x).position == x
+    assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
+    assert represent(XOp()*XKet()*XBra('y')) == x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
 
 
 def test_p():

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -55,3 +55,4 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XKet())
 
     assert represent(PxOp()*XKet(), basis=XKet) == -hbar*I*DiracDelta(x - x_2)*DifferentialOperator(x)
+    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == -hbar*I*DiracDelta(x-y)*DifferentialOperator(x)

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -5,11 +5,12 @@ from sympy import S, Interval, symbols, I, DiracDelta, exp, sqrt, pi
 from sympy.physics.quantum import qapply, represent, L2, Dagger
 from sympy.physics.quantum import Commutator, hbar
 from sympy.physics.quantum.cartesian import (
-    XOp, PxOp, X, Px, XKet, XBra, PxKet, PxBra
+    XOp, YOp, ZOp, PxOp, X, Y, Z, Px, XKet, XBra, PxKet, PxBra,
+    PositionKet3D, PositionBra3D
 )
 from sympy.physics.quantum.operator import DifferentialOperator
 
-x, y, x_1, x_2, x_3 = symbols('x,y,x_1,x_2,x_3')
+x, y, z, x_1, x_2, x_3, y_1, z_1 = symbols('x,y,z,x_1,x_2,x_3,y_1,z_1')
 px, py, px_1, px_2 = symbols('px py px_1 px_2')
 
 
@@ -26,7 +27,8 @@ def test_x():
     assert represent(XBra(x)) == DiracDelta(-x + x_1)
     assert XBra(x).position == x
     assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
-    assert represent(XOp()*XKet()*XBra('y')) == x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
+    assert represent(XOp()*XKet()*XBra('y')) == \
+           x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
     assert represent(XBra("y")*XKet()) == DiracDelta(x - y)
     assert represent(XKet()*XBra()) == DiracDelta(x - x_2) * DiracDelta(x_1 - x)
 
@@ -36,7 +38,8 @@ def test_x():
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
-    assert represent(XOp()*PxKet(), basis = PxKet) == hbar*I*DiracDelta(px - px_2)*DifferentialOperator(px)
+    assert represent(XOp()*PxKet(), basis = PxKet) == \
+           hbar*I*DiracDelta(px - px_2)*DifferentialOperator(px)
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -54,5 +57,39 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XKet)
     assert rep_x == represent(PxOp(), basis = XKet())
 
-    assert represent(PxOp()*XKet(), basis=XKet) == -hbar*I*DiracDelta(x - x_2)*DifferentialOperator(x)
-    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == -hbar*I*DiracDelta(x-y)*DifferentialOperator(x)
+    assert represent(PxOp()*XKet(), basis=XKet) == \
+           -hbar*I*DiracDelta(x - x_2)*DifferentialOperator(x)
+    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
+           -hbar*I*DiracDelta(x-y)*DifferentialOperator(x)
+
+def test_3dpos():
+    assert Y.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
+    assert Z.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
+
+    test_ket = PositionKet3D(x, y, z)
+    assert qapply(X*test_ket) == x*test_ket
+    assert qapply(Y*test_ket) == y*test_ket
+    assert qapply(Z*test_ket) == z*test_ket
+    assert qapply(X*Y*test_ket) == x*y*test_ket
+    assert qapply(X*Y*Z*test_ket) == x*y*z*test_ket
+    assert qapply(Y*Z*test_ket) == y*z*test_ket
+
+    assert PositionKet3D() == test_ket
+    assert YOp() == Y
+    assert ZOp() == Z
+
+    assert PositionKet3D.dual_class() == PositionBra3D
+    assert PositionBra3D.dual_class() == PositionKet3D
+
+    other_ket = PositionKet3D(x_1, y_1, z_1)
+    assert (Dagger(other_ket)*test_ket).doit() == \
+           DiracDelta(x - x_1)*DiracDelta(y - y_1)*DiracDelta(z - z_1)
+
+    assert test_ket.position_x == x
+    assert test_ket.position_y == y
+    assert test_ket.position_z == z
+    assert other_ket.position_x == x_1
+    assert other_ket.position_y == y_1
+    assert other_ket.position_z == z_1
+
+    # TODO: Add tests for representations

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -27,6 +27,7 @@ def test_x():
     assert XBra(x).position == x
     assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
     assert represent(XOp()*XKet()*XBra('y')) == x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
+    assert represent(XBra("x_prime")*XKet()) == DiracDelta(x - x_prime)
 
     rep_p = represent(XOp(), basis = PxOp)
     assert rep_p == hbar*I*DiracDelta(px_1 - px_2)*DifferentialOperator(px_1)
@@ -34,6 +35,7 @@ def test_x():
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
+    assert represent(XOp()*PxKet(), basis = PxKet) == hbar*I*DiracDelta(px - px_2)*DifferentialOperator(px)
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -50,3 +52,5 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XOp())
     assert rep_x == represent(PxOp(), basis = XKet)
     assert rep_x == represent(PxOp(), basis = XKet())
+
+    assert represent(PxOp()*XKet(), basis=XKet) == -hbar*I*DiracDelta(x - x_2)*DifferentialOperator(x)

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -16,8 +16,8 @@ def test_x():
     assert X.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
     assert Commutator(X, Px).doit() == I*hbar
     assert qapply(X*XKet(x)) == x*XKet(x)
-    assert XKet(x).dual_class == XBra
-    assert XBra(x).dual_class == XKet
+    assert XKet(x).dual_class() == XBra
+    assert XBra(x).dual_class() == XKet
     assert (Dagger(XKet(y))*XKet(x)).doit() == DiracDelta(x-y)
     assert (PxBra(px)*XKet(x)).doit() ==\
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
@@ -31,8 +31,8 @@ def test_x():
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
     assert qapply(Px*PxKet(px)) == px*PxKet(px)
-    assert PxKet(px).dual_class == PxBra
-    assert PxBra(x).dual_class == PxKet
+    assert PxKet(px).dual_class() == PxBra
+    assert PxBra(x).dual_class() == PxKet
     assert (Dagger(PxKet(py))*PxKet(px)).doit() == DiracDelta(px-py)
     assert (XBra(x)*PxKet(px)).doit() ==\
         exp(I*x*px/hbar)/sqrt(2*pi*hbar)

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -7,9 +7,10 @@ from sympy.physics.quantum import Commutator, hbar
 from sympy.physics.quantum.cartesian import (
     XOp, PxOp, X, Px, XKet, XBra, PxKet, PxBra
 )
+from sympy.physics.quantum.operator import DifferentialOperator
 
 x, y, x_1, x_2, x_3 = symbols('x,y,x_1,x_2,x_3')
-px, py = symbols('px py')
+px, py, px_1, px_2 = symbols('px py px_1 px_2')
 
 
 def test_x():
@@ -27,6 +28,12 @@ def test_x():
     assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
     assert represent(XOp()*XKet()*XBra('y')) == x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
 
+    rep_p = represent(XOp(), basis = PxOp)
+    assert rep_p == hbar*I*DiracDelta(px_1 - px_2)*DifferentialOperator(px_1)
+    assert rep_p == represent(XOp(), basis = PxOp())
+    assert rep_p == represent(XOp(), basis = PxKet)
+    assert rep_p == represent(XOp(), basis = PxKet())
+
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -36,4 +43,10 @@ def test_p():
     assert (Dagger(PxKet(py))*PxKet(px)).doit() == DiracDelta(px-py)
     assert (XBra(x)*PxKet(px)).doit() ==\
         exp(I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(PxKet(px)) == px
+    assert represent(PxKet(px)) == DiracDelta(px-px_1)
+
+    rep_x = represent(PxOp(), basis = XOp)
+    assert rep_x == -hbar*I*DiracDelta(x_1 - x_2)*DifferentialOperator(x_1)
+    assert rep_x == represent(PxOp(), basis = XOp())
+    assert rep_x == represent(PxOp(), basis = XKet)
+    assert rep_x == represent(PxOp(), basis = XKet())

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -27,7 +27,8 @@ def test_x():
     assert XBra(x).position == x
     assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
     assert represent(XOp()*XKet()*XBra('y')) == x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
-    assert represent(XBra("x_prime")*XKet()) == DiracDelta(x - x_prime)
+    assert represent(XBra("y")*XKet()) == DiracDelta(x - y)
+    assert represent(XKet()*XBra()) == DiracDelta(x - x_2) * DiracDelta(x_1 - x)
 
     rep_p = represent(XOp(), basis = PxOp)
     assert rep_p == hbar*I*DiracDelta(px_1 - px_2)*DifferentialOperator(px_1)

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -8,7 +8,7 @@ from sympy.physics.quantum.cartesian import (
     XOp, PxOp, X, Px, XKet, XBra, PxKet, PxBra
 )
 
-x, y = symbols('x,y')
+x, y, x_1 = symbols('x,y,x_1')
 px, py = symbols('px py')
 
 
@@ -21,7 +21,8 @@ def test_x():
     assert (Dagger(XKet(y))*XKet(x)).doit() == DiracDelta(x-y)
     assert (PxBra(px)*XKet(x)).doit() ==\
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(XKet(x)) == x
+    assert represent(XKet(x)) == DiracDelta(x-x_1)
+    assert represent(XBra(x)) == DiracDelta(-x + x_1)
     assert XBra(x).position == x
 
 

--- a/sympy/physics/quantum/tests/test_innerproduct.py
+++ b/sympy/physics/quantum/tests/test_innerproduct.py
@@ -29,7 +29,7 @@ class FooState(StateBase):
 
 class FooKet(Ket, FooState):
 
-    @property
+    @classmethod
     def dual_class(self):
         return FooBra
 
@@ -41,7 +41,7 @@ class FooKet(Ket, FooState):
 
 
 class FooBra(Bra, FooState):
-    @property
+    @classmethod
     def dual_class(self):
         return FooKet
 
@@ -51,13 +51,13 @@ class BarState(StateBase):
 
 
 class BarKet(Ket, BarState):
-    @property
+    @classmethod
     def dual_class(self):
         return BarBra
 
 
 class BarBra(Bra, BarState):
-    @property
+    @classmethod
     def dual_class(self):
         return BarKet
 

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -1,4 +1,4 @@
-from sympy import Symbol, Integer, Mul
+from sympy import Symbol, Integer, Mul, Function, Derivative, diff
 
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.dagger import Dagger
@@ -121,5 +121,25 @@ def test_differential_operator():
     x = Symbol('x')
     d = DifferentialOperator(x)
     f = Wavefunction(x**2, x)
-
     assert qapply(d*f) == Wavefunction(2*x, x)
+    assert d.expr == None
+    assert d.function == None
+    assert d.order == 1
+    assert d.variable == x
+    assert diff(d, x) == DifferentialOperator((x, 2))
+
+    d = DifferentialOperator((x, 2))
+    f = Wavefunction(x**3, x)
+    assert qapply(d*f) == Wavefunction(6*x, x)
+    assert d.order == 2
+    assert d.expr == None
+    assert d.function == None
+    assert d.variable == x
+    assert diff(d, x) == DifferentialOperator((x, 3))
+
+    f = Function('f')
+    d = DifferentialOperator(1/x*Derivative(f(x), x), (f, x))
+    assert d.expr == 1/x*Derivative(f(x), x)
+    assert d.function == f
+    assert d.variable == x
+    assert diff(d, x) == DifferentialOperator(Derivative(1/x*Derivative(f(x), x), x), (f, x))

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -4,9 +4,10 @@ from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.hilbert import HilbertSpace
 from sympy.physics.quantum.operator import (
-    Operator, UnitaryOperator, HermitianOperator, OuterProduct
+    Operator, UnitaryOperator, HermitianOperator, OuterProduct, DifferentialOperator
 )
-from sympy.physics.quantum.state import Ket, Bra
+from sympy.physics.quantum.state import Ket, Bra, Wavefunction
+from sympy.physics.quantum.qapply import qapply
 
 class TestKet(Ket):
     @classmethod
@@ -118,3 +119,10 @@ def test_operator_dagger():
     assert Dagger(A*B) == Dagger(B)*Dagger(A)
     assert Dagger(A+B) == Dagger(A) + Dagger(B)
     assert Dagger(A**2) == Dagger(A)**2
+
+def test_differential_operator():
+    x = Symbol('x')
+    d = DifferentialOperator(x)
+    f = Wavefunction(x, x**2)
+
+    assert qapply(d*f) == 2*x

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -8,6 +8,7 @@ from sympy.physics.quantum.operator import (
 )
 from sympy.physics.quantum.state import Ket, Bra, Wavefunction
 from sympy.physics.quantum.qapply import qapply
+from sympy.physics.quantum.represent import enumerate_states
 
 class TestKet(Ket):
     @classmethod
@@ -15,10 +16,6 @@ class TestKet(Ket):
         return TestOp
 
 class TestOp(HermitianOperator):
-    @classmethod
-    def basis_ket(self):
-        return TestKet
-
     @classmethod
     def default_label(self):
         return "T"
@@ -62,8 +59,6 @@ def test_hermitian():
     assert H.inv() != H
     assert H.is_commutative == False
     assert Dagger(H).is_commutative == False
-
-    assert t_op._get_basis_kets(1, 1)[0] == TestKet("t_1")
 
 def test_unitary():
     U = UnitaryOperator('U')

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -63,7 +63,7 @@ def test_hermitian():
     assert H.is_commutative == False
     assert Dagger(H).is_commutative == False
 
-    assert t_op._get_basis_kets(1, 1)[0] == t_ket
+    assert t_op._get_basis_kets(1, 1)[0] == TestKet("t_1")
 
 def test_unitary():
     U = UnitaryOperator('U')

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -123,6 +123,6 @@ def test_operator_dagger():
 def test_differential_operator():
     x = Symbol('x')
     d = DifferentialOperator(x)
-    f = Wavefunction(x, x**2)
+    f = Wavefunction(x**2, x)
 
     assert qapply(d*f) == 2*x

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -120,4 +120,4 @@ def test_differential_operator():
     d = DifferentialOperator(x)
     f = Wavefunction(x**2, x)
 
-    assert qapply(d*f) == 2*x
+    assert qapply(d*f) == Wavefunction(2*x, x)

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -119,27 +119,26 @@ def test_operator_dagger():
 
 def test_differential_operator():
     x = Symbol('x')
-    d = DifferentialOperator(x)
-    f = Wavefunction(x**2, x)
-    assert qapply(d*f) == Wavefunction(2*x, x)
-    assert d.expr == None
-    assert d.function == None
-    assert d.order == 1
-    assert d.variable == x
-    assert diff(d, x) == DifferentialOperator((x, 2))
-
-    d = DifferentialOperator((x, 2))
-    f = Wavefunction(x**3, x)
-    assert qapply(d*f) == Wavefunction(6*x, x)
-    assert d.order == 2
-    assert d.expr == None
-    assert d.function == None
-    assert d.variable == x
-    assert diff(d, x) == DifferentialOperator((x, 3))
-
     f = Function('f')
-    d = DifferentialOperator(1/x*Derivative(f(x), x), (f, x))
+    d = DifferentialOperator(Derivative(f(x), x), f(x))
+    g = Wavefunction(x**2, x)
+    assert qapply(d*g) == Wavefunction(2*x, x)
+    assert d.expr == Derivative(f(x), x)
+    assert d.function == f(x)
+    assert d.variables == set([x])
+    assert diff(d, x) == DifferentialOperator(Derivative(f(x), x, 2), f(x))
+
+    d = DifferentialOperator(Derivative(f(x), x, 2), f(x))
+    g = Wavefunction(x**3, x)
+    assert qapply(d*g) == Wavefunction(6*x, x)
+    assert d.expr == Derivative(f(x), x, 2)
+    assert d.function == f(x)
+    assert d.variables == set([x])
+    assert diff(d, x) == DifferentialOperator(Derivative(f(x), x, 3), f(x))
+
+    d = DifferentialOperator(1/x*Derivative(f(x), x), f(x))
     assert d.expr == 1/x*Derivative(f(x), x)
-    assert d.function == f
-    assert d.variable == x
-    assert diff(d, x) == DifferentialOperator(Derivative(1/x*Derivative(f(x), x), x), (f, x))
+    assert d.function == f(x)
+    assert d.variables == set([x])
+    assert diff(d, x) == \
+           DifferentialOperator(Derivative(1/x*Derivative(f(x), x), x), f(x))

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -17,8 +17,8 @@ class TestKet(Ket):
 
 class TestOp(HermitianOperator):
     @classmethod
-    def default_label(self):
-        return "T"
+    def default_args(self):
+        return ("T",)
 
 t_ket = TestKet()
 t_op = TestOp()
@@ -40,7 +40,7 @@ def test_operator():
     assert (A*(B+C)).expand() == A*B + A*C
     assert ((A+B)**2).expand() == A**2 + A*B + B*A + B**2
 
-    assert t_op.label[0] == Symbol(t_op.default_label())
+    assert t_op.label[0] == Symbol(t_op.default_args()[0])
 
 
 def test_operator_inv():

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -42,6 +42,8 @@ def test_operator():
 
     assert t_op.label[0] == Symbol(t_op.default_args()[0])
 
+    assert Operator() == Operator("O")
+
 
 def test_operator_inv():
     A = Operator('A')

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -12,8 +12,8 @@ from sympy.physics.quantum.represent import enumerate_states
 
 class TestKet(Ket):
     @classmethod
-    def basis_op(self):
-        return TestOp
+    def default_args(self):
+        return ("t",)
 
 class TestOp(HermitianOperator):
     @classmethod

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -63,7 +63,7 @@ def test_hermitian():
     assert H.is_commutative == False
     assert Dagger(H).is_commutative == False
 
-    assert t_op._get_basis_kets(1)[0] == t_ket
+    assert t_op._get_basis_kets(1, 1)[0] == t_ket
 
 def test_unitary():
     U = UnitaryOperator('U')

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -8,6 +8,22 @@ from sympy.physics.quantum.operator import (
 )
 from sympy.physics.quantum.state import Ket, Bra
 
+class TestKet(Ket):
+    @classmethod
+    def basis_op(self):
+        return TestOp
+
+class TestOp(HermitianOperator):
+    @classmethod
+    def basis_ket(self):
+        return TestKet
+
+    @classmethod
+    def default_label(self):
+        return "T"
+
+t_ket = TestKet()
+t_op = TestOp()
 
 def test_operator():
     A = Operator('A')
@@ -25,6 +41,8 @@ def test_operator():
 
     assert (A*(B+C)).expand() == A*B + A*C
     assert ((A+B)**2).expand() == A**2 + A*B + B*A + B**2
+
+    assert t_op.label[0] == Symbol(t_op.default_label())
 
 
 def test_operator_inv():
@@ -44,6 +62,7 @@ def test_hermitian():
     assert H.is_commutative == False
     assert Dagger(H).is_commutative == False
 
+    assert t_op._get_basis_kets(1)[0] == t_ket
 
 def test_unitary():
     U = UnitaryOperator('U')

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -23,6 +23,9 @@ def test_op_to_state():
     assert operators_to_state(set([J2Op, JxOp])) == JxKet()
     assert operators_to_state(set([J2Op, JyOp])) == JyKet()
     assert operators_to_state(set([J2Op, JzOp])) == JzKet()
+    assert operators_to_state(set([J2Op(), JxOp()])) ==  JxKet()
+    assert operators_to_state(set([J2Op(), JyOp()])) ==  JyKet()
+    assert operators_to_state(set([J2Op(), JzOp()])) ==  JzKet()
 
     assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
     assert state_to_operators(operators_to_state(XOp())) == XOp()
@@ -43,6 +46,13 @@ def test_state_to_op():
     assert state_to_operators(JxBra) == set([J2Op(), JxOp()])
     assert state_to_operators(JyBra) == set([J2Op(), JyOp()])
     assert state_to_operators(JzBra) == set([J2Op(), JzOp()])
+
+    assert state_to_operators(JxKet()) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyKet()) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzKet()) == set([J2Op(), JzOp()])
+    assert state_to_operators(JxBra()) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyBra()) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzBra()) == set([J2Op(), JzOp()])
 
     assert operators_to_state(state_to_operators(XKet("test"))) == XKet("test")
     assert operators_to_state(state_to_operators(XBra("test"))) == XKet("test")

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -1,25 +1,25 @@
-from sympy.physics.quantum.operatorset import operator_to_state, state_to_operator
+from sympy.physics.quantum.operatorset import operators_to_state, state_to_operators
 from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
 
 def test_op_to_state():
-    assert operator_to_state(XOp) == XKet
-    assert operator_to_state(PxOp) == PxKet
+    assert operators_to_state(XOp) == XKet
+    assert operators_to_state(PxOp) == PxKet
 
     exception = False
     try:
-        operator_to_state(XKet)
+        operators_to_state(XKet)
     except NotImplementedError:
         exception = True
 
     return exception
 
 def test_state_to_op():
-    assert state_to_operator(XKet) == XOp
-    assert state_to_operator(PxKet) == PxOp
+    assert state_to_operators(XKet) == XOp
+    assert state_to_operators(PxKet) == PxOp
 
     exception = False
     try:
-        state_to_operator(XOp)
+        state_to_operators(XOp)
     except NotImplementedError:
         exception = True
 

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -1,9 +1,11 @@
 from sympy.physics.quantum.operatorset import operators_to_state, state_to_operators
-from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
+from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet, XBra
 
 def test_op_to_state():
     assert operators_to_state(XOp) == XKet()
     assert operators_to_state(PxOp) == PxKet()
+    assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
+    assert state_to_operators(operators_to_state(XOp())) == XOp()
 
     exception = False
     try:
@@ -16,6 +18,10 @@ def test_op_to_state():
 def test_state_to_op():
     assert state_to_operators(XKet) == XOp()
     assert state_to_operators(PxKet) == PxOp()
+    assert operators_to_state(state_to_operators(XKet("test"))) == XKet("test")
+    assert operators_to_state(state_to_operators(XBra("test"))) == XKet("test")
+    assert operators_to_state(state_to_operators(XKet())) == XKet()
+    assert operators_to_state(state_to_operators(XBra())) == XKet()
 
     exception = False
     try:

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -1,0 +1,26 @@
+from sympy.physics.quantum.operatorset import operator_to_state, state_to_operator
+from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
+
+def test_op_to_state():
+    assert operator_to_state(XOp) == XKet
+    assert operator_to_state(PxOp) == PxKet
+
+    exception = False
+    try:
+        operator_to_state(XKet)
+    except NotImplementedError:
+        exception = True
+
+    return exception
+
+def test_state_to_op():
+    assert state_to_operator(XKet) == XOp
+    assert state_to_operator(PxKet) == PxOp
+
+    exception = False
+    try:
+        state_to_operator(XOp)
+    except NotImplementedError:
+        exception = True
+
+    return exception

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -8,6 +8,10 @@ from sympy.physics.quantum.cartesian import (
 
 from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.operator import Operator
+from sympy.physics.quantum.spin import (
+    JxKet, JyKet, JzKet, JxBra, JyBra, JzBra,
+    JxOp, JyOp, JzOp, J2Op
+)
 
 from sympy.utilities.pytest import raises
 
@@ -15,6 +19,10 @@ def test_op_to_state():
     assert operators_to_state(XOp) == XKet()
     assert operators_to_state(PxOp) == PxKet()
     assert operators_to_state(Operator) == Ket()
+
+    assert operators_to_state(set([J2Op, JxOp])) == JxKet()
+    assert operators_to_state(set([J2Op, JyOp])) == JyKet()
+    assert operators_to_state(set([J2Op, JzOp])) == JzKet()
 
     assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
     assert state_to_operators(operators_to_state(XOp())) == XOp()
@@ -28,6 +36,13 @@ def test_state_to_op():
     assert state_to_operators(PxBra) == PxOp()
     assert state_to_operators(Ket) == Operator()
     assert state_to_operators(Bra) == Operator()
+
+    assert state_to_operators(JxKet) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyKet) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzKet) == set([J2Op(), JzOp()])
+    assert state_to_operators(JxBra) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyBra) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzBra) == set([J2Op(), JzOp()])
 
     assert operators_to_state(state_to_operators(XKet("test"))) == XKet("test")
     assert operators_to_state(state_to_operators(XBra("test"))) == XKet("test")

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -1,32 +1,38 @@
-from sympy.physics.quantum.operatorset import operators_to_state, state_to_operators
-from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet, XBra
+from sympy.physics.quantum.operatorset import (
+    operators_to_state, state_to_operators
+)
+
+from sympy.physics.quantum.cartesian import (
+    XOp, XKet, PxOp, PxKet, XBra, PxBra
+)
+
+from sympy.physics.quantum.state import Ket, Bra
+from sympy.physics.quantum.operator import Operator
+
+from sympy.utilities.pytest import raises
 
 def test_op_to_state():
     assert operators_to_state(XOp) == XKet()
     assert operators_to_state(PxOp) == PxKet()
+    assert operators_to_state(Operator) == Ket()
+
     assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
     assert state_to_operators(operators_to_state(XOp())) == XOp()
 
-    exception = False
-    try:
-        operators_to_state(XKet)
-    except NotImplementedError:
-        exception = True
-
-    return exception
+    raises(NotImplementedError, 'operators_to_state(XKet)')
 
 def test_state_to_op():
     assert state_to_operators(XKet) == XOp()
     assert state_to_operators(PxKet) == PxOp()
+    assert state_to_operators(XBra) == XOp()
+    assert state_to_operators(PxBra) == PxOp()
+    assert state_to_operators(Ket) == Operator()
+    assert state_to_operators(Bra) == Operator()
+
     assert operators_to_state(state_to_operators(XKet("test"))) == XKet("test")
     assert operators_to_state(state_to_operators(XBra("test"))) == XKet("test")
     assert operators_to_state(state_to_operators(XKet())) == XKet()
     assert operators_to_state(state_to_operators(XBra())) == XKet()
 
-    exception = False
-    try:
-        state_to_operators(XOp)
-    except NotImplementedError:
-        exception = True
+    raises(NotImplementedError, 'state_to_operators(XOp)')
 
-    return exception

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -2,8 +2,8 @@ from sympy.physics.quantum.operatorset import operators_to_state, state_to_opera
 from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
 
 def test_op_to_state():
-    assert operators_to_state(XOp) == XKet
-    assert operators_to_state(PxOp) == PxKet
+    assert operators_to_state(XOp) == XKet()
+    assert operators_to_state(PxOp) == PxKet()
 
     exception = False
     try:
@@ -14,8 +14,8 @@ def test_op_to_state():
     return exception
 
 def test_state_to_op():
-    assert state_to_operators(XKet) == XOp
-    assert state_to_operators(PxKet) == PxOp
+    assert state_to_operators(XKet) == XOp()
+    assert state_to_operators(PxKet) == PxOp()
 
     exception = False
     try:

--- a/sympy/physics/quantum/tests/test_piab.py
+++ b/sympy/physics/quantum/tests/test_piab.py
@@ -19,9 +19,9 @@ def test_H():
 
 
 def test_states():
-    assert PIABKet(n).dual_class == PIABBra
+    assert PIABKet(n).dual_class() == PIABBra
     assert PIABKet(n).hilbert_space ==\
         L2(Interval(S.NegativeInfinity,S.Infinity))
     assert represent(PIABKet(n)) == sqrt(2/L)*sin(n*pi*x/L)
     assert (PIABBra(i)*PIABKet(j)).doit() == KroneckerDelta(i, j)
-    assert PIABBra(n).dual_class == PIABKet
+    assert PIABBra(n).dual_class() == PIABKet

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -27,8 +27,8 @@ def test_Qubit():
     qb = Qubit('110')
 
 def test_QubitBra():
-    assert Qubit(0).dual_class == QubitBra
-    assert QubitBra(0).dual_class == Qubit
+    assert Qubit(0).dual_class() == QubitBra
+    assert QubitBra(0).dual_class() == Qubit
     assert represent(Qubit(1,1,0), nqubits=3).H ==\
            represent(QubitBra(1,1,0), nqubits=3)
     assert Qubit(0,1)._eval_innerproduct_QubitBra(QubitBra(1,0)) == Integer(0)
@@ -41,8 +41,8 @@ def test_IntQubit():
     assert IntQubit(3) == IntQubit(3,2)
 
     #test Dual Classes
-    assert IntQubit(3).dual_class == IntQubitBra
-    assert IntQubitBra(3).dual_class == IntQubit
+    assert IntQubit(3).dual_class() == IntQubitBra
+    assert IntQubitBra(3).dual_class() == IntQubit
 
 def test_superposition_of_states():
     assert qapply(CNOT(0,1)*HadamardGate(0)*(1/sqrt(2)*Qubit('01') + 1/sqrt(2)*Qubit('10'))).expand() == (Qubit('01')/2 + Qubit('00')/2 - Qubit('11')/2 +\

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -158,8 +158,8 @@ x_bra = XBra('x')
 x_op = XOp('X')
 
 def test_innerprod_represent():
-    assert rep_innerproduct(x_ket) == InnerProduct(XBra(), x_ket).doit()
-    assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet()).doit()
+    assert rep_innerproduct(x_ket) == InnerProduct(XBra("x_1"), x_ket).doit()
+    assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet("x_1")).doit()
 
     try:
         test = rep_innerproduct(x_op)

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -1,7 +1,9 @@
 from sympy import Matrix, I, Float, Integer, symbols, DiracDelta
 
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.represent import represent, rep_innerproduct, rep_expectation, collapse_deltas
+from sympy.physics.quantum.represent import (
+    represent, rep_innerproduct, rep_expectation, enumerate_states
+)
 from sympy.physics.quantum.state import Bra, Ket
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -14,6 +16,7 @@ from sympy.physics.quantum.matrixutils import (
 )
 from sympy.physics.quantum.cartesian import XKet, XOp, XBra
 from sympy.physics.quantum.qapply import qapply
+from sympy.physics.quantum.operatorset import operator_to_state
 
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
@@ -167,9 +170,10 @@ def test_innerprod_represent():
         return True
 
 def test_operator_represent():
-    basis_kets = x_op._get_basis_kets(1, 2)
+    basis_kets = enumerate_states((operator_to_state(x_op))(), 1, 2)
     assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
 
+"""
 def test_collapse_deltas():
     x, x_1, z = symbols('x,x_1,z')
     f = x*x_1*DiracDelta(x-x_1)*DiracDelta(x_1-z)
@@ -177,3 +181,4 @@ def test_collapse_deltas():
     d = collapse_deltas(f, **{"unities" : [1], "basis": XOp()})
 
     assert d == x**2*DiracDelta(x-z)
+"""

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -177,6 +177,3 @@ def test_enumerate_states():
     test = XKet("foo")
     assert enumerate_states(test, 1, 1) == [XKet("foo_1")]
     assert enumerate_states(test, [1, 2, 4]) == [XKet("foo_1"), XKet("foo_2"), XKet("foo_4")]
-
-    time_dep = TimeDepKet("x", "t")
-    assert enumerate_states(time_dep, 1, 2) == [TimeDepKet("x_1", "t_1"), TimeDepKet("x_2", "t_2")]

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -1,7 +1,7 @@
 from sympy import Matrix, I, Float, Integer, symbols
 
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.represent import represent, rep_innerproduct
+from sympy.physics.quantum.represent import represent, rep_innerproduct, rep_expectation
 from sympy.physics.quantum.state import Bra, Ket
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -13,6 +13,7 @@ from sympy.physics.quantum.matrixutils import (
     to_sympy, to_numpy, to_scipy_sparse, numpy_ndarray, scipy_sparse_matrix
 )
 from sympy.physics.quantum.cartesian import XKet, XOp, XBra
+from sympy.physics.quantum.qapply import qapply
 
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
@@ -162,5 +163,9 @@ def test_innerprod_represent():
 
     try:
         test = rep_innerproduct(x_op)
-    except NotImplementedError:
+    except TypeError:
         return True
+
+def test_operator_represent():
+    basis_kets = x_op._get_basis_kets(2)
+    assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -1,7 +1,7 @@
-from sympy import Matrix, I, Float, Integer
+from sympy import Matrix, I, Float, Integer, symbols
 
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.represent import represent
+from sympy.physics.quantum.represent import represent, rep_innerproduct
 from sympy.physics.quantum.state import Bra, Ket
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -12,6 +12,7 @@ from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.matrixutils import (
     to_sympy, to_numpy, to_scipy_sparse, numpy_ndarray, scipy_sparse_matrix
 )
+from sympy.physics.quantum.cartesian import XKet, XOp, XBra
 
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
@@ -150,3 +151,16 @@ def test_scalar_scipy_sparse():
     assert represent(Integer(1), format='scipy.sparse') == 1
     assert represent(Float(1.0), format='scipy.sparse') == 1.0
     assert represent(1.0+I, format='scipy.sparse') == 1.0+1.0j
+
+x_ket = XKet('x')
+x_bra = XBra('x')
+x_op = XOp('X')
+
+def test_innerprod_represent():
+    assert rep_innerproduct(x_ket) == InnerProduct(XBra(), x_ket).doit()
+    assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet()).doit()
+
+    try:
+        test = rep_innerproduct(x_op)
+    except NotImplementedError:
+        return True

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -167,5 +167,5 @@ def test_innerprod_represent():
         return True
 
 def test_operator_represent():
-    basis_kets = x_op._get_basis_kets(2)
+    basis_kets = x_op._get_basis_kets(1, 2)
     assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -4,7 +4,7 @@ from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.represent import (
     represent, rep_innerproduct, rep_expectation, enumerate_states
 )
-from sympy.physics.quantum.state import Bra, Ket
+from sympy.physics.quantum.state import Bra, Ket, TimeDepKet
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.tensorproduct import matrix_tensor_product
@@ -173,12 +173,10 @@ def test_operator_represent():
     basis_kets = enumerate_states((operator_to_state(x_op))(), 1, 2)
     assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
 
-"""
-def test_collapse_deltas():
-    x, x_1, z = symbols('x,x_1,z')
-    f = x*x_1*DiracDelta(x-x_1)*DiracDelta(x_1-z)
+def test_enumerate_states():
+    test = XKet("foo")
+    assert enumerate_states(test, 1, 1) == [XKet("foo_1")]
+    assert enumerate_states(test, [1, 2, 4]) == [XKet("foo_1"), XKet("foo_2"), XKet("foo_4")]
 
-    d = collapse_deltas(f, **{"unities" : [1], "basis": XOp()})
-
-    assert d == x**2*DiracDelta(x-z)
-"""
+    time_dep = TimeDepKet("x", "t")
+    assert enumerate_states(time_dep, 1, 2) == [TimeDepKet("x_1", "t_1"), TimeDepKet("x_2", "t_2")]

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -16,7 +16,7 @@ from sympy.physics.quantum.matrixutils import (
 )
 from sympy.physics.quantum.cartesian import XKet, XOp, XBra
 from sympy.physics.quantum.qapply import qapply
-from sympy.physics.quantum.operatorset import operator_to_state
+from sympy.physics.quantum.operatorset import operators_to_state
 
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
@@ -170,7 +170,7 @@ def test_innerprod_represent():
         return True
 
 def test_operator_represent():
-    basis_kets = enumerate_states((operator_to_state(x_op))(), 1, 2)
+    basis_kets = enumerate_states((operators_to_state(x_op))(), 1, 2)
     assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
 
 def test_enumerate_states():

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -170,7 +170,7 @@ def test_innerprod_represent():
         return True
 
 def test_operator_represent():
-    basis_kets = enumerate_states((operators_to_state(x_op))(), 1, 2)
+    basis_kets = enumerate_states(operators_to_state(x_op), 1, 2)
     assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
 
 def test_enumerate_states():

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -1,7 +1,7 @@
-from sympy import Matrix, I, Float, Integer, symbols
+from sympy import Matrix, I, Float, Integer, symbols, DiracDelta
 
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.represent import represent, rep_innerproduct, rep_expectation
+from sympy.physics.quantum.represent import represent, rep_innerproduct, rep_expectation, collapse_deltas
 from sympy.physics.quantum.state import Bra, Ket
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -169,3 +169,11 @@ def test_innerprod_represent():
 def test_operator_represent():
     basis_kets = x_op._get_basis_kets(1, 2)
     assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
+
+def test_collapse_deltas():
+    x, x_1, z = symbols('x,x_1,z')
+    f = x*x_1*DiracDelta(x-x_1)*DiracDelta(x_1-z)
+
+    d = collapse_deltas(f, **{"unities" : [1], "basis": XOp()})
+
+    assert d == x**2*DiracDelta(x-z)

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -27,7 +27,7 @@ Avec = Matrix([[1],[I]])
 
 class AKet(Ket):
 
-    @property
+    @classmethod
     def dual_class(self):
         return ABra
 
@@ -40,7 +40,7 @@ class AKet(Ket):
 
 class ABra(Bra):
 
-    @property
+    @classmethod
     def dual_class(self):
         return AKet
 

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -135,7 +135,7 @@ def test_printing():
     assert latex(Dagger(psi)) == r"{\left\langle \psi\right|}"
 
 def test_wavefunction():
-    f = Wavefunction(x, x**2)
+    f = Wavefunction(x**2, x)
     p = f.prob()
 
     assert f.is_normalized == False

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -12,6 +12,26 @@ from sympy.physics.quantum.hilbert import HilbertSpace
 
 x,y,t = symbols('x,y,t')
 
+class TestKet(Ket):
+    @classmethod
+    def default_args(self):
+        return ("test",)
+
+class TestKetMultipleLabels(Ket):
+    @classmethod
+    def default_args(self):
+        return ("r", "theta", "phi")
+
+class TestTimeDepKet(TimeDepKet):
+    @classmethod
+    def default_args(self):
+        return ("test", "t")
+
+class TestTimeDepKetMultipleLabels(TimeDepKet):
+    @classmethod
+    def default_args(self):
+        return ("r", "theta", "phi", "t")
+
 def test_ket():
     k = Ket('0')
 
@@ -36,6 +56,12 @@ def test_ket():
     assert k.dual_class == Bra
     assert k.dual == Bra(x,y)
     assert k.subs(x,y) == Ket(y,y)
+
+    k = TestKet()
+    assert k == TestKet("test")
+
+    k = TestKetMultipleLabels()
+    assert k == TestKetMultipleLabels("r", "theta", "phi")
 
 
 def test_bra():
@@ -92,6 +118,16 @@ def test_time_dep_ket():
     k = TimeDepKet(x, 0.5)
     assert k.label == (x,)
     assert k.args == (x,sympify(0.5))
+
+    k = TestTimeDepKet()
+    assert k.label == (Symbol("test"),)
+    assert k.time == Symbol("t")
+    assert k == TestTimeDepKet("test", "t")
+
+    k = TestTimeDepKetMultipleLabels()
+    assert k.label == (Symbol("r"), Symbol("theta"), Symbol("phi"))
+    assert k.time == Symbol("t")
+    assert k == TestTimeDepKetMultipleLabels("r", "theta", "phi", "t")
 
 
 def test_time_dep_bra():

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -1,5 +1,5 @@
 from sympy import I, symbols, sqrt, Add, Mul, Rational, Pow, Symbol, sympify
-from sympy import Integer, conjugate, pretty, latex
+from sympy import Integer, conjugate, pretty, latex, oo
 
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr
@@ -137,8 +137,22 @@ def test_printing():
 def test_wavefunction():
     f = Wavefunction(x**2, x)
     p = f.prob()
+    lims = f.limits
 
     assert f.is_normalized == False
     assert f.norm_constant == 0
     assert f(10) == 100
     assert p(10) == 10000
+    assert lims[x] == (-oo, oo)
+
+    g = Wavefunction(x**2*y+y**2*x, (x, 0, 1), (y, 0, 2))
+    lims_g = g.limits
+
+    assert lims_g[x] == (0, 1)
+    assert lims_g[y] == (0, 2)
+    assert g.is_normalized == False
+    assert g.norm_constant == sqrt(1.0/(14.0/3.0))
+    assert g(2,4) == 48
+
+    h = Wavefunction(sqrt(5)*x**2, (x, 0, 1))
+    assert h.is_normalized == True

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -63,6 +63,8 @@ def test_ket():
     k = TestKetMultipleLabels()
     assert k == TestKetMultipleLabels("r", "theta", "phi")
 
+    assert Ket() == Ket('psi')
+
 
 def test_bra():
     b = Bra('0')
@@ -89,6 +91,7 @@ def test_bra():
     assert b.dual == Ket(x,y)
     assert b.subs(x,y) == Bra(y,y)
 
+    assert Bra() == Bra('psi')
 
 def test_ops():
     k0 = Ket(0)
@@ -129,6 +132,7 @@ def test_time_dep_ket():
     assert k.time == Symbol("t")
     assert k == TestTimeDepKetMultipleLabels("r", "theta", "phi", "t")
 
+    assert TimeDepKet() == TimeDepKet("psi", "t")
 
 def test_time_dep_bra():
     b = TimeDepBra(0,t)
@@ -149,6 +153,7 @@ def test_time_dep_bra():
     assert k.label == (x,)
     assert k.args == (x,sympify(0.5))
 
+    assert TimeDepBra() == TimeDepBra("psi", "t")
 
 def test_bra_ket_dagger():
     x = symbols('x',complex=True)

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -53,7 +53,7 @@ def test_ket():
     assert k.hilbert_space == HilbertSpace()
     assert k.is_commutative == False
 
-    assert k.dual_class == Bra
+    assert k.dual_class() == Bra
     assert k.dual == Bra(x,y)
     assert k.subs(x,y) == Ket(y,y)
 
@@ -85,7 +85,7 @@ def test_bra():
     assert b.hilbert_space == HilbertSpace()
     assert b.is_commutative == False
 
-    assert b.dual_class == Ket
+    assert b.dual_class() == Ket
     assert b.dual == Ket(x,y)
     assert b.subs(x,y) == Bra(y,y)
 
@@ -110,7 +110,7 @@ def test_time_dep_ket():
     assert k.args == (Integer(0),t)
     assert k.time == t
 
-    assert k.dual_class == TimeDepBra
+    assert k.dual_class() == TimeDepBra
     assert k.dual == TimeDepBra(0,t)
 
     assert k.subs(t,2) == TimeDepKet(0,2)
@@ -142,7 +142,7 @@ def test_time_dep_bra():
     assert b.args == (Integer(0),t)
     assert b.time == t
 
-    assert b.dual_class == TimeDepKet
+    assert b.dual_class() == TimeDepKet
     assert b.dual == TimeDepKet(0,t)
 
     k = TimeDepBra(x, 0.5)

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -1,4 +1,4 @@
-from sympy import I, symbols, sqrt, Add, Mul, Rational, Pow, Symbol, sympify
+from sympy import I, symbols, sqrt, Add, Mul, Rational, Pow, Symbol, sympify, S
 from sympy import Integer, conjugate, pretty, latex, oo, sin, pi
 
 from sympy.physics.quantum.dagger import Dagger
@@ -148,13 +148,15 @@ def test_wavefunction():
     assert p(10) == 10000
     assert lims[x] == (-oo, oo)
 
-    g = Wavefunction(x**2*y+y**2*x, (x, 0, 3), (y, 0, 5))
+    g = Wavefunction(x**2*y+y**2*x, (x, 0, 1), (y, 0, 2))
     lims_g = g.limits
 
-    assert lims_g[x] == (0, 3)
-    assert lims_g[y] == (0, 5)
+    assert lims_g[x] == (0, 1)
+    assert lims_g[y] == (0, 2)
     assert g.is_normalized == False
-    assert g(2,4) == 48
+    assert g.norm_constant == 42**(S(1)/2)/14
+    assert g(2,4) == 0
+    assert g(1,1) == 2
 
     h = Wavefunction(sqrt(5)*x**2, (x, 0, 1))
     assert h.is_normalized == True

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -5,7 +5,7 @@ from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.state import (
     Ket, Bra, TimeDepKet, TimeDepBra,
-    KetBase, BraBase, StateBase
+    KetBase, BraBase, StateBase, Wavefunction
 )
 from sympy.physics.quantum.hilbert import HilbertSpace
 
@@ -133,3 +133,12 @@ def test_printing():
     assert pretty(Dagger(psi), use_unicode=True) == u'\u27e8\u03c8\u2758'
     assert latex(psi) == r"{\left|\psi\right\rangle }"
     assert latex(Dagger(psi)) == r"{\left\langle \psi\right|}"
+
+def test_wavefunction():
+    f = Wavefunction(x, x**2)
+    p = f.prob()
+
+    assert f.is_normalized == False
+    assert f.norm_constant == 0
+    assert f(10) == 100
+    assert p(10) == 10000

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -1,5 +1,5 @@
 from sympy import I, symbols, sqrt, Add, Mul, Rational, Pow, Symbol, sympify
-from sympy import Integer, conjugate, pretty, latex, oo
+from sympy import Integer, conjugate, pretty, latex, oo, sin, pi
 
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr
@@ -135,6 +135,9 @@ def test_printing():
     assert latex(Dagger(psi)) == r"{\left\langle \psi\right|}"
 
 def test_wavefunction():
+    x, L = symbols('x,L', real=True)
+    n = symbols('n', integer=True)
+
     f = Wavefunction(x**2, x)
     p = f.prob()
     lims = f.limits
@@ -145,14 +148,19 @@ def test_wavefunction():
     assert p(10) == 10000
     assert lims[x] == (-oo, oo)
 
-    g = Wavefunction(x**2*y+y**2*x, (x, 0, 1), (y, 0, 2))
+    g = Wavefunction(x**2*y+y**2*x, (x, 0, 3), (y, 0, 5))
     lims_g = g.limits
 
-    assert lims_g[x] == (0, 1)
-    assert lims_g[y] == (0, 2)
+    assert lims_g[x] == (0, 3)
+    assert lims_g[y] == (0, 5)
     assert g.is_normalized == False
-    assert g.norm_constant == sqrt(1.0/(14.0/3.0))
     assert g(2,4) == 48
 
     h = Wavefunction(sqrt(5)*x**2, (x, 0, 1))
     assert h.is_normalized == True
+
+    piab = Wavefunction(sin(n*pi*x/L), (x, 0, L))
+    assert piab.norm_constant == sqrt(2/L)
+    assert piab(L+1) == 0
+    assert piab(0.5) == sin(0.5*n*pi/L)
+    assert piab(0.5, n=1, L=1) == sin(0.5*pi)


### PR DESCRIPTION
This PR has many changes in preparation for representing continuous functions in sympy. These include:

Summary of changes to code so far:
- Default labels in operators and kets, with examples in cartesian.py
- Added inner product formation in represent, if calling _represent_FOO fails
- Added expectation value type representations for operators, if calling _represent_FOO fails
- Wavefunction and DIfferentialOperator classes for representations in continuous bases
- Proper indexing and unity insertion in represent (including a function for enumerating states in represent.py)
- Add support for specifying bounds of coordinates in Wavefunction
- Correct printing for DifferentialOperator
- Add fixed DiracDelta integration into represent
- Add operatorset.py, for mapping between states and their operators and vice versa

Note: The default labeling is a bit incomplete, as it won't completely work with states with multiple labels, like time dependent states, but I think what is in here now is a good start and further improvements can be added to later PRs. 

EDIT: The default labeling has now been changed to default_args, and it should support multiple labels. Some tests with time dependent states were added as well to show that it works. 
