### PR TITLE
3001: a**1.0 == a

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -377,6 +377,11 @@ class Basic(PicklableWithSlots):
         """
 
         if type(self) is not type(other):
+            # issue 3001 a**1.0 == a like a**2.0 == a**2
+            while isinstance(self, C.Pow) and self.exp == 1:
+                self = self.base
+            while isinstance(other, C.Pow) and other.exp == 1:
+                other = other.base
             try:
                 other = _sympify(other)
             except SympifyError:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -1,5 +1,6 @@
 from basic import Basic
 from core import C
+from power import Pow
 from sympify import sympify
 from singleton import S
 from expr import Expr, AtomicExpr

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -1,4 +1,4 @@
-from sympy.core import Rational, Symbol, S, Float, Integer, Number
+from sympy.core import Rational, Symbol, S, Float, Integer, Number, Pow, Basic
 from sympy.functions.elementary.miscellaneous import sqrt
 
 def test_issue153():
@@ -168,3 +168,21 @@ def test_pow_as_base_exp():
     assert (S.Infinity**(x - 2)).as_base_exp() == (S.Infinity, x - 2)
     p = S.Half**x
     assert p.base, p.exp == p.as_base_exp() == (S(2), -x)
+
+def test_issue_3001():
+    x = Symbol('x')
+    y = Symbol('y')
+    assert x**1.0 == x
+    assert x == x**1.0
+    assert True != x**1.0
+    assert x**1.0 != True
+    assert x != True
+    assert x*y == (x*y)**1.0
+    assert (x**1.0)**1.0 == x
+    assert (x**1.0)**2.0 == x**2
+    b = Basic()
+    assert Pow(b, 1.0, evaluate=False) == b
+    # if the following gets distributed as a Mul (x**1.0*y**1.0 then
+    # __eq__ methods could be added to Symbol and Pow to detect the
+    # power-of-1.0 case.
+    assert ((x*y)**1.0).func is Pow


### PR DESCRIPTION
Whereas a**2.0 == a**2 and a**1.5 == sqrt(a)**3, a**1.0 does not
    equal `a` because the case of a trivial exponent is not considered.

```
This commit adds that introspection to Basic.__eq__. A new method
is not added to Pow since although that would be useful for catching
the case of x**1.0 == x it would not catch the case of x*y == (x*y)**1.0
(or any other object other than a Mul that might be the base of the
Pow having a 1.0 exponent).
```

http://code.google.com/p/sympy/issues/detail?id=3001 and discussion at http://groups.google.com/group/sympy/browse_thread/thread/4ebe4f90cc24877e#
