### PR TITLE
Continuous representations in sympy.physics.quantum, part 2

### DIFF
--- a/sympy/physics/quantum/__init__.py
+++ b/sympy/physics/quantum/__init__.py
@@ -54,3 +54,11 @@ __all__.extend(tensorproduct.__all__)
 import constants
 from constants import *
 __all__.extend(constants.__all__)
+
+import operatorset
+from operatorset import *
+__all__.extend(operatorset.__all__)
+
+import cartesian
+from cartesian import *
+__all__.extend(cartesian.__all__)

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -67,9 +67,9 @@ class XOp(HermitianOperator):
         return I*hbar*(d*delta)
 
     def _represent_XKet(self, basis, **options):
-        from sympy.physics.quantum.represent import rep_expectation
+        from sympy.physics.quantum.represent import expectation_helper
         options['basis'] = basis
-        return rep_expectation(self, **options)
+        return expectation_helper(self, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_XKet(XKet(), **options)
@@ -133,9 +133,9 @@ class PxOp(HermitianOperator):
         return -I*hbar*(d*delta)
 
     def _represent_PxKet(self, basis, **options):
-        from sympy.physics.quantum.represent import rep_expectation
+        from sympy.physics.quantum.represent import expectation_helper
         options['basis'] = basis
-        return rep_expectation(self, **options)
+        return expectation_helper(self, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_PxKet(PxKet(), **options)
@@ -183,9 +183,9 @@ class XKet(Ket):
         return exp(-I*self.position*bra.momentum/hbar)/sqrt(2*pi*hbar)
 
     def _represent_XKet(self, basis, **options):
-        from sympy.physics.quantum.represent import rep_innerproduct
+        from sympy.physics.quantum.represent import innerproduct_helper
         options['basis'] = basis
-        return rep_innerproduct(self, **options)
+        return innerproduct_helper(self, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_XKet(XKet(), **options)
@@ -313,9 +313,9 @@ class PxKet(Ket):
         return DiracDelta(self.momentum-bra.momentum)
 
     def _represent_PxKet(self, basis, **options):
-        from sympy.physics.quantum.represent import rep_innerproduct
+        from sympy.physics.quantum.represent import innerproduct_helper
         options['basis'] = basis
-        return rep_innerproduct(self, **options)
+        return innerproduct_helper(self, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_PxKet(PxKet(), **options)

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -187,6 +187,11 @@ class XKet(Ket):
         options['basis'] = basis
         return innerproduct_helper(self, wrap_wavefunction=True, **options)
 
+    def _represent_PxKet(self, basis, **options):
+        from sympy.physics.quantum.represent import innerproduct_helper
+        options['basis'] = basis
+        return innerproduct_helper(self, wrap_wavefunction=True, **options)
+
     def _get_default_basis(self, **options):
         return XKet
 
@@ -313,6 +318,11 @@ class PxKet(Ket):
         return DiracDelta(self.momentum-bra.momentum)
 
     def _represent_PxKet(self, basis, **options):
+        from sympy.physics.quantum.represent import innerproduct_helper
+        options['basis'] = basis
+        return innerproduct_helper(self, wrap_wavefunction=True, **options)
+
+    def _represent_XKet(self, basis, **options):
         from sympy.physics.quantum.represent import innerproduct_helper
         options['basis'] = basis
         return innerproduct_helper(self, wrap_wavefunction=True, **options)

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -71,8 +71,8 @@ class XOp(HermitianOperator):
         options['basis'] = basis
         return expectation_helper(self, wrap_wavefunction=True, **options)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_XKet(XKet(), **options)
+    def _get_default_basis(self, **options):
+        return XKet
 
 class YOp(HermitianOperator):
     """ Y cartesian coordinate operator (for 2D or 3D systems) """
@@ -137,8 +137,8 @@ class PxOp(HermitianOperator):
         options['basis'] = basis
         return expectation_helper(self, wrap_wavefunction=True, **options)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_PxKet(PxKet(), **options)
+    def _get_default_basis(self, **options):
+        return PxKet
 
 X = XOp('X')
 Y = YOp('Y')
@@ -187,8 +187,8 @@ class XKet(Ket):
         options['basis'] = basis
         return innerproduct_helper(self, wrap_wavefunction=True, **options)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_XKet(XKet(), **options)
+    def _get_default_basis(self, **options):
+        return XKet
 
 class XBra(Bra):
     """1D cartesian position eigenbra."""
@@ -317,8 +317,8 @@ class PxKet(Ket):
         options['basis'] = basis
         return innerproduct_helper(self, wrap_wavefunction=True, **options)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_PxKet(PxKet(), **options)
+    def _get_default_basis(self, **options):
+        return PxKet
 
 
 class PxBra(Bra):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -64,12 +64,12 @@ class XOp(HermitianOperator):
         d = DifferentialOperator(Derivative(f(coord1), coord1), f(coord1))
         delta = DiracDelta(coord1 - coord2)
 
-        return I*hbar*(d*delta)
+        return I*hbar*delta*d
 
     def _represent_XKet(self, basis, **options):
         from sympy.physics.quantum.represent import expectation_helper
         options['basis'] = basis
-        return expectation_helper(self, **options)
+        return expectation_helper(self, wrap_wavefunction=True, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_XKet(XKet(), **options)
@@ -130,12 +130,12 @@ class PxOp(HermitianOperator):
         d = DifferentialOperator(Derivative(f(coord1), coord1), f(coord1))
         delta = DiracDelta(coord1 - coord2)
 
-        return -I*hbar*(d*delta)
+        return -I*hbar*delta*d
 
     def _represent_PxKet(self, basis, **options):
         from sympy.physics.quantum.represent import expectation_helper
         options['basis'] = basis
-        return expectation_helper(self, **options)
+        return expectation_helper(self, wrap_wavefunction=True, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_PxKet(PxKet(), **options)
@@ -185,7 +185,7 @@ class XKet(Ket):
     def _represent_XKet(self, basis, **options):
         from sympy.physics.quantum.represent import innerproduct_helper
         options['basis'] = basis
-        return innerproduct_helper(self, **options)
+        return innerproduct_helper(self, wrap_wavefunction=True, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_XKet(XKet(), **options)
@@ -315,7 +315,7 @@ class PxKet(Ket):
     def _represent_PxKet(self, basis, **options):
         from sympy.physics.quantum.represent import innerproduct_helper
         options['basis'] = basis
-        return innerproduct_helper(self, **options)
+        return innerproduct_helper(self, wrap_wavefunction=True, **options)
 
     def _represent_default_basis(self, **options):
         return self._represent_PxKet(PxKet(), **options)

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -42,6 +42,10 @@ class XOp(HermitianOperator):
         return ("X",)
 
     @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
+
+    @classmethod
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
@@ -82,6 +86,10 @@ class YOp(HermitianOperator):
         return ("Y",)
 
     @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
+
+    @classmethod
     def _eval_hilbert_space(self, args):
         return L2(Interval(S.NegativeInfinity, S.Infinity))
 
@@ -94,6 +102,10 @@ class ZOp(HermitianOperator):
     @classmethod
     def default_args(self):
         return ("Z",)
+
+    @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
 
     @classmethod
     def _eval_hilbert_space(self, args):
@@ -112,6 +124,10 @@ class PxOp(HermitianOperator):
     @classmethod
     def default_args(self):
         return ("Px",)
+
+    @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
 
     @classmethod
     def _eval_hilbert_space(self, args):
@@ -162,7 +178,11 @@ class XKet(Ket):
 
     @classmethod
     def default_args(self):
-        return (Symbol("x", real=True),)
+        return ("x",)
+
+    @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
 
     @classmethod
     def dual_class(self):
@@ -197,10 +217,6 @@ class XKet(Ket):
 
 class XBra(Bra):
     """1D cartesian position eigenbra."""
-
-    @classmethod
-    def default_args(self):
-        return ("x",)
 
     @classmethod
     def dual_class(self):
@@ -243,6 +259,10 @@ class PositionState3D(State):
     @classmethod
     def default_args(self):
         return ("x", "y", "z")
+
+    @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
 
     @property
     def position_x(self):
@@ -300,6 +320,10 @@ class PxKet(Ket):
         return ("px",)
 
     @classmethod
+    def def_label_assumptions(self):
+        return {"real" : True}
+
+    @classmethod
     def dual_class(self):
         return PxBra
 
@@ -335,10 +359,6 @@ class PxBra(Bra):
     """1D cartesian momentum eigenbra."""
 
     @classmethod
-    def default_args(self):
-        return ("px",)
-
-    @classmethod
     def dual_class(self):
         return PxKet
 
@@ -366,7 +386,8 @@ def _enumerate_continuous_1D(*args, **options):
 
     for i, ind in enumerate(index_list):
         label = state.args[0]
-        enum_states[i] = state_class(_append_index(label, ind), **options)
+        enum_states[i] = state_class( \
+            _append_index(label, ind, **state.label_assumptions), **options)
 
     return enum_states
 

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -162,7 +162,7 @@ class XKet(Ket):
 
     @classmethod
     def default_args(self):
-        return ("x",)
+        return (Symbol("x", real=True),)
 
     @classmethod
     def dual_class(self):
@@ -352,6 +352,7 @@ class PxBra(Bra):
 #-------------------------------------------------------------------------
 
 def _enumerate_continuous_1D(*args, **options):
+    from sympy.physics.quantum.represent import _append_index
     state = args[0]
     num_states = args[1]
     state_class = state.__class__
@@ -365,7 +366,7 @@ def _enumerate_continuous_1D(*args, **options):
 
     for i, ind in enumerate(index_list):
         label = state.args[0]
-        enum_states[i] = state_class(str(label) + "_" + str(ind), **options)
+        enum_states[i] = state_class(_append_index(label, ind), **options)
 
     return enum_states
 

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -59,9 +59,10 @@ class XOp(HermitianOperator):
         return ket.position_x*ket
 
     def _represent_PxKet(self, basis, **options):
-        index = options.pop("index", 1)
+        from sympy.physics.quantum.represent import enumerate_states
 
-        states = basis._enumerate_state(2, start_index = index)
+        index = options.pop("index", 1)
+        states = enumerate_states(basis, index, 2)
         coord1 = states[0].momentum
         coord2 = states[1].momentum
         f = Function('f')
@@ -137,9 +138,10 @@ class PxOp(HermitianOperator):
         return ket.momentum*ket
 
     def _represent_XKet(self, basis, **options):
-        index = options.pop("index", 1)
+        from sympy.physics.quantum.represent import enumerate_states
 
-        states = basis._enumerate_state(2, start_index = index)
+        index = options.pop("index", 1)
+        states = enumerate_states(basis, index, 2)
         coord1 = states[0].position
         coord2 = states[1].position
         f = Function('f')
@@ -193,9 +195,6 @@ class XKet(Ket):
         """The position of the state."""
         return self.label[0]
 
-    def _enumerate_state(self, num_states, **options):
-        return _enumerate_continuous_1D(self, num_states, **options)
-
     def _eval_innerproduct_XBra(self, bra, **hints):
         return DiracDelta(self.position-bra.position)
 
@@ -229,6 +228,8 @@ class XBra(Bra):
 
 class PositionState3D(State):
     """ Base class for 3D cartesian position eigenstates """
+
+    _label_separator = ','
 
     @classmethod
     def _operators_to_state(self, ops, **options):
@@ -332,9 +333,6 @@ class PxKet(Ket):
         """The momentum of the state."""
         return self.label[0]
 
-    def _enumerate_state(self, *args, **options):
-        return _enumerate_continuous_1D(self, *args, **options)
-
     def _eval_innerproduct_XBra(self, bra, **hints):
         return exp(I*self.momentum*bra.position/hbar)/sqrt(2*pi*hbar)
 
@@ -370,26 +368,6 @@ class PxBra(Bra):
 #-------------------------------------------------------------------------
 # Global helper functions
 #-------------------------------------------------------------------------
-
-def _enumerate_continuous_1D(*args, **options):
-    from sympy.physics.quantum.represent import _append_index
-    state = args[0]
-    num_states = args[1]
-    state_class = state.__class__
-    index_list = options.pop('index_list', [])
-
-    if len(index_list) == 0:
-        start_index = options.pop('start_index', 1)
-        index_list = range(start_index, start_index + num_states)
-
-    enum_states = [0 for i in range(len(index_list))]
-
-    for i, ind in enumerate(index_list):
-        label = state.args[0]
-        enum_states[i] = state_class( \
-            _append_index(label, ind, **state.label_assumptions), **options)
-
-    return enum_states
 
 def _lowercase_labels(ops):
     if not isinstance(ops, list):

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -66,6 +66,14 @@ class XOp(HermitianOperator):
 
         return I*hbar*(d*delta)
 
+    def _represent_XKet(self, basis, **options):
+        from sympy.physics.quantum.represent import rep_expectation
+        options['basis'] = basis
+        return rep_expectation(self, **options)
+
+    def _represent_default_basis(self, **options):
+        return self._represent_XKet(XKet(), **options)
+
 class YOp(HermitianOperator):
     """ Y cartesian coordinate operator (for 2D or 3D systems) """
 
@@ -124,6 +132,14 @@ class PxOp(HermitianOperator):
 
         return -I*hbar*(d*delta)
 
+    def _represent_PxKet(self, basis, **options):
+        from sympy.physics.quantum.represent import rep_expectation
+        options['basis'] = basis
+        return rep_expectation(self, **options)
+
+    def _represent_default_basis(self, **options):
+        return self._represent_PxKet(PxKet(), **options)
+
 X = XOp('X')
 Y = YOp('Y')
 Z = ZOp('Z')
@@ -165,6 +181,14 @@ class XKet(Ket):
 
     def _eval_innerproduct_PxBra(self, bra, **hints):
         return exp(-I*self.position*bra.momentum/hbar)/sqrt(2*pi*hbar)
+
+    def _represent_XKet(self, basis, **options):
+        from sympy.physics.quantum.represent import rep_innerproduct
+        options['basis'] = basis
+        return rep_innerproduct(self, **options)
+
+    def _represent_default_basis(self, **options):
+        return self._represent_XKet(XKet(), **options)
 
 class XBra(Bra):
     """1D cartesian position eigenbra."""
@@ -287,6 +311,15 @@ class PxKet(Ket):
 
     def _eval_innerproduct_PxBra(self, bra, **hints):
         return DiracDelta(self.momentum-bra.momentum)
+
+    def _represent_PxKet(self, basis, **options):
+        from sympy.physics.quantum.represent import rep_innerproduct
+        options['basis'] = basis
+        return rep_innerproduct(self, **options)
+
+    def _represent_default_basis(self, **options):
+        return self._represent_PxKet(PxKet(), **options)
+
 
 class PxBra(Bra):
     """1D cartesian momentum eigenbra."""

--- a/sympy/physics/quantum/cartesian.py
+++ b/sympy/physics/quantum/cartesian.py
@@ -5,8 +5,8 @@ TODO:
 
 """
 
-from sympy import DiracDelta, exp, I, Interval, pi, S, sqrt
-
+from sympy import (DiracDelta, Derivative, exp, Function, I, Interval,
+                   pi, S, sqrt, Symbol)
 from sympy.physics.quantum.constants import hbar
 from sympy.physics.quantum.hilbert import L2
 from sympy.physics.quantum.operator import DifferentialOperator, HermitianOperator
@@ -60,7 +60,8 @@ class XOp(HermitianOperator):
         states = basis._enumerate_state(2, start_index = index)
         coord1 = states[0].momentum
         coord2 = states[1].momentum
-        d = DifferentialOperator(coord1)
+        f = Function('f')
+        d = DifferentialOperator(Derivative(f(coord1), coord1), f(coord1))
         delta = DiracDelta(coord1 - coord2)
 
         return I*hbar*(d*delta)
@@ -117,7 +118,8 @@ class PxOp(HermitianOperator):
         states = basis._enumerate_state(2, start_index = index)
         coord1 = states[0].position
         coord2 = states[1].position
-        d = DifferentialOperator(coord1)
+        f = Function('f')
+        d = DifferentialOperator(Derivative(f(coord1), coord1), f(coord1))
         delta = DiracDelta(coord1 - coord2)
 
         return -I*hbar*(d*delta)
@@ -184,12 +186,30 @@ class PositionState3D(State):
     """ Base class for 3D cartesian position eigenstates """
 
     @classmethod
-    def _operators_to_state(self, op, **options):
-        return self.__new__(self, *_lowercase_labels(op), **options)
+    def _operators_to_state(self, ops, **options):
+        if not isinstance(ops, set) or len(ops) != 3:
+            raise TypeError("This is not the set of commuting operators expected!")
 
-    def _state_to_operators(self, op_class, **options):
-        return op_class.__new__(op_class, \
-                                *_uppercase_labels(self), **options)
+        op_list = list(ops)
+        order = [XOp, YOp, ZOp]
+        op_list.sort(lambda a, b: _class_cmp(order, a, b))
+        return self.__new__(self, *_lowercase_labels(op_list), **options)
+
+    def _state_to_operators(self, op_classes, **options):
+        if not isinstance(op_classes, set) or len(op_classes) != 3:
+            raise TypeError("This is not the set of commuting operators expected!")
+
+        op_list = list(op_classes)
+        order = [XOp, YOp, ZOp]
+        op_list.sort(lambda a, b: _class_cmp(order, a, b, is_class=True))
+
+        labs = _uppercase_labels(self)
+        op_insts = [None for op in op_list]
+
+        for i, cls in enumerate(op_list):
+            op_insts[i] = cls.__new__(cls, labs[i], **options)
+
+        return set(op_insts)
 
     @classmethod
     def default_args(self):
@@ -307,16 +327,33 @@ def _enumerate_continuous_1D(*args, **options):
     return enum_states
 
 def _lowercase_labels(ops):
-    if not isinstance(ops, set):
+    if not isinstance(ops, list):
         ops = [ops]
 
     return [str(arg.label[0]).lower() for arg in ops]
 
-def _uppercase_labels(ops):
-    if not isinstance(ops, set):
-        ops = [ops]
-
-    new_args = [str(arg.label[0])[0].upper() + \
-                str(arg.label[0])[1:] for arg in ops]
+def _uppercase_labels(state):
+    new_args = [str(lab)[0].upper() + \
+                str(lab)[1:] for lab in state.label]
 
     return new_args
+
+def _class_cmp(ordering, a, b, **options):
+    ordering = list(ordering)
+
+    is_class = options.pop("is_class", False)
+
+    if not is_class:
+        a = a.__class__
+        b = b.__class__
+
+    try:
+        ind1 = ordering.index(a)
+        ind2 = ordering.index(b)
+    except ValueError:
+        raise TypeError("Expected Operators for this eigenstate not found!")
+
+    if ind1 < ind2:
+        return -1
+    else:
+        return 1

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -31,6 +31,7 @@ from sympy.physics.quantum.matrixutils import matrix_tensor_product, matrix_eye
 from sympy.physics.quantum.matrixcache import matrix_cache
 
 from sympy.matrices.matrices import MatrixBase
+from sympy.physics.quantum.qubit import Qubit
 
 __all__ = [
     'Gate',
@@ -232,10 +233,10 @@ class Gate(UnitaryOperator):
     # Represent
     #-------------------------------------------------------------------------
 
-    def _represent_default_basis(self, **options):
-        return self._represent_ZGate(None, **options)
+    def _get_default_basis(self, **options):
+        return Qubit(0)
 
-    def _represent_ZGate(self, basis, **options):
+    def _represent_Qubit(self, basis, **options):
         format = options.get('format','sympy')
         nqubits = options.get('nqubits',0)
         if nqubits == 0:
@@ -908,7 +909,7 @@ class SwapGate(TwoQubitGate):
         circ_plot.swap_point(gate_idx, min_wire)
         circ_plot.swap_point(gate_idx, max_wire)
 
-    def _represent_ZGate(self, basis, **options):
+    def _represent_Qubit(self, basis, **options):
         """Represent the SWAP gate in the computational basis.
 
         The following representation is used to compute this:

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -9,7 +9,9 @@ TODO:
   AntiCommutator, represent, apply_operators.
 """
 
-from sympy import Derivative, Expr
+from sympy import (Add, Derivative, diff, expand, Expr, Function,
+                   Integer, Symbol, Tuple)
+from sympy.core.function import UndefinedFunction
 from sympy.printing.pretty.stringpict import prettyForm
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr, dispatch_method
@@ -492,9 +494,30 @@ class DifferentialOperator(Operator):
         new_expr = Derivative(self.expr, symbol)
         return DifferentialOperator(new_expr, self.args[-1])
 
+    def _eval_expand_diffop(self, **hints):
+        exp = expand(self.expr)
+
+        if exp.is_Add:
+            add_args = exp.args
+            args = map(lambda x: DifferentialOperator(x, self.function), \
+                       add_args)
+
+            return Add(*args)
+        else:
+            return DifferentialOperator(exp, self.function)
+
     #-------------------------------------------------------------------------
     # Printing
     #-------------------------------------------------------------------------
+
+    def _print_operator_name(self, printer, *args):
+        return printer._print(self.__class__.__name__, *args)
+
+    def _print_operator_name_latex(self, printer, *args):
+        return printer._print(self.__class__.__name__[0], *args)
+
+    def _print_operator_name_pretty(self, printer, *args):
+        return prettyForm(self.__class__.__name__[0])
 
     def _print_contents(self, printer, *args):
         return '%s(%s)' % (

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -100,7 +100,7 @@ class Operator(QExpr):
 
     def _represent_XKet(self, basis, **options):
         from sympy.physics.quantum.state import Wavefunction
-        from sympy.physucs.quantum.represent import _append_index
+        from sympy.physics.quantum.represent import _append_index
         index = options.pop('index', 1)
         coord = _append_index(basis.label[0], index)
         func = Function(str(self.label[0]))

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -485,7 +485,7 @@ class DifferentialOperator(Operator):
         wf_vars = func.args[1:]
 
         f = self.function
-        new_expr = self.expr.subs(f, func(*var))
+        new_expr = self.expr.subs(f, func.expr)
         new_expr = new_expr.doit()
 
         return Wavefunction(new_expr, *wf_vars)

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -97,6 +97,15 @@ class Operator(QExpr):
     @classmethod
     def default_args(self):
         return ("O",)
+
+    def _represent_XKet(self, basis, **options):
+        from sympy.physics.quantum.state import Wavefunction
+        from sympy.physucs.quantum.represent import _append_index
+        index = options.pop('index', 1)
+        coord = _append_index(basis.label[0], index)
+        func = Function(str(self.label[0]))
+        return Wavefunction(func(coord), coord)
+
     #-------------------------------------------------------------------------
     # Printing
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -128,7 +128,7 @@ def operators_to_state(operators, **options):
             classes = frozenset(tmp)
 
             if classes in op_mapping:
-                ret = _get_state(op_mapping[classes], ops, **options)
+                ret = _get_state(op_mapping[classes], set(ops), **options)
             else:
                 ret = None
 

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -1,14 +1,12 @@
-""" A module for mapping operators to their corresponding eigenstates
-and vice versa
+""" A module for mapping operators to their corresponding eigenstates and vice
+versa
 
-It contains a global dictionary with eigenstate-operator pairings.
-If a new state-operator pair is created, this dictionary should be
-updated as well.
+It contains a global dictionary with eigenstate-operator pairings.  If a new
+state-operator pair is created, this dictionary should be updated as well.
 
-It also contains functions operators_to_state and state_to_operators
-for mapping between the two. These can handle both classes and
-instances of operators and states. See the individual function
-descriptions for details.
+It also contains functions operators_to_state and state_to_operators for mapping
+between the two. These can handle both classes and instances of operators and
+states. See the individual function descriptions for details.
 
 TODO List:
 - Update the dictionary with a complete list of state-operator pairs
@@ -27,17 +25,16 @@ __all__ = [
     'state_to_operators'
 ]
 
-#state_mapping stores the mappings between states and their associated
-#operators or tuples of operators. This should be updated when new
-#classes are written! Entries are of the form PxKet : PxOp or
-#something like 3DKet : (ROp, ThetaOp, PhiOp)
+#state_mapping stores the mappings between states and their associated operators
+#or tuples of operators. This should be updated when new classes are written!
+#Entries are of the form PxKet : PxOp or something like 3DKet : (ROp, ThetaOp,
+#PhiOp)
 
 #frozenset is used so that the reverse mapping can be made
 #(regular sets are not hashable because they are mutable
 state_mapping = { JxKet : frozenset((J2Op, JxOp)),
                   JyKet : frozenset((J2Op, JyOp)),
                   JzKet : frozenset((J2Op, JzOp)),
-                  Ket : Operator,
                   PositionKet3D : frozenset((XOp, YOp, ZOp)),
                   PxKet : PxOp,
                   XKet : XOp }
@@ -45,28 +42,30 @@ state_mapping = { JxKet : frozenset((J2Op, JxOp)),
 op_mapping = dict((v,k) for k,v in state_mapping.iteritems())
 
 def operators_to_state(operators, **options):
-    """ Returns the eigenstate of the given operator or set of operators
+    """ Returns the eigenstate of the given operator or set of commuting
+    operators
 
-    A global function for mapping operator classes to their associated
-    states. It takes either an Operator or a set of operators and
-    returns the state associated with these.
+    A global function for mapping operator classes to their associated states.
+    It takes either an Operator or a set of operators and returns the state
+    associated with these.
 
-    This function can handle both instances of a given operator or
-    just the class itself (i.e. both XOp() and XOp)
+    This function can handle both instances of a given operator or just the
+    class itself (i.e. both XOp() and XOp)
 
     There are multiple use cases to consider:
 
-    1) A class or set of classes is passed: First, we try to
-    instantiate default instances for these operators. If this fails,
-    then the class is simply returned. If we succeed in instantiating
-    default instances, then we try to call state._operators_to_state
-    on the operator instances. If this fails, the class is returned.
-    Otherwise, the instance returned by _operators_to_state is returned.
+    1) A class or set of classes is passed: First, we try to instantiate default
+    instances for these operators. If this fails, then the eigenstate class is
+    simply returned. If we succeed in instantiating default instances, then we
+    try to call state._operators_to_state on the operator instances. If this
+    fails, we try to instantiate a default instance of the eigenstate
+    class. Finally, if we cannot return a default instance of the eigenstate
+    class, the class is returned.
 
     2) An instance or set of instances is passed: In this case,
-    state._operators_to_state is called on the instances passed. If
-    this fails, a state class is returned. If the method returns an
-    instance, that instance is returned.
+    state._operators_to_state is called on the instances passed. If this fails,
+    we try to instantiate a default instance of the eigenstate class. Finally,
+    if we cannot get a default instance, the eigenstate class is returned.
 
     In both cases, if the operator class or set does not exist in the
     state_mapping dictionary, None is returned.
@@ -74,9 +73,15 @@ def operators_to_state(operators, **options):
     Parameters
     ==========
 
-    arg: Operator or set
-         The class or instance of the operator or set of operators
+    operators : Operator or set
+         The class or instance of the operator or set of commuting operators
          to be mapped to a state
+
+    Returns
+    =======
+
+    state : Ket class or instance
+         The eigenstate of the given operator or set of commuting operators
 
     Examples
     ========
@@ -146,39 +151,48 @@ def operators_to_state(operators, **options):
             return None
 
 def state_to_operators(state, **options):
-    """ Returns the operator or set of operators corresponding to the
+    """ Returns the operator or set of commuting operators corresponding to the
     given eigenstate
 
-    A global function for mapping state classes to their associated
-    operators or sets of operators. It takes either a state class
-    or instance.
+    A global function for mapping state classes to their associated operator or
+    complete set of commuting operators. It takes either a state class or
+    instance.
 
-    This function can handle both instances of a given state or just
-    the class itself (i.e. both XKet() and XKet)
+    This function can handle both instances of a given state or just the class
+    itself (i.e. both XKet() and XKet)
 
     There are multiple use cases to consider:
 
-    1) A state class is passed: In this case, we first try
-    instantiating a default instance of the class. If this succeeds,
-    then we try to call state._state_to_operators on that instance.
-    If the creation of the default instance or if the calling of
-    _state_to_operators fails, then either an operator class or set of
-    operator classes is returned. Otherwise, the appropriate
-    operator instances are returned.
+    1) A state class is passed: In this case, we first try instantiating a
+    default instance of the class. If this succeeds, then we try to call
+    state._state_to_operators on that instance.  If the creation of the default
+    instance or if the calling of _state_to_operators fails, we try to
+    instantiate default instances of the associated operator or set of commuting
+    operators. Finally, if this fails, the operator class or set of classes is
+    returned.
 
-    2) A state instance is returned: Here, state._state_to_operators
-    is called for the instance. If this fails, then a class or set of
-    operator classes is returned. Otherwise, the instances are returned.
+    2) A state instance is passed Here, state._state_to_operators is called
+    for the instance. If this fails, then we attempt to create default instances
+    of the operator or set of commuting operators. Finally, if this fails, the
+    operator class or set of classes is returned.
 
-    In either case, if the state's class does not exist in
-    state_mapping, None is returned.
+    In either case, if the state's class does not exist in state_mapping, None
+    is returned.
 
     Parameters
     ==========
 
-    arg: StateBase class or instance (or subclasses)
+    state : StateBase class or instance (or subclasses)
          The class or instance of the state to be mapped to an
          operator or set of operators
+
+    Returns
+    =======
+
+    operators : Operator or set of commuting Operators
+         The single operator or set of commuting operators that the given state
+         is an eigenstate of (if no instances can be instantiated, the classes
+         will be returned)
 
     Examples
     ========

--- a/sympy/physics/quantum/operatorset.py
+++ b/sympy/physics/quantum/operatorset.py
@@ -97,10 +97,7 @@ def operators_to_state(operators, **options):
     |px>
     >>> operators_to_state(PxOp())
     |px>
-    >>> operators_to_state(Operator)
-    |psi>
-    >>> operators_to_state(Operator())
-    |psi>
+
     """
 
     if not (isinstance(operators, Operator) \
@@ -212,10 +209,7 @@ def state_to_operators(state, **options):
     Px
     >>> state_to_operators(XBra)
     X
-    >>> state_to_operators(Ket)
-    O
-    >>> state_to_operators(Bra)
-    O
+
     """
 
     if not (isinstance(state, StateBase) or issubclass(state, StateBase)):

--- a/sympy/physics/quantum/piab.py
+++ b/sympy/physics/quantum/piab.py
@@ -37,8 +37,11 @@ class PIABKet(Ket):
 
     @classmethod
     def default_args(self):
-        n = Symbol('n', integer=True)
-        return (n,)
+        return ('n',)
+
+    @classmethod
+    def def_label_assumptions(self):
+        return {'integer':True}
 
     @classmethod
     def _eval_hilbert_space(cls, args):
@@ -57,7 +60,7 @@ class PIABKet(Ket):
 
         n = self.label[0]
         x = basis.position
-        x = _append_index(x, options.pop("index", 1))
+        x = _append_index(x, options.pop("index", 1), **basis.label_assumptions)
 
         expr = sqrt(2/L)*sin(n*pi*x/L).subs(subs_info)
         return Wavefunction(expr, (x, 0, L))

--- a/sympy/physics/quantum/piab.py
+++ b/sympy/physics/quantum/piab.py
@@ -33,7 +33,60 @@ class PIABHamiltonian(HermitianOperator):
 
 
 class PIABKet(Ket):
-    """Particle in a box eigenket."""
+    """Particle in a box eigenket.
+
+    Can be represented in continuous bases and manipulated with continuous
+    operators as well.
+
+    Examples
+    ========
+
+    >>> from sympy.physics.quantum.piab import PIABKet, PIABBra
+    >>> from sympy.physics.quantum.cartesian import XOp, XKet, PxOp
+
+    A default instance will simply give the ket an index of n, where n is an
+    integer
+
+    >>> p = PIABKet()
+    >>> p
+    |n>
+    >>> p.label[0].is_integer
+    True
+
+    When you represent the ket, you get a Wavefunction object. By default, it
+    will be represented in the XKet (1D cartesian) basis
+
+    >>> from sympy.physics.quantum import represent
+    >>> represent(p)
+    Wavefunction(2**(1/2)*sin(pi*n*x/L)/L**(1/2), (x, 0, L))
+
+    You can also then compute more complicated representations.
+    In this example, we get an extra factor of x in the resulting Wavefunction,
+    as expected.
+
+    >>> represent(XOp()*p, basis=XKet)
+    Wavefunction(2**(1/2)*x*sin(pi*n*x/L)/L**(1/2), (x, 0, L))
+
+    In this example, the momentum operator in the position basis is a
+    differential operator, so we actually end up with the derivative of the
+    original represented expression.
+
+    >>> represent(PxOp()*p, basis=XKet)
+    Wavefunction(-2**(1/2)*hbar*I*pi*n*cos(pi*n*x/L)/L**(3/2), (x, 0, L))
+
+    We can even compute expectation values for this state!
+
+    >>> p_bra = PIABBra()
+    >>> represent(p_bra*XOp()*p, basis=XKet)
+    L*cos(pi*n)**2/2
+
+    cos(pi*n)**2 is 1, so this gives L/2, as expected!
+
+    >>> represent(p_bra*PxOp()*p, basis=XKet)
+    0
+
+    The expectation value of the momentum for a piab state is 0, as expected!
+    """
 
     @classmethod
     def default_args(self):

--- a/sympy/physics/quantum/piab.py
+++ b/sympy/physics/quantum/piab.py
@@ -9,8 +9,8 @@ from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.quantum.hilbert import L2
 from sympy.physics.quantum.cartesian import XKet
 
-m = Symbol('m', real=True)
-L = Symbol('L', real=True)
+m = Symbol('m', real=True, positive=True)
+L = Symbol('L', real=True, positive=True)
 
 
 __all__ = [

--- a/sympy/physics/quantum/piab.py
+++ b/sympy/physics/quantum/piab.py
@@ -7,6 +7,7 @@ from sympy.physics.quantum.state import Ket, Bra
 from sympy.physics.quantum.constants import hbar
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.quantum.hilbert import L2
+from sympy.physics.quantum.cartesian import XKet
 
 m = Symbol('m')
 L = Symbol('L')
@@ -42,10 +43,10 @@ class PIABKet(Ket):
     def dual_class(self):
         return PIABBra
 
-    def _represent_default_basis(self, **options):
-        return self._represent_XOp(None, **options)
+    def _get_default_basis(self, **options):
+        return XKet
 
-    def _represent_XOp(self, basis, **options):
+    def _represent_XKet(self, basis, **options):
         x = Symbol('x')
         n = Symbol('n')
         subs_info = options.get('subs',{})

--- a/sympy/physics/quantum/piab.py
+++ b/sympy/physics/quantum/piab.py
@@ -58,29 +58,29 @@ class PIABKet(Ket):
 
     >>> from sympy.physics.quantum import represent
     >>> represent(p)
-    Wavefunction(2**(1/2)*sin(pi*n*x/L)/L**(1/2), (x, 0, L))
+    Wavefunction(sqrt(2)*sin(pi*n*x/L)/sqrt(L), (x, 0, L))
 
     You can also then compute more complicated representations.
     In this example, we get an extra factor of x in the resulting Wavefunction,
     as expected.
 
     >>> represent(XOp()*p, basis=XKet)
-    Wavefunction(2**(1/2)*x*sin(pi*n*x/L)/L**(1/2), (x, 0, L))
+    Wavefunction(sqrt(2)*x*sin(pi*n*x/L)/sqrt(L), (x, 0, L))
 
     In this example, the momentum operator in the position basis is a
     differential operator, so we actually end up with the derivative of the
     original represented expression.
 
     >>> represent(PxOp()*p, basis=XKet)
-    Wavefunction(-2**(1/2)*hbar*I*pi*n*cos(pi*n*x/L)/L**(3/2), (x, 0, L))
+    Wavefunction(-sqrt(2)*hbar*I*pi*n*cos(pi*n*x/L)/L**(3/2), (x, 0, L))
 
     We can even compute expectation values for this state!
 
     >>> p_bra = PIABBra()
     >>> represent(p_bra*XOp()*p, basis=XKet)
-    L*cos(pi*n)**2/2
+    L/2
 
-    cos(pi*n)**2 is 1, so this gives L/2, as expected!
+    THe expectation value is L/2, the middle of the box, as expected!
 
     >>> represent(p_bra*PxOp()*p, basis=XKet)
     0

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -11,7 +11,7 @@ from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.innerproduct import InnerProduct
-from sympy.physics.quantum.operator import OuterProduct, Operator
+from sympy.physics.quantum.operator import OuterProduct, Operator, DifferentialOperator
 from sympy.physics.quantum.state import State, KetBase, BraBase, Wavefunction
 from sympy.physics.quantum.tensorproduct import TensorProduct
 
@@ -150,7 +150,10 @@ def qapply_Mul(e, **options):
         result = lhs._apply_operator(rhs, **options)
     except (NotImplementedError, AttributeError):
         try:
-            result = rhs._apply_operator(lhs, **options)
+            if not isinstance(rhs, DifferentialOperator):
+                result = rhs._apply_operator(lhs, **options)
+            else:
+                result = None
         except (NotImplementedError, AttributeError):
             if isinstance(lhs, BraBase) and isinstance(rhs, KetBase):
                 result = InnerProduct(lhs, rhs)

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -308,8 +308,12 @@ class QExpr(Expr):
     # Represent
     #-------------------------------------------------------------------------
 
-    def _represent_default_basis(self, **options):
+    def _get_default_basis(self, **options):
         raise NotImplementedError('This object does not have a default basis')
+
+    def _represent_default_basis(self, **options):
+        def_basis = self._get_default_basis(**options)
+        return self._represent(basis=def_basis(), **options)
 
     def _represent(self, **options):
         """Represent this object in a given basis.
@@ -351,10 +355,10 @@ class QExpr(Expr):
             be used.
         """
         basis = options.pop('basis',None)
-        if basis is None:
-            result = self._represent_default_basis(**options)
-        else:
-            result = dispatch_method(self, '_represent', basis, **options)
+        #if basis is None:
+        #    result = self._represent_default_basis(**options)
+        #else:
+        result = dispatch_method(self, '_represent', basis, **options)
 
         # If we get a matrix representation, convert it to the right format.
         format = options.get('format', 'sympy')

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -115,9 +115,11 @@ class QExpr(Expr):
         """
 
         # First compute args and call Expr.__new__ to create the instance
-        args = cls._eval_args(args)
         if len(args) == 0:
-            args = cls._eval_args(tuple(cls.default_args()))
+            args = tuple(cls.default_args())
+
+        args = cls._eval_args(args)
+
         inst = Expr.__new__(cls, *args, **{'commutative':False})
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -311,9 +311,9 @@ class QExpr(Expr):
     def _get_default_basis(self, **options):
         raise NotImplementedError('This object does not have a default basis')
 
-    def _represent_default_basis(self, **options):
-        def_basis = self._get_default_basis(**options)
-        return self._represent(basis=def_basis(), **options)
+    #def _represent_default_basis(self, **options):
+    #    def_basis = self._get_default_basis(**options)
+    #    return self._represent(basis=def_basis(), **options)
 
     def _represent(self, **options):
         """Represent this object in a given basis.

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -23,7 +23,7 @@ class QuantumError(Exception):
     pass
 
 
-def _qsympify_sequence(seq):
+def _qsympify_sequence(seq, **assumptions):
     """Convert elements of a sequence to standard form.
 
     This is like sympify, but it performs special logic for arguments passed
@@ -47,9 +47,9 @@ def _qsympify_sequence(seq):
 
     """
 
-    return tuple(__qsympify_sequence_helper(seq))
+    return tuple(__qsympify_sequence_helper(seq, **assumptions))
 
-def __qsympify_sequence_helper(seq):
+def __qsympify_sequence_helper(seq, **assumptions):
     """
        Helper function for _qsympify_sequence
        This function does the actual work.
@@ -59,12 +59,12 @@ def __qsympify_sequence_helper(seq):
         if isinstance(seq, Matrix):
             return seq
         elif isinstance(seq, basestring):
-            return Symbol(seq)
+            return Symbol(seq, **assumptions)
         else:
             return sympify(seq)
 
     #if list, recurse on each item in the list
-    result = [__qsympify_sequence_helper(item) for item in seq]
+    result = [__qsympify_sequence_helper(item, **assumptions) for item in seq]
 
     return Tuple(*result)
 
@@ -81,7 +81,7 @@ class QExpr(Expr):
     # derive from args.
 
     # The Hilbert space a quantum Object belongs to.
-    __slots__ = ['hilbert_space']
+    __slots__ = ['hilbert_space', 'label_assumptions']
 
     # The separator used in printing the label.
     _label_separator = u''
@@ -112,21 +112,33 @@ class QExpr(Expr):
         (0,)
         >>> q.is_commutative
         False
+        >>> q1 = QExpr('x', label_assumptions={'real':True})
+        >>> q1.label
+        (x,)
+        >>> q1.label[0].is_real
+        True
+
         """
 
         # First compute args and call Expr.__new__ to create the instance
         if len(args) == 0:
             args = tuple(cls.default_args())
 
-        args = cls._eval_args(args)
+        user_assumptions = old_assumptions.pop("label_assumptions", {})
+        def_assumptions = cls.def_label_assumptions()
+        for key in user_assumptions:
+            def_assumptions[key] = user_assumptions[key]
+
+        args = cls._eval_args(args, **def_assumptions)
 
         inst = Expr.__new__(cls, *args, **{'commutative':False})
         # Now set the slots on the instance
         inst.hilbert_space = cls._eval_hilbert_space(args)
+        inst.label_assumptions = def_assumptions
         return inst
 
     @classmethod
-    def _new_rawargs(cls, hilbert_space, *args):
+    def _new_rawargs(cls, hilbert_space, label_assumptions, *args):
         """Create new instance of this class with hilbert_space and args.
 
         This is used to bypass the more complex logic in the ``__new__``
@@ -138,6 +150,7 @@ class QExpr(Expr):
 
         obj = Expr.__new__(cls, *args, **{'commutative':False})
         obj.hilbert_space = hilbert_space
+        obj.label_assumptions = label_assumptions
         return obj
 
     #-------------------------------------------------------------------------
@@ -163,6 +176,19 @@ class QExpr(Expr):
         return True
 
     @classmethod
+    def def_label_assumptions(self):
+        """
+        Options which are to be applied to any Symbol objects that are created
+        from the arguments passed to the QExpr constructor.
+
+        To be overridden in subclasses. Any of these options can also be
+        overridden by the user when the constructor is called with use of the
+        label_assumptions option. Should return a dictionary.
+        """
+
+        return {}
+
+    @classmethod
     def default_args(self):
         """If no arguments are specified, then this will return a default set of arguments to be run through the constructor.
 
@@ -176,12 +202,12 @@ class QExpr(Expr):
     #-------------------------------------------------------------------------
 
     @classmethod
-    def _eval_args(cls, args):
+    def _eval_args(cls, args, **assumptions):
         """Process the args passed to the __new__ method.
 
         This simply runs args through _qsympify_sequence.
         """
-        return _qsympify_sequence(args)
+        return _qsympify_sequence(args, **assumptions)
 
     @classmethod
     def _eval_hilbert_space(cls, args):

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -335,11 +335,16 @@ class QExpr(Expr):
     #-------------------------------------------------------------------------
 
     def _get_default_basis(self, **options):
-        raise NotImplementedError('This object does not have a default basis')
+        """
+        Returns the default basis for the object to be represented in.
 
-    #def _represent_default_basis(self, **options):
-    #    def_basis = self._get_default_basis(**options)
-    #    return self._represent(basis=def_basis(), **options)
+        This function can return either a class or instance, but it should
+        always return a class or instance of a State. This is meant to be
+        overridden in subclasses to give a default basis to be represented in if
+        no basis is specified to the top level represent.
+        """
+
+        raise NotImplementedError('This object does not have a default basis')
 
     def _represent(self, **options):
         """Represent this object in a given basis.

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -332,7 +332,12 @@ class QExpr(Expr):
 
         If the ``format`` option is given it can be ("sympy", "numpy",
         "scipy.sparse"). This will ensure that any matrices that result from
-        representing the object are returned in the appropriate matrix format.
+        representing the object are returned in the appropriate matrix
+        format.
+
+        If the ``index`` option is given, then any dummy kets that the internal
+        _represent methods insert into the expression before representing should
+        begin being indexed at the index specified.
 
         Parameters
         ==========

--- a/sympy/physics/quantum/qft.py
+++ b/sympy/physics/quantum/qft.py
@@ -23,6 +23,8 @@ from sympy.physics.quantum.gate import (
     Gate, HadamardGate, SwapGate, OneQubitGate, CGate, PhaseGate, TGate, ZGate
 )
 
+from sympy.physics.quantum.qubit import Qubit
+
 __all__ = [
     'QFT',
     'IQFT',
@@ -102,10 +104,10 @@ class Fourier(Gate):
             raise QuantumError("Start must be smaller than finish")
         return Gate._eval_args(args)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_ZGate(None, **options)
+    def _get_default_basis(self, **options):
+        return Qubit(0)
 
-    def _represent_ZGate(self, basis, **options):
+    def _represent_Qubit(self, basis, **options):
         """
             Represents the (I)QFT In the Z Basis
         """

--- a/sympy/physics/quantum/qho.py
+++ b/sympy/physics/quantum/qho.py
@@ -1,0 +1,125 @@
+"""1D quantum harmonic oscillator."""
+
+from sympy import Symbol, pi, sqrt, sin, Interval, S, factorial, exp
+from sympy.functions import hermite
+
+from sympy.physics.quantum.operator import HermitianOperator, Operator
+from sympy.physics.quantum.state import Ket, Bra, Wavefunction
+from sympy.physics.quantum.constants import hbar
+from sympy.physics.quantum.kronecker import KroneckerDelta
+from sympy.physics.quantum.hilbert import L2
+from sympy.physics.quantum.cartesian import XKet
+
+m = Symbol('m', real=True, positive=True)
+w = Symbol('w', real=True, positive=True) #omega
+
+
+__all__ = [
+    'QHOHamiltonian',
+    'QHOKet',
+    'QHOBra',
+    'AOp',
+    'ADaggerOp'
+]
+
+
+class QHOHamiltonian(HermitianOperator):
+    """Quantum harmonic oscillator Hamiltonian operator."""
+
+    @classmethod
+    def _eval_hilbert_space(cls, label):
+        return L2(Interval(S.NegativeInfinity,S.Infinity))
+
+    def _apply_operator_QHOKet(self, ket, **options):
+        n = ket.label[0]
+        return hbar*w*(n+S(1)/2)*ket
+
+
+class QHOKet(Ket):
+    """Quantum harmonic oscillator eigenket.
+
+    Can be represented in continuous bases and manipulated with continuous
+    operators as well.
+
+    """
+
+    @classmethod
+    def default_args(self):
+        return ('n',)
+
+    @classmethod
+    def def_label_assumptions(self):
+        return {'integer':True}
+
+    @classmethod
+    def _eval_hilbert_space(cls, args):
+        return L2(Interval(S.NegativeInfinity,S.Infinity))
+
+    @classmethod
+    def dual_class(self):
+        return QHOBra
+
+    def _get_default_basis(self, **options):
+        return XKet
+
+    def _represent_XKet(self, basis, **options):
+        from sympy.physics.quantum.represent import _append_index
+        subs_info = options.get('subs',{})
+
+        n = self.label[0]
+        x = basis.position
+        x = _append_index(x, options.pop("index", 1), **basis.label_assumptions)
+
+        prefactor = sqrt(S(1)/(2**n*factorial(n)))*(m*w/(pi*hbar))**(S(1)/4)
+        expo = exp(-m*w*x**2/(2*hbar))
+        herm = hermite(n, sqrt(m*w/hbar)*x)
+        return Wavefunction(prefactor*expo*herm, x)
+
+    def _eval_innerproduct_QHOBra(self, bra):
+        return KroneckerDelta(bra.label[0], self.label[0])
+
+
+class QHOBra(Bra):
+    """Particle in a box eigenbra."""
+
+    @classmethod
+    def _eval_hilbert_space(cls, label):
+        return L2(Interval(S.NegativeInfinity,S.Infinity))
+
+    @classmethod
+    def dual_class(self):
+        return QHOKet
+
+class AOp(Operator):
+    """ QHO Lowering operator """
+
+    @classmethod
+    def default_args(self):
+        ('a',)
+
+    def _apply_operator_QHOKet(self, ket, **options):
+        n = ket.label[0]
+        if n == 0:
+            return 0
+
+        return sqrt(n)*QHOKet(n-1)
+
+    def _eval_dagger(self):
+        return ADaggerOp(*self.args)
+
+    def _eval_commutator_ADaggerOp(self, ket, **options):
+        return S.One
+
+class ADaggerOp(Operator):
+    """ QHO raising operator """
+
+    @classmethod
+    def default_args(self):
+        ('a_d',)
+
+    def _apply_operator_QHOKet(self, ket, **options):
+        n = ket.label[0]
+        return sqrt(n+1)*QHOKet(n+1)
+
+    def _eval_dagger(self):
+        return AOp(*self.args)

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -181,10 +181,10 @@ class Qubit(QubitState, Ket):
         else:
             return Integer(0)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_ZGate(None, **options)
+    def _get_default_basis(self, **options):
+        return Qubit(0)
 
-    def _represent_ZGate(self, basis, **options):
+    def _represent_Qubit(self, basis, **options):
         """Represent this qubits in the computational basis (ZGate).
         """
         format = options.get('format', 'sympy')

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -141,7 +141,11 @@ def represent(expr, **options):
 
     format = options.get('format', 'sympy')
     if isinstance(expr, QExpr) and not isinstance(expr, OuterProduct):
+        if not 'basis' in options:
+            options['basis'] = expr._get_default_basis(**options)
+
         basis = get_basis_state(expr, **options)
+
         if basis is not None:
             options['basis'] = basis
         return expr._represent(**options)
@@ -479,7 +483,7 @@ def get_basis_state(expr, **options):
 
     if basis is None:
         return None
-    elif (isinstance(basis, Operator) or \
+    elif (isinstance(basis, Operator) or isinstance(basis, set) or \
           (not isinstance(basis, StateBase) and issubclass(basis, Operator))):
         state = operators_to_state(basis)
         if state is None:

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -264,10 +264,9 @@ def _represent_helper(expr, **options):
     if should_integrate:
         result = integrate_result(expr, unwrapped_res, **options)
 
-    if should_collapse:
-        result = _collapse_indices(result, basis)
-
     if not should_wrap:
+        if should_collapse:
+            result = _collapse_indices(result, basis)
         return (result, basis)
 
     if len(unwrapped_vars) != 0:
@@ -287,6 +286,9 @@ def _represent_helper(expr, **options):
 
         if len(unwrapped_vars) != 0:
             result = _rewrap_wf(result, unwrapped_vars, **options)
+
+    if should_collapse:
+        result = _collapse_indices(result, basis)
 
     return (result, basis)
 

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -354,9 +354,9 @@ def innerproduct_helper(expr, **options):
     >>> from sympy.physics.quantum.cartesian import XOp, XKet, PxOp, PxKet
     >>> innerproduct_helper(XKet(), basis=XKet())
     DiracDelta(x - x_1)
-    >>> rep_innerproduct(XKet(), basis=PxOp())
+    >>> innerproduct_helper(XKet(), basis=PxKet())
     sqrt(2)*exp(-I*px_1*x/hbar)/(2*sqrt(hbar)*sqrt(pi))
-    >>> rep_innerproduct(PxKet(), basis=XOp())
+    >>> innerproduct_helper(PxKet(), basis=XKet())
     sqrt(2)*exp(I*px*x_1/hbar)/(2*sqrt(hbar)*sqrt(pi))
 
     """

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -132,7 +132,6 @@ def represent(expr, **options):
 
     format = options.get('format', 'sympy')
     if isinstance(expr, QExpr) and not isinstance(expr, OuterProduct):
-        options['replace_none'] = False
         temp_basis = get_basis_state(expr, **options)
         if temp_basis is not None:
             options['basis'] = temp_basis
@@ -142,7 +141,6 @@ def represent(expr, **options):
             #If no _represent_FOO method exists, map to the
             #appropriate basis state and try
             #the other methods of representation
-            options['replace_none'] = True
 
             if isinstance(expr, (KetBase, BraBase)):
                 try:
@@ -363,7 +361,6 @@ def integrate_result(orig_expr, result, **options):
     if not isinstance(result, Expr):
         return result
 
-    options['replace_none'] = True
     if not "basis" in options:
         arg = orig_expr.args[-1]
         options["basis"] = get_basis_state(arg, **options)
@@ -445,21 +442,9 @@ def get_basis_state(expr, **options):
     """
 
     basis = options.pop("basis", None)
-    replace_none = options.pop("replace_none", True)
-
-    if basis is None and not replace_none:
-        return None
 
     if basis is None:
-        if isinstance(expr, KetBase):
-            return _make_default(expr.__class__)
-        elif isinstance(expr, BraBase):
-            return _make_default((expr.dual_class()))
-        elif isinstance(expr, Operator):
-            state_inst = operators_to_state(expr)
-            return (state_inst if state_inst is not None else None)
-        else:
-            return None
+        return None
     elif (isinstance(basis, Operator) or \
           (not isinstance(basis, StateBase) and issubclass(basis, Operator))):
         state = operators_to_state(basis)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -456,6 +456,15 @@ def integrate_result(orig_expr, result, **options):
     if not isinstance(result, Expr):
         return result
 
+    delta = options.pop("delta", False)
+    if delta:
+        unities = options.pop("delta_unities", [])
+    else:
+        unities = options.pop("unities", [])
+
+    if len(unities) == 0:
+        return result
+
     if not "basis" in options:
         arg = orig_expr.args[-1]
         options["basis"] = get_basis_state(arg, **options)
@@ -465,15 +474,6 @@ def integrate_result(orig_expr, result, **options):
     basis = options.pop("basis", None)
 
     if basis is None:
-        return result
-
-    delta = options.pop("delta", False)
-    if delta:
-        unities = options.pop("delta_unities", [])
-    else:
-        unities = options.pop("unities", [])
-
-    if len(unities) == 0:
         return result
 
     kets = enumerate_states(basis, unities)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -446,7 +446,7 @@ def integrate_result(orig_expr, result, **options):
     >>> from sympy.physics.quantum.cartesian import XOp, XKet
     >>> x_ket = XKet()
     >>> X_op = XOp()
-    >>> x, x_1, x_2 = symbols('x, x_1, x_2')
+    >>> x, x_1, x_2 = symbols('x, x_1, x_2', real=True)
     >>> integrate_result(X_op*x_ket, x*DiracDelta(x-x_1)*DiracDelta(x_1-x_2))
     x*DiracDelta(x - x_1)*DiracDelta(x_1 - x_2)
     >>> integrate_result(X_op*x_ket, x*DiracDelta(x-x_1)*DiracDelta(x_1-x_2), basis=XKet, unities=[1])
@@ -699,19 +699,14 @@ def _rewrap_wf(expr, unwrapped_vars, **options):
 
     return expr.__class__(*new_args)
 
-def _append_index(symbol, index):
+def _append_index(symbol, index, **assumptions):
     """
 
     A helper function to append an index to a symbol
-
-    NOTE: Directly changes the name of the symbol, so if you call this more than
-    once on the same symbol you will get multiple indices appended. It does this
-    so that the assumptions of the symbol can be kept. 
 
     """
 
     symbol_str = str(symbol)
     symbol_str += "_" + str(index)
 
-    return Symbol(symbol_str, **symbol._assumptions)
-    
+    return Symbol(symbol_str, **assumptions)

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -698,3 +698,20 @@ def _rewrap_wf(expr, unwrapped_vars, **options):
         new_args.append(wf)
 
     return expr.__class__(*new_args)
+
+def _append_index(symbol, index):
+    """
+
+    A helper function to append an index to a symbol
+
+    NOTE: Directly changes the name of the symbol, so if you call this more than
+    once on the same symbol you will get multiple indices appended. It does this
+    so that the assumptions of the symbol can be kept. 
+
+    """
+
+    symbol_str = str(symbol)
+    symbol_str += "_" + str(index)
+
+    return Symbol(symbol_str, **symbol._assumptions)
+    

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -27,6 +27,9 @@ __all__ = [
     'Jy',
     'Jz',
     'J2',
+    'Jx_basis',
+    'Jy_basis',
+    'Jz_basis',
     'JxKet',
     'JxBra',
     'JyKet',
@@ -536,10 +539,10 @@ class JplusOp(SpinOpBase, Operator):
         result *= KroneckerDelta(j, jp)
         return result
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(basis, **options)
 
     def _eval_rewrite_as_xyz(self, *args):
@@ -577,10 +580,10 @@ class JminusOp(SpinOpBase, Operator):
         result *= KroneckerDelta(j, jp)
         return result
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(basis, **options)
 
     def _eval_rewrite_as_xyz(self, *args):
@@ -610,12 +613,12 @@ class JxOp(SpinOpBase, HermitianOperator):
         jm = JminusOp(self.name)._apply_operator_JzKetCoupled(ket, **options)
         return (jp + jm)/Integer(2)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
-        jp = JplusOp(self.name)._represent_JzOp(basis, **options)
-        jm = JminusOp(self.name)._represent_JzOp(basis, **options)
+    def _represent_JzKet(self, basis, **options):
+        jp = JplusOp(self.name)._represent_JzKet(basis, **options)
+        jm = JminusOp(self.name)._represent_JzKet(basis, **options)
         return (jp + jm)/Integer(2)
 
     def _eval_rewrite_as_plusminus(self, *args):
@@ -645,12 +648,12 @@ class JyOp(SpinOpBase, HermitianOperator):
         jm = JminusOp(self.name)._apply_operator_JzKetCoupled(ket, **options)
         return (jp - jm)/(Integer(2)*I)
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
-        jp = JplusOp(self.name)._represent_JzOp(basis, **options)
-        jm = JminusOp(self.name)._represent_JzOp(basis, **options)
+    def _represent_JzKet(self, basis, **options):
+        jp = JplusOp(self.name)._represent_JzKet(basis, **options)
+        jm = JminusOp(self.name)._represent_JzKet(basis, **options)
         return (jp - jm)/(Integer(2)*I)
 
     def _eval_rewrite_as_plusminus(self, *args):
@@ -682,10 +685,10 @@ class JzOp(SpinOpBase, HermitianOperator):
         result *= KroneckerDelta(j, jp)
         return result
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(basis, **options)
 
 
@@ -739,10 +742,10 @@ class J2Op(SpinOpBase, HermitianOperator):
         result *= KroneckerDelta(j, jp)
         return result
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(basis, **options)
 
     def _pretty(self, printer, *args):
@@ -949,10 +952,10 @@ class Rotation(UnitaryOperator):
                 result[p, q] = me
         return result
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(basis, **options)
 
 
@@ -1163,6 +1166,9 @@ Jz = JzOp('J')
 J2 = J2Op('J')
 Jplus = JplusOp('J')
 Jminus = JminusOp('J')
+Jx_basis = set([J2, Jx])
+Jy_basis = set([J2, Jy])
+Jz_basis = set([J2, Jz])
 
 
 #-----------------------------------------------------------------------------
@@ -1327,16 +1333,16 @@ class JxKet(SpinState, Ket):
     def coupled_class(self):
         return JxKetCoupled
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JxOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JxKet
 
-    def _represent_JxOp(self, basis, **options):
+    def _represent_JxKet(self, basis, **options):
         return self._represent_base(**options)
 
-    def _represent_JyOp(self, basis, **options):
+    def _represent_JyKet(self, basis, **options):
         return self._represent_base(alpha=3*pi/2, **options)
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(beta=pi/2, **options)
 
 class JxBra(SpinState, Bra):
@@ -1380,18 +1386,17 @@ class JyKet(SpinState, Ket):
     def coupled_class(self):
         return JyKetCoupled
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JyOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JyKet
 
-    def _represent_JxOp(self, basis, **options):
+    def _represent_JxKet(self, basis, **options):
         return self._represent_base(gamma=pi/2, **options)
 
-    def _represent_JyOp(self, basis, **options):
+    def _represent_JyKet(self, basis, **options):
         return self._represent_base(**options)
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(alpha=3*pi/2,beta=-pi/2,gamma=pi/2, **options)
-
 
 class JyBra(SpinState, Bra):
     """Eigenbra of Jy.
@@ -1530,18 +1535,17 @@ class JzKet(SpinState, Ket):
     def coupled_class(self):
         return JzKetCoupled
 
-    def _represent_default_basis(self, **options):
-        return self._represent_JzOp(None, **options)
+    def _get_default_basis(self, **options):
+        return JzKet
 
-    def _represent_JxOp(self, basis, **options):
+    def _represent_JxKet(self, basis, **options):
         return self._represent_base(beta=3*pi/2, **options)
 
-    def _represent_JyOp(self, basis, **options):
+    def _represent_JyKet(self, basis, **options):
         return self._represent_base(alpha=3*pi/2,beta=pi/2,gamma=pi/2, **options)
 
-    def _represent_JzOp(self, basis, **options):
+    def _represent_JzKet(self, basis, **options):
         return self._represent_base(**options)
-
 
 class JzBra(SpinState, Bra):
     """Eigenbra of Jz.

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -1459,8 +1459,8 @@ class JzKet(SpinState, Ket):
     of the Jx operator:
 
         >>> from sympy.physics.quantum.represent import represent
-        >>> from sympy.physics.quantum.spin import Jx, Jz
-        >>> represent(JzKet(1,-1), basis=Jx)
+        >>> from sympy.physics.quantum.spin import Jx_basis
+        >>> represent(JzKet(1,-1), basis=Jx_basis)
         [      1/2]
         [sqrt(2)/2]
         [      1/2]

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -122,9 +122,6 @@ class StateBase(QExpr):
     def _enumerate_state(self, num_states, **options):
         raise NotImplementedError("Cannot enumerate this state!")
 
-    def _represent_default_basis(self, **options):
-        return self._represent(basis=self.operators)
-
     #-------------------------------------------------------------------------
     # Dagger/dual
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -607,6 +607,12 @@ class Wavefunction(Function):
     This class takes an expression and coordinates in its constructor. It can be
     used to easily calculate normalizations and probabilities.
 
+    If the ``keep_delta`` options is specified as False in the
+    constructor, then any DiracDeltas which appear in a Mul will be
+    factored out of the Wavefunction. This options exists to make
+    integration easier when representing in continuous bases. See the
+    examples below. ``keep_delta`` is True by default
+
     Parameters
     ==========
 
@@ -685,6 +691,16 @@ class Wavefunction(Function):
 
         >>> diff(f, x)
         Wavefunction(2*x, x)
+
+    The ``keep_delta`` option can be used to factor DiracDelta functions out of
+    the Wavefunction
+
+    >>> from sympy.functions import DiracDelta
+    >>> Wavefunction(x*DiracDelta(x), x)
+    Wavefunction(x*DiracDelta(x), x)
+    >>> Wavefunction(x*DiracDelta(x), x, keep_delta=False)
+    DiracDelta(x)*Wavefunction(x, x)
+
     """
 
     #Any passed tuples for coordinates and their bounds need to be

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -117,9 +117,6 @@ class StateBase(QExpr):
         from operatorset import state_to_operators #import internally to avoid circular import errors
         return state_to_operators(self)
 
-    def _enumerate_state(self, num_states, **options):
-        raise NotImplementedError("Cannot enumerate this state!")
-
     #-------------------------------------------------------------------------
     # Dagger/dual
     #-------------------------------------------------------------------------
@@ -263,10 +260,6 @@ class BraBase(StateBase):
 
     def _state_to_operators(self, op_classes, **options):
         return self.dual._state_to_operators(op_classes, **options)
-
-    def _enumerate_state(self, num_states, **options):
-        dual_states = self.dual._enumerate_state(num_states, **options)
-        return map(lambda x: x.dual, dual_states)
 
     @classmethod
     def default_args(self):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -298,6 +298,9 @@ class BraBase(StateBase):
         from sympy.physics.quantum.dagger import Dagger
         return Dagger(self.dual._represent(**options))
 
+    def _get_default_basis(self, **options):
+        """Get the default basis of the corresponding ket."""
+        return self.dual._get_default_basis(**options)
 
 class State(StateBase):
     """General abstract quantum state used as a base class for Ket and Bra."""

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -127,7 +127,8 @@ class StateBase(QExpr):
     @property
     def dual(self):
         """Return the dual state of this one."""
-        return self.dual_class()._new_rawargs(self.hilbert_space, *self.args)
+        return self.dual_class()._new_rawargs(\
+            self.hilbert_space, self.label_assumptions, *self.args)
 
     @classmethod
     def dual_class(self):
@@ -270,6 +271,10 @@ class BraBase(StateBase):
     @classmethod
     def default_args(self):
         return self.dual_class().default_args()
+
+    @classmethod
+    def def_label_assumptions(self):
+        return self.dual_class().def_label_assumptions()
 
     @classmethod
     def dual_class(self):

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -183,6 +183,12 @@ class KetBase(StateBase):
     def dual_class(self):
         return BraBase
 
+    def _represent_XKet(self, basis, **options):
+        from sympy.physics.quantum.represent import _append_index
+        coord = _append_index(basis.label[0], options.pop('index', 1))
+        psi = Function(str(self.label[0]))
+        return Wavefunction(psi(coord), coord)
+
     def __mul__(self, other):
         """KetBase*other"""
         from sympy.physics.quantum.operator import OuterProduct

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -13,8 +13,8 @@ from sympy.physics.quantum.cartesian import (
 from sympy.physics.quantum.operator import DifferentialOperator
 from sympy.physics.quantum.state import Wavefunction
 
-x, y, z, x_1, x_2, x_3, y_1, z_1 = symbols('x,y,z,x_1,x_2,x_3,y_1,z_1')
-px, py, px_1, px_2 = symbols('px py px_1 px_2')
+x, y, z, x_1, x_2, x_3, y_1, z_1 = symbols('x,y,z,x_1,x_2,x_3,y_1,z_1', real=True)
+px, py, px_1, px_2 = symbols('px py px_1 px_2', real=True)
 f = Function('f')
 
 

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -28,19 +28,19 @@ def test_x():
     assert (PxBra(px)*XKet(x)).doit() ==\
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
     assert represent(XKet(x)) == DiracDelta(x - x_1)
-    assert represent(XOp()) == DiracDelta(x_1 - x_2)*Wavefunction(x_1, x_1)
+    assert represent(XOp()) == DiracDelta(x - x_1)*Wavefunction(x, x)
     assert represent(XBra(x)) == DiracDelta(x - x_1)
     assert XBra(x).position == x
-    assert represent(XOp()*XKet()) == DiracDelta(x-x_2)*Wavefunction(x, x)
+    assert represent(XOp()*XKet()) == DiracDelta(x-x_1)*Wavefunction(x, x)
     assert represent(XOp()*XKet()*XBra('y')) == \
-           DiracDelta(x - x_3)*DiracDelta(y - x_1)*Wavefunction(x, x)
+           DiracDelta(x - x_2)*DiracDelta(y - x_1)*Wavefunction(x, x)
     assert represent(XBra("y")*XKet()) == DiracDelta(y - x)
     assert represent(XKet()*XBra()) == \
            DiracDelta(x - x_1)*DiracDelta(x - x_2)
 
     rep_p = represent(XOp(), basis = PxOp)
-    diff_op1 = DifferentialOperator(Derivative(f(px_1), px_1), f(px_1))
-    assert rep_p == hbar*I*DiracDelta(px_1 - px_2)*diff_op1
+    diff_op1 = DifferentialOperator(Derivative(f(px), px), f(px))
+    assert rep_p == hbar*I*DiracDelta(px - px_1)*diff_op1
     assert rep_p == represent(XOp(), basis = PxOp())
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
@@ -59,8 +59,8 @@ def test_p():
     assert represent(PxKet(px)) == DiracDelta(px - px_1)
 
     rep_x = represent(PxOp(), basis = XOp)
-    diff_op1 = DifferentialOperator(Derivative(f(x_1), x_1), f(x_1))
-    assert rep_x == -hbar*I*DiracDelta(x_1 - x_2)*diff_op1
+    diff_op1 = DifferentialOperator(Derivative(f(x), x), f(x))
+    assert rep_x == -hbar*I*DiracDelta(x - x_1)*diff_op1
     assert rep_x == represent(PxOp(), basis = XOp())
     assert rep_x == represent(PxOp(), basis = XKet)
     assert rep_x == represent(PxOp(), basis = XKet())

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -29,13 +29,14 @@ def test_x():
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
     assert represent(XKet(x)) == Wavefunction(DiracDelta(x - x_1), x)
     assert represent(XOp()) == Wavefunction(x_1*DiracDelta(x_1 - x_2), x_1)
-    #assert represent(XBra(x)) == DiracDelta(x_1 - x)
+    assert represent(XBra(x)) == Wavefunction(DiracDelta(x - x_1), x)
     assert XBra(x).position == x
-    #assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
-    #assert represent(XOp()*XKet()*XBra('y')) == \
-    #       x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
-    #assert represent(XBra("y")*XKet()) == DiracDelta(x - y)
-    #assert represent(XKet()*XBra()) == DiracDelta(x - x_2) * DiracDelta(x_1 - x)
+    assert represent(XOp()*XKet()) == Wavefunction(x*DiracDelta(x-x_2), x)
+    assert represent(XOp()*XKet()*XBra('y')) == \
+           Wavefunction(x*DiracDelta(x - x_3)*DiracDelta(y - x_1), x, y)
+    assert represent(XBra("y")*XKet()) == Wavefunction(DiracDelta(y - x), x, y)
+    assert represent(XKet()*XBra()) == \
+           Wavefunction(DiracDelta(x - x_1)*DiracDelta(x - x_2), x)
 
     rep_p = represent(XOp(), basis = PxOp)
     diff_op1 = DifferentialOperator(Derivative(f(px_1), px_1), f(px_1))
@@ -44,9 +45,7 @@ def test_x():
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
-    #diff_op = DifferentialOperator(Derivative(f(px), px), f(px))
-    #assert represent(XOp()*PxKet(), basis = PxKet) == \
-    #       hbar*I*DiracDelta(px - px_2)*diff_op
+    assert represent(XOp()*PxKet(), basis = PxKet) == 0
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -66,10 +65,8 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XKet())
 
     diff_op = DifferentialOperator(Derivative(f(x), x), f(x))
-    #assert represent(PxOp()*XKet(), basis=XKet) == \
-    #       -hbar*I*DiracDelta(x - x_2)*diff_op
-    #assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
-    #       -hbar*I*DiracDelta(x-y)*diff_op
+    assert represent(PxOp()*XKet(), basis=XKet) == 0
+    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == 0
 
 def test_3dpos():
     assert Y.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -26,14 +26,14 @@ def test_x():
     assert (Dagger(XKet(y))*XKet(x)).doit() == DiracDelta(x-y)
     assert (PxBra(px)*XKet(x)).doit() ==\
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(XKet(x)) == DiracDelta(x-x_1)
-    assert represent(XBra(x)) == DiracDelta(-x + x_1)
+    assert represent(XKet(x)) == DiracDelta(x - x_1)
+    #assert represent(XBra(x)) == DiracDelta(x_1 - x)
     assert XBra(x).position == x
-    assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
-    assert represent(XOp()*XKet()*XBra('y')) == \
-           x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
-    assert represent(XBra("y")*XKet()) == DiracDelta(x - y)
-    assert represent(XKet()*XBra()) == DiracDelta(x - x_2) * DiracDelta(x_1 - x)
+    #assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
+    #assert represent(XOp()*XKet()*XBra('y')) == \
+    #       x*DiracDelta(x - x_3)*DiracDelta(x_1 - y)
+    #assert represent(XBra("y")*XKet()) == DiracDelta(x - y)
+    #assert represent(XKet()*XBra()) == DiracDelta(x - x_2) * DiracDelta(x_1 - x)
 
     rep_p = represent(XOp(), basis = PxOp)
     diff_op1 = DifferentialOperator(Derivative(f(px_1), px_1), f(px_1))
@@ -66,8 +66,8 @@ def test_p():
     diff_op = DifferentialOperator(Derivative(f(x), x), f(x))
     assert represent(PxOp()*XKet(), basis=XKet) == \
            -hbar*I*DiracDelta(x - x_2)*diff_op
-    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
-           -hbar*I*DiracDelta(x-y)*diff_op
+    #assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
+    #       -hbar*I*DiracDelta(x-y)*diff_op
 
 def test_3dpos():
     assert Y.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -45,7 +45,8 @@ def test_x():
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
-    assert represent(XOp()*PxKet(), basis = PxKet) == 0
+    assert represent(XOp()*PxKet(), basis = PxKet) == \
+           Wavefunction(-hbar*I*DiracDelta(px - px_2, 1), px)
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -65,8 +66,10 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XKet())
 
     diff_op = DifferentialOperator(Derivative(f(x), x), f(x))
-    assert represent(PxOp()*XKet(), basis=XKet) == 0
-    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == 0
+    assert represent(PxOp()*XKet(), basis=XKet) == \
+           Wavefunction(hbar*I*DiracDelta(x - x_2, 1), x)
+    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
+           Wavefunction(hbar*I*DiracDelta(x - y, 1), x, y)
 
 def test_3dpos():
     assert Y.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -27,16 +27,16 @@ def test_x():
     assert (Dagger(XKet(y))*XKet(x)).doit() == DiracDelta(x-y)
     assert (PxBra(px)*XKet(x)).doit() ==\
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(XKet(x)) == Wavefunction(DiracDelta(x - x_1), x)
-    assert represent(XOp()) == Wavefunction(x_1*DiracDelta(x_1 - x_2), x_1)
-    assert represent(XBra(x)) == Wavefunction(DiracDelta(x - x_1), x)
+    assert represent(XKet(x)) == DiracDelta(x - x_1)
+    assert represent(XOp()) == DiracDelta(x_1 - x_2)*Wavefunction(x_1, x_1)
+    assert represent(XBra(x)) == DiracDelta(x - x_1)
     assert XBra(x).position == x
-    assert represent(XOp()*XKet()) == Wavefunction(x*DiracDelta(x-x_2), x)
+    assert represent(XOp()*XKet()) == DiracDelta(x-x_2)*Wavefunction(x, x)
     assert represent(XOp()*XKet()*XBra('y')) == \
-           Wavefunction(x*DiracDelta(x - x_3)*DiracDelta(y - x_1), x, y)
-    assert represent(XBra("y")*XKet()) == Wavefunction(DiracDelta(y - x), x, y)
+           DiracDelta(x - x_3)*DiracDelta(y - x_1)*Wavefunction(x, x)
+    assert represent(XBra("y")*XKet()) == DiracDelta(y - x)
     assert represent(XKet()*XBra()) == \
-           Wavefunction(DiracDelta(x - x_1)*DiracDelta(x - x_2), x)
+           DiracDelta(x - x_1)*DiracDelta(x - x_2)
 
     rep_p = represent(XOp(), basis = PxOp)
     diff_op1 = DifferentialOperator(Derivative(f(px_1), px_1), f(px_1))
@@ -45,8 +45,8 @@ def test_x():
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
-    assert represent(XOp()*PxKet(), basis = PxKet) == \
-           Wavefunction(-hbar*I*DiracDelta(px - px_2, 1), px)
+    #assert represent(XOp()*PxKet(), basis = PxKet) == \
+    #       Wavefunction(-hbar*I*DiracDelta(px - px_2, 1), px)
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -56,7 +56,7 @@ def test_p():
     assert (Dagger(PxKet(py))*PxKet(px)).doit() == DiracDelta(px-py)
     assert (XBra(x)*PxKet(px)).doit() ==\
         exp(I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(PxKet(px)) == Wavefunction(DiracDelta(px - px_1), px)
+    assert represent(PxKet(px)) == DiracDelta(px - px_1)
 
     rep_x = represent(PxOp(), basis = XOp)
     diff_op1 = DifferentialOperator(Derivative(f(x_1), x_1), f(x_1))
@@ -66,10 +66,10 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XKet())
 
     diff_op = DifferentialOperator(Derivative(f(x), x), f(x))
-    assert represent(PxOp()*XKet(), basis=XKet) == \
-           Wavefunction(hbar*I*DiracDelta(x - x_2, 1), x)
-    assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
-           Wavefunction(hbar*I*DiracDelta(x - y, 1), x, y)
+    #assert represent(PxOp()*XKet(), basis=XKet) == \
+    #       Wavefunction(hbar*I*DiracDelta(x - x_2, 1), x)
+    #assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
+    #       Wavefunction(hbar*I*DiracDelta(x - y, 1), x, y)
 
 def test_3dpos():
     assert Y.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -11,6 +11,7 @@ from sympy.physics.quantum.cartesian import (
     PositionKet3D, PositionBra3D
 )
 from sympy.physics.quantum.operator import DifferentialOperator
+from sympy.physics.quantum.state import Wavefunction
 
 x, y, z, x_1, x_2, x_3, y_1, z_1 = symbols('x,y,z,x_1,x_2,x_3,y_1,z_1')
 px, py, px_1, px_2 = symbols('px py px_1 px_2')
@@ -26,7 +27,8 @@ def test_x():
     assert (Dagger(XKet(y))*XKet(x)).doit() == DiracDelta(x-y)
     assert (PxBra(px)*XKet(x)).doit() ==\
         exp(-I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(XKet(x)) == DiracDelta(x - x_1)
+    assert represent(XKet(x)) == Wavefunction(DiracDelta(x - x_1), x)
+    assert represent(XOp()) == Wavefunction(x_1*DiracDelta(x_1 - x_2), x_1)
     #assert represent(XBra(x)) == DiracDelta(x_1 - x)
     assert XBra(x).position == x
     #assert represent(XOp()*XKet()) == x*DiracDelta(x-x_2)
@@ -42,9 +44,9 @@ def test_x():
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
-    diff_op = DifferentialOperator(Derivative(f(px), px), f(px))
-    assert represent(XOp()*PxKet(), basis = PxKet) == \
-           hbar*I*DiracDelta(px - px_2)*diff_op
+    #diff_op = DifferentialOperator(Derivative(f(px), px), f(px))
+    #assert represent(XOp()*PxKet(), basis = PxKet) == \
+    #       hbar*I*DiracDelta(px - px_2)*diff_op
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -54,7 +56,7 @@ def test_p():
     assert (Dagger(PxKet(py))*PxKet(px)).doit() == DiracDelta(px-py)
     assert (XBra(x)*PxKet(px)).doit() ==\
         exp(I*x*px/hbar)/sqrt(2*pi*hbar)
-    assert represent(PxKet(px)) == DiracDelta(px-px_1)
+    assert represent(PxKet(px)) == Wavefunction(DiracDelta(px - px_1), px)
 
     rep_x = represent(PxOp(), basis = XOp)
     diff_op1 = DifferentialOperator(Derivative(f(x_1), x_1), f(x_1))
@@ -64,8 +66,8 @@ def test_p():
     assert rep_x == represent(PxOp(), basis = XKet())
 
     diff_op = DifferentialOperator(Derivative(f(x), x), f(x))
-    assert represent(PxOp()*XKet(), basis=XKet) == \
-           -hbar*I*DiracDelta(x - x_2)*diff_op
+    #assert represent(PxOp()*XKet(), basis=XKet) == \
+    #       -hbar*I*DiracDelta(x - x_2)*diff_op
     #assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
     #       -hbar*I*DiracDelta(x-y)*diff_op
 

--- a/sympy/physics/quantum/tests/test_cartesian.py
+++ b/sympy/physics/quantum/tests/test_cartesian.py
@@ -1,6 +1,8 @@
 """Tests for cartesian.py"""
 
-from sympy import S, Interval, symbols, I, DiracDelta, exp, sqrt, pi
+from sympy import (
+    S, Interval, symbols, I, DiracDelta, exp, sqrt, pi, Derivative, Function
+)
 
 from sympy.physics.quantum import qapply, represent, L2, Dagger
 from sympy.physics.quantum import Commutator, hbar
@@ -12,6 +14,7 @@ from sympy.physics.quantum.operator import DifferentialOperator
 
 x, y, z, x_1, x_2, x_3, y_1, z_1 = symbols('x,y,z,x_1,x_2,x_3,y_1,z_1')
 px, py, px_1, px_2 = symbols('px py px_1 px_2')
+f = Function('f')
 
 
 def test_x():
@@ -33,13 +36,15 @@ def test_x():
     assert represent(XKet()*XBra()) == DiracDelta(x - x_2) * DiracDelta(x_1 - x)
 
     rep_p = represent(XOp(), basis = PxOp)
-    assert rep_p == hbar*I*DiracDelta(px_1 - px_2)*DifferentialOperator(px_1)
+    diff_op1 = DifferentialOperator(Derivative(f(px_1), px_1), f(px_1))
+    assert rep_p == hbar*I*DiracDelta(px_1 - px_2)*diff_op1
     assert rep_p == represent(XOp(), basis = PxOp())
     assert rep_p == represent(XOp(), basis = PxKet)
     assert rep_p == represent(XOp(), basis = PxKet())
 
+    diff_op = DifferentialOperator(Derivative(f(px), px), f(px))
     assert represent(XOp()*PxKet(), basis = PxKet) == \
-           hbar*I*DiracDelta(px - px_2)*DifferentialOperator(px)
+           hbar*I*DiracDelta(px - px_2)*diff_op
 
 def test_p():
     assert Px.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))
@@ -52,15 +57,17 @@ def test_p():
     assert represent(PxKet(px)) == DiracDelta(px-px_1)
 
     rep_x = represent(PxOp(), basis = XOp)
-    assert rep_x == -hbar*I*DiracDelta(x_1 - x_2)*DifferentialOperator(x_1)
+    diff_op1 = DifferentialOperator(Derivative(f(x_1), x_1), f(x_1))
+    assert rep_x == -hbar*I*DiracDelta(x_1 - x_2)*diff_op1
     assert rep_x == represent(PxOp(), basis = XOp())
     assert rep_x == represent(PxOp(), basis = XKet)
     assert rep_x == represent(PxOp(), basis = XKet())
 
+    diff_op = DifferentialOperator(Derivative(f(x), x), f(x))
     assert represent(PxOp()*XKet(), basis=XKet) == \
-           -hbar*I*DiracDelta(x - x_2)*DifferentialOperator(x)
+           -hbar*I*DiracDelta(x - x_2)*diff_op
     assert represent(XBra("y")*PxOp()*XKet(), basis=XKet) == \
-           -hbar*I*DiracDelta(x-y)*DifferentialOperator(x)
+           -hbar*I*DiracDelta(x-y)*diff_op
 
 def test_3dpos():
     assert Y.hilbert_space == L2(Interval(S.NegativeInfinity, S.Infinity))

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -1,11 +1,11 @@
-from sympy import (Derivative, diff, Function, Integer, Mul, pi, sin, Symbol,
+from sympy import (Derivative, diff, expand, Function, Integer, Mul, pi, sin, Symbol,
                    symbols)
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.hilbert import HilbertSpace
-from sympy.physics.quantum.operator import (Operator, UnitaryOperator,
-                                            HermitianOperator, OuterProduct,
-                                            DifferentialOperator)
+from sympy.physics.quantum.operator import (DifferentialOperator,
+                                            HermitianOperator, Operator,
+                                            OuterProduct, UnitaryOperator)
 from sympy.physics.quantum.state import Ket, Bra, Wavefunction
 from sympy.physics.quantum.qapply import qapply
 
@@ -173,3 +173,11 @@ def test_differential_operator():
     assert diff(d, th) == \
            DifferentialOperator(Derivative(d.expr, th), f(r, th))
     assert qapply(d*w) == Wavefunction(3*sin(th), r, (th, 0, pi))
+
+    d = DifferentialOperator((x+y)**2*Derivative(f(x), x), f(x))
+    exp = expand(d, diffop=True)
+    first_term = DifferentialOperator(x**2*Derivative(f(x), x), f(x))
+    sec_term = DifferentialOperator(2*x*y*Derivative(f(x), x), f(x))
+    third_term = DifferentialOperator(y**2*Derivative(f(x), x), f(x))
+
+    assert exp == first_term + sec_term + third_term

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -17,6 +17,11 @@ from sympy.utilities.pytest import raises
 
 from sympy.utilities.pytest import XFAIL
 
+def test_op_to_state():
+    assert operators_to_state(XOp) == XKet()
+    assert operators_to_state(PxOp) == PxKet()
+
+
 @XFAIL
 def test_spin():
     assert operators_to_state(set([J2Op, JxOp])) == JxKet()
@@ -25,6 +30,17 @@ def test_spin():
     assert operators_to_state(set([J2Op(), JxOp()])) ==  JxKet()
     assert operators_to_state(set([J2Op(), JyOp()])) ==  JyKet()
     assert operators_to_state(set([J2Op(), JzOp()])) ==  JzKet()
+
+    assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
+    assert state_to_operators(operators_to_state(XOp())) == XOp()
+
+    raises(NotImplementedError, 'operators_to_state(XKet)')
+
+def test_state_to_op():
+    assert state_to_operators(XKet) == XOp()
+    assert state_to_operators(PxKet) == PxOp()
+    assert state_to_operators(XBra) == XOp()
+    assert state_to_operators(PxBra) == PxOp()
 
     assert state_to_operators(JxKet) == set([J2Op(), JxOp()])
     assert state_to_operators(JyKet) == set([J2Op(), JyOp()])

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -3,7 +3,7 @@ from sympy.physics.quantum.operatorset import (
 )
 
 from sympy.physics.quantum.cartesian import (
-    XOp, XKet, PxOp, PxKet, XBra, PxBra
+    XOp, YOp, ZOp, XKet, PxOp, PxKet, XBra, PxBra, PositionKet3D, PositionBra3D
 )
 
 from sympy.physics.quantum.state import Ket, Bra
@@ -20,6 +20,11 @@ from sympy.utilities.pytest import XFAIL
 def test_op_to_state():
     assert operators_to_state(XOp) == XKet()
     assert operators_to_state(PxOp) == PxKet()
+    assert operators_to_state(XOp()) == XKet()
+    assert operators_to_state(PxOp()) == PxKet()
+
+    assert operators_to_state(set([XOp, YOp, ZOp])) == PositionKet3D()
+    assert operators_to_state(set([XOp(), YOp(), ZOp()])) == PositionKet3D()
 
 
 @XFAIL
@@ -41,6 +46,14 @@ def test_state_to_op():
     assert state_to_operators(PxKet) == PxOp()
     assert state_to_operators(XBra) == XOp()
     assert state_to_operators(PxBra) == PxOp()
+
+    assert state_to_operators(XKet()) == XOp()
+    assert state_to_operators(PxKet()) == PxOp()
+    assert state_to_operators(XBra()) == XOp()
+    assert state_to_operators(PxBra()) == PxOp()
+
+    assert state_to_operators(PositionKet3D()) == set([XOp(), YOp(), ZOp()])
+    assert state_to_operators(PositionBra3D()) == set([XOp(), YOp(), ZOp()])
 
     assert state_to_operators(JxKet) == set([J2Op(), JxOp()])
     assert state_to_operators(JyKet) == set([J2Op(), JyOp()])

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -25,9 +25,11 @@ def test_op_to_state():
 
     assert operators_to_state(set([XOp, YOp, ZOp])) == PositionKet3D()
     assert operators_to_state(set([XOp(), YOp(), ZOp()])) == PositionKet3D()
+    assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
+    assert state_to_operators(operators_to_state(XOp())) == XOp()
 
+    raises(NotImplementedError, 'operators_to_state(XKet)')
 
-@XFAIL
 def test_spin():
     assert operators_to_state(set([J2Op, JxOp])) == JxKet()
     assert operators_to_state(set([J2Op, JyOp])) == JyKet()
@@ -35,11 +37,20 @@ def test_spin():
     assert operators_to_state(set([J2Op(), JxOp()])) ==  JxKet()
     assert operators_to_state(set([J2Op(), JyOp()])) ==  JyKet()
     assert operators_to_state(set([J2Op(), JzOp()])) ==  JzKet()
+    
+    assert state_to_operators(JxKet) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyKet) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzKet) == set([J2Op(), JzOp()])
+    assert state_to_operators(JxBra) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyBra) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzBra) == set([J2Op(), JzOp()])
 
-    assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
-    assert state_to_operators(operators_to_state(XOp())) == XOp()
-
-    raises(NotImplementedError, 'operators_to_state(XKet)')
+    assert state_to_operators(JxKet()) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyKet()) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzKet()) == set([J2Op(), JzOp()])
+    assert state_to_operators(JxBra()) == set([J2Op(), JxOp()])
+    assert state_to_operators(JyBra()) == set([J2Op(), JyOp()])
+    assert state_to_operators(JzBra()) == set([J2Op(), JzOp()])
 
 def test_state_to_op():
     assert state_to_operators(XKet) == XOp()
@@ -55,42 +66,12 @@ def test_state_to_op():
     assert state_to_operators(PositionKet3D()) == set([XOp(), YOp(), ZOp()])
     assert state_to_operators(PositionBra3D()) == set([XOp(), YOp(), ZOp()])
 
-    assert state_to_operators(JxKet) == set([J2Op(), JxOp()])
-    assert state_to_operators(JyKet) == set([J2Op(), JyOp()])
-    assert state_to_operators(JzKet) == set([J2Op(), JzOp()])
-    assert state_to_operators(JxBra) == set([J2Op(), JxOp()])
-    assert state_to_operators(JyBra) == set([J2Op(), JyOp()])
-    assert state_to_operators(JzBra) == set([J2Op(), JzOp()])
-
-    assert state_to_operators(JxKet()) == set([J2Op(), JxOp()])
-    assert state_to_operators(JyKet()) == set([J2Op(), JyOp()])
-    assert state_to_operators(JzKet()) == set([J2Op(), JzOp()])
-    assert state_to_operators(JxBra()) == set([J2Op(), JxOp()])
-    assert state_to_operators(JyBra()) == set([J2Op(), JyOp()])
-    assert state_to_operators(JzBra()) == set([J2Op(), JzOp()])
-
-def test_op_to_state():
-    assert operators_to_state(XOp) == XKet()
-    assert operators_to_state(PxOp) == PxKet()
-    assert operators_to_state(Operator) == Ket()
-
-    assert state_to_operators(operators_to_state(XOp("Q"))) == XOp("Q")
-    assert state_to_operators(operators_to_state(XOp())) == XOp()
-
-    raises(NotImplementedError, 'operators_to_state(XKet)')
-
-def test_state_to_op():
-    assert state_to_operators(XKet) == XOp()
-    assert state_to_operators(PxKet) == PxOp()
-    assert state_to_operators(XBra) == XOp()
-    assert state_to_operators(PxBra) == PxOp()
-    assert state_to_operators(Ket) == Operator()
-    assert state_to_operators(Bra) == Operator()
-
     assert operators_to_state(state_to_operators(XKet("test"))) == XKet("test")
     assert operators_to_state(state_to_operators(XBra("test"))) == XKet("test")
     assert operators_to_state(state_to_operators(XKet())) == XKet()
     assert operators_to_state(state_to_operators(XBra())) == XKet()
 
     raises(NotImplementedError, 'state_to_operators(XOp)')
+ 
+
 

--- a/sympy/physics/quantum/tests/test_piab.py
+++ b/sympy/physics/quantum/tests/test_piab.py
@@ -4,6 +4,7 @@ from sympy import Interval, pi, S, sin, sqrt, symbols
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.quantum import L2, qapply, hbar, represent
 from sympy.physics.quantum.piab import PIABHamiltonian, PIABKet, PIABBra, m, L
+from sympy.physics.quantum.cartesian import XOp, XKet
 
 i, j, n, x = symbols('i j n x')
 
@@ -18,5 +19,7 @@ def test_states():
     assert PIABKet(n).hilbert_space ==\
         L2(Interval(S.NegativeInfinity,S.Infinity))
     assert represent(PIABKet(n)) == sqrt(2/L)*sin(n*pi*x/L)
+    assert represent(PIABKet(n), basis=XKet) == sqrt(2/L)*sin(n*pi*x/L)
+    assert represent(PIABKet(n), basis=XOp) == sqrt(2/L)*sin(n*pi*x/L)
     assert (PIABBra(i)*PIABKet(j)).doit() == KroneckerDelta(i, j)
     assert PIABBra(n).dual_class() == PIABKet

--- a/sympy/physics/quantum/tests/test_piab.py
+++ b/sympy/physics/quantum/tests/test_piab.py
@@ -7,7 +7,7 @@ from sympy.physics.quantum.piab import PIABHamiltonian, PIABKet, PIABBra, m, L
 from sympy.physics.quantum.cartesian import XOp, XKet
 from sympy.physics.quantum.state import Wavefunction
 
-x_1 = Symbol('x_1', real=True)
+x = Symbol('x', real=True)
 n = Symbol('n', integer=True)
 i, j = symbols('i,j')
 
@@ -22,10 +22,10 @@ def test_states():
     assert PIABKet(n).hilbert_space ==\
         L2(Interval(S.NegativeInfinity,S.Infinity))
     assert represent(PIABKet(n)) == \
-           Wavefunction(sqrt(2/L)*sin(n*pi*x_1/L), (x_1, 0, L))
+           Wavefunction(sqrt(2/L)*sin(n*pi*x/L), (x, 0, L))
     assert represent(PIABKet(n), basis=XKet) == \
-           Wavefunction(sqrt(2/L)*sin(n*pi*x_1 /L), (x_1, 0, L))
+           Wavefunction(sqrt(2/L)*sin(n*pi*x/L), (x, 0, L))
     assert represent(PIABKet(n), basis=XOp) == \
-           Wavefunction(sqrt(2/L)*sin(n*pi*x_1/L), (x_1, 0, L))
+           Wavefunction(sqrt(2/L)*sin(n*pi*x/L), (x, 0, L))
     assert (PIABBra(i)*PIABKet(j)).doit() == KroneckerDelta(i, j)
     assert PIABBra(n).dual_class() == PIABKet

--- a/sympy/physics/quantum/tests/test_piab.py
+++ b/sympy/physics/quantum/tests/test_piab.py
@@ -1,12 +1,16 @@
 """Tests for piab.py"""
 
-from sympy import Interval, pi, S, sin, sqrt, symbols
+<<<<<<< HEAD
+from sympy import DiracDelta, I, Interval, pi, S, sin, sqrt, Symbol, symbols
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.quantum import L2, qapply, hbar, represent
 from sympy.physics.quantum.piab import PIABHamiltonian, PIABKet, PIABBra, m, L
 from sympy.physics.quantum.cartesian import XOp, XKet
+from sympy.physics.quantum.state import Wavefunction
 
-i, j, n, x = symbols('i j n x')
+x_1 = Symbol('x_1', real=True)
+n = Symbol('n', integer=True)
+i, j = symbols('i,j')
 
 def test_H():
     assert PIABHamiltonian('H').hilbert_space ==\
@@ -18,8 +22,11 @@ def test_states():
     assert PIABKet(n).dual_class() == PIABBra
     assert PIABKet(n).hilbert_space ==\
         L2(Interval(S.NegativeInfinity,S.Infinity))
-    assert represent(PIABKet(n)) == sqrt(2/L)*sin(n*pi*x/L)
-    assert represent(PIABKet(n), basis=XKet) == sqrt(2/L)*sin(n*pi*x/L)
-    assert represent(PIABKet(n), basis=XOp) == sqrt(2/L)*sin(n*pi*x/L)
+    assert represent(PIABKet(n)) == \
+           Wavefunction(sqrt(2/L)*sin(n*pi*x_1/L), (x_1, 0, L))
+    assert represent(PIABKet(n), basis=XKet) == \
+           Wavefunction(sqrt(2/L)*sin(n*pi*x_1 /L), (x_1, 0, L))
+    assert represent(PIABKet(n), basis=XOp) == \
+           Wavefunction(sqrt(2/L)*sin(n*pi*x_1/L), (x_1, 0, L))
     assert (PIABBra(i)*PIABKet(j)).doit() == KroneckerDelta(i, j)
     assert PIABBra(n).dual_class() == PIABKet

--- a/sympy/physics/quantum/tests/test_piab.py
+++ b/sympy/physics/quantum/tests/test_piab.py
@@ -1,6 +1,5 @@
 """Tests for piab.py"""
 
-<<<<<<< HEAD
 from sympy import DiracDelta, I, Interval, pi, S, sin, sqrt, Symbol, symbols
 from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.quantum import L2, qapply, hbar, represent

--- a/sympy/physics/quantum/tests/test_qexpr.py
+++ b/sympy/physics/quantum/tests/test_qexpr.py
@@ -15,7 +15,7 @@ def test_qexpr_new():
     q = QExpr(0,1)
     assert q.label == (Integer(0),Integer(1))
 
-    q = QExpr._new_rawargs(HilbertSpace(), Integer(0), Integer(1))
+    q = QExpr._new_rawargs(HilbertSpace(), {}, Integer(0), Integer(1))
     assert q.label == (Integer(0),Integer(1))
     assert q.hilbert_space == HilbertSpace()
 

--- a/sympy/physics/quantum/tests/test_qho.py
+++ b/sympy/physics/quantum/tests/test_qho.py
@@ -1,0 +1,27 @@
+"""Tests for qho.py"""
+
+from sympy import S, Interval, symbols, I, DiracDelta, exp, sqrt, pi, sin, Symbol
+
+from sympy.physics.quantum import L2, qapply, hbar, represent
+from sympy.physics.quantum import KroneckerDelta
+from sympy.physics.quantum.qho import QHOHamiltonian, QHOBra, QHOKet, m, w
+from sympy.physics.quantum.cartesian import XOp, XKet
+from sympy.physics.quantum.state import Wavefunction
+
+
+x = Symbol('x', real=True)
+n = Symbol('n', integer=True)
+i, j = symbols('i,j')
+
+
+def test_H():
+    assert QHOHamiltonian('H').hilbert_space ==\
+        L2(Interval(S.NegativeInfinity,S.Infinity))
+    assert qapply(QHOHamiltonian('H')*QHOKet(n)) ==\
+        hbar*w*n*QHOKet(n) + hbar*w*(S(1)/2)*QHOKet(n)
+
+
+def test_states():
+    assert QHOKet(n).dual_class() == QHOBra
+    assert QHOKet(n).hilbert_space ==\
+        L2(Interval(S.NegativeInfinity,S.Infinity))

--- a/sympy/physics/quantum/tests/test_qho.py
+++ b/sympy/physics/quantum/tests/test_qho.py
@@ -1,9 +1,8 @@
 """Tests for qho.py"""
 
 from sympy import S, Interval, symbols, I, DiracDelta, exp, sqrt, pi, sin, Symbol
-
 from sympy.physics.quantum import L2, qapply, hbar, represent
-from sympy.physics.quantum import KroneckerDelta
+from sympy.functions.special.tensor_functions import KroneckerDelta
 from sympy.physics.quantum.qho import QHOHamiltonian, QHOBra, QHOKet, m, w
 from sympy.physics.quantum.cartesian import XOp, XKet
 from sympy.physics.quantum.state import Wavefunction

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -30,10 +30,10 @@ class AKet(Ket):
     def dual_class(self):
         return ABra
 
-    def _represent_default_basis(self, **options):
-        return self._represent_AOp(None, **options)
+    def _get_default_basis(self, **options):
+        return AKet
 
-    def _represent_AOp(self, basis, **options):
+    def _represent_AKet(self, basis, **options):
         return Avec
 
 
@@ -46,19 +46,19 @@ class ABra(Bra):
 
 class AOp(Operator):
 
-    def _represent_default_basis(self, **options):
-        return self._represent_AOp(None, **options)
+    def _get_default_basis(self, **options):
+        return AKet
 
-    def _represent_AOp(self, basis, **options):
+    def _represent_AKet(self, basis, **options):
         return Amat
 
 
 class BOp(Operator):
 
-    def _represent_default_basis(self, **options):
-        return self._represent_AOp(None, **options)
+    def _get_default_basis(self, **options):
+        return AKet
 
-    def _represent_AOp(self, basis, **options):
+    def _represent_AKet(self, basis, **options):
         return Bmat
 
 
@@ -96,7 +96,7 @@ _tests = [
 
 def test_format_sympy():
     for test in _tests:
-        lhs = represent(test[0], basis=A, format='sympy')
+        lhs = represent(test[0], basis=k, format='sympy')
         rhs = to_sympy(test[1])
         assert lhs == rhs
 
@@ -113,7 +113,7 @@ def test_format_numpy():
         skip("numpy not installed or Python too old.")
 
     for test in _tests:
-        lhs = represent(test[0], basis=A, format='numpy')
+        lhs = represent(test[0], basis=k, format='numpy')
         rhs = to_numpy(test[1])
         if isinstance(lhs, numpy_ndarray):
             assert (lhs == rhs).all()
@@ -138,7 +138,7 @@ def test_format_scipy_sparse():
         skip("scipy not installed.")
 
     for test in _tests:
-        lhs = represent(test[0], basis=A, format='scipy.sparse')
+        lhs = represent(test[0], basis=k, format='scipy.sparse')
         rhs = to_scipy_sparse(test[1])
         if isinstance(lhs, scipy_sparse_matrix):
             assert np.linalg.norm((lhs-rhs).todense()) == 0.0

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -3,9 +3,10 @@ from sympy.external import import_module
 from sympy.utilities.pytest import skip
 
 from sympy.physics.quantum.dagger import Dagger
-from sympy.physics.quantum.represent import (represent, rep_innerproduct,
-                                             rep_expectation, enumerate_states)
-from sympy.physics.quantum.state import Bra, Ket
+from sympy.physics.quantum.represent import (enumerate_states,
+                                             expectation_helper,
+                                             innerproduct_helper, represent)
+from sympy.physics.quantum.state import Bra, Ket, TimeDepKet
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.tensorproduct import TensorProduct
 from sympy.physics.quantum.tensorproduct import matrix_tensor_product

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -16,7 +16,7 @@ from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.matrixutils import (numpy_ndarray,
                                                scipy_sparse_matrix, to_numpy,
                                                to_scipy_sparse, to_sympy)
-from sympy.physics.quantum.cartesian import XKet, XOp, XBra
+from sympy.physics.quantum.cartesian import XKet, XOp, XBra, PositionKet3D
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.operatorset import operators_to_state
 
@@ -176,3 +176,10 @@ def test_enumerate_states():
     test = XKet("foo")
     assert enumerate_states(test, 1, 1) == [XKet("foo_1")]
     assert enumerate_states(test, [1, 2, 4]) == [XKet("foo_1"), XKet("foo_2"), XKet("foo_4")]
+
+    test2 = PositionKet3D()
+    assert enumerate_states(test2, 1, 2) == \
+           [PositionKet3D("x_1","y_1","z_1"), PositionKet3D("x_2","y_2","z_2")]
+    assert enumerate_states(test2, [4, 7]) == \
+           [PositionKet3D("x_4","y_4","z_4"), PositionKet3D("x_7","y_7","z_7")]
+

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -158,18 +158,18 @@ x_ket = XKet('x')
 x_bra = XBra('x')
 x_op = XOp('X')
 
-def test_innerprod_represent():
-    assert rep_innerproduct(x_ket) == InnerProduct(XBra("x_1"), x_ket).doit()
-    assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet("x_1")).doit()
-
-    try:
-        rep_innerproduct(x_op)
-    except TypeError:
-        return True
-
-def test_operator_represent():
-    basis_kets = enumerate_states(operators_to_state(x_op), 1, 2)
-    assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
+#def test_innerprod_represent():
+#   assert rep_innerproduct(x_ket) == InnerProduct(XBra("x_1"), x_ket).doit()
+#   assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet("x_1")).doit()
+#
+#   try:
+#       test = rep_innerproduct(x_op)
+#   except TypeError:
+#       return True
+#
+#def test_operator_represent():
+#   basis_kets = enumerate_states(operators_to_state(x_op), 1, 2)
+#   assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
 
 def test_enumerate_states():
     test = XKet("foo")

--- a/sympy/physics/quantum/tests/test_represent.py
+++ b/sympy/physics/quantum/tests/test_represent.py
@@ -159,18 +159,18 @@ x_ket = XKet('x')
 x_bra = XBra('x')
 x_op = XOp('X')
 
-#def test_innerprod_represent():
-#   assert rep_innerproduct(x_ket) == InnerProduct(XBra("x_1"), x_ket).doit()
-#   assert rep_innerproduct(x_bra) == InnerProduct(x_bra, XKet("x_1")).doit()
-#
-#   try:
-#       test = rep_innerproduct(x_op)
-#   except TypeError:
-#       return True
-#
-#def test_operator_represent():
-#   basis_kets = enumerate_states(operators_to_state(x_op), 1, 2)
-#   assert rep_expectation(x_op) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
+def test_innerprod_represent():
+   assert innerproduct_helper(x_ket, basis=XKet()) == InnerProduct(XBra("x_1"), x_ket).doit()
+   assert innerproduct_helper(x_bra, basis=XKet()) == InnerProduct(x_bra, XKet("x_1")).doit()
+
+   try:
+       test = innerproduct_helper(x_op)
+   except TypeError:
+       return True
+
+def test_operator_represent():
+   basis_kets = enumerate_states(operators_to_state(x_op), 1, 2)
+   assert expectation_helper(x_op, basis=XKet()) == qapply(basis_kets[1].dual*x_op*basis_kets[0])
 
 def test_enumerate_states():
     test = XKet("foo")

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -12,7 +12,7 @@ from sympy.physics.quantum.spin import (
     JxKet, JyKet, JzKet,
     JxKetCoupled, JyKetCoupled, JzKetCoupled,
     couple, uncouple,
-    Rotation, WignerD
+    Rotation, WignerD, Jx_basis, Jy_basis, Jz_basis
 )
 
 from sympy.utilities.pytest import raises
@@ -229,6 +229,41 @@ def test_represent():
         Matrix([0,0,1,0])
     assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,0,0,1])
+
+    # Jz basis (set)
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jz_basis) == sqrt(2)*Matrix([1,1])/2
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jz_basis) == sqrt(2)*Matrix([-1,1])/2
+    assert represent(JxKet(1,1), basis=Jz_basis) == Matrix([1,sqrt(2),1])/2
+    assert represent(JxKet(1,0), basis=Jz_basis) == sqrt(2)*Matrix([-1,0,1])/2
+    assert represent(JxKet(1,-1), basis=Jz_basis) == Matrix([1,-sqrt(2),1])/2
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jz_basis) == sqrt(2)*Matrix([-1,-I])/2
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jz_basis) == sqrt(2)*Matrix([-I,-1])/2
+    assert represent(JyKet(1,1), basis=Jz_basis) == Matrix([1,sqrt(2)*I,-1])/2
+    assert represent(JyKet(1,0), basis=Jz_basis) == sqrt(2)*Matrix([I,0,I])/2
+    assert represent(JyKet(1,-1), basis=Jz_basis) == Matrix([-1,sqrt(2)*I,1])/2
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jz_basis) == Matrix([1,0])
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jz_basis) == Matrix([0,1])
+    assert represent(JzKet(1,1), basis=Jz_basis) == Matrix([1,0,0])
+    assert represent(JzKet(1,0), basis=Jz_basis) == Matrix([0,1,0])
+    assert represent(JzKet(1,-1), basis=Jz_basis) == Matrix([0,0,1])
+
+    # Jz basis (ket)
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=JzKet) == sqrt(2)*Matrix([1,1])/2
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=JzKet) == sqrt(2)*Matrix([-1,1])/2
+    assert represent(JxKet(1,1), basis=JzKet) == Matrix([1,sqrt(2),1])/2
+    assert represent(JxKet(1,0), basis=JzKet) == sqrt(2)*Matrix([-1,0,1])/2
+    assert represent(JxKet(1,-1), basis=JzKet) == Matrix([1,-sqrt(2),1])/2
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=JzKet) == sqrt(2)*Matrix([-1,-I])/2
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=JzKet) == sqrt(2)*Matrix([-I,-1])/2
+    assert represent(JyKet(1,1), basis=JzKet) == Matrix([1,sqrt(2)*I,-1])/2
+    assert represent(JyKet(1,0), basis=JzKet) == sqrt(2)*Matrix([I,0,I])/2
+    assert represent(JyKet(1,-1), basis=JzKet) == Matrix([-1,sqrt(2)*I,1])/2
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=JzKet) == Matrix([1,0])
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=JzKet) == Matrix([0,1])
+    assert represent(JzKet(1,1), basis=JzKet) == Matrix([1,0,0])
+    assert represent(JzKet(1,0), basis=JzKet) == Matrix([0,1,0])
+    assert represent(JzKet(1,-1), basis=JzKet) == Matrix([0,0,1])
+
 
 def test_rewrite():
     # Rewrite to same basis

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -30,207 +30,38 @@ def test_represent():
     assert represent(Jz, j=1) == hbar*Matrix([[1,0,0],[0,0,0],[0,0,-1]])
     # Spin states
     # Jx basis
-    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jx) == Matrix([1,0])
-    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jx) == Matrix([0,1])
-    assert represent(JxKet(1,1), basis=Jx) == Matrix([1,0,0])
-    assert represent(JxKet(1,0), basis=Jx) == Matrix([0,1,0])
-    assert represent(JxKet(1,-1), basis=Jx) == Matrix([0,0,1])
-    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jx) == Matrix([exp(-I*pi/4),0])
-    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jx) == Matrix([0,exp(I*pi/4)])
-    assert represent(JyKet(1,1), basis=Jx) == Matrix([-I,0,0])
-    assert represent(JyKet(1,0), basis=Jx) == Matrix([0,1,0])
-    assert represent(JyKet(1,-1), basis=Jx) == Matrix([0,0,I])
-    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jx) == sqrt(2)*Matrix([-1,1])/2
-    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jx) == sqrt(2)*Matrix([-1,-1])/2
-    assert represent(JzKet(1,1), basis=Jx) == Matrix([1,-sqrt(2),1])/2
-    assert represent(JzKet(1,0), basis=Jx) == sqrt(2)*Matrix([1,0,-1])/2
-    assert represent(JzKet(1,-1), basis=Jx) == Matrix([1,sqrt(2),1])/2
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jx_basis) == Matrix([1,0])
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jx_basis) == Matrix([0,1])
+    assert represent(JxKet(1,1), basis=Jx_basis) == Matrix([1,0,0])
+    assert represent(JxKet(1,0), basis=Jx_basis) == Matrix([0,1,0])
+    assert represent(JxKet(1,-1), basis=Jx_basis) == Matrix([0,0,1])
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jx_basis) == Matrix([exp(-I*pi/4),0])
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jx_basis) == Matrix([0,exp(I*pi/4)])
+    assert represent(JyKet(1,1), basis=Jx_basis) == Matrix([-I,0,0])
+    assert represent(JyKet(1,0), basis=Jx_basis) == Matrix([0,1,0])
+    assert represent(JyKet(1,-1), basis=Jx_basis) == Matrix([0,0,I])
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jx_basis) == sqrt(2)*Matrix([-1,1])/2
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jx_basis) == sqrt(2)*Matrix([-1,-1])/2
+    assert represent(JzKet(1,1), basis=Jx_basis) == Matrix([1,-sqrt(2),1])/2
+    assert represent(JzKet(1,0), basis=Jx_basis) == sqrt(2)*Matrix([1,0,-1])/2
+    assert represent(JzKet(1,-1), basis=Jx_basis) == Matrix([1,sqrt(2),1])/2
     # Jy basis
-    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jy) == Matrix([exp(-3*I*pi/4),0])
-    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jy) == Matrix([0,exp(3*I*pi/4)])
-    assert represent(JxKet(1,1), basis=Jy) == Matrix([I,0,0])
-    assert represent(JxKet(1,0), basis=Jy) == Matrix([0,1,0])
-    assert represent(JxKet(1,-1), basis=Jy) == Matrix([0,0,-I])
-    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jy) == Matrix([1,0])
-    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jy) == Matrix([0,1])
-    assert represent(JyKet(1,1), basis=Jy) == Matrix([1,0,0])
-    assert represent(JyKet(1,0), basis=Jy) == Matrix([0,1,0])
-    assert represent(JyKet(1,-1), basis=Jy) == Matrix([0,0,1])
-    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jy) == sqrt(2)*Matrix([-1,I])/2
-    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jy) == sqrt(2)*Matrix([I,-1])/2
-    assert represent(JzKet(1,1), basis=Jy) == Matrix([1,-I*sqrt(2),-1])/2
-    assert represent(JzKet(1,0), basis=Jy) == Matrix([-sqrt(2)*I,0,-sqrt(2)*I])/2
-    assert represent(JzKet(1,-1), basis=Jy) == Matrix([-1,-sqrt(2)*I,1])/2
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jy_basis) == Matrix([exp(-3*I*pi/4),0])
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jy_basis) == Matrix([0,exp(3*I*pi/4)])
+    assert represent(JxKet(1,1), basis=Jy_basis) == Matrix([I,0,0])
+    assert represent(JxKet(1,0), basis=Jy_basis) == Matrix([0,1,0])
+    assert represent(JxKet(1,-1), basis=Jy_basis) == Matrix([0,0,-I])
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jy_basis) == Matrix([1,0])
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jy_basis) == Matrix([0,1])
+    assert represent(JyKet(1,1), basis=Jy_basis) == Matrix([1,0,0])
+    assert represent(JyKet(1,0), basis=Jy_basis) == Matrix([0,1,0])
+    assert represent(JyKet(1,-1), basis=Jy_basis) == Matrix([0,0,1])
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jy_basis) == sqrt(2)*Matrix([-1,I])/2
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jy_basis) == sqrt(2)*Matrix([I,-1])/2
+    assert represent(JzKet(1,1), basis=Jy_basis) == Matrix([1,-I*sqrt(2),-1])/2
+    assert represent(JzKet(1,0), basis=Jy_basis) == Matrix([-sqrt(2)*I,0,-sqrt(2)*I])/2
+    assert represent(JzKet(1,-1), basis=Jy_basis) == Matrix([-1,-sqrt(2)*I,1])/2
     # Jz basis
-    assert represent(JxKet(S(1)/2,S(1)/2), basis=Jz) == sqrt(2)*Matrix([1,1])/2
-    assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jz) == sqrt(2)*Matrix([-1,1])/2
-    assert represent(JxKet(1,1), basis=Jz) == Matrix([1,sqrt(2),1])/2
-    assert represent(JxKet(1,0), basis=Jz) == sqrt(2)*Matrix([-1,0,1])/2
-    assert represent(JxKet(1,-1), basis=Jz) == Matrix([1,-sqrt(2),1])/2
-    assert represent(JyKet(S(1)/2,S(1)/2), basis=Jz) == sqrt(2)*Matrix([-1,-I])/2
-    assert represent(JyKet(S(1)/2,-S(1)/2), basis=Jz) == sqrt(2)*Matrix([-I,-1])/2
-    assert represent(JyKet(1,1), basis=Jz) == Matrix([1,sqrt(2)*I,-1])/2
-    assert represent(JyKet(1,0), basis=Jz) == sqrt(2)*Matrix([I,0,I])/2
-    assert represent(JyKet(1,-1), basis=Jz) == Matrix([-1,sqrt(2)*I,1])/2
-    assert represent(JzKet(S(1)/2,S(1)/2), basis=Jz) == Matrix([1,0])
-    assert represent(JzKet(S(1)/2,-S(1)/2), basis=Jz) == Matrix([0,1])
-    assert represent(JzKet(1,1), basis=Jz) == Matrix([1,0,0])
-    assert represent(JzKet(1,0), basis=Jz) == Matrix([0,1,0])
-    assert represent(JzKet(1,-1), basis=Jz) == Matrix([0,0,1])
-    # Uncoupled states
-    # Jx basis
-    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([1,0,0,0])
-    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jx) == \
-        Matrix([0,1,0,0])
-    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,0,1,0])
-    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jx) == \
-        Matrix([0,0,0,1])
-    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([-I,0,0,0])
-    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jx) == \
-        Matrix([0,1,0,0])
-    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,0,1,0])
-    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jx) == \
-        Matrix([0,0,0,I])
-    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([S(1)/2,-S(1)/2,-S(1)/2,S(1)/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jx) == \
-        Matrix([S(1)/2,S(1)/2,-S(1)/2,-S(1)/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([S(1)/2,-S(1)/2,S(1)/2,-S(1)/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jx) == \
-        Matrix([S(1)/2,S(1)/2,S(1)/2,S(1)/2])
-    # Jy basis
-    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([I,0,0,0])
-    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jy) == \
-        Matrix([0,1,0,0])
-    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,0,1,0])
-    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jy) == \
-        Matrix([0,0,0,-I])
-    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([1,0,0,0])
-    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jy) == \
-        Matrix([0,1,0,0])
-    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,0,1,0])
-    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jy) == \
-        Matrix([0,0,0,1])
-    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([S(1)/2,-I/2,-I/2,-S(1)/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jy) == \
-        Matrix([-I/2,S(1)/2,-S(1)/2,-I/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([-I/2,-S(1)/2,S(1)/2,-I/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jy) == \
-        Matrix([-S(1)/2,-I/2,-I/2,S(1)/2])
-    # Jz basis
-    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([S(1)/2,S(1)/2,S(1)/2,S(1)/2])
-    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jz) == \
-        Matrix([-S(1)/2,S(1)/2,-S(1)/2,S(1)/2])
-    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([-S(1)/2,-S(1)/2,S(1)/2,S(1)/2])
-    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jz) == \
-        Matrix([S(1)/2,-S(1)/2,-S(1)/2,S(1)/2])
-    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([S(1)/2,I/2,I/2,-S(1)/2])
-    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jz) == \
-        Matrix([I/2,S(1)/2,-S(1)/2,I/2])
-    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([I/2,-S(1)/2,S(1)/2,I/2])
-    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jz) == \
-        Matrix([-S(1)/2,I/2,I/2,S(1)/2])
-    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([1,0,0,0])
-    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jz) == \
-        Matrix([0,1,0,0])
-    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,0,1,0])
-    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jz) == \
-        Matrix([0,0,0,1])
-    # Coupled spin states
-    # Jx basis
-    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([1,0,0,0])
-    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,1,0,0])
-    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,0,1,0])
-    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,0,0,1])
-    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([1,0,0,0])
-    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,-I,0,0])
-    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,0,1,0])
-    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,0,0,I])
-    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([1,0,0,0])
-    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,S(1)/2,-sqrt(2)/2,S(1)/2])
-    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,sqrt(2)/2,0,-sqrt(2)/2])
-    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx) == \
-        Matrix([0,S(1)/2,sqrt(2)/2,S(1)/2])
-    # Jy basis
-    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([1,0,0,0])
-    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,I,0,0])
-    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,0,1,0])
-    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,0,0,-I])
-    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([1,0,0,0])
-    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,1,0,0])
-    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,0,1,0])
-    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,0,0,1])
-    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([1,0,0,0])
-    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,S(1)/2,-I*sqrt(2)/2,-S(1)/2])
-    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,-I*sqrt(2)/2,0,-I*sqrt(2)/2])
-    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy) == \
-        Matrix([0,-S(1)/2,-I*sqrt(2)/2,S(1)/2])
-    # Jz basis
-    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([1,0,0,0])
-    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,S(1)/2,sqrt(2)/2,S(1)/2])
-    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,-sqrt(2)/2,0,sqrt(2)/2])
-    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,S(1)/2,-sqrt(2)/2,S(1)/2])
-    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([1,0,0,0])
-    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,S(1)/2,I*sqrt(2)/2,-S(1)/2])
-    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,I*sqrt(2)/2,0,I*sqrt(2)/2])
-    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,-S(1)/2,I*sqrt(2)/2,S(1)/2])
-    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([1,0,0,0])
-    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,1,0,0])
-    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,0,1,0])
-    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
-        Matrix([0,0,0,1])
-
-    # Jz basis (set)
     assert represent(JxKet(S(1)/2,S(1)/2), basis=Jz_basis) == sqrt(2)*Matrix([1,1])/2
     assert represent(JxKet(S(1)/2,-S(1)/2), basis=Jz_basis) == sqrt(2)*Matrix([-1,1])/2
     assert represent(JxKet(1,1), basis=Jz_basis) == Matrix([1,sqrt(2),1])/2
@@ -246,6 +77,192 @@ def test_represent():
     assert represent(JzKet(1,1), basis=Jz_basis) == Matrix([1,0,0])
     assert represent(JzKet(1,0), basis=Jz_basis) == Matrix([0,1,0])
     assert represent(JzKet(1,-1), basis=Jz_basis) == Matrix([0,0,1])
+    # Uncoupled states
+    # Jx basis
+    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,0,1])
+    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([-I,0,0,0])
+    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,0,I])
+    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([S(1)/2,-S(1)/2,-S(1)/2,S(1)/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jx_basis) == \
+        Matrix([S(1)/2,S(1)/2,-S(1)/2,-S(1)/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([S(1)/2,-S(1)/2,S(1)/2,-S(1)/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jx_basis) == \
+        Matrix([S(1)/2,S(1)/2,S(1)/2,S(1)/2])
+    # Jy basis
+    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([I,0,0,0])
+    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,0,-I])
+    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,0,1])
+    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([S(1)/2,-I/2,-I/2,-S(1)/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jy_basis) == \
+        Matrix([-I/2,S(1)/2,-S(1)/2,-I/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([-I/2,-S(1)/2,S(1)/2,-I/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jy_basis) == \
+        Matrix([-S(1)/2,-I/2,-I/2,S(1)/2])
+    # Jz basis
+    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([S(1)/2,S(1)/2,S(1)/2,S(1)/2])
+    assert represent(TensorProduct(JxKet(S(1)/2,S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jz_basis) == \
+        Matrix([-S(1)/2,S(1)/2,-S(1)/2,S(1)/2])
+    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([-S(1)/2,-S(1)/2,S(1)/2,S(1)/2])
+    assert represent(TensorProduct(JxKet(S(1)/2,-S(1)/2),JxKet(S(1)/2,-S(1)/2)), basis=Jz_basis) == \
+        Matrix([S(1)/2,-S(1)/2,-S(1)/2,S(1)/2])
+    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([S(1)/2,I/2,I/2,-S(1)/2])
+    assert represent(TensorProduct(JyKet(S(1)/2,S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jz_basis) == \
+        Matrix([I/2,S(1)/2,-S(1)/2,I/2])
+    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([I/2,-S(1)/2,S(1)/2,I/2])
+    assert represent(TensorProduct(JyKet(S(1)/2,-S(1)/2),JyKet(S(1)/2,-S(1)/2)), basis=Jz_basis) == \
+        Matrix([-S(1)/2,I/2,I/2,S(1)/2])
+    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,0,0,1])
+    # Coupled spin states
+    # Jx basis
+    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,0,1])
+    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,-I,0,0])
+    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,0,0,I])
+    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,S(1)/2,-sqrt(2)/2,S(1)/2])
+    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,sqrt(2)/2,0,-sqrt(2)/2])
+    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx_basis) == \
+        Matrix([0,S(1)/2,sqrt(2)/2,S(1)/2])
+    # Jy basis
+    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,I,0,0])
+    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,0,-I])
+    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,0,0,1])
+    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,S(1)/2,-I*sqrt(2)/2,-S(1)/2])
+    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,-I*sqrt(2)/2,0,-I*sqrt(2)/2])
+    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy_basis) == \
+        Matrix([0,-S(1)/2,-I*sqrt(2)/2,S(1)/2])
+    # Jz basis
+    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,S(1)/2,sqrt(2)/2,S(1)/2])
+    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,-sqrt(2)/2,0,sqrt(2)/2])
+    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,S(1)/2,-sqrt(2)/2,S(1)/2])
+    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,S(1)/2,I*sqrt(2)/2,-S(1)/2])
+    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,I*sqrt(2)/2,0,I*sqrt(2)/2])
+    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,-S(1)/2,I*sqrt(2)/2,S(1)/2])
+    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([1,0,0,0])
+    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,1,0,0])
+    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,0,1,0])
+    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz_basis) == \
+        Matrix([0,0,0,1])
+
+    # Jx basis (ket)
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=JxKet) == Matrix([1,0])
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=JxKet) == Matrix([0,1])
+    assert represent(JxKet(1,1), basis=JxKet) == Matrix([1,0,0])
+    assert represent(JxKet(1,0), basis=JxKet) == Matrix([0,1,0])
+    assert represent(JxKet(1,-1), basis=JxKet) == Matrix([0,0,1])
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=JxKet) == Matrix([exp(-I*pi/4),0])
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=JxKet) == Matrix([0,exp(I*pi/4)])
+    assert represent(JyKet(1,1), basis=JxKet) == Matrix([-I,0,0])
+    assert represent(JyKet(1,0), basis=JxKet) == Matrix([0,1,0])
+    assert represent(JyKet(1,-1), basis=JxKet) == Matrix([0,0,I])
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=JxKet) == sqrt(2)*Matrix([-1,1])/2
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=JxKet) == sqrt(2)*Matrix([-1,-1])/2
+    assert represent(JzKet(1,1), basis=JxKet) == Matrix([1,-sqrt(2),1])/2
+    assert represent(JzKet(1,0), basis=JxKet) == sqrt(2)*Matrix([1,0,-1])/2
+    assert represent(JzKet(1,-1), basis=JxKet) == Matrix([1,sqrt(2),1])/2
+
+    # Jy basis (ket)
+    assert represent(JxKet(S(1)/2,S(1)/2), basis=JyKet) == Matrix([exp(-3*I*pi/4),0])
+    assert represent(JxKet(S(1)/2,-S(1)/2), basis=JyKet) == Matrix([0,exp(3*I*pi/4)])
+    assert represent(JxKet(1,1), basis=JyKet) == Matrix([I,0,0])
+    assert represent(JxKet(1,0), basis=JyKet) == Matrix([0,1,0])
+    assert represent(JxKet(1,-1), basis=JyKet) == Matrix([0,0,-I])
+    assert represent(JyKet(S(1)/2,S(1)/2), basis=JyKet) == Matrix([1,0])
+    assert represent(JyKet(S(1)/2,-S(1)/2), basis=JyKet) == Matrix([0,1])
+    assert represent(JyKet(1,1), basis=JyKet) == Matrix([1,0,0])
+    assert represent(JyKet(1,0), basis=JyKet) == Matrix([0,1,0])
+    assert represent(JyKet(1,-1), basis=JyKet) == Matrix([0,0,1])
+    assert represent(JzKet(S(1)/2,S(1)/2), basis=JyKet) == sqrt(2)*Matrix([-1,I])/2
+    assert represent(JzKet(S(1)/2,-S(1)/2), basis=JyKet) == sqrt(2)*Matrix([I,-1])/2
+    assert represent(JzKet(1,1), basis=JyKet) == Matrix([1,-I*sqrt(2),-1])/2
+    assert represent(JzKet(1,0), basis=JyKet) == Matrix([-sqrt(2)*I,0,-sqrt(2)*I])/2
+    assert represent(JzKet(1,-1), basis=JyKet) == Matrix([-1,-sqrt(2)*I,1])/2
 
     # Jz basis (ket)
     assert represent(JxKet(S(1)/2,S(1)/2), basis=JzKet) == sqrt(2)*Matrix([1,1])/2
@@ -3292,7 +3309,7 @@ def test_j2():
 def test_jx():
     assert Commutator(Jx, Jz).doit() == -I*hbar*Jy
     assert Jx.rewrite('plusminus') == (Jminus + Jplus)/2
-    assert represent(Jx, basis=Jz, j=1) == (represent(Jplus, basis=Jz, j=1)+represent(Jminus, basis=Jz, j=1))/2
+    assert represent(Jx, basis=Jz_basis, j=1) == (represent(Jplus, basis=Jz_basis, j=1)+represent(Jminus, basis=Jz_basis, j=1))/2
     # Normal operators, normal states
     # Numerical
     assert qapply(Jx*JxKet(1,1)) == hbar*JxKet(1,1)
@@ -3376,7 +3393,7 @@ def test_jx():
 def test_jy():
     assert Commutator(Jy, Jz).doit() == I*hbar*Jx
     assert Jy.rewrite('plusminus') == (Jplus - Jminus)/(2*I)
-    assert represent(Jy, basis=Jz) == (represent(Jplus, basis=Jz) - represent(Jminus, basis=Jz))/(2*I)
+    assert represent(Jy, basis=Jz_basis) == (represent(Jplus, basis=Jz_basis) - represent(Jminus, basis=Jz_basis))/(2*I)
     # Normal operators, normal states
     # Numerical
     assert qapply(Jy*JxKet(1,1)) == hbar*JxKet(1,1)

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -1,13 +1,10 @@
-from sympy import (Add, conjugate, diff, I, Integer, latex, Mul, oo, pi, Pow,
-                   pretty, Rational, sin, sqrt, Symbol, symbols, sympify)
+from sympy import (Add, conjugate, diff, expand, I, Integer, latex, Mul, oo, pi,
+                   Pow, pretty, Rational, sin, sqrt, Symbol, symbols, sympify)
 from sympy.utilities.pytest import raises
-
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr
-from sympy.physics.quantum.state import (
-    Ket, Bra, TimeDepKet, TimeDepBra,
-    KetBase, BraBase, StateBase, Wavefunction
-)
+from sympy.physics.quantum.state import (Bra, BraBase, Ket, KetBase,
+                                         TimeDepKet, TimeDepBra, Wavefunction)
 from sympy.physics.quantum.hilbert import HilbertSpace
 
 x, y, t = symbols('x,y,t')
@@ -224,3 +221,8 @@ def test_wavefunction():
 
     k = Wavefunction(x**2, 'x')
     assert type(k.variables[0]) == Symbol
+
+    j = Wavefunction((x+y)**2, x, y)
+    e = expand(j, wavefunction=True)
+    assert e == Wavefunction(x**2, x, y) + Wavefunction(2*x*y, x, y) \
+           + Wavefunction(y**2, x, y)

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -3,7 +3,7 @@ from sympy import (Add, conjugate, diff, expand, I, Integer, latex, Mul, oo, pi,
 from sympy.utilities.pytest import raises
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr
-from sympy.physics.quantum.state import (Bra, BraBase, Ket, KetBase,
+from sympy.physics.quantum.state import (Bra, BraBase, Ket, KetBase, StateBase,
                                          TimeDepKet, TimeDepBra, Wavefunction)
 from sympy.physics.quantum.hilbert import HilbertSpace
 


### PR DESCRIPTION
NOTE: Updating this based on recent emails on the Sympy list. What is left to do on this is:

TODO - 
- [ ] Finish rebase and fix broken tests
- [ ] Review API 

As I'm sure you've noticed my time constraints have meant that I just have not been able to get this done. Every time I try to start back up with a rebase I get caught up and it ends up slipping again.
# 

This pull request is my last official GSoC pull, though I will continue spending next week adding some additional features I'd like to see, as well as working out the kinks in this PR.

Many things are accomplished here, namely:
- Cleanup of outstanding issues from my previous PR
- Change the rest of the quantum computing classes to follow the new conventions for representations introduced by this work. 
- Introduce a complete set of steps for continuous representations, including integration and correct application of operators

If you look at the examples in piab.py, I think it will give you a real sense of what the project has accomplished. While I haven't been able to implement as many example systems as I wanted (yet), you can do some very cool manipulation of expressions in continuous bases, including computation of expectation values. 
