### PR TITLE
Ask even, integer and prime correction

### DIFF
--- a/sympy/assumptions/handlers/ntheory.py
+++ b/sympy/assumptions/handlers/ntheory.py
@@ -4,19 +4,27 @@ Handlers for keys related to number theory: prime, even, odd, etc.
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler
 from sympy.ntheory import isprime
+from sympy.ntheory.residue_ntheory import int_tested
+from sympy.functions.elementary.miscellaneous import round
 
 class AskPrimeHandler(CommonHandler):
     """
     Handler for key 'prime'
-    Test that an expression represents a prime number
+    Test that an expression represents a prime number. When the
+    expression is a number the result, when True, is subject to
+    the limitations of isprime() which is used to return the result.
     """
 
     @staticmethod
     def _number(expr, assumptions):
         # helper method
-        if (expr.as_real_imag()[1] == 0) and int(expr.evalf()) == expr:
-            return isprime(expr.evalf(1))
-        return False
+        try:
+            i = int(round(expr))
+            if not (expr - i).equals(0):
+                raise TypeError
+        except TypeError:
+            return False
+        return isprime(i)
 
     @staticmethod
     def Basic(expr, assumptions):
@@ -96,9 +104,13 @@ class AskEvenHandler(CommonHandler):
     @staticmethod
     def _number(expr, assumptions):
         # helper method
-        if (expr.as_real_imag()[1] == 0) and expr.evalf(1) == expr:
-            return float(expr.evalf()) % 2 == 0
-        else: return False
+        try:
+            i = int(round(expr))
+            if not (expr - i).equals(0):
+                raise TypeError
+        except TypeError:
+            return False
+        return i % 2 == 0
 
     @staticmethod
     def Basic(expr, assumptions):
@@ -142,9 +154,6 @@ class AskEvenHandler(CommonHandler):
         Even + Even -> Even
         Odd  + Odd  -> Even
 
-        TODO: remove float() when issue
-        http://code.google.com/p/sympy/issues/detail?id=1473
-        is solved
         """
         if expr.is_number:
             return AskEvenHandler._number(expr, assumptions)

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -3,6 +3,7 @@ Handlers for predicates related to set membership: integer, rational, etc.
 """
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler
+from sympy.functions.elementary.miscellaneous import round
 
 class AskIntegerHandler(CommonHandler):
     """
@@ -13,9 +14,13 @@ class AskIntegerHandler(CommonHandler):
     @staticmethod
     def _number(expr, assumptions):
         # helper method
-        if expr.as_real_imag()[1] == 0:
-            return expr.evalf(1) == expr
-        return False
+        try:
+            i = int(round(expr))
+            if not (expr - i).equals(0):
+                raise TypeError
+            return True
+        except TypeError:
+            return False
 
     @staticmethod
     def Add(expr, assumptions):
@@ -139,7 +144,7 @@ class AskRationalHandler(CommonHandler):
 
     @staticmethod
     def Float(expr, assumptions):
-        # it's finite-precission
+        # it's finite-precision
         return True
 
     @staticmethod

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -4,7 +4,7 @@ from sympy.assumptions import (ask, AssumptionsContext, global_assumptions, Q,
 from sympy.assumptions.ask import (compute_known_facts, known_facts_cnf,
                                    known_facts_dict)
 from sympy.assumptions.handlers import AskHandler
-from sympy.core import I, Integer, oo, pi, Rational, S, symbols
+from sympy.core import I, Integer, oo, pi, Rational, S, symbols, Add
 from sympy.functions import Abs, cos, exp, im, log, re, sign, sin, sqrt
 from sympy.logic import Equivalent, Implies, Xor
 from sympy.utilities.pytest import raises, XFAIL, slow
@@ -22,6 +22,42 @@ def test_int_1():
     assert ask(Q.negative(z))         == False
     assert ask(Q.even(z))             == False
     assert ask(Q.odd(z))              == True
+    assert ask(Q.bounded(z))          == True
+    assert ask(Q.infinitesimal(z))    == False
+    assert ask(Q.prime(z))            == False
+    assert ask(Q.composite(z))        == True
+
+def test_int_11():
+    z = 11
+    assert ask(Q.commutative(z))      == True
+    assert ask(Q.integer(z))          == True
+    assert ask(Q.rational(z))         == True
+    assert ask(Q.real(z))             == True
+    assert ask(Q.complex(z))          == True
+    assert ask(Q.irrational(z))       == False
+    assert ask(Q.imaginary(z))        == False
+    assert ask(Q.positive(z))         == True
+    assert ask(Q.negative(z))         == False
+    assert ask(Q.even(z))             == False
+    assert ask(Q.odd(z))              == True
+    assert ask(Q.bounded(z))          == True
+    assert ask(Q.infinitesimal(z))    == False
+    assert ask(Q.prime(z))            == True
+    assert ask(Q.composite(z))        == False
+
+def test_int_12():
+    z = 12
+    assert ask(Q.commutative(z))      == True
+    assert ask(Q.integer(z))          == True
+    assert ask(Q.rational(z))         == True
+    assert ask(Q.real(z))             == True
+    assert ask(Q.complex(z))          == True
+    assert ask(Q.irrational(z))       == False
+    assert ask(Q.imaginary(z))        == False
+    assert ask(Q.positive(z))         == True
+    assert ask(Q.negative(z))         == False
+    assert ask(Q.even(z))             == True
+    assert ask(Q.odd(z))              == False
     assert ask(Q.bounded(z))          == True
     assert ask(Q.infinitesimal(z))    == False
     assert ask(Q.prime(z))            == False
@@ -1240,3 +1276,9 @@ def test_compute_known_facts():
     exec compute_known_facts() in globals(), ns
     assert ns['known_facts_cnf'] == known_facts_cnf
     assert ns['known_facts_dict'] == known_facts_dict
+
+def test_Add_queries():
+    assert ask(Q.prime(12345678901234567890 + (cos(1)**2 + sin(1)**2))) is True
+    assert ask(Q.even(Add(S(2), S(2), evaluate=0))) is True
+    assert ask(Q.prime(Add(S(2), S(2), evaluate=0))) is False
+    assert ask(Q.integer(Add(S(2), S(2), evaluate=0))) is True

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -387,7 +387,7 @@ class AssumeMixin(object):
 
         # For positive/negative try to ask evalf
         if k in _real_ordering and self.is_comparable:
-            e = self.evalf()
+            e = self.evalf(1)
 
             if e.is_Number:
                 a = _real_cmp0_table[k][cmp(e, 0)]

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -325,7 +325,7 @@ class Abs(Function):
             return known*unk
         if arg is S.NaN:
             return S.NaN
-        if arg.is_zero:
+        if arg.is_zero:#equals(0):
             return arg
         if arg.is_positive:
             return arg


### PR DESCRIPTION
When an expr is a number (not Number) comparing the computed int()
    of it to the original expression will fail so equals() is used to
    make the comparison.

Float is no longer used to test integers.

http://code.google.com/p/sympy/issues/detail?id=3133

After committing, search issues for this pull request number (e.g. put "1068" in the search box to see which might have been related to this issue.)
