### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -301,8 +301,8 @@ class TensorProductHilbertSpace(HilbertSpace):
     C(2)*F
     >>> hs.dimension
     oo
-    >>> list(hs.spaces)
-    [C(2), F]
+    >>> hs.spaces
+    (C(2), F)
 
     >>> c1 = ComplexSpace(2)
     >>> n = symbols('n')
@@ -382,7 +382,7 @@ class TensorProductHilbertSpace(HilbertSpace):
     @property
     def spaces(self):
         """A tuple of the Hilbert spaces in this tensor product."""
-        return set(self.args)
+        return self.args
 
     def _spaces_printer(self, printer, *args):
         spaces_strs = []
@@ -499,7 +499,7 @@ class DirectSumHilbertSpace(HilbertSpace):
     @property
     def spaces(self):
         """A tuple of the Hilbert spaces in this direct sum."""
-        return set(self.args)
+        return self.args
 
     def _sympyrepr(self, printer, *args):
         spaces_reprs = [printer._print(arg, *args) for arg in self.args]

--- a/sympy/physics/quantum/hilbert.py
+++ b/sympy/physics/quantum/hilbert.py
@@ -52,7 +52,7 @@ class HilbertSpace(Basic):
     """
 
     def __new__(cls):
-        obj = Basic.__new__(cls, **{'commutative': False})
+        obj = Basic.__new__(cls)
         return obj
 
     @property
@@ -139,7 +139,7 @@ class ComplexSpace(HilbertSpace):
         r = cls.eval(dimension)
         if isinstance(r, Basic):
             return r
-        obj = Basic.__new__(cls, dimension, **{'commutative': False})
+        obj = Basic.__new__(cls, dimension)
         return obj
 
     @classmethod
@@ -204,7 +204,7 @@ class L2(HilbertSpace):
         if not isinstance(interval, Interval):
             raise TypeError('L2 interval must be an Interval instance: %r'\
             % interval)
-        obj = Basic.__new__(cls, interval, **{'commutative': False})
+        obj = Basic.__new__(cls, interval)
         return obj
 
     @property
@@ -255,7 +255,7 @@ class FockSpace(HilbertSpace):
     """
 
     def __new__(cls):
-        obj = Basic.__new__(cls, **{'commutative': False})
+        obj = Basic.__new__(cls)
         return obj
 
     @property
@@ -323,7 +323,7 @@ class TensorProductHilbertSpace(HilbertSpace):
         r = cls.eval(args)
         if isinstance(r, Basic):
             return r
-        obj = Basic.__new__(cls, *args, **{'commutative': False})
+        obj = Basic.__new__(cls, *args)
         return obj
 
     @classmethod
@@ -465,7 +465,7 @@ class DirectSumHilbertSpace(HilbertSpace):
         r = cls.eval(args)
         if isinstance(r, Basic):
             return r
-        obj = Basic.__new__(cls, *args, **{'commutative': True})
+        obj = Basic.__new__(cls, *args)
         return obj
 
     @classmethod
@@ -580,7 +580,7 @@ class TensorPowerHilbertSpace(HilbertSpace):
         r = cls.eval(args)
         if isinstance(r, Basic):
             return r
-        return Basic.__new__(cls, *r, **{'commutative': False})
+        return Basic.__new__(cls, *r)
 
     @classmethod
     def eval(cls, args):

--- a/sympy/physics/quantum/tests/test_hilbert.py
+++ b/sympy/physics/quantum/tests/test_hilbert.py
@@ -54,7 +54,7 @@ def test_tensor_product():
     h = hs1*hs2
     assert isinstance(h, TensorProductHilbertSpace)
     assert h.dimension == 2*n
-    assert h.spaces == set([hs1, hs2])
+    assert h.spaces == (hs1, hs2)
 
     h = hs2*hs2
     assert isinstance(h, TensorPowerHilbertSpace)
@@ -91,10 +91,10 @@ def test_direct_sum():
     h = hs1+hs2
     assert isinstance(h, DirectSumHilbertSpace)
     assert h.dimension == 2+n
-    assert h.spaces == set([hs1, hs2])
+    assert h.spaces == (hs1, hs2)
 
     f = FockSpace()
     h = hs1 + f + hs2
     assert h.dimension == oo
