### PR TITLE
Improvements on the erf function

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -634,6 +634,10 @@ def test_sympy__functions__special__error_functions__erf():
     from sympy.functions.special.error_functions import erf
     assert _test_args(erf(2))
 
+def test_sympy__functions__special__error_functions__erfs():
+    from sympy.functions.special.error_functions import erfs
+    assert _test_args(erfs(2))
+
 def test_sympy__functions__special__error_functions__Ei():
     from sympy.functions.special.error_functions import Ei
     assert _test_args(Ei(2))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -635,8 +635,8 @@ def test_sympy__functions__special__error_functions__erf():
     assert _test_args(erf(2))
 
 def test_sympy__functions__special__error_functions__erfs():
-    from sympy.functions.special.error_functions import erfs
-    assert _test_args(erfs(2))
+    from sympy.functions.special.error_functions import _erfs
+    assert _test_args(_erfs(2))
 
 def test_sympy__functions__special__error_functions__Ei():
     from sympy.functions.special.error_functions import Ei

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -29,7 +29,7 @@ from elementary.hyperbolic import sinh, cosh, tanh, coth, asinh, acosh, atanh, a
 from elementary.integers import floor, ceiling
 from elementary.piecewise import Piecewise, piecewise_fold
 
-from special.error_functions import erf, Ei, expint, E1, Si, Ci, Shi, Chi
+from special.error_functions import erf, Ei, expint, E1, Si, Ci, Shi, Chi, erfs
 from special.gamma_functions import gamma, lowergamma, uppergamma, polygamma, \
          loggamma, digamma, trigamma, beta
 from special.zeta_functions import dirichlet_eta, zeta, lerchphi, polylog

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -29,7 +29,7 @@ from elementary.hyperbolic import sinh, cosh, tanh, coth, asinh, acosh, atanh, a
 from elementary.integers import floor, ceiling
 from elementary.piecewise import Piecewise, piecewise_fold
 
-from special.error_functions import erf, Ei, expint, E1, Si, Ci, Shi, Chi, erfs
+from special.error_functions import erf, Ei, expint, E1, Si, Ci, Shi, Chi
 from special.gamma_functions import gamma, lowergamma, uppergamma, polygamma, \
          loggamma, digamma, trigamma, beta
 from special.zeta_functions import dirichlet_eta, zeta, lerchphi, polylog

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -157,7 +157,8 @@ class erf(Function):
         return self.args[0].is_real
 
     def _eval_rewrite_as_uppergamma(self, z):
-        return sqrt(z**2)/z*(S.One-C.uppergamma(S.Half, z**2)/sqrt(S.Pi))
+        return sqrt(z**2)/z*(S.One - C.uppergamma(S.Half, z**2)/sqrt(S.Pi))
+
 
 ###############################################################################
 #################### EXPONENTIAL INTEGRALS ####################################

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1,7 +1,7 @@
 """ This module contains various functions that are special cases
     of incomplete gamma functions. It should probably be renamed. """
 
-from sympy.core import S, C, sympify, cacheit, pi, I
+from sympy.core import Add, S, C, sympify, cacheit, pi, I
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.functions.elementary.miscellaneous import sqrt
 
