### PR TITLE
Fix bug 2647: meijerg pretty printing

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -622,6 +622,7 @@ class PrettyPrinter(Printer):
         bq = [self._print(b) for b in e.bq]
 
         P = self._print(e.argument)
+        P.baseline = P.height()//2
 
         # Drawing result - first create the ap, bq vectors
         D = None
@@ -679,6 +680,7 @@ class PrettyPrinter(Printer):
         v[(1, 1)] = [self._print(b) for b in e.bother]
 
         P = self._print(e.argument)
+        P.baseline = P.height()//2
 
         vp = {}
         for idx in v:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2758,6 +2758,36 @@ u"""\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
+    expr = hyper([1,2],[3,4],  1/(1/(1/(1/x + 1) + 1) + 1))
+    ucode_str = \
+u"""\
+     ⎛     │       1      ⎞\n\
+     ⎜     │ ─────────────⎟\n\
+     ⎜     │         1    ⎟\n\
+ ┌─  ⎜1, 2 │ 1 + ─────────⎟\n\
+ ├─  ⎜     │           1  ⎟\n\
+2╵ 2 ⎜3, 4 │     1 + ─────⎟\n\
+     ⎜     │             1⎟\n\
+     ⎜     │         1 + ─⎟\n\
+     ⎝     │             x⎠\
+"""
+
+    ascii_str = \
+"""\
+                           \n\
+     /     |       1      \\\n\
+     |     | -------------|\n\
+  _  |     |         1    |\n\
+ |_  |1, 2 | 1 + ---------|\n\
+ |   |     |           1  |\n\
+2  2 |3, 4 |     1 + -----|\n\
+     |     |             1|\n\
+     |     |         1 + -|\n\
+     \\     |             x/\
+"""
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
 def test_meijerg():
     expr = meijerg([pi, pi, x], [1], [0, 1], [1, 2, 3], z)
     ucode_str = \
@@ -2812,6 +2842,76 @@ u"""\
     expr = meijerg([1]*10, [1], [1], [1], z)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+
+    expr = meijerg([1, 2,], [4, 3], [3], [4, 5], 1/(1/(1/(1/x + 1) + 1) + 1))
+
+    ucode_str = \
+u"""\
+        ⎛           │       1      ⎞\n\
+        ⎜           │ ─────────────⎟\n\
+        ⎜           │         1    ⎟\n\
+╭─╮1, 2 ⎜1, 2  4, 3 │ 1 + ─────────⎟\n\
+│╶┐     ⎜           │           1  ⎟\n\
+╰─╯4, 3 ⎜ 3    4, 5 │     1 + ─────⎟\n\
+        ⎜           │             1⎟\n\
+        ⎜           │         1 + ─⎟\n\
+        ⎝           │             x⎠\
+"""
+
+    ascii_str = \
+"""\
+        /           |       1      \\\n\
+        |           | -------------|\n\
+        |           |         1    |\n\
+ __1, 2 |1, 2  4, 3 | 1 + ---------|\n\
+/__     |           |           1  |\n\
+\_|4, 3 | 3    4, 5 |     1 + -----|\n\
+        |           |             1|\n\
+        |           |         1 + -|\n\
+        \\           |             x/\
+"""
+
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    expr = Integral(expr, x)
+
+    ucode_str = \
+u"""\
+⌠                                        \n\
+⎮         ⎛           │       1      ⎞   \n\
+⎮         ⎜           │ ─────────────⎟   \n\
+⎮         ⎜           │         1    ⎟   \n\
+⎮ ╭─╮1, 2 ⎜1, 2  4, 3 │ 1 + ─────────⎟   \n\
+⎮ │╶┐     ⎜           │           1  ⎟ dx\n\
+⎮ ╰─╯4, 3 ⎜ 3    4, 5 │     1 + ─────⎟   \n\
+⎮         ⎜           │             1⎟   \n\
+⎮         ⎜           │         1 + ─⎟   \n\
+⎮         ⎝           │             x⎠   \n\
+⌡                                        \
+"""
+
+    ascii_str = \
+"""\
+  /                                       \n\
+ |                                        \n\
+ |         /           |       1      \\   \n\
+ |         |           | -------------|   \n\
+ |         |           |         1    |   \n\
+ |  __1, 2 |1, 2  4, 3 | 1 + ---------|   \n\
+ | /__     |           |           1  | dx\n\
+ | \_|4, 3 | 3    4, 5 |     1 + -----|   \n\
+ |         |           |             1|   \n\
+ |         |           |         1 + -|   \n\
+ |         \\           |             x/   \n\
+ |                                        \n\
+/                                         \
+"""
+
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
 
 def test_noncommutative():
     A, B, C = symbols('A,B,C', commutative=False)


### PR DESCRIPTION
Was:

```
In [52]: meijerg([1, 2,], [4, 3], [3], [4, 5], 1/(1/(1/(1/x + 1) + 1)+ 1))

╭─╮1, 2 ⎛1, 2  4, 3 │       1      ⎞
│╶┐     ⎜           │ ─────────────⎟
╰─╯4, 3 ⎜ 3    4, 5 │         1    ⎟
        ⎜           │ 1 + ─────────⎟
        ⎜           │           1  ⎟
        ⎜           │     1 + ─────⎟
        ⎜           │             1⎟
        ⎜           │         1 + ─⎟
        ⎝           │             x⎠
```

Now:

```
In [1]: meijerg([1, 2,], [4, 3], [3], [4, 5], 1/(1/(1/(1/x + 1) + 1)+ 1))
Out[1]:
        ⎛           │       1      ⎞
        ⎜           │ ─────────────⎟
        ⎜           │         1    ⎟
╭─╮1, 2 ⎜1, 2  4, 3 │ 1 + ─────────⎟
│╶┐     ⎜           │           1  ⎟
╰─╯4, 3 ⎜ 3    4, 5 │     1 + ─────⎟
        ⎜           │             1⎟
        ⎜           │         1 + ─⎟
        ⎝           │             x⎠
```
