### PR TITLE
GreaterThan/LessThan refactor

### DIFF
--- a/doc/src/modules/core.txt
+++ b/doc/src/modules/core.txt
@@ -62,43 +62,43 @@ expr
    singletons, especially because the default protocol when pickling in Python 2
    is protocol 0, and a regular simplification will not evaluate the result with
    sufficient accuracy.
-   
+
    For example:
-   
+
    >>> from sympy import sin, pi
    >>> from pickle import loads, dumps
-   
+
    >>> picklepi = loads(dumps(pi,0))  # Uses default protocol 0 in Python 2 with no parameter
-   
+
    >>> sin(pi)
    0
    >>> sin(picklepi)
    sin(pi)
    >>> sin(picklepi).evalf()
    .0e-184
-   
+
    >>> pi - picklepi
    -pi + pi
    >>> (pi-picklepi).evalf()
    -.0e-125
-   
+
    >>> pi is picklepi
    False
-   
-   
+
+
    The optimal solution to this problem is to specify a protocol of 2 or higher
    when pickling the singleton (Specification of protocol redundant in Python 3).
-   
+
    For example:
-   
+
    >>> picklepi = loads(dumps(pi,-1))   # Defaults to highest protocol, which is 2 in Python 2 and 3 in Python 3
-   
+
    >>> pi is picklepi
    True
-   
+
    >>> sin(picklepi)
    0
-   
+
    >>> picklepi - pi
    0
 
@@ -310,9 +310,14 @@ Equality
 .. autoclass:: Equality
    :members:
 
-Inequality
+GreaterThan
 ^^^^^^^^^^
-.. autoclass:: Inequality
+.. autoclass:: GreaterThan
+   :members:
+
+LessThan
+^^^^^^^^^^
+.. autoclass:: LessThan
    :members:
 
 Unequality
@@ -320,9 +325,14 @@ Unequality
 .. autoclass:: Unequality
    :members:
 
-StrictInequality
+StrictGreaterThan
 ^^^^^^^^^^^^^^^^
-.. autoclass:: StrictInequality
+.. autoclass:: StrictGreaterThan
+   :members:
+
+StrictLessThan
+^^^^^^^^^^^^^^^^
+.. autoclass:: StrictLessThan
    :members:
 
 multidimensional

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -106,7 +106,7 @@ class Predicate(Boolean):
     The tautological predicate `Q.is_true` can be used to wrap other objects:
 
         >>> Q.is_true(x > 1)
-        Q.is_true(1 < x)
+        Q.is_true(x > 1)
 
     """
 

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -92,7 +92,7 @@ class Predicate(Boolean):
 
     Predicates merely wrap their argument and remain unevaluated:
 
-        >>> from sympy import Q, ask, Symbol
+        >>> from sympy import Q, ask, Symbol, S
         >>> x = Symbol('x')
         >>> Q.prime(7)
         Q.prime(7)
@@ -107,6 +107,8 @@ class Predicate(Boolean):
 
         >>> Q.is_true(x > 1)
         Q.is_true(x > 1)
+        >>> Q.is_true(S(1) < x)
+        Q.is_true(1 < x)
 
     """
 

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -13,8 +13,9 @@ from power import Pow, integer_nthroot
 from mul import Mul, prod
 from add import Add
 from mod import Mod
-from relational import Rel, Eq, Ne, Lt, Le, Gt, Ge, \
-    Equality, Inequality, Unequality, StrictInequality
+from relational import ( Rel, Eq, Ne, Lt, Le, Gt, Ge,
+    Equality, GreaterThan, LessThan, Unequality, StrictGreaterThan,
+    StrictLessThan )
 from multidimensional import vectorize
 from function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     Function, Subs, expand, PoleError, count_ops, \

--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -38,7 +38,8 @@ ordering_of_classes = [
     # Landau O symbol
     'Order',
     # relational operations
-    'Equality', 'Unequality', 'StrictInequality', 'Inequality',
+    'Equality', 'Unequality', 'StrictGreaterThan', 'StrictLessThan',
+    'GreaterThan', 'LessThan',
     ]
 
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -165,33 +165,33 @@ class Expr(Basic, EvalfMixin):
         re, im = result.as_real_imag()
         return complex(float(re), float(im))
 
-    @_sympifyit('other', False) # sympy >  other
-    def __lt__(self, other):
+    @_sympifyit('other', False)  # sympy >  other
+    def __ge__(self, other):
         dif = self - other
-        if dif.is_negative != dif.is_nonnegative:
-            return dif.is_negative
-        return C.StrictInequality(self, other)
-
-    @_sympifyit('other', True)  # sympy >  other
-    def __gt__(self, other):
-        dif = self - other
-        if dif.is_positive !=  dif.is_nonpositive:
-            return dif.is_positive
-        return C.StrictInequality(other, self)
+        if dif.is_nonnegative != dif.is_negative:
+            return dif.is_nonnegative
+        return C.GreaterThan(self, other)
 
     @_sympifyit('other', False) # sympy >  other
     def __le__(self, other):
         dif = self - other
         if dif.is_nonpositive != dif.is_positive:
             return dif.is_nonpositive
-        return C.Inequality(self, other)
+        return C.LessThan(self, other)
 
-    @_sympifyit('other', True)  # sympy >  other
-    def __ge__(self, other):
+    @_sympifyit('other', False)  # sympy >  other
+    def __gt__(self, other):
         dif = self - other
-        if dif.is_nonnegative != dif.is_negative:
-            return dif.is_nonnegative
-        return C.Inequality(other, self)
+        if dif.is_positive !=  dif.is_nonpositive:
+            return dif.is_positive
+        return C.StrictGreaterThan(self, other)
+
+    @_sympifyit('other', False) # sympy >  other
+    def __lt__(self, other):
+        dif = self - other
+        if dif.is_negative != dif.is_nonnegative:
+            return dif.is_negative
+        return C.StrictLessThan(self, other)
 
     @staticmethod
     def _from_mpmath(x, prec):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -500,6 +500,32 @@ class Float(Number):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            return False    # sympy > other
+        if isinstance(other, NumberSymbol):
+            return other.__le__(self)
+        if other.is_comparable:
+            other = other.evalf()
+        if isinstance(other, Number):
+            return bool(mlib.mpf_gt(self._mpf_, other._as_mpf_val(self._prec)))
+        return Expr.__gt__(self, other)
+
+    def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            return False    # sympy > other  -->  ! <=
+        if isinstance(other, NumberSymbol):
+            return other.__lt__(self)
+        if other.is_comparable:
+            other = other.evalf()
+        if isinstance(other, Number):
+            return bool(mlib.mpf_ge(self._mpf_, other._as_mpf_val(self._prec)))
+        return Expr.__ge__(self, other)
+
     def __lt__(self, other):
         try:
             other = _sympify(other)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -864,6 +864,37 @@ class Rational(Number):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __gt__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            return False    # sympy > other  --> not <
+        if isinstance(other, NumberSymbol):
+            return other.__le__(self)
+        if other.is_comparable and not isinstance(other, Rational):
+            other = other.evalf()
+        if isinstance(other, Number):
+            if isinstance(other, Float):
+                return bool(mlib.mpf_gt(self._as_mpf_val(other._prec), other._mpf_))
+            return bool(self.p * other.q > self.q * other.p)
+        return Expr.__gt__(self, other)
+
+    def __ge__(self, other):
+        try:
+            other = _sympify(other)
+        except SympifyError:
+            return False    # sympy > other  -->  not <=
+        if isinstance(other, NumberSymbol):
+            return other.__lt__(self)
+        if other.is_comparable and not isinstance(other, Rational):
+            other = other.evalf()
+        if isinstance(other, Number):
+            if isinstance(other, Float):
+                return bool(mlib.mpf_ge(self._as_mpf_val(other._prec), other._mpf_))
+            return bool(self.p * other.q >= self.q * other.p)
+        return Expr.__ge__(self, other)
+
+
     def __lt__(self, other):
         try:
             other = _sympify(other)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -551,7 +551,7 @@ class StrictGreaterThan(_Greater):
         return lhs > rhs
 
     def __nonzero__(self):
-        return self.lhs.compare( self.rhs ) == 1
+        return self.lhs.compare( self.rhs ) > 0
 
     def __eq__ ( self, other ):
         if isinstance(other, StrictGreaterThan):
@@ -579,7 +579,7 @@ class StrictLessThan(_Less):
         return lhs < rhs
 
     def __nonzero__(self):
-        return self.lhs.compare( self.rhs ) == -1
+        return self.lhs.compare( self.rhs ) < 0
 
     def __eq__ ( self, other ):
         if isinstance(other, StrictLessThan):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -487,9 +487,6 @@ class GreaterThan(_Greater):
 
     __slots__ = ()
 
-    def __hash__ ( self ):   # because __eq__ is overridden as well
-        return super(GreaterThan, self).__hash__()
-
     @classmethod
     def _eval_relation(cls, lhs, rhs):
         return lhs >= rhs
@@ -497,26 +494,11 @@ class GreaterThan(_Greater):
     def __nonzero__(self):
         return self.lhs.compare( self.rhs ) >= 0
 
-    def __eq__ ( self, other ):
-        if isinstance(other, GreaterThan):
-            ot = other._hashable_content()
-        elif isinstance(other, LessThan):
-            ot = tuple(reversed( other._hashable_content() ))
-        else:
-            return False
-
-        st = self._hashable_content()
-
-        return st == ot
-
 class LessThan(_Less):
     __doc__ = GreaterThan.__doc__
     __slots__ = ()
 
     rel_op = '<='
