### PR TITLE
Preview: to file, and LaTeX input

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -5,12 +5,15 @@ import tempfile
 from latex import latex
 
 def preview(expr, output='png', viewer=None, euler=True):
-    """View expression in PNG, DVI, PostScript or PDF form.
+    """View expression or LaTeX markup in PNG, DVI, PostScript or
+       PDF form.
 
-       This will generate LaTeX representation of the given expression
-       and compile it using available TeX distribution. Then it will
-       run appropriate viewer for the given output format or use the
-       user defined one. By default png output is generated.
+       If the expr argument is an expression, it will be exported to
+       LaTeX and then compiled using available the TeX distribution.
+       The first argument, 'expr', may also be a LaTeX string.
+       The function will then run the appropriate viewer for the given
+       output format or use the user defined one. By default png
+       output is generated.
 
        By default pretty Euler fonts are used for typesetting (they
        were used to typeset the well known "Concrete Mathematics"
@@ -104,10 +107,16 @@ def preview(expr, output='png', viewer=None, euler=True):
                      \end{document}
                  """
 
+    if isinstance(expr, str):
+        latex_string = expr
+    else:
+        latex_string = latex(expr, mode='inline')  
+
+
     tmp = tempfile.mktemp()
 
     tex = open(tmp + ".tex", "w")
-    tex.write(format % latex(expr, mode='inline'))
+    tex.write(format % latex_string)
     tex.close()
 
     cwd = os.getcwd()

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -26,9 +26,10 @@ def preview(expr, output='png', viewer=None, euler=True):
 
            >> preview(x + y, output='png')
 
-       This will choose 'pyglet by default. To select different one::
+       This will choose 'pyglet' by default. To select different one::
 
            >> preview(x + y, output='png', viewer='gimp')
+
 
        The 'png' format is considered special. For all other formats
        the rules are slightly different. As an example we will take
@@ -45,7 +46,9 @@ def preview(expr, output='png', viewer=None, euler=True):
 
        This will skip auto-detection and will run user specified
        'superior-dvi-viewer'. If 'view' fails to find it on
-       your system it will gracefully raise an exception.
+       your system it will gracefully raise an exception. You may also
+       enter 'file' for the viewer argument. Doing so will cause this function
+       to return a file object in read-only mode.
 
        Currently this depends on pexpect, which is not available for windows.
     """
@@ -134,8 +137,11 @@ def preview(expr, output='png', viewer=None, euler=True):
             raise SystemError("Invalid output format: %s" % output)
 
     src = "%s.%s" % (tmp, output)
+    src_file = None
 
-    if viewer == "pyglet":
+    if viewer == "file":
+        src_file = open(src, 'rb')
+    elif viewer == "pyglet":
         try:
             from pyglet import window, image, gl
             from pyglet.window import key
@@ -195,3 +201,6 @@ def preview(expr, output='png', viewer=None, euler=True):
 
     os.remove(src)
     os.chdir(cwd)
+
+    if src_file is not None:
+        return src_file

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -110,7 +110,7 @@ def preview(expr, output='png', viewer=None, euler=True):
     if isinstance(expr, str):
         latex_string = expr
     else:
-        latex_string = latex(expr, mode='inline')  
+        latex_string = latex(expr, mode='inline')
 
 
     tmp = tempfile.mktemp()


### PR DESCRIPTION
I noticed that all of the LaTeX rendering code was already in the preview function. Adding the option to just return the file makes it so we can use preview to render an expression to PNG, PDF, .etc, without making a popup window. 

(I'm using this for a project where I want to render sympy expressions to images, but handle how/where they are displayed by myself.)

I've also changed it so either a sympy Expr or a string of LaTeX can be entered. This is a piece of functionality that I've personally found the need for. Does it seem strange or out-of-place to others?
