### PR TITLE
Improve handling of qapply'ing symbolic spin states with basis conversion and coupled states

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -253,23 +253,32 @@ class SpinOpBase(object):
         state = ket.rewrite(self.basis)
         # If the state has only one term
         if isinstance(state, State):
-            return self._apply_operator(state, **options).rewrite(orig_basis)
+            ret = (hbar*state.m) * state
         # state is a linear combination of states
-        if isinstance(state, Sum):
+        elif isinstance(state, Sum):
             ret = self._apply_operator_Sum(state, **options)
         else:
             ret = qapply(self*state)
         if ret == self*state:
             raise NotImplementedError
-        return qapply(self*state).rewrite(orig_basis)
+        return ret.rewrite(orig_basis)
 
     def _apply_operator_JxKet(self, ket, **options):
+        return self._apply_op(ket, 'Jx', **options)
+
+    def _apply_operator_JxKetCoupled(self, ket, **options):
         return self._apply_op(ket, 'Jx', **options)
 
     def _apply_operator_JyKet(self, ket, **options):
         return self._apply_op(ket, 'Jy', **options)
 
+    def _apply_operator_JyKetCoupled(self, ket, **options):
+        return self._apply_op(ket, 'Jy', **options)
+
     def _apply_operator_JzKet(self, ket, **options):
+        return self._apply_op(ket, 'Jz', **options)
+
+    def _apply_operator_JzKetCoupled(self, ket, **options):
         return self._apply_op(ket, 'Jz', **options)
 
     def _apply_operator_TensorProduct(self, tp, **options):
@@ -309,6 +318,15 @@ class JplusOp(SpinOpBase, Operator):
                 return S.Zero
         return hbar*sqrt(j*(j+S.One)-m*(m+S.One))*JzKet(j, m+S.One)
 
+    def _apply_operator_JzKetCoupled(self, ket, **options):
+        j = ket.j
+        m = ket.m
+        jvals = ket.jvals
+        if m.is_Number and j.is_Number:
+            if m >= j:
+                return S.Zero
+        return hbar*sqrt(j*(j+S.One)-m*(m+S.One))*JzKetCoupled(j, m+S.One,*jvals)
+
     def matrix_element(self, j, m, jp, mp):
         result = hbar*sqrt(j*(j+S.One)-mp*(mp+S.One))
         result *= KroneckerDelta(m, mp+1)
@@ -340,6 +358,15 @@ class JminusOp(SpinOpBase, Operator):
                 return S.Zero
         return hbar*sqrt(j*(j+S.One)-m*(m-S.One))*JzKet(j, m-S.One)
 
+    def _apply_operator_JzKetCoupled(self, ket, **options):
+        j = ket.j
+        m = ket.m
+        jvals = ket.jvals
+        if m.is_Number and j.is_Number:
+            if m <= -j:
+                return S.Zero
+        return hbar*sqrt(j*(j+S.One)-m*(m-S.One))*JzKetCoupled(j, m-S.One,*jvals)
+
     def matrix_element(self, j, m, jp, mp):
         result = hbar*sqrt(j*(j+S.One)-mp*(mp-S.One))
         result *= KroneckerDelta(m, mp-1)
@@ -369,12 +396,14 @@ class JxOp(SpinOpBase, HermitianOperator):
     def _eval_commutator_JzOp(self, other):
         return -I*hbar*JyOp(self.name)
 
-    def _apply_operator_JxKet(self, ket, **options):
-        return (hbar*ket.m)*ket
-
     def _apply_operator_JzKet(self, ket, **options):
         jp = JplusOp(self.name)._apply_operator_JzKet(ket, **options)
         jm = JminusOp(self.name)._apply_operator_JzKet(ket, **options)
+        return (jp + jm)/Integer(2)
+
+    def _apply_operator_JzKetCoupled(self, ket, **options):
+        jp = JplusOp(self.name)._apply_operator_JzKetCoupled(ket, **options)
+        jm = JminusOp(self.name)._apply_operator_JzKetCoupled(ket, **options)
         return (jp + jm)/Integer(2)
 
     def _represent_default_basis(self, **options):
@@ -402,12 +431,14 @@ class JyOp(SpinOpBase, HermitianOperator):
     def _eval_commutator_JxOp(self, other):
         return -I*hbar*J2Op(self.name)
 
-    def _apply_operator_JyKet(self, ket, **options):
-        return (hbar*ket.m)*ket
-
     def _apply_operator_JzKet(self, ket, **options):
         jp = JplusOp(self.name)._apply_operator_JzKet(ket, **options)
         jm = JminusOp(self.name)._apply_operator_JzKet(ket, **options)
+        return (jp - jm)/(Integer(2)*I)
+
+    def _apply_operator_JzKetCoupled(self, ket, **options):
+        jp = JplusOp(self.name)._apply_operator_JzKetCoupled(ket, **options)
+        jm = JminusOp(self.name)._apply_operator_JzKetCoupled(ket, **options)
         return (jp - jm)/(Integer(2)*I)
 
     def _represent_default_basis(self, **options):
@@ -440,9 +471,6 @@ class JzOp(SpinOpBase, HermitianOperator):
 
     def _eval_commutator_JminusOp(self, other):
         return -hbar*JminusOp(self.name)
-
-    def _apply_operator_JzKet(self, ket, **options):
-        return (hbar*ket.m)*ket
 
     def matrix_element(self, j, m, jp, mp):
         result = hbar*mp
@@ -959,10 +987,21 @@ class SpinState(State):
 
     def _rewrite_basis(self, basis, evect, **options):
         from sympy.physics.quantum.represent import represent
-        j = sympify(self.j)
+        j = self.j
+        args = self.args[2:]
         if j.is_number:
+            if isinstance(self, CoupledSpinState):
+                if j == int(j):
+                    start = j**2
+                else:
+                    start = (2*j-1)*(2*j+1)/4
+            else:
+                start = 0
             vect = represent(self, basis=basis, **options)
