### PR TITLE
Fix master test failure with f2py (issue 3240)

### DIFF
--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -204,8 +204,8 @@ def test_symbols_each_char():
 
     # First, test the warning
     warnings.filterwarnings("error")
-    raises(UserWarning, "symbols('xyz', each_char=True)")
-    raises(UserWarning, "symbols('xyz', each_char=False)")
+    raises(SymPyDeprecationWarning, "symbols('xyz', each_char=True)")
+    raises(SymPyDeprecationWarning, "symbols('xyz', each_char=False)")
     # now test the actual output
     warnings.filterwarnings("ignore")
     assert symbols(['wx', 'yz'], each_char=True) == [(w, x), (y, z)]


### PR DESCRIPTION
Partially revert 1001408 beautify SymPyDeprecationWarning; use warn() method.

This fixes issue 3240: a test failure using 32-bit python 2.7.0, with f2py
installed, that ended in AttributeError: delete non-existing fortran attribute
