### PR TITLE
divisor count given a modulus option

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1210,8 +1210,9 @@ def divisors(n, generator=False):
             return sorted(rv)
         return rv
 
-def divisor_count(n):
-    """Return the number of divisors of n.
+def divisor_count(n, modulus=1):
+    """Return the number of divisors of ``n``. If ``modulus`` is not 1 then only
+       those that are divisible by ``modulus`` are counted.
 
     Reference:
     http://www.mayer.dial.pipex.com/maths/formulae.htm
@@ -1221,7 +1222,12 @@ def divisor_count(n):
     4
     """
 
-    n = abs(n)
+    if not modulus:
+        return 0
+    elif modulus != 1:
+        n, r = divmod(n, modulus)
+        if r:
+            return 0
     if n == 0:
         return 0
     return Mul(*[v+1 for k, v in factorint(n).items() if k > 1])

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -323,6 +323,9 @@ def divisors_and_divisor_count():
     assert divisor_count(6) == 4
     assert divisor_count(12) == 6
 
+    assert divisor_count(180, 3) == divisor_count(180//3)
+    assert divisor_count(2*3*5, 7) == 0
+
 def test_totient():
     assert [totient(k) for k in range(1, 12)] == \
         [1, 1, 2, 2, 4, 2, 6, 4, 6, 4, 10]


### PR DESCRIPTION
```
The number of divisors of n that are divisible by m is just
the divisor count of n/m if m divides n, else 0. This is given
by using the new `modulus` option for divisor_count.
```
