### PR TITLE
Relative paths in `doc/src/modules/ntheory.txt`

### DIFF
--- a/doc/src/modules/ntheory.txt
+++ b/doc/src/modules/ntheory.txt
@@ -1,88 +1,90 @@
 Number Theory
 ====================
 
+.. module:: sympy.ntheory
+
 Ntheory Class Reference
 -----------------------
-.. autoclass:: sympy.ntheory.generate.Sieve
+.. autoclass:: generate.Sieve
    :members:
 
 Ntheory Functions Reference
 ---------------------------
 
-.. autofunction:: sympy.ntheory.generate.prime
+.. autofunction:: prime
 
-.. autofunction:: sympy.ntheory.generate.primepi
+.. autofunction:: primepi
 
-.. autofunction:: sympy.ntheory.generate.nextprime
+.. autofunction:: nextprime
 
-.. autofunction:: sympy.ntheory.generate.prevprime
+.. autofunction:: prevprime
 
-.. autofunction:: sympy.ntheory.generate.primerange
+.. autofunction:: primerange
 
-.. autofunction:: sympy.ntheory.generate.randprime
+.. autofunction:: randprime
 
-.. autofunction:: sympy.ntheory.generate.primorial
+.. autofunction:: primorial
 
-.. autofunction:: sympy.ntheory.generate.cycle_length
+.. autofunction:: cycle_length
 
-.. autofunction:: sympy.ntheory.factor_.smoothness
+.. autofunction:: smoothness
 
-.. autofunction:: sympy.ntheory.factor_.smoothness_p
+.. autofunction:: smoothness_p
 
-.. autofunction:: sympy.ntheory.factor_.trailing
+.. autofunction:: trailing
 
-.. autofunction:: sympy.ntheory.factor_.multiplicity
+.. autofunction:: multiplicity
 
-.. autofunction:: sympy.ntheory.factor_.perfect_power
+.. autofunction:: perfect_power
 
-.. autofunction:: sympy.ntheory.factor_.pollard_rho
+.. autofunction:: pollard_rho
 
-.. autofunction:: sympy.ntheory.factor_.pollard_pm1
+.. autofunction:: pollard_pm1
 
-.. autofunction:: sympy.ntheory.factor_.factorint
+.. autofunction:: factorint
 
-.. autofunction:: sympy.ntheory.factor_.primefactors
+.. autofunction:: primefactors
 
-.. autofunction:: sympy.ntheory.factor_.divisors
+.. autofunction:: divisors
 
-.. autofunction:: sympy.ntheory.factor_.divisor_count
+.. autofunction:: divisor_count
 
-.. autofunction:: sympy.ntheory.factor_.totient
+.. autofunction:: totient
 
-.. autofunction:: sympy.ntheory.modular.symmetric_residue
+.. autofunction:: symmetric_residue
 
-.. autofunction:: sympy.ntheory.modular.crt
+.. autofunction:: crt
 
-.. autofunction:: sympy.ntheory.modular.crt1
+.. autofunction:: crt1
 
-.. autofunction:: sympy.ntheory.modular.crt2
+.. autofunction:: crt2
 
-.. autofunction:: sympy.ntheory.modular.solve_congruence
+.. autofunction:: solve_congruence
 
-.. autofunction:: sympy.ntheory.multinomial.binomial_coefficients
+.. autofunction:: binomial_coefficients
 
-.. autofunction:: sympy.ntheory.multinomial.binomial_coefficients_list
+.. autofunction:: binomial_coefficients_list
 
-.. autofunction:: sympy.ntheory.multinomial.multinomial_coefficients
+.. autofunction:: multinomial_coefficients
 
-.. autofunction:: sympy.ntheory.multinomial.multinomial_coefficients_iterator
+.. autofunction:: multinomial_coefficients_iterator
 
-.. autofunction:: sympy.ntheory.partitions_.npartitions
+.. autofunction:: npartitions
 
-.. autofunction:: sympy.ntheory.primetest.mr
+.. autofunction:: mr
 
-.. autofunction:: sympy.ntheory.primetest.isprime
+.. autofunction:: isprime
 
