### PR TITLE
better handling of Floats in solve

### DIFF
--- a/doc/src/modules/evalf.txt
+++ b/doc/src/modules/evalf.txt
@@ -10,6 +10,7 @@ Exact SymPy expressions can be converted to floating-point approximations
 (decimal numbers) using either the ``.evalf()`` method or the ``N()`` function.
 ``N(expr, <args>)`` is equivalent to ``sympify(expr).evalf(<args>)``.
 
+    >>> python_float = float
     >>> from sympy import *
     >>> N(sqrt(2)*pi)
     4.44288293815837
@@ -125,13 +126,18 @@ where φ is the golden ratio. With ordinary floating-point arithmetic,
 subtracting these numbers from each other erroneously results in a complete
 cancellation:
 
-    >>> float(GoldenRatio**1000/sqrt(5)) #doctest: +SKIP
+    >>> a, b = GoldenRatio**1000/sqrt(5), fibonacci(1000)
+    >>> python_float(a) #doctest: +SKIP
     4.34665576869...e+208
-    >>> float(fibonacci(1000)) #doctest: +SKIP
+    >>> python_float(b) #doctest: +SKIP
     4.34665576869...e+208
-    >>> float(fibonacci(1000)) - float(GoldenRatio**1000/sqrt(5))
+    >>> python_float(a) - python_float(b)
     0.0
 
+The SymPy float function, however, gives the correct difference:
+
+    >>> float(a) - float(b)
+    9.12488123524439e+192
 
 ``N`` and ``evalf`` keep track of errors and automatically increase the
 precision used internally in order to obtain a correct result:

--- a/doc/src/modules/evalf.txt
+++ b/doc/src/modules/evalf.txt
@@ -10,7 +10,6 @@ Exact SymPy expressions can be converted to floating-point approximations
 (decimal numbers) using either the ``.evalf()`` method or the ``N()`` function.
 ``N(expr, <args>)`` is equivalent to ``sympify(expr).evalf(<args>)``.
 
-    >>> python_float = float
     >>> from sympy import *
     >>> N(sqrt(2)*pi)
     4.44288293815837
@@ -127,17 +126,12 @@ subtracting these numbers from each other erroneously results in a complete
 cancellation:
 
     >>> a, b = GoldenRatio**1000/sqrt(5), fibonacci(1000)
-    >>> python_float(a) #doctest: +SKIP
+    >>> float(a) #doctest: +SKIP
     4.34665576869...e+208
-    >>> python_float(b) #doctest: +SKIP
+    >>> float(b) #doctest: +SKIP
     4.34665576869...e+208
-    >>> python_float(a) - python_float(b)
-    0.0
-
-The SymPy float function, however, gives the correct difference:
-
     >>> float(a) - float(b)
-    9.12488123524439e+192
+    0.0
 
 ``N`` and ``evalf`` keep track of errors and automatically increase the
 precision used internally in order to obtain a correct result:

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -18,7 +18,7 @@ from multidimensional import vectorize
 from function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     Function, Subs, expand, PoleError, count_ops, \
     expand_mul, expand_log, expand_func,\
-    expand_trig, expand_complex, expand_multinomial
+    expand_trig, expand_complex, expand_multinomial, float
 from sets import Set, Interval, Union, EmptySet, FiniteSet, ProductSet
 from evalf import PrecisionExhausted, N
 from containers import Tuple, Dict

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -18,7 +18,7 @@ from multidimensional import vectorize
 from function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     Function, Subs, expand, PoleError, count_ops, \
     expand_mul, expand_log, expand_func,\
-    expand_trig, expand_complex, expand_multinomial, float
+    expand_trig, expand_complex, expand_multinomial, nfloat
 from sets import Set, Interval, Union, EmptySet, FiniteSet, ProductSet
 from evalf import PrecisionExhausted, N
 from containers import Tuple, Dict

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -37,14 +37,16 @@ from expr import Expr, AtomicExpr
 from decorators import _sympifyit, deprecated
 from compatibility import iterable,is_sequence
 from cache import cacheit
-from numbers import Rational
+from numbers import Rational, Float
 
