### PR TITLE
Removed __call__ from MatrixSymbol object

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -151,6 +151,10 @@ class MatrixSymbol(MatrixExpr, Symbol):
             shape = Tuple(*self.shape).subs(old, new)
             return MatrixSymbol(self.name, *shape)
 
+    def __call__(self, *args):
+        raise TypeError( "%s object is not callable"%self.__class__ )
+
+
 class Identity(MatrixSymbol):
     """The Matrix Identity I - multiplicative identity
     >>> from sympy.matrices import Identity, MatrixSymbol

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -302,3 +302,10 @@ def test_linear_factors():
     raises(ShapeError, "linear_factors(2*A*B+C, D)")
 
     assert linear_factors(A, A) == {A:Identity(n)}
+
+def test_MatrixSymbol():
+    n,m,t = symbols('n,m,t')
+    X = MatrixSymbol('X', n, m)
+    assert X.shape == (n,m)
+    raises(TypeError, "MatrixSymbol('X', n, m)(t)") # issue 2756
+


### PR DESCRIPTION
This is a small change. It's a quick fix to the following issue. 

http://code.google.com/p/sympy/issues/detail?id=2759
