### PR TITLE
Integral.transform changes

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1576,7 +1576,7 @@ def _aresame(a, b):
 
     >>> sin.compare(cos)
     Traceback (most recent call last):
-     File "<stdin>", line 1, in <module>
+    ...
     TypeError: unbound method compare() must be called with sin instance as first ar
     gument (got FunctionClass instance instead)
 

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -7,7 +7,6 @@ dependencies, so that they can be easily imported anywhere in sympy/core.
 
 from functools import wraps
 from sympify import SympifyError, sympify
-import warnings
 
 def deprecated(func):
     """This is a decorator which can be used to mark functions
@@ -16,7 +15,10 @@ def deprecated(func):
     @wraps(func)
     def new_func(*args, **kwargs):
         from sympy.utilities.exceptions import SymPyDeprecationWarning
-        warnings.warn(SymPyDeprecationWarning("Call to deprecated function.", feature=func.__name__ + "()"))
+        SymPyDeprecationWarning(
+            "Call to deprecated function.",
+            feature=func.__name__ + "()"
+            ).warn()
         return func(*args, **kwargs)
     return new_func
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1490,20 +1490,18 @@ class Expr(Basic, EvalfMixin):
         """
         This method is deprecated. Use .as_coeff_mul() instead.
         """
-        import warnings
         from sympy.utilities.exceptions import SymPyDeprecationWarning
-        warnings.warn(SymPyDeprecationWarning(feature="as_coeff_terms()",
-                                              useinstead="as_coeff_mul()"))
+        SymPyDeprecationWarning(feature="as_coeff_terms()",
+                                useinstead="as_coeff_mul()").warn()
         return self.as_coeff_mul(*deps)
 
     def as_coeff_factors(self, *deps):
         """
         This method is deprecated.  Use .as_coeff_add() instead.
         """
-        import warnings
         from sympy.utilities.exceptions import SymPyDeprecationWarning
-        warnings.warn(SymPyDeprecationWarning(feature="as_coeff_factors()",
-                                              useinstead="as_coeff_add()"))
+        SymPyDeprecationWarning(feature="as_coeff_factors()",
+                                useinstead="as_coeff_add()").warn()
         return self.as_coeff_add(*deps)
 
     def as_coeff_mul(self, *deps):

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -10,7 +10,6 @@ from sympy.logic.boolalg import Boolean
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 import re
-import warnings
 
 class Symbol(AtomicExpr, Boolean):
     """
@@ -60,10 +59,10 @@ class Symbol(AtomicExpr, Boolean):
         """
 
         if 'dummy' in assumptions:
-            warnings.warn(
-                SymPyDeprecationWarning(
-                    feature="Symbol('x', dummy=True)",
-                    useinstead="Dummy() or symbols(..., cls=Dummy)"))
+            SymPyDeprecationWarning(
+                feature="Symbol('x', dummy=True)",
+                useinstead="Dummy() or symbols(..., cls=Dummy)"
+                ).warn()
             if assumptions.pop('dummy'):
                 return Dummy(name, **assumptions)
         if assumptions.get('zero', False):
@@ -286,10 +285,10 @@ def symbols(names, **args):
     """
     result = []
     if 'each_char' in args:
-        warnings.warn(
-            SymPyDeprecationWarning(
-                feature="each_char in the options to symbols() and var()",
-                useinstead="spaces or commas between symbol names"))
+        SymPyDeprecationWarning(
+            feature="each_char in the options to symbols() and var()",
+            useinstead="spaces or commas between symbol names"
+            ).warn()
 
     if isinstance(names, basestring):
         names = names.strip()

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -203,13 +203,11 @@ def test_symbols_each_char():
     z = Symbol('z')
 
     # First, test the warning
-    warnings.filterwarnings("error", "The each_char option to symbols\(\) and var\(\) is "
-        "deprecated.  Separate symbol names by spaces or commas instead.")
-    raises(SymPyDeprecationWarning, "symbols('xyz', each_char=True)")
-    raises(SymPyDeprecationWarning, "symbols('xyz', each_char=False)")
+    warnings.filterwarnings("error")
+    raises(UserWarning, "symbols('xyz', each_char=True)")
+    raises(UserWarning, "symbols('xyz', each_char=False)")
     # now test the actual output
