### PR TITLE
ImmutableMatrix

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1096,6 +1096,14 @@ def test_sympy__matrices__matrices__DeferredVector():
     from sympy.matrices.matrices import DeferredVector
     assert _test_args(DeferredVector("X"))
 
+@SKIP("abstract class")
+def test_sympy__matrices__expressions__matexpr__MatrixBase():
+    pass
+
+def test_sympy__matrices__immutable_matrix__ImmutableMatrix():
+    from sympy.matrices.immutable_matrix import ImmutableMatrix
+    assert _test_args(ImmutableMatrix([[1,2],[3,4]]))
+
 def test_sympy__matrices__expressions__blockmatrix__BlockDiagMatrix():
     from sympy.matrices.expressions.blockmatrix import BlockDiagMatrix
     from sympy.matrices.expressions import MatrixSymbol
@@ -1124,7 +1132,6 @@ def test_sympy__matrices__expressions__matadd__MatAdd():
     Y = MatrixSymbol('Y', x, y)
     assert _test_args(MatAdd(X, Y))
 
-@XFAIL
 def test_sympy__matrices__expressions__matexpr__Identity():
     from sympy.matrices.expressions.matexpr import Identity
     assert _test_args(Identity(3))
@@ -1288,7 +1295,6 @@ def test_sympy__physics__quantum__gate__TwoQubitGate():
     from sympy.physics.quantum.gate import TwoQubitGate
     assert _test_args(TwoQubitGate(0))
 
-@SKIP("TODO: Add ImmutableMatrix Class")
 def test_sympy__physics__quantum__gate__UGate():
     from sympy.physics.quantum.gate import UGate
     assert _test_args(UGate())

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1298,7 +1298,9 @@ def test_sympy__physics__quantum__gate__TwoQubitGate():
 
 def test_sympy__physics__quantum__gate__UGate():
     from sympy.physics.quantum.gate import UGate
-    assert _test_args(UGate())
+    from sympy.matrices.immutable_matrix import ImmutableMatrix
+    from sympy import Integer, Tuple
+    assert _test_args(UGate(Tuple(Integer(1)), ImmutableMatrix([[1,0],[0,2]])))
 
 def test_sympy__physics__quantum__gate__XGate():
     from sympy.physics.quantum.gate import XGate

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1132,6 +1132,7 @@ def test_sympy__matrices__expressions__matadd__MatAdd():
     Y = MatrixSymbol('Y', x, y)
     assert _test_args(MatAdd(X, Y))
 
+@XFAIL
 def test_sympy__matrices__expressions__matexpr__Identity():
     from sympy.matrices.expressions.matexpr import Identity
     assert _test_args(Identity(3))

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -3,10 +3,13 @@
 Includes functions for fast creating matrices like zero, one/eye, random
 matrix, etc.
 """
-from matrices import (Matrix, SparseMatrix, zeros, ones, eye, diag,
+from matrices import (SparseMatrix, zeros, ones, eye, diag,
      hessian, randMatrix, GramSchmidt, wronskian, casoratian,
      list2numpy, matrix2numpy, DeferredVector, symarray, ShapeError,
      NonSquareMatrixError, rot_axis1, rot_axis2, rot_axis3)
+
+from matrices import MutableMatrix as Matrix
+#from mutable_matrix import MutableMatrix as Matrix
 
 from immutable_matrix import ImmutableMatrix
 

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -8,4 +8,6 @@ from matrices import (Matrix, SparseMatrix, zeros, ones, eye, diag,
      list2numpy, matrix2numpy, DeferredVector, symarray, ShapeError,
      NonSquareMatrixError, rot_axis1, rot_axis2, rot_axis3)
 
+from immutable_matrix import ImmutableMatrix
+
 from expressions import *

--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -9,7 +9,6 @@ from matrices import (SparseMatrix, zeros, ones, eye, diag,
      NonSquareMatrixError, rot_axis1, rot_axis2, rot_axis3)
 
 from matrices import MutableMatrix as Matrix
-#from mutable_matrix import MutableMatrix as Matrix
 
 from immutable_matrix import ImmutableMatrix
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -56,12 +56,15 @@ class BlockMatrix(MatrixExpr):
         return self.mat.shape
 
     @property
+    def blocks(self):
+        return self.mat
+    @property
     def rowblocksizes(self):
-        return [self.mat[i,0].n for i in range(self.blockshape[0])]
+        return [self.blocks[i,0].n for i in range(self.blockshape[0])]
 
     @property
     def colblocksizes(self):
-        return [self.mat[0,i].m for i in range(self.blockshape[1])]
+        return [self.blocks[0,i].m for i in range(self.blockshape[1])]
 
     def _blockmul(self, other):
 
@@ -97,12 +100,13 @@ class BlockMatrix(MatrixExpr):
     def eval_inverse(self, expand=False):
         # Inverse of one by one block matrix is easy
         if self.blockshape==(1,1):
-            mat = Matrix(1, 1, (Inverse(self.mat[0]), ))
+            mat = Matrix(1, 1, (Inverse(self.blocks[0]), ))
             return BlockMatrix(mat)
         # Inverse of a two by two block matrix is known
         elif expand and self.blockshape==(2,2):
             # Cite: The Matrix Cookbook Section 9.1.3
-            A11, A12, A21, A22 = self[0,0], self[0,1], self[1,0], self[1,1]
+            A11, A12, A21, A22 = (self.blocks[0,0], self.blocks[0,1],
+                    self.blocks[1,0], self.blocks[1,1])
             C1 = A11 - A12*Inverse(A22)*A21
             C2 = A22 - A21*Inverse(A11)*A12
             mat = Matrix([[Inverse(C1), Inverse(-A11)*A12*Inverse(C2)],
@@ -114,8 +118,20 @@ class BlockMatrix(MatrixExpr):
     def inverse(self):
         return Inverse(self)
 
-    def __getitem__(self, *args):
-        return self.mat.__getitem__(*args)
+    def _entry(self, i, j):
+        idx = 0
+        # Find row entry
+        for row_block, numrows in enumerate(self.rowblocksizes):
+            if i < numrows:
+                break
+            else:
+                i -= numrows
+        for col_block, numcols in enumerate(self.colblocksizes):
+            if j < numcols:
+                break
+            else:
+                j -= numcols
+        return self.blocks[row_block, col_block][i,j]
 
     @property
     def is_Identity(self):
@@ -262,7 +278,7 @@ def block_collapse(expr):
             block = block._blockadd(b)
         if block.blockshape == (1,1):
             # Bring all the non-blocks into the block_matrix
-            mat = Matrix(1, 1, (block[0,0] + MatAdd(*nonblocks), ))
+            mat = Matrix(1, 1, (block.blocks[0,0] + MatAdd(*nonblocks), ))
             return BlockMatrix(mat)
         # Add identities to the blocks as block identities
         for i, mat in enumerate(nonblocks):

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -60,11 +60,11 @@ class BlockMatrix(MatrixExpr):
         return self.mat
     @property
     def rowblocksizes(self):
-        return [self.blocks[i,0].n for i in range(self.blockshape[0])]
+        return [self.blocks[i,0].rows for i in range(self.blockshape[0])]
 
     @property
     def colblocksizes(self):
-        return [self.blocks[0,i].m for i in range(self.blockshape[1])]
+        return [self.blocks[0,i].cols for i in range(self.blockshape[1])]
 
     def _blockmul(self, other):
 
@@ -170,8 +170,8 @@ class BlockDiagMatrix(BlockMatrix):
             for c in range(len(mats)):
                 if r == c:
                     continue
-                n = mats[r].n
-                m = mats[c].m
+                n = mats[r].rows
+                m = mats[c].cols
                 data_matrix[r, c] = ZeroMatrix(n, m)
 
         shape = Tuple(*sympify(mat.shape))

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -39,7 +39,7 @@ class MatAdd(MatrixExpr, Add):
 
         # Clear out Identities
         # Any zeros around?
-        if expr.is_Add and any(M.is_ZeroMatrix for M in expr.args):
+        if expr.is_Add and any([M.is_ZeroMatrix for M in expr.args]):
             newargs = [M for M in expr.args if not M.is_ZeroMatrix] # clear out
             if len(newargs)==0: # Did we lose everything?
                 return ZeroMatrix(*args[0].shape)

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -14,8 +14,6 @@ class MatAdd(MatrixExpr, Add):
     A + B + C
     """
 
-
-
     def __new__(cls, *args):
 
         args = map(matrixify, args)
@@ -53,5 +51,8 @@ class MatAdd(MatrixExpr, Add):
     @property
     def shape(self):
         return self.args[0].shape
+
+    def _entry(self, i, j):
+        return Add(*[arg._entry(i,j) for arg in self.args])
 
 from matmul import MatMul

--- a/sympy/matrices/expressions/matadd.py
+++ b/sympy/matrices/expressions/matadd.py
@@ -39,7 +39,7 @@ class MatAdd(MatrixExpr, Add):
 
         # Clear out Identities
         # Any zeros around?
-        if expr.is_Add and any([M.is_ZeroMatrix for M in expr.args]):
+        if expr.is_Add and any(M.is_ZeroMatrix for M in expr.args):
             newargs = [M for M in expr.args if not M.is_ZeroMatrix] # clear out
             if len(newargs)==0: # Did we lose everything?
                 return ZeroMatrix(*args[0].shape)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -20,6 +20,7 @@ class MatrixExpr(Expr):
     _op_priority = 11.0
 
     is_Matrix = True
+    is_MatrixExpr = True
     is_Identity = False
     is_Inverse = False
     is_Transpose = False
@@ -133,9 +134,16 @@ class MatrixExpr(Expr):
         raise TypeError("Only elementwise indexing currently supported")
 
     def to_explicit(self):
