### PR TITLE
Doctest Coverage for Integral module

### DIFF
--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -105,10 +105,10 @@ def deltaintegrate(f, x):
 
     Examples
     ========
-        >>> from sympy.functions import DiracDelta, Heaviside
+
         >>> from sympy.abc import x, y, z
         >>> from sympy.integrals.deltafunctions import deltaintegrate
-        >>> from sympy import sin, cos
+        >>> from sympy import sin, cos, DiracDelta, Heaviside
         >>> deltaintegrate(x*sin(x)*cos(x)*DiracDelta(x - 1), x)
         sin(1)*cos(1)*Heaviside(x - 1)
         >>> deltaintegrate(y**2*DiracDelta(x - z)*DiracDelta(y - z), y)

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -103,6 +103,17 @@ def deltaintegrate(f, x):
       2) We didn't have a simple term, but we do have an expression with
          simplified DiracDelta terms, so we integrate this expression.
 
+    Examples
+    ========
+        >>> from sympy.functions import DiracDelta, Heaviside
+        >>> from sympy.abc import x, y, z
+        >>> from sympy.integrals.deltafunctions import deltaintegrate
+        >>> from sympy import sin, cos
+        >>> deltaintegrate(x*sin(x)*cos(x)*DiracDelta(x - 1), x)
+        sin(1)*cos(1)*Heaviside(x - 1)
+        >>> deltaintegrate(y**2*DiracDelta(x - z)*DiracDelta(y - z), y)
+        z**2*DiracDelta(x - z)*Heaviside(y - z)
+
     """
     if not f.has(DiracDelta):
         return None

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -303,9 +303,9 @@ class Integral(Expr):
         ========
 
             >>> from sympy.abc import a, b, c
-            >>> from sympy import Integral
-            >>> Integral(a*b + 2 + c, (c, -1, 1/2)).transform(a, c*2)
-            Integral(a*b + c + 2, (c, -1, 0))
+            >>> from sympy import Integral, S
+            >>> Integral(a*b + 2 + c, (c, -1, S(1)/2)).transform(a, c*2)
+            Integral(a*b + c + 2, (c, -1, 1/2))
             >>> Integral(a**2 + 1, (a, -1, 2)).transform(a, 1+2*a)
             Integral(2*(2*a + 1)**2 + 2, (a, -1, 1/2))
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -171,6 +171,19 @@ class Integral(Expr):
 
         This is a very naive and quick test, not intended to check for special
         patterns like Integral(sin(m*x)*cos(n*x), (x, 0, 2*pi)) == 0.
+
+        Examples
+        ========
+
+            >>> from sympy import Integral
+            >>> from sympy.abc import x, y, z
+            >>> Integral(1, (x, 1, 1)).is_zero
+            True
+            >>> Integral(0, (x, y, z)).is_zero
+            True
+            >>> Integral(1, (x, 1, 2)).is_zero
+            False
+
         """
         if (self.function.is_zero or
             any(len(xab) == 3 and xab[1] == xab[2] for xab in self.limits)):
@@ -285,6 +298,17 @@ class Integral(Expr):
 
         The mapping must be uniquely invertible (e.g. a linear or linear
         fractional transformation).
