### PR TITLE
Implemented SymPyDeprecationWarning (done #2513)

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -152,7 +152,7 @@ See also isympy --help.
 """
 
 import os, sys, warnings
-from sympy.core.sympify import SymPyDeprecationWarning
+
 
 # hook in-tree SymPy into Python path, if possible
 
@@ -165,8 +165,6 @@ if os.path.isdir(sympy_dir):
     sys.path.insert(0, sympy_top)
 
 def main():
-    warnings.simplefilter("always", SymPyDeprecationWarning)
-
     from optparse import OptionParser
 
     if '-h' in sys.argv or '--help' in sys.argv:
@@ -296,6 +294,9 @@ def main():
 
     args['quiet'] = options.quiet
     args['auto'] = options.auto
+
+    from sympy.core.compatibility import SymPyDeprecationWarning
+    warnings.simplefilter("always", SymPyDeprecationWarning)
 
     from sympy.interactive import init_session
     init_session(ipython, **args)

--- a/bin/isympy
+++ b/bin/isympy
@@ -151,7 +151,8 @@ COMMAND LINE OPTIONS
 See also isympy --help.
 """
 
-import os, sys
+import os, sys, warnings
+from sympy.core.sympify import SymPyDeprecationWarning
 
 # hook in-tree SymPy into Python path, if possible
 
@@ -164,6 +165,8 @@ if os.path.isdir(sympy_dir):
     sys.path.insert(0, sympy_top)
 
 def main():
+    warnings.simplefilter("always", SymPyDeprecationWarning)
+
     from optparse import OptionParser
 
     if '-h' in sys.argv or '--help' in sys.argv:

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -3,6 +3,13 @@ Reimplementations of constructs introduced in later versions of Python than we
 support.
 """
 
+class SymPyDeprecationWarning(DeprecationWarning):
+    def __init__(self, value):
+        self.parameter = value
+
+    def __str__(self):
+        return repr(self.parameter)
+
 # These are in here because telling if something is an iterable just by calling
 # hasattr(obj, "__iter__") behaves differently in Python 2 and Python 3.  In
 # particular, hasattr(str, "__iter__") is False in Python 2 and True in Python 3.

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -4,8 +4,10 @@ SymPy core decorators.
 The purpose of this module is to expose decorators without any other
 dependencies, so that they can be easily imported anywhere in sympy/core.
 """
+
 from sympify import SympifyError, sympify
 from functools import wraps
+from sympify import SymPyDeprecationWarning, SympifyError, sympify
 import warnings
 
 def deprecated(func):
@@ -15,7 +17,7 @@ def deprecated(func):
     @wraps(func)
     def new_func(*args, **kwargs):
         warnings.warn("Call to deprecated function %s." % func.__name__,
-                      category=DeprecationWarning)
+                      category=SymPyDeprecationWarning)
         return func(*args, **kwargs)
     return new_func
 

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -5,9 +5,9 @@ The purpose of this module is to expose decorators without any other
 dependencies, so that they can be easily imported anywhere in sympy/core.
 """
 
-from sympify import SympifyError, sympify
 from functools import wraps
-from sympify import SymPyDeprecationWarning, SympifyError, sympify
+from sympify import SympifyError, sympify
+from sympy.core.compatibility import SymPyDeprecationWarning
 import warnings
 
 def deprecated(func):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -4,7 +4,7 @@ from singleton import S
 from evalf import EvalfMixin
 from decorators import _sympifyit, call_highest_priority
 from cache import cacheit
-from compatibility import reduce
+from compatibility import reduce, SymPyDeprecationWarning
 
 from collections import defaultdict
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1160,7 +1160,7 @@ class Expr(Basic, EvalfMixin):
         """
         import warnings
         warnings.warn("\nuse as_coeff_mul() instead of as_coeff_terms().",
-                      DeprecationWarning)
+                      SymPyDeprecationWarning)
         return self.as_coeff_mul(*deps)
 
     def as_coeff_factors(self, *deps):
