### PR TITLE
More robust way of recognizing Linux operating systems

### DIFF
--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -1157,7 +1157,7 @@ def xdvi(filename='tmplatex.tex',debug=False):
         if debug: #Display latex excution output for debugging purposes
             os.system(latex_str+' '+filename[:-4])
         else: #Works for Linux don't know about Windows
-            if sys.platform == 'linux2':
+            if sys.platform.startswith('linux'):
                 os.system(latex_str+' '+filename[:-4]+' > /dev/null')
             else:
                 os.system(latex_str+' '+filename[:-4]+' > NUL')


### PR DESCRIPTION
Originally Linux operating systems were recognized by checking if sys.platform is equal to 'linux2'. This approach isn't sufficient anymore with the release of Linux kernel 3.0, which uses 'linux3' identification string. See http://bugs.python.org/issue12326 for details.
