### PR TITLE
_keep_coeff,gcd-terms and factor_terms have option to not clear denomina...

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -376,11 +376,15 @@ def _gcd_terms(terms, isprimitive=False):
 
     return cont, numer, denom
 
-def gcd_terms(terms, isprimitive=False, clear=False):
+def gcd_terms(terms, isprimitive=False, clear=True):
     """
     Compute the GCD of ``terms`` and put them together. If ``isprimitive`` is
-    True the _gcd_terms will not run the primitive method on the terms. If
-    ``clear`` is True, all Add expressions will have Integer coefficients.
+    True the _gcd_terms will not run the primitive method on the terms.
+
+    ``clear`` controls the removal of integers from the denominator of an Add
+    expression. When True, all numerical denominator will be cleared; when
+    False the denominators will be cleared only if all terms had numerical
+    denominators.
 
     Examples
     ========
@@ -394,6 +398,8 @@ def gcd_terms(terms, isprimitive=False, clear=False):
     (x + 2)/2
     >>> gcd_terms(x/2 + 1, clear=False)
     x/2 + 1
+    >>> gcd_terms(x/2 + y/2, clear=False)
+    (x + y)/2
 
     """
     terms = sympify(terms)

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -376,10 +376,11 @@ def _gcd_terms(terms, isprimitive=False):
 
     return cont, numer, denom
 
-def gcd_terms(terms, isprimitive=False):
+def gcd_terms(terms, isprimitive=False, clear=False):
     """
     Compute the GCD of ``terms`` and put them together. If ``isprimitive`` is
-    True the _gcd_terms will not run the primitive method on the terms.
+    True the _gcd_terms will not run the primitive method on the terms. If
+    ``clear`` is True, all Add expressions will have Integer coefficients.
 
     Examples
     ========
@@ -389,6 +390,10 @@ def gcd_terms(terms, isprimitive=False):
 
     >>> gcd_terms((x + 1)**2*y + (x + 1)*y**2)
     y*(x + 1)*(x + y + 1)
+    >>> gcd_terms(x/2 + 1)
+    (x + 2)/2
+    >>> gcd_terms(x/2 + 1, clear=False)
+    x/2 + 1
 
     """
     terms = sympify(terms)
@@ -396,31 +401,35 @@ def gcd_terms(terms, isprimitive=False):
     if not isexpr or terms.is_Add:
         cont, numer, denom = _gcd_terms(terms, isprimitive)
         coeff, factors = cont.as_coeff_Mul()
-        return _keep_coeff(coeff, factors*numer/denom)
+        return _keep_coeff(coeff, factors*numer/denom, clear=clear)
 
     if terms.is_Atom:
         return terms
 
     if terms.is_Mul:
         c, args = terms.as_coeff_mul()
-        return _keep_coeff(c, Mul(*[gcd_terms(i, isprimitive) for i in args]))
+        return _keep_coeff(c, Mul(*[gcd_terms(i, isprimitive, clear) for i in args]), clear=clear)
 
     def handle(a):
         if iterable(a):
             if isinstance(a, Basic):
-                return a.func(*[gcd_terms(i, isprimitive) for i in a.args])
-            return type(a)([gcd_terms(i, isprimitive) for i in a])
-        return gcd_terms(a, isprimitive)
+                return a.func(*[gcd_terms(i, isprimitive, clear) for i in a.args])
+            return type(a)([gcd_terms(i, isprimitive, clear) for i in a])
+        return gcd_terms(a, isprimitive, clear)
     return terms.func(*[handle(i) for i in terms.args])
 
 
