### PR TITLE
Improved trigonometric Functions

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, acot, pi, atan,
         acos, Rational, sqrt, asin, acot, cot, coth, E, S, tan, tanh, cos,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,
-        Float)
+        Float,Pow)
 
 from sympy.utilities.pytest import XFAIL
 
@@ -91,6 +91,15 @@ def test_sin_rewrite():
     assert sin(x).rewrite(exp) == -I*(exp(I*x) - exp(-I*x))/2
     assert sin(x).rewrite(tan) == 2*tan(x/2)/(1 + tan(x/2)**2)
     assert sin(x).rewrite(cot) == 2*cot(x/2)/(1 + cot(x/2)**2)
+    assert sin(sinh(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, sinh(3)).n()
+    assert sin(cosh(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, cosh(3)).n()
+    assert sin(tanh(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, tanh(3)).n()
+    assert sin(coth(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, coth(3)).n()
+    assert sin(sin(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, sin(3)).n()
+    assert sin(cos(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, cos(3)).n()
+    assert sin(tan(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, tan(3)).n()
+    assert sin(cot(x)).rewrite(exp).subs(x, 3).n() == sin(x).rewrite(exp).subs(x, cot(3)).n()
+    assert sin(log(x)).rewrite(Pow)  == I*x**-I / 2 - I*x**I /2
 
 def test_sin_expansion():
     x,y = symbols('x,y')
@@ -227,6 +236,15 @@ def test_cos_rewrite():
     assert cos(x).rewrite(exp) == exp(I*x)/2 + exp(-I*x)/2
     assert cos(x).rewrite(tan) == (1 - tan(x/2)**2)/(1 + tan(x/2)**2)
     assert cos(x).rewrite(cot) == -(1 - cot(x/2)**2)/(1 + cot(x/2)**2)
+    assert cos(sinh(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, sinh(3)).n()
+    assert cos(cosh(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, cosh(3)).n()
+    assert cos(tanh(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, tanh(3)).n()
+    assert cos(coth(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, coth(3)).n()
+    assert cos(sin(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, sin(3)).n()
+    assert cos(cos(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, cos(3)).n()
+    assert cos(tan(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, tan(3)).n()
+    assert cos(cot(x)).rewrite(exp).subs(x, 3).n() == cos(x).rewrite(exp).subs(x, cot(3)).n()
+    assert cos(log(x)).rewrite(Pow) == x**I/2 + x**-I/2
 
 def test_cos_expansion():
     x,y = symbols('x,y')
@@ -304,6 +322,15 @@ def test_tan_rewrite():
     assert tan(x).rewrite(sin) == 2*sin(x)**2/sin(2*x)
     assert tan(x).rewrite(cos) == -cos(x + S.Pi/2)/cos(x)
     assert tan(x).rewrite(cot) == 1/cot(x)
+    assert tan(sinh(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, sinh(3)).n()
+    assert tan(cosh(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, cosh(3)).n()
+    assert tan(tanh(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, tanh(3)).n()
+    assert tan(coth(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, coth(3)).n()
+    assert tan(sin(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, sin(3)).n()
+    assert tan(cos(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, cos(3)).n()
+    assert tan(tan(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, tan(3)).n()
+    assert tan(cot(x)).rewrite(exp).subs(x, 3).n() == tan(x).rewrite(exp).subs(x, cot(3)).n()
+    assert tan(log(x)).rewrite(Pow) == I*(x**-I - x**I)/(x**-I + x**I)
 
 def test_tan_subs():
     x,y = symbols('x,y')
@@ -379,6 +406,13 @@ def test_cot_rewrite():
     assert cot(x).rewrite(sin) == 2*sin(2*x)/sin(x)**2
     assert cot(x).rewrite(cos) == -cos(x)/cos(x + S.Pi/2)
     assert cot(x).rewrite(tan) == 1/tan(x)
+    assert cot(sinh(x)).rewrite(exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, sinh(3)).n()
+    assert cot(cosh(x)).rewrite(exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, cosh(3)).n()
+    assert cot(tanh(x)).rewrite(exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, tanh(3)).n()
+    assert cot(coth(x)).rewrite(exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, coth(3)).n()
+    assert cot(sin(x)).rewrite(exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, sin(3)).n()
+    assert cot(tan(x)).rewrite(exp).subs(x, 3).n() == cot(x).rewrite(exp).subs(x, tan(3)).n()
+    assert cot(log(x)).rewrite(Pow) == -I*(x**-I + x**I)/(x**-I - x**I)
 
 def test_cot_subs():
     x,y = symbols('x,y')

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -5,6 +5,7 @@ from sympy.core.singleton import S
 from sympy.core.function import Function, ArgumentIndexError
 from miscellaneous import sqrt
 from exponential import log
+from sympy.functions.elementary.hyperbolic import HyperbolicFunction,sinh,cosh,tanh,coth
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################
@@ -248,7 +249,7 @@ class sin(TrigonometricFunction):
             return sqrt(1 - x**2)
 
         if arg.func is acot:
-            x = arg.args[0];
+            x = arg.args[0]
             return 1 / (sqrt(1 + 1 / x**2) * x)
 
     @staticmethod
@@ -267,7 +268,15 @@ class sin(TrigonometricFunction):
 
     def _eval_rewrite_as_exp(self, arg):
         exp, I = C.exp, S.ImaginaryUnit
+        if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction) :
+            arg = arg.func(arg.args[0]).rewrite(exp)
         return (exp(arg*I) - exp(-arg*I)) / (2*I)
+
+    def _eval_rewrite_as_Pow(self, arg):
+        if arg.func is log:
+            I = S.ImaginaryUnit
+            x = arg.args[0]
+            return I*x**-I / 2 - I*x**I /2
 
     def _eval_rewrite_as_cos(self, arg):
         return -cos(arg + S.Pi/2)
@@ -475,7 +484,6 @@ class cos(TrigonometricFunction):
             x = arg.args[0]
             return 1 / sqrt(1 + 1 / x**2)
 
-
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -492,7 +500,15 @@ class cos(TrigonometricFunction):
 
     def _eval_rewrite_as_exp(self, arg):
         exp, I = C.exp, S.ImaginaryUnit
+        if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction) :
+           arg = arg.func(arg.args[0]).rewrite(exp)
         return (exp(arg*I) + exp(-arg*I)) / 2
+
+    def _eval_rewrite_as_Pow(self, arg):
+        if arg.func is log:
+            I = S.ImaginaryUnit
+            x = arg.args[0]
+            return x**I/2 + x**-I/2
 
     def _eval_rewrite_as_sin(self, arg):
         return sin(arg + S.Pi/2)
@@ -682,7 +698,6 @@ class tan(TrigonometricFunction):
             x = arg.args[0]
             return 1 / x
 
-
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -703,6 +718,12 @@ class tan(TrigonometricFunction):
         if i and i.is_Integer:
             return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
         return Function._eval_nseries(self, x, n=n, logx=logx)
+
+    def _eval_rewrite_as_Pow(self, arg):
+        if arg.func is log:
+            I = S.ImaginaryUnit
+            x = arg.args[0]
+            return I*(x**-I - x**I)/(x**-I + x**I)
 
     def _eval_conjugate(self):
         return self.func(self.args[0].conjugate())
@@ -730,6 +751,8 @@ class tan(TrigonometricFunction):
 
     def _eval_rewrite_as_exp(self, arg):
         exp, I = C.exp, S.ImaginaryUnit
+        if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction) :
+            arg = arg.func(arg.args[0]).rewrite(exp)
         neg_exp, pos_exp = exp(-arg*I), exp(arg*I)
         return I*(neg_exp-pos_exp)/(neg_exp+pos_exp)
 
@@ -866,7 +889,6 @@ class cot(TrigonometricFunction):
             x = arg.args[0]
             return x / sqrt(1 - x**2)
 
-
     @staticmethod
     @cacheit
     def taylor_term(n, x, *previous_terms):
@@ -912,8 +934,16 @@ class cot(TrigonometricFunction):
 
     def _eval_rewrite_as_exp(self, arg):
         exp, I = C.exp, S.ImaginaryUnit
+        if isinstance(arg, TrigonometricFunction) or isinstance(arg, HyperbolicFunction) :
+           arg = arg.func(arg.args[0]).rewrite(exp)
         neg_exp, pos_exp = exp(-arg*I), exp(arg*I)
         return I*(pos_exp+neg_exp)/(pos_exp-neg_exp)
+
+    def _eval_rewrite_as_Pow(self, arg):
+        if arg.func is log:
+            I = S.ImaginaryUnit
+            x = arg.args[0]
+            return -I*(x**-I + x**I)/(x**-I - x**I)
 
     def _eval_rewrite_as_sin(self, x):
         return 2*sin(2*x)/sin(x)**2


### PR DESCRIPTION
Patch Status:
evaluates sin(log(x)) interms of x.Similarly for cos,tan,cot functions
Gives sin(sinh(x)).rewrite(exp) in terms of exp(x) only.
Gives sin(sinh(x)).rewrite(exp).subs(x, sinh(h)) in terms of exp(sinh(x))
Similar results for cos,tan,cot functions.
Added tests.All passed.

Present Status :
calling sin(log(x)) gives sin(log(x)).
gives sin(sinh(x)) in terms of exp(sinh(x)) but not in exp(x) which is expected by user.
gives sin(sinh(x)).rewrite(exp).subs(x, sinh(x)) gives in terms of exp(sinh(x)).
