### PR TITLE
Import functions module into doc

### DIFF
--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -3,10 +3,19 @@ Functions Module
 
 .. module:: sympy.functions
 
+All functions support the methods documented below, inherited from
+:py:class:`sympy.core.function.Function`.
+
+.. autoclass:: sympy.core.function.Function
+   :noindex:
+   :members:
+
+
 Elementary
 ==========
 
-This module implements elementary functions, as well as functions like Abs, Max, etc.
+This module implements elementary functions, as well as functions like Abs,
+Max, etc.
 
 
 Abs
@@ -15,12 +24,25 @@ Abs
 Returns the absolute value of the argument.
 
 Examples::
+
     >>> from sympy.functions import Abs
     >>> Abs(-1)
     1
 
 .. autoclass:: sympy.functions.elementary.complexes.Abs
+   :members:
 
+acosh
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.acosh
+   :members:
+
+acoth
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.acoth
+   :members:
 
 arg
 ---
@@ -29,6 +51,7 @@ Returns the argument (in radians) of a complex number. For a real
 number, the argument is always 0.
 
 Examples::
+
     >>> from sympy.functions import arg
     >>> from sympy import I, sqrt
     >>> arg(2.0)
@@ -39,21 +62,41 @@ Examples::
     pi/4
 
 .. autoclass:: sympy.functions.elementary.complexes.arg
+   :members:
+
+asinh
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.asinh
+   :members:
+
+atanh
+-----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.atanh
+   :members:
+
+ceiling
+-------
+
+.. autoclass:: sympy.functions.elementary.integers.ceiling
+   :members:
 
 conjugate
 ---------
 
-Returns the 'complex conjugate <http://en.wikipedia.org/wiki/Complex_conjugation>'_
+Returns the `complex conjugate <http://en.wikipedia.org/wiki/Complex_conjugation>`_
 of an argument. In mathematics, the complex conjugate of a complex number is given
 by changing the sign of the imaginary part. Thus, the conjugate of the complex number
 
-    a + ib
+    :math:`a + ib`
 
 (where a and b are real numbers) is
 
-    a - ib
+    :math:`a - ib`
 
 Examples::
+
     >>> from sympy.functions import conjugate
     >>> from sympy import I
     >>> conjugate(2)
@@ -62,6 +105,56 @@ Examples::
     -I
 
 .. autoclass:: sympy.functions.elementary.complexes.conjugate
+   :members:
+
+cos
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.cos
+   :members:
+
+cosh
+----
+.. autoclass:: sympy.functions.elementary.hyperbolic.cosh
+   :members:
+
+coth
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.coth
+   :members:
+
+exp
+---
+
+.. autoclass:: sympy.functions.elementary.exponential.exp
+   :members:
+
+.. seealso:: classes :py:class:`sympy.functions.elementary.exponential.log`
+
+ExprCondPair
+------------
+
+.. autoclass:: sympy.functions.elementary.piecewise.ExprCondPair
+   :members:
+
+floor
+-----
+
+.. autoclass:: sympy.functions.elementary.integers.floor
+   :members:
+
+HyperbolicFunction
+------------------
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.HyperbolicFunction
+   :members:
+
+IdentityFunction
+----------------
+
+.. autoclass:: sympy.functions.elementary.miscellaneous.IdentityFunction
+   :members:
 
 im
 --
@@ -70,16 +163,31 @@ Returns the imaginary part of an expression.
 
 Examples::
 
+
     >>> from sympy.functions import im
     >>> from sympy import I
     >>> im(2+3*I)
     3
 
-.. autoclass: sympy.functions.elementary.re
+.. autoclass: sympy.functions.elementary.im
    :members:
 
 .. seealso::
-   re
+   :py:class:`sympy.functions.elementary.complexes.re`
+
+LambertW
+--------
+
+.. autoclass:: sympy.functions.elementary.exponential.LambertW
+   :members:
+
+log
+---
+
+.. autoclass:: sympy.functions.elementary.exponential.log
+   :members:
+
+.. seealso:: classes :py:class:`sympy.functions.elementary.exponential.exp`
 
 Min
 ---
@@ -87,6 +195,7 @@ Min
 Returns the minimum of two (comparable) expressions.
 
 Examples::
+
     >>> from sympy.functions import Min
     >>> Min(1,2)
     1
@@ -97,6 +206,7 @@ Examples::
 It is named Min and not min to avoid conflicts with the built-in function min.
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.Min
+   :members:
 
 
 Max
@@ -107,12 +217,20 @@ Returns the maximum of two (comparable) expressions
 It is named Max and not max to avoid conflicts with the built-in function max.
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.Max
+   :members:
 
+Piecewise
+---------
+
+.. autoclass:: sympy.functions.elementary.piecewise.Piecewise
+   :members:
+
+.. autofunction:: sympy.functions.elementary.piecewise.piecewise_fold
 
 re
 --
 
-Return the real part of an expression
+Return the real part of an expression.
 
 Examples::
 
@@ -124,6 +242,30 @@ Examples::
 .. autoclass:: sympy.functions.elementary.complexes.re
    :members:
 
+.. seealso::
+   :py:class:`sympy.functions.elementary.complexes.im`
+
+root
+----
+
+.. autofunction:: sympy.functions.elementary.miscellaneous.root
+
+RoundFunction
+-------------
+
+.. autoclass:: sympy.functions.elementary.integers.RoundFunction
+
+sin
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.sin
+   :members:
+
+sinh
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.sinh
+   :members:
 
 sqrt
 ----
