### PR TITLE
issue 2983: fix exception for 'Max(x, 1)*Max(x, 2)'.

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -220,6 +220,8 @@ class Basic(PicklableWithSlots):
         for l,r in zip(st,ot):
             if isinstance(l, Basic):
                 c = l.compare(r)
+            elif isinstance(l, frozenset):
+                c = 0
             else:
                 c = cmp(l, r)
             if c: return c

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1252,3 +1252,13 @@ def test_issue_2941():
     assert b != a
     assert not (a == b)
     assert not (b == a)
+
+
+def test_issue_2983():
+    from sympy.functions.elementary.miscellaneous import Max
+    from sympy.logic.boolalg import Or
+    from sympy.abc import x, y, z
+
+    assert Max(x, 1) * Max(x, 2) == Max(x, 1) * Max(x, 2)
+    assert Or(x, z) * Or(x, z) == Or(x, z) * Or(x, z)
+


### PR DESCRIPTION
This fix the exceptions like

```
>>> Max(x, 1) * Max(x, 2)
TypeError: cannot compare sets using cmp(

>>> Or(x, z) * Or(x, y)
TypeError: cannot compare sets using cmp(
```

See [Issue 2983](http://code.google.com/p/sympy/issues/detail?id=2983)
