### PR TITLE
Faster multinomial_coefficients, multinomial_coefficients_iterator

### DIFF
--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -67,8 +67,11 @@ def multinomial_coefficients(m, n, _tuple=tuple, _zip=zip):
     """
     if m==2:
         return binomial_coefficients(n)
-    if m >= 2*n and n != 0:
+    if m >= 2*n and n > 1:
         return dict(multinomial_coefficients_iterator(m, n))
+    if m == 3 and n == 2:
+        return {(0, 0, 2): 1, (0, 1, 1): 2, (0, 2, 0): 1, (1, 0, 1): 2,
+                (1, 1, 0): 2, (2, 0, 0): 1}
     # The monomial tuples have entries between 0 and n;
     # in the algorithm new monomial tuples are obtained summing
     # them with tuples in `p0`, with the form (0,..,-1,0..,0,1,0...);
@@ -79,6 +82,11 @@ def multinomial_coefficients(m, n, _tuple=tuple, _zip=zip):
     bits_exp = bitcount(n)
     mask_exp = (1<<bits_exp)-1
     symbols = [(0,)*i + (1,) + (0,)*(m-i-1) for i in range(m)]
+    if n == 1:
+        r = {}
+        for t in symbols:
+            r[t] = 1
+        return r
     s0 = symbols[0]
     p0 = [_tuple(aa-bb for aa, bb in _zip(s, s0)) for s in symbols]
     p0 = [_code_t(t, bits_exp) for t in p0]

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,6 +1,3 @@
-from sympy.mpmath.libmp import bitcount
-from sympy.core.compatibility import combinations_with_replacement
-from collections import defaultdict
 from itertools import ifilter
 
 def binomial_coefficients(n):
@@ -24,45 +21,7 @@ def binomial_coefficients_list(n):
         d[k] = d[n-k] = a
     return d
 
-def _code_t(t, bits_exp):
-    """encode a tuple in an integer to do fast addition
-    """
-    expv = 0
-    for i, n in enumerate(t):
-        expv += n<<(i*bits_exp)
-    return expv
-
-def _bmpnl_calc(m, n, _tuple):
-    bits_exp = bitcount(n)
-    mask_exp = (1 << bits_exp) - 1
-    def t(i):
-        rv = [0]*m
-        if i==0: return rv
-        rv[0]=-1
-        rv[i]=1
-        return rv
-    p0 = [_code_t(_tuple(t(i)), bits_exp) for i in xrange(m)]
-    n0 = [0]*m
-    n0[0] = n
-    l = [0]*(n*(m - 1) + 1)
-    l[0] = [(_code_t(_tuple(n0), bits_exp), 1)]
-    return bits_exp, mask_exp, p0, n0, l
-
-def _dcalc(m, n, k, p0, l):
-    d = defaultdict(int)
-    for i in xrange(1, min(m, k+1)):
-        nn = (n + 1)*i - k
-        if not nn:
-            continue
-        t = p0[i]
-        for t2, c2 in l[k - i]:
-            if not c2:
-                continue
-            tt = t2 + t
-            d[tt] += nn * c2
-    return d
-
-def multinomial_coefficients(m, n, _tuple=tuple):
+def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
     """Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
     where ``C_kn`` are multinomial coefficients such that
     ``n=k1+k2+..+km``.
@@ -75,9 +34,9 @@ def multinomial_coefficients(m, n, _tuple=tuple):
 
     The algorithm is based on the following result:
 
-       Consider a polynomial and its ``n``-th exponent::
+       Consider a polynomial and its ``m``-th exponent::
 
-         P(x) = sum_{i=0}^m p_i x^i
+         P(x) = sum_{i=0}^m p_i x^k
          P(x)^n = sum_{k=0}^{m n} a(n,k) x^k
 
        The coefficients ``a(n,k)`` can be computed using the
@@ -88,52 +47,111 @@ def multinomial_coefficients(m, n, _tuple=tuple):
          a(n,k) = 1/(k p_0) sum_{i=1}^m p_i ((n+1)i-k) a(n,k-i),
 
        where ``a(n,0) = p_0^n``.
