### PR TITLE
Issue 2855: Move any sorting of arguments from Add.flatten

### DIFF
--- a/doc/src/guide.txt
+++ b/doc/src/guide.txt
@@ -439,13 +439,13 @@ Please use the same way as is shown below all across SymPy.
     x**2
 
     >>> (x+y*z).args
-    (y*z, x)
+    (x, y*z)
 
     >>> (x+y*z).args[0]
-    y*z
+    x
 
     >>> (x+y*z).args[1]
-    x
+    y*z
 
     >>> (y*z).args
     (y, z)

--- a/doc/src/modules/polys/basics.txt
+++ b/doc/src/modules/polys/basics.txt
@@ -211,8 +211,9 @@ polynomials and to solve some systems of polynomial equations::
     >>> solve_poly_system([y - x, x - 5], x, y)
     [(5, 5)]
 
-    >>> solve_poly_system([y**2 - x**3 + 1, y*x], x, y)
-                                       ___                 ___
-                                 1   \/ 3 *I         1   \/ 3 *I
-    [(0, I), (0, -I), (1, 0), (- - + -------, 0), (- - - -------, 0)]
-                                 2      2            2      2
+    >>> set(solve_poly_system([y**2 - x**3 + 1, y*x], x, y))
+                                          ___                 ___
+                                    1   \/ 3 *I         1   \/ 3 *I
+    set((0, -I), (0, I), (1, 0), (- - - -------, 0), (- - + -------, 0))
+                                    2      2            2      2
+

--- a/doc/src/modules/rewriting.txt
+++ b/doc/src/modules/rewriting.txt
@@ -77,9 +77,9 @@ subexpressions, collect them and evaluate them at once. This is implemented in t
     ⎛                ⎡  ________   ________⎤⎞
     ⎝[(x₀, sin(x))], ⎣╲╱ x₀ + 4 ⋅╲╱ x₀ + 5 ⎦⎠
 
-    >>> pprint(cse(sqrt(sin(x+1) + 5 + cos(y))*sqrt(sin(x+1) + 4 + cos(y))), use_unicode=True)
-    ⎛                                                 ⎡  ________   ________⎤⎞
-    ⎝[(x₀, cos(y)), (x₁, sin(x + 1)), (x₂, x₀ + x₁)], ⎣╲╱ x₂ + 4 ⋅╲╱ x₂ + 5 ⎦⎠
+    >>> pprint(cse(sqrt(sin(x)+5+cos(y))*sqrt(sin(x)+4+cos(y))), use_unicode=True)
+    ⎛                                             ⎡  ________   ________⎤⎞
+    ⎝[(x₀, sin(x)), (x₁, cos(y)), (x₂, x₀ + x₁)], ⎣╲╱ x₂ + 4 ⋅╲╱ x₂ + 5 ⎦⎠
 
     >>> pprint(cse((x-y)*(z-y) + sqrt((x-y)*(z-y))), use_unicode=True)
     ⎛                          ⎡  ____     ⎤⎞

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -18,9 +18,9 @@ class Add(AssocOp):
 
     def _hashable_content(self):
         #TODO: noncommutative case.
-        if self._hashable_tuple_chached == None:
-            self._hashable_tuple_chached = tuple(sorted(self._args, key=hash))
-        return self._hashable_tuple_chached
+        if self._hashable_tuple_cached == None:
+            self._hashable_tuple_cached = tuple(sorted(self._args, key=hash))
+        return self._hashable_tuple_cached
 
     @classmethod
     def flatten(cls, seq):
@@ -121,14 +121,9 @@ class Add(AssocOp):
 
             # Add([...])
             elif o.is_Add:
-                # NB: here we assume Add is always commutative
-                # Now we insert nested Add in-place, so we can to do not care
-                # about commutativity.
-                _args = o.args
-                i = len(_args)
-                while i>0:
-                    i -= 1
-                    seq.insert(current_pos, _args[i])
+                # insert nested Add in-place, and continue with their arguments
+                #     [1, (x, y), 2, 3) -->  [1, (x, y), x, y, 2, 3]
+                seq[current_pos:current_pos] = o.args
                 continue
 
             # Mul([...])
@@ -140,11 +135,7 @@ class Add(AssocOp):
                 # it can combine with other terms (just like is done
                 # with the Pow below)
                 if c.is_Number and s.is_Add:
-                    _args = s.args
-                    i = len(_args)
-                    while i>0:
-                        i -= 1
-                        seq.insert(current_pos, c *_args[i])
+                    seq[current_pos:current_pos] = (c*a for a in s.args)
                     continue
 
             # check for unevaluated Pow, e.g. 2**3 or 2**(-1/2)

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -142,7 +142,7 @@ class Add(AssocOp):
             elif o.is_Pow:
                 b, e = o.as_base_exp()
                 if b.is_Number and (e.is_Integer or (e.is_Rational and e.is_negative)):
-                    seq.append(Pow(b, e))
+                    seq[current_pos:current_pos] = (Pow(b, e), )
                     continue
                 c, s = S.One, o
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -105,9 +105,9 @@ class Basic(PicklableWithSlots):
 
     """
     __metaclass__ = WithAssumptions
-    __slots__ = ['_mhash',              # hash value
-                 '_args',               # arguments
-                 '_hashable_tuple_chached', # sorted arguments, to sort them once only (for speed, but not clear)
+    __slots__ = ['_mhash',                  # hash value
+                 '_args',                   # arguments
+                 '_hashable_tuple_cached',  # sorted arguments, to sort them once only.
                 ]
 
     # To be overridden with True in the appropriate subclasses
@@ -147,9 +147,9 @@ class Basic(PicklableWithSlots):
         obj = object.__new__(cls)
         obj._init_assumptions(assumptions)
 
-        obj._mhash = None # will be set by __hash__ method.
-        obj._hashable_tuple_chached = None # will be set by _hashable_content method
-        obj._args = args  # all items in args must be Basic objects
+        obj._mhash = None                   # will be set by __hash__ method.
+        obj._hashable_tuple_cached = None  # will be set by _hashable_content
+        obj._args = args    # all items in args must be Basic objects
         return obj
 
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -107,6 +107,7 @@ class Basic(PicklableWithSlots):
     __metaclass__ = WithAssumptions
     __slots__ = ['_mhash',              # hash value
                  '_args',               # arguments
+                 '_hashable_tuple_chached', # sorted arguments, to sort them once only (for speed, but not clear)
                 ]
 
     # To be overridden with True in the appropriate subclasses
@@ -147,6 +148,7 @@ class Basic(PicklableWithSlots):
         obj._init_assumptions(assumptions)
 
         obj._mhash = None # will be set by __hash__ method.
+        obj._hashable_tuple_chached = None # will be set by _hashable_content method
         obj._args = args  # all items in args must be Basic objects
         return obj
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1516,7 +1516,7 @@ class Expr(Basic, EvalfMixin):
         >>> (S(3)).as_coeff_add()
         (3, ())
         >>> (3 + x + y).as_coeff_add()
-        (3, (y, x))
+        (3, (x, y))
         >>> (3 + x +y).as_coeff_add(x)
         (y + 3, (x,))
         >>> (3 + y).as_coeff_add(x)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -128,7 +128,6 @@ class Mul(AssocOp):
                     else:
                         r, b = b.as_coeff_Add()
                         bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
-                        #bargs.sort(key=hash)
                         ar = a*r
                         if ar:
                             bargs.insert(0, ar)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -128,7 +128,7 @@ class Mul(AssocOp):
                     else:
                         r, b = b.as_coeff_Add()
                         bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
-                        bargs.sort(key=hash)
+                        #bargs.sort(key=hash)
                         ar = a*r
                         if ar:
                             bargs.insert(0, ar)

--- a/sympy/core/tests/test_flatten.py
+++ b/sympy/core/tests/test_flatten.py
@@ -1,6 +1,5 @@
 from sympy.utilities.pytest import XFAIL
 
-@XFAIL
 def test_as_coeff_add():
     from sympy.abc import x
     r = (7 + 3*x + 4*x**2).as_coeff_add()
@@ -17,7 +16,7 @@ def test_flatten_sort():
     e =  3 + x
     assert e.args == (3, x)
 
-def test_add_flatten_nessted_add():
+def test_add_flatten_nested_add():
     from sympy.core.add import Add
     from sympy.core.mul import Mul
     from sympy.abc import x, y, z, a, b, c, d, e, f
@@ -28,7 +27,7 @@ def test_add_flatten_nessted_add():
     args = (z + e + Add(y, x, z) + d + z**2 + f).args
     assert args == (2*z, e, y, x, d, z**2, f)
 
-def test_add_flatten_nessted_mul():
+def test_add_flatten_nested_mul():
     from sympy.core.add import Add
     from sympy.core.mul import Mul
     from sympy.abc import x, y, z, a, b, c, d, e, f
@@ -36,11 +35,16 @@ def test_add_flatten_nessted_mul():
     args = Add(z, e, Mul(2, Add(y, x, z)), d, z**2, f).args
     assert args == (3*z, e, 2*y, 2*x, d, z**2, f)
 
-    # as Add(x, y) is hashed, and its hash is rather equal to Add(y, x),
-    # (others tests have used it probebly)
-    # then we clear it to do not influence on this test
-    # Note that for the above assertrion (with manually Add construction)
-    # it is not needed.
+    # in case Add(y, x), whose cache is equal to Add(x, y), is already hashed
+    # we clear the cache to make sure that this test is independent of cache.
+    # Note: the string `(y + x + z)` is parsing with sequential creation of
+    # cached Add(y, x) and then Add(Add(y, x), z) and then `flatten` function
+    # calls. But the cached Add(y, x) is just a link Add(x, y), so `flatten`
+    # function treats `args` as the old ordered tuple (x, y) and insert it
+    # incorrectly.
+    # Note: with the manually constructed Add(y, x, z) this was not necessary.
+    # because it is flatten already.
+
     from sympy.core.cache import clear_cache
     clear_cache()
 
@@ -55,11 +59,7 @@ def test_mul_flatten():
     args = Mul(2, y + x + z).args
     assert args == (2*y, 2*x, 2*z)   # it is related with Add.flatten only
 
-    # as Add(x, y) is hashed, and its hash is rather equal to Add(y, x),
-    # (others tests have used it probebly)
-    # then we clear it to do not influence on this test
-    # Note that for the above assertrion (with manually Add construction)
-    # it is not needed.
+    # See the comment above
     from sympy.core.cache import clear_cache
     clear_cache()
 

--- a/sympy/core/tests/test_flatten.py
+++ b/sympy/core/tests/test_flatten.py
@@ -1,0 +1,67 @@
+from sympy.utilities.pytest import XFAIL
+
+@XFAIL
+def test_as_coeff_add():
+    from sympy.abc import x
+    r = (7 + 3*x + 4*x**2).as_coeff_add()
+    assert r == (7, (3*x, 4*x**2))
+
+def test_flatten_sort():
+    from sympy.core.add import Add
+    from sympy.abc import x, y, z
+    e = Add(x, z, y)
+    assert e.args == (x, z, y)
+    assert (x + y + z).args == (x, y, z)
+    e = Add(x, z)
+    assert e.args == (x, z)
+    e =  3 + x
+    assert e.args == (3, x)
+
+def test_add_flatten_nessted_add():
+    from sympy.core.add import Add
+    from sympy.core.mul import Mul
+    from sympy.abc import x, y, z, a, b, c, d, e, f
+
+    args = Add(z, e, Add(y, x, z), d, z**2, f).args
+    assert args == (2*z, e, y, x, d, z**2, f)
+
+    args = (z + e + Add(y, x, z) + d + z**2 + f).args
+    assert args == (2*z, e, y, x, d, z**2, f)
+
+def test_add_flatten_nessted_mul():
+    from sympy.core.add import Add
+    from sympy.core.mul import Mul
+    from sympy.abc import x, y, z, a, b, c, d, e, f
+
+    args = Add(z, e, Mul(2, Add(y, x, z)), d, z**2, f).args
+    assert args == (3*z, e, 2*y, 2*x, d, z**2, f)
+
+    # as Add(x, y) is hashed, and its hash is rather equal to Add(y, x),
+    # (others tests have used it probebly)
+    # then we clear it to do not influence on this test
+    # Note that for the above assertrion (with manually Add construction)
+    # it is not needed.
+    from sympy.core.cache import clear_cache
+    clear_cache()
+
+    args = (z + e + 2*(y + x + z) + d + z**2 + f).args
+    assert args == (3*z, e, 2*y, 2*x, d, z**2, f)
+
+def test_mul_flatten():
+    from sympy.abc import x, y, z
+    from sympy.core.add import Add
+    from sympy.core.mul import Mul
+
+    args = Mul(2, y + x + z).args
+    assert args == (2*y, 2*x, 2*z)   # it is related with Add.flatten only
+
+    # as Add(x, y) is hashed, and its hash is rather equal to Add(y, x),
+    # (others tests have used it probebly)
+    # then we clear it to do not influence on this test
+    # Note that for the above assertrion (with manually Add construction)
+    # it is not needed.
+    from sympy.core.cache import clear_cache
+    clear_cache()
+
+    args = (2*(y + x + z)).args
+    assert args == (2*y, 2*x, 2*z)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -159,10 +159,11 @@ def test_mellin_transform_bessel():
     # 8.4.19
     assert MT(besselj(a, 2*sqrt(x)), x, s) == \
            (gamma(a/2 + s)/gamma(a/2 - s + 1), (-re(a)/2, S(3)/4), True)
+    res = MT(sin(sqrt(x))*besselj(a, sqrt(x)), x, s)
     assert MT(sin(sqrt(x))*besselj(a, sqrt(x)), x, s) == \
-           (2**a*gamma(S(1)/2 - 2*s)*gamma((a+1)/2 + s) \
-                / (gamma(1 - s- a/2)*gamma(1 + a - 2*s)),
-            (-(re(a) + 1)/2, S(1)/4), True)
+        (2**(a + 2)*gamma(-2*s + S(1)/2)*gamma(a/2 + s + S(1)/2) \
+            /(4*gamma(-a/2 - s + 1)*gamma(a - 2*s + 1)), \
+        (-re(a)/2 - S(1)/2, S(1)/4), True)
     # TODO why does this 2**(a+2)/4 not cancel?
     assert MT(cos(sqrt(x))*besselj(a, sqrt(x)), x, s) == \
            (2**(a+2)*gamma(a/2 + s)*gamma(S(1)/2 - 2*s)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2739,8 +2739,8 @@ class MatrixBase(object):
         >>> from sympy import Matrix, Symbol, eye
         >>> x = Symbol('x', real=True)
         >>> A = Matrix([[0, 1, 0], [0, x, 0], [-1, 0, 0]])
-        >>> A.singular_values()
-        [1, sqrt(x**2 + 1), 0]
+        >>> set(A.singular_values())
+        set([0, 1, sqrt(x**2 + 1)])
 
         See Also
         ========

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,4 +1,5 @@
 from sympy.core import pi, oo, symbols, Function, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda, Dummy
+from sympy.core.cache import clear_cache
 from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt
 from sympy.utilities.pytest import raises
 from sympy.printing.ccode import CCodePrinter
@@ -54,6 +55,7 @@ def test_ccode_functions():
     assert ccode(sin(x) ** cos(x)) == "pow(sin(x), cos(x))"
 
 def test_ccode_inline_function():
+    clear_cache()
     x = symbols('x')
     g = implemented_function('g', Lambda(x, 2*x))
     assert ccode(g(x)) == "2*x"

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1107,7 +1107,7 @@ def split_surds(expr):
     >>> from sympy import sqrt
     >>> from sympy.simplify.simplify import split_surds
     >>> split_surds(3*sqrt(3) + sqrt(5)/7 + sqrt(6) + sqrt(10) + sqrt(15))
-    (sqrt(5)/7 + sqrt(10) + sqrt(15), sqrt(6) + 3*sqrt(3))
+     (sqrt(6) + sqrt(15) + 3*sqrt(3), sqrt(5)/7 + sqrt(10))
     """
     coeff_muls =  [x.as_coeff_Mul() for x in expr.args]
     surds = [x[1]**2 for x in coeff_muls if x[1].is_Pow]

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -483,7 +483,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
         >>> from sympy.abc import x
 
         >>> rsolve_hyper([-1, -1, 1], 0, x)
