### PR TITLE
Matrix, domain, and Subs evalf method need prec option and/or n alias

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1276,8 +1276,13 @@ class Subs(Expr):
     def doit(self):
         return self.expr.doit().subs(zip(self.variables, self.point))
 
-    def evalf(self):
-        return self.doit().evalf()
+    def evalf(self, prec=None, **options):
+        if prec is None:
+            return self.doit().evalf(**options)
+        else:
+            return self.doit().evalf(prec, **options)
+
+    n = evalf
 
     @property
     def variables(self):

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -180,7 +180,9 @@ def test_Subs():
     assert e1.__hash__() == e2.__hash__()
     assert Subs(z*f(x+1), x, 1) not in [ e1, e2 ]
     assert Derivative(f(x),x).subs(x,g(x)) == Derivative(f(g(x)),g(x))
-
+    assert Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).n(1) == \
+        Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).evalf(1) == \
+        z + Rational('1/2').n(1)*f(0)
 
 @XFAIL
 def test_Subs2():

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1375,6 +1375,8 @@ class Matrix(object):
         else:
             return self.applyfunc(lambda i: i.evalf(prec, **options))
 
+    n = evalf
+
     def reshape(self, _rows, _cols):
         """
         Reshape the matrix. Total number of elements must remain the same.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1081,12 +1081,10 @@ def test_issue882():
     assert m[1, 2] == 8
 
 def test_evalf():
-    def check(l, r):
-        # renormalize each Float so they compare the same
-        return l.__add__(0) == r.__add__(0)
     a = Matrix([sqrt(5), 6])
-    assert all(check(a.evalf()[i], a[i].evalf()) for i in range(2))
-    assert all(check(a.evalf(1)[i], a[i].evalf(1)) for i in range(2))
+    assert all(a.evalf()[i] == a[i].evalf() for i in range(2))
+    assert all(a.evalf(1)[i] == a[i].evalf(1) for i in range(2))
+    assert all(a.n(1)[i] == a[i].n(1) for i in range(2))
 
 def test_is_symbolic():
     x = Symbol('x')

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -474,9 +474,14 @@ class Domain(object):
         """Returns square root of `a`. """
         raise NotImplementedError
 
-    def evalf(self, a, **args):
+    def evalf(self, a, prec=None, **args):
         """Returns numerical approximation of `a`. """
-        return self.to_sympy(a).evalf(**args)
+        if prec is None:
+            return self.to_sympy(a).evalf(**args)
+        else:
+            return self.to_sympy(a).evalf(prec, **args)
+
+    n = evalf
 
     def real(self, a):
         return a

--- a/sympy/polys/tests/test_domains.py
+++ b/sympy/polys/tests/test_domains.py
@@ -634,6 +634,7 @@ def test_RealDomain_from_sympy():
     assert RR.convert(S(1)) == RR.dtype(1)
     assert RR.convert(S(1.0)) == RR.dtype(1.0)
     assert RR.convert(sin(1)) == RR.dtype(sin(1).evalf())
+    assert RR.n(3, 2) == RR.evalf(3, 2) == Rational(3).n(2)
     raises(CoercionFailed, "RR.convert(x)")
     raises(CoercionFailed, "RR.convert(oo)")
     raises(CoercionFailed, "RR.convert(-oo)")


### PR DESCRIPTION
The standard evalf method has for precision and other options. In addition, n is an alias for evalf. A few objects don't follow these conventions. This aims to fix that.
