### PR TITLE
fixed bugs in unrank_nonlex, rank_nonlex; added tests

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -299,14 +299,16 @@ don\'t match.")
         >>> Permutation.unrank_nonlex(6, 2)
         Permutation([1, 5, 3, 4, 0, 2])
         """
+        def unrank1(n, r, a):
+            if n > 0:
+                a[n-1], a[r % n] = a[r % n], a[n-1]
+                unrank1(n-1, r//n, a)
+
         id_perm = [i for i in xrange(n)]
-        while n > 1:
-            id_perm[n-1],id_perm[r % n] = id_perm[r % n], id_perm[n-1]
-            n -= 1
-            r = r//n
+        unrank1(n, r, id_perm)
         return Permutation(id_perm)
 
-    def rank_nonlex(self, inv_perm = None, n = 0):
+    def rank_nonlex(self):
         """
         This is a linear time ranking algorithm that does not
         enforce lexicographic order [3].
@@ -321,20 +323,19 @@ don\'t match.")
         >>> p.rank_nonlex()
         23
         """
-        if inv_perm is None:
-            inv_perm = (~self).array_form
-        if n == 0:
-            n = self.size
-        if n == 1:
-            return 0
-        perm_form = self.array_form[:]
-        temp_inv_form = inv_perm[:]
-        s = perm_form[n-1]
-        perm_form[n-1], perm_form[temp_inv_form[n-1]] = \
-            perm_form[temp_inv_form[n-1]], perm_form[n-1]
-        temp_inv_form[s], temp_inv_form[n-1] = \
-            temp_inv_form[n-1], temp_inv_form[s]
-        return s + n*self.rank_nonlex(temp_inv_form, n - 1)
+        def rank1(n, perm, inv_perm):
+            if n == 1:
+                return 0
+            s = perm[n-1]
+            perm[n-1], perm[inv_perm[n-1]] = perm[inv_perm[n-1]], perm[n-1]
+            inv_perm[s], inv_perm[n-1] = inv_perm[n-1], inv_perm[s]
+            return s + n*rank1(n-1, perm, inv_perm)
+
+        inv_perm = (~self).array_form
+        perm = self.array_form[:]
+        n = len(perm)
+        r = rank1(n, perm, inv_perm)
+        return r
 
     @property
     def rank(self):

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -1,5 +1,4 @@
 from sympy.combinatorics.permutations import Permutation
-from sympy.utilities.pytest import raises
 
 def test_Permutation():
     p = Permutation([2,5,1,6,3,0,4])
@@ -53,9 +52,22 @@ def test_Permutation():
     assert q.max == 4
     assert q.min == 0
 
-    assert p.rank_nonlex() == 14830
-    assert q.rank_nonlex() == 8441
-    assert Permutation.unrank_nonlex(7, 41) == Permutation([4, 2, 3, 5, 1, 0, 6])
+    prank = p.rank_nonlex()
+    assert prank == 1600
+    assert Permutation.unrank_nonlex(7, 1600) == p
+    qrank = q.rank_nonlex()
+    assert qrank == 41
+    assert Permutation.unrank_nonlex(7, 41) == Permutation(q.array_form)
+
+    a = [Permutation.unrank_nonlex(4, i).array_form for i in range(24)]
+    assert a == \
+    [[1, 2, 3, 0], [3, 2, 0, 1], [1, 3, 0, 2], [1, 2, 0, 3], [2, 3, 1, 0], \
+     [2, 0, 3, 1], [3, 0, 1, 2], [2, 0, 1, 3], [1, 3, 2, 0], [3, 0, 2, 1], \
+     [1, 0, 3, 2], [1, 0, 2, 3], [2, 1, 3, 0], [2, 3, 0, 1], [3, 1, 0, 2], \
+     [2, 1, 0, 3], [3, 2, 1, 0], [0, 2, 3, 1], [0, 3, 1, 2], [0, 2, 1, 3], \
+     [3, 1, 2, 0], [0, 3, 2, 1], [0, 1, 3, 2], [0, 1, 2, 3]]
+
+    assert [Permutation(pa).rank_nonlex() for pa in a] == range(24)
 
     assert q.rank == 870
     assert p.rank == 1964
@@ -125,17 +137,3 @@ def test_unrank_lex():
     assert p.rank == 23
     assert p.array_form == [3, 2, 1, 0]
 
-def test_args():
-    p = Permutation([(0, 3, 1, 2), (4,5)])
-    assert p.cyclic_form == [[0, 3, 1, 2], [4, 5]]
-    assert p._array_form == None
-    p = Permutation((0, 3, 1, 2))
-    assert p._cyclic_form == None
-    assert p._array_form == [0, 3, 1, 2]
-    assert Permutation([0]) == Permutation((0,))
-    assert Permutation([[0], [1]]) == Permutation(((0,), (1,))) == Permutation(((0,), [1]))
-    raises(ValueError, 'Permutation([[1, 2], [3]])') # 0, 1, 2 should be present
-    raises(ValueError, 'Permutation([1, 2, 3])') # 0, 1, 2 should be present
-    raises(ValueError, 'Permutation(0, 1, 2)') # enclosing brackets needed
-    raises(ValueError, 'Permutation([1, 2], [0])') # enclosing brackets needed
-    raises(ValueError, 'Permutation([[1, 2], 0])') # enclosing brackets needed on 0


### PR DESCRIPTION
unrank_nonlex gives wrong results

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_nonlex(4, i).array_form for i in range(24)]
[[1, 2, 3, 0], [3, 2, 0, 1], [1, 3, 0, 2], [2, 0, 1, 3], [2, 3, 1, 0], [2, 0, 3, 1], [0, 1, 3, 2], [0, 1, 2, 3], [3, 1, 2, 0], [2, 3, 0, 1], [3, 1, 0, 2], [2, 1, 0, 3], [2, 3, 1, 0], [2, 0, 3, 1], [3, 0, 1, 2], [1, 0, 2, 3], [1, 3, 2, 0], [3, 0, 2, 1], [3, 1, 0, 2], [2, 1, 0, 3], [2, 1, 3, 0], [0, 2, 3, 1], [0, 3, 1, 2], [0, 2, 1, 3]]
```

is not the list of permutations of [0,1,2,3] ; for example [2,0,3,1] appears twice.

In this pull request there is a fix for it, with which
the output of the above example is as in the paper by Myrvold and Ruskey
quoted in permutations.py

There is a bug fix also for rank_nonlex; after fixing it

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_nonlex(4, i).rank_nonlex() for i in range(24)] == range(24)
True
```

I have put in test_permutations.py a few tests for them.
