### PR TITLE
sqrt matching in sqrtdenest

### DIFF
--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -33,20 +33,6 @@ def sqrtdenest(expr):
             return expr.func(*[sqrtdenest(a) for a in args])
     return expr
 
-def normalize(s):
-    if s.is_Add:
-        a = list(s.args)
-        for i, x in enumerate(a):
-            if x.is_Number:
-                break
-        else:
-            return (1, s)
-        del a[i]
-        a = [y/x for y in a]
-        return x, 1 + Add(*a)
-    else:
-        return 1, s
-
 def _sqrtdenest(expr):
     from sympy.simplify.simplify import radsimp
     if not expr.is_Pow or expr.exp != S.Half:
@@ -61,24 +47,24 @@ def _sqrtdenest(expr):
         a, b, r = val
         # try a quick denesting
         d2 = expand_multinomial(a**2 - b**2*r)
-        if d2.is_Number and \
-            max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
+        if d2.is_Number and d2.is_positive and \
+           max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
             d = sqrt(d2)
             vad = a + d
-            vad1 = radsimp(1/vad)
-            return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
+            if sqrt_depth(vad) < sqrt_depth(a):
+                vad1 = radsimp(1/vad)
+                return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
         else:
             d = sqrt(d2)
             vad = a + d
-            vad1, vad2 = normalize(vad)
-            q = r/vad2
+            vp0, vp1 = vad.as_content_primitive()
+            rp0, rp1 = r.as_content_primitive()
+            q = rp1/vp1
             if q.is_Number:
-                c = (b**2 * q)/(2 * vad1)
-                #c1 = radsimp((b**2*r/(2*vad)).expand())
+                c = (b**2 * q * rp0)/(2 * vp0)
                 if sqrt_depth(r) > sqrt_depth(c):
-                    z = (sqrt(vad/2) + sign(b)*sqrt(c)).expand()
+                    z = (sqrt(vp0/2)*sqrt(vp1) + sign(b)*sqrt(c)).expand()
                     return z
-
 
     else:
         return expr
@@ -112,7 +98,7 @@ def sqrt_depth(p):
         return 0
 
 def sqrt_match(p):
-    """return (a, b, r) for match a + b*sqrt(r) where
+    """return (a, b, r) for match p = a + b*sqrt(r) where
     sqrt(r) has maximal nested sqrt among addends of p
 
     Examples:
@@ -124,19 +110,31 @@ def sqrt_match(p):
     p = p.expand()
     if p.is_Number:
         return (p, S.Zero, S.Zero)
-    pargs = list(p.args)
-    v = [(sqrt_depth(x), i) for i, x in enumerate(pargs)]
-    if not v:
-        return None
-    nmax = max(v)
-    if nmax[0] == 0:
-        return None
-    n = nmax[1]
-    p1 = pargs[n]
-    del pargs[n]
-    a = Add(*pargs)
-    b, r = p1.as_coeff_Mul()
-    return (a, b, r**2)
+    if p.is_Add:
+        pargs = list(p.args)
+        v = [(sqrt_depth(x), i) for i, x in enumerate(pargs)]
+        if not v:
+            return None
+        nmax = max(v)
+        if nmax[0] == 0:
+            b, r = p.as_coeff_Mul()
+            if p.is_Pow and p.exp == S.Half:
+                return (S.Zero, b, p.base)
+            else:
+                return None
+        n = nmax[1]
+        p1 = pargs[n]
+        del pargs[n]
+        a = Add(*pargs)
+        b, r = p1.as_coeff_Mul()
+        res = (a, b, r**2)
+    else:
+        b, r = p.as_coeff_Mul()
+        if r.is_Pow and r.exp == S.Half:
+            res = (S.Zero, b, r**2)
+        else:
+            return None
+    return res
 
 def _denester (nested, av0, h, max_depth_level=4):
     """
@@ -162,6 +160,7 @@ def _denester (nested, av0, h, max_depth_level=4):
     from sympy.simplify.simplify import radsimp
     if h > max_depth_level:
         return None, None
+    #if not av0 and all(n.is_Number and n.is_positive for n in nested): #If none of the arguments are nested
     if not av0 and all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
             p = prod(nested[i] for i in range(len(f)) if f[i]).expand()
@@ -212,6 +211,8 @@ def _denester (nested, av0, h, max_depth_level=4):
                 return (sqrt(vad/2) + sign(v[1])*sqrt((v[1]**2*R*vad1/2).expand())).expand(), f
             else: #Solution requires a fourth root
                 FR, s = (R.expand()**Rational(1,4)), sqrt((v[1]*R).expand()+d)
+                if s == 0:
+                    return sqrt(nested[-1]), [0]*len(nested)
                 return (s/(sqrt(2)*FR) + v[0]*FR/(sqrt(2)*s)).expand(), f
 
 def subsets(n):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -27,7 +27,7 @@ def _sqrt_symbolic_denest(a, b, r):
     >>> from sympy import sqrt
     >>> from sympy.abc import x
 
-    >>> _sqrt_symbolic_denest(16 - 2*sqrt(29), 2, -10*sqrt(29) + 55)
+    >>> _sqrt_symbolic_denest(16-2*sqrt(29), 2,-10*sqrt(29)+55,-24*sqrt(29)+152)
     sqrt(-2*sqrt(29) + 11) + sqrt(5)
 
     If sympy decides that sqrt and square can be simplified, it does,

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -33,6 +33,20 @@ def sqrtdenest(expr):
             return expr.func(*[sqrtdenest(a) for a in args])
     return expr
 
+def normalize(s):
+    if s.is_Add:
+        a = list(s.args)
+        for i, x in enumerate(a):
+            if x.is_Number:
+                break
+        else:
+            return (1, s)
+        del a[i]
+        a = [y/x for y in a]
+        return x, 1 + Add(*a)
+    else:
+        return 1, s
+
 def _sqrtdenest(expr):
     from sympy.simplify.simplify import radsimp
     if not expr.is_Pow or expr.exp != S.Half:
@@ -53,6 +67,19 @@ def _sqrtdenest(expr):
             vad = a + d
             vad1 = radsimp(1/vad)
             return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
+        else:
+            d = sqrt(d2)
+            vad = a + d
+            vad1, vad2 = normalize(vad)
+            q = r/vad2
+            if q.is_Number:
+                c = (b**2 * q)/(2 * vad1)
+                #c1 = radsimp((b**2*r/(2*vad)).expand())
+                if sqrt_depth(r) > sqrt_depth(c):
+                    z = (sqrt(vad/2) + sign(b)*sqrt(c)).expand()
+                    return z
+
+
     else:
         return expr
     z = _denester([radsimp(expr**2)], (a, b, r, d2), 0)[0]

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -157,7 +157,7 @@ def denester (nested, h):
     if all((n**2).is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
             p = prod(nested[i]**2 for i in range(len(f)) if f[i]).expand()
-            if 1 in f and f.count(1) > 1 and f[-1]: 
+            if 1 in f and f.count(1) > 1 and f[-1]:
                 p = -p
             if sqrt(p).is_Number:
                 return sqrt(p), f #If we got a perfect square, return its square root.

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -87,12 +87,16 @@ def _sqrtdenest(expr):
                         ccv.append(xx)
             cb = Add(*cbv)
             cc = Add(*ccv)
-            if ca != 0:
+            if ry not in cc.atoms() and ca != 0:
                 cb += b
                 discr = (cb**2 - 4*ca*cc).expand()
                 if discr == 0:
                     z = sqrt(ca)*(sqrt(r) + cb/(2*ca))
-                    return simplify(z)
+                    z = simplify(z)
+                    if z < 0:
+                        return -z
+                    else:
+                        return z
             d = sqrt(d2)
             vad = a + d
             vp0, vp1 = vad.as_content_primitive()

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -113,6 +113,8 @@ def sqrt_match0(p):
     sqrt(r) has maximal nested sqrt
 
     Examples:
+    >>> from sympy.functions.elementary.miscellaneous import sqrt
+    >>> from sympy.simplify.sqrtdenest import sqrt_match0
     >>> sqrt_match0(1 + sqrt(2) + sqrt(2)*sqrt(3) +  2*sqrt(1+sqrt(5)))
     (1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5))
     """

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -216,8 +216,6 @@ def _sqrtdenest(expr):
         return expr
     av0 = [a, b, r, d2]
     z = _denester([radsimp(expr**2)], av0, 0, sqrt_depth(expr)-1)[0]
-    if av0[1] == None:
-        return expr
     if z != None:
         return z
     return expr
@@ -339,8 +337,6 @@ def _denester (nested, av0, h, max_depth_level):
     from sympy.simplify.simplify import radsimp
     if h > max_depth_level:
         return None, None
-    if av0[1] == None:
-        return None, None
     #If none of the arguments are nested
     if av0[0] == None and all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
@@ -364,7 +360,6 @@ def _denester (nested, av0, h, max_depth_level):
                 if v[2]: #Since if b=0, r is not defined
                     if R is not None:
                         if R != v[2]:
-                            av0[1] = None
                             return None, None
                         #assert R == v[2] #All the 'r's should be the same.
                     else:
@@ -389,7 +384,6 @@ def _denester (nested, av0, h, max_depth_level):
                 if vad <= 0:
                     return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
                 if not(sqrt_depth(vad) < sqrt_depth(R) + 1 or (vad**2).is_Number):
-                    av0[1] = None
                     return None, None
 
                 vad1 = radsimp(1/vad)

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -129,7 +129,7 @@ def _four_terms(expr):
     return radsimp(c/sqrt(2) + b/(sqrt(2)*c)).expand()
 
 
-def sqrtdenest(expr):
+def sqrtdenest(expr, max_iter=3):
     """
     Denests sqrts in an expression that contain other square roots
     if possible, otherwise return the expr unchanged.
@@ -145,6 +145,15 @@ def sqrtdenest(expr):
 
     See also: unrad in sympy.solvers.solvers
     """
+    for i in range(max_iter):
+        z = sqrtdenest0(expr)
+        if expr == z:
+            return expr
+        expr = z
+    return expr
+
+
+def sqrtdenest0(expr):
     expr = sympify(expr)
     if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
         n, d = expr.as_numer_denom()
@@ -167,10 +176,14 @@ def sqrtdenest(expr):
                 d1 = _sqrtdenest(d)
 
             return n1/d1
+    elif expr.is_Pow and expr.exp == -S.Half:
+        return 1/sqrtdenest0(sqrt(expr.base))
+    elif expr.is_Mul:
+        return prod([sqrtdenest0(x) for x in expr.args])
     elif isinstance(expr, Expr):
         args = expr.args
         if args:
-            return expr.func(*[sqrtdenest(a) for a in args])
+            return expr.func(*[sqrtdenest0(a) for a in args])
     return expr
 
 def _sqrtdenest(expr):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -65,29 +65,26 @@ def sqrtdenest(expr):
     return expr
 
 def _sqrtdenest(expr):
-    expr = sympify(expr)
-    if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
-        val = sqrt_match(expr)
-        if val:
-            a, b, r = val
-            # try a quick denesting
-            d2 = (a**2 - b**2*r).expand()
-            if d2.is_Number and \
-                max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
-                d = sqrt(d2)
-                vad = a + d
-                vad1 = radsimp(1/vad)
-                return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
+    val = sqrt_match(expr)
+    if val:
+        a, b, r = val
+        # try a quick denesting
+        d2 = (a**2 - b**2*r).expand()
+        if d2.is_Number and \
+            max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
+            d = sqrt(d2)
+            vad = a + d
+            vad1 = radsimp(1/vad)
+            return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
-        z = denester([expr], 0)[0]
-        if z is expr or not z.is_Add:
-            return z
-        else:
-            a = z.args
-            a = [sqrtdenest(x) for x in a]
-            expr = Add(*a)
-            return expr
-    return expr
+    z = denester([expr], 0)[0]
+    if z is expr or not z.is_Add:
+        return z
+    else:
+        a = z.args
+        a = [sqrtdenest(x) for x in a]
+        expr = Add(*a)
+        return expr
 
 def sqrt_match(p):
     if not p.is_Pow or p.args[1] != S.Half:
@@ -117,8 +114,8 @@ def sqrt_depth(p):
         return 0
 
 def sqrt_match0(p):
-    """return (a, b, c) for match a + b*sqrt(r) where
-    sqrt(r) has maximal nested sqrt
+    """return (a, b, r) for match a + b*sqrt(r) where
+    sqrt(r) has maximal nested sqrt among addends of p
 
     Examples:
     >>> from sympy.functions.elementary.miscellaneous import sqrt
@@ -210,7 +207,7 @@ def denester (nested, h):
 def subsets(n):
     """
     Returns all possible subsets of the set (0, 1, ..., n-1) except the empty,
-    listed in reversed lexicographical order according to binary 
+    listed in reversed lexicographical order according to binary
     representation, so that the case of the fourth root is treated last.
     """
     if n == 1:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -53,8 +53,9 @@ def _sqrtdenest(expr):
             vad = a + d
             vad1 = radsimp(1/vad)
             return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
-
-    z = denester([radsimp(expr**2)], 0)[0]
+    else:
+        return expr
+    z = _denester([radsimp(expr**2)], (a, b, r, d2), 0)[0]
     if z == None:
         return expr
     if z is expr or not z.is_Add:
@@ -110,7 +111,7 @@ def sqrt_match(p):
     b, r = p1.as_coeff_Mul()
     return (a, b, r**2)
 
-def denester (nested, h, max_depth_level=4):
+def _denester (nested, av0, h, max_depth_level=4):
     """
     Denests a list of expressions that contain nested square roots.
     This method should not be called directly - use 'sqrtdenest' instead.
@@ -122,8 +123,8 @@ def denester (nested, h, max_depth_level=4):
 
     When evaluating all of the arguments in parallel, the bottom-level
     radicand only needs to be denested once. This means that calling
-    denester with x arguments results in a recursive invocation with x+1
-    arguments; hence denester has polynomial complexity.
+    _denester with x arguments results in a recursive invocation with x+1
+    arguments; hence _denester has polynomial complexity.
 
     However, if the arguments were evaluated separately, each call would
     result in two recursive invocations, and the algorithm would have
@@ -134,7 +135,7 @@ def denester (nested, h, max_depth_level=4):
     from sympy.simplify.simplify import radsimp
     if h > max_depth_level:
         return None, None
-    if all(n.is_Number for n in nested): #If none of the arguments are nested
+    if not av0 and all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
             p = prod(nested[i] for i in range(len(f)) if f[i]).expand()
             if 1 in f and f.count(1) > 1 and f[-1]:
@@ -144,17 +145,23 @@ def denester (nested, h, max_depth_level=4):
         return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
     else:
         R = None
-        values = filter(None, [sqrt_match(expr) for expr in nested])
-        for v in values:
-            if v[2]: #Since if b=0, r is not defined
-                if R is not None:
-                    assert R == v[2] #All the 'r's should be the same.
-                else:
-                    R = v[2]
-        if R is None:
-            return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the pravious invocation
-        nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
-        d, f = denester(nested2, h+1)
+        if av0:
+            values = [av0[:2]]
+            R = av0[2]
+            nested2 = [av0[3], R]
+        else:
+            av0 = False
+            values = filter(None, [sqrt_match(expr) for expr in nested])
+            for v in values:
+                if v[2]: #Since if b=0, r is not defined
+                    if R is not None:
+                        assert R == v[2] #All the 'r's should be the same.
+                    else:
+                        R = v[2]
+            if R is None:
+                return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the pravious invocation
+            nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
+        d, f = _denester(nested2, False, h+1)
         if f == None:
             return None, None
         if not any(f[i] for i in range(len(nested))):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -267,7 +267,7 @@ def sqrt_match(p):
     >>> from sympy.functions.elementary.miscellaneous import sqrt
     >>> from sympy.simplify.sqrtdenest import sqrt_match
     >>> sqrt_match(1 + sqrt(2) + sqrt(2)*sqrt(3) +  2*sqrt(1+sqrt(5)))
-    [1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5)]
+    (1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5))
     """
     p = _mexpand(p)
     if p.is_Number:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -34,7 +34,7 @@ def sqrtdenest(expr):
     return expr
 
 def _sqrtdenest(expr):
-    from sympy.simplify.simplify import radsimp, simplify
+    from sympy.simplify.simplify import radsimp
     if not expr.is_Pow or expr.exp != S.Half:
         val = None
     else:
@@ -92,7 +92,8 @@ def _sqrtdenest(expr):
                 discr = (cb**2 - 4*ca*cc).expand()
                 if discr == 0:
                     z = sqrt(ca)*(sqrt(r) + cb/(2*ca))
-                    z = simplify(z)
+                    c, q = z.as_content_primitive()
+                    z = (c*q).expand()
                     if z < 0:
                         return -z
                     else:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -55,6 +55,8 @@ def _sqrtdenest(expr):
             return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
     z = denester([radsimp(expr**2)], 0)[0]
+    if z == None:
+        return expr
     if z is expr or not z.is_Add:
         return z
     else:
@@ -108,7 +110,7 @@ def sqrt_match(p):
     b, r = p1.as_coeff_Mul()
     return (a, b, r**2)
 
-def denester (nested, h):
+def denester (nested, h, max_depth_level=4):
     """
     Denests a list of expressions that contain nested square roots.
     This method should not be called directly - use 'sqrtdenest' instead.
@@ -130,6 +132,8 @@ def denester (nested, h):
     This is discussed in the paper in the middle paragraph of page 179.
     """
     from sympy.simplify.simplify import radsimp
+    if h > max_depth_level:
+        return None, None
     if all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
             p = prod(nested[i] for i in range(len(f)) if f[i]).expand()
@@ -151,6 +155,8 @@ def denester (nested, h):
             return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the pravious invocation
         nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
         d, f = denester(nested2, h+1)
+        if f == None:
+            return None, None
         if not any(f[i] for i in range(len(nested))):
         #if all(fi == 0 for fi in f):
             v = values[-1]

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -149,11 +149,24 @@ def sqrtdenest(expr):
     if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
         n, d = expr.as_numer_denom()
         if d is S.One:
-            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1 and n.base.is_number:
+            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1 and \
+                n.base.is_number:
                 return _four_terms(n)
             return _sqrtdenest(expr)
         else:
-            return _sqrtdenest(n)/_sqrtdenest(d)
+            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1 and \
+                n.base.is_number:
+                n1 = _four_terms(n)
+            else:
+                n1 = _sqrtdenest(n)
+
+            if len(d.base.args) == 4 and sqrt_depth(d.base) == 1 and \
+                d.base.is_number:
+                d1 = _four_terms(d)
+            else:
+                d1 = _sqrtdenest(d)
+
+            return n1/d1
     elif isinstance(expr, Expr):
         args = expr.args
         if args:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -127,11 +127,11 @@ def _sqrt_four_terms_denest(expr):
     if d2 < 0:
         a, b = b, a
         d2 = -d2
-    d = sqrtdenest(sqrt(d2))
+    d = _sqrtdenest(sqrt(d2))
     if sqrt_depth(d) > 1:
         return expr
     vad = a + d
-    c = sqrtdenest(sqrt(vad))
+    c = _sqrtdenest(sqrt(vad))
     if sqrt_depth(c) > 1:
         return expr
     return radsimp((c/sqrt(2) + b/(sqrt(2)*c))).expand()

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -1,6 +1,5 @@
 from sympy.functions import sqrt, sign
 from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
-from sympy.core.mul import prod
 from sympy.core.function import expand_multinomial, expand_mul
 from sympy.core.symbol import Dummy
 
@@ -42,10 +41,10 @@ def _sqrt_symbolic_denest(a, b, r, d2=None):
     rval = sqrt_match(r)
     if rval is None:
         return None
-    y = Dummy('y', positive=True)
-    y2 = y**2
     ra, rb, rr = rval
     if rb != 0:
+        y = Dummy('y', positive=True)
+        y2 = y**2
         cav, cbv, ccv = [], [], []
         for ai in Add.make_args(a.subs(sqrt(rr), (y2 - ra)/rb)):
             margs = list(Mul.make_args(ai))
@@ -113,7 +112,7 @@ def _sqrt_four_terms_denest(expr):
     b = Add(*expr.base.args[2:])
     if a < 0:
         a, b = b, a
-    d2 = expand_multinomial(a**2 - b**2)
+    d2 = _mexpand(a**2 - b**2)
     if d2 < 0:
         a, b = b, a
         d2 = -d2
@@ -181,7 +180,7 @@ def sqrtdenest0(expr):
     elif expr.is_Pow and expr.exp == -S.Half:
         return 1/sqrtdenest0(sqrt(expr.base))
     elif expr.is_Mul:
-        return prod([sqrtdenest0(x) for x in expr.args])
+        return Mul(*[sqrtdenest0(x) for x in expr.args])
     elif isinstance(expr, Expr):
         args = expr.args
         if args:
@@ -318,8 +317,8 @@ def sqrt_match(p):
                 else:
                     rv.append(x)
 
-            b = prod(bv)
-            r = prod(rv)
+            b = Mul(*bv)
+            r = Mul(*rv)
         else:
             b = S.One
             r = p1
@@ -361,7 +360,7 @@ def _denester (nested, av0, h, max_depth_level):
     #If none of the arguments are nested
     if av0[0] == None and all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
-            p = _mexpand(prod(nested[i] for i in range(len(f)) if f[i]))
+            p = _mexpand(Mul(*[nested[i] for i in range(len(f)) if f[i]]))
             if 1 in f and f.count(1) > 1 and f[-1]:
                 p = -p
             sqp = sqrt(p)
@@ -396,7 +395,7 @@ def _denester (nested, av0, h, max_depth_level):
             v = values[-1]
             return sqrt(v[0] + v[1]*d), f
         else:
-            p = prod(nested[i] for i in range(len(nested)) if f[i])
+            p = Mul(*[nested[i] for i in range(len(nested)) if f[i]])
             if p == 1:
                 p = S(p)
             v = sqrt_match(_mexpand(p))
@@ -423,7 +422,7 @@ def _denester (nested, av0, h, max_depth_level):
 
 def subsets(n):
     """
-    Returns all possible subsets of the set (0, 1, ..., n-1) except the empty,
+    Returns all possible subsets of the set of n elements except the empty,
     listed in reversed lexicographical order according to binary
     representation, so that the case of the fourth root is treated last.
     """

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -1,38 +1,7 @@
 from sympy.functions import sqrt, sign
 from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
 from sympy.core.mul import prod
-
-
-def radsimp(expr):
-    """
-    Rationalize the denominator.
-    This is a simpler version than the one in simplify.py
-
-    Examples:
-        >>> from sympy import radsimp, sqrt, Symbol
-        >>> radsimp(1/(2+sqrt(2)))
-        -sqrt(2)/2 + 1
-        >>> x,y = map(Symbol, 'xy')
-        >>> e = ((2+2*sqrt(2))*x+(2+sqrt(8))*y)/(2+sqrt(2))
-        >>> radsimp(e)
-        sqrt(2)*x + sqrt(2)*y
-
-    """
-    n, d = expr.as_numer_denom()
-    a, b, c = map(Wild, 'abc')
-    r = d.match(a+b*sqrt(c))
-    if r is not None:
-        a = r[a]
-        if r[b] == 0:
-            b, c = 0, 0
-        else:
-            b, c = r[b], r[c]
-
-        n = (n*(a-b*sqrt(c))).expand()
-        d = a**2 - c*b**2
-
-    return n/d
-
+from sympy.core.function import expand_multinomial
 
 def sqrtdenest(expr):
     """
@@ -65,11 +34,12 @@ def sqrtdenest(expr):
     return expr
 
 def _sqrtdenest(expr):
+    from sympy.simplify.simplify import radsimp
     val = sqrt_match(expr)
     if val:
         a, b, r = val
         # try a quick denesting
-        d2 = (a**2 - b**2*r).expand()
+        d2 = expand_multinomial(a**2 - b**2*r)
         if d2.is_Number and \
             max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
             d = sqrt(d2)
@@ -161,6 +131,7 @@ def denester (nested, h):
 
     This is discussed in the paper in the middle paragraph of page 179.
     """
+    from sympy.simplify.simplify import radsimp
     if all((n**2).is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
             p = prod(nested[i]**2 for i in range(len(f)) if f[i]).expand()

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -273,11 +273,7 @@ def sqrt_match(p):
         v = [(sqrt_depth(x), i) for i, x in enumerate(pargs)]
         nmax = max(v)
         if nmax[0] == 0:
-            b, r = p.as_coeff_Mul()
-            if p.is_Pow and p.exp is S.Half:
-                return (S.Zero, b, p.base)
-            else:
-                return None
+            return None
         depth = nmax[0]
         n = nmax[1]
         p1 = pargs[n]

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -47,7 +47,7 @@ def _sqrtdenest(expr):
             vad1 = radsimp(1/vad)
             return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
-    z = denester([expr], 0)[0]
+    z = denester([radsimp(expr**2)], 0)[0]
     if z is expr or not z.is_Add:
         return z
     else:
@@ -132,17 +132,17 @@ def denester (nested, h):
     This is discussed in the paper in the middle paragraph of page 179.
     """
     from sympy.simplify.simplify import radsimp
-    if all((n**2).is_Number for n in nested): #If none of the arguments are nested
+    if all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
-            p = prod(nested[i]**2 for i in range(len(f)) if f[i]).expand()
+            p = prod(nested[i] for i in range(len(f)) if f[i]).expand()
             if 1 in f and f.count(1) > 1 and f[-1]:
                 p = -p
             if sqrt(p).is_Number:
                 return sqrt(p), f #If we got a perfect square, return its square root.
-        return nested[-1], [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
+        return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
     else:
         R = None
-        values = filter(None, [sqrt_match(expr) for expr in nested])
+        values = filter(None, [sqrt_match0(expr) for expr in nested])
         for v in values:
             if v[2]: #Since if b=0, r is not defined
                 if R is not None:
@@ -150,14 +150,15 @@ def denester (nested, h):
                 else:
                     R = v[2]
         if R is None:
-            return nested[-1], [0]*len(nested) # return the radicand from the pravious invocation
-        d, f = denester([sqrt((v[0]**2).expand()-(R*v[1]**2).expand()) for v in values] + [sqrt(R)], h+1)
+            return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the pravious invocation
+        nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
+        d, f = denester(nested2, h+1)
         if not any(f[i] for i in range(len(nested))):
         #if all(fi == 0 for fi in f):
             v = values[-1]
             return sqrt(v[0] + v[1]*d), f
         else:
-            p = prod(nested[i]**2 for i in range(len(nested)) if f[i])
+            p = prod(nested[i] for i in range(len(nested)) if f[i])
             if p == 1:
                 p = S(p)
             v = sqrt_match0(p.expand())
@@ -168,7 +169,7 @@ def denester (nested, h):
             if not f[len(nested)]: #Solution denests with square roots
                 vad = (v[0] + d).expand()
                 if not vad:
-                    return nested[-1], [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
+                    return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
                 vad1 = radsimp(1/vad)
                 return (sqrt(vad/2) + sign(v[1])*sqrt((v[1]**2*R*vad1/2).expand())).expand(), f
             else: #Solution requires a fourth root

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -287,7 +287,7 @@ def _denester (nested, av0, h, max_depth_level=4):
         d, f = _denester(nested2, False, h+1)
         if not f:
             return None, None
-        if all(fi == 0 for fi in f):
+        if not any(f[i] for i in range(len(nested))):
             v = values[-1]
             return sqrt(v[0] + v[1]*d), f
         else:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -100,7 +100,7 @@ def sqrt_numeric_denest(a, b, r, d2):
         return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
 
-def sqrt_four_terms_denest(expr):
+def _sqrt_four_terms_denest(expr):
     """denest the square root of three or four square root of rationals
 
     See D.J.Jeffrey and A.D.Rich
@@ -108,17 +108,17 @@ def sqrt_four_terms_denest(expr):
 
     Examples
     >>> from sympy import sqrt
-    >>> from sympy.simplify.sqrtdenest import sqrt_four_terms_denest
-    >>> sqrt_four_terms_denest(sqrt(-72*sqrt(2) + 158*sqrt(5) + 498))
+    >>> from sympy.simplify.sqrtdenest import _sqrt_four_terms_denest
+    >>> _sqrt_four_terms_denest(sqrt(-72*sqrt(2) + 158*sqrt(5) + 498))
     -sqrt(10) + sqrt(2) + 9 + 9*sqrt(5)
-    >>> sqrt_four_terms_denest(sqrt(12+2*sqrt(6)+2*sqrt(14)+2*sqrt(21)))
+    >>> _sqrt_four_terms_denest(sqrt(12+2*sqrt(6)+2*sqrt(14)+2*sqrt(21)))
     sqrt(2) + sqrt(3) + sqrt(7)
     """
     from sympy.simplify.simplify import radsimp
     if not (expr.is_Pow and expr.exp == S.Half):
         return expr
     if expr.base < 0:
-        return sqrt(-1)*sqrt_four_terms_denest(sqrt(-expr.base))
+        return sqrt(-1)*_sqrt_four_terms_denest(sqrt(-expr.base))
     a = Add(*expr.base.args[:2])
     b = Add(*expr.base.args[2:])
     if a < 0:
@@ -153,6 +153,7 @@ def sqrtdenest(expr, max_iter=3):
 
     See also: unrad in sympy.solvers.solvers
     """
+    expr = sympify(expr)
     for i in range(max_iter):
         z = sqrtdenest0(expr)
         if expr == z:
@@ -162,24 +163,25 @@ def sqrtdenest(expr, max_iter=3):
 
 
 def sqrtdenest0(expr):
-    expr = sympify(expr)
+    if expr.is_Atom:
+        return expr
     if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
         n, d = expr.as_numer_denom()
         if d is S.One:
             nn = len(n.base.args)
             if 3 <= nn <= 4 and all([(x**2).is_Number for x in n.base.args]):
-                return sqrt_four_terms_denest(n)
+                return _sqrt_four_terms_denest(n)
             return _sqrtdenest(expr)
         else:
             nn = len(n.base.args)
             if 3 <= nn <= 4 and all([(x**2).is_Number for x in n.base.args]):
-                n1 = sqrt_four_terms_denest(n)
+                n1 = _sqrt_four_terms_denest(n)
             else:
                 n1 = _sqrtdenest(n)
 
             if d.is_Pow and d.exp == S.Half and \
                 3 <= len(d.base.args) <= 4 and all([(x**2).is_Number for x in d.base.args]):
-                d1 = sqrt_four_terms_denest(d)
+                d1 = _sqrt_four_terms_denest(d)
             else:
                 d1 = _sqrtdenest(d)
             return n1/d1
@@ -303,8 +305,6 @@ def sqrt_match(p):
     if p.is_Add:
         pargs = list(p.args)
         v = [(sqrt_depth(x), i) for i, x in enumerate(pargs)]
-        if not v:
-            return None
         nmax = max(v)
         if nmax[0] == 0:
             b, r = p.as_coeff_Mul()
@@ -414,7 +414,7 @@ def _denester (nested, av0, h, max_depth_level):
                 v[1] = -1 * v[1]
             if not f[len(nested)]: #Solution denests with square roots
                 vad = (v[0] + d).expand()
-                if not vad:
+                if vad <= 0:
                     return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
                 if not(sqrt_depth(vad) < sqrt_depth(R) + 1 or (vad**2).is_Number):
                     av0[1] = None

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -35,7 +35,14 @@ def sqrtdenest(expr):
 
 def _sqrtdenest(expr):
     from sympy.simplify.simplify import radsimp
-    val = sqrt_match(expr)
+    if not expr.is_Pow or expr.exp != S.Half:
+        val = None
+    else:
+        a = expr.base
+        if not a.args:
+            val = (a, S.Zero, S.Zero)
+        val = sqrt_match(a)
+
     if val:
         a, b, r = val
         # try a quick denesting
@@ -56,15 +63,6 @@ def _sqrtdenest(expr):
         expr = Add(*a)
         return expr
 
-def sqrt_match(p):
-    if not p.is_Pow or p.args[1] != S.Half:
-        return None
-    else:
-        a = p.args[0]
-        if not a.args:
-            return (a, S.Zero, S.Zero)
-        return sqrt_match0(a)
-
 def sqrt_depth(p):
     """
     >>> from sympy.functions.elementary.miscellaneous import sqrt
@@ -83,14 +81,14 @@ def sqrt_depth(p):
     else:
         return 0
 
-def sqrt_match0(p):
+def sqrt_match(p):
     """return (a, b, r) for match a + b*sqrt(r) where
     sqrt(r) has maximal nested sqrt among addends of p
 
     Examples:
     >>> from sympy.functions.elementary.miscellaneous import sqrt
-    >>> from sympy.simplify.sqrtdenest import sqrt_match0
-    >>> sqrt_match0(1 + sqrt(2) + sqrt(2)*sqrt(3) +  2*sqrt(1+sqrt(5)))
+    >>> from sympy.simplify.sqrtdenest import sqrt_match
+    >>> sqrt_match(1 + sqrt(2) + sqrt(2)*sqrt(3) +  2*sqrt(1+sqrt(5)))
     (1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5))
     """
     p = p.expand()
@@ -113,7 +111,7 @@ def sqrt_match0(p):
 def denester (nested, h):
     """
     Denests a list of expressions that contain nested square roots.
-    This method should not be called directly - use 'denest' instead.
+    This method should not be called directly - use 'sqrtdenest' instead.
     This algorithm is based on <http://www.almaden.ibm.com/cs/people/fagin/symb85.pdf>.
 
     It is assumed that all of the elements of 'nested' share the same
@@ -142,7 +140,7 @@ def denester (nested, h):
         return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
     else:
         R = None
-        values = filter(None, [sqrt_match0(expr) for expr in nested])
+        values = filter(None, [sqrt_match(expr) for expr in nested])
         for v in values:
             if v[2]: #Since if b=0, r is not defined
                 if R is not None:
@@ -161,7 +159,7 @@ def denester (nested, h):
             p = prod(nested[i] for i in range(len(nested)) if f[i])
             if p == 1:
                 p = S(p)
-            v = sqrt_match0(p.expand())
+            v = sqrt_match(p.expand())
             v = list(v)
             if 1 in f and f.index(1) < len(nested) - 1 and f[len(nested)-1]:
                 v[0] = -1 * v[0]

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -19,6 +19,8 @@ def sqrt_symbolic_denest(a, b, r, d2=None):
     if d2 == None:
         d2 = expand_multinomial(a**2 - b**2*r)
     rval = sqrt_match(r)
+    if rval == None:
+        return None
     ry = Wild('ry', positive=True)
     ra, rb, rr = rval
     if rb != 0:
@@ -147,7 +149,7 @@ def sqrtdenest(expr):
     if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
         n, d = expr.as_numer_denom()
         if d is S.One:
-            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1:
+            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1 and n.base.is_number:
                 return _four_terms(n)
             return _sqrtdenest(expr)
         else:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -99,6 +99,14 @@ def sqrt_match(p):
         return sqrt_match0(a)
 
 def sqrt_depth(p):
+    """
+    >>> from sympy.functions.elementary.miscellaneous import sqrt
+    >>> from sympy.simplify.sqrtdenest import sqrt_depth
+    >>> sqrt_depth(1 + sqrt(2)*(1 + sqrt(3)))
+    1
+    >>> sqrt_depth(1 + sqrt(2)*sqrt(1 + sqrt(3)))
+    2
+    """
     if p.is_Atom:
         return 0
     elif p.is_Add or p.is_Mul:
@@ -202,15 +210,8 @@ def denester (nested, h):
 def subsets(n):
     """
     Returns all possible subsets of the set (0, 1, ..., n-1) except the empty,
-    listed in numerical order according to binary representation.
-
-    Examples
-    ========
-    >>> from sympy.simplify.sqrtdenest import subsets
-    >>> subsets(3)
-    [[0, 0, 1], [0, 1, 0], [0, 1, 1], [1, 0, 0], [1, 0, 1], [1, 1, 0], [1, 1, 1]]
-    listed in reversed lexicographical order so that the case of the fourth
-    root is treated last.
+    listed in reversed lexicographical order according to binary 
+    representation, so that the case of the fourth root is treated last.
     """
     if n == 1:
         a = [[1]]

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -1,7 +1,7 @@
 from sympy.functions import sqrt, sign
 from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
 from sympy.core.mul import prod
-from sympy.core.function import expand_multinomial
+from sympy.core.function import expand_multinomial, expand_mul
 
 def sqrt_symbolic_denest(a, b, r, d2=None):
     """
@@ -153,7 +153,7 @@ def sqrtdenest(expr, max_iter=3):
 
     See also: unrad in sympy.solvers.solvers
     """
