### PR TITLE
3109c

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -5,6 +5,8 @@ from inspect import getmro
 from core import all_classes as sympy_classes
 from sympy.core.compatibility import iterable
 
+import re
+
 class SympifyError(ValueError):
     def __init__(self, expr, base_exc=None):
         self.expr = expr
@@ -185,3 +187,5 @@ def _sympify(a):
        see: sympify
     """
     return sympify(a, strict=True)
+
+from sympy.core.basic import C

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -385,3 +385,16 @@ def test_geometry():
     assert p == Point(0, 1) and type(p) == Point
     L = sympify(Line(p, (1, 0)))
     assert L == Line((0, 1), (1, 0)) and type(L) == Line
+
+def test_no_autosimplify_into_Mul():
+    s = '-1 - 2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x)))'
+    def clean(s):
+        return ''.join(str(s).split())
+    assert -1 - 2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x))) == -1
+    # sympification should not allow the constant to enter a Mul
+    # or else the structure can change dramatically
+    ss = S(s)
+    assert ss != 1 and ss.simplify() == -1
+    s = '-1 - 2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x)))'.replace('x', '_kern')
+    ss = S(s)
+    assert ss != 1 and ss.simplify() == -1

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -131,9 +131,10 @@ class LinearEntity(GeometryEntity):
             return (S.One, S.Zero, -p1.x)
         elif p1.y == p2.y:
             return (S.Zero, S.One, -p1.y)
-        return (self.p1.y - self.p2.y,
+        return tuple([simplify(i) for i in
+               (self.p1.y - self.p2.y,
                 self.p2.x - self.p1.x,
-                self.p1.x*self.p2.y - self.p1.y*self.p2.x)
+                self.p1.x*self.p2.y - self.p1.y*self.p2.x)])
 
     def is_concurrent(*lines):
         """Is a sequence of linear entities concurrent?

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -160,6 +160,7 @@ def test_line():
     assert l7.equation() == y - 1
     assert p1 in l1 # is p1 on the line l1?
     assert p1 not in l3
+    assert Line((-x,x),(-x+1,x-1)).coefficients == (1, 1, 0)
 
     assert simplify(l1.equation()) in (x-y, y-x)
     assert simplify(l3.equation()) in (x-x1, x1-x)

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -486,9 +486,9 @@ def test_inverse_laplace_transform():
     # just test inverses of all of the above
     assert ILT(1/s, s, t) == Heaviside(t)
     assert ILT(1/s**2, s, t) == t*Heaviside(t)
-    assert ILT(1/s**5, s, t) == t**4*Heaviside(t)/factorial(4)
+    assert ILT(1/s**5, s, t) == t**4*Heaviside(t)/24
     assert ILT(exp(-a*s)/s, s, t) == Heaviside(t-a)
-    assert ILT(exp(-a*s)/(s+b), s, t) == Heaviside(t - a)*exp(b*(a - t))
+    assert ILT(exp(-a*s)/(s+b), s, t) == exp(b*(a - t))*Heaviside(-a + t)
     assert ILT(a/(s**2 + a**2), s, t) == sin(a*t)*Heaviside(t)
     assert ILT(s/(s**2 + a**2), s, t) == cos(a*t)*Heaviside(t)
     # TODO is there a way around simp_hyp?

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -8,7 +8,7 @@ from sympy.integrals.transforms import (mellin_transform,
 from sympy import (gamma, exp, oo, Heaviside, symbols, Symbol, re, factorial, pi,
                    cos, S, And, sin, sqrt, I, log, tan, hyperexpand, meijerg,
                    EulerGamma, erf, besselj, bessely, besseli, besselk,
-                   exp_polar, polar_lift, unpolarify, Function)
+                   exp_polar, polar_lift, unpolarify, Function, expint)
 from sympy.utilities.pytest import XFAIL, slow, skip
 from sympy.abc import x, s, a, b
 nu, beta, rho = symbols('nu beta rho')
@@ -488,7 +488,7 @@ def test_inverse_laplace_transform():
     assert ILT(1/s**2, s, t) == t*Heaviside(t)
     assert ILT(1/s**5, s, t) == t**4*Heaviside(t)/factorial(4)
     assert ILT(exp(-a*s)/s, s, t) == Heaviside(t-a)
