### PR TITLE
Intersection Set Class

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -21,7 +21,8 @@ from function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     Function, Subs, expand, PoleError, count_ops, \
     expand_mul, expand_log, expand_func,\
     expand_trig, expand_complex, expand_multinomial, nfloat, expand_power_base
-from sets import Set, Interval, Union, EmptySet, FiniteSet, ProductSet
+from sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
+        Intersection)
 from evalf import PrecisionExhausted, N
 from containers import Tuple, Dict
 from exprtools import gcd_terms, factor_terms, factor_nc

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -11,9 +11,10 @@ from sympy.logic.boolalg import And, Or
 
 class Set(Basic):
     """
-    The base class for any kind of set. This is not meant to be used directly
-    as a container of items. It does not behave like the builtin set; see
-    FiniteSet for that.
+    The base class for any kind of set.
+
+    This is not meant to be used directly as a container of items.
+    It does not behave like the builtin set; see FiniteSet for that.
 
     Real intervals are represented by the Interval class and unions of sets
     by the Union class. The empty set is represented by the EmptySet class
@@ -33,11 +34,11 @@ class Set(Basic):
 
     def union(self, other):
         """
-        Returns the union of 'self' and 'other'. As a shortcut it is possible
-        to use the '+' operator:
+        Returns the union of 'self' and 'other'.
+
+        As a shortcut it is possible to use the '+' operator:
 
         >>> from sympy import Interval, FiniteSet
-
         >>> Interval(0, 1).union(Interval(2, 3))
         [0, 1] U [2, 3]
         >>> Interval(0, 1) + Interval(2, 3)
@@ -45,8 +46,7 @@ class Set(Basic):
         >>> Interval(1, 2, True, True) + FiniteSet(2, 3)
         (1, 2] U {3}
 
-        Similarly it is possible to use the '-' operator for set
-        differences:
+        Similarly it is possible to use the '-' operator for set differences:
 
         >>> Interval(0, 2) - Interval(0, 1)
         (1, 2]
@@ -108,7 +108,7 @@ class Set(Basic):
     @property
     def inf(self):
         """
-        The infimum of 'self'.
+        The infimum of 'self'
 
         >>> from sympy import Interval, Union
 
@@ -126,7 +126,8 @@ class Set(Basic):
 
     @property
     def sup(self):
-        """ The supremum of 'self'.
+        """
+        The supremum of 'self'
 
         >>> from sympy import Interval, Union
 
@@ -181,7 +182,7 @@ class Set(Basic):
     @property
     def measure(self):
         """
-        The (Lebesgue) measure of 'self'.
+        The (Lebesgue) measure of 'self'
 
         >>> from sympy import Interval, Union
 
@@ -238,11 +239,10 @@ class ProductSet(Set):
     """
     Represents a Cartesian Product of Sets.
 
-    Usage:
-        Returns a cartesian product given several sets as either an iterable
-        or individual arguments.
+    Returns a cartesian product given several sets as either an iterable
+    or individual arguments.
 
-        Can use '*' operator on any sets for convenient shorthand.
+    Can use '*' operator on any sets for convenient shorthand.
 
     Examples
     ========
@@ -267,11 +267,15 @@ class ProductSet(Set):
         (T, T)
 
 
-    Notes:
-        - Passes most operations down to the argument sets
-        - Flattens Products of ProductSets
+    Notes
+    =====
+    - Passes most operations down to the argument sets
+    - Flattens Products of ProductSets
 
-    http://en.wikipedia.org/wiki/Cartesian_product
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Cartesian_product
     """
     is_ProductSet = True
 
@@ -294,7 +298,7 @@ class ProductSet(Set):
 
     def _contains(self, element):
         """
-        in operator for ProductSets
+        'in' operator for ProductSets
 
         >>> from sympy import Interval
 
@@ -402,13 +406,17 @@ class Interval(RealSet):
     >>> Interval(0, a)
     [0, a]
 
-    Notes:
-        - Only real end points are supported
-        - Interval(a, b) with a > b will return the empty set
-        - Use the evalf() method to turn an Interval into an mpmath
-          'mpi' interval instance
+    Notes
+    =====
+    - Only real end points are supported
+    - Interval(a, b) with a > b will return the empty set
+    - Use the evalf() method to turn an Interval into an mpmath
+      'mpi' interval instance
 
-    http://en.wikipedia.org/wiki/Interval_(mathematics)
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Interval_(mathematics)
     """
     is_Interval = True
 
