### PR TITLE
Renamed stats functions to lower-case

### DIFF
--- a/doc/src/modules/stats.txt
+++ b/doc/src/modules/stats.txt
@@ -49,12 +49,12 @@ Interface
 
 .. autofunction:: P
 .. autofunction:: E
-.. autofunction:: Density
-.. autofunction:: Given
-.. autofunction:: Where
-.. autofunction:: Var
-.. autofunction:: Std
-.. autofunction:: Sample
+.. autofunction:: density
+.. autofunction:: given
+.. autofunction:: where
+.. autofunction:: var
+.. autofunction:: std
+.. autofunction:: sample
 .. autofunction:: sample_iter
 
 Mechanics

--- a/doc/src/modules/stats.txt
+++ b/doc/src/modules/stats.txt
@@ -52,7 +52,7 @@ Interface
 .. autofunction:: density
 .. autofunction:: given
 .. autofunction:: where
-.. autofunction:: var
+.. autofunction:: variance
 .. autofunction:: std
 .. autofunction:: sample
 .. autofunction:: sample_iter

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3632,12 +3632,12 @@ def test_expint():
     assert upretty(Chi(x)) == 'Chi(x)'
 
 def test_RandomDomain():
-    from sympy.stats import Normal, Die, Exponential, pspace, Where
+    from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal(0, 1, symbol=Symbol('x1'))
-    assert upretty(Where(X>0)) == u"Domain: 0 < x₁"
+    assert upretty(where(X>0)) == u"Domain: 0 < x₁"
 
     D = Die(6, symbol=Symbol('d1'))
-    assert upretty(Where(D>4)) == u'Domain: d₁ = 5 ∨ d₁ = 6'
+    assert upretty(where(D>4)) == u'Domain: d₁ = 5 ∨ d₁ = 6'
 
     A = Exponential(1, symbol=Symbol('a'))
     B = Exponential(1, symbol=Symbol('b'))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -467,12 +467,12 @@ def test_matAdd():
     assert l._print_MatAdd(C + 2*B) in ['+ 2 B + C', '+ C + 2 B']
 
 def test_latex_RandomDomain():
-    from sympy.stats import Normal, Die, Exponential, pspace, Where
+    from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal(0, 1, symbol=Symbol('x1'))
-    assert latex(Where(X>0)) == "Domain: 0 < x_{1}"
+    assert latex(where(X>0)) == "Domain: 0 < x_{1}"
 
     D = Die(6, symbol=Symbol('d1'))
-    assert latex(Where(D>4)) == r"Domain: d_{1} = 5 \vee d_{1} = 6"
+    assert latex(where(D>4)) == r"Domain: d_{1} = 5 \vee d_{1} = 6"
 
     A = Exponential(1, symbol=Symbol('a'))
     B = Exponential(1, symbol=Symbol('b'))

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -450,12 +450,12 @@ def test_settings():
     raises(TypeError, 'sstr(S(4), method="garbage")')
 
 def test_RandomDomain():
-    from sympy.stats import Normal, Die, Exponential, pspace, Where
+    from sympy.stats import Normal, Die, Exponential, pspace, where
     X = Normal(0, 1, symbol=Symbol('x1'))
-    assert str(Where(X>0)) == "Domain: 0 < x1"
+    assert str(where(X>0)) == "Domain: 0 < x1"
 
     D = Die(6, symbol=Symbol('d1'))
-    assert str(Where(D>4)) == "Domain: Or(d1 == 5, d1 == 6)"
+    assert str(where(D>4)) == "Domain: Or(d1 == 5, d1 == 6)"
 
     A = Exponential(1, symbol=Symbol('a'))
     B = Exponential(1, symbol=Symbol('b'))

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -13,7 +13,7 @@ Queries on random expressions can be made using the functions
 -------------------- -----------------------------
  P(condition)         Probability
  E(expression)        Expectation value
- var(expression)      Variance
+ variance(expression) Variance
  density(expression)  Probability Density Function
  sample(expression)   Produce a realization
  where(condition)     Where the condition is true
@@ -22,7 +22,7 @@ Queries on random expressions can be made using the functions
 Examples
 ========
 
->>> from sympy.stats import P, E, var, Die, Normal
+>>> from sympy.stats import P, E, variance, Die, Normal
 >>> from sympy import Eq, simplify
 >>> X, Y = Die(6), Die(6) # Define two six sided dice
 >>> Z = Normal(0, 1) # Declare a Normal random variable with mean 0, std 1
@@ -30,7 +30,7 @@ Examples
 1/2
 >>> E(X+Y) # Expectation of the sum of two dice
 7
->>> var(X+Y) # Variance of the sum of two dice
+>>> variance(X+Y) # Variance of the sum of two dice
 35/6
 >>> simplify(P(Z>1)) # Probability of Z being greater than 1
 -erf(sqrt(2)/2)/2 + 1/2

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -8,16 +8,16 @@ Normal, Exponential, Coin, Die, etc...  or built with functions like FiniteRV.
 
 Queries on random expressions can be made using the functions
 
-==================== =============================
+===================== =============================
     Expression                Meaning
--------------------- -----------------------------
- P(condition)         Probability
- E(expression)        Expectation value
- variance(expression) Variance
- density(expression)  Probability Density Function
- sample(expression)   Produce a realization
- where(condition)     Where the condition is true
-==================== =============================
+--------------------- -----------------------------
+ P(condition)          Probability
+ E(expression)         Expectation value
+ variance(expression)  Variance
+ density(expression)   Probability Density Function
+ sample(expression)    Produce a realization
+ where(condition)      Where the condition is true
+===================== =============================
 
 Examples
 ========

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -13,16 +13,16 @@ Queries on random expressions can be made using the functions
 -------------------- -----------------------------
  P(condition)         Probability
  E(expression)        Expectation value
- Var(expression)      Variance
- Density(expression)  Probability Density Function
- Sample(expression)   Produce a realization
- Where(condition)     Where the condition is true
+ var(expression)      Variance
+ density(expression)  Probability Density Function
+ sample(expression)   Produce a realization
+ where(condition)     Where the condition is true
 ==================== =============================
 
 Examples
 ========
 
->>> from sympy.stats import P, E, Var, Die, Normal
+>>> from sympy.stats import P, E, var, Die, Normal
 >>> from sympy import Eq, simplify
 >>> X, Y = Die(6), Die(6) # Define two six sided dice
 >>> Z = Normal(0, 1) # Declare a Normal random variable with mean 0, std 1
@@ -30,7 +30,7 @@ Examples
 1/2
 >>> E(X+Y) # Expectation of the sum of two dice
 7
->>> Var(X+Y) # Variance of the sum of two dice
+>>> var(X+Y) # Variance of the sum of two dice
 35/6
 >>> simplify(P(Z>1)) # Probability of Z being greater than 1
 -erf(sqrt(2)/2)/2 + 1/2

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -189,7 +189,7 @@ class ContinuousPSpace(PSpace):
         cdf = Piecewise((0, z<left_bound), (cdf, True))
         return Lambda(z, cdf)
 
-    def P(self, condition, **kwargs):
+    def probability(self, condition, **kwargs):
         evaluate = kwargs.get("evaluate", True)
         z = Dummy('z', real=True, bounded=True)
         # Univariate case can be handled by where
@@ -211,7 +211,7 @@ class ContinuousPSpace(PSpace):
             density = self.compute_density(expr, **kwargs)
             # Turn problem into univariate case
             space = SingleContinuousPSpace(z, density(z))
