### PR TITLE
do no use posified symbols when checking solution

### DIFF
--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -427,7 +427,8 @@ def test_issue_1694():
     assert solve(Poly(sqrt(exp(x)) + sqrt(exp(-x)) - 4)) == \
             [2*log(-sqrt(3) + 2), 2*log(sqrt(3) + 2)]
     assert solve(Poly(exp(x) + exp(-x) - 4)) == [log(-sqrt(3) + 2), log(sqrt(3) + 2)]
-    assert solve(x**y + x**(2*y) - 1, x) == [(-S.Half + sqrt(5)/2)**(1/y), (-S.Half - sqrt(5)/2)**(1/y)]
+    assert solve(x**y + x**(2*y) - 1, x) == \
+        [(-S.Half + sqrt(5)/2)**(1/y), (-S.Half - sqrt(5)/2)**(1/y)]
 
     assert solve(exp(x/y)*exp(-z/y) - 2, y) == [(x - z)/log(2)]
     assert solve(x**z*y**z - 2, z) in [[log(2)/(log(x) + log(y))], [log(2)/(log(x*y))]]


### PR DESCRIPTION
When the solution is being checked to see if it satisfies the assumptions
    of the symbols used during the call to solve, the original symbols, not
    the posified one, should be in place during the check.

This problem arose in doing work with is_irrational. That work is not included here (and likely won't be at all) but the solve issue still is valid; I'm not sure of a good test for this now, however.
