### PR TITLE
Changed .unit to .normalize(), .mag to .magnitude()

### DIFF
--- a/doc/src/modules/physics/mechanics/vectors.txt
+++ b/doc/src/modules/physics/mechanics/vectors.txt
@@ -589,9 +589,9 @@ warnings. ::
 Two additional operations can be done with vectors: normalizing the vector to
 length 1, and getting its magnitude. These are done as follows:
 
-  >>> (N.x + N.y).unit
+  >>> (N.x + N.y).normalize()
   sqrt(2)/2*N.x + sqrt(2)/2*N.y
-  >>> (N.x + N.y).mag
+  >>> (N.x + N.y).magnitude()
   sqrt(2)
 
 Vector Calculus, in Mechanics

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -855,7 +855,7 @@ class ReferenceFrame(object):
             self._check_vector(axis)
             if not axis.dt(parent) == 0:
                 raise ValueError('Axis cannot be time-varying')
-            axis = axis.express(parent).unit
+            axis = axis.express(parent).normalize()
             axis = axis.args[0][0]
             parent_orient = ((eye(3) - axis * axis.T) * cos(theta) +
                     Matrix([[0, -axis[2], axis[1]],[axis[2], 0, -axis[0]],
@@ -904,7 +904,7 @@ class ReferenceFrame(object):
             wvec = Vector([(Matrix([w1, w2, w3]), self)])
         elif rot_type == 'AXIS':
             thetad = (amounts[0]).diff(dynamicsymbols._t)
-            wvec = thetad * amounts[1].express(parent).unit
+            wvec = thetad * amounts[1].express(parent).normalize()
         else:
             try:
                 from sympy.physics.mechanics.functions import kinematic_equations
@@ -1626,15 +1626,13 @@ class Vector(object):
             ov += Vector([(v[0].subs(dictin), v[1])])
         return ov
 
-    @property
-    def mag(self):
-        """Returns the magnitude of this Vector, as a scalar. """
+    def magnitude(self):
+        """Returns the magnitude (Euclidean norm) of self."""
         return sqrt(self & self)
 
-    @property
-    def unit(self):
-        """Returns this Vector, with unit length. """
-        return Vector(self.args + []) / self.mag
+    def normalize(self):
+        """Returns a Vector of magnitude 1, codirectional with self."""
+        return Vector(self.args + []) / self.magnitude()
 
 
 class MechanicsStrPrinter(StrPrinter):

--- a/sympy/physics/mechanics/tests/test_essential.py
+++ b/sympy/physics/mechanics/tests/test_essential.py
@@ -103,8 +103,8 @@ def test_ang_vel():
     assert F.ang_vel_in(N) == ((sin(q2)*sin(q3)*q1d + cos(q3)*q2d)*F.x +
         (sin(q2)*cos(q3)*q1d - sin(q3)*q2d)*F.y + (cos(q2)*q1d + q3d)*F.z)
     G = N.orientnew('G', 'Axis', (q1, N.x + N.y))
-    assert G.ang_vel_in(N) == q1d * (N.x + N.y).unit
-    assert N.ang_vel_in(G) == -q1d * (N.x + N.y).unit
+    assert G.ang_vel_in(N) == q1d * (N.x + N.y).normalize()
+    assert N.ang_vel_in(G) == -q1d * (N.x + N.y).normalize()
 
 def test_dcm():
     q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')


### PR DESCRIPTION
As per the discussion in Issue 2807 [0], this branch changes the .unit and .mag properties of the sympy.physics.mechanics Vector class to instance methods .normalize(self) and .magnitude(self), respectively.

[0] -- http://code.google.com/p/sympy/issues/detail?id=2807 
