### PR TITLE
give expand a frac hint (#849, #2820)

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -222,7 +222,7 @@ def test_telescopic_sums():
     assert telescopic(1/m, -m/(1+m),(m, n-1, n)) == \
            telescopic(1/k, -k/(1+k),(k, n-1, n))
 
-    assert Sum(1/x/(x - 1), (x, a, b)).doit() == 1/(-1 + a) - 1/b
+    assert Sum(1/x/(x - 1), (x, a, b)).doit() == -((a - b - 1)/(b*(a - 1)))
 
 def test_sum_reconstruct():
     s = Sum(n**2, (n, -1, 1))

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2083,7 +2083,7 @@ class Expr(Basic, EvalfMixin):
         """
         from sympy import powsimp
         x = sympify(x)
-        c, e = self.as_leading_term(x).as_coeff_exponent(x)
+        c, e = self.normal().as_leading_term(x).as_coeff_exponent(x)
         c = powsimp(c, deep=True, combine='exp')
         if not c.has(x):
             return c, e
@@ -2147,10 +2147,22 @@ class Expr(Basic, EvalfMixin):
 
         See the docstring in function.expand for more information.
         """
+        from sympy.simplify.simplify import fraction
+
         hints.update(power_base=power_base, power_exp=power_exp, mul=mul, \
            log=log, multinomial=multinomial, basic=basic)
 
         expr = self
+        if hints.pop('frac', False):
+            n, d = [a.expand(deep=deep, modulus=modulus, **hints)
+                    for a in fraction(self)]
+            return n/d
+        elif hints.pop('denom', False):
+            n, d = fraction(self)
+            return n/d.expand(deep=deep, modulus=modulus, **hints)
+        elif hints.pop('numer', False):
+            n, d = fraction(self)
+            return n.expand(deep=deep, modulus=modulus, **hints)/d
         for hint, use_hint in hints.iteritems():
             if use_hint:
                 func = getattr(expr, '_eval_expand_'+hint, None)

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1551,7 +1551,19 @@ def expand(e, deep=True, modulus=None, power_base=True, power_exp=True, \
     >>> expand_mul(_)
     x*y**2 + 2*x*y*z + x*z**2
 
+    >>> expand((x + y)*y/x)
+    y + y**2/x
+
+    The parts of a rational expression can be targeted, too:
+
+    >>> expand((x + y)*y/x/(x + 1), frac=True)
+    (x*y + y**2)/(x**2 + x)
+    >>> expand((x + y)*y/x/(x + 1), numer=True)
+    (x*y + y**2)/(x*(x + 1))
+    >>> expand((x + y)*y/x/(x + 1), denom=True)
+    y*(x + y)/(x**2 + x)
     """
+    # don't modify this; modify the Expr.expand method
     hints['power_base'] = power_base
     hints['power_exp'] = power_exp
     hints['mul'] = mul

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -713,8 +713,16 @@ class Mul(AssocOp):
         return self.func(*terms)
 
     def _eval_expand_mul(self, deep=True, **hints):
+        from sympy import fraction
+        expr = self
+        n, d = fraction(expr)
+        if d is not S.One:
+            expr = n/d._eval_expand_mul(deep=deep, **hints)
+            if not expr.is_Mul:
+                return expr._eval_expand_mul(deep=deep, **hints)
+
         plain, sums, rewrite = [], [], False
-        for factor in self.args:
+        for factor in expr.args:
             if deep:
                 term = factor.expand(deep=deep, **hints)
                 if term != factor:
@@ -732,7 +740,7 @@ class Mul(AssocOp):
                     sums.append(Wrapper(factor))
 
         if not rewrite:
-            return self
+            return expr
         else:
             plain = Mul(*plain)
             if sums:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1205,3 +1205,6 @@ def test_product_irrational():
     assert (I*pi).is_irrational is False
     # The following used to be deduced from the above bug:
     assert (I*pi).is_positive is False
+
+def test_issue_2820():
+    assert (x/(y*(1 + y))).expand() == x/(y**2 + y)

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -1,5 +1,6 @@
 from sympy import log, sqrt, Rational as R, Symbol
 
+from sympy.simplify.simplify import expand_numer, expand
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y
 
@@ -56,3 +57,13 @@ def test_expand_modulus():
 
 def test_issue_2644():
     assert (x*sqrt(x + y)*(1 + sqrt(x + y))).expand() == x**2 + x*y + x*sqrt(x + y)
+
+def test_expand_frac():
+    assert expand((x + y)*y/x/(x + 1), frac=True) == \
+        (x*y + y**2)/(x**2 + x)
+    assert expand((x + y)*y/x/(x + 1), numer=True) == \
+        (x*y + y**2)/(x*(x + 1))
+    assert expand((x + y)*y/x/(x + 1), denom=True) == \
+        y*(x + y)/(x**2 + x)
+    eq = (x+1)**2/y
+    assert expand_numer(eq, multinomial=False) == eq

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -106,17 +106,20 @@ def numer(expr):
 def denom(expr):
     return fraction(expr)[1]
 
-def fraction_expand(expr):
-    a, b = fraction(expr)
-    return a.expand() / b.expand()
+def fraction_expand(expr, **hints):
+    return expr.expand(frac=True, **hints)
 
-def numer_expand(expr):
+def numer_expand(expr, **hints):
     a, b = fraction(expr)
-    return a.expand() / b
+    return a.expand(numer=True, **hints) / b
 
-def denom_expand(expr):
+def denom_expand(expr, **hints):
     a, b = fraction(expr)
-    return a / b.expand()
+    return a / b.expand(denom=True, **hints)
+
+expand_numer = numer_expand
+expand_denom = denom_expand
+expand_fraction = fraction_expand
 
 def separate(expr, deep=False, force=False):
     """A wrapper to expand(power_base=True) which separates a power

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -6,6 +6,7 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
     factor, Mul, O, hyper, Add, Float, radsimp, collect_const)
 from sympy.core.mul import _keep_coeff
+from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
 
 from sympy.abc import x, y, z, t, a, b, c, d, e
@@ -879,3 +880,8 @@ def test_issue2834():
     x = Polygon(*RegularPolygon((0, 0), 1, 5).vertices).centroid.x
     assert abs(denom(x).n()) > 1e-12
     assert abs(denom(radsimp(x))) > 1e-12 # in case simplify didn't handle it
+
+def test_fraction_expand():
+    eq = (x + y)*y/x
+    assert eq.expand(frac=True) == fraction_expand(eq) == (x*y + y**2)/x
+    assert eq.expand() == y + y**2/x


### PR DESCRIPTION
Besides fraction_expand, expand now has a hint 'frac' that can be used to expand the numer and denom and then return the ratio.
