### PR TITLE
detect other non-zero expressions in equals() method

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -278,6 +278,7 @@ class Expr(Basic, EvalfMixin):
         Examples
         ========
 
+        >>> from sympy import sqrt
         >>> from sympy.abc import x, y
         >>> x._random()                         # doctest: +SKIP
         2.02156676842162 + 2.09079610844169*I
@@ -367,7 +368,7 @@ class Expr(Basic, EvalfMixin):
         given symbols.
 
         If neither evaluation nor differentiation can prove the expression is
-        constant, None is returned unles two numerical values happened to be
+        constant, None is returned unless two numerical values happened to be
         the same and the flag ``failing_number`` is True -- in that case the
         numerical value will be returned.
 
@@ -461,10 +462,8 @@ class Expr(Basic, EvalfMixin):
         # expression depends on them or not using differentiation. This is
         # not sufficient for all expressions, however, so we don't return
         # False if we get a derivative other than 0 with free symbols.
-        wrt = wrt or free
-        wrt = list(wrt)
-        for i in range(len(wrt)):
-            deriv = (self.diff(wrt[0])).simplify()
+        for w in wrt:
+            deriv = self.diff(w).simplify()
             if deriv != 0:
                 if not (deriv.is_Number or pure_complex(deriv)):
                     if flags.get('failing_number', False):
@@ -473,7 +472,6 @@ class Expr(Basic, EvalfMixin):
                         # dead line provided _random returns None in such cases
                         return None
                 return False
-            wrt.pop(0)
         return True
 
     def equals(self, other, failing_expression=False):
@@ -847,40 +845,40 @@ class Expr(Basic, EvalfMixin):
 
         You can select terms that have an explicit negative in front of them:
 
-        >>> (-x+2*y).coeff(-1)
+        >>> (-x + 2*y).coeff(-1)
         x
-        >>> (x-2*y).coeff(-1)
+        >>> (x - 2*y).coeff(-1)
         2*y
 
         You can select terms with no rational coefficient:
 
-        >>> (x+2*y).coeff(1)
+        >>> (x + 2*y).coeff(1)
         x
-        >>> (3+2*x+4*x**2).coeff(1)
+        >>> (3 + 2*x + 4*x**2).coeff(1)
 
         You can select terms that have a numerical term in front of them:
 
-        >>> (-x-2*y).coeff(2)
+        >>> (-x - 2*y).coeff(2)
         -y
         >>> from sympy import sqrt
-        >>> (x+sqrt(2)*x).coeff(sqrt(2))
+        >>> (x + sqrt(2)*x).coeff(sqrt(2))
         x
 
         The matching is exact:
 
-        >>> (3+2*x+4*x**2).coeff(x)
+        >>> (3 + 2*x + 4*x**2).coeff(x)
         2
-        >>> (3+2*x+4*x**2).coeff(x**2)
+        >>> (3 + 2*x + 4*x**2).coeff(x**2)
         4
-        >>> (3+2*x+4*x**2).coeff(x**3)
-        >>> (z*(x+y)**2).coeff((x+y)**2)
+        >>> (3 + 2*x + 4*x**2).coeff(x**3)
+        >>> (z*(x + y)**2).coeff((x + y)**2)
         z
-        >>> (z*(x+y)**2).coeff(x+y)
+        >>> (z*(x + y)**2).coeff(x + y)
 
         In addition, no factoring is done, so 2 + y is not obtained from the
         following:
 
-        >>> (2*x+2+(x+1)*y).coeff(x+1)
+        >>> (2*x + 2 + (x + 1)*y).coeff(x + 1)
         y
 
         >>> n, m, o = symbols('n m o', commutative=False)

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -145,9 +145,7 @@ class Relational(Expr, EvalfMixin):
         if lhs.is_number and rhs.is_number and (rop in ('==', '!=' ) or
         lhs.is_real and rhs.is_real):
             diff = lhs - rhs
-            know = (lhs - rhs).equals(0,
-                                      failing_expression=True,
-                                      )
+            know = (lhs - rhs).equals(0, failing_expression=True)
             if know is True: # exclude failing expression case
                 Nlhs = Nrhs = S.Zero
             elif know is False:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,4 +1,4 @@
-from basic import Basic
+from basic import Basic, S
 from expr import Expr
 from evalf import EvalfMixin
 from sympify import _sympify
@@ -144,12 +144,22 @@ class Relational(Expr, EvalfMixin):
                 raise ValueError(msg % repr(rop))
         if lhs.is_number and rhs.is_number and (rop in ('==', '!=' ) or
         lhs.is_real and rhs.is_real):
