### PR TITLE
2558: coeff(x, e) selects coeff of x**e

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -856,19 +856,19 @@ def test_extractions():
 
 def test_coeff():
     assert (x+1).coeff(x+1) == 1
-    assert (3*x).coeff(0) == None
+    assert (3*x).coeff(0) == 0
     assert (z*(1+x)*x**2).coeff(1+x) == z*x**2
     assert (1+2*x*x**(1+x)).coeff(x*x**(1+x)) == 2
     assert (1+2*x**(y+z)).coeff(x**(y+z)) == 2
-    assert (3+2*x+4*x**2).coeff(1) == None
-    assert (3+2*x+4*x**2).coeff(-1) == None
+    assert (3+2*x+4*x**2).coeff(1) == 0
+    assert (3+2*x+4*x**2).coeff(-1) == 0
     assert (3+2*x+4*x**2).coeff(x) == 2
     assert (3+2*x+4*x**2).coeff(x**2) == 4
-    assert (3+2*x+4*x**2).coeff(x**3) == None
+    assert (3+2*x+4*x**2).coeff(x**3) == 0
 
     assert (-x/8 + x*y).coeff(x) == -S(1)/8 + y
     assert (-x/8 + x*y).coeff(-x) == S(1)/8
-    assert (4*x).coeff(2*x) == None
+    assert (4*x).coeff(2*x) == 0
     assert (2*x).coeff(2*x) == 1
     assert (-oo*x).coeff(x*oo) == -1
 
@@ -878,8 +878,8 @@ def test_coeff():
     assert (n1*n2 + x*n1).coeff(n1) == 1 # 1*n1*(n2+x)
     assert (n2*n1 + x*n1).coeff(n1) == n2 + x
     assert (n2*n1 + x*n1**2).coeff(n1) == n2
-    assert (n1**x).coeff(n1) == None
-    assert (n1*n2 + n2*n1).coeff(n1) == None
+    assert (n1**x).coeff(n1) == 0
+    assert (n1*n2 + n2*n1).coeff(n1) == 0
     assert (2*(n1+n2)*n2).coeff(n1+n2, right=1) == n2
     assert (2*(n1+n2)*n2).coeff(n1+n2, right=0) == 2
 
@@ -889,39 +889,39 @@ def test_coeff():
     expr = z*(x+y)**2
     expr2 = z*(x+y)**2 + z*(2*x + 2*y)**2
     assert expr.coeff(z) == (x+y)**2
-    assert expr.coeff(x+y) == None
+    assert expr.coeff(x+y) == 0
     assert expr2.coeff(z) == (x+y)**2 + (2*x + 2*y)**2
 
     assert (x + y + 3*z).coeff(1) == x + y
     assert (-x + 2*y).coeff(-1) == x
     assert (x - 2*y).coeff(-1) == 2*y
-    assert (3 + 2*x + 4*x**2).coeff(1) == None
+    assert (3 + 2*x + 4*x**2).coeff(1) == 0
     assert (-x - 2*y).coeff(2) == -y
     assert (x + sqrt(2)*x).coeff(sqrt(2)) == x
     assert (3 + 2*x + 4*x**2).coeff(x) ==  2
     assert (3 + 2*x + 4*x**2).coeff(x**2) == 4
-    assert (3 + 2*x + 4*x**2).coeff(x**3) == None
+    assert (3 + 2*x + 4*x**2).coeff(x**3) == 0
     assert (z*(x + y)**2).coeff((x + y)**2) == z
-    assert (z*(x + y)**2).coeff(x + y) == None
+    assert (z*(x + y)**2).coeff(x + y) == 0
     assert (2 + 2*x + (x + 1)*y).coeff(x + 1) == y
 
     assert (x + 2*y + 3).coeff(1) == x
     assert (x + 2*y + 3).coeff(x, 0) == 2*y + 3
     assert (x**2 + 2*y + 3*x).coeff(x**2, 0) == 2*y + 3*x
-    assert x.coeff(0, 0) == None
-    assert x.coeff(x, 0) == None
+    assert x.coeff(0, 0) == 0
+    assert x.coeff(x, 0) == 0
 
     n, m, o, l = symbols('n m o l', commutative=False)
     assert n.coeff(n) ==  1