-.. autofunction:: sympy.ntheory.residue_ntheory.int_tested
+.. autofunction:: int_tested
 
-.. autofunction:: sympy.ntheory.residue_ntheory.totient_
+.. autofunction:: totient_
 
-.. autofunction:: sympy.ntheory.residue_ntheory.n_order
+.. autofunction:: n_order
 
-.. autofunction:: sympy.ntheory.residue_ntheory.is_primitive_root
+.. autofunction:: is_primitive_root
 
-.. autofunction:: sympy.ntheory.residue_ntheory.is_quad_residue
+.. autofunction:: is_quad_residue
 
-.. autofunction:: sympy.ntheory.residue_ntheory.legendre_symbol
+.. autofunction:: legendre_symbol
 
-.. autofunction:: sympy.ntheory.residue_ntheory.jacobi_symbol
+.. autofunction:: jacobi_symbol

--- a/doc/src/modules/ntheory.txt
+++ b/doc/src/modules/ntheory.txt
@@ -27,9 +27,9 @@ Ntheory Functions Reference
 
 .. autofunction:: cycle_length
 
-.. autofunction:: smoothness
+.. autofunction:: sympy.ntheory.factor_.smoothness
 
-.. autofunction:: smoothness_p
+.. autofunction:: sympy.ntheory.factor_.smoothness_p
 
 .. autofunction:: trailing
 

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -95,7 +95,7 @@ def sqrt(arg):
     L{root}, L{RootOf}
 
     External links
-    --------------
+    ==============
 
     * http://en.wikipedia.org/wiki/Square_root
     * http://en.wikipedia.org/wiki/Principal_value

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -90,15 +90,15 @@ def sqrt(arg):
     [-sqrt(3), sqrt(3)]
 
 
-    See also
+    See Also
     ========
-       L{root}, L{RootOf}
+    L{root}, L{RootOf}
 
-       External links
-       --------------
+    External links
+    --------------
 
-       * http://en.wikipedia.org/wiki/Square_root
-       * http://en.wikipedia.org/wiki/Principal_value
+    * http://en.wikipedia.org/wiki/Square_root
+    * http://en.wikipedia.org/wiki/Principal_value
     """
     # arg = sympify(arg) is handled by Pow
     return C.Pow(arg, S.Half)
@@ -147,7 +147,7 @@ def root(arg, n):
 
     See Also
     ========
-        L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
+    L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
 
         External Links
         --------------
@@ -179,9 +179,9 @@ def real_root(arg, n=None):
     -2
 
 
-    See also
+    See Also
     ========
-       L{sqrt}, L{RootOf}, L{root}, L{integer_nthroot}
+    L{sqrt}, L{RootOf}, L{root}, L{integer_nthroot}
 
     """
     if n is not None:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -145,9 +145,8 @@ def root(arg, n):
     [-1, 1, -I, I]
 
 
-    See also
+    See Also
     ========
-
         L{sqrt}, L{RootOf}, L{real_root}, L{integer_nthroot}
 
         External Links

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -134,7 +134,7 @@ class sin(TrigonometricFunction):
     L{cos}, L{tan}
 
     External links
-    --------------
+    ==============
 
     U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
     """
@@ -356,7 +356,7 @@ class cos(TrigonometricFunction):
     L{sin}, L{tan}
 
     External links
-    --------------
+    ==============
 
     U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
     """
@@ -568,7 +568,7 @@ class tan(TrigonometricFunction):
     L{sin}, L{tan}
 
     External links
-    --------------
+    ==============
 
     U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
     """

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -129,14 +129,14 @@ class sin(TrigonometricFunction):
         >>> sin(pi/6)
         1/2
 
-    See also
+    See Also
     ========
-       L{cos}, L{tan}
+    L{cos}, L{tan}
 
-       External links
-       --------------
+    External links
+    --------------
 
-         U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
+    U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
     """
 
     nargs = 1
@@ -351,14 +351,14 @@ class cos(TrigonometricFunction):
         >>> cos(2*pi/3)
         -1/2
 
