### PR TITLE
Improved doctest coverage for combinatorics

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -496,15 +496,15 @@ don\'t match.")
         Permutation([0, 1, 2, 3])
 
         """
-        def unrank1(n, r, a):
+        def _unrank1(n, r, a):
             if n > 0:
                 a[n - 1], a[r % n] = a[r % n], a[n - 1]
-                unrank1(n - 1, r//n, a)
+                _unrank1(n - 1, r//n, a)
 
         id_perm = range(n)
         n = int(n)
         r = r % ifac(n)
-        unrank1(n, r, id_perm)
+        _unrank1(n, r, id_perm)
         return _new_from_array_form(id_perm)
 
     def rank_nonlex(self, inv_perm = None):
@@ -520,21 +520,21 @@ don\'t match.")
         >>> p.rank_nonlex()
         23
         """
-        def rank1(n, perm, inv_perm):
+        def _rank1(n, perm, inv_perm):
             if n == 1:
                 return 0
             s = perm[n - 1]
             t = inv_perm[n - 1]
             perm[n - 1], perm[t] = perm[t], s
             inv_perm[n - 1], inv_perm[s] = inv_perm[s], t
-            return s + n*rank1(n - 1, perm, inv_perm)
+            return s + n*_rank1(n - 1, perm, inv_perm)
 
         if inv_perm is None:
             inv_perm = (~self).array_form
         if not inv_perm:
             return 0
         perm = self.array_form[:]
-        r = rank1(len(perm), perm, inv_perm)
+        r = _rank1(len(perm), perm, inv_perm)
         return r
 
     def next_nonlex(self):

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -19,22 +19,94 @@ class Prufer(Basic):
 
     @property
     def prufer_repr(self):
+        """
+        Returns the tree representation of the Prufer sequence.
+
+        Examples
+        ========
+
+            >>> from sympy.combinatorics.prufer import Prufer
+            >>> Prufer([[0, 3], [1, 3], [2, 3], [3, 4], [4, 5]], 6).prufer_repr
+            [3, 3, 0, 0]
+            >>> Prufer([1, 0, 0]).prufer_repr
+            [1, 0, 0]
+
+        See Also
+        ========
+
+        :class: 'Prufer', :function:'to_prufer()'
+
+        """
         if self._prufer_repr is None:
             self._prufer_repr = self.to_prufer(self._tree_repr[:], self.nodes)
         return self._prufer_repr
 
     @property
     def tree_repr(self):
+        """
+        Returns the tree representation of the Prufer sequence.
+
+        Examples
+        ========
+
+            >>> from sympy.combinatorics.prufer import Prufer
+            >>> Prufer([[0, 3], [1, 3], [2, 3], [3, 4], [4, 5]], 6).tree_repr
+            [[0, 3], [1, 3], [2, 3], [3, 4], [4, 5]]
+            >>> Prufer([1, 0, 0]).tree_repr
+            [[4, 1], [3, 0], [2, 0], [1, 0]]
+
+        See Also
+        ========
+
+        :class: 'Prufer', :function:'to_tree()'
+
+        """
         if self._tree_repr is None:
             self._tree_repr = self.to_tree(self._prufer_repr[:])
         return self._tree_repr
 
     @property
     def nodes(self):
+        """
+        Retunrs the number of nodes in the tree.
+
+        Examples
+        ======
+
+            >>> from sympy.combinatorics.prufer import Prufer
+            >>> Prufer([[0, 3], [1, 3], [2, 3], [3, 4], [4, 5]], 6).nodes
+            6
+            >>> Prufer([1, 0, 0]).nodes
+            5
+
+        """
         return self._nodes
 
     @property
     def rank(self):
+        """
+        Returns the rank of the Prufer sequence.
+
+        Examples
+        ========
+
+            >>> from sympy.combinatorics.prufer import Prufer
+            >>> p = Prufer([[0, 3], [1, 3], [2, 3], [3, 4], [4, 5]], 6)
+            >>> p.rank
+            756
+            >>> p.next().rank
+            757
+            >>> p.prev().rank
+            755
+
+        See Also
+        ========
+
+        :class: 'Prufer', :function:'prufer_rank()'
+        :class: 'Prufer', :function:'next()'
+        :class: 'Prufer', :function:'prev()'
+
+        """
         if self._rank is None:
             self._rank = self.prufer_rank()
         return self._rank

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -20,7 +20,7 @@ class Prufer(Basic):
     @property
     def prufer_repr(self):
         """
-        Returns the tree representation of the Prufer sequence.
+        Returns Prufer sequence for the Prufer object.
 
         Examples
         ========
@@ -44,7 +44,7 @@ class Prufer(Basic):
     @property
     def tree_repr(self):
         """
-        Returns the tree representation of the Prufer sequence.
+        Returns the tree representation of the Prufer object.
 
         Examples
         ========
@@ -233,9 +233,16 @@ class Prufer(Basic):
         Examples
         ========
         >>> from sympy.combinatorics.prufer import Prufer
+
+        A Prufer object can be constructed from a list of node connections
+        and the number of nodes:
+
         >>> a = Prufer([[0, 1], [0, 2], [0, 3]], 4)
         >>> a.prufer_repr
         [0, 0]
+
+        A Prufer object can be constructed from a Prufer sequence:
+
         >>> b = Prufer([1, 3])
         >>> b.tree_repr
         [[2, 1], [1, 3], [3, 0]]

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -211,15 +211,15 @@ class Subset(Basic):
         43
         """
         if self._rank_lex == None:
-            def ranklex(self, subset_index, i, n):
+            def _ranklex(self, subset_index, i, n):
                 if subset_index == [] or i > n:
                     return 0
                 if i in subset_index:
                     subset_index.remove(i)
-                    return 1 + ranklex(self, subset_index, i + 1, n)
-                return 2**(n - i - 1) + ranklex(self, subset_index, i + 1, n)
+                    return 1 + _ranklex(self, subset_index, i + 1, n)
+                return 2**(n - i - 1) + _ranklex(self, subset_index, i + 1, n)
             indices = Subset.subset_indices(self.subset, self.superset)
-            self._rank_lex = ranklex(self, indices, 0, self.superset_size)
+            self._rank_lex = _ranklex(self, indices, 0, self.superset_size)
         return self._rank_lex
 
     @property


### PR DESCRIPTION
Improved doctest coverage for combinatorics

Added doctests and documentations where it was missing. Made two methods in permutations and another in subsets private, as they are defined and used only inside another method. Two methods in subsets are still not implemented, and have no documentation/doctest.

GCI Task: http://www.google-melange.com/gci/task/view/google/gci2011/7230272
