### PR TITLE
Fix .args for ImmutableMatrix().

### DIFF
--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -1,6 +1,6 @@
 from matrices import MatrixBase, MutableMatrix
 from expressions import MatrixExpr, Transpose
-from sympy import Basic, Tuple
+from sympy import Basic, Integer, Tuple
 
 class ImmutableMatrix(MatrixExpr, MatrixBase):
 
@@ -11,19 +11,20 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
         if len(args)==1 and isinstance(args[0], ImmutableMatrix):
             return args[0]
         rows, cols, mat = MatrixBase._handle_creation_inputs(*args, **kwargs)
-        shape = Tuple(rows, cols)
+        rows = Integer(rows)
+        cols = Integer(cols)
         mat = Tuple(*mat)
-        return Basic.__new__(cls, shape, mat)
+        return Basic.__new__(cls, rows, cols, mat)
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
 
     @property
     def shape(self):
-        return self.args[0]
+        return self.args[0:2]
 
     @property
     def mat(self):
-        return self.args[1]
+        return self.args[2]
 
     def _entry(self, i, j):
         return MatrixBase.__getitem__(self, (i,j))

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,4 +1,5 @@
 from sympy import ImmutableMatrix, Matrix, eye, zeros
+from sympy.abc import x, y
 from sympy.utilities.pytest import raises, XFAIL
 
 IM = ImmutableMatrix([[1,2,3], [4,5,6], [7,8,9]])
@@ -15,6 +16,17 @@ def test_immutability():
 def test_slicing():
     IM[1,:] == ImmutableMatrix([[4,5,6]])
     IM[:2, :2] == ImmutableMatrix([[1,2],[4,5]])
+
+def test_subs():
+    A = ImmutableMatrix([[1,2],[3,4]])
+    B = ImmutableMatrix([[1,2],[x,4]])
+    C = ImmutableMatrix([[-x,x*y],[-(x+y),y**2]])
+    assert B.subs(x, 3) == A
+    assert (x*B).subs(x, 3) == 3*A
+    assert (x*eye(2) + B).subs(x, 3) == 3*eye(2) + A
+    assert C.subs([[x,-1],[y,-2]]) == A
+    assert C.subs([(x,-1),(y,-2)]) == A
+    assert C.subs({x:-1,y:-2}) == A
 
 def test_as_immutable():
     X = Matrix([[1,2], [3,4]])


### PR DESCRIPTION
This fixes `obj.__class__(*obj.args)` and `obj.subs(...)` for `ImmutableMatrix` instances.

See http://code.google.com/p/sympy/issues/detail?id=3208
