### PR TITLE
optimize slot 0 operations

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -30,6 +30,38 @@ class Add(AssocOp):
             See Mul.flatten
 
         """
+        rv = None
+        if len(seq) == 2:
+            a, b = seq
+            if b.is_Rational:
+                a, b = b, a
+            assert a
+            if a.is_Rational and a.q:
+                if b.is_Mul:
+                    # if it's an unevaluated 2-arg, expand it
+                    c, t = b.as_coeff_Mul()
+                    if t.is_Add:
+                        h, t = t.as_coeff_Add()
+                        bargs = [c*ti for ti in Add.make_args(t)]
+                        bargs.sort(key=hash)
+                        ch = c*h
+                        if ch:
+                            bargs.insert(0, ch)
+                        b = Add._from_args(bargs)
+                if b.is_Add:
+                    bargs = list(b.args)
+                    if bargs[0].is_Number:
+                        bargs[0] += a
+                        if not bargs[0]:
+                            bargs.pop(0)
+                    else:
+                        bargs.insert(0, a)
+                    rv = bargs, [], None
+                elif b.is_Mul:
+                    rv = [a, b], [], None
+            if rv:
+                return rv
+
         terms = {}      # term -> coeff
                         # e.g. x**2 -> 5   for ... + 5*x**2 + ...
 
@@ -80,7 +112,9 @@ class Add(AssocOp):
                 c, s = o.as_coeff_Mul()
 
                 # 3*...
-                # unevaluated 2-arg Mul
+                # unevaluated 2-arg Mul, but we always unfold it so
+                # it can combine with other terms (just like is done
+                # with the Pow below)
                 if c.is_Number and s.is_Add:
                     seq.extend([c*a for a in s.args])
                     continue

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -624,9 +624,9 @@ class Expr(Basic, EvalfMixin):
         if c and c[0].is_Rational and c[0].is_negative and c[0] != S.NegativeOne:
             c[:1] = [S.NegativeOne, -c[0]]
 
-        if not clist:
-            return [set(c), nc]
-        return [c, nc]
+        if clist:
+            return [c, nc]
+        return [set(c), nc]
 
     def coeff(self, x, right=False):
         """

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -107,6 +107,36 @@ class Mul(AssocOp):
               sensitive.
 
         """
+        rv = None
+        if len(seq) == 2:
+            a, b = seq
+            if b.is_Rational:
+                a, b = b, a
+            assert not a is S.One
+            if a and a.is_Rational and a.q:
+                r, b = b.as_coeff_Mul()
+                a *= r
+                if b.is_Mul:
+                    bargs, nc = b.args_cnc(clist=True)
+                    rv = bargs, nc, None
+                    if not a is S.One:
+                        bargs.insert(0, a)
+
+                elif b.is_Add and b.is_commutative:
+                    if a is S.One:
+                        rv = [b], [], None
+                    else:
+                        r, b = b.as_coeff_Add()
+                        bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
+                        bargs.sort(key=hash)
+                        ar = a*r
+                        if ar:
+                            bargs.insert(0, ar)
+                        bargs = [Add._from_args(bargs)]
+                        rv = bargs, [], None
+            if rv:
+                return rv
+
         # apply associativity, separate commutative part of seq
         c_part = []         # out: commutative factors
         nc_part = []        # out: non-commutative factors

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1194,6 +1194,7 @@ def test_Pow_as_content_primitive():
 def test_issue2361():
     u = Mul(2, (1 + x), evaluate=False)
     assert 2 + u == 4 + 2*x
+    # the Number is only suppose to distribute on a commutative Add
     n = Symbol('n', commutative=False)
     u = 2*(1 + n)
     assert u.is_Mul

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -52,8 +52,8 @@ from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, symbols, sqrt,
     exp, sin, expand, oo, I, pi, re, im, RootOf, Eq, Tuple)
 
-from sympy.core.mul import _keep_coeff
 from sympy.core.compatibility import iterable
+from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import raises, XFAIL
 
 x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e = symbols('x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e')

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -6,10 +6,10 @@ from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     Derivative, Wild, Symbol, sympify, expand, expand_mul, expand_func,
     Function, Equality, Dummy, Atom, count_ops, Expr, factor_terms)
 
-from sympy.core.mul import _keep_coeff
 from sympy.core.compatibility import iterable, reduce
 from sympy.core.numbers import igcd
 from sympy.core.function import expand_log, count_ops
+from sympy.core.mul import _keep_coeff
 from sympy.core.rules import Transform
 
 from sympy.utilities import flatten, default_sort_key


### PR DESCRIPTION
Adding or multiplying a Rational onto an Add or Mul should be
    very quick. Even though there are core-rewriting work that has
    been discussed, having at least the operations with Rationals
    be less penalized is an advantage. With these mods, adding a Rational
    to an Add or Mul is almost instantaneous for expressions with
    30,000 terms/factors; Multiplying a Mul by a Rational is also
    fast, but multiplying an Add by a Rational is a bit slower because
    of the 2-arg Mul behavior whereby Rationals are distributed on the
    terms.
