### PR TITLE
Correct missprint in the XFAIL test.

### DIFF
--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -213,7 +213,7 @@ def test_Subs2():
     x = Symbol('x')
     f = Function('f')
     # this reflects a limitation of subs(), probably won't fix
-    assert Subs(f(x), x**2, 0).doit() == f(sqrt(x))
+    assert Subs(f(x), x**2, x).doit() == f(sqrt(x))
 
 
 def test_expand_function():


### PR DESCRIPTION
Replace `0` by `x` in the `sympy/core/tests/test_functions.py`:

was:
`assert Subs(f(x), x**2, 0).doit() == f(sqrt(x))`

became:
`assert Subs(f(x), x**2, x).doit() == f(sqrt(x))`
