### PR TITLE
check for equality before doing subtraction

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -137,10 +137,14 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rdiv__')
     def __div__(self, other):
+        if self == other:
+            return S.One
         return Mul(self, Pow(other, S.NegativeOne))
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__div__')
     def __rdiv__(self, other):
+        if self == other:
+            return S.One
         return Mul(other, Pow(self, S.NegativeOne))
 
     __truediv__ = __div__

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -106,10 +106,14 @@ class Expr(Basic, EvalfMixin):
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__rsub__')
     def __sub__(self, other):
+        if self == other:
+            return S.Zero
         return Add(self, -other)
     @_sympifyit('other', NotImplemented)
     @call_highest_priority('__sub__')
     def __rsub__(self, other):
+        if self == other:
+            return S.Zero
         return Add(other, -self)
 
     @_sympifyit('other', NotImplemented)

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -156,6 +156,7 @@ def test_evalf_bugs():
     # 2107 related
     s = sqrt(2)
     assert s.n(2) - s.n(2) == 0
+    assert s.n(3) / s.n(3) == 1
     s = sqrt(3)
     ns = -s
     assert ns + s == 0

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -153,6 +153,12 @@ def test_evalf_bugs():
     # because the order depends on the hashes of the terms.
     assert NS(20 - 5008329267844*n**25 - 477638700*n**37 - 19*n,
               subs={n:.01}) == '19.8100000000000'
+    # 2107 related
+    s = sqrt(2)
+    assert s.n(2) - s.n(2) == 0
+    s = sqrt(3)
+    ns = -s
+    assert ns + s == 0
 
 def test_evalf_integer_parts():
     a = floor(log(8)/log(2) - exp(-1000), evaluate=False)


### PR DESCRIPTION
This allows sqrt(2).n(2) - sqrt(2).n(2) to give 0.
