### PR TITLE
Fourier name

### DIFF
--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -307,7 +307,7 @@ def mellin_transform(f, x, s, **hints):
     For all "sensible" functions, this converges absolutely in a strip
       `a < Re(s) < b`.
 
-    The mellin transform is related via change of variables to the fourier
+    The mellin transform is related via change of variables to the Fourier
     transform, and also to the (bilateral) laplace transform.
 
     This function returns (F, (a, b), cond)
@@ -1218,11 +1218,11 @@ def inverse_laplace_transform(F, s, t, plane=None, **hints):
 @_noconds_(True)
 def _fourier_transform(f, x, k, a, b, name, simplify=True):
     """
-    Compute a general fourier-type transform
+    Compute a general Fourier-type transform
         F(k) = a int_-oo^oo exp(b*I*x*k) f(x) dx.
 
-    For suitable choice of a and b, this reduces to the standard fourier
-    and inverse fourier transforms.
+    For suitable choice of a and b, this reduces to the standard Fourier
+    and inverse Fourier transforms.
     """
     from sympy import exp, I, oo
     F = integrate(a*f*exp(b*I*x*k), (x, -oo, oo))
@@ -1240,7 +1240,7 @@ def _fourier_transform(f, x, k, a, b, name, simplify=True):
     return _simplify(F, simplify), cond
 
 class FourierTypeTransform(IntegralTransform):
-    """ Base class for fourier transforms.
+    """ Base class for Fourier transforms.
         Specify cls._a and cls._b.
     """
 
@@ -1257,11 +1257,11 @@ class FourierTypeTransform(IntegralTransform):
 
 class FourierTransform(FourierTypeTransform):
     """
-    Class representing unevaluated fourier transforms.
+    Class representing unevaluated Fourier transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
 
-    For how to compute fourier transforms, see the :func:`fourier_transform`
+    For how to compute Fourier transforms, see the :func:`fourier_transform`
     docstring.
     """
 
@@ -1271,7 +1271,7 @@ class FourierTransform(FourierTypeTransform):
 
 def fourier_transform(f, x, k, **hints):
     r"""
-    Compute the unitary, ordinary-frequency fourier transform of `f`, defined
+    Compute the unitary, ordinary-frequency Fourier transform of `f`, defined
     as
 
     .. math:: F(k) = \int_{-\infty}^\infty f(x) e^{-2\pi i x k} \mathrm{d} x.
@@ -1279,7 +1279,7 @@ def fourier_transform(f, x, k, **hints):
     If the transform cannot be computed in closed form, this
     function returns an unevaluated FourierTransform object.
 
-    For other fourier transform conventions, see the function
+    For other Fourier transform conventions, see the function
     :func:`sympy.integrals.transforms._fourier_transform`.
 
     For a description of possible hints, refer to the docstring of
@@ -1305,11 +1305,11 @@ def fourier_transform(f, x, k, **hints):
 
 class InverseFourierTransform(FourierTypeTransform):
     """
-    Class representing unevaluated inverse fourier transforms.
+    Class representing unevaluated inverse Fourier transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
 
-    For how to compute inverse fourier transforms, see the
+    For how to compute inverse Fourier transforms, see the
     :func:`inverse_fourier_transform` docstring.
     """
 
