### PR TITLE
Test cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,6 @@ tests = [
     'sympy.printing.tests',
     'sympy.series.tests',
     'sympy.simplify.tests',
-    'sympy.slow_tests',
     'sympy.solvers.tests',
     'sympy.statistics.tests',
     'sympy.tensor.tests',

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -164,14 +164,6 @@ def test_pow3():
     assert sqrt(2)**3 == 2 * sqrt(2)
     assert sqrt(2)**3 == sqrt(8)
 
-def test_pow_issue_1724():
-    e = ((-1)**(S(1)/3))
-    assert e.conjugate().n() == e.n().conjugate()
-    e = S('-2/3 - (-29/54 + sqrt(93)/18)**(1/3) - 1/(9*(-29/54 + sqrt(93)/18)**(1/3))')
-    assert e.conjugate().n() == e.n().conjugate()
-    e = 2**I
-    assert e.conjugate().n() == e.n().conjugate()
-
 def test_expand():
     p = Rational(5)
     e = (a+b)*c

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -1,5 +1,6 @@
-from sympy import Symbol, sqrt, I, Integer, Rational, cos, sin, im, re, \
-        exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi, expand_complex
+from sympy import (S, Symbol, sqrt, I, Integer, Rational, cos, sin, im, re,
+        exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi,
+        expand_complex)
 from sympy.utilities.pytest import XFAIL
 
 def test_complex():
@@ -139,8 +140,13 @@ def test_real_imag():
     a = Symbol('a', real=True)
     assert (2*a*x).as_real_imag() == (2*a*re(x), 2*a*im(x))
 
-@XFAIL
-def test_issue_1724():
-    from sympy import S
-    a = S("(-29/54 + 93**(1/2)/18)**(1/3)")
-    assert a.conjugate().evalf() == a.evalf().conjugate()
+def test_pow_issue_1724():
+    e = ((-1)**(S(1)/3))
+    assert e.conjugate().n() == e.n().conjugate()
+    e = S('-2/3 - (-29/54 + sqrt(93)/18)**(1/3) - 1/(9*(-29/54 + sqrt(93)/18)**(1/3))')
+    assert e.conjugate().n() == e.n().conjugate()
+    e = 2**I
+    assert e.conjugate().n() == e.n().conjugate()
+
+def test_issue_2330():
+    assert sqrt(I).conjugate() != sqrt(I)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1268,7 +1268,3 @@ def test_equals():
 @XFAIL
 def test_equals_factorial():
     assert factorial(x + 1).diff(x).equals(((x + 1)*factorial(x)).diff(x))
-
-@XFAIL
-def test_issue_2330():
-    assert sqrt(I).conjugate() != sqrt(I)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -578,10 +578,9 @@ def test_powers():
     # Test that this is fast
     assert integer_nthroot(2,10**10) == (1, False)
 
-@slow
-def test_integer_nthroot():
-    assert integer_nthroot(10**(500*500), 500) == (10**500, True)
-    assert integer_nthroot(10**1000000, 100000) == (10**10, True)
+def test_integer_nthroot_overflow():
+    assert integer_nthroot(10**(50*50), 50) == (10**50, True)
+    assert integer_nthroot(10**100000, 10000) == (10**10, True)
 
 def test_powers_Integer():
     """Test Integer._eval_power"""

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,7 @@ from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
                    Number, zoo, log, Mul, Pow, Tuple, round)
 from sympy.core.power import integer_nthroot
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, slow
 
 from sympy.core.numbers import igcd, ilcm, igcdex, seterr, _intcache
 from sympy.utilities.pytest import raises
@@ -577,6 +577,11 @@ def test_powers():
 
     # Test that this is fast
     assert integer_nthroot(2,10**10) == (1, False)
