### PR TITLE
_int_ methods upgraded; round takes care of last digit better

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -161,8 +161,8 @@ class Expr(Basic, EvalfMixin):
         # if it appears to be an integer still we will warn that we aren't
         # sure if this is really an integer or not
         if i and i == f and not self.is_integer:
-            from sympy.solvers.solvers import _filldedent
-            raise ValueError(_filldedent('''
+            from sympy.utilities.misc import filldedent
+            raise ValueError(filldedent('''
             %s was calculated to 15 decimal digits and appeared to be
             %s; it was not confirmed to be an integer, however.
             Use round() to round your expression to the desired number
@@ -2132,8 +2132,8 @@ class Expr(Basic, EvalfMixin):
         never call this method directly (use .nseries() instead), so you don't
         have to write docstrings for _eval_nseries().
         """
-        from sympy.solvers.solvers import _filldedent
-        raise NotImplementedError(_filldedent("""
+        from sympy.utilities.misc import filldedent
+        raise NotImplementedError(filldedent("""
                      The _eval_nseries method should be added to
                      %s to give terms up to O(x**n) at x=0
                      from the positive direction so it is available when

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -177,7 +177,9 @@ class Expr(Basic, EvalfMixin):
         result = self.evalf()
         if result.is_Number:
             return float(result)
-        raise TypeError("%s should be a literal number." % self)
+        if result.is_number and result.as_real_imag()[1]:
+            raise TypeError("can't convert complex to float")
+        raise TypeError("can't convert expression to float")
 
     def __complex__(self):
         result = self.evalf()

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -381,8 +381,8 @@ class Function(Application, Expr):
         be called directly; derived classes can overwrite this to implement
         asymptotic expansions.
         """
-        from sympy.solvers.solvers import _filldedent
-        raise PoleError(_filldedent('''
+        from sympy.utilities.misc import filldedent
+        raise PoleError(filldedent('''
             Asymptotic expansion of %s around %s is
             not implemented.''' % (type(self), args0)))
 
@@ -409,8 +409,8 @@ class Function(Application, Expr):
 
         """
         if self.func.nargs is None:
-            from sympy.solvers.solvers import _filldedent
-            raise NotImplementedError(_filldedent('''
+            from sympy.utilities.misc import filldedent
+            raise NotImplementedError(filldedent('''
                 series for user-defined functions are not
                 supported.'''))
         args = self.args
@@ -874,8 +874,8 @@ class Derivative(Expr):
         if not variables:
             variables = expr.free_symbols
             if len(variables) != 1:
-                from sympy.solvers.solvers import _filldedent
-                raise ValueError(_filldedent('''
+                from sympy.utilities.misc import filldedent
+                raise ValueError(filldedent('''
                     Since there is more than one variable in the
                     expression, the variable(s) of differentiation
                     must be supplied to differentiate %s''' % expr))
@@ -907,8 +907,8 @@ class Derivative(Expr):
                     i += 1
 
             if i == iwas: # didn't get an update because of bad input
-                from sympy.solvers.solvers import _filldedent
-                raise ValueError(_filldedent('''
+                from sympy.utilities.misc import filldedent
+                raise ValueError(filldedent('''
                 Can\'t differentiate wrt the variable: %s, %s''' % (v, count)))
 
             variable_count.append((v, count))
@@ -1231,8 +1231,8 @@ class Lambda(Expr):
 
     def __call__(self, *args):
         if len(args) != self.nargs:
-            from sympy.solvers.solvers import _filldedent
-            raise TypeError(_filldedent('''
+            from sympy.utilities.misc import filldedent
+            raise TypeError(filldedent('''
                 %s takes %d arguments (%d given)
                 ''' % (self, self.nargs, len(args))))
         return self.expr.xreplace(dict(zip(self.variables, args)))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,8 +1,8 @@
 from __future__ import division
 
 from sympy import Symbol, sin, cos, exp, O, sqrt, Rational, Float, re, pi, \
-        sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo
-from sympy.utilities.pytest import XFAIL
+        sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo, Integer
+from sympy.utilities.pytest import XFAIL, raises
 
 x = Symbol('x')
 y = Symbol('y')
@@ -1312,3 +1312,22 @@ def test_issue_2061_2988_2990_2991():
     assert sqrt(-1.0*x) == 1.0*sqrt(-x)
     #2991
     assert (-2*x*y*A*B)**2 == 4*x**2*y**2*(A*B)**2
+
+def test_float_int():
+    assert int(float(sqrt(10))) == int(sqrt(10))
+    assert int(pi**1000) % 10 == 2
+    assert int(Float('1.123456789012345678901234567890e20','')) == \
+        112345678901234567890L
+    assert int(Float('1.123456789012345678901234567890e25','')) == \
+        11234567890123456789012345L
+    assert int(Float('1.123456789012345678901234567890e35','')) == \
+        112345678901234567890123456789000000L
+    assert Integer(Float('1.123456789012345678901234567890e20','')) == \
+        112345678901234567890
+    assert Integer(Float('1.123456789012345678901234567890e25','')) == \
+        11234567890123456789012345
+    assert Integer(Float('1.123456789012345678901234567890e35','')) == \
+        112345678901234567890123456789000000
+    assert int(1 + Rational('.9999999999999999999999999')) == 1
+    assert int(pi/1e20) == 0
+    raises(ValueError, 'int(1 + pi/1e20)')

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1331,3 +1331,5 @@ def test_float_int():
     assert int(1 + Rational('.9999999999999999999999999')) == 1
     assert int(pi/1e20) == 0
     raises(ValueError, 'int(1 + pi/1e20)')
+    raises(TypeError, 'float(x)')
+    raises(TypeError, 'float(sqrt(-1))')

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -195,8 +195,7 @@ def test_evalf_py_methods():
     assert abs(float(pi+1) - 4.1415926535897932) < 1e-10
     assert abs(complex(pi+1) - 4.1415926535897932) < 1e-10
     assert abs(complex(pi+E*I) - (3.1415926535897931+2.7182818284590451j)) < 1e-10
-    raises(ValueError, "float(pi+x)")
-    raises(ValueError, "complex(pi+x)")
+    raises(TypeError, "float(pi+x)")
 
 def test_evalf_power_subs_bugs():
     assert (x**2).evalf(subs={x:0}) == 0

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -89,6 +89,10 @@ def test_divmod():
     assert divmod(S(12), 8) == Tuple(1, 4)
     assert divmod(12, S(8)) == Tuple(1, 4)
 
+@XFAIL
+def test_divmod_rational():
+    assert divmod(S('3/2'), 2) == Tuple(0, S('3/2'))
+
 def test_igcd():
     assert igcd(0, 0) == 0
     assert igcd(0, 1) == 1
@@ -156,6 +160,7 @@ def test_Integer_new():
     _test_rational_new(Integer)
 
     raises(ValueError, 'Integer("10.5")')
+    assert Integer(Rational('1.'+'9'*20)) == 1
 
 def test_Rational_new():
     """"
@@ -1099,3 +1104,7 @@ def test_Float_eq():
     assert Float(.12, 3) == .12
     assert 0.12 == Float(.12, 3)
     assert Float('.12', 22) != .12
+
+def test_int_NumberSymbols():
+    assert [int(i) for i in [pi, EulerGamma, E, GoldenRatio, Catalan]] == \
+        [3, 0, 2, 1, 0]

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -3,7 +3,7 @@ from sympy.core.numbers import Rational
 from sympy.utilities.pytest import raises
 _pyround = round
 from sympy.functions.elementary.miscellaneous import sqrt, root, Min, Max, real_root, round
-from sympy import S, Float, I, cos, sin, oo, pi
+from sympy import S, Float, I, cos, sin, oo, pi, Add
 
 def test_Min():
     from sympy.abc import x, y, z
@@ -199,7 +199,7 @@ def test_round():
 
     assert round(pi + sqrt(2), 2) == 4.56
     assert round(10*(pi + sqrt(2)), -1) == 50
-    assert round(x + 2, 2) == x + 2
+    raises(TypeError, 'round(x + 2, 2)')
     assert round(S(2.3), 1) == 2.3
     e = round(12.345, 2)
     assert e == _pyround(12.345, 2)
@@ -209,3 +209,12 @@ def test_round():
     assert round(Float(.3, 3) + 2*pi*100) == 629
     assert round(Float(.03, 3) + 2*pi/100, 5) == 0.09283
     assert round(Float(.03, 3) + 2*pi/100, 4) == 0.0928
+
+    assert round(S.Zero) == 0
+
+    a = (Add(1, Float('1.'+'9'*27, ''), evaluate=0))
+    assert round(a, 10) == Float('3.0000000000','')
+    assert round(a, 25) == Float('3.0000000000000000000000000','')
+    assert round(a, 26) == Float('3.00000000000000000000000000','')
+    assert round(a, 27) == Float('2.999999999999999999999999999','')
+    assert round(a, 30) == Float('2.999999999999999999999999999','')

--- a/sympy/physics/gaussopt.py
+++ b/sympy/physics/gaussopt.py
@@ -16,7 +16,7 @@ The conventions for the distances are as follows:
 
 from sympy import (atan2, Expr, I, im, Matrix, oo, pi, re, sqrt, sympify,
     together)
-from sympy.solvers.solvers import _filldedent
+from sympy.utilities.misc import filldedent
 
 ###
 # A, B, C, D matrices
@@ -82,7 +82,7 @@ class RayTransferMatrix(Matrix):
              and args[0].shape == (2, 2):
             temp = args[0]
         else:
-            raise ValueError(_filldedent('''
+            raise ValueError(filldedent('''
                 Expecting 2x2 Matrix or the 4 elements of
                 the Matrix but got %s''' % str(args)))
         Matrix.__init__(self, temp)
@@ -367,7 +367,7 @@ class GeometricRay(Matrix):
         elif len(args) == 2:
             temp = ((args[0],), (args[1],))
         else:
-            raise ValueError(_filldedent('''
+            raise ValueError(filldedent('''
                 Expecting 2x1 Matrix or the 2 elements of
                 the Matrix but got %s''' % str(args)))
         Matrix.__init__(self, temp)
@@ -779,17 +779,17 @@ def conjugate_gauss_beams(wavelen, waist_in, waist_out, **kwargs):
     if len(kwargs) != 1:
         raise ValueError("The function expects only one named argument")
     elif 'dist' in kwargs:
-        raise NotImplementedError(_filldedent('''
+        raise NotImplementedError(filldedent('''
             Currently only focal length is supported as a parameter'''))
     elif 'f' in kwargs:
         f = sympify(kwargs['f'])
         s_in = f * (1 - sqrt(1/m**2 - z**2/f**2))
         s_out = gaussian_conj(s_in, z, f)[0]
     elif 's_in' in kwargs:
-        raise NotImplementedError(_filldedent('''
+        raise NotImplementedError(filldedent('''
             Currently only focal length is supported as a parameter'''))
     else:
-        raise ValueError(_filldedent('''
+        raise ValueError(filldedent('''
             The functions expects the focal length as a named argument'''))
     return (s_in, s_out, f)
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -36,7 +36,7 @@ from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
 from sympy.utilities.iterables import preorder_traversal
 from sympy.utilities.lambdify import lambdify
-from sympy.utilities.misc import default_sort_key
+from sympy.utilities.misc import default_sort_key, filldedent
 from sympy.mpmath import findroot
 
 from sympy.solvers.polysys import solve_poly_system
@@ -47,18 +47,8 @@ from sympy.core.compatibility import reduce
 from sympy.assumptions import Q, ask
 
 from warnings import warn
-from textwrap import fill, dedent
 from types import GeneratorType
 from collections import defaultdict
-
-# if you use
-# _filldedent('''
-#             the text''')
-# a space will be put before the first line because dedent will
-# put a \n as the first line and fill replaces \n with spaces
-# so we strip off any leading and trailing \n since printed wrapped
-# text should not have leading or trailing spaces.
-_filldedent = lambda s: '\n'+fill(dedent(s).strip('\n'))
 
 
 def _ispow(e):
@@ -751,7 +741,7 @@ def solve(f, *symbols, **flags):
             elif not solution:
                 break
         else:
-            raise NotImplementedError(_filldedent('''
+            raise NotImplementedError(filldedent('''
                             no handling of %s was implemented''' % solution))
 
     # Restore original Functions and Derivatives if a dictionary is returned.
@@ -852,7 +842,7 @@ def solve(f, *symbols, **flags):
     elif isinstance(solution, (Relational, And, Or)):
         assert len(symbols) == 1
         if warning and symbols[0].assumptions0:
-            print(_filldedent("""
+            print(filldedent("""
                 \tWarning: assumptions about variable '%s' are
                 not handled currently.""" %symbols[0]))
         # TODO: check also variable assumptions for inequalities
@@ -862,7 +852,7 @@ def solve(f, *symbols, **flags):
 
     solution = no_False
     if warning and got_None:
-        print(_filldedent("""
+        print(filldedent("""
             \tWarning: assumptions concerning following solution(s)
             can't be checked:""" + '\n\t' +
             ', '.join(str(s) for s in got_None)))
@@ -1234,7 +1224,7 @@ def _solve_system(exprs, symbols, **flags):
                     check = checksol(polys, r, **flags)
                     if check is not False:
                         if check is None and warning:
-                            print(_filldedent("""
+                            print(filldedent("""
                                 \tWarning: could not verify solution %s.""" %
                                 result))
                         # if it's a solution to any denom then exclude
@@ -1396,7 +1386,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     from sympy import Equality
     if isinstance(lhs, Equality):
         if rhs:
-            raise ValueError(_filldedent('''
+            raise ValueError(filldedent('''
             If lhs is an Equality, rhs must be 0 but was %s''' % rhs))
         rhs = lhs.rhs
         lhs = lhs.lhs
@@ -1418,7 +1408,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
                 eg = 'solve(%s, %s)' % (eq, symbols[0])
             else:
                 eg = 'solve(%s, *%s)' % (eq, list(symbols))
-            raise ValueError(_filldedent('''
+            raise ValueError(filldedent('''
                 solve_linear only handles symbols, not %s. To isolate
                 non-symbols use solve, e.g. >>> %s <<<.
                              ''' % (bad, eg)))
@@ -1934,7 +1924,7 @@ def nsolve(*args, **kwargs):
         if fargs is None:
             fargs = atoms.copy().pop()
         if not (len(atoms) == 1 and (fargs in atoms or fargs[0] in atoms)):
-            raise ValueError(_filldedent('''
+            raise ValueError(filldedent('''
                 expected a one-dimensional and numerical function'''))
 
         # the function is much better behaved if there is no denominator
@@ -1943,7 +1933,7 @@ def nsolve(*args, **kwargs):
         f = lambdify(fargs, f, modules)
         return findroot(f, x0, **kwargs)
     if len(fargs) > f.cols:
-        raise NotImplementedError(_filldedent('''
+        raise NotImplementedError(filldedent('''
             need at least as many equations as variables'''))
     verbose = kwargs.get('verbose', False)
     if verbose:

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -131,14 +131,14 @@ class Indexed(Expr):
     is_commutative = False
 
     def __new__(cls, base, *args, **kw_args):
-        from sympy.solvers.solvers import _filldedent
+        from sympy.utilities.misc import filldedent
 
         if not args:
             raise IndexException("Indexed needs at least one index.")
         if isinstance(base, (basestring, Symbol)):
             base = IndexedBase(base)
         elif not isinstance(base, IndexedBase):
-            raise TypeError(_filldedent("""
+            raise TypeError(filldedent("""
                 Indexed expects string, Symbol or IndexedBase as base."""))
         return Expr.__new__(cls, base, *args, **kw_args)
 
@@ -217,17 +217,17 @@ class Indexed(Expr):
         >>> B[i, j].shape
         (m, m)
         """
-        from sympy.solvers.solvers import _filldedent
+        from sympy.utilities.misc import filldedent
 
         if self.base.shape:
             return self.base.shape
         try:
             return Tuple(*[i.upper - i.lower + 1 for i in self.indices])
         except AttributeError:
-            raise IndexException(_filldedent("""
+            raise IndexException(filldedent("""
                 Range is not defined for all indices in: %s""" % self))
         except TypeError:
-            raise IndexException(_filldedent("""
+            raise IndexException(filldedent("""
                 Shape cannot be inferred from Idx with
                 undefined range: %s""" % self))
 
@@ -477,7 +477,7 @@ class Idx(Expr):
     is_integer = True
 
     def __new__(cls, label, range=None, **kw_args):
-        from sympy.solvers.solvers import _filldedent
+        from sympy.utilities.misc import filldedent
 
         if isinstance(label, basestring):
             label = Symbol(label, integer=True)
@@ -488,7 +488,7 @@ class Idx(Expr):
 
         elif is_sequence(range):
             if len(range) != 2:
-                raise ValueError(_filldedent("""
+                raise ValueError(filldedent("""
                     Idx range tuple must have length 2, but got %s""" % len(range)))
             for bound in range:
                 if not (bound.is_integer or abs(bound) is S.Infinity):
@@ -499,7 +499,7 @@ class Idx(Expr):
                 raise TypeError("Idx object requires an integer dimension.")
             args = label, Tuple(0, range - 1)
         elif range:
-            raise TypeError(_filldedent("""
+            raise TypeError(filldedent("""
                 The range must be an ordered iterable or
                 integer SymPy expression."""))
         else:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,5 +1,16 @@
 """Miscellaneous stuff that doesn't really fit anywhere else."""
 
+from textwrap import fill, dedent
+
+# if you use
+# filldedent('''
+#             the text''')
+# a space will be put before the first line because dedent will
+# put a \n as the first line and fill replaces \n with spaces
+# so we strip off any leading and trailing \n since printed wrapped
+# text should not have leading or trailing spaces.
+filldedent = lambda s: '\n' + fill(dedent(s).strip('\n'))
+
 def default_sort_key(item, order=None):
     """
     A default sort key for lists of SymPy objects to pass to functions like sorted().


### PR DESCRIPTION
sympy/core/expr.py

```
o add __int__ to expr and raise ValueError if the results might
  be wrong. Since python can represent arbitrarily large ints,
  we can do the translation exactly from sympy expression to int
  via Integer (rather than float which keeps only about 17 digits).

  A result is ambiguous if an expression which is not known to be
  an integer, rounds to a non-zero integer. There is no way (that
  I know of) to chase down the first non-zero decimal digit so the
  burden is placed on the user to pass the expression evaluated
  to the desired number of digits.

o make __float__ raise a TypeError if the wrong type of input
  was received. This is similar to what is received from Python:

      >>> float(3+4j)
      ...
      TypeError: can't convert complex to float

o with changes of __float__'s ValueError, __complex__ needs to
 catch TypeError, not ValueError
```

sympy/core/numbers.py

```
o Rational.__int__ does not use float to do the conversion from
  sympy to python as this loses precision:

    >>> big
    12345678901234567890
    >>> big//7
    1763668414462081127
    >>> int(float(Rational(big, 7))) # previous master
    1763668414462081024L
    >>> int(Rational(big, 7)) # now
    1763668414462081127L

o Integer - add not about using int to process input

o NumberSymbol - make __int__ a stub and subclass with the
  exact integer output (that doesn't have to depend on evalf).
  Note that evalf(0) only should give the magnitude of the number,
  not the integer value of an expression - evalf uses significant
  digits whereas round uses decimal places. (So it would have been
  appropriate to use round(self) but not self.evalf(0).)
```

sympy/functions/elementary/miscellaneous.py

```
o round() (like evalf) now takes care not to return results to a
  precision higher than the most precise Float in the expression.
  No calculation is done -- this is just a pragmatic limit.

o it is possible that a value greater than float's limit is
  being calculated, so an attempt to use math's functions is used
  and then a fallback to sympy functions if this fails.

o there is better handling of the last digit; tests were added for
  this
```

All lines modified or added are covered with existing tests and those
added in

```
sympy/core/tests/test_arit.py
sympy/functions/elementary/miscellaneous.py
sympy/core/tests/test_numbers.py

    Added an XFAIL test for issue 3046
```
