### PR TITLE
Allow keyword arguments to Matrix.subs().

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -382,12 +382,12 @@ class MatrixBase(object):
                 map(lambda i: i.expand(**hints), self.mat))
         return out
 
-    def subs(self, *args):
+    def subs(self, *args, **kwargs):
         """
         Create substituted expressions for each element with `Expr.subs`.
         """
         out = self._new(self.rows, self.cols,
-                map(lambda i: i.subs(*args),self.mat))
+                map(lambda i: i.subs(*args, **kwargs), self.mat))
         return out
 
     def __sub__(self,a):

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -27,6 +27,8 @@ def test_subs():
     assert C.subs([[x,-1],[y,-2]]) == A
     assert C.subs([(x,-1),(y,-2)]) == A
     assert C.subs({x:-1,y:-2}) == A
+    assert C.subs({x:y-1, y:x-1}, simultaneous=True) == \
+        ImmutableMatrix([[1-y, (x-1)*(y-1)], [2-x-y, (x-1)**2]])
 
 def test_as_immutable():
     X = Matrix([[1,2], [3,4]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1005,6 +1005,8 @@ def test_subs():
         Matrix([[-1,2],[-3,4]])
     assert Matrix([[x,2],[x+y,4]]).subs({x:-1,y:-2}) == \
         Matrix([[-1,2],[-3,4]])
+    assert Matrix([x*y]).subs({x:y-1, y:x-1}, simultaneous=True) == \
+        Matrix([(x-1)*(y-1)])
 
 def test_simplify():
     x,y,f,n = symbols('x y f n')


### PR DESCRIPTION
Fixes Issue 3217: simultaneous substitution for matrices
