### PR TITLE
2418 interval evalf mpmath interval

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -5,6 +5,7 @@ from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
 from sympy.core.containers import Tuple
 from sympy.core.compatibility import iterable
+from sympy.core.decorators import deprecated
 
 from sympy.mpmath import mpi, mpf
 from sympy.assumptions import ask
@@ -618,11 +619,12 @@ class Interval(Set, EvalfMixin):
     def _measure(self):
         return self.end - self.start
 
+    @deprecated
     def to_mpi(self, prec=53):
         return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
 
-    def to_mpmath(self, prec=53):
-        return self.to_mpi(prec)
+    def _to_mpmath(self, prec=53):
+        return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
 
     def _eval_evalf(self, prec):
         return Interval(self.left.evalf(), self.right.evalf(),

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -621,9 +621,13 @@ class Interval(Set, EvalfMixin):
     def to_mpi(self, prec=53):
         return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
 
+    def to_mpmath(self, prec):
+      return [ self.left._to_mpmath(prec), self.right._to_mpmath(prec)]
+      #return Interval(self.left._to_mpmath(prec), self.right._to_mpmath(prec),
+      #    left_open=self.left_open, right_open=self.right_open);
+
     def _eval_evalf(self, prec):
-        return Interval(self.left.evalf(), self.right.evalf(),
-            left_open=self.left_open, right_open=self.right_open)
+      return Interval(self.left.evalf(), self.right.evalf(),left_open=self.left_open, right_open=self.right_open)
 
     def _is_comparable(self, other):
         is_comparable = self.start.is_comparable

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -621,9 +621,9 @@ class Interval(Set, EvalfMixin):
 
     @deprecated
     def to_mpi(self, prec=53):
-        return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
+      return self._mpi_(prec)
 
-    def _to_mpmath(self, prec=53):
+    def _mpi_(self, prec=53):
         return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
 
     def _eval_evalf(self, prec):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -622,10 +622,10 @@ class Interval(Set, EvalfMixin):
         return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
 
     def to_mpmath(self, prec=53):
-      return self.to_mpi(prec)
+        return self.to_mpi(prec)
 
     def _eval_evalf(self, prec):
-      return Interval(self.left.evalf(), self.right.evalf(),
+        return Interval(self.left.evalf(), self.right.evalf(),
           left_open=self.left_open, right_open=self.right_open)
 
     def _is_comparable(self, other):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -625,7 +625,8 @@ class Interval(Set, EvalfMixin):
       return self.to_mpi(prec)
 
     def _eval_evalf(self, prec):
-      return Interval(self.left.evalf(), self.right.evalf(),left_open=self.left_open, right_open=self.right_open)
+      return Interval(self.left.evalf(), self.right.evalf(),
+          left_open=self.left_open, right_open=self.right_open)
 
     def _is_comparable(self, other):
         is_comparable = self.start.is_comparable

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -621,10 +621,8 @@ class Interval(Set, EvalfMixin):
     def to_mpi(self, prec=53):
         return mpi(mpf(self.start.evalf(prec)), mpf(self.end.evalf(prec)))
 
-    def to_mpmath(self, prec):
-      return [ self.left._to_mpmath(prec), self.right._to_mpmath(prec)]
-      #return Interval(self.left._to_mpmath(prec), self.right._to_mpmath(prec),
-      #    left_open=self.left_open, right_open=self.right_open);
+    def to_mpmath(self, prec=53):
+      return self.to_mpi(prec)
 
     def _eval_evalf(self, prec):
       return Interval(self.left.evalf(), self.right.evalf(),left_open=self.left_open, right_open=self.right_open)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -6,7 +6,7 @@ from sympy import (
 from sympy.mpmath import mpi
 
 from sympy.utilities.pytest import raises
-from sympy.core.compatibility import SymPyDeprecationWarning
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.pytest import raises, XFAIL
 
 def test_interval_arguments():

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -6,6 +6,8 @@ from sympy import (
 from sympy.mpmath import mpi
 
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import SymPyDeprecationWarning
+from sympy.utilities.pytest import raises, XFAIL
 
 def test_interval_arguments():
     assert Interval(0, oo) == Interval(0, oo, False, True)
@@ -203,14 +205,17 @@ def test_interval_subs():
     assert Interval(0, a).subs(a, 2) == Interval(0, 2)
     assert Interval(a, 0).subs(a, 2) == S.EmptySet
 
+@XFAIL
 def test_interval_to_mpi():
+    raises(SymPyDeprecationWarning, "Interval(0, 1).to_mpi()")
     assert Interval(0, 1).to_mpi() == mpi(0, 1)
     assert Interval(0, 1, True, False).to_mpi() == mpi(0, 1)
+    assert type(Interval(0,1).to_mpi()) == type(mpi(0,1))
 
-def test_interval_to_mpmath():
-    assert Interval(0,1)._to_mpmath() == mpi(0,1)
-    assert Interval(0,1,True,False)._to_mpmath() == mpi(0,1)
-    assert type(Interval(0,1)._to_mpmath()) == type(mpi(0,1))
+def test_interval_mpi():
+    assert Interval(0,1)._mpi_() == mpi(0,1)
+    assert Interval(0,1,True,False)._mpi_() == mpi(0,1)
+    assert type(Interval(0,1)._mpi_()) == type(mpi(0,1))
 
 def test_measure():
     a = Symbol('a', real=True)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -207,6 +207,11 @@ def test_interval_to_mpi():
     assert Interval(0, 1).to_mpi() == mpi(0, 1)
     assert Interval(0, 1, True, False).to_mpi() == mpi(0, 1)
 
+def test_interval_to_mpmath():
+    assert Interval(0,1).to_mpmath() == mpi(0,1)
+    assert Interval(0,1,True,False).to_mpmath() == mpi(0,1)
+    assert type(Interval(0,1).to_mpmath()) == type(mpi(0,1))
+
 def test_measure():
     a = Symbol('a', real=True)
 

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -208,9 +208,9 @@ def test_interval_to_mpi():
     assert Interval(0, 1, True, False).to_mpi() == mpi(0, 1)
 
 def test_interval_to_mpmath():
-    assert Interval(0,1).to_mpmath() == mpi(0,1)
-    assert Interval(0,1,True,False).to_mpmath() == mpi(0,1)
-    assert type(Interval(0,1).to_mpmath()) == type(mpi(0,1))
+    assert Interval(0,1)._to_mpmath() == mpi(0,1)
+    assert Interval(0,1,True,False)._to_mpmath() == mpi(0,1)
+    assert type(Interval(0,1)._to_mpmath()) == type(mpi(0,1))
 
 def test_measure():
     a = Symbol('a', real=True)

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -3,7 +3,6 @@
 from sympy.core import Symbol, Interval
 from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.core.singleton import S
-from sympy.core.decorators import deprecated
 
 from sympy.assumptions import ask, AppliedPredicate, Q
 from sympy.functions import re, im, Abs

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -8,24 +8,6 @@ from sympy.functions import re, im, Abs
 from sympy.logic import And
 from sympy.polys import Poly
 
-def interval_evalf(interval):
-    """Proper implementation of evalf() on Interval.
-
-    Examples
-    ========
-
-    >>> from sympy.core import Interval, Symbol
-    >>> from sympy.solvers.inequalities import interval_evalf
-
-    >>> interval_evalf(Interval(1, 3))
-    [1.0, 3.0]
-
-    >>> x = Symbol('x', real=True)
-    >>> interval_evalf(Interval(2*x, x - 5))
-    [2.0*x, x - 5.0]
-    """
-    return Interval(interval.left.evalf(), interval.right.evalf(),
-        left_open=interval.left_open, right_open=interval.right_open)
 
 def solve_poly_inequality(poly, rel):
     """Solve a polynomial inequality with rational coefficients.

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -10,27 +10,6 @@ from sympy.functions import re, im, Abs
 from sympy.logic import And
 from sympy.polys import Poly
 
-
-@deprecated
-def interval_evalf(interval):
-    """Proper implementation of evalf() on Interval.
-
-    Examples
-    ========
-
-    >>> from sympy.core import Interval, Symbol
-    >>> from sympy.solvers.inequalities import interval_evalf
-
-    >>> interval_evalf(Interval(1, 3))
-    [1.0, 3.0]
-
-    >>> x = Symbol('x', real=True)
-    >>> interval_evalf(Interval(2*x, x - 5))
-    [2.0*x, x - 5.0]
-    """
-    return Interval(interval.left.evalf(), interval.right.evalf(),
-        left_open=interval.left_open, right_open=interval.right_open)
-
 def solve_poly_inequality(poly, rel):
     """Solve a polynomial inequality with rational coefficients.
 

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -3,11 +3,33 @@
 from sympy.core import Symbol, Interval
 from sympy.core.relational import Relational, Eq, Ge, Lt
 from sympy.core.singleton import S
+from sympy.core.decorators import deprecated
+
 from sympy.assumptions import ask, AppliedPredicate, Q
 from sympy.functions import re, im, Abs
 from sympy.logic import And
 from sympy.polys import Poly
 
+
+@deprecated
+def interval_evalf(interval):
+    """Proper implementation of evalf() on Interval.
+
+    Examples
+    ========
+
+    >>> from sympy.core import Interval, Symbol
+    >>> from sympy.solvers.inequalities import interval_evalf
+
+    >>> interval_evalf(Interval(1, 3))
+    [1.0, 3.0]
+
+    >>> x = Symbol('x', real=True)
+    >>> interval_evalf(Interval(2*x, x - 5))
+    [2.0*x, x - 5.0]
+    """
+    return Interval(interval.left.evalf(), interval.right.evalf(),
+        left_open=interval.left_open, right_open=interval.right_open)
 
 def solve_poly_inequality(poly, rel):
     """Solve a polynomial inequality with rational coefficients.


### PR DESCRIPTION
Removed the interval_evalf() functions from inequalities.py
Added method Interval.to_mpmath(self, prec) that returns mpmath mpi object.
