### PR TITLE
[GCI 2011] Fix issue 2882: integration of 1/(1+x**2) works but 1/(1+u**2) fails

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -317,7 +317,7 @@ def log_to_real(h, q, x, t):
 
     log_to_atan
     """
-    u, v = symbols('u,v')
+    u, v = symbols('u,v', cls=Dummy)
 
     H = h.as_expr().subs({t:u+I*v}).expand()
     Q = q.as_expr().subs({t:u+I*v}).expand()


### PR DESCRIPTION
`log_to_real` used regular symbols instead of dummy ones. Changing this fixes the [issue 2882](http://code.google.com/p/sympy/issues/detail?id=2882)