+
+        Examples
+        ========
+
+            >>> from sympy.abc import a, b, c
+            >>> from sympy import Integral
+            >>> Integral(a*b + 2+c, (c, -1, 1/2)).transform(a, c*2)
+            Integral(a*b + c + 2, (c, -1, 0))
+            >>> Integral(a**2+1, (a, -1, 2)).transform(a, 1+2*a)
+            Integral(2*(2*a + 1)**2 + 2, (a, -1, 1/2))
+
         """
         if x not in self.variables:
             return self
@@ -300,8 +324,10 @@ class Integral(Expr):
         function = function.subs(x, mapping) * mapping.diff(x)
 
         def calc_limit(a, b):
-            """replace x with a, using subs if possible, otherwise limit
-            where sign of b is considered"""
+            """
+            replace x with a, using subs if possible, otherwise limit
+            where sign of b is considered
+            """
             wok = inverse_mapping.subs(x, a)
             if wok is S.NaN or wok.is_bounded is False and a.is_bounded:
                 return limit(sign(b)*inverse_mapping, x, a)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -304,9 +304,9 @@ class Integral(Expr):
 
             >>> from sympy.abc import a, b, c
             >>> from sympy import Integral
-            >>> Integral(a*b + 2+c, (c, -1, 1/2)).transform(a, c*2)
+            >>> Integral(a*b + 2 + c, (c, -1, 1/2)).transform(a, c*2)
             Integral(a*b + c + 2, (c, -1, 0))
-            >>> Integral(a**2+1, (a, -1, 2)).transform(a, 1+2*a)
+            >>> Integral(a**2 + 1, (a, -1, 2)).transform(a, 1+2*a)
             Integral(2*(2*a + 1)**2 + 2, (a, -1, 1/2))
 
         """
@@ -323,7 +323,7 @@ class Integral(Expr):
             mapping, inverse_mapping = inverse_mapping, mapping
         function = function.subs(x, mapping) * mapping.diff(x)
 
-        def calc_limit(a, b):
+        def _calc_limit(a, b):
             """
             replace x with a, using subs if possible, otherwise limit
             where sign of b is considered
@@ -338,7 +338,7 @@ class Integral(Expr):
             sym = xab[0]
             if sym == x and len(xab) == 3:
                 a, b = xab[1:]
-                a, b = calc_limit(a, b), calc_limit(b, a)
+                a, b = _calc_limit(a, b), _calc_limit(b, a)
                 if a == b:
                     raise ValueError("The mapping must transform the "
                         "endpoints into separate points")

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -111,8 +111,8 @@ def ratint_ratpart(f, g, x):
         >>> from sympy.integrals.rationaltools import ratint_ratpart
         >>> from sympy.abc import x, y
         >>> from sympy import Poly
-        >>> ratint_ratpart(Poly(1, x, domain='ZZ'),
-        ... Poly(x + 1, x, domain='ZZ'), x)
+        >>> ratint_ratpart(Poly(1, x, domain = 'ZZ'),
+        ... Poly(x + 1, x, domain = 'ZZ'), x)
         (0, 1/(x + 1))
         >>> ratint_ratpart(Poly(1, x, domain='EX'),
         ... Poly(x**2 + y**2, x, domain='EX'), x)
@@ -245,12 +245,12 @@ def log_to_atan(f, g):
 
         >>> from sympy.integrals.rationaltools import log_to_atan
         >>> from sympy.abc import x
-        >>> from sympy import Poly, sqrt
+        >>> from sympy import Poly, sqrt, S
         >>> log_to_atan(Poly(x, x, domain='ZZ'), Poly(1, x, domain='ZZ'))
         2*atan(x)
-        >>> log_to_atan(Poly(x + 1/2, x, domain='QQ'),
+        >>> log_to_atan(Poly(x + S(1)/2, x, domain='QQ'),
         ... Poly(sqrt(3)/2, x, domain='EX'))
-        2*atan(2*sqrt(3)*x/3)
+        2*atan(2*sqrt(3)*x/3 + sqrt(3)/3)
 
     """
     if f.degree() < g.degree():
@@ -287,10 +287,10 @@ def log_to_real(h, q, x, t):
 
         >>> from sympy.integrals.rationaltools import log_to_real
         >>> from sympy.abc import x, y