-        C0*(1/2 + sqrt(5)/2)**x + C1*(-sqrt(5)/2 + 1/2)**x
+        C0*(-sqrt(5)/2 + 1/2)**x + C1*(1/2 + sqrt(5)/2)**x
 
         >>> rsolve_hyper([-1, 1], 1+x, x)
         C0 + x*(x + 1)/2

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -48,9 +48,12 @@ def test_solve_biquadratic():
     f_1 = (x - 1)**2 + (y - 1)**2 - r**2
     f_2 = (x - 2)**2 + (y - 2)**2 - r**2
 
-    assert solve_poly_system([f_1, f_2], x, y) == \
-        [(S(3)/2 + sqrt(-1 + 2*r**2)/2, S(3)/2 - sqrt(-1 + 2*r**2)/2),
-         (S(3)/2 - sqrt(-1 + 2*r**2)/2, S(3)/2 + sqrt(-1 + 2*r**2)/2)]
+    res = solve_poly_system([f_1, f_2], x, y)
+    res_must = [(-sqrt(2*r**2 - 1)/2 + S(3)/2, sqrt(2*r**2 - 1)/2 + S(3)/2),
+                (sqrt(2*r**2 - 1)/2 + S(3)/2, -sqrt(2*r**2 - 1)/2 + S(3)/2)]
+    assert res[0] in res_must
+    assert res[1] in res_must
+    assert res[0] <> res[1]
 
     f_1 = (x - 1)**2 + (y - 2)**2 - r**2
     f_2 = (x - 1)**2 + (y - 1)**2 - r**2

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -48,12 +48,9 @@ def test_solve_biquadratic():
     f_1 = (x - 1)**2 + (y - 1)**2 - r**2
     f_2 = (x - 2)**2 + (y - 2)**2 - r**2
 
