### PR TITLE
Range set

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -352,6 +352,10 @@ def test_sympy__sets__fancysets__TransformationSet():
     x = Symbol('x')
     assert _test_args(TransformationSet(Lambda(x, x**2), S.Naturals))
 
+def test_sympy__sets__fancysets__RangeSet():
+    from sympy.sets.fancysets import RangeSet
+    assert _test_args(RangeSet(1, 5, 1))
+
 # STATS
 def normal_pdf(x):
     from sympy import pi, exp, sqrt

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -352,9 +352,9 @@ def test_sympy__sets__fancysets__TransformationSet():
     x = Symbol('x')
     assert _test_args(TransformationSet(Lambda(x, x**2), S.Naturals))
 
-def test_sympy__sets__fancysets__RangeSet():
-    from sympy.sets.fancysets import RangeSet
-    assert _test_args(RangeSet(1, 5, 1))
+def test_sympy__sets__fancysets__Range():
+    from sympy.sets.fancysets import Range
+    assert _test_args(Range(1, 5, 1))
 
 # STATS
 def normal_pdf(x):

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -346,6 +346,7 @@ def test_sympy__sets__fancysets__Integers():
     from sympy.sets.fancysets import Integers
     assert _test_args(Integers())
 
+@XFAIL # This fails for the same reason Interval fails. Not all args are Basic
 def test_sympy__sets__fancysets__Reals():
     from sympy.sets.fancysets import Reals
     assert _test_args(Reals())

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -346,6 +346,10 @@ def test_sympy__sets__fancysets__Integers():
     from sympy.sets.fancysets import Integers
     assert _test_args(Integers())
 
+def test_sympy__sets__fancysets__Reals():
+    from sympy.sets.fancysets import Reals
+    assert _test_args(Reals())
+
 def test_sympy__sets__fancysets__TransformationSet():
     from sympy.sets.fancysets import TransformationSet
     from sympy import S, Lambda, Symbol

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -974,7 +974,11 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_ProductSet(self, p):
-        return r" \times ".join(self._print(set) for set in p.sets)
+        if len(set(p.sets)) == 1 and len(p.sets) > 1:
+            from sympy import Pow
+            return self._print(p.sets[0]) + "^%d"%len(p.sets)
+        else:
+            return r" \times ".join(self._print(set) for set in p.sets)
 
     def _print_RandomDomain(self, d):
         try:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -996,7 +996,7 @@ class LatexPrinter(Printer):
 
     _print_frozenset = _print_set
 
-    def _print_RangeSet(self, s):
+    def _print_Range(self, s):
         if len(s) > 4:
             it = iter(s)
             printset = it.next(), it.next(), '\ldots', s._last_element

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -996,6 +996,17 @@ class LatexPrinter(Printer):
 
     _print_frozenset = _print_set
 
+    def _print_Range(self, s):
+        if len(s) > 4:
+            it = iter(s)
+            printset = it.next(), it.next(), '\ldots', s._last_element
+        else:
+            printset = tuple(s)
+
+        return (r"\left\{"
+              + r", ".join(self._print(el) for el in printset)
+              + r"\right\}")
+
     def _print_Interval(self, i):
         if i.start == i.end:
             return r"\left\{%s\right\}" % self._print(i.start)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1040,6 +1040,9 @@ class LatexPrinter(Printer):
     def _print_Integers(self, i):
         return r"\mathbb{Z}"
 
