### PR TITLE
Arbitrary angular momentum coupling

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -9,7 +9,7 @@ from __future__ import with_statement
 import os
 import re
 
-from sympy import Basic, symbols, sqrt, sin
+from sympy import Basic, S, symbols, sqrt, sin
 from sympy.utilities.pytest import XFAIL, SKIP
 
 x, y, z = symbols('x,y,z')
@@ -862,6 +862,14 @@ def test_sympy__physics__quantum__cg__Wigner3j():
     from sympy.physics.quantum.cg import Wigner3j
     assert _test_args(Wigner3j(6,0,4,0,2,0))
 
+def test_sympy__physics__quantum__cg__Wigner6j():
+    from sympy.physics.quantum.cg import Wigner6j
+    assert _test_args(Wigner6j(1,2,3,2,1,2))
+
+def test_sympy__physics__quantum__cg__Wigner9j():
+    from sympy.physics.quantum.cg import Wigner9j
+    assert _test_args(Wigner9j(2,1,1,S(3)/2,S(1)/2,1,S(1)/2,S(1)/2,0))
+
 def test_sympy__physics__quantum__commutator__Commutator():
     from sympy.physics.quantum.commutator import Commutator
     A, B = symbols('A,B', commutative=False)
@@ -1070,19 +1078,19 @@ def test_sympy__physics__quantum__shor__CMod():
 
 def test_sympy__physics__quantum__spin__CoupledSpinState():
     from sympy.physics.quantum.spin import CoupledSpinState
