### PR TITLE
Minor fix for tutorial

### DIFF
--- a/doc/src/tutorial.txt
+++ b/doc/src/tutorial.txt
@@ -202,6 +202,7 @@ symbolic variables explicitly::
     >>> from sympy import *
     >>> x = Symbol('x')
     >>> y = Symbol('y')
+    >>> z = Symbol('z')
 
 On the left is the normal Python variable which has been assigned to the
 SymPy Symbol class. Instances of the Symbol class "play well together"


### PR DESCRIPTION
The example in Algebra section showing the use of `together` needs a `z`.
