### PR TITLE
GCI Work - Slow functions

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -38,9 +38,9 @@ parser.add_option('-t', '--types', dest='types', action='store',
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
 parser.add_option("--timeout", action="store", dest="timeout",
-        default=False, help="Set a timeout for the slow functions. 'none' for no timeout.")
+        default=False, help="Set a timeout for the all functions. By default there is no timeout.")
 parser.add_option("--slow", action="store_true", dest="slow",
-        default=False, help="Run only the slow functions. The timeout is by default 30.")
+        default=False, help="Run only the slow functions.")
 parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = """\
 "options" are any of the options above. "tests" are 0 or more glob strings of \
@@ -49,10 +49,14 @@ tests to run. If no test arguments are given, all tests will be run.\
 
 options, args = parser.parse_args()
 
-if options.timeout == False:
-    timeout = 30
+timeout = False
+if options.timeout:
+    timeout = int(options.timeout)
+
+if options.slow:
+    slow = True
 else:
-    timeout = options.timeout
+    slow = False
 
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
@@ -61,17 +65,9 @@ if options.types:
 
 import sympy
 
-if options.slow:
-    if timeout == "none":
-        os.environ['SYMPY_TEST_TIMEOUT'] = 'slow'
-    else:
-        os.environ['SYMPY_TEST_TIMEOUT'] = str(timeout)
-else:
-    os.environ['SYMPY_TEST_TIMEOUT'] = 'nothing'
-
 ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
-    "sort": options.sort, "seed": options.seed, "slow": options.slow, "timeout": options.timeout})
+    "sort": options.sort, "seed": options.seed, "slow": slow, "timeout": timeout})
 
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -61,20 +61,17 @@ if options.types:
 
 import sympy
 
-with open("_tmp_timeout","w") as f:
-    if options.slow:
-        if timeout == "none":
-            f.write("slow")
-        else:
-            f.write(str(timeout))
+if options.slow:
+    if timeout == "none":
+        os.environ['SYMPY_TEST_TIMEOUT'] = 'slow'
     else:
-        f.write("nothing")
+        os.environ['SYMPY_TEST_TIMEOUT'] = str(timeout)
+else:
+    os.environ['SYMPY_TEST_TIMEOUT'] = 'nothing'
 
 ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
     "sort": options.sort, "seed": options.seed, "slow": options.slow, "timeout": options.timeout})
-
-os.remove("_tmp_timeout")
 
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -38,7 +38,7 @@ parser.add_option('-t', '--types', dest='types', action='store',
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
 parser.add_option("--timeout", action="store", dest="timeout",
-        default=False, help="Set a timeout for the all functions. By default there is no timeout.")
+        default=False, help="Set a timeout for the all functions. By default there is no timeout.",type='int')
 parser.add_option("--slow", action="store_true", dest="slow",
         default=False, help="Run only the slow functions.")
 parser.set_usage("test [options ...] [tests ...]")
@@ -48,10 +48,6 @@ tests to run. If no test arguments are given, all tests will be run.\
 """
 
 options, args = parser.parse_args()
-
-timeout = False
-if options.timeout:
-    timeout = int(options.timeout)
 
 if options.slow:
     slow = True
@@ -67,7 +63,7 @@ import sympy
 
 ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
