### PR TITLE
Remove fallback for functools.wraps

### DIFF
--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -5,20 +5,8 @@ The purpose of this module is to expose decorators without any other
 dependencies, so that they can be easily imported anywhere in sympy/core.
 """
 from sympify import SympifyError, sympify
+from functools import wraps
 import warnings
-
-try:
-    from functools import wraps
-except ImportError:
-    def wraps(old_func):
-        """Copy private data from ``old_func`` to ``new_func``. """
-        def decorate(new_func):
-            new_func.__dict__.update(old_func.__dict__)
-            new_func.__module__ = old_func.__module__
-            new_func.__name__   = old_func.__name__
-            new_func.__doc__    = old_func.__doc__
-            return new_func
-        return decorate
 
 def deprecated(func):
     """This is a decorator which can be used to mark functions


### PR DESCRIPTION
Since functools.wraps is included in the default distribution of Python as of version 2.5, there is no need to provide a fallback.

See:
http://www.google-melange.com/gci/task/view/google/gci2011/7184247

http://code.google.com/p/sympy/issues/detail?id=2873
