### PR TITLE
2390: factor obeys power rules

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4861,7 +4861,7 @@ def _symbolic_factor_list(expr, opt, method):
                         f, k = unk
                         factors.append((f, k*exp))
                     else:
-                        factors.append((Poly(Mul(*(f.as_expr()**k for f, k in unk)), opt), exp))
+                        factors.append((_poly_from_expr(Mul(*(f.as_expr()**k for f, k in unk)), opt)[0], exp))
 
     return coeff, factors
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1,7 +1,7 @@
 """User-friendly public interface to polynomial functions. """
 
 from sympy.core import (
-    S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple
+    S, Basic, Expr, I, Integer, Add, Mul, Dummy, Tuple, Pow
 )
 
 from sympy.core.sympify import (
@@ -4850,8 +4850,10 @@ def _symbolic_factor_list(expr, opt, method):
                 if exp is S.One:
                     factors.extend(_factors)
                 else:
-                    for factor, k in _factors:
-                        factors.append((factor, k*exp))
+                    muls = Mul(*(b.as_expr()**e for b, e in _factors))**exp
+                    for m in Mul.make_args(muls):
+                        b, e = m.as_base_exp()
+                        factors.append((Poly(b), e))
 
     return coeff, factors
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1880,11 +1880,15 @@ def test_factor():
     assert factor(f, x) == u*v**2*w
     assert factor(f, (x,)) == u*v**2*w
 
-    g, p, q = x**2 - y**2, x - y, x + y
+    g, p, q, r = x**2 - y**2, x - y, x + y, x**2 + 1
+    i = symbols('i', integer=True)
 
     assert factor(f/g) == (u*v**2*w)/(p*q)
     assert factor(f/g, x) == (u*v**2*w)/(p*q)
     assert factor(f/g, (x,)) == (u*v**2*w)/(p*q)
+    assert factor(sqrt(x*y)).is_Pow
+    assert factor(sqrt(3 + 3*x**2)) == sqrt(3)*sqrt(r)
+    assert factor((y + y*x**2)**i) == y**i*r**i
 
     f = Poly(sin(1)*x + 1, x, domain=EX)
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -444,7 +444,7 @@ def test_separatevars():
     assert separatevars(pi*x*z+pi*x*y*z) == pi*x*z*(1+y)
     assert separatevars(x*y**2*sin(x) + x*sin(x)*sin(y)) == x*(sin(y) + y**2)*sin(x)
     assert separatevars(x*exp(x+y)+x*exp(x)) == x*(1 + exp(y))*exp(x)
-    assert separatevars((x*(y+1))**z) == x**z*(1 + y)**z
+    assert separatevars((x*(y+1))**z).is_Pow # != x**z*(1 + y)**z
     assert separatevars(1+x+y+x*y) == (x+1)*(y+1)
     assert separatevars(y / pi * exp(-(z - x) / cos(n))) == y * exp((x - z) / cos(n)) / pi
     # 1759


### PR DESCRIPTION
This disallows `sqrt(x*y)` to factor to `sqrt(x)*sqrt(y)` and allows `(((x+y)*(x+1)).expand())**i` to factor to `(x+y)**i*(x+1)**i`
