### PR TITLE
Fix pretty printing of meijerg objects with many parameters.

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -699,6 +699,16 @@ class PrettyPrinter(Printer):
         pq = self._print(len(e.bq))
         pm = self._print(len(e.bm))
         pn = self._print(len(e.an))
+        def adjust(p1, p2):
+            diff = p1.width() - p2.width()
+            if diff == 0:
+                return p1, p2
+            elif diff > 0:
+                return p1, prettyForm(*p2.left(' '*diff))
+            else:
+                return prettyForm(*p1.left(' '*-diff)), p2
+        pp, pm = adjust(pp, pm)
+        pq, pn = adjust(pq, pn)
         pu = prettyForm(*pm.right(', ', pn))
         pl = prettyForm(*pp.right(', ', pq))
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2716,3 +2716,21 @@ u"""\
 """
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+
+    ucode_str = \
+u"""\
+╭─╮ 1, 10 ⎛1, 1, 1, 1, 1, 1, 1, 1, 1, 1  1 │  ⎞\n\
+│╶┐       ⎜                                │ z⎟\n\
+╰─╯11,  2 ⎝             1                1 │  ⎠\
+"""
+    ascii_str = \
+"""\
+ __ 1, 10 /1, 1, 1, 1, 1, 1, 1, 1, 1, 1  1 |  \\\n\
+/__       |                                | z|\n\
+\_|11,  2 \\             1                1 |  /\
+"""
+
+    expr = meijerg([1]*10, [1], [1], [1], z)
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str


### PR DESCRIPTION
In reference to issue 2604.

Used to be:

```
In [3]: meijerg([1], [1], [1], [1]*10, z)
Out[3]:
╭─╮ 1, 1 ⎛1               1               │  ⎞
│╶┐      ⎜                                │ z⎟
╰─╯2, 11 ⎝1  1, 1, 1, 1, 1, 1, 1, 1, 1, 1 │  ⎠
```

is now:

```
In [1]: meijerg([1], [1], [1], [1]*10, z)
Out[1]:
╭─╮1,  1 ⎛1               1               │  ⎞
│╶┐      ⎜                                │ z⎟
╰─╯2, 11 ⎝1  1, 1, 1, 1, 1, 1, 1, 1, 1, 1 │  ⎠
```
