### PR TITLE
Raise TypeError when wrong number of args was passed to a function

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -180,10 +180,19 @@ class Function(Application, Expr):
             return UndefinedFunction(*args)
 
         if cls.nargs is not None:
-            if (isinstance(cls.nargs, tuple) and len(args) not in cls.nargs) \
-               or (not isinstance(cls.nargs, tuple) and cls.nargs != len(args)):
-               raise ValueError('Function %s expects %s argument(s), got %s.' % (
-                                 cls, cls.nargs, len(args)))
+            if isinstance(cls.nargs, tuple):
+                nargs = cls.nargs
+            else:
+                nargs = (cls.nargs,)
+
+            n = len(args)
+
+            if n not in nargs:
+                # XXX: exception message must be in exactly this format to make it work with
+                # NumPy's functions like vectorize(). Ideal solution would be just to attach
+                # metadata to the exception and change NumPy to take advantage of this.
+                raise TypeError('%(name)s takes exactly %(args)s argument%(plural)s (%(given)s given)' %
+                    {'name': cls, 'args': cls.nargs, 'plural': 's'*(n != 1), 'given': n})
 
         args = map(sympify, args)
         evaluate = options.pop('evaluate', True)

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -383,7 +383,7 @@ def test_fdiff_argument_index_error():
             raise ArgumentIndexError
     mf = myfunc(x)
     assert mf.diff(x) == Derivative(mf, x)
-    raises(ValueError, 'myfunc(x, x)')
+    raises(TypeError, 'myfunc(x, x)')
 
 def test_deriv_wrt_function():
     t = Symbol('t')
@@ -537,4 +537,3 @@ def test_unhandled():
     expr = MyExpr(x,y,z)
     assert diff(expr,x,y,f(x),z) == Derivative(expr,f(x),z)
     assert diff(expr,f(x),x) == Derivative(expr,f(x),x)
-

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -284,3 +284,5 @@ def test_symarray():
     assert a3d[1,2,0] is a120
     assert a3d[1,2,1] is a121
 
+def test_vectorize():
+    assert (numpy.vectorize(sin)([1, 2, 3]) == numpy.array([sin(1), sin(2), sin(3)])).all()


### PR DESCRIPTION
Previously ValueError was raised which was semantically wrong and also made it hard to cooperate with other libraries. For example, in NumPy vectorize() assumes that TypeError (with specific error message) is raised when wrong number of arguments is passed to a function. Now it gives:

```
In [1]: import numpy as np

In [2]: np.vectorize(sin)
Out[2]: <numpy.lib.function_base.vectorize object at 0x2372750>
```

This problem was reported by Fernando Perez.
