### PR TITLE
printing/pretty: Add pretty printer for GeometryEntity

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -864,6 +864,10 @@ class PrettyPrinter(Printer):
 
         return pform
 
+    def _print_GeometryEntity(self, expr):
+        # GeometryEntity is special -- it's base is tuple
+        return self.emptyPrinter(expr)
+
     def _print_Lambda(self, e):
         symbols, expr = e.args
 


### PR DESCRIPTION
GeometryEntity didn't have a pretty printer defined. As it is not
subclassed from a SymPy class, but rather a Python tuple, this caused
errors when pretty printing. Fix by just calling the emptyPrinter (which
is the same as str(expr)) for GeometryEntity. This fixes issue 2761.

This also helps with ipython, which uses pretty printing by default.
