### PR TITLE
Comb fixes

### DIFF
--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,6 +1,8 @@
 from sympy.core import Basic
 from sympy.functions import ceiling, log
 
+from sympy.core.compatibility import bin
+
 import random
 
 class GrayCode(Basic):
@@ -218,7 +220,7 @@ class GrayCode(Basic):
         '100'
         """
         if self._rank is None:
-            self._rank = int('0b' + gray_to_bin(self.current), 2)
+            self._rank = int(gray_to_bin(self.current), 2)
         return self._rank
 
     @property

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -1,6 +1,8 @@
 from sympy.core import Basic
 from sympy.combinatorics.graycode import GrayCode
 
+from sympy.core.compatibility import bin, combinations
+
 import itertools
 
 class Subset(Basic):
@@ -375,4 +377,4 @@ def ksubsets(superset, k):
     [(1, 2), (1, 3), (1, 4), (1, 5), (2, 3), (2, 4), \
     (2, 5), (3, 4), (3, 5), (4, 5)]
     """
-    return (itertools.combinations(superset, k))
+    return combinations(superset, k)

--- a/sympy/combinatorics/tests/test_graycode.py
+++ b/sympy/combinatorics/tests/test_graycode.py
@@ -34,8 +34,12 @@ def test_graycode():
     assert a.current == '000000000001000'
 
     assert bin_to_gray('111') == '100'
-    random.seed(0)
-    assert [random_bitstring(5) for i in range(3)] == ['11001', '01001', '11011']
+
+    a = random_bitstring(5)
+    assert type(a) is str
+    assert len(a) == 5
+    assert all(i in ['0', '1'] for i in a)
+
     assert get_subset_from_bitstring(['a','b','c','d'], '0011') == ['c', 'd']
     assert get_subset_from_bitstring('abcd','1001') == ['a', 'd']
     assert list(graycode_subsets(['a','b','c'])) == \

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -325,3 +325,21 @@ def set_union(*sets):
     for s in sets:
         rv |= s
     return rv
+
+try:
+    bin = bin
+except NameError: # Python 2.5
+    def bin(x):
+        """
+        bin(number) -> string
+
+        Stringifies an int or long in base 2.
+        """
+        if x < 0: return '-' + bin(-x)
+        out = []
+        if x == 0: out.append('0')
+        while x > 0:
+            out.append('01'[x & 1])
+            x >>= 1
+            pass
+        return '0b' + ''.join(reversed(out))

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -353,6 +353,8 @@ class Point(GeometryEntity):
         divisor = sympify(divisor)
         return Point([x/divisor for x in self])
 
+    __truediv__ = __div__
+
     def __neg__(self):
         """Negate the point."""
         return Point([-x for x in self])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1343,7 +1343,7 @@ def test_diagonal_symmetrical():
     m = Matrix(3,3,[1, 0, 0, 0, 2, 0, 0, 0, 3])
     assert m == diag(1, 2, 3)
 
-    m = Matrix(2, 3, [0, 0, 0, 0, 0, 0])
+    m = Matrix(2, 3, zeros(2, 3))
     assert not m.is_symmetric()
     assert m.is_diagonal()
 
@@ -1854,7 +1854,7 @@ def test_zeros_eye():
 def test_is_zero():
     assert Matrix().is_zero
     assert Matrix([[0, 0], [0, 0]]).is_zero
-    assert zeros((3, 4)).is_zero
+    assert zeros(3, 4).is_zero
     assert not eye(3).is_zero
 
 def test_rotation_matrices():


### PR DESCRIPTION
This fixes the current tests failing in sympy.combinatorics in py25 and py32.. they were, quite annoying, on every single sympy-bot run. :)

I just see now that there's also a py3k failure in test_geometry, but it's non-trivial and I'm not sure how to fix it. If you know what's going on, please feel free to comment here/send me a pull request/just point me to a patch or something. 
