### PR TITLE
Fix test failure in master related to ambiguous match result

### DIFF
--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -120,11 +120,15 @@ def test_complex():
 
     assert (1+I).match(x+I) == {x : 1}
     assert (a+I).match(x+I) == {x : a}
-    assert (a+b*I).match(x+y*I) == {x : a, y : b}
     assert (2*I).match(x*I) == {x : 2}
     assert (a*I).match(x*I) == {x : a}
     assert (a*I).match(x*y) == {x : I, y : a}
     assert (2*I).match(x*y) == {x : 2, y : I}
+
+    #Result is ambiguous, so we need to use Wild's exclude keyword
+    x = Wild('x', exclude=[I])
+    y = Wild('y', exclude=[I])
+    assert (a+b*I).match(x+y*I) == {x : a, y : b}
 
 def test_functions():
     from sympy.core.function import WildFunction


### PR DESCRIPTION
This is to fix the current test failure in master that happens on certain systems (including my Mac OS X 10.6.7, Python 2.7). 

In one of the match tests, there are multiple possible matches and different systems produce different matches. So, we use the exclude keywords for Wild on that test to make the results consistent.

The tests now pass on my system.