-    res = solve_poly_system([f_1, f_2], x, y)
-    res_must = [(-sqrt(2*r**2 - 1)/2 + S(3)/2, sqrt(2*r**2 - 1)/2 + S(3)/2),
-                (sqrt(2*r**2 - 1)/2 + S(3)/2, -sqrt(2*r**2 - 1)/2 + S(3)/2)]
-    assert res[0] in res_must
-    assert res[1] in res_must
-    assert res[0] <> res[1]
+    assert set(solve_poly_system([f_1, f_2], x, y)) == \
+        set([(S(3)/2 + sqrt(-1 + 2*r**2)/2, S(3)/2 - sqrt(-1 + 2*r**2)/2),
+         (S(3)/2 - sqrt(-1 + 2*r**2)/2, S(3)/2 + sqrt(-1 + 2*r**2)/2)])
 
     f_1 = (x - 1)**2 + (y - 2)**2 - r**2
     f_2 = (x - 1)**2 + (y - 1)**2 - r**2

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -484,7 +484,7 @@ def sift(expr, keyfunc):
     used dict's .get() method:
 
     >>> sift(x+y, lambda x: x.is_commutative)
-    {True: [y, x]}
+    {True: [x, y]}
     >>> _.get(False, [])
     []
 


### PR DESCRIPTION
Main aims: remove dependence on platforms, when tests checked the order in the resulted expressions.

