### PR TITLE
Replace a bare except statement with an explicit one

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -6,7 +6,7 @@ from threading import RLock
 # it is sufficient to import "pyglet" here once
 try:
     from pyglet.gl import *
-except:
+except ImportError:
     raise ImportError("pyglet is required for plotting.\n visit http://www.pyglet.org/")
 
 from plot_object import PlotObject


### PR DESCRIPTION
This was making it falsely claim that Pyglet was not installed when it gave an error at import time.  Also see issue 2570.