-    assert ILT(exp(-a*s)/(s+b), s, t) == exp(-b*(-a + t))*Heaviside(t - a)
+    assert ILT(exp(-a*s)/(s+b), s, t) == Heaviside(t - a)*exp(b*(a - t))
     assert ILT(a/(s**2 + a**2), s, t) == sin(a*t)*Heaviside(t)
     assert ILT(s/(s**2 + a**2), s, t) == cos(a*t)*Heaviside(t)
     # TODO is there a way around simp_hyp?
@@ -529,7 +529,7 @@ def test_fourier_transform():
     a = symbols('a', positive=True)
     b = symbols('b', positive=True)
 
-    posk = symbols('k', positive=True)
+    posk = symbols('posk', positive=True)
 
     # Test unevaluated form
     assert fourier_transform(f(x), x, k) == FourierTransform(f(x), x, k)
@@ -544,11 +544,12 @@ def test_fourier_transform():
     assert factor(FT(exp(-a*x)*Heaviside(x), x, k), extension=I) \
            == 1/(a + 2*pi*I*k)
     # NOTE: the ift comes out in pieces
-    assert IFT(1/(a + 2*pi*I*x), x, posk, noconds=False) == (exp(-a*posk), True)
+    assert IFT(1/(a + 2*pi*I*x), x, posk,
+            noconds=False) == (exp(-a*posk), True)
     assert IFT(1/(a + 2*pi*I*x), x, -posk,
-               noconds=False) == (0, True)
+            noconds=False) == (0, True)
     assert IFT(1/(a + 2*pi*I*x), x, symbols('k', negative=True),
-               noconds=False) == (0, True)
+            noconds=False) == (0, True)
     # TODO IFT without factoring comes out as meijer g
 
     assert factor(FT(x*exp(-a*x)*Heaviside(x), x, k), extension=I) \

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -72,22 +72,25 @@ def pl_true(expr, model={}):
         return expr
 
     expr = sympify(expr)
-    if expr.is_Atom:
+
+    if expr.is_Symbol:
         return model.get(expr)
 
     args = expr.args
-    if expr.func is Not:
+    func = expr.func
+
+    if func is Not:
         p = pl_true(args[0], model)
         if p is None: return None
         else: return not p
-    elif expr.func is Or:
+    elif func is Or:
         result = False
         for arg in args:
             p = pl_true(arg, model)
             if p == True: return True
             if p == None: result = None
         return result
-    elif expr.func is And:
+    elif func is And:
         result = True
         for arg in args:
             p = pl_true(arg, model)
@@ -95,11 +98,11 @@ def pl_true(expr, model={}):
             if p == None: result = None
         return result
 
-    elif expr.func is Implies:
+    elif func is Implies:
         p, q = args
         return pl_true(Or(Not(p), q), model)
 
-    elif expr.func is Equivalent:
+    elif func is Equivalent:
         p, q = args
         pt = pl_true(p, model)
         if pt == None:

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -115,7 +115,7 @@ def test_pl_true_wrong_input():
     from sympy import pi
     raises(ValueError, "pl_true('John Cleese')")
     raises(ValueError, "pl_true(42+pi+pi**2)")
-    #raises(ValueError, "pl_true(42)")  #returns None, but should it?
+    raises(ValueError, "pl_true(42)")
 
 def test_PropKB():
     A, B, C = symbols('A,B,C')

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -9,7 +9,7 @@ from sympy.core.sympify import sympify, converter, SympifyError
 from sympy.core.compatibility import is_sequence
 
 from sympy.polys import PurePoly, roots, cancel
-from sympy.simplify import simplify as _simplify
+from sympy.simplify import simplify as _simplify, signsimp
 from sympy.utilities.iterables import flatten
 from sympy.utilities.misc import filldedent
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
@@ -2729,7 +2729,7 @@ class MatrixBase(object):
 
         simplify = flags.pop('simplify', False)
         simpfunc = simplify if isinstance(simplify, FunctionType) else \
-            lambda x: x.as_content_primitive()
+            lambda x: signsimp(x).as_content_primitive()
 
         if 'multiple' in flags:
             del flags['multiple']

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,5 +1,6 @@
 from sympy.core.add import Add
 from sympy.core.basic import Basic, C
