### PR TITLE
use args_cnc(), delete extra split_commutative_parts, sympify in TensorPr

### DIFF
--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -3,7 +3,6 @@
 from sympy import S, Expr, Mul, Integer
 from sympy.printing.pretty.stringpict import prettyForm
 
-from sympy.physics.quantum.qexpr import split_commutative_parts
 from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.dagger import Dagger
 
@@ -89,18 +88,11 @@ class AntiCommutator(Expr):
 
         # [xA,yB]  ->  xy*[A,B]
         # from sympy.physics.qmul import QMul
-        c_part = []
-        nc_part = []
-        nc_part2 = []
-        if isinstance(a, Mul):
-            c_part, nc_part = split_commutative_parts(a)
-        if isinstance(b, Mul):
-            c_part2, nc_part2 = split_commutative_parts(b)
-            c_part.extend(c_part2)
+        ca, nca = a.args_cnc()
+        cb, ncb = b.args_cnc()
+        c_part = list(ca) + list(cb)
         if c_part:
-            a = nc_part or [a]
-            b = nc_part2 or [b]
-            return Mul(Mul(*c_part), cls(Mul(*a), Mul(*b)))
+            return Mul(Mul(*c_part), cls(Mul._from_args(nca), Mul._from_args(ncb)))
 
         # Canonical ordering of arguments
         if a.compare(b) == 1:

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -3,7 +3,6 @@
 from sympy import S, Expr, Mul, Add
 from sympy.printing.pretty.stringpict import prettyForm
 
-from sympy.physics.quantum.qexpr import split_commutative_parts
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.operator import Operator
 
@@ -101,17 +100,11 @@ class Commutator(Expr):
 
         # [xA,yB]  ->  xy*[A,B]
         # from sympy.physics.qmul import QMul
-        c_part = c_part2 = []
-        nc_part = nc_part2 = []
-        if isinstance(a, Mul):
-            c_part, nc_part = split_commutative_parts(a)
-        if isinstance(b, Mul):
-            c_part2, nc_part2 = split_commutative_parts(b)
-            c_part.extend(c_part2)
+        ca, nca = a.args_cnc()
+        cb, ncb = b.args_cnc()
+        c_part = list(ca) + list(cb)
         if c_part:
-            a = nc_part or [a]
-            b = nc_part2 or [b]
-            return Mul(*c_part)*cls(Mul(*a),Mul(*b))
+            return Mul(Mul(*c_part), cls(Mul._from_args(nca), Mul._from_args(ncb)))
 
         # Canonical ordering of arguments
         if a.compare(b) == 1:

--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -5,7 +5,7 @@ Todo:
 """
 
 
-from sympy import Add, Mul, Pow, sympify
+from sympy import Add, Mul, Pow, sympify, S
 
 from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.commutator import Commutator
@@ -52,7 +52,7 @@ def qapply(e, **options):
     dagger = options.get('dagger', False)
 
     if e == 0:
-        return 0
+        return S.Zero
 
     # This may be a bit aggressive but ensures that everything gets expanded
     # to its simplest form before trying to apply operators. This includes
@@ -159,7 +159,7 @@ def qapply_Mul(e, **options):
 
     # TODO: I may need to expand before returning the final result.
     if result == 0:
-        return 0
+        return S.Zero
     elif result is None:
         return qapply_Mul(e._new_rawargs(*(args+[lhs])), **options)*rhs
     elif isinstance(result, InnerProduct):

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -365,10 +365,9 @@ class QExpr(Expr):
 
 def split_commutative_parts(e):
     """Split into commutative and non-commutative parts."""
-    c_part = [p for p in e.args if p.is_commutative]
-    nc_part = [p for p in e.args if not p.is_commutative]
+    c_part, nc_part = e.args_cnc()
+    c_part = list(c_part)
     return c_part, nc_part
-
 
 def split_qexpr_parts(e):
     """Split an expression into Expr and noncommutative QExpr parts."""

--- a/sympy/physics/quantum/shor.py
+++ b/sympy/physics/quantum/shor.py
@@ -10,7 +10,7 @@ Todo:
 import math
 import random
 
-from sympy import Mul
+from sympy import Mul, S
 from sympy import log, sqrt
 from sympy.core.numbers import igcd
 
@@ -130,7 +130,7 @@ def getr(x, y, N):
 
 def ratioize(list, N):
     if list[0] > N:
-        return 0
+        return S.Zero
     if len(list) == 1:
         return list[0]
     return list[0] + ratioize(list[1:], N)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -688,7 +688,7 @@ class Wavefunction(Function):
             if args[ct] < lower or args[ct] > upper:
                 return 0
 
-            ct+=1
+            ct += 1
 
         expr = self.expr
 
@@ -698,7 +698,7 @@ class Wavefunction(Function):
                 val = options[str(symbol)]
                 expr = expr.subs(symbol, val)
 
-        return expr.subs(tuple(zip(var, args)))
+        return expr.subs(zip(var, args))
 
     def _eval_derivative(self, symbol):
         expr = self.expr

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -988,10 +988,8 @@ class CreateFermion(FermionicOperator, Creator):
             if isinstance(nc_part[0], FockStateFermionKet):
                 element = self.state
                 return Mul(*(c_part + [nc_part[0].up(element)] + nc_part[1:]))
-            else:
-                return Mul(self, state)
-        else:
-            return Mul(self, state)
+
+        return Mul(self, state)
 
     @property
     def is_q_creator(self):


### PR DESCRIPTION
use args_cnc(), delete extra split_commutative_parts, sympify in TensorProduct

```
There are a few other places where values of 1 or 0 that were being
returned are now returned as S.One or S.Zero, respectively.
```