@@ -136,12 +278,20 @@ Returns the square root of an expression. It is equivalent to raise to Rational(
     True
 
 .. autoclass:: sympy.functions.elementary.miscellaneous.sqrt
+   :members:
 
 
 sign
 ----
 
 .. autoclass:: sympy.functions.elementary.complexes.sign
+   :members:
+
+tanh
+----
+
+.. autoclass:: sympy.functions.elementary.hyperbolic.tanh
+   :members:
 
 
 Combinatorial
@@ -154,30 +304,35 @@ Binomial
 --------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.binomial
+   :members:
 
 
 Factorial
 ---------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.factorial
+   :members:
 
 
 FallingFactorial
 ----------------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.FallingFactorial
+   :members:
 
 
 MultiFactorial
 --------------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.MultiFactorial
+   :members:
 
 
 RisingFactorial
 ---------------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.RisingFactorial
+   :members:
 
 
 Special
@@ -186,30 +341,37 @@ Special
 DiracDelta
 ----------
 .. autoclass:: sympy.functions.special.delta_functions.DiracDelta
+   :members:
 
 Heaviside
 ---------
 .. autoclass:: sympy.functions.special.delta_functions.Heaviside
+   :members:
 
 gamma
 -----
 .. autoclass:: sympy.functions.special.gamma_functions.gamma
+   :members:
 
 loggamma
 --------
 .. autoclass:: sympy.functions.special.gamma_functions.loggamma
+   :members:
 
 polygamma
 ---------
 .. autoclass:: sympy.functions.special.gamma_functions.polygamma
+   :members:
 
 uppergamma
 ----------
 .. autoclass:: sympy.functions.special.gamma_functions.uppergamma
+   :members:
 
 lowergamma
 ----------
 .. autoclass:: sympy.functions.special.gamma_functions.lowergamma
+   :members:
 
 Bessel Type Functions
 ---------------------

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -63,6 +63,23 @@ Examples::
 
 .. autoclass:: sympy.functions.elementary.complexes.conjugate
 
+im
+--
+
+Returns the imaginary part of an expression.
+
+Examples::
+
+    >>> from sympy.functions import im
+    >>> from sympy import I
+    >>> im(2+3*I)
+    3
+
+.. autoclass: sympy.functions.elementary.re
+   :members:
+
+.. seealso::
+   re
 
 Min
 ---
@@ -98,12 +115,14 @@ re
 Return the real part of an expression
 
 Examples::
+
     >>> from sympy.functions import re
     >>> from sympy import I
     >>> re(2+3*I)
     2
 
 .. autoclass:: sympy.functions.elementary.complexes.re
+   :members:
 
 
 sqrt

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -32,10 +32,22 @@ Examples::
 .. autoclass:: sympy.functions.elementary.complexes.Abs
    :members:
 
+acos
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.acos
+   :members:
+
 acosh
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.acosh
+   :members:
+
+acot
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.acot
    :members:
 
 acoth
@@ -64,10 +76,31 @@ Examples::
 .. autoclass:: sympy.functions.elementary.complexes.arg
    :members:
 
+asin
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.asin
+   :members:
+
 asinh
 -----
 
 .. autoclass:: sympy.functions.elementary.hyperbolic.asinh
+   :members:
+
+atan
+----
+
+.. autoclass:: sympy.functions.elementary.trigonometric.atan
+   :members:
+
+atan2
+-----
+
+This function is like `atan`, but considers the sign of both arguments in
+order to correctly determine the quadrant of its result.
+
+.. autoclass:: sympy.functions.elementary.trigonometric.atan2
    :members:
 
 atanh
@@ -116,6 +149,12 @@ cos
 cosh
 ----
 .. autoclass:: sympy.functions.elementary.hyperbolic.cosh
+   :members:
+
+cot
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.cot
    :members:
 
 coth
@@ -287,6 +326,12 @@ sign
 .. autoclass:: sympy.functions.elementary.complexes.sign
    :members:
 
+tan
+---
+
+.. autoclass:: sympy.functions.elementary.trigonometric.tan
+   :members:
+
 tanh
 ----
 
@@ -299,18 +344,48 @@ Combinatorial
 
 This module implements various combinatorial functions.
 
+bell
+----
 
-Binomial
+.. autoclass:: sympy.functions.combinatorial.numbers.bell
+   :members:
+
+bernoulli
+---------
+
+.. autoclass:: sympy.functions.combinatorial.numbers.bernoulli
+   :members:
+
+binomial
 --------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.binomial
    :members:
 
+catalan
+-------
 
-Factorial
+.. autoclass:: sympy.functions.combinatorial.numbers.catalan
+   :members:
+
+
+euler
+-----
+
+.. autoclass:: sympy.functions.combinatorial.numbers.euler
+   :members:
+
+
+factorial
 ---------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.factorial
+   :members:
+
+factorial2 / double factorial
+-----------------------------
+
+.. autoclass:: sympy.functions.combinatorial.factorials.factorial2
    :members:
 
 
@@ -318,6 +393,25 @@ FallingFactorial
 ----------------
 
 .. autoclass:: sympy.functions.combinatorial.factorials.FallingFactorial
+   :members:
+
+fibonacci
+---------
+
+.. autoclass:: sympy.functions.combinatorial.numbers.fibonacci
+   :members:
+
+harmonic
+--------
+
+.. autoclass:: sympy.functions.combinatorial.numbers.harmonic
+   :members:
+
+
+lucas
+-----
+
+.. autoclass:: sympy.functions.combinatorial.numbers.lucas
    :members:
 
 

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -512,4 +512,80 @@ B-Splines
 Hypergeometric Functions
 ------------------------
 .. autoclass:: sympy.functions.special.hyper.hyper
+   :members:
+
 .. autoclass:: sympy.functions.special.hyper.meijerg
+   :members:
+
+Orthogonal Polynomials
+----------------------
+
+.. automodule:: sympy.functions.special.polynomials
+
+Chebyshev Polynomials
++++++++++++++++++++++
+
+.. autoclass:: sympy.functions.special.polynomials.chebyshevt
+   :members:
+
+.. autoclass:: sympy.functions.special.polynomials.chebyshevu
+   :members:
+
+.. autoclass:: sympy.functions.special.polynomials.chebyshevt_root
+   :members:
+
+.. autoclass:: sympy.functions.special.polynomials.chebyshevu_root
+   :members:
+
+Legendre Polynomials
+++++++++++++++++++++
+
+.. autoclass:: sympy.functions.special.polynomials.legendre
+   :members:
+
+.. autoclass:: sympy.functions.special.polynomials.assoc_legendre
+   :members:
+
+Hermite Polynomials
++++++++++++++++++++
+
+.. autoclass:: sympy.functions.special.polynomials.hermite
+   :members:
+
+Laguerre Polynomials
+++++++++++++++++++++
+
+.. autofunction:: sympy.functions.special.polynomials.laguerre_l
+
+Spherical Harmonics
+-------------------
+
+.. autofunction:: sympy.functions.special.spherical_harmonics.Plmcos
+
+.. autofunction:: sympy.functions.special.spherical_harmonics.Ylm
+
+.. autofunction:: sympy.functions.special.spherical_harmonics.Ylm_c
+
+.. autofunction:: sympy.functions.special.spherical_harmonics.Zlm
+
+Tensor Functions
+----------------
+
+.. autofunction:: sympy.functions.special.tensor_functions.Eijk
+
+.. autofunction:: sympy.functions.special.tensor_functions.eval_levicivita
+
+.. autoclass:: sympy.functions.special.tensor_functions.LeviCivita
+   :members:
+
+.. autoclass:: sympy.functions.special.tensor_functions.KroneckerDelta
+   :members:
+
+Zeta Functions
+--------------
+
+.. autoclass:: sympy.functions.special.zeta_functions.zeta
+   :members:
+
+.. autoclass:: sympy.functions.special.zeta_functions.dirichlet_eta
+   :members:

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -469,6 +469,10 @@ lowergamma
 
 Bessel Type Functions
 ---------------------
+
+.. autoclass:: sympy.functions.special.bessel.BesselBase
+   :members:
+
 .. autoclass:: sympy.functions.special.bessel.besselj
 .. autoclass:: sympy.functions.special.bessel.bessely
 .. autoclass:: sympy.functions.special.bessel.besseli
@@ -477,6 +481,8 @@ Bessel Type Functions
 .. autoclass:: sympy.functions.special.bessel.hankel2
 .. autoclass:: sympy.functions.special.bessel.jn
 .. autoclass:: sympy.functions.special.bessel.yn
+
+.. autofunction:: sympy.functions.special.bessel.jn_zeros
 
 Hypergeometric Functions
 ------------------------

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -442,6 +442,17 @@ Heaviside
 .. autoclass:: sympy.functions.special.delta_functions.Heaviside
    :members:
 
+beta
+----
+
+.. autofunction:: sympy.functions.special.gamma_functions.beta
+
+erf
+---
+
+.. autoclass:: sympy.functions.special.error_functions.erf
+   :members:
+
 gamma
 -----
 .. autoclass:: sympy.functions.special.gamma_functions.gamma
@@ -456,6 +467,14 @@ polygamma
 ---------
 .. autoclass:: sympy.functions.special.gamma_functions.polygamma
    :members:
+
+digamma
+-------
+.. autofunction:: sympy.functions.special.gamma_functions.digamma
+
+trigamma
+--------
+.. autofunction:: sympy.functions.special.gamma_functions.trigamma
 
 uppergamma
 ----------

--- a/doc/src/modules/functions.txt
+++ b/doc/src/modules/functions.txt
@@ -484,6 +484,12 @@ Bessel Type Functions
 
 .. autofunction:: sympy.functions.special.bessel.jn_zeros
 
+B-Splines
+---------
+
+.. autofunction:: sympy.functions.special.bsplines.bspline_basis
+.. autofunction:: sympy.functions.special.bsplines.bspline_basis_set
+
 Hypergeometric Functions
 ------------------------
 .. autoclass:: sympy.functions.special.hyper.hyper

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -250,6 +250,9 @@ class Function(Application, Expr):
 
     @property
     def is_commutative(self):
+        """
+        Returns whether the functon is commutative.
+        """
         if all(getattr(t, 'is_commutative') for t in self.args):
             return True
         else:
@@ -321,6 +324,9 @@ class Function(Application, Expr):
         return r
 
     def as_base_exp(self):
+        """
+        Returns the method as the 2-tuple (base, exponent).
+        """
         return self, S.One
 
     def _eval_aseries(self, n, args0, x, logx):
@@ -541,6 +547,9 @@ functions are not supported.')
         return self.func(*args)
 
     def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of the function.
+        """
         if self.nargs is not None:
             if isinstance(self.nargs, tuple):
                 nargs = self.nargs[-1]

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -32,6 +32,9 @@ class factorial(CombinatorialFunction):
        known and computes n! via prime factorization of special class
        of numbers, called here the 'Swing Numbers'.
 
+       Examples
+       ========
+
        >>> from sympy import Symbol, factorial
        >>> n = Symbol('n', integer=True)
 
@@ -153,12 +156,15 @@ class MultiFactorial(CombinatorialFunction):
 class factorial2(CombinatorialFunction):
     """The double factorial n!!, not to be confused with (n!)!
 
-    The double factorial is defined for integers >= -1 as
+    The double factorial is defined for integers >= -1 as:
                  ,
                 |  n*(n - 2)*(n - 4)* ... * 1    for n odd
         n!! =  -|  n*(n - 2)*(n - 4)* ... * 2    for n even
                 |  1                             for n = 0, -1
                  '
+
+    Examples
+    ========
 
     >>> from sympy import factorial2, var
     >>> var('n')
@@ -193,13 +199,16 @@ class factorial2(CombinatorialFunction):
 class RisingFactorial(CombinatorialFunction):
     """Rising factorial (also called Pochhammer symbol) is a double valued
        function arising in concrete mathematics, hypergeometric functions
-       and series expansions. It is defined by
+       and series expansions. It is defined by:
 
                    rf(x, k) = x * (x+1) * ... * (x + k-1)
 
        where 'x' can be arbitrary expression and 'k' is an integer. For
        more information check "Concrete mathematics" by Graham, pp. 66
        or visit http://mathworld.wolfram.com/RisingFactorial.html page.
+
+       Examples
+       ========
 
        >>> from sympy import rf
        >>> from sympy.abc import x
@@ -340,6 +349,9 @@ class binomial(CombinatorialFunction):
 
        For the sake of convenience for negative 'k' this function
        will return zero no matter what valued is the other argument.
+
+       Examples
+       ========
 
        >>> from sympy import Symbol, Rational, binomial
        >>> n = Symbol('n', integer=True)

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -156,7 +156,8 @@ class MultiFactorial(CombinatorialFunction):
 class factorial2(CombinatorialFunction):
     """The double factorial n!!, not to be confused with (n!)!
 
-    The double factorial is defined for integers >= -1 as:
+    The double factorial is defined for integers >= -1 as::
+
                  ,
                 |  n*(n - 2)*(n - 4)* ... * 1    for n odd
         n!! =  -|  n*(n - 2)*(n - 4)* ... * 2    for n even

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -38,9 +38,6 @@ class re(Function):
 
     @classmethod
     def eval(cls, arg):
-        """
-        Helper method for implementing this class.
-        """
         if arg is S.NaN:
             return S.NaN
         elif arg.is_real:
@@ -120,9 +117,6 @@ class im(Function):
 
     @classmethod
     def eval(cls, arg):
-        """
-        Helper method for implementing this class.
-        """
         if arg is S.NaN:
             return S.NaN
         elif arg.is_real:
@@ -155,6 +149,14 @@ class im(Function):
     def as_real_imag(self, deep=True):
         """
         Return the imaginary part with a zero real part.
+
+        Examples
+        ========
+
+        >>> from sympy.functions import im
+        >>> from sympy import I
+        >>> im(2 + 3*I).as_real_imag()
+        (3, 0)
         """
         return (self, S.Zero)
 
@@ -171,19 +173,21 @@ class im(Function):
 ###############################################################################
 
 class sign(Function):
-    """Returns the sign of an expression, that is:
+    """
+    Returns the sign of an expression, that is:
 
-       * 1 if expression is positive
-       * 0 if expression is equal to zero
-       * -1 if expression is negative
+    * 1 if expression is positive
+    * 0 if expression is equal to zero
+    * -1 if expression is negative
 
-       **Examples**
+    Examples
+    ========
 
-       >>> from sympy.functions import sign
-       >>> sign(-1)
-       -1
-       >>> sign(0)
-       0
+    >>> from sympy.functions import sign
+    >>> sign(-1)
+    -1
+    >>> sign(0)
+    0
 
     """
 
@@ -227,24 +231,26 @@ class sign(Function):
         return sage.sgn(self.args[0]._sage_())
 
 class Abs(Function):
-    """Return the absolute value of the argument.
+    """
+    Return the absolute value of the argument.
 
     This is an extension of the built-in function abs() to accept symbolic
     values.  If you pass a SymPy expression to the built-in abs(), it will
     pass it automatically to Abs().
 
     Examples
+    ========
 
-        >>> from sympy import Abs, Symbol, S
-        >>> Abs(-1)
-        1
-        >>> x = Symbol('x', real=True)
-        >>> Abs(-x)
-        Abs(x)
-        >>> Abs(x**2)
-        x**2
-        >>> abs(-x) # The Python built-in
-        Abs(x)
+    >>> from sympy import Abs, Symbol, S
+    >>> Abs(-1)
+    1
+    >>> x = Symbol('x', real=True)
+    >>> Abs(-x)
+    Abs(x)
+    >>> Abs(x**2)
+    x**2
+    >>> abs(-x) # The Python built-in
+    Abs(x)
 
     Note that the Python built-in will return either an Expr or int depending on
     the argument::
@@ -264,6 +270,17 @@ class Abs(Function):
     is_negative = False
 
     def fdiff(self, argindex=1):
+        """
+        Get the first derivative of the argument to Abs().
+
+        Examples
+        ========
+
+        >>> from sympy.abc import x
+        >>> from sympy.functions import Abs
+        >>> Abs(-x).fdiff()
+        sign(x)
+        """
         if argindex == 1:
             return sign(self.args[0])
         else:
@@ -349,12 +366,16 @@ class arg(Function):
                 Derivative(x, t, **{'evaluate': True})) / (x**2 + y**2)
 
 class conjugate(Function):
-    """Changes the sign of the imaginary part of a complex number.
+    """
+    Changes the sign of the imaginary part of a complex number.
 
-        >>> from sympy import conjugate, I
+    Examples
+    ========
 
-        >>> conjugate(1 + I)
-        1 - I
+    >>> from sympy import conjugate, I
+
+    >>> conjugate(1 + I)
+    1 - I
 
     """
 

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -38,6 +38,9 @@ class re(Function):
 
     @classmethod
     def eval(cls, arg):
+        """
+        Helper method for implementing this class.
+        """
         if arg is S.NaN:
             return S.NaN
         elif arg.is_real:
@@ -69,6 +72,9 @@ class re(Function):
         return self
 
     def as_real_imag(self, deep=True):
+        """
+        Returns the real number with a zero complex part.
+        """
         return (self, S.Zero)
 
     def _eval_expand_complex(self, deep=True, **hints):
@@ -81,26 +87,30 @@ class re(Function):
         return re(Derivative(self.args[0], x, **{'evaluate': True}))
 
 class im(Function):
-    """Returns imaginary part of expression. This function performs
-       only elementary analysis and so it will fail to decompose
-       properly more complicated expressions. If completely simplified
-       result is needed then use Basic.as_real_imag() or perform complex
-       expansion on instance of this function.
+    """
+    Returns imaginary part of expression. This function performs only
+    elementary analysis and so it will fail to decompose properly more
+    complicated expressions. If completely simplified result is needed then
+    use Basic.as_real_imag() or perform complex expansion on instance of
+    this function.
 
-       >>> from sympy import re, im, E, I
-       >>> from sympy.abc import x, y
+    Examples
+    ========
 
-       >>> im(2*E)
-       0
+    >>> from sympy import re, im, E, I
+    >>> from sympy.abc import x, y
 
-       >>> re(2*I + 17)
-       17
+    >>> im(2*E)
+    0
 
-       >>> im(x*I)
-       re(x)
+    >>> re(2*I + 17)
+    17
 
-       >>> im(re(x) + y)
-       im(y)
+    >>> im(x*I)
+    re(x)
+
+    >>> im(re(x) + y)
+    im(y)
 
     """
 
@@ -110,6 +120,9 @@ class im(Function):
 
     @classmethod
     def eval(cls, arg):
+        """
+        Helper method for implementing this class.
+        """
         if arg is S.NaN:
             return S.NaN
         elif arg.is_real:
@@ -140,6 +153,9 @@ class im(Function):
         return self
 
     def as_real_imag(self, deep=True):
+        """
+        Return the imaginary part with a zero real part.
+        """
         return (self, S.Zero)
 
     def _eval_expand_complex(self, deep=True, **hints):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -20,19 +20,40 @@ from sympy.ntheory import multiplicity, perfect_power
 # p.is_positive.]
 
 class exp(Function):
+    """
+    The exponential function, :math:`e^x`.
+    """
 
     nargs = 1
 
     def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of this function.
+        """
         if argindex == 1:
             return self
         else:
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse function of ``exp(x)``.
+        """
         return log
 
     def as_numer_denom(self):
+        """
+        Returns this with a positive exponent as a 2-tuple (a fraction).
+
+        Examples
+        ========
+        >>> from sympy.functions import exp
+        >>> from sympy.abc import x
+        >>> exp(-x).as_numer_denom()
+        (1, exp(x))
+        >>> exp(x).as_numer_denom()
+        (exp(x), 1)
+        """
         c, t = self.args[0].as_coeff_mul()
         if c.is_negative:
             return S.One, exp(-self.args[0])
@@ -108,15 +129,24 @@ class exp(Function):
 
     @property
     def base(self):
+        """
+        Returns the base of the exponential function.
+        """
         return S.Exp1
 
     @property
     def exp(self):
+        """
+        Returns the exponent of the function.
+        """
         return self.args[0]
 
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
+        """
+        Calculates the next term in the Taylor series expansion.
+        """
         if n<0: return S.Zero
         if n==0: return S.One
         x = sympify(x)
@@ -131,6 +161,24 @@ class exp(Function):
         return re_part + im_part*S.ImaginaryUnit
 
     def as_real_imag(self, deep=True, **hints):
+        """
+        Returns this function as a 2-tuple representing a complex number.
+
+        Examples
+        ========
+        >>> from sympy import I
+        >>> from sympy.abc import x
+        >>> from sympy.functions import exp
+        >>> exp(x).as_real_imag()
+        (exp(re(x))*cos(im(x)), exp(re(x))*sin(im(x)))
+        >>> exp(1).as_real_imag()
+        (E, 0)
+        >>> exp(I).as_real_imag()
+        (cos(1), sin(1))
+        >>> exp(1+I).as_real_imag()
+        (E*cos(1), E*sin(1))
+
+        """
         re, im = self.args[0].as_real_imag()
         if deep:
             re = re.expand(deep, **hints)
@@ -142,6 +190,9 @@ class exp(Function):
         return self.func(self.args[0].conjugate())
 
     def as_base_exp(self):
+        """
+        Returns the 2-tuple (base, exponent).
+        """
         return S.Exp1, Mul(*self.args)
 
     def _eval_subs(self, old, new):
@@ -280,10 +331,16 @@ class exp(Function):
         return sage.exp(self.args[0]._sage_())
 
 class log(Function):
+    """
+    The logarithmic function :math:`ln(x)` or :math:`log(x)`.
+    """
 
     nargs = (1,2)
 
     def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of the function.
+        """
         if argindex == 1:
             return 1/self.args[0]
             s = C.Dummy('x')
@@ -292,6 +349,9 @@ class log(Function):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse function, log(x) (or ln(x)).
+        """
         return exp
 
     @classmethod
@@ -354,11 +414,17 @@ class log(Function):
                         return -S.Pi * S.ImaginaryUnit * S.Half + cls(-coeff)
 
     def as_base_exp(self):
+        """
+        Returns this function in the form (base, exponent).
+        """
         return self, S.One
 
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms): # of log(1+x)
+        """
+        Returns the next term in the Taylor series expansion of log(1+x).
+        """
         from sympy import powsimp
         if n<0: return S.Zero
         x = sympify(x)
@@ -400,6 +466,24 @@ class log(Function):
         return self.func(arg)
 
     def as_real_imag(self, deep=True, **hints):
+        """
+        Returns this function as a complex coordinate.
+
+        Examples
+        ========
+        >>> from sympy import I
+        >>> from sympy.abc import x
+        >>> from sympy.functions import log
+        >>> log(x).as_real_imag()
+        (log(Abs(x)), arg(x))
+        >>> log(I).as_real_imag()
+        (0, pi/2)
+        >>> log(1+I).as_real_imag()
+        (log(sqrt(2)), pi/4)
+        >>> log(I*x).as_real_imag()
+        (log(Abs(I*x)), arg(I*x))
+
+        """
         if deep:
             abs = C.Abs(self.args[0].expand(deep, **hints))
             arg = C.arg(self.args[0].expand(deep, **hints))
@@ -508,6 +592,9 @@ class LambertW(Function):
         if x == S.Infinity: return S.Infinity
 
     def fdiff(self, argindex=1):
+        """
+        Return the first derivative of this function.
+        """
         if argindex == 1:
             x = self.args[0]
             return LambertW(x)/(x*(1+LambertW(x)))

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -12,19 +12,28 @@ class HyperbolicFunction(Function):
 
 class sinh(HyperbolicFunction):
     """
+    The hyperbolic sine function, :math:`\\frac{exp(x) - exp(-x)}{2}`.
+
     Usage
     =====
       sinh(x) -> Returns the hyperbolic sine of x
+
     """
     nargs = 1
 
     def fdiff(self, argindex=1):
+        """
+        Returns the first derivative of this function.
+        """
         if argindex == 1:
             return cosh(self.args[0])
         else:
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse of this function.
+        """
         return asinh
 
     @classmethod
@@ -72,6 +81,9 @@ class sinh(HyperbolicFunction):
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
+        """
+        Returns the next term in the Taylor series expansion.
+        """
         if n < 0 or n % 2 == 0:
             return S.Zero
         else:
@@ -87,6 +99,9 @@ class sinh(HyperbolicFunction):
         return self.func(self.args[0].conjugate())
 
     def as_real_imag(self, deep=True, **hints):
+        """
+        Returns this function as a complex coordinate.
+        """
         if self.args[0].is_real:
             if deep:
                 hints['complex'] = False
@@ -139,6 +154,8 @@ class sinh(HyperbolicFunction):
 
 class cosh(HyperbolicFunction):
     """
+    The hyperbolic cosine function, :math:`\\frac{exp(x) + exp(-x)}{2}`.
+
     Usage
     =====
       cosh(x) -> Returns the hyperbolic cosine of x
@@ -152,6 +169,9 @@ class cosh(HyperbolicFunction):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse of this function.
+        """
         return acosh
 
     @classmethod
@@ -265,6 +285,8 @@ class cosh(HyperbolicFunction):
 
 class tanh(HyperbolicFunction):
     """
+    The hyperbolic tangent function, :math:`\\frac{sinh(x)}{cosh(x)}`.
+
     Usage
     =====
       tanh(x) -> Returns the hyperbolic tangent of x
@@ -278,6 +300,9 @@ class tanh(HyperbolicFunction):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse of this function.
+        """
         return atanh
 
     @classmethod
@@ -394,6 +419,8 @@ class tanh(HyperbolicFunction):
 
 class coth(HyperbolicFunction):
     """
+    The hyperbolic tangent function, :math:`\\frac{cosh(x)}{sinh(x)}`.
+
     Usage
     =====
       coth(x) -> Returns the hyperbolic cotangent of x
@@ -407,6 +434,9 @@ class coth(HyperbolicFunction):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse of this function.
+        """
         return acoth
 
     @classmethod
@@ -519,6 +549,8 @@ class coth(HyperbolicFunction):
 
 class asinh(Function):
     """
+    The inverse hyperbolic sine function.
+
     Usage
     =====
       asinh(x) -> Returns the inverse hyperbolic sine of x
@@ -592,6 +624,8 @@ class asinh(Function):
 
 class acosh(Function):
     """
+    The inverse hyperbolic cosine function.
+
     Usage
     =====
       acosh(x) -> Returns the inverse hyperbolic cosine of x
@@ -696,6 +730,8 @@ class acosh(Function):
 
 class atanh(Function):
     """
+    The inverse hyperbolic tangent function.
+
     Usage
     =====
       atanh(x) -> Returns the inverse hyperbolic tangent of x
@@ -762,6 +798,8 @@ class atanh(Function):
 
 class acoth(Function):
     """
+    The inverse hyperbolic cotangent function.
+
     Usage
     =====
       acoth(x) -> Returns the inverse hyperbolic cotangent of x

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -9,6 +9,7 @@ from sympy.core.evalf import get_integer_part, PrecisionExhausted
 ###############################################################################
 
 class RoundFunction(Function):
+    """The base class for rounding functions."""
 
     nargs = 1
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -379,8 +379,6 @@ class Max(MinMaxBase, Application, Basic):
 
     Algorithm
 
-    .. Not a heading since Numpydoc does not display the text otherwise.
-
     The task can be considered as searching of supremums in the
     directed complete partial orders [1]_.
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -148,12 +148,15 @@ def root(arg, n):
     See also
     ========
 
-    L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
+        L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
 
-    * http://en.wikipedia.org/wiki/Square_root
-    * http://en.wikipedia.org/wiki/real_root
-    * http://en.wikipedia.org/wiki/Root_of_unity
-    * http://en.wikipedia.org/wiki/Principal_value
+        External Links
+        --------------
+
+        * http://en.wikipedia.org/wiki/Square_root
+        * http://en.wikipedia.org/wiki/real_root
+        * http://en.wikipedia.org/wiki/Root_of_unity
+        * http://en.wikipedia.org/wiki/Principal_value
 
     """
     n = sympify(n)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -11,7 +11,11 @@ from sympy.core.rules import Transform
 from sympy.ntheory.residue_ntheory import int_tested
 
 class IdentityFunction(Lambda):
-    """The identity function
+    """
+    The identity function
+
+    Examples
+    ========
 
     >>> from sympy import Id, Symbol
     >>> x = Symbol('x')
@@ -143,15 +147,14 @@ def root(arg, n):
 
     See also
     ========
-       L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
 
-       External links
-       --------------
+    L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
 
-       * http://en.wikipedia.org/wiki/Square_root
-       * http://en.wikipedia.org/wiki/real_root
-       * http://en.wikipedia.org/wiki/Root_of_unity
-       * http://en.wikipedia.org/wiki/Principal_value
+    * http://en.wikipedia.org/wiki/Square_root
+    * http://en.wikipedia.org/wiki/real_root
+    * http://en.wikipedia.org/wiki/Root_of_unity
+    * http://en.wikipedia.org/wiki/Principal_value
+
     """
     n = sympify(n)
     return C.Pow(arg, 1/n)
@@ -339,8 +342,8 @@ class Max(MinMaxBase, Application, Basic):
 
     Also, only comparable arguments are permitted.
 
-    Example
-    -------
+    Examples
+    ========
 
     >>> from sympy import Max, Symbol, oo
     >>> from sympy.abc import x, y
@@ -372,7 +375,9 @@ class Max(MinMaxBase, Application, Basic):
     oo
 
     Algorithm
-    ---------
+
+    .. Not a heading since Numpydoc does not display the text otherwise.
+
     The task can be considered as searching of supremums in the
     directed complete partial orders [1]_.
 
@@ -395,8 +400,8 @@ class Max(MinMaxBase, Application, Basic):
        - if A > B > C then A > C
        - if A==B then B can be removed
 
-    [1] http://en.wikipedia.org/wiki/Directed_complete_partial_order
-    [2] http://en.wikipedia.org/wiki/Lattice_(order)
+    .. [1] http://en.wikipedia.org/wiki/Directed_complete_partial_order
+    .. [2] http://en.wikipedia.org/wiki/Lattice_(order)
 
     See Also
     --------
@@ -425,8 +430,8 @@ class Min(MinMaxBase, Application, Basic):
     """
     Return, if possible, the minimum value of the list.
 
-    Example
-    -------
+    Examples
+    ========
 
     >>> from sympy import Min, Symbol, oo
     >>> from sympy.abc import x, y

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -61,7 +61,7 @@ class Piecewise(Function):
     """
     Represents a piecewise function.
 
-    Usage: .. XXX Not a heading since Numpydoc won't display it otherwise.
+    Usage:
 
       Piecewise( (expr,cond), (expr,cond), ... )
         - Each argument is a 2-tuple defining a expression and condition
@@ -318,4 +318,3 @@ def piecewise_fold(expr):
         if len(piecewise_args) > 1:
             return piecewise_fold(Piecewise(*new_args))
     return Piecewise(*new_args)
-

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -24,10 +24,16 @@ class ExprCondPair(Function):
 
     @property
     def expr(self):
+        """
+        Returns the expression of this pair.
+        """
         return self.args[0]
 
     @property
     def cond(self):
+        """
+        Returns the condition of this pair.
+        """
         if self.args[1] == ExprCondPair.true_sentinel:
             return True
         return self.args[1]
@@ -38,6 +44,9 @@ class ExprCondPair(Function):
 
     @property
     def free_symbols(self):
+        """
+        Return the free symbols of this pair.
+        """
         # Overload Basic.free_symbols because self.args[1] may contain non-Basic
         result = self.expr.free_symbols
         if hasattr(self.cond, 'free_symbols'):
@@ -52,8 +61,8 @@ class Piecewise(Function):
     """
     Represents a piecewise function.
 
-    Usage
-    =====
+    Usage: .. XXX Not a heading since Numpydoc won't display it otherwise.
+
       Piecewise( (expr,cond), (expr,cond), ... )
         - Each argument is a 2-tuple defining a expression and condition
         - The conds are evaluated in turn returning the first that is True.
@@ -65,6 +74,7 @@ class Piecewise(Function):
 
     Examples
     ========
+
       >>> from sympy import Piecewise, log
       >>> from sympy.abc import x
       >>> f = x**2
@@ -150,6 +160,9 @@ class Piecewise(Function):
         return None
 
     def doit(self, **hints):
+        """
+        Evaluate this piecewise function.
+        """
         newargs = []
         for e, c in self.args:
             if hints.get('deep', True):
@@ -278,6 +291,9 @@ def piecewise_fold(expr):
     """
     Takes an expression containing a piecewise function and returns the
     expression in piecewise form.
+
+    Examples
+    ========
 
     >>> from sympy import Piecewise, piecewise_fold
     >>> from sympy.abc import x

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -103,6 +103,8 @@ def _pi_coeff(arg, cycles=1):
 
 class sin(TrigonometricFunction):
     """
+    The sine function.
+
     Usage
     =====
       sin(x) -> Returns the sine of x (measured in radians)
@@ -146,6 +148,9 @@ class sin(TrigonometricFunction):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse of this function.
+        """
         return asin
 
     @classmethod
@@ -320,6 +325,8 @@ class sin(TrigonometricFunction):
 
 class cos(TrigonometricFunction):
     """
+    The cosine function.
+
     Usage
     =====
       cos(x) -> Returns the cosine of x (measured in radians)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -582,6 +582,9 @@ class tan(TrigonometricFunction):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Returns the inverse of this function.
+        """
         return atan
 
     @classmethod
@@ -760,6 +763,9 @@ class cot(TrigonometricFunction):
             raise ArgumentIndexError(self, argindex)
 
     def inverse(self, argindex=1):
+        """
+        Return the inverse of this function.
+        """
         return acot
 
     @classmethod

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -72,7 +72,8 @@ class besselj(BesselBase):
     .. math ::
         J_{-n}(z) = (-1)^n J_n(z).
 
-    **Examples**
+    Examples
+    ========
 
     Create a bessel function object:
 
@@ -97,7 +98,8 @@ class besselj(BesselBase):
     >>> b.argument
     z
 
-    **References**
+    References
+    ==========
 
     - Abramowitz, Milton; Stegun, Irene A., eds. (1965), "Chapter 9",
       Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical
@@ -144,7 +146,8 @@ class bessely(BesselBase):
     It is a solution to Bessel's equation, and linearly independent from
     :math:`J_\nu`.
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy import bessely, yn
     >>> from sympy.abc import z, n
@@ -154,7 +157,10 @@ class bessely(BesselBase):
     >>> b.rewrite(yn)
     sqrt(2)*sqrt(z)*yn(n - 1/2, z)/sqrt(pi)
 
-    **See also:** :class:`besselj`
+    See Also
+    ========
+
+    :class:`sympy.functions.special.bessel.besselj`
     """
 
     _a = S.One
@@ -191,14 +197,19 @@ class besseli(BesselBase):
 
     where :math:`J_\mu(z)` is the Bessel function of the first kind.
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy import besseli
     >>> from sympy.abc import z, n
     >>> besseli(n, z).diff(z)
     besseli(n - 1, z)/2 + besseli(n + 1, z)/2
 
-    **See also:** :class:`besselj`
+    See Also
+    ========
+
+    :class:`sympy.functions.special.bessel.besselj`
+
     """
 
     _a = -S.One
@@ -226,14 +237,19 @@ class besselk(BesselBase):
     It is a solution of the modified Bessel equation, and linearly independent
     from :math:`Y_\nu`.
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy import besselk
     >>> from sympy.abc import z, n
     >>> besselk(n, z).diff(z)
     -besselk(n - 1, z)/2 - besselk(n + 1, z)/2
 
-    **See also:** :class:`besselj`
+    See Also
+    ========
+
+    :class:`besselj`
+
     """
 
     _a = S.One
@@ -253,14 +269,19 @@ class hankel1(BesselBase):
 
     It is a solution to Bessel's equation.
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy import hankel1
     >>> from sympy.abc import z, n
     >>> hankel1(n, z).diff(z)
     hankel1(n - 1, z)/2 - hankel1(n + 1, z)/2
 
-    **See also:** :class:`besselj`
+    See Also
+    ========
+
+    :class:`besselj`
+
     """
 
     _a = S.One
@@ -281,14 +302,19 @@ class hankel2(BesselBase):
     It is a solution to Bessel's equation, and linearly independent from
     :math:`H_\nu^{(1)}`.
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy import hankel2
     >>> from sympy.abc import z, n
     >>> hankel2(n, z).diff(z)
     hankel2(n - 1, z)/2 - hankel2(n + 1, z)/2
 
-    **See also:** :class:`besselj`
+    See Also
+    ========
+
+    :class:`besselj`
+
     """
 
     _a = S.One
@@ -348,16 +374,17 @@ class jn(SphericalBesselBase):
 
     where :math:`J_\nu(z)` is the Bessel function of the first kind.
 
-    **Examples**
+    Examples
+    ========
 
-        >>> from sympy import Symbol, jn, sin, cos, expand_func
-        >>> z = Symbol("z")
-        >>> print jn(0, z).expand(func=True)
-        sin(z)/z
-        >>> jn(1, z).expand(func=True) == sin(z)/z**2 - cos(z)/z
-        True
-        >>> expand_func(jn(3, z))
-        (-6/z**2 + 15/z**4)*sin(z) + (1/z - 15/z**3)*cos(z)
+    >>> from sympy import Symbol, jn, sin, cos, expand_func
+    >>> z = Symbol("z")
+    >>> print jn(0, z).expand(func=True)
+    sin(z)/z
+    >>> jn(1, z).expand(func=True) == sin(z)/z**2 - cos(z)/z
+    True
+    >>> expand_func(jn(3, z))
+    (-6/z**2 + 15/z**4)*sin(z) + (1/z - 15/z**3)*cos(z)
 
     The spherical Bessel functions of integral order
     are calculated using the formula:
@@ -367,7 +394,11 @@ class jn(SphericalBesselBase):
     where the coefficients :math:`f_n(z)` are available as
     :func:`polys.orthopolys.spherical_bessel_fn`.
 
-    **See also:** :class:`besselj`
+    See Also
+    ========
+
+    :class:`besselj`
+
     """
 
     def _rewrite(self):
@@ -393,20 +424,25 @@ class yn(SphericalBesselBase):
 
     where :math:`Y_\nu(z)` is the Bessel function of the second kind.
 
-    **Examples**
+    Examples
+    ========
 
-        >>> from sympy import Symbol, yn, sin, cos, expand_func
-        >>> z = Symbol("z")
-        >>> print expand_func(yn(0, z))
-        -cos(z)/z
-        >>> expand_func(yn(1, z)) == -cos(z)/z**2-sin(z)/z
-        True
+    >>> from sympy import Symbol, yn, sin, cos, expand_func
+    >>> z = Symbol("z")
+    >>> print expand_func(yn(0, z))
+    -cos(z)/z
+    >>> expand_func(yn(1, z)) == -cos(z)/z**2-sin(z)/z
+    True
 
     For integral orders :math:`n`, :math:`y_n` is calculated using the formula:
 
     .. math:: y_n(z) = (-1)^{n+1} j_{-n-1}(z)
 
-    **See also:** :class:`besselj`, :class:`bessely`, :class:`jn`
+    See Also
+    ========
+
+    :class:`besselj`, :class:`bessely`, :class:`jn`
+
     """
 
     def _rewrite(self):
@@ -428,19 +464,20 @@ def jn_zeros(n, k, method="sympy", dps=15):
 
     This returns an array of zeros of jn up to the k-th zero.
 
-    method = "sympy": uses mpmath besseljzero
-    method = "scipy": uses the SciPy's sph_jn and newton to find all roots,
-            which is faster than computing the zeros using a general numerical
-            solver, but it requires SciPy and only
-            works with low precision floating point numbers.
-            [the function used with method="sympy" is a recent addition to
-             mpmath, before that a general solver was used]
+    * method = "sympy": uses mpmath besseljzero
+    * method = "scipy": uses the SciPy's sph_jn and newton to find all
+      roots, which is faster than computing the zeros using a general
+      numerical solver, but it requires SciPy and only works with low
+      precision floating point numbers.  [the function used with
+      method="sympy" is a recent addition to mpmath, before that a general
+      solver was used]
 
-    **Examples**
+    Examples
+    ========
 
-        >>> from sympy import jn_zeros
-        >>> jn_zeros(2, 4, dps=5)
-        [5.7635, 9.095, 12.323, 15.515]
+    >>> from sympy import jn_zeros
+    >>> jn_zeros(2, 4, dps=5)
+    [5.7635, 9.095, 12.323, 15.515]
 
     """
     from math import pi

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -65,7 +65,11 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> f = lambdify(x, b0)
         >>> y = f(0.5)
 
+    References
+    ==========
+
     [1] http://en.wikipedia.org/wiki/B-spline
+
     """
     knots = [sympify(k) for k in knots]
     d = int(d)
@@ -113,13 +117,17 @@ def bspline_basis_set(d, knots, x):
     len(knots)-d-1 B-splines of degree d for the given knots. This function
     calls bspline_basis(d, knots, n, x) for different values of n.
 
-        >>> from sympy import bspline_basis_set
-        >>> from sympy.abc import x
-        >>> d = 2
-        >>> knots = range(5)
-        >>> splines = bspline_basis_set(d, knots, x)
-        >>> splines
-        [Piecewise((x**2/2, [0, 1)), (-x**2 + 3*x - 3/2, [1, 2)), (x**2/2 - 3*x + 9/2, [2, 3]), (0, True)), Piecewise((x**2/2 - x + 1/2, [1, 2)), (-x**2 + 5*x - 11/2, [2, 3)), (x**2/2 - 4*x + 8, [3, 4]), (0, True))]
+    Examples
+    ========
+
+    >>> from sympy import bspline_basis_set
+    >>> from sympy.abc import x
+    >>> d = 2
+    >>> knots = range(5)
+    >>> splines = bspline_basis_set(d, knots, x)
+    >>> splines
+    [Piecewise((x**2/2, [0, 1)), (-x**2 + 3*x - 3/2, [1, 2)), (x**2/2 - 3*x + 9/2, [2, 3]), (0, True)), Piecewise((x**2/2 - x + 1/2, [1, 2)), (-x**2 + 5*x - 11/2, [2, 3)), (x**2/2 - 4*x + 8, [3, 4]), (0, True))]
+
     """
     n_splines = len(knots)-d-1
     return [bspline_basis(d, knots, i, x) for i in range(n_splines)]

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -160,18 +160,18 @@ class Heaviside(Function):
         integrate(DiracDelta(x),(x,-oo,oo)) = 1
 
     and since DiracDelta is a symmetric function,
-    `integrate(DiracDelta(x),(x,0,oo))` should be 1/2 in fact, that is what
+    ``integrate(DiracDelta(x),(x,0,oo))`` should be 1/2 in fact, that is what
     maple returns.
 
-    If we take `Heaviside(0)=1/2`, we would have
-    `integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0)=1-1/2= 1/2`
+    If we take ``Heaviside(0)=1/2``, we would have
+    ``integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0)=1-1/2= 1/2``
     and