-    assert y.coeff(n) == None
+    assert y.coeff(n) == 0
     assert (3*n).coeff(n) == 3
-    assert (2 + n).coeff(x*m) == None
+    assert (2 + n).coeff(x*m) == 0
     assert (2*x*n*m).coeff(x) == 2*n*m
-    assert (2 + n).coeff(x*m*n + y) == None
-    assert (2*x*n*m).coeff(3*n) == None
+    assert (2 + n).coeff(x*m*n + y) == 0
+    assert (2*x*n*m).coeff(3*n) == 0
     assert (n*m + m*n*m).coeff(n) == 1 + m
     assert (n*m + m*n*m).coeff(n, right=True) == m # = (1 + m)*n*m
-    assert (n*m + m*n).coeff(n) == None
+    assert (n*m + m*n).coeff(n) == 0
     assert (n*m + o*m*n).coeff(m*n) == o
     assert (n*m + o*m*n).coeff(m*n, right=1) == 1
     assert (n*m + n*m*n).coeff(n*m, right=1) == 1 + n # = n*m*(n + 1)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -906,8 +906,10 @@ def test_coeff():
     assert (2 + 2*x + (x + 1)*y).coeff(x + 1) == y
 
     assert (x + 2*y + 3).coeff(1) == x
-    assert (x + 2*y + 3).coeff(x, 0) == 3
-    assert (x + 2*y + 3).coeff(0, 0) == 3
+    assert (x + 2*y + 3).coeff(x, 0) == 2*y + 3
+    assert (x**2 + 2*y + 3*x).coeff(x**2, 0) == 2*y + 3*x
+    assert x.coeff(0, 0) == None
+    assert x.coeff(x, 0) == None
 
     n, m, o, l = symbols('n m o l', commutative=False)
     assert n.coeff(n) ==  1

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -901,9 +901,13 @@ def test_coeff():
     assert (3 + 2*x + 4*x**2).coeff(x) ==  2
     assert (3 + 2*x + 4*x**2).coeff(x**2) == 4
     assert (3 + 2*x + 4*x**2).coeff(x**3) == None
-    assert (z*(x + y)**2).coeff((x+y)**2) == z
-    assert (z*(x + y)**2).coeff(x+y) == None
-    assert (2 + 2*x + (x+1)*y).coeff(x+1) == y
+    assert (z*(x + y)**2).coeff((x + y)**2) == z
+    assert (z*(x + y)**2).coeff(x + y) == None
+    assert (2 + 2*x + (x + 1)*y).coeff(x + 1) == y
+
+    assert (x + 2*y + 3).coeff(1) == x
+    assert (x + 2*y + 3).coeff(x, 0) == 3
+    assert (x + 2*y + 3).coeff(0, 0) == 3
 
     n, m, o, l = symbols('n m o l', commutative=False)
     assert n.coeff(n) ==  1

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -178,7 +178,7 @@ class exp(ExpBase):
                 return S.NaN
 
             coeff = arg.coeff(S.Pi*S.ImaginaryUnit)
-            if coeff is not None:
+            if coeff:
                 if (2*coeff).is_integer:
                     if coeff.is_even:
                         return S.One

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -761,8 +761,8 @@ def classify_ode(eq, func=None, dict=False, prep=True):
             u = Dummy('u')
             ind, dep = (reduced_eq + u).as_independent(f)
             ind, dep = [tmp.subs(u, 0) for tmp in [ind, dep]]
-        r = {a: dep.coeff(df) or S.Zero, # if we get None for coeff, take 0
-             b: dep.coeff(f(x)) or S.Zero, # ditto
+        r = {a: dep.coeff(df),
+             b: dep.coeff(f(x)),
              c: ind}
         # double check f[a] since the preconditioning may have failed
         if not r[a].has(f) and (r[a]*df + r[b]*f(x) + r[c]).expand() - reduced_eq == 0:


### PR DESCRIPTION
e defaults to 1; the constant in an Add is only
selected if e == 0

```
>>> (x + 2*y + 3).coeff(1)
x
>>> (x + 2*y + 3).coeff(x, 0)
3
>>> (x + 2*y + 3).coeff(0, 0)
3
>>> (x + 2*y + 3).coeff(y, 1)
2
```
