### PR TITLE
Matrix creation

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -176,6 +176,14 @@ class MatrixExpr(Expr):
         """
         return self.as_explicit().as_mutable()
 
+    def __array__(self):
+        from numpy import empty
+        a = empty(self.shape, dtype=object)
+        for i in range(self.rows):
+            for j in range(self.cols):
+                a[i, j] = self[i, j]
+        return a
+
     def equals(self, other):
         """
         Test elementwise equality between matrices, potentially of different

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -304,8 +304,6 @@ def matrixify(expr):
 
     Calling matrixify after calling these functions will reset classes back to
     their matrix equivalents
-
-    For internal use
     """
     class_dict = {Mul:MatMul, Add:MatAdd, MatMul:MatMul, MatAdd:MatAdd,
             Pow:MatPow, MatPow:MatPow}

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -317,7 +317,7 @@ def test_matrixify():
     assert matrixify(n+m) == n+m
     assert matrixify(Mul(A,B)) == MatMul(A,B)
 
-def test_dense_converstion():
+def test_dense_conversion():
     X = MatrixSymbol('X', 2,2)
     x00,x01,x10,x11 = symbols('X_00 X_01 X_10 X_11')
     assert ImmutableMatrix(X) == ImmutableMatrix([[x00, x01], [x10, x11]])

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -2,7 +2,7 @@ from sympy.utilities.pytest import raises
 from sympy import S, symbols, Symbol, Tuple, Mul
 from sympy.matrices import (eye, MatrixSymbol, Transpose, Inverse, ShapeError,
         MatMul, Identity, BlockMatrix, BlockDiagMatrix, block_collapse, Matrix,
-        ZeroMatrix, MatAdd, MatPow, matrixify)
+        ZeroMatrix, MatAdd, MatPow, matrixify, ImmutableMatrix)
 
 def test_transpose():
     n, m, l = symbols('n m l', integer=True)
@@ -316,3 +316,9 @@ def test_matrixify():
     B = MatrixSymbol('B', m, l)
     assert matrixify(n+m) == n+m
     assert matrixify(Mul(A,B)) == MatMul(A,B)
+
+def test_dense_converstion():
+    X = MatrixSymbol('X', 2,2)
+    x00,x01,x10,x11 = symbols('X_00 X_01 X_10 X_11')
+    assert ImmutableMatrix(X) == ImmutableMatrix([[x00, x01], [x10, x11]])
+    assert Matrix(X) == Matrix([[x00, x01], [x10, x11]])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -84,9 +84,15 @@ class MatrixBase(object):
         [0, 2]
 
         """
+        # Matrix(Matrix(...))
         if len(args) == 1 and isinstance(args[0], MatrixBase):
             return args[0].rows, args[0].cols, args[0].mat
 
+        # Matrix(MatrixSymbol('X', 2,2))
+        if len(args) == 1 and isinstance(args[0], Basic) and args[0].is_Matrix:
+            return args[0].rows, args[0].cols, args[0].as_explicit().mat
+
+        # Matrix(2, 2, lambda i,j: i+j)
         if len(args) == 3 and callable(args[2]):
             operation = args[2]
             rows = int(args[0])
@@ -95,6 +101,8 @@ class MatrixBase(object):
             for i in range(rows):
                 for j in range(cols):
                     mat.append(sympify(operation(i, j)))
+
+        # Matrix(2, 2, [1,2,3,4])
         elif len(args)==3 and is_sequence(args[2]):
             rows = args[0]
             cols = args[1]
@@ -102,6 +110,8 @@ class MatrixBase(object):
             if len(mat) != rows*cols:
                 raise ValueError('List length should be equal to rows*columns')
             mat = map(lambda i: sympify(i), mat)
+
+        # Matrix(numpy.ones((2,2)))
         elif len(args) == 1:
             in_mat = args[0]
             if hasattr(in_mat, "__array__"): #pragma: no cover
@@ -146,6 +156,8 @@ class MatrixBase(object):
                         args)
                 for i in xrange(cols):
                     mat.append(sympify(in_mat[j][i]))
+
+        # Matrix()
         elif len(args) == 0:
             # Empty Matrix
             rows = cols = 0

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -87,73 +87,73 @@ class MatrixBase(object):
         if len(args) == 1 and isinstance(args[0], MatrixBase):
             return args[0].rows, args[0].cols, args[0].mat
 
-        self = object.__new__(cls)
         if len(args) == 3 and callable(args[2]):
             operation = args[2]
-            self.rows = int(args[0])
-            self.cols = int(args[1])
-            self.mat = []
-            for i in range(self.rows):
-                for j in range(self.cols):
-                    self.mat.append(sympify(operation(i, j)))
+            rows = int(args[0])
+            cols = int(args[1])
+            mat = []
+            for i in range(rows):
+                for j in range(cols):
+                    mat.append(sympify(operation(i, j)))
         elif len(args)==3 and is_sequence(args[2]):
