### PR TITLE
Add class Mod for modulo operation

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -12,6 +12,7 @@ from numbers import Number, Float, Rational, Integer, NumberSymbol,\
 from power import Pow, integer_nthroot
 from mul import Mul, prod
 from add import Add
+from mod import Mod
 from relational import Rel, Eq, Ne, Lt, Le, Gt, Ge, \
     Equality, Inequality, Unequality, StrictInequality
 from multidimensional import vectorize

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -144,6 +144,14 @@ class Expr(Basic, EvalfMixin):
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
 
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rmod__')
+    def __mod__(self, other):
+        return Mod(self, other)
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__mod__')
+    def __rmod__(self, other):
+        return Mod(other, self)
 
     def __float__(self):
         result = self.evalf()
@@ -2306,6 +2314,7 @@ from mul import Mul
 from add import Add
 from power import Pow
 from function import Derivative, expand_mul
+from mod import Mod
 from sympify import sympify
 from symbol import Wild
 from exprtools import factor_terms

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,0 +1,30 @@
+from cache import cacheit
+from expr import Expr
+from sympify import sympify
+
+class Mod(Expr):
+    '''Represents a modulo operation on symbolic expressions.
+
+    Receives two arguments, dividend and divisor. If both are Numbers, the
+    result is evaluated immediately.
+
+    The convention used is the same as python's: the remainder always has the
+    same sign as the divisor.
+
+    Examples:
+    >>> from sympy.abc import x, y
+    >>> x**2 % y
+    Mod(x**2, y)
+    >>> _.subs({x: 5, y: 6})
+    1
+
+    '''
+    @cacheit
+    def __new__(cls, *args, **options):
+        if len(args) != 2:
+            raise TypeError("Mod receives two arguments, only %s passed" %
+                    len(args))
+        dividend, divisor = map(sympify, args)
+        if dividend.is_Number and divisor.is_Number:
+            return dividend % divisor
+        return Expr.__new__(cls, *args)

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,17 +1,16 @@
-from cache import cacheit
-from expr import Expr
-from sympify import sympify
+from function import Function
 
-class Mod(Expr):
+class Mod(Function):
     '''Represents a modulo operation on symbolic expressions.
 
-    Receives two arguments, dividend and divisor. If both are Numbers, the
-    result is evaluated immediately.
+    Receives two arguments, dividend p and divisor q.
 
     The convention used is the same as python's: the remainder always has the
     same sign as the divisor.
 
-    Examples:
+    Examples
+    --------
+
     >>> from sympy.abc import x, y
     >>> x**2 % y
     Mod(x**2, y)
@@ -19,12 +18,10 @@ class Mod(Expr):
     1
 
     '''
-    @cacheit
-    def __new__(cls, *args, **options):
-        if len(args) != 2:
-            raise TypeError("Mod receives two arguments, only %s passed" %
-                    len(args))
-        dividend, divisor = map(sympify, args)
-        if dividend.is_Number and divisor.is_Number:
-            return dividend % divisor
-        return Expr.__new__(cls, *args)
+    nargs = 2
+
+    @classmethod
+    def eval(cls, p, q):
+        if p.is_Number and q.is_Number:
+            return p % q
+        return Mod(p, q, evaluate=False)

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -168,6 +168,10 @@ def test_sympy__core__function__WildFunction():
     from sympy.core.function import WildFunction
     assert _test_args(WildFunction('f'))
 
+def test_sympy__core__mod__Mod():
+    from sympy.core.mod import Mod
+    assert _test_args(Mod(x, 2))
+
 def test_sympy__core__mul__Mul():
     from sympy.core.mul import Mul
     assert _test_args(Mul(2, x, y, z))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 from sympy import Symbol, sin, cos, exp, O, sqrt, Rational, Float, re, pi, \
-        sympify, Add, Mul, Pow, I, log, S
+        sympify, Add, Mul, Pow, Mod, I, log, S
 from sympy.utilities.pytest import XFAIL
 
 x = Symbol('x')
@@ -1208,3 +1208,13 @@ def test_product_irrational():
 
 def test_issue_2820():
     assert (x/(y*(1 + y))).expand() == x/(y**2 + y)
+
+def test_Mod():
+    assert Mod(5, 3) == 2
+    assert Mod(-5, 3) == 1
+    assert Mod(5, -3) == -1
+    assert Mod(-5, -3) == -2
+    assert 5 % x == Mod(5, x)
+    assert x % 5 == Mod(x, 5)
+    assert x % y == Mod(x, y)
+    assert (x % y).subs({x: 5, y: 3}) == 2

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1214,6 +1214,7 @@ def test_Mod():
     assert Mod(-5, 3) == 1
     assert Mod(5, -3) == -1
     assert Mod(-5, -3) == -2
+    assert type(Mod(3.2, 2, evaluate=False)) == Mod
     assert 5 % x == Mod(5, x)
     assert x % 5 == Mod(x, 5)
     assert x % y == Mod(x, y)


### PR DESCRIPTION
This pull request is based on PR 442 by @renatocoutinho. I implemented recommendations from that PR. See also issue 2490.

Here are some examples from isympy that show the functionality now available:

``` python
In [1]: x % 4.2
Out[1]: Mod(x, 4.2)

In [2]: Mod(4, 3, evaluate=False)
Out[2]: Mod(4, 3)

In [3]: _.doit()
Out[3]: 1

In [4]: 5 % 3
Out[4]: 2
```