+
+@slow
+def test_integer_nthroot():
+    assert integer_nthroot(10**(500*500), 500) == (10**500, True)
+    assert integer_nthroot(10**1000000, 100000) == (10**10, True)
 
 def test_powers_Integer():
     """Test Integer._eval_power"""

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -4,28 +4,28 @@ from sympy import (Symbol, Wild, sin, cos, exp, sqrt, pi, Function, Derivative,
 from sympy.utilities.pytest import XFAIL
 
 def test_subs():
-    n3=Rational(3)
-    x=Symbol("x")
-    e=x
-    e=e.subs(x,n3)
+    n3 = Rational(3)
+    x = Symbol("x")
+    e = x
+    e = e.subs(x,n3)
     assert e == Rational(3)
 
-    e=2*x
+    e = 2*x
     assert e == 2*x
-    e=e.subs(x,n3)
+    e = e.subs(x,n3)
     assert e == Rational(6)
 
 def test_trigonometric():
     x = Symbol('x')
     n3 = Rational(3)
-    e=(sin(x)**2).diff(x)
+    e = (sin(x)**2).diff(x)
     assert e == 2*sin(x)*cos(x)
-    e=e.subs(x,n3)
+    e = e.subs(x,n3)
     assert e == 2*cos(n3)*sin(n3)
 
-    e=(sin(x)**2).diff(x)
+    e = (sin(x)**2).diff(x)
     assert e == 2*sin(x)*cos(x)
-    e=e.subs(sin(x),cos(x))
+    e = e.subs(sin(x),cos(x))
     assert e == 2*cos(x)**2
 
     assert exp(pi).subs(exp, sin) == 0
@@ -138,14 +138,15 @@ def test_issue643():
 
 def test_subs_dict1():
     x, y = symbols('x y')
-    assert (1+x*y).subs(x, pi) == 1 + pi*y
-    assert (1+x*y).subs({x:pi, y:2}) == 1 + 2*pi
-    c2,c3,q1p,q2p,c1,s1,s2,s3= symbols('c2 c3 q1p q2p c1 s1 s2 s3')
-    test=c2**2*q2p*c3 + c1**2*s2**2*q2p*c3 + s1**2*s2**2*q2p*c3 \
-        - c1**2*q1p*c2*s3 - s1**2*q1p*c2*s3
-    assert test.subs({c1**2 : 1-s1**2, c2**2 : 1-s2**2, c3**3: 1-s3**2}) \
-        == c3*q2p*(1 - s2**2) + c3*q2p*s2**2*(1 - s1**2) - c2*q1p*s3*(1 - s1**2) \
-        + c3*q2p*s1**2*s2**2 - c2*q1p*s3*s1**2
+    assert (1 + x*y).subs(x, pi) == 1 + pi*y
+    assert (1 + x*y).subs({x:pi, y:2}) == 1 + 2*pi
+
+    c2,c3,q1p,q2p,c1,s1,s2,s3 = symbols('c2 c3 q1p q2p c1 s1 s2 s3')
+    test = (c2**2*q2p*c3 + c1**2*s2**2*q2p*c3 + s1**2*s2**2*q2p*c3
+            - c1**2*q1p*c2*s3 - s1**2*q1p*c2*s3)
+    assert (test.subs({c1**2 : 1-s1**2, c2**2 : 1-s2**2, c3**3: 1-s3**2})
+        == c3*q2p*(1 - s2**2) + c3*q2p*s2**2*(1 - s1**2)
+            - c2*q1p*s3*(1 - s1**2) + c3*q2p*s1**2*s2**2 - c2*q1p*s3*s1**2)
 
 def test_mul():
     x, y, z, a, b, c = symbols('x,y,z,a,b,c')
@@ -169,13 +170,11 @@ def test_mul():
     assert (x**3*A).subs(x**2*A, a) == a*x
     assert (x**2*A*B).subs(x**2*B, a) == a*A
     assert (x**2*A*B).subs(x**2*A, a) == a*B
-    assert (b*A**3/(a**3*c**3)).subs(a**4*c**3*A**3/b**4, z) == \
-            b*A**3/(a**3*c**3)
+    assert (b*A**3/(a**3*c**3)).subs(a**4*c**3*A**3/b**4, z) == b*A**3/(a**3*c**3)
     assert (6*x).subs(2*x, y) == 3*y
     assert (y*exp(3*x/2)).subs(y*exp(x), 2) == 2*exp(x/2)
     assert (y*exp(3*x/2)).subs(y*exp(x), 2) == 2*exp(x/2)
-    assert (A**2*B*A**2*B*A**2).subs(A*B*A, C) == \
-            A*C**2*A
+    assert (A**2*B*A**2*B*A**2).subs(A*B*A, C) == A*C**2*A
     assert (x*A**3).subs(x*A, y) == y*A**2
     assert (x**2*A**3).subs(x*A, y) == y**2*A
     assert (x*A**3).subs(x*A, B) == B*A**2
@@ -187,11 +186,9 @@ def test_mul():
     assert (-I*a*b).subs(a*b, 2) == -2*I
 
 def test_subs_simple():
-    # Define symbols
     a = symbols('a', commutative=True)
     x = symbols('x', commutative=False)
 
-    """ SIMPLE TESTS """
     assert (2*a ).subs(1,3) == 2*a
     assert (2*a ).subs(2,3) == 3*a
     assert (2*a ).subs(a,3) == 6
@@ -205,11 +202,9 @@ def test_subs_simple():
     assert sin(x).subs(x,3) == sin(3)
 
 def test_subs_constants():
-    # Define symbols
     a,b = symbols('a b', commutative=True)
     x,y = symbols('x y', commutative=False)
 
-    """ CONSTANTS TESTS """
     assert (a*b  ).subs(2*a,1) == a*b
     assert (1.5*a*b).subs(a,1) == 1.5*b
     assert (2*a*b).subs(2*a,1) == b
@@ -221,10 +216,8 @@ def test_subs_constants():
     assert (2*x*y).subs(4*x,1) == 2*x*y
 
 def test_subs_commutative():
-    # Define symbols
     a,b,c,d,K = symbols('a b c d K', commutative=True)
 
-    """ COMMUTATIVE TESTS """
     assert (a*b    ).subs(a*b,K) == K
     assert (a*b*a*b).subs(a*b,K) == K**2
     assert (a*a*b*b).subs(a*b,K) == K**2
@@ -236,29 +229,25 @@ def test_subs_commutative():
     assert (a**3*b**2*a).subs(a*b,K) == a**2*K**2
 
 def test_subs_noncommutative():
-    # Define symbols
     w,x,y,z,L = symbols('w x y z L', commutative=False)
 
-    """ NONCOMMUTATIVE TESTS """
-    assert (x*y    ).subs(x*y,L) == L
-    assert (w*y*x  ).subs(x*y,L) == w*y*x
-    assert (w*x*y*z).subs(x*y,L) == w*L*z
-    assert (x*y*x*y).subs(x*y,L) == L**2
-    assert (x*x*y  ).subs(x*y,L) == x*L
-    assert (x*x*y*y).subs(x*y,L) == x*L*y
-    assert (w*x*y  ).subs(x*y*z,L) == w*x*y
-    assert (x*y**z     ).subs(x,L) == L*y**z
-    assert (x*y**z     ).subs(y,L) == x*L**z
-    assert (x*y**z     ).subs(z,L) == x*y**L
-    assert (w*x*y*z*x*y).subs(x*y*z,L) == w*L*x*y
-    assert (w*x*y*y*w*x*x*y*x*y*y*x*y).subs(x*y,L) == w*L*y*w*x*L**2*y*L
+    assert (x*y).subs(x*y, L) == L
+    assert (w*y*x).subs(x*y, L) == w*y*x
+    assert (w*x*y*z).subs(x*y, L) == w*L*z
+    assert (x*y*x*y).subs(x*y, L) == L**2
+    assert (x*x*y).subs(x*y, L) == x*L
+    assert (x*x*y*y).subs(x*y, L) == x*L*y
+    assert (w*x*y).subs(x*y*z, L) == w*x*y
+    assert (x*y**z).subs(x, L) == L*y**z
+    assert (x*y**z).subs(y, L) == x*L**z
+    assert (x*y**z).subs(z, L) == x*y**L
+    assert (w*x*y*z*x*y).subs(x*y*z, L) == w*L*x*y
+    assert (w*x*y*y*w*x*x*y*x*y*y*x*y).subs(x*y, L) == w*L*y*w*x*L**2*y*L
 
 def test_subs_basic_funcs():
-    # Define symbols
     a,b,c,d,K = symbols('a b c d K', commutative=True)
     w,x,y,z,L = symbols('w x y z L', commutative=False)
 
-    """ OTHER OPERATION TESTS"""
     assert (x+y  ).subs(x+y,L) == L
     assert (x-y  ).subs(x-y,L) == L
     assert (x/y  ).subs(x,L) == L/y
@@ -274,13 +263,11 @@ def test_subs_basic_funcs():
 def test_subs_basic_funcs_division_bug():
     # Fails because of division
     a,b,c,K = symbols('a b c K', commutative=True)
-    assert (a/(b*c)).subs(b*c,K) == a/K
+    assert (a/(b*c)).subs(b*c, K) == a/K
 
 def test_subs_wild():
-    # Define symbols
-    R = Wild('R'); S = Wild('S'); T = Wild('T'); U = Wild('U')
+    R,S,T,U = Wild('R'), Wild('S'), Wild('T'), Wild('U')
 
-    """ WILD TESTS """
     assert (R*S ).subs(R*S,T) == T
     assert (S*R ).subs(R*S,T) == T
     assert (R+S ).subs(R+S,T) == T
@@ -291,30 +278,32 @@ def test_subs_wild():
     assert (R*S**T).subs(T,U) == R*S**U
 
 def test_subs_mixed():
-    # Define symbols
     a,b,c,d,K = symbols('a b c d K', commutative=True)
     w,x,y,z,L = symbols('w x y z L', commutative=False)
     R,S,T,U = Wild('R'), Wild('S'), Wild('T'), Wild('U')
 
-    """ MIXED TESTS """
-    assert (    a*x*y     ).subs(x*y,L) == a*L
-    assert (  a*b*x*y*x   ).subs(x*y,L) == a*b*L*x
+    assert (a*x*y).subs(x*y,L) == a*L
+    assert (a*b*x*y*x).subs(x*y,L) == a*b*L*x
     assert (R*x*y*exp(x*y)).subs(x*y,L) == R*L*exp(L)
-    assert (     a*x*y*y*x-x*y*z*exp(a*b)   ).subs(x*y,L) == a*L*y*x-L*z*exp(a*b)
-    assert (c*y*x*y*x**(R*S-a*b)-T*(a*R*b*S)).subs(x*y,L).subs(a*b,K).subs(R*S,U) == c*y*L*x**(U-K)-T*(U*K)
+    assert (a*x*y*y*x - x*y*z*exp(a*b)).subs(x*y,L) == a*L*y*x - L*z*exp(a*b)
+    assert (c*y*x*y*x**(R*S - a*b) - T*(a*R*b*S)).subs(x*y,L).subs(a*b,K).subs(R*S,U) == c*y*L*x**(U-K)-T*(U*K)
 
 def test_division():
     a,b,c = symbols('a b c', commutative=True)
     x,y,z = symbols('x y z', commutative=True)
-    assert (    1/a   ).subs(a,c)  == 1/c
-    assert (   1/a**2 ).subs(a,c)  == 1/c**2
-    assert (   1/a**2 ).subs(a,-2) == Rational(1,4)
-    assert ( -(1/a**2)).subs(a,-2) == -Rational(1,4)
 
-    assert (    1/x   ).subs(x,z)  == 1/z
-    assert (   1/x**2 ).subs(x,z)  == 1/z**2
-    assert (   1/x**2 ).subs(x,-2) == Rational(1,4)
-    assert ( -(1/x**2)).subs(x,-2) == -Rational(1,4)
+    assert (1/a).subs(a, c)  == 1/c
+    assert (1/a**2).subs(a, c)  == 1/c**2
+    assert (1/a**2).subs(a, -2) == Rational(1,4)
+    assert (-(1/a**2)).subs(a, -2) == -Rational(1,4)
+
+    assert (1/x).subs(x, z)  == 1/z
+    assert (1/x**2).subs(x, z)  == 1/z**2
+    assert (1/x**2).subs(x, -2) == Rational(1,4)
+    assert (-(1/x**2)).subs(x, -2) == -Rational(1,4)
+
+    #issue 2261
+    assert (1/x).subs(x, 0) == 1/S(0)
 
 def test_add():
     a, b, c, d, x, y, t = symbols('a,b,c,d,x,y,t')
@@ -393,8 +382,3 @@ def test_no_arith_subs_on_floats():
 
     (x + y + 3.0).subs(x + 3.0, a) == a + y
     (x + y + 3.0).subs(x + 2.0, a) == x + y + 3.0
-
-@XFAIL
-def test_issue_2261() :
-    x = Symbol("x")
-    assert (1/x).subs(x, 0) == 1/S(0)

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -266,7 +266,7 @@ def test_subs_basic_funcs_division_bug():
     assert (a/(b*c)).subs(b*c, K) == a/K
 
 def test_subs_wild():
-    R,S,T,U = Wild('R'), Wild('S'), Wild('T'), Wild('U')
+    R, S, T, U = symbols('R, S, T, U', cls=Wild)
 
     assert (R*S ).subs(R*S,T) == T
     assert (S*R ).subs(R*S,T) == T
@@ -280,7 +280,7 @@ def test_subs_wild():
 def test_subs_mixed():
     a,b,c,d,K = symbols('a b c d K', commutative=True)
     w,x,y,z,L = symbols('w x y z L', commutative=False)
-    R,S,T,U = Wild('R'), Wild('S'), Wild('T'), Wild('U')
+    R, S, T, U = symbols('R, S, T, U', cls=Wild)
 
     assert (a*x*y).subs(x*y,L) == a*L
     assert (a*b*x*y*x).subs(x*y,L) == a*b*L*x

--- a/sympy/slow_tests/test_core.py
+++ b/sympy/slow_tests/test_core.py
@@ -1,5 +1,0 @@
-from sympy import integer_nthroot
-
-def test_integer_nthroot():
-    assert integer_nthroot(10**(500*500), 500) == (10**500, True)
-    assert integer_nthroot(10**1000000, 100000) == (10**10, True)


### PR DESCRIPTION
This removes 3 xpassing tests and kills the directory `sympy/slow_tests/`, which is rather useless now that we have `@slow`.
