### PR TITLE
Add `module` directive in `ntheory.txt` for every file (submodule).

### DIFF
--- a/doc/src/modules/ntheory.txt
+++ b/doc/src/modules/ntheory.txt
@@ -1,11 +1,11 @@
 Number Theory
 ====================
 
-.. module:: sympy.ntheory
+.. module:: sympy.ntheory.generate
 
 Ntheory Class Reference
 -----------------------
-.. autoclass:: sympy.ntheory.generate.Sieve
+.. autoclass:: Sieve
    :members:
 
 Ntheory Functions Reference
@@ -27,9 +27,11 @@ Ntheory Functions Reference
 
 .. autofunction:: cycle_length
 
-.. autofunction:: sympy.ntheory.factor_.smoothness
+.. module:: sympy.ntheory.factor_
 
-.. autofunction:: sympy.ntheory.factor_.smoothness_p
+.. autofunction:: smoothness
+
+.. autofunction:: smoothness_p
 
 .. autofunction:: trailing
 
@@ -51,6 +53,8 @@ Ntheory Functions Reference
 
 .. autofunction:: totient
 
+.. module:: sympy.ntheory.modular
+
 .. autofunction:: symmetric_residue
 
 .. autofunction:: crt
@@ -61,6 +65,8 @@ Ntheory Functions Reference
 
 .. autofunction:: solve_congruence
 
+.. module:: sympy.ntheory.multinomial
+
 .. autofunction:: binomial_coefficients
 
 .. autofunction:: binomial_coefficients_list
@@ -69,11 +75,17 @@ Ntheory Functions Reference
 
 .. autofunction:: multinomial_coefficients_iterator
 
+.. module:: sympy.ntheory.partitions_
+
 .. autofunction:: npartitions
+
+.. module:: sympy.ntheory.primetest
 
 .. autofunction:: mr
 
 .. autofunction:: isprime
+
+.. module:: sympy.ntheory.residue_ntheory
 
 .. autofunction:: int_tested
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -155,7 +155,7 @@ def prime(n):
 
         See Also
         ========
-        isprime, primerange, primepi
+        sympy.ntheory.primetest.isprime, primerange, primepi
     """
 
     assert n > 0
@@ -174,7 +174,7 @@ def primepi(n):
 
         See Also
         ========
-        isprime, primerange, prime
+        sympy.ntheory.primetest.isprime, primerange, prime
     """
 
     if n < 2:

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -194,7 +194,9 @@ def isprime(n):
 
     See Also
     ========
-    primerange, primepi, prime
+    sympy.ntheory.generate.primerange
+    sympy.ntheory.generate.primepi
+    sympy.ntheory.generate.prime
     """
     n = int(n)
     if n < 2:

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -19,8 +19,8 @@ def int_tested(*j):
     return i
 
 def totient_(n):
-    """Returns the number of integers less than n
-    and relatively prime to n
+    """Returns the number of integers less than n and relatively prime to n.
+
     Examples
     ========
     >>> from sympy.ntheory import totient_
@@ -28,6 +28,7 @@ def totient_(n):
     2
     >>> totient_(67)
     66
+
     """
     n = int_tested(n)
     if n < 1:


### PR DESCRIPTION
This fixes problems (in ntheory module) introduced in PR 863. Now Source link is
displayed in html documentation and all the relevant objects are shown in the
html documentation (none are accidentally left out).

I still have to apply the same fixes in the `functions` module, which was also affected by the PR 863, but first I want to see, if this is ok.
