### PR TITLE
[printing] Move unicode specifics to pretty_symbology.

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -6,7 +6,8 @@ from sympy.printing.str import sstr
 
 from stringpict import prettyForm, stringPict
 from pretty_symbology import xstr, hobj, vobj, xobj, xsym, pretty_symbol,\
-        pretty_atom, pretty_use_unicode, pretty_try_use_unicode, greek, U
+        pretty_atom, pretty_use_unicode, pretty_try_use_unicode, greek, U, \
+        annotated
 
 from sympy.core.compatibility import cmp_to_key
 
@@ -655,10 +656,9 @@ class PrettyPrinter(Printer):
         if self._use_unicode:
             pic = (2, 0, 2, u'\u250c\u2500\n\u251c\u2500\n\u2575')
         else:
-            pic = ((3, 0, 3, ' _\n|_\n|\n'))
+            pic = (3, 0, 3, ' _\n|_\n|\n')
 
-        add = 0
-        sz, t, b, img = pic
+        sz, t, b, add, img = annotated('F')
         F = prettyForm('\n' * (above - t) + img + '\n' * (below - b),
                        baseline = above + sz)
         add = (sz+1)//2
@@ -719,14 +719,7 @@ class PrettyPrinter(Printer):
         above = D.height()//2 - 1
         below = D.height() - above - 1
 
-        if self._use_unicode:
-            pic = (3, 0, 3, 1,
-                   u'\u256d\u2500\u256e\n\u2502\u2576\u2510\n\u2570\u2500\u256f')
-        else:
-            pic = (3, 0, 3, 1, ' __\n/__\n\_|')
-
-        add = 0
-        sz, t, b, add, img = pic
+        sz, t, b, add, img = annotated('G')
         F = prettyForm('\n' * (above - t) + img + '\n' * (below - b),
                        baseline = above + sz)
 

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -33,7 +33,8 @@ from sympy.printing.conventions import split_super_sub
 # S   - SYMBOL    +
 
 
-__all__ = ['greek','sub','sup','xsym','vobj','hobj','pretty_symbol']
+__all__ = ['greek','sub','sup','xsym','vobj','hobj','pretty_symbol',
+           'annotated']
 
 
 _use_unicode = False
@@ -462,3 +463,28 @@ def pretty_symbol(symb_name):
 
 
     return ''.join([name, sups_result, subs_result])
+
+
+def annotated(letter):
+    """
+    Return a stylised drawing of the letter `letter`, together with
+    information on how to put annotations (super- and subscripts to the
+    left and to the right) on it.
+
+    See pretty.py functions _print_meijerg, _print_hyper on how to use this
+    information.
+    """
+    ucode_pics = {
+        'F': (2, 0, 2, 0, u'\u250c\u2500\n\u251c\u2500\n\u2575'),
+        'G': (3, 0, 3, 1,
+              u'\u256d\u2500\u256e\n\u2502\u2576\u2510\n\u2570\u2500\u256f')
+    }
+    ascii_pics = {
+        'F': (3, 0, 3, 0, ' _\n|_\n|\n'),
+        'G': (3, 0, 3, 1, ' __\n/__\n\_|')
+    }
+
+    if _use_unicode:
+        return ucode_pics[letter]
+    else:
+        return ascii_pics[letter]


### PR DESCRIPTION
In response to issue 2690.

This commit moves specifics on how to draw stylised 'F' and 'G' letters,
from pretty.py to pretty_symbology.py.

Specifically, create a new function `annotated(letter)` in pretty_symbology.py
which encapsulates the specific strings, and certain information on where to
place annotating numbers (i.e. p, q in pFq) relative to the string returned.