-        >>> from sympy import Poly, sqrt
-        >>> log_to_real(Poly(x + 3*y/2 + 1/2, x, domain='QQ[y]'),
+        >>> from sympy import Poly, sqrt, S
+        >>> log_to_real(Poly(x + 3*y/2 + S(1)/2, x, domain='QQ[y]'),
         ... Poly(3*y**2 + 1, y, domain='ZZ'), x, y)
-        2*sqrt(3)*atan(2*sqrt(3)*x/3)/3
+        2*sqrt(3)*atan(2*sqrt(3)*x/3 + sqrt(3)/3)/3
         >>> log_to_real(Poly(x**2 - 1, x, domain='ZZ'),
         ... Poly(-2*y + 1, y, domain='ZZ'), x, y)
         log(x**2 - 1)/2

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -98,11 +98,28 @@ def ratint(f, x, **flags):
     return coeff*result
 
 def ratint_ratpart(f, g, x):
-    """Horowitz-Ostrogradsky algorithm.
+    """
+    Horowitz-Ostrogradsky algorithm.
 
-       Given a field K and polynomials f and g in K[x], such that f and g
-       are coprime and deg(f) < deg(g), returns fractions A and B in K(x),
-       such that f/g = A' + B and B has square-free denominator.
+    Given a field K and polynomials f and g in K[x], such that f and g
+    are coprime and deg(f) < deg(g), returns fractions A and B in K(x),
+    such that f/g = A' + B and B has square-free denominator.
+
+    Examples
+    ========
+
+        >>> from sympy.integrals.rationaltools import ratint_ratpart
+        >>> from sympy.abc import x, y
+        >>> from sympy import Poly
+        >>> ratint_ratpart(Poly(1, x, domain = 'ZZ'),Poly(x + 1, x,
+        ... domain = 'ZZ'),x)
+        (0, 1/(x + 1))
+        >>> ratint_ratpart(Poly(1, x, domain='EX'), Poly(x**2 + y**2, x,
+        ... domain='EX'), x)
+        (0, 1/(x**2 + y**2))
+        >>> ratint_ratpart(Poly(36, x, domain='ZZ'), Poly(x**5 - 2*x**4 -
+        ... 2*x**3 + 4*x**2 + x - 2, x, domain = 'ZZ'), x)
+        ((12*x + 6)/(x**2 - 1), 12/(x**2 - x - 2))
 
     """
     f = Poly(f, x)
@@ -134,17 +151,33 @@ def ratint_ratpart(f, g, x):
     return rat_part, log_part
 
 def ratint_logpart(f, g, x, t=None):
-    """Lazard-Rioboo-Trager algorithm.
+    """
+    Lazard-Rioboo-Trager algorithm.
 
-       Given a field K and polynomials f and g in K[x], such that f and g
-       are coprime, deg(f) < deg(g) and g is square-free, returns a list
-       of tuples (s_i, q_i) of polynomials, for i = 1..n, such that s_i
-       in K[t, x] and q_i in K[t], and:
-                               ___    ___
-                     d  f   d  \  `   \  `
-                     -- - = --  )      )   a log(s_i(a, x))
-                     dx g   dx /__,   /__,
-                              i=1..n a | q_i(a) = 0
+    Given a field K and polynomials f and g in K[x], such that f and g
+    are coprime, deg(f) < deg(g) and g is square-free, returns a list
+    of tuples (s_i, q_i) of polynomials, for i = 1..n, such that s_i
+    in K[t, x] and q_i in K[t], and:
+                           ___    ___
+                 d  f   d  \  `   \  `
+                 -- - = --  )      )   a log(s_i(a, x))
+                 dx g   dx /__,   /__,
+                          i=1..n a | q_i(a) = 0
+
+    Examples
+    ========
+
+        >>> from sympy.integrals.rationaltools import ratint_logpart
+        >>> from sympy.abc import x
+        >>> from sympy import Poly
+        >>> ratint_logpart(Poly(1, x, domain='ZZ'), Poly(x**2 + x + 1, x,
+        ... domain='ZZ'), x)
+        [(Poly(x + 3*_t/2 + 1/2, x, domain='QQ[_t]'), Poly(3*_t**2 + 1, _t,
+        ...domain='ZZ'))]
+        >>> ratint_logpart(Poly(12, x, domain='ZZ'), Poly(x**2 - x - 2, x,
+        ... domain='ZZ'), x)
+        [(Poly(x - 3*_t/8 - 1/2, x, domain='QQ[_t]'), Poly(-_t**2 + 16, _t,
+        ...domain='ZZ'))]
 
     """
     f, g = Poly(f, x), Poly(g, x)
@@ -197,14 +230,27 @@ def ratint_logpart(f, g, x, t=None):
     return H
 
 def log_to_atan(f, g):
-    """Convert complex logarithms to real arctangents.
+    """
+    Convert complex logarithms to real arctangents.
 
-       Given a real field K and polynomials f and g in K[x], with g != 0,
-       returns a sum h of arctangents of polynomials in K[x], such that:
+    Given a real field K and polynomials f and g in K[x], with g != 0,
+    returns a sum h of arctangents of polynomials in K[x], such that:
 
-                       df   d         f + I g
-                       -- = -- I log( ------- )
-                       dx   dx        f - I g
+                   df   d         f + I g
+                   -- = -- I log( ------- )
+                   dx   dx        f - I g
+
+    Examples
+    ========
+
+        >>> from sympy.integrals.rationaltools import log_to_atan
+        >>> from sympy.abc import x
+        >>> from sympy import Poly, sqrt
+        >>> log_to_atan(Poly(x, x, domain='ZZ'), Poly(1, x, domain='ZZ'))
+        2*atan(x)
+        >>> log_to_atan(Poly(x + 1/2, x, domain='QQ'), Poly(sqrt(3)/2, x,
+        ... domain='EX'))
+        2*atan(2*sqrt(3)*x/3)
 
     """
     if f.degree() < g.degree():
@@ -225,15 +271,29 @@ def log_to_atan(f, g):
         return A + log_to_atan(s, t)
 
 def log_to_real(h, q, x, t):
-    """Convert complex logarithms to real functions.
+    """
+    Convert complex logarithms to real functions.
 
-       Given real field K and polynomials h in K[t,x] and q in K[t],
-       returns real function f such that:
-                              ___
-                      df   d  \  `
-                      -- = --  )  a log(h(a, x))
-                      dx   dx /__,
-                             a | q(a) = 0
+    Given real field K and polynomials h in K[t,x] and q in K[t],
+    returns real function f such that:
+                          ___
+                  df   d  \  `
+                  -- = --  )  a log(h(a, x))
+                  dx   dx /__,
+                         a | q(a) = 0
+
+    Examples
+    ========
+
+        >>> from sympy.integrals.rationaltools import log_to_real
+        >>> from sympy.abc import x, y
+        >>> from sympy import Poly, sqrt
+        >>> log_to_real(Poly(x + 3*y/2 + 1/2, x, domain='QQ[y]'), Poly(3*y**2
+        ... + 1, y, domain='ZZ'), x, y)
+        2*sqrt(3)*atan(2*sqrt(3)*x/3)/3
+        >>> log_to_real(Poly(x**2 - 1, x, domain='ZZ'), Poly(-2*y + 1, y,
+        ... domain='ZZ'), x, y)
+        log(x**2 - 1)/2
 
     """
     u, v = symbols('u,v')

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -111,14 +111,14 @@ def ratint_ratpart(f, g, x):
         >>> from sympy.integrals.rationaltools import ratint_ratpart
         >>> from sympy.abc import x, y
         >>> from sympy import Poly
-        >>> ratint_ratpart(Poly(1, x, domain = 'ZZ'),
-        ... Poly(x + 1, x, domain = 'ZZ'), x)
+        >>> ratint_ratpart(Poly(1, x, domain='ZZ'),
+        ... Poly(x + 1, x, domain='ZZ'), x)
         (0, 1/(x + 1))
         >>> ratint_ratpart(Poly(1, x, domain='EX'),
         ... Poly(x**2 + y**2, x, domain='EX'), x)
         (0, 1/(x**2 + y**2))
         >>> ratint_ratpart(Poly(36, x, domain='ZZ'),
-        ... Poly(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2, x, domain = 'ZZ'), x)
+        ... Poly(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2, x, domain='ZZ'), x)
         ((12*x + 6)/(x**2 - 1), 12/(x**2 - x - 2))
 
     """

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -111,14 +111,14 @@ def ratint_ratpart(f, g, x):
         >>> from sympy.integrals.rationaltools import ratint_ratpart
         >>> from sympy.abc import x, y
         >>> from sympy import Poly
-        >>> ratint_ratpart(Poly(1, x, domain = 'ZZ'),Poly(x + 1, x,
-        ... domain = 'ZZ'),x)
+        >>> ratint_ratpart(Poly(1, x, domain='ZZ'),
+        ... Poly(x + 1, x, domain='ZZ'), x)
         (0, 1/(x + 1))
-        >>> ratint_ratpart(Poly(1, x, domain='EX'), Poly(x**2 + y**2, x,
-        ... domain='EX'), x)
+        >>> ratint_ratpart(Poly(1, x, domain='EX'),
+        ... Poly(x**2 + y**2, x, domain='EX'), x)
         (0, 1/(x**2 + y**2))
-        >>> ratint_ratpart(Poly(36, x, domain='ZZ'), Poly(x**5 - 2*x**4 -
-        ... 2*x**3 + 4*x**2 + x - 2, x, domain = 'ZZ'), x)
+        >>> ratint_ratpart(Poly(36, x, domain='ZZ'),
+        ... Poly(x**5 - 2*x**4 - 2*x**3 + 4*x**2 + x - 2, x, domain = 'ZZ'), x)
         ((12*x + 6)/(x**2 - 1), 12/(x**2 - x - 2))
 
     """
