### PR TITLE
apply cacheit to expand method

### DIFF
--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -6,7 +6,6 @@
 CACHE = []  # [] of
             #    (item, {} or tuple of {})
 
-from sympy.core.logic import fuzzy_bool
 from sympy.core.decorators import wraps
 
 def print_cache():
@@ -75,19 +74,9 @@ def __cacheit(func):
     def wrapper(*args, **kw_args):
         """
         Assemble the args and kw_args to compute the hash.
-        It is important that kw_args be standardized since if they
-        have the same meaning but in different forms (e.g. one
-        kw_arg having a value of 1 for an object and another object
-        with identical args but a kw_arg of True) then two different
-        hashes will be computed and the two objects will not be identical.
         """
         if kw_args:
             keys = kw_args.keys()
-
-            # make keywords all the same
-            for k in keys:
-                kw_args[k] = fuzzy_bool(kw_args[k])
-
             keys.sort()
             items = [(k+'=', kw_args[k]) for k in keys]
             k = args + tuple(items)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1905,6 +1905,7 @@ class Expr(Basic, EvalfMixin):
     def _eval_expand_func(self, deep=True, **hints):
         return self
 
+    @cacheit
     def expand(self, deep=True, modulus=None, power_base=True, power_exp=True, \
             mul=True, log=True, multinomial=True, basic=True, **hints):
         """

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -222,7 +222,7 @@ def test_implemented_function_evalf():
     del f._imp_     # XXX: due to caching _imp_ would influence all other tests
 
 def test_evaluate_false():
-    for no in [[], 0, False, None]:
+    for no in [0, False, None]:
         assert Add(3, 2, evaluate=no).is_Add
         assert Mul(3, 2, evaluate=no).is_Mul
         assert Pow(3, 2, evaluate=no).is_Pow

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -53,6 +53,7 @@ def test_expand_radicals():
 def test_expand_modulus():
     assert ((x + y)**11).expand(modulus=11) == x**11 + y**11
     assert ((x + sqrt(2)*y)**11).expand(modulus=11) == x**11 + 10*sqrt(2)*y**11
+    assert (x + y/2).expand(modulus=1) == y/2
 
     raises(ValueError, "((x + y)**11).expand(modulus=0)")
     raises(ValueError, "((x + y)**11).expand(modulus=x)")


### PR DESCRIPTION
```
Since all args are being turned into bool this doesn't work unless
only args of 0 or 1 are made into bool, so this change was made, too.
```
