### PR TITLE
Generalized polynomial rings

### DIFF
--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -518,7 +518,7 @@ def dup_convert(f, K0, K1):
     [1, 2]
 
     >>> dup_convert([ZZ(1), ZZ(2)], ZZ, ZZ['x'])
-    [DMP([1], ZZ), DMP([2], ZZ)]
+    [DMP([1], ZZ, ZZ[x]), DMP([2], ZZ, ZZ[x])]
 
     """
     if K0 is not None and K0 == K1:
@@ -545,7 +545,7 @@ def dmp_convert(f, u, K0, K1):
     [[1], [2]]
 
     >>> dmp_convert(g, 1, ZZ, ZZ['x'])
-    [[DMP([1], ZZ)], [DMP([2], ZZ)]]
+    [[DMP([1], ZZ, ZZ[x])], [DMP([2], ZZ, ZZ[x])]]
 
     """
     if not u:
@@ -1588,7 +1588,7 @@ def dmp_eject(f, u, K, front=False):
     >>> K = ZZ['x', 'y']
 
     >>> dmp_eject([[[1]], [[1], [2]]], 2, K)
-    [DMP([[1]], ZZ), DMP([[1], [2]], ZZ)]
+    [DMP([[1]], ZZ, ZZ[x,y]), DMP([[1], [2]], ZZ, ZZ[x,y])]
 
     """
     f, h = dmp_to_dict(f, u), {}

--- a/sympy/polys/distributedmodules.py
+++ b/sympy/polys/distributedmodules.py
@@ -456,14 +456,17 @@ def sdm_groebner(G, NF, O, K):
         [SCA, remark 2.5.11].
         """
         remove = set()
+        retain = set()
         for (a, b, c) in permutations(S, 3):
             A = sdm_LM(a)
             B = sdm_LM(b)
             C = sdm_LM(c)
-            if len(set([A[0], B[0], C[0]])) != 1 or not h in [a, b, c]:
+            if len(set([A[0], B[0], C[0]])) != 1 or not h in [a, b, c] or \
+               any(tuple(x) in retain for x in [a, b, c]):
                 continue
             if monomial_divides(B[1:], monomial_lcm(A[1:], C[1:])):
                 remove.add((tuple(a), tuple(c)))
+                retain.update([tuple(b), tuple(c), tuple(a)])
         return [(f, g) for (f, g) in P if (h not in [f, g]) or \
                     ((tuple(f), tuple(g)) not in remove and \
                      (tuple(g), tuple(f)) not in remove)]
@@ -472,9 +475,9 @@ def sdm_groebner(G, NF, O, K):
         # TODO better data structures!!!
         #print len(P), len(S)
         # Use the "normal selection strategy"