+    """
 
-    The following optimizations have been made:
-    i) monomial tuples are packed in integers to speed up their sums;
-    ii) for `m` large with respect to `n` the monomial tuples `t` have
+    if m==2:
+        return binomial_coefficients(n)
+    symbols = [(0,)*i + (1,) + (0,)*(m-i-1) for i in range(m)]
+    s0 = symbols[0]
+    p0 = [_tuple(aa-bb for aa,bb in _zip(s,s0)) for s in symbols]
+    r = {_tuple(aa*n for aa in s0):1}
+    r_get = r.get
+    r_update = r.update
+    l = [0] * (n*(m-1)+1)
+    l[0] = r.items()
+    for k in xrange(1, n*(m-1)+1):
+        d = {}
+        d_get = d.get
+        for i in xrange(1, min(m,k+1)):
+            nn = (n+1)*i-k
+            if not nn:
+                continue
+            t = p0[i]
+            for t2, c2 in l[k-i]:
+                tt = _tuple([aa+bb for aa,bb in _zip(t2,t)])
+                cc = nn * c2
+                b = d_get(tt)
+                if b is None:
+                    d[tt] = cc
+                else:
+                    cc = b + cc
+                    if cc:
+                        d[tt] = cc
+                    else:
+                        del d[tt]
+        r1 = [(t, c//k) for (t, c) in d.iteritems()]
+        l[k] = r1
+        r_update(r1)
+    return r
+
+def multinomial_coefficients(m, n):
+    """Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
+    where ``C_kn`` are multinomial coefficients such that
+    ``n=k1+k2+..+km``.
+
+    For example:
+
+    >>> from sympy.ntheory import multinomial_coefficients
+    >>> multinomial_coefficients(2, 5)
+    {(0, 5): 1, (1, 4): 5, (2, 3): 10, (3, 2): 10, (4, 1): 5, (5, 0): 1}
+
+    The algorithm is based on the following result:
+
+        binom(n, k_1, ..., k_m) =
+        (k_1+1)/(n-k_1)*sum_{i=2}^m binom(n, k_1+1, ..., k_i-1, ...)
+
+    Code contributed to Sage by Yann Laigle-Chapuy, copied with permission
+    of the author.
+
+    The following optimizations has been made:
+    for `m` large with respect to `n` the monomial tuples `t` have
     many zeroes, and have the same coefficient as
     in `monomial_coefficients(n,n)` for `t` stripped of its zeroes;
     therefore by precomputing the latter coefficients memory and time
     are saved.
     """
+    if not m:
+        if n:
+            return {}
+        else:
+            return {(): 1}
     if m == 2:
         return binomial_coefficients(n)
     if m >= 2*n and n > 1:
         return dict(multinomial_coefficients_iterator(m, n))
-    if m == 3 and n == 2:
-        return {(0, 0, 2): 1, (0, 1, 1): 2, (0, 2, 0): 1, (1, 0, 1): 2,
-                (1, 1, 0): 2, (2, 0, 0): 1}
-    # The monomial tuples have entries between 0 and n;
-    # in the algorithm new monomial tuples are obtained summing
-    # them with tuples in `p0`, with the form (0,..,-1,0..,0,1,0...);
-    # in these sums the sums and differences of the entries are
-    # between 0 and n, so that one can pack a tuple in an int,
-    # giving bitcount(n) bits for each entry; in this way sums of
-    # tuples become sums of ints, which are fast.
-    bits_exp, mask_exp, p0, n0, l = _bmpnl_calc(m, n, _tuple)
-    r = {_tuple(n0):1}
-    for k in xrange(1, n*(m-1)+1):
-        d = _dcalc(m, n, k, p0, l)
-        b = []
-        for t, c in d.iteritems():
-            if not c:
-                continue
-            c //= k
-            if (t&mask_exp) > 0:
-                b.append((t, c))
-            # decode t
-            a = [0]*m
-            i = 0
-            while t:
-                exp = t&mask_exp
-                t >>= bits_exp
-                a[i] = exp
-                i += 1
-            r[_tuple(a)] = c
-        l[k] = b
+    t = [n] + [0] * (m - 1)
+    r = {tuple(t): 1}
+    if n:
+        j = 0 # j will be the leftmost nonzero position
+    else:
+        j = m
+    # enumerate tuples in co-lex order
+    while j < m - 1:
+        # compute next tuple
+        tj = t[j]
+        if j:
+            t[j] = 0
+            t[0] = tj
+        if tj > 1:
+            t[j + 1] += 1
+            j = 0
+            start = 1
+            v = 0
+        else:
+            j += 1
+            start = j + 1
+            v = r[tuple(t)]
+            t[j] += 1
+        # compute the value
+        # NB: the initialization of v was done above
+        for k in xrange(start, m):
+            if t[k]:
+                t[k] -= 1
+                v += r[tuple(t)]
+                t[k] += 1
+        t[0] -= 1
+        r[tuple(t)] = (v * tj) // (n - t[0])
     return r
-
 
 def multinomial_coefficients_iterator(m, n, _tuple=tuple):
     """multinomial coefficient iterator
