### PR TITLE
3101: handle Mul.flatten assertion case for (-1)**e

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -426,11 +426,10 @@ class Mul(AssocOp):
             if p.is_Number:
                 coeff *= p
             else:
-                if p.is_Mul:
-                    c, p = p.args
-                    coeff *= c
-                    assert p.is_Pow and p.base is S.NegativeOne
-                    neg1e = p.args[1]
+                c, p = p.as_coeff_Mul()
+                coeff *= c
+                if p.is_Pow and p.base is S.NegativeOne:
+                    neg1e = p.exp
                 for e, b in pnew.iteritems():
                     if e == neg1e and b.is_positive:
                         pnew[e] = -b
@@ -497,7 +496,7 @@ class Mul(AssocOp):
         coeff, b = b.as_coeff_Mul()
         bc, bnc = b.args_cnc()
 
-        bnc = Pow(Mul._from_args(bnc), e, evaluate=False)
+        bnc = Pow(Mul._from_args(bnc), e, evaluate=False) if bnc else S.One
         if e.is_Number:
             if e.is_Integer:
                 # (a*b)**2 -> a**2 * b**2

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -146,6 +146,8 @@ class Mul(AssocOp):
         coeff = S.One       # standalone term
                             # e.g. 3 * ...
 
+        iu = []             # ImaginaryUnits, I
+
         c_powers = []       # (base,exp)      n
                             # e.g. (x,n) for x
 
@@ -216,6 +218,10 @@ class Mul(AssocOp):
                 coeff = S.ComplexInfinity
                 continue
 
+            elif o is S.ImaginaryUnit:
+                iu.append(o)
+                continue
+
             elif o.is_commutative:
                 #      e
                 # o = b
@@ -244,7 +250,7 @@ class Mul(AssocOp):
                     elif b.is_positive or e.is_integer:
                         num_exp.append((b, e))
                         continue
-                c_powers.append((b,e))
+                c_powers.append((b, e))
 
             # NON-COMMUTATIVE
             # TODO: Make non-commutative exponents not combine automatically
@@ -282,6 +288,18 @@ class Mul(AssocOp):
                     else:
                         nc_part.append(o1)
                         nc_part.append(o)
+
+        # handle the ImaginaryUnits
+        if iu:
+            if len(iu) == 1:
+                c_powers.append((iu[0], S.One))
+            else:
+                # iu = [I, -1, -I, 1][len(iu) % 4]
+                niu = len(iu) % 4
+                if niu % 2:
+                    c_powers.append((S.ImaginaryUnit, S.One))
+                if niu in (2, 3):
+                    coeff = -coeff
 
         # We do want a combined exponent if it would not be an Add, such as
         #  y    2y     3y

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -294,7 +294,10 @@ class Mul(AssocOp):
             if len(iu) == 1:
                 c_powers.append((iu[0], S.One))
             else:
-                # iu = [I, -1, -I, 1][len(iu) % 4]
+                # a product of I's has one of 4 values; select that value
+                # based on the length of iu:
+                # len(iu) % 4 of (0, 1, 2, 3) has a corresponding value of
+                #                (1, I,-1,-I)
                 niu = len(iu) % 4
                 if niu % 2:
                     c_powers.append((S.ImaginaryUnit, S.One))

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -107,6 +107,9 @@ class Pow(Expr):
 
     def _eval_power(self, other):
         b, e = self.as_base_exp()
+        ##could process e.is_integer here; for now it's in powdenest
+        #if e.is_integer:
+        #    return Pow(b, e * other)
         if other.is_integer:
             return Pow(b, e * other)
         if b.is_nonnegative and (e.is_real or other.is_real):

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -165,9 +165,34 @@ def test_pow3():
 def test_pow_issue417():
     assert 4**Rational(1, 4) == sqrt(2)
 