+    def _print_Reals(self, i):
+        return r"\mathbb{R}"
+
     def _print_TransformationSet(self, s):
         return r"\left\{%s\; |\; %s \in %s\right\}"%(
                 self._print(s.lamda.expr),

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -975,7 +975,6 @@ class LatexPrinter(Printer):
 
     def _print_ProductSet(self, p):
         if len(set(p.sets)) == 1 and len(p.sets) > 1:
-            from sympy import Pow
             return self._print(p.sets[0]) + "^%d"%len(p.sets)
         else:
             return r" \times ".join(self._print(set) for set in p.sets)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -996,7 +996,7 @@ class LatexPrinter(Printer):
 
     _print_frozenset = _print_set
 
-    def _print_Range(self, s):
+    def _print_RangeSet(self, s):
         if len(s) > 4:
             it = iter(s)
             printset = it.next(), it.next(), '\ldots', s._last_element

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1133,8 +1133,12 @@ class PrettyPrinter(Printer):
             return self.emptyPrinter(expr)
 
     def _print_ProductSet(self, p):
-        prod_char = u'\xd7'
-        return self._print_seq(p.sets, None, None, ' %s '%prod_char,
+        if len(set(p.sets)) == 1 and len(p.sets) > 1:
+            from sympy import Pow
+            return self._print(Pow(p.sets[0], len(p.sets), evaluate=False))
+        else:
+            prod_char = u'\xd7'
+            return self._print_seq(p.sets, None, None, ' %s '%prod_char,
                 parenthesize = lambda set:set.is_Union or set.is_Intersection)
 
     def _print_FiniteSet(self, s):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -79,6 +79,7 @@ class PrettyPrinter(Printer):
     _print_EmptySet         = _print_Atom
     _print_Naturals         = _print_Atom
     _print_Integers         = _print_Atom
+    _print_Reals            = _print_Atom
 
     def _print_factorial(self, e):
         x = e.args[0]

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1140,6 +1140,10 @@ class PrettyPrinter(Printer):
         items = sorted(s.args, key=default_sort_key)
         return self._print_seq(items, '{', '}', ', ' )
 
+    def _print_Range(self, s):
+        from sympy.core.sets import FiniteSet
+        return self._print_FiniteSet(FiniteSet(*s))
+
     def _print_Interval(self, i):
         if i.start == i.end:
             return self._print_seq(i.args[:1], '{', '}')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1140,7 +1140,7 @@ class PrettyPrinter(Printer):
         items = sorted(s.args, key=default_sort_key)
         return self._print_seq(items, '{', '}', ', ' )
 
-    def _print_Range(self, s):
+    def _print_RangeSet(self, s):
 
         if self._use_unicode:
             dots = u"\u2026"

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1141,9 +1141,15 @@ class PrettyPrinter(Printer):
         return self._print_seq(items, '{', '}', ', ' )
 
     def _print_Range(self, s):
+
+        if self._use_unicode:
+            dots = u"\u2026"
+        else:
+            dots = '...'
+
         if len(s) > 4:
             it = iter(s)
-            printset = it.next(), it.next(), '...', s._last_element
+            printset = it.next(), it.next(), dots, s._last_element
         else:
             printset = tuple(s)
 
@@ -1181,10 +1187,13 @@ class PrettyPrinter(Printer):
              parenthesize = lambda set:set.is_ProductSet or set.is_Intersection)
 
     def _print_TransformationSet(self, ts):
+        if self._use_unicode:
+            inn = u"\u220a"
+        else:
+            inn = 'in'
         variables = self._print_seq(ts.lamda.variables)
         expr = self._print(ts.lamda.expr)
         bar = self._print("|")
-        inn = self._print(u"\u220a")
         base = self._print(ts.base_set)
 
         return self._print_seq((expr, bar, variables, inn, base), "{", "}", ' ')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1141,8 +1141,13 @@ class PrettyPrinter(Printer):
         return self._print_seq(items, '{', '}', ', ' )
 
     def _print_Range(self, s):
-        from sympy.core.sets import FiniteSet
-        return self._print_FiniteSet(FiniteSet(*s))
+        if len(s) > 4:
+            it = iter(s)
+            printset = it.next(), it.next(), '...', s._last_element
+        else:
+            printset = tuple(s)
+
+        return self._print_seq(printset, '{', '}', ', ' )
 
     def _print_Interval(self, i):
         if i.start == i.end:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1140,7 +1140,7 @@ class PrettyPrinter(Printer):
         items = sorted(s.args, key=default_sort_key)
         return self._print_seq(items, '{', '}', ', ' )
 
-    def _print_RangeSet(self, s):
+    def _print_Range(self, s):
 
         if self._use_unicode:
             dots = u"\u2026"

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -394,6 +394,7 @@ atoms_table = {
     'EmptySet'          :   U('EMPTY SET'),
     'Naturals'          :   U('DOUBLE-STRUCK CAPITAL N'),
     'Integers'          :   U('DOUBLE-STRUCK CAPITAL Z'),
+    'Reals'             :   U('DOUBLE-STRUCK CAPITAL R'),
     'Union'             :   U('UNION'),
     'Intersection'      :   U('INTERSECTION')
 }

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -8,7 +8,7 @@ from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
     Tuple, MellinTransform, InverseMellinTransform, LaplaceTransform,
     InverseLaplaceTransform, FourierTransform, InverseFourierTransform,
     SineTransform, InverseSineTransform, CosineTransform,
-    InverseCosineTransform, FiniteSet, TransformationSet)
+    InverseCosineTransform, FiniteSet, TransformationSet, Range)
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
@@ -246,6 +246,11 @@ def test_latex_sets():
         assert latex(s(range(1, 6))) == r"\left\{1, 2, 3, 4, 5\right\}"
         assert latex(s(range(1, 13))) == \
             r"\left\{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12\right\}"
