### PR TITLE
Improvements to latex(Integral)

### DIFF
--- a/doc/src/tutorial.txt
+++ b/doc/src/tutorial.txt
@@ -817,7 +817,7 @@ Tip: To make the pretty printing default in the python interpreter, use::
     >>> latex(1/x)
     \frac{1}{x}
     >>> latex(Integral(x**2, x))
-    \int x^{2}\,dx
+    \int x^{2}\, dx
 
 **MathML**
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -346,25 +346,33 @@ class LatexPrinter(Printer):
     def _print_Integral(self, expr):
         tex, symbols = "", []
 
-        for lim in reversed(expr.limits):
-            symbol = lim[0]
-            tex += r"\int"
+        # Only up to \iiiint exists
+        if len(expr.limits) <= 4 and all(len(lim) == 1 for lim in expr.limits):
+            # Use len(expr.limits)-1 so that syntax highlighters don't think
+            # \" is an escaped quote
+            tex = r"\i" + "i"*(len(expr.limits)-1) + "nt"
+            symbols = [r"\, d%s" % self._print(symbol[0]) for symbol in expr.limits]
 
-            if len(lim) > 1:
-                if self._settings['mode'] in ['equation','equation*'] \
-                   and not self._settings['itex']:
-                    tex += r"\limits"
+        else:
+            for lim in reversed(expr.limits):
+                symbol = lim[0]
+                tex += r"\int"
 
-                if len(lim) == 3:
-                    tex += "_{%s}^{%s}" % (self._print(lim[1]),
-                                           self._print(lim[2]))
-                if len(lim) == 2:
-                    tex += "^{%s}" % (self._print(lim[1]))
+                if len(lim) > 1:
+                    if self._settings['mode'] in ['equation','equation*'] \
+                       and not self._settings['itex']:
+                        tex += r"\limits"
 
-            symbols.insert(0, "d%s" % self._print(symbol))
+                    if len(lim) == 3:
+                        tex += "_{%s}^{%s}" % (self._print(lim[1]),
+                                               self._print(lim[2]))
+                    if len(lim) == 2:
+                        tex += "^{%s}" % (self._print(lim[1]))
 
-        return r"%s %s\,%s" % (tex,
-            str(self._print(expr.function)), " ".join(symbols))
+                symbols.insert(0, r"\, d%s" % self._print(symbol))
+
+        return r"%s %s%s" % (tex,
+            str(self._print(expr.function)), "".join(symbols))
 
     def _print_Limit(self, expr):
         e, z, z0, dir = expr.args

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -7,8 +7,8 @@ from sympy.printing.latex import latex
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.functions import DiracDelta
 
-x,y = symbols('x,y')
-k,n = symbols('k,n', integer=True)
+x, y, z, t = symbols('x y z t')
+k, n = symbols('k n', integer=True)
 
 def test_printmethod():
     class R(Abs):
@@ -142,14 +142,23 @@ def test_latex_derivatives():
     r"\frac{\partial}{\partial x}\left(x^{2} + \operatorname{sin}\left(x\right)\right)"
 
 def test_latex_integrals():
-    assert latex(Integral(log(x), x)) == r"\int \operatorname{log}\left(x\right)\,dx"
-    assert latex(Integral(x**2, (x,0,1))) == r"\int_{0}^{1} x^{2}\,dx"
-    assert latex(Integral(x**2, (x,10,20))) == r"\int_{10}^{20} x^{2}\,dx"
-    assert latex(Integral(y*x**2, (x,0,1), y)) == r"\int\int_{0}^{1} x^{2} y\,dx dy"
+    assert latex(Integral(log(x), x)) == r"\int \operatorname{log}\left(x\right)\, dx"
+    assert latex(Integral(x**2, (x,0,1))) == r"\int_{0}^{1} x^{2}\, dx"
+    assert latex(Integral(x**2, (x,10,20))) == r"\int_{10}^{20} x^{2}\, dx"
+    assert latex(Integral(y*x**2, (x,0,1), y)) == r"\int\int_{0}^{1} x^{2} y\, dx\, dy"
     assert latex(Integral(y*x**2, (x,0,1), y), mode='equation*') \
-        == r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\,dx dy\end{equation*}"
+        == r"\begin{equation*}\int\int\limits_{0}^{1} x^{2} y\, dx\, dy\end{equation*}"
     assert latex(Integral(y*x**2, (x,0,1), y), mode='equation*', itex=True) \
-        == r"$$\int\int_{0}^{1} x^{2} y\,dx dy$$"
+        == r"$$\int\int_{0}^{1} x^{2} y\, dx\, dy$$"
+    assert latex(Integral(x, (x, 0))) == r"\int^{0} x\, dx"
+    assert latex(Integral(x*y, x, y)) == r"\iint x y\, dx\, dy"
+    assert latex(Integral(x*y*z, x, y, z)) == r"\iiint x y z\, dx\, dy\, dz"
+    assert latex(Integral(x*y*z*t, x, y, z, t)) == \
+        r"\iiiint t x y z\, dx\, dy\, dz\, dt"
+    assert latex(Integral(x, x, x, x, x, x, x)) == \
+        r"\int\int\int\int\int\int x\, dx\, dx\, dx\, dx\, dx\, dx"
+    assert latex(Integral(x, x, y, (z, 0, 1))) == \
+        r"\int_{0}^{1}\int\int x\, dx\, dy\, dz"
 
 def test_latex_intervals():
     a = Symbol('a', real=True)


### PR DESCRIPTION
The improvements are:
- Print multiple indefinite integrals (up to four) as \iint, \iiint, or
  \iiiint.  See issue 2538.
- Print \, before each dsymbol.
- Print a space after each \,.
