### PR TITLE
Fixes to Integer.__divmod__

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1016,7 +1016,18 @@ class Integer(Rational):
             return Integer(-self.p)
 
     def __divmod__(self, other):
-        return divmod(self.p, other.p)
+        from containers import Tuple
+        if isinstance(other, Integer):
+            return Tuple(*(divmod(self.p, other.p)))
+        else:
+            return Tuple(*(divmod(self.p, other)))
+
+    def __rdivmod__(self, other):
+        from containers import Tuple
+        if isinstance(other, Integer):
+            return Tuple(*divmod(other.p, self.p))
+        else:
+            return Tuple(*divmod(other, self.p))
 
     # TODO make it decorator + bytecodehacks?
     def __add__(a, b):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1,6 +1,6 @@
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
-                   Number, zoo, log, Mul, Pow)
+                   Number, zoo, log, Mul, Pow, Tuple)
 from sympy.core.power import integer_nthroot
 
 from sympy.core.numbers import igcd, ilcm, igcdex, seterr, _intcache
@@ -81,11 +81,13 @@ def test_mod():
     assert 15 % Integer(4) == Integer(3)
 
 def test_divmod():
-    assert divmod(S(12), S(8)) == (1, 4)
-    assert divmod(-S(12), S(8)) == (-2, 4)
-    assert divmod(S(0), S(1)) == (0, 0)
+    assert divmod(S(12), S(8)) == Tuple(1, 4)
+    assert divmod(-S(12), S(8)) == Tuple(-2, 4)
+    assert divmod(S(0), S(1)) == Tuple(0, 0)
     raises(ZeroDivisionError, "divmod(S(0), S(0))")
     raises(ZeroDivisionError, "divmod(S(1), S(0))")
+    assert divmod(S(12), 8) == Tuple(1, 4)
+    assert divmod(12, S(8)) == Tuple(1, 4)
 
 def test_igcd():
     assert igcd(0, 0) == 0


### PR DESCRIPTION
This was only working correctly if both arguments were sympified.  Now `divmod(int, Integer)` and `divmod(Integer, int)` both work correctly. Also, change it to return a Tuple.  See issue 2613.
