### PR TITLE
Removed errant is_commutative check from add.py

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -75,11 +75,10 @@ class Add(AssocOp):
                 c, s = o.as_coeff_Mul()
 
                 # 3*...
-                if c.is_Number:
-                    # unevaluated 2-arg Mul
-                    if s.is_Add and s.is_commutative:
-                        seq.extend([c*a for a in s.args])
-                        continue
+                # unevaluated 2-arg Mul
+                if c.is_Number and s.is_Add:
+                    seq.extend([c*a for a in s.args])
+                    continue
 
             # everything else
             else:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -273,6 +273,8 @@ def test_ncmul():
 
     assert A/(1+A) == A/(1+A)
 
+    assert (A+B + 2*(A+B)) == 3*A + 3*B
+
 def test_ncpow():
     x = Symbol('x', commutative=False)
     y = Symbol('y', commutative=False)
@@ -1196,4 +1198,4 @@ def test_issue2361():
     n = Symbol('n', commutative=False)
     u = 2*(1 + n)
     assert u.is_Mul
-    assert (2 + u).args == (S(2), u)
+    assert 2 + u == 4 + 2*n


### PR DESCRIPTION
Previously

> > > a, b = symbols('a b', commutative=False)
> > > 
> > > a + b + 2*(a+b) 
> > > a + b + 2⋅(a + b)

Issue 2568
http://code.google.com/p/sympy/issues/detail?id=2568