@@ -442,8 +450,9 @@ class Interval(RealSet):
     @property
     def start(self):
         """
-        The left end point of 'self'. This property takes the same value as the
-        'inf' property.
+        The left end point of 'self'.
+
+        This property takes the same value as the 'inf' property.
 
         >>> from sympy import Interval
 
@@ -458,8 +467,9 @@ class Interval(RealSet):
     @property
     def end(self):
         """
-        The right end point of 'self'. This property takes the same value as the
-        'sup' property.
+        The right end point of 'self'.
+
+        This property takes the same value as the 'sup' property.
 
         >>> from sympy import Interval
 
@@ -637,7 +647,10 @@ class Union(Set):
     ========
     Intersection
 
-    http://en.wikipedia.org/wiki/Union_(set_theory)
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Union_(set_theory)
     """
     is_Union = True
 
@@ -771,8 +784,7 @@ class Union(Set):
         return measure
 
     def as_relational(self, symbol):
-        """Rewrite a Union in terms of equalities and logic operators.
-        """
+        """Rewrite a Union in terms of equalities and logic operators. """
         return Or(*[set.as_relational(symbol) for set in self.args])
 
     @property
@@ -801,7 +813,10 @@ class Intersection(Set):
     ========
     Union
 
-    http://en.wikipedia.org/wiki/Intersection_(set_theory)
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Intersection_(set_theory)
     """
     is_Intersection = True
 
@@ -1052,7 +1067,10 @@ class EmptySet(Set):
     ========
     UniversalSet
 
-    http://en.wikipedia.org/wiki/Empty_set
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Empty_set
     """
     __metaclass__ = Singleton
     is_EmptySet = True
@@ -1103,7 +1121,10 @@ class UniversalSet(Set):
     ========
     EmptySet
 
-    http://en.wikipedia.org/wiki/Universal_set
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Universal_set
     """
 
     __metaclass__ = Singleton
@@ -1143,7 +1164,10 @@ class FiniteSet(CountableSet):
         >>> 3 in FiniteSet(1, 2, 3, 4)
         True
 
-    http://en.wikipedia.org/wiki/Finite_set
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Finite_set
     """
     is_FiniteSet = True
 
@@ -1184,8 +1208,9 @@ class FiniteSet(CountableSet):
 
     def union(self, other):
         """
-        Returns the union of 'self' and 'other'. As a shortcut it is possible
-        to use the '+' operator:
+        Returns the union of 'self' and 'other'.
+
+        As a shortcut it is possible to use the '+' operator:
 
         >>> from sympy import FiniteSet, Interval, Symbol
 
@@ -1214,6 +1239,7 @@ class FiniteSet(CountableSet):
     def _contains(self, other):
         """
         Tests whether an element, other, is in the set.
+
         Relies on Python's set class. This tests for object equality
         All inputs are sympified
 
@@ -1244,8 +1270,7 @@ class FiniteSet(CountableSet):
         return FiniteSet(el for el in self if el not in other)
 
     def as_relational(self, symbol):
-        """Rewrite a FiniteSet in terms of equalities and logic operators.
-        """
+        """Rewrite a FiniteSet in terms of equalities and logic operators. """
         from sympy.core.relational import Eq
         return Or(*[Eq(symbol, elem) for elem in self])
 
@@ -1259,11 +1284,14 @@ class FiniteSet(CountableSet):
 class RealFiniteSet(FiniteSet, RealSet):
     """
     A FiniteSet with all elements Real Numbers.
-    Allows for good integration with Intervals
+
+    Allows for good integration with Intervals.
 
     This class for internal use only. Use FiniteSet to create a RealFiniteSet
 
-    See FiniteSet for more details
+    See Also
+    ========
+    FiniteSet
     """
 
     def _eval_evalf(self, prec):
@@ -1294,8 +1322,7 @@ class RealFiniteSet(FiniteSet, RealSet):
         return Union(*intervals)
 
     def as_relational(self, symbol):
-        """Rewrite a FiniteSet in terms of equalities and logic operators.
-        """
+        """Rewrite a FiniteSet in terms of equalities and logic operators. """
         from sympy.core.relational import Eq
         return Or(*[Eq(symbol, elem) for elem in self])
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -270,6 +270,8 @@ class ProductSet(Set):
     Notes:
         - Passes most operations down to the argument sets
         - Flattens Products of ProductSets
+
+    http://en.wikipedia.org/wiki/Cartesian_product
     """
     is_ProductSet = True
 
