### PR TITLE
2506: use func not new in _eval_expand_trig

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -565,7 +565,7 @@ class Pow(Expr):
             else:
                 newterm = term
             terms.append(newterm)
-        return self.new(*terms)
+        return self.func(*terms)
 
     def _eval_expand_func(self, deep=True, **hints):
         sargs, terms = self.args, []

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -209,6 +209,9 @@ def test_expand():
     assert ((-2*x*y*n*m)**z).expand() == 2**z*(-m)**z*(-n)**z*(-x*y)**z
     # issue 2383
     assert sqrt(-2*x*n) == sqrt(2)*sqrt(-n)*sqrt(x)
+    # issue 2506 (2)
+    assert (cos(x+y)**2).expand(trig=True) == \
+      sin(x)**2*sin(y)**2 - 2*sin(x)*sin(y)*cos(x)*cos(y) + cos(x)**2*cos(y)**2
 
     # Check that this isn't too slow
     x = Symbol('x')


### PR DESCRIPTION
This fixes http://code.google.com/p/sympy/issues/detail?id=2506 (point 2). Other instances of self.new were checked to see that this method is defined. This was the only failing instance. A test was added.
