### PR TITLE
[GCI 2011] Corrected string giving method of Matrix class.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -535,27 +535,18 @@ class Matrix(object):
     def __hash__(self):
         return super(Matrix, self).__hash__()
 
-    def _format_str(self, strfunc, rowsep='\n'):
+    def _format_str(self, strfunc):
         # Handle zero dimensions:
         if self.rows == 0 or self.cols == 0:
-            return '[]'
-        # Build table of string representations of the elements
+            return 'Matrix(%s, %s)' % (self.rows, self.cols)
+        # Build table of the elements
         res = []
-        # Track per-column max lengths for pretty alignment
-        maxlen = [0] * self.cols
         for i in range(self.rows):
             res.append([])
             for j in range(self.cols):
-                string = strfunc(self[i,j])
-                res[-1].append(string)
-                maxlen[j] = max(len(string), maxlen[j])
-        # Patch strings together
-        for i, row in enumerate(res):
-            for j, elem in enumerate(row):
-                # Pad each element up to maxlen so the columns line up
-                row[j] = elem.rjust(maxlen[j])
-            res[i] = "[" + ", ".join(row) + "]"
-        return rowsep.join(res)
+                elem = self[i,j]
+                res[-1].append(elem)
+        return 'Matrix(%s)' % res
 
     def __str__(self):
         return sstr(self)

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -13,7 +13,7 @@ class LambdaPrinter(StrPrinter):
     """
 
     def _print_Matrix(self, expr):
-        return "Matrix([%s])"%expr._format_str(self._print, ",")
+        return expr._format_str(self._print)
 
     def _print_Piecewise(self, expr):
         from sympy.core.sets import Interval

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -12,7 +12,7 @@ def test_basic():
 
 def test_matrix():
     A = Matrix([[x,y],[y*x,z**2]])
-    assert lambdarepr(A)=="Matrix([[  x,    y],[x*y, z**2]])"
+    assert lambdarepr(A)=="Matrix([[x, y], [x*y, z**2]])"
 
 def test_piecewise():
     # In each case, test eval() the lambdarepr() to make sure there are a

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -144,11 +144,11 @@ def test_list():
 
 def test_Matrix():
     M = Matrix([[x**+1, 1], [y, x+y]])
-    assert str(M) == sstr(M) == "[x,     1]\n[y, x + y]"
+    assert str(M) == sstr(M) == "Matrix([[x, 1], [y, x + y]])"
     M = Matrix()
-    assert str(M) == sstr(M) == "[]"
+    assert str(M) == sstr(M) == "Matrix(0, 0)"
     M = Matrix(0, 1, lambda i, j: 0)
-    assert str(M) == sstr(M) == "[]"
+    assert str(M) == sstr(M) == "Matrix(0, 1)"
 
 def test_Mul():
     assert str(x/y) == "x/y"
@@ -340,7 +340,7 @@ def test_set():
 
 def test_SparseMatrix():
     M = SparseMatrix([[x**+1, 1], [y, x+y]])
-    assert str(M) == sstr(M) == "[x,     1]\n[y, x + y]"
+    assert str(M) == sstr(M) == "Matrix([[x, 1], [y, x + y]])"
 
 def test_Sum():
     assert str(summation(cos(3*z), (z, x, y))) == "Sum(cos(3*z), (z, x, y))"


### PR DESCRIPTION
For matrices with shapes (0, n) or (n, 0) I use "Matrix(0, n)" and "Matrix(n, 0)", respectively. I think this is more consistent than using "Matrix([[], [], [] ... ])" for one case and "Matrix(0, n)" for the other.

Concerns issue http://code.google.com/p/sympy/issues/detail?id=2865