-    warnings.filterwarnings("ignore",  "The each_char option to symbols\(\) and var\(\) is "
-        "deprecated.  Separate symbol names by spaces or commas instead.")
+    warnings.filterwarnings("ignore")
     assert symbols(['wx', 'yz'], each_char=True) == [(w, x), (y, z)]
     assert all(w.is_Function for w in flatten(symbols(['wx', 'yz'], each_char=True, cls=Function)))
     assert symbols('xyz', each_char=True) == (x, y, z)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -9,6 +9,7 @@ from sympy.integrals.rationaltools import ratint
 from sympy.integrals.risch import heurisch
 from sympy.integrals.meijerint import meijerint_definite, meijerint_indefinite
 from sympy.utilities import xthreaded, flatten
+from sympy.utilities.misc import filldedent
 from sympy.polys import Poly, PolynomialError
 from sympy.solvers import solve
 from sympy.functions import Piecewise, sqrt, sign
@@ -371,29 +372,89 @@ class Integral(Expr):
         f = f.subs(reps)
         return Integral(f, *limits)
 
-    def transform(self, x, mapping, z, inverse=False):
+    def transform(self, x, u):
         """
-        Replace the integration variable x in the integrand with the
-        expression given by `mapping`, e.g. 2*y or 1/y. The integrand and
-        endpoints are rescaled to preserve the value of the original
-        integral.
+        Performs a change of variables from `x` to `u` using the relationship
+        given by `x` and `u` which will define the transformations `f` and `F`
+        (which are inverses of each other) as follows:
 
-        In effect, this performs a variable substitution.
+        1) If `x` is a Symbol (which is a variable of integration) then `u`
+           will be interpreted as some function, f(u), with inverse F(u).
+           This, in effect, just makes the substitution of x with f(x).
 
-        With inverse=True, the inverse transformation is performed.
+        2) If `u` is a Symbol then `x` will be interpreted as some function,
+           F(x), with inverse f(u). This is commonly referred to as
+           u-substitution.
 
-        The mapping must be uniquely invertible (e.g. a linear or linear
-        fractional transformation).
+        Once f and F have been identified, the transformation is made as
+        follows:
+
+                       F(b)
+          b              /
+          /             |
+         |              |       d
+         |  x dx  -->   |  f(x)*--(f(x)) dx  where F(x) is the inverse of f(x)
+         |              |       dx
+        /               |
+        a              /
+                      F(a)
+
+        where the limits and integrand have been corrected so as to retain the
+        same value after integration.
+
+        Notes
+        =====
+        The mappings, F(x) or f(u), must lead to a unique integral. Linear
+        or rational linear expression, `2*x`, `1/x` and `sqrt(x)`, will
+        always work; quadratic expressions like `x**2 - 1` are acceptable
+        as long as the resulting integrand does not depend on the sign of
+        the solutions (see examples).
+
+        The integral will be returned unchanged if `x` is not a variable of
+        integration.
+
+        `x` must be (or contain) only one of of the integration variables.
 
         Examples
         ========
 
-            >>> from sympy.abc import a, b, c
-            >>> from sympy import Integral, S
-            >>> Integral(a*b + 2 + c, (c, -1, S(1)/2)).transform(a, c*2, c)
-            Integral(a*b + c + 2, (c, -1, 1/2))
-            >>> Integral(a**2 + 1, (a, -1, 2)).transform(a, 1 + 2*a, a)
-            Integral(2*(2*a + 1)**2 + 2, (a, -1, 1/2))
+        >>> from sympy.abc import a, b, c, d, x, u, y
+        >>> from sympy import Integral, S, cos, sqrt
+
+        >>> i = Integral(x*cos(x**2 - 1), (x, 0, 1))
+
+        transform can change the variable of integration
+
+        >>> i.transform(x, u)
+        Integral(u*cos(u**2 - 1), (u, 0, 1))
+
+        transform can perform u-substitution
+
+        >>> i.transform(x**2 - 1, u)
+        Integral(cos(u)/2, (u, -1, 0))
+
+        transform can do a substitution. Here, the previous
+        result is transformed back into the original expression:
+
+        >>> ui = _
+        >>> _.transform(sqrt(u + 1), x) == i
+        True
+
+        But the substitution can only be done if there is a unique
+        result. Here, the attempt to transform ui back to i with a
+        substution fails because F(u) has two solutions, +/-sqrt(u + 1),
+        so the upper limit could be +/-1:
+
+        >>> ui.transform(u, x**2 - 1) == i
+        Traceback (most recent call last):
+        ...
+        ValueError: f and F must give a unique change
+
+        If the `x` does not contain a symbol of integration then
+        the integral will be returned unchanged:
+
+        >>> i.transform(a, x) == i
+        True
 
         See Also
         ========
@@ -401,49 +462,99 @@ class Integral(Expr):
         variables : Lists the integration variables
         as_dummy : Replace integration variables with dummy ones
         """
