### PR TITLE
3050: content removal defers break for 1 iteration

### DIFF
--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -589,16 +589,22 @@ def dup_content(f, K):
     2/1
 
     """
+    from sympy.polys.domains import QQ
+
     if not f:
         return K.zero
 
     cont = K.zero
 
-    for c in f:
-        cont = K.gcd(cont, c)
+    if K == QQ:
+        for c in f:
+            cont = K.gcd(cont, c)
+    else:
+        for c in f:
+            cont = K.gcd(cont, c)
 
-        if K.is_one(cont):
-            break
+            if K.is_one(cont):
+                break
 
     return cont
 
@@ -622,19 +628,25 @@ def dmp_ground_content(f, u, K):
     2/1
 
     """
+    from sympy.polys.domains import QQ
+
     if not u:
         return dup_content(f, K)
 
     if dmp_zero_p(f, u):
         return K.zero
 
-    cont, v = K.zero, u-1
+    cont, v = K.zero, u - 1
 
-    for c in f:
-        cont = K.gcd(cont, dmp_ground_content(c, v, K))
+    if K == QQ:
+        for c in f:
+            cont = K.gcd(cont, dmp_ground_content(c, v, K))
+    else:
+        for c in f:
+            cont = K.gcd(cont, dmp_ground_content(c, v, K))
 
-        if K.is_one(cont):
-            break
+            if K.is_one(cont):
+                break
 
     return cont
 

--- a/sympy/polys/distributedpolys.py
+++ b/sympy/polys/distributedpolys.py
@@ -296,16 +296,22 @@ def sdp_monic(f, K):
 
 def sdp_content(f, K):
     """Returns GCD of coefficients in `K[X]`. """
+    from sympy.polys.domains import QQ
+
     if K.has_Field:
         return K.one
     else:
         cont = K.zero
 
-        for _, c in f:
-            cont = K.gcd(cont, c)
+        if K == QQ:
+            for c in f:
+                cont = K.gcd(cont, c)
+        else:
+            for c in f:
+                cont = K.gcd(cont, c)
 
-            if K.is_one(cont):
-                break
+                if K.is_one(cont) and i:
+                    break
 
         return cont
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1758,6 +1758,9 @@ def test_primitive():
     assert f.primitive() == (1, f)
     assert g.primitive() == (1.0, g)
 
+    assert primitive(S('-3*x/4 + y + 11/8')) == \
+        S('(1/8, -6*x + 8*y + 11)')
+
 def test_compose():
     f = x**12+20*x**10+150*x**8+500*x**6+625*x**4-2*x**3-10*x+9
     g = x**4 - 2*x + 9


### PR DESCRIPTION
When the domain is QQ we should not break from content
    extraction if the first term leads to a 1 for content since
    the next term may change that:

``` python
>>> g = 0
>>> for i in [1,S.Half]:
...  g = gcd(g, i)
...  print g
...
1
1/2
```

So now anywhere there was a is_one(cont) appearing in polys,
if it was in a loop, an enumeration is used and the break
only occurs if i > 0. One known failing example was added, but
if the other loops are every traversed with domain QQ and similar
coefficients, similar failure will be avoided.

see http://code.google.com/p/sympy/issues/detail?id=3050
