### PR TITLE
factor_terms handles more objects and _make_tuple -> _prep_tuple

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -433,15 +433,19 @@ def factor_terms(expr, radical=False):
     """
 
     expr = sympify(expr)
-
-    if iterable(expr):
-        return type(expr)([factor_terms(i, radical=radical) for i in expr])
+    is_iterable = iterable(expr)
 
     if not isinstance(expr, Basic) or expr.is_Atom:
+        if is_iterable:
+            return type(expr)([factor_terms(i, radical=radical) for i in expr])
         return expr
 
-    if expr.is_Function:
-        return expr.func(*[factor_terms(i, radical=radical) for i in expr.args])
+    if expr.is_Function or is_iterable or not hasattr(expr, 'args_cnc'):
+        args = expr.args
+        newargs = tuple([factor_terms(i, radical=radical) for i in args])
+        if newargs == args:
+            return expr
+        return expr.func(*newargs)
 
     cont, p = expr.as_content_primitive(radical=radical)
     list_args, nc = zip(*[ai.args_cnc(clist=True) for ai in Add.make_args(p)])

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,6 +1,6 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
-from sympy import S, Add, sin, Mul, Symbol, oo, Integral, sqrt
+from sympy import S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, Interval
 from sympy.abc import a, b, t, x, y, z
 from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
                                   gcd_terms, factor_terms)
@@ -114,6 +114,12 @@ def test_factor_terms():
     eq = sqrt(2) + sqrt(10)
     assert factor_terms(eq) == eq
     assert factor_terms(eq, radical=True) == sqrt(2)*(1 + sqrt(5))
+    eq = [x + x*y]
+    ans = [x*(y + 1)]
+    for c in [list, tuple, set]:
+        assert factor_terms(c(eq)) == c(ans)
+    assert factor_terms(Tuple(x + x*y)) == Tuple(x*(y + 1))
+    assert factor_terms(Interval(0, 1)) == Interval(0, 1)
 
 def test_xreplace():
     e = Mul(2, 1 + x, evaluate=False)

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -1,6 +1,7 @@
 """Hypergeometric and Meijer G-functions"""
 
 from sympy import S
+from sympy.core.compatibility import iterable
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.core.containers import Tuple
 from sympy.core.sympify import sympify
@@ -9,25 +10,22 @@ from sympy.core.mul import Mul
 # TODO should __new__ accept **options?
 # TODO should constructors should check if parameters are sensible?
 
-# TODO when pull request #399 is in, this should be no longer necessary
-def _make_tuple(v):
+def _prep_tuple(v):
     """
-    Turn an iterable argument V into a Tuple.
-    Also unpolarify, since both hypergeometric and meijer g-functions are
-    unbranched in their parameters.
+    Turn an iterable argument V into a Tuple and unpolarify, since both
+    hypergeometric and meijer g-functions are unbranched in their parameters.
 
     Examples:
-    >>> from sympy.functions.special.hyper import _make_tuple as mt
-    >>> from sympy.core.containers import Tuple
-    >>> mt([1, 2, 3])
+    >>> from sympy.functions.special.hyper import _prep_tuple
+    >>> _prep_tuple([1, 2, 3])
     (1, 2, 3)
-    >>> mt((4, 5))
+    >>> _prep_tuple((4, 5))
     (4, 5)
-    >>> mt((7, 8, 9))
+    >>> _prep_tuple((7, 8, 9))
     (7, 8, 9)
     """
-    from sympy import unpolarify
-    return Tuple(*[unpolarify(sympify(x)) for x in v])
+    from sympy.simplify.simplify import unpolarify
+    return Tuple(*[unpolarify(x) for x in v])
 
 class TupleParametersBase(Function):
     """ Base class that takes care of differentiation, when some of
@@ -163,7 +161,7 @@ class hyper(TupleParametersBase):
 
     def __new__(cls, ap, bq, z):
         # TODO should we check convergence conditions?
-        return Function.__new__(cls, _make_tuple(ap), _make_tuple(bq), z)
+        return Function.__new__(cls, _prep_tuple(ap), _prep_tuple(bq), z)
 
     def fdiff(self, argindex=3):
         if argindex != 3:
@@ -177,7 +175,7 @@ class hyper(TupleParametersBase):
         from sympy import gamma, hyperexpand
         if len(self.ap) == 2 and len(self.bq) == 1 and self.argument == 1:
             a, b = self.ap
-            c    = self.bq[0]
+            c = self.bq[0]
             return gamma(c)*gamma(c - a - b)/gamma(c - a)/gamma(c - b)
         return hyperexpand(self)
 
@@ -406,7 +404,7 @@ class meijerg(TupleParametersBase):
         def tr(p):
             if len(p) != 2:
                 raise TypeError("wrong argument")
-            return Tuple(_make_tuple(p[0]), _make_tuple(p[1]))
+            return Tuple(_prep_tuple(p[0]), _prep_tuple(p[1]))
 
         # TODO should we check convergence conditions?
         return Function.__new__(cls, tr(args[0]), tr(args[1]), args[2])

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1365,6 +1365,7 @@ def unpolarify(eq, subs={}, exponents_only=False):
     if isinstance(eq, bool):
         return eq
 
+    eq = sympify(eq)
     if subs != {}:
         return unpolarify(eq.subs(subs))
     changed = True

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -943,6 +943,7 @@ def test_unpolarify():
     p = exp_polar(7*I) + 1
     u = exp(7*I) + 1
 
+    assert unpolarify(1) == 1
     assert unpolarify(p) == u
     assert unpolarify(p**2) == u**2
     assert unpolarify(p**x) == p**x


### PR DESCRIPTION
Not all objects presently pass through factor_terms. This pull request make modifications so that more object pass successfully through. Also, _make_tuple was a hack until PR 399 was implemented; and it has been so that code was renamed _prep_tuple since it has been repurposed by the GSOC-2 work.
