### PR TITLE
Added test for parallel axis in mechanics

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -96,22 +96,38 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
     ol += sympify(izz) * (frame.z | frame.z)
     return ol
 
-def inertia_of_point_mass(m, p, frame):
+def inertia_of_point_mass(mass, pos_vec, frame):
     """Determine the Inertia dyadic of a particle.
 
-    Input:
-        m:  Mass
-        p:  Position from point O to mass m
-        F:  Reference frame to express the dyad entries with respect to.
+    Inertia Dyadic relative to O of a point mass m, located relative
+    to the point O by the position vector p.
 
-    Output:
-        Inertia Dyadic relative to O of a particle of mass m, located relative
-        to the point O by the position vector p.
+    Parameters
+    ==========
+
+    mass : Sympifyable
+        Mass of the point mass
+    pos_vec : Vector
+        Position from point O to point mass
+    frame : ReferenceFrame
+        Reference frame to express the dyad entries with respect to.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols
+    >>> from sympy.physics.mechanics import ReferenceFrame, inertia_of_point_mass
+    >>> N = ReferenceFrame('N')
+    >>> r, m = symbols('r m')
+    >>> px = r * N.x
+    >>> inertia_of_point_mass(m, px, N)
+    m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
 
     """
-    return m * (((frame.x | frame.x) + (frame.y | frame.y) + (frame.z | frame.z)) *
-                              (p & p) - (p | p))
-    
+
+    return mass * (((frame.x | frame.x) + (frame.y | frame.y) +
+                   (frame.z | frame.z)) * (pos_vec & pos_vec) -
+                   (pos_vec | pos_vec))
 
 def mechanics_printing():
     """Sets up interactive printing for mechanics' derivatives.

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -97,10 +97,7 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
     return ol
 
 def inertia_of_point_mass(mass, pos_vec, frame):
-    """Determine the Inertia dyadic of a particle.
-
-    Inertia Dyadic relative to O of a point mass m, located relative
-    to the point O by the position vector p.
+    """Inertia dyadic of a point mass realtive to point O.
 
     Parameters
     ==========
@@ -110,7 +107,7 @@ def inertia_of_point_mass(mass, pos_vec, frame):
     pos_vec : Vector
         Position from point O to point mass
     frame : ReferenceFrame
-        Reference frame to express the dyad entries with respect to.
+        Reference frame to express the dyadic in
 
     Examples
     ========

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -7,7 +7,8 @@ __all__ = ['cross',
            'mprint',
            'mpprint',
            'mlatex',
-           'kinematic_equations']
+           'kinematic_equations',
+           'inertia_of_point_mass']
 
 from sympy.physics.mechanics.essential import (Vector, Dyadic, ReferenceFrame,
                                                MechanicsStrPrinter,
@@ -94,6 +95,23 @@ def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):
     ol += sympify(iyz) * (frame.z | frame.y)
     ol += sympify(izz) * (frame.z | frame.z)
     return ol
+
+def inertia_of_point_mass(m, p, frame):
+    """Determine the Inertia dyadic of a particle.
+
+    Input:
+        m:  Mass
+        p:  Position from point O to mass m
+        F:  Reference frame to express the dyad entries with respect to.
+
+    Output:
+        Inertia Dyadic relative to O of a particle of mass m, located relative
+        to the point O by the position vector p.
+
+    """
+    return m * (((frame.x | frame.x) + (frame.y | frame.y) + (frame.z | frame.z)) *
+                              (p & p) - (p | p))
+    
 
 def mechanics_printing():
     """Sets up interactive printing for mechanics' derivatives.
@@ -365,4 +383,6 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
         return list(edots.T - 0.5 * w.T * E.T)
     else:
         raise ValueError('Not an approved rotation type for this function')
+
+
 

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -6,6 +6,7 @@ from sympy.physics.mechanics.essential import ReferenceFrame, dynamicsymbols
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.point import Point
 from sympy.physics.mechanics.rigidbody import RigidBody
