### PR TITLE
Symbol.is commutative

### DIFF
--- a/doc/src/gotchas.txt
+++ b/doc/src/gotchas.txt
@@ -440,7 +440,7 @@ unsimplified trig identity, multiplied by a big number:
     >>> big = 12345678901234567890
     >>> big_trig_identity = big*cos(x)**2 + big*sin(x)**2 - big*1
     >>> big_trig_identity.subs(x, .1).n(2)
-    -1.4e+3
+    -2.0e+3
 
 When the cos and sin terms were evaluated to 15 digits of precision and
 multiplied by the big number, they gave a large number that was only

--- a/doc/src/modules/physics/mechanics/examples.txt
+++ b/doc/src/modules/physics/mechanics/examples.txt
@@ -171,9 +171,9 @@ represent the constraint forces in those directions. ::
   [                                          -2*u1*u3/3]
   [                             (-2*u2 + u3*tan(q2))*u1]
   >>> mprint(KM.auxiliary_eqs, order=None)
-  [                                                        -m*(r*u1*u3 + r*u2') + f1]
-  [     m*(-r*(u3*q3' - u1') - r*u2*u3)*cos(q2) - m*(r*u1**2 + r*u2**2)*sin(q2) + f2]
-  [-g*m + m*(r*(u1**2 + u2**2)*cos(q2) + (-r*(u3*q3' - u1') - r*u2*u3)*sin(q2)) + f3]
+  [                                                         -m*(r*u1*u3 + r*u2') + f1]
+  [      -m*(r*(u3*q3' - u1') + r*u2*u3)*cos(q2) - m*(r*u1**2 + r*u2**2)*sin(q2) + f2]
+  [-g*m - m*(r*(u3*q3' - u1') + r*u2*u3)*sin(q2) + m*(r*u1**2 + r*u2**2)*cos(q2) + f3]
 
 The Bicycle
 ===========

--- a/doc/src/modules/rewriting.txt
+++ b/doc/src/modules/rewriting.txt
@@ -77,12 +77,12 @@ subexpressions, collect them and evaluate them at once. This is implemented in t
     ⎛                ⎡  ________   ________⎤⎞
     ⎝[(x₀, sin(x))], ⎣╲╱ x₀ + 4 ⋅╲╱ x₀ + 5 ⎦⎠
 
-    >>> pprint(cse(sqrt(sin(x)+5+cos(y))*sqrt(sin(x)+4+cos(y))), use_unicode=True)
-    ⎛                                             ⎡  ________   ________⎤⎞
-    ⎝[(x₀, cos(y)), (x₁, sin(x)), (x₂, x₀ + x₁)], ⎣╲╱ x₂ + 4 ⋅╲╱ x₂ + 5 ⎦⎠
+    >>> pprint(cse(sqrt(sin(x+1) + 5 + cos(y))*sqrt(sin(x+1) + 4 + cos(y))), use_unicode=True)
+    ⎛                                                 ⎡  ________   ________⎤⎞
+    ⎝[(x₀, cos(y)), (x₁, sin(x + 1)), (x₂, x₀ + x₁)], ⎣╲╱ x₂ + 4 ⋅╲╱ x₂ + 5 ⎦⎠
 
     >>> pprint(cse((x-y)*(z-y) + sqrt((x-y)*(z-y))), use_unicode=True)
-    ⎛                         ⎡  ____     ⎤⎞
+    ⎛                          ⎡  ____     ⎤⎞
     ⎝[(x₀, -(x - y)⋅(y - z))], ⎣╲╱ x₀  + x₀⎦⎠
 
 More information:

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -278,7 +278,7 @@ class AssumeMixin(object):
         >>> from sympy import Symbol
         >>> from sympy.abc import x
         >>> x.assumptions0
-        {}
+        {'commutative': True}
         >>> x = Symbol("x", positive=True)
         >>> x.assumptions0
         {'commutative': True, 'complex': True, 'imaginary': False,

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -188,12 +188,6 @@ class Dict(Basic):
         '''x.__len__() <==> len(x)'''
         return self._dict.__len__()
 
-    def __str__(self):
-        return str(self._dict)
-
-    def __repr__(self):
-        return self._dict.__repr__()
-
     def get(self, key, default=None):
         '''D.get(k[,d]) -> D[k] if k in D, else d.  d defaults to None.'''
         return self._dict.get(sympify(key), default)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -377,6 +377,17 @@ def test_prime_symbol():
     assert x.is_nonpositive == None
     assert x.is_nonnegative == None
 
+def test_symbol_noncommutative():
+    x = Symbol('x', commutative=True)
+    assert x.is_complex is None
+
+    x = Symbol('x', commutative=False)
+    assert x.is_integer is False
+    assert x.is_rational is False
+    assert x.is_irrational is False
+    assert x.is_real is False
+    assert x.is_complex is False
+
 def test_other_symbol():
     x = Symbol('x', integer=True)
     assert x.is_integer == True
@@ -533,3 +544,7 @@ def test_special_is_rational():
     assert (r**i).is_rational is True
     assert (r**r).is_rational is None
     assert (r**x).is_rational is None
+
+def test_inconsistent():
+    # cf. issues 2696 and 2446
+    raises(AssertionError, "Symbol('x', real=True, commutative=False)")

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -293,6 +293,18 @@ def test_I():
     assert z.is_prime == False
     assert z.is_composite == False
 
+def test_symbol_real():
+    # issue 749
+    a = Symbol('a', real=False)
+
+    assert a.is_real        == False
+    assert a.is_integer     == False
+    assert a.is_negative    == False
+    assert a.is_positive    == False
+    assert a.is_nonnegative == False
+    assert a.is_nonpositive == False
+    assert a.is_zero        == False
+
 def test_symbol_zero():
     x = Symbol('x',zero=True)
     assert x.is_positive == False
@@ -410,10 +422,20 @@ def test_other_symbol():
     assert x.is_even == False
     assert x.is_integer == True
 
+    x = Symbol('x', odd=False)
+    assert x.is_odd == False
+    assert x.is_even == None
+    assert x.is_integer == None
+
     x = Symbol('x', even=True)
     assert x.is_even == True
     assert x.is_odd == False
     assert x.is_integer == True
+
+    x = Symbol('x', even=False)
+    assert x.is_even == False
+    assert x.is_odd == None
+    assert x.is_integer == None
 
     x = Symbol('x', integer=True, nonnegative=True)
     assert x.is_integer == True
@@ -424,34 +446,6 @@ def test_other_symbol():
     assert x.is_nonpositive == True
 
     raises(AttributeError, "x.is_real = False")
-
-
-def test_other_symbol_fail1():
-    # XXX x.is_even currently will be True
-    x = Symbol('x', odd=False)
-    assert x.is_odd == False
-    assert x.is_even == None
-    assert x.is_integer == None
-
-def test_other_symbol_fail2():
-    # XXX x.is_odd currently will be True
-    x = Symbol('x', even=False)
-    assert x.is_even == False
-    assert x.is_odd == None
-    assert x.is_integer == None
-
-
-def test_issue749():
-    a = Symbol('a', real=False)
-
-    assert a.is_real        == False
-    assert a.is_integer     == False
-    assert a.is_negative    == False
-    assert a.is_positive    == False
-    assert a.is_nonnegative == False
-    assert a.is_nonpositive == False
-    assert a.is_zero        == False
-
 
 def test_issue726():
     """catch: hash instability"""
@@ -479,7 +473,6 @@ def test_hash_vs_typeinfo():
     assert hash(x1) == hash(x2)
     assert x1 == x2
 
-
 def test_hash_vs_typeinfo_2():
     """different typeinfo should mean !eq"""
     # the following two are semantically different
@@ -488,7 +481,6 @@ def test_hash_vs_typeinfo_2():
 
     assert x != x1
     assert hash(x) != hash(x1) # This might fail with very low probability
-
 
 def test_hash_vs_eq():
     """catch: different hash for equal objects"""

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -101,7 +101,7 @@ def test_Dict():
     raises(NotImplementedError, "d[5] = 6") # assert immutability
 
     assert set(d.items()) == set((Tuple(x,S(1)), Tuple(y,S(2)), Tuple(z,S(3))))
-    assert list(d) == [x,y,z]
+    assert set(d) == set([x,y,z])
     assert str(d) == '{x: 1, y: 2, z: 3}'
     assert d.__repr__() == '{x: 1, y: 2, z: 3}'
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -45,10 +45,6 @@ def test_as_dummy():
     assert x1 != x
     assert x1.is_commutative == False
 
-    # issue 2446
-    x = Symbol('x', real=True, commutative=False)
-    assert x.as_dummy().assumptions0 == x.assumptions0
-
 def test_lt_gt():
     from sympy import sympify as S
     x, y = Symbol('x'), Symbol('y')

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -859,8 +859,8 @@ class Integral(Expr):
         >>> from sympy.abc import a, b, c, x, y
 
         >>> i = Integral(a + x, (a, a, 3), (b, x, c))
-        >>> list(i.free_symbols) # only these can be changed
-        [x, a, c]
+        >>> i.free_symbols # only these can be changed
+        set([a, c, x])
         >>> i.subs(a, c) # note that the variable of integration is unchanged
         Integral(a + x, (a, c, 3), (b, x, c))
         >>> i.subs(a + x, b) == i # there is no x + a, only x + <a>

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -139,7 +139,7 @@ class PropKB(KB):
         ========
 
         >>> from sympy.logic.inference import PropKB
-        >>> from sympy.abc import x, y, z
+        >>> from sympy.abc import x, y
         >>> l = PropKB()
         >>> l.clauses
         []
@@ -148,9 +148,9 @@ class PropKB(KB):
         >>> l.clauses
         [Or(x, y)]
 
-        >>> l.tell(y & z)
+        >>> l.tell(y)
         >>> l.clauses
-        [Or(x, y), y, z]
+        [Or(x, y), y]
         """
         for c in conjuncts(to_cnf(sentence)):
             if not c in self.clauses: self.clauses.append(c)

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -75,7 +75,8 @@ def test_dpll_satisfiable():
     assert dpll_satisfiable( A & ~B ) == {A: True, B: False}
     assert dpll_satisfiable( A | B ) in ({A: True}, {B: True}, {A: True, B: True})
     assert dpll_satisfiable( (~A | B) & (~B | A) ) in ({A: True, B: True}, {A: False, B:False})
-    assert dpll_satisfiable( (A | B) & (~B | C) ) in ({A: True, B: False}, {A: True, C:True})
+    assert dpll_satisfiable( (A | B) & (~B | C) ) in ({A: True, B: False},
+            {A: True, C:True}, {B: True, C: True})
     assert dpll_satisfiable( A & B & C  ) == {A: True, B: True, C: True}
     assert dpll_satisfiable( (A | B) & (A >> B) ) == {B: True}
     assert dpll_satisfiable( Equivalent(A, B) & A ) == {A: True, B: True}

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -12,7 +12,7 @@ source code files that are compilable without further modifications.
 from sympy.core import S, C
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence
-
+from sympy.utilities.misc import default_sort_key
 
 # dictionary mapping sympy function to (argument_conditions, C_function).
 # Used in CCodePrinter._print_Function(self)
@@ -175,11 +175,13 @@ class CCodePrinter(CodePrinter):
 
     def _print_And(self, expr):
         PREC = precedence(expr)
-        return '&&'.join(self.parenthesize(a, PREC) for a in expr.args)
+        return ' && '.join(self.parenthesize(a, PREC)
+                for a in sorted(expr.args, key=default_sort_key))
 
     def _print_Or(self, expr):
         PREC = precedence(expr)
-        return '||'.join(self.parenthesize(a, PREC) for a in expr.args)
+        return ' || '.join(self.parenthesize(a, PREC)
+                for a in sorted(expr.args, key=default_sort_key))
 
     def _print_Not(self, expr):
         PREC = precedence(expr)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -530,13 +530,14 @@ class LatexPrinter(Printer):
         return r"\neg %s" % self._print(e.args[0])
 
     def _print_And(self, e):
-        arg = e.args[0]
+        args = sorted(e.args, key=default_sort_key)
+        arg = args[0]
         if arg.is_Boolean and not arg.is_Not:
-            tex = r"\left(%s\right)" % self._print(e.args[0]);
+            tex = r"\left(%s\right)" % self._print(arg)
         else:
-            tex = r"%s" % self._print(e.args[0]);
+            tex = r"%s" % self._print(arg)
 
-        for arg in e.args[1:]:
+        for arg in args[1:]:
             if arg.is_Boolean and not arg.is_Not:
                 tex += r" \wedge \left(%s\right)" % (self._print(arg))
             else:
@@ -545,13 +546,14 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_Or(self, e):
-        arg = e.args[0]
+        args = sorted(e.args, key=default_sort_key)
+        arg = args[0]
         if arg.is_Boolean and not arg.is_Not:
-            tex = r"\left(%s\right)" % self._print(e.args[0]);
+            tex = r"\left(%s\right)" % self._print(arg)
         else:
-            tex = r"%s" % self._print(e.args[0]);
+            tex = r"%s" % self._print(arg)
 
-        for arg in e.args[1:]:
+        for arg in args[1:]:
             if arg.is_Boolean and not arg.is_Not:
                 tex += r" \vee \left(%s\right)" % (self._print(arg))
             else:
@@ -998,7 +1000,7 @@ class LatexPrinter(Printer):
 
     def _print_RandomDomain(self, d):
         try:
-            return 'Domain: '+self._print(d.as_boolean())
+            return 'Domain: '+ self._print(d.as_boolean())
         except:
             try:
                 return ('Domain: ' + self._print(d.symbols) + ' in ' +

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -132,14 +132,14 @@ class PrettyPrinter(Printer):
         else:
             return self._print_Function(e)
 
-    def __print_Boolean(self, e, char):
-        arg = e.args[0]
+    def __print_Boolean(self, args, char):
+        arg = args[0]
         pform = self._print(arg)
 
         if arg.is_Boolean and not arg.is_Not:
             pform = prettyForm(*pform.parens())
 
-        for arg in e.args[1:]:
+        for arg in args[1:]:
             pform_arg = self._print(arg)
 
             if arg.is_Boolean and not arg.is_Not:
@@ -151,44 +151,47 @@ class PrettyPrinter(Printer):
         return pform
 
     def _print_And(self, e):
+        args = sorted(e.args, key=default_sort_key)
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u2227")
+            return self.__print_Boolean(args, u"\u2227")
         else:
             return self._print_Function(e)
 
     def _print_Or(self, e):
+        args = sorted(e.args, key=default_sort_key)
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u2228")
+            return self.__print_Boolean(args, u"\u2228")
         else:
             return self._print_Function(e)
 
     def _print_Xor(self, e):
+        args = sorted(e.args, key=default_sort_key)
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u22bb")
+            return self.__print_Boolean(args, u"\u22bb")
         else:
             return self._print_Function(e)
 
     def _print_Nand(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u22bc")
+            return self.__print_Boolean(e.args, u"\u22bc")
         else:
             return self._print_Function(e)
 
     def _print_Nor(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u22bd")
+            return self.__print_Boolean(e.args, u"\u22bd")
         else:
             return self._print_Function(e)
 
     def _print_Implies(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u2192")
+            return self.__print_Boolean(e.args, u"\u2192")
         else:
             return self._print_Function(e)
 
     def _print_Equivalent(self, e):
         if self._use_unicode:
-            return self.__print_Boolean(e, u"\u2261")
+            return self.__print_Boolean(e.args, u"\u2261")
         else:
             return self._print_Function(e)
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3630,4 +3630,4 @@ def test_RandomDomain():
 
     A = Exponential(1, symbol=Symbol('a'))
     B = Exponential(1, symbol=Symbol('b'))
-    assert upretty(pspace(Tuple(A,B)).domain) ==u'Domain: 0 ≤ b ∧ 0 ≤ a'
+    assert upretty(pspace(Tuple(A,B)).domain) ==u'Domain: 0 ≤ a ∧ 0 ≤ b'

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -73,16 +73,16 @@ def test_ccode_exceptions():
     assert ccode(Abs(x)) == "fabs(x)"
 
 def test_ccode_boolean():
-    assert ccode(x&y) == "x&&y"
-    assert ccode(x|y) == "x||y"
+    assert ccode(x & y) == "x && y"
+    assert ccode(x | y) == "x || y"
     assert ccode(~x) == "!x"
-    assert ccode(x&y&z) == "x&&y&&z"
-    assert ccode(x|y|z) == "x||y||z"
-    assert ccode((x&y)|z) == "x&&y||z"
-    assert ccode((x|y)&z) == "(x||y)&&z"
+    assert ccode(x & y & z) == "x && y && z"
+    assert ccode(x | y | z) == "x || y || z"
+    assert ccode((x & y) | z) == "z || x && y"
+    assert ccode((x | y) & z) == "z && (x || y)"
 
 def test_ccode_Piecewise():
-    p = ccode(Piecewise((x,x<1),(x**2,True)))
+    p = ccode(Piecewise((x, x<1), (x**2, True)))
     s = \
 """\
 if (x < 1) {

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -57,7 +57,7 @@ def test_latex_basic():
     assert latex(x & y & z) == r"x \wedge y \wedge z"
     assert latex(x | y) == r"x \vee y"
     assert latex(x | y | z) == r"x \vee y \vee z"
-    assert latex((x & y) | z) == r"\left(x \wedge y\right) \vee z"
+    assert latex((x & y) | z) == r"z \vee \left(x \wedge y\right)"
     assert latex(Implies(x,y)) == r"x \Rightarrow y"
 
     assert latex(~x, symbol_names={x: "x_i"}) == r"\neg x_i"
@@ -69,7 +69,7 @@ def test_latex_basic():
     assert latex(x | y | z, symbol_names={x: "x_i", y: "y_i", z: "z_i"}) == \
         r"x_i \vee y_i \vee z_i"
     assert latex((x & y) | z, symbol_names={x: "x_i", y: "y_i", z: "z_i"}) ==\
-        r"\left(x_i \wedge y_i\right) \vee z_i"
+        r"z_i \vee \left(x_i \wedge y_i\right)"
     assert latex(Implies(x,y), symbol_names={x: "x_i", y: "y_i"}) == \
         r"x_i \Rightarrow y_i"
 
@@ -462,7 +462,7 @@ def test_latex_RandomDomain():
 
     A = Exponential(1, symbol=Symbol('a'))
     B = Exponential(1, symbol=Symbol('b'))
-    assert latex(pspace(Tuple(A,B)).domain) =="Domain: 0 \leq b \wedge 0 \leq a"
+    assert latex(pspace(Tuple(A,B)).domain) =="Domain: 0 \leq a \wedge 0 \leq b"
 
 def test_integral_transforms():
     x = Symbol("x")

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -328,9 +328,10 @@ def sub_func_doit(eq, func, new):
     Examples
     ========
 
-    >>> from sympy import Derivative
-    >>> from sympy.abc import x, y, z
+    >>> from sympy import Derivative, symbols, Function
     >>> from sympy.solvers.ode import sub_func_doit
+    >>> x, z = symbols('x, z')
+    >>> y = Function('y')
 
     >>> sub_func_doit(3*Derivative(y(x), x) - 1, y(x), x)
     2
@@ -2923,10 +2924,10 @@ def ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match
     return _solve_variation_of_parameters(eq, func, order, match)
 
 def _solve_variation_of_parameters(eq, func, order, match):
-    """	  	
+    """
     Helper function for the method of variation of parameters.
 
-    See the ode_nth_linear_constant_coeff_variation_of_parameters() 	
+    See the ode_nth_linear_constant_coeff_variation_of_parameters()
     docstring for more information on this method.
 
     match should be a dictionary that has the following keys:
@@ -2950,7 +2951,7 @@ def _solve_variation_of_parameters(eq, func, order, match):
         wr = simplify(wr) # We need much better simplification for some ODEs.
         #                   See issue 1563, for example.
 
-        # To reduce commonly occuring sin(x)**2 + cos(x)**2 to 1  	
+        # To reduce commonly occuring sin(x)**2 + cos(x)**2 to 1
         wr = trigsimp(wr, deep=True, recursive=True)
     if not wr:
         # The wronskian will be 0 iff the solutions are not linearly independent.

--- a/sympy/solvers/polysys.py
+++ b/sympy/solvers/polysys.py
@@ -2,7 +2,8 @@
 
 from sympy.polys import Poly, groebner, roots
 from sympy.polys.polytools import parallel_poly_from_expr
-from sympy.polys.polyerrors import ComputationFailed, PolificationFailed
+from sympy.polys.polyerrors import (ComputationFailed,
+    PolificationFailed, CoercionFailed)
 from sympy.utilities import postfixes
 from sympy.simplify import rcollect
 from sympy.core import S
@@ -216,7 +217,10 @@ def solve_generic(polys, opt):
 
         return solutions
 
-    result = _solve_reduced_system(polys, opt.gens, entry=True)
+    try:
+        result = _solve_reduced_system(polys, opt.gens, entry=True)
+    except CoercionFailed:
+        raise NotImplementedError
 
     if result is not None:
         return sorted(result)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -34,7 +34,7 @@ from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, Poly, together, factor
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
-from sympy.utilities.iterables import preorder_traversal
+from sympy.utilities.iterables import preorder_traversal, sift
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import default_sort_key, filldedent
 from sympy.mpmath import findroot
@@ -1186,9 +1186,10 @@ def _solve_system(exprs, symbols, **flags):
         else:
             if len(symbols) != len(polys):
                 from sympy.utilities.iterables import subsets
-                free = reduce(set.union,
+                free = list(reduce(set.union,
                                 [p.free_symbols for p in polys], set()
-                                ).intersection(symbols)
+                                ).intersection(symbols))
+                free.sort(key=default_sort_key)
                 for syms in subsets(free, len(polys)):
                     try:
                         # returns [] or list of tuples of solutions for syms
@@ -1243,8 +1244,12 @@ def _solve_system(exprs, symbols, **flags):
         legal = set(symbols) # what we are interested in
         simplify_flag = flags.get('simplify', None)
         do_simplify = flags.get('simplify', True)
-        # sort so equation with the fewest potential symbols is first
-        failed.sort(key=lambda x: len((x.free_symbols - solved_syms) & legal))
+        # sort so equation with the fewest potential symbols is first; break ties with
+        # count_ops and sort_key
+        short = sift(failed, lambda x: len((x.free_symbols - solved_syms) & legal))
+        failed = []
+        for k in sorted(short):
+            failed.extend(sorted(short[k], key=lambda x: (x.count_ops(), x.sort_key())))
         for eq in failed:
             newresult = []
             got_s = None
@@ -1252,12 +1257,11 @@ def _solve_system(exprs, symbols, **flags):
             for r in result:
                 # update eq with everything that is known so far
                 eq2 = eq.subs(r)
-                if eq2.is_number:
-                    b = checksol(u, u, eq2, minimal=True)
-                    if b is not None:
-                        if b:
-                            newresult.append(r)
-                        continue
+                b = checksol(u, u, eq2, minimal=True)
+                if b is not None:
+                    if b:
+                        newresult.append(r)
+                    continue
                 # search for a symbol amongst those available that
                 # can be solved for
                 ok_syms = (eq2.free_symbols - solved_syms) & legal

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -890,21 +890,23 @@ def test_issue_2574():
     assert checksol(eq, x, 2) == True
     assert checksol(eq, x, 2, numerical=False) is None
 
-@XFAIL  # depends on dict ordering
 def test_exclude():
-    R, C, Ri, Vout, V1, Rf, Vminus, Vplus, s = \
-        symbols('R, C, Ri, Vout, V1, Rf, Vminus, Vplus, s')
+    R, C, Ri, Vout, V1, Vminus, Vplus, s = \
+        symbols('R, C, Ri, Vout, V1, Vminus, Vplus, s')
+    Rf = symbols('Rf', positive=True) # to eliminate Rf = 0 soln
     eqs = [C*V1*s + Vplus*(-2*C*s - 1/R),
            Vminus*(-1/Ri - 1/Rf) + Vout/Rf,
            C*Vplus*s + V1*(-C*s - 1/R) + Vout/R,
            -Vminus + Vplus]
     assert solve(eqs, exclude=s*C*R) == [
-                {Vminus: Vplus,
-                 Vout: Vplus*(C**2*R**2*s**2 + 3*C*R*s + 1)/(C*R*s),
-                 V1: Vplus*(2*C*R*s + 1)/(C*R*s),
-                 Ri: C*R*Rf*s/(C*R*s + 1)**2}]
+        {
+        Rf: Ri*(C*R*s + 1)**2/(C*R*s),
+        Vminus: Vplus,
+        V1: Vplus*(2*C*R*s + 1)/(C*R*s),
+        Vout: Vplus*(C**2*R**2*s**2 + 3*C*R*s + 1)/(C*R*s)}]
     assert solve(eqs, exclude=[Vplus, s, C]) == [
-                {Vminus: Vplus,
-                 Vout: (V1**2 - V1*Vplus - Vplus**2)/(V1 - 2*Vplus),
-                 R: Vplus/(C*s*(V1 - 2*Vplus)),
-                 Ri: Rf*Vplus*(V1 - 2*Vplus)/(V1 - Vplus)**2}]
+        {
+        Rf: Ri*(V1 - Vplus)**2/(Vplus*(V1 - 2*Vplus)),
+        Vminus: Vplus,
+        Vout: (V1**2 - V1*Vplus - Vplus**2)/(V1 - 2*Vplus),
+        R: Vplus/(C*s*(V1 - 2*Vplus))}]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -176,7 +176,7 @@ def test_solve_rational():
     assert solve( ( x - y**3 )/( (y**2)*sqrt(1 - y**2) ), x) == [y**3]
 
 def test_linear_system():
-    n, t = symbols('n,t')
+    x, y, z, t, n = symbols('x, y, z, t, n')
 
     assert solve([x - 1, x - y, x - 2*y, y - 1], [x,y]) is None
 
@@ -194,6 +194,8 @@ def test_linear_system():
 
     assert solve([x + y + z + t, -z - t], x, y, z, t) == {x: -y, z: -t}
 
+def test_linear_system_function():
+    a = Function('a')
     assert solve([a(0, 0) + a(0, 1) + a(1, 0) + a(1, 1), -a(1, 0) - a(1, 1)],
         a(0, 0), a(0, 1), a(1, 0), a(1, 1)) == {a(1, 0): -a(1, 1), a(0, 0): -a(0, 1)}
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -213,15 +213,15 @@ def test_linear_systemLU():
 # in such a way that a different branch is chosen
 def test_tsolve():
     assert solve(exp(x)-3, x) == [log(3)]
-    assert solve((a*x+b)*(exp(x)-3), x) == [-b/a, log(3)]
+    assert set(solve((a*x+b)*(exp(x)-3), x)) == set([-b/a, log(3)])
     assert solve(cos(x)-y, x) == [acos(y)]
     assert solve(2*cos(x)-y,x)== [acos(y/2)]
     assert solve(Eq(cos(x), sin(x)), x) == [-3*pi/4, pi/4]
 
-    assert solve(exp(x) + exp(-x) - y, x) == [
+    assert set(solve(exp(x) + exp(-x) - y, x)) == set([
                         log(y/2 - sqrt(y**2 - 4)/2),
                         log(y/2 + sqrt(y**2 - 4)/2),
-                        ]
+                        ])
     assert solve(exp(x)-3, x) == [log(3)]
     assert solve(Eq(exp(x), 3), x) == [log(3)]
     assert solve(log(x)-3, x) == [exp(3)]
@@ -243,7 +243,7 @@ def test_tsolve():
     assert solve(2*x+5+log(3*x-2), x) == \
         [Rational(2,3) + LambertW(2*exp(-Rational(19, 3))/3)/2]
     assert solve(3*x+log(4*x), x) == [LambertW(Rational(3,4))/3]
-    assert solve((2*x+8)*(8+exp(x)), x) == [-4, log(8) + pi*I]
+    assert set(solve((2*x+8)*(8+exp(x)), x)) == set([S(-4), log(8) + pi*I])
     eq = 2*exp(3*x+4)-3
     ans = solve(eq, x)
     assert len(ans) == 3 and all(eq.subs(x, a).n(chop=True) == 0 for a in ans)
@@ -378,7 +378,7 @@ def test_issue_1694():
     assert len(ans) == 5 and all(eq.subs(x, a).n(chop=True) == 0 for a in ans)
     assert solve(log(x**2) - y**2/exp(x), x, y) == [{y: -sqrt(exp(x)*log(x**2))},
                                                     {y: sqrt(exp(x)*log(x**2))}]
-    assert solve(x**2*z**2 - z**2*y**2) == [{x: -y}, {x: y}]
+    assert solve(x**2*z**2 - z**2*y**2) in ([{x: y}, {x: -y}], [{x: -y}, {x: y}])
     assert solve((x - 1)/(1 + 1/(x - 1))) == []
     assert solve(x**(y*z) - x, x) == [1]
     raises(NotImplementedError, 'solve(log(x) - exp(x), x)')
@@ -439,8 +439,8 @@ def test_failing():
     assert solve((2*(3*x+4)**5 - 6*7**(3*x+9)).expand(), x)
 
 def test_checking():
-    assert solve(x*(x - y/x),x, check=False) == [0, -sqrt(y), sqrt(y)]
-    assert solve(x*(x - y/x),x, check=True) == [-sqrt(y), sqrt(y)]
+    assert set(solve(x*(x - y/x),x, check=False)) == set([sqrt(y), S(0), -sqrt(y)])
+    assert set(solve(x*(x - y/x),x, check=True)) == set([sqrt(y), -sqrt(y)])
     # {x: 0, y: 4} sets denominator to 0 in the following so system should return None
     assert solve((1/(1/x + 2), 1/(y - 3) - 1)) is None
     # 0 sets denominator of 1/x to zero so [] is returned
@@ -890,6 +890,7 @@ def test_issue_2574():
     assert checksol(eq, x, 2) == True
     assert checksol(eq, x, 2, numerical=False) is None
 
+@XFAIL  # depends on dict ordering
 def test_exclude():
     R, C, Ri, Vout, V1, Rf, Vminus, Vplus, s = \
         symbols('R, C, Ri, Vout, V1, Rf, Vminus, Vplus, s')

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -79,9 +79,8 @@ def test_core_basic():
         check(c)
 
 def test_core_symbol():
-    for c in (Dummy, Dummy("x", False),
-              Symbol, Symbol("x", False),
-              Wild, Wild("x")):
+    for c in (Dummy, Dummy("x", commutative=False), Symbol,
+            Symbol("x", commutative=False), Wild, Wild("x")):
         check(c)
 
 def test_core_numbers():
@@ -298,7 +297,7 @@ from sympy.polys.domains import (
 )
 
 def test_polys():
-    x = Symbol("x")
+    x = Symbol("X")
 
     ZZ = PythonIntegerRing()
     QQ = SymPyRationalField()


### PR DESCRIPTION
This removes the 'is_commutative' slot from Symbol and allows the assumption system to handle it correctly, cf. [issue 2696](http://code.google.com/p/sympy/issues/detail?id=2696).

Note that the pull request isn't quite ready yet: there are still failures caused by the fact that this changes the hash.
