### PR TITLE
Quantum printing tests

### DIFF
--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -136,6 +136,6 @@ class AntiCommutator(Expr):
         return pform
 
     def _latex(self, printer, *args):
-        return "\\left{}%s,%s\\right}" % tuple([
+        return "\\left\\{%s,%s\\right\\}" % tuple([
             printer._print(arg, *args) for arg in self.args])
 

--- a/sympy/physics/quantum/anticommutator.py
+++ b/sympy/physics/quantum/anticommutator.py
@@ -122,8 +122,9 @@ class AntiCommutator(Expr):
         return AntiCommutator(Dagger(self.args[0]), Dagger(self.args[1]))
 
     def _sympyrepr(self, printer, *args):
-        return "%s(%s,%s)" % (self.__class__.__name__, self.args[0],\
-        self.args[1])
+        return "%s(%s,%s)" % (
+            self.__class__.__name__, printer._print(self.args[0]), printer._print(self.args[1])
+        )
 
     def _sympystr(self, printer, *args):
         return "{%s,%s}" % (self.args[0], self.args[1])

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -45,8 +45,7 @@ class Wigner3j(Expr):
         >>> from sympy.physics.quantum.cg import Wigner3j
         >>> w3j = Wigner3j(6,0,4,0,2,0)
         >>> w3j
-        (6, 4, 2)
-        (0, 0, 0)
+        Wigner3j(6,4,2,0,0,0)
         >>> w3j.doit()
         sqrt(715)/143
 

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -86,18 +86,12 @@ class Wigner3j(Expr):
     def is_symbolic(self):
         return not all([arg.is_number for arg in self.args])
 
-    # This is modified from the _print_Matrix method
     def _sympystr(self, printer, *args):
-        res = [[printer._print(self.j1), printer._print(self.j2), printer._print(self.j3)], \
-            [printer._print(self.m1), printer._print(self.m2), printer._print(self.m3)]]
-        maxw = [-1] * 3
-        for j in range(3):
-            maxw[j] = max([ len(res[i][j]) for i in range(2) ])
-        for i, row in enumerate(res):
-            for j, elem in enumerate(row):
-                row[j] = elem.rjust(maxw[j])
-            res[i] = "(" + ", ".join(row) + ")"
-        return '\n'.join(res)
+        return '%s(%s,%s,%s,%s,%s,%s)' % (
+            self.__class__.__name__,
+            printer._print(self.j1), printer._print(self.j2), printer._print(self.j3),
+            printer._print(self.m1), printer._print(self.m2), printer._print(self.m3)
+        )
 
     # This is modified from the _print_Matrix method
     def _pretty(self, printer, *args):
@@ -187,9 +181,10 @@ class CG(Wigner3j):
         return clebsch_gordan(self.j1,self.j2, self.j3, self.m1, self.m2, self.m3)
 
     def _sympystr(self, printer, *args):
-        return 'CG(%s, %s, %s, %s, %s, %s)' % \
-            (printer._print(self.j1), printer._print(self.m1), printer._print(self.j2), \
-            printer._print(self.m2), printer._print(self.j3), printer._print(self.m3))
+        return 'CG(%s, %s, %s, %s, %s, %s)' % (
+            printer._print(self.j1), printer._print(self.m1), printer._print(self.j2), \
+            printer._print(self.m2), printer._print(self.j3), printer._print(self.m3)
+        )
 
     def _pretty(self, printer, *args):
         bot = printer._print(self.j1)

--- a/sympy/physics/quantum/commutator.py
+++ b/sympy/physics/quantum/commutator.py
@@ -175,8 +175,9 @@ class Commutator(Expr):
         return Commutator(Dagger(self.args[1]), Dagger(self.args[0]))
 
     def _sympyrepr(self, printer, *args):
-        return "%s(%s,%s)" % (self.__class__.__name__, self.args[0],\
-        self.args[1])
+        return "%s(%s,%s)" % (
+            self.__class__.__name__, printer._print(self.args[0]), printer._print(self.args[1])
+        )
 
     def _sympystr(self, printer, *args):
         return "[%s,%s]" % (self.args[0], self.args[1])

--- a/sympy/physics/quantum/tests/test_innerproduct.py
+++ b/sympy/physics/quantum/tests/test_innerproduct.py
@@ -68,10 +68,3 @@ def test_doit():
     assert InnerProduct(b,f).doit() == I
     assert InnerProduct(Dagger(f),Dagger(b)).doit() == -I
     assert InnerProduct(Dagger(f),f).doit() == Integer(1)
-
-
-def test_printing():
-    psi = Ket('psi')
-    ip = Dagger(psi)*psi
-    assert pretty(ip, use_unicode=True) == u'\u27e8\u03c8\u2758\u03c8\u27e9'
-    assert latex(ip) == r"\left\langle \psi \right. {\left|\psi\right\rangle }"

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -50,33 +50,34 @@ def upretty(expr):
     """Unicode pretty-printing"""
     return xpretty(expr, use_unicode=True, wrap_line=False)
 
-A, B = symbols('A,B', commutative=False)
 
 def test_anticommutator():
+    A = Operator('A')
+    B = Operator('B')
     ac = AntiCommutator(A,B)
     ac_tall = AntiCommutator(A**2,B)
     assert str(ac) == '{A,B}'
     assert pretty(ac) == '{A,B}'
     assert upretty(ac) == u'{A,B}'
     assert latex(ac) == r'\left\{A,B\right\}'
-    sT(ac, "AntiCommutator(A,B)")
-    assert str(ac_tall) == '{B,A**2}'
+    sT(ac, "AntiCommutator(Operator(Symbol('A')),Operator(Symbol('B')))")
+    assert str(ac_tall) == '{A**2,B}'
     ascii_str = \
 """\
-/   2\\\n\
-<B,A >\n\
+/ 2  \\\n\
+<A ,B>\n\
 \\    /\
 """
     ucode_str = \
 u"""\
-⎧   2⎫\n\
-⎨B,A ⎬\n\
+⎧ 2  ⎫\n\
+⎨A ,B⎬\n\
 ⎩    ⎭\
 """
     assert pretty(ac_tall) == ascii_str
     assert upretty(ac_tall) == ucode_str
-    assert latex(ac_tall) == r'\left\{B,A^{2}\right\}'
-    sT(ac_tall, "AntiCommutator(B,A**2)")
+    assert latex(ac_tall) == r'\left\{\left(A\right)^{2},B\right\}'
+    sT(ac_tall, "AntiCommutator(Pow(Operator(Symbol('A')), Integer(2)),Operator(Symbol('B')))")
 
 def test_cg():
     cg = CG(1,2,3,4,5,6)
@@ -98,9 +99,7 @@ C       \n\
     assert latex(cg) == r'C^{5,6}_{1,2,3,4}'
     sT(cg, "CG(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6))")
     wigner3j = Wigner3j(1,2,3,4,5,6)
-    assert str(wigner3j) == '\
-(1, 3, 5)\n\
-(2, 4, 6)'
+    assert str(wigner3j) == 'Wigner3j(1,3,5,2,4,6)'
     ascii_str = \
 """\
 /1  3  5\\\n\
@@ -119,28 +118,30 @@ u"""\
     sT(wigner3j, "Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6))")
 
 def test_commutator():
+    A = Operator('A')
+    B = Operator('B')
     c = Commutator(A,B)
     c_tall = Commutator(A**2,B)
     assert str(c) == '[A,B]'
     assert pretty(c) == '[A,B]'
     assert upretty(c) == u'[A,B]'
     assert latex(c) == r'\left[A,B\right]'
-    sT(c, "Commutator(A,B)")
-    assert str(c_tall) == '-[B,A**2]'
+    sT(c, "Commutator(Operator(Symbol('A')),Operator(Symbol('B')))")
+    assert str(c_tall) == '[A**2,B]'
     ascii_str = \
 """\
- [   2]\n\
--[B,A ]\
+[ 2  ]\n\
+[A ,B]\
 """
     ucode_str = \
 u"""\
- ⎡   2⎤\n\
--⎣B,A ⎦\
+⎡ 2  ⎤\n\
+⎣A ,B⎦\
 """
     assert pretty(c_tall) == ascii_str
     assert upretty(c_tall) == ucode_str
-    assert latex(c_tall) == r'- \left[B,A^{2}\right]'
-    sT(c_tall, "Mul(Integer(-1), Commutator(B,A**2))")
+    assert latex(c_tall) == r'\left[\left(A\right)^{2},B\right]'
+    sT(c_tall, "Commutator(Pow(Operator(Symbol('A')), Integer(2)),Operator(Symbol('B')))")
 
 def test_constants():
     assert str(hbar) == 'hbar'
@@ -669,27 +670,7 @@ def test_tensorproduct():
     assert latex(tp) == r'{{\left|1,1\right\rangle }}\otimes {{\left|1,0\right\rangle }}'
     sT(tp, "TensorProduct(JzKet(Integer(1),Integer(1)), JzKet(Integer(1),Integer(0)))")
 
-@XFAIL
-def test_big_expr_failing_srepr():
-    f = Function('f')
-    x = symbols('x')
-    e1 = Dagger(AntiCommutator(Operator('A')+Operator('B'),Pow(DifferentialOperator(Derivative(f(x), x), f(x)),3))*TensorProduct(Jz**2,Operator('A')+Operator('B')))*(JzBra(1,0)+JzBra(1,1))*(JzKet(0,0)+JzKet(1,-1))
-    sT(e1,"Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x'))))**3,Dagger(Operator('A')) + Dagger(Operator('B'))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
-    e2 = Commutator(Jz**2,Operator('A')+Operator('B'))*AntiCommutator(Dagger(Operator('C')*Operator('D')),Operator('E').inv()**2)*Dagger(Commutator(Jz,J2))
-    sT(e2, "Mul(Commutator(JzOp(Symbol('J'))**2,Operator(Symbol('A')) + Operator(Symbol('B'))), AntiCommutator(Operator(Symbol('E'))**(-2),Dagger(Operator(Symbol('D')))*Dagger(Operator(Symbol('C')))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
-    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,1,1)+JzKetCoupled(1,0,1,1),JzKetCoupled(1,-1,1,1))
-    sT(e3,"Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Dagger(Operator('B')) + Operator('A'),Operator('C') + Operator('D')), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Integer(1),Integer(1)), JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))), JzKetCoupled(Integer(1),Integer(-1),Integer(1),Integer(1))))")
-
-@XFAIL
-def test_big_expr_failing_str():
-    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,1,1)+JzKetCoupled(1,0,1,1),JzKetCoupled(1,-1,1,1))
-    assert str(e3) == "\
-(1, 3, 5)                                                                               \n\
-(2, 4, 6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,1,1> + |1,1,1,1>)x|1,-1,1,1>"
-
 def test_big_expr():
