### PR TITLE
New: func_equal tests for equality under a test function

### DIFF
--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,5 +1,48 @@
 """Miscellaneous stuff that doesn't really fit anywhere else."""
 
+def func_equal(funcname, func, **args):
+    """ Apply func to all arguments, test results for equality, and return results.
+
+    If, for any keyword arguments, func(arg) != arg, raise a ValueError.
+    Otherwise, return args, with func() applied to each argument.
+
+    func_equal wants keyword arguments for more informative error messages.
+
+    >>> from sympy.utilities.misc import func_equal
+    >>> func_equal("int", int, a = 3.0)
+    2
+    >>> func_equal("float", float, a = 3, b = 4.0)
+    (3.0, 4.0)
+    >>> func_equal("int", int, a = 3, b = 4.1)
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid type for parameter b: int(4.1) yielded 4, which is not equal to 4.1
+    """
+    # To minimize the number of Python statements executed, we use list
+    # comprehension and tuple comparison.
+    result = tuple([func(value) for name, value in args.items()])
+    if result != args.values():
+        # Some tuple elements have an inequal value.
+        # Use the (slower) for loop to iterate over the parameters and
+        # report the first that has a problem with an exception.
+        for name, value in args.items ():
+            if value != func(value):
+                raise ValueError(
+                    "Invalid type for parameter %(name)s: "
+                    "%(funcname)s(%(value)s) yielded %(result)s, "
+                    "which is not equal to %(value)s"
+                    % {
+                        "funcname": funcname,
+                        "name": name,
+                        "value": value,
+                        "result": func(value)
+                    }
+                )
+    if len(result) == 1:
+        return result[0]
+    return result
+
+
 def default_sort_key(item, order=None):
     """
     A default sort key for lists of SymPy objects to pass to functions like sorted().

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -10,7 +10,7 @@ def func_equal(funcname, func, **args):
 
     >>> from sympy.utilities.misc import func_equal
     >>> func_equal("int", int, a = 3.0)
-    2
+    3
     >>> func_equal("float", float, a = 3, b = 4.0)
     (3.0, 4.0)
     >>> func_equal("int", int, a = 3, b = 4.1)


### PR DESCRIPTION
This is my idea of a type_tested function, but with the added twist that it can use any lambda that normalizes a single input.

Usage e.g. to normalize variables a and b via the int() function:
  a, b = type_tested("int", int, a=a, b=b)
Yes this looks silly, but the keywords are used to generate error messages (they are really strings in disguise if you will).

This is experimental, feedback appreciated.

One thing I don't like already is that the text for the function is explicit as a string, the texts for the values are via keyword parameters. It should really either be type_tested(int=int, a=a, b=b) or type_tested("int", int, "a", a, "b", b).
Except the first variant does not work with lambdas (you can't have special characters and blanks in keywords), and the second makes it harder to use list comprehension (which is supposed to make it fast - this function could be called quite often if we do type testing on internal interfaces).

The other thing is that I should really benchmark whether a list comprehension is really faster than an ordinary Python loop. The current implementation is a bit ugly - that's normal for optimized code, but it better be worth it :-)