-            return Add(*[vect[i] * evect(j,j-i) for i in range(2*j+1)])
+            result = Add(*[vect[start+i] * evect(j,j-i,*args) for i in range(2*j+1)])
+            if isinstance(self, CoupledSpinState) and options.get('coupled') is False:
+                return uncouple(result)
+            return result
         else:
             i = 0
             mi = symbols('mi')
@@ -972,14 +1011,18 @@ class SpinState(State):
                 mi = symbols('mi%d' % i)
                 break
             # TODO: better way to get angles of rotation
-            if isinstance(self, Ket):
-                angles = represent(self.__class__(0,mi),basis=basis)[0].args[3:6]
+            if isinstance(self, CoupledSpinState):
+                test_args = (0,mi,0)
             else:
-                angles = represent(self.__class__(0,mi),basis=basis)[0].args[0].args[3:6]
+                test_args = (0,mi)
+            if isinstance(self, Ket):
+                angles = represent(self.__class__(*test_args),basis=basis)[0].args[3:6]
+            else:
+                angles = represent(self.__class__(*test_args),basis=basis)[0].args[0].args[3:6]
             if angles == (0,0,0):
                 return self
             else:
-                state = evect(j, mi)
+                state = evect(j, mi, *args)
                 lt = Rotation.D(j, mi, self.m, *angles)
                 return Sum(lt * state, (mi,-j,j))
 
@@ -1280,32 +1323,6 @@ class CoupledSpinState(SpinState):
         if isinstance(self, Bra):
             return self._rewrite_basis(Jz, JzBraCoupled, **options)
         return self._rewrite_basis(Jz, JzKetCoupled, **options)
-
-    def _rewrite_basis(self, basis, evect, **options):
-        from sympy.physics.quantum.represent import represent
-        j = sympify(self.j)
-        jvals = self.jvals
-        if j.is_number:
-            if j == int(j):
-                start = j**2
-            else:
-                start = (2*j-1)*(2*j+1)/4
-            vect = represent(self, basis=basis, **options)
-            result = Add(*[vect[start+i] * evect(j,j-i,*jvals) for i in range(2*j+1)])
-            if options.get('coupled') is False:
-                return uncouple(result)
-            return result
-        else:
-            # TODO: better way to get angles of rotation
-            mi = symbols('mi')
-            angles = represent(self.__class__(0,mi),basis=basis)[0].args[3:6]
-            if angles == (0,0,0):
-                return self
-            else:
-                state = evect(j, mi, *jvals)
-                lt = Rotation.D(j, mi, self.m, *angles)
-                result = lt * state
-                return Sum(lt * state, (mi,-j,j))
 
 
 class JxKetCoupled(CoupledSpinState, Ket):

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -17,7 +17,7 @@ from sympy.physics.quantum.spin import (
 
 from sympy.utilities.pytest import XFAIL
 
-j1, j2, m1, m2, mi, mp = symbols('j1 j2 m1 m2 mi mp')
+j1, j2, m1, m2, mi, mi1, mp = symbols('j1 j2 m1 m2 mi mi1 mp')
 
 def test_represent():
     # Spin operators
@@ -815,79 +815,101 @@ def test_j2():
 
 def test_jx():
     assert Commutator(Jx, Jz).doit() == -I*hbar*Jy
-    assert qapply(Jx*JzKet(1,1)) == sqrt(2)*hbar*JzKet(1,0)/2
     assert Jx.rewrite('plusminus') == (Jminus + Jplus)/2
     assert represent(Jx, basis=Jz, j=1) == (represent(Jplus, basis=Jz, j=1)+represent(Jminus, basis=Jz, j=1))/2
-    # Normal Operators
+    # Normal operators, normal states
     # Numerical
     assert qapply(Jx*JxKet(1,1)) == hbar*JxKet(1,1)
     assert qapply(Jx*JyKet(1,1)) == hbar*JyKet(1,1)
     assert qapply(Jx*JzKet(1,1)) == sqrt(2)*hbar*JzKet(1,0)/2
-    assert qapply(Jx*TensorProduct(JxKet(1,1), JxKet(1,1))) == 2*hbar*TensorProduct(JxKet(1,1), JxKet(1,1))
-    assert qapply(Jx*TensorProduct(JyKet(1,1), JyKet(1,1))) == \
-        hbar*TensorProduct(JyKet(1,1),JyKet(1,1))+hbar*TensorProduct(JyKet(1,1),JyKet(1,1))
-    assert qapply(Jx*TensorProduct(JzKet(1,1), JzKet(1,1))) == \
-        sqrt(2)*hbar*TensorProduct(JzKet(1,1),JzKet(1,0))/2+sqrt(2)*hbar*TensorProduct(JzKet(1,0),JzKet(1,1))/2
-    assert qapply(Jx*TensorProduct(JxKet(1,1), JxKet(1,-1))) == 0
     # Symbolic
     assert qapply(Jx*JxKet(j,m)) == hbar*m*JxKet(j,m)
+    assert qapply(Jx*JyKet(j,m)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,0,0,pi/2)*Sum(WignerD(j,mi1,mi,3*pi/2,0,0)*JyKet(j,mi1),(mi1,-j,j)),(mi,-j,j))
     assert qapply(Jx*JzKet(j,m)) == \
         hbar*sqrt(j**2+j-m**2-m)*JzKet(j,m+1)/2 + hbar*sqrt(j**2+j-m**2+m)*JzKet(j,m-1)/2
+    # Normal operators, uncoupled states
+    # Numerical
+    assert qapply(Jx*TensorProduct(JxKet(1,1), JxKet(1,1))) == \
+        2*hbar*TensorProduct(JxKet(1,1), JxKet(1,1))
+    assert qapply(Jx*TensorProduct(JyKet(1,1), JyKet(1,1))) == \
+        hbar*TensorProduct(JyKet(1,1),JyKet(1,1)) + \
+        hbar*TensorProduct(JyKet(1,1),JyKet(1,1))
+    assert qapply(Jx*TensorProduct(JzKet(1,1), JzKet(1,1))) == \
+        sqrt(2)*hbar*TensorProduct(JzKet(1,1),JzKet(1,0))/2 + \
+        sqrt(2)*hbar*TensorProduct(JzKet(1,0),JzKet(1,1))/2
+    assert qapply(Jx*TensorProduct(JxKet(1,1), JxKet(1,-1))) == 0
+    # Symbolic
     assert qapply(Jx*TensorProduct(JxKet(j1,m1), JxKet(j2,m2))) == \
         hbar*m1*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))+hbar*m2*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))
