### PR TITLE
(Try to) fix issue 3014

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -391,4 +391,4 @@ def print_mathml(expr, **settings):
 
     """
     s = MathMLPrinter(settings)
-    print s._print(sympify(expr)).toprettyxml()
+    print s._print(sympify(expr)).toprettyxml(),


### PR DESCRIPTION
The mathml printer already adds a newline to the end of the output, so the
print statement in print_mathml should have a , at the end.  Based on the
error from that issue, I think this might fix the problem (though I won't know
for sure until Tom tests it, as I cannot reproduce it myself).

@ness needs to test this to see if it works.