-        if x not in self.variables:
+        d = Dummy('d')
+        _sign = sign(Dummy('+/-', integer=True, nonzero=True))
+
+        xfree = x.free_symbols.intersection(self.variables)
+        if len(xfree) > 1:
+            raise ValueError('F(x) can only contain one of: %s' % self.variables)
+        xvar = xfree.pop() if xfree else d
+
+        if xvar not in self.variables:
             return self
-        limits = self.limits
-        function = self.function
-        y = Dummy('y')
-        inverse_mapping = solve(mapping.subs(z, y) - z, y)
-        if len(inverse_mapping) != 1 or z not in inverse_mapping[0].free_symbols:
-            raise ValueError("The mapping must be uniquely invertible")
-        inverse_mapping = inverse_mapping[0]
-        if inverse:
-            mapping, inverse_mapping = inverse_mapping, mapping
-        function = function.subs(x, mapping) * mapping.diff(z)
+
+        if x.is_Symbol and u.is_Symbol:
+            return self.xreplace({x: u})
+
+        if not x.is_Symbol and not u.is_Symbol:
+            raise ValueError('either x or u must be a symbol')
+
+        ufree = u.free_symbols
+        if len(ufree) != 1:
+            # XXX allow for tuple input (f(u, v), u) where u defines which is the new
+            # integration variable
+            raise ValueError('f(u) must contain only one free variable, but got %s' % list(ufree))
+        uvar = ufree.pop()
+
+        if uvar == xvar:
+            return self.transform(x, u.subs(uvar, d)).xreplace({d: uvar})
+
+        if uvar in self.limits:
+            raise ValueError(filldedent('''
+            u must contain the same variable as in x
+            or a variable that is not already an integration variable'''))
+
+        def _valid(f):
+            if len(f) == 2 and f[0] + f[1] == 0:
+                f = _sign*f[0]
+            elif len(f) == 1:
+                f = f[0]
+            else:
+                raise ValueError('f and F must give a unique change')
+            return f
+
+        if not x.is_Symbol:
+            F = x.subs(xvar, d)
+            soln = solve(u - x, xvar, check=False)
+            f = _valid(soln).subs(uvar, d)
+        else:
+            f = u.subs(uvar, d)
+            soln = solve(u - x, uvar, check=False)
+            F = _valid(soln).subs(xvar, d)
+
+        mapping = f
+        inverse_mapping = F
+
+        newfunc = (self.function.subs(xvar, f)* f.diff(d)).subs(d, uvar)
+        if newfunc.has(_sign):
+            raise ValueError('f and F must give a unique change')
 
         def _calc_limit(a, b):
             """
-            replace x with a, using subs if possible, otherwise limit
+            replace d with a, using subs if possible, otherwise limit
             where sign of b is considered
             """
-            wok = inverse_mapping.subs(z, a)
+            wok = inverse_mapping.subs(d, a)
             if wok is S.NaN or wok.is_bounded is False and a.is_bounded:
-                return limit(sign(b)*inverse_mapping, z, a)
+                return limit(sign(b)*inverse_mapping, d, a)
+            if wok.has(_sign):
+                raise ValueError('f and F must give a unique change')
             return wok
 
         newlimits = []
-        for xab in limits:
+        for xab in self.limits:
             sym = xab[0]