+    assert qapply(Jx*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))) == \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,0,pi/2)*Sum(WignerD(j1,mi1,mi,3*pi/2,0,0)*JyKet(j1,mi1),(mi1,-j1,j1)),(mi,-j1,j1)),JyKet(j2,m2)) + \
+        TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,0,pi/2)*Sum(WignerD(j2,mi1,mi,3*pi/2,0,0)*JyKet(j2,mi1),(mi1,-j2,j2)),(mi,-j2,j2)))
     assert qapply(Jx*TensorProduct(JzKet(j1,m1), JzKet(j2,m2))) == \
         hbar*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + \
         hbar*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2 + \
         hbar*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + \
         hbar*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
-    # Uncoupled Operators
+    # Uncoupled operators, uncoupled states
     # Numerical
-    assert qapply(TensorProduct(Jx,1)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
-    assert qapply(TensorProduct(1,Jx)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == -hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
-    assert qapply(TensorProduct(Jx,1)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
-    assert qapply(TensorProduct(1,Jx)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == -hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
-    assert qapply(TensorProduct(Jx,1)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == hbar*sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,-1))/2
-    assert qapply(TensorProduct(1,Jx)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == hbar*sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,0))/2
+    assert qapply(TensorProduct(Jx,1)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == \
+        hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
+    assert qapply(TensorProduct(1,Jx)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == \
+        -hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
+    assert qapply(TensorProduct(Jx,1)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == \
+        hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
+    assert qapply(TensorProduct(1,Jx)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == \
+        -hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
+    assert qapply(TensorProduct(Jx,1)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == \
+        hbar*sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,-1))/2
+    assert qapply(TensorProduct(1,Jx)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == \
+        hbar*sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,0))/2
     # Symbolic
     assert qapply(TensorProduct(Jx,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
         hbar*m1*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))
     assert qapply(TensorProduct(1,Jx)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
         hbar*m2*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))
-    assert qapply(TensorProduct(Jx,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
-        hbar*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + hbar*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2
-    assert qapply(TensorProduct(1,Jx)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
-        hbar*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + hbar*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
-
-@XFAIL
-def test_jx_failing():
-    assert qapply(Jx*JyKet(j,m)) == Sum(hbar*mi*WignerD(j,mi,m,0,0,pi/2)*JxKet(j,mi),(mi,-j,j))
-    assert qapply(Jx*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))) == \
-                TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,0,pi/2)*JxKet(j1,mi),(mi,-j1,j1)),JyKet(j2,m2)) + \
-                TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,0,pi/2)*JxKet(j2,mi),(mi,-j2,j2)))
     assert qapply(TensorProduct(Jx,1)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
-                TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,0,pi/2) * JxKet(j1,mi), (mi,-j1,j1)),JyKet(j2,m2))
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,0,pi/2) * Sum(WignerD(j1,mi1,mi,3*pi/2,0,0)*JyKet(j1,mi1),(mi1,-j1,j1)), (mi,-j1,j1)),JyKet(j2,m2))
     assert qapply(TensorProduct(1,Jx)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
-        TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,0,pi/2) * JxKet(j2,mi), (mi,-j2,j2)))
+        TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,0,pi/2) * Sum(WignerD(j2,mi1,mi,3*pi/2,0,0)*JyKet(j2,mi1),(mi1,-j2,j2)), (mi,-j2,j2)))
+    assert qapply(TensorProduct(Jx,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        hbar*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + \
+        hbar*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2
+    assert qapply(TensorProduct(1,Jx)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        hbar*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + \
+        hbar*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
 
 def test_jy():
     assert Commutator(Jy, Jz).doit() == I*hbar*Jx
     assert Jy.rewrite('plusminus') == (Jplus - Jminus)/(2*I)
     assert represent(Jy, basis=Jz) == (represent(Jplus, basis=Jz) - represent(Jminus, basis=Jz))/(2*I)
-    # Normal Operators
+    # Normal operators, normal states
     # Numerical
     assert qapply(Jy*JxKet(1,1)) == hbar*JxKet(1,1)
     assert qapply(Jy*JyKet(1,1)) == hbar*JyKet(1,1)
     assert qapply(Jy*JzKet(1,1)) == sqrt(2)*hbar*I*JzKet(1,0)/2
-    assert qapply(Jy*TensorProduct(JxKet(1,1), JxKet(1,1))) == \
-        hbar*TensorProduct(JxKet(1,1),JxKet(1,1)) + hbar*TensorProduct(JxKet(1,1),JxKet(1,1))
-    assert qapply(Jy*TensorProduct(JyKet(1,1), JyKet(1,1))) == 2*hbar*TensorProduct(JyKet(1,1), JyKet(1,1))
-    assert qapply(Jy*TensorProduct(JzKet(1,1), JzKet(1,1))) == \
-        sqrt(2)*hbar*I*TensorProduct(JzKet(1,1),JzKet(1,0))/2+sqrt(2)*hbar*I*TensorProduct(JzKet(1,0),JzKet(1,1))/2
-    assert qapply(Jy*TensorProduct(JyKet(1,1), JyKet(1,-1))) == 0
     # Symbolic
+    assert qapply(Jy*JxKet(j,m)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,0,0)*Sum(WignerD(j,mi1,mi,0,0,pi/2)*JxKet(j,mi1),(mi1,-j,j)), (mi,-j,j))
     assert qapply(Jy*JyKet(j,m)) == hbar*m*JyKet(j,m)
     assert qapply(Jy*JzKet(j,m)) == \
         -hbar*I*sqrt(j**2+j-m**2-m)*JzKet(j,m+1)/2 + hbar*I*sqrt(j**2+j-m**2+m)*JzKet(j,m-1)/2
+    # Normal operators, uncoupled states
+    # Numerical
+    assert qapply(Jy*TensorProduct(JxKet(1,1), JxKet(1,1))) == \
+        hbar*TensorProduct(JxKet(1,1),JxKet(1,1)) + \
+        hbar*TensorProduct(JxKet(1,1),JxKet(1,1))
+    assert qapply(Jy*TensorProduct(JyKet(1,1), JyKet(1,1))) == \
+        2*hbar*TensorProduct(JyKet(1,1), JyKet(1,1))
+    assert qapply(Jy*TensorProduct(JzKet(1,1), JzKet(1,1))) == \
+        sqrt(2)*hbar*I*TensorProduct(JzKet(1,1),JzKet(1,0))/2 + \
+        sqrt(2)*hbar*I*TensorProduct(JzKet(1,0),JzKet(1,1))/2
+    assert qapply(Jy*TensorProduct(JyKet(1,1), JyKet(1,-1))) == 0
+    # Symbolic
+    assert qapply(Jy*TensorProduct(JxKet(j1,m1), JxKet(j2,m2))) == \
+        TensorProduct(JxKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,0,0)*Sum(WignerD(j2,mi1,mi,0,0,pi/2)*JxKet(j2,mi1),(mi1,-j2,j2)),(mi,-j2,j2))) + \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,0,0)*Sum(WignerD(j1,mi1,mi,0,0,pi/2)*JxKet(j1,mi1),(mi1,-j1,j1)),(mi,-j1,j1)),JxKet(j2,m2))
     assert qapply(Jy*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))) == \
         hbar*m1*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))+hbar*m2*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))
     assert qapply(Jy*TensorProduct(JzKet(j1,m1), JzKet(j2,m2))) == \