-    See also
+    See Also
     ========
-       L{sin}, L{tan}
+    L{sin}, L{tan}
 
-       External links
-       --------------
+    External links
+    --------------
 
-         U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
+    U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
     """
 
     nargs = 1
@@ -563,14 +563,14 @@ class tan(TrigonometricFunction):
         >>> tan(1).diff(x)
         0
 
-    See also
+    See Also
     ========
-       L{sin}, L{tan}
+    L{sin}, L{tan}
 
-       External links
-       --------------
+    External links
+    --------------
 
-         U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
+    U{Definitions in trigonometry<http://planetmath.org/encyclopedia/DefinitionsInTrigonometry.html>}
     """
 
     nargs = 1

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -159,7 +159,7 @@ class bessely(BesselBase):
 
     See Also
     ========
-    :class:`sympy.functions.special.bessel.besselj`
+    besselj
     """
 
     _a = S.One
@@ -206,7 +206,7 @@ class besseli(BesselBase):
 
     See Also
     ========
-    :class:`sympy.functions.special.bessel.besselj`
+    besselj
 
     """
 
@@ -245,7 +245,7 @@ class besselk(BesselBase):
 
     See Also
     ========
-    :class:`besselj`
+    besselj
 
     """
 
@@ -276,7 +276,7 @@ class hankel1(BesselBase):
 
     See Also
     ========
-    :class:`besselj`
+    besselj
 
     """
 
@@ -308,7 +308,7 @@ class hankel2(BesselBase):
 
     See Also
     ========
-    :class:`besselj`
+    besselj
 
     """
 
@@ -391,7 +391,7 @@ class jn(SphericalBesselBase):
 
     See Also
     ========
-    :class:`besselj`
+    besselj
 
     """
 
@@ -434,7 +434,7 @@ class yn(SphericalBesselBase):
 
     See Also
     ========
-    :class:`besselj`, :class:`bessely`, :class:`jn`
+    besselj, :class:`bessely`, :class:`jn`
 
     """
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -434,7 +434,7 @@ class yn(SphericalBesselBase):
 
     See Also
     ========
-    besselj, :class:`bessely`, :class:`jn`
+    besselj, bessely, jn
 
     """
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -159,7 +159,6 @@ class bessely(BesselBase):
 
     See Also
     ========
-
     :class:`sympy.functions.special.bessel.besselj`
     """
 
@@ -207,7 +206,6 @@ class besseli(BesselBase):
 
     See Also
     ========
-
     :class:`sympy.functions.special.bessel.besselj`
 
     """
@@ -247,7 +245,6 @@ class besselk(BesselBase):
 
     See Also
     ========
-
     :class:`besselj`
 
     """
@@ -279,7 +276,6 @@ class hankel1(BesselBase):
 
     See Also
     ========
-
     :class:`besselj`
 
     """
@@ -312,7 +308,6 @@ class hankel2(BesselBase):
 
     See Also
     ========
-
     :class:`besselj`
 
     """
@@ -396,7 +391,6 @@ class jn(SphericalBesselBase):
 
     See Also
     ========
-
     :class:`besselj`
 
     """
@@ -440,7 +434,6 @@ class yn(SphericalBesselBase):
 
     See Also
     ========