-    expr = sympify(expr)
+    expr = expand_mul(sympify(expr))
     for i in range(max_iter):
         z = sqrtdenest0(expr)
         if expr == z:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -203,7 +203,7 @@ def _sqrtdenest(expr):
     if not is_algebraic(expr):
         return expr
     av0 = [a, b, r, d2]
-    z = _denester([radsimp(expr**2)], av0, 0)[0]
+    z = _denester([radsimp(expr**2)], av0, 0, sqrt_depth(expr)-1)[0]
     if av0[1] == None:
         return expr
     if z != None:
@@ -304,7 +304,7 @@ def sqrt_match(p):
             return None
     return res
 
-def _denester (nested, av0, h, max_depth_level=4):
+def _denester (nested, av0, h, max_depth_level):
     """
     Denests a list of expressions that contain nested square roots.
     This method should not be called directly - use 'sqrtdenest' instead.
@@ -361,7 +361,7 @@ def _denester (nested, av0, h, max_depth_level=4):
             if R is None:
                 return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the previous invocation
             nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
-        d, f = _denester(nested2, av0, h+1)
+        d, f = _denester(nested2, av0, h+1, max_depth_level)
         if not f:
             return None, None
         if not any(f[i] for i in range(len(nested))):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -99,17 +99,6 @@ def sqrt_numeric_denest(a, b, r, d2):
         vad1 = radsimp(1/vad)
         return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
-    else:
-            # sqrtdenest(sqrt(5 + 2 * sqrt(6))) = sqrt(2) + sqrt(3)
-            vp0, vp1 = vad.as_content_primitive()
-            rp0, rp1 = r.as_content_primitive()
-            q = rp1/vp1
-            if q.is_Number:
-                c = (b**2 * q * rp0)/(2 * vp0)
-                depthc = sqrt_depth(c)
-                if depthr > depthc or depthr == depthc == 0:
-                    z = (sqrt(vp0/2)*sqrt(vp1) + sign(b)*sqrt(c)).expand()
-                    return z
 
 def _four_terms(expr):
     """denest the square root of four terms

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -9,11 +9,29 @@ def sqrt_symbolic_denest(a, b, r, d2=None):
     with d2 = expand_multinomial(a**2 - b**2*r)
     if denested return the denested sqrt(a + b*sqrt(r)) , else return None
 
+    Algorithm:
+    In the case in which r = ra + rb*sqrt(rr), attempt denesting by
+    replacing the occurrences of rr with ry**2;
+    if the result is a quadratic expression in ry,
+    if it is a square, write it in square form and take the square root
+
     Examples
-    >>> from sympy import sqrt
+    >>> from sympy import sqrt, Symbol
     >>> from sympy.simplify.sqrtdenest import sqrt_symbolic_denest
     >>> sqrt_symbolic_denest(16 - 2*sqrt(29), 2, -10*sqrt(29) + 55)
     sqrt(-2*sqrt(29) + 11) + sqrt(5)
+    >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3)))
+
+    if sympy decides that sqrt and square can be simplified, it does,
+    otherwise it leaves it in that form
+
+    >>> from sympy.simplify.sqrtdenest import sqrtdenest
+    >>> sqrtdenest(sqrt((w**2).expand()))
+    1 + sqrt(2) + sqrt(1 + sqrt(1 + sqrt(3)))
+    >>> x = Symbol('x')
+    >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3+x)))
+    >>> sqrtdenest(sqrt((w**2).expand()))
+    sqrt((sqrt(sqrt(sqrt(x + 3) + 1) + 1) + 1 + sqrt(2))**2)
     """
     a, b, r = S(a), S(b), S(r)
     if d2 == None:
@@ -55,13 +73,12 @@ def sqrt_symbolic_denest(a, b, r, d2=None):
             cb += b
             discr = (cb**2 - 4*ca*cc).expand()
             if discr == 0:
-                z = sqrt(ca)*(sqrt(r) + cb/(2*ca))
+                z = sqrt(ca*(sqrt(r) + cb/(2*ca))**2)
                 c, q = z.as_content_primitive()
-                z = (c*q).expand()
-                if z < 0:
-                    return -z
-                else:
-                    return z
+                z = c*q
+                if z.is_number:
+                    z = z.expand()
+                return z
 
 
 def sqrt_numeric_denest(a, b, r, d2):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -124,6 +124,8 @@ def sqrtdenest(expr):
 
 def _sqrtdenest(expr):
     from sympy.simplify.simplify import radsimp
+    # maximum denester level
+    max_den = 4
     if not expr.is_Pow or expr.exp != S.Half:
         val = None
     else:
@@ -167,7 +169,7 @@ def _sqrtdenest(expr):
     if not is_algebraic(expr):
         return expr
     av0 = [a, b, r, d2]
-    z = _denester([radsimp(expr**2)], av0, 0)[0]
+    z = _denester([radsimp(expr**2)], av0, 0, min(sqrt_depth(expr)-1, max_den))[0]
     if av0[1] == None:
         return expr
     if z != None:
@@ -268,7 +270,7 @@ def sqrt_match(p):
             return None
     return res
 
-def _denester (nested, av0, h, max_depth_level=4):
+def _denester (nested, av0, h, max_depth_level):
     """
     Denests a list of expressions that contain nested square roots.
     This method should not be called directly - use 'sqrtdenest' instead.
@@ -325,7 +327,7 @@ def _denester (nested, av0, h, max_depth_level=4):
             if R is None:
                 return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the previous invocation
             nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
-        d, f = _denester(nested2, av0, h+1)
+        d, f = _denester(nested2, av0, h+1, max_depth_level)
         if not f:
             return None, None
         if not any(f[i] for i in range(len(nested))):

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -2,84 +2,74 @@ from sympy.functions import sqrt, sign
 from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
 from sympy.core.mul import prod
 from sympy.core.function import expand_multinomial, expand_mul
+from sympy.core.symbol import Dummy
 
-def sqrt_symbolic_denest(a, b, r, d2=None):
+def _mexpand(expr):
+    return expand_mul(expand_multinomial(expr))
+
+def _sqrt_symbolic_denest(a, b, r, d2=None):
     """
-    denest symbolically sqrt(a + b*sqrt(r)),
-    with d2 = expand_multinomial(a**2 - b**2*r)
-    if denested return the denested sqrt(a + b*sqrt(r)) , else return None
+    Given an expression, sqrt(A + B*sqrt(R)), return the denested
+    expression or None. This is called by _sqrtdenest when A**2 - B**2*R is
+    not a Rational.
 
     Algorithm:
-    In the case in which r = ra + rb*sqrt(rr), attempt denesting by
-    replacing the occurrences of rr with ry**2;
-    if the result is a quadratic expression in ry,
-    if it is a square, write it in square form and take the square root
+    If r = ra + rb*sqrt(rr), try replacing sqrt(rr) in A with (y**2 - ra)/rb,
+    and if the result is a quadratic expression in y, see if it is a square,
+    in which case write it in square form and take the square root
 
     Examples
-    >>> from sympy import sqrt, Symbol
-    >>> from sympy.simplify.sqrtdenest import sqrt_symbolic_denest
-    >>> sqrt_symbolic_denest(16 - 2*sqrt(29), 2, -10*sqrt(29) + 55)
+    >>> from sympy.simplify.sqrtdenest import _sqrt_symbolic_denest, sqrtdenest
+    >>> from sympy import sqrt
+    >>> from sympy.abc import x
+
+    >>> _sqrt_symbolic_denest(16 - 2*sqrt(29), 2, -10*sqrt(29) + 55)
     sqrt(-2*sqrt(29) + 11) + sqrt(5)
-    >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3)))
 
     if sympy decides that sqrt and square can be simplified, it does,
     otherwise it leaves it in that form
 
-    >>> from sympy.simplify.sqrtdenest import sqrtdenest
+    >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3)))
     >>> sqrtdenest(sqrt((w**2).expand()))
     1 + sqrt(2) + sqrt(1 + sqrt(1 + sqrt(3)))
-    >>> x = Symbol('x')
     >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3+x)))
     >>> sqrtdenest(sqrt((w**2).expand()))
     sqrt((sqrt(sqrt(sqrt(x + 3) + 1) + 1) + 1 + sqrt(2))**2)
     """
     a, b, r = S(a), S(b), S(r)
     if d2 == None:
-        d2 = expand_multinomial(a**2 - b**2*r)
+        d2 = _mexpand(a**2 - b**2*r)
     rval = sqrt_match(r)
-    if rval == None:
+    if rval is None:
         return None
-    ry = Wild('ry', positive=True)
+    y = Dummy('y', positive=True)
+    y2 = y**2
     ra, rb, rr = rval
     if rb != 0:
-        a2 = a.subs(sqrt(rr), (ry**2 - ra)/rb)
-        ca, cb = S.Zero, S.Zero
         cav, cbv, ccv = [], [], []
-        for xx in a2.args:
-            cx, qx = xx.as_coeff_Mul()
-            if qx.is_Mul:
-                qxa = list(qx.args)
-                if ry in qxa:
-                    qxa.remove(ry)
-                    cbv.append( prod(qxa+[cx]) )
-                elif ry**2 in qxa:
-                    qxa.remove(ry**2)
-                    ca = prod(qxa+[cx])
-                else:
-                    ccv.append(xx)
-            elif qx == ry**2:
-                cav.append(cx)
+        for ai in Add.make_args(a.subs(sqrt(rr), (y2 - ra)/rb)):
+            margs = list(Mul.make_args(ai))
+            if y in margs:
+                margs.remove(y)
+                cbv.append(Mul._from_args(margs))
+            elif y2 in margs:
+                margs.remove(y2)
+                cav.append(Mul._from_args(margs))
             else:
-                if ry == qx:
-                    cbv.append( cx )
-                elif ry**2 == qx:
-                    cav.append(cx)
-                else:
-                    ccv.append(xx)
+                ccv.append(ai)
         ca = Add(*cav)
         cb = Add(*cbv)
         cc = Add(*ccv)
-        if ry not in cc.atoms() and ca != 0:
+        if ca and not cc.has(y):
             cb += b
-            discr = (cb**2 - 4*ca*cc).expand()
-            if discr == 0:
+            discr = _mexpand(cb**2 - 4*ca*cc)
+            if not discr:
                 z = sqrt(ca*(sqrt(r) + cb/(2*ca))**2)
                 c, q = z.as_content_primitive()
                 z = c*q
                 if z.is_number:
-                    z = z.expand()
+                    z = _mexpand(z)
                 return z
-
 
 def sqrt_numeric_denest(a, b, r, d2):
     """
@@ -211,7 +201,7 @@ def _sqrtdenest(expr):
     if val:
         a, b, r = val
         # try a quick numeric denesting
-        d2 = expand_multinomial(a**2 - b**2*r)
+        d2 = _mexpand(a**2 - b**2*r)
         if d2.is_Number:
             if d2.is_positive:
                 z = sqrt_numeric_denest(a, b, r, d2)
@@ -222,15 +212,15 @@ def _sqrtdenest(expr):
                 # fourth root case
                 # sqrtdenest(sqrt(3 + 2*sqrt(3))) =
                 # sqrt(2)*3**(1/4)/2 + sqrt(2)*3**(3/4)/2
-                dr2 = (-d2*r).expand()
+                dr2 = _mexpand(-d2*r)
                 dr = sqrt(dr2)
                 if dr.is_Number:
-                    z = sqrt_numeric_denest((b*r).expand(), a, r, dr2)
+                    z = sqrt_numeric_denest(_mexpand(b*r), a, r, dr2)
                     if z != None:
                         return z/r**Rational(1,4)
 
         else:
-            z = sqrt_symbolic_denest(a, b, r, d2)
+            z = _sqrt_symbolic_denest(a, b, r, d2)
             if z != None:
                 return z
 
@@ -299,7 +289,7 @@ def sqrt_match(p):
     >>> sqrt_match(1 + sqrt(2) + sqrt(2)*sqrt(3) +  2*sqrt(1+sqrt(5)))
     (1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5))
     """
-    p = p.expand()
+    p = _mexpand(p)
     if p.is_Number:
         return (p, S.Zero, S.Zero)
     if p.is_Add:
@@ -369,7 +359,7 @@ def _denester (nested, av0, h, max_depth_level):
     #If none of the arguments are nested
     if av0[0] == None and all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
-            p = prod(nested[i] for i in range(len(f)) if f[i]).expand()
+            p = _mexpand(prod(nested[i] for i in range(len(f)) if f[i]))
             if 1 in f and f.count(1) > 1 and f[-1]:
                 p = -p
             sqp = sqrt(p)
@@ -396,7 +386,7 @@ def _denester (nested, av0, h, max_depth_level):
                         R = v[2]
             if R is None:
                 return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the previous invocation
-            nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
+            nested2 = [_mexpand(v[0]**2) - _mexpand(R*v[1]**2) for v in values] + [R]
         d, f = _denester(nested2, av0, h+1, max_depth_level)
         if not f:
             return None, None
@@ -407,13 +397,13 @@ def _denester (nested, av0, h, max_depth_level):
             p = prod(nested[i] for i in range(len(nested)) if f[i])
             if p == 1:
                 p = S(p)
-            v = sqrt_match(p.expand())
+            v = sqrt_match(_mexpand(p))
             v = list(v)
             if 1 in f and f.index(1) < len(nested) - 1 and f[len(nested)-1]:
                 v[0] = -1 * v[0]
                 v[1] = -1 * v[1]
             if not f[len(nested)]: #Solution denests with square roots
-                vad = (v[0] + d).expand()
+                vad = _mexpand(v[0] + d)
                 if vad <= 0:
                     return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
                 if not(sqrt_depth(vad) < sqrt_depth(R) + 1 or (vad**2).is_Number):
@@ -421,13 +411,13 @@ def _denester (nested, av0, h, max_depth_level):
                     return None, None
 
                 vad1 = radsimp(1/vad)
-                return (sqrt(vad/2) + sign(v[1])*sqrt((v[1]**2*R*vad1/2).expand())).expand(), f
+                return _mexpand(sqrt(vad/2) + sign(v[1])*sqrt(_mexpand(v[1]**2*R*vad1/2))), f
             else: #Solution requires a fourth root
-                s2 = (v[1]*R).expand()+d
+                s2 = _mexpand(v[1]*R) + d
                 if s2 <= 0:
                     return sqrt(nested[-1]), [0]*len(nested)
-                FR, s = (R.expand()**Rational(1,4)), sqrt(s2)
-                return (s/(sqrt(2)*FR) + v[0]*FR/(sqrt(2)*s)).expand(), f
+                FR, s = (_mexpand(R)**Rational(1,4)), sqrt(s2)
+                return _mexpand(s/(sqrt(2)*FR) + v[0]*FR/(sqrt(2)*s)), f
 
 def subsets(n):
     """

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -62,6 +62,7 @@ def _sqrtdenest(expr):
             ra, rb, rr = rval
             a2 = a.subs(sqrt(rr), (ry**2 - ra)/rb)
             ca, cb = S.Zero, S.Zero
+            cbv = []
             ccv = []
             for xx in a2.args:
                 cx, qx = xx.as_coeff_Mul()
@@ -69,7 +70,7 @@ def _sqrtdenest(expr):
                     qxa = list(qx.args)
                     if ry in qxa:
                         qxa.remove(ry)
-                        cb = prod(qxa+[cx])
+                        cbv.append( prod(qxa+[cx]) )
                     elif ry**2 in qxa:
                         qxa.remove(ry**2)
                         ca = prod(qxa+[cx])
@@ -79,11 +80,12 @@ def _sqrtdenest(expr):
                     ca = cx
                 else:
                     if ry == qx:
-                        cb = S.One
+                        cbv.append( S.One )
                     elif ry**2 == qx:
                         ca == S.One
                     else:
                         ccv.append(xx)
+            cb = Add(*cbv)
             cc = Add(*ccv)
             if ca != 0:
                 cb += b

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -45,17 +45,29 @@ def _sqrt_symbolic_denest(a, b, r, d2=None):
     if rb != 0:
         y = Dummy('y', positive=True)
         y2 = y**2
+        a2 = a.subs(sqrt(rr), (y**2 - ra)/rb).expand()
         cav, cbv, ccv = [], [], []
-        for ai in Add.make_args(a.subs(sqrt(rr), (y2 - ra)/rb)):
-            margs = list(Mul.make_args(ai))
-            if y in margs:
-                margs.remove(y)
-                cbv.append(Mul._from_args(margs))
-            elif y2 in margs:
-                margs.remove(y2)
-                cav.append(Mul._from_args(margs))
+        for xx in a2.args:
+            cx, qx = xx.as_coeff_Mul()
+            if qx.is_Mul:
+                qxa = list(qx.args)
+                if y in qxa:
+                    qxa.remove(y)
+                    cbv.append( Mul(*(qxa+[cx])) )
+                elif y2 in qxa:
+                    qxa.remove(y2)
+                    cav.append(Mul(*(qxa+[cx])))
+                else:
+                    ccv.append(xx)
+            elif qx == y2:
+                cav.append(cx)
             else:
-                ccv.append(ai)
+                if y == qx:
+                    cbv.append( cx )
+                elif y2 == qx:
+                    cav.append(cx)
+                else:
+                    ccv.append(xx)
         ca = Add(*cav)
         cb = Add(*cbv)
         cc = Add(*ccv)
@@ -69,6 +81,7 @@ def _sqrt_symbolic_denest(a, b, r, d2=None):
                 if z.is_number:
                     z = _mexpand(z)
                 return z
+
 
 def sqrt_numeric_denest(a, b, r, d2):
     """
@@ -396,8 +409,6 @@ def _denester (nested, av0, h, max_depth_level):
             return sqrt(v[0] + v[1]*d), f
         else:
             p = Mul(*[nested[i] for i in range(len(nested)) if f[i]])
-            if p == 1:
-                p = S(p)
             v = sqrt_match(_mexpand(p))
             v = list(v)
             if 1 in f and f.index(1) < len(nested) - 1 and f[len(nested)-1]:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -2,20 +2,25 @@ from sympy.functions import sqrt, sign
 from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
 from sympy.core.function import expand_multinomial, expand_mul
 from sympy.core.symbol import Dummy