+
+def test_latex_Range():
+    assert latex(Range(1, 51)) ==\
+            r'\left\{1, 2, \ldots, 50\right\}'
+    assert latex(Range(1, 4)) == r'\left\{1, 2, 3\right\}'
 
 def test_latex_intervals():
     a = Symbol('a', real=True)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -8,7 +8,7 @@ from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
     Tuple, MellinTransform, InverseMellinTransform, LaplaceTransform,
     InverseLaplaceTransform, FourierTransform, InverseFourierTransform,
     SineTransform, InverseSineTransform, CosineTransform,
-    InverseCosineTransform, FiniteSet, TransformationSet, Range)
+    InverseCosineTransform, FiniteSet, TransformationSet, RangeSet)
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
@@ -247,10 +247,10 @@ def test_latex_sets():
         assert latex(s(range(1, 13))) == \
             r"\left\{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12\right\}"
 
-def test_latex_Range():
-    assert latex(Range(1, 51)) ==\
+def test_latex_RangeSet():
+    assert latex(RangeSet(1, 51)) ==\
             r'\left\{1, 2, \ldots, 50\right\}'
-    assert latex(Range(1, 4)) == r'\left\{1, 2, 3\right\}'
+    assert latex(RangeSet(1, 4)) == r'\left\{1, 2, 3\right\}'
 
 def test_latex_intervals():
     a = Symbol('a', real=True)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -8,7 +8,7 @@ from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
     Tuple, MellinTransform, InverseMellinTransform, LaplaceTransform,
     InverseLaplaceTransform, FourierTransform, InverseFourierTransform,
     SineTransform, InverseSineTransform, CosineTransform,
-    InverseCosineTransform, FiniteSet, TransformationSet, RangeSet)
+    InverseCosineTransform, FiniteSet, TransformationSet, Range)
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
@@ -247,10 +247,10 @@ def test_latex_sets():
         assert latex(s(range(1, 13))) == \
             r"\left\{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12\right\}"
 
-def test_latex_RangeSet():
-    assert latex(RangeSet(1, 51)) ==\
+def test_latex_Range():
+    assert latex(Range(1, 51)) ==\
             r'\left\{1, 2, \ldots, 50\right\}'
-    assert latex(RangeSet(1, 4)) == r'\left\{1, 2, 3\right\}'
+    assert latex(Range(1, 4)) == r'\left\{1, 2, 3\right\}'
 
 def test_latex_intervals():
     a = Symbol('a', real=True)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -272,8 +272,11 @@ def test_latex_union():
 
 def test_latex_productset():
     line = Interval(0,1)
-    assert latex(line**2) == r"%s \times %s"%(latex(line), latex(line))
-    assert latex(line**3) == r"%s \times %s \times %s"%((latex(line),)*3)
+    bigline = Interval(0, 10)
+    fset = FiniteSet(1, 2, 3)
+    assert latex(line**2) == r"%s^2"%latex(line)
+    assert latex(line * bigline * fset) == r"%s \times %s \times %s"%(
+            latex(line), latex(bigline), latex(fset))
 
 def test_latex_Naturals():
     assert latex(S.Naturals) == r"\mathbb{N}"

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,1 +1,1 @@
-from fancysets import TransformationSet, RangeSet
+from fancysets import TransformationSet, Range

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,1 +1,1 @@
-from fancysets import TransformationSet, Range
+from fancysets import TransformationSet, RangeSet

--- a/sympy/sets/__init__.py
+++ b/sympy/sets/__init__.py
@@ -1,1 +1,1 @@
-from fancysets import TransformationSet
+from fancysets import TransformationSet, Range

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -177,21 +177,21 @@ class TransformationSet(Set):
     def is_iterable(self):
         return self.base_set.is_iterable
 
