### PR TITLE
Use extension=True automatically in apart() (#2717)

### DIFF
--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -2,12 +2,13 @@
 
 from sympy.polys import Poly, RootSum, cancel, factor
 from sympy.polys.polytools import parallel_poly_from_expr
+from sympy.polys.polyoptions import allowed_flags, set_defaults
 
 from sympy.core import S, Add, sympify, Symbol, Function, Lambda, Dummy
 from sympy.utilities import numbered_symbols, take, threaded
 
 @threaded
-def apart(f, x=None, full=False, **args):
+def apart(f, x=None, full=False, **options):
     """
     Compute partial fraction decomposition of a rational function.
 
@@ -25,6 +26,8 @@ def apart(f, x=None, full=False, **args):
     -y/(x + 2) + y/(x + 1)
 
     """
+    allowed_flags(options, [])
+
     f = sympify(f)
 
     if f.is_Atom:
@@ -32,7 +35,8 @@ def apart(f, x=None, full=False, **args):
     else:
         P, Q = f.as_numer_denom()
 
-    (P, Q), opt = parallel_poly_from_expr((P, Q), x, **args)
+    options = set_defaults(options, extension=True)
+    (P, Q), opt = parallel_poly_from_expr((P, Q), x, **options)
 
     if P.is_multivariate:
         raise NotImplementedError("multivariate partial fraction decomposition")

--- a/sympy/polys/polyoptions.py
+++ b/sympy/polys/polyoptions.py
@@ -126,19 +126,37 @@ class Options(dict):
             args = dict(args)
             args['gens'] = gens
 
-        for option, value in args.iteritems():
-            try:
-                cls = self.__options__[option]
-            except KeyError:
-                raise OptionError("'%s' is not a valid option" % option)
+        defaults = args.pop('defaults', {})
 
-            if issubclass(cls, Flag):
-                if flags is None or option not in flags:
-                    if strict:
-                        raise OptionError("'%s' flag is not allowed in this context" % option)
+        def preprocess_options(args):
+            for option, value in args.iteritems():
+                try:
+                    cls = self.__options__[option]
+                except KeyError:
+                    raise OptionError("'%s' is not a valid option" % option)
 
-            if value is not None:
-                self[option] = cls.preprocess(value)
+                if issubclass(cls, Flag):
+                    if flags is None or option not in flags:
+                        if strict:
+                            raise OptionError("'%s' flag is not allowed in this context" % option)
+
+                if value is not None:
+                    self[option] = cls.preprocess(value)
+
+        preprocess_options(args)
+
+        for key, value in dict(defaults).iteritems():
+            if key in self:
+                del defaults[key]
+            else:
+                for option in self.keys():
+                    cls = self.__options__[option]
+
+                    if key in cls.excludes:
+                        del defaults[key]
+                        break
+
+        preprocess_options(defaults)
 
         for option in self.keys():
             cls = self.__options__[option]
@@ -738,5 +756,12 @@ def allowed_flags(args, flags):
         except KeyError:
             raise OptionError("'%s' is not a valid option" % arg)
 
-Options._init_dependencies_order()
+def set_defaults(options, **defaults):
+    """Update options with default values. """
+    if 'defaults' not in options:
+        options = dict(options)
+        options['defaults'] = defaults
 
+    return options
+
+Options._init_dependencies_order()

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -6,7 +6,7 @@ from sympy.polys.partfrac import (
     apart,
 )
 
-from sympy import S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda
+from sympy import S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda, factor, together
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y, a, b, c
 
@@ -59,6 +59,10 @@ def test_apart_extension():
 
     assert apart(f, extension=I) == g
     assert apart(f, gaussian=True) == g
+
+    f = x/((x - 2)*(x + I))
+
+    assert factor(together(apart(f))) == f
 
 def test_apart_full():
     f = 1/(x**2 + 1)


### PR DESCRIPTION
This fixes issue #2717, e.g.:

```
In [1]: apart(z/((z - 2)*(z + I)))
Out[1]:
 1 + 2⋅ⅈ    2⋅(-2 + ⅈ)
───────── - ──────────
5⋅(z + ⅈ)   5⋅(z - 2)
```