-    assert h.spaces == set([hs1, hs2, f])
+    assert h.spaces == (hs1, f, hs2)
 

--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -39,13 +39,6 @@ class Unit(AtomicExpr):
     def _hashable_content(self):
         return (self.name,self.abbrev)
 
-def defunit(value, *names):
-    u = value
-    g = globals()
-    for name in names:
-        g[name] = u
-
-
 # Dimensionless
 
 percent = percents = Rational(1,100)
@@ -79,80 +72,80 @@ deg = degree = degrees = pi/180
 
 # Base units
 
-defunit(Unit('meter', 'm'), 'm', 'meter', 'meters')
-defunit(Unit('kilogram', 'kg'), 'kg', 'kilogram', 'kilograms')
-defunit(Unit('second', 's'), 's', 'second', 'seconds')
-defunit(Unit('ampere', 'A'), 'A', 'ampere', 'amperes')
-defunit(Unit('kelvin', 'K'), 'K', 'kelvin', 'kelvins')
-defunit(Unit('mole', 'mol'), 'mol', 'mole', 'moles')
-defunit(Unit('candela', 'cd'), 'cd', 'candela', 'candelas')
+m = meter = meters = Unit('meter', 'm')
+kg = kilogram = kilograms = Unit('kilogram', 'kg')
+s = second = seconds = Unit('second', 's')
+A = ampere = amperes = Unit('ampere', 'A')
+K = kelvin = kelvins = Unit('kelvin', 'K')
+mol = mole = moles = Unit('mole', 'mol')
+cd = candela = candelas = Unit('candela', 'cd')
 
 
 # Derived units
 
-defunit(1/s, 'Hz', 'hz', 'hertz')
-defunit(m*kg/s**2, 'N', 'newton', 'newtons')
-defunit(N*m, 'J', 'joule', 'joules')
-defunit(J/s, 'W', 'watt', 'watts')
-defunit(N/m**2, 'Pa', 'pa', 'pascal', 'pascals')
-defunit(s*A, 'C', 'coulomb', 'coulombs')
-defunit(W/A, 'v', 'V', 'volt', 'volts')
-defunit(V/A, 'ohm', 'ohms')
-defunit(A/V, 'S', 'siemens', 'mho', 'mhos')
-defunit(C/V, 'F', 'farad', 'farads')
-defunit(J/A, 'Wb', 'wb', 'weber', 'webers')
-defunit(V*s/m**2, 'T', 'tesla', 'teslas')
-defunit(V*s/A, 'H', 'henry', 'henrys')
+Hz = hz = hertz = 1/s
+N = newton = newtons = m*kg/s**2
+J = joule = joules = N*m
+W = watt = watts = J/s
+Pa = pa = pascal = pascals = N/m**2
+C = coulomb = coulombs = s*A
+v = V = volt = volts = W/A
+ohm = ohms = V/A
+S = siemens = mho = mhos = A/V
+F = farad = farads = C/V
+Wb = wb = weber = webers = J/A
+T = tesla = teslas = V*s/m**2
+H = henry = henrys = V*s/A
 
 
 # Common length units
 
-defunit(kilo*m, 'km', 'kilometer', 'kilometers')
-defunit(deci*m, 'dm', 'decimeter', 'decimeters')
-defunit(centi*m, 'cm', 'centimeter', 'centimeters')
-defunit(milli*m, 'mm', 'millimeter', 'millimeters')
-defunit(micro*m, 'um', 'micrometer', 'micrometers', 'micron', 'microns')
-defunit(nano*m, 'nm', 'nanometer', 'nanometers')
-defunit(pico*m, 'pm', 'picometer', 'picometers')
+km = kilometer = kilometers = kilo*m
+dm = decimeter = decimeters = deci*m
+cm = centimeter = centimeters = centi*m
+mm = millimeter = millimeters = milli*m
+um = micrometer = micrometers = micron = microns = micro*m
+nm = nanometer = nanometers = nano*m
+pm = picometer = picometers = pico*m
 