-    "sort": options.sort, "seed": options.seed, "slow": slow, "timeout": timeout})
+    "sort": options.sort, "seed": options.seed, "slow": slow, "timeout": options.timeout})
 
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -37,6 +37,10 @@ parser.add_option('-t', '--types', dest='types', action='store',
         help='setup ground types: gmpy | python | sympy')
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
+parser.add_option("--timeout", action="store", dest="timeout",
+        default=False, help="Set a timeout for the slow functions. 'none' for no timeout.")
+parser.add_option("--slow", action="store_true", dest="slow",
+        default=False, help="Run only the slow functions. The timeout is by default 30.")
 parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = """\
 "options" are any of the options above. "tests" are 0 or more glob strings of \
@@ -45,6 +49,11 @@ tests to run. If no test arguments are given, all tests will be run.\
 
 options, args = parser.parse_args()
 
+if options.timeout == False:
+    timeout = 30
+else:
+    timeout = options.timeout
+
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
 if options.types:
@@ -52,9 +61,20 @@ if options.types:
 
 import sympy
 
+with open("_tmp_timeout","w") as f:
+    if options.slow:
+        if timeout == "none":
+            f.write("slow")
+        else:
+            f.write(str(timeout))
+    else:
+        f.write("nothing")
+
 ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
-    "sort": options.sort, "seed": options.seed})
+    "sort": options.sort, "seed": options.seed, "slow": options.slow, "timeout": options.timeout})
+
+os.remove("_tmp_timeout")
 
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -49,11 +49,6 @@ tests to run. If no test arguments are given, all tests will be run.\
 
 options, args = parser.parse_args()
 
-if options.slow:
-    slow = True
-else:
-    slow = False
-
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
 if options.types:
@@ -63,7 +58,7 @@ import sympy
 
 ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
-    "sort": options.sort, "seed": options.seed, "slow": slow, "timeout": options.timeout})
+    "sort": options.sort, "seed": options.seed, "slow": options.slow, "timeout": options.timeout})
 
 if ok:
     sys.exit(0)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -7,7 +7,7 @@ from sympy.assumptions.handlers import AskHandler
 from sympy.core import I, Integer, oo, pi, Rational, S, symbols
 from sympy.functions import Abs, cos, exp, im, log, re, sign, sin, sqrt
 from sympy.logic import Equivalent, Implies, Xor
-from sympy.utilities.pytest import raises, XFAIL, SLOW
+from sympy.utilities.pytest import raises, XFAIL, slow
 
 def test_int_1():
     z = 1
@@ -375,7 +375,7 @@ def test_I():
     assert ask(Q.prime(z))            == False
     assert ask(Q.composite(z))        == False
 
-@SLOW
+@slow
 def test_bounded():
     x, y, z = symbols('x,y,z')
     assert ask(Q.bounded(x)) == None

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -7,7 +7,7 @@ from sympy.assumptions.handlers import AskHandler
 from sympy.core import I, Integer, oo, pi, Rational, S, symbols
 from sympy.functions import Abs, cos, exp, im, log, re, sign, sin, sqrt
 from sympy.logic import Equivalent, Implies, Xor
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises, XFAIL, SLOW
 
 def test_int_1():
     z = 1
@@ -375,6 +375,7 @@ def test_I():
     assert ask(Q.prime(z))            == False
     assert ask(Q.composite(z))        == False
 
+@SLOW
 def test_bounded():
     x, y, z = symbols('x,y,z')
     assert ask(Q.bounded(x)) == None

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -2,7 +2,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, S, erf, tan, asin, asinh, acos, acosh, Function, Derivative, diff, simplify, \
     LambertW
 from sympy.integrals.risch import heurisch, components
-from sympy.utilities.pytest import XFAIL, skip
+from sympy.utilities.pytest import XFAIL, skip, SLOW
 
 x, y, z = symbols('x,y,z')
 f = Function('f')
@@ -161,36 +161,37 @@ def test_issue510():
 
 # Besides, they are skipped(), because they take too much time to execute.
 
+@SLOW
 @XFAIL
 def test_pmint_rat():
-    skip('takes too much time')
+    #skip('takes too much time')
     f = (x**7-24*x**4-4*x**2+8*x-8) / (x**8+6*x**6+12*x**4+8*x**2)
     g = (4 + 8*x**2 + 6*x + 3*x**3) / (x*(x**4 + 4*x**2 + 4))  +  log(x)
 
     assert heurisch(f, x) == g
 
-
+@SLOW
 @XFAIL
 def test_pmint_trig():
-    skip('takes too much time')
+    #skip('takes too much time')
     f = (x-tan(x)) / tan(x)**2  +  tan(x)
     g = (-x - tan(x)*x**2 / 2) / tan(x)  +  log(1+tan(x)**2) / 2
 
     assert heurisch(f, x) == g
 
-
+@SLOW
 @XFAIL
 def test_pmint_logexp():
-    skip('takes too much time')
+    #skip('takes too much time')
     f = (1+x+x*exp(x))*(x+log(x)+exp(x)-1)/(x+log(x)+exp(x))**2/x
     g = 1/(x+log(x)+exp(x)) + log(x + log(x) + exp(x))
 
     assert heurisch(f, x) == g
 
-
+@SLOW
 @XFAIL
 def test_pmint_erf():
-    skip('takes too much time')
+    #skip('takes too much time')
     f = exp(-x**2)*erf(x)/(erf(x)**3-erf(x)**2-erf(x)+1)
     g = sqrt(pi)/4 * (-1/(erf(x)-1) - log(erf(x)+1)/2 + log(erf(x)-1)/2)
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -161,19 +161,15 @@ def test_issue510():
 
 # Besides, they are skipped(), because they take too much time to execute.
 
-@slow
 @XFAIL
 def test_pmint_rat():
-    #skip('takes too much time')
     f = (x**7-24*x**4-4*x**2+8*x-8) / (x**8+6*x**6+12*x**4+8*x**2)
     g = (4 + 8*x**2 + 6*x + 3*x**3) / (x*(x**4 + 4*x**2 + 4))  +  log(x)
 
     assert heurisch(f, x) == g
 
-@slow
 @XFAIL
 def test_pmint_trig():
-    #skip('takes too much time')
     f = (x-tan(x)) / tan(x)**2  +  tan(x)
     g = (-x - tan(x)*x**2 / 2) / tan(x)  +  log(1+tan(x)**2) / 2
 
@@ -182,7 +178,6 @@ def test_pmint_trig():
 @slow
 @XFAIL
 def test_pmint_logexp():
-    #skip('takes too much time')
     f = (1+x+x*exp(x))*(x+log(x)+exp(x)-1)/(x+log(x)+exp(x))**2/x
     g = 1/(x+log(x)+exp(x)) + log(x + log(x) + exp(x))
 
@@ -191,7 +186,6 @@ def test_pmint_logexp():
 @slow
 @XFAIL
 def test_pmint_erf():
-    #skip('takes too much time')
     f = exp(-x**2)*erf(x)/(erf(x)**3-erf(x)**2-erf(x)+1)
     g = sqrt(pi)/4 * (-1/(erf(x)-1) - log(erf(x)+1)/2 + log(erf(x)-1)/2)
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -2,7 +2,7 @@ from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, S, erf, tan, asin, asinh, acos, acosh, Function, Derivative, diff, simplify, \
     LambertW
 from sympy.integrals.risch import heurisch, components
-from sympy.utilities.pytest import XFAIL, skip, SLOW
+from sympy.utilities.pytest import XFAIL, skip, slow
 
 x, y, z = symbols('x,y,z')
 f = Function('f')
@@ -161,7 +161,7 @@ def test_issue510():
 
 # Besides, they are skipped(), because they take too much time to execute.
 
-@SLOW
+@slow
 @XFAIL
 def test_pmint_rat():
     #skip('takes too much time')
@@ -170,7 +170,7 @@ def test_pmint_rat():
 
     assert heurisch(f, x) == g
 
-@SLOW
+@slow
 @XFAIL
 def test_pmint_trig():
     #skip('takes too much time')
@@ -179,7 +179,7 @@ def test_pmint_trig():
 
     assert heurisch(f, x) == g
 
-@SLOW
+@slow
 @XFAIL
 def test_pmint_logexp():
     #skip('takes too much time')
@@ -188,7 +188,7 @@ def test_pmint_logexp():
 
     assert heurisch(f, x) == g
 
-@SLOW
+@slow
 @XFAIL
 def test_pmint_erf():
     #skip('takes too much time')

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -7,15 +7,11 @@ from sympy import hyper, I, S, meijerg, Piecewise
 from sympy.utilities.pytest import raises
 from sympy.abc import z, a, b, c
 from sympy.utilities.randtest import test_numerically as tn
-from sympy.utilities.pytest import XFAIL, skip
+from sympy.utilities.pytest import XFAIL, skip, SLOW
 from random import randrange
 
 from sympy import (cos, sin, log, exp, asin, lowergamma, atanh, besseli,
                    gamma, sqrt, pi)
-
-# whether to veryify that we can indeed do everything in the tables
-# beware: this takes a *long* time
-do_tables = False
 
 def test_hyperexpand():
     # Luke, Y. L. (1969), The Special Functions and Their Approximations,
@@ -27,15 +23,6 @@ def test_hyperexpand():
     assert hyperexpand(z*hyper([], [S('3/2')], -z**2/4)) == sin(z)
     assert hyperexpand(hyper([S('1/2'), S('1/2')], [S('3/2')], z**2)*z) \
            == asin(z)
-
-def tables(fn):
-    def wrapper():
-        skip("This is too slow.")
-    wrapper.__name__ = fn.__name__
-    if do_tables:
-        return fn
-    else:
-        return wrapper
 
 def can_do(ap, bq, numerical=True):
     r = hyperexpand(hyper(ap, bq, z))
@@ -403,7 +390,7 @@ def test_meijerg_confluence():
     assert u([1, 1], [2, 2, 5], [1, 1, 6], [0, 0])
     assert u([1, 1], [2, 2, 5], [1, 1, 6], [0])
 
-@tables
+@SLOW
 def test_prudnikov_misc():
     assert can_do([1, (3 + I)/2, (3 - I)/2], [S(3)/2, 2])
     assert can_do([S.Half, a - 1], [S(3)/2, a + 1])
@@ -423,7 +410,7 @@ def test_prudnikov_misc():
     assert can_do([a, a+S.Half], [2*a, b, 2*a - b + 1])
     assert can_do([a, a+S.Half], [S.Half, 2*a, 2*a + S.Half])
 
-@tables
+@SLOW
 def test_prudnikov_1():
     # A. P. Prudnikov, Yu. A. Brychkov and O. I. Marichev (1990).
     # Integrals and Series: More Special Functions, Vol. 3,.
@@ -448,7 +435,7 @@ def test_prudnikov_1():
     assert can_do([a], [2*a + 1])
     assert can_do([a], [2*a - 1])
 
-@tables
+@SLOW
 def test_prudnikov_2():
     h = S.Half
     assert can_do([-h, -h], [h])
@@ -465,7 +452,7 @@ def test_prudnikov_2():
           for m in [1, 2, 3, 4]:
               assert can_do([p, n], [m])
 
-@tables
+@SLOW
 def test_prudnikov_3():
     h = S.Half
     assert can_do([S(1)/4, S(3)/4], [h])
@@ -480,7 +467,7 @@ def test_prudnikov_3():
               assert can_do([p, m], [n])
 
 
-@tables
+@SLOW
 def test_prudnikov_4():
     h = S.Half
     for p in [3*h, 5*h, 7*h]:
@@ -491,7 +478,7 @@ def test_prudnikov_4():
           for m in [2, 3, 4]:
               assert can_do([p, m], [n])
 
-@tables
+@SLOW
 def test_prudnikov_5():
     h = S.Half
 
@@ -514,7 +501,7 @@ def test_prudnikov_5():
                 for s in [1, 2, 3]:
                     assert can_do([-h, p, q], [r, s])
 
-@tables
+@SLOW
 def test_prudnikov_6():
     h = S.Half
 
@@ -539,7 +526,7 @@ def test_prudnikov_6():
 
     # pages 435 to 457 contain more PFDD and stuff like this
 
-@tables
+@SLOW
 def test_prudnikov_7():
     assert can_do([3], [6])
 
@@ -550,7 +537,7 @@ def test_prudnikov_7():
         for n in [-h, h, 3*h, 5*h, 7*h, 1, 2, 3, 4]:
             assert can_do([m], [n])
 
-@tables
+@SLOW
 def test_prudnikov_8():
     h = S.Half
 
@@ -576,7 +563,7 @@ def test_prudnikov_8():
                     if c <= b:
                         assert can_do([a, b], [c, d])
 
-@tables
+@SLOW
 def test_prudnikov_9():
     # 7.13.1 [we have a general formula ... so this is a bit pointless]
     for i in range(9):
@@ -584,7 +571,7 @@ def test_prudnikov_9():
     for i in range(5):
         assert can_do([], [-(2*S(i) + 1)/2])
 
-@tables
+@SLOW
 def test_prudnikov_10():
     # 7.14.2
     h = S.Half
@@ -606,7 +593,7 @@ def test_prudnikov_10():
     for m in [h, 1, 2, 5*h, 3, 7*h, 4]:
        assert can_do([7*h], [5*h, m])
 
-@tables
+@SLOW
 def test_prudnikov_11():
     # 7.15
     assert can_do([a, a+S.Half], [2*a, b, 2*a - b])
@@ -617,7 +604,7 @@ def test_prudnikov_11():
     assert can_do([S(5)/4, S(3)/4], [S(3)/2, S(3)/2, 1])
     assert can_do([S(5)/4, S(7)/4], [S(3)/2, S(5)/2, 2])
 
-@tables
+@SLOW
 def test_prudnikov_12():
     # 7.16
     assert can_do([], [a, a + S.Half, 2*a], False) # branches only agree for some z!

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -7,7 +7,7 @@ from sympy import hyper, I, S, meijerg, Piecewise
 from sympy.utilities.pytest import raises
 from sympy.abc import z, a, b, c
 from sympy.utilities.randtest import test_numerically as tn
-from sympy.utilities.pytest import XFAIL, skip, SLOW
+from sympy.utilities.pytest import XFAIL, skip, slow
 from random import randrange
 
 from sympy import (cos, sin, log, exp, asin, lowergamma, atanh, besseli,
@@ -390,7 +390,7 @@ def test_meijerg_confluence():
     assert u([1, 1], [2, 2, 5], [1, 1, 6], [0, 0])
     assert u([1, 1], [2, 2, 5], [1, 1, 6], [0])
 
-@SLOW
+@slow
 def test_prudnikov_misc():
     assert can_do([1, (3 + I)/2, (3 - I)/2], [S(3)/2, 2])
     assert can_do([S.Half, a - 1], [S(3)/2, a + 1])
@@ -410,7 +410,7 @@ def test_prudnikov_misc():
     assert can_do([a, a+S.Half], [2*a, b, 2*a - b + 1])
     assert can_do([a, a+S.Half], [S.Half, 2*a, 2*a + S.Half])
 
-@SLOW
+@slow
 def test_prudnikov_1():
     # A. P. Prudnikov, Yu. A. Brychkov and O. I. Marichev (1990).
     # Integrals and Series: More Special Functions, Vol. 3,.
@@ -435,7 +435,7 @@ def test_prudnikov_1():
     assert can_do([a], [2*a + 1])
     assert can_do([a], [2*a - 1])
 
-@SLOW
+@slow
 def test_prudnikov_2():
     h = S.Half
     assert can_do([-h, -h], [h])
@@ -452,7 +452,7 @@ def test_prudnikov_2():
           for m in [1, 2, 3, 4]:
               assert can_do([p, n], [m])
 
-@SLOW
+@slow
 def test_prudnikov_3():
     h = S.Half
     assert can_do([S(1)/4, S(3)/4], [h])
@@ -467,7 +467,7 @@ def test_prudnikov_3():
               assert can_do([p, m], [n])
 
 
-@SLOW
+@slow
 def test_prudnikov_4():
     h = S.Half
     for p in [3*h, 5*h, 7*h]:
@@ -478,7 +478,7 @@ def test_prudnikov_4():
           for m in [2, 3, 4]:
               assert can_do([p, m], [n])
 
-@SLOW
+@slow
 def test_prudnikov_5():
     h = S.Half
 
@@ -501,7 +501,7 @@ def test_prudnikov_5():
                 for s in [1, 2, 3]:
                     assert can_do([-h, p, q], [r, s])
 
-@SLOW
+@slow
 def test_prudnikov_6():
     h = S.Half
 
@@ -526,7 +526,7 @@ def test_prudnikov_6():
 
     # pages 435 to 457 contain more PFDD and stuff like this
 
-@SLOW
+@slow
 def test_prudnikov_7():
     assert can_do([3], [6])
 
@@ -537,7 +537,7 @@ def test_prudnikov_7():
         for n in [-h, h, 3*h, 5*h, 7*h, 1, 2, 3, 4]:
             assert can_do([m], [n])
 
-@SLOW
+@slow
 def test_prudnikov_8():
     h = S.Half
 
@@ -563,7 +563,7 @@ def test_prudnikov_8():
                     if c <= b:
                         assert can_do([a, b], [c, d])
 
-@SLOW
+@slow
 def test_prudnikov_9():
     # 7.13.1 [we have a general formula ... so this is a bit pointless]
     for i in range(9):
@@ -571,7 +571,7 @@ def test_prudnikov_9():
     for i in range(5):
         assert can_do([], [-(2*S(i) + 1)/2])
 
-@SLOW
+@slow
 def test_prudnikov_10():
     # 7.14.2
     h = S.Half
@@ -593,7 +593,7 @@ def test_prudnikov_10():
     for m in [h, 1, 2, 5*h, 3, 7*h, 4]:
        assert can_do([7*h], [5*h, m])
 
-@SLOW
+@slow
 def test_prudnikov_11():
     # 7.15
     assert can_do([a, a+S.Half], [2*a, b, 2*a - b])
@@ -604,7 +604,7 @@ def test_prudnikov_11():
     assert can_do([S(5)/4, S(3)/4], [S(3)/2, S(3)/2, 1])
     assert can_do([S(5)/4, S(7)/4], [S(3)/2, S(5)/2, 2])
 
-@SLOW
+@slow
 def test_prudnikov_12():
     # 7.16
     assert can_do([], [a, a + S.Half, 2*a], False) # branches only agree for some z!

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -8,7 +8,7 @@ from sympy.abc import x, y, z
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
                                classify_ode, constant_renumber, constantsimp,
                                homogeneous_order, ode_order)
-from sympy.utilities.pytest import XFAIL, skip, raises
+from sympy.utilities.pytest import XFAIL, skip, raises, SLOW
 
 C1 = Symbol('C1')
 C2 = Symbol('C2')
@@ -308,6 +308,7 @@ def test_1st_exact1():
     assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
+@SLOW
 @XFAIL
 def test_1st_exact2():
     """
