### PR TITLE
Clean sets - Union simplification

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -236,7 +236,7 @@ class Set(Basic):
 
     @property
     def is_real(self):
-        return False
+        return None
 
 class ProductSet(Set):
     """
@@ -561,7 +561,8 @@ class Interval(RealSet):
         new_other = other
         if other.is_FiniteSet:
             # Remove any duplicated elements in the FiniteSet
-            new_other = other.__class__(*[x for x in other if x not in self])
+            new_other = other.__class__(*[x for x in other
+                if self.contains(x) is not True])
             # Fill in open end points if they are contained in FiniteSet
             open_left  = self.left_open and self.start not in other
             open_right = self.right_open and self.end not in other
@@ -716,7 +717,7 @@ class Union(Set):
         if evaluate:
             return Union.reduce(args)
 
-        return Basic.__new__(cls, *args)
+        return Basic.__new__(cls, *frozenset(args))
 
     @staticmethod
     def reduce(args):
@@ -848,6 +849,10 @@ class Union(Set):
             return itertools.chain(*(iter(arg) for arg in self.args))
         else:
             raise TypeError("Not all constituent sets are iterable")
+
+    @property
+    def is_real(self):
+        return all(set.is_real for set in self.args)
 
 class Intersection(Set):
     """

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -687,7 +687,7 @@ def set_sort_fn(s):
     except NotImplementedError:
         return 1e9+abs(hash(s))
 
-class Union(Set):
+class Union(Set, EvalfMixin):
     """
     Represents a union of sets as a Set.
 
@@ -1124,7 +1124,7 @@ class UniversalSet(Set):
     def _union(self, other):
         return self
 
-class FiniteSet(Set):
+class FiniteSet(Set, EvalfMixin):
     """
     Represents a finite set of discrete numbers
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -365,12 +365,6 @@ class ProductSet(Set):
             measure *= set.measure
         return measure
 
-class RealSet(Set, EvalfMixin):
-    """
-    A set of real values
-    """
-    is_real = True
-
 class CountableSet(Set):
     """
     Represents a set of countable numbers such as {1, 2, 3, 4} or {1, 2, 3, ...}
@@ -384,7 +378,7 @@ class CountableSet(Set):
     def __iter__(self):
         raise NotImplementedError("Iteration not yet implemented")
 
-class Interval(RealSet):
+class Interval(Set, EvalfMixin):
     """
     Represents a real interval as a Set.
 
@@ -422,6 +416,7 @@ class Interval(RealSet):
     .. [1] http://en.wikipedia.org/wiki/Interval_(mathematics)
     """
     is_Interval = True
+    is_real = True
 
     def __new__(cls, start, end, left_open=False, right_open=False):
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1124,11 +1124,13 @@ class UniversalSet(Set):
     def _union(self, other):
         return self
 
-def sort_fn(x):
-    if x.is_comparable is True:
-        return x
-    else:
-        return 1e9+abs(hash(x))
+def element_sort_fn(x):
+    try:
+        if x.is_comparable is True:
+            return x
+    except:
+        pass
+    return 1e9+abs(hash(x))
 
 class FiniteSet(Set, EvalfMixin):
     """
@@ -1162,7 +1164,7 @@ class FiniteSet(Set, EvalfMixin):
             return EmptySet()
 
         args = frozenset(args) # remove duplicates
-        args = sorted(args, key = sort_fn)
+        args = sorted(args, key = element_sort_fn)
         obj = Basic.__new__(cls, *args)
         obj.elements = args
         return obj

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1124,6 +1124,12 @@ class UniversalSet(Set):
     def _union(self, other):
         return self
 
