### PR TITLE
Import printing module into doc

### DIFF
--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -10,14 +10,14 @@ internally.
 Printer Class
 -------------
 
-.. module:: sympy.printing.printer
+.. automodule:: sympy.printing.printer
 
 The main class responsible for printing is ``Printer`` (see also its
 `source code
 <https://github.com/sympy/sympy/blob/master/sympy/printing/printer.py>`_):
 
 .. autoclass:: Printer
-    :members: doprint, _print
+    :members: doprint, _print, set_global_settings, order
 
 PrettyPrinter Class
 -------------------
@@ -274,7 +274,46 @@ This class implements Python printing. Usage::
     x = Symbol('x')
     e = 5*x**3 + sin(x)
 
+ReprPrinter
+-----------
 
+.. module:: sympy.printing.repr
+
+This printer generates executable code. This code satisfies the identity
+``eval(srepr(expr))=expr``.
+
+.. autoclass:: ReprPrinter
+   :members:
+
+.. autofunction:: srepr
+
+StrPrinter
+----------
+
+.. module:: sympy.printing.str
+
+This module generates readable representations of SymPy expressions.
+
+.. autoclass:: StrPrinter
+   :members: parenthesize, stringify, emptyPrinter
+
+.. autofunction:: sstrrepr
+
+Tree Printing
+-------------
+
+.. module:: sympy.printing.tree
+
+The functions in this module create a representation of an expression as a
+tree.
+
+.. autofunction:: pprint_nodes
+
+.. autofunction:: print_node
+
+.. autofunction:: tree
+
+.. autofunction:: print_tree
 
 Preview
 -------

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -45,7 +45,6 @@ when possible.
 
 .. autofunction:: pretty
 .. autofunction:: pretty_print
-.. autofunction:: pprint
 
 CCodePrinter
 ------------

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -39,6 +39,46 @@ The module ``pretty_symbology`` provides primitives to construct 2D shapes
 (hline, vline, etc) together with a technique to use unicode automatically when
 possible.
 
+CCodePrinter
+------------
+
+.. module:: sympy.printing.ccode
+
+This class implements C code printing (i.e. it converts Python expressions
+to strings of C code).
+
+Usage::
+
+    >>> from sympy.printing import print_ccode
+    >>> from sympy.functions import sin, cos, Abs
+    >>> from sympy.abc import x
+    >>> print_ccode(sin(x)**2 + cos(x)**2)
+    pow(sin(x), 2) + pow(cos(x), 2)
+    >>> print_ccode(2*x + cos(x), assign_to="result")
+    result = 2*x + cos(x);
+    >>> print_ccode(Abs(x**2))
+    fabs(pow(x, 2))
+
+.. autodata:: sympy.printing.ccode.known_functions
+
+.. autoclass:: sympy.printing.ccode.CCodePrinter
+   :members:
+
+.. autofunction:: sympy.printing.ccode.ccode
+
+.. autofunction:: sympy.printing.ccode.print_ccode
+
+CodePrinter
+-----------
+
+This class is a base class for other classes that implement code-printing
+functionality, and additionally lists a number of functions that cannot be
+easily translated to C or Fortran.
+
+.. autoclass:: sympy.printing.codeprinter.CodePrinter
+
+.. autoexception:: sympy.printing.codeprinter.AssignmentError
+
 Gtk
 ---
 
@@ -72,7 +112,6 @@ MathMLPrinter
 This class is responsible for MathML printing. See ``sympy.printing.mathml``.
 
 More info on mathml content: http://www.w3.org/TR/MathML2/chapter4.html
-
 
 PythonPrinter
 -------------

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -38,8 +38,6 @@ when possible.
 
 .. module:: sympy.printing.pretty.pretty
 
-.. autodata:: pprint_use_unicode
-.. autodata:: pprint_try_use_unicode
 .. autoclass:: PrettyPrinter
    :members: _use_unicode, doprint
 
@@ -376,16 +374,12 @@ Pretty-Printing Implementation Helpers
 .. autofunction:: pretty_use_unicode
 .. autofunction:: pretty_try_use_unicode
 .. autofunction:: xstr
-.. autodata:: g
 
-   This function returns the Unicode version of the inputted lowercase Greek
-   letter.
+The following two functions return the Unicode version of the inputted Greek
+letter.
 
+.. autofunction:: g
 .. autofunction:: G
