### PR TITLE
apart(f, full=True) gives linear denominators (#2548)

### DIFF
--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -53,7 +53,10 @@ def apart(f, x=None, full=False, **args):
     terms = S.Zero
 
     for term in Add.make_args(partial):
-        terms += factor(term)
+        if term.has(RootSum):
+            terms += term
+        else:
+            terms += factor(term)
 
     return common*(poly.as_expr() + terms)
 
@@ -154,8 +157,7 @@ def apart_full_decomposition(P, Q):
             numer = b.as_expr()
             denom = (x-a)**(n-j)
 
-            expr = numer.subs(x, a) / denom
-
-            partial += RootSum(D, Lambda(a, expr))
+            func = Lambda(a, numer.subs(x, a)/denom)
+            partial += RootSum(D, func, auto=False)
 
     return partial

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -2970,8 +2970,7 @@ class Poly(Expr):
 
         """
         if f.is_multivariate:
-            raise MultivariatePolynomialError("can't compute numerical roots "
-                                              "of %s" % f)
+            raise MultivariatePolynomialError("can't compute numerical roots of %s" % f)
 
         if f.degree() <= 0:
             return []

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -11,8 +11,8 @@ from sympy.polys.rootisolation import (
     dup_isolate_real_roots_sqf)
 
 from sympy.polys.polyroots import (
-    roots_linear, roots_quadratic,
-    roots_binomial, preprocess_roots)
+    roots_linear, roots_quadratic, roots_binomial,
+    preprocess_roots, roots)
 
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -653,10 +653,15 @@ class RootSum(Expr):
         return True
 
     def doit(self, **hints):
-        if hints.get('roots', True):
-            return Add(*map(self.fun, self.poly.all_roots()))
-        else:
+        if not hints.get('roots', True):
             return self
+
+        _roots = roots(self.poly, multiple=True)
+
+        if len(_roots) < self.poly.degree():
+            return self
+        else:
+            return Add(*[ self.fun(r) for r in _roots ])
 
     def _eval_derivative(self, x):
         var, expr = self.fun.args

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -17,12 +17,13 @@ from sympy.polys.polyroots import (
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
     GeneratorsNeeded,
-    PolynomialError)
+    PolynomialError,
+    DomainError)
 
 from sympy.polys.domains import QQ
 
-from sympy.mpmath import (
-    mp, mpf, mpc, findroot)
+from sympy.mpmath import mp, mpf, mpc, findroot
+from sympy.mpmath.libmp.libmpf import prec_to_dps
 
 from sympy.utilities import lambdify
 
@@ -659,6 +660,14 @@ class RootSum(Expr):
         _roots = roots(self.poly, multiple=True)
 
         if len(_roots) < self.poly.degree():
+            return self
+        else:
+            return Add(*[ self.fun(r) for r in _roots ])
+
+    def _eval_evalf(self, prec):
+        try:
+            _roots = self.poly.nroots(n=prec_to_dps(prec))
+        except (DomainError, PolynomialError):
             return self
         else:
             return Add(*[ self.fun(r) for r in _roots ])

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -6,7 +6,7 @@ from sympy.polys.partfrac import (
     apart,
 )
 
-from sympy import S, Poly, E, pi, I, Matrix, Eq
+from sympy import S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y, a, b, c
 
@@ -60,6 +60,24 @@ def test_apart_extension():
     assert apart(f, extension=I) == g
     assert apart(f, gaussian=True) == g
 
+def test_apart_full():
+    f = 1/(x**2 + 1)
+
+    assert apart(f, full=False) == f
+    assert apart(f, full=True) == -RootSum(x**2 + 1, Lambda(a, a/(x - a)), auto=False)/2
+
+    f = 1/(x**3 + x + 1)
+
+    assert apart(f, full=False) == f
+    assert apart(f, full=True) == RootSum(x**3 + x + 1, Lambda(a, (6*a**2/31 - 9*a/31 + S(4)/31)/(x - a)), auto=False)
+
+    f = 1/(x**5 + 1)
+
+    assert apart(f, full=False) == \
+        (-S(1)/5)*((x**3 - 2*x**2 + 3*x - 4)/(x**4 - x**3 + x**2 - x + 1)) + (S(1)/5)/(x + 1)
+    assert apart(f, full=True) == \
+        -RootSum(x**4 - x**3 + x**2 - x + 1, Lambda(a, a/(x - a)), auto=False)/5 + (S(1)/5)/(x + 1)
+
 def test_apart_undetermined_coeffs():
     p = Poly(2*x - 3)
     q = Poly(x**9 - x**8 - x**6 + x**5 - 2*x**2 + 3*x - 1)
@@ -72,10 +90,3 @@ def test_apart_undetermined_coeffs():
     r = 1/((x + b)*(a - b)) + 1/((x + a)*(b - a))
 
     assert apart_undetermined_coeffs(p, q) == r
-
-def test_apart_full_decomposition():
-    p = Poly(1, x)
-    q = Poly(x**5 + 1, x)
-
-    assert apart_full_decomposition(p, q) == \
-        (-S(1)/5)*((x**3 - 2*x**2 + 3*x - 4)/(x**4 - x**3 + x**2 - x + 1)) + (S(1)/5)/(x + 1)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -173,16 +173,11 @@ def test_RootSum___new__():
     g = Lambda(r, log(r*x))
     s = RootSum(f, g)
 
-    rootofs = sum(log(RootOf(f, i)*x) for i in (0, 1, 2))
-
     assert isinstance(s, RootSum) == True
-    assert s.doit() == rootofs
 
     assert RootSum(f**2, g) == 2*RootSum(f, g)
-    assert RootSum(f**2, g).doit() == 2*rootofs
-
     assert RootSum((x - 7)*f**3, g) == log(7*x) + 3*RootSum(f, g)
-    assert RootSum((x - 7)*f**3, g).doit() == log(7*x) + 3*rootofs
+
     # Issue 2472
     assert hash(RootSum((x - 7)*f**3, g)) == hash(log(7*x) + 3*RootSum(f, g))
 
@@ -230,6 +225,17 @@ def test_RootSum___eq__():
 
     assert (RootSum(x**3 + x + 1, f) == RootSum(x**3 + x + 2, f)) == False
     assert (RootSum(x**3 + x + 1, f) == RootSum(y**3 + y + 2, f)) == False
+
+def test_RootSum_doit():
+    rs = RootSum(x**2 + 1, exp)
+
+    assert isinstance(rs, RootSum) == True
+    assert rs.doit() == exp(-I) + exp(I)
+
+    rs = RootSum(x**2 + a, exp, x)
+
+    assert isinstance(rs, RootSum) == True
+    assert rs.doit() == exp(-sqrt(-a)) + exp(sqrt(-a))
 
 def test_RootSum_diff():
     f = x**3 + x + 3

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -237,6 +237,16 @@ def test_RootSum_doit():
     assert isinstance(rs, RootSum) == True
     assert rs.doit() == exp(-sqrt(-a)) + exp(sqrt(-a))
 
+def test_RootSum_evalf():
+    rs = RootSum(x**2 + 1, exp)
+
+    assert rs.evalf(n=20, chop=True).epsilon_eq(Float("1.0806046117362794348", 20), Float("1e-20")) == True
+    assert rs.evalf(n=15, chop=True).epsilon_eq(Float("1.08060461173628", 15), Float("1e-15")) == True
+
+    rs = RootSum(x**2 + a, exp, x)
+
+    assert rs.evalf() == rs
+
 def test_RootSum_diff():
     f = x**3 + x + 3
 


### PR DESCRIPTION
Example:

<pre>
In [1]: apart(1/(x**2 + 1), full=True)
Out[1]: 
        ⎛ 2       ⎛     a   ⎞⎞
-RootSum⎜x  + 1, Λ⎜a, ──────⎟⎟
        ⎝         ⎝   -a + x⎠⎠
──────────────────────────────
              2               

In [2]: _.doit()
Out[2]: 
    ⅈ           ⅈ    
───────── - ─────────
2⋅(x + ⅈ)   2⋅(x - ⅈ)

In [3]: apart(1/(x**3 + 1), full=True)
Out[3]: 
         ⎛ 2           ⎛     a   ⎞⎞            
  RootSum⎜x  - x + 1, Λ⎜a, ──────⎟⎟            
         ⎝             ⎝   -a + x⎠⎠       1    
- ───────────────────────────────── + ─────────
                  3                   3⋅(x + 1)

In [4]: _.doit()
Out[4]: 
            ⎽⎽⎽                   ⎽⎽⎽                  
      1   ╲╱ 3 ⋅ⅈ           1   ╲╱ 3 ⋅ⅈ                
      ─ - ───────           ─ + ───────                
      2      2              2      2              1    
- ─────────────────── - ─────────────────── + ─────────
    ⎛          ⎽⎽⎽  ⎞     ⎛          ⎽⎽⎽  ⎞   3⋅(x + 1)
    ⎜    1   ╲╱ 3 ⋅ⅈ⎟     ⎜    1   ╲╱ 3 ⋅ⅈ⎟            
  3⋅⎜x - ─ + ───────⎟   3⋅⎜x - ─ - ───────⎟            
    ⎝    2      2   ⎠     ⎝    2      2   ⎠     
</pre>

`apart(f, full=True)` always gives answer in terms of `RootSum` objects (besides the linear case). This way no radicals are introduced in the result by default (unless they were present in the input expression). To get an expression without `RootSum` objects, call `.doit()` on the result (`.doit()` uses `roots()` to compute symbolic roots of the polynomial).