+from sympy.polys import Poly
 
 def _mexpand(expr):
     return expand_mul(expand_multinomial(expr))
 
-def _sqrt_symbolic_denest(a, b, r, d2=None):
+def is_sqrt(expr):
+    # XXX expr.exp.q == 2?
+    return expr.is_Pow and expr.exp.is_Rational and abs(expr.exp) is S.Half
+
+def _sqrt_symbolic_denest(a, b, r):
     """
-    Given an expression, sqrt(A + B*sqrt(R)), return the denested
-    expression or None. This is called by _sqrtdenest when A**2 - B**2*R is
+    Given an expression, sqrt(a + b*sqrt(b)), return the denested
+    expression or None. This is called by _sqrtdenest when a**2 - b**2*r is
     not a Rational.
 
     Algorithm:
-    If r = ra + rb*sqrt(rr), try replacing sqrt(rr) in A with (y**2 - ra)/rb,
-    and if the result is a quadratic expression in y, see if it is a square,
-    in which case write it in square form and take the square root
+    If r = ra + rb*sqrt(rr), try replacing sqrt(rr) in a with (y**2 - ra)/rb,
+    and if the result is a quadratic expression in y that can be XXX?, write it
+    in square form and take the square root.
 
     Examples
     >>> from sympy.simplify.sqrtdenest import _sqrt_symbolic_denest, sqrtdenest
@@ -25,7 +30,7 @@ def _sqrt_symbolic_denest(a, b, r, d2=None):
     >>> _sqrt_symbolic_denest(16 - 2*sqrt(29), 2, -10*sqrt(29) + 55)
     sqrt(-2*sqrt(29) + 11) + sqrt(5)
 
-    if sympy decides that sqrt and square can be simplified, it does,
+    If sympy decides that sqrt and square can be simplified, it does,
     otherwise it leaves it in that form
 
     >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3)))
@@ -35,51 +40,22 @@ def _sqrt_symbolic_denest(a, b, r, d2=None):
     >>> sqrtdenest(sqrt((w**2).expand()))
     sqrt((sqrt(sqrt(sqrt(x + 3) + 1) + 1) + 1 + sqrt(2))**2)
     """
+
     a, b, r = S(a), S(b), S(r)
-    if d2 == None:
-        d2 = _mexpand(a**2 - b**2*r)
     rval = sqrt_match(r)
-    if rval is None:
+    if not rval:
         return None
     ra, rb, rr = rval
-    if rb != 0:
+    if rb:
         y = Dummy('y', positive=True)
-        y2 = y**2
-        a2 = a.subs(sqrt(rr), (y**2 - ra)/rb).expand()
-        cav, cbv, ccv = [], [], []
-        for xx in a2.args:
-            cx, qx = xx.as_coeff_Mul()
-            if qx.is_Mul:
-                qxa = list(qx.args)
-                if y in qxa:
-                    qxa.remove(y)
-                    cbv.append( Mul(*(qxa+[cx])) )
-                elif y2 in qxa:
-                    qxa.remove(y2)
-                    cav.append(Mul(*(qxa+[cx])))
-                else:
-                    ccv.append(xx)
-            elif qx == y2:
-                cav.append(cx)
-            else:
-                if y == qx:
-                    cbv.append( cx )
-                elif y2 == qx:
-                    cav.append(cx)
-                else:
-                    ccv.append(xx)
-        ca = Add(*cav)
-        cb = Add(*cbv)
-        cc = Add(*ccv)
-        if ca and not cc.has(y):
+        newa = Poly(a.subs(sqrt(rr), (y**2 - ra)/rb), y)
+        if newa.degree() == 2:
+            ca, cb, cc = newa.all_coeffs()
             cb += b
-            discr = _mexpand(cb**2 - 4*ca*cc)
-            if not discr:
+            if _mexpand(cb**2 - 4*ca*cc).equals(0):
                 z = sqrt(ca*(sqrt(r) + cb/(2*ca))**2)
-                c, q = z.as_content_primitive()
-                z = c*q
                 if z.is_number:
-                    z = _mexpand(z)
+                    z = _mexpand(Mul._from_args(z.as_content_primitive()))
                 return z
 
 
@@ -103,7 +79,7 @@ def sqrt_numeric_denest(a, b, r, d2):
 
 
 def _sqrt_four_terms_denest(expr):
-    """denest the square root of three or four square root of rationals
+    """Denest the square root of three or four surds
 
     See D.J.Jeffrey and A.D.Rich
     'Symplifying Square Roots of Square Roots by Denesting'
@@ -117,7 +93,7 @@ def _sqrt_four_terms_denest(expr):
     sqrt(2) + sqrt(3) + sqrt(7)
     """
     from sympy.simplify.simplify import radsimp
-    if not (expr.is_Pow and expr.exp == S.Half):
+    if not is_sqrt(expr):
         return expr
     if expr.base < 0:
         return sqrt(-1)*_sqrt_four_terms_denest(sqrt(-expr.base))
@@ -165,10 +141,10 @@ def sqrtdenest(expr, max_iter=3):
 
 
 def sqrtdenest0(expr):
-    if expr.is_Atom:
-        return expr
-    if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
+    if is_sqrt(expr):
         n, d = expr.as_numer_denom()
+        if n is S.One:
+            return 1/sqrtdenest0(sqrt(expr.base))
         if d is S.One:
             nn = len(n.base.args)
             if 3 <= nn <= 4 and all([(x**2).is_Rational for x in n.base.args]):
@@ -183,18 +159,13 @@ def sqrtdenest0(expr):
             else:
                 n1 = _sqrtdenest(n)
 
-            if d.is_Pow and d.exp == S.Half and \
+            if is_sqrt(d) and \
                 3 <= len(d.base.args) <= 4 and all([(x**2).is_Rational for x in d.base.args]):
                 d1 = _sqrt_four_terms_denest(d)
             else:
                 d1 = _sqrtdenest(d)
             return n1/d1
-
-    elif expr.is_Pow and expr.exp == -S.Half:
-        return 1/sqrtdenest0(sqrt(expr.base))
-    elif expr.is_Mul:
-        return Mul(*[sqrtdenest0(x) for x in expr.args])
-    elif isinstance(expr, Expr):
+    if isinstance(expr, Expr):
         args = expr.args
         if args:
             return expr.func(*[sqrtdenest0(a) for a in args])
@@ -202,7 +173,7 @@ def sqrtdenest0(expr):
 
 def _sqrtdenest(expr):
     from sympy.simplify.simplify import radsimp
-    if not expr.is_Pow or expr.exp != S.Half:
+    if not is_sqrt(expr):
         val = None
     else:
         a = expr.base
@@ -222,7 +193,6 @@ def _sqrtdenest(expr):
                 if z != None:
                     return z
             else:
-                # d2 negative
                 # fourth root case
                 # sqrtdenest(sqrt(3 + 2*sqrt(3))) =
                 # sqrt(2)*3**(1/4)/2 + sqrt(2)*3**(3/4)/2
@@ -234,7 +204,7 @@ def _sqrtdenest(expr):
                         return z/r**Rational(1,4)
 
         else:
-            z = _sqrt_symbolic_denest(a, b, r, d2)
+            z = _sqrt_symbolic_denest(a, b, r)
             if z != None:
                 return z
 
@@ -265,7 +235,7 @@ def sqrt_depth(p):
         return 0
     elif p.is_Add or p.is_Mul:
         return max([sqrt_depth(x) for x in p.args])
-    elif p.is_Pow and p.exp == S.Half:
+    elif is_sqrt(p):
         return sqrt_depth(p.base) + 1
     else:
         return 0
@@ -284,7 +254,7 @@ def is_algebraic(p):
         return True
     elif p.is_Atom:
         return False
-    elif p.is_Pow and (p.exp == S.Half or p.exp == -1):
+    elif is_sqrt(p) or p.is_Pow and p.exp == -1: # XXX p.exp.is_Integer?
         return is_algebraic(p.base)
     elif p.is_Add or p.is_Mul:
         return all([is_algebraic(x) for x in p.args])
@@ -292,7 +262,7 @@ def is_algebraic(p):
         return False
 
 def sqrt_match(p):
-    """return (a, b, r) for match p = a + b*sqrt(r) where
+    """return [a, b, r] for match p = a + b*sqrt(r) where
     sqrt(r) has maximal nested sqrt among addends of p
 
     # FIXME should one count also fourth roots, or maybe any root?
@@ -305,44 +275,45 @@ def sqrt_match(p):
     """
     p = _mexpand(p)
     if p.is_Number:
-        return (p, S.Zero, S.Zero)
-    if p.is_Add:
+        res = (p, S.Zero, S.Zero)
+    elif p.is_Add:
         pargs = list(p.args)
         v = [(sqrt_depth(x), i) for i, x in enumerate(pargs)]
         nmax = max(v)
         if nmax[0] == 0:
             b, r = p.as_coeff_Mul()
-            if p.is_Pow and p.exp == S.Half:
-                return (S.Zero, b, p.base)
+            if is_sqrt(p):
+                res = (S.Zero, b, p.base)
             else:
-                return None
-        depth = nmax[0]
-        n = nmax[1]
-        p1 = pargs[n]
-        del pargs[n]
-        a = Add(*pargs)
-        bv = []
-        rv = []
-        if p1.is_Mul:
-            for x in p1.args:
-                if sqrt_depth(x) < depth:
-                    bv.append(x)
-                else:
-                    rv.append(x)
-
-            b = Mul(*bv)
-            r = Mul(*rv)
+                res = []
         else:
-            b = S.One
-            r = p1
-        res = (a, b, r**2)
+            depth = nmax[0]
+            n = nmax[1]
+            p1 = pargs[n]
+            del pargs[n]
+            a = Add(*pargs)
+            bv = []
+            rv = []
+            if p1.is_Mul:
+                for x in p1.args:
+                    if sqrt_depth(x) < depth:
+                        bv.append(x)
+                    else:
+                        rv.append(x)
+
+                b = Mul(*bv)
+                r = Mul(*rv)
+            else:
+                b = S.One
+                r = p1
+            res = (a, b, r**2)
     else:
         b, r = p.as_coeff_Mul()
-        if r.is_Pow and r.exp == S.Half:
+        if is_sqrt(r):
             res = (S.Zero, b, r**2)
         else:
-            return None
-    return res
+            res = []
+    return list(res)
 
 def _denester (nested, av0, h, max_depth_level):
     """
@@ -409,9 +380,8 @@ def _denester (nested, av0, h, max_depth_level):
             return sqrt(v[0] + v[1]*d), f
         else:
             p = Mul(*[nested[i] for i in range(len(nested)) if f[i]])
-            v = sqrt_match(_mexpand(p))
-            v = list(v)
-            if 1 in f and f.index(1) < len(nested) - 1 and f[len(nested)-1]:
+            v = sqrt_match(p)
+            if 1 in f and f.index(1) < len(nested) - 1 and f[len(nested) - 1]:
                 v[0] = -1 * v[0]
                 v[1] = -1 * v[1]
             if not f[len(nested)]: #Solution denests with square roots

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -166,8 +166,9 @@ def _denester (nested, av0, h, max_depth_level=4):
             p = prod(nested[i] for i in range(len(f)) if f[i]).expand()
             if 1 in f and f.count(1) > 1 and f[-1]:
                 p = -p
-            if sqrt(p).is_Number:
-                return sqrt(p), f #If we got a perfect square, return its square root.
+            sqp = sqrt(p)
+            if sqp.is_Number:
+                return sqp, f #If we got a perfect square, return its square root.
         return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
     else:
         R = None
@@ -185,13 +186,12 @@ def _denester (nested, av0, h, max_depth_level=4):
                     else:
                         R = v[2]
             if R is None:
-                return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the pravious invocation
+                return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the previous invocation
             nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
         d, f = _denester(nested2, False, h+1)
         if f == None:
             return None, None
-        if not any(f[i] for i in range(len(nested))):
-        #if all(fi == 0 for fi in f):
+        if all(fi == 0 for fi in f):
             v = values[-1]
             return sqrt(v[0] + v[1]*d), f
         else:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -51,7 +51,9 @@ def _sqrtdenest(expr):
            max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
             d = sqrt(d2)
             vad = a + d
-            if sqrt_depth(vad) < sqrt_depth(a):
+            # if a = m1*sqrt(m) and d = m2*sqrt(m) then a*d is Number
+            # and vad = (m1 + m2)*sqrt(m)
+            if sqrt_depth(vad) < sqrt_depth(a) or (a*d).is_Number:
                 vad1 = radsimp(1/vad)
                 return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
         else:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -101,15 +101,17 @@ def sqrt_numeric_denest(a, b, r, d2):
 
 
 def sqrt_four_terms_denest(expr):
-    """denest the square root of four terms
+    """denest the square root of three or four square root of rationals
 
     See D.J.Jeffrey and A.D.Rich
     'Symplifying Square Roots of Square Roots by Denesting'
 
     Examples
     >>> from sympy import sqrt
-    >>> from sympy.simplify.sqrtdenest import sqrtdenest, sqrt_four_terms_denest
-    >>> sqrtdenest(sqrt(12+2*sqrt(6)+2*sqrt(14)+2*sqrt(21)))
+    >>> from sympy.simplify.sqrtdenest import sqrt_four_terms_denest
+    >>> sqrt_four_terms_denest(sqrt(-72*sqrt(2) + 158*sqrt(5) + 498))
+    -sqrt(10) + sqrt(2) + 9 + 9*sqrt(5)
+    >>> sqrt_four_terms_denest(sqrt(12+2*sqrt(6)+2*sqrt(14)+2*sqrt(21)))
     sqrt(2) + sqrt(3) + sqrt(7)
     """
     from sympy.simplify.simplify import radsimp
@@ -164,21 +166,24 @@ def sqrtdenest0(expr):
     if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
         n, d = expr.as_numer_denom()
         if d is S.One:
-            if len(n.base.args) == 4 and all([x**2 for x in n.base.args]):
+            nn = len(n.base.args)
+            if 3 <= nn <= 4 and all([(x**2).is_Number for x in n.base.args]):
                 return sqrt_four_terms_denest(n)
             return _sqrtdenest(expr)
         else:
-            if len(n.base.args) == 4 and all([x**2 for x in n.base.args]):
+            nn = len(n.base.args)
+            if 3 <= nn <= 4 and all([(x**2).is_Number for x in n.base.args]):
                 n1 = sqrt_four_terms_denest(n)
             else:
                 n1 = _sqrtdenest(n)
 
-            if len(d.base.args) == 4 and all([x**2 for x in n.base.args]):
+            if d.is_Pow and d.exp == S.Half and \
+                3 <= len(d.base.args) <= 4 and all([(x**2).is_Number for x in d.base.args]):
                 d1 = sqrt_four_terms_denest(d)
             else:
                 d1 = _sqrtdenest(d)
-
             return n1/d1
+
     elif expr.is_Pow and expr.exp == -S.Half:
         return 1/sqrtdenest0(sqrt(expr.base))
     elif expr.is_Mul:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -143,28 +143,16 @@ def sqrtdenest(expr, max_iter=3):
 def sqrtdenest0(expr):
     if is_sqrt(expr):
         n, d = expr.as_numer_denom()
-        if n is S.One:
-            return 1/sqrtdenest0(sqrt(expr.base))
         if d is S.One:
-            nn = len(n.base.args)
-            if 3 <= nn <= 4 and all([(x**2).is_Rational for x in n.base.args]):
-                return _sqrt_four_terms_denest(n)
             if n.base.is_Add:
+                nn = len(n.base.args)
+                if 3 <= nn <= 4 and all([(x**2).is_Rational for x in n.base.args]):
+                    return _sqrt_four_terms_denest(n)
                 expr = sqrt(_mexpand(Add(*[sqrtdenest0(x) for x in n.base.args])))
             return _sqrtdenest(expr)
         else:
-            nn = len(n.base.args)
-            if 3 <= nn <= 4 and all([(x**2).is_Rational for x in n.base.args]):
-                n1 = _sqrt_four_terms_denest(n)
-            else:
-                n1 = _sqrtdenest(n)
-
-            if is_sqrt(d) and \
-                3 <= len(d.base.args) <= 4 and all([(x**2).is_Rational for x in d.base.args]):
-                d1 = _sqrt_four_terms_denest(d)
-            else:
-                d1 = _sqrtdenest(d)
-            return n1/d1
+            n, d = [sqrtdenest0(i) for i in (n, d)]
+            return n/d
     if isinstance(expr, Expr):
         args = expr.args
         if args:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -2,7 +2,7 @@ from sympy.functions import sqrt, sign
 from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
 from sympy.core.function import expand_multinomial, expand_mul
 from sympy.core.symbol import Dummy
-from sympy.polys import Poly
+from sympy.polys import Poly, PolynomialError
 
 def _mexpand(expr):
     return expand_mul(expand_multinomial(expr))
@@ -14,31 +14,39 @@ def is_sqrt(expr):
 def _sqrt_symbolic_denest(a, b, r):
     """
     Given an expression, sqrt(a + b*sqrt(b)), return the denested
-    expression or None. This is called by _sqrtdenest when a**2 - b**2*r is
-    not a Rational.
-
+    expression or None.
+s
     Algorithm:
     If r = ra + rb*sqrt(rr), try replacing sqrt(rr) in a with (y**2 - ra)/rb,
-    and if the result is a quadratic expression in y that can be XXX?, write it
-    in square form and take the square root.
+    and if the result is a quadratic, ca*y**2 + cb*y + cc, and has a
+    discriminant of 0, then sqrt(a + b*sqrt(r)) can be rewritten as
+    sqrt(ca*(sqrt(r) + cb/(2*ca))**2). XXX a simple example would be nice
 
     Examples
     >>> from sympy.simplify.sqrtdenest import _sqrt_symbolic_denest, sqrtdenest
-    >>> from sympy import sqrt
+    >>> from sympy import sqrt, Symbol
     >>> from sympy.abc import x
 
     >>> _sqrt_symbolic_denest(16-2*sqrt(29), 2,-10*sqrt(29)+55,-24*sqrt(29)+152)
     sqrt(-2*sqrt(29) + 11) + sqrt(5)
 
-    If sympy decides that sqrt and square can be simplified, it does,
-    otherwise it leaves it in that form
+    If the expression is numeric, it will be simplified:
 
-    >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3)))
+    >>> w = sqrt(sqrt(sqrt(3) + 1) + 1) + 1 + sqrt(2)
     >>> sqrtdenest(sqrt((w**2).expand()))
     1 + sqrt(2) + sqrt(1 + sqrt(1 + sqrt(3)))
-    >>> w = 1 + sqrt(2) + sqrt(1 + sqrt(1+sqrt(3+x)))
+
+    Otherwise, it will only be simplified if assumptions allow:
+
+    >>> w = w.subs(sqrt(3), sqrt(x + 3))
     >>> sqrtdenest(sqrt((w**2).expand()))
     sqrt((sqrt(sqrt(sqrt(x + 3) + 1) + 1) + 1 + sqrt(2))**2)
+
+    Notice that the argument of the sqrt is a square. If x is made positive
+    then the sqrt of the square is resolved:
+
+    >>> _.subs(x, Symbol('x', positive=True))
+    sqrt(sqrt(sqrt(x + 3) + 1) + 1) + 1 + sqrt(2)
     """
 
     a, b, r = S(a), S(b), S(r)
