### PR TITLE
Fix Integer.is_prime

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1373,8 +1373,9 @@ class Integer(Rational):
         return result
 
     def _eval_is_prime(self):
-        if self.p < 0:
-            return False
+        from sympy.ntheory import isprime
+
+        return isprime(self)
 
     def as_numer_denom(self):
         return self, S.One
@@ -1461,7 +1462,6 @@ class Zero(IntegerConstant):
     is_negative = False
     is_finite = False
     is_zero = True
-    is_prime = False
     is_composite = False
 
     __slots__ = []
@@ -1508,8 +1508,6 @@ class One(IntegerConstant):
 
     p = 1
     q = 1
-
-    is_prime = True
 
     __slots__ = []
 

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,5 +1,5 @@
 from sympy.core import Symbol, S, Rational, Integer
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 from sympy import I, sqrt
 
 def test_symbol_unset():
@@ -54,8 +54,11 @@ def test_one():
     assert z.is_finite == True
     assert z.is_infinitesimal == False
     assert z.is_comparable == True
-    assert z.is_prime == True
-    assert z.is_composite == False
+    assert z.is_prime == False
+
+@XFAIL
+def test_one_is_composite():
+    assert S(1).is_composite is False
 
 def test_negativeone():
     z = Integer(-1)
@@ -337,6 +340,25 @@ def test_neg_symbol_nonpositive():
     assert x.is_nonnegative == True
     assert x.is_zero == None
     assert x.is_nonzero == None
+
+def test_prime():
+    assert S(-1).is_prime is False
+    assert S(-2).is_prime is False
+    assert S(-4).is_prime is False
+    assert S(0).is_prime is False
+    assert S(1).is_prime is False
+    assert S(2).is_prime is True
+    assert S(17).is_prime is True
+    assert S(4).is_prime is False
+
+def test_composite():
+    assert S(-1).is_composite is False
+    assert S(-2).is_composite is False
+    assert S(-4).is_composite is False
+    assert S(0).is_composite is False
+    assert S(2).is_composite is False
+    assert S(17).is_composite is False
+    assert S(4).is_composite is True
 
 def test_prime_symbol():
     x = Symbol('x', prime=True)


### PR DESCRIPTION
This fixes issue 2964.  Integer.is_prime returned None, except for S.One,
which returned True!  This was fixed to use isprime().  Note that is_composite
still uses integer & positive & !prime, so S(1).is_composite will return True.
I don't think this can be fixed with the new assumptions system, so I just
created an XFAIL test for it for now. Note that this was right before, but
only because S(1).is_prime was wrong.  So I think if one must be wrong,
composite is better (and anyway, this is just a side-effect of using isprime()
in _eval_is_prime).