-def test_issue_3101():
-    assert (-2*I)**Rational(5,3) == 2*2**Rational(2, 3)*I
-    assert (-I)**Rational(4,3) is S.One
+def test_pow_im():
+    for m in (-2, -1, 2):
+        for d in (3, 4, 5):
+            b = m*I
+            for i in range(1, 4*d + 1):
+                e = Rational(i, d)
+                assert (b**e - b.n()**e.n()).n(2, chop=1e-10) == 0
+
+    e = Rational(7, 3)
+    assert (2*x*I)**e == 4*2**Rational(1, 3)*(I*x)**e # same as Wolfram Alpha
+    im = symbols('im', imaginary=True)
+    assert (2*im*I)**e == 4*2**Rational(1, 3)*(I*im)**e
+
+    args = [I, I, I, I, 2]
+    e = Rational(1, 3)
+    ans = 2**e
+    assert Mul(*args, evaluate=False)**e == ans
+    assert Mul(*args)**e == ans
+    args = [I, I, I, 2]
+    e = Rational(1, 3)
+    ans = -(-1)**Rational(5, 6)*2**e
+    assert Mul(*args, evaluate=False)**e == ans
+    assert Mul(*args)**e == ans
+    args = [I, I, 2]
+    e = Rational(1, 3)
+    ans = (-2)**e
+    assert Mul(*args, evaluate=False)**e == ans
+    assert Mul(*args)**e == ans
 
 def test_expand():
     p = Rational(5)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -158,12 +158,16 @@ def test_pow2():
     assert (-x)**Rational(2,3) != x**Rational(2,3)
     assert (-x)**Rational(5,7) != -x**Rational(5,7)
 
-def test_pow_issue417():
-    assert 4**Rational(1, 4) == sqrt(2)
-
 def test_pow3():
     assert sqrt(2)**3 == 2 * sqrt(2)
     assert sqrt(2)**3 == sqrt(8)
+
+def test_pow_issue417():
+    assert 4**Rational(1, 4) == sqrt(2)
+
+def test_issue_3101():
+    assert (-2*I)**Rational(5,3) == 2*2**Rational(2, 3)*I
+    assert (-I)**Rational(4,3) is S.One
 
 def test_expand():
     p = Rational(5)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -181,17 +181,17 @@ def test_pow_im():
     args = [I, I, I, I, 2]
     e = Rational(1, 3)
     ans = 2**e
-    assert Mul(*args, evaluate=False)**e == ans
+    assert Mul(*args, **dict(evaluate=False))**e == ans
     assert Mul(*args)**e == ans
     args = [I, I, I, 2]
     e = Rational(1, 3)
     ans = -(-1)**Rational(5, 6)*2**e
-    assert Mul(*args, evaluate=False)**e == ans
+    assert Mul(*args, **dict(evaluate=False))**e == ans
     assert Mul(*args)**e == ans
     args = [I, I, 2]
     e = Rational(1, 3)
     ans = (-2)**e
-    assert Mul(*args, evaluate=False)**e == ans
+    assert Mul(*args, **dict(evaluate=False))**e == ans
     assert Mul(*args)**e == ans
 
 def test_expand():

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1563,16 +1563,10 @@ def _denest_pow(eq):
     if glogb.func is C.log or not glogb.is_Mul:
         if glogb.args[0].is_Pow or glogb.args[0].func is exp:
             glogb = _denest_pow(glogb.args[0])
-            c = glogb.exp.as_coeff_mul()[0]
-            ok = c.p != 1
-            if ok:
-                ok = c.q != 1
-                if not ok:
-                    n, d = glogb.exp.as_numer_denom()
-                    ok = d is not S.One and any(di.is_integer for di in Mul.make_args(d))
-            if ok:
-                return Pow(Pow(glogb.base, glogb.exp/c.p), c.p*e)
+            if (abs(glogb.exp) < 1) is True:
+                return Pow(glogb.base, glogb.exp*e)
         return eq
+
     # the log(b) was a Mul so join any adds with logcombine
     add= []
     other = []
@@ -1588,10 +1582,9 @@ def powdenest(eq, force=False, polar=False):
     Collect exponents on powers as assumptions allow.
 
     Given (bb**be)**e, this can be simplified as follows:
-
-    - if bb is positive or e is an integer, bb**(be*e)
-    - if be has an integer in the denominator, then
-      all integers from its numerator can be joined with e
+        o if bb is positive, or
+        o e is an integer, or
+        o |be| < 1 then this simplifies to bb**(be*e)
 
     Given a product of powers raised to a power, (bb1**be1 * bb2**be2...)**e,
     simplification can be done as follows:
@@ -1621,7 +1614,7 @@ def powdenest(eq, force=False, polar=False):
     >>> from sympy import Symbol, exp, log, sqrt, symbols, powdenest
 
     >>> powdenest((x**(2*a/3))**(3*x))
-    (x**(a/3))**(6*x)
+    (x**(2*a/3))**(3*x)
     >>> powdenest(exp(3*x*log(2)))
     2**(3*x)
 
@@ -1664,7 +1657,7 @@ def powdenest(eq, force=False, polar=False):
     p**(6*a*x*y)
 
     >>> powdenest(((x**(2*a/3))**(3*y/i))**x)
-    ((x**(a/3))**(y/i))**(6*x)
+    ((x**(2*a/3))**(3*y/i))**x
     >>> powdenest((x**(2*i)*y**(4*i))**z, force=True)
     (x*y**2)**(2*i*z)
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -696,9 +696,9 @@ def test_powdenest():
     i, j = symbols('i,j', integer=True)
 
     assert powdenest(x) == x
-    assert powdenest(x + 2*(x**(2*a/3))**(3*x)) == x + 2*(x**(a/3))**(6*x)
+    assert powdenest(x + 2*(x**(2*a/3))**(3*x)) == (x + 2*(x**(2*a/3))**(3*x))
     assert powdenest((exp(2*a/3))**(3*x)) == (exp(a/3))**(6*x)
-    assert powdenest((x**(2*a/3))**(3*x)) == (x**(a/3))**(6*x)
+    assert powdenest((x**(2*a/3))**(3*x)) == ((x**(2*a/3))**(3*x))
     assert powdenest(exp(3*x*log(2))) == 2**(3*x)
     assert powdenest(sqrt(p**2)) == p
     i, j = symbols('i,j', integer=True)
@@ -710,7 +710,7 @@ def test_powdenest():
     assert powdenest(exp(3*(log(a) + log(b)))) == a**3*b**3
     assert powdenest(((x**(2*i))**(3*y))**x) == ((x**(2*i))**(3*y))**x
     assert powdenest(((x**(2*i))**(3*y))**x, force=True) == x**(6*i*x*y)
-    assert powdenest(((x**(2*a/3))**(3*y/i))**x) == ((x**(a/3))**(y/i))**(6*x)
+    assert powdenest(((x**(2*a/3))**(3*y/i))**x) == (((x**(2*a/3))**(3*y/i))**x)
     assert powdenest((x**(2*i)*y**(4*i))**z, force=True) == (x*y**2)**(2*i*z)
     assert powdenest((p**(2*i)*q**(4*i))**j) == (p*q**2)**(2*i*j)
     assert powdenest(((p**(2*a))**(3*y))**x) == p**(6*a*x*y)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -447,9 +447,9 @@ def test_checking():
 def test_issue_1572_1364_1368():
     assert solve((sqrt(x**2 - 1) - 2)) in ([sqrt(5), -sqrt(5)],
                                            [-sqrt(5), sqrt(5)])
-    assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == \
-        [-sqrt(x)*sqrt(-log(log(2)) + log(log(2) + I*pi)),
-          sqrt(x)*sqrt(-log(log(2)) + log(log(2) + I*pi))]
+    assert solve((2**exp(y**2/x) + 2)/(x**2 + 15), y) == [
+        -sqrt(x*(-log(log(2)) + log(log(2) + I*pi))),
+         sqrt(x*(-log(log(2)) + log(log(2) + I*pi)))]
 
     C1, C2 = symbols('C1 C2')
     f = Function('f')


### PR DESCRIPTION
This is the case that failed the assertion:

``` py
>>> b, e=(-2*I),Rational(5,3)
>>> (b**e).n(2),(b.n()**e.n()).n(2)
(3.2*I, -8.9e-16 + 3.2*I)
```

There were several other related problems so I added individual commits. That can be reviewed independently.
