### PR TITLE
Revert "Work-around \middle."

### DIFF
--- a/doc/src/modules/simplify/hyperexpand.txt
+++ b/doc/src/modules/simplify/hyperexpand.txt
@@ -13,8 +13,8 @@ Most of it is based on the papers [Roach1996]_ and [Roach1997]_.
 Recall that the hypergeometric function is (initially) defined as
 
 .. math ::
-    {}_pF_q\left.\left(\begin{matrix} a_1, \dots, a_p \\ b_1, \dots, b_q \end{matrix}
-                     \right| z \right)
+    {}_pF_q\left(\begin{matrix} a_1, \dots, a_p \\ b_1, \dots, b_q \end{matrix}
+                     \middle| z \right)
         = \sum_{n=0}^\infty \frac{(a_1)_n \dots (a_p)_n}{(b_1)_n \dots (b_q)_n}
                             \frac{z^n}{n!}.
 
@@ -46,30 +46,29 @@ Incrementing and decrementing indices
 
 Suppose `a_i \ne 0`. Set `A(a_i) =
 \frac{z}{a_i}\frac{\mathrm{d}}{dz}+1`. It is then easy to show that
-`A(a_i) {}_p F_q\left.\left({a_p \atop b_q} \right| z \right) =
-{}_p F_q\left.\left({a_p + e_i \atop b_q} \right| z \right)`,
-where `e_i` is the i-th unit vector.
+`A(a_i) {}_p F_q\left({a_p \atop b_q} \middle| z \right) = {}_p F_q\left({a_p +
+e_i \atop b_q} \middle| z \right)`, where `e_i` is the i-th unit vector.
 Similarly for `b_j \ne 1` we set `B(b_j) = \frac{z}{b_j-1}
-\frac{\mathrm{d}}{dz}+1` and find `B(b_j) {}_p F_q\left.\left({a_p \atop b_q}
-\right| z \right) = {}_p F_q\left.\left({a_p \atop b_q - e_i} \right| z \right)`.
+\frac{\mathrm{d}}{dz}+1` and find `B(b_j) {}_p F_q\left({a_p \atop b_q}
+\middle| z \right) = {}_p F_q\left({a_p \atop b_q - e_i} \middle| z \right)`.
 Thus we can increment upper and decrement lower indices at will, as long as we
 don't go through zero. The `A(a_i)` and `B(b_j)` are called shift
 operators.
 
-It is also easy to show that `\frac{\mathrm{d}}{dz} {}_p F_q\left.\left({a_p
-\atop b_q} \right| z \right) = \frac{a_1 \dots a_p}{b_1 \dots b_q} {}_p
-F_q\left.\left({a_p + 1 \atop b_q + 1} \right| z \right)`, where `a_p + 1` is
+It is also easy to show that `\frac{\mathrm{d}}{dz} {}_p F_q\left({a_p
+\atop b_q} \middle| z \right) = \frac{a_1 \dots a_p}{b_1 \dots b_q} {}_p
+F_q\left({a_p + 1 \atop b_q + 1} \middle| z \right)`, where `a_p + 1` is
 the vector `a_1 + 1, a_2 + 1, \dots` and similarly for `b_q + 1`.
 Combining this with the shift operators,  we arrive at one form of the
 Hypergeometric differential equation: `\left[ \frac{\mathrm{d}}{dz}
 \prod_{j=1}^q B(b_j) - \frac{a_1 \dots a_p}{(b_1-1) \dots (b_q-1)}
-\prod_{i=1}^p A(a_i) \right] {}_p F_q\left.\left({a_p \atop b_q} \right| z \right) =
+\prod_{i=1}^p A(a_i) \right] {}_p F_q\left({a_p \atop b_q} \middle| z \right) =
 0`. This holds if all shift operators are defined, i.e. if no `a_i = 0`
 and no `b_j = 1`. Clearing denominators and multiplying through by z we
 arrive at the following equation: `\left[ z\frac{\mathrm{d}}{dz}
 \prod_{j=1}^q \left(z\frac{\mathrm{d}}{dz} + b_j-1 \right) - z \prod_{i=1}^p
-\left( z\frac{\mathrm{d}}{\mathrm{d}z} + a_i \right) \right] {}_p F_q\left.\left({a_p
-\atop b_q} \right| z\right) = 0`. Even though our derivation does not show it,
+\left( z\frac{\mathrm{d}}{\mathrm{d}z} + a_i \right) \right] {}_p F_q\left({a_p
+\atop b_q} \middle| z\right) = 0`. Even though our derivation does not show it,
 it can be checked that this equation holds whenever the `{}_p F_q` is
 defined.
 
@@ -77,11 +76,11 @@ Notice that, under suitable conditions on `a_I, b_J`, each of the
 operators `A(a_i)`, `B(b_j)` and
 `z\frac{\mathrm{d}}{\mathrm{d}z}` can be expressed in terms of `A(a_I)` or
 `B(b_J)`. Our next aim is to write the Hypergeometric differential
