### PR TITLE
2744 fix extract_multiplicatively for two-arg mul term

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1145,3 +1145,10 @@ def test_primitive():
     assert eq.primitive()[0] == 1
     assert (4.0*x).primitive() == (1, 4.0*x)
     assert (-2*x).primitive() == (2, -x)
+
+def test_issue_2744():
+    a = 1 + x
+    assert (2*a).extract_multiplicatively(a) == 2
+    assert (4*a).extract_multiplicatively(2*a) == 2
+    assert ((3*a)*(2*a)).extract_multiplicatively(a) == 6*a
+


### PR DESCRIPTION
```
Since 2*(1+x) -> 2 + 2*x automatically, the extraction routine should
watch for this.

Also, since the args of c as a Mul are tested at the outset, if self
is a Mul we needn't delete each term to see if the remainder can be
extracted. We only need to see if c can be extracted from any of
the factors.

The two terms are captured into a and b instead of recomputing them.
```

This also fixes issue 2707.