@@ -895,73 +917,94 @@ def test_jy():
         hbar*I*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2 + \
         -hbar*I*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + \
         hbar*I*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
-    # Uncoupled Operators
+    # Uncoupled operators, uncoupled states
     # Numerical
-    assert qapply(TensorProduct(Jy,1)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
-    assert qapply(TensorProduct(1,Jy)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == -hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
-    assert qapply(TensorProduct(Jy,1)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
-    assert qapply(TensorProduct(1,Jy)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == -hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
-    assert qapply(TensorProduct(Jy,1)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == hbar*sqrt(2)*I*TensorProduct(JzKet(1,0),JzKet(1,-1))/2
-    assert qapply(TensorProduct(1,Jy)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == -hbar*sqrt(2)*I*TensorProduct(JzKet(1,1),JzKet(1,0))/2
+    assert qapply(TensorProduct(Jy,1)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == \
+        hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
+    assert qapply(TensorProduct(1,Jy)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == \
+        -hbar*TensorProduct(JxKet(1,1),JxKet(1,-1))
+    assert qapply(TensorProduct(Jy,1)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == \
+        hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
+    assert qapply(TensorProduct(1,Jy)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == \
+        -hbar*TensorProduct(JyKet(1,1),JyKet(1,-1))
+    assert qapply(TensorProduct(Jy,1)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == \
+        hbar*sqrt(2)*I*TensorProduct(JzKet(1,0),JzKet(1,-1))/2
+    assert qapply(TensorProduct(1,Jy)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == \
+        -hbar*sqrt(2)*I*TensorProduct(JzKet(1,1),JzKet(1,0))/2
     # Symbolic
+    assert qapply(TensorProduct(Jy,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,0,0) * Sum(WignerD(j1,mi1,mi,0,0,pi/2)*JxKet(j1,mi1),(mi1,-j1,j1)), (mi,-j1,j1)), JxKet(j2,m2))
+    assert qapply(TensorProduct(1,Jy)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+        TensorProduct(JxKet(j1,m1), Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,0,0) * Sum(WignerD(j2,mi1,mi,0,0,pi/2)*JxKet(j2,mi1),(mi1,-j2,j2)), (mi,-j2,j2)))
     assert qapply(TensorProduct(Jy,1)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
         hbar*m1*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))
     assert qapply(TensorProduct(1,Jy)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
         hbar*m2*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))
     assert qapply(TensorProduct(Jy,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
-        -hbar*I*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + hbar*I*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2
+        -hbar*I*sqrt(j1**2+j1-m1**2-m1)*TensorProduct(JzKet(j1,m1+1),JzKet(j2,m2))/2 + \
+        hbar*I*sqrt(j1**2+j1-m1**2+m1)*TensorProduct(JzKet(j1,m1-1),JzKet(j2,m2))/2
     assert qapply(TensorProduct(1,Jy)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
-        -hbar*I*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + hbar*I*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
-
-@XFAIL
-def test_jy_failing():
-    assert qapply(Jy*JxKet(j,m)) == Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,0,0)*JyKet(j,mi), (mi,-j,j))
-    assert qapply(Jy*TensorProduct(JxKet(j1,m1), JxKet(j2,m2))) == \
-                    TensorProduct(JxKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,0,0)*JyKet(j2,mi),(mi,-j2,j2))) + \
-                    TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,0,0)*JyKet(j1,mi),(mi,-j1,j1)),JxKet(j2,m2))
-    assert qapply(TensorProduct(Jy,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
-                    TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,0,0) * JyKet(j1,mi), (mi,-j1,j1)), JxKet(j2,m2))
-    assert qapply(TensorProduct(1,Jy)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
-                    TensorProduct(JxKet(j1,m1), Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,0,0) * JyKet(j2,mi), (mi,-j2,j2)))
+        -hbar*I*sqrt(j2**2+j2-m2**2-m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2+1))/2 + \
+        hbar*I*sqrt(j2**2+j2-m2**2+m2)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2-1))/2
 
 def test_jz():
     assert Commutator(Jz, Jminus).doit() == -hbar*Jminus
-    # Normal Operators
+    # Normal operators, normal states
     # Numerical
     assert qapply(Jz*JxKet(1,1)) == -sqrt(2)*hbar*JxKet(1,0)/2
     assert qapply(Jz*JyKet(1,1)) == -sqrt(2)*hbar*I*JyKet(1,0)/2
     assert qapply(Jz*JzKet(2,1)) == hbar*JzKet(2,1)
