### PR TITLE
isympy works with IPython 0.11

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -30,7 +30,7 @@ def _init_ipython_printing(ip, stringify_func):
             print
 
         print out
-    
+
     def result_display(self, arg):
         """IPython's pretty-printer display hook.
 
@@ -43,12 +43,12 @@ def _init_ipython_printing(ip, stringify_func):
             pretty_print(arg)
         else:
             print repr(arg)
-    
+
     import IPython
     if IPython.__version__ >= '0.11':
         formatter = ip.display_formatter.formatters['text/plain']
         # caller that fits pretty's call pattern:
-        
+
         # use this instead to *always* use the sympy printer
         # formatter.for_type(object, pretty_print)
         # this loads pretty printing for objects that inherit from Basic or Matrix:
@@ -58,7 +58,6 @@ def _init_ipython_printing(ip, stringify_func):
         formatter.for_type_by_name(
             'sympy.matrices.matrices', 'Matrix', pretty_print
         )
-        
     else:
         ip.set_hook('result_display', result_display_10)
 
@@ -80,8 +79,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None, wrap_line=Non
             stringify_func = lambda expr: _stringify_func(expr, order=order, use_unicode=use_unicode, wrap_line=wrap_line)
         else:
             stringify_func = lambda expr: _stringify_func(expr, order=order)
-    
-    if ip.__module__.startswith('IPython'):
+
+    if ip is not None and ip.__module__.startswith('IPython'):
         _init_ipython_printing(ip, stringify_func)
     else:
         _init_python_printing(stringify_func)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -22,6 +22,15 @@ def _init_python_printing(stringify_func):
 def _init_ipython_printing(ip, stringify_func):
     """Setup printing in IPython interactive session. """
 
+    def pretty_print(arg, p=None, cycle=None):
+        """pretty printer that accepts pretty's arg format."""
+        out = stringify_func(arg)
+
+        if '\n' in out:
+            print
+
+        print out
+    
     def result_display(self, arg):
         """IPython's pretty-printer display hook.
 
@@ -31,18 +40,29 @@ def _init_ipython_printing(ip, stringify_func):
 
         """
         if self.rc.pprint:
-            out = stringify_func(arg)
-
-            if '\n' in out:
-                print
-
-            print out
+            pretty_print(arg)
         else:
             print repr(arg)
+    
+    import IPython
+    if IPython.__version__ >= '0.11':
+        formatter = ip.display_formatter.formatters['text/plain']
+        # caller that fits pretty's call pattern:
+        
+        # use this instead to *always* use the sympy printer
+        # formatter.for_type(object, pretty_print)
+        # this loads pretty printing for objects that inherit from Basic or Matrix:
+        formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', pretty_print
+        )
+        formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'Matrix', pretty_print
+        )
+        
+    else:
+        ip.set_hook('result_display', result_display_10)
 
-    ip.set_hook('result_display', result_display)
-
-def init_printing(pretty_print=True, order=None, use_unicode=None, wrap_line=None, no_global=False):
+def init_printing(pretty_print=True, order=None, use_unicode=None, wrap_line=None, no_global=False, ip=None):
     """Initializes pretty-printer depending on the environment. """
     from sympy.printing.printer import Printer
 
@@ -60,21 +80,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None, wrap_line=Non
             stringify_func = lambda expr: _stringify_func(expr, order=order, use_unicode=use_unicode, wrap_line=wrap_line)
         else:
             stringify_func = lambda expr: _stringify_func(expr, order=order)
-
-    try:
-        import IPython
-    except ImportError:
-        _init_python_printing(stringify_func)
+    
+    if ip.__module__.startswith('IPython'):
+        _init_ipython_printing(ip, stringify_func)
     else:
-        if IPython.__version__ >= '0.11':
-            try:
-                ip = get_ipython()
-            except NameError:
-                ip = None
-        else:
-            ip = IPython.ipapi.get()
-
-        if ip is not None:
-            _init_ipython_printing(ip, stringify_func)
-        else:
-            _init_python_printing(stringify_func)
+        _init_python_printing(stringify_func)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -66,7 +66,13 @@ def init_printing(pretty_print=True, order=None, use_unicode=None, wrap_line=Non
     except ImportError:
         _init_python_printing(stringify_func)
     else:
-        ip = IPython.ipapi.get()
+        if IPython.__version__ >= '0.11':
+            try:
+                ip = get_ipython()
+            except NameError:
+                ip = None
+        else:
+            ip = IPython.ipapi.get()
 
         if ip is not None:
             _init_ipython_printing(ip, stringify_func)

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -138,10 +138,12 @@ def init_session(ipython=None, pretty_print=True, order=None,
                     ip = None
             else:
                 ip = IPython.ipapi.get()
+                if ip:
+                    ip = ip.IP
                 mainloop = ip.interact
 
             if ip is not None:
-                ip, in_ipython = ip.IP, True
+                in_ipython = True
             else:
                 ip = _init_ipython_session(argv)
 
@@ -155,7 +157,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
     _preexec_source = preexec_source
 
     ip.runsource(_preexec_source, symbol='exec')
-    init_printing(pretty_print=pretty_print, order=order, use_unicode=use_unicode)
+    init_printing(pretty_print=pretty_print, order=order, use_unicode=use_unicode, ip=ip)
 
     message = _make_message(ipython, quiet, _preexec_source)
 

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -71,8 +71,9 @@ def _init_ipython_session(argv=[]):
         from IPython.frontend.terminal import ipapp
         # use an app to parse the command line, and init config
         app = ipapp.TerminalIPythonApp()
+        # don't draw IPython banner during initialization:
+        app.display_banner = False
         app.initialize(argv)
-        
         return app.shell
     else:
         from IPython.Shell import make_IPython


### PR DESCRIPTION
updated a few IPython imports to match 0.11 if found, so isympy seems to work with trunk IPython.  I'm not 100% sure this is complete, or the right thing to do everywhere, but at least it starts.

While 0.11 hasn't been released, the APIs used here are stable.

Unrelated, but I was asked this at the same time:

For loading the LaTeX printing in the qtconsole, you would do: `%load_ext sympyprinting`.  If you use the bundled sympy profile, this will be set up by default:

```
ipython qtconsole --profile=sympy
```
