### PR TITLE
[GCI 2011] Refactor and fix pyflakes errors in modules a-e

### DIFF
--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -1,25 +1,22 @@
 """rename this to test_assumptions.py when the old assumptions system is deleted"""
+from sympy.abc import x, y
+from sympy.assumptions import global_assumptions, Predicate
+from sympy.assumptions.ask import _extract_facts, Q
 from sympy.core import symbols
-from sympy.assumptions import AppliedPredicate, global_assumptions, Predicate
-from sympy.assumptions.ask import _extract_facts
-from sympy.printing import pretty
-from sympy.assumptions.ask import Q
 from sympy.logic.boolalg import Or
+from sympy.printing import pretty
 
 def test_equal():
     """Test for equality"""
-    x = symbols('x')
     assert Q.positive(x)  == Q.positive(x)
     assert Q.positive(x)  != ~Q.positive(x)
     assert ~Q.positive(x) == ~Q.positive(x)
 
 def test_pretty():
-    x = symbols('x')
     assert pretty(Q.positive(x)) == "Q.positive(x)"
 
 def test_extract_facts():
     a, b = symbols('a b', cls=Predicate)
-    x, y = symbols('x y')
     assert _extract_facts(a(x), x)  == a
     assert _extract_facts(a(x), y)  == None
     assert _extract_facts(~a(x), x) == ~a
@@ -29,7 +26,6 @@ def test_extract_facts():
 
 def test_global():
     """Test for global assumptions"""
-    x, y = symbols('x,y')
     global_assumptions.add(Q.is_true(x > 0))
     assert Q.is_true(x > 0) in global_assumptions
     global_assumptions.remove(Q.is_true(x > 0))
@@ -43,7 +39,6 @@ def test_global():
     assert not Q.is_true(y > 0) in global_assumptions
 
 def test_composite_predicates():
-    x = symbols('x')
     pred = Q.integer | ~Q.positive
     assert type(pred(x)) is Or
     assert pred(x) == Q.integer(x) | ~Q.positive(x)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1,12 +1,13 @@
-from sympy.utilities.pytest import raises, XFAIL
-
-from sympy.core import Symbol, symbols, S, Rational, Integer, I, pi, oo
-from sympy.functions import exp, log, sin, cos, sign, re, im, sqrt, Abs
-from sympy.assumptions import (global_assumptions, Q, ask,
-    register_handler, remove_handler, AssumptionsContext)
+from sympy.abc import t, w, x, y, z
+from sympy.assumptions import (ask, AssumptionsContext, global_assumptions, Q,
+                               register_handler, remove_handler)
+from sympy.assumptions.ask import (compute_known_facts, known_facts_cnf,
+                                   known_facts_dict)
 from sympy.assumptions.handlers import AskHandler
-from sympy.assumptions.ask import (compute_known_facts,
-                                   known_facts_cnf, known_facts_dict)
+from sympy.core import I, Integer, oo, pi, Rational, S, symbols
+from sympy.functions import Abs, cos, exp, im, log, re, sign, sin, sqrt
+from sympy.logic import Equivalent, Implies, Xor
+from sympy.utilities.pytest import raises, XFAIL
 
 def test_int_1():
     z = 1
@@ -99,7 +100,6 @@ def test_negativeone():
     assert ask(Q.composite(z))        == False
 
 def test_infinity():
-    oo = S.Infinity
     assert ask(Q.commutative(oo))     == True
     assert ask(Q.integer(oo))         == False
     assert ask(Q.rational(oo))        == False
@@ -324,7 +324,6 @@ def test_E():
     assert ask(Q.composite(z))        == False
 
 def test_I():
-    I = S.ImaginaryUnit
     z = I
     assert ask(Q.commutative(z))      == True
     assert ask(Q.integer(z))          == False
@@ -685,7 +684,6 @@ def test_bounded():
 @XFAIL
 def test_bounded_xfail():
     """We need to support relations in ask for this to work"""
-    x = Symbol('x')
     assert ask(Q.bounded(sin(x)**x)) == True
     assert ask(Q.bounded(cos(x)**x)) == True
     assert ask(Q.bounded(sin(x) ** x)) == True
@@ -693,7 +691,6 @@ def test_bounded_xfail():
 def test_commutative():
     """By default objects are Q.commutative that is why it returns True
     for both key=True and key=False"""
-    x, y = symbols('x,y')
     assert ask(Q.commutative(x)) == True
     assert ask(Q.commutative(x), ~Q.commutative(x)) == False
     assert ask(Q.commutative(x), Q.complex(x)) == True
@@ -714,7 +711,6 @@ def test_commutative():
     assert ask(Q.commutative(log(x))) == True
 
 def test_complex():
-    x, y = symbols('x,y')
     assert ask(Q.complex(x)) == None
     assert ask(Q.complex(x), Q.complex(x)) == True
     assert ask(Q.complex(x), Q.complex(y)) == None
@@ -788,7 +784,6 @@ def test_complex():
     assert ask(Q.complex(im(x))) == True
 
 def test_even():
-    x, y, z, t = symbols('x,y,z,t')
     assert ask(Q.even(x)) == None
     assert ask(Q.even(x), Q.integer(x)) == None
     assert ask(Q.even(x), ~Q.integer(x)) == False
@@ -830,7 +825,6 @@ def test_even():
     assert ask(Q.even(im(x)), Q.real(x)) == True
 
 def test_extended_real():
-    x = symbols('x')
     assert ask(Q.extended_real(x), Q.positive(x)) == True
     assert ask(Q.extended_real(-x), Q.positive(x)) == True
     assert ask(Q.extended_real(-x), Q.negative(x)) == True
@@ -838,7 +832,6 @@ def test_extended_real():
     assert ask(Q.extended_real(x+S.Infinity), Q.real(x)) == True
 
 def test_rational():
-    x, y = symbols('x,y')
     assert ask(Q.rational(x), Q.integer(x)) == True
     assert ask(Q.rational(x), Q.irrational(x)) == False
     assert ask(Q.rational(x), Q.real(x)) == None
@@ -879,8 +872,6 @@ def test_rational():
     assert ask(Q.rational(y/x), Q.irrational(x) & Q.rational(y)) == False
 
 def test_imaginary():
