### PR TITLE
Add simplification cos(pi*n) == (-1)**n for integer n to cos function

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -190,6 +190,9 @@ def test_cos():
 
     assert cos(r).is_real == True
 
+    assert cos(k*pi) == (-1)**k
+    assert cos(2*k*pi) == 1
+
 def test_cos_rewrite():
     x = Symbol('x')
     assert cos(x).rewrite(exp) == exp(I*x)/2 + exp(-I*x)/2

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -386,11 +386,7 @@ class cos(TrigonometricFunction):
         if pi_coeff is not None:
             if not pi_coeff.is_Rational:
                 if pi_coeff.is_integer:
-                    even = pi_coeff.is_even
-                    if even:
-                        return S.One
-                    elif even is False:
-                        return S.NegativeOne
+                    return (S.NegativeOne)**pi_coeff
                 narg = pi_coeff*S.Pi
                 if narg != arg:
                     return cls(narg)


### PR DESCRIPTION
Rather than having special cases for even or odd integers, the cos function now simply returns (-1)*_n for cos(pi_n) if n is an integer. 

Previously cos(pi_n) remained unevaluated, but it is nice to have sympy know about this simplification so that things like cos(pi_n)**2 = 1 happen correctly.
