### PR TITLE
AssocOp creation

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -570,7 +570,6 @@ class Add(AssocOp):
             if cont == 1: # not S.One in case Float is ever handled
                 return S.One, self
 
-        MUL = object.__new__(Mul)._new_rawargs
         for i, (coeff, term) in enumerate(terms):
             c = coeff/cont
             if c == 1:  # not S.One in case Float is ever handled
@@ -578,7 +577,7 @@ class Add(AssocOp):
             elif term is S.One:
                 terms[i] = c
             else:
-                terms[i] = MUL(*((c,) + Mul.make_args(term)))
+                terms[i] = Mul._from_args((c,) + Mul.make_args(term))
 
         # we don't need a complete re-flattening since no new terms will join
         # so we just use the same sort as is used in Add.flatten. When the

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -97,43 +97,10 @@ class AssocOp(Expr):
            Although this routine tries to do as little as possible with the
            input, getting the commutativity right is important, so this level
            of safety is enforced: commutativity will always be recomputed if
-           either a) self has no is_commutate attribute or b) self is
-           non-commutative and kwarg `reeval=False` has not been passed.
-
-           If you don't have an existing Add or Mul and need one quickly, try
-           the following.
-
-               >>> m = object.__new__(Mul)
-               >>> m._new_rawargs(x, y)
-               x*y
-
-           Note that the commutativity is always computed in this case since
-           m doesn't have an is_commutative attribute; reeval is ignored:
-
-               >>> _.is_commutative
-               True
-               >>> hasattr(m, 'is_commutative')
-               False
-               >>> m._new_rawargs(x, y, reeval=False).is_commutative
-               True
-
-           It is possible to define the commutativity of m. If it's False then
-           the new Mul's commutivity will be re-evaluated:
-
-               >>> m.is_commutative = False
-               >>> m._new_rawargs(x, y).is_commutative
-               True
-
-           But if reeval=False then a non-commutative self can pass along
-           its non-commutativity to the result (but at least you have to *work*
-           to get this wrong):
-
-               >>> m._new_rawargs(x, y, reeval=False).is_commutative
-               False
-
+           self is non-commutative and kwarg `reeval=False` has not been
+           passed.
         """
-        if not hasattr(self, 'is_commutative') or (kwargs.pop('reeval', True)
-                and self.is_commutative is False):
+        if kwargs.pop('reeval', True) and self.is_commutative is False:
             is_commutative = None
         else:
             is_commutative = self.is_commutative

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -915,30 +915,12 @@ def test_as_powers_dict():
 def test_new_rawargs():
     x, y = symbols('x,y')
     n = Symbol('n', commutative=False)
-    a = object.__new__(Add)
-    assert 2 + x == a._new_rawargs(*[S(2), x])
-    assert x == a._new_rawargs(*[x])
-    assert 0 == a._new_rawargs()
-    assert 0 == a._new_rawargs(*[])
-    assert a._new_rawargs(x).is_commutative
-    assert a._new_rawargs(x, y).is_commutative
-    assert a._new_rawargs(x, n).is_commutative is False
-    assert a._new_rawargs(x, y, n).is_commutative is False
     a = x + n
     assert a.is_commutative is False
     assert a._new_rawargs(x).is_commutative
     assert a._new_rawargs(x, y).is_commutative
     assert a._new_rawargs(x, n).is_commutative is False
     assert a._new_rawargs(x, y, n).is_commutative is False
-    m = object.__new__(Mul)
-    assert 2*x == m._new_rawargs(*[S(2), x])
-    assert x == m._new_rawargs(*[x])
-    assert 1 == m._new_rawargs()
-    assert 1 == m._new_rawargs(*[])
-    assert m._new_rawargs(x).is_commutative
-    assert m._new_rawargs(x, y).is_commutative
-    assert m._new_rawargs(x, n).is_commutative is False
-    assert m._new_rawargs(x, y, n).is_commutative is False
     m = x*n
     assert m.is_commutative is False
     assert m._new_rawargs(x).is_commutative

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2106,8 +2106,7 @@ class NO(Expr):
 
         """
         arg0 = self.args[0] # it's a Mul by definition of how it's created
-        mul = Mul._new_rawargs(arg0, Mul._new_rawargs(arg0, arg0.args[:i]),
-                                     Mul._new_rawargs(arg0, arg0.args[i + 1:]))
+        mul = arg0._new_rawargs(arg0.args[:i] + arg0.args[i + 1:])
         return NO(mul)
 
     def _latex(self,printer):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1321,8 +1321,6 @@ def powsimp(expr, deep=False, combine='all', force=False):
                     x**(2*y/3) -> x, 2*y/3
 
                 '''
-                from sympy import Rational as r
-                MUL = lambda *args: object.__new__(Mul)._new_rawargs(*args)
                 if e is not None: # coming from c_powers or from below
                     if e.is_Integer:
                         return (b, S.One), e
@@ -1331,7 +1329,7 @@ def powsimp(expr, deep=False, combine='all', force=False):
                     else:
                         c, m = e.as_coeff_mul()
                         if c is not S.One:
-                            return (b**MUL(*m), Integer(c.q)), Integer(c.p)
+                            return (b**Mul._from_args(m), Integer(c.q)), Integer(c.p)
                         else:
                             return (b**e, S.One), S.One
                 else:


### PR DESCRIPTION
These are a few small improvements to the instantiation of AssocOp objects. The most important change is the addition of a classmethod `_from_args` to simplify fast object creation from a raw argument list. This is now called by the other constructors, which eliminates some code duplication.
