### PR TITLE
WIP: use chop and expand(complex=True) in eigenvects

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -638,7 +638,7 @@ def test_eigen():
 
     m = Matrix([[1, .6, .6], [.6, .9, .9], [.9, .6, .6]])
     evals = {-sqrt(385)/20 + S(5)/4: 1, sqrt(385)/20 + S(5)/4: 1, S.Zero: 1}
-    assert m.eigenvals() == evals
+    assert m.eigenvals() == evals #dict([(r.evalf(), k) for r, k in evals.iteritems()])
     nevals = list(sorted(m.eigenvals(rational=False).keys()))
     sevals = list(sorted(evals.keys()))
     assert all(abs(nevals[i] - sevals[i]) < 1e-9 for i in range(len(nevals)))


### PR DESCRIPTION
Here is an experimental branch for discussion. It looks like it's not simplification as much as expansion that is necessary for computing the eigen vectors. Here are 3 matrices that cause problems in master. 

```
    >>> Matrix([[1,0],[0,I]]).eigenvects()
    -1
    1
    -1
    1
    [(1, 1, [[1]
             [0]]), 
     (I, 1, [[0]
             [1]])]
    >>> Matrix(3,3,[1., 2, 2, 2, 1., 0, 2, 0, 1.1]).eigenvects()
    0
    0
    0
    [(3.85398737702615, 1, [[ 1.37699368851308]
    [0.964961302630497]
    [              1.0]]), (1.04998437988281, 1, [[-0.0250078100585945]
    [    -1.000624999939]
    [                1.0]]), (-1.80397175690896, 1, [[-1.45198587845448]
    [ 1.03566369730851]
    [              1.0]])]
    >>> Matrix([[1,0],[a,I]]).eigenvects()
    -1
    1
    -1
    1
    [(1, 1, [[-(-1 + I)/a]
             [          1]]), 
     (I, 1, [[0]
             [1]])]
```

Expansion with complex=True and the use of chop when it seems fruitful allow simple solutions to be returned. (There are also some printings of -1, 0, 1, 2, 3 that might happen to indicate what combination of simplification steps were necessary: 

```
-1 = rref failed to give a basis
0 eigenvects found without expansion or simplification; 
1 expansion with complex=True gave a result
2 expansion with complex and simplification gave a result
3 simplification without expansion gave a result
```

and in all cases, the shorter of the eigen value and its expanded(complex=True) form is taken.
