### PR TITLE
utilities/runtests: Clear cache for every file tested

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -26,6 +26,8 @@ from doctest import DocTestFinder, DocTestRunner
 import re as pre
 import random
 
+from sympy.core.cache import clear_cache
+
 # Use sys.stdout encoding for ouput.
 # This was only added to Python's doctest in Python 2.6, so we must duplicate
 # it here to make utf8 files work in Python 2.5.
@@ -507,6 +509,7 @@ class SymPyTests(object):
         return self._reporter.finish()
 
     def test_file(self, filename):
+        clear_cache()
         name = "test%d" % self._count
         name = os.path.splitext(os.path.basename(filename))[0]
         self._count += 1
@@ -628,6 +631,7 @@ class SymPyDocTests(object):
         return self._reporter.finish()
 
     def test_file(self, filename):
+        clear_cache()
 
         import unittest
         from StringIO import StringIO


### PR DESCRIPTION
This fixes the bloated memory usage of our test runner, see issue 2585.
It went up to ~450 MB; it doesn't pass 200 MB now. There shouldn't be
any slowdown due to this (and anecdotally, there isn't).

Signed-off-by: Vladimir Perić vlada.peric@gmail.com

Simple commit, really. I'm putting down Tom as the author as he had the idea and the original patch.
