### PR TITLE
Issue 3129: stats symbols

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -464,27 +464,27 @@ def test_sympy__stats__rv__ProductDomain():
 
 def test_sympy__stats__frv_types__DiscreteUniformPSpace():
     from sympy.stats.frv_types import DiscreteUniformPSpace
-    assert _test_args(DiscreteUniformPSpace(range(6)))
+    assert _test_args(DiscreteUniformPSpace('X', range(6)))
 
 def test_sympy__stats__frv_types__DiePSpace():
     from sympy.stats.frv_types import DiePSpace
-    assert _test_args(DiePSpace(6))
+    assert _test_args(DiePSpace('X', 6))
 
 def test_sympy__stats__frv_types__BernoulliPSpace():
     from sympy.stats.frv_types import BernoulliPSpace
-    assert _test_args(BernoulliPSpace(S.Half, 0, 1))
+    assert _test_args(BernoulliPSpace('X', S.Half, 0, 1))
 
 def test_sympy__stats__frv_types__CoinPSpace():
     from sympy.stats.frv_types import CoinPSpace
-    assert _test_args(CoinPSpace(S.Half))
+    assert _test_args(CoinPSpace('X', S.Half))
 
 def test_sympy__stats__frv_types__BinomialPSpace():
     from sympy.stats.frv_types import BinomialPSpace
-    assert _test_args(BinomialPSpace(5, S.Half))
+    assert _test_args(BinomialPSpace('X', 5, S.Half, 1, 0))
 
 def test_sympy__stats__frv_types__HypergeometricPSpace():
     from sympy.stats.frv_types import HypergeometricPSpace
-    assert _test_args(HypergeometricPSpace(10, 5, 3))
+    assert _test_args(HypergeometricPSpace('X', 10, 5, 3))
 
 def test_sympy__stats__frv__FiniteDomain():
     from sympy.stats.frv import FiniteDomain
@@ -526,95 +526,95 @@ def test_sympy__stats__frv__ProductFinitePSpace():
 
 def test_sympy__stats__crv_types__ArcsinPSpace():
     from sympy.stats.crv_types import ArcsinPSpace
-    assert _test_args(ArcsinPSpace(0,1))
+    assert _test_args(ArcsinPSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__BeniniPSpace():
     from sympy.stats.crv_types import BeniniPSpace
-    assert _test_args(BeniniPSpace(1,1,1))
+    assert _test_args(BeniniPSpace('X', 1,1,1))
 
 def test_sympy__stats__crv_types__BetaPSpace():
     from sympy.stats.crv_types import BetaPSpace
-    assert _test_args(BetaPSpace(1,1))
+    assert _test_args(BetaPSpace('X', 1,1))
 
 def test_sympy__stats__crv_types__BetaPrimePSpace():
     from sympy.stats.crv_types import BetaPrimePSpace
-    assert _test_args(BetaPrimePSpace(1,1))
+    assert _test_args(BetaPrimePSpace('X', 1,1))
 
 def test_sympy__stats__crv_types__CauchyPSpace():
     from sympy.stats.crv_types import CauchyPSpace
-    assert _test_args(CauchyPSpace(0,1))
+    assert _test_args(CauchyPSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__ChiPSpace():
     from sympy.stats.crv_types import ChiPSpace
-    assert _test_args(ChiPSpace(1))
+    assert _test_args(ChiPSpace('X', 1))
 
 def test_sympy__stats__crv_types__DagumPSpace():
     from sympy.stats.crv_types import DagumPSpace
-    assert _test_args(DagumPSpace(1,1,1))
+    assert _test_args(DagumPSpace('X', 1,1,1))
 
 def test_sympy__stats__crv_types__ExponentialPSpace():
     from sympy.stats.crv_types import ExponentialPSpace
-    assert _test_args(ExponentialPSpace(1))
+    assert _test_args(ExponentialPSpace('X', 1))
 
 def test_sympy__stats__crv_types__GammaPSpace():
     from sympy.stats.crv_types import GammaPSpace
-    assert _test_args(GammaPSpace(1,1))
+    assert _test_args(GammaPSpace('X', 1,1))
 
 def test_sympy__stats__crv_types__LaplacePSpace():
     from sympy.stats.crv_types import LaplacePSpace
-    assert _test_args(LaplacePSpace(0,1))
+    assert _test_args(LaplacePSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__LogisticPSpace():
     from sympy.stats.crv_types import LogisticPSpace
-    assert _test_args(LogisticPSpace(0,1))
+    assert _test_args(LogisticPSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__LogNormalPSpace():
     from sympy.stats.crv_types import LogNormalPSpace
-    assert _test_args(LogNormalPSpace(0,1))
+    assert _test_args(LogNormalPSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__MaxwellPSpace():
     from sympy.stats.crv_types import MaxwellPSpace
-    assert _test_args(MaxwellPSpace(1))
+    assert _test_args(MaxwellPSpace('X', 1))
 
 def test_sympy__stats__crv_types__NakagamiPSpace():
     from sympy.stats.crv_types import NakagamiPSpace
-    assert _test_args(NakagamiPSpace(1,1))
+    assert _test_args(NakagamiPSpace('X', 1,1))
 
 def test_sympy__stats__crv_types__NormalPSpace():
     from sympy.stats.crv_types import NormalPSpace
-    assert _test_args(NormalPSpace(0,1))
+    assert _test_args(NormalPSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__ParetoPSpace():
     from sympy.stats.crv_types import ParetoPSpace
-    assert _test_args(ParetoPSpace(1,1))
+    assert _test_args(ParetoPSpace('X', 1,1))
 
 def test_sympy__stats__crv_types__RayleighPSpace():
     from sympy.stats.crv_types import RayleighPSpace
-    assert _test_args(RayleighPSpace(1))
+    assert _test_args(RayleighPSpace('X', 1))
 
 def test_sympy__stats__crv_types__StudentTPSpace():
     from sympy.stats.crv_types import StudentTPSpace
-    assert _test_args(StudentTPSpace(1))
+    assert _test_args(StudentTPSpace('X', 1))
 
 def test_sympy__stats__crv_types__TriangularPSpace():
     from sympy.stats.crv_types import TriangularPSpace
-    assert _test_args(TriangularPSpace(-1,0,1))
+    assert _test_args(TriangularPSpace('X', -1,0,1))
 
 def test_sympy__stats__crv_types__UniformPSpace():
     from sympy.stats.crv_types import UniformPSpace
-    assert _test_args(UniformPSpace(0,1))
+    assert _test_args(UniformPSpace('X', 0,1))
 
 def test_sympy__stats__crv_types__UniformSumPSpace():
     from sympy.stats.crv_types import UniformSumPSpace
-    assert _test_args(UniformSumPSpace(1))
+    assert _test_args(UniformSumPSpace('X', 1))
 
 def test_sympy__stats__crv_types__WeibullPSpace():
     from sympy.stats.crv_types import WeibullPSpace
-    assert _test_args(WeibullPSpace(1,1))
+    assert _test_args(WeibullPSpace('X', 1,1))
 
 def test_sympy__stats__crv_types__WignerSemicirclePSpace():
     from sympy.stats.crv_types import WignerSemicirclePSpace
-    assert _test_args(WignerSemicirclePSpace(1))
+    assert _test_args(WignerSemicirclePSpace('X', 1))
 
 def test_sympy__core__symbol__Dummy():
     from sympy.core.symbol import Dummy

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3662,14 +3662,14 @@ def test_expint():
 
 def test_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
-    X = Normal(0, 1, symbol=Symbol('x1'))
+    X = Normal('x1', 0, 1)
     assert upretty(where(X>0)) == u"Domain: 0 < x₁"
 
-    D = Die(6, symbol=Symbol('d1'))
+    D = Die('d1', 6)
     assert upretty(where(D>4)) == u'Domain: d₁ = 5 ∨ d₁ = 6'
 
-    A = Exponential(1, symbol=Symbol('a'))
-    B = Exponential(1, symbol=Symbol('b'))
+    A = Exponential('a', 1)
+    B = Exponential('b', 1)
     assert upretty(pspace(Tuple(A,B)).domain) ==u'Domain: 0 ≤ a ∧ 0 ≤ b'
 
 def test_PrettyPoly():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -524,14 +524,14 @@ def test_matMul():
 
 def test_latex_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
-    X = Normal(0, 1, symbol=Symbol('x1'))
+    X = Normal('x1', 0, 1)
     assert latex(where(X>0)) == "Domain: 0 < x_{1}"
 
-    D = Die(6, symbol=Symbol('d1'))
+    D = Die('d1', 6)
     assert latex(where(D>4)) == r"Domain: d_{1} = 5 \vee d_{1} = 6"
 
-    A = Exponential(1, symbol=Symbol('a'))
-    B = Exponential(1, symbol=Symbol('b'))
+    A = Exponential('a', 1)
+    B = Exponential('b', 1)
     assert latex(pspace(Tuple(A,B)).domain) =="Domain: 0 \leq a \wedge 0 \leq b"
 
 def test_PrettyPoly():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -451,14 +451,14 @@ def test_settings():
 
 def test_RandomDomain():
     from sympy.stats import Normal, Die, Exponential, pspace, where
-    X = Normal(0, 1, symbol=Symbol('x1'))
+    X = Normal('x1', 0, 1)
     assert str(where(X>0)) == "Domain: 0 < x1"
 
-    D = Die(6, symbol=Symbol('d1'))
+    D = Die('d1', 6)
     assert str(where(D>4)) == "Domain: Or(d1 == 5, d1 == 6)"
 
-    A = Exponential(1, symbol=Symbol('a'))
-    B = Exponential(1, symbol=Symbol('b'))
+    A = Exponential('a', 1)
+    B = Exponential('b', 1)
     assert str(pspace(Tuple(A,B)).domain) =="Domain: And(0 <= a, 0 <= b)"
 
 def test_FiniteSet():

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -24,8 +24,8 @@ Examples
 
 >>> from sympy.stats import P, E, variance, Die, Normal
 >>> from sympy import Eq, simplify
->>> X, Y = Die(6), Die(6) # Define two six sided dice
->>> Z = Normal(0, 1) # Declare a Normal random variable with mean 0, std 1
+>>> X, Y = Die('X', 6), Die('Y', 6) # Define two six sided dice
+>>> Z = Normal('Z', 0, 1) # Declare a Normal random variable with mean 0, std 1
 >>> P(X>3) # Probability X is greater than 3
 1/2
 >>> E(X+Y) # Expectation of the sum of two dice

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -11,7 +11,7 @@ sympy.stats.frv
 from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain,
         ProductDomain, PSpace, SinglePSpace, random_symbols, ProductPSpace)
 from sympy.functions.special.delta_functions import DiracDelta
-from sympy import (S, Interval, symbols, Dummy, FiniteSet, Mul, Tuple,
+from sympy import (S, Interval, symbols, sympify, Dummy, FiniteSet, Mul, Tuple,
         Integral, And, Or, Piecewise, solve, cacheit, integrate, oo, Lambda)
 from sympy.solvers.inequalities import reduce_poly_inequalities
 from sympy.polys.polyerrors import PolynomialError
@@ -152,7 +152,7 @@ class ContinuousPSpace(PSpace):
     is_Continuous = True
 
     def integrate(self, expr, rvs=None, **kwargs):
-        if rvs == None:
+        if rvs is None:
             rvs = self.values
         else:
             rvs = frozenset(rvs)
@@ -175,6 +175,7 @@ class ContinuousPSpace(PSpace):
         z = Dummy('z', real=True, bounded=True)
         return Lambda(z, self.integrate(DiracDelta(expr - z), **kwargs))
 
+    @cacheit
     def compute_cdf(self, expr, **kwargs):
         if not self.domain.set.is_Interval:
             raise ValueError("CDF not well defined on multivariate expressions")
@@ -242,11 +243,8 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
     This class is commonly implemented by the various ContinuousRV types
     such as Normal, Exponential, Uniform, etc....
     """
-    _count = 0
-    _name = 'x'
     def __new__(cls, symbol, density, set=Interval(-oo, oo)):
-        assert symbol.is_Symbol
-        domain = SingleContinuousDomain(symbol, set)
+        domain = SingleContinuousDomain(sympify(symbol), set)
         obj = ContinuousPSpace.__new__(cls, domain, density)
         obj._cdf = None
         return obj

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -29,7 +29,8 @@ WignerSemicircle
 """
 
 from sympy import (exp, log, sqrt, pi, S, Dummy, Interval, S, sympify, gamma,
-                   Piecewise, And, Eq, binomial, factorial, Sum, floor, Abs, log)
+                   Piecewise, And, Eq, binomial, factorial, Sum, floor, Abs,
+                   Symbol, log)
 from sympy import beta as beta_fn
 from crv import SingleContinuousPSpace
 from sympy.core.decorators import _sympifyit
@@ -92,7 +93,8 @@ def ContinuousRV(symbol, density, set=Interval(-oo,oo)):
     >>> from sympy import Symbol, sqrt, exp, pi
     >>> from sympy.stats import ContinuousRV, P, E
 
-    >>> x = Symbol('x')
+    >>> x = Symbol("x")
+
     >>> pdf = sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)) # Normal distribution
     >>> X = ContinuousRV(x, pdf)
 
@@ -111,14 +113,14 @@ def ContinuousRV(symbol, density, set=Interval(-oo,oo)):
 # Arcsin distribution ----------------------------------------------------------
 
 class ArcsinPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, a, b):
+    def __new__(cls, name, a, b):
         a, b = sympify(a), sympify(b)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 1/(pi*sqrt((x-a)*(b-x)))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(a, b))
         return obj
 
-def Arcsin(symbol, a=0, b=1):
+def Arcsin(name, a=0, b=1):
     r"""
     Create a Continuous Random Variable with an arcsin distribution.
 
@@ -148,9 +150,8 @@ def Arcsin(symbol, a=0, b=1):
 
     >>> a = Symbol("a", real=True)
     >>> b = Symbol("b", real=True)
-    >>> x = Symbol("x")
 
-    >>> X = Arcsin(x, a, b)
+    >>> X = Arcsin("x", a, b)
 
     >>> density(X)
     Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
@@ -161,22 +162,22 @@ def Arcsin(symbol, a=0, b=1):
     [1] http://en.wikipedia.org/wiki/Arcsine_distribution
     """
 
-    return ArcsinPSpace(symbol, a, b).value
+    return ArcsinPSpace(name, a, b).value
 
 #-------------------------------------------------------------------------------
 # Benini distribution ----------------------------------------------------------
 
 class BeniniPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, alpha, beta, sigma):
+    def __new__(cls, name, alpha, beta, sigma):
         alpha, beta, sigma = sympify(alpha), sympify(beta), sympify(sigma)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = (exp(-alpha*log(x/sigma)-beta*log(x/sigma)**2)
                *(alpha/x+2*beta*log(x/sigma)/x))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf,
                                              set = Interval(sigma, oo))
         return obj
 
-def Benini(symbol, alpha, beta, sigma):
+def Benini(name, alpha, beta, sigma):
     r"""
     Create a Continuous Random Variable with a Benini distribution.
 
@@ -208,9 +209,8 @@ def Benini(symbol, alpha, beta, sigma):
     >>> alpha = Symbol("alpha", positive=True)
     >>> beta = Symbol("beta", positive=True)
     >>> sigma = Symbol("sigma", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Benini(x, alpha, beta, sigma)
+    >>> X = Benini("x", alpha, beta, sigma)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -227,19 +227,19 @@ def Benini(symbol, alpha, beta, sigma):
     [1] http://en.wikipedia.org/wiki/Benini_distribution
     """
 
-    return BeniniPSpace(symbol, alpha, beta, sigma).value
+    return BeniniPSpace(name, alpha, beta, sigma).value
 
 #-------------------------------------------------------------------------------
 # Beta distribution ------------------------------------------------------------
 
 class BetaPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, alpha, beta):
+    def __new__(cls, name, alpha, beta):
         alpha, beta = sympify(alpha), sympify(beta)
 
         _value_check(alpha > 0, "Alpha must be positive")
         _value_check(beta > 0, "Beta must be positive")
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = x**(alpha-1) * (1-x)**(beta-1) / beta_fn(alpha, beta)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, 1))
@@ -250,7 +250,7 @@ class BetaPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.betavariate(self.alpha, self.beta)}
 
-def Beta(symbol, alpha, beta):
+def Beta(name, alpha, beta):
     r"""
     Create a Continuous Random Variable with a Beta distribution.
 
@@ -280,9 +280,8 @@ def Beta(symbol, alpha, beta):
 
     >>> alpha = Symbol("alpha", positive=True)
     >>> beta = Symbol("beta", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Beta(x, alpha, beta)
+    >>> X = Beta("x", alpha, beta)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -304,20 +303,20 @@ def Beta(symbol, alpha, beta):
     [2] http://mathworld.wolfram.com/BetaDistribution.html
     """
 
-    return BetaPSpace(symbol, alpha, beta).value
+    return BetaPSpace(name, alpha, beta).value
 
 #-------------------------------------------------------------------------------
 # Beta prime distribution ------------------------------------------------------
 
 class BetaPrimePSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, alpha, beta):
