### PR TITLE
Fix Poly().total_degree()

### DIFF
--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -495,7 +495,7 @@ class DMP(object):
 
     def total_degree(f):
         """Returns the total degree of `f`. """
-        return sum(dmp_degree_list(f.rep, f.lev))
+        return max([sum(m) for m in f.monoms()])
 
     def LC(f):
         """Returns the leading coefficent of `f`. """

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1671,6 +1671,8 @@ class Poly(Expr):
 
         >>> Poly(x**2 + y*x + 1, x, y).total_degree()
         2
+        >>> Poly(x + y**5, x, y).total_degree()
+        5
 
         """
         if hasattr(f.rep, 'total_degree'):

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1670,7 +1670,7 @@ class Poly(Expr):
         >>> from sympy.abc import x, y
 
         >>> Poly(x**2 + y*x + 1, x, y).total_degree()
-        3
+        2
 
         """
         if hasattr(f.rep, 'total_degree'):

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -161,7 +161,7 @@ def test_DMP_functionality():
 
     assert f.degree() == 2
     assert f.degree_list() == (2, 2)
-    assert f.total_degree() == 4
+    assert f.total_degree() == 2
 
     assert f.LC() == ZZ(1)
     assert f.TC() == ZZ(0)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -993,6 +993,9 @@ def test_Poly_degree_list():
 
 def test_Poly_total_degree():
     assert Poly(x**2*y+x**3*z**2+1).total_degree() == 5
+    assert Poly(x**2 + z**3).total_degree() == 3
+    assert Poly(x*y*z + z**4).total_degree() == 4
+    assert Poly(x**3 + x + 1).total_degree() == 3
 
 def test_Poly_LC():
     assert Poly(0, x).LC() == 0

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -992,7 +992,7 @@ def test_Poly_degree_list():
     raises(ComputationFailed, "degree_list(1)")
 
 def test_Poly_total_degree():
-    assert Poly(x**2*y+x**3*z**2+1).total_degree() == 6
+    assert Poly(x**2*y+x**3*z**2+1).total_degree() == 5
 
 def test_Poly_LC():
     assert Poly(0, x).LC() == 0


### PR DESCRIPTION
`total_degree()` used to return `sum(dmp_degree_list(f.rep, f.lev))`. This is not the total degree, e.g.:

```
 Poly(x**2+y).total_degree()
 3
```

because `dmp_degree_list(f.rep, f.lev)` returns `(2, 1)`, corresponding to the x-degree and y-degree.

`total_degree` is only used in `heurisch` so far.
