### PR TITLE
physics/mechanics: Fix 2to3 parsing errors

### DIFF
--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -414,8 +414,7 @@ class Dyadic(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import ReferenceFrame, outer,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, outer, dynamicsymbols
         >>> N = ReferenceFrame('N')
         >>> q = dynamicsymbols('q')
         >>> B = N.orientnew('B', 'Axis', [q, N.z])
@@ -445,8 +444,7 @@ class Dyadic(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import ReferenceFrame, outer,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, outer, dynamicsymbols
         >>> N = ReferenceFrame('N')
         >>> q = dynamicsymbols('q')
         >>> B = N.orientnew('B', 'Axis', [q, N.z])
@@ -1505,8 +1503,7 @@ class Vector(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import ReferenceFrame, Vector,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, Vector, dynamicsymbols
         >>> from sympy import Symbol
         >>> t = Symbol('t')
         >>> q1 = dynamicsymbols('q1')
@@ -1546,8 +1543,7 @@ class Vector(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import ReferenceFrame, Vector,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, Vector, dynamicsymbols
         >>> from sympy import Symbol
         >>> q1 = Symbol('q1')
         >>> u1 = dynamicsymbols('u1')
@@ -1586,8 +1582,7 @@ class Vector(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import ReferenceFrame, Vector,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import ReferenceFrame, Vector, dynamicsymbols
         >>> q1 = dynamicsymbols('q1')
         >>> N = ReferenceFrame('N')
         >>> A = N.orientnew('A', 'Axis', [q1, N.y])

--- a/sympy/physics/mechanics/point.py
+++ b/sympy/physics/mechanics/point.py
@@ -83,8 +83,7 @@ class Point(object):
 
         Examples
         ========
-        >>> from sympy.physics.mechanics import Point, ReferenceFrame,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import Point, ReferenceFrame, dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> q2 = dynamicsymbols('q2')
         >>> qd = dynamicsymbols('q', 1)
@@ -136,8 +135,7 @@ class Point(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import Point, ReferenceFrame,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import Point, ReferenceFrame, dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> qd = dynamicsymbols('q', 1)
         >>> N = ReferenceFrame('N')
@@ -345,8 +343,7 @@ class Point(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import Point, ReferenceFrame,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import Point, ReferenceFrame, dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> q2 = dynamicsymbols('q2')
         >>> qd = dynamicsymbols('q', 1)
@@ -395,8 +392,7 @@ class Point(object):
         Examples
         ========
 
-        >>> from sympy.physics.mechanics import Point, ReferenceFrame,\
-                dynamicsymbols
+        >>> from sympy.physics.mechanics import Point, ReferenceFrame, dynamicsymbols
         >>> q = dynamicsymbols('q')
         >>> qd = dynamicsymbols('q', 1)
         >>> N = ReferenceFrame('N')


### PR DESCRIPTION
The new mechanics module has some docstrings that incorrectly used the
multiline syntax (for docstrings), which caused errors when using the
2to3 tool ("TokenError: ('EOF in multi-line statement', (2, 0))"). Fix
this by just writing them in one line.