-    # Some srepr stuff looks pretty broken, inner-most stuff is just being printed
-    #I've written what the srepr string should be and tested that it evaluates to the correct expression, see the above XFAIL test for commented out sT tests
     f = Function('f')
     x = symbols('x')
     e1 = Dagger(AntiCommutator(Operator('A')+Operator('B'),Pow(DifferentialOperator(Derivative(f(x), x), f(x)),3))*TensorProduct(Jz**2,Operator('A')+Operator('B')))*(JzBra(1,0)+JzBra(1,1))*(JzKet(0,0)+JzKet(1,-1))
@@ -716,8 +697,7 @@ u"""\
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )})^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
-    #sT(e1, '')
-    assert e1 == eval("Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x'))))**3,Dagger(Operator('A')) + Dagger(Operator('B'))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
+    sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
     ascii_str = \
 u"""\
@@ -734,10 +714,8 @@ u"""\
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
     assert latex(e2) == r'\left[\left(J_z\right)^{2},A + B\right] \left\{\left(E\right)^{-2},D^{\dag} C^{\dag}\right\} \left[J^2,J_z\right]'
-    #sT(e2, '')
-    assert e2 == eval("Mul(Commutator(JzOp(Symbol('J'))**2,Operator(Symbol('A')) + Operator(Symbol('B'))), AntiCommutator(Operator(Symbol('E'))**(-2),Dagger(Operator(Symbol('D')))*Dagger(Operator(Symbol('C')))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
-    # Broken, see test_big_expr_failing_str
-    #assert str(e3) == ""
+    sT(e2, "Mul(Commutator(Pow(JzOp(Symbol('J')), Integer(2)),Add(Operator(Symbol('A')), Operator(Symbol('B')))), AntiCommutator(Pow(Operator(Symbol('E')), Integer(-2)),Mul(Dagger(Operator(Symbol('D'))), Dagger(Operator(Symbol('C'))))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
+    assert str(e3) == "Wigner3j(1,3,5,2,4,6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,1,1> + |1,1,1,1>)x|1,-1,1,1>"
     ascii_str = \
 u"""\
           [ †          ]  /   2     \\                                               \n\
@@ -755,8 +733,7 @@ u"""\
     assert pretty(e3) == ascii_str
     assert upretty(e3) == ucode_str
     assert latex(e3) == r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,1,1\right\rangle } + {\left|1,1,1,1\right\rangle }}\right)\otimes {{\left|1,-1,1,1\right\rangle }}'
-    #sT(e3, '')
-    assert e3 == eval("Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Dagger(Operator('B')) + Operator('A'),Operator('C') + Operator('D')), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Integer(1),Integer(1)), JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))), JzKetCoupled(Integer(1),Integer(-1),Integer(1),Integer(1))))")
+    sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Integer(1),Integer(1)), JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))), JzKetCoupled(Integer(1),Integer(-1),Integer(1),Integer(1))))")
     assert str(e4) == '(C(1)*C(2)+F**2)*(L2([0, oo))+H)'
     ascii_str = \
 u"""\

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -249,7 +249,7 @@ U \n\
     assert pretty(g4) == ascii_str
     assert upretty(g4) == ucode_str
     assert latex(g4) == r'U_{0}'
-    sT(g4, "UGate((Integer(0),),Matrix([[Symbol('a'), Symbol('b')], [Symbol('c'), Symbol('d')]]))")
+    sT(g4, "UGate(Tuple(Integer(0)),Matrix([[Symbol('a'), Symbol('b')], [Symbol('c'), Symbol('d')]]))")
 
 def test_hilbert():
     h1 = HilbertSpace()

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -347,7 +347,7 @@ def test_innerproduct():
     ip1 = InnerProduct(Bra(), Ket())
     ip2 = InnerProduct(TimeDepBra(),TimeDepKet())
     ip3 = InnerProduct(JzBra(1,1),JzKet(1,1))
-    ip4 = InnerProduct(JzBraCoupled(1,1,1,1),JzKetCoupled(1,1,1,1))
+    ip4 = InnerProduct(JzBraCoupled(1, 1, (1,1)),JzKetCoupled(1, 1, (1,1)))
     ip_tall1 = InnerProduct(Bra(x/2), Ket(x/2))
     ip_tall2 = InnerProduct(Bra(x), Ket(x/2))
     ip_tall3 = InnerProduct(Bra(x/2), Ket(x))
@@ -366,11 +366,11 @@ def test_innerproduct():
     assert upretty(ip3) == u'⟨1,1❘1,1⟩'
     assert latex(ip3) == r'\left\langle 1,1 \right. {\left|1,1\right\rangle }'
     sT(ip3, "InnerProduct(JzBra(Integer(1),Integer(1)),JzKet(Integer(1),Integer(1)))")
