### PR TITLE
args_cnc returns list for commutative; can return checked set

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -604,14 +604,13 @@ class Expr(Basic, EvalfMixin):
         return count_ops(self, visual)
 
     def args_cnc(self, cset=False, warn=True):
-        """Treat self as a Mul and return the commutative and noncommutative
-        arguments as [c_list, nc_list] with items appearing in the same
-        order that they appeared in the expression; if ``cset`` is True the
-        commutative items will be returned in a set. If there were repeated
-        arguments (as may happen with an unevaluated Mul) then an error will be
-        raised unless it is explicitly supressed with ``warn`` set to False.
-        In such cases, the calling code should figure out what to do with the
-        arguments, i.e. rebuild them unevaluated term
+        """Return [commutative factors, non-commutative factors] of self.
+
+        self is treated as a Mul and the ordering of the factors is maintained.
+        If ``cset`` is True the commutative factors will be returned in a set.
+        If there were repeated factors (as may happen with an unevaluated Mul)
+        then an error will be raised unless it is explicitly supressed by
+        setting ``warn`` to False.
 
         Note: -1 is always separated from a Rational.
 

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -445,7 +445,7 @@ def factor_terms(expr, radical=False):
         return expr.func(*[factor_terms(i, radical=radical) for i in expr.args])
 
     cont, p = expr.as_content_primitive(radical=radical)
-    list_args, nc = zip(*[ai.args_cnc(clist=True) for ai in Add.make_args(p)])
+    list_args, nc = zip(*[ai.args_cnc() for ai in Add.make_args(p)])
     list_args = list(list_args)
     nc = [((Dummy(), Mul._from_args(i)) if i else None) for i in nc]
     ncreps = dict([i for i in nc if i is not None])

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -117,7 +117,7 @@ class Mul(AssocOp):
                 r, b = b.as_coeff_Mul()
                 a *= r
                 if b.is_Mul:
-                    bargs, nc = b.args_cnc(clist=True)
+                    bargs, nc = b.args_cnc()
                     rv = bargs, nc, None
                     if a is not S.One:
                         bargs.insert(0, a)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -974,13 +974,20 @@ def test_as_coefficients_dict():
 def test_args_cnc():
     A = symbols('A', commutative=False)
     assert (x+A).args_cnc() == \
-        [set([]), [x + A]]
+        [[], [x + A]]
     assert (x+a).args_cnc() == \
-        [set([a + x]), []]
+        [[a + x], []]
     assert (x*a).args_cnc() == \
-        [set([x, a]), []]
-    assert (x*y*A*(A+1)).args_cnc(clist=True) == \
-        [[x, y], [A, 1 + A]]
+        [[a, x], []]
+    assert (x*y*A*(A+1)).args_cnc(cset=True) == \
+        [set([x, y]), [A, 1 + A]]
+    assert Mul(x, x, evaluate=False).args_cnc(cset=True, warn=False) == \
+        [set([x]), []]
+    assert Mul(x, x**2, evaluate=False).args_cnc(cset=True, warn=False) == \
+        [set([x, x**2]), []]
+    raises(ValueError, 'Mul(x, x, evaluate=False).args_cnc(cset=True)')
+    assert Mul(x, y, x, evaluate=False).args_cnc() == \
+        [[x, y, x], []]
 
 def test_new_rawargs():
     n = Symbol('n', commutative=False)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -787,8 +787,7 @@ def test_Rational_factors():
     assert str(F(12,1, visual=True)) == '2**2*3**1'
     assert str(F(1,1, visual=True)) == '1'
     assert str(F(25, 14, visual=True)) == '5**2/(2*7)'
-    assert str(F(-25, 14*9, visual=True)) == '-5**2/(2*9*7)' # XXX fix str to not evaluate 3**2
-    assert Rational(-25, 14*9).factors()[3] == -2 # XXX delete this when the str issue is fixed
+    assert str(F(-25, 14*9, visual=True)) == '-5**2/(2*3**2*7)'
 
 def test_issue1008():
     assert pi*(E + 10) + pi*(-E - 10)         != 0

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -89,7 +89,7 @@ class AntiCommutator(Expr):
         # from sympy.physics.qmul import QMul
         ca, nca = a.args_cnc()
         cb, ncb = b.args_cnc()