-        lcms = [(i, monomial_lcm(sdm_LM(f)[1:], sdm_LM(g)[1:]), sdm_LM(f)[0]) for \
+        lcms = [(i, sdm_LM(f)[:1] + monomial_lcm(sdm_LM(f)[1:], sdm_LM(g)[1:])) for \
                 i, (f, g) in enumerate(P)]
-        i = min(lcms, key=lambda x: O((x[0],) + x[1]))[0]
+        i = min(lcms, key=lambda x: O(x[1]))[0]
         f, g = P.pop(i)
         h = NF(sdm_spoly(f, g, O, K), S, O, K)
         if h:

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -173,7 +173,7 @@ class Domain(object):
         """Convert a `ANP` object to `dtype`. """
         return None
 
-    def from_PolynomialRing(K1, a, K0):
+    def from_GlobalPolynomialRing(K1, a, K0):
         """Convert a `DMP` object to `dtype`. """
         if a.degree() <= 0:
             return K1.convert(a.LC(), K0.dom)
@@ -352,10 +352,10 @@ class Domain(object):
         else:
             return self.poly_ring(gens)
 
-    def poly_ring(self, *gens):
+    def poly_ring(self, *gens, **opts):
         """Returns a polynomial ring, i.e. `K[X]`. """
         from sympy.polys.domains import PolynomialRing
-        return PolynomialRing(self, *gens)
+        return PolynomialRing(self, *gens, **opts)
 
     def frac_field(self, *gens):
         """Returns a fraction field, i.e. `K(X)`. """

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -186,6 +186,9 @@ class Domain(object):
         """Convert a `EX` object to `dtype`. """
         return K1.from_sympy(a.ex)
 
+    def from_GeneralizedPolynomialRing(K1, a, K0):
+        return K1.from_FractionField(a, K0)
+
     def unify(K0, K1, gens=None):
         """Returns a maximal domain containg `K0` and `K1`. """
         if gens is not None:

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -152,7 +152,7 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
         """Convert a mpmath `mpf` object to `dtype`. """
         return K1(K0.to_sympy(a))
 
-    def from_PolynomialRing(K1, a, K0):
+    def from_GlobalPolynomialRing(K1, a, K0):
         """Convert a `DMP` object to `dtype`. """
         return K1(K0.to_sympy(a))
 

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -101,7 +101,7 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
         """Convert a mpmath `mpf` object to `dtype`. """
         return K1(K1.dom.convert(a, K0))
 
-    def from_PolynomialRing(K1, a, K0):
+    def from_GlobalPolynomialRing(K1, a, K0):
         """Convert a `DMF` object to `dtype`. """
         if K1.gens == K0.gens:
             if K1.dom == K0.dom:

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -23,8 +23,8 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
 
         lev = len(gens) - 1
 
-        self.zero = self.dtype.zero(lev, dom)
-        self.one  = self.dtype.one(lev, dom)
+        self.zero = self.dtype.zero(lev, dom, ring=self)
+        self.one  = self.dtype.one(lev, dom, ring=self)
 
         self.dom  = dom
         self.gens = gens
@@ -37,10 +37,12 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
 
     def __call__(self, a):
         """Construct an element of `self` domain from `a`. """
-        return DMF(a, self.dom, len(self.gens)-1)
+        return DMF(a, self.dom, len(self.gens)-1, ring=self)
 
     def __eq__(self, other):
         """Returns `True` if two domains are equivalent. """
+        if not isinstance(other, FractionField):
+            return False
         return self.dtype == other.dtype and self.dom == other.dom and self.gens == other.gens
 
     def __ne__(self, other):

--- a/sympy/polys/domains/fractionfield.py
+++ b/sympy/polys/domains/fractionfield.py
@@ -133,7 +133,7 @@ class FractionField(Field, CharacteristicZero, CompositeDomain):
         >>> ZZx = ZZ.frac_field(x)
 
         >>> QQx.from_FractionField(f, ZZx)
-        DMF(([1/1, 2/1], [1/1, 1/1]), QQ)
+        (x + 2)/(x + 1)
 
         """
         if K1.gens == K0.gens:

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -23,8 +23,8 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
 
         lev = len(gens) - 1
 
-        self.zero = self.dtype.zero(lev, dom)
-        self.one  = self.dtype.one(lev, dom)
+        self.zero = self.dtype.zero(lev, dom, ring=self)
+        self.one  = self.dtype.one(lev, dom, ring=self)
 
         self.dom  = dom
         self.gens = gens
@@ -37,10 +37,12 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
 
     def __call__(self, a):
         """Construct an element of `self` domain from `a`. """
-        return DMP(a, self.dom, len(self.gens)-1)
+        return DMP(a, self.dom, len(self.gens)-1, ring=self)
 
     def __eq__(self, other):
         """Returns `True` if two domains are equivalent. """
+        if not isinstance(other, PolynomialRing):
+            return False
         return self.dtype == other.dtype and self.dom == other.dom and self.gens == other.gens
 
     def __ne__(self, other):

--- a/sympy/polys/domains/polynomialring.py
+++ b/sympy/polys/domains/polynomialring.py
@@ -3,21 +3,33 @@
 from sympy.polys.domains.ring import Ring
 from sympy.polys.domains.compositedomain import CompositeDomain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
+from sympy.polys.domains.fractionfield import FractionField
 
-from sympy.polys.polyclasses import DMP
+from sympy.polys.polyclasses import DMP, DMF
 from sympy.polys.polyerrors import GeneratorsNeeded, PolynomialError, CoercionFailed
 from sympy.polys.polyutils import dict_from_basic, basic_from_dict, _dict_reorder
 
-class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
-    """A class for representing multivariate polynomial rings. """
+from sympy.polys.monomialtools import monomial_key, build_product_order
 
-    dtype        = DMP
-    is_Poly      = True
+from sympy.core.compatibility import iterable
+
+# XXX why does this derive from CharacteristicZero???
+class PolynomialRingBase(Ring, CharacteristicZero, CompositeDomain):
+    """
+    Base class for generalized polynomial rings.
+
+    This base class should be used for uniform access to generalized polynomial
+    rings. Subclasses only supply information about the element storage etc.
+
+    Do not instantiate.
+    """
 
     has_assoc_Ring         = True
     has_assoc_Field        = True
 
-    def __init__(self, dom, *gens):
+    default_order = "grevlex"
+
+    def __init__(self, dom, *gens, **opts):
         if not gens:
             raise GeneratorsNeeded("generators not specified")
 
@@ -28,42 +40,32 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
 
         self.dom  = dom
         self.gens = gens
+        # NOTE 'order' may not be set if inject was called through CompositeDomain
+        self.order = opts.get('order', monomial_key(self.default_order))
 
     def __str__(self):
-        return str(self.dom) + '[' + ','.join(map(str, self.gens)) + ']'
+        s_order = str(self.order)
+        orderstr = (" order=" + s_order) if s_order != self.default_order else ""
+        return str(self.dom) + '[' + ','.join(map(str, self.gens)) + orderstr + ']'
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self.dtype, self.dom, self.gens))
+        return hash((self.__class__.__name__, self.dtype, self.dom,
+                     self.gens, self.order))
 
     def __call__(self, a):
         """Construct an element of `self` domain from `a`. """
-        return DMP(a, self.dom, len(self.gens)-1, ring=self)
+        return self.dtype(a, self.dom, len(self.gens)-1, ring=self)
 
     def __eq__(self, other):
         """Returns `True` if two domains are equivalent. """
-        if not isinstance(other, PolynomialRing):
+        if not isinstance(other, PolynomialRingBase):
             return False
-        return self.dtype == other.dtype and self.dom == other.dom and self.gens == other.gens
+        return self.dtype == other.dtype and self.dom == other.dom and \
+               self.gens == other.gens and self.order == other.order
 
     def __ne__(self, other):
         """Returns `False` if two domains are equivalent. """
         return not self.__eq__(other)
-
-    def to_sympy(self, a):
-        """Convert `a` to a SymPy object. """
-        return basic_from_dict(a.to_sympy_dict(), *self.gens)
-
-    def from_sympy(self, a):
-        """Convert SymPy's expression to `dtype`. """
-        try:
-            rep, _ = dict_from_basic(a, gens=self.gens)
-        except PolynomialError:
-            raise CoercionFailed("can't convert %s to type %s" % (a, self))
-
-        for k, v in rep.iteritems():
-            rep[k] = self.dom.from_sympy(v)
-
-        return self(rep)
 
     def from_ZZ_python(K1, a, K0):
         """Convert a Python `int` object to `dtype`. """
@@ -102,13 +104,13 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
         if K1.dom == K0:
             return K1(a)
 
-    def from_PolynomialRing(K1, a, K0):
+    def from_GlobalPolynomialRing(K1, a, K0):
         """Convert a `DMP` object to `dtype`. """
         if K1.gens == K0.gens:
             if K1.dom == K0.dom:
-                return a
+                return K1(a.rep) # set the correct ring
             else:
-                return a.convert(K1.dom)
+                return K1(a.convert(K1.dom).rep)
         else:
             monoms, coeffs = _dict_reorder(a.to_dict(), K0.gens, K1.gens)
 
@@ -116,6 +118,40 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
                 coeffs = [ K1.dom.convert(c, K0.dom) for c in coeffs ]
 
             return K1(dict(zip(monoms, coeffs)))
+
+    def get_field(self):
+        """Returns a field associated with `self`. """
+        return FractionField(self.dom, *self.gens)
+
+    def poly_ring(self, *gens):
+        """Returns a polynomial ring, i.e. `K[X]`. """
+        raise NotImplementedError('nested domains not allowed')
+
+    def frac_field(self, *gens):
+        """Returns a fraction field, i.e. `K(X)`. """
+        raise NotImplementedError('nested domains not allowed')
+
+    def gcdex(self, a, b):
+        """Extended GCD of `a` and `b`. """
+        return a.gcdex(b)
+
+    def gcd(self, a, b):
+        """Returns GCD of `a` and `b`. """
+        return a.gcd(b)
+
+    def lcm(self, a, b):
+        """Returns LCM of `a` and `b`. """
+        return a.lcm(b)
+
+    def factorial(self, a):
+        """Returns factorial of `a`. """
+        return self.dtype(self.dom.factorial(a))
+
+class GlobalPolynomialRing(PolynomialRingBase):
+    """A true polynomial ring, with objects DMP. """
+
+    is_Poly = True
+    dtype = DMP
 
     def from_FractionField(K1, a, K0):
         """
@@ -140,20 +176,23 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
 
         """
         if a.denom().is_one:
-            return K1.from_PolynomialRing(a.numer(), K0)
+            return K1.from_GlobalPolynomialRing(a.numer(), K0)
 
-    def get_field(self):
-        """Returns a field associated with `self`. """
-        from sympy.polys.domains import FractionField
-        return FractionField(self.dom, *self.gens)
+    def to_sympy(self, a):
+        """Convert `a` to a SymPy object. """
+        return basic_from_dict(a.to_sympy_dict(), *self.gens)
 
-    def poly_ring(self, *gens):
-        """Returns a polynomial ring, i.e. `K[X]`. """
-        raise NotImplementedError('nested domains not allowed')
+    def from_sympy(self, a):
+        """Convert SymPy's expression to `dtype`. """
+        try:
+            rep, _ = dict_from_basic(a, gens=self.gens)
+        except PolynomialError:
+            raise CoercionFailed("can't convert %s to type %s" % (a, self))
 
-    def frac_field(self, *gens):
-        """Returns a fraction field, i.e. `K(X)`. """
-        raise NotImplementedError('nested domains not allowed')
+        for k, v in rep.iteritems():
+            rep[k] = self.dom.from_sympy(v)
+
+        return self(rep)
 
     def is_positive(self, a):
         """Returns True if `LC(a)` is positive. """
@@ -171,18 +210,128 @@ class PolynomialRing(Ring, CharacteristicZero, CompositeDomain):
         """Returns True if `LC(a)` is non-negative. """
         return self.dom.is_nonnegative(a.LC())
 
-    def gcdex(self, a, b):
-        """Extended GCD of `a` and `b`. """
-        return a.gcdex(b)
+class GeneralizedPolynomialRing(PolynomialRingBase):
+    """A generalized polynomial ring, with objects DMF. """
 
-    def gcd(self, a, b):
-        """Returns GCD of `a` and `b`. """
-        return a.gcd(b)
+    dtype = DMF
 
-    def lcm(self, a, b):
-        """Returns LCM of `a` and `b`. """
-        return a.lcm(b)
+    def __call__(self, a):
+        """Construct an element of `self` domain from `a`. """
+        res = self.dtype(a, self.dom, len(self.gens)-1, ring=self)
 
-    def factorial(self, a):
-        """Returns factorial of `a`. """
-        return self.dtype(self.dom.factorial(a))
+        # make sure res is actually in our ring
+        if res.denom().terms(order=self.order)[0][0] != (0,)*len(self.gens):
+            from sympy.printing.str import sstr
+            raise CoercionFailed("denominator %s not allowed in %s" \
+                                  % (sstr(res), self))
+        return res
+
+    def __contains__(self, a):
+        try:
+            a = self.convert(a)
+        except CoercionFailed:
+            return False
+        return a.denom().terms(order=self.order)[0][0] == (0,)*len(self.gens)
+
+    def from_FractionField(K1, a, K0):
+        dmf = K1.get_field().from_FractionField(a, K0)
+        return K1((dmf.num, dmf.den))
+
+    def to_sympy(self, a):
+        """Convert `a` to a SymPy object. """
+        return (basic_from_dict(a.numer().to_sympy_dict(), *self.gens) /
+                basic_from_dict(a.denom().to_sympy_dict(), *self.gens))
+
+    def from_sympy(self, a):
+        """Convert SymPy's expression to `dtype`. """
+        p, q = a.as_numer_denom()
+
+        num, _ = dict_from_basic(p, gens=self.gens)
+        den, _ = dict_from_basic(q, gens=self.gens)
+
+        for k, v in num.iteritems():
+            num[k] = self.dom.from_sympy(v)
+
+        for k, v in den.iteritems():
+            den[k] = self.dom.from_sympy(v)
+
+        return self((num, den)).cancel()
+
+def PolynomialRing(dom, *gens, **opts):
+    """
+    Create a generalized multivariate polynomial ring.
+
+    A generalized polynomial ring is defined by a ground field `K`, a set
+    of generators (typically `x_1, \dots, x_n`) and a monomial order `<`.
+    The monomial order can be global, local or mixed. In any case it induces
+    a total ordering on the monomials, and there exists for every (non-zero)
+    polynomial `f \n K[x_1, \dots, x_n]` a well-defined "leading monomial"
+    `LM(f) = LM(f, >)`. One can then define a multiplicative subset
+    `S = S_> = \{f \in K[x_1, \dots, x_n] | LM(f) = 1\}`. The generalized
+    polynomial ring corresponding to the monomial order is
+    `R = S^{-1}K[x_1, \dots, x_n]`.
+
+    If `>` is a so-called global order, that is `1` is the smallest monomial,
+    then we just have `S = K` and `R = K[x_1, \dots, x_n]`.
+
+    Examples
+    ========
+
+    A few examples may make this clearer.
+
+    >>> from sympy.abc import x, y
+    >>> from sympy import QQ
+
+    Our first ring uses global lexicographic order.
+
+    >>> R1 = QQ.poly_ring(x, y, order=(("lex", x, y),))
+
+    The second ring uses local lexicographic order. Note that when using a
+    single (non-product) order, you can just specify the name and omit the
+    variables:
+
+    >>> R2 = QQ.poly_ring(x, y, order="ilex")
+
+    The third and fourth rings use a mixed orders:
+
+    >>> o1 = (("ilex", x), ("lex", y))
+    >>> o2 = (("lex", x), ("ilex", y))
+    >>> R3 = QQ.poly_ring(x, y, order=o1)
+    >>> R4 = QQ.poly_ring(x, y, order=o2)
+
+    We will investigate what elements of `K(x, y)` are contained in the various
+    rings.
+
+    >>> L = [x, 1/x, y/(1 + x), 1/(1 + y), 1/(1 + x*y)]
+    >>> test = lambda R: [f in R for f in L]
+
+    The first ring is just `K[x, y]`:
+    >>> test(R1)
+    [True, False, False, False, False]
+
+    The second ring is R1 localised at the maximal ideal (x, y):
+
+    >>> test(R2)
+    [True, False, True, True, True]
+
+    The third ring is R1 localised at the prime ideal (x):
+
+    >>> test(R3)
+    [True, False, True, False, True]
+
+    Finally the fourth ring is R1 localised at `S = K[x, y] \setminus yK[y]`:
+
+    >>> test(R4)
+    [True, False, False, True, False]
+    """
+
+    order = opts.get("order", GeneralizedPolynomialRing.default_order)
+    if iterable(order):
+        order = build_product_order(order, gens)
+    order = monomial_key(order)
+    opts['order'] = order
+
+    if order.is_global:
+        return GlobalPolynomialRing(dom, *gens, **opts)
+    else:
+        return GeneralizedPolynomialRing(dom, *gens, **opts)

--- a/sympy/polys/monomialtools.py
+++ b/sympy/polys/monomialtools.py
@@ -85,6 +85,7 @@ class MonomialOrder(object):
     """Base class for monomial orderings. """
 
     alias = None
+    is_global = None
 
     def key(self, monomial):
         raise NotImplementedError
@@ -99,6 +100,7 @@ class LexOrder(MonomialOrder):
     """Lexicographic order of monomials. """
 
     alias = 'lex'
+    is_global = True
 
     def key(self, monomial):
         return monomial
@@ -107,6 +109,7 @@ class GradedLexOrder(MonomialOrder):
     """Graded lexicographic order of monomials. """
 
     alias = 'grlex'
+    is_global = True
 
     def key(self, monomial):
         return (sum(monomial), monomial)
@@ -115,6 +118,7 @@ class ReversedGradedLexOrder(MonomialOrder):
     """Reversed graded lexicographic order of monomials. """
 
     alias = 'grevlex'
+    is_global = True
 
     def key(self, monomial):
         return (sum(monomial), tuple(reversed([-m for m in monomial])))
@@ -178,6 +182,14 @@ class ProductOrder(MonomialOrder):
             return False
         return self.args == other.args
 
+    @property
+    def is_global(self):
+        if all(o.is_global is True for o, _ in self.args):
+            return True
+        if all(o.is_global is False for o, _ in self.args):
+            return False
+        return None
+
 class InverseOrder(MonomialOrder):
     """
     The "inverse" of another monomial order.
@@ -210,6 +222,14 @@ class InverseOrder(MonomialOrder):
                 return tuple(inv(x) for x in l)
             return -l
         return inv(self.O.key(monomial))
+
+    @property
+    def is_global(self):
+        if self.O.is_global is True:
+            return False
+        if self.O.is_global is False:
+            return True
+        return None
 
 lex = LexOrder()
 grlex = GradedLexOrder()

--- a/sympy/polys/monomialtools.py
+++ b/sympy/polys/monomialtools.py
@@ -96,6 +96,15 @@ class MonomialOrder(object):
     def __call__(self, monomial):
         return self.key(monomial)
 
+    def __eq__(self, other):
+        return self.__class__ == other.__class__
+
+    def __hash__(self):
+        return hash(self.__class__)
+
+    def __ne__(self, other):
+        return not (self == other)
+
 class LexOrder(MonomialOrder):
     """Lexicographic order of monomials. """
 
@@ -182,6 +191,9 @@ class ProductOrder(MonomialOrder):
             return False
         return self.args == other.args
 
+    def __hash__(self):
+        return hash((self.__class__, self.args))
+
     @property
     def is_global(self):
         if all(o.is_global is True for o, _ in self.args):
@@ -230,6 +242,12 @@ class InverseOrder(MonomialOrder):
         if self.O.is_global is False:
             return True
         return None
+
+    def __eq__(self, other):
+        return isinstance(other, InverseOrder) and other.O == self.O
+
+    def __hash__(self, other):
+        return hash((self.__class__, self.O))
 
 lex = LexOrder()
 grlex = GradedLexOrder()

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -355,7 +355,7 @@ class DMP(PicklableWithSlots):
         >>> from sympy.polys.domains import ZZ
 
         >>> DMP([[[ZZ(1)]], [[ZZ(1)], [ZZ(2)]]], ZZ).exclude()
-        ([2], DMP([[1], [1, 2]], ZZ))
+        ([2], DMP([[1], [1, 2]], ZZ, None))
 
         """
         J, F, u = dmp_exclude(f.rep, f.lev, f.dom)
@@ -372,10 +372,10 @@ class DMP(PicklableWithSlots):
         >>> from sympy.polys.domains import ZZ
 
         >>> DMP([[[ZZ(2)], [ZZ(1), ZZ(0)]], [[]]], ZZ).permute([1, 0, 2])
-        DMP([[[2], []], [[1, 0], []]], ZZ)
+        DMP([[[2], []], [[1, 0], []]], ZZ, None)
 
         >>> DMP([[[ZZ(2)], [ZZ(1), ZZ(0)]], [[]]], ZZ).permute([1, 2, 0])
-        DMP([[[1], []], [[2, 0], []]], ZZ)
+        DMP([[[1], []], [[2, 0], []]], ZZ, None)
 
         """
         return f.per(dmp_permute(f.rep, P, f.lev, f.dom))

--- a/sympy/polys/tests/test_distributedmodules.py
+++ b/sympy/polys/tests/test_distributedmodules.py
@@ -171,3 +171,9 @@ def test_uncovered_line():
 
     assert sdm_spoly(f1, f2, lex, QQ) == sdm_zero()
     assert sdm_spoly(f3, f2, lex, QQ) == sdm_zero()
+
+def test_chain_criterion():
+    gens = [x]
+    f1 = sdm_from_vector([1, x], grlex, QQ, gens=gens)
+    f2 = sdm_from_vector([0, x - 2], grlex, QQ, gens=gens)
+    assert len(sdm_groebner([f1, f2], sdm_nf_mora, grlex, QQ)) == 2

--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -2,7 +2,7 @@
 
 from sympy.polys.monomialtools import (
     monomials, monomial_count,
-    monomial_key, lex, grlex, grevlex,
+    monomial_key, lex, grlex, grevlex, ilex, igrlex, igrevlex,
     monomial_mul, monomial_div,
     monomial_gcd, monomial_lcm,
     monomial_max, monomial_min,
@@ -50,6 +50,8 @@ def test_lex_order():
     assert lex((1,1,3)) < lex((1,2,3))
     assert lex((1,2,2)) < lex((1,2,3))
 
+    assert lex.is_global is True
+
 def test_grlex_order():
     assert grlex((1,2,3)) == (6, (1,2,3))
     assert str(grlex) == 'grlex'
@@ -69,6 +71,8 @@ def test_grlex_order():
 
     assert grlex((0,2,3)) < grlex((1,2,2))
     assert grlex((1,1,3)) < grlex((1,2,2))
+
+    assert grlex.is_global is True
 
 def test_grevlex_order():
     assert grevlex((1,2,3)) == (6, (-3,-2,-1))
@@ -93,6 +97,8 @@ def test_grevlex_order():
     assert grevlex((0,1,1)) > grevlex((0,0,2))
     assert grevlex((0,3,1)) < grevlex((2,2,1))
 
+    assert grevlex.is_global is True
+
 def test_InverseOrder():
     ilex = InverseOrder(lex)
     igrlex = InverseOrder(grlex)
@@ -101,11 +107,16 @@ def test_InverseOrder():
     assert igrlex((1, 2, 3)) < igrlex((0, 2, 3))
     assert str(ilex) == "ilex"
     assert str(igrlex) == "igrlex"
+    assert ilex.is_global is False
+    assert igrlex.is_global is False
 
 def test_ProductOrder():
     P = ProductOrder((grlex, lambda m: m[:2]), (grlex, lambda m: m[2:]))
     assert P((1, 3, 3, 4, 5)) > P((2, 1, 5, 5, 5))
     assert str(P) == "ProductOrder(grlex, grlex)"
+    assert P.is_global is True
+    assert ProductOrder((grlex, None), (ilex, None)).is_global is None
+    assert ProductOrder((igrlex, None), (ilex, None)).is_global is False
 
 def test_monomial_key():
     assert monomial_key() == lex

--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -8,7 +8,7 @@ from sympy.polys.monomialtools import (
     monomial_max, monomial_min,
     monomial_divides,
     Monomial,
-    InverseOrder, ProductOrder
+    InverseOrder, ProductOrder, build_product_order
 )
 
 from sympy.polys.polyerrors import ExactQuotientFailed
@@ -116,6 +116,14 @@ def test_monomial_key():
 
     raises(ValueError, lambda: monomial_key('foo'))
     raises(ValueError, lambda: monomial_key(1))
+
+def test_build_product_order():
+    from sympy.abc import x, y, z, t
+    assert build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t]) \
+        ((4, 5, 6, 7)) == ((9, (4, 5)), (13, (6, 7)))
+
+    assert build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t]) == \
+               build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t])
 
 def test_monomial_mul():
     assert monomial_mul((3,4,1), (1,2,0)) == (4,6,1)

--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -8,7 +8,8 @@ from sympy.polys.monomialtools import (
     monomial_max, monomial_min,
     monomial_divides,
     Monomial,
-    InverseOrder, ProductOrder, build_product_order
+    InverseOrder, ProductOrder, build_product_order,
+    LexOrder
 )
 
 from sympy.polys.polyerrors import ExactQuotientFailed
@@ -51,6 +52,8 @@ def test_lex_order():
     assert lex((1,2,2)) < lex((1,2,3))
 
     assert lex.is_global is True
+    assert lex == LexOrder()
+    assert lex != grlex
 
 def test_grlex_order():
     assert grlex((1,2,3)) == (6, (1,2,3))
@@ -109,6 +112,8 @@ def test_InverseOrder():
     assert str(igrlex) == "igrlex"
     assert ilex.is_global is False
     assert igrlex.is_global is False
+    assert ilex != igrlex
+    assert ilex == InverseOrder(LexOrder())
 
 def test_ProductOrder():
     P = ProductOrder((grlex, lambda m: m[:2]), (grlex, lambda m: m[2:]))
@@ -135,6 +140,9 @@ def test_build_product_order():
 
     assert build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t]) == \
                build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t])
+    assert (build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t]) != \
+               build_product_order((("grlex", x, y), ("grlex", z, t)), [x, y, z, t])) \
+           is False
 
 def test_monomial_mul():
     assert monomial_mul((3,4,1), (1,2,0)) == (4,6,1)

--- a/sympy/polys/tests/test_polynomialring.py
+++ b/sympy/polys/tests/test_polynomialring.py
@@ -24,7 +24,7 @@ def test_globalring():
     assert X.ring == R
     assert X * (Y**2 + 1) == R.convert(x * (y**2 + 1))
     assert X * y == X * Y == R.convert(x * y) == x * Y
-    assert X + y == X + Y == R.convert(x + y)
+    assert X + y == X + Y == R.convert(x + y) == x + Y
     assert X + 1 == R.convert(x + 1)
     raises(ExactQuotientFailed, 'X/Y')
     raises(ExactQuotientFailed, 'x/Y')
@@ -51,10 +51,18 @@ def test_localring():
     raises(ExactQuotientFailed, 'X/Y')
     raises(ExactQuotientFailed, 'x/Y')
     raises(ExactQuotientFailed, 'X/y')
-    assert X + y == X + Y == R.convert(x + y)
+    assert X + y == X + Y == R.convert(x + y) == x + Y
     assert X + 1 == R.convert(x + 1)
     assert X**2 / X == X
 
     assert R.from_GlobalPolynomialRing(ZZ[x, y].convert(x), ZZ[x, y]) == X
     assert R.from_FractionField(Qxy.convert(x), Qxy) == X
     raises(CoercionFailed, 'R.from_FractionField(Qxy.convert(x)/y, Qxy)')
+
+def test_conversion():
+    L = QQ.poly_ring(x, y, order="ilex")
+    G = QQ[x, y]
+
+    assert L.convert(x) == L.convert(G.convert(x), G)
+    assert G.convert(x) == G.convert(L.convert(x), L)
+    raises(CoercionFailed, 'G.convert(L.convert(1/(1+x)), L)')

--- a/sympy/polys/tests/test_polynomialring.py
+++ b/sympy/polys/tests/test_polynomialring.py
@@ -1,0 +1,55 @@
+"""Tests for the PolynomialRing classes. """
+
+from sympy.polys.domains import QQ, ZZ, PolynomialRing
+from sympy.polys.polyerrors import ExactQuotientFailed, CoercionFailed
+
+from sympy.abc import x, y
+
+from sympy.utilities.pytest import raises
+
+def test_build_order():
+    R = QQ.poly_ring(x, y, order=(("lex", x), ("ilex", y)))
+    assert R.order((1, 5)) == ((1,), (-5,))
+
+def test_globalring():
+    Qxy = QQ.frac_field(x, y)
+    R   = QQ[x, y]
+    X = R.convert(x)
+    Y = R.convert(y)
+
+    assert x in R
+    assert 1/x not in R
+    assert 1/(1 + x) not in R
+    assert Y in R
+    assert X.ring == R
+    assert X * (Y**2 + 1) == R.convert(x * (y**2 + 1))
+    assert X * y == X * Y == R.convert(x * y) == x * Y
+    assert X + y == X + Y == R.convert(x + y)
+    assert X + 1 == R.convert(x + 1)
+
+    assert R.from_GlobalPolynomialRing(ZZ[x, y].convert(x), ZZ[x, y]) == X
+    assert R.from_FractionField(Qxy.convert(x), Qxy) == X
+    assert R.from_FractionField(Qxy.convert(x)/y, Qxy) is None
+
+def test_localring():
+    Qxy = QQ.frac_field(x, y)
+    R   = QQ.poly_ring(x, y, order="ilex")
+    X = R.convert(x)
+    Y = R.convert(y)
+
+    assert x in R
+    assert 1/x not in R
+    assert 1/(1 + x) in R
+    assert Y in R
+    assert X.ring == R
+    assert X*(Y**2+1)/(1 + X) == R.convert(x*(y**2 + 1)/(1 + x))
+    assert X*y == X*Y
+    raises(ExactQuotientFailed, 'X/Y')
+    raises(ExactQuotientFailed, 'x/Y')
+    raises(ExactQuotientFailed, 'X/y')
+    assert X + y == X + Y == R.convert(x + y)
+    assert X + 1 == R.convert(x + 1)
+
+    assert R.from_GlobalPolynomialRing(ZZ[x, y].convert(x), ZZ[x, y]) == X
+    assert R.from_FractionField(Qxy.convert(x), Qxy) == X
+    raises(CoercionFailed, 'R.from_FractionField(Qxy.convert(x)/y, Qxy)')

--- a/sympy/polys/tests/test_polynomialring.py
+++ b/sympy/polys/tests/test_polynomialring.py
@@ -26,6 +26,10 @@ def test_globalring():
     assert X * y == X * Y == R.convert(x * y) == x * Y
     assert X + y == X + Y == R.convert(x + y)
     assert X + 1 == R.convert(x + 1)
+    raises(ExactQuotientFailed, 'X/Y')
+    raises(ExactQuotientFailed, 'x/Y')
+    raises(ExactQuotientFailed, 'X/y')
+    assert X**2 / X == X
 
     assert R.from_GlobalPolynomialRing(ZZ[x, y].convert(x), ZZ[x, y]) == X
     assert R.from_FractionField(Qxy.convert(x), Qxy) == X
@@ -49,6 +53,7 @@ def test_localring():
     raises(ExactQuotientFailed, 'X/y')
     assert X + y == X + Y == R.convert(x + y)
     assert X + 1 == R.convert(x + 1)
+    assert X**2 / X == X
 
     assert R.from_GlobalPolynomialRing(ZZ[x, y].convert(x), ZZ[x, y]) == X
     assert R.from_FractionField(Qxy.convert(x), Qxy) == X

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -7,6 +7,7 @@ from sympy.core.function import _coeff_isneg
 from printer import Printer
 from conventions import split_super_sub
 from sympy.simplify import fraction
+from sympy.core.sympify import SympifyError
 
 import sympy.mpmath.libmp as mlib
 from sympy.mpmath.libmp import prec_to_dps
@@ -1164,6 +1165,18 @@ class LatexPrinter(Printer):
 
     def _print_InverseCosineTransform(self, expr):
         return r"\mathcal{COS}^{-1}_{%s}\left[%s\right]\left(%s\right)" % (self._print(expr.args[1]), self._print(expr.args[0]), self._print(expr.args[2]))
+
+    def _print_DMP(self, p):
+        try:
+            if p.ring is not None:
+                # TODO incorporate order
+                return self._print(p.ring.to_sympy(p))
+        except SympifyError:
+            pass
+        return self._print(repr(p))
+
+    def _print_DMF(self, p):
+        return self._print_DMP(p)
 
 
 def latex(expr, **settings):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1084,10 +1084,13 @@ class LatexPrinter(Printer):
     def _print_ComplexDomain(self, expr):
         return r"\mathbb{C}"
 
-    def _print_PolynomialRing(self, expr):
+    def _print_PolynomialRingBase(self, expr):
         domain = self._print(expr.dom)
         gens = ", ".join(map(self._print, expr.gens))
-        return r"%s\left\[%s\right\]" % (domain, gens)
+        inv = ""
+        if not expr.is_Poly:
+            inv = r"S_<^{-1}"
+        return r"%s%s\left[%s\right]" % (inv, domain, gens)
 
     def _print_FractionField(self, expr):
         domain = self._print(expr.dom)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1334,8 +1334,11 @@ class PrettyPrinter(Printer):
         else:
             return prettyForm('CC')
 
-    def _print_PolynomialRing(self, expr):
-        pform = self._print_seq(expr.gens, '[', ']')
+    def _print_PolynomialRingBase(self, expr):
+        g = expr.gens
+        if str(expr.order) != str(expr.default_order):
+            g = g + ("order=" + str(expr.order),)
+        pform = self._print_seq(g, '[', ']')
         pform = prettyForm(*pform.left(self._print(expr.dom)))
 
         return pform

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1,6 +1,7 @@
 from sympy.core import S, C, Basic, Interval
 from sympy.core.function import _coeff_isneg
 from sympy.utilities import group
+from sympy.core.sympify import SympifyError
 
 from sympy.printing.printer import Printer
 from sympy.printing.str import sstr
@@ -1429,6 +1430,18 @@ class PrettyPrinter(Printer):
                 return pform
             except:
                 return self._print(None)
+
+    def _print_DMP(self, p):
+        try:
+            if p.ring is not None:
+                # TODO incorporate order
+                return self._print(p.ring.to_sympy(p))
+        except SympifyError:
+            pass
+        return self._print(repr(p))
+
+    def _print_DMF(self, p):
+        return self._print_DMP(p)
 
 def pretty(expr, **settings):
     """Returns a string containing the prettified form of expr.

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2672,6 +2672,16 @@ def test_pretty_Domain():
     assert  pretty(expr) == "ZZ(x, y)"
     assert upretty(expr) == u"ℤ(x, y)"
 
+    expr = QQ.poly_ring(x, y, order="lex")
+
+    assert  pretty(expr) == "QQ[x, y, order=lex]"
+    assert upretty(expr) == u"ℚ[x, y, order=lex]"
+
+    expr = QQ.poly_ring(x, y, order="ilex")
+
+    assert  pretty(expr) == "QQ[x, y, order=ilex]"
+    assert upretty(expr) == u"ℚ[x, y, order=ilex]"
+
 def test_pretty_prec():
     assert xpretty(S("0.3"), full_prec=True) == "0.300000000000000"
     assert xpretty(S("0.3"), full_prec="auto") == "0.300000000000000"

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3662,6 +3662,18 @@ def test_RandomDomain():
     B = Exponential(1, symbol=Symbol('b'))
     assert upretty(pspace(Tuple(A,B)).domain) ==u'Domain: 0 ≤ a ∧ 0 ≤ b'
 
+def test_PrettyPoly():
+    F = QQ.frac_field(x, y)
+    R = QQ[x, y]
+
+    expr = F.convert(x/(x + y))
+    assert pretty(expr) == pretty(x/(x + y))
+    assert upretty(expr) == upretty(x/(x + y))
+
+    expr = R.convert(x + y)
+    assert pretty(expr) == pretty(x + y)
+    assert upretty(expr) == upretty(x + y)
+
 def test_issue_3186():
     assert pretty(Pow(2, -5, evaluate=False)) == '1 \n--\n 5\n2 '
     assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -418,21 +418,6 @@ class StrPrinter(Printer):
                            expr.rel_op,
                            self.parenthesize(expr.rhs, precedence(expr)))
 