-            self.rows=args[0]
-            self.cols=args[1]
-            mat = args[2]
-            if len(mat) != len(self):
+            rows = args[0]
+            cols = args[1]
+            mat  = args[2]
+            if len(mat) != rows*cols:
                 raise ValueError('List length should be equal to rows*columns')
-            self.mat = map(lambda i: sympify(i), mat)
+            mat = map(lambda i: sympify(i), mat)
         elif len(args) == 1:
-            mat = args[0]
-            if hasattr(mat, "__array__"): #pragma: no cover
+            in_mat = args[0]
+            if hasattr(in_mat, "__array__"): #pragma: no cover
                 # NumPy array or matrix or some other object that implements
                 # __array__. So let's first use this method to get a
                 # numpy.array() and then make a python list out of it.
-                arr = mat.__array__()
+                arr = in_mat.__array__()
                 if len(arr.shape) == 2:
-                    self.rows, self.cols = arr.shape[0], arr.shape[1]
-                    self.mat = map(lambda i: sympify(i), arr.ravel())
-                    return self.rows, self.cols, self.mat
+                    rows, cols = arr.shape[0], arr.shape[1]
+                    mat = map(lambda i: sympify(i), arr.ravel())
+                    return rows, cols, mat
                 elif len(arr.shape) == 1:
-                    self.rows, self.cols = 1, arr.shape[0]
-                    self.mat = [0]*self.cols
+                    rows, cols = 1, arr.shape[0]
+                    mat = [0]*cols
                     for i in xrange(len(arr)):
-                        self.mat[i] = sympify(arr[i])
-                    return self.rows, self.cols, self.mat
+                        mat[i] = sympify(arr[i])
+                    return rows, cols, mat
                 else:
                     raise NotImplementedError("SymPy supports just 1D and 2D matrices")
-            elif not is_sequence(mat, include=MatrixBase):
-                raise TypeError("Matrix constructor doesn't accept %s as input" % str(type(mat)))
-            mat = []
+            elif not is_sequence(in_mat, include=MatrixBase):
+                raise TypeError("Matrix constructor doesn't accept %s as input"
+                        % str(type(in_mat)))
+            in_mat = []
             for row in args[0]:
                 if isinstance(row, MatrixBase):
-                    mat.extend(row.tolist())
+                    in_mat.extend(row.tolist())
                 else:
-                    mat.append(row)
-            self.rows = len(mat)
-            if len(mat) != 0:
-                if not is_sequence(mat[0]):
-                    self.cols = 1
-                    self.mat = map(lambda i: sympify(i), mat)
-                    return self.rows, self.cols, self.mat
-                self.cols = len(mat[0])
+                    in_mat.append(row)
+            rows = len(in_mat)
+            if len(in_mat) != 0:
+                if not is_sequence(in_mat[0]):
+                    cols = 1
+                    mat = map(lambda i: sympify(i), in_mat)
+                    return rows, cols, mat
+                cols = len(in_mat[0])
             else:
-                self.cols = 0
-            self.mat = []
-            for j in xrange(self.rows):
-                if len(mat[j]) != self.cols:
+                cols = 0
+            mat = []
+            for j in xrange(rows):
+                if len(in_mat[j]) != cols:
                     raise ValueError("Input %s inconsistant to form a Matrix." %
                         args)
-                for i in xrange(self.cols):
-                    self.mat.append(sympify(mat[j][i]))
+                for i in xrange(cols):
+                    mat.append(sympify(in_mat[j][i]))
         elif len(args) == 0:
             # Empty Matrix
-            self.rows = self.cols = 0
-            self.mat = []
+            rows = cols = 0
+            mat = []
         else:
             raise TypeError("Data type not understood")
 
-        return self.rows, self.cols, self.mat
+        return rows, cols, mat
 
     def transpose(self):
         """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3241,8 +3241,6 @@ class MutableMatrix(MatrixBase):
 
     @classmethod
     def _new(cls, *args, **kwargs):
-        if len(args)==1 and isinstance(args[0], MutableMatrix):
-            return args[0]
         rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
         self = object.__new__(cls)
         self.rows = rows

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -133,6 +133,8 @@ def test_creation():
     assert ImmutableMatrix(c) == c.as_immutable()
     assert Matrix(ImmutableMatrix(c)) == ImmutableMatrix(c).as_mutable()
 
+    assert c is not Matrix(c)
+
 def test_tolist():
     x, y, z = symbols('x y z')
     lst = [[S.One,S.Half,x*y,S.Zero],[x,y,z,x**2],[y,-S.One,z*x,3]]


### PR DESCRIPTION
This pull request cleans up matrix creation. Particularly the following behaviors were changed

x = Matrix(2,2, range(4))

Matrix(x) is x # this is now False, used to be True

X = MatrixSymbol('X', 2, 2)

Matrix(X) # this is now a dense mutable Matrix. 

I think that the Matrix(MatExpr) change should replace the as_mutable/as_explicit syntax . 

Additionally the _handle_creation_inputs method in MatrixBase was cleaned up a bit. 