-    x, y, z = symbols('x,y,z')
-    I = S.ImaginaryUnit
     assert ask(Q.imaginary(x)) == None
     assert ask(Q.imaginary(x), Q.real(x)) == False
     assert ask(Q.imaginary(x), Q.prime(x)) == False
@@ -904,7 +895,6 @@ def test_imaginary():
     assert ask(Q.imaginary(x+y+z), Q.real(x) & Q.imaginary(y) & Q.imaginary(z)) == False
 
 def test_infinitesimal():
-    x, y = symbols('x,y')
     assert ask(Q.infinitesimal(x)) == None
     assert ask(Q.infinitesimal(x), Q.infinitesimal(x)) == True
 
@@ -916,7 +906,6 @@ def test_infinitesimal():
     assert ask(Q.infinitesimal(x**2), Q.infinitesimal(x)) == True
 
 def test_integer():
-    x = symbols('x')
     assert ask(Q.integer(x)) == None
     assert ask(Q.integer(x), Q.integer(x)) == True
     assert ask(Q.integer(x), ~Q.integer(x)) == False
@@ -937,7 +926,6 @@ def test_integer():
     assert ask(Q.integer(x/3), Q.even(x)) == None
 
 def test_negative():
-    x, y = symbols('x,y')
     assert ask(Q.negative(x), Q.negative(x)) == True
     assert ask(Q.negative(x), Q.positive(x)) == False
     assert ask(Q.negative(x), ~Q.real(x)) == False
@@ -971,7 +959,6 @@ def test_negative():
     assert ask(Q.negative(Abs(x))) == False
 
 def test_nonzero():
-    x, y = symbols('x,y')
     assert ask(Q.nonzero(x)) == None
     assert ask(Q.nonzero(x), Q.real(x)) == None
     assert ask(Q.nonzero(x), Q.positive(x)) == True
@@ -993,7 +980,6 @@ def test_nonzero():
     assert ask(Q.nonzero(Abs(x)), Q.nonzero(x)) == True
 
 def test_odd():
-    x, y, z, t = symbols('x,y,z,t')
     assert ask(Q.odd(x)) == None
     assert ask(Q.odd(x), Q.odd(x)) == True
     assert ask(Q.odd(x), Q.integer(x)) == None
@@ -1040,7 +1026,6 @@ def test_odd():
     assert ask(Q.odd(Abs(x)), Q.odd(x)) == True
 
 def test_prime():
-    x, y = symbols('x,y')
     assert ask(Q.prime(x), Q.prime(x)) == True
     assert ask(Q.prime(x), ~Q.prime(x)) == False
     assert ask(Q.prime(x), Q.integer(x)) == None
@@ -1056,7 +1041,6 @@ def test_prime():
     assert ask(Q.prime(x**y), Q.integer(x) & Q.integer(y)) == False
 
 def test_positive():
-    x, y, z, w = symbols('x,y,z,w')
     assert ask(Q.positive(x), Q.positive(x)) == True
     assert ask(Q.positive(x), Q.negative(x)) == False
     assert ask(Q.positive(x), Q.nonzero(x)) == None
@@ -1089,7 +1073,6 @@ def test_positive_xfail():
     assert ask(Q.positive(1/(1 + x**2)), Q.real(x)) == True
 
 def test_real():
-    x, y = symbols('x,y')
     assert ask(Q.real(x)) == None
     assert ask(Q.real(x), Q.real(x)) == True
     assert ask(Q.real(x), Q.nonzero(x)) == True
@@ -1102,7 +1085,6 @@ def test_real():
     assert ask(Q.real(x/sqrt(2)), Q.real(x)) == True
     assert ask(Q.real(x/sqrt(-2)), Q.real(x)) == False
 
-    I = S.ImaginaryUnit
     assert ask(Q.real(x+1), Q.real(x)) == True
     assert ask(Q.real(x+I), Q.real(x)) == False
     assert ask(Q.real(x+I), Q.complex(x)) == None
@@ -1134,8 +1116,6 @@ def test_real():
     assert ask(Q.real(im(x))) == True
 
 def test_algebraic():
-    x, y = symbols('x,y')
-
     assert ask(Q.algebraic(x)) == None
 
     assert ask(Q.algebraic(I)) == True
@@ -1163,7 +1143,6 @@ def test_algebraic():
 
 def test_global():
     """Test ask with global assumptions"""
-    x = symbols('x')
     assert ask(Q.integer(x)) == None
     global_assumptions.add(Q.integer(x))
     assert ask(Q.integer(x)) == True
@@ -1172,7 +1151,6 @@ def test_global():
 
 def test_custom_context():
     """Test ask with custom assumptions context"""
-    x = symbols('x')
     assert ask(Q.integer(x)) == None
     local_context = AssumptionsContext()
     local_context.add(Q.integer(x))
@@ -1180,20 +1158,15 @@ def test_custom_context():
     assert ask(Q.integer(x)) == None
 
 def test_functions_in_assumptions():
-    from sympy.logic.boolalg import Equivalent, Xor
-    x = symbols('x')
     assert ask(Q.negative(x), Q.real(x) >> Q.positive(x)) is False
     assert ask(Q.negative(x), Equivalent(Q.real(x), Q.positive(x))) is False
     assert ask(Q.negative(x), Xor(Q.real(x), Q.negative(x))) is False
 
 def test_composite_ask():
-    x = symbols('x')
     assert ask(Q.negative(x) & Q.integer(x),
-            assumptions=Q.real(x) >> Q.positive(x)) is False
+           assumptions=Q.real(x) >> Q.positive(x)) is False
 
 def test_composite_proposition():
-    from sympy.logic.boolalg import Equivalent, Implies
-    x = symbols('x')
     assert ask(True) is True
     assert ask(~Q.negative(x), Q.positive(x)) is True
     assert ask(~Q.real(x), Q.commutative(x)) is None
@@ -1209,7 +1182,6 @@ def test_composite_proposition():
     assert ask(Equivalent(Q.positive(x), Q.integer(x)), Q.integer(x)) is None
 
 def test_incompatible_resolutors():
-    x = symbols('x')
     class Prime2AskHandler(AskHandler):
         @staticmethod
         def Number(expr, assumptions):
