### PR TITLE
Don't display deprecation warning when running tests

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1270,7 +1270,10 @@ class PyTestReporter(Reporter):
         self.write("f", "Green")
 
     def test_xpass(self, v):
-        message = getattr(v, 'msg', getattr(v, 'message', ''))
+        if sys.version_info[:2] < (2, 6):
+            message = getattr(v, 'message', '')
+        else:
+            message = str(v)
         self._xpassed.append((self._active_file, message))
         self.write("X", "Green")
 
@@ -1294,7 +1297,10 @@ class PyTestReporter(Reporter):
             self.write(".", "Green")
 
     def test_skip(self, v):
-        message = getattr(v, 'msg', getattr(v, 'message', ''))
+        if sys.version_info[:2] < (2, 6):
+            message = getattr(v, 'message', '')
+        else:
+            message = str(v)
         self._skipped += 1
         self.write("s", "Green")
         if self._verbose:


### PR DESCRIPTION
Previously the following deprecation warning was showed:

```
$ python2.6 bin/test sympy/core/tests/test_symbol.py
executable:   /usr/bin/python2.6  (2.6.6-final-0)
architecture: 64-bit
cache:        yes
ground types: gmpy
random seed:  47140786

sympy/core/tests/test_symbol.py[9] ....
/home/mateusz/repo/git/sympy/sympy/utilities/runtests.py:1273: DeprecationWarning:
BaseException.message has been deprecated as of Python 2.6 message = getattr(v, 'msg', getattr(v, 'message', ''))
X....
```
