### PR TITLE
Fixing issue 2974 where qapply_Mul was being passed a non Mul.

### DIFF
--- a/sympy/physics/quantum/qapply.py
+++ b/sympy/physics/quantum/qapply.py
@@ -105,7 +105,7 @@ def qapply_Mul(e, **options):
     args = list(e.args)
 
     # If we only have 0 or 1 args, we have nothing to do and return.
-    if len(args) <= 1:
+    if len(args) <= 1 or not isinstance(e, Mul):
         return e
     rhs = args.pop()
     lhs = args.pop()
@@ -163,7 +163,11 @@ def qapply_Mul(e, **options):
     if result == 0:
         return S.Zero
     elif result is None:
-        return qapply_Mul(e._new_rawargs(*(args+[lhs])), **options)*rhs
+        if len(args) == 0:
+            # We had two args to begin with so args=[].
+            return e
+        else:
+            return qapply_Mul(e._new_rawargs(*(args+[lhs])), **options)*rhs
     elif isinstance(result, InnerProduct):
         return result*qapply_Mul(e._new_rawargs(*args), **options)
     else:  # result is a scalar times a Mul, Add or TensorProduct

--- a/sympy/physics/quantum/tests/test_qapply.py
+++ b/sympy/physics/quantum/tests/test_qapply.py
@@ -9,6 +9,7 @@ from sympy.physics.quantum.operator import Operator
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import Qubit
 from sympy.physics.quantum.spin import Jx, Jy, Jz, Jplus, Jminus, J2, JzKet
+from sympy.physics.quantum.state import Ket
 
 
 j, jp, m, mp = symbols("j j' m m'")
@@ -81,3 +82,11 @@ def test_dagger():
     lhs = Dagger(Qubit(0))*Dagger(H(0))
     rhs = Dagger(Qubit(1))/sqrt(2) + Dagger(Qubit(0))/sqrt(2)
     assert qapply(lhs, dagger=True) == rhs
+
+
+def test_issue2974():
+    x, y = symbols('x y', commutative=False)
+    A = Ket(x,y)
+    B = Operator('B')
+    assert qapply(A) == A
+    assert qapply(A.dual*B) == A.dual*B


### PR DESCRIPTION
This fixes this issue:

http://code.google.com/p/sympy/issues/detail?id=2974

Basically qapply is called recursively on Mul instances, but it was calling itself with a non-Mul in certain cases.  Now we make sure it is always passed a Mul on the front and back sides.