-
-    def __hash__ ( self ):   # because __eq__ is overridden as well
-        return super(LessThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -525,26 +507,11 @@ class LessThan(_Less):
     def __nonzero__(self):
         return self.lhs.compare( self.rhs ) <= 0
 
-    def __eq__ ( self, other ):
-        if isinstance(other, LessThan):
-            ot = other._hashable_content()
-        elif isinstance(other, GreaterThan):
-            ot = tuple(reversed( other._hashable_content() ))
-        else:
-            return False
-
-        st = self._hashable_content()
-
-        return st == ot
-
 class StrictGreaterThan(_Greater):
     __doc__ = GreaterThan.__doc__
     __slots__ = ()
 
     rel_op = '>'
-
-    def __hash__ ( self ):   # because __eq__ is overridden as well
-        return super(StrictGreaterThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -553,26 +520,11 @@ class StrictGreaterThan(_Greater):
     def __nonzero__(self):
         return self.lhs.compare( self.rhs ) > 0
 
-    def __eq__ ( self, other ):
-        if isinstance(other, StrictGreaterThan):
-            ot = other._hashable_content()
-        elif isinstance(other, StrictLessThan):
-            ot = tuple(reversed( other._hashable_content() ))
-        else:
-            return False
-
-        st = self._hashable_content()
-
-        return st == ot
-
 class StrictLessThan(_Less):
     __doc__ = GreaterThan.__doc__
     __slots__ = ()
 
     rel_op = '<'
-
-    def __hash__ ( self ):   # because __eq__ is overridden as well
-        return super(StrictLessThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -580,18 +532,6 @@ class StrictLessThan(_Less):
 
     def __nonzero__(self):
         return self.lhs.compare( self.rhs ) < 0
-
-    def __eq__ ( self, other ):
-        if isinstance(other, StrictLessThan):
-            ot = other._hashable_content()
-        elif isinstance(other, StrictGreaterThan):
-            ot = tuple(reversed( other._hashable_content() ))
-        else:
-            return False
-
-        st = self._hashable_content()
-
-        return st == ot
 
 # A class-specific (not object-specific) data item used for a minor speedup.  It
 # is defined here, rather than directly in the class, because the classes that

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -131,20 +131,17 @@ class Relational(Expr, EvalfMixin):
     # ValidRelationOperator - Defined below, because the necessary classes
     #   have not yet been defined
 
-    @staticmethod
-    def get_relational_class(rop):
-        try:
-            return Relational.ValidRelationOperator[ rop ]
-        except KeyError:
-            raise ValueError("Invalid relational operator symbol: %r" % (rop))
-
     def __new__(cls, lhs, rhs, rop=None, **assumptions):
         lhs = _sympify(lhs)
         rhs = _sympify(rhs)
         if cls is not Relational:
             rop_cls = cls
         else:
-            rop_cls = Relational.get_relational_class(rop)
+            try:
+                rop_cls = Relational.ValidRelationOperator[ rop ]
+            except KeyError:
+                msg = "Invalid relational operator symbol: '%r'"
+                raise ValueError(msg % repr(rop))
         if lhs.is_number and rhs.is_number and lhs.is_real and rhs.is_real:
             # Just becase something is a number, doesn't mean you can evalf it.
             Nlhs = lhs.evalf()

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,3 +1,4 @@
+from basic import Basic
 from expr import Expr
 from evalf import EvalfMixin
 from sympify import _sympify
@@ -247,6 +248,7 @@ class GreaterThan(_Greater):
     rel_op = '>='
 
     __slots__ = ()
+    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -272,6 +274,7 @@ class LessThan(_Less):
     rel_op = '<='
 
     __slots__ = ()
+    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -297,6 +300,7 @@ class StrictGreaterThan(_Greater):
     rel_op = '>'
 
     __slots__ = ()
+    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -322,6 +326,7 @@ class StrictLessThan(_Less):
     rel_op = '<'
 
     __slots__ = ()
+    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -238,18 +238,6 @@ class _Less(Relational):
     def lts(self):
         return self._args[0]
 
-    def __eq__ ( self, other ):
-        if isinstance(other, _Less):
-            ot = other._hashable_content()
-        elif isinstance(other, _Greater):
-            ot = tuple(reversed( other._hashable_content() ))
-        else:
-            return False
-
-        st = self._hashable_content()
-
-        return st == ot
-
 class GreaterThan(_Greater):
 
     rel_op = '>='

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -219,6 +219,10 @@ class Unequality(Relational):
         return self.lhs.compare(self.rhs)!=0
 
 class _Greater(Relational):
+    """\
+Not intended for general use; _Greater is only used so that GreaterThan and
+StrictGreaterThan may subclass it for the .gts and .lts properties.
+"""
     __slots__ = ()
 
     @property
@@ -230,6 +234,11 @@ class _Greater(Relational):
         return self._args[1]
 
 class _Less(Relational):
+    """\
+
+Not intended for general use; _Less is only used so that LessThan and
+StrictLessThan may subclass it for the .gts and .lts properties.
+"""
     __slots__ = ()
 
     @property
@@ -241,6 +250,187 @@ class _Less(Relational):
         return self._args[0]
 
 class GreaterThan(_Greater):
+    """\
+The *Than classes represent inequal relationships, where the left-hand side is
+generally bigger or smaller than the right-hand side.  For example, the
+GreaterThan class represents an inequal relationship where the left-hand side is
+at least as big as the right side, if not bigger.  In mathematical notation:
+
+    lhs >= rhs
+
+In total, there are four *Than classes, to represent the four inequalities:
+
+GreaterThan       (>=)
+LessThan          (<=)
+StrictGreaterThan (>)
+StrictLessThan    (<)
+
+In addition to the normal .lhs and .rhs of Relations, *Than inequality objects
+also have the .lts and .gts properties, which represent the "less than side" and
+"greater than side" of the operator.  Use of .lts and .gts in an algorithm
+rather than .lhs, .rhs, and an assumption of inequality direction, will make
+more explicit the intent of a certain section of code, and will make it
+similarly more robust to client code changes:
+
+    >>> from sympy import GreaterThan, StrictGreaterThan
+    >>> from sympy import LessThan,    StrictLessThan
+    >>> from sympy import Ge, Gt, Le, Lt, Rel, S
+    >>> from sympy.abc import x
+    >>> from sympy.core.relational import Relational
+    >>> e = Ge(x, 1)
+    >>> print( e )
+    x >= 1
+    >>> print "%s >= %s is the same as %s <= %s" % (e.gts, e.lts, e.lts, e.gts)
+    x >= 1 is the same as 1 <= x
+
+One generally does not instantiate these classes directly, but uses various
+convenience methods:
+
+    >>> e1 = Ge( x, 2 )      # Ge is a convenience wrapper
+    >>> print e1
+    x >= 2
+
+    >>> Ge( x, 2 )
+    x >= 2
+    >>> Gt( x, 2 )
+    x > 2
+    >>> Le( x, 2 )
+    x <= 2
+    >>> Lt( x, 2 )
+    x < 2
+
+Another option is to use the Python inequality operatoers.  The advantage over
+using one of >=, >, <=, < over their Ge, Gt, Le, and Lt counterparts, is that
+code can take advantage of Python's builtin order of algebraic operations, and
+can generally write a more "mathematical looking" statement rather than one
+littered with oddball functions.  However there are certain (minor) caveats of
+which to be aware (search for 'gotcha', below).
+
+    >>> e2 = x >= 2
+    >>> print e2
+    x >= 2
+    >>> print "e1: %s,    e2: %s" % (e1, e2)
+    e1: x >= 2,    e2: x >= 2
+    >>> e1 == e2
+    True
+
+However, it is also perfectly valid to instantiate a *Than class less succinctly
+and less conviently:
+
+    >>> Rel(x, 1, '>=')
+    x >= 1
+    >>> Relational(x, 1, '>=')
+    x >= 1
+    >>> GreaterThan(x, 1)
+    x >= 1
+
+    >>> Rel(x, 1, '>')
+    x > 1
+    >>> Relational(x, 1, '>')
+    x > 1
+    >>> StrictGreaterThan(x, 1)
+    x > 1
+
+    >>> Rel(x, 1, '<=')
+    x <= 1
+    >>> Relational(x, 1, '<=')
+    x <= 1
+    >>> LessThan(x, 1)
+    x <= 1
+
+    >>> Rel(x, 1, '<')
+    x < 1
+    >>> Relational(x, 1, '<')
+    x < 1
+    >>> StrictLessThan(x, 1)
+    x < 1
+
+
+The *Than inequality classes smartly compare equivalent:
+
+    >>> e3 = Le( 2, x )
+    >>> print "e2: %s,   e3: %s" % (e2, e3)
+    e2: x >= 2,   e3: 2 <= x
+    >>> e2 == e3
+    True
+
+    >>> print "e: %s,   e3: %s" % (e, e3)
+    e: x >= 1,   e3: 2 <= x
+    >>> e == e3
+    False
+    >>> e != e3
+    True
+
+SymPy allows nesting of inequalities, so to compare whole inequality
+expressions, use .compare():
+
+    >>> e4 = Le( x, 4 )
+    >>> print "e3: %s,   e4: %s" % (e3, e4)
+    e3: 2 <= x,   e4: x <= 4
+    >>> print "Nested inequality: %s" % (e3 > e4)
+    Nested inequality: (2 <= x) > (x <= 4)
+
+When comparing lhs to rhs (lhs.compare(rhs)), a value of -1 means that lhs is
+less than rhs.  A value of 0 means they're equivalent, and a value of 1 means
+lhs is greater than rhs.
+
+    >>> print "To compare, use .compare(): %d" % (e3.compare(e4))
+    To compare, use .compare(): -1
+
+    >>> e5 = x <= 4
+    >>> e4.compare(e5)
+    0
+
+There is a "gotcha" when using Python's operators and literal numbers as the lhs
+argument.  Due to the order that Python decides to parse a statement, it may not
+immediately find two objects comparable.  For example to evaluate the statement
+(1 < x), Python will first recognize the number 1 as a native number, and then
+that x is *not* a native number.  At this point, because Python numbers have no
+__lt__ methods, it will instead call the reflective operation:
+
+x > 1
+
+this is equivalent to x.__gt__( 1 ).  Unfortunately, there is no way available
+to SymPy to recognize this has happened, so the statement (1 < x) will turn
+silently into (x > 1).  (Note that the position of the literal as an lhs or rhs
+is only dependent on the specific implementation of Python.  On another parser,
+this could easily turn (x > 1) into (1 < x).  This is another reason to use S()
+and the .lts/.gts over .lhs/.rhs, as appropriate.)
+
+    >>> e1 = x >  1
+    >>> e2 = x >= 1
+    >>> e3 = x <  1
+    >>> e4 = x <= 1
+    >>> e5 = 1 >  x
+    >>> e6 = 1 >= x
+    >>> e7 = 1 <  x
+    >>> e8 = 1 <= x
+    >>> print "%s     %s\\n"*4 % (e1, e2, e3, e4, e5, e6, e7, e8)
+    x > 1     x >= 1
+    x < 1     x <= 1
+    x < 1     x <= 1
+    x > 1     x >= 1
+
+If the order of the statement is important (for visual output to the console,
+perhaps), one can work around this annoyance in a couple ways: (1) "Sympify" the
+literal before comparison, (2) use one of the wrappers, or (3) use the less
+succinct methods described above:
+
+    >>> e1 = S(1) >  x
+    >>> e2 = S(1) >= x
+    >>> e3 = S(1) <  x
+    >>> e4 = S(1) <= x
+    >>> e5 = Gt(1, x)
+    >>> e6 = Ge(1, x)
+    >>> e7 = Lt(1, x)
+    >>> e8 = Le(1, x)
+    >>> print "%s     %s\\n"*4 % (e1, e2, e3, e4, e5, e6, e7, e8)
+    1 > x     1 >= x
+    1 < x     1 <= x
+    1 > x     1 >= x
+    1 < x     1 <= x
+
+"""
 
     rel_op = '>='
 
@@ -269,10 +459,10 @@ class GreaterThan(_Greater):
         return st == ot
 
 class LessThan(_Less):
+    __doc__ = GreaterThan.__doc__
+    __slots__ = ()
 
     rel_op = '<='
-
-    __slots__ = ()
 
     def __hash__ ( self ):   # because __eq__ is overridden as well
         return super(LessThan, self).__hash__()
@@ -297,10 +487,10 @@ class LessThan(_Less):
         return st == ot
 
 class StrictGreaterThan(_Greater):
+    __doc__ = GreaterThan.__doc__
+    __slots__ = ()
 
     rel_op = '>'
-
-    __slots__ = ()
 
     def __hash__ ( self ):   # because __eq__ is overridden as well
         return super(StrictGreaterThan, self).__hash__()
@@ -325,10 +515,10 @@ class StrictGreaterThan(_Greater):
         return st == ot
 
 class StrictLessThan(_Less):
+    __doc__ = GreaterThan.__doc__
+    __slots__ = ()
 
     rel_op = '<'
-
-    __slots__ = ()
 
     def __hash__ ( self ):   # because __eq__ is overridden as well
         return super(StrictLessThan, self).__hash__()
@@ -352,9 +542,9 @@ class StrictLessThan(_Less):
 
         return st == ot
 
-# A class (not object) specific data item used for a minor speedup.  It is
-# defined here, rather than directly in the class, because the classes that it
-# references have not been defined until now (e.g. StrictLessThan).
+# A class-specific (not object-specific) data item used for a minor speedup.  It
+# is defined here, rather than directly in the class, because the classes that
+# it references have not been defined until now (e.g. StrictLessThan).
 Relational.ValidRelationOperator = {
   None : Equality,
   '==' : Equality,

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -245,7 +245,9 @@ class GreaterThan(_Greater):
     rel_op = '>='
 
     __slots__ = ()
-    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
+
+    def __hash__ ( self ):   # because __eq__ is overridden as well
+        return super(GreaterThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -271,7 +273,9 @@ class LessThan(_Less):
     rel_op = '<='
 
     __slots__ = ()
-    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
+
+    def __hash__ ( self ):   # because __eq__ is overridden as well
+        return super(LessThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -297,7 +301,9 @@ class StrictGreaterThan(_Greater):
     rel_op = '>'
 
     __slots__ = ()
-    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
+
+    def __hash__ ( self ):   # because __eq__ is overridden as well
+        return super(StrictGreaterThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -323,7 +329,9 @@ class StrictLessThan(_Less):
     rel_op = '<'
 
     __slots__ = ()
-    __hash__ = Basic.__hash__  # because __eq__ is overridden as well
+
+    def __hash__ ( self ):   # because __eq__ is overridden as well
+        return super(StrictLessThan, self).__hash__()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -447,13 +447,14 @@ class GreaterThan(_Greater):
     >>> e
     (x < y) < z
 
-    Any code that explicitly relies on this latter behavior will not be robust
-    as this is not correct and will be fixed at some point.  For the time being
-    (circa Jan 2012), use And to create chained inequalities.
+    Any code that explicitly relies on this latter functionality will not be
+    robust as this behaviour is completely wrong and will be corrected at some
+    point.  For the time being (circa Jan 2012), use And to create chained
+    inequalities.
 
-    .. [1] This implementation detail is that Python provides no reliable method to
-    determine that a chained inequality is being built.  Chained comparison
-    operators are evaluated pairwise, using "and" logic (see
+    ..  [1] This implementation detail is that Python provides no reliable
+    method to determine that a chained inequality is being built.  Chained
+    comparison operators are evaluated pairwise, using "and" logic (see
     http://docs.python.org/reference/expressions.html#notin).  This is done in
     an efficient way, so that each object being compared is only evaluated once
     and the comparison can short-circuit.  For example, ``1 > 2 > 3`` is

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -225,8 +225,6 @@ class _Greater(Relational):
     it for the .gts and .lts properties.
     """
 
-    is_comparable = False
-
     __slots__ = ()
 
     @property
@@ -243,8 +241,6 @@ class _Less(Relational):
     _Less is only used so that LessThan and StrictLessThan may subclass it for
     the .gts and .lts properties.
     """
-
-    is_comparable = False
 
     __slots__ = ()
 
@@ -272,17 +268,31 @@ class GreaterThan(_Greater):
 
     In total, there are four *Than classes, to represent the four inequalities:
 
-    GreaterThan       (>=)
-    LessThan          (<=)
-    StrictGreaterThan (>)
-    StrictLessThan    (<)
+    +-----------------+--------+
+    |Class Name       | Symbol |
+    +=================+========+
+    |GreaterThan      | (>=)   |
+    +-----------------+--------+
+    |LessThan         | (<=)   |
+    +-----------------+--------+
+    |StrictGreaterThan| (>)    |
+    +-----------------+--------+
+    |StrictLessThan   | (<)    |
+    +-----------------+--------+
 
     All classes take two arguments, lhs and rhs.
 
-    GreaterThan(lhs, rhs)       --> lhs >= rhs
-    LessThan(lhs, rhs)          --> lhs <= rhs
-    StrictGreaterThan(lhs, rhs) --> lhs >  rhs
-    StrictLessThan(lhs, rhs)    --> lhs <  rhs
+    +----------------------------+-----------------+
+    |Signature Example           | Math equivalent |
+    +============================+=================+
+    |GreaterThan(lhs, rhs)       |   lhs >= rhs    |
+    +----------------------------+-----------------+
+    |LessThan(lhs, rhs)          |   lhs <= rhs    |
+    +----------------------------+-----------------+
+    |StrictGreaterThan(lhs, rhs) |   lhs >  rhs    |
+    +----------------------------+-----------------+
+    |StrictLessThan(lhs, rhs)    |   lhs <  rhs    |
+    +----------------------------+-----------------+
 
     In addition to the normal .lhs and .rhs of Relations, *Than inequality
     objects also have the .lts and .gts properties, which represent the "less
@@ -372,10 +382,9 @@ class GreaterThan(_Greater):
     statement (1 < x), Python will first recognize the number 1 as a native
     number, and then that x is *not* a native number.  At this point, because a
     native Python number does not know how to compare itself with a SymPy object
-    Python will try the reflective operation (x > 1), which is equivalent to
-    x.__gt__( 1 ).  Unfortunately, there is no way available to SymPy to
-    recognize this has happened, so the statement (1 < x) will turn silently
-    into (x > 1).
+    Python will try the reflective operation (x > 1).  Unfortunately, there is
+    no way available to SymPy to recognize this has happened, so the statement
+    (1 < x) will turn silently into (x > 1).
 
     >>> e1 = x >  1
     >>> e2 = x >= 1
@@ -413,11 +422,12 @@ class GreaterThan(_Greater):
     The other gotcha is with chained inequalities.  Occasionally, one may be
     tempted to write statements like:
 
+    #doctest: +SKIP
     >>> e = x < y < z  # silent error!  Where did ``x`` go?
     >>> e
     y < z
 
-    Due to an implementation detail or decision of Python[2], there is no way
+    Due to an implementation detail or decision of Python[1], there is no way
     for SymPy to reliably create that as a chained inequality.  To create a
     chained inequality, the only method currently available is to make use of
     And:
@@ -429,7 +439,7 @@ class GreaterThan(_Greater):
     And(x < y, y < z)
 
     Note that this is different than chaining an equality directly via use of
-    parenthesis (this is currently an open bug in SymPy[1]):
+    parenthesis (this is currently an open bug in SymPy[2]):
 
     >>> e = (x < y) < z
     >>> type( e )
@@ -441,15 +451,7 @@ class GreaterThan(_Greater):
     as this is not correct and will be fixed at some point.  For the time being
     (circa Jan 2012), use And to create chained inequalities.
 
-    [1] For more information, see these two bug reports:
-
-    "Separate boolean and symbolic relationals"
-    http://code.google.com/p/sympy/issues/detail?id=1887
-
-    "It right 0 < x < 1 ?"
-    http://code.google.com/p/sympy/issues/detail?id=2960
-
-    [2] This implementation detail is that Python provides no reliable method to
+    .. [1] This implementation detail is that Python provides no reliable method to
     determine that a chained inequality is being built.  Chained comparison
     operators are evaluated pairwise, using "and" logic (see
     http://docs.python.org/reference/expressions.html#notin).  This is done in
@@ -472,14 +474,22 @@ class GreaterThan(_Greater):
 
     Because of the "and" added at step 2, the statement gets turned into a weak
     ternary statement.  If the first object evalutes __nonzero__ as True, then
-    the second object is returned.  If the first object evaluates __nonzero__ as
-    False, then nothing is returned.
+    the second object, (y > z) is returned.  If the first object evaluates
+    __nonzero__ as False (step 5), then (x > y) is returned.
 
-    In Python, there is no way to override the ``and`` operator, or to control
-    how it short circuits, so it is impossible to make something like ``x > y >
-    z`` work.  There is an open PEP to change this
-    http://www.python.org/dev/peps/pep-0335/, but until that is implemented,
-    this cannot be made to work.
+        In Python, there is no way to override the ``and`` operator, or to
+        control how it short circuits, so it is impossible to make something
+        like ``x > y > z`` work.  There is an open PEP to change this
+        http://www.python.org/dev/peps/pep-0335/, but until that is implemented,
+        this cannot be made to work.
+
+    .. [2] For more information, see these two bug reports:
+
+    "Separate boolean and symbolic relationals"
+    `Issue 1887 <http://code.google.com/p/sympy/issues/detail?id=1887>`
+
+    "It right 0 < x < 1 ?"
+    `Issue 2960 <http://code.google.com/p/sympy/issues/detail?id=2960>`
 
 """
 

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -221,6 +221,8 @@ class Unequality(Relational):
         return self.lhs.compare(self.rhs)!=0
 
 class _Greater(Relational):
+    __slots__ = ()
+
     @property
     def gts(self):
         return self._args[0]
@@ -230,6 +232,8 @@ class _Greater(Relational):
         return self._args[1]
 
 class _Less(Relational):
+    __slots__ = ()
+
     @property
     def gts(self):
         return self._args[1]
@@ -242,7 +246,7 @@ class GreaterThan(_Greater):
 
     rel_op = '>='
 
-    __slots__ = []
+    __slots__ = ()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -267,7 +271,7 @@ class LessThan(_Less):
 
     rel_op = '<='
 
-    __slots__ = []
+    __slots__ = ()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -292,7 +296,7 @@ class StrictGreaterThan(_Greater):
 
     rel_op = '>'
 
-    __slots__ = []
+    __slots__ = ()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
@@ -317,7 +321,7 @@ class StrictLessThan(_Less):
 
     rel_op = '<'
 
-    __slots__ = []
+    __slots__ = ()
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -99,8 +99,8 @@ def Gt(a, b):
 
     >>> from sympy import Gt
     >>> from sympy.abc import x, y
-    >>> Gt(y, x+x**2)
-    x**2 + x < y
+    >>> Gt(y, x + x**2)
+    y > x**2 + x
 
     """
     return Relational(a,b,'>')
@@ -115,8 +115,8 @@ def Ge(a, b):
 
     >>> from sympy import Ge
     >>> from sympy.abc import x, y
-    >>> Ge(y, x+x**2)
-    x**2 + x <= y
+    >>> Ge(y, x + x**2)
+    y >= x**2 + x
 
     """
     return Relational(a,b,'>=')

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -219,10 +219,14 @@ class Unequality(Relational):
         return self.lhs.compare(self.rhs)!=0
 
 class _Greater(Relational):
-    """\
-Not intended for general use; _Greater is only used so that GreaterThan and
-StrictGreaterThan may subclass it for the .gts and .lts properties.
-"""
+    """Not intended for general use
+
+    _Greater is only used so that GreaterThan and StrictGreaterThan may subclass
+    it for the .gts and .lts properties.
+    """
+
+    is_comparable = False
+
     __slots__ = ()
 
     @property
@@ -234,11 +238,14 @@ StrictGreaterThan may subclass it for the .gts and .lts properties.
         return self._args[1]
 
 class _Less(Relational):
-    """\
+    """Not intended for general use.
 
-Not intended for general use; _Less is only used so that LessThan and
-StrictLessThan may subclass it for the .gts and .lts properties.
-"""
+    _Less is only used so that LessThan and StrictLessThan may subclass it for
+    the .gts and .lts properties.
+    """
+
+    is_comparable = False
+
     __slots__ = ()
 
     @property
@@ -250,60 +257,74 @@ StrictLessThan may subclass it for the .gts and .lts properties.
         return self._args[0]
 
 class GreaterThan(_Greater):
-    """\
-The *Than classes represent inequal relationships, where the left-hand side is
-generally bigger or smaller than the right-hand side.  For example, the
-GreaterThan class represents an inequal relationship where the left-hand side is
-at least as big as the right side, if not bigger.  In mathematical notation:
+    """Class representations of inequalities.
+
+    Extended Summary
+    ================
+
+    The *Than classes represent inequal relationships, where the left-hand side
+    is generally bigger or smaller than the right-hand side.  For example, the
+    GreaterThan class represents an inequal relationship where the left-hand
+    side is at least as big as the right side, if not bigger.  In mathematical
+    notation:
 
     lhs >= rhs
 
-In total, there are four *Than classes, to represent the four inequalities:
+    In total, there are four *Than classes, to represent the four inequalities:
 
-GreaterThan       (>=)
-LessThan          (<=)
-StrictGreaterThan (>)
-StrictLessThan    (<)
+    GreaterThan       (>=)
+    LessThan          (<=)
+    StrictGreaterThan (>)
+    StrictLessThan    (<)
 
-In addition to the normal .lhs and .rhs of Relations, *Than inequality objects
-also have the .lts and .gts properties, which represent the "less than side" and
-"greater than side" of the operator.  Use of .lts and .gts in an algorithm
-rather than .lhs, .rhs, and an assumption of inequality direction, will make
-more explicit the intent of a certain section of code, and will make it
-similarly more robust to client code changes:
+    All classes take two arguments, lhs and rhs.
+
+    GreaterThan(lhs, rhs)       --> lhs >= rhs
+    LessThan(lhs, rhs)          --> lhs <= rhs
+    StrictGreaterThan(lhs, rhs) --> lhs >  rhs
+    StrictLessThan(lhs, rhs)    --> lhs <  rhs
+
+    In addition to the normal .lhs and .rhs of Relations, *Than inequality
+    objects also have the .lts and .gts properties, which represent the "less
+    than side" and "greater than side" of the operator.  Use of .lts and .gts in
+    an algorithm rather than .lhs and .rhs as an assumption of inequality
+    direction will make more explicit the intent of a certain section of code,
+    and will make it similarly more robust to client code changes:
 
     >>> from sympy import GreaterThan, StrictGreaterThan
     >>> from sympy import LessThan,    StrictLessThan
     >>> from sympy import And, Ge, Gt, Le, Lt, Rel, S
     >>> from sympy.abc import x, y, z
     >>> from sympy.core.relational import Relational
-    >>> e = Ge(x, 1)
-    >>> print( e )
-    x >= 1
-    >>> print "%s >= %s is the same as %s <= %s" % (e.gts, e.lts, e.lts, e.gts)
-    x >= 1 is the same as 1 <= x
 
-One generally does not instantiate these classes directly, but uses various
-convenience methods:
+    >>> e = GreaterThan(x, 1)
+    >>> e
+    x >= 1
+    >>> '%s >= %s is the same as %s <= %s' % (e.gts, e.lts, e.lts, e.gts)
+    'x >= 1 is the same as 1 <= x'
+
+    Examples
+    ========
+
+    One generally does not instantiate these classes directly, but uses various
+    convenience methods:
 
     >>> e1 = Ge( x, 2 )      # Ge is a convenience wrapper
     >>> print e1
     x >= 2
 
-    >>> Ge( x, 2 )
+    >>> rels = Ge( x, 2 ), Gt( x, 2 ), Le( x, 2 ), Lt( x, 2 )
+    >>> print '%s\\n%s\\n%s\\n%s' % rels
     x >= 2
-    >>> Gt( x, 2 )
     x > 2
-    >>> Le( x, 2 )
     x <= 2
-    >>> Lt( x, 2 )
     x < 2
 
-Another option is to use the Python inequality operators (>=, >, <=, <)
-directly.  Their main advantage over the Ge, Gt, Le, and Lt counterparts, is
-that one can write a more "mathematical looking" statement rather than littering
-the math with oddball function calls.  However there are certain (minor) caveats
-of which to be aware (search for 'gotcha', below).
+    Another option is to use the Python inequality operators (>=, >, <=, <)
+    directly.  Their main advantage over the Ge, Gt, Le, and Lt counterparts, is
+    that one can write a more "mathematical looking" statement rather than
+    littering the math with oddball function calls.  However there are certain
+    (minor) caveats of which to be aware (search for 'gotcha', below).
 
     >>> e2 = x >= 2
     >>> print e2
@@ -313,90 +334,48 @@ of which to be aware (search for 'gotcha', below).
     >>> e1 == e2
     True
 
-However, it is also perfectly valid to instantiate a *Than class less succinctly
-and less conviently:
+    However, it is also perfectly valid to instantiate a *Than class less
+    succinctly and less conviently:
 
-    >>> Rel(x, 1, '>=')
+    >>> rels = Rel(x, 1, '>='), Relational(x, 1, '>='), GreaterThan(x, 1)
+    >>> print '%s\\n%s\\n%s' % rels
     x >= 1
-    >>> Relational(x, 1, '>=')
     x >= 1
-    >>> GreaterThan(x, 1)
     x >= 1
 
-    >>> Rel(x, 1, '>')
+    >>> rels = Rel(x, 1, '>'), Relational(x, 1, '>'), StrictGreaterThan(x, 1)
+    >>> print '%s\\n%s\\n%s' % rels
     x > 1
-    >>> Relational(x, 1, '>')
     x > 1
-    >>> StrictGreaterThan(x, 1)
     x > 1
 
-    >>> Rel(x, 1, '<=')
+    >>> rels = Rel(x, 1, '<='), Relational(x, 1, '<='), LessThan(x, 1)
+    >>> print "%s\\n%s\\n%s" % rels
     x <= 1
-    >>> Relational(x, 1, '<=')
     x <= 1
-    >>> LessThan(x, 1)
     x <= 1
 
-    >>> Rel(x, 1, '<')
+    >>> rels = Rel(x, 1, '<'), Relational(x, 1, '<'), StrictLessThan(x, 1)
+    >>> print '%s\\n%s\\n%s' % rels
     x < 1
-    >>> Relational(x, 1, '<')
     x < 1
-    >>> StrictLessThan(x, 1)
     x < 1
 
+    Notes
+    =====
 
-The *Than inequality classes smartly compare equivalent:
+    There are a couple of "gotchas" when using Python's operators.
 
-    >>> e3 = Le( 2, x )
-    >>> print "e2: %s,   e3: %s" % (e2, e3)
-    e2: x >= 2,   e3: 2 <= x
-    >>> e2 == e3
-    True
-
-    >>> print "e: %s,   e3: %s" % (e, e3)
-    e: x >= 1,   e3: 2 <= x
-    >>> e == e3
-    False
-    >>> e != e3
-    True
-
-SymPy allows nesting of inequalities[1], so to compare whole inequality
-expressions, use .compare():
-
-    >>> e4 = Le( x, 4 )
-    >>> print "e3: %s,   e4: %s" % (e3, e4)
-    e3: 2 <= x,   e4: x <= 4
-    >>> print "Nested inequality: %s" % (e3 > e4)
-    Nested inequality: (2 <= x) > (x <= 4)
-
-When comparing lhs to rhs (lhs.compare(rhs)), a value of -1 means that lhs is
-less than rhs.  A value of 0 means they're equivalent, and a value of 1 means
-lhs is greater than rhs.
-
-    >>> print "To compare, use .compare(): %d" % (e3.compare(e4))
-    To compare, use .compare(): -1
-
-    >>> e5 = x <= 4
-    >>> e4.compare(e5)
-    0
-
-There are a couple of "gotchas" when using Python's operators.
-
-The first enters the mix when comparing against a literal number as the lhs
-argument.  Due to the order that Python decides to parse a statement, it may not
-immediately find two objects comparable.  For example to evaluate the statement
-(1 < x), Python will first recognize the number 1 as a native number, and then
-that x is *not* a native number.  At this point, because Python numbers have no
-__lt__ methods, it will instead call the reflective operation:
-
-x > 1
-
-this is equivalent to x.__gt__( 1 ).  Unfortunately, there is no way available
-to SymPy to recognize this has happened, so the statement (1 < x) will turn
-silently into (x > 1).  (Note that the position of the literal as an lhs or rhs
-is only dependent on the specific implementation of Python.  On another parser,
-this could easily turn (x > 1) into (1 < x).  This is another reason to use S()
-and the .lts/.gts over .lhs/.rhs, as appropriate.)
+    The first enters the mix when comparing against a literal number as the lhs
+    argument.  Due to the order that Python decides to parse a statement, it may
+    not immediately find two objects comparable.  For example, to evaluate the
+    statement (1 < x), Python will first recognize the number 1 as a native
+    number, and then that x is *not* a native number.  At this point, because a
+    native Python number does not know how to compare itself with a SymPy object
+    Python will try the reflective operation (x > 1), which is equivalent to
+    x.__gt__( 1 ).  Unfortunately, there is no way available to SymPy to
+    recognize this has happened, so the statement (1 < x) will turn silently
+    into (x > 1).
 
     >>> e1 = x >  1
     >>> e2 = x >= 1
@@ -412,10 +391,10 @@ and the .lts/.gts over .lhs/.rhs, as appropriate.)
     x < 1     x <= 1
     x > 1     x >= 1
 
-If the order of the statement is important (for visual output to the console,
-perhaps), one can work around this annoyance in a couple ways: (1) "Sympify" the
-literal before comparison, (2) use one of the wrappers, or (3) use the less
-succinct methods described above:
+    If the order of the statement is important (for visual output to the
+    console, perhaps), one can work around this annoyance in a couple ways: (1)
+    "sympify" the literal before comparison, (2) use one of the wrappers, or (3)
+    use the less succinct methods described above:
 
     >>> e1 = S(1) >  x
     >>> e2 = S(1) >= x
@@ -431,15 +410,17 @@ succinct methods described above:
     1 > x     1 >= x
     1 < x     1 <= x
 
-The other gotcha is with chained inequalities.  Occasionally, one may be tempted
-to write statements like:
+    The other gotcha is with chained inequalities.  Occasionally, one may be
+    tempted to write statements like:
 
-e = x < y < z  # silent error!
-e
+    >>> e = x < y < z  # silent error!  Where did ``x`` go?
+    >>> e
+    y < z
 
-Due to an implementation detail or decision of Python[2], there is no way for
-SymPy to reliably create that as a chained inequality.  To create a chained
-inequality, the only method currently available is to make use of And:
+    Due to an implementation detail or decision of Python[2], there is no way
+    for SymPy to reliably create that as a chained inequality.  To create a
+    chained inequality, the only method currently available is to make use of
+    And:
 
     >>> e = And(x < y, y < z)
     >>> type( e )
@@ -447,8 +428,8 @@ inequality, the only method currently available is to make use of And:
     >>> e
     And(x < y, y < z)
 
-Note that this is different than chaining an equality directly via use of
-parenthesis (this is currently an open bug in SymPy):
+    Note that this is different than chaining an equality directly via use of
+    parenthesis (this is currently an open bug in SymPy[1]):
 
     >>> e = (x < y) < z
     >>> type( e )
@@ -456,23 +437,49 @@ parenthesis (this is currently an open bug in SymPy):
     >>> e
     (x < y) < z
 
-Any code that explicitly relies on this latter behavior will not be robust as
-this is not correct and will be corrected at some point.  For the time being
-(circa Jan 2012), use And to create chained inequalities.
+    Any code that explicitly relies on this latter behavior will not be robust
+    as this is not correct and will be fixed at some point.  For the time being
+    (circa Jan 2012), use And to create chained inequalities.
 
-[1] As currently implemented, this is actually a bug.  For more information,
-see these two bug reports:
+    [1] For more information, see these two bug reports:
 
-"Separate boolean and symbolic relationals"
-http://code.google.com/p/sympy/issues/detail?id=1887
+    "Separate boolean and symbolic relationals"
+    http://code.google.com/p/sympy/issues/detail?id=1887
 
-"It right 0 < x < 1 ?"
-http://code.google.com/p/sympy/issues/detail?id=2960
+    "It right 0 < x < 1 ?"
+    http://code.google.com/p/sympy/issues/detail?id=2960
 
-[2] This implementation detail is that Python provides no reliable method to
-determine that a chained inequality is being built.  For that, SymPy would at
-least need Python to allow code to override __and__, which it currently does
-not.  See issue 2960, referenced in the previous footnote.
+    [2] This implementation detail is that Python provides no reliable method to
+    determine that a chained inequality is being built.  Chained comparison
+    operators are evaluated pairwise, using "and" logic (see
+    http://docs.python.org/reference/expressions.html#notin).  This is done in
+    an efficient way, so that each object being compared is only evaluated once
+    and the comparison can short-circuit.  For example, ``1 > 2 > 3`` is
+    evaluated by Python as ``(1 > 2) and (2 > 3)``.  The ``and`` operator
+    coerces each side into a bool, returning the object itself when it
+    short-circuits.  Currently, the bool of the *Than operators will give True
+    or False arbitrarily.  Thus, if we were to compute ``x > y > z``, with
+    ``x``, ``y``, and ``z`` being Symbols, Python converts the statement
+    (roughly) into these steps:
+
+    (1) x > y > z
+    (2) (x > y) and (y > z)
+    (3) (GreaterThanObject) and (y > z)
+    (4) (GreaterThanObject.__nonzero__()) and (y > z)
+    (5) (True) and (y > z)
+    (6) (y > z)
+    (7) LessThanObject
+
+    Because of the "and" added at step 2, the statement gets turned into a weak
+    ternary statement.  If the first object evalutes __nonzero__ as True, then
+    the second object is returned.  If the first object evaluates __nonzero__ as
+    False, then nothing is returned.
+
+    In Python, there is no way to override the ``and`` operator, or to control
+    how it short circuits, so it is impossible to make something like ``x > y >
+    z`` work.  There is an open PEP to change this
+    http://www.python.org/dev/peps/pep-0335/, but until that is implemented,
+    this cannot be made to work.
 
 """
 
@@ -513,7 +520,7 @@ class LessThan(_Less):
 
     @classmethod
     def _eval_relation(cls, lhs, rhs):
-         return lhs <= rhs
+        return lhs <= rhs
 
     def __nonzero__(self):
         return self.lhs.compare( self.rhs ) <= 0

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -127,15 +127,15 @@ class Relational(Expr, EvalfMixin):
 
     is_Relational = True
 
+    # ValidRelationOperator - Defined below, because the necessary classes
+    #   have not yet been defined
+
     @staticmethod
     def get_relational_class(rop):
-        if rop is None or rop in ('==','eq'): return Equality
-        if rop in ('!=','<>','ne'):           return Unequality
-        if rop in ('<','lt'):                 return StrictLessThan
-        if rop in ('<=','le'):                return LessThan
-        if rop in ('>','gt'):                 return StrictGreaterThan
-        if rop in ('>=','ge'):                return GreaterThan
-        raise ValueError("Invalid relational operator symbol: %r" % (rop))
+        try:
+            return Relational.ValidRelationOperator[ rop ]
+        except KeyError:
+            raise ValueError("Invalid relational operator symbol: %r" % (rop))
 
     def __new__(cls, lhs, rhs, rop=None, **assumptions):
         lhs = _sympify(lhs)
@@ -349,3 +349,23 @@ class StrictLessThan(_Less):
         st = self._hashable_content()
 
         return st == ot
+
+# A class (not object) specific data item used for a minor speedup.  It is
+# defined here, rather than directly in the class, because the classes that it
+# references have not been defined until now (e.g. StrictLessThan).
+Relational.ValidRelationOperator = {
+  None : Equality,
+  '==' : Equality,
+  'eq' : Equality,
+  '!=' : Unequality,
+  '<>' : Unequality,
+  'ne' : Unequality,
+  '>=' : GreaterThan,
+  'ge' : GreaterThan,
+  '<=' : LessThan,
+  'le' : LessThan,
+  '>'  : StrictGreaterThan,
+  'gt' : StrictGreaterThan,
+  '<'  : StrictLessThan,
+  'lt' : StrictLessThan,
+}

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -278,17 +278,25 @@ def test_sympy__core__relational__Equality():
     from sympy.core.relational import Equality
     assert _test_args(Equality(x, 2))
 
-def test_sympy__core__relational__Inequality():
-    from sympy.core.relational import Inequality
-    assert _test_args(Inequality(x, 2))
+def test_sympy__core__relational__GreaterThan():
+    from sympy.core.relational import GreaterThan
+    assert _test_args(GreaterThan(x, 2))
+
+def test_sympy__core__relational__LessThan():
+    from sympy.core.relational import LessThan
+    assert _test_args(LessThan(x, 2))
 
 @SKIP("abstract class")
 def test_sympy__core__relational__Relational():
     pass
 
-def test_sympy__core__relational__StrictInequality():
-    from sympy.core.relational import StrictInequality
-    assert _test_args(StrictInequality(x, 2))
+def test_sympy__core__relational__StrictGreaterThan():
+    from sympy.core.relational import StrictGreaterThan
+    assert _test_args(StrictGreaterThan(x, 2))
+
+def test_sympy__core__relational__StrictLessThan():
+    from sympy.core.relational import StrictLessThan
+    assert _test_args(StrictLessThan(x, 2))
 
 def test_sympy__core__relational__Unequality():
     from sympy.core.relational import Unequality

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,8 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import symbols, oo
-from sympy.core.relational import ( Relational, Equality, GreaterThan,
-    LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le, Gt, Ge, Ne )
+from sympy import Symbol, symbols, oo
+from sympy.core.relational import ( Relational, Equality, Unequality,
+    GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le,
+    Gt, Ge, Ne )
 
 x,y,z = symbols('x,y,z')
 
@@ -143,6 +144,102 @@ def test_doit():
     assert Lt(nn, 0).doit() is False
 
     assert Eq(x, 0).doit() == Eq(x, 0)
+
+def test_new_relational():
+    x = Symbol('x')
+
+    assert Eq(x)     == Relational(x, 0)       # None ==> Equality
+    assert Eq(x)     == Relational(x, 0, '==')
+    assert Eq(x)     == Relational(x, 0, 'eq')
+    assert Eq(x)     == Equality(x, 0)
+    assert Eq(x, -1) == Relational(x, -1)       # None ==> Equality
+    assert Eq(x, -1) == Relational(x, -1, '==')
+    assert Eq(x, -1) == Relational(x, -1, 'eq')
+    assert Eq(x, -1) == Equality(x, -1)
+    assert Eq(x)     != Relational(x, 1)       # None ==> Equality
+    assert Eq(x)     != Relational(x, 1, '==')
+    assert Eq(x)     != Relational(x, 1, 'eq')
+    assert Eq(x)     != Equality(x, 1)
+    assert Eq(x, -1) != Relational(x, 1)       # None ==> Equality
+    assert Eq(x, -1) != Relational(x, 1, '==')
+    assert Eq(x, -1) != Relational(x, 1, 'eq')
+    assert Eq(x, -1) != Equality(x, 1)
+
+    assert Ne(x, 0) == Relational(x, 0, '!=')
+    assert Ne(x, 0) == Relational(x, 0, '<>')
+    assert Ne(x, 0) == Relational(x, 0, 'ne')
+    assert Ne(x, 0) == Unequality(x, 0)
+    assert Ne(x, 0) != Relational(x, 1, '!=')
+    assert Ne(x, 0) != Relational(x, 1, '<>')
+    assert Ne(x, 0) != Relational(x, 1, 'ne')
+    assert Ne(x, 0) != Unequality(x, 1)
+
+    assert Ge(x, 0) == Relational(x, 0, '>=')
+    assert Ge(x, 0) == Relational(x, 0, 'ge')
+    assert Ge(x, 0) == GreaterThan(x, 0)
+    assert Ge(x, 1) != Relational(x, 0, '>=')
+    assert Ge(x, 1) != Relational(x, 0, 'ge')
+    assert Ge(x, 1) != GreaterThan(x, 0)
+    assert (x >= 1) == Relational(x, 1, '>=')
+    assert (x >= 1) == Relational(x, 1, 'ge')
+    assert (x >= 1) == GreaterThan(x, 1)
+    assert (x >= 0) != Relational(x, 1, '>=')
+    assert (x >= 0) != Relational(x, 1, 'ge')
+    assert (x >= 0) != GreaterThan(x, 1)
+
+    assert Le(x, 0) == Relational(x, 0, '<=')
+    assert Le(x, 0) == Relational(x, 0, 'le')
+    assert Le(x, 0) == LessThan(x, 0)
+    assert Le(x, 1) != Relational(x, 0, '<=')
+    assert Le(x, 1) != Relational(x, 0, 'le')
+    assert Le(x, 1) != LessThan(x, 0)
+    assert (x <= 1) == Relational(x, 1, '<=')
+    assert (x <= 1) == Relational(x, 1, 'le')
+    assert (x <= 1) == LessThan(x, 1)
+    assert (x <= 0) != Relational(x, 1, '<=')
+    assert (x <= 0) != Relational(x, 1, 'le')
+    assert (x <= 0) != LessThan(x, 1)
+
+    assert Gt(x, 0) == Relational(x, 0, '>')
+    assert Gt(x, 0) == Relational(x, 0, 'gt')
+    assert Gt(x, 0) == StrictGreaterThan(x, 0)
+    assert Gt(x, 1) != Relational(x, 0, '>')
+    assert Gt(x, 1) != Relational(x, 0, 'gt')
+    assert Gt(x, 1) != StrictGreaterThan(x, 0)
+    assert (x > 1) == Relational(x, 1, '>')
+    assert (x > 1) == Relational(x, 1, 'gt')
+    assert (x > 1) == StrictGreaterThan(x, 1)
+    assert (x > 0) != Relational(x, 1, '>')
+    assert (x > 0) != Relational(x, 1, 'gt')
+    assert (x > 0) != StrictGreaterThan(x, 1)
+
+    assert Lt(x, 0) == Relational(x, 0, '<')
+    assert Lt(x, 0) == Relational(x, 0, 'lt')
+    assert Lt(x, 0) == StrictLessThan(x, 0)
+    assert Lt(x, 1) != Relational(x, 0, '<')
+    assert Lt(x, 1) != Relational(x, 0, 'lt')
+    assert Lt(x, 1) != StrictLessThan(x, 0)
+    assert (x < 1)  == Relational(x, 1, '<')
+    assert (x < 1)  == Relational(x, 1, 'lt')
+    assert (x < 1)  == StrictLessThan(x, 1)
+    assert (x < 0)  != Relational(x, 1, '<')
+    assert (x < 0)  != Relational(x, 1, 'lt')
+    assert (x < 0)  != StrictLessThan(x, 1)
+
+
+    # finally, some fuzz testing
+    from random import randint
+    for i in range(100):
+        while 1:
+            strtype, length = (unichr, 65535) if randint(0, 1) else (chr, 255)
+            relation_type = strtype( randint(0, length) )
+            if randint(0, 1):
+                relation_type += strtype( randint(0, length) )
+            if relation_type not in ('==', 'eq', '!=', '<>', 'ne', '>=', 'ge',
+                                     '<=', 'le', '>', 'gt', '<', 'lt'):
+                break
+
+        raises(ValueError, "Relational(x, 1, relation_type)" )
 
 @XFAIL
 def test_relational_bool_output():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import symbols, oo
-from sympy.core.relational import Relational, Equality, StrictGreaterThan, \
-    StrictLessThan, Rel, Eq, Lt, Le, Gt, Ge, Ne
+from sympy.core.relational import ( Relational, Equality, GreaterThan,
+    LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le, Gt, Ge, Ne )
 
 x,y,z = symbols('x,y,z')
 
@@ -15,6 +15,27 @@ def test_rel_subs():
     e = e.subs(x,z)
 
     assert isinstance(e, Equality)
+    assert e.lhs == z
+    assert e.rhs == y
+
+    e = Relational(x, y, '>=')
+    e = e.subs(x,z)
+
+    assert isinstance(e, GreaterThan)
+    assert e.lhs == z
+    assert e.rhs == y
+
+    e = Relational(x, y, '<=')
+    e = e.subs(x,z)
+
+    assert isinstance(e, LessThan)
+    assert e.lhs == z
+    assert e.rhs == y
+
+    e = Relational(x, y, '>')
+    e = e.subs(x,z)
+
+    assert isinstance(e, StrictGreaterThan)
     assert e.lhs == z
     assert e.rhs == y
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -21,7 +21,7 @@ def test_rel_subs():
     e = Relational(x, y, '<')
     e = e.subs(x,z)
 
-    assert isinstance(e, StrictInequality)
+    assert isinstance(e, StrictLessThan)
     assert e.lhs == z
     assert e.rhs == y
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import symbols, oo
-from sympy.core.relational import Relational, Equality, StrictInequality, \
-    Rel, Eq, Lt, Le, Gt, Ge, Ne
+from sympy.core.relational import Relational, Equality, StrictGreaterThan, \
+    StrictLessThan, Rel, Eq, Lt, Le, Gt, Ge, Ne
 
 x,y,z = symbols('x,y,z')
 

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -320,9 +320,9 @@ def test_Finite_as_relational():
 def test_Union_as_relational():
     x = Symbol('x')
     assert (Interval(0,1) + FiniteSet(2)).as_relational(x) ==\
-            Or(And(Ge(x,0), Le(x,1)) , Eq(x,2))
+            Or(And(Le(0, x), Le(x, 1)), Eq(x, 2))
     assert (Interval(0,1, True, True) + FiniteSet(1)).as_relational(x) ==\
-            And(Gt(x,0), Le(x,1))
+            And(Lt(0, x), Le(x, 1))
 
 def test_EmptySet_as_relational():
     assert S.EmptySet.as_relational(Symbol('x')) == False

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,6 +1,7 @@
 from sympy import (
     Symbol, Set, Union, Interval, oo, S, sympify, nan,
-    Inequality, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float, FiniteSet
+    GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
+    FiniteSet
 )
 from sympy.mpmath import mpi
 

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -33,7 +33,7 @@ def test_interval_symbolic_end_points():
     assert Union(Interval(0, a), Interval(0, 3)).sup == Max(a, 3)
     assert Union(Interval(a, 0), Interval(-3, 0)).inf == Min(-3, a)
 
-    assert Interval(0, a).contains(1) == Inequality(1, a)
+    assert Interval(0, a).contains(1) == LessThan(1, a)
 
 def test_union():
     assert Union(Interval(1, 2), Interval(2, 3)) == Interval(1, 3)

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -50,19 +50,62 @@ def test_as_dummy():
     assert x.as_dummy().assumptions0 == x.assumptions0
 
 def test_lt_gt():
+    from sympy import sympify as S
     x, y = Symbol('x'), Symbol('y')
 
-    assert (x <= y) == LessThan(x, y)
-    assert (x >= y) == GreaterThan(x, y)
-    assert (x <= 0) == LessThan(x, 0)
-    assert (x >= 0) == GreaterThan(x, 0)
+    assert (x >= y)    == GreaterThan(x, y)
+    assert (x >= 0)    == GreaterThan(x, 0)
+    assert (x <= y)    == LessThan(x, y)
+    assert (x <= 0)    == LessThan(x, 0)
 
-    assert (x < y) == StrictLessThan(x, y)
-    assert (x > y) == StrictGreaterThan(x, y)
-    assert (x < 0) == StrictLessThan(x, 0)
-    assert (x > 0) == StrictGreaterThan(x, 0)
+    assert (0 <= x)    == GreaterThan(x, 0)
+    assert (0 >= x)    == LessThan(x, 0)
+    assert (S(0) >= x) == GreaterThan(0, x)
+    assert (S(0) <= x) == LessThan(0, x)
 
-    assert (x**2+4*x+1 > 0) == StrictGreaterThan(x**2+4*x+1, 0)
+    assert (x > y)    == StrictGreaterThan(x, y)
+    assert (x > 0)    == StrictGreaterThan(x, 0)
+    assert (x < y)    == StrictLessThan(x, y)
+    assert (x < 0)    == StrictLessThan(x, 0)
+
+    assert (0 < x)    == StrictGreaterThan(x, 0)
+    assert (0 > x)    == StrictLessThan(x, 0)
+    assert (S(0) > x) == StrictGreaterThan(0, x)
+    assert (S(0) < x) == StrictLessThan(0, x)
+
+    e = x**2 + 4*x + 1
+    assert (e >= 0) == GreaterThan(e, 0)
+    assert (0 <= e) == GreaterThan(e, 0)
+    assert (e >  0) == StrictGreaterThan(e, 0)
+    assert (0 <  e) == StrictGreaterThan(e, 0)
+
+    assert (e <= 0) == LessThan(e, 0)
+    assert (0 >= e) == LessThan(e, 0)
+    assert (e <  0) == StrictLessThan(e, 0)
+    assert (0 >  e) == StrictLessThan(e, 0)
+
+    assert (S(0) >= e) == GreaterThan(0, e)
+    assert (S(0) <= e) == LessThan(0, e)
+    assert (S(0) <  e) == StrictLessThan(0, e)
+    assert (S(0) >  e) == StrictGreaterThan(0, e)
+
+def test_lt__eq__gt():
+    from sympy import Ge, Le, Gt, Lt
+    x = Symbol('x')
+
+    lhs, rhs = Ge(x, 5), Le(5, x)
+    assert lhs == rhs
+
+    lhs, rhs = Ge(x, 5), Lt(5, x)
+    assert lhs != rhs
+
+    lhs, rhs = Gt(x, 5), Le(5, x)
+    assert lhs != rhs
+
+    lhs, rhs = Gt(x, 5), Lt(5, x)
+    assert lhs == rhs
+
+
 
 def test_no_len():
     # there should be no len for numbers

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -89,24 +89,6 @@ def test_lt_gt():
     assert (S(0) <  e) == StrictLessThan(0, e)
     assert (S(0) >  e) == StrictGreaterThan(0, e)
 
-def test_lt__eq__gt():
-    from sympy import Ge, Le, Gt, Lt
-    x = Symbol('x')
-
-    lhs, rhs = Ge(x, 5), Le(5, x)
-    assert lhs == rhs
-
-    lhs, rhs = Ge(x, 5), Lt(5, x)
-    assert lhs != rhs
-
-    lhs, rhs = Gt(x, 5), Le(5, x)
-    assert lhs != rhs
-
-    lhs, rhs = Gt(x, 5), Lt(5, x)
-    assert lhs == rhs
-
-
-
 def test_no_len():
     # there should be no len for numbers
     x = Symbol('x')

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -94,6 +94,65 @@ def test_no_len():
     x = Symbol('x')
     raises(TypeError, "len(x)")
 
+def test_ineq_inequal():
+    S = sympify
+
+    x, y, z = symbols('x,y,z')
+
+    e = (
+      S(-1)    >=  x,   S(-1)    >=  y,   S(-1)    >=  z,
+      S(-1)    >   x,   S(-1)    >   y,   S(-1)    >   z,
+      S(-1)    <=  x,   S(-1)    <=  y,   S(-1)    <=  z,
+      S(-1)    <   x,   S(-1)    <   y,   S(-1)    <   z,
+      S(0)     >=  x,   S(0)     >=  y,   S(0)     >=  z,
+      S(0)     >   x,   S(0)     >   y,   S(0)     >   z,
+      S(0)     <=  x,   S(0)     <=  y,   S(0)     <=  z,
+      S(0)     <   x,   S(0)     <   y,   S(0)     <   z,
+      S('3/7') >=  x,   S('3/7') >=  y,   S('3/7') >=  z,
+      S('3/7') >   x,   S('3/7') >   y,   S('3/7') >   z,
+      S('3/7') <=  x,   S('3/7') <=  y,   S('3/7') <=  z,
+      S('3/7') <   x,   S('3/7') <   y,   S('3/7') <   z,
+      S(1.5)   >=  x,   S(1.5)   >=  y,   S(1.5)   >=  z,
+      S(1.5)   >   x,   S(1.5)   >   y,   S(1.5)   >   z,
+      S(1.5)   <=  x,   S(1.5)   <=  y,   S(1.5)   <=  z,
+      S(1.5)   <   x,   S(1.5)   <   y,   S(1.5)   <   z,
+      S(2)     >=  x,   S(2)     >=  y,   S(2)     >=  z,
+      S(2)     >   x,   S(2)     >   y,   S(2)     >   z,
+      S(2)     <=  x,   S(2)     <=  y,   S(2)     <=  z,
+      S(2)     <   x,   S(2)     <   y,   S(2)     <   z,
+      x      >= -1,   y      >= -1,   z      >= -1,
+      x      >  -1,   y      >  -1,   z      >  -1,
+      x      <= -1,   y      <= -1,   z      <= -1,
+      x      <  -1,   y      <  -1,   z      <  -1,
+      x      >=  0,   y      >=  0,   z      >=  0,
+      x      >   0,   y      >   0,   z      >   0,
+      x      <=  0,   y      <=  0,   z      <=  0,
+      x      <   0,   y      <   0,   z      <   0,
+      x      >=  1.5, y      >=  1.5, z      >=  1.5,
+      x      >   1.5, y      >   1.5, z      >   1.5,
+      x      <=  1.5, y      <=  1.5, z      <=  1.5,
+      x      <   1.5, y      <   1.5, z      <   1.5,
+      x      >=  2,   y      >=  2,   z      >=  2,
+      x      >   2,   y      >   2,   z      >   2,
+      x      <=  2,   y      <=  2,   z      <=  2,
+      x      <   2,   y      <   2,   z      <   2,
+
+      x >= y,  x >= z,  y >= x, y >= z, z >= x, z >= y,
+      x >  y,  x >  z,  y >  x, y >  z, z >  x, z >  y,
+      x <= y,  x <= z,  y <= x, y <= z, z <= x, z <= y,
+      x <  y,  x <  z,  y <  x, y <  z, z <  x, z <  y,
+
+      x - pi >= y + z,  y - pi >= x + z,  z - pi >= x + y,
+      x - pi >  y + z,  y - pi >  x + z,  z - pi >  x + y,
+      x - pi <= y + z,  y - pi <= x + z,  z - pi <= x + y,
+      x - pi <  y + z,  y - pi <  x + z,  z - pi <  x + y,
+    )
+
+    left_e = e[:-1]
+    for i, e1 in enumerate( left_e ):
+        for e2 in e[i +1:]:
+            assert e1 != e2
+
 def test_Wild_properties():
     # these tests only include Atoms
     x   = Symbol("x")

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -1,5 +1,6 @@
-from sympy import (Symbol, Wild, Inequality, StrictInequality, pi, I, Rational,
-    sympify, symbols, Dummy, Function, flatten)
+from sympy import (Symbol, Wild, GreaterThan, LessThan, StrictGreaterThan,
+    StrictLessThan, pi, I, Rational, sympify, symbols, Dummy, Function, flatten
+)
 
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.core.compatibility import SymPyDeprecationWarning

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -146,6 +146,7 @@ def test_ineq_unequal():
       x - pi >  y + z,  y - pi >  x + z,  z - pi >  x + y,
       x - pi <= y + z,  y - pi <= x + z,  z - pi <= x + y,
       x - pi <  y + z,  y - pi <  x + z,  z - pi <  x + y,
+      True, False
     )
 
     left_e = e[:-1]

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -94,7 +94,7 @@ def test_no_len():
     x = Symbol('x')
     raises(TypeError, "len(x)")
 
-def test_ineq_inequal():
+def test_ineq_unequal():
     S = sympify
 
     x, y, z = symbols('x,y,z')

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -52,17 +52,17 @@ def test_as_dummy():
 def test_lt_gt():
     x, y = Symbol('x'), Symbol('y')
 
-    assert (x <= y) == Inequality(x, y)
-    assert (x >= y) == Inequality(y, x)
-    assert (x <= 0) == Inequality(x, 0)
-    assert (x >= 0) == Inequality(0, x)
+    assert (x <= y) == LessThan(x, y)
+    assert (x >= y) == GreaterThan(x, y)
+    assert (x <= 0) == LessThan(x, 0)
+    assert (x >= 0) == GreaterThan(x, 0)
 
-    assert (x < y) == StrictInequality(x, y)
-    assert (x > y) == StrictInequality(y, x)
-    assert (x < 0) == StrictInequality(x, 0)
-    assert (x > 0) == StrictInequality(0, x)
+    assert (x < y) == StrictLessThan(x, y)
+    assert (x > y) == StrictGreaterThan(x, y)
+    assert (x < 0) == StrictLessThan(x, 0)
+    assert (x > 0) == StrictGreaterThan(x, 0)
 
-    assert (x**2+4*x+1 > 0) == StrictInequality(0, x**2+4*x+1)
+    assert (x**2+4*x+1 > 0) == StrictGreaterThan(x**2+4*x+1, 0)
 
 def test_no_len():
     # there should be no len for numbers

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -213,24 +213,31 @@ class Piecewise(Function):
                     continue
             elif isinstance(cond, Equality):
                 continue
-            curr = list(cond.args)
-            if cond.args[0].has(sym):
-                curr[0] = S.NegativeInfinity
-            elif cond.args[1].has(sym):
-                curr[1] = S.Infinity
+
+            lower, upper = cond.lts, cond.gts # part 1: initialize with givens
+            if cond.lts.has(sym):     # part 1a: expand the side ...
+                lower = S.NegativeInfinity   # e.g. x <= 0 ---> -oo <= 0
+            elif cond.gts.has(sym):   # part 1a: ... that can be expanded
+                upper = S.Infinity           # e.g. x >= 0 --->  oo >= 0
             else:
-                raise NotImplementedError(\
-                        "Unable handle interval evaluation of expression.")
-            curr = [max(a, curr[0]), min(b, curr[1])]
+                raise NotImplementedError(
+                        "Unable to handle interval evaluation of expression.")
+
+            # part 1b: Reduce (-)infinity to what was passed in.
+            lower, upper = max(a, lower), min(b, upper)
+
             for n in xrange(len(int_expr)):
-                if self.__eval_cond(curr[0] < int_expr[n][1]) and \
-                        self.__eval_cond(curr[0] >= int_expr[n][0]):
-                    curr[0] = int_expr[n][1]
-                if self.__eval_cond(curr[1] > int_expr[n][0]) and \
-                        self.__eval_cond(curr[1] <= int_expr[n][1]):
-                    curr[1] = int_expr[n][0]
-            if self.__eval_cond(curr[0] < curr[1]):
-                int_expr.append(curr + [expr])
+                # Part 2: remove any interval overlap.  For any conflicts, the
+                # iterval already there wins, and the incoming interval updates
+                # its bounds accordingly.
+                if self.__eval_cond(lower < int_expr[n][1]) and \
+                        self.__eval_cond(lower >= int_expr[n][0]):
+                    lower = int_expr[n][1]
+                if self.__eval_cond(upper > int_expr[n][0]) and \
+                        self.__eval_cond(upper <= int_expr[n][1]):
+                    upper = int_expr[n][0]
+            if self.__eval_cond(lower < upper):  # Is it still an interval?
+                int_expr.append((lower, upper, expr))
         int_expr.sort(key=lambda x:x[0])
 
         # Add holes to list of intervals if there is a default value,

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -309,9 +309,9 @@ def piecewise_fold(expr):
     Examples
     ========
 
-    >>> from sympy import Piecewise, piecewise_fold
+    >>> from sympy import Piecewise, piecewise_fold, sympify as S
     >>> from sympy.abc import x
-    >>> p = Piecewise((x, x < 1), (1, 1 <= x))
+    >>> p = Piecewise((x, x < 1), (1, S(1) <= x))
     >>> piecewise_fold(x*p)
     Piecewise((x**2, x < 1), (x, 1 <= x))
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -486,13 +486,20 @@ def test_expint():
 def test_messy():
     from sympy import (laplace_transform, Si, Ci, Shi, Chi, atan, Piecewise,
                        atanh, acoth, E1, besselj, acosh, asin, Ne, And, re,
-                       fourier_transform, sqrt)
+                       fourier_transform, sqrt, Abs)
     assert laplace_transform(Si(x), x, s) == ((pi - 2*atan(s))/(2*s), 0, True)
 
-    assert laplace_transform(Shi(x), x, s) == (acoth(s)/s, 1, True) \
+    # The hand-coded test result (rhs) is an improvement over the previous test
+    # result, but I believe still incorrect.  E.g. see WolframAlpha's result:
+    #  http://www.wolframalpha.com/input/?i=Laplace(Shi(x),x,s)
+    assert laplace_transform(Shi(x), x, s) == (Piecewise((acoth(s)/s, Abs(s**2) > 1), ((2*atanh(s) - I*pi)/(2*s), True)), 1, True)
+
     # where should the logs be simplified?
+    # This also does not jive with the result returned by WolframAlpha:
+    #  http://www.wolframalpha.com/input/?i=laplace(Chi(x),x,s)
     assert laplace_transform(Chi(x), x, s) == \
            ((log(s**(-2)) - log((s**2 - 1)/s**2))/(2*s), 1, True)
+
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \
            (0, And(0 < re(a/2) + S(1)/2, 0 < re(a/2) + 1))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -489,10 +489,7 @@ def test_messy():
                        fourier_transform, sqrt, Abs)
     assert laplace_transform(Si(x), x, s) == ((pi - 2*atan(s))/(2*s), 0, True)
 
-    # The hand-coded test result (rhs) is an improvement over the previous test
-    # result, but I believe still incorrect.  E.g. see WolframAlpha's result:
-    #  http://www.wolframalpha.com/input/?i=Laplace(Shi(x),x,s)
-    assert laplace_transform(Shi(x), x, s) == (Piecewise((acoth(s)/s, Abs(s**2) > 1), ((2*atanh(s) - I*pi)/(2*s), True)), 1, True)
+    assert laplace_transform(Shi(x), x, s) == (acoth(s)/s, 1, True)
 
     # where should the logs be simplified?
     assert laplace_transform(Chi(x), x, s) == \

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -497,7 +497,8 @@ def test_messy():
 
     # TODO maybe simplify the inequalities?
     assert laplace_transform(besselj(a, x), x, s)[1:] == \
-           (0, And(0 < re(a/2) + S(1)/2, 0 < re(a/2) + 1))
+           (0, And(S(0) < re(a/2) + S(1)/2, S(0) < re(a/2) + 1))
+
     # NOTE s < 0 can be done, but argument reduction is currently not good enough
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \
            (Piecewise((0, 1 < 4*abs(pi**2*s**2)),

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -495,8 +495,6 @@ def test_messy():
     assert laplace_transform(Shi(x), x, s) == (Piecewise((acoth(s)/s, Abs(s**2) > 1), ((2*atanh(s) - I*pi)/(2*s), True)), 1, True)
 
     # where should the logs be simplified?
-    # This also does not jive with the result returned by WolframAlpha:
-    #  http://www.wolframalpha.com/input/?i=laplace(Chi(x),x,s)
     assert laplace_transform(Chi(x), x, s) == \
            ((log(s**(-2)) - log((s**2 - 1)/s**2))/(2*s), 1, True)
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -267,7 +267,7 @@ def test_expint():
     # TODO LT of Si, Shi, Chi is a mess ...
     assert laplace_transform(Ci(x), x, s) == (-log(1 + s**2)/2/s, 0, True)
     assert laplace_transform(expint(a, x), x, s) == \
-           (lerchphi(s*polar_lift(-1), 1, a), 0, 0 < re(a))
+           (lerchphi(s*polar_lift(-1), 1, a), 0, S(0) < re(a))
     assert laplace_transform(expint(1, x), x, s) == (log(s + 1)/s, 0, True)
     assert laplace_transform(expint(2, x), x, s) == \
            ((s - log(s + 1))/s**2, 0, True)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -894,7 +894,7 @@ def _simplifyconds(expr, s, a):
             return not r
         return (x < y)
     def replue(x, y):
-        if bigger(x, y) in [True, False]:
+        if bigger(x, y) in (True, False):
             return True
         return Unequality(x, y)
     def repl(ex, *args):

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1112,11 +1112,11 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
         if a.has(t):
             return Heaviside(arg)
         rel = _solve_inequality(a > 0, u)
-        if rel.lhs == u:
-            k = log(rel.rhs)
+        if rel.lts == u:
+            k = log(rel.gts)
             return Heaviside(t + k)
         else:
-            k = log(rel.lhs)
+            k = log(rel.lts)
             return Heaviside(-(t + k))
     f = f.replace(Heaviside, simp_heaviside)
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -854,7 +854,7 @@ def _simplifyconds(expr, s, a):
     >>> simp(Ne(1, x**3), x, 0)
     1 != x**3
     """
-    from sympy.core.relational import StrictInequality, Unequality
+    from sympy.core.relational import StrictLessThan, Unequality
     from sympy import Abs
     def power(ex):
         if ex == s:
@@ -897,7 +897,7 @@ def _simplifyconds(expr, s, a):
         if isinstance(ex, bool):
             return ex
         return ex.replace(*args)
-    expr = repl(expr, StrictInequality, replie)
+    expr = repl(expr, StrictLessThan, replie)
     expr = repl(expr, Unequality, replue)
     return expr
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -856,8 +856,10 @@ def _simplifyconds(expr, s, a):
     >>> simp(Ne(1, x**3), x, 0)
     1 != x**3
     """
-    from sympy.core.relational import StrictLessThan, Unequality
+    from sympy.core.relational import ( StrictGreaterThan, StrictLessThan,
+        Unequality )
     from sympy import Abs
+
     def power(ex):
         if ex == s:
             return 1
@@ -900,6 +902,7 @@ def _simplifyconds(expr, s, a):
             return ex
         return ex.replace(*args)
     expr = repl(expr, StrictLessThan, replie)
+    expr = repl(expr, StrictGreaterThan, lambda x, y: replie(y, x))
     expr = repl(expr, Unequality, replue)
     return expr
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -834,6 +834,7 @@ def _simplifyconds(expr, s, a):
 
     >>> from sympy.integrals.transforms import _simplifyconds as simp
     >>> from sympy.abc import x
+    >>> from sympy import sympify as S
     >>> simp(abs(x**2) < 1, x, 1)
     False
     >>> simp(abs(x**2) < 1, x, 2)
@@ -842,9 +843,9 @@ def _simplifyconds(expr, s, a):
     Abs(x**2) < 1
     >>> simp(abs(1/x**2) < 1, x, 1)
     True
-    >>> simp(1 < abs(x), x, 1)
+    >>> simp(S(1) < abs(x), x, 1)
     True
-    >>> simp(1 < abs(1/x), x, 1)
+    >>> simp(S(1) < abs(1/x), x, 1)
     False
 
     >>> from sympy import Ne

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -233,19 +233,20 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
             aux_ = []
             for d in disjuncts(c):
                 d_ = d.replace(re, lambda x: x.as_real_imag()[0]).subs(re(s), t)
-                if not d.is_Relational or (d.rel_op != '<' and d.rel_op != '<=') \
+                if not d.is_Relational or \
+                   d.rel_op not in ('>', '>=', '<', '<=') \
                    or d_.has(s) or not d_.has(t):
                     aux_ += [d]
                     continue
                 soln = _solve_inequality(d_, t)
                 if not soln.is_Relational or \
-                   (soln.rel_op != '<' and soln.rel_op != '<='):
+                   soln.rel_op not in ('>', '>=', '<', '<='):
                     aux_ += [d]
                     continue
-                if soln.lhs == t:
-                    b_ = Max(soln.rhs, b_)
+                if soln.lts == t:
+                    b_ = Max(soln.gts, b_)
                 else:
-                    a_ = Min(soln.lhs, a_)
+                    a_ = Min(soln.lts, a_)
             if a_ != oo and a_ != b:
                 a = Max(a_, a)
             elif b_ != -oo and b_ != a:
@@ -946,20 +947,21 @@ def _laplace_transform(f, t, s_, simplify=True):
                 if m and all(m[wild] > 0 for wild in [w1, w2, w3, w4, w5]):
                     d = re(s) > m[p]
                 d_ = d.replace(re, lambda x: x.expand().as_real_imag()[0]).subs(re(s), t)
-                if not d.is_Relational or (d.rel_op != '<' and d.rel_op != '<=') \
+                if not d.is_Relational or \
+                   d.rel_op not in ('>', '>=', '<', '<=') \
                    or d_.has(s) or not d_.has(t):
                     aux_ += [d]
                     continue
                 soln = _solve_inequality(d_, t)
                 if not soln.is_Relational or \
-                   (soln.rel_op != '<' and soln.rel_op != '<='):
+                   soln.rel_op not in ('>', '>=', '<', '<='):
                     aux_ += [d]
                     continue
-                if soln.lhs == t:
+                if soln.lts == t:
                     raise IntegralTransformError('Laplace', f,
                                          'convergence not in half-plane?')
                 else:
-                    a_ = Min(soln.lhs, a_)
+                    a_ = Min(soln.lts, a_)
             if a_ != oo:
                 a = Max(a_, a)
             else:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -831,13 +831,17 @@ class LatexPrinter(Printer):
 
     def _print_Relational(self, expr):
         if self._settings['itex']:
+            gt = r"\gt"
             lt = r"\lt"
         else:
+            gt = ">"
             lt = "<"
 
         charmap = {
             "==" : "=",
+            ">"  : gt,
             "<"  : lt,
+            ">=" : r"\geq",
             "<=" : r"\leq",
             "!=" : r"\neq",
         }

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -60,8 +60,10 @@ class MathMLPrinter(Printer):
             'log': 'ln',
             'Equality': 'eq',
             'Unequality': 'neq',
-            'StrictInequality': 'lt',
-            'Inequality': 'leq'
+            'GreaterThan': 'geq',
+            'LessThan': 'leq',
+            'StrictGreaterThan': 'gt',
+            'StrictLessThan': 'lt',
         }
 
         for cls in e.__class__.__mro__:

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -362,6 +362,7 @@ frac = {
 _xsym = {
     '=='    : ( '=',    '='),
     '<'     : ( '<',    '<'),
+    '>'     : ( '>',    '>'),
     '<='    : ('<=',    U('LESS-THAN OR EQUAL TO')),
     '>='    : ('>=',    U('GREATER-THAN OR EQUAL TO')),
     '!='    : ('!=',    U('NOT EQUAL TO')),

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from sympy import (Basic, Matrix, Piecewise, Ne, symbols, sqrt, Function,
     Rational, conjugate, Derivative, tan, Function, log, floor, Symbol, Tuple,
     pprint, sqrt, factorial, factorial2, binomial, pi, sin, ceiling, pprint_use_unicode,
@@ -730,11 +731,11 @@ x < y\
     expr = Gt(x, y)
     ascii_str = \
 """\
-y < x\
+x > y\
 """
     ucode_str = \
 u"""\
-y < x\
+x > y\
 """
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -754,11 +755,11 @@ x ≤ y\
     expr = Ge(x, y)
     ascii_str = \
 """\
-y <= x\
+x >= y\
 """
     ucode_str = \
 u"""\
-y ≤ x\
+x ≥ y\
 """
     assert  pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -176,7 +176,7 @@ def test_fcode_Piecewise():
     assert fcode(Piecewise((x,x<1),(x**2,x>1),(sin(x),True))) == (
         "      if (x < 1) then\n"
         "         x\n"
-        "      else if (1 < x) then\n"
+        "      else if (x > 1) then\n"
         "         x**2\n"
         "      else\n"
         "         sin(x)\n"
@@ -185,9 +185,9 @@ def test_fcode_Piecewise():
     assert fcode(Piecewise((x,x<1),(x**2,x>1),(sin(x),x>0))) == (
         "      if (x < 1) then\n"
         "         x\n"
-        "      else if (1 < x) then\n"
+        "      else if (x > 1) then\n"
         "         x**2\n"
-        "      else if (0 < x) then\n"
+        "      else if (x > 0) then\n"
         "         sin(x)\n"
         "      end if"
     )

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -56,7 +56,7 @@ def test_piecewise():
     l = lambdarepr(p)
     eval(h + l)
     assert l == "((x) if (x < 1) else (((x**2) if (((x <= 4) "\
-        "and (3 < x))) else (((0) if (True) else None)))))"
+        "and (x > 3))) else (((0) if (True) else None)))))"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -66,8 +66,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (((x) if (((x < 1) and (0 <= x))) "\
-        "else (((-x + 2) if (1 <= x) else (((0) if (True) else None)))))))"
+    assert l == "((x**2) if (x < 0) else (((x) if (((x >= 0) and (x < 1))) "\
+        "else (((-x + 2) if (x >= 1) else (((0) if (True) else None)))))))"
 
     p = Piecewise(
         (x**2, x < 0),
@@ -76,8 +76,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x**2) if (x < 0) else (((x) if (((x < 1) and "\
-        "(0 <= x))) else (((-x + 2) if (1 <= x) else None)))))"
+    assert l == "((x**2) if (x < 0) else (((x) if (((x >= 0) "\
+        "and (x < 1))) else (((-x + 2) if (x >= 1) else None)))))"
 
     p = Piecewise(
         (1, x < 1),

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -80,6 +80,48 @@ def test_piecewise():
         "and (x < 1))) else (((-x + 2) if (x >= 1) else None)))))"
 
     p = Piecewise(
+        (1, x >= 1),
+        (2, x >= 2),
+        (3, x >= 3),
+        (4, x >= 4),
+        (5, x >= 5),
+        (6, True)
+    )
+    l = lambdarepr(p)
+    eval(h + l)
+    assert l == ("((1) if (x >= 1) else (((2) if (x >= 2) else (((3) if "
+        "(x >= 3) else (((4) if (x >= 4) else (((5) if (x >= 5) else (((6) if "
+        "(True) else None)))))))))))")
+
+    p = Piecewise(
+        (1, x <= 1),
+        (2, x <= 2),
+        (3, x <= 3),
+        (4, x <= 4),
+        (5, x <= 5),
+        (6, True)
+    )
+    l = lambdarepr(p)
+    eval(h + l)
+    assert l == "((1) if (x <= 1) else (((2) if (x <= 2) else (((3) if "\
+        "(x <= 3) else (((4) if (x <= 4) else (((5) if (x <= 5) else (((6) if "\
+        "(True) else None)))))))))))"
+
+    p = Piecewise(
+        (1, x > 1),
+        (2, x > 2),
+        (3, x > 3),
+        (4, x > 4),
+        (5, x > 5),
+        (6, True)
+    )
+    l = lambdarepr(p)
+    eval(h + l)
+    assert l == ("((1) if (x > 1) else (((2) if (x > 2) else (((3) if "
+        "(x > 3) else (((4) if (x > 4) else (((5) if (x > 5) else (((6) if "
+        "(True) else None)))))))))))")
+
+    p = Piecewise(
         (1, x < 1),
         (2, x < 2),
         (3, x < 3),

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -184,11 +184,11 @@ def test_mathml_relational():
 
     mml_3 = mp._print(Ge(1,x))
     assert mml_3.nodeName == 'apply'
-    assert mml_3.childNodes[0].nodeName == 'leq'
-    assert mml_3.childNodes[1].nodeName == 'ci'
-    assert mml_3.childNodes[1].childNodes[0].nodeValue == 'x'
-    assert mml_3.childNodes[2].nodeName == 'cn'
-    assert mml_3.childNodes[2].childNodes[0].nodeValue == '1'
+    assert mml_3.childNodes[0].nodeName == 'geq'
+    assert mml_3.childNodes[1].nodeName == 'cn'
+    assert mml_3.childNodes[1].childNodes[0].nodeValue == '1'
+    assert mml_3.childNodes[2].nodeName == 'ci'
+    assert mml_3.childNodes[2].childNodes[0].nodeValue == 'x'
 
     mml_4 = mp._print(Lt(1,x))
     assert mml_4.nodeName == 'apply'

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -63,7 +63,7 @@ def test_python_basic():
 def test_python_relational():
     assert python(Eq(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x == y"
     assert python(Le(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x <= y"
-    assert python(Gt(x, y)) == "y = Symbol('y')\nx = Symbol('x')\ne = y < x"
+    assert python(Gt(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x > y"
     assert python(Ne(x/(y+1), y**2)) in [
             "x = Symbol('x')\ny = Symbol('y')\ne = x/(1 + y) != y**2",
             "x = Symbol('x')\ny = Symbol('y')\ne = x/(y + 1) != y**2"]

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from sympy import (Symbol, symbols, oo, limit, Rational, Integral, Derivative,
-    log, exp, sqrt, pi, Function, sin, Eq, Le, Gt, Ne, Abs)
+    log, exp, sqrt, pi, Function, sin, Eq, Ge, Le, Gt, Lt, Ne, Abs)
 
 from sympy.printing.python import python
 
@@ -62,8 +62,10 @@ def test_python_basic():
 
 def test_python_relational():
     assert python(Eq(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x == y"
+    assert python(Ge(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x >= y"
     assert python(Le(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x <= y"
     assert python(Gt(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x > y"
+    assert python(Lt(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x < y"
     assert python(Ne(x/(y+1), y**2)) in [
             "x = Symbol('x')\ny = Symbol('y')\ne = x/(1 + y) != y**2",
             "x = Symbol('x')\ny = Symbol('y')\ne = x/(y + 1) != y**2"]

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -343,14 +343,14 @@ def reduce_inequalities(inequalities, assume=True, symbols=[]):
     Examples
     ========
 
-    >>> from sympy import Q
+    >>> from sympy import Q, sympify as S
     >>> from sympy.abc import x, y
     >>> from sympy.solvers.inequalities import reduce_inequalities
 
-    >>> reduce_inequalities(0 <= x + 3, Q.real(x), [])
+    >>> reduce_inequalities(S(0) <= x + 3, Q.real(x), [])
     -3 <= x
 
-    >>> reduce_inequalities(0 <= x + y*2 - 1, True, [x])
+    >>> reduce_inequalities(S(0) <= x + y*2 - 1, True, [x])
     -2*y + 1 <= x
     """
     if not hasattr(inequalities, '__iter__'):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -323,7 +323,7 @@ def _solve_inequality(ie, s):
     """ A hacky replacement for solve, since the latter only works for
         univariate inequalities. """
     from sympy import Poly
-    if not ie.rel_op in ['<', '<=']:
+    if not ie.rel_op in ('>', '>=', '<', '<='):
         raise NotImplementedError
     expr = ie.lhs - ie.rhs
     p = Poly(expr, s)

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -101,10 +101,10 @@ def test_reduce_poly_inequalities_complex_relational():
 def test_reduce_abs_inequalities():
     real = Q.real(x)
 
-    assert reduce_inequalities(abs(x - 5) < 3, assume=real) == And(Gt(x, 2), Lt(x, 8))
-    assert reduce_inequalities(abs(2*x + 3) >= 8, assume=real) == Or(Le(x, -S(11)/2), Ge(x, S(5)/2))
-    assert reduce_inequalities(abs(x - 4) + abs(3*x - 5) < 7, assume=real) == And(Gt(x, S(1)/2), Lt(x, 4))
-    assert reduce_inequalities(abs(x - 4) + abs(3*abs(x) - 5) < 7, assume=real) == Or(And(-2 < x, x < -1), And(S(1)/2 < x, x < 4))
+    assert reduce_inequalities(abs(x - 5) < 3, assume=real) == And(Lt(2, x), Lt(x, 8))
+    assert reduce_inequalities(abs(2*x + 3) >= 8, assume=real) == Or(Le(x, -S(11)/2), Le(S(5)/2, x))
+    assert reduce_inequalities(abs(x - 4) + abs(3*x - 5) < 7, assume=real) == And(Lt(S(1)/2, x), Lt(x, 4))
+    assert reduce_inequalities(abs(x - 4) + abs(3*abs(x) - 5) < 7, assume=real) == Or(And(S(-2) < x, x < -1), And(S(1)/2 < x, x < 4))
 
     raises(NotImplementedError, "reduce_inequalities(abs(x - 5) < 3)")
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -12,8 +12,8 @@ from sympy.core.numbers import Catalan, ComplexInfinity, EulerGamma, Exp1,\
         GoldenRatio, Half, ImaginaryUnit, Infinity, Integer, NaN,\
         NegativeInfinity,  NegativeOne, Number, NumberSymbol, One, Pi,\
         Rational, Float, Zero
-from sympy.core.relational import Equality, Inequality, Relational,\
-        StrictInequality, Unequality
+from sympy.core.relational import ( Equality, GreaterThan, LessThan, Relational,
+        StrictGreaterThan, StrictLessThan, Unequality )
 from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
@@ -97,9 +97,10 @@ def test_core_numbers():
 def test_core_relational():
     x = Symbol("x")
     y = Symbol("y")
-    for c in (Equality, Equality(x,y), Inequality, Inequality(x,y), Relational,
-              Relational(x,y), StrictInequality, StrictInequality(x,y), Unequality,
-              Unequality(x,y)):
+    for c in (Equality, Equality(x,y), GreaterThan, GreaterThan(x, y),
+              LessThan, LessThan(x,y), Relational, Relational(x,y),
+              StrictGreaterThan, StrictGreaterThan(x,y), StrictLessThan,
+              StrictLessThan(x,y), Unequality, Unequality(x,y)):
         check(c)
 
 def test_core_add():


### PR DESCRIPTION
Hullo SymPy Devs,

I've a branch that replaces Inequality with GreaterThan/LessThan.  In short, this means that equations with >(=) no longer get converted to LessThan relations:

```
>>> x > y
x > y
>>> simpify(2) > x
2 > x
```

It currently passes all doctests and all but 3 tests.  However, I need some help with those, and I'm not entirely sure they aren't incorrect tests to begin with.  The specific tests that fail:
- test_autowrap [130]: test_wrap_twice_c_cython
  This also fails for me on the master branch where I've done nothing.
- test_transforms [281]: test_expint
  I do not know how to verify if this is (in)correct.  (In multiple lines here for clarity.)

``` python
assert inverse_laplace_transform((s - log(s + 1))/s**2, s, x)
        .rewrite(expint).expand()
          ==
 (expint(2, x)*Heaviside(x)).rewrite(Ei).rewrite(expint).expand()
```
- test_transforms [465]: test_inverse_laplace_transform
  I similarly do not have the context to verify if it's correct.
  <code>assert ILT(1/s, s, t) == Heaviside(t)</code>

Thanks for your help,

Kevin
