### PR TITLE
remove itertools calls for 2.5 compatibility

### DIFF
--- a/doc/src/modules/utilities/iterables.txt
+++ b/doc/src/modules/utilities/iterables.txt
@@ -8,16 +8,8 @@ Returns the cartesian product of sequences as a generator.
 
 Examples::
     >>> from sympy.utilities.iterables import cartes
-    >>> list(cartes([1,2,3], 'abc'))
-    [[1, 'a'],
-    [1, 'b'],
-    [1, 'c'],
-    [2, 'a'],
-    [2, 'b'],
-    [2, 'c'],
-    [3, 'a'],
-    [3, 'b'],
-    [3, 'c']]
+    >>> list(cartes([1,2,3], 'ab'))
+    [(1, 'a'), (1, 'b'), (2, 'a'), (2, 'b'), (3, 'a'), (3, 'b')]
 
 
 
@@ -36,4 +28,3 @@ Examples::
     [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
     >>> list(variations([1,2,3], 2, True))
     [[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3]]
-    

--- a/doc/src/modules/utilities/iterables.txt
+++ b/doc/src/modules/utilities/iterables.txt
@@ -25,6 +25,6 @@ without repetition if set to False.
 Examples::
     >>> from sympy.utilities.iterables import variations
     >>> list(variations([1,2,3], 2))
-    [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
+    [(1, 2), (1, 3), (2, 1), (2, 3), (3, 1), (3, 2)]
     >>> list(variations([1,2,3], 2, True))
-    [[1, 1], [1, 2], [1, 3], [2, 1], [2, 2], [2, 3], [3, 1], [3, 2], [3, 3]]
+    [(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3)]

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -140,8 +140,28 @@ try:
     from itertools import product
 except ImportError: # Python 2.5
     def product(*args, **kwds):
-        # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
-        # product(range(2), repeat=3) --> 000 001 010 011 100 101 110 111
+        """
+        Cartesian product of input iterables.
+
+        Equivalent to nested for-loops in a generator expression. For example,
+        product(A, B) returns the same as ((x,y) for x in A for y in B).
+
+        The nested loops cycle like an odometer with the rightmost element
+        advancing on every iteration. This pattern creates a lexicographic
+        ordering so that if the input's iterables are sorted, the product
+        tuples are emitted in sorted order.
+
+        To compute the product of an iterable with itself, specify the number
+        of repetitions with the optional repeat keyword argument. For example,
+        product(A, repeat=4) means the same as product(A, A, A, A).
+
+        Examples:
+        >>> from sympy.core.compatibility import product
+        >>> [''.join(p) for p in list(product('ABC', 'xy'))]
+        ['Ax', 'Ay', 'Bx', 'By', 'Cx', 'Cy']
+        >>> list(product(range(2), repeat=2))
+        [(0, 0), (0, 1), (1, 0), (1, 1)]
+        """
         pools = map(tuple, args) * kwds.get('repeat', 1)
         result = [[]]
         for pool in pools:
@@ -153,8 +173,28 @@ try:
     from itertools import permutations
 except ImportError: # Python 2.5
     def permutations(iterable, r=None):
-        # permutations('ABCD', 2) --> AB AC AD BA BC BD CA CB CD DA DB DC
-        # permutations(range(3)) --> 012 021 102 120 201 210
+        """
+        Return successive r length permutations of elements in the iterable.
+
+        If r is not specified or is None, then r defaults to the length of
+        the iterable and all possible full-length permutations are generated.
+
+        Permutations are emitted in lexicographic sort order. So, if the input
+        iterable is sorted, the permutation tuples will be produced in sorted
+        order.
+
+        Elements are treated as unique based on their position, not on their
+        value. So if the input elements are unique, there will be no repeat
+        values in each permutation.
+
+        Examples;
+        >>> from sympy.core.compatibility import permutations
+        >>> [''.join(p) for p in list(permutations('ABC', 2))]
+        ['AB', 'AC', 'BA', 'BC', 'CA', 'CB']
+        >>> list(permutations(range(3)))
+        [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
+        """
+
         pool = tuple(iterable)
         n = len(pool)
         r = n if r is None else r
@@ -176,3 +216,78 @@ except ImportError: # Python 2.5
                     break
             else:
                 return
+
+try:
+    from itertools import combinations, combinations_with_replacement
+except ImportError: # < python 2.6
+    def combinations(iterable, r):
+        """
+        Return r length subsequences of elements from the input iterable.
+
+        Combinations are emitted in lexicographic sort order. So, if the
+        input iterable is sorted, the combination tuples will be produced
+        in sorted order.
+
+        Elements are treated as unique based on their position, not on their
+        value. So if the input elements are unique, there will be no repeat
+        values in each combination.
+
+        See also: combinations_with_replacements
+
+        Examples:
+        >>> from sympy.core.compatibility import combinations
+        >>> list(combinations('ABC', 2))
+        [('A', 'B'), ('A', 'C'), ('B', 'C')]
+        >>> list(combinations(range(4), 3))
+        [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]
+        """
+        pool = tuple(iterable)
+        n = len(pool)
+        if r > n:
+            return
+        indices = range(r)
+        yield tuple(pool[i] for i in indices)
+        while True:
+            for i in reversed(range(r)):
+                if indices[i] != i + n - r:
+                    break
+            else:
+                return
+            indices[i] += 1
+            for j in range(i+1, r):
+                indices[j] = indices[j-1] + 1
+            yield tuple(pool[i] for i in indices)
+
+    def combinations_with_replacement(iterable, r):
+        """Return r length subsequences of elements from the input iterable
+        allowing individual elements to be repeated more than once.
+
+        Combinations are emitted in lexicographic sort order. So, if the
+        input iterable is sorted, the combination tuples will be produced
+        in sorted order.
+
+        Elements are treated as unique based on their position, not on their
+        value. So if the input elements are unique, the generated combinations
+        will also be unique.
+
+        See also: combinations
+
+        Example:
+        >>> from sympy.core.compatibility import combinations_with_replacement
+        >>> list(combinations_with_replacement('AB', 2))
+        [('A', 'A'), ('A', 'B'), ('B', 'B')]
+        """
+        pool = tuple(iterable)
+        n = len(pool)
+        if not n and r:
+            return
+        indices = [0] * r
+        yield tuple(pool[i] for i in indices)
+        while True:
+            for i in reversed(range(r)):
+                if indices[i] != n - 1:
+                    break
+            else:
+                return
+            indices[i:] = [indices[i] + 1] * (r - i)
+            yield tuple(pool[i] for i in indices)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -150,7 +150,7 @@ minpoly = minimal_polynomial
 def _coeffs_generator(n):
     """Generate coefficients for `primitive_element()`. """
     for coeffs in variations([1,-1], n, repetition=True):
-        yield coeffs
+        yield list(coeffs)
 
 def primitive_element(extension, x=None, **args):
     """Construct a common number field for all extensions. """

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -4,7 +4,7 @@ from sympy import (limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
 
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.utilities.iterables import cartes
+from sympy.core.compatibility import product as cartes
 
 def test_basic1():
     assert limit(x, x, oo) == oo

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -307,19 +307,19 @@ def variations(seq, n=None, repetition=False):
     repetition of seq's elements:
         >>> from sympy.utilities.iterables import variations
         >>> list(variations([1, 2], 2))
-        [[1, 2], [2, 1]]
+        [(1, 2), (2, 1)]
 
     variations(seq, n, True) will return the N**n permutations obtained
     by allowing repetition of elements:
         >>> list(variations([1, 2], 2, repetition=True))
-        [[1, 1], [1, 2], [2, 1], [2, 2]]
+        [(1, 1), (1, 2), (2, 1), (2, 2)]
 
     If you ask for more items than are in the set you get the empty set unless
     you allow repetitions:
         >>> list(variations([0, 1], 3, repetition=False))
         []
         >>> list(variations([0, 1], 3, repetition=True))[:4]
-        [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1]]
+        [(0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1)]
 
 
     """
@@ -327,14 +327,14 @@ def variations(seq, n=None, repetition=False):
 
     if not repetition:
         for i in permutations(seq, n):
-            yield list(i)
+            yield i
     else:
         if n == 0:
-            yield []
+            yield ()
         else:
             for i in xrange(len(seq)):
                 for cc in variations(seq, n - 1, True):
-                    yield [seq[i]] + cc
+                    yield (seq[i],) + cc
 
 def subsets(seq, k=None, repetition=False):
     """Generates all k-subsets (combinations) from an n-element set, seq.
@@ -351,24 +351,24 @@ def subsets(seq, k=None, repetition=False):
        without repetition, i.e. once an item has been removed, it can no
        longer be "taken":
            >>> list(subsets([1, 2], 2))
-           [[1, 2]]
+           [(1, 2)]
            >>> list(subsets([1, 2]))
-           [[], [1], [2], [1, 2]]
+           [(), (1,), (2,), (1, 2)]
            >>> list(subsets([1, 2, 3], 2))
-           [[1, 2], [1, 3], [2, 3]]
+           [(1, 2), (1, 3), (2, 3)]
 
 
        subsets(seq, k, repetition=True) will return the (n - 1 + k)!/k!/(n - 1)!
        combinations *with* repetition:
            >>> list(subsets([1, 2], 2, repetition=True))
-           [[1, 1], [1, 2], [2, 2]]
+           [(1, 1), (1, 2), (2, 2)]
 
        If you ask for more items than are in the set you get the empty set unless
        you allow repetitions:
            >>> list(subsets([0, 1], 3, repetition=False))
            []
            >>> list(subsets([0, 1], 3, repetition=True))
-           [[0, 0, 0], [0, 0, 1], [0, 1, 1], [1, 1, 1]]
+           [(0, 0, 0), (0, 0, 1), (0, 1, 1), (1, 1, 1)]
        """
     if k is None:
         for k in range(len(seq) + 1):
@@ -377,10 +377,10 @@ def subsets(seq, k=None, repetition=False):
     else:
         if not repetition:
             for i in combinations(seq, k):
-                yield list(i)
+                yield i
         else:
             for i in combinations_with_replacement(seq, k):
-                yield list(i)
+                yield i
 
 def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
     """

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -1,6 +1,6 @@
 from sympy.core import Basic, C
-from sympy.core.compatibility import is_sequence, iterable #logically, they belong here
-
+from sympy.core.compatibility import is_sequence, iterable #logically, these belong here
+from sympy.core.compatibility import product as cartes, combinations, combinations_with_replacement
 import random
 
 def flatten(iterable, levels=None, cls=None):
@@ -297,36 +297,7 @@ def interactive_traversal(expr):
 
     return _interactive_traversal(expr, 0)
 
-def cartes(*seqs):
-    """Return Cartesian product (combinations) of items from iterable
-    sequences, seqs, as a generator.
-
-    Examples::
-    >>> from sympy import Add, Mul
-    >>> from sympy.abc import x, y
-    >>> from sympy.utilities.iterables import cartes
-    >>> do=list(cartes([Mul, Add], [x, y], [2]))
-    >>> for di in do:
-    ...     print di[0](*di[1:])
-    ...
-    2*x
-    2*y
-    x + 2
-    y + 2
-    >>>
-
-    >>> list(cartes([1, 2], [3, 4, 5]))
-    [[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5]]
-    """
-
-    if not seqs:
-        yield []
-    else:
-        for item in seqs[0]:
-            for subitem in cartes(*seqs[1:]):
-                yield [item] + subitem
-
-def variations(seq, n, repetition=False):
+def variations(seq, n=None, repetition=False):
     """Returns a generator of the variations (size n) of the list `seq` (size N).
     `repetition` controls whether items in seq can appear more than once;
 
@@ -351,17 +322,15 @@ def variations(seq, n, repetition=False):
         [[0, 0, 0], [0, 0, 1], [0, 1, 0], [0, 1, 1]]
 
 
-    Reference:
-        http://code.activestate.com/recipes/190465/
     """
+    from sympy.core.compatibility import permutations
 
-    if n == 0:
-        yield []
+    if not repetition:
+        for i in permutations(seq, n):
+            yield list(i)
     else:
-        if not repetition:
-            for i in xrange(len(seq)):
-                for cc in variations(seq[:i] + seq[i + 1:], n - 1, False):
-                    yield [seq[i]] + cc
+        if n == 0:
+            yield []
         else:
             for i in xrange(len(seq)):
                 for cc in variations(seq, n - 1, True):
@@ -401,36 +370,17 @@ def subsets(seq, k=None, repetition=False):
            >>> list(subsets([0, 1], 3, repetition=True))
            [[0, 0, 0], [0, 0, 1], [0, 1, 1], [1, 1, 1]]
        """
-
-    if type(seq) is not list:
-        seq = list(seq)
-    if k == 0:
-        yield []
-    elif k is None:
-        yield []
-        for k in range(1, len(seq) + 1):
-            for s in subsets(seq, k, repetition=repetition):
-                yield list(s)
+    if k is None:
+        for k in range(len(seq) + 1):
+            for i in subsets(seq, k, repetition):
+                yield i
     else:
         if not repetition:
-            for i in xrange(len(seq)):
-                for cc in subsets(seq[i + 1:], k - 1, False):
-                    yield [seq[i]] + cc
+            for i in combinations(seq, k):
+                yield list(i)
         else:
-            nmax = len(seq) - 1
-            indices = [0] * k
-            yield seq[:1] * k
-            while 1:
-                indices[-1] += 1
-                if indices[-1] > nmax:
-                    #find first digit that can be incremented
-                    for j in range(-2, -k - 1, -1):
-                        if indices[j] < nmax:
-                            indices[j:] = [indices[j] + 1] * -j
-                            break # increment and copy to the right
-                    else:
-                        break # we didn't for-break so we are done
-                yield [seq[li] for li in indices]
+            for i in combinations_with_replacement(seq, k):
+                yield list(i)
 
 def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
     """

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -101,65 +101,65 @@ def test_group():
 
 def test_subsets():
     # combinations
-    assert list(subsets([1, 2, 3], 0)) == [[]]
-    assert list(subsets([1, 2, 3], 1)) == [[1], [2], [3]]
-    assert list(subsets([1, 2, 3], 2)) == [[1, 2], [1,3], [2, 3]]
-    assert list(subsets([1, 2, 3], 3)) == [[1, 2, 3]]
+    assert list(subsets([1, 2, 3], 0)) == [()]
+    assert list(subsets([1, 2, 3], 1)) == [(1,), (2,), (3,)]
+    assert list(subsets([1, 2, 3], 2)) == [(1, 2), (1,3), (2, 3)]
+    assert list(subsets([1, 2, 3], 3)) == [(1, 2, 3)]
     l = range(4)
-    assert list(subsets(l, 0, repetition=True)) == [[]]
-    assert list(subsets(l, 1, repetition=True)) == [[0], [1], [2], [3]]
-    assert list(subsets(l, 2, repetition=True)) == [[0, 0], [0, 1], [0, 2],
-                                                    [0, 3], [1, 1], [1, 2],
-                                                    [1, 3], [2, 2], [2, 3],
-                                                    [3, 3]]
-    assert list(subsets(l, 3, repetition=True)) == [[0, 0, 0], [0, 0, 1],
-                                                    [0, 0, 2], [0, 0, 3],
-                                                    [0, 1, 1], [0, 1, 2],
-                                                    [0, 1, 3], [0, 2, 2],
-                                                    [0, 2, 3], [0, 3, 3],
-                                                    [1, 1, 1], [1, 1, 2],
-                                                    [1, 1, 3], [1, 2, 2],
-                                                    [1, 2, 3], [1, 3, 3],
-                                                    [2, 2, 2], [2, 2, 3],
-                                                    [2, 3, 3], [3, 3, 3]]
+    assert list(subsets(l, 0, repetition=True)) == [()]
+    assert list(subsets(l, 1, repetition=True)) == [(0,), (1,), (2,), (3,)]
+    assert list(subsets(l, 2, repetition=True)) == [(0, 0), (0, 1), (0, 2),
+                                                    (0, 3), (1, 1), (1, 2),
+                                                    (1, 3), (2, 2), (2, 3),
+                                                    (3, 3)]
+    assert list(subsets(l, 3, repetition=True)) == [(0, 0, 0), (0, 0, 1),
+                                                    (0, 0, 2), (0, 0, 3),
+                                                    (0, 1, 1), (0, 1, 2),
+                                                    (0, 1, 3), (0, 2, 2),
+                                                    (0, 2, 3), (0, 3, 3),
+                                                    (1, 1, 1), (1, 1, 2),
+                                                    (1, 1, 3), (1, 2, 2),
+                                                    (1, 2, 3), (1, 3, 3),
+                                                    (2, 2, 2), (2, 2, 3),
+                                                    (2, 3, 3), (3, 3, 3)]
     assert len(list(subsets(l, 4, repetition=True))) == 35
 
     assert list(subsets(l[:2], 3, repetition=False)) == []
-    assert list(subsets(l[:2], 3, repetition=True)) == [[0, 0, 0],
-                                                        [0, 0, 1],
-                                                        [0, 1, 1],
-                                                        [1, 1, 1]]
+    assert list(subsets(l[:2], 3, repetition=True)) == [(0, 0, 0),
+                                                        (0, 0, 1),
+                                                        (0, 1, 1),
+                                                        (1, 1, 1)]
     assert list(subsets([1, 2], repetition=True)) == \
-           [[], [1], [2], [1, 1], [1, 2], [2, 2]]
+           [(), (1,), (2,), (1, 1), (1, 2), (2, 2)]
     assert list(subsets([1, 2], repetition=False)) == \
-           [[], [1], [2], [1, 2]]
+           [(), (1,), (2,), (1, 2)]
     assert list(subsets([1, 2, 3], 2)) == \
-           [[1, 2], [1, 3], [2, 3]]
+           [(1, 2), (1, 3), (2, 3)]
     assert list(subsets([1, 2, 3], 2, repetition=True)) == \
-           [[1, 1], [1, 2], [1, 3], [2, 2], [2, 3], [3, 3]]
+           [(1, 1), (1, 2), (1, 3), (2, 2), (2, 3), (3, 3)]
 
 def test_variations():
     # permutations
     l = range(4)
-    assert list(variations(l, 0, repetition=False)) == [[]]
-    assert list(variations(l, 1, repetition=False)) == [[0], [1], [2], [3]]
-    assert list(variations(l, 2, repetition=False)) == [[0, 1], [0, 2], [0, 3], [1, 0], [1, 2], [1, 3], [2, 0], [2, 1], [2, 3], [3, 0], [3, 1], [3, 2]]
-    assert list(variations(l, 3, repetition=False)) == [[0, 1, 2], [0, 1, 3], [0, 2, 1], [0, 2, 3], [0, 3, 1], [0, 3, 2], [1, 0, 2], [1, 0, 3], [1, 2, 0], [1, 2, 3], [1, 3, 0], [1, 3, 2], [2, 0, 1], [2, 0, 3], [2, 1, 0], [2, 1, 3], [2, 3, 0], [2, 3, 1], [3, 0, 1], [3, 0, 2], [3, 1, 0], [3, 1, 2], [3, 2, 0], [3, 2, 1]]
-    assert list(variations(l, 0, repetition=True)) == [[]]
-    assert list(variations(l, 1, repetition=True)) == [[0], [1], [2], [3]]
-    assert list(variations(l, 2, repetition=True)) == [[0, 0], [0, 1], [0, 2],
-                                                       [0, 3], [1, 0], [1, 1],
-                                                       [1, 2], [1, 3], [2, 0],
-                                                       [2, 1], [2, 2], [2, 3],
-                                                       [3, 0], [3, 1], [3, 2],
-                                                       [3, 3]]
+    assert list(variations(l, 0, repetition=False)) == [()]
+    assert list(variations(l, 1, repetition=False)) == [(0,), (1,), (2,), (3,)]
+    assert list(variations(l, 2, repetition=False)) == [(0, 1), (0, 2), (0, 3), (1, 0), (1, 2), (1, 3), (2, 0), (2, 1), (2, 3), (3, 0), (3, 1), (3, 2)]
+    assert list(variations(l, 3, repetition=False)) == [(0, 1, 2), (0, 1, 3), (0, 2, 1), (0, 2, 3), (0, 3, 1), (0, 3, 2), (1, 0, 2), (1, 0, 3), (1, 2, 0), (1, 2, 3), (1, 3, 0), (1, 3, 2), (2, 0, 1), (2, 0, 3), (2, 1, 0), (2, 1, 3), (2, 3, 0), (2, 3, 1), (3, 0, 1), (3, 0, 2), (3, 1, 0), (3, 1, 2), (3, 2, 0), (3, 2, 1)]
+    assert list(variations(l, 0, repetition=True)) == [()]
+    assert list(variations(l, 1, repetition=True)) == [(0,), (1,), (2,), (3,)]
+    assert list(variations(l, 2, repetition=True)) == [(0, 0), (0, 1), (0, 2),
+                                                       (0, 3), (1, 0), (1, 1),
+                                                       (1, 2), (1, 3), (2, 0),
+                                                       (2, 1), (2, 2), (2, 3),
+                                                       (3, 0), (3, 1), (3, 2),
+                                                       (3, 3)]
     assert len(list(variations(l, 3, repetition=True))) == 64
     assert len(list(variations(l, 4, repetition=True))) == 256
     assert list(variations(l[:2], 3, repetition=False)) == []
-    assert list(variations(l[:2], 3, repetition=True)) == [[0, 0, 0], [0, 0, 1],
-                                                           [0, 1, 0], [0, 1, 1],
-                                                           [1, 0, 0], [1, 0, 1],
-                                                           [1, 1, 0], [1, 1, 1]]
+    assert list(variations(l[:2], 3, repetition=True)) == [(0, 0, 0), (0, 0, 1),
+                                                           (0, 1, 0), (0, 1, 1),
+                                                           (1, 0, 0), (1, 0, 1),
+                                                           (1, 1, 0), (1, 1, 1)]
 
 def test_cartes():
     assert list(cartes([1, 2], [3, 4, 5])) == \

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -163,8 +163,8 @@ def test_variations():
 
 def test_cartes():
     assert list(cartes([1, 2], [3, 4, 5])) == \
-           [[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5]]
-    assert list(cartes()) == [[]]
+           [(1, 3), (1, 4), (1, 5), (2, 3), (2, 4), (2, 5)]
+    assert list(cartes()) == [()]
 
 def test_numbered_symbols():
     s = numbered_symbols(cls=Dummy)


### PR DESCRIPTION
There are existing tools in sympy that can be used for some itertools compatibility, but a couple new ones had to be added. In addition, the default n = len(seq) was added to variations since this is the default behavior of itertools.permutations (and it seems like a good idea).
