### PR TITLE
Solve - [] not None; allow 'dict' flag for canonical return structure

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -558,7 +558,7 @@ class Integral(Expr):
         if not x.is_Symbol:
             F = [x.subs(xvar, d)]
             soln = solve(u - x, xvar, check=False)
-            if len(soln) == 0:
+            if not soln:
                 raise ValueError('no solution for solve(F(x) - f(u), x)')
             f = [fi.subs(uvar, d) for fi in soln]
         else:
@@ -566,7 +566,7 @@ class Integral(Expr):
             pdiff, reps = posify(u - x)
             puvar = uvar.subs([(v, k) for k, v in reps.iteritems()])
             soln = [s.subs(reps) for s in solve(pdiff, puvar)]
-            if len(soln) == 0:
+            if not soln:
                 raise ValueError('no solution for solve(F(x) - f(u), u)')
             F = [fi.subs(xvar, d) for fi in soln]
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -428,10 +428,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3):
 
         solution = solve(equations.values(), *coeffs)
 
-        if solution is not None:
-            return (solution, candidate, coeffs)
-        else:
-            return None
+        return (solution, candidate, coeffs) if solution else None
 
     if not (F.atoms(Symbol) - set(V)):
         result = _integrate('Q')

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1016,7 +1016,7 @@ def odesimp(eq, func, order, hint):
         # The solution is not solved, so try to solve it
         try:
             eqsol = solve(eq, func)
-            if eqsol == []:
+            if eqsol is None:
                 raise NotImplementedError
         except NotImplementedError:
             eq = [eq]
@@ -1159,7 +1159,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
         (sol.rhs == func and not sol.lhs.has(func)):
         try:
             solved = solve(sol, func)
-            if solved == []:
+            if solved is None:
                 raise NotImplementedError
         except NotImplementedError:
             pass
@@ -1230,7 +1230,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
                     ds = sol.diff(x)
                     try:
                         sdf = solve(ds,func.diff(x, i))
-                        if len(sdf) != 1:
+                        if sdf is None:
                             raise NotImplementedError
                     except NotImplementedError:
                         testnum += 1

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1016,7 +1016,7 @@ def odesimp(eq, func, order, hint):
         # The solution is not solved, so try to solve it
         try:
             eqsol = solve(eq, func)
-            if eqsol is None:
+            if not eqsol:
                 raise NotImplementedError
         except NotImplementedError:
             eq = [eq]
@@ -1159,7 +1159,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
         (sol.rhs == func and not sol.lhs.has(func)):
         try:
             solved = solve(sol, func)
-            if solved is None:
+            if not solved:
                 raise NotImplementedError
         except NotImplementedError:
             pass
@@ -1230,7 +1230,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
                     ds = sol.diff(x)
                     try:
                         sdf = solve(ds,func.diff(x, i))
-                        if sdf is None:
+                        if not sdf:
                             raise NotImplementedError
                     except NotImplementedError:
                         testnum += 1
@@ -1371,7 +1371,7 @@ def ode_sol_simplicity(sol, func, trysolving=True):
     if trysolving:
         try:
             sols = solve(sol, func)
-            if sols == []:
+            if not sols:
                 raise NotImplementedError
         except NotImplementedError:
             pass

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -304,7 +304,7 @@ def rsolve_poly(coeffs, f, n, **hints):
         if E != []:
             solutions = solve(E, *C)
 
-            if solutions is None:
+            if not solutions:
                 if homogeneous:
                     if hints.get('symbols', False):
                         return (S.Zero, [])
@@ -754,7 +754,7 @@ def rsolve(f, y, init=None):
 
         result = solve(equations, *symbols)
 
-        if result is None:
+        if not result:
             return None
         else:
             for k, v in result.iteritems():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -931,6 +931,8 @@ def solve(f, *symbols, **flags):
             solution = [solution]
         elif iterable(solution[0]):
             solution = [dict(zip(symbols, s)) for s in solution]
