### PR TITLE
Set printing issues

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -987,13 +987,7 @@ class LatexPrinter(Printer):
                 return 'Domain on ' + self._print(d.symbols)
 
     def _print_FiniteSet(self, s):
-        if len(s) > 10:
-            printset = s.args[:3] + (r"\ldots",) + s.args[-3:]
-        else:
-            printset = s.args
-        return (r"\left\{"
-              + r", ".join(self._print(el) for el in printset)
-              + r"\right\}")
+        return self._print_set(s.args)
 
     def _print_set(self, s):
         items = sorted(s, key=default_sort_key)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -988,15 +988,19 @@ class LatexPrinter(Printer):
 
     def _print_FiniteSet(self, s):
         if len(s) > 10:
-            printset = s.args[:3] + ('...',) + s.args[-3:]
+            printset = s.args[:3] + (r"\ldots",) + s.args[-3:]
         else:
             printset = s.args
         return (r"\left\{"
               + r", ".join(self._print(el) for el in printset)
               + r"\right\}")
 
-    _print_frozenset = _print_FiniteSet
-    _print_set = _print_FiniteSet
+    def _print_set(self, s):
+        items = sorted(s, key=default_sort_key)
+        items = ", ".join(map(self._print, items))
+        return r"\left\{%s\right\}" % items
+
+    _print_frozenset = _print_set
 
     def _print_Interval(self, i):
         if i.start == i.end:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1000,7 +1000,7 @@ class LatexPrinter(Printer):
 
     def _print_Interval(self, i):
         if i.start == i.end:
-            return r"\left{%s\right}" % self._print(i.start)
+            return r"\left\{%s\right\}" % self._print(i.start)
 
         else:
             if i.left_open:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1240,7 +1240,8 @@ class PrettyPrinter(Printer):
 
     def _print_set(self, s):
         items = sorted(s, key=default_sort_key)
-        pretty = self._print_seq(items, '(', ')')
+        pretty = self._print_seq(items, '[', ']')
+        pretty = prettyForm(*pretty.parens('(', ')', ifascii_nougly=True))
         pretty = prettyForm(*stringPict.next(type(s).__name__, pretty))
         return pretty
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1135,11 +1135,8 @@ class PrettyPrinter(Printer):
                 parenthesize = lambda set:set.is_Union or set.is_Intersection)
 
     def _print_FiniteSet(self, s):
-        if len(s) > 10:
-            printset = s.args[:3] + ('...',) + s.args[-3:]
-        else:
-            printset = s.args
-        return self._print_seq(printset, '{', '}', ', ' )
+        items = sorted(s.args, key=default_sort_key)
+        return self._print_seq(items, '{', '}', ', ' )
 
     def _print_Interval(self, i):
         if i.start == i.end:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7,7 +7,7 @@ from sympy import (Basic, Matrix, Piecewise, Ne, symbols, sqrt, Function,
     RootOf, RootSum, Lambda, Not, And, Or, Xor, Nand, Nor, Implies, Equivalent,
     Sum, Subs, FF, ZZ, QQ, RR, O, uppergamma, lowergamma, hyper, meijerg, Dict,
     euler, groebner, catalan, Product, KroneckerDelta, Ei, expint, Shi, Chi, Si,
-    Ci, Segment, Ray)
+    Ci, Segment, Ray, FiniteSet)
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
@@ -2403,6 +2403,14 @@ def test_any_object_in_sequence():
     assert upretty(expr2) == u"{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
 
 def test_pretty_sets():
