### PR TITLE
Expandmul

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -680,12 +680,18 @@ class Mul(AssocOp):
         if not rewrite:
             return self
         else:
+            plain = Mul(*plain)
             if sums:
                 terms = Mul._expandsums(sums)
-                plain = Mul(*plain)
-                return Add(*[Mul(plain, term) for term in terms])
+                args = []
+                for term in terms:
+                    t = Mul(plain, term)
+                    if t.is_Mul and any(a.is_Add for a in t.args):
+                        t = t._eval_expand_mul(deep=deep)
+                    args.append(t)
+                return Add(*args)
             else:
-                return Mul(*plain)
+                return plain
 
     def _eval_expand_multinomial(self, deep=True, **hints):
         sargs, terms = self.args, []

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -57,3 +57,6 @@ def test_expand_modulus():
 
     raises(ValueError, "((x + y)**11).expand(modulus=0)")
     raises(ValueError, "((x + y)**11).expand(modulus=x)")
+
+def test_issue_2644():
+    assert (x*sqrt(x + y)*(1 + sqrt(x + y))).expand() == x**2 + x*y + x*sqrt(x + y)


### PR DESCRIPTION
Now expand_mul will return a flat result:

``` python
(x*sqrt(x + y)*(1 + sqrt(x + y))).expand() == x**2 + x*y + x*sqrt(x + y)
```

rather than `x*sqrt(x + y) + x*(x + y)`

There are also some other minor edits in mul.py

http://code.google.com/p/sympy/issues/detail?id=2644