+    def __new__(cls, name, alpha, beta):
         alpha, beta = sympify(alpha), sympify(beta)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = x**(alpha-1)*(1+x)**(-alpha-beta)/beta_fn(alpha, beta)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def BetaPrime(symbol, alpha, beta):
+def BetaPrime(name, alpha, beta):
     r"""
     Create a continuous random variable with a Beta prime distribution.
 
@@ -347,9 +346,8 @@ def BetaPrime(symbol, alpha, beta):
 
     >>> alpha = Symbol("alpha", positive=True)
     >>> beta = Symbol("beta", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = BetaPrime(x, alpha, beta)
+    >>> X = BetaPrime("x", alpha, beta)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -365,20 +363,20 @@ def BetaPrime(symbol, alpha, beta):
     [2] http://mathworld.wolfram.com/BetaPrimeDistribution.html
     """
 
-    return BetaPrimePSpace(symbol, alpha, beta).value
+    return BetaPrimePSpace(name, alpha, beta).value
 
 #-------------------------------------------------------------------------------
 # Cauchy distribution ----------------------------------------------------------
 
 class CauchyPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, x0, gamma):
+    def __new__(cls, name, x0, gamma):
         x0, gamma = sympify(x0), sympify(gamma)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 1/(pi*gamma*(1+((x-x0)/gamma)**2))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Cauchy(symbol, x0, gamma):
+def Cauchy(name, x0, gamma):
     r"""
     Create a continuous random variable with a Cauchy distribution.
 
@@ -407,9 +405,8 @@ def Cauchy(symbol, x0, gamma):
 
     >>> x0 = Symbol("x0")
     >>> gamma = Symbol("gamma", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Cauchy(x, x0, gamma)
+    >>> X = Cauchy("x", x0, gamma)
 
     >>> density(X)
     Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
@@ -421,20 +418,20 @@ def Cauchy(symbol, x0, gamma):
     [2] http://mathworld.wolfram.com/CauchyDistribution.html
     """
 
-    return CauchyPSpace(symbol, x0, gamma).value
+    return CauchyPSpace(name, x0, gamma).value
 
 #-------------------------------------------------------------------------------
 # Chi distribution -------------------------------------------------------------
 
 class ChiPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, k):
+    def __new__(cls, name, k):
         k = sympify(k)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 2**(1-k/2)*x**(k-1)*exp(-x**2/2)/gamma(k/2)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Chi(symbol, k):
+def Chi(name, k):
     r"""
     Create a continuous random variable with a Chi distribution.
 
@@ -462,9 +459,8 @@ def Chi(symbol, k):
     >>> from sympy import Symbol, simplify
 
     >>> k = Symbol("k", integer=True)
-    >>> x = Symbol("x")
 
-    >>> X = Chi(x, k)
+    >>> X = Chi("x", k)
 
     >>> density(X)
     Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)*exp(-_x**2/2)/gamma(k/2))
@@ -476,20 +472,20 @@ def Chi(symbol, k):
     [2] http://mathworld.wolfram.com/ChiDistribution.html
     """
 
-    return ChiPSpace(symbol, k).value
+    return ChiPSpace(name, k).value
 
 #-------------------------------------------------------------------------------
 # Dagum distribution -----------------------------------------------------------
 
 class DagumPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, p, a, b):
+    def __new__(cls, name, p, a, b):
         p, a, b = sympify(p), sympify(a), sympify(b)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = a*p/x*((x/b)**(a*p)/(((x/b)**a+1)**(p+1)))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Dagum(symbol, p, a, b):
+def Dagum(name, p, a, b):
     r"""
     Create a continuous random variable with a Dagum distribution.
 
@@ -522,9 +518,8 @@ def Dagum(symbol, p, a, b):
     >>> p = Symbol("p", positive=True)
     >>> b = Symbol("b", positive=True)
     >>> a = Symbol("a", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Dagum(x, p, a, b)
+    >>> X = Dagum("x", p, a, b)
 
     >>> density(X)
     Lambda(_x, a*p*(_x/b)**(a*p)*((_x/b)**a + 1)**(-p - 1)/_x)
@@ -535,18 +530,18 @@ def Dagum(symbol, p, a, b):
     [1] http://en.wikipedia.org/wiki/Dagum_distribution
     """
 
-    return DagumPSpace(symbol, p, a, b).value
+    return DagumPSpace(name, p, a, b).value
 
 #-------------------------------------------------------------------------------
 # Exponential distribution -----------------------------------------------------
 
 class ExponentialPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, rate):
+    def __new__(cls, name, rate):
         rate = sympify(rate)
 
         _value_check(rate > 0, "Rate must be positive.")
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = rate * exp(-rate*x)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -556,7 +551,7 @@ class ExponentialPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.expovariate(self.rate)}
 
-def Exponential(symbol, rate):
+def Exponential(name, rate):
     r"""
     Create a continuous random variable with an Exponential distribution.
 
@@ -585,9 +580,8 @@ def Exponential(symbol, rate):
     >>> from sympy import Symbol
 
     >>> l = Symbol("lambda", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Exponential(x, l)
+    >>> X = Exponential("x", l)
 
     >>> density(X)
     Lambda(_x, lambda*exp(-_x*lambda))
@@ -622,19 +616,19 @@ def Exponential(symbol, rate):
     [2] http://mathworld.wolfram.com/ExponentialDistribution.html
     """
 
-    return ExponentialPSpace(symbol, rate).value
+    return ExponentialPSpace(name, rate).value
 
 #-------------------------------------------------------------------------------
 # Gamma distribution -----------------------------------------------------------
 
 class GammaPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, k, theta):
+    def __new__(cls, name, k, theta):
         k, theta = sympify(k), sympify(theta)
 
         _value_check(k > 0, "k must be positive")
         _value_check(theta > 0, "Theta must be positive")
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = x**(k-1) * exp(-x/theta) / (gamma(k)*theta**k)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -645,7 +639,7 @@ class GammaPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.gammavariate(self.k, self.theta)}
 
-def Gamma(symbol, k, theta):
+def Gamma(name, k, theta):
     r"""
     Create a continuous random variable with a Gamma distribution.
 
@@ -675,9 +669,8 @@ def Gamma(symbol, k, theta):
 
     >>> k = Symbol("k", positive=True)
     >>> theta = Symbol("theta", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Gamma(x, k, theta)
+    >>> X = Gamma("x", k, theta)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -716,20 +709,20 @@ def Gamma(symbol, k, theta):
     [2] http://mathworld.wolfram.com/GammaDistribution.html
     """
 
-    return GammaPSpace(symbol, k, theta).value
+    return GammaPSpace(name, k, theta).value
 
 #-------------------------------------------------------------------------------
 # Laplace distribution ---------------------------------------------------------
 
 class LaplacePSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, mu, b):
+    def __new__(cls, name, mu, b):
         mu, b = sympify(mu), sympify(b)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 1/(2*b)*exp(-Abs(x-mu)/b)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Laplace(symbol, mu, b):
+def Laplace(name, mu, b):
     r"""
     Create a continuous random variable with a Laplace distribution.
 
@@ -757,9 +750,8 @@ def Laplace(symbol, mu, b):
 
     >>> mu = Symbol("mu")
     >>> b = Symbol("b", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Laplace(x, mu, b)
+    >>> X = Laplace("x", mu, b)
 
     >>> density(X)
     Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
@@ -771,22 +763,22 @@ def Laplace(symbol, mu, b):
     [2] http://mathworld.wolfram.com/LaplaceDistribution.html
     """
 
-    return LaplacePSpace(symbol, mu, b).value
+    return LaplacePSpace(name, mu, b).value
 
 #-------------------------------------------------------------------------------
 # Logistic distribution --------------------------------------------------------
 
 class LogisticPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, mu, s):
+    def __new__(cls, name, mu, s):
         mu, s = sympify(mu), sympify(s)
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = exp(-(x-mu)/s)/(s*(1+exp(-(x-mu)/s))**2)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Logistic(symbol, mu, s):
+def Logistic(name, mu, s):
     r"""
     Create a continuous random variable with a logistic distribution.
 
@@ -814,9 +806,8 @@ def Logistic(symbol, mu, s):
 
     >>> mu = Symbol("mu", real=True)
     >>> s = Symbol("s", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Logistic(x, mu, s)
+    >>> X = Logistic("x", mu, s)
 
     >>> density(X)
     Lambda(_x, exp((-_x + mu)/s)/(s*(exp((-_x + mu)/s) + 1)**2))
@@ -828,16 +819,16 @@ def Logistic(symbol, mu, s):
     [2] http://mathworld.wolfram.com/LogisticDistribution.html
     """
 
-    return LogisticPSpace(symbol, mu, s).value
+    return LogisticPSpace(name, mu, s).value
 
 #-------------------------------------------------------------------------------
 # Log Normal distribution ------------------------------------------------------
 
 class LogNormalPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, mean, std):
+    def __new__(cls, name, mean, std):
         mean, std = sympify(mean), sympify(std)
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = exp(-(log(x)-mean)**2 / (2*std**2)) / (x*sqrt(2*pi)*std)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -848,7 +839,7 @@ class LogNormalPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.lognormvariate(self.mean, self.std)}
 
-def LogNormal(symbol, mean, std):
+def LogNormal(name, mean, std):
     r"""
     Create a continuous random variable with a log-normal distribution.
 
@@ -879,9 +870,8 @@ def LogNormal(symbol, mean, std):
 
     >>> mu = Symbol("mu", real=True)
     >>> sigma = Symbol("sigma", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = LogNormal(x, mu, sigma)
+    >>> X = LogNormal("x", mu, sigma)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -907,22 +897,22 @@ def LogNormal(symbol, mean, std):
     [2] http://mathworld.wolfram.com/LogNormalDistribution.html
     """
 
-    return LogNormalPSpace(symbol, mean, std).value
+    return LogNormalPSpace(name, mean, std).value
 
 #-------------------------------------------------------------------------------
 # Maxwell distribution ---------------------------------------------------------
 
 class MaxwellPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, a):
+    def __new__(cls, name, a):
         a = sympify(a)
 
-        x = sympify(symbol)
+        x = Symbol(name)
 
         pdf = sqrt(2/pi)*x**2*exp(-x**2/(2*a**2))/a**3
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Maxwell(symbol, a):
+def Maxwell(name, a):
     r"""
     Create a continuous random variable with a Maxwell distribution.
 
@@ -950,9 +940,8 @@ def Maxwell(symbol, a):
     >>> from sympy import Symbol, simplify
 
     >>> a = Symbol("a", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Maxwell(x, a)
+    >>> X = Maxwell("x", a)
 
     >>> density(X)
     Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/(sqrt(pi)*a**3))
@@ -970,20 +959,20 @@ def Maxwell(symbol, a):
     [2] http://mathworld.wolfram.com/MaxwellDistribution.html
     """
 
-    return MaxwellPSpace(symbol, a).value
+    return MaxwellPSpace(name, a).value
 
 #-------------------------------------------------------------------------------
 # Nakagami distribution --------------------------------------------------------
 
 class NakagamiPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, mu, omega):
+    def __new__(cls, name, mu, omega):
         mu, omega = sympify(mu), sympify(omega)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 2*mu**mu/(gamma(mu)*omega**mu)*x**(2*mu-1)*exp(-mu/omega*x**2)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Nakagami(symbol, mu, omega):
+def Nakagami(name, mu, omega):
     r"""
     Create a continuous random variable with a Nakagami distribution.
 
@@ -1014,9 +1003,8 @@ def Nakagami(symbol, mu, omega):
 
     >>> mu = Symbol("mu", positive=True)
     >>> omega = Symbol("omega", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Nakagami(x, mu, omega)
+    >>> X = Nakagami("x", mu, omega)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -1044,18 +1032,18 @@ def Nakagami(symbol, mu, omega):
     [1] http://en.wikipedia.org/wiki/Nakagami_distribution
     """
 
-    return NakagamiPSpace(symbol, mu, omega).value
+    return NakagamiPSpace(name, mu, omega).value
 
 #-------------------------------------------------------------------------------
 # Normal distribution ----------------------------------------------------------
 
 class NormalPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, mean, std):
+    def __new__(cls, name, mean, std):
         mean, std = sympify(mean), sympify(std)
 
         _value_check(std > 0, "Standard deviation must be positive")
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = exp(-(x-mean)**2 / (2*std**2)) / (sqrt(2*pi)*std)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
@@ -1067,7 +1055,7 @@ class NormalPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.normalvariate(self.mean, self.std)}
 
-def Normal(symbol, mean, std):
+def Normal(name, mean, std):
     r"""
     Create a continuous random variable with a Normal distribution.
 
@@ -1095,9 +1083,8 @@ def Normal(symbol, mean, std):
 
     >>> mu = Symbol("mu")
     >>> sigma = Symbol("sigma", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Normal(x, mu, sigma)
+    >>> X = Normal("x", mu, sigma)
 
     >>> density(X)
     Lambda(_x, sqrt(2)*exp(-(_x - mu)**2/(2*sigma**2))/(2*sqrt(pi)*sigma))
@@ -1117,7 +1104,7 @@ def Normal(symbol, mean, std):
     >>> simplify(skewness(X))
     0
 
-    >>> X = Normal(x, 0, 1) # Mean 0, standard deviation 1
+    >>> X = Normal("x", 0, 1) # Mean 0, standard deviation 1
     >>> density(X)
     Lambda(_x, sqrt(2)*exp(-_x**2/2)/(2*sqrt(pi)))
 
@@ -1134,19 +1121,19 @@ def Normal(symbol, mean, std):
     [2] http://mathworld.wolfram.com/NormalDistributionFunction.html
     """
 
-    return NormalPSpace(symbol, mean, std).value
+    return NormalPSpace(name, mean, std).value
 
 #-------------------------------------------------------------------------------
 # Pareto distribution ----------------------------------------------------------
 
 class ParetoPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, xm, alpha):
+    def __new__(cls, name, xm, alpha):
         xm, alpha = sympify(xm), sympify(alpha)
 
         _value_check(xm > 0, "Xm must be positive")
         _value_check(alpha > 0, "Alpha must be positive")
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = alpha * xm**alpha / x**(alpha+1)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(xm, oo))
@@ -1157,7 +1144,7 @@ class ParetoPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.paretovariate(self.alpha)}
 
-def Pareto(symbol, xm, alpha):
+def Pareto(name, xm, alpha):
     r"""
     Create a continuous random variable with the Pareto distribution.
 
@@ -1187,9 +1174,8 @@ def Pareto(symbol, xm, alpha):
 
     >>> xm = Symbol("xm", positive=True)
     >>> beta = Symbol("beta", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Pareto(x, xm, beta)
+    >>> X = Pareto("x", xm, beta)
 
     >>> density(X)
     Lambda(_x, _x**(-beta - 1)*beta*xm**beta)
@@ -1201,20 +1187,20 @@ def Pareto(symbol, xm, alpha):
     [2] http://mathworld.wolfram.com/ParetoDistribution.html
     """
 
-    return ParetoPSpace(symbol, xm, alpha).value
+    return ParetoPSpace(name, xm, alpha).value
 
 #-------------------------------------------------------------------------------
 # Rayleigh distribution --------------------------------------------------------
 
 class RayleighPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, sigma):
+    def __new__(cls, name, sigma):
         sigma = sympify(sigma)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = x/sigma**2*exp(-x**2/(2*sigma**2))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Rayleigh(symbol, sigma):
+def Rayleigh(name, sigma):
     r"""
     Create a continuous random variable with a Rayleigh distribution.
 
@@ -1242,9 +1228,8 @@ def Rayleigh(symbol, sigma):
     >>> from sympy import Symbol, simplify
 
     >>> sigma = Symbol("sigma", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Rayleigh(x, sigma)
+    >>> X = Rayleigh("x", sigma)
 
     >>> density(X)
     Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
@@ -1262,20 +1247,20 @@ def Rayleigh(symbol, sigma):
     [2] http://mathworld.wolfram.com/RayleighDistribution.html
     """
 
-    return RayleighPSpace(symbol, sigma).value
+    return RayleighPSpace(name, sigma).value
 
 #-------------------------------------------------------------------------------
 # StudentT distribution --------------------------------------------------------
 
 class StudentTPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, nu):
+    def __new__(cls, name, nu):
         nu = sympify(nu)
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 1/(sqrt(nu)*beta_fn(S(1)/2,nu/2))*(1+x**2/nu)**(-(nu+1)/2)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def StudentT(symbol, nu):
+def StudentT(name, nu):
     r"""
     Create a continuous random variable with a student's t distribution.
 
@@ -1303,9 +1288,8 @@ def StudentT(symbol, nu):
     >>> from sympy import Symbol, simplify, pprint
 
     >>> nu = Symbol("nu", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = StudentT(x, nu)
+    >>> X = StudentT("x", nu)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -1328,16 +1312,16 @@ def StudentT(symbol, nu):
     [2] http://mathworld.wolfram.com/Studentst-Distribution.html
     """
 
-    return StudentTPSpace(symbol, nu).value
+    return StudentTPSpace(name, nu).value
 
 #-------------------------------------------------------------------------------
 # Triangular distribution ------------------------------------------------------
 
 class TriangularPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, a, b, c):
