### PR TITLE
2962: fix of defect.

### DIFF
--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -61,7 +61,11 @@ def alternating(n):
 
 def dihedral(n):
     """
-    Generates the dihedral group of order 2n, D2n.
+    Generates the dihedral group of order 2n, Dn.
+
+    The result is given as a subgroup of Sn, except for the special cases n=1
+    (the group S2) and n=2 (the Klein 4-group) where that's not possible
+    and embeddings in S2 and S4 respectively are given.
 
     Examples
     ========
@@ -77,8 +81,17 @@ def dihedral(n):
     ========
     cyclic
     """
-    gen = range(n)
-    for i in xrange(n):
-        yield Permutation(gen)
-        yield Permutation(gen[::-1])
-        gen = rotate_left(gen, 1)
+    if n == 1:
+        yield Permutation([0, 1])
+        yield Permutation([1, 0])
+    elif n == 2:
+        yield Permutation([0, 1, 2, 3])
+        yield Permutation([1, 0, 3, 2])
+        yield Permutation([2, 3, 0, 1])
+        yield Permutation([3, 2, 1, 0])
+    else:
+        gen = range(n)
+        for i in xrange(n):
+            yield Permutation(gen)
+            yield Permutation(gen[::-1])
+            gen = rotate_left(gen, 1)

--- a/sympy/combinatorics/tests/test_generators.py
+++ b/sympy/combinatorics/tests/test_generators.py
@@ -32,6 +32,9 @@ def test_generators():
                                   Permutation([3, 0, 1, 2]), Permutation([3, 0, 2, 1]), Permutation([3, 1, 0, 2]), \
                                   Permutation([3, 1, 2, 0]), Permutation([3, 2, 0, 1]), Permutation([3, 2, 1, 0])]
 
+    assert list(dihedral(2)) == [Permutation([0, 1, 2, 3]), Permutation([1, 0, 3, 2]), \
+                                 Permutation([2, 3, 0, 1]), Permutation([3, 2, 1, 0])]
+
     assert list(dihedral(3)) == [Permutation([0, 1, 2]), Permutation([2, 1, 0]), Permutation([1, 2, 0]), \
                                  Permutation([0, 2, 1]), Permutation([2, 0, 1]), Permutation([1, 0, 2])]
 


### PR DESCRIPTION
Handling explicitly the dihedral groups D_n for n = 1, 2 since they cannot be represented as subgroups of S_n, which is what the general algorithm attempts to do.
