### PR TITLE
To compute limits of e.is_Pow and resolve issue id #2455

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -92,7 +92,7 @@ def limit(e, z, z0, dir="+"):
         if ex.is_number:
             if c is None:
                 base = b.subs(z, z0)
-                if base.is_bounded and (ex.is_bounded or base is not S.One):
+                if base.is_finite and (ex.is_bounded or base is not S.One):
                     return base**ex
             else:
                 if z0 == 0 and ex < 0:

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -33,6 +33,22 @@ def test_basic1():
     assert limit(gamma(1/x + 3), x, oo) == 2
     assert limit(S.NaN, x, -oo) == S.NaN
     assert limit(Order(2)*x, x, S.NaN) == S.NaN
+    assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))
+    assert limit(gamma(1/x + 3), x, oo) == 2
+    assert limit(S.NaN, x, -oo) == S.NaN
+    assert limit(Order(2)*x, x, S.NaN) == S.NaN
+    assert limit(1/(x-1), x, 1, dir="+") == oo
+    assert limit(1/(x-1), x, 1, dir="-") == -oo
+    assert limit(1/(5-x)**3, x, 5, dir="+") == -oo
+    assert limit(1/(5-x)**3, x, 5, dir="-") == oo
+    assert limit(1/sin(x), x, pi, dir="+") == -oo
+    assert limit(1/sin(x), x, pi, dir="-") == oo
+    assert limit(1/cos(x), x, pi/2, dir="+") == -oo
+    assert limit(1/cos(x), x, pi/2, dir="-") == oo
+    assert limit(1/tan(x**3), x, (2*pi)**(S(1)/3), dir="+") == oo
+    assert limit(1/tan(x**3), x, (2*pi)**(S(1)/3), dir="-") == -oo
+    assert limit(1/cot(x)**3, x, (3*pi/2), dir="+") == -oo
+    assert limit(1/cot(x)**3, x, (3*pi/2), dir="-") == oo
 
     # approaching 0
     # from dir="+"


### PR DESCRIPTION
For the limits of the form, limit(1/(x-a)^b, x, a, dir="+/-") and limit(1/(a-x)^b, x, a, dir="+/-") and also limit(1/sin(x^a)^b, x, x0, dir="+/-") , limit(1/cos(x^a)^b, x, x0, dir="+/-") , limit(1/tan(x^a)^b, x, x0, dir="+/-") and limit(1/cot(x^a)^b, x, x0, dir="+/-") shows wrong results when (x0)**a is an integral multiple of pi or pi/2, depending upon where the denominator goes to zero, the answer obtained by finding through current code is wrong.
This patch gives the accurate results.
Necessary test cases are also attached.