+from sympy.core.function import count_ops
 from sympy.core.power import Pow
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.numbers import Integer, ilcm, Rational
@@ -8,8 +9,9 @@ from sympy.core.sympify import sympify, converter, SympifyError
 from sympy.core.compatibility import is_sequence
 
 from sympy.polys import PurePoly, roots, cancel
-from sympy.simplify import simplify as sympy_simplify
+from sympy.simplify import simplify as _simplify
 from sympy.utilities.iterables import flatten
+from sympy.utilities.misc import filldedent
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.printing import sstr
 from sympy.functions.elementary.trigonometric import cos, sin
@@ -19,6 +21,7 @@ from sympy.core.decorators import call_highest_priority
 
 import random
 import warnings
+from types import FunctionType
 
 class MatrixError(Exception):
     pass
@@ -2404,7 +2407,7 @@ class MatrixBase(object):
         if not self.is_square:
             raise NonSquareMatrixError()
 
-        ok = self.rref(simplified=True)[0]
+        ok = self.rref(simplify=True)[0]
         if any(iszerofunc(ok[j, j]) for j in range(ok.rows)):
             raise ValueError("Matrix det == 0; not invertible.")
 
@@ -2425,7 +2428,7 @@ class MatrixBase(object):
             raise NonSquareMatrixError()
 
         big = self.row_join(self.eye(self.rows))
-        red = big.rref(iszerofunc=iszerofunc, simplified=True)[0]
+        red = big.rref(iszerofunc=iszerofunc, simplify=True)[0]
         if any(iszerofunc(red[j, j]) for j in range(red.rows)):
             raise ValueError("Matrix det == 0; not invertible.")
 
@@ -2449,7 +2452,7 @@ class MatrixBase(object):
         zero = d.equals(0)
         if zero is None:
             # if equals() can't decide, will rref be able to?
-            ok = self.rref(simplified=True)[0]
+            ok = self.rref(simplify=True)[0]
             zero = any(iszerofunc(ok[j, j]) for j in range(ok.rows))
         if zero:
             raise ValueError("Matrix det == 0; not invertible.")
@@ -2457,25 +2460,40 @@ class MatrixBase(object):
         return self.adjugate()/d
 
     def rref(self, simplified=False, iszerofunc=_iszero,
-            simplify=sympy_simplify):
+            simplify=False):
         """
-        Take any matrix and return reduced row-echelon form and indices of pivot vars
+        Return reduced row-echelon form of matrix and indices of pivot vars.
 
-        To simplify elements before finding nonzero pivots set simplified=True.
-        To set a custom simplify function, use the simplify keyword argument.
+        To simplify elements before finding nonzero pivots set simplify=True
+        (to use the default SymPy simplify function) or pass a custom
+        simplify function.
+
+        >>> from sympy import Matrix
+        >>> from sympy.abc import x
+        >>> m = Matrix([[1, 2], [x, 1 - 1/x]])
+        >>> m.rref()
+        ([1, 0]
+        [0, 1], [0, 1])
         """
-
+        if simplified is not False:
+            warnings.warn(filldedent('''
+            Use of simplified is deprecated. Set simplify=True to
+            use SymPy's simplify function or set simplify to your
+            own custom simplification function.
+            '''))
+            simplify = simplify or True
+        simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
         pivot, r = 0, self[:,:].as_mutable()        # pivot: index of next row to contain a pivot
         pivotlist = []                  # indices of pivot variables (non-free)
         for i in range(r.cols):
             if pivot == r.rows:
                 break
-            if simplified:
-                r[pivot,i] = simplify(r[pivot,i])
+            if simplify:
+                r[pivot,i] = simpfunc(r[pivot,i])
             if iszerofunc(r[pivot,i]):
                 for k in range(pivot, r.rows):
-                    if simplified and k > pivot:
-                        r[k,i] = simplify(r[k,i])
+                    if simplify and k > pivot:
+                        r[k,i] = simpfunc(r[k,i])
                     if not iszerofunc(r[k,i]):
                         break
                 if k == r.rows - 1 and iszerofunc(r[k,i]):
@@ -2492,11 +2510,19 @@ class MatrixBase(object):
             pivot += 1
         return self._new(r), pivotlist
 
