### PR TITLE
Removed is_zero and change is_negative test to is_nonpositive

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -325,11 +325,9 @@ class Abs(Function):
             return known*unk
         if arg is S.NaN:
             return S.NaN
-        if arg.is_zero:#equals(0):
-            return arg
         if arg.is_nonnegative:
             return arg
-        if arg.is_negative:
+        if arg.is_nonpositive:
             return -arg
         if arg.is_real is False:
             from sympy import expand_mul

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -167,7 +167,7 @@ def test_Abs():
     a = Symbol('a', positive=True)
     assert Abs(2*pi*x*a) == 2*pi*a*Abs(x)
 
-def test_abs_real():
+def test_Abs_real():
     # test some properties of abs that only apply
     # to real numbers
     x = Symbol('x', complex=True)
@@ -178,7 +178,13 @@ def test_abs_real():
     assert sqrt(x**2) == Abs(x)
     assert Abs(x**2) == x**2
 
-def test_abs_properties():
+    # if the symbol is zero, the following will still apply
+    nn = Symbol('nn', nonnegative=True, real=True)
+    np = Symbol('np', nonpositive=True, real=True)
+    assert Abs(nn) == nn
+    assert Abs(np) == -np
+
+def test_Abs_properties():
     x = Symbol('x')
     assert Abs(x).is_real == True
     assert Abs(x).is_positive == None
@@ -195,6 +201,8 @@ def test_abs_properties():
     assert Abs(q).is_zero == False
 
 def test_abs():
+    # this tests that abs calls Abs; don't rename to
+    # test_Abs since that test is already above
     a = Symbol('a', positive=True)
     assert abs(I*(1 + a)**2) == (1 + a)**2
 


### PR DESCRIPTION
For nonpositive args, returning the negated arg will be correct
    even if the arg is zero; for nonnegative args, returning the
    arg will also be correct if the arg is zero.