@@ -48,7 +56,10 @@ def _sqrt_symbolic_denest(a, b, r):
     ra, rb, rr = rval
     if rb:
         y = Dummy('y', positive=True)
-        newa = Poly(a.subs(sqrt(rr), (y**2 - ra)/rb), y)
+        try:
+            newa = Poly(a.subs(sqrt(rr), (y**2 - ra)/rb), y)
+        except PolynomialError:
+            return None
         if newa.degree() == 2:
             ca, cb, cc = newa.all_coeffs()
             cb += b
@@ -57,7 +68,6 @@ def _sqrt_symbolic_denest(a, b, r):
                 if z.is_number:
                     z = _mexpand(Mul._from_args(z.as_content_primitive()))
                 return z
-
 
 def sqrt_numeric_denest(a, b, r, d2):
     """
@@ -257,7 +267,7 @@ def sqrt_match(p):
     >>> from sympy.functions.elementary.miscellaneous import sqrt
     >>> from sympy.simplify.sqrtdenest import sqrt_match
     >>> sqrt_match(1 + sqrt(2) + sqrt(2)*sqrt(3) +  2*sqrt(1+sqrt(5)))
-    (1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5))
+    [1 + sqrt(2) + sqrt(6), 2, 1 + sqrt(5)]
     """
     p = _mexpand(p)
     if p.is_Number:

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -3,6 +3,68 @@ from sympy.core import S, Wild, Rational, sympify, Mul, Add, Expr
 from sympy.core.mul import prod
 from sympy.core.function import expand_multinomial
 
+def sqrt_symbolic_denest(a, b, r, d2=None):
+    """
+    denest symbolically sqrt(a + b*sqrt(r)),
+    with d2 = expand_multinomial(a**2 - b**2*r)
+    if denested return the denested sqrt(a + b*sqrt(r)) , else return None
+
+    Examples:
+    >>> from sympy import sqrt
+    >>> from sympy.simplify.sqrtdenest import sqrt_symbolic_denest
+    >>> sqrt_symbolic_denest(16 - 2*sqrt(29), 2, -10*sqrt(29) + 55)
+    sqrt(-2*sqrt(29) + 11) + sqrt(5)
+    """
+    # attempt to factorize a + b*sqrt(r) as a square
+    # 1) using r = ra + rb*sqrt(rr)
+    a, b, r = S(a), S(b), S(r)
+    if d2 == None:
+        d2 = expand_multinomial(a**2 - b**2*r)
+    rval = sqrt_match(r)
+    ry = Wild('ry', positive=True)
+    ra, rb, rr = rval
+    if rb != 0:
+        a2 = a.subs(sqrt(rr), (ry**2 - ra)/rb)
+        ca, cb = S.Zero, S.Zero
+        cav = []
+        cbv = []
+        ccv = []
+        for xx in a2.args:
+            cx, qx = xx.as_coeff_Mul()
+            if qx.is_Mul:
+                qxa = list(qx.args)
+                if ry in qxa:
+                    qxa.remove(ry)
+                    cbv.append( prod(qxa+[cx]) )
+                elif ry**2 in qxa:
+                    qxa.remove(ry**2)
+                    ca = prod(qxa+[cx])
+                else:
+                    ccv.append(xx)
+            elif qx == ry**2:
+                cav.append(cx)
+            else:
+                if ry == qx:
+                    cbv.append( cx )
+                elif ry**2 == qx:
+                    cav.append(cx)
+                else:
+                    ccv.append(xx)
+        ca = Add(*cav)
+        cb = Add(*cbv)
+        cc = Add(*ccv)
+        if ry not in cc.atoms() and ca != 0:
+            cb += b
+            discr = (cb**2 - 4*ca*cc).expand()
+            if discr == 0:
+                z = sqrt(ca)*(sqrt(r) + cb/(2*ca))
+                c, q = z.as_content_primitive()
+                z = (c*q).expand()
+                if z < 0:
+                    return -z
+                else:
+                    return z
+
 def sqrtdenest(expr):
     """
     Denests sqrts in an expression that contain other square roots
@@ -58,53 +120,9 @@ def _sqrtdenest(expr):
                 vad1 = radsimp(1/vad)
                 return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
         else:
-            # attempt to factorize a + b*sqrt(r) as a square
-            # 1) using r = ra + rb*sqrt(rr)
-            rval = sqrt_match(r)
-            ry = Wild('ry', positive=True)
-            ra, rb, rr = rval
-            if rb != 0:
-                a2 = a.subs(sqrt(rr), (ry**2 - ra)/rb)
-                ca, cb = S.Zero, S.Zero
-                cav = []
-                cbv = []
-                ccv = []
-                for xx in a2.args:
-                    cx, qx = xx.as_coeff_Mul()
-                    if qx.is_Mul:
-                        qxa = list(qx.args)
-                        if ry in qxa:
-                            qxa.remove(ry)
-                            cbv.append( prod(qxa+[cx]) )
-                        elif ry**2 in qxa:
-                            qxa.remove(ry**2)
-                            ca = prod(qxa+[cx])
-                        else:
-                            ccv.append(xx)
-                    elif qx == ry**2:
-                        cav.append(cx)
-                    else:
-                        if ry == qx:
-                            cbv.append( cx )
-                        elif ry**2 == qx:
-                            cav.append(cx)
-                        else:
-                            ccv.append(xx)
-                ca = Add(*cav)
-                cb = Add(*cbv)
-                cc = Add(*ccv)
-                if ry not in cc.atoms() and ca != 0:
-                    cb += b
-                    discr = (cb**2 - 4*ca*cc).expand()
-                    if discr == 0:
-                        z = sqrt(ca)*(sqrt(r) + cb/(2*ca))
-                        c, q = z.as_content_primitive()
-                        z = (c*q).expand()
-                        if z < 0:
-                            return -z
-                        else:
-                            return z
-            # 2)
+            z = sqrt_symbolic_denest(a, b, r, d2)
+            if z:
+                return z
             if d2.is_Number:
                 if d2.is_positive:
                     # sqrtdenest(sqrt(5 + 2 * sqrt(6))) = sqrt(2) + sqrt(3)

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -100,7 +100,7 @@ def sqrt_numeric_denest(a, b, r, d2):
         return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
 
-def _four_terms(expr):
+def sqrt_four_terms_denest(expr):
     """denest the square root of four terms
 
     See D.J.Jeffrey and A.D.Rich
@@ -108,7 +108,7 @@ def _four_terms(expr):
 
     Examples
     >>> from sympy import sqrt
-    >>> from sympy.simplify.sqrtdenest import sqrtdenest, _four_terms
+    >>> from sympy.simplify.sqrtdenest import sqrtdenest, sqrt_four_terms_denest
     >>> sqrtdenest(sqrt(12+2*sqrt(6)+2*sqrt(14)+2*sqrt(21)))
     sqrt(2) + sqrt(3) + sqrt(7)
     """
@@ -116,7 +116,7 @@ def _four_terms(expr):
     if not (expr.is_Pow and expr.exp == S.Half):
         return expr
     if expr.base < 0:
-        return sqrt(-1)*_four_terms(sqrt(-expr.base))
+        return sqrt(-1)*sqrt_four_terms_denest(sqrt(-expr.base))
     a = Add(*expr.base.args[:2])
     b = Add(*expr.base.args[2:])
     if a < 0:
@@ -132,7 +132,7 @@ def _four_terms(expr):
     c = sqrtdenest(sqrt(vad))
     if sqrt_depth(c) > 1:
         return expr
-    return radsimp(c/sqrt(2) + b/(sqrt(2)*c)).expand()
+    return radsimp((c/sqrt(2) + b/(sqrt(2)*c))).expand()
 
 
 def sqrtdenest(expr, max_iter=3):
@@ -164,20 +164,17 @@ def sqrtdenest0(expr):
     if expr.is_Pow and expr.exp is S.Half: #If expr is a square root
         n, d = expr.as_numer_denom()
         if d is S.One:
-            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1 and \
-                n.base.is_number:
-                return _four_terms(n)
+            if len(n.base.args) == 4 and all([x**2 for x in n.base.args]):
+                return sqrt_four_terms_denest(n)
             return _sqrtdenest(expr)
         else:
-            if len(n.base.args) == 4 and sqrt_depth(n.base) == 1 and \
-                n.base.is_number:
-                n1 = _four_terms(n)
+            if len(n.base.args) == 4 and all([x**2 for x in n.base.args]):
+                n1 = sqrt_four_terms_denest(n)
             else:
                 n1 = _sqrtdenest(n)
 
-            if len(d.base.args) == 4 and sqrt_depth(d.base) == 1 and \
-                d.base.is_number:
-                d1 = _four_terms(d)
+            if len(d.base.args) == 4 and all([x**2 for x in n.base.args]):
+                d1 = sqrt_four_terms_denest(d)
             else:
                 d1 = _sqrtdenest(d)
 

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -41,7 +41,6 @@ def _sqrtdenest(expr):
         a = expr.base
         if a.is_Number:
             return expr
-        #    return (a, S.Zero, S.Zero)
         if not a.args:
             val = (a, S.Zero, S.Zero)
         val = sqrt_match(a)
@@ -67,6 +66,7 @@ def _sqrtdenest(expr):
             if rb != 0:
                 a2 = a.subs(sqrt(rr), (ry**2 - ra)/rb)
                 ca, cb = S.Zero, S.Zero
+                cav = []
                 cbv = []
                 ccv = []
                 for xx in a2.args:
@@ -82,14 +82,15 @@ def _sqrtdenest(expr):
                         else:
                             ccv.append(xx)
                     elif qx == ry**2:
-                        ca = cx
+                        cav.append(cx)
                     else:
                         if ry == qx:
-                            cbv.append( S.One )
+                            cbv.append( cx )
                         elif ry**2 == qx:
-                            ca == S.One
+                            cav.append(cx)
                         else:
                             ccv.append(xx)
+                ca = Add(*cav)
                 cb = Add(*cbv)
                 cc = Add(*ccv)
                 if ry not in cc.atoms() and ca != 0:
@@ -185,11 +186,25 @@ def sqrt_match(p):
                 return (S.Zero, b, p.base)
             else:
                 return None
+        depth = nmax[0]
         n = nmax[1]
         p1 = pargs[n]
         del pargs[n]
         a = Add(*pargs)
-        b, r = p1.as_coeff_Mul()
+        bv = []
+        rv = []
+        if p1.is_Mul:
+            for x in p1.args:
+                if sqrt_depth(x) < depth:
+                    bv.append(x)
+                else:
+                    rv.append(x)
+
+            b = prod(bv)
+            r = prod(rv)
+        else:
+            b = S.One
+            r = p1
         res = (a, b, r**2)
     else:
         b, r = p.as_coeff_Mul()

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -34,7 +34,7 @@ def sqrtdenest(expr):
     return expr
 
 def _sqrtdenest(expr):
-    from sympy.simplify.simplify import radsimp
+    from sympy.simplify.simplify import radsimp, simplify
     if not expr.is_Pow or expr.exp != S.Half:
         val = None
     else:
@@ -51,12 +51,46 @@ def _sqrtdenest(expr):
            max([sqrt_depth(a), sqrt_depth(b), sqrt_depth(r)]) >= 1:
             d = sqrt(d2)
             vad = a + d
-            # if a = m1*sqrt(m) and d = m2*sqrt(m) then a*d is Number
-            # and vad = (m1 + m2)*sqrt(m)
             if sqrt_depth(vad) < sqrt_depth(a) or (a*d).is_Number:
                 vad1 = radsimp(1/vad)
                 return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
         else:
+            # attempt to factorize a + b*sqrt(r) as a square
+            # using r = ra + rb*sqrt(rr)
+            rval = sqrt_match(r)
+            ry = Wild('ry', positive=True)
+            ra, rb, rr = rval
+            a2 = a.subs(sqrt(rr), (ry**2 - ra)/rb)
+            ca, cb = S.Zero, S.Zero
+            ccv = []
+            for xx in a2.args:
+                cx, qx = xx.as_coeff_Mul()
+                if qx.is_Mul:
+                    qxa = list(qx.args)
+                    if ry in qxa:
+                        qxa.remove(ry)
+                        cb = prod(qxa+[cx])
+                    elif ry**2 in qxa:
+                        qxa.remove(ry**2)
+                        ca = prod(qxa+[cx])
+                    else:
+                        ccv.append(xx)
+                elif qx == ry**2:
+                    ca = cx
+                else:
+                    if ry == qx:
+                        cb = S.One
+                    elif ry**2 == qx:
+                        ca == S.One
+                    else:
+                        ccv.append(xx)
+            cc = Add(*ccv)
+            if ca != 0:
+                cb += b
+                discr = (cb**2 - 4*ca*cc).expand()
+                if discr == 0:
+                    z = sqrt(ca)*(sqrt(r) + cb/(2*ca))
+                    return simplify(z)
             d = sqrt(d2)
             vad = a + d
             vp0, vp1 = vad.as_content_primitive()

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -85,7 +85,7 @@ def sqrt_numeric_denest(a, b, r, d2):
     # sqrt_depth(expr) = depthr + 2
     # there is denesting if sqrt_depth(vad)+1 < depthr + 2
     # if vad**2 is Number there is a fourth root
-    if sqrt_depth(vad) < depthr + 1 or (vad**2).is_Number:
+    if sqrt_depth(vad) < depthr + 1 or (vad**2).is_Rational:
         vad1 = radsimp(1/vad)
         return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()
 
@@ -159,18 +159,20 @@ def sqrtdenest0(expr):
         n, d = expr.as_numer_denom()
         if d is S.One:
             nn = len(n.base.args)
-            if 3 <= nn <= 4 and all([(x**2).is_Number for x in n.base.args]):
+            if 3 <= nn <= 4 and all([(x**2).is_Rational for x in n.base.args]):
                 return _sqrt_four_terms_denest(n)
+            if n.base.is_Add:
+                expr = sqrt(_mexpand(Add(*[sqrtdenest0(x) for x in n.base.args])))
             return _sqrtdenest(expr)
         else:
             nn = len(n.base.args)
-            if 3 <= nn <= 4 and all([(x**2).is_Number for x in n.base.args]):
+            if 3 <= nn <= 4 and all([(x**2).is_Rational for x in n.base.args]):
                 n1 = _sqrt_four_terms_denest(n)
             else:
                 n1 = _sqrtdenest(n)
 
             if d.is_Pow and d.exp == S.Half and \
-                3 <= len(d.base.args) <= 4 and all([(x**2).is_Number for x in d.base.args]):
+                3 <= len(d.base.args) <= 4 and all([(x**2).is_Rational for x in d.base.args]):
                 d1 = _sqrt_four_terms_denest(d)
             else:
                 d1 = _sqrtdenest(d)
@@ -202,7 +204,7 @@ def _sqrtdenest(expr):
         a, b, r = val
         # try a quick numeric denesting
         d2 = _mexpand(a**2 - b**2*r)
-        if d2.is_Number:
+        if d2.is_Rational:
             if d2.is_positive:
                 z = sqrt_numeric_denest(a, b, r, d2)
                 if z != None:
@@ -214,7 +216,7 @@ def _sqrtdenest(expr):
                 # sqrt(2)*3**(1/4)/2 + sqrt(2)*3**(3/4)/2
                 dr2 = _mexpand(-d2*r)
                 dr = sqrt(dr2)
-                if dr.is_Number:
+                if dr.is_Rational:
                     z = sqrt_numeric_denest(_mexpand(b*r), a, r, dr2)
                     if z != None:
                         return z/r**Rational(1,4)
@@ -266,7 +268,7 @@ def is_algebraic(p):
     >>> is_algebraic(sqrt(2)*(3/(sqrt(7) + sqrt(5)*cos(2))))
     False
     """
-    if p.is_Number:
+    if p.is_Rational:
         return True
     elif p.is_Atom:
         return False

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -76,7 +76,6 @@ def sqrt_numeric_denest(a, b, r, d2):
     # sqrt_depth(expr) = depthr + 2
     # there is denesting if sqrt_depth(vad)+1 < depthr + 2
     # if vad**2 is Number there is a fourth root
-    # 
     if sqrt_depth(vad) < depthr + 1 or (vad**2).is_Number:
         vad1 = radsimp(1/vad)
         return (sqrt(vad/2) + sign(b)*sqrt((b**2*r*vad1/2).expand())).expand()

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -182,14 +182,15 @@ def _denester (nested, av0, h, max_depth_level=4):
             for v in values:
                 if v[2]: #Since if b=0, r is not defined
                     if R is not None:
-                        assert R == v[2] #All the 'r's should be the same.
+                        if R != v[2]:
+                            return None, False
                     else:
                         R = v[2]
             if R is None:
                 return sqrt(nested[-1]), [0]*len(nested) # return the radicand from the previous invocation
             nested2 = [(v[0]**2).expand()-(R*v[1]**2).expand() for v in values] + [R]
         d, f = _denester(nested2, False, h+1)
-        if f == None:
+        if not f:
             return None, None
         if all(fi == 0 for fi in f):
             v = values[-1]

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -168,6 +168,8 @@ def _sqrtdenest(expr):
         return expr
     av0 = [a, b, r, d2]
     z = _denester([radsimp(expr**2)], av0, 0)[0]
+    if av0[1] == None:
+        return expr
     if z != None:
         return z
     return expr
@@ -290,6 +292,8 @@ def _denester (nested, av0, h, max_depth_level=4):
     from sympy.simplify.simplify import radsimp
     if h > max_depth_level:
         return None, None