+    # Symbolic
+    j, m, j1, j2, m1, m2, mi, mi1 = symbols("j m j1:3 m1:3 mi mi1")
+    assert qapply(Jz*JxKet(j,m)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,0,pi/2,0)*Sum(WignerD(j,mi1,mi,0,3*pi/2,0)*JxKet(j,mi1),(mi1,-j,j)), (mi,-j,j))
+    assert qapply(Jz*JyKet(j,m)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j,mi1,mi,3*pi/2,pi/2,pi/2)*JyKet(j,mi1),(mi1,-j,j)), (mi,-j,j))
+    assert qapply(Jz*JzKet(j,m)) == hbar*m*JzKet(j,m)
+    # Normal operators, uncoupled states
+    # Numerical
     assert qapply(Jz*TensorProduct(JxKet(1,1), JxKet(1,1))) == \
-        -sqrt(2)*hbar*TensorProduct(JxKet(1,1),JxKet(1,0))/2 - sqrt(2)*hbar*TensorProduct(JxKet(1,0),JxKet(1,1))/2
+        -sqrt(2)*hbar*TensorProduct(JxKet(1,1),JxKet(1,0))/2 - \
+        sqrt(2)*hbar*TensorProduct(JxKet(1,0),JxKet(1,1))/2
     assert qapply(Jz*TensorProduct(JyKet(1,1), JyKet(1,1))) == \
-        -sqrt(2)*hbar*I*TensorProduct(JyKet(1,1), JyKet(1,0))/2 - sqrt(2)*hbar*I*TensorProduct(JyKet(1,0), JyKet(1,1))/2
-    assert qapply(Jz*TensorProduct(JzKet(1,1), JzKet(1,1))) == 2*hbar*TensorProduct(JzKet(1,1), JzKet(1,1))
+        -sqrt(2)*hbar*I*TensorProduct(JyKet(1,1), JyKet(1,0))/2 - \
+        sqrt(2)*hbar*I*TensorProduct(JyKet(1,0), JyKet(1,1))/2
+    assert qapply(Jz*TensorProduct(JzKet(1,1), JzKet(1,1))) == \
+        2*hbar*TensorProduct(JzKet(1,1), JzKet(1,1))
     assert qapply(Jz*TensorProduct(JzKet(1,1), JzKet(1,-1))) == 0
     # Symbolic
-    assert qapply(Jz*JzKet(j,m)) == hbar*m*JzKet(j,m)
+    # Uncoupled Operators
+    assert qapply(Jz*TensorProduct(JxKet(j1,m1), JxKet(j2,m2))) == \
+        TensorProduct(JxKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,pi/2,0)*Sum(WignerD(j2,mi1,mi,0,3*pi/2,0)*JxKet(j2,mi1),(mi1,-j2,j2)),(mi,-j2,j2))) + \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,pi/2,0)*Sum(WignerD(j1,mi1,mi,0,3*pi/2,0)*JxKet(j1,mi1),(mi1,-j1,j1)),(mi,-j1,j1)),JxKet(j2,m2))
+    assert qapply(Jz*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))) == \
+        TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j2,mi1,mi,3*pi/2,pi/2,pi/2)*JyKet(j2,mi1),(mi1,-j2,j2)),(mi,-j2,j2))) + \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j1,mi1,mi,3*pi/2,pi/2,pi/2)*JyKet(j1,mi1),(mi1,-j1,j1)),(mi,-j1,j1)),JyKet(j2,m2))
     assert qapply(Jz*TensorProduct(JzKet(j1,m1), JzKet(j2,m2))) == \
         hbar*m1*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))+hbar*m2*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))
-    # Uncoupled Operators
     # Numerical