-    `integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo)=1/2-0= 1/2`
+    ``integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo)=1/2-0= 1/2``
 
     If we consider, instead `Heaviside(0)=1`, we would have
-    `integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0) = 0`
+    ``integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0) = 0``
     and
-    `integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo) = 1`
+    ``integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo) = 1``
 
 
     For more information, see:

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -154,7 +154,7 @@ class Heaviside(Function):
     .. [*] Regarding to the value at 0, Mathematica defines ``H(0)=1``,
            but Maple uses ``H(0)=undefined``
 
-    I think is better to have H(0)=1/2, due to the following:
+    I think is better to have H(0)=1/2, due to the following::
 
         integrate(DiracDelta(x),x) = Heaviside(x)
         integrate(DiracDelta(x),(x,-oo,oo)) = 1
@@ -168,7 +168,7 @@ class Heaviside(Function):
     and
     ``integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo)=1/2-0= 1/2``
 
-    If we consider, instead `Heaviside(0)=1`, we would have
+    If we consider, instead ``Heaviside(0)=1``, we would have
     ``integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0) = 0``
     and
     ``integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo) = 1``
@@ -198,4 +198,3 @@ class Heaviside(Function):
             return S.Half
         elif arg.is_positive:
             return S.One
-

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -6,7 +6,8 @@ from sympy.polys.polyerrors import PolynomialError
 ################################ DELTA FUNCTION ###############################
 ###############################################################################
 class DiracDelta(Function):