-    def _print_DMP(self, expr):
-        cls = expr.__class__.__name__
-        rep = self._print(expr.rep)
-        dom = self._print(expr.dom)
-
-        return "%s(%s, %s)" % (cls, rep, dom)
-
-    def _print_DMF(self, expr):
-        cls = expr.__class__.__name__
-        num = self._print(expr.num)
-        den = self._print(expr.den)
-        dom = self._print(expr.dom)
-
-        return "%s((%s, %s), %s)" % (cls, num, den, dom)
-
     def _print_RootOf(self, expr):
         return "RootOf(%s, %d)" % (self._print_Add(expr.expr, order='lex'), expr.index)
 
@@ -521,6 +506,26 @@ class StrPrinter(Printer):
 
     def _print_Zero(self, expr):
         return "0"
+
+    def _print_DMP(self, p):
+        from sympy.core.sympify import SympifyError
+        try:
+            if p.ring is not None:
+                # TODO incorporate order
+                return self._print(p.ring.to_sympy(p))
+        except SympifyError:
+            pass
+
+        cls = p.__class__.__name__
+        rep = self._print(p.rep)
+        dom = self._print(p.dom)
+        ring = self._print(p.ring)
+
+        return "%s(%s, %s, %s)" % (cls, rep, dom, ring)
+
+    def _print_DMF(self, expr):
+        return self._print_DMP(expr)
+
 
 
 def sstr(expr, **settings):

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -534,6 +534,14 @@ def test_latex_RandomDomain():
     B = Exponential(1, symbol=Symbol('b'))
     assert latex(pspace(Tuple(A,B)).domain) =="Domain: 0 \leq a \wedge 0 \leq b"
 