@@ -856,16 +856,18 @@ class erfs(Function):
     tractable for the Gruntz algorithm.
     """
 
+    nargs = 1
+
     def _eval_aseries(self, n, args0, x, logx):
-        if args0[0] != oo:
+        if args0[0] != S.Infinity:
             return super(erfs, self)._eval_aseries(n, args0, x, logx)
 
         z = self.args[0]
-        l = [ C.factorial(2*k)*(-4)**(-k)/C.factorial(k)*(1/z)**(2*k+1) for k in xrange(1,n) ]
+        l = [ C.factorial(2*k)*(-S(4))**(-k)/C.factorial(k)*(1/z)**(2*k+1) for k in xrange(1,n) ]
 
         # Not sure about the order terms
         o = None
-        if m == 0:
+        if n == 0:
             o = C.Order(1, x)
         else:
             o = C.Order(1/z**(2*n+2), x)
@@ -878,3 +880,6 @@ class erfs(Function):
             return -2/sqrt(S.Pi)+2*z*erfs(z)
         else:
             raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_intractable(self, z):
+        return (S.One-erf(z))*C.exp(z**2)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -148,7 +148,7 @@ class erf(Function):
         z = self.args[0]
         #h0 = C.hyper([S.One,S.Half],[],-1/z**2)
         #return z/sqrt(z**2) - 1/(sqrt(pi)*z)*C.exp(-z**2)*h0
-        if -S.Half*S.Pi < C.arg(args0) and C.arg(args0) <= S.Half*S.Pi:
+        if -S.Half*S.Pi < C.arg(args0[0]) and C.arg(args0[0]) <= S.Half*S.Pi:
             return S.One - C.exp(-z**2)/(sqrt(S.Pi)*z)
         else:
             return -S.One - C.exp(-z**2)/(sqrt(S.Pi)*z)

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -69,11 +69,11 @@ class erf(Function):
     Differentiation with respect to z is supported:
 
     >>> from sympy import diff
-    >>> diff(erf(z),z)
+    >>> diff(erf(z), z)
     2*exp(-z**2)/sqrt(pi)
 
     We can numerically evaluate the error function to arbitrary precision
-    on the whole complex plane
+    on the whole complex plane:
 
     >>> erf(4).evalf(30)
     0.999999984582742099719981147840
@@ -136,23 +136,6 @@ class erf(Function):
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
 
-    def _eval_as_leading_term(self, x):
-        arg = self.args[0].as_leading_term(x)
-
-        if C.Order(1,x).contains(arg):
-            return arg
-        else:
-            return self.func(arg)
-
-    def _eval_aseries(self, n, args0, x, logx):
-        z = self.args[0]
-        #h0 = C.hyper([S.One,S.Half],[],-1/z**2)
-        #return z/sqrt(z**2) - 1/(sqrt(pi)*z)*C.exp(-z**2)*h0
-        if -S.Half*S.Pi < C.arg(args0[0]) and C.arg(args0[0]) <= S.Half*S.Pi:
-            return S.One - C.exp(-z**2)/(sqrt(S.Pi)*z)
-        else:
-            return -S.One - C.exp(-z**2)/(sqrt(S.Pi)*z)
-
     def _eval_is_real(self):
         return self.args[0].is_real
 
@@ -160,7 +143,7 @@ class erf(Function):
         return sqrt(z**2)/z*(S.One - C.uppergamma(S.Half, z**2)/sqrt(S.Pi))
 
     def _eval_rewrite_as_tractable(self, z):
-        return S.One - erfs(z)*C.exp(-z**2)
+        return S.One - _erfs(z)*C.exp(-z**2)
 
 
 ###############################################################################
@@ -850,7 +833,7 @@ class Chi(TrigonometricIntegral):
 ###############################################################################
 
 
-class erfs(Function):
+class _erfs(Function):
     """
     Helper function to make the :math:`erf(z)` function
     tractable for the Gruntz algorithm.
@@ -860,20 +843,18 @@ class erfs(Function):
 
     def _eval_aseries(self, n, args0, x, logx):
         if args0[0] != S.Infinity:
-            return super(erfs, self)._eval_aseries(n, args0, x, logx)
+            return super(_erfs, self)._eval_aseries(n, args0, x, logx)
 
         z = self.args[0]
         l = [ 1/sqrt(S.Pi) * C.factorial(2*k)*(-S(4))**(-k)/C.factorial(k) * (1/z)**(2*k+1) for k in xrange(0,n) ]
-
-        # Still not sure about the order terms
-        o = C.Order(1/z**(2*n+2), x)
+        o = C.Order(1/z**(2*n+1), x)
         # It is very inefficient to first add the order and then do the nseries
         return (Add(*l))._eval_nseries(x, n, logx) + o
 
     def fdiff(self, argindex=1):
         if argindex == 1:
             z = self.args[0]
-            return -2/sqrt(S.Pi)+2*z*erfs(z)
+            return -2/sqrt(S.Pi)+2*z*_erfs(z)
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -125,9 +125,7 @@ class erf(Function):
             return S.Zero
         else:
             x = sympify(x)