-            if sym == x and len(xab) == 3:
-                a, b = xab[1:]
-                a, b = _calc_limit(a, b), _calc_limit(b, a)
-                if a == b:
-                    raise ValueError("The mapping must transform the "
-                        "endpoints into separate points")
-                if a > b:
-                    a, b = b, a
-                    function = -function
-                newlimits.append((z, a, b))
-            elif len(xab) == 3:
-                print "in elif part"
-                newlimits.append(z,xab[1:])
+            if sym == xvar:
+                if len(xab) == 3:
+                    a, b = xab[1:]
+                    a, b = _calc_limit(a, b), _calc_limit(b, a)
+                    if a == b:
+                        raise ValueError("The mapping must transform the "
+                            "endpoints into separate points")
+                    if a > b:
+                        a, b = b, a
+                        newfunc = -newfunc
+                    newlimits.append((uvar, a, b))
+                elif len(xab) == 2:
+                    a = _calc_limit(xab[1], 1)
+                    newlimits.append((uvar, a))
+                else:
+                    # XXX raise error
+                    newlimits.append(uvar)
             else:
-                newlimits.append(z)
-            return Integral(function, *newlimits)
+                newlimits.append(xab)
 
+        return Integral(newfunc, *newlimits)
 
     def doit(self, **hints):
         """

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -249,21 +249,25 @@ def test_integrate_derivatives():
     assert integrate(Derivative(f(y), y), x) == x*Derivative(f(y), y)
 
 def test_transform():
-    a = Integral(x**2+1, (x, -1, 2))
-    assert a.doit() == a.transform(x, 3*y+1,y).doit()
-    assert a.transform(x, 3*y+1,y).transform(y, 3*x+1, x, inverse=True) == a
-    assert a.transform(x, 3*y+1, y, inverse=True).transform(y, 3*x+1, x) == a
+    a = Integral(x**2 + 1, (x, -1, 2))
+    fx = x
+    fy = 3*y + 1
+    assert a.doit() == a.transform(fx, fy).doit()
+    assert a.transform(fx, fy).transform(fy, fx) == a
+    fx = 3*x + 1
+    fy = y
+    assert a.transform(fx, fy).transform(fy, fx) == a
     a = Integral(sin(1/x), (x, 0, 1))
-    assert a.transform(x, 1/y, y) == Integral(sin(y)/y**2, (y, 1, oo))
-    assert a.transform(x, 1/y, y).transform(y, 1/x, x) == a
+    assert a.transform(x, 1/y) == Integral(sin(y)/y**2, (y, 1, oo))
+    assert a.transform(x, 1/y).transform(y, 1/x) == a
     a = Integral(exp(-x**2), (x, -oo, oo))
-    assert a.transform(x, 2*y, y) == Integral(2*exp(-4*y**2), (y, -oo, oo))
+    assert a.transform(x, 2*y) == Integral(2*exp(-4*y**2), (y, -oo, oo))
     # < 3 arg limit handled properly
-    assert Integral(x, x).transform(x, a*y, y).doit() == Integral(y*a**2, y).doit()
+    assert Integral(x, x).transform(x, a*y).doit() == Integral(y*a**2, y).doit()
     _3 = S(3)
-    assert Integral(x, (x, 0, -_3)).transform(x, 1/y, y).doit() == \
+    assert Integral(x, (x, 0, -_3)).transform(x, 1/y).doit() == \
     Integral(-1/x**3, (x, -oo, -1/_3)).doit()
-    assert Integral(x, (x, 0, _3)).transform(x, 1/y, y) == \
+    assert Integral(x, (x, 0, _3)).transform(x, 1/y) == \
     Integral(y**(-3), (y, 1/_3, oo))
 
 def test_issue953():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -250,23 +250,21 @@ def test_integrate_derivatives():
 
 def test_transform():
     a = Integral(x**2+1, (x, -1, 2))
-    assert a.doit() == a.transform(x, 3*x+1).doit()
-    assert a.transform(x, 3*x+1).transform(x, 3*x+1, inverse=True) == a
-    assert a.transform(x, 3*x+1, inverse=True).transform(x, 3*x+1) == a
+    assert a.doit() == a.transform(x, 3*y+1,y).doit()
+    assert a.transform(x, 3*y+1,y).transform(y, 3*x+1, x, inverse=True) == a
+    assert a.transform(x, 3*y+1, y, inverse=True).transform(y, 3*x+1, x) == a
     a = Integral(sin(1/x), (x, 0, 1))
-    assert a.transform(x, 1/x) == Integral(sin(x)/x**2, (x, 1, oo))
-    assert a.transform(x, 1/x).transform(x, 1/x) == a
+    assert a.transform(x, 1/y, y) == Integral(sin(y)/y**2, (y, 1, oo))
+    assert a.transform(x, 1/y, y).transform(y, 1/x, x) == a
     a = Integral(exp(-x**2), (x, -oo, oo))
-    assert a.transform(x, 2*x) == Integral(2*exp(-4*x**2), (x, -oo, oo))
+    assert a.transform(x, 2*y, y) == Integral(2*exp(-4*y**2), (y, -oo, oo))
     # < 3 arg limit handled properly
-    assert Integral(x, x).transform(x, a*x) == Integral(x*a**2, x)
-    raises(ValueError, "a.transform(x, 1/x)")
-    raises(ValueError, "a.transform(x, 1/x)")
+    assert Integral(x, x).transform(x, a*y, y).doit() == Integral(y*a**2, y).doit()
     _3 = S(3)
-    assert Integral(x, (x, 0, -_3)).transform(x, 1/x) == \
-    Integral(-1/x**3, (x, -oo, -1/_3))
-    assert Integral(x, (x, 0, _3)).transform(x, 1/x) == \
-    Integral(x**(-3), (x, 1/_3, oo))
+    assert Integral(x, (x, 0, -_3)).transform(x, 1/y, y).doit() == \
+    Integral(-1/x**3, (x, -oo, -1/_3)).doit()
+    assert Integral(x, (x, 0, _3)).transform(x, 1/y, y) == \
+    Integral(y**(-3), (y, 1/_3, oo))
 
 def test_issue953():
     f = S(1)/2*asin(x) + x*sqrt(1 - x**2)/2

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -21,7 +21,6 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.decorators import call_highest_priority
 
 import random
-import warnings
 from types import FunctionType
 
 class MatrixError(Exception):
@@ -1912,7 +1911,9 @@ class MatrixBase(object):
         fill
         """
         if is_sequence(r):