-    def nullspace(self, simplified=False):
+    def nullspace(self, simplified=False, simplify=False):
         """
         Returns list of vectors (Matrix objects) that span nullspace of self
         """
-        reduced, pivots = self.rref(simplified)
+        if simplified is not False:
+            warnings.warn(filldedent('''
+            Use of simplified is deprecated. Set simplify=True to
+            use SymPy's simplify function or set simplify to your
+            own custom simplification function.
+            '''))
+            simplify = simplify or True
+        simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
+        reduced, pivots = self.rref(simplify=simpfunc)
 
         basis = []
         # create a set of vectors for the basis
@@ -2645,7 +2671,7 @@ class MatrixBase(object):
 
         return tuple(minors)
 
-    def berkowitz_charpoly(self, x=Dummy('lambda'), simplify=sympy_simplify):
+    def berkowitz_charpoly(self, x=Dummy('lambda'), simplify=_simplify):
         """Computes characteristic polynomial minors using Berkowitz method.
 
         A PurePoly is returned so using different variables for ``x`` does
@@ -2695,9 +2721,15 @@ class MatrixBase(object):
     eigenvals = berkowitz_eigenvals
 
     def eigenvects(self, **flags):
-        """Return list of triples (eigenval, multiplicity, basis)."""
+        """Return list of triples (eigenval, multiplicity, basis).
+
+        If the flag ``simplify`` is True, as_content_primitive() will
+        be used to tidy up normalization artifacts; if the flag is a
+        function, that function will be used to do the simplification."""
 
         simplify = flags.pop('simplify', False)
+        simpfunc = simplify if isinstance(simplify, FunctionType) else \
+            lambda x: x.as_content_primitive()
 
         if 'multiple' in flags:
             del flags['multiple']
@@ -2712,17 +2744,17 @@ class MatrixBase(object):
             # necessary.
             if not basis:
                 # The nullspace routine failed, try it again with simplification
-                basis = tmp.nullspace(simplified=True)
+                basis = tmp.nullspace(simplify=simpfunc)
                 if not basis:
                     raise NotImplementedError("Can't evaluate eigenvector for eigenvalue %s" % r)
             if simplify:
                 # the relationship A*e = lambda*e will still hold if we change the
                 # eigenvector; so if simplify is True we tidy up any normalization
-                # artifacts with as_content_primtive and remove any pure Integer
-                # denominators
+                # artifacts with as_content_primtive (default) and remove any pure Integer
+                # denominators.
                 l = 1
                 for i, b in enumerate(basis[0]):
-                    c, p = b.as_content_primitive()
+                    c, p = simpfunc(b)
                     if c is not S.One:
                         b = c*p
                         l = ilcm(l, c.q)
@@ -3546,11 +3578,10 @@ class MutableMatrix(MatrixBase):
         self.cols -= 1
 
     # Utility functions
-    def simplify(self, simplify=sympy_simplify, ratio=1.7):
-        """Simplify the elements of a matrix in place.
+    def simplify(self, ratio=1.7, measure=count_ops):
+        """Applies simplify to the elements of a matrix in place.
 
-        If (result length)/(input length) > ratio, then input is returned
-        unmodified. If 'ratio=oo', then simplify() is applied anyway.
+        This is a shortcut for M.applyfunc(lambda x: simplify(x, ratio, measure))
 
         See Also
         ========
@@ -3558,7 +3589,7 @@ class MutableMatrix(MatrixBase):
         sympy.simplify.simplify.simplify
         """
         for i in xrange(len(self.mat)):