@@ -1225,10 +1197,8 @@ def test_incompatible_resolutors():
     register_handler('prime', InconclusiveHandler)
     assert ask(Q.prime(3)) == True
 
-
 def test_key_extensibility():
     """test that you can add keys to the ask system at runtime"""
-    x = Symbol('x')
     # make sure the key is not defined
     raises(AttributeError, "ask(Q.my_key(x))")
     class MyAskHandler(AskHandler):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,7 +1,7 @@
-from sympy import S, symbols, exp, pi, sqrt, Rational, I, Q, refine, Abs
+from sympy import Abs, exp, Expr, I, pi, Q, Rational, refine, S, sqrt
+from sympy.abc import x, y, z
 
 def test_Abs():
-    x = symbols('x')
     assert refine(Abs(x), Q.positive(x)) == x
     assert refine(1+Abs(x), Q.positive(x)) == 1+x
     assert refine(Abs(x), Q.negative(x)) == -x
@@ -11,7 +11,6 @@ def test_Abs():
     assert refine(Abs(x**2), Q.real(x)) == x**2
 
 def test_pow():
-    x, y, z = symbols('x,y,z')
     assert refine((-1)**x, Q.even(x)) == 1
     assert refine((-1)**x, Q.odd(x)) == -1
     assert refine((-2)**x, Q.even(x)) == 2**x
@@ -38,7 +37,6 @@ def test_pow():
 
 
 def test_exp():
-    x = symbols('x')
     assert refine(exp(pi*I*2*x), Q.integer(x)) == 1
     assert refine(exp(pi*I*2*(x+Rational(1,2))), Q.integer(x)) == -1
     assert refine(exp(pi*I*2*(x+Rational(1,4))), Q.integer(x)) == I
@@ -46,7 +44,6 @@ def test_exp():
 
 
 def test_func_args():
-    from sympy.core import Expr
     class MyClass(Expr):
         # A class with nontrivial .func
 

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
-from timeit import default_timer as clock
 from random import random
-from sympy import Symbol, I, sqrt, Integer, factorial, pi, exp, pprint, \
-    simplify, sin, sympify, factor
-
-x = Symbol("x")
-y = Symbol("y")
-z = Symbol("z")
+from sympy import factor, I, Integer, pi, simplify, sin, sqrt, Symbol, sympify
+from sympy.abc import x, y, z
+from timeit import default_timer as clock
 
 def bench_R1():
     "real(f(f(f(f(f(f(f(f(f(f(i/2)))))))))))"

--- a/sympy/combinatorics/tests/test_graycode.py
+++ b/sympy/combinatorics/tests/test_graycode.py
@@ -1,5 +1,4 @@
 from sympy.combinatorics.graycode import GrayCode, bin_to_gray, random_bitstring, get_subset_from_bitstring, graycode_subsets
-import random
 
 def test_graycode():
     a = GrayCode(6)

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -1,4 +1,4 @@
-from sympy.core import Expr, S, C, Mul, sympify, Symbol, Tuple
+from sympy.core import C, Expr, Mul, S, sympify, Tuple
 from sympy.core.compatibility import is_sequence
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1,6 +1,6 @@
-from sympy.core import (Expr, S, C, sympify, Wild, Dummy, Derivative, Symbol, Add)
-from sympy.functions.elementary.piecewise import piecewise_fold
+from sympy.core import Add, C, Derivative, Dummy, Expr, S, sympify, Wild
 from sympy.concrete.gosper import gosper_sum
+from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.polys import apart, PolynomialError
 from sympy.solvers import solve
 
@@ -158,7 +158,6 @@ class Sum(Expr):
         Sum(a*b*x, (x, 1, a)) can be differentiated wrt x or b but not `a`
         since the value of the sum is discontinuous in `a`. In a case
         involving a limit variable, the unevaluated derivative is returned.
-
         """
 
         # diff already confirmed that x is in the free symbols of self, but we

--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -1,9 +1,8 @@
 """Tests for Gosper's algorithm for hypergeometric summation. """
 
-from sympy.concrete.gosper import gosper_normal, gosper_term, gosper_sum
-from sympy import S, Poly, symbols, factorial, binomial, gamma, sqrt, simplify
-
-a, b, n, m, k, i, j, r, x = symbols('a,b,n,m,k,i,j,r,x')
+from sympy import binomial, factorial, gamma, Poly, S, simplify, sqrt
+from sympy.abc import a, b, j, k, m, n, r, x
+from sympy.concrete.gosper import gosper_normal, gosper_sum, gosper_term
 
 def test_gosper_normal():
     assert gosper_normal(4*n + 5, 2*(4*n + 1)*(2*n + 3), n) == \
@@ -74,12 +73,6 @@ def test_gosper_sum_AeqB_part1():
 
     g1a = m*(m + 1)*(2*m + 1)*(3*m**2 + 3*m - 1)/30
     g1b = 26 + 2**(m + 1)*(m**3 - 3*m**2 + 9*m - 13)
-    g1c = (m + 1)*(m*(m**2 - 7*m + 3)*sqrt(5) - (3*m**3 - 7*m**2 + 19*m - 6))/(2*m**3*sqrt(5) + m**4 + m**2 - 1)/6
-    g1d = -S(2)/231 + 24**m*(m + 1)*(63*m**4 + 112*m**3 + 18*m**2 - 22*m + 3)/(693*binomial(2*m, m))
-    g1e = -S(9)/2 + (81*m**2 + 261*m + 200)*factorial(3*m + 2)/(40*27**m*factorial(m)*factorial(m + 1)*factorial(m + 2))
-    g1f = (2*m + 1)**2*binomial(2*m, m)**2/(4**(2*m)*(m + 1))
-    g1g = -binomial(2*m, m)**2/4**(2*m)
-    g1h = -(2*m + 1)**2*(3*m + 4)*factorial(m - S(1)/2)**2/factorial(m + 1)**2
 
     g = gosper_sum(f1a, (n, 0, m))
     assert g is not None and simplify(g - g1a) == 0
@@ -104,11 +97,6 @@ def test_gosper_sum_AeqB_part2():
     f2c = factorial(n - 1)**2/(factorial(n - x)*factorial(n + x))
     f2d = n*(n + a + b)*a**n*b**n/(factorial(n + a)*factorial(n + b))
 
