### PR TITLE
canonical Abs: Abs(real)**3 -> real**2*Abs(real)

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -274,6 +274,9 @@ class Abs(Function):
         if self.args[0].is_real and other.is_integer:
             if other.is_even:
                 return self.args[0]**other
+            elif other is not S.NegativeOne and other.is_Integer:
+                e = other - sign(other)
+                return self.args[0]**e*self
         return
 
     def _eval_nseries(self, x, n, logx):

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -107,6 +107,10 @@ def test_Abs():
     assert x**(2*n) == Abs(x)**(2*n)
     assert Abs(x).diff(x) == sign(x)
     assert abs(x) == Abs(x) # Python built-in
+    assert Abs(x)**3 == x**2*Abs(x)
+    assert (Abs(x)**(3*n)).args == (Abs(x), 3*n) # leave symbolic odd unchanged
+    assert (1/Abs(x)).args == (Abs(x), -1)
+    assert 1/Abs(x)**3 == 1/(x**2*Abs(x))
 
 def test_abs_real():
     # test some properties of abs that only apply


### PR DESCRIPTION
This updates _eval_power for Abs so that if the exponent is an odd Integer then only 1 instance of Abs will remain. We already have `Abs(real)**2 -> x**2`.
