### PR TITLE
1809: extract additively succeeds if coeff move towards zero

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1720,13 +1720,8 @@ class Expr(Basic, EvalfMixin):
            >>> (x+1).extract_additively(x)
            1
 
-           >>> (x+1).extract_additively(2*x)
-
-           >>> (x+1).extract_additively(-x)
-           2*x + 1
-
-           >>> (-x+1).extract_additively(2*x)
-           -3*x + 1
+           >>> (x+1).extract_additively(2*x) is None
+           True
 
         """
         c = sympify(c)
@@ -1736,60 +1731,50 @@ class Expr(Basic, EvalfMixin):
             return S.Zero
         elif self is S.Zero:
             return None
-        elif c.is_Add:
-            x = self.extract_additively(c.as_two_terms()[0])
-            if x != None:
-                return x.extract_additively(c.as_two_terms()[1])
-        sub = self - c
+
         if self.is_Number:
-            if self.is_Integer:
-                if not sub.is_Integer:
-                    return None
-                elif self.is_positive and sub.is_negative:
-                    return None
-                else:
-                    return sub
-            elif self.is_Rational:
-                if not sub.is_Rational:
-                    return None
-                elif self.is_positive and sub.is_negative:
-                    return None
-                else:
-                    return sub
-            elif self.is_Float:
-                if not sub.is_Float:
-                    return None
-                elif self.is_positive and sub.is_negative:
-                    return None
-                else:
-                    return sub
-        elif self.is_NumberSymbol or self.is_Symbol or self is S.ImaginaryUnit:
-            if sub.is_Mul and len(sub.args) == 2:
-                if sub.args[0].is_Integer and sub.args[0].is_positive and sub.args[1] == self:
-                    return sub
-            elif sub.is_Integer:
-                return sub
-        elif self.is_Add:
-            terms = self.as_two_terms()
-            subs0 = terms[0].extract_additively(c)
-            if subs0 != None:
-                return subs0 + terms[1]
-            else:
-                subs1 = terms[1].extract_additively(c)
-                if subs1 != None:
-                    return subs1 + terms[0]
-        elif self.is_Mul:
-            self_coeff, self_terms = self.as_coeff_Mul(rational=True)
-            if c.is_Mul:
-                c_coeff, c_terms = c.as_coeff_Mul(rational=True)
-                if c_terms == self_terms:
-                    new_coeff = self_coeff.extract_additively(c_coeff)
-                    if new_coeff != None:
-                        return new_coeff * c_terms
-            elif c == self_terms:
-                new_coeff = self_coeff.extract_additively(1)
-                if new_coeff != None:
-                    return new_coeff * c
+            if not c.is_Number:
+                return None
+            co = self
+            diff = co - c
+            # XXX should we match types? i.e should 3 - .1 succeed?
+            if (co > 0 and diff > 0 and diff < co or
+                co < 0 and diff < 0 and diff > co):
+                return diff
+            return None
+
+        if c.is_Number:
+            co, t = self.as_coeff_Add()
+            xa = co.extract_additively(c)
+            if xa is None:
+                return None
+            return xa + t
+
+        if c.is_Add and c.args[0].is_Number:
+            h, t = c.as_coeff_Add()
+            sh, st = self.as_coeff_Add()
+            xa = sh.extract_additively(h)
+            if xa is None:
+                return None
+            xa2 = st.extract_additively(t)
+            if xa2 is None:
+                return None
+            return xa + xa2
+
+        coeffs = []
+        for a in Add.make_args(c):
+            ac, at = a.as_coeff_Mul()
+            co = self.coeff(at)
+            if not co:
+                return None
+            coc, cot = co.as_coeff_Add()
+            xa = coc.extract_additively(ac)
+            if xa is None:
+                return None
+            self -= co*at
+            coeffs.append((cot + xa)*at)
+        coeffs.append(self)
+        return Add(*coeffs)
 
     def could_extract_minus_sign(self):
         """Canonical way to choose an element in the set {e, -e} where

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1707,23 +1707,19 @@ class Expr(Basic, EvalfMixin):
                     return self.base ** (new_exp)
 
     def extract_additively(self, c):
-        """Return None if it's not possible to make self in the form
-           something + c in a nice way, i.e. preserving the properties
-           of arguments of self.
+        """Return self - c if it's possible to subtract c from self such
+        that all term coefficients move towards zero, else return None.
 
