### PR TITLE
Bring the SparseMatrix constructor in compliance with the Matrix class

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -102,8 +102,8 @@ class MatrixBase(object):
         # Matrix(2, 2, lambda i,j: i+j)
         if len(args) == 3 and callable(args[2]):
             operation = args[2]
-            rows = int(args[0])
-            cols = int(args[1])
+            rows = args[0]
+            cols = args[1]
             mat = []
             for i in range(rows):
                 for j in range(cols):
@@ -4316,13 +4316,13 @@ class SparseMatrix(MatrixBase):
     """
 
     def __init__(self, *args):
+        self.mat = {}
         if len(args) == 3 and callable(args[2]):
             op = args[2]
             if not isinstance(args[0], (int, Integer)) or not isinstance(args[1], (int, Integer)):
                 raise TypeError("`args[0]` and `args[1]` must both be integers.")
             self.rows = args[0]
             self.cols = args[1]
-            self.mat = {}
             for i in range(self.rows):
                 for j in range(self.cols):
                     value = sympify(op(i,j))
@@ -4333,7 +4333,6 @@ class SparseMatrix(MatrixBase):
             self.rows = args[0]
             self.cols = args[1]
             mat = args[2]
-            self.mat = {}
             for i in range(self.rows):
                 for j in range(self.cols):
                     value = sympify(mat[i*self.cols+j])
@@ -4343,29 +4342,20 @@ class SparseMatrix(MatrixBase):
                 isinstance(args[1],int) and isinstance(args[2], dict):
             self.rows = args[0]
             self.cols = args[1]
-            self.mat = {}
             # manual copy, copy.deepcopy() doesn't work
             for key in args[2].keys():
                 self.mat[key] = args[2][key]
         else:
-            if len(args) == 1:
-                mat = args[0]
-            else:
-                mat = args
-            if not mat:
-                self.mat = {}
-                self.rows = self.cols = 0
-                return
-            if not is_sequence(mat[0]):
-                raise TypeError('Matrix rows must be given in an iterable.')
-            self.rows = len(mat)
-            self.cols = len(mat[0])
-            self.mat = {}
+            # TODO: _handle_creation_inputs creates a temporary dense array
+            # and calls sympify on each element. This is a waste of time.
+            # Just like above rewrite the rest of the handled cases with
+            # "sparse" logic.
+            r, c, mat = self._handle_creation_inputs(*args)
+            self.rows = r
+            self.cols = c
             for i in range(self.rows):
-                if len(mat[i]) != self.cols:
-                    raise ValueError("All arguments must have the same length.")
                 for j in range(self.cols):
-                    value = sympify(mat[i][j])
+                    value = mat[self.cols*i+j]
                     if value != 0:
                         self.mat[(i,j)] = value
 
@@ -4517,7 +4507,7 @@ class SparseMatrix(MatrixBase):
         Returns a Row-sorted list of non-zero elements of the matrix.
 
         >>> from sympy.matrices import SparseMatrix
-        >>> a=SparseMatrix((1,2),(3,4))
+        >>> a=SparseMatrix(((1,2),(3,4)))
         >>> a
         [1, 2]
         [3, 4]
@@ -4544,7 +4534,7 @@ class SparseMatrix(MatrixBase):
         """
         Returns a Column-sorted list of non-zero elements of the matrix.
         >>> from sympy.matrices import SparseMatrix
-        >>> a=SparseMatrix((1,2),(3,4))
+        >>> a=SparseMatrix(((1,2),(3,4)))
         >>> a
         [1, 2]
         [3, 4]
@@ -4570,7 +4560,7 @@ class SparseMatrix(MatrixBase):
         """
         Returns the transposed SparseMatrix of this SparseMatrix
         >>> from sympy.matrices import SparseMatrix
-        >>> a = SparseMatrix((1,2),(3,4))
+        >>> a = SparseMatrix(((1,2),(3,4)))
         >>> a
         [1, 2]
         [3, 4]

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1694,12 +1694,12 @@ def test_exp():
     assert m.exp() == Matrix([[E,0],[0,E]])
 
 def test_SparseMatrix_transpose():
-    assert SparseMatrix((1,2),(3,4)).transpose() == SparseMatrix((1,3),(2,4))
+    assert SparseMatrix(((1,2),(3,4))).transpose() == Matrix(((1,3),(2,4)))
 
 def test_SparseMatrix_CL_RL():
-    assert SparseMatrix((1,2),(3,4)).row_list() == \
+    assert SparseMatrix(((1,2),(3,4))).row_list() == \
         [(0, 0, 1), (0, 1, 2), (1, 0, 3), (1, 1, 4)]
-    assert SparseMatrix((1,2),(3,4)).col_list() == \
+    assert SparseMatrix(((1,2),(3,4))).col_list() == \
         [(0, 0, 1), (1, 0, 3), (0, 1, 2), (1, 1, 4)]
 
 def test_SparseMatrix_add():
@@ -1770,7 +1770,7 @@ def test_errors():
     raises(ValueError, lambda: hessian(Matrix([[1, 2], [3, 4]]), []))
     raises(ValueError, lambda: hessian(Symbol('x')**2, 'a'))
     raises(TypeError, lambda: SparseMatrix(1.4, 2, lambda i, j: 0))
-    raises(ValueError, lambda: SparseMatrix([1, 2, 3], [1, 2]))
+    raises(TypeError, lambda: SparseMatrix([1, 2, 3], [1, 2]))
     raises(ValueError, lambda: SparseMatrix([[1, 2], [3, 4]])[(1, 2, 3)])
     raises(ValueError, lambda: SparseMatrix([[1, 2], [3, 4]]).rowdecomp(5))
     with raises(ValueError):


### PR DESCRIPTION
The SparceMatrix constructor was duplicating code and some of the semantics
were different from those imposed by MatrixBase. Now the
_handle_creation_inputs is used when appropriate.
