### PR TITLE
functions/special/tensor: Import reduce from compatibility.py

### DIFF
--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,5 +1,5 @@
 import operator
-from functools import reduce
+from sympy.core.compatibility import reduce
 from sympy.core.function import Function
 from sympy.core import sympify, S, Integer
 


### PR DESCRIPTION
Commit c11a433f: "implement Levi-Civita symbol" introduced an import of
reduce from functools. This isn't available in Python 2.5, import reduce
from compatibility instead.