+    def __new__(cls, name, a, b, c):
         a, b, c = sympify(a), sympify(b), sympify(c)
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = Piecewise(
                 (2*(x-a)/((b-a)*(c-a)), And(a<=x, x<c)),
                 (2/(b-a), Eq(x,c)),
@@ -1347,7 +1331,7 @@ class TriangularPSpace(SingleContinuousPSpace):
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Triangular(symbol, a, b, c):
+def Triangular(name, a, b, c):
     r"""
     Create a continuous random variable with a triangular distribution.
 
@@ -1383,9 +1367,8 @@ def Triangular(symbol, a, b, c):
     >>> a = Symbol("a")
     >>> b = Symbol("b")
     >>> c = Symbol("c")
-    >>> x = Symbol("x")
 
-    >>> X = Triangular(x, a,b,c)
+    >>> X = Triangular("x", a,b,c)
 
     >>> density(X)
     Lambda(_x, Piecewise(((2*_x - 2*a)/((-a + b)*(-a + c)),
@@ -1401,16 +1384,16 @@ def Triangular(symbol, a, b, c):
     [2] http://mathworld.wolfram.com/TriangularDistribution.html
     """
 
-    return TriangularPSpace(symbol, a, b, c).value
+    return TriangularPSpace(name, a, b, c).value
 
 #-------------------------------------------------------------------------------
 # Uniform distribution ---------------------------------------------------------
 
 class UniformPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, left, right):
+    def __new__(cls, name, left, right):
         left, right = sympify(left), sympify(right)
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = Piecewise(
                 (S.Zero, x<left),
                 (S.Zero, x>right),
@@ -1424,7 +1407,7 @@ class UniformPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.uniform(self.left, self.right)}
 
-def Uniform(symbol, left, right):
+def Uniform(name, left, right):
     r"""
     Create a continuous random variable with a uniform distribution.
 
@@ -1457,9 +1440,8 @@ def Uniform(symbol, left, right):
 
     >>> a = Symbol("a")
     >>> b = Symbol("b")
-    >>> x = Symbol("x")
 
-    >>> X = Uniform(x, a, b)
+    >>> X = Uniform("x", a, b)
 
     >>> density(X)
     Lambda(_x, Piecewise((0, _x < a), (0, _x > b), (1/(-a + b), True)))
@@ -1483,23 +1465,23 @@ def Uniform(symbol, left, right):
     [2] http://mathworld.wolfram.com/UniformDistribution.html
     """
 
-    return UniformPSpace(symbol, left, right).value
+    return UniformPSpace(name, left, right).value
 
 #-------------------------------------------------------------------------------
 # UniformSum distribution ------------------------------------------------------
 
 class UniformSumPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, n):
+    def __new__(cls, name, n):
         n = sympify(n)
 
-        x = sympify(symbol)
+        x = Symbol(name)
         k = Dummy("k")
         pdf =1/factorial(n-1)*Sum((-1)**k*binomial(n,k)*(x-k)**(n-1), (k,0,floor(x)))
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0,n))
         return obj
 
-def UniformSum(symbol, n):
+def UniformSum(name, n):
     r"""
     Create a continuous random variable with an Irwin-Hall distribution.
 
@@ -1529,9 +1511,8 @@ def UniformSum(symbol, n):
     >>> from sympy import Symbol, pprint
 
     >>> n = Symbol("n", integer=True)
-    >>> x = Symbol("x")
 
-    >>> X = UniformSum(x, n)
+    >>> X = UniformSum("x", n)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -1553,19 +1534,19 @@ def UniformSum(symbol, n):
     [2] http://mathworld.wolfram.com/UniformSumDistribution.html
     """
 
-    return UniformSumPSpace(symbol, n).value
+    return UniformSumPSpace(name, n).value
 
 #-------------------------------------------------------------------------------
 # Weibull distribution ---------------------------------------------------------
 
 class WeibullPSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, alpha, beta):
+    def __new__(cls, name, alpha, beta):
         alpha, beta = sympify(alpha), sympify(beta)
 
         _value_check(alpha > 0, "Alpha must be positive")
         _value_check(beta > 0, "Beta must be positive")
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = beta * (x/alpha)**(beta-1) * exp(-(x/alpha)**beta) / alpha
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -1576,7 +1557,7 @@ class WeibullPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.weibullvariate(self.alpha, self.beta)}
 
-def Weibull(symbol, alpha, beta):
+def Weibull(name, alpha, beta):
     r"""
     Create a continuous random variable with a Weibull distribution.
 
@@ -1608,9 +1589,8 @@ def Weibull(symbol, alpha, beta):
 
     >>> l = Symbol("lambda", positive=True)
     >>> k = Symbol("k", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = Weibull(x, l, k)
+    >>> X = Weibull("x", l, k)
 
     >>> density(X)
     Lambda(_x, k*(_x/lambda)**(k - 1)*exp(-(_x/lambda)**k)/lambda)
@@ -1629,22 +1609,22 @@ def Weibull(symbol, alpha, beta):
 
     """
 
-    return WeibullPSpace(symbol, alpha, beta).value
+    return WeibullPSpace(name, alpha, beta).value
 
 #-------------------------------------------------------------------------------
 # Wigner semicircle distribution -----------------------------------------------
 
 class WignerSemicirclePSpace(SingleContinuousPSpace):
-    def __new__(cls, symbol, R):
+    def __new__(cls, name, R):
         R = sympify(R)
 
-        x = sympify(symbol)
+        x = Symbol(name)
         pdf = 2/(pi*R**2)*sqrt(R**2-x**2)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(-R, R))
         return obj
 
-def WignerSemicircle(symbol, R):
+def WignerSemicircle(name, R):
     r"""
     Create a continuous random variable with a Wigner semicircle distribution.
 
@@ -1672,9 +1652,8 @@ def WignerSemicircle(symbol, R):
     >>> from sympy import Symbol, simplify
 
     >>> R = Symbol("R", positive=True)
-    >>> x = Symbol("x")
 
-    >>> X = WignerSemicircle(x, R)
+    >>> X = WignerSemicircle("x", R)
 
     >>> density(X)
     Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
@@ -1689,4 +1668,4 @@ def WignerSemicircle(symbol, R):
     [2] http://mathworld.wolfram.com/WignersSemicircleLaw.html
     """
 
-    return WignerSemicirclePSpace(symbol, R).value
+    return WignerSemicirclePSpace(name, R).value

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -111,14 +111,14 @@ def ContinuousRV(symbol, density, set=Interval(-oo,oo)):
 # Arcsin distribution ----------------------------------------------------------
 
 class ArcsinPSpace(SingleContinuousPSpace):
-    def __new__(cls, a, b, symbol=None):
+    def __new__(cls, symbol, a, b):
         a, b = sympify(a), sympify(b)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 1/(pi*sqrt((x-a)*(b-x)))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(a, b))
         return obj
 
-def Arcsin(a=0, b=1, symbol=None):
+def Arcsin(symbol, a=0, b=1):
     r"""
     Create a Continuous Random Variable with an arcsin distribution.
 
@@ -150,7 +150,7 @@ def Arcsin(a=0, b=1, symbol=None):
     >>> b = Symbol("b", real=True)
     >>> x = Symbol("x")
 
-    >>> X = Arcsin(a, b, symbol=x)
+    >>> X = Arcsin(x, a, b)
 
     >>> density(X)
     Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
@@ -161,22 +161,22 @@ def Arcsin(a=0, b=1, symbol=None):
     [1] http://en.wikipedia.org/wiki/Arcsine_distribution
     """
 
-    return ArcsinPSpace(a, b, symbol).value
+    return ArcsinPSpace(symbol, a, b).value
 
 #-------------------------------------------------------------------------------
 # Benini distribution ----------------------------------------------------------
 
 class BeniniPSpace(SingleContinuousPSpace):
-    def __new__(cls, alpha, beta, sigma, symbol = None):
+    def __new__(cls, symbol, alpha, beta, sigma):
         alpha, beta, sigma = sympify(alpha), sympify(beta), sympify(sigma)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = (exp(-alpha*log(x/sigma)-beta*log(x/sigma)**2)
                *(alpha/x+2*beta*log(x/sigma)/x))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf,
                                              set = Interval(sigma, oo))
         return obj
 
-def Benini(alpha, beta, sigma, symbol=None):
+def Benini(symbol, alpha, beta, sigma):
     r"""
     Create a Continuous Random Variable with a Benini distribution.
 
@@ -210,7 +210,7 @@ def Benini(alpha, beta, sigma, symbol=None):
     >>> sigma = Symbol("sigma", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Benini(alpha, beta, sigma, symbol=x)
+    >>> X = Benini(x, alpha, beta, sigma)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -227,19 +227,19 @@ def Benini(alpha, beta, sigma, symbol=None):
     [1] http://en.wikipedia.org/wiki/Benini_distribution
     """
 
-    return BeniniPSpace(alpha, beta, sigma, symbol).value
+    return BeniniPSpace(symbol, alpha, beta, sigma).value
 
 #-------------------------------------------------------------------------------
 # Beta distribution ------------------------------------------------------------
 
 class BetaPSpace(SingleContinuousPSpace):
-    def __new__(cls, alpha, beta, symbol=None):
+    def __new__(cls, symbol, alpha, beta):
         alpha, beta = sympify(alpha), sympify(beta)
 
         _value_check(alpha > 0, "Alpha must be positive")
         _value_check(beta > 0, "Beta must be positive")
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = x**(alpha-1) * (1-x)**(beta-1) / beta_fn(alpha, beta)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, 1))
@@ -250,7 +250,7 @@ class BetaPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.betavariate(self.alpha, self.beta)}
 
-def Beta(alpha, beta, symbol=None):
+def Beta(symbol, alpha, beta):
     r"""
     Create a Continuous Random Variable with a Beta distribution.
 
@@ -282,7 +282,7 @@ def Beta(alpha, beta, symbol=None):
     >>> beta = Symbol("beta", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Beta(alpha, beta, symbol=x)
+    >>> X = Beta(x, alpha, beta)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -304,20 +304,20 @@ def Beta(alpha, beta, symbol=None):
     [2] http://mathworld.wolfram.com/BetaDistribution.html
     """
 
-    return BetaPSpace(alpha, beta, symbol).value
+    return BetaPSpace(symbol, alpha, beta).value
 
 #-------------------------------------------------------------------------------
 # Beta prime distribution ------------------------------------------------------
 
 class BetaPrimePSpace(SingleContinuousPSpace):
-    def __new__(cls, alpha, beta, symbol=None):
+    def __new__(cls, symbol, alpha, beta):
         alpha, beta = sympify(alpha), sympify(beta)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = x**(alpha-1)*(1+x)**(-alpha-beta)/beta_fn(alpha, beta)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def BetaPrime(alpha, beta, symbol=None):
+def BetaPrime(symbol, alpha, beta):
     r"""
     Create a continuous random variable with a Beta prime distribution.
 
@@ -349,7 +349,7 @@ def BetaPrime(alpha, beta, symbol=None):
     >>> beta = Symbol("beta", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = BetaPrime(alpha, beta, symbol=x)
+    >>> X = BetaPrime(x, alpha, beta)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -365,20 +365,20 @@ def BetaPrime(alpha, beta, symbol=None):
     [2] http://mathworld.wolfram.com/BetaPrimeDistribution.html
     """
 
-    return BetaPrimePSpace(alpha, beta, symbol).value
+    return BetaPrimePSpace(symbol, alpha, beta).value
 
 #-------------------------------------------------------------------------------
 # Cauchy distribution ----------------------------------------------------------
 
 class CauchyPSpace(SingleContinuousPSpace):
-    def __new__(cls, x0, gamma, symbol = None):
+    def __new__(cls, symbol, x0, gamma):
         x0, gamma = sympify(x0), sympify(gamma)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 1/(pi*gamma*(1+((x-x0)/gamma)**2))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Cauchy(x0, gamma, symbol=None):
+def Cauchy(symbol, x0, gamma):
     r"""
     Create a continuous random variable with a Cauchy distribution.
 
@@ -409,7 +409,7 @@ def Cauchy(x0, gamma, symbol=None):
     >>> gamma = Symbol("gamma", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Cauchy(x0, gamma, symbol=x)
+    >>> X = Cauchy(x, x0, gamma)
 
     >>> density(X)
     Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
@@ -421,20 +421,20 @@ def Cauchy(x0, gamma, symbol=None):
     [2] http://mathworld.wolfram.com/CauchyDistribution.html
     """
 
-    return CauchyPSpace(x0, gamma, symbol).value
+    return CauchyPSpace(symbol, x0, gamma).value
 
 #-------------------------------------------------------------------------------
 # Chi distribution -------------------------------------------------------------
 
 class ChiPSpace(SingleContinuousPSpace):
-    def __new__(cls, k, symbol = None):
+    def __new__(cls, symbol, k):
         k = sympify(k)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 2**(1-k/2)*x**(k-1)*exp(-x**2/2)/gamma(k/2)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Chi(k, symbol=None):
+def Chi(symbol, k):
     r"""
     Create a continuous random variable with a Chi distribution.
 
@@ -464,7 +464,7 @@ def Chi(k, symbol=None):
     >>> k = Symbol("k", integer=True)
     >>> x = Symbol("x")
 
-    >>> X = Chi(k, symbol=x)
+    >>> X = Chi(x, k)
 
     >>> density(X)
     Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)*exp(-_x**2/2)/gamma(k/2))
@@ -476,20 +476,20 @@ def Chi(k, symbol=None):
     [2] http://mathworld.wolfram.com/ChiDistribution.html
     """
 
-    return ChiPSpace(k, symbol).value
+    return ChiPSpace(symbol, k).value
 
 #-------------------------------------------------------------------------------
 # Dagum distribution -----------------------------------------------------------
 
 class DagumPSpace(SingleContinuousPSpace):
-    def __new__(cls, p, a, b, symbol = None):
+    def __new__(cls, symbol, p, a, b):
         p, a, b = sympify(p), sympify(a), sympify(b)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = a*p/x*((x/b)**(a*p)/(((x/b)**a+1)**(p+1)))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Dagum(p, a, b, symbol=None):
+def Dagum(symbol, p, a, b):
     r"""
     Create a continuous random variable with a Dagum distribution.
 
@@ -524,7 +524,7 @@ def Dagum(p, a, b, symbol=None):
     >>> a = Symbol("a", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Dagum(p, a, b, symbol=x)
+    >>> X = Dagum(x, p, a, b)
 
     >>> density(X)
     Lambda(_x, a*p*(_x/b)**(a*p)*((_x/b)**a + 1)**(-p - 1)/_x)
@@ -535,18 +535,18 @@ def Dagum(p, a, b, symbol=None):
     [1] http://en.wikipedia.org/wiki/Dagum_distribution
     """
 
-    return DagumPSpace(p, a, b, symbol).value
+    return DagumPSpace(symbol, p, a, b).value
 
 #-------------------------------------------------------------------------------
 # Exponential distribution -----------------------------------------------------
 
 class ExponentialPSpace(SingleContinuousPSpace):
-    def __new__(cls, rate, symbol=None):
+    def __new__(cls, symbol, rate):
         rate = sympify(rate)
 
         _value_check(rate > 0, "Rate must be positive.")
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = rate * exp(-rate*x)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -556,7 +556,7 @@ class ExponentialPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.expovariate(self.rate)}
 
-def Exponential(rate, symbol=None):
+def Exponential(symbol, rate):
     r"""
     Create a continuous random variable with an Exponential distribution.
 
@@ -587,7 +587,7 @@ def Exponential(rate, symbol=None):
     >>> l = Symbol("lambda", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Exponential(l, symbol=x)
+    >>> X = Exponential(x, l)
 
     >>> density(X)
     Lambda(_x, lambda*exp(-_x*lambda))
@@ -604,7 +604,7 @@ def Exponential(rate, symbol=None):
     >>> skewness(X)
     2
 
-    >>> X = Exponential(10, symbol=x)
+    >>> X = Exponential('x', 10)
 
     >>> density(X)
     Lambda(_x, 10*exp(-10*_x))
@@ -622,19 +622,19 @@ def Exponential(rate, symbol=None):
     [2] http://mathworld.wolfram.com/ExponentialDistribution.html
     """
 
-    return ExponentialPSpace(rate, symbol).value
+    return ExponentialPSpace(symbol, rate).value
 
 #-------------------------------------------------------------------------------
 # Gamma distribution -----------------------------------------------------------
 
 class GammaPSpace(SingleContinuousPSpace):
-    def __new__(cls, k, theta, symbol=None):
+    def __new__(cls, symbol, k, theta):
         k, theta = sympify(k), sympify(theta)
 
         _value_check(k > 0, "k must be positive")
         _value_check(theta > 0, "Theta must be positive")
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = x**(k-1) * exp(-x/theta) / (gamma(k)*theta**k)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -645,7 +645,7 @@ class GammaPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.gammavariate(self.k, self.theta)}
 
-def Gamma(k, theta, symbol=None):
+def Gamma(symbol, k, theta):
     r"""
     Create a continuous random variable with a Gamma distribution.
 
@@ -677,7 +677,7 @@ def Gamma(k, theta, symbol=None):
     >>> theta = Symbol("theta", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Gamma(k, theta, symbol=x)
+    >>> X = Gamma(x, k, theta)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -716,20 +716,20 @@ def Gamma(k, theta, symbol=None):
     [2] http://mathworld.wolfram.com/GammaDistribution.html
     """
 
