### PR TITLE
evalf: 1->1.0; no expand or conjugate with symbolic expressions

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -551,7 +551,20 @@ class Mul(AssocOp):
 
 
     def _eval_evalf(self, prec):
-        return AssocOp._eval_evalf(self, prec).expand()
+        c, m = self.as_coeff_Mul()
+        if c is S.NegativeOne:
+            if m.is_Mul:
+                rv = -AssocOp._eval_evalf(m, prec)
+            else:
+                mnew = m._eval_evalf(prec)
+                if mnew is not None:
+                    m = mnew
+                rv = -m
+        else:
+            rv = AssocOp._eval_evalf(self, prec)
+        if rv.is_number:
+            return rv.expand()
+        return rv
 
     @cacheit
     def as_two_terms(self):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1427,9 +1427,6 @@ class One(IntegerConstant):
 
     __slots__ = []
 
-    def _eval_evalf(self, prec):
-        return self
-
     @staticmethod
     def __abs__():
         return S.One
@@ -1452,9 +1449,6 @@ class NegativeOne(IntegerConstant):
     q = 1
 
     __slots__ = []
-
-    def _eval_evalf(self, prec):
-        return self
 
     @staticmethod
     def __abs__():

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -602,10 +602,11 @@ class Pow(Expr):
         base = base._evalf(prec)
         if not exp.is_Integer:
             exp = exp._evalf(prec)
-        if exp < 0 and not base.is_real:
+        if exp < 0 and base.is_number and base.is_real is False:
             base = base.conjugate() / (base * base.conjugate())._evalf(prec)
             exp = -exp
-        return Pow(base, exp).expand()
+            return Pow(base, exp).expand()
+        return Pow(base, exp)
 
     def _eval_is_polynomial(self, syms):
         if self.exp.has(*syms):

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -153,6 +153,10 @@ def test_evalf_bugs():
     # because the order depends on the hashes of the terms.
     assert NS(20 - 5008329267844*n**25 - 477638700*n**37 - 19*n,
               subs={n:.01}) == '19.8100000000000'
+    assert NS(((x - 1)*((1 - x))**1000).n()) == '(-x + 1.00000000000000)**1000*(x - 1.00000000000000)'
+    assert NS((-x).n()) == '-x'
+    assert NS((-2*x).n()) == '-2.00000000000000*x'
+    assert NS((-2*x*y).n()) == '-2.00000000000000*x*y'
 
 def test_evalf_integer_parts():
     a = floor(log(8)/log(2) - exp(-1000), evaluate=False)


### PR DESCRIPTION
TODO: add docstring as in dot

Expanding a Mul or Power makes sense when dealing with numeric
    expressions, e.g. (1 + I)**2, but need not be done for symbolic
    expressions. The same applies for the use of conjugate to deal
    with expressions like 1/(1 + I).

```
Also, +/-1 were not being processed but they are now. The only
caveat is that the negative 1 on an expression like -x is not
changed to 1.0.
```