-def factor_terms(expr, radical=False):
+def factor_terms(expr, radical=False, clear=False):
     """Remove common factors from terms in all arguments without
     changing the underlying structure of the expr. No expansion or
     simplification (and no processing of non-commutatives) is performed.
 
     If radical=True then a radical common to all terms will be factored
     out of any Add sub-expressions of the expr.
+
+    If clear=False (default) then coefficients will not be separated
+    from a single Add if they can be distributed to leave one or more
+    terms with integer coefficients.
 
     Examples
     ========
@@ -433,20 +442,22 @@ def factor_terms(expr, radical=False):
     >>> factor_terms(x*A + x*A + x*y*A)
     x*(y*A + 2*A)
 
-    Notes
-    =====
+    When clear is False, a fraction will only appear factored out of an
+    Add expression if all terms of the Add have coefficients that are
+    fractions:
 
-    A fraction will only appear factored out of an Add expression if all
-    terms of the Add have coefficients that are fractions:
-
-    >>> factor_terms(x*y/2 + y) # result has fraction before Mul
-    y*(x + 2)/2
-    >>> factor_terms(x/2 + 1) # not (x + 2)/2
+    >>> factor_terms(x/2 + 1, clear=False)
     x/2 + 1
-    >>> Mul(*primitive(_), **dict(evaluate=False))
+    >>> factor_terms(x/2 + 1, clear=True)
     (x + 2)/2
-    >>> factor_terms(x/2 + y/4) # fraction separated from Add
-    (2*x + y)/4
+
+    This only applies when there is a single Add that the coefficient
+    multiplies:
+
+    >>> factor_terms(x*y/2 + y, clear=True)
+    y*(x + 2)/2
+    >>> factor_terms(x*y/2 + y, clear=False) == _
+    True
 
     """
 
@@ -455,12 +466,12 @@ def factor_terms(expr, radical=False):
 
     if not isinstance(expr, Basic) or expr.is_Atom:
         if is_iterable:
-            return type(expr)([factor_terms(i, radical=radical) for i in expr])
+            return type(expr)([factor_terms(i, radical=radical, clear=clear) for i in expr])
         return expr
 
-    if expr.is_Function or is_iterable or not hasattr(expr, 'args_cnc'):
+    if expr.is_Pow or expr.is_Function or is_iterable or not hasattr(expr, 'args_cnc'):
         args = expr.args
-        newargs = tuple([factor_terms(i, radical=radical) for i in args])
+        newargs = tuple([factor_terms(i, radical=radical, clear=clear) for i in args])
         if newargs == args:
             return expr
         return expr.func(*newargs)
@@ -474,15 +485,8 @@ def factor_terms(expr, radical=False):
         if nc[i] is not None:
             a.append(nc[i][0])
         a = Mul._from_args(a) # gcd_terms will fix up ordering
-        list_args[i] = gcd_terms(a, isprimitive=True)
+        list_args[i] = gcd_terms(a, isprimitive=True, clear=clear)
         # cancel terms that may not have cancelled
     p = Add._from_args(list_args) # gcd_terms will fix up ordering
-    p = gcd_terms(p, isprimitive=True).xreplace(ncreps)
-    if cont.is_Rational and cont.q != 1 and p.is_Add:
-        q = sympify(cont.q)
-        for i in p.args:
-            c, t = i.as_coeff_Mul()
-            r = c/q
-            if r == int(r):
-                return cont*p
-    return _keep_coeff(cont, p)
+    p = gcd_terms(p, isprimitive=True, clear=clear).xreplace(ncreps)
+    return _keep_coeff(cont, p, clear=clear)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -120,6 +120,9 @@ def test_factor_terms():
         assert factor_terms(c(eq)) == c(ans)
     assert factor_terms(Tuple(x + x*y)) == Tuple(x*(y + 1))
     assert factor_terms(Interval(0, 1)) == Interval(0, 1)
+    e = 1/sqrt(a/2 + 1)
+    assert factor_terms(e, clear=False) == 1/sqrt(a/2 + 1)
+    assert factor_terms(e) == sqrt(2)/sqrt(a + 2)
 
 def test_xreplace():
     e = Mul(2, 1 + x, evaluate=False)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -122,7 +122,7 @@ def test_factor_terms():
     assert factor_terms(Interval(0, 1)) == Interval(0, 1)
     e = 1/sqrt(a/2 + 1)
     assert factor_terms(e, clear=False) == 1/sqrt(a/2 + 1)
-    assert factor_terms(e) == sqrt(2)/sqrt(a + 2)
+    assert factor_terms(e, clear=True) == sqrt(2)/sqrt(a + 2)
 
 def test_xreplace():
     e = Mul(2, 1 + x, evaluate=False)


### PR DESCRIPTION
...tors

In order to allow Rationals to not be extracted from an Add when there
    are some terms that have Integer coefficients, the 'clear' option
    has been added. Since factor_terms depends on gcd_terms which depends
    on _keep_coeff, this option was added to all 3 routines.
