### PR TITLE
Remove a test that tests the output of a specific random seed

### DIFF
--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -94,14 +94,6 @@ def test_coset_rank():
     assert G.coset_rank(gens[0]) == 6
     assert G.coset_unrank(6) == gens[0]
 
-def test_random():
-    random.seed(10)
-    gens_cube = [[1, 3, 5, 7, 0, 2, 4, 6], [1, 3, 0, 2, 5, 7, 4, 6]]
-    gens = [Permutation(p) for p in gens_cube]
-    G = PermutationGroup(gens)
-    h = G.random(af=True)
-    assert h == [4, 5, 6, 7, 0, 1, 2, 3]
-
 def test_coset_decomposition():
     a = Permutation([2,0,1,3,4,5])
     b = Permutation([2,1,3,4,5,0])


### PR DESCRIPTION
This test fails in Python 3 due to a modification in the random number
algorithm, and this is not the correct way to test random functions anyway.

See for example http://reviews.sympy.org/report/agZzeW1weTNyDAsSBFRhc2sY9dgZDA.  If anyone (@pernici maybe) has any ideas on a better test to replace this, let me know.  I personally think it's fine to just remove the test completely.
