### PR TITLE
Update code quality tests

### DIFF
--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 from sympy.core.compatibility import reduce
 
 from os import walk, sep, chdir, pardir
@@ -35,7 +36,10 @@ message_gen_raise = "File contains generic exception: %s, line %s"
 message_old_raise = "File contains old style raise statement: %s, line %s, \"%s\""
 message_eof = "File does not end with a newline: %s, line %s"
 
-implicit_test_re = re.compile('^\s*(>>> )?from .* import .*\*')
+implicit_test_re = re.compile('^\s*(>>> )?(\.\.\. )?from .* import .*\*')
+str_raise_re = re.compile(r'^\s*(>>> )?(\.\.\. )?raise(\s+(\'|\")|\s*(\(\s*)+(\'|\"))')
+gen_raise_re = re.compile(r'^\s*(>>> )?(\.\.\. )?raise(\s+Exception|\s*(\(\s*)+Exception)')
+old_raise_re = re.compile(r'^\s*(>>> )?(\.\.\. )?raise(\s+\w+\s*,)')
 
 def tab_in_leading(s):
     """Returns True if there are tabs in the leading whitespace of a line,
@@ -62,7 +66,7 @@ def check_directory_tree(base_path, file_check, exclusions=set()):
                 continue
             file_check(fname)
 
-def test_whitespace_and_exceptions():
+def test_files():
     """
     This test tests all files in sympy and checks that:
       o no lines contains a trailing whitespace