@@ -170,14 +170,14 @@ def ratint_logpart(f, g, x, t=None):
         >>> from sympy.integrals.rationaltools import ratint_logpart
         >>> from sympy.abc import x
         >>> from sympy import Poly
-        >>> ratint_logpart(Poly(1, x, domain='ZZ'), Poly(x**2 + x + 1, x,
-        ... domain='ZZ'), x)
-        [(Poly(x + 3*_t/2 + 1/2, x, domain='QQ[_t]'), Poly(3*_t**2 + 1, _t,
-        ...domain='ZZ'))]
-        >>> ratint_logpart(Poly(12, x, domain='ZZ'), Poly(x**2 - x - 2, x,
-        ... domain='ZZ'), x)
-        [(Poly(x - 3*_t/8 - 1/2, x, domain='QQ[_t]'), Poly(-_t**2 + 16, _t,
-        ...domain='ZZ'))]
+        >>> ratint_logpart(Poly(1, x, domain='ZZ'),
+        ... Poly(x**2 + x + 1, x, domain='ZZ'), x)
+        [(Poly(x + 3*_t/2 + 1/2, x, domain='QQ[_t]'),
+        ...Poly(3*_t**2 + 1, _t, domain='ZZ'))]
+        >>> ratint_logpart(Poly(12, x, domain='ZZ'),
+        ... Poly(x**2 - x - 2, x, domain='ZZ'), x)
+        [(Poly(x - 3*_t/8 - 1/2, x, domain='QQ[_t]'),
+        ...Poly(-_t**2 + 16, _t, domain='ZZ'))]
 
     """
     f, g = Poly(f, x), Poly(g, x)
@@ -248,8 +248,8 @@ def log_to_atan(f, g):
         >>> from sympy import Poly, sqrt
         >>> log_to_atan(Poly(x, x, domain='ZZ'), Poly(1, x, domain='ZZ'))
         2*atan(x)
-        >>> log_to_atan(Poly(x + 1/2, x, domain='QQ'), Poly(sqrt(3)/2, x,
-        ... domain='EX'))
+        >>> log_to_atan(Poly(x + 1/2, x, domain='QQ'),
+        ... Poly(sqrt(3)/2, x, domain='EX'))
         2*atan(2*sqrt(3)*x/3)
 
     """
