### PR TITLE
added is_square check to is_identity

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3224,6 +3224,8 @@ class MatrixBase(object):
 
     @property
     def is_Identity(self):
+        if not self.is_square:
+            return False
         for i in xrange(self.rows):
             for j in xrange(self.cols):
                 if i==j and self[i,j] != 1:

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2110,6 +2110,8 @@ def test_is_Identity():
     assert eye(3).as_immutable().is_Identity
     assert not zeros(3).is_Identity
     assert not ones(3).is_Identity
+    # issue 3143
+    assert not Matrix([[1,0,0]]).is_Identity
 
 def test_dot():
     assert ones(1,3).dot(ones(3,1)) == 3


### PR DESCRIPTION
Before we had the following wrong result 

> > > Matrix([[1,0,0]]).is_Identity
> > > True

This was because for all valid i,j index pairs X[i,j] == 1 when i==j and  X[i,j] == 0 when i!=j . Added an is_square check which should resolve the issue 

http://code.google.com/p/sympy/issues/detail?id=3143