@@ -72,79 +76,39 @@ def test_whitespace_and_exceptions():
       o there are no general or string exceptions
       o there are no old style raise statements
     """
-    strRaise = re.compile(r'raise(\s+(\'|\")|\s*(\(\s*)+(\'|\"))')
-    genRaise = re.compile(r'raise(\s+Exception|\s*(\(\s*)+Exception)')
-    oldRaise = re.compile(r'raise(\s+\w+\s*,)')
 
     def test(fname):
-        file = open(fname, "rt") # without "t" the lines from all systems may appear to be \n terminated
-        try:
+        # without "t" the lines from all systems may appear to be \n terminated
+        with open(fname, "rt") as test_file:
             line = None # to flag the case where there were no lines in file
-            for idx, line in enumerate(file):
+            for idx, line in enumerate(test_file):
                 if line.endswith(" \n"):
                     assert False, message_space % (fname, idx+1)
                 if line.endswith("\r\n"):
                     assert False, message_carriage % (fname, idx+1)
                 if tab_in_leading(line):
                     assert False, message_tabs % (fname, idx+1)
-                if strRaise.search(line):
+                if str_raise_re.search(line):
                     assert False, message_str_raise % (fname, idx+1)
-                if genRaise.search(line):
+                if gen_raise_re.search(line):
                     assert False, message_gen_raise % (fname, idx+1)
+                if (implicit_test_re.search(line) and
+                    not filter(lambda ex: ex in fname, import_exclude)):
+                        assert False, message_implicit % (fname, idx+1)
 
-                result = oldRaise.search(line)
+                result = old_raise_re.search(line)
 
                 if result is not None:
-                    assert False, message_old_raise % (fname, idx+1, result.group())
-        finally:
-            if line != None:
+                    assert False, message_old_raise % (fname, idx+1, result.group(2))
+
+            if line is not None and not line.endswith('\n'):
                 # eof newline check
-                if not line.endswith('\n'):
-                    assert False, message_eof % (fname, idx+1)
-            file.close()
+                assert False, message_eof % (fname, idx+1)
 
     exclude = set([
         "%(sep)smpmath%(sep)s" % sepd,
     ])
-    check_directory_tree(SYMPY_PATH, test, exclude)
-    check_directory_tree(EXAMPLES_PATH, test, exclude)
-
-def test_implicit_imports_regular_expression():
-    candidates_ok = [
-            "from sympy import something",
-            ">>> from sympy import something",
-            "from sympy.somewhere import something",
-            ">>> from sympy.somewhere import something",
-            "import sympy",
-            ">>> import sympy",
-            "import sympy.something.something",
-            ]
-    candidates_fail = [
-            "from sympy import *",
-            ">>> from sympy import *",
-            "from sympy.somewhere import *",
-            ">>> from sympy.somewhere import *",
-            ]
-    for c in candidates_ok:
-        assert implicit_test_re.search(c) is None
-    for c in candidates_fail:
-        assert implicit_test_re.search(c) is not None
-
-def test_implicit_imports():
-    """
-    Tests that all files except __init__.py use explicit imports,
-    even in the docstrings.
-    """
-    def test(fname):
-        file = open(fname, "r")
-        try:
-            for idx, line in enumerate(file):
-                if implicit_test_re.search(line):
-                    assert False, message_implicit % (fname, idx+1)
-        finally:
-            file.close()
-
-    exclude = set([
+    import_exclude = set([
         "%(sep)s__init__.py" % sepd,
         "%(sep)sinteractive%(sep)ssession.py" % sepd,
         # Taken from Python stdlib:
@@ -155,3 +119,144 @@ def test_implicit_imports():
     ])
     check_directory_tree(SYMPY_PATH, test, exclude)
     check_directory_tree(EXAMPLES_PATH, test, exclude)
+
+def test_raise_statement_regular_expression():
+    candidates_ok = [
+        "some text # raise Exception, 'text'",
+        "    some text # raise Exception, 'text'",
+        "raise ValueError('text') # raise Exception, 'text'",
+        "    raise ValueError('text') # raise Exception, 'text'",
+        "raise ValueError('text')",
+        "    raise ValueError('text')",
+        "raise ValueError",
+        "    raise ValueError",
+        "raise ValueError('text')",
+        "    raise ValueError('text')",
+        "raise ValueError('text') #,",
+        "    raise ValueError('text') #,",
+        # Talking about an exception in a docstring
+        ''''"""This function will raise ValueError, except when it doesn't"""''',
+    ]
+    str_candidates_fail = [
+        "raise 'exception'",
+        "    raise 'exception'",
+        "raise 'Exception'",
+        "    raise 'Exception'",
+        'raise "exception"',
+        '    raise "exception"',
+        'raise "Exception"',
+        '    raise "Exception"',
+        "raise 'ValueError'",
+        "    raise 'ValueError'",
+    ]
+    gen_candidates_fail = [
+        "raise Exception('text') # raise Exception, 'text'",
+        "    raise Exception('text') # raise Exception, 'text'",
+        "raise Exception('text')",
+        "    raise Exception('text')",
+        "raise Exception",
+        "    raise Exception",
+        "raise Exception('text')",
+        "    raise Exception('text')",
+        "raise Exception('text') #,",
+        "    raise Exception('text') #,",
+        "raise Exception, 'text'",
+        "    raise Exception, 'text'",
+        "raise Exception, 'text' # raise Exception('text')",
+        "    raise Exception, 'text' # raise Exception('text')",
+        "raise Exception, 'text' # raise Exception, 'text'",
+        "    raise Exception, 'text' # raise Exception, 'text'",
+        ">>> raise Exception, 'text'",
+        "    >>> raise Exception, 'text'",
+        ">>> raise Exception, 'text' # raise Exception('text')",
+        "    >>> raise Exception, 'text' # raise Exception('text')",
+        ">>> raise Exception, 'text' # raise Exception, 'text'",
+        "    >>> raise Exception, 'text' # raise Exception, 'text'",
+    ]
+    old_candidates_fail = [
+        "raise Exception, 'text'",
+        "    raise Exception, 'text'",
+        "raise Exception, 'text' # raise Exception('text')",
+        "    raise Exception, 'text' # raise Exception('text')",
+        "raise Exception, 'text' # raise Exception, 'text'",
+        "    raise Exception, 'text' # raise Exception, 'text'",
+        ">>> raise Exception, 'text'",
+        "    >>> raise Exception, 'text'",
+        ">>> raise Exception, 'text' # raise Exception('text')",
+        "    >>> raise Exception, 'text' # raise Exception('text')",
+        ">>> raise Exception, 'text' # raise Exception, 'text'",
+        "    >>> raise Exception, 'text' # raise Exception, 'text'",
+        "raise ValueError, 'text'",
+        "    raise ValueError, 'text'",
+        "raise ValueError, 'text' # raise Exception('text')",
+        "    raise ValueError, 'text' # raise Exception('text')",
+        "raise ValueError, 'text' # raise Exception, 'text'",
+        "    raise ValueError, 'text' # raise Exception, 'text'",
+        ">>> raise ValueError, 'text'",
+        "    >>> raise ValueError, 'text'",
+        ">>> raise ValueError, 'text' # raise Exception('text')",
+        "    >>> raise ValueError, 'text' # raise Exception('text')",
+        ">>> raise ValueError, 'text' # raise Exception, 'text'",
+        "    >>> raise ValueError, 'text' # raise Exception, 'text'",
+    ]
+    for c in candidates_ok:
+        assert str_raise_re.search(c) is None, c
+        assert gen_raise_re.search(c) is None, c
+        assert old_raise_re.search(c) is None, c
+    for c in str_candidates_fail:
+        assert str_raise_re.search(c) is not None, c
+    for c in gen_candidates_fail:
+        assert gen_raise_re.search(c) is not None, c
+    for c in old_candidates_fail:
+        assert old_raise_re.search(c) is not None, c
+
+
+def test_implicit_imports_regular_expression():
+    candidates_ok = [
+        "from sympy import something",
+        "    from sympy import something",
+        ">>> from sympy import something",
+        "    >>> from sympy import something",
+        "from sympy.somewhere import something",
+        "    from sympy.somewhere import something",
+        ">>> from sympy.somewhere import something",
+        "    >>> from sympy.somewhere import something",
+        "import sympy",
+        "    import sympy",
+        ">>> import sympy",
+        "    >>> import sympy",
+        "import sympy.something.something",
+        "    import sympy.something.something",
+        "... import sympy",
+        "    ... import sympy",
+        "... import sympy.something.something",
+        "    ... import sympy.something.something",
+        "... from sympy import something",
+        "    ... from sympy import something",
+        "... from sympy.somewhere import something",
+        "    ... from sympy.somewhere import something",
+        ">> from sympy import *", # To allow 'fake' docstrings
+        "    >> from sympy import *",
+        "# from sympy import *",
+        "    # from sympy import *",
+        "some text # from sympy import *",
+        "    some text # from sympy import *",
+    ]
+    candidates_fail = [
+        "from sympy import *",
+        "    from sympy import *",
+        ">>> from sympy import *",
+        "    >>> from sympy import *",
+        "from sympy.somewhere import *",
+        "    from sympy.somewhere import *",
+        ">>> from sympy.somewhere import *",
+        "     >>> from sympy.somewhere import *",
+        "... from sympy import *",
+        "    ... from sympy import *",
+        "... from sympy.somwhere import *",
+        "    ... from sympy.somwhere import *",
+    ]
+    for c in candidates_ok:
+        assert implicit_test_re.search(c) is None, c
+    for c in candidates_fail:
+        assert implicit_test_re.search(c) is not None, c


### PR DESCRIPTION
The exception tests were updated to handle more cases better.  For
example, it now correctly gets stuff in doctests, but ignores talking
about an exception in a docstring (like "this function will raise
NotImplementedError, in which case the case is not implemented", which
previously was flagged as an old style raise statement).

Tests were added for the exception regular expressions.

I also fixed the import regular expression to handle ... from a
docstring and added more tests for the regular expression.

Finally, I made the tests only open each file once, and made the open()
block use a with statement.
