### PR TITLE
Robustify sympify(iterable)

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -13,7 +13,9 @@ class SympifyError(ValueError):
         if self.base_exc is None:
             return "SympifyError: %r" % (self.expr,)
 
-        return "Sympify of expression '%s' failed, because of exception being raised:\n%s: %s" % (self.expr, self.base_exc.__class__.__name__, str(self.base_exc))
+        return ("Sympify of expression '%s' failed, because of exception being "
+            "raised:\n%s: %s" % (self.expr, self.base_exc.__class__.__name__,
+            str(self.base_exc)))
 
 
 converter = {}
@@ -128,7 +130,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
             rational=rational) for x in a])
     if iterable(a):
         try:
-            return type(a)([sympify(x, locals=locals, convert_xor=convert_xor, rational=rational) for x in a])
+            return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
+                rational=rational) for x in a])
         except TypeError:
             # Not all iterables are rebuildable with their type.
             pass

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -127,8 +127,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
         return Tuple(*[sympify(x, locals=locals, convert_xor=convert_xor,
             rational=rational) for x in a])
     if iterable(a):
-        return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
-            rational=rational) for x in a])
+        try:
+            return type(a)([sympify(x, locals=locals, convert_xor=convert_xor, rational=rational) for x in a])
+        except TypeError:
+            # Not all iterables are rebuildable with their type.
+            pass
 
     # At this point we were given an arbitrary expression
     # which does not inherit from Basic and doesn't implement


### PR DESCRIPTION
If the iterable didn't rebuild itself with type(a)(list), it would raise
a TypeError.  Now we just catch that and move on to the other heuristics
in sympify().  This was causing a failure in the sage tests.

This was originally pull #411.
