### PR TITLE
Primitive additions

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -622,14 +622,25 @@ class Add(AssocOp):
             terms = [c] + terms
         return cont, self._new_rawargs(*terms)
 
-    def _as_content_primitive(self):
+    def as_content_primitive(self):
         from sympy import gcd
-        c_args = [a._as_content_primitive() for a in self.args]
+        c_args = [a.as_content_primitive() for a in self.args]
         g = reduce(gcd, [c[0] for c in c_args])
         if g is S.One:
-            return g, Add(*[c[0]*c[1] for c in c_args])
+            a = Add(*[c[0]*c[1] for c in c_args])
         else:
-            return g, Add(*[c[0]/g*c[1] for c in c_args])
+            a = Add(*[c[0]/g*c[1] for c in c_args])
+        c, ai = a.as_coeff_Mul()
+        if c.is_Rational:
+            if c.is_negative:
+                c = -c
+                ai = -ai
+            g *= c
+            a = ai
+        else:
+            a *= g
+            g = S.One
+        return g, a
 
 from function import FunctionClass
 from mul import Mul

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -557,7 +557,6 @@ class Add(AssocOp):
             s += x._sage_()
         return s
 
-
     def primitive(self):
         """
         Return ``(R, self/R)`` where ``R``` is the Rational GCD of ``self```.
@@ -582,7 +581,13 @@ class Add(AssocOp):
         >>> ((2 + 2*x)*x + 2).primitive()
         (1, x*(2*x + 2) + 2)
 
-        See also: primtive()
+        Recursive subprocessing can be done with the as_content_primitive()
+        method:
+
+        >>> ((2 + 2*x)*x + 2).as_content_primitive()
+        (2, x*(x + 1) + 1)
+
+        See also: primitive() function in polytools.py
 
         """
         cont = S.Zero
@@ -616,6 +621,15 @@ class Add(AssocOp):
         if c:
             terms = [c] + terms
         return cont, self._new_rawargs(*terms)
+
+    def _as_content_primitive(self):
+        from sympy import gcd
+        c_args = [a._as_content_primitive() for a in self.args]
+        g = reduce(gcd, [c[0] for c in c_args])
+        if g is S.One:
+            return g, Add(*[c[0]*c[1] for c in c_args])
+        else:
+            return g, Add(*[c[0]/g*c[1] for c in c_args])
 
 from function import FunctionClass
 from mul import Mul

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -623,6 +623,16 @@ class Add(AssocOp):
         return cont, self._new_rawargs(*terms)
 
     def as_content_primitive(self):
+        """Return the tuple (R, self/R) where R is the positive Rational
+        extracted from self.
+
+        **Example**
+        >>> from sympy import sqrt
+        >>> (3 + 3*sqrt(2)).as_content_primitive()
+        (3, 1 + sqrt(2))
+
+        See docstring of Expr.as_content_primitive for more examples.
+        """
         from sympy import gcd
         c_args = [a.as_content_primitive() for a in self.args]
         g = reduce(gcd, [c[0] for c in c_args])

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -671,6 +671,11 @@ class Basic(object):
             return None
 
     def as_content_primitive(self):
+        """A stub to allow Basic args (like Tuple) to be skipped when computing
+        the content and primitive components of an expression.
+
+        See docstring of Expr.as_content_primitive
+        """
         return S.One, self
 
     def subs(self, *args):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -7,6 +7,7 @@ from core import BasicType, C
 from sympify import _sympify, sympify, SympifyError
 from compatibility import callable, reduce, cmp, iterable
 from sympy.core.decorators import deprecated
+from sympy.core.singleton import S
 
 class Basic(object):
     """
@@ -312,7 +313,6 @@ class Basic(object):
         [x**(-2), 1/x, x**(1/4), sqrt(x), x, x**(3/2), x**2]
 
         """
-        from sympy.core.singleton import S
 
         # XXX: remove this when issue #2070 is fixed
         def inner_key(arg):
@@ -669,6 +669,12 @@ class Basic(object):
                 return poly
         except PolynomialError:
             return None