+        elif isinstance(solution[0], dict):
+            pass
         else:
             assert len(symbols) == 1
             solution = [{symbols[0]: s} for s in solution]
@@ -945,6 +947,9 @@ def _solve(f, *symbols, **flags):
         soln = None
         free = f.free_symbols
         ex = free - set(symbols)
+        if len(ex) != 1:
+            ind, dep = f.as_independent(*symbols)
+            ex = ind.free_symbols & dep.free_symbols
         if len(ex) == 1:
             ex = ex.pop()
             try:

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -3,7 +3,7 @@ from sympy import (Matrix, Symbol, solve, exp, log, cos, acos, Rational, Eq,
     S, sympify, sstr, Wild, solve_linear, Integral,
     And, Or, Lt, Gt, Q, re, im, expand, tan, Poly, cosh, sinh, atanh,
     atan, Dummy, Float, tanh)
-from sympy.abc import a, b, c, d, x, y, z, t
+from sympy.abc import a, b, c, d, k, h, p, x, y, z, t
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU,\
      solve_undetermined_coeffs
@@ -90,6 +90,10 @@ def test_solve_args():
     assert solve(x + y - 3, [x, y]) == [{x: 3 - y}]
     # unless it is an undetermined coefficients system
     assert solve(a + b*x - 2, [a, b]) == {a: 2, b: 0}
+    assert solve(a*x**2 + b*x + c -
+                ((x-h)**2 + 4*p*k)/4/p,
+                [h, p, k], exclude=[a, b, c], dict=True) == \
+        [{k: (4*a*c - b**2)/(4*a), h: -b/(2*a), p: 1/(4*a)}]
     # failing undetermined system
     assert solve(a*x + b**2/(x + 4) - 3*x - 4/x, a, b) == \
         [{a: (-b**2*x + 3*x**3 + 12*x**2 + 4*x + 16)/(x**2*(x + 4))}]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -79,8 +79,13 @@ def test_solve_args():
     assert set(int(tmp) for tmp in solve(x**2-4)) == set([2,-2])
     assert solve([x+y-3,x-y-5]) == {x: 4, y: -1}
     #no symbol to solve for
-    assert solve(42) is None
-    assert solve([1, 2]) is None
+    assert solve(42) == []
+    assert solve([1, 2]) == []
+    #unordered symbols
+    #only 1
+    assert solve(y - 3, set([y])) == [3]
+    #more than 1
+    assert solve(y - 3, set([x, y])) == [{y: 3}]
     #multiple symbols: take the first linear solution
     assert solve(x + y - 3, [x, y]) == [{x: 3 - y}]
     # unless it is an undetermined coefficients system
@@ -89,7 +94,7 @@ def test_solve_args():
     assert solve(a*x + b**2/(x + 4) - 3*x - 4/x, a, b) == \
         [{a: (-b**2*x + 3*x**3 + 12*x**2 + 4*x + 16)/(x**2*(x + 4))}]
     # failed single equation
-    assert solve(1/(1/x - y + exp(y))) is None
+    assert solve(1/(1/x - y + exp(y))) == []
     raises(NotImplementedError, lambda: solve(exp(x) + sin(x) + exp(y) + sin(y)))
     # failed system
     # --  when no symbols given, 1 fails
@@ -101,7 +106,7 @@ def test_solve_args():
     #symbol is not a symbol or function
     raises(TypeError, lambda: solve(x**2-pi, pi))
     # no equations
-    assert solve([], [x]) is None
+    assert solve([], [x]) == []
     # overdetermined system
     # - nonlinear
     assert solve([(x + y)**2 - 4, x + y - 2]) == [{x: -y + 2}]
@@ -145,7 +150,7 @@ def test_solve_polynomial1():
                    sqrt(1 - sqrt(a)), -sqrt(1 - sqrt(a))])
 
 def test_solve_polynomial2():
