### PR TITLE
WIP: Remove the __cmp__ method of BasicMeta and add a simpler __eq__ method.

### DIFF
--- a/sympy/core/core.py
+++ b/sympy/core/core.py
@@ -99,38 +99,7 @@ class BasicMeta(BasicType):
     def __init__(cls, *args, **kws):
         setattr(C, cls.__name__, cls)
 
-    def __cmp__(cls, other):
-        # If the other object is not a Basic subclass, then we are not equal to
-        # it.
-        if not isinstance(other, BasicType):
-            return -1
-        n1 = cls.__name__
-        n2 = other.__name__
-        c = cmp(n1, n2)
-        if not c:
-            return 0
-
-        UNKNOWN = len(ordering_of_classes) + 1
-        try:
-            i1 = ordering_of_classes.index(n1)
-        except ValueError:
-            i1 = UNKNOWN
-        try:
-            i2 = ordering_of_classes.index(n2)
-        except ValueError:
-            i2 = UNKNOWN
-        if i1 == UNKNOWN and i2 == UNKNOWN:
-            return c
-        return cmp(i1, i2)
-
-    def __lt__(cls, other):
-        if cls.__cmp__(other) == -1:
-            return True
-        return False
-
-    def __gt__(cls, other):
-        if cls.__cmp__(other) == 1:
-            return True
-        return False
+    def __eq__(cls, other):
+        return isinstance(other, BasicType) and cls.__name__ == other.__name__
 
 C.BasicMeta = BasicMeta


### PR DESCRIPTION
The ordering_of_classes list is no longer used in BasicMeta.
This is the first step needed for the removal of ordering_of_classes.

This is obviously not ready for inclusion. It is here so I can get help with the many tests that are failing.
