### PR TITLE
Fix ode_order (issue 2736).

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1711,21 +1711,23 @@ def ode_order(expr, func):
 
     """
     a = Wild('a', exclude=[func])
+    if expr.match(a):
+        return 0
 
-    order = 0
-    if isinstance(expr, Derivative) and expr.args[0] == func:
-        order = len(expr.variables)
+    if isinstance(expr, Derivative):
+        if expr.args[0] == func:
+            return len(expr.variables)
+        else:
+            order = 0
+            for arg in expr.args[0].args:
+                order = max(order, ode_order(arg, func) + len(expr.variables))
+            return order
     else:
+        order = 0
         for arg in expr.args:
-            if isinstance(arg, Derivative) and arg.args[0] == func:
-                order = max(order, len(arg.variables))
-            elif expr.match(a):
-                order = 0
-            else :
-                for arg1 in arg.args:
-                    order = max(order, ode_order(arg1, func))
+            order = max(order, ode_order(arg, func))
+        return order
 
-    return order
 
 # FIXME: replace the general solution in the docstring with
 # dsolve(equation, hint='1st_exact_Integral').  You will need to be able

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3,7 +3,7 @@ from __future__ import division
 from sympy import (Function, dsolve, Symbol, sin, cos, sinh, acos, tan, cosh,
     I, exp, log, simplify, together, powsimp, fraction, radsimp, Eq, sqrt, pi,
     erf,  diff, Rational, asinh, trigsimp, S, RootOf, Poly, Integral, atan,
-    Equality, solve, O, LambertW, Dummy, acosh)
+    Equality, solve, O, LambertW, Dummy, acosh, Derivative)
 from sympy.abc import x, y, z
 from sympy.solvers.ode import (ode_order, homogeneous_order,
     _undetermined_coefficients_match, classify_ode, checkodesol,
@@ -194,6 +194,15 @@ def test_ode_order():
     assert ode_order(diff(f(x), x, x)*diff(g(x), x), f(x)) == 2
     assert ode_order(diff(f(x), x, x)*diff(g(x), x), g(x)) == 1
     assert ode_order(diff(x*diff(x*exp(f(x)), x,x), x), g(x)) == 0
+    # issue 2736: ode_order has to also work for unevaluated derivatives
+    # (ie, without using doit()).
+    assert ode_order(Derivative(x*f(x), x), f(x)) == 1 
+    assert ode_order(x*sin(Derivative(x*f(x)**2, x, x)), f(x)) == 2
+    assert ode_order(Derivative(x*Derivative(x*exp(f(x)), x,x), x), g(x)) == 0
+    assert ode_order(Derivative(f(x), x, x), g(x)) == 0
+    assert ode_order(Derivative(x*exp(f(x)),x,x), f(x)) == 2
+    assert ode_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
+    
 
 # In all tests below, checkodesol has the order option set to prevent superfluous
 # calls to ode_order(), and the solve_for_func flag set to False because

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -202,6 +202,8 @@ def test_ode_order():
     assert ode_order(Derivative(f(x), x, x), g(x)) == 0
     assert ode_order(Derivative(x*exp(f(x)),x,x), f(x)) == 2
     assert ode_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
+    assert ode_order(Derivative(x*Derivative(f(x), x, x), x), f(x)) == 3
+    assert ode_order(x*sin(Derivative(x*Derivative(f(x), x)**2, x, x)), f(x)) == 3
     
 
 # In all tests below, checkodesol has the order option set to prevent superfluous

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -196,7 +196,7 @@ def test_ode_order():
     assert ode_order(diff(x*diff(x*exp(f(x)), x,x), x), g(x)) == 0
     # issue 2736: ode_order has to also work for unevaluated derivatives
     # (ie, without using doit()).
-    assert ode_order(Derivative(x*f(x), x), f(x)) == 1 
+    assert ode_order(Derivative(x*f(x), x), f(x)) == 1
     assert ode_order(x*sin(Derivative(x*f(x)**2, x, x)), f(x)) == 2
     assert ode_order(Derivative(x*Derivative(x*exp(f(x)), x,x), x), g(x)) == 0
     assert ode_order(Derivative(f(x), x, x), g(x)) == 0
@@ -204,7 +204,7 @@ def test_ode_order():
     assert ode_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
     assert ode_order(Derivative(x*Derivative(f(x), x, x), x), f(x)) == 3
     assert ode_order(x*sin(Derivative(x*Derivative(f(x), x)**2, x, x)), f(x)) == 3
-    
+
 
 # In all tests below, checkodesol has the order option set to prevent superfluous
 # calls to ode_order(), and the solve_for_func flag set to False because


### PR DESCRIPTION
Before these commits `ode_order` incorrectly calculated order for expressions
like `Derivative(x*f(x), x)`, because it assumed that any derivative is a
derivative of f(x) only, which is ussually not true (in the former example, we
have a derivative of a product, `x*f(x)`).
