### PR TITLE
2977: Tuple should introspect better on sorting.

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -82,6 +82,14 @@ class Tuple(Basic):
 
     def __lt__(self, other):
         return self.args < other.args
+    def __le__(self, other):
+        return self.args <= other.args
+	
+    def __gt__(self, other):
+        return self.args > other.args
+		
+    def __ge__(self, other):
+        return self.args >= other.args
 
 converter[tuple] = lambda tup: Tuple(*tup)
 


### PR DESCRIPTION
Before

> > > sorted([Tuple(1,2),Tuple(1,-2)])
> > > [(1, 2), (1, -2)]
> > > vs
> > > sorted([tuple([1,2]),tuple([1,-2])])
> > > [(1, -2), (1, 2)]

Now

> > > sorted([Tuple(1,2),Tuple(1,-2)])
> > > [(1, -2), (1, 2)]
