### PR TITLE
TODO: rebase Solution to  "Issue 2328: expand() doesn't parse bad hints correctly "

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2530,7 +2530,8 @@ class Expr(Basic, EvalfMixin):
                 func = getattr(expr, '_eval_expand_'+hint, None)
                 if func is not None:
                     expr = func(deep=deep, **hints)
-                else : raise TypeError('Unknown hint %s' % hint)  # This will now raise TypeError if hint is misspelled
+                else : raise TypeError('Unknown hint %s' % hint)  
+                # This will now raise TypeError if hint in unknown or misspelled
 
         if modulus is not None:
             modulus = sympify(modulus)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2530,8 +2530,9 @@ class Expr(Basic, EvalfMixin):
                 func = getattr(expr, '_eval_expand_'+hint, None)
                 if func is not None:
                     expr = func(deep=deep, **hints)
-                else : raise TypeError('Unknown hint %s' % hint)  
-                # This will now raise TypeError if hint in unknown or misspelled
+                else : 
+                    raise TypeError('Unknown hint %s' % hint)  
+                
 
         if modulus is not None:
             modulus = sympify(modulus)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2530,7 +2530,7 @@ class Expr(Basic, EvalfMixin):
                 func = getattr(expr, '_eval_expand_'+hint, None)
                 if func is not None:
                     expr = func(deep=deep, **hints)
-                else : raise TypeError        # This will now raise TypeError if hint is misspelled
+                else : raise TypeError('Unknown hint %s' % hint)  # This will now raise TypeError if hint is misspelled
 
         if modulus is not None:
             modulus = sympify(modulus)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2530,6 +2530,7 @@ class Expr(Basic, EvalfMixin):
                 func = getattr(expr, '_eval_expand_'+hint, None)
                 if func is not None:
                     expr = func(deep=deep, **hints)
+                else : raise TypeError        # This will now raise TypeError if hint is misspelled
 
         if modulus is not None:
             modulus = sympify(modulus)


### PR DESCRIPTION
TODO: figure out what to do with hints like 'force' which don't select an expansion method so errors are not raised by the mods that have been made here.

Added line 2533 in sympy/core/expr.py

See commit 550e7b8 instead of d9b3f40