@@ -319,7 +320,7 @@ def test_1st_exact2():
     equivalent, but it is so complex that checkodesol fails, and takes a long time
     to do so.
     """
-    skip("takes too much time")
+    #skip("takes too much time")
     eq = x*sqrt(x**2 + f(x)**2) - (x**2*f(x)/(f(x) - sqrt(x**2 + f(x)**2)))*f(x).diff(x)
     sol = dsolve(eq)
     assert sol == Eq(log(x),C1 - 9*sqrt(1 + f(x)**2/x**2)*asinh(f(x)/x)/(-27*f(x)/x + \
@@ -505,8 +506,9 @@ def test_1st_homogeneous_coeff_ode():
     assert dsolve(eq8, hint='1st_homogeneous_coeff_best') == sol8
     # checks are below
 
+@SLOW
 def test_1st_homogeneous_coeff_ode_check14568():
-    skip("This test passes, but it takes too long")
+    #skip("This test passes, but it takes too long")
     # These are the checkodesols from test_homogeneous_coeff_ode1.
     eq1 = f(x)/x*cos(f(x)/x) - (x/f(x)*sin(f(x)/x) + cos(f(x)/x))*f(x).diff(x)
     eq4 = 2*f(x)*exp(x/f(x)) + f(x)*f(x).diff(x) - 2*x*exp(x/f(x))*f(x).diff(x)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -8,7 +8,7 @@ from sympy.abc import x, y, z
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
                                classify_ode, constant_renumber, constantsimp,
                                homogeneous_order, ode_order)
-from sympy.utilities.pytest import XFAIL, skip, raises, SLOW
+from sympy.utilities.pytest import XFAIL, skip, raises, slow
 
 C1 = Symbol('C1')
 C2 = Symbol('C2')
@@ -308,7 +308,7 @@ def test_1st_exact1():
     assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
 
-@SLOW
+@slow
 @XFAIL
 def test_1st_exact2():
     """
