### PR TITLE
Imported parsing module documentation into Sphinx

### DIFF
--- a/doc/src/modules/index.txt
+++ b/doc/src/modules/index.txt
@@ -42,6 +42,7 @@ access any SymPy module, or use this contens:
    solvers/solvers.txt
    tensor/index.txt
    utilities/index.txt
+   parsing.txt
    physics/index.txt
 
 Contributions to docs

--- a/doc/src/modules/parsing.txt
+++ b/doc/src/modules/parsing.txt
@@ -1,0 +1,32 @@
+Parsing input
+=============
+
+Parsing Functions Reference
+---------------------------
+
+.. autofunction:: sympy.parsing.sympy_parser.parse_expr
+
+.. autofunction:: sympy.parsing.sympy_tokenize.printtoken
+
+.. autofunction:: sympy.parsing.sympy_tokenize.tokenize
+
+.. autofunction:: sympy.parsing.sympy_tokenize.untokenize
+
+.. autofunction:: sympy.parsing.sympy_tokenize.generate_tokens
+
+.. autofunction:: sympy.parsing.sympy_tokenize.group
+
+.. autofunction:: sympy.parsing.sympy_tokenize.any
+
+.. autofunction:: sympy.parsing.sympy_tokenize.maybe
+
+.. autofunction:: sympy.parsing.maxima.parse_maxima
+
+.. autofunction:: sympy.parsing.mathematica.mathematica
+
+Parsing Exceptions Reference
+----------------------------
+
+.. autoclass:: sympy.parsing.sympy_tokenize.TokenError
+
+.. autoclass:: sympy.parsing.sympy_tokenize.StopTokenizing

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -91,7 +91,8 @@ def parse_expr(s, local_dict=None, rationalize=False, convert_xor=False):
     """
     Converts the string ``s`` to a SymPy expression, in ``local_dict``
 
-    **Examples**
+    Examples
+    ========
 
     >>> from sympy.parsing.sympy_parser import parse_expr
 

--- a/sympy/parsing/sympy_tokenize.py
+++ b/sympy/parsing/sympy_tokenize.py
@@ -251,6 +251,9 @@ def untokenize(iterable):
         Untokenized source will match input source exactly
 
     Round-trip invariant for limited intput:
+
+    ::
+
         # Output text will tokenize the back to the input
         t1 = [tok[:2] for tok in generate_tokens(f.readline)]
         newcode = untokenize(t1)
@@ -268,6 +271,9 @@ def generate_tokens(readline):
     readline() method of built-in file objects. Each call to the function
     should return one line of input as a string.  Alternately, readline
     can be a callable function terminating with StopIteration:
+
+    ::
+
         readline = open(myfile).next    # Example of alternate readline
 
     The generator produces 5-tuples with these members: the token type; the

--- a/sympy/parsing/sympy_tokenize.py
+++ b/sympy/parsing/sympy_tokenize.py
@@ -250,7 +250,7 @@ def untokenize(iterable):
     Round-trip invariant for full input:
         Untokenized source will match input source exactly
 
-    Round-trip invariant for limited intput: ::
+    Round-trip invariant for limited intput::
 
         # Output text will tokenize the back to the input
         t1 = [tok[:2] for tok in generate_tokens(f.readline)]
@@ -268,7 +268,7 @@ def generate_tokens(readline):
     must be a callable object which provides the same interface as the
     readline() method of built-in file objects. Each call to the function
     should return one line of input as a string.  Alternately, readline
-    can be a callable function terminating with StopIteration: ::
+    can be a callable function terminating with StopIteration::
 
         readline = open(myfile).next    # Example of alternate readline
 

--- a/sympy/parsing/sympy_tokenize.py
+++ b/sympy/parsing/sympy_tokenize.py
@@ -250,9 +250,7 @@ def untokenize(iterable):
     Round-trip invariant for full input:
         Untokenized source will match input source exactly
 
-    Round-trip invariant for limited intput:
-
-    ::
+    Round-trip invariant for limited intput: ::
 
         # Output text will tokenize the back to the input
         t1 = [tok[:2] for tok in generate_tokens(f.readline)]
@@ -270,9 +268,7 @@ def generate_tokens(readline):
     must be a callable object which provides the same interface as the
     readline() method of built-in file objects. Each call to the function
     should return one line of input as a string.  Alternately, readline
-    can be a callable function terminating with StopIteration:
-
-    ::
+    can be a callable function terminating with StopIteration: ::
 
         readline = open(myfile).next    # Example of alternate readline
 


### PR DESCRIPTION
I've fixed details in formatting.

I didn't include all functions. Some looked irrelevant to docs site and didn't have any docstrings.

Also: errors while compiling docs are due to some changes in core module - I didn't touch this.

Note: this is GCI task http://www.google-melange.com/gci/task/view/google/gci2011/7134390
