### PR TITLE
Reset random seed for each function.

### DIFF
--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -620,6 +620,7 @@ class SymPyTests(object):
                 if timeout:
                     self._timeout(f, timeout)
                 else:
+                    random.seed(self._seed)
                     f()
             except KeyboardInterrupt:
                 if getattr(f, '_slow', False):


### PR DESCRIPTION
Cite from Aaron's comment #4 from issue [2956](http://code.google.com/p/sympy/issues/detail?id=2956):

"""
this is a problem with random testing.  If any intermediate test is added (or even changed), then the same seed will not produce the same result. 

This can be helped a little bit by resetting the seed before each test function.
"""

It should help to reproduce the failures for different branches when the test function uses random.
