### PR TITLE
add preprocessing to dsolve (autodetection of function, etc.)

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -291,3 +291,37 @@ except ImportError: # < python 2.6
                 return
             indices[i:] = [indices[i] + 1] * (r - i)
             yield tuple(pool[i] for i in indices)
+
+def set_intersection(*sets):
+    """Return the intersection of all the given sets.
+
+    As of Python 2.6 you can write set.intersection(*sets).
+
+    >>> from sympy.core.compatibility import set_intersection
+    >>> set_intersection(set([1, 2]), set([2, 3]))
+    set([2])
+    >>> set_intersection()
+    set()
+    """
+    if not sets:
+        return set()
+    rv = sets[0]
+    for s in sets:
+        rv &= s
+    return rv
+
+def set_union(*sets):
+    """Return the union of all the given sets.
+
+    As of Python 2.6 you can write set.union(*sets).
+
+    >>> from sympy.core.compatibility import set_union
+    >>> set_union(set([1, 2]), set([2, 3]))
+    set([1, 2, 3])
+    >>> set_union()
+    set()
+    """
+    rv = set()
+    for s in sets:
+        rv |= s
+    return rv

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1084,10 +1084,10 @@ def checkodesol(ode, sol, order='auto', solve_for_func=True):
             pass
         else:
             if len(solved) == 1:
-                result = checkodesol(ode, func, Eq(func, solved[0]), \
+                result = checkodesol(ode, Eq(func, solved[0]), \
                     order=order, solve_for_func=False)
             else:
-                result = checkodesol(ode, func, [Eq(func, t) for t in solved],
+                result = checkodesol(ode, [Eq(func, t) for t in solved],
                 order=order, solve_for_func=False)
 
             return result
@@ -2196,7 +2196,7 @@ def ode_Riccati_special_minus2(eq, func, order, match):
     f(x) = -----------------------------------------------------------------------
                                             2*b*x
 
-    >>> checkodesol(genform, y, sol, order=1)[0]
+    >>> checkodesol(genform, sol, order=1)[0]
     True
 
     References:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -33,37 +33,37 @@ g = Function('g')
 def test_checkodesol():
     # For the most part, checkodesol is well tested in the tests below.
     # These tests only handle cases not checked below.
-    raises(ValueError, "checkodesol(f(x).diff(x), f(x), x)")
-    raises(ValueError, "checkodesol(f(x).diff(x), f(x, y), Eq(f(x), x))")
-    assert checkodesol(f(x).diff(x), f(x), Eq(f(x), x)) is not True
-    assert checkodesol(f(x).diff(x), f(x), Eq(f(x), x)) == (False, 1)
+    assert checkodesol(f(x).diff(x), Eq(f(x, y), x)) == \
+        (False, -Derivative(f(x), x) + Derivative(f(x, y), x) - 1)
+    assert checkodesol(f(x).diff(x), Eq(f(x), x)) is not True
+    assert checkodesol(f(x).diff(x), Eq(f(x), x)) == (False, 1)
     sol1 = Eq(f(x)**5 + 11*f(x) - 2*f(x) + x, 0)
-    assert checkodesol(diff(sol1.lhs, x), f(x), sol1) == (True, 0)
-    assert checkodesol(diff(sol1.lhs, x)*exp(f(x)), f(x), sol1) == (True, 0)
-    assert checkodesol(diff(sol1.lhs, x, 2), f(x), sol1) == (True, 0)
-    assert checkodesol(diff(sol1.lhs, x, 2)*exp(f(x)), f(x), sol1) == (True, 0)
-    assert checkodesol(diff(sol1.lhs, x, 3), f(x), sol1) == (True, 0)
-    assert checkodesol(diff(sol1.lhs, x, 3)*exp(f(x)), f(x), sol1) == (True, 0)
-    assert checkodesol(diff(sol1.lhs, x, 3), f(x), Eq(f(x), x*log(x))) == \
+    assert checkodesol(diff(sol1.lhs, x), sol1) == (True, 0)
+    assert checkodesol(diff(sol1.lhs, x)*exp(f(x)), sol1) == (True, 0)
+    assert checkodesol(diff(sol1.lhs, x, 2), sol1) == (True, 0)
+    assert checkodesol(diff(sol1.lhs, x, 2)*exp(f(x)), sol1) == (True, 0)
+    assert checkodesol(diff(sol1.lhs, x, 3), sol1) == (True, 0)
+    assert checkodesol(diff(sol1.lhs, x, 3)*exp(f(x)), sol1) == (True, 0)
+    assert checkodesol(diff(sol1.lhs, x, 3), Eq(f(x), x*log(x))) == \
         (False, -9 + 60*x**4*log(x)**2 + 240*x**4*log(x)**3 +
         235*x**4*log(x)**4 + 60*x**4*log(x)**5)
-    assert checkodesol(diff(exp(f(x)) + x, x)*x, f(x), Eq(exp(f(x)) + x)) == (True, 0)
-    assert checkodesol(diff(exp(f(x)) + x, x)*x, f(x), Eq(exp(f(x)) + x), \
+    assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x)) == (True, 0)
+    assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x), \
         solve_for_func=False) == (True, 0)