-        return Matrix([[    self[i,j]
+        from sympy.matrices.immutable_matrix import ImmutableMatrix
+        return ImmutableMatrix([[    self[i,j]
                             for j in range(self.m)]
                             for i in range(self.n)])
+
+    def as_mutable(self):
+        return self.to_explicit().as_mutable()
+
+    def equals(self, other):
+        return self.to_explicit().equals(other)
 
 class MatrixSymbol(MatrixExpr, Symbol):
     """Symbolic representation of a Matrix object

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -128,6 +128,8 @@ class MatrixExpr(Expr):
             i,j = key
             if self.valid_index(i, j) is not False:
                 return self._entry(*key)
+            else:
+                raise ValueError("Invalid indices (%s, %s)"%(str(i), str(j)))
         raise TypeError("Only elementwise indexing currently supported")
 
     def to_explicit(self):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -239,13 +239,10 @@ def matrixify(expr):
 
     For internal use
     """
-    if len(matrix_symbols(expr))==0: # No matrix symbols present
-        return expr
-
     class_dict = {Mul:MatMul, Add:MatAdd, MatMul:MatMul, MatAdd:MatAdd,
             Pow:MatPow, MatPow:MatPow}
 
-    if expr.__class__ not in class_dict.keys():
+    if expr.__class__ not in class_dict:
         return expr
 
     args = map(matrixify, expr.args) # Recursively call down the tree

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -125,6 +125,7 @@ class MatrixExpr(Expr):
 
     def __getitem__(self, key):
         if isinstance(key, tuple) and len(key)==2:
+            key = sympify(key)
             i,j = key
             if self.valid_index(i, j) is not False:
                 return self._entry(*key)
@@ -229,7 +230,14 @@ class MatrixSymbol(MatrixExpr, Symbol):
         raise TypeError( "%s object is not callable"%self.__class__ )
 
     def _entry(self, i, j):
-        return Symbol(self.name)(i,j)
+        # MatMul _entry will pass us a Dummy and ask that we remember it
+        # so that it can be summed over later. We'll use the function syntax
+        if i.is_Dummy or j.is_Dummy:
+            return Symbol(self.name)(i,j)
+        # If that isn't the case we'd really rather just make a symbol
+        # They are simpler and look much nicer
+        else:
+            return Symbol('%s_%s%s'%(self.name, str(i), str(j)))
 
 class Identity(MatrixSymbol):
     """The Matrix Identity I - multiplicative identity

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -162,6 +162,7 @@ class MatrixSymbol(MatrixExpr, Symbol):
     is_commutative = False
 
     def __new__(cls, name, n, m):
+        n, m = sympify(n), sympify(m)
         obj = Basic.__new__(cls, name, n, m)
         return obj
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -299,7 +299,10 @@ def matrixify(expr):
 
     args = map(matrixify, expr.args) # Recursively call down the tree
 
-    return Basic.__new__(class_dict[expr.__class__], *args)
+    if not any(arg.is_Matrix for arg in args):
+        return expr
+    else:
+        return Basic.__new__(class_dict[expr.__class__], *args)
 
 def linear_factors(expr, *syms):
     """Reduce a Matrix Expression to a sum of linear factors

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -130,8 +130,8 @@ class MatrixExpr(Expr):
             if self.valid_index(i, j) is not False:
                 return self._entry(*key)
             else:
-                raise ValueError("Invalid indices (%s, %s)"%(str(i), str(j)))
-        raise TypeError("Only elementwise indexing currently supported")
+                raise IndexError("Invalid indices (%s, %s)"%(str(i), str(j)))
+        raise IndexError("Invalid index, wanted %s[i,j]"%str(self))
 
     def as_explicit(self):
         """

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -21,7 +21,7 @@ class MatrixExpr(Expr):
 
     is_Matrix = True
     is_MatrixExpr = True
-    is_Identity = False
+    is_Identity = None
     is_Inverse = False
     is_Transpose = False
     is_ZeroMatrix = False
@@ -133,17 +133,17 @@ class MatrixExpr(Expr):
                 raise ValueError("Invalid indices (%s, %s)"%(str(i), str(j)))
         raise TypeError("Only elementwise indexing currently supported")
 
-    def to_explicit(self):
+    def as_explicit(self):
         from sympy.matrices.immutable_matrix import ImmutableMatrix
         return ImmutableMatrix([[    self[i,j]
                             for j in range(self.m)]
                             for i in range(self.n)])
 
     def as_mutable(self):
-        return self.to_explicit().as_mutable()
+        return self.as_explicit().as_mutable()
 
     def equals(self, other):
-        return self.to_explicit().equals(other)
+        return self.as_explicit().equals(other)
 
 class MatrixSymbol(MatrixExpr, Symbol):
     """Symbolic representation of a Matrix object

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -134,15 +134,57 @@ class MatrixExpr(Expr):
         raise TypeError("Only elementwise indexing currently supported")
 
     def as_explicit(self):
+        """
+        Returns a dense Matrix with elements represented explicitly
+
+        Returns an object of type ImmutableMatrix.
+
+        See Also
+        --------
+        as_mutable: returns MutableMatrix type
+        >>> from sympy import Identity
+        >>> I = Identity(3)
+        >>> I
+        I
+        >>> I.as_explicit()
+        [1, 0, 0]
+        [0, 1, 0]
+        [0, 0, 1]
+        """
         from sympy.matrices.immutable_matrix import ImmutableMatrix
         return ImmutableMatrix([[    self[i,j]
                             for j in range(self.m)]
                             for i in range(self.n)])
 
     def as_mutable(self):
+        """
+        Returns a dense Matrix with elements represented explicitly
+
+        Returns an object of type MutableMatrix.
+
+        See Also
+        --------
+        as_explicit: returns ImmutableMatrix
+        >>> from sympy import Identity
+        >>> I = Identity(3)
+        >>> I
+        I
+        >>> I.as_mutable()
+        [1, 0, 0]
+        [0, 1, 0]
+        [0, 0, 1]
+        """
         return self.as_explicit().as_mutable()
 
     def equals(self, other):
+        """
+        Test elementwise equality between matrices, potentially of different
+        types
+
+        >>> from sympy import Identity, eye
+        >>> Identity(3).equals(eye(3))
+        True
+        """
         return self.as_explicit().equals(other)
 
 class MatrixSymbol(MatrixExpr, Symbol):

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -56,6 +56,15 @@ class MatMul(MatrixExpr, Mul):
         matrices = [arg for arg in self.args if arg.is_Matrix]
         return (matrices[0].n, matrices[-1].m)
 
+    def _entry(self, i, j):
+        from sympy import Dummy, summation
+        head, tail = self.args[0], self.args[1:]
+        X = head
+        Y = MatMul(*tail)
+        k = Dummy('k', integer=True)
+        return summation(X[i,k]*Y[k,j], (k, 0, X.m))
+        return summation(*[arg._entry(i,j) for arg in self.args])
+
 from matadd import MatAdd
 from matpow import MatPow
 from inverse import Inverse

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -62,7 +62,7 @@ class MatMul(MatrixExpr, Mul):
         X = head
         Y = MatMul(*tail)
         k = Dummy('k', integer=True)
-        return summation(X[i,k]*Y[k,j], (k, 0, X.m))
+        return summation(X[i,k]*Y[k,j], (k, 0, X.m-1))
         return summation(*[arg._entry(i,j) for arg in self.args])
 
 from matadd import MatAdd

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -1,5 +1,5 @@
 from matexpr import MatrixExpr, ShapeError, matrixify, Identity, ZeroMatrix
-from sympy.core import Mul, Add
+from sympy.core import Mul, Add, Basic
 
 class MatMul(MatrixExpr, Mul):
     """A Product of Matrix Expressions
@@ -31,7 +31,8 @@ class MatMul(MatrixExpr, Mul):
         if expr.is_Add:
             return MatAdd(*expr.args)
         if expr.is_Pow:
-            return MatPow(*expr.args)
+            assert expr.exp.is_Integer
+            expr = Basic.__new__(MatMul, *[expr.base for i in range(expr.exp)])
         if not expr.is_Mul:
             return expr
 
@@ -84,5 +85,4 @@ class MatMul(MatrixExpr, Mul):
         return coeff, MatMul(*matrices)
 
 from matadd import MatAdd
-from matpow import MatPow
 from inverse import Inverse

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -73,9 +73,8 @@ class MatMul(MatrixExpr, Mul):
     def as_coeff_mmul(self):
         scalars = [x for x in self.args if not x.is_Matrix]
         matrices = [x for x in self.args if x.is_Matrix]
-        coeff = 1
-        for scalar in scalars:
-            coeff *= scalar
+        coeff = Mul(*scalars)
+
         return coeff, MatMul(*matrices)
 
 from matadd import MatAdd

--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -21,11 +21,11 @@ class MatMul(MatrixExpr, Mul):
 
         for i in range(len(matrices)-1):
             A,B = matrices[i:i+2]
-            if A.m != B.n:
+            if A.cols != B.rows:
                 raise ShapeError("Matrices %s and %s are not aligned"%(A, B))
 
         if any(arg.is_zero for arg in args):
-            return ZeroMatrix(matrices[0].n, matrices[-1].m)
+            return ZeroMatrix(matrices[0].rows, matrices[-1].cols)
 
         expr = matrixify(Mul.__new__(cls, *args))
         if expr.is_Add:
@@ -44,7 +44,7 @@ class MatMul(MatrixExpr, Mul):
         if any(M.is_Identity for M in mats): # Any identities around?
             newmats = [M for M in mats if not M.is_Identity] # clear out
             if len(newmats)==0: # Did we lose everything?
-                newmats = [Identity(expr.n)] # put just one back in
+                newmats = [Identity(expr.rows)] # put just one back in
 
             if mats != newmats: # Removed some I's but not everything?
                 return MatMul(*(nonmats+newmats)) # Repeat with simpler expr
@@ -54,7 +54,7 @@ class MatMul(MatrixExpr, Mul):
     @property
     def shape(self):
         matrices = [arg for arg in self.args if arg.is_Matrix]
-        return (matrices[0].n, matrices[-1].m)
+        return (matrices[0].rows, matrices[-1].cols)
 
     def _entry(self, i, j):
         coeff, matmul = self.as_coeff_mmul()
@@ -74,7 +74,7 @@ class MatMul(MatrixExpr, Mul):
             # Symbolic shape like (n, m)
             from sympy import Dummy, summation
             k = Dummy('k', integer=True)
-            return summation(coeff*X[i,k]*Y[k,j], (k, 0, X.m-1))
+            return summation(coeff*X[i,k]*Y[k,j], (k, 0, X.cols-1))
 
     def as_coeff_mmul(self):
         scalars = [x for x in self.args if not x.is_Matrix]

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -1,10 +1,11 @@
 from matexpr import MatrixExpr, ShapeError, Identity
-from sympy import Pow, S
+from sympy import Pow, S, Basic
 from sympy.core.sympify import _sympify
 
 class MatPow(MatrixExpr, Pow):
 
     def __new__(cls, b, e):
+        assert b.is_Matrix
         e = _sympify(e)
         if e is S.One or b.is_ZeroMatrix:
             return b
@@ -18,3 +19,11 @@ class MatPow(MatrixExpr, Pow):
     @property
     def shape(self):
         return self.base.shape
+
+    def _entry(self, i, j):
+        if self.exp.is_Integer:
+            # Make an explicity MatMul out of the MatPow
+            return Basic.__new__(MatMul,
+                    *[self.base for k in range(self.exp)])._entry(i, j)
+
+from matmul import MatMul

--- a/sympy/matrices/expressions/matpow.py
+++ b/sympy/matrices/expressions/matpow.py
@@ -11,7 +11,7 @@ class MatPow(MatrixExpr, Pow):
         elif not b.is_square:
             raise ShapeError("Power of non-square matrix %s"%b)
         elif e is S.Zero:
-            return Identity(b.n)
+            return Identity(b.rows)
         else:
             return MatrixExpr.__new__(cls, b, e)
 

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -1,0 +1,49 @@
+from sympy import *
+from sympy.utilities.pytest import raises, XFAIL
+
+k,l,m,n = symbols('k l m n', integer=True)
+i,j = symbols('i j', integer=True)
+
+W = MatrixSymbol('W', k, l)
+X = MatrixSymbol('X', l, m)
+Y = MatrixSymbol('Y', l, m)
+Z = MatrixSymbol('Z', m, n)
+
+A = MatrixSymbol('A', 2,2)
+B = MatrixSymbol('B', 2,2)
+x = MatrixSymbol('x', 1,2)
+y = MatrixSymbol('x', 2,1)
+
+def test_symbolic_indexing():
+    x12 = X[1,2]
+    assert x12 == Symbol(X.name)(1,2)
+    assert X[i,j] == Symbol(X.name)(i,j)
+
+def test_add_index():
+    assert (X+Y)[i,j] == X[i,j] + Y[i,j]
+
+def test_mul_index():
+    assert (A*y)[0,0] == A[0,0]*y[0,0] + A[0,1]*y[1,0]
+    assert (A*B).to_explicit() == A.to_explicit() * B.to_explicit()
+
+def test_Identity_index():
+    I = Identity(3)
+    assert I[0,0] == I[1,1] == I[2,2] == 1
+    assert I[1,0] == I[0,1] == I[2,1] == 0
+    raises(ValueError, "I[3,3]")
+
+def test_block_index():
+    I = Identity(3)
+    Z = ZeroMatrix(3,3)
+    B = BlockMatrix([[I,I],[I,I]])
+    BB = BlockMatrix([[eye(3), eye(3)], [eye(3), eye(3)]])
+    assert B[0,0] == B[3,0] == B[0,3] == B[3,3] == 1
+    assert B[4,3] == B[5,1] == 0
+
+    BB = BlockMatrix([[eye(3), eye(3)], [eye(3), eye(3)]])
+    assert B.to_explicit() == BB.to_explicit()
+
+    BI = BlockMatrix([[I, Z], [Z, I]])
+
+    assert BI.to_explicit() == eye(6)
+

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -24,7 +24,7 @@ def test_add_index():
 
 def test_mul_index():
     assert (A*y)[0,0] == A[0,0]*y[0,0] + A[0,1]*y[1,0]
-    assert (A*B).to_explicit() == A.to_explicit() * B.to_explicit()
+    assert (A*B).as_mutable() == (A.as_mutable() * B.as_mutable())
 
 def test_Identity_index():
     I = Identity(3)
@@ -36,14 +36,15 @@ def test_block_index():
     I = Identity(3)
     Z = ZeroMatrix(3,3)
     B = BlockMatrix([[I,I],[I,I]])
-    BB = BlockMatrix([[eye(3), eye(3)], [eye(3), eye(3)]])
+    e3 = ImmutableMatrix(eye(3))
+    BB = BlockMatrix([[e3, e3], [e3, e3]])
     assert B[0,0] == B[3,0] == B[0,3] == B[3,3] == 1
     assert B[4,3] == B[5,1] == 0
 
-    BB = BlockMatrix([[eye(3), eye(3)], [eye(3), eye(3)]])
+    BB = BlockMatrix([[e3, e3], [e3, e3]])
     assert B.to_explicit() == BB.to_explicit()
 
     BI = BlockMatrix([[I, Z], [Z, I]])
 
-    assert BI.to_explicit() == eye(6)
+    assert BI.to_explicit().equals(eye(6))
 

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -1,4 +1,5 @@
-from sympy import *
+from sympy import (symbols, MatrixSymbol, Symbol, MatPow, BlockMatrix,
+        Identity, ZeroMatrix, ImmutableMatrix, eye)
 from sympy.utilities.pytest import raises, XFAIL
 
 k,l,m,n = symbols('k l m n', integer=True)

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -25,6 +25,11 @@ def test_add_index():
 def test_mul_index():
     assert (A*y)[0,0] == A[0,0]*y[0,0] + A[0,1]*y[1,0]
     assert (A*B).as_mutable() == (A.as_mutable() * B.as_mutable())
+    X = MatrixSymbol('X', n, m)
+    Y = MatrixSymbol('Y', m, k)
+    # Using str to avoid dealing with a Dummy variable
+    assert str((X*Y)[4,2]) == "Sum(X(4, _k)*Y(_k, 2), (_k, 0, m - 1))"
+
 
 def test_Identity_index():
     I = Identity(3)

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -16,8 +16,8 @@ y = MatrixSymbol('x', 2,1)
 
 def test_symbolic_indexing():
     x12 = X[1,2]
-    assert x12 == Symbol(X.name)(1,2)
-    assert X[i,j] == Symbol(X.name)(i,j)
+    assert x12 == Symbol(X.name+"_12")
+    assert X[i,j] == Symbol(X.name+"_ij")
 
 def test_add_index():
     assert (X+Y)[i,j] == X[i,j] + Y[i,j]
@@ -30,6 +30,12 @@ def test_mul_index():
     # Using str to avoid dealing with a Dummy variable
     assert str((X*Y)[4,2]) == "Sum(X(4, _k)*Y(_k, 2), (_k, 0, m - 1))"
 
+def test_pow_index():
+    Q = MatPow(A, 2)
+    assert Q[0,0] == A[0,0]**2 + A[0,1]*A[1,0]
+
+def test_transpose_index():
+    assert X.T[i,j] == X[j,i]
 
 def test_Identity_index():
     I = Identity(3)
@@ -52,4 +58,9 @@ def test_block_index():
     BI = BlockMatrix([[I, Z], [Z, I]])
 
     assert BI.as_explicit().equals(eye(6))
+
+def test_slicing():
+    raises(ValueError, "W[3,:]")
+    A.as_explicit()[0,:] # does not raise an error
+
 

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -41,7 +41,7 @@ def test_Identity_index():
     I = Identity(3)
     assert I[0,0] == I[1,1] == I[2,2] == 1
     assert I[1,0] == I[0,1] == I[2,1] == 0
-    raises(ValueError, "I[3,3]")
+    raises(IndexError, "I[3,3]")
 
 def test_block_index():
     I = Identity(3)
@@ -60,7 +60,11 @@ def test_block_index():
     assert BI.as_explicit().equals(eye(6))
 
 def test_slicing():
-    raises(ValueError, "W[3,:]")
+    raises(IndexError, "W[3,:]")
     A.as_explicit()[0,:] # does not raise an error
+
+def test_errors():
+    raises(IndexError, "Identity(2)[1,2,3,4,5]")
+    raises(IndexError, "Identity(2)[[1,2,3,4,5]]")
 
 

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -42,9 +42,9 @@ def test_block_index():
     assert B[4,3] == B[5,1] == 0
 
     BB = BlockMatrix([[e3, e3], [e3, e3]])
-    assert B.to_explicit() == BB.to_explicit()
+    assert B.as_explicit() == BB.as_explicit()
 
     BI = BlockMatrix([[I, Z], [Z, I]])
 
-    assert BI.to_explicit().equals(eye(6))
+    assert BI.as_explicit().equals(eye(6))
 

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -113,8 +113,8 @@ def test_BlockMatrix():
     Y = BlockMatrix(Matrix([[E], [F]]))
 
     assert (X*Y).shape == (l+n, 1)
-    assert block_collapse(X*Y)[0,0] == A*E + B*F
-    assert block_collapse(X*Y)[1,0] == C*E + D*F
+    assert block_collapse(X*Y).blocks[0,0] == A*E + B*F
+    assert block_collapse(X*Y).blocks[1,0] == C*E + D*F
     assert (block_collapse(Transpose(block_collapse(Transpose(X*Y)))) ==
             block_collapse(X*Y))
 
@@ -152,7 +152,7 @@ def test_squareBlockMatrix():
     assert (X + MatrixSymbol('Q', n+m, n+m)).is_Add
     assert (X * MatrixSymbol('Q', n+m, n+m)).is_Mul
 
-    assert Y.I[0,0] == A.I
+    assert Y.I.blocks[0,0] == A.I
     assert Inverse(X, expand=True) == BlockMatrix([
         [(-B*D.I*C + A).I, -A.I*B*(D+-C*A.I*B).I],
         [-(D-C*A.I*B).I*C*A.I, (D-C*A.I*B).I]])
@@ -176,9 +176,9 @@ def test_BlockDiagMatrix():
     X = BlockDiagMatrix(A,B,C)
     Y = BlockDiagMatrix(A, 2*B, 3*C)
 
-    assert X[1,1] == B
+    assert X.blocks[1,1] == B
     assert X.shape == (n+m+l, n+m+l)
-    assert all(X[i,j].is_ZeroMatrix if i!=j else X[i,j] in [A,B,C]
+    assert all(X.blocks[i,j].is_ZeroMatrix if i!=j else X.blocks[i,j] in [A,B,C]
             for i in range(3) for j in range(3))
 
     assert block_collapse(X.I * X).is_Identity

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -2,7 +2,7 @@ from sympy.utilities.pytest import raises
 from sympy import S, symbols, Symbol, Tuple
 from sympy.matrices import (eye, MatrixSymbol, Transpose, Inverse, ShapeError,
         MatMul, Identity, BlockMatrix, BlockDiagMatrix, block_collapse, Matrix,
-        ZeroMatrix, MatAdd)
+        ZeroMatrix, MatAdd, MatPow)
 
 def test_transpose():
     n, m, l = symbols('n m l', integer=True)
@@ -183,11 +183,11 @@ def test_BlockDiagMatrix():
 
     assert block_collapse(X.I * X).is_Identity
 
-    assert block_collapse(X*X) == BlockDiagMatrix(A**2, B**2, C**2)
+    assert block_collapse(X*X) == BlockDiagMatrix(A*A, B*B, C*C)
 
     assert block_collapse(X+X) == BlockDiagMatrix(2*A, 2*B, 2*C)
 
-    assert block_collapse(X*Y) == BlockDiagMatrix(A**2, 2*B**2, 3*C**2)
+    assert block_collapse(X*Y) == BlockDiagMatrix(A*A, 2*B*B, 3*C*C)
 
     assert block_collapse(X+Y) == BlockDiagMatrix(2*A, 3*B, 4*C)
 
@@ -269,9 +269,10 @@ def test_MatPow():
     A = MatrixSymbol('A', n, n)
 
     assert Inverse(A).is_Pow
-    assert (A*A).is_Pow
-    assert (A*A).exp == 2
-    assert (A*A).base == A
+    AA = MatPow(A, 2)
+    assert AA.is_Pow
+    assert AA.exp == 2
+    assert AA.base == A
     assert (A**n).exp == n
 
     assert A**0 == Identity(n)

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,8 +1,8 @@
 from sympy.utilities.pytest import raises
-from sympy import S, symbols, Symbol, Tuple
+from sympy import S, symbols, Symbol, Tuple, Mul
 from sympy.matrices import (eye, MatrixSymbol, Transpose, Inverse, ShapeError,
         MatMul, Identity, BlockMatrix, BlockDiagMatrix, block_collapse, Matrix,
-        ZeroMatrix, MatAdd, MatPow)
+        ZeroMatrix, MatAdd, MatPow, matrixify)
 
 def test_transpose():
     n, m, l = symbols('n m l', integer=True)
@@ -310,3 +310,9 @@ def test_MatrixSymbol():
     assert X.shape == (n,m)
     raises(TypeError, "MatrixSymbol('X', n, m)(t)") # issue 2756
 
+def test_matrixify():
+    n, m, l = symbols('n m l')
+    A = MatrixSymbol('A', n, m)
+    B = MatrixSymbol('B', m, l)
+    assert matrixify(n+m) == n+m
+    assert matrixify(Mul(A,B)) == MatMul(A,B)

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -30,7 +30,7 @@ def test_inverse():
     raises(ShapeError, "Inverse(A)")
     assert Inverse(Inverse(C)) == C
 
-    assert Inverse(C)*C == Identity(C.n)
+    assert Inverse(C)*C == Identity(C.rows)
 
     assert Inverse(eye(3)) == eye(3)
 

--- a/sympy/matrices/expressions/transpose.py
+++ b/sympy/matrices/expressions/transpose.py
@@ -46,5 +46,8 @@ class Transpose(MatrixExpr):
     def shape(self):
         return self.arg.shape[::-1]
 
+    def _entry(self, i, j):
+        return self.arg._entry(j, i)
+
 from matmul import MatMul
 from matadd import MatAdd

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -1,0 +1,63 @@
+from matrices import Matrix
+from expressions import MatrixExpr, Transpose
+from sympy import Basic, Tuple
+
+class ImmutableMatrix(MatrixExpr, Matrix):
+
+    def __new__(cls, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], Matrix):
+            mat = args[0]
+        else:
+            mat = Matrix(*args, **kwargs)
+        shape = Tuple(*mat.shape)
+        data = Tuple(*mat.mat)
+        return Basic.__new__(cls, shape, data)
+
+    @property
+    def shape(self):
+        return self.args[0]
+
+    @property
+    def mat(self):
+        return self.args[1]
+
+    @property
+    def rows(self):
+        return self.shape[0]
+
+    @property
+    def cols(self):
+        return self.shape[1]
+
+    def as_mutable(self):
+        return Matrix(self.rows, self.cols, self.mat)
+
+    def __setitem__(self, *args):
+        raise TypeError('Can not set values in ImmutableMatrix')
+
+    def __getitem__(self, *args):
+        result = Matrix.__getitem__(self, *args)
+        if result.is_Matrix:
+            result = ImmutableMatrix(result)
+        return result
+
+    def transpose(self):
+        return ImmutableMatrix(Matrix.transpose(self))
+
+    def conjugate(self):
+        return ImmutableMatrix(Matrix.conjugate(self))
+
+    def expand(self, **hints):
+        return ImmutableMatrix(Matrix.expand(self, **hints))
+
+    def rref(self, *args, **kwargs):
+        r, pivotlist = self.as_mutable().rref()
+        return ImmutableMatrix(r), pivotlist
+
+    def QRdecomposition(self):
+        Q, R = self.as_mutable().QRdecomposition()
+        return ImmutableMatrix(Q), ImmutableMatrix(R)
+
+    def reshape(self, *args, **kwargs):
+        return ImmutableMatrix(Matrix.reshape(self, *args, **kwargs))
+

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -24,3 +24,6 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     @property
     def cols(self):
         return self.shape[1]
+
+    def _entry(self, i, j):
+        return MatrixBase.__getitem__(self, (i,j))

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -1,4 +1,4 @@
-from matrices import MatrixBase
+from matrices import MatrixBase, MutableMatrix
 from expressions import MatrixExpr, Transpose
 from sympy import Basic, Tuple
 
@@ -25,5 +25,20 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     def cols(self):
         return self.shape[1]
 
+    def __getitem__(self, *args):
+        return MatrixBase.__getitem__(self, *args)
+
+    def __setitem__(self, *args):
+        raise TypeError("Can not set values in Immutable Matrix")
+
     def _entry(self, i, j):
         return MatrixBase.__getitem__(self, (i,j))
+
+    def as_mutable(self):
+        return MutableMatrix(self)
+
+    def to_explicit(self):
+        return self
+
+    def equals(self, other):
+        return MatrixBase.equals(self, other)

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -1,17 +1,13 @@
-from matrices import Matrix
+from matrices import MatrixBase
 from expressions import MatrixExpr, Transpose
 from sympy import Basic, Tuple
 
-class ImmutableMatrix(MatrixExpr, Matrix):
-
+class ImmutableMatrix(MatrixExpr, MatrixBase):
     def __new__(cls, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], Matrix):
-            mat = args[0]
-        else:
-            mat = Matrix(*args, **kwargs)
-        shape = Tuple(*mat.shape)
-        data = Tuple(*mat.mat)
-        return Basic.__new__(cls, shape, data)
+        rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
+        shape = Tuple(rows, cols)
+        mat = Tuple(*mat)
+        return Basic.__new__(cls, shape, mat)
 
     @property
     def shape(self):
@@ -28,36 +24,3 @@ class ImmutableMatrix(MatrixExpr, Matrix):
     @property
     def cols(self):
         return self.shape[1]
-
-    def as_mutable(self):
-        return Matrix(self.rows, self.cols, self.mat)
-
-    def __setitem__(self, *args):
-        raise TypeError('Can not set values in ImmutableMatrix')
-
-    def __getitem__(self, *args):
-        result = Matrix.__getitem__(self, *args)
-        if result.is_Matrix:
-            result = ImmutableMatrix(result)
-        return result
-
-    def transpose(self):
-        return ImmutableMatrix(Matrix.transpose(self))
-
-    def conjugate(self):
-        return ImmutableMatrix(Matrix.conjugate(self))
-
-    def expand(self, **hints):
-        return ImmutableMatrix(Matrix.expand(self, **hints))
-
-    def rref(self, *args, **kwargs):
-        r, pivotlist = self.as_mutable().rref()
-        return ImmutableMatrix(r), pivotlist
-
-    def QRdecomposition(self):
-        Q, R = self.as_mutable().QRdecomposition()
-        return ImmutableMatrix(Q), ImmutableMatrix(R)
-
-    def reshape(self, *args, **kwargs):
-        return ImmutableMatrix(Matrix.reshape(self, *args, **kwargs))
-

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -3,6 +3,7 @@ from expressions import MatrixExpr, Transpose
 from sympy import Basic, Tuple
 
 class ImmutableMatrix(MatrixExpr, MatrixBase):
+
     def __new__(cls, *args, **kwargs):
         rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
         shape = Tuple(rows, cols)
@@ -34,11 +35,5 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     def _entry(self, i, j):
         return MatrixBase.__getitem__(self, (i,j))
 
-    def as_mutable(self):
-        return MutableMatrix(self)
-
-    def as_explicit(self):
-        return self
-
-    def equals(self, other):
-        return MatrixBase.equals(self, other)
+    as_mutable = MatrixBase.as_mutable
+    equals = MatrixBase.equals

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -37,7 +37,7 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     def as_mutable(self):
         return MutableMatrix(self)
 
-    def to_explicit(self):
+    def as_explicit(self):
         return self
 
     def equals(self, other):

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -4,6 +4,8 @@ from sympy import Basic, Tuple
 
 class ImmutableMatrix(MatrixExpr, MatrixBase):
 
+    _class_priority = 8
+
     @classmethod
     def _new(cls, *args, **kwargs):
         if len(args)==1 and isinstance(args[0], ImmutableMatrix):

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -5,6 +5,8 @@ from sympy import Basic, Tuple
 class ImmutableMatrix(MatrixExpr, MatrixBase):
 
     def __new__(cls, *args, **kwargs):
+        if len(args)==1 and isinstance(args[0], ImmutableMatrix):
+            return args[0]
         rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
         shape = Tuple(rows, cols)
         mat = Tuple(*mat)

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -4,13 +4,16 @@ from sympy import Basic, Tuple
 
 class ImmutableMatrix(MatrixExpr, MatrixBase):
 
-    def __new__(cls, *args, **kwargs):
+    @classmethod
+    def _new(cls, *args, **kwargs):
         if len(args)==1 and isinstance(args[0], ImmutableMatrix):
             return args[0]
         rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
         shape = Tuple(rows, cols)
         mat = Tuple(*mat)
         return Basic.__new__(cls, shape, mat)
+    def __new__(cls, *args, **kwargs):
+        return cls._new(*args, **kwargs)
 
     @property
     def shape(self):

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -18,22 +18,14 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     def mat(self):
         return self.args[1]
 
-    @property
-    def rows(self):
-        return self.shape[0]
-
-    @property
-    def cols(self):
-        return self.shape[1]
-
-    def __getitem__(self, *args):
-        return MatrixBase.__getitem__(self, *args)
+    def _entry(self, i, j):
+        return MatrixBase.__getitem__(self, (i,j))
 
     def __setitem__(self, *args):
         raise TypeError("Can not set values in Immutable Matrix")
 
-    def _entry(self, i, j):
-        return MatrixBase.__getitem__(self, (i,j))
+    __getitem__ = MatrixBase.__getitem__
 
     as_mutable = MatrixBase.as_mutable
+
     equals = MatrixBase.equals

--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -29,3 +29,4 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     as_mutable = MatrixBase.as_mutable
 
     equals = MatrixBase.equals
+    is_Identity = MatrixBase.is_Identity

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -449,15 +449,8 @@ class MatrixBase(object):
         except AttributeError:
             return False
 
-    def __ne__(self, a):
-        if not isinstance(a, (MatrixBase, Basic)):
-            a = sympify(a)
-        if isinstance(a, MatrixBase) and self.shape == a.shape:
-            return any(self[i, j] != a[i, j]
-                for i in xrange(self.rows)
-                for j in xrange(self.cols))
-        else:
-            return True
+    def __ne__(self, other):
+        return not self == other
 
     def __hash__(self):
         return super(MatrixBase, self).__hash__()

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -68,7 +68,7 @@ class Matrix(object):
 
     is_Matrix = True
 
-    def __init__(self, *args):
+    def __new__(cls, *args):
         """
         Matrix can be constructed with values or a rule.
 
@@ -81,6 +81,7 @@ class Matrix(object):
         [0, 2]
 
         """
+        self = object.__new__(Matrix)
         if len(args) == 3 and callable(args[2]):
             operation = args[2]
             self.rows = int(args[0])
@@ -102,7 +103,7 @@ class Matrix(object):
                 self.rows = mat.rows
                 self.cols = mat.cols
                 self.mat = mat[:]
-                return
+                return self
             elif hasattr(mat, "__array__"): #pragma: no cover
                 # NumPy array or matrix or some other object that implements
                 # __array__. So let's first use this method to get a
@@ -111,13 +112,13 @@ class Matrix(object):
                 if len(arr.shape) == 2:
                     self.rows, self.cols = arr.shape[0], arr.shape[1]
                     self.mat = map(lambda i: sympify(i), arr.ravel())
-                    return
+                    return self
                 elif len(arr.shape) == 1:
                     self.rows, self.cols = 1, arr.shape[0]
                     self.mat = [0]*self.cols
                     for i in xrange(len(arr)):
                         self.mat[i] = sympify(arr[i])
-                    return
+                    return self
                 else:
                     raise NotImplementedError("Sympy supports just 1D and 2D matrices")
             elif not is_sequence(mat, include=Matrix):
@@ -133,7 +134,7 @@ class Matrix(object):
                 if not is_sequence(mat[0]):
                     self.cols = 1
                     self.mat = map(lambda i: sympify(i), mat)
-                    return
+                    return self
                 self.cols = len(mat[0])
             else:
                 self.cols = 0
@@ -150,6 +151,8 @@ class Matrix(object):
             self.mat = []
         else:
             raise TypeError("Data type not understood")
+
+        return self
 
     def transpose(self):
         """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3627,8 +3627,7 @@ def classof(A,B):
     if frozenset((A.__class__, B.__class__)) == frozenset(
             (MutableMatrix, ImmutableMatrix)):
         return MutableMatrix
-    raise TypeError('No defined strategy to combine types %s, %s'%(
-        A.__class__, B.__class__))
+    return MutableMatrix
 
 def matrix_multiply(A, B):
     """
@@ -4699,3 +4698,6 @@ def rot_axis1(theta):
            (0,ct,st),
            (0,-st,ct))
     return MutableMatrix(mat)
+
+Matrix = MutableMatrix
+Matrix.__name__ = "Matrix"

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3218,6 +3218,16 @@ class MatrixBase(object):
         """
         return any(a.has(*patterns) for a in self.mat)
 
+    @property
+    def is_Identity(self):
+        for i in xrange(self.rows):
+            for j in xrange(self.cols):
+                if i==j and self[i,j] != 1:
+                    return False
+                if i!=j and self[i,j] != 0:
+                    return False
+        return True
+
 class MutableMatrix(MatrixBase):
 
     is_MatrixExpr = False

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3627,7 +3627,14 @@ def classof(A,B):
     if frozenset((A.__class__, B.__class__)) == frozenset(
             (MutableMatrix, ImmutableMatrix)):
         return MutableMatrix
-    return MutableMatrix
+    try:
+        import numpy
+        if isinstance(A, numpy.ndarray):
+            return B.__class__
+        if isinstance(B, numpy.ndarray):
+            return A.__class__
+    except:        pass
+    raise TypeError("Incompatible classes %s, %s"%(A.__class__, B.__class__))
 
 def matrix_multiply(A, B):
     """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -104,12 +104,7 @@ class MatrixBase(object):
             self.mat = map(lambda i: sympify(i), mat)
         elif len(args) == 1:
             mat = args[0]
-            if isinstance(mat, MatrixBase):
-                self.rows = mat.rows
-                self.cols = mat.cols
-                self.mat = mat[:]
-                return self.rows, self.cols, self.mat
-            elif hasattr(mat, "__array__"): #pragma: no cover
+            if hasattr(mat, "__array__"): #pragma: no cover
                 # NumPy array or matrix or some other object that implements
                 # __array__. So let's first use this method to get a
                 # numpy.array() and then make a python list out of it.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -456,6 +456,13 @@ class Matrix(object):
         """The shape (dimensions) of the matrix as the 2-tuple (rows, cols)."""
         return (self.rows, self.cols)
 
+    @property
+    def n(self):
+        return self.shape[0]
+    @property
+    def m(self):
+        return self.shape[1]
+
     def __rmul__(self,a):
         if hasattr(a, "__array__") and a.shape != ():
             return matrix_multiply(a,self)
@@ -3898,7 +3905,8 @@ def casoratian(seqs, n, zero=True):
 
 # Add sympify converters
 def _matrix_sympify(matrix):
-    raise SympifyError('Matrix cannot be sympified')
+    warnings.warn("Attempting to sympify Matrix. Matrix is not Basic", Warning)
+    return matrix
 converter[Matrix] = _matrix_sympify
 del _matrix_sympify
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -297,11 +297,25 @@ class MatrixBase(object):
         raise NotImplementedError()
 
     def as_mutable(self):
-        return MutableMatrix(self.rows, self.cols, self[:,:].mat)
+        """
+        Returns a Mutable version of this Matrix
+
+        >>> from sympy import ImmutableMatrix
+        >>> X = ImmutableMatrix([[1,2],[3,4]])
+        >>> Y = X.as_mutable()
+        >>> Y[1,1] = 5 # Can set values in Y
+        >>> Y
+        [1, 2]
+        [3, 5]
+        """
+        return MutableMatrix(self.rows, self.cols, self.mat)
 
     def as_immutable(self):
+        """
+        Returns an Immutable version of this Matrix
+        """
         from immutable_matrix import ImmutableMatrix
-        return ImmutableMatrix(self.rows, self.cols, self[:,:].mat)
+        return ImmutableMatrix(self.rows, self.cols, self.mat)
 
     def __array__(self):
         return matrix2numpy(self)
@@ -3239,7 +3253,7 @@ class MutableMatrix(MatrixBase):
         self = object.__new__(cls)
         self.rows = rows
         self.cols = cols
-        self.mat = mat
+        self.mat = list(mat) # create a shallow copy
         return self
 
     def __setitem__(self, key, value):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -177,7 +177,7 @@ class MatrixBase(object):
         a = [0]*len(self)
         for i in xrange(self.cols):
             a[i*self.rows:(i+1)*self.rows] = self.mat[i::self.cols]
-        return self.__class__(self.cols,self.rows,a)
+        return self._new(self.cols,self.rows,a)
 
     T = property(transpose,None,None,"Matrix transposition.")
 
@@ -191,7 +191,7 @@ class MatrixBase(object):
         H: Hermite conjugation
         D: Dirac conjugation
         """
-        out = self.__class__(self.rows,self.cols,
+        out = self._new(self.rows,self.cols,
                 lambda i,j: self[i,j].conjugate())
         return out
 
@@ -355,14 +355,14 @@ class MatrixBase(object):
     def __rmul__(self,a):
         if hasattr(a, "__array__") and a.shape != ():
             return matrix_multiply(a,self)
-        out = self.__class__(self.rows, self.cols, map(lambda i: a*i,self.mat))
+        out = self._new(self.rows, self.cols, map(lambda i: a*i,self.mat))
         return out
 
     def expand(self, **hints):
         """
         Expand each element of the matrix by calling `expand()`.
         """
-        out = self.__class__(self.rows, self.cols,
+        out = self._new(self.rows, self.cols,
                 map(lambda i: i.expand(**hints), self.mat))
         return out
 
@@ -370,7 +370,7 @@ class MatrixBase(object):
         """
         Create substituted expressions for each element with `Expr.subs`.
         """
-        out = self.__class__(self.rows, self.cols,
+        out = self._new(self.rows, self.cols,
                 map(lambda i: i.subs(*args),self.mat))
         return out
 
@@ -383,7 +383,7 @@ class MatrixBase(object):
     def __mul__(self,a):
         if hasattr(a, "__array__") and a.shape != ():
             return matrix_multiply(self,a)
-        out = self.__class__(self.rows, self.cols, map(lambda i: i*a,self.mat))
+        out = self._new(self.rows, self.cols, map(lambda i: i*a,self.mat))
         return out
 
     def __pow__(self, num):
@@ -536,7 +536,7 @@ class MatrixBase(object):
                     for k in xrange(j)))
             L[i, i] = sqrt(self[i, i] - sum(L[i, k] ** 2
                 for k in xrange(i)))
-        return self.__class__(L)
+        return self._new(L)
 
     def LDLdecomposition(self):
         """
@@ -588,7 +588,7 @@ class MatrixBase(object):
                     L[i, k] * L[j, k] * D[k, k] for k in xrange(j)))
             D[i, i] = self[i, i] - sum(L[i, k]**2 * D[k, k]
                 for k in xrange(i))
-        return self.__class__(L), self.__class__(D)
+        return self._new(L), self._new(D)
 
     def lower_triangular_solve(self, rhs):
         """
@@ -625,7 +625,7 @@ class MatrixBase(object):
                 raise TypeError("Matrix must be non-singular.")
             X[i, 0] = (rhs[i, 0] - sum(self[i, k] * X[k, 0]
                 for k in xrange(i))) / self[i, i]
-        return self.__class__(X)
+        return self._new(X)
 
     def upper_triangular_solve(self, rhs):
         """
@@ -659,7 +659,7 @@ class MatrixBase(object):
                 raise ValueError("Matrix must be non-singular.")
             X[i, 0] = (rhs[i, 0] - sum(self[i, k] * X[k, 0]
                 for k in xrange(i+1, self.rows))) / self[i, i]
-        return self.__class__(X)
+        return self._new(X)
 
     def cholesky_solve(self, rhs):
         """
@@ -714,7 +714,7 @@ class MatrixBase(object):
         Helper function of function diagonal_solve,
         without the error checks, to be used privately.
         """
-        return self.__class__(rhs.rows, 1, lambda i, j: rhs[i, 0] / self[i, i])
+        return self._new(rhs.rows, 1, lambda i, j: rhs[i, 0] / self[i, i])
 
     def LDLsolve(self, rhs):
         """
@@ -992,7 +992,7 @@ class MatrixBase(object):
         outMat = [0]*outLines*outCols
         for i in xrange(outLines):
             outMat[i*outCols:(i+1)*outCols] = self.mat[(i+rlo)*self.cols+clo:(i+rlo)*self.cols+chi]
-        return self.__class__(outLines,outCols,outMat)
+        return self._new(outLines,outCols,outMat)
 
     def extract(self, rowsList, colsList):
         """
@@ -1037,7 +1037,7 @@ class MatrixBase(object):
         mat = self.mat
         rowsList = [self.key2ij((k,0))[0] for k in rowsList]
         colsList = [self.key2ij((0,k))[1] for k in colsList]
-        return self.__class__(len(rowsList), len(colsList),
+        return self._new(len(rowsList), len(colsList),
                 lambda i,j: mat[rowsList[i]*cols + colsList[j]])
 
     def key2bounds(self, keys):
@@ -1124,7 +1124,7 @@ class MatrixBase(object):
         if not callable(f):
             raise TypeError("`f` must be callable.")
 
-        out = self.__class__(self.rows, self.cols, map(f,self.mat))
+        out = self._new(self.rows, self.cols, map(f,self.mat))
         return out
 
     def evalf(self, prec=None, **options):
@@ -1157,7 +1157,7 @@ class MatrixBase(object):
         """
         if len(self) != _rows*_cols:
             raise ValueError("Invalid reshape parameters %d %d" % (_rows, _cols))
-        return self.__class__(_rows, _cols, lambda i,j: self.mat[i*_cols + j])
+        return self._new(_rows, _cols, lambda i,j: self.mat[i*_cols + j])
 
     def print_nonzero (self, symb="X"):
         """
@@ -1369,7 +1369,7 @@ class MatrixBase(object):
         minorMatrix
         adjugate
         """
-        out = self.__class__(self.rows, self.cols, lambda i,j:
+        out = self._new(self.rows, self.cols, lambda i,j:
                 self.cofactor(i, j, method))
         return out
 
@@ -1456,7 +1456,7 @@ class MatrixBase(object):
         wronskian
         """
         if not isinstance(X, MatrixBase):
-            X = self.__class__(X)
+            X = self._new(X)
         # Both X and self can be a row or a column matrix, so we need to make
         # sure all valid combinations work, but everything else fails:
         if self.shape[0] == 1:
@@ -1474,7 +1474,7 @@ class MatrixBase(object):
 
         # m is the number of functions and n is the number of variables
         # computing the Jacobian is now easy:
-        return self.__class__(m, n, lambda j, i: self[j].diff(X[i]))
+        return self._new(m, n, lambda j, i: self[j].diff(X[i]))
 
     def QRdecomposition(self):
         """
@@ -1592,7 +1592,7 @@ class MatrixBase(object):
             for k in range(j+1, n):
                 tmp -= R[j,k] * x[n-1-k]
             x.append(tmp/R[j,j])
-        return self.__class__([row.mat for row in reversed(x)])
+        return self._new([row.mat for row in reversed(x)])
 
     #def evaluate(self):    # no more eval() so should be removed
     #    for i in range(self.rows):
@@ -1619,7 +1619,7 @@ class MatrixBase(object):
                 b.rows == 3 and b.cols == 1):
             raise ShapeError("Dimensions incorrect for cross product.")
         else:
-            return self.__class__(1,3,((self[1]*b[2] - self[2]*b[1]),
+            return self._new(1,3,((self[1]*b[2] - self[2]*b[1]),
                                (self[2]*b[0] - self[0]*b[2]),
                                (self[0]*b[1] - self[1]*b[0])))
 
@@ -1863,7 +1863,7 @@ class MatrixBase(object):
         M = self.as_mutable()
         M.row_del(i)
         M.col_del(j)
-        return self.__class__(M)
+        return self._new(M)
 
     def exp(self):
         """ Returns the exponentiation of a matrix
@@ -2267,7 +2267,7 @@ class MatrixBase(object):
         """
         Create a shallow copy of this matrix.
         """
-        return self.__class__(self.rows, self.cols, lambda i, j: self[i, j])
+        return self._new(self.rows, self.cols, lambda i, j: self[i, j])
 
     def det(self, method="bareis"):
         """
@@ -2477,7 +2477,7 @@ class MatrixBase(object):
                 r.row(j, lambda x, k: x - scale*r[pivot,k])
             pivotlist.append(i)
             pivot += 1
-        return self.__class__(r), pivotlist
+        return self._new(r), pivotlist
 
     def nullspace(self, simplified=False):
         """
@@ -2506,7 +2506,7 @@ class MatrixBase(object):
                             # XXX: Is this the correct error?
                             raise NotImplementedError("Could not compute the nullspace of `self`.")
                         basis[basiskey.index(j)][i,0] = -1 * reduced[line, j]
-        return [self.__class__(b) for b in basis]
+        return [self._new(b) for b in basis]
 
     def berkowitz(self):
         """The Berkowitz algorithm.
@@ -2592,7 +2592,7 @@ class MatrixBase(object):
 
             transforms[k-1] = T
 
-        polys = [ self.__class__([S.One, -A[0,0]]) ]
+        polys = [ self._new([S.One, -A[0,0]]) ]
 
         for i, T in enumerate(transforms):
             polys.append(T * polys[i])
@@ -2716,7 +2716,7 @@ class MatrixBase(object):
                     basis[0][i] = b
                 if l != 1:
                     basis[0] *= l
-            out.append((r, k, [self.__class__(b) for b in basis]))
+            out.append((r, k, [self._new(b) for b in basis]))
         return out
 
     def singular_values(self):
@@ -2801,7 +2801,7 @@ class MatrixBase(object):
         limit
         diff
         """
-        return self.__class__(self.rows, self.cols,
+        return self._new(self.rows, self.cols,
                 lambda i, j: self[i, j].integrate(*args))
 
     def limit(self, *args):
@@ -2824,7 +2824,7 @@ class MatrixBase(object):
         integrate
         diff
         """
-        return self.__class__(self.rows, self.cols,
+        return self._new(self.rows, self.cols,
                 lambda i, j: self[i, j].limit(*args))
 
     def diff(self, *args):
@@ -2847,7 +2847,7 @@ class MatrixBase(object):
         integrate
         limit
         """
-        return self.__class__(self.rows, self.cols,
+        return self._new(self.rows, self.cols,
                 lambda i, j: self[i, j].diff(*args))
 
     def vec(self):
@@ -3236,7 +3236,8 @@ class MutableMatrix(MatrixBase):
 
     _op_priority = 12.0
 
-    def __new__(cls, *args, **kwargs):
+    @classmethod
+    def _new(cls, *args, **kwargs):
         if len(args)==1 and isinstance(args[0], MutableMatrix):
             return args[0]
         rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
@@ -3245,6 +3246,8 @@ class MutableMatrix(MatrixBase):
         self.cols = cols
         self.mat = list(mat) # create a shallow copy
         return self
+    def __new__(cls, *args, **kwargs):
+        return cls._new(*args, **kwargs)
 
     def __setitem__(self, key, value):
         """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -440,14 +440,13 @@ class MatrixBase(object):
     def __neg__(self):
         return -1*self
 
-    def __eq__(self, a):
-        if not isinstance(a, (MatrixBase, Basic)):
-            a = sympify(a)
-        if isinstance(a, MatrixBase) and self.shape == a.shape:
-            return all(self[i, j] == a[i, j]
-                for i in xrange(self.rows)
-                for j in xrange(self.cols))
-        else:
+    def __eq__(self, other):
+        try:
+            return (self.shape == other.shape and
+                    all([self[i,j] == other[i,j]
+                        for i in xrange(self.rows)
+                        for j in xrange(self.cols)]))
+        except AttributeError:
             return False
 
     def __ne__(self, a):
@@ -3999,7 +3998,7 @@ def casoratian(seqs, n, zero=True):
 
 # Add sympify converters
 def _matrix_sympify(matrix):
-    return matrix.as_immutable()
+    #return matrix.as_immutable()
     raise SympifyError('Matrix cannot be sympified')
 converter[MatrixBase] = _matrix_sympify
 del _matrix_sympify

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -357,13 +357,6 @@ class MatrixBase(object):
         """The shape (dimensions) of the matrix as the 2-tuple (rows, cols)."""
         return (self.rows, self.cols)
 
-    @property
-    def n(self):
-        return self.shape[0]
-    @property
-    def m(self):
-        return self.shape[1]
-
     def __rmul__(self,a):
         if hasattr(a, "__array__") and a.shape != ():
             return matrix_multiply(a,self)
@@ -1657,9 +1650,6 @@ class MatrixBase(object):
         multiply
         multiply_elementwise
         """
-#        if a.is_Immutable: # this would be slow
-#            return a.as_mutable().dot(b)
-
         if not isinstance(b, MatrixBase):
             if is_sequence(b):
                 if len(b) != self.cols and len(b) != self.rows:
@@ -3605,15 +3595,32 @@ class MutableMatrix(MatrixBase):
         raise NotImplementedError("Matrix Power not defined")
 
 def force_mutable(x):
+    """
+    Safely turn a Matrix object into a Mutable Matrix
+    """
     if not isinstance(x, Basic):
         return x
     if not x.is_Matrix:
         return x
-    if x.is_Matrix and x.is_MatrixExpr:
+    if x.is_MatrixExpr:
         return x.as_mutable()
     return x
 
 def classof(A,B):
+    """
+    Determines strategy for combining Immutable and Mutable matrices
+
+    Currently the strategy is that Mutability is contagious
+
+    Example
+
+    >>> from sympy import Matrix, ImmutableMatrix
+    >>> from sympy.matrices.matrices import classof
+    >>> M = Matrix([[1,2],[3,4]]) # a Mutable Matrix
+    >>> IM = ImmutableMatrix([[1,2],[3,4]])
+    >>> classof(M, IM)
+    sympy.matrices.matrices.MutableMatrix
+    """
     from immutable_matrix import ImmutableMatrix
     if A.__class__ == B.__class__:
         return A.__class__

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -440,7 +440,7 @@ class MatrixBase(object):
     def __neg__(self):
         return -1*self
 
-    def __eq__(self, other):
+    def equals(self, other):
         try:
             return (self.shape == other.shape and
                     all([self[i,j] == other[i,j]
@@ -448,6 +448,9 @@ class MatrixBase(object):
                         for j in xrange(self.cols)]))
         except AttributeError:
             return False
+
+    def __eq__(self, other):
+        return self.equals(other)
 
     def __ne__(self, other):
         return not self == other
@@ -3217,6 +3220,8 @@ class MatrixBase(object):
 
 class MutableMatrix(MatrixBase):
 
+    is_MatrixExpr = False
+
     _op_priority = 12.0
 
     def __new__(cls, *args, **kwargs):
@@ -3540,32 +3545,32 @@ class MutableMatrix(MatrixBase):
 
     @call_highest_priority('__radd__')
     def __add__(self, other):
-        return MatrixBase.__add__(self, other)
+        return MatrixBase.__add__(self, force_mutable(other))
 
     @call_highest_priority('__add__')
     def __radd__(self, other):
-        return MatrixBase.__radd__(self, other)
+        return MatrixBase.__radd__(self, force_mutable(other))
 
     @call_highest_priority('__rsub__')
     def __sub__(self, other):
-        return MatrixBase.__sub__(self, other)
+        return MatrixBase.__sub__(self, force_mutable(other))
     @call_highest_priority('__sub__')
     def __rsub__(self, other):
-        return MatrixBase.__rsub__(self, other)
+        return MatrixBase.__rsub__(self, force_mutable(other))
 
     @call_highest_priority('__rmul__')
     def __mul__(self, other):
-        return MatrixBase.__mul__(self, other)
+        return MatrixBase.__mul__(self, force_mutable(other))
     @call_highest_priority('__mul__')
     def __rmul__(self, other):
-        return MatrixBase.__rmul__(self, other)
+        return MatrixBase.__rmul__(self, force_mutable(other))
 
     @call_highest_priority('__div__')
     def __div__(self, other):
-        return MatrixBase.__div__(self, other)
+        return MatrixBase.__div__(self, force_mutable(other))
     @call_highest_priority('__truediv__')
     def __truediv__(self, other):
-        return MatrixBase.__truediv__(self, other)
+        return MatrixBase.__truediv__(self, force_mutable(other))
 
     @call_highest_priority('__rpow__')
     def __pow__(self, other):
@@ -3574,6 +3579,15 @@ class MutableMatrix(MatrixBase):
     @call_highest_priority('__pow__')
     def __rpow__(self, other):
         raise NotImplementedError("Matrix Power not defined")
+
+def force_mutable(x):
+    if not isinstance(x, Basic):
+        return x
+    if not x.is_Matrix:
+        return x
+    if x.is_Matrix and x.is_MatrixExpr:
+        return x.as_mutable()
+    return x
 
 def classof(A,B):
     from immutable_matrix import ImmutableMatrix

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3624,7 +3624,7 @@ def classof(A,B):
     >>> M = Matrix([[1,2],[3,4]]) # a Mutable Matrix
     >>> IM = ImmutableMatrix([[1,2],[3,4]])
     >>> classof(M, IM)
-    sympy.matrices.matrices.MutableMatrix
+    <class 'sympy.matrices.matrices.Matrix'>
     """
     from immutable_matrix import ImmutableMatrix
     try:

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,4 +1,4 @@
-from sympy import *
+from sympy import ImmutableMatrix, Matrix, eye, zeros
 from sympy.utilities.pytest import raises, XFAIL
 
 IM = ImmutableMatrix([[1,2,3], [4,5,6], [7,8,9]])

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -5,7 +5,6 @@ IM = ImmutableMatrix([[1,2,3], [4,5,6], [7,8,9]])
 ieye = ImmutableMatrix(eye(3))
 
 def test_immutable_creation():
-
     assert IM.shape == (3,3)
     assert IM[1,2] == 6
     assert IM[2,2] == 9

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -20,3 +20,35 @@ def test_slicing():
 def test_as_immutable():
     X = Matrix([[1,2], [3,4]])
     assert X.as_immutable() == ImmutableMatrix([[1,2],[3,4]])
+
+def test_function_return_types():
+    # Lets ensure that decompositions of immutable matrices remain immutable
+    # I.e. do MatrixBase methods return the correct class?
+    X = ImmutableMatrix([[1,2],[3,4]])
+    Y = ImmutableMatrix([[1],[0]])
+    q, r = X.QRdecomposition()
+    assert (type(q), type(r)) == (ImmutableMatrix, ImmutableMatrix)
+
+    assert type(X.LUsolve(Y)) == ImmutableMatrix
+    assert type(X.QRsolve(Y)) == ImmutableMatrix
+
+    X = ImmutableMatrix([[1,2],[2,1]])
+    assert X.T == X
+    assert X.is_symmetric
+    assert type(X.cholesky()) == ImmutableMatrix
+    L, D = X.LDLdecomposition()
+    assert (type(L), type(D)) == (ImmutableMatrix, ImmutableMatrix)
+
+    assert X.is_diagonalizable()
+    assert X.berkowitz_det() == -3
+    assert X.norm(2) == 3
+
+    assert type(X.eigenvects()[0][2][0]) == ImmutableMatrix
+
+    assert type(zeros(3,3).as_immutable().nullspace()[0]) == ImmutableMatrix
+
+    X = ImmutableMatrix([[1,0], [2,1]])
+    assert type(X.lower_triangular_solve(Y)) == ImmutableMatrix
+    assert type(X.T.upper_triangular_solve(Y)) == ImmutableMatrix
+
+    assert type(X.minorMatrix(0,0)) == ImmutableMatrix

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -16,3 +16,7 @@ def test_immutability():
 def test_slicing():
     IM[1,:] == ImmutableMatrix([[4,5,6]])
     IM[:2, :2] == ImmutableMatrix([[1,2],[4,5]])
+
+def test_as_immutable():
+    X = Matrix([[1,2], [3,4]])
+    assert X.as_immutable() == ImmutableMatrix([[1,2],[3,4]])

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,0 +1,18 @@
+from sympy import *
+from sympy.utilities.pytest import raises, XFAIL
+
+IM = ImmutableMatrix([[1,2,3], [4,5,6], [7,8,9]])
+ieye = ImmutableMatrix(eye(3))
+
+def test_immutable_creation():
+
+    assert IM.shape == (3,3)
+    assert IM[1,2] == 6
+    assert IM[2,2] == 9
+
+def test_immutability():
+    raises(TypeError, "IM[2,2] = 5")
+
+def test_slicing():
+    IM[1,:] == ImmutableMatrix([[4,5,6]])
+    IM[:2, :2] == ImmutableMatrix([[1,2],[4,5]])

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -1,0 +1,46 @@
+"""
+We have a few different kind of Matrices
+MutableMatrix, ImmutableMatrix, MatrixExpr
+
+Here we test the extent to which they cooperate
+"""
+
+from sympy import *
+from sympy.matrices.matrices import MutableMatrix
+from sympy.utilities.pytest import raises, XFAIL
+
+
+
+SM = MatrixSymbol('X', 3, 3)
+MM = Matrix([[1,2,3], [4,5,6], [7,8,9]])
+IM = ImmutableMatrix([[1,2,3], [4,5,6], [7,8,9]])
+meye = eye(3)
+imeye = ImmutableMatrix(eye(3))
+ideye = Identity(3)
+a,b,c = symbols('a,b,c')
+
+def test_IM_MM():
+    assert (MM+IM).__class__ is MutableMatrix
+    assert (2*IM + MM).__class__ is MutableMatrix
+    assert MM.equals(IM)
+
+def test_ME_MM():
+    assert (Identity(3) + MM).__class__ is MutableMatrix
+    assert (Identity(3) + MM)[1,1] == 6
+
+def test_equality():
+    a,b,c = Identity(3), eye(3), ImmutableMatrix(eye(3))
+    for x in [a,b,c]:
+        for y in [a,b,c]:
+            assert x.equals(y)
+
+def test_matrix_symbol_MM():
+    X = MatrixSymbol('X', 3,3)
+    Y = eye(3) + X
+    assert Y[1,1] == 1 + Symbol('X')(1,1)
+
+def test_indexing_interactions():
+    assert (a * IM)[1,1] == 5*a
+    assert (SM + IM)[1,1] == SM[1,1] + IM[1,1]
+    assert (SM * IM)[1,1] == SM[1,0]*IM[0,1] + SM[1,1]*IM[1,1] + SM[1,2]*IM[2,1]
+

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -21,11 +21,14 @@ a,b,c = symbols('a,b,c')
 
 def test_IM_MM():
     assert (MM+IM).__class__ is MutableMatrix
+    assert (IM+MM).__class__ is MutableMatrix
     assert (2*IM + MM).__class__ is MutableMatrix
     assert MM.equals(IM)
 
 def test_ME_MM():
     assert (Identity(3) + MM).__class__ is MutableMatrix
+    assert (SM + MM).__class__ is MutableMatrix
+    assert (MM + SM).__class__ is MutableMatrix
     assert (Identity(3) + MM)[1,1] == 6
 
 def test_equality():

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -5,7 +5,9 @@ MutableMatrix, ImmutableMatrix, MatrixExpr
 Here we test the extent to which they cooperate
 """
 
-from sympy import *
+from sympy import symbols
+from sympy.matrices import (Matrix, MatrixSymbol, eye, Identity,
+        ImmutableMatrix)
 from sympy.matrices.matrices import MutableMatrix, classof
 from sympy.utilities.pytest import raises, XFAIL
 

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -6,7 +6,7 @@ Here we test the extent to which they cooperate
 """
 
 from sympy import *
-from sympy.matrices.matrices import MutableMatrix
+from sympy.matrices.matrices import MutableMatrix, classof
 from sympy.utilities.pytest import raises, XFAIL
 
 
@@ -40,10 +40,19 @@ def test_equality():
 def test_matrix_symbol_MM():
     X = MatrixSymbol('X', 3,3)
     Y = eye(3) + X
-    assert Y[1,1] == 1 + Symbol('X')(1,1)
+    assert Y[1,1] == 1 + X[1,1]
 
 def test_indexing_interactions():
     assert (a * IM)[1,1] == 5*a
     assert (SM + IM)[1,1] == SM[1,1] + IM[1,1]
     assert (SM * IM)[1,1] == SM[1,0]*IM[0,1] + SM[1,1]*IM[1,1] + SM[1,2]*IM[2,1]
+
+def test_classof():
+    A = MutableMatrix(3,3,range(9))
+    B = ImmutableMatrix(3,3,range(9))
+    C = MatrixSymbol('C', 3,3)
+    assert classof(A,A) == MutableMatrix
+    assert classof(B,B) == ImmutableMatrix
+    assert classof(A,B) == MutableMatrix
+    raises(TypeError, "classof(A,C)")
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2097,3 +2097,6 @@ def test_issue_2865() :
 def test_DeferredVector():
     assert sympify(DeferredVector("d")) == DeferredVector("d")
 
+def test_is_Identity():
+    assert eye(3).is_Identity
+    assert not ones(3).is_Identity

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -6,6 +6,7 @@ from sympy.matrices.matrices import (ShapeError, MatrixError,
     matrix_multiply_elementwise, diag, GramSchmidt, casoratian,
     SparseMatrix, SparseMatrix, NonSquareMatrixError,
     matrix_multiply_elementwise, diag, NonSquareMatrixError, DeferredVector)
+from sympy.matrices import ImmutableMatrix
 from sympy.utilities.iterables import flatten, capture
 from sympy.utilities.pytest import raises, XFAIL
 from sympy.matrices import rot_axis1, rot_axis2, rot_axis3
@@ -126,6 +127,9 @@ def test_creation():
     assert c.cols == 3
     assert c.rows == 3
     assert c[:] == [1,2,3,4,5,6,7,8,9]
+
+    assert Matrix(c) == c
+    assert ImmutableMatrix(c) == c.as_immutable()
 
 def test_tolist():
     x, y, z = symbols('x y z')

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -128,8 +128,10 @@ def test_creation():
     assert c.rows == 3
     assert c[:] == [1,2,3,4,5,6,7,8,9]
 
-    assert Matrix(c) == c
+    assert Matrix(eye(2)) == eye(2)
+    assert ImmutableMatrix(ImmutableMatrix(eye(2))) == ImmutableMatrix(eye(2))
     assert ImmutableMatrix(c) == c.as_immutable()
+    assert Matrix(ImmutableMatrix(c)) == ImmutableMatrix(c).as_mutable()
 
 def test_tolist():
     x, y, z = symbols('x y z')
@@ -1688,6 +1690,8 @@ def test_errors():
     raises(NotImplementedError, "Matrix([[1, 0],[1, 1]])**(S(1)/2)")
     raises(NotImplementedError,
         "Matrix([[1, 2, 3],[4, 5, 6],[7,  8, 9]])**(0.5)")
+    raises(IndexError, "eye(3)[5,2]")
+    raises(IndexError, "eye(3)[2,5]")
 
 def test_len():
     assert len(Matrix()) == 0
@@ -2106,3 +2110,8 @@ def test_is_Identity():
     assert eye(3).as_immutable().is_Identity
     assert not zeros(3).is_Identity
     assert not ones(3).is_Identity
+
+def test_dot():
+    assert ones(1,3).dot(ones(3,1)) == 3
+    assert ones(1,3).dot([1,1,1]) == 3
+

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2099,4 +2099,6 @@ def test_DeferredVector():
 
 def test_is_Identity():
     assert eye(3).is_Identity
+    assert eye(3).as_immutable().is_Identity
+    assert not zeros(3).is_Identity
     assert not ones(3).is_Identity

--- a/sympy/physics/gaussopt.py
+++ b/sympy/physics/gaussopt.py
@@ -74,7 +74,8 @@ class RayTransferMatrix(Matrix):
     [1] http://en.wikipedia.org/wiki/Ray_transfer_matrix_analysis
     """
 
-    def __init__(self, *args):
+    def __new__(cls, *args):
+
         if len(args) == 4:
             temp = ((args[0], args[1]), (args[2], args[3]))
         elif len(args) == 1 \
@@ -85,7 +86,7 @@ class RayTransferMatrix(Matrix):
             raise ValueError(filldedent('''
                 Expecting 2x2 Matrix or the 4 elements of
                 the Matrix but got %s''' % str(args)))
-        Matrix.__init__(self, temp)
+        return Matrix.__new__(cls, temp)
 
     def __mul__(self, other):
         if isinstance(other, RayTransferMatrix):
@@ -185,8 +186,8 @@ class FreeSpace(RayTransferMatrix):
     [1, d]
     [0, 1]
     """
-    def __init__(self, d):
-        RayTransferMatrix.__init__(self, 1, d, 0, 1)
+    def __new__(cls, d):
+        return RayTransferMatrix.__new__(cls, 1, d, 0, 1)
 
 class FlatRefraction(RayTransferMatrix):
     """
@@ -213,9 +214,9 @@ class FlatRefraction(RayTransferMatrix):
     [1,     0]
     [0, n1/n2]
     """
-    def __init__(self, n1, n2):
+    def __new__(cls, n1, n2):
         n1, n2 = sympify((n1, n2))
-        RayTransferMatrix.__init__(self, 1, 0, 0, n1/n2)
+        return RayTransferMatrix.__new__(cls, 1, 0, 0, n1/n2)
 
 class CurvedRefraction(RayTransferMatrix):
     """
@@ -243,9 +244,9 @@ class CurvedRefraction(RayTransferMatrix):
     [               1,     0]
     [(n1 - n2)/(R*n2), n1/n2]
     """
-    def __init__(self, R, n1, n2):
+    def __new__(cls, R, n1, n2):
         R, n1 , n2 = sympify((R, n1, n2))
-        RayTransferMatrix.__init__(self, 1, 0, (n1-n2)/R/n2, n1/n2)
+        return RayTransferMatrix.__new__(cls, 1, 0, (n1-n2)/R/n2, n1/n2)
 
 class FlatMirror(RayTransferMatrix):
     """
@@ -261,8 +262,8 @@ class FlatMirror(RayTransferMatrix):
     [1, 0]
     [0, 1]
     """
-    def __init__(self):
-        RayTransferMatrix.__init__(self, 1, 0, 0, 1)
+    def __new__(cls):
+        return RayTransferMatrix.__new__(cls, 1, 0, 0, 1)
 
 class CurvedMirror(RayTransferMatrix):
     """
@@ -288,9 +289,9 @@ class CurvedMirror(RayTransferMatrix):
     [   1, 0]
     [-2/R, 1]
     """
-    def __init__(self, R):
+    def __new__(cls, R):
         R = sympify(R)
-        RayTransferMatrix.__init__(self, 1, 0, -2/R, 1)
+        return RayTransferMatrix.__new__(cls, 1, 0, -2/R, 1)
 
 class ThinLens(RayTransferMatrix):
     """
@@ -316,9 +317,9 @@ class ThinLens(RayTransferMatrix):
     [   1, 0]
     [-1/f, 1]
     """
-    def __init__(self, f):
+    def __new__(cls, f):
         f = sympify(f)
-        RayTransferMatrix.__init__(self, 1, 0, -1/f, 1)
+        return RayTransferMatrix.__new__(cls, 1, 0, -1/f, 1)
 
 
 ###
@@ -360,7 +361,7 @@ class GeometricRay(Matrix):
 
     """
 
-    def __init__(self, *args):
+    def __new__(cls, *args):
         if len(args) == 1 and isinstance(args[0], Matrix) \
                           and args[0].shape == (2, 1):
             temp = args[0]
@@ -370,7 +371,7 @@ class GeometricRay(Matrix):
             raise ValueError(filldedent('''
                 Expecting 2x1 Matrix or the 2 elements of
                 the Matrix but got %s''' % str(args)))
-        Matrix.__init__(self, temp)
+        return Matrix.__new__(cls, temp)
 
     @property
     def height(self):

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -29,6 +29,8 @@ from sympy.physics.quantum.operator import (UnitaryOperator, Operator,
 from sympy.physics.quantum.matrixutils import matrix_tensor_product, matrix_eye
 from sympy.physics.quantum.matrixcache import matrix_cache
 
+from sympy.matrices.matrices import MatrixBase
+
 __all__ = [
     'Gate',
     'CGate',
@@ -124,7 +126,7 @@ class Gate(UnitaryOperator):
 
     @classmethod
     def _eval_args(cls, args):
-        args = UnitaryOperator._eval_args(args)
+        args = Tuple(*UnitaryOperator._eval_args(args))
         _validate_targets_controls(args)
         return args
 
@@ -444,7 +446,7 @@ class UGate(Gate):
         targets = Gate._eval_args(targets)
         _validate_targets_controls(targets)
         mat = args[1]
-        if not isinstance(mat, Matrix):
+        if not isinstance(mat, MatrixBase):
             raise TypeError('Matrix expected, got: %r' % mat)
         dim = 2**len(targets)
         if not all(dim == shape for shape in mat.shape):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -871,7 +871,7 @@ class LatexPrinter(Printer):
         tex = r"\begin{cases} %s \end{cases}"
         return tex % r" \\".join(ecpairs)
 
-    def _print_Matrix(self, expr):
+    def _print_MatrixBase(self, expr):
         lines = []
 
         for line in range(expr.rows): # horrible, should be 'rows'

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -886,6 +886,7 @@ class LatexPrinter(Printer):
                       r'\right' + right_delim
         return out_str % r"\\".join(lines)
     _print_ImmutableMatrix = _print_MatrixBase
+    _print_MutableMatrix = _print_MatrixBase
 
     def _print_BlockMatrix(self, expr):
         return self._print(expr.mat)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -885,6 +885,7 @@ class LatexPrinter(Printer):
             out_str = r'\left' + left_delim + out_str + \
                       r'\right' + right_delim
         return out_str % r"\\".join(lines)
+    _print_ImmutableMatrix = _print_MatrixBase
 
     def _print_BlockMatrix(self, expr):
         return self._print(expr.mat)

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -137,7 +137,7 @@ class MathMLPrinter(Printer):
             x.appendChild(plusNodes.pop(0))
         return x
 
-    def _print_Matrix(self, m):
+    def _print_MatrixBase(self, m):
         x = self.dom.createElement('matrix')
         for i in range(m.lines):
             x_r = self.dom.createElement('matrixrow')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -528,9 +528,9 @@ class PrettyPrinter(Printer):
     #
     # see _MatrixAsBasic docstring, and #420
     def _print__MatrixAsBasic(self, e):
-        return self._print_Matrix(e.m)
+        return self._print_MatrixBase(e.m)
 
-    def _print_Matrix(self, e):
+    def _print_MatrixBase(self, e):
         M = e   # matrix
         Ms = {}  # i,j -> pretty(M[i,j])
         for i in range(M.rows):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -598,6 +598,7 @@ class PrettyPrinter(Printer):
         D = prettyForm(*D.parens('[',']'))
         return D
     _print_ImmutableMatrix = _print_MatrixBase
+    _print_MutableMatrix = _print_MatrixBase
 
     def _print_Transpose(self, T):
         pform = self._print(T.arg)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -520,16 +520,6 @@ class PrettyPrinter(Printer):
 
         return Lim
 
-    # Matrix is special:
-    #
-    # it can exist in SymPy in two forms:
-    # - as Matrix
-    # - as _MatrixAsBasic
-    #
-    # see _MatrixAsBasic docstring, and #420
-    def _print__MatrixAsBasic(self, e):
-        return self._print_MatrixBase(e.m)
-
     def _print_MatrixBase(self, e):
         M = e   # matrix
         Ms = {}  # i,j -> pretty(M[i,j])

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -597,6 +597,7 @@ class PrettyPrinter(Printer):
 
         D = prettyForm(*D.parens('[',']'))
         return D
+    _print_ImmutableMatrix = _print_MatrixBase
 
     def _print_Transpose(self, T):
         pform = self._print(T.arg)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -75,7 +75,7 @@ class ReprPrinter(Printer):
     def _print_list(self, expr):
         return "[%s]" % self.reprify(expr, ", ")
 
-    def _print_Matrix(self, expr):
+    def _print_MatrixBase(self, expr):
         l = []
         for i in range(expr.rows):
             l.append([])

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -203,6 +203,7 @@ class StrPrinter(Printer):
     def _print_MatrixBase(self, expr):
         return expr._format_str(lambda elem: self._print(elem))
     _print_ImmutableMatrix = _print_MatrixBase
+    _print_MutableMatrix = _print_MatrixBase
 
     def _print_DeferredVector(self, expr):
         return expr.name

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -202,6 +202,7 @@ class StrPrinter(Printer):
 
     def _print_MatrixBase(self, expr):
         return expr._format_str(lambda elem: self._print(elem))
+    _print_ImmutableMatrix = _print_MatrixBase
 
     def _print_DeferredVector(self, expr):
         return expr.name

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -200,7 +200,7 @@ class StrPrinter(Printer):
     def _print_list(self, expr):
         return "[%s]"%self.stringify(expr, ", ")
 
-    def _print_Matrix(self, expr):
+    def _print_MatrixBase(self, expr):
         return expr._format_str(lambda elem: self._print(elem))
 
     def _print_DeferredVector(self, expr):

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import raises
 from sympy import Symbol, symbols, Function, Integer, Matrix, nan, oo, Abs, \
-    Rational, Float, S, WildFunction
+    Rational, Float, S, WildFunction, ImmutableMatrix
 from sympy.geometry import Point, Circle, Ellipse
 from sympy.printing import srepr
 
@@ -65,11 +65,14 @@ def test_list():
     sT([x, Integer(4)], "[Symbol('x'), Integer(4)]")
 
 def test_Matrix():
-    sT(Matrix([[x**+1, 1], [y, x+y]]),
-       "Matrix([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])")
-    sT(Matrix(), "Matrix([])")
+    for cls in [Matrix, ImmutableMatrix]:
+        name = cls.__name__
+        sT(cls([[x**+1, 1], [y, x+y]]),
+           "%s([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])"%name)
 
-    sT(Matrix([[x**+1, 1], [y, x+y]]), "Matrix([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])")
+        sT(cls(), "%s([])"%name)
+
+        sT(cls([[x**+1, 1], [y, x+y]]), "%s([[Symbol('x'), Integer(1)], [Symbol('y'), Add(Symbol('x'), Symbol('y'))]])"%name)
 
 def test_Rational():
     sT(Rational(1,3), "Rational(1, 3)")


### PR DESCRIPTION
This pull request adds an ImmutableMatrix type that inherits from Basic. 

It does this by splitting the current Matrix class into a MatrixBase and an inherited MutableMatrix I.e. we have

MatrixBase:
    MutableMatrix (the old matrix, still aliased to Matrix)
    ImmutableMatrix (this is a Basic that acts like Matrix except for mutability

This pull also includes some additional work in making MatrixExpr's interact nicely with explicitly defined matrices (I.e. MatrixBase objects ). This was related so I merged the two branches. 

Issue: http://code.google.com/p/sympy/issues/detail?id=3021
E-mail Thread: https://groups.google.com/group/sympy/browse_thread/thread/f9882fa106ac9726

Some particular questions/issues

Mutability is contagious. That is whenever a MutableMatrix interacts with any other type of matrix the other type gets turned into a MutableMatrix. This could go the other way around MutableMatrix -> ImmutableMatrix or it could raise an error. 

I would like to have sympify(MutableMatrix) -> ImmutableMatrix but this destroys MutableMatrix's ability to interact with SymPy scalars. I.e. x \* eye(3) becomes a MatMul object rather than MutableMatrix([[x,0,0],[0,x,0],[0,0,x]]). 

I've made ImmutableMatrix an Expr object rather than just a Basic. If folks wanted to take this one step at a time I could split apart the pull requests. 

This work overlaps somewhat with Sherjil's work from the Summer. I assume that progressing down this path makes it less easy to pick up his work. 
