### PR TITLE
Fixing pyflakes errors from sympy.utilities (GCI)

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -805,7 +805,6 @@ class Add(AssocOp):
                     for q in r:
                         r[q] = prod(r[q])
                 # find the gcd of bases for each q
-                n = len(rads)
                 G = []
                 for q in common_q:
                     g = reduce(igcd, [r[q] for r in rads], 0)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -5,7 +5,6 @@ from sympy.core.numbers import Rational
 from sympy.core.operations import LatticeOp, ShortCircuit
 from sympy.core.function import Application, Lambda
 from sympy.core.expr import Expr
-from sympy.core.mul import Mul
 from sympy.core.singleton import Singleton
 from sympy.core.rules import Transform
 from sympy.ntheory.residue_ntheory import int_tested

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,5 +1,5 @@
 from sympy.core.function import Function, C
-from sympy.core import sympify, S, Integer
+from sympy.core import S, Integer
 from sympy.core.mul import prod
 
 ###############################################################################

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -5,8 +5,6 @@ Generating and counting primes.
 import random
 from bisect import bisect
 from primetest import isprime
-from sympy.core.numbers import integer_nthroot
-
 
 # Using arrays for sieving instead of lists greatly reduces
 # memory consumption

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -218,10 +218,8 @@ def multinomial_coefficients_iterator(m, n, _tuple=tuple):
             if tj > 1:
                 t[j + 1] += 1
                 j = 0
-                start = 1
             else:
                 j += 1
-                start = j + 1
                 t[j] += 1
 
             t[0] -= 1

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -9,7 +9,7 @@
     objects instead.  When things stabilize this could be a useful refactoring.
 """
 
-from sympy.tensor.indexed import Idx, IndexedBase, Indexed
+from sympy.tensor.indexed import Idx, Indexed
 from sympy.functions import exp
 from sympy.core import C
 

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -105,7 +105,7 @@
 #      - Idx with stepsize != 1
 #      - Idx with step determined by function call
 
-from sympy.core import Expr, Basic, Tuple, Symbol, Integer, sympify, S
+from sympy.core import Expr, Tuple, Symbol, sympify, S
 from sympy.core.compatibility import is_sequence
 
 class IndexException(Exception):

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -71,7 +71,7 @@ import tempfile
 import subprocess
 
 from sympy.utilities.codegen import (
-        codegen, get_code_generator, Routine, OutputArgument, InOutArgument,
+        get_code_generator, Routine, OutputArgument, InOutArgument,
         CodeGenArgumentListError, Result
         )
 from sympy.utilities.lambdify import implemented_function

--- a/sympy/utilities/benchmarking.py
+++ b/sympy/utilities/benchmarking.py
@@ -5,7 +5,6 @@ from py.__.test.item import Item
 from py.__.test.terminal.terminal import TerminalSession
 
 from math import ceil as _ceil, floor as _floor, log10
-from time import time
 import timeit
 
 from inspect import getsource

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -85,7 +85,6 @@ from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import Idx, Indexed, IndexedBase
-from sympy.utilities import flatten
 
 
 

--- a/sympy/utilities/compilef.py
+++ b/sympy/utilities/compilef.py
@@ -78,7 +78,6 @@ to see the results of some benchmarks.
 
 """
 
-import os
 import ctypes
 from sympy import Symbol, cse, sympify
 from sympy.utilities.lambdify import lambdastr as getlambdastr

--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -5,8 +5,6 @@
 
 import sys
 import functools
-import signal
-import os
 
 try:
     # tested with py-lib 0.9.0

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -686,7 +686,6 @@ class SymPyDocTests(object):
     def test_file(self, filename):
         clear_cache()
 
-        import unittest
         from StringIO import StringIO
 
         rel_name = filename[len(self._root_dir)+1:]

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -24,7 +24,6 @@ from doctest import DocTestFinder, DocTestRunner
 import re as pre
 import random
 import subprocess
-import time
 import signal
 
 from sympy.core.cache import clear_cache
@@ -631,7 +630,7 @@ class SymPyTests(object):
         def callback(x,y):
             signal.alarm(0)
             raise Skipped("Timeout")
-        handler = signal.signal(signal.SIGALRM, callback)
+        signal.signal(signal.SIGALRM, callback)
         signal.alarm(timeout) # Set an alarm with a given timeout
         function()
         signal.alarm(0) # Disable the alarm


### PR DESCRIPTION
I've cleared of errors the utilities module. (GCI Task: http://www.google-melange.com/gci/task/view/google/gci2011/7134380 ). I've used setup.py audit.

The warnings present aren't applicable/ok as they are. Here's the list.

```
sympy/utilities/pytest.py:53: redefinition of unused 'Skipped' from line 11
sympy/utilities/pytest.py:74: redefinition of unused 'skip' from line 13
sympy/utilities/pytest.py:146: redefinition of function 'XFAIL' from line 56
sympy/utilities/cythonutils.py:16: redefinition of function 'cythonized' from line 8
sympy/utilities/autowrap.py:253: local variable 'prototype_c' is assigned to but never used
sympy/utilities/iterables.py:6: 'cartes' imported but unused
sympy/utilities/lambdify.py:7: 'import_module' imported but unused
sympy/utilities/runtests.py:56: undefined name 'sys_case_insensitive'
sympy/utilities/runtests.py:844: local variable 'msg' is assigned to but never used
sympy/utilities/compilef.py:421: '_exp' imported but unused
sympy/utilities/compilef.py:421: '_cos' imported but unused
sympy/utilities/compilef.py:548: redefinition of unused '_exp' from line 421
sympy/utilities/compilef.py:548: redefinition of unused '_cos' from line 421
sympy/utilities/compilef.py:548: 'diff' imported but unused
sympy/utilities/decorator.py:7: 'Add' imported but unused
```

In many occasions, it is due to that some classes are written inside if/else, so according to PyFlakes they are "redefined". Others are simply necessary and errors appear without them.
