### PR TITLE
Make Relational subclass from Boolean

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -3,6 +3,8 @@ from expr import Expr
 from evalf import EvalfMixin
 from sympify import _sympify
 
+from sympy.logic.boolalg import Boolean
+
 __all__ = (
  'Rel', 'Eq', 'Ne', 'Lt', 'Le', 'Gt', 'Ge',
  'Relational', 'Equality', 'Unequality', 'StrictLessThan', 'LessThan',
@@ -122,7 +124,7 @@ def Ge(a, b):
     """
     return Relational(a,b,'>=')
 
-class Relational(Expr, EvalfMixin):
+class Relational(Boolean, Expr, EvalfMixin):
 
     __slots__ = []
 
@@ -350,7 +352,7 @@ class GreaterThan(_Greater):
     True
 
     However, it is also perfectly valid to instantiate a ``*Than`` class less
-    succinctly and less conviently:
+    succinctly and less conveniently:
 
     >>> rels = Rel(x, 1, '>='), Relational(x, 1, '>='), GreaterThan(x, 1)
     >>> print '%s\\n%s\\n%s' % rels

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -124,6 +124,8 @@ def Ge(a, b):
     """
     return Relational(a,b,'>=')
 
+# Note, see issue 1887.  Ideally, we wouldn't want to subclass both Boolean
+# and Expr.
 class Relational(Boolean, Expr, EvalfMixin):
 
     __slots__ = []

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1,10 +1,10 @@
 from sympy.utilities.pytest import XFAIL, raises
-from sympy import Symbol, symbols, oo, I, pi, Float
+from sympy import Symbol, symbols, oo, I, pi, Float, And, Or, Not, Implies, Xor
 from sympy.core.relational import ( Relational, Equality, Unequality,
     GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le,
     Gt, Ge, Ne )
 
-x,y,z = symbols('x,y,z')
+x, y, z, t = symbols('x,y,z,t')
 
 
 def test_rel_ne():
@@ -255,3 +255,19 @@ def test_relational_bool_output():
     # XFail test for issue:
     # http://code.google.com/p/sympy/issues/detail?id=2832
     raises(ValueError, "bool(x > 3)")
+
+def test_relational_logic_symbols():
+    # See issue 3105
+    assert (x < y) & (z < t) == And(x < y, z < t)
+    assert (x < y) | (z < t) == Or(x < y, z < t)
+    assert ~(x < y) == Not(x < y)
+    assert (x < y) >> (z < t) == Implies(x < y, z < t)
+    assert (x < y) << (z < t) == Implies(z < t, x < y)
+    assert (x < y) ^ (z < t) == Xor(x < y, z < t)
+
+    assert isinstance((x < y) & (z < t), And)
+    assert isinstance((x < y) | (z < t), Or)
+    assert isinstance(~(x < y), Not)
+    assert isinstance((x < y) >> (z < t), Implies)
+    assert isinstance((x < y) << (z < t), Implies)
+    assert isinstance((x < y) ^ (z < t), (Or, Xor))


### PR DESCRIPTION
This is a temporary workaround to fix issue 3105, that (a < b) & (c < d) does
not work.  See that issue and issue 1887 for more discussion.
