### PR TITLE
[GCI 2011] Refactor and fix pyflakes errors in sympy.solvers.

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -1,11 +1,11 @@
 """Tools for solving inequalities and systems of inequalities. """
 
-from sympy.core import Symbol, Interval, Union
+from sympy.core import Symbol, Interval
 from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.core.singleton import S
 from sympy.assumptions import ask, AppliedPredicate, Q
 from sympy.functions import re, im, Abs
-from sympy.logic import And, Or
+from sympy.logic import And
 from sympy.polys import Poly
 
 def interval_evalf(interval):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -205,17 +205,17 @@ anything is broken, one of those tests will surely fail.
 """
 from collections import defaultdict
 
-from sympy.core import Add, Basic, C, S, Mul, Pow, oo
-from sympy.core.compatibility import iterable, cmp_to_key, is_sequence, set_union, SymPyDeprecationWarning
-from sympy.core.function import Derivative, Function, AppliedUndef, diff, expand_mul
+from sympy.core import Add, C, S, Mul, Pow, oo
+from sympy.core.compatibility import iterable, is_sequence, set_union, SymPyDeprecationWarning
+from sympy.core.function import Derivative, AppliedUndef, diff, expand_mul
 from sympy.core.multidimensional import vectorize
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, Dummy
 from sympy.core.sympify import sympify
 
-from sympy.functions import cos, exp, im, log, re, sin, tan, sign, sqrt
+from sympy.functions import cos, exp, im, log, re, sin, tan, sqrt
 from sympy.matrices import wronskian
-from sympy.polys import Poly, RootOf, terms_gcd
+from sympy.polys import Poly, RootOf
 from sympy.series import Order
 from sympy.simplify import collect, logcombine, powsimp, separatevars, \
     simplify, trigsimp

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -13,19 +13,18 @@
 
 from sympy.core.compatibility import iterable, is_sequence, SymPyDeprecationWarning
 from sympy.core.sympify import sympify
-from sympy.core import C, S, Mul, Add, Pow, Symbol, Wild, Equality, Dummy, Basic, Expr
+from sympy.core import C, S, Add, Symbol, Wild, Equality, Dummy, Basic
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
-        Derivative, Function, AppliedUndef, UndefinedFunction, count_ops,
-        nfloat)
+                          Derivative, AppliedUndef, UndefinedFunction, nfloat)
 from sympy.core.numbers import ilcm, Float
 from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or
 
-from sympy.functions import (log, exp, LambertW, cos, sin, tan, cot,
-                             cosh, sinh, tanh, coth, acos, asin, atan, acot,
-                             acosh, asinh, atanh, acoth, sqrt, Abs)
-from sympy.simplify import (simplify, collect, powsimp, fraction, posify,
-                            powdenest, nsimplify)
+from sympy.functions import (log, exp, LambertW, cos, sin, tan, cot, cosh,
+                             sinh, tanh, coth, acos, asin, atan, acot, acosh,
+                             asinh, atanh, acoth, Abs)
+from sympy.simplify import (simplify, collect, powsimp, posify, powdenest,
+                            nsimplify)
 from sympy.matrices import Matrix, zeros
 from sympy.polys import roots, cancel, Poly, together, factor
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
@@ -548,7 +547,6 @@ def solve(f, *symbols, **flags):
     # with Dummy symbols or functions
     symbols_new = []
     symbol_swapped = False
-    symbols_passed = list(symbols)
     funcs = []
     for i, s in enumerate(symbols):
         if s.is_Symbol:
@@ -1068,12 +1066,12 @@ def _solve_system(exprs, symbols, **flags):
                 result = [dict(zip(solved_syms, r)) for r in result]
 
                 checked = []
-                warn = flags.get('warn', False)
+                warning = flags.get('warn', False)
                 for r in result:
                     check = checksol(polys, r, **flags)
                     if check is not False:
-                        if check is None and warn:
-                            print("\n\tWarning: could not verify solution %s." % sol)
+                        if check is None and warning:
+                            print("\n\tWarning: could not verify solution %s." % result)
                         if not dens or not checksol(dens, r, **flags): # if it's a solution to any denom then exclude
                             checked.append(r)
                 result = checked
@@ -1122,7 +1120,6 @@ def _solve_system(exprs, symbols, **flags):
                     # result in the new result list; use copy since the
                     # solution for s in being added in-place
                     if do_simplify:
-                        solutions = map(simplify, soln)
                         flags['simplify'] = False # for checksol's sake
                     for sol in soln:
                         # check that it satisfies *other* equations
@@ -1618,7 +1615,6 @@ def _tsolve(eq, sym, **flags):
         #      x    -x                   -1
         # UC: e  + e   = y      ->  t + t   = y
         t = Dummy('t')
-        terms = lhs.args
 
         # find first term which is a Function
         for f1 in lhs.args:

--- a/sympy/solvers/tests/test_constantsimp.py
+++ b/sympy/solvers/tests/test_constantsimp.py
@@ -3,9 +3,9 @@ If the arbitrary constant class from issue 1336 is ever implemented, this
 should serve as a set of test cases.
 """
 
-from sympy import sin, exp, Function, Symbol, S, Pow, Eq, I, sinh, cosh, acos,\
-cos, log, Rational, sqrt, Integral
-from sympy.solvers.ode import constantsimp, constant_renumber
+from sympy import (acos, cos, cosh, Eq, exp, Function, I, Integral, log, Pow,
+                   S, sin, sinh, sqrt, Symbol)
+from sympy.solvers.ode import constant_renumber, constantsimp
 from sympy.utilities.pytest import XFAIL
 
 

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -1,14 +1,11 @@
 """Tests for tools for solving inequalities and systems of inequalities. """
 