-defunit(Rational('0.3048')*m, 'ft', 'foot', 'feet')
-defunit(Rational('25.4')*mm, 'inch', 'inches')
-defunit(3*ft, 'yd', 'yard', 'yards')
-defunit(5280*ft, 'mi', 'mile', 'miles')
+ft = foot = feet = Rational('0.3048')*m
+inch = inches = Rational('25.4')*mm
+yd = yard = yards = 3*ft
+mi = mile = miles = 5280*ft
 
 
 # Common volume and area units
 
-defunit(m**3 / 1000, 'l', 'liter', 'liters')
-defunit(deci*l, 'dl', 'deciliter', 'deciliters')
-defunit(centi*l, 'cl', 'centiliter', 'centiliters')
-defunit(milli*l, 'ml', 'milliliter', 'milliliters')
+l = liter = liters = m**3 / 1000
+dl = deciliter = deciliters = deci*l
+cl = centiliter = centiliters = centi*l
+ml = milliliter = milliliters = milli*l
 
 
 # Common time units
 
-defunit(milli*s, 'ms', 'millisecond', 'milliseconds')
-defunit(micro*s, 'us', 'microsecond', 'microseconds')
-defunit(nano*s, 'ns', 'nanosecond', 'nanoseconds')
-defunit(pico*s, 'ps', 'picosecond', 'picoseconds')
+ms = millisecond = milliseconds = milli*s
+us = microsecond = microseconds = micro*s
+ns = nanosecond = nanoseconds = nano*s
+ps = picosecond = picoseconds = pico*s
 
-defunit(60*s, 'minute', 'minutes')
-defunit(60*minute, 'h', 'hour', 'hours')
-defunit(24*hour, 'day', 'days')
+minute = minutes = 60*s
+h = hour = hours = 60*minute
+day = days = 24*hour
 
-defunit(Rational('31558149.540')*s, 'sidereal_year', 'sidereal_years')
-defunit(Rational('365.24219')*day, 'tropical_year', 'tropical_years')
-defunit(Rational('365')*day, 'common_year', 'common_years')
-defunit(Rational('365.25')*day, 'julian_year', 'julian_years')
+sidereal_year = sidereal_years = Rational('31558149.540')*s
+tropical_year = tropical_years = Rational('365.24219')*day
+common_year = common_years = Rational('365')*day
+julian_year = julian_years = Rational('365.25')*day
 
 year = years = tropical_year
 
 
 # Common mass units
 
-defunit(kilogram / kilo, 'g', 'gram', 'grams')
-defunit(milli * g, 'mg', 'milligram', 'milligrams')
-defunit(micro * g, 'ug', 'microgram', 'micrograms')
+g = gram = grams = kilogram / kilo
+mg = milligram = milligrams = milli * g
+ug = microgram = micrograms = micro * g
 
 
 
@@ -187,8 +180,8 @@ eV = 1.602176487e-19 * J
 
 # Other convenient units and magnitudes
 
-defunit(c*julian_year, 'ly', 'lightyear', 'lightyears')
-defunit(149597870691*m, 'au', 'astronomical_unit', 'astronomical_units')
+ly = lightyear = lightyears = c*julian_year
+au = astronomical_unit = astronomical_units = 149597870691*m
 
 # Delete this so it doesn't pollute the namespace
 del Rational, pi

--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -16,6 +16,7 @@ class Unit(AtomicExpr):
     """
     is_positive = True    # make sqrt(m**2) --> m
     is_commutative = True
+    is_number = False
 
     __slots__ = ["name", "abbrev"]
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -241,8 +241,9 @@ class StrPrinter(Printer):
         if len(a)==0:
             a = [S.One]
 
-        a_str = map(lambda x:self.parenthesize(x, precedence(expr)), a)
-        b_str = map(lambda x:self.parenthesize(x, precedence(expr)), b)
+        prec = precedence(expr)
+        a_str = map(lambda x:self.parenthesize(x, prec), a)
+        b_str = map(lambda x:self.parenthesize(x, prec), b)
 
         if len(b)==0:
             return sign + '*'.join(a_str)


### PR DESCRIPTION
- Avoid using magic hacks to create variables in `sympy/physics/units.py`. This silences umpteen warnings from pyflakes.
- Improve printing performance a little.
- Fix (DirectSum|TensorProduct)HilbertSpace.spaces to return a tuple as advertised in the docstring. 
- Remove incorrect uses of 'commutative' in hilbert.py.

@ellisonbg should have a look at the last two.
