### PR TITLE
Radical content removal

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -766,11 +766,59 @@ class Add(AssocOp):
         >>> (3 + 3*sqrt(2)).as_content_primitive()
         (3, 1 + sqrt(2))
 
+        Radical content is also factored out of the primitive:
+
+        >>> (2*sqrt(2) + 4*sqrt(10)).as_content_primitive()
+        (2, sqrt(2)*(1 + 2*sqrt(5)))
+
         See docstring of Expr.as_content_primitive for more examples.
         """
-        return Add(*[_keep_coeff(*a.as_content_primitive()) for a in self.args]).primitive()
+        con, prim = Add(*[_keep_coeff(*a.as_content_primitive()) for a in self.args]).primitive()
+        if prim.is_Add:
+            # look for common radicals that can be removed
+            args = prim.args
+            rads = []
+            common_q = None
+            for m in args:
+                term_rads = defaultdict(list)
+                for ai in Mul.make_args(m):
+                    if ai.is_Pow:
+                        b, e = ai.as_base_exp()
+                        if e.is_Rational and b.is_Integer and b > 0:
+                            term_rads[e.q].append(int(b)**e.p)
+                if not term_rads:
+                    break
+                if common_q is None:
+                    common_q = set(term_rads.keys())
+                else:
+                    common_q = common_q & set(term_rads.keys())
+                    if not common_q:
+                        break
+                rads.append(term_rads)
+            else:
+                # process rads
+                # keep only those in common_q
+                for r in rads:
+                    for q in r.keys():
+                        if q not in common_q:
+                            r.pop(q)
+                    for q in r:
+                        r[q] = prod(r[q])
+                # find the gcd of bases for each q
+                n = len(rads)
+                G = []
+                for q in common_q:
+                    g = reduce(igcd, [r[q] for r in rads], 0)
+                    if g != 1:
+                        G.append(Pow(g, Rational(1, q)))
+                if G:
+                    G = Mul(*G)
+                    args = [ai/G for ai in args]
+                    prim = G*Add(*args)
+
+        return con, prim
 
 from function import FunctionClass
-from mul import Mul, _keep_coeff
+from mul import Mul, _keep_coeff, prod
 from power import Pow
 from sympy.core.numbers import Rational

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -831,8 +831,9 @@ class Basic(object):
         """
         if self in rule:
             return rule[self]
-        else:
+        elif rule:
             return self.func(*[arg.xreplace(rule) for arg in self.args])
+        return self
 
     @deprecated
     def __contains__(self, obj):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -832,7 +832,9 @@ class Basic(object):
         if self in rule:
             return rule[self]
         elif rule:
-            return self.func(*[arg.xreplace(rule) for arg in self.args])
+            args = tuple([arg.xreplace(rule) for arg in self.args])
+            if args != self.args:
+                return self.func(*args)
         return self
 
     @deprecated

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -451,5 +451,5 @@ def factor_terms(expr):
         list_args[i] = gcd_terms(a, isprimitive=True)
         # cancel terms that may not have cancelled
     p = Add._from_args(list_args) # gcd_terms will fix up ordering
-    p = gcd_terms(p, isprimitive=True).subs(ncreps) # exact subs could be used here
+    p = gcd_terms(p, isprimitive=True).xreplace(ncreps)
     return _keep_coeff(cont, p)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -111,3 +111,7 @@ def test_factor_terms():
         x*(a + 2*b)*(y + 1)
     i = Integral(x, (x, 0, oo))
     assert factor_terms(i) == i
+
+def test_xreplace():
+    e = Mul(2, 1 + x, evaluate=False)
+    assert e.xreplace({}) == e

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -115,3 +115,4 @@ def test_factor_terms():
 def test_xreplace():
     e = Mul(2, 1 + x, evaluate=False)
     assert e.xreplace({}) == e
+    assert e.xreplace({y: x}) == e

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2254,25 +2254,30 @@ def simplify(expr, ratio=1.7, measure=count_ops):
 
         # cancel already took care of things like 1/sqrt(3) -> sqrt(3)/3
         # so we don't have to worry about `a` matching with `b`=0 as we
-        # do in radsimp
+        # do in radsimp yet, but we do below...
         r = denom.match(a + b*sqrt(c))
 
         if r is not None and r[b]:
             # be careful not to multiply by 0/0 when removing denom;
             # this will happen in a = +/- b*sqrt(c), so collect c so
-            # it's not also in `a`
+            # it's not also in `a` but this may turn the denom into
+            # a Mul so we have to watch out for that.
             if r[c].is_number:
                 newdenom = collect_const(denom, sqrt(r[c]))
                 if newdenom != denom:
-                    r = newdenom.match(a + b*sqrt(c))
-            a, b, c = r[a], r[b], r[c]
+                    if newdenom.is_Add:
+                        r = newdenom.match(a + b*sqrt(c))
+                    else:
+                        r = None # Add turned into a Mul
+            if r:
+                a, b, c = r[a], r[b], r[c]
 
-            numer *= a-b*sqrt(c)
-            numer = numer.expand()
+                numer *= a-b*sqrt(c)
+                numer = numer.expand()
 
-            denom = a**2 - c*b**2
+                denom = a**2 - c*b**2
 
-            expr = numer/denom
+                expr = numer/denom
 
     if expr.could_extract_minus_sign():
         n, d = expr.as_numer_denom()

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -809,6 +809,8 @@ def test_as_content_primitive():
     assert (5**(S(7)/4)).as_content_primitive() == (5, 5**(S(3)/4))
     assert Add(5*z/7, 0.5*x, 3*y/2, evaluate=False).as_content_primitive() == \
             (S(1)/14, 7.0*x + 21*y + 10*z)
+    assert (2**(S(3)/4) + 2**(S(1)/4)*sqrt(3)).as_content_primitive() == \
+            (1, 2**(S(1)/4)*(sqrt(2) + sqrt(3)))
 
 def test_radsimp():
     r2=sqrt(2)


### PR DESCRIPTION
radicals with Integer bases can now be factored out of the primitive portion of an expression:

``` python
>>> (root(3,3)*root(27*2,3)**2+root(6,3)).as_content_primitive()
(1, 6**(1/3)*(1 + 9*2**(1/3)))
```

Since factor_terms relies on as_content_primitive, this means that factor_terms will also be able to factor out such terms

``` python
>>> factor_terms(sqrt(2+2*x)+sqrt(10+10*x))
sqrt(2)*(1 + sqrt(5))*sqrt(x + 1)
```
