### PR TITLE
sympify could/should ignore newlines:fixed issue 3218

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -155,6 +155,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     from sympy.parsing.sympy_parser import parse_expr, TokenError
 
     try:
+        a = a.replace('\n', '')
         expr = parse_expr(a, locals or {}, rational, convert_xor)
     except (TokenError, SyntaxError):
         raise SympifyError('could not parse %r' % a)

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -370,6 +370,9 @@ def test_issue1689():
 def test_issue1699_None():
     assert S(None) is None
 
+def test_issue3218():
+    assert sympify("x+\ny") == x + y
+
 def test_issue1889_builtins():
     C = Symbol('C')
     vars = {}


### PR DESCRIPTION
sympify("x+\ny") == x + y