-            # Just because something is a number, doesn't mean you can evalf it.
-            Nlhs = lhs.evalf() if not lhs.is_Atom else lhs
-            if Nlhs.is_Atom:
-                Nrhs = rhs.evalf() if not rhs.is_Atom else rhs
-                if Nrhs.is_Atom:
-                    return rop_cls._eval_relation(Nlhs, Nrhs)
+            diff = lhs - rhs
+            know = (lhs - rhs).equals(0,
+                                      failing_expression=True,
+                                      )
+            if know is True: # exclude failing expression case
+                Nlhs = Nrhs = S.Zero
+            elif know is False:
+                from sympy import sign
+                Nlhs = sign((lhs - rhs).n(1))
+                Nrhs = S.Zero
+            else:
+                Nlhs = None
+                lhs = know
+                rhs = S.Zero
+            if Nlhs is not None:
+                return rop_cls._eval_relation(Nlhs, S.Zero)
 
         obj = Expr.__new__(rop_cls, lhs, rhs, **assumptions)
         return obj

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1336,3 +1336,5 @@ def test_float_int():
     assert int(Add(1 + Float('.99999999999999999', ''), evaluate=False)) == 1
     raises(TypeError, 'float(x)')
     raises(TypeError, 'float(sqrt(-1))')
+
+    assert int(12345678901234567890 + cos(1)**2 + sin(1)**2) == 12345678901234567891

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1259,7 +1259,9 @@ def test_equals():
         2*sqrt(2)*x**(S(3)/2)*(1 + 1/(2*x))**(S(5)/2)/(-6 - 3/x)
     ans = sqrt(2*x + 1)*(6*x**2 + x - 1)/15
     diff = i - ans
-    assert diff.equals(0) is None
+    assert diff.equals(0) is not False # should be True, but now it's None
+    # XXX TODO add a force=True option to equals to posify both
+    # self and other before beginning comparisions
     p = Symbol('p', positive=True)
     assert diff.subs(x, p).equals(0) is True
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1253,10 +1253,15 @@ def test_equals():
     assert meter.equals(0) is False
     assert (3*meter**2).equals(0) is False
 
-    # from integrate(x*sqrt(1+2*x), x)
+    # from integrate(x*sqrt(1+2*x), x);
+    # diff is zero, but differentiation does not show it
     i = 2*sqrt(2)*x**(S(5)/2)*(1 + 1/(2*x))**(S(5)/2)/5 + \
         2*sqrt(2)*x**(S(3)/2)*(1 + 1/(2*x))**(S(5)/2)/(-6 - 3/x)
-    assert i.equals(sqrt(2*x + 1)*(6*x**2 + x - 1)/15)
+    ans = sqrt(2*x + 1)*(6*x**2 + x - 1)/15
+    diff = i - ans
+    assert diff.equals(0) is None
+    p = Symbol('p', positive=True)
+    assert diff.subs(x, p).equals(0) is True
 
 @XFAIL
 def test_equals_factorial():

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1239,12 +1239,24 @@ def test_is_not_constant():
     assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero != False
 
 def test_equals():
+    assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).equals(0)
     assert (x**2 - 1).equals((x + 1)*(x - 1))
     assert (cos(x)**2 + sin(x)**2).equals(1)
     assert (a*cos(x)**2 + a*sin(x)**2).equals(a)
     r = sqrt(2)
     assert (-1/(r + r*x) + 1/r/(1 + x)).equals(0)
     assert factorial(x + 1).equals((x + 1)*factorial(x))
+    assert sqrt(3).equals(2*sqrt(3)) is False
+    assert (sqrt(5)*sqrt(3)).equals(sqrt(3)) is False
+    assert (sqrt(5) + sqrt(3)).equals(0) is False
+    assert (sqrt(5) + pi).equals(0) is False
+    assert meter.equals(0) is False
+    assert (3*meter**2).equals(0) is False
+
+    # from integrate(x*sqrt(1+2*x), x)
+    i = 2*sqrt(2)*x**(S(5)/2)*(1 + 1/(2*x))**(S(5)/2)/5 + \
+        2*sqrt(2)*x**(S(3)/2)*(1 + 1/(2*x))**(S(5)/2)/(-6 - 3/x)
+    assert i.equals(sqrt(2*x + 1)*(6*x**2 + x - 1)/15)
 
 @XFAIL
 def test_equals_factorial():

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,5 +1,5 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import Symbol, symbols, oo, I
+from sympy import Symbol, symbols, oo, I, pi, Float
 from sympy.core.relational import ( Relational, Equality, Unequality,
     GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le,
     Gt, Ge, Ne )
