### PR TITLE
setup.py: Add clasifiers, long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -235,13 +235,35 @@ tests = [
     'sympy.utilities.tests',
     ]
 
+classifiers = [
+    'License :: OSI Approved :: BSD License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Topic :: Scientific/Engineering',
+    'Topic :: Scientific/Engineering :: Mathematics',
+    'Topic :: Scientific/Engineering :: Physics',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.5',
+    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.2',
+    ]
+
+long_description = '''SymPy is a Python library for symbolic mathematics. It aims
+to become a full-featured computer algebra system (CAS) while keeping the code
+as simple as possible in order to be comprehensible and easily extensible.
+SymPy is written entirely in Python and does not require any external libraries.'''
+
 setup(
       name = 'sympy',
       version = sympy.__version__,
       description = 'Computer algebra system (CAS) in Python',
+      long_description = long_description,
       author = 'SymPy development team',
       author_email = 'sympy@googlegroups.com',
       license = 'BSD',
+      keywords = "Math CAS",
       url = 'http://code.google.com/p/sympy',
       packages = ['sympy'] + modules + tests,
       scripts = ['bin/isympy'],
@@ -253,4 +275,5 @@ setup(
                      'clean': clean,
                      'audit' : audit,
                      },
+      classifiers = classifiers,
       )


### PR DESCRIPTION
setup.py can define metadata about the package. Some of it is
non-mandatory, but is useful for PyPi and elsewhere. As such, add a
long_description field (copied from current PyPi package, which was in
turn copied from the website) and a list of classifiers (based on the
current list on PyPi). Because we use the same setup.py file for both
Python 2 and 3, add a version check to determine which classifiers to
include.

This fixes issue 2615.

---

It should work, but I'm not exactly sure how to test this. @asmeurer?