@@ -144,66 +162,43 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
     >>> it.next()
     ((3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 1)
     """
-    if n == 0:
-        d = multinomial_coefficients(m, 0)
-        for x in d.items():
-            yield x
-    elif m < 2*n or n == 1:
-        if m == 2:
-            yield ((0, n), 1)
-            yield ((n, 0), 1)
-            a = 1
-            for k in range(1, n//2):
-                a = (a * (n-k+1))//k
-                yield ((k, n-k), a)
-                yield ((n-k, k), a)
-            if n < 2:
-                return
-            k = n//2
-            a = (a * (n-k+1))//k
-            yield ((k, n-k), a)
-            if n%2 == 1:
-                yield ((n-k, k), a)
-            return
-
-        bits_exp, mask_exp, p0, n0, l = _bmpnl_calc(m, n, _tuple)
-        yield (_tuple(n0), 1)
-        for k in xrange(1, n*(m-1)+1):
-            d = _dcalc(m, n, k, p0, l)
-            b = []
-            for t, c in d.iteritems():
-                if not c:
-                    continue
-                c //= k
-                if (t&mask_exp) > 0:
-                    b.append((t, c))
-                # decode t
-                a = [0]*m
-                i = 0
-                while t:
-                    exp = t&mask_exp
-                    t >>= bits_exp
-                    a[i] = exp
-                    i += 1
-                yield (_tuple(a), c)
-            l[k] = b
+    if m < 2*n or n == 1:
+        mc = multinomial_coefficients(m, n)
+        for k, v in mc.iteritems():
+            yield(k, v)
     else:
         mc = multinomial_coefficients(n, n)
         mc1 = {}
         for k, v in mc.iteritems():
             mc1[_tuple(ifilter(None, k))] = v
         mc = mc1
-        comb_it = combinations_with_replacement(range(m), n)
-        # one can iterate the monomial tuples by iterating
-        # over the combinations with repetition of `n` objects
-        # in `range(m)`
-        # e.g. for `m=10, n=3 t=(5, 7, 7)` corresponds to
-        # the monomial tuple `a = (0, 0, 0, 0, 0, 1, 0, 2, 0, 0) `
-        # which in stripped form becomes `b = (1, 2)
-        for t in comb_it:
-            a = [0]*m
-            for i in t:
-                a[i] += 1
-            a = _tuple(a)
-            b = _tuple(ifilter(None, a))
-            yield (a, mc[b])
+
+        t = [n] + [0] * (m - 1)
+        t1 = _tuple(t)
+        b = _tuple(ifilter(None, t1))
+        yield (t1, mc[b])
+        if n:
+            j = 0 # j will be the leftmost nonzero position
+        else:
+            j = m
+        # enumerate tuples in co-lex order
+        while j < m - 1:
+            # compute next tuple
+            tj = t[j]
+            if j:
+                t[j] = 0
+                t[0] = tj
+            if tj > 1:
+                t[j + 1] += 1
+                j = 0
+                start = 1
+            else:
+                j += 1
+                start = j + 1
+                t[j] += 1
+
+            t[0] -= 1
+            t1 = _tuple(t)
+            b = _tuple(ifilter(None, t1))
+            yield (t1, mc[b])
+

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -22,43 +22,6 @@ def binomial_coefficients_list(n):
         d[k] = d[n-k] = a
     return d
 
-# original algorithm using tuples
-def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
-    if m==2:
-        return binomial_coefficients(n)
-    symbols = [(0,)*i + (1,) + (0,)*(m-i-1) for i in range(m)]
-    s0 = symbols[0]
-    p0 = [_tuple(aa-bb for aa,bb in _zip(s,s0)) for s in symbols]
-    r = {_tuple(aa*n for aa in s0):1}
-    r_get = r.get
-    r_update = r.update
-    l = [0] * (n*(m-1)+1)
-    l[0] = r.items()
-    for k in xrange(1, n*(m-1)+1):
-        d = {}
-        d_get = d.get
-        for i in xrange(1, min(m,k+1)):
-            nn = (n+1)*i-k
-            if not nn:
-                continue
-            t = p0[i]
-            for t2, c2 in l[k-i]:
-                tt = _tuple([aa+bb for aa,bb in _zip(t2,t)])
-                cc = nn * c2
-                b = d_get(tt)
-                if b is None:
-                    d[tt] = cc
-                else:
-                    cc = b + cc
-                    if cc:
-                        d[tt] = cc
-                    else:
-                        del d[tt]
-        r1 = [(t, c//k) for (t, c) in d.iteritems()]
-        l[k] = r1
-        r_update(r1)
-    return r
-
 def _code_t(t, bits_exp):
     """encode a tuple in an integer to do fast addition
     """
@@ -99,8 +62,8 @@ def multinomial_coefficients(m, n, _tuple=tuple, _zip=zip):
     ii) for `m` large with respect to `n` the monomial tuples `t` have
     many zeroes, and have the same coefficient as
     in `monomial_coefficients(n,n)` for `t` stripped of its zeroes;
-    therefore precomputing the latter coefficients memory and time are
-    saved.
+    therefore by precomputing the latter coefficients memory and time
+    are saved.
     """
     if m==2:
         return binomial_coefficients(n)
@@ -173,13 +136,12 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple, _zip=zip):
         d = multinomial_coefficients(m, 0)
         for x in d.items():
             yield x