-    assert _test_args(CoupledSpinState(0, 1))
+    assert _test_args(CoupledSpinState(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__J2Op():
     from sympy.physics.quantum.spin import J2Op
-    assert _test_args(J2Op(0, 1))
+    assert _test_args(J2Op('J'))
 
 def test_sympy__physics__quantum__spin__JminusOp():
     from sympy.physics.quantum.spin import JminusOp
-    assert _test_args(JminusOp(0, 1))
+    assert _test_args(JminusOp('J'))
 
 def test_sympy__physics__quantum__spin__JplusOp():
     from sympy.physics.quantum.spin import JplusOp
-    assert _test_args(JplusOp(0, 1))
+    assert _test_args(JplusOp('J'))
 
 def test_sympy__physics__quantum__spin__JxBra():
     from sympy.physics.quantum.spin import JxBra
@@ -1090,7 +1098,7 @@ def test_sympy__physics__quantum__spin__JxBra():
 
 def test_sympy__physics__quantum__spin__JxBraCoupled():
     from sympy.physics.quantum.spin import JxBraCoupled
-    assert _test_args(JxBraCoupled(0, 1))
+    assert _test_args(JxBraCoupled(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__JxKet():
     from sympy.physics.quantum.spin import JxKet
@@ -1098,11 +1106,11 @@ def test_sympy__physics__quantum__spin__JxKet():
 
 def test_sympy__physics__quantum__spin__JxKetCoupled():
     from sympy.physics.quantum.spin import JxKetCoupled
-    assert _test_args(JxKetCoupled(0, 1))
+    assert _test_args(JxKetCoupled(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__JxOp():
     from sympy.physics.quantum.spin import JxOp
-    assert _test_args(JxOp(0, 1))
+    assert _test_args(JxOp('J'))
 
 def test_sympy__physics__quantum__spin__JyBra():
     from sympy.physics.quantum.spin import JyBra
@@ -1110,7 +1118,7 @@ def test_sympy__physics__quantum__spin__JyBra():
 
 def test_sympy__physics__quantum__spin__JyBraCoupled():
     from sympy.physics.quantum.spin import JyBraCoupled
-    assert _test_args(JyBraCoupled(0, 1))
+    assert _test_args(JyBraCoupled(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__JyKet():
     from sympy.physics.quantum.spin import JyKet
@@ -1118,11 +1126,11 @@ def test_sympy__physics__quantum__spin__JyKet():
 
 def test_sympy__physics__quantum__spin__JyKetCoupled():
     from sympy.physics.quantum.spin import JyKetCoupled
-    assert _test_args(JyKetCoupled(0, 1))
+    assert _test_args(JyKetCoupled(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__JyOp():
     from sympy.physics.quantum.spin import JyOp
-    assert _test_args(JyOp(0, 1))
+    assert _test_args(JyOp('J'))
 
 def test_sympy__physics__quantum__spin__JzBra():
     from sympy.physics.quantum.spin import JzBra
@@ -1130,7 +1138,7 @@ def test_sympy__physics__quantum__spin__JzBra():
 
 def test_sympy__physics__quantum__spin__JzBraCoupled():
     from sympy.physics.quantum.spin import JzBraCoupled
-    assert _test_args(JzBraCoupled(0, 1))
+    assert _test_args(JzBraCoupled(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__JzKet():
     from sympy.physics.quantum.spin import JzKet
@@ -1138,11 +1146,11 @@ def test_sympy__physics__quantum__spin__JzKet():
 
 def test_sympy__physics__quantum__spin__JzKetCoupled():
     from sympy.physics.quantum.spin import JzKetCoupled
-    assert _test_args(JzKetCoupled(0, 1))
+    assert _test_args(JzKetCoupled(1, 0, (1, 1)))
 
 def test_sympy__physics__quantum__spin__JzOp():
     from sympy.physics.quantum.spin import JzOp
-    assert _test_args(JzOp(0, 1))
+    assert _test_args(JzOp('J'))
 
 def test_sympy__physics__quantum__spin__Rotation():
     from sympy.physics.quantum.spin import Rotation

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1079,6 +1079,12 @@ def test_sympy__physics__quantum__shor__CMod():
 def test_sympy__physics__quantum__spin__CoupledSpinState():
     from sympy.physics.quantum.spin import CoupledSpinState
     assert _test_args(CoupledSpinState(1, 0, (1, 1)))
+    assert _test_args(CoupledSpinState(1, 0, (1, S(1)/2, S(1)/2)))
+    assert _test_args(CoupledSpinState(1, 0, (1, S(1)/2, S(1)/2), ((2,3,S(1)/2),) ))
+    j,m,j1,j2,j3,j12,x = symbols('j m j1:4 j12 x')
+    assert CoupledSpinState(j, m, (j1,j2,j3)).subs(j2,x) == CoupledSpinState(j, m, (j1,x,j3))
+    assert CoupledSpinState(j, m, (j1,j2,j3),((1,3,j12),) ).subs(j12,x) == \
+        CoupledSpinState(j, m, (j1,j2,j3), ((1,3,x),) )
 
 def test_sympy__physics__quantum__spin__J2Op():
     from sympy.physics.quantum.spin import J2Op

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -8,11 +8,13 @@ from sympy import Add, expand, Eq, Expr, Function, Mul, Piecewise, Pow, sqrt, Su
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.functions.special.tensor_functions import KroneckerDelta
-from sympy.physics.wigner import wigner_3j, clebsch_gordan
+from sympy.physics.wigner import clebsch_gordan, wigner_3j, wigner_6j, wigner_9j
 
 
 __all__ = [
     'Wigner3j',
+    'Wigner6j',
+    'Wigner9j',
     'CG',
     'cg_simp'
 ]
@@ -83,8 +85,7 @@ class Wigner3j(Expr):
 
     @property
     def is_symbolic(self):
-        return not (self.j1.is_number and self.j2.is_number and self.j3.is_number and
-            self.m1.is_number and self.m2.is_number and self.m3.is_number)
+        return not all([arg.is_number for arg in self.args])
 
     # This is modified from the _print_Matrix method
     def _sympystr(self, printer, *args):
@@ -221,6 +222,208 @@ class CG(Wigner3j):
             (printer._print(self.j3), printer._print(self.m3),
             printer._print(self.j1), printer._print(self.m1),
             printer._print(self.j2), printer._print(self.m2))
+
+
+class Wigner6j(Expr):
+    """Class for the Wigner-6j symbols"""
+    def __new__(cls, j1, j2, j12, j3, j, j23):
+        j1,j2,j12,j3,j,j23 = map(sympify, (j1,j2,j12,j3,j,j23))
+        return Expr.__new__(cls, j1, j2, j12, j3, j, j23)
+
+    @property
+    def j1(self):
+        return self.args[0]
+
+    @property
+    def j2(self):
+        return self.args[1]
+
+    @property
+    def j12(self):
+        return self.args[2]
+
+    @property
+    def j3(self):
+        return self.args[3]
+
+    @property
+    def j(self):
+        return self.args[4]
+
+    @property
+    def j23(self):
+        return self.args[5]
+
+    @property
+    def is_symbolic(self):
+        return not all([arg.is_number for arg in self.args])
+
+    # This is modified from the _print_Matrix method
+    def _sympystr(self, printer, *args):
+        res = [[printer._print(self.j1), printer._print(self.j2), printer._print(self.j12)], \
+            [printer._print(self.j3), printer._print(self.j), printer._print(self.j23)]]
+        maxw = [-1] * 3
+        for j in range(3):
+            maxw[j] = max([ len(res[i][j]) for i in range(2) ])
+        for i, row in enumerate(res):
+            for j, elem in enumerate(row):
+                row[j] = elem.rjust(maxw[j])
+            res[i] = "{" + ", ".join(row) + "}"
+        return '\n'.join(res)
+
+    # This is modified from the _print_Matrix method
+    def _pretty(self, printer, *args):
+        m = ((printer._print(self.j1), printer._print(self.j3)), \
+            (printer._print(self.j2), printer._print(self.j)), \
+            (printer._print(self.j12), printer._print(self.j23)))
+        hsep = 2
+        vsep = 1
+        maxw = [-1] * 3
+        for j in range(3):
+            maxw[j] = max([ m[j][i].width() for i in range(2) ])
+        D = None
+        for i in range(2):
+            D_row = None
+            for j in range(3):
+                s = m[j][i]
+                wdelta = maxw[j] - s.width()
+                wleft  = wdelta //2
+                wright = wdelta - wleft
+
+                s = prettyForm(*s.right(' '*wright))
+                s = prettyForm(*s.left(' '*wleft))
+
+                if D_row is None:
+                    D_row = s
+                    continue
+                D_row = prettyForm(*D_row.right(' '*hsep))
+                D_row = prettyForm(*D_row.right(s))
+            if D is None:
+                D = D_row
+                continue
+            for _ in range(vsep):
+                D = prettyForm(*D.below(' '))
+            D = prettyForm(*D.below(D_row))
+        D = prettyForm(*D.parens(left='{', right='}'))
+        return D
+
+    def _latex(self, printer, *args):
+        return r'\left{\begin{array}{ccc} %s & %s & %s \\ %s & %s & %s \end{array}\right}' % \
+            (printer._print(self.j1), printer._print(self.j2), printer._print(self.j12), \
+            printer._print(self.j3), printer._print(self.j), printer._print(self.j23))
+
+    def doit(self, **hints):
+        if self.is_symbolic:
+            raise ValueError("Coefficients must be numerical")
+        return wigner_6j(self.j1, self.j2, self.j12, self.j3, self.j, self.j3)
+
+
+class Wigner9j(Expr):
+    """Class for the Wigner-9j symbols"""
+    def __new__(cls, j1, j2, j12, j3, j4, j34, j13, j24, j):
+        j1,j2,j12,j3,j4,j34,j13,j24,j = map(sympify, (j1,j2, j12, j3, j4, j34, j13, j24, j))
+        return Expr.__new__(cls, j1, j2, j12, j3, j4, j34, j13, j24, j)
+
+    @property
+    def j1(self):
+        return self.args[0]
+
+    @property
+    def j2(self):
+        return self.args[1]
+
+    @property
+    def j12(self):
+        return self.args[2]
+
+    @property
+    def j3(self):
+        return self.args[3]
+
+    @property
+    def j4(self):
+        return self.args[4]
+
+    @property
+    def j34(self):
+        return self.args[5]
+
+    @property
+    def j13(self):
+        return self.args[6]
+
+    @property
+    def j24(self):
+        return self.args[7]
+
+    @property
+    def j(self):
+        return self.args[8]
+
+    @property
+    def is_symbolic(self):
+        return not all([arg.is_number for arg in self.args])
+
+    # This is modified from the _print_Matrix method
+    def _sympystr(self, printer, *args):
+        res = [[printer._print(self.j1), printer._print(self.j2), printer._print(self.j12)], \
+            [printer._print(self.j3), printer._print(self.j4), printer._print(self.j34)], \
+            [printer._print(self.j13), printer._print(self.j24), printer._print(self.j)]]
+        maxw = [-1] * 3
+        for j in range(3):
+            maxw[j] = max([ len(res[i][j]) for i in range(2) ])
+        for i, row in enumerate(res):
+            for j, elem in enumerate(row):
+                row[j] = elem.rjust(maxw[j])
+            res[i] = "{" + ", ".join(row) + "}"
+        return '\n'.join(res)
+
+    # This is modified from the _print_Matrix method
+    def _pretty(self, printer, *args):
+        m = ((printer._print(self.j1), printer._print(self.j3), printer._print(self.j13)), \
+            (printer._print(self.j2), printer._print(self.j4), printer._print(self.j24)), \
+            (printer._print(self.j12), printer._print(self.j34), printer._print(self.j)))
+        hsep = 2
+        vsep = 1
+        maxw = [-1] * 3
+        for j in range(3):
+            maxw[j] = max([ m[j][i].width() for i in range(3) ])
+        D = None
+        for i in range(3):
+            D_row = None
+            for j in range(3):
+                s = m[j][i]
+                wdelta = maxw[j] - s.width()
+                wleft  = wdelta //2
+                wright = wdelta - wleft
+
+                s = prettyForm(*s.right(' '*wright))
+                s = prettyForm(*s.left(' '*wleft))
+
+                if D_row is None:
+                    D_row = s
+                    continue
+                D_row = prettyForm(*D_row.right(' '*hsep))
+                D_row = prettyForm(*D_row.right(s))
+            if D is None:
+                D = D_row
+                continue
+            for _ in range(vsep):
+                D = prettyForm(*D.below(' '))
+            D = prettyForm(*D.below(D_row))
+        D = prettyForm(*D.parens(left='{', right='}'))
+        return D
+
+    def _latex(self, printer, *args):
+        return r'\left{\begin{array}{ccc} %s & %s & %s \\ %s & %s & %s \\ %s & %s & %s \end{array}\right}' % \
+            (printer._print(self.j1), printer._print(self.j2), printer._print(self.j12), \
+            printer._print(self.j3), printer._print(self.j4), printer._print(self.j34), \
+            printer._print(self.j13), printer._print(self.j24), printer._print(self.j))
+
+    def doit(self, **hints):
+        if self.is_symbolic:
+            raise ValueError("Coefficients must be numerical")
+        return wigner_9j(self.j1, self.j2, self.j12, self.j3, self.j4, self.j34, self.j13, self.j24, self.j)
 
 
 def cg_simp(e):

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -76,14 +76,11 @@ def couple(tp, jcoupling_list=None):
         Elements of this list are sub-lists of length 2 specifying the order of
         the coupling of the spin spaces. The length of this must be N-2, where N
         is the number of states in the tensor product to be coupled. The
-        elements of the sub-list are integers corresponding n value to the
-        spaces, j_n, that are coupled, where the spin spaces are counted
-        starting at n=1. If two spaces are coupled, the new coupled space is
-        referenced with the smaller of the two n's, e.g. the space defined by
-        the coupling (1, 3) would be referenced in later couplings by n=1. If
-        this parameter is not specified, the default method is to couple the
-        first and second spaces, then this coupled space to the third space,
-        etc.
+        elements of this sublist are the same as the first two elements of each
+        sublist in *jcoupling as defined in JzKetCoupled. If this argument is
+        not specified, the default value is taken, which couples the first and
+        second product basis spaces, then couples this new coupled space to the
+        third product space, etc
 
     Examples
     ========
@@ -263,13 +260,15 @@ def uncouple(state, jn=None, jcoupling_list=None):
         state.
 
     jn : list or tuple
-        The list of the j-values that are coupled. Must be defined if state is
-        not a subclass of CoupledSpinState. See the jn parameter of the
-        JzKetCoupled class to see how this must be defined.
+        The list of the j-values that are coupled. If state is a
+        CoupledSpinState, this parameter is ignored. This must be defined if
+        state is not a subclass of CoupledSpinState. See the jn parameter of
+        the JzKetCoupled class to see how this must be defined.
 
     jcoupling_list : list or tuple
-        The list defining how the j-values are coupled together. Must be defined
-        if state is not a subclass of CoupledSpinState. See the jcoupling
+        The list defining how the j-values are coupled together. If state is a
+        CoupledSpinState, this parameter is ignored. This must be defined if
+        state is not a subclass of CoupledSpinState. See the jcoupling
         parameter of the JzKetCoupled class to see how this must be defined.
 
     Examples
@@ -1673,29 +1672,56 @@ class JzKetCoupled(CoupledSpinState, Ket):
     Spin state that is an eigenket of Jz which represents the coupling of
     separate spin spaces.
 
-    See uncouple and couple for coupling of states and JzKetCoupled for coupled
-    states.
+    The arguments for creating instances of JzKetCoupled are j, m, jn and an
+    optional jcoupling argument. The j and m options are the total angular
+    momentum quantum numbers, as used for normal states (e.g. JzKet).
+
+    The other required parameter in *jn, which is a tuple defining the j_n
+    angular momentum quantum numbers of the product spaces. So for example, if
+    a state represented the coupling of the product basis state |j1,m1>x|j2,m2>,
+    the *jn for this state would be (j1,j2).
+
+    The final option is *jcoupling, which is used to define how the spaces
+    specified by *jn are coupled, which includes both the order these spaces
+    are coupled together and the quantum numbers that arise from these
+    couplings. The *jcoupling parameter itself is a list of lists, such that
+    each of the sublists defines a single coupling between the spin spaces. If
+    there are N coupled angular momentum spaces, that is *jn has N elements,
+    then there must be N-2 sublists. Note this will leave two uncoupled spaces,
+    and these last two spaces are automatically coupled together. Each of these
+    sublists making up the *jcoupling parameter have length 3. The first two
+    elements are the indicies of the product spaces that are considered to be
+    coupled together. For example, if we want to couple j_1 and j_4, the
+    indicies would be 1 and 4. If a state has already been coupled, it is
+    referenced by the smallest index that is coupled, so if j_2 and j_4 has
+    already been coupled to some j24, then this value can be coupled by
+    referencing it with index 2. The final element of the sublist is the
+    quantum number of the new quantum number. So putting everything together,
+    into a valid sublist for *jcoupling, if j_1 and j_2 are coupled to an
+    angular momentum space with quantum number j12, the sublist would be
+    (1,2,j12), N-2 of these sublists are used in the list for *jcoupling.
+
+    Note the *jcoupling parameter is optional, if it is not specified, the
+    default coupling is taken. This default value is to coupled the spaces in
+    order and take the quantum number of the coupling to be the maximum value.
+    For example, if the spin spaces are j1,j2,j3,j4, then the default coupling
+    couples j1 and j2 to j12=j1+j2, then, j12 and j3 are coupled to
+    j123=j12+j3, and finally j123 and j4 to j1234=j123+j4. The jcoupling value
+    that would correspond to this is:
+    ((1,2,j1+j2),(1,3,j1+j2+j3))
+
+    See uncouple and couple for coupling and uncoupling of states.
 
     Parameters
     ==========
 
-    j : Number, Symbol
-        Total spin angular momentum
-    m : Number, Symbol
-        Eigenvalue of the Jz spin operator
-    *jn : tuple or list
-        The j values of the spaces that are coupled
-    jcoupling : tuple or list
-        Optional parameter defining the order and j values of the spaces that
-        are coupled together. This list is composed of sub-lists of length 3. In
-        the sub-list, the first two elements define the n values for the states
-        that are coupled, j_n, and the third element gives the j value of the
-        new coupled space. If a coupled space is to be referenced later, it is
-        done by referencing the smallest n of the j_n's that are coupled in that
-        space. If there are N elements of jn, the length of this parameter must
-        be N-2. If no value if given, the default coupling is used, which
-        couples the first space to the second with a j value j_12=j_1+j_2, then
-        j_12 is coupled to the third space with j value j_123=j_12+j3, etc.
+    *args : tuple
+        The arguments that must be passed are j, m, *jn, and *jcoupling. The j
+        value is the total angular momentum. The m value is the eigenvalue of
+        the Jz spin operator. The *jn list are the j values of argular momentum
+        spaces coupled together. The jcoupling parameter is an optional
+        parameter defining how the spaces are coupled together. See the above
+        description for how these coupling parameters are defined.
 
     Examples
     ========

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -1451,8 +1451,7 @@ class CoupledSpinState(SpinState):
             raise ValueError('jcoupling must have length of %d, got %d' % (len(jn)-1, len(jcoupling)))
         if not all(len(x) == 3 for x in jcoupling):
             raise ValueError('All elements of jcoupling must have length 3')
-        coupled_n, coupled_jn = _build_coupled(jcoupling, len(jn))
-        return State.__new__(cls, j, m, jn, coupled_jn, coupled_n)
+        return State.__new__(cls, j, m, jn, jcoupling)
 
     def _print_label(self, printer, *args):
         label = [self.j, self.m]
@@ -1504,11 +1503,11 @@ class CoupledSpinState(SpinState):
 
     @property
     def coupled_jn(self):
-        return self.label[3]
+        return _build_coupled(self.label[3], len(self.label[2]))[1]
 
     @property
     def coupled_n(self):
-        return self.label[4]
+        return _build_coupled(self.label[3], len(self.label[2]))[0]
 
     @classmethod
     def _eval_hilbert_space(cls, label):

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -212,7 +212,7 @@ def couple(tp, jcoupling_list=None):
                     cg_terms.append( (j1, m1, j2, m2, j3, m3) )
                     jcoupling.append( (min(j1_n), min(j2_n), j3) )
                 coeff = Mul( *[ CG(*term).doit() for term in cg_terms] )
-                state = coupled_evect(j3, m3, jn, jcoupling=jcoupling[:-1])
+                state = coupled_evect(j3, m3, jn, jcoupling[:-1])
                 result.append(coeff*state)
 
         return Add(*result).doit()
@@ -238,7 +238,7 @@ def couple(tp, jcoupling_list=None):
             jcoupling.append( (min(j1_n), min(j2_n), j3) )
             sum_terms.append((j3,m3,j1+j2))
         coeff = Mul( *[ CG(*term) for term in cg_terms] )
-        state = coupled_evect(j3, m3, jn, jcoupling=jcoupling[:-1])
+        state = coupled_evect(j3, m3, jn, jcoupling[:-1])
         return Sum(coeff*state, *sum_terms)
 
 
@@ -289,7 +289,7 @@ def uncouple(state, jn=None, jcoupling_list=None):
 
     Uncouple a numerical state of three coupled spaces using a CoupledSpinState state:
 
-        >>> uncouple(JzKetCoupled(1, 1, (1, 1, 1), jcoupling=((1,3,1),) ))
+        >>> uncouple(JzKetCoupled(1, 1, (1, 1, 1), ((1,3,1),) ))
         |1,-1>x|1,1>x|1,1>/2 - |1,0>x|1,0>x|1,1>/2 + |1,1>x|1,0>x|1,0>/2 - |1,1>x|1,1>x|1,-1>/2
 
     Perform the same calculation using a SpinState state:
@@ -1437,12 +1437,16 @@ def _build_coupled(jcoupling, length):
 class CoupledSpinState(SpinState):
     """Base class for coupled angular momentum states."""
 
-    def __new__(cls, j, m, jn, **options):
-        jcoupling = options.get('jcoupling')
-        if jcoupling is None:
+    def __new__(cls, *args):
+        if len(args) == 4:
+            j, m, jn, jcoupling = args
+        elif len(args) == 3:
+            j, m, jn = args
             jcoupling = []
             for n in range(2,len(jn)):
                 jcoupling.append((1,n,Add(*[jn[i] for i in range(n)])))
+        else:
+            raise ValueError("args must have length 3 or 4")
         if not len(jn)-2 == len(jcoupling):
             raise ValueError('jcoupling must have length of %d, got %d' % (len(jn)-1, len(jcoupling)))
         if not all(len(x) == 3 for x in jcoupling):
@@ -1741,9 +1745,9 @@ class JzKetCoupled(CoupledSpinState, Ket):
 
         >>> JzKetCoupled(2, 1, (1, 1, 1))
         |2,1,j1=1,j2=1,j3=1,j(1,2)=2>
-        >>> JzKetCoupled(2, 1, (1, 1, 1), jcoupling=((1,2,2),) )
+        >>> JzKetCoupled(2, 1, (1, 1, 1), ((1,2,2),) )
         |2,1,j1=1,j2=1,j3=1,j(1,2)=2>
-        >>> JzKetCoupled(2, 1, (1, 1, 1), jcoupling=((2,3,1),) )
+        >>> JzKetCoupled(2, 1, (1, 1, 1), ((2,3,1),) )
         |2,1,j1=1,j2=1,j3=1,j(2,3)=1>
 
     Rewriting the JzKetCoupled in terms of eigenkets of the Jx operator:

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -56,82 +56,196 @@ def m_values(j):
     return size, [j-i for i in range(int(2*j+1))]
 
 
-def couple(tp):
-    """ Couple an uncoupled spin states
+def couple(tp, jcoupling_list=None):
+    """ Couple a tensor product of spin states
 
     This function can be used to couple an uncoupled tensor product of spin
     states. All of the eigenstates to be coupled must be of the same class. It
     will return a linear combination of eigenstates that are subclasses of
-    CoupledSpinState.
+    CoupledSpinState determined by Clebsch-Gordan angular momentum coupling
+    coefficients.
 
     Parameters
     ==========
 
-    tp: TensorProduct
-        TensorProduct of spin states to be coupled
+    tp : TensorProduct
+        TensorProduct of spin states to be coupled. Each state must be a
+        subclass of SpinState and they all must be the same class.
+
+    jcoupling_list : list or tuple
+        Elements of this list are sub-lists of length 2 specifying the order of
+        the coupling of the spin spaces. The length of this must be N-2, where N
+        is the number of states in the tensor product to be coupled. The
+        elements of the sub-list are integers corresponding n value to the
+        spaces, j_n, that are coupled, where the spin spaces are counted
+        starting at n=1. If two spaces are coupled, the new coupled space is
+        referenced with the smaller of the two n's, e.g. the space defined by
+        the coupling (1, 3) would be referenced in later couplings by n=1. If
+        this parameter is not specified, the default method is to couple the
+        first and second spaces, then this coupled space to the third space,
+        etc.
 
     Examples
     ========
 
-    Couple a tensor product of numerical states:
+    Couple a tensor product of numerical states for two spaces:
 
         >>> from sympy.physics.quantum.spin import JzKet, couple
         >>> from sympy.physics.quantum.tensorproduct import TensorProduct
         >>> couple(TensorProduct(JzKet(1,0), JzKet(1,1)))
-        -sqrt(2)*|1,1,1,1>/2 + sqrt(2)*|2,1,1,1>/2
+        -sqrt(2)*|1,1,j1=1,j2=1>/2 + sqrt(2)*|2,1,j1=1,j2=1>/2
+
+
+    Numerical coupling of three spaces using the default coupling method, i.e.
+    first and second spaces couple, then this couples to the third space:
+
+        >>> couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)))
+        sqrt(6)*|2,2,j1=1,j2=1,j3=1,j1,2=2>/3 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j1,2=2>/3
+
+    Perform this same coupling, but we define the coupling to first couple
+    the first and third spaces:
+
+        >>> couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)), ((1,3),) )
+        sqrt(2)*|2,2,j1=1,j2=1,j3=1,j1,3=1>/2 - sqrt(6)*|2,2,j1=1,j2=1,j3=1,j1,3=2>/6 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j1,3=2>/3
 
     Couple a tensor product of symbolic states:
 
         >>> from sympy import symbols
         >>> j1,m1,j2,m2 = symbols('j1 m1 j2 m2')
         >>> couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2)))
-        Sum(CG(j1, m1, j2, m2, j, m1 + m2)*|j,m1 + m2>, (j, 0, j1 + j2))
+        Sum(CG(j1, m1, j2, m2, j, m1 + m2)*|j,m1 + m2,j1=j1,j2=j2>, (j, m1 + m2, j1 + j2))
 
     """
+    if not isinstance(tp, TensorProduct):
+        raise TypeError('tp must be a TensorProduct')
     states = tp.args
-    evect = states[0].__class__
-    if not all([arg.__class__ is evect for arg in states]):
-        raise TypeError('All operands must be of the same class')
-    evect = evect.coupled_class()
-    if all(state.j.is_number for state in states):
+    if not all([ issubclass(state.__class__, SpinState) for state in states]):
+        raise TypeError('States in tensor product must be subclasses of SpinState')
+    if not all([state.__class__ is states[0].__class__ for state in states]):
+        raise TypeError('All states must be the same basis')
+    coupled_evect = states[0].__class__.coupled_class()
+
+    # Define default coupling if none is specified
+    if jcoupling_list is None:
+        jcoupling_list = []
+        for n in range(1, len(states)-1):
+            jcoupling_list.append( (1, n+1) )
+
+    # Check jcoupling_list valid
+    if not len(jcoupling_list) == len(states)-2:
+        raise TypeError('jcoupling_list must be length %d, got %d' % (len(states)-2,len(j_coupling_list)))
+    if not all( len(coupling) == 2 for coupling in jcoupling_list):
+        raise ValueError('Each coupling must define 2 spaces')
+    if any([n1 == n2 for n1, n2 in jcoupling_list]):
+        raise ValueError('Spin spaces cannot couple to themselves')
+    if all([sympify(n1).is_number and sympify(n2).is_number for n1,n2 in jcoupling_list]):
+        j_test = [0]*len(states)
+        for n1, n2 in jcoupling_list:
+            if j_test[n1-1] == -1 or j_test[n2-1] == -1:
+                raise ValueError('Spaces coupling j_n\'s are referenced by smallest n value')
+            j_test[max(n1,n2)-1] = -1
+
+    # j values of states to be coupled together
+    jn = [state.j for state in states]
+
+    # Create coupling_list, which defines all the couplings between all
+    # the spaces from jcoupling_list
+    coupling_list = []
+    n_list = [ [i+1] for i in range(len(states)) ]
+    for j_coupling in jcoupling_list:
+        # Least n for all j_n which is coupled as first and second spaces
+        n1, n2 = j_coupling
+        # List of all n's coupled in first and second spaces
+        j1_n = list(n_list[n1-1])
+        j2_n = list(n_list[n2-1])
+        coupling_list.append( (j1_n, j2_n) )
+        # Set new j_n to be coupling of all j_n in both first and second spaces
+        n_list[n1-1] = sorted(j1_n+j2_n)
+        n_list[n2-1] = []
+    # Couple last two spaces together
+    n1 = [ x == [] for x in n_list].index(False)
+    n2 = [ x == [] for x in n_list][n1+1:].index(False)+n1+1
+    j1_n = list(n_list[n1])
+    j2_n = list(n_list[n2])
+    coupling_list.append( (j1_n, j2_n) )
+
+    if all(state.j.is_number and state.m.is_number for state in states):
         # Numerical coupling
-        vect = TensorProduct(*[state._represent() for state in states])
-        maxj = states[0].j + states[1].j
-        j1, j2 = states[0].j, states[1].j
-        if maxj == int(maxj):
-            minj = 0
-        else:
-            minj = S(1)/2
+
+        # Iterate over difference between maximum possible j value of each coupling and the actual value
+        diff_list = [0] * len(coupling_list)
+        diff_max = [ Add( *[ states[n-1].j-states[n-1].m for n in coupling[0]+coupling[1] ] ) for coupling in coupling_list ]
+
         result = []
-        for i in range(maxj-minj+1):
-            j = maxj-i
-            for k in range(2*j+1):
-                m = j-k
-                max_m1 = min(j1, m+j2)
-                min_m1 = max(-j1, m-j2)
-                min_m2 = m-max_m1
-                result.append(Add(*[vect[(j1-(max_m1-l))*(2*j2+1)+(j2-(min_m2+l)),0] * CG(j1,max_m1-l,j2,min_m2+l,j,m) * evect(j,m,j1,j2) for l in range(max_m1-min_m1+1)]))
-        if all(state.m.is_number for state in states):
-            return Add(*result).doit()
-        else:
-            return Add(*result)
+        for diff in range(diff_max[-1]+1):
+            # Determine available configurations
+            m = diff
+            n = len(coupling_list)
+            tot = Mul(*range(n,n+m)) // Mul(*range(1,m+1))
+
+            for config_num in range(tot):
+                # Find configuration given by i
+                m = diff
+                config_offset = 0
+                for k in range(n):
+                    prev = m
+                    n1 = n-k-1
+                    while  config_num >= Mul(*range(n1,n1+m)) // Mul(*range(1,m+1)) + config_offset:
+                        config_offset += Mul(*range(n1,n1+m)) // Mul(*range(1,m+1))
+                        m -= 1
+                    diff_list[k] = prev - m
+
+                # Skip the configuration if non-physical
+                if any( [ d > m for d, m in zip(diff_list, diff_max) ] ):
+                    continue
+
+                # Determine term
+                cg_terms = []
+                coupled_j = list(jn)
+                jcoupling = []
+                for coupling, diff in zip(coupling_list, diff_list):
+                    j1_n, j2_n = coupling
+                    j1 = coupled_j[ min(j1_n)-1 ]
+                    j2 = coupled_j[ min(j2_n)-1 ]
+                    j3 = j1 + j2 - diff
+                    coupled_j[ min(j1_n+j2_n) - 1 ] = j3
+                    m1 = Add( *[ states[x-1].m for x in j1_n] )
+                    m2 = Add( *[ states[x-1].m for x in j2_n] )
+                    m3 = m1 + m2
+                    cg_terms.append( (j1, m1, j2, m2, j3, m3) )
+                    jcoupling.append( (min(j1_n), min(j2_n), j3) )
+                coeff = Mul( *[ CG(*term).doit() for term in cg_terms] )
+                state = coupled_evect(j3, m3, jn, jcoupling=jcoupling[:-1])
+                result.append(coeff*state)
+
+        return Add(*result).doit()
     else:
         # Symbolic coupling
-        maxj = Add(*[state.j for state in states])
-        m = Add(*[state.m for state in states])
-        j = symbols('j')
-        if not maxj.is_number or maxj == int(maxj):
-            minj = 0
-        else:
-            minj = S(1)/2
-        j1 = states[0].j
-        j2 = states[1].j
-        m1 = states[0].m
-        m2 = states[1].m
-        return Sum(CG(j1,m1,j2,m2,j,m) * evect(j,m), (j,minj,maxj))
+        cg_terms = []
+        jcoupling = []
+        sum_terms = []
+        coupled_j = list(jn)
+        for j1_n,j2_n in coupling_list:
+            j1 = coupled_j[ min(j1_n)-1 ]
+            j2 = coupled_j[ min(j2_n)-1 ]
+            if len(j1_n+j2_n) == len(states):
+                j3 = symbols('j')
+            else:
+                j3_name = 'j' + ''.join(["%s" % n for n in j1_n+j2_n])
+                j3 = symbols(j3_name)
+            coupled_j[ min(j1_n+j2_n) - 1 ] = j3
+            m1 = Add( *[ states[x-1].m for x in j1_n] )
+            m2 = Add( *[ states[x-1].m for x in j2_n] )
+            m3 = m1 + m2
+            cg_terms.append( (j1, m1, j2, m2, j3, m3) )
+            jcoupling.append( (min(j1_n), min(j2_n), j3) )
+            sum_terms.append((j3,m3,j1+j2))
+        coeff = Mul( *[ CG(*term) for term in cg_terms] )
+        state = coupled_evect(j3, m3, jn, jcoupling=jcoupling[:-1])
+        return Sum(coeff*state, *sum_terms)
 
 
-def uncouple(*args):
+def uncouple(state, jn=None, jcoupling_list=None):
     """ Uncouple a coupled spin state
 
     Gives the uncoupled representation of a coupled spin state. Arguments must
@@ -142,10 +256,21 @@ def uncouple(*args):
     Parameters
     ==========
 
-    args: CoupledSpinState or SpinState
+    state : CoupledSpinState or SpinState
         The state that is to be coupled. If a subclass of SpinState is used,
-        the state must be followed by the j values of the spaces that are to
-        be coupled.
+        the jn and jcoupling parameters must be defined. If a subclass of
+        CoupledSpinState is used, jn and jcoupling will be taken from the
+        state.
+
+    jn : list or tuple
+        The list of the j-values that are coupled. Must be defined if state is
+        not a subclass of CoupledSpinState. See the jn parameter of the
+        JzKetCoupled class to see how this must be defined.
+
+    jcoupling_list : list or tuple
+        The list defining how the j-values are coupled together. Must be defined
+        if state is not a subclass of CoupledSpinState. See the jcoupling
+        parameter of the JzKetCoupled class to see how this must be defined.
 
     Examples
     ========
@@ -154,59 +279,139 @@ def uncouple(*args):
 
         >>> from sympy.physics.quantum.spin import JzKetCoupled, uncouple
         >>> from sympy import S
-        >>> uncouple(JzKetCoupled(1, 0, S(1)/2, S(1)/2))
+        >>> uncouple(JzKetCoupled(1, 0, (S(1)/2, S(1)/2)))
         sqrt(2)*|1/2,-1/2>x|1/2,1/2>/2 + sqrt(2)*|1/2,1/2>x|1/2,-1/2>/2
 
     Perform the same calculation using a SpinState state:
 
         >>> from sympy.physics.quantum.spin import JzKet
-        >>> uncouple(JzKet(1, 0), S(1)/2, S(1)/2)
+        >>> uncouple(JzKet(1, 0), (S(1)/2, S(1)/2))
         sqrt(2)*|1/2,-1/2>x|1/2,1/2>/2 + sqrt(2)*|1/2,1/2>x|1/2,-1/2>/2
+
+    Uncouple a numerical state of three coupled spaces using a CoupledSpinState state:
+
+        >>> uncouple(JzKetCoupled(1, 1, (1, 1, 1), jcoupling=((1,3,1),) ))
+        |1,-1>x|1,1>x|1,1>/2 - |1,0>x|1,0>x|1,1>/2 + |1,1>x|1,0>x|1,0>/2 - |1,1>x|1,1>x|1,-1>/2
+
+    Perform the same calculation using a SpinState state:
+
+        >>> uncouple(JzKet(1, 1), (1, 1, 1), ((1,3,1),) )
+        |1,-1>x|1,1>x|1,1>/2 - |1,0>x|1,0>x|1,1>/2 + |1,1>x|1,0>x|1,0>/2 - |1,1>x|1,1>x|1,-1>/2
 
     Uncouple a symbolic state using a CoupledSpinState state:
 
         >>> from sympy import symbols
         >>> j,m,j1,j2 = symbols('j m j1 j2')
-        >>> uncouple(JzKetCoupled(j, m, j1, j2))
+        >>> uncouple(JzKetCoupled(j, m, (j1, j2)))
         Sum(CG(j1, m1, j2, m2, j, m)*|j1,m1>x|j2,m2>, (m1, -j1, j1), (m2, -j2, j2))
 
     Perform the same calculation using a SpinState state
 
-        >>> uncouple(JzKet(j, m), j1, j2)
+        >>> uncouple(JzKet(j, m), (j1, j2))
         Sum(CG(j1, m1, j2, m2, j, m)*|j1,m1>x|j2,m2>, (m1, -j1, j1), (m2, -j2, j2))
 
     """
-    if len(args) == 3:
-        state, j1, j2 = args
-        evect = state.__class__
-    elif len(args) == 1:
-        state = args[0]
+    if isinstance(state, CoupledSpinState):
+        jn = state.jn
+        coupled_n = state.coupled_n
+        coupled_jn = state.coupled_jn
         evect = state.uncoupled_class()
-        j1, j2 =  state.jvals
-        state = evect(state.j, state.m)
+    elif isinstance(state, SpinState):
+        if jn is None:
+            raise ValueError("Must specify j-values for coupled state")
+        if not (isinstance(jn,list) or isinstance(jn,tuple)):
+            raise TypeError("jn must be list or tuple")
+        if len(jn) > 2:
+            if jcoupling_list is None:
+                raise ValueError("Must specify coupling between j's in jcoupling")
+            if not (isinstance(jcoupling_list,list) or isinstance(jcoupling_list,tuple)):
+                raise TypeError("jcoupling must be a list or tuple")
+        else:
+            jcoupling_list = []
+        if not len(jcoupling_list) == len(jn)-2:
+            raise ValueError("Must specify 2 fewer coupling terms than the number of j values")
+        coupled_n, coupled_jn = _build_coupled(jcoupling_list, len(jn))
+        evect = state.__class__
     else:
-        raise TypeError
+        raise TypeError("state must be a spin state")
     j = state.j
     m = state.m
-    if state.j.is_number and state.m.is_number:
-        result = []
-        for i_m1 in range(2*j1+1):
-            m1 = j1-i_m1
-            for i_m2 in range(2*j2+1):
-                m2 = j2-i_m2
-                result.append(CG(j1,m1,j2,m2,j,m).doit() * TensorProduct(evect(j1,m1), evect(j2,m2)))
-        return Add(*result)
+    coupling_list = []
+    n_list = [ [i+1] for i in range(len(jn)) ]
+    j_list = list(jn)
+
+    # Create coupling, which defines all the couplings between all the spaces
+    for j3, (n1,n2) in zip(coupled_jn, coupled_n):
+        # j's which are coupled as first and second spaces
+        j1 = j_list[n1[0]-1]
+        j2 = j_list[n2[0]-1]
+        # Build coupling list
+        coupling_list.append( (n1, n2, j1, j2, j3) )
+        # Set new value in j_list
+        j_list[min(n1+n2)-1] = j3
+    # Couple last two spaces together
+    if len(jn) > 2:
+        n1 = sorted(coupled_n[-1][0]+coupled_n[-1][1])
+        j1 = coupled_jn[-1]
+        n2 = [ n for n in range(1,len(jn)+1) if n not in n1 ]
+        j2 = j_list[n2[0]-1]
     else:
-        m1,m2,mi = symbols('m1 m2 mi')
-        # Hack to get rotation angles
-        angles = (evect(0,mi)._represent())[0].args[3:6]
-        out_state = TensorProduct(evect(j1,m1),evect(j2,m2))
-        if angles == (0,0,0):
-            lt = CG(j1,m1,j2,m2,state.j,state.m)
-            return Sum(lt * out_state, (m1,-j1,j1), (m2,-j2,j2))
-        else:
-            lt = CG(j1,m1,j2,m2,state.j,mi) * Rotation.D(state.j,mi,state.m,*angles)
-            return Sum(lt * out_state, (mi,-state.j,state.j), (m1,-j1,j1), (m2,-j2,j2))
+        n1 = [1]
+        j1 = j_list[0]
+        n2 = [2]
+        j2 = j_list[1]
+    coupling_list.append( (n1, n2, j1, j2, j) )
+
+    if j.is_number and m.is_number:
+        diff_list = [0] * len(jn)
+        diff_max = [ 2*x for x in jn ]
+        diff = Add(*jn) - m
+
+        p = diff
+        n = len(jn)
+        tot = Mul(*range(n,n+p)) // Mul(*range(1,p+1))
+
+        result = []
+        for config_num in range(tot):
+            # Find configurations given by i
+            p = diff
+            config_offset = 0
+            for k in range(n):
+                prev = p
+                n1 = n-k-1
+                while config_num >= Mul(*range(n1,n1+p)) // Mul(*range(1,p+1)) + config_offset:
+                    config_offset += Mul(*range(n1,n1+p)) // Mul(*range(1,p+1))
+                    p -= 1
+                diff_list[k] = prev - p
+
+            if any( [ d > p for d, p in zip(diff_list, diff_max) ] ):
+                continue
+
+            cg_terms = []
+            for coupling in coupling_list:
+                j1_n, j2_n, j1, j2, j3 = coupling
+                m1 = Add( *[ jn[x-1] - diff_list[x-1] for x in j1_n ] )
+                m2 = Add( *[ jn[x-1] - diff_list[x-1] for x in j2_n ] )
+                m3 = Add( *[ jn[x-1] - diff_list[x-1] for x in j1_n+j2_n ] )
+                cg_terms.append( (j1, m1, j2, m2, j3, m3) )
+            coeff = Mul( *[ CG(*term).doit() for term in cg_terms ] )
+            state = TensorProduct( *[ evect(j, j - d) for j,d in zip(jn,diff_list) ] )
+            result.append(coeff*state)
+        return Add(*result).doit()
+    else:
+        # Symbolic coupling
+        m_str = "m1:%d" % (len(jn)+1)
+        mvals = symbols(m_str)
+        cg_terms = [(j1, Add(*[mvals[n-1] for n in j1_n]),
+                     j2, Add(*[mvals[n-1] for n in j2_n]),
+                     j3, Add(*[mvals[n-1] for n in j1_n+j2_n])) for j1_n,j2_n,j1,j2,j3 in coupling_list[:-1] ]
+        cg_terms.append(*[(j1, Add(*[mvals[n-1] for n in j1_n]),
+                           j2, Add(*[mvals[n-1] for n in j2_n]),
+                           j, m) for j1_n,j2_n,j1,j2,j3 in [coupling_list[-1]] ])
+        cg_coeff = Mul(*[CG(*cg_term) for cg_term in cg_terms])
+        sum_terms = [ (m,-j,j) for j,m in zip(jn,mvals) ]
+        state = TensorProduct( *[ evect(j,m) for j,m in zip(jn,mvals) ] )
+        return Sum(cg_coeff*state,*sum_terms)
 
 
 #-----------------------------------------------------------------------------
@@ -534,16 +739,16 @@ class Rotation(UnitaryOperator):
         >>> from sympy import pi
         >>> from sympy.physics.quantum.spin import Rotation
         >>> Rotation(pi, 0, pi/2)
-        'R'(pi,0,pi/2)
+        R(pi,0,pi/2)
 
     With symbolic Euler angles and calculating the inverse rotation operator:
 
         >>> from sympy import symbols
         >>> a, b, c = symbols('a b c')
         >>> Rotation(a, b, c)
-        'R'(a,b,c)
+        R(a,b,c)
         >>> Rotation(a, b, c).inverse()
-        'R'(-c,-b,-a)
+        R(-c,-b,-a)
 
 
     References
@@ -577,7 +782,7 @@ class Rotation(UnitaryOperator):
         return self.label[2]
 
     def _print_operator_name(self, printer, *args):
-        return printer._print('R', *args)
+        return printer._print(u'R', *args)
 
     def _print_operator_name_pretty(self, printer, *args):
         return prettyForm(u"\u211B" + u" ")
@@ -919,11 +1124,11 @@ class SpinState(State):
         if self.j.is_number:
             size, mvals = m_values(j)
             result = zeros(size, 1)
-            for p in range(size):
+            for p, mval in enumerate(mvals):
                 if m.is_number and alpha.is_number and beta.is_number and gamma.is_number:
-                    result[p,0] = Rotation.D(self.j, mvals[p], self.m, alpha, beta, gamma).doit()
+                    result[p,0] = Rotation.D(self.j, mval, self.m, alpha, beta, gamma).doit()
                 else:
-                    result[p,0] = Rotation.D(self.j, mvals[p], self.m, alpha, beta, gamma)
+                    result[p,0] = Rotation.D(self.j, mval, self.m, alpha, beta, gamma)
             return result
         else:
             mi = symbols("mi")
@@ -953,6 +1158,7 @@ class SpinState(State):
             vect = represent(self, basis=basis, **options)
             return Add(*[vect[i] * evect(j,j-i) for i in range(2*j+1)])
         else:
+            j = sympify(self.j)
             # TODO: better way to get angles of rotation
             mi = symbols('mi')
             angles = represent(self.__class__(0,mi),basis=basis)[0].args[3:6]
@@ -1133,7 +1339,7 @@ class JzKet(SpinState, Ket):
         1/2
 
     Uncoupled States
-    ---------------
+    ----------------
 
     Define an uncoupled state as a TensorProduct between two Jz eigenkets:
 
@@ -1213,34 +1419,120 @@ class JzBra(SpinState, Bra):
         return JzBraCoupled
 
 
+# Method used primarily to create coupled_n and coupled_jn by __new__ in
+# CoupledSpinState
+# This same method is also used by the uncouple method, and is separated from
+# the CoupledSpinState class to maintain consistency in defining coupling
+def _build_coupled(jcoupling, length):
+    n_list = [ [n+1] for n in range(length) ]
+    coupled_jn = []
+    coupled_n = []
+    for n1,n2,j_new in jcoupling:
+        coupled_jn.append(j_new)
+        coupled_n.append( (n_list[n1-1], n_list[n2-1]) )
+        n_sort = sorted(n_list[n1-1]+n_list[n2-1])
+        n_list[n_sort[0]-1] = n_sort
+    return coupled_n, coupled_jn
+
+
 class CoupledSpinState(SpinState):
     """Base class for coupled angular momentum states."""
 
-    def __new__(cls, j, m, *jvals):
-        return State.__new__(cls, j, m, *jvals)
+    def __new__(cls, j, m, jn, **options):
+        jcoupling = options.get('jcoupling')
+        if jcoupling is None:
+            jcoupling = []
+            for n in range(2,len(jn)):
+                jcoupling.append((1,n,Add(*[jn[i] for i in range(n)])))
+        if not len(jn)-2 == len(jcoupling):
+            raise ValueError('jcoupling must have length of %d, got %d' % (len(jn)-1, len(jcoupling)))
+        if not all(len(x) == 3 for x in jcoupling):
+            raise ValueError('All elements of jcoupling must have length 3')
+        coupled_n, coupled_jn = _build_coupled(jcoupling, len(jn))
+        return State.__new__(cls, j, m, jn, coupled_jn, coupled_n)
+
+    def _print_label(self, printer, *args):
+        label = [self.j, self.m]
+        for i, ji in enumerate(self.jn, start=1):
+            label.append(u'j%d=%s' % (i, ji) )
+            pass
+        for jn, (n1,n2) in zip(self.coupled_jn, self.coupled_n):
+            label.append(u'j%s=%s' % (','.join(str(i) for i in sorted(n1+n2)), printer._print(jn)) )
+        return self._print_sequence(
+            label, self._label_separator, printer, *args
+        )
+
+    def _print_label_pretty(self, printer, *args):
+        label = [self.j, self.m]
+        for i, ji in enumerate(self.jn, start=1):
+            n = '%d' % (i)
+            j = self._print_subscript_pretty(
+                stringPict('j'), stringPict(n)
+            )
+            item = prettyForm(*j.right(stringPict('=')))
+            item = prettyForm(*item.right(printer._print(ji)))
+            label.append(item)
+        for jn, (n1,n2) in zip(self.coupled_jn, self.coupled_n):
+            n = ','.join(str(i) for i in sorted(n1+n2))
+            j = self._print_subscript_pretty(
+                stringPict('j'), stringPict(n)
+            )
+            item = prettyForm(*j.right(stringPict('=')))
+            item = prettyForm(*item.right(printer._print(jn)))
+            label.append(item)
+        return self._print_sequence_pretty(
+            label, self._label_separator, printer, *args
+        )
+
+    def _print_label_latex(self, printer, *args):
+        label = [self.j, self.m]
+        for i, ji in enumerate(self.jn, start=1):
+            label.append('j_{%d}=%s' % (i, printer._print(ji)) )
+        for jn, (n1,n2) in zip(self.coupled_jn, self.coupled_n):
+            n = ','.join(str(i) for i in sorted(n1+n2))
+            label.append('j_{%s}=%s' % (n, printer._print(jn)) )
+        return self._print_sequence(
+            label, self._label_separator, printer, *args
+        )
 
     @property
-    def jvals(self):
-        return self.label[2:]
+    def jn(self):
+        return self.label[2]
+
+    @property
+    def coupled_jn(self):
+        return self.label[3]
+
+    @property
+    def coupled_n(self):
+        return self.label[4]
 
     @classmethod
     def _eval_hilbert_space(cls, label):
-        j = Add(*label[2:])
+        j = Add(*label[2])
+        # TODO: Need hilbert space fix, see issue 2633
         if j.is_number:
+            # Desired behavior:
+            #return Add( *[ComplexSpace(jn) for jn in range(1,2*j+1,2)] )
+            # Temporary fix
             ret = ComplexSpace(2*j+1)
             while j >= 1:
                 j -= 1
                 ret += ComplexSpace(2*j+1)
             return ret
         else:
-            # TODO
-            # Need hilbert space fix
+            # Desired behavior:
             #ji = symbols('ji')
-            #ret = Sum(ComplexSpace(2*ji + 1), (ji, j, 0))
+            #ret = Sum(ComplexSpace(2*ji + 1), (ji, 0, j))
+            # Temporary fix:
             return ComplexSpace(2*j+1)
 
     def _represent_coupled_base(self, **options):
         evect = self.uncoupled_class()
+        if not self.j.is_number:
+            raise ValueError('State must not have symbolic j value to represent')
+        if not self.hilbert_space.dimension.is_number:
+            raise ValueError('State must not have symbolic j values to represent')
         result = zeros(self.hilbert_space.dimension, 1)
         if self.j == int(self.j):
             start = self.j**2
@@ -1267,25 +1559,25 @@ class CoupledSpinState(SpinState):
     def _rewrite_basis(self, basis, evect, **options):
         from sympy.physics.quantum.represent import represent
         j = sympify(self.j)
-        jvals = self.jvals
+        jn = self.jn
         if j.is_number:
             if j == int(j):
                 start = j**2
             else:
                 start = (2*j-1)*(2*j+1)/4
             vect = represent(self, basis=basis, **options)
-            result = Add(*[vect[start+i] * evect(j,j-i,*jvals) for i in range(2*j+1)])
+            result = Add(*[vect[start+i] * evect(j, j-i, jn) for i in range(2*j+1)])
             if options.get('coupled') is False:
                 return uncouple(result)
             return result
         else:
             # TODO: better way to get angles of rotation
             mi = symbols('mi')
-            angles = represent(self.__class__(0,mi),basis=basis)[0].args[3:6]
+            angles = represent(self.uncoupled_class()(0, mi),basis=basis)[0].args[3:6]
             if angles == (0,0,0):
                 return self
             else:
-                state = evect(j, mi, *jvals)
+                state = evect(j, mi, jn)
                 lt = Rotation.D(j, mi, self.m, *angles)
                 result = lt * state
                 return Sum(lt * state, (mi,-j,j))
@@ -1391,8 +1683,19 @@ class JzKetCoupled(CoupledSpinState, Ket):
         Total spin angular momentum
     m : Number, Symbol
         Eigenvalue of the Jz spin operator
-    *jvals : tuple
+    *jn : tuple or list
         The j values of the spaces that are coupled
+    jcoupling : tuple or list
+        Optional parameter defining the order and j values of the spaces that
+        are coupled together. This list is composed of sub-lists of length 3. In
+        the sub-list, the first two elements define the n values for the states
+        that are coupled, j_n, and the third element gives the j value of the
+        new coupled space. If a coupled space is to be referenced later, it is
+        done by referencing the smallest n of the j_n's that are coupled in that
+        space. If there are N elements of jn, the length of this parameter must
+        be N-2. If no value if given, the default coupling is used, which
+        couples the first space to the second with a j value j_12=j_1+j_2, then
+        j_12 is coupled to the third space with j value j_123=j_12+j3, etc.
 
     Examples
     ========
@@ -1401,22 +1704,32 @@ class JzKetCoupled(CoupledSpinState, Ket):
 
         >>> from sympy.physics.quantum.spin import JzKetCoupled
         >>> from sympy import symbols
-        >>> JzKetCoupled(1, 0, 1, 1)
-        |1,0,1,1>
+        >>> JzKetCoupled(1, 0, (1, 1))
+        |1,0,j1=1,j2=1>
         >>> j, m, j1, j2 = symbols('j m j1 j2')
-        >>> JzKetCoupled(j, m, j1, j2)
-        |j,m,j1,j2>
+        >>> JzKetCoupled(j, m, (j1, j2))
+        |j,m,j1=j1,j2=j2>
+
+    Defining coupled spin states for more than 2 coupled spaces with various
+    coupling parameters:
+
+        >>> JzKetCoupled(2, 1, (1, 1, 1))
+        |2,1,j1=1,j2=1,j3=1,j1,2=2>
+        >>> JzKetCoupled(2, 1, (1, 1, 1), jcoupling=((1,2,2),) )
+        |2,1,j1=1,j2=1,j3=1,j1,2=2>
+        >>> JzKetCoupled(2, 1, (1, 1, 1), jcoupling=((2,3,1),) )
+        |2,1,j1=1,j2=1,j3=1,j2,3=1>
 
     Rewriting the JzKetCoupled in terms of eigenkets of the Jx operator:
     Note: that the resulting eigenstates are JxKetCoupled
 
-        >>> JzKetCoupled(1,1,1,1).rewrite("Jx")
-        |1,-1,1,1>/2 - sqrt(2)*|1,0,1,1>/2 + |1,1,1,1>/2
+        >>> JzKetCoupled(1,1,(1,1)).rewrite("Jx")
+        |1,-1,j1=1,j2=1>/2 - sqrt(2)*|1,0,j1=1,j2=1>/2 + |1,1,j1=1,j2=1>/2
 
     The rewrite method can be used to convert a coupled state to an uncoupled
     state. This is done by passing coupled=False to the rewrite function:
 
-        >>> JzKetCoupled(1, 0, 1, 1).rewrite('Jz', coupled=False)
+        >>> JzKetCoupled(1, 0, (1, 1)).rewrite('Jz', coupled=False)
         -sqrt(2)*|1,-1>x|1,1>/2 + sqrt(2)*|1,1>x|1,-1>/2
 
     Get the vector representation of a state in terms of the basis elements
@@ -1425,7 +1738,7 @@ class JzKetCoupled(CoupledSpinState, Ket):
         >>> from sympy.physics.quantum.represent import represent
         >>> from sympy.physics.quantum.spin import Jx
         >>> from sympy import S
-        >>> represent(JzKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jx)
+        >>> represent(JzKetCoupled(1,-1,(S(1)/2,S(1)/2)), basis=Jx)
         [        0]
         [      1/2]
         [sqrt(2)/2]

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -90,27 +90,27 @@ def couple(tp, jcoupling_list=None):
         >>> from sympy.physics.quantum.spin import JzKet, couple
         >>> from sympy.physics.quantum.tensorproduct import TensorProduct
         >>> couple(TensorProduct(JzKet(1,0), JzKet(1,1)))
-        -sqrt(2)*|1,1,j1=1,j2=1>/2 + sqrt(2)*|2,1,j1=1,j2=1>/2
+        -sqrt(2)*|1,1,'j1=1','j2=1'>/2 + sqrt(2)*|2,1,'j1=1','j2=1'>/2
 
 
     Numerical coupling of three spaces using the default coupling method, i.e.
     first and second spaces couple, then this couples to the third space:
 
         >>> couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)))
-        sqrt(6)*|2,2,j1=1,j2=1,j3=1,j(1,2)=2>/3 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j(1,2)=2>/3
+        sqrt(6)*|2,2,'j1=1','j2=1','j3=1','j(1,2)=2'>/3 + sqrt(3)*|3,2,'j1=1','j2=1','j3=1','j(1,2)=2'>/3
 
     Perform this same coupling, but we define the coupling to first couple
     the first and third spaces:
 
         >>> couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)), ((1,3),) )
-        sqrt(2)*|2,2,j1=1,j2=1,j3=1,j(1,3)=1>/2 - sqrt(6)*|2,2,j1=1,j2=1,j3=1,j(1,3)=2>/6 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j(1,3)=2>/3
+        sqrt(2)*|2,2,'j1=1','j2=1','j3=1','j(1,3)=1'>/2 - sqrt(6)*|2,2,'j1=1','j2=1','j3=1','j(1,3)=2'>/6 + sqrt(3)*|3,2,'j1=1','j2=1','j3=1','j(1,3)=2'>/3
 
     Couple a tensor product of symbolic states:
 
         >>> from sympy import symbols
         >>> j1,m1,j2,m2 = symbols('j1 m1 j2 m2')
         >>> couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2)))
-        Sum(CG(j1, m1, j2, m2, j, m1 + m2)*|j,m1 + m2,j1=j1,j2=j2>, (j, m1 + m2, j1 + j2))
+        Sum(CG(j1, m1, j2, m2, j, m1 + m2)*|j,m1 + m2,'j1=j1','j2=j2'>, (j, m1 + m2, j1 + j2))
 
     """
     if not isinstance(tp, TensorProduct):
@@ -738,16 +738,16 @@ class Rotation(UnitaryOperator):
         >>> from sympy import pi
         >>> from sympy.physics.quantum.spin import Rotation
         >>> Rotation(pi, 0, pi/2)
-        R(pi,0,pi/2)
+        'R'(pi,0,pi/2)
 
     With symbolic Euler angles and calculating the inverse rotation operator:
 
         >>> from sympy import symbols
         >>> a, b, c = symbols('a b c')
         >>> Rotation(a, b, c)
-        R(a,b,c)
+        'R'(a,b,c)
         >>> Rotation(a, b, c).inverse()
-        R(-c,-b,-a)
+        'R'(-c,-b,-a)
 
 
     References
@@ -781,7 +781,7 @@ class Rotation(UnitaryOperator):
         return self.label[2]
 
     def _print_operator_name(self, printer, *args):
-        return printer._print(u'R', *args)
+        return printer._print('R', *args)
 
     def _print_operator_name_pretty(self, printer, *args):
         return prettyForm(u"\u211B" + u" ")
@@ -1456,10 +1456,10 @@ class CoupledSpinState(SpinState):
     def _print_label(self, printer, *args):
         label = [self.j, self.m]
         for i, ji in enumerate(self.jn, start=1):
-            label.append(u'j%d=%s' % (i, ji) )
+            label.append('j%d=%s' % (i, ji) )
             pass
         for jn, (n1,n2) in zip(self.coupled_jn, self.coupled_n):
-            label.append(u'j(%s)=%s' % (','.join(str(i) for i in sorted(n1+n2)), printer._print(jn)) )
+            label.append('j(%s)=%s' % (','.join(str(i) for i in sorted(n1+n2)), printer._print(jn)) )
         return self._print_sequence(
             label, self._label_separator, printer, *args
         )
@@ -1734,26 +1734,26 @@ class JzKetCoupled(CoupledSpinState, Ket):
         >>> from sympy.physics.quantum.spin import JzKetCoupled
         >>> from sympy import symbols
         >>> JzKetCoupled(1, 0, (1, 1))
-        |1,0,j1=1,j2=1>
+        |1,0,'j1=1','j2=1'>
         >>> j, m, j1, j2 = symbols('j m j1 j2')
         >>> JzKetCoupled(j, m, (j1, j2))
-        |j,m,j1=j1,j2=j2>
+        |j,m,'j1=j1','j2=j2'>
 
     Defining coupled spin states for more than 2 coupled spaces with various
     coupling parameters:
 
         >>> JzKetCoupled(2, 1, (1, 1, 1))
-        |2,1,j1=1,j2=1,j3=1,j(1,2)=2>
+        |2,1,'j1=1','j2=1','j3=1','j(1,2)=2'>
         >>> JzKetCoupled(2, 1, (1, 1, 1), ((1,2,2),) )
-        |2,1,j1=1,j2=1,j3=1,j(1,2)=2>
+        |2,1,'j1=1','j2=1','j3=1','j(1,2)=2'>
         >>> JzKetCoupled(2, 1, (1, 1, 1), ((2,3,1),) )
-        |2,1,j1=1,j2=1,j3=1,j(2,3)=1>
+        |2,1,'j1=1','j2=1','j3=1','j(2,3)=1'>
 
     Rewriting the JzKetCoupled in terms of eigenkets of the Jx operator:
     Note: that the resulting eigenstates are JxKetCoupled
 
         >>> JzKetCoupled(1,1,(1,1)).rewrite("Jx")
-        |1,-1,j1=1,j2=1>/2 - sqrt(2)*|1,0,j1=1,j2=1>/2 + |1,1,j1=1,j2=1>/2
+        |1,-1,'j1=1','j2=1'>/2 - sqrt(2)*|1,0,'j1=1','j2=1'>/2 + |1,1,'j1=1','j2=1'>/2
 
     The rewrite method can be used to convert a coupled state to an uncoupled
     state. This is done by passing coupled=False to the rewrite function:

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -100,13 +100,13 @@ def couple(tp, jcoupling_list=None):
     first and second spaces couple, then this couples to the third space:
 
         >>> couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)))
