### PR TITLE
Fix for issue #2631- preserve ordering of non-commutative symbols in deltaintegrate

### DIFF
--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -34,10 +34,15 @@ def change_mul(node, x):
     """
     if not node.is_Mul:
         return node
+
     new_args = []
     dirac = None
-    sorted_args = list(node.args)
-    sorted_args.sort(key=default_sort_key)
+
+    #Sorting is needed so that we consistently collapse the same delta;
+    #However, we must preserve the ordering of non-commutative terms
+    c, nc = node.args_cnc()
+    sorted_args = sorted(c, key=default_sort_key)
+    sorted_args.extend(nc)
 
     for arg in sorted_args:
         if arg.func == DiracDelta and arg.is_simple(x) \

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -349,6 +349,15 @@ def test_integrate_DiracDelta():
     assert integrate((x+1)*DiracDelta(2*x), (x, -oo, oo)) == S(1)/2
     assert integrate((x+1)*DiracDelta(2*x/3 + 4/S(9)), (x, -oo, oo)) == S(1)/2
 
+    a, b, c = symbols('a b c', commutative=False)
+    assert integrate(DiracDelta(x - y)*f(x - b)*f(x - a), (x, -oo, oo)) == \
+           f(y - b)*f(y - a)
+    assert integrate(f(x - a)*DiracDelta(x - y)*f(x - c)*f(x - b), \
+                     (x, -oo, oo)) == f(y - a)*f(y - c)*f(y - b)
+
+    assert integrate(DiracDelta(x - z)*f(x - b)*f(x - a)*DiracDelta(x - y), \
+                     (x, -oo, oo)) == DiracDelta(y - z)*f(y - b)*f(y - a)
+
 def test_subs1():
     e = Integral(exp(x-y), x)
     assert e.subs(y, 3) == Integral(exp(x-3), x)


### PR DESCRIPTION
Fix for issue #2631- preserve ordering of non-commutative symbols in deltaintegrate

Issue 2631 [0] describes most of the details of this problem. In a previous pull request [1], I inserted some code to sort the arguments of the Mul in deltaintegrate so that the same delta function was collapsed on every machine (due to issue 2509 [2]). However, in doing this sorting, we completely clobber the ordering of non-commutative terms.

So, this PR adds code to sort only the commutative terms of the Mul. I don't know if there's a more efficient way to do it than what I have here, but I think this way works ok. 

[0] http://code.google.com/p/sympy/issues/detail?id=2631
[1] https://github.com/sympy/sympy/pull/457
[2] http://code.google.com/p/sympy/issues/detail?id=2509
