### PR TITLE
Move is_comparable out of the assumption system

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -414,7 +414,6 @@ class Add(AssocOp):
     _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded')
     _eval_is_commutative = lambda self: self._eval_template_is_attr('is_commutative')
     _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer')
-    _eval_is_comparable = lambda self: self._eval_template_is_attr('is_comparable')
 
     def _eval_is_odd(self):
         l = [f for f in self.args if not (f.is_even==True)]

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -437,6 +437,8 @@ class Add(AssocOp):
         return False
 
     def _eval_is_positive(self):
+        if self.is_number:
+            return super(Add, self)._eval_is_positive()
         pos = nonneg = nonpos = unknown_sign = False
         unbounded = set()
         args = [a for a in self.args if not a.is_zero]
@@ -486,6 +488,8 @@ class Add(AssocOp):
             return False
 
     def _eval_is_negative(self):
+        if self.is_number:
+            return super(Add, self)._eval_is_negative()
         neg = nonpos = nonneg = unknown_sign = False
         unbounded = set()
         args = [a for a in self.args if not a.is_zero]

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -1,4 +1,3 @@
-from sympy.core.compatibility import cmp
 from sympy.core.facts import FactRules
 from sympy.core.core import BasicMeta
 
@@ -58,26 +57,9 @@ _assume_rules = FactRules([
 ])
 
 _assume_defined = _assume_rules.defined_facts.copy()
-_assume_defined.add('comparable')
 _assume_defined.add('polar')
 _assume_defined = frozenset(_assume_defined)
 
-
-###################################
-# positive/negative from .evalf() #
-###################################
-
-# properties that indicate ordering on real axis
-_real_ordering = set(['negative', 'nonnegative', 'positive', 'nonpositive'])
-
-# what can be said from cmp(x.evalf(),0)
-# if x.evalf() is zero we can say nothing so nonpositive is the same as negative
-_real_cmp0_table= {
-        'positive': {1: True,  -1: False, 0: None},
-        'negative': {1: False, -1: True,  0: None},
-        }
-_real_cmp0_table['nonpositive'] = _real_cmp0_table['negative']
-_real_cmp0_table['nonnegative'] = _real_cmp0_table['positive']
 
 class CycleDetected(Exception):
     """(internal) used to detect cycles when evaluating assumptions
@@ -196,7 +178,7 @@ class AssumeMixin(object):
         - infinitesimal - object value is infinitesimal
 
 
-    Examples rules:
+    Example rules:
 
       positive=T            ->  nonpositive=F, real=T
       real=T & positive=F   ->  nonpositive=T
@@ -334,15 +316,6 @@ class AssumeMixin(object):
            so in the latter case if we are looking at what 'even' value is,
            'integer' and 'odd' facts will be asked.
 
-
-           3. evalf() for comparable
-           -------------------------
-
-           as a last resort for comparable objects we get their numerical value
-           -- this helps to determine facts like 'positive' and 'negative'
-
-
-
            In all cases when we settle on some fact value, it is given to
            _learn_new_facts to deduce all its implications, and also the result
            is cached in ._assumptions for later quick access.
@@ -384,17 +357,6 @@ class AssumeMixin(object):
                             pass
         finally:
             seen.pop()
-
-        # For positive/negative try to ask evalf
-        if k in _real_ordering and self.is_comparable:
-            e = self.evalf(1)
-
-            if e.is_Number:
-                a = _real_cmp0_table[k][cmp(e, 0)]
-
-                if a is not None:
-                    self._learn_new_facts( ((k,a),) )
-                    return a
 
         # No result -- unknown
         # cache it  (NB ._learn_new_facts(k, None) to learn other properties,

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -631,6 +631,16 @@ class Basic(PicklableWithSlots):
         return False
 
     @property
+    def is_comparable(self):
+        is_real = self.is_real
+        if is_real is False:
+            return False
+        is_number = self.is_number
+        if is_number is False:
+            return False
+        return self.is_real and self.is_number
+
+    @property
     def func(self):
         """
         The top-level function in an expression.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -528,6 +528,22 @@ class Expr(Basic, EvalfMixin):
             return diff
         return None
 
