### PR TITLE
Fix latex printing of MatAdd and MatMul (issue 3183).

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -932,10 +932,10 @@ class LatexPrinter(Printer):
             if coeff < 0:
                 tex.append("-")
                 coeff = -coeff
-            else:
+            elif tex:
                 tex.append("+")
 
-            if coeff != 1:
+            if coeff is not S.One:
                 tex.append(self._print(coeff))
             tex.append(self._print(M))
 
@@ -944,11 +944,7 @@ class LatexPrinter(Printer):
     def _print_MatMul(self, expr):
         coeff, tail = expr.as_coeff_Mul()
 
-        if not coeff.is_negative:
-            tex = ""
-        else:
-            coeff = -coeff
-            tex = "- "
+        tex = " " + self._print(coeff)
 
         if not tail.is_Mul:
             return tex + self._print(tail)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -920,40 +920,10 @@ class LatexPrinter(Printer):
             return "%s^T"%self._print(mat)
 
     def _print_MatAdd(self, expr):
-        tex = []
-        for term in Add.make_args(expr):
-            coeff, tail = term.as_coeff_Mul()
-
-            if coeff.is_negative:
-                tex.append("-")
-                coeff = -coeff
-            elif tex:
-                tex.append("+")
-
-            if coeff is not S.One:
-                tex.append(self._print(coeff))
-            tex.append(self._print(tail))
-
-        return " ".join(tex)
+        return self._print_Add(expr)
 
     def _print_MatMul(self, expr):
-        coeff, tail = expr.as_coeff_Mul()
-
-        tex = []
-        if coeff.is_negative:
-            tex.append("-")
-            coeff = -coeff
-        tex.append(self._print(coeff))
-
-        for term in C.Mul.make_args(tail):
-            pretty = str(self._print(term))
-
-            if term.is_Add:
-                pretty = (r"\left(%s\right)" % pretty)
-
-            tex.append(pretty)
-
-        return ' '.join(tex)
+        return self._print_Mul(expr)
 
     def _print_MatPow(self, expr):
         base, exp = expr.base, expr.exp

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -459,6 +459,8 @@ def test_matAdd():
     l = LatexPrinter()
     assert l._print_MatAdd(C - 2*B) in ['- 2 B + C', 'C - 2 B']
     assert l._print_MatAdd(C + 2*B) in ['2 B + C', 'C + 2 B']
+    assert l._print_MatAdd(B - 2*C) in ['B - 2 C', '- 2 C + B']
+    assert l._print_MatAdd(B + 2*C) in ['B + 2 C', '2 C + B']
 
 def test_latex_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, Where

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -472,6 +472,10 @@ def test_matMul():
     assert l._print_MatMul(2*A) == '2 A'
     assert l._print_MatMul(2*x*A) == '2 x A'
     assert l._print_MatMul(-2*A) == '- 2 A'
+    assert l._print_MatMul(1.0*A) == '1.0 A'
+    assert l._print_MatMul(sqrt(2)*A) == r'\sqrt{2} A'
+    assert l._print_MatMul(-sqrt(2)*A) == r'- \sqrt{2} A'
+    assert l._print_MatMul(2*sqrt(2)*x*A) == r'2 \sqrt{2} x A'
     assert l._print_MatMul(-2*A*(A+2*B)) in [r'- 2 A \left(A + 2 B\right)',
         r'- 2 A \left(2 B + A\right)']
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -457,8 +457,8 @@ def test_matAdd():
     C = MatrixSymbol('C', 5, 5)
     B = MatrixSymbol('B', 5, 5)
     l = LatexPrinter()
-    assert l._print_MatAdd(C - 2*B) in ['- 2 B + C', '+ C - 2 B']
-    assert l._print_MatAdd(C + 2*B) in ['+ 2 B + C', '+ C + 2 B']
+    assert l._print_MatAdd(C - 2*B) in ['- 2 B + C', 'C - 2 B']
+    assert l._print_MatAdd(C + 2*B) in ['2 B + C', 'C + 2 B']
 
 def test_latex_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, Where

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -462,6 +462,19 @@ def test_matAdd():
     assert l._print_MatAdd(B - 2*C) in ['B - 2 C', '- 2 C + B']
     assert l._print_MatAdd(B + 2*C) in ['B + 2 C', '2 C + B']
 
+def test_matMul():
+    from sympy import MatrixSymbol
+    from sympy.printing.latex import LatexPrinter
+    A = MatrixSymbol('A', 5, 5)
+    B = MatrixSymbol('B', 5, 5)
+    x = Symbol('x')
+    l = LatexPrinter()
+    assert l._print_MatMul(2*A) == '2 A'
+    assert l._print_MatMul(2*x*A) == '2 x A'
+    assert l._print_MatMul(-2*A) == '- 2 A'
+    assert l._print_MatMul(-2*A*(A+2*B)) in [r'- 2 A \left(A + 2 B\right)',
+        r'- 2 A \left(2 B + A\right)']
+
 def test_latex_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, Where
     X = Normal(0, 1, symbol=Symbol('x1'))


### PR DESCRIPTION
The latex printing for MatMul misses integer prefactors and for MatAdd includes leading + sign.

This is corrected and now:

> > > from sympy import *
> > > print latex(Integer(3)_ImmutableMatrix([1,2]))
> > >  3\left[\begin{smallmatrix}1\2\end{smallmatrix}\right]
> > > print latex(Integer(3)_ImmutableMatrix([1,2])+ImmutableMatrix([10,20]))
> > > \left[\begin{smallmatrix}10\20\end{smallmatrix}\right] + 3 \left[\begin{smallmatrix}1\2\end{smallmatrix}\right]

http://code.google.com/p/sympy/issues/detail?id=3183
