### PR TITLE
Create the msympify function in order to sympify matrices.

### DIFF
--- a/sympy/matrices/__init__.py
+++ b/sympy/matrices/__init__.py
@@ -6,7 +6,8 @@ matrix, etc.
 from matrices import (SparseMatrix, zeros, ones, eye, diag,
      hessian, randMatrix, GramSchmidt, wronskian, casoratian,
      list2numpy, matrix2numpy, DeferredVector, symarray, ShapeError,
-     NonSquareMatrixError, rot_axis1, rot_axis2, rot_axis3)
+     NonSquareMatrixError, rot_axis1, rot_axis2, rot_axis3,
+     msympify)
 
 from matrices import MutableMatrix as Matrix
 

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -16,7 +16,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.printing import sstr
 from sympy.functions.elementary.trigonometric import cos, sin
 
-from sympy.core.compatibility import callable, reduce
+from sympy.core.compatibility import iterable, callable, reduce
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.decorators import call_highest_priority
 
@@ -3855,7 +3855,10 @@ def force_mutable(x):
     Safely turn a Matrix object into a Mutable Matrix
     """
     if not isinstance(x, Basic):
-        return x
+        if hasattr(x, '__array__') or not iterable(x):
+            return x
+        else:
+            return msympify(x)
     if not x.is_Matrix:
         return x
     if x.is_MatrixExpr:
@@ -4962,6 +4965,28 @@ def rot_axis1(theta):
            (0,ct,st),
            (0,-st,ct))
     return MutableMatrix(mat)
+
+def msympify(a, **kwargs):
+    """Sympify and transform iterables to matrices.
+
+    >>> from sympy import msympify, Matrix
+    >>> from sympy.abc import x, y
+    >>> msympify([x,y])
+    [x]
+    [y]
+    >>> msympify([[x],[y]])
+    [x]
+    [y]
+    >>> msympify([[x,y],])
+    [x, y]
+
+    """
+    if isinstance(a, MatrixBase):
+        return a
+    elif iterable(a):
+        return MutableMatrix([sympify(i, **kwargs) for i in a])
+    else:
+        return sympify(a, **kwargs)
 
 Matrix = MutableMatrix
 Matrix.__name__ = "Matrix"

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2259,3 +2259,27 @@ def test_anti_symmetric():
     assert m.is_anti_symmetric(simplify=False) is True
     m[0, 0] = 1
     assert m.is_anti_symmetric() is False
+
+def test_interaction_with_iterables():
+    assert Matrix([[1,2],[3,4]])*[1,2] == Matrix([[1,2],[3,4]])*Matrix([1,2])
+    assert Matrix([[1,2],[3,4]])*[[1,2],[3,4]] == Matrix([[1,2],[3,4]])**2
+    assert [[1,2],]*Matrix([[1,2],[3,4]]) == Matrix([[1,2],])*Matrix([[1,2],[3,4]])
+    assert [[1,2],[3,4]]*Matrix([[1,2],[3,4]]) == Matrix([[1,2],[3,4]])**2
+
+    assert Matrix([1,2]) + [1,2] == 2*Matrix([1,2])
+    assert [[1,2],[3,4]] + Matrix([[1,2],[3,4]]) == 2*Matrix([[1,2],[3,4]])
+    assert [[1,2],] + Matrix([[1,2],]) == 2*Matrix([[1,2],])
+    assert [[1,2],] - Matrix([[1,2],]) == 0*Matrix([[1,2],])
+
+
+    # TODO immutable matrix inherits __mul__ and co from MatExpr, so you should
+    # change them there
+    #assert ImmutableMatrix([[1,2],[3,4]])*[1,2] == ImmutableMatrix([[1,2],[3,4]])*ImmutableMatrix([1,2])
+    #assert ImmutableMatrix([[1,2],[3,4]])*[[1,2],[3,4]] == ImmutableMatrix([[1,2],[3,4]])**2
+    #assert [[1,2],]*ImmutableMatrix([[1,2],[3,4]]) == ImmutableMatrix([[1,2],])*ImmutableMatrix([[1,2],[3,4]])
+    #assert [[1,2],[3,4]]*ImmutableMatrix([[1,2],[3,4]]) == ImmutableMatrix([[1,2],[3,4]])**2
+
+    #assert ImmutableMatrix([1,2]) + [1,2] == 2*ImmutableMatrix([1,2])
+    #assert [[1,2],[3,4]] + ImmutableMatrix([[1,2],[3,4]]) == 2*ImmutableMatrix([[1,2],[3,4]])
+    #assert [[1,2],] + ImmutableMatrix([[1,2],]) == 2*ImmutableMatrix([[1,2],])
+    #assert [[1,2],] - ImmutableMatrix([[1,2],]) == 0*ImmutableMatrix([[1,2],])


### PR DESCRIPTION
Add a msympify function that transforms iterables into matrices and
use it in all the **mul** & co. methods of Matrix.

The following is now possible:

```
msympify([x,y]) == Matrix([x,y])
msympify([[x,y],]) == Matrix([[x,y],])

msympify(Matrix([1,2])) == Matrix([1,2])

Matrix([[1,2],[3,4]]) * [1,2]
Matrix([[1,2],[3,4]]) * [[1,2],[3,4]]
[[1,2],] * Matrix([[1,2],[3,4]])
Matrix([1,2]) + [1,2]
```
