### PR TITLE
Remove setting order in _from_poly

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -199,9 +199,6 @@ class Poly(Expr):
             else:
                 rep = rep.reorder(*gens)
 
-        if 'order' in opt:
-            rep = rep.set_order(order)
-
         if 'domain' in opt and domain:
             rep = rep.set_domain(domain)
         elif field is True:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1248,6 +1248,9 @@ def test_parallel_poly_from_expr():
     assert parallel_poly_from_expr([Poly(x**2-1, x), 1])[0] == [Poly(x**2-1, x), Poly(1, x)]
     assert parallel_poly_from_expr([Poly(x**2-1, x), 1])[0] == [Poly(x**2-1, x), Poly(1, x)]
 
+    assert parallel_poly_from_expr([Poly(x, x, y), Poly(y, x, y)], x, y, order='lex')[0] == \
+        [Poly(x, x, y, domain='ZZ'), Poly(y, x, y, domain='ZZ')]
+
     raises(PolificationFailed, "parallel_poly_from_expr([0, 1])")
 
 def test_pdiv():


### PR DESCRIPTION
Poly doesn't have a `set_order` method, which caused something like:

```
reduced(Poly(x, x,y), [Poly(x, x, y)], x, y, order='grevlex')
```

or

```
groebner([Poly(x, x, y), Poly(y, x, y)], x, y, order='lex')
```

not to work.

The problem was calling `parallel_poly_from_expr` with two Polys and order
option. `_from_poly` isn't used anywhere but in `parallel_poly_from_expr` and
its tests.

(This is necessary for using fglm in solvers and will improve ratsimpmodprime a bit)