-            warnings.warn(SymPyDeprecationWarning("Pass row and column count as zeros(%i, %i)." % r))
+            SymPyDeprecationWarning(
+            "Pass row and column count as zeros(%i, %i)." % r
+            ).warn()
             r, c = r
         else:
             c = r if c is None else c
@@ -2476,11 +2477,11 @@ class MatrixBase(object):
         [0, 1], [0, 1])
         """
         if simplified is not False:
-            warnings.warn(filldedent('''
-            Use of simplified is deprecated. Set simplify=True to
-            use SymPy's simplify function or set simplify to your
-            own custom simplification function.
-            '''))
+            SymPyDeprecationWarning(
+            feature="'simplified' as a keyword to rref",
+            useinstead="simplify=True or set simplify equal to your " +
+                       "own custom simplification function"
+            ).warn()
             simplify = simplify or True
         simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
         pivot, r = 0, self[:,:].as_mutable()        # pivot: index of next row to contain a pivot
@@ -2515,11 +2516,11 @@ class MatrixBase(object):
         Returns list of vectors (Matrix objects) that span nullspace of self
         """
         if simplified is not False:
-            warnings.warn(filldedent('''
-            Use of simplified is deprecated. Set simplify=True to
-            use SymPy's simplify function or set simplify to your
-            own custom simplification function.
-            '''))
+            SymPyDeprecationWarning(
+            feature="'simplified' as a keyword to rref",
+            useinstead="simplify=True or set simplify equal to your " +
+                       "own custom simplification function"
+            ).warn()
             simplify = simplify or True
         simpfunc = simplify if isinstance(simplify, FunctionType) else _simplify
         reduced, pivots = self.rref(simplify=simpfunc)
@@ -3829,7 +3830,9 @@ def zeros(r, c=None, cls=MutableMatrix):
     diag
     """
     if is_sequence(r):
-        warnings.warn(SymPyDeprecationWarning("Pass row and column count as zeros(%i, %i)." % r))
+        SymPyDeprecationWarning(
+        "Pass row and column count as zeros(%i, %i)." % r
+        ).warn()
         r, c = r
     else:
         c = r if c is None else c
@@ -3849,7 +3852,9 @@ def ones(r, c=None):
     """
 
     if is_sequence(r):
-        warnings.warn(SymPyDeprecationWarning("Pass row and column count as ones(%i, %i)." % r))
+        SymPyDeprecationWarning(
+        "Pass row and column count as ones(%i, %i)." % r
+        ).warn()
         r, c = r
     else:
         c = r if c is None else c
