### PR TITLE
Fix doctest failures for Python3 (pickle examples)

### DIFF
--- a/doc/src/modules/core.txt
+++ b/doc/src/modules/core.txt
@@ -66,7 +66,7 @@ expr
    >>> from sympy import sin, pi
    >>> from pickle import loads, dumps
    
-   >>> picklepi = loads(dumps(pi))  # Uses default protocol 0
+   >>> picklepi = loads(dumps(pi, 0))  # Uses default protocol 0
    
    >>> sin(pi)
    0


### PR DESCRIPTION
Fix the default protocol in the doc/modules/core.txt to be 0 where it is needed.
