### PR TITLE
made doctests run even if other tests fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,10 +164,10 @@ class test_sympy(Command):
     def run(self):
         tests_successful = True
         try:
-            #if not sympy.test():
+            if not sympy.test():
                 # some regular test fails, so set the tests_successful
                 # flag to false and continue running the doctests
-                #tests_successful = False
+                tests_successful = False
 
             if not sympy.doctest():
                 tests_successful = False

--- a/setup.py
+++ b/setup.py
@@ -163,18 +163,23 @@ class test_sympy(Command):
 
     def run(self):
         tests_successful = True
-        if not sympy.test():
-            # some regular test fails, so set the tests_successful
-            # flag to false and continue running the doctests
-            tests_successful = False
+        try:
+            #if not sympy.test():
+                # some regular test fails, so set the tests_successful
+                # flag to false and continue running the doctests
+                #tests_successful = False
 
-        if not sympy.doctest():
-            tests_successful = False
+            if not sympy.doctest():
+                tests_successful = False
 
-        if tests_successful:
-            return
-        else:
-            # Return nonzero exit code
+            if tests_successful:
+                return
+            else:
+                # Return nonzero exit code
+                sys.exit(1)
+        except KeyboardInterrupt:
+            print
+            print("DO *NOT* COMMIT!")
             sys.exit(1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -162,14 +162,20 @@ class test_sympy(Command):
         pass
 
     def run(self):
-        if sympy.test():
-            # all regular tests run successfuly, so let's also run doctests
-            # (if some regular test fails, the doctests are not run)
-            if sympy.doctest():
-                # All ok
-                return
-        # Return nonzero exit code
-        sys.exit(1)
+        tests_successful = True
+        if not sympy.test():
+            # some regular test fails, so set the tests_successful
+            # flag to false and continue running the doctests
+            tests_successful = False
+
+        if not sympy.doctest():
+            tests_successful = False
+
+        if tests_successful:
+            return
+        else:
+            # Return nonzero exit code
+            sys.exit(1)
 
 
 class run_benchmarks(Command):

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -519,6 +519,7 @@ class SymPyTests(object):
                 self.test_file(f)
             except KeyboardInterrupt:
                 print " interrupted by user"
+                sys.exit(1)
                 break
         return self._reporter.finish()
 
@@ -641,6 +642,7 @@ class SymPyDocTests(object):
                 self.test_file(f)
             except KeyboardInterrupt:
                 print " interrupted by user"
+                sys.exit(1)
                 break
         return self._reporter.finish()
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -519,8 +519,8 @@ class SymPyTests(object):
                 self.test_file(f)
             except KeyboardInterrupt:
                 print " interrupted by user"
-                sys.exit(1)
-                break
+                self._reporter.finish()
+                raise
         return self._reporter.finish()
 
     def test_file(self, filename):
@@ -642,8 +642,8 @@ class SymPyDocTests(object):
                 self.test_file(f)
             except KeyboardInterrupt:
                 print " interrupted by user"
-                sys.exit(1)
-                break
+                self._reporter.finish()
+                raise
         return self._reporter.finish()
 
     def test_file(self, filename):
@@ -665,6 +665,8 @@ class SymPyDocTests(object):
         try:
             module = pdoctest._normalize_module(module)
             tests = SymPyDocTestFinder().find(module)
+        except (SystemExit, KeyboardInterrupt):
+            raise
         except:
             self._reporter.import_error(filename, sys.exc_info())
             return
@@ -703,6 +705,8 @@ class SymPyDocTests(object):
                 #exec('from sympy import *') in test.globs
             try:
                 f, t = runner.run(test, out=new.write, clear_globs=False)
+            except KeyboardInterrupt:
+                raise
             finally:
                 sys.stdout = old
             if f > 0:
@@ -799,6 +803,8 @@ class SymPyDocTestFinder(DocTestFinder):
                         try:
                             valname = '%s.%s' % (name, rawname)
                             self._find(tests, val, valname, module, source_lines, globs, seen)
+                        except KeyboardInterrupt:
+                            raise
                         except ValueError, msg:
                             raise
                         except:


### PR DESCRIPTION
This is to fix the GCI issue:

http://www.google-melange.com/gci/task/view/google/gci2011/7121277

http://code.google.com/p/sympy/issues/detail?id=1752

I removed the if-block and replaced it with 2 separate if-blocks. I also used a flag to test for failure, and exit with a non-zero code if that is the case.
