### PR TITLE
Pypy support

### DIFF
--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -106,6 +106,10 @@ def import_module(module, min_module_version=None, min_python_version=None,
                     UserWarning)
             return
 
+    # PyPy 1.6 has rudimentary NumPy support and importing it produces errors, so skip it
+    if module == 'numpy' and '__pypy__' in sys.builtin_module_names:
+        return
+
     try:
         mod = __import__(module, **__import__kwargs)
     except ImportError:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -229,7 +229,8 @@ class MinMaxBase(LatticeOp):
         localzeros = set()
         for v in values:
             is_newzero = True
-            for z in localzeros:
+            localzeros_ = list(localzeros)
+            for z in localzeros_:
                 if id(v) == id(z):
                     is_newzero = False
                 elif cls._is_connected(v, z):
@@ -237,7 +238,6 @@ class MinMaxBase(LatticeOp):
                     if cls._is_asneeded(v, z):
                         localzeros.remove(z)
                         localzeros.update([v])
-                        break
             if is_newzero:
                 localzeros.update([v])
         return localzeros

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -79,6 +79,7 @@ def test_Min():
     assert Min(x, Min(y, z)) == Min(z, y, x)
     assert Min(x, Max(y, -oo)) == Min(x, y)
     assert Min(p, oo, n,  p, p, p_) == n
+    assert Min(p_, n_, p) == n_
     assert Min(n, oo, -7, p,  p, 2) == Min(n, -7)
     assert Min(2, x, p, n, oo, n_,  p, 2, -2, -2) == Min(-2, x, n, n_)
     assert Min(0, x, 1, y) == Min(0, x, y)

--- a/sympy/galgebra/tests/test_GA.py
+++ b/sympy/galgebra/tests/test_GA.py
@@ -7,19 +7,15 @@ The reference D&L is "Geometric Algebra for Physicists" by Doran and Lasenby
 
 import sys
 
-try:
-    import numpy
-    disabled = False
-except ImportError:
-    #py.test will not execute any tests now
+from sympy.external import import_module
+numpy = import_module('numpy')
+if not numpy:
     disabled = True
-
-if not disabled:
+else:
     sys.path.append('../')
     from sympy.galgebra.GA import set_main, MV, make_symbols, types, ZERO, ONE, HALF, S
     import sympy
     from sympy import collect, sympify
-
 
     set_main(sys.modules[__name__])
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -873,7 +873,7 @@ class Matrix(object):
         [2, 3, 4]
 
         """
-        if pos is 0:
+        if pos == 0:
             return mti.col_join(self)
         elif pos < 0:
             pos = self.rows + pos
@@ -910,7 +910,7 @@ class Matrix(object):
         [2, 0, 3, 4]
 
         """
-        if pos is 0:
+        if pos == 0:
             return mti.row_join(self)
         elif pos < 0:
             pos = self.cols + pos

--- a/sympy/mpmath/ctx_mp_python.py
+++ b/sympy/mpmath/ctx_mp_python.py
@@ -870,7 +870,7 @@ class PythonMPContext:
             s = ctx.make_mpc((s, mpf_sum(imag, prec, rnd)))
         else:
             s = ctx.make_mpf(s)
-        if other is 0:
+        if other == 0:
             return s
         else:
             return s + other
@@ -964,7 +964,7 @@ class PythonMPContext:
             s = ctx.make_mpc((s, mpf_sum(imag, prec, rnd)))
         else:
             s = ctx.make_mpf(s)
-        if other is 0:
+        if other == 0:
             return s
         else:
             return s + other

--- a/sympy/mpmath/tests/test_matrices.py
+++ b/sympy/mpmath/tests/test_matrices.py
@@ -191,10 +191,11 @@ def test_matrix_copy():
     assert A != B
 
 def test_matrix_numpy():
-    try:
-        import numpy
-    except ImportError:
+    from sympy.external import import_module
+    numpy = import_module('numpy')
+    if not numpy:
         return
+
     l = [[1, 2], [3, 4], [5, 6]]
     a = numpy.matrix(l)
     assert matrix(l) == matrix(a)

--- a/sympy/plotting/plot_mode_base.py
+++ b/sympy/plotting/plot_mode_base.py
@@ -303,7 +303,7 @@ class PlotModeBase(PlotMode):
     @synchronized
     def _set_style(self, v):
         if v is None: return
