### PR TITLE
move solve_congruence to ntheory.modular

### DIFF
--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -41,7 +41,7 @@ def crt(m, v, symmetric=False, check=True):
        >>> from sympy.ntheory.modular import crt, solve_congruence
 
        >>> crt([99, 97, 95], [49, 76, 65])
-       639985
+       (639985, 912285)
 
     This is the correct result because::
 
@@ -52,21 +52,21 @@ def crt(m, v, symmetric=False, check=True):
     if you use ``check=False``:
 
        >>> crt([12, 6, 17], [3, 4, 2], check=False)
-       954
+       (954, 1224)
        >>> [954 % m for m in [12, 6, 17]]
        [6, 0, 2]
        >>> crt([12, 6, 17], [3, 4, 2]) is None
        True
        >>> crt([3, 6], [2, 5])
-       5
+       (5, 6)
+
+    Note: the order of gf_crt's arguments is reversed relative to crt,
+    and that solve_congruence takes residue, modulus pairs.
 
     Programmer's note: rather than checking that all pairs of moduli share
     no GCD (an O(n**2) test) and rather than factoring all moduli and seeing
     that there is no factor in common, a check that the result gives the
     indicated residuals is performed -- an O(n) operation.
-
-    Note also that the order of gf_crt's arguments is reversed relative to crt,
-    and that solve_congruence takes residue, modulus pairs.
     """
     if check:
         m = int_tested(*m)
@@ -80,12 +80,13 @@ def crt(m, v, symmetric=False, check=True):
             result = solve_congruence(*zip(v, m),
                                       **dict(check=False,
                                              symmetric=symmetric))
-            if result is not None:
-                return result[0]
+            if result is None:
+                return result
+            result, mm = result
 
     if symmetric:
-        return symmetric_residue(result, mm)
-    return result
+        return symmetric_residue(result, mm), mm
+    return result, mm
 
 def crt1(m):
     """First part of Chinese Remainder Theorem, for multiple application. """
@@ -98,8 +99,8 @@ def crt2(m, v, mm, e, s, symmetric=False):
     result = gf_crt2(v, m, mm, e, s, ZZ)
 
     if symmetric:
-        return symmetric_residue(result, mm)
-    return result
+        return symmetric_residue(result, mm), mm
+    return result, mm
 
 def solve_congruence(*remainder_modulus_pairs, **hint):
     """Compute the integer ``n`` that has the residual ``ai`` when it is
@@ -196,7 +197,7 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
         # test is a good trade-off
         if all(isprime(m) for r, m in rm):
             r, m = zip(*rm)
-            return crt(m, r, symmetric=symmetric, check=False), prod(m)
+            return crt(m, r, symmetric=symmetric, check=False)
 
     rv = (0, 1)
     for rmi in rm:

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -1,63 +1,211 @@
-from sympy.core.numbers import igcdex
+from sympy.core.numbers import igcdex, igcd
+from sympy.core.mul import prod
+from sympy.ntheory.residue_ntheory import int_tested
+from sympy.ntheory.primetest import isprime
+from sympy.polys.domains import ZZ
+from sympy.polys.galoistools import gf_crt, gf_crt1, gf_crt2
 