-from sympy.core.containers import Tuple
+from sympy.core.containers import Tuple, Dict
 from sympy.utilities import default_sort_key
 from sympy.utilities.iterables import uniq
 
 from sympy import mpmath
 import sympy.mpmath.libmp as mlib
+
+_float = float
 
 class PoleError(Exception):
     pass
@@ -1833,5 +1835,72 @@ def count_ops(expr, visual=False):
 
     return sum(int((a.args or [1])[0]) for a in Add.make_args(ops))
 
+def float(expr, denom_of_1=False, exponent=False):
+    """Make all Rationals in expr Floats except if they are exponents
+    (unless the exponents flag is set to True). If denom_of_1 is True then
+    all Rationals not appearing as exponents will be changed, otherwise only
+    those that don't have a numerator of 1.
+
+    Examples:
+
+    >>> from sympy.solvers.solvers import float
+    >>> from sympy.abc import x
+    >>> from sympy import cos, pi, S
+    >>> float(x**4 + x/2 + cos(pi/3) + 1)
+    x**4 + x/2 + 1.5
+    >>> float(x**4 + x/2 + cos(pi/3) + 1, denom_of_1=True, exponent=True)
+    0.5*x + x**4.0 + 1.5
+
+    """
+
+    if iterable(expr, exclude=basestring):
+        if isinstance(expr, (dict, Dict)):
+            return type(expr)([(k, float(v, denom_of_1, exponent)) for k, v in expr.iteritems()])
+        return type(expr)([float(a, denom_of_1, exponent) for a in expr])
+    elif not isinstance(expr, Expr):
+        return _float(expr)
+    elif expr.is_Float:
+        return expr
+    elif expr.is_Integer:
+        return Float(_float(expr))
+    elif expr.is_Rational:
+        return Float(expr)
+
+    denoms = []
+    if not denom_of_1:
+        denoms = [(r, Dummy()) for r in expr.atoms(Rational) if r.p == 1 and r.q != 1]
+
+    if exponent is False:
+        pows = [p for p in expr.atoms(Pow) if p.exp.is_Rational and p.exp.q != 1]
+        pows.sort(key=count_ops)
+        pows.reverse()
+        rats = {}
+        for p in pows:
+            if p.exp not in rats:
+                e = Dummy()
+                rats[p.exp] = e
+        reps = [(p, Pow(p.base, rats[p.exp], evaluate=False)) for p in pows]
+        rv = expr.subs(reps).subs(denoms).n()
+        rv = rv.subs([(v, k) for k, v in rats.iteritems()]).subs([(n, o) for o, n in denoms])
+    else:
+        expr = expr.subs(denoms).n().subs([(n, o) for o, n in denoms])
+        if exponent is True:
+            pows = [p for p in expr.atoms(Pow) if p.exp.is_Integer]
+            pows.sort(key=count_ops)
+            pows.reverse()
+            ints = {}
+            for p in pows:
+                if p.exp not in ints:
+                    ints[p.exp] = Float(_float(p.exp))
+            reps = [(p, p.base**ints[p.exp]) for p in pows]
+            rv = expr.subs(reps)
+
+    funcs = [f for f in rv.atoms(Function)]
+    funcs.sort(key=count_ops)
+    funcs.reverse()
+    return rv.subs([(f, f.func(*[float(a, denom_of_1, exponent) for a in f.args])) for f in funcs])
+
 from sympify import sympify
-from add    import Add
+from add import Add
+from power import Pow
+from sympy.core.symbol import Dummy

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1835,7 +1835,7 @@ def count_ops(expr, visual=False):
 
     return sum(int((a.args or [1])[0]) for a in Add.make_args(ops))
 