-
     :class:`besselj`, :class:`bessely`, :class:`jn`
 
     """

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -117,9 +117,9 @@ class lowergamma(Function):
 
     See Also
     ========
-    :class:`sympy.functions.special.gamma_functions.gamma`
-    :class:`sympy.functions.special.gamma_functions.uppergamma`
-    :class:`sympy.functions.special.hyper.hyper`
+    gamma
+    uppergamma
+    sympy.functions.special.hyper.hyper
 
     Examples
     ========
@@ -220,9 +220,9 @@ class uppergamma(Function):
 
     See Also
     ========
-    :class:`sympy.functions.special.gamma_functions.gamma`
-    :class:`sympy.functions.special.gamma_functions.lowergamma`
-    :class:`sympy.functions.special.hyper.hyper`.
+    gamma
+    lowergamma
+    sympy.functions.special.hyper.hyper
 
     References
     ==========

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -117,7 +117,6 @@ class lowergamma(Function):
 
     See Also
     ========
-
     :class:`sympy.functions.special.gamma_functions.gamma`
     :class:`sympy.functions.special.gamma_functions.uppergamma`
     :class:`sympy.functions.special.hyper.hyper`
@@ -221,7 +220,6 @@ class uppergamma(Function):
 
     See Also
     ========
-
     :class:`sympy.functions.special.gamma_functions.gamma`
     :class:`sympy.functions.special.gamma_functions.lowergamma`
     :class:`sympy.functions.special.hyper.hyper`.

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -139,7 +139,7 @@ class hyper(TupleParametersBase):
 
     See Also
     ========
-    - :func:`sympy.simplify.hyperexpand`
+    sympy.simplify.hyperexpand
 
     References
     ==========
@@ -370,7 +370,7 @@ class meijerg(TupleParametersBase):
 
     See Also
     ========
-    - :func:`sympy.simplify.hyperexpand`
+    sympy.simplify.hyperexpand
 
     References
     ==========

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -139,7 +139,6 @@ class hyper(TupleParametersBase):
 
     See Also
     ========
-
     - :func:`sympy.simplify.hyperexpand`
 
     References
@@ -371,7 +370,6 @@ class meijerg(TupleParametersBase):
 
     See Also
     ========
-
     - :func:`sympy.simplify.hyperexpand`
 
     References

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -32,6 +32,11 @@ def smoothness(n):
     (13, 16)
     >>> smoothness(2)
     (2, 2)
+
+    See Also
+    ========
+
+    factorint, smoothness_p
     """
 
     if n == 1:
@@ -92,6 +97,11 @@ def smoothness_p(n, m=-1, power=0, visual=None):
     n       str    tuple   tuple
     mul     str    tuple   tuple
     ====== ====== ======= =======
+
+    See Also
+    ========
+
+    factorint, smoothness
     """
     from sympy.utilities import flatten
 
@@ -875,6 +885,11 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     =====================
 
     If ``verbose`` is set to ``True``, detailed progress is printed.
+
+    See Also
+    ========
+
+    smoothness, smoothness_p, divisors
     """
     factordict = {}
     if visual and not isinstance(n, Mul) and not isinstance(n, dict):
@@ -1161,6 +1176,10 @@ def primefactors(n, limit=None, verbose=False):
         >>> primefactors(10000000001, limit=300)
         [101]
 
+    See Also
+    ========
+
+    divisors
     """
     n = int(n)
     s = []
@@ -1213,6 +1232,11 @@ def divisors(n, generator=False):
 
     This is a slightly modified version of Tim Peters referenced at:
     http://stackoverflow.com/questions/1010381/python-factorization
+
+    See Also
+    ========
+
+    primefactors, factorint, divisor_count
     """
 
     n = abs(n)
@@ -1239,6 +1263,11 @@ def divisor_count(n, modulus=1):
     >>> from sympy import divisor_count
     >>> divisor_count(6)
     4
+
+    See Also
+    ========
+
+    factorint, divisors, totient
     """
 
     if not modulus:
@@ -1260,6 +1289,10 @@ def totient(n):
     >>> totient(25)
     20
 
+    See Also
+    ========
+
+    divisor_count
     """
     if n < 1:
         raise ValueError("n must be a positive integer")

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -35,7 +35,6 @@ def smoothness(n):
 
     See Also
     ========
-
     factorint, smoothness_p
     """
 
@@ -86,21 +85,20 @@ def smoothness_p(n, m=-1, power=0, visual=None):
 
     The table of the output logic is:
 
-    ====== ====== ======= =======
-    x                Visual
-    ------ ----------------------
-    Input  True   False   other
-    ====== ====== ======= =======
-    dict    str    tuple   str
-    str     str    tuple   dict
-    tuple   str    tuple   str
-    n       str    tuple   tuple
-    mul     str    tuple   tuple
-    ====== ====== ======= =======
+        _______________________________
+        |      |       visual=        |
+        |input + -----+-------+-------+
+        |      | True | False | other |
+        +------+------+-------+-------+
+        |dict  | str  | tuple | str   |
+        |str   | str  | tuple | dict  |
+        |tuple | str  | tuple | str   |
+        |n     | str  | tuple | tuple |
+        |mul   | str  | tuple | tuple |
+        +------+------+-------+-------+
 
     See Also
     ========
-
     factorint, smoothness
     """
     from sympy.utilities import flatten
