### PR TITLE
Automatically construct missing symbols in isympy

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -118,6 +118,13 @@ def main():
         default=True,
         help='disable caching mechanism')
 
+    parser.add_option(
+        '-a', '--auto',
+        dest='auto',
+        action='store_true',
+        default=False,
+        help='automatically construct missing symbols')
+
     (options, ipy_args) = parser.parse_args()
 
     if not options.cache:
@@ -155,6 +162,7 @@ def main():
         args['order'] = options.order
 
     args['quiet'] = options.quiet
+    args['auto'] = options.auto
 
     from sympy.interactive import init_session
     init_session(ipython, **args)

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -64,16 +64,45 @@ def _make_message(ipython=True, quiet=False, source=None):
 
     return message
 
-def _init_ipython_session(argv=[]):
+def _init_ipython_session(argv=[], auto=False):
     """Construct new IPython session. """
     import IPython
+
     if IPython.__version__ >= '0.11':
-        from IPython.frontend.terminal import ipapp
         # use an app to parse the command line, and init config
+        from IPython.frontend.terminal import ipapp
         app = ipapp.TerminalIPythonApp()
+
         # don't draw IPython banner during initialization:
         app.display_banner = False
         app.initialize(argv)
+
+        import re
+        re_nameerror = re.compile("name '(?P<symbol>[A-Za-z_][A-Za-z0-9_]*)' is not defined")
+
+        def handler(self, etype, value, tb, tb_offset=None):
+            """Handle :exc:`NameError` exception and allow injection of missing symbols. """
+            if etype is NameError and tb.tb_next and not tb.tb_next.tb_next:
+                match = re_nameerror.match(str(value))
+
+                if match is not None:
+                    self.run_cell("%(symbol)s = Symbol('%(symbol)s')" %
+                        {'symbol': match.group("symbol")}, store_history=False)
+
+                    try:
+                        code = self.user_ns_hidden['In'][-1]
+                    except (KeyError, IndexError):
+                        pass
+                    else:
+                        self.run_cell(code, store_history=False)
+                        return None
+
+            stb = self.InteractiveTB.structured_traceback(etype, value, tb, tb_offset=tb_offset)
+            self._showtraceback(etype, value, stb)
+
+        if auto:
+            app.shell.set_custom_exc((NameError,), handler)
+
         return app.shell
     else:
         from IPython.Shell import make_IPython
@@ -112,7 +141,7 @@ def _init_python_session():
     return SymPyConsole()
 
 def init_session(ipython=None, pretty_print=True, order=None,
-        use_unicode=None, quiet=False, argv=[]):
+        use_unicode=None, quiet=False, auto=False, argv=[]):
     """Initialize an embedded IPython or Python session. """
     import sys
 
@@ -134,6 +163,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 raise RuntimeError("IPython is not available on this system")
         else:
             ipython = True
+
             if IPython.__version__ >= '0.11':
                 try:
                     ip = get_ipython()
@@ -147,7 +177,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
             if ip is not None:
                 in_ipython = True
             else:
-                ip = _init_ipython_session(argv)
+                ip = _init_ipython_session(argv=argv, auto=auto)
 
             if IPython.__version__ >= '0.11':
                 # runsource is gone, use run_cell instead, which doesn't
@@ -157,6 +187,9 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 mainloop = ip.mainloop
             else:
                 mainloop = ip.interact
+
+    if auto and (not ipython or IPython.__version__ < '0.11'):
+        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above")
 
     _preexec_source = preexec_source
 


### PR DESCRIPTION
By default, if a symbol was not defined before code execution, NameError
exception is raised:

```
$ bin/isympy -q
IPython console for SymPy 0.7.1-git (Python 2.6.6-64-bit) (ground types: gmpy)

In [1]: 'a' in globals()
Out[1]: False

In [2]: integrate(a*x, x)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/home/mateusz/repo/git/sympy/<ipython-input-2-26a8cf347e13> in <module>()
----> 1 integrate(a*x, x)

NameError: name 'a' is not defined

In [3]: 'a' in globals()
Out[3]: False

In [4]:
Do you really want to exit ([y]/n)?
Exiting ...
```

However, in IPython (>= 0.11) if -a or --auto command line option is
specified, all NameError exceptions that are raised in the interpreter's
stack frame are ignored and appropriate symbols constructed and injected
into the global namespace, and code rerun:

```
$ bin/isympy -q -a
IPython console for SymPy 0.7.1-git (Python 2.6.6-64-bit) (ground types: gmpy)

In [1]: 'a' in globals()
Out[1]: False

In [2]: integrate(a*x, x)
Out[2]:
   2
a⋅x
────
 2

In [3]: 'a' in globals()
Out[3]: True
```

Note that any other NameError exceptions are handled by standard
IPython traceback printing procedures:

```
In [4]: def f(): return b

In [5]: f()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/home/mateusz/repo/git/sympy/<ipython-input-5-0ec059b9bfe1> in <module>()
----> 1 f()

/home/mateusz/repo/git/sympy/<ipython-input-4-ca2b6b0871d2> in f()
----> 1 def f(): return b

NameError: global name 'b' is not defined
```