@@ -505,7 +505,7 @@ def test_1st_homogeneous_coeff_ode():
     assert dsolve(eq8, hint='1st_homogeneous_coeff_best') == sol8
     # checks are below
 
-@SLOW
+@slow
 def test_1st_homogeneous_coeff_ode_check14568():
     # These are the checkodesols from test_homogeneous_coeff_ode1.
     eq1 = f(x)/x*cos(f(x)/x) - (x/f(x)*sin(f(x)/x) + cos(f(x)/x))*f(x).diff(x)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -320,7 +320,6 @@ def test_1st_exact2():
     equivalent, but it is so complex that checkodesol fails, and takes a long time
     to do so.
     """
-    #skip("takes too much time")
     eq = x*sqrt(x**2 + f(x)**2) - (x**2*f(x)/(f(x) - sqrt(x**2 + f(x)**2)))*f(x).diff(x)
     sol = dsolve(eq)
     assert sol == Eq(log(x),C1 - 9*sqrt(1 + f(x)**2/x**2)*asinh(f(x)/x)/(-27*f(x)/x + \
@@ -508,7 +507,6 @@ def test_1st_homogeneous_coeff_ode():
 
 @SLOW
 def test_1st_homogeneous_coeff_ode_check14568():
-    #skip("This test passes, but it takes too long")
     # These are the checkodesols from test_homogeneous_coeff_ode1.
     eq1 = f(x)/x*cos(f(x)/x) - (x/f(x)*sin(f(x)/x) + cos(f(x)/x))*f(x).diff(x)
     eq4 = 2*f(x)*exp(x/f(x)) + f(x)*f(x).diff(x) - 2*x*exp(x/f(x))*f(x).diff(x)

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -58,8 +58,11 @@ if not USE_PYTEST:
         def wrapper():
             try:
                 func()
-            except Exception:
-                raise XFail(func.func_name)
+            except Exception, e:
+                if e.message != "Timeout":
+                    raise XFail(func.func_name)
+                else:
+                    raise Skipped("Timeout")
             raise XPass(func.func_name)
 
         wrapper = functools.update_wrapper(wrapper, func)

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -59,7 +59,11 @@ if not USE_PYTEST:
             try:
                 func()
             except Exception, e:
-                if e.message != "Timeout":
+                if sys.version_info[:2] < (2, 6):
+                    message = getattr(e, 'message', '')
+                else:
+                    message = str(e)
+                if message != "Timeout":
                     raise XFail(func.func_name)
                 else:
                     raise Skipped("Timeout")

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -162,9 +162,6 @@ def SKIP(reason):
 
     return wrapper
 
-class Slow(Exception):
-    pass
-
 def SLOW(func):
     timeout = 0
 

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -163,7 +163,7 @@ def SKIP(reason):
 
     return wrapper
 
-def SLOW(func):
+def slow(func):
     func._slow = True
     def func_wrapper():
         func()

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -168,7 +168,7 @@ def SLOW(func):
     contents = os.environ['SYMPY_TEST_TIMEOUT']
     try:
         timeout = int(contents)
-    except:
+    except ValueError:
         timeout = contents
 
     if type(timeout) == int:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -623,10 +623,10 @@ class SymPyTests(object):
         def callback(x,y):
             raise Skipped("Timeout")
         handler = signal.signal(signal.SIGALRM, callback)
-        signal.alarm(timeout)
+        signal.alarm(timeout) # Set an alarm with a given timeout
         function()
         signal.signal(signal.SIGALRM, handler)
-        signal.alarm(0)
+        signal.alarm(0) # Disable the alarm
 
     def matches(self, x):
         """

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -558,8 +558,7 @@ class SymPyTests(object):
                                                    inspect.getsourcefile(gl[f]) == pytestfile or
                                                    inspect.getsourcefile(gl[f]) == pytestfile2)]
             if slow:
