### PR TITLE
give cse a postprocess option and better Pow handling

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -26,18 +26,9 @@ import cse_opts
 
 cse_optimizations = list(cse_opts.default_optimizations)
 
-# sometimes we want the output in a different format; here are
-# some common idioms
-# ============================================================
-
-# reverse reps so they are ready to use in a subs call to restore
-# an expression
-cse_reversed = lambda r, e: [list(reversed(r)), e]
-
-# return a single dictionary and the single expression
-# from cse(expr); the replacement dictionary can be used with
-# xreplace
-cse_dict_expr = lambda r, e: [dict(r), e[0]]
+# sometimes we want the output in a different format; non-trivial
+# transformations can be put here for users
+# ===============================================================
 
 def reps_toposort(r):
     """Sort replacements `r` so (k1, v1) appears before (k2, v2)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -182,3 +182,9 @@ def test_pow_invpow():
         ([(x0, x**2)], [(1 + 1/x0)/x0])
     assert cse(x**(2*y) + x**(-2*y)) == \
         ([(x0, x**(2*y))], [x0 + 1/x0])
+
+def test_postprocess():
+    eq = (x + 1 + exp((x + 1)/(y + 1)) + cos(y + 1))
+    assert cse([eq, Eq(x, z + 1), z - 2],
+           postprocess=cse_main.cse_separate) == \
+    [[(x0, y + 1), (x, z + 1), (x1, x + 1)], [x1 + exp(x1/x0) + cos(x0), z - 2]]

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -1,7 +1,7 @@
 import itertools
 
 from sympy import (Add, Mul, Pow, Symbol, exp, sqrt, symbols, sympify, cse,
-    Matrix, S, sin, Eq)
+    Matrix, S, cos, sin, Eq)
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
 from sympy.utilities.pytest import XFAIL
@@ -162,3 +162,23 @@ def test_dont_cse_tuples():
     assert name_val == [(x0, x + y)]
     assert expr == (Subs(f(x, y), (x, y), (0, x0))
             + Subs(g(x, y), (x, y), (0, x0)))
+
+def test_pow_invpow():
+    assert cse(1/x**2 + x**2) == \
+        ([(x0, x**2)], [x0 + 1/x0])
+    assert cse(x**2 + (1 + 1/x**2)/x**2) == \
+        ([(x0, x**2)], [x0 + (1 + 1/x0)/x0])
+    assert cse(1/x**2 + (1 + 1/x**2)*x**2) == \
+        ([(x0, x**2)], [x0*(1 + 1/x0) + 1/x0])
+    assert cse(cos(1/x**2) + sin(1/x**2)) == \
+        ([(x0, x**2)], [sin(1/x0) + cos(1/x0)])
+    assert cse(cos(x**2) + sin(x**2)) == \
+        ([(x0, x**2)], [sin(x0) + cos(x0)])
+    assert cse(y/(2 + x**2) + z/x**2/y) == \
+        ([(x0, x**2)], [y/(x0 + 2) + z/(x0*y)])
+    assert cse(exp(x**2) + x**2*cos(1/x**2)) == \
+        ([(x0, x**2)], [x0*cos(1/x0) + exp(x0)])
+    assert cse((1 + 1/x**2)/x**2) == \
+        ([(x0, x**2)], [(1 + 1/x0)/x0])
+    assert cse(x**(2*y) + x**(-2*y)) == \
+        ([(x0, x**(2*y))], [x0 + 1/x0])


### PR DESCRIPTION
There are some predifined post-processors in cse_main which allow the
return value of a call to cse to be modified:

```
>>> eq = (x+1+exp((x+1)/(y+1))+cos(y+1))
>>> from sympy.simplify.cse_main import *
>>> cse(eq)
([(x0, y + 1), (x1, x + 1)], [x1 + exp(x1/x0) + cos(x0)])
>>> cse(eq, postprocess=cse_reversed)
[[(x1, x + 1), (x0, y + 1)], [x1 + exp(x1/x0) + cos(x0)]]
>>> cse(eq, postprocess=cse_dict_expr)
[{x0: y + 1, x1: x + 1}, x1 + exp(x1/x0) + cos(x0)]
>>> cse([eq, Eq(x, z + 1), z - 2], postprocess=cse_separate)
[[(x0, y + 1), (x, z + 1), (x1, x + 1)], [x1 + exp(x1/x0) + cos(x0), z - 2]]
```
