### PR TITLE
GCI Work - Shuffling also functions

### DIFF
--- a/sympy/mpmath/tests/test_elliptic.py
+++ b/sympy/mpmath/tests/test_elliptic.py
@@ -34,6 +34,7 @@ jdn = ellipfun('dn')
 calculate_nome = lambda k: qfrom(k=k)
 
 def test_ellipfun():
+    mp.dps = 15
     assert ellipfun('ss', 0, 0) == 1
     assert ellipfun('cc', 0, 0) == 1
     assert ellipfun('dd', 0, 0) == 1

--- a/sympy/mpmath/tests/test_functions.py
+++ b/sympy/mpmath/tests/test_functions.py
@@ -393,6 +393,8 @@ def test_complex_functions():
             assert tanh(mpc(z)).ae(cmath.tanh(z))
 
 def test_complex_inverse_functions():
+    mp.dps = 15
+    iv.dps = 15
     for (z1, z2) in random_complexes(30):
         # apparently cmath uses a different branch, so we
         # can't use it for comparison

--- a/sympy/mpmath/tests/test_interval.py
+++ b/sympy/mpmath/tests/test_interval.py
@@ -379,6 +379,7 @@ def test_interval_nstr():
     assert iv.nstr(mpi('1e123', '1e129'), n, mode='diff') == '[1.0e+123, 1.0e+129]'
     exp = iv.exp
     assert iv.nstr(iv.exp(mpi('5000.1')), n, mode='diff') == '3.2797365856787867069110487[0926, 1191]e+2171'
+    iv.dps = 15
 
 def test_mpi_from_str():
     iv.dps = 15

--- a/sympy/mpmath/tests/test_interval.py
+++ b/sympy/mpmath/tests/test_interval.py
@@ -303,6 +303,8 @@ def test_interval_complex():
     assert iv.sin(2+3j).ae(mp.sin(2+3j))
 
 def test_interval_complex_arg():
+    mp.dps = 15
+    iv.dps = 15
     assert iv.arg(3) == 0
     assert iv.arg(0) == 0
     assert iv.arg([0,3]) == 0

--- a/sympy/mpmath/tests/test_linalg.py
+++ b/sympy/mpmath/tests/test_linalg.py
@@ -194,6 +194,8 @@ def test_precision():
     assert mnorm(inverse(inverse(A)) - A, 1) < 1.e-45
 
 def test_interval_matrix():
+    mp.dps = 15
+    iv.dps = 15
     a = iv.matrix([['0.1','0.3','1.0'],['7.1','5.5','4.8'],['3.2','4.4','5.6']])
     b = iv.matrix(['4','0.6','0.5'])
     c = iv.lu_solve(a, b)

--- a/sympy/mpmath/tests/test_power.py
+++ b/sympy/mpmath/tests/test_power.py
@@ -4,6 +4,7 @@ from sympy.mpmath.libmp import *
 import random
 
 def test_fractional_pow():
+    mp.dps = 15
     assert mpf(16) ** 2.5 == 1024
     assert mpf(64) ** 0.5 == 8
     assert mpf(64) ** -0.5 == 0.125

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -516,14 +516,14 @@ class SymPyTests(object):
         self._reporter.start(self._seed)
         for f in self._testfiles:
             try:
-                self.test_file(f)
+                self.test_file(f, sort)
             except KeyboardInterrupt:
                 print " interrupted by user"
                 self._reporter.finish()
                 raise
         return self._reporter.finish()
 
-    def test_file(self, filename):
+    def test_file(self, filename, sort=True):
         clear_cache()
         self._count += 1
         gl = {'__file__':filename}
@@ -572,6 +572,7 @@ class SymPyTests(object):
         if not funcs:
             return
         self._reporter.entering_filename(filename, len(funcs))
+        if not sort: random.shuffle(funcs)
         for f in funcs:
             self._reporter.entering_test(f)
             try:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -572,7 +572,8 @@ class SymPyTests(object):
         if not funcs:
             return
         self._reporter.entering_filename(filename, len(funcs))
-        if not sort: random.shuffle(funcs)
+        if not sort:
+            random.shuffle(funcs)
         for f in funcs:
             self._reporter.entering_test(f)
             try:


### PR DESCRIPTION
It now also shuffles functions inside a function, too. Apparently, no errors derive from it. Adding random.shuffle(funcs) and getting the sort option apparently did the trick.

GCI task: http://www.google-melange.com/gci/task/view/google/gci2011/7141264

Issue ticket: http://code.google.com/p/sympy/issues/detail?id=1594
