### PR TITLE
Paulialgebra fix

### DIFF
--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -62,7 +62,11 @@ class Pauli(Symbol):
     (for example: 2*I*(Pauli(3)*Pauli(2)))
 
     Another variant is to use eval_sigma function to evaluate the product
-    of Pauli matricex and other symbols (with commutative multiply rules)
+    of Pauli matrices and other symbols (with commutative multiply rules)
+
+    See Also
+    =======
+    eval_sigma
 
     Examples
     ========

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -10,6 +10,8 @@ See also:
 
 from sympy import Symbol, I
 
+__all__ = ['evaluate_pauli_product']
+
 def delta(i,j):
     """
     Returns 1 if i == j, else 0.
@@ -55,10 +57,10 @@ def epsilon(i,j,k):
         return 0
 
 class Pauli(Symbol):
-    """ The class, representing algebraic properties of Pauli matrices
+    """ The class representing algebraic properties of Pauli matrices
 
-    If the left multiplication of symbol or number with Pauli matrix needed,
-    please use round brackets to separate Pauli and symbolic multiplication
+    If the left multiplication of symbol or number with Pauli matrix is needed,
+    please use parantheses to separate Pauli and symbolic multiplication
     (for example: 2*I*(Pauli(3)*Pauli(2)))
 
     Another variant is to use eval_sigma function to evaluate the product
@@ -123,7 +125,7 @@ class Pauli(Symbol):
         if e.is_Integer and e.is_positive:
             return super(Pauli, b).__pow__(int(e) % 2)
 
-def eval_sigma(arg):
+def evaluate_pauli_product(arg):
     ''' Help function to evaluate Pauli matrices product
     with symbolic obejcts
 

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -55,7 +55,18 @@ def epsilon(i,j,k):
         return 0
 
 class Pauli(Symbol):
-    """
+    """ The class, representing algebraic properties of Pauli matrices
+
+    If the left multiplication of symbol or number with Pauli matrix needed,
+    please use round brackets to separate Pauli and symbolic multiplication
+    (for example: 2*I*(Pauli(3)*Pauli(2)))
+
+    Another variant is to use eval_sigma function to evaluate the product
+    of Pauli matricex and other symbols (with commutative multiply rules)
+
+    Examples
+    ========
+
     >>> from sympy.physics.paulialgebra import Pauli
     >>> Pauli(1)
     sigma1
@@ -67,6 +78,17 @@ class Pauli(Symbol):
     1
     >>> Pauli(1)*Pauli(2)*Pauli(3)
     I
+
+    >>> from sympy import I
+    >>> I*(Pauli(2)*Pauli(3))
+    -sigma1
+
+    >>> from sympy.physics.paulialgebra import eval_sigma
+    >>> f = I*Pauli(2)*Pauli(3)
+    >>> f
+    I*sigma2*sigma3
+    >>> eval_sigma(f)
+    -sigma1
 
     """
 
@@ -96,3 +118,33 @@ class Pauli(Symbol):
     def _eval_power(b, e):
         if e.is_Integer and e.is_positive:
             return super(Pauli, b).__pow__(int(e) % 2)
+
+def eval_sigma(arg):
+    ''' Help function to evaluate Pauli matrices product
+    with symbolic obejcts
+
+    Parameters
+    ==========
+    arg: symbolic expression that contains Paulimatrices
+
+    Examples
+    ========
+
+    >>> from sympy.physics.paulialgebra import Pauli, eval_sigma
+    >>> from sympy import I
+    >>> eval_sigma(I*Pauli(1)*Pauli(2))
+    -sigma3
+
+    >>> from sympy.abc import x,y
+    >>> eval_sigma(x**2*Pauli(2)*Pauli(1))
+    -I*x**2*sigma3
+    '''
+    tmp = arg.as_coeff_mul()
+    sigma_product = 1
+    com_product = 1
+    for el in tmp[1]:
+        if isinstance(el, Pauli):
+            sigma_product *= el
+        else:
+            com_product *= el
+    return (sigma_product*com_product)

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -57,18 +57,19 @@ def epsilon(i,j,k):
         return 0
 
 class Pauli(Symbol):
-    """ The class representing algebraic properties of Pauli matrices
+    """The class representing algebraic properties of Pauli matrices
 
     If the left multiplication of symbol or number with Pauli matrix is needed,