-    return GammaPSpace(k, theta, symbol).value
+    return GammaPSpace(symbol, k, theta).value
 
 #-------------------------------------------------------------------------------
 # Laplace distribution ---------------------------------------------------------
 
 class LaplacePSpace(SingleContinuousPSpace):
-    def __new__(cls, mu, b, symbol=None):
+    def __new__(cls, symbol, mu, b):
         mu, b = sympify(mu), sympify(b)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 1/(2*b)*exp(-Abs(x-mu)/b)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Laplace(mu, b, symbol=None):
+def Laplace(symbol, mu, b):
     r"""
     Create a continuous random variable with a Laplace distribution.
 
@@ -759,7 +759,7 @@ def Laplace(mu, b, symbol=None):
     >>> b = Symbol("b", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Laplace(mu, b, symbol=x)
+    >>> X = Laplace(x, mu, b)
 
     >>> density(X)
     Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
@@ -771,22 +771,22 @@ def Laplace(mu, b, symbol=None):
     [2] http://mathworld.wolfram.com/LaplaceDistribution.html
     """
 
-    return LaplacePSpace(mu, b, symbol).value
+    return LaplacePSpace(symbol, mu, b).value
 
 #-------------------------------------------------------------------------------
 # Logistic distribution --------------------------------------------------------
 
 class LogisticPSpace(SingleContinuousPSpace):
-    def __new__(cls, mu, s, symbol=None):
+    def __new__(cls, symbol, mu, s):
         mu, s = sympify(mu), sympify(s)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = exp(-(x-mu)/s)/(s*(1+exp(-(x-mu)/s))**2)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Logistic(mu, s, symbol=None):
+def Logistic(symbol, mu, s):
     r"""
     Create a continuous random variable with a logistic distribution.
 
@@ -816,7 +816,7 @@ def Logistic(mu, s, symbol=None):
     >>> s = Symbol("s", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Logistic(mu, s, symbol=x)
+    >>> X = Logistic(x, mu, s)
 
     >>> density(X)
     Lambda(_x, exp((-_x + mu)/s)/(s*(exp((-_x + mu)/s) + 1)**2))
@@ -828,16 +828,16 @@ def Logistic(mu, s, symbol=None):
     [2] http://mathworld.wolfram.com/LogisticDistribution.html
     """
 
-    return LogisticPSpace(mu, s, symbol).value
+    return LogisticPSpace(symbol, mu, s).value
 
 #-------------------------------------------------------------------------------
 # Log Normal distribution ------------------------------------------------------
 
 class LogNormalPSpace(SingleContinuousPSpace):
-    def __new__(cls, mean, std, symbol=None):
+    def __new__(cls, symbol, mean, std):
         mean, std = sympify(mean), sympify(std)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = exp(-(log(x)-mean)**2 / (2*std**2)) / (x*sqrt(2*pi)*std)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -848,7 +848,7 @@ class LogNormalPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.lognormvariate(self.mean, self.std)}
 
-def LogNormal(mean, std, symbol=None):
+def LogNormal(symbol, mean, std):
     r"""
     Create a continuous random variable with a log-normal distribution.
 
@@ -881,7 +881,7 @@ def LogNormal(mean, std, symbol=None):
     >>> sigma = Symbol("sigma", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = LogNormal(mu, sigma, symbol=x)
+    >>> X = LogNormal(x, mu, sigma)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -895,7 +895,7 @@ def LogNormal(mean, std, symbol=None):
           |             ____         |
           \       2*x*\/ pi *sigma   /
 
-    >>> X = LogNormal(0, 1, symbol=Symbol('x')) # Mean 0, standard deviation 1
+    >>> X = LogNormal('x', 0, 1) # Mean 0, standard deviation 1
 
     >>> density(X)
     Lambda(_x, sqrt(2)*exp(-log(_x)**2/2)/(2*_x*sqrt(pi)))
@@ -907,22 +907,22 @@ def LogNormal(mean, std, symbol=None):
     [2] http://mathworld.wolfram.com/LogNormalDistribution.html
     """
 
-    return LogNormalPSpace(mean, std, symbol).value
+    return LogNormalPSpace(symbol, mean, std).value
 
 #-------------------------------------------------------------------------------
 # Maxwell distribution ---------------------------------------------------------
 
 class MaxwellPSpace(SingleContinuousPSpace):
-    def __new__(cls, a, symbol = None):
+    def __new__(cls, symbol, a):
         a = sympify(a)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
 
         pdf = sqrt(2/pi)*x**2*exp(-x**2/(2*a**2))/a**3
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Maxwell(a, symbol=None):
+def Maxwell(symbol, a):
     r"""
     Create a continuous random variable with a Maxwell distribution.
 
@@ -952,7 +952,7 @@ def Maxwell(a, symbol=None):
     >>> a = Symbol("a", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Maxwell(a, symbol=x)
+    >>> X = Maxwell(x, a)
 
     >>> density(X)
     Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/(sqrt(pi)*a**3))
@@ -970,20 +970,20 @@ def Maxwell(a, symbol=None):
     [2] http://mathworld.wolfram.com/MaxwellDistribution.html
     """
 
-    return MaxwellPSpace(a, symbol).value
+    return MaxwellPSpace(symbol, a).value
 
 #-------------------------------------------------------------------------------
 # Nakagami distribution --------------------------------------------------------
 
 class NakagamiPSpace(SingleContinuousPSpace):
-    def __new__(cls, mu, omega, symbol = None):
+    def __new__(cls, symbol, mu, omega):
         mu, omega = sympify(mu), sympify(omega)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 2*mu**mu/(gamma(mu)*omega**mu)*x**(2*mu-1)*exp(-mu/omega*x**2)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Nakagami(mu, omega, symbol=None):
+def Nakagami(symbol, mu, omega):
     r"""
     Create a continuous random variable with a Nakagami distribution.
 
@@ -1016,7 +1016,7 @@ def Nakagami(mu, omega, symbol=None):
     >>> omega = Symbol("omega", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Nakagami(mu, omega, symbol=x)
+    >>> X = Nakagami(x, mu, omega)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -1044,18 +1044,18 @@ def Nakagami(mu, omega, symbol=None):
     [1] http://en.wikipedia.org/wiki/Nakagami_distribution
     """
 
-    return NakagamiPSpace(mu, omega, symbol).value
+    return NakagamiPSpace(symbol, mu, omega).value
 
 #-------------------------------------------------------------------------------
 # Normal distribution ----------------------------------------------------------
 
 class NormalPSpace(SingleContinuousPSpace):
-    def __new__(cls, mean, std, symbol=None):
+    def __new__(cls, symbol, mean, std):
         mean, std = sympify(mean), sympify(std)
 
         _value_check(std > 0, "Standard deviation must be positive")
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = exp(-(x-mean)**2 / (2*std**2)) / (sqrt(2*pi)*std)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
@@ -1067,7 +1067,7 @@ class NormalPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.normalvariate(self.mean, self.std)}
 
-def Normal(mean, std, symbol=None):
+def Normal(symbol, mean, std):
     r"""
     Create a continuous random variable with a Normal distribution.
 
@@ -1097,7 +1097,7 @@ def Normal(mean, std, symbol=None):
     >>> sigma = Symbol("sigma", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Normal(mu, sigma, symbol=x)
+    >>> X = Normal(x, mu, sigma)
 
     >>> density(X)
     Lambda(_x, sqrt(2)*exp(-(_x - mu)**2/(2*sigma**2))/(2*sqrt(pi)*sigma))
@@ -1117,7 +1117,7 @@ def Normal(mean, std, symbol=None):
     >>> simplify(skewness(X))
     0
 
-    >>> X = Normal(0, 1, symbol=x) # Mean 0, standard deviation 1
+    >>> X = Normal(x, 0, 1) # Mean 0, standard deviation 1
     >>> density(X)
     Lambda(_x, sqrt(2)*exp(-_x**2/2)/(2*sqrt(pi)))
 
@@ -1134,19 +1134,19 @@ def Normal(mean, std, symbol=None):
     [2] http://mathworld.wolfram.com/NormalDistributionFunction.html
     """
 
-    return NormalPSpace(mean, std, symbol).value
+    return NormalPSpace(symbol, mean, std).value
 
 #-------------------------------------------------------------------------------
 # Pareto distribution ----------------------------------------------------------
 
 class ParetoPSpace(SingleContinuousPSpace):
-    def __new__(cls, xm, alpha, symbol=None):
+    def __new__(cls, symbol, xm, alpha):
         xm, alpha = sympify(xm), sympify(alpha)
 
         _value_check(xm > 0, "Xm must be positive")
         _value_check(alpha > 0, "Alpha must be positive")
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = alpha * xm**alpha / x**(alpha+1)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(xm, oo))
@@ -1157,7 +1157,7 @@ class ParetoPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.paretovariate(self.alpha)}
 
-def Pareto(xm, alpha, symbol=None):
+def Pareto(symbol, xm, alpha):
     r"""
     Create a continuous random variable with the Pareto distribution.
 
@@ -1189,7 +1189,7 @@ def Pareto(xm, alpha, symbol=None):
     >>> beta = Symbol("beta", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Pareto(xm, beta, symbol=x)
+    >>> X = Pareto(x, xm, beta)
 
     >>> density(X)
     Lambda(_x, _x**(-beta - 1)*beta*xm**beta)
@@ -1201,20 +1201,20 @@ def Pareto(xm, alpha, symbol=None):
     [2] http://mathworld.wolfram.com/ParetoDistribution.html
     """
 
-    return ParetoPSpace(xm, alpha, symbol).value
+    return ParetoPSpace(symbol, xm, alpha).value
 
 #-------------------------------------------------------------------------------
 # Rayleigh distribution --------------------------------------------------------
 
 class RayleighPSpace(SingleContinuousPSpace):
-    def __new__(cls, sigma, symbol = None):
+    def __new__(cls, symbol, sigma):
         sigma = sympify(sigma)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = x/sigma**2*exp(-x**2/(2*sigma**2))
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(0, oo))
         return obj
 
-def Rayleigh(sigma, symbol=None):
+def Rayleigh(symbol, sigma):
     r"""
     Create a continuous random variable with a Rayleigh distribution.
 
@@ -1244,7 +1244,7 @@ def Rayleigh(sigma, symbol=None):
     >>> sigma = Symbol("sigma", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Rayleigh(sigma, symbol=x)
+    >>> X = Rayleigh(x, sigma)
 
     >>> density(X)
     Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
@@ -1262,20 +1262,20 @@ def Rayleigh(sigma, symbol=None):
     [2] http://mathworld.wolfram.com/RayleighDistribution.html
     """
 
-    return RayleighPSpace(sigma, symbol).value
+    return RayleighPSpace(symbol, sigma).value
 
 #-------------------------------------------------------------------------------
 # StudentT distribution --------------------------------------------------------
 
 class StudentTPSpace(SingleContinuousPSpace):
-    def __new__(cls, nu, symbol = None):
+    def __new__(cls, symbol, nu):
         nu = sympify(nu)
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 1/(sqrt(nu)*beta_fn(S(1)/2,nu/2))*(1+x**2/nu)**(-(nu+1)/2)
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def StudentT(nu, symbol=None):
+def StudentT(symbol, nu):
     r"""
     Create a continuous random variable with a student's t distribution.
 
@@ -1305,7 +1305,7 @@ def StudentT(nu, symbol=None):
     >>> nu = Symbol("nu", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = StudentT(nu, symbol=x)
+    >>> X = StudentT(x, nu)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -1328,16 +1328,16 @@ def StudentT(nu, symbol=None):
     [2] http://mathworld.wolfram.com/Studentst-Distribution.html
     """
 
-    return StudentTPSpace(nu, symbol).value
+    return StudentTPSpace(symbol, nu).value
 
 #-------------------------------------------------------------------------------
 # Triangular distribution ------------------------------------------------------
 
 class TriangularPSpace(SingleContinuousPSpace):
-    def __new__(cls, a, b, c, symbol=None):
+    def __new__(cls, symbol, a, b, c):
         a, b, c = sympify(a), sympify(b), sympify(c)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = Piecewise(
                 (2*(x-a)/((b-a)*(c-a)), And(a<=x, x<c)),
                 (2/(b-a), Eq(x,c)),
@@ -1347,7 +1347,7 @@ class TriangularPSpace(SingleContinuousPSpace):
         obj = SingleContinuousPSpace.__new__(cls, x, pdf)
         return obj
 
-def Triangular(a, b, c, symbol=None):
+def Triangular(symbol, a, b, c):
     r"""
     Create a continuous random variable with a triangular distribution.
 
@@ -1385,7 +1385,7 @@ def Triangular(a, b, c, symbol=None):
     >>> c = Symbol("c")
     >>> x = Symbol("x")
 
-    >>> X = Triangular(a,b,c, symbol=x)
+    >>> X = Triangular(x, a,b,c)
 
     >>> density(X)
     Lambda(_x, Piecewise(((2*_x - 2*a)/((-a + b)*(-a + c)),
@@ -1401,16 +1401,16 @@ def Triangular(a, b, c, symbol=None):
     [2] http://mathworld.wolfram.com/TriangularDistribution.html
     """
 
-    return TriangularPSpace(a, b, c, symbol).value
+    return TriangularPSpace(symbol, a, b, c).value
 
 #-------------------------------------------------------------------------------
 # Uniform distribution ---------------------------------------------------------
 
 class UniformPSpace(SingleContinuousPSpace):
-    def __new__(cls, left, right, symbol=None):
+    def __new__(cls, symbol, left, right):
         left, right = sympify(left), sympify(right)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = Piecewise(
                 (S.Zero, x<left),
                 (S.Zero, x>right),
@@ -1424,7 +1424,7 @@ class UniformPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.uniform(self.left, self.right)}
 
-def Uniform(left, right, symbol=None):
+def Uniform(symbol, left, right):
     r"""
     Create a continuous random variable with a uniform distribution.
 
@@ -1459,7 +1459,7 @@ def Uniform(left, right, symbol=None):
     >>> b = Symbol("b")
     >>> x = Symbol("x")
 
-    >>> X = Uniform(a, b, symbol=x)
+    >>> X = Uniform(x, a, b)
 
     >>> density(X)
     Lambda(_x, Piecewise((0, _x < a), (0, _x > b), (1/(-a + b), True)))
@@ -1483,23 +1483,23 @@ def Uniform(left, right, symbol=None):
     [2] http://mathworld.wolfram.com/UniformDistribution.html
     """
 
-    return UniformPSpace(left, right, symbol).value
+    return UniformPSpace(symbol, left, right).value
 
 #-------------------------------------------------------------------------------
 # UniformSum distribution ------------------------------------------------------
 
 class UniformSumPSpace(SingleContinuousPSpace):
-    def __new__(cls, n, symbol=None):
+    def __new__(cls, symbol, n):
         n = sympify(n)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         k = Dummy("k")
         pdf =1/factorial(n-1)*Sum((-1)**k*binomial(n,k)*(x-k)**(n-1), (k,0,floor(x)))
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0,n))
         return obj
 
-def UniformSum(n, symbol=None):
+def UniformSum(symbol, n):
     r"""
     Create a continuous random variable with an Irwin-Hall distribution.
 
@@ -1531,7 +1531,7 @@ def UniformSum(n, symbol=None):
     >>> n = Symbol("n", integer=True)
     >>> x = Symbol("x")
 
-    >>> X = UniformSum(n, symbol=x)
+    >>> X = UniformSum(x, n)
 
     >>> D = density(X)
     >>> pprint(D, use_unicode=False)
@@ -1553,19 +1553,19 @@ def UniformSum(n, symbol=None):
     [2] http://mathworld.wolfram.com/UniformSumDistribution.html
     """
 
-    return UniformSumPSpace(n, symbol).value
+    return UniformSumPSpace(symbol, n).value
 
 #-------------------------------------------------------------------------------
 # Weibull distribution ---------------------------------------------------------
 
 class WeibullPSpace(SingleContinuousPSpace):
-    def __new__(cls, alpha, beta, symbol=None):
+    def __new__(cls, symbol, alpha, beta):
         alpha, beta = sympify(alpha), sympify(beta)
 
         _value_check(alpha > 0, "Alpha must be positive")
         _value_check(beta > 0, "Beta must be positive")
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = beta * (x/alpha)**(beta-1) * exp(-(x/alpha)**beta) / alpha
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set=Interval(0, oo))
@@ -1576,7 +1576,7 @@ class WeibullPSpace(SingleContinuousPSpace):
     def sample(self):
         return {self.value: random.weibullvariate(self.alpha, self.beta)}
 
-def Weibull(alpha, beta, symbol=None):
+def Weibull(symbol, alpha, beta):
     r"""
     Create a continuous random variable with a Weibull distribution.
 
@@ -1610,7 +1610,7 @@ def Weibull(alpha, beta, symbol=None):
     >>> k = Symbol("k", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = Weibull(l, k, symbol=x)
+    >>> X = Weibull(x, l, k)
 
     >>> density(X)
     Lambda(_x, k*(_x/lambda)**(k - 1)*exp(-(_x/lambda)**k)/lambda)
@@ -1629,22 +1629,22 @@ def Weibull(alpha, beta, symbol=None):
 
     """
 
