### PR TITLE
fixed bugs in unrank_nonlex, rank_nonlex; added tests

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -293,6 +293,8 @@ don\'t match.")
         >>> from sympy.combinatorics.permutations import Permutation
         >>> Permutation.unrank_nonlex(4, 5)
         Permutation([2, 0, 3, 1])
+        >>> Permutation.unrank_nonlex(4, -1)
+        Permutation([0, 1, 2, 3])
 
         >>> Permutation.unrank_nonlex(6, 2)
         Permutation([1, 5, 3, 4, 0, 2])
@@ -303,6 +305,7 @@ don\'t match.")
                 unrank1(n - 1, r//n, a)
 
         id_perm = range(n)
+        r = r % factorial(n)
         unrank1(n, r, id_perm)
         return Permutation(id_perm)
 
@@ -354,11 +357,15 @@ don\'t match.")
         """
         rank = 0
         rho = self.array_form[:]
+        n = self.size - 1
+        psize = factorial(n)
         for j in xrange(self.size - 1):
-            rank += (rho[j])*factorial(self.size - j - 1)
+            rank += rho[j]*psize
             for i in xrange(j + 1, self.size):
                 if rho[i] > rho[j]:
-                    rho[i] = rho[i] - 1
+                    rho[i] -= 1
+            psize /= n
+            n -= 1
         return rank
 
     @property
@@ -974,11 +981,14 @@ don\'t match.")
         Permutation([0, 2, 4, 1, 3])
         """
         perm_array = [0] * size
+        psize = 1
         for i in xrange(size):
-            d = (rank % int(factorial(i + 1))) / int(factorial(i))
-            rank = rank - d*int(factorial(i))
+            new_psize = psize*(i + 1)
+            d = (rank % new_psize) // psize
+            rank -= d*psize
             perm_array[size - i - 1] = d
             for j in xrange(size - i, size):
                 if perm_array[j] > d-1:
                     perm_array[j] += 1
+            psize = new_psize
         return Permutation(perm_array)

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -294,16 +294,16 @@ don\'t match.")
         >>> Permutation.unrank_nonlex(4, 5)
         Permutation([2, 0, 3, 1])
 
-        Consider in the cyclic form
-        >>> from sympy.combinatorics.permutations import Permutation
         >>> Permutation.unrank_nonlex(6, 2)
         Permutation([1, 5, 3, 4, 0, 2])
         """
+        def unrank1(n, r, a):
+            if n > 0:
+                a[n-1], a[r % n] = a[r % n], a[n-1]
+                unrank1(n-1, r//n, a)
+
         id_perm = [i for i in xrange(n)]
-        while n > 1:
-            id_perm[n-1],id_perm[r % n] = id_perm[r % n], id_perm[n-1]
-            n -= 1
-            r = r//n
+        unrank1(n, r, id_perm)
         return Permutation(id_perm)
 
     def rank_nonlex(self, inv_perm = None, n = 0):
@@ -321,20 +321,19 @@ don\'t match.")
         >>> p.rank_nonlex()
         23
         """
-        if inv_perm is None:
-            inv_perm = (~self).array_form
-        if n == 0:
-            n = self.size
-        if n == 1:
-            return 0
-        perm_form = self.array_form[:]
-        temp_inv_form = inv_perm[:]
-        s = perm_form[n-1]
-        perm_form[n-1], perm_form[temp_inv_form[n-1]] = \
-            perm_form[temp_inv_form[n-1]], perm_form[n-1]
-        temp_inv_form[s], temp_inv_form[n-1] = \
-            temp_inv_form[n-1], temp_inv_form[s]
-        return s + n*self.rank_nonlex(temp_inv_form, n - 1)
+        def rank1(n, perm, inv_perm):
+            if n == 1:
+                return 0
+            s = perm[n-1]
+            perm[n-1], perm[inv_perm[n-1]] = perm[inv_perm[n-1]], perm[n-1]
+            inv_perm[s], inv_perm[n-1] = inv_perm[n-1], inv_perm[s]
+            return s + n*rank1(n-1, perm, inv_perm)
+
+        inv_perm = (~self).array_form
+        perm = self.array_form[:]
+        n = len(perm)
+        r = rank1(n, perm, inv_perm)
+        return r
 
     @property
     def rank(self):

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -299,10 +299,10 @@ don\'t match.")
         """
         def unrank1(n, r, a):
             if n > 0:
-                a[n-1], a[r % n] = a[r % n], a[n-1]
-                unrank1(n-1, r//n, a)
+                a[n - 1], a[r % n] = a[r % n], a[n - 1]
+                unrank1(n - 1, r//n, a)
 
-        id_perm = [i for i in xrange(n)]
+        id_perm = range(n)
         unrank1(n, r, id_perm)
         return Permutation(id_perm)
 
@@ -324,18 +324,18 @@ don\'t match.")
         def rank1(n, perm, inv_perm):
             if n == 1:
                 return 0
-            s = perm[n-1]
-            perm[n-1], perm[inv_perm[n-1]] = perm[inv_perm[n-1]], perm[n-1]
-            inv_perm[s], inv_perm[n-1] = inv_perm[n-1], inv_perm[s]
-            return s + n*rank1(n-1, perm, inv_perm)
+            s = perm[n - 1]
+            t = inv_perm[n - 1]
+            perm[n - 1], perm[t] = perm[t], s
+            inv_perm[n - 1], inv_perm[s] = inv_perm[s], t
+            return s + n*rank1(n - 1, perm, inv_perm)
 
         if inv_perm is None:
             inv_perm = (~self).array_form
-        perm = self.array_form[:]
-        n = len(perm)
-        if n == 0:
+        if not inv_perm:
             return 0
-        r = rank1(n, perm, inv_perm)
+        perm = self.array_form[:]
+        r = rank1(len(perm), perm, inv_perm)
         return r
 
     @property
@@ -904,7 +904,7 @@ don\'t match.")
         m -= 1
         if s <= 0:
             s = 1
-        Q = deque([i for i in xrange(n)])
+        Q = deque(range(n))
         perm = []
         while len(Q) > s:
             for dp in xrange(m):
@@ -956,7 +956,7 @@ don\'t match.")
         >>> (a*(~a)).is_Identity
         True
         """
-        perm_array = [i for i in xrange(n)]
+        perm_array = range(n)
         random.shuffle(perm_array)
         return Permutation(perm_array)
 

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -306,7 +306,7 @@ don\'t match.")
         unrank1(n, r, id_perm)
         return Permutation(id_perm)
 
-    def rank_nonlex(self, inv_perm = None, n = 0):
+    def rank_nonlex(self, inv_perm = None):
         """
         This is a linear time ranking algorithm that does not
         enforce lexicographic order [3].
@@ -329,9 +329,12 @@ don\'t match.")
             inv_perm[s], inv_perm[n-1] = inv_perm[n-1], inv_perm[s]
             return s + n*rank1(n-1, perm, inv_perm)
 
-        inv_perm = (~self).array_form
+        if inv_perm is None:
+            inv_perm = (~self).array_form
         perm = self.array_form[:]
         n = len(perm)
+        if n == 0:
+            return 0
         r = rank1(n, perm, inv_perm)
         return r
 

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -53,9 +53,22 @@ def test_Permutation():
     assert q.max == 4
     assert q.min == 0
 
-    assert p.rank_nonlex() == 14830
-    assert q.rank_nonlex() == 8441
-    assert Permutation.unrank_nonlex(7, 41) == Permutation([4, 2, 3, 5, 1, 0, 6])
+    prank = p.rank_nonlex()
+    assert prank == 1600
+    assert Permutation.unrank_nonlex(7, 1600) == p
+    qrank = q.rank_nonlex()
+    assert qrank == 41
+    assert Permutation.unrank_nonlex(7, 41) == Permutation(q.array_form)
+
+    a = [Permutation.unrank_nonlex(4, i).array_form for i in range(24)]
+    assert a == \
+    [[1, 2, 3, 0], [3, 2, 0, 1], [1, 3, 0, 2], [1, 2, 0, 3], [2, 3, 1, 0], \
+     [2, 0, 3, 1], [3, 0, 1, 2], [2, 0, 1, 3], [1, 3, 2, 0], [3, 0, 2, 1], \
+     [1, 0, 3, 2], [1, 0, 2, 3], [2, 1, 3, 0], [2, 3, 0, 1], [3, 1, 0, 2], \
+     [2, 1, 0, 3], [3, 2, 1, 0], [0, 2, 3, 1], [0, 3, 1, 2], [0, 2, 1, 3], \
+     [3, 1, 2, 0], [0, 3, 2, 1], [0, 1, 3, 2], [0, 1, 2, 3]]
+
+    assert [Permutation(pa).rank_nonlex() for pa in a] == range(24)
 
     assert q.rank == 870
     assert p.rank == 1964

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -2,8 +2,8 @@ from sympy.combinatorics.permutations import Permutation
 from sympy.utilities.pytest import raises
 
 def test_Permutation():
-    p = Permutation([2,5,1,6,3,0,4])
-    q = Permutation([[1,4,5],[2,0,6],[3]])
+    p = Permutation([2, 5, 1, 6, 3, 0, 4])
+    q = Permutation([[1, 4, 5], [2, 0, 6], [3]])
 
     assert q.cycles == 3
     assert p*q == Permutation([4, 6, 1, 2, 5, 3, 0])
@@ -39,7 +39,7 @@ def test_Permutation():
 
     assert s.is_Singleton
 
-    r = Permutation([3,2,1,0])
+    r = Permutation([3, 2, 1, 0])
     assert (r**2).is_Identity
 
     assert (p*(~p)).is_Identity
@@ -48,11 +48,12 @@ def test_Permutation():
     assert p.max == 6
     assert p.min == 0
 
-    q = Permutation([[4,1,2,3],[0,5,6]])
+    q = Permutation([[4, 1, 2, 3], [0, 5, 6]])
 
     assert q.max == 4
     assert q.min == 0
 
+    assert Permutation([]).rank_nonlex() == 0
     prank = p.rank_nonlex()
     assert prank == 1600
     assert Permutation.unrank_nonlex(7, 1600) == p
@@ -73,8 +74,8 @@ def test_Permutation():
     assert q.rank == 870
     assert p.rank == 1964
 
-    p = Permutation([1,5,2,0,3,6,4])
-    q = Permutation([[2,3,5],[1,0,6],[4]])
+    p = Permutation([1, 5, 2, 0, 3, 6, 4])
+    q = Permutation([[2, 3, 5], [1, 0, 6], [4]])
 
     assert p.ascents == [0, 3, 4]
     assert q.ascents == [1, 2, 4]
@@ -139,14 +140,14 @@ def test_unrank_lex():
     assert p.array_form == [3, 2, 1, 0]
 
 def test_args():
-    p = Permutation([(0, 3, 1, 2), (4,5)])
+    p = Permutation([(0, 3, 1, 2), (4, 5)])
     assert p.cyclic_form == [[0, 3, 1, 2], [4, 5]]
     assert p._array_form == None
     p = Permutation((0, 3, 1, 2))
     assert p._cyclic_form == None
     assert p._array_form == [0, 3, 1, 2]
-    assert Permutation([0]) == Permutation((0,))
-    assert Permutation([[0], [1]]) == Permutation(((0,), (1,))) == Permutation(((0,), [1]))
+    assert Permutation([0]) == Permutation((0, ))
+    assert Permutation([[0], [1]]) == Permutation(((0, ), (1, ))) == Permutation(((0, ), [1]))
     raises(ValueError, 'Permutation([[1, 2], [3]])') # 0, 1, 2 should be present
     raises(ValueError, 'Permutation([1, 2, 3])') # 0, 1, 2 should be present
     raises(ValueError, 'Permutation(0, 1, 2)') # enclosing brackets needed


### PR DESCRIPTION
unrank_nonlex gives wrong results

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_nonlex(4, i).array_form for i in range(24)]
[[1, 2, 3, 0], [3, 2, 0, 1], [1, 3, 0, 2], [2, 0, 1, 3], [2, 3, 1, 0], [2, 0, 3, 1], [0, 1, 3, 2], [0, 1, 2, 3], [3, 1, 2, 0], [2, 3, 0, 1], [3, 1, 0, 2], [2, 1, 0, 3], [2, 3, 1, 0], [2, 0, 3, 1], [3, 0, 1, 2], [1, 0, 2, 3], [1, 3, 2, 0], [3, 0, 2, 1], [3, 1, 0, 2], [2, 1, 0, 3], [2, 1, 3, 0], [0, 2, 3, 1], [0, 3, 1, 2], [0, 2, 1, 3]]
```

is not the list of permutations of [0,1,2,3] ; for example [2,0,3,1] appears twice.

In this pull request there is a fix for it, with which
the output of the above example is as in the paper by Myrvold and Ruskey
quoted in permutations.py

There is a bug fix also for rank_nonlex; after fixing it

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_nonlex(4, i).rank_nonlex() for i in range(24)] == range(24)
True
```

I have put in test_permutations.py a few tests for them.
