### PR TITLE
3219: infinite recursion for as_leading_term is fixed

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2467,9 +2467,9 @@ class Expr(Basic, EvalfMixin):
         ========
 
         >>> from sympy.abc import x
-        >>> (1+x+x**2).as_leading_term(x)
+        >>> (1 + x + x**2).as_leading_term(x)
         1
-        >>> (1/x**2+x+x**2).as_leading_term(x)
+        >>> (1/x**2 + x + x**2).as_leading_term(x)
         x**(-2)
 
         Note:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2477,7 +2477,7 @@ class Expr(Basic, EvalfMixin):
         self is assumed to be the result returned by Basic.series().
         """
         from sympy import powsimp
-        if len(symbols)>1:
+        if len(symbols) > 1:
             c = self
             for x in symbols:
                 c = c.as_leading_term(x)
@@ -2485,8 +2485,9 @@ class Expr(Basic, EvalfMixin):
         elif not symbols:
             return self
         x = sympify(symbols[0])
-        assert x.is_Symbol, repr(x)
-        if not self.has(x):
+        if not x.is_Symbol:
+            raise ValueError('expecting a Symbol but got %s' % x)
+        if x not in self.free_symbols:
             return self
         obj = self._eval_as_leading_term(x)
         if obj is not None:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2380,7 +2380,7 @@ class Expr(Basic, EvalfMixin):
             yield series - e
             e = series
 
-    def nseries(self, x=None, x0=0, n=6, dir='+',logx=None):
+    def nseries(self, x=None, x0=0, n=6, dir='+', logx=None):
         """
         Wrapper to _eval_nseries if assumptions allow, else to series.
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -843,20 +843,22 @@ class Pow(Expr):
                 raise ValueError('expecting numerical exponent but got %s' % ei)
 
             nuse = n - ei
-            lt = b.compute_leading_term(x, logx=logx) # arg = sin(x); lt = x
-            #  XXX o is not used -- was this to be used as o and o2 below to compute a new e?
-            o = order*lt**(1 - e)
             bs = b._eval_nseries(x, n=nuse, logx=logx)
-            if bs.is_Add:
-                bs = bs.removeO()
-            if bs.is_Add:
+            terms = bs.removeO()
+            if terms.is_Add:
+                bs = terms
+                lt = terms.as_leading_term(x)
+
                 # bs -> lt + rest -> lt*(1 + (bs/lt - 1))
                 return ((Pow(lt, e)*
                          Pow((bs/lt).expand(), e).
                          nseries(x, n=nuse, logx=logx)).expand() +
                          order)
 
-            return bs**e + order
+            rv = bs**e
+            if terms != bs:
+                rv += order
+            return rv
 
         # either b0 is bounded but neither 1 nor 0 or e is unbounded
         # b -> b0 + (b-b0) -> b0 * (1 + (b/b0-1))

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -794,8 +794,12 @@ class Pow(Expr):
         if e.has(Symbol):
             return exp(e*log(b))._eval_nseries(x, n=n, logx=logx)
 
-        if b == x:
-            return powsimp(self, deep=True, combine='exp')
+        # see if the base is as simple as possible
+        bx = b
+        while bx.is_Pow and bx.exp.is_Rational:
+            bx = bx.base
+        if bx == x:
+            return self
 
         # work for b(x)**e where e is not an Integer and does not contain x
         # and hopefully has no other symbols

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -93,3 +93,7 @@ def test_1484():
 def test_issue_3219():
     eq = (1/x)**(S(2)/3)
     assert (eq + 1).as_leading_term(x) == eq
+
+def test_x_is_base_detection():
+    eq = (x**2)**(S(2)/3)
+    assert eq.series() == eq

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -89,3 +89,7 @@ def test_1484():
     assert cos(1+x+x**2).series(x,0,5) == cos(1) - x*sin(1) + x**2*(-sin(1) - \
                                           cos(1)/2) + x**3*(-cos(1) + sin(1)/6) + \
                                           x**4*(-11*cos(1)/24 + sin(1)/2) + O(x**5)
+
+def test_issue_3219():
+    eq = (1/x)**(S(2)/3)
+    assert (eq + 1).as_leading_term(x) == eq


### PR DESCRIPTION
There is also better detection of a bare Symbol base in Pow._eval_nseries