+    def _eval_is_positive(self):
+        if self.is_real and self.is_number:
+            n = self.evalf(1)
+            if n > 0:
+                return True
+            elif n < 0:
+                return False
+
+    def _eval_is_negative(self):
+        if self.is_real and self.is_number:
+            n = self.evalf(1)
+            if n < 0:
+                return True
+            elif n > 0:
+                return False
+
     def _eval_interval(self, x, a, b):
         """
         Returns evaluation over an interval.  For most functions this is:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -326,18 +326,6 @@ class Function(Application, Expr):
 
         return Expr._from_mpmath(v, prec)
 
-    def _eval_is_comparable(self):
-        if self.is_Function:
-            r = True
-            for s in self.args:
-                c = s.is_comparable
-                if c is None:
-                    return
-                if not c:
-                    r = False
-            return r
-        return
-
     def _eval_derivative(self, s):
         # f(x).diff(s) -> x.diff(s) * f.fdiff(1)(s)
         i = 0

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -983,7 +983,6 @@ class Mul(AssocOp):
     _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded')
     _eval_is_commutative = lambda self: self._eval_template_is_attr('is_commutative')
     _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer')
-    _eval_is_comparable = lambda self: self._eval_template_is_attr('is_comparable')
 
     def _eval_is_polar(self):
         has_polar = any(arg.is_polar for arg in self.args)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -160,7 +160,6 @@ class Number(AtomicExpr):
       Rational(1) + sqrt(Rational(2))
     """
     is_commutative = True
-    is_comparable = True
     is_bounded = True
     is_finite = True
     is_number = True
@@ -798,7 +797,7 @@ class Float(Number):
             return False    # sympy > other
         if isinstance(other, NumberSymbol):
             return other.__ge__(self)
-        if other.is_comparable:
+        if other.is_real and other.is_number:
             other = other.evalf()
         if isinstance(other, Number):
             return bool(mlib.mpf_lt(self._mpf_, other._as_mpf_val(self._prec)))
@@ -811,7 +810,7 @@ class Float(Number):
             return False    # sympy > other  -->  ! <=
         if isinstance(other, NumberSymbol):
             return other.__gt__(self)
-        if other.is_comparable:
+        if other.is_real and other.is_number:
             other = other.evalf()
         if isinstance(other, Number):
             return bool(mlib.mpf_le(self._mpf_, other._as_mpf_val(self._prec)))
@@ -1157,7 +1156,7 @@ class Rational(Number):
             return False    # sympy > other  --> not <
         if isinstance(other, NumberSymbol):
             return other.__le__(self)
-        if other.is_comparable and not isinstance(other, Rational):
+        if other.is_real and other.is_number and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
             if isinstance(other, Float):
@@ -1173,7 +1172,7 @@ class Rational(Number):
             return False    # sympy > other  -->  not <=
         if isinstance(other, NumberSymbol):
             return other.__lt__(self)
-        if other.is_comparable and not isinstance(other, Rational):
+        if other.is_real and other.is_number and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
             if isinstance(other, Float):
@@ -1190,7 +1189,7 @@ class Rational(Number):
             return False    # sympy > other  --> not <
         if isinstance(other, NumberSymbol):
             return other.__ge__(self)
-        if other.is_comparable and not isinstance(other, Rational):
+        if other.is_real and other.is_number and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
             if isinstance(other, Float):
@@ -1206,7 +1205,7 @@ class Rational(Number):
             return False    # sympy > other  -->  not <=
         if isinstance(other, NumberSymbol):
             return other.__gt__(self)
-        if other.is_comparable and not isinstance(other, Rational):
+        if other.is_real and other.is_number and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
             if isinstance(other, Float):
@@ -2218,16 +2217,15 @@ class NaN(Number):
     __metaclass__ = Singleton
 
     is_commutative = True
-    is_real        = None
-    is_rational    = None
-    is_integer     = None
-    is_comparable  = False
-    is_finite      = None
-    is_bounded     = None
-    #is_unbounded  = False
-    is_zero        = None
-    is_prime       = None
-    is_positive    = None
+    is_real = None
+    is_rational = None
+    is_integer = None
+    is_comparable = False
+    is_finite = None
+    is_bounded = None
+    is_zero = None
+    is_prime = None
+    is_positive = None
 
     __slots__ = []
 
@@ -2286,10 +2284,9 @@ class ComplexInfinity(AtomicExpr):
     __metaclass__ = Singleton
 
     is_commutative = True
-    is_comparable  = None
-    is_bounded     = False
-    is_real        = None
-    is_number      = True
+    is_bounded = False
+    is_real = None
+    is_number = False
 
     __slots__ = []
 
@@ -2323,7 +2320,6 @@ class NumberSymbol(AtomicExpr):
     __metaclass__ = Singleton
 
     is_commutative = True
-    is_comparable = True
     is_bounded = True
     is_finite = True
     is_number = True
