### PR TITLE
2536 exp latex printing

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -172,7 +172,7 @@ class LatexPrinter(Printer):
             coeff = -coeff
             tex = "- "
 
-        numer, denom = fraction(tail)
+        numer, denom = fraction(tail, exact=True)
         separator = self._settings['mul_symbol_latex']
 
         def convert(expr):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -258,6 +258,18 @@ def test_latex_issue1477():
     assert latex(Symbol("alpha^aleph")) == r"\alpha^{\aleph}"
     assert latex(Symbol("alpha__aleph")) == r"\alpha^{\aleph}"
 
+def test_latex_pow_fraction():
+    x = Symbol('x')
+    # Testing exp
+    assert 'e^{-x}' in latex(exp(-x)/2).replace(' ', '') # Remove Whitespace
+
+    # Testing just e^{-x} in case future changes alter behavior of muls or fracs
+    # In particular current output is \frac{1}{2}e^{- x} but perhaps this will
+    # change to \frac{e^{-x}}{2}
+
+    # Testing general, non-exp, power
+    assert '3^{-x}' in latex(3**-x/2).replace(' ', '')
+
 def test_latex_order():
     expr = x**3 + x**2*y + 3*x*y**3 + y**4
 


### PR DESCRIPTION
Simplify.fraction keeps exp(-x) in the numerator rather than sending it to the denominator with positive exponent. 

simplify(exp(-x)/2) == 

Before :: 1 / (2*exp(x)) 
After :: exp(-2) / 2

See issue http://code.google.com/p/sympy/issues/detail?id=2536 