@@ -888,7 +886,6 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     See Also
     ========
-
     smoothness, smoothness_p, divisors
     """
     factordict = {}
@@ -1178,7 +1175,6 @@ def primefactors(n, limit=None, verbose=False):
 
     See Also
     ========
-
     divisors
     """
     n = int(n)
@@ -1235,7 +1231,6 @@ def divisors(n, generator=False):
 
     See Also
     ========
-
     primefactors, factorint, divisor_count
     """
 
@@ -1266,7 +1261,6 @@ def divisor_count(n, modulus=1):
 
     See Also
     ========
-
     factorint, divisors, totient
     """
 
@@ -1291,7 +1285,6 @@ def totient(n):
 
     See Also
     ========
-
     divisor_count
     """
     if n < 1:

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -152,6 +152,11 @@ def prime(n):
         29
         >>> prime(1)
         2
+
+        See Also
+        ========
+
+        isprime, primerange, primepi
     """
 
     assert n > 0
@@ -167,6 +172,11 @@ def primepi(n):
         >>> from sympy import primepi
         >>> primepi(25)
         9
+
+        See Also
+        ========
+
+        isprime, primerange, prime
     """
 
     if n < 2:
@@ -185,6 +195,11 @@ def nextprime(n, i=1):
         [(10, 11), (11, 13), (12, 13), (13, 17), (14, 17)]
         >>> nextprime(2, i=2) # the 2nd prime after 2
         5
+
+        See Also
+        ========
+
+        prevprime, primerange
     """
 
     if i > 1:
@@ -231,6 +246,11 @@ def prevprime(n):
         >>> from sympy import prevprime
         >>> [(i, prevprime(i)) for i in range(10, 15)]
         [(10, 7), (11, 7), (12, 11), (13, 11), (14, 13)]
+
+        See Also
+        ========
+
+        nextprime, primerange
     """
 
     n = int(n)
@@ -285,6 +305,11 @@ def primerange(a, b):
         >>> from sympy import primerange
         >>> print [i for i in primerange(1, 30)]
         [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+
+        See Also
+        ========
+
+        nextprime, prevprime, randprime, primorial
     """
     assert a <= b
     a -= 1
@@ -312,6 +337,11 @@ def randprime(a, b):
         13
         >>> isprime(randprime(1, 30))
         True
+
+        See Also
+        ========
+
+        primerange
     """
 
     n = random.randint(a-1, b)
@@ -351,6 +381,11 @@ def primorial(n, nth=True):
     >>> p = list(primerange(10, 20))
     >>> sorted(set(primefactors(Mul(*p) + 1)).difference(set(p)))
     [2, 5, 31, 149]
+
+    See Also
+    ========
+
+    primerange
     """
 
     if n < 1:
@@ -405,7 +440,7 @@ def cycle_length(f, x0, nmax=None, values=False):
     There are 6 repeating values after the first 2.
 
     If a sequence is suspected of being longer than you might wish, ``nmax``
-    can be used to exit early (in which mu will be returned as None):
+    can be used to exit early (and mu will be returned as None):
 
         >>> cycle_length(func, 4, nmax = 4).next()
         (4, None)

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -155,7 +155,6 @@ def prime(n):
 
         See Also
         ========
-
         isprime, primerange, primepi
     """
 
@@ -175,7 +174,6 @@ def primepi(n):
 
         See Also
         ========
-
         isprime, primerange, prime
     """
 
@@ -198,7 +196,6 @@ def nextprime(n, i=1):
 
         See Also
         ========
