### PR TITLE
Matrices fixes

### DIFF
--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -4,7 +4,7 @@ Includes functions for fast creating matrices like zero, one/eye, random matrix 
 """
 from matrices import (Matrix, SparseMatrix, zeros, ones, eye, diag,
      hessian, randMatrix, GramSchmidt, wronskian, casoratian,
-     list2numpy, matrix2numpy, DeferredVector, block_diag, symarray, ShapeError,
+     list2numpy, matrix2numpy, DeferredVector, symarray, ShapeError,
      NonSquareMatrixError, rot_axis1, rot_axis2, rot_axis3)
 
 from expressions import *

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2841,14 +2841,6 @@ def diag(*values):
             i_col += 1
     return res
 
-def block_diag(matrices):
-    """
-    Warning: this function is deprecated. See .diag()
-
-    """
-    warnings.warn("block_diag() is deprecated, use diag() instead", DeprecationWarning)
-    return diag(*matrices)
-
 def jordan_cell(eigenval, n):
     """
     Create matrix of Jordan cell kind:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1663,7 +1663,7 @@ class Matrix(object):
         Example::
             >>> from sympy import Matrix, zeros
             >>> a = Matrix([[0, 0], [0, 0]])
-            >>> b = zeros((3, 4))
+            >>> b = zeros(3, 4)
             >>> c = Matrix([[0, 1], [0, 0]])
             >>> d = Matrix([])
             >>> a.is_zero


### PR DESCRIPTION
Another small pull request, this fixes a deprecated function use in a doctest (missed it last time, sympy-bot doesn't run doctests usually) and removes the deprecated block_diag method from matrices (scheduled for removal in the next release).