@@ -1319,7 +1319,7 @@ class InverseFourierTransform(FourierTypeTransform):
 
 def inverse_fourier_transform(F, k, x, **hints):
     r"""
-    Compute the unitary, ordinary-frequency inverse fourier transform of `F`,
+    Compute the unitary, ordinary-frequency inverse Fourier transform of `F`,
     defined as
 
     .. math:: f(x) = \int_{-\infty}^\infty F(k) e^{2\pi i x k} \mathrm{d} k.
@@ -1327,7 +1327,7 @@ def inverse_fourier_transform(F, k, x, **hints):
     If the transform cannot be computed in closed form, this
     function returns an unevaluated InverseFourierTransform object.
 
-    For other fourier transform conventions, see the function
+    For other Fourier transform conventions, see the function
     :func:`sympy.integrals.transforms._fourier_transform`.
 
     For a description of possible hints, refer to the docstring of

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -201,7 +201,7 @@ def _default_integrator(f, x):
 
 @_noconds
 def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
-    """ Backend function to compute mellin transforms. """
+    """ Backend function to compute Mellin transforms. """
     from sympy import re, Max, Min, count_ops
     # We use a fresh dummy, because assumptions on s might drop conditions on
     # convergence of the integral.
@@ -267,11 +267,11 @@ def _mellin_transform(f, x, s_, integrator=_default_integrator, simplify=True):
 
 class MellinTransform(IntegralTransform):
     """
-    Class representing unevaluated mellin transforms.
+    Class representing unevaluated Mellin transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
 
-    For how to compute mellin transforms, see the :func:`mellin_transform`
+    For how to compute Mellin transforms, see the :func:`mellin_transform`
     docstring.
     """
 
@@ -300,18 +300,18 @@ class MellinTransform(IntegralTransform):
 
 def mellin_transform(f, x, s, **hints):
     r"""
-    Compute the mellin transform `F(s)` of `f(x)`,
+    Compute the Mellin transform `F(s)` of `f(x)`,
 
     .. math :: F(s) = \int_0^\infty x^{s-1} f(x) \mathrm{d}x.
 
     For all "sensible" functions, this converges absolutely in a strip
       `a < Re(s) < b`.
 
-    The mellin transform is related via change of variables to the Fourier
+    The Mellin transform is related via change of variables to the Fourier
     transform, and also to the (bilateral) Laplace transform.
 
     This function returns (F, (a, b), cond)
-    where `F` is the mellin transform of `f`, `(a, b)` is the fundamental strip
+    where `F` is the Mellin transform of `f`, `(a, b)` is the fundamental strip
     (as above), and cond are auxiliary convergence conditions.
 
     If the integral cannot be computed in closed form, this function returns
@@ -384,11 +384,11 @@ class MellinTransformStripError(ValueError):
 def _rewrite_gamma(f, s, a, b):
     """
     Try to rewrite the product f(s) as a product of gamma functions,
-    so that the inverse mellin transform of f can be expressed as a meijer
+    so that the inverse Mellin transform of f can be expressed as a meijer
     G function.
 
     Return (an, ap), (bm, bq), arg, exp, fac such that
-    G((an, ap), (bm, bq), arg/z**exp)*fac is the inverse mellin transform of f(s).
+    G((an, ap), (bm, bq), arg/z**exp)*fac is the inverse Mellin transform of f(s).
 
     Raises IntegralTransformError or MellinTransformStripError on failure.
 
@@ -724,11 +724,11 @@ def _inverse_mellin_transform(F, s, x_, strip, as_meijerg=False):
 _allowed = None
 class InverseMellinTransform(IntegralTransform):
     """
-    Class representing unevaluated inverse mellin transforms.
+    Class representing unevaluated inverse Mellin transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
 
-    For how to compute inverse mellin transforms, see the
+    For how to compute inverse Mellin transforms, see the
     :func:`inverse_mellin_transform` docstring.
     """
 
@@ -776,7 +776,7 @@ class InverseMellinTransform(IntegralTransform):
 
 def inverse_mellin_transform(F, s, x, strip, **hints):
     r"""
-    Compute the inverse mellin transform of `F(s)` over the fundamental
+    Compute the inverse Mellin transform of `F(s)` over the fundamental
     strip given by ``strip=(a, b)``.
 
     This can be defined as
@@ -785,7 +785,7 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     for any `c` in the fundamental strip. Under certain regularity
     conditions on `F` and/or `f`,
