### PR TITLE
relax is_real constraint on Eq test

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -545,6 +545,7 @@ class Basic(PicklableWithSlots):
            set([I*pi, 2*sin(y + I*pi)])
 
         """
+        from sympy.core.function import UndefinedFunction, Function
 
         def _atoms(expr, typ):
             """Helper function for recursively denesting atoms"""
@@ -578,6 +579,19 @@ class Basic(PicklableWithSlots):
 
             return result
 
+        # UndefinedFunction is a subset of Function, so it
+        # need not be present if Function is present, otherwise
+        # to find it you need to filter Functions
+        if UndefinedFunction in types:
+            types = list(types)
+            types.remove(UndefinedFunction)
+            if Function not in types:
+                u = set(f for f in _atoms(self, typ=[Function]) if
+                        isinstance(f.func, UndefinedFunction))
+                if types:
+                    return u | _atoms(self, typ=types)
+                else:
+                    return u
         return _atoms(self, typ=types)
 
     @property

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -3,7 +3,7 @@ from math import log as _log
 from sympify import _sympify
 from cache import cacheit
 from core import C
-from sympy.core.function import _coeff_isneg
+from sympy.core.function import _coeff_isneg, expand_complex
 from singleton import S
 from expr import Expr
 
@@ -269,7 +269,15 @@ class Pow(Expr):
 
     def _eval_conjugate(self):
         from sympy.functions.elementary.complexes import conjugate as c
-        return c(self.base)**self.exp
+        i, p = self.exp.is_integer, self.base.is_positive
+        if i:
+            return c(self.base)**self.exp
+        if p:
+            return self.base**c(self.exp)
+        if i is False and p is False:
+            expanded = expand_complex(self)
+            if expanded != self:
+                return c(expanded)
 
     def _eval_expand_basic(self, deep=True, **hints):
         sargs, terms = self.args, []

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -142,13 +142,13 @@ class Relational(Expr, EvalfMixin):
             except KeyError:
                 msg = "Invalid relational operator symbol: '%r'"
                 raise ValueError(msg % repr(rop))
-        if lhs.is_number and rhs.is_number and lhs.is_real and rhs.is_real:
-            # Just becase something is a number, doesn't mean you can evalf it.
-            Nlhs = lhs.evalf()
-            if Nlhs.is_Number:
-                # S.Zero.evalf() returns S.Zero, so test Number instead of Float
-                Nrhs = rhs.evalf()
-                if Nrhs.is_Number:
+        if lhs.is_number and rhs.is_number and (rop in ('==', '!=' ) or
+        lhs.is_real and rhs.is_real):
+            # Just because something is a number, doesn't mean you can evalf it.
+            Nlhs = lhs.evalf() if not lhs.is_Atom else lhs
+            if Nlhs.is_Atom:
+                Nrhs = rhs.evalf() if not rhs.is_Atom else rhs
+                if Nrhs.is_Atom:
                     return rop_cls._eval_relation(Nlhs, Nrhs)
 
         obj = Expr.__new__(rop_cls, lhs, rhs, **assumptions)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -164,6 +164,14 @@ def test_pow3():
     assert sqrt(2)**3 == 2 * sqrt(2)
     assert sqrt(2)**3 == sqrt(8)
 
+def test_pow_issue_1724():
+    e = ((-1)**(S(1)/3))
+    assert e.conjugate().n() == e.n().conjugate()
+    e = S('-2/3 - (-29/54 + sqrt(93)/18)**(1/3) - 1/(9*(-29/54 + sqrt(93)/18)**(1/3))')
+    assert e.conjugate().n() == e.n().conjugate()
+    e = 2**I
+    assert e.conjugate().n() == e.n().conjugate()
+
 def test_expand():
     p = Rational(5)
     e = (a+b)*c

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,6 +6,7 @@ from sympy import (Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I,
     Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp, simplify, together,
     separate, collect, factorial, apart, combsimp, factor, refine, cancel,
     Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum)
+from sympy.core.function import UndefinedFunction
 from sympy.abc import a, b, c, d, e, n, t, u, x, y, z
 from sympy.physics.secondquant import FockState
 
@@ -242,6 +243,20 @@ def test_atoms():
                                                    [1 + x*(2 + y)+exp(3 + z),
                                                     2 + y,
                                                     3 + z])
+
+    # issue 3033
+    f = Function('f')
+    e = (f(x) + sin(x) + 2)
+    assert e.atoms(UndefinedFunction) == \
+        set([f(x)])
+    assert e.atoms(UndefinedFunction, Function) == \
+        set([f(x), sin(x)])
+    assert e.atoms(Function) == \
+        set([f(x), sin(x)])
+    assert e.atoms(UndefinedFunction, Number) == \
+        set([f(x), S(2)])
+    assert e.atoms(Function, Number) == \
+        set([S(2), sin(x), f(x)])
 
 def test_is_polynomial():
     k = Symbol('k', nonnegative=True, integer=True)

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,5 +1,5 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import Symbol, symbols, oo
+from sympy import Symbol, symbols, oo, I
 from sympy.core.relational import ( Relational, Equality, Unequality,
     GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le,
     Gt, Ge, Ne )
@@ -120,6 +120,12 @@ def test_bool():
     assert Ge(1,0) is True
     assert Ge(0,1) is False
     assert Ge(1,1) is True
+    assert Eq(I, 2) is False
+    assert Ne(I, 2) is True
+    assert Gt(I, 2) not in [True, False]
+    assert Ge(I, 2) not in [True, False]
+    assert Lt(I, 2) not in [True, False]
+    assert Le(I, 2) not in [True, False]
 
 def test_rich_cmp():
     assert (x<y) == Lt(x,y)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -723,3 +723,8 @@ def test_issue1388():
 def test_issue_1116() :
     x = Symbol("x")
     assert integrate(1/(x**2), (x, -1, 1)) == oo
+
+def test_issue_1301():
+    assert integrate((x**n)*log(x), x) == \
+    n*x*x**n*log(x)/(n**2 + 2*n + 1) + x*x**n*log(x)/(n**2 + 2*n + 1) - \
+    x*x**n/(n**2 + 2*n + 1)

--- a/sympy/physics/quantum/state.py
+++ b/sympy/physics/quantum/state.py
@@ -621,7 +621,7 @@ class Wavefunction(Function):
     >>> from sympy import symbols, pi, diff
     >>> from sympy.functions import sqrt, sin
     >>> from sympy.physics.quantum.state import Wavefunction
-    >>> x, L = symbols('x,L', real=True)
+    >>> x, L = symbols('x,L', positive=True)
     >>> n = symbols('n', integer=True)
     >>> g = sqrt(2/L)*sin(n*pi*x/L)
     >>> f = Wavefunction(g, (x, 0, L))
@@ -630,11 +630,11 @@ class Wavefunction(Function):
     >>> f(L+1)
     0
     >>> f(L-1)
-    sqrt(2)*sqrt(1/L)*sin(pi*n*(L - 1)/L)
+    sqrt(2)*sin(pi*n*(L - 1)/L)/sqrt(L)
     >>> f(-1)
     0
     >>> f(0.85)
-    sqrt(2)*sqrt(1/L)*sin(0.85*pi*n/L)
+    sqrt(2)*sin(0.85*pi*n/L)/sqrt(L)
     >>> f(0.85, n=1, L=1)
     sqrt(2)*sin(0.85*pi)
     >>> f.is_commutative
@@ -809,7 +809,7 @@ class Wavefunction(Function):
         >>> from sympy import symbols, pi
         >>> from sympy.functions import sqrt, sin
         >>> from sympy.physics.quantum.state import Wavefunction
-        >>> x, L = symbols('x,L', real=True)
+        >>> x, L = symbols('x,L', positive=True)
         >>> n = symbols('n', integer=True)
         >>> g = sqrt(2/L)*sin(n*pi*x/L)
         >>> f = Wavefunction(g, (x, 0, L))
@@ -835,7 +835,7 @@ class Wavefunction(Function):
         >>> from sympy import symbols, pi
         >>> from sympy.functions import sqrt, sin
         >>> from sympy.physics.quantum.state import Wavefunction
-        >>> x, L = symbols('x,L', real=True)
+        >>> x, L = symbols('x,L', positive=True)
         >>> n = symbols('n', integer=True)
         >>> g = sqrt(2/L)*sin(n*pi*x/L)
         >>> f = Wavefunction(g, (x, 0, L))


### PR DESCRIPTION
Allow Eq(I, 2)-like expressions to return bool just like Eq(1, 2) returns False.

A test is also added for an issue and a small fix for issue 1724 included.
