### PR TITLE
Fixe failures for a Python3/windows platform.

### DIFF
--- a/bin/use2to3
+++ b/bin/use2to3
@@ -81,12 +81,12 @@ for root, dirs, files in os.walk('.'):
         for filename in fnmatch.filter(files, pattern):
             files.remove(filename)
     for directory in dirs:
-        dstdir = os.path.normpath(os.path.join(destination, root, directory))
+        dstdir = np(os.path.join(destination, root, directory))
         if not os.path.exists(dstdir):
             os.makedirs(dstdir)
     for filename in files:
         src = os.path.join(root, filename)
-        dst = os.path.normpath(os.path.join(destination, root, filename))
+        dst = np(os.path.join(destination, root, filename))
         if os.path.isfile(dst):
             if os.path.getmtime(src) - os.path.getmtime(dst) < 1:
                 # the file hasn't been modified since the last run, so skip it

--- a/bin/use2to3
+++ b/bin/use2to3
@@ -47,6 +47,8 @@ skip_files = (
     'use2to3',
     )
 
+np = os.path.normpath
+
 modified_files = []
 modified_txt_files = []
 
@@ -56,19 +58,19 @@ relevant_txt_files = []
 
 # generate the relevant txt files
 # most of them should be in this directory:
-for root, dirs, files in os.walk('./doc/src/modules'):
+for root, dirs, files in os.walk(np('./doc/src/modules')):
     # NOTE: this will consider mpmath-related files relevant, but it doesn't matter
     for filename in fnmatch.filter(files, '*.txt'):
         relevant_txt_files.append(os.path.join(root, filename))
 
 # some files aren't in /doc/src/modules, add them explicitly
-relevant_txt_files.append('./doc/src/tutorial.txt')
-relevant_txt_files.append('./doc/src/tutorial.bg.txt')
-relevant_txt_files.append('./doc/src/tutorial.cs.txt')
-relevant_txt_files.append('./doc/src/tutorial.ru.txt')
-relevant_txt_files.append('./doc/src/gotchas.txt')
-relevant_txt_files.append('./doc/src/guide.txt')
-relevant_txt_files.append('./doc/src/python-comparisons.txt')
+relevant_txt_files.append(np('./doc/src/tutorial.txt'))
+relevant_txt_files.append(np('./doc/src/tutorial.bg.txt'))
+relevant_txt_files.append(np('./doc/src/tutorial.cs.txt'))
+relevant_txt_files.append(np('./doc/src/tutorial.ru.txt'))
+relevant_txt_files.append(np('./doc/src/gotchas.txt'))
+relevant_txt_files.append(np('./doc/src/guide.txt'))
+relevant_txt_files.append(np('./doc/src/python-comparisons.txt'))
 
 # walk the tree and copy over files as necessary
 for root, dirs, files in os.walk('.'):
@@ -98,7 +100,7 @@ for root, dirs, files in os.walk('.'):
         elif filename.endswith(".txt"):
             # we need to check the exact path here, not just the filename
             # as there are eg. multiple index.txt files and not all are relevant
-            if src in relevant_txt_files:
+            if np(src) in relevant_txt_files:
                 modified_txt_files.append(dst)
         # FIXME: Also run 2to3 on files with no extensions; now we just skip them
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -459,7 +459,7 @@ def sympytestfile(filename, module_relative=True, name=None, package=None,
     if sys.version_info[0] < 3:
         text, filename = pdoctest._load_testfile(filename, package, module_relative)
     else:
-        encoding = None
+        # encoding = None
         text, filename = pdoctest._load_testfile(filename, package, module_relative, encoding)
 
     # If no name was given, then use the file's name.

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -459,7 +459,6 @@ def sympytestfile(filename, module_relative=True, name=None, package=None,
     if sys.version_info[0] < 3:
         text, filename = pdoctest._load_testfile(filename, package, module_relative)
     else:
-        # encoding = None
         text, filename = pdoctest._load_testfile(filename, package, module_relative, encoding)
 
     # If no name was given, then use the file's name.
@@ -482,7 +481,8 @@ def sympytestfile(filename, module_relative=True, name=None, package=None,
         runner = SymPyDocTestRunner(verbose=verbose, optionflags=optionflags)
 
     if encoding is not None:
-        text = text.decode(encoding)
+        if sys.version_info[0] < 3:
+            text = text.decode(encoding)
 
     # Read the file, convert it to a test, and run it.
     test = parser.get_doctest(text, globs, name, filename, 0)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1186,6 +1186,9 @@ class PyTestReporter(Reporter):
             if text[0] != "\n":
                 sys.stdout.write("\n")
 
+        if IS_PYTHON_3 and IS_WINDOWS:
+            text = text.encode('raw_unicode_escape').decode('utf8', 'ignore')
+
         if color == "":
             sys.stdout.write(text)
         else:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -554,7 +554,13 @@ class SymPyTests(object):
         gl = {'__file__':filename}
         random.seed(self._seed)
         try:
-            execfile(filename, gl)
+            if IS_PYTHON_3 and IS_WINDOWS:
+                with open(filename, encoding="utf8") as f:
+                    source = f.read()
+                c = compile(source, filename, 'exec')
+                exec c in gl
+            else:
+                execfile(filename, gl)
         except (SystemExit, KeyboardInterrupt):
             raise
         except ImportError:


### PR DESCRIPTION
This pull request rebased with previous ones (PR 935 and PR 941). So it is solid and there must be no interfered errors.

The fixes are:
- use2to3: handle pathes correctly (use os.path.normpath).
- doctest and test: handle an output of failures in python3/windows terminal, to do not interrupt with encodings problems.
  
  The method for it is rough: do not analyze what terminal encoding is indeed and whether it is possible to show the unicode symbols with the current terminal fonts -  just use 'raw_unicode_escape' to show the unicode strings not as the symbols but as simple representation with '\uXXXX' symbols.
- doctest and test: read files with utf-8 encoding.
  
  One remark about 'execfile': the standard '2to3' replaces it by 'exec(compile(open', but without encoding. I just add 'if ... else' statement to handle python3/windows and explicitly write similar code for this case, but with encoding.