+from sympy.physics.mechanics.functions import inertia_of_point_mass
 
 class Kane(object):
     """Kane's method object.
@@ -470,8 +471,7 @@ class Kane(object):
                     # I S/O = I S/S* + I S*/O; I S/S* = I S/O - I S*/O
                     f = v.frame
                     d = v.mc.pos_from(P)
-                    I -= m * (((f.x | f.x) + (f.y | f.y) + (f.z | f.z)) *
-                              (d & d) - (d | d))
+                    I -= inertia_of_point_mass(m, d, f)
                 templist = []
                 # One could think of r star as a collection of coefficients of
                 # the udots plus another term. What we do here is get all of

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -468,10 +468,6 @@ class Kane(object):
                     # redefine I about mass center
                     # have I S/O, want I S/S*
                     # I S/O = I S/S* + I S*/O; I S/S* = I S/O - I S*/O
-
-                    # This block of code needs to have a test written for it
-                    print('This functionality has not yet been tested yet, '
-                          'use at your own risk.')
                     f = v.frame
                     d = v.mc.pos_from(P)
                     I -= m * (((f.x | f.x) + (f.y | f.y) + (f.z | f.z)) *

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -1,7 +1,8 @@
 from sympy import symbols, sin, cos
 from sympy.physics.mechanics import (cross, dot, dynamicsymbols, express,
                                      ReferenceFrame, inertia,
-                                     kinematic_equations, Vector)
+                                     kinematic_equations, Vector,
+                                     inertia_of_point_mass)
 
 Vector.simp = True
 q1, q2, q3, q4, q5 = symbols('q1 q2 q3 q4 q5')
@@ -256,21 +257,25 @@ def test_inertia_of_point_mass():
 
     px = r * N.x
     I = inertia_of_point_mass(m, px, N)
-    assert I == m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
+    assert I == m * r**2 * (N.y | N.y) + m * r**2 * (N.z | N.z)
 
     py = s * N.y
     I = inertia_of_point_mass(m, py, N)
-    assert I == m*s**2*(N.x|N.x) + m*s**2*(N.z|N.z)
+    assert I == m * s**2 * (N.x | N.x) + m * s**2 * (N.z | N.z)
 
     pz = t * N.z
     I = inertia_of_point_mass(m, pz, N)
-    assert I == m * t**2 * (N.x|N.x) + m * t**2 * (N.y|N.y)
+    assert I == m * t**2 * (N.x | N.x) + m * t**2 * (N.y | N.y)
 
     p = px + py + pz
     I = inertia_of_point_mass(m, p, N)
-    assert I == (m * s**2 + m * t**2) * (N.x|N.x) - m * r * s * (N.x|N.y) \
-		- m* r * t * (N.x|N.z) - m * r * s * (N.y|N.x) \
-		+ (m * r**2 + m * t**2) * (N.y|N.y) - m * s * t * (N.y|N.z) \
-		- m * r * t * (N.z|N.x) - m * s * t * (N.z|N.y) \
-		+ (m * r**2 + m * s**2) * (N.z|N.z)
+    assert I == (m * (s**2 + t**2) * (N.x | N.x) -
+                 m * r * s * (N.x | N.y) -
+                 m * r * t * (N.x | N.z) -
+                 m * r * s * (N.y | N.x) +
+                 m * (r**2 + t**2) * (N.y | N.y) -
+                 m * s * t * (N.y | N.z) -
+                 m * r * t * (N.z | N.x) -
+                 m * s * t * (N.z | N.y) +
+                 m * (r**2 + s**2) * (N.z | N.z))
 

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -249,3 +249,28 @@ def test_kin_eqs():
             -0.5 * q0 * u2 + 0.5 * q1 * u3 - 0.5 * q3 * u1 + q2d,
             -0.5 * q0 * u3 - 0.5 * q1 * u2 + 0.5 * q2 * u1 + q3d,
             0.5 * q1 * u1 + 0.5 * q2 * u2 + 0.5 * q3 * u3 + q0d]
+
+def test_inertia_of_point_mass():
+    r, s, t, m = symbols('r s t m')
+    N = ReferenceFrame('N')
+
+    px = r * N.x
+    I = inertia_of_point_mass(m, px, N)
+    assert I == m*r**2*(N.y|N.y) + m*r**2*(N.z|N.z)
+
+    py = s * N.y
+    I = inertia_of_point_mass(m, py, N)
+    assert I == m*s**2*(N.x|N.x) + m*s**2*(N.z|N.z)
+
+    pz = t * N.z
+    I = inertia_of_point_mass(m, pz, N)
+    assert I == m * t**2 * (N.x|N.x) + m * t**2 * (N.y|N.y)
+
+    p = px + py + pz
+    I = inertia_of_point_mass(m, p, N)
+    assert I == (m * s**2 + m * t**2) * (N.x|N.x) - m * r * s * (N.x|N.y) \
+		- m* r * t * (N.x|N.z) - m * r * s * (N.y|N.x) \
+		+ (m * r**2 + m * t**2) * (N.y|N.y) - m * s * t * (N.y|N.z) \
+		- m * r * t * (N.z|N.x) - m * s * t * (N.z|N.y) \
+		+ (m * r**2 + m * s**2) * (N.z|N.z)
+

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -212,8 +212,8 @@ def test_aux():
 
 def test_parallel_axis():
     # This is for a 2 dof inverted pendulum on a cart.
-    # This test the parallel axis code in Kane.
-    ## Defining the constants and knowns of the system 
+    # This tests the parallel axis code in Kane. The inertia of the pendulum is defined about the cart, not about the mass center.
+    ## Defining the constants and knowns of the system
     gravity        = symbols('g')
     k, ls          = symbols('k ls')
     a, mA, mC      = symbols('a mA mC')
@@ -242,9 +242,8 @@ def test_parallel_axis():
 
     ## Defining velocities of the points
     O.set_vel(N, 0)
-    C.set_vel(N, u1*N.x)
-    Ao.v2pt_theory(C , N , A)
-       
+    C.set_vel(N, u1 * N.x)
+    Ao.v2pt_theory(C, N, A)
     Cart     = Particle('Cart', C, mC)
     Pendulum = RigidBody('Pendulum', Ao, A, mA, (inertia(A, Ix, Iy, Iz), C))
 

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -213,7 +213,7 @@ def test_aux():
 def test_parallel_axis():
     # This is for a 2 dof inverted pendulum on a cart.
     # This tests the parallel axis code in Kane. The inertia of the pendulum is
-    # defined about the cart, not about the mass center.
+    # defined about the hinge, not about the mass center.
 
     # Defining the constants and knowns of the system
     gravity        = symbols('g')

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -212,42 +212,44 @@ def test_aux():
 
 def test_parallel_axis():
     # This is for a 2 dof inverted pendulum on a cart.
-    # This tests the parallel axis code in Kane. The inertia of the pendulum is defined about the cart, not about the mass center.
-    ## Defining the constants and knowns of the system
+    # This tests the parallel axis code in Kane. The inertia of the pendulum is
+    # defined about the cart, not about the mass center.
+
+    # Defining the constants and knowns of the system
     gravity        = symbols('g')
     k, ls          = symbols('k ls')
     a, mA, mC      = symbols('a mA mC')
     F              = dynamicsymbols('F')
     Ix, Iy, Iz     = symbols('Ix Iy Iz')
 
-    ## Declaring the Generalized coordinates and speeds
+    # Declaring the Generalized coordinates and speeds
     q1, q2   = dynamicsymbols('q1 q2')
     q1d, q2d = dynamicsymbols('q1 q2', 1)
     u1, u2   = dynamicsymbols('u1 u2')
     u1d, u2d = dynamicsymbols('u1 u2', 1)
 
-    ## Creating reference frames
+    # Creating reference frames
     N = ReferenceFrame('N')
     A = ReferenceFrame('A')
 
     A.orient(N, 'Axis', [-q2, N.z])
     A.set_ang_vel(N, -u2 * N.z)
 
-    ## Origin of Newtonian reference frame
+    # Origin of Newtonian reference frame
     O = Point('O')
 
-    ## Creating and Locating the positions of the cart,C, and mass center of the pendulum, A
+    # Creating and Locating the positions of the cart,C, and mass center of the pendulum, A
     C  = O.locatenew('C',  q1 * N.x)
     Ao = C.locatenew('Ao', a * A.y)
 
-    ## Defining velocities of the points
+    # Defining velocities of the points
     O.set_vel(N, 0)
     C.set_vel(N, u1 * N.x)
     Ao.v2pt_theory(C, N, A)
     Cart     = Particle('Cart', C, mC)
     Pendulum = RigidBody('Pendulum', Ao, A, mA, (inertia(A, Ix, Iy, Iz), C))
 
-    ## kinematical differential equations
+    # kinematical differential equations
 
     kindiffs  = [q1d - u1, q2d - u2]
 
@@ -263,7 +265,5 @@ def test_parallel_axis():
     km.speeds([u1, u2])
     km.kindiffeq(kindiffs)
     (fr,frstar) = km.kanes_equations(forceList, bodyList)
-    kdd = km.kindiffdict()
-    zero = fr + frstar
     mm = km.mass_matrix_full
     assert mm[3, 3] == -Iz

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -209,3 +209,62 @@ def test_aux():
 
     assert fr.expand() == fr2.expand()
     assert frstar.expand() == frstar2.expand()
+
+def test_parallel_axis():
+    # This is for a 2 dof inverted pendulum on a cart.
+    # This test the parallel axis code in Kane.
+    ## Defining the constants and knowns of the system 
+    gravity        = symbols('g')
+    k, ls          = symbols('k ls')
+    a, mA, mC      = symbols('a mA mC')
+    F              = dynamicsymbols('F')
+    Ix, Iy, Iz     = symbols('Ix Iy Iz')
+
+    ## Declaring the Generalized coordinates and speeds
+    q1, q2   = dynamicsymbols('q1 q2')
+    q1d, q2d = dynamicsymbols('q1 q2', 1)
+    u1, u2   = dynamicsymbols('u1 u2')
+    u1d, u2d = dynamicsymbols('u1 u2', 1)
+
+    ## Creating reference frames
+    N = ReferenceFrame('N')
+    A = ReferenceFrame('A')
+
+    A.orient(N, 'Axis', [-q2, N.z])
+    A.set_ang_vel(N, -u2 * N.z)
+
+    ## Origin of Newtonian reference frame
+    O = Point('O')
+
+    ## Creating and Locating the positions of the cart,C, and mass center of the pendulum, A
+    C  = O.locatenew('C',  q1 * N.x)
+    Ao = C.locatenew('Ao', a * A.y)
+
+    ## Defining velocities of the points
+    O.set_vel(N, 0)
+    C.set_vel(N, u1*N.x)
+    Ao.v2pt_theory(C , N , A)
+       
+    Cart     = Particle('Cart', C, mC)
+    Pendulum = RigidBody('Pendulum', Ao, A, mA, (inertia(A, Ix, Iy, Iz), C))
+
+    ## kinematical differential equations
+
+    kindiffs  = [q1d - u1, q2d - u2]
+
+    bodyList  = [Cart, Pendulum]
+
+    forceList = [(Ao, -N.y * gravity * mA),
+                 (C,  -N.y * gravity * mC),
+                 (C,  -N.x * k * (q1 - ls)),
+                 (C,   N.x * F)]
+
+    km=Kane(N)
+    km.coords([q1, q2])
+    km.speeds([u1, u2])
+    km.kindiffeq(kindiffs)
+    (fr,frstar) = km.kanes_equations(forceList, bodyList)
+    kdd = km.kindiffdict()
+    zero = fr + frstar
+    mm = km.mass_matrix_full
+    assert mm[3, 3] == -Iz


### PR DESCRIPTION
Turned off the warning message for parallel axis in kane.py and wrote a
test for the parallel axis theorem for an inverted pendulum on a cart.
