### PR TITLE
Fix issue 3016.

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1973,10 +1973,8 @@ class Infinity(Number):
         if exp is S.NaN:
             return S.NaN
 
-        n = exp.evalf()
-
-        if isinstance(n, Number):
-            return self**n
+        if exp.is_number:
+            return self**exp.evalf()
 
     def _as_mpf_val(self, prec):
         return mlib.finf
@@ -2331,10 +2329,10 @@ class NumberSymbol(AtomicExpr):
                     return False
                 if other > u:
                     return True
-            return self.evalf()<other
+            return self.evalf() < other
         if other.is_comparable:
             other = other.evalf()
-            return self.evalf()<other
+            return self.evalf() < other
         return Expr.__lt__(self, other)
 
     def __le__(self, other):
@@ -2347,7 +2345,7 @@ class NumberSymbol(AtomicExpr):
         if other.is_comparable:
             other = other.evalf()
         if isinstance(other, Number):
-            return self.evalf()<=other
+            return self.evalf() <= other
         return Expr.__le__(self, other)
 
     def __gt__(self, other):

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -364,6 +364,7 @@ def _split_mul(f, x):
     >>> _split_mul((3*x)**s*sin(x**2)*x, x)
     (3**s, x*x**s, sin(x**2))
     """
+    from sympy import polarify, unpolarify
     fac = S(1)
     po  = S(1)
     g   = S(1)
@@ -374,7 +375,9 @@ def _split_mul(f, x):
         if not a.has(x):
             fac *= a
         elif a.is_Pow and a.base == x:
-            po *= a
+            c = a.base.as_coeff_mul(x)[0]
+            po *= x**a.exp
+            fac *= unpolarify(polarify(c**a.exp, subs=False))
         elif a == x:
             po *= x
         else:
@@ -1306,7 +1309,7 @@ def _rewrite_single(f, x, recursive=True):
     Returns a list of tuples (C, s, G) and a condition cond.
     Returns None on failure.
     """
-    from sympy import polarify, unpolarify
+    from sympy import polarify, unpolarify, oo, zoo, Tuple
     global _lookup_table
     if not _lookup_table:
         _lookup_table = {}
@@ -1353,10 +1356,16 @@ def _rewrite_single(f, x, recursive=True):
                     r1 = _get_coeff_exp(unpolarify(fac.subs(subs).subs(z, x),
                                                    exponents_only=True), x)
                     g = g.subs(subs).subs(z, x)
+                    # NOTE these substitutions can in principle introduce oo,
+                    #      zoo and other
+                    #      absurdities. It shouldn't matter, but better be safe.
+                    if Tuple(*(r1 + (g,))).has(oo, zoo, -oo):
+                        continue
                     g = meijerg(g.an, g.aother, g.bm, g.bother,
                                 unpolarify(g.argument, exponents_only=True))
                     res.append(r1 + (g,))
-                return res, cond
+                if res:
+                    return res, cond
 
     # try recursive mellin transform
     if not recursive:
@@ -1475,10 +1484,17 @@ def meijerint_indefinite(f, x):
     >>> meijerint_indefinite(sin(x), x)
     -cos(x)
     """
+    from sympy import hyper, meijerg, count_ops
+    results = []
     for a in list(_find_splitting_points(f, x)) + [S(0)]:
         res = _meijerint_indefinite_1(f.subs(x, x + a), x)
-        if res is not None:
-            return res.subs(x, x - a)
+        if res is None:
+            continue
+        results.append(res.subs(x, x - a))
+        if not res.has(hyper, meijerg):
+            return results[-1]
+    if results:
+        return sorted(results, key=count_ops)[0]
 
 def _meijerint_indefinite_1(f, x):
     """ Helper that does not attempt any substitution. """

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -372,15 +372,17 @@ def _split_mul(f, x):
 
     args = Mul.make_args(f)
     for a in args:
-        if not a.has(x):
-            fac *= a
-        elif a.is_Pow and a.base.as_coeff_mul(x)[1] == (x,):
-            c = a.base.as_coeff_mul(x)[0]
-            po *= x**a.exp
-            fac *= unpolarify(polarify(c**a.exp, subs=False))
-        elif a == x:
+        if a == x:
             po *= x
+        elif not a.has(x):
+            fac *= a
         else:
+            if a.is_Pow:
+                c, t = a.base.as_coeff_mul(x)
+                if t == (x,):
+                    po *= x**a.exp
+                    fac *= unpolarify(polarify(c**a.exp, subs=False))
+                    continue
             g *= a
 
     return fac, po, g
@@ -1357,8 +1359,8 @@ def _rewrite_single(f, x, recursive=True):
                                                    exponents_only=True), x)
                     g = g.subs(subs).subs(z, x)
                     # NOTE these substitutions can in principle introduce oo,
-                    #      zoo and other
-                    #      absurdities. It shouldn't matter, but better be safe.
+                    #      zoo and other absurdities. It shouldn't matter,
+                    #      but better be safe.
                     if Tuple(*(r1 + (g,))).has(oo, zoo, -oo):
                         continue
                     g = meijerg(g.an, g.aother, g.bm, g.bother,

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -374,7 +374,7 @@ def _split_mul(f, x):
     for a in args:
         if not a.has(x):
             fac *= a
-        elif a.is_Pow and a.base == x:
+        elif a.is_Pow and a.base.as_coeff_mul(x)[1] == (x,):
             c = a.base.as_coeff_mul(x)[0]
             po *= x**a.exp
             fac *= unpolarify(polarify(c**a.exp, subs=False))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -369,6 +369,16 @@ def test_probability():
     assert combsimp(j[0] - i[0]**2) == (alpha + beta - 1)*alpha \
                                         /(beta - 2)/(beta - 1)**2
 
+    # Beta distribution
+    a, b = symbols('a b', positive=True)
+    betadist = x**(a - 1)*(-x + 1)**(b - 1)*gamma(a + b)/(gamma(a)*gamma(b))
+    assert simplify(integrate(betadist, (x, 0, 1), meijerg=True)) == 1
+    assert simplify(integrate(x*betadist, (x, 0, 1), meijerg=True)) == a/(a + b)
+    assert simplify(integrate(x**2*betadist, (x, 0, 1), meijerg=True)) == \
+           a*(a + 1)/(a + b)/(a + b + 1)
+    assert simplify(integrate(x**y*betadist, (x, 0, 1), meijerg=True)) == \
+           gamma(a + b)*gamma(a + y)/gamma(a)/gamma(a + b + y)
+
     # Chi distribution
     k = Symbol('k', integer=True, positive=True)
     chi = 2**(1-k/2)*x**(k-1)*exp(-x**2/2)/gamma(k/2)

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -300,7 +300,7 @@ def test_linear_subs():
 def test_probability():
     # various integrals from probability theory
     from sympy.abc import x, y, z
-    from sympy import symbols, Symbol, Abs, expand_mul, combsimp, powsimp
+    from sympy import symbols, Symbol, Abs, expand_mul, combsimp, powsimp, sin
     mu1, mu2 = symbols('mu1 mu2', real=True, finite=True, bounded=True)
     sigma1, sigma2 = symbols('sigma1 sigma2', real=True, finite=True,
                                               bounded=True, positive=True)
@@ -418,7 +418,38 @@ def test_probability():
     assert simplify(integrate(x**2*f, (x, 0, oo), meijerg=True, conds='none')) == \
            d2**2*(d1 + 2)/d1/(d2 - 4)/(d2 - 2)
 
-    # TODO gamma, inverse gaussian, Levi, log-logistic, rayleigh, weibull
+    # TODO gamma, rayleigh
+
+    # inverse gaussian
+    lamda, mu = symbols('lamda mu', positive=True)
+    dist = sqrt(lamda/2/pi)*x**(-S(3)/2)*exp(-lamda*(x-mu)**2/x/2/mu**2)
+    mysimp = lambda expr: simplify(expr.rewrite(exp))
+    assert mysimp(integrate(dist, (x, 0, oo))) == 1
+    assert mysimp(integrate(x*dist, (x, 0, oo))) == mu
+    assert mysimp(integrate((x-mu)**2*dist, (x, 0, oo))) == mu**3/lamda
+    assert mysimp(integrate((x-mu)**3*dist, (x, 0, oo))) == 3*mu**5/lamda**2
+
+    # Levi
+    c = Symbol('c', positive=True)
+    assert integrate(sqrt(c/2/pi)*exp(-c/2/(x-mu))/(x-mu)**S('3/2'), (x, mu, oo)) == 1
+    # higher moments oo
+
+    # log-logistic
+    distn = (beta/alpha)*x**(beta-1)/alpha**(beta-1)/(1 + x**beta/alpha**beta)**2
+    assert simplify(integrate(distn, (x, 0, oo))) == 1
+    # NOTE the conditions are a mess, but correctly state beta > 1
+    assert simplify(integrate(x*distn, (x, 0, oo), conds='none')) == \
+           pi*alpha/beta/sin(pi/beta)
+    # (similar comment for conditions applies)
+    assert simplify(integrate(x**y*distn, (x, 0, oo), conds='none')) == \
+           pi*alpha**y*y/beta/sin(pi*y/beta)
+
+    # weibull
+    k = Symbol('k', positive=True)
+    n = Symbol('n', positive=True)
+    distn = k/lamda*(x/lamda)**(k-1)*exp(-(x/lamda)**k)
+    assert simplify(integrate(distn, (x, 0, oo))) == 1
+    assert simplify(integrate(x**n*distn, (x, 0, oo))) == lamda**n*gamma(1 + n/k)
 
     # rice distribution
     from sympy import besseli

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -190,6 +190,11 @@ def test_meijerint():
             *meijerg([S(1)/2, 0, S(1)/2], [1], [],
                      [-alpha/2, -alpha/2 - S(1)/2], 16/alpha**2), True)
 
+    # test a bug related to 3016
+    a, s = symbols('a s', positive=True)
+    assert simplify(integrate(x**s*exp(-a*x**2), (x, -oo, oo))) == \
+           a**(-s/2 - S(1)/2)*(exp(I*pi*s) + 1)*gamma(s/2 + S(1)/2)/2
+
 def test_bessel():
     from sympy import (besselj, Heaviside, besseli, polar_lift, exp_polar,
                        powdenest)
@@ -370,6 +375,8 @@ def test_probability():
                                         /(beta - 2)/(beta - 1)**2
 
     # Beta distribution
+    # NOTE: this is evaluated using antiderivatives. It also tests that
+    #       meijerint_indefinite returns the simplest possible answer.
     a, b = symbols('a b', positive=True)
     betadist = x**(a - 1)*(-x + 1)**(b - 1)*gamma(a + b)/(gamma(a)*gamma(b))
     assert simplify(integrate(betadist, (x, 0, 1), meijerg=True)) == 1

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -35,10 +35,11 @@ def test_rewrite_single():
     # It is probably not worth fixing
     #u(exp(-x)*sin(x)*cos(x), x)
 
-    # This one cannot be done numerically, since it comes out as a g-function of
-    # argument 4*pi
-    # NOTE This also tests a bug in inverse mellin transform (which used to turn
-    #      exp(4*pi*I*t) into a factor of exp(4*pi*I)**t instead of exp_polar).
+    # This one cannot be done numerically, since it comes out as a g-function
+    # of argument 4*pi
+    # NOTE This also tests a bug in inverse mellin transform (which used to
+    #      turn exp(4*pi*I*t) into a factor of exp(4*pi*I)**t instead of
+    #      exp_polar).
     #u(exp(x)*sin(x), x)
     assert _rewrite_single(exp(x)*sin(x), x) == \
            ([(-sqrt(2)/(2*sqrt(pi)), 0,
@@ -47,7 +48,8 @@ def test_rewrite_single():
 
 def test_rewrite1():
     assert _rewrite1(x**3*meijerg([a], [b], [c], [d], x**2 + y*x**2)*5, x) \
-           == (5, x**3, [(1, 0, meijerg([a], [b], [c], [d], x**2*(y + 1)))], True)
+           == (5, x**3, [(1, 0, meijerg([a], [b], [c], [d], x**2*(y + 1)))], \
+               True)
 
 def test_meijerint_indefinite_numerically():
     def t(fac, arg):
@@ -73,7 +75,7 @@ def test_inflate():
         m1 = meijerg(a, b, arg)
         m2 = Mul(*_inflate_g(m1, n))
         # NOTE: (the random number)**9 must still be on the principal sheet.
-        # Thus make b, d small to create random numbers of small imaginary part.
+        # Thus make b&d small to create random numbers of small imaginary part.
         return test_numerically(m1.subs(subs), m2.subs(subs), x, b=0.1, d=-0.1)
     assert t([[a], [b]], [[c], [d]], x, 3)
     assert t([[a, y], [b]], [[c], [d]], x, 3)
@@ -82,16 +84,16 @@ def test_inflate():
 def test_recursive():
     from sympy import symbols, exp_polar, expand
     a, b, c = symbols('a b c', positive=True)
-    assert simplify(integrate(exp(-(x-a)**2)*exp(-(x-b)**2), (x, 0, oo))) \
+    assert simplify(integrate(exp(-(x-a)**2)*exp(-(x - b)**2), (x, 0, oo))) \
            == sqrt(2*pi)/4*(1 + erf(sqrt(2)/2*(a + b))) \
               *exp(-a**2 - b**2 + (a + b)**2/2)
     assert simplify(integrate
-                  (exp(-(x-a)**2)*exp(-(x-b)**2)*exp(c*x), (x, 0, oo))) \
+                  (exp(-(x - a)**2)*exp(-(x - b)**2)*exp(c*x), (x, 0, oo))) \
            == sqrt(2*pi)/4*(1 + erf(sqrt(2)/4*(2*a + 2*b + c))) \
               *exp(-a**2 - b**2 + (2*a + 2*b + c)**2/8)
-    assert simplify(integrate(exp(-(x-a-b-c)**2), (x, 0, oo))) \
+    assert simplify(integrate(exp(-(x - a - b - c)**2), (x, 0, oo))) \
            == sqrt(pi)/2*(1 + erf(a + b + c))
-    assert simplify(integrate(exp(-(x+a+b+c)**2), (x, 0, oo))) \
+    assert simplify(integrate(exp(-(x + a + b + c)**2), (x, 0, oo))) \
            == sqrt(pi)/2*(1 - erf(a + b + c))
 
 def test_meijerint():
@@ -122,7 +124,7 @@ def test_meijerint():
 
     # Again, how about simplifications?
     sigma, mu = symbols('sigma mu', positive=True)
-    i, c = meijerint_definite(exp(-((x-mu)/(2*sigma))**2), x, 0, oo)
+    i, c = meijerint_definite(exp(-((x - mu)/(2*sigma))**2), x, 0, oo)
     assert simplify(i) \
            == sqrt(pi)*sigma*(erf(mu/(2*sigma)) + 1)
     assert c is True
@@ -140,9 +142,10 @@ def test_meijerint():
     # Test -oo to oo
     assert meijerint_definite(exp(-x**2), x, -oo, oo) == (sqrt(pi), True)
     assert meijerint_definite(exp(-abs(x)), x, -oo, oo) == (2, True)
-    assert meijerint_definite(exp(-(2*x-3)**2), x, -oo, oo) == (sqrt(pi)/2, True)
+    assert meijerint_definite(exp(-(2*x-3)**2), x, -oo, oo) == \
+        (sqrt(pi)/2, True)
     assert meijerint_definite(exp(-abs(2*x-3)), x, -oo, oo) == (1, True)
-    assert meijerint_definite(exp(-((x-mu)/sigma)**2/2)/sqrt(2*pi*sigma**2),
+    assert meijerint_definite(exp(-((x - mu)/sigma)**2/2)/sqrt(2*pi*sigma**2),
                               x, -oo, oo) == (1, True)
 
     # Test one of the extra conditions for 2 g-functinos
@@ -151,11 +154,12 @@ def test_meijerint():
     # Test a bug
     def res(n): return (1/(1+x**2)).diff(x, n).subs(x,1)*(-1)**n
     for n in range(6):
-       assert integrate(exp(-x)*sin(x)*x**n, (x, 0, oo), meijerg=True) == res(n)
+       assert integrate(exp(-x)*sin(x)*x**n, (x, 0, oo), meijerg=True) == \
+        res(n)
 
     # This used to test trigexpand... now it is done by linear substitution
-    assert simplify(integrate(exp(-x)*sin(x + a), (x, 0, oo), meijerg=True)).expand().rewrite(sin).expand() == \
-           sin(a)/2 + cos(a)/2
+    assert simplify(integrate(exp(-x)*sin(x + a), (x, 0, oo), meijerg=True)
+                    ).expand().rewrite(sin).expand() == sin(a)/2 + cos(a)/2
 
     # Test the condition 14 from prudnikov.
     # (This is besselj*besselj in disguise, to stop the product from being
@@ -200,7 +204,7 @@ def test_bessel():
                        powdenest)
     assert simplify(integrate(besselj(a, z)*besselj(b, z)/z, (z, 0, oo),
                      meijerg=True, conds='none')) == \
-           2*sin(pi*a/2 - pi*b/2)/(pi*(a-b)*(a+b))
+           2*sin(pi*a/2 - pi*b/2)/(pi*(a - b)*(a + b))
     assert simplify(integrate(besselj(a, z)*besselj(a, z)/z, (z, 0, oo),
                      meijerg=True, conds='none')) == 1/(2*a)
 
@@ -233,7 +237,8 @@ def test_bessel():
     assert integrate(x**2*besselj(0, x)*besselj(1, x), x, meijerg=True) == \
            x**2*besselj(1, x)**2/2
     assert integrate(besselj(0, x)*besselj(1, x)/x, x, meijerg=True) == \
-           x*besselj(0, x)**2 + x*besselj(1, x)**2 - besselj(0, x)*besselj(1, x)
+           (x*besselj(0, x)**2 + x*besselj(1, x)**2 - \
+            besselj(0, x)*besselj(1, x))
     # TODO how does besselj(0, a*x)*besselj(0, b*x) work?
     # TODO how does besselj(0, x)**2*besselj(1, x)**2 work?
     # TODO sin(x)*besselj(0, x) etc come out a mess
@@ -242,7 +247,8 @@ def test_bessel():
     # TODO more indefinite integrals when struve functions etc are implemented
 
     # test a substitution
-    assert integrate(besselj(1, x**2)*x, x, meijerg=True) == -besselj(0, x**2)/2
+    assert integrate(besselj(1, x**2)*x, x, meijerg=True) == \
+        -besselj(0, x**2)/2
 
 def test_inversion():
     from sympy import piecewise_fold, besselj, sqrt, I, sin, cos, Heaviside
@@ -291,11 +297,11 @@ def test_lookup_table():
 def test_branch_bug():
     from sympy import powdenest, lowergamma
     # TODO combsimp cannot prove that the factor is unity
-    assert powdenest(integrate(erf(x**3), x, meijerg=True).diff(x), polar=True) \
-           == 2*erf(x**3)*gamma(S(2)/3)/3/gamma(S(5)/3)
+    assert powdenest(integrate(erf(x**3), x, meijerg=True).diff(x),
+           polar=True) == 2*erf(x**3)*gamma(S(2)/3)/3/gamma(S(5)/3)
     assert integrate(erf(x**3), x, meijerg=True) == \
-           2*x*erf(x**3)*gamma(S(2)/3)/(3*gamma(S(5)/3)) \
-           - 2*gamma(S(2)/3)*lowergamma(S(2)/3, x**6)/(3*sqrt(pi)*gamma(S(5)/3))
+       2*x*erf(x**3)*gamma(S(2)/3)/(3*gamma(S(5)/3)) \
+       - 2*gamma(S(2)/3)*lowergamma(S(2)/3, x**6)/(3*sqrt(pi)*gamma(S(5)/3))
 
 def test_linear_subs():
     from sympy import besselj
@@ -311,12 +317,13 @@ def test_probability():
                                               bounded=True, positive=True)
     rate = Symbol('lambda', real=True, positive=True, bounded=True)
     def normal(x, mu, sigma):
-        return 1/sqrt(2*pi*sigma**2)*exp(-(x-mu)**2/2/sigma**2)
+        return 1/sqrt(2*pi*sigma**2)*exp(-(x - mu)**2/2/sigma**2)
     def exponential(x, rate):
         return rate*exp(-rate*x)
 
     assert integrate(normal(x, mu1, sigma1), (x, -oo, oo), meijerg=True) == 1
-    assert integrate(x*normal(x, mu1, sigma1), (x, -oo, oo), meijerg=True) == mu1
+    assert integrate(x*normal(x, mu1, sigma1), (x, -oo, oo), meijerg=True) == \
+        mu1
     assert integrate(x**2*normal(x, mu1, sigma1), (x, -oo, oo), meijerg=True) \
            == mu1**2 + sigma1**2
     assert integrate(x**3*normal(x, mu1, sigma1), (x, -oo, oo), meijerg=True) \
@@ -329,10 +336,11 @@ def test_probability():
                      (x, -oo, oo), (y, -oo, oo), meijerg=True) == mu2
     assert integrate(x*y*normal(x, mu1, sigma1)*normal(y, mu2, sigma2),
                      (x, -oo, oo), (y, -oo, oo), meijerg=True) == mu1*mu2
-    assert integrate((x+y+1)*normal(x, mu1, sigma1)*normal(y, mu2, sigma2),
+    assert integrate((x + y + 1)*normal(x, mu1, sigma1)*normal(y, mu2, sigma2),
                      (x, -oo, oo), (y, -oo, oo), meijerg=True) == 1 + mu1 + mu2
-    assert integrate((x+y-1)*normal(x, mu1, sigma1)*normal(y, mu2, sigma2),
-                     (x, -oo, oo), (y, -oo, oo), meijerg=True) == -1 + mu1 + mu2
+    assert integrate((x + y - 1)*normal(x, mu1, sigma1)*normal(y, mu2, sigma2),
+                     (x, -oo, oo), (y, -oo, oo), meijerg=True) == \
+        -1 + mu1 + mu2
 
     i = integrate(x**2*normal(x, mu1, sigma1)*normal(y, mu2, sigma2),
                   (x, -oo, oo), (y, -oo, oo), meijerg=True)
@@ -343,7 +351,8 @@ def test_probability():
            sigma2**2 + mu2**2
 
     assert integrate(exponential(x, rate), (x, 0, oo), meijerg=True) == 1
-    assert integrate(x*exponential(x, rate), (x, 0, oo), meijerg=True) == 1/rate
+    assert integrate(x*exponential(x, rate), (x, 0, oo), meijerg=True) == \
+        1/rate
     assert integrate(x**2*exponential(x, rate), (x, 0, oo), meijerg=True) \
            == 2/rate**2
 
@@ -358,13 +367,14 @@ def test_probability():
     assert E(1) == 1
     assert E(x*y) == mu1/rate
     assert E(x*y**2) == mu1**2/rate + sigma1**2/rate
-    assert simplify(E((x+y+1)**2) - E(x+y+1)**2) == (rate**2*sigma1**2 + 1)/rate**2
-    assert simplify(E((x+y-1)**2) - E(x+y-1)**2) == (rate**2*sigma1**2 + 1)/rate**2
-    assert simplify(E((x+y)**2) - E(x+y)**2) == (rate**2*sigma1**2 + 1)/rate**2
+    ans = (rate**2*sigma1**2 + 1)/rate**2
+    assert simplify(E((x + y + 1)**2) - E(x + y + 1)**2) == ans
+    assert simplify(E((x + y - 1)**2) - E(x + y - 1)**2) == ans
+    assert simplify(E((x + y)**2) - E(x + y)**2) == ans
 
     # Beta' distribution
     alpha, beta = symbols('alpha beta', positive=True)
-    betadist = x**(alpha-1)*(1+x)**(-alpha - beta)*gamma(alpha+beta) \
+    betadist = x**(alpha-1)*(1+x)**(-alpha - beta)*gamma(alpha + beta) \
               /gamma(alpha)/gamma(beta)
     assert integrate(betadist, (x, 0, oo), meijerg=True) == 1
     i = integrate(x*betadist, (x, 0, oo), meijerg=True, conds='separate')
@@ -380,7 +390,8 @@ def test_probability():
     a, b = symbols('a b', positive=True)
     betadist = x**(a - 1)*(-x + 1)**(b - 1)*gamma(a + b)/(gamma(a)*gamma(b))
     assert simplify(integrate(betadist, (x, 0, 1), meijerg=True)) == 1
-    assert simplify(integrate(x*betadist, (x, 0, 1), meijerg=True)) == a/(a + b)
+    assert simplify(integrate(x*betadist, (x, 0, 1), meijerg=True)) == \
+        a/(a + b)
     assert simplify(integrate(x**2*betadist, (x, 0, 1), meijerg=True)) == \
            a*(a + 1)/(a + b)/(a + b + 1)
     assert simplify(integrate(x**y*betadist, (x, 0, 1), meijerg=True)) == \
@@ -400,7 +411,7 @@ def test_probability():
     assert simplify(integrate(x*chisquared, (x, 0, oo), meijerg=True)) == k
     assert simplify(integrate(x**2*chisquared, (x, 0, oo), meijerg=True)) == \
            k*(k + 2)
-    assert combsimp(integrate(((x-k)/sqrt(2*k))**3*chisquared, (x, 0, oo),
+    assert combsimp(integrate(((x - k)/sqrt(2*k))**3*chisquared, (x, 0, oo),
                     meijerg=True)) == 2*sqrt(2)/sqrt(k)
 
     # Dagum distribution
@@ -409,10 +420,11 @@ def test_probability():
     dagum = a*p/x*(x/b)**(a*p)/(1 + x**a/b**a)**(p+1)
     assert simplify(integrate(dagum, (x, 0, oo), meijerg=True)) == 1
     # XXX conditions are a mess
-    assert simplify(integrate(x*dagum, (x, 0, oo), meijerg=True, conds='none')) \
-           == b*gamma(1 - 1/a)*gamma(p + 1/a)/gamma(p)
-    assert simplify(integrate(x**2*dagum, (x, 0, oo), meijerg=True, conds='none')) \
-           == b**2*gamma(1 - 2/a)*gamma(p + 2/a)/gamma(p)
+    arg = x*dagum
+    assert simplify(integrate(arg, (x, 0, oo), meijerg=True, conds='none')
+                    ) == b*gamma(1 - 1/a)*gamma(p + 1/a)/gamma(p)
+    assert simplify(integrate(x*arg, (x, 0, oo), meijerg=True, conds='none')
+                    ) == b**2*gamma(1 - 2/a)*gamma(p + 2/a)/gamma(p)
 
     # F-distribution
     d1, d2 = symbols('d1 d2', positive=True)
@@ -420,29 +432,31 @@ def test_probability():
           /gamma(d1/2)/gamma(d2/2)*gamma((d1 + d2)/2)
     assert simplify(integrate(f, (x, 0, oo), meijerg=True)) == 1
     # TODO conditions are a mess
-    assert simplify(integrate(x*f, (x, 0, oo), meijerg=True, conds='none')) == \
-           d2/(d2 - 2)
-    assert simplify(integrate(x**2*f, (x, 0, oo), meijerg=True, conds='none')) == \
-           d2**2*(d1 + 2)/d1/(d2 - 4)/(d2 - 2)
+    assert simplify(integrate(x*f, (x, 0, oo), meijerg=True, conds='none')
+                    ) == d2/(d2 - 2)
+    assert simplify(integrate(x**2*f, (x, 0, oo), meijerg=True, conds='none')
+                    ) == d2**2*(d1 + 2)/d1/(d2 - 4)/(d2 - 2)
 
     # TODO gamma, rayleigh
 
     # inverse gaussian
     lamda, mu = symbols('lamda mu', positive=True)
-    dist = sqrt(lamda/2/pi)*x**(-S(3)/2)*exp(-lamda*(x-mu)**2/x/2/mu**2)
+    dist = sqrt(lamda/2/pi)*x**(-S(3)/2)*exp(-lamda*(x - mu)**2/x/2/mu**2)
     mysimp = lambda expr: simplify(expr.rewrite(exp))
     assert mysimp(integrate(dist, (x, 0, oo))) == 1
     assert mysimp(integrate(x*dist, (x, 0, oo))) == mu
-    assert mysimp(integrate((x-mu)**2*dist, (x, 0, oo))) == mu**3/lamda
-    assert mysimp(integrate((x-mu)**3*dist, (x, 0, oo))) == 3*mu**5/lamda**2
+    assert mysimp(integrate((x - mu)**2*dist, (x, 0, oo))) == mu**3/lamda
+    assert mysimp(integrate((x - mu)**3*dist, (x, 0, oo))) == 3*mu**5/lamda**2
 
     # Levi
     c = Symbol('c', positive=True)
-    assert integrate(sqrt(c/2/pi)*exp(-c/2/(x-mu))/(x-mu)**S('3/2'), (x, mu, oo)) == 1
+    assert integrate(sqrt(c/2/pi)*exp(-c/2/(x - mu))/(x - mu)**S('3/2'),
+                    (x, mu, oo)) == 1
     # higher moments oo
 
     # log-logistic
-    distn = (beta/alpha)*x**(beta-1)/alpha**(beta-1)/(1 + x**beta/alpha**beta)**2
+    distn = (beta/alpha)*x**(beta-1)/alpha**(beta-1)\
+            /(1 + x**beta/alpha**beta)**2
     assert simplify(integrate(distn, (x, 0, oo))) == 1
     # NOTE the conditions are a mess, but correctly state beta > 1
     assert simplify(integrate(x*distn, (x, 0, oo), conds='none')) == \
@@ -456,7 +470,8 @@ def test_probability():
     n = Symbol('n', positive=True)
     distn = k/lamda*(x/lamda)**(k-1)*exp(-(x/lamda)**k)
     assert simplify(integrate(distn, (x, 0, oo))) == 1
-    assert simplify(integrate(x**n*distn, (x, 0, oo))) == lamda**n*gamma(1 + n/k)
+    assert simplify(integrate(x**n*distn, (x, 0, oo))) == \
+        lamda**n*gamma(1 + n/k)
 
     # rice distribution
     from sympy import besseli
@@ -468,25 +483,26 @@ def test_probability():
     # Laplace distribution
     mu = Symbol('mu', real=True)
     b = Symbol('b', positive=True)
-    laplace = exp(-abs(x-mu)/b)/2/b
+    laplace = exp(-abs(x - mu)/b)/2/b
     assert integrate(laplace, (x, -oo, oo), meijerg=True) == 1
     assert integrate(x*laplace, (x, -oo, oo), meijerg=True) == mu
-    assert integrate(x**2*laplace, (x, -oo, oo), meijerg=True) == 2*b**2 + mu**2
+    assert integrate(x**2*laplace, (x, -oo, oo), meijerg=True) == \
+        2*b**2 + mu**2
 
     # TODO are there other distributions supported on (-oo, oo) that we can do?
 
     # misc tests
     k = Symbol('k', positive=True)
-    assert combsimp(expand_mul(integrate(log(x) * x**(k-1) * exp(-x) / gamma(k),
-                                     (x, 0, oo)))) == polygamma(0, k)
+    assert combsimp(expand_mul(integrate(log(x)*x**(k - 1)*exp(-x)/gamma(k),
+                              (x, 0, oo)))) == polygamma(0, k)
 
 def test_expint():
     """ Test various exponential integrals. """
     from sympy import (expint, unpolarify, Symbol, Ci, Si, Shi, Chi,
                        sin, cos, sinh, cosh, Ei)
     assert simplify(unpolarify(integrate(exp(-z*x)/x**y, (x, 1, oo),
-                meijerg=True, conds='none').rewrite(expint).expand(func=True))) \
-           == expint(y, z)
+                meijerg=True, conds='none'
+                ).rewrite(expint).expand(func=True))) == expint(y, z)
 
     assert integrate(exp(-z*x)/x, (x, 1, oo), meijerg=True,
                      conds='none').rewrite(expint).expand() == \
@@ -512,13 +528,14 @@ def test_expint():
     u = Symbol('u', polar=True)
     assert integrate(cos(u)/u, u, meijerg=True).expand().as_independent(u)[1] \
            == Ci(u)
-    assert integrate(cosh(u)/u, u, meijerg=True).expand().as_independent(u)[1] \
+    assert integrate(cosh(u)/u, u, meijerg=True).expand().as_independent(u)[1]\
            == Chi(u)
 
-    assert integrate(expint(1, x), x, meijerg=True).rewrite(expint).expand() == \
-           x*expint(1, x) - exp(-x)
-    assert integrate(expint(2, x), x, meijerg=True).rewrite(expint).expand() == \
-           -x**2*expint(1, x)/2 + x*exp(-x)/2 - exp(-x)/2
+    assert integrate(expint(1, x), x, meijerg=True
+            ).rewrite(expint).expand() == x*expint(1, x) - exp(-x)
+    assert integrate(expint(2, x), x, meijerg=True
+            ).rewrite(expint).expand() == \
+            -x**2*expint(1, x)/2 + x*exp(-x)/2 - exp(-x)/2
     assert simplify(unpolarify(integrate(expint(y,x), x,
                  meijerg=True).rewrite(expint).expand(func=True))) == \
            -expint(y + 1, x)
@@ -547,7 +564,7 @@ def test_messy():
     assert laplace_transform(besselj(a, x), x, s)[1:] == \
            (0, And(S(0) < re(a/2) + S(1)/2, S(0) < re(a/2) + 1))
 
-    # NOTE s < 0 can be done, but argument reduction is currently not good enough
+    # NOTE s < 0 can be done, but argument reduction is not good enough yet
     assert fourier_transform(besselj(1, x)/x, x, s, noconds=False) == \
            (Piecewise((0, 1 < 4*abs(pi**2*s**2)),
                       (2*sqrt(-4*pi**2*s**2 + 1), True)), 0 < s)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -453,6 +453,10 @@ def test_laplace_transform():
     # TODO general order works, but is a *mess*
     # TODO besseli also works, but is an even greater mess
 
+    # test a bug in conditions processing
+    # TODO the auxiliary condition should be recognised/simplified
+    assert LT(exp(t)*cos(t), t, s)[0:-1] == ((s - 1)/(s**2 - 2*s + 2), -oo)
+
 def test_inverse_laplace_transform():
     from sympy import (expand, sinh, cosh, besselj, besseli, exp_polar,
                        unpolarify, simplify)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -973,7 +973,10 @@ def _laplace_transform(f, t, s_, simplify=True):
         return a, aux
 
     conds = [process_conds(c) for c in disjuncts(cond)]
-    conds = filter(lambda x: x[1] is not False and x[0] != -oo, conds)
+    conds2 = filter(lambda x: x[1] is not False and x[0] != -oo, conds)
+    if not conds2:
+        conds2 = filter(lambda x: x[1] is not False, conds)
+    conds = conds2
     def cnt(expr):
         if isinstance(expr, bool):
             return 0

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1896,6 +1896,8 @@ def hyperexpand_special(ap, bq, z):
     p, q = len(ap), len(bq)
     z_ = z
     z = unpolarify(z)
+    if z == 0:
+        return S.Zero
     if p == 2 and q == 1:
         # 2F1
         a, b, c = ap + bq

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -570,6 +570,8 @@ def test_hyperexpand_special():
     assert hyperexpand(meijerg([1 - z - a/2], [1 - z + a/2], [b/2], [-b/2], 1)) == \
            gamma(1 - 2*z)*gamma(z + a/2 + b/2)/gamma(1 - z + a/2 - b/2) \
            /gamma(1 - z - a/2 + b/2)/gamma(1 - z + a/2 + b/2)
+    assert hyperexpand(hyper([a], [b], 0)) == 0
+    assert hyper([a], [b], 0) != 0
 
 def test_Mod1_behavior():
     from sympy import Symbol, simplify, lowergamma


### PR DESCRIPTION
1) Certain substitutions may result in exceptions (akin to 0**0).
   Wrap such a subs in an exception handler and fail gracefully in meijerint
   code _rewrite_single.

2) Add tests for beta distribution.

3) Make hyperexpand turn hyper([..], [..], 0) into 0.
   (We don't want to autoevaluate, but simplify should do this.)

4) Add a test for this as well.
# Some discussion

Consider the integrand `betadist = x**(a - 1)*(-x + 1)**(b - 1)*gamma(a + b)/(gamma(a)*gamma(b))`, where `a, b` are declared positive. We wish to compute (e.g.) `integrate(betadist, (x, 0, 1))`. There are three approaches, tried in this order:
1. Find an antiderivative with heurisch, evalute it over the limits.
2. Find an antiderivative with meijerint, evaluate it over the limits.
3. Compute the definite integral with meijerint.

As explained in the `integrate()` docstring, the reason for trying things in this order is heuristical, but it usually does a good job. However, in this case, the order is exactly wrong!

(3) Works like a charm.

(2) Works, with the following caveat: the antiderivative is in terms of a hypergeometric function which cannot be expanded. When evaluating it over the limits `(0, 1)` it turns into two terms which _can_ be computed (because it vanishes at zero, and at one there is a formula due to gauss). The `integrate()` code does not call hyperexpand, and so the result is expressed in terms of hypergeometric functions even though it is elementary.

(1) Hangs.

There are thus two problems: the cosmetic one that even when calling `integrate(betadist, (x,0,1), meijerg=True)` the result will _not_ look elementary (however calling simplify resolves this); and the somewhat more important problem that without the parameter meijerg the integral does not seem to finish in any sensible amount of time.

I would argue that both of these behaviours are OK. Namely, having to call simplify is not a real problem. My code tries to hide hypergeometric terms, but if the most obvious thing to get rid of them works, that's fine. Regarding the hanging integral: I see no better heuristic. A hanging integral is probably something every user of sympy has seen, we just have to educate them that passing `meijerg=True` may sometimes (rather seldomly) alleviate the problem.

So much for the woffle. If you have better suggestions, I'm of course happy to implement them.