-    assert solve(4, x) is None
+    assert solve(4, x) == []
 
 def test_solve_polynomial_cv_1a():
     """
@@ -178,10 +183,10 @@ def test_solve_rational():
 def test_linear_system():
     x, y, z, t, n = symbols('x, y, z, t, n')
 
-    assert solve([x - 1, x - y, x - 2*y, y - 1], [x,y]) is None
+    assert solve([x - 1, x - y, x - 2*y, y - 1], [x,y]) == []
 
-    assert solve([x - 1, x - y, x - 2*y, x - 1], [x,y]) is None
-    assert solve([x - 1, x - 1, x - y, x - 2*y], [x,y]) is None
+    assert solve([x - 1, x - y, x - 2*y, x - 1], [x,y]) == []
+    assert solve([x - 1, x - 1, x - y, x - 2*y], [x,y]) == []
 
     assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) == {x: -3, y: 1}
 
@@ -226,8 +231,8 @@ def test_tsolve():
     assert solve(Eq(exp(x), 3), x) == [log(3)]
     assert solve(log(x)-3, x) == [exp(3)]
     assert solve(sqrt(3*x)-4, x) == [Rational(16,3)]
-    assert solve(3**(x+2), x) is None
-    assert solve(3**(2-x), x) is None
+    assert solve(3**(x+2), x) == []
+    assert solve(3**(2-x), x) == []
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
     assert solve(3*x+5+2**(-5*x+3), x) in [
         [-((25*log(2) - 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2)))],
@@ -363,15 +368,15 @@ def test_solve_inequalities():
         Or(And(Lt(-sqrt(2), x), Lt(x, -1)), And(Lt(1, x), Lt(x, sqrt(2))))
 
 def test_issue_1694():
-    assert solve(1/x) is None
+    assert solve(1/x) == []
     assert solve(x*(1 - 5/x)) == [5]
     assert solve(x + sqrt(x) - 2) == [1]
-    assert solve(-(1 + x)/(2 + x)**2 + 1/(2 + x)) is None
-    assert solve(-x**2 - 2*x + (x + 1)**2 - 1) is None
-    assert solve((x/(x + 1) + 3)**(-2)) is None
+    assert solve(-(1 + x)/(2 + x)**2 + 1/(2 + x)) == []
+    assert solve(-x**2 - 2*x + (x + 1)**2 - 1) == []
+    assert solve((x/(x + 1) + 3)**(-2)) == []
     assert solve(x/sqrt(x**2 + 1),x) == [0]
     assert solve(exp(x) - y, x) == [log(y)]
-    assert solve(exp(x)) is None
+    assert solve(exp(x)) == []
     assert solve(x**2 + x + sin(y)**2 + cos(y)**2 - 1, x) in [[0, -1], [-1, 0]]
     eq = 4*3**(5*x + 2) - 7
     ans = solve(eq, x)
@@ -379,7 +384,7 @@ def test_issue_1694():
     assert solve(log(x**2) - y**2/exp(x), x, y) == [{y: -sqrt(exp(x)*log(x**2))},
                                                     {y: sqrt(exp(x)*log(x**2))}]
     assert solve(x**2*z**2 - z**2*y**2) in ([{x: y}, {x: -y}], [{x: -y}, {x: y}])
-    assert solve((x - 1)/(1 + 1/(x - 1))) is None
+    assert solve((x - 1)/(1 + 1/(x - 1))) == []
     assert solve(x**(y*z) - x, x) == [1]
     raises(NotImplementedError, lambda: solve(log(x) - exp(x), x))
 
@@ -388,7 +393,7 @@ def test_issue_1694():
     assert solve(sqrt(x - 1)) == [1]
     # 1363
     a = Symbol('a')
-    assert solve(-3*a/sqrt(x),x) is None
+    assert solve(-3*a/sqrt(x),x) == []
     # 1387
     assert solve(2*x/(x + 2) - 1,x) == [2]
     # 1397
@@ -419,12 +424,12 @@ def test_issue_1694():
 
 def test_issue_2098():
     x = Symbol('x', real=True)
-    assert solve(x**2 + 1, x) is None
+    assert solve(x**2 + 1, x) == []
     n = Symbol('n', integer=True, positive=True)
     assert solve((n - 1)*(n + 2)*(2*n - 1), n) == [1]
     x = Symbol('x', positive=True)
     y = Symbol('y')
-    assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) == None # not {x: -3, y: 1} b/c x is positive
+    assert solve([x + 5*y - 2, -3*x + 6*y - 15], x, y) == [] # not {x: -3, y: 1} b/c x is positive
     # The solution following should not contain (-sqrt(2), sqrt(2))
     assert solve((x + y)*n - y**2 + 2, x, y) == [(sqrt(2), -sqrt(2))]
     y = Symbol('y', positive=True)
@@ -445,9 +450,9 @@ def test_checking():
     assert set(solve(x*(x - y/x),x, check=False)) == set([sqrt(y), S(0), -sqrt(y)])
     assert set(solve(x*(x - y/x),x, check=True)) == set([sqrt(y), -sqrt(y)])
     # {x: 0, y: 4} sets denominator to 0 in the following so system should return None
-    assert solve((1/(1/x + 2), 1/(y - 3) - 1)) is None
+    assert solve((1/(1/x + 2), 1/(y - 3) - 1)) == []
     # 0 sets denominator of 1/x to zero so None is returned
-    assert solve(1/(1/x + 2)) is None
+    assert solve(1/(1/x + 2)) == []
 
 def test_issue_1572_1364_1368():
     assert solve((sqrt(x**2 - 1) - 2)) in ([sqrt(5), -sqrt(5)],
@@ -555,7 +560,7 @@ def test_issue_2668():
 def test_polysys():
     assert solve([x**2 + 2/y - 2 , x + y - 3], [x, y]) == \
         [(1, 2), (1 + sqrt(5), 2 - sqrt(5)), (1 - sqrt(5), 2 + sqrt(5))]
-    assert solve([x**2 + y - 2, x**2 + y]) is None
+    assert solve([x**2 + y - 2, x**2 + y]) == []
     # the ordering should be whatever the user requested
     assert solve([x**2 + y - 3, x - y - 4], (x, y)) != solve([x**2 + y - 3, x - y - 4], (y, x))
 
@@ -618,7 +623,7 @@ def test_unrad():
     assert check(unrad(eq),
                (16*x**3 - 9*x**2, [], []))
     assert solve(eq, check=False) == [0, S(9)/16]
-    assert solve(eq) is None
+    assert solve(eq) == []
     # but this one really does have those solutions
     assert solve(sqrt(x) - sqrt(x + 1) + sqrt(1 - sqrt(x))) == [0, S(9)/16]
 
@@ -684,13 +689,13 @@ def test_unrad():
     #        Classes/Alg/SolveRadicalEqns.aspx#Solve_Rad_Ex2_a
     assert solve(Eq(x, sqrt(x + 6))) == [3]
     assert solve(Eq(x + sqrt(x - 4), 4)) == [4]
-    assert solve(Eq(1, x + sqrt(2*x - 3))) is None
+    assert solve(Eq(1, x + sqrt(2*x - 3))) == []
     assert solve(Eq(sqrt(5*x + 6) - 2, x)) == [-1, 2]
     assert solve(Eq(sqrt(2*x - 1) - sqrt(x - 4), 2)) == [5, 13]
     assert solve(Eq(sqrt(x + 7) + 2, sqrt(3 - x))) == [-6]
     # http://www.purplemath.com/modules/solverad.htm
     assert solve((2*x - 5)**Rational(1, 3) - 3) == [16]
-    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) is None
+    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) == []
     assert solve(x + 1 - (x**4 + 4*x**3 - x)**Rational(1, 4)) == \
         [-S(1)/2, -S(1)/3]
     assert solve(sqrt(2*x**2 - 7) - (3 - x)) == [-8, 2]
@@ -700,19 +705,19 @@ def test_unrad():
     assert solve(sqrt(x - 3) + sqrt(x) - 3) == [4]
     assert solve(sqrt(9*x**2 + 4) - (3*x + 2)) == [0]
     assert solve(sqrt(x) - 2 - 5) == [49]
-    assert solve(sqrt(x - 3) - sqrt(x) - 3) is None
+    assert solve(sqrt(x - 3) - sqrt(x) - 3) == []
     assert solve(sqrt(x - 1) - x + 7) == [10]
     assert solve(sqrt(x - 2) - 5) == [27]
     assert solve(sqrt(17*x - sqrt(x**2 - 5)) - 7) == [3]
-    assert solve(sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))) is None
+    assert solve(sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))) == []
 
     # don't posify the expession in unrad and use _mexpand
     z = sqrt(2*x + 1)/sqrt(x) - sqrt(2 + 1/x)
     p = posify(z)[0]
-    assert solve(p) is None
-    assert solve(z) is None
+    assert solve(p) == []
+    assert solve(z) == []
     assert solve(z + 6*I) == [-S(1)/11]
-    assert solve(p + 6*I) is None
+    assert solve(p + 6*I) == []
 
 @XFAIL
 def test_multivariate():
@@ -735,7 +740,7 @@ def test__invert():
 def test_issue_1364():
     assert solve(-a*x + 2*x*log(x), x) == [exp(a/2)]
     assert solve(a/x + exp(x/2), x) == [2*LambertW(-a/2)]
-    assert solve(x**x) is None
+    assert solve(x**x) == []
     assert solve(x**x - 2) == [exp(LambertW(log(2)))]
     assert solve(((x - 3)*(x - 2))**((x - 3)*(x - 4))) == [2]
     assert solve((a/x + exp(x/2)).diff(x), x) == [4*LambertW(sqrt(2)*sqrt(a)/4)]
@@ -867,7 +872,7 @@ def test_issue_2802():
         [-sqrt(-x), sqrt(-x)]
     assert solve(x + exp(x), x, implicit=True) == \
         [-exp(x)]
-    assert solve(cos(x) - sin(x), x, implicit=True) is None
+    assert solve(cos(x) - sin(x), x, implicit=True) == []
     assert solve(x - sin(x), x, implicit=True) == \
         [sin(x)]
     assert solve(x**2 + x - 3, x, implicit=True) == \
@@ -907,7 +912,7 @@ def test_float_handling():
             x**4 + 2.0*x + 1.94495694631474)
     # don't call nfloat if there is no solution
     tot = 100 + c + z + t
-    assert solve(((.7 + c)/tot - .6, (.2 + z)/tot - .3, t/tot - .1)) is None
+    assert solve(((.7 + c)/tot - .6, (.2 + z)/tot - .3, t/tot - .1)) == []
 
 def test_check_assumptions():
     x = symbols('x', positive=1)
@@ -917,7 +922,7 @@ def test_solve_abs():
     assert solve(abs(x - 7) - 8) == [-1, 15]
 
 def test_issue_2957():
-    assert solve(tanh(x + 3)*tanh(x - 3) - 1) is None
+    assert solve(tanh(x + 3)*tanh(x - 3) - 1) == []
     assert solve(tanh(x - 1)*tanh(x + 1) + 1) == [
         -log(2)/2 + log(-1 - I),
         -log(2)/2 + log(-1 + I),

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -79,7 +79,7 @@ def test_solve_args():
     assert set(int(tmp) for tmp in solve(x**2-4)) == set([2,-2])
     assert solve([x+y-3,x-y-5]) == {x: 4, y: -1}
     #no symbol to solve for
-    assert solve(42) == []
+    assert solve(42) is None
     assert solve([1, 2]) is None
     #multiple symbols: take the first linear solution
     assert solve(x + y - 3, [x, y]) == [{x: 3 - y}]
@@ -89,7 +89,7 @@ def test_solve_args():
     assert solve(a*x + b**2/(x + 4) - 3*x - 4/x, a, b) == \
         [{a: (-b**2*x + 3*x**3 + 12*x**2 + 4*x + 16)/(x**2*(x + 4))}]
     # failed single equation
-    assert solve(1/(1/x - y + exp(y))) ==  []
+    assert solve(1/(1/x - y + exp(y))) is None
     raises(NotImplementedError, lambda: solve(exp(x) + sin(x) + exp(y) + sin(y)))
     # failed system
     # --  when no symbols given, 1 fails
@@ -101,7 +101,7 @@ def test_solve_args():
     #symbol is not a symbol or function
     raises(TypeError, lambda: solve(x**2-pi, pi))
     # no equations
-    assert solve([], [x]) == []
+    assert solve([], [x]) is None
     # overdetermined system
     # - nonlinear
     assert solve([(x + y)**2 - 4, x + y - 2]) == [{x: -y + 2}]
@@ -145,7 +145,7 @@ def test_solve_polynomial1():
                    sqrt(1 - sqrt(a)), -sqrt(1 - sqrt(a))])
 
 def test_solve_polynomial2():
-    assert solve(4, x) == []
+    assert solve(4, x) is None
 
 def test_solve_polynomial_cv_1a():
     """
