### PR TITLE
don't ask for ip.interact before ip exists

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -59,7 +59,7 @@ def _init_ipython_printing(ip, stringify_func):
             'sympy.matrices.matrices', 'Matrix', pretty_print
         )
     else:
-        ip.set_hook('result_display', result_display_10)
+        ip.set_hook('result_display', result_display)
 
 def init_printing(pretty_print=True, order=None, use_unicode=None, wrap_line=None, no_global=False, ip=None):
     """Initializes pretty-printer depending on the environment. """

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -141,7 +141,6 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 ip = IPython.ipapi.get()
                 if ip:
                     ip = ip.IP
-                mainloop = ip.interact
 
             if ip is not None:
                 in_ipython = True
@@ -154,6 +153,8 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 # and False means don't add the line to IPython's history.
                 ip.runsource = lambda src, symbol='exec': ip.run_cell(src, False)
                 mainloop = ip.mainloop
+            else:
+                mainloop = ip.interact
 
     _preexec_source = preexec_source
 


### PR DESCRIPTION
PR #487 had a typo breaking isympy in 0.10, as described [here](https://github.com/sympy/sympy/pull/487#issuecomment-1580139).