-    this recovers `f` from its mellin transform `F`
+    this recovers `f` from its Mellin transform `F`
     (and vice versa), for positive real `x`.
 
     One of `a` or `b` may be passed as None; a suitable `c` will be

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -308,7 +308,7 @@ def mellin_transform(f, x, s, **hints):
       `a < Re(s) < b`.
 
     The mellin transform is related via change of variables to the Fourier
-    transform, and also to the (bilateral) laplace transform.
+    transform, and also to the (bilateral) Laplace transform.
 
     This function returns (F, (a, b), cond)
     where `F` is the mellin transform of `f`, `(a, b)` is the fundamental strip
@@ -908,7 +908,7 @@ def _simplifyconds(expr, s, a):
 
 @_noconds
 def _laplace_transform(f, t, s_, simplify=True):
-    """ The backend function for laplace transforms. """
+    """ The backend function for Laplace transforms. """
     from sympy import (re, Max, exp, pi, Abs, Min, periodic_argument as arg,
                        cos, Wild, symbols, polar_lift)
     s = Dummy('s')
@@ -998,11 +998,11 @@ def _laplace_transform(f, t, s_, simplify=True):
 
 class LaplaceTransform(IntegralTransform):
     """
-    Class representing unevaluated laplace transforms.
+    Class representing unevaluated Laplace transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
 
-    For how to compute laplace transforms, see the :func:`laplace_transform`
+    For how to compute Laplace transforms, see the :func:`laplace_transform`
     docstring.
     """
 
@@ -1016,10 +1016,10 @@ class LaplaceTransform(IntegralTransform):
         return Integral(f*exp(-s*t), (t, 0, oo))
 
     """
-    Class representing unevaluated laplace transforms.
+    Class representing unevaluated Laplace transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
-    For how to compute laplace transforms, see the :func:`laplace_transform`
+    For how to compute Laplace transforms, see the :func:`laplace_transform`
     docstring.
     """
     def _collapse_extra(self, extra):
@@ -1045,7 +1045,7 @@ def laplace_transform(f, t, s, **hints):
     half plane  `a < Re(s)`.
 
     This function returns (F, a, cond)
-    where `F` is the laplace transform of `f`, `Re(s) > a` is the half-plane
+    where `F` is the Laplace transform of `f`, `Re(s) > a` is the half-plane
     of convergence, and cond are auxiliary convergence conditions.
 
     If the integral cannot be computed in closed form, this function returns
@@ -1069,7 +1069,7 @@ def laplace_transform(f, t, s, **hints):
 
 @_noconds_(True)
 def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
-    """ The backend function for inverse laplace transforms. """
+    """ The backend function for inverse Laplace transforms. """
     from sympy import exp, Heaviside, log, expand_complex, Integral, Piecewise
     from sympy.integrals.meijerint import meijerint_inversion, _get_coeff_exp
     # There are two strategies we can try:
@@ -1137,11 +1137,11 @@ def _inverse_laplace_transform(F, s, t_, plane, simplify=True):
 
 class InverseLaplaceTransform(IntegralTransform):
     """
-    Class representing unevaluated inverse laplace transforms.
+    Class representing unevaluated inverse Laplace transforms.
 
     For usage of this class, see the :class:`IntegralTransform` docstring.
 
-    For how to compute inverse laplace transforms, see the
+    For how to compute inverse Laplace transforms, see the
     :func:`inverse_laplace_transform` docstring.
     """
 
@@ -1173,7 +1173,7 @@ class InverseLaplaceTransform(IntegralTransform):
 
 def inverse_laplace_transform(F, s, t, plane=None, **hints):
     r"""
-    Compute the inverse laplace transform of `F(s)`, defined as
+    Compute the inverse Laplace transform of `F(s)`, defined as
 
     .. math :: f(t) = \int_{c-i\infty}^{c+i\infty} e^{st} F(s) \mathrm{d}s,
 


### PR DESCRIPTION
Fixed the spelling of the names Fourier, Laplace and Mellin.
