### PR TITLE
Tuple (and Dict) can be sorted; Dict sorts args

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -143,12 +143,14 @@ class Dict(Basic):
 
     def __new__(cls, *args):
         if len(args)==1 and args[0].__class__ is dict:
-            items = [Tuple(k, v) for k, v in args[0].iteritems()]
+            items = [Tuple(k, v) for k, v in args[0].items()]
         elif iterable(args) and all(len(arg) == 2 for arg in args):
             items = [Tuple(k, v) for k, v in args]
         else:
             raise TypeError('Pass Dict args as Dict((k1, v1), ...) or Dict({k1: v1, ...})')
-        obj = Basic.__new__(cls, *items)
+        elements = frozenset(items)
+        obj = Basic.__new__(cls, elements)
+        obj.elements = elements
         obj._dict = dict(items) # In case Tuple decides it wants to sympify
         return obj
 
@@ -159,9 +161,18 @@ class Dict(Basic):
     def __setitem__(self, key, value):
         raise NotImplementedError("SymPy Dicts are Immutable")
 
+    @property
+    def args(self):
+        return tuple(self.elements)
+
+    def __eq__(self, other):
+        if isinstance(other, Basic):
+            return super(Dict, self).__eq__(other)
+        return self.elements == other
+
     def items(self):
         '''D.items() -> list of D's (key, value) pairs, as 2-tuples'''
-        return list(self.args)
+        return self._dict.items()
 
     def keys(self):
         '''D.keys() -> list of D's keys'''

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -114,7 +114,7 @@ class Dict(Basic):
     """
     Wrapper around the builtin dict object
 
-    The Tuple is a subclass of Basic, so that it works well in the
+    The Dict is a subclass of Basic, so that it works well in the
     SymPy framework.  Because it is immutable, it may be included
     in sets, but its values must all be given at instantiation and
     cannot be changed afterwards.  Otherwise it behaves identically
@@ -164,11 +164,6 @@ class Dict(Basic):
     @property
     def args(self):
         return tuple(self.elements)
-
-    def __eq__(self, other):
-        if isinstance(other, Basic):
-            return super(Dict, self).__eq__(other)
-        return self.elements == other
 
     def items(self):
         '''D.items() -> list of D's (key, value) pairs, as 2-tuples'''

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1028,11 +1028,6 @@ class FiniteSet(CountableSet):
     def args(self):
         return tuple(self.elements)
 
-    def __eq__(self, other):
-        if isinstance(other, Basic):
-            return super(FiniteSet, self).__eq__(other)
-        return self.elements == other
-
     def __iter__(self):
         return self.elements.__iter__()
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -9,7 +9,9 @@ from containers import Tuple
 
 class Set(Basic):
     """
-    Represents any kind of set.
+    The base class for any kind of set. This is not meant to be used directly
+    as a container of items. It does not behave like the builtin set; see
+    FiniteSet for that.
 
     Real intervals are represented by the Interval class and unions of sets
     by the Union class. The empty set is represented by the EmptySet class
@@ -1018,9 +1020,18 @@ class FiniteSet(CountableSet):
             cls = RealFiniteSet
 
         elements = frozenset(map(sympify, args))
-        obj = Basic.__new__(cls, *elements)
+        obj = Basic.__new__(cls, elements)
         obj.elements = elements
         return obj
+
+    @property
+    def args(self):
+        return tuple(self.elements)
+
+    def __eq__(self, other):
+        if isinstance(other, Basic):
+            return super(FiniteSet, self).__eq__(other)
+        return self.elements == other
 
     def __iter__(self):
         return self.elements.__iter__()
@@ -1158,6 +1169,6 @@ class RealFiniteSet(FiniteSet, RealSet):
 genclass = (1 for i in xrange(2)).__class__
 def is_flattenable(obj):
     """
-    Checks that an argument to a Set constructor  should be flattened
+    Checks that an argument to a Set constructor should be flattened
     """
     return obj.__class__ in [list, set, genclass]

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -1,4 +1,4 @@
-from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S
+from sympy import Matrix, Tuple, symbols, sympify, Basic, Dict, S, FiniteSet
 from sympy.core.containers import tuple_wrapper
 from sympy.utilities.pytest import raises
 from sympy.core.compatibility import is_sequence, iterable
@@ -105,3 +105,12 @@ def test_Dict():
     assert str(d) == '{x: 1, y: 2, z: 3}'
     assert d.__repr__() == '{x: 1, y: 2, z: 3}'
 
+def issue_2689():
+    args = [(1,2),(2,1)]
+    for o in [Dict, Tuple, FiniteSet]:
+        # __eq__ and arg handling
+        if o != Tuple:
+            assert o(*args) == o(*reversed(args))
+        pair = [o(*args), o(*reversed(args))]
+        assert sorted(pair) == sorted(reversed(pair))
+        assert set(o(*args)) # doesn't fail

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -48,7 +48,7 @@ def flatten(iterable, levels=None, cls=None):
             raise ValueError("expected non-negative number of levels, got %s" % levels)
 
     if cls is None:
-        reducible = lambda x: hasattr(x, "__iter__") and not isinstance(x, basestring)
+        reducible = lambda x: is_sequence(x, set)
     else:
         reducible = lambda x: isinstance(x, cls)
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -80,6 +80,8 @@ def test_flatten():
     assert flatten([MyOp(x, y), z]) == [MyOp(x, y), z]
     assert flatten([MyOp(x, y), z], cls=MyOp) == [x, y, z]
 
+    assert flatten(set([1,11,2])) == list(set([1,11,2]))
+
 def test_group():
     assert group([]) == []
     assert group([], multiple=False) == []


### PR DESCRIPTION
```
Even though Dict is a mapping, it can't compare well with another
dict if the args aren't sorted, so now they are sorted.
```