-    return WeibullPSpace(alpha, beta, symbol).value
+    return WeibullPSpace(symbol, alpha, beta).value
 
 #-------------------------------------------------------------------------------
 # Wigner semicircle distribution -----------------------------------------------
 
 class WignerSemicirclePSpace(SingleContinuousPSpace):
-    def __new__(cls, R, symbol=None):
+    def __new__(cls, symbol, R):
         R = sympify(R)
 
-        x = symbol or SingleContinuousPSpace.create_symbol()
+        x = sympify(symbol)
         pdf = 2/(pi*R**2)*sqrt(R**2-x**2)
 
         obj = SingleContinuousPSpace.__new__(cls, x, pdf, set = Interval(-R, R))
         return obj
 
-def WignerSemicircle(R, symbol=None):
+def WignerSemicircle(symbol, R):
     r"""
     Create a continuous random variable with a Wigner semicircle distribution.
 
@@ -1674,7 +1674,7 @@ def WignerSemicircle(R, symbol=None):
     >>> R = Symbol("R", positive=True)
     >>> x = Symbol("x")
 
-    >>> X = WignerSemicircle(R, symbol=x)
+    >>> X = WignerSemicircle(x, R)
 
     >>> density(X)
     Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
@@ -1689,4 +1689,4 @@ def WignerSemicircle(R, symbol=None):
     [2] http://mathworld.wolfram.com/WignersSemicircleLaw.html
     """
 
-    return WignerSemicirclePSpace(R, symbol).value
+    return WignerSemicirclePSpace(symbol, R).value

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -11,8 +11,8 @@ sympy.stats.crv
 from sympy import (And, Eq, Basic, S, Expr, Symbol, cacheit, sympify, Mul, Add,
         And, Or, Tuple)
 from sympy.core.sets import FiniteSet
-from rv import (RandomDomain, ProductDomain, ConditionalDomain, PSpace,
-        ProductPSpace, SinglePSpace, random_symbols, sumsets, rv_subs)
+from sympy.stats.rv import (RandomDomain, ProductDomain, ConditionalDomain,
+        PSpace, ProductPSpace, SinglePSpace, random_symbols, sumsets, rv_subs)
 from sympy.core.compatibility import product
 from sympy.core.containers import Dict
 import random
@@ -241,12 +241,9 @@ class SingleFinitePSpace(FinitePSpace, SinglePSpace):
     This class is implemented by many of the standard FiniteRV types such as
     Die, Bernoulli, Coin, etc....
     """
-    _count = 0
-    _name = 'fx'
 
     @classmethod
-    def fromdict(cls, density, symbol=None):
-        symbol = symbol or cls.create_symbol()
+    def fromdict(cls, symbol, density):
         domain = SingleFiniteDomain(symbol, frozenset(density.keys()))
         density = dict((frozenset(((symbol, val),)) , prob)
                 for val, prob in density.items())

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -243,7 +243,8 @@ class SingleFinitePSpace(FinitePSpace, SinglePSpace):
     """
 
     @classmethod
-    def fromdict(cls, symbol, density):
+    def fromdict(cls, name, density):
+        symbol = Symbol(name);
         domain = SingleFiniteDomain(symbol, frozenset(density.keys()))
         density = dict((frozenset(((symbol, val),)) , prob)
                 for val, prob in density.items())

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -18,7 +18,7 @@ from sympy import S, sympify, Rational, binomial
 __all__ = ['FiniteRV', 'DiscreteUniform', 'Die', 'Bernoulli', 'Coin',
         'Binomial', 'Hypergeometric']
 
-def FiniteRV(symbol, density):
+def FiniteRV(name, density):
     """
     Create a Finite Random Variable given a dict representing the density.
 
@@ -34,7 +34,7 @@ def FiniteRV(symbol, density):
     >>> P(X>=2)
     0.700000000000000
     """
-    return SingleFinitePSpace.fromdict(symbol, density).value
+    return SingleFinitePSpace.fromdict(name, density).value
 
 class DiscreteUniformPSpace(SingleFinitePSpace):
     """
@@ -59,12 +59,12 @@ class DiscreteUniformPSpace(SingleFinitePSpace):
     >>> density(Y)
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
     """
-    def __new__(cls, symbol, items):
+    def __new__(cls, name, items):
         density = dict((sympify(item), Rational(1, len(items)))
                        for item in items)
-        return cls.fromdict(symbol, density)
+        return cls.fromdict(name, density)
 
-def DiscreteUniform(symbol, items):
+def DiscreteUniform(name, items):
     """
     Create a Finite Random Variable representing a uniform distribution over
     the input set.
@@ -86,7 +86,7 @@ def DiscreteUniform(symbol, items):
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
 
     """
-    return DiscreteUniformPSpace(symbol, items).value
+    return DiscreteUniformPSpace(name, items).value
 
 class DiePSpace(DiscreteUniformPSpace):
     """
@@ -106,10 +106,10 @@ class DiePSpace(DiscreteUniformPSpace):
     >>> density(D4)
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
     """
-    def __new__(cls, symbol, sides):
-        return DiscreteUniformPSpace.__new__(cls, symbol, range(1, sides+1))
+    def __new__(cls, name, sides):
+        return DiscreteUniformPSpace.__new__(cls, name, range(1, sides+1))
 
-def Die(symbol, sides=6):
+def Die(name, sides=6):
     """
     Create a Finite Random Variable representing a fair die.
 
@@ -126,7 +126,7 @@ def Die(symbol, sides=6):
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
     """
 
-    return DiePSpace(symbol, sides).value
+    return DiePSpace(name, sides).value
 
 class BernoulliPSpace(SingleFinitePSpace):
     """
@@ -150,12 +150,12 @@ class BernoulliPSpace(SingleFinitePSpace):
     {Heads: 1/2, Tails: 1/2}
     """
 
-    def __new__(cls, symbol,  p, succ, fail):
+    def __new__(cls, name,  p, succ, fail):
         succ, fail, p = map(sympify, (succ, fail, p))
         density = {succ: p, fail: (1-p)}
-        return cls.fromdict(symbol, density)
+        return cls.fromdict(name, density)
 
-def Bernoulli(symbol, p, succ=1, fail=0):
+def Bernoulli(name, p, succ=1, fail=0):
     """
     Create a Finite Random Variable representing a Bernoulli process.
 
@@ -173,7 +173,7 @@ def Bernoulli(symbol, p, succ=1, fail=0):
     {Heads: 1/2, Tails: 1/2}
     """
 
-    return BernoulliPSpace(symbol, p, succ, fail).value
+    return BernoulliPSpace(name, p, succ, fail).value
 
 class CoinPSpace(BernoulliPSpace):
     """
@@ -196,10 +196,10 @@ class CoinPSpace(BernoulliPSpace):
     >>> density(C2)
     {H: 3/5, T: 2/5}
     """
-    def __new__(cls, symbol, p):
-        return BernoulliPSpace.__new__(cls, symbol, p, 'H', 'T')
+    def __new__(cls, name, p):
+        return BernoulliPSpace.__new__(cls, name, p, 'H', 'T')
 
-def Coin(symbol, p=S.Half):
+def Coin(name, p=S.Half):
     """
     Create a Finite Random Variable representing a Coin toss.
 
@@ -218,7 +218,7 @@ def Coin(symbol, p=S.Half):
     >>> density(C2)
     {H: 3/5, T: 2/5}
     """
-    return CoinPSpace(symbol, p).value
+    return CoinPSpace(name, p).value
 
 class BinomialPSpace(SingleFinitePSpace):
     """
@@ -239,13 +239,13 @@ class BinomialPSpace(SingleFinitePSpace):
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
     """
 
-    def __new__(cls, symbol, n, p, succ, fail):
+    def __new__(cls, name, n, p, succ, fail):
         n, p, succ, fail = map(sympify, (n, p, succ, fail))
         density = dict((k*succ + (n-k)*fail,
                 binomial(n, k) * p**k * (1-p)**(n-k)) for k in range(0, n+1))
-        return cls.fromdict(symbol, density)
+        return cls.fromdict(name, density)
 
-def Binomial(symbol, n, p, succ=1, fail=0):
+def Binomial(name, n, p, succ=1, fail=0):
     """
     Create a Finite Random Variable representing a binomial distribution.
 
@@ -262,7 +262,7 @@ def Binomial(symbol, n, p, succ=1, fail=0):
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
     """
 
-    return BinomialPSpace(symbol, n, p, succ, fail).value
+    return BinomialPSpace(name, n, p, succ, fail).value
 
 class HypergeometricPSpace(SingleFinitePSpace):
     """
@@ -283,13 +283,13 @@ class HypergeometricPSpace(SingleFinitePSpace):
     {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
     """
 
-    def __new__(cls, symbol, N, m, n):
+    def __new__(cls, name, N, m, n):
         N, m, n = map(sympify, (N, m, n))
         density = dict((k, binomial(m, k) * binomial(N-m, n-k) / binomial(N, n))
                 for k in range(max(0, n+m-N), min(m, n) + 1))
-        return cls.fromdict(symbol, density)
+        return cls.fromdict(name, density)
 
-def Hypergeometric(symbol, N, m, n):
+def Hypergeometric(name, N, m, n):
     """
     Create a Finite Random Variable representing a hypergeometric distribution.
 
@@ -306,4 +306,4 @@ def Hypergeometric(symbol, N, m, n):
     {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
     """
 
-    return HypergeometricPSpace(symbol, N, m, n).value
+    return HypergeometricPSpace(name, N, m, n).value

--- a/sympy/stats/frv_types.py
+++ b/sympy/stats/frv_types.py
@@ -18,7 +18,7 @@ from sympy import S, sympify, Rational, binomial
 __all__ = ['FiniteRV', 'DiscreteUniform', 'Die', 'Bernoulli', 'Coin',
         'Binomial', 'Hypergeometric']
 
-def FiniteRV(density, symbol=None):
+def FiniteRV(symbol, density):
     """
     Create a Finite Random Variable given a dict representing the density.
 
@@ -27,14 +27,14 @@ def FiniteRV(density, symbol=None):
     >>> from sympy.stats import FiniteRV, P, E
 
     >>> density = {0: .1, 1: .2, 2: .3, 3: .4}
-    >>> X = FiniteRV(density)
+    >>> X = FiniteRV('X', density)
 
     >>> E(X)
     2.00000000000000
     >>> P(X>=2)
     0.700000000000000
     """
-    return SingleFinitePSpace.fromdict(density, symbol).value
+    return SingleFinitePSpace.fromdict(symbol, density).value
 
 class DiscreteUniformPSpace(SingleFinitePSpace):
     """
@@ -51,20 +51,20 @@ class DiscreteUniformPSpace(SingleFinitePSpace):
     >>> from sympy.stats import DiscreteUniform, density
     >>> from sympy import symbols
 
-    >>> X = DiscreteUniform(symbols('a b c')) # equally likely over a, b, c
+    >>> X = DiscreteUniform('X', symbols('a b c')) # equally likely over a, b, c
     >>> density(X)
     {a: 1/3, b: 1/3, c: 1/3}
 
-    >>> Y = DiscreteUniform(range(5)) # distribution over a range
+    >>> Y = DiscreteUniform('Y', range(5)) # distribution over a range
     >>> density(Y)
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
     """
-    def __new__(cls, items, symbol=None):
+    def __new__(cls, symbol, items):
         density = dict((sympify(item), Rational(1, len(items)))
                        for item in items)
-        return cls.fromdict(density, symbol)
+        return cls.fromdict(symbol, density)
 
-def DiscreteUniform(items, symbol=None):
+def DiscreteUniform(symbol, items):
     """
     Create a Finite Random Variable representing a uniform distribution over
     the input set.
@@ -77,16 +77,16 @@ def DiscreteUniform(items, symbol=None):
     >>> from sympy.stats import DiscreteUniform, density
     >>> from sympy import symbols
 
-    >>> X = DiscreteUniform(symbols('a b c')) # equally likely over a, b, c
+    >>> X = DiscreteUniform('X', symbols('a b c')) # equally likely over a, b, c
     >>> density(X)
     {a: 1/3, b: 1/3, c: 1/3}
 
-    >>> Y = DiscreteUniform(range(5)) # distribution over a range
+    >>> Y = DiscreteUniform('Y', range(5)) # distribution over a range
     >>> density(Y)
     {0: 1/5, 1: 1/5, 2: 1/5, 3: 1/5, 4: 1/5}
 
     """
-    return DiscreteUniformPSpace(items, symbol).value
+    return DiscreteUniformPSpace(symbol, items).value
 
 class DiePSpace(DiscreteUniformPSpace):
     """
@@ -98,20 +98,18 @@ class DiePSpace(DiscreteUniformPSpace):
 
     >>> from sympy.stats import Die, density
 
-    >>> X = Die(6) # Six sided Die
-    >>> density(X)
+    >>> D6 = Die('D6', 6) # Six sided Die
+    >>> density(D6)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
 
-    >>> X = Die(4) # Four sided Die
-    >>> density(X)
+    >>> D4 = Die('D4', 4) # Four sided Die
+    >>> density(D4)
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
     """
-    _count = 0
-    _name = 'die'
-    def __new__(cls, sides=6, symbol=None):
-        return DiscreteUniformPSpace.__new__(cls, range(1, sides+1), symbol)
+    def __new__(cls, symbol, sides):
+        return DiscreteUniformPSpace.__new__(cls, symbol, range(1, sides+1))
 
-def Die(sides=6, symbol=None):
+def Die(symbol, sides=6):
     """
     Create a Finite Random Variable representing a fair die.
 
@@ -119,16 +117,16 @@ def Die(sides=6, symbol=None):
 
     >>> from sympy.stats import Die, density
 
-    >>> X = Die(6) # Six sided Die
-    >>> density(X)
+    >>> D6 = Die('D6', 6) # Six sided Die
+    >>> density(D6)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
 
-    >>> X = Die(4) # Four sided Die
-    >>> density(X)
+    >>> D4 = Die('D4', 4) # Four sided Die
+    >>> density(D4)
     {1: 1/4, 2: 1/4, 3: 1/4, 4: 1/4}
     """
 
-    return DiePSpace(sides, symbol).value
+    return DiePSpace(symbol, sides).value
 
 class BernoulliPSpace(SingleFinitePSpace):
     """
@@ -143,22 +141,21 @@ class BernoulliPSpace(SingleFinitePSpace):
     >>> from sympy.stats import Bernoulli, density
     >>> from sympy import S
 
-    >>> X = Bernoulli(S(3)/4) # 1-0 Bernoulli variable, probability = 3/4
+    >>> X = Bernoulli('X', S(3)/4) # 1-0 Bernoulli variable, probability = 3/4
     >>> density(X)
     {0: 1/4, 1: 3/4}
 
-    >>> X = Bernoulli(S.Half, 'Heads', 'Tails') # A fair coin toss
+    >>> X = Bernoulli('X', S.Half, 'Heads', 'Tails') # A fair coin toss
     >>> density(X)
     {Heads: 1/2, Tails: 1/2}
     """
 
-    _name = 'bernoulli'
-    def __new__(cls, p, succ=1, fail=0, symbol=None):
+    def __new__(cls, symbol,  p, succ, fail):
         succ, fail, p = map(sympify, (succ, fail, p))
-        density = {succ:p, fail:(1-p)}
-        return cls.fromdict(density, symbol)
+        density = {succ: p, fail: (1-p)}
+        return cls.fromdict(symbol, density)
 
-def Bernoulli(p, succ=1, fail=0, symbol=None):
+def Bernoulli(symbol, p, succ=1, fail=0):
     """
     Create a Finite Random Variable representing a Bernoulli process.
 
@@ -167,16 +164,16 @@ def Bernoulli(p, succ=1, fail=0, symbol=None):
     >>> from sympy.stats import Bernoulli, density
     >>> from sympy import S
 
-    >>> X = Bernoulli(S(3)/4, 1, 0) # 1-0 Bernoulli variable, probability = 3/4
+    >>> X = Bernoulli('X', S(3)/4) # 1-0 Bernoulli variable, probability = 3/4
     >>> density(X)
     {0: 1/4, 1: 3/4}
 
-    >>> X = Bernoulli(S.Half, 'Heads', 'Tails') # A fair coin toss
+    >>> X = Bernoulli('X', S.Half, 'Heads', 'Tails') # A fair coin toss
     >>> density(X)
     {Heads: 1/2, Tails: 1/2}
     """
 
-    return BernoulliPSpace(p, succ, fail, symbol).value
+    return BernoulliPSpace(symbol, p, succ, fail).value
 
 class CoinPSpace(BernoulliPSpace):
     """
@@ -191,20 +188,18 @@ class CoinPSpace(BernoulliPSpace):
     >>> from sympy.stats import Coin, density
     >>> from sympy import Rational
 
-    >>> X = Coin() # A fair coin toss
-    >>> density(X)
+    >>> C = Coin('C') # A fair coin toss
+    >>> density(C)
     {H: 1/2, T: 1/2}
 
-    >>> X = Coin(Rational(3, 5)) # An unfair coin
-    >>> density(X)
+    >>> C2 = Coin('C2', Rational(3, 5)) # An unfair coin
+    >>> density(C2)
     {H: 3/5, T: 2/5}
     """
