### PR TITLE
Latex Printing of TransformationSet

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -974,7 +974,7 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_ProductSet(self, p):
-        return r" \cross ".join(self._print(set) for set in p.sets)
+        return r" \times ".join(self._print(set) for set in p.sets)
 
     def _print_RandomDomain(self, d):
         try:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1025,6 +1025,18 @@ class LatexPrinter(Printer):
     def _print_EmptySet(self, e):
         return r"\emptyset"
 
+    def _print_Naturals(self, n):
+        return r"\mathbb{N}"
+
+    def _print_Integers(self, i):
+        return r"\mathbb{Z}"
+
+    def _print_TransformationSet(self, s):
+        return r"\left\{%s\; |\; %s \in %s\right\}"%(
+                self._print(s.lamda.expr),
+                ', '.join([self._print(var) for var in s.lamda.variables]),
+                self._print(s.base_set))
+
     def _print_FiniteField(self, expr):
         return r"\mathbb{F}_{%s}" % expr.mod
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1178,7 +1178,7 @@ class PrettyPrinter(Printer):
         variables = self._print_seq(ts.lamda.variables)
         expr = self._print(ts.lamda.expr)
         bar = self._print("|")
-        inn = self._print("in")
+        inn = self._print(u"\u220a")
         base = self._print(ts.base_set)
 
         return self._print_seq((expr, bar, variables, inn, base), "{", "}", ' ')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -77,6 +77,8 @@ class PrettyPrinter(Printer):
     _print_Infinity         = _print_Atom
     _print_NegativeInfinity = _print_Atom
     _print_EmptySet         = _print_Atom
+    _print_Naturals         = _print_Atom
+    _print_Integers         = _print_Atom
 
     def _print_factorial(self, e):
         x = e.args[0]

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1172,6 +1172,15 @@ class PrettyPrinter(Printer):
         return self._print_seq(u.args, None, None, union_delimiter,
              parenthesize = lambda set:set.is_ProductSet or set.is_Intersection)
 
+    def _print_TransformationSet(self, ts):
+        variables = self._print_seq(ts.lamda.variables)
+        expr = self._print(ts.lamda.expr)
+        bar = self._print("|")
+        inn = self._print("in")
+        base = self._print(ts.base_set)
+
+        return self._print_seq((expr, bar, variables, inn, base), "{", "}", ' ')
+
     def _print_seq(self, seq, left=None, right=None, delimiter=', ',
             parenthesize=lambda x: False):
         s = None

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -392,6 +392,8 @@ atoms_table = {
     #'ImaginaryUnit'     :   U('MATHEMATICAL ITALIC SMALL I'),
     'ImaginaryUnit'     :   U('DOUBLE-STRUCK ITALIC SMALL I'),
     'EmptySet'          :   U('EMPTY SET'),
+    'Naturals'          :   U('DOUBLE-STRUCK CAPITAL N'),
+    'Integers'          :   U('DOUBLE-STRUCK CAPITAL Z'),
     'Union'             :   U('UNION'),
     'Intersection'      :   U('INTERSECTION')
 }

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -8,7 +8,7 @@ from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
     Tuple, MellinTransform, InverseMellinTransform, LaplaceTransform,
     InverseLaplaceTransform, FourierTransform, InverseFourierTransform,
     SineTransform, InverseSineTransform, CosineTransform,
-    InverseCosineTransform, FiniteSet)
+    InverseCosineTransform, FiniteSet, TransformationSet)
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
@@ -271,6 +271,15 @@ def test_latex_union():
         r"\left[0, 1\right] \cup \left[2, 3\right]"
     assert latex(Union(Interval(1, 1), Interval(2, 2), Interval(3, 4))) == \
         r"\left\{1, 2\right\} \cup \left[3, 4\right]"
+
+def test_latex_Naturals():
+    assert latex(S.Naturals) == r"\mathbb{N}"
+    assert latex(S.Integers) == r"\mathbb{Z}"
+
+def test_latex_TransformationSet():
+    x = Symbol('x')
+    assert latex(TransformationSet(Lambda(x, x**2), S.Naturals)) == \
+            r"\left\{x^{2}\; |\; x \in \mathbb{N}\right\}"
 
 def test_latex_sum():
     assert latex(Sum(x*y**2, (x, -2, 2), (y, -5, 5))) == \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -272,6 +272,11 @@ def test_latex_union():
     assert latex(Union(Interval(1, 1), Interval(2, 2), Interval(3, 4))) == \
         r"\left\{1, 2\right\} \cup \left[3, 4\right]"
 
+def test_latex_productset():
+    line = Interval(0,1)
+    assert latex(line**2) == r"%s \times %s"%(latex(line), latex(line))
+    assert latex(line**3) == r"%s \times %s \times %s"%((latex(line),)*3)
+
 def test_latex_Naturals():
     assert latex(S.Naturals) == r"\mathbb{N}"
     assert latex(S.Integers) == r"\mathbb{Z}"

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -783,7 +783,7 @@ def ratsimpmodprime(expr, G, *gens, **args):
     from sympy.polys.polyerrors import PolificationFailed
     from sympy import monomials, symbols, solve, Monomial
     from sympy.polys.monomialtools import monomial_div
-    from itertools import product
+    from sympy.core.compatibility import product
 
     # usual preparation of polynomials:
 


### PR DESCRIPTION
Now we latex print TransformationSets in the form

``` python
In [1]: print latex(TransformationSet(Lambda(x, x**2), S.Naturals))
\left\{x^{2}\; |\; x \in \mathbb{N}\right\}
```

looks like {x^2  |  x \in N}

Or for multiple variables in the base set 

``` python
In [4]: r, th = symbols('r, theta', real=True)
In [5]: L = Lambda((r, th), (r*cos(th), r*sin(th)))
In [6]: halfcircle = TransformationSet(L, Interval(0, 1)*Interval(0, pi))
In [7]: print latex(halfcircle)
```

looks like 
http://goo.gl/BrDQa

Also fixed ProductSet to use \times rather than \cross (which doesn't seem to exist)