-        return
-    if m < 2*n or n == 1:
-        if m==2:
+    elif m < 2*n or n == 1:
+        if m == 2:
             yield ((0, n), 1)
             yield ((n, 0), 1)
             a = 1
-            for k in xrange(1, n//2):
+            for k in range(1, n//2):
                 a = (a * (n-k+1))//k
                 yield ((k, n-k), a)
                 yield ((n-k, k), a)

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -23,8 +23,7 @@ def binomial_coefficients_list(n):
 
 def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
     """Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
-    where ``C_kn`` are multinomial coefficients such that
-    ``n=k1+k2+..+km``.
+    where ``C_kn`` are multinomial coefficients such that ``n=k1+k2+..+km``.
 
     For example:
 
@@ -103,12 +102,6 @@ def multinomial_coefficients(m, n):
     Code contributed to Sage by Yann Laigle-Chapuy, copied with permission
     of the author.
 
-    The following optimizations have been made:
-    for `m` large with respect to `n` the monomial tuples `t` have
-    many zeroes, and have the same coefficient as
-    in `monomial_coefficients(n,n)` for `t` stripped of its zeroes;
-    therefore by precomputing the latter coefficients, memory and time
-    are saved.
     """
     if not m:
         if n:
@@ -156,6 +149,16 @@ def multinomial_coefficients(m, n):
 def multinomial_coefficients_iterator(m, n, _tuple=tuple):
     """multinomial coefficient iterator
 
+    This routine has been optimized for `m` large with respect to `n` by taking
+    advantage of the fact that when the monomial tuples `t` are stripped of
+    zeros, their coefficient is the same as that of the monomial tuples from
+    `multinomial_coefficients(n, n)`. Therefore, the latter coefficients are
+    precomputed to save memory and time.
+
+    >>> m53, m33 = multinomial_coefficients(5,3), multinomial_coefficients(3,3)
+    >>> m53[(0,0,0,1,2)] == m53[(0,0,1,0,2)] == m53[(1,0,2,0,0)] == m33[(0,1,2)]
+    True
+
     Examples:
     >>> from sympy.ntheory.multinomial import multinomial_coefficients_iterator
     >>> it = multinomial_coefficients_iterator(20,3)
@@ -201,4 +204,3 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
             t1 = _tuple(t)
             b = _tuple(ifilter(None, t1))
             yield (t1, mc[b])
-

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,3 +1,5 @@
+from sympy.mpmath.libmp import bitcount
+
 def binomial_coefficients(n):
     """Return a dictionary containing pairs {(k1,k2) : C_kn} where
     C_kn are binomial coefficients and n=k1+k2."""
@@ -19,34 +21,8 @@ def binomial_coefficients_list(n):
         d[k] = d[n-k] = a
     return d
 
-def multinomial_coefficients(m, n, _tuple=tuple, _zip=zip):
-    """Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
-    where ``C_kn`` are multinomial coefficients such that
-    ``n=k1+k2+..+km``.
-
-    For example:
-
-    >>> from sympy.ntheory import multinomial_coefficients
-    >>> multinomial_coefficients(2, 5)
-    {(0, 5): 1, (1, 4): 5, (2, 3): 10, (3, 2): 10, (4, 1): 5, (5, 0): 1}
-
-    The algorithm is based on the following result:
-
-       Consider a polynomial and its ``m``-th exponent::
-
-         P(x) = sum_{i=0}^m p_i x^k
-         P(x)^n = sum_{k=0}^{m n} a(n,k) x^k
-
-       The coefficients ``a(n,k)`` can be computed using the
-       J.C.P. Miller Pure Recurrence [see D.E.Knuth, Seminumerical
-       Algorithms, The art of Computer Programming v.2, Addison
-       Wesley, Reading, 1981;]::
-
-         a(n,k) = 1/(k p_0) sum_{i=1}^m p_i ((n+1)i-k) a(n,k-i),
-
-       where ``a(n,0) = p_0^n``.
-    """
-
+# original algorithm using tuples
+def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
     if m==2:
         return binomial_coefficients(n)
     symbols = [(0,)*i + (1,) + (0,)*(m-i-1) for i in range(m)]
@@ -81,3 +57,215 @@ def multinomial_coefficients(m, n, _tuple=tuple, _zip=zip):
         l[k] = r1
         r_update(r1)
     return r
+
+def _code_t(t, bits_exp):
+    """encode a tuple in an integer to do fast addition
+    """
+    expv = 0
+    for i, n in enumerate(t):
+        expv += n<<(i*bits_exp)
+    return expv
+
+def multinomial_coefficients(m, n, _tuple=tuple, _zip=zip):
+    """Return a dictionary containing pairs ``{(k1,k2,..,km) : C_kn}``
+    where ``C_kn`` are multinomial coefficients such that
+    ``n=k1+k2+..+km``.
+
+    For example:
+
+    >>> from sympy.ntheory import multinomial_coefficients
+    >>> multinomial_coefficients(2, 5)
+    {(0, 5): 1, (1, 4): 5, (2, 3): 10, (3, 2): 10, (4, 1): 5, (5, 0): 1}
+
+    The algorithm is based on the following result:
+
+       Consider a polynomial and its ``n``-th exponent::
+
+         P(x) = sum_{i=0}^m p_i x^i
+         P(x)^n = sum_{k=0}^{m n} a(n,k) x^k
+
+       The coefficients ``a(n,k)`` can be computed using the
+       J.C.P. Miller Pure Recurrence [see D.E.Knuth, Seminumerical
+       Algorithms, The art of Computer Programming v.2, Addison
+       Wesley, Reading, 1981;]::
+
+         a(n,k) = 1/(k p_0) sum_{i=1}^m p_i ((n+1)i-k) a(n,k-i),
+
+       where ``a(n,0) = p_0^n``.
+
+    The following optimizations have been made:
+    i) monomial tuples are packed in integers to speed up their sums;
+    ii) for `m` large with respect to `n` the monomial tuples `t` have
+    many zeroes, and have the same coefficient as
+    in `monomial_coefficients(n,n)` for `t` stripped of its zeroes;
+    therefore precomputing the latter coefficients memory and time are
+    saved.
+    """
+    if m==2:
+        return binomial_coefficients(n)
+    if m >= 2*n and n != 0:
+        return dict(multinomial_coefficients_iterator(m, n))
+    # The monomial tuples have entries between 0 and n;
+    # in the algorithm new monomial tuples are obtained summing
+    # them with tuples in `p0`, with the form (0,..,-1,0..,0,1,0...);
+    # in these sums the sums and differences of the entries are
+    # between 0 and n, so that one can pack a tuple in an int,
+    # giving bitcount(n) bits for each entry; in this way sums of
+    # tuples become sums of ints, which are fast.
+    bits_exp = bitcount(n)
+    mask_exp = (1<<bits_exp)-1
+    symbols = [(0,)*i + (1,) + (0,)*(m-i-1) for i in range(m)]
+    s0 = symbols[0]
+    p0 = [_tuple(aa-bb for aa, bb in _zip(s, s0)) for s in symbols]
+    p0 = [_code_t(t, bits_exp) for t in p0]
+    r = {_tuple(aa*n for aa in s0):1}
+    r_get = r.get
+    r_update = r.update
+    l = [0] * (n*(m-1)+1)
+    l[0] = [(_code_t(_tuple(aa*n for aa in s0), bits_exp), 1)]
+    for k in xrange(1, n*(m-1)+1):
+        d = {}
+        d_get = d.get
+        for i in xrange(1, min(m, k+1)):
+            nn = (n+1)*i-k
+            if not nn:
+                continue
+            t = p0[i]
+            for t2, c2 in l[k-i]:
+                tt = t2 + t
+                cc = nn * c2
+                d[tt] = d_get(tt, 0) + cc
+        b = []
+        for t, c in d.iteritems():
+            if not c:
+                continue
+            c //= k
+            if (t&mask_exp) > 0:
+                b.append((t, c))
+            # decode t
+            a = [0]*m
+            i = 0
+            while t:
+                exp = t&mask_exp
+                t >>= bits_exp
+                a[i] = exp
+                i += 1
+            r[_tuple(a)] = c
+        l[k] = b
+    return r
+
+def _strip(a):
+    b = [x for x in a if x]
+    b.sort()
+    return tuple(b)
+
+try:
+    # since Python2.6
+    from itertools import combinations_with_replacement
+except:
+    def combinations_with_replacement(iterable, r):
+        "combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC"
+        # number items returned:  (n+r-1)! / r! / (n-1)!
+        pool = tuple(iterable)
+        n = len(pool)
+        indices = [0] * r
+        yield tuple(pool[i] for i in indices)
+        while 1:
+            for i in reversed(range(r)):
+                if indices[i] != n - 1:
+                    break
+            else:
+                return
+            indices[i:] = [indices[i] + 1] * (r - i)
+            yield tuple(pool[i] for i in indices)
+
+
+def multinomial_coefficients_iterator(m, n, _tuple=tuple, _zip=zip):
+    """multinomial coefficient iterator
+
+    Examples:
+    >>> from sympy.ntheory.multinomial import multinomial_coefficients_iterator
+    >>> it = multinomial_coefficients_iterator(20,3)
+    >>> it.next()
+    ((3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0), 1)
+    """
+    if n == 0:
+        d = multinomial_coefficients(m, 0)
+        for x in d.items():
+            yield x
+        return
+    if m < 2*n or n == 1:
+        if m==2:
+            yield ((0, n), 1)
+            yield ((n, 0), 1)
+            a = 1
+            for k in xrange(1, n//2):
+                a = (a * (n-k+1))//k
+                yield ((k, n-k), a)
+                yield ((n-k, k), a)
+            if n < 2:
+                return
+            k = n//2
+            a = (a * (n-k+1))//k
+            yield ((k, n-k), a)
+            if n%2 == 1:
+                yield ((n-k, k), a)
+            return
+
+        bits_exp = bitcount(n)
+        mask_exp = (1<<bits_exp)-1
+        symbols = [(0,)*i + (1,) + (0,)*(m-i-1) for i in range(m)]
+        s0 = symbols[0]
+        p0 = [_tuple(aa-bb for aa,bb in _zip(s,s0)) for s in symbols]
+        p0 = [_code_t(t,bits_exp) for t in p0]
+        l = [0] * (n*(m-1)+1)
+        l[0] = [(_code_t(_tuple(aa*n for aa in s0), bits_exp), 1)]
+        yield (_tuple(aa*n for aa in s0), 1)
+        for k in xrange(1, n*(m-1)+1):
+            d = {}
+            d_get = d.get
+            for i in xrange(1, min(m, k+1)):
+                nn = (n+1)*i-k
+                if not nn:
+                    continue
+                t = p0[i]
+                for t2, c2 in l[k-i]:
+                    tt = t2 + t
+                    cc = nn * c2
+                    d[tt] = d_get(tt, 0) + cc
+            b = []
+            for t, c in d.iteritems():
+                if not c:
+                    continue
+                c //= k
+                if (t&mask_exp) > 0:
+                    b.append((t, c))
+                # decode t
+                a = [0]*m
+                i = 0
+                while t:
+                    exp = t&mask_exp
+                    t >>= bits_exp
+                    a[i] = exp
+                    i += 1
+                yield (_tuple(a), c)
+            l[k] = b
+    else:
+        mc = multinomial_coefficients(n, n)
+        mc1 = {}
+        for k, v in mc.iteritems():
+            mc1[_strip(k)] = v
+        mc = mc1
+        comb_it = combinations_with_replacement(range(m), n)
+        # one can iterate the monomial tuples by iterating
+        # over the combinations with repetition of `n` objects
+        # in `range(m)`
+        # e.g. for `m=10, n=3 t=(5, 7, 7)` corresponds to
+        # the monomial tuple `a = (0, 0, 0, 0, 0, 1, 0, 2, 0, 0) `
+        # which in stripped form becomes `b = (1, 2)
+        for t in comb_it:
+            a = [0]*m
+            for i in t:
+                a[i] += 1
+            b = _strip(a)
+            yield (_tuple(a), mc[b])

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,6 +1,7 @@
 from sympy.mpmath.libmp import bitcount
 from sympy.core.compatibility import combinations_with_replacement
 from collections import defaultdict
+from itertools import ifilter
 
 def binomial_coefficients(n):
     """Return a dictionary containing pairs {(k1,k2) : C_kn} where
