### PR TITLE
Added Fresnel integrals into functions/special/error_functions.py

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -883,6 +883,14 @@ def test_sympy__functions__special__error_functions__Ei():
     from sympy.functions.special.error_functions import Ei
     assert _test_args(Ei(2))
 
+def test_sympy__functions__special__error_functions__FresnelS():
+    from sympy.functions.special.error_functions import FresnelS
+    assert _test_args(FresnelS(2))
+
+def test_sympy__functions__special__error_functions__FresnelC():
+    from sympy.functions.special.error_functions import FresnelC
+    assert _test_args(FresnelC(2))
+
 @SKIP("abstract class")
 def test_sympy__functions__special__error_functions__TrigonometricIntegral():
     pass

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -29,7 +29,8 @@ from elementary.hyperbolic import sinh, cosh, tanh, coth, asinh, acosh, atanh, a
 from elementary.integers import floor, ceiling
 from elementary.piecewise import Piecewise, piecewise_fold
 
-from special.error_functions import erf, Ei, expint, E1, Si, Ci, Shi, Chi
+from special.error_functions import erf, Ei, expint, E1, Si, Ci, Shi, Chi, \
+                                    FresnelS, FresnelC
 from special.gamma_functions import gamma, lowergamma, uppergamma, polygamma, \
          loggamma, digamma, trigamma, beta
 from special.zeta_functions import dirichlet_eta, zeta, lerchphi, polylog

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -451,6 +451,45 @@ def E1(z):
     """
     return expint(1, z)
 
+###############################################################################
+########################### FRESNAL INTEGRALS #################################
+###############################################################################
+class FresnelS(Function):
+    """The Fresnel sine integral
+    S(x)=sqrt(2/pi)*int_0^x\sin(t^2)dt
+    """
+    
+    def fdiff(self, argindex=1):
+        if argindex == 1:
+            return sqrt(2/S.Pi)*C.sin(self.args[0]**2)
+        else:
+            raise ArgumentIndexError(self, argindex)
+        
+    @classmethod
+    def eval(cls, arg):
+        if arg.is_Number:
+            if arg is S.NaN:
+                return S.NaN
+            elif arg is S.Infinity:
+                return sqrt(2*S.Pi)/4
+            elif arg is S.NegativeInfinity:
+                return -sqrt(2*S.Pi)/4
+            elif arg is S.Zero:
+                return S.Zero
+
+        #t = arg.extract_multiplicatively(S.ImaginaryUnit)
+        #if t == S.Infinity or t == S.NegativeInfinity:
+        #    return arg
+
+        if arg.could_extract_minus_sign():
+            return -cls(-arg)    
+    
+    def _eval_nseries(self, x, n):
+    
+class FresnelC(Function):
+    """The Fresnel cosine integral
+    C(x)=sqrt(2/pi)*int_0^x\cos(t^2)dt
+    """
 
 ###############################################################################
 #################### TRIGONOMETRIC INTEGRALS ##################################

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -500,8 +500,7 @@ class FresnelS(Function):
 
     @classmethod
     def eval(cls, arg):
-	"""Evaluates the Fresnel sine integral (asymptotics)
-	"""
+        """Evaluates the Fresnel sine integral (asymptotics)"""
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -531,12 +530,12 @@ class FresnelS(Function):
                (4. * n + 3.) / C.factorial(2 * n + 1).n()
 
     def _eval_num(self, x, e=1e-10):
-        """Calculates the Fresnel sine integral value by obtaining
-	the expansion series sum.
-	Convergence parameter e is set as argument (default = 1e-10)
+        """Calculates the Fresnel sine integral value by obtaining the
+        expansion series sum.
+        Convergence parameter e is set as argument (default = 1e-10)
 
-	Examples
-	========
+        Examples
+        ========
 
         >>> from sympy.functions.special.error_functions import FresnelS
         >>> from sympy import Symbol
@@ -580,11 +579,11 @@ class FresnelS(Function):
         return sum
 
     def _eval_rewrite_as_erf(self):
-	"""Rewrites the Fresnel sine integral using erf function
+        """Rewrites the Fresnel sine integral using erf function
 
-	SeeAlso
-	========
-	erf
+        SeeAlso
+        =======
+        erf
 
         Examples
         ========
@@ -673,11 +672,12 @@ class FresnelC(Function):
                (4. * n + 1.) / C.factorial(2 * n).n()
 
     def _eval_num(self, x, e=1e-10):
-	"""Calculates the Fresnel cosine integral value by obtaining the expansion series sum.
-	Convergence parameter e is set as argument (default = 1e-10)
+        """Calculates the Fresnel cosine integral value by obtaining the
+        expansion series sum.
+        Convergence parameter e is set as argument (default = 1e-10)
 
-	Examples
-	========
+        Examples
+        ========
 
         >>> from sympy.functions.special.error_functions import FresnelC
         >>> from sympy import Symbol

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -457,9 +457,26 @@ def E1(z):
 class FresnelS(Function):
     """The Fresnel sine integral
     S(x)=sqrt(2/pi)*int_0^x\sin(t^2)dt