@@ -403,6 +405,8 @@ class Interval(RealSet):
         - Interval(a, b) with a > b will return the empty set
         - Use the evalf() method to turn an Interval into an mpmath
           'mpi' interval instance
+
+    http://en.wikipedia.org/wiki/Interval_(mathematics)
     """
     is_Interval = True
 
@@ -627,6 +631,11 @@ class Union(Set):
         >>> Union(Interval(1, 2), Interval(2, 3))
         [1, 3]
 
+    See Also
+    ========
+    Intersection
+
+    http://en.wikipedia.org/wiki/Union_(set_theory)
     """
     is_Union = True
 
@@ -785,6 +794,12 @@ class Intersection(Set):
 
         >>> Interval(1,3).intersect(Interval(2,4))
         [2, 3]
+
+    See Also
+    ========
+    Union
+
+    http://en.wikipedia.org/wiki/Intersection_(set_theory)
     """
     is_Intersection = True
 
@@ -1022,6 +1037,11 @@ class EmptySet(Set):
         >>> Interval(1, 2).intersect(S.EmptySet)
         EmptySet()
 
+    See Also
+    ========
+    UniversalSet
+
+    http://en.wikipedia.org/wiki/Empty_set
     """
     __metaclass__ = Singleton
     is_EmptySet = True
@@ -1068,6 +1088,11 @@ class UniversalSet(Set):
         >>> Interval(1, 2).intersect(S.UniversalSet)
         [1, 2]
 
+    See Also
+    ========
+    EmptySet
+
+    http://en.wikipedia.org/wiki/Universal_set
     """
 
     __metaclass__ = Singleton
@@ -1107,6 +1132,7 @@ class FiniteSet(CountableSet):
         >>> 3 in FiniteSet(1, 2, 3, 4)
         True
 
+    http://en.wikipedia.org/wiki/Finite_set
     """
     is_FiniteSet = True
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -80,7 +80,7 @@ class Set(Basic):
 
         Used within the Intersection class
         """
-        raise NotImplementedError("(%s)._intersect(%s)" % (self, other))
+        return None
 
     @property
     def complement(self):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -930,7 +930,7 @@ class Intersection(Set):
         if len(args)==1:
             return args.pop()
         else:
-            return Intersection(*args, evaluate=False)
+            return Intersection(args, evaluate=False)
 
 class RealUnion(Union, RealSet):
     """

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -343,6 +343,10 @@ def test_sympy__core__sets__Set():
     from sympy.core.sets import Set
     assert _test_args(Set())
 
+def test_sympy__core__sets__Intersection():
+    from sympy.core.sets import Intersection, Interval
+    assert _test_args(Intersection(Interval(0, 3), Interval(2, 4)))
+
 def test_sympy__core__sets__Union():
     from sympy.core.sets import Union, Interval
     assert _test_args(Union(Interval(0, 1), Interval(2, 3)))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -312,6 +312,10 @@ def test_sympy__core__sets__EmptySet():
     from sympy.core.sets import EmptySet
     assert _test_args(EmptySet())
 
+def test_sympy__core__sets__UniversalSet():
+    from sympy.core.sets import UniversalSet
+    assert _test_args(UniversalSet())
+
 def test_sympy__core__sets__FiniteSet():
     from sympy.core.sets import FiniteSet
     assert _test_args(FiniteSet(x, y, z))
@@ -345,7 +349,8 @@ def test_sympy__core__sets__Set():
 
 def test_sympy__core__sets__Intersection():
     from sympy.core.sets import Intersection, Interval
-    assert _test_args(Intersection(Interval(0, 3), Interval(2, 4)))
+    assert _test_args(Intersection(Interval(0, 3), Interval(2, 4),
+        evaluate=False))
 
 def test_sympy__core__sets__Union():
     from sympy.core.sets import Union, Interval

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -192,9 +192,9 @@ def test_intersection():
 
     # Products
     line = Interval(0, 5)
-    i = Intersection(line**2, line)
+    i = Intersection(line**2, line**3, evaluate=False)
     assert (2,2) not in i
-    assert 5 not in i
+    assert (2,2,2) not in i
     raises(ValueError, "list(i)")
 
 def test_interval_subs():

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -116,7 +116,8 @@ def test_complement():
     assert -S.EmptySet == S.EmptySet.complement
     assert ~S.EmptySet == S.EmptySet.complement
 
