### PR TITLE
added evaluate keyword handling to P()

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -189,6 +189,7 @@ class ContinuousPSpace(PSpace):
         return z, cdf
 
     def P(self, condition, **kwargs):
+        evaluate = kwargs.get("evaluate", True)
         # Univariate case can be handled by where
         try:
             domain = self.where(condition)
@@ -196,7 +197,10 @@ class ContinuousPSpace(PSpace):
             # Integrate out all other random variables
             z, pdf = self.compute_density(rv, **kwargs)
             # Integrate out this last variable over the special domain
-            return integrate(pdf, (z, domain.set), **kwargs)
+            if evaluate:
+                return integrate(pdf, (z, domain.set), **kwargs)
+            else:
+                return Integral(pdf, (z, domain.set), **kwargs)
         # Other cases can be turned into univariate case
         # by computing a density handled by density computation
         except NotImplementedError:

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -460,7 +460,7 @@ def E(expr, given=None, numsamples=None, **kwargs):
 
     # A few known statements for efficiency
     if expr.is_Add:
-        return Add(*[E(arg) for arg in expr.args]) # E is Linear
+        return Add(*[E(arg, **kwargs) for arg in expr.args]) # E is Linear
 
     # Otherwise case is simple, pass work off to the ProbabilitySpace
     return pspace(expr).integrate(expr, **kwargs)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1,7 +1,7 @@
 from sympy.stats import (Normal, LogNormal, Exponential, P, E, Where, Density,
         Var, Covar, Skewness, Gamma, Pareto, Weibull, Beta, Uniform, Given, pspace, CDF, ContinuousRV, Sample)
 from sympy import (Symbol, exp, S, N, pi, simplify, Interval, erf, Eq, symbols,
-        sqrt, And, gamma, beta, Piecewise)
+        sqrt, And, gamma, beta, Piecewise, Integral)
 from sympy.utilities.pytest import raises
 
 oo = S.Infinity
@@ -255,3 +255,20 @@ def test_input_value_assertions():
         raises(ValueError, "%s(a, p)" % fn_name)
         raises(ValueError, "%s(p, a)" % fn_name)
         eval("%s(p, q)" % fn_name) # No error raised
+
+def test_unevaluated():
+    x = Symbol('x')
+    X = Normal(0,1, symbol=x)
+    assert E(X, evaluate=False) == \
+            Integral(sqrt(2)*x*exp(-x**2/2)/(2*sqrt(pi)), (x, -oo, oo))
+
+    assert E(X+1, evaluate=False) == \
+            Integral(sqrt(2)*x*exp(-x**2/2)/(2*sqrt(pi)), (x, -oo, oo)) + 1
+
+    assert P(X>0, evaluate=False).args == \
+            Integral(sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)), (x, 0, oo)).args
+
+    assert P(X>0, X**2<1, evaluate=False).args == \
+            Integral(sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)*
+            Integral(sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)),
+                (x, -1, 1))), (x, 0, 1)).args


### PR DESCRIPTION
The evaluate keyword was taken out of integrate in a previous commit. As a result calls such as 
P(X>0, evaluate=False)
were returning evaluated integrals. I added logic within P to handle this. I also added tests that were obviously missing before.

Also fixed a bug involving E(Add(...), evaluate=False) 