@@ -2375,7 +2371,7 @@ class NumberSymbol(AtomicExpr):
                 if other > u:
                     return True
             return self.evalf() < other
-        if other.is_comparable:
+        if other.is_real and other.is_number:
             other = other.evalf()
             return self.evalf() < other
         return Expr.__lt__(self, other)
@@ -2387,7 +2383,7 @@ class NumberSymbol(AtomicExpr):
             return False    # sympy > other  --> not <=
         if self is other:
             return True
-        if other.is_comparable:
+        if other.is_real and other.is_number:
             other = other.evalf()
         if isinstance(other, Number):
             return self.evalf() <= other

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -121,13 +121,6 @@ class Pow(Expr):
         if b.is_polar:
             return Pow(b, e * other)
 
-    def _eval_is_comparable(self):
-        c1 = self.base.is_comparable
-        if c1 is None: return
-        c2 = self.exp.is_comparable
-        if c2 is None: return
-        return c1 and c2
-
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:
             if self.base.is_even:

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -8,6 +8,7 @@ def test_symbol_unset():
     assert x.is_integer == True
     assert x.is_imaginary == False
     assert x.is_noninteger == False
+    assert x.is_number is False
 
 def test_zero():
     z = Integer(0)
@@ -32,6 +33,7 @@ def test_zero():
     assert z.is_comparable == True
     assert z.is_prime == False
     assert z.is_composite == False
+    assert z.is_number is True
 
 def test_one():
     z = Integer(1)
@@ -55,6 +57,7 @@ def test_one():
     assert z.is_infinitesimal == False
     assert z.is_comparable == True
     assert z.is_prime == False
+    assert z.is_number is True
 
 @XFAIL
 def test_one_is_composite():
@@ -83,6 +86,7 @@ def test_negativeone():
     assert z.is_comparable == True
     assert z.is_prime == False
     assert z.is_composite == False
+    assert z.is_number is True
 
 def test_infinity():
     oo = S.Infinity
@@ -108,6 +112,7 @@ def test_infinity():
     assert oo.is_comparable     == True
     assert oo.is_prime          == None
     assert oo.is_composite      == None
+    assert oo.is_number is True
 
 def test_neg_infinity():
     mm = S.NegativeInfinity
@@ -133,6 +138,8 @@ def test_neg_infinity():
     assert mm.is_comparable     == True
     assert mm.is_prime          == False
     assert mm.is_composite      == False
+    assert mm.is_number is True
+
 
 def test_nan():
     nan = S.NaN
@@ -158,6 +165,7 @@ def test_nan():
     assert nan.is_comparable    == False
     assert nan.is_prime         == None
     assert nan.is_composite     == None
+    assert nan.is_number is True
 
 def test_pos_rational():
     r = Rational(3,4)

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -271,27 +271,27 @@ def test_E():
 
 def test_I():
     z = S.ImaginaryUnit
-    assert z.is_commutative == True
-    assert z.is_integer == False
-    assert z.is_rational == False
-    assert z.is_real == False
-    assert z.is_complex == True
-    assert z.is_noninteger == False
-    assert z.is_irrational == False
-    assert z.is_imaginary == True
-    assert z.is_positive == False
-    assert z.is_negative == False
-    assert z.is_nonpositive == False
-    assert z.is_nonnegative == False
-    assert z.is_even == False
-    assert z.is_odd == False
-    assert z.is_bounded == True
-    assert z.is_unbounded == False
-    assert z.is_finite == True
-    assert z.is_infinitesimal == False
-    assert z.is_comparable == None
-    assert z.is_prime == False
-    assert z.is_composite == False
+    assert z.is_commutative is True
+    assert z.is_integer is False
+    assert z.is_rational is False
+    assert z.is_real is False
+    assert z.is_complex is True
+    assert z.is_noninteger is False
+    assert z.is_irrational is False
+    assert z.is_imaginary is True
+    assert z.is_positive is False
+    assert z.is_negative is False
+    assert z.is_nonpositive is False
+    assert z.is_nonnegative is False
+    assert z.is_even is False
+    assert z.is_odd is False
+    assert z.is_bounded is True
+    assert z.is_unbounded is False
+    assert z.is_finite is True
+    assert z.is_infinitesimal is False
+    assert z.is_comparable is False
+    assert z.is_prime is False
+    assert z.is_composite is False
 
 def test_symbol_real():
     # issue 749

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -2,6 +2,11 @@ from sympy import symbols, Symbol, sqrt, oo, re, nan, im, sign, I, E, log, \
         pi, arg, conjugate, expand, exp, sin, cos, Function, Abs, zoo
 from sympy.utilities.pytest import XFAIL
 
