### PR TITLE
Rewrite coverage doctest

### DIFF
--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -250,11 +250,16 @@ def process_function(name, c_name, b_obj, mod_path, f_sk, f_md, f_mdt, f_idt, f_
     return f_doctest, function
 
 
-def process_class(c_name, obj, c_md, c_mdt, c_idt, c_has_doctest):
+def process_class(c_name, obj, c_sk, c_md, c_mdt, c_idt, c_has_doctest):
 
     """ Extracts information about the class regarding documentation.
     It is assumed that the function calling this subroutine has already
     checked that the class is valid. """
+
+    # Skip class case
+    if c_name.startswith('_'):
+        c_sk.append(c_name)
+        return False, False, None
 
     c = False
     c_dt = False
@@ -340,7 +345,7 @@ def coverage(module_path, verbose=False):
         elif inspect.isclass(obj):
 
             # Process the class first
-            c_dt, c, source = process_class(member, obj, c_md, c_mdt, c_idt, c_has_doctest)
+            c_dt, c, source = process_class(member, obj, c_skipped, c_md, c_mdt, c_idt, c_has_doctest)
             if not c: continue
             else:  classes += 1
             if c_dt: c_doctests += 1

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
     if os.path.isdir(sympy_dir):
         sys.path.insert(0, sympy_top)
 
-    usage = "usage: ./bin/doctest_coverage.py sympy/core"
+    usage = "usage: ./bin/doctest_coverage.py PATH"
 
     parser = OptionParser(
         description = __doc__,

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -64,6 +64,7 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
                 print_header('Indirect doctests', '-')
                 for md in c_idt:
                     print '  * '+md
+                print '\n    Use \"# indirect doctest\" in the docstring to supress this warning'
 
 
         print_header('FUNCTIONS','*')

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -181,9 +181,18 @@ def go(file, verbose=False, exact=True):
     if not os.path.exists(file):
         print "File %s does not exist."%file
         sys.exit(1)
-    # Handle trailing slashes
-    if file[:-1] == '/': file = file[:-1]
-    return coverage(string.replace(file,'/','.')[:-3], verbose)
+
+    # Remove the file extension
+    file, ign = os.path.splitext(file)
+
+    # Replace separators by . for module path
+    file_module = ""
+    h, t = os.path.split(file)
+    while h or t:
+        if t: file_module = t + '.' + file_module
+        h, t = os.path.split(h)
+
+    return coverage(file_module[:-1], verbose)
 
 if __name__ == "__main__":
 
@@ -203,6 +212,7 @@ if __name__ == "__main__":
         parser.print_help()
     else:
         for file in args:
+            file = os.path.normpath(file)
             doctests, num_functions = go(file, options.verbose)
             if num_functions == 0:
                 score = 100

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -36,11 +36,12 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
 
     if verbose:
         print '\n'+'-'*70
-
-    print "%s: %s%% (%s of %s)" % (module_path, score, total_doctests, total_members)
-
-    if verbose:
+        print module_path
         print '-'*70
+    else:
+        print "%s: %s%% (%s of %s)" % (module_path, score, total_doctests, total_members)
+
+
 
 
     if verbose:
@@ -81,6 +82,12 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
                 print_header('Indirect doctests', '-')
                 for md in f_idt:
                     print '  * '+md
+
+    if verbose:
+        print '\n'+'-'*70
+        print "SCORE: %s%% (%s of %s)" % (score, total_doctests, total_members)
+        print '-'*70
+
 
 def _is_indirect(member, doc):
 

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -231,6 +231,11 @@ def coverage(module_path, verbose=False):
                 class_m_obj = getattr(obj, class_m)
                 class_m_mod = inspect.getmodule(class_m_obj)
 
+                # Check for a function
+                if not inspect.isfunction(class_m_obj) and \
+                    not inspect.ismethod(class_m_obj):
+                        continue
+
                 # Method not part of our module
                 if not class_m_mod or not class_m_obj or \
                     not class_m_mod.__name__ == module_path:

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -331,6 +331,15 @@ def coverage(module_path, verbose=False):
     else: score = 0
     score = int(score)
 
+    # Sort functions/classes by line number
+    c_md = sorted(c_md, key = lambda x: int(x.split()[1][:-1]))
+    c_mdt = sorted(c_mdt, key = lambda x: int(x.split()[1][:-1]))
+    c_idt = sorted(c_idt, key = lambda x: int(x.split()[1][:-1]))
+
+    f_md = sorted(f_md, key = lambda x: int(x.split()[1][:-1]))
+    f_mdt = sorted(f_mdt, key = lambda x: int(x.split()[1][:-1]))
+    f_idt = sorted(f_idt, key = lambda x: int(x.split()[1][:-1]))
+
     print_coverage(module_path, classes, c_md, c_mdt, c_idt, functions, f_md, f_mdt, f_idt, score, total_doctests, total_members, verbose)
 
 

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -24,8 +24,36 @@ import string
 import inspect
 from optparse import OptionParser
 
+# Load color templates, used from sympy/utilities/runtests.py
+color_templates = (
+    ("Black"       , "0;30"),
+    ("Red"         , "0;31"),
+    ("Green"       , "0;32"),
+    ("Brown"       , "0;33"),
+    ("Blue"        , "0;34"),
+    ("Purple"      , "0;35"),
+    ("Cyan"        , "0;36"),
+    ("LightGray"   , "0;37"),
+    ("DarkGray"    , "1;30"),
+    ("LightRed"    , "1;31"),
+    ("LightGreen"  , "1;32"),
+    ("Yellow"      , "1;33"),
+    ("LightBlue"   , "1;34"),
+    ("LightPurple" , "1;35"),
+    ("LightCyan"   , "1;36"),
+    ("White"       , "1;37"),  )
+
+colors = {}
+
+for name, value in color_templates:
+    colors[name] = value
+c_normal = '\033[0m'
+c_color = '\033[%sm'
+
+
 
 def print_header(name, underline=None, overline=None):
+
   print
   print name
   if underline: print underline*len(name)
@@ -34,15 +62,19 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
 
     """ Prints details (depending on verbose) of a module """
 
+    if score < 100:
+        score_string = "%s%s%% (%s of %s)%s" % (c_color % (colors["Red"]) \
+           , score , total_doctests, total_members, c_normal)
+    else:
+        score_string = "%s%s%% (%s of %s)%s" % (c_color % (colors["Green"]) \
+           , score , total_doctests, total_members, c_normal)
+
     if verbose:
         print '\n'+'-'*70
         print module_path
         print '-'*70
     else:
-        print "%s: %s%% (%s of %s)" % (module_path, score, total_doctests, total_members)
-
-
-
+        print "%s: %s" % (module_path, score_string)
 
     if verbose:
         print_header('CLASSES', '*')
@@ -86,7 +118,7 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
 
     if verbose:
         print '\n'+'-'*70
-        print "SCORE: %s%% (%s of %s)" % (score, total_doctests, total_members)
+        print "SCORE: %s" % (score_string)
         print '-'*70
 
 
@@ -414,6 +446,13 @@ if __name__ == "__main__":
             score = int(score)
         print
         print '='*70
-        print "TOTAL SCORE for %s: %s%% (%s of %s)" % \
-            (get_mod_name(file, sympy_top), score, doctests, num_functions)
+        if score < 100:
+            print "TOTAL SCORE for %s: %s%s%% (%s of %s)%s" % \
+                (get_mod_name(file, sympy_top), c_color % (colors["Red"]),\
+                score, doctests, num_functions, c_normal)
+        else:
+            print "TOTAL SCORE for %s: %s%s%% (%s of %s)%s" % \
+                (get_mod_name(file, sympy_top), c_color % (colors["Green"]),\
+                score, doctests, num_functions, c_normal)
+
         print

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -32,6 +32,7 @@ def print_header(name, underline=None, overline=None):
 
 def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, score, total_doctests, total_members, verbose=False):
 
+    """ Prints details (depending on verbose) of a module """
 
     if verbose:
         print '\n'+'-'*70
@@ -107,7 +108,7 @@ def coverage(module_path, verbose=False):
         print module_path + ' could not be loaded due to, \"' + a.args[0] + '\"'
         return 0, 0
 
-    # Get the list of members (currently everything possible)
+    # Get the list of members
     m_members = dir(m)
 
 
@@ -136,7 +137,7 @@ def coverage(module_path, verbose=False):
         if not obj_mod or not obj_mod.__name__ == module_path:
           continue
 
-        # If it's a function, simply process it
+        # If it's a function
         if inspect.isfunction(obj) or inspect.ismethod(obj):
             # Various scenarios
             if member.startswith('_'): f_skipped.append(member)
@@ -147,6 +148,7 @@ def coverage(module_path, verbose=False):
                 else:
                     f_doctests = f_doctests + 1
                     f_has_doctest.append(member)
+                    # indirect doctest
                     if _is_indirect(member, obj.__doc__):
                         f_indirect_doctest.append(member)
 
@@ -161,6 +163,7 @@ def coverage(module_path, verbose=False):
             else:
                 c_doctests = c_doctests + 1
                 c_has_doctest.append(member)
+                # indirect doctest
                 if _is_indirect(member, obj.__doc__):
                     c_indirect_doctest.append(member)
 
@@ -178,6 +181,7 @@ def coverage(module_path, verbose=False):
                 except:
                     continue
 
+                # Method not part of our module
                 if not class_m_mod or not class_m_obj or \
                     not class_m_mod.__name__ == module_path:
                     continue
@@ -190,11 +194,13 @@ def coverage(module_path, verbose=False):
                     elif not '>>>' in class_m_obj.__doc__: f_mdt.append(full_name)
                     else:
                         f_has_doctest.append(full_name)
+                        # Indirect doctest
                         if _is_indirect(member, class_m_obj.__doc__):
                             f_indirect_doctest.append(full_name)
                         f_doctests = f_doctests + 1
                     functions = functions + 1
 
+    # Evaluate the percent coverage
     total_doctests = c_doctests + f_doctests
     total_members = classes + functions
     if total_members: score = 100 * float(total_doctests) / (total_members)

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -24,48 +24,37 @@ import string
 import inspect
 from optparse import OptionParser
 
+
+def print_header(name, underline=None):
+  print '\n'+name
+  if underline: print underline*len(name)
+
 def print_coverage(c, c_md, c_mdt, f, f_md, f_mdt):
 
-    # Print routines (can be deported?)
-
-    print
-    print 'CLASSES'
-    print '*'*10
-
+    print_header('CLASSES', '*')
     if not c:
-        print
-        print 'No classes found!\n'
+        print_header('No classes found!')
+
     else:
         if c_md:
-            print
-            print 'Missing docstrings'
-            print '-'*15
+            print_header('Missing docstrings','-')
             for md in c_md:
                print md
         if c_mdt:
-            print
-            print 'Missing doctests'
-            print '-'*15
+            print_header('Missing doctests')
             for md in c_mdt:
                 print md
 
-    print
-    print 'DEFINITIONS'
-    print '*'*10
+    print_header('FUNCTIONS','*')
     if not f:
-        print
-        print 'No functions found!\n'
+        print_header('No functions found!')
     else:
         if f_md:
-            print
-            print 'Missing docstrings'
-            print '-'*15
+            print_header('Missing docstrings', '-')
             for md in f_md:
                print md
         if f_mdt:
-            print
-            print 'Missing doctests'
-            print '-'*15
+            print_header('Missing doctests', '-')
             for md in f_mdt:
                 print md
 
@@ -192,6 +181,8 @@ def go(file, verbose=False, exact=True):
     if not os.path.exists(file):
         print "File %s does not exist."%file
         sys.exit(1)
+    # Handle trailing slashes
+    if file[:-1] == '/': file = file[:-1]
     return coverage(string.replace(file,'/','.')[:-3], verbose)
 
 if __name__ == "__main__":

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -81,9 +81,9 @@ def coverage(module_path, verbose=False):
     try:
         __import__(module_path)
         m = sys.modules[module_path]
-    except:
+    except Exception, a:
         # Most likely cause, absence of __init__
-        print module_path + ' could not be loaded!'
+        print module_path + ' could not be loaded due to, \"' + a.args[0] + '\"'
         return 0, 0
 
     # Get the list of members (currently everything possible)

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -52,15 +52,17 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
             if c_md:
                 print_header('Missing docstrings','-')
                 for md in c_md:
-                   print '\t* '+md
+                   print '  * '+md
             if c_mdt:
                 print_header('Missing doctests','-')
                 for md in c_mdt:
-                    print '\t* '+md
+                    print '  * '+md
             if c_idt:
+                # Use "# indirect doctest" in the docstring to
+                # supress this warning.
                 print_header('Indirect doctests', '-')
                 for md in c_idt:
-                    print '\t* '+md
+                    print '  * '+md
 
 
         print_header('FUNCTIONS','*')
@@ -70,15 +72,15 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
             if f_md:
                 print_header('Missing docstrings', '-')
                 for md in f_md:
-                   print '\t* '+md
+                   print '  * '+md
             if f_mdt:
                 print_header('Missing doctests', '-')
                 for md in f_mdt:
-                    print '\t* '+md
+                    print '  * '+md
             if f_idt:
                 print_header('Indirect doctests', '-')
                 for md in f_idt:
-                    print '\t* '+md
+                    print '  * '+md
 
 def _is_indirect(member, doc):
 
@@ -248,7 +250,7 @@ def coverage(module_path, verbose=False):
         m = sys.modules[module_path]
     except Exception, a:
         # Most likely cause, absence of __init__
-        print module_path + ' could not be loaded due to, \"' + a.args[0] + '\"'
+        print "%s could not be loaded due to %s." % (module_path, repr(a))
         return 0, 0
 
 
@@ -351,6 +353,7 @@ def go(sympy_top, file, verbose=False, exact=True):
         print "File %s does not exist."%file
         sys.exit(1)
 
+    # Relpath for constructing the module name
     return coverage(get_mod_name(file, sympy_top), verbose)
 
 

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -185,11 +185,10 @@ def process_function(name, c_name, b_obj, mod_path, f_sk, f_md, f_mdt, f_idt, f_
             add_md = True
         elif not '>>>' in obj.__doc__:
             add_mdt = True
-        else:
-            # Indirect doctest
-            if _is_indirect(name, obj.__doc__):
+        elif _is_indirect(name, obj.__doc__):
                 add_idt = True
-            f_doctest = True
+        else: f_doctest = True
+
         function = True
 
     if add_md or add_mdt or add_idt:
@@ -229,12 +228,11 @@ def process_class(c_name, obj, c_md, c_mdt, c_idt, c_has_doctest):
     full_name = "LINE %d: %s" % (line_no, c_name)
     if not obj.__doc__: c_md.append(full_name)
     elif not '>>>' in obj.__doc__: c_mdt.append(full_name)
-    else:
+    elif _is_indirect(c_name, obj.__doc__):
+        c_idt.append(full_name)
+    else: # indirect doctest
         c_dt =  True
         c_has_doctest.append(full_name)
-        # indirect doctest
-        if _is_indirect(c_name, obj.__doc__):
-            c_idt.append(full_name)
     return c_dt, c
 
 def coverage(module_path, verbose=False):

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -45,11 +45,55 @@ def _is_skip(module_path, name, obj):
     if inspect.getmodule(obj).__name__ != module_path:
         skip = True
 
-    if skip or name.startswith('_') or \
-        not 'sympy' in filename:
+    if skip or name.startswith('_'):
             skip = True
 
     return skip
+
+def print_coverage(c, c_md, c_mdt, f, f_md, f_mdt):
+
+    # Print routines (can be deported?)
+
+    print
+    print 'CLASSES'
+    print '*'*10
+
+    if not c:
+        print
+        print 'No classes found!\n'
+    else:
+        if c_md:
+            print
+            print 'Missing docstrings'
+            print '-'*15
+            for md in c_md:
+               print md[0]
+        if c_mdt:
+            print
+            print 'Missing doctests'
+            print '-'*15
+            for md in c_mdt:
+                print md[0]
+
+    print
+    print 'DEFINITIONS'
+    print '*'*10
+    if not f:
+        print
+        print 'No functions found!\n'
+    else:
+        if f_md:
+            print
+            print 'Missing docstrings'
+            print '-'*15
+            for md in f_md:
+               print md[0]
+        if f_mdt:
+            print
+            print 'Missing doctests'
+            print '-'*15
+            for md in f_mdt:
+                print md[0]
 
 def coverage(module_path, verbose=False):
 
@@ -74,52 +118,58 @@ def coverage(module_path, verbose=False):
     m_classes = filter(lambda x: inspect.isclass(x[1]), m_members)
     m_functions = filter(lambda x: inspect.isfunction(x[1]), m_members)
 
-    # Iterate over functions first
+
     print
     print '='*70
     print module_path
     print '='*70
 
-    skipped = []
-    missing_docstring = []
-    missing_doctest = []
-    has_doctest = []
-    indirect_doctest = []
+    # Iterate over classes
+    c_skipped = []
+    c_md = []
+    c_mdt = []
+    c_has_doctest = []
+    c_indirect_doctest = []
     classes = 0
 
-    print
-    print 'CLASSES'
-    print '-'*10
     for c in m_classes:
         class_name, class_obj = c[0], c[1]
         # Check if the class needs to be skipped
         skip = _is_skip(module_path, class_name, class_obj)
-        if skip:  skipped.append(c)
+        if skip:  c_skipped.append(c)
         else:   classes = classes + 1
         # Check if the class has docstrings
         if not skip and not class_obj.__doc__:
-             missing_docstring.append(c)
+             c_md.append(c)
         # Check for a docstring
         if not skip and class_obj.__doc__ and \
             not '>>>' in class_obj.__doc__:
-                missing_doctest.append(c)
+                c_mdt.append(c)
 
-    if not classes:
-        print
-        print 'No classes found!\n'
-    else:
-        if missing_docstring:
-            print
-            print 'Missing docstrings'
-            print '*'*15
-            for md in missing_docstring:
-               print md[0]
-        if missing_doctest:
-            print
-            print 'Missing doctests'
-            print '*'*15
-            for md in missing_doctest:
-                print md[0]
+    # Iterate over functions
+    f_skipped = []
+    f_md = []
+    f_mdt = []
+    f_has_doctest = []
+    f_indirect_doctest = []
+    functions = 0
+
+
+    for f in m_functions:
+        f_name, f_obj = f[0], f[1]
+        # Check if the class needs to be skipped
+        skip = _is_skip(module_path, f_name, f_obj)
+        if skip:  f_skipped.append(f)
+        else:   functions = functions + 1
+        # Check if the class has docstrings
+        if not skip and not f_obj.__doc__:
+             f_md.append(f)
+        # Check for a docstring
+        if not skip and f_obj.__doc__ and \
+            not '>>>' in f_obj.__doc__:
+                f_mdt.append(f)
+
+    print_coverage(classes, c_md, c_mdt, functions, f_md, f_mdt)
 
     return 0, 0
 

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -350,7 +350,13 @@ if __name__ == "__main__":
     if os.path.isdir(sympy_dir):
         sys.path.insert(0, sympy_top)
 
-    parser = OptionParser()
+    usage = "usage: ./bin/doctest_coverage.py sympy/core"
+
+    parser = OptionParser(
+        description = __doc__,
+        usage = usage,
+    )
+
     parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
             default=False)
 

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -97,12 +97,14 @@ def _get_arg_list(name, fobj):
     """ Given a function object, constructs a list of arguments
     and their defaults. Takes care of varargs and kwargs """
 
+    trunc = 20 # Sometimes argument length can be huge
+
     argspec = inspect.getargspec(fobj)
 
     arg_list = []
 
     if argspec.args:
-        for arg in argspec.args: arg_list.append(arg)
+        for arg in argspec.args: arg_list.append(str(arg))
 
     arg_list.reverse()
 
@@ -121,15 +123,11 @@ def _get_arg_list(name, fobj):
     if argspec.keywords:
           arg_list.append(argspec.keywords)
 
+    # Truncate long arguments
+    arg_list = map(lambda x: x[:trunc], arg_list)
 
     # Construct the parameter string (enclosed in brackets)
-    if arg_list:
-        str_param = name + '('
-        for arg in arg_list[:-1]:
-            str_param = str_param + arg + ', '
-        str_param = str_param + arg_list[-1] + ')'
-    else:
-        str_param = name + '()'
+    str_param = "%s(%s)" % (name, ', '.join(arg_list))
 
     return str_param
 
@@ -315,7 +313,7 @@ if __name__ == "__main__":
     else:
         for file in args:
             file = os.path.normpath(file)
-            print 'DOCTEST for %s' % (file)
+            print 'DOCTEST COVERAGE for %s' % (file)
             print '='*70
             print
             doctests, num_functions = go(file, options.verbose)

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -115,6 +115,8 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
                 print_header('Indirect doctests', '-')
                 for md in f_idt:
                     print '  * '+md
+                print '\n    Use \"# indirect doctest\" in the docstring to supress this warning'
+
 
     if verbose:
         print '\n'+'-'*70

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -128,7 +128,13 @@ def coverage(module_path, verbose=False):
     functions = 0
     f_doctests = 0
 
+    skip_members = ['__abstractmethods__']
+
     for member in m_members:
+        # Check for skipped functions first, they throw nasty errors
+        # when combined with getattr
+        if member in skip_members: continue
+
         # Identify if the member (class/def) a part of this module
         obj = getattr(m, member)
         obj_mod = inspect.getmodule(obj)
@@ -170,16 +176,16 @@ def coverage(module_path, verbose=False):
             # Iterate through it's members
             for class_m in dir(obj):
 
+                # Check in skip function list
+                if class_m in skip_members: continue
+
                 # Check if the method is a part of this module
                 class_m_mod = None
                 class_m_obj = None
 
                 # Gutsy hack; need to expand reasons
-                try:
-                    class_m_obj = getattr(obj, class_m)
-                    class_m_mod = inspect.getmodule(class_m_obj)
-                except:
-                    continue
+                class_m_obj = getattr(obj, class_m)
+                class_m_mod = inspect.getmodule(class_m_obj)
 
                 # Method not part of our module
                 if not class_m_mod or not class_m_obj or \

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -52,15 +52,15 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
             if c_md:
                 print_header('Missing docstrings','-')
                 for md in c_md:
-                   print md
+                   print '\t* '+md
             if c_mdt:
                 print_header('Missing doctests','-')
                 for md in c_mdt:
-                    print md
-            if f_idt:
+                    print '\t* '+md
+            if c_idt:
                 print_header('Indirect doctests', '-')
-                for md in f_idt:
-                    print md
+                for md in c_idt:
+                    print '\t* '+md
 
 
         print_header('FUNCTIONS','*')
@@ -70,15 +70,15 @@ def print_coverage(module_path, c, c_md, c_mdt, c_idt, f, f_md, f_mdt, f_idt, sc
             if f_md:
                 print_header('Missing docstrings', '-')
                 for md in f_md:
-                   print md
+                   print '\t* '+md
             if f_mdt:
                 print_header('Missing doctests', '-')
                 for md in f_mdt:
-                    print md
+                    print '\t* '+md
             if f_idt:
                 print_header('Indirect doctests', '-')
                 for md in f_idt:
-                    print md
+                    print '\t* '+md
 
 def _is_indirect(member, doc):
 

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -25,38 +25,50 @@ import inspect
 from optparse import OptionParser
 
 
-def print_header(name, underline=None):
-  print '\n'+name
+def print_header(name, underline=None, overline=None):
+  print
+  print name
   if underline: print underline*len(name)
 
-def print_coverage(c, c_md, c_mdt, f, f_md, f_mdt):
+def print_coverage(module_path, c, c_md, c_mdt, f, f_md, f_mdt, score, total_doctests, total_members, verbose=False):
 
-    print_header('CLASSES', '*')
-    if not c:
-        print_header('No classes found!')
 
-    else:
-        if c_md:
-            print_header('Missing docstrings','-')
-            for md in c_md:
-               print md
-        if c_mdt:
-            print_header('Missing doctests')
-            for md in c_mdt:
-                print md
+    if verbose:
+        print '\n'+'-'*70
 
-    print_header('FUNCTIONS','*')
-    if not f:
-        print_header('No functions found!')
-    else:
-        if f_md:
-            print_header('Missing docstrings', '-')
-            for md in f_md:
-               print md
-        if f_mdt:
-            print_header('Missing doctests', '-')
-            for md in f_mdt:
-                print md
+    print "%s: %s%% (%s of %s)" % (module_path, score, total_doctests, total_members)
+
+    if verbose:
+        print '-'*70
+
+
+    if verbose:
+        print_header('CLASSES', '*')
+        if not c:
+            print_header('No classes found!')
+
+        else:
+            if c_md:
+                print_header('Missing docstrings','-')
+                for md in c_md:
+                   print md
+            if c_mdt:
+                print_header('Missing doctests','-')
+                for md in c_mdt:
+                    print md
+
+        print_header('FUNCTIONS','*')
+        if not f:
+            print_header('No functions found!')
+        else:
+            if f_md:
+                print_header('Missing docstrings', '-')
+                for md in f_md:
+                   print md
+            if f_mdt:
+                print_header('Missing doctests', '-')
+                for md in f_mdt:
+                    print md
 
 def coverage(module_path, verbose=False):
 
@@ -76,11 +88,6 @@ def coverage(module_path, verbose=False):
 
     # Get the list of members (currently everything possible)
     m_members = dir(m)
-
-    print
-    print '='*70
-    print module_path
-    print '='*70
 
 
     c_skipped = []
@@ -155,14 +162,13 @@ def coverage(module_path, verbose=False):
 
     total_doctests = c_doctests + f_doctests
     total_members = classes + functions
-    print_coverage(classes, c_md, c_mdt, functions, f_md, f_mdt)
-
     if total_members: score = 100 * float(total_doctests) / (total_members)
     else: score = 0
-
     score = int(score)
-    print '-'*70
-    print "SCORE %s: %s%% (%s of %s)" % (module_path, score, total_doctests, total_members)
+
+    print_coverage(module_path, classes, c_md, c_mdt, functions, f_md, f_mdt, score, total_doctests, total_members, verbose)
+
+
     return total_doctests, total_members
 
 def go(file, verbose=False, exact=True):
@@ -213,6 +219,9 @@ if __name__ == "__main__":
     else:
         for file in args:
             file = os.path.normpath(file)
+            print 'DOCTEST for %s' % (file)
+            print '='*70
+            print
             doctests, num_functions = go(file, options.verbose)
             if num_functions == 0:
                 score = 100

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -371,7 +371,7 @@ def coverage(module_path, verbose=False):
     total_doctests = c_doctests + f_doctests
     total_members = classes + functions
     if total_members: score = 100 * float(total_doctests) / (total_members)
-    else: score = 0
+    else: score = 100
     score = int(score)
 
     # Sort functions/classes by line number
@@ -410,6 +410,7 @@ def go(sympy_top, file, verbose=False, exact=True):
 
 
 if __name__ == "__main__":
+
 
     bintest_dir = os.path.abspath(os.path.dirname(__file__))   # bin/cover...
     sympy_top  = os.path.split(bintest_dir)[0]      # ../

--- a/bin/coverage_doctest.py
+++ b/bin/coverage_doctest.py
@@ -302,7 +302,7 @@ def coverage(module_path, verbose=False):
             if c_dt: c_doctests += 1
 
             # Iterate through it's members
-            for f_name in dir(obj):
+            for f_name in obj.__dict__:
 
                 if f_name in skip_members: continue
 


### PR DESCRIPTION
Current implementation of coverage_doctest.py includes patchy parsing, and is prone to small edge cases (like having a "def" inside a comment/doc etc). Besides there is an outstanding issue by asmeurer at: http://code.google.com/p/sympy/issues/detail?id=2970.

The current implementation takes care of the following:
- Does not depend on parsing, just imports the module in question and uses **import**, inspect, getattr etc to figure out what methods/functions/classes (top level) lie within.
- Uses **doc** to access a member's doc
- Fixes the issue of handling class documentation
