### PR TITLE
improvements to DeferredVector

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -870,6 +870,10 @@ def test_sympy__logic__boolalg__Xor():
     from sympy.logic.boolalg import Xor
     assert _test_args(Xor(x, y, 2))
 
+def test_sympy__matrices__matrices__DeferredVector():
+    from sympy.matrices.matrices import DeferredVector
+    assert _test_args(DeferredVector("X"))
+
 def test_sympy__matrices__expressions__blockmatrix__BlockDiagMatrix():
     from sympy.matrices.expressions.blockmatrix import BlockDiagMatrix
     from sympy.matrices.expressions import MatrixSymbol

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -46,6 +46,10 @@ class DeferredVector(Symbol):
     (3, 6)
     """
     def __getitem__(self,i):
+        if i == -0:
+            i = 0
+        if i < 0:
+            raise IndexError('DeferredVector index out of range')
         component_name = '%s[%d]'%(self.name,i)
         return Symbol(component_name)
 
@@ -53,7 +57,7 @@ class DeferredVector(Symbol):
         return sstr(self)
 
     def __repr__(self):
-        return sstr(self)
+        return "DeferredVector('%s')"%(self.name)
 
 
 class Matrix(object):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -33,11 +33,18 @@ def _iszero(x):
     """Returns True if x is zero."""
     return x.is_zero
 
+class DeferredVector(Symbol):
+    """A vector whose components are deferred (e.g. for use with lambdify)
 
-class DeferredVector(object):
-    def __init__(self,name):
-        self.name=name
-
+    >>> from sympy import DeferredVector, lambdify
+    >>> X = DeferredVector( 'X' )
+    >>> X
+    X
+    >>> expr = (X[0] + 2, X[2] + 3)
+    >>> func = lambdify( X, expr )
+    >>> func( [1, 2, 3] )
+    (3, 6)
+    """
     def __getitem__(self,i):
         component_name = '%s[%d]'%(self.name,i)
         return Symbol(component_name)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2041,3 +2041,7 @@ def test_issue_860():
 @XFAIL
 def test_issue_2865() :
     assert str(Matrix([[1, 2], [3, 4]])) == 'Matrix([[1, 2], [3, 4]])'
+
+def test_DeferredVector():
+    assert sympify(DeferredVector("d")) == DeferredVector("d")
+


### PR DESCRIPTION
Following [some](http://groups.google.com/group/sympy/browse_thread/thread/e70aa378c02ea029) [discussion](http://groups.google.com/group/sympy/browse_thread/thread/9f9934d7b596ea4a), I updated DeferredVector a bit to address the points that I saw raised. In particular, I added a test that elicits the failure mode reported by Matthew Bret and a fix is made for it. I also added a docstring and some doctests.
