### PR TITLE
issue 2975: Simplification of hyperbolic identity.

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -775,7 +775,7 @@ def trigsimp(expr, deep=False, recursive=False):
     Examples
     ========
 
-    >>> from sympy import trigsimp, sin, cos, log
+    >>> from sympy import trigsimp, sin, cos, log, cosh, sinh
     >>> from sympy.abc import x, y
     >>> e = 2*sin(x)**2 + 2*cos(x)**2
     >>> trigsimp(e)
@@ -786,103 +786,102 @@ def trigsimp(expr, deep=False, recursive=False):
     log(2)
 
     """
-    sin, cos, tan, cot = C.sin, C.cos, C.tan, C.cot
-    if not expr.has(sin, cos, tan, cot):
+    if not expr.has(C.TrigonometricFunction) and not expr.has(C.HyperbolicFunction):
         return expr
 
     if recursive:
         w, g = cse(expr)
-        g = trigsimp_nonrecursive(g[0])
+        g = trigsimp_recursive(g[0])
 
         for sub in reversed(w):
             g = g.subs(sub[0], sub[1])
-            g = trigsimp_nonrecursive(g)
+            g = trigsimp_recursive(g)
         result = g
     else:
-        result = trigsimp_nonrecursive(expr, deep)
+        result = trigsimp_recursive(expr, deep)
 
     return result
 
-
-def trigsimp_nonrecursive(expr, deep=False):
-    """
-    A nonrecursive trig simplifier, used from trigsimp. Reduces expression by
-    using known trig identities
-
-    Notes
-    =====
-
-    deep -> apply trigsimp inside functions
-
-    Examples
-    ========
-
-    >>> from sympy import cos, sin, log
-    >>> from sympy.simplify.simplify import trigsimp, trigsimp_nonrecursive
-    >>> from sympy.abc import x, y
-    >>> e = 2*sin(x)**2 + 2*cos(x)**2
-    >>> trigsimp(e)
-    2
-    >>> trigsimp_nonrecursive(log(e))
-    log(2*sin(x)**2 + 2*cos(x)**2)
-    >>> trigsimp_nonrecursive(log(e), deep=True)
-    log(2)
-
-    """
+def trigsimp_recursive(expr, deep = False):
+    a,b,c = map(Wild, 'abc')
     sin, cos, tan, cot = C.sin, C.cos, C.tan, C.cot
+    sinh, cosh, tanh, coth = C.sinh, C.cosh, C.tanh, C.coth
+    # for the simplifications like sinh/cosh -> tanh:
+    matchers_division = (
+        (a*sin(b)**c/cos(b)**c, a*tan(b)**c),
+        (a*tan(b)**c*cos(b)**c, a*sin(b)**c),
+        (a*cot(b)**c*sin(b)**c, a*cos(b)**c),
+        (a*tan(b)**c/sin(b)**c, a/cos(b)**c),
+        (a*cot(b)**c/cos(b)**c, a/sin(b)**c),
+        (a*cot(b)**c*tan(b)**c, a),
+
+        (a*sinh(b)**c/cosh(b)**c, a*tanh(b)**c),
+        (a*tanh(b)**c*cosh(b)**c, a*sinh(b)**c),
+        (a*coth(b)**c*sinh(b)**c, a*cosh(b)**c),
+        (a*tanh(b)**c/sinh(b)**c, a/cosh(b)**c),
+        (a*coth(b)**c/cosh(b)**c, a/sinh(b)**c),
+        (a*coth(b)**c*tanh(b)**c, a)
+        )
+    # for cos(x)**2 + sin(x)**2 -> 1
+    matchers_identity = (
+        (a*sin(b)**2,  a - a*cos(b)**2),
+        (a*tan(b)**2,  a*(1/cos(b))**2 - a),
+        (a*cot(b)**2,  a*(1/sin(b))**2 - a),
+
+        (a*sinh(b)**2, a*cosh(b)**2 - a),
+        (a*tanh(b)**2, a - a*(1/cosh(b))**2),
+        (a*coth(b)**2, a + a*(1/sinh(b))**2)
+        )
+    # Reduce any lingering artefacts, such as sin(x)**2 changing
+    # to 1-cos(x)**2 when sin(x)**2 was "simpler"
+    artifacts = (
+        (a - a*cos(b)**2 + c,        a*sin(b)**2 + c, cos),
+        (a - a*(1/cos(b))**2 + c,   -a*tan(b)**2 + c, cos),
+        (a - a*(1/sin(b))**2 + c,   -a*cot(b)**2 + c, sin),
+
+        (a - a*cosh(b)**2 + c,      -a*sinh(b)**2 + c, cosh),
+        (a - a*(1/cosh(b))**2 + c,   a*tanh(b)**2 + c, cosh),
+        (a + a*(1/sinh(b))**2 + c,   a*coth(b)**2 + c, sinh)
+        )
 
     if expr.is_Function:
         if deep:
-            return expr.func(trigsimp_nonrecursive(expr.args[0], deep))
+            return expr.func(trigsimp_recursive(expr.args[0], deep))
     elif expr.is_Mul:
         # do some simplifications like sin/cos -> tan:
-        a,b,c = map(Wild, 'abc')
-        matchers = (
-                (a*sin(b)**c/cos(b)**c, a*tan(b)**c),
-                (a*tan(b)**c*cos(b)**c, a*sin(b)**c),
-                (a*cot(b)**c*sin(b)**c, a*cos(b)**c),
-                (a*tan(b)**c/sin(b)**c, a/cos(b)**c),
-                (a*cot(b)**c/cos(b)**c, a/sin(b)**c),
-        )
-        for pattern, simp in matchers:
+        for pattern, simp in matchers_division:
             res = expr.match(pattern)
             if res is not None:
                 # if c is missing or zero, do nothing:
                 if (not c in res) or res[c] == 0:
                     continue
-                # if "a" contains any of sin("b"), cos("b"), tan("b") or cot("b),
+                # if "a" contains any of sin("b"), cos("b"), tan("b"), cot("b),
+                # sinh("b"), cosh("b"), tanh("b") or coth("b),
                 # skip the simplification:
-                if res[a].has(cos(res[b]), sin(res[b]), tan(res[b]), cot(res[b])):
+                if res[a].has(C.TrigonometricFunction) or res[a].has(C.HyperbolicFunction):
                     continue
                 # simplify and finish:
                 expr = simp.subs(res)
                 break
         if not expr.is_Mul:
-            return trigsimp_nonrecursive(expr, deep)
+            return trigsimp_recursive(expr, deep)
         ret = S.One
         for x in expr.args:
-            ret *= trigsimp_nonrecursive(x, deep)
+            ret *= trigsimp_recursive(x, deep)
         return ret
     elif expr.is_Pow:
-        return Pow(trigsimp_nonrecursive(expr.base, deep),
-                trigsimp_nonrecursive(expr.exp, deep))
+        return Pow(trigsimp_recursive(expr.base, deep),
+                trigsimp_recursive(expr.exp, deep))
     elif expr.is_Add:
         # TODO this needs to be faster
 
-        # The types of trig functions we are looking for
-        a,b,c = map(Wild, 'abc')
-        matchers = (
-            (a*sin(b)**2, a - a*cos(b)**2),
-            (a*tan(b)**2, a*(1/cos(b))**2 - a),
-            (a*cot(b)**2, a*(1/sin(b))**2 - a)
-        )
-
+        # The types of hyper functions we are looking for
         # Scan for the terms we need
         ret = S.Zero
         for term in expr.args:
-            term = trigsimp_nonrecursive(term, deep)
+            term = trigsimp_recursive(term, deep)
             res = None
-            for pattern, result in matchers:
+            for pattern, result in matchers_identity:
                 res = term.match(pattern)
                 if res is not None:
                     ret += result.subs(res)
@@ -892,12 +891,6 @@ def trigsimp_nonrecursive(expr, deep=False):
 
         # Reduce any lingering artifacts, such as sin(x)**2 changing
         # to 1-cos(x)**2 when sin(x)**2 was "simpler"
-        artifacts = (
-            (a - a*cos(b)**2 + c, a*sin(b)**2 + c, cos),
-            (a - a*(1/cos(b))**2 + c, -a*tan(b)**2 + c, cos),
-            (a - a*(1/sin(b))**2 + c, -a*cot(b)**2 + c, sin)
-        )
-
         expr = ret
         for pattern, result, ex in artifacts:
             # Substitute a new wild that excludes some function(s)
@@ -918,6 +911,7 @@ def trigsimp_nonrecursive(expr, deep=False):
 
         return expr
     return expr
+
 
 def collect_sqrt(expr, evaluate=True):
     """Return expr with terms having common square roots collected together.
