### PR TITLE
Make Expr recursively callable.

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -5,7 +5,8 @@ from sympy import (Add, Basic, S, Symbol, Wild,  Float, Integer, Rational, I,
     Poly, Function, Derivative, Number, pi, NumberSymbol, zoo, Piecewise, Mul,
     Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp, simplify, together,
     separate, collect, factorial, apart, combsimp, factor, refine, cancel,
-    Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E, exp_polar)
+    Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E, exp_polar,
+    Lambda)
 from sympy.core.function import AppliedUndef
 from sympy.abc import a, b, c, d, e, n, t, u, x, y, z
 from sympy.physics.secondquant import FockState
@@ -501,11 +502,19 @@ def test_as_independent():
            (Integral(x, (x, 1, 2)), x)
 
 def test_call():
-    # Unlike what used to be the case, the following should NOT work.
-    # See issue 1927.
+    # See the long history of this in issues 1927 and 2006.
 
-    raises(TypeError, "sin(x)({ x : 1, sin(x) : 2})")
-    raises(TypeError, "sin(x)(1)")
+    # No effect as there are no callables
+    assert sin(x)(1) == sin(x)
+    assert (1+sin(x))(1) == 1+sin(x)
+
+    # Effect in the pressence of callables
+    l = Lambda(x, 2*x)
+    assert (l+x)(y) == 2*y+x
+    assert (x**l)(2) == x**4
+    # TODO UndefinedFunction does not subclass Expr
+    #f = Function('f')
+    #assert (2*f)(x) == 2*f(x)
 
 def test_replace():
     f = log(sin(x)) + tan(sin(x**2))

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -14,6 +14,7 @@ from sympy.printing.pretty.pretty import PrettyPrinter
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.str import StrPrinter
 from sympy.utilities import group
+from sympy.core.compatibility import reduce
 
 class Dyadic(object):
     """A Dyadic object.
@@ -1956,20 +1957,12 @@ def dynamicsymbols(names, level=0):
     """
 
     esses = symbols(names, cls=Function)
-    try:
-        esses = [i.__call__(dynamicsymbols._t) for i in list(esses)]
-        ol = esses
-        for i in range(level):
-            ol = []
-            for j, v in enumerate(esses):
-                ol.append(diff(v, dynamicsymbols._t))
-            esses = ol
-        return list(ol)
-    except TypeError:
-        esses = esses.__call__(dynamicsymbols._t)
-        for i in range(level):
-            esses = diff(esses, dynamicsymbols._t)
+    t = dynamicsymbols._t
+    if hasattr(esses, '__iter__'):
+        esses = [reduce(diff, [t]*level, e(t)) for e in esses]
         return esses
+    else:
+        return reduce(diff, [t]*level, esses(t))
 
 dynamicsymbols._t = Symbol('t')
 dynamicsymbols._str = '\''


### PR DESCRIPTION
Addresses issue 2006. If an expression is called on an argument it traverses
the expression tree and if an atom is a callable it is called on the argument.
If it is not a callable it is left unchanges:

Examples:

```
>>> (1+x)(y)
1+x

>>> (1+f)(y)
1+f(y)
```