-    g2a = -a*(a + 1)/(a - 1)**3 + a**(m + 1)*(a**2*m**2 - 2*a*m*22 + m**2 - 2*a*m + 2*m + a + 1)/(a - 1)**3
-    g2b = -((-m + r)*binomial(r, m))
-    g2c = 1/(factorial(1 - x)*factorial(1 + x)) - 1/(x**2*factorial(1 - x)*factorial(1 + x)) + factorial(m)**2/(x**2*factorial(1 - x)*factorial(1 + x))
-    g2d = 1/(factorial(a - 1)*factorial(b - 1)) - a**(m + 1)*b**(m + 1)/(factorial(a + m)*factorial(b + m))
-
     g = gosper_sum(f2a, (n, 0, m))
     assert g is not None # and simplify(g - g2a) == 0
     g = gosper_sum(f2b, (n, 0, m))
@@ -126,14 +114,6 @@ def test_gosper_sum_AeqB_part3():
     f3e = 2**n/(n + 1)
     f3f = 4*(n - 1)*(n**2 - 2*n - 1)/(n**2*(n + 1)**2*(n - 2)**2*(n - 3)**2)
     f3g = (n**4 - 14*n**2 - 24*n - 9)*2**n/(n**2*(n + 1)**2*(n + 2)**2*(n + 3)**2)
-
-    # g3a -> no closed form
-    g3b = m*(m + 2)/(2*m**2 + 4*m + 3)
-    g3c = 2**m/m**2 - 2
-    g3d = S(2)/3 + 4**(m + 1)*(m - 1)/(m + 2)/3
-    # g3e -> no closed form
-    g3f = -S(1)/16 + 1/((m - 2)**2*(m + 1)**2)
-    g3g = -S(2)/9 + 2**(m + 1)/((m + 1)**2*(m + 3)**2)
 
     g = gosper_sum(f3a, (n, 1, m))
     assert g is None

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,10 +1,11 @@
-from sympy import (S, Symbol, Sum, oo, Float, Rational, summation, pi, cos,
-    zeta, exp, log, factorial, sqrt, E, sympify, binomial, harmonic, Catalan,
-    EulerGamma, Function, Integral, Product, product, nan, diff, Derivative)
+from sympy import (binomial, Catalan, cos, Derivative, E, exp, EulerGamma,
+                   factorial, Function, harmonic, Integral, log, nan, oo, pi,
+                   Product, product, Rational, S, sqrt, Sum, summation, Symbol,
+                   sympify, zeta)
+from sympy.abc import a, b, c, d, k, m, x, y, z
 from sympy.concrete.summations import telescopic
 from sympy.utilities.pytest import XFAIL, raises
 
-a, b, c, d, m, k, x, y, z = map(Symbol, 'abcdmkxyz')
 n = Symbol('n', integer=True)
 
 def test_arithmetic_sums():

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -774,4 +774,3 @@ from function import FunctionClass
 from mul import Mul, _keep_coeff
 from power import Pow
 from sympy.core.numbers import Rational
-from sympy.core.symbol import Dummy

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -786,7 +786,7 @@ class Expr(Basic, EvalfMixin):
 
         if self_c:
             xargs = set(arglist(x))
-            for a in Add.make_args(self):
+            for a in args:
                 margs = set(arglist(a))
                 if len(xargs) > len(margs):
                     continue
@@ -799,7 +799,7 @@ class Expr(Basic, EvalfMixin):
                 return Add(*co)
         elif x_c:
             xargs = set(arglist(x))
-            for a in Add.make_args(self):
+            for a in args:
                 margs, nc = a.args_cnc()
                 if len(xargs) > len(margs):
                     continue
@@ -813,7 +813,7 @@ class Expr(Basic, EvalfMixin):
         else: # both nc
             xargs, nx = x.args_cnc()
             # find the parts that pass the commutative terms
-            for a in Add.make_args(self):
+            for a in args:
                 margs, nc = a.args_cnc()
                 if len(xargs) > len(margs):
                     continue
@@ -1982,7 +1982,7 @@ class Expr(Basic, EvalfMixin):
         never call this method directly (use .nseries() instead), so you don't
         have to write docstrings for _eval_nseries().
         """
-        raise NotImplementedError("(%s).nseries(%s, %s, %s)" % (self, x, x0, n))
+        raise NotImplementedError("(%s).nseries(%s, %s, %s)" % (self, x, n, logx))
 
     def limit(self, x, xlim, dir='+'):
         """ Compute limit x->xlim.
@@ -2001,7 +2001,7 @@ class Expr(Basic, EvalfMixin):
             (This is needed for the gruntz algorithm.)
         """
         from sympy.series.gruntz import calculate_series
-        from sympy import cancel, expand_mul
+        from sympy import cancel
         if self.removeO() == 0:
             return self
         if logx is None:
@@ -2305,7 +2305,7 @@ class AtomicExpr(Atom, Expr):
 from mul import Mul
 from add import Add
 from power import Pow
-from function import Derivative, expand_mul, expand_multinomial, UndefinedFunction
+from function import Derivative, expand_mul
 from sympify import sympify
 from symbol import Wild
 from exprtools import factor_terms

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -13,8 +13,6 @@ from sympy.core.symbol import Dummy
 from sympy.core.coreerrors import NonCommutativeExpression
 from sympy.core.containers import Tuple
 
-from collections import defaultdict
-
 def decompose_power(expr):
     """
     Decompose power into symbolic base and integer exponent.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -360,7 +360,7 @@ functions are not supported.')
         args = self.args
         args0 = [t.limit(x, 0) for t in args]
         if any(t.is_bounded == False for t in args0):
-            from sympy import Dummy, oo, zoo, nan
+            from sympy import oo, zoo, nan
             a = [t.compute_leading_term(x, logx=logx) for t in args]
             a0 = [t.limit(x, 0) for t in a]
             if any ([t.has(oo, -oo, zoo, nan) for t in a0]):

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1005,7 +1005,6 @@ def test_sympy__physics__quantum__operator__UnitaryOperator():
 
 def test_sympy__physics__quantum__piab__PIABBra():
     from sympy.physics.quantum.piab import PIABBra
