### PR TITLE
Faster algorithm for inversion in Permutation

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -887,6 +887,14 @@ don\'t match.")
 
         An inversion is where i > j but p[i] < p[j].
 
+        For small length of p, it iterates over all i and j
+        values and calculates the number of inversions.
+        For large length of p, it uses a variation of merge
+        sort to calculate the number of inversions.
+        References
+        =========
+        [1] http://www.cp.eng.chula.ac.th/~piak/teaching/algo/algo2008/count-inv.htm
+
         Examples
         ========
 
@@ -894,6 +902,8 @@ don\'t match.")
         >>> p = Permutation([0,1,2,3,4,5])
         >>> p.inversions()
         0
+        >>> Permutation([3,2,1,0]).inversions()
+        6
 
         See Also
         ========
@@ -902,11 +912,26 @@ don\'t match.")
         inversions = 0
         a = self.array_form
         n = len(a)
-        for i in xrange(n - 1):
-            b = a[i]
-            for j in xrange(i + 1, n):
-                if b > a[j]:
-                    inversions += 1
+        if n < 130:
+            for i in xrange(n - 1):
+                b = a[i]
+                for c in a[i + 1:]:
+                    if b > c:
+                        inversions += 1
+        else:
+            k = 1
+            right = 0
+            arr = a[:]
+            temp = a[:]
+            while k < n:
+                i = 0
+                while i + k < n:
+                    right = i + k * 2 - 1
+                    if right >= n:
+                        right = n -1
+                    inversions += _merge(arr, temp, i, i+k, right)
+                    i = i + k * 2;
+                k = k * 2
         return inversions
 
     def conjugate(self, x):
@@ -1603,3 +1628,35 @@ def _new_from_array_form(perm):
     p = Basic.__new__(Permutation, perm)
     p._array_form = perm
     return p
+
+def _merge(arr, temp, left, mid, right):
+    """
+    Helper function for calculating inversions.This method is
+    for internal use only.
+    Merges two sorted arrays and calculates the inversion count.
+    """
+    i = left
+    j = mid
+    k = left
+    inv_count = 0
+    while i < mid and j <= right:
+        if arr[i] < arr[j]:
+            temp[k] = arr[i]
+            k += 1
+            i += 1
+        else:
+            temp[k] = arr[j]
+            k += 1
+            j += 1
+            inv_count += (mid -i)
+    while i < mid:
+        temp[k] = arr[i]
+        k += 1
+        i += 1
+    if j <= right:
+        k += right - j + 1
+        j += right - j + 1
+        arr[left:k + 1] = temp[left:k + 1]
+    else:
+        arr[left:right + 1] = temp[left:right + 1]
+    return inv_count

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -44,6 +44,7 @@ def test_Permutation():
     assert Permutation.from_inversion_vector(p.inversion_vector()) == p
     assert Permutation.from_inversion_vector(q.inversion_vector()).array_form\
            == q.array_form
+    assert Permutation([i for i in range(500,-1,-1)]).inversions() == 125250
 
     assert Permutation([0, 4, 1, 3, 2]).parity() == 0
     assert Permutation([0, 1, 4, 3, 2]).parity() == 1


### PR DESCRIPTION
I have implemented a faster algorithm for inversion if the length of the permutation array is greater than 100. The performance of the new algorithm compared to the old one is as follows :
## Code 

``` python

a = Permutation([i for i in range(100, -1, -1)])
t = time()
r = a.array_form
print _merge_count(r[:], r[:], 0, len(r)-1)
print time()-t
b = Permutation([i for i in range(100, -1, -1)])
t = time()
print b.inversions()
print time()-t
```
## Output

```
5050
0.000481843948364
5050
0.000545978546143
```

For 100 numbers, the improvement is not significant. Running the same for 500 numbers, the results are as follows:
## Code

``` python

a = Permutation([i for i in range(500, -1, -1)])
t = time()
r = a.array_form
print _merge_count(r[:], r[:], 0, len(r)-1)
print time()-t
b = Permutation([i for i in range(500, -1, -1)])
t = time()
print b.inversions()
print time()-t
```
## Output

```
125250
0.00265789031982
125250
0.0123178958893
```

Its 5x faster for input length of 500.

Running it for 1000 length array gives an 10x improvement. As the length of the array increases the performance is better.
The algorithm is based on merge sort.
Ref : http://www.cp.eng.chula.ac.th/~piak/teaching/algo/algo2008/count-inv.htm 
