### PR TITLE
[GCI 2011] Fix issue 2481: Run the sage tests with ./bin/test when possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ sympy@googlegroups.com and ask for help.
 from distutils.core import setup
 from distutils.core import Command
 import sys
+import subprocess
+import os
 
 import sympy
 
@@ -163,6 +165,13 @@ class test_sympy(Command):
 
     def run(self):
         tests_successful = True
+
+        def get_sage_executable():
+            if sys.platform == "win32":
+                return "sage.exe"
+            else:
+                return "sage"
+
         try:
             if not sympy.test():
                 # some regular test fails, so set the tests_successful
@@ -171,6 +180,11 @@ class test_sympy(Command):
 
             if not sympy.doctest():
                 tests_successful = False
+
+            with open(os.devnull, 'w') as dev_null:
+                if subprocess.call(get_sage_executable() + " -v", shell = True, stdout = dev_null, stderr = dev_null) == 0:
+                    if subprocess.call(get_sage_executable() + " -python bin/test sympy/external/tests/test_sage.py", shell = True) != 0:
+                        tests_successful = False
 
             if tests_successful:
                 return

--- a/setup.py
+++ b/setup.py
@@ -166,12 +166,6 @@ class test_sympy(Command):
     def run(self):
         tests_successful = True
 
-        def get_sage_executable():
-            if sys.platform == "win32":
-                return "sage.exe"
-            else:
-                return "sage"
-
         try:
             if not sympy.test():
                 # some regular test fails, so set the tests_successful
@@ -181,9 +175,10 @@ class test_sympy(Command):
             if not sympy.doctest():
                 tests_successful = False
 
-            with open(os.devnull, 'w') as dev_null:
-                if subprocess.call(get_sage_executable() + " -v", shell = True, stdout = dev_null, stderr = dev_null) == 0:
-                    if subprocess.call(get_sage_executable() + " -python bin/test sympy/external/tests/test_sage.py", shell = True) != 0:
+            if not sys.platform == "win32":
+                dev_null = open(os.devnull, 'w')
+                if subprocess.call("sage -v", shell = True, stdout = dev_null, stderr = dev_null) == 0:
+                    if subprocess.call("sage -python bin/test sympy/external/tests/test_sage.py", shell = True) != 0:
                         tests_successful = False
 
             if tests_successful:

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -34,7 +34,8 @@ def check_expression(expr, var_symbols):
     """Does eval(expr) both in Sage and SymPy and does other checks."""
 
     # evaluate the expression in the context of Sage:
-    sage.var(var_symbols)
+    if var_symbols:
+        sage.var(var_symbols)
     a = globals().copy()
     # safety checks...
     assert not "sin" in a


### PR DESCRIPTION
`test_sage.py` is now part of tests executed by `setup.py test` if Sage is installed.
Sage tests can't be simply executed from ./bin/test as they need to be run by Python bundled with Sage.
Check for Sage is done by looking at the exit status of `sage -v`. (I didn't come with a better way that's likely to work everywhere.)
This needs to be tested on other platforms than Linux-based OSes.