-        if v is '':
+        if v == '':
             step_max = 0
             for i in self.intervals:
                 if i.v_steps is None: continue

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -444,7 +444,7 @@ class AlgebraicNumber(Expr):
         return obj
 
     def __eq__(a, b):
-        if not b.is_AlgebraicNumber:
+        if not getattr(b, 'is_AlgebraicNumber', False):
             try:
                 b = to_number_field(b, a)
             except (NotAlgebraic, IsomorphismFailed):

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -48,7 +48,7 @@ class BooleanOption(Option):
 
     @classmethod
     def preprocess(cls, value):
-        if value is True or value is False or value is 1 or value is 0:
+        if value in [True, False]:
             return bool(value)
         else:
             raise OptionError("'%s' must have a boolean value assigned, got %s" % (cls.option, value))
@@ -489,9 +489,9 @@ class Extension(Option):
 
     @classmethod
     def preprocess(cls, extension):
-        if extension is True or extension is 1:
+        if extension == 1:
             return bool(extension)
-        elif extension is False or extension is 0:
+        elif extension == 0:
             raise OptionError("'False' is an invalid argument for 'extension'")
         else:
             if not hasattr(extension, '__iter__'):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1249,7 +1249,7 @@ def powsimp(expr, deep=False, combine='all', force=False):
         if combine in ('exp', 'all'):
             # Collect base/exp data, while maintaining order in the
             # non-commutative parts of the product
-            if combine is 'all' and deep and any((t.is_Add for t in expr.args)):
+            if combine == 'all' and deep and any((t.is_Add for t in expr.args)):
                 # Once we get to 'base', there is no more 'exp', so we need to
                 # distribute here.
                 return powsimp(expand_mul(expr, deep=False), deep, combine, force)
@@ -1438,7 +1438,7 @@ def powsimp(expr, deep=False, combine='all', force=False):
 
             # rebuild the expression
             newexpr = Mul(*(newexpr + [Pow(b, e) for b, e in c_powers.iteritems()]))
-            if combine is 'exp':
+            if combine == 'exp':
                 return Mul(newexpr, Mul(*nc_part))
             else:
                 # combine is 'all', get stuff ready for 'base'

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -574,7 +574,8 @@ def test_logcombine_1():
     assert logcombine(b*log(z)-log(w)) == log(z**b/w)
     assert logcombine(log(x)*log(z)) == log(x)*log(z)
     assert logcombine(log(w)*log(x)) == log(w)*log(x)
-    assert logcombine(cos(-2*log(z)+b*log(w))) == cos(log(w**b/z**2))
+    assert logcombine(cos(-2*log(z)+b*log(w))) in [cos(log(w**b/z**2)),
+                                                   cos(log(z**2/w**b))]
     assert logcombine(log(log(x)-log(y))-log(z), force=True) == \
         log(log((x/y)**(1/z)))
     assert logcombine((2+I)*log(x), force=True) == I*log(x)+log(x**2)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -129,9 +129,9 @@ def test_solve_polynomial1():
     assert solve((x - y, x+y), (x, y)) == solution
     assert solve((x - y, x+y), [x, y]) == solution
 
-    assert solve( x**3 - 15*x - 4, x) == [-2 + sqrt(3),
-                                           4,
-                                           -2 - sqrt(3) ]
+    assert set(solve(x**3 - 15*x - 4, x)) == set([-2 + 3**Rational(1,2),
+                                           S(4),
+                                           -2 - 3**Rational(1,2) ])
 
     assert sorted(solve((x**2 - 1)**2 - a, x)) == \
            sorted([sqrt(1 + sqrt(a)), -sqrt(1 + sqrt(a)),


### PR DESCRIPTION
Currently, running the test suite in PyPy crashes, because the implementation of NumPy in PyPy is still rudimentary. Fix this by explicitly skipping NumPy under PyPy (first commit), then a few issues that that raised (second commit) and then I added (and fixed some merge conflicts) the three commits made by Renato in pull request #480. The final result is that there are 13 failures and 29 exceptions (much more without the work from Renato). The remaining exceptions are as far as I can see just two errors; I'll try to fix them soon and add to this pull request, else I'll leave them for the next one. The failures are probably going to be much subtler.