-        sqrt(6)*|2,2,j1=1,j2=1,j3=1,j1,2=2>/3 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j1,2=2>/3
+        sqrt(6)*|2,2,j1=1,j2=1,j3=1,j(1,2)=2>/3 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j(1,2)=2>/3
 
     Perform this same coupling, but we define the coupling to first couple
     the first and third spaces:
 
         >>> couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)), ((1,3),) )
-        sqrt(2)*|2,2,j1=1,j2=1,j3=1,j1,3=1>/2 - sqrt(6)*|2,2,j1=1,j2=1,j3=1,j1,3=2>/6 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j1,3=2>/3
+        sqrt(2)*|2,2,j1=1,j2=1,j3=1,j(1,3)=1>/2 - sqrt(6)*|2,2,j1=1,j2=1,j3=1,j(1,3)=2>/6 + sqrt(3)*|3,2,j1=1,j2=1,j3=1,j(1,3)=2>/3
 
     Couple a tensor product of symbolic states:
 
@@ -1457,7 +1457,7 @@ class CoupledSpinState(SpinState):
             label.append(u'j%d=%s' % (i, ji) )
             pass
         for jn, (n1,n2) in zip(self.coupled_jn, self.coupled_n):
-            label.append(u'j%s=%s' % (','.join(str(i) for i in sorted(n1+n2)), printer._print(jn)) )
+            label.append(u'j(%s)=%s' % (','.join(str(i) for i in sorted(n1+n2)), printer._print(jn)) )
         return self._print_sequence(
             label, self._label_separator, printer, *args
         )