-def crt(m, v, symmetric=False):
+def symmetric_residue(a, m):
+    """Return the residual mod m such that it is within half of the modulus.
+
+    >>> from sympy.ntheory.modular import symmetric_residue
+    >>> symmetric_residue(1, 6)
+    1
+    >>> symmetric_residue(4, 6)
+    -2
+    """
+    if a <= m // 2:
+        return a
+    else:
+        return a - m
+
+def crt(m, v, symmetric=False, check=True):
     """Chinese Remainder Theorem.
 
-       The integers in m are assumed to be pairwise coprime.  The output
-       is then an integer f, such that f = v_i mod m_i for each pair out
-       of v and m.
+    The moduli in m are assumed to be pairwise coprime.  The output
+    is then an integer f, such that f = v_i mod m_i for each pair out
+    of v and m. If ``symmetric`` is False a positive integer will be
+    returned, else |f| will be less than or equal to the LCM of the
+    moduli, and thus f may be negative.
 
+    If the moduli are not co-prime the correct result will be returned
+    if/when the test of the result is found to be incorrect. This result
+    will be None if there is no solution.
+
+    The keyword ``check`` can be set to False if it is known that the moduli
+    are coprime.
+
+    As an example consider a set of residues ``U = [49, 76, 65]``
+    and a set of moduli ``M = [99, 97, 95]``. Then we have::
+
+       >>> from sympy.ntheory.modular import crt, solve_congruence
+
+       >>> crt([99, 97, 95], [49, 76, 65])
+       639985
+
+    This is the correct result because::
+
+       >>> [639985 % m for m in [99, 97, 95]]
+       [49, 76, 65]
+
+    If the moduli are not co-prime, you may receive an incorrect result
+    if you use ``check=False``:
+
+       >>> crt([12, 6, 17], [3, 4, 2], check=False)
+       954
+       >>> [954 % m for m in [12, 6, 17]]
+       [6, 0, 2]
+       >>> crt([12, 6, 17], [3, 4, 2]) is None
+       True
+       >>> crt([3, 6], [2, 5])
+       5
+
+    Programmer's note: rather than checking that all pairs of moduli share
+    no GCD (an O(n**2) test) and rather than factoring all moduli and seeing
+    that there is no factor in common, a check that the result gives the
+    indicated residuals is performed -- an O(n) operation.
+
+    Note also that the order of gf_crt's arguments is reversed relative to crt,
+    and that solve_congruence takes residue, modulus pairs.
     """
-    mm = 1
+    if check:
+        m = int_tested(*m)
+        v = int_tested(*v)
 
-    for m_i in m:
-        mm *= m_i
+    result = gf_crt(v, m, ZZ)
+    mm = prod(m)
 
-    result = 0
-
-    for m_i, v_i in zip(m, v):
-        e = mm // m_i
-        s, t, g = igcdex(e, m_i)
-        c = v_i*s % m_i
-        result += c*e
-
-    result %= mm
+    if check:
+        if not all(v % m == result % m for v, m in zip(v, m)):
+            result = solve_congruence(*zip(v, m),
+                                      **dict(check=False,
+                                             symmetric=symmetric))
+            if result is not None:
+                return result[0]
 
     if symmetric:
-        if result <= mm//2:
-            return result
-        else:
-            return result - mm
-    else:
-        return result
+        return symmetric_residue(result, mm)
+    return result
 
 def crt1(m):
-    """First part of chines remainder theorem, for multiple application. """
-    mm, e, s = 1, [], []
+    """First part of Chinese Remainder Theorem, for multiple application. """
 
