### PR TITLE
Bugfix issue 2684+2204 (deepcopying Objects that have evaluate=False)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -13,7 +13,7 @@ def _new_Basic(cls, args, state):
     Creates a new object while pickling. We need to call the __new__ method
     with keyword argument evaluate=False because some evaluation can occur
     at creation time and we don't want that while deepcopying an object..
-    This function is called by the __reduce__method.
+    This function is called by the __reduce__ method.
     """
     try:
         obj = cls.__new__(cls, *args, evaluate=False)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -8,14 +8,12 @@ from sympify import _sympify, sympify, SympifyError
 from compatibility import callable, reduce, cmp, iterable
 from sympy.core.decorators import deprecated
 
-def _new_Basic(cls, args, kwargs, assumptions):
+def _new_Basic(cls, args, state):
     try:
-        obj = cls.__new__(cls, *args, **kwargs)
+        obj = cls.__new__(cls, *args, evaluate=False)
     except TypeError:
-        kwargs.pop('evaluate')
-        obj = cls.__new__(cls, *args, **kwargs)
-    if assumptions is not None:
-        obj._assumptions = assumptions
+        obj = cls.__new__(cls, *args)
+    obj.__setstate__(state)
     return obj
 
 class Basic(object):
@@ -100,9 +98,7 @@ class Basic(object):
         return obj
 
     def __reduce__(self):
-        assumptions = getattr(self, '_assumptions', None)
-        kwargs = {'evaluate': False}
-        return _new_Basic, (self.__class__, self.__getnewargs__(), kwargs, assumptions), None
+        return _new_Basic, (self.__class__, self.__getnewargs__(), self.__getstate__()), None
 
     def __getnewargs__(self):
         """ Pickling support.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -89,6 +89,7 @@ class Basic(object):
 
     def __new__(cls, *args, **assumptions):
         obj = object.__new__(cls)
+        assumptions.pop('evaluate', None)
         obj._init_assumptions(assumptions)
 
         obj._mhash = None # will be set by __hash__ method.

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -9,7 +9,10 @@ from compatibility import callable, reduce, cmp, iterable
 from sympy.core.decorators import deprecated
 
 def _new_Basic(cls, args, kwargs):
-    obj =  cls.__new__(cls, *args, **kwargs)
+    try:
+        obj = cls.__new__(cls, *args, **kwargs)
+    except TypeError:
+        obj = cls.__new__(cls, *args)
     return obj
 
 class Basic(object):
@@ -49,7 +52,6 @@ class Basic(object):
     __metaclass__ = WithAssumptions
     __slots__ = ['_mhash',              # hash value
                  '_args',               # arguments
-                 '_evaluate',
                 ]
 
     # To be overridden with True in the appropriate subclasses
@@ -89,17 +91,12 @@ class Basic(object):
         obj = object.__new__(cls)
         obj._init_assumptions(assumptions)
 
-        obj._evaluate = assumptions.pop('evaluate', True)
-
         obj._mhash = None # will be set by __hash__ method.
         obj._args = args  # all items in args must be Basic objects
         return obj
 
     def __reduce__(self):
-        if self._evaluate:
-            kwargs = {}
-        else:
-            kwargs = {'evaluate': self._evaluate}
+        kwargs = {'evaluate': False}
         return _new_Basic, (self.__class__, self.__getnewargs__(), kwargs)
 
     def __getnewargs__(self):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -8,11 +8,14 @@ from sympify import _sympify, sympify, SympifyError
 from compatibility import callable, reduce, cmp, iterable
 from sympy.core.decorators import deprecated
 
-def _new_Basic(cls, args, kwargs):
+def _new_Basic(cls, args, kwargs, assumptions):
     try:
         obj = cls.__new__(cls, *args, **kwargs)
     except TypeError:
-        obj = cls.__new__(cls, *args)
+        kwargs.pop('evaluate')
+        obj = cls.__new__(cls, *args, **kwargs)
+    if assumptions is not None:
+        obj._assumptions = assumptions
     return obj
 
 class Basic(object):
@@ -97,8 +100,9 @@ class Basic(object):
         return obj
 
     def __reduce__(self):
+        assumptions = getattr(self, '_assumptions', None)
         kwargs = {'evaluate': False}
