### PR TITLE
allow Pow, exp, log to answer is_rational if possible

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -656,6 +656,18 @@ class Pow(Expr):
         else:
             return True
 
+    def _eval_is_rational(self):
+        p = self.func(*self.as_base_exp()) # in case it's unevaluated
+        if not p.is_Pow:
+            return p.is_rational
+        b, e = p.as_base_exp()
+        if e.is_Rational and b.is_Rational:
+            # we didn't check that e is not an Integer
+            # because Rational**Integer autosimplifies
+            return False
+        if e.is_integer:
+            return b.is_rational
+
     def _eval_is_rational_function(self, syms):
         if self.exp.has(*syms):
             return False

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,6 +1,6 @@
 from sympy.core import Symbol, S, Rational, Integer
 from sympy.utilities.pytest import raises, XFAIL
-from sympy import I, sqrt
+from sympy import I, sqrt, log, exp
 
 def test_symbol_unset():
     x = Symbol('x',real=True, integer=True)
@@ -508,3 +508,28 @@ def test_Add_is_pos_neg():
     assert (n + p).is_negative is None
     assert (n + x).is_negative is True
     assert (p + x).is_negative is False
+
+def test_special_is_rational():
+    i = Symbol('i', integer=True)
+    r = Symbol('r', rational=True)
+    x = Symbol('x')
+    assert sqrt(3).is_rational is False
+    assert (3+sqrt(3)).is_rational is False
+    assert (3*sqrt(3)).is_rational is False
+    assert exp(3).is_rational is False
+    assert exp(i).is_rational is False
+    assert exp(r).is_rational is False
+    assert exp(x).is_rational is None
+    assert exp(log(3), evaluate=False).is_rational is True
+    assert log(exp(3), evaluate=False).is_rational is True
+    assert log(3).is_rational is False
+    assert log(i).is_rational is False
+    assert log(r).is_rational is False
+    assert log(x).is_rational is None
+    assert (sqrt(3) + sqrt(5)).is_rational is None
+    assert (sqrt(3) + S.Pi).is_rational is None
+    assert (x**i).is_rational is None
+    assert (i**i).is_rational is True
+    assert (r**i).is_rational is True
+    assert (r**r).is_rational is None
+    assert (r**x).is_rational is None

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -67,6 +67,15 @@ class ExpBase(Function):
                 return False
         if arg.is_bounded:
             return True
+
+    def _eval_is_rational(self):
+        s = self.func(*self.args)
+        if s.func == self.func:
+            if s.args[0].is_rational:
+                return False
+        else:
+            return s.is_rational
+
     def _eval_is_zero(self):
         return (self.args[0] is S.NegativeInfinity)
 
@@ -582,6 +591,14 @@ class log(Function):
     def _eval_expand_complex(self, deep=True, **hints):
         re_part, im_part = self.as_real_imag(deep=deep, **hints)
         return re_part + im_part*S.ImaginaryUnit
+
+    def _eval_is_rational(self):
+        s = self.func(*self.args)
+        if s.func == self.func:
+            if s.args[0].is_rational:
+                return False
+        else:
+            return s.is_rational
 
     def _eval_is_real(self):
         return self.args[0].is_positive


### PR DESCRIPTION
http://planetmath.org/encyclopedia/TheoryOfRationalAndIrrationalNumbers.html
says the following about combinations of Rational and irrational numbers:

```
    the sum, difference, product and quotient of two non-zero real numbers,
    from which one is rational and the other irrational, is irrational.
```

With this change, SymPy appears to be able to follow such conventions with
the existing assumptions system and avoids answering that expressions
involving more than 1 surd are irrational.
