### PR TITLE
[pretty] Fix pager_print for unicode.

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1451,6 +1451,7 @@ def pager_print(expr, **settings):
 
     """
     from pydoc import pager
+    from locale import getpreferredencoding
     if 'num_columns' not in settings:
         settings['num_columns'] = 500000 # disable line wrap
-    pager(pretty(expr, **settings))
+    pager(pretty(expr, **settings).encode(getpreferredencoding()))


### PR DESCRIPTION
Hi,

this is a small fix for `pager_print`, which I hadn't noticed does not work with unicode (in <python3).

Compare the following upstream issue for python: http://bugs.python.org/issue1065986 (TLDR: the necessesity of this PR is a bug in python which should have been fixed in 2.6 but only actually was fixed in 3.0).