@@ -288,11 +288,11 @@ def log_to_real(h, q, x, t):
         >>> from sympy.integrals.rationaltools import log_to_real
         >>> from sympy.abc import x, y
         >>> from sympy import Poly, sqrt
-        >>> log_to_real(Poly(x + 3*y/2 + 1/2, x, domain='QQ[y]'), Poly(3*y**2
-        ... + 1, y, domain='ZZ'), x, y)
+        >>> log_to_real(Poly(x + 3*y/2 + 1/2, x, domain='QQ[y]'),
+        ... Poly(3*y**2 + 1, y, domain='ZZ'), x, y)
         2*sqrt(3)*atan(2*sqrt(3)*x/3)/3
-        >>> log_to_real(Poly(x**2 - 1, x, domain='ZZ'), Poly(-2*y + 1, y,
-        ... domain='ZZ'), x, y)
+        >>> log_to_real(Poly(x**2 - 1, x, domain='ZZ'),
+        ... Poly(-2*y + 1, y, domain='ZZ'), x, y)
         log(x**2 - 1)/2
 
     """

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -95,7 +95,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
        this algorithm can be made a full decision procedure.
 
        This is an internal integrator procedure. You should use toplevel
-       'integrate' function in most cases,  as this procedure needs some
+       '_integrate' function in most cases,  as this procedure needs some
        preprocessing steps and otherwise may fail.
 
        **Specification**
@@ -239,12 +239,12 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
 
     if mappings is None:
         # Pre-sort mapping in order of largest to smallest expressions (last is always x).
-        def sort_key(arg):
+        def _sort_key(arg):
             return default_sort_key(arg[0].as_independent(x)[1])
-        mapping = sorted(mapping.items(), key=sort_key, reverse=True)
+        mapping = sorted(mapping.items(), key=_sort_key, reverse=True)
         mappings = permutations(mapping)
 
-    def substitute(expr):
+    def _substitute(expr):
         return expr.subs(mapping)
 
     for mapping in mappings:
@@ -254,10 +254,10 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
 
         mapping = list(mapping)
 
-        diffs = [ substitute(cancel(g.diff(x))) for g in terms ]
+        diffs = [ _substitute(cancel(g.diff(x))) for g in terms ]
         denoms = [ g.as_numer_denom()[1] for g in diffs ]
 
-        if all(h.is_polynomial(*V) for h in denoms) and substitute(f).is_rational_function(*V):
+        if all(h.is_polynomial(*V) for h in denoms) and _substitute(f).is_rational_function(*V):
             denom = reduce(lambda p, q: lcm(p, q, *V), denoms)
             break
     else:
@@ -271,39 +271,39 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
 
     numers = [ cancel(denom*g) for g in diffs ]
 
-    def derivation(h):
+    def _derivation(h):
         return Add(*[ d * h.diff(v) for d, v in zip(numers, V) ])
 
-    def deflation(p):
+    def _deflation(p):
         for y in V:
             if not p.has(y):
                 continue
 
-            if derivation(p) is not S.Zero:
+            if _derivation(p) is not S.Zero:
                 c, q = p.as_poly(y).primitive()
-                return deflation(c)*gcd(q, q.diff(y)).as_expr()
+                return _deflation(c)*gcd(q, q.diff(y)).as_expr()
         else:
             return p
 
-    def splitter(p):
+    def _splitter(p):
         for y in V:
             if not p.has(y):
                 continue
 
-            if derivation(y) is not S.Zero:
+            if _derivation(y) is not S.Zero:
                 c, q = p.as_poly(y).primitive()
 
                 q = q.as_expr()
 
-                h = gcd(q, derivation(q), y)
+                h = gcd(q, _derivation(q), y)
                 s = quo(h, gcd(q, q.diff(y), y), y)
 
-                c_split = splitter(c)
+                c_split = _splitter(c)
 
                 if s.as_poly(y).degree() == 0:
                     return (c_split[0], q * c_split[1])
 
-                q_split = splitter(cancel(q / s))
+                q_split = _splitter(cancel(q / s))
 
                 return (c_split[0]*q_split[0]*s, c_split[1]*q_split[1])
         else:
@@ -314,19 +314,19 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
     for term in terms:
         if term.is_Function:
             if term.func is tan:
-                special[1 + substitute(term)**2] = False
+                special[1 + _substitute(term)**2] = False
             elif term.func is tanh:
-                special[1 + substitute(term)] = False
-                special[1 - substitute(term)] = False
+                special[1 + _substitute(term)] = False
+                special[1 - _substitute(term)] = False
             elif term.func is C.LambertW:
-                special[substitute(term)] = True
+                special[_substitute(term)] = True
 
-    F = substitute(f)
+    F = _substitute(f)
 
     P, Q = F.as_numer_denom()
 
-    u_split = splitter(denom)
-    v_split = splitter(Q)
+    u_split = _splitter(denom)
+    v_split = _splitter(Q)
 
     polys = list(v_split) + [ u_split[0] ] + special.keys()
 
@@ -338,9 +338,9 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
 
     a, b, c = [ p.total_degree() for p in polified ]
 
-    poly_denom = (s * v_split[0] * deflation(v_split[1])).as_expr()
+    poly_denom = (s * v_split[0] * _deflation(v_split[1])).as_expr()
 
-    def exponent(g):
+    def _exponent(g):
         if g.is_Pow:
             if g.exp.is_Rational and g.exp.q != 1:
                 if g.exp.p > 0:
@@ -350,11 +350,11 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
             else:
                 return 1
         elif not g.is_Atom:
-            return max([ exponent(h) for h in g.args ])
+            return max([ _exponent(h) for h in g.args ])
         else:
             return 1
 
-    A, B = exponent(f), a + max(b, c)
+    A, B = _exponent(f), a + max(b, c)
 
     if A > 1 and B > 1:
         monoms = monomials(V, A + B - 1)
@@ -381,7 +381,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
             else:
                 reducibles.add(factorization)
 
-    def integrate(field=None):
+    def _integrate(field=None):
         irreducibles = set()
 
         for poly in reducibles:
@@ -405,7 +405,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
 
         candidate = poly_part/poly_denom + Add(*log_part)
 
-        h = F - derivation(candidate) / denom
+        h = F - _derivation(candidate) / denom
 
         numer = h.as_numer_denom()[0].expand(force=True)
 
@@ -423,12 +423,12 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
             return None
 
     if not (F.atoms(Symbol) - set(V)):
-        result = integrate('Q')
+        result = _integrate('Q')
 
         if result is None:
-            result = integrate()
+            result = _integrate()
     else:
-        result = integrate()
+        result = _integrate()
 
     if result is not None:
         (solution, candidate, coeffs) = result

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -107,10 +107,10 @@ def trigintegrate(f, x):
                 # C   = (1-S )  = sum(i, (-) * B(k,i) * S  )
                 if m > 0 :
                     for i in range(0,m/2+1):
-                        res += (-1)**i * binomial(m/2,i) * sin_pow_integrate(n+2*i, x)
+                        res += (-1)**i * binomial(m/2,i) * _sin_pow_integrate(n+2*i, x)
 
                 elif m == 0:
-                    res=sin_pow_integrate(n,x)
+                    res=_sin_pow_integrate(n,x)
                 else:
                     # m < 0 , |n| > |m|
                     #  /                                                           /
@@ -140,7 +140,7 @@ def trigintegrate(f, x):
                     #       n                                        2
                     #    sin (x) term is expanded here interms of cos (x), and then integrated.
                     for i in range(0,n/2+1):
-                        res += (-1)**i * binomial(n/2,i) * cos_pow_integrate(m+2*i, x)
+                        res += (-1)**i * binomial(n/2,i) * _cos_pow_integrate(m+2*i, x)
 
                 elif n == 0 :
                     ##  /
@@ -150,7 +150,7 @@ def trigintegrate(f, x):
                     #  |    m
                     #  | cos (x)
                     # /
-                    res= cos_pow_integrate(m,x)
+                    res= _cos_pow_integrate(m,x)
                 else:
                     # n < 0 , |m| > |n|
                     #  /                                                         /
@@ -176,7 +176,7 @@ def trigintegrate(f, x):
                         res=Rational(-1,m+1)*cos(x)**(m+1)*sin(x)**(n-1) + Rational(n-1,m+1)*sympy.integrals.integrate(cos(x)**(m+2)*sin(x)**(n-2),x)
             return res.subs(x, a*x) / a
 
-def sin_pow_integrate(n,x):
+def _sin_pow_integrate(n,x):
     if n > 0 :
         if n == 1:
             #Recursion break
@@ -193,7 +193,7 @@ def sin_pow_integrate(n,x):
         #
         #
 
-        return Rational(-1,n)*cos(x)*sin(x)**(n-1)+Rational(n-1,n)*sin_pow_integrate(n-2,x)
+        return Rational(-1,n)*cos(x)*sin(x)**(n-1)+Rational(n-1,n)*_sin_pow_integrate(n-2,x)
 
     if n < 0:
         if n == -1:
@@ -211,14 +211,14 @@ def sin_pow_integrate(n,x):
         #/                                                 /
         #
         #
-        return Rational(1,n+1)*cos(x)*sin(x)**(n+1) + Rational(n+2,n+1) * sin_pow_integrate(n+2,x)
+        return Rational(1,n+1)*cos(x)*sin(x)**(n+1) + Rational(n+2,n+1) * _sin_pow_integrate(n+2,x)
 
     else:
         #n == 0
         #Recursion break.
         return x
 
-def cos_pow_integrate(n,x):
+def _cos_pow_integrate(n,x):
     if n > 0 :
         if n==1:
             #Recursion break.
@@ -235,7 +235,7 @@ def cos_pow_integrate(n,x):
         #
         #
 
-        return Rational(1,n)*sin(x)*cos(x)**(n-1)+Rational(n-1,n)*cos_pow_integrate(n-2,x)
+        return Rational(1,n)*sin(x)*cos(x)**(n-1)+Rational(n-1,n)*_cos_pow_integrate(n-2,x)
 
     if n < 0:
         if n == -1:
@@ -254,7 +254,7 @@ def cos_pow_integrate(n,x):
         #
 
 
-        return Rational(-1,n+1)*sin(x)*cos(x)**(n+1) + Rational(n+2,n+1) * cos_pow_integrate(n+2,x)
+        return Rational(-1,n+1)*sin(x)*cos(x)**(n+1) + Rational(n+2,n+1) * _cos_pow_integrate(n+2,x)
     else :
         # n == 0
         #Recursion Break.


### PR DESCRIPTION
Doctest Coverage for Integral module

Improved the Doctest Coverage for Integral module. Several functions which are defined within other functions are not covered with doctests.

The functions not covered are:
integrals\integrals.py calc_limit(a, h)
integrals\risch.py sort_key(arg)
integrals\risch.py substitute(expr)
integrals\risch.py derivation(h)
integrals\risch.py deflation(p)
integrals\risch.py splitter(p)
integrals\risch.py exponent(g)
integrals\risch.py integrate(field=None)

GCI Task:http://www.google-melange.com/gci/task/view/google/gci2011/7237316
