### PR TITLE
Fix invalid syntax (in Python2.5) in except.

### DIFF
--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -138,7 +138,7 @@ def represent(expr, **options):
             options['basis'] = temp_basis
         try:
             return expr._represent(**options)
-        except NotImplementedError as strerr:
+        except NotImplementedError, strerr:
             #If no _represent_FOO method exists, map to the
             #appropriate basis state and try
             #the other methods of representation


### PR DESCRIPTION
This is a trivial fix for a bug introduced in today's quantum commits.
