### PR TITLE
do not rely on is_real for comparable test

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -410,10 +410,10 @@ class Add(AssocOp):
         return all(term._eval_is_rational_function(syms) for term in self.args)
 
     # assumption methods
-    _eval_is_real = lambda self: self._eval_template_is_attr('is_real')
-    _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded')
+    _eval_is_real = lambda self: self._eval_template_is_attr('is_real', when_multiple=None)
+    _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded', when_multiple=None)
+    _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer', when_multiple=None)
     _eval_is_commutative = lambda self: self._eval_template_is_attr('is_commutative')
-    _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer')
 
     def _eval_is_odd(self):
         l = [f for f in self.args if not (f.is_even==True)]

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -638,7 +638,15 @@ class Basic(PicklableWithSlots):
         is_number = self.is_number
         if is_number is False:
             return False
-        return self.is_real and self.is_number
+        if is_real and is_number:
+            return True
+        n, i = self.evalf(2).as_real_imag()
+        if not i.is_Number or not n.is_Number:
+            return False
+        if i:
+            if i._prec != 1:
+                return False
+        return n._prec != 1
 
     @property
     def func(self):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -529,19 +529,47 @@ class Expr(Basic, EvalfMixin):
         return None
 
     def _eval_is_positive(self):
-        if self.is_real and self.is_number:
-            n = self.evalf(1)
-            if n > 0:
-                return True
-            elif n < 0:
+        if self.is_number:
+            if self.is_real is False:
+                return False
+            try:
+                # check to see that we can get a value
+                n2 = self._eval_evalf(1)
+            except AttributeError:
+                n2 = None
+            if n2 is None:
+                return None
+            n, i = self.evalf(2).as_real_imag()
+            if not i.is_Number or not n.is_Number:
+                return False
+            if i:
+                if i._prec != 1:
+                    return False
+            elif n._prec != 1:
+                if n > 0:
+                    return True
                 return False
 
     def _eval_is_negative(self):
-        if self.is_real and self.is_number:
-            n = self.evalf(1)
-            if n < 0:
-                return True
-            elif n > 0:
+        if self.is_number:
+            if self.is_real is False:
+                return False
+            try:
+                # check to see that we can get a value
+                n2 = self._eval_evalf(1)
+            except AttributeError:
+                n2 = None
+            if n2 is None:
+                return None
+            n, i = self.evalf(2).as_real_imag()
+            if not i.is_Number or not n.is_Number:
+                return False
+            if i:
+                if i._prec != 1:
+                    return False
+            elif n._prec != 1:
+                if n < 0:
+                    return True
                 return False
 
     def _eval_interval(self, x, a, b):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -981,8 +981,8 @@ class Mul(AssocOp):
         return all(term._eval_is_rational_function(syms) for term in self.args)
 
     _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded')
+    _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer', when_multiple=None)
     _eval_is_commutative = lambda self: self._eval_template_is_attr('is_commutative')
-    _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer')
 
     def _eval_is_polar(self):
         has_polar = any(arg.is_polar for arg in self.args)
@@ -990,7 +990,6 @@ class Mul(AssocOp):
                all(arg.is_polar or arg.is_positive for arg in self.args)
 
     # I*I -> R,  I*I*I -> -I
-
     def _eval_is_real(self):
         im_count = 0
         is_neither = False

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2226,6 +2226,7 @@ class NaN(Number):
     is_zero = None
     is_prime = None
     is_positive = None
+    is_negative = None
 
     __slots__ = []
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -202,14 +202,24 @@ class AssocOp(Expr):
 
         return
 
-    def _eval_template_is_attr(self, is_attr):
-        # return True if all elements have the property
-        r = True
+    def _eval_template_is_attr(self, is_attr, when_multiple=False):
+        # return True if all elements have the property;
+        # False if one doesn't have the property; and
+        # if more than one doesn't have property, return
+        #    False if when_multiple = False
+        #    None if when_multiple is not False
+        quick = when_multiple is None
+        multi = False
         for t in self.args:
             a = getattr(t, is_attr)
-            if a is None: return
-            if r and not a: r = False
-        return r
+            if a is True:
+                continue
+            if a is None:
+                return
+            if quick and multi:
+                return None
+            multi = True
+        return not multi
 
     def _eval_evalf(self, prec):
         return self.func(*[s._evalf(prec) for s in self.args])

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -550,7 +550,7 @@ class Pow(Expr):
         if self.exp.is_Integer:
             exp = self.exp
             re, im = self.base.as_real_imag(deep=deep)