-    from sympy.physics.quantum import Bra
     assert _test_args(PIABBra('B'))
 
 def test_sympy__physics__quantum__piab__PIABHamiltonian():
@@ -1053,7 +1052,7 @@ def test_sympy__physics__quantum__qubit__Qubit():
     assert _test_args(Qubit(0, 0, 0))
 
 def test_sympy__physics__quantum__qubit__QubitBra():
-    from sympy.physics.quantum.qubit import QubitBra, QubitState
+    from sympy.physics.quantum.qubit import QubitBra
     assert _test_args(QubitBra('1', 0))
 
 def test_sympy__physics__quantum__qubit__QubitState():
@@ -1152,7 +1151,6 @@ def test_sympy__physics__quantum__spin__SpinState():
 
 def test_sympy__physics__quantum__spin__WignerD():
     from sympy.physics.quantum.spin import WignerD
-    from sympy import sympify
     assert _test_args(WignerD(0, 1, 2, 3, 4, 5))
 
 def test_sympy__physics__quantum__state__Bra():
@@ -1193,7 +1191,7 @@ def test_sympy__physics__quantum__state__TimeDepState():
 
 def test_sympy__physics__quantum__state__Wavefunction():
     from sympy.physics.quantum.state import Wavefunction
-    from sympy.functions import sqrt, sin
+    from sympy.functions import sin
     from sympy import Piecewise, pi
     n = 1
     L = 1
@@ -1223,7 +1221,7 @@ def test_sympy__physics__secondquant__AntiSymmetricTensor():
     assert _test_args(AntiSymmetricTensor('v', (a, i), (b, j)))
 
 def test_sympy__physics__secondquant__BosonState():
-    from sympy.physics.secondquant import BosonState, FockState
+    from sympy.physics.secondquant import BosonState
     assert _test_args(BosonState((0, 1)))
 
 @SKIP("abstract class")
@@ -1289,7 +1287,7 @@ def test_sympy__physics__secondquant__FockStateKet():
 
 def test_sympy__physics__secondquant__InnerProduct():
     from sympy.physics.secondquant import InnerProduct
-    from sympy.physics.secondquant import NO, FockStateKet, FockStateBra
+    from sympy.physics.secondquant import FockStateKet, FockStateBra
     assert _test_args(InnerProduct(FockStateBra((0, 1)), FockStateKet((0, 1))))
 
 def test_sympy__physics__secondquant__NO():

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -1,6 +1,5 @@
 from sympy.core import Rational, Symbol, S, Float, Integer, Number
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.utilities.pytest import XFAIL
 
 def test_issue153():
     #test that is runs:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,17 +1,10 @@
-from sympy.core.evalf import PrecisionExhausted, complex_accuracy
-
-from sympy import pi, I, Symbol, Add, Rational, exp, sqrt, sin, cos, \
-    fibonacci, E, log, floor, ceiling, Sum, oo,\
-    factorial, GoldenRatio, sympify, \
-    sstr, Function, Eq, Mul, Pow
-
+from sympy import (Add, ceiling, cos, E, Eq, exp, factorial, fibonacci, floor,
+                   Function, GoldenRatio, I, log, Mul, oo, pi, Pow, Rational,
+                   sin, sqrt, sstr, Sum, sympify)
+from sympy.core.evalf import complex_accuracy, PrecisionExhausted
+from sympy.abc import n, x, y
 from sympy.mpmath.libmp.libmpf import from_float
-
 from sympy.utilities.pytest import raises, XFAIL
-
-x = Symbol('x')
-y = Symbol('y')
-n = Symbol('n')
 
 def NS(e, n=15, **options):
     return sstr(sympify(e).evalf(n, **options), full_prec=True)
@@ -221,7 +214,6 @@ def test_evalf_arguments():
 def test_implemented_function_evalf():
     from sympy.utilities.lambdify import implemented_function
     f = Function('f')
-    x = Symbol('x')
     f = implemented_function(f, lambda x: x + 1)
     assert str(f(x)) == "f(x)"
     assert str(f(2)) == "f(2)"

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,8 +6,8 @@ from sympy import (Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I,
     Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp, simplify, together,
     separate, collect, factorial, apart, combsimp, factor, refine, cancel,
     Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum)
+from sympy.abc import a, b, c, d, e, n, t, u, x, y, z
 from sympy.physics.secondquant import FockState
-from sympy.physics.units import m, s
 
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -96,11 +96,8 @@ class F1_1(DummyNumber):
     def __float__(self):
         return self.number
 
-x,y,z,t,u,n = symbols('x,y,z,t,u,n')
-
 i5 = I5()
 f1_1 = F1_1()
-
 
 # basic sympy objects
 basic_objs = [
@@ -161,11 +158,11 @@ def test_relational():
 
 def test_relational_noncommutative():
     from sympy import Lt, Gt, Le, Ge
-    a, b = symbols('a b', commutative=False)
-    assert (a < b)  == Lt(a, b)
-    assert (a <= b) == Le(a, b)
-    assert (a > b)  == Gt(a, b)
-    assert (a >= b) == Ge(a, b)
+    A, B = symbols('A,B', commutative=False)
+    assert (A < B)  == Lt(A, B)
+    assert (A <= B) == Le(A, B)
+    assert (A > B)  == Gt(A, B)
+    assert (A >= B) == Ge(A, B)
 
 def test_basic_nostr():
     for obj in basic_objs:
@@ -235,7 +232,6 @@ def test_atoms():
     assert sorted(list(Poly(x + y, x, y, z).atoms())) == sorted([x, y])
     assert sorted(list(Poly(x + y*t, x, y, z).atoms())) == sorted([t, x, y])
 
-    I = S.ImaginaryUnit
     assert list((I*pi).atoms(NumberSymbol)) == [pi]
     assert sorted((I*pi).atoms(NumberSymbol, I)) == \
            sorted((I*pi).atoms(I,NumberSymbol)) == [pi, I]
@@ -248,8 +244,6 @@ def test_atoms():
                                                     3 + z])
 
 def test_is_polynomial():
-    z = Symbol('z')
-
     k = Symbol('k', nonnegative=True, integer=True)
 
     assert Rational(2).is_polynomial(x, y, z) == True