@@ -1714,11 +1714,11 @@ class JzKetCoupled(CoupledSpinState, Ket):
     coupling parameters:
 
         >>> JzKetCoupled(2, 1, (1, 1, 1))
-        |2,1,j1=1,j2=1,j3=1,j1,2=2>
+        |2,1,j1=1,j2=1,j3=1,j(1,2)=2>
         >>> JzKetCoupled(2, 1, (1, 1, 1), jcoupling=((1,2,2),) )
-        |2,1,j1=1,j2=1,j3=1,j1,2=2>
+        |2,1,j1=1,j2=1,j3=1,j(1,2)=2>
         >>> JzKetCoupled(2, 1, (1, 1, 1), jcoupling=((2,3,1),) )
-        |2,1,j1=1,j2=1,j3=1,j2,3=1>
+        |2,1,j1=1,j2=1,j3=1,j(2,3)=1>
 
     Rewriting the JzKetCoupled in terms of eigenkets of the Jx operator:
     Note: that the resulting eigenstates are JxKetCoupled

--- a/sympy/physics/quantum/tests/test_cg.py
+++ b/sympy/physics/quantum/tests/test_cg.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from sympy import S, sqrt, Sum, symbols
-from sympy.physics.quantum.cg import Wigner3j, CG, cg_simp
+from sympy.physics.quantum.cg import Wigner3j, Wigner6j, Wigner9j, CG, cg_simp
 from sympy.functions.special.tensor_functions import KroneckerDelta
 
 
@@ -157,4 +157,6 @@ def test_cg_simp_sum():
 
 def test_doit():
     assert Wigner3j(1/2,-1/2,1/2,1/2,0,0).doit() == -sqrt(2)/2
+    assert Wigner6j(1,2,3,2,1,2).doit() == sqrt(21)/105
+    assert Wigner9j(2,1,1,S(3)/2,S(1)/2,1,S(1)/2,S(1)/2,0).doit() == sqrt(2)/12
     assert CG(1/2,1/2,1/2,-1/2,1,0).doit() == sqrt(2)/2

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -153,79 +153,79 @@ def test_represent():
         Matrix([0,0,0,1])
     # Coupled spin states
     # Jx basis
-    assert represent(JxKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([1,0,0,0])
-    assert represent(JxKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,1,0,0])
-    assert represent(JxKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,0,1,0])
-    assert represent(JxKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,0,0,1])
-    assert represent(JyKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([1,0,0,0])
-    assert represent(JyKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,-I,0,0])
-    assert represent(JyKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,0,1,0])
-    assert represent(JyKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,0,0,I])
-    assert represent(JzKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([1,0,0,0])
-    assert represent(JzKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,S(1)/2,-sqrt(2)/2,S(1)/2])
-    assert represent(JzKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,sqrt(2)/2,0,-sqrt(2)/2])
-    assert represent(JzKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jx) == \
+    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jx) == \
         Matrix([0,S(1)/2,sqrt(2)/2,S(1)/2])
     # Jy basis
-    assert represent(JxKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([1,0,0,0])
-    assert represent(JxKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,I,0,0])
-    assert represent(JxKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,0,1,0])
-    assert represent(JxKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,0,0,-I])
-    assert represent(JyKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([1,0,0,0])
-    assert represent(JyKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,1,0,0])
-    assert represent(JyKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,0,1,0])
-    assert represent(JyKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,0,0,1])
-    assert represent(JzKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([1,0,0,0])
-    assert represent(JzKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,S(1)/2,-I*sqrt(2)/2,-S(1)/2])
-    assert represent(JzKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,-I*sqrt(2)/2,0,-I*sqrt(2)/2])
-    assert represent(JzKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jy) == \
+    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jy) == \
         Matrix([0,-S(1)/2,-I*sqrt(2)/2,S(1)/2])
     # Jz basis
-    assert represent(JxKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JxKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([1,0,0,0])
-    assert represent(JxKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JxKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,S(1)/2,sqrt(2)/2,S(1)/2])
-    assert represent(JxKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JxKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,-sqrt(2)/2,0,sqrt(2)/2])
-    assert represent(JxKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JxKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,S(1)/2,-sqrt(2)/2,S(1)/2])
-    assert represent(JyKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JyKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([1,0,0,0])
-    assert represent(JyKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JyKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,S(1)/2,I*sqrt(2)/2,-S(1)/2])
-    assert represent(JyKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JyKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,I*sqrt(2)/2,0,I*sqrt(2)/2])
-    assert represent(JyKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JyKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,-S(1)/2,I*sqrt(2)/2,S(1)/2])
-    assert represent(JzKetCoupled(0,0,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JzKetCoupled(0, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([1,0,0,0])
-    assert represent(JzKetCoupled(1,1,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JzKetCoupled(1, 1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,1,0,0])
-    assert represent(JzKetCoupled(1,0,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JzKetCoupled(1, 0, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,0,1,0])
-    assert represent(JzKetCoupled(1,-1,S(1)/2,S(1)/2), basis=Jz) == \
+    assert represent(JzKetCoupled(1, -1, (S(1)/2,S(1)/2)), basis=Jz) == \
         Matrix([0,0,0,1])
 
 def test_rewrite():
@@ -309,67 +309,67 @@ def test_rewrite():
             TensorProduct(JyKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,pi/2,pi/2) * JyKet(j2,mi), (mi, -j2, j2)))
     # Rewrite a coupled state
     # Numerical
-    assert JyKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jx') == \
-        JxKetCoupled(0,0,S(1)/2,S(1)/2)
-    assert JyKetCoupled(1,1,S(1)/2,S(1)/2).rewrite('Jx') == \
-        -I*JxKetCoupled(1,1,S(1)/2,S(1)/2)
-    assert JyKetCoupled(1,0,S(1)/2,S(1)/2).rewrite('Jx') == \
-        JxKetCoupled(1,0,S(1)/2,S(1)/2)
-    assert JyKetCoupled(1,-1,S(1)/2,S(1)/2).rewrite('Jx') == \
-        I*JxKetCoupled(1,-1,S(1)/2,S(1)/2)
-    assert JzKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jx') == \
-        JxKetCoupled(0,0,S(1)/2,S(1)/2)
-    assert JzKetCoupled(1,1,S(1)/2,S(1)/2).rewrite('Jx') == \
-        JxKetCoupled(1,1,S(1)/2,S(1)/2)/2 - sqrt(2)*JxKetCoupled(1,0,S(1)/2,S(1)/2)/2 + JxKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JzKetCoupled(1,0,S(1)/2,S(1)/2).rewrite('Jx') == \
-        sqrt(2)*JxKetCoupled(1,1,S(1)/2,S(1)/2)/2 - sqrt(2)*JxKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JzKetCoupled(1,-1,S(1)/2,S(1)/2).rewrite('Jx') == \
-        JxKetCoupled(1,1,S(1)/2,S(1)/2)/2 + sqrt(2)*JxKetCoupled(1,0,S(1)/2,S(1)/2)/2 + JxKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JxKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jy') == \
-        JyKetCoupled(0,0,S(1)/2,S(1)/2)
-    assert JxKetCoupled(1,1,S(1)/2,S(1)/2).rewrite('Jy') == \
-        I*JyKetCoupled(1,1,S(1)/2,S(1)/2)
-    assert JxKetCoupled(1,0,S(1)/2,S(1)/2).rewrite('Jy') == \
-        JyKetCoupled(1,0,S(1)/2,S(1)/2)
-    assert JxKetCoupled(1,-1,S(1)/2,S(1)/2).rewrite('Jy') == \
-        -I*JyKetCoupled(1,-1,S(1)/2,S(1)/2)
-    assert JzKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jy') == \
-        JyKetCoupled(0,0,S(1)/2,S(1)/2)
-    assert JzKetCoupled(1,1,S(1)/2,S(1)/2).rewrite('Jy') == \
-        JyKetCoupled(1,1,S(1)/2,S(1)/2)/2 - I*sqrt(2)*JyKetCoupled(1,0,S(1)/2,S(1)/2)/2 - JyKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JzKetCoupled(1,0,S(1)/2,S(1)/2).rewrite('Jy') == \
-        -I*sqrt(2)*JyKetCoupled(1,1,S(1)/2,S(1)/2)/2 - I*sqrt(2)*JyKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JzKetCoupled(1,-1,S(1)/2,S(1)/2).rewrite('Jy') == \
-        -JyKetCoupled(1,1,S(1)/2,S(1)/2)/2 - I*sqrt(2)*JyKetCoupled(1,0,S(1)/2,S(1)/2)/2 + JyKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JxKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jz') == \
-        JzKetCoupled(0,0,S(1)/2,S(1)/2)
-    assert JxKetCoupled(1,1,S(1)/2,S(1)/2).rewrite('Jz') == \
-        JzKetCoupled(1,1,S(1)/2,S(1)/2)/2 + sqrt(2)*JzKetCoupled(1,0,S(1)/2,S(1)/2)/2 + JzKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JxKetCoupled(1,0,S(1)/2,S(1)/2).rewrite('Jz') == \
-        -sqrt(2)*JzKetCoupled(1,1,S(1)/2,S(1)/2)/2 + sqrt(2)*JzKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JxKetCoupled(1,-1,S(1)/2,S(1)/2).rewrite('Jz') == \
-        JzKetCoupled(1,1,S(1)/2,S(1)/2)/2 - sqrt(2)*JzKetCoupled(1,0,S(1)/2,S(1)/2)/2 + JzKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JyKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jz') == \
-        JzKetCoupled(0,0,S(1)/2,S(1)/2)
-    assert JyKetCoupled(1,1,S(1)/2,S(1)/2).rewrite('Jz') == \
-        JzKetCoupled(1,1,S(1)/2,S(1)/2)/2 + I*sqrt(2)*JzKetCoupled(1,0,S(1)/2,S(1)/2)/2 - JzKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JyKetCoupled(1,0,S(1)/2,S(1)/2).rewrite('Jz') == \
-        I*sqrt(2)*JzKetCoupled(1,1,S(1)/2,S(1)/2)/2 + I*sqrt(2)*JzKetCoupled(1,-1,S(1)/2,S(1)/2)/2
-    assert JyKetCoupled(1,-1,S(1)/2,S(1)/2).rewrite('Jz') == \
-        -JzKetCoupled(1,1,S(1)/2,S(1)/2)/2 + I*sqrt(2)*JzKetCoupled(1,0,S(1)/2,S(1)/2)/2 + JzKetCoupled(1,-1,S(1)/2,S(1)/2)/2
+    assert JyKetCoupled(0, 0, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        JxKetCoupled(0, 0, (S(1)/2,S(1)/2))
+    assert JyKetCoupled(1, 1, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        -I*JxKetCoupled(1, 1, (S(1)/2,S(1)/2))
+    assert JyKetCoupled(1, 0, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        JxKetCoupled(1, 0, (S(1)/2,S(1)/2))
+    assert JyKetCoupled(1, -1, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        I*JxKetCoupled(1, -1, (S(1)/2,S(1)/2))
+    assert JzKetCoupled(0, 0, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        JxKetCoupled(0, 0, (S(1)/2,S(1)/2))
+    assert JzKetCoupled(1, 1, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        JxKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 - sqrt(2)*JxKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 + JxKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JzKetCoupled(1, 0, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        sqrt(2)*JxKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 - sqrt(2)*JxKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JzKetCoupled(1, -1, (S(1)/2,S(1)/2)).rewrite('Jx') == \
+        JxKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 + sqrt(2)*JxKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 + JxKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JxKetCoupled(0, 0, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        JyKetCoupled(0, 0, (S(1)/2, S(1)/2))
+    assert JxKetCoupled(1, 1, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        I*JyKetCoupled(1, 1, (S(1)/2,S(1)/2))
+    assert JxKetCoupled(1, 0, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        JyKetCoupled(1, 0, (S(1)/2,S(1)/2))
+    assert JxKetCoupled(1, -1, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        -I*JyKetCoupled(1, -1, (S(1)/2,S(1)/2))
+    assert JzKetCoupled(0, 0, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        JyKetCoupled(0, 0, (S(1)/2,S(1)/2))
+    assert JzKetCoupled(1, 1, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        JyKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 - I*sqrt(2)*JyKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 - JyKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JzKetCoupled(1, 0, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        -I*sqrt(2)*JyKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 - I*sqrt(2)*JyKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JzKetCoupled(1, -1, (S(1)/2,S(1)/2)).rewrite('Jy') == \
+        -JyKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 - I*sqrt(2)*JyKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 + JyKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JxKetCoupled(0, 0, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        JzKetCoupled(0, 0, (S(1)/2,S(1)/2))
+    assert JxKetCoupled(1, 1, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 + sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 + JzKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JxKetCoupled(1, 0, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        -sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 + sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JxKetCoupled(1, -1, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 - sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 + JzKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JyKetCoupled(0, 0, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        JzKetCoupled(0, 0, (S(1)/2,S(1)/2))
+    assert JyKetCoupled(1, 1, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 + I*sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 - JzKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JyKetCoupled(1, 0, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        I*sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 + I*sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
+    assert JyKetCoupled(1, -1, (S(1)/2,S(1)/2)).rewrite('Jz') == \
+        -JzKetCoupled(1, 1, (S(1)/2,S(1)/2))/2 + I*sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2))/2 + JzKetCoupled(1, -1, (S(1)/2,S(1)/2))/2
     # Symbolic
-    assert JyKetCoupled(j,m,j1,j2).rewrite('Jx') == \
-        Sum(WignerD(j,mi,m,0,0,pi/2) * JxKetCoupled(j,mi,j1,j2), (mi,-j,j))
-    assert JzKetCoupled(j,m,j1,j2).rewrite('Jx') == \
-        Sum(WignerD(j,mi,m,0,3*pi/2,0) * JxKetCoupled(j,mi,j1,j2), (mi,-j,j))
-    assert JxKetCoupled(j,m,j1,j2).rewrite('Jy') == \
-        Sum(WignerD(j,mi,m,3*pi/2,0,0) * JyKetCoupled(j,mi,j1,j2), (mi,-j,j))
-    assert JzKetCoupled(j,m,j1,j2).rewrite('Jy') == \
-        Sum(WignerD(j,mi,m,3*pi/2,pi/2,pi/2) * JyKetCoupled(j,mi,j1,j2), (mi,-j,j))
-    assert JxKetCoupled(j,m,j1,j2).rewrite('Jz') == \
-        Sum(WignerD(j,mi,m,0,pi/2,0) * JzKetCoupled(j,mi,j1,j2), (mi,-j,j))
-    assert JyKetCoupled(j,m,j1,j2).rewrite('Jz') == \
-        Sum(WignerD(j,mi,m,3*pi/2,-pi/2,pi/2) * JzKetCoupled(j,mi,j1,j2), (mi,-j,j))
+    assert JyKetCoupled(j, m, (j1,j2)).rewrite('Jx') == \
+        Sum(WignerD(j,mi,m,0,0,pi/2) * JxKetCoupled(j, mi, (j1,j2)), (mi,-j,j))
+    assert JzKetCoupled(j, m, (j1,j2)).rewrite('Jx') == \
+        Sum(WignerD(j,mi,m,0,3*pi/2,0) * JxKetCoupled(j, mi, (j1,j2)), (mi,-j,j))
+    assert JxKetCoupled(j, m, (j1,j2)).rewrite('Jy') == \
+        Sum(WignerD(j,mi,m,3*pi/2,0,0) * JyKetCoupled(j, mi, (j1,j2)), (mi,-j,j))
+    assert JzKetCoupled(j, m, (j1,j2)).rewrite('Jy') == \
+        Sum(WignerD(j,mi,m,3*pi/2,pi/2,pi/2) * JyKetCoupled(j, mi, (j1,j2)), (mi,-j,j))
+    assert JxKetCoupled(j, m, (j1,j2)).rewrite('Jz') == \
+        Sum(WignerD(j,mi,m,0,pi/2,0) * JzKetCoupled(j, mi, (j1,j2)), (mi,-j,j))
+    assert JyKetCoupled(j, m, (j1,j2)).rewrite('Jz') == \
+        Sum(WignerD(j,mi,m,3*pi/2,-pi/2,pi/2) * JzKetCoupled(j, mi, (j1,j2)), (mi,-j,j))
     # Innerproducts of rewritten states
     # Numerical
     assert qapply(JxBra(1,1)*JxKet(1,1).rewrite('Jy')).doit() == 1
@@ -433,93 +433,3547 @@ def test_rewrite_failing():
 
 def test_uncouple():
     # Numerical
-    assert uncouple(JzKetCoupled(0,0,S(1)/2,S(1)/2)) == \
-        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2))/2 - sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2))/2
-    assert uncouple(JzKetCoupled(1,1,S(1)/2,S(1)/2)) == \
+    # 2 coupled spaces
+    # j1=1/2, j2=1/2
+    assert uncouple(JzKetCoupled(0, 0, (S(1)/2,S(1)/2))) == \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2))/2 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2))/2
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2))) == \
         TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,S(1)/2))
-    assert uncouple(JzKetCoupled(1,0,S(1)/2,S(1)/2)) == \
-        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2))/2 + sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2))/2
-    assert uncouple(JzKetCoupled(1,-1,S(1)/2,S(1)/2)) == \
-        1.0*TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2))
-    assert uncouple(JzKetCoupled(S(1)/2,S(1)/2,1,S(1)/2)) == \
-        -sqrt(3)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,S(1)/2))/3 + sqrt(6)*TensorProduct(JzKet(1,1),JzKet(S(1)/2,-S(1)/2))/3
-    assert uncouple(JzKetCoupled(S(1)/2,-S(1)/2,1,S(1)/2)) == \
-        sqrt(3)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,-S(1)/2))/3 - sqrt(6)*TensorProduct(JzKet(1,-1),JzKet(S(1)/2,S(1)/2))/3
-    assert uncouple(JzKetCoupled(S(3)/2,S(3)/2,1,S(1)/2)) == \
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2))) == \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2),JzKet(S(1)/2,-S(1)/2))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,S(1)/2))/2
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2),JzKet(S(1)/2,-S(1)/2))
+    # j1=1, j2=1/2
+    assert uncouple(JzKetCoupled(S(1)/2, S(1)/2, (1,S(1)/2))) == \
+        -sqrt(3)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,S(1)/2))/3 +\
+        sqrt(6)*TensorProduct(JzKet(1,1),JzKet(S(1)/2,-S(1)/2))/3
+    assert uncouple(JzKetCoupled(S(1)/2, -S(1)/2, (1,S(1)/2))) == \
+        sqrt(3)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,-S(1)/2))/3 - \
+        sqrt(6)*TensorProduct(JzKet(1,-1),JzKet(S(1)/2,S(1)/2))/3
+    assert uncouple(JzKetCoupled(S(3)/2, S(3)/2, (1,S(1)/2))) == \
         TensorProduct(JzKet(1,1),JzKet(S(1)/2,S(1)/2))