-    for m_i in m:
-        mm *= m_i
-
-    for m_i in m:
-        e.append(mm // m_i)
-        s.append(igcdex(e[-1], m_i)[0])
-
-    return mm, e, s
+    return gf_crt1(m, ZZ)
 
 def crt2(m, v, mm, e, s, symmetric=False):
     """Second part of Chinese Remainder Theorem, for multiple application. """
-    result = 0
 
-    for m_i, v_i, e_i, s_i in zip(m, v, e, s):
-        c = v_i*s_i % m_i
-        result += c*e_i
-
-    result %= mm
+    result = gf_crt2(v, m, mm, e, s, ZZ)
 
     if symmetric:
-        if result <= mm // 2:
-            return result
-        else:
-            return result - mm
+        return symmetric_residue(result, mm)
+    return result
+
+def solve_congruence(*remainder_modulus_pairs, **hint):
+    """Compute the integer ``n`` that has the residual ``ai`` when it is
+    divided by ``mi`` where the ``ai`` and ``mi`` are given as pairs to
+    this function: ((a1, m1), (a2, m2), ...). If there is no solution,
+    return None. Otherwise return ``n`` and its modulus.
+
+    The ``mi`` values need not be co-prime. If it is known that the moduli are
+    not co-prime then the hint ``check`` can be set to False (default=True) and
+    the check for a quicker solution via crt() (valid when the moduli are
+    co-prime) will be skipped.
+
+    If the hint ``symmetric`` is True (default is False), the value of ``n``
+    will be within 1/2 of the modulus, possibly negative.
+
+    Examples::
+    >>> from sympy.ntheory.modular import solve_congruence
+
+    What number is 2 mod 3, 3 mod 5 and 2 mod 7?
+    >>> solve_congruence((2, 3), (3, 5), (2, 7))
+    (23, 105)
+    >>> [23 % m for m in [3, 5, 7]]
+    [2, 3, 2]
+
+    If you prefer to work with all remainder in one list and
+    all moduli in another, send the arguments like this:
+    >>> solve_congruence(*zip((2, 3, 2), (3, 5, 7)))
+    (23, 105)
+
+    The moduli need not be co-prime; in this case there may or
+    may not be a solution:
+    >>> solve_congruence((2, 3), (4, 6)) is None
+    True
+    >>> solve_congruence((2, 3), (5, 6))
+    (5, 6)
+
+    The symmetric flag will make the result be within 1/2 of the modulus:
+    >>> solve_congruence((2, 3), (5, 6), symmetric=True)
+    (-1, 6)
+
+    See also: crt and sympy.polys.galoistools.gf_crt
+    """
+    def combine(c1, c2):
+        """Return the tuple (a, m) which satisfies the requirement
+        that n = a + i*m satisfy n = a1 + j*m1 and n = a2 = k*m2.
+
+        Reference:
+           http://en.wikipedia.org/wiki/Method_of_successive_substitution
+        """
+        from sympy.core.numbers import igcdex
+        a1, m1 = c1
+        a2, m2 = c2
+        a, b, c = m1, a2 - a1, m2
+        g = reduce(igcd, [a, b, c])
+        a, b, c = [i//g for i in [a, b, c]]
+        if a != 1:
+            inv_a, _, g = igcdex(a, c)
+            if g != 1:
+                return None
+            b *= inv_a
+        a, m = a1 + m1*b, m1*c
+        return a, m
+
+    rm = remainder_modulus_pairs
+    symmetric = hint.get('symmetric', False)
+
+    if hint.get('check', True):
+        rm = [int_tested(*pair) for pair in rm]
+
+        # ignore redundant pairs but raise an error otherwise; also
+        # make sure that a unique set of bases is sent to gf_crt if
+        # they are all prime.
+        #
+        # The routine will work out less-trivial violations and
+        # return None, e.g. for the pairs (1,3) and (14,42) there
+        # is no answer because 14 mod 42 (having a gcd of 14) implies
+        # (14/2) mod (42/2), (14/7) mod (42/7) and (14/14) mod (42/14)
+        # which, being 0 mod 3, is inconsistent with 1 mod 3. But to
+        # preprocess the input beyond checking of another pair with 42
+        # or 3 as the modulus (for this example) is not necessary.
+        uniq = {}
+        for r, m in rm:
+            r %= m
+            if m in uniq:
+                if r != uniq[m]:
+                    return None
+                continue
+            uniq[m] = r
+        rm = [(r, m) for m, r in uniq.iteritems()]
+        del uniq
+
+        # if the moduli are co-prime, the crt will be significantly faster;
+        # checking all pairs for being co-prime gets to be slow but a prime
+        # test is a good trade-off
+        if all(isprime(m) for r, m in rm):
+            r, m = zip(*rm)
+            return crt(m, r, symmetric=symmetric, check=False), prod(m)
+
+    rv = (0, 1)
+    for rmi in rm:
+        rv = combine(rv, rmi)
+        if rv is None:
+            break
+        n, m = rv
+        n = n % m
     else:
-        return result
+        if symmetric:
+            return symmetric_residue(n, m), m
+        return n, m

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -395,9 +395,9 @@ def test_hex_pi_nth_digits():
 
 def test_crt():
     def mcrt(m, v, r, symmetric=False):
-        assert crt(m, v, symmetric) == r
+        assert crt(m, v, symmetric)[0] == r
         mm, e, s = crt1(m)
-        assert crt2(m, v, mm, e, s, symmetric) == r
+        assert crt2(m, v, mm, e, s, symmetric) == (r, mm)
 
     mcrt([2, 3, 5], [0, 0, 0], 0)
     mcrt([2, 3, 5], [1, 1, 1], 1)
@@ -405,6 +405,7 @@ def test_crt():
     mcrt([2, 3, 5], [-1, -1, -1], -1, True)
     mcrt([2, 3, 5], [-1, -1, -1], 2*3*5 - 1, False)
 
+    assert crt([656, 350], [811, 133], symmetric=True) == (-56917, 114800)
 
 def test_binomial_coefficients_list():
     assert binomial_coefficients_list(0) == [1]

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -11,7 +11,7 @@ from sympy.ntheory.factor_ import smoothness, smoothness_p
 from sympy.ntheory.generate import cycle_length
 from sympy.ntheory.primetest import _mr_safe_helper, mr
 from sympy.ntheory.bbp_pi import pi_hex_digits
-from sympy.ntheory.modular import crt, crt1, crt2
+from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence
 
 from sympy.utilities.pytest import raises
 from sympy.utilities.iterables import capture
@@ -517,3 +517,15 @@ def test_visual_io():
     assert fi({4: 2}, visual=False) == fi(16)
     assert fi(Mul(*[Pow(k, v, **no) for k, v in {4: 2, 2: 6}.items()], **no),
               visual=False) == fi(2**10)
+
+def test_modular():
+    assert solve_congruence(*zip([3, 4, 2], [12, 35, 17])) == (1719, 7140)
+    assert solve_congruence(*zip([3, 4, 2], [12, 6, 17])) is None
+    assert solve_congruence(*zip([3, 4, 2], [13, 7, 17])) == (172, 1547)
+    assert solve_congruence(*zip([-10, -3, -15], [13, 7, 17])) == (172, 1547)
+    assert solve_congruence(*zip([-10, -3, 1, -15], [13, 7, 7, 17])) is None
+    assert solve_congruence(*zip([-10, -5, 2, -15], [13, 7, 7, 17])) == (835, 1547)
+    assert solve_congruence(*zip([-10, -5, 2, -15], [13, 7, 14, 17])) == (2382, 3094)
+    assert solve_congruence(*zip([-10, 2, 2, -15], [13, 7, 14, 17])) == (2382, 3094)
+    assert solve_congruence(*zip((1, 1, 2),(3, 2, 4))) is None
+    raises(ValueError, 'solve_congruence(*zip([3, 4, 2], [12.1, 35, 17]))')

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -682,7 +682,7 @@ def dmp_zz_modular_resultant(f, g, p, u, K):
 
 def _collins_crt(r, R, P, p, K):
     """Wrapper of CRT for Collins's resultant algorithm. """
-    return gf_int(gf_crt([r, R], [P, p], K, check=False), P*p)
+    return gf_int(gf_crt([r, R], [P, p], K), P*p)
 
 @cythonized("u,v,n,m")
 def dmp_zz_collins_resultant(f, g, u, K):

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -18,7 +18,7 @@ from sympy.ntheory import factorint
 
 
 
-def gf_crt(U, M, K=None, check=True):
+def gf_crt(U, M, K=None):
     """
     Chinese Remainder Theorem.
 
@@ -26,18 +26,12 @@ def gf_crt(U, M, K=None, check=True):
     co-prime integer moduli ``m_0,...,m_n``, returns an integer
     ``u``, such that ``u = u_i mod m_i`` for ``i = ``0,...,n``.
 
-    It is assumed that all moduli are coprime. If this is not True, the
-    correct result will be returned if/when the test of the results is
-    found to be incorrect if ``K == ZZ`` (default) otherwise None will be
-    returned. The keyword ``check`` can be set to False if it is known that
-    the moduli are coprime. All other checking is omitted to not slow
-    down this low-level routine.
-
     As an example consider a set of residues ``U = [49, 76, 65]``
     and a set of moduli ``M = [99, 97, 95]``. Then we have::
 
        >>> from sympy.polys.domains import ZZ
-       >>> from sympy.polys.galoistools import gf_crt, solve_congruence
+       >>> from sympy.polys.galoistools import gf_crt
+       >>> from sympy.ntheory.modular import solve_congruence
 
        >>> gf_crt([49, 76, 65], [99, 97, 95], ZZ)
        639985
@@ -47,25 +41,10 @@ def gf_crt(U, M, K=None, check=True):
        >>> [639985 % m for m in [99, 97, 95]]
        [49, 76, 65]
 
-    If the moduli are not co-prime, you may receive an incorrect result
-    if you use ``check=False``:
+    Note: this is a low-level routine with no error checking.
 
-       >>> gf_crt([3, 4, 2], [12, 6, 17], check=False)
-       954
-       >>> [954 % m for m in [12, 6, 17]]
-       [6, 0, 2]
-       >>> gf_crt([3, 4, 2], [12, 6, 17]) is None
-       True
-       >>> gf_crt([2, 5], [3, 6])
-       5
-
-    Programmer's note: rather than checking that all pairs of moduli share
-    no GCD (an O(n**2) test) and rather than factoring all moduli and seeing
-    that there is no factor in common, a check that the result gives the
-    indicated residuals is performed, an O(n) operation.
+    See also: crt and solve_congruence in sympy.ntheory.modular.
     """
-    from sympy.polys.domains import ZZ
-    K = K or ZZ
     p = prod(M, start=K.one)
     v = K.zero
 
@@ -74,17 +53,7 @@ def gf_crt(U, M, K=None, check=True):
         s, _, _ = K.gcdex(e, m)
         v += e*(u*s % m)
 
-    rv = v % p
-    if not check:
-        return rv
-    if K == ZZ:
-        if all(u % m == rv % m for u, m in zip(U, M)):
-            return rv
-        rv = solve_congruence(*zip(U, M), **dict(check=False))
-        if rv is not None:
-            rv = rv[0]
-        return rv
-    # XXX TODO what should be done if K is not ZZ?
+    return v % p
 
 def gf_crt1(M, K):
     """
@@ -99,10 +68,8 @@ def gf_crt1(M, K):
     (912285, [9215, 9405, 9603], [62, 24, 12])
 
     """
-    p, E, S = K.one, [], []
-
-    for m in M:
-        p *= m
+    E, S = [], []
+    p = prod(M, start=K.one)
 
     for m in M:
         E.append(p // m)
@@ -2168,97 +2135,4 @@ def gf_csolve(f, n):
     for pool in pools:
         perms = [x + [y] for x in perms for y in pool]
     dist_factors = [pow(p, e) for p, e in P.iteritems()]
-    return sorted([gf_crt(per, dist_factors, ZZ, check=False) for per in perms])
-
-def solve_congruence(*remainder_modulus_pairs, **hint):
-    """Return `ai`, `mi` for n = ai + ji*mi where ``remainder_modulus_pairs``
-    contain (ai, mi). If there is no solution, return None. The ``mi`` values
-    need not be co-prime. If it is known that the moduli are not co-prime then
-    the hint check=False (default=True) can be used to bypass the check for a
-    quicker solution through use of gf_crt().
-
-    Examples::
-    >>> from sympy.polys.galoistools import solve_congruence
-
-    What number is 2 mod 3, 3 mod 5 and 2 mod 7?
-    >>> solve_congruence((2, 3), (3, 5), (2, 7))
-    (23, 105)
-    >>> [23 % m for m in [3, 5, 7]]
-    [2, 3, 2]
-
-    If you prefer to work with all remainder in one list and
-    all moduli in another, send the arguments like this:
-    >>> solve_congruence(*zip((2, 3, 2), (3, 5, 7)))
-    (23, 105)
-
-    The moduli need not be co-prime; in this case there may or
-    may not be a solution:
-    >>> solve_congruence((2, 3), (5, 6))
-    (5, 6)
-    >>> solve_congruence((2, 3), (4, 6)) is None
-    True
-
-    See also: sympy.polys.galoistools.gf_crt
-    """
-    from sympy.polys.domains import ZZ
-    def combine(c1, c2):
-        """Return the tuple (a, m) which satisfies the requirement
-        that n = a + i*m satisfy n = a1 + j*m1 and n = a2 = k*m2.
-
-        Reference:
-           http://en.wikipedia.org/wiki/Method_of_successive_substitution
-        """
-        from sympy.core.numbers import igcdex
-        a1, m1 = c1
-        a2, m2 = c2
-        a, b, c = m1, a2 - a1, m2
-        g = reduce(igcd, [a, b, c])
-        a, b, c = [i//g for i in [a, b, c]]
-        if a != 1:
-            inv_a, _, g = igcdex(a, c)
-            if g != 1:
-                return None
-            b *= inv_a
-        a, m = a1 + m1*b, m1*c
-        return a % m, m
-
-    rm = remainder_modulus_pairs
-    rm = [int_tested(*pair) for pair in rm]
-
-    if hint.get('check', True):
-        # ignore redundant pairs but raise an error otherwise; also
-        # make sure that a unique set of bases is sent to gf_crt if
-        # they are all prime.
-        #
-        # The routine will work out less-trivial violations and
-        # return None, e.g. for the pairs (1,3) and (14,42) there
-        # is no answer because 14 mod 42 (having a gcd of 14) implies
-        # (14/2) mod (42/2), (14/7) mod (42/7) and (14/14) mod (42/14)
-        # which, being 0 mod 3, is inconsistent with 1 mod 3. But to
-        # preprocess the input beyond checking of another pair with 42
-        # or 3 as the modulus (for this example) is not necessary.
-        uniq = {}
-        for r, m in rm:
-            r %= m
-            if m in uniq:
-                if r != uniq[m]:
-                    return None
-                continue
-            uniq[m] = r
-        rm = [(r, m) for m, r in uniq.iteritems()]
-        del uniq
-
-        # if the moduli are co-prime, the crt will be significantly faster;
-        # checking all pairs for being co-prime gets to be slow but a prime
-        # test is a good trade-off
-        if all(isprime(m) for r, m in rm):
-            r, m = zip(*rm)
-            return gf_crt(r, m, ZZ, check=False), prod(m)
-
-    rv = (0, 1)
-    for rmi in rm:
-        rv = combine(rv, rmi)
-        if rv is None:
-            break
-    else:
-        return tuple(rv)
+    return sorted([gf_crt(per, dist_factors, ZZ) for per in perms])

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -24,7 +24,6 @@ from sympy.polys.galoistools import (
     gf_berlekamp, gf_zassenhaus, gf_shoup,
     gf_factor_sqf, gf_factor,
     gf_value, linear_congruence, csolve_prime, gf_csolve,
-    solve_congruence
 )
 
 from sympy.polys.polyerrors import (
@@ -799,15 +798,3 @@ def test_gf_csolve():
     assert gf_csolve([1, 1, 7], 189) == [13, 49, 76, 112, 139, 175]
     assert gf_csolve([1, 3, 4, 1, 30], 60) ==  [10, 30]
     assert gf_csolve([1, 1, 7], 15) == []
-
-def test_solve_congruence():
-    assert solve_congruence(*zip([3, 4, 2], [12, 35, 17])) == (1719, 7140)
-    assert solve_congruence(*zip([3, 4, 2], [12, 6, 17])) is None
-    assert solve_congruence(*zip([3, 4, 2], [13, 7, 17])) == (172, 1547)
-    assert solve_congruence(*zip([-10, -3, -15], [13, 7, 17])) == (172, 1547)
-    assert solve_congruence(*zip([-10, -3, 1, -15], [13, 7, 7, 17])) is None
-    assert solve_congruence(*zip([-10, -5, 2, -15], [13, 7, 7, 17])) == (835, 1547)
-    assert solve_congruence(*zip([-10, -5, 2, -15], [13, 7, 14, 17])) == (2382, 3094)
-    assert solve_congruence(*zip([-10, 2, 2, -15], [13, 7, 14, 17])) == (2382, 3094)
-    assert solve_congruence(*zip((1, 1, 2),(3, 2, 4))) is None
-    raises(ValueError, 'solve_congruence(*zip([3, 4, 2], [12.1, 35, 17]))')


### PR DESCRIPTION
```
This is a better place for this function since the gf routines which
are suppose to be more low level are then left uncluttered with the
extra testing that solve_congruence and crt (now) do. In addition, the
symmetric flag is used in solve_congruence as it was in crt; the
symmetric_residual code was factored out into its own function; the
modular crt routines call the galoistools functions so as not to
duplicate code.
```
