### PR TITLE
Sympify matrix opt

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -142,6 +142,11 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
 
     try:
         return a._sympy_()
+    except SympifyError, e:
+        if iter_to_matrix and e.expr=='Matrix cannot be sympified':
+            return a
+        else:
+            raise e
     except AttributeError:
         pass
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -20,7 +20,8 @@ class SympifyError(ValueError):
 
 converter = {} #See sympify docstring.
 
-def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
+def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
+        iter_to_matrix=False):
     """
     Converts an arbitrary expression to a type that can be used inside sympy.
 
@@ -106,6 +107,17 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     [1]
     [2]
 
+    Finally there is the option to sympify all iterables to matrices. As there
+    is tension between the internals of sympy relying much on the assumption
+    that all objects are instances of subclasses of Basic, this may cause
+    problems.
+
+    >>> sympify(['x', 'y']) # Returns a list
+    [x, y]
+    >>> sympify(['x', 'y'], iter_to_matrix=True) # Returns a Matrix instance
+    [x]
+    [y]
+
     """
     try:
         cls = a.__class__
@@ -144,12 +156,17 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
         raise SympifyError(a)
 
     if iterable(a):
-        try:
-            return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
+        if iter_to_matrix:
+            from sympy.matrices import Matrix
+            return Matrix([sympify(x, locals=locals, convert_xor=convert_xor,
                 rational=rational) for x in a])
-        except TypeError:
-            # Not all iterables are rebuildable with their type.
-            pass
+        else:
+            try:
+                return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,
+                    rational=rational) for x in a])
+            except TypeError:
+                # Not all iterables are rebuildable with their type.
+                pass
     if isinstance(a, dict):
         try:
             return type(a)([sympify(x, locals=locals, convert_xor=convert_xor,

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -6,6 +6,7 @@ from sympy.core.decorators import _sympifyit
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
+from sympy.matrices import Matrix
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 
 from sympy import mpmath
@@ -401,3 +402,8 @@ def test_no_autosimplify_into_Mul():
     s = '-1 - 2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x)))'.replace('x', '_kern')
     ss = S(s)
     assert ss != 1 and ss.simplify() == -1
+
+def test_sympify_iter_to_matrix():
+    assert sympify([x,y], iter_to_matrix=True) == Matrix([x,y])
+    assert sympify([[x],[y]], iter_to_matrix=True) == Matrix([[x],[y]])
+    assert sympify([[x,y],], iter_to_matrix=True) == Matrix([[x,y],])

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -407,3 +407,5 @@ def test_sympify_iter_to_matrix():
     assert sympify([x,y], iter_to_matrix=True) == Matrix([x,y])
     assert sympify([[x],[y]], iter_to_matrix=True) == Matrix([[x],[y]])
     assert sympify([[x,y],], iter_to_matrix=True) == Matrix([[x,y],])
+
+    assert sympify(Matrix([1,2]), iter_to_matrix=True) == Matrix([1,2])


### PR DESCRIPTION
Add a `iter_to_matrix` option to sympify. The following is now possible:

```
sympify([x,y], iter_to_matrix=True) == Matrix([x,y])
sympify([[x,y],], iter_to_matrix=True) == Matrix([[x,y],])

sympify(Matrix([1,2]), iter_to_matrix=True) == Matrix([1,2])

```