-    """**DiracDelta function and its derivatives**
+    """
+    The DiracDelta function and its derivatives.
 
     DiracDelta function has the following properties:
 
@@ -63,7 +64,7 @@ class DiracDelta(Function):
            - a symbol
 
            Examples
-           --------
+           ========
 
            >>> from sympy import DiracDelta
            >>> from sympy.abc import x, y
@@ -111,7 +112,7 @@ class DiracDelta(Function):
            - a symbol
 
            Examples
-           --------
+           ========
 
            >>> from sympy import DiracDelta, cos
            >>> from sympy.abc import x, y
@@ -141,39 +142,41 @@ class DiracDelta(Function):
 ###############################################################################
 
 class Heaviside(Function):
-    """**Heaviside Piecewise function**
+    """Heaviside Piecewise function
 
-    Heaviside function has the following properties:
+    Heaviside function has the following properties [*]_:
 
     1) ``diff(Heaviside(x),x) = DiracDelta(x)``
                         ``( 0, if x < 0``
     2) ``Heaviside(x) = < [*]  1/2 if x==0``
                         ``( 1, if x>0``
 
-    [*] Regarding to the value at 0, Mathematica defines ``H(0)=1``,
-    but Maple uses ``H(0)=undefined``
+    .. [*] Regarding to the value at 0, Mathematica defines ``H(0)=1``,
+           but Maple uses ``H(0)=undefined``
 
     I think is better to have H(0)=1/2, due to the following:
-    integrate(DiracDelta(x),x) = Heaviside(x)
-    integrate(DiracDelta(x),(x,-oo,oo)) = 1
+
+        integrate(DiracDelta(x),x) = Heaviside(x)
+        integrate(DiracDelta(x),(x,-oo,oo)) = 1
 
     and since DiracDelta is a symmetric function,
-    integrate(DiracDelta(x),(x,0,oo)) should be 1/2
-    in fact, that is what maple returns.
+    `integrate(DiracDelta(x),(x,0,oo))` should be 1/2 in fact, that is what
+    maple returns.
 
-    If we take Heaviside(0)=1/2, we would have
-    integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0)=1-1/2= 1/2
+    If we take `Heaviside(0)=1/2`, we would have
+    `integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0)=1-1/2= 1/2`
     and