-from sympy.solvers.inequalities import (
-    reduce_poly_inequalities,
-    reduce_inequalities)
-
-from sympy import (S, Symbol, Union, Interval, FiniteSet, Eq, Ne, Lt, Le, Gt,
-        Ge, Or, And, pi, oo, sqrt, Q, global_assumptions, re, im, sin)
-
-from sympy.utilities.pytest import raises
+from sympy import (And, Eq, FiniteSet, Ge, global_assumptions, Gt, im,
+                   Interval, Le, Lt, Ne, oo, Or, Q, re, S, sin, sqrt, Union)
 from sympy.abc import x, y
+from sympy.solvers.inequalities import (reduce_inequalities,
+                                        reduce_poly_inequalities)
+from sympy.utilities.pytest import raises
 
 inf = oo.evalf()
 

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -1,12 +1,11 @@
+from sympy import Eq, Matrix, pi, sin, sqrt, Symbol
 from sympy.mpmath import mnorm, mpf
 from sympy.solvers import nsolve
 from sympy.utilities.lambdify import lambdify
-from sympy import Symbol, Matrix, sqrt, Eq
 from sympy.utilities.pytest import raises
 
 def test_nsolve():
     # onedimensional
-    from sympy import Symbol, sin, pi
     x = Symbol('x')
     assert nsolve(sin(x), 2) - pi.evalf() < 1e-16
     assert nsolve(Eq(2*x, 2), x, -10) == nsolve(2*x - 2, -10)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1,13 +1,13 @@
 from __future__ import division
 
-from sympy import (Function, dsolve, Symbol, sin, cos, sinh, acos, tan, cosh,
-    I, exp, log, simplify, together, powsimp, fraction, radsimp, Eq, sqrt, pi,
-    erf,  diff, Rational, asinh, trigsimp, S, RootOf, Poly, Integral, atan,
-    Equality, solve, O, LambertW, Dummy, acosh, Derivative)
+
+from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve, Eq,
+                   erf, exp, Function, I, Integral, LambertW, log, O, pi,
+                   Rational, RootOf, S, simplify, sin, sqrt, Symbol, tan)
 from sympy.abc import x, y, z
-from sympy.solvers.ode import (ode_order, homogeneous_order,
-    _undetermined_coefficients_match, classify_ode, checkodesol,
-    constant_renumber, constantsimp)
+from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
+                               classify_ode, constant_renumber, constantsimp,
+                               homogeneous_order, ode_order)
 from sympy.utilities.pytest import XFAIL, skip, raises
 
 C1 = Symbol('C1')

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -1,11 +1,9 @@
-from sympy.solvers.pde import pde_separate_add, pde_separate_mul, _separate
-from sympy import Eq, exp, Function, Symbol, symbols
-from sympy import Derivative as D
+from sympy import Derivative as D, Eq, exp, Function, Symbol, symbols
+from sympy.solvers.pde import pde_separate_add, pde_separate_mul
 from sympy.utilities.pytest import raises
 
 def test_pde_separate_add():
     x, y, z, t = symbols("x,y,z,t")
-    c = Symbol("C", real=True)
     F, T, X, Y, Z, u = map(Function, 'FTXYZu')
 
     eq = Eq(D(u(x, t), x), D(u(x, t), t)*exp(u(x, t)))

--- a/sympy/solvers/tests/test_polysys.py
+++ b/sympy/solvers/tests/test_polysys.py
@@ -1,7 +1,6 @@
 """Tests for solvers of systems of polynomial equations. """
 
-from sympy import S, symbols, Integer, Rational, sqrt, I, Poly, QQ, flatten
-
+from sympy import flatten, I, Integer, Poly, QQ, Rational, S, sqrt, symbols
 from sympy.abc import x, y, z
 from sympy.polys import PolynomialError
 from sympy.solvers.polysys import solve_poly_system, solve_triangulated

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -1,5 +1,5 @@
-from sympy import Function, symbols, S, sqrt, rf, factorial
-from sympy.solvers.recurr import rsolve, rsolve_poly, rsolve_ratio, rsolve_hyper
+from sympy import factorial, Function, rf, S, sqrt, symbols
+from sympy.solvers.recurr import rsolve, rsolve_hyper, rsolve_poly, rsolve_ratio
 
 y = Function('y')
 n, k = symbols('n,k', integer=True)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -477,8 +477,7 @@ def test_issue_1572_1364_1368():
     assert solve(atan(x) - 1) == [tan(1)]
 
 def test_issue_2033():
-    #r, t = symbols('r,t')
-    r, t, z = symbols('r,t,z')
+    r, t = symbols('r,t')
     assert solve([r - x**2 - y**2, tan(t) - y/x], [x, y]) == \
      [
      (-sqrt(r*sin(t)**2)/tan(t), -sqrt(r*sin(t)**2)),


### PR DESCRIPTION
This commit fixes pyflakes errors in sympy.solvers (extraneous imports, variable shadowing, etc) and also refactors some code in test_solvers.py.

Tested with Python 2.7.1 and 3.2.1 on Windows.

GCI Task: http://google-melange.appspot.com/gci/task/view/google/gci2011/7141263