-            self.mat[i] = simplify(self.mat[i], ratio=ratio)
+            self.mat[i] = _simplify(self.mat[i], ratio=ratio, measure=measure)
 
     def fill(self, value):
         """Fill the matrix with the scalar value.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -628,8 +628,8 @@ def test_eigen():
     assert max(i.q for i in M._eigenvects[0][2][0]) == 1
     M = Matrix([[S(1)/4, 1], [1, 1]])
     assert M.eigenvects(simplify=True) == [
-      (-sqrt(73)/8 + S(5)/8, 1, [Matrix([[-8/(sqrt(73) - 3)], [1]])]),
-      (S(5)/8 + sqrt(73)/8, 1, [Matrix([[-8/(-3 - sqrt(73))],   [1]])])]
+        (-sqrt(73)/8 + S(5)/8, 1, [Matrix([[8/(-sqrt(73) + 3)], [1]])]),
+        (S(5)/8 + sqrt(73)/8, 1, [Matrix([[8/(3 + sqrt(73))],   [1]])])]
     assert M.eigenvects(simplify=False) == [
     (-sqrt(73)/8 + Rational(5, 8), 1,
         [Matrix([[-1/(Rational(-3, 8) + sqrt(73)/8)], [1]])]),

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Matrix, SparseMatrix, eye, I, Symbol, Rational,
     Float, wronskian, cos, sin, exp, hessian, sqrt, zeros, ones, randMatrix,
     Poly, S, pi, E, oo, trigsimp, Integer, N, sympify,
-    Pow, simplify, Min, Max, Abs, PurePoly)
+    Pow, simplify, Min, Max, Abs, PurePoly, count_ops, signsimp)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
     matrix_multiply_elementwise, diag, GramSchmidt, casoratian,
     SparseMatrix, SparseMatrix, NonSquareMatrixError,
@@ -628,8 +628,8 @@ def test_eigen():
     assert max(i.q for i in M._eigenvects[0][2][0]) == 1
     M = Matrix([[S(1)/4, 1], [1, 1]])
     assert M.eigenvects(simplify=True) == [
-      (-sqrt(73)/8 + Rational(5, 8), 1, [Matrix([[-8/(-3 + sqrt(73))], [1]])]),
-      (Rational(5, 8) + sqrt(73)/8, 1, [Matrix([[-8/(-sqrt(73) - 3)], [1]])])]
+      (-sqrt(73)/8 + S(5)/8, 1, [Matrix([[-8/(sqrt(73) - 3)], [1]])]),
+      (S(5)/8 + sqrt(73)/8, 1, [Matrix([[-8/(-3 - sqrt(73))],   [1]])])]
     assert M.eigenvects(simplify=False) == [
     (-sqrt(73)/8 + Rational(5, 8), 1,
         [Matrix([[-1/(Rational(-3, 8) + sqrt(73)/8)], [1]])]),
@@ -2086,10 +2086,10 @@ def test_invertible_check():
     [ x,  1,  1],
     [ 1,  x, -1],])
     assert len(m.rref()[1]) == m.rows
-    # in addition, unless simplified=True in the call to rref, the identity
+    # in addition, unless simplify=True in the call to rref, the identity
     # matrix will be returned even though m is not invertible
     assert m.rref()[0] == eye(3)
-    assert m.rref(simplified=True)[0] != eye(3)
+    assert m.rref(simplify=signsimp)[0] != eye(3)
     raises(ValueError, 'm.inv(method="ADJ")')
     raises(ValueError, 'm.inv(method="GE")')
     raises(ValueError, 'm.inv(method="LU")')
@@ -2119,3 +2119,10 @@ def test_dot():
     assert ones(1,3).dot(ones(3,1)) == 3
     assert ones(1,3).dot([1,1,1]) == 3
 
+def test_simplify():
+    from sympy.abc import x
+    m = Matrix([[1, x], [x + 1/x, x - 1]])
+    m = m.row_join(eye(m.cols))
+    raw = m.rref(simplify=lambda x: x)[0]
+    assert raw != \
+           m.rref(simplify=True)[0]

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -7,7 +7,7 @@ the expression (x+x)**2 will be converted into 4*x**2
 from simplify import (collect, rcollect, separate, radsimp, ratsimp, fraction,
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify,
     logcombine, separatevars, numer, denom, powdenest, posify, polarify,
-    unpolarify, collect_const)
+    unpolarify, collect_const, signsimp)
 
 from sqrtdenest import sqrtdenest
 

--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -11,7 +11,7 @@ class Neg(Expr):
     __slots__ = []
 
 def sub_pre(e):
-    """ Replace Add(x, Mul(NegativeOne(-1), y)) with Sub(x, y).
+    """ Replace y - x with Neg(x - y) if -1 can be extracted from y - x.
     """
     # make canonical, first
     adds = {}

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2635,8 +2635,11 @@ def signsimp(expr, evaluate=True):
     exp(-(x - y))
 
     """
+    expr = sympify(expr)
+    if not isinstance(expr, Expr) or expr.is_Atom:
+        return expr
     e = sub_post(sub_pre(expr))
-    if evaluate:
+    if evaluate and isinstance(e, Expr):
         e = e.xreplace(dict([(m, -(-m)) for m in e.atoms(Mul) if -(-m) != m]))
     return e
 
@@ -2766,7 +2769,9 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     """
     from sympy.simplify.hyperexpand import hyperexpand
 
