### PR TITLE
fixed rank_trotterjohnson, added unrank_trotterjohnson

### DIFF
--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -46,7 +46,7 @@ def alternating(n):
     """
     for perm in variations(range(n), n):
         p = Permutation(perm)
-        if p.is_even:
+        if p.is_even():
             yield p
 
 def dihedral(n):

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -4,6 +4,7 @@ from sympy.utilities.iterables import rotate_left, flatten
 from sympy.polys.polytools import lcm
 from sympy.matrices import Matrix, zeros
 from sympy.mpmath.libmp.libintmath import ifac
+from sympy.core.numbers import Integer
 
 import itertools, random
 
@@ -246,23 +247,34 @@ don\'t match.")
         >>> p**4
         Permutation([0, 1, 2, 3])
         """
+        rn = range(self.size)
         n = int(n)
         if n == 0:
-            return Permutation(range(self.size))
+            return Permutation(rn)
         if n < 0:
             return pow(~self, -n)
-        if n < 8:
-            return reduce(lambda x, y: x*y, [self]*n)
-        p = Permutation(range(self.size))
-        while 1:
-            if n&1:
-                p = p*self
-                n -= 1
-                if not n:
-                    break
-            self = self*self
-            n = n // 2
-        return p
+        a = self.array_form
+        if n == 2:
+            b = [a[a[i]] for i in rn]
+        elif n == 3:
+            b = [a[a[a[i]]] for i in rn]
+        elif n == 4:
+            b = [a[a[a[a[i]]]] for i in rn]
+        else:
+            b = range(self.size)
+            while 1:
+                if n&1:
+                    b = [b[a[i]] for i in rn]
+                    n -= 1
+                    if not n:
+                        break
+                if n%4 == 0:
+                    a = [a[a[a[a[i]]]] for i in rn]
+                    n = n // 4
+                elif n%2 == 0:
+                    a = [a[a[i]] for i in rn]
+                    n = n // 2
+        return Permutation(b)
 
     def __invert__(self):
         """
@@ -338,7 +350,7 @@ don\'t match.")
         enforce lexicographic order [3].
 
 
-        Examples
+        Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3])
         >>> p.rank_nonlex()
@@ -393,8 +405,14 @@ don\'t match.")
     def cardinality(self):
         """
         Returns the number of all possible permutations.
+
+        Examples:
+        >>> from sympy.combinatorics.permutations import Permutation
+        >>> p = Permutation([0,1,2,3])
+        >>> p.cardinality
+        24
         """
-        return ifac(self.size)
+        return Integer(ifac(self.size))
 
     @property
     def parity(self):

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -167,6 +167,7 @@ class Permutation(Basic):
         permutation. The Lehmer code is nothing but the
         inversion vector of a permutation. In this scheme
         the identity permutation is like a zero element.
+        # TODO add a reference
 
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
@@ -183,8 +184,8 @@ class Permutation(Basic):
         if self.size != other.size:
             raise ValueError("The permutations must be of equal size.")
         n = self.size
-        a = self.inversion_vector
-        b = other.inversion_vector
+        a = self.inversion_vector()
+        b = other.inversion_vector()
         result_inv = [(a[i] + b[i]) % (n - i) for i in xrange(n - 1)]
         return Permutation.from_inversion_vector(result_inv)
 
@@ -211,8 +212,8 @@ class Permutation(Basic):
         if self.size != other.size:
             raise ValueError("The permutations must be of equal size.")
         n = self.size
-        a = self.inversion_vector
-        b = other.inversion_vector
+        a = self.inversion_vector()
+        b = other.inversion_vector()
         result_inv = [(a[i] - b[i]) % (n - i) for i in xrange(n - 1)]
         return Permutation.from_inversion_vector(result_inv)
 
@@ -376,7 +377,6 @@ don\'t match.")
         r = rank1(len(perm), perm, inv_perm)
         return r
 
-    @property
     def rank(self):
         """
         Returns the lexicographic rank of the permutation.
@@ -384,10 +384,10 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3])
-        >>> p.rank
+        >>> p.rank()
         0
         >>> p = Permutation([3,2,1,0])
-        >>> p.rank
+        >>> p.rank()
         23
         """
         rank = 0
@@ -417,7 +417,6 @@ don\'t match.")
         """
         return Integer(ifac(self.size))
 
-    @property
     def parity(self):
         """
         Computes the parity of a permutation.
@@ -429,10 +428,10 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3])
-        >>> p.parity
+        >>> p.parity()
         0
         >>> p = Permutation([3,2,0,1])
-        >>> p.parity
+        >>> p.parity()
         1
         """
         if self._cyclic_form is not None:
@@ -452,7 +451,6 @@ don\'t match.")
         return (self.size - c) % 2
 
 
-    @property
     def is_even(self):
         """
         Checks if a permutation is even.
@@ -460,15 +458,14 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3])
-        >>> p.is_even
+        >>> p.is_even()
         True
         >>> p = Permutation([3,2,1,0])
-        >>> p.is_odd
-        False
+        >>> p.is_even()
+        True
         """
-        return S(self.parity).is_even
+        return S(self.parity()).is_even
 
-    @property
     def is_odd(self):
         """
         Checks if a permutation is odd.
@@ -476,13 +473,13 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3])
-        >>> p.is_odd
+        >>> p.is_odd()
         False
         >>> p = Permutation([3,2,0,1])
-        >>> p.is_odd
+        >>> p.is_odd()
         True
         """
-        return S(self.parity).is_odd
+        return S(self.parity()).is_odd
 
     @property
     def is_Singleton(self):
@@ -494,9 +491,22 @@ don\'t match.")
 
     @property
     def is_Identity(self):
-        return self.size == len(self.cyclic_form)
+        """
+        >>> from sympy.combinatorics.permutations import Permutation
+        >>> p = Permutation([[0],[1],[2]])
+        >>> p.is_Identity
+        True
+        >>> p = Permutation([0,1,2])
+        >>> p.is_Identity
+        True
+        >>> p = Permutation([0,2,1])
+        >>> p.is_Identity
+        False
+        """
+        if self.cyclic_form:
+            return self.size == len(self.cyclic_form)
+        return self.array_form == range(self.size)
 
-    @property
     def ascents(self):
         """
         Returns the positions of ascents in a permutation, ie, the location
@@ -505,14 +515,13 @@ don\'t match.")
         Example:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([4,0,1,3,2])
-        >>> p.ascents
+        >>> p.ascents()
         [1, 2]
         """
         a = self.array_form
         pos = [i for i in xrange(self.size-1) if a[i] < a[i+1]]
         return pos
 
-    @property
     def descents(self):
         """
         Returns the positions of descents in a permutation, ie, the location
@@ -521,14 +530,13 @@ don\'t match.")
         Example:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([4,0,1,3,2])
-        >>> p.descents
+        >>> p.descents()
         [0, 3]
         """
         a = self.array_form
         pos = [i for i in xrange(self.size-1) if a[i] > a[i+1]]
         return pos
 
-    @property
     def max(self):
         """
         The maximum element moved by the permutation.
@@ -536,7 +544,7 @@ don\'t match.")
         Example:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([1,0,2,3,4])
-        >>> p.max
+        >>> p.max()
         1
         """
         max = 0
@@ -546,7 +554,6 @@ don\'t match.")
                 max = a[i]
         return max
 
-    @property
     def min(self):
         """
         The minimum element moved by the permutation.
@@ -554,7 +561,7 @@ don\'t match.")
         Example:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,4,3,2])
-        >>> p.min
+        >>> p.min()
         2
         """
         min = self.size
@@ -564,7 +571,6 @@ don\'t match.")
                 min = a[i]
         return min
 
-    @property
     def inversions(self):
         """
         Computes the number of inversions of a permutation.
@@ -574,13 +580,13 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3,4,5])
-        >>> p.inversions
+        >>> p.inversions()
         0
 
         In the cyclic form
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([[4,0,2],[3,5],[1]])
-        >>> p.inversions
+        >>> p.inversions()
         8
         """
         inversions = 0
@@ -593,7 +599,6 @@ don\'t match.")
                     inversions += 1
         return inversions
 
-    @property
     def signature(self):
         """
         Gives the signature of the permutation needed to place the
@@ -604,15 +609,14 @@ don\'t match.")
         Example:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2])
-        >>> p.signature
+        >>> p.signature()
         1
         >>> q = Permutation([0,2,1])
-        >>> q.signature
+        >>> q.signature()
         -1
         """
-        return (-1)**self.inversions
+        return (-1)**self.inversions()
 
-    @property
     def order(self):
         """
         Computes the order of a permutation.
@@ -623,14 +627,13 @@ don\'t match.")
         Example:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([3,1,5,2,4,0])
-        >>> p.order
+        >>> p.order()
         4
-        >>> (p**(p.order))
+        >>> (p**(p.order()))
         Permutation([0, 1, 2, 3, 4, 5])
         """
         return reduce(lcm,[1]+[len(cycle) for cycle in self.cyclic_form])
 
