### PR TITLE
Install sets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ modules = [
     'sympy.printing',
     'sympy.printing.pretty',
     'sympy.series',
+    'sympy.sets',
     'sympy.simplify',
     'sympy.solvers',
     'sympy.statistics',


### PR DESCRIPTION
I'm seeing the following errors on master since the sets module is not installed 
by doing `python setup.py install` This should fix that and all tests pass.

---

_____ sympy/core/tests/test_args.py:test_sympy__sets__fancysets__Naturals ______
  File "/usr/local/lib/python2.7/dist-packages/sympy/core/tests/test_args.py", line 342, in test_sympy__sets__fancysets__Naturals
    from sympy.sets.fancysets import Naturals
ImportError: No module named sets.fancysets

---

_____ sympy/core/tests/test_args.py:test_sympy__sets__fancysets__Integers ______
  File "/usr/local/lib/python2.7/dist-packages/sympy/core/tests/test_args.py", line 346, in test_sympy__sets__fancysets__Integers
    from sympy.sets.fancysets import Integers
ImportError: No module named sets.fancysets

---

_ sympy/core/tests/test_args.py:test_sympy__sets__fancysets__TransformationSet _
  File "/usr/local/lib/python2.7/dist-packages/sympy/core/tests/test_args.py", line 355, in test_sympy__sets__fancysets__TransformationSet
    from sympy.sets.fancysets import TransformationSet
ImportError: No module named sets.fancysets

---

_______ sympy/core/tests/test_args.py:test_sympy__sets__fancysets__Range _______
  File "/usr/local/lib/python2.7/dist-packages/sympy/core/tests/test_args.py", line 361, in test_sympy__sets__fancysets__Range
    from sympy.sets.fancysets import Range
ImportError: No module named sets.fancysets

---

_________________ sympy/core/tests/test_sets.py:test_is_number _________________
  File "/usr/local/lib/python2.7/dist-packages/sympy/core/tests/test_sets.py", line 310, in test_is_number
    assert Set().is_number is False
AttributeError: 'Set' object has no attribute 'is_number'

---

__ /usr/local/lib/python2.7/dist-packages/sympy/printing/tests/test_latex.py ___
  File "/usr/local/lib/python2.7/dist-packages/sympy/printing/tests/test_latex.py", line 1, in <module>
    from sympy import (symbols, Rational, Symbol, Integral, log, diff, sin, exp,
ImportError: cannot import name TransformationSet

---

___________________ sympy/core/tests/test_sets.py:test_union ___________________
  File "/usr/local/lib/python2.7/dist-packages/sympy/core/tests/test_sets.py", line 69, in test_union
    assert Union(Set()) == Set()
AssertionError

---

_________ sympy/mpmath/tests/test_elliptic.py:test_sn_cn_dn_identities _________
  File "/usr/local/lib/python2.7/dist-packages/sympy/mpmath/tests/test_elliptic.py", line 556, in test_sn_cn_dn_identities
    assert(equality.ae(0))
AssertionError

 tests finished: 3613 passed, 2 failed, 53 skipped, 123 expected to fail, 
5 expected to fail but passed, 6 exceptions, in 602.60 seconds 