-class Range(Set):
+class RangeSet(Set):
     """
     Represents a range of integers.
 
     Examples
     ========
 
-        >>> from sympy import Range
-        >>> Range(5) # 0 to 5
+        >>> from sympy import RangeSet
+        >>> RangeSet(5) # 0 to 5
         {0, 1, 2, 3, 4}
-        >>> Range(10, 15) # 10 to 15
+        >>> RangeSet(10, 15) # 10 to 15
         {10, 11, 12, 13, 14}
-        >>> Range(10, 20, 2) # 10 to 20 in steps of 2
+        >>> RangeSet(10, 20, 2) # 10 to 20 in steps of 2
         {10, 12, 14, 16, 18}
-        >>> Range(20, 10, -2)
+        >>> RangeSet(20, 10, -2)
         {20, 18, 16, 14, 12} # 20 to 10 backward in steps of 2
 
     """
@@ -206,7 +206,7 @@ class Range(Set):
 
         start, stop, step = map(sympify, (start, stop, step))
         if not all(ask(Q.integer(x)) for x in (start, stop, step)):
-            raise ValueError("Inputs to Range must be Integer Valued\n"+
+            raise ValueError("Inputs to RangeSet must be Integer Valued\n"+
                     "Use TransformationSets of Ranges for other cases")
 
         s = Basic.__new__(cls, start, stop, step)
@@ -238,7 +238,7 @@ class Range(Set):
             while(inf not in self):
                 inf += 1
 
-            return Range(inf, sup+1, abs(self.step))
+            return RangeSet(inf, sup+1, abs(self.step))
 
         if other == S.Naturals:
             return self._intersect(Interval(1, oo))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -238,7 +238,7 @@ class Range(Set):
             while(inf not in self):
                 inf += 1
 
-            return Range(inf, sup, self.step)
+            return Range(inf, sup+1, abs(self.step))
 
         if other == S.Naturals:
             return self._intersect(Interval(1, oo))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -187,14 +187,14 @@ class RangeSet(Set):
     ========
 
         >>> from sympy import RangeSet
-        >>> RangeSet(5) # 0 to 5
-        RangeSet(0, 5, 1) or {0, 1, 2, 3, 4}
-        >>> RangeSet(10, 15) # 10 to 15
-        RangeSet(10, 15, 1) or {10, 11, 12, 13, 14}
-        >>> RangeSet(10, 20, 2) # 10 to 20 in steps of 2
-        RangeSet(10, 20, 2) or {10, 12, 14, 16, 18}
-        >>> RangeSet(20, 10, -2) # 20 to 10 backward in steps of 2
-        RangeSet(12, 22, 2) or {12, 14, 16, 18, 20}
+        >>> list(RangeSet(5)) # 0 to 5
+        [0, 1, 2, 3, 4]
+        >>> list(RangeSet(10, 15)) # 10 to 15
+        [10, 11, 12, 13, 14]
+        >>> list(RangeSet(10, 20, 2)) # 10 to 20 in steps of 2
+        [10, 12, 14, 16, 18]
+        >>> list(RangeSet(20, 10, -2)) # 20 to 10 backward in steps of 2
+        [12, 14, 16, 18, 20]
 
     """
 
@@ -212,7 +212,7 @@ class RangeSet(Set):
         n = ceiling((stop - start)/step)
         if n <= 0:
             return S.EmptySet
-        
+
         # normalize args: regardless of how they are entered they will show
         # canonically as RangeSet(inf, sup, step) with step > 0
         start, stop = sorted((start, start + (n - 1)*step))
@@ -228,8 +228,6 @@ class RangeSet(Set):
         if other.is_Interval:
             osup = other.sup
             oinf = other.inf
-            # XXX shouldn't inf give lowest element *in* the interval
-            # and hence do this automatically?
             # if other is [0, 10) we can only go up to 9
             if osup.is_integer and other.right_open:
                 osup -= 1

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -206,15 +206,17 @@ class Range(Set):
         if len(args) == 3:                      # Range(1, 6, 2) = {1, 3, 5}
             start, stop, step = args[0], args[1], args[2]
 
-        if (stop <= start and step>0):
-            return S.EmptySet
-
         start, stop, step = map(sympify, (start, stop, step))
         if not all(ask(Q.integer(x)) for x in (start, stop, step)):
             raise ValueError("Inputs to Range must be Integer Valued\n"+
                     "Use TransformationSets of Ranges for other cases")
 
-        return Basic.__new__(cls, start, stop, step)
+        s = Basic.__new__(cls, start, stop, step)
+
+        if len(s) == 0:
+            return S.EmptySet
+
+        return s
 
     start = property(lambda self : self.args[0])
     stop  = property(lambda self : self.args[1])
@@ -268,4 +270,4 @@ class Range(Set):
         return Max(self.start, self._last_element)
 
     def __len__(self):
-        return floor((self.stop - self.start)/self.step)
+        return ceiling((self.stop - self.start)/self.step)

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -179,21 +179,21 @@ class TransformationSet(Set):
     def is_iterable(self):
         return self.base_set.is_iterable
 
-class RangeSet(Set):
+class Range(Set):
     """
     Represents a range of integers.
 
     Examples
     ========
 
-        >>> from sympy import RangeSet
-        >>> list(RangeSet(5)) # 0 to 5
+        >>> from sympy import Range
+        >>> list(Range(5)) # 0 to 5
         [0, 1, 2, 3, 4]
-        >>> list(RangeSet(10, 15)) # 10 to 15
+        >>> list(Range(10, 15)) # 10 to 15
         [10, 11, 12, 13, 14]
-        >>> list(RangeSet(10, 20, 2)) # 10 to 20 in steps of 2
+        >>> list(Range(10, 20, 2)) # 10 to 20 in steps of 2
         [10, 12, 14, 16, 18]
-        >>> list(RangeSet(20, 10, -2)) # 20 to 10 backward in steps of 2
+        >>> list(Range(20, 10, -2)) # 20 to 10 backward in steps of 2
         [12, 14, 16, 18, 20]
 
     """
@@ -207,14 +207,14 @@ class RangeSet(Set):
         try:
             start, stop, step = [S(int_tested(w)) for w in (start, stop, step)]
         except ValueError:
-            raise ValueError("Inputs to RangeSet must be Integer Valued\n"+
+            raise ValueError("Inputs to Range must be Integer Valued\n"+
                     "Use TransformationSets of Ranges for other cases")
         n = ceiling((stop - start)/step)
         if n <= 0:
             return S.EmptySet
 
         # normalize args: regardless of how they are entered they will show
-        # canonically as RangeSet(inf, sup, step) with step > 0
+        # canonically as Range(inf, sup, step) with step > 0
         start, stop = sorted((start, start + (n - 1)*step))
         step = abs(step)
 
@@ -243,7 +243,7 @@ class RangeSet(Set):
             if off:
                 inf += self.step - off
 
-            return RangeSet(inf, sup + 1, self.step)
+            return Range(inf, sup + 1, self.step)
 
         if other == S.Naturals:
             return self._intersect(Interval(1, oo))

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -192,7 +192,7 @@ class Range(Set):
         >>> Range(10, 20, 2) # 10 to 20 in steps of 2
         {10, 12, 14, 16, 18}
         >>> Range(20, 10, -2)
-        {20, 18, 16, 14, 12} # 20 10 10 backward in steps of 2
+        {20, 18, 16, 14, 12} # 20 to 10 backward in steps of 2
 
     """
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -114,6 +114,11 @@ class Integers(Set):
     def _sup(self):
         return oo
 
+class Reals(Interval):
+    __metaclass__ = Singleton
+    def __new__(cls):
+        return Interval.__new__(cls, -oo, oo)
+
 class TransformationSet(Set):
     """
     A set that is a transformation of another through some algebraic expression

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,4 +1,4 @@
-from sympy.sets.fancysets import TransformationSet, Range
+from sympy.sets.fancysets import TransformationSet, RangeSet
 from sympy.core.sets import FiniteSet, Interval
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
         Rational, sqrt)
@@ -79,49 +79,49 @@ def test_transformation_iterator_not_injetive():
     # No repeats here
     assert (i.next(), i.next(), i.next(), i.next()) == (0, 2, 4, 6)
 
-def test_range():
-    assert Range(5) == Range(0, 5) == Range(0, 5, 1)
+def test_RangeSet():
+    assert RangeSet(5) == RangeSet(0, 5) == RangeSet(0, 5, 1)
 
-    r = Range(10, 20, 2)
+    r = RangeSet(10, 20, 2)
     assert 12 in r
     assert 8 not in r
     assert 11 not in r
     assert 30 not in r
 
-    assert list(Range(0, 5)) == [0, 1, 2, 3, 4]
-    assert list(Range(5, 0, -1)) == [5, 4, 3, 2, 1]
+    assert list(RangeSet(0, 5)) == [0, 1, 2, 3, 4]
+    assert list(RangeSet(5, 0, -1)) == [5, 4, 3, 2, 1]
 
-    assert Range(5, 15).sup == 14
-    assert Range(5, 15).inf == 5
-    assert Range(15, 5, -1).sup == 15
-    assert Range(15, 5, -1).inf == 6
-    assert Range(10, 67, 10).sup == 60
-    assert Range(60, 7, -10).inf == 10
+    assert RangeSet(5, 15).sup == 14
+    assert RangeSet(5, 15).inf == 5
+    assert RangeSet(15, 5, -1).sup == 15
+    assert RangeSet(15, 5, -1).inf == 6
+    assert RangeSet(10, 67, 10).sup == 60
+    assert RangeSet(60, 7, -10).inf == 10
 
-    assert len(Range(10, 38, 10)) == 3
+    assert len(RangeSet(10, 38, 10)) == 3
 
-    assert Range(0, 0, 5) == S.EmptySet
+    assert RangeSet(0, 0, 5) == S.EmptySet
 
 
 def test_range_interval_intersection():
     # Intersection with intervals
-    assert FiniteSet(Range(0, 10, 1).intersect(Interval(2, 6))) == \
+    assert FiniteSet(RangeSet(0, 10, 1).intersect(Interval(2, 6))) == \
             FiniteSet(2, 3, 4, 5, 6)
 
     # Open Intervals are removed
-    assert FiniteSet(Range(0, 10, 1).intersect(Interval(2, 6, True, True))) == \
-            FiniteSet(3, 4, 5)
+    assert (FiniteSet(RangeSet(0, 10, 1).intersect(Interval(2, 6, True, True)))
+            == FiniteSet(3, 4, 5))
 
     # Try this with large steps
-    assert (FiniteSet(Range(0, 100, 10).intersect(Interval(15, 55))) ==
+    assert (FiniteSet(RangeSet(0, 100, 10).intersect(Interval(15, 55))) ==
             FiniteSet(20, 30, 40, 50))
 
     # Going backwards
-    assert FiniteSet(Range(10, -9, -3).intersect(Interval(-5, 6))) == \
+    assert FiniteSet(RangeSet(10, -9, -3).intersect(Interval(-5, 6))) == \
             FiniteSet(4, 1, -2, -5)
-    assert FiniteSet(Range(10, -9, -3).intersect(Interval(-5, 6, True))) == \
+    assert FiniteSet(RangeSet(10, -9, -3).intersect(Interval(-5, 6, True))) == \
             FiniteSet(4, 1, -2)
 
 def test_fun():
-    assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)), Range(-10,11)))
-            == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))
+    assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)),
+        RangeSet(-10,11))) == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -88,9 +88,6 @@ def test_range():
     assert 11 not in r
     assert 30 not in r
 
-    assert (FiniteSet(Range(0, 100, 10).intersect(Interval(15, 55))) ==
-            FiniteSet(20, 30, 40, 50))
-
     assert list(Range(0, 5)) == [0, 1, 2, 3, 4]
     assert list(Range(5, 0, -1)) == [5, 4, 3, 2, 1]
 
@@ -104,6 +101,26 @@ def test_range():
     assert len(Range(10, 38, 10)) == 3
 
     assert Range(0, 0, 5) == S.EmptySet
+
+
+def test_range_interval_intersection():
+    # Intersection with intervals
+    assert FiniteSet(Range(0, 10, 1).intersect(Interval(2, 6))) == \
+            FiniteSet(2, 3, 4, 5, 6)
+
+    # Open Intervals are removed
+    assert FiniteSet(Range(0, 10, 1).intersect(Interval(2, 6, True, True))) == \
+            FiniteSet(3, 4, 5)
+
+    # Try this with large steps
+    assert (FiniteSet(Range(0, 100, 10).intersect(Interval(15, 55))) ==
+            FiniteSet(20, 30, 40, 50))
+
+    # Going backwards
+    assert FiniteSet(Range(10, -9, -3).intersect(Interval(-5, 6))) == \
+            FiniteSet(4, 1, -2, -5)
+    assert FiniteSet(Range(10, -9, -3).intersect(Interval(-5, 6, True))) == \
+            FiniteSet(4, 1, -2)
 
 def test_fun():
     assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)), Range(-10,11)))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -125,3 +125,13 @@ def test_range_interval_intersection():
 def test_fun():
     assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)),
         Range(-10,11))) == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))
+
+def test_reals():
+    assert 5 in S.Reals
+    assert S.Pi in S.Reals
+    assert -sqrt(2) in S.Reals
+    assert (2,5) not in S.Reals
+
+@XFAIL # this is because contains is now very strict
+def test_reals_fail():
+    assert sqrt(-1) not in S.Reals

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,4 +1,4 @@
-from sympy.sets.fancysets import TransformationSet, RangeSet
+from sympy.sets.fancysets import TransformationSet, Range
 from sympy.core.sets import FiniteSet, Interval
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
         Rational, sqrt)
@@ -79,49 +79,49 @@ def test_transformation_iterator_not_injetive():
     # No repeats here
     assert (i.next(), i.next(), i.next(), i.next()) == (0, 2, 4, 6)
 
-def test_RangeSet():
-    assert RangeSet(5) == RangeSet(0, 5) == RangeSet(0, 5, 1)
+def test_Range():
+    assert Range(5) == Range(0, 5) == Range(0, 5, 1)
 
-    r = RangeSet(10, 20, 2)
+    r = Range(10, 20, 2)
     assert 12 in r
     assert 8 not in r
     assert 11 not in r
     assert 30 not in r
 
-    assert list(RangeSet(0, 5)) == range(5)
-    assert list(RangeSet(5, 0, -1)) == range(1, 6)
+    assert list(Range(0, 5)) == range(5)
+    assert list(Range(5, 0, -1)) == range(1, 6)
 
-    assert RangeSet(5, 15).sup == 14
-    assert RangeSet(5, 15).inf == 5
-    assert RangeSet(15, 5, -1).sup == 15
-    assert RangeSet(15, 5, -1).inf == 6
-    assert RangeSet(10, 67, 10).sup == 60
-    assert RangeSet(60, 7, -10).inf == 10
+    assert Range(5, 15).sup == 14
+    assert Range(5, 15).inf == 5
+    assert Range(15, 5, -1).sup == 15
+    assert Range(15, 5, -1).inf == 6
+    assert Range(10, 67, 10).sup == 60
+    assert Range(60, 7, -10).inf == 10
 
-    assert len(RangeSet(10, 38, 10)) == 3
+    assert len(Range(10, 38, 10)) == 3
 
-    assert RangeSet(0, 0, 5) == S.EmptySet
+    assert Range(0, 0, 5) == S.EmptySet
 
 
 def test_range_interval_intersection():
     # Intersection with intervals
-    assert FiniteSet(RangeSet(0, 10, 1).intersect(Interval(2, 6))) == \
+    assert FiniteSet(Range(0, 10, 1).intersect(Interval(2, 6))) == \
             FiniteSet(2, 3, 4, 5, 6)
 
     # Open Intervals are removed
-    assert (FiniteSet(RangeSet(0, 10, 1).intersect(Interval(2, 6, True, True)))
+    assert (FiniteSet(Range(0, 10, 1).intersect(Interval(2, 6, True, True)))
             == FiniteSet(3, 4, 5))
 
     # Try this with large steps
-    assert (FiniteSet(RangeSet(0, 100, 10).intersect(Interval(15, 55))) ==
+    assert (FiniteSet(Range(0, 100, 10).intersect(Interval(15, 55))) ==
             FiniteSet(20, 30, 40, 50))
 
     # Going backwards
-    assert FiniteSet(RangeSet(10, -9, -3).intersect(Interval(-5, 6))) == \
+    assert FiniteSet(Range(10, -9, -3).intersect(Interval(-5, 6))) == \
             FiniteSet(-5, -2, 1, 4)
-    assert FiniteSet(RangeSet(10, -9, -3).intersect(Interval(-5, 6, True))) == \
+    assert FiniteSet(Range(10, -9, -3).intersect(Interval(-5, 6, True))) == \
             FiniteSet(-2, 1, 4)
 
 def test_fun():
     assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)),
-        RangeSet(-10,11))) == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))
+        Range(-10,11))) == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,6 +1,7 @@
 from sympy.sets.fancysets import TransformationSet, Range
 from sympy.core.sets import FiniteSet, Interval
-from sympy import S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic, Rational
+from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
+        Rational, sqrt)
 from sympy.utilities.pytest import XFAIL
 
 x = Symbol('x')

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -103,3 +103,7 @@ def test_range():
     assert len(Range(10, 38, 10)) == 3
 
     assert Range(0, 0, 5) == S.EmptySet
+
+def test_fun():
+    assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)), Range(-10,11)))
+            == FiniteSet(-1, -sqrt(2)/2, 0, sqrt(2)/2, 1))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,4 +1,4 @@
-from sympy.sets.fancysets import TransformationSet
+from sympy.sets.fancysets import TransformationSet, Range
 from sympy.core.sets import FiniteSet, Interval
 from sympy import S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic, Rational
 from sympy.utilities.pytest import XFAIL
@@ -77,3 +77,29 @@ def test_transformation_iterator_not_injetive():
     i = iter(evens)
     # No repeats here
     assert (i.next(), i.next(), i.next(), i.next()) == (0, 2, 4, 6)
+
+def test_range():
+    assert Range(5) == Range(0, 5) == Range(0, 5, 1)
+
+    r = Range(10, 20, 2)
+    assert 12 in r
+    assert 8 not in r
+    assert 11 not in r
+    assert 30 not in r
+
+    assert (FiniteSet(Range(0, 100, 10).intersect(Interval(15, 55))) ==
+            FiniteSet(20, 30, 40, 50))
+
+    assert list(Range(0, 5)) == [0, 1, 2, 3, 4]
+    assert list(Range(5, 0, -1)) == [5, 4, 3, 2, 1]
+
+    assert Range(5, 15).sup == 14
+    assert Range(5, 15).inf == 5
+    assert Range(15, 5, -1).sup == 15
+    assert Range(15, 5, -1).inf == 6
+    assert Range(10, 67, 10).sup == 60
+    assert Range(60, 7, -10).inf == 10
+
+    assert len(Range(10, 38, 10)) == 3
+
+    assert Range(0, 0, 5) == S.EmptySet

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -88,8 +88,8 @@ def test_RangeSet():
     assert 11 not in r
     assert 30 not in r
 
-    assert list(RangeSet(0, 5)) == [0, 1, 2, 3, 4]
-    assert list(RangeSet(5, 0, -1)) == [5, 4, 3, 2, 1]
+    assert list(RangeSet(0, 5)) == range(5)
+    assert list(RangeSet(5, 0, -1)) == range(1, 6)
 
     assert RangeSet(5, 15).sup == 14
     assert RangeSet(5, 15).inf == 5
@@ -118,9 +118,9 @@ def test_range_interval_intersection():
 
     # Going backwards
     assert FiniteSet(RangeSet(10, -9, -3).intersect(Interval(-5, 6))) == \
-            FiniteSet(4, 1, -2, -5)
+            FiniteSet(-5, -2, 1, 4)
     assert FiniteSet(RangeSet(10, -9, -3).intersect(Interval(-5, 6, True))) == \
-            FiniteSet(4, 1, -2)
+            FiniteSet(-2, 1, 4)
 
 def test_fun():
     assert (FiniteSet(TransformationSet(Lambda(x, sin(pi*x/4)),


### PR DESCRIPTION
Added a lazy range set to represent sets like 1, 2, ...,  100 . 

Mimics behavior of python range. 

``` python

In [10]: Range(10, 60, 5)
Out[10]: {10, 15, ..., 55}

In [11]: Range(0, 100, 10).intersect(Interval(15, 65))
Out[11]: {20, 30, ..., 60}

In [12]: TransformationSet(Lambda(x, sin(pi*x/60)), Range(0, 120))
Out[12]: 
⎧   ⎛x⋅π⎞                       ⎫
⎨sin⎜───⎟ | x ∊ {0, 1, ..., 119}⎬
⎩   ⎝ 60⎠                       ⎭
```

This is currently branched off of tset_printing in PR https://github.com/sympy/sympy/pull/1251