@@ -2842,7 +2836,7 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     if expr.has(BesselBase):
         expr = besselsimp(expr)
 
-    if expr.has(C.TrigonometricFunction):
+    if expr.has(C.TrigonometricFunction) or expr.has(C.HyperbolicFunction):
         expr = trigsimp(expr)
 
     if expr.has(C.log):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1,6 +1,7 @@
 from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     collect, Function, powsimp, separate, sin, exp, Rational, fraction,
     simplify, trigsimp, cos, tan, cot, log, ratsimp, Matrix, pi, integrate,
+    sinh, cosh, tanh, coth,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
@@ -82,7 +83,7 @@ def test_trigsimp2():
 
 def test_issue1274():
     x = Symbol("x")
-    assert abs(trigsimp(2.0*sin(x)**2+2.0*cos(x)**2)-2.0) < 1e-10
+    assert abs(trigsimp(2.0*sin(x)**2 + 2.0*cos(x)**2)-2.0) < 1e-10
 
 def test_trigsimp3():
     x, y = symbols('x,y')
@@ -101,6 +102,65 @@ def test_trigsimp_issue_2515():
     x = Symbol('x')
     assert trigsimp(x*cos(x)*tan(x)) == x*sin(x)
     assert trigsimp(-sin(x)+cos(x)*tan(x)) == 0