-    _count = 0
-    _name = 'coin'
-    def __new__(cls, p=S.Half, symbol=None):
-        return BernoulliPSpace.__new__(cls, p, 'H', 'T', symbol)
+    def __new__(cls, symbol, p):
+        return BernoulliPSpace.__new__(cls, symbol, p, 'H', 'T')
 
-def Coin(p=S.Half, symbol=None):
+def Coin(symbol, p=S.Half):
     """
     Create a Finite Random Variable representing a Coin toss.
 
@@ -215,15 +210,15 @@ def Coin(p=S.Half, symbol=None):
     >>> from sympy.stats import Coin, density
     >>> from sympy import Rational
 
-    >>> X = Coin() # A fair coin toss
-    >>> density(X)
+    >>> C = Coin('C') # A fair coin toss
+    >>> density(C)
     {H: 1/2, T: 1/2}
 
-    >>> X = Coin(Rational(3, 5)) # An unfair coin
-    >>> density(X)
+    >>> C2 = Coin('C2', Rational(3, 5)) # An unfair coin
+    >>> density(C2)
     {H: 3/5, T: 2/5}
     """
-    return CoinPSpace(p, symbol).value
+    return CoinPSpace(symbol, p).value
 
 class BinomialPSpace(SingleFinitePSpace):
     """
@@ -239,18 +234,18 @@ class BinomialPSpace(SingleFinitePSpace):
     >>> from sympy.stats import Binomial, density
     >>> from sympy import S
 
-    >>> X = Binomial(4, S.Half) # Four "coin flips"
+    >>> X = Binomial('X', 4, S.Half) # Four "coin flips"
     >>> density(X)
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
     """
 
-    def __new__(cls, n, p, succ=1, fail=0, symbol=None):
+    def __new__(cls, symbol, n, p, succ, fail):
         n, p, succ, fail = map(sympify, (n, p, succ, fail))
         density = dict((k*succ + (n-k)*fail,
                 binomial(n, k) * p**k * (1-p)**(n-k)) for k in range(0, n+1))
-        return cls.fromdict(density, symbol)
+        return cls.fromdict(symbol, density)
 
-def Binomial(n, p, succ=1, fail=0, symbol=None):
+def Binomial(symbol, n, p, succ=1, fail=0):
     """
     Create a Finite Random Variable representing a binomial distribution.
 
@@ -262,12 +257,12 @@ def Binomial(n, p, succ=1, fail=0, symbol=None):
     >>> from sympy.stats import Binomial, density
     >>> from sympy import S
 
-    >>> X = Binomial(4, S.Half) # Four "coin flips"
+    >>> X = Binomial('X', 4, S.Half) # Four "coin flips"
     >>> density(X)
     {0: 1/16, 1: 1/4, 2: 3/8, 3: 1/4, 4: 1/16}
     """
 
-    return BinomialPSpace(n, p, succ, fail, symbol).value
+    return BinomialPSpace(symbol, n, p, succ, fail).value
 
 class HypergeometricPSpace(SingleFinitePSpace):
     """
@@ -283,18 +278,18 @@ class HypergeometricPSpace(SingleFinitePSpace):
     >>> from sympy.stats import Hypergeometric, density
     >>> from sympy import S
 
-    >>> X = Hypergeometric(10, 5, 3) # 10 marbles, 5 white (success), 3 draws
+    >>> X = Hypergeometric('X', 10, 5, 3) # 10 marbles, 5 white (success), 3 draws
     >>> density(X)
     {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
     """
 
-    def __new__(cls, N, m, n, symbol=None):
+    def __new__(cls, symbol, N, m, n):
         N, m, n = map(sympify, (N, m, n))
         density = dict((k, binomial(m, k) * binomial(N-m, n-k) / binomial(N, n))
                 for k in range(max(0, n+m-N), min(m, n) + 1))
-        return cls.fromdict(density, symbol)
+        return cls.fromdict(symbol, density)
 
-def Hypergeometric(N, m, n, symbol=None):
+def Hypergeometric(symbol, N, m, n):
     """
     Create a Finite Random Variable representing a hypergeometric distribution.
 
@@ -306,9 +301,9 @@ def Hypergeometric(N, m, n, symbol=None):
     >>> from sympy.stats import Hypergeometric, density
     >>> from sympy import S
 
-    >>> X = Hypergeometric(10, 5, 3) # 10 marbles, 5 white (success), 3 draws
+    >>> X = Hypergeometric('X', 10, 5, 3) # 10 marbles, 5 white (success), 3 draws
     >>> density(X)
     {0: 1/12, 1: 5/12, 2: 5/12, 3: 1/12}
     """
 
-    return HypergeometricPSpace(N, m, n, symbol).value
+    return HypergeometricPSpace(symbol, N, m, n).value

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -149,15 +149,6 @@ class PSpace(Basic):
     def integrate(self, expr):
         raise NotImplementedError()
 
-    _count = 0
-    _name = 'space'
-
-    @classmethod
-    def create_symbol(cls):
-        cls._count += 1
-        return Symbol('%s%d'%(cls._name, cls._count),
-                real=True, finite=True, bounded=True)
-
 class SinglePSpace(PSpace):
     """
     Represents the probabilities of a set of random events that can be
@@ -355,7 +346,7 @@ def pspace(expr):
 
     >>> from sympy.stats import pspace, Normal
     >>> from sympy.stats.rv import ProductPSpace
-    >>> X, Y = Normal(0, 1), Normal(0, 1)
+    >>> X = Normal('X', 0, 1)
     >>> pspace(2*X + 1) == X.pspace
     True
     """
@@ -403,7 +394,7 @@ def given(expr, condition=None, **kwargs):
     ========
 
     >>> from sympy.stats import given, density, Die
-    >>> X = Die(6)
+    >>> X = Die('X', 6)
     >>> Y = given(X, X>3)
     >>> density(Y)
     {4: 1/3, 5: 1/3, 6: 1/3}
@@ -444,7 +435,7 @@ def expectation(expr, condition=None, numsamples=None, **kwargs):
     ========
 
     >>> from sympy.stats import E, Die
-    >>> X = Die(6)
+    >>> X = Die('X', 6)
     >>> E(X)
     7/2
     >>> E(2*X + 1)
@@ -493,7 +484,7 @@ def probability(condition, given_condition=None, numsamples=None,  **kwargs):
 
     >>> from sympy.stats import P, Die
     >>> from sympy import Eq
-    >>> X, Y = Die(6), Die(6)
+    >>> X, Y = Die('X', 6), Die('Y', 6)
     >>> P(X>3)
     1/2
     >>> P(Eq(X, 5), X>2) # Probability that X == 5 given that X > 2
@@ -529,8 +520,8 @@ def density(expr, condition=None, **kwargs):
     >>> from sympy.stats import density, Die, Normal
     >>> from sympy import Symbol
 
-    >>> D = Die(6)
-    >>> X = Normal(0, 1, symbol=Symbol('x'))
+    >>> D = Die('D', 6)
+    >>> X = Normal('x', 0, 1)
 
     >>> density(D)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
@@ -563,8 +554,8 @@ def cdf(expr, condition=None, **kwargs):
     >>> from sympy.stats import density, Die, Normal, cdf
     >>> from sympy import Symbol
 
-    >>> D = Die(6)
-    >>> X = Normal(0, 1)
+    >>> D = Die('D', 6)
+    >>> X = Normal('X', 0, 1)
 
     >>> density(D)
     {1: 1/6, 2: 1/6, 3: 1/6, 4: 1/6, 5: 1/6, 6: 1/6}
@@ -594,8 +585,8 @@ def where(condition, given_condition=None, **kwargs):
     >>> from sympy import symbols, And
 
     >>> x, a, b = symbols('x a b')
-    >>> D1, D2 = Die(6, symbol=a), Die(6, symbol=b)
-    >>> X = Normal(0, 1, symbol=x)
+    >>> D1, D2 = Die(a, 6), Die(b, 6)
+    >>> X = Normal(x, 0, 1)
 
     >>> where(X**2<1)
     Domain: And(-1 < x, x < 1)
@@ -621,7 +612,7 @@ def sample(expr, condition=None, **kwargs):
     ========
 
     >>> from sympy.stats import Die, sample
