### PR TITLE
Improved `.has()` and changed the meaning of `Basic.__contains__()`

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -784,7 +784,6 @@ class Basic(object):
 
         return self._subs_list(subst)
 
-
     def __contains__(self, obj):
         if self == obj:
             return True
@@ -821,25 +820,68 @@ class Basic(object):
         False
 
         """
-        def search(expr, test):
-            if not isinstance(expr, Basic):
-                try:
-                    return any(search(i, test) for i in expr)
-                except TypeError:
-                    return False
-            elif test(expr):
+        def _ncsplit(expr):
+            if expr.is_Add or expr.is_Mul:
+                cpart, ncpart = [], []
+
+                for arg in expr.args:
+                    if arg.is_commutative:
+                        cpart.append(arg)
+                    else:
+                        ncpart.append(arg)
+            elif expr.is_commutative:
+                cpart, ncpart = [expr], []
+            else:
+                cpart, ncpart = [], [expr]
+
+            return set(cpart), ncpart
+
+        def _contains(expr, subexpr, iterative, c, nc):
+            if expr == subexpr:
                 return True
-            else:
-                return any(search(i, test) for i in expr.iter_basic_args())
+            elif not isinstance(expr, Basic):
+                return False
+            elif iterative and (expr.is_Add or expr.is_Mul):
+                _c, _nc = _ncsplit(expr)
 
-        def _match(p):
-            if isinstance(p, BasicType):
-                return lambda w: isinstance(w, p)
-            else:
-                return lambda w: p.matches(w) is not None
+                if (c & _c) == c:
+                    if not nc:
+                        return True
+                    elif len(nc) <= len(_nc):
+                        for i in xrange(len(_nc) - len(nc)):
+                            if _nc[i:i+len(nc)] == nc:
+                                return True
 
-        patterns = map(sympify, patterns)
-        return any(search(self, _match(p)) for p in patterns)
+            return False
+
+        def _match(pattern):
+            pattern = sympify(pattern)
+
+            if isinstance(pattern, BasicType):
+                return lambda expr: (isinstance(expr, pattern) or
+                    (isinstance(expr, BasicType) and expr == pattern))
+            else:
+                if pattern.is_Add or pattern.is_Mul:
+                    iterative, (c, nc) = True, _ncsplit(pattern)
+                else:
+                    iterative, (c, nc) = False, (None, None)
+
+                return lambda expr: _contains(expr, pattern, iterative, c, nc)
+
+        def _search(expr, match):
+            if match(expr):
+                return True
+
+            if isinstance(expr, Basic):
+                args = expr.args
+            elif iterable(expr):
+                args = expr
+            else:
+                return False
+
+            return any(_search(arg, match) for arg in args)
+
+        return any(_search(self, _match(pattern)) for pattern in patterns)
 
     def replace(self, query, value, map=False):
         """

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -786,6 +786,7 @@ class Basic(object):
 
         return self._subs_list(subst)
 
+    @deprecated
     def __contains__(self, obj):
         if self == obj:
             return True
@@ -1223,6 +1224,7 @@ class Atom(Basic):
     def doit(self, **hints):
         return self
 