-    integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo)=1/2-0= 1/2
+    `integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo)=1/2-0= 1/2`
 
-    If we consider, instead Heaviside(0)=1, we would have
-    integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0) = 0
+    If we consider, instead `Heaviside(0)=1`, we would have
+    `integrate(DiracDelta(x),(x,0,oo)) = Heaviside(oo)-Heaviside(0) = 0`
     and
-    integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo) = 1
+    `integrate(DiracDelta(x),(x,-oo,0)) = Heaviside(0)-Heaviside(-oo) = 1`
 
 
     For more information, see:
     http://mathworld.wolfram.com/HeavisideStepFunction.html
+
     """
     nargs = 1
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -7,6 +7,30 @@ from sympy.functions.elementary.miscellaneous import sqrt
 ###############################################################################
 
 class erf(Function):
+    """
+    The Gauss error function.
+
+    This function is defined as:
+
+    :math:`\\mathrm{erf}(x)=\\frac{2}{\\sqrt{\\pi}} \\int_0^x e^{-t^2} \\, \\mathrm{d}x`
+
+    Or, in ASCII::
+
+                x
+            /
+           |
+           |     2
+           |   -t
+        2* |  e    dt
+           |
+          /
+          0
+        -------------
+              ____
+            \/ pi
+
+
+    """
 
     nargs = 1
 

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -482,7 +482,7 @@ def beta(x, y):
     """
     Euler Beta function
 