-    assert qapply(TensorProduct(Jz,1)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == -sqrt(2)*hbar*TensorProduct(JxKet(1,0),JxKet(1,-1))/2
-    assert qapply(TensorProduct(1,Jz)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == -sqrt(2)*hbar*TensorProduct(JxKet(1,1),JxKet(1,0))/2
-    assert qapply(TensorProduct(Jz,1)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == -sqrt(2)*I*hbar*TensorProduct(JyKet(1,0),JyKet(1,-1))/2
-    assert qapply(TensorProduct(1,Jz)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == sqrt(2)*I*hbar*TensorProduct(JyKet(1,1),JyKet(1,0))/2
-    assert qapply(TensorProduct(Jz,1)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == hbar*TensorProduct(JzKet(1,1),JzKet(1,-1))
-    assert qapply(TensorProduct(1,Jz)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == -hbar*TensorProduct(JzKet(1,1),JzKet(1,-1))
+    assert qapply(TensorProduct(Jz,1)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == \
+        -sqrt(2)*hbar*TensorProduct(JxKet(1,0),JxKet(1,-1))/2
+    assert qapply(TensorProduct(1,Jz)*TensorProduct(JxKet(1,1),JxKet(1,-1))) == \
+        -sqrt(2)*hbar*TensorProduct(JxKet(1,1),JxKet(1,0))/2
+    assert qapply(TensorProduct(Jz,1)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == \
+        -sqrt(2)*I*hbar*TensorProduct(JyKet(1,0),JyKet(1,-1))/2
+    assert qapply(TensorProduct(1,Jz)*TensorProduct(JyKet(1,1),JyKet(1,-1))) == \
+        sqrt(2)*I*hbar*TensorProduct(JyKet(1,1),JyKet(1,0))/2
+    assert qapply(TensorProduct(Jz,1)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == \
+        hbar*TensorProduct(JzKet(1,1),JzKet(1,-1))
+    assert qapply(TensorProduct(1,Jz)*TensorProduct(JzKet(1,1),JzKet(1,-1))) == \
+        -hbar*TensorProduct(JzKet(1,1),JzKet(1,-1))
     # Symbolic
-    assert qapply(TensorProduct(1,Jz)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
-        hbar*m2*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))
-
-@XFAIL
-def test_jz_failing():
-    assert qapply(Jz*JxKet(j,m)) == Sum(hbar*mi*WignerD(j,mi,m,0,pi/2,0)*JzKet(j,mi), (mi,-j,j))
-    assert qapply(Jz*JyKet(j,m)) == Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,-pi/2,pi/2)*JzKet(j,mi), (mi,-j,j))
-    assert qapply(Jz*TensorProduct(JxKet(j1,m1), JxKet(j2,m2))) == \
-        TensorProduct(JxKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,pi/2,0)*JzKet(j2,mi),(mi,-j2,j2))) + \
-        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,pi/2,0)*JzKet(j1,mi),(mi,-j1,j1)),JxKet(j2,m2))
-    assert qapply(Jz*TensorProduct(JyKet(j1,m1), JyKet(j2,m2))) == \
-        TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,-pi/2,pi/2)*JzKet(j2,mi),(mi,-j2,j2))) + \
-        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,-pi/2,pi/2)*JzKet(j1,mi),(mi,-j1,j1)),JyKet(j2,m2))
+    assert qapply(TensorProduct(Jz,1)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,0,pi/2,0)*Sum(WignerD(j1,mi1,mi,0,3*pi/2,0)*JxKet(j1,mi1),(mi1,-j1,j1)),(mi,-j1,j1)),JxKet(j2,m2))
+    assert qapply(TensorProduct(1,Jz)*TensorProduct(JxKet(j1,m1),JxKet(j2,m2))) == \
+        TensorProduct(JxKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,0,pi/2,0)*Sum(WignerD(j2,mi1,mi,0,3*pi/2,0)*JxKet(j2,mi1),(mi1,-j2,j2)),(mi,-j2,j2)))
+    assert qapply(TensorProduct(Jz,1)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+        TensorProduct(Sum(hbar*mi*WignerD(j1,mi,m1,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j1,mi1,mi,3*pi/2,pi/2,pi/2)*JyKet(j1,mi1),(mi1,-j1,j1)),(mi,-j1,j1)),JyKet(j2,m2))
+    assert qapply(TensorProduct(1,Jz)*TensorProduct(JyKet(j1,m1),JyKet(j2,m2))) == \
+        TensorProduct(JyKet(j1,m1),Sum(hbar*mi*WignerD(j2,mi,m2,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j2,mi1,mi,3*pi/2,pi/2,pi/2)*JyKet(j2,mi1),(mi1,-j2,j2)),(mi,-j2,j2)))
     assert qapply(TensorProduct(Jz,1)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
         hbar*m1*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))
+    assert qapply(TensorProduct(1,Jz)*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))) == \
+        hbar*m2*TensorProduct(JzKet(j1,m1),JzKet(j2,m2))

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -296,45 +296,45 @@ def test_rewrite():
     assert TensorProduct(JyKet(1,0),JxKet(1,1)).rewrite('Jx') == TensorProduct(JxKet(1,0),JxKet(1,1))
     assert TensorProduct(JyKet(1,-1),JxKet(1,1)).rewrite('Jx') == I*TensorProduct(JxKet(1,-1),JxKet(1,1))
     assert TensorProduct(JzKet(1,1),JxKet(1,1)).rewrite('Jx') == \
-            TensorProduct(JxKet(1,-1),JxKet(1,1))/2-sqrt(2)*TensorProduct(JxKet(1,0),JxKet(1,1))/2+TensorProduct(JxKet(1,1),JxKet(1,1))/2
+        TensorProduct(JxKet(1,-1),JxKet(1,1))/2-sqrt(2)*TensorProduct(JxKet(1,0),JxKet(1,1))/2+TensorProduct(JxKet(1,1),JxKet(1,1))/2
     assert TensorProduct(JzKet(1,0),JxKet(1,1)).rewrite('Jx') == \
-            -sqrt(2)*TensorProduct(JxKet(1,-1),JxKet(1,1))/2+sqrt(2)*TensorProduct(JxKet(1,1),JxKet(1,1))/2
+        -sqrt(2)*TensorProduct(JxKet(1,-1),JxKet(1,1))/2+sqrt(2)*TensorProduct(JxKet(1,1),JxKet(1,1))/2
     assert TensorProduct(JzKet(1,-1),JxKet(1,1)).rewrite('Jx') == \
-            TensorProduct(JxKet(1,-1),JxKet(1,1))/2 + sqrt(2)*TensorProduct(JxKet(1,0),JxKet(1,1))/2 + TensorProduct(JxKet(1,1),JxKet(1,1))/2
+        TensorProduct(JxKet(1,-1),JxKet(1,1))/2 + sqrt(2)*TensorProduct(JxKet(1,0),JxKet(1,1))/2 + TensorProduct(JxKet(1,1),JxKet(1,1))/2
     assert TensorProduct(JxKet(1,1),JyKet(1,1)).rewrite('Jy') == I*TensorProduct(JyKet(1,1),JyKet(1,1))
     assert TensorProduct(JxKet(1,0),JyKet(1,1)).rewrite('Jy') == TensorProduct(JyKet(1,0),JyKet(1,1))
     assert TensorProduct(JxKet(1,-1),JyKet(1,1)).rewrite('Jy') == -I*TensorProduct(JyKet(1,-1),JyKet(1,1))
     assert TensorProduct(JzKet(1,1),JyKet(1,1)).rewrite('Jy') == \
-            -TensorProduct(JyKet(1,-1),JyKet(1,1))/2 - sqrt(2)*I*TensorProduct(JyKet(1,0),JyKet(1,1))/2 + TensorProduct(JyKet(1,1),JyKet(1,1))/2
+        -TensorProduct(JyKet(1,-1),JyKet(1,1))/2 - sqrt(2)*I*TensorProduct(JyKet(1,0),JyKet(1,1))/2 + TensorProduct(JyKet(1,1),JyKet(1,1))/2
     assert TensorProduct(JzKet(1,0),JyKet(1,1)).rewrite('Jy') == \
