### PR TITLE
print **(Rational(a,b)) as **Rational(a,b)

### DIFF
--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1051,7 +1051,7 @@ class acos(Function):
         >>> acos(0)
         pi/2
         >>> acos(oo)
-        (oo)*I
+        oo*I
     """
 
     nargs = 1

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -1,5 +1,7 @@
 """A module providing information about the necessity of brackets"""
 
+from sympy import S
+
 # Default precedence values for some basic types
 PRECEDENCE = {
     "Lambda":1,
@@ -40,6 +42,8 @@ def precedence_Mul(item):
 def precedence_Rational(item):
     if item.p < 0:
         return PRECEDENCE["Add"]
+    if item is S.Infinity:
+        return PRECEDENCE["Atom"]
     return PRECEDENCE["Mul"]
 
 def precedence_Integer(item):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -347,8 +347,15 @@ class StrPrinter(Printer):
             if expr.exp is S.NegativeOne:
                 return '1/%s' % self.parenthesize(expr.base, PREC)
 
-        return '%s**%s' % (self.parenthesize(expr.base, PREC),
-                               self.parenthesize(expr.exp, PREC))
+        e = self.parenthesize(expr.exp, PREC)
+        if self.printmethod == '_sympyrepr' and expr.exp.is_Rational and expr.exp.q != 1:
+            try:
+                # the parenthesized exp should be '(Rational(a, b))' so strip parens
+                assert e.startswith('(Rational')
+                return '%s**%s' % (self.parenthesize(expr.base, PREC), e[1:-1])
+            except AssertionError:
+                pass
+        return '%s**%s' % (self.parenthesize(expr.base, PREC), e)
 
     def _print_Integer(self, expr):
         return str(expr.p)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -349,12 +349,10 @@ class StrPrinter(Printer):
 
         e = self.parenthesize(expr.exp, PREC)
         if self.printmethod == '_sympyrepr' and expr.exp.is_Rational and expr.exp.q != 1:
-            try:
-                # the parenthesized exp should be '(Rational(a, b))' so strip parens
-                assert e.startswith('(Rational')
+            # the parenthesized exp should be '(Rational(a, b))' so strip parens,
+            # but just check to be sure.
+            if e.startswith('(Rational'):
                 return '%s**%s' % (self.parenthesize(expr.base, PREC), e[1:-1])
-            except AssertionError:
-                pass
         return '%s**%s' % (self.parenthesize(expr.base, PREC), e)
 
     def _print_Integer(self, expr):

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -21,7 +21,7 @@ def test_python_basic():
     assert python((x**2)) == "x = Symbol(\'x\')\ne = x**2"
     assert python(1/x) == "x = Symbol('x')\ne = 1/x"
     assert python(y*x**-2) == "y = Symbol('y')\nx = Symbol('x')\ne = y/x**2"
-    assert python(x**Rational(-5, 2)) == "x = Symbol('x')\ne = x**(Rational(-5, 2))"
+    assert python(x**Rational(-5, 2)) == "x = Symbol('x')\ne = x**Rational(-5, 2)"
 
     # Sums of terms
     assert python((x**2 + x + 1)) in [
@@ -72,9 +72,10 @@ def test_python_functions():
     # Simple
     assert python((2*x + exp(x))) in "x = Symbol('x')\ne = 2*x + exp(x)"
     assert python(sqrt(2)) == 'e = sqrt(2)'
-    assert python(2**Rational(1, 3)) == 'e = 2**(Rational(1, 3))'
-    assert python(sqrt(2+pi)) == 'e = sqrt(2 + pi)'
-    assert python((2 + pi)**Rational(1, 3)) == 'e = (2 + pi)**(Rational(1, 3))'
+    assert python(2**Rational(1, 3)) == 'e = 2**Rational(1, 3)'
+    assert python(sqrt(2 + pi)) == 'e = sqrt(2 + pi)'
+    assert python((2 + pi)**Rational(1, 3)) == 'e = (2 + pi)**Rational(1, 3)'
+    assert python(2**Rational(1, 4)) == 'e = 2**Rational(1, 4)'
     assert python(Abs(x)) == "x = Symbol('x')\ne = Abs(x)"
     assert python(Abs(x/(x**2+1))) in ["x = Symbol('x')\ne = Abs(x/(1 + x**2))",
             "x = Symbol('x')\ne = Abs(x/(x**2 + 1))"]
@@ -94,8 +95,8 @@ def test_python_functions():
 
     # Nesting of powers
     assert python((((x+1)**Rational(1, 3))+1)**Rational(1, 3)) in [
-            "x = Symbol('x')\ne = (1 + (1 + x)**(Rational(1, 3)))**(Rational(1, 3))",
-            "x = Symbol('x')\ne = ((x + 1)**(Rational(1, 3)) + 1)**(Rational(1, 3))"]
+            "x = Symbol('x')\ne = (1 + (1 + x)**Rational(1, 3))**Rational(1, 3)",
+            "x = Symbol('x')\ne = ((x + 1)**Rational(1, 3) + 1)**Rational(1, 3)"]
 
     # Function powers
     assert python(sin(x)**2) == "x = Symbol('x')\ne = sin(x)**2"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -102,7 +102,7 @@ def test_ImaginaryUnit():
 
 def test_Infinity():
     assert str(oo) == "oo"
-    assert str(I * oo) == "(oo)*I"
+    assert str(I * oo) == "oo*I"
 
 def test_Integer():
     assert str(Integer(-1)) == "-1"
@@ -388,7 +388,7 @@ def test_sstrrepr():
     assert sstrrepr(e)  == "['a', 'b', 'c', x]"
 
 def test_infinity():
-    assert sstr(I*oo) == "(oo)*I"
+    assert sstr(I*oo) == "oo*I"
 
 def test_full_prec():
     assert sstr(S("0.3"), full_prec=True) == "0.300000000000000"

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -228,7 +228,7 @@ def test_tsolve():
     assert solve(4*3**(5*x+2)-7, x) == [(-2*log(3) - 2*log(2) + log(7))/(5*log(3))]
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
     assert solve(3*x+5+2**(-5*x+3), x) in [
-        [Rational(-5, 3) + LambertW(log(2**(-10240*2**(Rational(1, 3))/3)))/(5*log(2))],
+        [Rational(-5, 3) + LambertW(log(2**(-10240*2**Rational(1, 3)/3)))/(5*log(2))],
         [-Rational(5,3) + LambertW(-10240*2**Rational(1, 3)*log(2)/3)/(5*log(2))],
         [(-25*log(2) + 3*LambertW(-10240*2**Rational(1, 3)*log(2)/3))/(15*log(2))],
         [-((25*log(2) - 3*LambertW(-10240*2**Rational(1, 3)*log(2)/3)))/(15*log(2))],


### PR DESCRIPTION
Is there a better way to do this? It's related to precedence but I don't know of a good way to make this change.