+from sympy.utilities.randtest import comp
+def N_equals(a, b):
+    """Check whether two complex numbers are numerically close"""
+    return comp(a.n(), b.n(), 1.e-6)
+
 def test_re():
     x, y = symbols('x,y')
 
@@ -128,6 +133,8 @@ def test_Abs():
     assert Abs(1) == 1
     assert Abs(-1)== 1
     assert Abs(nan) == nan
+    assert Abs(I * pi) == pi
+
     x = Symbol('x',real=True)
     n = Symbol('n',integer=True)
     assert x**(2*n) == Abs(x)**(2*n)
@@ -235,17 +242,12 @@ def test_periodic_argument():
     x = Symbol('x')
     p = Symbol('p', positive = True)
 
-    def tn(a, b):
-        from sympy.utilities.randtest import test_numerically
-        from sympy import Dummy
-        return test_numerically(a, b, Dummy('x'))
-
     assert unbranched_argument(2 + I) == periodic_argument(2 + I, oo)
     assert unbranched_argument(1 + x) == periodic_argument(1 + x, oo)
-    assert tn(unbranched_argument((1+I)**2), pi/2)
-    assert tn(unbranched_argument((1-I)**2), -pi/2)
-    assert tn(periodic_argument((1+I)**2, 3*pi), pi/2)
-    assert tn(periodic_argument((1-I)**2, 3*pi), -pi/2)
+    assert N_equals(unbranched_argument((1+I)**2), pi/2)
+    assert N_equals(unbranched_argument((1-I)**2), -pi/2)
+    assert N_equals(periodic_argument((1+I)**2, 3*pi), pi/2)
+    assert N_equals(periodic_argument((1-I)**2, 3*pi), -pi/2)
 
     assert unbranched_argument(principal_branch(x, pi)) \
            == periodic_argument(x, pi)
@@ -265,7 +267,7 @@ def test_periodic_argument():
 @XFAIL
 def test_principal_branch_fail():
     # TODO XXX why does abs(x)._eval_evalf() not fall back to global evalf?
-    assert tn(principal_branch((1 + I)**2, pi/2), 0)
+    assert N_equals(principal_branch((1 + I)**2, pi/2), 0)
 
 def test_principal_branch():
     from sympy import principal_branch, polar_lift, exp_polar
@@ -283,20 +285,12 @@ def test_principal_branch():
            principal_branch(exp_polar(I*pi)*x, 2*pi)
     assert principal_branch(neg*exp_polar(pi*I), 2*pi) == neg*exp_polar(-I*pi)
 
-    def tn(a, b):
-        from sympy.utilities.randtest import test_numerically
-        from sympy import Dummy
-        return test_numerically(a, b, Dummy('x'))
-    assert tn(principal_branch((1 + I)**2, 2*pi), 2*I)
-    assert tn(principal_branch((1 + I)**2, 3*pi), 2*I)
-    assert tn(principal_branch((1 + I)**2, 1*pi), 2*I)
+    assert N_equals(principal_branch((1 + I)**2, 2*pi), 2*I)
+    assert N_equals(principal_branch((1 + I)**2, 3*pi), 2*I)
+    assert N_equals(principal_branch((1 + I)**2, 1*pi), 2*I)
 
     # test argument sanitization
     assert principal_branch(x, I).func is principal_branch
     assert principal_branch(x, -4).func is principal_branch
     assert principal_branch(x, -oo).func is principal_branch
     assert principal_branch(x, zoo).func is principal_branch
-
-@XFAIL
-def test_issue_2453():
-    assert abs(I * pi) == pi

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1403,7 +1403,7 @@ class atan2(Function):
         elif x.is_zero:
             if sign_y.is_Number:
                 return sign_y * S.Pi/2
-        else:
+        elif x.is_zero is False:
             abs_yx = C.Abs(y/x)
             if sign_y.is_Number and abs_yx.is_number:
                 phi = C.atan(abs_yx)


### PR DESCRIPTION
`is_comparable` doesn't fit with the rest of the assumptions, it doesn't make sense to assume that a Symbol is comparable. So it's more consistent to make it an ordinary property, like `is_number`

This also removes the hardcoded fallback to evalf() to evaluate assumptions `is_positive`, `is_negative`, etc. This behavior is now implemented in Expr._eval_is_positive and Expr._eval_is_negative instead.