-equation as follows: `[X A(a_I) - r] {}_p F_q\left.\left({a_p \atop b_q}
-\right| z\right) = 0`, for some operator `X` and some constant `r`
+equation as follows: `[X A(a_I) - r] {}_p F_q\left({a_p \atop b_q}
+\middle| z\right) = 0`, for some operator `X` and some constant `r`
 to be determined. If
-`r \ne 0`, then we can write this as `\frac{-1}{r} X {}_p F_q\left.\left({a_p +
-e_I \atop b_q} \right| z\right) = {}_p F_q\left.\left({a_p \atop b_q} \right|
+`r \ne 0`, then we can write this as `\frac{-1}{r} X {}_p F_q\left({a_p +
+e_I \atop b_q} \middle| z\right) = {}_p F_q\left({a_p \atop b_q} \middle|
 z\right)`, and so `\frac{-1}{r}X` undoes the shifting of `A(a_I)`,
 whence it will be called an inverse-shift operator.
 
@@ -118,8 +117,8 @@ Reduction of Order
 ==================
 
 Notice that, quite trivially, if `a_I = b_J`, we have `{}_p
-F_q\left.\left({a_p \atop b_q} \right| z \right) = {}_{p-1} F_{q-1}\left.\left({a_p^*
-\atop b_q^*} \right| z \right)`, where `a_p^*` means `a_p` with
+F_q\left({a_p \atop b_q} \middle| z \right) = {}_{p-1} F_{q-1}\left({a_p^*
+\atop b_q^*} \middle| z \right)`, where `a_p^*` means `a_p` with
 `a_I` omitted, and similarly for `b_q^*`. We call this reduction of
 order.
 
@@ -131,11 +130,11 @@ we find:
 
   If `a_I - b_J \in \mathbb{Z}_{>0}`, then there exists a polynomial
   `p(n) = p_0 + p_1 n + \dots` (of degree `a_I - b_J`) such
-  that `\frac{(a_I)_n}{(b_J)_n} = p(n)` and `{}_p F_q\left.\left({a_p
-  \atop b_q} \right| z \right) = \left(p_0 + p_1
+  that `\frac{(a_I)_n}{(b_J)_n} = p(n)` and `{}_p F_q\left({a_p
+  \atop b_q} \middle| z \right) = \left(p_0 + p_1
   z\frac{\mathrm{d}}{\mathrm{d}z} + p_2
-  \left.\left(z\frac{\mathrm{d}}{\mathrm{d}z}\right)^2 + \dots \right) {}_{p-1}
-  F_{q-1}\left({a_p^* \atop b_q^*} \right| z \right)`.
+  \left(z\frac{\mathrm{d}}{\mathrm{d}z}\right)^2 + \dots \right) {}_{p-1}
+  F_{q-1}\left({a_p^* \atop b_q^*} \middle| z \right)`.
 
 Thus any set of parameters `a_p, b_q` is reachable from a set of
 parameters `c_r, d_s` where `c_i - d_j \in \mathbb{Z}` implies
@@ -216,7 +215,7 @@ we store a vector `B` of `N` functions, a matrix `M` and a
 vector `C` (the latter two with entries in `\mathbb{C}(z)`), with
 the following properties:
 
-* `{}_r F_s\left.\left({a_r^0 \atop b_s^0} \right| z \right) = C B`
+* `{}_r F_s\left({a_r^0 \atop b_s^0} \middle| z \right) = C B`
 * `z\frac{\mathrm{d}}{\mathrm{d}z} B = M B`.
 
 Then we can compute as many derivatives as we want and we will always end up
@@ -347,10 +346,10 @@ where the `*` means to omit the terms we treated specially.
 We thus arrive at
 
 .. math ::
-    F(z) = C \times {}_{p+1}F_{q}\left.\left(
+    F(z) = C \times {}_{p+1}F_{q}\left(
         \begin{matrix} 1, (1 + l_u - l_i), (1 + l_u + b - a_i)^* \\
                        1 + l_u, (1 + l_u - k_i), (1 + l_u + b - b_i)^*
-        \end{matrix} \right| (-1)^{p-m-n} z\right),
+        \end{matrix} \middle| (-1)^{p-m-n} z\right),
 
 where `C` designates the factor in the residue independent of `t`.
 (This result can also be written in slightly simpler form by converting

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -119,7 +119,7 @@ class lowergamma(Function):
     This can be shown to be the same as
 
     .. math ::
-        \gamma(s, x) = \frac{x^s}{s} {}_1F_1\left.\left({s \atop s+1} \right| -x\right),
+        \gamma(s, x) = \frac{x^s}{s} {}_1F_1\left({s \atop s+1} \middle| -x\right),
 
     where :math:`{}_1F_1` is the (confluent) hypergeometric function.
 
@@ -244,7 +244,7 @@ class uppergamma(Function):
 
     .. math ::
         \Gamma(s, x) = \Gamma(s)
-                - \frac{x^s}{s} {}_1F_1\left.\left({s \atop s+1} \right| -x\right),
+                - \frac{x^s}{s} {}_1F_1\left({s \atop s+1} \middle| -x\right),
 
     where :math:`{}_1F_1` is the (confluent) hypergeometric function.
 

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -58,8 +58,8 @@ class hyper(TupleParametersBase):
     :math:`b_q`. It also has an argument :math:`z`. The series definition is
 
     .. math ::
-        {}_pF_q\left.\left(\begin{matrix} a_1, \dots, a_p \\ b_1, \dots, b_q \end{matrix}
-                     \right| z \right)
+        {}_pF_q\left(\begin{matrix} a_1, \dots, a_p \\ b_1, \dots, b_q \end{matrix}
+                     \middle| z \right)
         = \sum_{n=0}^\infty \frac{(a_1)_n \dots (a_p)_n}{(b_1)_n \dots (b_q)_n}
                             \frac{z^n}{n!},
 
@@ -292,9 +292,9 @@ class meijerg(TupleParametersBase):
     parameter vectors):
 
     .. math ::
