### PR TITLE
Fix to issue 3206 - Abs should denest

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -327,6 +327,8 @@ class Abs(Function):
             return S.NaN
         if arg.is_zero:#equals(0):
             return arg
+        if isinstance(arg,Abs):
+            return apply(Abs, arg.args)
         if arg.is_positive:
             return arg
         if arg.is_negative:


### PR DESCRIPTION
This should fix the problem when Abs() is called with another Abs() as parameter
If you enter Abs(Abs(x)) it would return Abs(Abs(x)). With the fix Abs(Abs(x)) will return Abs(x)