-    >>> X, Y, Z = Die(6), Die(6), Die(6)
+    >>> X, Y, Z = Die('X', 6), Die('Y', 6), Die('Z', 6)
 
     >>> die_roll = sample(X+Y+Z) # A random realization of three dice
     """
@@ -638,7 +629,7 @@ def sample_iter(expr, condition=None, numsamples=S.Infinity, **kwargs):
     Examples
     --------
     >>> from sympy.stats import Normal, sample_iter
-    >>> X = Normal(0,1)
+    >>> X = Normal('X', 0, 1)
     >>> expr = X*X + 3
     >>> iterator = sample_iter(expr, numsamples=3)
     >>> list(iterator) # doctest: +SKIP
@@ -795,7 +786,7 @@ def dependent(a, b):
     >>> from sympy.stats import Normal, dependent, given
     >>> from sympy import Tuple, Eq
 
-    >>> X, Y = Normal(0, 1), Normal(0, 1)
+    >>> X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
     >>> dependent(X, Y)
     False
     >>> dependent(2*X + Y, -Y)
@@ -830,7 +821,7 @@ def independent(a, b):
     >>> from sympy.stats import Normal, independent, given
     >>> from sympy import Tuple, Eq
 
-    >>> X, Y = Normal(0, 1), Normal(0, 1)
+    >>> X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
     >>> independent(X, Y)
     True
     >>> independent(2*X + Y, -Y)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -584,9 +584,9 @@ def where(condition, given_condition=None, **kwargs):
     >>> from sympy.stats import where, Die, Normal
     >>> from sympy import symbols, And
 
-    >>> x, a, b = symbols('x a b')
-    >>> D1, D2 = Die(a, 6), Die(b, 6)
-    >>> X = Normal(x, 0, 1)
+    >>> D1, D2 = Die('a', 6), Die('b', 6)
+    >>> a, b = D1.symbol, D2.symbol
+    >>> X = Normal('x', 0, 1)
 
     >>> where(X**2<1)
     Domain: And(-1 < x, x < 1)

--- a/sympy/stats/rv_interface.py
+++ b/sympy/stats/rv_interface.py
@@ -18,9 +18,9 @@ def variance(X, condition=None, **kwargs):
     >>> from sympy.stats import Die, E, Bernoulli, variance
     >>> from sympy import simplify, Symbol
 
-    >>> X = Die(6)
+    >>> X = Die('X', 6)
     >>> p = Symbol('p')
-    >>> B = Bernoulli(p, 1, 0)
+    >>> B = Bernoulli('B', p, 1, 0)
 
     >>> variance(2*X)
     35/3
@@ -44,7 +44,7 @@ def standard_deviation(X, condition=None, **kwargs):
     >>> from sympy import Symbol
 
     >>> p = Symbol('p')
-    >>> B = Bernoulli(p, 1, 0)
+    >>> B = Bernoulli('B', p, 1, 0)
 
     >>> std(B)
     sqrt(-p**2 + p)
@@ -67,8 +67,8 @@ def covariance(X, Y, condition=None, **kwargs):
     >>> from sympy import Symbol
 
     >>> rate = Symbol('lambda', positive=True, real=True, bounded = True)
-    >>> X = Exponential(rate)
-    >>> Y = Exponential(rate)
+    >>> X = Exponential('X', rate)
+    >>> Y = Exponential('Y', rate)
 
     >>> covariance(X, X)
     lambda**(-2)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -18,7 +18,7 @@ _z = Dummy("z")
 def test_single_normal():
     mu = Symbol('mu', real=True, bounded=True)
     sigma = Symbol('sigma', real=True, positive=True, bounded=True)
-    X = Normal(0,1)
+    X = Normal('x', 0,1)
     Y = X*sigma + mu
 
     assert simplify(E(Y)) == mu
@@ -33,7 +33,7 @@ def test_single_normal():
 
 @XFAIL
 def test_conditional_1d():
-    X = Normal(0,1)
+    X = Normal('x', 0,1)
     Y = given(X, X>=0)
 
     assert density(Y) == 2 * density(X)
@@ -44,7 +44,7 @@ def test_conditional_1d():
     assert E(X**2) == E(Y**2)
 
 def test_ContinuousDomain():
-    X = Normal(0,1)
+    X = Normal('x', 0,1)
     assert where(X**2<=1).set == Interval(-1,1)
     assert where(X**2<=1).symbol == X.symbol
     where(And(X**2<=1, X>=0)).set == Interval(0,1)
@@ -55,7 +55,7 @@ def test_ContinuousDomain():
     assert Y.pspace.domain.set == Interval(0, oo)
 
 def test_multiple_normal():
-    X, Y = Normal(0,1), Normal(0,1)
+    X, Y = Normal('x', 0,1), Normal('y', 0,1)
 
     assert E(X+Y) == 0
     assert variance(X+Y) == 2
@@ -70,9 +70,9 @@ def test_symbolic():
     mu1, mu2 = symbols('mu1 mu2', real=True, bounded=True)
     s1, s2 = symbols('sigma1 sigma2', real=True, bounded=True, positive=True)
     rate = Symbol('lambda', real=True, positive=True, bounded=True)
-    X = Normal(mu1, s1)
-    Y = Normal(mu2, s2)
-    Z = Exponential(rate)
+    X = Normal('x', mu1, s1)
+    Y = Normal('y', mu2, s2)
+    Z = Exponential('z', rate)
     a, b, c = symbols('a b c', real=True, bounded=True)
 
     assert E(X) == mu1
@@ -86,7 +86,7 @@ def test_symbolic():
     assert E(X+a*Z+b) == mu1 + a/rate + b
 
 def test_cdf():
-    X = Normal(0,1)
+    X = Normal('x', 0,1)
 
     d = cdf(X)
     assert P(X<1) == d(1)
@@ -95,14 +95,14 @@ def test_cdf():
     d = cdf(X, X>0) # given X>0
     assert d(0) == 0
 
-    Y = Exponential(10)
+    Y = Exponential('y', 10)
     d = cdf(Y)
     assert d(-5) == 0
     assert P(Y > 3) == 1 - d(3)
 
     raises(ValueError, lambda: cdf(X+Y))
 
-    Z = Exponential(1)
+    Z = Exponential('z', 1)
     f = cdf(Z)
     z = Symbol('z')
     assert f(z) == Piecewise((0, z < 0), (1 - exp(-z), True))
@@ -119,7 +119,7 @@ def test_ContinuousRV():
     pdf = sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)) # Normal distribution
     # X and Y should be equivalent
     X = ContinuousRV(x, pdf)
-    Y = Normal(0, 1)
+    Y = Normal('y', 0, 1)
 
     assert variance(X) == variance(Y)
     assert P(X>0) == P(Y>0)
@@ -130,7 +130,7 @@ def test_arcsin():
     b = Symbol("b", real=True)
     x = Symbol("x")
 
-    X = Arcsin(a, b, symbol=x)
+    X = Arcsin(x, a, b)
     assert density(X) == Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
 
 
@@ -140,7 +140,7 @@ def test_benini():
     sigma = Symbol("sigma", positive=True)
     x = Symbol("x")
 
-    X = Benini(alpha, b, sigma, symbol=x)
+    X = Benini(x, alpha, b, sigma)
     assert density(X) == (Lambda(_x, (alpha/_x + 2*b*log(_x/sigma)/_x)
                           *exp(-alpha*log(_x/sigma) - b*log(_x/sigma)**2)))
 
@@ -148,7 +148,7 @@ def test_benini():
 def test_beta():
     a, b = symbols('alpha beta', positive=True)
 
-    B = Beta(a, b)
+    B = Beta('x', a, b)
 
     assert pspace(B).domain.set == Interval(0, 1)
 
@@ -162,7 +162,7 @@ def test_beta():
 
     # Full symbolic solution is too much, test with numeric version
     a, b = 1, 2
-    B = Beta(a, b)
+    B = Beta('x', a, b)
     assert E(B) == a / S(a + b)
     assert variance(B) == (a*b) / S((a+b)**2 * (a+b+1))
 
@@ -172,7 +172,7 @@ def test_betaprime():
     beta = Symbol("beta", positive=True)
     x = Symbol("x")
 
-    X = BetaPrime(alpha, beta, symbol=x)
+    X = BetaPrime(x, alpha, beta)
     assert density(X) == (Lambda(_x, _x**(alpha - 1)*(_x + 1)**(-alpha - beta)
                           *gamma(alpha + beta)/(gamma(alpha)*gamma(beta))))
 
@@ -182,7 +182,7 @@ def test_cauchy():
     gamma = Symbol("gamma", positive=True)
     x = Symbol("x")
 
-    X = Cauchy(x0, gamma, symbol=x)
+    X = Cauchy(x, x0, gamma)
     assert density(X) == Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
 
 
@@ -190,7 +190,7 @@ def test_chi():
     k = Symbol("k", integer=True)
     x = Symbol("x")
 
-    X = Chi(k, symbol=x)
+    X = Chi(x, k)
     assert density(X) == (Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)
                           *exp(-_x**2/2)/gamma(k/2)))
 
@@ -201,14 +201,14 @@ def test_dagum():
     a = Symbol("a", positive=True)
     x = Symbol("x")
 
-    X = Dagum(p, a, b, symbol=x)
+    X = Dagum(x, p, a, b)
     assert density(X) == Lambda(_x,
                                 a*p*(_x/b)**(a*p)*((_x/b)**a + 1)**(-p - 1)/_x)
 
 
 def test_exponential():
     rate = Symbol('lambda', positive=True, real=True, bounded=True)
-    X = Exponential(rate)
+    X = Exponential('x', rate)
 
     assert E(X) == 1/rate
     assert variance(X) == 1/rate**2
@@ -225,7 +225,7 @@ def test_gamma():
     theta = Symbol("theta", positive=True)
     x = Symbol("x")
 
-    X = Gamma(k, theta, symbol=x)
+    X = Gamma(x, k, theta)
     assert density(X) == Lambda(_x,
                                 _x**(k - 1)*theta**(-k)*exp(-_x/theta)/gamma(k))
     assert cdf(X, meijerg=True) == Lambda(_z, Piecewise((0, _z < 0),
@@ -234,7 +234,7 @@ def test_gamma():
            theta*theta**(-k)*theta**(k + 1)*gamma(k + 2)/gamma(k))
 
     k, theta = symbols('k theta', real=True, bounded=True, positive=True)
-    X = Gamma(k, theta)
+    X = Gamma(x, k, theta)
 
     assert simplify(E(X)) == k*theta
     # can't get things to simplify on this one so we use subs
@@ -248,7 +248,7 @@ def test_laplace():
     b = Symbol("b", positive=True)
     x = Symbol("x")
 
-    X = Laplace(mu, b, symbol=x)
+    X = Laplace(x, mu, b)
     assert density(X) == Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
 
 
@@ -257,7 +257,7 @@ def test_logistic():
     s = Symbol("s", positive=True)
     x = Symbol("x")
 
-    X = Logistic(mu, s, symbol=x)
+    X = Logistic(x, mu, s)
     assert density(X) == Lambda(_x,
                                 exp((-_x + mu)/s)/(s*(exp((-_x + mu)/s) + 1)**2))
 
@@ -265,7 +265,7 @@ def test_logistic():
 def test_lognormal():
     mean = Symbol('mu', real=True, bounded=True)
     std = Symbol('sigma', positive=True, real=True, bounded=True)
-    X = LogNormal(mean, std)
+    X = LogNormal('x', mean, std)
     # The sympy integrator can't do this too well
     #assert E(X) == exp(mean+std**2/2)
     #assert variance(X) == (exp(std**2)-1) * exp(2*mean + std**2)
@@ -273,7 +273,7 @@ def test_lognormal():
     # Right now, only density function and sampling works
     # Test sampling: Only e^mean in sample std of 0
     for i in range(3):
-        X = LogNormal(i, 0)
+        X = LogNormal('x', i, 0)
         assert S(sample(X)) == N(exp(i))
     # The sympy integrator can't do this too well
     #assert E(X) ==
@@ -282,11 +282,11 @@ def test_lognormal():
     sigma = Symbol("sigma", positive=True)
     x = Symbol("x")
 
-    X = LogNormal(mu, sigma, symbol=x)
+    X = LogNormal(x, mu, sigma)
     assert density(X) == (Lambda(_x, sqrt(2)*exp(-(-mu + log(_x))**2
                                     /(2*sigma**2))/(2*_x*sqrt(pi)*sigma)))
 
-    X = LogNormal(0, 1, symbol=Symbol('x')) # Mean 0, standard deviation 1
+    X = LogNormal('x', 0, 1) # Mean 0, standard deviation 1
     assert density(X) == Lambda(_x, sqrt(2)*exp(-log(_x)**2/2)/(2*_x*sqrt(pi)))
 
 
@@ -294,7 +294,7 @@ def test_maxwell():
     a = Symbol("a", positive=True)
     x = Symbol("x")
 
-    X = Maxwell(a, symbol=x)
+    X = Maxwell(x, a)
 
     assert density(X) == (Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/
         (sqrt(pi)*a**3)))
@@ -306,7 +306,7 @@ def test_nakagami():
     omega = Symbol("omega", positive=True)
     x = Symbol("x")
 
-    X = Nakagami(mu, omega, symbol=x)
+    X = Nakagami(x, mu, omega)
     assert density(X) == (Lambda(_x, 2*_x**(2*mu - 1)*mu**mu*omega**(-mu)
                                 *exp(-_x**2*mu/omega)/gamma(mu)))
     assert simplify(E(X, meijerg=True)) == (sqrt(mu)*sqrt(omega)
@@ -318,7 +318,7 @@ def test_nakagami():
 def test_pareto():
     xm, beta = symbols('xm beta', positive=True, bounded=True)
     alpha = beta + 5
-    X = Pareto(xm, alpha)
+    X = Pareto('x', xm, alpha)
 
     dens = density(X)
     x = Symbol('x')
@@ -331,7 +331,7 @@ def test_pareto():
 def test_pareto_numeric():
     xm, beta = 3, 2
     alpha = beta + 5
-    X = Pareto(xm, alpha)
+    X = Pareto('x', xm, alpha)
 
     assert E(X) == alpha*xm/S(alpha-1)
     assert variance(X) == xm**2*alpha / S(((alpha-1)**2*(alpha-2)))
@@ -341,7 +341,7 @@ def test_rayleigh():
     sigma = Symbol("sigma", positive=True)
     x = Symbol("x")
 
-    X = Rayleigh(sigma, symbol=x)
+    X = Rayleigh(x, sigma)
     assert density(X) == Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
     assert E(X) == sqrt(2)*sqrt(pi)*sigma/2
     assert variance(X) == -pi*sigma**2/2 + 2*sigma**2
@@ -350,7 +350,7 @@ def test_studentt():
     nu = Symbol("nu", positive=True)
     x = Symbol("x")
 
-    X = StudentT(nu, symbol=x)
+    X = StudentT(x, nu)
     assert density(X) == (Lambda(_x, (_x**2/nu + 1)**(-nu/2 - S.Half)
                         *gamma(nu/2 + S.Half)/(sqrt(pi)*sqrt(nu)*gamma(nu/2))))
 
@@ -361,7 +361,7 @@ def test_triangular():
     c = Symbol("c")
     x = Symbol("x")
 
-    X = Triangular(a,b,c, symbol=x)
+    X = Triangular(x, a,b,c)
     assert Density(X) == Lambda(_x,
              Piecewise(((2*_x - 2*a)/((-a + b)*(-a + c)), And(a <= _x, _x < c)),
                        (2/(-a + b), _x == c),
@@ -371,7 +371,7 @@ def test_triangular():
 def test_uniform():
     l = Symbol('l', real=True, bounded=True)
     w = Symbol('w', positive=True, bounded=True)
-    X = Uniform(l, l+w)
+    X = Uniform('x', l, l+w)
 
     assert simplify(E(X)) == l + w/2
     assert simplify(variance(X)) == w**2/12
@@ -379,7 +379,7 @@ def test_uniform():
     assert P(X<l) == 0 and P(X>l+w) == 0
 
     # With numbers all is well
-    X = Uniform(3, 5)
+    X = Uniform('x', 3, 5)
     assert P(X<3) == 0 and P(X>5) == 0
     assert P(X<4) == P(X>4) == S.Half
 
@@ -390,13 +390,13 @@ def test_uniformsum():
     x = Symbol("x")
     _k = Symbol("k")
 
-    X = UniformSum(n, symbol=x)
+    X = UniformSum(x, n)
     assert density(X) == (Lambda(_x, Sum((-1)**_k*(-_k + _x)**(n - 1)
                         *binomial(n, _k), (_k, 0, floor(_x)))/factorial(n - 1)))
 
 def test_weibull():
     a, b = symbols('a b', positive=True)
-    X = Weibull(a, b)
+    X = Weibull('x', a, b)
 
     assert simplify(E(X)) == simplify(a * gamma(1 + 1/b))
     assert simplify(variance(X)) == simplify(a**2 * gamma(1 + 2/b) - E(X)**2)
@@ -407,7 +407,7 @@ def test_weibull_numeric():
     a = 1
     bvals = [S.Half, 1, S(3)/2, 5]
     for b in bvals:
-        X = Weibull(a, b)
+        X = Weibull('x', a, b)
         assert simplify(E(X)) == simplify(a * gamma(1 + 1/S(b)))
         assert simplify(variance(X)) == simplify(
                 a**2 * gamma(1 + 2/S(b)) - E(X)**2)
@@ -417,19 +417,19 @@ def test_wignersemicircle():
     R = Symbol("R", positive=True)
     x = Symbol("x")
 
-    X = WignerSemicircle(R, symbol=x)
+    X = WignerSemicircle(x, R)
     assert density(X) == Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
     assert E(X) == 0
 
 def test_prefab_sampling():
-    N = Normal(0, 1)
-    L = LogNormal(0, 1)
-    E = Exponential(1)
-    P = Pareto(1, 3)
-    W = Weibull(1, 1)
-    U = Uniform(0, 1)
-    B = Beta(2,5)
-    G = Gamma(1,3)
+    N = Normal('X', 0, 1)
+    L = LogNormal('L', 0, 1)
+    E = Exponential('Ex', 1)
+    P = Pareto('P', 1, 3)
+    W = Weibull('W', 1, 1)
+    U = Uniform('U', 0, 1)
+    B = Beta('B', 2, 5)
+    G = Gamma('G', 1, 3)
 
     variables = [N,L,E,P,W,U,B,G]
     niter = 10
@@ -441,20 +441,20 @@ def test_input_value_assertions():
     a, b = symbols('a b')
     p, q = symbols('p q', positive=True)
 
-    raises(ValueError, lambda: Normal(3, 0))
-    raises(ValueError, lambda: Normal(a, b))
-    Normal(a, p) # No error raised
-    raises(ValueError, lambda: Exponential(a))
-    Exponential(p) # No error raised
+    raises(ValueError, lambda: Normal('x', 3, 0))
+    raises(ValueError, lambda: Normal('x', a, b))
+    Normal('X', a, p) # No error raised
+    raises(ValueError, lambda: Exponential('x', a))
+    Exponential('Ex', p) # No error raised
     for fn in [Pareto, Weibull, Beta, Gamma]:
-        raises(ValueError, lambda: fn(a, p))
-        raises(ValueError, lambda: fn(p, a))
-        fn(p, q) # No error raised
+        raises(ValueError, lambda: fn('x', a, p))
+        raises(ValueError, lambda: fn('x', p, a))
+        fn('x', p, q) # No error raised
 
 @XFAIL
 def test_unevaluated():
     x = Symbol('x')
-    X = Normal(0,1, symbol=x)
+    X = Normal(x, 0,1)
     assert E(X, evaluate=False) == (
             Integral(sqrt(2)*x*exp(-x**2/2)/(2*sqrt(pi)), (x, -oo, oo)))
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -25,7 +25,8 @@ def test_single_normal():
     assert simplify(variance(Y)) == sigma**2
     pdf = density(Y)
     x = Symbol('x')
-    assert pdf(x) == 2**S.Half*exp(-(x - mu)**2/(2*sigma**2))/(2*pi**S.Half*sigma)
+    assert (pdf(x) ==
+            2**S.Half*exp(-(x - mu)**2/(2*sigma**2))/(2*pi**S.Half*sigma))
 
     assert P(X**2 < 1) == erf(2**S.Half/2)
 
@@ -128,9 +129,8 @@ def test_ContinuousRV():
 def test_arcsin():
     a = Symbol("a", real=True)
     b = Symbol("b", real=True)
-    x = Symbol("x")
 
-    X = Arcsin(x, a, b)
+    X = Arcsin('x', a, b)
     assert density(X) == Lambda(_x, 1/(pi*sqrt((-_x + b)*(_x - a))))
 
 
@@ -138,9 +138,8 @@ def test_benini():
     alpha = Symbol("alpha", positive=True)
     b = Symbol("beta", positive=True)
     sigma = Symbol("sigma", positive=True)
-    x = Symbol("x")
 
-    X = Benini(x, alpha, b, sigma)
+    X = Benini('x', alpha, b, sigma)
     assert density(X) == (Lambda(_x, (alpha/_x + 2*b*log(_x/sigma)/_x)
                           *exp(-alpha*log(_x/sigma) - b*log(_x/sigma)**2)))
 
@@ -170,9 +169,8 @@ def test_beta():
 def test_betaprime():
     alpha = Symbol("alpha", positive=True)
     beta = Symbol("beta", positive=True)
-    x = Symbol("x")
 
-    X = BetaPrime(x, alpha, beta)
+    X = BetaPrime('x', alpha, beta)
     assert density(X) == (Lambda(_x, _x**(alpha - 1)*(_x + 1)**(-alpha - beta)
                           *gamma(alpha + beta)/(gamma(alpha)*gamma(beta))))
 
@@ -180,17 +178,15 @@ def test_betaprime():
 def test_cauchy():
     x0 = Symbol("x0")
     gamma = Symbol("gamma", positive=True)
-    x = Symbol("x")
 
-    X = Cauchy(x, x0, gamma)
+    X = Cauchy('x', x0, gamma)
     assert density(X) == Lambda(_x, 1/(pi*gamma*(1 + (_x - x0)**2/gamma**2)))
 
 
 def test_chi():
     k = Symbol("k", integer=True)
-    x = Symbol("x")
 
-    X = Chi(x, k)
+    X = Chi('x', k)
     assert density(X) == (Lambda(_x, 2**(-k/2 + 1)*_x**(k - 1)
                           *exp(-_x**2/2)/gamma(k/2)))
 
@@ -199,9 +195,8 @@ def test_dagum():
     p = Symbol("p", positive=True)
     b = Symbol("b", positive=True)
     a = Symbol("a", positive=True)
-    x = Symbol("x")
 
-    X = Dagum(x, p, a, b)
+    X = Dagum('x', p, a, b)
     assert density(X) == Lambda(_x,
                                 a*p*(_x/b)**(a*p)*((_x/b)**a + 1)**(-p - 1)/_x)
 
@@ -223,9 +218,8 @@ def test_exponential():
 def test_gamma():
     k = Symbol("k", positive=True)
     theta = Symbol("theta", positive=True)
-    x = Symbol("x")
 
-    X = Gamma(x, k, theta)
+    X = Gamma('x', k, theta)
     assert density(X) == Lambda(_x,
                                 _x**(k - 1)*theta**(-k)*exp(-_x/theta)/gamma(k))
     assert cdf(X, meijerg=True) == Lambda(_z, Piecewise((0, _z < 0),
@@ -234,8 +228,7 @@ def test_gamma():
            theta*theta**(-k)*theta**(k + 1)*gamma(k + 2)/gamma(k))
 
     k, theta = symbols('k theta', real=True, bounded=True, positive=True)
-    X = Gamma(x, k, theta)
-
+    X = Gamma('x', k, theta)
     assert simplify(E(X)) == k*theta
     # can't get things to simplify on this one so we use subs
     assert variance(X).subs(k,5) == (k*theta**2).subs(k, 5)
@@ -246,18 +239,16 @@ def test_gamma():
 def test_laplace():
     mu = Symbol("mu")
     b = Symbol("b", positive=True)
-    x = Symbol("x")
 
-    X = Laplace(x, mu, b)
+    X = Laplace('x', mu, b)
     assert density(X) == Lambda(_x, exp(-Abs(_x - mu)/b)/(2*b))
 
 
 def test_logistic():
     mu = Symbol("mu", real=True)
     s = Symbol("s", positive=True)
-    x = Symbol("x")
 
-    X = Logistic(x, mu, s)
+    X = Logistic('x', mu, s)
     assert density(X) == Lambda(_x,
                                 exp((-_x + mu)/s)/(s*(exp((-_x + mu)/s) + 1)**2))
 
@@ -280,9 +271,8 @@ def test_lognormal():
 
     mu = Symbol("mu", real=True)
     sigma = Symbol("sigma", positive=True)
-    x = Symbol("x")
 
-    X = LogNormal(x, mu, sigma)
+    X = LogNormal('x', mu, sigma)
     assert density(X) == (Lambda(_x, sqrt(2)*exp(-(-mu + log(_x))**2
                                     /(2*sigma**2))/(2*_x*sqrt(pi)*sigma)))
 
@@ -292,9 +282,8 @@ def test_lognormal():
 
 def test_maxwell():
     a = Symbol("a", positive=True)
-    x = Symbol("x")
 
-    X = Maxwell(x, a)
+    X = Maxwell('x', a)
 
     assert density(X) == (Lambda(_x, sqrt(2)*_x**2*exp(-_x**2/(2*a**2))/
         (sqrt(pi)*a**3)))
@@ -304,9 +293,8 @@ def test_maxwell():
 def test_nakagami():
     mu = Symbol("mu", positive=True)
     omega = Symbol("omega", positive=True)
-    x = Symbol("x")
 
-    X = Nakagami(x, mu, omega)
+    X = Nakagami('x', mu, omega)
     assert density(X) == (Lambda(_x, 2*_x**(2*mu - 1)*mu**mu*omega**(-mu)
                                 *exp(-_x**2*mu/omega)/gamma(mu)))
     assert simplify(E(X, meijerg=True)) == (sqrt(mu)*sqrt(omega)
@@ -339,18 +327,16 @@ def test_pareto_numeric():
 
 def test_rayleigh():
     sigma = Symbol("sigma", positive=True)
-    x = Symbol("x")
 
-    X = Rayleigh(x, sigma)
+    X = Rayleigh('x', sigma)
     assert density(X) == Lambda(_x, _x*exp(-_x**2/(2*sigma**2))/sigma**2)
     assert E(X) == sqrt(2)*sqrt(pi)*sigma/2
     assert variance(X) == -pi*sigma**2/2 + 2*sigma**2
 
 def test_studentt():
     nu = Symbol("nu", positive=True)
-    x = Symbol("x")
 
-    X = StudentT(x, nu)
+    X = StudentT('x', nu)
     assert density(X) == (Lambda(_x, (_x**2/nu + 1)**(-nu/2 - S.Half)
                         *gamma(nu/2 + S.Half)/(sqrt(pi)*sqrt(nu)*gamma(nu/2))))
 
@@ -359,9 +345,8 @@ def test_triangular():
     a = Symbol("a")
     b = Symbol("b")
     c = Symbol("c")
-    x = Symbol("x")
 
-    X = Triangular(x, a,b,c)
+    X = Triangular('x', a,b,c)
     assert Density(X) == Lambda(_x,
              Piecewise(((2*_x - 2*a)/((-a + b)*(-a + c)), And(a <= _x, _x < c)),
                        (2/(-a + b), _x == c),
@@ -387,10 +372,9 @@ def test_uniform():
 @XFAIL
 def test_uniformsum():
     n = Symbol("n", integer=True)
-    x = Symbol("x")
     _k = Symbol("k")
 
-    X = UniformSum(x, n)
+    X = UniformSum('x', n)
     assert density(X) == (Lambda(_x, Sum((-1)**_k*(-_k + _x)**(n - 1)
                         *binomial(n, _k), (_k, 0, floor(_x)))/factorial(n - 1)))
 
@@ -415,9 +399,8 @@ def test_weibull_numeric():
 
 def test_wignersemicircle():
     R = Symbol("R", positive=True)
-    x = Symbol("x")
 
-    X = WignerSemicircle(x, R)
+    X = WignerSemicircle('x', R)
     assert density(X) == Lambda(_x, 2*sqrt(-_x**2 + R**2)/(pi*R**2))
     assert E(X) == 0
 
@@ -453,8 +436,7 @@ def test_input_value_assertions():
 
 @XFAIL
 def test_unevaluated():
-    x = Symbol('x')
-    X = Normal(x, 0,1)
+    X = Normal('x', 0,1)
     assert E(X, evaluate=False) == (
             Integral(sqrt(2)*x*exp(-x**2/2)/(2*sqrt(pi)), (x, -oo, oo)))
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -79,8 +79,8 @@ def test_given():
     sample(X, X>5) == 6
 
 def test_domains():
-    x, y = symbols('x y')
-    X, Y= Die(x, 6), Die(y, 6)
+    X, Y= Die('x', 6), Die('y', 6)
+    x, y = X.symbol, Y.symbol
     # Domains
     d = where(X>Y)
     assert d.condition == (x > y)
@@ -91,7 +91,7 @@ def test_domains():
 
     assert len(pspace(X+Y).domain.elements) == 36
 
-    Z = Die(x, 4)
+    Z = Die('x', 4)
 
     raises(ValueError, lambda: P(X>Z)) # Two domains with same internal symbol
 

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -13,13 +13,13 @@ def BayesTest(A,B):
 def test_discreteuniform():
     # Symbolic
     a, b, c = symbols('a b c')
-    X = DiscreteUniform([a,b,c])
+    X = DiscreteUniform('X', [a,b,c])
 
     assert E(X) == (a+b+c)/3
     assert variance(X) == (a**2+b**2+c**2)/3 - (a/3+b/3+c/3)**2
     assert P(Eq(X, a)) == P(Eq(X, b)) == P(Eq(X, c)) == S('1/3')
 
-    Y = DiscreteUniform(range(-5, 5))
+    Y = DiscreteUniform('Y', range(-5, 5))
 
     # Numeric
     assert E(Y) == S('-1/2')
@@ -30,10 +30,11 @@ def test_discreteuniform():
         assert P(Y <= x) == S(x+6)/10
         assert P(Y >= x) == S(5-x)/10
 
-    assert density(Die(6)) == density(DiscreteUniform(range(1,7)))
+    assert density(Die('D', 6)) == density(DiscreteUniform('U', range(1,7)))
 
 def test_dice():
-    X, Y, Z= Die(6), Die(6), Die(6)
+    # TODO: Make iid method!
+    X, Y, Z= Die('X', 6), Die('Y', 6), Die('Z', 6)
     a,b = symbols('a b')
 
     assert E(X) == 3+S.Half
@@ -72,14 +73,14 @@ def test_dice():
     assert where(X>3).set == FiniteSet(4,5,6)
 
 def test_given():
-    X = Die(6)
+    X = Die('X', 6)
     density(X, X>5) == {S(6): S(1)}
     where(X>2, X>5).as_boolean() == Eq(X.symbol, 6)
     sample(X, X>5) == 6
 
 def test_domains():
     x, y = symbols('x y')
-    X, Y= Die(6, symbol=x), Die(6, symbol=y)
+    X, Y= Die(x, 6), Die(y, 6)
     # Domains
     d = where(X>Y)
     assert d.condition == (x > y)
@@ -90,7 +91,7 @@ def test_domains():
 
     assert len(pspace(X+Y).domain.elements) == 36
 
-    Z = Die(4, symbol=x)
+    Z = Die(x, 4)
 
     raises(ValueError, lambda: P(X>Z)) # Two domains with same internal symbol
 
@@ -104,7 +105,7 @@ def test_domains():
             for i in range(1,7) for j in range(1,7) if i>j)
 
 def test_dice_bayes():
-    X, Y, Z = Die(6), Die(6), Die(6)
+    X, Y, Z= Die('X', 6), Die('Y', 6), Die('Z', 6)
 
     BayesTest(X>3, X+Y<5)
     BayesTest(Eq(X-Y, Z), Z>Y)
@@ -112,13 +113,13 @@ def test_dice_bayes():
 
 def test_bernoulli():
     p, a, b = symbols('p a b')
-    X = Bernoulli(p, a, b, symbol='B')
+    X = Bernoulli('B', p, a, b)
 
     assert E(X) == a*p + b*(-p+1)
     assert density(X)[a] == p
     assert density(X)[b] == 1-p
 
-    X = Bernoulli(p, 1, 0, symbol='B')
+    X = Bernoulli('B', p, 1, 0)
 
     assert E(X) == p
     assert variance(X) == -p**2 + p
@@ -126,21 +127,21 @@ def test_bernoulli():
     variance(a*X+b) == a**2 * variance(X)
 
 def test_cdf():
-    D = Die(6)
+    D = Die('D', 6)
     o = S.One
 
     assert cdf(D) == sympify({1:o/6, 2:o/3, 3:o/2, 4:2*o/3, 5:5*o/6, 6:o})
 
 def test_coins():
-    C, D = Coin(), Coin()
+    C, D = Coin('C'), Coin('D')
     H, T = sorted(density(C).keys())
     assert P(Eq(C, D)) == S.Half
     assert density(Tuple(C, D)) == {(H, H): S.One/4, (H, T): S.One/4,
             (T, H): S.One/4, (T, T): S.One/4}
     assert density(C) == {H: S.Half, T: S.Half}
 
-    E = Coin(S.One/10)
-    assert P(Eq(E, H))==S(1)/10
+    F = Coin('F', S.One/10)
+    assert P(Eq(F, H)) == S(1)/10
 
     d = pspace(C).domain
 
@@ -154,7 +155,7 @@ def test_binomial_numeric():
 
     for n in nvals:
         for p in pvals:
-            X = Binomial(n, p)
+            X = Binomial('X', n, p)
             assert Eq(E(X), n*p)
             assert Eq(variance(X), n*p*(1-p))
             if n > 0 and 0 < p < 1:
@@ -165,7 +166,7 @@ def test_binomial_numeric():
 def test_binomial_symbolic():
     n = 10 # Because we're using for loops, can't do symbolic n
     p = symbols('p', positive=True)
-    X = Binomial(n, p)
+    X = Binomial('X', n, p)
     assert Eq(simplify(E(X)), n*p)
     assert Eq(simplify(variance(X)), n*p*(1-p))
 # Can't detect the equality
@@ -173,14 +174,14 @@ def test_binomial_symbolic():
 
     # Test ability to change success/failure winnings
     H, T = symbols('H T')
-    Y = Binomial(n, p, succ=H, fail=T)
+    Y = Binomial('Y', n, p, succ=H, fail=T)
     assert Eq(simplify(E(Y)), simplify(n*(H*p+T*(1-p))))
 
 def test_hypergeometric_numeric():
     for N in range(1, 5):
         for m in range(0, N+1):
             for n in range(1, N+1):
-                X = Hypergeometric(N, m, n)
+                X = Hypergeometric('X', N, m, n)
                 N, m, n = map(sympify, (N, m, n))
                 assert sum(density(X).values()) == 1
                 assert E(X) == n * m / N
@@ -193,10 +194,10 @@ def test_hypergeometric_numeric():
 
 
 def test_FiniteRV():
-    F = FiniteRV({1:S.Half, 2:S.One/4, 3:S.One/4})
+    F = FiniteRV('F', {1:S.Half, 2:S.One/4, 3:S.One/4})
 
-    assert density(F) =={S(1):S.Half, S(2):S.One/4, S(3):S.One/4}
-    assert P(F>=2)==S.Half
+    assert density(F) == {S(1):S.Half, S(2):S.One/4, S(3):S.One/4}
+    assert P(F>=2) == S.Half
 
     assert pspace(F).domain.as_boolean() == Or(
             *[Eq(F.symbol, i) for i in [1,2,3]])

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -44,12 +44,11 @@ def test_pspace():
     assert pspace(2*X+Y) == ProductPSpace(Y.pspace, X.pspace)
 
 def test_rs_swap():
-    x, y = symbols('x y')
-    X = Normal(x, 0, 1)
-    Y = Exponential(y, 1)
+    X = Normal('x', 0, 1)
+    Y = Exponential('y', 1)
 
-    XX = Normal(x, 0, 2)
-    YY = Normal(y, 0, 3)
+    XX = Normal('x', 0, 2)
+    YY = Normal('y', 0, 3)
 
     expr = 2*X+Y
     assert expr.subs(rs_swap((X,Y), (YY,XX))) == 2*XX+YY

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -7,8 +7,8 @@ from sympy.stats.rv import ProductPSpace, rs_swap
 from sympy.utilities.pytest import raises, XFAIL
 
 def test_where():
-    X, Y = Die(), Die()
-    Z = Normal(0, 1)
+    X, Y = Die('X'), Die('Y')
+    Z = Normal('Z', 0, 1)
 
     assert where(Z**2<=1).set == Interval(-1, 1)
     assert where(Z**2<=1).as_boolean() == Interval(-1,1).as_relational(Z.symbol)
@@ -18,7 +18,7 @@ def test_where():
     assert len(where(X<3).set) == 2
     assert 1 in where(X<3).set
 
-    X, Y = Normal(0, 1), Normal(0, 1)
+    X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
     assert where(And(X**2 <= 1, X >= 0)).set == Interval(0, 1)
     XX = given(X, And(X**2 <= 1, X >= 0))
     assert XX.pspace.domain.set == Interval(0, 1)
@@ -28,7 +28,7 @@ def test_where():
         XX = given(X, X+3)
 
 def test_random_symbols():
-    X, Y = Normal(0,1), Normal(0,1)
+    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
 
     assert set(random_symbols(2*X+1)) == set((X,))
     assert set(random_symbols(2*X+Y)) == set((X,Y))
@@ -36,7 +36,7 @@ def test_random_symbols():
     assert set(random_symbols(2)) == set()
 
 def test_pspace():
-    X, Y = Normal(0,1), Normal(0,1)
+    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
 
     assert not pspace(5+3)
     assert pspace(X) == X.pspace
@@ -45,33 +45,33 @@ def test_pspace():
 
 def test_rs_swap():
     x, y = symbols('x y')
-    X = Normal(0, 1, symbol=x)
-    Y = Exponential(1, symbol=y)
+    X = Normal(x, 0, 1)
+    Y = Exponential(y, 1)
 
-    XX = Normal(0, 2, symbol=x)
-    YY = Normal(0, 3, symbol=y)
+    XX = Normal(x, 0, 2)
+    YY = Normal(y, 0, 3)
 
     expr = 2*X+Y
     assert expr.subs(rs_swap((X,Y), (YY,XX))) == 2*XX+YY
 
 def test_RandomSymbol():
 
-    X = Normal(0, 1, symbol=Symbol('x'))
-    Y = Normal(0, 2, symbol=Symbol('x'))
+    X = Normal('x', 0, 1)
+    Y = Normal('x', 0, 2)
     assert X.symbol == Y.symbol
     assert X!=Y
 
     assert X.name == X.symbol.name
 
 def test_overlap():
-    X = Normal(0, 1, symbol=Symbol('x'))
-    Y = Normal(0, 2, symbol=Symbol('x'))
+    X = Normal('x', 0, 1)
+    Y = Normal('x', 0, 2)
 
     raises(ValueError, lambda: P(X>Y))
 
 def test_ProductPSpace():
-    X = Normal(0, 1)
-    Y = Normal(0, 1)
+    X = Normal('X', 0, 1)
+    Y = Normal('Y', 0, 1)
     px = X.pspace
     py = Y.pspace
     assert pspace(X+Y) == ProductPSpace(px, py)
@@ -81,8 +81,8 @@ def test_E():
     assert E(5) == 5
 
 def test_Sample():
-    X = Die(6)
-    Y = Normal(0,1)
+    X = Die('X', 6)
+    Y = Normal('Y', 0,1)
     z = Symbol('z')
 
     assert sample(X) in [1,2,3,4,5,6]
@@ -101,19 +101,19 @@ def test_Sample():
     E(Sum(1/z**Y, (z,1,oo)), Y>2, numsamples=3)
 
 def test_given():
-    X = Normal(0, 1)
-    Y = Normal(0, 1)
+    X = Normal('X', 0, 1)
+    Y = Normal('Y', 0, 1)
     A = given(X, True)
     B = given(X, Y>2)
 
     assert X == A == B
 
 def test_dependence():
-    X, Y = Die(), Die()
+    X, Y = Die('X'), Die('Y')
     assert independent(X, 2*Y)
     assert not dependent(X, 2*Y)
 
-    X, Y = Normal(0,1), Normal(0,1)
+    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
     assert independent(X, Y)
     assert dependent(X, 2*X)
 
@@ -123,7 +123,7 @@ def test_dependence():
 
 @XFAIL
 def test_dependent_finite():
-    X, Y = Die(), Die()
+    X, Y = Die('X'), Die('Y')
     # Dependence testing requires symbolic conditions which currently break
     # finite random variables
     assert dependent(X, Y+X)
@@ -132,7 +132,7 @@ def test_dependent_finite():
     assert dependent(XX, YY)
 
 def test_normality():
-    X, Y = Normal(0,1), Normal(0,1)
+    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
     x, z = symbols('x, z', real=True)
     dens = density(X-Y, Eq(X+Y, z))
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -28,7 +28,7 @@ def test_where():
         XX = given(X, X+3)
 
 def test_random_symbols():
-    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
+    X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
 
     assert set(random_symbols(2*X+1)) == set((X,))
     assert set(random_symbols(2*X+Y)) == set((X,Y))
@@ -36,7 +36,7 @@ def test_random_symbols():
     assert set(random_symbols(2)) == set()
 
 def test_pspace():
-    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
+    X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
 
     assert not pspace(5+3)
     assert pspace(X) == X.pspace
@@ -112,7 +112,7 @@ def test_dependence():
     assert independent(X, 2*Y)
     assert not dependent(X, 2*Y)
 
-    X, Y = Normal('X', 0,1), Normal('Y', 0,1)
+    X, Y = Normal('X', 0, 1), Normal('Y', 0, 1)
     assert independent(X, Y)
     assert dependent(X, 2*X)
 


### PR DESCRIPTION
Moved `symbol` argument to the first argument and made it mandatory (removing the need for auto-variable generation). Allowed strings to be used as the symbol input (as they will be sympified) for continuous random variables.

todo/issues:
- Error about code-wrapping; not sure how to fix
- Doctests and tests have some extraneous symbol creation, making `x = Symbol('x')` and then passing it to `Binomial(x, n, p)` or whatever, when we could just do `Binomial('x', n, p)`
- Sympifying is imperfect: it doesn't let you use some strings as symbols: `E` returns Euler's constant, `N` returns the approximation function and so on. Instead, we should detect if the variable is already a symbol, and explicitly use `Symbol` if it is a string.
