### PR TITLE
Improve jn_zeros().

### DIFF
--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -76,16 +76,3 @@ def test_jn_zeros():
     assert eq(jn_zeros(2, 4), [5.763459, 9.095011, 12.322940, 15.514603])
     assert eq(jn_zeros(3, 4), [6.987932, 10.417118, 13.698023, 16.923621])
     assert eq(jn_zeros(4, 4), [8.182561, 11.704907, 15.039664, 18.301255])
-
-def test_jn_zeros_mpmath():
-    try:
-        from mpmath import besseljzero
-    except ImportError:
-        skip("Cannot import mpmath.besseljzero.")
-    zeros = lambda n, k: jn_zeros(n, k, method='mpmath')
-    assert eq(zeros(0, 4), [3.141592, 6.283185, 9.424777, 12.566370])
-    assert eq(zeros(1, 4), [4.493409, 7.725251, 10.904121, 14.066193])
-    assert eq(zeros(2, 4), [5.763459, 9.095011, 12.322940, 15.514603])
-    assert eq(zeros(3, 4), [6.987932, 10.417118, 13.698023, 16.923621])
-    assert eq(zeros(4, 4), [8.182561, 11.704907, 15.039664, 18.301255])
-


### PR DESCRIPTION
In reference to issue 2590:

The function jn_zeros() computes the first `n` zeros of the spherical
bessel function jn of order `nu`, `nu` being real. It used to use a
generic mpmath solving routine, and return python floats.

This commit updates jn_zeros() to

o Use the mpmath function besseljzeros - this is now in the version of
  mpmath shipped with sympy.
o Return sympy Floats (unless computing using scypy).
o Accept an argument dps which controles the precision of the output for
  method sympy.

Also erase a test for method=mpmath (now default), and update the doctest.