+def sort_fn(x):
+    if x.is_comparable is True:
+        return x
+    else:
+        return 1e9+abs(hash(x))
+
 class FiniteSet(Set, EvalfMixin):
     """
     Represents a finite set of discrete numbers
@@ -1155,14 +1161,11 @@ class FiniteSet(Set, EvalfMixin):
         if len(args) == 0:
             return EmptySet()
 
-        elements = frozenset(args)
-        obj = Basic.__new__(cls, elements)
-        obj.elements = elements
+        args = frozenset(args) # remove duplicates
+        args = sorted(args, key = sort_fn)
+        obj = Basic.__new__(cls, *args)
+        obj.elements = args
         return obj
-
-    @property
-    def args(self):
-        return tuple(self.elements)
 
     def __iter__(self):
         return self.elements.__iter__()

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -666,6 +666,21 @@ class Interval(Set, EvalfMixin):
         else:
             return And(left, right)
 
+def set_sort_fn(s):
+    """
+    Sort by infimum if possible
+
+    Otherwise sort by hash. Try to put these at the end.
+    """
+    try:
+        val = s.inf
+        if val.is_comparable:
+            return val
+        else:
+            return 1e9+abs(hash(s))
+    except NotImplementedError:
+        return 1e9+abs(hash(s))
+
 class Union(Set):
     """
     Represents a union of sets as a Set.
@@ -715,11 +730,13 @@ class Union(Set):
         if len(args)==0:
             return S.EmptySet
 
+        args = sorted(args, key = set_sort_fn)
+
         # Reduce sets using known rules
         if evaluate:
             return Union.reduce(args)
 
-        return Basic.__new__(cls, *frozenset(args))
+        return Basic.__new__(cls, *args)
 
     @staticmethod
     def reduce(args):
@@ -903,6 +920,8 @@ class Intersection(Set):
         # Intersection of no sets is everything
         if len(args)==0:
             return S.UniversalSet
+
+        args = sorted(args, key = set_sort_fn)
 
         # Reduce sets using known rules
         if evaluate:

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -83,6 +83,11 @@ class Set(Basic):
         return None
 
     def _union(self, other):
+        """
+        This function should only be used internally
+
+        See Set._union for docstring
+        """
         return None
 
     @property
@@ -321,6 +326,11 @@ class ProductSet(Set):
         return And(*[set.contains(item) for set, item in zip(self.sets, element)])
 
     def _intersect(self, other):
+        """
+        This function should only be used internally
+
+        See Set._intersect for docstring
+        """
         if not other.is_ProductSet:
             return None
         if len(other.args) != len(self.args):
@@ -510,6 +520,11 @@ class Interval(Set, EvalfMixin):
         return self._args[3]
 
     def _intersect(self, other):
+        """
+        This function should only be used internally
+
+        See Set._intersect for docstring
+        """
         # We only know how to intersect with other intervals
         if not other.is_Interval:
             return None
@@ -552,8 +567,11 @@ class Interval(Set, EvalfMixin):
         return self.__class__(start, end, left_open, right_open)
 
     def _union(self, other):