@@ -4549,7 +4554,9 @@ class SparseMatrix(MatrixBase):
         """Returns a matrix of zeros with ``r`` rows and ``c`` columns;
         if ``c`` is omitted a square matrix will be returned."""
         if is_sequence(r):
-            warnings.warn("Pass row and column count as zeros(%i, %i)." % r, SymPyDeprecationWarning)
+            SymPyDeprecationWarning(
+            "Pass row and column count as zeros(%i, %i)." % r
+            ).warn()
             r, c = r
         else:
             c = r if c is None else c

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1132,14 +1132,17 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     # ----------
     # assume, during deprecation that sol and func are reversed
     if hasattr(sol, '_is_Function') and isinstance(sol, AppliedUndef) and len(sol.args) == 1:
-        import warnings
         msg = "sol appears to be a valid function. " +\
               "The order of sol and func will be reversed. " +\
               "If this is not desired, send sol as Eq(sol, 0)."
-        warnings.warn(SymPyDeprecationWarning(msg))
+        SymPyDeprecationWarning(msg
+        ).warn()
         sol, func = func, sol
     elif not (isinstance(func, AppliedUndef) and len(func.args) == 1):
-        raise ValueError("func (or sol, during deprecation) must be a function of one variable. Got sol = %s, func = %s" % (sol, func))
+        from sympy.utilities.misc import filldedent
+        raise ValueError(filldedent('''
+        func (or sol, during deprecation) must be a function
+        of one variable. Got sol = %s, func = %s''' % (sol, func)))
     # ========== end of deprecation handling
     if is_sequence(sol, set):
         return type(sol)(map(lambda i: checkodesol(ode, i, order=order,

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -46,7 +46,6 @@ from sympy.core.compatibility import reduce
 
 from sympy.assumptions import Q, ask
 
-from warnings import warn
 from types import GeneratorType
 from collections import defaultdict
 
@@ -1742,7 +1741,10 @@ def _generate_patterns():
 
 
 def tsolve(eq, sym):
-    warn(SymPyDeprecationWarning(feature="tsolve()", useinstead="solve()"))
+    SymPyDeprecationWarning(
+    feature="tsolve()",
+    useinstead="solve()"
+    ).warn()
     return _tsolve(eq, sym)
 
 

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -2,6 +2,9 @@
 General SymPy exceptions and warnings.
 """
 
+from sympy.utilities.misc import filldedent
+from warnings import warn as warning
+
 class SymPyDeprecationWarning(DeprecationWarning):
     r"""A warning for deprecated features of SymPy.
 
@@ -14,49 +17,54 @@ class SymPyDeprecationWarning(DeprecationWarning):
     >>> warnings.warn("Don't do this, it's deprecated", SymPyDeprecationWarning) #doctest:+SKIP
     __main__:1: SymPyDeprecationWarning: "Don't do this, it's deprecated"
 
-    The recommended way to use this class is, however, by directly passing
-    instances of it to warnings.warn:
+    The recommended way to use this class is, however, is by calling
+    the warn method after constructing the message:
 
-    >>> warnings.warn(SymPyDeprecationWarning("Don't do this, it's deprecated")) #doctest:+SKIP
-    __main__:1: SymPyDeprecationWarning: "Don't do this, it's deprecated"
+        >>> SymPyDeprecationWarning("Don't do this, it's deprecated.").warn #doctest:+SKIP
+        __main__:1: SymPyDeprecationWarning:
+
+        Don't do this, it's deprecated.
+
+          warning (see_above, SymPyDeprecationWarning)
 
     To provide additional information, create an instance of this
     class in this way:
 
-    >>> SymPyDeprecationWarning(feature="such and such",
+    >>> SymPyDeprecationWarning(
+    ...     feature="such and such",
     ...     last_supported_version="1.2.3",
     ...     useinstead="this other feature")
-    SymPyDeprecationWarning("The feature such and such is deprecated.
-    It will be last supported in SymPy version 1.2.3.  Use this other
-    feature instead.")
+    The feature such and such is deprecated. It will be last supported in
+    SymPy version 1.2.3. Use this other feature instead.
 
     Either (or both) of the arguments last_supported_version and
-    useinstead can be omitted.  In this case the corresponding
+    useinstead can be omitted. In this case the corresponding
     sentence will not be shown:
 
     >>> SymPyDeprecationWarning(feature="such and such",
     ...     useinstead="this other feature")
-    SymPyDeprecationWarning("The feature such and such is deprecated.
-    Use this other feature instead.")
+    The feature such and such is deprecated. Use this other feature
+    instead.
 
     You can still provide the argument value.  If it is a string, it
     will be appended to the end of the message:
 
-    >>> SymPyDeprecationWarning(feature="such and such",
+    >>> SymPyDeprecationWarning(
+    ...     feature="such and such",
     ...     useinstead="this other feature",
     ...     value="Contact the developers for further information.")
-    SymPyDeprecationWarning("The feature such and such is deprecated.
-    Use this other feature instead.  Contact the developers for
-    further information.")
+    The feature such and such is deprecated. Use this other feature
+    instead. Contact the developers for further information.
 
     If, however, the argument value does not hold a string, a string
     representation of the object will be appended to the message:
 
-    >>> SymPyDeprecationWarning(feature="such and such",
+    >>> SymPyDeprecationWarning(
+    ...     feature="such and such",
     ...     useinstead="this other feature",
     ...     value=[1,2,3])
-    SymPyDeprecationWarning("The feature such and such is deprecated.
-    Use this other feature instead.  ([1, 2, 3])")
+    The feature such and such is deprecated. Use this other feature
+    instead. ([1, 2, 3])
 
     To mark a function as deprecated, you can use the decorator
     @deprecated.
@@ -68,27 +76,29 @@ class SymPyDeprecationWarning(DeprecationWarning):
 
     def __init__(self, value=None, feature=None, last_supported_version=None,
                  useinstead=None):
-        self.fullMessage=""
+        self.fullMessage = ""
 
         if feature:
             self.fullMessage = "The feature %s is deprecated." % feature
 
             if last_supported_version:
-                self.fullMessage += "  It will be last supported in SymPy version %s." % last_supported_version
+                self.fullMessage += " It will be last supported in SymPy version %s." % last_supported_version
             if useinstead:
-                self.fullMessage += "  Use %s instead." % useinstead
+                self.fullMessage += " Use %s instead." % useinstead
 
         if value:
             if not isinstance(value, str):
                 value = "(%s)" % repr(value)
+            value = " " + value
         else:
             value = ""
 
-        if self.fullMessage:
-            if value:
-                self.fullMessage += "  " + value
-        else:
-            self.fullMessage = value
+        self.fullMessage += value
 
     def __str__(self):
-        return "SymPyDeprecationWarning(\"%s\")" % self.fullMessage
+        return '\n%s\n' % filldedent(self.fullMessage)
+
+    def warn(self):
+        see_above = self
+        # the next line is what the user will see after the error is printed
+        warning (see_above, SymPyDeprecationWarning)

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -429,11 +429,10 @@ def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
     """
     if cls is None:
         if 'dummy' in assumptions and assumptions.pop('dummy'):
-            import warnings
-            warnings.warn(
-                SymPyDeprecationWarning(
-                    feature="'dummy' in assumptions",
-                    useinstead="cls=Dummy to create dummy symbols"))
+            SymPyDeprecationWarning(
+                feature="'dummy' in assumptions",
+                useinstead="cls=Dummy to create dummy symbols"
+                ).warn()
             cls = C.Dummy
         else:
             cls = C.Symbol

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -35,7 +35,7 @@ def check(a, check_attr=True):
     """
     # The below hasattr() check will warn about is_Real in Python 2.5, so
     # disable this to keep the tests clean
-    warnings.filterwarnings("ignore", ".*is_Real.*", SymPyDeprecationWarning)
+    warnings.filterwarnings("ignore", ".*is_Real.*")
     protocols = [0, 1, 2, copy.copy, copy.deepcopy]
     # Python 2.x doesn't support the third pickling protocol
     if sys.version_info[0] > 2:


### PR DESCRIPTION
There is no inverse option any more: you either pass something like `transform(x**2 - 1, u)` and undo the transform with `transform(u, x**2-1)` -- the integration variable being changed will always be listed first. u (or f(u)) can be written in terms of x if you don't want a new variable -- a temporary u is used internally to make this work. 

This should feel a lot more natural in terms of thought process (IMHO). If you have any transforms that you think should work that don't work here, please make a note.

This is an alternative to https://github.com/sympy/sympy/pull/1232 .