+    if av0[1] == None:
+        return None, None
     #If none of the arguments are nested
     if av0[0] == None and all(n.is_Number for n in nested): #If none of the arguments are nested
         for f in subsets(len(nested)): #Test subset 'f' of nested
@@ -312,7 +316,10 @@ def _denester (nested, av0, h, max_depth_level=4):
             for v in values:
                 if v[2]: #Since if b=0, r is not defined
                     if R is not None:
-                        assert R == v[2] #All the 'r's should be the same.
+                        if R != v[2]:
+                            av0[1] = None
+                            return None, None
+                        #assert R == v[2] #All the 'r's should be the same.
                     else:
                         R = v[2]
             if R is None:
@@ -337,6 +344,10 @@ def _denester (nested, av0, h, max_depth_level=4):
                 vad = (v[0] + d).expand()
                 if not vad:
                     return sqrt(nested[-1]), [0]*len(nested) #Otherwise, return the radicand from the previous invocation.
+                if not(sqrt_depth(vad) < sqrt_depth(R) + 1 or (vad**2).is_Number):
+                    av0[1] = None
+                    return None, None
+
                 vad1 = radsimp(1/vad)
                 return (sqrt(vad/2) + sign(v[1])*sqrt((v[1]**2*R*vad1/2).expand())).expand(), f
             else: #Solution requires a fourth root

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -18,6 +18,9 @@ def test_sqrtdenest2():
             sqrt(5) + sqrt(11-2*sqrt(29))
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \
             -1 + sqrt(2) + sqrt(10)
+    assert sqrtdenest(sqrt(1+sqrt(1+sqrt(7)))) == sqrt(1+sqrt(1+sqrt(7)))
+    assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+sqrt(2)+sqrt(5))))**2).expand())) == \
+        1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,23 +1,25 @@
-from sympy import sqrt, Rational, sqrtdenest, Integral, cos
+from sympy import sqrt, Rational, S, sqrtdenest, Integral, cos
 from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
-r2, r3, r5, r7 = sqrt(2), sqrt(3), sqrt(5), sqrt(7)
+r2, r3, r5, r7, r29 = sqrt(2), sqrt(3), sqrt(5), sqrt(7), sqrt(29)
 
 def test_sqrtdenest():
     d = {sqrt(5 + 2 * sqrt(6)): sqrt(2) + sqrt(3),
         sqrt(sqrt(2)): sqrt(sqrt(2)),
         sqrt(5+sqrt(7)): sqrt(5+sqrt(7)),
         sqrt(3+sqrt(5+2*sqrt(7))):
-            sqrt(6+3*sqrt(7))/(sqrt(2)*(5+2*sqrt(7))**Rational(1,4)) +
-            3*(5+2*sqrt(7))**Rational(1,4)/(sqrt(2)*sqrt(6+3*sqrt(7))),
-        sqrt(3+2*sqrt(3)): 3**Rational(1,4)/sqrt(2)+3/(sqrt(2)*3**Rational(1,4))}
+            3*sqrt(2)*(5 + 2*sqrt(7))**(S(1)/4)/(2*sqrt(6 + 3*sqrt(7))) +
+            sqrt(2)*sqrt(6 + 3*sqrt(7))/(2*(5 + 2*sqrt(7))**(S(1)/4)),
+        sqrt(3+2*sqrt(3)): 3**(S(3)/4)*(sqrt(6)/2 + 3*sqrt(2)/2)/3}
     for i in d:
-        assert sqrtdenest(i) == d[i] or _denester([i])[0] == d[i]
+        assert sqrtdenest(i) == d[i]
 
 def test_sqrtdenest2():
     assert sqrtdenest(sqrt(16-2*sqrt(29)+2*sqrt(55-10*sqrt(29)))) == \
             sqrt(5) + sqrt(11-2*sqrt(29))
+    assert sqrtdenest(sqrt(-r5+sqrt(-2*r29+2*sqrt(-10*r29+55)+16))) == \
+    (-2*sqrt(29) + 11)**Rational(1,4)
     assert sqrtdenest(sqrt(1+sqrt(1+sqrt(7)))) == sqrt(1+sqrt(1+sqrt(7)))
     assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+sqrt(2)+sqrt(5))))**2).expand())) == \
         1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
@@ -35,6 +37,10 @@ def test_sqrtdenest2():
 
     assert sqrtdenest(sqrt(-2*sqrt(10)+2*r2*sqrt(-2*sqrt(10)+11)+14)) == \
         sqrt(-2*sqrt(10)+2*r2*(-1+sqrt(10))+14)
+
+    # currencty cannot denest this; check one does not get a wrong answer
+    z = sqrt(8 - sqrt(2)*sqrt(5-sqrt(5)) - 3*(1+sqrt(5)))
+    assert (sqrtdenest(z) - z).evalf() < 1.0e-100
 
 @XFAIL
 def test_sqrtdenest2a():

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -2,7 +2,7 @@ from sympy import sqrt, Rational, S, Symbol, sqrtdenest, Integral, cos
 from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
-r2, r3, r5, r6, r7, r29 = sqrt(2), sqrt(3), sqrt(5), sqrt(6), sqrt(7), sqrt(29)
+r2, r3, r5, r6, r7, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 29]]
 
 def test_sqrtdenest():
     d = {sqrt(5 + 2 * sqrt(6)): sqrt(2) + sqrt(3),
@@ -78,6 +78,9 @@ def test_sqrtdenest3():
       r7*(1+r6+r7)/(7*(sqrt(-2*sqrt(29)+ 11)+r5))).expand() == 0
     z = sqrt(sqrt(sqrt(2) + 2) + 2)
     assert sqrtdenest(z) == z
+    assert sqrtdenest(sqrt(-2*sqrt(10)+4*r2*sqrt(-2*sqrt(10)+11)+20)) == \
+    sqrt(-2*r5-sqrt(10)+r2+10)+sqrt(-sqrt(10)-r2+2*r5+10)
+
 
 def test_sqrt_symbolic_denest():
     x = Symbol('x')

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -99,6 +99,8 @@ def test_sqrt_symbolic_denest():
     assert sqrtdenest(z) == z
     z= sqrt( ((1+sqrt(sqrt(2+cos(3*x))+3))**2+1).expand())
     assert sqrtdenest(z) == z
+    assert sqrtdenest(sqrt(2*sqrt(1+r3)*cos(3)+cos(3)**2+1+r3*cos(3)**2)) == \
+      -1 - sqrt(1 + sqrt(3))*cos(3)
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -120,3 +120,9 @@ def test_issue_2758():
     assert sqrtdenest(1 + z) == 1 + ans
     assert sqrtdenest(Integral(z + 1, (x, 1, 2))) == Integral(1 + ans, (x, 1, 2))
     assert sqrtdenest(x + sqrt(y)) == x + sqrt(y)
+
+def test_subsets():
+    assert subsets(1) == [[1]]
+    assert subsets(4) == [[1,0,0,0], [0,1,0,0], [1,1,0,0], [0,0,1,0], \
+      [1,0,1,0], [0,1,1,0], [1,1,1,0], [0,0,0,1], [1,0,0,1], [0,1,0,1], \
+      [1,1,0,1], [0,0,1,1], [1,0,1,1], [0,1,1,1], [1,1,1,1]]

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -57,6 +57,8 @@ def test_sqrtdenest_four_terms():
       -sqrt(2) + sqrt(3) + 2*sqrt(7)
     assert sqrtdenest(sqrt(-28*sqrt(7)-14*sqrt(5)+4*sqrt(35) + 82)) == \
       -7 + sqrt(5) + 2*sqrt(7)
+    assert sqrtdenest(sqrt(6*sqrt(2)/11+2*sqrt(22)/11+6*sqrt(11)/11+2)) == \
+      sqrt(11)*(sqrt(2) + 3 + sqrt(11))/11
 
 @XFAIL
 def test_sqrtdenest2a():

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -6,6 +6,8 @@ r2, r3, r5, r6, r7, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 29]]
 
 def test_sqrtdenest():
     d = {sqrt(5 + 2 * sqrt(6)): sqrt(2) + sqrt(3),
+        sqrt(5. + 2 * sqrt(6)): sqrt(5. + 2 * sqrt(6)),
+        sqrt(5. + 4*sqrt(5 + 2 * sqrt(6))): sqrt(5.0 + 4*sqrt(2) + 4*sqrt(3)),
         sqrt(sqrt(2)): sqrt(sqrt(2)),
         sqrt(5+sqrt(7)): sqrt(5+sqrt(7)),
         sqrt(3+sqrt(5+2*sqrt(7))):
@@ -21,7 +23,7 @@ def test_sqrtdenest2():
     assert sqrtdenest(sqrt(-r5+sqrt(-2*r29+2*sqrt(-10*r29+55)+16))) == \
     (-2*sqrt(29) + 11)**Rational(1,4)
     assert sqrtdenest(sqrt(1+sqrt(1+sqrt(7)))) == sqrt(1+sqrt(1+sqrt(7)))
-    assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+sqrt(2)+sqrt(5))))**2).expand())) == \
+    assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+r2+r5)))**2).expand())) == \
         1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
     assert sqrtdenest(sqrt(5*sqrt(3) + 6*sqrt(2))) == \
         sqrt(2)*3**Rational(1,4) + 3**Rational(3,4)
@@ -36,7 +38,7 @@ def test_sqrtdenest2():
                 cos(3)+cos(2)+1+sqrt(1+r3)
 
     assert sqrtdenest(sqrt(-2*sqrt(10)+2*r2*sqrt(-2*sqrt(10)+11)+14)) == \
-        sqrt(-2*sqrt(10)+2*r2*(-1+sqrt(10))+14)
+        sqrt(-2*sqrt(10) - 2*sqrt(2) + 4*sqrt(5) + 14)
 
     # currently cannot denest this; check one does not get a wrong answer
     z = sqrt(8 - sqrt(2)*sqrt(5-sqrt(5)) - 3*(1+sqrt(5)))
@@ -79,9 +81,12 @@ def test_sqrtdenest3():
     z = sqrt(sqrt(sqrt(2) + 2) + 2)
     assert sqrtdenest(z) == z
     assert sqrtdenest(sqrt(-2*sqrt(10)+4*r2*sqrt(-2*sqrt(10)+11)+20)) == \
-      sqrt(-2*r5-sqrt(10)+r2+10)+sqrt(-sqrt(10)-r2+2*r5+10)
+      sqrt(-2*sqrt(10) - 4*sqrt(2) + 8*sqrt(5) + 20)
     assert sqrtdenest(sqrt((112+70*r2)+(46+34*r2)*r5)) == \
       sqrt(10) + 5 + 4*sqrt(2) + 3*sqrt(5)
+    z = sqrt(5+sqrt(2*r6+5)*sqrt(-2*r29+2*sqrt(-10*r29+55)+16))
+    assert sqrtdenest(z) == \
+      sqrt(r2*sqrt(-2*r29+11)+r3*sqrt(-2*r29+11)+sqrt(10)+sqrt(15)+5)
 
 
 def test_sqrt_symbolic_denest():

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,5 +1,6 @@
 from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos
 from sympy.utilities.pytest import XFAIL
+from sympy.simplify.sqrtdenest import _sqrt_four_terms_denest
 
 r2, r3, r5, r6, r7, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 29]]
 
@@ -18,19 +19,19 @@ def test_sqrtdenest():
         assert sqrtdenest(i) == d[i]
 
 def test_sqrtdenest2():
-    assert sqrtdenest(sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))) == \
-            sqrt(5) + sqrt(11 - 2*sqrt(29))
+    assert sqrtdenest(sqrt(16 - 2*r29 + 2*sqrt(55 - 10*r29))) == \
+            r5 + sqrt(11 - 2*r29)
     assert sqrtdenest(sqrt(-r5 + sqrt(-2*r29 + 2*sqrt(-10*r29 + 55) + 16))) == \
-    root(-2*sqrt(29) + 11, 4)
-    r = sqrt(1 + sqrt(7))
+    root(-2*r29 + 11, 4)
+    r = sqrt(1 + r7)
     assert sqrtdenest(sqrt(1 + r)) == sqrt(1 + r)
     assert sqrtdenest(sqrt(((1 + sqrt(1 + 2*sqrt(3 + r2 + r5)))**2).expand())) == \
-        1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
-    assert sqrtdenest(sqrt(5*sqrt(3) + 6*sqrt(2))) == \
-        sqrt(2)*root(3, 4) + root(3, 4)**3
+        1 + sqrt(1 + 2*sqrt(r2 + r5 + 3))
+    assert sqrtdenest(sqrt(5*r3 + 6*r2)) == \
+        r2*root(3, 4) + root(3, 4)**3
 
-    assert sqrtdenest(sqrt(((1 + sqrt(5) + sqrt(1 + sqrt(3)))**2).expand())) == \
-         1 + sqrt(5) + sqrt(1 + sqrt(3))
+    assert sqrtdenest(sqrt(((1 + r5 + sqrt(1 + r3))**2).expand())) == \
+         1 + r5 + sqrt(1 + r3)
 
     assert sqrtdenest(sqrt(((1 + r5 + r7 + sqrt(1 + r3))**2).expand())) == \
         1 + sqrt(1 + r3) + r5 + r7
@@ -39,63 +40,67 @@ def test_sqrtdenest2():
                 cos(3) + cos(2) + 1 + sqrt(1 + r3)
 
     assert sqrtdenest(sqrt(-2*sqrt(10) + 2*r2*sqrt(-2*sqrt(10) + 11) + 14)) == \
-        sqrt(-2*sqrt(10) - 2*sqrt(2) + 4*sqrt(5) + 14)
+        sqrt(-2*sqrt(10) - 2*r2 + 4*r5 + 14)
 
     # check that the result is not more complicated than the input
-    z= sqrt(-2*sqrt(29) + cos(2) + 2*sqrt(-10*sqrt(29) + 55) + 16)
+    z= sqrt(-2*r29 + cos(2) + 2*sqrt(-10*r29 + 55) + 16)
     assert sqrtdenest(z) == z
 
-    assert sqrtdenest(sqrt(sqrt(6) + sqrt(15))) == sqrt(sqrt(6) + sqrt(15))
+    assert sqrtdenest(sqrt(r6 + sqrt(15))) == sqrt(r6 + sqrt(15))
 
     # no assertion error when the 'r's are not the same in _denester
-    z = sqrt(15 - 2*sqrt(31) + 2*sqrt(55 - 10*sqrt(29)))
+    z = sqrt(15 - 2*sqrt(31) + 2*sqrt(55 - 10*r29))
     assert sqrtdenest(z) == z
 
     # currently cannot denest this; check one does not get a wrong answer
-    z = sqrt(8 - sqrt(2)*sqrt(5 - sqrt(5)) - 3*(1 + sqrt(5)))
+    z = sqrt(8 - r2*sqrt(5 - r5) - 3*(1 + r5))
     assert (sqrtdenest(z) - z).evalf() < 1.0e-100
 
 @XFAIL
 def test_sqrtdenest_fail():
     # when this doesn't fail, put the correct value at line 55
-    z = sqrt(8 - sqrt(2)*sqrt(5 - sqrt(5)) - 3*(1 + sqrt(5)))
+    z = sqrt(8 - r2*sqrt(5 - r5) - 3*(1 + r5))
     assert sqrtdenest(z) != z
 
 def test_sqrtdenest_four_terms():
-    assert sqrtdenest(sqrt(-4*sqrt(14) - 2*sqrt(6) + 4*sqrt(21) + 33)) == \
-      -sqrt(2) + sqrt(3) + 2*sqrt(7)
-    assert sqrtdenest(sqrt(468*sqrt(3) + 3024*r2 + 2912*r6 + 19735)) == \
-      9*sqrt(3) + 26 + 56*sqrt(6)
-    assert sqrtdenest(sqrt(-28*sqrt(7) - 14*sqrt(5) + 4*sqrt(35) + 82)) == \
-      -7 + sqrt(5) + 2*sqrt(7)
-    assert sqrtdenest(sqrt(6*sqrt(2)/11 + 2*sqrt(22)/11 + 6*sqrt(11)/11 + 2)) == \
-      sqrt(11)*(sqrt(2) + 3 + sqrt(11))/11
-    z = sqrt(-490*sqrt(3) - 98*sqrt(115) - 98*sqrt(345) - 2107)
-    assert sqrtdenest(z) == sqrt(-1)*(7*sqrt(5) + 7*sqrt(15) + 7*sqrt(23))
-    z = sqrt(-4*sqrt(14) - 2*sqrt(6) + 4*sqrt(21) + 34)
+    assert sqrtdenest(sqrt(-4*sqrt(14) - 2*r6 + 4*sqrt(21) + 33)) == \
+      -r2 + r3 + 2*r7
+    assert sqrtdenest(sqrt(468*r3 + 3024*r2 + 2912*r6 + 19735)) == \
+      9*r3 + 26 + 56*r6
+    assert sqrtdenest(sqrt(-28*r7 - 14*r5 + 4*sqrt(35) + 82)) == \
+      -7 + r5 + 2*r7
+    assert sqrtdenest(sqrt(6*r2/11 + 2*sqrt(22)/11 + 6*sqrt(11)/11 + 2)) == \
+      sqrt(11)*(r2 + 3 + sqrt(11))/11
+    z = sqrt(-490*r3 - 98*sqrt(115) - 98*sqrt(345) - 2107)
+    assert sqrtdenest(z) == sqrt(-1)*(7*r5 + 7*sqrt(15) + 7*sqrt(23))
+    z = sqrt(-4*sqrt(14) - 2*r6 + 4*sqrt(21) + 34)
     assert sqrtdenest(z) == z
     assert sqrtdenest(sqrt(-8*r2 - 2*r5 + 18)) == -sqrt(10) + 1 + r2 + r5
+    assert sqrtdenest(sqrt(8*r2 + 2*r5 - 18)) == sqrt(-1)*(-sqrt(10) + 1 + r2 + r5)
     assert sqrtdenest(sqrt(8*r2/3 + 14*r5/3 + S(154)/9)) == -sqrt(10)/3 + r2 + r5 + 3