@@ -294,8 +288,6 @@ def test_is_polynomial():
     assert ((x**2)*(y**2) + x*(y**2) + y*x + exp(x)).is_polynomial(x, y) == False
 
 def test_is_rational_function():
-    x,y = symbols('x y')
-
     assert Integer(1).is_rational_function() == True
     assert Integer(1).is_rational_function(x) == True
 
@@ -350,7 +342,6 @@ def test_SAGE3():
     assert e == ('mys', x, o)
 
 def test_len():
-    x, y, z = symbols("x y z")
     e = x*y
     assert len(e.args) == 2
     e = x+y+z
@@ -392,7 +383,6 @@ def test_noncommutative_expand_issue658():
     assert (A*(A+B+C)*B).expand() == A**2*B + A*B**2 + A*C*B
 
 def test_as_numer_denom():
-    a, b, c = symbols('a, b, c')
     assert oo.as_numer_denom() == (1, 0)
     assert (-oo).as_numer_denom() == (-1, 0)
     assert zoo.as_numer_denom() == (zoo, 1)
@@ -489,8 +479,6 @@ def test_as_independent():
            (Integral(x, (x, 1, 2)), x)
 
 def test_subs_dict():
-    a,b,c,d,e = symbols('a,b,c,d,e')
-
     assert (sin(x))._subs_dict({ x : 1, sin(x) : 2}) == 2
     assert (sin(x))._subs_dict([(x, 1), (sin(x), 2)]) == 2
 
@@ -503,7 +491,6 @@ def test_subs_dict():
     assert expr._subs_dict(seq) == c + a*b*sin(d*e)
 
 def test_subs_list():
-
     assert (sin(x))._subs_list([(sin(x), 2), (x, 1)]) == 2
     assert (sin(x))._subs_list([(x, 1), (sin(x), 2)]) == sin(1)
 
@@ -764,9 +751,6 @@ def test_is_number():
     assert a.is_number == False
 
 def test_as_coeff_add():
-    x = Symbol('x')
-    y = Symbol('y')
-
     assert S(2).as_coeff_add() == (2, ())
     assert S(3.0).as_coeff_add() == (0, (S(3.0),))
     assert S(-3.0).as_coeff_add() == (0, (S(-3.0),))
@@ -781,9 +765,6 @@ def test_as_coeff_add():
     assert e.as_coeff_add(y) == (0, (e,))
 
 def test_as_coeff_mul():
-    x = Symbol('x')
-    y = Symbol('y')
-
     assert S(2).as_coeff_mul() == (2, ())
     assert S(3.0).as_coeff_mul() == (1, (S(3.0),))
     assert S(-3.0).as_coeff_mul() == (-1, (S(3.0),))
@@ -855,9 +836,6 @@ def test_extractions():
     assert (-x + y).could_extract_minus_sign() == True
 
 def test_coeff():
-    from sympy.abc import x, y, z
-    from sympy import sqrt
-
     assert (x+1).coeff(x+1) == 1
     assert (3*x).coeff(0) == None
     assert (z*(1+x)*x**2).coeff(1+x) == z*x**2
@@ -962,7 +940,6 @@ def test_issue1864():
     assert hasattr(expr, "is_commutative")
 
 def test_action_verbs():
-    a,b,c,d = symbols('a,b,c,d')
     assert nsimplify((1/(exp(3*pi*x/5)+1))) == (1/(exp(3*pi*x/5)+1)).nsimplify()
     assert ratsimp(1/x + 1/y) == (1/x + 1/y).ratsimp()
     assert trigsimp(log(x), deep=True) == (log(x)).trigsimp(deep = True)
@@ -992,7 +969,6 @@ def test_as_coefficients_dict():
     assert (3.0*x*y).as_coefficients_dict()[3.0*x*y] == 1
 
 def test_args_cnc():
-    a, x = symbols('a,x')
     A = symbols('A', commutative=False)
     assert (x+A).args_cnc() == \
         [set([]), [x + A]]
@@ -1004,7 +980,6 @@ def test_args_cnc():
         [[x, y], [A, 1 + A]]
 
 def test_new_rawargs():
-    x, y = symbols('x,y')
     n = Symbol('n', commutative=False)
     a = x + n
     assert a.is_commutative is False
@@ -1158,6 +1133,7 @@ def test_as_ordered_terms():
     assert f.as_ordered_terms(order="rev-grlex") == [2, y, x**2*y**2, x*y**4]
 
 def test_sort_key_atomic_expr():
+    from sympy.physics.units import m, s
     assert sorted([-m, s], key=lambda arg: arg.sort_key()) == [-m, s]
 
 def test_issue_1100():
@@ -1197,7 +1173,6 @@ def test_issue_2744():
     assert ((3*a)*(2*a)).extract_multiplicatively(a) == 6*a
 
 def test_is_constant():
-    from sympy.abc import a, n, x, y
     from sympy.solvers.solvers import checksol
     Sum(x, (x, 1, 10)).is_constant() == True
     Sum(x, (x, 1, n)).is_constant() == False
@@ -1230,7 +1205,6 @@ def test_is_not_constant():
     assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero != False
 
 def test_equals():
-    a, x = symbols('a, x')
     assert (x**2 - 1).equals((x + 1)*(x - 1))
     assert (cos(x)**2 + sin(x)**2).equals(1)
     assert (a*cos(x)**2 + a*sin(x)**2).equals(a)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,10 +1,9 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
-from sympy.core.exprtools import (
-    decompose_power, Factors, Term, _gcd_terms, gcd_terms, factor_terms)
-
 from sympy import S, Add, sin, Mul, Symbol, oo, Integral
-from sympy.abc import a, b, x, y, z, t
+from sympy.abc import a, b, t, x, y, z
+from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
+                                  gcd_terms, factor_terms)
 from sympy.core.mul import _keep_coeff as _keep_coeff
 
 def test_decompose_power():

--- a/sympy/core/tests/test_facts.py
+++ b/sympy/core/tests/test_facts.py
@@ -1,12 +1,11 @@
 from sympy.core.facts import deduce_alpha_implications, apply_beta_to_alpha_route, \
         rules_2prereq, split_rules_tt_tf_ft_ff, FactRules
 from sympy.core.logic import And
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises
 
 T = True
 F = False
 U = None