-        new_self = self
-        new_other = other
+        """
+        This function should only be used internally
+
+        See Set._union for docstring
+        """
         if other.is_FiniteSet:
             # Remove any duplicated elements in the FiniteSet
             new_other = other.__class__(*[x for x in other
@@ -567,6 +585,7 @@ class Interval(Set, EvalfMixin):
                 return None
             else:
                 return set((new_self, new_other))
+
         if other.is_Interval and self._is_comparable(other):
             from sympy.functions.elementary.miscellaneous import Min, Max
             # Non-overlapping intervals
@@ -1138,33 +1157,20 @@ class FiniteSet(CountableSet):
         return self.elements.__iter__()
 
     def _intersect(self, other):
+        """
+        This function should only be used internally
+
+        See Set._intersect for docstring
+        """
         if isinstance(other, self.__class__):
             return self.__class__(*(self.elements & other.elements))
         return self.__class__(el for el in self if el in other)
 
     def _union(self, other):
         """
-        Returns the union of 'self' and 'other'.
+        This function should only be used internally
 
-        As a shortcut it is possible to use the '+' operator:
-
-        >>> from sympy import FiniteSet, Interval, Symbol
-
-        >>> FiniteSet(0, 1).union(FiniteSet(2, 3))
-        {0, 1, 2, 3}
-        >>> FiniteSet(Symbol('x'), 1, 2) + FiniteSet(2, 3)
-        {1, 2, 3, x}
-        >>> Interval(1, 2, True, True) + FiniteSet(2, 3)
-        (1, 2] U {3}
-
-        Similarly it is possible to use the '-' operator for set
-        differences:
-
-        >>> FiniteSet(Symbol('x'), 1, 2) - FiniteSet(2, 3)
-        {1, x}
-        >>> Interval(1, 2) - FiniteSet(2, 3)
-        [1, 2)
-
+        See Set._union for docstring
         """
         if other.is_FiniteSet:
             return FiniteSet(*(self.elements | other.elements))

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -727,7 +727,7 @@ class Union(Set):
         Simplify a Union using known rules
 
         We first start with global rules like
-        'if any empty sets return empty set' and 'distribute any unions'
+        'if any UniversalSets return UniversalSet'
 
         Then we iterate through all pairs and ask the constituent sets if they
         can simplify themselves with any other constituent

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1201,7 +1201,7 @@ class FiniteSet(Set):
         for a, b in zip(sorted_elements[:-1], sorted_elements[1:]):
             intervals.append(Interval(a, b, True, True)) # open intervals
         intervals.append(Interval(sorted_elements[-1], S.Infinity, True, True))
-        return Union(*intervals, evaluate=False)
+        return Union(intervals, evaluate=False)
 
     @property
     def _inf(self):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -376,19 +376,6 @@ class ProductSet(Set):
             measure *= set.measure
         return measure
 
-class CountableSet(Set):
-    """
-    Represents a set of countable numbers such as {1, 2, 3, 4} or {1, 2, 3, ...}
-    """
-    is_iterable = True
-
-    @property
-    def _measure(self):
-        return 0
-
-    def __iter__(self):
-        raise NotImplementedError("Iteration not yet implemented")
-
 class Interval(Set, EvalfMixin):
     """
     Represents a real interval as a Set.
@@ -1112,7 +1099,7 @@ class UniversalSet(Set):
     def _union(self, other):
         return self
 
-class FiniteSet(CountableSet):
+class FiniteSet(Set):
     """
     Represents a finite set of discrete numbers
 
@@ -1132,6 +1119,7 @@ class FiniteSet(CountableSet):
     .. [1] http://en.wikipedia.org/wiki/Finite_set
     """
     is_FiniteSet = True
+    is_iterable = True
 
     def __new__(cls, *args):
         if len(args)==1 and iterable(args[0]):
@@ -1224,6 +1212,10 @@ class FiniteSet(CountableSet):
     def _sup(self):
         from sympy.functions.elementary.miscellaneous import Max
         return Max(*self)
+
+    @property
+    def measure(self):
+        return 0
 
     def __len__(self):
         return len(self.elements)

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -295,7 +295,7 @@ class ProductSet(Set):
                     return sum(map(flatten, arg.args), [])
                 else:
                     return [arg]
-            elif is_flattenable(arg):
+            elif iterable(arg):
                 return sum(map(flatten, arg), [])
             raise TypeError("Input must be Sets or iterables of Sets")
         sets = flatten(list(sets))
@@ -719,7 +719,7 @@ class Union(Set):
                     return sum(map(flatten, arg.args), [])
                 else:
                     return [arg]
-            if is_flattenable(arg): # and not isinstance(arg, Set) (implicit)
+            if iterable(arg): # and not isinstance(arg, Set) (implicit)
                 return sum(map(flatten, arg), [])
             raise TypeError("Input must be Sets or iterables of Sets")
         args = flatten(args)
@@ -908,7 +908,7 @@ class Intersection(Set):
                     return sum(map(flatten, arg.args), [])
                 else:
                     return [arg]
-            if is_flattenable(arg): # and not isinstance(arg, Set) (implicit)
+            if iterable(arg): # and not isinstance(arg, Set) (implicit)
                 return sum(map(flatten, arg), [])
             raise TypeError("Input must be Sets or iterables of Sets")
         args = flatten(args)
@@ -1245,10 +1245,3 @@ class FiniteSet(CountableSet):
 
     def _eval_evalf(self, prec):
         return FiniteSet(elem.evalf(prec) for elem in self)
-
-genclass = (1 for i in xrange(2)).__class__
-def is_flattenable(obj):
-    """
-    Checks that an argument to a Set constructor should be flattened
-    """
-    return obj.__class__ in [list, set, genclass]

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -87,7 +87,13 @@ class Set(Basic):
         """
         This function should only be used internally
 
-        See Set._union for docstring
+        self._union(other) returns a new, joined set if self knows how
+        to join itself with other, otherwise it returns None.
+        It may also return a python set of SymPy Sets if they are somehow
+        simpler. If it does this it must be idempotent i.e. the sets returned
+        must return None with _union'ed with each other
+
+        Used within the Union class
         """
         return None
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1166,11 +1166,11 @@ class FiniteSet(Set, EvalfMixin):
         args = frozenset(args) # remove duplicates
         args = sorted(args, key = element_sort_fn)
         obj = Basic.__new__(cls, *args)
-        obj.elements = args
+        obj._elements = args
         return obj
 
     def __iter__(self):
-        return self.elements.__iter__()
+        return iter(self.args)
 
     def _intersect(self, other):
         """
@@ -1179,7 +1179,7 @@ class FiniteSet(Set, EvalfMixin):
         See Set._intersect for docstring
         """
         if isinstance(other, self.__class__):
-            return self.__class__(*(self.elements & other.elements))
+            return self.__class__(*(self._elements & other._elements))
         return self.__class__(el for el in self if el in other)
 
     def _union(self, other):
@@ -1189,7 +1189,7 @@ class FiniteSet(Set, EvalfMixin):
         See Set._union for docstring
         """
         if other.is_FiniteSet:
-            return FiniteSet(*(self.elements | other.elements))
+            return FiniteSet(*(self._elements | other._elements))
 
         # If other set contains one of my elements, remove it from myself
         if any(other.contains(x) is True for x in self):
@@ -1214,7 +1214,7 @@ class FiniteSet(Set, EvalfMixin):
         False
 
         """
-        return other in self.elements
+        return other in self._elements
 
     @property
     def _complement(self):
@@ -1228,16 +1228,16 @@ class FiniteSet(Set, EvalfMixin):
 
 
         """
-        if not all(elem.is_number for elem in self.elements):
+        if not all(elem.is_number for elem in self):
             raise ValueError("%s: Complement not defined for symbolic inputs"
                     %self)
-        sorted_elements = sorted(list(self.elements))
+        sorted_elements = self.args
 
         intervals = [] # Build up a list of intervals between the elements
-        intervals += [Interval(S.NegativeInfinity,sorted_elements[0],True,True)]
-        for a, b in zip(sorted_elements[:-1], sorted_elements[1:]):
+        intervals += [Interval(S.NegativeInfinity, self.args[0],True,True)]
+        for a, b in zip(self.args[:-1], self.args[1:]):
             intervals.append(Interval(a, b, True, True)) # open intervals
-        intervals.append(Interval(sorted_elements[-1], S.Infinity, True, True))
+        intervals.append(Interval(self.args[-1], S.Infinity, True, True))
         return Union(intervals, evaluate=False)
 
     @property
@@ -1255,7 +1255,7 @@ class FiniteSet(Set, EvalfMixin):
         return 0
 
     def __len__(self):
-        return len(self.elements)
+        return len(self.args)
 
     def __sub__(self, other):
         return FiniteSet(el for el in self if el not in other)

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -4,6 +4,7 @@ from sympy.core.singleton import Singleton, S
 from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
 from sympy.core.containers import Tuple
+from sympy.core.compatibility import iterable
 
 from sympy.mpmath import mpi, mpf
 from sympy.assumptions import ask
@@ -1133,11 +1134,8 @@ class FiniteSet(CountableSet):
     is_FiniteSet = True
 
     def __new__(cls, *args):
-        def flatten(arg):
-            if is_flattenable(arg):
-                return sum(map(flatten, arg), [])
-            return [arg]
-        args = flatten(list(args))
+        if len(args)==1 and iterable(args[0]):
+            args = args[0]
 
         args = map(sympify, args)
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -303,11 +303,6 @@ def test_sympy__core__relational__Unequality():
     from sympy.core.relational import Unequality
     assert _test_args(Unequality(x, 2))
 
-@XFAIL
-def test_sympy__core__sets__CountableSet():
-    from sympy.core.sets import CountableSet
-    assert _test_args(CountableSet(1, 2, 3))
-
 def test_sympy__core__sets__EmptySet():
     from sympy.core.sets import EmptySet
     assert _test_args(EmptySet())

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -329,19 +329,6 @@ def test_sympy__core__sets__ProductSet():
     from sympy.core.sets import ProductSet, Interval
     assert _test_args(ProductSet(Interval(0, 1), Interval(0, 1)))
 
-def test_sympy__core__sets__RealFiniteSet():
-    from sympy.core.sets import RealFiniteSet
-    assert _test_args(RealFiniteSet(1, 2, 3))
-
-@SKIP("does it make sense to test this?")
-def test_sympy__core__sets__RealSet():
-    from sympy.core.sets import RealSet
-    assert _test_args(RealSet())
-
-def test_sympy__core__sets__RealUnion():
-    from sympy.core.sets import RealUnion, Interval
-    assert _test_args(RealUnion(Interval(0, 1), Interval(2, 3)))
-
 @SKIP("does it make sense to test this?")
 def test_sympy__core__sets__Set():
     from sympy.core.sets import Set

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1029,16 +1029,12 @@ class LatexPrinter(Printer):
 
     def _print_FiniteSet(self, s):
         if len(s) > 10:
-            #take ten elements from the set at random
-            q = iter(s)
-            printset = [q.next() for i in xrange(10)]
+            printset = s.args[:3] + ('...',) + s.args[-3:]
         else:
-            printset = s
-        try:
-            printset.sort()
-        except AttributeError:
-            pass
-        return r"\left\{" + r", ".join(self._print(el) for el in printset) + r"\right\}"
+            printset = s.args
+        return (r"\left\{"
+              + r", ".join(self._print(el) for el in printset)
+              + r"\right\}")
     def _print_Interval(self, i):
         if i.start == i.end:
             return r"\left{%s\right}" % self._print(i.start)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1131,18 +1131,10 @@ class PrettyPrinter(Printer):
 
     def _print_FiniteSet(self, s):
         if len(s) > 10:
-            # Take ten elements from the set at random
-            q = iter(s)
-            printset = [q.next() for i in xrange(10)]
-            printset.append('...')
+            printset = s.args[:3] + ('...',) + s.args[-3:]
         else:
-            printset = s
-        try:
-            printset = sorted(printset)
-        except AttributeError:  pass
-
+            printset = s.args
         return self._print_seq(printset, '{', '}', ', ' )
-
 
     def _print_Interval(self, i):
         if i.start == i.end:

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -126,14 +126,9 @@ class StrPrinter(Printer):
 
     def _print_FiniteSet(self, s):
         if len(s) > 10:
-            #take ten elements from the set at random
-            q = iter(s)
-            printset = [q.next() for i in xrange(10)]
+            printset = s.args[:3] + ('...',) + s.args[-3:]
         else:
-            printset = s
-        try:
-            printset = sorted(printset)
-        except AttributeError:  pass
+            printset = s.args
         return '{' + ', '.join(self._print(el) for el in printset) + '}'
 
     def _print_Function(self, expr):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2,12 +2,13 @@ from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
     Function, factorial, factorial2, floor, ceiling, Abs, re, im, conjugate,
     Order, Piecewise, Matrix, asin, Interval, EmptySet, Union, S, Sum, Product,
     Limit, oo, Poly, Float, lowergamma, uppergamma, hyper, meijerg, polar_lift,
-    Lambda, Poly, RootOf, RootSum, sqrt, Dict, catalan, Min, Max,
-    cot, coth, re, im, root, arg, zeta, dirichlet_eta, binomial, RisingFactorial,
-    FallingFactorial, polylog, lerchphi, Ei, expint, Si, Ci, Shi, Chi, gamma, Tuple,
-    MellinTransform, InverseMellinTransform, LaplaceTransform, InverseLaplaceTransform,
-    FourierTransform, InverseFourierTransform, SineTransform, InverseSineTransform,
-    CosineTransform, InverseCosineTransform)
+    Lambda, Poly, RootOf, RootSum, sqrt, Dict, catalan, Min, Max, cot, coth,
+    re, im, root, arg, zeta, dirichlet_eta, binomial, RisingFactorial,
+    FallingFactorial, polylog, lerchphi, Ei, expint, Si, Ci, Shi, Chi, gamma,
+    Tuple, MellinTransform, InverseMellinTransform, LaplaceTransform,
+    InverseLaplaceTransform, FourierTransform, InverseFourierTransform,
+    SineTransform, InverseSineTransform, CosineTransform,
+    InverseCosineTransform, FiniteSet)
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
@@ -237,6 +238,11 @@ def test_latex_integrals():
         r"\int\int\int\int\int\int x\, dx\, dx\, dx\, dx\, dx\, dx"
     assert latex(Integral(x, x, y, (z, 0, 1))) == \
         r"\int_{0}^{1}\int\int x\, dx\, dy\, dz"
