### PR TITLE
prefilter operations args for cls.identity

### DIFF
--- a/sympy/assumptions/handlers/calculus.py
+++ b/sympy/assumptions/handlers/calculus.py
@@ -121,14 +121,14 @@ class AskBoundedHandler(CommonHandler):
         """
         base_bounded = ask(Q.bounded(expr.base), assumptions)
         if not base_bounded:
-            return base_bounded
-        if ask(Q.bounded(expr.exp), assumptions) and base_bounded:
+            return False
+        if ask(Q.bounded(expr.exp), assumptions):# and base_bounded:
             return True
-        if base_bounded and expr.base.is_number:
+        if expr.base.is_number:# and base_bounded and not exp_bounded:
             # We need to implement relations for this
             if abs(expr.base) > 1:
                 return False
-            return True
+            return ask(~Q.negative(expr.exp), assumptions)
 
     @staticmethod
     def log(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -399,7 +399,9 @@ def test_bounded():
     assert ask(Q.bounded(2**x)) == False
     assert ask(Q.bounded(2**x), Q.bounded(x)) == True
     assert ask(Q.bounded(x**x)) == False
-    assert ask(Q.bounded(Rational(1,2) ** x)) == True
+    assert ask(Q.bounded(Rational(1,2) ** x)) == None
+    assert ask(Q.bounded(Rational(1,2) ** x), Q.positive(x)) == True
+    assert ask(Q.bounded(Rational(1,2) ** x), Q.negative(x)) == False
     assert ask(Q.bounded(x ** Rational(1,2))) == False
 
     # sign function

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -83,8 +83,16 @@ class Add(AssocOp):
                     seq.extend([c*a for a in s.args])
                     continue
 
-            # everything else
+            # check for unevaluated Pow, e.g. 2**3 or 2**(-1/2)
+            elif o.is_Pow:
+                b, e = o.as_base_exp()
+                if b.is_Number and (e.is_Integer or (e.is_Rational and e.is_negative)):
+                    seq.append(Pow(b, e))
+                    continue
+                c, s = S.One, o
+
             else:
+                # everything else
                 c = S.One
                 s = o
 
@@ -568,3 +576,4 @@ class Add(AssocOp):
 
 from function import FunctionClass
 from mul import Mul
+from power import Pow

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -819,7 +819,10 @@ class Mul(AssocOp):
             return S.One
         def check(l, r):
             if l.is_Float and r.is_comparable:
-                return Add(l, 0) == Add(r.evalf(), 0)
+                # if both objects are added to 0 they will share the same "normalization"
+                # and are more likely to compare the same. Since Add(foo, 0) will not allow
+                # the 0 to pass, we use __add__ directly.
+                return l.__add__(0) == r.evalf().__add__(0)
             return False
         if check(lhs, rhs) or check(rhs, lhs):
            return S.One

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -26,10 +26,20 @@ class AssocOp(Expr):
 
     @cacheit
     def __new__(cls, *args, **options):
+
         if len(args) == 0:
             return cls.identity
 
         args = map(_sympify, args)
+
+        try:
+            args = [a for a in args if a is not cls.identity]
+        except AttributeError:
+            pass
+
+        if len(args) == 0: # recheck after filtering
+            return cls.identity
+
         if len(args) == 1:
             return args[0]
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -249,9 +249,16 @@ class Pow(Expr):
         return Pow(self.base._eval_subs(old, new), self.exp._eval_subs(old, new))
 
     def as_base_exp(self):
-        if self.base.is_Rational and self.base.p==1 and self.base is not S.Infinity:
-            return 1/self.base, -self.exp
-        return self.base, self.exp
+        """Return base and exp of self unless base is 1/Integer, then return Integer, -exp.
+
+        If this extra processing is not needed, the base and exp properties will
+        give the raw arguments, e.g. (1/2, 2) for (1/2)**2 rather than (2, -2).
+        """
+
+        b, e = self.args
+        if b.is_Rational and b.p == 1 and b is not S.Infinity:
+            return Integer(b.q), -e
+        return b, e
 
     def _eval_conjugate(self):
         from sympy.functions.elementary.complexes import conjugate as c

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1121,15 +1121,15 @@ def test_bug3():
     assert e == f
 
 def test_suppressed_evaluation():
-    a = Add(1,3,2,evaluate=False)
+    a = Add(0,3,2,evaluate=False)
     b = Mul(1,3,2,evaluate=False)
     c = Pow(3,2,evaluate=False)
     assert a != 6
     assert a.func is Add
-    assert a.args == (1,3,2)
+    assert a.args == (3,2)
     assert b != 6
     assert b.func is Mul
-    assert b.args == (1,3,2)
+    assert b.args == (3,2)
     assert c != 9
     assert c.func is Pow
     assert c.args == (3,2)

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -164,3 +164,5 @@ def test_pow_as_base_exp():
     x = Symbol('x')
     assert (S.Infinity**(2 - x)).as_base_exp() == (S.Infinity, 2 - x)
     assert (S.Infinity**(x - 2)).as_base_exp() == (S.Infinity, x - 2)
+    p = S.Half**x
+    assert p.base, p.exp == p.as_base_exp() == (S(2), -x)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -449,7 +449,7 @@ def pollard_pm1(n, B=10, a=2, retries=0, seed=1234):
             factors:
 
             >>> from sympy.core.numbers import ilcm, igcd
-            >>> from sympy import factorint
+            >>> from sympy import factorint, Pow
             >>> M = reduce(ilcm, range(2, 256))
             >>> set([igcd(pow(a, M, n) - 1, n) for a in range(2, 256) if
             ...      igcd(pow(a, M, n) - 1, n) != n])
@@ -458,7 +458,7 @@ def pollard_pm1(n, B=10, a=2, retries=0, seed=1234):
             But does aM % d for every divisor of n give 1?
 
             >>> aM = pow(a, M, n)
-            >>> [(d, aM%(1*d)) for d in factorint(n, visual=True).args]
+            >>> [(d, aM%Pow(*d.args)) for d in factorint(n, visual=True).args]
             [(257**1, 1), (1009**1, 1)]
 
             No, only one of them. So perhaps the principle is that a root will

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -28,7 +28,7 @@ from sympy.physics.quantum.operator import UnitaryOperator, Operator, HermitianO
 from sympy.physics.quantum.matrixutils import (
     matrix_tensor_product, matrix_eye
 )
-from sympy.physics.quantum.matrixcache import matrix_cache
+from sympy.physics.quantum.matrixcache import matrix_cache, sqrt2_inv
 
 __all__ = [
     'Gate',
@@ -60,8 +60,6 @@ __all__ = [
     'gate_simp',
     'random_circuit',
 ]
-
-sqrt2_inv = Pow(2, Rational(-1,2), evaluate=False)
 
 #-----------------------------------------------------------------------------
 # Gate Super-Classes

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -241,7 +241,7 @@ class UnitaryOperator(Operator):
 
 
 class OuterProduct(Operator):
-    """An unevaluated outer product between a ket and kra.
+    """An unevaluated outer product between a ket and bra.
 
     This constructs an outer product between any subclass of KetBase and
     BraBase as |a><b|. An OuterProduct inherits from Operator as they act as

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -163,10 +163,10 @@ def represent(expr, **options):
             result = result + represent(args, **options)
         return result
     elif isinstance(expr, Pow):
-        exp = expr.exp
+        base, exp = expr.as_base_exp()
         if format == 'numpy' or format == 'scipy.sparse':
             exp = _sympy_to_scalar(exp)
-        return represent(expr.base, **options)**exp
+        return represent(base, **options)**exp
     elif isinstance(expr, TensorProduct):
         new_args = [represent(arg, **options) for arg in expr.args]
         return TensorProduct(*new_args)

--- a/sympy/physics/quantum/tests/test_gate.py
+++ b/sympy/physics/quantum/tests/test_gate.py
@@ -11,6 +11,7 @@ from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import Qubit, IntQubit, qubit_to_matrix,\
      matrix_to_qubit
 from sympy.physics.quantum.matrixutils import matrix_to_zero
+from sympy.physics.quantum.matrixcache import sqrt2_inv
 from sympy.physics.quantum import Dagger
 
 def test_gate():
@@ -102,8 +103,7 @@ def test_represent_hadamard():
     circuit = HadamardGate(0)*Qubit('00')
     answer = represent(circuit, nqubits=2)
     # Check that the answers are same to within an epsilon.
-    assert answer == Matrix([1/sqrt(2),1/sqrt(2), 0, 0])
-
+    assert answer == Matrix([sqrt2_inv, sqrt2_inv, 0, 0])
 
 def test_represent_xgate():
     """Test the representation of the X gate."""
@@ -218,9 +218,9 @@ def test_one_qubit_commutators():
             a = matrix_to_zero(represent(e, nqubits=1, format='sympy'))
             b = matrix_to_zero(represent(e.doit(), nqubits=1, format='sympy'))
             assert a == b
+
             e = Commutator(g1(0),g2(1))
             assert e.doit() == 0
-
 
 def test_one_qubit_anticommutators():
     """Test single qubit gate anticommutation relations."""

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1627,7 +1627,7 @@ def test_terms_gcd():
     assert terms_gcd(x - 1) == x - 1
     assert terms_gcd(-x - 1) == -x - 1
 
-    assert terms_gcd(2*x + 3) != Mul(1, 2*x + 3, evaluate=False)
+    assert terms_gcd(2*x + 3) == 2*x + 3
     assert terms_gcd(6*x + 4) == Mul(2, 3*x + 2, evaluate=False)
 
     assert terms_gcd(x**3*y + x*y**3) == x*y*(x**2 + y**2)
@@ -1855,7 +1855,7 @@ def test_sqf():
     assert sqf(x - 1) == x - 1
     assert sqf(-x - 1) == -x - 1
 
-    assert sqf(x - 1) != Mul(1, x - 1, evaluate=False)
+    assert sqf(x - 1) == x - 1
     assert sqf(6*x - 10) == Mul(2, 3*x - 5, evaluate=False)
 
     assert sqf((6*x - 10)/(3*x - 6)) == S(2)/3*((3*x - 5)/(x - 2))


### PR DESCRIPTION
This efficiently avoids cls.identity values if Add and Mul operations, leading to an optimization of trivial calculations like `1*m` where, if `m` were a Mul, then all `m`'s args would be re-traversed by Mul.flatten and similarly for `0+a`.