+
+def test_hyperbolic_simp():
+    x, y = symbols('x,y')
+
+    assert trigsimp(sinh(x)**2 + 1) == cosh(x)**2
+    assert trigsimp(cosh(x)**2 - 1) == sinh(x)**2
+    assert trigsimp(cosh(x)**2 - sinh(x)**2) == 1
+    assert trigsimp(1 - tanh(x)**2) == 1/cosh(x)**2
+    assert trigsimp(1 - 1/cosh(x)**2) == tanh(x)**2
+    assert trigsimp(tanh(x)**2 + 1/cosh(x)**2) == 1
+    assert trigsimp(coth(x)**2 - 1) == 1/sinh(x)**2
+    assert trigsimp(1/sinh(x)**2 + 1) == coth(x)**2
+    assert trigsimp(coth(x)**2 - 1/sinh(x)**2) == 1
+
+    assert trigsimp(5*cosh(x)**2 - 5*sinh(x)**2) == 5
+    assert trigsimp(5*cosh(x/2)**2 - 2*sinh(x/2)**2) in \
+                [2 + 3*cosh(x/2)**2, 5 + 3*sinh(x/2)**2]
+
+    assert trigsimp(sinh(x)/cosh(x)) == tanh(x)
+    assert trigsimp(tanh(x)) == trigsimp(sinh(x)/cosh(x))
+    assert trigsimp(cosh(x)/sinh(x)) == 1/tanh(x)
+    assert trigsimp(2*tanh(x)*cosh(x)) == 2*sinh(x)
+    assert trigsimp(coth(x)**3*sinh(x)**3) == cosh(x)**3
+    assert trigsimp(y*tanh(x)**2/sinh(x)**2) == y/cosh(x)**2
+    assert trigsimp(coth(x)/cosh(x)) == 1/sinh(x)
+
+    e = 2*cosh(x)**2 - 2*sinh(x)**2
+    assert trigsimp(log(e), deep=True) == log(2)
+
+    assert trigsimp(cosh(x)**2*cosh(y)**2 - cosh(x)**2*sinh(y)**2 - sinh(x)**2,
+            recursive=True) == 1
+    assert trigsimp(sinh(x)**2*sinh(y)**2 - sinh(x)**2*cosh(y)**2 + cosh(x)**2,
+            recursive=True) == 1
+
+    assert abs(trigsimp(2.0*cosh(x)**2 - 2.0*sinh(x)**2)-2.0) < 1e-10
+
+    assert trigsimp(sinh(x)**2/cosh(x)**2) == tanh(x)**2
+    assert trigsimp(sinh(x)**3/cosh(x)**3) == tanh(x)**3
+    assert trigsimp(sinh(x)**10/cosh(x)**10) == tanh(x)**10
+    assert trigsimp(cosh(x)**3/sinh(x)**3) == 1/tanh(x)**3
+
+    assert trigsimp(cosh(x)/sinh(x)) == 1/tanh(x)
+    assert trigsimp(cosh(x)**2/sinh(x)**2) == 1/tanh(x)**2
+    assert trigsimp(cosh(x)**10/sinh(x)**10) == 1/tanh(x)**10
+
+    assert trigsimp(x*cosh(x)*tanh(x)) == x*sinh(x)
+    assert trigsimp(-sinh(x) + cosh(x)*tanh(x)) == 0
+
+@XFAIL
+def test_tan_cot():
+    x = Symbol('x')
+    ### ???
+    assert tan(x) == 1/cot(x)
+
+@XFAIL
+def test_tan_cot2():
+    x = Symbol('x')
+    assert trigsimp(tan(x) - 1/cot(x)) == 0
+    assert trigsimp(3*tanh(x)**7 - 2/coth(x)**7) == tanh(x)**7
 
 @XFAIL
 def test_factorial_simplify():


### PR DESCRIPTION
For hyperbolic functions added simplification rules, similar like for trigonometric ones.

That is:

``````
```
>>> (cosh(x)**2 - sinh(x)**2).simplify()
1
>>> (sinh(x)**2 + 1).simplify()
cosh(x)**2
```
``````

Remarks:
The new analog of  'trigsim' is 'hyperbolic_simp'. This name-token is not fine.
But there is the 'hypersimp' which is present already and deal with combinatorics.

Updated:
`trigsim` combines both trigonometric and hyperbolic simplifications.

See [Issue 2975](http://code.google.com/p/sympy/issues/detail?id=2975)