The code of the method 'flatten` of the class 'sympy.core.add.Add'
contain the following lines.

```
    # order args canonically
    # Currently we sort things using hashes, as it is quite fast. A
    # better solution is not to sort things at all - but this needs
    # some more fixing. NOTE: this is used in primitive, too, so if
    # it changes here it should be changed there.

    newseq.sort(key=hash)   <-- this line.
```

It is related with an Add class constructor (ordering of args before constructing), and therefore with basic hash functions (which is a hash of tuple of sorted arguments).

This kind of sorting moved to _hashable_content method of Add class. so ther orders of args of the Add class became as they are created from constructor.

While cycling in Add.flatten the recursion was organized as
a cycle, which in particular two problems solves.

But with reordering.
1. The task to collect similar terms
   
   `2*x**2 + y + 5*x**2   --> 7*x**2 + y`

was solved originally with the help of the dictionary
(`{x**2:7,y:S.One}`) but further cycle by keys reorder them
randomly (or by hash).

The way of accumulation is changed, so do not break
original order. Instead of cycle by keys of hash, the arguments iterated in order as they were originally.
1. The task of nested Adds was solved with the help of the recursion
   which is organized as a cycle.
   
   `Add(a, Add(b, c), d) --> Add(a, d, b, c)`

Now nested Add's are inserted in-place now:

```
`Add(a, Add(b, c), d) --> Add(a, b, c, d)`
```

See also:
[issue 2855](http://code.google.com/p/sympy/issues/detail?id=2855)
[Maillist](http://groups.google.com/group/sympy/browse_thread/thread/314b6f1841c00907)