@@ -226,8 +226,8 @@ def test_tsolve():
     assert solve(Eq(exp(x), 3), x) == [log(3)]
     assert solve(log(x)-3, x) == [exp(3)]
     assert solve(sqrt(3*x)-4, x) == [Rational(16,3)]
-    assert solve(3**(x+2), x) == []
-    assert solve(3**(2-x), x) == []
+    assert solve(3**(x+2), x) is None
+    assert solve(3**(2-x), x) is None
     assert solve(x+2**x, x) == [-LambertW(log(2))/log(2)]
     assert solve(3*x+5+2**(-5*x+3), x) in [
         [-((25*log(2) - 3*LambertW(-10240*2**(Rational(1, 3))*log(2)/3))/(15*log(2)))],
@@ -363,15 +363,15 @@ def test_solve_inequalities():
         Or(And(Lt(-sqrt(2), x), Lt(x, -1)), And(Lt(1, x), Lt(x, sqrt(2))))
 
 def test_issue_1694():
-    assert solve(1/x) == []
+    assert solve(1/x) is None
     assert solve(x*(1 - 5/x)) == [5]
     assert solve(x + sqrt(x) - 2) == [1]
-    assert solve(-(1 + x)/(2 + x)**2 + 1/(2 + x)) == []
-    assert solve(-x**2 - 2*x + (x + 1)**2 - 1) == []
-    assert solve((x/(x + 1) + 3)**(-2)) == []
+    assert solve(-(1 + x)/(2 + x)**2 + 1/(2 + x)) is None
+    assert solve(-x**2 - 2*x + (x + 1)**2 - 1) is None
+    assert solve((x/(x + 1) + 3)**(-2)) is None
     assert solve(x/sqrt(x**2 + 1),x) == [0]
     assert solve(exp(x) - y, x) == [log(y)]
-    assert solve(exp(x)) == []
+    assert solve(exp(x)) is None
     assert solve(x**2 + x + sin(y)**2 + cos(y)**2 - 1, x) in [[0, -1], [-1, 0]]
     eq = 4*3**(5*x + 2) - 7
     ans = solve(eq, x)
@@ -379,7 +379,7 @@ def test_issue_1694():
     assert solve(log(x**2) - y**2/exp(x), x, y) == [{y: -sqrt(exp(x)*log(x**2))},
                                                     {y: sqrt(exp(x)*log(x**2))}]
     assert solve(x**2*z**2 - z**2*y**2) in ([{x: y}, {x: -y}], [{x: -y}, {x: y}])
-    assert solve((x - 1)/(1 + 1/(x - 1))) == []
+    assert solve((x - 1)/(1 + 1/(x - 1))) is None
     assert solve(x**(y*z) - x, x) == [1]
     raises(NotImplementedError, lambda: solve(log(x) - exp(x), x))
 
@@ -388,7 +388,7 @@ def test_issue_1694():
     assert solve(sqrt(x - 1)) == [1]
     # 1363
     a = Symbol('a')
-    assert solve(-3*a/sqrt(x),x) == []
+    assert solve(-3*a/sqrt(x),x) is None
     # 1387
     assert solve(2*x/(x + 2) - 1,x) == [2]
     # 1397
@@ -419,7 +419,7 @@ def test_issue_1694():
 
 def test_issue_2098():
     x = Symbol('x', real=True)
-    assert solve(x**2 + 1, x) == []
+    assert solve(x**2 + 1, x) is None
     n = Symbol('n', integer=True, positive=True)
     assert solve((n - 1)*(n + 2)*(2*n - 1), n) == [1]
     x = Symbol('x', positive=True)
@@ -446,8 +446,8 @@ def test_checking():
     assert set(solve(x*(x - y/x),x, check=True)) == set([sqrt(y), -sqrt(y)])
     # {x: 0, y: 4} sets denominator to 0 in the following so system should return None
     assert solve((1/(1/x + 2), 1/(y - 3) - 1)) is None
-    # 0 sets denominator of 1/x to zero so [] is returned
-    assert solve(1/(1/x + 2)) == []
+    # 0 sets denominator of 1/x to zero so None is returned
+    assert solve(1/(1/x + 2)) is None
 
 def test_issue_1572_1364_1368():
     assert solve((sqrt(x**2 - 1) - 2)) in ([sqrt(5), -sqrt(5)],
@@ -618,7 +618,7 @@ def test_unrad():
     assert check(unrad(eq),
                (16*x**3 - 9*x**2, [], []))
     assert solve(eq, check=False) == [0, S(9)/16]
-    assert solve(eq) == []
+    assert solve(eq) is None
     # but this one really does have those solutions
     assert solve(sqrt(x) - sqrt(x + 1) + sqrt(1 - sqrt(x))) == [0, S(9)/16]
 
@@ -684,13 +684,13 @@ def test_unrad():
     #        Classes/Alg/SolveRadicalEqns.aspx#Solve_Rad_Ex2_a
     assert solve(Eq(x, sqrt(x + 6))) == [3]
     assert solve(Eq(x + sqrt(x - 4), 4)) == [4]
-    assert solve(Eq(1, x + sqrt(2*x - 3))) == []
+    assert solve(Eq(1, x + sqrt(2*x - 3))) is None
     assert solve(Eq(sqrt(5*x + 6) - 2, x)) == [-1, 2]
     assert solve(Eq(sqrt(2*x - 1) - sqrt(x - 4), 2)) == [5, 13]
     assert solve(Eq(sqrt(x + 7) + 2, sqrt(3 - x))) == [-6]
     # http://www.purplemath.com/modules/solverad.htm
     assert solve((2*x - 5)**Rational(1, 3) - 3) == [16]
-    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) == []
+    assert solve((x**3 - 3*x**2)**Rational(1, 3) + 1 - x) is None
     assert solve(x + 1 - (x**4 + 4*x**3 - x)**Rational(1, 4)) == \
         [-S(1)/2, -S(1)/3]
     assert solve(sqrt(2*x**2 - 7) - (3 - x)) == [-8, 2]
@@ -700,19 +700,19 @@ def test_unrad():
     assert solve(sqrt(x - 3) + sqrt(x) - 3) == [4]
     assert solve(sqrt(9*x**2 + 4) - (3*x + 2)) == [0]
     assert solve(sqrt(x) - 2 - 5) == [49]
-    assert solve(sqrt(x - 3) - sqrt(x) - 3) == []
+    assert solve(sqrt(x - 3) - sqrt(x) - 3) is None
     assert solve(sqrt(x - 1) - x + 7) == [10]
     assert solve(sqrt(x - 2) - 5) == [27]
     assert solve(sqrt(17*x - sqrt(x**2 - 5)) - 7) == [3]
-    assert solve(sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))) == []
+    assert solve(sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))) is None
 
     # don't posify the expession in unrad and use _mexpand
     z = sqrt(2*x + 1)/sqrt(x) - sqrt(2 + 1/x)
     p = posify(z)[0]