-
-            k = (n - 1)//2
-
+            k = C.floor((n - 1)/S(2))
             if len(previous_terms) > 2:
                 return -previous_terms[-2] * x**2 * (n-2)/(n*k)
             else:

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -863,14 +863,10 @@ class erfs(Function):
             return super(erfs, self)._eval_aseries(n, args0, x, logx)
 
         z = self.args[0]
-        l = [ C.factorial(2*k)*(-S(4))**(-k)/C.factorial(k)*(1/z)**(2*k+1) for k in xrange(1,n) ]
+        l = [ 1/sqrt(S.Pi) * C.factorial(2*k)*(-S(4))**(-k)/C.factorial(k) * (1/z)**(2*k+1) for k in xrange(0,n) ]
 
-        # Not sure about the order terms
-        o = None
-        if n == 0:
-            o = C.Order(1, x)
-        else:
-            o = C.Order(1/z**(2*n+2), x)
+        # Still not sure about the order terms
+        o = C.Order(1/z**(2*n+2), x)
         # It is very inefficient to first add the order and then do the nseries
         return (Add(*l))._eval_nseries(x, n, logx) + o
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -31,8 +31,8 @@ def test_erf():
     assert erf(x).as_leading_term(x) == x
     assert erf(1/x).as_leading_term(x) == erf(1/x)
 
