### PR TITLE
[printing] Implement pager_print.

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -68,7 +68,7 @@ from parsing import *
 #from physics import units
 from plotting import Plot, textplot
 from printing import pretty, pretty_print, pprint, pprint_use_unicode, \
-    pprint_try_use_unicode, print_gtk, print_tree
+    pprint_try_use_unicode, print_gtk, print_tree, pager_print
 from printing import ccode, fcode, latex, preview
 from printing import python, print_python, srepr, sstr, sstrrepr
 from interactive import init_session, init_printing

--- a/sympy/printing/pretty/__init__.py
+++ b/sympy/printing/pretty/__init__.py
@@ -1,6 +1,7 @@
 """ASCII-ART 2D pretty-printer"""
 
-from pretty import pretty, pretty_print, pprint, pprint_use_unicode, pprint_try_use_unicode
+from pretty import (pretty, pretty_print, pprint, pprint_use_unicode,
+    pprint_try_use_unicode, pager_print)
 
 # if unicode output is available -- let's use it
 pprint_try_use_unicode()

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1438,3 +1438,19 @@ def pretty_print(expr, **settings):
     print pretty(expr, **settings)
 
 pprint = pretty_print
+
+def pager_print(expr, **settings):
+    """Prints expr using the pager, in pretty form.
+
+    This invokes a pager command using pydoc. Lines are not wrapped
+    automatically. This routine is meant to be used with a pager that allows
+    sideways scrolling, like ``less -S``.
+
+    Parameters are the same as for ``pretty_print``. If you wish to wrap lines,
+    pass ``num_columns=None`` to auto-detect the width of the terminal.
+
+    """
+    from pydoc import pager
+    if 'num_columns' not in settings:
+        settings['num_columns'] = 500000 # disable line wrap
+    pager(pretty(expr, **settings))


### PR DESCRIPTION
This is a function which invokes an external pager, as determined by the
pydoc module, to print output. It is meant mainly to display long
expressions in a sideways scrolling pager like "less -S".

Try:

```
>>> e = Add(*[x**n for n in range(100)])
>>> pager_print(e)  # use sideways scrolling
>>> pager_print(e, num_columns=None) # use line wrapping
```

Note that `~/.ipython/profile_default/startup` can be used to set `os.environ['PAGER'] = 'less -S'`.

[This example is not terribly useful, but I plan to write code for chain complexes where sideways scrolling is going to be fairly crucial.]
