### PR TITLE
Fixed handling of corner cases in dmp_cancel()

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1827,12 +1827,6 @@ def dmp_cancel(f, g, u, K, include=True):
     ([[2], [2]], [[1], [-1]])
 
     """
-    if dmp_zero_p(f, u) or dmp_zero_p(g, u):
-        if include:
-            return f, g
-        else:
-            return K.one, K.one, f, g
-
     K0 = None
 
     if K.has_Field and K.has_assoc_Ring:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5300,6 +5300,10 @@ def cancel(f, *gens, **args):
             return f
         else:
             p, q = f.as_numer_denom()
+
+            # XXX: remove this when issue #281 is fixed
+            if p.is_zero or q.is_zero:
+                return f
     else:
         p, q = f
 

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -610,6 +610,15 @@ def test_dup_cancel():
     assert dup_cancel(f, g, ZZ) == (f, g)
     assert dup_cancel(F, G, ZZ) == (f, g)
 
+    assert dup_cancel([], [], ZZ) == ([], [])
+    assert dup_cancel([], [], ZZ, include=False) == (ZZ(1), ZZ(1), [], [])
+
+    assert dup_cancel([ZZ(1), ZZ(0)], [], ZZ) == ([ZZ(1)], [])
+    assert dup_cancel([ZZ(1), ZZ(0)], [], ZZ, include=False) == (ZZ(1), ZZ(1), [ZZ(1)], [])
+
+    assert dup_cancel([], [ZZ(1), ZZ(0)], ZZ) == ([], [ZZ(1)])
+    assert dup_cancel([], [ZZ(1), ZZ(0)], ZZ, include=False) == (ZZ(1), ZZ(1), [], [ZZ(1)])
+
 def test_dmp_cancel():
     f = ZZ.map([[2], [0], [-2]])
     g = ZZ.map([[1], [-2], [1]])
@@ -619,3 +628,12 @@ def test_dmp_cancel():
 
     assert dmp_cancel(f, g, 1, ZZ) == (p, q)
     assert dmp_cancel(f, g, 1, ZZ, include=False) == (ZZ(1), ZZ(1), p, q)
+
+    assert dmp_cancel([[]], [[]], 1, ZZ) == ([[]], [[]])
+    assert dmp_cancel([[]], [[]], 1, ZZ, include=False) == (ZZ(1), ZZ(1), [[]], [[]])
+
+    assert dmp_cancel([[ZZ(1), ZZ(0)]], [[]], 1, ZZ) == ([[ZZ(1)]], [[]])
+    assert dmp_cancel([[ZZ(1), ZZ(0)]], [[]], 1, ZZ, include=False) == (ZZ(1), ZZ(1), [[ZZ(1)]], [[]])
+
+    assert dmp_cancel([[]], [[ZZ(1), ZZ(0)]], 1, ZZ) == ([[]], [[ZZ(1)]])
+    assert dmp_cancel([[]], [[ZZ(1), ZZ(0)]], 1, ZZ, include=False) == (ZZ(1), ZZ(1), [[]], [[ZZ(1)]])


### PR DESCRIPTION
This fixes the problem from http://groups.google.com/group/sympy/browse_thread/thread/d2657bf62f6fddb1:

<pre>
In [1]: Poly(0, x).cancel(Poly(0, x))
Out[1]: (1, Poly(0, x, domain='ZZ'), Poly(0, x, domain='ZZ'))

In [2]: Poly(0, x).cancel(Poly(x, x))
Out[2]: (1, Poly(0, x, domain='ZZ'), Poly(1, x, domain='ZZ'))

In [3]: Poly(x, x).cancel(Poly(0, x))
Out[3]: (1, Poly(1, x, domain='ZZ'), Poly(0, x, domain='ZZ'))
</pre>

The `include=False` case is handled as follows:

<pre>
In [4]: Poly(0, x).cancel(Poly(x/2, x))
Out[4]: (2, Poly(0, x, domain='QQ'), Poly(1, x, domain='QQ'))

In [5]: Poly(x/2, x).cancel(Poly(0, x))
Out[5]: (1/2, Poly(1, x, domain='QQ'), Poly(0, x, domain='QQ'))
</pre>

This is correct, but could be refined to always return `1`.
