### PR TITLE
[integrals] Fix issue 3153.

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -379,6 +379,8 @@ def _split_mul(f, x):
         else:
             if a.is_Pow:
                 c, t = a.base.as_coeff_mul(x)
+                if t != (x,):
+                    c, t = expand_mul(a.base).as_coeff_mul(x)
                 if t == (x,):
                     po *= x**a.exp
                     fac *= unpolarify(polarify(c**a.exp, subs=False))

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -582,3 +582,10 @@ def test_messy():
 def test_3023():
     assert integrate(exp(-I*x**2), (x, -oo, oo), meijerg=True) == \
            -I*sqrt(pi)*exp(I*pi/4)
+
+def test_3153():
+    expr = 1/x/(a+b*x)**(S(1)/3)
+    anti = integrate(expr, x, meijerg=True)
+    assert not expr.has(hyper)
+    # XXX the expression is a mess, but actually upon differentiation and
+    # putting in numerical values seems to work...


### PR DESCRIPTION
Slightly improve _split_mul in meijerint.py to recognise `(b*(x-1/b) + 1)**a`
as `x**a`.

Add a test regarding the particular integral of the issue.