-    expr = sympify(expr)
+    original_expr = expr = sympify(expr)
+
+    expr = signsimp(expr)
 
     if not isinstance(expr, Basic): # XXX: temporary hack
         return expr
@@ -2781,9 +2786,6 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     # TODO: Apply different strategies, considering expression pattern:
     # is it a purely rational function? Is there any trigonometric function?...
     # See also https://github.com/sympy/sympy/pull/185.
-
-    original_expr = expr
-    expr = signsimp(expr)
 
     def shorter(*choices):
         '''Return the choice that has the fewest ops. In case of a tie,

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -4,7 +4,8 @@ from sympy import (Symbol, symbols, hypersimp, factorial, binomial,
     solve, nsimplify, GoldenRatio, sqrt, E, I, sympify, atan, Derivative,
     S, diff, oo, Eq, Integer, gamma, acos, Integral, logcombine, Wild,
     separatevars, erf, rcollect, count_ops, combsimp, posify, expand,
-    factor, Mul, O, hyper, Add, Float, radsimp, collect_const, hyper)
+    factor, Mul, O, hyper, Add, Float, radsimp, collect_const, hyper,
+    signsimp)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
@@ -1033,3 +1034,7 @@ def test_unpolarify():
 def test_issue_2998():
     collect(a*y**(2.0*x)+b*y**(2.0*x),y**(x)) == y**(2.0*x)*(a + b)
     collect(a*2**(2.0*x)+b*2**(2.0*x),2**(x)) == 2**(2.0*x)*(a + b)
+
+def test_signsimp():
+    e = x*(-x + 1) + x*(x - 1)
+    assert signsimp(Eq(e, 0)) == True

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -157,7 +157,7 @@ def test_simplify():
     f_2 = x*d + y*e + z*f - 1
     f_3 = x*g + y*h + z*i - 1
 
-    solutions = solve([f_1, f_2, f_3], x, y, z, simplified=False)
+    solutions = solve([f_1, f_2, f_3], x, y, z, simplify=False)
 
     assert simplify(solutions[y]) == \
         (a*i+c*d+f*g-a*f-c*g-d*i)/(a*e*i+b*f*g+c*d*h-a*f*h-b*d*i-c*e*g)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -179,7 +179,7 @@ def checksol(f, symbol, sol=None, **flags):
     while 1:
         attempt += 1
         if attempt == 0:
-            val = real_root(f.subs(sol))
+            val = f.subs(sol)
             if val.atoms() & illegal:
                 return False
         elif attempt == 1:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -621,6 +621,40 @@ def test_unrad():
     assert solve(eq) == []
     # but this one really does have those solutions
     assert solve(sqrt(x) - sqrt(x + 1) + sqrt(1 - sqrt(x))) == [0, S(9)/16]
+
+    '''real_root changes the value of the result if the solution is
+    simplified; `a` in the text below is the root that is not 4/5:
+    >>> eq
+    sqrt(x) + sqrt(-x + 1) + sqrt(x + 1) - 6*sqrt(5)/5
+    >>> eq.subs(x, a).n()
+    -0.e-123 + 0.e-127*I
+    >>> real_root(eq.subs(x, a)).n()
+    -0.e-123 + 0.e-127*I
+    >>> (eq.subs(x,simplify(a))).n()
+    -0.e-126
+    >>> real_root(eq.subs(x, simplify(a))).n()
+    0.194825975605452 + 2.15093623885838*I
+
+    >>> sqrt(x).subs(x, real_root(a)).n()
+    0.809823827278194 - 0.e-25*I
+    >>> sqrt(x).subs(x, (a)).n()
+    0.809823827278194 - 0.e-25*I
+    >>> sqrt(x).subs(x, simplify(a)).n()
+    0.809823827278194 - 5.32999467690853e-25*I
+    >>> sqrt(x).subs(x, real_root(simplify(a))).n()
+    0.49864610868139 + 1.44572604257047*I
+    '''
+    eq=(sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
+    ra = S('''-1484/375 - 4*(-1/2 + sqrt(3)*I/2)*(-12459439/52734375 +
+    114*sqrt(12657)/78125)**(1/3) - 172564/(140625*(-1/2 +
+    sqrt(3)*I/2)*(-12459439/52734375 + 114*sqrt(12657)/78125)**(1/3))''')
+    rb = S(4)/5
+    ans = solve(sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
+    assert all(abs(eq.subs(x, i).n()) < 1e-10 for i in (ra, rb)) and \
+        len(ans) == 2 and \
+        sorted([i.n(chop=True) for i in ans]) == \
+        sorted([i.n(chop=True) for i in (ra, rb)])
+
     ans = solve(sqrt(x) + sqrt(x + 1) - \
                  sqrt(1 - x) - sqrt(2 + x))
     assert len(ans) == 1 and NS(ans[0])[:4] == '0.73'
@@ -656,7 +690,7 @@ def test_unrad():
     assert solve(Eq(sqrt(x + 7) + 2, sqrt(3 - x))) == [-6]
     # http://www.purplemath.com/modules/solverad.htm
     assert solve((2*x - 5)**Rational(1, 3) - 3) == [16]
-    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) == [S(1)/3]
+    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) == []
     assert solve(x + 1 - (x**4 + 4*x**3 - x)**Rational(1, 4)) == \
         [-S(1)/2, -S(1)/3]
     assert solve(sqrt(2*x**2 - 7) - (3 - x)) == [-8, 2]
@@ -671,11 +705,6 @@ def test_unrad():
     assert solve(sqrt(x - 2) - 5) == [27]
     assert solve(sqrt(17*x - sqrt(x**2 - 5)) - 7) == [3]
     assert solve(sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))) == []
-
-@XFAIL
-def test_unrad_evalf_problem():
-    ans = solve(sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
-    assert len(ans) == 2 and S(4)/5 in ans
 
 @XFAIL
 def test_multivariate():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -621,8 +621,6 @@ def test_unrad():
     assert solve(eq) == []
     # but this one really does have those solutions
     assert solve(sqrt(x) - sqrt(x + 1) + sqrt(1 - sqrt(x))) == [0, S(9)/16]
-    ans = solve(sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
-    assert len(ans) == 2 and S(4)/5 in ans
     ans = solve(sqrt(x) + sqrt(x + 1) - \
                  sqrt(1 - x) - sqrt(2 + x))
     assert len(ans) == 1 and NS(ans[0])[:4] == '0.73'
@@ -673,6 +671,11 @@ def test_unrad():
     assert solve(sqrt(x - 2) - 5) == [27]
     assert solve(sqrt(17*x - sqrt(x**2 - 5)) - 7) == [3]
     assert solve(sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))) == []
+
+@XFAIL
+def test_unrad_evalf_problem():
+    ans = solve(sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
+    assert len(ans) == 2 and S(4)/5 in ans
 
 @XFAIL
 def test_multivariate():


### PR DESCRIPTION
The commits after the 3109 commits are precipitated by the creation and use of a signsimp function that is added to simplify.py.

Sign simplification is one of the most fundamental simplifications that a routine should attempt before doing any other simplification. I tried to write my own version but found the one added to cse was already much better. So the signsimp function just calls the two cse processors and does a little clean up to remove hollow simplification (so `exp(y-x)` goes to `exp(-(x-y))` after simplification and back to its original form if this change didn't cause any simplification to occur).

Also, I wonder if we can clean up the use of simplify and simplified in matrices.py . It's confusing to know which word to use to say you want to simplification to be used (and there was one test that had used the wrong keyword). The way I've done it now is to not have two keywords: set simplify to True if you want simplification (defaulting to sympy's simplify) or pass your own function to use that instead. There is no need for two words (`simplified` to use simplification, defaulting to sympy's simplify and `simplify` to define a different function). The use of `simplified` now raises a deprecation warning.

Also, it was noted in a recent discussion about the asymmetry of how expressions are parsed ( http://tinyurl.com/7tmnm47 ) it was noted that sympification could perhaps be modified to keep signs from slipping into the leading term of a Mul and causing cut-and-paste expressions to become very different than what was copied. That modification (which will affect any string sympification) is now added.
