### PR TITLE
2562: Add itertools product and permutations to compatibility module.

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -236,3 +236,44 @@ try:
 except AttributeError:
     def cmp(a,b):
         return (a > b) - (a < b)
+
+try:
+    from itertools import product
+except ImportError:
+    def product(*args, **kwds):
+        # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
+        # product(range(2), repeat=3) --> 000 001 010 011 100 101 110 111
+        pools = map(tuple, args) * kwds.get('repeat', 1)
+        result = [[]]
+        for pool in pools:
+            result = [x+[y] for x in result for y in pool]
+        for prod in result:
+            yield tuple(prod)
+
+try:
+    from itertools import permutations
+except ImportError:
+    def permutations(iterable, r=None):
+        # permutations('ABCD', 2) --> AB AC AD BA BC BD CA CB CD DA DB DC
+        # permutations(range(3)) --> 012 021 102 120 201 210
+        pool = tuple(iterable)
+        n = len(pool)
+        r = n if r is None else r
+        if r > n:
+            return
+        indices = range(n)
+        cycles = range(n, n-r, -1)
+        yield tuple(pool[i] for i in indices[:r])
+        while n:
+            for i in reversed(range(r)):
+                cycles[i] -= 1
+                if cycles[i] == 0:
+                    indices[i:] = indices[i+1:] + indices[i:i+1]
+                    cycles[i] = n - i
+                else:
+                    j = cycles[i]
+                    indices[i], indices[-j] = indices[-j], indices[i]
+                    yield tuple(pool[i] for i in indices[:r])
+                    break
+            else:
+                return

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -360,8 +360,8 @@ class ProductSet(Set):
 
     def __iter__(self):
         if self.is_iterable:
-            import itertools
-            return itertools.product(*self.sets)
+            from sympy.core.compatibility import product
+            return product(*self.sets)
         else:
             raise TypeError("Not all constituent sets are iterable")
 

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -553,7 +553,7 @@ class Formula(object):
             raise TypeError('Cannot instantiate other number of parameters')
 
         from sympy import solve
-        from itertools import permutations, product
+        from sympy.core.compatibility import permutations, product
         res = []
         our_params = list(self.indices.ap) + list(self.indices.bq)
         for na in permutations(ap):


### PR DESCRIPTION
This is used to fix python2.5 compatibility problems.
