### PR TITLE
change names of imported math functions (e.g. sqrt -> _sqrt)

### DIFF
--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -1,6 +1,6 @@
 from sympy.core import S, C, sympify, Function
 from sympy.ntheory import sieve
-from math import sqrt
+from math import sqrt as _sqrt
 
 from sympy.core.compatibility import reduce
 
@@ -70,7 +70,7 @@ class factorial(CombinatorialFunction):
         if n < 33:
             return cls._small_swing[n]
         else:
-            N, primes = int(sqrt(n)), []
+            N, primes = int(_sqrt(n)), []
 
             for prime in sieve.primerange(3, N+1):
                 p, q = 1, n
@@ -400,7 +400,7 @@ class binomial(CombinatorialFunction):
                     elif k > n // 2:
                         k = n - k
 
-                    M, result = int(sqrt(n)), 1
+                    M, result = int(_sqrt(n)), 1
 
                     for prime in sieve.primerange(2, n+1):
                         if prime > n - k:

--- a/sympy/plotting/plot_rotation.py
+++ b/sympy/plotting/plot_rotation.py
@@ -1,5 +1,5 @@
 from pyglet.gl import *
-from math import sqrt, acos
+from math import sqrt as _sqrt, acos as _acos
 
 def cross(a, b):
     return (a[1]*b[2] - a[2]*b[1],
@@ -10,7 +10,7 @@ def dot(a, b):
     return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
 
 def mag(a):
-    return sqrt(a[0]**2 + a[1]**2 + a[2]**2)
+    return _sqrt(a[0]**2 + a[1]**2 + a[2]**2)
 
 def norm(a):
     m = mag(a)
@@ -20,7 +20,7 @@ def get_sphere_mapping(x, y, width, height):
     x = min([max([x,0]), width])
     y = min([max([y,0]), height])
 
-    sr = sqrt( (width/2)**2 + (height/2)**2 )
+    sr = _sqrt( (width/2)**2 + (height/2)**2 )
     #sr *= 1.5
     sx = ( (x - width/2)  / sr )
     sy = ( (y - height/2) / sr )
@@ -28,7 +28,7 @@ def get_sphere_mapping(x, y, width, height):
     sz = 1.0 - sx**2 - sy**2
 
     if sz > 0.0:
-        sz = sqrt(sz)
+        sz = _sqrt(sz)
         return (sx, sy, sz)
     else:
         sz = 0
@@ -46,8 +46,8 @@ def get_spherical_rotatation(p1, p2, width, height, theta_multiplier):
         return None
 
     raxis = norm( cross(v1, v2) )
-    rtheta = theta_multiplier * rad2deg * acos(d)
-    #rtheta = 2.0 * rad2deg * acos(d)
+    rtheta = theta_multiplier * rad2deg * _acos(d)
+    #rtheta = 2.0 * rad2deg * _acos(d)
 
     glPushMatrix()
     glLoadIdentity()

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -52,7 +52,7 @@ from sympy.utilities import (
     cythonized, variations
 )
 
-from math import ceil, log
+from math import ceil as _ceil, log as _log
 
 @cythonized("m,n,i,j")
 def dup_integrate(f, m, K):
@@ -1239,7 +1239,7 @@ def dup_revert(f, n, K):
     g = [K.revert(dup_TC(f, K))]
     h = [K.one, K.zero, K.zero]
 
-    N = int(ceil(log(n, 2)))
+    N = int(_ceil(_log(n, 2)))
 
     for i in xrange(1, N + 1):
         a = dup_mul_ground(g, K(2), K)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -75,7 +75,7 @@ from sympy.polys.polyerrors import (
 from sympy.ntheory import nextprime, isprime, factorint
 from sympy.utilities import subsets, cythonized
 
-from math import ceil, log
+from math import ceil as _ceil, log as _log
 from random import randint
 
 @cythonized("k")
@@ -221,7 +221,7 @@ def dup_zz_hensel_lift(p, f, f_list, l, K):
 
     m = p
     k = r // 2
-    d = int(ceil(log(l, 2)))
+    d = int(_ceil(_log(l, 2)))
 
     g = gf_from_int_poly([lc], p)
 
@@ -258,8 +258,8 @@ def dup_zz_zassenhaus(f, K):
     b = dup_LC(f, K)
     B = int(abs(K.sqrt(K(n+1))*2**n*A*b))
     C = int((n+1)**(2*n)*A**(2*n-1))
-    gamma = int(ceil(2*log(C, 2)))
-    bound = int(2*gamma*log(gamma))
+    gamma = int(_ceil(2*_log(C, 2)))
+    bound = int(2*gamma*_log(gamma))
 
     for p in xrange(3, bound+1):
         if not isprime(p) or b % p == 0:
@@ -272,7 +272,7 @@ def dup_zz_zassenhaus(f, K):
         if gf_sqf_p(F, p, K):
             break
 
-    l = int(ceil(log(2*B + 1, p)))
+    l = int(_ceil(_log(2*B + 1, p)))
 
     modular = []
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1,7 +1,7 @@
 """Dense univariate polynomials with coefficients in Galois fields. """
 
 from random import uniform
-from math import ceil, sqrt, log
+from math import ceil as _ceil, log as _log, sqrt as _sqrt
 
 from sympy.core.mul import prod
 from sympy.core.numbers import igcd, Integer
@@ -1780,7 +1780,7 @@ def gf_ddf_shoup(f, p, K):
 
     """
     n = gf_degree(f)
-    k = int(ceil(sqrt(n//2)))
+    k = int(_ceil(_sqrt(n//2)))
 
     h = gf_pow_mod([K.one, K.zero], int(p), f, p, K)
 

--- a/sympy/utilities/benchmarking.py
+++ b/sympy/utilities/benchmarking.py
@@ -4,7 +4,7 @@ import py
 from py.__.test.item import Item
 from py.__.test.terminal.terminal import TerminalSession
 
-from math import ceil, floor, log10
+from math import ceil as _ceil, floor as _floor, log10
 from time import time
 import timeit
 
@@ -88,7 +88,7 @@ class Function(py.__.test.item.Function):
 
                 if t >= 0.2:
                     number *= (0.2 / t)
-                    number  = int(ceil(number))
+                    number  = int(_ceil(number))
                     break
 
                 if t <= 0.02:
@@ -99,7 +99,7 @@ class Function(py.__.test.item.Function):
                     # since we are very close to be > 0.2s we'd better adjust number
                     # so that timing time is not too high
                     number *= (0.2 / t)
-                    number  = int(ceil(number))
+                    number  = int(_ceil(number))
                     break
 
 
@@ -145,7 +145,7 @@ class BenchSession(TerminalSession):
                 else:
                     # from IPython.Magic.magic_timeit
                     if best > 0.0:
-                        order = min(-int(floor(log10(best)) // 3), 3)
+                        order = min(-int(_floor(log10(best)) // 3), 3)
                     else:
                         order = 3
 

--- a/sympy/utilities/compilef.py
+++ b/sympy/utilities/compilef.py
@@ -419,7 +419,7 @@ void evalonarray(double *array, int length)
 #########
 
 from sympy import sqrt, pi, lambdify
-from math import exp, cos, sin
+from math import exp as _exp, cos as _cos, sin as _sin
 
 def test_cexpr():
     expr = '1/(g(x)*3.5)**(x - a**x)/(x**2 + a)'
@@ -442,7 +442,7 @@ def test_clambdify():
     # FIXME: slight difference in precision
 
 def test_frange():
-    fstr = 'lambda x: exp(x)*cos(x)**x'
+    fstr = 'lambda x: _exp(x)*_cos(x)**x'
     f = eval(fstr)
     a = frange(fstr, 30, 168, 3)
     args = range(30, 168, 3)
@@ -483,9 +483,9 @@ def test_frange():
 
 def test_evalonarray_ctypes():
     a = frange('lambda x: x', 10)
-    evalonarray('lambda x: sin(x)', a)
+    evalonarray('lambda x: _sin(x)', a)
     for i, j in enumerate(a):
-        assert sin(i) == j
+        assert _sin(i) == j
 # TODO: test for ctypes pointers
 ##    evalonarray('lambda x: asin(x)', ctypes.byref(a), len(a))
 ##    for i, j in enumerater(a):
@@ -546,14 +546,14 @@ def benchmark():
             print 'Psyco lambda:  %.4f %.4f %.4f' % tuple(t3.repeat(3, 20))
 
     print 'big function:'
-    from sympy import diff, exp, sin, cos, pi, lambdify
+    from sympy import diff, _exp, _sin, _cos, pi, lambdify
     x = Symbol('x')
-##    f1 = diff(exp(x)**2 - sin(x)**pi, x) \
-##        * x**12-2*x**3+2*exp(x**2)-3*x**7+4*exp(123+x-x**5+2*x**4) \
+##    f1 = diff(_exp(x)**2 - _sin(x)**pi, x) \
+##        * x**12-2*x**3+2*_exp(x**2)-3*x**7+4*_exp(123+x-x**5+2*x**4) \
 ##        * ((x + pi)**5).expand()
-    f1 = 2*exp(x**2) + x**12*(-pi*sin(x)**((-1) + pi)*cos(x) + 2*exp(2*x)) \
+    f1 = 2*_exp(x**2) + x**12*(-pi*_sin(x)**((-1) + pi)*_cos(x) + 2*_exp(2*x)) \
          + 4*(10*pi**3*x**2 + 10*pi**2*x**3 + 5*pi*x**4 + 5*x*pi**4 + pi**5 \
-         + x**5)*exp(123 + x + 2*x**4 - x**5) - 2*x**3 - 3*x**7
+         + x**5)*_exp(123 + x + 2*x**4 - x**5) - 2*x**3 - 3*x**7
     fbenchmark(f1)
     print
     print 'simple function:'
@@ -561,7 +561,7 @@ def benchmark():
     f2 = sqrt(x*y)+x*5
     fbenchmark(f2, [x,y])
     times = 100000
-    fstr = 'exp(sin(exp(-x**2)) + sqrt(pi)*cos(x**5/(x**3-x**2+pi*x)))'
+    fstr = '_exp(_sin(_exp(-x**2)) + sqrt(pi)*_cos(x**5/(x**3-x**2+pi*x)))'
     print
     print 'frange with f(x) ='
     print fstr


### PR DESCRIPTION
```
If 'from math import sqrt' is imported at the main level of a
module, then when someone does 'from module import *' those
functions will wipe out the sympy versions. Places where such
imports occur have been changed so the name is renamed as a
private function, e.g. cos -> _cos.
```
