### PR TITLE
use2to3: normalize pathes in a windows.

### DIFF
--- a/bin/use2to3
+++ b/bin/use2to3
@@ -81,12 +81,12 @@ for root, dirs, files in os.walk('.'):
         for filename in fnmatch.filter(files, pattern):
             files.remove(filename)
     for directory in dirs:
-        dstdir = os.path.normpath(os.path.join(destination, root, directory))
+        dstdir = np(os.path.join(destination, root, directory))
         if not os.path.exists(dstdir):
             os.makedirs(dstdir)
     for filename in files:
         src = os.path.join(root, filename)
-        dst = os.path.normpath(os.path.join(destination, root, filename))
+        dst = np(os.path.join(destination, root, filename))
         if os.path.isfile(dst):
             if os.path.getmtime(src) - os.path.getmtime(dst) < 1:
                 # the file hasn't been modified since the last run, so skip it

--- a/bin/use2to3
+++ b/bin/use2to3
@@ -47,6 +47,8 @@ skip_files = (
     'use2to3',
     )
 
+np = os.path.normpath
+
 modified_files = []
 modified_txt_files = []
 
@@ -56,19 +58,19 @@ relevant_txt_files = []
 
 # generate the relevant txt files
 # most of them should be in this directory:
-for root, dirs, files in os.walk('./doc/src/modules'):
+for root, dirs, files in os.walk(np('./doc/src/modules')):
     # NOTE: this will consider mpmath-related files relevant, but it doesn't matter
     for filename in fnmatch.filter(files, '*.txt'):
         relevant_txt_files.append(os.path.join(root, filename))
 
 # some files aren't in /doc/src/modules, add them explicitly
-relevant_txt_files.append('./doc/src/tutorial.txt')
-relevant_txt_files.append('./doc/src/tutorial.bg.txt')
-relevant_txt_files.append('./doc/src/tutorial.cs.txt')
-relevant_txt_files.append('./doc/src/tutorial.ru.txt')
-relevant_txt_files.append('./doc/src/gotchas.txt')
-relevant_txt_files.append('./doc/src/guide.txt')
-relevant_txt_files.append('./doc/src/python-comparisons.txt')
+relevant_txt_files.append(np('./doc/src/tutorial.txt'))
+relevant_txt_files.append(np('./doc/src/tutorial.bg.txt'))
+relevant_txt_files.append(np('./doc/src/tutorial.cs.txt'))
+relevant_txt_files.append(np('./doc/src/tutorial.ru.txt'))
+relevant_txt_files.append(np('./doc/src/gotchas.txt'))
+relevant_txt_files.append(np('./doc/src/guide.txt'))
+relevant_txt_files.append(np('./doc/src/python-comparisons.txt'))
 
 # walk the tree and copy over files as necessary
 for root, dirs, files in os.walk('.'):
@@ -98,7 +100,7 @@ for root, dirs, files in os.walk('.'):
         elif filename.endswith(".txt"):
             # we need to check the exact path here, not just the filename
             # as there are eg. multiple index.txt files and not all are relevant
-            if src in relevant_txt_files:
+            if np(src) in relevant_txt_files:
                 modified_txt_files.append(dst)
         # FIXME: Also run 2to3 on files with no extensions; now we just skip them
 


### PR DESCRIPTION
Many *.txt files was not converted in a windows system because
the comparison of the pathes was not correct due to backslashes.
So we use os.path.normpath for accuracy.
