### PR TITLE
Isympy options

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -69,7 +69,7 @@ def main():
         # allows you to disable this, though, but it's only available in
         # Python 2.7+.
         print __doc__ # the docstring of this module above
-    usage = 'usage: isympy [options] -- [ipython options]'
+    usage = 'usage: isympy [options] -- [python/ipython options]'
     parser = OptionParser(
         usage=usage,
         version='0.7.1-git',
@@ -84,7 +84,8 @@ def main():
         action='store',
         default=None,
         choices=['ipython', 'python'],
-        help='select type of interactive session: ipython | python')
+        help='select type of interactive session: ipython | python; defaults '
+        'to ipython if IPython is installed, otherwise python')
 
     parser.add_option(
         '-p', '--pretty',
@@ -92,7 +93,8 @@ def main():
         action='store',
         default=None,
         choices=['unicode', 'ascii', 'no'],
-        help='setup pretty printing: unicode | ascii | no')
+        help='setup pretty printing: unicode | ascii | no; defaults to '
+        'unicode printing if the terminal supports it, otherwise ascii')
 
     parser.add_option(
         '-t', '--types',
@@ -100,7 +102,9 @@ def main():
         action='store',
         default=None,
         choices=['gmpy', 'python', 'sympy'],
-        help='setup ground types: gmpy | python | sympy')
+        help='setup ground types: gmpy | python | sympy; defaults to gmpy if '
+        'gmpy is installed, otherwise python (note that sympy ground types are '
+        'not supported and should be used for experimental purposes only)')
 
     parser.add_option(
         '-o', '--order',
@@ -108,7 +112,7 @@ def main():
         action='store',
         default=None,
         choices=['lex', 'grlex', 'grevlex', 'rev-lex', 'rev-grlex', 'rev-grevlex', 'old', 'none'],
-        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none')
+        help='setup ordering of terms: [rev-]lex | [rev-]grlex | [rev-]grevlex | old | none; defaults to lex')
 
     parser.add_option(
         '-q', '--quiet',

--- a/bin/isympy
+++ b/bin/isympy
@@ -65,7 +65,20 @@ def main():
     from optparse import OptionParser
 
     usage = 'usage: isympy [options] -- [ipython options]'
-    parser = OptionParser(usage)
+    description = """A Python (or IPython, if it's installed) shell for SymPy
+that automatically executes `from sympy import *` and defines common symbols."""
+    parser = OptionParser(
+        usage=usage,
+        description=description,
+        # XXX: We can't use description=__doc__ (the docstring of this module
+        # above), because optparse line wraps it weird.  The argparse module
+        # allows you to disable this, though, but it's only available in
+        # Python 2.7+.
+        version='0.7.1-git',
+        # XXX: We need a more centralized place to store the version.
+        # It is currently stored in sympy.__version__, but we can't yet
+        # import sympy at this point.
+        )
 
     parser.add_option(
         '-c', '--console',

--- a/bin/isympy
+++ b/bin/isympy
@@ -125,6 +125,13 @@ def main():
         default=False,
         help='automatically construct missing symbols')
 
+    parser.add_option(
+        '-D', '--debug',
+        dest='debug',
+        action='store_true',
+        default=False,
+        help='enable debugging output')
+
     (options, ipy_args) = parser.parse_args()
 
     if not options.cache:
@@ -132,6 +139,9 @@ def main():
 
     if options.types:
         os.environ['SYMPY_GROUND_TYPES'] = options.types
+
+    if options.debug:
+        os.environ['SYMPY_DEBUG'] = str(options.debug)
 
     if options.doctest:
         options.pretty = 'no'

--- a/bin/isympy
+++ b/bin/isympy
@@ -1,10 +1,14 @@
 #! /usr/bin/env python
 
+# XXX: Don't put a newline here, or it will add an extra line with
+# isympy --help
+#  |
+#  v
 """Python shell for SymPy.
 
 This is just a normal Python shell (IPython shell if you have the
-IPython package installed),  that executes the following commands
-for the user:
+IPython package installed), that executes the following commands for
+the user:
 
     >>> from __future__ import division
     >>> from sympy import *
@@ -12,40 +16,109 @@ for the user:
     >>> k, m, n = symbols('k m n', integer=True)
     >>> f, g, h = symbols('f g h', cls=Function)
 
-So starting 'isympy' is equivalent to starting Python (or IPython)
-and executing the above commands by hand.  It is intended for easy
-and quick experimentation with SymPy.
+So starting 'isympy' is equivalent to starting Python (or IPython) and
+executing the above commands by hand.  It is intended for easy and quick
+experimentation with SymPy.  isympy is a good way to use SymPy as an
+interactive calculator
 
 COMMAND LINE OPTIONS
 --------------------
 
 -c CONSOLE, --console=CONSOLE
 
-     Use the specified Python or IPython shell as console backend instead
-     of the default one (IPython if present or Python otherwise), e.g.:
+     Use the specified shell (Python or IPython) shell as the console
+     backend instead of the default one (IPython if present, Python
+     otherwise), e.g.:
 
-        isympy -c python
+        $isympy -c python
+
+    CONSOLE must be one of 'ipython' or 'python'
 
 -p PRETTY, --pretty PRETTY
 
-    Setup pretty printing in SymPy. By default the most pretty,  Unicode
-    printing is enabled. User can use less pretty ASCII printing instead
-    or no pretty printing at all, e.g.:
+    Setup pretty printing in SymPy. By default the most pretty, unicode
+    printing is enabled (if the terminal supports it). You can use less
+    pretty ASCII printing instead or no pretty printing at all, e.g.:
+
+        $isympy -p no
+
+    PRETTY must be one of 'unicode', 'ascii', or 'no'
+
+-t TYPES, --types=TYPES
+
+    Setup the ground types for the polys.  By default, gmpy ground types
+    are used if gmpy is installed, otherwise it falls back to python
+    ground types, which are a little bit slower.  You can manually
+    choose python ground types even if gmpy is installed (e.g., for
+    testing purposes), e.g.:
+
+        $isympy -t python
+
+    TYPES must be one of 'gmpy', 'python', or 'sympy'
+
+    Note that sympy ground types are not supported, and should be used
+    only for experimental purposes.
+
+    This is the same as setting the environment variable
+    SYMPY_GROUND_TYPES to the given ground type (e.g.,
+    SYMPY_GROUND_TYPES='gmpy')
+
+    The ground types can be determined interactively from the variable
+    sympy.polys.domains.GROUND_TYPES.
+
+-o ORDER, --order ORDER
+
+    Setup the ordering of terms for printing.  The default is lex, which
+    orders terms lexicographically (e.g., x**2 + x + 1). You can choose
+    other orderings, such as rev-lex, which will use reverse
+    lexicographic ordering (e.g., 1 + x + x**2), e.g.:
+
+        $isympy -o rev-lex
+
+    ORDER must be one of 'lex', 'rev-lex', 'grlex', 'rev-grlex',
+    'grevlex', 'rev-grevlex', 'old', or 'none'.
+
+    Note that for very large expressions, ORDER='none' may speed up
+    printing considerably, with the tradeoff that the order of the terms
+    in the printed expression will have no canonical order.
 
 -q, --quiet
 
     Print only Python's and SymPy's versions to stdout at startup.
 
--- IPython's options
+-d, --doctest
 
-    Additionally you can pass command line options directly to IPython
-    interpreter (standard Python shell is not supported).  However you
-    need to add '--' separator between two types of options. To run
-    SymPy without startup banner and colors, for example, issue:
+    Use the same format that should be used for doctests.  This is
+    equivalent to -c python -p no.
 
-        isympy -q -- -colors NoColor
+-C, --no-cache
 
-See also the isympy --help for more options.
+    Disable the caching mechanism.  Disabling the cache may slow certain
+    operations down considerably.  This is useful for testing the cache,
+    or for benchmarking, as the cache can result in deceptive timings.
+
+    This is the same as setting the environment variable SYMPY_USE_CACHE
+    to 'no'.
+
+    This is equivalent to setting the environment variable
+    SYMPY_USE_CACHE='no'.
+
+-D, --debug
+
+    Enable debugging output.  This is the same as setting the
+    environment variable SYMPY_DEBUG to 'True'.  The debug status is set
+    in the variable SYMPY_DEBUG within isympy.
+
+-- IPython options
+
+    Additionally you can pass command line options directly to the
+    IPython interpreter (the standard Python shell is not supported).
+    However you need to add '--' separator between two types of options.
+    To run SymPy without startup banner and colors, for example, issue in IPython 0.10 or lower:
+
+        $isympy -q -- -colors NoColor
+
+See also isympy --help.
 """
 
 import os, sys
@@ -69,7 +142,7 @@ def main():
         # allows you to disable this, though, but it's only available in
         # Python 2.7+.
         print __doc__ # the docstring of this module above
-    usage = 'usage: isympy [options] -- [python/ipython options]'
+    usage = 'usage: isympy [options] -- [ipython options]'
     parser = OptionParser(
         usage=usage,
         version='0.7.1-git',

--- a/bin/isympy
+++ b/bin/isympy
@@ -1,50 +1,52 @@
 #! /usr/bin/env python
 
-"""Python shell for SymPy.
+"""
+Python shell for SymPy.
 
-   This is just a normal Python shell (IPython shell if you have the
-   IPython package installed),  that executes the following commands
-   for the user:
+This is just a normal Python shell (IPython shell if you have the
+IPython package installed),  that executes the following commands
+for the user:
 
-       >>> from __future__ import division
-       >>> from sympy import *
-       >>> x, y, z, t = symbols('x y z t')
-       >>> k, m, n = symbols('k m n', integer=True)
-       >>> f, g, h = symbols('f g h', cls=Function)
+    >>> from __future__ import division
+    >>> from sympy import *
+    >>> x, y, z, t = symbols('x y z t')
+    >>> k, m, n = symbols('k m n', integer=True)
+    >>> f, g, h = symbols('f g h', cls=Function)
 
-   So starting 'isympy' is equivalent to starting Python (or IPython)
-   and executing the above commands by hand.  It is intended for easy
-   and quick experimentation with SymPy.
+So starting 'isympy' is equivalent to starting Python (or IPython)
+and executing the above commands by hand.  It is intended for easy
+and quick experimentation with SymPy.
 
-   COMMAND LINE OPTIONS
-   --------------------
+COMMAND LINE OPTIONS
+--------------------
 
-   -c CONSOLE, --console=CONSOLE
+-c CONSOLE, --console=CONSOLE
 
      Use the specified Python or IPython shell as console backend instead
      of the default one (IPython if present or Python otherwise), e.g.:
 
         isympy -c python
 
-   -p PRETTY, --pretty PRETTY
+-p PRETTY, --pretty PRETTY
 
-     Setup pretty printing in SymPy. By default the most pretty,  Unicode
-     printing is enabled. User can use less pretty ASCII printing instead
-     or no pretty printing at all, e.g.:
+    Setup pretty printing in SymPy. By default the most pretty,  Unicode
+    printing is enabled. User can use less pretty ASCII printing instead
+    or no pretty printing at all, e.g.:
 
-   -q, --quiet
+-q, --quiet
 
-     Print only Python's and SymPy's versions to stdout at startup.
+    Print only Python's and SymPy's versions to stdout at startup.
 
-   -- IPython's options
+-- IPython's options
 
-     Additionally you can pass command line options directly to IPython
-     interpreter (standard Python shell is not supported).  However you
-     need to add '--' separator between two types of options. To run
-     SymPy without startup banner and colors, for example, issue:
+    Additionally you can pass command line options directly to IPython
+    interpreter (standard Python shell is not supported).  However you
+    need to add '--' separator between two types of options. To run
+    SymPy without startup banner and colors, for example, issue:
 
         isympy -q -- -colors NoColor
 
+See also the isympy --help for more options.
 """
 
 import os, sys

--- a/bin/isympy
+++ b/bin/isympy
@@ -114,7 +114,11 @@ COMMAND LINE OPTIONS
     Additionally you can pass command line options directly to the
     IPython interpreter (the standard Python shell is not supported).
     However you need to add '--' separator between two types of options.
-    To run SymPy without startup banner and colors, for example, issue in IPython 0.10 or lower:
+    To run SymPy without startup banner and colors, for example, issue in IPython 0.11 or higher:
+
+        $isympy -q -- --colors=NoColor
+
+    Or in an older version of IPython:
 
         $isympy -q -- -colors NoColor
 

--- a/bin/isympy
+++ b/bin/isympy
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
-"""
-Python shell for SymPy.
+"""Python shell for SymPy.
 
 This is just a normal Python shell (IPython shell if you have the
 IPython package installed),  that executes the following commands
@@ -64,16 +63,15 @@ if os.path.isdir(sympy_dir):
 def main():
     from optparse import OptionParser
 
-    usage = 'usage: isympy [options] -- [ipython options]'
-    description = """A Python (or IPython, if it's installed) shell for SymPy
-that automatically executes `from sympy import *` and defines common symbols."""
-    parser = OptionParser(
-        usage=usage,
-        description=description,
-        # XXX: We can't use description=__doc__ (the docstring of this module
-        # above), because optparse line wraps it weird.  The argparse module
+    if '-h' in sys.argv or '--help' in sys.argv:
+        # XXX: We can't use description=__doc__  in the OptionParser call
+        # below because optparse line wraps it weird.  The argparse module
         # allows you to disable this, though, but it's only available in
         # Python 2.7+.
+        print __doc__ # the docstring of this module above
+    usage = 'usage: isympy [options] -- [ipython options]'
+    parser = OptionParser(
+        usage=usage,
         version='0.7.1-git',
         # XXX: We need a more centralized place to store the version.
         # It is currently stored in sympy.__version__, but we can't yet

--- a/bin/isympy
+++ b/bin/isympy
@@ -103,6 +103,32 @@ COMMAND LINE OPTIONS
     This is equivalent to setting the environment variable
     SYMPY_USE_CACHE='no'.
 
+-a, --auto
+
+    Automatically create missing symbols.  Normally, typing a name of a
+    Symbol that has not been instantiated first would raise NameError,
+    but with this option enabled, any undefined name will be
+    automatically created as a Symbol.  This only works in IPython 0.11.
+
+    Note that this is intended only for interactive, calculator style
+    usage. In a script that uses SymPy, Symbols should be instantiated
+    at the top, so that it's clear what they are.
+
+    This will not override any names that are already defined, which
+    includes the single character letters represented by the mnemonic
+    QCOSINE (see the "Gotchas and Pitfalls" document in the
+    documentation). You can delete existing names by executing "del
+    name".  You can see if a name is defined by typing "'name' in
+    globals()".
+
+    The Symbols that are created using this have default assumptions.
+    If you want to place assumptions on symbols, you should create them
+    using symbols() or var().
+
+    Finally, this only works in the top level namespace. So, for
+    example, if you define a function in isympy with an undefined
+    Symbol, it will not work.
+
 -D, --debug
 
     Enable debugging output.  This is the same as setting the

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -27,6 +27,7 @@ def _make_message(ipython=True, quiet=False, source=None):
     from sympy import __version__ as sympy_version
     from sympy.polys.domains import GROUND_TYPES
     from sympy.utilities.misc import ARCH
+    from sympy import SYMPY_DEBUG
 
     import sys
     import os
@@ -44,6 +45,9 @@ def _make_message(ipython=True, quiet=False, source=None):
 
     if cache is not None and cache.lower() == 'no':
         info.append('cache: off')
+
+    if SYMPY_DEBUG:
+        info.append('debugging: on')
 
     args = shell_name, sympy_version, python_version, ARCH, ', '.join(info)
     message = "%s console for SymPy %s (Python %s-%s) (%s)\n" % args


### PR DESCRIPTION
I added a -D option to isympy, which enables debugging output (used extensively by Tom's new integration code, for example).  I also made the docstring of the file print with --help, and made --version/-v work as expected (print the sympy version).

Please see the XXX comments in the code.  Some of these are done in a less than ideal way.
