### PR TITLE
TODO: rebase Add an XFAIL test for issue 2587.

### DIFF
--- a/doc/src/modules/core.txt
+++ b/doc/src/modules/core.txt
@@ -108,6 +108,35 @@ expr
    protocol 3. The highest protocol available also can be checked with
    pickle.HIGHEST_PROTOCOL
 
+.. note:: Pickling of SymPy Objects with Assumptions
+   =================================================
+
+   When pickling SymPy objects with assumptions, 'fast' mode must be used.
+
+   By default pickle will try to optimize the serialized form by combining
+   identical objects, storing only one instance and accessing them by refernce.
+   This behavior causes issues with SymPy because default assumptions will be
+   detected as identical and still be accessed through reference when they are
+   unpickled.  Any assumptions generated for those objects after being
+   unpickled will apply to all the objects with the same default assumptions,
+   whether applicable or not. Fast mode in Pickler causes pickle to bypass this
+   optimization returning the correct result.
+
+   For example:
+
+   >>> from pickle import dumps, loads
+   >>> from sympy.abc import x
+   >>> f = x**2 + x**-2
+   >>> g = loads(dumps(f))
+   >>> f.args[0].exp.is_positive # 2
+   True
+   >>> f.args[1].exp.is_negative # -2
+   True
+   >>> g.args[0].exp.is_positive # 2
+   True
+   >>> g.args[1].exp.is_negative # -2
+   False
+
 Expr
 ^^^^
 .. autoclass:: Expr

--- a/doc/src/modules/core.txt
+++ b/doc/src/modules/core.txt
@@ -122,20 +122,25 @@ expr
    whether applicable or not. Fast mode in Pickler causes pickle to bypass this
    optimization returning the correct result.
 
-   For example:
+   Workaround using fast mode:
 
-   >>> from pickle import dumps, loads
-   >>> from sympy.abc import x
-   >>> f = x**2 + x**-2
-   >>> g = loads(dumps(f))
-   >>> f.args[0].exp.is_positive # 2
+   >>> from cStringIO import StringIO
+   >>> from pickle import loads, Pickler
+   >>> from sympy.abc import u
+   >>> f = u**2 + u**-2
+   >>> s = StringIO()
+   >>> p = Pickler(s)
+   >>> p.fast = True
+   >>> p.dump(f)
+   >>> g = loads(s.getvalue())
+   >>> f.args[1].exp.is_positive # 2
    True
-   >>> f.args[1].exp.is_negative # -2
+   >>> f.args[0].exp.is_negative # -2
    True
-   >>> g.args[0].exp.is_positive # 2
+   >>> g.args[1].exp.is_positive # 2
    True
-   >>> g.args[1].exp.is_negative # -2
-   False
+   >>> g.args[0].exp.is_negative # -2, would be False without fast mode
+   True
 
 Expr
 ^^^^

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -139,8 +139,8 @@ def test_core_multidimensional():
 
 @XFAIL
 def test_issue_2587():
-    x = Symbol("x")
-    f = x**2 + x**-2
+    u = Symbol("u")
+    f = u**2 + u**-2
     g = pickle.loads(pickle.dumps(f))
     assert f.args[0].exp.is_positive # 2
     assert f.args[1].exp.is_negative # -2

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -137,6 +137,16 @@ def test_core_multidimensional():
     for c in (vectorize, vectorize(0)):
         check(c)
 
+@XFAIL
+def test_issue_2587():
+    x = Symbol("x")
+    f = x**2 + x**-2
+    g = pickle.loads(pickle.dumps(f))
+    assert f.args[0].exp.is_positive # 2
+    assert f.args[1].exp.is_negative # -2
+    assert g.args[0].exp.is_positive # 2
+    assert g.args[1].exp.is_negative # -2
+
 # This doesn't have to be pickable.
 #@XFAIL
 #def test_core_astparser():


### PR DESCRIPTION
I've created an XFAIL test for issue 2587.  One curious thing is that the test does not actually fail, though copying & pasting the exact code into a python shell will cause it to fail on the last assertion.  Any thoughts?

Also, where should we document the fact that SymPy objects must be pickled with fast mode on?

Issue 2587: http://code.google.com/p/sympy/issues/detail?id=2587
