### PR TITLE
Robustified sort_key() and default_sort_key()

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1236,4 +1236,4 @@ class Atom(Basic):
     @cacheit
     def sort_key(self, order=None):
         from sympy.core import S
-        return self.class_key(), (1, (self,)), S.One.sort_key(), S.One
+        return self.class_key(), (1, (str(self),)), S.One.sort_key(), S.One

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -43,7 +43,6 @@ class Expr(Basic, EvalfMixin):
     @cacheit
     def sort_key(self, order=None):
         # XXX: The order argument does not actually work
-        from sympy.core import S
 
         def key_inner(arg):
             if isinstance(arg, Basic):
@@ -54,16 +53,14 @@ class Expr(Basic, EvalfMixin):
                 return arg
 
         coeff, expr = self.as_coeff_Mul()
+
         if expr.is_Pow:
             expr, exp = expr.args
         else:
             expr, exp = expr, S.One
 
         if expr.is_Atom:
-            if expr.is_Symbol:
-                args = (str(expr),)
-            else:
-                args = (expr,)
+            args = (str(expr),)
         else:
             if expr.is_Add:
                 args = expr.as_ordered_terms(order=order)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -44,13 +44,7 @@ class Expr(Basic, EvalfMixin):
     def sort_key(self, order=None):
         # XXX: The order argument does not actually work
 
-        def key_inner(arg):
-            if isinstance(arg, Basic):
-                return arg.sort_key(order=order)
-            elif hasattr(arg, '__iter__'):
-                return tuple(key_inner(arg) for arg in args)
-            else:
-                return arg
+        from sympy.utilities import default_sort_key
 
         coeff, expr = self.as_coeff_Mul()
 
@@ -64,13 +58,12 @@ class Expr(Basic, EvalfMixin):
         else:
             if expr.is_Add:
                 args = expr.as_ordered_terms(order=order)
+            elif expr.is_Mul:
+                args = expr.as_ordered_factors(order=order)
             else:
                 args = expr.args
 
-            args = tuple(key_inner(arg) for arg in args)
-
-            if expr.is_Mul:
-                args = sorted(args)
+            args = tuple([ default_sort_key(arg, order=order) for arg in args ])
 
         args = (len(args), tuple(args))
         exp = exp.sort_key(order=order)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -7,6 +7,7 @@ from sympy import (Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I,
     separate, collect, factorial, apart, combsimp, factor, refine, cancel,
     Tuple, default_sort_key, DiracDelta, gamma)
 from sympy.physics.secondquant import FockState
+from sympy.physics.units import m, s
 
 from sympy.utilities.pytest import raises
 
@@ -1102,6 +1103,9 @@ def test_as_ordered_terms():
     assert f.as_ordered_terms(order="grlex") == [x*y**4, x**2*y**2, y, 2]
     assert f.as_ordered_terms(order="rev-lex") == [2, y, x*y**4, x**2*y**2]
     assert f.as_ordered_terms(order="rev-grlex") == [2, y, x**2*y**2, x*y**4]
+
+def test_sort_key_atomic_expr():
+    assert sorted([-m, s], key=lambda arg: arg.sort_key()) == [-m, s]
 
 def test_issue_1100():
     # first subs and limit gives NaN

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -634,8 +634,14 @@ def test_issue_1793a():
     P1 = -A*exp(-z)
     P2 = -A/(c*t)*(sin(x)**2 + cos(y)**2)
 
-    assert integrate(c*(P2 - P1), t) == \
-        c*(A*(-cos(y)**2 - sin(x)**2)*log(c*t)/c + A*t*exp(-z))
+    # TODO: make trigsimp() deterministic
+    h1 = -sin(x)**2 - cos(y)**2
+    h2 = -sin(x)**2 + sin(y)**2 - 1
+
+    assert integrate(c*(P2 - P1), t) in [
+        c*(A*h1*log(c*t)/c + A*t*exp(-z)),
+        c*(A*h2*log(c*t)/c + A*t*exp(-z)),
+    ]
 
 def test_issue_1793b():
     # Issues relating to issue 1497 are making the actual result of this hard


### PR DESCRIPTION
Now both `sort_key()` and `default_sort_key()` return only comparable objects (tuples, strings, numbers). I also added a new switch `-A` to isympy, test and doctest, which allows to choose sorting algorithm for `Add.args`: `hash`, `random` or `sort_key`. `hash` is the default. `random` doesn't really give much, because almost whole SymPy fails with this. But `sort_key` is very useful and allows to reproduce problems that we have under PyPy (for example). If you run `bin/test -A sort_key`, then all tests pass besides well know `piecewise_fold`. There are also doctest failures if your run `bin/doctest -A sort_key`, but you will see that this is only a coincidence that they pass with `-A hash`. SymPy is about 5% slower when running tests with `-A sort_key`. It should be possible to reduce this by using customized caching for `sort_key()` (as we use for `__hash__()`).
