### PR TITLE
Model function added to simplify

### DIFF
--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -6,7 +6,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 """
 from simplify import collect, rcollect, separate, radsimp, ratsimp, fraction, \
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars, numer, denom, powdenest, posify, collect_constants
+    logcombine, separatevars, numer, denom, powdenest, posify, collect_constants, condense
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -6,7 +6,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 """
 from simplify import collect, rcollect, separate, radsimp, ratsimp, fraction, \
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars, numer, denom, powdenest, posify, collect_constants, condense
+    logcombine, separatevars, numer, denom, powdenest, posify, condense
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -6,7 +6,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 """
 from simplify import collect, rcollect, separate, radsimp, ratsimp, fraction, \
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars, numer, denom, powdenest, posify, model
+    logcombine, separatevars, numer, denom, powdenest, posify, collect_constants
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -6,7 +6,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 """
 from simplify import collect, rcollect, separate, radsimp, ratsimp, fraction, \
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars, numer, denom, powdenest, posify
+    logcombine, separatevars, numer, denom, powdenest, posify, model
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2385,9 +2385,9 @@ def condense(eq, x, constant_name='C'):
     if is_csym(x):
         raise ValueError('Chosen constant name clashes with the variable %s' % x)
 
-    # expand any powers
-    eq = eq.expand(power_base=True, power_exp=True, force=True,
-                   log=False, mul=False, multinomial=False, basic=False)
+    # expand any powers and logs
+    eq = eq.expand(power_base=True, power_exp=True, log=True, force=True,
+                   mul=False, multinomial=False, basic=False)
 
     # identify constants
     eq, d = _condense(eq, x)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2238,7 +2238,7 @@ def _logcombine(expr, force=False):
     return expr
 
 def model(expr, variable, constant_name='C', numbers=False):
-    """Return ``expr`` with all symbols that are the ``variable``
+    """Return ``expr`` with all symbols different than ``variable``
     absorbed into constant(s) with name ``constant_name`` having consecutive
     numbers e.g. C0, C1, C2, .... The absorbing is done by combining added or
     multiplied constants, and by expanding powers that have an added constant
@@ -2377,7 +2377,7 @@ def model(expr, variable, constant_name='C', numbers=False):
     u_all = [u] # the list of all constants created
 
     # handle independent of x
-    if not (eq.has(x) and x in eq.free_symbols):
+    if eq.as_independent(x, as_Add=True)[1] == 0:
         return renumu(u)[0]
 
     # handle all Adds; they each need their own u since there

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2412,19 +2412,28 @@ def condense(eq, x, constant_name='C'):
             if count_ops(v) < count_ops(vv):
                 eq = eq.subs(dups[vv][0], -dups[v][0])
                 dups[v].extend(dups.pop(vv)[1:])
-                continue
+            else:
+                eq = eq.subs(dups[v][0], 1/dups[vv][0])
+                dups[vv].extend(dups.pop(v)[1:])
+            continue
         vv = 1/v
         if vv in dups:
             if count_ops(v) < count_ops(vv):
                 eq = eq.subs(dups[vv][0], 1/dups[v][0])
                 dups[v].extend(dups.pop(vv)[1:])
-                continue
+            else:
+                eq = eq.subs(dups[v][0], 1/dups[vv][0])
+                dups[vv].extend(dups.pop(v)[1:])
+            continue
         vv = -1/v
         if vv in dups:
             if count_ops(v) < count_ops(vv):
                 eq = eq.subs(dups[vv][0], -1/dups[v][0])
                 dups[v].extend(dups.pop(vv)[1:])
-                continue
+            else:
+                eq = eq.subs(dups[v][0], 1/dups[vv][0])
+                dups[vv].extend(dups.pop(v)[1:])
+            continue
     d = {}
     for k, v in dups.iteritems():
         if len(v) > 1:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2236,7 +2236,7 @@ def _logcombine(expr, force=False):
 
     return expr
 
