### PR TITLE
Evaluation of meijer g functions outside standard branch

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1974,7 +1974,11 @@ class Expr(Basic, EvalfMixin):
                     piimult += coeff
                     continue
             extras += [exp]
-        coeff, tail = piimult.as_coeff_add()
+        if not piimult.free_symbols:
+            coeff = piimult
+            tail = ()
+        else:
+            coeff, tail = piimult.as_coeff_add(*piimult.free_symbols)
         # round down to nearest multiple of 2
         branchfact = ceiling(coeff/2 - S(1)/2)*2
         n += branchfact/2

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -5,7 +5,7 @@ from sympy import (Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I,
     Poly, Function, Derivative, Number, pi, NumberSymbol, zoo, Piecewise, Mul,
     Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp, simplify, together,
     separate, collect, factorial, apart, combsimp, factor, refine, cancel,
-    Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E)
+    Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E, exp_polar)
 from sympy.core.function import AppliedUndef
 from sympy.abc import a, b, c, d, e, n, t, u, x, y, z
 from sympy.physics.secondquant import FockState
@@ -1359,3 +1359,6 @@ def test_round():
 
     # issue 3815
     assert (I**(I+3)).round(3) == Float('-0.208','')*I
+
+def test_extract_branch_factor():
+    assert exp_polar(2.0*I*pi).extract_branch_factor() == (1, 1)

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -167,11 +167,15 @@ class exp_polar(ExpBase):
 
     def _eval_evalf(self, prec):
         """ Careful! any evalf of polar numbers is flaky """
-        from sympy import im, pi
+        from sympy import im, pi, re
         i = im(self.args[0])
         if i <= -pi or i > pi:
             return self # cannot evalf for this argument
-        return exp(self.args[0])._eval_evalf(prec)
+        res = exp(self.args[0])._eval_evalf(prec)
+        if i > 0 and im(res) < 0:
+            # i ~ pi, but exp(I*i) evaluated to argument slightly bigger than pi
+            return re(res)
+        return res
 
     def as_base_exp(self):
         # XXX exp_polar(0) is special!

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -309,3 +309,6 @@ def test_polar():
     assert log(x**z).expand() == z*log(x)
 
     assert exp_polar(3).exp == 3
+
+    # Compare exp(1.0*pi*I).
+    assert (exp_polar(1.0*pi*I).n(n=5)).as_real_imag()[1] >= 0

--- a/sympy/functions/special/tests/test_hyper.py
+++ b/sympy/functions/special/tests/test_hyper.py
@@ -249,3 +249,32 @@ def test_hyperrep():
     assert t(HyperRep_log2(z), -z/4*hyper([S(3)/2, 1, 1], [2, 2], z), z)
     assert t(HyperRep_cosasin(a, z), hyper([-a, a], [S(1)/2], z), z)
     assert t(HyperRep_sinasin(a, z), 2*a*z*hyper([1-a, 1+a], [S(3)/2], z), z)
+
+def test_meijerg_eval():
+    from sympy import besseli, exp_polar
+    from sympy.abc import l
+    a = randcplx()
+    arg = x*exp_polar(k*pi*I)
+    expr1 = pi*meijerg([[], [(a+1)/2]], [[a/2], [-a/2, (a+ 1)/2]], arg**2/4)
+    expr2 = besseli(a, arg)
+
+    # Test that the two expressions agree for all arguments.
+    for x_ in [0.5, 1.5]:
+        for k_ in [0.0, 0.1, 0.3, 0.5, 0.8, 1, 5.751, 15.3]:
+            assert abs((expr1 - expr2).n(subs={x: x_, k: k_})) < 1e-10
+            assert abs((expr1 - expr2).n(subs={x: x_, k: -k_})) < 1e-10
+
+    # Test continuity independently
+    eps = 1e-13
+    expr2 = expr1.subs(k, l)
+    for x_ in [0.5, 1.5]:
+        for k_ in [0.5, S(1)/3, 0.25, 0.75, S(2)/3, 1.0, 1.5]:
+            assert abs((expr1 - expr2).n(
+                          subs={x: x_, k: k_ + eps, l: k_ - eps})) < 1e-10
+            assert abs((expr1 - expr2).n(
+                          subs={x: x_, k: -k_ + eps, l: -k_ - eps})) < 1e-10
+
+    expr = (meijerg(((0.5,), ()), ((0.5, 0, 0.5), ()), exp_polar(-I*pi)/4)
+            + meijerg(((0.5,), ()), ((0.5, 0, 0.5), ()), exp_polar(I*pi)/4)) \
+         /(2*sqrt(pi))
+    assert (expr - pi/exp(1)).n(chop=True) == 0


### PR DESCRIPTION
This pull request implement numerical evaluation of meijer g functions, outside the standard branch. In particular expressions like `meijerg(..., exp_polar(-I*pi))` can be evaluated.
