### PR TITLE
Added support for truncated series to integrate() (#1732)

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -553,6 +553,24 @@ class Integral(Expr):
                 parts.append(coeff*x)
                 continue
 
+            # g(x) = expr + O(x**n)
+            order_term = g.getO()
+
+            if order_term is not None:
+                h = self._eval_integral(g.removeO(), x)
+
+                if h is not None:
+                    h_order_expr = self._eval_integral(order_term.expr, x)
+
+                    if h_order_expr is not None:
+                        h_order_term = order_term.func(h_order_expr, *order_term.variables)
+                        parts.append(coeff*(h + h_order_term))
+                        continue
+
+                # NOTE: if there is O(x**n) and we fail to integrate then there is
+                # no point in trying other methods because they will fail anyway.
+                return None
+
             #               c
             # g(x) = (a*x+b)
             if g.is_Pow and not g.exp.has(x):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1,7 +1,7 @@
 from sympy import (S, symbols, integrate, Integral, Derivative, exp, erf, oo, Symbol,
         Function, Rational, log, sin, cos, pi, E, I, Poly, LambertW, diff, Matrix,
         sympify, sqrt, atan, asin, acos, asinh, acosh, DiracDelta, Heaviside,
-        Lambda, sstr, Add, Tuple, Interval, Sum, factor, trigsimp, simplify)
+        Lambda, sstr, Add, Tuple, Interval, Sum, factor, trigsimp, simplify, O)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.physics.units import m, s
 
@@ -658,3 +658,12 @@ def test_issue_1793b():
 def test_issue_2079():
     assert integrate(sin(x)*f(y, z), (x, 0, pi), (y, 0, pi), (z, 0, pi)) == \
         Integral(2*f(y, z), (y, 0, pi), (z, 0, pi))
+
+def test_integrate_series():
+    f = sin(x).series(x, 0, 10)
+    g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + x**10/3628800 + O(x**11)
+
+    assert integrate(f, x) == g
+    assert diff(integrate(f, x), x) == f
+
+    assert integrate(O(x**5), x) == O(x**6)


### PR DESCRIPTION
```
In [1]: series(sin(x), x, 0, 10)
Out[1]:
     3     5     7       9
    x     x     x       x       ⎛ 10⎞
x - ── + ─── - ──── + ────── + O⎝x  ⎠
    6    120   5040   362880

In [2]: integrate(_, x)
Out[2]:
 2    4     6      8       10
x    x     x      x       x        ⎛ 11⎞
── - ── + ─── - ───── + ─────── + O⎝x  ⎠
2    24   720   40320   3628800

In [3]: diff(_, x)
Out[3]:
     3     5     7       9
    x     x     x       x       ⎛ 10⎞
x - ── + ─── - ──── + ────── + O⎝x  ⎠
    6    120   5040   362880
```