@@ -190,7 +191,7 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
         mc = multinomial_coefficients(n, n)
         mc1 = {}
         for k, v in mc.iteritems():
-            mc1[filter(None, k)] = v
+            mc1[_tuple(ifilter(None, k))] = v
         mc = mc1
         comb_it = combinations_with_replacement(range(m), n)
         # one can iterate the monomial tuples by iterating
@@ -204,5 +205,5 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
             for i in t:
                 a[i] += 1
             a = _tuple(a)
-            b = filter(None, a)
+            b = _tuple(ifilter(None, a))
             yield (a, mc[b])

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,4 +1,5 @@
 from sympy.mpmath.libmp import bitcount
+from sympy.core.compatibility import combinations_with_replacement
 
 def binomial_coefficients(n):
     """Return a dictionary containing pairs {(k1,k2) : C_kn} where
@@ -158,27 +159,6 @@ def _strip(a):
     b = [x for x in a if x]
     b.sort()
     return tuple(b)
-
-try:
-    # since Python2.6
-    from itertools import combinations_with_replacement
-except:
-    def combinations_with_replacement(iterable, r):
-        "combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC"
-        # number items returned:  (n+r-1)! / r! / (n-1)!
-        pool = tuple(iterable)
-        n = len(pool)
-        indices = [0] * r
-        yield tuple(pool[i] for i in indices)
-        while 1:
-            for i in reversed(range(r)):
-                if indices[i] != n - 1:
-                    break
-            else:
-                return
-            indices[i:] = [indices[i] + 1] * (r - i)
-            yield tuple(pool[i] for i in indices)
-
 
 def multinomial_coefficients_iterator(m, n, _tuple=tuple, _zip=zip):
     """multinomial coefficient iterator

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -103,11 +103,11 @@ def multinomial_coefficients(m, n):
     Code contributed to Sage by Yann Laigle-Chapuy, copied with permission
     of the author.
 