-            -sqrt(2)*I*TensorProduct(JyKet(1,-1),JyKet(1,1))/2 - sqrt(2)*I*TensorProduct(JyKet(1,1),JyKet(1,1))/2
+        -sqrt(2)*I*TensorProduct(JyKet(1,-1),JyKet(1,1))/2 - sqrt(2)*I*TensorProduct(JyKet(1,1),JyKet(1,1))/2
     assert TensorProduct(JzKet(1,-1),JyKet(1,1)).rewrite('Jy') == \
-            TensorProduct(JyKet(1,-1),JyKet(1,1))/2 - sqrt(2)*I*TensorProduct(JyKet(1,0),JyKet(1,1))/2 - TensorProduct(JyKet(1,1),JyKet(1,1))/2
+        TensorProduct(JyKet(1,-1),JyKet(1,1))/2 - sqrt(2)*I*TensorProduct(JyKet(1,0),JyKet(1,1))/2 - TensorProduct(JyKet(1,1),JyKet(1,1))/2
     assert TensorProduct(JxKet(1,1),JzKet(1,1)).rewrite('Jz') == \
-            TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2 + TensorProduct(JzKet(1,1),JzKet(1,1))/2
+        TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2 + TensorProduct(JzKet(1,1),JzKet(1,1))/2
     assert TensorProduct(JxKet(1,0),JzKet(1,1)).rewrite('Jz') == \
-            sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,1))/2 - sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,1))/2
+        sqrt(2)*TensorProduct(JzKet(1,-1),JzKet(1,1))/2 - sqrt(2)*TensorProduct(JzKet(1,1),JzKet(1,1))/2
     assert TensorProduct(JxKet(1,-1),JzKet(1,1)).rewrite('Jz') == \
-            TensorProduct(JzKet(1,-1),JzKet(1,1))/2 - sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2 + TensorProduct(JzKet(1,1),JzKet(1,1))/2
+        TensorProduct(JzKet(1,-1),JzKet(1,1))/2 - sqrt(2)*TensorProduct(JzKet(1,0),JzKet(1,1))/2 + TensorProduct(JzKet(1,1),JzKet(1,1))/2
     assert TensorProduct(JyKet(1,1),JzKet(1,1)).rewrite('Jz') == \
-            -TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*I*TensorProduct(JzKet(1,0),JzKet(1,1))/2 + TensorProduct(JzKet(1,1),JzKet(1,1))/2
+        -TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*I*TensorProduct(JzKet(1,0),JzKet(1,1))/2 + TensorProduct(JzKet(1,1),JzKet(1,1))/2
     assert TensorProduct(JyKet(1,0),JzKet(1,1)).rewrite('Jz') == \
-            sqrt(2)*I*TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*I*TensorProduct(JzKet(1,1),JzKet(1,1))/2
+        sqrt(2)*I*TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*I*TensorProduct(JzKet(1,1),JzKet(1,1))/2
     assert TensorProduct(JyKet(1,-1),JzKet(1,1)).rewrite('Jz') == \
-            TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*I*TensorProduct(JzKet(1,0),JzKet(1,1))/2 - TensorProduct(JzKet(1,1),JzKet(1,1))/2
+        TensorProduct(JzKet(1,-1),JzKet(1,1))/2 + sqrt(2)*I*TensorProduct(JzKet(1,0),JzKet(1,1))/2 - TensorProduct(JzKet(1,1),JzKet(1,1))/2
     # Symbolic
     assert TensorProduct(JyKet(j1,m1), JxKet(j2,m2)).rewrite('Jy') == \
-            TensorProduct(JyKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,0,0) * JyKet(j2,mi), (mi, -j2, j2)))
+        TensorProduct(JyKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,0,0) * JyKet(j2,mi), (mi, -j2, j2)))
     assert TensorProduct(JzKet(j1,m1), JxKet(j2,m2)).rewrite('Jz') == \
-            TensorProduct(JzKet(j1,m1), Sum(WignerD(j2,mi,m2,0,pi/2,0) * JzKet(j2,mi), (mi, -j2, j2)))
+        TensorProduct(JzKet(j1,m1), Sum(WignerD(j2,mi,m2,0,pi/2,0) * JzKet(j2,mi), (mi, -j2, j2)))
     assert TensorProduct(JxKet(j1,m1), JyKet(j2,m2)).rewrite('Jx') == \
-            TensorProduct(JxKet(j1,m1), Sum(WignerD(j2,mi,m2,0,0,pi/2) * JxKet(j2,mi), (mi, -j2, j2)))
+        TensorProduct(JxKet(j1,m1), Sum(WignerD(j2,mi,m2,0,0,pi/2) * JxKet(j2,mi), (mi, -j2, j2)))
     assert TensorProduct(JzKet(j1,m1), JyKet(j2,m2)).rewrite('Jz') == \
-            TensorProduct(JzKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,-pi/2,pi/2) * JzKet(j2,mi), (mi, -j2, j2)))
+        TensorProduct(JzKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,-pi/2,pi/2) * JzKet(j2,mi), (mi, -j2, j2)))
     assert TensorProduct(JxKet(j1,m1), JzKet(j2,m2)).rewrite('Jx') == \
-            TensorProduct(JxKet(j1,m1), Sum(WignerD(j2,mi,m2,0,3*pi/2,0) * JxKet(j2,mi), (mi, -j2, j2)))
+        TensorProduct(JxKet(j1,m1), Sum(WignerD(j2,mi,m2,0,3*pi/2,0) * JxKet(j2,mi), (mi, -j2, j2)))
     assert TensorProduct(JyKet(j1,m1), JzKet(j2,m2)).rewrite('Jy') == \
-            TensorProduct(JyKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,pi/2,pi/2) * JyKet(j2,mi), (mi, -j2, j2)))
+        TensorProduct(JyKet(j1,m1), Sum(WignerD(j2,mi,m2,3*pi/2,pi/2,pi/2) * JyKet(j2,mi), (mi, -j2, j2)))
     # Rewrite a coupled state
     # Numerical
     assert JyKetCoupled(0,0,S(1)/2,S(1)/2).rewrite('Jx') == \