-    assert uncouple(JzKetCoupled(S(3)/2,S(1)/2,1,S(1)/2)) == \
-        sqrt(3)*TensorProduct(JzKet(1,1),JzKet(S(1)/2,-S(1)/2))/3 + sqrt(6)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,S(1)/2))/3
-    assert uncouple(JzKetCoupled(S(3)/2,-S(1)/2,1,S(1)/2)) == \
-        sqrt(6)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,-S(1)/2))/3 + sqrt(3)*TensorProduct(JzKet(1,-1),JzKet(S(1)/2,S(1)/2))/3
-    assert uncouple(JzKetCoupled(S(3)/2,-S(3)/2,1,S(1)/2)) == \
-        1.0*TensorProduct(JzKet(1,-1),JzKet(S(1)/2,-S(1)/2))
-    assert uncouple(JzKetCoupled(0,0,1,1)) == \
-        sqrt(3)*TensorProduct(JzKet(1,1),JzKet(1,-1))/3 - sqrt(3)*TensorProduct(JzKet(1,0),JzKet(1,0))/3 + sqrt(3)*TensorProduct(JzKet(1,-1),JzKet(1,1))/3
-    assert uncouple(JzKetCoupled(1,1,1,1)) == \
-        sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,0))/2 - sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2
-    assert uncouple(JzKetCoupled(1,0,1,1)) == \
-        sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,-1))/2 - sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,1))/2
-    assert uncouple(JzKetCoupled(1,-1,1,1)) == \
-        0.5*sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,-1)) - 0.5*sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,0))
-    assert uncouple(JzKetCoupled(2,2,1,1)) == \
+    assert uncouple(JzKetCoupled(S(3)/2, S(1)/2, (1,S(1)/2))) == \
+        sqrt(3)*TensorProduct(JzKet(1,1),JzKet(S(1)/2,-S(1)/2))/3 + \
+        sqrt(6)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,S(1)/2))/3
+    assert uncouple(JzKetCoupled(S(3)/2, -S(1)/2, (1,S(1)/2))) == \
+        sqrt(6)*TensorProduct(JzKet(1,0),JzKet(S(1)/2,-S(1)/2))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,-1),JzKet(S(1)/2,S(1)/2))/3
+    assert uncouple(JzKetCoupled(S(3)/2, -S(3)/2, (1,S(1)/2))) == \
+        TensorProduct(JzKet(1,-1),JzKet(S(1)/2,-S(1)/2))
+    # j1=1, j2=1
+    assert uncouple(JzKetCoupled(0, 0, (1,1))) == \
+        sqrt(3)*TensorProduct(JzKet(1,1),JzKet(1,-1))/3 - \
+        sqrt(3)*TensorProduct(JzKet(1,0),JzKet(1,0))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,-1),JzKet(1,1))/3
+    assert uncouple(JzKetCoupled(1, 1, (1,1))) == \
+        sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,0))/2 - \
+        sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2
+    assert uncouple(JzKetCoupled(1, 0, (1,1))) == \
+        sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,-1))/2 - \
+        sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,1))/2
+    assert uncouple(JzKetCoupled(1, -1, (1,1))) == \
+        sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,-1))/2 - \
+        sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(2, 2, (1,1))) == \
         TensorProduct(JzKet(1,1),JzKet(1,1))
-    assert uncouple(JzKetCoupled(2,1,1,1)) == \
-        sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,0))/2 + sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2
-    assert uncouple(JzKetCoupled(2,0,1,1)) == \
-        sqrt(6)*TensorProduct(JzKet(1,1),JzKet(1,-1))/6 + sqrt(6)*TensorProduct(JzKet(1,0),JzKet(1,0))/3 + sqrt(6)*TensorProduct(JzKet(1,-1),JzKet(1,1))/6
-    assert uncouple(JzKetCoupled(2,-1,1,1)) == \
-        0.5*sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,-1)) + 0.5*sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,0))
-    assert uncouple(JzKetCoupled(2,-2,1,1)) == \
-        1.0*TensorProduct(JzKet(1,-1),JzKet(1,-1))
+    assert uncouple(JzKetCoupled(2, 1, (1,1))) == \
+        sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,0))/2 + \
+        sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2
+    assert uncouple(JzKetCoupled(2, 0, (1,1))) == \
+        sqrt(6)*TensorProduct(JzKet(1,1),JzKet(1,-1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(1,0),JzKet(1,0))/3 + \
+        sqrt(6)*TensorProduct(JzKet(1,-1),JzKet(1,1))/6
+    assert uncouple(JzKetCoupled(2, -1, (1,1))) == \
+        sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,-1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(2, -2, (1,1))) == \
+        TensorProduct(JzKet(1,-1),JzKet(1,-1))
+    # 3 coupled spaces
+    # Default coupling
+    # j1=1/2, j2=1/2, j3=1/2
+    assert uncouple(JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,S(1)/2,S(1)/2))) == \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))
+    assert uncouple(JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2))/3
+    assert uncouple(JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2))/3
+    assert uncouple(JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,S(1)/2,S(1)/2))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2))
+    # j1=1/2, j2=1/2, j3=1
+    assert uncouple(JzKetCoupled(2, 2, (S(1)/2, S(1)/2, 1))) == \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))
+    assert uncouple(JzKetCoupled(2, 1, (S(1)/2, S(1)/2, 1))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(2, 0, (S(1)/2, S(1)/2, 1))) == \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(2, -1, (S(1)/2, S(1)/2, 1))) == \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/2 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))/2 + \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, -2, (S(1)/2, S(1)/2, 1))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2, S(1)/2, 1))) == \
+        -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2, S(1)/2, 1))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2, S(1)/2, 1))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2, -S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/2 + \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))/2 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))/2
+    # j1=1/2, j2=1, j3=1
+    assert uncouple(JzKetCoupled(S(5)/2, S(5)/2, (S(1)/2, 1, 1))) == \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))
+    assert uncouple(JzKetCoupled(S(5)/2, S(3)/2, (S(1)/2, 1, 1))) == \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/5 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/5 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/5
+    assert uncouple(JzKetCoupled(S(5)/2, S(1)/2, (S(1)/2, 1, 1))) == \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/5 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(S(5)/2, -S(1)/2, (S(1)/2, 1, 1))) == \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/5
+    assert uncouple(JzKetCoupled(S(5)/2, -S(3)/2, (S(1)/2, 1, 1))) == \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/5 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/5
+    assert uncouple(JzKetCoupled(S(5)/2, -S(5)/2, (S(1)/2, 1, 1))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))
+    assert uncouple(JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2, 1, 1))) == \
+        -sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/15 - \
+        2*sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/5
+    assert uncouple(JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2, 1, 1))) == \
+        -4*sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/15 - \
+        2*sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/5
+    assert uncouple(JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2, 1, 1))) == \
+        -sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/5 - \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        2*sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/15 - \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
+        4*sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2, 1, 1))) == \
+        -sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/5 + \
+        2*sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2, 1, 1))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/3 - \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/3 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/6 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2, 1, 1))) == \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/2 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/3
+    # j1=1, j2=1, j3=1
+    assert uncouple(JzKetCoupled(3, 3, (1,1,1))) == \
+        TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1))
+    assert uncouple(JzKetCoupled(3, 2, (1,1,1))) == \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(3, 1, (1,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(3, 0, (1,1,1))) == \
+        sqrt(10)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))/10 + \
+        sqrt(10)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(10)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))/10 + \
+        sqrt(10)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(3, -1, (1,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(3, -2, (1,1,1))) == \
+        sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(3, -3, (1,1,1))) == \
+        TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))
+    assert uncouple(JzKetCoupled(2, 2, (1,1,1))) == \
+        -sqrt(6)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(2, 1, (1,1,1))) == \
+        -sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/6 - \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0))/6 - \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(2, 0, (1,1,1))) == \
+        -TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, -1, (1,1,1))) == \
+        -sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/3 - \
+        sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1))/6 - \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(2, -2, (1,1,1))) == \
+        -sqrt(6)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0))/3 + \
+        sqrt(6)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(1, 1, (1,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/30 + \
+        sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/15 - \
+        sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1))/30 - \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/5
+    assert uncouple(JzKetCoupled(1, 0, (1,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))/10 - \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/10 - \
+        2*sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/10 - \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(1, -1, (1,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/5 - \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1))/30 - \
+        sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/30
+    # Defined j13
+    # j1=1/2, j2=1/2, j3=1, j13=1/2
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )) == \
+        -sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))/3 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))/3
+    # j1=1/2, j2=1, j3=1, j13=1/2
+    assert uncouple(JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+        -sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+        -2*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/3 - \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/3 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/3 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
+        2*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/3
+    # j1=1, j2=1, j3=1, j13=1
+    assert uncouple(JzKetCoupled(2, 2, (1,1,1), jcoupling=((1,3,1),))) == \
+        -sqrt(2)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(2, 1, (1,1,1), jcoupling=((1,3,1),))) == \
+        -TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, 0, (1,1,1), jcoupling=((1,3,1),))) == \
+        -sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))/3 - \
+        sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))/6 - \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(2, -1, (1,1,1), jcoupling=((1,3,1),))) == \
+        -TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/2 + \
+        TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, -2, (1,1,1), jcoupling=((1,3,1),))) == \
+        -sqrt(2)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0))/2 + \
+        sqrt(2)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(1, 1, (1,1,1), jcoupling=((1,3,1),))) == \
+        TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/2 - \
+        TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(1, 0, (1,1,1), jcoupling=((1,3,1),))) == \
+        TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))/2 - \
+        TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(1, -1, (1,1,1), jcoupling=((1,3,1),))) == \
+        -TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/2 - \
+        TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/2 + \
+        TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/2
+    # 4 coupled spaces
+    # j1=1/2, j2=1/2, j3=1, j4=1, default coupling
+    assert uncouple(JzKetCoupled(3, 3, (S(1)/2,S(1)/2,1,1))) == \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))
+    assert uncouple(JzKetCoupled(3, 2, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(3, 1, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(3, 0, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(3, -1, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-1/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(3, -2, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(3, -3, (S(1)/2,S(1)/2,1,1))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))
+    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1))) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))/6 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1))) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/12 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/12 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1))) == \
+        -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/2 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/4 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/4 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1))) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/3 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/12 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/12 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1))) == \
+        -sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/30 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/20 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/20 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/30 - \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/5
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/10 - \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/20 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/20 - \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/5 - \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/20 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/20 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/30 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/30
+    # j1=1/2, j2=1/2, j3=1, j4=1, j12=1, j34=1
+    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/2
+    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/4 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/4 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/2 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/4 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/4
+    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/4 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/4 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/2 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/2 + \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/2 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+        -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/2 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/4 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/4 + \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/4 - \
+        sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/4
+    # j1=1/2, j2=1/2, j3=1, j4=1, j12=1, j34=2
+    assert uncouple(JzKetCoupled(3, 3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))
+    assert uncouple(JzKetCoupled(3, 2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/3
+    assert uncouple(JzKetCoupled(3, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(3, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/5 + \
+        sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/10 + \
+        sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(3, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
+        2*sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/15
+    assert uncouple(JzKetCoupled(3, -2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(3, -3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))
+    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/3 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/6
+    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/3 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/12 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/12 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/12 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/12 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/6 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/3 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/6
+    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/2 + \
+        TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/2 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/2 - \
+        TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/2
+    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/6 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/12 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/12 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/12 - \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/12 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/6 + \
+        sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/6 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/3 - \
+        sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))/3
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/5 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/20 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/30 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/30
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/10 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/10 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/30 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/10 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/10
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/30 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/30 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/20 - \
+        sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/20 + \
+        sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/5
     # Symbolic
-    j,m,j1,j2,m1,m2 = symbols('j m j1 j2 m1 m2')
-    assert uncouple(JzKetCoupled(j,m,j1,j2)) == \
-        Sum(CG(j1,m1,j2,m2,j,m) * TensorProduct(JzKet(j1,m1), JzKet(j2,m2)), (m1, -j1, j1), (m2, -j2, j2))
+    j,m,j1,j2,j3,j4,m1,m2,m3,m4 = symbols('j m j1:5 m1:5')
+    j13,j24 = symbols('j13 j24')
+    assert uncouple(JzKetCoupled(j, m, (j1,j2) )) == \
+        Sum(CG(j1,m1,j2,m2,j,m) * \
+            TensorProduct(JzKet(j1,m1), JzKet(j2,m2)), \
+            (m1, -j1, j1), (m2, -j2, j2))
+    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3) )) == \
+        Sum(CG(j1,m1,j2,m2,j1+j2,m1+m2) * CG(j1+j2,m1+m2,j3,m3,j,m) * \
+            TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3)), \
+            (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3))
+    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3), jcoupling=((1,3,j13),) )) == \
+        Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j13,m1+m3,j2,m2,j,m) * \
+            TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3)), \
+            (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3))
+    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3,j4) )) == \
+        Sum(CG(j1,m1,j2,m2,j1+j2,m1+m2) * CG(j1+j2,m1+m2,j3,m3,j1+j2+j3,m1+m2+m3) * CG(j1+j2+j3,m1+m2+m3,j4,m4,j,m) * \
+            TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), \
+            (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3), (m4,-j4,j4))
+    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3,j4), jcoupling=((1,3,j13),(2,4,j24)) )) ==  \
+        Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j2,m2,j4,m4,j24,m2+m4) * CG(j24,m2+m4,j13,m1+m3,j,m) * \
+            TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), \
+            (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3), (m4,-j4,j4))
 
 def test_couple():
     # Numerical
+    # 2 coupled spaces
+    # j1=1/2, j2=1/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        JzKetCoupled(1,1,S(1)/2,S(1)/2)
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2))
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2))) == \
-        sqrt(2)*JzKetCoupled(0,0,S(1)/2,S(1)/2)/2 + sqrt(2)*JzKetCoupled(1,0,S(1)/2,S(1)/2)/2
+        sqrt(2)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2))/2 + sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2))/2
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(2)*JzKetCoupled(0,0,S(1)/2,S(1)/2)/2 + sqrt(2)*JzKetCoupled(1,0,S(1)/2,S(1)/2)/2
+        -sqrt(2)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2))/2 + sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2))/2
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2))) == \
-        1.0*JzKetCoupled(1,-1,S(1)/2,S(1)/2)
+        JzKetCoupled(1, -1, (S(1)/2,S(1)/2))
+    # j1=1, j2=1/2
     assert couple(TensorProduct(JzKet(1,1), JzKet(S(1)/2,S(1)/2))) == \