-    assert checkodesol(f(x).diff(x, 2), f(x), [Eq(f(x), C1 + C2*x), \
+    assert checkodesol(f(x).diff(x, 2), [Eq(f(x), C1 + C2*x), \
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)]) == \
             [(True, 0), (True, 0), (False, 2*C2)]
-    assert checkodesol(f(x).diff(x, 2), f(x), set([Eq(f(x), C1 + C2*x), \
+    assert checkodesol(f(x).diff(x, 2), set([Eq(f(x), C1 + C2*x), \
         Eq(f(x), C2 + C1*x), Eq(f(x), C1*x + C2*x**2)])) == \
             set([(True, 0), (True, 0), (False, 2*C2)])
-    assert checkodesol(f(x).diff(x) - 1/f(x)/2, f(x), Eq(f(x)**2, x)) == \
+    assert checkodesol(f(x).diff(x) - 1/f(x)/2, Eq(f(x)**2, x)) == \
         [(True, 0), (True, 0)]
-    assert checkodesol(f(x).diff(x) - f(x), f(x), Eq(C1*exp(x), f(x))) == (True, 0)
+    assert checkodesol(f(x).diff(x) - f(x), Eq(C1*exp(x), f(x))) == (True, 0)
     # Based on test_1st_homogeneous_coeff_ode2_eq3sol.  Make sure that
     # checkodesol tries back substituting f(x) when it can.
     eq3 = x*exp(f(x)/x) + f(x) - x*f(x).diff(x)
     sol3 = Eq(f(x), log(log(C1/x)**(-x)))
-    assert not checkodesol(eq3, f(x), sol3)[1].has(f(x))
+    assert not checkodesol(eq3, sol3)[1].has(f(x))
 
 def test_dsolve_options():
     eq = x*f(x).diff(x) + f(x)
@@ -216,17 +216,17 @@ def test_old_ode_tests():
     assert dsolve(eq9, f(x)) == sol9
     assert dsolve(eq10, f(x)) == sol10
     assert dsolve(eq11, f(x)) == sol11
-    assert checkodesol(eq1, f(x), sol1, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq6, f(x), sol6, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq7, f(x), sol7, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq8, f(x), sol8, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq9, f(x), sol9, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq10, f(x), sol10, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq11, f(x), sol11, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq6, sol6, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq7, sol7, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq8, sol8, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq9, sol9, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq10, sol10, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq11, sol11, order=1, solve_for_func=False)[0]
 
 def test_1st_linear():
     # Type: first order linear form f'(x)+p(x)f(x)=q(x)
@@ -234,7 +234,7 @@ def test_1st_linear():
     sol = Eq(f(x),exp(-x**2/2)*(sqrt(2)*sqrt(pi)*I*erf(I*x/sqrt(2))/2 \
     + x*exp(x**2/2) + C1))
     assert dsolve(eq, f(x), hint='1st_linear') == sol
-    assert checkodesol(eq, f(x), sol, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
 
 def test_Bernoulli():
@@ -242,13 +242,13 @@ def test_Bernoulli():
     eq = Eq(x*f(x).diff(x) + f(x) - f(x)**2,0)
     sol = dsolve(eq,f(x), hint='Bernoulli')
     assert sol == Eq(f(x),1/(x*(C1 + 1/x)))
-    assert checkodesol(eq, f(x), sol, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
 def test_Riccati_special_minus2():
     # Type: Riccati special alpha = -2, a*dy/dx + b*y**2 + c*y/x +d/x**2
     eq = 2*f(x).diff(x) + f(x)**2 - f(x)/x + 3*x**(-2)
     sol = dsolve(eq,f(x), hint='Riccati_special_minus2')
-    assert checkodesol(eq, f(x), sol, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
 def test_1st_exact1():
     # Type: Exact differential equation, p(x,f) + q(x,f)*f' == 0,
@@ -268,11 +268,11 @@ def test_1st_exact1():
     assert dsolve(eq3,f(x), hint='1st_exact') == sol3
     assert dsolve(eq4, f(x), hint='1st_exact') == sol4
     assert dsolve(eq5, f(x), hint='1st_exact', simplify=False) == sol5
-    assert checkodesol(eq1, f(x), sol1, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
 @XFAIL
 def test_1st_exact2():
@@ -294,7 +294,7 @@ def test_1st_exact2():
     + 9*asinh(f(x)/x)*f(x)/(x*(-27*f(x)/x + 27*sqrt(1 + f(x)**2/x**2))) \
     + 9*f(x)*log(1 - sqrt(1 + f(x)**2/x**2)*f(x)/x + 2*f(x)**2/x**2)/\
     (x*(-27*f(x)/x + 27*sqrt(1 + f(x)**2/x**2))))
-    assert checkodesol(eq, f(x), sol, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
 def test_separable1():
     # test_separable1-5 are from Ordinary Differential Equations, Tenenbaum and
@@ -316,11 +316,11 @@ def test_separable1():
     assert dsolve(eq3, f(x), hint='separable') == sol3
     assert dsolve(eq4, f(x), hint='separable') == sol4
     assert dsolve(eq5, f(x), hint='separable') == simplify(sol5)
-    assert checkodesol(eq1, f(x), sol1, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
 def test_separable2():
     a = Symbol('a')
@@ -342,9 +342,9 @@ def test_separable2():
     assert dsolve(eq8, f(x), hint='separable') == sol8
     assert str(dsolve(eq9, f(x), hint='separable_Integral')) == sol9str
     assert dsolve(eq10, f(x), hint='separable') == sol10
-    assert checkodesol(eq7, f(x), sol7, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq8, f(x), sol8, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq10, f(x), sol10, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq7, sol7, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq8, sol8, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq10, sol10, order=1, solve_for_func=False)[0]
 
 def test_separable3():
     eq11 = f(x).diff(x) - f(x)*tan(x)
@@ -356,15 +356,15 @@ def test_separable3():
     assert dsolve(eq11, f(x), hint='separable') == simplify(sol11)
     assert dsolve(eq12, f(x), hint='separable') == sol12
     assert dsolve(eq13, f(x), hint='separable') == sol13
-    assert checkodesol(eq11, f(x), sol11, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq13, f(x), sol13, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq11, sol11, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq13, sol13, order=1, solve_for_func=False)[0]
 
 def test_separable4():
     # This has a slow integral (1/((1 + y**2)*atan(y))), so we isolate it.
     eq14 = x*f(x).diff(x) + (1 + f(x)**2)*atan(f(x))
     sol14 = Eq(log(atan(f(x))), C1 - log(x))
     assert dsolve(eq14, f(x), hint='separable') == sol14
-    assert checkodesol(eq14, f(x), sol14, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq14, sol14, order=1, solve_for_func=False)[0]
 
 def test_separable5():
     eq15 = f(x).diff(x) + x*(f(x) + 1)
@@ -395,18 +395,18 @@ def test_separable5():
                                                     sol19d, sol19e]
     assert dsolve(eq20, f(x), hint='separable') == sol20
     assert dsolve(eq21, f(x), hint='separable') == sol21
-    assert checkodesol(eq15, f(x), sol15, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq16, f(x), sol16, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq17, f(x), sol17, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq18, f(x), sol18, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq19, f(x), sol19a, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq20, f(x), sol20, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq21, f(x), sol21, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq15, sol15, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq16, sol16, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq17, sol17, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq18, sol18, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq19, sol19a, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq20, sol20, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq21, sol21, order=1, solve_for_func=False)[0]
 
 def test_separable_1_5_checkodesol():
     eq12 = (x - 1)*cos(f(x))*f(x).diff(x) - 2*x*sin(f(x))
     sol12 = Eq(-log(1 - cos(f(x))**2)/2, C1 - 2*x - 2*log(1 - x))
-    assert checkodesol(eq12, f(x), sol12, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq12, sol12, order=1, solve_for_func=False)[0]
 
 def test_homogeneous_order():
     assert homogeneous_order(exp(y/x) + tan(y/x), x, y) == 0
@@ -485,12 +485,12 @@ def test_1st_homogeneous_coeff_ode1_sol():
     sol5 = Eq(log(C1*x*sqrt(1/x)*sqrt(f(x))) + x**2/(2*f(x)**2), 0)
     sol6 = Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(C1*x) - cos(f(x)/x)*exp(-f(x)/x)/2, 0)
     sol8 = Eq(-atan(f(x)/x) + log(C1*x*sqrt(1 + f(x)**2/x**2)), 0)
-    assert checkodesol(eq1, f(x), sol1, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq6, f(x), sol6, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq8, f(x), sol8, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq6, sol6, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq8, sol8, order=1, solve_for_func=False)[0]
 
 @XFAIL
 def test_1st_homogeneous_coeff_ode1_sol_fail():
@@ -505,9 +505,9 @@ def test_1st_homogeneous_coeff_ode1_sol_fail():
     sol7 = Eq(log(C1*f(x)) + 2*sqrt(1 - x/f(x)), 0)
     sol9 = Eq(-Integral(-1/(-(1 - sqrt(1 - _u2**2))*_u2 + _u2), (_u2, __a,
         x/f(x))) + log(C1*f(x)), 0)
-    assert checkodesol(eq2, f(x), sol2, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq7, f(x), sol7, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq9, f(x), sol9, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq7, sol7, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq9, sol9, order=1, solve_for_func=False)[0]
 
 
 def test_1st_homogeneous_coeff_ode2():
@@ -521,17 +521,17 @@ def test_1st_homogeneous_coeff_ode2():
     assert dsolve(eq1, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol1
     assert set(dsolve(eq2, f(x), hint='1st_homogeneous_coeff_best')) == sol2
     assert dsolve(eq3, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol3
-    assert checkodesol(eq1, f(x), sol1, order=1, solve_for_func=False)[0]
-    assert all(i[0] for i in checkodesol(eq2, f(x), sol2, order=1, solve_for_func=False))
+    assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
+    assert all(i[0] for i in checkodesol(eq2, sol2, order=1, solve_for_func=False))
     # the solution doesn't check...perhaps there is something wrong with the routine or the solver?
-    # assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
+    # assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
 
 @XFAIL
 def test_1st_homogeneous_coeff_ode2_eq3sol():
     # simplify() will need to get way better before it can do this one
     eq3 = x*exp(f(x)/x) + f(x) - x*f(x).diff(x)
     sol3 = Eq(f(x), log(log(C1/x)**(-x)))
-    assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
 
 def test_1st_homogeneous_coeff_ode3():
     # This can be solved explicitly, but the the integration engine cannot handle
@@ -547,7 +547,7 @@ def test_1st_homogeneous_coeff_ode4_explicit():
     x = Symbol('x', positive=True)
     eq = f(x)**2+(x*sqrt(f(x)**2-x**2)-x*f(x))*f(x).diff(x)
     sol = dsolve(eq, f(x))
-    assert checkodesol(eq, f(x), sol)[0]
+    assert checkodesol(eq, sol)[0]
 
 def test_1st_homogeneous_coeff_corner_case():
     eq1 = f(x).diff(x) - f(x)/x
@@ -687,36 +687,36 @@ def test_nth_linear_constant_coeff_homogeneous():
     assert dsolve(eq28, f(x)) in (sol28, sol28s)
     assert dsolve(eq29, f(x)) in (sol29, sol29s)
     assert dsolve(eq30, f(x)) in (sol30, sol30s)
-    assert checkodesol(eq1, f(x), sol1, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq6, f(x), sol6, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq7, f(x), sol7, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq8, f(x), sol8, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq9, f(x), sol9, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq10, f(x), sol10, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq11, f(x), sol11, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq12, f(x), sol12, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq13, f(x), sol13, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq14, f(x), sol14, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq15, f(x), sol15, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq16, f(x), sol16, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq17, f(x), sol17, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq18, f(x), sol18, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq19, f(x), sol19, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq20, f(x), sol20, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq21, f(x), sol21, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq22, f(x), sol22, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq23, f(x), sol23, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq24, f(x), sol24, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq25, f(x), sol25, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq26, f(x), sol26, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq27, f(x), sol27, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq28, f(x), sol28, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq29, f(x), sol29, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq30, f(x), sol30, order=5, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq6, sol6, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq7, sol7, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq8, sol8, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq9, sol9, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq10, sol10, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq11, sol11, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq12, sol12, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq13, sol13, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq14, sol14, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq15, sol15, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq16, sol16, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq17, sol17, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq18, sol18, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq19, sol19, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq20, sol20, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq21, sol21, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq22, sol22, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq23, sol23, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq24, sol24, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq25, sol25, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq26, sol26, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq27, sol27, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq28, sol28, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq29, sol29, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq30, sol30, order=5, solve_for_func=False)[0]
 
 def test_nth_linear_constant_coeff_homogeneous_RootOf():
     eq = f(x).diff(x, 5) + 11*f(x).diff(x) - 2*f(x)
@@ -737,7 +737,7 @@ def test_nth_linear_constant_coeff_homogeneous_RootOf_sol():
         C3*exp(x*RootOf(x**5 + 11*x - 2, 2)) + \
         C4*exp(x*RootOf(x**5 + 11*x - 2, 3)) + \
         C5*exp(x*RootOf(x**5 + 11*x - 2, 4)))
-    assert checkodesol(eq, f(x), sol, order=5, solve_for_func=False)[0]
+    assert checkodesol(eq, sol, order=5, solve_for_func=False)[0]
 
 def test_undetermined_coefficients_match():
     assert _undetermined_coefficients_match(g(x), x) == {'test': False}
@@ -955,34 +955,34 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     assert dsolve(eq26, f(x), hint=hint) in (sol26, sol26s)
     assert dsolve(eq27, f(x), hint=hint) in (sol27, sol27s)
     assert dsolve(eq28, f(x), hint=hint) == sol28
-    assert checkodesol(eq1, f(x), sol1, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq6, f(x), sol6, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq7, f(x), sol7, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq8, f(x), sol8, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq9, f(x), sol9, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq10, f(x), sol10, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq11, f(x), sol11, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq12, f(x), sol12, order=4, solve_for_func=False)[0]
-    assert checkodesol(eq13, f(x), sol13, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq14, f(x), sol14, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq15, f(x), sol15, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq16, f(x), sol16, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq17, f(x), sol17, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq18, f(x), sol18, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq19, f(x), sol19, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq20, f(x), sol20, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq21, f(x), sol21, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq22, f(x), sol22, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq23, f(x), sol23, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq24, f(x), sol24, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq25, f(x), sol25, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq26, f(x), sol26, order=5, solve_for_func=False)[0]
-    assert checkodesol(eq27, f(x), sol27, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq28, f(x), sol28, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq6, sol6, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq7, sol7, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq8, sol8, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq9, sol9, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq10, sol10, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq11, sol11, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq12, sol12, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq13, sol13, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq14, sol14, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq15, sol15, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq16, sol16, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq17, sol17, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq18, sol18, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq19, sol19, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq20, sol20, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq21, sol21, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq22, sol22, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq23, sol23, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq24, sol24, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq25, sol25, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq26, sol26, order=5, solve_for_func=False)[0]
+    assert checkodesol(eq27, sol27, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq28, sol28, order=1, solve_for_func=False)[0]
 
 @XFAIL
 def test_nth_linear_constant_coeff_undetermined_coefficients_imaginary_exp():
@@ -993,7 +993,7 @@ def test_nth_linear_constant_coeff_undetermined_coefficients_imaginary_exp():
     eq26a = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x) - 2*x - exp(I*x)
     sol26 = Eq(f(x), C1 + (C2 + C3*x - x**2/8)*sin(x) + (C4 + C5*x + x**2/8)*cos(x) + x**2)
     assert dsolve(eq26a, f(x), hint=hint) == sol26
-    assert checkodesol(eq26a, f(x), sol26, order=5, solve_for_func=False)[0]
+    assert checkodesol(eq26a, sol26, order=5, solve_for_func=False)[0]
 
 def test_nth_linear_constant_coeff_variation_of_parameters():
     hint = 'nth_linear_constant_coeff_variation_of_parameters'
@@ -1046,17 +1046,17 @@ def test_nth_linear_constant_coeff_variation_of_parameters():
     assert dsolve(eq10, f(x), hint=hint) in (sol10, sol10s)
     assert dsolve(eq11, f(x), hint=hint+'_Integral') in (sol11, sol11s)
     assert dsolve(eq12, f(x), hint=hint) in (sol12, sol12s)
-    assert checkodesol(eq1, f(x), sol1, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq3, f(x), sol3, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq4, f(x), sol4, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq5, f(x), sol5, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq6, f(x), sol6, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq7, f(x), sol7, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq8, f(x), sol8, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq9, f(x), sol9, order=3, solve_for_func=False)[0]
-    assert checkodesol(eq10, f(x), sol10, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq12, f(x), sol12, order=4, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq4, sol4, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq5, sol5, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq6, sol6, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq7, sol7, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq8, sol8, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq9, sol9, order=3, solve_for_func=False)[0]
+    assert checkodesol(eq10, sol10, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq12, sol12, order=4, solve_for_func=False)[0]
 
 def test_nth_linear_constant_coeff_variation_of_parameters_simplify_False():
     # solve_variation_of_parameters shouldn't attempt to simplify the
@@ -1094,12 +1094,12 @@ def test_Liouville_ODE():
     assert set(dsolve(eq3, f(x), hint)) in (sol3, sol3s)
     assert set(dsolve(eq4, f(x), hint)) in (sol4, sol4s) # XXX: remove sqrt(2) factor
     assert dsolve(eq5, f(x), hint) in (sol5, sol5s)
-    assert checkodesol(eq1, f(x), sol1, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq1a, f(x), sol1a, order=2, solve_for_func=False)[0]
-    assert checkodesol(eq2, f(x), sol2, order=2, solve_for_func=False)[0]
-    assert all(i[0] for i in checkodesol(eq3, f(x), sol3, order=2, solve_for_func=False))
-    assert all(i[0] for i in checkodesol(eq4, f(x), sol4, order=2, solve_for_func=False))
-    assert checkodesol(eq5, f(x), sol5, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq1, sol1, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq1a, sol1a, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
+    assert all(i[0] for i in checkodesol(eq3, sol3, order=2, solve_for_func=False))
+    assert all(i[0] for i in checkodesol(eq4, sol4, order=2, solve_for_func=False))
+    assert checkodesol(eq5, sol5, order=2, solve_for_func=False)[0]
     not_Liouville1 = classify_ode(diff(f(x),x)/x + f(x)*diff(f(x),x,x)/2 -
         diff(f(x),x)**2/2, f(x))
     not_Liouville2 = classify_ode(diff(f(x),x)/x + diff(f(x),x,x)/2 -
@@ -1116,7 +1116,7 @@ def test_unexpanded_Liouville_ODE():
     sol2 = Eq(f(x), log(x/(C1 + C2*x)))
     sol2s = constant_renumber(sol2, 'C', 1, 2)
     assert dsolve(eq2, f(x)) in (sol2, sol2s)
-    assert checkodesol(eq2, f(x), sol2, order=2, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
 
 def test_1686():
     from sympy.abc import A

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -33,6 +33,8 @@ g = Function('g')
 def test_checkodesol():
     # For the most part, checkodesol is well tested in the tests below.
     # These tests only handle cases not checked below.
+    raises(ValueError, 'checkodesol(f(x, y).diff(x), Eq(f(x, y), x))')
+    raises(ValueError, 'checkodesol(f(x).diff(x), Eq(f(x, y), x), f(x, y))')
     assert checkodesol(f(x).diff(x), Eq(f(x, y), x)) == \
         (False, -f(x).diff(x) + f(x, y).diff(x) - 1)
     assert checkodesol(f(x).diff(x), Eq(f(x), x)) is not True
@@ -125,7 +127,10 @@ def test_dsolve_options():
     raises(ValueError, "dsolve(eq, hint='Liouville')")
     assert dsolve(f(x).diff(x) - 1/f(x)**2, hint='all')['best'] == \
         dsolve(f(x).diff(x) - 1/f(x)**2, hint='best')
-
+    assert dsolve(f(x) + f(x).diff(x) + sin(x).diff(x) + 1, f(x),
+                  hint="1st_linear_Integral") == \
+        Eq(f(x), (C1 + Integral((-sin(x).diff(x) - \
+        1)*exp(Integral(1, x)), x))*exp(-Integral(1, x)))
 
 def test_classify_ode():
     assert classify_ode(f(x).diff(x, 2), f(x)) == \
@@ -157,6 +162,23 @@ def test_classify_ode():
                                 '1st_exact',
                                 'separable_Integral',
                                 '1st_exact_Integral')
+    # preprocessing
+    ans = ('separable', '1st_exact', '1st_linear', 'Bernoulli',
+        '1st_homogeneous_coeff_best', '1st_homogeneous_coeff_subs_indep_div_dep',
+        '1st_homogeneous_coeff_subs_dep_div_indep',
+        'nth_linear_constant_coeff_undetermined_coefficients',
+        'nth_linear_constant_coeff_variation_of_parameters',
+        'separable_Integral', '1st_exact_Integral',
+        '1st_linear_Integral',
+        'Bernoulli_Integral',
+        '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
+       '1st_homogeneous_coeff_subs_dep_div_indep_Integral',
+       'nth_linear_constant_coeff_variation_of_parameters_Integral')
+    #     w/o f(x) given
+    assert classify_ode(diff(f(x) + x, x) + diff(f(x), x)) == ans
+    #     w/ f(x) and prep=True
+    assert classify_ode(diff(f(x) + x, x) + diff(f(x), x), f(x),
+                        prep=True) == ans
 
 def test_ode_order():
     f = Function('f')

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -34,7 +34,7 @@ def test_checkodesol():
     # For the most part, checkodesol is well tested in the tests below.
     # These tests only handle cases not checked below.
     assert checkodesol(f(x).diff(x), Eq(f(x, y), x)) == \
-        (False, -Derivative(f(x), x) + Derivative(f(x, y), x) - 1)
+        (False, -f(x).diff(x) + f(x, y).diff(x) - 1)
     assert checkodesol(f(x).diff(x), Eq(f(x), x)) is not True
     assert checkodesol(f(x).diff(x), Eq(f(x), x)) == (False, 1)
     sol1 = Eq(f(x)**5 + 11*f(x) - 2*f(x) + x, 0)
@@ -67,9 +67,9 @@ def test_checkodesol():
 
 def test_dsolve_options():
     eq = x*f(x).diff(x) + f(x)
-    a = dsolve(eq, f(x), hint='all')
-    b = dsolve(eq, f(x), hint='all', simplify=False)
-    c = dsolve(eq, f(x), hint='all_Integral')
+    a = dsolve(eq, hint='all')
+    b = dsolve(eq, hint='all', simplify=False)
+    c = dsolve(eq, hint='all_Integral')
     keys = ['1st_exact', '1st_exact_Integral', '1st_homogeneous_coeff_best', \
         '1st_homogeneous_coeff_subs_dep_div_indep', \
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral', \
@@ -84,7 +84,7 @@ def test_dsolve_options():
     assert sorted(a.keys()) == keys
     assert a['order'] == ode_order(eq, f(x))
     assert a['best'] == Eq(f(x), C1/x)
-    assert dsolve(eq, f(x), hint='best') == Eq(f(x), C1/x)
+    assert dsolve(eq, hint='best') == Eq(f(x), C1/x)
     assert a['default'] == 'separable'
     assert a['best_hint'] == 'separable'
     assert not a['1st_exact'].has(Integral)
@@ -101,7 +101,7 @@ def test_dsolve_options():
     assert sorted(b.keys()) == keys
     assert b['order'] == ode_order(eq, f(x))
     assert b['best'] == Eq(f(x), C1/x)
-    assert dsolve(eq, f(x), hint='best', simplify=False) == Eq(f(x), C1/x)
+    assert dsolve(eq, hint='best', simplify=False) == Eq(f(x), C1/x)
     assert b['default'] == 'separable'
     assert b['best_hint'] == '1st_linear'
     assert a['separable'] != b['separable']
@@ -121,10 +121,10 @@ def test_dsolve_options():
     assert b['1st_homogeneous_coeff_subs_indep_div_dep_Integral'].has(Integral)
     assert b['separable_Integral'].has(Integral)
     assert sorted(c.keys()) == Integral_keys
-    raises(ValueError, "dsolve(eq, f(x), 'notarealhint')")
-    raises(ValueError, "dsolve(eq, f(x), 'Liouville')")
-    assert dsolve(f(x).diff(x) - 1/f(x)**2, f(x), 'all')['best'] == \
-        dsolve(f(x).diff(x) - 1/f(x)**2, f(x), 'best')
+    raises(ValueError, "dsolve(eq, hint='notarealhint')")
+    raises(ValueError, "dsolve(eq, hint='Liouville')")
+    assert dsolve(f(x).diff(x) - 1/f(x)**2, hint='all')['best'] == \
+        dsolve(f(x).diff(x) - 1/f(x)**2, hint='best')
 
 
 def test_classify_ode():
@@ -204,18 +204,18 @@ def test_old_ode_tests():
     sol9 = Eq(f(x), (C1*cos(x*sqrt(2)) + C2*sin(x*sqrt(2)))*exp(-x))
     sol10 = Eq(f(x), C1 + x/3)
     sol11 = Eq(f(x), C1 + log(x))
-    assert dsolve(eq1, f(x)) == sol1
-    assert dsolve(eq1.lhs, f(x)) == sol1
-    assert dsolve(eq2, f(x)) == sol2
-    assert dsolve(eq3, f(x)) == sol3
-    assert dsolve(eq4, f(x)) == sol4
-    assert dsolve(eq5, f(x)) == sol5
-    assert dsolve(eq6, f(x)) == sol6
-    assert dsolve(eq7, f(x)) == sol7
-    assert dsolve(eq8, f(x)) == sol8
-    assert dsolve(eq9, f(x)) == sol9
-    assert dsolve(eq10, f(x)) == sol10
-    assert dsolve(eq11, f(x)) == sol11
+    assert dsolve(eq1) == sol1
+    assert dsolve(eq1.lhs) == sol1
+    assert dsolve(eq2) == sol2
+    assert dsolve(eq3) == sol3
+    assert dsolve(eq4) == sol4
+    assert dsolve(eq5) == sol5
+    assert dsolve(eq6) == sol6
+    assert dsolve(eq7) == sol7
+    assert dsolve(eq8) == sol8
+    assert dsolve(eq9) == sol9
+    assert dsolve(eq10) == sol10
+    assert dsolve(eq11) == sol11
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
@@ -233,7 +233,7 @@ def test_1st_linear():
     eq = Eq(f(x).diff(x) + x*f(x), x**2)
     sol = Eq(f(x),exp(-x**2/2)*(sqrt(2)*sqrt(pi)*I*erf(I*x/sqrt(2))/2 \
     + x*exp(x**2/2) + C1))
-    assert dsolve(eq, f(x), hint='1st_linear') == sol
+    assert dsolve(eq, hint='1st_linear') == sol
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
 
@@ -266,8 +266,8 @@ def test_1st_exact1():
     assert dsolve(eq1,f(x), hint='1st_exact') == sol1
     assert dsolve(eq2,f(x), hint='1st_exact') == sol2
     assert dsolve(eq3,f(x), hint='1st_exact') == sol3
-    assert dsolve(eq4, f(x), hint='1st_exact') == sol4
-    assert dsolve(eq5, f(x), hint='1st_exact', simplify=False) == sol5
+    assert dsolve(eq4, hint='1st_exact') == sol4
+    assert dsolve(eq5, hint='1st_exact', simplify=False) == sol5
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
@@ -287,7 +287,7 @@ def test_1st_exact2():
     """
     skip("takes too much time")
     eq = x*sqrt(x**2 + f(x)**2) - (x**2*f(x)/(f(x) - sqrt(x**2 + f(x)**2)))*f(x).diff(x)
-    sol = dsolve(eq, f(x))
+    sol = dsolve(eq)
     assert sol == Eq(log(x),C1 - 9*sqrt(1 + f(x)**2/x**2)*asinh(f(x)/x)/(-27*f(x)/x + \
     27*sqrt(1 + f(x)**2/x**2)) - 9*sqrt(1 + f(x)**2/x**2)*log(1 - sqrt(1 + f(x)**2/x**2)*\
     f(x)/x + 2*f(x)**2/x**2)/(-27*f(x)/x + 27*sqrt(1 + f(x)**2/x**2)) \
@@ -311,11 +311,11 @@ def test_separable1():
     sol5 = Eq(f(x), -2 + C1*sqrt(1 + tan(x)**2))
     #sol5 = Eq(f(x), C1*(C2 + sqrt(1 + tan(x)**2)))
     #sol5 = Eq(-log(2 + f(x)), C1 - log(1 + tan(x)**2)/2)
-    assert dsolve(eq1, f(x), hint='separable') == sol1
-    assert dsolve(eq2, f(x), hint='separable') == sol2
-    assert dsolve(eq3, f(x), hint='separable') == sol3
-    assert dsolve(eq4, f(x), hint='separable') == sol4
-    assert dsolve(eq5, f(x), hint='separable') == simplify(sol5)
+    assert dsolve(eq1, hint='separable') == sol1
+    assert dsolve(eq2, hint='separable') == sol2
+    assert dsolve(eq3, hint='separable') == sol3
+    assert dsolve(eq4, hint='separable') == sol4
+    assert dsolve(eq5, hint='separable') == simplify(sol5)
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
@@ -337,11 +337,11 @@ def test_separable2():
     # integrate cannot handle the integral on the lhs (cos/tan)
     sol9str = "Integral(cos(_y)/tan(_y), (_y, f(x))) == C1 + Integral(-E*exp(x), x)"
     sol10 = Eq(-log(-1 + sin(f(x))**2)/2, C1 - log(x**2 - a**2)/2)
-    assert str(dsolve(eq6, f(x), hint='separable_Integral')) == sol6str
-    assert dsolve(eq7, f(x), hint='separable') == sol7
-    assert dsolve(eq8, f(x), hint='separable') == sol8
-    assert str(dsolve(eq9, f(x), hint='separable_Integral')) == sol9str
-    assert dsolve(eq10, f(x), hint='separable') == sol10
+    assert str(dsolve(eq6, hint='separable_Integral')) == sol6str
+    assert dsolve(eq7, hint='separable') == sol7
+    assert dsolve(eq8, hint='separable') == sol8
+    assert str(dsolve(eq9, hint='separable_Integral')) == sol9str
+    assert dsolve(eq10, hint='separable') == sol10
     assert checkodesol(eq7, sol7, order=1, solve_for_func=False)[0]
     assert checkodesol(eq8, sol8, order=1, solve_for_func=False)[0]
     assert checkodesol(eq10, sol10, order=1, solve_for_func=False)[0]
@@ -353,9 +353,9 @@ def test_separable3():
     sol11 = Eq(f(x), C1*sqrt(1 + tan(x)**2))
     sol12 = Eq(log(-1 + cos(f(x))**2)/2, C1 + 2*x + 2*log(x - 1))
     sol13 = Eq(log(log(f(x))), C1 - log(1 + tan(x)**2)/2 + log(tan(x)))
-    assert dsolve(eq11, f(x), hint='separable') == simplify(sol11)
-    assert dsolve(eq12, f(x), hint='separable') == sol12
-    assert dsolve(eq13, f(x), hint='separable') == sol13
+    assert dsolve(eq11, hint='separable') == simplify(sol11)
+    assert dsolve(eq12, hint='separable') == sol12
+    assert dsolve(eq13, hint='separable') == sol13
     assert checkodesol(eq11, sol11, order=1, solve_for_func=False)[0]
     assert checkodesol(eq13, sol13, order=1, solve_for_func=False)[0]
 
@@ -363,7 +363,7 @@ def test_separable4():
     # This has a slow integral (1/((1 + y**2)*atan(y))), so we isolate it.
     eq14 = x*f(x).diff(x) + (1 + f(x)**2)*atan(f(x))
     sol14 = Eq(log(atan(f(x))), C1 - log(x))
-    assert dsolve(eq14, f(x), hint='separable') == sol14
+    assert dsolve(eq14, hint='separable') == sol14
     assert checkodesol(eq14, sol14, order=1, solve_for_func=False)[0]
 
 def test_separable5():
@@ -386,15 +386,15 @@ def test_separable5():
     sol19e = Eq(f(x), (C1*(1 - x) - x*(-x*exp(x) + exp(x)) -
                             x*exp(x) + exp(x))/((1 - x)*(-exp(x) + x*exp(x))))
     sol20 = Eq(log(-1 + 3*f(x)**2)/6, C1 + x**2/2)
-    sol21 = Eq(f(x), log(-1/(C1 + exp(x))))
-    assert dsolve(eq15, f(x), hint='separable') == sol15
-    assert dsolve(eq16, f(x), hint='separable', simplify=False) == sol16
-    assert dsolve(eq17, f(x), hint='separable') == sol17
-    assert dsolve(eq18, f(x), hint='separable') == sol18
-    assert dsolve(eq19, f(x), hint='separable') in [sol19a, sol19b, sol19c,
+    sol21 = Eq(-exp(-f(x)), C1 + exp(x))
+    assert dsolve(eq15, hint='separable') == sol15
+    assert dsolve(eq16, hint='separable') == sol16
+    assert dsolve(eq17, hint='separable') == sol17
+    assert dsolve(eq18, hint='separable') == sol18
+    assert dsolve(eq19, hint='separable') in [sol19a, sol19b, sol19c,
                                                     sol19d, sol19e]
-    assert dsolve(eq20, f(x), hint='separable') == sol20
-    assert dsolve(eq21, f(x), hint='separable') == sol21
+    assert dsolve(eq20, hint='separable') == sol20
+    assert dsolve(eq21, hint='separable') == sol21
     assert checkodesol(eq15, sol15, order=1, solve_for_func=False)[0]
     assert checkodesol(eq16, sol16, order=1, solve_for_func=False)[0]
     assert checkodesol(eq17, sol17, order=1, solve_for_func=False)[0]
@@ -460,15 +460,15 @@ def test_1st_homogeneous_coeff_ode1():
     sol6 = Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(C1*x) - cos(f(x)/x)*exp(-f(x)/x)/2, 0)
     sol7 = Eq(log(C1*f(x)) + 2*sqrt(1 - x/f(x)), 0)
     sol8 = Eq(-atan(f(x)/x) + log(C1*x*sqrt(1 + f(x)**2/x**2)), 0)
-    assert dsolve(eq1, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol1
+    assert dsolve(eq1, hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol1
     # indep_div_dep actually has a simpler solution for eq2, but it runs too slow
-    assert dsolve(eq2, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol2
-    assert dsolve(eq3, f(x), hint='1st_homogeneous_coeff_best') == sol3
-    assert dsolve(eq4, f(x), hint='1st_homogeneous_coeff_best') == sol4
-    assert dsolve(eq5, f(x), hint='1st_homogeneous_coeff_best') == sol5
-    assert dsolve(eq6, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol6
-    assert dsolve(eq7, f(x), hint='1st_homogeneous_coeff_best') == sol7
-    assert dsolve(eq8, f(x), hint='1st_homogeneous_coeff_best') == sol8
+    assert dsolve(eq2, hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol2
+    assert dsolve(eq3, hint='1st_homogeneous_coeff_best') == sol3
+    assert dsolve(eq4, hint='1st_homogeneous_coeff_best') == sol4
+    assert dsolve(eq5, hint='1st_homogeneous_coeff_best') == sol5
+    assert dsolve(eq6, hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol6
+    assert dsolve(eq7, hint='1st_homogeneous_coeff_best') == sol7
+    assert dsolve(eq8, hint='1st_homogeneous_coeff_best') == sol8
 
 def test_1st_homogeneous_coeff_ode1_sol():
     skip("This test passes, but it takes too long")
@@ -518,9 +518,9 @@ def test_1st_homogeneous_coeff_ode2():
     sol2 = set([Eq(f(x), -sqrt(C1*x + x**2)), Eq(f(x), sqrt(C1*x + x**2))])
     sol3 = Eq(f(x), log((-1/log(C1*x))**x))
     # specific hints are applied for speed reasons
-    assert dsolve(eq1, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol1
-    assert set(dsolve(eq2, f(x), hint='1st_homogeneous_coeff_best')) == sol2
-    assert dsolve(eq3, f(x), hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol3
+    assert dsolve(eq1, hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol1
+    assert set(dsolve(eq2, hint='1st_homogeneous_coeff_best')) == sol2
+    assert dsolve(eq3, hint='1st_homogeneous_coeff_subs_dep_div_indep') == sol3
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     assert all(i[0] for i in checkodesol(eq2, sol2, order=1, solve_for_func=False))
     # the solution doesn't check...perhaps there is something wrong with the routine or the solver?
@@ -541,12 +541,12 @@ def test_1st_homogeneous_coeff_ode3():
     # expressions because u2 is a dummy variable.
     eq = f(x)**2+(x*sqrt(f(x)**2-x**2)-x*f(x))*f(x).diff(x)
     solstr = "log(C1*f(x)) - Integral(-1/(_u2*sqrt(-_u2**2 + 1)), (_u2, x/f(x))) == 0"
-    assert str(dsolve(eq, f(x), hint='1st_homogeneous_coeff_subs_indep_div_dep')) == solstr
+    assert str(dsolve(eq, hint='1st_homogeneous_coeff_subs_indep_div_dep')) == solstr
 
 def test_1st_homogeneous_coeff_ode4_explicit():
     x = Symbol('x', positive=True)
     eq = f(x)**2+(x*sqrt(f(x)**2-x**2)-x*f(x))*f(x).diff(x)
-    sol = dsolve(eq, f(x))
+    sol = dsolve(eq)
     assert checkodesol(eq, sol)[0]
 
 def test_1st_homogeneous_coeff_corner_case():
@@ -657,36 +657,36 @@ def test_nth_linear_constant_coeff_homogeneous():
     sol28s = constant_renumber(sol28, 'C', 1, 3)
     sol29s = constant_renumber(sol29, 'C', 1, 4)
     sol30s = constant_renumber(sol30, 'C', 1, 5)
-    assert dsolve(eq1, f(x)) in (sol1, sol1s)
-    assert dsolve(eq2, f(x)) in (sol2, sol2s)
-    assert dsolve(eq3, f(x)) in (sol3, sol3s)
-    assert dsolve(eq4, f(x)) in (sol4, sol4s)
-    assert dsolve(eq5, f(x)) in (sol5, sol5s)
-    assert dsolve(eq6, f(x)) in (sol6, sol6s)
-    assert dsolve(eq7, f(x)) in (sol7, sol7s)
-    assert dsolve(eq8, f(x)) in (sol8, sol8s)
-    assert dsolve(eq9, f(x)) in (sol9, sol9s)
-    assert dsolve(eq10, f(x)) in (sol10, sol10s)
-    assert dsolve(eq11, f(x)) in (sol11, sol11s)
-    assert dsolve(eq12, f(x)) in (sol12, sol12s)
-    assert dsolve(eq13, f(x)) in (sol13, sol13s)
-    assert dsolve(eq14, f(x)) in (sol14, sol14s)
-    assert dsolve(eq15, f(x)) in (sol15, sol15s)
-    assert dsolve(eq16, f(x)) in (sol16, sol16s)
-    assert dsolve(eq17, f(x)) in (sol17, sol17s)
-    assert dsolve(eq18, f(x)) in (sol18, sol18s)
-    assert dsolve(eq19, f(x)) in (sol19, sol19s)
-    assert dsolve(eq20, f(x)) in (sol20, sol20s)
-    assert dsolve(eq21, f(x)) in (sol21, sol21s)
-    assert dsolve(eq22, f(x)) in (sol22, sol22s)
-    assert dsolve(eq23, f(x)) in (sol23, sol23s)
-    assert dsolve(eq24, f(x)) in (sol24, sol24s)
-    assert dsolve(eq25, f(x)) in (sol25, sol25s)
-    assert dsolve(eq26, f(x)) in (sol26, sol26s)
-    assert dsolve(eq27, f(x)) in (sol27, sol27s)
-    assert dsolve(eq28, f(x)) in (sol28, sol28s)
-    assert dsolve(eq29, f(x)) in (sol29, sol29s)
-    assert dsolve(eq30, f(x)) in (sol30, sol30s)
+    assert dsolve(eq1) in (sol1, sol1s)
+    assert dsolve(eq2) in (sol2, sol2s)
+    assert dsolve(eq3) in (sol3, sol3s)
+    assert dsolve(eq4) in (sol4, sol4s)
+    assert dsolve(eq5) in (sol5, sol5s)
+    assert dsolve(eq6) in (sol6, sol6s)
+    assert dsolve(eq7) in (sol7, sol7s)
+    assert dsolve(eq8) in (sol8, sol8s)
+    assert dsolve(eq9) in (sol9, sol9s)
+    assert dsolve(eq10) in (sol10, sol10s)
+    assert dsolve(eq11) in (sol11, sol11s)
+    assert dsolve(eq12) in (sol12, sol12s)
+    assert dsolve(eq13) in (sol13, sol13s)
+    assert dsolve(eq14) in (sol14, sol14s)
+    assert dsolve(eq15) in (sol15, sol15s)
+    assert dsolve(eq16) in (sol16, sol16s)
+    assert dsolve(eq17) in (sol17, sol17s)
+    assert dsolve(eq18) in (sol18, sol18s)
+    assert dsolve(eq19) in (sol19, sol19s)
+    assert dsolve(eq20) in (sol20, sol20s)
+    assert dsolve(eq21) in (sol21, sol21s)
+    assert dsolve(eq22) in (sol22, sol22s)
+    assert dsolve(eq23) in (sol23, sol23s)
+    assert dsolve(eq24) in (sol24, sol24s)
+    assert dsolve(eq25) in (sol25, sol25s)
+    assert dsolve(eq26) in (sol26, sol26s)
+    assert dsolve(eq27) in (sol27, sol27s)
+    assert dsolve(eq28) in (sol28, sol28s)
+    assert dsolve(eq29) in (sol29, sol29s)
+    assert dsolve(eq30) in (sol30, sol30s)
     assert checkodesol(eq1, sol1, order=2, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=2, solve_for_func=False)[0]
@@ -726,7 +726,7 @@ def test_nth_linear_constant_coeff_homogeneous_RootOf():
         C3*exp(x*RootOf(x**5 + 11*x - 2, 2)) + \
         C4*exp(x*RootOf(x**5 + 11*x - 2, 3)) + \
         C5*exp(x*RootOf(x**5 + 11*x - 2, 4)))
-    assert dsolve(eq, f(x)) == sol
+    assert dsolve(eq) == sol
 
 @XFAIL
 def test_nth_linear_constant_coeff_homogeneous_RootOf_sol():
@@ -927,34 +927,34 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     sol25s = constant_renumber(sol25, 'C', 1, 3)
     sol26s = constant_renumber(sol26, 'C', 1, 5)
     sol27s = constant_renumber(sol27, 'C', 1, 2)
-    assert dsolve(eq1, f(x), hint=hint) in (sol1, sol1s)
-    assert dsolve(eq2, f(x), hint=hint) in (sol2, sol2s)
-    assert dsolve(eq3, f(x), hint=hint) in (sol3, sol3s)
-    assert dsolve(eq4, f(x), hint=hint) in (sol4, sol4s)
-    assert dsolve(eq5, f(x), hint=hint) in (sol5, sol5s)
-    assert dsolve(eq6, f(x), hint=hint) in (sol6, sol6s)
-    assert dsolve(eq7, f(x), hint=hint) in (sol7, sol7s)
-    assert dsolve(eq8, f(x), hint=hint) in (sol8, sol8s)
-    assert dsolve(eq9, f(x), hint=hint) in (sol9, sol9s)
-    assert dsolve(eq10, f(x), hint=hint) in (sol10, sol10s)
-    assert dsolve(eq11, f(x), hint=hint) in (sol11, sol11s)
-    assert dsolve(eq12, f(x), hint=hint) in (sol12, sol12s)
-    assert dsolve(eq13, f(x), hint=hint) in (sol13, sol13s)
-    assert dsolve(eq14, f(x), hint=hint) in (sol14, sol14s)
-    assert dsolve(eq15, f(x), hint=hint) in (sol15, sol15s)
-    assert dsolve(eq16, f(x), hint=hint) in (sol16, sol16s)
-    assert dsolve(eq17, f(x), hint=hint) in (sol17, sol17s)
-    assert dsolve(eq18, f(x), hint=hint) in (sol18, sol18s)
-    assert dsolve(eq19, f(x), hint=hint) in (sol19, sol19s)
-    assert dsolve(eq20, f(x), hint=hint) in (sol20, sol20s)
-    assert dsolve(eq21, f(x), hint=hint) in (sol21, sol21s)
-    assert dsolve(eq22, f(x), hint=hint) in (sol22, sol22s)
-    assert dsolve(eq23, f(x), hint=hint) in (sol23, sol23s)
-    assert dsolve(eq24, f(x), hint=hint) in (sol24, sol24s)
-    assert dsolve(eq25, f(x), hint=hint) in (sol25, sol25s)
-    assert dsolve(eq26, f(x), hint=hint) in (sol26, sol26s)
-    assert dsolve(eq27, f(x), hint=hint) in (sol27, sol27s)
-    assert dsolve(eq28, f(x), hint=hint) == sol28
+    assert dsolve(eq1, hint=hint) in (sol1, sol1s)
+    assert dsolve(eq2, hint=hint) in (sol2, sol2s)
+    assert dsolve(eq3, hint=hint) in (sol3, sol3s)
+    assert dsolve(eq4, hint=hint) in (sol4, sol4s)
+    assert dsolve(eq5, hint=hint) in (sol5, sol5s)
+    assert dsolve(eq6, hint=hint) in (sol6, sol6s)
+    assert dsolve(eq7, hint=hint) in (sol7, sol7s)
+    assert dsolve(eq8, hint=hint) in (sol8, sol8s)
+    assert dsolve(eq9, hint=hint) in (sol9, sol9s)
+    assert dsolve(eq10, hint=hint) in (sol10, sol10s)
+    assert dsolve(eq11, hint=hint) in (sol11, sol11s)
+    assert dsolve(eq12, hint=hint) in (sol12, sol12s)
+    assert dsolve(eq13, hint=hint) in (sol13, sol13s)
+    assert dsolve(eq14, hint=hint) in (sol14, sol14s)
+    assert dsolve(eq15, hint=hint) in (sol15, sol15s)
+    assert dsolve(eq16, hint=hint) in (sol16, sol16s)
+    assert dsolve(eq17, hint=hint) in (sol17, sol17s)
+    assert dsolve(eq18, hint=hint) in (sol18, sol18s)
+    assert dsolve(eq19, hint=hint) in (sol19, sol19s)
+    assert dsolve(eq20, hint=hint) in (sol20, sol20s)
+    assert dsolve(eq21, hint=hint) in (sol21, sol21s)
+    assert dsolve(eq22, hint=hint) in (sol22, sol22s)
+    assert dsolve(eq23, hint=hint) in (sol23, sol23s)
+    assert dsolve(eq24, hint=hint) in (sol24, sol24s)
+    assert dsolve(eq25, hint=hint) in (sol25, sol25s)
+    assert dsolve(eq26, hint=hint) in (sol26, sol26s)
+    assert dsolve(eq27, hint=hint) in (sol27, sol27s)
+    assert dsolve(eq28, hint=hint) == sol28
     assert checkodesol(eq1, sol1, order=3, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=3, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=2, solve_for_func=False)[0]
@@ -992,7 +992,7 @@ def test_nth_linear_constant_coeff_undetermined_coefficients_imaginary_exp():
     # dependent on sin(x) and cos(x).
     eq26a = f(x).diff(x, 5) + 2*f(x).diff(x, 3) + f(x).diff(x) - 2*x - exp(I*x)
     sol26 = Eq(f(x), C1 + (C2 + C3*x - x**2/8)*sin(x) + (C4 + C5*x + x**2/8)*cos(x) + x**2)
-    assert dsolve(eq26a, f(x), hint=hint) == sol26
+    assert dsolve(eq26a, hint=hint) == sol26
     assert checkodesol(eq26a, sol26, order=5, solve_for_func=False)[0]
 
 def test_nth_linear_constant_coeff_variation_of_parameters():
@@ -1034,18 +1034,18 @@ def test_nth_linear_constant_coeff_variation_of_parameters():
     sol10s = constant_renumber(sol10, 'C', 1, 2)
     sol11s = constant_renumber(sol11, 'C', 1, 2)
     sol12s = constant_renumber(sol12, 'C', 1, 4)
-    assert dsolve(eq1, f(x), hint=hint) in (sol1, sol1s)
-    assert dsolve(eq2, f(x), hint=hint) in (sol2, sol2s)
-    assert dsolve(eq3, f(x), hint=hint) in (sol3, sol3s)
-    assert dsolve(eq4, f(x), hint=hint) in (sol4, sol4s)
-    assert dsolve(eq5, f(x), hint=hint) in (sol5, sol5s)
-    assert dsolve(eq6, f(x), hint=hint) in (sol6, sol6s)
-    assert dsolve(eq7, f(x), hint=hint) in (sol7, sol7s)
-    assert dsolve(eq8, f(x), hint=hint) in (sol8, sol8s)
-    assert dsolve(eq9, f(x), hint=hint) in (sol9, sol9s)
-    assert dsolve(eq10, f(x), hint=hint) in (sol10, sol10s)
-    assert dsolve(eq11, f(x), hint=hint+'_Integral') in (sol11, sol11s)
-    assert dsolve(eq12, f(x), hint=hint) in (sol12, sol12s)
+    assert dsolve(eq1, hint=hint) in (sol1, sol1s)
+    assert dsolve(eq2, hint=hint) in (sol2, sol2s)
+    assert dsolve(eq3, hint=hint) in (sol3, sol3s)
+    assert dsolve(eq4, hint=hint) in (sol4, sol4s)
+    assert dsolve(eq5, hint=hint) in (sol5, sol5s)
+    assert dsolve(eq6, hint=hint) in (sol6, sol6s)
+    assert dsolve(eq7, hint=hint) in (sol7, sol7s)
+    assert dsolve(eq8, hint=hint) in (sol8, sol8s)
+    assert dsolve(eq9, hint=hint) in (sol9, sol9s)
+    assert dsolve(eq10, hint=hint) in (sol10, sol10s)
+    assert dsolve(eq11, hint=hint+'_Integral') in (sol11, sol11s)
+    assert dsolve(eq12, hint=hint) in (sol12, sol12s)
     assert checkodesol(eq1, sol1, order=3, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=3, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
@@ -1088,12 +1088,12 @@ def test_Liouville_ODE():
     sol3s = constant_renumber(sol3, 'C', 1, 2)
     sol4s = constant_renumber(sol4, 'C', 1, 2)
     sol5s = constant_renumber(sol5, 'C', 1, 2)
-    assert dsolve(eq1, f(x), hint) in (sol1, sol1s)
-    assert dsolve(eq1a, f(x), hint) in (sol1, sol1s)
-    assert dsolve(eq2, f(x), hint) in (sol2, sol2s)
-    assert set(dsolve(eq3, f(x), hint)) in (sol3, sol3s)
-    assert set(dsolve(eq4, f(x), hint)) in (sol4, sol4s) # XXX: remove sqrt(2) factor
-    assert dsolve(eq5, f(x), hint) in (sol5, sol5s)
+    assert dsolve(eq1, hint=hint) in (sol1, sol1s)
+    assert dsolve(eq1a, hint=hint) in (sol1, sol1s)
+    assert dsolve(eq2, hint=hint) in (sol2, sol2s)
+    assert set(dsolve(eq3, hint=hint)) in (sol3, sol3s)
+    assert set(dsolve(eq4, hint=hint)) in (sol4, sol4s) # XXX: remove sqrt(2) factor
+    assert dsolve(eq5, hint=hint) in (sol5, sol5s)
     assert checkodesol(eq1, sol1, order=2, solve_for_func=False)[0]
     assert checkodesol(eq1a, sol1a, order=2, solve_for_func=False)[0]
     assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
@@ -1115,7 +1115,7 @@ def test_unexpanded_Liouville_ODE():
     eq2 = eq1*exp(-f(x))/exp(f(x))
     sol2 = Eq(f(x), log(x/(C1 + C2*x)))
     sol2s = constant_renumber(sol2, 'C', 1, 2)
-    assert dsolve(eq2, f(x)) in (sol2, sol2s)
+    assert dsolve(eq2) in (sol2, sol2s)
     assert checkodesol(eq2, sol2, order=2, solve_for_func=False)[0]
 
 def test_1686():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -410,13 +410,13 @@ def test_separable5():
     sol20 = Eq(log(-1 + 3*f(x)**2)/6, C1 + x**2/2)
     sol21 = Eq(-exp(-f(x)), C1 + exp(x))
     assert dsolve(eq15, hint='separable') == sol15
-    assert dsolve(eq16, hint='separable') == sol16
+    assert dsolve(eq16, hint='separable', simplify=False) == sol16
     assert dsolve(eq17, hint='separable') == sol17
     assert dsolve(eq18, hint='separable') == sol18
     assert dsolve(eq19, hint='separable') in [sol19a, sol19b, sol19c,
                                                     sol19d, sol19e]
     assert dsolve(eq20, hint='separable') == sol20
-    assert dsolve(eq21, hint='separable') == sol21
+    assert dsolve(eq21, hint='separable', simplify=False) == sol21
     assert checkodesol(eq15, sol15, order=1, solve_for_func=False)[0]
     assert checkodesol(eq16, sol16, order=1, solve_for_func=False)[0]
     assert checkodesol(eq17, sol17, order=1, solve_for_func=False)[0]


### PR DESCRIPTION
This is an alternate request to #169 which appears to be no longer active.

```
All Derivatives in the variables of interest will be evaluated
if they have more than the function being solved for. Otherwise,
other Derivatives will only be evaluated if necessary.

In many cases the function can be detected by analysis of the
derivatives and functions, so the func arg is now optional.
```

(Every equation in the ode test suite passed through this function with no errors when preprocess was made to guess the function of interest.)