@@ -1169,7 +1169,7 @@ class Expr(Basic, EvalfMixin):
         """
         import warnings
         warnings.warn("\nuse as_coeff_add() instead of as_coeff_factors().",
-                      DeprecationWarning)
+                      SymPyDeprecationWarning)
         return self.as_coeff_add(*deps)
 
     def as_coeff_mul(self, *deps):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -62,7 +62,7 @@ class Symbol(AtomicExpr, Boolean):
                     "\nThe syntax Symbol('x', dummy=True) is deprecated and will"
                     "\nbe dropped in a future version of Sympy. Please use Dummy()"
                     "\nor symbols(..., cls=Dummy) to create dummy symbols.",
-                    DeprecationWarning)
+                    SymPyDeprecationWarning)
             if assumptions.pop('dummy'):
                 return Dummy(name, commutative, **assumptions)
         return Symbol.__xnew_cached_(cls, name, commutative, **assumptions)
@@ -285,7 +285,7 @@ def symbols(names, **args):
     if 'each_char' in args:
         warnings.warn("The each_char option to symbols() and var() is "
             "deprecated.  Separate symbol names by spaces or commas instead.",
-            DeprecationWarning)
+            SymPyDeprecationWarning)
 
     if isinstance(names, basestring):
         names = names.strip()

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -6,6 +6,7 @@ from expr import Expr, AtomicExpr
 from cache import cacheit
 from function import FunctionClass
 from sympy.logic.boolalg import Boolean
+from sympy.core.compatibility import SymPyDeprecationWarning
 
 import re
 import warnings

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -5,13 +5,6 @@ from inspect import getmro
 from core import all_classes as sympy_classes
 from sympy.core.compatibility import iterable
 
-class SymPyDeprecationWarning(DeprecationWarning):
-    def __init__(self, value):
-        self.parameter = value
-
-    def __str__(self):
-        return repr(self.parameter)
-
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
         self.expr = expr

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -5,6 +5,13 @@ from inspect import getmro
 from core import all_classes as sympy_classes
 from sympy.core.compatibility import iterable
 
+class SymPyDeprecationWarning(DeprecationWarning):
+    def __init__(self, value):
+        self.parameter = value
+
+    def __str__(self):
+        return repr(self.parameter)
+
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
         self.expr = expr
@@ -16,7 +23,6 @@ class SympifyError(ValueError):
         return ("Sympify of expression '%s' failed, because of exception being "
             "raised:\n%s: %s" % (self.expr, self.base_exc.__class__.__name__,
             str(self.base_exc)))
-
 
 converter = {}
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -2,6 +2,7 @@ from sympy import (Symbol, Wild, Inequality, StrictInequality, pi, I, Rational,
     sympify, symbols, Dummy, S, Function, flatten)
 
 from sympy.utilities.pytest import raises, XFAIL
+from sympy.core.compatibility import SymPyDeprecationWarning
 
 def test_Symbol():
     a = Symbol("a")

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -125,8 +125,8 @@ def test_symbols_each_char():
     # First, test the warning
     warnings.filterwarnings("error", "The each_char option to symbols\(\) and var\(\) is "
         "deprecated.  Separate symbol names by spaces or commas instead.")
-    raises(DeprecationWarning, "symbols('xyz', each_char=True)")
-    raises(DeprecationWarning, "symbols('xyz', each_char=False)")
+    raises(SymPyDeprecationWarning, "symbols('xyz', each_char=True)")
+    raises(SymPyDeprecationWarning, "symbols('xyz', each_char=False)")
     # now test the actual output
     warnings.filterwarnings("ignore",  "The each_char option to symbols\(\) and var\(\) is "
         "deprecated.  Separate symbol names by spaces or commas instead.")

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -14,7 +14,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.printing import sstr
 from sympy.functions.elementary.trigonometric import cos, sin
 
-from sympy.core.compatibility import callable, reduce
+from sympy.core.compatibility import callable, reduce, SymPyDeprecationWarning
 
 import random
 import warnings

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1616,7 +1616,7 @@ class Matrix(object):
         """Returns a matrix of zeros with ``r`` rows and ``c`` columns;
         if ``c`` is omitted a square matrix will be returned."""
         if is_sequence(r):
-            warnings.warn("pass row and column as zeros(%i, %i)" % r, DeprecationWarning)
+            warnings.warn("pass row and column as zeros(%i, %i)" % r, SymPyDeprecationWarning)
             r, c = r
         else:
             c = r if c is None else c
@@ -2777,7 +2777,7 @@ def zeros(r, c=None, cls=Matrix):
     """Returns a matrix of zeros with ``r`` rows and ``c`` columns;
     if ``c`` is omitted a square matrix will be returned."""
     if is_sequence(r):
-        warnings.warn("pass row and column as zeros(%i, %i)" % r, DeprecationWarning)
+        warnings.warn("pass row and column as zeros(%i, %i)" % r, SymPyDeprecationWarning)
         r, c = r
     else:
         c = r if c is None else c
@@ -2789,7 +2789,7 @@ def ones(r, c=None):
     if ``c`` is omitted a square matrix will be returned."""
 
     if is_sequence(r):
-        warnings.warn("pass row and column as ones(%i, %i)" % r, DeprecationWarning)
+        warnings.warn("pass row and column as ones(%i, %i)" % r, SymPyDeprecationWarning)
         r, c = r
     else:
         c = r if c is None else c