-            return space.P(condition.__class__(space.value, 0))
+            return space.probability(condition.__class__(space.value, 0))
 
 
     def where(self, condition):

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -670,7 +670,7 @@ def Gamma(k, theta, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Gamma, Density, CDF, E, Var
+    >>> from sympy.stats import Gamma, density, cdf, E, variance
     >>> from sympy import Symbol, pprint
 
     >>> k = Symbol("k", positive=True)
@@ -679,7 +679,7 @@ def Gamma(k, theta, symbol=None):
 
     >>> X = Gamma(k, theta, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /                     -x \
           |                   -----|
@@ -688,7 +688,7 @@ def Gamma(k, theta, symbol=None):
     Lambda|x, ---------------------|
           \          gamma(k)      /
 
-    >>> C = CDF(X, meijerg=True)
+    >>> C = cdf(X, meijerg=True)
     >>> pprint(C, use_unicode=False)
     Lambda/z, /                      0                        for z < 0\
           |   |                                                        |
@@ -701,7 +701,7 @@ def Gamma(k, theta, symbol=None):
     >>> E(X)
     theta*gamma(k + 1)/gamma(k)
 
-    >>> V = Var(X)
+    >>> V = variance(X)
     >>> pprint(V, use_unicode=False)
            2      2                     -k      k + 1
       theta *gamma (k + 1)   theta*theta  *theta     *gamma(k + 2)
@@ -752,7 +752,7 @@ def Laplace(mu, b, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Laplace, Density
+    >>> from sympy.stats import Laplace, density
     >>> from sympy import Symbol
 
     >>> mu = Symbol("mu")
@@ -761,7 +761,7 @@ def Laplace(mu, b, symbol=None):
 
     >>> X = Laplace(mu, b, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
 
     References
@@ -809,7 +809,7 @@ def Logistic(mu, s, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Logistic, Density
+    >>> from sympy.stats import Logistic, density
     >>> from sympy import Symbol
 
     >>> mu = Symbol("mu", real=True)
@@ -818,7 +818,7 @@ def Logistic(mu, s, symbol=None):
 
     >>> X = Logistic(mu, s, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, exp((-_x + mu)/s)/(s*(exp((-_x + mu)/s) + 1)**2))
 
     References
@@ -874,7 +874,7 @@ def LogNormal(mean, std, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import LogNormal, Density
+    >>> from sympy.stats import LogNormal, density
     >>> from sympy import Symbol, simplify, pprint
 
     >>> mu = Symbol("mu", real=True)
@@ -883,7 +883,7 @@ def LogNormal(mean, std, symbol=None):
 
     >>> X = LogNormal(mu, sigma, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /                         2\
           |          -(-mu + log(x)) |
@@ -897,7 +897,7 @@ def LogNormal(mean, std, symbol=None):
 
     >>> X = LogNormal(0, 1, symbol=Symbol('x')) # Mean 0, standard deviation 1
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, sqrt(2)*exp(-log(_x)**2/2)/(2*_x*sqrt(pi)))
 
     References
@@ -946,7 +946,7 @@ def Maxwell(a, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Maxwell, Density, E, Var
+    >>> from sympy.stats import Maxwell, density, E, variance
     >>> from sympy import Symbol, simplify
 
     >>> a = Symbol("a", positive=True)
@@ -954,13 +954,13 @@ def Maxwell(a, symbol=None):
 
     >>> X = Maxwell(a, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/(sqrt(pi)*a**3))
 
     >>> E(X)
     2*sqrt(2)*a/sqrt(pi)
 
-    >>> simplify(Var(X))
+    >>> simplify(variance(X))
     a**2*(-8 + 3*pi)/pi
 
     References
@@ -1009,7 +1009,7 @@ def Nakagami(mu, omega, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Nakagami, Density, E, Var
+    >>> from sympy.stats import Nakagami, density, E, variance
     >>> from sympy import Symbol, simplify, pprint
 
     >>> mu = Symbol("mu", positive=True)
@@ -1018,7 +1018,7 @@ def Nakagami(mu, omega, symbol=None):
 
     >>> X = Nakagami(mu, omega, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /                                2   \
           |                              -x *mu|
@@ -1031,7 +1031,7 @@ def Nakagami(mu, omega, symbol=None):
     >>> simplify(E(X, meijerg=True))
     sqrt(mu)*sqrt(omega)*gamma(mu + 1/2)/gamma(mu + 1)
 
-    >>> V = simplify(Var(X, meijerg=True))
+    >>> V = simplify(variance(X, meijerg=True))
     >>> pprint(V, use_unicode=False)
           /                               2          \
     omega*\gamma(mu)*gamma(mu + 1) - gamma (mu + 1/2)/
@@ -1090,7 +1090,7 @@ def Normal(mean, std, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Normal, Density, E, Std, CDF, Skewness
+    >>> from sympy.stats import Normal, density, E, std, cdf, skewness
     >>> from sympy import Symbol, simplify, pprint
 
     >>> mu = Symbol("mu")
@@ -1099,10 +1099,10 @@ def Normal(mean, std, symbol=None):
 
     >>> X = Normal(mu, sigma, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, sqrt(2)*exp(-(_x - mu)**2/(2*sigma**2))/(2*sqrt(pi)*sigma))
 
-    >>> C = simplify(CDF(X))
+    >>> C = simplify(cdf(X))
     >>> pprint(C, use_unicode=False)
           /                                      2      2              2\
           |                              (z - mu)    - z  + 2*z*mu - mu |
@@ -1114,17 +1114,17 @@ def Normal(mean, std, symbol=None):
     Lambda|z, ----------------------------------------------------------|
           \                               2                             /
 
-    >>> simplify(Skewness(X))
+    >>> simplify(skewness(X))
     0
 
     >>> X = Normal(0, 1, symbol=x) # Mean 0, standard deviation 1
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, sqrt(2)*exp(-_x**2/2)/(2*sqrt(pi)))
 
     >>> E(2*X + 1)
     1
 
-    >>> simplify(Std(2*X + 1))
+    >>> simplify(std(2*X + 1))
     2
 
     References
@@ -1182,7 +1182,7 @@ def Pareto(xm, alpha, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Pareto, Density
+    >>> from sympy.stats import Pareto, density
     >>> from sympy import Symbol
 
     >>> xm = Symbol("xm", positive=True)
@@ -1191,7 +1191,7 @@ def Pareto(xm, alpha, symbol=None):
 
     >>> X = Pareto(xm, beta, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, _x**(-beta - 1)*beta*xm**beta)
 
     References
@@ -1238,7 +1238,7 @@ def Rayleigh(sigma, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Rayleigh, Density, E, Var
+    >>> from sympy.stats import Rayleigh, density, E, variance
     >>> from sympy import Symbol, simplify
 
     >>> sigma = Symbol("sigma", positive=True)
@@ -1246,13 +1246,13 @@ def Rayleigh(sigma, symbol=None):
 
     >>> X = Rayleigh(sigma, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
 
     >>> E(X)
     sqrt(2)*sqrt(pi)*sigma/2
 
-    >>> Var(X)
+    >>> variance(X)
     -pi*sigma**2/2 + 2*sigma**2
 
     References
@@ -1299,7 +1299,7 @@ def StudentT(nu, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import StudentT, Density, E, Var
+    >>> from sympy.stats import StudentT, density, E, variance
     >>> from sympy import Symbol, simplify, pprint
 
     >>> nu = Symbol("nu", positive=True)
@@ -1307,7 +1307,7 @@ def StudentT(nu, symbol=None):
 
     >>> X = StudentT(nu, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /             nu   1              \
           |           - -- - -              |
@@ -1377,7 +1377,7 @@ def Triangular(a, b, c, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Triangular, Density, E, Var
+    >>> from sympy.stats import Triangular, density, E
     >>> from sympy import Symbol
 
     >>> a = Symbol("a")
@@ -1387,7 +1387,7 @@ def Triangular(a, b, c, symbol=None):
 
     >>> X = Triangular(a,b,c, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, Piecewise(((2*_x - 2*a)/((-a + b)*(-a + c)),
                          And(a <= _x, _x < c)),
                          (2/(-a + b), _x == c),
@@ -1452,7 +1452,7 @@ def Uniform(left, right, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Uniform, Density, CDF, E, Var, Skewness
+    >>> from sympy.stats import Uniform, density, cdf, E, variance, skewness
     >>> from sympy import Symbol, simplify
 
     >>> a = Symbol("a")
@@ -1461,19 +1461,19 @@ def Uniform(left, right, symbol=None):
 
     >>> X = Uniform(a, b, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, Piecewise((0, _x < a), (0, _x > b), (1/(-a + b), True)))
 
-    >>> CDF(X)
+    >>> cdf(X)
     Lambda(_z, _z/(-a + b) - a/(-a + b))
 
     >>> simplify(E(X))
     a/2 + b/2
 
-    >>> simplify(Var(X))
+    >>> simplify(variance(X))
     a**2/12 - a*b/6 + b**2/12
 
-    >>> simplify(Skewness(X))
+    >>> simplify(skewness(X))
     0
 
     References
@@ -1525,7 +1525,7 @@ def UniformSum(n, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import UniformSum, Density, E, Var
+    >>> from sympy.stats import UniformSum, density
     >>> from sympy import Symbol, pprint
 
     >>> n = Symbol("n", integer=True)
@@ -1533,7 +1533,7 @@ def UniformSum(n, symbol=None):
 
     >>> X = UniformSum(n, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /   floor(x)                        \
           |     ___                           |
@@ -1603,7 +1603,7 @@ def Weibull(alpha, beta, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Weibull, Density, E, Var
+    >>> from sympy.stats import Weibull, density, E, variance
     >>> from sympy import Symbol, simplify
 
     >>> l = Symbol("lambda", positive=True)
@@ -1612,13 +1612,13 @@ def Weibull(alpha, beta, symbol=None):
 
     >>> X = Weibull(l, k, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, k*(_x/lambda)**(k - 1)*exp(-(_x/lambda)**k)/lambda)
 
     >>> simplify(E(X))
     lambda*gamma(1 + 1/k)
 
-    >>> simplify(Var(X))
+    >>> simplify(variance(X))
     -lambda**2*(gamma(1 + 1/k)**2 - gamma(1 + 2/k))
 
     References
@@ -1627,20 +1627,8 @@ def Weibull(alpha, beta, symbol=None):
     .. [1] http://en.wikipedia.org/wiki/Weibull_distribution
     .. [2] http://mathworld.wolfram.com/WeibullDistribution.html
 
-=======
-    >>> from sympy.stats import Weibull, density, E, var
-    >>> from sympy import symbols, simplify
-    >>> x, a, b = symbols('x a b', positive=True)
-
-    >>> X = Weibull(a, b, symbol=x)
-    >>> density(X)
-    Lambda(_x, b*(_x/a)**(b - 1)*exp(-(_x/a)**b)/a)
-    >>> simplify(E(X))
-    a*gamma(1 + 1/b)
-    >>> simplify(var(X))
-    -a**2*(gamma(1 + 1/b)**2 - gamma(1 + 2/b))
->>>>>>> Renamed stats functions to lower-case
     """
+
     return WeibullPSpace(alpha, beta, symbol).value
 
 #-------------------------------------------------------------------------------
@@ -1680,7 +1668,7 @@ def WignerSemicircle(R, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import WignerSemicircle, Density, E, Std
+    >>> from sympy.stats import WignerSemicircle, density, E
     >>> from sympy import Symbol, simplify
 
     >>> R = Symbol("R", positive=True)
@@ -1688,7 +1676,7 @@ def WignerSemicircle(R, symbol=None):
 
     >>> X = WignerSemicircle(R, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
 
     >>> E(X)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -158,7 +158,7 @@ def Arcsin(a=0, b=1, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Arcsine_distribution
+    [1] http://en.wikipedia.org/wiki/Arcsine_distribution
     """
 
     return ArcsinPSpace(a, b, symbol).value
@@ -224,7 +224,7 @@ def Benini(alpha, beta, sigma, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Benini_distribution
+    [1] http://en.wikipedia.org/wiki/Benini_distribution
     """
 
     return BeniniPSpace(alpha, beta, sigma, symbol).value
@@ -300,8 +300,8 @@ def Beta(alpha, beta, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Beta_distribution
-    .. [2] http://mathworld.wolfram.com/BetaDistribution.html
+    [1] http://en.wikipedia.org/wiki/Beta_distribution
+    [2] http://mathworld.wolfram.com/BetaDistribution.html
     """
 
     return BetaPSpace(alpha, beta, symbol).value
@@ -361,8 +361,8 @@ def BetaPrime(alpha, beta, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Beta_prime_distribution
-    .. [2] http://mathworld.wolfram.com/BetaPrimeDistribution.html
+    [1] http://en.wikipedia.org/wiki/Beta_prime_distribution
+    [2] http://mathworld.wolfram.com/BetaPrimeDistribution.html
     """
 
     return BetaPrimePSpace(alpha, beta, symbol).value
@@ -417,8 +417,8 @@ def Cauchy(x0, gamma, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Cauchy_distribution
-    .. [2] http://mathworld.wolfram.com/CauchyDistribution.html
+    [1] http://en.wikipedia.org/wiki/Cauchy_distribution
+    [2] http://mathworld.wolfram.com/CauchyDistribution.html
     """
 
     return CauchyPSpace(x0, gamma, symbol).value
@@ -472,8 +472,8 @@ def Chi(k, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Chi_distribution
-    .. [2] http://mathworld.wolfram.com/ChiDistribution.html
+    [1] http://en.wikipedia.org/wiki/Chi_distribution
+    [2] http://mathworld.wolfram.com/ChiDistribution.html
     """
 
     return ChiPSpace(k, symbol).value
@@ -532,7 +532,7 @@ def Dagum(p, a, b, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Dagum_distribution
+    [1] http://en.wikipedia.org/wiki/Dagum_distribution
     """
 
     return DagumPSpace(p, a, b, symbol).value
@@ -618,8 +618,8 @@ def Exponential(rate, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Exponential_distribution
-    .. [2] http://mathworld.wolfram.com/ExponentialDistribution.html
+    [1] http://en.wikipedia.org/wiki/Exponential_distribution
+    [2] http://mathworld.wolfram.com/ExponentialDistribution.html
     """
 
     return ExponentialPSpace(rate, symbol).value
@@ -712,8 +712,8 @@ def Gamma(k, theta, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Gamma_distribution
-    .. [2] http://mathworld.wolfram.com/GammaDistribution.html
+    [1] http://en.wikipedia.org/wiki/Gamma_distribution
+    [2] http://mathworld.wolfram.com/GammaDistribution.html
     """
 
     return GammaPSpace(k, theta, symbol).value
@@ -767,8 +767,8 @@ def Laplace(mu, b, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Laplace_distribution
-    .. [2] http://mathworld.wolfram.com/LaplaceDistribution.html
+    [1] http://en.wikipedia.org/wiki/Laplace_distribution
+    [2] http://mathworld.wolfram.com/LaplaceDistribution.html
     """
 
     return LaplacePSpace(mu, b, symbol).value
@@ -824,8 +824,8 @@ def Logistic(mu, s, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Logistic_distribution
-    .. [2] http://mathworld.wolfram.com/LogisticDistribution.html
+    [1] http://en.wikipedia.org/wiki/Logistic_distribution
+    [2] http://mathworld.wolfram.com/LogisticDistribution.html
     """
 
     return LogisticPSpace(mu, s, symbol).value
@@ -903,8 +903,8 @@ def LogNormal(mean, std, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Lognormal
-    .. [2] http://mathworld.wolfram.com/LogNormalDistribution.html
+    [1] http://en.wikipedia.org/wiki/Lognormal
+    [2] http://mathworld.wolfram.com/LogNormalDistribution.html
     """
 
     return LogNormalPSpace(mean, std, symbol).value
@@ -966,8 +966,8 @@ def Maxwell(a, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Maxwell_distribution
-    .. [2] http://mathworld.wolfram.com/MaxwellDistribution.html
+    [1] http://en.wikipedia.org/wiki/Maxwell_distribution
+    [2] http://mathworld.wolfram.com/MaxwellDistribution.html
     """
 
     return MaxwellPSpace(a, symbol).value
@@ -1041,7 +1041,7 @@ def Nakagami(mu, omega, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Nakagami_distribution
+    [1] http://en.wikipedia.org/wiki/Nakagami_distribution
     """
 
     return NakagamiPSpace(mu, omega, symbol).value
@@ -1130,8 +1130,8 @@ def Normal(mean, std, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Normal_distribution
-    .. [2] http://mathworld.wolfram.com/NormalDistributionFunction.html
+    [1] http://en.wikipedia.org/wiki/Normal_distribution
+    [2] http://mathworld.wolfram.com/NormalDistributionFunction.html
     """
 
     return NormalPSpace(mean, std, symbol).value
@@ -1197,8 +1197,8 @@ def Pareto(xm, alpha, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Pareto_distribution
-    .. [2] http://mathworld.wolfram.com/ParetoDistribution.html
+    [1] http://en.wikipedia.org/wiki/Pareto_distribution
+    [2] http://mathworld.wolfram.com/ParetoDistribution.html
     """
 
     return ParetoPSpace(xm, alpha, symbol).value
@@ -1258,8 +1258,8 @@ def Rayleigh(sigma, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Rayleigh_distribution
-    .. [2] http://mathworld.wolfram.com/RayleighDistribution.html
+    [1] http://en.wikipedia.org/wiki/Rayleigh_distribution
+    [2] http://mathworld.wolfram.com/RayleighDistribution.html
     """
 
     return RayleighPSpace(sigma, symbol).value
@@ -1324,8 +1324,8 @@ def StudentT(nu, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Student_t-distribution
-    .. [2] http://mathworld.wolfram.com/Studentst-Distribution.html
+    [1] http://en.wikipedia.org/wiki/Student_t-distribution
+    [2] http://mathworld.wolfram.com/Studentst-Distribution.html
     """
 
     return StudentTPSpace(nu, symbol).value
@@ -1397,8 +1397,8 @@ def Triangular(a, b, c, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Triangular_distribution
-    .. [2] http://mathworld.wolfram.com/TriangularDistribution.html
+    [1] http://en.wikipedia.org/wiki/Triangular_distribution
+    [2] http://mathworld.wolfram.com/TriangularDistribution.html
     """
 
     return TriangularPSpace(a, b, c, symbol).value
@@ -1479,8 +1479,8 @@ def Uniform(left, right, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Uniform_distribution_%28continuous%29
-    .. [2] http://mathworld.wolfram.com/UniformDistribution.html
+    [1] http://en.wikipedia.org/wiki/Uniform_distribution_%28continuous%29
+    [2] http://mathworld.wolfram.com/UniformDistribution.html
     """
 
     return UniformPSpace(left, right, symbol).value
@@ -1549,8 +1549,8 @@ def UniformSum(n, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Uniform_sum_distribution
-    .. [2] http://mathworld.wolfram.com/UniformSumDistribution.html
+    [1] http://en.wikipedia.org/wiki/Uniform_sum_distribution
+    [2] http://mathworld.wolfram.com/UniformSumDistribution.html
     """
 
     return UniformSumPSpace(n, symbol).value
@@ -1624,8 +1624,8 @@ def Weibull(alpha, beta, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Weibull_distribution
-    .. [2] http://mathworld.wolfram.com/WeibullDistribution.html
+    [1] http://en.wikipedia.org/wiki/Weibull_distribution
+    [2] http://mathworld.wolfram.com/WeibullDistribution.html
 
     """
 
@@ -1685,8 +1685,8 @@ def WignerSemicircle(R, symbol=None):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Wigner_semicircle_distribution
-    .. [2] http://mathworld.wolfram.com/WignersSemicircleLaw.html
+    [1] http://en.wikipedia.org/wiki/Wigner_semicircle_distribution
+    [2] http://mathworld.wolfram.com/WignersSemicircleLaw.html
     """
 
     return WignerSemicirclePSpace(R, symbol).value

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -143,7 +143,7 @@ def Arcsin(a=0, b=1, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Arcsin, Density
+    >>> from sympy.stats import Arcsin, density
     >>> from sympy import Symbol, simplify
 
     >>> a = Symbol("a", real=True)
@@ -152,7 +152,7 @@ def Arcsin(a=0, b=1, symbol=None):
 
     >>> X = Arcsin(a, b, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
 
     References
@@ -202,7 +202,7 @@ def Benini(alpha, beta, sigma, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Benini, Density
+    >>> from sympy.stats import Benini, density
     >>> from sympy import Symbol, simplify, pprint
 
     >>> alpha = Symbol("alpha", positive=True)
@@ -212,7 +212,7 @@ def Benini(alpha, beta, sigma, symbol=None):
 
     >>> X = Benini(alpha, beta, sigma, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /                                                             2       \
           |   /                  /  x  \\             /  x  \            /  x  \|
@@ -275,7 +275,7 @@ def Beta(alpha, beta, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Beta, Density, E, Var
+    >>> from sympy.stats import Beta, density, E, variance
     >>> from sympy import Symbol, simplify, pprint
 
     >>> alpha = Symbol("alpha", positive=True)
@@ -284,7 +284,7 @@ def Beta(alpha, beta, symbol=None):
 
     >>> X = Beta(alpha, beta, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /    alpha - 1         beta - 1                    \
           |   x         *(-x + 1)        *gamma(alpha + beta)|
@@ -294,7 +294,7 @@ def Beta(alpha, beta, symbol=None):
     >>> simplify(E(X, meijerg=True))
     alpha/(alpha + beta)
 
-    >>> simplify(Var(X, meijerg=True))
+    >>> simplify(variance(X, meijerg=True))
     alpha*beta/((alpha + beta)**2*(alpha + beta + 1))
 
     References
@@ -342,7 +342,7 @@ def BetaPrime(alpha, beta, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import BetaPrime, Density
+    >>> from sympy.stats import BetaPrime, density
     >>> from sympy import Symbol, pprint
 
     >>> alpha = Symbol("alpha", positive=True)
@@ -351,7 +351,7 @@ def BetaPrime(alpha, beta, symbol=None):
 
     >>> X = BetaPrime(alpha, beta, symbol=x)
 
-    >>> D = Density(X)
+    >>> D = density(X)
     >>> pprint(D, use_unicode=False)
           /    alpha - 1        -alpha - beta                    \
           |   x         *(x + 1)             *gamma(alpha + beta)|
@@ -402,7 +402,7 @@ def Cauchy(x0, gamma, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Cauchy, Density
+    >>> from sympy.stats import Cauchy, density
     >>> from sympy import Symbol
 
     >>> x0 = Symbol("x0")
@@ -411,7 +411,7 @@ def Cauchy(x0, gamma, symbol=None):
 
     >>> X = Cauchy(x0, gamma, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
 
     References
@@ -458,7 +458,7 @@ def Chi(k, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Chi, Density, E, Std
+    >>> from sympy.stats import Chi, density, E, std
     >>> from sympy import Symbol, simplify
 
     >>> k = Symbol("k", integer=True)
@@ -466,7 +466,7 @@ def Chi(k, symbol=None):
 
     >>> X = Chi(k, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)*exp(-_x**2/2)/gamma(k/2))
 
     References
@@ -516,7 +516,7 @@ def Dagum(p, a, b, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Dagum, Density
+    >>> from sympy.stats import Dagum, density
     >>> from sympy import Symbol, simplify
 
     >>> p = Symbol("p", positive=True)
@@ -526,7 +526,7 @@ def Dagum(p, a, b, symbol=None):
 
     >>> X = Dagum(p, a, b, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, a*p*(_x/b)**(a*p)*((_x/b)**a + 1)**(-p - 1)/_x)
 
     References
@@ -580,7 +580,8 @@ def Exponential(rate, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Exponential, Density, CDF, E, Var, Std, Skewness
+    >>> from sympy.stats import Exponential, density, cdf, E
+    >>> from sympy.stats import variance, std, skewness
     >>> from sympy import Symbol
 
     >>> l = Symbol("lambda", positive=True)
@@ -588,30 +589,30 @@ def Exponential(rate, symbol=None):
 
     >>> X = Exponential(l, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, lambda*exp(-_x*lambda))
 
-    >>> CDF(X)
+    >>> cdf(X)
     Lambda(_z, Piecewise((0, _z < 0), (1 - exp(-_z*lambda), True)))
 
     >>> E(X)
     1/lambda
 
-    >>> Var(X)
+    >>> variance(X)
     lambda**(-2)
 
-    >>> Skewness(X)
+    >>> skewness(X)
     2
 
     >>> X = Exponential(10, symbol=x)
 
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, 10*exp(-10*_x))
 
     >>> E(X)
     1/10
 
-    >>> Std(X)
+    >>> std(X)
     1/10
 
     References
@@ -1626,6 +1627,19 @@ def Weibull(alpha, beta, symbol=None):
     .. [1] http://en.wikipedia.org/wiki/Weibull_distribution
     .. [2] http://mathworld.wolfram.com/WeibullDistribution.html
 
+=======
+    >>> from sympy.stats import Weibull, density, E, var
+    >>> from sympy import symbols, simplify
+    >>> x, a, b = symbols('x a b', positive=True)
+
+    >>> X = Weibull(a, b, symbol=x)
+    >>> density(X)
+    Lambda(_x, b*(_x/a)**(b - 1)*exp(-(_x/a)**b)/a)
+    >>> simplify(E(X))
+    a*gamma(1 + 1/b)
+    >>> simplify(var(X))
+    -a**2*(gamma(1 + 1/b)**2 - gamma(1 + 2/b))
+>>>>>>> Renamed stats functions to lower-case
     """
     return WeibullPSpace(alpha, beta, symbol).value
 

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -200,14 +200,14 @@ class FinitePSpace(PSpace):
         return sum(expr.subs(dict(elem)) * self.prob_of(elem)
                 for elem in self.domain)
 
-    def P(self, condition):
+    def probability(self, condition):
         cond_symbols = frozenset(rs.symbol for rs in random_symbols(condition))
         assert cond_symbols.issubset(self.symbols)
         return sum(self.prob_of(elem) for elem in self.where(condition))
 
     def conditional_space(self, condition):
         domain = self.where(condition)
-        prob = self.P(condition)
+        prob = self.probability(condition)
         density = dict((key, val / prob)
                 for key, val in self._density.items() if key in domain)
         return FinitePSpace(domain, density)

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -48,15 +48,15 @@ class DiscreteUniformPSpace(SingleFinitePSpace):
     Examples
     ========
 
-    >>> from sympy.stats import DiscreteUniform, Density
+    >>> from sympy.stats import DiscreteUniform, density
     >>> from sympy import symbols
 
     >>> X = DiscreteUniform(symbols('a b c')) # equally likely over a, b, c
-    >>> Density(X)
+    >>> density(X)
     {a: 1/3, b: 1/3, c: 1/3}
 
     >>> Y = DiscreteUniform(range(5)) # distribution over a range
-    >>> Density(Y)
+    >>> density(Y)
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
     """
     def __new__(cls, items, symbol=None):
@@ -74,15 +74,15 @@ def DiscreteUniform(items, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import DiscreteUniform, Density
+    >>> from sympy.stats import DiscreteUniform, density
     >>> from sympy import symbols
 
     >>> X = DiscreteUniform(symbols('a b c')) # equally likely over a, b, c
-    >>> Density(X)
+    >>> density(X)
     {a: 1/3, b: 1/3, c: 1/3}
 
     >>> Y = DiscreteUniform(range(5)) # distribution over a range
-    >>> Density(Y)
+    >>> density(Y)
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
 
     """
@@ -96,14 +96,14 @@ class DiePSpace(DiscreteUniformPSpace):
 
     Create Dice Random Symbols using Die function
 
-    >>> from sympy.stats import Die, Density
+    >>> from sympy.stats import Die, density
 
     >>> X = Die(6) # Six sided Die
-    >>> Density(X)
+    >>> density(X)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
 
     >>> X = Die(4) # Four sided Die
-    >>> Density(X)
+    >>> density(X)
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
     """
     _count = 0
@@ -117,14 +117,14 @@ def Die(sides=6, symbol=None):
 
     Returns a RandomSymbol.
 
-    >>> from sympy.stats import Die, Density
+    >>> from sympy.stats import Die, density
 
     >>> X = Die(6) # Six sided Die
-    >>> Density(X)
+    >>> density(X)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
 
     >>> X = Die(4) # Four sided Die
-    >>> Density(X)
+    >>> density(X)
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
     """
 
@@ -140,15 +140,15 @@ class BernoulliPSpace(SingleFinitePSpace):
 
     Create Bernoulli Random Symbols using Bernoulli function.
 
-    >>> from sympy.stats import Bernoulli, Density
+    >>> from sympy.stats import Bernoulli, density
     >>> from sympy import S
 
     >>> X = Bernoulli(S(3)/4) # 1-0 Bernoulli variable, probability = 3/4
-    >>> Density(X)
+    >>> density(X)
     {0: 1/4, 1: 3/4}
 
     >>> X = Bernoulli(S.Half, 'Heads', 'Tails') # A fair coin toss
-    >>> Density(X)
+    >>> density(X)
     {Heads: 1/2, Tails: 1/2}
     """
 
@@ -164,15 +164,15 @@ def Bernoulli(p, succ=1, fail=0, symbol=None):
 
     Returns a RandomSymbol
 
-    >>> from sympy.stats import Bernoulli, Density
+    >>> from sympy.stats import Bernoulli, density
     >>> from sympy import S
 
     >>> X = Bernoulli(S(3)/4, 1, 0) # 1-0 Bernoulli variable, probability = 3/4
-    >>> Density(X)
+    >>> density(X)
     {0: 1/4, 1: 3/4}
 
     >>> X = Bernoulli(S.Half, 'Heads', 'Tails') # A fair coin toss
-    >>> Density(X)
+    >>> density(X)
     {Heads: 1/2, Tails: 1/2}
     """
 
@@ -188,15 +188,15 @@ class CoinPSpace(BernoulliPSpace):
 
     Create Coin's using Coin function
 
-    >>> from sympy.stats import Coin, Density
+    >>> from sympy.stats import Coin, density
     >>> from sympy import Rational
 
     >>> X = Coin() # A fair coin toss
-    >>> Density(X)
+    >>> density(X)
     {H: 1/2, T: 1/2}
 
     >>> X = Coin(Rational(3, 5)) # An unfair coin
-    >>> Density(X)
+    >>> density(X)
     {H: 3/5, T: 2/5}
     """
     _count = 0
@@ -212,15 +212,15 @@ def Coin(p=S.Half, symbol=None):
 
     Returns a RandomSymbol.
 
-    >>> from sympy.stats import Coin, Density
+    >>> from sympy.stats import Coin, density
     >>> from sympy import Rational
 
     >>> X = Coin() # A fair coin toss
-    >>> Density(X)
+    >>> density(X)
     {H: 1/2, T: 1/2}
 
     >>> X = Coin(Rational(3, 5)) # An unfair coin
-    >>> Density(X)
+    >>> density(X)
     {H: 3/5, T: 2/5}
     """
     return CoinPSpace(p, symbol).value
@@ -236,11 +236,11 @@ class BinomialPSpace(SingleFinitePSpace):
     Examples
     ========
 
-    >>> from sympy.stats import Binomial, Density
+    >>> from sympy.stats import Binomial, density
     >>> from sympy import S
 
     >>> X = Binomial(4, S.Half) # Four "coin flips"
-    >>> Density(X)
+    >>> density(X)
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
     """
 
@@ -259,11 +259,11 @@ def Binomial(n, p, succ=1, fail=0, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Binomial, Density
+    >>> from sympy.stats import Binomial, density
     >>> from sympy import S
 
     >>> X = Binomial(4, S.Half) # Four "coin flips"
-    >>> Density(X)
+    >>> density(X)
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
     """
 
@@ -280,11 +280,11 @@ class HypergeometricPSpace(SingleFinitePSpace):
     Examples
     ========
 
-    >>> from sympy.stats import Hypergeometric, Density
+    >>> from sympy.stats import Hypergeometric, density
     >>> from sympy import S
 
     >>> X = Hypergeometric(10, 5, 3) # 10 marbles, 5 white (success), 3 draws
-    >>> Density(X)
+    >>> density(X)
     {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
     """
 
@@ -303,11 +303,11 @@ def Hypergeometric(N, m, n, symbol=None):
     Examples
     ========
 
-    >>> from sympy.stats import Hypergeometric, Density
+    >>> from sympy.stats import Hypergeometric, density
     >>> from sympy import S
 
     >>> X = Hypergeometric(10, 5, 3) # 10 marbles, 5 white (success), 3 draws
-    >>> Density(X)
+    >>> density(X)
     {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
     """
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -3,7 +3,7 @@ Main Random Variables Module
 
 Defines abstract random variable type.
 Contains interfaces for probability space object (PSpace) as well as standard
-operators, P, E, Sample, Density, Where
+operators, P, E, sample, density, where
 
 See Also
 ========
@@ -143,7 +143,7 @@ class PSpace(Basic):
     def sample(self):
         raise NotImplementedError()
 
-    def P(self, condition):
+    def probability(self, condition):
         raise NotImplementedError()
 
     def integrate(self, expr):
@@ -185,8 +185,8 @@ class RandomSymbol(Symbol):
 
     E - Expectation of a random expression
     P - Probability of a condition
-    Density - Probability Density of an expression
-    Given - A new random expression (with new random symbols) given a condition
+    density - Probability Density of an expression
+    given - A new random expression (with new random symbols) given a condition
 
     An object of the RandomSymbol type should almost never be created by the
     user. They tend to be created instead by the PSpace class's value method.
@@ -393,7 +393,7 @@ def rs_swap(a,b):
         d[rsa] = [rsb for rsb in b if rsa.symbol==rsb.symbol][0]
     return d
 
-def Given(expr, given=None, **kwargs):
+def given(expr, condition=None, **kwargs):
     """
     From a random expression and a condition on that expression creates a new
     probability space from the condition and returns the same expression on that
@@ -402,20 +402,20 @@ def Given(expr, given=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Given, Density, Die
+    >>> from sympy.stats import given, density, Die
     >>> X = Die(6)
-    >>> Y = Given(X, X>3)
-    >>> Density(Y)
+    >>> Y = given(X, X>3)
+    >>> density(Y)
     {4: 1/3, 5: 1/3, 6: 1/3}
     """
 
-    if not random_symbols(given) or pspace_independent(expr, given):
+    if not random_symbols(condition) or pspace_independent(expr, condition):
         return expr
 
     # Get full probability space of both the expression and the condition
-    fullspace = pspace(Tuple(expr, given))
+    fullspace = pspace(Tuple(expr, condition))
     # Build new space given the condition
-    space = fullspace.conditional_space(given, **kwargs)
+    space = fullspace.conditional_space(condition, **kwargs)
     # Dictionary to swap out RandomSymbols in expr with new RandomSymbols
     # That point to the new conditional space
     swapdict = rs_swap(fullspace.values, space.values)
@@ -423,7 +423,7 @@ def Given(expr, given=None, **kwargs):
     expr = expr.subs(swapdict)
     return expr
 
-def E(expr, given=None, numsamples=None, **kwargs):
+def expectation(expr, condition=None, numsamples=None, **kwargs):
     """
     Returns the expected value of a random expression
 
@@ -457,21 +457,21 @@ def E(expr, given=None, numsamples=None, **kwargs):
     if not random_symbols(expr): # expr isn't random?
         return expr
     if numsamples: # Computing by monte carlo sampling?
-        return sampling_E(expr, given, numsamples=numsamples, **kwargs)
+        return sampling_E(expr, condition, numsamples=numsamples, **kwargs)
 
     # Create new expr and recompute E
-    if given is not None: # If there is a condition
-        return E(Given(expr, given, **kwargs), **kwargs)
+    if condition is not None: # If there is a condition
+        return expectation(given(expr, condition, **kwargs), **kwargs)
 
     # A few known statements for efficiency
-    if expr.is_Add:
-        return Add(*[E(arg, **kwargs) for arg in expr.args]) # E is Linear
+
+    if expr.is_Add: # We know that E is Linear
+        return Add(*[expectation(arg, **kwargs) for arg in expr.args])
 
     # Otherwise case is simple, pass work off to the ProbabilitySpace
     return pspace(expr).integrate(expr, **kwargs)
 
-
-def P(condition, given=None, numsamples=None,  **kwargs):
+def probability(condition, given_condition=None, numsamples=None,  **kwargs):
     """
     Probability that a condition is true, optionally given a second condition
 
@@ -479,7 +479,7 @@ def P(condition, given=None, numsamples=None,  **kwargs):
     ----------
     expr : Relational containing RandomSymbols
         The condition of which you want to compute the probability
-    given : Relational containing RandomSymbols
+    given_condition : Relational containing RandomSymbols
         A conditional expression. P(X>1, X>0) is expectation of X>1 given X>0
     numsamples : int
         Enables sampling and approximates the probability with this many samples
@@ -503,17 +503,18 @@ def P(condition, given=None, numsamples=None,  **kwargs):
     """
 
     if numsamples:
-        return sampling_P(condition, given, numsamples=numsamples, **kwargs)
-    if given is not None: # If there is a condition
+        return sampling_P(condition, given_condition, numsamples=numsamples,
+                **kwargs)
+    if given_condition is not None: # If there is a condition
         # Recompute on new conditional expr
-        return P(Given(condition, given, **kwargs), **kwargs)
+        return probability(given(condition, given_condition, **kwargs),**kwargs)
 
     # Otherwise pass work off to the ProbabilitySpace
-    return pspace(condition).P(condition, **kwargs)
+    return pspace(condition).probability(condition, **kwargs)
 
-def Density(expr, given=None, **kwargs):
+def density(expr, condition=None, **kwargs):
     """
-    Probability Density of a random expression
+    Probability density of a random expression
 
     Optionally given a second condition
 
@@ -525,27 +526,27 @@ def Density(expr, given=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Density, Die, Normal
+    >>> from sympy.stats import density, Die, Normal
     >>> from sympy import Symbol
 
     >>> D = Die(6)
     >>> X = Normal(0, 1, symbol=Symbol('x'))
 
-    >>> Density(D)
+    >>> density(D)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
-    >>> Density(2*D)
+    >>> density(2*D)
     {2: 1/6, 4: 1/6, 6: 1/6, 8: 1/6, 10: 1/6, 12: 1/6}
-    >>> Density(X)
+    >>> density(X)
     Lambda(_x, sqrt(2)*exp(-_x**2/2)/(2*sqrt(pi)))
     """
-    if given is not None: # If there is a condition
+    if condition is not None: # If there is a condition
         # Recompute on new conditional expr
-        return Density(Given(expr, given, **kwargs), **kwargs)
+        return density(given(expr, condition, **kwargs), **kwargs)
 
     # Otherwise pass work off to the ProbabilitySpace
     return pspace(expr).compute_density(expr, **kwargs)
 
-def CDF(expr, given=None, **kwargs):
+def cdf(expr, condition=None, **kwargs):
     """
     Cumulative Distribution Function of a random expression.
 
@@ -559,79 +560,79 @@ def CDF(expr, given=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Density, Die, Normal, CDF
+    >>> from sympy.stats import density, Die, Normal, cdf
     >>> from sympy import Symbol
 
     >>> D = Die(6)
     >>> X = Normal(0, 1)
 
-    >>> Density(D)
+    >>> density(D)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
-    >>> CDF(D)
+    >>> cdf(D)
     {1: 1/6, 2: 1/3, 3: 1/2, 4: 2/3, 5: 5/6, 6: 1}
-    >>> CDF(3*D, D>2)
+    >>> cdf(3*D, D>2)
     {9: 1/4, 12: 1/2, 15: 3/4, 18: 1}
 
-    >>> CDF(X)
+    >>> cdf(X)
     Lambda(_z, erf(sqrt(2)*_z/2)/2 + 1/2)
     """
-    if given is not None: # If there is a condition
+    if condition is not None: # If there is a condition
         # Recompute on new conditional expr
-        return CDF(Given(expr, given, **kwargs), **kwargs)
+        return cdf(given(expr, condition, **kwargs), **kwargs)
 
     # Otherwise pass work off to the ProbabilitySpace
     return pspace(expr).compute_cdf(expr, **kwargs)
 
-def Where(condition, given=None, **kwargs):
+def where(condition, given_condition=None, **kwargs):
     """
     Returns the domain where a condition is True.
 
     Examples
     ========
 
-    >>> from sympy.stats import Where, Die, Normal
+    >>> from sympy.stats import where, Die, Normal
     >>> from sympy import symbols, And
 
     >>> x, a, b = symbols('x a b')
     >>> D1, D2 = Die(6, symbol=a), Die(6, symbol=b)
     >>> X = Normal(0, 1, symbol=x)
 
-    >>> Where(X**2<1)
+    >>> where(X**2<1)
     Domain: And(-1 < x, x < 1)
 
-    >>> Where(X**2<1).set
+    >>> where(X**2<1).set
     (-1, 1)
 
-    >>> Where(And(D1<=D2 , D2<3))
+    >>> where(And(D1<=D2 , D2<3))
     Domain: Or(And(a == 1, b == 1), And(a == 1, b == 2), And(a == 2, b == 2))
     """
-    if given is not None: # If there is a condition
+    if given_condition is not None: # If there is a condition
         # Recompute on new conditional expr
-        return Where(Given(condition, given, **kwargs), **kwargs)
+        return where(given(condition, given_condition, **kwargs), **kwargs)
 
     # Otherwise pass work off to the ProbabilitySpace
     return pspace(condition).where(condition, **kwargs)
 
-def Sample(expr, given=None, **kwargs):
+def sample(expr, condition=None, **kwargs):
     """
     A realization of the random expression
 
     Examples
     ========
 
-    >>> from sympy.stats import Die, Sample
+    >>> from sympy.stats import Die, sample
     >>> X, Y, Z = Die(6), Die(6), Die(6)
 
-    >>> die_roll = Sample(X+Y+Z) # A random realization of three dice
+    >>> die_roll = sample(X+Y+Z) # A random realization of three dice
     """
-    return sample_iter(expr, given, numsamples=1).next()
+    return sample_iter(expr, condition, numsamples=1).next()
 
-def sample_iter(expr, given=None, numsamples=S.Infinity, **kwargs):
+def sample_iter(expr, condition=None, numsamples=S.Infinity, **kwargs):
     """
     Returns an iterator of realizations from the expression given a condition
 
     expr: Random expression to be realized
-    given: A conditional expression (optional)
+    condition: A conditional expression (optional)
     numsamples: Length of the iterator (defaults to infinity)
 
     Examples
@@ -653,26 +654,26 @@ def sample_iter(expr, given=None, numsamples=S.Infinity, **kwargs):
     """
     # lambdify is much faster but not as robust
     try:
-        return sample_iter_lambdify(expr, given, numsamples, **kwargs)
+        return sample_iter_lambdify(expr, condition, numsamples, **kwargs)
     # use subs when lambdify fails
     except TypeError:
-        return sample_iter_subs(expr, given, numsamples, **kwargs)
+        return sample_iter_subs(expr, condition, numsamples, **kwargs)
 
-def sample_iter_lambdify(expr, given=None, numsamples=S.Infinity, **kwargs):
+def sample_iter_lambdify(expr, condition=None, numsamples=S.Infinity, **kwargs):
     """
     See sample_iter
 
     Uses lambdify for computation. This is fast but does not always work.
     """
-    if given:
-        ps = pspace(Tuple(expr, given))
+    if condition:
+        ps = pspace(Tuple(expr, condition))
     else:
         ps = pspace(expr)
 
     rvs = list(ps.values)
     fn = lambdify(rvs, expr, **kwargs)
-    if given:
-        given_fn = lambdify(rvs, given, **kwargs)
+    if condition:
+        given_fn = lambdify(rvs, condition, **kwargs)
 
     # Check that lambdify can handle the expression
     # Some operations like Sum can prove difficult
@@ -680,10 +681,10 @@ def sample_iter_lambdify(expr, given=None, numsamples=S.Infinity, **kwargs):
         d = ps.sample() # a dictionary that maps RVs to values
         args = [d[rv] for rv in rvs]
         fn(*args)
-        if given:
+        if condition:
             given_fn(*args)
     except:
-        raise TypeError("Expr/given too complex for lambdify")
+        raise TypeError("Expr/condition too complex for lambdify")
 
     def return_generator():
         count = 0
@@ -691,7 +692,7 @@ def sample_iter_lambdify(expr, given=None, numsamples=S.Infinity, **kwargs):
             d = ps.sample() # a dictionary that maps RVs to values
             args = [d[rv] for rv in rvs]
 
-            if given: # Check that these values satisfy the condition
+            if condition: # Check that these values satisfy the condition
                 gd = given_fn(*args)
                 if not isinstance(gd, bool):
                     raise ValueError("Conditions must not contain free symbols")
@@ -702,14 +703,14 @@ def sample_iter_lambdify(expr, given=None, numsamples=S.Infinity, **kwargs):
             count += 1
     return return_generator()
 
-def sample_iter_subs(expr, given=None, numsamples=S.Infinity, **kwargs):
+def sample_iter_subs(expr, condition=None, numsamples=S.Infinity, **kwargs):
     """
     See sample_iter
 
     Uses subs for computation. This is slow but almost always works.
     """
-    if given:
-        ps = pspace(Tuple(expr, given))
+    if condition:
+        ps = pspace(Tuple(expr, condition))
     else:
         ps = pspace(expr)
 
@@ -719,8 +720,8 @@ def sample_iter_subs(expr, given=None, numsamples=S.Infinity, **kwargs):
         d = ps.sample() # a dictionary that maps RVs to values
 
 
-        if given: # Check that these values satisfy the condition
-            gd = given.subs(d)
+        if condition: # Check that these values satisfy the condition
+            gd = condition.subs(d)
             if not isinstance(gd, bool):
                 raise ValueError("Conditions must not contain free symbols")
             if gd == False: # If the values don't satisfy then try again
@@ -729,7 +730,8 @@ def sample_iter_subs(expr, given=None, numsamples=S.Infinity, **kwargs):
         yield expr.subs(d)
 
         count += 1
-def sampling_P(condition, given=None, numsamples=1, evalf=True, **kwargs):
+def sampling_P(condition, given_condition=None, numsamples=1,
+               evalf=True, **kwargs):
     """
     Sampling version of P
 
@@ -742,7 +744,8 @@ def sampling_P(condition, given=None, numsamples=1, evalf=True, **kwargs):
     count_true = 0
     count_false = 0
 
-    samples = sample_iter(condition, given, numsamples=numsamples, **kwargs)
+    samples = sample_iter(condition, given_condition,
+                          numsamples=numsamples, **kwargs)
 
     for x in samples:
         if not isinstance(x, bool):
@@ -759,7 +762,8 @@ def sampling_P(condition, given=None, numsamples=1, evalf=True, **kwargs):
     else:
         return result
 
-def sampling_E(condition, given=None, numsamples=1, evalf=True, **kwargs):
+def sampling_E(condition, given_condition=None, numsamples=1,
+               evalf=True, **kwargs):
     """
     Sampling version of E
 
@@ -769,7 +773,8 @@ def sampling_E(condition, given=None, numsamples=1, evalf=True, **kwargs):
     sampling_P
     """
 
-    samples = sample_iter(condition, given, numsamples=numsamples, **kwargs)
+    samples = sample_iter(condition, given_condition,
+                          numsamples=numsamples, **kwargs)
 
     result = Add(*list(samples)) / numsamples
     if evalf:
@@ -787,7 +792,7 @@ def dependent(a, b):
     Examples
     ========
 
-    >>> from sympy.stats import Normal, dependent, Given
+    >>> from sympy.stats import Normal, dependent, given
     >>> from sympy import Tuple, Eq
 
     >>> X, Y = Normal(0, 1), Normal(0, 1)
@@ -795,7 +800,7 @@ def dependent(a, b):
     False
     >>> dependent(2*X + Y, -Y)
     True
-    >>> X, Y = Given(Tuple(X, Y), Eq(X+Y,3))
+    >>> X, Y = given(Tuple(X, Y), Eq(X+Y,3))
     >>> dependent(X, Y)
     True
 
@@ -809,8 +814,8 @@ def dependent(a, b):
     z = Symbol('z', real=True)
     # Dependent if density is unchanged when one is given information about
     # the other
-    return (Density(a, Eq(b, z)) != Density(a) or
-            Density(b, Eq(a, z)) != Density(b))
+    return (density(a, Eq(b, z)) != density(a) or
+            density(b, Eq(a, z)) != density(b))
 
 def independent(a, b):
     """
@@ -822,7 +827,7 @@ def independent(a, b):
     Examples
     ========
 
-    >>> from sympy.stats import Normal, independent, Given
+    >>> from sympy.stats import Normal, independent, given
     >>> from sympy import Tuple, Eq
 
     >>> X, Y = Normal(0, 1), Normal(0, 1)
@@ -830,7 +835,7 @@ def independent(a, b):
     True
     >>> independent(2*X + Y, -Y)
     False
-    >>> X, Y = Given(Tuple(X, Y), Eq(X+Y,3))
+    >>> X, Y = given(Tuple(X, Y), Eq(X+Y,3))
     >>> independent(X, Y)
     False
 

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -3,7 +3,7 @@ from rv import (probability, expectation, density, where, given, pspace, cdf,
 from sympy import sqrt
 
 __all__ = ['P', 'E', 'density', 'where', 'given', 'sample', 'cdf', 'pspace',
-        'sample_iter', 'var', 'std', 'skewness', 'covar', 'dependent',
+        'sample_iter', 'variance', 'std', 'skewness', 'covariance', 'dependent',
         'independent', 'random_symbols']
 
 def variance(X, condition=None, **kwargs):
@@ -15,23 +15,21 @@ def variance(X, condition=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Die, E, Bernoulli, var
+    >>> from sympy.stats import Die, E, Bernoulli, variance
     >>> from sympy import simplify, Symbol
 
     >>> X = Die(6)
     >>> p = Symbol('p')
     >>> B = Bernoulli(p, 1, 0)
 
-    >>> var(2*X)
+    >>> variance(2*X)
     35/3
 
-    >>> simplify(var(B))
+    >>> simplify(variance(B))
     p*(-p + 1)
     """
     return (expectation(X**2, condition, **kwargs) -
             expectation(X, condition, **kwargs)**2)
-var = variance
-
 
 def standard_deviation(X, condition=None, **kwargs):
     """
@@ -65,18 +63,18 @@ def covariance(X, Y, condition=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Exponential, covar
+    >>> from sympy.stats import Exponential, covariance
     >>> from sympy import Symbol
 
     >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
     >>> X = Exponential(rate)
     >>> Y = Exponential(rate)
 
-    >>> covar(X, X)
+    >>> covariance(X, X)
     lambda**(-2)
-    >>> covar(X, Y)
+    >>> covariance(X, Y)
     0
-    >>> covar(X, Y + rate*X)
+    >>> covariance(X, Y + rate*X)
     1/lambda
     """
 
@@ -84,7 +82,6 @@ def covariance(X, Y, condition=None, **kwargs):
             (X - expectation(X, condition, **kwargs)) *
             (Y - expectation(Y, condition, **kwargs)),
                       condition, **kwargs)
-covar = covariance
 
 def skewness(X, condition=None, **kwargs):
 

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -1,12 +1,12 @@
-from rv import (P, E, Density, Where, Given, pspace, CDF, Sample, sample_iter,
-        random_symbols, independent, dependent)
+from rv import (probability, expectation, density, where, given, pspace, cdf,
+        sample, sample_iter, random_symbols, independent, dependent)
 from sympy import sqrt
 
-__all__ = ['P', 'E', 'Density', 'Where', 'Given', 'Sample', 'CDF', 'pspace',
-        'sample_iter', 'Var', 'Std', 'Skewness', 'Covar', 'dependent',
+__all__ = ['P', 'E', 'density', 'where', 'given', 'sample', 'cdf', 'pspace',
+        'sample_iter', 'var', 'std', 'skewness', 'covar', 'dependent',
         'independent', 'random_symbols']
 
-def variance(X, given=None, **kwargs):
+def variance(X, condition=None, **kwargs):
     """
     Variance of a random expression
 
@@ -15,24 +15,25 @@ def variance(X, given=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Die, E, Bernoulli, Var
+    >>> from sympy.stats import Die, E, Bernoulli, var
     >>> from sympy import simplify, Symbol
 
     >>> X = Die(6)
     >>> p = Symbol('p')
     >>> B = Bernoulli(p, 1, 0)
 
-    >>> Var(2*X)
+    >>> var(2*X)
     35/3
 
-    >>> simplify(Var(B))
+    >>> simplify(var(B))
     p*(-p + 1)
     """
-    return E(X**2, given, **kwargs) - E(X, given, **kwargs)**2
-Var = variance
+    return (expectation(X**2, condition, **kwargs) -
+            expectation(X, condition, **kwargs)**2)
+var = variance
 
 
-def standard_deviation(X, given=None, **kwargs):
+def standard_deviation(X, condition=None, **kwargs):
     """
     Standard Deviation of a random expression
 
@@ -41,19 +42,19 @@ def standard_deviation(X, given=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Bernoulli, Std
+    >>> from sympy.stats import Bernoulli, std
     >>> from sympy import Symbol
 
     >>> p = Symbol('p')
     >>> B = Bernoulli(p, 1, 0)
 
-    >>> Std(B)
+    >>> std(B)
     sqrt(-p**2 + p)
     """
-    return sqrt(variance(X, given, **kwargs))
-Std = standard_deviation
+    return sqrt(variance(X, condition, **kwargs))
+std = standard_deviation
 
-def covariance(X, Y, given=None, **kwargs):
+def covariance(X, Y, condition=None, **kwargs):
     """
     Covariance of two random expressions
 
@@ -64,29 +65,32 @@ def covariance(X, Y, given=None, **kwargs):
     Examples
     ========
 
-    >>> from sympy.stats import Exponential, Covar
+    >>> from sympy.stats import Exponential, covar
     >>> from sympy import Symbol
 
     >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
     >>> X = Exponential(rate)
     >>> Y = Exponential(rate)
 
-    >>> Covar(X, X)
+    >>> covar(X, X)
     lambda**(-2)
-    >>> Covar(X, Y)
+    >>> covar(X, Y)
     0
-    >>> Covar(X, Y + rate*X)
+    >>> covar(X, Y + rate*X)
     1/lambda
     """
 
-    return E( (X-E(X, given, **kwargs)) * (Y-E(Y, given, **kwargs)),
-            given, **kwargs)
-Covar = covariance
+    return expectation(
+            (X - expectation(X, condition, **kwargs)) *
+            (Y - expectation(Y, condition, **kwargs)),
+                      condition, **kwargs)
+covar = covariance
 
-def skewness(X, given=None, **kwargs):
+def skewness(X, condition=None, **kwargs):
 
-    mu = E(X, given, **kwargs)
-    sigma = Std(X, given, **kwargs)
-    return E( ((X-mu)/sigma) ** 3 , given, **kwargs)
-Skewness = skewness
+    mu = expectation(X, condition, **kwargs)
+    sigma = std(X, condition, **kwargs)
+    return expectation( ((X-mu)/sigma) ** 3 , condition, **kwargs)
 
+P = probability
+E = expectation

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1,4 +1,4 @@
-from sympy.stats import (P, E, where, density, var, covar, skewness,
+from sympy.stats import (P, E, where, density, variance, covariance, skewness,
                          given, pspace, cdf, ContinuousRV, sample)
 from sympy.stats import (Arcsin, Benini, Beta, BetaPrime, Cauchy, Chi, Dagum,
                          Exponential, Gamma, Laplace, Logistic, LogNormal,
@@ -10,7 +10,6 @@ from sympy import (Symbol, Dummy, Abs, exp, S, N, pi, simplify, Interval, erf,
                    Piecewise, Integral, sin, Lambda, factorial, binomial, floor)
 from sympy.utilities.pytest import raises, XFAIL
 
-variance = var
 oo = S.Infinity
 
 _x = Dummy("x")
@@ -23,7 +22,7 @@ def test_single_normal():
     Y = X*sigma + mu
 
     assert simplify(E(Y)) == mu
-    assert simplify(var(Y)) == sigma**2
+    assert simplify(variance(Y)) == sigma**2
     pdf = density(Y)
     x = Symbol('x')
     assert pdf(x) == 2**S.Half*exp(-(x - mu)**2/(2*sigma**2))/(2*pi**S.Half*sigma)
@@ -59,13 +58,13 @@ def test_multiple_normal():
     X, Y = Normal(0,1), Normal(0,1)
 
     assert E(X+Y) == 0
-    assert var(X+Y) == 2
-    assert var(X+X) == 4
-    assert covar(X, Y) == 0
-    assert covar(2*X + Y, -X) == -2*var(X)
+    assert variance(X+Y) == 2
+    assert variance(X+X) == 4
+    assert covariance(X, Y) == 0
+    assert covariance(2*X + Y, -X) == -2*variance(X)
 
     assert E(X, Eq(X+Y, 0)) == 0
-    assert var(X, Eq(X+Y, 0)) == S.Half
+    assert variance(X, Eq(X+Y, 0)) == S.Half
 
 def test_symbolic():
     mu1, mu2 = symbols('mu1 mu2', real=True, bounded=True)
@@ -79,8 +78,8 @@ def test_symbolic():
     assert E(X) == mu1
     assert E(X+Y) == mu1+mu2
     assert E(a*X+b) == a*E(X)+b
-    assert var(X) == s1**2
-    assert simplify(var(X+a*Y+b)) == var(X) + a**2*var(Y)
+    assert variance(X) == s1**2
+    assert simplify(variance(X+a*Y+b)) == variance(X) + a**2*variance(Y)
 
     assert E(Z) == 1/rate
     assert E(a*Z+b) == a*E(Z)+b
@@ -122,7 +121,7 @@ def test_ContinuousRV():
     X = ContinuousRV(x, pdf)
     Y = Normal(0, 1)
 
-    assert var(X) == var(Y)
+    assert variance(X) == variance(Y)
     assert P(X>0) == P(Y>0)
 
 
@@ -159,13 +158,13 @@ def test_beta():
 
     # This is too slow
     # assert E(B) == a / (a + b)
-    # assert var(B) == (a*b) / ((a+b)**2 * (a+b+1))
+    # assert variance(B) == (a*b) / ((a+b)**2 * (a+b+1))
 
     # Full symbolic solution is too much, test with numeric version
     a, b = 1, 2
     B = Beta(a, b)
     assert E(B) == a / S(a + b)
-    assert var(B) == (a*b) / S((a+b)**2 * (a+b+1))
+    assert variance(B) == (a*b) / S((a+b)**2 * (a+b+1))
 
 
 def test_betaprime():
@@ -212,7 +211,7 @@ def test_exponential():
     X = Exponential(rate)
 
     assert E(X) == 1/rate
-    assert var(X) == 1/rate**2
+    assert variance(X) == 1/rate**2
     assert skewness(X) == 2
     assert P(X>0) == S(1)
     assert P(X>1) == exp(-rate)
@@ -231,7 +230,7 @@ def test_gamma():
                                 _x**(k - 1)*theta**(-k)*exp(-_x/theta)/gamma(k))
     assert cdf(X, meijerg=True) == Lambda(_z, Piecewise((0, _z < 0),
     (-k*lowergamma(k, 0)/gamma(k + 1) + k*lowergamma(k, _z/theta)/gamma(k + 1), True)))
-    assert var(X) == (-theta**2*gamma(k + 1)**2/gamma(k)**2 +
+    assert variance(X) == (-theta**2*gamma(k + 1)**2/gamma(k)**2 +
            theta*theta**(-k)*theta**(k + 1)*gamma(k + 2)/gamma(k))
 
     k, theta = symbols('k theta', real=True, bounded=True, positive=True)
@@ -239,7 +238,7 @@ def test_gamma():
 
     assert simplify(E(X)) == k*theta
     # can't get things to simplify on this one so we use subs
-    assert var(X).subs(k,5) == (k*theta**2).subs(k, 5)
+    assert variance(X).subs(k,5) == (k*theta**2).subs(k, 5)
     # The following is too slow
     # assert simplify(skewness(X)).subs(k, 5) == (2/sqrt(k)).subs(k, 5)
 
@@ -269,7 +268,7 @@ def test_lognormal():
     X = LogNormal(mean, std)
     # The sympy integrator can't do this too well
     #assert E(X) == exp(mean+std**2/2)
-    #assert var(X) == (exp(std**2)-1) * exp(2*mean + std**2)
+    #assert variance(X) == (exp(std**2)-1) * exp(2*mean + std**2)
 
     # Right now, only density function and sampling works
     # Test sampling: Only e^mean in sample std of 0
@@ -300,7 +299,7 @@ def test_maxwell():
     assert density(X) == (Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/
         (sqrt(pi)*a**3)))
     assert E(X) == 2*sqrt(2)*a/sqrt(pi)
-    assert simplify(var(X)) == a**2*(-8 + 3*pi)/pi
+    assert simplify(variance(X)) == a**2*(-8 + 3*pi)/pi
 
 def test_nakagami():
     mu = Symbol("mu", positive=True)
@@ -327,7 +326,7 @@ def test_pareto():
 
     # These fail because SymPy can not deduce that 1/xm != 0
     # assert simplify(E(X)) == alpha*xm/(alpha-1)
-    # assert simplify(var(X)) == xm**2*alpha / ((alpha-1)**2*(alpha-2))
+    # assert simplify(variance(X)) == xm**2*alpha / ((alpha-1)**2*(alpha-2))
 
 def test_weibull_numeric():
     # Test for integers and rationals
@@ -336,7 +335,7 @@ def test_weibull_numeric():
     for b in bvals:
         X = Weibull(a, b)
         assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
-        assert simplify(var(X)) == simplify(a**2 * gamma(1 + 2/S(b)) - E(X)**2)
+        assert simplify(variance(X)) == simplify(a**2 * gamma(1 + 2/S(b)) - E(X)**2)
         # Not testing Skew... it's slow with int/frac values > 3/2
 
 def test_pareto_numeric():
@@ -385,7 +384,7 @@ def test_uniform():
     X = Uniform(l, l+w)
 
     assert simplify(E(X)) == l + w/2
-    assert simplify(var(X)) == w**2/12
+    assert simplify(variance(X)) == w**2/12
 
     assert P(X<l) == 0 and P(X>l+w) == 0
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -328,16 +328,6 @@ def test_pareto():
     # assert simplify(E(X)) == alpha*xm/(alpha-1)
     # assert simplify(variance(X)) == xm**2*alpha / ((alpha-1)**2*(alpha-2))
 
-def test_weibull_numeric():
-    # Test for integers and rationals
-    a = 1
-    bvals = [S.Half, 1, S(3)/2, 5]
-    for b in bvals:
-        X = Weibull(a, b)
-        assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
-        assert simplify(variance(X)) == simplify(a**2 * gamma(1 + 2/S(b)) - E(X)**2)
-        # Not testing Skew... it's slow with int/frac values > 3/2
-
 def test_pareto_numeric():
     xm, beta = 3, 2
     alpha = beta + 5

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1,14 +1,16 @@
-from sympy.stats import (P, E, Where, Density, Var, Covar, Skewness, Given,
-                         pspace, CDF, ContinuousRV, Sample, Arcsin, Benini,
-                         Beta, BetaPrime, Cauchy, Chi, Dagum, Exponential,
-                         Gamma, Laplace, Logistic, LogNormal, Maxwell, Nakagami,
-                         Normal, Pareto, Rayleigh, StudentT, Triangular,
-                         Uniform, UniformSum, Weibull, WignerSemicircle)
+from sympy.stats import (P, E, where, density, var, covar, skewness,
+                         given, pspace, cdf, ContinuousRV, sample)
+from sympy.stats import (Arcsin, Benini, Beta, BetaPrime, Cauchy, Chi, Dagum,
+                         Exponential, Gamma, Laplace, Logistic, LogNormal,
+                         Maxwell, Nakagami, Normal, Pareto, Rayleigh, StudentT,
+                         Triangular, Uniform, UniformSum, Weibull,
+                         WignerSemicircle)
 from sympy import (Symbol, Dummy, Abs, exp, S, N, pi, simplify, Interval, erf,
                    Eq, log, lowergamma, Sum, symbols, sqrt, And, gamma, beta,
                    Piecewise, Integral, sin, Lambda, factorial, binomial, floor)
 from sympy.utilities.pytest import raises, XFAIL
 
+variance = var
 oo = S.Infinity
 
 _x = Dummy("x")
@@ -21,8 +23,8 @@ def test_single_normal():
     Y = X*sigma + mu
 
     assert simplify(E(Y)) == mu
-    assert simplify(Var(Y)) == sigma**2
-    pdf = Density(Y)
+    assert simplify(var(Y)) == sigma**2
+    pdf = density(Y)
     x = Symbol('x')
     assert pdf(x) == 2**S.Half*exp(-(x - mu)**2/(2*sigma**2))/(2*pi**S.Half*sigma)
 
@@ -33,9 +35,9 @@ def test_single_normal():
 @XFAIL
 def test_conditional_1d():
     X = Normal(0,1)
-    Y = Given(X, X>=0)
+    Y = given(X, X>=0)
 
-    assert Density(Y) == 2 * Density(X)
+    assert density(Y) == 2 * density(X)
 
     assert Y.pspace.domain.set == Interval(0, oo)
     assert E(Y) == sqrt(2) / sqrt(pi)
@@ -44,12 +46,12 @@ def test_conditional_1d():
 
 def test_ContinuousDomain():
     X = Normal(0,1)
-    assert Where(X**2<=1).set == Interval(-1,1)
-    assert Where(X**2<=1).symbol == X.symbol
-    Where(And(X**2<=1, X>=0)).set == Interval(0,1)
-    raises(ValueError, "Where(sin(X)>1)")
+    assert where(X**2<=1).set == Interval(-1,1)
+    assert where(X**2<=1).symbol == X.symbol
+    where(And(X**2<=1, X>=0)).set == Interval(0,1)
+    raises(ValueError, "where(sin(X)>1)")
 
-    Y = Given(X, X>=0)
+    Y = given(X, X>=0)
 
     assert Y.pspace.domain.set == Interval(0, oo)
 
@@ -57,13 +59,13 @@ def test_multiple_normal():
     X, Y = Normal(0,1), Normal(0,1)
 
     assert E(X+Y) == 0
-    assert Var(X+Y) == 2
-    assert Var(X+X) == 4
-    assert Covar(X, Y) == 0
-    assert Covar(2*X + Y, -X) == -2*Var(X)
+    assert var(X+Y) == 2
+    assert var(X+X) == 4
+    assert covar(X, Y) == 0
+    assert covar(2*X + Y, -X) == -2*var(X)
 
     assert E(X, Eq(X+Y, 0)) == 0
-    assert Var(X, Eq(X+Y, 0)) == S.Half
+    assert var(X, Eq(X+Y, 0)) == S.Half
 
 def test_symbolic():
     mu1, mu2 = symbols('mu1 mu2', real=True, bounded=True)
@@ -77,39 +79,39 @@ def test_symbolic():
     assert E(X) == mu1
     assert E(X+Y) == mu1+mu2
     assert E(a*X+b) == a*E(X)+b
-    assert Var(X) == s1**2
-    assert simplify(Var(X+a*Y+b)) == Var(X) + a**2*Var(Y)
+    assert var(X) == s1**2
+    assert simplify(var(X+a*Y+b)) == var(X) + a**2*var(Y)
 
     assert E(Z) == 1/rate
     assert E(a*Z+b) == a*E(Z)+b
     assert E(X+a*Z+b) == mu1 + a/rate + b
 
-def test_CDF():
+def test_cdf():
     X = Normal(0,1)
 
-    d = CDF(X)
+    d = cdf(X)
     assert P(X<1) == d(1)
     assert d(0) == S.Half
 
-    d = CDF(X, X>0) # given X>0
+    d = cdf(X, X>0) # given X>0
     assert d(0) == 0
 
     Y = Exponential(10)
-    d = CDF(Y)
+    d = cdf(Y)
     assert d(-5) == 0
     assert P(Y > 3) == 1 - d(3)
 
-    raises(ValueError, "CDF(X+Y)")
+    raises(ValueError, "cdf(X+Y)")
 
     Z = Exponential(1)
-    cdf = CDF(Z)
+    f = cdf(Z)
     z = Symbol('z')
-    assert cdf(z) == Piecewise((0, z < 0), (1 - exp(-z), True))
+    assert f(z) == Piecewise((0, z < 0), (1 - exp(-z), True))
 
 def test_sample():
     z = Symbol('z')
     Z = ContinuousRV(z, exp(-z), set=Interval(0,oo))
-    assert Sample(Z) in Z.pspace.domain.set
+    assert sample(Z) in Z.pspace.domain.set
     sym, val = Z.pspace.sample().items()[0]
     assert sym == Z and val in Interval(0, oo)
 
@@ -120,7 +122,7 @@ def test_ContinuousRV():
     X = ContinuousRV(x, pdf)
     Y = Normal(0, 1)
 
-    assert Var(X) == Var(Y)
+    assert var(X) == var(Y)
     assert P(X>0) == P(Y>0)
 
 
@@ -130,7 +132,7 @@ def test_arcsin():
     x = Symbol("x")
 
     X = Arcsin(a, b, symbol=x)
-    assert Density(X) == Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
+    assert density(X) == Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
 
 
 def test_benini():
@@ -140,7 +142,7 @@ def test_benini():
     x = Symbol("x")
 
     X = Benini(alpha, b, sigma, symbol=x)
-    assert Density(X) == (Lambda(_x, (alpha/_x + 2*b*log(_x/sigma)/_x)
+    assert density(X) == (Lambda(_x, (alpha/_x + 2*b*log(_x/sigma)/_x)
                           *exp(-alpha*log(_x/sigma) - b*log(_x/sigma)**2)))
 
 
@@ -151,19 +153,19 @@ def test_beta():
 
     assert pspace(B).domain.set == Interval(0, 1)
 
-    dens = Density(B)
+    dens = density(B)
     x = Symbol('x')
     assert dens(x) == x**(a-1)*(1-x)**(b-1) / beta(a,b)
 
     # This is too slow
     # assert E(B) == a / (a + b)
-    # assert Var(B) == (a*b) / ((a+b)**2 * (a+b+1))
+    # assert var(B) == (a*b) / ((a+b)**2 * (a+b+1))
 
     # Full symbolic solution is too much, test with numeric version
     a, b = 1, 2
     B = Beta(a, b)
     assert E(B) == a / S(a + b)
-    assert Var(B) == (a*b) / S((a+b)**2 * (a+b+1))
+    assert var(B) == (a*b) / S((a+b)**2 * (a+b+1))
 
 
 def test_betaprime():
@@ -172,7 +174,7 @@ def test_betaprime():
     x = Symbol("x")
 
     X = BetaPrime(alpha, beta, symbol=x)
-    assert Density(X) == (Lambda(_x, _x**(alpha - 1)*(_x + 1)**(-alpha - beta)
+    assert density(X) == (Lambda(_x, _x**(alpha - 1)*(_x + 1)**(-alpha - beta)
                           *gamma(alpha + beta)/(gamma(alpha)*gamma(beta))))
 
 
@@ -182,7 +184,7 @@ def test_cauchy():
     x = Symbol("x")
 
     X = Cauchy(x0, gamma, symbol=x)
-    assert Density(X) == Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
+    assert density(X) == Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
 
 
 def test_chi():
@@ -190,7 +192,7 @@ def test_chi():
     x = Symbol("x")
 
     X = Chi(k, symbol=x)
-    assert Density(X) == (Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)
+    assert density(X) == (Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)
                           *exp(-_x**2/2)/gamma(k/2)))
 
 
@@ -201,7 +203,7 @@ def test_dagum():
     x = Symbol("x")
 
     X = Dagum(p, a, b, symbol=x)
-    assert Density(X) == Lambda(_x,
+    assert density(X) == Lambda(_x,
                                 a*p*(_x/b)**(a*p)*((_x/b)**a + 1)**(-p - 1)/_x)
 
 
@@ -210,13 +212,13 @@ def test_exponential():
     X = Exponential(rate)
 
     assert E(X) == 1/rate
-    assert Var(X) == 1/rate**2
-    assert Skewness(X) == 2
+    assert var(X) == 1/rate**2
+    assert skewness(X) == 2
     assert P(X>0) == S(1)
     assert P(X>1) == exp(-rate)
     assert P(X>10) == exp(-10*rate)
 
-    assert Where(X<=1).set == Interval(0,1)
+    assert where(X<=1).set == Interval(0,1)
 
 
 def test_gamma():
@@ -225,11 +227,11 @@ def test_gamma():
     x = Symbol("x")
 
     X = Gamma(k, theta, symbol=x)
-    assert Density(X) == Lambda(_x,
+    assert density(X) == Lambda(_x,
                                 _x**(k - 1)*theta**(-k)*exp(-_x/theta)/gamma(k))
-    assert CDF(X, meijerg=True) == Lambda(_z, Piecewise((0, _z < 0),
+    assert cdf(X, meijerg=True) == Lambda(_z, Piecewise((0, _z < 0),
     (-k*lowergamma(k, 0)/gamma(k + 1) + k*lowergamma(k, _z/theta)/gamma(k + 1), True)))
-    assert Var(X) == (-theta**2*gamma(k + 1)**2/gamma(k)**2 +
+    assert var(X) == (-theta**2*gamma(k + 1)**2/gamma(k)**2 +
            theta*theta**(-k)*theta**(k + 1)*gamma(k + 2)/gamma(k))
 
     k, theta = symbols('k theta', real=True, bounded=True, positive=True)
@@ -237,9 +239,9 @@ def test_gamma():
 
     assert simplify(E(X)) == k*theta
     # can't get things to simplify on this one so we use subs
-    assert Var(X).subs(k,5) == (k*theta**2).subs(k, 5)
+    assert var(X).subs(k,5) == (k*theta**2).subs(k, 5)
     # The following is too slow
-    # assert simplify(Skewness(X)).subs(k, 5) == (2/sqrt(k)).subs(k, 5)
+    # assert simplify(skewness(X)).subs(k, 5) == (2/sqrt(k)).subs(k, 5)
 
 
 def test_laplace():
@@ -248,7 +250,7 @@ def test_laplace():
     x = Symbol("x")
 
     X = Laplace(mu, b, symbol=x)
-    assert Density(X) == Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
+    assert density(X) == Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
 
 
 def test_logistic():
@@ -257,7 +259,7 @@ def test_logistic():
     x = Symbol("x")
 
     X = Logistic(mu, s, symbol=x)
-    assert Density(X) == Lambda(_x,
+    assert density(X) == Lambda(_x,
                                 exp((-_x + mu)/s)/(s*(exp((-_x + mu)/s) + 1)**2))
 
 
@@ -267,13 +269,13 @@ def test_lognormal():
     X = LogNormal(mean, std)
     # The sympy integrator can't do this too well
     #assert E(X) == exp(mean+std**2/2)
-    #assert Var(X) == (exp(std**2)-1) * exp(2*mean + std**2)
+    #assert var(X) == (exp(std**2)-1) * exp(2*mean + std**2)
 
     # Right now, only density function and sampling works
     # Test sampling: Only e^mean in sample std of 0
     for i in range(3):
         X = LogNormal(i, 0)
-        assert S(Sample(X)) == N(exp(i))
+        assert S(sample(X)) == N(exp(i))
     # The sympy integrator can't do this too well
     #assert E(X) ==
 
@@ -282,11 +284,11 @@ def test_lognormal():
     x = Symbol("x")
 
     X = LogNormal(mu, sigma, symbol=x)
-    assert Density(X) == (Lambda(_x, sqrt(2)*exp(-(-mu + log(_x))**2
+    assert density(X) == (Lambda(_x, sqrt(2)*exp(-(-mu + log(_x))**2
                                     /(2*sigma**2))/(2*_x*sqrt(pi)*sigma)))
 
     X = LogNormal(0, 1, symbol=Symbol('x')) # Mean 0, standard deviation 1
-    assert Density(X) == Lambda(_x, sqrt(2)*exp(-log(_x)**2/2)/(2*_x*sqrt(pi)))
+    assert density(X) == Lambda(_x, sqrt(2)*exp(-log(_x)**2/2)/(2*_x*sqrt(pi)))
 
 
 def test_maxwell():
@@ -295,10 +297,10 @@ def test_maxwell():
 
     X = Maxwell(a, symbol=x)
 
-    assert Density(X) == Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/(sqrt(pi)*a**3))
+    assert density(X) == (Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/
+        (sqrt(pi)*a**3)))
     assert E(X) == 2*sqrt(2)*a/sqrt(pi)
-    assert simplify(Var(X)) == a**2*(-8 + 3*pi)/pi
-
+    assert simplify(var(X)) == a**2*(-8 + 3*pi)/pi
 
 def test_nakagami():
     mu = Symbol("mu", positive=True)
@@ -306,27 +308,36 @@ def test_nakagami():
     x = Symbol("x")
 
     X = Nakagami(mu, omega, symbol=x)
-    assert Density(X) == (Lambda(_x, 2*_x**(2*mu - 1)*mu**mu*omega**(-mu)
+    assert density(X) == (Lambda(_x, 2*_x**(2*mu - 1)*mu**mu*omega**(-mu)
                                 *exp(-_x**2*mu/omega)/gamma(mu)))
     assert simplify(E(X, meijerg=True)) == (sqrt(mu)*sqrt(omega)
            *gamma(mu + S.Half)/gamma(mu + 1))
-    assert simplify(Var(X, meijerg=True)) == (omega*(gamma(mu)*gamma(mu + 1)
-                          - gamma(mu + S.Half)**2)/(gamma(mu)*gamma(mu + 1)))
-
+    assert (simplify(variance(X, meijerg=True)) ==
+                            (omega*(gamma(mu)*gamma(mu + 1)
+                          - gamma(mu + S.Half)**2)/(gamma(mu)*gamma(mu + 1))))
 
 def test_pareto():
     xm, beta = symbols('xm beta', positive=True, bounded=True)
     alpha = beta + 5
     X = Pareto(xm, alpha)
 
-    density = Density(X)
+    dens = density(X)
     x = Symbol('x')
-    assert density(x) == x**(-(alpha+1))*xm**(alpha)*(alpha)
+    assert dens(x) == x**(-(alpha+1))*xm**(alpha)*(alpha)
 
     # These fail because SymPy can not deduce that 1/xm != 0
     # assert simplify(E(X)) == alpha*xm/(alpha-1)
-    # assert simplify(Var(X)) == xm**2*alpha / ((alpha-1)**2*(alpha-2))
+    # assert simplify(var(X)) == xm**2*alpha / ((alpha-1)**2*(alpha-2))
 
+def test_weibull_numeric():
+    # Test for integers and rationals
+    a = 1
+    bvals = [S.Half, 1, S(3)/2, 5]
+    for b in bvals:
+        X = Weibull(a, b)
+        assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
+        assert simplify(var(X)) == simplify(a**2 * gamma(1 + 2/S(b)) - E(X)**2)
+        # Not testing Skew... it's slow with int/frac values > 3/2
 
 def test_pareto_numeric():
     xm, beta = 3, 2
@@ -334,27 +345,25 @@ def test_pareto_numeric():
     X = Pareto(xm, alpha)
 
     assert E(X) == alpha*xm/S(alpha-1)
-    assert Var(X) == xm**2*alpha / S(((alpha-1)**2*(alpha-2)))
-
+    assert variance(X) == xm**2*alpha / S(((alpha-1)**2*(alpha-2)))
+    # Skewness tests too slow. Try shortcutting function?
 
 def test_rayleigh():
     sigma = Symbol("sigma", positive=True)
     x = Symbol("x")
 
     X = Rayleigh(sigma, symbol=x)
-    assert Density(X) == Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
+    assert density(X) == Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
     assert E(X) == sqrt(2)*sqrt(pi)*sigma/2
-    assert Var(X) == -pi*sigma**2/2 + 2*sigma**2
-
+    assert variance(X) == -pi*sigma**2/2 + 2*sigma**2
 
 def test_studentt():
     nu = Symbol("nu", positive=True)
     x = Symbol("x")
 
     X = StudentT(nu, symbol=x)
-    assert Density(X) == (Lambda(_x, (_x**2/nu + 1)**(-nu/2 - S.Half)
-                          *gamma(nu/2 + S.Half)/(sqrt(pi)*sqrt(nu)*gamma(nu/2))))
-
+    assert density(X) == (Lambda(_x, (_x**2/nu + 1)**(-nu/2 - S.Half)
+                        *gamma(nu/2 + S.Half)/(sqrt(pi)*sqrt(nu)*gamma(nu/2))))
 
 @XFAIL
 def test_triangular():
@@ -370,14 +379,13 @@ def test_triangular():
                        ((-2*_x + 2*b)/((-a + b)*(b - c)), And(_x <= b, c < _x)),
                        (0, True)))
 
-
 def test_uniform():
     l = Symbol('l', real=True, bounded=True)
     w = Symbol('w', positive=True, bounded=True)
     X = Uniform(l, l+w)
 
     assert simplify(E(X)) == l + w/2
-    assert simplify(Var(X)) == w**2/12
+    assert simplify(var(X)) == w**2/12
 
     assert P(X<l) == 0 and P(X>l+w) == 0
 
@@ -394,18 +402,16 @@ def test_uniformsum():
     _k = Symbol("k")
 
     X = UniformSum(n, symbol=x)
-    assert Density(X) == (Lambda(_x, Sum((-1)**_k*(-_k + _x)**(n - 1)
-                         *binomial(n, _k), (_k, 0, floor(_x)))/factorial(n - 1)))
-
+    assert density(X) == (Lambda(_x, Sum((-1)**_k*(-_k + _x)**(n - 1)
+                        *binomial(n, _k), (_k, 0, floor(_x)))/factorial(n - 1)))
 
 def test_weibull():
     a, b = symbols('a b', positive=True)
     X = Weibull(a, b)
 
     assert simplify(E(X)) == simplify(a * gamma(1 + 1/b))
-    assert simplify(Var(X)) == simplify(a**2 * gamma(1 + 2/b) - E(X)**2)
+    assert simplify(variance(X)) == simplify(a**2 * gamma(1 + 2/b) - E(X)**2)
     # Skewness tests too slow. Try shortcutting function?
-
 
 def test_weibull_numeric():
     # Test for integers and rationals
@@ -414,18 +420,17 @@ def test_weibull_numeric():
     for b in bvals:
         X = Weibull(a, b)
         assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
-        assert simplify(Var(X)) == simplify(a**2 * gamma(1 + 2/S(b)) - E(X)**2)
+        assert simplify(variance(X)) == simplify(
+                a**2 * gamma(1 + 2/S(b)) - E(X)**2)
         # Not testing Skew... it's slow with int/frac values > 3/2
-
 
 def test_wignersemicircle():
     R = Symbol("R", positive=True)
     x = Symbol("x")
 
     X = WignerSemicircle(R, symbol=x)
-    assert Density(X) == Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
+    assert density(X) == Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
     assert E(X) == 0
-
 
 def test_prefab_sampling():
     N = Normal(0, 1)
@@ -441,7 +446,7 @@ def test_prefab_sampling():
     niter = 10
     for var in variables:
         for i in xrange(niter):
-            assert Sample(var) in var.pspace.domain.set
+            assert sample(var) in var.pspace.domain.set
 
 def test_input_value_assertions():
     a, b = symbols('a b')

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -1,8 +1,8 @@
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial)
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,
-        Hypergeometric, P, E, var, covar, skewness, sample, density, given,
-        independent, dependent, where, FiniteRV, pspace, cdf)
+        Hypergeometric, P, E, variance, covariance, skewness, sample, density,
+        given, independent, dependent, where, FiniteRV, pspace, cdf)
 from sympy.utilities.pytest import raises
 
 oo = S.Infinity
@@ -16,14 +16,14 @@ def test_discreteuniform():
     X = DiscreteUniform([a,b,c])
 
     assert E(X) == (a+b+c)/3
-    assert var(X) == (a**2+b**2+c**2)/3 - (a/3+b/3+c/3)**2
+    assert variance(X) == (a**2+b**2+c**2)/3 - (a/3+b/3+c/3)**2
     assert P(Eq(X, a)) == P(Eq(X, b)) == P(Eq(X, c)) == S('1/3')
 
     Y = DiscreteUniform(range(-5, 5))
 
     # Numeric
     assert E(Y) == S('-1/2')
-    assert var(Y) == S('33/4')
+    assert variance(Y) == S('33/4')
     assert skewness(Y) == 0
     for x in range(-5, 5):
         assert P(Eq(Y, x)) == S('1/10')
@@ -37,14 +37,14 @@ def test_dice():
     a,b = symbols('a b')
 
     assert E(X) == 3+S.Half
-    assert var(X) == S(35)/12
+    assert variance(X) == S(35)/12
     assert E(X+Y) == 7
     assert E(X+X) == 7
     assert E(a*X+b) == a*E(X)+b
-    assert var(X+Y) == var(X) + var(Y)
-    assert var(X+X) == 4 * var(X)
-    assert covar(X,Y) == S.Zero
-    assert covar(X, X+Y) == var(X)
+    assert variance(X+Y) == variance(X) + variance(Y)
+    assert variance(X+X) == 4 * variance(X)
+    assert covariance(X,Y) == S.Zero
+    assert covariance(X, X+Y) == variance(X)
     assert density(Eq(cos(X*S.Pi),1))[True] == S.Half
 
     assert P(X>3) == S.Half
@@ -121,9 +121,9 @@ def test_bernoulli():
     X = Bernoulli(p, 1, 0, symbol='B')
 
     assert E(X) == p
-    assert var(X) == -p**2 + p
+    assert variance(X) == -p**2 + p
     E(a*X+b) == a*E(X)+b
-    var(a*X+b) == a**2 * var(X)
+    variance(a*X+b) == a**2 * variance(X)
 
 def test_cdf():
     D = Die(6)
@@ -156,7 +156,7 @@ def test_binomial_numeric():
         for p in pvals:
             X = Binomial(n, p)
             assert Eq(E(X), n*p)
-            assert Eq(var(X), n*p*(1-p))
+            assert Eq(variance(X), n*p*(1-p))
             if n > 0 and 0 < p < 1:
                 assert Eq(skewness(X), (1-2*p)/sqrt(n*p*(1-p)))
             for k in range(n+1):
@@ -167,7 +167,7 @@ def test_binomial_symbolic():
     p = symbols('p', positive=True)
     X = Binomial(n, p)
     assert Eq(simplify(E(X)), n*p)
-    assert Eq(simplify(var(X)), n*p*(1-p))
+    assert Eq(simplify(variance(X)), n*p*(1-p))
 # Can't detect the equality
 #    assert Eq(simplify(skewness(X)), (1-2*p)/sqrt(n*p*(1-p)))
 
@@ -185,7 +185,7 @@ def test_hypergeometric_numeric():
                 assert sum(density(X).values()) == 1
                 assert E(X) == n * m / N
                 if N > 1:
-                    assert var(X) == n*(m/N)*(N-m)/N*(N-n)/(N-1)
+                    assert variance(X) == n*(m/N)*(N-m)/N*(N-n)/(N-1)
                 # Only test for skewness when defined
                 if N > 2 and 0 < m < N and n < N:
                     assert Eq(skewness(X),simplify((N-2*m)*sqrt(N-1)*(N-2*n)

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -1,8 +1,8 @@
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, Or, Dict, sympify, binomial)
 from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,
-        Hypergeometric, P, E, Var, Covar, Skewness, Sample, Density, Given,
-        independent, dependent, Where, FiniteRV, pspace, CDF)
+        Hypergeometric, P, E, var, covar, skewness, sample, density, given,
+        independent, dependent, where, FiniteRV, pspace, cdf)
 from sympy.utilities.pytest import raises
 
 oo = S.Infinity
@@ -16,36 +16,36 @@ def test_discreteuniform():
     X = DiscreteUniform([a,b,c])
 
     assert E(X) == (a+b+c)/3
-    assert Var(X) == (a**2+b**2+c**2)/3 - (a/3+b/3+c/3)**2
+    assert var(X) == (a**2+b**2+c**2)/3 - (a/3+b/3+c/3)**2
     assert P(Eq(X, a)) == P(Eq(X, b)) == P(Eq(X, c)) == S('1/3')
 
     Y = DiscreteUniform(range(-5, 5))
 
     # Numeric
     assert E(Y) == S('-1/2')
-    assert Var(Y) == S('33/4')
-    assert Skewness(Y) == 0
+    assert var(Y) == S('33/4')
+    assert skewness(Y) == 0
     for x in range(-5, 5):
         assert P(Eq(Y, x)) == S('1/10')
         assert P(Y <= x) == S(x+6)/10
         assert P(Y >= x) == S(5-x)/10
 
-    assert Density(Die(6)) == Density(DiscreteUniform(range(1,7)))
+    assert density(Die(6)) == density(DiscreteUniform(range(1,7)))
 
 def test_dice():
     X, Y, Z= Die(6), Die(6), Die(6)
     a,b = symbols('a b')
 
     assert E(X) == 3+S.Half
-    assert Var(X) == S(35)/12
+    assert var(X) == S(35)/12
     assert E(X+Y) == 7
     assert E(X+X) == 7
     assert E(a*X+b) == a*E(X)+b
-    assert Var(X+Y) == Var(X) + Var(Y)
-    assert Var(X+X) == 4 * Var(X)
-    assert Covar(X,Y) == S.Zero
-    assert Covar(X, X+Y) == Var(X)
-    assert Density(Eq(cos(X*S.Pi),1))[True] == S.Half
+    assert var(X+Y) == var(X) + var(Y)
+    assert var(X+X) == 4 * var(X)
+    assert covar(X,Y) == S.Zero
+    assert covar(X, X+Y) == var(X)
+    assert density(Eq(cos(X*S.Pi),1))[True] == S.Half
 
     assert P(X>3) == S.Half
     assert P(2*X > 6) == S.Half
@@ -62,28 +62,28 @@ def test_dice():
     assert P(Eq(X+Y, 12)) == S.One/36
     assert P(Eq(X+Y, 12), Eq(X, 6)) == S.One/6
 
-    assert Density(X+Y) == Density(Y+Z) != Density(X+X)
-    d = Density(2*X+Y**Z)
+    assert density(X+Y) == density(Y+Z) != density(X+X)
+    d = density(2*X+Y**Z)
     assert d[S(22)] == S.One/108 and d[S(4100)]==S.One/216 and S(3130) not in d
 
     assert pspace(X).domain.as_boolean() == Or(
             *[Eq(X.symbol, i) for i in [1,2,3,4,5,6]])
 
-    assert Where(X>3).set == FiniteSet(4,5,6)
+    assert where(X>3).set == FiniteSet(4,5,6)
 
 def test_given():
     X = Die(6)
-    Density(X, X>5) == {S(6): S(1)}
-    Where(X>2, X>5).as_boolean() == Eq(X.symbol, 6)
-    Sample(X, X>5) == 6
+    density(X, X>5) == {S(6): S(1)}
+    where(X>2, X>5).as_boolean() == Eq(X.symbol, 6)
+    sample(X, X>5) == 6
 
 def test_domains():
     x, y = symbols('x y')
     X, Y= Die(6, symbol=x), Die(6, symbol=y)
     # Domains
-    d = Where(X>Y)
+    d = where(X>Y)
     assert d.condition == (x > y)
-    d = Where(And(X>Y, Y>3))
+    d = where(And(X>Y, Y>3))
     assert d.as_boolean() == Or(And(Eq(x,5), Eq(y,4)), And(Eq(x,6), Eq(y,5)),
         And(Eq(x,6), Eq(y,4)))
     assert len(d.elements) == 3
@@ -96,11 +96,11 @@ def test_domains():
 
     pspace(X+Y).domain.set == FiniteSet(1,2,3,4,5,6)**2
 
-    assert Where(X>3).set == FiniteSet(4,5,6)
+    assert where(X>3).set == FiniteSet(4,5,6)
     assert X.pspace.domain.dict == FiniteSet(
             Dict({X.symbol:i}) for i in range(1,7))
 
-    assert Where(X>Y).dict == FiniteSet(Dict({X.symbol:i, Y.symbol:j})
+    assert where(X>Y).dict == FiniteSet(Dict({X.symbol:i, Y.symbol:j})
             for i in range(1,7) for j in range(1,7) if i>j)
 
 def test_dice_bayes():
@@ -115,29 +115,29 @@ def test_bernoulli():
     X = Bernoulli(p, a, b, symbol='B')
 
     assert E(X) == a*p + b*(-p+1)
-    assert Density(X)[a] == p
-    assert Density(X)[b] == 1-p
+    assert density(X)[a] == p
+    assert density(X)[b] == 1-p
 
     X = Bernoulli(p, 1, 0, symbol='B')
 
     assert E(X) == p
-    assert Var(X) == -p**2 + p
+    assert var(X) == -p**2 + p
     E(a*X+b) == a*E(X)+b
-    Var(a*X+b) == a**2 * Var(X)
+    var(a*X+b) == a**2 * var(X)
 
-def test_CDF():
+def test_cdf():
     D = Die(6)
     o = S.One
 
-    assert CDF(D) == sympify({1:o/6, 2:o/3, 3:o/2, 4:2*o/3, 5:5*o/6, 6:o})
+    assert cdf(D) == sympify({1:o/6, 2:o/3, 3:o/2, 4:2*o/3, 5:5*o/6, 6:o})
 
 def test_coins():
     C, D = Coin(), Coin()
-    H, T = sorted(Density(C).keys())
+    H, T = sorted(density(C).keys())
     assert P(Eq(C, D)) == S.Half
-    assert Density(Tuple(C, D)) == {(H, H): S.One/4, (H, T): S.One/4,
+    assert density(Tuple(C, D)) == {(H, H): S.One/4, (H, T): S.One/4,
             (T, H): S.One/4, (T, T): S.One/4}
-    assert Density(C) == {H: S.Half, T: S.Half}
+    assert density(C) == {H: S.Half, T: S.Half}
 
     E = Coin(S.One/10)
     assert P(Eq(E, H))==S(1)/10
@@ -156,9 +156,9 @@ def test_binomial_numeric():
         for p in pvals:
             X = Binomial(n, p)
             assert Eq(E(X), n*p)
-            assert Eq(Var(X), n*p*(1-p))
+            assert Eq(var(X), n*p*(1-p))
             if n > 0 and 0 < p < 1:
-                assert Eq(Skewness(X), (1-2*p)/sqrt(n*p*(1-p)))
+                assert Eq(skewness(X), (1-2*p)/sqrt(n*p*(1-p)))
             for k in range(n+1):
                 assert Eq(P(Eq(X, k)), binomial(n, k)*p**k*(1-p)**(n-k))
 
@@ -167,9 +167,9 @@ def test_binomial_symbolic():
     p = symbols('p', positive=True)
     X = Binomial(n, p)
     assert Eq(simplify(E(X)), n*p)
-    assert Eq(simplify(Var(X)), n*p*(1-p))
+    assert Eq(simplify(var(X)), n*p*(1-p))
 # Can't detect the equality
-#    assert Eq(simplify(Skewness(X)), (1-2*p)/sqrt(n*p*(1-p)))
+#    assert Eq(simplify(skewness(X)), (1-2*p)/sqrt(n*p*(1-p)))
 
     # Test ability to change success/failure winnings
     H, T = symbols('H T')
@@ -182,20 +182,20 @@ def test_hypergeometric_numeric():
             for n in range(1, N+1):
                 X = Hypergeometric(N, m, n)
                 N, m, n = map(sympify, (N, m, n))
-                assert sum(Density(X).values()) == 1
+                assert sum(density(X).values()) == 1
                 assert E(X) == n * m / N
                 if N > 1:
-                    assert Var(X) == n*(m/N)*(N-m)/N*(N-n)/(N-1)
+                    assert var(X) == n*(m/N)*(N-m)/N*(N-n)/(N-1)
                 # Only test for skewness when defined
                 if N > 2 and 0 < m < N and n < N:
-                    assert Eq(Skewness(X),simplify((N-2*m)*sqrt(N-1)*(N-2*n)
+                    assert Eq(skewness(X),simplify((N-2*m)*sqrt(N-1)*(N-2*n)
                         / (sqrt(n*m*(N-m)*(N-n))*(N-2))))
 
 
 def test_FiniteRV():
     F = FiniteRV({1:S.Half, 2:S.One/4, 3:S.One/4})
 
-    assert Density(F) =={S(1):S.Half, S(2):S.One/4, S(3):S.One/4}
+    assert density(F) =={S(1):S.Half, S(2):S.One/4, S(3):S.One/4}
     assert P(F>=2)==S.Half
 
     assert pspace(F).domain.as_boolean() == Or(

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,8 +1,8 @@
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum)
-from sympy.stats import (Die, Normal, Exponential , P, E, Var, Covar,
-        Skewness, Density, Given, independent, dependent, Where, pspace,
-        random_symbols, Sample)
+from sympy.stats import (Die, Normal, Exponential , P, E, var, covar,
+        skewness, density, given, independent, dependent, where, pspace,
+        random_symbols, sample)
 from sympy.stats.rv import ProductPSpace, rs_swap
 from sympy.utilities.pytest import raises, XFAIL
 
@@ -10,21 +10,21 @@ def test_where():
     X, Y = Die(), Die()
     Z = Normal(0, 1)
 
-    assert Where(Z**2<=1).set == Interval(-1, 1)
-    assert Where(Z**2<=1).as_boolean() == Interval(-1,1).as_relational(Z.symbol)
-    assert Where(And(X>Y, Y>4)).as_boolean() == And(
+    assert where(Z**2<=1).set == Interval(-1, 1)
+    assert where(Z**2<=1).as_boolean() == Interval(-1,1).as_relational(Z.symbol)
+    assert where(And(X>Y, Y>4)).as_boolean() == And(
             Eq(X.symbol, 6), Eq(Y.symbol, 5))
 
-    assert len(Where(X<3).set) == 2
-    assert 1 in Where(X<3).set
+    assert len(where(X<3).set) == 2
+    assert 1 in where(X<3).set
 
     X, Y = Normal(0, 1), Normal(0, 1)
-    assert Where(And(X**2 <= 1, X >= 0)).set == Interval(0, 1)
-    XX = Given(X, And(X**2 <= 1, X >= 0))
+    assert where(And(X**2 <= 1, X >= 0)).set == Interval(0, 1)
+    XX = given(X, And(X**2 <= 1, X >= 0))
     assert XX.pspace.domain.set == Interval(0, 1)
     assert XX.pspace.domain.as_boolean() == And(0 <= X.symbol, X.symbol**2 <= 1)
 
-    raises(TypeError, "XX = Given(X, X+3)")
+    raises(TypeError, "XX = given(X, X+3)")
 
 def test_random_symbols():
     X, Y = Normal(0,1), Normal(0,1)
@@ -84,12 +84,12 @@ def test_Sample():
     Y = Normal(0,1)
     z = Symbol('z')
 
-    assert Sample(X) in [1,2,3,4,5,6]
-    assert Sample(X+Y).is_Float
+    assert sample(X) in [1,2,3,4,5,6]
+    assert sample(X+Y).is_Float
 
     P(X+Y>0, Y<0, numsamples=10).is_number
     assert E(X+Y, numsamples=10).is_number
-    assert Var(X+Y, numsamples=10).is_number
+    assert var(X+Y, numsamples=10).is_number
 
     raises(ValueError, "P(Y>z, numsamples=5)")
 
@@ -99,11 +99,11 @@ def test_Sample():
     # Make sure this doesn't raise an error
     E(Sum(1/z**Y, (z,1,oo)), Y>2, numsamples=3)
 
-def test_Given():
+def test_given():
     X = Normal(0, 1)
     Y = Normal(0, 1)
-    A = Given(X, True)
-    B = Given(X, Y>2)
+    A = given(X, True)
+    B = given(X, Y>2)
 
     assert X == A == B
 
@@ -117,7 +117,7 @@ def test_dependence():
     assert dependent(X, 2*X)
 
     # Create a dependency
-    XX, YY = Given(Tuple(X,Y), Eq(X+Y, 3))
+    XX, YY = given(Tuple(X,Y), Eq(X+Y, 3))
     assert dependent(XX, YY)
 
 @XFAIL
@@ -127,12 +127,12 @@ def test_dependent_finite():
     # finite random variables
     assert dependent(X, Y+X)
 
-    XX, YY = Given(Tuple(X, Y), X+Y>5) # Create a dependency
+    XX, YY = given(Tuple(X, Y), X+Y>5) # Create a dependency
     assert dependent(XX, YY)
 
 def test_normality():
     X, Y = Normal(0,1), Normal(0,1)
     x, z = symbols('x, z', real=True)
-    density = Density(X-Y, Eq(X+Y, z))
+    dens = density(X-Y, Eq(X+Y, z))
 
-    assert integrate(density(x), (x, -oo, oo)) == 1
+    assert integrate(dens(x), (x, -oo, oo)) == 1

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,6 +1,6 @@
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
         symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum)
-from sympy.stats import (Die, Normal, Exponential , P, E, var, covar,
+from sympy.stats import (Die, Normal, Exponential , P, E, variance, covariance,
         skewness, density, given, independent, dependent, where, pspace,
         random_symbols, sample)
 from sympy.stats.rv import ProductPSpace, rs_swap
@@ -89,7 +89,7 @@ def test_Sample():
 
     P(X+Y>0, Y<0, numsamples=10).is_number
     assert E(X+Y, numsamples=10).is_number
-    assert var(X+Y, numsamples=10).is_number
+    assert variance(X+Y, numsamples=10).is_number
 
     raises(ValueError, "P(Y>z, numsamples=5)")
 


### PR DESCRIPTION
The functions 
Density, Where, Sample, Given, Var, Covar 
have been renamed to 
density, where, sample, given, var, covar

The functions 
P, E
have been renamed to 
probability, expectation

with aliases set back to the original names. These aliases exist only in rv_interface and are not depended upon by the internal code. 

There is an issue with "var" it overlaps an important sympy function. We could
1) Remove the alias and stick with variance
2) Overlap var in the sympy.stats module and hope no one minds

This pull request is connected to the following issue
http://code.google.com/p/sympy/issues/detail?id=3123