+    @deprecated
     def __contains__(self, obj):
         return (self == obj)
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -768,6 +768,8 @@ class Basic(object):
            a*c*sin(d*e) + b
 
         """
+        sequence = sympify(sequence)
+
         if isinstance(sequence, dict):
             sequence = sequence.items()
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -777,7 +777,7 @@ class Basic(object):
 
         for pattern in sequence:
             for i, (expr, _) in enumerate(subst):
-                if pattern[0] in expr:
+                if expr.has(pattern[0]):
                     subst.insert(i, pattern)
                     break
             else:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -34,7 +34,7 @@ from assumptions import WithAssumptions
 from basic import Basic
 from singleton import S
 from expr import Expr, AtomicExpr
-from decorators import _sympifyit
+from decorators import _sympifyit, deprecated
 from compatibility import iterable,is_sequence
 from cache import cacheit
 from numbers import Rational
@@ -68,6 +68,7 @@ class FunctionClass(WithAssumptions):
     def __repr__(cls):
         return cls.__name__
 
+    @deprecated
     def __contains__(self, obj):
         return (self == obj)
 
@@ -143,6 +144,7 @@ class Application(Basic):
                     return new(*self.args)
         return self.func(*[s.subs(old, new) for s in self.args])
 
+    @deprecated
     def __contains__(self, obj):
         if self.func == obj:
             return True

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -184,7 +184,7 @@ class AssocOp(Expr):
         from function import WildFunction
         from symbol import Wild
         for p in self.args:
-            if p.has(Wild, WildFunction) and (not p in expr):
+            if p.has(Wild, WildFunction) and (not expr.has(p)):
                 # not all Wild should stay Wilds, for example:
                 # (w2+w3).matches(w1) -> (w1+w3).matches(w1) -> w3.matches(0)
                 wild_part.append(p)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -198,7 +198,7 @@ class Wild(Symbol):
                 return None
         if self.exclude:
             for x in self.exclude:
-                if x in expr:
+                if expr.has(x):
                     return None
         if self.properties:
             for f in self.properties:

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -135,6 +135,13 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
         except TypeError:
             # Not all iterables are rebuildable with their type.
             pass
+    if isinstance(a, dict):
+        try:
+            return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
+                rational=rational) for x in a.iteritems()])
+        except TypeError:
+            # Not all iterables are rebuildable with their type.
+            pass
 
     # At this point we were given an arbitrary expression
     # which does not inherit from Basic and doesn't implement

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -372,3 +372,7 @@ def test_subs_iter():
     it = iter([[x, y]])
     assert x.subs(it) == y
     assert x.subs(Tuple((x, y))) == y
+
+def test_subs_dict():
+    x, y, z = symbols('x,y,z')
+    (2*x + y + z).subs(dict(x=1, y=2)) == 4 + z

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -132,6 +132,7 @@ def test_sympyify_iterables():
     assert sympify(['.3', '.2'], rational=1) == ans
     assert sympify(set(['.3', '.2']), rational=1) == set(ans)
     assert sympify(tuple(['.3', '.2']), rational=1) == Tuple(*ans)
+    assert sympify(dict(x=0, y=1)) == {x: 0, y: 1}
     assert sympify(['1', '2', ['3', '4']]) == [S(1), S(2), [S(3), S(4)]]
 
 def test_sympify4():

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -518,10 +518,10 @@ def test_Tensors():
     assert AT('t',(a,b,c),(i,j,k)) == AT('t',(b,a,c),(i,k,j))
 
     tabij = AT('t',(a,b),(i,j))
-    assert a in tabij
-    assert b in tabij
-    assert i in tabij
-    assert j in tabij
+    assert tabij.has(a)
+    assert tabij.has(b)
+    assert tabij.has(i)
+    assert tabij.has(j)
     assert tabij.subs(b,c) == AT('t',(a,c),(i,j))
     assert (2*tabij).subs(i,c) == 2*AT('t',(a,b),(c,j))
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1667,7 +1667,7 @@ def _handle_Integral(expr, func, order, hint):
         sol = 0
         assert tmpsol.is_Add
         for i in tmpsol.args:
-            if x0 not in i and y0 not in i:
+            if not i.has(x0) and not i.has(y0):
                 sol += i
         assert sol != 0
         sol = Eq(sol.subs(y, f(x)),expr.rhs) # expr.rhs == C1
@@ -2106,7 +2106,7 @@ def _homogeneous_order(eq, *symbols):
     eqs = eq.subs(dict(zip(symbols,(t*i for i in symbols))))
 
     if eqs.is_Mul:
-        if t not in eqs:
+        if not eqs.has(t):
             n.add(sympify(0))
         else:
             m = eqs.match(r*t**a)


### PR DESCRIPTION
This is continuation of pull request #291. Now `.has()` implements the extended algorithm from issue #2283. I also changed `Basic.__contains__()` (and related). Now `subexpr in expr` is equivalent to `subexpr in expr.args`. Note that this pull request doesn't make `.has()` more compatible with OOP, so this will have to be done in the future.