-    @property
     def length(self):
         """
         Returns the number of integers moved by a permutation.
@@ -641,13 +644,11 @@ don\'t match.")
                 length += 1
         return length
 
-    @property
     def is_Positive(self):
-        return self.signature > 0
+        return self.signature() > 0
 
-    @property
     def is_Negative(self):
-        return self.signature < 0
+        return self.signature() < 0
 
     @property
     def cycles(self):
@@ -657,7 +658,6 @@ don\'t match.")
         """
         return len(self.cyclic_form)
 
-    @property
     def index(self):
         """
         Returns the index of a permutation.
@@ -669,7 +669,7 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([3, 0, 2, 1, 4])
-        >>> p.index
+        >>> p.index()
         2
         """
         return sum([j for j in xrange(self.size - 1) if
@@ -724,7 +724,6 @@ don\'t match.")
             cycles.append([next_elem])
         return cycles
 
-    @property
     def inversion_vector(self):
         """
         Gets the inversion vector of the permutation.
@@ -736,10 +735,10 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([4,8,0,7,1,5,3,6,2])
-        >>> p.inversion_vector
+        >>> p.inversion_vector()
         [4, 7, 0, 5, 0, 2, 1, 1]
         >>> p = Permutation([3,2,1,0])
-        >>> p.inversion_vector
+        >>> p.inversion_vector()
         [3, 2, 1]
         """
         n = self.size
@@ -754,7 +753,6 @@ don\'t match.")
             inversion_vector[i] = val
         return inversion_vector
 
-    @property
     def rank_trotterjohnson(self):
         """
         Returns the Trotter Johnson rank, which we get from the minimal
@@ -763,14 +761,14 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([0,1,2,3])
-        >>> p.rank_trotterjohnson
+        >>> p.rank_trotterjohnson()
         0
         >>> p = Permutation([0,2,1,3])
-        >>> p.rank_trotterjohnson
+        >>> p.rank_trotterjohnson()
         7
 
         >>> p = Permutation([2, 3, 1, 0])
-        >>> p.rank_trotterjohnson
+        >>> p.rank_trotterjohnson()
         13
         """
         if self.array_form == [] or self.is_Identity:
@@ -1015,7 +1013,7 @@ don\'t match.")
 
         >>> from sympy.combinatorics.permutations import Permutation
         >>> a = Permutation([3,5,1,4,2,0,7,6])
-        >>> Permutation.from_inversion_vector(a.inversion_vector) == a
+        >>> Permutation.from_inversion_vector(a.inversion_vector()) == a
         True
         """
         size = len(inversion) + 1
@@ -1057,7 +1055,7 @@ don\'t match.")
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
         >>> a = Permutation.unrank_lex(5,10)
-        >>> a.rank
+        >>> a.rank()
         10
         >>> a
         Permutation([0, 2, 4, 1, 3])

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -17,12 +17,12 @@ class Permutation(Basic):
 
     A representation of a permutation as a product of permutation cycles
     is unique (up to the ordering of the cycles). An example of a cyclic
-    decomposition is the permutation [4, 2, 1, 3] of the set [1, 2, 3, 4].
-    This is denoted as [[2], [1, 4, 3]], corresponding to the disjoint
-    permutation cycles [2] and [1, 4, 3]. We can choose the cyclic form as
+    decomposition is the permutation [3, 1, 0, 2] of the set [0, 1, 2, 3].
+    This is denoted as [[1], [0, 3, 2]], corresponding to the disjoint
+    permutation cycles [1] and [0, 3, 2]. We can choose the cyclic form as
     we want since the cycles are disjoint and can therefore be specified
     in any order and a rotation of a given cycle specifies the same cycle [1]
-    Therefore, (431)(2), (314)(2), (143)(2), (2)(431), (2)(314), and (2)(143)
+    Therefore, (320)(1), (203)(1), (032)(1), (1)(320), (1)(203), and (1)(032)
     all describe the same permutation.
 
     Another notation that explicitly identifies the positions occupied by
@@ -69,23 +69,28 @@ class Permutation(Basic):
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([[2,0],[3,1]])
         >>> p.array_form
-        [1, 3, 0, 2]
+        [2, 3, 0, 1]
+        >>> Permutation([[2,0,3,1]]).array_form
+        [3, 2, 0, 1]
+        >>> Permutation([2,0,3,1]).array_form
+        [2, 0, 3, 1]
         """
         if self._array_form is not None:
             return self._array_form
         if not isinstance(self.args[0][0], list):
             self._array_form = self.args[0]
             return self._array_form
+        size = 0
         cycles = self.args[0]
-        linear_form = []
-        for cycle in cycles:
-            min_element = min(cycle)
-            while cycle[0] != min_element:
-                cycle = rotate_left(cycle, 1)
-            linear_form.append(cycle)
-        linear_form.sort(key=lambda t: -t[0])
-        self._array_form = list(itertools.chain(*linear_form))
-        return self._array_form
+        for c in cycles:
+            size += len(c)
+        perm = [None]*size
+        for c in cycles:
+            for i in range(len(c)-1):
+                perm[c[i]] = c[i+1]
+            perm[c[-1]] = c[0]
+        self._array_form = perm
+        return perm
 
     @property
     def cyclic_form(self):
@@ -232,7 +237,7 @@ class Permutation(Basic):
         converted to an array form and then multiplied.
         >>> q = Permutation([[1,3,2],[0]])
         >>> p*q
-        Permutation([2, 0, 3, 1])
+        Permutation([1, 0, 2, 3])
         """
         if self.size != other.size:
             raise ValueError("The number of elements in the permutations \
@@ -291,7 +296,7 @@ don\'t match.")
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([[2,0],[3,1]])
         >>> ~p
-        Permutation([2, 0, 3, 1])
+        Permutation([2, 3, 0, 1])
         >>> p*(~p) == Permutation([0,1,2,3])
         True
         """
@@ -309,7 +314,7 @@ don\'t match.")
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([[2,0],[3,1]])
         >>> p(3)
-        2
+        1
         """
         if not isinstance(arg, int):
             raise ValueError("Arguments must be integers.")
@@ -587,7 +592,7 @@ don\'t match.")
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([[4,0,2],[3,5],[1]])
         >>> p.inversions()
-        8
+        7
         """
         inversions = 0
         a = self.array_form

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -158,6 +158,7 @@ class Permutation(Basic):
         ret_obj._cyclic_form, ret_obj._array_form = cform, aform
         return ret_obj
 
+
     def __add__(self, other):
         """
         Routine for addition of permutations.
@@ -237,7 +238,8 @@ class Permutation(Basic):
 don\'t match.")
         a = self.array_form
         b = other.array_form
-        return Permutation([a[i] for i in b])
+        perm = [a[i] for i in b]
+        return _new_from_array_form(perm)
 
     def __pow__(self, n):
         """
@@ -275,7 +277,7 @@ don\'t match.")
                 elif n%2 == 0:
                     a = [a[i] for i in a]
                     n = n // 2
-        return Permutation(b)
+        return _new_from_array_form(b)
 
     def __invert__(self):
         """
@@ -296,7 +298,7 @@ don\'t match.")
         a = self.array_form
         for i in xrange(self.size):
             inv_form[a[i]] = i
-        return Permutation(inv_form)
+        return _new_from_array_form(inv_form)
 
     def __call__(self, arg):
         """
@@ -343,7 +345,7 @@ don\'t match.")
         n = int(n)
         r = r % ifac(n)
         unrank1(n, r, id_perm)
-        return Permutation(id_perm)
+        return _new_from_array_form(id_perm)
 
     def rank_nonlex(self, inv_perm = None):
         """
@@ -816,7 +818,7 @@ don\'t match.")
                     perm[i] = perm[i-1]
                 perm[k] = j-1
             r2 = r1
-        return Permutation(perm)
+        return _new_from_array_form(perm)
 
     def get_precedence_matrix(self):
         """
@@ -1027,7 +1029,7 @@ don\'t match.")
         except IndexError:
             raise ValueError("The inversion vector is not valid.")
         perm.extend(N)
-        return Permutation(perm)
+        return _new_from_array_form(perm)
 
     @classmethod
     def random_permutation(self, n):
@@ -1045,7 +1047,7 @@ don\'t match.")
         """
         perm_array = range(n)
         random.shuffle(perm_array)
-        return Permutation(perm_array)
+        return _new_from_array_form(perm_array)
 
     @classmethod
     def unrank_lex(self, size, rank):
@@ -1071,4 +1073,22 @@ don\'t match.")
                 if perm_array[j] > d-1:
                     perm_array[j] += 1
             psize = new_psize
-        return Permutation(perm_array)
+        return _new_from_array_form(perm_array)
+
+def _new_from_array_form(perm):
+    """
+    factory function to produce a Permutation object from a list;
+    the list is bound to the _array_form attribute, so it must
+    not be modified; this method is meant for internal use only;
+    the list a is supposed to be generated as a temporary value in a method,
+    so p = _new_from_array_form(a) is the only object to hold a
+    reference to a.
+    >>> from sympy.combinatorics.permutations import _new_from_array_form
+    >>> a = [2,1,3,0]
+    >>> p = _new_from_array_form(a)
+    >>> p
+    Permutation([2, 1, 3, 0])
+    """
+    p = Basic.__new__(Permutation, perm)
+    p._array_form = perm
+    return p

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -34,6 +34,9 @@ class Permutation(Basic):
 
     Permutations are commonly denoted in lexicographic or transposition order.
 
+    The product of two permutations a and q is defined as their composition as
+    functions, (p*q)(i) = p(q(i)), see [6].
+
     [1] Skiena, S. 'Permutations.' 1.1 in Implementing Discrete Mathematics
         Combinatorics and Graph Theory with Mathematica.
         Reading, MA: Addison-Wesley, pp. 3-16, 1990.
@@ -47,6 +50,7 @@ class Permutation(Basic):
     [5] Graham, R. L.; Knuth, D. E.; and Patashnik, O.
         Concrete Mathematics: A Foundation for Computer Science, 2nd ed.
         Reading, MA: Addison-Wesley, 1994.
+    [6] http://en.wikipedia.org/wiki/Permutation#Product_and_inverse
     """
     is_Permutation = True
 
@@ -217,24 +221,22 @@ class Permutation(Basic):
 
         Examples:
         >>> from sympy.combinatorics.permutations import Permutation
-        >>> p = Permutation([0,1,2,3])
-        >>> q = Permutation([3,2,1,0])
+        >>> p = Permutation([1,2,3,0])
+        >>> q = Permutation([3,2,0,1])
         >>> p*q
-        Permutation([3, 2, 1, 0])
+        Permutation([0, 3, 1, 2])
 
         If one of the permutations is in a cyclic form then it is first
         converted to an array form and then multiplied.
-        >>> from sympy.combinatorics.permutations import Permutation
         >>> q = Permutation([[1,3,2],[0]])
-        >>> p = Permutation([0,3,1,2])
         >>> p*q
-        Permutation([1, 0, 3, 2])
+        Permutation([2, 0, 3, 1])
         """
         if self.size != other.size:
             raise ValueError("The number of elements in the permutations \
 don\'t match.")
-        a = other.array_form
-        b = self.array_form
+        a = self.array_form
+        b = other.array_form
         return Permutation([a[i] for i in b])
 
     def __pow__(self, n):

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -235,7 +235,7 @@ class Permutation(Basic):
 don\'t match.")
         a = other.array_form
         b = self.array_form
-        return Permutation([a[b[i]] for i in range(self.size)])
+        return Permutation([a[i] for i in b])
 
     def __pow__(self, n):
         """
@@ -247,32 +247,31 @@ don\'t match.")
         >>> p**4
         Permutation([0, 1, 2, 3])
         """
-        rn = range(self.size)
         n = int(n)
         if n == 0:
-            return Permutation(rn)
+            return Permutation(range(self.size))
         if n < 0:
             return pow(~self, -n)
         a = self.array_form
         if n == 2:
-            b = [a[a[i]] for i in rn]
+            b = [a[i] for i in a]
         elif n == 3:
-            b = [a[a[a[i]]] for i in rn]
+            b = [a[a[i]] for i in a]
         elif n == 4:
-            b = [a[a[a[a[i]]]] for i in rn]
+            b = [a[a[a[i]]] for i in a]
         else:
             b = range(self.size)
             while 1:
                 if n&1:
-                    b = [b[a[i]] for i in rn]
+                    b = [b[i] for i in a]
                     n -= 1
                     if not n:
                         break
                 if n%4 == 0:
-                    a = [a[a[a[a[i]]]] for i in rn]
+                    a = [a[a[a[i]]] for i in a]
                     n = n // 4
                 elif n%2 == 0:
-                    a = [a[a[i]] for i in rn]
+                    a = [a[i] for i in a]
                     n = n // 2
         return Permutation(b)
 

--- a/sympy/combinatorics/tests/test_generators.py
+++ b/sympy/combinatorics/tests/test_generators.py
@@ -21,12 +21,6 @@ def test_generators():
                                     Permutation([2, 0, 1, 3]), Permutation([2, 1, 3, 0]), \
                                     Permutation([2, 3, 0, 1]), Permutation([3, 0, 2, 1]), \
                                     Permutation([3, 1, 0, 2]), Permutation([3, 2, 1, 0])]
-    assert list(alternating(4)) == [Permutation([0, 1, 2, 3]), Permutation([0, 2, 3, 1]), \
-                                    Permutation([0, 3, 1, 2]), Permutation([1, 0, 3, 2]), \
-                                    Permutation([1, 2, 0, 3]), Permutation([1, 3, 2, 0]), \
-                                    Permutation([2, 0, 1, 3]), Permutation([2, 1, 3, 0]), \
-                                    Permutation([2, 3, 0, 1]), Permutation([3, 0, 2, 1]), \
-                                    Permutation([3, 1, 0, 2]), Permutation([3, 2, 1, 0])]
     assert list(symmetric(3)) == [Permutation([0, 1, 2]), Permutation([0, 2, 1]), Permutation([1, 0, 2]), \
                                   Permutation([1, 2, 0]), Permutation([2, 0, 1]), Permutation([2, 1, 0])]
     assert list(symmetric(4)) == [Permutation([0, 1, 2, 3]), Permutation([0, 1, 3, 2]), Permutation([0, 2, 1, 3]), \

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -5,6 +5,8 @@ def test_Permutation():
     p = Permutation([2, 5, 1, 6, 3, 0, 4])
     q = Permutation([[1, 4, 5], [2, 0, 6], [3]])
 
+    assert p.cardinality == 5040
+    assert q.cardinality == 5040
     assert q.cycles == 3
     assert p*q == Permutation([4, 6, 1, 2, 5, 3, 0])
     assert q*p == Permutation([6, 5, 3, 0, 2, 4, 1])
@@ -115,8 +117,12 @@ def test_Permutation():
     assert q.index == 8
     assert r.index == 3
 
-    assert q.rank_trotterjohnson == 259
-    assert p.rank_trotterjohnson == 1087
+    a = [Permutation.unrank_trotterjohnson(4, i).array_form for i in range(5)]
+    assert a == [[0,1,2,3], [0,1,3,2], [0,3,1,2], [3,0,1,2], [3,0,2,1] ]
+    assert [Permutation(pa).rank_trotterjohnson for pa in a] == range(5)
+
+    assert q.rank_trotterjohnson == 2283
+    assert p.rank_trotterjohnson == 3389
 
     assert p.get_precedence_distance(q) == q.get_precedence_distance(p)
     assert p.get_adjacency_distance(q) == p.get_adjacency_distance(q)

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -30,13 +30,15 @@ def test_Permutation():
     assert len(p.atoms()) == 7
     assert q.atoms() == set([0, 1, 2, 3, 4, 5, 6])
 
-    assert p.inversion_vector == [2, 4, 1, 3, 1, 0]
-    assert q.inversion_vector == [3, 1, 2, 2, 0, 1]
+    assert p.inversion_vector() == [2, 4, 1, 3, 1, 0]
+    assert q.inversion_vector() == [3, 1, 2, 2, 0, 1]
 
-    assert Permutation.from_inversion_vector(p.inversion_vector) == p
-    assert Permutation.from_inversion_vector(q.inversion_vector).array_form\
+    assert Permutation.from_inversion_vector(p.inversion_vector()) == p
+    assert Permutation.from_inversion_vector(q.inversion_vector()).array_form\
            == q.array_form
 
+    assert Permutation([0, 4, 1, 3, 2]).parity() == 0
+    assert Permutation([0, 1, 4, 3, 2]).parity() == 1
     s = Permutation([0])
 
     assert s.is_Singleton
@@ -47,13 +49,13 @@ def test_Permutation():
     assert (p*(~p)).is_Identity
     assert (~p)**13 == Permutation([5, 2, 0, 4, 6, 1, 3])
     assert ~(r**2).is_Identity
-    assert p.max == 6
-    assert p.min == 0
+    assert p.max() == 6
+    assert p.min() == 0
 
     q = Permutation([[4, 1, 2, 3], [0, 5, 6]])
 
-    assert q.max == 4
-    assert q.min == 0
+    assert q.max() == 4
+    assert q.min() == 0
 
     assert Permutation([]).rank_nonlex() == 0
     prank = p.rank_nonlex()
@@ -73,56 +75,56 @@ def test_Permutation():
 
     assert [Permutation(pa).rank_nonlex() for pa in a] == range(24)
 
-    assert q.rank == 870
-    assert p.rank == 1964
+    assert q.rank() == 870
+    assert p.rank() == 1964
 
     p = Permutation([1, 5, 2, 0, 3, 6, 4])
     q = Permutation([[2, 3, 5], [1, 0, 6], [4]])
 
-    assert p.ascents == [0, 3, 4]
-    assert q.ascents == [1, 2, 4]
-    assert r.ascents == []
+    assert p.ascents() == [0, 3, 4]
+    assert q.ascents() == [1, 2, 4]
+    assert r.ascents() == []
 
-    assert p.descents == [1, 2, 5]
-    assert q.descents == [0, 3, 5]
-    assert Permutation(r.descents).is_Identity
+    assert p.descents() == [1, 2, 5]
+    assert q.descents() == [0, 3, 5]
+    assert Permutation(r.descents()).is_Identity
 
-    assert p.inversions == 7
-    assert p.signature == -1
-    assert q.inversions == 11
-    assert q.signature == -1
-    assert (p*(~p)).inversions == 0
-    assert (p*(~p)).signature == 1
+    assert p.inversions() == 7
+    assert p.signature() == -1
+    assert q.inversions() == 11
+    assert q.signature() == -1
+    assert (p*(~p)).inversions() == 0
+    assert (p*(~p)).signature() == 1
 
-    assert p.order == 6
-    assert q.order == 3
-    assert (p**(p.order)).is_Identity
+    assert p.order() == 6
+    assert q.order() == 3
+    assert (p**(p.order())).is_Identity
 
-    assert p.length == 6
-    assert q.length == 7
-    assert r.length == 4
+    assert p.length() == 6
+    assert q.length() == 7
+    assert r.length() == 4
 
-    assert not p.is_Positive
-    assert p.is_Negative
-    assert not q.is_Positive
-    assert q.is_Negative
-    assert r.is_Positive
-    assert not r.is_Negative
+    assert not p.is_Positive()
+    assert p.is_Negative()
+    assert not q.is_Positive()
+    assert q.is_Negative()
+    assert r.is_Positive()
+    assert not r.is_Negative()
 
     assert p.runs() == [[1, 5], [2], [0, 3, 6], [4]]
     assert q.runs() == [[4], [2, 3, 5], [0, 6], [1]]
     assert r.runs() == [[3], [2], [1], [0]]
 
-    assert p.index == 8
-    assert q.index == 8
-    assert r.index == 3
+    assert p.index() == 8
+    assert q.index() == 8
+    assert r.index() == 3
 
     a = [Permutation.unrank_trotterjohnson(4, i).array_form for i in range(5)]
     assert a == [[0,1,2,3], [0,1,3,2], [0,3,1,2], [3,0,1,2], [3,0,2,1] ]
-    assert [Permutation(pa).rank_trotterjohnson for pa in a] == range(5)
+    assert [Permutation(pa).rank_trotterjohnson() for pa in a] == range(5)
 
-    assert q.rank_trotterjohnson == 2283
-    assert p.rank_trotterjohnson == 3389
+    assert q.rank_trotterjohnson() == 2283
+    assert p.rank_trotterjohnson() == 3389
 
     assert p.get_precedence_distance(q) == q.get_precedence_distance(p)
     assert p.get_adjacency_distance(q) == p.get_adjacency_distance(q)
@@ -138,11 +140,11 @@ def test_josephus():
     assert Permutation.josephus(1, 5, 1).is_Identity
 
 def test_unrank_lex():
-    assert Permutation.unrank_lex(5, 10).rank == 10
-    assert Permutation.unrank_lex(15, 225).rank == 225
+    assert Permutation.unrank_lex(5, 10).rank() == 10
+    assert Permutation.unrank_lex(15, 225).rank() == 225
     assert Permutation.unrank_lex(10, 0).is_Identity
     p = Permutation.unrank_lex(4, 23)
-    assert p.rank == 23
+    assert p.rank() == 23
     assert p.array_form == [3, 2, 1, 0]
 
 def test_args():

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -8,8 +8,8 @@ def test_Permutation():
     assert p.cardinality == 5040
     assert q.cardinality == 5040
     assert q.cycles == 3
-    assert p*q == Permutation([4, 6, 1, 2, 5, 3, 0])
-    assert q*p == Permutation([6, 5, 3, 0, 2, 4, 1])
+    assert q*p == Permutation([4, 6, 1, 2, 5, 3, 0])
+    assert p*q == Permutation([6, 5, 3, 0, 2, 4, 1])
 
     assert q.array_form == [3, 1, 4, 5, 0, 6, 2]
     assert p.cyclic_form == [[3, 6, 4], [0, 2, 1, 5]]

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -3,14 +3,17 @@ from sympy.utilities.pytest import raises
 
 def test_Permutation():
     p = Permutation([2, 5, 1, 6, 3, 0, 4])
-    q = Permutation([[1, 4, 5], [2, 0, 6], [3]])
+    q = Permutation([[1], [0, 3, 5, 6, 2, 4]])
 
+    assert Permutation(p.cyclic_form).array_form == p.array_form
     assert p.cardinality == 5040
     assert q.cardinality == 5040
-    assert q.cycles == 3
+    assert q.cycles == 2
     assert q*p == Permutation([4, 6, 1, 2, 5, 3, 0])
     assert p*q == Permutation([6, 5, 3, 0, 2, 4, 1])
 
+    assert (Permutation([[1,2,3],[0,4]])*Permutation([[1,2,4],[0],[3]])).cyclic_form == \
+        [[1, 3], [0, 4, 2]]
     assert q.array_form == [3, 1, 4, 5, 0, 6, 2]
     assert p.cyclic_form == [[3, 6, 4], [0, 2, 1, 5]]
 
@@ -52,7 +55,7 @@ def test_Permutation():
     assert p.max() == 6
     assert p.min() == 0
 
-    q = Permutation([[4, 1, 2, 3], [0, 5, 6]])
+    q = Permutation([[6], [5], [0, 1, 2, 3, 4]])
 
     assert q.max() == 4
     assert q.min() == 0
@@ -79,7 +82,7 @@ def test_Permutation():
     assert p.rank() == 1964
 
     p = Permutation([1, 5, 2, 0, 3, 6, 4])
-    q = Permutation([[2, 3, 5], [1, 0, 6], [4]])
+    q = Permutation([[1, 2, 3, 5, 6], [0, 4]])
 
     assert p.ascents() == [0, 3, 4]
     assert q.ascents() == [1, 2, 4]
@@ -97,7 +100,7 @@ def test_Permutation():
     assert (p*(~p)).signature() == 1
 
     assert p.order() == 6
-    assert q.order() == 3
+    assert q.order() == 10
     assert (p**(p.order())).is_Identity
 
     assert p.length() == 6


### PR DESCRIPTION
rank_trotterjohnson gives wrong results; for instance

```
>>> from sympy.combinatorics.permutations import Permutation
>>> Permutation([0,1,2,3]).rank_trotterjohnson
0
>>> Permutation([3,0,1,2]).rank_trotterjohnson
0
```

In this pull request rank_trotterjohnson and unrank_trotterjohnson
are taken from 
D. L. Kreher, D. R. Stinson 'Combinatorial Algorithms' CRC Press, 1999'

The following example agrees with this reference

```
>>> from sympy.combinatorics.permutations import Permutation
>>> [Permutation.unrank_trotterjohnson(4, i).array_form for i in range(24)]
[[0, 1, 2, 3], [0, 1, 3, 2], [0, 3, 1, 2], [3, 0, 1, 2], [3, 0, 2, 1], [0, 3, 2, 1], [0, 2, 3, 1], [0, 2, 1, 3], [2, 0, 1, 3], [2, 0, 3, 1], [2, 3, 0, 1], [3, 2, 0, 1], [3, 2, 1, 0], [2, 3, 1, 0], [2, 1, 3, 0], [2, 1, 0, 3], [1, 2, 0, 3], [1, 2, 3, 0], [1, 3, 2, 0], [3, 1, 2, 0], [3, 1, 0, 2], [1, 3, 0, 2], [1, 0, 3, 2], [1, 0, 2, 3]]
>>> [Permutation(p).rank_trotterjohnson for p in _] == range(24)
True
```

There are also the following changes:

Added the `cardinality` property.

`__pow__`  is generalized to work also for 0 or negative power; used
binary splitting for large powers.

Used `ifac` instead of factorial, since it is likely that if `factorial(n)`
is called once it is called many times, in which case `ifac` uses a cached
value.

Optimized  `parity`  in the case in which the cyclic form is available.

Made some trivial optimizations; the biggest speedup is in  `__add__`
e.g.

```
from time import time
from sympy.combinatorics.permutations import Permutation
from sympy.functions import factorial
N = 8
factN = factorial(N)

a = [Permutation.unrank_nonlex(N, i) for i in range(factN)]

b = []
t0 = time()
for i in range(factN-1):
    b.append(a[i]+a[i+1])
t1 = time()
print b
print '%.4f' % (t1-t0)
```

is almost 9x faster on my computer.

@saptman
Could you add a reference in  `__add__`? I have not find one.
