### PR TITLE
fixed bugs in unrank_nonlex, rank_nonlex; added tests

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -964,12 +964,11 @@ class Permutation(Basic):
         Permutation([0, 2, 4, 1, 3])
         """
         perm_array = [0] * size
-        perm_array[size - 1] = 1
-        for i in xrange(size - 1):
-            d = (rank % factorial(i + 1)) // factorial(i)
-            rank = rank - d*factorial(i)
-            perm_array[size - i - 1] = d + 1
+        for i in xrange(size):
+            d = (rank % int(factorial(i + 1))) / int(factorial(i))
+            rank = rank - d*int(factorial(i))
+            perm_array[size - i - 1] = d
             for j in xrange(size - i, size):
-                if perm_array[j] > d:
+                if perm_array[j] > d-1:
                     perm_array[j] += 1
         return Permutation(perm_array)

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -52,9 +52,22 @@ def test_Permutation():
     assert q.max == 4
     assert q.min == 0
 
-    assert p.rank_nonlex() == 14830
-    assert q.rank_nonlex() == 8441
-    assert Permutation.unrank_nonlex(7, 41) == Permutation([4, 2, 3, 5, 1, 0, 6])
+    prank = p.rank_nonlex()
+    assert prank == 1600
+    assert Permutation.unrank_nonlex(7, 1600) == p
+    qrank = q.rank_nonlex()
+    assert qrank == 41
+    assert Permutation.unrank_nonlex(7, 41) == Permutation(q.array_form)
+
+    a = [Permutation.unrank_nonlex(4, i).array_form for i in range(24)]
+    assert a == \
+    [[1, 2, 3, 0], [3, 2, 0, 1], [1, 3, 0, 2], [1, 2, 0, 3], [2, 3, 1, 0], \
+     [2, 0, 3, 1], [3, 0, 1, 2], [2, 0, 1, 3], [1, 3, 2, 0], [3, 0, 2, 1], \
+     [1, 0, 3, 2], [1, 0, 2, 3], [2, 1, 3, 0], [2, 3, 0, 1], [3, 1, 0, 2], \
+     [2, 1, 0, 3], [3, 2, 1, 0], [0, 2, 3, 1], [0, 3, 1, 2], [0, 2, 1, 3], \
+     [3, 1, 2, 0], [0, 3, 2, 1], [0, 1, 3, 2], [0, 1, 2, 3]]
+
+    assert [Permutation(pa).rank_nonlex() for pa in a] == range(24)
 
     assert q.rank == 870
     assert p.rank == 1964

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -120,4 +120,7 @@ def test_unrank_lex():
     assert Permutation.unrank_lex(5, 10).rank == 10
     assert Permutation.unrank_lex(15, 225).rank == 225
     assert Permutation.unrank_lex(10, 0).is_Identity
-    assert Permutation.unrank_lex(4, 23).array_form == [0, 3, 2, 1]
+    p = Permutation.unrank_lex(4, 23)
+    assert p.rank == 23
+    assert p.array_form == [3, 2, 1, 0]
+


### PR DESCRIPTION
unrank_nonlex gives wrong results

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_nonlex(4, i).array_form for i in range(24)]
[[1, 2, 3, 0], [3, 2, 0, 1], [1, 3, 0, 2], [2, 0, 1, 3], [2, 3, 1, 0], [2, 0, 3, 1], [0, 1, 3, 2], [0, 1, 2, 3], [3, 1, 2, 0], [2, 3, 0, 1], [3, 1, 0, 2], [2, 1, 0, 3], [2, 3, 1, 0], [2, 0, 3, 1], [3, 0, 1, 2], [1, 0, 2, 3], [1, 3, 2, 0], [3, 0, 2, 1], [3, 1, 0, 2], [2, 1, 0, 3], [2, 1, 3, 0], [0, 2, 3, 1], [0, 3, 1, 2], [0, 2, 1, 3]]
```

is not the list of permutations of `[0,1,2,3]` ; for example `[2,0,3,1]` appears twice.

In  this pull request there is a fix for it, with which
the output of the above example is as in the paper by Myrvold and Ruskey
quoted in permutations.py

There is a bug fix also for rank_nonlex; after fixing it

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_nonlex(4, i).rank_nonlex() for i in range(24)] == range(24)
True
```

I have put in test_permutations.py a few tests for them.
