### PR TITLE
integrate loses evaluate keyword; solve gives simpler results when trig(h) funcs are involved

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1092,10 +1092,9 @@ def integrate(*args, **kwargs):
     """
     meijerg = kwargs.pop('meijerg', None)
     conds = kwargs.pop('conds', 'piecewise')
-    evaluate = kwargs.pop('evaluate', True)
     integral = Integral(*args, **kwargs)
 
-    if evaluate and isinstance(integral, Integral):
+    if isinstance(integral, Integral):
         return integral.doit(deep = False, meijerg = meijerg, conds = conds)
     else:
         return integral

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -45,7 +45,11 @@ class SingleContinuousDomain(ContinuousDomain, SingleDomain):
             return expr
         assert frozenset(variables) == frozenset(self.symbols)
         # assumes only intervals
-        return integrate(expr, (self.symbol, self.set), **kwargs)
+        evaluate = kwargs.pop('evaluate', True)
+        if evaluate:
+            return integrate(expr, (self.symbol, self.set), **kwargs)
+        else:
+            return Integral(expr, (self.symbol, self.set), **kwargs)
 
     def as_boolean(self):
         return self.set.as_relational(self.symbol)
@@ -118,7 +122,10 @@ class ConditionalContinuousDomain(ContinuousDomain, ConditionalDomain):
                 raise TypeError(
                         "Condition %s is not a relational or Boolean"%cond)
 
-        return integrate(integrand, *limits, **kwargs)
+        evaluate = kwargs.pop('evaluate', True)
+        if evaluate:
+            return integrate(integrand, *limits, **kwargs)
+        return Integral(integrand, *limits, **kwargs)
 
     def as_boolean(self):
         return And(self.fulldomain.as_boolean(), self.condition)


### PR DESCRIPTION
see issue 3058
