### PR TITLE
Fix use of deprecated behavior in matricies tests

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -420,8 +420,8 @@ def test_util():
     assert v1.cross(v2) == Matrix(1,3,[-2,4,-2])
     assert v1.norm() == sqrt(14)
     assert v1.project(v2) == Matrix(1, 3, [R(39)/25, R(52)/25, R(13)/5])
-    assert Matrix.zeros((1, 2)) == Matrix(1, 2, [0, 0])
-    assert ones((1, 2)) == Matrix(1, 2, [1, 1])
+    assert Matrix.zeros(1, 2) == Matrix(1, 2, [0, 0])
+    assert ones(1, 2) == Matrix(1, 2, [1, 1])
     assert v1.clone() == v1
     # cofactor
     assert eye(3) == eye(3).cofactorMatrix()


### PR DESCRIPTION
When using sympy-bot, I noticed there were deprecation warnings for the usage of `zeros` and `ones` in the matrices tests, see [1]. This fixes these to use new syntax.

[1] http://reviews.sympy.org/report/agZzeW1weTNyDAsSBFRhc2sYv-4KDA
