### PR TITLE
external/test_sage: Disable Sage tests under Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,8 @@ class test_sympy(Command):
             if not sympy.doctest():
                 tests_successful = False
 
-            if not sys.platform == "win32":
+            if not (sys.platform == "win32" or sys.version_info[0] == 3):
+                # run Sage tests; Sage currently doesn't support Windows or Python 3
                 dev_null = open(os.devnull, 'w')
                 if subprocess.call("sage -v", shell = True, stdout = dev_null, stderr = dev_null) == 0:
                     if subprocess.call("sage -python bin/test sympy/external/tests/test_sage.py", shell = True) != 0:

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -26,6 +26,10 @@ if not sage:
     #py.test will not execute any tests now
     disabled = True
 
+if sys.version_info[0] == 3:
+    # Sage does not support Python 3 currently
+    disabled = True
+
 import sympy
 
 from sympy.utilities.pytest import XFAIL


### PR DESCRIPTION
A recent commit allowed us to run Sage tests if Sage is installed (as
they have to be ran from within Sage). However, Sage does not currently
support Python 3, so disable the tests if running under Python 3.

---

I noticed this in this sympy-bot report: http://reviews.sympy.org/report/agZzeW1weTNyDAsSBFRhc2sYw6AKDA

@asmeurer, can you test it please? I don't have Sage (and I'd rather not install it). 