+
+    def as_content_primitive(self):
+        return S.One, self
+
+    def _as_content_primitive(self):
+        return S.One, self
 
     def subs(self, *args):
         """

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -673,9 +673,6 @@ class Basic(object):
     def as_content_primitive(self):
         return S.One, self
 
-    def _as_content_primitive(self):
-        return S.One, self
-
     def subs(self, *args):
         """
         Substitutes an expression.

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -9,6 +9,7 @@
 from basic import Basic
 from sympify import sympify
 from sympy.utilities.iterables import iterable
+from sympy.core.singleton import S
 
 class Tuple(Basic):
     """
@@ -79,7 +80,6 @@ class Tuple(Basic):
 
     def _to_mpmath(self, prec):
         return tuple([a._to_mpmath(prec) for a in self.args])
-
 
 def tuple_wrapper(method):
     """

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1098,6 +1098,28 @@ class Expr(Basic, EvalfMixin):
                 return self, tuple()
         return S.Zero, (self,)
 
+    def primitive(self):
+        """Return the positive Rational that can be extracted non-recursively
+        from every term of self.
+
+        **Examples**
+        >>> from sympy.abc import x
+        >>> (3*(x + 1)**2).primitive()
+        (3, (x + 1)**2)
+        >>> (6*x + 2).primitive()
+        (2, 3*x + 1)
+        >>> (x/2 + 3).primitive()
+        (1/2, x + 6)
+        >>> eq = (6*x + 2)*(x/2 + 3)
+        >>> eq.primitive()[0] == 1
+        True
+        """
+        c, r = self.as_coeff_mul()
+        r = Mul._from_args(r)
+        if c.is_negative:
+            c, r = -c, -r
+        return c, r
+
     def as_content_primitive(self):
         """
         Return expr separated into ``R`` and ``expr/R`` where R is

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1100,18 +1100,19 @@ class Expr(Basic, EvalfMixin):
 
     def primitive(self):
         """Return the positive Rational that can be extracted non-recursively
-        from every term of self.
+        from every term of self (i.e., self is treated like an Add). This is
+        like the as_coeff_Mul() method but primitive always extracts a positive
+        Rational (never a negative or a Float).
 
         **Examples**
         >>> from sympy.abc import x
         >>> (3*(x + 1)**2).primitive()
         (3, (x + 1)**2)
-        >>> (6*x + 2).primitive()
+        >>> a = (6*x + 2); a.primitive()
         (2, 3*x + 1)
-        >>> (x/2 + 3).primitive()
+        >>> b = (x/2 + 3); b.primitive()
         (1/2, x + 6)
