### PR TITLE
Fix mathml printer.

### DIFF
--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -340,7 +340,7 @@ def test_settings():
     raises(TypeError, 'mathml(Symbol("x"), method="garbage")')
 
 def test_toprettyxml_hooking():
-    # test that patch of don't influence on standard library.
+    # test that the patch doesn't influence the behavior of the standard library
     import xml.dom.minidom
     doc = xml.dom.minidom.parseString("<apply><plus/><ci>x</ci><cn>1</cn></apply>")
     prettyxml_old = doc.toprettyxml()

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -338,3 +338,14 @@ def test_mathml_order():
 
 def test_settings():
     raises(TypeError, 'mathml(Symbol("x"), method="garbage")')
+
+def test_toprettyxml_hooking():
+    # test that patch of don't influence on standard library.
+    import xml.dom.minidom
+    doc = xml.dom.minidom.parseString("<apply><plus/><ci>x</ci><cn>1</cn></apply>")
+    prettyxml_old = doc.toprettyxml()
+
+    mp.apply_patch()
+    mp.restore_patch()
+
+    assert prettyxml_old == doc.toprettyxml()


### PR DESCRIPTION
If anyone uses the mathml printer, the behavior of toprettyxml
was changed globally. This still could cause subtle bugs for people
who use that function.

This commit restore standard xml library after each MathML printer
as it was before.

See also discussion in previous [pull 1184](https://github.com/sympy/sympy/pull/1184#issuecomment-5532877)