-            if re.func == C.re or im.func == C.im:
+            if re.func == C.re or im.func == C.im or not im:
                 return self, S.Zero
             a, b = symbols('a b', cls=Dummy)
             if exp >= 0:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -372,6 +372,9 @@ def test_Add_Mul_is_integer():
     assert (k+n*x).is_integer == None
     assert (k+n/3).is_integer == False
 
+    assert ((1 + sqrt(3))*(-sqrt(3) + 1)).is_integer != False
+    assert (1 + (1 + sqrt(3))*(-sqrt(3) + 1)).is_integer != False
+
 def test_Add_Mul_is_bounded():
     x = Symbol('x', real=True, bounded=False)
 
@@ -384,6 +387,10 @@ def test_Add_Mul_is_bounded():
 
     assert (sin(x)-67).is_bounded == True
     assert (sin(x)+exp(x)).is_bounded is not True
+    assert (1 + x).is_bounded is False
+    assert (1 + x**2 + (1 + x)*(1 - x)).is_bounded is None
+    assert (sqrt(2)*(1 + x)).is_bounded is False
+    assert (sqrt(2)*(1 + x)*(1 - x)).is_bounded is False
 
 def test_Mul_is_even_odd():
     x = Symbol('x', integer=True)
@@ -743,6 +750,8 @@ def test_Add_is_negative_positive():
 
     assert (n+x).is_positive == None
     assert (n+x-k).is_positive == None
+
+    assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero != False
 
 def test_Add_is_nonpositive_nonnegative():
     x = Symbol('x', real=True)
@@ -1270,8 +1279,18 @@ def test_issue_2902():
     A = Symbol("A", commutative=False)
     eq = A + A**2
     # it doesn't matter whether it's True or False; they should
-    # just both be the same
-    assert eq.is_commutative == (eq + 1).is_commutative
+    # just all be the same
+    assert (
+        eq.is_commutative ==
+        (eq + 1).is_commutative ==
+        (A + 1).is_commutative)
+
+    B = Symbol("B", commutative=False)
+    # Although commutative terms could cancel we return True
+    # meaning "there are non-commutative symbols; aftersubstitution
+    # that definition can change, e.g. (A*B).subs(B,A**-1) -> 1
+    assert (sqrt(2)*A).is_commutative is False
+    assert (sqrt(2)*A*B).is_commutative is False
 
 def test_polar():
     from sympy import polar_lift

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -561,6 +561,12 @@ def test_special_assumptions():
     b = Symbol('b', bounded=None)
     assert (b*z).is_zero is None
 
+    e = -3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2
+    assert (e < 0) is False
+    assert (e > 0) is False
+    assert (e == 0) is False # it's not a literal 0
+    assert e.equals(0) is True
+
 def test_inconsistent():
     # cf. issues 2696 and 2446
     raises(AssertionError, "Symbol('x', real=True, commutative=False)")

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1242,10 +1242,6 @@ def test_is_constant():
     assert (3*meter).is_constant() is True
     assert (x*meter).is_constant() is False
 
-@XFAIL
-def test_is_not_constant():
-    assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).is_zero != False
-
 def test_equals():
     assert (-3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2).equals(0)
     assert (x**2 - 1).equals((x + 1)*(x - 1))

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -113,6 +113,14 @@ def test_sign():
     x = 0
     assert sign(x).is_zero == True
 
+def test_as_real_imag():
+    n = pi**1000
+    # the special code for working out the real
+    # and complex parts of a power with Integer exponent
+    # should not run if there is no imaginary part, hence
+    # this should not hang
+    assert n.as_real_imag() == (n, 0)
+
 @XFAIL
 def test_sign_issue_3068():
     n = pi**1000

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -532,9 +532,10 @@ def test_lerchphi():
     assert can_do([1, a, a, a, b + 5], [a + 1, a + 1, a + 1, b], numerical=False)
 
     # test a bug
+    from sympy import Abs
     assert hyperexpand(hyper([S(1)/2, S(1)/2, S(1)/2, 1],
                              [S(3)/2, S(3)/2, S(3)/2], S(1)/4)) == \
-           -polylog(3, exp_polar(I*pi)/2) + polylog(3, S(1)/2)
+        Abs(-polylog(3, exp_polar(I*pi)/2) + polylog(3, S(1)/2))
 
 def test_partial_simp():
     # First test that hypergeometric function formulae work.


### PR DESCRIPTION
When foo.is_number and foo.is_real is used to determine whether
something is positive or negative there are two problems:

1) this discriminates against expressions for which is_real is None
2) this doesn't allow is_positive|negative to answer False for
   complex numbers -- they answer None at present

When evaluating is_real|integer, the presence of more than one
argument that does not have that attribute necessitates returning None
rather than False since those two properties may cancel out. A key
word to allow this option has been added to the
operations._eval_template_is_attr function.