-    The following optimizations has been made:
+    The following optimizations have been made:
     for `m` large with respect to `n` the monomial tuples `t` have
     many zeroes, and have the same coefficient as
     in `monomial_coefficients(n,n)` for `t` stripped of its zeroes;
-    therefore by precomputing the latter coefficients memory and time
+    therefore by precomputing the latter coefficients, memory and time
     are saved.
     """
     if not m:

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -155,6 +155,7 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
     `multinomial_coefficients(n, n)`. Therefore, the latter coefficients are
     precomputed to save memory and time.
 
+    >>> from sympy.ntheory.multinomial import multinomial_coefficients
     >>> m53, m33 = multinomial_coefficients(5,3), multinomial_coefficients(3,3)
     >>> m53[(0,0,0,1,2)] == m53[(0,0,1,0,2)] == m53[(1,0,2,0,0)] == m33[(0,1,2)]
     True

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -133,10 +133,6 @@ def multinomial_coefficients(m, n, _tuple=tuple):
         l[k] = b
     return r
 
-def _strip(a):
-    b = [x for x in a if x]
-    b.sort()
-    return tuple(b)
 
 def multinomial_coefficients_iterator(m, n, _tuple=tuple):
     """multinomial coefficient iterator
@@ -194,7 +190,7 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
         mc = multinomial_coefficients(n, n)
         mc1 = {}
         for k, v in mc.iteritems():