-
         prevprime, primerange
     """
 
@@ -249,7 +246,6 @@ def prevprime(n):
 
         See Also
         ========
-
         nextprime, primerange
     """
 
@@ -308,7 +304,6 @@ def primerange(a, b):
 
         See Also
         ========
-
         nextprime, prevprime, randprime, primorial
     """
     assert a <= b
@@ -340,7 +335,6 @@ def randprime(a, b):
 
         See Also
         ========
-
         primerange
     """
 
@@ -384,7 +378,6 @@ def primorial(n, nth=True):
 
     See Also
     ========
-
     primerange
     """
 

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -67,6 +67,11 @@ def crt(m, v, symmetric=False, check=True):
     no GCD (an O(n**2) test) and rather than factoring all moduli and seeing
     that there is no factor in common, a check that the result gives the
     indicated residuals is performed -- an O(n) operation.
+
+    See Also
+    ========
+
+    solve_congruence
     """
     if check:
         m = int_tested(*m)
@@ -163,7 +168,10 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
     >>> solve_congruence((2, 3), (5, 6), symmetric=True)
     (-1, 6)
 
-    See also: crt and sympy.polys.galoistools.gf_crt
+    See Also
+    ========
+
+    crt, sympy.polys.galoistools.gf_crt
     """
     def combine(c1, c2):
         """Return the tuple (a, m) which satisfies the requirement

--- a/sympy/ntheory/modular.py
+++ b/sympy/ntheory/modular.py
@@ -70,8 +70,8 @@ def crt(m, v, symmetric=False, check=True):
 
     See Also
     ========
-
     solve_congruence
+    sympy.polys.galoistools.gf_crt : low level crt routine used by this routine
     """
     if check:
         m = int_tested(*m)
@@ -170,8 +170,8 @@ def solve_congruence(*remainder_modulus_pairs, **hint):
 
     See Also
     ========
+    crt : high level routine implementing the Chinese Remainder Theorem
 
-    crt, sympy.polys.galoistools.gf_crt
     """
     def combine(c1, c2):
         """Return the tuple (a, m) which satisfies the requirement

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -9,6 +9,11 @@ def binomial_coefficients(n):
     >>> from sympy.ntheory import binomial_coefficients
     >>> binomial_coefficients(9)
     {(0, 9): 1, (1, 8): 9, (2, 7): 36, (3, 6): 84, (4, 5): 126, (5, 4): 126, (6, 3): 84, (7, 2): 36, (8, 1): 9, (9, 0): 1}
+
+    See Also
+    ========
+
+    binomial_coefficients_list, multinomial_coefficients
     """
     d = {(0, n):1, (n, 0):1}
     a = 1
@@ -26,6 +31,11 @@ def binomial_coefficients_list(n):
     >>> from sympy.ntheory import binomial_coefficients_list
     >>> binomial_coefficients_list(9)
     [1, 9, 36, 84, 126, 126, 84, 36, 9, 1]
+
+    See Also
+    ========
+
+    binomial_coefficients, multinomial_coefficients
     """
     d = [1] * (n+1)
     a = 1
@@ -112,6 +122,10 @@ def multinomial_coefficients(m, n):
     Code contributed to Sage by Yann Laigle-Chapuy, copied with permission
     of the author.
 
+    See Also
+    ========
+
+    binomial_coefficients_list, binomial_coefficients
     """
     if not m:
         if n:

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -12,7 +12,6 @@ def binomial_coefficients(n):
 
     See Also
     ========
-
     binomial_coefficients_list, multinomial_coefficients
     """
     d = {(0, n):1, (n, 0):1}
@@ -34,7 +33,6 @@ def binomial_coefficients_list(n):
 
     See Also
     ========
-
     binomial_coefficients, multinomial_coefficients
     """
     d = [1] * (n+1)
@@ -124,7 +122,6 @@ def multinomial_coefficients(m, n):
 
     See Also
     ========
-
     binomial_coefficients_list, binomial_coefficients
     """
     if not m:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -191,6 +191,11 @@ def isprime(n):
     True
     >>> isprime(15)
     False
+
+    See Also
+    ========
+
+    primerange, primepi, prime
     """
     n = int(n)
     if n < 2:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -194,7 +194,6 @@ def isprime(n):
 
     See Also
     ========
