### PR TITLE
as_independent gives a strict separation based on free symbols

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -468,6 +468,10 @@ def test_as_independent():
     assert (DiracDelta(x - n1)*DiracDelta(y - n1)*DiracDelta(x - n2)).as_independent(y) == \
            (DiracDelta(x - n1), DiracDelta(y - n1)*DiracDelta(x - n2))
 
+    # issue 2685
+    assert (x + Integral(x, (x, 1, 2))).as_independent(x, strict=True) == \
+           (Integral(x, (x, 1, 2)), x)
+
 def test_subs_dict():
     a,b,c,d,e = symbols('a,b,c,d,e')
 


### PR DESCRIPTION
```
as_independent uses has to determine whether an expression has the
symbol of interest or not. A potential problem is that an expression
may have a bound symbol x that is not part of the free symbols of the
expression. Now only subexpressions that don't have the symbol in the 
free symbols will be returned as independent.
```