-               funcs = [f for f in funcs if inspect.getsourcefile(f) == pytestfile2 and f.__doc__
-                                                                and f.__doc__.startswith("SLOW") ]
+               funcs = [f for f in funcs if f.func_code.co_name == "slowwrapper"]
             # Sorting of XFAILed functions isn't fixed yet :-(
             funcs.sort(key=lambda x: inspect.getsourcelines(x)[1])
             i = 0

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -626,11 +626,11 @@ class SymPyTests(object):
 
     def _timeout(self, function, timeout):
         def callback(x,y):
+            signal.alarm(0)
             raise Skipped("Timeout")
         handler = signal.signal(signal.SIGALRM, callback)
         signal.alarm(timeout) # Set an alarm with a given timeout
         function()
-        signal.signal(signal.SIGALRM, handler)
         signal.alarm(0) # Disable the alarm
 
     def matches(self, x):

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -563,8 +563,6 @@ class SymPyTests(object):
                                                    inspect.getsourcefile(gl[f]) == pytestfile2)]
             if slow:
                funcs = [f for f in funcs if getattr(f, '_slow', False)]
-            else:
-               funcs = [f for f in funcs if not getattr(f, '_slow', False)]
             # Sorting of XFAILed functions isn't fixed yet :-(
             funcs.sort(key=lambda x: inspect.getsourcelines(x)[1])
             i = 0