-        c_part = list(ca) + list(cb)
+        c_part = ca + cb
         if c_part:
             return Mul(Mul(*c_part), cls(Mul._from_args(nca), Mul._from_args(ncb)))
 

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -101,7 +101,7 @@ class Commutator(Expr):
         # from sympy.physics.qmul import QMul
         ca, nca = a.args_cnc()
         cb, ncb = b.args_cnc()
-        c_part = list(ca) + list(cb)
+        c_part = ca + cb
         if c_part:
             return Mul(Mul(*c_part), cls(Mul._from_args(nca), Mul._from_args(ncb)))
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -13,6 +13,7 @@ from sympy.core.compatibility import reduce
 from sympy.printing.str import StrPrinter
 
 from sympy.physics.quantum.qexpr import split_commutative_parts
+from sympy.core.compatibility import reduce
 
 __all__ = [
     'Dagger',
@@ -577,7 +578,7 @@ class AnnihilateFermion(FermionicOperator, Annihilator):
             return state.down(element)
 
         elif isinstance(state, Mul):
-            c_part, nc_part = split_commutative_parts(state)
+            c_part, nc_part = state.args_cnc()
             if isinstance(nc_part[0], FockStateFermionKet):
                 element = self.state
                 return Mul(*(c_part+[nc_part[0].down(element)]+nc_part[1:]))
@@ -699,7 +700,7 @@ class CreateFermion(FermionicOperator, Creator):
 
 
         elif isinstance(state, Mul):
-            c_part, nc_part = split_commutative_parts(state)
+            c_part, nc_part = state.args_cnc()
             if isinstance(nc_part[0], FockStateFermionKet):
                 element = self.state
                 return Mul(*(c_part + [nc_part[0].up(element)] + nc_part[1:]))
@@ -1131,7 +1132,7 @@ def apply_Mul(m):
     """
     if not isinstance(m, Mul):
         return m
-    c_part, nc_part = split_commutative_parts(m)
+    c_part, nc_part = m.args_cnc()
     n_nc = len(nc_part)
     if n_nc == 0 or n_nc == 1:
         return m

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -217,7 +217,10 @@ class StrPrinter(Printer):
         # Gather args for numerator/denominator
         for item in args:
             if item.is_commutative and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
-                b.append(Pow(item.base, -item.exp))
+                if item.exp != -1:
+                    b.append(Pow(item.base, -item.exp, evaluate=False))
+                else:
+                    b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
                 if item.p != 1:
                     a.append(Rational(item.p))

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -176,7 +176,7 @@ def cse(exprs, symbols=None, optimizations=None):
     # in common between the two nc parts
     sm = difflib.SequenceMatcher()
 
-    muls = [a.args_cnc() for a in muls]
+    muls = [a.args_cnc(cset=True) for a in muls]
     for i in xrange(len(muls)):
         if muls[i][1]:
             sm.set_seq1(muls[i][1])

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -957,8 +957,8 @@ def collect_sqrt(expr, evaluate=True):
         nrad = 0
         args = list(Add.make_args(d))
         for m in args:
-            cset, nc = m.args_cnc()
-            for ci in cset:
+            c, nc = m.args_cnc()
+            for ci in c:
                 if ci.is_Pow and ci.exp.is_Rational and ci.exp.q == 2 or \
                    ci is S.ImaginaryUnit:
                     nrad += 1
@@ -1450,7 +1450,7 @@ def _denest_pow(eq):
     def nc_gcd(aa, bb):
         a, b = [i.as_coeff_Mul() for i in [aa, bb]]
         c = gcd(a[0], b[0]).as_numer_denom()[0]
-        g = Mul(*(a[1].args_cnc()[0] & b[1].args_cnc()[0]))
+        g = Mul(*(a[1].args_cnc(cset=True)[0] & b[1].args_cnc(cset=True)[0]))
         return _keep_coeff(c, g)
 
     glogb = expand_log(log(b))


### PR DESCRIPTION
If there are repeated arguments in a Mul and a set has been requested
    then the calling code should figure out what to do:

```
1) should the Mul be rebuilt? should only the repeated args be combined?
2) should the set be taken anyway because repeats don't matter?

So when this case is detected, an error is raised unless warn is set
to False; in that case the set will be returned even though it doesn't
contain the repeated args.

A note was added to Expr.as_powers_dict warning against using the
dictionary obtained from it to rebuild a Mul that contains noncommutative
factors.
```
