### PR TITLE
Refactor ExprCondPair

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -31,10 +31,6 @@ class ExprCondPair(Tuple):
         return self.args[1]
 
     @property
-    def is_commutative(self):
-        return self.expr.is_commutative
-
-    @property
     def free_symbols(self):
         """
         Return the free symbols of this pair.
@@ -166,6 +162,10 @@ class Piecewise(Function):
                     c = c.doit(**hints)
             newargs.append((e, c))
         return Piecewise(*newargs)
+
+    @property
+    def is_commutative(self):
+        return all(expr.is_commutative for expr, _ in self.args)
 
     def _eval_integral(self,x):
         from sympy.integrals import integrate

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -134,8 +134,6 @@ def test_piecewise_solve():
     g = Piecewise(((x - 5)**5, x >= 2), (f, True), (10, False))
     assert solve(g, x) == [5]
 
-    assert solve(Piecewise((x, x < 0), (x, -1))) == [0]
-
 # See issue 1253 (enhance the solver to handle inequalities).
 @XFAIL
 def test_piecewise_solve2():

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -339,7 +339,7 @@ def _find_splitting_points(expr, x):
     from sympy import Tuple
     p, q = map(lambda n: Wild(n, exclude=[x]), 'pq')
     def compute_innermost(expr, res):
-        if expr.func is Tuple:
+        if isinstance(expr, Tuple):
             return
         m = expr.match(p*x+q)
         if m and m[p] != 0:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -925,17 +925,13 @@ def _solve(f, *symbols, **flags):
         result = set()
         for expr, cond in f.args:
             candidates = _solve(expr, *symbols)
-            if isinstance(cond, bool) or cond.is_Number:
-                if not cond:
-                    continue
-
+            if cond is True:
                 # Only include solutions that do not match the condition
                 # of any of the other pieces.
                 for candidate in candidates:
                     matches_other_piece = False
                     for other_expr, other_cond in f.args:
-                        if isinstance(other_cond, bool) \
-                            or other_cond.is_Number:
+                        if other_cond is True:
                             continue
                         if bool(other_cond.subs(symbol, candidate)):
                             matches_other_piece = True


### PR DESCRIPTION
A few small changes to simplify Piecewise by trying to get rid of ExprCondPair incrementally. The 2nd commit also implements args canonicalisation as discussed in [issue 3025](http://code.google.com/p/sympy/issues/detail?id=3025). 

This has to go in before #1009, but shouldn't interfere too badly with it, since #1009 removes ExprCondPair in one go in its first commit.