@@ -3386,7 +3386,7 @@ class SparseMatrix(Matrix):
         """Returns a matrix of zeros with ``r`` rows and ``c`` columns;
         if ``c`` is omitted a square matrix will be returned."""
         if is_sequence(r):
-            warnings.warn("pass row and column as zeros(%i, %i)" % r, DeprecationWarning)
+            warnings.warn("pass row and column as zeros(%i, %i)" % r, SymPyDeprecationWarning)
             r, c = r
         else:
             c = r if c is None else c

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -206,7 +206,7 @@ anything is broken, one of those tests will surely fail.
 from collections import defaultdict
 
 from sympy.core import Add, Basic, C, S, Mul, Pow, oo
-from sympy.core.compatibility import iterable, cmp_to_key, is_sequence, set_union
+from sympy.core.compatibility import iterable, cmp_to_key, is_sequence, set_union, SymPyDeprecationWarning
 from sympy.core.function import Derivative, Function, AppliedUndef, diff, expand_mul
 from sympy.core.multidimensional import vectorize
 from sympy.core.relational import Equality, Eq

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1104,7 +1104,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
         msg = "sol appears to be a valid function. " +\
               "The order of sol and func will be reversed. " +\
               "If this is not desired, send sol as Eq(sol, 0)."
-        warnings.warn(msg, category=DeprecationWarning)
+        warnings.warn(msg, category=SymPyDeprecationWarning)
         sol, func = func, sol
     elif not (isinstance(func, AppliedUndef) and len(func.args) == 1):
         raise ValueError("func (or sol, during deprecation) must be a function of one variable. Got sol = %s, func = %s" % (sol, func))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -11,7 +11,7 @@
 
 """
 
-from sympy.core.compatibility import iterable, is_sequence
+from sympy.core.compatibility import iterable, is_sequence, SymPyDeprecationWarning
 from sympy.core.sympify import sympify
 from sympy.core import C, S, Mul, Add, Pow, Symbol, Wild, Equality, Dummy, Basic
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1550,7 +1550,7 @@ def _generate_patterns():
     ]
 
 def tsolve(eq, sym):
-    warn("tsolve is deprecated, use solve.", DeprecationWarning)
+    warn("tsolve is deprecated, use solve.", SymPyDeprecationWarning)
     return _tsolve(eq, sym)
 
 def _tsolve(eq, sym, **flags):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -421,7 +421,7 @@ def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
         if 'dummy' in assumptions and assumptions.pop('dummy'):
             import warnings
             warnings.warn("\nuse cls=Dummy to create dummy symbols",
-                          DeprecationWarning)
+                          SymPyDeprecationWarning)
             cls = C.Dummy
         else:
             cls = C.Symbol

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -3,7 +3,7 @@ import random
 
 from sympy.core import Basic, C
 from sympy.core.compatibility import is_sequence, iterable #logically, these belong here
-from sympy.core.compatibility import product as cartes, combinations, combinations_with_replacement
+from sympy.core.compatibility import product as cartes, combinations, combinations_with_replacement, SymPyDeprecationWarning
 
 def flatten(iterable, levels=None, cls=None):
     """

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -23,9 +23,7 @@ from sympy.core.sets import Interval
 from sympy.core.multidimensional import vectorize
 #from sympy.core.ast_parser import SymPyParser, SymPyTransformer
 
-from sympy.core.compatibility import callable
-
-from sympy.core.sympify import SymPyDeprecationWarning
+from sympy.core.compatibility import callable, SymPyDeprecationWarning
 
 from sympy import symbols
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -25,6 +25,8 @@ from sympy.core.multidimensional import vectorize
 
 from sympy.core.compatibility import callable
 
+from sympy.core.sympify import SymPyDeprecationWarning
+
 from sympy import symbols
 
 
@@ -33,7 +35,7 @@ def check(a, check_attr = True):
     """
     # The below hasattr() check will warn about is_Real in Python 2.5, so
     # disable this to keep the tests clean
-    warnings.filterwarnings("ignore", ".*is_Real.*", DeprecationWarning)
+    warnings.filterwarnings("ignore", ".*is_Real.*", SymPyDeprecationWarning)
     protocols = [0, 1, 2, copy.copy, copy.deepcopy]
     # Python 2.x doesn't support the third pickling protocol
     if sys.version_info[0] > 2:


### PR DESCRIPTION
DeprecationWarnings are replaced with SymPyDeprecationWarning. When deprecated method is invoked from isympy, warning is shown even without additional ipython flags.

Note: this is code written for Google Code-In. Be sure to mark http://www.google-melange.com/gci/task/view/google/gci2011/7125289 as completed if successfully reviewed. Thanks. :)