-    assert solve(p) == []
-    assert solve(z) == []
+    assert solve(p) is None
+    assert solve(z) is None
     assert solve(z + 6*I) == [-S(1)/11]
-    assert solve(p + 6*I) == []
+    assert solve(p + 6*I) is None
 
 @XFAIL
 def test_multivariate():
@@ -735,7 +735,7 @@ def test__invert():
 def test_issue_1364():
     assert solve(-a*x + 2*x*log(x), x) == [exp(a/2)]
     assert solve(a/x + exp(x/2), x) == [2*LambertW(-a/2)]
-    assert solve(x**x) == []
+    assert solve(x**x) is None
     assert solve(x**x - 2) == [exp(LambertW(log(2)))]
     assert solve(((x - 3)*(x - 2))**((x - 3)*(x - 4))) == [2]
     assert solve((a/x + exp(x/2)).diff(x), x) == [4*LambertW(sqrt(2)*sqrt(a)/4)]
@@ -867,8 +867,7 @@ def test_issue_2802():
         [-sqrt(-x), sqrt(-x)]
     assert solve(x + exp(x), x, implicit=True) == \
         [-exp(x)]
-    assert solve(cos(x) - sin(x), x, implicit=True) == \
-        []
+    assert solve(cos(x) - sin(x), x, implicit=True) is None
     assert solve(x - sin(x), x, implicit=True) == \
         [sin(x)]
     assert solve(x**2 + x - 3, x, implicit=True) == \