-    please use parantheses to separate Pauli and symbolic multiplication
+    please use parentheses  to separate Pauli and symbolic multiplication
     (for example: 2*I*(Pauli(3)*Pauli(2)))
 
-    Another variant is to use eval_sigma function to evaluate the product
-    of Pauli matrices and other symbols (with commutative multiply rules)
+    Another variant is to use evaluate_pauli_product function to evaluate
+    the product of Pauli matrices and other symbols (with commutative
+    multiply rules)
 
     See Also
     =======
-    eval_sigma
+    evaluate_pauli_product
 
     Examples
     ========
@@ -89,11 +90,11 @@ class Pauli(Symbol):
     >>> I*(Pauli(2)*Pauli(3))
     -sigma1
 
-    >>> from sympy.physics.paulialgebra import eval_sigma
+    >>> from sympy.physics.paulialgebra import evaluate_pauli_product
     >>> f = I*Pauli(2)*Pauli(3)
     >>> f
     I*sigma2*sigma3
-    >>> eval_sigma(f)
+    >>> evaluate_pauli_product(f)
     -sigma1
 
     """
@@ -126,23 +127,24 @@ class Pauli(Symbol):
             return super(Pauli, b).__pow__(int(e) % 2)
 
 def evaluate_pauli_product(arg):
-    ''' Help function to evaluate Pauli matrices product
-    with symbolic obejcts
+    '''Help function to evaluate Pauli matrices product
+    with symbolic objects
 
     Parameters
     ==========
+
     arg: symbolic expression that contains Paulimatrices
 
     Examples
     ========
 
-    >>> from sympy.physics.paulialgebra import Pauli, eval_sigma
+    >>> from sympy.physics.paulialgebra import Pauli, evaluate_pauli_product
     >>> from sympy import I
-    >>> eval_sigma(I*Pauli(1)*Pauli(2))
+    >>> evaluate_pauli_product(I*Pauli(1)*Pauli(2))
     -sigma3
 
     >>> from sympy.abc import x,y
-    >>> eval_sigma(x**2*Pauli(2)*Pauli(1))
+    >>> evaluate_pauli_product(x**2*Pauli(2)*Pauli(1))
     -I*x**2*sigma3
     '''
     tmp = arg.as_coeff_mul()

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -7,7 +7,7 @@ sigma2 = Pauli(2)
 sigma3 = Pauli(3)
 
 def test_Pauli():
-    from sympy.physics.paulialgebra import eval_sigma
+    from sympy.physics.paulialgebra import evaluate_pauli_product
 
     assert sigma1 == sigma1
     assert sigma1 != sigma2
@@ -20,7 +20,7 @@ def test_Pauli():
     assert sigma2*sigma2 == 1
     assert sigma3*sigma3 == 1
 
-    assert eval_sigma(I*sigma2*sigma3) == -sigma1
+    assert evaluate_pauli_product(I*sigma2*sigma3) == -sigma1
 
     assert sigma1**0 == 1
     assert sigma1**1 == sigma1

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -7,6 +7,8 @@ sigma2 = Pauli(2)
 sigma3 = Pauli(3)
 
 def test_Pauli():
+    from sympy.physics.paulialgebra import eval_sigma
+
     assert sigma1 == sigma1
     assert sigma1 != sigma2
 
@@ -17,6 +19,8 @@ def test_Pauli():
     assert sigma1*sigma1 == 1
     assert sigma2*sigma2 == 1
     assert sigma3*sigma3 == 1
+
+    assert eval_sigma(I*sigma2*sigma3) == -sigma1
 
     assert sigma1**0 == 1
     assert sigma1**1 == sigma1


### PR DESCRIPTION
Fixed "FIXME don't work for -I_Pauli(2)_Pauli(3)" multiplication problem

Added eval_sigma function to evaluate the product of Pauli matrices and other symbols (with commutative multiply rules)

Added documentation and examples on using round brackets when calculating product of Pauli matrices and symbols (or numbers), or evaluating the obtained expression in terms of sigma matrices. 

Another idea to obtain the correct product (needs proper realization using _op_priority attribute):
to calculate the right product of Pauli matrices first rather then left one.

alexandr.s.popov@gmail.com
