### PR TITLE
relax constraints on is_quad_residue

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -136,16 +136,11 @@ def jacobi_symbol(m, n):
     1
 
     The relationship between the jacobi_symbol and legendre_symbol can
-    be seen by taking the product of the legendre_symbol for the prime factors
-    of a number. e.g. for 90 mod 7 we have:
+    be demonstrated as follows:
         >>> L = legendre_symbol
-        >>> fac_l_m = [(f, L(f, 7), m) for f, m in S(90).factors().items()]
-        >>> fac_l_m
-        [(2, 1, 1), (3, -1, 2), (5, -1, 1)]
-
-    The jacobi_symbol(90, 7) is the product of the legendre_symbols, l, of the
-    prime factors of 90 (raised to their multiplicity):
-        >>> jacobi_symbol(90, 7) == Mul(*[l**m for (f, l, m) in fac_l_m]) == -1
+        >>> S(45).factors()
+        {3: 2, 5: 1}
+        >>> jacobi_symbol(7, 45) == L(7, 3)**2 * L(7, 5)**1
         True
     """
     m, n = int_tested(m, n)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -53,16 +53,29 @@ def is_primitive_root(a, p):
 
 def is_quad_residue(a, p):
     """
-    returns True if a is a quadratic residue of p
-    p should be a prime and a should be relatively
-    prime to p
+    Returns True if ``a`` (mod ``p``) is in the set of squares mod ``p``,
+    i.e a % p in set([i**2 % p for i in range(p)]). If ``p`` is an odd
+    prime, an iterative method is used to make the determination.
+
+    >>> from sympy.ntheory import is_quad_residue
+    >>> set([i**2 % 7 for i in range(7)])
+    [0, 1, 2, 4]
+    >>> [j for j in range(7) if is_quad_residue(j, 7)]
+    [0, 1, 2, 4]
     """
-    if not isprime(p) or p == 2:
-        raise ValueError("p should be an odd prime")
-    if igcd(a, p) != 1:
-        raise ValueError("The two numbers should be relatively prime")
-    if a > p:
+    if any(int(i) != i for i in [a, p]) or p < 1:
+        raise ValueError('a and p must be integers and p must be > 1')
+    if a == 0 or a == 1 or p == 2:
+        return True
+    if p == 1:
+        return a == 0
+    if a > p or a < 0:
         a = a % p
+    if not isprime(p):
+        for i in range(2, p//2):
+            if i**2 % p == a:
+                return True
+        return False
 
     def square_and_multiply(a, n, p):
         if n == 0:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -77,14 +77,10 @@ def is_quad_residue(a, p):
     a, p = int_tested(a, p)
     if p < 1:
         raise ValueError('p must be > 0')
-    if a == 0 or p == 2:
-        return True
-    if p == 1:
-        return a == 0
-    elif a == 1:
-        return True
     if a > p or a < 0:
         a = a % p
+    if a < 2 or p < 3:
+        return True
     if not isprime(p):
         if p % 2 and jacobi_symbol(a, p) == -1:
             return False

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -77,7 +77,7 @@ def is_quad_residue(a, p):
     a, p = int_tested(a, p)
     if p < 1:
         raise ValueError('p must be > 0')
-    if a > p or a < 0:
+    if a >= p or a < 0:
         a = a % p
     if a < 2 or p < 3:
         return True

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -72,6 +72,9 @@ def is_quad_residue(a, p):
     if a > p or a < 0:
         a = a % p
     if not isprime(p):
+        if jacobi_symbol(a, p) == -1:
+            print 'yo'
+            return False
         for i in range(2, p//2):
             if i**2 % p == a:
                 return True

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -358,8 +358,13 @@ def test_residue():
 
     assert is_quad_residue(3, 7) == False
     assert is_quad_residue(10, 13) == True
-    assert is_quad_residue(12364, 139) == is_quad_residue(132, 139)
+    assert is_quad_residue(12364, 139) == is_quad_residue(12364 % 139, 139)
     assert is_quad_residue(207, 251) == True
+    assert is_quad_residue(0, 2) == is_quad_residue(1, 2) == True
+    assert is_quad_residue(1, 4) == True
+    assert [j for j in range(14) if is_quad_residue(j, 14)] == \
+           [0, 1, 2, 4, 7, 8, 9, 11]
+    raises(ValueError, 'is_quad_residue(1.1, 2)')
 
     assert legendre_symbol(5, 11) == 1
     assert legendre_symbol(25, 41) == 1

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -360,8 +360,11 @@ def test_residue():
     assert is_quad_residue(10, 13) == True
     assert is_quad_residue(12364, 139) == is_quad_residue(12364 % 139, 139)
     assert is_quad_residue(207, 251) == True
+    assert is_quad_residue(0, 1) == True
+    assert is_quad_residue(1, 1) == False
     assert is_quad_residue(0, 2) == is_quad_residue(1, 2) == True
     assert is_quad_residue(1, 4) == True
+    assert is_quad_residue(2, 27) == False
     assert [j for j in range(14) if is_quad_residue(j, 14)] == \
            [0, 1, 2, 4, 7, 8, 9, 11]
     raises(ValueError, 'is_quad_residue(1.1, 2)')
@@ -377,6 +380,12 @@ def test_residue():
     assert jacobi_symbol(-23, 83) == -1
     assert jacobi_symbol(3, 9) == 0
     assert jacobi_symbol(42, 97) == -1
+    assert jacobi_symbol(3, 5) == -1
+    assert jacobi_symbol(7, 9) == 1
+    assert jacobi_symbol(0, 3) == 0
+    assert jacobi_symbol(0, 1) == 1
+    assert jacobi_symbol(2, 1) == 1
+    assert jacobi_symbol(1, 3) == 1
     raises(ValueError, 'jacobi_symbol(3, 8)')
 
 def test_hex_pi_nth_digits():

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -361,7 +361,7 @@ def test_residue():
     assert is_quad_residue(12364, 139) == is_quad_residue(12364 % 139, 139)
     assert is_quad_residue(207, 251) == True
     assert is_quad_residue(0, 1) == True
-    assert is_quad_residue(1, 1) == False
+    assert is_quad_residue(1, 1) == True
     assert is_quad_residue(0, 2) == is_quad_residue(1, 2) == True
     assert is_quad_residue(1, 4) == True
     assert is_quad_residue(2, 27) == False


### PR DESCRIPTION
```
Whether a number 'a' is in the set of squares mod p can be answered
for any integer 'a' or 'p', so code to do so is now included for those
cases rather than raising an error.
```