@@ -918,7 +917,7 @@ def test_solve_abs():
     assert solve(abs(x - 7) - 8) == [-1, 15]
 
 def test_issue_2957():
-    assert solve(tanh(x + 3)*tanh(x - 3) - 1) == []
+    assert solve(tanh(x + 3)*tanh(x - 3) - 1) is None
     assert solve(tanh(x - 1)*tanh(x + 1) + 1) == [
         -log(2)/2 + log(-1 - I),
         -log(2)/2 + log(-1 + I),

--- a/sympy/statistics/distributions.py
+++ b/sympy/statistics/distributions.py
@@ -498,7 +498,7 @@ class PDF(ContinuousProbability):
 
         from sympy import solve
         from sympy import S
-        inverse = solve(func-w, var)
+        inverse = solve(func - w, var)
         newPdf = S.Zero
         funcdiff = func.diff(var)
         #TODO check if x is in domain

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -267,8 +267,8 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         try:
             inverse_cdf = solve(d(x)-z, x)
         except NotImplementedError:
-            raise NotImplementedError("Could not invert CDF")
-        if len(inverse_cdf) != 1:
+            inverse_cdf = None
+        if not inverse_cdf or len(inverse_cdf) != 1:
             raise NotImplementedError("Could not invert CDF")
 
         return Lambda(z, inverse_cdf[0])


### PR DESCRIPTION
With dict=True a list (perhaps empty) or a list of solution mappings will be returned from solve regardless of input:

solve(x - 3, dict=True) -> [{x: 3}]