@@ -592,6 +590,8 @@ class SymPyTests(object):
         for f in funcs:
             self._reporter.entering_test(f)
             try:
+                if getattr(f, '_slow', False) and not slow:
+                    raise Skipped("Slow")
                 if timeout:
                     self._timeout(f, timeout)
                 else:
@@ -1349,6 +1349,7 @@ class PyTestReporter(Reporter):
         char = "s"
         if message == "KeyboardInterrupt": char = "K"
         elif message == "Timeout": char = "T"
+        elif message == "Slow": char = "W"
         self.write(char, "Blue")
         if self._verbose:
             self.write(" - ", "Blue")

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1349,7 +1349,7 @@ class PyTestReporter(Reporter):
         char = "s"
         if message == "KeyboardInterrupt": char = "K"
         elif message == "Timeout": char = "T"
-        elif message == "Slow": char = "W"
+        elif message == "Slow": char = "w"
         self.write(char, "Blue")
         if self._verbose:
             self.write(" - ", "Blue")

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -26,7 +26,6 @@ import re as pre
 import random
 import subprocess
 import time
-from multiprocessing import Process, Queue
 
 from sympy.core.cache import clear_cache
 
@@ -558,6 +557,9 @@ class SymPyTests(object):
                                                  (inspect.getsourcefile(gl[f]) == filename or
                                                    inspect.getsourcefile(gl[f]) == pytestfile or
                                                    inspect.getsourcefile(gl[f]) == pytestfile2)]