-        JzKetCoupled(S(3)/2,S(3)/2,1,S(1)/2)
+        JzKetCoupled(S(3)/2, S(3)/2, (1,S(1)/2))
     assert couple(TensorProduct(JzKet(1,1), JzKet(S(1)/2,-S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2,1,S(1)/2)/3 + sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2,1,S(1)/2)/3
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (1,S(1)/2))/3 + sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (1,S(1)/2))/3
     assert couple(TensorProduct(JzKet(1,0), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(3)*JzKetCoupled(S(1)/2,S(1)/2,1,S(1)/2)/3 + sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2,1,S(1)/2)/3
+        -sqrt(3)*JzKetCoupled(S(1)/2, S(1)/2, (1,S(1)/2))/3 + sqrt(6)*JzKetCoupled(S(3)/2, S(1)/2, (1,S(1)/2))/3
     assert couple(TensorProduct(JzKet(1,0), JzKet(S(1)/2,-S(1)/2))) == \
-        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2,1,S(1)/2)/3 + sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2,1,S(1)/2)/3
+        sqrt(3)*JzKetCoupled(S(1)/2, -S(1)/2, (1,S(1)/2))/3 + sqrt(6)*JzKetCoupled(S(3)/2, -S(1)/2, (1,S(1)/2))/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2,1,S(1)/2)/3 + sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2,1,S(1)/2)/3
+        -sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (1,S(1)/2))/3 + sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (1,S(1)/2))/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(S(1)/2,-S(1)/2))) == \
-        1.0*JzKetCoupled(S(3)/2,-S(3)/2,1,S(1)/2)
+        JzKetCoupled(S(3)/2, -S(3)/2, (1,S(1)/2))
+    # j1=1, j2=1
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(2,2,1,1)
+        JzKetCoupled(2, 2, (1,1))
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0))) == \
-        sqrt(2)*JzKetCoupled(1,1,1,1)/2 + sqrt(2)*JzKetCoupled(2,1,1,1)/2
+        sqrt(2)*JzKetCoupled(1, 1, (1,1))/2 + sqrt(2)*JzKetCoupled(2, 1, (1,1))/2
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(0,0,1,1)/3 + sqrt(2)*JzKetCoupled(1,0,1,1)/2 + sqrt(6)*JzKetCoupled(2,0,1,1)/6
+        sqrt(3)*JzKetCoupled(0, 0, (1,1))/3 + sqrt(2)*JzKetCoupled(1, 0, (1,1))/2 + sqrt(6)*JzKetCoupled(2, 0, (1,1))/6
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(2)*JzKetCoupled(1,1,1,1)/2 + sqrt(2)*JzKetCoupled(2,1,1,1)/2
+        -sqrt(2)*JzKetCoupled(1, 1, (1,1))/2 + sqrt(2)*JzKetCoupled(2, 1, (1,1))/2
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(3)*JzKetCoupled(0,0,1,1)/3+sqrt(6)*JzKetCoupled(2,0,1,1)/3
+        -sqrt(3)*JzKetCoupled(0, 0, (1,1))/3+sqrt(6)*JzKetCoupled(2, 0, (1,1))/3
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1))) == \
-        0.5*sqrt(2)*JzKetCoupled(1,-1,1,1) + 0.5*sqrt(2)*JzKetCoupled(2,-1,1,1)
+        sqrt(2)*JzKetCoupled(1, -1, (1,1))/2 + sqrt(2)*JzKetCoupled(2, -1, (1,1))/2
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(0,0,1,1)/3 - sqrt(2)*JzKetCoupled(1,0,1,1)/2 + sqrt(6)*JzKetCoupled(2,0,1,1)/6
+        sqrt(3)*JzKetCoupled(0, 0, (1,1))/3 - sqrt(2)*JzKetCoupled(1, 0, (1,1))/2 + sqrt(6)*JzKetCoupled(2, 0, (1,1))/6
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0))) == \
-        -0.5*sqrt(2)*JzKetCoupled(1,-1,1,1) + 0.5*sqrt(2)*JzKetCoupled(2,-1,1,1)
+        -sqrt(2)*JzKetCoupled(1, -1, (1,1))/2 + sqrt(2)*JzKetCoupled(2, -1, (1,1))/2
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1))) == \
-        1.0*JzKetCoupled(2,-2,1,1)
-    # Numerical
-    j, j1, m1, j2, m2 = symbols('j j1 m1 j2 m2')
+        JzKetCoupled(2, -2, (1,1))
+    # j1=3/2, j2=1/2
+    assert couple(TensorProduct(JzKet(S(3)/2,S(3)/2), JzKet(S(1)/2,S(1)/2))) == \
+        JzKetCoupled(2,2,(S(3)/2,S(1)/2))
+    assert couple(TensorProduct(JzKet(S(3)/2,S(3)/2), JzKet(S(1)/2,-S(1)/2))) == \
+        sqrt(3)*JzKetCoupled(1,1,(S(3)/2,S(1)/2))/2 + JzKetCoupled(2,1,(S(3)/2,S(1)/2))/2
+    assert couple(TensorProduct(JzKet(S(3)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -JzKetCoupled(1,1,(S(3)/2,S(1)/2))/2 + sqrt(3)*JzKetCoupled(2,1,(S(3)/2,S(1)/2))/2
+    assert couple(TensorProduct(JzKet(S(3)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2))) == \
+        sqrt(2)*JzKetCoupled(1,0,(S(3)/2,S(1)/2))/2 + sqrt(2)*JzKetCoupled(2,0,(S(3)/2,S(1)/2))/2
+    assert couple(TensorProduct(JzKet(S(3)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(2)*JzKetCoupled(1,0,(S(3)/2,S(1)/2))/2 + sqrt(2)*JzKetCoupled(2,0,(S(3)/2,S(1)/2))/2
+    assert couple(TensorProduct(JzKet(S(3)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2))) == \
+        JzKetCoupled(1,-1,(S(3)/2,S(1)/2))/2 + sqrt(3)*JzKetCoupled(2,-1,(S(3)/2,S(1)/2))/2
+    assert couple(TensorProduct(JzKet(S(3)/2,-S(3)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(3)*JzKetCoupled(1,-1,(S(3)/2,S(1)/2))/2 + JzKetCoupled(2,-1,(S(3)/2,S(1)/2))/2
+    assert couple(TensorProduct(JzKet(S(3)/2,-S(3)/2), JzKet(S(1)/2,-S(1)/2))) == \
+        JzKetCoupled(2,-2,(S(3)/2,S(1)/2))
+    # 3 coupled spaces
+    # Default coupling
+    # j1=1/2,j2=1/2,j3=1/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )
+    # j1=S(1)/2, j2=S(1)/2, j3=1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
+        JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
+        sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(2)*JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3 + \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
+        sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 - \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6 + \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
+        sqrt(3)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
+        JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
+        -sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 - \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6 - \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
+        sqrt(3)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
+        -sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
+        JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3 - \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(2)*JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))) == \
+        JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )
+    # j1=S(1)/2, j2=1, j3=1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))) == \
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))) == \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))) == \
+        -2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 - \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1))) == \
+        -2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0))) == \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1))) == \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )
+    #  j1=1, j2=1, j3=1
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
+        JzKetCoupled(3,3, (1,1,1), jcoupling=((1,2,2),) )
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,2,2),) )/3
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/5 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,2,2),) )/3
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
+        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/10 + \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,0),) )/3 - \
+        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/30 + \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
+        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/30 + \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,2,2),) )/3
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
+        -JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/10 - \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
+        -2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,0),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/15 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/5
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
+        -2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
+        -JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/10 + \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,2,2),) )/3
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
+        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/30 - \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,0),) )/3 - \
+        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/30 - \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
+        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/10 - \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,2,2),) )/3
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/5 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,2,2),) )/3
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
+        JzKetCoupled(3,-3, (1,1,1), jcoupling=((1,2,2),) )
+    # j1=S(1)/2, j2=S(1)/2, j3=S(3)/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 + \
+        2*sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 - \
+        2*sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )
+    # Couple j1 to j3
+    # j1=1/2, j2=1/2, j3=1/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
+        JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
+        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )
+    # j1=1/2, j2=1/2, j3=1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,3),) ) == \
+        JzKetCoupled(2,2, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,3),) ) == \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )
+    # j 1=1/2, j 2=1, j 3=1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
+        -2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 - \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
+        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
+        -2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )
+    # j1=1, 1, 1
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
+        JzKetCoupled(3,3, (1,1,1), jcoupling=((1,3,2),) )
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,3,2),) )/3
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,0),) )/3 - \
+        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/30 + \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,3,2),) )/3
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
+        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/10 + \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/5 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
+        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/30 + \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,3,2),) )/3
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
+        -JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/10 - \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
+        -2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,0),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/15 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
+        -JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/10 + \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
+        -2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,3,2),) )/3
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
+        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/30 - \
+        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/5 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
+        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/10 - \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,3,2),) )/3
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,0),) )/3 - \
+        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/30 - \
+        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,3,2),) )/3
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
+        JzKetCoupled(3,-3, (1,1,1), jcoupling=((1,3,2),) )
+    # j1=1/2, j2=1/2, j3=3/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
+        JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
+        2*sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
+        3*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
+        -sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
+        3*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
+        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
+        -JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )
+    # Couple 4 spaces
+    # Default coupling
+    # j1=1/2, j2=1/2, j3=1/2, j4=1/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
+        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+    # j1=S(1)/2, S(1)/2, S(1)/2, 1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) );
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 + \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
+        2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
+        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
+        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
+        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
+        2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 - \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
+        -sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
+        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+    # j1=1/2, j2=1/2, j3=1, j4=1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))) == \
+        JzKetCoupled(3,3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
+        sqrt(3)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(2)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))) == \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))) == \
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))) == \
+        -JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 + \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1))) == \
+        -JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 + \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 + \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 - \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))) == \
+        -JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 + \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 + \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 - \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))) == \
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1))) == \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 - \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0))) == \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 - \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1))) == \
+        JzKetCoupled(3,-3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )
+    # j1=S(1)/2, 1, 1, 1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
+        JzKetCoupled(S(7)/2,S(7)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/3 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
+        3*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
+        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
+        -2*sqrt(15)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
+        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
+        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
+        -2*sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        6*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
+        2*sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        8*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        4*sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        4*sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
+        4*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
+        2*sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
+        8*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/90 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/30 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/5 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/90 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/30 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
+        2*sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
+        8*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
+        2*sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
+        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        4*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
+        4*sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
+        4*sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        8*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        6*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
+        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 - \
+        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/5 - \
+        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
+        -sqrt(3)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/2 - \
+        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 - \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
+        3*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(15)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/3 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
+        JzKetCoupled(S(7)/2,-S(7)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )
+    # j1=1, 1, 1, 1
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
+        JzKetCoupled(4,4, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
+        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7 + \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
+        2*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/5 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
+        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        2*sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
+        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
+        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
+        2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
+        2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
+        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
+        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        2*sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/5 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
+        -2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        2*sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35 + \
+        2*sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/5 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        2*sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
+        -2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 + \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 - \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
+        sqrt(2)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
+        sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
+        sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
+        2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
+        2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 - \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
+        -sqrt(2)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
+        sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
+        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        2*sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/5 - \
+        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
+        -sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/5 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
+        2*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
+        -sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7 - \
+        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
+        -sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
+        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+    assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
+        JzKetCoupled(4,-4, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )
+    # j1=1/2, j2=1/2, j3=1/2, j4=3/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        JzKetCoupled(3,3, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(2)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(2)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        3*sqrt(5)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 - \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
+        -JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        3*sqrt(5)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(2)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
+        JzKetCoupled(3,-3, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+    # j1=S(1)/2, S(1)/2, 1, S(3)/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
+        JzKetCoupled(S(7)/2,S(7)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
+        2*sqrt(7)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        4*sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(42)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(3)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(5)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        3*sqrt(105)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
+        sqrt(105)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
+        sqrt(105)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
+        -JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(21)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
+        sqrt(210)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 + \
+        sqrt(210)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(21)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
+        -JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(21)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
+        -JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 + \
+        sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
+        sqrt(210)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
+        -sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 + \
+        sqrt(210)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 - \
+        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(21)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
+        sqrt(105)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
+        sqrt(105)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
+        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
+        sqrt(5)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        3*sqrt(105)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
+        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
+        -sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
+        sqrt(42)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
+        -sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
+        sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
+        4*sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
+        -2*sqrt(7)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
+        JzKetCoupled(S(7)/2,-S(7)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )
+    # Couple j1 to j2, j3 to j4
+    # j1=1/2, j2=1/2, j3=1/2, j4=1/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/3 + \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/3 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 - \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 - \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )
+    # j1=S(1)/2, S(1)/2, S(1)/2, 1
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
+        2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
+        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+    assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )
+    # Symbolic
+    j1,j2,j3,j4,m1,m2,m3,m4,j,m = symbols('j1:5 m1:5 j m')
+    j12,j123,j13,j134,j34 = symbols('j12 j123 j13 j134 j34')
     assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2))) == \
-        Sum(CG(j1,m1,j2,m2,j,m1+m2) * JzKetCoupled(j,m1+m2), (j,0,j1+j2))
+        Sum(CG(j1,m1,j2,m2,j,m1+m2) * JzKetCoupled(j, m1+m2, (j1,j2)), (j,m1+m2,j1+j2))
+    #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3))) == \
+    #    Sum(CG(j1,m1,j2,m2,j12,m1+m2) * CG(j12,m1+m2,j3,m3,j,m1+m2+m3) * \
+    #        JzKetCoupled(j, m1+m2+m3, (j1,j2,j3)), \
+    #        (j12, m1 + m2, j1 + j2), (j, m1 + m2 + m3, j12 + j3))
+    assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3)), ((1,3),) ) == \
+        Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j13,m1+m3,j2,m2,j,m1+m2+m3) * \
+            JzKetCoupled(j, m1+m2+m3, (j1,j2,j3), jcoupling=((1,3,j13),) ), \
+            (j13, m1+m3, j1+j3), (j, m1+m2+m3, j13+j2))
+    #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4))) == \
+    #    Sum(CG(j1,m1,j2,m2,j12,m1+m2) * CG(j12,m1+m2,j3,m3,j123,m1+m2+m3) * CG(j123,m1+m2+m3,j4,m4,j,m) * \
+    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4)), \
+    #        (j12, m1+m2, j1+j2), (j123, m1+m2+m3, j1+j2+j3), (j, m1+m2+m3+m4, j123+j4))
+    #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), ((1,2),(3,4)) ) == \
+    #    Sum(CG(j1,m1,j2,m2,j12,m1+m2) * CG(j3,m3,j4,m4,j34,m3+m4) * CG(j12,m1+m2,j34,m3+m4,j,m) * \
+    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4), jcoupling=((1,2,j12),(3,4,j34)) ), \
+    #        (j12, m1+m2, j1+j2), (j34, m4+m4, j3+j4), (j, m1+m2+m3+m4, j12+j34))
+    #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), ((1,3),(1,4)) ) == \
+    #    Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j13,m1+m3,j4,m4,j134,m1+m3+m4) * CG(j134,m1+m3+m4,j2,m2,j,m) * \
+    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4), jcoupling=((1,3,j13),(1,4,j134)) ), \
+    #        (j13, m1+m3, j1+j3), (j134, m1+m3+m4, j1+j3+j4), (j, m1+m2+m3+m4, j134+j2))
 
 def test_innerproduct():
     j,m = symbols("j m")
@@ -939,6 +4393,40 @@ def test_jz():
     assert qapply(TensorProduct(1,Jz)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == -hbar*TensorProduct(JzKet(1,1),JzKet(1,-1))
     # Symbolic
     j1,j2,m1,m2,mi = symbols('j1 j2 m1 m2 mi')
+    assert qapply(TensorProduct(Jx,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+        hbar*m1*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))
+    assert qapply(TensorProduct(1,Jx)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+        hbar*m2*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))
+    #assert qapply(TensorProduct(Jx,1)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+    #    TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,0,pi/2) * JxKet(j1,mi), (mi,-j1,j1)),JyKet(j2,m2))
+    #assert qapply(TensorProduct(1,Jx)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+    #    TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,0,pi/2) * JxKet(j2,mi), (mi,-j2,j2)))
+    assert qapply(TensorProduct(Jx,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        hbar*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + hbar*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2
+    assert qapply(TensorProduct(1,Jx)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        hbar*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + hbar*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
+    #assert qapply(TensorProduct(Jy,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+    #    TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,0,0) * JyKet(j1,mi), (mi,-j1,j1)), JxKet(j2,m2))
+    #assert qapply(TensorProduct(1,Jy)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+    #    TensorProduct(JxKet(j1,m1), Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,0,0) * JyKet(j2,mi), (mi,-j2,j2)))
+    assert qapply(TensorProduct(Jy,1)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+        hbar*m1*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))
+    assert qapply(TensorProduct(1,Jy)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+        hbar*m2*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))
+    assert qapply(TensorProduct(Jy,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        -hbar*I*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + hbar*I*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2
+    assert qapply(TensorProduct(1,Jy)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        -hbar*I*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + hbar*I*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
+    #assert qapply(TensorProduct(Jz,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+    #    TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,pi/2,0)*JzKet(j1,mi), (mi,-j1,j1)),JxKet(j2,m2))
+    #assert qapply(TensorProduct(1,Jz)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+    #    TensorProduct(JxKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,pi/2,0)*JzKet(j2,mi), (mi,-j2,j2)))
+    #assert qapply(TensorProduct(Jz,1)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+    #    TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,-pi/2,pi/2)*JzKet(j1,mi), (mi,-j1,j1)),JyKet(j2,m2))
+    #assert qapply(TensorProduct(1,Jz)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+    #    TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,-pi/2,pi/2)*JzKet(j2,mi), (mi,-j2,j2)))
+    assert qapply(TensorProduct(Jz,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        hbar*m1*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))
     assert qapply(TensorProduct(1,Jz)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
         hbar*m2*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))
 

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -677,69 +677,69 @@ def test_uncouple():
         sqrt(15)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/30
     # Defined j13
     # j1=1/2, j2=1/2, j3=1, j13=1/2
-    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )) == \
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )) == \
         -sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))/3 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/3
-    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )) == \
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )) == \
         -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))/3 - \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))/6 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/6 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))/3
-    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )) == \
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )) == \
         -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))/3 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))/3
     # j1=1/2, j2=1, j3=1, j13=1/2
-    assert uncouple(JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+    assert uncouple(JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,1,1), ((1,3,S(1)/2),))) == \
         -sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/3 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/3
-    assert uncouple(JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+    assert uncouple(JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),))) == \
         -2*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/3 - \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/3 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/3
-    assert uncouple(JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+    assert uncouple(JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),))) == \
         -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/3 - \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
         2*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/3
-    assert uncouple(JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),))) == \
+    assert uncouple(JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,1,1), ((1,3,S(1)/2),))) == \
         -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/3
     # j1=1, j2=1, j3=1, j13=1
-    assert uncouple(JzKetCoupled(2, 2, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(2, 2, (1,1,1), ((1,3,1),))) == \
         -sqrt(2)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1))/2 + \
         sqrt(2)*TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0))/2
-    assert uncouple(JzKetCoupled(2, 1, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(2, 1, (1,1,1), ((1,3,1),))) == \
         -TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/2 - \
         TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/2 + \
         TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/2 + \
         TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(2, 0, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(2, 0, (1,1,1), ((1,3,1),))) == \
         -sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))/3 - \
         sqrt(3)*TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))/6 - \
         sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/6 + \
         sqrt(3)*TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/6 + \
         sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))/6 + \
         sqrt(3)*TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))/3
-    assert uncouple(JzKetCoupled(2, -1, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(2, -1, (1,1,1), ((1,3,1),))) == \
         -TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/2 - \
         TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/2 + \
         TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/2 + \
         TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(2, -2, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(2, -2, (1,1,1), ((1,3,1),))) == \
         -sqrt(2)*TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0))/2 + \
         sqrt(2)*TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(1, 1, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(1, 1, (1,1,1), ((1,3,1),))) == \
         TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))/2 - \
         TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))/2 + \
         TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))/2 - \
         TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(1, 0, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(1, 0, (1,1,1), ((1,3,1),))) == \
         TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))/2 - \
         TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))/2 - \
         TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))/2 + \
         TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))/2
-    assert uncouple(JzKetCoupled(1, -1, (1,1,1), jcoupling=((1,3,1),))) == \
+    assert uncouple(JzKetCoupled(1, -1, (1,1,1), ((1,3,1),))) == \
         -TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))/2 + \
         TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))/2 - \
         TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))/2 + \
@@ -854,17 +854,17 @@ def test_uncouple():
         sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/30 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/30
     # j1=1/2, j2=1/2, j3=1, j4=1, j12=1, j34=1
-    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/2 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/2
-    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/4 - \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/4 - \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/2 + \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/6 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/6 - \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/6 + \
@@ -873,29 +873,29 @@ def test_uncouple():
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/6 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/6
-    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/2 + \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/2 - \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/4 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/4 - \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/4 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/4
-    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/2 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/4 - \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/4 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/4 + \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/2 - \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/2 + \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/2 + \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/2 - \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,1)))) == \
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,1)))) == \
         -TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/2 + \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/2 + \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/4 - \
@@ -903,14 +903,14 @@ def test_uncouple():
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/4 - \
         sqrt(2)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/4
     # j1=1/2, j2=1/2, j3=1, j4=1, j12=1, j34=2