+    assert sqrtdenest(sqrt(sqrt(2*r6 + 5) + sqrt(2*r7 + 8))) == \
+      sqrt(1 + r2 + r3 + r7)
+    assert _sqrt_four_terms_denest(sqrt(4*sqrt(15) + 8*r5 + 12*r3 + 24)) == \
+      1 + r3 + r5 + sqrt(15)
 
 def test_sqrtdenest3():
-    assert sqrtdenest(sqrt(13 - 2*sqrt(10) + 2*sqrt(2)*sqrt(-2*sqrt(10) + 11))) == \
-            -1 + sqrt(2) + sqrt(10)
-
-    n = sqrt(2*sqrt(6)/7 + 2*sqrt(7)/7 + 2*sqrt(42)/7 + 2)
-    d = sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))
+    z = sqrt(13 - 2*sqrt(10) + 2*r2*sqrt(-2*sqrt(10) + 11))
+    assert sqrtdenest(z) == -1 + r2 + sqrt(10)
+    assert sqrtdenest(z, max_iter=1) == sqrt(-2*sqrt(10) - 2*r2 + 4*r5 + 13)
+    n = sqrt(2*r6/7 + 2*r7/7 + 2*sqrt(42)/7 + 2)
+    d = sqrt(16 - 2*r29 + 2*sqrt(55 - 10*r29))
     assert sqrtdenest(n/d).equals(
-        r7*(1 + r6 + r7)/(7*(sqrt(-2*sqrt(29) + 11) + r5)))
-    z = sqrt(sqrt(sqrt(2) + 2) + 2)
+        r7*(1 + r6 + r7)/(7*(sqrt(-2*r29 + 11) + r5)))
+    z = sqrt(sqrt(r2 + 2) + 2)
     assert sqrtdenest(z) == z
     assert sqrtdenest(sqrt(-2*sqrt(10) + 4*r2*sqrt(-2*sqrt(10) + 11) + 20)) == \
-        sqrt(-2*sqrt(10) - 4*sqrt(2) + 8*sqrt(5) + 20)
+        sqrt(-2*sqrt(10) - 4*r2 + 8*r5 + 20)
     assert sqrtdenest(sqrt((112 + 70*r2) + (46 + 34*r2)*r5)) == \
-        sqrt(10) + 5 + 4*sqrt(2) + 3*sqrt(5)
+        sqrt(10) + 5 + 4*r2 + 3*r5
     z = sqrt(5 + sqrt(2*r6 + 5)*sqrt(-2*r29 + 2*sqrt(-10*r29 + 55) + 16))
     r = sqrt(-2*r29 + 11)
     assert sqrtdenest(z) == \
         sqrt(r2*r + r3*r + sqrt(10) + sqrt(15) + 5)
-
 
 def test_sqrt_symbolic_denest():
     x = Symbol('x')
@@ -111,11 +116,13 @@ def test_sqrt_symbolic_denest():
     c2 = c**2
     assert sqrtdenest(sqrt(2*sqrt(1 + r3)*c + c2 + 1 + r3*c2)) == \
         -1 - sqrt(1 + r3)*c
+    z = sqrt(20*sqrt(1 + r3)*sqrt(3 + 3*r3) + 12*r3*sqrt(1 + r3)*sqrt(3 + 3*r3) + 64*r3 + 112)
+    assert sqrtdenest(z) == z
 
 def test_issue_2758():
     from sympy.abc import x, y
-    z = sqrt(1/(4*sqrt(3) + 7) + 1)
-    ans = (sqrt(2) + sqrt(6))/(sqrt(3) + 2)
+    z = sqrt(1/(4*r3 + 7) + 1)
+    ans = (r2 + r6)/(r3 + 2)
     assert sqrtdenest(z) == ans
     assert sqrtdenest(1 + z) == 1 + ans
     assert sqrtdenest(Integral(z + 1, (x, 1, 2))) == Integral(1 + ans, (x, 1, 2))

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -81,6 +81,7 @@ def test_sqrtdenest_four_terms():
     assert sqrtdenest(sqrt(8*r2/3 + 14*r5/3 + S(154)/9)) == -sqrt(10)/3 + r2 + r5 + 3
     assert sqrtdenest(sqrt(sqrt(2*r6 + 5) + sqrt(2*r7 + 8))) == \
       sqrt(1 + r2 + r3 + r7)
+    assert _sqrt_four_terms_denest(S.One) == S.One
     assert _sqrt_four_terms_denest(sqrt(4*sqrt(15) + 8*r5 + 12*r3 + 24)) == \
       1 + r3 + r5 + sqrt(15)
 

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -16,13 +16,19 @@ def test_sqrtdenest():
 def test_sqrtdenest2():
     assert sqrtdenest(sqrt(16-2*sqrt(29)+2*sqrt(55-10*sqrt(29)))) == \
             sqrt(5) + sqrt(11-2*sqrt(29))
-    assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \
-            -1 + sqrt(2) + sqrt(10)
     assert sqrtdenest(sqrt(1+sqrt(1+sqrt(7)))) == sqrt(1+sqrt(1+sqrt(7)))
     assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+sqrt(2)+sqrt(5))))**2).expand())) == \
         1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
     assert sqrtdenest(sqrt(5*sqrt(3) + 6*sqrt(2))) == \
         sqrt(2)*3**Rational(1,4) + 3**Rational(3,4)
+
+    assert sqrtdenest(sqrt(((1+sqrt(5)+sqrt(1+sqrt(3)))**2).expand())) == \
+         1+sqrt(5)+sqrt(1+sqrt(3))
+
+@XFAIL
+def test_sqrtdenest2a():
+    assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \
+            -1 + sqrt(2) + sqrt(10)
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -42,7 +42,14 @@ def test_sqrtdenest2():
     z = sqrt(8 - sqrt(2)*sqrt(5-sqrt(5)) - 3*(1+sqrt(5)))
     assert (sqrtdenest(z) - z).evalf() < 1.0e-100
 
+    # check that the result is not more complicated than the input
     z= sqrt(-2*sqrt(29) + cos(2) + 2*sqrt(-10*sqrt(29) + 55) + 16)
+    assert sqrtdenest(z) == z
+
+    assert sqrtdenest(sqrt(sqrt(6) + sqrt(15))) == sqrt(sqrt(6) + sqrt(15))
+
+    # no assertion error when the 'r's are not the same in _denester
+    z = sqrt(15 - 2*sqrt(31) + 2*sqrt(55 - 10*sqrt(29)))
     assert sqrtdenest(z) == z
 
 @XFAIL

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -65,6 +65,8 @@ def test_sqrtdenest_four_terms():
     assert sqrtdenest(z) == sqrt(-1)*(7*sqrt(5)+7*sqrt(15)+7*sqrt(23))
     z = sqrt(-4*sqrt(14)-2*sqrt(6)+4*sqrt(21)+34)
     assert sqrtdenest(z) == z
+    assert sqrtdenest(sqrt(-8*r2-2*r5+18)) == -sqrt(10)+1+r2+r5
+    assert sqrtdenest(sqrt(8*r2/3+14*r5/3+S(154)/9)) == -sqrt(10)/3+r2+r5+3
 
 def test_sqrtdenest3():
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,4 +1,4 @@
-from sympy import sqrt, Rational, S, sqrtdenest, Integral, cos
+from sympy import sqrt, Rational, S, Symbol, sqrtdenest, Integral, cos
 from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
@@ -38,7 +38,7 @@ def test_sqrtdenest2():
     assert sqrtdenest(sqrt(-2*sqrt(10)+2*r2*sqrt(-2*sqrt(10)+11)+14)) == \
         sqrt(-2*sqrt(10)+2*r2*(-1+sqrt(10))+14)
 
-    # currencty cannot denest this; check one does not get a wrong answer
+    # currently cannot denest this; check one does not get a wrong answer
     z = sqrt(8 - sqrt(2)*sqrt(5-sqrt(5)) - 3*(1+sqrt(5)))
     assert (sqrtdenest(z) - z).evalf() < 1.0e-100
 
@@ -68,6 +68,13 @@ def test_sqrtdenest3():
     d = sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))
     assert (sqrtdenest(n/d) - \
       r7*(1+r6+r7)/(7*(sqrt(-2*sqrt(29)+ 11)+r5))).expand() == 0
+
+def test_sqrt_symbolic_denest():
+    x = Symbol('x')
+    z = sqrt( ((1 + sqrt(sqrt(2+x)+3))**2 ).expand())
+    assert sqrtdenest(z) == sqrt((1 + sqrt(sqrt(2+x)+3))**2)
+    z = sqrt( ((1 + sqrt(sqrt(2+cos(1))+3))**2 ).expand())
+    assert sqrtdenest(z) == 1 + sqrt(sqrt(2+cos(1))+3)
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -13,7 +13,8 @@ def test_sqrtdenest():
         sqrt(3+sqrt(5+2*sqrt(7))):
             3*sqrt(2)*(5 + 2*sqrt(7))**(S(1)/4)/(2*sqrt(6 + 3*sqrt(7))) +
             sqrt(2)*sqrt(6 + 3*sqrt(7))/(2*(5 + 2*sqrt(7))**(S(1)/4)),
-        sqrt(3+2*sqrt(3)): 3**(S(3)/4)*(sqrt(6)/2 + 3*sqrt(2)/2)/3}
+        sqrt(3+2*sqrt(3)): 3**(S(3)/4)*(sqrt(6)/2 + 3*sqrt(2)/2)/3,
+        sqrt(sqrt(5) + sqrt(14)): sqrt(sqrt(5) + sqrt(14))}
     for i in d:
         assert sqrtdenest(i) == d[i]
 

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -100,7 +100,7 @@ def test_sqrt_symbolic_denest():
     z= sqrt( ((1+sqrt(sqrt(2+cos(3*x))+3))**2+1).expand())
     assert sqrtdenest(z) == z
     assert sqrtdenest(sqrt(2*sqrt(1+r3)*cos(3)+cos(3)**2+1+r3*cos(3)**2)) == \
-      -1 - sqrt(1 + sqrt(3))*cos(3)
+        -1 - sqrt(1 + r3)*cos(3)
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -33,6 +33,9 @@ def test_sqrtdenest2():
     assert sqrtdenest(sqrt(((1+cos(2)+cos(3)+sqrt(1+r3))**2).expand())) == \
                 cos(3)+cos(2)+1+sqrt(1+r3)
 
+    assert sqrtdenest(sqrt(-2*sqrt(10)+2*r2*sqrt(-2*sqrt(10)+11)+14)) == \
+        sqrt(-2*sqrt(10)+2*r2*(-1+sqrt(10))+14)
+
 @XFAIL
 def test_sqrtdenest2a():
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -55,10 +55,16 @@ def test_sqrtdenest2():
 def test_sqrtdenest_four_terms():
     assert sqrtdenest(sqrt(-4*sqrt(14)-2*sqrt(6)+4*sqrt(21)+33)) == \
       -sqrt(2) + sqrt(3) + 2*sqrt(7)
+    assert sqrtdenest(sqrt(468*sqrt(3)+3024*r2+2912*r6+19735)) == \
+      9*sqrt(3) + 26 + 56*sqrt(6)
     assert sqrtdenest(sqrt(-28*sqrt(7)-14*sqrt(5)+4*sqrt(35) + 82)) == \
       -7 + sqrt(5) + 2*sqrt(7)
     assert sqrtdenest(sqrt(6*sqrt(2)/11+2*sqrt(22)/11+6*sqrt(11)/11+2)) == \
       sqrt(11)*(sqrt(2) + 3 + sqrt(11))/11
+    z = sqrt(-490*sqrt(3) - 98*sqrt(115) - 98*sqrt(345) - 2107)
+    assert sqrtdenest(z) == sqrt(-1)*(7*sqrt(5)+7*sqrt(15)+7*sqrt(23))
+    z = sqrt(-4*sqrt(14)-2*sqrt(6)+4*sqrt(21)+34)
+    assert sqrtdenest(z) == z
 
 def test_sqrtdenest3():
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,4 +1,4 @@
-from sympy import sqrt, Rational, sqrtdenest, Integral
+from sympy import sqrt, Rational, sqrtdenest, Integral, cos
 from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
@@ -29,6 +29,9 @@ def test_sqrtdenest2():
 
     assert sqrtdenest(sqrt(((1+r5+r7+sqrt(1+r3))**2).expand())) == \
         1+sqrt(1+r3)+r5+r7
+
+    assert sqrtdenest(sqrt(((1+cos(2)+cos(3)+sqrt(1+r3))**2).expand())) == \
+                cos(3)+cos(2)+1+sqrt(1+r3)
 
 @XFAIL
 def test_sqrtdenest2a():

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -11,35 +11,11 @@ def test_sqrtdenest():
             sqrt(6+3*sqrt(7))/(sqrt(2)*(5+2*sqrt(7))**Rational(1,4)) +
             3*(5+2*sqrt(7))**Rational(1,4)/(sqrt(2)*sqrt(6+3*sqrt(7))),
         sqrt(3+2*sqrt(3)): 3**Rational(1,4)/sqrt(2)+3/(sqrt(2)*3**Rational(1,4))}
-    for i in d:
-        assert sqrtdenest(i) == d[i] or denester([i])[0] == d[i]
-
-    # this test caused a pattern recognition failure in sqrtdenest
-    # nest = sqrt(2) + sqrt(5) - sqrt(7)
-    nest = symbols('nest')
-    x0, x1, x2, x3, x4, x5, x6 = symbols('x:7')
-    l = sqrt(2) + sqrt(5)
-    r = sqrt(7) + nest
-    s = (l**2 - r**2).expand() + nest**2 # == nest**2
-    ok = solve(nest**4 - s**2, nest)[1] # this will change if results order changes
-    assert abs((l - r).subs(nest, ok).n()) < 1e-12
-    x0 = sqrt(3)
-    x2 = root(45*I*x0 - 28, 3)
-    x3 = 19/x2
-    x4 = x2 + x3
-    x5 = -x4 - 14
-    x6 = sqrt(-x5)
-    ans = -x0*x6/3 + x0*sqrt(-x4 + 28 - 6*sqrt(210)*x6/x5)/3
-    assert expand_mul(radsimp(ok) - ans) == 0
-    # issue 2554
-    eq = sqrt(sqrt(sqrt(2) + 2) + 2)
-    assert sqrtdenest(eq) == eq
-
-# more complex example:
-@XFAIL # this fails on amd64
 def test_sqrtdenest2():
     assert sqrtdenest(sqrt(16-2*sqrt(29)+2*sqrt(55-10*sqrt(29)))) == \
             sqrt(5) + sqrt(11-2*sqrt(29))
+    assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \
+            -1 + sqrt(2) + sqrt(10)
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -2,7 +2,7 @@ from sympy import sqrt, Rational, S, sqrtdenest, Integral, cos
 from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
-r2, r3, r5, r7, r29 = sqrt(2), sqrt(3), sqrt(5), sqrt(7), sqrt(29)
+r2, r3, r5, r6, r7, r29 = sqrt(2), sqrt(3), sqrt(5), sqrt(6), sqrt(7), sqrt(29)
 
 def test_sqrtdenest():
     d = {sqrt(5 + 2 * sqrt(6)): sqrt(2) + sqrt(3),
@@ -60,10 +60,14 @@ def test_sqrtdenest_four_terms():
     assert sqrtdenest(sqrt(6*sqrt(2)/11+2*sqrt(22)/11+6*sqrt(11)/11+2)) == \
       sqrt(11)*(sqrt(2) + 3 + sqrt(11))/11
 
-@XFAIL
-def test_sqrtdenest2a():
+def test_sqrtdenest3():
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \
             -1 + sqrt(2) + sqrt(10)
+
+    n = sqrt(2*sqrt(6)/7 + 2*sqrt(7)/7 + 2*sqrt(42)/7 + 2)
+    d = sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))
+    assert (sqrtdenest(n/d) - \
+      r7*(1+r6+r7)/(7*(sqrt(-2*sqrt(29)+ 11)+r5))).expand() == 0
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -52,6 +52,12 @@ def test_sqrtdenest2():
     z = sqrt(15 - 2*sqrt(31) + 2*sqrt(55 - 10*sqrt(29)))
     assert sqrtdenest(z) == z
 
+def test_sqrtdenest_four_terms():
+    assert sqrtdenest(sqrt(-4*sqrt(14)-2*sqrt(6)+4*sqrt(21)+33)) == \
+      -sqrt(2) + sqrt(3) + 2*sqrt(7)
+    assert sqrtdenest(sqrt(-28*sqrt(7)-14*sqrt(5)+4*sqrt(35) + 82)) == \
+      -7 + sqrt(5) + 2*sqrt(7)
+
 @XFAIL
 def test_sqrtdenest2a():
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,5 +1,4 @@
-from sympy import sqrt, Rational, S, Symbol, sqrtdenest, Integral, cos
-from sympy.simplify.sqrtdenest import _denester
+from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos
 from sympy.utilities.pytest import XFAIL
 
 r2, r3, r5, r6, r7, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 29]]
@@ -9,8 +8,8 @@ def test_sqrtdenest():
         sqrt(5. + 2 * sqrt(6)): sqrt(5. + 2 * sqrt(6)),
         sqrt(5. + 4*sqrt(5 + 2 * sqrt(6))): sqrt(5.0 + 4*sqrt(2) + 4*sqrt(3)),
         sqrt(sqrt(2)): sqrt(sqrt(2)),
-        sqrt(5+sqrt(7)): sqrt(5+sqrt(7)),
-        sqrt(3+sqrt(5+2*sqrt(7))):
+        sqrt(5 + sqrt(7)): sqrt(5 + sqrt(7)),
+        sqrt(3 + sqrt(5 + 2*sqrt(7))):
             3*sqrt(2)*(5 + 2*sqrt(7))**(S(1)/4)/(2*sqrt(6 + 3*sqrt(7))) +
             sqrt(2)*sqrt(6 + 3*sqrt(7))/(2*(5 + 2*sqrt(7))**(S(1)/4)),
         sqrt(3+2*sqrt(3)): 3**(S(3)/4)*(sqrt(6)/2 + 3*sqrt(2)/2)/3,
@@ -19,31 +18,28 @@ def test_sqrtdenest():
         assert sqrtdenest(i) == d[i]
 
 def test_sqrtdenest2():
