### PR TITLE
Fix syntax for Python 2.5

### DIFF
--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -125,7 +125,9 @@ def import_module(module, min_module_version=None, min_python_version=None,
         if warn_not_installed:
             warnings.warn("%s module is not installed" % module, UserWarning)
         return
-    except catch as e:
+    # TODO: After 2.5 is dropped, use new 'as' keyword
+    #except catch as e:
+    except catch, e:
         if warn_not_installed:
             warnings.warn("%s module could not be used (%s)" % (module, repr(e)))
         return


### PR DESCRIPTION
The 'as' keyword is not implemented in Python 2.5, this commit fixes the use of this keyword in importing external modules, which was causing an error in running tests with 2.5.
