### PR TITLE
eigenvects uses Rationals; nullspace uses simplify

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -636,9 +636,12 @@ def test_eigen():
     (Rational(5, 8) + sqrt(73)/8, 1,
         [Matrix([[-1/(-sqrt(73)/8 + Rational(-3, 8))], [1]])])]
 
-    M = Matrix(S([ [1, .6, .6], [.6, 1, .9], [.6, .9, 1] ]))
-    assert all(abs(a - b) < 1e-9 for a, b in zip(zip(*M.eigenvects())[0],
-    (0.489531364385073, 0.100000000000000, 2.41046863561493)))
+    m = Matrix([[1, .6, .6], [.6, .9, .9], [.9, .6, .6]])
+    evals = {-sqrt(385)/20 + S(5)/4: 1, sqrt(385)/20 + S(5)/4: 1, S.Zero: 1}
+    assert m.eigenvals() == evals
+    nevals = list(sorted(m.eigenvals(rational=False).keys()))
+    sevals = list(sorted(evals.keys()))
+    assert all(abs(nevals[i] - sevals[i]) < 1e-9 for i in range(len(nevals)))
 
 @XFAIL
 def test_sparse_matrix():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -636,6 +636,10 @@ def test_eigen():
     (Rational(5, 8) + sqrt(73)/8, 1,
         [Matrix([[-1/(-sqrt(73)/8 + Rational(-3, 8))], [1]])])]
 
+    M = Matrix(S([ [1, .6, .6], [.6, 1, .9], [.6, .9, 1] ]))
+    assert all(abs(a - b) < 1e-9 for a, b in zip(zip(*M.eigenvects())[0],
+    (0.489531364385073, 0.100000000000000, 2.41046863561493)))
+
 @XFAIL
 def test_sparse_matrix():
     def eye(n):


### PR DESCRIPTION
Related with:

[Issue 3189](http://code.google.com/p/sympy/issues/detail?id=3189):     Calculate eigenvectors numericly if it impossible calculate symbolical

[Issue 2193](http://code.google.com/p/sympy/issues/detail?id=2193): Matrix.eigenvects() return empty vectors in some cases