-    assert sqrtdenest(sqrt(16-2*sqrt(29)+2*sqrt(55-10*sqrt(29)))) == \
-            sqrt(5) + sqrt(11-2*sqrt(29))
-    assert sqrtdenest(sqrt(-r5+sqrt(-2*r29+2*sqrt(-10*r29+55)+16))) == \
-    (-2*sqrt(29) + 11)**Rational(1,4)
-    assert sqrtdenest(sqrt(1+sqrt(1+sqrt(7)))) == sqrt(1+sqrt(1+sqrt(7)))
-    assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+r2+r5)))**2).expand())) == \
+    assert sqrtdenest(sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))) == \
+            sqrt(5) + sqrt(11 - 2*sqrt(29))
+    assert sqrtdenest(sqrt(-r5 + sqrt(-2*r29 + 2*sqrt(-10*r29 + 55) + 16))) == \
+    root(-2*sqrt(29) + 11, 4)
+    r = sqrt(1 + sqrt(7))
+    assert sqrtdenest(sqrt(1 + r)) == sqrt(1 + r)
+    assert sqrtdenest(sqrt(((1 + sqrt(1 + 2*sqrt(3 + r2 + r5)))**2).expand())) == \
         1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
     assert sqrtdenest(sqrt(5*sqrt(3) + 6*sqrt(2))) == \
-        sqrt(2)*3**Rational(1,4) + 3**Rational(3,4)
+        sqrt(2)*root(3, 4) + root(3, 4)**3
 
-    assert sqrtdenest(sqrt(((1+sqrt(5)+sqrt(1+sqrt(3)))**2).expand())) == \
-         1+sqrt(5)+sqrt(1+sqrt(3))
+    assert sqrtdenest(sqrt(((1 + sqrt(5) + sqrt(1 + sqrt(3)))**2).expand())) == \
+         1 + sqrt(5) + sqrt(1 + sqrt(3))
 
-    assert sqrtdenest(sqrt(((1+r5+r7+sqrt(1+r3))**2).expand())) == \
-        1+sqrt(1+r3)+r5+r7
+    assert sqrtdenest(sqrt(((1 + r5 + r7 + sqrt(1 + r3))**2).expand())) == \
+        1 + sqrt(1 + r3) + r5 + r7
 
-    assert sqrtdenest(sqrt(((1+cos(2)+cos(3)+sqrt(1+r3))**2).expand())) == \
-                cos(3)+cos(2)+1+sqrt(1+r3)
+    assert sqrtdenest(sqrt(((1 + cos(2) + cos(3) + sqrt(1 + r3))**2).expand())) == \
+                cos(3) + cos(2) + 1 + sqrt(1 + r3)
 
-    assert sqrtdenest(sqrt(-2*sqrt(10)+2*r2*sqrt(-2*sqrt(10)+11)+14)) == \
+    assert sqrtdenest(sqrt(-2*sqrt(10) + 2*r2*sqrt(-2*sqrt(10) + 11) + 14)) == \
         sqrt(-2*sqrt(10) - 2*sqrt(2) + 4*sqrt(5) + 14)
-
-    # currently cannot denest this; check one does not get a wrong answer
-    z = sqrt(8 - sqrt(2)*sqrt(5-sqrt(5)) - 3*(1+sqrt(5)))
-    assert (sqrtdenest(z) - z).evalf() < 1.0e-100
 
     # check that the result is not more complicated than the input
     z= sqrt(-2*sqrt(29) + cos(2) + 2*sqrt(-10*sqrt(29) + 55) + 16)
@@ -55,53 +51,66 @@ def test_sqrtdenest2():
     z = sqrt(15 - 2*sqrt(31) + 2*sqrt(55 - 10*sqrt(29)))
     assert sqrtdenest(z) == z
 
+    # currently cannot denest this; check one does not get a wrong answer
+    z = sqrt(8 - sqrt(2)*sqrt(5 - sqrt(5)) - 3*(1 + sqrt(5)))
+    assert (sqrtdenest(z) - z).evalf() < 1.0e-100
+
+@XFAIL
+def test_sqrtdenest_fail():
+    # when this doesn't fail, put the correct value at line 55
+    z = sqrt(8 - sqrt(2)*sqrt(5 - sqrt(5)) - 3*(1 + sqrt(5)))
+    assert sqrtdenest(z) != z
+
 def test_sqrtdenest_four_terms():
-    assert sqrtdenest(sqrt(-4*sqrt(14)-2*sqrt(6)+4*sqrt(21)+33)) == \
+    assert sqrtdenest(sqrt(-4*sqrt(14) - 2*sqrt(6) + 4*sqrt(21) + 33)) == \
       -sqrt(2) + sqrt(3) + 2*sqrt(7)
-    assert sqrtdenest(sqrt(468*sqrt(3)+3024*r2+2912*r6+19735)) == \
+    assert sqrtdenest(sqrt(468*sqrt(3) + 3024*r2 + 2912*r6 + 19735)) == \
       9*sqrt(3) + 26 + 56*sqrt(6)
-    assert sqrtdenest(sqrt(-28*sqrt(7)-14*sqrt(5)+4*sqrt(35) + 82)) == \
+    assert sqrtdenest(sqrt(-28*sqrt(7) - 14*sqrt(5) + 4*sqrt(35) + 82)) == \
       -7 + sqrt(5) + 2*sqrt(7)
-    assert sqrtdenest(sqrt(6*sqrt(2)/11+2*sqrt(22)/11+6*sqrt(11)/11+2)) == \
+    assert sqrtdenest(sqrt(6*sqrt(2)/11 + 2*sqrt(22)/11 + 6*sqrt(11)/11 + 2)) == \
       sqrt(11)*(sqrt(2) + 3 + sqrt(11))/11
     z = sqrt(-490*sqrt(3) - 98*sqrt(115) - 98*sqrt(345) - 2107)
-    assert sqrtdenest(z) == sqrt(-1)*(7*sqrt(5)+7*sqrt(15)+7*sqrt(23))
-    z = sqrt(-4*sqrt(14)-2*sqrt(6)+4*sqrt(21)+34)
+    assert sqrtdenest(z) == sqrt(-1)*(7*sqrt(5) + 7*sqrt(15) + 7*sqrt(23))
+    z = sqrt(-4*sqrt(14) - 2*sqrt(6) + 4*sqrt(21) + 34)
     assert sqrtdenest(z) == z
-    assert sqrtdenest(sqrt(-8*r2-2*r5+18)) == -sqrt(10)+1+r2+r5
-    assert sqrtdenest(sqrt(8*r2/3+14*r5/3+S(154)/9)) == -sqrt(10)/3+r2+r5+3
+    assert sqrtdenest(sqrt(-8*r2 - 2*r5 + 18)) == -sqrt(10) + 1 + r2 + r5
+    assert sqrtdenest(sqrt(8*r2/3 + 14*r5/3 + S(154)/9)) == -sqrt(10)/3 + r2 + r5 + 3
 
 def test_sqrtdenest3():
-    assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \
+    assert sqrtdenest(sqrt(13 - 2*sqrt(10) + 2*sqrt(2)*sqrt(-2*sqrt(10) + 11))) == \
             -1 + sqrt(2) + sqrt(10)
 
     n = sqrt(2*sqrt(6)/7 + 2*sqrt(7)/7 + 2*sqrt(42)/7 + 2)
     d = sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))
-    assert (sqrtdenest(n/d) - \
-      r7*(1+r6+r7)/(7*(sqrt(-2*sqrt(29)+ 11)+r5))).expand() == 0
+    assert sqrtdenest(n/d).equals(
+        r7*(1 + r6 + r7)/(7*(sqrt(-2*sqrt(29) + 11) + r5)))
     z = sqrt(sqrt(sqrt(2) + 2) + 2)
     assert sqrtdenest(z) == z
-    assert sqrtdenest(sqrt(-2*sqrt(10)+4*r2*sqrt(-2*sqrt(10)+11)+20)) == \
-      sqrt(-2*sqrt(10) - 4*sqrt(2) + 8*sqrt(5) + 20)
-    assert sqrtdenest(sqrt((112+70*r2)+(46+34*r2)*r5)) == \
-      sqrt(10) + 5 + 4*sqrt(2) + 3*sqrt(5)
-    z = sqrt(5+sqrt(2*r6+5)*sqrt(-2*r29+2*sqrt(-10*r29+55)+16))
+    assert sqrtdenest(sqrt(-2*sqrt(10) + 4*r2*sqrt(-2*sqrt(10) + 11) + 20)) == \
+        sqrt(-2*sqrt(10) - 4*sqrt(2) + 8*sqrt(5) + 20)
+    assert sqrtdenest(sqrt((112 + 70*r2) + (46 + 34*r2)*r5)) == \
+        sqrt(10) + 5 + 4*sqrt(2) + 3*sqrt(5)
+    z = sqrt(5 + sqrt(2*r6 + 5)*sqrt(-2*r29 + 2*sqrt(-10*r29 + 55) + 16))
+    r = sqrt(-2*r29 + 11)
     assert sqrtdenest(z) == \
-      sqrt(r2*sqrt(-2*r29+11)+r3*sqrt(-2*r29+11)+sqrt(10)+sqrt(15)+5)
+        sqrt(r2*r + r3*r + sqrt(10) + sqrt(15) + 5)
 
 
 def test_sqrt_symbolic_denest():
     x = Symbol('x')
-    z = sqrt( ((1 + sqrt(sqrt(2+x)+3))**2 ).expand())
-    assert sqrtdenest(z) == sqrt((1 + sqrt(sqrt(2+x)+3))**2)
-    z = sqrt( ((1 + sqrt(sqrt(2+cos(1))+3))**2 ).expand())
-    assert sqrtdenest(z) == 1 + sqrt(sqrt(2+cos(1))+3)
+    z = sqrt(((1 + sqrt(sqrt(2 + x) + 3))**2).expand())
+    assert sqrtdenest(z) == sqrt((1 + sqrt(sqrt(2 + x) + 3))**2)
+    z = sqrt(((1 + sqrt(sqrt(2 + cos(1)) + 3))**2).expand())
+    assert sqrtdenest(z) == 1 + sqrt(sqrt(2 + cos(1)) + 3)
     z = ((1 + cos(2))**4 + 1).expand()
     assert sqrtdenest(z) == z
-    z= sqrt( ((1+sqrt(sqrt(2+cos(3*x))+3))**2+1).expand())
+    z= sqrt(((1 + sqrt(sqrt(2 + cos(3*x)) + 3))**2 + 1).expand())
     assert sqrtdenest(z) == z
-    assert sqrtdenest(sqrt(2*sqrt(1+r3)*cos(3)+cos(3)**2+1+r3*cos(3)**2)) == \
-        -1 - sqrt(1 + r3)*cos(3)
+    c = cos(3)
+    c2 = c**2
+    assert sqrtdenest(sqrt(2*sqrt(1 + r3)*c + c2 + 1 + r3*c2)) == \
+        -1 - sqrt(1 + r3)*c
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -42,6 +42,9 @@ def test_sqrtdenest2():
     z = sqrt(8 - sqrt(2)*sqrt(5-sqrt(5)) - 3*(1+sqrt(5)))
     assert (sqrtdenest(z) - z).evalf() < 1.0e-100
 
+    z= sqrt(-2*sqrt(29) + cos(2) + 2*sqrt(-10*sqrt(29) + 55) + 16)
+    assert sqrtdenest(z) == z
+
 @XFAIL
 def test_sqrtdenest2a():
     assert sqrtdenest(sqrt(13-2*sqrt(10)+2*sqrt(2)*sqrt(-2*sqrt(10)+11))) == \

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,6 +1,7 @@
 from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos
 from sympy.utilities.pytest import XFAIL
-from sympy.simplify.sqrtdenest import _sqrt_four_terms_denest
+from sympy.simplify.sqrtdenest import _sqrt_four_terms_denest, subsets
+from sympy.simplify.simplify import radsimp
 
 r2, r3, r5, r6, r7, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 29]]
 
@@ -65,7 +66,7 @@ def test_sqrtdenest_fail():
 def test_sqrtdenest_four_terms():
     assert sqrtdenest(sqrt(-4*sqrt(14) - 2*r6 + 4*sqrt(21) + 33)) == \
       -r2 + r3 + 2*r7
-    assert sqrtdenest(sqrt(468*r3 + 3024*r2 + 2912*r6 + 19735)) == \
+    assert radsimp(sqrtdenest(sqrt(468*r3 + 3024*r2 + 2912*r6 + 19735))) == \
       9*r3 + 26 + 56*r6
     assert sqrtdenest(sqrt(-28*r7 - 14*r5 + 4*sqrt(35) + 82)) == \
       -7 + r5 + 2*r7

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -2,6 +2,8 @@ from sympy import sqrt, Rational, sqrtdenest, Integral
 from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
+r2, r3, r5, r7 = sqrt(2), sqrt(3), sqrt(5), sqrt(7)
+
 def test_sqrtdenest():
     d = {sqrt(5 + 2 * sqrt(6)): sqrt(2) + sqrt(3),
         sqrt(sqrt(2)): sqrt(sqrt(2)),
@@ -24,6 +26,9 @@ def test_sqrtdenest2():
 
     assert sqrtdenest(sqrt(((1+sqrt(5)+sqrt(1+sqrt(3)))**2).expand())) == \
          1+sqrt(5)+sqrt(1+sqrt(3))
+
+    assert sqrtdenest(sqrt(((1+r5+r7+sqrt(1+r3))**2).expand())) == \
+        1+sqrt(1+r3)+r5+r7
 
 @XFAIL
 def test_sqrtdenest2a():

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,6 +1,5 @@
-from sympy import (cse, expand_mul, I, Integral, Rational, solve, sqrt,
-                   sqrtdenest, symbols, radsimp, root)
-from sympy.simplify.sqrtdenest import denester
+from sympy import sqrt, Rational, sqrtdenest, Integral
+from sympy.simplify.sqrtdenest import _denester
 from sympy.utilities.pytest import XFAIL
 
 def test_sqrtdenest():
@@ -11,6 +10,9 @@ def test_sqrtdenest():
             sqrt(6+3*sqrt(7))/(sqrt(2)*(5+2*sqrt(7))**Rational(1,4)) +
             3*(5+2*sqrt(7))**Rational(1,4)/(sqrt(2)*sqrt(6+3*sqrt(7))),
         sqrt(3+2*sqrt(3)): 3**Rational(1,4)/sqrt(2)+3/(sqrt(2)*3**Rational(1,4))}
+    for i in d:
+        assert sqrtdenest(i) == d[i] or _denester([i])[0] == d[i]
+
 def test_sqrtdenest2():
     assert sqrtdenest(sqrt(16-2*sqrt(29)+2*sqrt(55-10*sqrt(29)))) == \
             sqrt(5) + sqrt(11-2*sqrt(29))

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -76,6 +76,8 @@ def test_sqrtdenest3():
     d = sqrt(16 - 2*sqrt(29) + 2*sqrt(55 - 10*sqrt(29)))
     assert (sqrtdenest(n/d) - \
       r7*(1+r6+r7)/(7*(sqrt(-2*sqrt(29)+ 11)+r5))).expand() == 0
+    z = sqrt(sqrt(sqrt(2) + 2) + 2)
+    assert sqrtdenest(z) == z
 
 def test_sqrt_symbolic_denest():
     x = Symbol('x')
@@ -83,6 +85,10 @@ def test_sqrt_symbolic_denest():
     assert sqrtdenest(z) == sqrt((1 + sqrt(sqrt(2+x)+3))**2)
     z = sqrt( ((1 + sqrt(sqrt(2+cos(1))+3))**2 ).expand())
     assert sqrtdenest(z) == 1 + sqrt(sqrt(2+cos(1))+3)
+    z = ((1 + cos(2))**4 + 1).expand()
+    assert sqrtdenest(z) == z
+    z= sqrt( ((1+sqrt(sqrt(2+cos(3*x))+3))**2+1).expand())
+    assert sqrtdenest(z) == z
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -21,6 +21,8 @@ def test_sqrtdenest2():
     assert sqrtdenest(sqrt(1+sqrt(1+sqrt(7)))) == sqrt(1+sqrt(1+sqrt(7)))
     assert sqrtdenest(sqrt(((1+sqrt(1+2*sqrt(3+sqrt(2)+sqrt(5))))**2).expand())) == \
         1 + sqrt(1 + 2*sqrt(sqrt(2) + sqrt(5) + 3))
+    assert sqrtdenest(sqrt(5*sqrt(3) + 6*sqrt(2))) == \
+        sqrt(2)*3**Rational(1,4) + 3**Rational(3,4)
 
 def test_issue_2758():
     from sympy.abc import x, y

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -79,7 +79,9 @@ def test_sqrtdenest3():
     z = sqrt(sqrt(sqrt(2) + 2) + 2)
     assert sqrtdenest(z) == z
     assert sqrtdenest(sqrt(-2*sqrt(10)+4*r2*sqrt(-2*sqrt(10)+11)+20)) == \
-    sqrt(-2*r5-sqrt(10)+r2+10)+sqrt(-sqrt(10)-r2+2*r5+10)
+      sqrt(-2*r5-sqrt(10)+r2+10)+sqrt(-sqrt(10)-r2+2*r5+10)
+    assert sqrtdenest(sqrt((112+70*r2)+(46+34*r2)*r5)) == \
+      sqrt(10) + 5 + 4*sqrt(2) + 3*sqrt(5)
 
 
 def test_sqrt_symbolic_denest():


### PR DESCRIPTION
In master  on my computer `sqrtdenest` does not denest this example (appearing with XFAIL in test_sqrtdenest.py)

```
>>> sqrtdenest(sqrt(16-2*sqrt(29)+2*sqrt(55-10*sqrt(29))))
sqrt(-2*sqrt(29) + 2*sqrt(-10*sqrt(29) + 55) + 16)
```

The reason is that `expr.match(sqrt(a + b * sqrt(r)))` does
not guarantee that `sqrt(r)` contains the deepest sqrt; on my computer

```
>>> a, b, r = Wild('a'), Wild('b'), Wild('r')
>>> expr = sqrt(-2*sqrt(29) + 2*sqrt(-10*sqrt(29) + 55) + 16)
>>> expr.match(sqrt(a + b * sqrt(r)))
{r_: 29, b_: -2, a_: 2*sqrt(-10*sqrt(29) + 55) + 16}
```

I fixed this problem using `sqrt_depth` to find the depth of `sqrt` in an expression.

In this pull request `sqrtdenest`  denests arbitrary denestable square root of a constant and up to 
three square roots of rationals; it also denests some deeply nested radicals.
