### PR TITLE
Fix is_even/is_odd for integer powers of integers.

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -125,10 +125,7 @@ class Pow(Expr):
 
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:
-            if self.base.is_even:
-                return True
-            if self.base.is_integer:
-                return False
+            return self.base.is_even
 
     def _eval_is_positive(self):
         if self.base.is_positive:
@@ -215,8 +212,11 @@ class Pow(Expr):
                     return ok
 
     def _eval_is_odd(self):
-        if not (self.base.is_integer and self.exp.is_nonnegative): return
-        return self.base.is_odd
+        if self.exp.is_integer:
+            if self.exp.is_positive:
+                return self.base.is_odd
+            elif self.exp.is_nonnegative and self.base.is_odd:
+                return True
 
     def _eval_is_bounded(self):
         if self.exp.is_negative:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -936,14 +936,24 @@ def test_Pow_is_even_odd():
     k = Symbol('k', even=True)
     n = Symbol('n', odd=True)
     m = Symbol('m', integer=True, nonnegative=True)
+    p = Symbol('p', integer=True, positive=True)
 
     assert (k**2).is_even == True
     assert (n**2).is_even == False
     assert (2**k).is_even == None
     assert (x**2).is_even == None
 
-    assert (k**m).is_even == True
+    assert (k**m).is_even == None
     assert (n**m).is_even == False
+
+    assert (k**p).is_even == True
+    assert (n**p).is_even == False
+
+    assert (m**k).is_even == None
+    assert (p**k).is_even == None
+
+    assert (m**n).is_even == None
+    assert (p**n).is_even == None
 
     assert (k**x).is_even == None
     assert (n**x).is_even == None
@@ -952,8 +962,17 @@ def test_Pow_is_even_odd():
     assert (n**2).is_odd == True
     assert (3**k).is_odd == None
 
-    assert (k**m).is_odd == False
+    assert (k**m).is_odd == None
     assert (n**m).is_odd == True
+
+    assert (k**p).is_odd == False
+    assert (n**p).is_odd == True
+
+    assert (m**k).is_odd == None
+    assert (p**k).is_odd == None
+
+    assert (m**n).is_odd == None
+    assert (p**n).is_odd == None
 
     assert (k**x).is_odd == None
     assert (n**x).is_odd == None


### PR DESCRIPTION
Fixes the wrong result from http://code.google.com/p/sympy/issues/detail?id=2416
