### PR TITLE
Added power notation for conjugation and commutator function

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -428,14 +428,26 @@ don\'t match.")
         """
         Routine for finding powers of a permutation.
 
+        Power notation is also used for conjugation.
+
         Examples
         ========
 
         >>> from sympy.combinatorics.permutations import Permutation
         >>> p = Permutation([2,0,3,1])
+        >>> q = Permutation([1,0,3,2])
+        >>> r = Permutation([0,2,3,1])
         >>> p**4
         Permutation([0, 1, 2, 3])
+        >>> p**q == p.conjugate(q)
+        True
+        >>> q**p == q.conjugate(p)
+        True
+        >>> (p**q)**r == p**(q * r)
+        True
         """
+        if type(n) == Permutation:
+            return self.conjugate(n)
         n = int(n)
         if n == 0:
             return Permutation(range(self.size))
@@ -1028,6 +1040,36 @@ don\'t match.")
         for i in xrange(n):
             invb[b[i]] = i
         return _new_from_array_form([invb[a[i]] for i in b])
+
+    def commutator(self, x):
+        """
+        Computes the commutator Permutation ``~p*~x*p*x``
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.permutations import Permutation
+        >>> a = Permutation([0,2,1,3])
+        >>> b = Permutation([0,2,3,1])
+        >>> a.commutator(b)
+        Permutation([0, 3, 1, 2])
+        >>> ~a*~b*a*b
+        Permutation([0, 3, 1, 2])
+        """
+
+        a = self.array_form
+        b = x.array_form
+        n = len(a)
+        if len(b) != n:
+            raise ValueError("The number of elements in the permutations \
+don\'t match.")
+        inva = [None]*n
+        for i in xrange(n):
+            inva[a[i]] = i
+        invb = [None]*n
+        for i in xrange(n):
+            invb[b[i]] = i
+        return _new_from_array_form([inva[invb[a[i]]] for i in b])
 
     def signature(self):
         """

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -81,8 +81,8 @@ def perm_af_mul(a, b):
     Permutation
     """
     if len(a) != len(b):
-        raise ValueError("The number of elements in the permutations \
-don\'t match.")
+        raise ValueError("The number of elements in the permutations "
+                         "do not match.")
 
     return [a[i] for i in b]
 
@@ -300,12 +300,14 @@ class Permutation(Basic):
         """
         if not args or not is_sequence(args[0]) or len(args) > 1 or \
            len(set(is_sequence(a) for a in args[0])) > 1:
-            raise ValueError('Permutation argument must be a list of ints or a list of lists.')
+            raise ValueError("Permutation argument must be a list of ints "
+                             "or a list of lists.")
 
         # 0, 1, ..., n-1 should all be present
         temp = [int(i) for i in flatten(args[0])]
         if set(range(len(temp))) != set(temp):
-            raise ValueError("Integers 0 through %s must be present." % len(temp))
+            raise ValueError("Integers 0 through %s must be present." %
+                             len(temp))
 
         cform = aform = None
         if args[0] and is_sequence(args[0][0]):
@@ -398,8 +400,8 @@ class Permutation(Basic):
         a = self.array_form
         b = other.array_form
         if len(a) != len(b):
-            raise ValueError("The number of elements in the permutations \
-don\'t match.")
+            raise ValueError("The number of elements in the permutations "
+                             "do not match.")
 
         perm = [a[i] for i in b]
         return _new_from_array_form(perm)
@@ -477,7 +479,8 @@ don\'t match.")
         return _new_from_array_form(b)
 
     def transpositions(self):
-        """a list of transpositions representing the permutation
+        """
+        A list of transpositions representing the permutation.
 
         Examples
         ========
@@ -1034,8 +1037,8 @@ don\'t match.")
         b = x.array_form
         n = len(a)
         if len(b) != n:
-            raise ValueError("The number of elements in the permutations \
-don\'t match.")
+            raise ValueError("The number of elements in the permutations "
+                             "do not match.")
         invb = [None]*n
         for i in xrange(n):
             invb[b[i]] = i
@@ -1061,8 +1064,8 @@ don\'t match.")
         b = x.array_form
         n = len(a)
         if len(b) != n:
-            raise ValueError("The number of elements in the permutations \
-don\'t match.")
+            raise ValueError("The number of elements in the permutations "
+                             "do not match.")
         inva = [None]*n
         for i in xrange(n):
             inva[a[i]] = i

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -36,6 +36,15 @@ def test_Permutation():
     b = q-p
     assert (a+b).is_Identity
 
+    assert p.conjugate(q) == Permutation([5, 3, 0, 4, 6, 2, 1])
+    assert p.conjugate(q) == ~q*p*q == p**q
+    assert q.conjugate(p) == Permutation([6, 3, 2, 0, 1, 4, 5])
+    assert q.conjugate(p) == ~p*q*p == q**p
+
+    assert p.commutator(q) == Permutation([1, 4, 5, 6, 3, 0, 2])
+    assert q.commutator(p) == Permutation([5, 0, 6, 4, 1, 2, 3])
+    assert p.commutator(q) == ~ q.commutator(p)
+
     assert len(p.atoms()) == 7
     assert q.atoms() == set([0, 1, 2, 3, 4, 5, 6])
 
@@ -121,9 +130,13 @@ def test_Permutation():
     assert p.get_positional_distance(q) == 8
 
     a = [Permutation.unrank_nonlex(4, i) for i in range(5)]
+    iden = Permutation([0, 1, 2, 3])
     for i in range(5):
         for j in range(i+1, 5):
             assert a[i].commutes_with(a[j]) == (a[i]*a[j] == a[j]*a[i])
+            if a[i].commutes_with(a[j]):
+                assert a[i].commutator(a[j]) == iden
+                assert a[j].commutator(a[i]) == iden
 
 def test_josephus():
     assert Permutation.josephus(4, 6, 1) == Permutation([3, 1, 0, 2, 5, 4])


### PR DESCRIPTION
http://en.wikipedia.org/wiki/Commutator

The power notation appears in a couple of group theory pages in Wikipedia, such as the 2nd example here: http://en.wikipedia.org/wiki/Group_action#Examples, and the commutator page above. It is also used in the CAS system GAP.

Also I added a test for conjugation, which was oddly missing from the combinatorics test suite...
