### PR TITLE
Use a better character for the horizontal line in unicode roots

### DIFF
--- a/doc/src/modules/polys/wester.txt
+++ b/doc/src/modules/polys/wester.txt
@@ -228,7 +228,7 @@ We would like to reduce degrees of the numerator and the denominator of a
 rational function ``f/g``. Do do this we employ :func:`cancel` function::
 
     >>> cancel(f/g)
-     3      2     ⎽⎽⎽  2             ⎽⎽⎽         ⎽⎽⎽
+     3      2     ___  2             ___         ___
     x  - 2⋅x  + ╲╱ 2 ⋅x  - 3⋅x - 2⋅╲╱ 2 ⋅x - 3⋅╲╱ 2
     ────────────────────────────────────────────────
                           2
@@ -243,7 +243,7 @@ one needs to use ``extension`` keyword::
      2
     x  - 2⋅x - 3
     ────────────
-           ⎽⎽⎽
+           ___
      x - ╲╱ 2
 
 Setting ``extension=True`` tells :func:`cancel` to find minimal algebraic
@@ -256,7 +256,7 @@ keyword with an explicit algebraic number::
      2
     x  - 2⋅x - 3
     ────────────
-           ⎽⎽⎽
+           ___
      x - ╲╱ 2
 
 Univariate factoring over various domains
@@ -412,7 +412,7 @@ in univariate case. For example consider the following factorization over
 `\mathbb{Q}(\sqrt{-3})`::
 
     >>> factor(x**3 + y**3, extension=sqrt(-3))
-            ⎛      ⎛        ⎽⎽⎽  ⎞⎞ ⎛      ⎛        ⎽⎽⎽  ⎞⎞
+            ⎛      ⎛        ___  ⎞⎞ ⎛      ⎛        ___  ⎞⎞
             ⎜      ⎜  1   ╲╱ 3 ⋅ⅈ⎟⎟ ⎜      ⎜  1   ╲╱ 3 ⋅ⅈ⎟⎟
     (x + y)⋅⎜x + y⋅⎜- ─ - ───────⎟⎟⋅⎜x + y⋅⎜- ─ + ───────⎟⎟
             ⎝      ⎝  2      2   ⎠⎠ ⎝      ⎝  2      2   ⎠⎠

--- a/doc/src/modules/rewriting.txt
+++ b/doc/src/modules/rewriting.txt
@@ -71,19 +71,19 @@ subexpressions, collect them and evaluate them at once. This is implemented in t
     >>> from sympy.abc import x
 
     >>> pprint(cse(sqrt(sin(x))), use_unicode=True)
-    ⎛    ⎡  ⎽⎽⎽⎽⎽⎽⎽⎽⎤⎞
+    ⎛    ⎡  ________⎤⎞
     ⎝[], ⎣╲╱ sin(x) ⎦⎠
 
     >>> pprint(cse(sqrt(sin(x)+5)*sqrt(sin(x)+4)), use_unicode=True)
-    ⎛                ⎡  ⎽⎽⎽⎽⎽⎽⎽⎽   ⎽⎽⎽⎽⎽⎽⎽⎽⎤⎞
+    ⎛                ⎡  ________   ________⎤⎞
     ⎝[(x₀, sin(x))], ⎣╲╱ x₀ + 4 ⋅╲╱ x₀ + 5 ⎦⎠
 
     >>> pprint(cse(sqrt(sin(x)+5+cos(y))*sqrt(sin(x)+4+cos(y))), use_unicode=True)
-    ⎛                                             ⎡  ⎽⎽⎽⎽⎽⎽⎽⎽   ⎽⎽⎽⎽⎽⎽⎽⎽⎤⎞
+    ⎛                                             ⎡  ________   ________⎤⎞
     ⎝[(x₀, cos(y)), (x₁, sin(x)), (x₂, x₀ + x₁)], ⎣╲╱ x₂ + 4 ⋅╲╱ x₂ + 5 ⎦⎠
 
     >>> pprint(cse((x-y)*(z-y) + sqrt((x-y)*(z-y))), use_unicode=True)
