### PR TITLE
Faster power of a matrix

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -415,6 +415,8 @@ class MatrixBase(object):
                 if n%2:
                     a *= s
                     n -= 1
+                if not n:
+                    break
                 s *= s
                 n //= 2
             return a


### PR DESCRIPTION
A multiplication is saved computing `M**n`, which becomes typically
roughly `(1 + 1/log2(n))` faster for matrices of `order >= 10`;
for smaller orders there is still a speedup, but smaller.
