### PR TITLE
correct as_real_imag and don't allow symbol with zero=True

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -587,8 +587,6 @@ class Pow(Expr):
             #       x being imaginary there are actually q roots, but
             #       only a single one is returned from here.
             re, im = self.base.as_real_imag(deep=deep)
-            if re.func == C.re or im.func == C.im:
-                return self, S.Zero
             r = Pow(Pow(re, 2) + Pow(im, 2), S.Half)
             t = C.atan2(im, re)
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -67,6 +67,8 @@ class Symbol(AtomicExpr, Boolean):
                     SymPyDeprecationWarning)
             if assumptions.pop('dummy'):
                 return Dummy(name, **assumptions)
+        if assumptions.get('zero', False):
+            return S.Zero
         assumptions.setdefault('commutative', True)
         return Symbol.__xnew_cached_(cls, name, **assumptions)
 

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -545,21 +545,26 @@ def test_special_is_rational():
     assert (r**r).is_rational is None
     assert (r**x).is_rational is None
 
+@XFAIL
+def test_issue_3176():
+    x = Symbol('x')
+    # both zero or both Muls...but neither "change would be very appreciated.
+    # This is similar to x/x => 1 even though if x = 0, it is really nan.
+    assert type(x*0) == type(0*S.Infinity)
+    if 0*S.Infinity is S.NaN:
+        b = Symbol('b', bounded=None)
+        assert (b*0).is_zero is None
+
 def test_special_assumptions():
     x = Symbol('x')
-    z = Symbol('z', zero=True)
-    z2 = Symbol('z2', zero=True)
+    z2 = z = Symbol('z', zero=True)
+    assert z2 == z == S.Zero
     assert (2*z).is_positive is False
     assert (2*z).is_negative is False
     assert (2*z).is_zero is True
     assert (z2*z).is_positive is False
     assert (z2*z).is_negative is False
     assert (z2*z).is_zero is True
-    # if this doesn't pass, the Mul._eval_is_zero routine
-    # probably needs some attention
-    assert (x*z).is_zero == (0*S.Infinity).is_zero
-    b = Symbol('b', bounded=None)
-    assert (b*z).is_zero is None
 
     e = -3 - sqrt(5) + (-sqrt(10)/2 - sqrt(2)/2)**2
     assert (e < 0) is False

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -79,6 +79,22 @@ def test_expand_frac():
     assert expand_numer(eq, multinomial=False) == eq
 
 def test_issue_3022():
-    assert (-I*exp(-3*I*pi/4)/(4*pi**(S(3)/2)*sqrt(x))).expand(complex=True
-    ) == -sqrt(2)/(8*pi**(S(3)/2)*sqrt(re(x) + I*im(x))) + \
-          sqrt(2)*I/(8*pi**(S(3)/2)*sqrt(re(x) + I*im(x)))
+    from sympy import cse
+    ans = S('''([
+        (x0, im(x)),
+        (x1, re(x)),
+        (x2, atan2(x0, x1)/2),
+        (x3, sin(x2)), (x4, cos(x2)),
+        (x5, x0**2 + x1**2),
+        (x6, atan2(0, x5)/4),
+        (x7, cos(x6)),
+        (x8, sin(x6)),
+        (x9, x4*x7),
+        (x10, x4*x8),
+        (x11, x3*x8),
+        (x12, x3*x7)],
+        [sqrt(2)*(x10 + I*x10 + x11 - I*x11 + x12 + I*x12 - x9 + I*x9)/
+        (8*pi**(3/2)*x5**(1/4))])''')
+    eq = -I*exp(-3*I*pi/4)/(4*pi**(S(3)/2)*sqrt(x))
+    r, e = cse((eq).expand(complex=True))
+    assert abs((eq - e[0].subs(reversed(r))).subs(x, 1 + 3*I)) < 1e-9

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -1,5 +1,6 @@
-from sympy import symbols, Symbol, sqrt, oo, re, nan, im, sign, I, E, log, \
-        pi, arg, conjugate, expand, exp, sin, cos, Function, Abs, zoo
+from sympy import (symbols, Symbol, sqrt, oo, re, nan, im, sign, I, E, log,
+        pi, arg, conjugate, expand, exp, sin, cos, Function, Abs, zoo, atan2,
+        S)
 from sympy.utilities.pytest import XFAIL
 
 from sympy.utilities.randtest import comp
@@ -120,6 +121,12 @@ def test_as_real_imag():
     # should not run if there is no imaginary part, hence
     # this should not hang
     assert n.as_real_imag() == (n, 0)
+
+    # issue 3162
+    x = Symbol('x')
+    assert sqrt(x).as_real_imag() == \
+    ((re(x)**2 + im(x)**2)**(S(1)/4)*cos(atan2(im(x), re(x))/2), \
+     (re(x)**2 + im(x)**2)**(S(1)/4)*sin(atan2(im(x), re(x))/2))
 
 @XFAIL
 def test_sign_issue_3068():


### PR DESCRIPTION
3162: Pow.as_real_imag() doesn't return (foo, 0)
3134: no symbol can have zero as assumption; return S.Zero
