### PR TITLE
Fixed constructor of Float class (#2107)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -298,9 +298,15 @@ class Float(Number):
 
     def __new__(cls, num, prec=15):
         prec = mlib.libmpf.dps_to_prec(prec)
-        if isinstance(num, (int, long)):
+
+        if isinstance(num, (int, long, Integer)):
             return Integer(num)
-        if isinstance(num, (str, decimal.Decimal)):
+
+        if isinstance(num, float):
+            _mpf_ = mlib.from_float(num, prec, rnd)
+        elif isinstance(num, Rational):
+            _mpf_ = mlib.from_rational(num.p, num.q, prec, rnd)
+        elif isinstance(num, (str, decimal.Decimal)):
             _mpf_ = mlib.from_str(str(num), prec, rnd)
         elif isinstance(num, tuple) and len(num) == 4:
             if type(num[1]) is str:
@@ -314,6 +320,7 @@ class Float(Number):
                     S.NegativeOne ** num[0] * num[1] * 2 ** num[2])._mpf_
         else:
             _mpf_ = mpmath.mpf(num)._mpf_
+
         if not num:
             return C.Zero()
         obj = Expr.__new__(cls)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -266,12 +266,29 @@ def test_Float():
     teq(2*pi)
     teq(cos(0.1, evaluate=False))
 
-    assert Float(1) is S.One
     assert Float(0) is S.Zero
+    assert Float(1) is S.One
+
+    assert Float(S.Zero) is S.Zero
+    assert Float(S.One) is S.One
 
 def test_Float_eval():
     a = Float(3.2)
     assert (a**2).is_Float
+
+def test_Float_issue_2107():
+    a = Float(0.1, 10)
+    b = Float("0.1", 10)
+
+    assert a - a == 0
+    assert a + (-a) == 0
+    assert S.Zero + a - a == 0
+    assert S.Zero + a + (-a) == 0
+
+    assert b - b == 0
+    assert b + (-b) == 0
+    assert S.Zero + b - b == 0
+    assert S.Zero + b + (-b) == 0
 
 def test_Infinity():
     assert oo != 1


### PR DESCRIPTION
Previously 'prec' argument was ignored when constructing a Float from Python's float. This caused problems and could result in `a - a != 0`.
