### PR TITLE
Fix sign of derivative of hyperbolic cotangent

### DIFF
--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -402,7 +402,7 @@ class coth(HyperbolicFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return 1/sinh(self.args[0])**2
+            return -1/sinh(self.args[0])**2
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -475,12 +475,12 @@ def test_coth_rewrite():
 
 def test_derivs():
     x = Symbol('x')
-    assert [f(x).diff(x) for f in [coth, sinh, cosh, tanh, acoth, asinh, acosh, atanh]] == \
-    [-sinh(x)**(-2),
-     cosh(x),
-     sinh(x),
-     -tanh(x)**2 + 1,
-     1/(-x**2 + 1),
-     1/sqrt(x**2 + 1),
-     1/sqrt(x**2 - 1),
-     1/(-x**2 + 1)]
+    assert coth(x).diff(x) == -sinh(x)**(-2)
+    assert sinh(x).diff(x) == cosh(x)
+    assert cosh(x).diff(x) == sinh(x)
+    assert tanh(x).diff(x) == -tanh(x)**2 + 1
+    assert acoth(x).diff(x) == 1/(-x**2 + 1)
+    assert asinh(x).diff(x) == 1/sqrt(x**2 + 1)
+    assert acosh(x).diff(x) == 1/sqrt(x**2 - 1)
+    assert atanh(x).diff(x) == 1/(-x**2 + 1)
+

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -472,3 +472,15 @@ def test_coth_rewrite():
     assert coth(x).rewrite(sinh) == -I*sinh(I*pi/2-x)/sinh(x)
     assert coth(x).rewrite(cosh) == -I*cosh(x)/cosh(I*pi/2-x)
     assert coth(x).rewrite(tanh) == 1/tanh(x)
+
+def test_derivs():
+    x = Symbol('x')
+    assert [f(x).diff(x) for f in [coth, sinh, cosh, tanh, acoth, asinh, acosh, atanh]] == \
+    [-sinh(x)**(-2),
+     cosh(x),
+     sinh(x),
+     -tanh(x)**2 + 1,
+     1/(-x**2 + 1),
+     1/sqrt(x**2 + 1),
+     1/sqrt(x**2 - 1),
+     1/(-x**2 + 1)]


### PR DESCRIPTION
There was a minus sign missing in the derivative of the hyperbolic cotangent. Taking the derivative of the ratio of hyperbolic cosine and sine gave the correct (negative) value.
