### PR TITLE
Modified inverse_GE() to use rref() instead of det()

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2036,7 +2036,7 @@ class Matrix(object):
         if not self.is_square:
             raise NonSquareMatrixError()
 
-        if self.det() == 0:
+        if len(self.rref()[1]) != self.rows:
             raise ValueError("A Matrix must have non-zero determinant to invert.")
 
         big = self.row_join(self.eye(self.rows))
@@ -2063,7 +2063,6 @@ class Matrix(object):
         To simplify elements before finding nonzero pivots set simplified=True.
         To set a custom simplify function, use the simplify keyword argument.
         """
-        # TODO: rewrite inverse_GE to use this
         pivots, r = 0, self[:,:]        # pivot: index of next row to contain a pivot
         pivotlist = []                  # indices of pivot variables (non-free)
         for i in range(r.cols):


### PR DESCRIPTION
As mentioned at http://groups.google.com/group/sympy/browse_thread/thread/ba37b597b851df7c# and http://code.google.com/p/sympy/issues/detail?id=2683
inverse_GE(), the default method for matrix inversion, was calling det() to check for inversion; this greatly damaged performance. It was replaced with a call to rref().

Part of GCI http://www.google-melange.com/gci/task/view/google/gci2011/7134392
