### PR TITLE
Document the _sympy_ method and use it instead of `converter` in a few p...

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -18,7 +18,7 @@ class SympifyError(ValueError):
             "raised:\n%s: %s" % (self.expr, self.base_exc.__class__.__name__,
             str(self.base_exc)))
 
-converter = {}
+converter = {} #See sympify docstring.
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     """
@@ -74,17 +74,37 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     SympifyError: SympifyError: True
 
     To extend `sympify` to convert custom objects (not derived from `Basic`),
-    the static dictionary `convert` is provided. The custom converters are
-    usually added at import time, and will apply to all objects of the given
-    class or its derived classes.
+    just define a `_sympy_` method to your class. You can do that even to
+    classes that you do not own by subclassing or adding the method at runtime.
 
-    For example, all geometry objects derive from `GeometryEntity` class, and
-    should not be altered by the converter, so we add the following after
-    defining that class:
+    >>> from sympy import Matrix
+    >>> class MyList1(object):
+    ...     def __iter__(self):
+    ...         yield 1
+    ...         yield 2
+    ...         raise StopIteration
+    ...     def __getitem__(self, i): return list(self)[i]
+    ...     def _sympy_(self): return Matrix(self)
+    >>> sympify(MyList1())
+    [1]
+    [2]
 
+    If you do not have control over the class definition you could also use the
+    `converter` global dictionary. The key is the class and the value is a
+    function that takes a single argument and returns the desired SymPy
+    object, e.g. `converter[MyList] = lambda x: Matrix(x)`.
+
+    >>> class MyList2(object):   # XXX Do not do this if you control the class!
+    ...     def __iter__(self):  #     Use _sympy_!
+    ...         yield 1
+    ...         yield 2
+    ...         raise StopIteration
+    ...     def __getitem__(self, i): return list(self)[i]
     >>> from sympy.core.sympify import converter
-    >>> from sympy.geometry.entity import GeometryEntity
-    >>> converter[GeometryEntity] = lambda x: x
+    >>> converter[MyList2] = lambda x: Matrix(x)
+    >>> sympify(MyList2())
+    [1]
+    [2]
 
     """
     try:

--- a/sympy/geometry/entity.py
+++ b/sympy/geometry/entity.py
@@ -38,6 +38,9 @@ class GeometryEntity(Basic):
     def __new__(cls, *args, **kwargs):
         return Basic.__new__(cls, *sympify(args))
 
+    def _sympy_(self):
+        return self
+
     def __getnewargs__(self):
         return tuple(self.args)
 
@@ -326,5 +329,3 @@ def rotate(th):
     rv[2, 2] = 1
     return rv
 
-from sympy.core.sympify import converter, sympify
-converter[GeometryEntity] = lambda x: x

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -5,7 +5,7 @@ from sympy.core.power import Pow
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.numbers import Integer, ilcm, Rational, Float
 from sympy.core.singleton import S
-from sympy.core.sympify import sympify, converter, SympifyError
+from sympy.core.sympify import sympify, SympifyError
 from sympy.core.compatibility import is_sequence
 
 from sympy.polys import PurePoly, roots, cancel
@@ -72,6 +72,10 @@ class MatrixBase(object):
 
     is_Matrix = True
     _class_priority = 3
+
+    def _sympy_(self):
+        #return self.as_immutable()
+        raise SympifyError('Matrix cannot be sympified')
 
     @classmethod
     def _handle_creation_inputs(cls, *args, **kwargs):
@@ -4297,12 +4301,6 @@ def casoratian(seqs, n, zero=True):
 
     return MutableMatrix(k, k, f).det()
 
-# Add sympify converters
-def _matrix_sympify(matrix):
-    #return matrix.as_immutable()
-    raise SympifyError('Matrix cannot be sympified')
-converter[MatrixBase] = _matrix_sympify
-del _matrix_sympify
 
 
 class SparseMatrix(MatrixBase):


### PR DESCRIPTION
...laces

The sympify function has among others two methods to convert 3rd party objects
to sympy objects. First is the use of the `converter` dict which is useful for
classes upon which we do not have control. The second is the more pythonic
definition of a `_sympy_` method to be used by the `sympify` function.

Beside documenting it better it is now used instead of `converter` for
MatrixBase and for GeometricEntity.