-    assert str(ip4) == "<1,1,1,1|1,1,1,1>"
-    assert pretty(ip4) == u'⟨1,1,1,1❘1,1,1,1⟩'
-    assert upretty(ip4) == u'⟨1,1,1,1❘1,1,1,1⟩'
-    assert latex(ip4) == r'\left\langle 1,1,1,1 \right. {\left|1,1,1,1\right\rangle }'
-    sT(ip4, "InnerProduct(JzBraCoupled(Integer(1),Integer(1),Integer(1),Integer(1)),JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1)))")
+    assert str(ip4) == "<1,1,j1=1,j2=1|1,1,j1=1,j2=1>"
+    assert pretty(ip4) == u'⟨1,1,j1=1,j2=1❘1,1,j1=1,j2=1⟩'
+    assert upretty(ip4) == u'⟨1,1,j₁=1,j₂=1❘1,1,j₁=1,j₂=1⟩'
+    assert latex(ip4) == r'\left\langle 1,1,j_{1}=1,j_{2}=1 \right. {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }'
+    sT(ip4, "InnerProduct(JzBraCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))),JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))))")
     assert str(ip_tall1) == '<x/2|x/2>'
     ascii_str = \
 u"""\
@@ -502,10 +502,12 @@ def test_qubit():
     sT(q2, "IntQubit(8)")
 
 def test_spin():
-    ket = JzKet(1,1)
-    bra = JzBra(1,1)
-    cket = JzKetCoupled(1,1,1,1)
-    cbra = JzBraCoupled(1,1,1,1)
+    ket = JzKet(1,0)
+    bra = JzBra(1,0)
+    cket = JzKetCoupled(1, 0, (1, 2))
+    cbra = JzBraCoupled(1, 0, (1, 2))
+    cket_big = JzKetCoupled(1, 0, (1,2,3))
+    cbra_big = JzBraCoupled(1, 0, (1,2,3))
     rot = Rotation(1,2,3)
     bigd = WignerD(1,2,3,4,5,6)
     smalld = WignerD(1,2,3,0,4,0)
@@ -539,26 +541,38 @@ J \n\
     assert upretty(Jz) == ucode_str
     assert latex(Jz) == 'J_z'
     sT(Jz, "JzOp(Symbol('J'))")
-    assert str(ket) == '|1,1>'
-    assert pretty(ket) == u'❘1,1⟩'
-    assert upretty(ket) == u'❘1,1⟩'
-    assert latex(ket) == r'{\left|1,1\right\rangle }'
-    sT(ket, "JzKet(Integer(1),Integer(1))")
-    assert str(bra) == '<1,1|'
-    assert pretty(bra) == u'⟨1,1❘'
-    assert upretty(bra) == u'⟨1,1❘'
-    assert latex(bra) == r'{\left\langle 1,1\right|}'
-    sT(bra, "JzBra(Integer(1),Integer(1))")
-    assert str(cket) == '|1,1,1,1>'
-    assert pretty(cket) == u'❘1,1,1,1⟩'
-    assert upretty(cket) == u'❘1,1,1,1⟩'
-    assert latex(cket) == r'{\left|1,1,1,1\right\rangle }'
-    sT(cket, "JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))")
-    assert str(cbra) == '<1,1,1,1|'
-    assert pretty(cbra) == u'⟨1,1,1,1❘'
-    assert upretty(cbra) == u'⟨1,1,1,1❘'
-    assert latex(cbra) == r'{\left\langle 1,1,1,1\right|}'
-    sT(cbra, "JzBraCoupled(Integer(1),Integer(1),Integer(1),Integer(1))")
+    assert str(ket) == '|1,0>'
+    assert pretty(ket) == u'❘1,0⟩'
+    assert upretty(ket) == u'❘1,0⟩'
+    assert latex(ket) == r'{\left|1,0\right\rangle }'
+    sT(ket, "JzKet(Integer(1),Integer(0))")
+    assert str(bra) == '<1,0|'
+    assert pretty(bra) == u'⟨1,0❘'
+    assert upretty(bra) == u'⟨1,0❘'
+    assert latex(bra) == r'{\left\langle 1,0\right|}'
+    sT(bra, "JzBra(Integer(1),Integer(0))")
+    assert str(cket) == '|1,0,j1=1,j2=2>'
+    assert pretty(cket) == u'❘1,0,j1=1,j2=2⟩'
+    assert upretty(cket) == u'❘1,0,j₁=1,j₂=2⟩'
+    assert latex(cket) == r'{\left|1,0,j_{1}=1,j_{2}=2\right\rangle }'
+    sT(cket, "JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))")
+    assert str(cbra) == '<1,0,j1=1,j2=2|'
+    assert pretty(cbra) == u'⟨1,0,j1=1,j2=2❘'
+    assert upretty(cbra) == u'⟨1,0,j₁=1,j₂=2❘'
+    assert latex(cbra) == r'{\left\langle 1,0,j_{1}=1,j_{2}=2\right|}'
+    sT(cbra, "JzBraCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))")
+    assert str(cket_big) == '|1,0,j1=1,j2=2,j3=3,j(1,2)=3>'
+    # TODO: Fix non-unicode pretty printing
+    # i.e. j1,2 -> j(1,2)
+    assert pretty(cket_big) == u'❘1,0,j1=1,j2=2,j3=3,j1,2=3⟩'
+    assert upretty(cket_big) == u'❘1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3⟩'
+    assert latex(cket_big) == r'{\left|1,0,j_{1}=1,j_{2}=2,j_{3}=3,j_{1,2}=3\right\rangle }'
+    sT(cket_big, "JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2), Integer(3)),Tuple(Tuple(Integer(1), Integer(2), Integer(3)), Tuple(Integer(1), Integer(3), Integer(1))))")
+    assert str(cbra_big) == '<1,0,j1=1,j2=2,j3=3,j(1,2)=3|'
+    assert pretty(cbra_big) == u'⟨1,0,j1=1,j2=2,j3=3,j1,2=3❘'
+    assert upretty(cbra_big) == u'⟨1,0,j₁=1,j₂=2,j₃=3,j₁,₂=3❘'
+    assert latex(cbra_big) == r'{\left\langle 1,0,j_{1}=1,j_{2}=2,j_{3}=3,j_{1,2}=3\right|}'
+    sT(cbra_big, "JzBraCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(2), Integer(3)),Tuple(Tuple(Integer(1), Integer(2), Integer(3)), Tuple(Integer(1), Integer(3), Integer(1))))")
     assert str(rot) == 'R(1,2,3)'
     assert pretty(rot) == u'ℛ (1,2,3)'
     assert upretty(rot) == u'ℛ (1,2,3)'
@@ -675,7 +689,7 @@ def test_big_expr():
     x = symbols('x')
     e1 = Dagger(AntiCommutator(Operator('A')+Operator('B'),Pow(DifferentialOperator(Derivative(f(x), x), f(x)),3))*TensorProduct(Jz**2,Operator('A')+Operator('B')))*(JzBra(1,0)+JzBra(1,1))*(JzKet(0,0)+JzKet(1,-1))
     e2 = Commutator(Jz**2,Operator('A')+Operator('B'))*AntiCommutator(Dagger(Operator('C')*Operator('D')),Operator('E').inv()**2)*Dagger(Commutator(Jz,J2))
-    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,1,1)+JzKetCoupled(1,0,1,1),JzKetCoupled(1,-1,1,1))
+    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,(1,1))+JzKetCoupled(1,0,(1,1)),JzKetCoupled(1,-1,(1,1)))
     e4 = (ComplexSpace(1)*ComplexSpace(2)+FockSpace()**2)*(L2(Interval(0,oo))+HilbertSpace())
     assert str(e1) == '(Jz**2)x(Dagger(A) + Dagger(B))*{Dagger(DifferentialOperator(Derivative(f(x), x),f(x)))**3,Dagger(A) + Dagger(B)}*(<1,0| + <1,1|)*(|0,0> + |1,-1>)'
     ascii_str = \
@@ -715,25 +729,25 @@ u"""\
     assert upretty(e2) == ucode_str
     assert latex(e2) == r'\left[\left(J_z\right)^{2},A + B\right] \left\{\left(E\right)^{-2},D^{\dag} C^{\dag}\right\} \left[J^2,J_z\right]'
     sT(e2, "Mul(Commutator(Pow(JzOp(Symbol('J')), Integer(2)),Add(Operator(Symbol('A')), Operator(Symbol('B')))), AntiCommutator(Pow(Operator(Symbol('E')), Integer(-2)),Mul(Dagger(Operator(Symbol('D'))), Dagger(Operator(Symbol('C'))))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
-    assert str(e3) == "Wigner3j(1,3,5,2,4,6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,1,1> + |1,1,1,1>)x|1,-1,1,1>"
+    assert str(e3) == "Wigner3j(1,3,5,2,4,6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,j1=1,j2=1> + |1,1,j1=1,j2=1>)x|1,-1,j1=1,j2=1>"
     ascii_str = \
 u"""\
-          [ †          ]  /   2     \\                                               \n\
-/1  3  5\\*[B  + A,C + D]⨂ |- J  + J |*❘1,0⟩⟨1,1❘*(❘1,0,1,1⟩ + ❘1,1,1,1⟩)⨂ ❘1,-1,1,1⟩\n\
-|       |                 \\        z/                                               \n\
-\\2  4  6/                                                                           \
+          [ †          ]  /   2     \\                                                                 \n\
+/1  3  5\\*[B  + A,C + D]⨂ |- J  + J |*❘1,0⟩⟨1,1❘*(❘1,0,j1=1,j2=1⟩ + ❘1,1,j1=1,j2=1⟩)⨂ ❘1,-1,j1=1,j2=1⟩\n\
+|       |                 \\        z/                                                                 \n\
+\\2  4  6/                                                                                             \
 """
     ucode_str = \
 u"""\
-          ⎡ †          ⎤  ⎛   2     ⎞                                               \n\
-⎛1  3  5⎞⋅⎣B  + A,C + D⎦⨂ ⎜- J  + J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,1,1⟩ + ❘1,1,1,1⟩)⨂ ❘1,-1,1,1⟩\n\
-⎜       ⎟                 ⎝        z⎠                                               \n\
-⎝2  4  6⎠                                                                           \
+          ⎡ †          ⎤  ⎛   2     ⎞                                                                 \n\
+⎛1  3  5⎞⋅⎣B  + A,C + D⎦⨂ ⎜- J  + J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,j₁=1,j₂=1⟩ + ❘1,1,j₁=1,j₂=1⟩)⨂ ❘1,-1,j₁=1,j₂=1⟩\n\
+⎜       ⎟                 ⎝        z⎠                                                                 \n\
+⎝2  4  6⎠                                                                                             \
 """
     assert pretty(e3) == ascii_str
     assert upretty(e3) == ucode_str
-    assert latex(e3) == r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,1,1\right\rangle } + {\left|1,1,1,1\right\rangle }}\right)\otimes {{\left|1,-1,1,1\right\rangle }}'
-    sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Integer(1),Integer(1)), JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))), JzKetCoupled(Integer(1),Integer(-1),Integer(1),Integer(1))))")
+    assert latex(e3) == r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,j_{1}=1,j_{2}=1\right\rangle } + {\left|1,1,j_{1}=1,j_{2}=1\right\rangle }}\right)\otimes {{\left|1,-1,j_{1}=1,j_{2}=1\right\rangle }}'
+    sT(e3, "Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Add(Dagger(Operator(Symbol('B'))), Operator(Symbol('A'))),Add(Operator(Symbol('C')), Operator(Symbol('D')))), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1)))), JzKetCoupled(Integer(1),Integer(1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))), JzKetCoupled(Integer(1),Integer(-1),Tuple(Integer(1), Integer(1)),Tuple(Tuple(Integer(1), Integer(2), Integer(1))))))")
     assert str(e4) == '(C(1)*C(2)+F**2)*(L2([0, oo))+H)'
     ascii_str = \
 u"""\

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -715,7 +715,7 @@ u"""\
 """
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
-    assert latex(e1) == r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left{}\left(DifferentialOperator(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )})^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+    assert latex(e1) == r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )})^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
     #sT(e1, '')
     assert e1 == eval("Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x'))))**3,Dagger(Operator('A')) + Dagger(Operator('B'))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
@@ -733,7 +733,7 @@ u"""\
 """
     assert pretty(e2) == ascii_str
     assert upretty(e2) == ucode_str
-    assert latex(e2) == r'\left[\left(J_z\right)^{2},A + B\right] \left{}\left(E\right)^{-2},D^{\dag} C^{\dag}\right} \left[J^2,J_z\right]'
+    assert latex(e2) == r'\left[\left(J_z\right)^{2},A + B\right] \left\{\left(E\right)^{-2},D^{\dag} C^{\dag}\right\} \left[J^2,J_z\right]'
     #sT(e2, '')
     assert e2 == eval("Mul(Commutator(JzOp(Symbol('J'))**2,Operator(Symbol('A')) + Operator(Symbol('B'))), AntiCommutator(Operator(Symbol('E'))**(-2),Dagger(Operator(Symbol('D')))*Dagger(Operator(Symbol('C')))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
     # Broken, see test_big_expr_failing_str

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -1,0 +1,774 @@
+# -*- encoding: utf-8 -*-
+"""
+TODO:
+* Fix problems with Issue 2510, ascii printing using unicode
+* Address Issue 2251, printing of spin states
+"""
+from sympy.physics.quantum.anticommutator import AntiCommutator
+from sympy.physics.quantum.cg import CG, Wigner3j
+from sympy.physics.quantum.commutator import Commutator
+from sympy.physics.quantum.constants import hbar
+from sympy.physics.quantum.dagger import Dagger
+from sympy.physics.quantum.gate import CGate, CNotGate, IdentityGate, UGate, XGate
+from sympy.physics.quantum.hilbert import ComplexSpace, FockSpace, HilbertSpace, L2
+from sympy.physics.quantum.innerproduct import InnerProduct
+from sympy.physics.quantum.operator import Operator, OuterProduct, DifferentialOperator
+from sympy.physics.quantum.qexpr import QExpr
+from sympy.physics.quantum.qubit import Qubit, IntQubit
+from sympy.physics.quantum.spin import Jz, J2, JzBra, JzBraCoupled, JzKet, JzKetCoupled, Rotation, WignerD
+from sympy.physics.quantum.state import Bra, Ket, TimeDepBra, TimeDepKet
+from sympy.physics.quantum.tensorproduct import TensorProduct
+
+from sympy import Derivative, Function, Interval, Matrix, Pow, S, symbols, Symbol, oo
+from sympy.utilities.pytest import XFAIL
+
+# Imports used in srepr strings
+from sympy.physics.quantum.constants import HBar
+from sympy.physics.quantum.hilbert import DirectSumHilbertSpace, TensorProductHilbertSpace, TensorPowerHilbertSpace
+from sympy.physics.quantum.spin import JzOp, J2Op
+from sympy import Add, Integer, Mul, Rational, Tuple
+
+from sympy.printing import srepr
+from sympy.printing.pretty import pretty as xpretty
+from sympy.printing.latex import latex
+
+ENV = {}
+exec "from sympy import *" in ENV
+def sT(expr, string):
+    """
+    sT := sreprTest
+    from sympy/printing/tests/test_repr.py
+    """
+    assert srepr(expr) == string
+    assert eval(string) == expr
+
+def pretty(expr):
+    """ASCII pretty-printing"""
+    return xpretty(expr, use_unicode=False, wrap_line=False)
+
+def upretty(expr):
+    """Unicode pretty-printing"""
+    return xpretty(expr, use_unicode=True, wrap_line=False)
+
+A, B = symbols('A,B', commutative=False)
+
+def test_anticommutator():
+    ac = AntiCommutator(A,B)
+    ac_tall = AntiCommutator(A**2,B)
+    assert str(ac) == '{A,B}'
+    assert pretty(ac) == '{A,B}'
+    assert upretty(ac) == u'{A,B}'
+    assert latex(ac) == r'\left\{A,B\right\}'
+    sT(ac, "AntiCommutator(A,B)")
+    assert str(ac_tall) == '{B,A**2}'
+    ascii_str = \
+"""\
+/   2\\\n\
+<B,A >\n\
+\\    /\
+"""
+    ucode_str = \
+u"""\
+⎧   2⎫\n\
+⎨B,A ⎬\n\
+⎩    ⎭\
+"""
+    assert pretty(ac_tall) == ascii_str
+    assert upretty(ac_tall) == ucode_str
+    assert latex(ac_tall) == r'\left\{B,A^{2}\right\}'
+    sT(ac_tall, "AntiCommutator(B,A**2)")
+
+def test_cg():
+    cg = CG(1,2,3,4,5,6)
+    assert str(cg) == 'CG(1, 2, 3, 4, 5, 6)'
+    ascii_str = \
+"""\
+ 5,6    \n\
+C       \n\
+ 1,2,3,4\
+"""
+    ucode_str = \
+u"""\
+ 5,6    \n\
+C       \n\
+ 1,2,3,4\
+"""
+    assert pretty(cg) == ascii_str
+    assert upretty(cg) == ucode_str
+    assert latex(cg) == r'C^{5,6}_{1,2,3,4}'
+    sT(cg, "CG(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6))")
+    wigner3j = Wigner3j(1,2,3,4,5,6)
+    assert str(wigner3j) == '\
+(1, 3, 5)\n\
+(2, 4, 6)'
+    ascii_str = \
+"""\
+/1  3  5\\\n\
+|       |\n\
+\\2  4  6/\
+"""
+    ucode_str = \
+u"""\
+⎛1  3  5⎞\n\
+⎜       ⎟\n\
+⎝2  4  6⎠\
+"""
+    assert pretty(wigner3j) == ascii_str
+    assert upretty(wigner3j) == ucode_str
+    assert latex(wigner3j) == r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right)'
+    sT(wigner3j, "Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6))")
+
+def test_commutator():
+    c = Commutator(A,B)
+    c_tall = Commutator(A**2,B)
+    assert str(c) == '[A,B]'
+    assert pretty(c) == '[A,B]'
+    assert upretty(c) == u'[A,B]'
+    assert latex(c) == r'\left[A,B\right]'
+    sT(c, "Commutator(A,B)")
+    assert str(c_tall) == '-[B,A**2]'
+    ascii_str = \
+"""\
+ [   2]\n\
+-[B,A ]\
+"""
+    ucode_str = \
+u"""\
+ ⎡   2⎤\n\
+-⎣B,A ⎦\
+"""
+    assert pretty(c_tall) == ascii_str
+    assert upretty(c_tall) == ucode_str
+    assert latex(c_tall) == r'- \left[B,A^{2}\right]'
+    sT(c_tall, "Mul(Integer(-1), Commutator(B,A**2))")
+
+def test_constants():
+    assert str(hbar) == 'hbar'
+    assert pretty(hbar) == u'ℏ'
+    assert upretty(hbar) == u'ℏ'
+    assert latex(hbar) == r'\hbar'
+    sT(hbar, "HBar()")
+
+def test_dagger():
+    x = symbols('x')
+    expr = Dagger(x)
+    assert str(expr) == 'Dagger(x)'
+    ascii_str = \
+u"""\
+ †\n\
+x \
+"""
+    ucode_str = \
+u"""\
+ †\n\
+x \
+"""
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+    assert latex(expr) == r'x^{\dag}'
+    sT(expr, "Dagger(Symbol('x'))")
+
+@XFAIL
+def test_gate_failing():
+    a,b,c,d = symbols('a,b,c,d')
+    uMat = Matrix([[a,b],[c,d]])
+    g = UGate((0,), uMat)
+    assert str(g) == 'U(0)'
+
+def test_gate():
+    a,b,c,d = symbols('a,b,c,d')
+    uMat = Matrix([[a,b],[c,d]])
+    q = Qubit(1,0,1,0,1)
+    g1 = IdentityGate(2)
+    g2 = CGate((3,0), XGate(1))
+    g3 = CNotGate(1,0)
+    g4 = UGate((0,), uMat)
+    assert str(g1) == '1(2)'
+    assert pretty(g1) == '1 \n 2'
+    assert upretty(g1) == u'1 \n 2'
+    assert latex(g1) == r'1_{2}'
+    sT(g1, "IdentityGate(Integer(2))")
+    assert str(g1*q) == '1(2)*|10101>'
+    ascii_str = \
+u"""\
+1 *❘10101⟩\n\
+ 2        \
+"""
+    ucode_str = \
+u"""\
+1 ⋅❘10101⟩\n\
+ 2        \
+"""
+    assert pretty(g1*q) == ascii_str
+    assert upretty(g1*q) == ucode_str
+    assert latex(g1*q) == r'1_{2} {\left|10101\right\rangle }'
+    sT(g1*q, "Mul(IdentityGate(Integer(2)), Qubit(Integer(1),Integer(0),Integer(1),Integer(0),Integer(1)))")
+    assert str(g2) == 'C((3,0),X(1))'
+    ascii_str = \
+"""\
+C   /X \\\n\
+ 3,0\\ 1/\
+"""
+    ucode_str = \
+u"""\
+C   ⎛X ⎞\n\
+ 3,0⎝ 1⎠\
+"""
+    assert pretty(g2) == ascii_str
+    assert upretty(g2) == ucode_str
+    assert latex(g2) == r'C_{3,0}{\left(X_{1}\right)}'
+    sT(g2, "CGate(Tuple(Integer(3), Integer(0)),XGate(Integer(1)))")
+    assert str(g3) == 'CNOT(1,0)'
+    ascii_str = \
+"""\
+CNOT   \n\
+    1,0\
+"""
+    ucode_str = \
+u"""\
+CNOT   \n\
+    1,0\
+"""
+    assert pretty(g3) == ascii_str
+    assert upretty(g3) == ucode_str
+    assert latex(g3) == r'CNOT_{1,0}'
+    sT(g3, "CNotGate(Integer(1),Integer(0))")
+    # str(g4) Fails
+    #assert str(g4) == ''
+    ascii_str = \
+"""\
+U \n\
+ 0\
+"""
+    ucode_str = \
+u"""\
+U \n\
+ 0\
+"""
+    assert pretty(g4) == ascii_str
+    assert upretty(g4) == ucode_str
+    assert latex(g4) == r'U_{0}'
+    sT(g4, "UGate((Integer(0),),Matrix([[Symbol('a'), Symbol('b')], [Symbol('c'), Symbol('d')]]))")
+
+def test_hilbert():
+    h1 = HilbertSpace()
+    h2 = ComplexSpace(2)
+    h3 = FockSpace()
+    h4 = L2(Interval(0,oo))
+    assert str(h1) == 'H'
+    assert pretty(h1) == 'H'
+    assert upretty(h1) == u'H'
+    assert latex(h1) == r'\mathcal{H}'
+    sT(h1, "HilbertSpace()")
+    assert str(h2) == 'C(2)'
+    ascii_str = \
+"""\
+ 2\n\
+C \
+"""
+    ucode_str = \
+u"""\
+ 2\n\
+C \
+"""
+    assert pretty(h2) == ascii_str
+    assert upretty(h2) == ucode_str
+    assert latex(h2) == r'\mathcal{C}^{2}'
+    sT(h2, "ComplexSpace(Integer(2))")
+    assert str(h3) == 'F'
+    assert pretty(h3) == 'F'
+    assert upretty(h3) == u'F'
+    assert latex(h3) == r'\mathcal{F}'
+    sT(h3, "FockSpace()")
+    assert str(h4) == 'L2([0, oo))'
+    ascii_str = \
+"""\
+ 2\n\
+L \
+"""
+    ucode_str = \
+u"""\
+ 2\n\
+L \
+"""
+    assert pretty(h4) == ascii_str
+    assert upretty(h4) == ucode_str
+    assert latex(h4) == r'{\mathcal{L}^2}\left( \left[0, \infty\right) \right)'
+    sT(h4, "L2(Interval(Integer(0), oo, False, True))")
+    assert str(h1+h2) == 'H+C(2)'
+    ascii_str = \
+u"""\
+     2\n\
+H ⊕ C \
+"""
+    ucode_str = \
+u"""\
+     2\n\
+H ⊕ C \
+"""
+    assert pretty(h1+h2) == ascii_str
+    assert upretty(h1+h2) == ucode_str
+    assert latex(h1+h2)
+    sT(h1+h2, "DirectSumHilbertSpace(HilbertSpace(),ComplexSpace(Integer(2)))")
+    assert str(h1*h2) == "H*C(2)"
+    ascii_str = \
+u"""\
+     2\n\
+H ⨂ C \
+"""
+    ucode_str = \
+u"""\
+     2\n\
+H ⨂ C \
+"""
+    assert pretty(h1*h2) == ascii_str
+    assert upretty(h1*h2) == ucode_str
+    assert latex(h1*h2)
+    sT(h1*h2, "TensorProductHilbertSpace(HilbertSpace(),ComplexSpace(Integer(2)))")
+    assert str(h1**2) == 'H**2'
+    ascii_str = \
+u"""\
+ ⨂2\n\
+H  \
+"""
+    ucode_str = \
+u"""\
+ ⨂2\n\
+H  \
+"""
+    assert pretty(h1**2) == ascii_str
+    assert upretty(h1**2) == ucode_str
+    assert latex(h1**2) == r'{\mathcal{H}}^{\otimes 2}'
+    sT(h1**2, "TensorPowerHilbertSpace(HilbertSpace(),Integer(2))")
+
+def test_innerproduct():
+    x = symbols('x')
+    ip1 = InnerProduct(Bra(), Ket())
+    ip2 = InnerProduct(TimeDepBra(),TimeDepKet())
+    ip3 = InnerProduct(JzBra(1,1),JzKet(1,1))
+    ip4 = InnerProduct(JzBraCoupled(1,1,1,1),JzKetCoupled(1,1,1,1))
+    ip_tall1 = InnerProduct(Bra(x/2), Ket(x/2))
+    ip_tall2 = InnerProduct(Bra(x), Ket(x/2))
+    ip_tall3 = InnerProduct(Bra(x/2), Ket(x))
+    assert str(ip1) == '<psi|psi>'
+    assert pretty(ip1) == u'⟨psi❘psi⟩'
+    assert upretty(ip1) == u'⟨ψ❘ψ⟩'
+    assert latex(ip1) == r'\left\langle \psi \right. {\left|\psi\right\rangle }'
+    sT(ip1, "InnerProduct(Bra(Symbol('psi')),Ket(Symbol('psi')))")
+    assert str(ip2) == '<psi;t|psi;t>'
+    assert pretty(ip2) == u'⟨psi❘psi;t⟩'
+    assert upretty(ip2) == u'⟨ψ❘ψ;t⟩'
+    assert latex(ip2) == r'\left\langle \psi \right. {\left|\psi;t\right\rangle }'
+    sT(ip2, "InnerProduct(TimeDepBra(Symbol('psi'),Symbol('t')),TimeDepKet(Symbol('psi'),Symbol('t')))")
+    assert str(ip3) == "<1,1|1,1>"
+    assert pretty(ip3) == u'⟨1,1❘1,1⟩'
+    assert upretty(ip3) == u'⟨1,1❘1,1⟩'
+    assert latex(ip3) == r'\left\langle 1,1 \right. {\left|1,1\right\rangle }'
+    sT(ip3, "InnerProduct(JzBra(Integer(1),Integer(1)),JzKet(Integer(1),Integer(1)))")
+    assert str(ip4) == "<1,1,1,1|1,1,1,1>"
+    assert pretty(ip4) == u'⟨1,1,1,1❘1,1,1,1⟩'
+    assert upretty(ip4) == u'⟨1,1,1,1❘1,1,1,1⟩'
+    assert latex(ip4) == r'\left\langle 1,1,1,1 \right. {\left|1,1,1,1\right\rangle }'
+    sT(ip4, "InnerProduct(JzBraCoupled(Integer(1),Integer(1),Integer(1),Integer(1)),JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1)))")
+    assert str(ip_tall1) == '<x/2|x/2>'
+    ascii_str = \
+u"""\
+ x x \n\
+⟨-❘-⟩\n\
+ 2 2 \
+"""
+    ucode_str = \
+u"""\
+ x x \n\
+⟨─❘─⟩\n\
+ 2 2 \
+"""
+    assert pretty(ip_tall1) == ascii_str
+    assert upretty(ip_tall1) == ucode_str
+    assert latex(ip_tall1) == r'\left\langle \frac{1}{2} x \right. {\left|\frac{1}{2} x\right\rangle }'
+    sT(ip_tall1, "InnerProduct(Bra(Mul(Rational(1, 2), Symbol('x'))),Ket(Mul(Rational(1, 2), Symbol('x'))))")
+    assert str(ip_tall2) == '<x|x/2>'
+    ascii_str = \
+u"""\
+   x \n\
+⟨x❘-⟩\n\
+   2 \
+"""
+    ucode_str = \
+u"""\
+   x \n\
+⟨x❘─⟩\n\
+   2 \
+"""
+    assert pretty(ip_tall2) == ascii_str
+    assert upretty(ip_tall2) == ucode_str
+    assert latex(ip_tall2) == r'\left\langle x \right. {\left|\frac{1}{2} x\right\rangle }'
+    sT(ip_tall2, "InnerProduct(Bra(Symbol('x')),Ket(Mul(Rational(1, 2), Symbol('x'))))")
+    assert str(ip_tall3) == '<x/2|x>'
+    ascii_str = \
+u"""\
+ x   \n\
+⟨-❘x⟩\n\
+ 2   \
+"""
+    ucode_str = \
+u"""\
+ x   \n\
+⟨─❘x⟩\n\
+ 2   \
+"""
+    assert pretty(ip_tall3) == ascii_str
+    assert upretty(ip_tall3) == ucode_str
+    assert latex(ip_tall3) == r'\left\langle \frac{1}{2} x \right. {\left|x\right\rangle }'
+    sT(ip_tall3, "InnerProduct(Bra(Mul(Rational(1, 2), Symbol('x'))),Ket(Symbol('x')))")
+
+def test_operator():
+    a = Operator('A')
+    b = Operator('B', Symbol('t'), S(1)/2)
+    inv = a.inv()
+    f = Function('f')
+    x = symbols('x')
+    d = DifferentialOperator(Derivative(f(x),x), f(x))
+    op = OuterProduct(Ket(), Bra())
+    assert str(a) == 'A'
+    assert pretty(a) == 'A'
+    assert upretty(a) == u'A'
+    assert latex(a) == 'A'
+    sT(a, "Operator(Symbol('A'))")
+    assert str(inv) == 'A**(-1)'
+    ascii_str = \
+"""\
+ -1\n\
+A  \
+"""
+    ucode_str = \
+u"""\
+ -1\n\
+A  \
+"""
+    assert pretty(inv) == ascii_str
+    assert upretty(inv) == ucode_str
+    assert latex(inv) == r'\left(A\right)^{-1}'
+    sT(inv, "Pow(Operator(Symbol('A')), Integer(-1))")
+    assert str(d) == 'DifferentialOperator(Derivative(f(x), x),f(x))'
+    ascii_str = \
+"""\
+                    /d            \\\n\
+DifferentialOperator|--(f(x)),f(x)|\n\
+                    \dx           /\
+"""
+    ucode_str = \
+u"""\
+                    ⎛d            ⎞\n\
+DifferentialOperator⎜──(f(x)),f(x)⎟\n\
+                    ⎝dx           ⎠\
+"""
+    assert pretty(d) == ascii_str
+    assert upretty(d) == ucode_str
+    assert latex(d) == r'DifferentialOperator(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )})'
+    sT(d, "DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))")
+    assert str(b) == 'Operator(B,t,1/2)'
+    assert pretty(b) == 'Operator(B,t,1/2)'
+    assert upretty(b) == u'Operator(B,t,1/2)'
+    assert latex(b) == r'Operator(B,t,\frac{1}{2})'
+    sT(b, "Operator(Symbol('B'),Symbol('t'),Rational(1, 2))")
+    assert str(op) == '|psi><psi|'
+    assert pretty(op) == u'❘psi⟩⟨psi❘'
+    assert upretty(op) == u'❘ψ⟩⟨ψ❘'
+    assert latex(op) == r'{\left|\psi\right\rangle }{\left\langle \psi\right|}'
+    sT(op, "OuterProduct(Ket(Symbol('psi')),Bra(Symbol('psi')))")
+
+def test_qexpr():
+    q = QExpr('q')
+    assert str(q) == 'q'
+    assert pretty(q) == 'q'
+    assert upretty(q) == u'q'
+    assert latex(q) == r'q'
+    sT(q, "QExpr(Symbol('q'))")
+
+def test_qubit():
+    q1 = Qubit('0101')
+    q2 = IntQubit(8)
+    assert str(q1) == '|0101>'
+    assert pretty(q1) == u'❘0101⟩'
+    assert upretty(q1) == u'❘0101⟩'
+    assert latex(q1) == r'{\left|0101\right\rangle }'
+    sT(q1,"Qubit(Integer(0),Integer(1),Integer(0),Integer(1))")
+    assert str(q2) == '|8>'
+    assert pretty(q2) == u'❘8⟩'
+    assert upretty(q2) == u'❘8⟩'
+    assert latex(q2) == r'{\left|8\right\rangle }'
+    sT(q2, "IntQubit(8)")
+
+def test_spin():
+    ket = JzKet(1,1)
+    bra = JzBra(1,1)
+    cket = JzKetCoupled(1,1,1,1)
+    cbra = JzBraCoupled(1,1,1,1)
+    rot = Rotation(1,2,3)
+    bigd = WignerD(1,2,3,4,5,6)
+    smalld = WignerD(1,2,3,0,4,0)
+    assert str(J2) == 'J2'
+    ascii_str = \
+"""\
+ 2\n\
+J \
+"""
+    ucode_str = \
+u"""\
+ 2\n\
+J \
+"""
+    assert pretty(J2) == ascii_str
+    assert upretty(J2) == ucode_str
+    assert latex(J2) == r'J^2'
+    sT(J2, "J2Op(Symbol('J'))")
+    assert str(Jz) == 'Jz'
+    ascii_str = \
+"""\
+J \n\
+ z\
+"""
+    ucode_str = \
+u"""\
+J \n\
+ z\
+"""
+    assert pretty(Jz) == ascii_str
+    assert upretty(Jz) == ucode_str
+    assert latex(Jz) == 'J_z'
+    sT(Jz, "JzOp(Symbol('J'))")
+    assert str(ket) == '|1,1>'
+    assert pretty(ket) == u'❘1,1⟩'
+    assert upretty(ket) == u'❘1,1⟩'
+    assert latex(ket) == r'{\left|1,1\right\rangle }'
+    sT(ket, "JzKet(Integer(1),Integer(1))")
+    assert str(bra) == '<1,1|'
+    assert pretty(bra) == u'⟨1,1❘'
+    assert upretty(bra) == u'⟨1,1❘'
+    assert latex(bra) == r'{\left\langle 1,1\right|}'
+    sT(bra, "JzBra(Integer(1),Integer(1))")
+    assert str(cket) == '|1,1,1,1>'
+    assert pretty(cket) == u'❘1,1,1,1⟩'
+    assert upretty(cket) == u'❘1,1,1,1⟩'
+    assert latex(cket) == r'{\left|1,1,1,1\right\rangle }'
+    sT(cket, "JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))")
+    assert str(cbra) == '<1,1,1,1|'
+    assert pretty(cbra) == u'⟨1,1,1,1❘'
+    assert upretty(cbra) == u'⟨1,1,1,1❘'
+    assert latex(cbra) == r'{\left\langle 1,1,1,1\right|}'
+    sT(cbra, "JzBraCoupled(Integer(1),Integer(1),Integer(1),Integer(1))")
+    assert str(rot) == 'R(1,2,3)'
+    assert pretty(rot) == u'ℛ (1,2,3)'
+    assert upretty(rot) == u'ℛ (1,2,3)'
+    assert latex(rot) == r'Rotation(1,2,3)'
+    sT(rot, "Rotation(Integer(1),Integer(2),Integer(3))")
+    assert str(bigd) == 'WignerD(1, 2, 3, 4, 5, 6)'
+    ascii_str = \
+"""\
+ 1         \n\
+D   (4,5,6)\n\
+ 2,3       \
+"""
+    ucode_str = \
+u"""\
+ 1         \n\
+D   (4,5,6)\n\
+ 2,3       \
+"""
+    assert pretty(bigd) == ascii_str
+    assert upretty(bigd) == ucode_str
+    assert latex(bigd) == r'D^{1}_{2,3}\left(4,5,6\right)'
+    sT(bigd, "WignerD(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6))")
+    assert str(smalld) == 'WignerD(1, 2, 3, 0, 4, 0)'
+    ascii_str = \
+"""\
+ 1     \n\
+d   (4)\n\
+ 2,3   \
+"""
+    ucode_str = \
+u"""\
+ 1     \n\
+d   (4)\n\
+ 2,3   \
+"""
+    assert pretty(smalld) == ascii_str
+    assert upretty(smalld) == ucode_str
+    assert latex(smalld) == r'd^{1}_{2,3}\left(4\right)'
+    sT(smalld, "WignerD(Integer(1), Integer(2), Integer(3), Integer(0), Integer(4), Integer(0))")
+
+def test_state():
+    x = symbols('x')
+    bra = Bra()
+    ket = Ket()
+    bra_tall = Bra(x/2)
+    ket_tall = Ket(x/2)
+    tbra = TimeDepBra()
+    tket = TimeDepKet()
+    assert str(bra) == '<psi|'
+    assert pretty(bra) == u'⟨psi❘'
+    assert upretty(bra) == u'⟨ψ❘'
+    assert latex(bra) == r'{\left\langle \psi\right|}'
+    sT(bra, "Bra(Symbol('psi'))")
+    assert str(ket) == '|psi>'
+    assert pretty(ket) == u'❘psi⟩'
+    assert upretty(ket) == u'❘ψ⟩'
+    assert latex(ket) == r'{\left|\psi\right\rangle }'
+    sT(ket, "Ket(Symbol('psi'))")
+    assert str(bra_tall) == '<x/2|'
+    ascii_str = \
+u"""\
+ x \n\
+⟨-❘\n\
+ 2 \
+"""
+    ucode_str = \
+u"""\
+ x \n\
+⟨─❘\n\
+ 2 \
+"""
+    assert pretty(bra_tall) == ascii_str
+    assert upretty(bra_tall) == ucode_str
+    assert latex(bra_tall) == r'{\left\langle \frac{1}{2} x\right|}'
+    sT(bra_tall, "Bra(Mul(Rational(1, 2), Symbol('x')))")
+    assert str(ket_tall) == '|x/2>'
+    ascii_str = \
+u"""\
+ x \n\
+❘-⟩\n\
+ 2 \
+"""
+    ucode_str = \
+u"""\
+ x \n\
+❘─⟩\n\
+ 2 \
+"""
+    assert pretty(ket_tall) == ascii_str
+    assert upretty(ket_tall) == ucode_str
+    assert latex(ket_tall) == r'{\left|\frac{1}{2} x\right\rangle }'
+    sT(ket_tall, "Ket(Mul(Rational(1, 2), Symbol('x')))")
+    assert str(tbra) == '<psi;t|'
+    assert pretty(tbra) == u'⟨psi;t❘'
+    assert upretty(tbra) == u'⟨ψ;t❘'
+    assert latex(tbra) == r'{\left\langle \psi;t\right|}'
+    sT(tbra, "TimeDepBra(Symbol('psi'),Symbol('t'))")
+    assert str(tket) == '|psi;t>'
+    assert pretty(tket) == u'❘psi;t⟩'
+    assert upretty(tket) == u'❘ψ;t⟩'
+    assert latex(tket) == r'{\left|\psi;t\right\rangle }'
+    sT(tket, "TimeDepKet(Symbol('psi'),Symbol('t'))")
+
+def test_tensorproduct():
+    tp = TensorProduct(JzKet(1,1),JzKet(1,0))
+    assert str(tp) == '|1,1>x|1,0>'
+    assert pretty(tp) == u'❘1,1⟩⨂ ❘1,0⟩'
+    assert upretty(tp) == u'❘1,1⟩⨂ ❘1,0⟩'
+    assert latex(tp) == r'{{\left|1,1\right\rangle }}\otimes {{\left|1,0\right\rangle }}'
+    sT(tp, "TensorProduct(JzKet(Integer(1),Integer(1)), JzKet(Integer(1),Integer(0)))")
+
+@XFAIL
+def test_big_expr_failing_srepr():
+    f = Function('f')
+    x = symbols('x')
+    e1 = Dagger(AntiCommutator(Operator('A')+Operator('B'),Pow(DifferentialOperator(Derivative(f(x), x), f(x)),3))*TensorProduct(Jz**2,Operator('A')+Operator('B')))*(JzBra(1,0)+JzBra(1,1))*(JzKet(0,0)+JzKet(1,-1))
+    sT(e1,"Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x'))))**3,Dagger(Operator('A')) + Dagger(Operator('B'))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
+    e2 = Commutator(Jz**2,Operator('A')+Operator('B'))*AntiCommutator(Dagger(Operator('C')*Operator('D')),Operator('E').inv()**2)*Dagger(Commutator(Jz,J2))
+    sT(e2, "Mul(Commutator(JzOp(Symbol('J'))**2,Operator(Symbol('A')) + Operator(Symbol('B'))), AntiCommutator(Operator(Symbol('E'))**(-2),Dagger(Operator(Symbol('D')))*Dagger(Operator(Symbol('C')))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
+    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,1,1)+JzKetCoupled(1,0,1,1),JzKetCoupled(1,-1,1,1))
+    sT(e3,"Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Dagger(Operator('B')) + Operator('A'),Operator('C') + Operator('D')), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Integer(1),Integer(1)), JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))), JzKetCoupled(Integer(1),Integer(-1),Integer(1),Integer(1))))")
+
+@XFAIL
+def test_big_expr_failing_str():
+    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,1,1)+JzKetCoupled(1,0,1,1),JzKetCoupled(1,-1,1,1))
+    assert str(e3) == "\
+(1, 3, 5)                                                                               \n\
+(2, 4, 6)*[Dagger(B) + A,C + D]x(-J2 + Jz)*|1,0><1,1|*(|1,0,1,1> + |1,1,1,1>)x|1,-1,1,1>"
+
+def test_big_expr():
+    # Some srepr stuff looks pretty broken, inner-most stuff is just being printed
+    #I've written what the srepr string should be and tested that it evaluates to the correct expression, see the above XFAIL test for commented out sT tests
+    f = Function('f')
+    x = symbols('x')
+    e1 = Dagger(AntiCommutator(Operator('A')+Operator('B'),Pow(DifferentialOperator(Derivative(f(x), x), f(x)),3))*TensorProduct(Jz**2,Operator('A')+Operator('B')))*(JzBra(1,0)+JzBra(1,1))*(JzKet(0,0)+JzKet(1,-1))
+    e2 = Commutator(Jz**2,Operator('A')+Operator('B'))*AntiCommutator(Dagger(Operator('C')*Operator('D')),Operator('E').inv()**2)*Dagger(Commutator(Jz,J2))
+    e3 = Wigner3j(1,2,3,4,5,6)*TensorProduct(Commutator(Operator('A')+Dagger(Operator('B')),Operator('C')+Operator('D')),Jz-J2)*Dagger(OuterProduct(Dagger(JzBra(1,1)),JzBra(1,0)))*TensorProduct(JzKetCoupled(1,1,1,1)+JzKetCoupled(1,0,1,1),JzKetCoupled(1,-1,1,1))
+    e4 = (ComplexSpace(1)*ComplexSpace(2)+FockSpace()**2)*(L2(Interval(0,oo))+HilbertSpace())
+    assert str(e1) == '(Jz**2)x(Dagger(A) + Dagger(B))*{Dagger(DifferentialOperator(Derivative(f(x), x),f(x)))**3,Dagger(A) + Dagger(B)}*(<1,0| + <1,1|)*(|0,0> + |1,-1>)'
+    ascii_str = \
+u"""\
+                 /                                      3        \\                                 \n\
+                 |/                                   †\\         |                                 \n\
+    2  / †    †\\ <|                    /d            \\ |   †    †>                                 \n\
+/J \\ ⨂ \\A  + B /*||DifferentialOperator|--(f(x)),f(x)| | ,A  + B |*(⟨1,0❘ + ⟨1,1❘)*(❘0,0⟩ + ❘1,-1⟩)\n\
+\\ z/             \\\\                    \dx           / /         /                                 \
+"""
+    ucode_str = \
+u"""\
+                 ⎧                                      3        ⎫                                 \n\
+                 ⎪⎛                                   †⎞         ⎪                                 \n\
+    2  ⎛ †    †⎞ ⎨⎜                    ⎛d            ⎞ ⎟   †    †⎬                                 \n\
+⎛J ⎞ ⨂ ⎝A  + B ⎠⋅⎪⎜DifferentialOperator⎜──(f(x)),f(x)⎟ ⎟ ,A  + B ⎪⋅(⟨1,0❘ + ⟨1,1❘)⋅(❘0,0⟩ + ❘1,-1⟩)\n\
+⎝ z⎠             ⎩⎝                    ⎝dx           ⎠ ⎠         ⎭                                 \
+"""
+    assert pretty(e1) == ascii_str
+    assert upretty(e1) == ucode_str
+    assert latex(e1) == r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left{}\left(DifferentialOperator(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )})^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+    #sT(e1, '')
+    assert e1 == eval("Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x'))))**3,Dagger(Operator('A')) + Dagger(Operator('B'))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
+    assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
+    ascii_str = \
+u"""\
+[    2      ] / -2  †  †\\ [ 2   ]\n\
+[/J \\ ,A + B]*<E  ,D *C >*[J ,J ]\n\
+[\\ z/       ] \\         / [    z]\
+"""
+    ucode_str = \
+u"""\
+⎡    2      ⎤ ⎧ -2  †  †⎫ ⎡ 2   ⎤\n\
+⎢⎛J ⎞ ,A + B⎥⋅⎨E  ,D ⋅C ⎬⋅⎢J ,J ⎥\n\
+⎣⎝ z⎠       ⎦ ⎩         ⎭ ⎣    z⎦\
+"""
+    assert pretty(e2) == ascii_str
+    assert upretty(e2) == ucode_str
+    assert latex(e2) == r'\left[\left(J_z\right)^{2},A + B\right] \left{}\left(E\right)^{-2},D^{\dag} C^{\dag}\right} \left[J^2,J_z\right]'
+    #sT(e2, '')
+    assert e2 == eval("Mul(Commutator(JzOp(Symbol('J'))**2,Operator(Symbol('A')) + Operator(Symbol('B'))), AntiCommutator(Operator(Symbol('E'))**(-2),Dagger(Operator(Symbol('D')))*Dagger(Operator(Symbol('C')))), Commutator(J2Op(Symbol('J')),JzOp(Symbol('J'))))")
+    # Broken, see test_big_expr_failing_str
+    #assert str(e3) == ""
+    ascii_str = \
+u"""\
+          [ †          ]  /   2     \\                                               \n\
+/1  3  5\\*[B  + A,C + D]⨂ |- J  + J |*❘1,0⟩⟨1,1❘*(❘1,0,1,1⟩ + ❘1,1,1,1⟩)⨂ ❘1,-1,1,1⟩\n\
+|       |                 \\        z/                                               \n\
+\\2  4  6/                                                                           \
+"""
+    ucode_str = \
+u"""\
+          ⎡ †          ⎤  ⎛   2     ⎞                                               \n\
+⎛1  3  5⎞⋅⎣B  + A,C + D⎦⨂ ⎜- J  + J ⎟⋅❘1,0⟩⟨1,1❘⋅(❘1,0,1,1⟩ + ❘1,1,1,1⟩)⨂ ❘1,-1,1,1⟩\n\
+⎜       ⎟                 ⎝        z⎠                                               \n\
+⎝2  4  6⎠                                                                           \
+"""
+    assert pretty(e3) == ascii_str
+    assert upretty(e3) == ucode_str
+    assert latex(e3) == r'\left(\begin{array}{ccc} 1 & 3 & 5 \\ 2 & 4 & 6 \end{array}\right) {\left[B^{\dag} + A,C + D\right]}\otimes \left({- J^2 + J_z}\right) {\left|1,0\right\rangle }{\left\langle 1,1\right|} \left({{\left|1,0,1,1\right\rangle } + {\left|1,1,1,1\right\rangle }}\right)\otimes {{\left|1,-1,1,1\right\rangle }}'
+    #sT(e3, '')
+    assert e3 == eval("Mul(Wigner3j(Integer(1), Integer(2), Integer(3), Integer(4), Integer(5), Integer(6)), TensorProduct(Commutator(Dagger(Operator('B')) + Operator('A'),Operator('C') + Operator('D')), Add(Mul(Integer(-1), J2Op(Symbol('J'))), JzOp(Symbol('J')))), OuterProduct(JzKet(Integer(1),Integer(0)),JzBra(Integer(1),Integer(1))), TensorProduct(Add(JzKetCoupled(Integer(1),Integer(0),Integer(1),Integer(1)), JzKetCoupled(Integer(1),Integer(1),Integer(1),Integer(1))), JzKetCoupled(Integer(1),Integer(-1),Integer(1),Integer(1))))")
+    assert str(e4) == '(C(1)*C(2)+F**2)*(L2([0, oo))+H)'
+    ascii_str = \
+u"""\
+// 1    2\\    ⨂2\\   / 2    \\\n\
+\\\\C  ⨂ C / ⊕ F  / ⨂ \L  ⊕ H/\
+"""
+    ucode_str = \
+u"""\
+⎛⎛ 1    2⎞    ⨂2⎞   ⎛ 2    ⎞\n\
+⎝⎝C  ⨂ C ⎠ ⊕ F  ⎠ ⨂ ⎝L  ⊕ H⎠\
+"""
+    assert pretty(e4) == ascii_str
+    assert upretty(e4) == ucode_str
+    assert latex(e4) == r'\left(\left(\mathcal{C}^{1}\otimes \mathcal{C}^{2}\right)\oplus {\mathcal{F}}^{\otimes 2}\right)\otimes \left({\mathcal{L}^2}\left( \left[0, \infty\right) \right)\oplus \mathcal{H}\right)'
+    sT(e4, "TensorProductHilbertSpace((DirectSumHilbertSpace(TensorProductHilbertSpace(ComplexSpace(Integer(1)),ComplexSpace(Integer(2))),TensorPowerHilbertSpace(FockSpace(),Integer(2)))),(DirectSumHilbertSpace(L2(Interval(Integer(0), oo, False, True)),HilbertSpace())))")

--- a/sympy/physics/quantum/tests/test_state.py
+++ b/sympy/physics/quantum/tests/test_state.py
@@ -167,14 +167,6 @@ def test_bra_ket_dagger():
     e = 2*I*k + x*k2
     assert Dagger(e) == conjugate(x)*Dagger(k2) - 2*I*Dagger(k)
 
-
-def test_printing():
-    psi = Ket('psi')
-    assert pretty(psi, use_unicode=True) == u'\u2758\u03c8\u27e9'
-    assert pretty(Dagger(psi), use_unicode=True) == u'\u27e8\u03c8\u2758'
-    assert latex(psi) == r"{\left|\psi\right\rangle }"
-    assert latex(Dagger(psi)) == r"{\left\langle \psi\right|}"
-
 def test_wavefunction():
     x, L = symbols('x,L', real=True)
     n = symbols('n', integer=True)


### PR DESCRIPTION
This pull gives full coverage of all the printing methods in the physics.quantum module, inspired as the first step in @Krastanov 's old pull #186 to rework the printing in the quantum module.

This first commit implements tests for all printing methods in the quantum module, which I checked with the coverage report. No changes are made to the printing methods, this is just to establish a baseline for verifying valid output capable of working in the ipython Qt console and html notebook. Note XFAIL tests show where there are errors in the printing methods.

Also in this pull is a fix for latex printing of AntiCommutator, which would give an invalid latex expression which would not display in either the Qt console or html notebook. The current implementation gives valid latex output which displays in the ipython html notebook, but I could not get the ipython Qt console to output the curly brackets.

I have a few decently large nested expressions which can display alright in the html notebook, but I may gradually add some depending on when this is merged and how much free time I get. Any suggestions on these would be greatly appreciated.

I have a ipynb file that can be run to see the output from everything in the new tests rendered by the html notebook and a py script that does the same for the qtconsole. Note that the py script is not a normal example, as has function calls to display in the IPython environment when executed with `%run` magic.

**TODO:**