-            mc1[_strip(k)] = v
+            mc1[filter(None, k)] = v
         mc = mc1
         comb_it = combinations_with_replacement(range(m), n)
         # one can iterate the monomial tuples by iterating
@@ -207,5 +203,6 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
             a = [0]*m
             for i in t:
                 a[i] += 1
-            b = _strip(a)
-            yield (_tuple(a), mc[b])
+            a = _tuple(a)
+            b = filter(None, a)
+            yield (a, mc[b])

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -446,9 +446,9 @@ def test_multinomial_coefficients():
         {(2, 0): 1, (0, 2): 1, (1, 1): 2}
     assert dict(multinomial_coefficients_iterator(3, 3)) == mc
     it = multinomial_coefficients_iterator(7, 2)
-    assert [it.next() for i in range(4)] == [((2, 0, 0, 0, 0, 0, 0), 1),
-    ((1, 1, 0, 0, 0, 0, 0), 2), ((1, 0, 1, 0, 0, 0, 0), 2),
-    ((1, 0, 0, 1, 0, 0, 0), 2)]
+    assert [it.next() for i in range(4)] == \
+    [((2, 0, 0, 0, 0, 0, 0), 1), ((1, 1, 0, 0, 0, 0, 0), 2),
+      ((0, 2, 0, 0, 0, 0, 0), 1), ((1, 0, 1, 0, 0, 0, 0), 2)]
 
 def test_issue1257():
     assert factorint(1030903) == {53: 2, 367: 1}

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -15,6 +15,7 @@ from sympy.ntheory.modular import crt, crt1, crt2, solve_congruence
 
 from sympy.utilities.pytest import raises
 from sympy.utilities.iterables import capture
+from sympy.ntheory.multinomial import multinomial_coefficients_iterator
 
 def test_trailing():
     assert trailing(0) == 0
