### PR TITLE
[simplify] Implement besselsimp.

### DIFF
--- a/doc/src/modules/simplify/simplify.txt
+++ b/doc/src/modules/simplify/simplify.txt
@@ -40,6 +40,10 @@ trigsimp
 
 .. autofunction:: trigsimp_nonrecursive
 
+besselsimp
+----------
+.. autofunction:: besselsimp
+
 powsimp
 -------
 .. autofunction:: powsimp

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -210,13 +210,10 @@ def test_bessel():
 
     # TODO more orthogonality integrals
 
-    # TODO there is some improvement possible here:
-    #  - the result can be simplified to besselj(y, z))
-    assert powdenest(simplify(integrate(sin(z*x)*(x**2-1)**(-(y+S(1)/2)),
+    assert simplify(integrate(sin(z*x)*(x**2-1)**(-(y+S(1)/2)),
                               (x, 1, oo), meijerg=True, conds='none')
-                              *2/((z/2)**y*sqrt(pi)*gamma(S(1)/2-y))),
-                     polar=True) == \
-           exp(-I*pi*y/2)*besseli(y, z*exp_polar(I*pi/2))
+                              *2/((z/2)**y*sqrt(pi)*gamma(S(1)/2-y))) == \
+           besselj(y, z)
 
     # Werner Rosenheinrich
     # SOME INDEFINITE INTEGRALS OF BESSEL FUNCTIONS

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -7,7 +7,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 from simplify import (collect, rcollect, separate, radsimp, ratsimp, fraction,
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify,
     logcombine, separatevars, numer, denom, powdenest, posify, polarify,
-    unpolarify, collect_const, signsimp)
+    unpolarify, collect_const, signsimp, besselsimp)
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2768,6 +2768,7 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     from the input expression by doing this.
     """
     from sympy.simplify.hyperexpand import hyperexpand
+    from sympy.functions.special.bessel import BesselBase
 
     original_expr = expr = sympify(expr)
 
@@ -2824,6 +2825,9 @@ def simplify(expr, ratio=1.7, measure=count_ops):
 
     # hyperexpand automatically only works on hypergeometric terms
     expr = hyperexpand(expr)
+
+    if expr.has(BesselBase):
+        expr = besselsimp(expr)
 
     if expr.has(C.TrigonometricFunction):
         expr = trigsimp(expr)
@@ -3135,5 +3139,72 @@ def _logcombine(expr, force=False):
     if expr.is_Pow:
         return _logcombine(expr.args[0], force)**\
         _logcombine(expr.args[1], force)
+
+    return expr
+
+def besselsimp(expr):
+    """
+    Simplify bessel-type functions.
+
+    This routine tries to simplify bessel-type functions. Currently it only
+    works on the Bessel J and I functions, however. It works by looking at all
+    such functions in turn, and eliminating factors of "I" and "-1" (actually
+    their polar equivalents) in front of the argument. After that, functions of
+    half-integer order are rewritten using trigonometric functions.
+
+    >>> from sympy import besselj, besseli, besselsimp, polar_lift, I, S
+    >>> from sympy.abc import z, nu
+    >>> besselsimp(besselj(nu, z*polar_lift(-1)))
+    exp(I*pi*nu)*besselj(nu, z)
+    >>> besselsimp(besseli(nu, z*polar_lift(-I)))
+    exp(-I*pi*nu/2)*besselj(nu, z)
+    >>> besselsimp(besseli(S(-1)/2, z))
+    sqrt(2)*cosh(z)/(sqrt(pi)*sqrt(z))
+    """
+    from sympy import besselj, besseli, jn, I, pi, Dummy
+    # TODO
+    # - extension to more types of functions
+    #   (at least rewriting functions of half integer order should be straight
+    #    forward also for Y and K)
+    # - better algorithm?
+    # - simplify (cos(pi*b)*besselj(b,z) - besselj(-b,z))/sin(pi*b) ...
+    # - use contiguity relations?
+
+    def replacer(fro, to, factors):
+        factors = set(factors)
+        def repl(nu, z):
+            if factors.intersection(Mul.make_args(z)):
+                return to(nu, z)
+            return fro(nu, z)
+        return repl
+    def torewrite(fro, to):
+        def tofunc(nu, z):
+            return fro(nu, z).rewrite(to)
+        return tofunc
+    def tominus(fro):
+        def tofunc(nu, z):
+            return exp(I*pi*nu)*fro(nu, exp_polar(-I*pi)*z)
+        return tofunc
+
+    ifactors = [I, exp_polar(I*pi/2), exp_polar(-I*pi/2)]
+    expr = expr.replace(besselj, replacer(besselj,
+                                          torewrite(besselj, besseli), ifactors))
+    expr = expr.replace(besseli, replacer(besseli,
+                                          torewrite(besseli, besselj), ifactors))
+
+    minusfactors = [-1, exp_polar(I*pi)]
+    expr = expr.replace(besselj, replacer(besselj, tominus(besselj), minusfactors))
+    expr = expr.replace(besseli, replacer(besseli, tominus(besseli), minusfactors))
+
+    z0 = Dummy('z')
+    def expander(fro):
+        def repl(nu, z):
+            if (nu % 1) != S(1)/2:
+                return fro(nu, z)
+            return unpolarify(fro(nu, z0).rewrite(besselj).rewrite(jn).expand(func=True)).subs(z0, z)
+        return repl
+
+    expr = expr.replace(besselj, expander(besselj))
+    expr = expr.replace(besseli, expander(besseli))
 
     return expr

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -5,7 +5,7 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
     factor, Mul, O, hyper, Add, Float, radsimp, collect_const, hyper,
-    signsimp)
+    signsimp, besselsimp)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
@@ -1038,3 +1038,16 @@ def test_issue_2998():
 def test_signsimp():
     e = x*(-x + 1) + x*(x - 1)
     assert signsimp(Eq(e, 0)) == True
+
+def test_besselsimp():
+    from sympy import besselj, besseli, besselk, bessely, jn, yn, exp_polar, cosh
+    assert besselsimp(exp(-I*pi*y/2)*besseli(y, z*exp_polar(I*pi/2))) == \
+           besselj(y, z)
+    assert besselsimp(exp(-I*pi*a/2)*besseli(a, 2*sqrt(x)*exp_polar(I*pi/2))) == \
+           besselj(a, 2*sqrt(x))
+    assert besselsimp(sqrt(2)*sqrt(pi)*x**(S(1)/4)*exp(I*pi/4)*exp(-I*pi*a/2) * \
+                      besseli(-S(1)/2, sqrt(x)*exp_polar(I*pi/2)) * \
+                      besseli(a, sqrt(x)*exp_polar(I*pi/2))/2) == \
+           besselj(a, sqrt(x)) * cos(sqrt(x))
+    assert besselsimp(besseli(S(-1)/2, z)) == sqrt(2)*cosh(z)/(sqrt(pi)*sqrt(z))
+    assert besselsimp(besseli(a, z*exp_polar(-I*pi/2))) == exp(-I*pi*a/2)*besselj(a, z)


### PR DESCRIPTION
In reference to issue 2917.

This commit adds (the start of) a routine for simplifying bessel-type functions.
It currently only works on besseli and besselj and only implements a very
simplistic algorithm. It however works nicely in many cases occurring in practice.

Add tests for this.

Also adapt some existing tests (mostly transforms) to the new, better simplification.
