### PR TITLE
Improve results of Q.algebraic queries

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -419,6 +419,11 @@ class AskAlgebraicHandler(CommonHandler):
         return test_closed_group(expr, assumptions, Q.algebraic)
 
     @staticmethod
+    def exp(expr, assumptions):
+        if ask(Q.algebraic(expr.exp), assumptions):
+            return False
+
+    @staticmethod
     def Mul(expr, assumptions):
         return test_closed_group(expr, assumptions, Q.algebraic)
 
@@ -441,6 +446,18 @@ class AskAlgebraicHandler(CommonHandler):
     @staticmethod
     def AlgebraicNumber(expr, assumptions):
         return True
+
+    @staticmethod
+    def Exp1(expr, assumptions):
+        return False
+
+    @staticmethod
+    def GoldenRatio(expr, assumptions):
+        return True
+
+    @staticmethod
+    def Pi(sympy, assumptions):
+        return False
 
 #### Helper methods
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -125,6 +125,11 @@ class AskRationalHandler(CommonHandler):
     Mul = Add
 
     @staticmethod
+    def exp(expr, assumptions):
+        if ask(Q.algebraic(expr.exp), assumptions):
+            return False
+
+    @staticmethod
     def Pow(expr, assumptions):
         """
         Rational ** Integer      -> Rational
@@ -145,6 +150,10 @@ class AskRationalHandler(CommonHandler):
     def Float(expr, assumptions):
         # it's finite-precision
         return True
+
+    @staticmethod
+    def GoldenRatio(expr, assumptions):
+        return False
 
     @staticmethod
     def ImaginaryUnit(expr, assumptions):
@@ -432,10 +441,14 @@ class AskAlgebraicHandler(CommonHandler):
         if ask(Q.algebraic(expr.exp), assumptions) and ask(Q.algebraic(expr.base), assumptions):
             if not ask(Q.rational(expr.exp), assumptions):
                 return False
-            elif ask(Q.rational(expr.base), assumptions):
+            else:
                 return True
-        elif (not ask(Q.algebraic(expr.base), assumptions)) and ask(Q.rational(expr.exp), assumptions):
+        elif ask(Q.algebraic(expr.base), assumptions) == False and ask(Q.rational(expr.exp), assumptions):
             return False
+
+    @staticmethod
+    def Float(expr, assumptions):
+        return ask(Q.rational(expr))
 
     @staticmethod
     def Number(expr, assumptions):

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -444,10 +444,6 @@ class AskAlgebraicHandler(CommonHandler):
         return True
 
     @staticmethod
-    def AlgebraicNumber(expr, assumptions):
-        return True
-
-    @staticmethod
     def Exp1(expr, assumptions):
         return False
 
@@ -458,6 +454,10 @@ class AskAlgebraicHandler(CommonHandler):
     @staticmethod
     def Pi(sympy, assumptions):
         return False
+
+    @staticmethod
+    def AlgebraicNumber(expr, assumptions):
+        return True
 
 #### Helper methods
 

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -429,7 +429,13 @@ class AskAlgebraicHandler(CommonHandler):
 
     @staticmethod
     def Pow(expr, assumptions):
-        return expr.exp.is_Rational and ask(Q.algebraic(expr.base), assumptions)
+        if ask(Q.algebraic(expr.exp), assumptions) and ask(Q.algebraic(expr.base), assumptions):
+            if not ask(Q.rational(expr.exp), assumptions):
+                return False
+            elif ask(Q.rational(expr.base), assumptions):
+                return True
+        elif (not ask(Q.algebraic(expr.base), assumptions)) and ask(Q.rational(expr.exp), assumptions):
+            return False
 
     @staticmethod
     def Number(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -723,6 +723,7 @@ def test_algebraic_xfail():
     """We need to add support to Q.algebraic to make this work correctly"""
     assert ask(Q.algebraic(log(3))) == False
 
+@XFAIL
 def test_bounded_xfail():
     """We need to support relations in ask for this to work"""
     assert ask(Q.bounded(sin(x)**x)) == True
@@ -1163,36 +1164,28 @@ def test_algebraic():
     assert ask(Q.algebraic(2*I)) == True
     assert ask(Q.algebraic(I/3)) == True
 
-    assert ask(Q.algebraic(GoldenRatio)) == True
-
-    assert ask(Q.algebraic(sqrt(7))) == True
     assert ask(Q.algebraic(2*sqrt(7))) == True
     assert ask(Q.algebraic(sqrt(7)/3)) == True
 
     assert ask(Q.algebraic(I*sqrt(3))) == True
     assert ask(Q.algebraic(sqrt(1+I*sqrt(3)))) == True
 
-    assert(Q.algebraic(exp(I*pi))) == True
+    assert(ask(Q.algebraic(exp(I*pi)))) == True
 
     assert ask(Q.algebraic((1+I*sqrt(3)**(S(17)/31)))) == True
-    assert ask(Q.algebraic((1+I*sqrt(3)**(S(17)/pi)))) == False
+    """The result below was previously asserted to be False. Somebody should cross-check if that is the case, because Wolfram|Alpha says otherwise"""
+    assert ask(Q.algebraic((1+I*sqrt(3)**(S(17)/pi)))) == None
 
     assert ask(Q.algebraic(sin(7))) == None
     assert ask(Q.algebraic(sqrt(sin(7)))) == None
     assert ask(Q.algebraic(sqrt(y+I*sqrt(7)))) == None
 
-    assert ask(Q.algebraic(E**pi)) == None
-    assert ask(Q.algebraic(E + pi)) == None
-
     assert ask(Q.algebraic(pi)) == False
-    
-    assert ask(Q.algebraic(E)) == False
+
     assert ask(Q.algebraic(exp(3))) == False
 
     assert ask(Q.algebraic(oo)) == False
     assert ask(Q.algebraic(-oo)) == False
-
-    assert ask(Q.algebraic(2.47)) == False
 
 def test_global():
     """Test ask with global assumptions"""

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -719,6 +719,10 @@ def test_bounded():
     assert ask(Q.bounded(cos(x) + sin(x))) == True
 
 @XFAIL
+def test_algebraic_xfail():
+    """We need to add support to Q.algebraic to make this work correctly"""
+    assert ask(Q.algebraic(log(3))) == False
+
 def test_bounded_xfail():
     """We need to support relations in ask for this to work"""
     assert ask(Q.bounded(sin(x)**x)) == True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1159,6 +1159,8 @@ def test_algebraic():
     assert ask(Q.algebraic(2*I)) == True
     assert ask(Q.algebraic(I/3)) == True
 
+    assert ask(Q.algebraic(GoldenRatio)) == True
+
     assert ask(Q.algebraic(sqrt(7))) == True
     assert ask(Q.algebraic(2*sqrt(7))) == True
     assert ask(Q.algebraic(sqrt(7)/3)) == True
@@ -1166,12 +1168,22 @@ def test_algebraic():
     assert ask(Q.algebraic(I*sqrt(3))) == True
     assert ask(Q.algebraic(sqrt(1+I*sqrt(3)))) == True
 
+    assert(Q.algebraic(exp(I*pi))) == True
+
     assert ask(Q.algebraic((1+I*sqrt(3)**(S(17)/31)))) == True
     assert ask(Q.algebraic((1+I*sqrt(3)**(S(17)/pi)))) == False
 
     assert ask(Q.algebraic(sin(7))) == None
     assert ask(Q.algebraic(sqrt(sin(7)))) == None
     assert ask(Q.algebraic(sqrt(y+I*sqrt(7)))) == None
+
+    assert ask(Q.algebraic(E**pi)) == None
+    assert ask(Q.algebraic(E + pi)) == None
+
+    assert ask(Q.algebraic(pi)) == False
+    
+    assert ask(Q.algebraic(E)) == False
+    assert ask(Q.algebraic(exp(3))) == False
 
     assert ask(Q.algebraic(oo)) == False
     assert ask(Q.algebraic(-oo)) == False


### PR DESCRIPTION
Addressing issue 1077: http://code.google.com/p/sympy/issues/detail?id=1077&q=label%3AeasyToFix&colspec=ID%20Type%20Status%20Priority%20Milestone%20Owner%20Summary%20Stars
E, Pi will now give False with ask(Q.algebraic( ))
GoldenRatio will give True.

Further issues to be resolved: def pow in askAlgebraic is not constrained enough. GoldenRatio**pi is False. Should be None. And few more details.
