### PR TITLE
allow 4**x -> 2**(2*x) again

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1111,10 +1111,12 @@ def powdenest(eq, force=False):
         return Pow(C.exp(logs), efunc(*other))
 
     _, be = b.as_base_exp()
-    if be is S.One and not (b.is_Mul or b.is_Rational and b.q != 1):
+    if be is S.One and not (b.is_Mul or
+                            b.is_Rational and b.q != 1 or
+                            b.is_positive):
         return eq
 
-    # denest eq which is either Pow**e or Mul**e or Mul(b1**e1, b2**e2)
+    # denest eq which is either pos**e or Pow**e or Mul**e or Mul(b1**e1, b2**e2)
 
     # see if there is a positive, non-Mul base at the very bottom
     exponents = False
@@ -1129,6 +1131,13 @@ def powdenest(eq, force=False):
             if kernel.is_Mul:
                 b = kernel
             else:
+                if kernel.is_Integer:
+                    # use log to see if there is a power here
+                    logkernel = log(kernel)
+                    if logkernel.is_Mul:
+                        c, logk = logkernel.args
+                        e *= c
+                        kernel = logk.args[0]
                 return Pow(kernel, e)
 
     # if any factor is an atom then there is nothing to be done

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -690,6 +690,9 @@ def test_powdenest():
     # issue 2706
     assert powdenest(((gamma(x)*hyper((),(),x))*pi)**2) == (pi*gamma(x)*hyper((), (), x))**2
 
+    assert powdenest(4**x) == 2**(2*x)
+    assert powdenest((4**x)**y) == 2**(2*x*y)
+
 @XFAIL
 def test_issue_2706():
     assert (((gamma(x)*hyper((),(),x))*pi)**2).is_positive is None

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -665,7 +665,8 @@ def test_powdenest():
     assert powdenest(exp(3*x*log(2))) == 2**(3*x)
     assert powdenest(sqrt(p**2)) == p
     i, j = symbols('i,j', integer=True)
-    assert powdenest(p**(2*i)*q**(4*i)) == (p*q**2)**(2*i)
+    eq = p**(2*i)*q**(4*i)
+    assert powdenest(eq) == (p*q**2)**(2*i)
     assert powdenest((x**x)**(i + j)) # -X-> (x**x)**i*(x**x)**j == x**(x*(i + j))
     assert powdenest(exp(3*y*log(x))) == x**(3*y)
     assert powdenest(exp(y*(log(a) + log(b)))) == (a*b)**y
@@ -685,13 +686,14 @@ def test_powdenest():
     assert powdenest((x**2*y**6)**i) != (x*y**3)**(2*i)
     x, y = symbols('x,y', positive=True)
     assert powdenest((x**2*y**6)**i) == (x*y**3)**(2*i)
-    assert powdenest((x**(2*i/3)*y**(i/2))**(2*i)) == (x**(S(2)/3)*sqrt(y))**(2*i**2)
+    assert powdenest((x**(2*i/3)*y**(i/2))**(2*i)) == (x**(S(4)/3)*y)**(i**2)
     assert powdenest(sqrt(x**(2*i)*y**(6*i))) == (x*y**3)**i
     # issue 2706
     assert powdenest(((gamma(x)*hyper((),(),x))*pi)**2) == (pi*gamma(x)*hyper((), (), x))**2
 
     assert powdenest(4**x) == 2**(2*x)
     assert powdenest((4**x)**y) == 2**(2*x*y)
+    assert powdenest(4**x*y) == 2**(2*x)*y
 
 @XFAIL
 def test_issue_2706():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -310,6 +310,10 @@ def test_powsimp():
     # force=True overrides assumptions
     assert powsimp((-1)**(2*x), force=True) == 1
 
+    eq = x**(2*a/3)
+    assert powsimp(eq).exp == eq.exp == 2*a/3 # eq != (x**a)**(2/3) (try x = -1 and a = 3 to see)
+    assert powsimp(2**(2*x)) == 4**x # powdenest goes the other direction
+
 def test_powsimp_nc():
     x, y, z = symbols('x,y,z')
     A, B, C = symbols('A B C', commutative=False)


### PR DESCRIPTION
```
The reason for allowing this behavior is that (2**4)**x automatically
becomes 16**x and you can no longer 'see' the exponent of 4. In order
to allow terms to become canonical wrt bases, this function allows
that "hidden" 4 to be recovered so 2**(4*x) is obtained.
```