-
-   This function returns the Unicode version of the inputted uppercase Greek
-   letter.
-
 .. autodata:: greek_letters
 .. autodata:: greek
 .. autodata:: digit_2txt
@@ -394,26 +388,10 @@ Pretty-Printing Implementation Helpers
 The following functions return the Unicode subscript/superscript version of
 the character.
 
-.. autofunction:: LSUB
-.. autofunction:: GSUB
-.. autofunction:: DSUB
-.. autofunction:: SSUB
-.. autofunction:: LSUP
-.. autofunction:: DSUP
-.. autofunction:: SSUP
 .. autodata:: sub
 .. autodata:: sup
 
 The following functions return Unicode vertical objects.
-
-.. autofunction:: HUP
-.. autofunction:: CUP
-.. autofunction:: MID
-.. autofunction:: EXT
-.. autofunction:: HLO
-.. autofunction:: CLO
-.. autofunction:: TOP
-.. autofunction:: BOT
 
 .. autofunction:: xobj
 .. autofunction:: vobj

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -22,22 +22,30 @@ The main class responsible for printing is ``Printer`` (see also its
 PrettyPrinter Class
 -------------------
 
-.. module:: sympy.printing.pretty.pretty
-.. module:: sympy.printing.pretty.pretty_symbology
-.. module:: sympy.printing.pretty.pretty_stringpict
-
-Pretty printing subsystem is implemented in ``sympy.printing.pretty.pretty`` by
-the ``PrettyPrinter`` class deriving from ``Printer``.  It relies on modules
-``sympy.printing.pretty.stringPict``, and
-``sympy.printing.pretty.pretty_symbology`` for rendering nice-looking formulas.
+Pretty printing subsystem is implemented in ``sympy.printing.pretty.pretty``
+by the ``PrettyPrinter`` class deriving from ``Printer``. It relies on
+modules ``sympy.printing.pretty.stringPict``, and
+``sympy.printing.pretty.pretty_symbology`` for rendering nice-looking
+formulas.
 
 The module ``stringPict`` provides a base class ``stringPict`` and a derived
-class ``prettyForm`` that ease the creation and manipulation of formulas that
-span across multiple lines.
+class ``prettyForm`` that ease the creation and manipulation of formulas
+that span across multiple lines.
 
 The module ``pretty_symbology`` provides primitives to construct 2D shapes
-(hline, vline, etc) together with a technique to use unicode automatically when
-possible.
+(hline, vline, etc) together with a technique to use unicode automatically
+when possible.
+
+.. module:: sympy.printing.pretty.pretty
+
+.. autodata:: pprint_use_unicode
+.. autodata:: pprint_try_use_unicode
+.. autoclass:: PrettyPrinter
+   :members: _use_unicode, doprint
+
+.. autofunction:: pretty
+.. autofunction:: pretty_print
+.. autofunction:: pprint
 
 CCodePrinter
 ------------
@@ -68,67 +76,21 @@ Usage::
 
 .. autofunction:: sympy.printing.ccode.print_ccode
 
-Gtk
----
-
-.. module:: sympy.printing.gtk
-
-You can print to a grkmathview widget using the function print_gtk located in
-sympy.printing.gtk (it requires to have installed gtkmatmatview and
-libgtkmathview-bin in some systems).
-
-GtkMathView accepts MathML, so this rendering depends on the mathml representation of the expression
-
-Usage::
-
-    from sympy import *
-    print_gtk(x**2 + 2*exp(x**3))
-
-LatexPrinter
-------------
-
-.. module:: sympy.printing.latex
-
-This class implements LaTeX printing. See ``sympy.printing.latex``.
-
-See also the extended LatexPrinter: :ref:`Extended LaTeXModule for Sympy <extended-latex>`
-
-MathMLPrinter
--------------
-
-.. module:: sympy.printing.mathml
-
-This class is responsible for MathML printing. See ``sympy.printing.mathml``.
-
-More info on mathml content: http://www.w3.org/TR/MathML2/chapter4.html
-
-PythonPrinter
--------------
-
-.. module:: sympy.printing.python
-
-This class implements Python printing. Usage::
-
-    >>> from sympy import print_python, sin
-    >>> from sympy.abc import x
-
-    >>> print_python(5*x**3 + sin(x))
-    x = Symbol('x')
-    e = 5*x**3 + sin(x)
-
-fcode
------
+Fortran Printing
+----------------
 
 The fcode function translates a sympy expression into Fortran code. The main
 purpose is to take away the burden of manually translating long mathematical
-expressions. Therefore the resulting expression should also require no (or very
-little) manual tweaking to make it compilable. The optional arguments of fcode
-can be used to fine-tune the behavior of fcode in such a way that manual changes
-in the result are no longer needed.
+expressions. Therefore the resulting expression should also require no (or
+very little) manual tweaking to make it compilable. The optional arguments
+of fcode can be used to fine-tune the behavior of fcode in such a way that
+manual changes in the result are no longer needed.
 
 .. module:: sympy.printing.fcode
 .. autofunction:: fcode
 .. autofunction:: print_fcode
+.. autoclass:: FCodePrinter
+   :members:
 
 Two basic examples:
 
@@ -233,6 +195,87 @@ translated in pure Fortran and (iii) a string of Fortran code. A few examples:
     >>> fcode(x - pi**2, human=False)
     (set([(pi, '3.14159265358979d0')]), set(), '      x - pi**2')
 
+Gtk
+---
+
+.. module:: sympy.printing.gtk
+
+You can print to a grkmathview widget using the function ``print_gtk``
+located in ``sympy.printing.gtk`` (it requires to have installed
+gtkmatmatview and libgtkmathview-bin in some systems).
+
+GtkMathView accepts MathML, so this rendering depends on the MathML
+representation of the expression.
+
+Usage::
+
+    from sympy import *
+    print_gtk(x**2 + 2*exp(x**3))
+
+.. autofunction:: print_gtk
+
+LambdaPrinter
+-------------
+
+.. module:: sympy.printing.lambdarepr
+
+This classes implements printing to strings that can be used by the
+:py:func:`sympy.utilities.lambdify.lambdify` function.
+
+.. autoclass:: LambdaPrinter
+
+.. autofunction:: lambdarepr
+
+LatexPrinter
+------------
+
+.. module:: sympy.printing.latex
+
+This class implements LaTeX printing. See ``sympy.printing.latex``.
+
+See also the extended LatexPrinter: :ref:`Extended LaTeXModule for Sympy <extended-latex>`
+
+.. autodata:: accepted_latex_functions
+
+.. autoclass:: LatexPrinter
+   :members:
+
+.. autofunction:: latex
+
+.. autofunction:: print_latex
+
+MathMLPrinter
+-------------
+
+.. module:: sympy.printing.mathml
+
+This class is responsible for MathML printing. See ``sympy.printing.mathml``.
+
+More info on mathml content: http://www.w3.org/TR/MathML2/chapter4.html
+
+.. autoclass:: MathMLPrinter
+   :members:
+
+.. autofunction:: mathml
+
+.. autofunction:: print_mathml
+
+PythonPrinter
+-------------
+
+.. module:: sympy.printing.python
+
+This class implements Python printing. Usage::
+
+    >>> from sympy import print_python, sin
+    >>> from sympy.abc import x
+
+    >>> print_python(5*x**3 + sin(x))
+    x = Symbol('x')
+    e = 5*x**3 + sin(x)
+
+
+
 Preview
 -------
 
@@ -261,3 +304,101 @@ easily translated to C or Fortran.
 .. autoclass:: sympy.printing.codeprinter.CodePrinter
 
 .. autoexception:: sympy.printing.codeprinter.AssignmentError
+
+Precedence
+++++++++++
+
+.. module:: sympy.printing.precedence
+
+.. autodata:: PRECEDENCE
+
+   Default precedence values for some basic types.
+
+.. autodata:: PRECEDENCE_VALUES
+
+   A dictionary assigning precedence values to certain classes. These values
+   are treated like they were inherited, so not every single class has to be
+   named here.
+
+.. autodata:: PRECEDENCE_FUNCTIONS
+
+   Sometimes it's not enough to assign a fixed precedence value to a
+   class. Then a function can be inserted in this dictionary that takes an
+   instance of this class as argument and returns the appropriate precedence
+   value.
+
+.. autofunction:: precedence
+
+Pretty-Printing Implementation Helpers
+--------------------------------------
+
+.. module:: sympy.printing.pretty.pretty_symbology
+
+.. autofunction:: U
+.. autofunction:: pretty_use_unicode
+.. autofunction:: pretty_try_use_unicode
+.. autofunction:: xstr
+.. autodata:: g
+
+   This function returns the Unicode version of the inputted lowercase Greek
+   letter.
+
+.. autofunction:: G
+
+   This function returns the Unicode version of the inputted uppercase Greek
+   letter.
+
+.. autodata:: greek_letters
+.. autodata:: greek
+.. autodata:: digit_2txt
+.. autodata:: symb_2txt
+
+The following functions return the Unicode subscript/superscript version of
+the character.
+
+.. autofunction:: LSUB
+.. autofunction:: GSUB
+.. autofunction:: DSUB
+.. autofunction:: SSUB
+.. autofunction:: LSUP
+.. autofunction:: DSUP
+.. autofunction:: SSUP
+.. autodata:: sub
+.. autodata:: sup
+
+The following functions return Unicode vertical objects.
+
+.. autofunction:: HUP
+.. autofunction:: CUP
+.. autofunction:: MID
+.. autofunction:: EXT
+.. autofunction:: HLO
+.. autofunction:: CLO
+.. autofunction:: TOP
+.. autofunction:: BOT
+
+.. autofunction:: xobj
+.. autofunction:: vobj
+.. autofunction:: hobj
+
+The following constants are for rendering roots and fractions.
+
+.. autodata:: root
+.. autofunction:: VF
+.. autodata:: frac
+
+The following constants/functions are for rendering atoms and symbols.
+
+.. autofunction:: xsym
+.. autodata:: atoms_table
+.. autofunction:: pretty_atom
+.. autofunction:: pretty_symbol
+.. autofunction:: annotated
+
+.. automodule:: sympy.printing.pretty.stringpict
+
+.. autoclass:: stringPict
+   :members:
+
+.. autoclass:: prettyForm
+   :members:

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -39,24 +39,6 @@ The module ``pretty_symbology`` provides primitives to construct 2D shapes
 (hline, vline, etc) together with a technique to use unicode automatically when
 possible.
 
-MathMLPrinter
--------------
-
-.. module:: sympy.printing.mathml
-
-This class is responsible for MathML printing. See ``sympy.printing.mathml``.
-
-More info on mathml content: http://www.w3.org/TR/MathML2/chapter4.html
-
-LatexPrinter
-------------
-
-.. module:: sympy.printing.latex
-
-This class implements LaTeX printing. See ``sympy.printing.latex``.
-
-See also the extended LatexPrinter: :ref:`Extended LaTeXModule for Sympy <extended-latex>`
-
 Gtk
 ---
 
@@ -72,6 +54,25 @@ Usage::
 
     from sympy import *
     print_gtk(x**2 + 2*exp(x**3))
+
+LatexPrinter
+------------
+
+.. module:: sympy.printing.latex
+
+This class implements LaTeX printing. See ``sympy.printing.latex``.
+
+See also the extended LatexPrinter: :ref:`Extended LaTeXModule for Sympy <extended-latex>`
+
+MathMLPrinter
+-------------
+
+.. module:: sympy.printing.mathml
+
+This class is responsible for MathML printing. See ``sympy.printing.mathml``.
+
+More info on mathml content: http://www.w3.org/TR/MathML2/chapter4.html
+
 
 PythonPrinter
 -------------

--- a/doc/src/modules/printing.txt
+++ b/doc/src/modules/printing.txt
@@ -68,17 +68,6 @@ Usage::
 
 .. autofunction:: sympy.printing.ccode.print_ccode
 
-CodePrinter
------------
-
-This class is a base class for other classes that implement code-printing
-functionality, and additionally lists a number of functions that cannot be
-easily translated to C or Fortran.
-
-.. autoclass:: sympy.printing.codeprinter.CodePrinter
-
-.. autoexception:: sympy.printing.codeprinter.AssignmentError
-
 Gtk
 ---
 
@@ -253,3 +242,22 @@ A useful function is ``preview``:
 
 .. autofunction:: preview
 
+Implementation - Helper Classes/Functions
+-----------------------------------------
+
+.. module:: sympy.printing.conventions
+
+.. autofunction:: split_super_sub
+
+CodePrinter
++++++++++++
+
+.. module:: sympy.printing.codeprinter
+
+This class is a base class for other classes that implement code-printing
+functionality, and additionally lists a number of functions that cannot be
+easily translated to C or Fortran.
+
+.. autoclass:: sympy.printing.codeprinter.CodePrinter
+
+.. autoexception:: sympy.printing.codeprinter.AssignmentError

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -228,7 +228,7 @@ def ccode(expr, assign_to=None, **settings):
     r"""Converts an expr to a string of c code
 
         Parameters
-        ----------
+        ==========
         expr : sympy.core.Expr
             a sympy expression to be converted
         precision : optional
@@ -244,8 +244,8 @@ def ccode(expr, assign_to=None, **settings):
             same information is returned in a more programmer-friendly
             data structure.
 
-        Usage
-        -----
+        Examples
+        ========
 
         >>> from sympy import ccode, symbols, Rational, sin
         >>> x, tau = symbols(["x", "tau"])

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -55,6 +55,9 @@ class CCodePrinter(CodePrinter):
         return "%s;" % codestring
 
     def doprint(self, expr, assign_to=None):
+        """
+        Actually format the expression as C code.
+        """
 
         if isinstance(assign_to, basestring):
             assign_to = C.Symbol(assign_to)
@@ -224,20 +227,25 @@ class CCodePrinter(CodePrinter):
 def ccode(expr, assign_to=None, **settings):
     r"""Converts an expr to a string of c code
 
-        Arguments:
-          expr  --  a sympy expression to be converted
+        Parameters
+        ----------
+        expr : sympy.core.Expr
+            a sympy expression to be converted
+        precision : optional
+            the precision for numbers such as pi [default=15]
+        user_functions : optional
+            A dictionary where keys are FunctionClass instances and values
+            are there string representations.  Alternatively, the
+            dictionary value can be a list of tuples i.e. [(argument_test,
+            cfunction_string)].  See below for examples.
+        human : optional
+            If True, the result is a single string that may contain some
+            constant declarations for the number symbols. If False, the
+            same information is returned in a more programmer-friendly
+            data structure.
 
-        Optional arguments:
-          precision  --  the precision for numbers such as pi [default=15]
-          user_functions  --  A dictionary where keys are FunctionClass instances
-                              and values are there string representations.
-                              Alternatively, the dictionary value can be a list
-                              of tuples i.e. [(argument_test, cfunction_string)].
-                              See below for examples.
-          human  --  If True, the result is a single string that may contain
-                     some constant declarations for the number symbols. If
-                     False, the same information is returned in a more
-                     programmer-friendly data structure.
+        Usage
+        -----
 
         >>> from sympy import ccode, symbols, Rational, sin
         >>> x, tau = symbols(["x", "tau"])

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -3,9 +3,15 @@ from sympy.printing.str import StrPrinter
 from sympy.tensor import get_indices, get_contraction_structure
 
 class AssignmentError(Exception):
+    """
+    Raised if an assignment variable for a loop is missing.
+    """
     pass
 
 class CodePrinter(StrPrinter):
+    """
+    The base class for code-printing subclasses.
+    """
 
     def _doprint_a_piece(self, expr, assign_to=None):
         # Here we print an expression that may contain Indexed objects, they

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -9,11 +9,11 @@ import re
 def split_super_sub(text):
     """Split a symbol name into a name, superscripts and subscripts
 
-       The first part of the symbol name is considered to be its actual 'name',
-       followed by super- and subscripts. Each superscript is preceded with a
-       "^" character or by "__". Each subscript is preceded by a "_" character.
-       The three return values are the actual name, a list with superscripts and
-       a list with subscripts.
+       The first part of the symbol name is considered to be its actual
+       'name', followed by super- and subscripts. Each superscript is
+       preceded with a "^" character or by "__". Each subscript is preceded
+       by a "_" character.  The three return values are the actual name, a
+       list with superscripts and a list with subscripts.
 
        >>> from sympy.printing.conventions import split_super_sub
        >>> split_super_sub('a_x^1')

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -377,26 +377,31 @@ class FCodePrinter(CodePrinter):
 def fcode(expr, **settings):
     """Converts an expr to a string of Fortran 77 code
 
-       Arguments:
-         expr  --  a sympy expression to be converted
+       Parameters
+       ==========
 
-       Optional arguments:
-         assign_to  --  When given, the argument is used as the name of the
-                        variable to which the Fortran expression is assigned.
-                        (This is helpful in case of line-wrapping.)
+       expr : sympy.core.Expr
+           a sympy expression to be converted
+       assign_to : optional
+           When given, the argument is used as the name of the
+           variable to which the Fortran expression is assigned.
+           (This is helpful in case of line-wrapping.)
+       precision : optional
+           the precision for numbers such as pi [default=15]
+       user_functions : optional
+           A dictionary where keys are FunctionClass instances and values
+           are there string representations.
+       human : optional
+           If True, the result is a single string that may contain some
+           parameter statements for the number symbols. If False, the same
+           information is returned in a more programmer-friendly data
+           structure.
+       source_format : optional
+           The source format can be either 'fixed' or 'free'.
+           [default='fixed']
 
-         precision  --  the precision for numbers such as pi [default=15]
-
-         user_functions  --  A dictionary where keys are FunctionClass instances
-                             and values are there string representations.
-
-         human  --  If True, the result is a single string that may contain
-                    some parameter statements for the number symbols. If
-                    False, the same information is returned in a more
-                    programmer-friendly data structure.
-
-         source_format  --  The source format can be either 'fixed' or 'free'.
-                            [default='fixed']
+       Examples
+       ========
 
        >>> from sympy import fcode, symbols, Rational, pi, sin
        >>> x, tau = symbols('x,tau')

--- a/sympy/printing/gtk.py
+++ b/sympy/printing/gtk.py
@@ -6,6 +6,7 @@ import os
 
 def print_gtk(x, start_viewer=True):
     """Print to Gtkmathview, a gtk widget capable of rendering MathML.
+
     Needs libgtkmathview-bin"""
     from sympy.utilities.mathml import c2p
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1052,7 +1052,6 @@ def latex(expr, **settings):
     Printer. For very large expressions, set the 'order' keyword to 'none' if
     speed is a concern.
 
-
     mode: Specifies how the generated code will be delimited. 'mode' can be one
     of 'plain', 'inline', 'equation' or 'equation*'.  If 'mode' is set to
     'plain', then the resulting code will not be delimited at all (this is the
@@ -1060,7 +1059,7 @@ def latex(expr, **settings):
     If 'mode' is set to 'equation' or 'equation*', the resulting code will be
     enclosed in the 'equation' or 'equation*' environment (remember to import
     'amsmath' for 'equation*'), unless the 'itex' option is set. In the latter
-    case, the $$ $$ syntax is used.
+    case, the ``$$ $$`` syntax is used.
 
     >>> latex((2*mu)**Rational(7,2), mode='plain')
     '8 \\sqrt{2} \\mu^{\\frac{7}{2}}'
@@ -1074,7 +1073,7 @@ def latex(expr, **settings):
     >>> latex((2*mu)**Rational(7,2), mode='equation')
     '\\begin{equation}8 \\sqrt{2} \\mu^{\\frac{7}{2}}\\end{equation}'
 
-    itex: Specifies if itex-specific syntax is used, including emitting $$ $$.
+    itex: Specifies if itex-specific syntax is used, including emitting ``$$ $$``.
 
     >>> latex((2*mu)**Rational(7,2), mode='equation', itex=True)
     '$$8 \\sqrt{2} \\mu^{\\frac{7}{2}}$$'

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -27,6 +27,9 @@ class MathMLPrinter(Printer):
         self.dom = Document()
 
     def doprint(self, expr):
+        """
+        Prints the expression as MathML.
+        """
         mathML = Printer._print(self, expr)
         return mathML.toxml()
 
@@ -363,6 +366,9 @@ def mathml(expr, **settings):
 def print_mathml(expr, **settings):
     """
     Prints a pretty representation of the MathML code for expr
+
+    Examples
+    ========
 
     >>> ##
     >>> from sympy.printing.mathml import print_mathml

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -2,6 +2,7 @@
 
 from sympy import S
 
+
 # Default precedence values for some basic types
 PRECEDENCE = {
     "Lambda":1,

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1344,6 +1344,7 @@ def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.
 
     For information on keyword arguments see pretty_print function.
+
     """
     pp = PrettyPrinter(settings)
 
@@ -1359,18 +1360,26 @@ def pretty(expr, **settings):
 def pretty_print(expr, **settings):
     """Prints expr in pretty form.
 
-    Arguments
-    ---------
-    expr: the expression to print
-    wrap_line: line wrapping enabled/disabled, should be a boolean value (default to True)
-    num_columns: number of columns before line breaking (default to None which reads the
-        terminal width), it is useful when using SymPy without terminal.
-    use_unicode: use unicode characters, such as the Greek letter pi instead of
-        the string pi. Values should be boolean or None
-    full_prec: use full precision. Default to "auto"
-    order: set to 'none' for long expressions if slow; default is None
+    Parameters
+    ==========
+    expr : expression
+        the expression to print
+    wrap_line : bool, optional
+        line wrapping enabled/disabled, defaults to True
+    num_columns : bool, optional
+        number of columns before line breaking (default to None which reads
+        the terminal width), useful when using SymPy without terminal.
+    use_unicode : bool or None, optional
+        use unicode characters, such as the Greek letter pi instead of
+        the string pi.
+    full_prec : bool or string, optional
+        use full precision. Default to "auto"
+    order : bool or string, optional
+        set to 'none' for long expressions if slow; default is None
 
+<<<<<<< HEAD
     pprint is just a shortcut for this function.
+
     """
     print pretty(expr, **settings)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1360,6 +1360,9 @@ def pretty(expr, **settings):
 def pretty_print(expr, **settings):
     """Prints expr in pretty form.
 
+    pprint is just a shortcut for this function.
+
+
     Parameters
     ==========
     expr : expression
@@ -1376,9 +1379,6 @@ def pretty_print(expr, **settings):
         use full precision. Default to "auto"
     order : bool or string, optional
         set to 'none' for long expressions if slow; default is None
-
-<<<<<<< HEAD
-    pprint is just a shortcut for this function.
 
     """
     print pretty(expr, **settings)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -161,8 +161,8 @@ for l in 'aeioruvx':
 for l in 'in':
     sup[l] = LSUP(l)
 
-for g in ['beta', 'gamma', 'rho', 'phi', 'chi']:
-    sub[g] = GSUB(g)
+for gl in ['beta', 'gamma', 'rho', 'phi', 'chi']:
+    sub[gl] = GSUB(gl)
 
 for d in [str(i) for i in range(10)]:
     sub[d] = DSUB(d)
@@ -246,7 +246,6 @@ _xobj_ascii = {
     '/' :   '/',
     '\\':   '\\',
 }
-
 
 def xobj(symb, length):
     """Construct spatial object of given length.

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -467,7 +467,7 @@ def pretty_symbol(symb_name):
 
 def annotated(letter):
     """
-    Return a stylised drawing of the letter `letter`, together with
+    Return a stylised drawing of the letter ``letter``, together with
     information on how to put annotations (super- and subscripts to the
     left and to the right) on it.
 

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -41,9 +41,11 @@ class stringPict(object):
         return [line.center(width) for line in lines]
 
     def height(self):
+        """The height of the picture in characters."""
         return len(self.picture)
 
     def width(self):
+        """The width of the picture in characters."""
         return len(self.picture[0])
 
     @staticmethod
@@ -81,6 +83,10 @@ class stringPict(object):
         r"""Put pictures next to this one.
         Returns string, baseline arguments for stringPict.
         (Multiline) strings are allowed, and are given a baseline of 0.
+
+        Examples
+        ========
+
         >>> from sympy.printing.pretty.stringpict import stringPict
         >>> print stringPict("10").right(" + ",stringPict("1\r-\r2",1))[0]
              1
@@ -139,6 +145,10 @@ class stringPict(object):
         """Put pictures under this picture.
         Returns string, baseline arguments for stringPict.
         Baseline is baseline of top picture
+
+        Examples
+        ========
+
         >>> from sympy.printing.pretty.stringpict import stringPict
         >>> print stringPict("x+3").below(stringPict.LINE, '3')[0] #doctest: +NORMALIZE_WHITESPACE
         x+3
@@ -343,14 +353,17 @@ class stringPict(object):
 class prettyForm(stringPict):
     """Extension of the stringPict class that knows about
     basic math applications, optimizing double minus signs.
-    "Binding" is interpreted as follows:
-    ATOM this is an atom: never needs to be parenthesized
-    FUNC this is a function application: parenthesize if added (?)
-    DIV  this is a division: make wider division if divided
-    POW  this is a power: only parenthesize if exponent
-    MUL  this is a multiplication: parenthesize if powered
-    ADD  this is an addition: parenthesize if multiplied or powered
-    NEG  this is a negative number: optimize if added, parenthesize if multiplied or powered
+
+    "Binding" is interpreted as follows::
+
+        ATOM this is an atom: never needs to be parenthesized
+        FUNC this is a function application: parenthesize if added (?)
+        DIV  this is a division: make wider division if divided
+        POW  this is a power: only parenthesize if exponent
+        MUL  this is a multiplication: parenthesize if powered
+        ADD  this is an addition: parenthesize if multiplied or powered
+        NEG  this is a negative number: optimize if added, parenthesize if multiplied or powered
+
     """
     ATOM, FUNC, DIV, POW, MUL, ADD, NEG = range(7)
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -84,29 +84,32 @@ class Printer(object):
        If a object has a method with that name, this method will be used
        for printing.
 
-    3. In your subclass, define _print_<CLASS> methods
+    3. In your subclass, define ``_print_<CLASS>`` methods
 
        For each class you want to provide printing to, define an appropriate
        method how to do it. For example if you want a class FOO to be printed in
-       its own way, define _print_FOO:
+       its own way, define _print_FOO::
 
-       def _print_FOO(self, e):
-           ...
+           def _print_FOO(self, e):
+               ...
 
        this should return how FOO instance e is printed
 
-       Also, if BAR is a subclass of FOO, _print_FOO(bar) will be called for
-       instance of BAR, if no _print_BAR is provided.  Thus, usually, we don't
-       need to provide printing routines for every class we want to support --
-       only generic routine has to be provided for a set of classes.
+       Also, if ``BAR`` is a subclass of ``FOO``, ``_print_FOO(bar)`` will
+       be called for instance of ``BAR``, if no ``_print_BAR`` is provided.
+       Thus, usually, we don't need to provide printing routines for every
+       class we want to support -- only generic routine has to be provided
+       for a set of classes.
 
-       A good example for this are functions - for example PrettyPrinter only
-       defines _print_Function, and there is no _print_sin, _print_tan, etc...
+       A good example for this are functions - for example ``PrettyPrinter``
+       only defines ``_print_Function``, and there is no ``_print_sin``,
+       ``_print_tan``, etc...
 
-       On the other hand, a good printer will probably have to define separate
-       routines for Symbol, Atom, Number, Integral, Limit, etc...
+       On the other hand, a good printer will probably have to define
+       separate routines for ``Symbol``, ``Atom``, ``Number``, ``Integral``,
+       ``Limit``, etc...
 
-    4. If convenient, override self.emptyPrinter
+    4. If convenient, override ``self.emptyPrinter``
 
        This callable will be called to obtain printing result as a last resort,
        that is when no appropriate print method was found for an expression.

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -17,9 +17,15 @@ class ReprPrinter(Printer):
     }
 
     def reprify(self, args, sep):
+        """
+        Prints each item in `args` and joins them with `sep`.
+        """
         return sep.join([self.doprint(item) for item in args])
 
     def emptyPrinter(self, expr):
+        """
+        The fallback printer.
+        """
         if isinstance(expr, str):
             return expr
         elif hasattr(expr, "__srepr__"):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -549,4 +549,3 @@ def sstrrepr(expr, **settings):
     s = p.doprint(expr)
 
     return s
-

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -7,12 +7,11 @@ def pprint_nodes(subtrees):
     Examples
     ========
 
-    >> print pprint_nodes(["a", "b1\nb2", "c"])
+    >>> print pprint_nodes(["a", "b1\\nb2", "c"])
     +-a
     +-b1
     | b2
     +-c
-    >>
 
     """
     def indent(s,type=1):
@@ -61,6 +60,9 @@ def tree(node):
 def print_tree(node):
     """
     Prints a tree representation of "node".
+
+    Examples
+    ========
 
     >>> from sympy.printing import print_tree
     >>> from sympy.abc import x

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -7,6 +7,7 @@ def pprint_nodes(subtrees):
     Examples
     ========
 
+    >>> from sympy.printing.tree import pprint_nodes
     >>> print pprint_nodes(["a", "b1\\nb2", "c"])
     +-a
     +-b1


### PR DESCRIPTION
- Imported/improved modules:
  - ccode
  - codeprinter
  - conventions
  - fcode
  - gtk
  - lambdarepr
  - latex
  - mathml
  - precedence
  - pretty
  - preview
  - printer
  - python
  - repr
  - str
  - tree
- New section at end of printing docs for implementation details (`sympy.printing.pretty.*`, `sympy.printing.conventions`, `sympy.printing.precedence`)
- Printing classes alphabetized except for `Printer`, `PrettyPrinter`

Caveat: the Russian tutorial appears to share a section identifier with the English tutorial, so this page links to the Russian one instead of the English one.

This is a GCI task: http://www.google-melange.com/gci/task/view/google/gci2011/7137321
