### PR TITLE
Preview to file

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -26,9 +26,10 @@ def preview(expr, output='png', viewer=None, euler=True):
 
            >> preview(x + y, output='png')
 
-       This will choose 'pyglet by default. To select different one::
+       This will choose 'pyglet' by default. To select different one::
 
            >> preview(x + y, output='png', viewer='gimp')
+
 
        The 'png' format is considered special. For all other formats
        the rules are slightly different. As an example we will take
@@ -45,7 +46,9 @@ def preview(expr, output='png', viewer=None, euler=True):
 
        This will skip auto-detection and will run user specified
        'superior-dvi-viewer'. If 'view' fails to find it on
-       your system it will gracefully raise an exception.
+       your system it will gracefully raise an exception. You may also
+       enter 'file' for the viewer argument. Doing so will cause this function
+       to return a file object in read-only mode.
 
        Currently this depends on pexpect, which is not available for windows.
     """
@@ -134,8 +137,11 @@ def preview(expr, output='png', viewer=None, euler=True):
             raise SystemError("Invalid output format: %s" % output)
 
     src = "%s.%s" % (tmp, output)
+    src_file = None
 
-    if viewer == "pyglet":
+    if viewer == "file":
+        src_file = open(src, 'rb')
+    elif viewer == "pyglet":
         try:
             from pyglet import window, image, gl
             from pyglet.window import key
@@ -195,3 +201,6 @@ def preview(expr, output='png', viewer=None, euler=True):
 
     os.remove(src)
     os.chdir(cwd)
+
+    if src_file is not None:
+        return src_file


### PR DESCRIPTION
I noticed that all of the LaTeX rendering code was already in the preview function. Adding the option to just return the file makes it so we can use preview to render an expression to PNG, PDF, .etc, without making a popup window.

(I'm using this for a project where I want to render sympy expressions to images, but handle how/where they are displayed by myself.)