@@ -126,6 +126,9 @@ def test_bool():
     assert Ge(I, 2) not in [True, False]
     assert Lt(I, 2) not in [True, False]
     assert Le(I, 2) not in [True, False]
+    a = Float('.000000000000000000001', '')
+    b = Float('.0000000000000000000001', '')
+    assert Eq(pi + a, pi + b) is False
 
 def test_rich_cmp():
     assert (x<y) == Lt(x,y)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -24,7 +24,7 @@ def test_piecewise():
 
     # More subs tests
     p2 = Piecewise((1, x < pi), (-1, x < 2*pi), (0, x > 2*pi))
-    assert p2.subs(x,2) == 1
+    assert p2.subs(x, 2) == 1
     assert p2.subs(x,4) == -1
     assert p2.subs(x,10) == 0
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2837,6 +2837,10 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=None):
         >>> nsimplify(pi, tolerance=0.01)
         22/7
 
+    See Also
+    ========
+    sympy.core.function.nfloat
+
     """
     expr = sympify(expr)
     if rational or expr.free_symbols:

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -1,27 +1,46 @@
-""" Helpers for randomised testing """
+""" Helpers for randomized testing """
 
-from sympy import I
+from sympy import I, nsimplify, S, Tuple, Dummy
 from random import uniform
 
-def random_complex_number(a=2, b=-1, c=3, d=1):
+def random_complex_number(a=2, b=-1, c=3, d=1, rational=False):
     """
     Return a random complex number.
 
     To reduce chance of hitting branch cuts or anything, we guarantee
     b <= Im z <= d, a <= Re z <= c
     """
-    return uniform(a, c) + I*uniform(b, d)
+    A, B = uniform(a, c), uniform(b, d)
+    if not rational:
+        return A + I*B
+    return nsimplify(A, rational=True) + I*nsimplify(B, rational=True)
+
 
 def comp(z1, z2, tol):
+    """Return a bool indicating whether the error between z1 and z2 is <= tol.
+
+    If z2 is non-zero and |z1| > 1 the error is normalized by |z1|, so if you
+    want the absolute error, call this as comp(z1 - z2, 0, tol).
+    """
+    if not z1:
+        z1, z2 = z2, z1
+    if not z1:
+        return True
     diff = abs(z1 - z2)
-    if abs(z1) > 1:
-        return diff/abs(z1) <= tol
+    az1 = abs(z1)
+    if z2 and az1 > 1:
+        return diff/az1 <= tol
     else:
         return diff <= tol
 
-def test_numerically(f, g, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):
+def test_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     """
     Test numerically that f and g agree when evaluated in the argument z.
+
+    If z is None, all symbols will be tested. This routine does not test
+    whether there are Floats present with precision higher than 15 digits
+    so if there are, your results may not be what you expect due to round-
+    off errors.
 
     Examples
     ========
@@ -29,18 +48,24 @@ def test_numerically(f, g, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     >>> from sympy import sin, cos, S
     >>> from sympy.abc import x
     >>> from sympy.utilities.randtest import test_numerically as tn
-    >>> tn(sin(x)**2 + cos(x)**2, S(1), x)
+    >>> tn(sin(x)**2 + cos(x)**2, 1, x)
     True
     """
-    z0 = random_complex_number(a, b, c, d)
-    z1 = f.subs(z, z0).n()
-    z2 = g.subs(z, z0).n()
+    f, g, z = Tuple(f, g, z)
+    z = [z] if z else (f.free_symbols | g.free_symbols)
+    reps = zip(z, [random_complex_number(a, b, c, d) for zi in z])
+    z1 = f.subs(reps).n()
+    z2 = g.subs(reps).n()
     return comp(z1, z2, tol)
 
 def test_derivative_numerically(f, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     """
     Test numerically that the symbolically computed derivative of f
     with respect to z is correct.
+
+    This routine does not test whether there are Floats present with
+    precision higher than 15 digits so if there are, your results may
+    not be what you expect due to round-off errors.
 
     Examples
     ========


### PR DESCRIPTION
Numerical evaluation which results in significant digits is used to test expressions which are numbers. (If there are no significant digits in the evaluation, the numerical result is not used.) Some updates to randtest are also included.
