### PR TITLE
[GCI 2011] Implemented dsolve speeding up in integrate().

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -889,7 +889,7 @@ def integrate(*args, **kwargs):
 
         for limit in limits:
             integrate_symbols.append(limit[0])
-            if len(limit) > 1: 
+            if len(limit) > 1:
                 is_indefinite = False
                 break
     

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -892,7 +892,7 @@ def integrate(*args, **kwargs):
             if len(limit) > 1:
                 is_indefinite = False
                 break
-    
+
     dsolve_hint = 'nth_linear_constant_coeff_undetermined_coefficients'
     if is_indefinite and len(symbols) == 1 and not expr.getO() \
             and dsolve_hint in classify_ode(f(*symbols).diff(*integrate_symbols) - expr, f(*symbols)):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -670,12 +670,3 @@ def test_integrate_series():
     assert diff(integrate(f, x), x) == f
 
     assert integrate(O(x**5), x) == O(x**6)
-
-def test_integrate_with_dsolve():
-    epsilon = 0.5
-    prepare = """from sympy import (symbols, Function, sin, exp, integrate); from sympy.solvers.ode import dsolve; x = symbols("x"); f = Function("f") """
-    integrate_time = Timer("integrate(x**2*exp(x)*sin(x), x)", prepare).timeit(10)
-    dsolve_time = Timer("dsolve(f(x).diff(x) - x**2*exp(x)*sin(x), f(x), hint='nth_linear_constant_coeff_undetermined_coefficients')", prepare).timeit(10)
-    
-    assert abs(integrate_time - dsolve_time) < epsilon
-

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -5,6 +5,8 @@ from sympy import (S, symbols, integrate, Integral, Derivative, exp, erf, oo, Sy
         terms_gcd)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.physics.units import m, s
+from sympy.solvers.ode import dsolve
+from timeit import Timer
 
 x,y,a,t,x_1,x_2,z = symbols('x,y,a,t,x_1,x_2,z')
 n = Symbol('n', integer=True)
@@ -668,3 +670,12 @@ def test_integrate_series():
     assert diff(integrate(f, x), x) == f
 
     assert integrate(O(x**5), x) == O(x**6)
+
+def test_integrate_with_dsolve():
+    epsilon = 0.5
+    prepare = """from sympy import (symbols, Function, sin, exp, integrate); from sympy.solvers.ode import dsolve; x = symbols("x"); f = Function("f") """
+    integrate_time = Timer("integrate(x**2*exp(x)*sin(x), x)", prepare).timeit(10)
+    dsolve_time = Timer("dsolve(f(x).diff(x) - x**2*exp(x)*sin(x), f(x), hint='nth_linear_constant_coeff_undetermined_coefficients')", prepare).timeit(10)
+    
+    assert abs(integrate_time - dsolve_time) < epsilon
+


### PR DESCRIPTION
- integrate() now uses ODE utilities to speed up computation of some
  integrals.
  - Documentation is updated accordingly.
  - New test has been added to the test_integrals.py, which checks
    whether new implementation computes as nearly quick as dsolve
    when possible.
