### PR TITLE
Also run 2to3 on files with no extensions

### DIFF
--- a/bin/use2to3
+++ b/bin/use2to3
@@ -96,14 +96,13 @@ for root, dirs, files in os.walk('.'):
                 continue
         shutil.copy2(src, dst)
         # add to the list of files to pass to 2to3 if needed
-        if filename.endswith(".py"):
+        if filename.endswith(".py") or root == "./bin":
             modified_files.append(dst)
         elif filename.endswith(".txt"):
             # we need to check the exact path here, not just the filename
             # as there are eg. multiple index.txt files and not all are relevant
             if np(src) in relevant_txt_files:
                 modified_txt_files.append(dst)
-        # FIXME: Also run 2to3 on files with no extensions; now we just skip them
 
 # arguments to call 2to3 with
 args_2to3 = [


### PR DESCRIPTION
Otherwise, isympy does not work with python3
