### PR TITLE
Actually enable pytest definitions in sympy.utilities.pytest

### DIFF
--- a/sympy/utilities/pytest.py
+++ b/sympy/utilities/pytest.py
@@ -4,7 +4,8 @@ import sys
 import functools
 
 try:
-    from pytest import skip, raises
+    import py
+    from py.test import skip, raises
     USE_PYTEST = getattr(sys, '_running_pytest', False)
 except ImportError:
     USE_PYTEST = False


### PR DESCRIPTION
'import pytest' was actually attempting to import
sympy/utilities/pytest.py, which always failed, thus preventing the
pytest-specific definitions from being used when running py.test.

This fixes a mistake in #805