-
 
 def test_deduce_alpha_implications():
     def D(i):

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -1,16 +1,16 @@
 from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma,
-        Tuple, Dummy, Eq, Expr)
+        Tuple, Dummy, Eq, Expr, symbols)
 from sympy.utilities.pytest import XFAIL, raises
-from sympy.abc import x, y, n
+from sympy.abc import t, w, x, y, z
 from sympy.core.function import PoleError
 from sympy.utilities.iterables import subsets, variations
 
+f, g, h = symbols('f g h', cls=Function)
+
 def test_f_expand_complex():
-    f = Function('f')
     x = Symbol('x', real=True)
-    z = Symbol('z')
 
     assert f(x).expand(complex=True)        == I*im(f(x)) + re(f(x))
     assert exp(x).expand(complex=True)      == exp(x)
@@ -19,8 +19,6 @@ def test_f_expand_complex():
                                              I*sin(im(z))*exp(re(z))
 
 def test_bug1():
-    w = Symbol("w")
-
     e = sqrt(-log(w))
     assert e.subs(log(w),-x) == sqrt(x)
 
@@ -43,7 +41,6 @@ def test_general_function():
     assert edxdy == 0
 
 def test_derivative_subs_bug():
-    x = Symbol("x y")
     l = Function('l')
     n = Function('n')
 
@@ -55,15 +52,12 @@ def test_derivative_subs_bug():
     assert e.subs(x, y) == Derivative(n(y), y)
 
 def test_derivative_subs_self_bug():
-    f = Function('f')
     d = diff(f(x), x)
 
     assert d.subs(d, y) == y
 
 
 def test_derivative_linearity():
-    x = Symbol("x")
-    y = Symbol("y")
     n = Function('n')
 
     assert diff(-n(x), x) == -diff(n(x), x)
@@ -73,21 +67,13 @@ def test_derivative_linearity():
     assert diff(8*n(x)*y*x, x) == 8*y*n(x) + 8*y*x*diff(n(x), x)
 
 def test_derivative_evaluate():
-    x = Symbol('x')
-
     assert Derivative(sin(x), x) != diff(sin(x), x)
     assert Derivative(sin(x), x).doit() == diff(sin(x), x)
 
-    f = Function('f')
     assert Derivative(Derivative(f(x), x), x) == diff(f(x), x, x)
     assert Derivative(sin(x), x, 0) == sin(x)
 
 def test_diff_symbols():
-    x = Symbol('x')
-    y = Symbol('y')
-    z = Symbol('z')
-    f = Function('f')
-
     assert diff(f(x, y, z), x, y, z) == Derivative(f(x, y, z), x, y, z)
     assert diff(f(x, y, z), x, x, x) == Derivative(f(x, y, z), x, x, x)
     assert diff(f(x, y, z), x, 3) == Derivative(f(x, y, z), x, 3)
@@ -104,7 +90,6 @@ def test_diff_symbols():
 
 def test_Lambda():
     e = Lambda(x, x**2)
-    f = Function('f')
     assert e(4) == 16
     assert e(x) == x**2
     assert e(y) == y**2
@@ -125,8 +110,6 @@ def test_Lambda():
 
     assert Lambda((x, y), x+y).nargs == 2
 
-    z = Symbol('z')
-    t = Symbol('t')
     p = x, y, z, t
     assert Lambda(p, t*(x+y+z))(*p) == t * (x + y + z)
 
@@ -155,12 +138,6 @@ def test_Lambda_equality():
     assert (Lambda(x, 2*x) == 2*x) is False
 
 def test_Subs():
-    x = Symbol('x')
-    y = Symbol('y')
-    z = Symbol('z')
-    f = Function('f')
-    g = Function('g')
-
     assert Subs(f(x), x, 0).doit() == f(0)
     assert Subs(f(x**2), x**2, 0).doit() == f(0)
     assert Subs(f(x, y), (x, y), (0, 1)).doit() == f(0, 1)
@@ -207,8 +184,6 @@ def test_Subs():
 
 @XFAIL
 def test_Subs2():
-    x = Symbol('x')
-    f = Function('f')
     # this reflects a limitation of subs(), probably won't fix
     assert Subs(f(x), x**2, x).doit() == f(sqrt(x))
 
@@ -219,8 +194,6 @@ def test_expand_function():
     assert expand((x + y)**11, modulus=11) == x**11 + y**11
 
 def test_function_comparable():
-    x = Symbol('x')
-
     assert sin(x).is_comparable == False
     assert cos(x).is_comparable == False
 
@@ -243,9 +216,6 @@ def test_function_comparable_infinities():
 def test_deriv1():
     # These all requre derivatives evaluated at a point (issue 1620) to work.
     # See issue 1525
-    f = Function('f')
-    x = Symbol('x')
-
     assert f(2*x).diff(x) == 2*Subs(Derivative(f(x), x), Tuple(x), Tuple(2*x))
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
     assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Subs(Derivative(f(x), x), Tuple(x),
@@ -258,8 +228,6 @@ def test_deriv1():
             Tuple(x), Tuple(3*sin(x)))
 
 def test_deriv2():
-    x = Symbol('x')
-
     assert (x**3).diff(x) == 3*x**2
     assert (x**3).diff(x, evaluate=False) != 3*x**2
     assert (x**3).diff(x, evaluate=False) == Derivative(x**3, x)
@@ -269,10 +237,6 @@ def test_deriv2():
     assert diff(x**3, x, evaluate=False) == Derivative(x**3, x)
 
 def test_func_deriv():
-    f = Function('f')
-    x = Symbol('x')
-    y = Symbol('y')
-
     assert f(x).diff(x) == Derivative(f(x), x)
     # issue 1435
     assert f(x, y).diff(x, y) - f(x, y).diff(y, x) == 0
@@ -306,14 +270,14 @@ def test_extensibility_eval():
 
 def test_function_non_commutative():
     x = Symbol('x', commutative=False)
-    f = Function('f')
     assert f(x).is_commutative == False
     assert sin(x).is_commutative == False
     assert exp(x).is_commutative == False
     assert log(x).is_commutative == False
 
 def test_function__eval_nseries():