-    `beta(x, y) == gamma(x)*gamma(y) / gamma(x+y)`
+    ``beta(x, y) == gamma(x)*gamma(y) / gamma(x+y)``
 
     """
     return gamma(x)*gamma(y) / gamma(x+y)

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -15,7 +15,7 @@ from sympy.functions.combinatorial.factorials import rf
 class gamma(Function):
     """The gamma function returns a function which passes through the integral
     values of the factorial function, i.e. though defined in the complex plane,
-    when n is an integer, gamma(n) = (n - 1)!
+    when n is an integer, `gamma(n) = (n - 1)!`
 
     Reference:
         http://en.wikipedia.org/wiki/Gamma_function
@@ -101,7 +101,7 @@ class gamma(Function):
 
 class lowergamma(Function):
     r"""
-    Lower incomplete gamma function
+    The lower incomplete gamma function.
 
     It can be defined as the meromorphic continuation of
 
@@ -115,9 +115,15 @@ class lowergamma(Function):
 
     where :math:`{}_1F_1` is the (confluent) hypergeometric function.
 
-    **See also:** :class:`gamma`, :class:`uppergamma`, :class:`hyper`.
+    See Also
+    ========
 
-    **Examples**
+    :class:`sympy.functions.special.gamma_functions.gamma`
+    :class:`sympy.functions.special.gamma_functions.uppergamma`
+    :class:`sympy.functions.special.hyper.hyper`
+
+    Examples
+    ========
 
     >>> from sympy import lowergamma, S
     >>> from sympy.abc import s, x
@@ -128,12 +134,14 @@ class lowergamma(Function):
     >>> lowergamma(-S(1)/2, x)
     -2*sqrt(pi)*erf(sqrt(x)) - 2*exp(-x)/sqrt(x)
 
-    **References**
+    References
+    ==========
 
     - Abramowitz, Milton; Stegun, Irene A., eds. (1965), Chapter 6, Section 5,
       Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical
       Tables
     - http://en.wikipedia.org/wiki/Incomplete_gamma_function
+
     """
 
     nargs = 2