-        >>> eq = (6*x + 2)*(x/2 + 3)
-        >>> eq.primitive()[0] == 1
+        >>> (a*b).primitive() == (1, a*b)
         True
         """
         c, r = self.as_coeff_mul()
@@ -1121,42 +1122,40 @@ class Expr(Basic, EvalfMixin):
         return c, r
 
     def as_content_primitive(self):
-        """
-        Return self separated into ``R`` and ``expr/R`` where R is
-        the Rational that can be extracted from all terms to which
-        as_content_primitive has been applied. In addition, each of the
-        sub-argument of an Add expr will also be returned in
-        as_content_primitive form (i.e. with a Rational in front of a Mul if
-        possible. The as_content_primitive form is not necessarily canonical
-        since the structure of the underlying expr is retained and
-        expansion is not done on the original expression.
+        """This method should recursively remove a Rational from all arguments
+        and return that (content) and the new self (primitive). The content
+        should always be positive and Mul(*foo.as_content_primitive()) == foo.
+        The primitive need no be in canonical form and should try to preserve
+        the underlying structure if possible (i.e. expand_mul should not be
+        applied to self).
 
+        **Examples**
+        >>> from sympy.abc import x, y, z
 
-        Examples::
-            >>> from sympy.abc import x, y, z
+        >>> eq = 2 + 2*x + 2*y*(3 + 3*y)
 
-            >>> eq = 2 + 2*x + 2*y*(3 + 3*y)
+        The as_content_primitive function is recursive and retains structure:
 
-            The as_content_primitive function is recursive and retains structure:
-                >>> eq.as_content_primitive()
-                (2, x + 3*y*(y + 1) + 1)
+        >>> eq.as_content_primitive()
+        (2, x + 3*y*(y + 1) + 1)
 
-            Integer powers will have Rationals extracted from the base:
-                >>> ((2 + 6*x)**2).as_content_primitive()
-                (4, (3*x + 1)**2)
-                >>> ((2 + 6*x)**(2*y)).as_content_primitive()
-                (1, (2*(3*x + 1))**(2*y))
+        Integer powers will have Rationals extracted from the base:
 
-            Terms may end up joining once their as_content_primitives are added:
-                >>> ((5*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive()
-                (11, x*(y + 1))
-                >>> ((3*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive()
-                (9, x*(y + 1))
-                >>> ((3*(z*(1 + y)) + 2.0*x*(3 + 3*y))).as_content_primitive()
-                (3, 2.0*x*(y + 1) + z*(y + 1))
-                >>> ((5*(x*(1 + y)) + 2*x*(3 + 3*y))**2).as_content_primitive()
-                (121, x**2*(y + 1)**2)
+        >>> ((2 + 6*x)**2).as_content_primitive()
+        (4, (3*x + 1)**2)
+        >>> ((2 + 6*x)**(2*y)).as_content_primitive()
+        (1, (2*(3*x + 1))**(2*y))
 
+        Terms may end up joining once their as_content_primitives are added:
+
+        >>> ((5*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive()
+        (11, x*(y + 1))
+        >>> ((3*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive()
+        (9, x*(y + 1))
+        >>> ((3*(z*(1 + y)) + 2.0*x*(3 + 3*y))).as_content_primitive()
+        (3, 2.0*x*(y + 1) + z*(y + 1))
+        >>> ((5*(x*(1 + y)) + 2*x*(3 + 3*y))**2).as_content_primitive()
+        (121, x**2*(y + 1)**2)
         """
         return S.One, self
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1155,7 +1155,7 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.polys.polytools import _keep_coeff as MUL
-        expr = sympify(self)
+        expr = self
         if not expr.args:
             return expr._as_content_primitive()
         args = list(Add.make_args(expr))

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1122,7 +1122,7 @@ class Expr(Basic, EvalfMixin):
 
     def as_content_primitive(self):
         """
-        Return expr separated into ``R`` and ``expr/R`` where R is
+        Return self separated into ``R`` and ``expr/R`` where R is
         the Rational that can be extracted from all terms to which
         as_content_primitive has been applied. In addition, each of the
         sub-argument of an Add expr will also be returned in
@@ -1133,7 +1133,7 @@ class Expr(Basic, EvalfMixin):
 
 
         Examples::
-            >>> from sympy.abc import x, y
+            >>> from sympy.abc import x, y, z
 
             >>> eq = 2 + 2*x + 2*y*(3 + 3*y)
 
@@ -1150,29 +1150,15 @@ class Expr(Basic, EvalfMixin):
             Terms may end up joining once their as_content_primitives are added:
                 >>> ((5*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive()
                 (11, x*(y + 1))
+                >>> ((3*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive()
+                (9, x*(y + 1))
+                >>> ((3*(z*(1 + y)) + 2.0*x*(3 + 3*y))).as_content_primitive()
+                (3, 2.0*x*(y + 1) + z*(y + 1))
                 >>> ((5*(x*(1 + y)) + 2*x*(3 + 3*y))**2).as_content_primitive()
                 (121, x**2*(y + 1)**2)
 
         """
-        from sympy.polys.polytools import _keep_coeff as MUL
-        expr = self
-        if not expr.args:
-            return expr._as_content_primitive()
-        args = list(Add.make_args(expr))
-        if len(args) == 1:
-            p = expr.func(*[MUL(*a._as_content_primitive()) for a in expr.args])
-            c = S.One
-        else:
-            c = S.Zero
-            for i, a in enumerate(args):
-                ci, p = a._as_content_primitive()
-                args[i] = (ci, p)
-                c = c.gcd(ci)
-            p = expr.func(*[MUL(ci/c, p) for ci, p in args])
-        if p.is_Mul:
-            ci, p = p.as_coeff_Mul()
-            c *= ci
-        return c, p
+        return S.One, self
 
     def as_numer_denom(self):
         """ a/b -> a,b

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1276,9 +1276,33 @@ class Mul(AssocOp):
             s *= x._sage_()
         return s
 
+    def _as_content_primitive(self):
+        """Return ``(R, self/R)`` where ``R`` is the product of the Rational
+        GCD that can be extracted from self's arguments while retaining
+        self's structure.
+
+        Example:
+
+        >>> from sympy.abc import x
+        >>> ((3+3*x)*(2+2*x)*(1+x)**2).as_content_primitive()
+        (6, (x + 1)**4)
+        """
+
+        coef = S.One
+        args = []
+        for i, a in enumerate(self.args):
+            c, p = a._as_content_primitive()
+            coef *= c
+            if p is not S.One:
+                args.append(p)
+        # don't use self._from_args here to reconstruct args
+        # since there may be identical args now that should be combined
+        # e.g. (2+2*x)*(3+3*x) should be (6, (1 + x)**2) not (6, (1+x)*(1+x))
+        return coef, Mul(*args)
+
 def prod(a):
-    """Return product of elements of a. Start with int 1 so if only ints are included,
-    an int result is returned.
+    """Return product of elements of a. Start with int 1 so if only
+       ints are included then an int result is returned.
 
     Example:
     >>> from sympy import prod, S

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1276,7 +1276,7 @@ class Mul(AssocOp):
             s *= x._sage_()
         return s
 
-    def _as_content_primitive(self):
+    def as_content_primitive(self):
         """Return ``(R, self/R)`` where ``R`` is the product of the Rational
         GCD that can be extracted from self's arguments while retaining
         self's structure.
@@ -1291,7 +1291,7 @@ class Mul(AssocOp):
         coef = S.One
         args = []
         for i, a in enumerate(self.args):
-            c, p = a._as_content_primitive()
+            c, p = a.as_content_primitive()
             coef *= c
             if p is not S.One:
                 args.append(p)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1277,15 +1277,15 @@ class Mul(AssocOp):
         return s
 
     def as_content_primitive(self):
-        """Return ``(R, self/R)`` where ``R`` is the product of the Rational
-        GCD that can be extracted from self's arguments while retaining
-        self's structure.
+        """Return the tuple (R, self/R) where R is the positive Rational
+        extracted from self.
 
-        Example:
+        **Example**
+        >>> from sympy import sqrt
+        >>> (-3*sqrt(2)*(2 - 2*sqrt(2))).as_content_primitive()
+        (6, -sqrt(2)*(-sqrt(2) + 1))
 
-        >>> from sympy.abc import x
-        >>> ((3+3*x)*(2+2*x)*(1+x)**2).as_content_primitive()
-        (6, (x + 1)**4)
+        See docstring of Expr.as_content_primitive for more examples.
         """
 
         coef = S.One

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -927,6 +927,17 @@ class Rational(Number):
         return sage.Integer(self.p)/sage.Integer(self.q)
 
     def as_content_primitive(self):
+        """Return the tuple (R, self/R) where R is the positive Rational
+        extracted from self.
+
+        **Example**
+        >>> from sympy import S
+        >>> (S(-3)/2).as_content_primitive()
+        (3/2, -1)
+
+        See docstring of Expr.as_content_primitive for more examples.
+        """
+
         if self and self.q:
             if self.is_positive:
                 return self, S.One

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -926,7 +926,7 @@ class Rational(Number):
         import sage.all as sage
         return sage.Integer(self.p)/sage.Integer(self.q)
 
-    def _as_content_primitive(self):
+    def as_content_primitive(self):
         if self and self.q:
             if self.is_positive:
                 return self, S.One

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -926,6 +926,13 @@ class Rational(Number):
         import sage.all as sage
         return sage.Integer(self.p)/sage.Integer(self.q)
 
+    def _as_content_primitive(self):
+        if self and self.q:
+            if self.is_positive:
+                return self, S.One
+            return -self, S.NegativeOne
+        return  S.One, self
+
 # int -> Integer
 _intcache = {}
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -864,6 +864,26 @@ class Pow(Expr):
     def _sage_(self):
         return self.args[0]._sage_()**self.args[1]._sage_()
 
+    def _as_content_primitive(self):
+        """Return ``(R**i, (b/R)**i)`` where ``R`` is the Rational GCD
+        that can be extracted from the base ``b`` of self if the exponent of
+        self, ``i`` is an Integer, else return ``(1, self)``.
+
+        Example:
+
+        >>> from sympy.abc import x, y
+        >>> ((2*x + 2)**2).as_content_primitive()
+        (4, (x + 1)**2)
+        >>> ((2 + 2*x)**y).as_content_primitive()
+        (1, (2*(x + 1))**y)
+        """
+
+        if self.exp.is_Integer:
+            c, p = self.base._as_content_primitive()
+            c = c**self.exp
+            return c, Pow(p, self.exp)
+        return S.One, self
+
 from add import Add
 from numbers import Integer
 from mul import Mul

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -865,10 +865,16 @@ class Pow(Expr):
         return self.args[0]._sage_()**self.args[1]._sage_()
 
     def as_content_primitive(self):
-        """Rewrite self as (R, b**e) where R is the largest Rational that can
-        extracted from self and b and e are in primitive form.
+        """Return the tuple (R, self/R) where R is the positive Rational
+        extracted from self.
 
         **Examples**
+
+        >>> from sympy import sqrt
+        >>> sqrt(4 + 4*sqrt(2)).as_content_primitive()
+        (2, sqrt(1 + sqrt(2)))
+        >>> sqrt(3 + 3*sqrt(2)).as_content_primitive()
+        (1, sqrt(3)*sqrt(1 + sqrt(2)))
 
         >>> from sympy import separate, powsimp, Mul
         >>> from sympy.abc import x, y
@@ -896,13 +902,16 @@ class Pow(Expr):
         (1, (2*(x + 1))**y)
         >>> s = separate(_[1]); s.is_Mul, s
         (True, 2**y*(x + 1)**y)
+
+        See docstring of Expr.as_content_primitive for more examples.
         """
+
         from sympy.polys.polytools import _keep_coeff
         b, e = self.as_base_exp()
         b = _keep_coeff(*b.as_content_primitive())
         ce, pe = e.as_content_primitive()
         if b.is_Rational:
-            # e
+            #e
             #= ce*pe
             #= ce*(h + t)
             #= ce*h + ce*t
@@ -929,8 +938,9 @@ class Pow(Expr):
             m, me = m.as_base_exp()
             if m is S.One or me == e: # probably always true
                 # return the following, not return c, m*Pow(t, e)
-                # which would change Pow into Mul
-                return c, Pow(m*t, e)
+                # which would change Pow into Mul; we let sympy
+                # decide what to do by using the unevaluated Mul
+                return c, Pow(_keep_coeff(m, t), e)
         return S.One, Pow(b, e)
 
 from add import Add

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -922,11 +922,15 @@ class Pow(Expr):
                     c = Pow(b, iceh)
                 return c, Pow(b, _keep_coeff(ce, t + r/ce/ceh.q))
         e = _keep_coeff(ce, pe)
+        # b**e = (h*t)**e = h**e*t**e = c*m*t**e
         if e.is_Rational and b.is_Mul:
-            h, t = b.as_two_terms()
-            c = Pow(h, e)
-            if c.is_Rational:
-                return c, Pow(t, e)
+            h, t = b.as_content_primitive() # h is positive
+            c, m = Pow(h, e).as_coeff_Mul() # so c is positive
+            m, me = m.as_base_exp()
+            if m is S.One or me == e: # probably always true
+                # return the following, not return c, m*Pow(t, e)
+                # which would change Pow into Mul
+                return c, Pow(m*t, e)
         return S.One, Pow(b, e)
 
 from add import Add

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1182,31 +1182,47 @@ def test_issue2027():
     i = Symbol('i', integer=1)
     assert (-2)**i*(-3)**i == 6**i
 
-def test_Add_primitive():
-    assert (x + 2).primitive() == (1, x + 2)
+def test_Rational_as_content_primitive():
+    c, p = S(1), S(0)
+    assert (c*p).as_content_primitive() == (c, p)
+    c, p = S(1)/2, S(1)
+    assert (c*p).as_content_primitive() == (c, p)
 
-    assert (3*x + 2).primitive() == (1, 3*x + 2)
-    assert (3*x + 3).primitive() == (3, x + 1)
-    assert (3*x + 6).primitive() == (3, x + 2)
+def test_Add_as_content_primitive():
+    assert (x + 2).as_content_primitive() == (1, x + 2)
 
-    assert (3*x + 2*y).primitive() == (1, 3*x + 2*y)
-    assert (3*x + 3*y).primitive() == (3, x + y)
-    assert (3*x + 6*y).primitive() == (3, x + 2*y)
+    assert (3*x + 2).as_content_primitive() == (1, 3*x + 2)
+    assert (3*x + 3).as_content_primitive() == (3, x + 1)
+    assert (3*x + 6).as_content_primitive() == (3, x + 2)
 
-    assert (3/x + 2*x*y*z**2).primitive() == (1, 3/x + 2*x*y*z**2)
-    assert (3/x + 3*x*y*z**2).primitive() == (3, 1/x + x*y*z**2)
-    assert (3/x + 6*x*y*z**2).primitive() == (3, 1/x + 2*x*y*z**2)
+    assert (3*x + 2*y).as_content_primitive() == (1, 3*x + 2*y)
+    assert (3*x + 3*y).as_content_primitive() == (3, x + y)
+    assert (3*x + 6*y).as_content_primitive() == (3, x + 2*y)
 
-    assert (2*x/3 + 4*y/9).primitive() == (Rational(2, 9), 3*x + 2*y)
-    assert (2*x/3 + 4.1*y).primitive() == (1, 2*x/3 + 4.1*y)
-    assert S.Zero.gcd(1.0) == 1 # the loop in primitive assumes this to be true
+    assert (3/x + 2*x*y*z**2).as_content_primitive() == (1, 3/x + 2*x*y*z**2)
+    assert (3/x + 3*x*y*z**2).as_content_primitive() == (3, 1/x + x*y*z**2)
+    assert (3/x + 6*x*y*z**2).as_content_primitive() == (3, 1/x + 2*x*y*z**2)
+
+    assert (2*x/3 + 4*y/9).as_content_primitive() == (Rational(2, 9), 3*x + 2*y)
+    assert (2*x/3 + 2.5*y).as_content_primitive() == (Rational(1, 3), 2*x + 7.5*y)
 
     # the coefficient may sort to a position other than 0
     p = 3 + x + y
-    assert (2*p).expand().primitive() == (2, p)
-    assert (2.0*p).expand().primitive() == (1, 2.*p)
+    assert (2*p).expand().as_content_primitive() == (2, p)
+    assert (2.0*p).expand().as_content_primitive() == (1, 2.*p)
     p *= -1
-    assert (2*p).expand().primitive() == (2, p)
+    assert (2*p).expand().as_content_primitive() == (2, p)
+
+def test_Mul_as_content_primitive():
+    assert (2*x).as_content_primitive() == (2, x)
+    assert (x*(2+2*x)).as_content_primitive() == (2, x*(1 + x))
+    assert (x*(2 + 2*y)*(3*x + 3)**2).as_content_primitive() == (18, x*(1 + y)*(x + 1)**2)
+    assert ((2+2*x)**2*(3+6*x)+S.Half).as_content_primitive() == (S.Half, 24*(x + 1)**2*(2*x + 1) + 1)
+
+def test_Pow_as_content_primitive():
+    assert (x**y).as_content_primitive() == (1, x**y)
+    assert ((2*x + 2)**y).as_content_primitive() == (1, (Mul(2,(x + 1), evaluate=False))**y)
+    assert ((2*x + 2)**3).as_content_primitive() == (8, (x + 1)**3)
 
 def test_issue2361():
     u = Mul(2, (1 + x), evaluate=False)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1133,3 +1133,14 @@ def test_issue_1100():
     a = x - y
     assert a._eval_interval(x, 1, oo)._eval_interval(y, oo, 1) is S.NaN
     raises(ValueError, 'x._eval_interval(x, None, None)')
+
+def test_primitive():
+    assert (3*(x + 1)**2).primitive() == (3, (x + 1)**2)
+    assert (6*x + 2).primitive() == (2, 3*x + 1)
+    assert (x/2 + 3).primitive() == (S(1)/2, x + 6)
+    eq = (6*x + 2)*(x/2 + 3)
+    assert eq.primitive()[0] == 1
+    eq = (2 + 2*x)**2
+    assert eq.primitive()[0] == 1
+    assert (4.0*x).primitive() == (1, 4.0*x)
+    assert (-2*x).primitive() == (2, -x)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -392,6 +392,7 @@ def test_noncommutative_expand_issue658():
     assert (A*(A+B+C)*B).expand() == A**2*B + A*B**2 + A*C*B
 
 def test_as_numer_denom():
+    a, b, c = symbols('a, b, c')
     assert oo.as_numer_denom() == (1, 0)
     assert (-oo).as_numer_denom() == (-1, 0)
     assert zoo.as_numer_denom() == (zoo, 1)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -858,3 +858,10 @@ def test_issue_1023():
 
 def test_GoldenRatio_expand():
     assert GoldenRatio.expand(func=True) == S.Half + sqrt(5)/2
+
+def test_as_content_primitive():
+    assert S.Zero.as_content_primitive() == (1, 0)
+    assert S.Half.as_content_primitive() == (S.Half, 1)
+    assert (-S.Half).as_content_primitive() == (S.Half, -1)
+    assert S(3).as_content_primitive() == (3, 1)
+    assert S(3.1).as_content_primitive() == (1, 3.1)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,7 +1,8 @@
 from sympy import (S, symbols, integrate, Integral, Derivative, exp, erf, oo, Symbol,
         Function, Rational, log, sin, cos, pi, E, I, Poly, LambertW, diff, Matrix,
         sympify, sqrt, atan, asin, acos, asinh, acosh, DiracDelta, Heaviside,
-        Lambda, sstr, Add, Tuple, Interval, Sum, factor, trigsimp, simplify, O)
+        Lambda, sstr, Add, Tuple, Interval, Sum, factor, trigsimp, simplify, O,
+        terms_gcd)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.physics.units import m, s
 