-        G_{p,q}^{m,n} \left.\left(\begin{matrix}a_1, \dots, a_n & a_{n+1}, \dots, a_p \\
+        G_{p,q}^{m,n} \left(\begin{matrix}a_1, \dots, a_n & a_{n+1}, \dots, a_p \\
                                         b_1, \dots, b_m & b_{m+1}, \dots, b_q
-                          \end{matrix} \right| z \right).
+                          \end{matrix} \middle| z \right).
 
     However, in sympy the four parameter vectors are always available
     separately (see examples), so that there is no need to keep track of the

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -734,8 +734,8 @@ class LatexPrinter(Printer):
         return self._hprint_BesselBase(expr, exp, 'H^{(2)}')
 
     def _print_hyper(self, expr, exp=None):
-        tex = r"{{}_{%s}F_{%s}\left.\left(\begin{matrix} %s \\ %s \end{matrix}" \
-              r"\right| {%s} \right)}" % \
+        tex = r"{{}_{%s}F_{%s}\left(\begin{matrix} %s \\ %s \end{matrix}" \
+              r"\middle| {%s} \right)}" % \
              (self._print(len(expr.ap)), self._print(len(expr.bq)),
               self._hprint_vec(expr.ap), self._hprint_vec(expr.bq),
               self._print(expr.argument))
@@ -745,8 +745,8 @@ class LatexPrinter(Printer):
         return tex
 
     def _print_meijerg(self, expr, exp=None):
-        tex = r"{G_{%s, %s}^{%s, %s}\left.\left(\begin{matrix} %s & %s \\" \
-              r"%s & %s \end{matrix} \right| {%s} \right)}" % \
+        tex = r"{G_{%s, %s}^{%s, %s}\left(\begin{matrix} %s & %s \\" \
+              r"%s & %s \end{matrix} \middle| {%s} \right)}" % \
              (self._print(len(expr.ap)), self._print(len(expr.bq)),
               self._print(len(expr.bm)), self._print(len(expr.an)),
               self._hprint_vec(expr.an), self._hprint_vec(expr.aother),

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -188,15 +188,15 @@ def test_hyper_printing():
 
     assert latex(meijerg(Tuple(pi, pi, x), Tuple(1), \
                          (0,1), Tuple(1, 2, 3/pi),z)) == \
-             r'{G_{4, 5}^{2, 3}\left.\left(\begin{matrix} \pi, \pi, x & 1 \\0, 1 & 1, 2, \frac{3}{\pi} \end{matrix} \right| {z} \right)}'
+             r'{G_{4, 5}^{2, 3}\left(\begin{matrix} \pi, \pi, x & 1 \\0, 1 & 1, 2, \frac{3}{\pi} \end{matrix} \middle| {z} \right)}'
     assert latex(meijerg(Tuple(), Tuple(1), (0,), Tuple(),z)) == \
-             r'{G_{1, 1}^{1, 0}\left.\left(\begin{matrix}  & 1 \\0 &  \end{matrix} \right| {z} \right)}'
+             r'{G_{1, 1}^{1, 0}\left(\begin{matrix}  & 1 \\0 &  \end{matrix} \middle| {z} \right)}'
     assert latex(hyper((x, 2), (3,), z)) == \
-               r'{{}_{2}F_{1}\left.\left(\begin{matrix} x, 2 ' \
-               r'\\ 3 \end{matrix}\right| {z} \right)}'
+               r'{{}_{2}F_{1}\left(\begin{matrix} x, 2 ' \
+               r'\\ 3 \end{matrix}\middle| {z} \right)}'
     assert latex(hyper(Tuple(), Tuple(1), z)) == \
-               r'{{}_{0}F_{1}\left.\left(\begin{matrix}  ' \
-               r'\\ 1 \end{matrix}\right| {z} \right)}'
+               r'{{}_{0}F_{1}\left(\begin{matrix}  ' \
+               r'\\ 1 \end{matrix}\middle| {z} \right)}'
 
 def test_latex_bessel():
     from sympy.functions.special.bessel import (besselj, bessely, besseli,


### PR DESCRIPTION
This reverts commit 366e4a79b4ef73e7b991bb4e8546f3695764f044.

MathJax now supports \middle, so this workaround is no longer necessary.
