### PR TITLE
Fix for issue #2549; give as_independent more support for non commutative symbols

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -908,25 +908,18 @@ class Expr(Basic, EvalfMixin):
         else:
             if func is Add:
                 args = list(self.args)
-                nc = ndeps = []
-                func = Add
             else:
                 args, nc = self.args_cnc()
-                d = sift(deps, lambda w: bool(getattr(w, 'is_commutative', True)))
-                ndeps = d.pop(False, [])
-                deps = d.pop(True, [])
-                func = Mul
 
-        # do commutative terms
         d = sift(args, lambda x: x.has(*deps))
         depend = d.pop(True, [])
         indep = d.pop(False, [])
-        if func is Add:
-            return (func(*(indep + nc)),
-                    func(*depend))
-        else:
+        if func is Add: # all terms were treated as commutative
+            return (Add(*indep),
+                    Add(*depend))
+        else: # handle noncommutative by stopping at first dependent term
             for i, n in enumerate(nc):
-                if n.has(*ndeps) or n.has(*deps):
+                if n.has(*deps):
                     depend.extend(nc[i:])
                     break
                 indep.append(n)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -843,6 +843,8 @@ class Expr(Basic, EvalfMixin):
             (1, n1*n2*n3)
             >>> (n1*n2*n3).as_independent(n2)
             (n1, n2*n3)
+            >>> ((x-n1)*(x-y)).as_independent(x)
+            (1, (x - y)*(x - n1))
 
           -- self is anything else:
             >>> (sin(x)).as_independent(x)
@@ -920,8 +922,11 @@ class Expr(Basic, EvalfMixin):
         depend = d.pop(True, [])
         indep = d.pop(False, [])
         if func is Add or not ndeps:
-            return (func(*(indep + nc)),
-                    func(*depend))
+            d = sift(nc, lambda x: x.has(*deps))
+            nc_indep = d.pop(False, [])
+            nc_dep = d.pop(True, [])
+            return (func(*(indep + nc_indep)),
+                    func(*(depend + nc_dep)))
         else:
             for i, n in enumerate(nc):
                 if n.has(*ndeps):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -921,15 +921,12 @@ class Expr(Basic, EvalfMixin):
         d = sift(args, lambda x: x.has(*deps))
         depend = d.pop(True, [])
         indep = d.pop(False, [])
-        if func is Add or not ndeps:
-            d = sift(nc, lambda x: x.has(*deps))
-            nc_indep = d.pop(False, [])
-            nc_dep = d.pop(True, [])
-            return (func(*(indep + nc_indep)),
-                    func(*(depend + nc_dep)))
+        if func is Add:
+            return (func(*(indep + nc)),
+                    func(*depend))
         else:
             for i, n in enumerate(nc):
-                if n.has(*ndeps):
+                if n.has(*ndeps) or n.has(*deps):
                     depend.extend(nc[i:])
                     break
                 indep.append(n)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -435,7 +435,7 @@ def test_as_independent():
     assert (2*sin(x)).as_independent(y) == (2*sin(x), 1)
 
     # issue 1804 = 1766b
-    n1, n2 = symbols('n1 n2', commutative=False)
+    n1, n2, n3 = symbols('n1 n2 n3', commutative=False)
     assert (n1 + n1*n2).as_independent(n2) == (n1, n1*n2)
     assert (n2*n1 + n1*n2).as_independent(n2) == (0, n1*n2 + n2*n1)
     assert (n1*n2*n1).as_independent(n2) == (n1, n2*n1)
@@ -454,6 +454,9 @@ def test_as_independent():
     assert ((x + n1)*(x - y)).as_independent(x) == (1, (x + n1)*(x - y))
     assert ((x + n1)*(x - y)).as_independent(y) == (x + n1, x - y)
     assert (DiracDelta(x - n1)*DiracDelta(x - y)).as_independent(x) == (1, DiracDelta(x - n1)*DiracDelta(x - y))
+    assert (x*y*n1*n2*n3).as_independent(n2) == (x*y*n1, n2*n3)
+    assert (x*y*n1*n2*n3).as_independent(n1) == (x*y, n1*n2*n3)
+    assert (x*y*n1*n2*n3).as_independent(n3) == (x*y*n1*n2, n3)
 
 def test_subs_dict():
     a,b,c,d,e = symbols('a,b,c,d,e')

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -457,6 +457,8 @@ def test_as_independent():
     assert (x*y*n1*n2*n3).as_independent(n2) == (x*y*n1, n2*n3)
     assert (x*y*n1*n2*n3).as_independent(n1) == (x*y, n1*n2*n3)
     assert (x*y*n1*n2*n3).as_independent(n3) == (x*y*n1*n2, n3)
+    assert (DiracDelta(x - n1)*DiracDelta(y - n1)*DiracDelta(x - n2)).as_independent(y) == \
+           (DiracDelta(x - n1), DiracDelta(y - n1)*DiracDelta(x - n2))
 
 def test_subs_dict():
     a,b,c,d,e = symbols('a,b,c,d,e')

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -5,7 +5,7 @@ from sympy import (Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I,
     WildFunction, Poly, Function, Derivative, Number, pi, var,
     NumberSymbol, zoo, Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp,
     radsimp, powsimp, simplify, together, separate, collect, factorial,
-    apart, combsimp, factor, refine, cancel, invert, Tuple, default_sort_key)
+    apart, combsimp, factor, refine, cancel, invert, Tuple, default_sort_key, DiracDelta)
 from sympy.physics.secondquant import FockState
 
 from sympy.core.cache import clear_cache
@@ -448,6 +448,12 @@ def test_as_independent():
 
     # issue 2380
     assert (3*x).as_independent(Symbol) == (3, x)
+
+    # issue 2549
+    assert (n1*x*y).as_independent(x) == (n1*y, x)
+    assert ((x + n1)*(x - y)).as_independent(x) == (1, (x + n1)*(x - y))
+    assert ((x + n1)*(x - y)).as_independent(y) == (x + n1, x - y)
+    assert (DiracDelta(x - n1)*DiracDelta(x - y)).as_independent(x) == (1, DiracDelta(x - n1)*DiracDelta(x - y))
 
 def test_subs_dict():
     a,b,c,d,e = symbols('a,b,c,d,e')


### PR DESCRIPTION
Issue 2549: http://code.google.com/p/sympy/issues/detail?id=2549

There seemed to be a problem where any expression involving the argument to as_independent and a non-commutative symbol was treated as independent even though it wasn't. I added a few lines to check the non-commutative expressions for the argument before adding them to the list of independent expressions. I am not sure if this supports all possible non-commutative expressions, but it does fix the bug I observed in the issue. 