-def float(expr, denom_of_1=False, exponent=False):
+def float(expr, n=15, denom_of_1=False, exponent=False):
     """Make all Rationals in expr Floats except if they are exponents
     (unless the exponents flag is set to True). If denom_of_1 is True then
     all Rationals not appearing as exponents will be changed, otherwise only
@@ -1855,16 +1855,16 @@ def float(expr, denom_of_1=False, exponent=False):
 
     if iterable(expr, exclude=basestring):
         if isinstance(expr, (dict, Dict)):
-            return type(expr)([(k, float(v, denom_of_1, exponent)) for k, v in expr.iteritems()])
-        return type(expr)([float(a, denom_of_1, exponent) for a in expr])
+            return type(expr)([(k, float(v, n, denom_of_1, exponent)) for k, v in expr.iteritems()])
+        return type(expr)([float(a, n, denom_of_1, exponent) for a in expr])
     elif not isinstance(expr, Expr):
         return _float(expr)
     elif expr.is_Float:
-        return expr
+        return expr.n(n)
     elif expr.is_Integer:
-        return Float(_float(expr))
+        return Float(_float(expr)).n(n)
     elif expr.is_Rational:
-        return Float(expr)
+        return Float(expr).n(n)
 
     denoms = []
     if not denom_of_1:
@@ -1880,10 +1880,10 @@ def float(expr, denom_of_1=False, exponent=False):
                 e = Dummy()
                 rats[p.exp] = e
         reps = [(p, Pow(p.base, rats[p.exp], evaluate=False)) for p in pows]
-        rv = expr.subs(reps).subs(denoms).n()
+        rv = expr.subs(reps).subs(denoms).n(n)
         rv = rv.subs([(v, k) for k, v in rats.iteritems()]).subs([(n, o) for o, n in denoms])
     else:
-        expr = expr.subs(denoms).n().subs([(n, o) for o, n in denoms])
+        expr = expr.subs(denoms).n(n).subs([(n, o) for o, n in denoms])
         if exponent is True:
             pows = [p for p in expr.atoms(Pow) if p.exp.is_Integer]
             pows.sort(key=count_ops)
@@ -1898,7 +1898,7 @@ def float(expr, denom_of_1=False, exponent=False):
     funcs = [f for f in rv.atoms(Function)]
     funcs.sort(key=count_ops)
     funcs.reverse()
-    return rv.subs([(f, f.func(*[float(a, denom_of_1, exponent) for a in f.args])) for f in funcs])
+    return rv.subs([(f, f.func(*[float(a, n, denom_of_1, exponent) for a in f.args])) for f in funcs])
 
 from sympify import sympify
 from add import Add

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -16,7 +16,7 @@ from sympy.core.sympify import sympify
 from sympy.core import C, S, Mul, Add, Pow, Symbol, Wild, Equality, Dummy, Basic, Expr
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
         Derivative, Function, AppliedUndef, UndefinedFunction, count_ops,
-	float)
+	nfloat)
 from sympy.core.numbers import ilcm, Float
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or
@@ -683,7 +683,7 @@ def solve(f, *symbols, **flags):
 
     # restore floats
     if floats and flags.get('rational', None) is None:
-        solution = float(solution, denom_of_1=True, exponent=False)
+        solution = nfloat(solution, denom_of_1=True, exponent=False)
 
     if not check or not solution:
         return solution

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -16,14 +16,14 @@ from sympy.core.sympify import sympify
 from sympy.core import C, S, Mul, Add, Pow, Symbol, Wild, Equality, Dummy, Basic, Expr
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
         Derivative, Function, AppliedUndef, UndefinedFunction, count_ops,
-	nfloat)
+        nfloat)
 from sympy.core.numbers import ilcm, Float
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or
 
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, cot,
                              cosh, sinh, tanh, coth, acos, asin, atan, acot,
-                             acosh, asinh, atanh, acoth, sqrt)
+                             acosh, asinh, atanh, acoth, sqrt, Abs)
 from sympy.simplify import (simplify, collect, powsimp, fraction, posify,
                             powdenest, nsimplify)
 from sympy.matrices import Matrix, zeros
@@ -1829,13 +1829,14 @@ def _invert(eq, *symbols, **kwargs):
 
     inverses = {
     asin: sin,
-    acos:cos,
-    atan:tan,
-    acot:cot,
+    acos: cos,
+    atan: tan,
+    acot: cot,
     asinh: sinh,
-    acosh:cosh,
-    atanh:tanh,
-    acoth:coth,}
+    acosh: cosh,
+    atanh: tanh,
+    acoth: coth,
+    }
 
     lhs = eq
     rhs = S.Zero
@@ -1894,9 +1895,15 @@ def _invert(eq, *symbols, **kwargs):
 
         #                    -1
         # f(x) = g  ->  x = f  (g)
-        elif lhs.is_Function and (lhs.nargs==1 or len(lhs.args) == 1) and (hasattr(lhs, 'inverse') or lhs.func in inverses):
+        elif lhs.is_Function and (lhs.nargs==1 or len(lhs.args) == 1) and \
+                                 (hasattr(lhs, 'inverse') or
+                                  lhs.func in inverses or
+                                  lhs.func is Abs):
             if lhs.func in inverses:
                 inv = inverses[lhs.func]
+            elif lhs.func is Abs:
+                inv = lambda w: w**2
+                lhs = Basic(lhs.args[0]**2) # get it ready to remove the args
             else:
                 inv = lhs.inverse()
             rhs = inv(rhs)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -286,7 +286,9 @@ def check_assumptions(expr, **assumptions):
     for key, expected in assumptions.iteritems():
         if expected is None:
             continue
-        if not(expected in [0, 1] or isinstance(expected, bool)):
+        if expected in [0, 1]:
+            expected = bool(expected)
+        if not isinstance(expected, bool):
             raise ValueError('A boolean is expected for %s but got %s.' % (key, expected))
         if hasattr(Q, key):
             test = ask(getattr(Q, key)(expr))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -305,6 +305,26 @@ def check_assumptions(expr, **assumptions):
     return result
 
 def float_coeff(expr, deep=False, exponent=False):
+    """Make all Rationals in expr Floats except if they are exponents
+    (unless the exponents flag is set to True). This function avoids the
+    'conjugates' that can appear when using evalf[1] to evaluate expressions.
+
+    Example:
+
+    >>> from sympy.solvers.solvers import float_coeff
+    >>> from sympy.abc import x
+    >>> from sympy import cos, pi
+    >>> float_coeff(x**4 + 2*x + cos(pi/8) + 1)
+    1.0*x**4 + 2.0*x + 1.0*cos(pi/8) + 1.0
+    >>> float_coeff(x**4 + 2*x + cos(pi/8) + 1, deep=True)
+    x**4 + 2.0*x + cos(0.125*pi) + 1.0
+    >>> float_coeff(x**4 + 2*x + cos(pi/8) + 1, exponent=True)
+    2.0*x + 1.0*x**4.0 + 1.0*cos(pi/8) + 1.0
+
+    Reference:
+    [1] http://groups.google.com/group/sympy/t/d778f1cd00358e97
+    """
+
     if isinstance(expr, (Dict, dict)):
         return type(expr)([(k, float_coeff(v, deep, exponent)) for k, v in expr.iteritems()])
     elif iterable(expr):
@@ -315,7 +335,7 @@ def float_coeff(expr, deep=False, exponent=False):
         return expr.n()
     elif not expr.args:
         return expr
-    elif expr.func is exp:
+    elif deep and expr.func is exp:
         return exp(float_coeff(expr.args[0], deep, exponent))
     elif expr.is_Pow:
         b, e = expr.as_base_exp()

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -188,7 +188,7 @@ def checksol(f, symbol, sol=None, **flags):
                 val = posify(val)[0]
                 # expansion may work now, so try again and check
                 exval = expand_mul(expand_multinomial(val))
-                if not exval.free_symbols:
+                if exval.is_number or not exval.free_symbols:
                     # we can decide now
                     val = exval
         elif attempt == 3:
@@ -683,7 +683,7 @@ def solve(f, *symbols, **flags):
 
     # restore floats
     if floats and flags.get('rational', None) is None:
-        solution = nfloat(solution, denom_of_1=True, exponent=False)
+        solution = nfloat(solution, exponent=False)
 
     if not check or not solution:
         return solution

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -7,7 +7,7 @@ from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve, solve_undetermined_coeffs
 from sympy.solvers.solvers import unrad, _invert
-from sympy.core.function import float
+from sympy.core.function import nfloat
 
 from sympy.utilities.pytest import XFAIL, raises, skip
 
@@ -904,17 +904,17 @@ def test_float_handling():
     assert solve(x - S.Half, rational=False)[0].is_Rational
     assert solve(x - 0.5, rational=None)[0].is_Float
     assert solve(x - S.Half, rational=None)[0].is_Rational
-    assert test(float(1 + 2*x), 1.0 + 2.0*x)
+    assert test(nfloat(1 + 2*x), 1.0 + 2.0*x)
     for contain in [list, tuple, set]:
-        ans = float(contain([1 + 2*x]))
+        ans = nfloat(contain([1 + 2*x]))
         assert type(ans) is contain and test(list(ans)[0], 1.0 + 2.0*x)
-    k, v = float({2*x: [1 + 2*x]}).items()[0]
+    k, v = nfloat({2*x: [1 + 2*x]}).items()[0]
     assert test(k, 2*x) and test(v[0], 1.0 + 2.0*x)
-    assert test(float(cos(2*x)), cos(2.0*x))
-    assert test(float(3*x**2), 3.0*x**2)
-    assert test(float(3*x**2, exponent=True), 3.0*x**2.0)
-    assert test(float(exp(2*x)), exp(2.0*x))
-    assert test(float(x/3), x/3)
-    assert test(float(x/3, denom_of_1=True), x/3.0)
-    assert test(float(x**4 + 2*x + cos(S(1)/3) + 1, denom_of_1=False),
+    assert test(nfloat(cos(2*x)), cos(2.0*x))
+    assert test(nfloat(3*x**2), 3.0*x**2)
+    assert test(nfloat(3*x**2, exponent=True), 3.0*x**2.0)
+    assert test(nfloat(exp(2*x)), exp(2.0*x))
+    assert test(nfloat(x/3), x/3)
+    assert test(nfloat(x/3, denom_of_1=True), x/3.0)
+    assert test(nfloat(x**4 + 2*x + cos(S(1)/3) + 1, denom_of_1=False),
             x**4 + 2.0*x + 1.94495694631474)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -921,3 +921,6 @@ def test_float_handling():
 def test_check_assumptions():
     x = symbols('x', positive=1)
     assert solve(x**2 - 1) == [1]
+
+def test_solve_abs():
+    assert solve(abs(x - 7) - 8) == [-1, 15]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -917,3 +917,7 @@ def test_float_handling():
     assert test(nfloat(x/3), x/3.0)
     assert test(nfloat(x**4 + 2*x + cos(S(1)/3) + 1),
             x**4 + 2.0*x + 1.94495694631474)
+
+def test_check_assumptions():
+    x = symbols('x', positive=1)
+    assert solve(x**2 - 1) == [1]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -6,7 +6,8 @@ from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve, solve_undetermined_coeffs
-from sympy.solvers.solvers import unrad, _invert, float
+from sympy.solvers.solvers import unrad, _invert
+from sympy.core.function import float
 
 from sympy.utilities.pytest import XFAIL, raises, skip
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -6,7 +6,7 @@ from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve, solve_undetermined_coeffs
-from sympy.solvers.solvers import unrad, _invert, float_coeff
+from sympy.solvers.solvers import unrad, _invert, float
 
 from sympy.utilities.pytest import XFAIL, raises, skip
 
@@ -903,16 +903,17 @@ def test_float_handling():
     assert solve(x - S.Half, rational=False)[0].is_Rational
     assert solve(x - 0.5, rational=None)[0].is_Float
     assert solve(x - S.Half, rational=None)[0].is_Rational
-    assert test(float_coeff(1 + 2*x), 1.0 + 2.0*x)
+    assert test(float(1 + 2*x), 1.0 + 2.0*x)
     for contain in [list, tuple, set]:
-        ans = float_coeff(contain([1 + 2*x]))
+        ans = float(contain([1 + 2*x]))
         assert type(ans) is contain and test(list(ans)[0], 1.0 + 2.0*x)
-    k, v = float_coeff({2*x: [1 + 2*x]}).items()[0]
+    k, v = float({2*x: [1 + 2*x]}).items()[0]
     assert test(k, 2*x) and test(v[0], 1.0 + 2.0*x)
-    assert test(float_coeff(cos(2*x)), cos(2*x))
-    assert test(float_coeff(cos(2*x), deep=True), cos(2.0*x))
-    assert test(float_coeff(3*x**2), 3.0*x**2)
-    assert test(float_coeff(3*x**2, exponent=True), 3.0*x**2.0)
-    assert test(float_coeff(exp(2*x)), exp(2*x))
-    assert test(float_coeff(exp(2*x), exponent=True), exp(2*x))
-    assert test(float_coeff(exp(2*x), deep=True), exp(2.0*x))
+    assert test(float(cos(2*x)), cos(2.0*x))
+    assert test(float(3*x**2), 3.0*x**2)
+    assert test(float(3*x**2, exponent=True), 3.0*x**2.0)
+    assert test(float(exp(2*x)), exp(2.0*x))
+    assert test(float(x/3), x/3)
+    assert test(float(x/3, denom_of_1=True), x/3.0)
+    assert test(float(x**4 + 2*x + cos(S(1)/3) + 1, denom_of_1=False),
+            x**4 + 2.0*x + 1.94495694631474)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -6,7 +6,7 @@ from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
 
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,dsolve,\
      tsolve, solve_undetermined_coeffs
-from sympy.solvers.solvers import unrad, _invert
+from sympy.solvers.solvers import unrad, _invert, float_coeff
 
 from sympy.utilities.pytest import XFAIL, raises, skip
 
@@ -894,3 +894,21 @@ def test_issue_2813():
     assert len(ans) == 2 and all(a.is_Number for a in ans)
     ans = solve(x**2 - x - 0.1)
     assert len(ans) == 2 and all(a.is_Number for a in ans)
+
+def test_float_handling():
+    assert solve(x - 0.5, rational=True) == [S.Half]
+    assert solve(x - 0.5, rational=False) == [0.5]
+    assert solve(x - S.Half, rational=False) == [0.5]
+    assert solve(x - 0.5, rational=None) == [0.5]
+    assert solve(x - S.Half, rational=None) == [S.Half]
+    assert float_coeff(1 + 2*x) == 1.0 + 2.0*x
+    for contain in [list, tuple, set]:
+        assert float_coeff(contain([1 + 2*x])) == contain([1.0 + 2.0*x])
+    assert float_coeff({2*x: [1 + 2*x]}) == {2*x: [1.0 + 2.0*x]}
+    assert float_coeff(cos(2*x)) == cos(2*x)
+    assert float_coeff(cos(2*x), deep=True) == cos(2.0*x)
+    assert float_coeff(3*x**2) == 3.0*x**2
+    assert float_coeff(3*x**2, exponent=True) == 3.0*x**2.0
+    assert float_coeff(exp(2*x)) == exp(2*x)
+    assert float_coeff(exp(2*x), exponent=True) == exp(2*x)
+    assert float_coeff(exp(2*x), deep=True) == exp(2.0*x)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -914,7 +914,6 @@ def test_float_handling():
     assert test(nfloat(3*x**2), 3.0*x**2)
     assert test(nfloat(3*x**2, exponent=True), 3.0*x**2.0)
     assert test(nfloat(exp(2*x)), exp(2.0*x))
-    assert test(nfloat(x/3), x/3)
-    assert test(nfloat(x/3, denom_of_1=True), x/3.0)
-    assert test(nfloat(x**4 + 2*x + cos(S(1)/3) + 1, denom_of_1=False),
+    assert test(nfloat(x/3), x/3.0)
+    assert test(nfloat(x**4 + 2*x + cos(S(1)/3) + 1),
             x**4 + 2.0*x + 1.94495694631474)


### PR DESCRIPTION
when rational is None, floats are converted to rationals and returned to floats in the solution;
when False, nothing is done with floats or rationals; manual=True may need to be used to avoid polys
when True, floats are converted to rationals and retained in the solution

floats are handled independently of the checking portion of solve