+    s = FiniteSet
+    assert pretty(s([x*y, x**2])) == \
+"""\
+  2      \n\
+{x , x*y}\
+"""
+    assert pretty(s(range(1, 6))) == "{1, 2, 3, 4, 5}"
+    assert pretty(s(range(1, 13))) == "{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}"
     for s in (frozenset, set):
         assert pretty(s([x*y, x**2])) == \
 """\

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -2392,8 +2392,8 @@ def test_any_object_in_sequence():
     assert upretty(expr) == u"[Basic(Basic()), Basic()]"
 
     expr = set([b2, b1])
-    assert pretty(expr) == "set(Basic(), Basic(Basic()))"
-    assert upretty(expr) == u"set(Basic(), Basic(Basic()))"
+    assert pretty(expr) == "set([Basic(), Basic(Basic())])"
+    assert upretty(expr) == u"set([Basic(), Basic(Basic())])"
 
     expr = {b2:b1, b1:b2}
     expr2 = Dict({b2:b1, b1:b2})
@@ -2401,6 +2401,17 @@ def test_any_object_in_sequence():
     assert pretty(expr2) == "{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
     assert upretty(expr) == u"{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
     assert upretty(expr2) == u"{Basic(): Basic(Basic()), Basic(Basic()): Basic()}"
+
+def test_pretty_sets():
+    for s in (frozenset, set):
+        assert pretty(s([x*y, x**2])) == \
+"""\
+%s   2       \n\
+%s([x , x*y])\
+""" % (" " * len(s.__name__), s.__name__)
+        assert pretty(s(range(1, 6))) == "%s([1, 2, 3, 4, 5])" % s.__name__
+        assert pretty(s(range(1, 13))) == \
+            "%s([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])" % s.__name__
 
 def test_pretty_limits():
     expr = Limit(x, x, oo)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -257,6 +257,7 @@ def test_latex_set():
 
 def test_latex_intervals():
     a = Symbol('a', real=True)
+    assert latex(Interval(0, 0)) == r"\left\{0\right\}"
     assert latex(Interval(0, a)) == r"\left[0, a\right]"
     assert latex(Interval(0, a, False, False)) == r"\left[0, a\right]"
     assert latex(Interval(0, a, True, False)) == r"\left(0, a\right]"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -240,13 +240,8 @@ def test_latex_integrals():
     assert latex(Integral(x, x, y, (z, 0, 1))) == \
         r"\int_{0}^{1}\int\int x\, dx\, dy\, dz"
 
-def test_latex_finiteset():
-    assert latex(FiniteSet(range(1, 51))) == \
-            r"\left\{1, 2, 3, \ldots, 48, 49, 50\right\}"
-    assert latex(FiniteSet(range(1, 6))) == r"\left\{1, 2, 3, 4, 5\right\}"
-
 def test_latex_sets():
-    for s in (frozenset, set):
+    for s in (FiniteSet, frozenset, set):
         assert latex(s([x*y, x**2])) == r"\left\{x^{2}, x y\right\}"
         assert latex(s(range(1, 6))) == r"\left\{1, 2, 3, 4, 5\right\}"
         assert latex(s(range(1, 13))) == \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -241,19 +241,16 @@ def test_latex_integrals():
         r"\int_{0}^{1}\int\int x\, dx\, dy\, dz"
 
 def test_latex_finiteset():
-    assert latex(FiniteSet(range(1, 51)) ==\
-            r'\left{1, 2, 3, ..., 48, 49, 50\right}')
-    assert latex(FiniteSet(range(1, 6)) == r'\left{1, 2, 3, 4, 5\right}')
+    assert latex(FiniteSet(range(1, 51))) == \
+            r"\left\{1, 2, 3, \ldots, 48, 49, 50\right\}"
+    assert latex(FiniteSet(range(1, 6))) == r"\left\{1, 2, 3, 4, 5\right\}"
 
-def test_latex_frozenset():
-    assert latex(frozenset(range(1, 51)) ==\
-            r'\left{1, 2, 3, ..., 48, 49, 50\right}')
-    assert latex(frozenset(range(1, 6)) == r'\left{1, 2, 3, 4, 5\right}')
-
-def test_latex_set():
-    assert latex(set(range(1, 51)) ==\
-            r'\left{1, 2, 3, ..., 48, 49, 50\right}')
-    assert latex(set(range(1, 6)) == r'\left{1, 2, 3, 4, 5\right}')
+def test_latex_sets():
+    for s in (frozenset, set):
+        assert latex(s([x*y, x**2])) == r"\left\{x^{2}, x y\right\}"
+        assert latex(s(range(1, 6))) == r"\left\{1, 2, 3, 4, 5\right\}"
+        assert latex(s(range(1, 13))) == \
+            r"\left\{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12\right\}"
 
 def test_latex_intervals():
     a = Symbol('a', real=True)


### PR DESCRIPTION
Printing set and frozenset now looks like this:

``` py
>>> print str(set([y**2, x**2, x*y]))
set([x*y, x**2, y**2])
>>> print str(frozenset([x**2, x*y, y**2]))
frozenset([x*y, x**2, y**2])
>>> print pretty(set([y**2, x**2, x*y]))
      2   2       
set([x , y , x*y])
>>> print pretty(frozenset([x**2, x*y, y**2]))
            2   2       
frozenset([x , y , x*y])
>>> print latex(set([y**2, x**2, x*y]))
\left\{x^{2}, y^{2}, x y\right\}
>>> print latex(frozenset([x**2, x*y, y**2]))
\left\{x^{2}, y^{2}, x y\right\}
```

Fixes these issues:
http://code.google.com/p/sympy/issues/detail?id=3062
http://code.google.com/p/sympy/issues/detail?id=3063
