### PR TITLE
collect_terms

### DIFF
--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -4,9 +4,10 @@ for example:
 the expression E**(pi*I) will be converted into -1
 the expression (x+x)**2 will be converted into 4*x**2
 """
-from simplify import collect, rcollect, separate, radsimp, ratsimp, fraction, \
-    simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify, \
-    logcombine, separatevars, numer, denom, powdenest, posify, collect_const
+from simplify import (collect, rcollect, separate, radsimp, ratsimp, fraction,
+    simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify,
+    logcombine, separatevars, numer, denom, powdenest, posify, collect_const,
+    collect_terms)
 from sqrtdenest import sqrtdenest
 
 from cse_main import cse

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -677,16 +677,25 @@ def collect_terms(expr, *vars, **hint):
         vars.sort(key=default_sort_key)
         if not vars:
             return _keep_coeff(*expr.as_content_primitive())
+    else:
+        vars = list(vars)
 
     expr = expr.func(*[collect_terms(a, *vars) for a in expr.args])
     if not expr.is_Add:
         return expr
 
     rat, expr = expr.as_content_primitive() # maybe only primitive now?
+    more = set()
     for var in vars:
         terms = defaultdict(list)
         for m in expr.args:
             i, d = m.as_independent(var)
+            # add the sub-args that depend on var in case
+            # this collection doesn't do anything
+            for di in Mul.make_args(d):
+                if di not in more:
+                    vars.append(di)
+                    more.add(di)
             terms[d].append(i)
         missed = []
         hit = []


### PR DESCRIPTION
This builds off of the work of pull request https://github.com/sympy/sympy/pull/567 and adds a collect_terms function and uses rprimitive in terms_gcd so a fast gcd can be extracted without destroying the initial structure (and without unecessarily expanding multinomials).