@@ -426,6 +427,7 @@ def test_multinomial_coefficients():
     assert multinomial_coefficients(1, 1) == {(1,): 1}
     assert multinomial_coefficients(1, 2) == {(2,): 1}
     assert multinomial_coefficients(1, 3) == {(3,): 1}
+    assert multinomial_coefficients(2, 0) == {(0, 0): 1}
     assert multinomial_coefficients(2, 1) == {(0, 1): 1, (1, 0): 1}
     assert multinomial_coefficients(2, 2) == {(2, 0): 1, (0, 2): 1, (1, 1): 2}
     assert multinomial_coefficients(2, 3) == {(3, 0): 1, (1, 2): 3, (0, 3): 1,
@@ -434,9 +436,14 @@ def test_multinomial_coefficients():
             (0, 0, 1): 1}
     assert multinomial_coefficients(3, 2) == {(0, 1, 1): 2, (0, 0, 2): 1,
             (1, 1, 0): 2, (0, 2, 0): 1, (1, 0, 1): 2, (2, 0, 0): 1}
-    assert multinomial_coefficients(3, 3) == {(2, 1, 0): 3, (0, 3, 0): 1,
+    mc = multinomial_coefficients(3, 3)
+    assert mc == {(2, 1, 0): 3, (0, 3, 0): 1,
             (1, 0, 2): 3, (0, 2, 1): 3, (0, 1, 2): 3, (3, 0, 0): 1,
             (2, 0, 1): 3, (1, 2, 0): 3, (1, 1, 1): 6, (0, 0, 3): 1}
+    assert dict(multinomial_coefficients_iterator(2, 0)) == {(0, 0): 1}
+    assert dict(multinomial_coefficients_iterator(3, 3)) == mc
+    assert dict(multinomial_coefficients_iterator(7, 2)) == \
+        multinomial_coefficients(7, 2)
 
 def test_issue1257():
     assert factorint(1030903) == {53: 2, 367: 1}

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -445,8 +445,10 @@ def test_multinomial_coefficients():
     assert dict(multinomial_coefficients_iterator(2, 2)) == \
         {(2, 0): 1, (0, 2): 1, (1, 1): 2}
     assert dict(multinomial_coefficients_iterator(3, 3)) == mc
-    assert dict(multinomial_coefficients_iterator(7, 2)) == \
-        multinomial_coefficients(7, 2)
+    it = multinomial_coefficients_iterator(7, 2)
+    assert [it.next() for i in range(4)] == [((2, 0, 0, 0, 0, 0, 0), 1),
+    ((1, 1, 0, 0, 0, 0, 0), 2), ((1, 0, 1, 0, 0, 0, 0), 2),
+    ((1, 0, 0, 1, 0, 0, 0), 2)]
 
 def test_issue1257():
     assert factorint(1030903) == {53: 2, 367: 1}

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -441,6 +441,9 @@ def test_multinomial_coefficients():
             (1, 0, 2): 3, (0, 2, 1): 3, (0, 1, 2): 3, (3, 0, 0): 1,
             (2, 0, 1): 3, (1, 2, 0): 3, (1, 1, 1): 6, (0, 0, 3): 1}
     assert dict(multinomial_coefficients_iterator(2, 0)) == {(0, 0): 1}
+    assert dict(multinomial_coefficients_iterator(2, 1)) == {(0, 1): 1, (1, 0): 1}
+    assert dict(multinomial_coefficients_iterator(2, 2)) == \
+        {(2, 0): 1, (0, 2): 1, (1, 1): 2}
     assert dict(multinomial_coefficients_iterator(3, 3)) == mc
     assert dict(multinomial_coefficients_iterator(7, 2)) == \
         multinomial_coefficients(7, 2)


### PR DESCRIPTION
Faster `multinomial_coefficients(m,n)` using encoding of the tuples
in the Miller recurrence algorithm and cashing values for `m >= 2*n`

`multinomial_coefficients_iterator` is faster and uses little memory.

Iterating over items with `multinomial_coefficients_iterator(m,n)`
is faster then using `multinomial_coefficients(m,n)` in master;  the speedup
increases with `m`; on my computer with Intel Core i7 2.80GHz
for `n=2` I get 

```
m                2       4      10       30      50     100     200
x               1.1     2      8.4      46      93     236      575
```

In this pull request `multinomial_coefficients(m,n)` is a bit slower than `multinomial_coefficients_iterator`,
but it can use much more memory, e.g. for `m=100, n=4`   the former is only 50% slower, but it
uses `4GB` of RAM, while the latter uses little memory.

For `m=60, n=4` in master it takes 345s and  420MB,  multinomial_coefficients here takes 3.2s and 310MB, the iterator takes 2.4s and little memory.