-    x = Symbol('x')
+    n = Symbol('n')
+
     assert sin(x)._eval_nseries(x,2,None) == x + O(x**2)
     assert sin(x+1)._eval_nseries(x,2,None) == x*cos(1) + sin(1) + O(x**2)
     assert sin(pi*(1-x))._eval_nseries(x,2,None) == pi*x + O(x**2)
@@ -328,7 +292,7 @@ def test_function__eval_nseries():
     assert loggamma(log(1/x)).nseries(x,n=1,logx=y) == loggamma(-y)
 
 def test_doit():
-    n = Symbol('n', integer = True)
+    n = Symbol('n', integer=True)
     f = Sum(2 * n * x, (n, 1, 3))
     d = Derivative(f, x)
     assert d.doit() == 12
@@ -381,7 +345,6 @@ def test_fdiff_argument_index_error():
     raises(TypeError, 'myfunc(x, x)')
 
 def test_deriv_wrt_function():
-    t = Symbol('t')
     xfunc = Function('x')
     yfunc = Function('y')
     x = xfunc(t)
@@ -389,7 +352,6 @@ def test_deriv_wrt_function():
     xdd = diff(xd, t)
     y = yfunc(t)
     yd = diff(y, t)
-    ydd = diff(yd, t)
 
     assert diff(x, t) == xd
     assert diff(2 * x + 4, t) == 2 * xd
@@ -407,9 +369,6 @@ def test_deriv_wrt_function():
     assert diff(sqrt(x), t) == xd / (2 * sqrt(x))
 
 def test_diff_wrt_value():
-    x = Symbol('x')
-    f = Function('f')
-
     assert Expr()._diff_wrt == False
     assert x._diff_wrt == True
     assert f(x)._diff_wrt == True
@@ -417,10 +376,6 @@ def test_diff_wrt_value():
     assert Derivative(x**2,x)._diff_wrt == False
 
 def test_diff_wrt():
-    x = Symbol('x')
-    f = Function('f')
-    g = Function('g')
-    h = Function('h')
     fx = f(x)
     dfx = diff(f(x),x)
     ddfx = diff(f(x),x,x)
@@ -454,16 +409,11 @@ def test_diff_wrt():
     assert diff(f(g(x)),g(x)) == Derivative(f(g(x)),g(x))
 
 def test_diff_wrt_not_allowed():
-    x = Symbol('x')
-    y = Symbol('y')
-
     raises(ValueError, 'diff(sin(x**2),x**2)')
     raises(ValueError, 'diff(exp(x*y)),x*y')
     raises(ValueError, 'diff(1+x,1+x)')
 
 def test_klein_gordon_lagrangian():
-    x = Symbol('x')
-    t = Symbol('t')
     m = Symbol('m')
     phi = Function('phi')(x,t)
 
@@ -473,7 +423,6 @@ def test_klein_gordon_lagrangian():
     assert eqna == eqnb
 
 def test_sho_lagrangian():
-    t = Symbol('t')
     m = Symbol('m')
     k = Symbol('k')
     x = Function('x')(t)
@@ -488,7 +437,6 @@ def test_sho_lagrangian():
     assert diff(L,t,diff(x,t)) == -k*x + m*diff(x,t,2)
 
 def test_straight_line():
-    x = Symbol('x')
     f = Function('f')(x)
 
     L = sqrt(1 + diff(f,x)**2)
@@ -497,12 +445,6 @@ def test_straight_line():
 
 def test_sort_variable():
     vsort = Derivative._sort_variables
-    x = Symbol('x')
-    y = Symbol('y')
-    z = Symbol('z')
-    f = Function('f')
-    g = Function('g')
-    h = Function('h')
 
     assert vsort((x,y,z)) == [x, y, z]
     assert vsort((h(x),g(x),f(x))) == [f(x), g(x), h(x)]
@@ -515,13 +457,6 @@ def test_sort_variable():
         [y, z, f(x), x, f(x), g(x), x, y, z, z]
 
 def test_unhandled():
-    x = Symbol('x')
-    y = Symbol('y')
-    z = Symbol('z')
-    f = Function('f')
-    g = Function('g')
-    h = Function('h')
-
     class MyExpr(Expr):
         def _eval_derivative(self, s):
             if not s.name.startswith('diff_wrt'):

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -5,10 +5,7 @@ from sympy.utilities.pytest import XFAIL
 
 def test_subs():
     n3=Rational(3)
-    n2=Rational(2)
-    n6=Rational(6)
     x=Symbol("x")
-    c=Symbol("c")
     e=x
     e=e.subs(x,n3)
     assert e == Rational(3)

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,5 +1,5 @@
 from sympy import (Symbol, Wild, Inequality, StrictInequality, pi, I, Rational,
-    sympify, symbols, Dummy, S, Function, flatten)
+    sympify, symbols, Dummy, Function, flatten)
 
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.core.compatibility import SymPyDeprecationWarning
@@ -66,9 +66,7 @@ def test_lt_gt():
 def test_no_len():
     # there should be no len for numbers
     x = Symbol('x')
-    xxl = Symbol('xxl')
     raises(TypeError, "len(x)")
-    raises(TypeError, "len(xxl)")
 
 def test_Wild_properties():
     # these tests only include Atoms
@@ -76,7 +74,6 @@ def test_Wild_properties():
     y   = Symbol("y")
     p   = Symbol("p", positive=True)
     k   = Symbol("k", integer=True)
-    r   = Symbol("r", real=True)
     n   = Symbol("n", integer=True, positive=True)
 
     given_patterns = [ x, y, p, k, -k, n, -n, sympify(-3), sympify(3), pi, Rational(3,2), I ]

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -11,7 +11,6 @@ from sympy import mpmath
 
 def test_439():
     v = sympify("exp(x)")
-    x = Symbol("x")
     assert v == exp(x)
     assert type(v) == type(exp(x))
     assert str(type(v)) == str(type(exp(x)))


### PR DESCRIPTION
These commits fix pyflakes errors in assumptions, benchmarks, combinatorics, concrete, and core as well as refactor a few of the tests.

Tested on Windows using Python 2.7.2 and 3.2.1.

GCI Task: http://www.google-melange.com/gci/task/view/google/gci2011/7134381