-def model(expr, variable, constant_name='C', numbers=False, vars=False, reps=False):
+def collect_constants(expr, variable, constant_name='C', numbers=False, vars=False, reps=False):
     """Return ``expr`` with all symbols different than ``variable``
     absorbed into constant(s) with name ``constant_name`` having consecutive
     numbers e.g. C0, C1, C2, .... The absorbing is done by combining added or
@@ -2251,25 +2251,25 @@ def model(expr, variable, constant_name='C', numbers=False, vars=False, reps=Fal
 
     Examples::
 
-    >>> from sympy import model, exp
+    >>> from sympy import collect_constants, exp
     >>> from sympy.abc import x, y, z
-    >>> model(y + 3, x)
+    >>> collect_constants(y + 3, x)
     C0
-    >>> model(y + 3, x, 'k')
+    >>> collect_constants(y + 3, x, 'k')
     k0
-    >>> model(x + 3, x)
+    >>> collect_constants(x + 3, x)
     x + 3
-    >>> model(x + 3, x, numbers=True)
+    >>> collect_constants(x + 3, x, numbers=True)
     C0 + x
-    >>> model(-x + 3, x, numbers=True)
+    >>> collect_constants(-x + 3, x, numbers=True)
     C0 - x
-    >>> model(x + 3*y, x)
+    >>> collect_constants(x + 3*y, x)
     C0 + x
-    >>> model(x + 3*y, x, 'x')
+    >>> collect_constants(x + 3*y, x, 'x')
     x + x0
-    >>> model(exp(x + 3), x)
+    >>> collect_constants(exp(x + 3), x)
     exp(x + 3)
-    >>> model(y*exp(x + 3), x)
+    >>> collect_constants(y*exp(x + 3), x)
     C0*exp(x)
     """
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2268,7 +2268,6 @@ def model(expr, variable, constant_name='C', numbers=False):
     >>> model(y*exp(x + 3), x)
     C0*exp(x)
     """
-    from string import digits
 
     eq = expr
     x = variable

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2675,8 +2675,14 @@ def condense(eq, x, constant_name='C', reps=False):
             args = list(eq.args)
             if eq.is_Add or eq.is_Mul:
                 unify = zip(u_all, [S.One]*len(u_all))
-                args = [i[1] for i in sorted([(e.subs(unify), e)
-                                      for e in eq.args], key=default_sort_key)]
+                sargs = sorted([(e.subs(unify), e)
+                                      for e in eq.args], key=default_sort_key)
+                # put integer negative powers last
+                if eq.is_Mul:
+                    from sympy.utilities.iterables import sift
+                    d = sift(sargs, lambda w: w[0].is_Pow and w[0].exp.is_Integer and w[0].exp < 0)
+                    sargs = d.get(False, []) + d.get(True, [])
+                args = [i[1] for i in sargs]
             for i, a in enumerate(args):
                 a, k, map = renumu(a, k, map)
                 args[i] = a

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2315,7 +2315,7 @@ def _condense(expr, var, _symbols={}):
     return rv, _symbols
 
 def condense(eq, x, constant_name='C'):
-    """Return ``expr`` with all symbols different than ``variable``
+    """Return ``expr`` with all symbols different than ``x``
     absorbed into constant(s) with name ``constant_name`` having consecutive
     numbers e.g. C0, C1, C2, .... The absorbing is done by combining added or
     multiplied constants, and by expanding powers that have an added constant
@@ -2391,6 +2391,13 @@ def condense(eq, x, constant_name='C'):
 
     # identify constants
     eq, d = _condense(eq, x)
+
+    # update rhs
+    free = eq.free_symbols
+    for k, v in d.items():
+        if v in d and v not in free:
+            d.pop(k)
+            eq  = eq.subs(k, v)
 
     # restore Rational powers
     reps = {}

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -886,3 +886,4 @@ def test_condense():
     m = -1/p
     assert check_condense(x*p + sin(x)*m, x, reps=True) == (C0*x + sin(x)/C0, {C0: a + b})
     assert check_condense(x*m + sin(x)*p, x, reps=True) == (C0*sin(x) + x/C0, {C0: a + b})
+    assert check_condense(x*a + x*b - y, x, reps=True) == (C0 + C1*x, {C0: -y, C1: a + b})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,7 +4,7 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add, Float, collect_constants, condense)
+    factor, Mul, O, hyper, Add, Float, condense)
 from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -811,7 +811,9 @@ def test_as_content_primitive():
 
 collect_constants1=condense
 def collect_constants(expr, variable, constant_name='C', numbers=False, reps=False):
-    rv = collect_constants1(expr, variable, constant_name, reps)
+    rv = collect_constants1(expr, variable, constant_name)
+    if not reps:
+        rv = rv[0]
     return rv
 
 def test_collect_constants():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -870,3 +870,6 @@ def test_model():
     assert model(e - 1/exp(3 + y + x), x, reps=True) == \
         (C0*exp(x) + C1*exp(-x), {C0: exp(y + 2), C1: -exp(-y - 3)})
     assert model(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
+    assert model(x + a/(y + b + x), x, vars=True) == (C0/(C1 + x) + x, (C0, C1))
+    # reps overrides vars
+    assert model(x + a/(y + b + x), x, vars=True, reps=True) == (C0/(C1 + x) + x, {C0: a, C1: b + y})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -835,7 +835,7 @@ def test_collect_constants():
     assert collect_constants(-2*x + y, x) == C0 + C1*x
     assert collect_constants(exp(x + 3) + exp(x + 4), x) == C0*exp(x)
     assert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
-    assert collect_constants((x + C1)/(x + C2), x) == (C1 + x)/(C0 + x)
+    assert collect_constants((x + C1)/(x + C2), x) == (C0 + x)/(C1 + x)
     assert collect_constants(exp(x + C1)/exp(x + C2), x) == C0
     assert collect_constants((x + 2 + C1)/(x + C2), x) != 1
     assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x) # XXX is it ok to pull out the constant?
@@ -847,7 +847,7 @@ def test_collect_constants():
     assert collect_constants(C1*exp(3 + x), x) == C0*exp(x)
     assert collect_constants(3*exp(C1 + x), x) == C0*exp(x)
     assert collect_constants(a*exp(4 + x)*exp(2*x + 3), x, reps=True) == (C0*exp(C1*x), {C0: a*exp(7), C1: 3})
-    assert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x) # XXX the **-1 term gets numbered first :-(
+    assert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C0 + C1*x)/(C2 + C3*x)
     assert collect_constants(C4/(C2 + C3*x), x) == 1/(C0 + C1*x)
     assert collect_constants(C4/(C2 + C3*x)**2, x, reps=True) == \
           ((C0 + C1*x)**(-2), {C0: C2/sqrt(C4), C1: C3/sqrt(C4)})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -874,11 +874,15 @@ def test_condense():
     assert check_condense(x + a/(y + b + x), x, reps=True) ==(x + 1/(C0 + C1*x), {C0: b/a + y/a, C1: 1/a})
     assert check_condense(x*(a + b) + sin(x)*(-a - b), x, reps=True) == (C0*x - C0*sin(x), {C0: a + b})
     assert check_condense(x*(a+b)+sin(x)/(a+b),x, reps=True) == (C0*x + sin(x)/C0, {C0: a + b})
+    assert check_condense(log(3*x), x) == C0 + log(x)
 
     p = a + b
     m = -p
+    assert check_condense(x*p + sin(x)*m, x, reps=True) == (C0*x - C0*sin(x), {C0: a + b})
     assert check_condense(sin(x)*p + exp(x)*m, x, reps=True) == (C0*sin(x) + exp(x)/C0, {C0: a + b})
     m = 1/p
+    assert check_condense(x*p + sin(x)*m, x, reps=True) == (C0*x + sin(x)/C0, {C0: a + b})
     assert check_condense(x*m + sin(x)*p, x, reps=True) == (C0*sin(x) + x/C0, {C0: a + b})
     m = -1/p
+    assert check_condense(x*p + sin(x)*m, x, reps=True) == (C0*x + sin(x)/C0, {C0: a + b})
     assert check_condense(x*m + sin(x)*p, x, reps=True) == (C0*sin(x) + x/C0, {C0: a + b})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -809,6 +809,12 @@ def test_as_content_primitive():
     assert Add(5*z/7, 0.5*x, 3*y/2, evaluate=False).as_content_primitive() == \
             (S(1)/14, 7.0*x + 21*y + 10*z)
 
+model1=model
+def model(expr, variable, constant_name='C', numbers=False, reps=False):
+    rv = model1(expr, variable, constant_name, numbers, reps)
+    if not reps:
+        print expr,';',model1(expr, variable, constant_name, numbers, reps=True)
+    return rv
 def test_model():
     x,y,z,C,k = symbols('x y z C k')
     C0, C1, C2, C3, C4 = symbols('C:5')
@@ -821,6 +827,7 @@ def test_model():
     assert model(k + z, k, 'k') == k + k0
     raises(ValueError, 'model(k2 + z, k2, "k")')
     assert model(Integral(x, (x, 1, 2)), x) == C0
+    print model(x**2*y*exp(x+z) + x*y + x*z, x, 'C')
     assert model(x**2*y*exp(x+z) + x*y + x*z, x, 'C') == C0*x + C1*x**2*exp(x)
     assert model(x**2*y*exp(x+z) + x*y + x*z, x, 'k') == k0*x + k1*x**2*exp(x)
     assert model(3 + y*x + x*z, x) == 3 + C0*x
@@ -854,3 +861,12 @@ def test_model():
     assert model(a*(y*x + z), x) == C0 + C1*x
     assert model(a*cos(x), x) == C0*cos(x)
     assert model(2*a*x, x) == C0*x
+
+    assert model(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
+        (1/(C0 + C1*exp(x) + x), {C0: y, C1: exp(y + 2)})
+    e = exp(2 + y + x)
+    assert model(e - 1/e, x, reps=True) == \
+        (C0*exp(x) - exp(-x)/C0, {C0: exp(y + 2)})
+    assert model(e - 1/exp(3 + y + x), x, reps=True) == \
+        (C0*exp(x) + C1*exp(-x), {C0: exp(y + 2), C1: -exp(-y - 3)})
+    assert model(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,9 +4,9 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add, Float, model)
+    factor, Mul, O, hyper, Add, Float, collect_constants)
 from sympy.core.mul import _keep_coeff
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 from sympy.abc import x, y, z, t, a, b, c, d, e
 
@@ -809,67 +809,67 @@ def test_as_content_primitive():
     assert Add(5*z/7, 0.5*x, 3*y/2, evaluate=False).as_content_primitive() == \
             (S(1)/14, 7.0*x + 21*y + 10*z)
 
-model1=model
-def model(expr, variable, constant_name='C', numbers=False, reps=False):
-    rv = model1(expr, variable, constant_name, numbers, reps)
+collect_constants1=collect_constants
+def collect_constants(expr, variable, constant_name='C', numbers=False, reps=False):
+    rv = collect_constants1(expr, variable, constant_name, numbers, reps)
     if not reps:
-        print expr,';',model1(expr, variable, constant_name, numbers, reps=True)
+        print expr,';',collect_constants1(expr, variable, constant_name, numbers, reps=True)
     return rv
-def test_model():
+def test_collect_constants():
     x,y,z,C,k = symbols('x y z C k')
     C0, C1, C2, C3, C4 = symbols('C:5')
     k0, k1, k2 = symbols('k:3')
 
-    assert model(y + C, x) == C0
-    assert model(y + C + C4, x) == C0
-    assert model(y + z, x, 'C') == C0
-    assert model(y + z, x) == C0
-    assert model(k + z, k, 'k') == k + k0
-    raises(ValueError, 'model(k2 + z, k2, "k")')
-    assert model(Integral(x, (x, 1, 2)), x) == C0
-    print model(x**2*y*exp(x+z) + x*y + x*z, x, 'C')
-    assert model(x**2*y*exp(x+z) + x*y + x*z, x, 'C') == C0*x + C1*x**2*exp(x)
-    assert model(x**2*y*exp(x+z) + x*y + x*z, x, 'k') == k0*x + k1*x**2*exp(x)
-    assert model(3 + y*x + x*z, x) == 3 + C0*x
-    assert model(3 + y*x + x*z, x, numbers=True) == C0 + C1*x
-    assert model(3 + y*x + x*z + x**2*z, x) == 3 + C0*x + C1*x**2
-    assert model(3 + y*x + x*z + x**2*z, x, numbers=True) == C0 + C1*x + C2*x**2
-    assert model(x - y, x) == C0 + x
-    assert model(-x + y, x) == C0 - x
-    assert model(-2*x + y, x) == C0 - 2*x
-    assert model(-2*x + y, x, numbers=True) == C0 + C1*x
-    assert model(exp(x + 3) + exp(x + 4), x) == exp(x + 3) + exp(x + 4)
-    assert model(exp(x + 3) + exp(x + 4), x, numbers=True) == C0*exp(x)
-    assert model(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
-    assert model((x + C1)/(x + C2), x) == (C1 + x)/(C0 + x)
-    assert model(exp(x + C1)/exp(x + C2), x) == C0
-    assert model((x + 2 + C1)/(x + C2), x) != 1
-    assert model(2*sqrt(a*x), x) == C0*sqrt(x)
-    assert model((2 + x + 3*x**2 + a*x**2), x) == C0*x**2 + x + 2
-    assert model((2 + x + 3*x**2 + a*x**2), x, numbers=True) == C0 + C1*x**2 + x
-    assert model((2 + x + 3*x**2), x) == 3*x**2 + x + 2
-    assert model((2 + x + 3*x**2), x, numbers=True) == C0 + C1*x**2 + x
-    assert model(a*x + b*x, x) == C0*x
-    assert model(2*sqrt(a*x), x) == C0*sqrt(x)
-    assert model(2*(a*x)**(1 + x), x) == C0*x**(x + 1)
-    assert model(2*(a*x)**(1 + x), x, numbers=True) == C0*x**x
-    assert model(2*(a*x)**(a + x), x) == C0*x**x
-    assert model(C1*exp(3 + x), x) == C0*exp(x)
-    assert model(3*exp(C1 + x), x) == C0*exp(x)
-    assert model(a*exp(4 + x)*exp(2*x + 3), x) == C0*exp(3*x)
-    assert model(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x)
-    assert model(a*(y*x + z), x) == C0 + C1*x
-    assert model(a*cos(x), x) == C0*cos(x)
-    assert model(2*a*x, x) == C0*x
+    assert collect_constants(y + C, x) == C0
+    assert collect_constants(y + C + C4, x) == C0
+    assert collect_constants(y + z, x, 'C') == C0
+    assert collect_constants(y + z, x) == C0
+    assert collect_constants(k + z, k, 'k') == k + k0
+    raises(ValueError, 'collect_constants(k2 + z, k2, "k")')
+    assert collect_constants(Integral(x, (x, 1, 2)), x) == C0
+    print collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'C')
+    assert collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'C') == C0*x + C1*x**2*exp(x)
+    assert collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'k') == k0*x + k1*x**2*exp(x)
+    assert collect_constants(3 + y*x + x*z, x) == 3 + C0*x
+    assert collect_constants(3 + y*x + x*z, x, numbers=True) == C0 + C1*x
+    assert collect_constants(3 + y*x + x*z + x**2*z, x) == 3 + C0*x + C1*x**2
+    assert collect_constants(3 + y*x + x*z + x**2*z, x, numbers=True) == C0 + C1*x + C2*x**2
+    assert collect_constants(x - y, x) == C0 + x
+    assert collect_constants(-x + y, x) == C0 - x
+    assert collect_constants(-2*x + y, x) == C0 - 2*x
+    assert collect_constants(-2*x + y, x, numbers=True) == C0 + C1*x
+    assert collect_constants(exp(x + 3) + exp(x + 4), x) == exp(x + 3) + exp(x + 4)
+    assert collect_constants(exp(x + 3) + exp(x + 4), x, numbers=True) == C0*exp(x)
+    assert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
+    assert collect_constants((x + C1)/(x + C2), x) == (C1 + x)/(C0 + x)
+    assert collect_constants(exp(x + C1)/exp(x + C2), x) == C0
+    assert collect_constants((x + 2 + C1)/(x + C2), x) != 1
+    assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
+    assert collect_constants((2 + x + 3*x**2 + a*x**2), x) == C0*x**2 + x + 2
+    assert collect_constants((2 + x + 3*x**2 + a*x**2), x, numbers=True) == C0 + C1*x**2 + x
+    assert collect_constants((2 + x + 3*x**2), x) == 3*x**2 + x + 2
+    assert collect_constants((2 + x + 3*x**2), x, numbers=True) == C0 + C1*x**2 + x
+    assert collect_constants(a*x + b*x, x) == C0*x
+    assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
+    assert collect_constants(2*(a*x)**(1 + x), x) == C0*x**(x + 1)
+    assert collect_constants(2*(a*x)**(1 + x), x, numbers=True) == C0*x**x
+    assert collect_constants(2*(a*x)**(a + x), x) == C0*x**x
+    assert collect_constants(C1*exp(3 + x), x) == C0*exp(x)
+    assert collect_constants(3*exp(C1 + x), x) == C0*exp(x)
+    assert collect_constants(a*exp(4 + x)*exp(2*x + 3), x) == C0*exp(3*x)
+    assert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x)
+    assert collect_constants(a*(y*x + z), x) == C0 + C1*x
+    assert collect_constants(a*cos(x), x) == C0*cos(x)
+    assert collect_constants(2*a*x, x) == C0*x
 
-    assert model(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
+    assert collect_constants(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
         (1/(C0 + C1*exp(x) + x), {C0: y, C1: exp(y + 2)})
     e = exp(2 + y + x)
-    assert model(e - 1/e, x, reps=True) == \
+    assert collect_constants(e - 1/e, x, reps=True) == \
         (C0*exp(x) - exp(-x)/C0, {C0: exp(y + 2)})
-    assert model(e - 1/exp(3 + y + x), x, reps=True) == \
+    assert collect_constants(e - 1/exp(3 + y + x), x, reps=True) == \
         (C0*exp(x) + C1*exp(-x), {C0: exp(y + 2), C1: -exp(-y - 3)})
-    assert model(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
-    assert model(x + a/(y + b + x), x, vars=True) == (C0/(C1 + x) + x, (C0, C1))
+    assert collect_constants(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
+    assert collect_constants(x + a/(y + b + x), x, vars=True) == (C0/(C1 + x) + x, (C0, C1))
     # reps overrides vars
-    assert model(x + a/(y + b + x), x, vars=True, reps=True) == (C0/(C1 + x) + x, {C0: a, C1: b + y})
+    assert collect_constants(x + a/(y + b + x), x, vars=True, reps=True) == (C0/(C1 + x) + x, {C0: a, C1: b + y})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,7 +4,7 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add, Float, collect_constants)
+    factor, Mul, O, hyper, Add, Float, collect_constants, condense)
 from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -809,12 +809,11 @@ def test_as_content_primitive():
     assert Add(5*z/7, 0.5*x, 3*y/2, evaluate=False).as_content_primitive() == \
             (S(1)/14, 7.0*x + 21*y + 10*z)
 
-collect_constants1=collect_constants
+collect_constants1=condense
 def collect_constants(expr, variable, constant_name='C', numbers=False, reps=False):
-    rv = collect_constants1(expr, variable, constant_name, numbers, reps)
-    if not reps:
-        print expr,';',collect_constants1(expr, variable, constant_name, numbers, reps=True)
+    rv = collect_constants1(expr, variable, constant_name, reps)
     return rv
+
 def test_collect_constants():
     x,y,z,C,k = symbols('x y z C k')
     C0, C1, C2, C3, C4 = symbols('C:5')
@@ -827,49 +826,39 @@ def test_collect_constants():
     assert collect_constants(k + z, k, 'k') == k + k0
     raises(ValueError, 'collect_constants(k2 + z, k2, "k")')
     assert collect_constants(Integral(x, (x, 1, 2)), x) == C0
-    print collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'C')
     assert collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'C') == C0*x + C1*x**2*exp(x)
     assert collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'k') == k0*x + k1*x**2*exp(x)
-    assert collect_constants(3 + y*x + x*z, x) == 3 + C0*x
-    assert collect_constants(3 + y*x + x*z, x, numbers=True) == C0 + C1*x
-    assert collect_constants(3 + y*x + x*z + x**2*z, x) == 3 + C0*x + C1*x**2
-    assert collect_constants(3 + y*x + x*z + x**2*z, x, numbers=True) == C0 + C1*x + C2*x**2
+    assert collect_constants(3 + y*x + x*z, x) == C0 + C1*x
+    assert collect_constants(3 + y*x + x*z + x**2*z, x) == C0 + C1*x + C2*x**2
     assert collect_constants(x - y, x) == C0 + x
     assert collect_constants(-x + y, x) == C0 - x
-    assert collect_constants(-2*x + y, x) == C0 - 2*x
-    assert collect_constants(-2*x + y, x, numbers=True) == C0 + C1*x
-    assert collect_constants(exp(x + 3) + exp(x + 4), x) == exp(x + 3) + exp(x + 4)
-    assert collect_constants(exp(x + 3) + exp(x + 4), x, numbers=True) == C0*exp(x)
-    assert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
+    assert collect_constants(-2*x + y, x) == C0 + C1*x
+    #XXXassert collect_constants(exp(x + 3) + exp(x + 4), x) == C0*exp(x)
+    #XXXassert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
     assert collect_constants((x + C1)/(x + C2), x) == (C1 + x)/(C0 + x)
     assert collect_constants(exp(x + C1)/exp(x + C2), x) == C0
     assert collect_constants((x + 2 + C1)/(x + C2), x) != 1
-    assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
-    assert collect_constants((2 + x + 3*x**2 + a*x**2), x) == C0*x**2 + x + 2
-    assert collect_constants((2 + x + 3*x**2 + a*x**2), x, numbers=True) == C0 + C1*x**2 + x
-    assert collect_constants((2 + x + 3*x**2), x) == 3*x**2 + x + 2
-    assert collect_constants((2 + x + 3*x**2), x, numbers=True) == C0 + C1*x**2 + x
+    #XXXassert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
+    assert collect_constants((2 + x + 3*x**2 + a*x**2), x) == C0 + C1*x**2 + x
+    assert collect_constants((2 + x + 3*x**2), x) == C0 + C1*x**2 + x
     assert collect_constants(a*x + b*x, x) == C0*x
-    assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
-    assert collect_constants(2*(a*x)**(1 + x), x) == C0*x**(x + 1)
-    assert collect_constants(2*(a*x)**(1 + x), x, numbers=True) == C0*x**x
-    assert collect_constants(2*(a*x)**(a + x), x) == C0*x**x
+    #XXXassert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
+    #XXXassert collect_constants(2*(a*x)**(1 + x), x) == C0*x**x
+    #XXXassert collect_constants(2*(a*x)**(a + x), x) == C0*x**x
     assert collect_constants(C1*exp(3 + x), x) == C0*exp(x)
     assert collect_constants(3*exp(C1 + x), x) == C0*exp(x)
-    assert collect_constants(a*exp(4 + x)*exp(2*x + 3), x) == C0*exp(3*x)
-    assert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x)
-    assert collect_constants(a*(y*x + z), x) == C0 + C1*x
+    #XXXassert collect_constants(a*exp(4 + x)*exp(2*x + 3), x) == C0*exp(3*x) # C0*exp(x)*exp(c1*x)
+    #XXXassert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x)
+    #XXXassert collect_constants(a*(y*x + z), x) == C0 + C1*x
     assert collect_constants(a*cos(x), x) == C0*cos(x)
     assert collect_constants(2*a*x, x) == C0*x
 
     assert collect_constants(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
         (1/(C0 + C1*exp(x) + x), {C0: y, C1: exp(y + 2)})
     e = exp(2 + y + x)
-    assert collect_constants(e - 1/e, x, reps=True) == \
-        (C0*exp(x) - exp(-x)/C0, {C0: exp(y + 2)})
-    assert collect_constants(e - 1/exp(3 + y + x), x, reps=True) == \
-        (C0*exp(x) + C1*exp(-x), {C0: exp(y + 2), C1: -exp(-y - 3)})
+    #assert collect_constants(e - 1/e, x, reps=True) == \
+    #    (C0*exp(x) - exp(-x)/C0, {C0: exp(y + 2)}) # (C0*exp(x) + C1*exp(C2*x), {C2: -1, C0: exp(y + 2), C1: -exp(-y - 2)})
+    #assert collect_constants(e - 1/exp(3 + y + x), x, reps=True) == \
+    #    (C0*exp(x) + C1*exp(-x), {C0: exp(y + 2), C1: -exp(-y - 3)})
     assert collect_constants(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
-    assert collect_constants(x + a/(y + b + x), x, vars=True) == (C0/(C1 + x) + x, (C0, C1))
-    # reps overrides vars
-    assert collect_constants(x + a/(y + b + x), x, vars=True, reps=True) == (C0/(C1 + x) + x, {C0: a, C1: b + y})
+    assert collect_constants(x + a/(y + b + x), x, reps=True) == (C0/(C1 + x) + x, {C0: a, C1: b + y})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -874,3 +874,11 @@ def test_condense():
     assert check_condense(x + a/(y + b + x), x, reps=True) ==(x + 1/(C0 + C1*x), {C0: b/a + y/a, C1: 1/a})
     assert check_condense(x*(a + b) + sin(x)*(-a - b), x, reps=True) == (C0*x - C0*sin(x), {C0: a + b})
     assert check_condense(x*(a+b)+sin(x)/(a+b),x, reps=True) == (C0*x + sin(x)/C0, {C0: a + b})
+
+    p = a + b
+    m = -p
+    assert check_condense(sin(x)*p + exp(x)*m, x, reps=True) == (C0*sin(x) + exp(x)/C0, {C0: a + b})
+    m = 1/p
+    assert check_condense(x*m + sin(x)*p, x, reps=True) == (C0*sin(x) + x/C0, {C0: a + b})
+    m = -1/p
+    assert check_condense(x*m + sin(x)*p, x, reps=True) == (C0*sin(x) + x/C0, {C0: a + b})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -833,32 +833,40 @@ def test_collect_constants():
     assert collect_constants(x - y, x) == C0 + x
     assert collect_constants(-x + y, x) == C0 - x
     assert collect_constants(-2*x + y, x) == C0 + C1*x
-    #XXXassert collect_constants(exp(x + 3) + exp(x + 4), x) == C0*exp(x)
-    #XXXassert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
+    assert collect_constants(exp(x + 3) + exp(x + 4), x) == C0*exp(x)
+    assert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
     assert collect_constants((x + C1)/(x + C2), x) == (C1 + x)/(C0 + x)
     assert collect_constants(exp(x + C1)/exp(x + C2), x) == C0
     assert collect_constants((x + 2 + C1)/(x + C2), x) != 1
-    #XXXassert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
+    assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x) # XXX is it ok to pull out the constant?
     assert collect_constants((2 + x + 3*x**2 + a*x**2), x) == C0 + C1*x**2 + x
     assert collect_constants((2 + x + 3*x**2), x) == C0 + C1*x**2 + x
     assert collect_constants(a*x + b*x, x) == C0*x
-    #XXXassert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x)
-    #XXXassert collect_constants(2*(a*x)**(1 + x), x) == C0*x**x
-    #XXXassert collect_constants(2*(a*x)**(a + x), x) == C0*x**x
+    assert collect_constants(2*(a*x)**(1 + x), x, reps=True) == (C0*C1**x*x**(x + 1), {C0: 2*a, C1: a})
+    assert collect_constants(2*(a*x)**(a + x), x, reps=True) == (C0*C1**x*x**(C1 + x), {C0: 2*a**a, C1: a})
     assert collect_constants(C1*exp(3 + x), x) == C0*exp(x)
     assert collect_constants(3*exp(C1 + x), x) == C0*exp(x)
-    #XXXassert collect_constants(a*exp(4 + x)*exp(2*x + 3), x) == C0*exp(3*x) # C0*exp(x)*exp(c1*x)
-    #XXXassert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x)
-    #XXXassert collect_constants(a*(y*x + z), x) == C0 + C1*x
+    assert collect_constants(a*exp(4 + x)*exp(2*x + 3), x, reps=True) == (C0*exp(C1*x), {C0: a*exp(7), C1: 3})
+    assert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x) # XXX the **-1 term gets numbered first :-(
+    assert collect_constants(C4/(C2 + C3*x), x) == 1/(C0 + C1*x)
+    assert collect_constants(C4/(C2 + C3*x)**2, x, reps=True) == \
+          ((C0 + C1*x)**(-2), {C0: C2/sqrt(C4), C1: C3/sqrt(C4)})
+    assert collect_constants(C4/(C2 + C3*x)**a, x, reps=True) == \
+          ((C0 + C1*x)**C2, {C2: -a, C0: C2*C4**(-1/a), C1: C3*C4**(-1/a)})
+    assert collect_constants(a*(y*x + z), x) == C0 + C1*x
     assert collect_constants(a*cos(x), x) == C0*cos(x)
     assert collect_constants(2*a*x, x) == C0*x
 
     assert collect_constants(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
-        (1/(C0 + C1*exp(x) + x), {C0: y, C1: exp(y + 2)})
+        (1/(C0 + C1*exp(x) + x), {C0: y, C1: exp(2)*exp(y)})
     e = exp(2 + y + x)
-    #assert collect_constants(e - 1/e, x, reps=True) == \
-    #    (C0*exp(x) - exp(-x)/C0, {C0: exp(y + 2)}) # (C0*exp(x) + C1*exp(C2*x), {C2: -1, C0: exp(y + 2), C1: -exp(-y - 2)})
-    #assert collect_constants(e - 1/exp(3 + y + x), x, reps=True) == \
-    #    (C0*exp(x) + C1*exp(-x), {C0: exp(y + 2), C1: -exp(-y - 3)})
+    # keep the shorter representation if given the choice
+    # (so exp(2+y) is better than 1/exp(2+y)
+    assert collect_constants(e - 1/e, x, reps=True) == \
+        (C0*exp(x) - exp(-x)/C0, {C0: exp(2)*exp(y)})
+    # but keep constants in the numerator if there is no alternate,
+    # so C0*exp(-x) instead of exp(-x)/C0 (with C0 = exp(3+y))
+    assert collect_constants(e - 1/exp(3 + y + x), x, reps=True) == \
+        (C0*exp(-x) + C1*exp(x), {C0: -exp(-3)*exp(-y), C1: exp(2)*exp(y)})
     assert collect_constants(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
-    assert collect_constants(x + a/(y + b + x), x, reps=True) == (C0/(C1 + x) + x, {C0: a, C1: b + y})
+    assert collect_constants(x + a/(y + b + x), x, reps=True) ==(x + 1/(C0 + C1*x), {C0: b/a + y/a, C1: 1/a})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -809,66 +809,68 @@ def test_as_content_primitive():
     assert Add(5*z/7, 0.5*x, 3*y/2, evaluate=False).as_content_primitive() == \
             (S(1)/14, 7.0*x + 21*y + 10*z)
 
-collect_constants1=condense
-def collect_constants(expr, variable, constant_name='C', numbers=False, reps=False):
-    rv = collect_constants1(expr, variable, constant_name)
+condense_orig = condense
+def check_condense(expr, variable, constant_name='C', numbers=False, reps=False):
+    rv = condense_orig(expr, variable, constant_name)
     if not reps:
         rv = rv[0]
     return rv
 
-def test_collect_constants():
+def test_condense():
     x,y,z,C,k = symbols('x y z C k')
     C0, C1, C2, C3, C4 = symbols('C:5')
     k0, k1, k2 = symbols('k:3')
 
-    assert collect_constants(y + C, x) == C0
-    assert collect_constants(y + C + C4, x) == C0
-    assert collect_constants(y + z, x, 'C') == C0
-    assert collect_constants(y + z, x) == C0
-    assert collect_constants(k + z, k, 'k') == k + k0
-    raises(ValueError, 'collect_constants(k2 + z, k2, "k")')
-    assert collect_constants(Integral(x, (x, 1, 2)), x) == C0
-    assert collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'C') == C0*x + C1*x**2*exp(x)
-    assert collect_constants(x**2*y*exp(x+z) + x*y + x*z, x, 'k') == k0*x + k1*x**2*exp(x)
-    assert collect_constants(3 + y*x + x*z, x) == C0 + C1*x
-    assert collect_constants(3 + y*x + x*z + x**2*z, x) == C0 + C1*x + C2*x**2
-    assert collect_constants(x - y, x) == C0 + x
-    assert collect_constants(-x + y, x) == C0 - x
-    assert collect_constants(-2*x + y, x) == C0 + C1*x
-    assert collect_constants(exp(x + 3) + exp(x + 4), x) == C0*exp(x)
-    assert collect_constants(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
-    assert collect_constants((x + C1)/(x + C2), x) == (C0 + x)/(C1 + x)
-    assert collect_constants(exp(x + C1)/exp(x + C2), x) == C0
-    assert collect_constants((x + 2 + C1)/(x + C2), x) != 1
-    assert collect_constants(2*sqrt(a*x), x) == C0*sqrt(x) # XXX is it ok to pull out the constant?
-    assert collect_constants((2 + x + 3*x**2 + a*x**2), x) == C0 + C1*x**2 + x
-    assert collect_constants((2 + x + 3*x**2), x) == C0 + C1*x**2 + x
-    assert collect_constants(a*x + b*x, x) == C0*x
-    assert collect_constants(2*(a*x)**(1 + x), x, reps=True) == (C0*C1**x*x**(x + 1), {C0: 2*a, C1: a})
-    assert collect_constants(2*(a*x)**(a + x), x, reps=True) == (C0*C1**x*x**(C1 + x), {C0: 2*a**a, C1: a})
-    assert collect_constants(C1*exp(3 + x), x) == C0*exp(x)
-    assert collect_constants(3*exp(C1 + x), x) == C0*exp(x)
-    assert collect_constants(a*exp(4 + x)*exp(2*x + 3), x, reps=True) == (C0*exp(C1*x), {C0: a*exp(7), C1: 3})
-    assert collect_constants(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C0 + C1*x)/(C2 + C3*x)
-    assert collect_constants(C4/(C2 + C3*x), x) == 1/(C0 + C1*x)
-    assert collect_constants(C4/(C2 + C3*x)**2, x, reps=True) == \
+    assert check_condense(y + C, x) == C0
+    assert check_condense(y + C + C4, x) == C0
+    assert check_condense(y + z, x, 'C') == C0
+    assert check_condense(y + z, x) == C0
+    assert check_condense(k + z, k, 'k') == k + k0
+    raises(ValueError, 'check_condense(k2 + z, k2, "k")')
+    assert check_condense(Integral(x, (x, 1, 2)), x) == C0
+    assert check_condense(x**2*y*exp(x+z) + x*y + x*z, x, 'C') == C0*x + C1*x**2*exp(x)
+    assert check_condense(x**2*y*exp(x+z) + x*y + x*z, x, 'k') == k0*x + k1*x**2*exp(x)
+    assert check_condense(3 + y*x + x*z, x) == C0 + C1*x
+    assert check_condense(3 + y*x + x*z + x**2*z, x) == C0 + C1*x + C2*x**2
+    assert check_condense(x - y, x) == C0 + x
+    assert check_condense(-x + y, x) == C0 - x
+    assert check_condense(-2*x + y, x) == C0 + C1*x
+    assert check_condense(exp(x + 3) + exp(x + 4), x) == C0*exp(x)
+    assert check_condense(a*exp(x) + b*exp(x + 4), x) == C0*exp(x)
+    assert check_condense((x + C1)/(x + C2), x) == (C0 + x)/(C1 + x)
+    assert check_condense(exp(x + C1)/exp(x + C2), x) == C0
+    assert check_condense((x + 2 + C1)/(x + C2), x) != 1
+    assert check_condense(2*sqrt(a*x), x) == C0*sqrt(x) # XXX is it ok to pull out the constant?
+    assert check_condense((2 + x + 3*x**2 + a*x**2), x) == C0 + C1*x**2 + x
+    assert check_condense((2 + x + 3*x**2), x) == C0 + C1*x**2 + x
+    assert check_condense(a*x + b*x, x) == C0*x
+    assert check_condense(2*(a*x)**(1 + x), x, reps=True) == (C0*C1**x*x**(x + 1), {C0: 2*a, C1: a})
+    assert check_condense(2*(a*x)**(a + x), x, reps=True) == (C0*C1**x*x**(C1 + x), {C0: 2*a**a, C1: a})
+    assert check_condense(C1*exp(3 + x), x) == C0*exp(x)
+    assert check_condense(3*exp(C1 + x), x) == C0*exp(x)
+    assert check_condense(a*exp(4 + x)*exp(2*x + 3), x, reps=True) == (C0*exp(C1*x), {C0: a*exp(7), C1: 3})
+    assert check_condense(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C0 + C1*x)/(C2 + C3*x)
+    assert check_condense(C4/(C2 + C3*x), x) == 1/(C0 + C1*x)
+    assert check_condense(C4/(C2 + C3*x)**2, x, reps=True) == \
           ((C0 + C1*x)**(-2), {C0: C2/sqrt(C4), C1: C3/sqrt(C4)})
-    assert collect_constants(C4/(C2 + C3*x)**a, x, reps=True) == \
+    assert check_condense(C4/(C2 + C3*x)**a, x, reps=True) == \
           ((C0 + C1*x)**C2, {C2: -a, C0: C2*C4**(-1/a), C1: C3*C4**(-1/a)})
-    assert collect_constants(a*(y*x + z), x) == C0 + C1*x
-    assert collect_constants(a*cos(x), x) == C0*cos(x)
-    assert collect_constants(2*a*x, x) == C0*x
+    assert check_condense(a*(y*x + z), x) == C0 + C1*x
+    assert check_condense(a*cos(x), x) == C0*cos(x)
+    assert check_condense(2*a*x, x) == C0*x
 
-    assert collect_constants(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
+    assert check_condense(1/(x + y + exp(x + 2 + y)), x, reps=True) == \
         (1/(C0 + C1*exp(x) + x), {C0: y, C1: exp(2)*exp(y)})
     e = exp(2 + y + x)
     # keep the shorter representation if given the choice
     # (so exp(2+y) is better than 1/exp(2+y)
-    assert collect_constants(e - 1/e, x, reps=True) == \
+    assert check_condense(e - 1/e, x, reps=True) == \
         (C0*exp(x) - exp(-x)/C0, {C0: exp(2)*exp(y)})
     # but keep constants in the numerator if there is no alternate,
     # so C0*exp(-x) instead of exp(-x)/C0 (with C0 = exp(3+y))
-    assert collect_constants(e - 1/exp(3 + y + x), x, reps=True) == \
+    assert check_condense(e - 1/exp(3 + y + x), x, reps=True) == \
         (C0*exp(-x) + C1*exp(x), {C0: -exp(-3)*exp(-y), C1: exp(2)*exp(y)})
-    assert collect_constants(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
-    assert collect_constants(x + a/(y + b + x), x, reps=True) ==(x + 1/(C0 + C1*x), {C0: b/a + y/a, C1: 1/a})
+    assert check_condense(3*y*x, x, reps=True) == (C0*x, {C0: 3*y})
+    assert check_condense(x + a/(y + b + x), x, reps=True) ==(x + 1/(C0 + C1*x), {C0: b/a + y/a, C1: 1/a})
+    assert check_condense(x*(a + b) + sin(x)*(-a - b), x, reps=True) == (C0*x - C0*sin(x), {C0: a + b})
+    assert check_condense(x*(a+b)+sin(x)/(a+b),x, reps=True) == (C0*x + sin(x)/C0, {C0: a + b})

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -844,12 +844,13 @@ def test_model():
     assert model((2 + x + 3*x**2), x, numbers=True) == C0 + C1*x**2 + x
     assert model(a*x + b*x, x) == C0*x
     assert model(2*sqrt(a*x), x) == C0*sqrt(x)
-    assert model(2*(a*x)**(1+x), x) == C0*x**(x + 1)
-    assert model(2*(a*x)**(1+x), x, numbers=True) == C0*x**x
-    assert model(2*(a*x)**(a+x), x) == C0*x**x
+    assert model(2*(a*x)**(1 + x), x) == C0*x**(x + 1)
+    assert model(2*(a*x)**(1 + x), x, numbers=True) == C0*x**x
+    assert model(2*(a*x)**(a + x), x) == C0*x**x
     assert model(C1*exp(3 + x), x) == C0*exp(x)
     assert model(3*exp(C1 + x), x) == C0*exp(x)
     assert model(a*exp(4 + x)*exp(2*x + 3), x) == C0*exp(3*x)
     assert model(C4*(C0 + C1*x)/(C2 + C3*x), x) == (C2 + C3*x)/(C0 + C1*x)
     assert model(a*(y*x + z), x) == C0 + C1*x
     assert model(a*cos(x), x) == C0*cos(x)
+    assert model(2*a*x, x) == C0*x

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1563,12 +1563,17 @@ def constant_renumber(expr, symbolname, startnumber, endnumber):
     **Example**
         >>> from sympy import symbols, Eq, pprint
         >>> from sympy.solvers.ode import constant_renumber
-        >>> x, C1, C2, C3, C4 = symbols('x,C1,C2,C3,C4')
+        >>> x, C0, C1, C2, C3, C4 = symbols('x,C:5')
 
-        Only constants in the given range are renumbered:
+        Only constants in the given range (inclusive) are renumbered;
+        the renumbering always starts from 1:
 
         >>> constant_renumber(C1 + C3 + C4, 'C', 1, 3)
         C1 + C2 + C4
+        >>> constant_renumber(C0 + C1 + C3 + C4, 'C', 2, 4)
+        C0 + 2*C1 + C2
+        >>> constant_renumber(C0 + 2*C1 + C2, 'C', 0, 1)
+        C1 + 3*C2
         >>> pprint(C2 + C1*x + C3*x**2)
                         2
         C1*x + C2 + C3*x


### PR DESCRIPTION
This function allows one to group all non-x symbols together into lumped variables:

```
>>> from sympy import model, exp
>>> from sympy.abc import x, y, z
>>> model(y + 3, x)
C0
>>> model(y + 3, x, 'k')
k0
>>> model(x + 3, x)
x + 3
>>> model(x + 3, x, numbers=True)
C0 + x
>>> model(-x + 3, x, numbers=True)
C0 - x
>>> model(x + 3*y, x)
C0 + x
>>> model(x + 3*y, x, 'x')
x + x0
>>> model(exp(x + 3), x)
exp(x + 3)
>>> model(y*exp(x + 3), x)
C0*exp(x)
>>> model(3*exp(y + x), x)
C0*exp(x)
```

An attempt was made to be able to simply use constantsimp in ode to do this, but the logic there is to ode-centric and there are many corner cases that led to code that became increasingly unwieldy, so I reverted to writing a standalone routine.
