### PR TITLE
Added option to printers for large expressions

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -94,8 +94,8 @@ def main():
         dest='order',
         action='store',
         default=None,
-        choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old'],
-        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old')
+        choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old', 'none'],
+        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none')
 
     parser.add_option(
         '-q', '--quiet',

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -292,6 +292,7 @@ class Basic(object):
         """Nice order of classes. """
         return 5, 0, cls.__name__
 
+    @cacheit
     def sort_key(self, order=None):
         """
         Return a sort key.
@@ -1171,6 +1172,7 @@ class Atom(Basic):
     def class_key(cls):
         return 2, 0, cls.__name__
 
+    @cacheit
     def sort_key(self, order=None):
         from sympy.core import S
         return self.class_key(), (1, (self,)), S.One.sort_key(), S.One

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -40,6 +40,7 @@ class Expr(Basic, EvalfMixin):
         """
         return False
 
+    @cacheit
     def sort_key(self, order=None):
         # XXX: The order argument does not actually work
         from sympy.core import S

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -173,6 +173,7 @@ class Number(AtomicExpr):
     def class_key(cls):
         return 1, 0, 'Number'
 
+    @cacheit
     def sort_key(self, order=None):
         return self.class_key(), (0, ()), (), self
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -83,6 +83,7 @@ class Symbol(AtomicExpr, Boolean):
     def _hashable_content(self):
         return (self.is_commutative, self.name)
 
+    @cacheit
     def sort_key(self, order=None):
         from sympy.core import S
         return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -125,7 +125,10 @@ class LatexPrinter(Printer):
             return expr
 
     def _print_Add(self, expr, order=None):
-        terms = self._as_ordered_terms(expr, order=order)
+        if self.order == 'unsorted':
+            terms = list(expr.args)
+        else:
+            terms = self._as_ordered_terms(expr, order=order)
         tex = self._print(terms[0])
 
         for term in terms[1:]:
@@ -181,7 +184,7 @@ class LatexPrinter(Printer):
             else:
                 _tex = last_term_tex = ""
 
-                if self.order != 'old':
+                if (self.order != 'old') and (self.order != 'unsorted'):
                     args = expr.as_ordered_factors()
                 else:
                     args = expr.args
@@ -940,7 +943,8 @@ def latex(expr, **settings):
         used.  If 'mode' is set to 'equation' or 'equation*', the resulting
         code will be enclosed in the 'equation' or 'equation*' environment
         (remember to import 'amsmath' for 'equation*'), unless the 'itex'
-        option is set. In the latter case, the $$ $$ syntax is used.
+        option is set. In the latter case, the $$ $$ syntax is used. For very
+        large expressions, set the 'order' keyword to 'unsorted'.
 
         >>> from sympy import latex, Rational
         >>> from sympy.abc import x, y, mu, tau

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -184,7 +184,7 @@ class LatexPrinter(Printer):
             else:
                 _tex = last_term_tex = ""
 
-                if (self.order != 'old') and (self.order != 'none'):
+                if self.order not in ('old', 'none'):
                     args = expr.as_ordered_factors()
                 else:
                     args = expr.args
@@ -944,7 +944,8 @@ def latex(expr, **settings):
         code will be enclosed in the 'equation' or 'equation*' environment
         (remember to import 'amsmath' for 'equation*'), unless the 'itex'
         option is set. In the latter case, the $$ $$ syntax is used. For very
-        large expressions, set the 'order' keyword to 'none'.
+        large expressions, set the 'order' keyword to 'none' if speed is a
+        concern.
 
         >>> from sympy import latex, Rational
         >>> from sympy.abc import x, y, mu, tau

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -125,7 +125,7 @@ class LatexPrinter(Printer):
             return expr
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'unsorted':
+        if self.order == 'none':
             terms = list(expr.args)
         else:
             terms = self._as_ordered_terms(expr, order=order)
@@ -184,7 +184,7 @@ class LatexPrinter(Printer):
             else:
                 _tex = last_term_tex = ""
 
-                if (self.order != 'old') and (self.order != 'unsorted'):
+                if (self.order != 'old') and (self.order != 'none'):
                     args = expr.as_ordered_factors()
                 else:
                     args = expr.args
@@ -944,7 +944,7 @@ def latex(expr, **settings):
         code will be enclosed in the 'equation' or 'equation*' environment
         (remember to import 'amsmath' for 'equation*'), unless the 'itex'
         option is set. In the latter case, the $$ $$ syntax is used. For very
-        large expressions, set the 'order' keyword to 'unsorted'.
+        large expressions, set the 'order' keyword to 'none'.
 
         >>> from sympy import latex, Rational
         >>> from sympy.abc import x, y, mu, tau

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -902,7 +902,7 @@ class PrettyPrinter(Printer):
         a = [] # items in the numerator
         b = [] # items that are in the denominator (if any)
 
-        if (self.order != 'old') and (self.order != 'none'):
+        if self.order not in ('old', 'none'):
             args = product.as_ordered_factors()
         else:
             args = product.args
@@ -1221,7 +1221,7 @@ def pretty(expr, **settings):
     use_unicode: use unicode characters, such as the Greek letter pi instead of
         the string pi. Values should be boolean or None
     full_prec: use full precision. Default to "auto"
-    order: set to 'none' for long expressions; default is None
+    order: set to 'none' for long expressions if slow; default is None
     """
     pp = PrettyPrinter(settings)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -839,7 +839,7 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'unsorted':
+        if self.order == 'none':
             terms = list(expr.args)
         else:
             terms = self._as_ordered_terms(expr, order=order)
@@ -902,7 +902,7 @@ class PrettyPrinter(Printer):
         a = [] # items in the numerator
         b = [] # items that are in the denominator (if any)
 
-        if (self.order != 'old') and (self.order != 'unsorted'):
+        if (self.order != 'old') and (self.order != 'none'):
             args = product.as_ordered_factors()
         else:
             args = product.args
@@ -1221,7 +1221,7 @@ def pretty(expr, **settings):
     use_unicode: use unicode characters, such as the Greek letter pi instead of
         the string pi. Values should be boolean or None
     full_prec: use full precision. Default to "auto"
-    order: set to 'unsorted' for long expressions; default is None
+    order: set to 'none' for long expressions; default is None
     """
     pp = PrettyPrinter(settings)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -839,7 +839,10 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_Add(self, expr, order=None):
-        terms = self._as_ordered_terms(expr, order=order)
+        if self.order == 'unsorted':
+            terms = list(expr.args)
+        else:
+            terms = self._as_ordered_terms(expr, order=order)
         pforms, indices = [], []
 
         def pretty_negative(pform, index):
@@ -899,7 +902,7 @@ class PrettyPrinter(Printer):
         a = [] # items in the numerator
         b = [] # items that are in the denominator (if any)
 
-        if self.order != 'old':
+        if (self.order != 'old') and (self.order != 'unsorted'):
             args = product.as_ordered_factors()
         else:
             args = product.args
@@ -1218,6 +1221,7 @@ def pretty(expr, **settings):
     use_unicode: use unicode characters, such as the Greek letter pi instead of
         the string pi. Values should be boolean or None
     full_prec: use full precision. Default to "auto"
+    order: set to 'unsorted' for long expressions; default is None
     """
     pp = PrettyPrinter(settings)
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -41,7 +41,7 @@ class StrPrinter(Printer):
             return str(expr)
 
     def _print_Add(self, expr, order=None):
-        if self.order == 'unsorted':
+        if self.order == 'none':
             terms = list(expr.args)
         else:
             terms = self._as_ordered_terms(expr, order=order)
@@ -219,7 +219,7 @@ class StrPrinter(Printer):
         a = [] # items in the numerator
         b = [] # items that are in the denominator (if any)
 
-        if (self.order != 'old') and (self.order != 'unsorted'):
+        if (self.order != 'old') and (self.order != 'none'):
             args = expr._new_rawargs(*terms).as_ordered_factors()
         else:
             args = terms
@@ -509,7 +509,7 @@ class StrPrinter(Printer):
 def sstr(expr, **settings):
     """Returns the expression as a string.
 
-    For large expressions, use the setting order='unsorted'.
+    For large expressions, use the setting order='none'.
 
     Example:
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -219,7 +219,7 @@ class StrPrinter(Printer):
         a = [] # items in the numerator
         b = [] # items that are in the denominator (if any)
 
-        if (self.order != 'old') and (self.order != 'none'):
+        if self.order not in ('old', 'none'):
             args = expr._new_rawargs(*terms).as_ordered_factors()
         else:
             args = terms
@@ -509,7 +509,8 @@ class StrPrinter(Printer):
 def sstr(expr, **settings):
     """Returns the expression as a string.
 
-    For large expressions, use the setting order='none'.
+    For large expressions where speed is a concern, use the setting
+    order='none'.
 
     Example:
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -41,7 +41,10 @@ class StrPrinter(Printer):
             return str(expr)
 
     def _print_Add(self, expr, order=None):
-        terms = self._as_ordered_terms(expr, order=order)
+        if self.order == 'unsorted':
+            terms = list(expr.args)
+        else:
+            terms = self._as_ordered_terms(expr, order=order)
 
         PREC = precedence(expr)
         l = []
@@ -216,7 +219,7 @@ class StrPrinter(Printer):
         a = [] # items in the numerator
         b = [] # items that are in the denominator (if any)
 
-        if self.order != 'old':
+        if (self.order != 'old') and (self.order != 'unsorted'):
             args = expr._new_rawargs(*terms).as_ordered_factors()
         else:
             args = terms
@@ -505,6 +508,9 @@ class StrPrinter(Printer):
 
 def sstr(expr, **settings):
     """Returns the expression as a string.
+
+    For large expressions, use the setting order='unsorted'.
+
     Example:
 
     >>> from sympy import symbols, Eq, sstr


### PR DESCRIPTION
For large outputs, use the setting: order='unsorted' for sstr, pretty, and
latex. This only affects _print_Add and _print_Mul methods. It takes the time
down from minutes to seconds on some print operations.
