### PR TITLE
Stop pretty-printing from messing up symbol names

### DIFF
--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -53,6 +53,6 @@ def split_super_sub(text):
     m = re.match('(^[a-zA-Z]+)([0-9]+)$', name)
     if m is not None:
         name, sub = m.groups()
-        subs.append(sub)
+        subs.insert(0, sub)
 
     return name, supers, subs

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -453,18 +453,10 @@ def pretty_symbol(symb_name):
 
     # glue the results into one string
     if pretty_subs is None: # nice formatting of sups/subs did not work
-        if len(sups) > 0:
-            sups_result = '^' + '^'.join(sups)
-        else:
-            sups_result = ''
-        if len(subs) > 0:
-            subs_result = '_' + '_'.join(subs)
-        else:
-            subs_result = ''
+        return symb_name
     else:
         sups_result = ' '.join(pretty_sups)
         subs_result = ' '.join(pretty_subs)
-
 
     return ''.join([name, sups_result, subs_result])
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3665,3 +3665,7 @@ def test_RandomDomain():
 def test_issue_3186():
     assert pretty(Pow(2, -5, evaluate=False)) == '1 \n--\n 5\n2 '
     assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '
+
+def test_complicated_symbol_unchanged():
+    for symb_name in ["dexpr2_d1tau", "dexpr2^d1tau"]:
+        assert pretty(Symbol(symb_name)) == symb_name


### PR DESCRIPTION
These commits help sympy pass the following test:

```
import sympy as sp
symb_name = "dexpr2_d1tau"
s = sp.Symbol(symb_name)
assert sp.pretty(s) == symb_name
```

Previously, it would output `dexpr_d1tau_2`--i.e. not just not do anything useful, but also randomly mangle the symbol name.

Andreas
