### PR TITLE
fix sympification of repeated decimal

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -30,6 +30,7 @@ def test_sympify1():
     assert sympify('+0.[3]*10**-2') == Rational(1, 300)
     assert sympify('.[052631578947368421]') == Rational(1, 19)
     assert sympify('.0[526315789473684210]') == Rational(1, 19)
+    assert sympify('.034[56]') == Rational(1711, 49500)
     # options to make reals into rationals
     assert sympify('1.22[345]', rational=1) == \
            1 + Rational(22, 100) + Rational(345, 99900)

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -33,7 +33,7 @@ def _transform(s, local_dict, global_dict, rationalize, convert_xor):
                     pre, post, repetend = match.groups()
 
                     zeros = '0'*len(post)
-                    repetends = repetend.lstrip('0')
+                    post, repetends = [w.lstrip('0') for w in [post, repetend]] # or else interpreted as octal
 
                     a = pre or '0'
                     b, c = post or '0', '1' + zeros


### PR DESCRIPTION
If you don't strip the leading zeros off of the post part, too,
    it is interpreted as octal: 033 -> 27