-    assert uncouple(JzKetCoupled(3, 3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, 3, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))
-    assert uncouple(JzKetCoupled(3, 2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, 2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))/6 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/6 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/3 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/3
-    assert uncouple(JzKetCoupled(3, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, 1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/15 + \
         sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/15 + \
         sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/15 + \
@@ -919,7 +919,7 @@ def test_uncouple():
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
         2*sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/15
-    assert uncouple(JzKetCoupled(3, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, 0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/10 + \
         sqrt(10)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/10 + \
         sqrt(5)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/10 + \
@@ -930,7 +930,7 @@ def test_uncouple():
         sqrt(5)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/10 + \
         sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/10 + \
         sqrt(10)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/10
-    assert uncouple(JzKetCoupled(3, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, -1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/15 + \
         2*sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/15 + \
@@ -939,19 +939,19 @@ def test_uncouple():
         sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/15 + \
         sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/15 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/15
-    assert uncouple(JzKetCoupled(3, -2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, -2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/3 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/3 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/6 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))/6
-    assert uncouple(JzKetCoupled(3, -3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(3, -3, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))
-    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))/3 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/3 - \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/6 - \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/6
-    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/3 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/12 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/12 + \
@@ -960,12 +960,12 @@ def test_uncouple():
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/6 - \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/3 - \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/6
-    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/2 + \
         TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/2 - \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/2 - \
         TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/2
-    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/6 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/3 + \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/6 - \
@@ -974,12 +974,12 @@ def test_uncouple():
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/12 - \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/12 - \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/3
-    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,0))/6 + \
         sqrt(6)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,-1))/6 - \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))/3 - \
         sqrt(3)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,-1))/3
-    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,1))/5 - \
         sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))/20 - \
         sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))/20 - \
@@ -988,7 +988,7 @@ def test_uncouple():
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/30 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))/30
-    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,1))/10 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,0))/10 - \
         sqrt(30)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))/30 - \
@@ -999,7 +999,7 @@ def test_uncouple():
         sqrt(30)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/30 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))/10 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))/10
-    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(3,4,2)))) == \
+    assert uncouple(JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(3,4,2)))) == \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1), JzKet(1,1))/30 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0), JzKet(1,0))/15 + \
         sqrt(15)*TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1), JzKet(1,-1))/30 - \
@@ -1019,7 +1019,7 @@ def test_uncouple():
         Sum(CG(j1,m1,j2,m2,j1+j2,m1+m2) * CG(j1+j2,m1+m2,j3,m3,j,m) * \
             TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3)), \
             (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3))
-    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3), jcoupling=((1,3,j13),) )) == \
+    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3), ((1,3,j13),) )) == \
         Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j13,m1+m3,j2,m2,j,m) * \
             TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3)), \
             (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3))
@@ -1027,7 +1027,7 @@ def test_uncouple():
         Sum(CG(j1,m1,j2,m2,j1+j2,m1+m2) * CG(j1+j2,m1+m2,j3,m3,j1+j2+j3,m1+m2+m3) * CG(j1+j2+j3,m1+m2+m3,j4,m4,j,m) * \
             TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), \
             (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3), (m4,-j4,j4))
-    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3,j4), jcoupling=((1,3,j13),(2,4,j24)) )) ==  \
+    assert uncouple(JzKetCoupled(j, m, (j1,j2,j3,j4), ((1,3,j13),(2,4,j24)) )) ==  \
         Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j2,m2,j4,m4,j24,m2+m4) * CG(j24,m2+m4,j13,m1+m3,j,m) * \
             TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), \
             (m1,-j1,j1), (m2,-j2,j2), (m3,-j3,j3), (m4,-j4,j4))
@@ -1097,2858 +1097,2858 @@ def test_couple():
     # Default coupling
     # j1=1/2,j2=1/2,j3=1/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )
+        JzKetCoupled(S(3)/2, S(3)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 - \
-        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+        sqrt(2)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 + \
-        sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+        sqrt(2)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 - \
-        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+        -sqrt(2)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),) )/2 + \
-        sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+        -sqrt(2)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )/3
+        -sqrt(6)*JzKetCoupled(S(1)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2, -S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),) )
+        JzKetCoupled(S(3)/2, -S(3)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,2,1),) )
     # j1=S(1)/2, j2=S(1)/2, j3=1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
-        JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )
+        JzKetCoupled(2, 2, (S(1)/2,S(1)/2,1), ((1,2,1),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
-        sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(2)*JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+        sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        sqrt(2)*JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3 + \
-        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(6)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6
+        sqrt(3)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/3 + \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
-        sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 - \
-        JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+        sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), ((1,2,0),) )/2 - \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6 + \
-        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
-        sqrt(3)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3
+        -sqrt(6)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/6 + \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), ((1,2,0),) )/2 + \
+        sqrt(3)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
-        JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+        sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), ((1,2,0),) )/2 + \
+        JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
-        -sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 - \
-        JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+        -sqrt(2)*JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), ((1,2,0),) )/2 - \
+        JzKetCoupled(1, 1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        JzKetCoupled(2, 1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6 - \
-        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
-        sqrt(3)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3
+        -sqrt(6)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/6 - \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), ((1,2,0),) )/2 + \
+        sqrt(3)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
-        -sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,0),) )/2 + \
-        JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+        -sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), ((1,2,0),) )/2 + \
+        JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/3 - \
-        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(6)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/6
+        sqrt(3)*JzKetCoupled(0, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/3 - \
+        sqrt(2)*JzKetCoupled(1, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2, 0, (S(1)/2,S(1)/2,1), ((1,2,1),) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(2)*JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )/2
+        -sqrt(2)*JzKetCoupled(1, -1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2 + \
+        sqrt(2)*JzKetCoupled(2, -1, (S(1)/2,S(1)/2,1), ((1,2,1),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,-S(1)/2), JzKet(S(1)/2,-S(1)/2), JzKet(1,-1))) == \
-        JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1), jcoupling=((1,2,1),) )
+        JzKetCoupled(2, -2, (S(1)/2,S(1)/2,1), ((1,2,1),) )
     # j1=S(1)/2, j2=1, j3=1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/2 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))) == \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))) == \
-        -2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+        -2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 + \
-        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/3 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 - \
-        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/3 - \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1))) == \
-        -2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+        -2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0))) == \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/3 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(1)/2),) )/3 + \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(1)/2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/2 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )/5
+        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1))) == \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1), jcoupling=((1,2,S(3)/2),) )
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1), ((1,2,S(3)/2),) )
     #  j1=1, j2=1, j3=1
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(3,3, (1,1,1), jcoupling=((1,2,2),) )
+        JzKetCoupled(3,3, (1,1,1), ((1,2,2),) )
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,2),) )/3 + \
-        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,2,2),) )/3
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), ((1,2,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), ((1,2,2),) )/3
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/5 + \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
-        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,2,2),) )/5 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,2,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,2,2),) )/3
+        sqrt(2)*JzKetCoupled(2,2, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), ((1,2,2),) )/3
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
-        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/10 + \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+        JzKetCoupled(1,1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,2,2),) )/10 + \
+        JzKetCoupled(2,1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
-        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 + \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,2,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,2,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), ((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/10
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,0),) )/3 - \
-        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/30 + \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), ((1,2,0),) )/3 - \
+        JzKetCoupled(1,1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,2,2),) )/30 + \
+        JzKetCoupled(2,1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
-        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,0),) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/15 + \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/3 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,2,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), ((1,2,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,2,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/10
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
-        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
-        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/30 + \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), ((1,2,0),) )/3 + \
+        JzKetCoupled(1,-1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,2,2),) )/30 + \
+        JzKetCoupled(2,-1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,2,2),) )/3
+        -sqrt(2)*JzKetCoupled(2,2, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), ((1,2,2),) )/3
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
-        -JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/10 - \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+        -JzKetCoupled(1,1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,2,2),) )/10 - \
+        JzKetCoupled(2,1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 - \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,2,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,2,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), ((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/10
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/15 - \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+        -sqrt(3)*JzKetCoupled(1,1, (1,1,1), ((1,2,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,2,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,2,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
-        -2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,0),) )/3 - \
-        2*sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/15 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/5
+        -2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), ((1,2,0),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/15 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/5
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
-        -2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/15 + \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+        -2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), ((1,2,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,2,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,2,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 + \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,2,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,2,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), ((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/10
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
-        -JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/10 + \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+        -JzKetCoupled(1,-1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,2,2),) )/10 + \
+        JzKetCoupled(2,-1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,2,2),) )/3
+        sqrt(2)*JzKetCoupled(2,-2, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), ((1,2,2),) )/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,0),) )/3 + \
-        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,2,2),) )/30 - \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,2,2),) )/15
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), ((1,2,0),) )/3 + \
+        JzKetCoupled(1,1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,2,2),) )/30 - \
+        JzKetCoupled(2,1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
-        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,0),) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/15 - \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/3 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,2,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), ((1,2,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,2,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/10
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
-        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,0),) )/3 - \
-        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/30 - \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), ((1,2,0),) )/3 - \
+        JzKetCoupled(1,-1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,2,2),) )/30 - \
+        JzKetCoupled(2,-1, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,2,1),) )/6 + \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,2,2),) )/10 - \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,1),) )/6 - \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,2,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,2,2),) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,2,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,2,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,2,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), ((1,2,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,2,2),) )/10
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
-        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/10 - \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+        JzKetCoupled(1,-1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,2,2),) )/10 - \
+        JzKetCoupled(2,-1, (1,1,1), ((1,2,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,2,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,1),) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,2,2),) )/3
+        -sqrt(2)*JzKetCoupled(2,-2, (1,1,1), ((1,2,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), ((1,2,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), ((1,2,2),) )/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,2,2),) )/5 - \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,2,2),) )/3 + \
-        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,2,2),) )/15
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,2,2),) )/5 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,2,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,2,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,2,2),) )/3 + \
-        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,2,2),) )/3
+        -sqrt(6)*JzKetCoupled(2,-2, (1,1,1), ((1,2,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), ((1,2,2),) )/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
-        JzKetCoupled(3,-3, (1,1,1), jcoupling=((1,2,2),) )
+        JzKetCoupled(3,-3, (1,1,1), ((1,2,2),) )
     # j1=S(1)/2, j2=S(1)/2, j3=S(3)/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 + \
-        2*sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/15 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/6 + \
+        2*sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/2 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+        sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),) )/2 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,0),) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/2 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/6 - \
-        2*sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/15 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/10
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/6 - \
+        2*sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )/5
+        -sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),) )
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,2,1),) )
     # Couple j1 to j3
     # j1=1/2, j2=1/2, j3=1/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
-        JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )
+        JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 - \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 + \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 - \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,0),) )/2 - \
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,0),) )/2 + \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )/3
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,0),) )/2 + \
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,3),) ) == \
-        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,3,1),) )
+        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2), ((1,3,1),) )
     # j1=1/2, j2=1/2, j3=1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,3),) ) == \
-        JzKetCoupled(2,2, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )
+        JzKetCoupled(2,2, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 + \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/6 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 - \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/6 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/3
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/6 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/6 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/3 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )/2
+        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,3),) ) == \
-        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1), jcoupling=((1,3,S(3)/2),) )
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1), ((1,3,S(3)/2),) )
     # j 1=1/2, j 2=1, j 3=1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
-        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
-        -2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+        -2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 + \
-        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/3 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/2 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/2 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 - \
-        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/3 - \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/3 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/3 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
-        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
-        -2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/10
+        -2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(1)/2),) )/3 + \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )/5
+        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(1)/2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1), jcoupling=((1,3,S(3)/2),) )
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1), ((1,3,S(3)/2),) )
     # j1=1, 1, 1
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
-        JzKetCoupled(3,3, (1,1,1), jcoupling=((1,3,2),) )
+        JzKetCoupled(3,3, (1,1,1), ((1,3,2),) )
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,3,2),) )/3
+        sqrt(2)*JzKetCoupled(2,2, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), ((1,3,2),) )/3
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,0),) )/3 - \
-        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/30 + \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), ((1,3,0),) )/3 - \
+        JzKetCoupled(1,1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,3,2),) )/30 + \
+        JzKetCoupled(2,1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,2),) )/3 + \
-        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,3,2),) )/3
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), ((1,3,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), ((1,3,2),) )/3
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
-        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/10 + \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+        JzKetCoupled(1,1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,3,2),) )/10 + \
+        JzKetCoupled(2,1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
-        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,0),) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/15 + \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/3 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,3,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), ((1,3,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,3,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/5 + \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
-        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,3,2),) )/5 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,3,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 + \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,3,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,3,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), ((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
-        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
-        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/30 + \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), ((1,3,0),) )/3 + \
+        JzKetCoupled(1,-1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,3,2),) )/30 + \
+        JzKetCoupled(2,-1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(6)*JzKetCoupled(2,2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,2, (1,1,1), jcoupling=((1,3,2),) )/3
+        -sqrt(2)*JzKetCoupled(2,2, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (1,1,1), ((1,3,2),) )/3
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/15 - \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+        -sqrt(3)*JzKetCoupled(1,1, (1,1,1), ((1,3,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,3,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,3,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 + \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,3,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,3,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), ((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
-        -JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/10 - \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+        -JzKetCoupled(1,1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,3,2),) )/10 - \
+        JzKetCoupled(2,1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
-        -2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,0),) )/3 - \
-        2*sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/15 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/5
+        -2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), ((1,3,0),) )/3 - \
+        2*sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/15 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
-        -JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/10 + \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+        -JzKetCoupled(1,-1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,3,2),) )/10 + \
+        JzKetCoupled(2,-1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 - \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,3,1),) )/6 - \
+        JzKetCoupled(1,0, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,3,1),) )/6 + \
+        JzKetCoupled(2,0, (1,1,1), ((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
-        -2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/15 + \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+        -2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), ((1,3,0),) )/3 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,3,2),) )/15 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,3,2),) )/3 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,3,2),) )/3
+        sqrt(2)*JzKetCoupled(2,-2, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), ((1,3,2),) )/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(3)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,0),) )/3 + \
-        JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,1, (1,1,1), jcoupling=((1,3,2),) )/30 - \
-        JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (1,1,1), jcoupling=((1,3,2),) )/15
+        sqrt(3)*JzKetCoupled(1,1, (1,1,1), ((1,3,0),) )/3 + \
+        JzKetCoupled(1,1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (1,1,1), ((1,3,2),) )/30 - \
+        JzKetCoupled(2,1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
-        JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/10 - \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/6 - \
-        JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,2),) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,3,1),) )/6 + \
+        JzKetCoupled(1,0, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,3,1),) )/6 - \
+        JzKetCoupled(2,0, (1,1,1), ((1,3,2),) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1)), ((1,3),) ) == \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/5 - \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/3 + \
-        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,3,2),) )/5 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,3,2),) )/3 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(0,0, (1,1,1), jcoupling=((1,3,1),) )/6 + \
-        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,0),) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (1,1,1), jcoupling=((1,3,2),) )/15 - \
-        sqrt(3)*JzKetCoupled(2,0, (1,1,1), jcoupling=((1,3,1),) )/3 + \
-        sqrt(10)*JzKetCoupled(3,0, (1,1,1), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(0,0, (1,1,1), ((1,3,1),) )/6 + \
+        2*sqrt(3)*JzKetCoupled(1,0, (1,1,1), ((1,3,0),) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (1,1,1), ((1,3,2),) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (1,1,1), ((1,3,1),) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (1,1,1), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0)), ((1,3),) ) == \
-        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/10 - \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 - \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+        JzKetCoupled(1,-1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,3,2),) )/10 - \
+        JzKetCoupled(2,-1, (1,1,1), ((1,3,1),) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,3,2),) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,2),) )/3 + \
-        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,3,2),) )/3
+        -sqrt(6)*JzKetCoupled(2,-2, (1,1,1), ((1,3,2),) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), ((1,3,2),) )/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1)), ((1,3),) ) == \
-        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,0),) )/3 - \
-        JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), jcoupling=((1,3,2),) )/30 - \
-        JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), jcoupling=((1,3,2),) )/15
+        2*sqrt(3)*JzKetCoupled(1,-1, (1,1,1), ((1,3,0),) )/3 - \
+        JzKetCoupled(1,-1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (1,1,1), ((1,3,2),) )/30 - \
+        JzKetCoupled(2,-1, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (1,1,1), ((1,3,2),) )/15
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,1),) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), jcoupling=((1,3,2),) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), jcoupling=((1,3,2),) )/3
+        -sqrt(2)*JzKetCoupled(2,-2, (1,1,1), ((1,3,1),) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (1,1,1), ((1,3,2),) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (1,1,1), ((1,3,2),) )/3
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1)), ((1,3),) ) == \
-        JzKetCoupled(3,-3, (1,1,1), jcoupling=((1,3,2),) )
+        JzKetCoupled(3,-3, (1,1,1), ((1,3,2),) )
     # j1=1/2, j2=1/2, j3=3/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
-        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
-        JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+        JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
-        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
-        2*sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+        2*sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
-        3*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 + \
+        3*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
-        -sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+        -sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
-        3*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 - \
+        3*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
-        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2)), ((1,3),) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2)), ((1,3),) ) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/6 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/6 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2)), ((1,3),) ) == \
-        -JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,1),) )/2 + \
-        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/10 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )/5
+        -JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,1),) )/2 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2)), ((1,3),) ) == \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,3,2),) )
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(3)/2), ((1,3,2),) )
     # Couple 4 spaces
     # Default coupling
     # j1=1/2, j2=1/2, j3=1/2, j4=1/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+        JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2))) == \
-        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        -sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2))) == \
-        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(1,3,S(3)/2)) )
     # j1=S(1)/2, S(1)/2, S(1)/2, 1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
-        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) );
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) );
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 + \
-        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/3 + \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
-        2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
-        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
-        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
-        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/3 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1))) == \
-        2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/3 - \
-        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/3 - \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1))) == \
-        -sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0))) == \
-        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1))) == \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(1,3,S(3)/2)) )
     # j1=1/2, j2=1/2, j3=1, j4=1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(3,3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )
+        JzKetCoupled(3,3, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
-        sqrt(3)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3 + \
+        sqrt(3)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
-        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(2)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(3)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+        sqrt(2)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))) == \
-        JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))) == \
-        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))) == \
-        -JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 + \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/3 + \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1))) == \
-        -JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+        -JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 + \
-        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/12 + \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 - \
-        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5
+        -sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 + \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/6 + \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 - \
-        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/12 - \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+        sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1))) == \
-        -JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+        -JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 - \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 + \
-        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/12 + \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 - \
-        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5
+        -sqrt(6)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/6 + \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/6 + \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/12 - \
-        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(30)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/12 - \
+        sqrt(2)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/20 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1))) == \
-        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,0)) )/3 - \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        sqrt(3)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,0)) )/3 - \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
-        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10
+        -sqrt(6)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/6 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/2 + \
+        sqrt(10)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0))) == \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        2*sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        2*sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 - \
-        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
-        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/15
+        sqrt(15)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/5 - \
+        sqrt(3)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 + \
-        sqrt(3)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )/3
+        -sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )/3
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1))) == \
-        JzKetCoupled(3,-3, (S(1)/2,S(1)/2,1,1), jcoupling=((1,2,1),(1,3,2)) )
+        JzKetCoupled(3,-3, (S(1)/2,S(1)/2,1,1), ((1,2,1),(1,3,2)) )
     # j1=S(1)/2, 1, 1, 1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(S(7)/2,S(7)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )
+        JzKetCoupled(S(7)/2,S(7)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/3 + \
-        sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/3 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        sqrt(15)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
-        3*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        3*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
-        4*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
-        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/30 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
-        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
-        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 + \
-        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/10 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
-        -2*sqrt(15)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        -2*sqrt(15)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
-        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/30 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
-        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -2*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        2*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
-        -2*sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        6*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -2*sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        6*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
-        2*sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        8*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 + \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        2*sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        8*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/30 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        4*sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        4*sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
-        4*sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        4*sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
-        4*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        4*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
-        2*sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        2*sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        2*sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
-        8*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
+        8*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/90 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/30 - \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/90 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/30 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
-        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/5 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/5 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/3 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(70)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(70)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        -sqrt(30)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        3*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/90 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/30 + \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/90 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/30 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
-        2*sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
-        8*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        3*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        2*sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
+        8*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/10 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
-        2*sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/18 - \
+        2*sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
-        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
-        4*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        4*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
-        4*sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        4*sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(7)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
-        4*sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        4*sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        2*sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
-        8*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 - \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        2*sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 - \
+        8*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/30 - \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        6*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        6*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
-        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/9 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/45 - \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
-        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 - \
-        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        -2*sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/3 - \
+        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/30 + \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/30 + \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/5 - \
-        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/5 - \
+        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
-        -sqrt(3)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(1)/2),(1,3,S(3)/2)) )/3 + \
-        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        2*sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        -sqrt(3)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(1)/2),(1,3,S(3)/2)) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
-        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/10 - \
-        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        3*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        4*sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/10 - \
+        sqrt(3)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        3*sqrt(7)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/15 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(1)/2)) )/2 - \
-        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/30 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        2*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(1)/2)) )/2 - \
+        2*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/30 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/10 - \
-        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35
+        -sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/10 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/5 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/10 - \
+        4*sqrt(14)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
-        3*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
-        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        3*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        2*sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 - \
+        3*sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        2*sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(15)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
-        2*sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        -sqrt(15)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(3)/2)) )/5 + \
+        2*sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/35 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/3 - \
-        sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/21
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/3 - \
+        sqrt(14)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )/7
+        -sqrt(35)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
-        JzKetCoupled(S(7)/2,-S(7)/2, (S(1)/2,1,1,1), jcoupling=((1,2,S(3)/2),(1,3,S(5)/2)) )
+        JzKetCoupled(S(7)/2,-S(7)/2, (S(1)/2,1,1,1), ((1,2,S(3)/2),(1,3,S(5)/2)) )
     # j1=1, 1, 1, 1
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
-        JzKetCoupled(4,4, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )
+        JzKetCoupled(4,4, (1,1,1,1), ((1,2,2),(1,3,3)) )
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
-        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2 + \
+        JzKetCoupled(4,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7 + \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7 + \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/2 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
-        2*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        2*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
-        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/5 + \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/5 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
-        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        2*sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        2*sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        -sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
-        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
-        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 + \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
-        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        -sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,0),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,0),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
-        2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 + \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,1), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
-        2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        JzKetCoupled(4,3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        -sqrt(6)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        sqrt(3)*JzKetCoupled(3,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
-        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
-        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 - \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
-        -JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        -sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        2*sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        2*sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,0),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        4*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        2*sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/5 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,0),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/35 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/5 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
-        -2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        2*sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35 + \
-        2*sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        -2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        2*sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35 + \
+        2*sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/5 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/35 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/5 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        2*sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        2*sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
-        -2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 + \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 + \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 + \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 - \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
-        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 + \
-        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 + \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 + \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 - \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 + \
-        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/3 - \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 + \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,0), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
-        sqrt(2)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
-        sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        sqrt(2)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,1),(1,3,2)) )/2 + \
+        sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1), JzKet(1,1))) == \
-        sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        JzKetCoupled(3,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(3)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,0),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 + \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/6 - \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(6)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,0),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0), JzKet(1,0))) == \
-        2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/15 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        2*sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/15 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 + \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 + \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/60 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/60 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,1), JzKet(1,-1), JzKet(1,-1))) == \
-        2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,0),(1,3,1)) )/3 - \
-        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/30 + \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        2*sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,0),(1,3,1)) )/3 - \
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,1)) )/30 + \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 - \
-        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(10)*JzKetCoupled(1,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(30)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(3,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1), JzKet(1,0))) == \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/4 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70 - \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/10 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/4 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/70 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/10 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0), JzKet(1,1))) == \
-        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 - \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 - \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 + \
-        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/35
+        sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 + \
+        2*sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(5)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/35
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0), JzKet(1,0))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/20 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/12 - \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/20 + \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/12 - \
-        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/15 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/20 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/12 - \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/20 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/12 - \
+        4*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/15 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        -sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        2*sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 - \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
-        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/30 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 - \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 - \
+        sqrt(30)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1), JzKet(1,0))) == \
-        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/3 - \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
-        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/6 + \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        sqrt(3)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/3 - \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 - \
+        sqrt(6)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,1),(1,3,2)) )/6 + \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,0), JzKet(1,-1), JzKet(1,-1))) == \
-        -sqrt(2)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,1),(1,3,2)) )/2 + \
-        sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        -sqrt(2)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,1),(1,3,2)) )/2 + \
+        sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1), JzKet(1,1))) == \
-        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
-        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 + \
-        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/70
+        -sqrt(30)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(1,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(10)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 + \
+        sqrt(210)*JzKetCoupled(2,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(15)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(3,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(70)*JzKetCoupled(4,0, (1,1,1,1), ((1,2,2),(1,3,3)) )/70
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1), JzKet(1,0))) == \
-        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/10 + \
-        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/10 + \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/6 - \
-        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        2*sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/30 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(30)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,1)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/6 - \
+        2*sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        2*sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/30 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,1), JzKet(1,-1))) == \
-        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,1)) )/5 - \
-        JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/105 - \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(15)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,1)) )/5 - \
+        JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/105 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0), JzKet(1,1))) == \
-        -sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/5 + \
-        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
-        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        -sqrt(10)*JzKetCoupled(1,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/5 + \
+        sqrt(2)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        sqrt(70)*JzKetCoupled(2,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 - \
+        sqrt(10)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(3,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        sqrt(7)*JzKetCoupled(4,-1, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0), JzKet(1,0))) == \
-        2*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/21 - \
-        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 - \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/3 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7
+        2*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/21 - \
+        sqrt(2)*JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 - \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/3 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,0), JzKet(1,-1))) == \
-        -sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,2)) )/3 + \
-        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/6 + \
-        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        -sqrt(6)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,2)) )/3 + \
+        sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/6 + \
+        JzKetCoupled(4,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1), JzKet(1,1))) == \
-        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/7 - \
-        JzKetCoupled(3,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
-        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/14
+        sqrt(35)*JzKetCoupled(2,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/7 - \
+        JzKetCoupled(3,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/2 + \
+        sqrt(7)*JzKetCoupled(4,-2, (1,1,1,1), ((1,2,2),(1,3,3)) )/14
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1), JzKet(1,0))) == \
-        -sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2 + \
-        JzKetCoupled(4,-3, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )/2
+        -sqrt(3)*JzKetCoupled(3,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2 + \
+        JzKetCoupled(4,-3, (1,1,1,1), ((1,2,2),(1,3,3)) )/2
     assert couple(TensorProduct(JzKet(1,-1), JzKet(1,-1), JzKet(1,-1), JzKet(1,-1))) == \
-        JzKetCoupled(4,-4, (1,1,1,1), jcoupling=((1,2,2),(1,3,3)) )
+        JzKetCoupled(4,-4, (1,1,1,1), ((1,2,2),(1,3,3)) )
     # j1=1/2, j2=1/2, j3=1/2, j4=3/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        JzKetCoupled(3,3, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+        JzKetCoupled(3,3, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(2)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(2)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        sqrt(2)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(2)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        3*sqrt(5)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        3*sqrt(5)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
-        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/30 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
-        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 + \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/30 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
-        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 + \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 + \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 + \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/30 + \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
-        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 - \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/30 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
-        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 - \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 + \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 + \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
-        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 - \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 - \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/30 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/12 - \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 - \
-        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/4 + \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/4 + \
-        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/12 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15 - \
+        sqrt(6)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/4 + \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/4 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,0),(1,3,S(1)/2)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,0),(1,3,S(1)/2)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
-        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15
+        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/30 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(3)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(15)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/30 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(15)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/6 - \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/15 - \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/2 + \
-        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(6)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/6 - \
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/15 - \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(1)/2)) )/3 + \
-        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/6
+        -sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(1)/2)) )/3 + \
+        sqrt(6)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(3)/2))) == \
-        -JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        3*sqrt(5)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
-        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10
+        -JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        3*sqrt(5)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 - \
+        JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,0, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/10 - \
-        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/5
+        sqrt(30)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/10 - \
+        sqrt(2)*JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(5)*JzKetCoupled(3,-1, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2 + \
-        sqrt(2)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )/2
+        -sqrt(2)*JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2 + \
+        sqrt(2)*JzKetCoupled(3,-2, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(3)/2,S(-3)/2))) == \
-        JzKetCoupled(3,-3, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), jcoupling=((1,2,1),(1,3,S(3)/2)) )
+        JzKetCoupled(3,-3, (S(1)/2,S(1)/2,S(1)/2,S(3)/2), ((1,2,1),(1,3,S(3)/2)) )
     # j1=S(1)/2, S(1)/2, 1, S(3)/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
-        JzKetCoupled(S(7)/2,S(7)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )
+        JzKetCoupled(S(7)/2,S(7)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
-        2*sqrt(7)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        2*sqrt(7)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        4*sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 + \
+        4*sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(42)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(2)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(42)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(70)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(3)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(3)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(5)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        3*sqrt(105)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(5)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        3*sqrt(105)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
-        sqrt(105)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        -sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 - \
+        sqrt(105)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
-        sqrt(105)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 + \
+        sqrt(105)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
-        -JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(21)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(21)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 - \
-        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 + \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/15 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
-        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/12 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
-        3*sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 + \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
-        sqrt(210)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 - \
+        sqrt(210)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
-        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 + \
-        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 + \
-        sqrt(210)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/6 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 + \
+        sqrt(210)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
-        3*sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 - \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
-        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/12 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/15 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(21)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(21)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
-        -JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(21)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(21)*JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 - \
-        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/15 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
-        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/12 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
-        -JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 + \
-        sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 + \
-        3*sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/2 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/4 + \
+        sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 + \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
-        sqrt(210)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 - \
+        sqrt(210)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
-        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(15)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
-        -sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 - \
-        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/6 - \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/6 + \
-        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/15 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 + \
-        sqrt(210)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        -sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/6 + \
+        sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/15 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 + \
+        sqrt(210)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(42)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/4 - \
-        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
-        3*sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/140 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/4 - \
+        sqrt(10)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 - \
+        3*sqrt(210)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/140 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/12 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/20 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/20 - \
-        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/28 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/12 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/20 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/20 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/28 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/5 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/10 + \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/5 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/10 + \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,0),(1,3,1)) )/2 + \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(21)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,0),(1,3,1)) )/2 + \
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(21)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(3)/2))) == \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
-        sqrt(105)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 - \
+        sqrt(105)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(6)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/6 + \
+        sqrt(30)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 - \
-        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        sqrt(6)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/6 - \
+        sqrt(30)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(105)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1), JzKet(S(3)/2,S(-3)/2))) == \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,0)) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/30 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
-        sqrt(105)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/21
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,0)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/30 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 + \
+        sqrt(105)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/21
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(3)/2))) == \
-        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 - \
-        sqrt(5)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        3*sqrt(105)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 - \
+        sqrt(5)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 - \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        3*sqrt(105)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(70)*JzKetCoupled(S(7)/2,S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(1)/2))) == \
-        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/6 + \
-        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/10 + \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/15 - \
-        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(3)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/6 + \
+        sqrt(15)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/10 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/15 - \
+        sqrt(15)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(35)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(210)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-1)/2))) == \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/5 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
-        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/10 - \
-        sqrt(70)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/70 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/5 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 - \
+        sqrt(30)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/10 - \
+        sqrt(70)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/70 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0), JzKet(S(3)/2,S(-3)/2))) == \
-        -sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,1)) )/2 + \
-        sqrt(42)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/14 + \
-        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -sqrt(2)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,1)) )/2 + \
+        sqrt(42)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/14 + \
+        sqrt(14)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(3)/2))) == \
-        -sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
-        sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35
+        -sqrt(10)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 - \
+        sqrt(210)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(35)*JzKetCoupled(S(7)/2,-S(1)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(1)/2))) == \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/5 - \
-        4*sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/35 + \
-        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/5 - \
+        4*sqrt(35)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/35 + \
+        sqrt(7)*JzKetCoupled(S(7)/2,-S(3)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-1)/2))) == \
-        -2*sqrt(7)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7 + \
-        sqrt(21)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )/7
+        -2*sqrt(7)*JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7 + \
+        sqrt(21)*JzKetCoupled(S(7)/2,-S(5)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )/7
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1), JzKet(S(3)/2,S(-3)/2))) == \
-        JzKetCoupled(S(7)/2,-S(7)/2, (S(1)/2,S(1)/2,1,S(3)/2), jcoupling=((1,2,1),(1,3,2)) )
+        JzKetCoupled(S(7)/2,-S(7)/2, (S(1)/2,S(1)/2,1,S(3)/2), ((1,2,1),(1,3,2)) )
     # Couple j1 to j2, j3 to j4
     # j1=1/2, j2=1/2, j3=1/2, j4=1/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )
+        JzKetCoupled(2,2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
-        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 + \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
-        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 + \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/3 + \
-        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/3 + \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
-        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
-        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        -sqrt(2)*JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 - \
-        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+        -sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 - \
+        JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,0),(3,4,1)) )/2 + \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,0),(3,4,1)) )/2 + \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/3 - \
-        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/6
+        sqrt(3)*JzKetCoupled(0,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/3 - \
+        sqrt(2)*JzKetCoupled(1,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        sqrt(6)*JzKetCoupled(2,0, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/6
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 - \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 - \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,0)) )/2 - \
-        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2 + \
-        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )/2
+        -sqrt(2)*JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,0)) )/2 - \
+        JzKetCoupled(1,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2 + \
+        JzKetCoupled(2,-1, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )/2
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), jcoupling=((1,2,1),(3,4,1)) )
+        JzKetCoupled(2,-2, (S(1)/2,S(1)/2,S(1)/2,S(1)/2), ((1,2,1),(3,4,1)) )
     # j1=S(1)/2, S(1)/2, S(1)/2, 1
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )
+        JzKetCoupled(S(5)/2,S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        sqrt(3)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        2*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(6)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 - \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/2 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/2 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 + \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 + \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/6 + \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 + \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 - \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/3 + \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/2 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 + \
-        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(5)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 + \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/6 + \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 - \
-        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/30 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/6 - \
+        sqrt(6)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/30 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/6 - \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 - \
-        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/3 - \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/6 - \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/3 - \
+        sqrt(3)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/3 - \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,0),(3,4,S(3)/2)) )/2 + \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,0),(3,4,S(3)/2)) )/2 + \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/2 - \
-        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        sqrt(2)*JzKetCoupled(S(1)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/2 - \
+        sqrt(10)*JzKetCoupled(S(3)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/3 + \
-        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/3 + \
+        JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        4*sqrt(5)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        sqrt(6)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        sqrt(30)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(5)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,1)), ((1,2),(3,4)) ) == \
-        2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 + \
-        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/6 - \
-        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/10
+        2*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 + \
+        sqrt(2)*JzKetCoupled(S(1)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/6 - \
+        sqrt(2)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        2*sqrt(10)*JzKetCoupled(S(3)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(1)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/10
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,0)), ((1,2),(3,4)) ) == \
-        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(1)/2)) )/3 - \
-        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/15 + \
-        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )/5
+        -sqrt(3)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(1)/2)) )/3 - \
+        2*sqrt(15)*JzKetCoupled(S(3)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/15 + \
+        sqrt(10)*JzKetCoupled(S(5)/2,-S(3)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )/5
     assert couple(TensorProduct(JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(S(1)/2,S(-1)/2), JzKet(1,-1)), ((1,2),(3,4)) ) == \
-        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), jcoupling=((1,2,1),(3,4,S(3)/2)) )
+        JzKetCoupled(S(5)/2,-S(5)/2, (S(1)/2,S(1)/2,S(1)/2,1), ((1,2,1),(3,4,S(3)/2)) )
     # Symbolic
     j1,j2,j3,j4,m1,m2,m3,m4,j,m = symbols('j1:5 m1:5 j m')
     j12,j123,j13,j134,j34 = symbols('j12 j123 j13 j134 j34')
@@ -3960,7 +3960,7 @@ def test_couple():
     #        (j12, m1 + m2, j1 + j2), (j, m1 + m2 + m3, j12 + j3))
     assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3)), ((1,3),) ) == \
         Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j13,m1+m3,j2,m2,j,m1+m2+m3) * \
-            JzKetCoupled(j, m1+m2+m3, (j1,j2,j3), jcoupling=((1,3,j13),) ), \
+            JzKetCoupled(j, m1+m2+m3, (j1,j2,j3), ((1,3,j13),) ), \
             (j13, m1+m3, j1+j3), (j, m1+m2+m3, j13+j2))
     #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4))) == \
     #    Sum(CG(j1,m1,j2,m2,j12,m1+m2) * CG(j12,m1+m2,j3,m3,j123,m1+m2+m3) * CG(j123,m1+m2+m3,j4,m4,j,m) * \
@@ -3968,11 +3968,11 @@ def test_couple():
     #        (j12, m1+m2, j1+j2), (j123, m1+m2+m3, j1+j2+j3), (j, m1+m2+m3+m4, j123+j4))
     #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), ((1,2),(3,4)) ) == \
     #    Sum(CG(j1,m1,j2,m2,j12,m1+m2) * CG(j3,m3,j4,m4,j34,m3+m4) * CG(j12,m1+m2,j34,m3+m4,j,m) * \
-    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4), jcoupling=((1,2,j12),(3,4,j34)) ), \
+    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4), ((1,2,j12),(3,4,j34)) ), \
     #        (j12, m1+m2, j1+j2), (j34, m4+m4, j3+j4), (j, m1+m2+m3+m4, j12+j34))
     #assert couple(TensorProduct(JzKet(j1,m1), JzKet(j2,m2), JzKet(j3,m3), JzKet(j4,m4)), ((1,3),(1,4)) ) == \
     #    Sum(CG(j1,m1,j3,m3,j13,m1+m3) * CG(j13,m1+m3,j4,m4,j134,m1+m3+m4) * CG(j134,m1+m3+m4,j2,m2,j,m) * \
-    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4), jcoupling=((1,3,j13),(1,4,j134)) ), \
+    #        JzKetCoupled(j, m1+m2+m3+m4, (j1,j2,j3,j4), ((1,3,j13),(1,4,j134)) ), \
     #        (j13, m1+m3, j1+j3), (j134, m1+m3+m4, j1+j3+j4), (j, m1+m2+m3+m4, j134+j2))
 
 def test_innerproduct():

--- a/sympy/physics/wigner.py
+++ b/sympy/physics/wigner.py
@@ -27,7 +27,7 @@ AUTHORS:
 
 Copyright (C) 2008 Jens Rasch <jyr2000@gmail.com>
 """
-from sympy import Integer, pi, sqrt
+from sympy import Integer, pi, sqrt, sympify
 #from sage.rings.complex_number import ComplexNumber
 #from sage.rings.finite_rings.integer_mod import Mod
 
@@ -262,7 +262,7 @@ def clebsch_gordan(j_1, j_2, j_3, m_1, m_2, m_3, prec=None):
 
     - Jens Rasch (2009-03-24): initial version
     """
-    res = (-1) ** int(j_1 - j_2 + m_3) * sqrt(2 * j_3 + 1) * \
+    res = (-1) ** sympify(j_1 - j_2 + m_3) * sqrt(2 * j_3 + 1) * \
         wigner_3j(j_1, j_2, j_3, m_1, m_2, -m_3, prec)
     return res
 


### PR DESCRIPTION
This pull is primarily finishing up the coupled spin states and the coupling/uncoupling between states. In addition to this, this pull includes Wigner6j and Wigner9j symbols (similar in implementation to Wigner3j and CG) and some minor fixes to the test_args for physics classes.

With the coupled states, the primary change in the handling of states is a jcoupling option that allows one to define the order in which states are coupled. I wasn't sure the best way to do this, as for coupling 2 spaces it is not necessary and having to pass an empty list for this case every time seemed bad, but I remember being told not to use default parameter values in `__new__` methods, so this was the best I could come up with.

The couple and uncouple methods are re-done with the ability to handle an arbitrary number of spin spaces, in addition to adding parameters, like jcoupling, to define how the states are coupled in the case a normal state is used to uncouple or a specific coupling is desired for coupling a tensor product state. I try to describe the algorithm I use, but I'll explain it briefly, since it's not very apparent. Basically, it uses the fact for both coupling and uncoupling, there is some maximum value for some quantum number and the actual value it takes, and in the total number of couplings, the value drops from this maximum to the actual value. For example, when coupling a tensor product state, the maximum coupled j is j1+...+jn, but it attains some j<=j1+...jn; uncoupling has a similar case for m values. Then, the heart of the algorithm is this is treated as a n balls in m boxes to distribute the drop from the max value to the actual value, which is a simple combinatorial computation. Each of these cases is then iterated over.

Of note with this is the _huge_ number of coupling and uncoupling tests implemented. I will note I only hand checked these calculations for a few (selectively chosen) cases, however, should any change arise, this will definitely trigger a failure, forcing a closer look. In generating the tests, I did run the script and check that all of the states are normalized, and they all are, which is very promising for how accurate the methods are.

Any feedback would be greatly appreciated.

TODO:
- (DONE) Change CoupledSpinState to use *args
- (DONE) Document jcoupling
- (DONE) Check args w.r.t. jcoupling and Tuples/tuples, test with subs
- (DONE) Change printing j1,2 -> j(1,2)
