### PR TITLE
Trailing tabs

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2923,10 +2923,10 @@ def ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match
     return _solve_variation_of_parameters(eq, func, order, match)
 
 def _solve_variation_of_parameters(eq, func, order, match):
-    """	  	
+    """
     Helper function for the method of variation of parameters.
 
-    See the ode_nth_linear_constant_coeff_variation_of_parameters() 	
+    See the ode_nth_linear_constant_coeff_variation_of_parameters()
     docstring for more information on this method.
 
     match should be a dictionary that has the following keys:
@@ -2950,7 +2950,7 @@ def _solve_variation_of_parameters(eq, func, order, match):
         wr = simplify(wr) # We need much better simplification for some ODEs.
         #                   See issue 1563, for example.
 
-        # To reduce commonly occuring sin(x)**2 + cos(x)**2 to 1  	
+        # To reduce commonly occuring sin(x)**2 + cos(x)**2 to 1
         wr = trigsimp(wr, deep=True, recursive=True)
     if not wr:
         # The wronskian will be 0 iff the solutions are not linearly independent.

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -92,7 +92,7 @@ def test_files():
     def test_this_file(fname, test_file):
         line = None # to flag the case where there were no lines in file
         for idx, line in enumerate(test_file):
-            if line.endswith(" \n"):
+            if line.endswith(" \n") or line.endswith("\t\n"):
                 assert False, message_space % (fname, idx+1)
             if line.endswith("\r\n"):
                 assert False, message_carriage % (fname, idx+1)


### PR DESCRIPTION
The code quality checker was not testing for lines with tabs at the end of the line, only spaces.  This fixes that, and corrects ode.py, where this happened a couple of times.
