### PR TITLE
gaussopt module patch

### DIFF
--- a/sympy/physics/gaussopt.py
+++ b/sympy/physics/gaussopt.py
@@ -17,11 +17,6 @@ The conventions for the distances are as follows:
 from sympy import (atan2, cos, Expr, I, im, Matrix, oo, pi, re, sqrt, sympify,
     together, symbols)
 from sympy.utilities.misc import filldedent
-from sympy import Plot
-from sympy.external import import_module
-from sympy.core.compatibility import is_sequence
-from numpy import arange, empty
-# sample = import_module('sympy.examples.intermidiate.sample')
 
 ###
 # A, B, C, D matrices


### PR DESCRIPTION
Realization of plotting the gaussian beam propagation (and some functionality like single angle prism) 

Added the beam_plot and beam_plot2 utilities (one of TODO tasks) for plotting gaussian beam propagation (waist parameter). They are helpful in understanding of beam parameters and its behaviour in space.The first utility uses pyglet (this method appears to be not convenient and unstable for such purpose), the second uses matplotlib (looks good and works stable).
Also added BeamExpansionFactor class [1] and SingleRightAnglePrism class, which uses the first. Features concerning prisms can be implemented via these basic classes.
1. (http://www.springerlink.com/content/b048n408137185p2/)  

The patch was revised. 
The discussion on "gaussopt module patch" is opened in new pull request https://github.com/sympy/sympy/pull/1226
