### PR TITLE
count will count literal matches

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -956,6 +956,8 @@ class Basic(object):
 
     def find(self, query, group=False):
         """Find all subexpressions matching a query. """
+        if not callable(query):
+            query = sympify(query)
         if isinstance(query, type):
             _query = lambda expr: isinstance(expr, query)
         elif isinstance(query, Basic):
@@ -966,7 +968,8 @@ class Basic(object):
         results = []
 
         def rec_find(expr):
-            if _query(expr):
+            q = _query(expr)
+            if q or q == {}:
                 results.append(expr)
 
             for arg in expr.args:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -553,6 +553,7 @@ def test_count():
 
     assert expr.count(Integer) == 2
     assert expr.count(Symbol) == 3
+    assert expr.count(2) == 1
 
     a = Wild('a')
 


### PR DESCRIPTION
When find has an exact match, match returns {}. This was being treated as False and was not being counted.
