### PR TITLE
Use PurePoly for Matrix.charpoly, and let it work without specifying a Sy

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2239,6 +2239,16 @@ class Matrix(object):
 
         >>> A.berkowitz_charpoly().as_expr()
         _lambda**2 - _lambda - 6
+
+        No test is done to see that ``x`` doesn't clash with an existing
+        symbol, so using the default (``lambda``) or your own Dummy symbol is
+        the safest option:
+
+        >>> A = Matrix([[1, 2], [x, 0]])
+        >>> A.charpoly().as_expr()
+        _lambda**2 - _lambda - 2*x
+        >>> A.charpoly(x).as_expr()
+        x**2 - 3*x
         """
         return PurePoly(map(simplify, self.berkowitz()[-1]), x)
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2,7 +2,7 @@ from sympy import Basic, Symbol, Integer, C, S, Dummy, Rational, Add, Pow
 from sympy.core.sympify import sympify, converter, SympifyError
 from sympy.core.compatibility import is_sequence
 
-from sympy.polys import Poly, roots, cancel
+from sympy.polys import PurePoly, roots, cancel
 from sympy.simplify import simplify as sympy_simplify
 from sympy.utilities.iterables import flatten
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
@@ -2222,9 +2222,9 @@ class Matrix(object):
 
         return tuple(minors)
 
-    def berkowitz_charpoly(self, x, simplify=sympy_simplify):
+    def berkowitz_charpoly(self, x=Dummy('lambda'), simplify=sympy_simplify):
         """Computes characteristic polynomial minors using Berkowitz method."""
-        return Poly(map(simplify, self.berkowitz()[-1]), x)
+        return PurePoly(map(simplify, self.berkowitz()[-1]), x)
 
     charpoly = berkowitz_charpoly
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2223,7 +2223,23 @@ class Matrix(object):
         return tuple(minors)
 
     def berkowitz_charpoly(self, x=Dummy('lambda'), simplify=sympy_simplify):
-        """Computes characteristic polynomial minors using Berkowitz method."""
+        """Computes characteristic polynomial minors using Berkowitz method.
+
+        A PurePoly is returned so using different variables for ``x`` does
+        not affect the comparison or the polynomials:
+
+        >>> from sympy import Matrix
+        >>> from sympy.abc import x, y
+        >>> A = Matrix([[1, 3], [2, 0]])
+        >>> A.berkowitz_charpoly(x) == A.berkowitz_charpoly(y)
+        True
+
+        Specifying ``x`` is optional; a Dummy with name ``lambda`` is used by
+        default (which looks good when pretty-printed in unicode):
+
+        >>> A.berkowitz_charpoly().as_expr()
+        _lambda**2 - _lambda - 6
+        """
         return PurePoly(map(simplify, self.berkowitz()[-1]), x)
 
     charpoly = berkowitz_charpoly

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Matrix, SparseMatrix, eye, I, Symbol, Rational,
     Float, wronskian, cos, sin, exp, hessian, sqrt, zeros, ones, randMatrix,
     Poly, S, pi, E, oo, trigsimp, Integer, N, sympify,
-    Pow, simplify, Min, Max, Abs)
+    Pow, simplify, Min, Max, Abs, PurePoly)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
     matrix_multiply_elementwise, diag,
     SparseMatrix, SparseMatrix, NonSquareMatrixError,
@@ -1496,8 +1496,16 @@ def test_Matrix_berkowitz_charpoly():
     A = Matrix([[-K_i - UA + K_i**2/(K_i + K_w),       K_i*K_w/(K_i + K_w)],
                 [           K_i*K_w/(K_i + K_w), -K_w + K_w**2/(K_i + K_w)]])
 
-    assert A.berkowitz_charpoly(x) == \
+    charpoly = A.berkowitz_charpoly(x)
+
+    assert charpoly == \
         Poly(x**2 + (K_i*UA + K_w*UA + 2*K_i*K_w)/(K_i + K_w)*x + K_i*K_w*UA/(K_i + K_w), x, domain='ZZ(K_i,K_w,UA)')
+
+    assert type(charpoly) is PurePoly
+
+    A = Matrix([[1, 3], [2, 0]])
+
+    assert A.charpoly() == A.charpoly(x) == PurePoly(x**2 - x - 6)
 
 def test_exp():
     m = Matrix([[3,4],[0,-2]])


### PR DESCRIPTION
Use PurePoly for Matrix.charpoly, and let it work without specifying a Symbol

I used Symbol('lambda') as the default Symbol, since this is the common
name used for this variable.