@@ -828,6 +828,22 @@ def test_jx():
         Sum(hbar*mi*WignerD(j,mi,m,0,0,pi/2)*Sum(WignerD(j,mi1,mi,3*pi/2,0,0)*JyKet(j,mi1),(mi1,-j,j)),(mi,-j,j))
     assert qapply(Jx*JzKet(j,m)) == \
         hbar*sqrt(j**2+j-m**2-m)*JzKet(j,m+1)/2 + hbar*sqrt(j**2+j-m**2+m)*JzKet(j,m-1)/2
+    # Normal operators, coupled states
+    # Numerical
+    assert qapply(Jx*JxKetCoupled(1,1,1,1)) == \
+        hbar*JxKetCoupled(1,1,1,1)
+    assert qapply(Jx*JyKetCoupled(1,1,1,1)) == \
+        hbar*JyKetCoupled(1,1,1,1)
+    assert qapply(Jx*JzKetCoupled(1,1,1,1)) == \
+        sqrt(2)*hbar*JzKetCoupled(1,0,1,1)/2
+    # Symbolic
+    assert qapply(Jx*JxKetCoupled(j,m,j1,j2)) == \
+        hbar*m*JxKetCoupled(j,m,j1,j2)
+    assert qapply(Jx*JyKetCoupled(j,m,j1,j2)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,0,0,pi/2)*Sum(WignerD(j,mi1,mi,3*pi/2,0,0)*JyKetCoupled(j,mi1,j1,j2), (mi1,-j,j)), (mi,-j,j))
+    assert qapply(Jx*JzKetCoupled(j,m,j1,j2)) == \
+        hbar*sqrt(j**2+j-m**2-m)*JzKetCoupled(j,m+1,j1,j2)/2 + \
+        hbar*sqrt(j**2+j-m**2+m)*JzKetCoupled(j,m-1,j1,j2)/2
     # Normal operators, uncoupled states
     # Numerical
     assert qapply(Jx*TensorProduct(JxKet(1,1), JxKet(1,1))) == \
@@ -895,6 +911,22 @@ def test_jy():
     assert qapply(Jy*JyKet(j,m)) == hbar*m*JyKet(j,m)
     assert qapply(Jy*JzKet(j,m)) == \
         -hbar*I*sqrt(j**2+j-m**2-m)*JzKet(j,m+1)/2 + hbar*I*sqrt(j**2+j-m**2+m)*JzKet(j,m-1)/2
+    # Normal operators, coupled states
+    # Numerical
+    assert qapply(Jy*JxKetCoupled(1,1,1,1)) == \
+        hbar*JxKetCoupled(1,1,1,1)
+    assert qapply(Jy*JyKetCoupled(1,1,1,1)) == \
+        hbar*JyKetCoupled(1,1,1,1)
+    assert qapply(Jy*JzKetCoupled(1,1,1,1)) == \
+        sqrt(2)*hbar*I*JzKetCoupled(1,0,1,1)/2
+    # Symbolic
+    assert qapply(Jy*JxKetCoupled(j,m,j1,j2)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,0,0)*Sum(WignerD(j,mi1,mi,0,0,pi/2)*JxKetCoupled(j,mi1,j1,j2), (mi1,-j,j)), (mi,-j,j))
+    assert qapply(Jy*JyKetCoupled(j,m,j1,j2)) == \
+        hbar*m*JyKetCoupled(j,m,j1,j2)
+    assert qapply(Jy*JzKetCoupled(j,m,j1,j2)) == \
+        -hbar*I*sqrt(j**2+j-m**2-m)*JzKetCoupled(j,m+1,j1,j2)/2 + \
+        hbar*I*sqrt(j**2+j-m**2+m)*JzKetCoupled(j,m-1,j1,j2)/2
     # Normal operators, uncoupled states
     # Numerical
     assert qapply(Jy*TensorProduct(JxKet(1,1), JxKet(1,1))) == \
@@ -961,6 +993,21 @@ def test_jz():
     assert qapply(Jz*JyKet(j,m)) == \
         Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j,mi1,mi,3*pi/2,pi/2,pi/2)*JyKet(j,mi1),(mi1,-j,j)), (mi,-j,j))
     assert qapply(Jz*JzKet(j,m)) == hbar*m*JzKet(j,m)
+    # Normal operators, coupled states
+    # Numerical
+    assert qapply(Jz*JxKetCoupled(1,1,1,1)) == \
+        -sqrt(2)*hbar*JxKetCoupled(1,0,1,1)/2
+    assert qapply(Jz*JyKetCoupled(1,1,1,1)) == \
+        -sqrt(2)*hbar*I*JyKetCoupled(1,0,1,1)/2
+    assert qapply(Jz*JzKetCoupled(1,1,1,1)) == \
+        hbar*JzKetCoupled(1,1,1,1)
+    # Symbolic
+    assert qapply(Jz*JxKetCoupled(j,m,j1,j2)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,0,pi/2,0)*Sum(WignerD(j,mi1,mi,0,3*pi/2,0)*JxKetCoupled(j,mi1,j1,j2), (mi1,-j,j)), (mi,-j,j))
+    assert qapply(Jz*JyKetCoupled(j,m,j1,j2)) == \
+        Sum(hbar*mi*WignerD(j,mi,m,3*pi/2,-pi/2,pi/2)*Sum(WignerD(j,mi1,mi,3*pi/2,pi/2,pi/2)*JyKetCoupled(j,mi1,j1,j2), (mi1,-j,j)), (mi,-j,j))
+    assert qapply(Jz*JzKetCoupled(j,m,j1,j2)) == \
+        hbar*m*JzKetCoupled(j,m,j1,j2)
     # Normal operators, uncoupled states
     # Numerical
     assert qapply(Jz*TensorProduct(JxKet(1,1), JxKet(1,1))) == \


### PR DESCRIPTION
The first commit takes care of some previously XFAIL tests using qapply to evaluate a spin operator with a symbolic state that requires a sum over Wigner-D functions to evaluate. This defines a method which deals with spin operators applied to sums. It also checks that the _apply_op method is doing something before returning it.

The second commit deals with allowing the evaluation of spin operators on coupled spin states, improving the implementation of the code and implementing tests for numerical and symbolic cases.