-
     primerange, primepi, prime
     """
     n = int(n)

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -115,6 +115,11 @@ def is_quad_residue(a, p):
     [0, 1, 2, 4]
     >>> [j for j in range(7) if is_quad_residue(j, 7)]
     [0, 1, 2, 4]
+
+    See Also
+    ========
+
+    legendre_symbol, jacobi_symbol
     """
     a, p = int_tested(a, p)
     if p < 1:
@@ -161,6 +166,11 @@ def legendre_symbol(a, p):
     [0, 1, 1, -1, 1, -1, -1]
     >>> list(set([i**2 % 7 for i in range(7)]))
     [0, 1, 2, 4]
+
+    See Also
+    ========
+
+    is_quad_residue, jacobi_symbol
     """
     a, p = int_tested(a, p)
     if not isprime(p) or p == 2:
@@ -203,6 +213,11 @@ def jacobi_symbol(m, n):
         {3: 2, 5: 1}
         >>> jacobi_symbol(7, 45) == L(7, 3)**2 * L(7, 5)**1
         True
+
+    See Also
+    ========
+
+    is_quad_residue, legendre_symbol
     """
     m, n = int_tested(m, n)
     if not n % 2:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -118,7 +118,6 @@ def is_quad_residue(a, p):
 
     See Also
     ========
-
     legendre_symbol, jacobi_symbol
     """
     a, p = int_tested(a, p)
@@ -169,7 +168,6 @@ def legendre_symbol(a, p):
 
     See Also
     ========
-
     is_quad_residue, jacobi_symbol
     """
     a, p = int_tested(a, p)
@@ -216,7 +214,6 @@ def jacobi_symbol(m, n):
 
     See Also
     ========
-
     is_quad_residue, legendre_symbol
     """
     m, n = int_tested(m, n)

--- a/sympy/physics/gaussopt.py
+++ b/sympy/physics/gaussopt.py
@@ -62,7 +62,6 @@ class RayTransferMatrix(Matrix):
 
     See Also
     ========
-
     GeometricRay, BeamParameter,
     FreeSpace, FlatRefraction, CurvedRefraction,
     FlatMirror, CurvedMirror, ThinLens
@@ -271,7 +270,6 @@ class GeometricRay(Matrix):
 
     See Also
     ========
-
     RayTransferMatrix
     """
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -43,7 +43,11 @@ def gf_crt(U, M, K=None):
 
     Note: this is a low-level routine with no error checking.
 
-    See also: crt and solve_congruence in sympy.ntheory.modular.
+    See Also
+    --------
+    sympy.ntheory.modular.crt : a higher level crt routine
+    sympy.ntheory.modular.solve_congruence
+
     """
     p = prod(M, start=K.one)
     v = K.zero

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -44,7 +44,7 @@ def gf_crt(U, M, K=None):
     Note: this is a low-level routine with no error checking.
 
     See Also
-    --------
+    ========
     sympy.ntheory.modular.crt : a higher level crt routine
     sympy.ntheory.modular.solve_congruence
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -50,7 +50,7 @@ class Order(Expr):
     O(x)
 
     External links
-    --------------
+    ==============
 
     U{Big O notation<http://en.wikipedia.org/wiki/Big_O_notation>}
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -49,10 +49,10 @@ class Order(Expr):
     >>> O(x)-O(x)
     O(x)
 
-       External links
-       --------------
+    External links
+    --------------
 
-         U{Big O notation<http://en.wikipedia.org/wiki/Big_O_notation>}
+    U{Big O notation<http://en.wikipedia.org/wiki/Big_O_notation>}
 
     Properties:
     ===========


### PR DESCRIPTION
Change absolute paths in ntheory.txt to relative paths.

This way in See Also section one can reference objects just by their name (objname) instead of the full path (path.to.objname). This makes the section more readable.

Relative paths are already used in matrices.txt, printing.txt,...
