### PR TITLE
Some misc py3k fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,15 +83,26 @@ in the current directory.
 For more fine-grained running of tests, use ``bin/test`` or respectively
 ``bin/doctest``.
 
+5. Usage in Python 3
+-------------------
 
-5. Clean
+SymPy also supports Python 3. Currently, this is implemented by maintaining a
+Python 2 compatible codebase and running our own 2to3 script on it. Run it with::
+
+    $ bin/use2to3
+
+When ran, it will create a new directory, sympy-py3k, which holds a Python 3
+compatible version of the code. SymPy can then be used normally with Python 3
+from that directory (installation, interactive shell, etc.).
+
+6. Clean
 --------
 
 To clean everything (thus getting the same tree as in the repository)::
 
     $./setup.py clean
 
-6. Brief History
+7. Brief History
 ----------------
 
 SymPy was started by Ondrej Certik in 2005, he wrote some code during the
@@ -112,7 +123,7 @@ http://docs.sympy.org/aboutus.html#sympy-development-team
 For people that don't want to be listed there, see the git history.
 
 
-7. Citation
+8. Citation
 -----------
 
 To cite SymPy in publications use::

--- a/bin/use2to3
+++ b/bin/use2to3
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This script converts SymPy code to a Python 3-compatible version.

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -1,6 +1,7 @@
 import copy
 import pickle
 import warnings
+import sys
 from sympy.utilities.pytest import XFAIL
 
 from sympy.core.basic import Atom, Basic
@@ -33,8 +34,11 @@ def check(a, check_attr = True):
     # The below hasattr() check will warn about is_Real in Python 2.5, so
     # disable this to keep the tests clean
     warnings.filterwarnings("ignore", ".*is_Real.*", DeprecationWarning)
-    #FIXME-py3k: Add support for protocol 3.
-    for protocol in [0, 1, 2, copy.copy, copy.deepcopy]:
+    protocols = [0, 1, 2, copy.copy, copy.deepcopy]
+    # Python 2.x doesn't support the third pickling protocol
+    if sys.version_info[0] > 2:
+        protocols.extend([3])
+    for protocol in protocols:
         if callable(protocol):
             if isinstance(a, BasicType):
                 # Classes can't be copied, but that's okay.
@@ -212,7 +216,6 @@ from sympy.matrices.matrices import Matrix, SparseMatrix
 
 def test_matrices():
     for c in (Matrix, Matrix([1,2,3]), SparseMatrix, SparseMatrix([[1,2],[3,4]])):
-        #FIXME-py3k: This raises sympy.matrices.matrices.ShapeError
         check(c)
 
 #================== ntheory =====================
@@ -362,9 +365,6 @@ def test_printing():
     for c in (LatexPrinter, LatexPrinter(), MathMLPrinter,
               PrettyPrinter, prettyForm, stringPict, stringPict("a"),
               Printer, Printer(), PythonPrinter, PythonPrinter()):
-        #FIXME-py3k: sympy/printing/printer.py", line 220, in order
-        #FIXME-py3k: return self._settings['order']
-        #FIXME-py3k: KeyError: 'order'
         check(c)
 
 @XFAIL


### PR DESCRIPTION
Just two simple commits. The first updates test_pickling to test protocol 3 too and cleans up some outdated comments related to Python 3 support; the second adds a section to the README file about using SymPy with Python 3. I'm open to suggestions for the second one, I didn't really know what to write exactly.