+            if slow:
+               funcs = [f for f in funcs if inspect.getsourcefile(f) == pytestfile2 and f.__doc__
+                                                                and f.__doc__.startswith("SLOW") ]
             # Sorting of XFAILed functions isn't fixed yet :-(
             funcs.sort(key=lambda x: inspect.getsourcelines(x)[1])
             i = 0

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -602,6 +602,8 @@ class SymPyTests(object):
                 else:
                     raise
             except Exception:
+                if timeout:
+                    signal.alarm(0) # Disable the alarm. It could not be handled before.
                 t, v, tr = sys.exc_info()
                 if t is AssertionError:
                     self._reporter.test_fail((t, v, tr))
@@ -618,10 +620,7 @@ class SymPyTests(object):
                     if self._post_mortem:
                         pdb.post_mortem(tr)
             else:
-                if not getattr(f, '_slow', False):
-                    self._reporter.test_pass()
-                else:
-                    self._reporter.test_pass("W")
+                self._reporter.test_pass()
         self._reporter.leaving_filename()
 
     def _timeout(self, function, timeout):


### PR DESCRIPTION
GCI task: http://www.google-melange.com/gci/task/view/google/gci2011/7114334

I have implemented a better handling of slow functions. That begins by setting a SLOW decorator, located on pytest.py. It also requires the doc of the slow function to begin with SLOW. An example slow function would be:

``` python
@SLOW
def hi():
      "SLOW. (It does bla, bla, bla)"
      pass
```

it also includes two commandline arguments: --slow and --timeout.

Slow indicates that only the slow tests must be run. Timeout sets a timeout after which a slow function will be skipped. In case slow isn't given, any slow function will be automatically skipped. The timeout is by default 30 seconds. It can be set to either another number or 'none' for an infinite timeout.

It also allows KeyboardInterrupt to be triggered while in a slow function, and it will only skip that function continuing the rest.

It is necessary for functions to include SLOW inside the doc, for it is impossible to know which decorators a function has (you don't know exactly if it's XFAIL or SLOW, since they are in the same file).

Slow functions should begin to be ported to that system. By now, I have only implemented the "infrastructure" - then functions which right now skipped should be moved to that system.