-    ⎛                         ⎡  ⎽⎽⎽⎽     ⎤⎞
+    ⎛                         ⎡  ____     ⎤⎞
     ⎝[(x₀, (x - y)⋅(-y + z))], ⎣╲╱ x₀  + x₀⎦⎠
 
 More information:

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -207,7 +207,11 @@ _xobj_unicode = {
     # horizontal objects
     #'-' :  '-',
     '-' :   U('BOX DRAWINGS LIGHT HORIZONTAL'),
-    '_' :   U('HORIZONTAL SCAN LINE-9'),        # XXX symbol ok?
+    '_' :   U('LOW LINE'),
+    # We used to use this, but LOW LINE looks better for roots, as it's a
+    # little lower (i.e., it lines up with the / perfectly.  But perhaps this
+    # one would still be wanted for some cases?
+    # '_' :   U('HORIZONTAL SCAN LINE-9'),
 
     # diagonal objects '\' & '/' ?
     '/' :   U('BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT'),

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -638,7 +638,7 @@ def test_issue_2425():
 
     assert upretty(-(-x + 5)*(-x - 2*sqrt(2) + 5) - (-y + 5)*(-y + 5)) == \
 u"""\
-        ⎛         ⎽⎽⎽    ⎞           2\n\
+        ⎛         ___    ⎞           2\n\
 (x - 5)⋅⎝-x - 2⋅╲╱ 2  + 5⎠ - (-y + 5) \
 """
 
@@ -1055,7 +1055,7 @@ x\
 """
     ucode_str = \
 u"""\
-⎽\n\
+_\n\
 x\
 """
     assert  pretty(expr) == ascii_str
@@ -1075,12 +1075,12 @@ f(x + 1)\
 """
     ucode_str_1 = \
 u"""\
-⎽⎽⎽⎽⎽⎽⎽⎽\n\
+________\n\
 f(1 + x)\
 """
     ucode_str_2 = \
 u"""\
-⎽⎽⎽⎽⎽⎽⎽⎽\n\
+________\n\
 f(x + 1)\
 """
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
@@ -1160,7 +1160,7 @@ a - I*b\
 """
     ucode_str = \
 u"""\
-⎽     ⎽\n\
+_     _\n\
 a - ⅈ⋅b\
 """
     assert  pretty(expr) == ascii_str
@@ -1175,7 +1175,7 @@ e       \
 """
     ucode_str = \
 u"""\
- ⎽     ⎽\n\
+ _     _\n\
  a - ⅈ⋅b\n\
 ℯ       \
 """
@@ -1197,14 +1197,14 @@ f\\f(x) + 1/\
 """
     ucode_str_1 = \
 u"""\
-⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽\n\
- ⎛    ⎽⎽⎽⎽⎞\n\
+___________\n\
+ ⎛    ____⎞\n\
 f⎝1 + f(x)⎠\
 """
     ucode_str_2 = \
 u"""\
-⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽\n\
- ⎛⎽⎽⎽⎽    ⎞\n\
+___________\n\
+ ⎛____    ⎞\n\
 f⎝f(x) + 1⎠\
 """
     assert  pretty(expr) in [ascii_str_1, ascii_str_2]
@@ -1280,7 +1280,7 @@ def test_pretty_sqrt():
 """
     ucode_str = \
 u"""\
-  ⎽⎽⎽\n\
+  ___\n\
 ╲╱ 2 \
 """
     assert  pretty(expr) == ascii_str
@@ -1294,7 +1294,7 @@ u"""\
 """
     ucode_str = \
 u"""\
-3 ⎽⎽⎽\n\
+3 ___\n\
 ╲╱ 2 \
 """
     assert  pretty(expr) == ascii_str
@@ -1308,7 +1308,7 @@ u"""\
 """
     ucode_str = \
 u"""\
-1000⎽⎽⎽\n\
+1000___\n\
   ╲╱ 2 \
 """
     assert  pretty(expr) == ascii_str
@@ -1323,7 +1323,7 @@ u"""\
 """
     ucode_str = \
 u"""\
-   ⎽⎽⎽⎽⎽⎽⎽⎽\n\
+   ________\n\
   ╱  2     \n\
 ╲╱  x  + 1 \
 """
@@ -1339,8 +1339,8 @@ u"""\
 """
     ucode_str = \
 u"""\
-   ⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽\n\
-3 ╱       ⎽⎽⎽ \n\
+   ___________\n\
+3 ╱       ___ \n\
 ╲╱  1 + ╲╱ 5  \
 """
     assert  pretty(expr) == ascii_str
@@ -1354,7 +1354,7 @@ x ___\n\
 """
     ucode_str = \
 u"""\
-x ⎽⎽⎽\n\
+x ___\n\
 ╲╱ 2 \
 """
     assert  pretty(expr) == ascii_str
@@ -1368,7 +1368,7 @@ x ⎽⎽⎽\n\
 """
     ucode_str = \
 u"""\
-  ⎽⎽⎽⎽⎽⎽⎽\n\
+  _______\n\
 ╲╱ 2 + π \
 """
     assert  pretty(expr) == ascii_str
@@ -1387,11 +1387,11 @@ u"""\
 """
     ucode_str = \
 u"""\
-     ⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽              \n\
-    ╱      2        1000⎽⎽⎽    \n\
+     ____________              \n\
+    ╱      2        1000___    \n\
    ╱      x  + 1      ╲╱ x  + 1\n\
 4 ╱   2 + ──────  + ───────────\n\
-╲╱        x + 2        ⎽⎽⎽⎽⎽⎽⎽⎽\n\
+╲╱        x + 2        ________\n\
                       ╱  2     \n\
                     ╲╱  x  + 3 \
 """


### PR DESCRIPTION
See issue 447. Previously, we used HORIZONTAL SCAN LINE-9.  This looked like this:

```
In [8]: a = x

In [9]: for i in xrange(5):
   ...:     a **= Rational(1, 2)
   ...:     a += x
   ...:

In [10]: a
Out[10]:
          ⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽
         ╱          ⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽
        ╱          ╱         ⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽
       ╱          ╱         ╱        ⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽
      ╱          ╱         ╱        ╱   ⎽⎽⎽
x + ╲╱     x + ╲╱    x + ╲╱   x + ╲╱  ╲╱ x  + x
```

Now, we use LOW LINE.  This looks like this:

```
In [2]: a = x

In [3]: for i in xrange(5):
   ...:     a **= Rational(1, 2)
   ...:     a += x
   ...:

In [4]: a
Out[4]:
          _________________________________________
         ╱          ______________________________
        ╱          ╱         ____________________
       ╱          ╱         ╱        ___________
      ╱          ╱         ╱        ╱   ___
x + ╲╱     x + ╲╱    x + ╲╱   x + ╲╱  ╲╱ x  + x
```

At least on my computer, the new one aligns exactly with the /, whereas
with the old one there was a gap.

This symbol is also used for pretty printing unicode conjugates.  We
have old:

```
In [11]: conjugate(x)
Out[11]:
⎽
x

In [12]: conjugate(f(x + sin(x)))
Out[12]:
⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽⎽
f(x + sin(x))
```

New:

```
In [5]: conjugate(x)
Out[5]:
_
x

In [6]: conjugate(f(x + sin(x)))
Out[6]:
_____________
f(x + sin(x))
```

Please compare this in your terminal, where output may look a little different from in the browser.  

This might be considered as somewhat of a followup on my print-sqrt branch that just got pushed in :)
