### PR TITLE
mind commutativity in optimized Add.flatten

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -60,7 +60,9 @@ class Add(AssocOp):
                 elif b.is_Mul:
                     rv = [a, b], [], None
             if rv:
-                return rv
+                if all(s.is_commutative for s in rv[0]):
+                    return rv
+                return [], rv[0], None
 
         terms = {}      # term -> coeff
                         # e.g. x**2 -> 5   for ... + 5*x**2 + ...

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1219,3 +1219,10 @@ def test_Mod():
     assert x % 5 == Mod(x, 5)
     assert x % y == Mod(x, y)
     assert (x % y).subs({x: 5, y: 3}) == 2
+
+def test_issue_2902():
+    A = Symbol("A", commutative=False)
+    eq = A + A**2
+    # it doesn't matter whether it's True or False; they should
+    # just both be the same
+    assert eq.is_commutative == (eq + 1).is_commutative


### PR DESCRIPTION
When Adds contain non-commutative terms the flattened sequence  should be returned in position 1, not 0, as is done at the end of the full routine:

``` python

        # we are done
        if noncommutative:
            return [], newseq, None
        else:
            return newseq, [], None

```
