### PR TITLE
Disable is_Real DeprecationWarning in test_pickling.py

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -75,6 +75,8 @@ class Basic(object):
     @deprecated
     def is_Real(self):  # pragma: no cover
         """Deprecated alias for ``is_Float``"""
+        # When this is removed, remove the piece of code disabling the warning
+        # from test_pickling.py
         return self.is_Float
 
     def __new__(cls, *args, **assumptions):

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -1,6 +1,7 @@
 import copy
 import pickle
 import types
+import warnings
 from sympy.utilities.pytest import XFAIL
 
 from sympy.core.basic import Atom, Basic
@@ -31,6 +32,9 @@ from sympy import symbols
 def check(a, check_attr = True):
     """ Check that pickling and copying round-trips.
     """
+    # The below hasattr() check will warn about is_Real in Python 2.5, so
+    # disable this to keep the tests clean
+    warnings.filterwarnings("ignore", ".*is_Real.*", DeprecationWarning)
     #FIXME-py3k: Add support for protocol 3.
     for protocol in [0, 1, 2, copy.copy, copy.deepcopy]:
         if callable(protocol):


### PR DESCRIPTION
This was being raised because the pickling test does a hasattr() check
on every attribute of the objects. In Python 2.5, the warning is enabled
by default, leading to noise in the test output.