@@ -620,7 +621,7 @@ def test_issue_841():
     i = integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo))
     ans = sqrt(pi)*exp(d**2/a)*(1 + erf(oo - d/sqrt(a)))/(2*sqrt(a))
     n, d = i.as_numer_denom()
-    assert factor(n, expand=False)/d == ans
+    assert terms_gcd(n, expand=False)/d == ans
 
 def test_issue_2314():
     # Note that this is not the same as testing ratint() becuase integrate()

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4687,16 +4687,27 @@ def primitive(f, *gens, **args):
     **Examples**
 
     >>> from sympy.polys.polytools import primitive
-    >>> from sympy.abc import x
+    >>> from sympy.abc import x, y
 
     >>> primitive(6*x**2 + 8*x + 12)
     (2, 3*x**2 + 4*x + 6)
 
     >>> eq = (2 + 2*x)*x + 2
+
+    Expansion is performed by default:
+
     >>> primitive(eq)
     (2, x**2 + x + 1)
+
+    Set ``expand`` to False to shut this off (but not that the
+    extraction will not be recursive (use the as_content_primitive method
+    for recursive, non-destructive Rational extraction.)
+
     >>> primitive(eq, expand=False)
     (1, x*(2*x + 2) + 2)
+
+    >>> eq.as_content_primitive()
+    (2, x*(x + 1) + 1)
 
     """
     options.allowed_flags(args, ['polys'])

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4,7 +4,7 @@ from sympy import SYMPY_DEBUG
 
 from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     Derivative, Wild, Symbol, sympify, expand, expand_mul, expand_func,
-    Function, Equality, Dummy, Atom, count_ops)
+    Function, Equality, Dummy, Atom, count_ops, Expr)
 
 from sympy.core.compatibility import iterable
 from sympy.core.numbers import igcd

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -787,10 +787,13 @@ def test_as_content_primitive():
     assert (S.Infinity).as_content_primitive() == (1, oo)
     eq = x**(2+y)
     assert (eq).as_content_primitive() == (1, eq)
-    assert (S.Half**(2 + x)).as_content_primitive() == (S(1)/4, S.Half**x)
-    assert ((-S.Half)**(2 + x)).as_content_primitive() == (S(1)/4, (-S.Half)**x)
-    assert ((-S.Half)**(2 + x)).as_content_primitive() == (S(1)/4, (-S.Half)**x)
+    assert (S.Half**(2 + x)).as_content_primitive() == (S(1)/4, 2**-x)
+    assert ((-S.Half)**(2 + x)).as_content_primitive() == \
+            (S(1)/4, (-S.Half)**x)
+    assert ((-S.Half)**(2 + x)).as_content_primitive() == \
+            (S(1)/4, (-S.Half)**x)
     assert (4**((1 + y)/2)).as_content_primitive() == (2, 4**(y/2))
-    assert (3**((1 + y)/2)).as_content_primitive() == (1, 3**(y/2 + 1/2))
+    assert (3**((1 + y)/2)).as_content_primitive() == \
+            (1, 3**(Mul(S(1)/2, 1 + y, evaluate=False)))
     assert (5**(S(3)/4)).as_content_primitive() == (1, 5**(S(3)/4))
     assert (5**(S(7)/4)).as_content_primitive() == (5, 5**(S(3)/4))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -762,3 +762,26 @@ def test_issue_2629():
     assert powsimp(a*sqrt(a)) == sqrt(a)**3
     assert powsimp(a**2*sqrt(a)) == sqrt(a)**5
     assert powsimp(a**2*sqrt(sqrt(a))) == sqrt(sqrt(a))**9
+
+def test_as_content_primitive():
+    # although the _as_content_primitive methods do not alter the underlying structure,
+    # the as_content_primitive function will touch up the expression and join
+    # bases that would otherwise have not been joined.
+    from sympy.polys.polytools import _keep_coeff as mul2
+    assert ((x*(2 + 2*x)*(3*x + 3)**2)).as_content_primitive() ==\
+    (18, x*(x + 1)**3)
+    assert (2 + 2*x + 2*y*(3 + 3*y)).as_content_primitive() ==\
+    (2, x + 3*y*(y + 1) + 1)
+    assert ((2 + 6*x)**2).as_content_primitive() ==\
+    (4, (3*x + 1)**2)
+    assert ((2 + 6*x)**(2*y)).as_content_primitive() ==\
+    (1, (mul2(S(2), (3*x + 1)))**(2*y))
+    assert (5 + 10*x + 2*y*(3+3*y)).as_content_primitive() ==\
+    (1, 10*x + 6*y*(y + 1) + 5)
+    assert ((5*(x*(1 + y)) + 2*x*(3 + 3*y))).as_content_primitive() ==\
+    (11, x*(y + 1))
+    assert ((5*(x*(1 + y)) + 2*x*(3 + 3*y))**2).as_content_primitive() ==\
+    (121, x**2*(y + 1)**2)
+    assert (y**2).as_content_primitive() ==\
+    (1, y**2)
+    assert (S.Infinity).as_content_primitive() == (1, oo)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -792,3 +792,5 @@ def test_as_content_primitive():
     assert ((-S.Half)**(2 + x)).as_content_primitive() == (S(1)/4, (-S.Half)**x)
     assert (4**((1 + y)/2)).as_content_primitive() == (2, 4**(y/2))
     assert (3**((1 + y)/2)).as_content_primitive() == (1, 3**(y/2 + 1/2))
+    assert (5**(S(3)/4)).as_content_primitive() == (1, 5**(S(3)/4))
+    assert (5**(S(7)/4)).as_content_primitive() == (5, 5**(S(3)/4))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -785,3 +785,10 @@ def test_as_content_primitive():
     assert (y**2).as_content_primitive() ==\
     (1, y**2)
     assert (S.Infinity).as_content_primitive() == (1, oo)
+    eq = x**(2+y)
+    assert (eq).as_content_primitive() == (1, eq)
+    assert (S.Half**(2 + x)).as_content_primitive() == (S(1)/4, S.Half**x)
+    assert ((-S.Half)**(2 + x)).as_content_primitive() == (S(1)/4, (-S.Half)**x)
+    assert ((-S.Half)**(2 + x)).as_content_primitive() == (S(1)/4, (-S.Half)**x)
+    assert (4**((1 + y)/2)).as_content_primitive() == (2, 4**(y/2))
+    assert (3**((1 + y)/2)).as_content_primitive() == (1, 3**(y/2 + 1/2))


### PR DESCRIPTION
These methods help to fill out the functionality introduced by Add.primitive, allowing Mul and Pow to return primitive forms which have a Rational factor pulled out, e.g. `x*(2*x + 2) -> 2*x*(x + 1)`.

Also, polytools primitive probably doesn't belong in the namespace as it is polys specialized. A replacement has been added to simplify which uses the new methods along with the existing primitive method of Add.
