### PR TITLE
beautify the error message for inconsistent assumptions

### DIFF
--- a/sympy/core/facts.py
+++ b/sympy/core/facts.py
@@ -438,8 +438,15 @@ class FactRules(object):
 
 class InconsistentAssumptions(ValueError):
     def __str__(self):
+        from textwrap import fill, dedent
+        filldedent = lambda s: '\n' + fill(dedent(s).strip('\n'))
         kb, fact, value = self.args
-        return "%s, %s=%s" % (kb, fact, value)
+        sorted_kb = '{%s}' % ', '.join(["'%s': %s" % (k, v) for
+                    k, v in sorted(kb.items())])
+        return filldedent('''
+        The assumption '%s=%s' is inconsistent with the existing
+        value of '%s' in the current knowledge base for this object: %s
+        ''' % (fact, value, kb[fact], sorted_kb))
 
 class FactKB(dict):
     """


### PR DESCRIPTION
Before

sympy.core.facts.InconsistentAssumptions: {'real': False, 'nonzero': True, 'irra
tional': False, 'nonpositive': False, 'composite': False, 'prime': False, 'odd':
 False, 'noninteger': False, 'negative': False, 'nonnegative': False, 'zero': Fa
 lse, 'rational': False, 'positive': False, 'integer': False, 'even': False}, integer=True

After (sorted by keys and wrapped and brief explanation given about offending values):

sympy.core.facts.InconsistentAssumptions:
The assumption 'integer=True' is inconsistent with the existing value
of 'False' in the current knowledge base for this object:
{'composite': False, 'even': False, 'integer': False, 'irrational':
False, 'negative': False, 'noninteger': False, 'nonnegative': False,
'nonpositive': False, 'nonzero': True, 'odd': False, 'positive':
False, 'prime': False, 'rational': False, 'real': False, 'zero':
False}