@@ -199,7 +207,8 @@ class uppergamma(Function):
 
     where :math:`{}_1F_1` is the (confluent) hypergeometric function.
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy import uppergamma, S
     >>> from sympy.abc import s, x
@@ -210,14 +219,21 @@ class uppergamma(Function):
     >>> uppergamma(-S(1)/2, x)
     -2*sqrt(pi)*(-erf(sqrt(x)) + 1) + 2*exp(-x)/sqrt(x)
 
-    **See also:** :class:`gamma`, :class:`lowergamma`, :class:`hyper`.
+    See Also
+    ========
 
-    **References**
+    :class:`sympy.functions.special.gamma_functions.gamma`
+    :class:`sympy.functions.special.gamma_functions.lowergamma`
+    :class:`sympy.functions.special.hyper.hyper`.
+
+    References
+    ==========
 
     - Abramowitz, Milton; Stegun, Irene A., eds. (1965), Chapter 6, Section 5,
       Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical
       Tables
     - http://en.wikipedia.org/wiki/Incomplete_gamma_function
+
     """
 
     nargs = 2
@@ -278,7 +294,7 @@ class uppergamma(Function):
 ###############################################################################
 
 class polygamma(Function):
-    """The function polygamma(n, z) returns log(gamma(z)).diff(n + 1)
+    """The function `polygamma(n, z)` returns `log(gamma(z)).diff(n + 1)`
 
     Reference:
         http://en.wikipedia.org/wiki/Polygamma_function
@@ -405,6 +421,15 @@ class polygamma(Function):
         return (-1)**(n+1)*C.factorial(n)*zeta(n+1, z-1)
 
 class loggamma(Function):
+    """
+    The loggamma function is `ln(gamma(x))`.
+
+    References
+    ==========
+
+    http://mathworld.wolfram.com/LogGammaFunction.html
+
+    """
 
     nargs = 1
 
@@ -436,14 +461,29 @@ class loggamma(Function):
             raise ArgumentIndexError(self, argindex)
 
 def digamma(x):
+    """
+    The digamma function is the logarithmic derivative of the gamma function.
+
+    In this case, `digamma(x) = polygamma(0, x)`.
+
+    """
     return polygamma(0, x)
 
 def trigamma(x):
+    """
+    The trigamma function is the second of the polygamma functions.
+
+    In this case, `trigamma(x) = polygamma(1, x)`.
+
+    """
     return polygamma(1, x)
 
 def beta(x, y):
-    """ Euler Beta function
-    beta(x, y) == gamma(x)*gamma(y) / gamma(x+y)
+    """
+    Euler Beta function
+
+    `beta(x, y) == gamma(x)*gamma(y) / gamma(x+y)`
+
     """
     return gamma(x)*gamma(y) / gamma(x+y)
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -75,7 +75,8 @@ class hyper(TupleParametersBase):
     parameters actually yield a well-defined function.
 
 
-    **Examples**
+    Examples
+    ========
 
     The parameters :math:`a_p` and :math:`b_q` can be passed as arbitrary
     iterables, for example:
@@ -136,11 +137,13 @@ class hyper(TupleParametersBase):
     >>> hyperexpand(hyper([-a], [], x))
     (-x + 1)**a
 
-    See Also:
+    See Also
+    ========
 
     - :func:`sympy.simplify.hyperexpand`
 
-    **References**
+    References
+    ==========
 
     - Luke, Y. L. (1969), The Special Functions and Their Approximations,
       Volume 1
@@ -298,7 +301,8 @@ class meijerg(TupleParametersBase):
     convergence conditions.
 
 
-    **Examples**
+    Examples
+    ========
 
     You can pass the parameters either as four separate vectors:
 
@@ -365,15 +369,18 @@ class meijerg(TupleParametersBase):
     >>> hyperexpand(meijerg([[],[]], [[S(1)/2],[0]], (x/2)**2))
     sin(x)/sqrt(pi)
 
-    See Also:
+    See Also
+    ========
 
     - :func:`sympy.simplify.hyperexpand`
 
-    **References**
+    References
+    ==========
 
     - Luke, Y. L. (1969), The Special Functions and Their Approximations,
       Volume 1
     - http://en.wikipedia.org/wiki/Meijer_G-function
+
     """
 
     nargs = 3

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -240,22 +240,25 @@ class hermite(PolynomialSequence):
     hermite(n, x) gives the nth Hermite polynomial in x, H_n(x)
 
     The Hermite polynomials are orthogonal on (-oo, oo) with respect to
-    the weight exp(-x**2/2).
+    the weight `exp(-x**2/2)`.
 
     Examples
     ========
-        >>> from sympy import hermite
-        >>> from sympy.abc import x
-        >>> hermite(0, x)
-        1
-        >>> hermite(1, x)
-        2*x
-        >>> hermite(2, x)
-        4*x**2 - 2
+
+    >>> from sympy import hermite
+    >>> from sympy.abc import x
+    >>> hermite(0, x)
+    1
+    >>> hermite(1, x)
+    2*x
+    >>> hermite(2, x)
+    4*x**2 - 2
 
     References
     ==========
+
     * http://mathworld.wolfram.com/HermitePolynomial.html
+
     """
 
     _ortho_poly = staticmethod(hermite_poly)