-    assert S.EmptySet.complement == Interval(-oo, oo)
+    assert S.EmptySet.complement == S.UniversalSet
+    assert S.UniversalSet.complement == S.EmptySet
 
     assert Union(Interval(0, 1), Interval(2, 3)).complement == \
            Union(Interval(-oo, 0, True, True), Interval(1, 2, True, True),
@@ -373,7 +374,7 @@ def test_product_basic():
 
     assert (Interval(-10,10)**3).subset(Interval(-5,5)**3)
     assert not (Interval(-5,5)**3).subset(Interval(-10,10)**3)
-    raises(ValueError, "(Interval(-10,10)**2).subset(Interval(-5,5)**3)")
+    assert not (Interval(-10,10)**2).subset(Interval(-5,5)**3)
 
     assert square.subset(Interval(.2,.5)*FiniteSet(.5)) # segment in square
 

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -85,7 +85,6 @@ def test_union():
     assert 2 in X and 3 in X and 3 in XandY
     assert X.subset(XandY) and Y.subset(XandY)
 
-
     raises(TypeError, "Union(1, 2, 3)")
 
 def test_difference():

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1060,6 +1060,9 @@ class LatexPrinter(Printer):
     def _print_Union(self, u):
         return r" \cup ".join([self._print(i) for i in u.args])
 
+    def _print_Intersection(self, u):
+        return r" \cap ".join([self._print(i) for i in u.args])
+
     def _print_EmptySet(self, e):
         return r"\emptyset"
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1127,7 +1127,7 @@ class PrettyPrinter(Printer):
     def _print_ProductSet(self, p):
         prod_char = u'\xd7'
         return self._print_seq(p.sets, None, None, ' %s '%prod_char,
-                parenthesize = lambda set:set.is_Union )
+                parenthesize = lambda set:set.is_Union or set.is_Intersection)
 
     def _print_FiniteSet(self, s):
         if len(s) > 10:
@@ -1161,12 +1161,19 @@ class PrettyPrinter(Printer):
 
             return self._print_seq(i.args[:2], left, right)
 
+    def _print_Intersection(self, u):
+
+        delimiter = ' %s ' % pretty_atom('Intersection')
+
+        return self._print_seq(u.args, None, None, delimiter,
+                parenthesize = lambda set:set.is_ProductSet or set.is_Union)
+
     def _print_Union(self, u):
 
         union_delimiter = ' %s ' % pretty_atom('Union')
 
         return self._print_seq(u.args, None, None, union_delimiter,
-                parenthesize = lambda set:set.is_ProductSet)
+             parenthesize = lambda set:set.is_ProductSet or set.is_Intersection)
 
     def _print_seq(self, seq, left=None, right=None, delimiter=', ',
             parenthesize=lambda x: False):

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -392,7 +392,8 @@ atoms_table = {
     #'ImaginaryUnit'     :   U('MATHEMATICAL ITALIC SMALL I'),
     'ImaginaryUnit'     :   U('DOUBLE-STRUCK ITALIC SMALL I'),
     'EmptySet'          :   U('EMPTY SET'),
-    'Union'             :   U('UNION')
+    'Union'             :   U('UNION'),
+    'Intersection'      :   U('INTERSECTION')
 }
 
 def pretty_atom(atom_name, default=None):


### PR DESCRIPTION
Added an Intersection class for sets

This fixes two problems. 

Problem 1:
Previously all intersection logic was distributed throughout the set classes in a confusing way. Every class needed to know how every other class worked to ensure all valid intersections could be computed. Now there is a central and distributed method for computing intersections. 

Global rules like "intersections containing an empty set are empty" and "distribute unions" are handled in the intersection class. 

Additionally, any class can implement a _intersect(self, other) method. If self knows how to intersect itself with other it returns that class, reducing the number of sets in the intersection by one. If self does not know how to intersect itself with other then it returns None. After Intersection finishes with global rules it iterates over the pairs of constituent sets finding simplifications until there is no change

Problem 2:
Sometimes we don't know how to intersect two sets. Previously we would just raise an error in this case. Now we fall back on the Intersection class as an unevaluated object much like Union, Integral, etc....

Issue here:
http://code.google.com/p/sympy/issues/detail?id=3159

There are some other small changes. We've introduced a UniversalSet singleton (to pair with EmptySet).
