### PR TITLE
bin/use2to3 now makes converted files end in exactly one newline

### DIFF
--- a/bin/use2to3
+++ b/bin/use2to3
@@ -134,6 +134,17 @@ for filepath in modified_files + modified_txt_files:
 
     text, n = whitespace.subn("", text)
 
+    # Also make sure that each file ends with exactly one newline.  These are
+    # important because they are tested by test_code_quality.py.
+
+    for i, char in enumerate(reversed(text)):
+        if char != '\n':
+            break
+
+    if i != 1:
+        text = text[:-i] + '\n'
+        n += 1
+
     if n > 0:
         sys.stdout.write("Removed trailing whitespace from %s\n" % filepath)
 


### PR DESCRIPTION
The code quality tester checks for this, and sometimes 2to3 adds extra
newlines, so this keeps the tests passing in Python 3.

This fixes a Python 3 test failure in master.  See for example http://reviews.sympy.org/report/agZzeW1weTNyDAsSBFRhc2sY9dgZDA.