-    assert erf(z)._eval_aseries(None, oo, z,0) == 1 - exp(-z**2)/(sqrt(pi)*z)
-    assert erf(z)._eval_aseries(None, -oo, z,0) == -1 - exp(-z**2)/(sqrt(pi)*z)
+    assert erf(z)._eval_aseries(None, [oo], z,0) == 1 - exp(-z**2)/(sqrt(pi)*z)
+    assert erf(z)._eval_aseries(None, [-oo], z,0) == -1 - exp(-z**2)/(sqrt(pi)*z)
 
     assert erf(z)._eval_rewrite_as_uppergamma(z) == sqrt(z**2)*erf(sqrt(z**2))/z
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,4 +1,4 @@
-from sympy import (symbols, erf, nan, oo, Float, sqrt, pi, O, Ei,
+from sympy import (symbols, erf, nan, oo, Float, conjugate, sqrt, exp, pi, O, I, Ei,
                    exp_polar, polar_lift, Symbol, I, exp, uppergamma, expint,
                    meijerg, gamma, S, Shi, Chi, Si, Ci, E1, sin, cos, sinh, cosh)
 
@@ -6,7 +6,7 @@ from sympy.core.function import ArgumentIndexError
 
 from sympy.utilities.pytest import raises
 
-x, y = symbols('x,y')
+x, y, z = symbols('x,y,z')
 
 def test_erf():
     assert erf(nan) == nan
@@ -16,6 +16,9 @@ def test_erf():
 
     assert erf(0) == 0
 
+    assert erf(I*oo) == oo*I
+    assert erf(-I*oo) == -oo*I
+
     assert erf(-2) == -erf(2)
     assert erf(-x*y) == -erf(x*y)
     assert erf(-x - y) == -erf(x + y)
@@ -23,8 +26,15 @@ def test_erf():
     assert erf(I).is_real == False
     assert erf(0).is_real == True
 
+    assert conjugate(erf(z)) == erf(conjugate(z))
+
     assert erf(x).as_leading_term(x) == x
     assert erf(1/x).as_leading_term(x) == erf(1/x)
+
+    assert erf(z)._eval_aseries(None, oo, z,0) == 1 - exp(-z**2)/(sqrt(pi)*z)
+    assert erf(z)._eval_aseries(None, -oo, z,0) == -1 - exp(-z**2)/(sqrt(pi)*z)
+
+    assert erf(z)._eval_rewrite_as_uppergamma(z) == sqrt(z**2)*erf(sqrt(z**2))/z
 
     raises(ArgumentIndexError, 'erf(x).fdiff(2)')
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -37,9 +37,8 @@ def test_erf():
 
     assert limit(exp(x)*exp(x**2)*(erf(x+1/exp(x))-erf(x)), x, oo) == 2/sqrt(pi)
     assert limit((1-erf(z))*exp(z**2)*z, z, oo) == 1/sqrt(pi)
-    assert expand(limit(erf(erf(erf(z))), z, oo)) == erf(erf(1))
-    assert limit(exp(gamma(erf(z))), z, oo) == exp(1)
-    assert limit(exp(gamma(erf(log(loggamma(z))))), z, oo) == exp(1)
+    assert limit((1-erf(x))*exp(x**2)*sqrt(pi)*x, x, oo) == 1
+    assert limit(((1-erf(x))*exp(x**2)*sqrt(pi)*x-1)*2*x**2, x, oo) == -1
 
     raises(ArgumentIndexError, 'erf(x).fdiff(2)')
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,6 +1,8 @@
-from sympy import (symbols, erf, nan, oo, Float, conjugate, sqrt, exp, pi, O, I, Ei,
-                   exp_polar, polar_lift, Symbol, I, exp, uppergamma, expint,
+from sympy import (symbols, expand, erf, nan, oo, Float, conjugate, sqrt, exp, pi, O, I, Ei,
+                   exp_polar, polar_lift, Symbol, I, exp, uppergamma, expint, log, loggamma, limit,
                    meijerg, gamma, S, Shi, Chi, Si, Ci, E1, sin, cos, sinh, cosh)
+
+from sympy.functions.special.error_functions import _erfs
 
 from sympy.core.function import ArgumentIndexError
 
@@ -31,10 +33,13 @@ def test_erf():
     assert erf(x).as_leading_term(x) == x
     assert erf(1/x).as_leading_term(x) == erf(1/x)
 
-    assert erf(z)._eval_aseries(None, [oo], z,0) == 1 - exp(-z**2)/(sqrt(pi)*z)
-    assert erf(z)._eval_aseries(None, [-oo], z,0) == -1 - exp(-z**2)/(sqrt(pi)*z)
+    assert erf(z).rewrite('uppergamma') == sqrt(z**2)*erf(sqrt(z**2))/z
 
-    assert erf(z)._eval_rewrite_as_uppergamma(z) == sqrt(z**2)*erf(sqrt(z**2))/z
+    assert limit(exp(x)*exp(x**2)*(erf(x+1/exp(x))-erf(x)), x, oo) == 2/sqrt(pi)
+    assert limit((1-erf(z))*exp(z**2)*z, z, oo) == 1/sqrt(pi)
+    assert expand(limit(erf(erf(erf(z))), z, oo)) == erf(erf(1))
+    assert limit(exp(gamma(erf(z))), z, oo) == exp(1)
+    assert limit(exp(gamma(erf(log(loggamma(z))))), z, oo) == exp(1)
 
     raises(ArgumentIndexError, 'erf(x).fdiff(2)')
 
@@ -45,6 +50,13 @@ def test_erf_series():
 def test_erf_evalf():
     assert abs( erf(Float(2.0)) - 0.995322265 )  <  1E-8  # XXX
 
+def test__erfs():
+    assert _erfs(z).diff(z) == -2/sqrt(S.Pi)+2*z*_erfs(z)
+
+    assert _erfs(1/z).series(z) == z/sqrt(pi) - z**3/(2*sqrt(pi)) + 3*z**5/(4*sqrt(pi)) + O(z**6)
+
+    assert expand(erf(z).rewrite('tractable').diff(z).rewrite('intractable')) == erf(z).diff(z)
+    assert _erfs(z).rewrite("intractable") == (-erf(z) + 1)*exp(z**2)
 
 # NOTE we multiply by exp_polar(I*pi) and need this to be on the principal
 #      branch, hence take x in the lower half plane (d=0).


### PR DESCRIPTION
Some smaller improvements on the error function `erf(x)`.

Note that this breaks `limit(erf(x),x,oo)` but I could not
figure out the reason.

The rewrite to `uppergamma` has little effect as `uppergamma(1/2, ...)`
autosimplifies.