+
+def test_latex_finiteset():
+    assert latex(FiniteSet(range(1, 51)) ==\
+            r'\left{1, 2, 3, ..., 48, 49, 50\right}')
+    assert latex(FiniteSet(range(1, 6)) == r'\left{1, 2, 3, 4, 5\right}')
 
 def test_latex_intervals():
     a = Symbol('a', real=True)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -253,7 +253,7 @@ def test_latex_union():
     assert latex(Union(Interval(0, 1), Interval(2, 3))) == \
         r"\left[0, 1\right] \cup \left[2, 3\right]"
     assert latex(Union(Interval(1, 1), Interval(2, 2), Interval(3, 4))) == \
-        r"\left[3, 4\right] \cup \left\{1, 2\right\}"
+        r"\left\{1, 2\right\} \cup \left[3, 4\right]"
 
 def test_latex_sum():
     assert latex(Sum(x*y**2, (x, -2, 2), (y, -5, 5))) == \

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,7 +4,7 @@ from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     factorial, factorial2, Function, GoldenRatio, I, Integer, Integral,
     Interval, Lambda, Limit, log, Matrix, nan, O, oo, pi, Rational, Float, Rel,
     S, sin, SparseMatrix, sqrt, summation, Sum, Symbol, symbols, Wild,
-    WildFunction, zeta, zoo, Dummy, Dict, Tuple)
+    WildFunction, zeta, zoo, Dummy, Dict, Tuple, FiniteSet)
 from sympy.core import Expr
 from sympy.physics.units import second, joule
 from sympy.polys import Poly, RootOf, RootSum, groebner
@@ -460,3 +460,7 @@ def test_RandomDomain():
     A = Exponential(1, symbol=Symbol('a'))
     B = Exponential(1, symbol=Symbol('b'))
     assert str(pspace(Tuple(A,B)).domain) =="Domain: And(0 <= a, 0 <= b)"
+
+def test_FiniteSet():
+    assert str(FiniteSet(range(1, 51))) == '{1, 2, 3, ..., 48, 49, 50}'
+    assert str(FiniteSet(range(1, 6))) == '{1, 2, 3, 4, 5}'


### PR DESCRIPTION
I went back over sets.py and simplified a number of things. 

Notably Unions now work like Intersections. 
Joining rules are distributed rather than collected in a mess in the union class. 
This is simpler than before and easier to extend. 

I also removed a lot of the empty interfaces like RealSet and CountableSet

The Real sets are gone (RealUnion, RealFiniteSet). 