-        return _new_Basic, (self.__class__, self.__getnewargs__(), kwargs)
+        return _new_Basic, (self.__class__, self.__getnewargs__(), kwargs, assumptions), None
 
     def __getnewargs__(self):
         """ Pickling support.

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -27,15 +27,21 @@ class AssocOp(Expr):
     @cacheit
     def __new__(cls, *args, **options):
         args = map(_sympify, args)
-        args = [a for a in args if a is not cls.identity]
 
         if not options.pop('evaluate', True):
             return cls._from_args(args)
+
+        args = [a for a in args if a is not cls.identity]
 
         if len(args) == 0:
             return cls.identity
         if len(args) == 1:
             return args[0]
+
+        if not options.get('evaluate', True):
+            obj = Expr.__new__(cls, *args, **options)
+            obj.is_commutative = all(a.is_commutative for a in args)
+            return obj
 
         c_part, nc_part, order_symbols = cls.flatten(args)
         obj = cls._from_args(c_part + nc_part, not nc_part)

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -38,11 +38,6 @@ class AssocOp(Expr):
         if len(args) == 1:
             return args[0]
 
-        if not options.get('evaluate', True):
-            obj = Expr.__new__(cls, *args, **options)
-            obj.is_commutative = all(a.is_commutative for a in args)
-            return obj
-
         c_part, nc_part, order_symbols = cls.flatten(args)
         obj = cls._from_args(c_part + nc_part, not nc_part)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1126,10 +1126,10 @@ def test_suppressed_evaluation():
     c = Pow(3,2,evaluate=False)
     assert a != 6
     assert a.func is Add
-    assert a.args == (3,2)
+    assert a.args == (0,3,2)
     assert b != 6
     assert b.func is Mul
-    assert b.args == (3,2)
+    assert b.args == (1,3,2)
     assert c != 9
     assert c.func is Pow
     assert c.args == (3,2)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -12,7 +12,6 @@ from sympy.core.cache import clear_cache
 
 from sympy.utilities.pytest import XFAIL, raises
 
-
 class DummyNumber(object):
     """
     Minimal implementation of a number that works with SymPy.

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -12,6 +12,8 @@ from sympy.core.cache import clear_cache
 
 from sympy.utilities.pytest import XFAIL, raises
 
+from copy import deepcopy
+
 class DummyNumber(object):
     """
     Minimal implementation of a number that works with SymPy.
@@ -1048,3 +1050,8 @@ def test_issue_1100():
     a = x - y
     assert a._eval_interval(x, 1, oo)._eval_interval(y, oo, 1) is S.NaN
     raises(ValueError, 'x._eval_interval(x, None, None)')
+
+def test_copy():
+    mul = Mul(3, 4, evaluate=False)
+    mul_copy = deepcopy(mul)
+    assert isinstance(mul_copy, Mul)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1051,7 +1051,11 @@ def test_issue_1100():
     assert a._eval_interval(x, 1, oo)._eval_interval(y, oo, 1) is S.NaN
     raises(ValueError, 'x._eval_interval(x, None, None)')
 
-def test_copy():
+def test_evaluate_false():
+    #Issue 2684
     mul = Mul(3, 4, evaluate=False)
     mul_copy = deepcopy(mul)
     assert isinstance(mul_copy, Mul)
+    #Multiplying by identity but is really not evaluated
+    mul = Mul(1, Add(1, 2, evaluate=False), evaluate=False)
+    assert type(mul) == Mul

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -12,7 +12,6 @@ from sympy.core.cache import clear_cache
 
 from sympy.utilities.pytest import XFAIL, raises
 
-from copy import deepcopy
 
 class DummyNumber(object):
     """
@@ -1050,12 +1049,3 @@ def test_issue_1100():
     a = x - y
     assert a._eval_interval(x, 1, oo)._eval_interval(y, oo, 1) is S.NaN
     raises(ValueError, 'x._eval_interval(x, None, None)')
-
-def test_evaluate_false():
-    #Issue 2684
-    mul = Mul(3, 4, evaluate=False)
-    mul_copy = deepcopy(mul)
-    assert isinstance(mul_copy, Mul)
-    #Multiplying by identity but is really not evaluated
-    mul = Mul(1, Add(1, 2, evaluate=False), evaluate=False)
-    assert type(mul) == Mul

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -28,6 +28,8 @@ from sympy.core.compatibility import callable
 
 from sympy import symbols
 
+from copy import deepcopy
+
 
 def check(a, check_attr = True):
     """ Check that pickling and copying round-trips.
@@ -407,3 +409,8 @@ def test_concrete():
     for c in (Product, Product(1,2), Sum, Sum(x, (x, 2, 4))):
         check(c)
 
+def test_deepcopy():
+    #Issue 2684
+    mul = Mul(3, 4, evaluate=False)
+    mul_copy = deepcopy(mul)
+    assert isinstance(mul_copy, Mul)


### PR DESCRIPTION
This patch should fix both issues by correctly pickling/unpickling objects.

When unpickling an object, evaluate=False is passed whenever possible because object has already been evaluated before. Some constructors do not accept evaluate kwarg which is why we have a try:except:.

After calling **new**, **setstate** needs to be called to set assumptions and other slots for objects.