@@ -264,14 +267,18 @@ def laguerre_l(n, alpha, x):
     """
     Returns the generalized Laguerre polynomial.
 
-    ``n`` : ``int``
+    Parameters
+    ==========
+
+    n : int
         Degree of Laguerre polynomial. Must be ``n >= 0``.
 
-    ``alpha`` : ``Expr``
+    alpha : Expr
         Arbitrary expression. For ``alpha=0`` regular Laguerre
         polynomials will be generated.
 
-    **Examples**
+    Examples
+    ========
 
     To construct generalized Laguerre polynomials issue::
 

--- a/sympy/functions/special/polynomials.py
+++ b/sympy/functions/special/polynomials.py
@@ -47,17 +47,19 @@ class chebyshevt(PolynomialSequence):
 
     Examples
     ========
-        >>> from sympy import chebyshevt
-        >>> from sympy.abc import x
-        >>> chebyshevt(0, x)
-        1
-        >>> chebyshevt(1, x)
-        x
-        >>> chebyshevt(2, x)
-        2*x**2 - 1
+
+    >>> from sympy import chebyshevt
+    >>> from sympy.abc import x
+    >>> chebyshevt(0, x)
+    1
+    >>> chebyshevt(1, x)
+    x
+    >>> chebyshevt(2, x)
+    2*x**2 - 1
 
     References
     ==========
+
     * http://en.wikipedia.org/wiki/Chebyshev_polynomial
     """
 
@@ -77,14 +79,15 @@ class chebyshevu(PolynomialSequence):
 
     Examples
     ========
-        >>> from sympy import chebyshevu
-        >>> from sympy.abc import x
-        >>> chebyshevu(0, x)
-        1
-        >>> chebyshevu(1, x)
-        2*x
-        >>> chebyshevu(2, x)
-        4*x**2 - 1
+
+    >>> from sympy import chebyshevu
+    >>> from sympy.abc import x
+    >>> chebyshevu(0, x)
+    1
+    >>> chebyshevu(1, x)
+    2*x
+    >>> chebyshevu(2, x)
+    4*x**2 - 1
 
     """
 
@@ -124,11 +127,11 @@ class chebyshevu_root(Function):
     Examples
     ========
 
-        >>> from sympy import chebyshevu, chebyshevu_root
-        >>> chebyshevu_root(3, 2)
-        -sqrt(2)/2
-        >>> chebyshevu(3, chebyshevu_root(3, 2))
-        0
+    >>> from sympy import chebyshevu, chebyshevu_root
+    >>> chebyshevu_root(3, 2)
+    -sqrt(2)/2
+    >>> chebyshevu(3, chebyshevu_root(3, 2))
+    0
 
     """
 
@@ -154,18 +157,21 @@ class legendre(PolynomialSequence):
 
     Examples
     ========
-        >>> from sympy import legendre
-        >>> from sympy.abc import x
-        >>> legendre(0, x)
-        1
-        >>> legendre(1, x)
-        x
-        >>> legendre(2, x)
-        3*x**2/2 - 1/2
+
+    >>> from sympy import legendre
+    >>> from sympy.abc import x
+    >>> legendre(0, x)
+    1
+    >>> legendre(1, x)
+    x
+    >>> legendre(2, x)
+    3*x**2/2 - 1/2
 
     References
     ==========
+
     * http://en.wikipedia.org/wiki/Legendre_polynomial
+
     """
 
     _ortho_poly = staticmethod(legendre_poly)
@@ -185,18 +191,21 @@ class assoc_legendre(Function):
 
     Examples
     ========
-        >>> from sympy import assoc_legendre
-        >>> from sympy.abc import x
-        >>> assoc_legendre(0,0, x)
-        1
-        >>> assoc_legendre(1,0, x)
-        x
-        >>> assoc_legendre(1,1, x)
-        -sqrt(-x**2 + 1)
+
+    >>> from sympy import assoc_legendre
+    >>> from sympy.abc import x
+    >>> assoc_legendre(0,0, x)
+    1
+    >>> assoc_legendre(1,0, x)
+    x
+    >>> assoc_legendre(1,1, x)
+    -sqrt(-x**2 + 1)
 
     References
     ==========
+
     * http://en.wikipedia.org/wiki/Associated_Legendre_polynomials
+
     """
 
     nargs = 3

--- a/sympy/functions/special/spherical_harmonics.py
+++ b/sympy/functions/special/spherical_harmonics.py
@@ -9,6 +9,9 @@ Plm= assoc_legendre
 _x = Dummy("x")
 
 def Plmcos(l, m, th):
+    """
+    Plm(cos(th)).
+    """
     l = sympify(l)
     m = sympify(m)
     sin = C.sin
@@ -23,16 +26,17 @@ def Ylm(l, m, theta, phi):
     """
     Spherical harmonics Ylm.
 
-    Examples:
+    Examples
+    ========
 
-        >>> from sympy import symbols, Ylm
-        >>> theta, phi = symbols("theta phi")
-        >>> Ylm(0, 0, theta, phi)
-        1/(2*sqrt(pi))
-        >>> Ylm(1, -1, theta, phi)
-        sqrt(6)*exp(-I*phi)*sin(theta)/(4*sqrt(pi))
-        >>> Ylm(1, 0, theta, phi)
-        sqrt(3)*cos(theta)/(2*sqrt(pi))
+    >>> from sympy import symbols, Ylm
+    >>> theta, phi = symbols("theta phi")
+    >>> Ylm(0, 0, theta, phi)
+    1/(2*sqrt(pi))
+    >>> Ylm(1, -1, theta, phi)
+    sqrt(6)*exp(-I*phi)*sin(theta)/(4*sqrt(pi))
+    >>> Ylm(1, 0, theta, phi)
+    sqrt(3)*cos(theta)/(2*sqrt(pi))
 
     """
     l, m, theta, phi = [sympify(x) for x in (l, m, theta, phi)]

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -31,6 +31,9 @@ class LeviCivita(Function):
 
     Thus it represents an alternating pseudotensor.
 
+    Examples
+    ========
+
     >>> from sympy import LeviCivita, symbols
     >>> LeviCivita(1,2,3)
     1
@@ -43,6 +46,7 @@ class LeviCivita(Function):
     LeviCivita(i, j, k)
     >>> LeviCivita(i,j,i)
     0
+
     """
     @classmethod
     def eval(cls, *args):
@@ -62,6 +66,7 @@ class KroneckerDelta(Function):
 
     Parameters
     ==========
+
     i : Number, Symbol
         The first index of the delta function.
     j : Number, Symbol
@@ -105,6 +110,9 @@ class KroneckerDelta(Function):
         """
         Evaluates the discrete delta function.
 
+        Examples
+        ========
+
         >>> from sympy import symbols
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> i, j, k = symbols('i,j,k')
@@ -142,6 +150,9 @@ class KroneckerDelta(Function):
         """
         True if Delta can be non-zero above fermi
 
+        Examples
+        ========
+
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol
         >>> a = Symbol('a',above_fermi=True)
@@ -166,6 +177,9 @@ class KroneckerDelta(Function):
     def is_below_fermi(self):
         """
         True if Delta can be non-zero below fermi
+
+        Examples
+        ========
 
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol
@@ -192,6 +206,9 @@ class KroneckerDelta(Function):
         """
         True if Delta is restricted to above fermi
 
+        Examples
+        ========
+
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol
         >>> a = Symbol('a',above_fermi=True)
@@ -215,6 +232,9 @@ class KroneckerDelta(Function):
     def is_only_below_fermi(self):
         """
         True if Delta is restricted to below fermi
+
+        Examples
+        ========
 
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol
@@ -240,7 +260,8 @@ class KroneckerDelta(Function):
         """
         Returns True if indices are either both above or below fermi.
 
-        Example:
+        Examples
+        ========
 
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol
@@ -276,6 +297,9 @@ class KroneckerDelta(Function):
         level.  If indices contain same information, 'a' is preferred before
         'b'.
 
+        Examples
+        ========
+
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol
         >>> a = Symbol('a',above_fermi=True)
@@ -303,6 +327,9 @@ class KroneckerDelta(Function):
         The index to substitute is the index with less information regarding fermi
         level.  If indices contain same information, 'a' is preferred before
         'b'.
+
+        Examples
+        ========
 
         >>> from sympy.functions.special.tensor_functions import KroneckerDelta
         >>> from sympy import Symbol

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -5,6 +5,9 @@ from sympy.core import Function, S, C, sympify, pi
 ###############################################################################
 
 class zeta(Function):
+    """
+    The Riemann zeta function, :math:`\\zeta(s)`.
+    """
 
     nargs = (1, 2)
 


### PR DESCRIPTION
Imported all public members in `sympy.functions` into the Sphinx doc, and fixed some errors/warmings.

Caveat: Any part of a docstring that falls under a heading that Numpydoc does not recognize may not show up in the documentation. I did not change the headings in order to avoid changing the original formatting.

Modules:
- sympy.functions
  - bessel
  - bsplines
  - delta_functions
  - error_functions
  - gamma_functions
  - hyper
  - polynomials
  - spherical_harmonics
  - tensor_functions
  - zeta_functions
- sympy.core.function.Function

I have run `doctest`: `tests finished: 1442 passed, in 35.03 seconds`

This is a task for Google Code-In: http://www.google-melange.com/gci/task/view/google/gci2011/7122304
