### PR TITLE
2553: simplify conditionally uses together

### DIFF
--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -147,7 +147,7 @@ def test_simplify():
     A = Matrix([[2*k-m*w**2, -k], [-k, k-m*w**2]]).inv()
 
     assert simplify((A*Matrix([0,f]))[1]) == \
-        (f*(2*k - m*w**2))/(k**2 - 3*k*m*w**2 + m**2*w**4)
+        f/(-k**2/(2*k - m*w**2) + k - m*w**2)
 
     a, b, c, d, e, f, g, h, i = symbols('a,b,c,d,e,f,g,h,i')
 
@@ -194,7 +194,11 @@ def test_simplify_ratio():
 def test_simplify_issue_1308():
     assert simplify(exp(-Rational(1, 2)) + exp(-Rational(3, 2))) == \
         (1 + E)*exp(-Rational(3, 2))
-    assert simplify(exp(1)+exp(-exp(1))) == (1 + exp(1 + E))*exp(-E)
+
+def test_issue_2553():
+    assert simplify(E + exp(-E)) == E + exp(-E)
+    n = symbols('n', commutative=False)
+    assert simplify(n + n**(-n)) == n + n**(-n)
 
 def test_simplify_fail1():
     x = Symbol('x')
@@ -491,7 +495,7 @@ def test_hypersimp():
 
     assert hypersimp(1/factorial(k), k) == 1/(k + 1)
 
-    assert hypersimp(2**k/factorial(k)**2, k) == 2/(k**2+2*k+1)
+    assert hypersimp(2**k/factorial(k)**2, k) == 2/(k**2 + 2*k + 1)
 
     assert hypersimp(binomial(n, k), k) == (n-k)/(k+1)
     assert hypersimp(binomial(n+1, k), k) == (n-k+1)/(k+1)
@@ -503,7 +507,7 @@ def test_hypersimp():
     assert hypersimp(term, k) == (2*k - 1)/(3 + 11*k + 12*k**2 + 4*k**3)/2
 
     term = binomial(n, k)*(-1)**k/factorial(k)
-    assert hypersimp(term, k) == (k - n)/(k**2+2*k+1)
+    assert hypersimp(term, k) == (k - n)/(k**2 + 2*k + 1)
 
 def test_nsimplify():
     x = Symbol("x")

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2185,8 +2185,8 @@ def ode_Liouville(eq, func, order, match):
         >>> f = Function('f')
         >>> pprint(dsolve(diff(f(x), x, x) + diff(f(x), x)**2/f(x) +
         ... diff(f(x), x)/x, f(x), hint='Liouville'))
-                   ___   ________________           ___   ________________
-        [f(x) = -\/ 2 *\/ C1 + C2*log(x) , f(x) = \/ 2 *\/ C1 + C2*log(x) ]
+                   ________________           ________________
+        [f(x) = -\/ C1 + C2*log(x) , f(x) = \/ C1 + C2*log(x) ]
 
 
     **References**

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1081,7 +1081,7 @@ def test_Liouville_ODE():
     # If solve() is ever improved, this is a better solution
     sol1a = Eq(f(x), -log((C1*x+C2)/x))
     sol2 = Eq(C1 + C2/x - exp(-f(x)), 0) # This is equivalent to sol1
-    sol3 = set([Eq(f(x), -sqrt(2)*sqrt(C1 + C2*log(x))), Eq(f(x), sqrt(2)*sqrt(C1 + C2*log(x)))])
+    sol3 = set([Eq(f(x), sqrt(C1 + C2*log(x))), Eq(f(x), -sqrt(C1 + C2*log(x)))])
     sol4 = set([Eq(f(x), -sqrt(2)*sqrt(C1 + C2*exp(-x))), Eq(f(x), sqrt(2)*sqrt(C1 + C2*exp(-x)))])
     sol5 = Eq(f(x), log(C1 + C2/x))
     sol1s = constant_renumber(sol1, 'C', 1, 2)
@@ -1092,7 +1092,7 @@ def test_Liouville_ODE():
     assert dsolve(eq1, f(x), hint) in (sol1, sol1s)
     assert dsolve(eq1a, f(x), hint) in (sol1, sol1s)
     assert dsolve(eq2, f(x), hint) in (sol2, sol2s)
-    assert set(dsolve(eq3, f(x), hint)) in (sol3, sol3s) # XXX: remove sqrt(2) factor
+    assert set(dsolve(eq3, f(x), hint)) in (sol3, sol3s)
     assert set(dsolve(eq4, f(x), hint)) in (sol4, sol4s) # XXX: remove sqrt(2) factor
     assert dsolve(eq5, f(x), hint) in (sol5, sol5s)
     assert checkodesol(sol1, f(x), sol1a, order=2, solve_for_func=False)[0]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -217,8 +217,8 @@ def test_tsolve():
     raises(NotImplementedError, "solve(Eq(cos(x), sin(x)), x)")
 
     assert solve(exp(x) + exp(-x) - y, x, simplified=False) == [
-        log(y**2/2 + y*sqrt(y**2 - 4)/2 - 1)/2,
-        log(y**2/2 - y*sqrt(y**2 - 4)/2 - 1)/2]
+        log((y/2 + sqrt(y**2 - 4)/2)**2)/2,
+        log((y/2 - sqrt(y**2 - 4)/2)**2)/2]
     assert solve(exp(x)-3, x) == [log(3)]
     assert solve(Eq(exp(x), 3), x) == [log(3)]
     assert solve(log(x)-3, x) == [exp(3)]
@@ -228,10 +228,11 @@ def test_tsolve():
     assert solve(4*3**(5*x+2)-7, x) == [(-2*log(3) - 2*log(2) + log(7))/(5*log(3))]
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
     assert solve(3*x+5+2**(-5*x+3), x) in [
-        [Rational(-5, 3) + LambertW(log(2**(-10240*2**Rational(1, 3)/3)))/(5*log(2))],
-        [-Rational(5,3) + LambertW(-10240*2**Rational(1, 3)*log(2)/3)/(5*log(2))],
-        [(-25*log(2) + 3*LambertW(-10240*2**Rational(1, 3)*log(2)/3))/(15*log(2))],
-        [-((25*log(2) - 3*LambertW(-10240*2**Rational(1, 3)*log(2)/3)))/(15*log(2))],
+        [-((25*log(2) - 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2)))],
+        [Rational(-5, 3) + LambertW(log(2**(-10240*2**(Rational(1, 3))/3)))/(5*log(2))],
+        [-Rational(5,3) + LambertW(-10240*2**Rational(1,3)*log(2)/3)/(5*log(2))],
+        [(-25*log(2) + 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2))],
+        [-((25*log(2) - 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3)))/(15*log(2))],
         [-(25*log(2) - 3*LambertW(log(2**(-10240*2**Rational(1, 3)/3))))/(15*log(2))],
         [(25*log(2) - 3*LambertW(log(2**(-10240*2**Rational(1, 3)/3))))/(-15*log(2))]
         ]


### PR DESCRIPTION
```
both commutative and non-commutative expressions accept
together's result only if it has fewer ops than the original expr.
In the case of commutative expressions, the cancel(powsimp(expr))
is also considered.

This conditional simplification can be ignored by passing ratio=oo;
this is necessary for hypersimp which hangs during test_sums_products.
```

tests and doctests pass here