-           >>> from sympy import symbols
-
-           >>> x, y = symbols('x,y', real=True)
-
-           >>> ((x*y)**3).extract_additively(1)
-
-           >>> (x+1).extract_additively(x)
-           1
-
-           >>> (x+1).extract_additively(2*x) is None
-           True
+        >>> from sympy import S
+        >>> from sympy.abc import x, y
+        >>> e = 2*x + 3
+        >>> e.extract_additively(x + 1)
+        x + 2
+        >>> e.extract_additively(3*x)
+        >>> e.extract_additively(4)
 
         """
+
         c = sympify(c)
         if c is S.Zero:
             return self

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -850,6 +850,15 @@ def test_extractions():
         4*a*x + 3*x + y
     assert ((a + 1)*x*4 + 3*y).extract_additively(x + 2*y).expand() == \
         4*a*x + 3*x + y
+    assert (y*(x + 1)).extract_additively(x + 1) is None
+    assert ((y + 1)*(x + 1) + 3).extract_additively(x + 1) == \
+        y*(x + 1) + 3
+    assert ((x + y)*(x + 1) + x + y + 3).extract_additively(x + y) == \
+        x*(x + y) + 3
+    assert (x + y + 2*((x + y)*(x + 1)) + 3).extract_additively((x + y)*(x + 1)) == \
+        x + y + (x + 1)*(x + y) + 3
+    assert ((y + 1)*(x + 2*y + 1) + 3).extract_additively(y + 1) == \
+        (x + 2*y)*(y + 1) + 3
 
     n = Symbol("n", integer=True)
     assert (Integer(-3)).could_extract_minus_sign() == True

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -819,22 +819,39 @@ def test_as_coeff_exponent():
     assert fx.as_coeff_exponent(f(x)) == (fx ,0)
 
 def test_extractions():
-    n = Symbol("n", integer=True)
     assert ((x*y)**3).extract_multiplicatively(x**2 * y) == x*y**2
     assert ((x*y)**3).extract_multiplicatively(x**4 * y) == None
     assert (2*x).extract_multiplicatively(2) == x
     assert (2*x).extract_multiplicatively(3) == None
     assert (2*x).extract_multiplicatively(-1) == None
-    assert (Rational(1,2)*x).extract_multiplicatively(3) == x/6
+    assert (Rational(1, 2)*x).extract_multiplicatively(3) == x/6
     assert (sqrt(x)).extract_multiplicatively(x) == None
-    assert (sqrt(x)).extract_multiplicatively(1/x) == sqrt(x)**3
+    assert (sqrt(x)).extract_multiplicatively(1/x) == None
 
     assert ((x*y)**3).extract_additively(1) == None
-    assert (x+1).extract_additively(x) == 1
-    assert (x+1).extract_additively(2*x) == None
-    assert (x+1).extract_additively(-x) == 1+2*x
-    assert (-x+1).extract_additively(2*x) == 1-3*x
+    assert (x + 1).extract_additively(x) == 1
+    assert (x + 1).extract_additively(2*x) == None
+    assert (x + 1).extract_additively(-x) == None
+    assert (-x + 1).extract_additively(2*x) == None
+    assert (2*x + 3).extract_additively(x) == x + 3
+    assert (2*x + 3).extract_additively(2) == 2*x + 1
+    assert (2*x + 3).extract_additively(3) == 2*x
+    assert (2*x + 3).extract_additively(-2) == None
+    assert (2*x + 3).extract_additively(3*x) == None
+    assert (2*x + 3).extract_additively(2*x) == 3
+    assert x.extract_additively(0) == x
+    assert S(2).extract_additively(x) is None
+    assert S(2.).extract_additively(2) == S.Zero
+    assert S(2*x + 3).extract_additively(x + 1) == x + 2
+    assert S(2*x + 3).extract_additively(y + 1) is None
+    assert S(2*x - 3).extract_additively(x + 1) is None
+    assert S(2*x - 3).extract_additively(y + z) is None
+    assert ((a + 1)*x*4 + y).extract_additively(x).expand() == \
+        4*a*x + 3*x + y
+    assert ((a + 1)*x*4 + 3*y).extract_additively(x + 2*y).expand() == \
+        4*a*x + 3*x + y
 
+    n = Symbol("n", integer=True)
     assert (Integer(-3)).could_extract_minus_sign() == True
     assert (-n*x+x).could_extract_minus_sign() != (n*x-x).could_extract_minus_sign()
     assert (x-y).could_extract_minus_sign() != (-x+y).could_extract_minus_sign()

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2975,7 +2975,7 @@ def _logcombine(expr, force=False):
         retval = Equality(_logcombine(expr.lhs-expr.rhs, force),\
         Integer(0))
         # If logcombine couldn't do much with the equality, try to make it like
-        # it was.  Hopefully extract_additively won't become smart enought to
+        # it was.  Hopefully extract_additively won't become smart enough to
         # take logs apart :)
         right = retval.lhs.extract_additively(expr.lhs)
         if right:


### PR DESCRIPTION
Although I don't think it was clearly stated nor tested, the intent
of extract_additively is to see if something can be subtracted so as
to move an expression closer to zero. Anything can be subtracted from
anything; what makes extraction unique is when the expression moves
towards 0, so

```
>>> (x + 2).extract_additively(x + 1)
1
>>> (x + 2).extract_additively(x + 3) is None
True
```
