### PR TITLE
let nsimplify select tolerance and autodetect rational case

### DIFF
--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -573,6 +573,9 @@ def test_nsimplify():
     assert nsimplify(Float(0.272198261287950).n(3), [pi,log(2)]) == \
         -pi/4 - log(2) + S(7)/4
     assert nsimplify(x/7.0) == x/7
+    assert nsimplify(pi/1e2) == pi/100
+    assert nsimplify(pi/1e2, rational=False) == pi/100.0
+    assert nsimplify(pi/1e-7) == 10000000*pi
 
 def test_extract_minus_sign():
     x = Symbol("x")

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,7 +4,7 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add)
+    factor, Mul, O, hyper, Add, Float)
 from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import XFAIL
 
@@ -569,6 +569,10 @@ def test_nsimplify():
     assert nsimplify(1/.3 + x, rational=True) == Rational(10, 3) + x
     assert nsimplify(log(3).n(), rational=True) == \
            sympify('109861228866811/100000000000000')
+    assert nsimplify(Float(0.272198261287950), [pi,log(2)]) == pi*log(2)/8
+    assert nsimplify(Float(0.272198261287950).n(3), [pi,log(2)]) == \
+        -pi/4 - log(2) + S(7)/4
+    assert nsimplify(x/7.0) == x/7
 
 def test_extract_minus_sign():
     x = Symbol("x")


### PR DESCRIPTION
nsimplify is meant to convert numbers into alternate forms;
    sometimes one just wants Rationals for Floats. The rational
    flag can be used to do this, but if the expression contains
    symbols (i.e., is not a number) then the rational flag is automatically
    selected.

```
In addition, the tolerance is set to the highest tolerance of the
numbers appearing in the expression if none is given.
```

see issues:
http://code.google.com/p/sympy/issues/detail?id=1975
http://code.google.com/p/sympy/issues/detail?id=2100