+    
+    Exampls
+    =======
+    >>> from sympy.functions.special.error_functions import FresnelS
+    >>> from sympy.abc import x, y
+    >>> FresnelS(x)
+    FresnelS(x)
     """
     
     def fdiff(self, argindex=1):
+        """Derivative for Fresnel S(x) integral
+        
+        Examples
+        ========
+        >>> from sympy.functions.special.error_functions import FresnelS
+        >>> from sympy import symbols, diff
+        >>> b, z = symbols(('b z'))
+        >>> diff(FresnelS(b*z), z)
+        sqrt(2)*b*sin(b**2*z**2)/sqrt(pi)
+        """
         if argindex == 1:
             return sqrt(2/S.Pi)*C.sin(self.args[0]**2)
         else:
@@ -471,25 +488,34 @@ class FresnelS(Function):
             if arg is S.NaN:
                 return S.NaN
             elif arg is S.Infinity:
-                return sqrt(2*S.Pi)/4
+                return sqrt(2 * S.Pi) / 4
             elif arg is S.NegativeInfinity:
-                return -sqrt(2*S.Pi)/4
+                return -sqrt(2 * S.Pi) / 4
             elif arg is S.Zero:
                 return S.Zero
-
-        #t = arg.extract_multiplicatively(S.ImaginaryUnit)
-        #if t == S.Infinity or t == S.NegativeInfinity:
-        #    return arg
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)    
     
-    def _eval_nseries(self, x, n):
+    def expansion_term(self, x, n):
+        """The most generalized and simple expansion term
+        
+        Example
+        =======
+        
+        >>> from sympy.functions.special.error_functions import FresnelS
+        >>> from sympy.abc import x
+        >>> FresnelS(x).expansion_term(x, 1)
+        -sqrt(2)*x**7/(63*sqrt(pi))
+        """
+        return sqrt(2 / S.Pi)*(x**3 / 3)*(-x**4 * n) / \
+               (4 * n + 3) / factorial(2 * n + 1)
     
 class FresnelC(Function):
     """The Fresnel cosine integral
     C(x)=sqrt(2/pi)*int_0^x\cos(t^2)dt
     """
+    pass
 
 ###############################################################################
 #################### TRIGONOMETRIC INTEGRALS ##################################

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, expand, erf, nan, oo, Float, conjugate, sqrt, exp, pi, O, I, Ei,
                    exp_polar, polar_lift, Symbol, I, exp, uppergamma, expint, log, loggamma, limit,
-                   meijerg, gamma, S, Shi, Chi, Si, Ci, E1, sin, cos, sinh, cosh)
+                   meijerg, gamma, S, Shi, Chi, Si, Ci, E1, FresnelS, FresnelC, sin, cos, sinh, cosh, diff)
 
 from sympy.functions.special.error_functions import _erfs
 
@@ -157,6 +157,26 @@ def tn_arg(func):
            test(exp_polar(-I*pi/2), -I, 1) and \
            test(exp_polar(I*pi), -1, I) and \
            test(exp_polar(-I*pi), -1, -I)
+
+def test_fresnel():
+    b, z = symbols(('b z'))
+    assert FresnelS(oo) == sqrt(2)*sqrt(pi)/4
+    assert FresnelS(-z) == -FresnelS(z)
+    assert diff(FresnelS(b*z), z) == sqrt(2)*b*sin(b**2*z**2)/sqrt(pi)
+    c, d = FresnelS(x)._eval_expansion_term(x,1).as_two_terms()
+    assert round(c, 5) == -0.00633
+    assert d == x**7
+    assert FresnelS(x)._eval_rewrite_as_erf() ==  \
+          (S.Pi/4) * (sqrt(I) * erf(sqrt(I) * x) + sqrt(-I) * erf(sqrt(-I) * x))
+
+    assert FresnelC(oo) == sqrt(2)*sqrt(pi)/4
+    assert FresnelC(-z) == -FresnelC(z)
+    assert diff(FresnelC(b*z), z) == sqrt(2)*b*cos(b**2*z**2)/sqrt(pi)
+    c, d = FresnelC(x)._eval_expansion_term(x,1).as_two_terms()
+    assert round(c, 5) == -0.07979
+    assert d == x**5
+    assert FresnelC(x)._eval_rewrite_as_erf() ==  \
+          (S.Pi/4) * (sqrt(-I) * erf(sqrt(I) * x) + sqrt(I) * erf(sqrt(-I) * x))
 
 def test_si():
     assert Si(I*x) == I*Shi(x)


### PR DESCRIPTION
Fresnel sine and cosine integrals were added (`FresnelS` and `FresnelC`). 
The asymptotic evaluation, generalised expansion, numerical evaluation and
error function representation was implemented for these classes.

Both with Fresnel cosine integral C(x), Fresnel integrals used in optics,
arise in the description of near field Fresnel diffraction phenomena.
Parametric plot of S(t) against C(t) forms Euler (Cornu) spiral.
