### PR TITLE
Product sum

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -127,8 +127,7 @@ class Product(Expr):
             if not term.base.has(k):
                 s = summation(term.exp, (k, a, n))
 
-                if not isinstance(s, Sum):
-                    return term.base**s
+                return term.base**s
             elif not term.exp.has(k):
                 p = self._eval_product(a, n, term.base)
 

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -37,7 +37,7 @@ class Product(Expr):
 
             k, a, n = map(sympify, (k, a, n))
 
-            if isinstance(a, C.Number) and isinstance(n, C.Number):
+            if isinstance(a, C.Integer) and isinstance(n, C.Integer):
                 return Mul(*[term.subs(k, i) for i in xrange(int(a), int(n)+1)])
         else:
             raise NotImplementedError

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,5 +1,5 @@
 from sympy import (symbols, product, factorial, rf, sqrt, cos,
-                   Function, Product, Rational, Sum)
+                   Function, Product, Rational, Sum, oo)
 
 a, k, n = symbols('a,k,n', integer=True)
 f = Function('f')
@@ -14,7 +14,7 @@ def test_simple_products():
 
     assert product(cos(k), (k, 0, 5)) == cos(1)*cos(2)*cos(3)*cos(4)*cos(5)
     assert product(cos(k), (k, 3, 5)) == cos(3)*cos(4)*cos(5)
-    assert product(cos(k), (k, 1, Rational(5, 2))) == cos(1)*cos(2)
+    assert product(cos(k), (k, 1, Rational(5, 2))) != cos(1)*cos(2)
 
     assert isinstance(product(k**k, (k, 1, n)), Product)
 
@@ -39,5 +39,10 @@ def test__eval_product():
     assert product(2**i, (i, 1, n)) == 2**(n/2 + n**2/2)
 
 def test_product_pow():
+    # Issue 1718
     assert product(2**f(k), (k, 1, n)) == 2**Sum(f(k), (k, 1, n))
     assert product(2**(2*f(k)), (k, 1, n)) == 2**Sum(2*f(k), (k, 1, n))
+
+def test_infinite_product():
+    # Issue 2638
+    assert isinstance(Product(2**(1/factorial(n)), (n, 0, oo)), Product)

--- a/sympy/concrete/tests/test_products.py
+++ b/sympy/concrete/tests/test_products.py
@@ -1,7 +1,8 @@
 from sympy import (symbols, product, factorial, rf, sqrt, cos,
-                   Function, Product, Rational)
+                   Function, Product, Rational, Sum)
 
 a, k, n = symbols('a,k,n', integer=True)
+f = Function('f')
 
 def test_simple_products():
     assert product(2, (k, a, n)) == 2**(n-a+1)
@@ -36,3 +37,7 @@ def test__eval_product():
     assert product(2*a(i), (i, 1, n)) == 2**n * Product(a(i), (i, 1, n))
     # 1711
     assert product(2**i, (i, 1, n)) == 2**(n/2 + n**2/2)
+
+def test_product_pow():
+    assert product(2**f(k), (k, 1, n)) == 2**Sum(f(k), (k, 1, n))
+    assert product(2**(2*f(k)), (k, 1, n)) == 2**Sum(2*f(k), (k, 1, n))


### PR DESCRIPTION
This fixes issues 1718 and 2638.  The fix for issue 1718 (make Product(Pow) return Pow(Sum)), may be controversial, so it can be taken out if no one likes it.  But I think it's a good idea, especially considering that it prevents from returning an unevaluated Product, which is a good thing because this class is seriously messed up (see issue 2639).
