### PR TITLE
Make imports in doc/src/modules/geometry.txt relative to files.

### DIFF
--- a/doc/src/modules/geometry.txt
+++ b/doc/src/modules/geometry.txt
@@ -195,14 +195,18 @@ API Reference
 Utils
 ~~~~~
 
-.. automethod:: sympy.geometry.util.intersection
+.. module:: sympy.geometry.util
 
-.. automethod:: sympy.geometry.util.convex_hull
+.. autofunction:: intersection
 
-.. automethod:: sympy.geometry.util.are_similar
+.. autofunction:: convex_hull
+
+.. autofunction:: are_similar
 
 Points
 ~~~~~~
+
+.. module:: sympy.geometry.point
 
 .. autoclass:: Point
    :members:
@@ -210,7 +214,9 @@ Points
 Lines
 ~~~~~
 
-.. autoclass:: sympy.geometry.line.LinearEntity
+.. module:: sympy.geometry.line
+
+.. autoclass:: LinearEntity
    :members:
 
 .. autoclass:: Line
@@ -225,11 +231,15 @@ Lines
 Curves
 ~~~~~~
 
+.. module:: sympy.geometry.curve
+
 .. autoclass:: Curve
    :members:
 
 Ellipses
 ~~~~~~~~
+
+.. module:: sympy.geometry.ellipse
 
 .. autoclass:: Ellipse
    :members:
@@ -239,6 +249,8 @@ Ellipses
 
 Polygons
 ~~~~~~~~
+
+.. module:: sympy.geometry.polygon
 
 .. autoclass:: Polygon
    :members:


### PR DESCRIPTION
After this change the viewcode Sphinx extension starts working for geometry
module - the source link appears next to object definition.