+def test_PrettyPoly():
+    from sympy.polys.domains import QQ
+    F = QQ.frac_field(x, y)
+    R = QQ[x, y]
+
+    assert latex(F.convert(x/(x + y))) == latex(x/(x + y))
+    assert latex(R.convert(x + y)) == latex(x + y)
+
 def test_integral_transforms():
     x = Symbol("x")
     k = Symbol("k")

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -563,3 +563,9 @@ def test_integral_transforms():
 
     assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[\operatorname{f}{\left (x \right )}\right]\left(k\right)"
     assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[\operatorname{f}{\left (k \right )}\right]\left(x\right)"
+
+def test_PolynomialRing():
+    from sympy.polys.domains import QQ
+    assert latex(QQ[x, y]) == r"\mathbb{Q}\left[x, y\right]"
+    assert latex(QQ.poly_ring(x, y, order="ilex")) == \
+            r"S_<^{-1}\mathbb{Q}\left[x, y\right]"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -464,3 +464,10 @@ def test_RandomDomain():
 def test_FiniteSet():
     assert str(FiniteSet(range(1, 51))) == '{1, 2, 3, ..., 48, 49, 50}'
     assert str(FiniteSet(range(1, 6))) == '{1, 2, 3, 4, 5}'
+
+def test_PrettyPoly():
+    from sympy.polys.domains import QQ
+    F = QQ.frac_field(x, y)
+    R = QQ[x, y]
+    assert sstr(F.convert(x/(x + y))) == sstr(x/(x + y))
+    assert sstr(R.convert(x + y)) == sstr(x + y)


### PR DESCRIPTION
This PR is meant to be a start in a series of pull requests implementing basic commutative algebra using Groebner bases. It builds on my previous one (groebner bases for modules), but only the new monomial orders are used. Thus the first five commits are not technically part of this PR.

This PR implements very little actual content. There are two main commits ("beef up DMP" and "Implement Generalized poly rings") and a few smaller ones I separated out. The first one extends the `polys.DMP` and `polys.DMF` classes to carry an optional reference to a containing ring. This information is used mainly for two purposes: automatic coercion and pretty printing. The second main commit extends the PolynomialRing class, please refer to the commit message for more details.

All commits include tests where appropriate, except that "functionality tests" for the first main commit are only added in the second one, since it seemed more natural to tests the two together.
