### PR TITLE
Add angular momentum ipython notebook example

### DIFF
--- a/examples/notebooks/spin.ipynb
+++ b/examples/notebooks/spin.ipynb
@@ -1,0 +1,1575 @@
+{
+ "metadata": {
+  "name": "spin"
+ },
+ "nbformat": 3,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "source": [
+      "# Quantum Angular Momentum Module",
+      "",
+      "This file will show how to use the various objects and methods in the `sympy.physics.quantum.spin` module, with some examples. Much of the work in this module is based off Varschalovich \"Quantum Theory of Angular Momentum\"."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "from sympy.physics.quantum.spin import Jminus, Jx, Jz, J2, J2Op, JzKet, JzKetCoupled, Rotation, WignerD, couple, uncouple",
+      "from sympy.physics.quantum import Dagger, hbar, qapply, represent, TensorProduct",
+      "from sympy import factor, pi, S, Sum, symbols"
+     ],
+     "language": "python",
+     "outputs": [],
+     "prompt_number": 1
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "## Basic spin states and operators",
+      "",
+      "We can define simple spin states and operators and manipulate them with standard quantum machinery."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Define a spin ket:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jz = JzKet(1,1); jz"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAACcAAAAXCAYAAACI2VaYAAAABHNCSVQICAgIfAhkiAAAATlJREFU\nSInt1i1LREEYxfGfy4KyoEUwaDSIZl+SwU+gWAwiBtNi2o/gFzBYBEEQzQYFg8mtYhExWMRosClY\nRNawXrhc7q6zs4texZNmzsx55s8DMwy/SMc/DZBWKTMfbrGvgpsuzmmX30E5pEg9x5vBFRpRWF/n\nl7GSt5DtXFqTOMMm3iOgQvMnWAwpWG/hH4jvXEi+htms2a5z36l9bGTNosA94wVjabMocLCLatoo\nEtw9RjWfHRQLDg6xlkyKBgd9yaBocOua3UPv4CYw0GWNcTziNTFC4ZKDKzlrC7jDUWQ+UVXzxrZU\nPTUewTluNV/3Bp5wgdXUvqlP/yFTKzQPQ9hrB5aF61RbXWRrmMuavbwQ/ZG5EqZxmbeQ1lvkAfO4\njswu4TRk42BE8TK2pd6nDhX82fzXn9AHkLc0qQpHOW4AAAAASUVORK5CYII=\n",
+       "prompt_number": 2,
+       "text": [
+        "\u27581,1\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 2
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Find the vector representation of the state:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "represent(jz)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\left[\\begin{smallmatrix}1\\\\0\\\\0\\end{smallmatrix}\\right]$$"
+       ],
+       "output_type": "pyout",
+       "prompt_number": 3,
+       "text": [
+        "",
+        "\u23a11\u23a4",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a30\u23a6"
+       ]
+      }
+     ],
+     "prompt_number": 3
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Create and evaluate an innerproduct of a bra and a ket:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "ip = Dagger(jz) * jz; ip"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\left\\langle 1,1 \\right. {\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAEgAAAAXCAYAAACoNQllAAAABHNCSVQICAgIfAhkiAAAActJREFU\nWIXt2D1rFFEUxvGfMRCJqIUgmJQRRDvxJZWg3yCxSaHBQi0sLPwISa2CNgElEJLKQjHprNxWElDE\nwsJgaWGXQJoQYnFdmYyzs3Pnxt0N2X81c84+9zmc3bv3zNDnQPGm2wXkGSjJPW8RH8aXmn7ttKcT\ntCneLzAYs9gNPCiIX8UqdmMWi9A2ErQp3rcwVZRo1bU7eJS5v4An+IWdyOK6pY3RL2MJr6ssOobZ\nkvyC+t9kO23jP/lW0T/GtXyw6D/oIeYSCjmozONePphv0Ckcx89OVNRjbGATo9lgvkH3hU4eVuaE\nHfSXbIOO4hLWOllRj7GOEWEkwN4GTeBdpyvqQRYx3bzJNqhsaDxsHGleZJvyFpOdr6XnuCv8irC3\nQTv4hMuJBudxLHGNbvmOCSf4VjOQ31avhJOsjGYRwwW5m/gmTKWx2nak+Fb1rjQDPsXZXOwM3uOr\nMI3uCuP7B9zOfO7in/iPGlr+naRTfGO9T+KlCpxT/qhRhZmaukaXfAmPGuP5YNHJ9V2YJlP281CC\nNoW6vgO4go9FiSKWZGaBSK7jc03tdk1dqu8EVmJFrV6YlTGIZzJzRCQnaupSfaNfmPXp02df+A0V\naWV8f9YGUgAAAABJRU5ErkJggg==\n",
+       "prompt_number": 4,
+       "text": [
+        "\u27e81,1\u27581,1\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "ip.doit()"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$1$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAAsAAAASCAYAAACNdSR1AAAABHNCSVQICAgIfAhkiAAAAF5JREFU\nKJFjYKAC4GJgYLhEjEJTBgaG0wwMDP/RJViQ2JoMDAw9DAwMrxkYGP6S4owF2ExmIsWEUcVUV8wB\npblwaRRjYGDYycDAcIUBEnv/GSBRv5+BgSGaFBfQGAAA/84M5lOscPUAAAAASUVORK5CYII=\n",
+       "prompt_number": 5,
+       "text": [
+        "1"
+       ]
+      }
+     ],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Apply an angular momentum operator to the state:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "Jz * jz"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$J_z {\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAADsAAAAZCAYAAACPQVaOAAAABHNCSVQICAgIfAhkiAAAAgtJREFU\nWIXt10+ITWEYx/HPvaZoQqEm+bOQxEgiGVJkVjaKbCyYLJTybzFZWKtZWGChpJSSIiWFskCZu2DB\nSEh2srTAZsTCMGPxntuce7t/zrxnzkzqfut0ep/n/T3v85y398+hw7Rxb7YTSFNu49+Mp3iJcUzg\nHY5ljL+kha8b7zPGmar+MrpiA5fwHW+mqKs0sW/FiPDxYminP4CD9cZ2M1tlAxbjSVRqk/TiEU7i\nb4H6B9gXER+cFr7ininqKi18N8TPbBb9IPrShqwz248/eB6V1uxwHUfThizFlrALr/GzgKSKYhQ/\nsLxqyFLsRmFXHS4oqSK5iuPVRpZi+5N3pYhsCuYTlgnHVKZid2MML4rLqVBuYoD2xZaF9Tri/1qv\n9ZSoLXY7vuFMyrYJi/Bs5vKado4Is1tT7GFhIxpN2QaEw/v2jKU2yVrMyxljNb7gV73jFM6m2nvx\nO7HHUmnhuyNcCrob+PoT391IfZULWNnIMQdDSYcruC+s12YM4St2YKmwDOqp1LV78BgfkkQnkhjD\nOJTqtz6xf47Uw0Jca5F/ZlYJl+35wi2lr0m/Ss5xzuXQDmJbzvFrKGu9o1dyxj8fqSvjViNjLKXk\nGccKzG3QZyxH/J14G6ndj4c5xq5hC04IO2YPLjbptyAyfhcuSc7HCHL9vKfpxTphvb7CR6yZjsAd\nOnTokOYfv15fmYxfZs8AAAAASUVORK5CYII=\n",
+       "prompt_number": 6,
+       "text": [
+        "",
+        "J \u22c5\u27581,1\u27e9",
+        " z      "
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(Jz * jz)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\hbar {\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAADEAAAAXCAYAAACiaac3AAAABHNCSVQICAgIfAhkiAAAAhpJREFU\nWIXt1ztoFUEUxvFfQiR6xYAKikZQoiKKgoUPBA0It1axsVCxsEqZxlZSWSgWNgFF8FEpWMRCEYRc\nRAPBRkREwUc6C9HCF4pILGZX914369y9cQvJH5adOTtn5js7e2Zm+U9ZiB1YX9DmRkVaouhuqe/H\nPUxiTYHf0hnsNTzuQE+R/zn0xHZ0Fp/QW9CmkWPbjoeYjh2oTf+DOJT3IBvZEkwJb6Mb7xL7FDYX\nDL4RZ/AWPyIFl/Efw1VcK+qsFzuFN3ES65JrRU7bxgx9XFJ+JmL8h4V8bSKbE9+wMinfxIvketOB\nqNnmIo63GlsTexAfheRaLEzfZ1z+1+oi+SDo688a84KYQB9O4xTuYl8FAmMZxVDWkA2iD1vxACeE\n7++psNQ+r0ZfFC+Fz76WGrJB7E7qA7ggTNtybMF4dRqjuIKjaSUbxGByf4RXSbmOLtyqRFp7dKWF\n1iDeC7OQUhf2i4lqdEVzTJgN/A6ihm24ji+ZxnXcFjahgVkYfAPmd9jHWmHZ/6UzDWIX5gn7Q8pq\nrMJ9HMH3iAFSgbWcZ3vxTFi2y/inDAkr1B+M4CsWZGz9wlFgTDgaZGlkystwB0+E3XY68RvH4Uy7\nTYn9dUtfsf6EFfR8fmzt0+jAd6QD32HhaNRE62ZXBUWn4yK6hbydzHtQhpj8yGOPsISX4YDmnO2Y\nRSV8eoR/la6/NZyBtn6K5pijJD8BAqxjIW7wMpQAAAAASUVORK5CYII=\n",
+       "prompt_number": 7,
+       "text": [
+        "\u210f\u22c5\u27581,1\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "Jminus * jz"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$J_- {\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAEIAAAAWCAYAAAB0S0oJAAAABHNCSVQICAgIfAhkiAAAAehJREFU\nWIXt2E+oTGEYx/HPjFt0i0JZkA0LkUT5tyGzslFkY8HNQin/FjcLa2UpSqGUkoVICmWBYhYsNBKy\nlaUFNlcsXFyLd0bHae7MmfedmSPudzPzPr/ze85znt6e98wwQ6ncKruAPNUu+jo8xDP8xBRe4WDi\nfRd20EbxOiF3J/85jCTkVsEnvEhJkqE+TXwDGkLDY+jm34097YRuO6LFaizAg55LK8ZK3MMR/Big\n/w52RuT/zTGhy9tTkmSod9CuiN8RRfzj2JgPFt0RNXzHk57L+vu4jAP5YJFGVLAVz/Glz0WVwQQ+\nY0k2WKQRa4Qp/3gARZXFRRzKBoo0otb8rPe7mhJ5i8XCUYtijdiGSTwdTE2lcRVjrUW3RlSF+dDw\nb8yHPJXWl2wjNuMjjmdiazEfj4ZT11DZL+wK/NmIfcJQnMjExoQXlGtDKa0YKzAnMcdyvMfXduJR\nnMisd+BbM95v6h2068IL0WgbrdbUbkb6W5zG0unEWTjVvOg8bgvzYRDUc+tFuI83wkNM4YNwZO/N\nXLeqGX8X6Yd5uJT6AP2inug/meAdx6Z8MPYn6WEs66A3cCMydxFmR/qqWI+zeSG2ERcifS0mE7xb\n8DLSuwt3E+7dd+ZG+kZwRub875HkP2Zm+F/4BZltWVGn5m3TAAAAAElFTkSuQmCC\n",
+       "prompt_number": 8,
+       "text": [
+        "",
+        "J \u22c5\u27581,1\u27e9",
+        " -      "
+       ]
+      }
+     ],
+     "prompt_number": 8
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(Jminus * jz)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\sqrt{2} \\hbar {\\left|1,0\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAFEAAAAfCAYAAACf3SEqAAAABHNCSVQICAgIfAhkiAAABB5JREFU\naIHt2VuIVlUUwPGfl5oaL6WgomJWTllCZDcLM8Eyqqciih5KIXrQogv60EMXQjLyoTSil0px0i6S\nZahol4f6KpIuCJUVFJUgYZSW4Y3ErB7W+ejMcX9n5sx8MI3OHz7Od9ZaZ+/1rbP3Xmvvj376+T8w\noEnt/NOENprlS59lM07qbSd6i4FNaONavI8/m9DWccsGDO9tJ3qTno7Ey/El9jbBl+OWtRjV2070\nNj0ZiedjJ3Y1yRcYgmk4q8Tm9Sb21+uswmkl+mlYhzexDSswvsT+emwV5dLVJXa1El2rWF6qMln4\nugxLxW8bU7B5GoO70XZD2rC8RH8h3sGp2f1QfIBfcXrJc0uxHy0lNrUG8kvwmeo16yn4CbflZA/g\nK5yYk92IWyq2XcqzOKdEv0kEOs8F4geuSdiPFMnpL/wtArlf/JAitcL9uVl/7fhY9SA+Jl5ufpSN\nxGHcmZMNwstVGh5Wohvfhcb2YwdGF+R7sDth34JLRQAeES+gDWMTtrWSfttVD+J32JiQb8O7BdkC\nsUx1oJhYWvESlpR0uhBPduLYdrGmDCnID+HkhP0hjMu+b8D32efnTvrpKcNEEtuR0O3ERQXZCtxR\nNMwHcbAI0I+YK11Aj8QZIgGUcRkmimDWGScC+2mDZ2Zin0gMI7AaB/BCJ331hInZNVXnHhAxyK/P\nezMfyxIkIlAHcV9CtwizKrn5H0twBNMb6LfiLRHA5ZiC9WIJyFMr6aNdtek8PbNflNCtznTFLD0J\ni/OCVJ34u5jSd+l4sjIUF+O9Ck7WacPdeBxbEvrhmIqPcL9Ye74RmfzbbvTXVY5k11TgT8iugwry\nH8Ssaq0LGhXbz+BsXJOTzRdZuSotIhE9h4ca2MzIfDkTz4spMwbn6d5L6yplG4X6er4voVuFOfWb\nRkH8Ah/inuy+RRTAqSxWxgCsFNN0YYndzOz6uViTYXb2/OaKfVbhFzEKRyR0Q/CHdBDp4vnnzaJm\na8M83FrdR4vxcEE2N2G3Bb/JTRER/N2Onk61kv7aVS9xtordSpEdGs+ClbowneENkebvxU3SRXIZ\nt4uX8GhBPqNw3yrW2ldFQqszW2wZj4hp3gwmO/rweJOoUfMjaxIm4LVEG5NE6XUwoUvyoAjE/Cqe\n4koxil4sfNbglYLtVWL0XJeTTcxk88R2bEJOVyvpd032XGtCNyvTrS3Ix4ppOycnewpf67jtq/NE\nwZ9OGSWK3qpH/3uEw6lPcWQuEqfi+SJ8vFj014ttXZ5a4X403hZbxHofu8RUzC9BUzL5dkczVYzI\nZaK8WicdqOEiQfZ5aj18PlUTdpUFYup3oBn/sfQ1yk6Iyhgo1u5PUoq+xuEePHuFKKO6ww1iX39M\nUHbCVMZgcV7Z3f+3m34o208//fRzLPIv82vR8KM+l6AAAAAASUVORK5CYII=\n",
+       "prompt_number": 9,
+       "text": [
+        "",
+        "  ___        ",
+        "\u2572\u2571 2 \u22c5\u210f\u22c5\u27581,0\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "We can also do this for symbolic angular momentum states:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "j, m = symbols('j m')",
+      "jz = JzKet(j, m); jz"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${\\left|j,m\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAC0AAAAXCAYAAACf+8ZRAAAABHNCSVQICAgIfAhkiAAAAlNJREFU\nWIXt11uITVEYB/DfDI1LzNQIIdF4QEK5ltxGklKUS7xNnjyQSJpX5IkhScqTUnhAyIOHoQ6h5IlS\nHigluT5RyG08rDU5rdln763TIPnX7uz1X9/61v9867+/fQ7/AC78aQFl0JiMRxTEH8ODftKS4igG\nZk2kooswBDfqllMOFawrG/i3YADOZE38aqV/J77hHuYVBVb6XcqvoRknUjLT6AlmYDPG4CV2lFiz\nBssxEx1oxQb0YAG6cBU7hYd/FJriPl+q8rzDe4zD81qbVZLxWBwRbDQtbjq9QHBTXEM43lvYhYbI\ndeI1DmFi5AZEcR0Z+SZhfzVR5Ond2IPvcTF8LlizJAptQJtwOoeEL0yoZKvwkD2N3Ld4jc7I90Qo\n3tBaG1aS8ZSq+y6hQkUYI7TGGVHoomT+LO4kXFuMXVUj51Js6R0UVfpRsrBMj36Bj1gWP+9mCKgk\n3Ep8KsjfUGsiTdaLFnzFtpykKS7jesJNFSq6IuG7cTHeTxA8Xo2TquxRtk8vjIkqGXOTMTjhGrE4\nI75d8PTtKq418qfjuFPwdy8mCaf3oZa4LFFwEG/0PaJ2oXLnEn62bD+fSwTDrBjbjLnYmsx3YXw1\nUaZPE3x4088O0ItXeIs5CT8OD/X180icSrj7OI8DQqfZVzXXHK9neeIqGVyz4OftOev25iWtAzsx\nPyVreXq94FVYLdjiSk7yQXVJy0ajcILpafVBt/DG6xHeQi14LL+Si7Cpfo19sBYbywQOxzBcw3Fc\nEn4P1MJAHJbTQ+tAzT8B//EfOfgB1hltMRlg1uwAAAAASUVORK5CYII=\n",
+       "prompt_number": 10,
+       "text": [
+        "\u2758j,m\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 10
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "J2 * jz"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$J^2 {\\left|j,m\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAEUAAAAbCAYAAAAqCUKuAAAABHNCSVQICAgIfAhkiAAAA11JREFU\nWIXt2E2IHEUUwPHfbEI0Jk4wojEuomQPKpJo/CYaMys5BAyK4tdBWYIHDwYxiMSj0SCiq4iK4sGL\nYDxERRBRiGgrfhAifoHgQUUQcf26RI3iGtfDq3Z7endmmvlIFOcPTXW/elX1uuq919XFkDnUumx3\nAdZhGS7CPXirX0b9F1mK+wrP1+IARg+POf8O1uAvjKXnOmbE5PxvqYnwyUPvDDEpayu0fX5QRvWT\nkQ71a7EHe4V3zOAjnJnu4U48hA8rjHdsBZ3H8EkFvX7wCBZ227iGn/BBSX4T7lc9YWcVdJ7Co5Ut\n642rcF23jVcLzygm2M1iUuBInFKhn6xbAwbEAuwqCzuFT04jlW+kcgNW4GWcgE1Y2Zt9h4WD2Ifz\nu2n8AqaxBKvws/Cc4lWv0E/WzeADpo4ni4IqSaaGS/A+fsWXOLrPhq3BFuFtU7itg/4V2CgS/gSW\n4xqxOOswiVewTST347EojTFd6mu/WORRfFPV4PxLc2/VBm3I5pGdiIdFKOef99Vt+liU9AnXfxu3\nm0322/E9HjSb5xaIF59o0ecYduYPVXLKeCqzCrrdcAfu0rwh/KON/gYxETURylNiAvItwrTwnF34\nKskOpmtFiz6/EItzVFWjX0xGLqnaoA3ZPLLTCveTYpXbsRKLRcjNYH2p/lm8W5KtSrqXtem3gZvp\n7CkjIp/sE/lkEHxWuG/gzQ763+I3XJrKvaX6hrmTvwm/V+i7RvOkXIgfRXzmnIVj8HqHzvrBsjRe\nJ8NzxvGe5lA7XWwRspLulXgVv+BkkWPKTOBpmiflBpGp9xdkN4pYnLPBGQAXC2OzkvxUsTkskntw\nWXdc5JR3CrLlSf5Met4u3qnImPDAA2WjtqYGOZvFKmxt9RZdkLWpewA/aP5lGBe5YHdJ9xzz55Pd\nmicEzja7jzoPt8wz9iROyh+K+5QnsCMpLBbf7Y0O3eFRI401U5B9J0L63JLuKD41N58cJ4VAgY/x\nnPhHm8Ldpfp6ur7u0u6eyVrI6/gTt7ao3zEQa4Jt4ijkH6r++wyCq0W+gMtF2LzUQveIAdkwIryw\n7HGHlD2pzP+6d4qvzudae8N6XD8ge3o6OugX+T/TUryGx8XmcEsL/YXiAKvbA/ZO9HTINGTIkCFV\n+BvGEKDJmNTtoAAAAABJRU5ErkJggg==\n",
+       "prompt_number": 11,
+       "text": [
+        "",
+        " 2      ",
+        "J \u22c5\u2758j,m\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 11
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(J2 * jz)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\hbar^{2} j^{2} {\\left|j,m\\right\\rangle } + \\hbar^{2} j {\\left|j,m\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAALEAAAAcCAYAAAAuq171AAAABHNCSVQICAgIfAhkiAAABQVJREFU\neJzt23/oXXMcx/HHfjCG75j8nFgb+dXGCsuv2YQ0y5iffyhpf0hJll9/IivSSBIptS8yJWIUMuoQ\nSlIsRCElbURqftsvf7zPbcfZ/d7vuZ977o/Nfdbpe++5n8/r8zmv9+d+7vvzOefLkCG7OBMS6szH\nGZiGM3EP3qmzU0OSGcamAvvivsL7K/EHZiRozccK3IV1WNBp5/7n1Bmb3Zq52IbZ+fsRbBeGtcPQ\n8PqpKza7PRPEDNpIQ04URs1rU2doeP3UFZvdgn1wGo6pUPZpPJDQRorhLyS0s7vRi9g02GX9XoqP\nxIA6f5yyy3G/9haHj2B9k/NVDM860K+bhzG5B+0U6XVssoQ63WRMzyeW3q/F2/hd61Xtkvzv7ZiC\nmRU7sneuX2Q5NuDWihrt6neDDJf1oJ0i/YhNN+qkkqng+XRswhaRr/6WH5+Wyp0jBt6h+XEJTk/s\n2JJcC/bS2vAssY1uMAlrOtSYq/ps3o/YZIn1ukUlz6eIPHU77sTR+XFYocws/JqXKR4jCZ1q1/As\noY1uskLkp6mMqj5L9jo2DJ7fVPT8Ur1Z0aYYnnW5T+0ygsc7qD+q+iCmd7FpkPWonXZo6nn552yB\nGFzrcYBIppfheVyb2PBcXCdmjY24Gd9gv0S9KvqtWIrzcJK4pum4QgyQM7AKr4lv/YE4GHvmbWwu\n6GwSXs3A9/VcSkt6FZu669TlNxU9/wivC5OewAliQfFLhYtrxuF4SCwgG9tocxK1shr098zLw4d4\nF7fYsYq/Az+KnZKZ+blJwrhmA2U2Vlbsf5lR7c3EvY5NllCnTN1+08Tz4u7ECE7Ge2JluwKf5+Jf\ntuhoK24Tt5WLNzb+SdSqQ/8cYeQEkdJsFAZuzz/fLGaKNfg2P7c1Pw5pove1COzUxP5XZVBi02+/\nGcfzxbn46rxBudA23Nuio604rvB6lfjWpZLVoH+Y2BaaK6717NLnz+L90rlZedmLxtBciOvHabcZ\no6rPxP2ITZZQp0w3/KbkeTEnbjyA87HIWYlcZgJeHaezY/FFqeG69xTb1d+Q/z0Xf+KD0ucLxUAp\nciH+Gke71U2FJ0U+WOZIsdJuNpMtF+lDg0GJzaD4zRiev4+f/XeaXo2fRJ7SCdPEHueNHWhkNeqv\nxVulc8eLGeCC0vl1eDF/fZSdvVgtLZ0YVX0m7kdssoQ6Y1Gn35Q8b+TEU3EKnhNPkzU4T6wct9rx\nM5bCWXlnsg40UvSPFTdRikwUM1u57CKRo71XODc9P/9M/v4O4UWD2WK2KXpWN4MYm375TRPPG4P4\ndOyBlwuFj8IRIjG/xs7bHe2wUMwan3Wg0a7+IvHz93Sp7Dzsr7mpH4rbug1mimC9gVPt3P8b8Fhy\nr6sxiLFpVqcXftPE88YgXoC/Sw1tyTu6WORn3zW/nkosFPf7t49Trk79H0T/TymVnSHMKednB+Gp\n0rlPxD7s/WKhUTRvJD868aUKgxibZnW67Te983wnRoTpN3WokyXq391hu2OxQtwKTmVUe/vE3aCV\nd1lCHbrnN2N4Xn6KrS4uF/kRXCxWkq/0SX9Kje02mChmnPLs0g6bxCq816TEpt9+U4/nlZkjfmZW\nilXsV+r5dq5L0D8bV9fQdplluKoLut2mHe8GyW967Pm+eBOP4iVxD7wOGs9aVNWfjAel/Uf3ePTj\nofg6aCc2g+Q3u67nQ4YMGTJkyJAhQ4Z0nX8BhgWzuUASqbIAAAAASUVORK5CYII=\n",
+       "prompt_number": 12,
+       "text": [
+        "",
+        " 2  2          2        ",
+        "\u210f \u22c5j \u22c5\u2758j,m\u27e9 + \u210f \u22c5j\u22c5\u2758j,m\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 12
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Find the matrix representation of a angular momentum operator:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "represent(Jz, j=1)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\left[\\begin{smallmatrix}\\hbar & 0 & 0\\\\0 & 0 & 0\\\\0 & 0 & - \\hbar\\end{smallmatrix}\\right]$$"
+       ],
+       "output_type": "pyout",
+       "prompt_number": 13,
+       "text": [
+        "",
+        "\u23a1\u210f  0  0 \u23a4",
+        "\u23a2        \u23a5",
+        "\u23a20  0  0 \u23a5",
+        "\u23a2        \u23a5",
+        "\u23a30  0  -\u210f\u23a6"
+       ]
+      }
+     ],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "## Utilizing different bases",
+      "",
+      "Angular momentum states and operators are able to go between different spin bases"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "We can rewrite states as states in another basis:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jz = JzKet(1, 1)",
+      "jz.rewrite(\"Jx\")"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} {\\left|1,-1\\right\\rangle } - \\frac{1}{2} \\sqrt{2} {\\left|1,0\\right\\rangle } + \\frac{1}{2} {\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAOMAAAAkCAYAAAB7Y41AAAAABHNCSVQICAgIfAhkiAAABcdJREFU\neJztnFtoHUUYx39pq2nTxEukFSy22lSrgvdLtV4riD74IOLlQS1IBK20lSr4ICotVgyKLYpQrJYe\nrUpBraDEK+iqIF4oqBERb4VSFK1YSVXUGuvDt4dsJrOzt9md3WR+cEjOzO7Md/7fNzuzM7MLHo/H\n4/F4RulwbYAnFfstlOF97fFY4FVgumsjPOUyxbUBnkQuA94F/nJtiMcz2XkZOMi1EZ7yUXvGHuAF\nYK4DW5pMWbqdC3wODFsud6LT+Di+CViNTBYc5dSSZlGmbs8DsyyXOdGZUHGc9CNerMiOpmHb+ScD\nj1gsb7L5rXFxnGcC5zBDXhcyrHKBqe5HgWkV2mKDO4CHDflnAduA14AhYBMwx3B8GX5bGNqwHlgH\nPA0crhxTV+3LjGNrsZh0RQli0s8EPsHOmlhWkuq+Eri2ZBts9owLgCcN+acBbwKHhN+7gfeAnw02\nBDHpef12MLALuD6SdhfwBXBgJK0K7XW4imOrsZj1RxwPDAIt4EODEWWQtu6pwHMl22KzMT4OHGfI\nH0QabJRTQxu2xpwTKN+L+u1+pPFHr/K9wD5gWSTNhvYnkb13rTqOS4nFvFcUQkNc9Ixp6l6FDO3K\nIktj7DHkzSHZWb8DO4HZSvoe4JeYcwJDeS2y++1r4BVN+hDwtpJWVPsW2S90LuM46XytHpNp0X8T\n0O/Yhi7gWWDAcMztmO8VAXYg92YzlfS/gRm5rUtPD3AMckFQ+QE4XUmrg/Z1QqtHtDFeB2wI/x8A\nlldgVJUMA3sxT3LkIa1u05CG9j2wFP1Cfi9wNLA9oc6zgXlIo2xzBNJAP05ldTHmhX91659/IL+t\nM5JWlvY6mhDH1vQIDHkt6jtMBegD1pZvipFe4E/gNk3eGmBJznIHgBFgcUx+YDi3RTa/LQ6PX6PJ\n2xLmqbOqRbRvYX/NMEior8xhKmj0mEzDVIDvkB6ky6ENvyJD1VsZ+yRFN3AG8E6OMhcgPcADwAdF\nDUzBSPhXF3AHhH+nKul10L5OjNNjsjVGkLWwGxzb8BhwLHBpJO0WZBY1K53IhM9G4O7ipqVityGv\nfR+7V5NXB+3rxBg96rAYeyISSGmft/sUCdwiROtyUf9nwPvACuB1pEFdQvLEjUoHsDks496CNmXh\nJ6RXPFSTNxP4DX1jBLPOTyE7j1TmIrOP/2jy+km+x64z4/TYn/CJEhgKbmmOr4q0dW/G3lApSTeT\nPVcD/yFDzJuRiYesrAXuUdKWxhwbGMppkd1v25HdNyo7iR9q59W+Rbp7xiz+CBLqK/ueERQ92sPU\njoSPLRbi9iHZPuBHZALFBkm6mbR7CVkGWAlcRfxifRw3Io35PiX9vIzlpEHnt0FgEWN/Yx9wJPLE\nhIpt7XUU8UcWbMTxOD1s3zO2DdRd/ZYAXyGzbWVgqrvNMkanvV3zL2LLcmTT8oj58DFcDDwEzAee\niXy2Yt5QEEcev21AhqTR7XArgC+BJzTl1En7JIrGceFYXITsDFgNvAVcEHNcoHyfDbyB7ElsDwV2\nI0OV6NDrhDB9B/ZIWzfI2tdGi3W3SaubjlnAt2S/yu4hfhim9pRtAuW7Db+dgvSQ65G9tNuQnlGl\nqPYt0i9tuIpja7HYzdhdIdcg3aduUVL9EVnRrU1VwSrEUTbJoptrgoLnF/FbUe1bpGuMTYljrR7t\nYep84E5kHAsyOzcDedLcNp3Jh1hnCrKG95HlcqvUzTV5/WZD+2HSvQOoCXEcq0d7aWMIOAfZqgWj\nQ41vNIXty2kEwPnI0kDVXIG8S8Y2WXRzjSu/2dB+ZcrjmhDHmfXYQvyaV54JApCGvw437++s6gFX\nk26uceU3lw8X1zGOM+nRDzxYoLLJitetXjTeH5cz+mjHdCbAC30qwutWLxrpj+hm3guRbUeDyKzU\nRchVZVf1ZjUKr1u9aLw/5iN7CdU1K//yXDNet3rh/eHxeDwej8fj8Xg8Ho/H4ymP/wEzzZd2JaYA\nVQAAAABJRU5ErkJggg==\n",
+       "prompt_number": 14,
+       "text": [
+        "",
+        "           ___              ",
+        "\u27581,-1\u27e9   \u2572\u2571 2 \u22c5\u27581,0\u27e9   \u27581,1\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500",
+        "  2           2          2  "
+       ]
+      }
+     ],
+     "prompt_number": 14
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Vector representation can also be done into different bases:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "represent(jz, basis=Jx)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\left[\\begin{smallmatrix}\\frac{1}{2}\\\\- \\frac{1}{2} \\sqrt{2}\\\\\\frac{1}{2}\\end{smallmatrix}\\right]$$"
+       ],
+       "output_type": "pyout",
+       "prompt_number": 15,
+       "text": [
+        "",
+        "\u23a1 1/2  \u23a4",
+        "\u23a2      \u23a5",
+        "\u23a2   ___\u23a5",
+        "\u23a2-\u2572\u2571 2 \u23a5",
+        "\u23a2\u2500\u2500\u2500\u2500\u2500\u2500\u23a5",
+        "\u23a2  2   \u23a5",
+        "\u23a2      \u23a5",
+        "\u23a3 1/2  \u23a6"
+       ]
+      }
+     ],
+     "prompt_number": 15
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "When applying operators in another spin basis, any conversion necessary to apply the state is done, then the states are given back in the original basis. So in the following example, the state returned by `qapply` are in the $J_z$ basis:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "Jx * jz"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$J_x {\\left|1,1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAD0AAAAZCAYAAACCXybJAAAABHNCSVQICAgIfAhkiAAAAi1JREFU\nWIXt2E+ITWEYx/HPjClMGaEkUmIhksj/RGYhGxrZWDANKRLSZGGtLEUpKaX8KSn/lQXCXbDQSMjG\nQpYImxGNGYzFe+7MmTv33jnz3u6d1P1u7jnP8/7e9/ec95zzvudSp2rcGGsDaRpHyC/FQzzHX/Tj\nNfaOcpxpZXLNeDPK/rLqT6MptuMGfMPLSH2uRHwFuoSLGcNI+m3YXhgcaabzLMJUPIiyNpwFuIcD\n+FNF/R20RfQPDglXc1OkPlcmd0H8TGfRd2JlOpB1plvxG0+jbI0t57EnHchSdAPW4wV+VMFUtenG\nd8zKB7IUvVh4+z6pkqlacBb78ydZim5NfnPVcFMj3mOmsLxlKnoD+vCsep5qwiW0M3LRjcLz3OX/\nfJ4LaWBo0avxFUdSsSWYgse181U1OoTZHlL0TuGF1Z2KtQuL/5WaWRvOfEyosI95+IifhYmDOJo6\n34zeJF4puTK5q8LmorlIrjXJXYvU5zmB2cUS43A8aXAGt4XnuRhrsQunhDtkH25ibon2uYLz6biP\nt4nhfnwRlsUdqXYLk/iHSD204FwJX5lpMbjDaRO+wOAiZpTQ5Coc81gF2k6sSgeybkPT9OJycrwG\nt5LjDnyKtlae8ZG6Riw3ODEDwdHSIxQOG/EoOZ5cRtMXMU6edXgVqd2KuxWMPcAW4ZaZg1/CR3oD\nDpfRTIocqwknk/5jKPonQkxnu7EM7zBRWNJ6cB2fI83VqVOnTjT/AFLpagvFmvsXAAAAAElFTkSu\nQmCC\n",
+       "prompt_number": 16,
+       "text": [
+        "",
+        "J \u22c5\u27581,1\u27e9",
+        " x      "
+       ]
+      }
+     ],
+     "prompt_number": 16
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(Jx * jz)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} \\sqrt{2} \\hbar {\\left|1,0\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAFoAAAAkCAYAAAAJgC2zAAAABHNCSVQICAgIfAhkiAAABKpJREFU\naIHt2mmoVVUUwPGfZT17DuUDFRWzfDYJkU1a2ZxRQVBEw4cyCAMtGtAPfWggpSKJZoKoFF/ZINlA\nhjZB3YqkAaGygkZBpCgrwwnFrD6s8/S847nnjvlK7x8O5561h7XfOnuvtfY+jxYtWtTHcfi7CVeL\nCixFv94eRG+x1y7Scy7exeZdpG+PZTEG9fYgepPsjB6IF3BgE3VMwudY18Q+/9dcjVki4BzUxH4X\nYUgT+9ttaKahj8JDTeorTX9MwCEFdV78F/Q2lWYa+inFbmgCXsJrWIF5GFmhzwuwXIzz7IJ6pYKy\nduHOauUwMd4HcL/4+4Zl6jyMvtV01ixDj8XcgvJj8CYOSJ4H4D38UoX++7EBbQV1SmXkx+MTtefk\n+2M1rkjJbsYX2DcluwiXVdNhswz9GA4vKF8iXkaaoxP9C8u06RBB9U/8JYy9QfyxWUqZ5yMSnV34\nUO2GvktMgvRs7cBWXJOS7Y1nq+mwWkMPLCgbWYWyDViFoRn5Wvxapk0bJoox3i5e1FgMz6lbKtDd\npXZDf4NXc+Qr8HZGNkO4xe3Us2FpxzOYU1BnJu6r0M9K4d/6Z+RbsF+ZNlswIvm9GN8l108VdDXK\nQBF4V+WU/YhjM7J5mJoWpA19OR5Nfs/BdTmd9hVG/AFXyt+EdOBgEbCKOAGjhcG7GSGM/3FBu1Ox\nXgSzwViAjXiygr5GGJ3c8/YCG4Ud0vFiXTLGSoG9Ih3YhBtzymbjjDr7nYNtOKmgznK8Low8F+Pw\ninA5aUoFfXSpzXWclNSfnVO2ICnLZh+duLP7od6zjt+F+7gWfVLyAeKU7p06+hwrVtHdWFamziCM\nxwe4SfjCr0RM+boOndWyLbnnvZx9kvveGfn3YoW209ih0iM4FOekZNNFtlErbSJ4Po5bC+qdLMY8\nBk+I5TkMR6rv5VbLmoKy7hizPqfsKUyhMUN/hvdxffLcJjYQeZG5iD6YL9zBzAp1T03un4o4AZOT\nPpbWqLcWfhazeXBOWX/8Id/Q9FzxdR+2XyLy2bGYJgJqrdyJ2zKyK8vUXYbfJMsxYb5IB7NLt1Sg\ns0vt6d1ysSvMskr51TRfxnX0qXCV42WR3tyAi5XfaJTjKvGi7sjIT86p2y78//MiEHczWWzhtwmX\n0gwOs/NHiiUih0/boxOjxIlnlk6Rdm7KKauLW4SxptfY7kwxE5/OXAvxXE79s8QsPC8lG53Ipomt\n8ahUWalA98KkXXtO2RlJ2aKMfLhwEVNSsgfxpZ5b8G7uzYxnOxNFFJ+Ft+zwh5UYIjYNtX6mWqu8\nq8rOcCK12qznZmakCFSviC12mlLmeSjeENv1bj1rxLJPu7xxiXylnRkvZvYDIrV8Sb4xB4nAvhMD\n9NzpXSqmfMMJdy9SarB9Xs5cLTPExN1Ot48eI/LSzuT5dTFzJjWg7P9O0clgEXuJWPJRVkgcjJxo\nR8rUvRy+rVPZf4GtDbQ9RaSQ9XChOIepigUqHwr91yk6XSyirzjvLsq2iqj64H8q7mlAUYsqON+O\n471+mvuRdo8mvZs6TXzfWyKykNPFrF6964e1+zJG7NWz+ewe/U8vLVq0aNGiRYsm8g9t9gZJzKYP\nXwAAAABJRU5ErkJggg==\n",
+       "prompt_number": 17,
+       "text": [
+        "",
+        "  ___        ",
+        "\u2572\u2571 2 \u22c5\u210f\u22c5\u27581,0\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "      2      "
+       ]
+      }
+     ],
+     "prompt_number": 17
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Rewriting states and applying operators between bases can also be done symbolically. In this case, the result is given in terms of Wigner-D matrix elements (see the next section for more information on the `Rotation` operator)."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jz = JzKet(j, m)",
+      "jz.rewrite(\"Jx\")"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\sum_{mi=- j}^{j} d^{j}_{mi,m}\\left(\\frac{3}{2} \\pi\\right) {\\left|j,mi\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAALYAAABCCAYAAAD68ywLAAAABHNCSVQICAgIfAhkiAAACjdJREFU\neJztnX2UFlUdxz+7y/Kyygq7WiKVuKsskqxBlFEIu4itlGJ6cH0BJVvIMA4GZOjxnN6OL70g2uZL\nCmimWRYlpZVHrB4tLcKkE2l6ICWPIRb2ImkvENsf3xlnntmZ55lnnzszz+7ezzl7nmfuzHPvnZnf\nvff3cu9dsFgGIDUpltUNHAv8IsUyLZbEORIYnnUlLBaLpd9SlUIZncAwYAawOIXyLJbEOQHoAKqB\n3RnXxWIxxhjnczLw0ywrYhlcVCec/4vOZzvwSMJlWSyvk7Rgu7QBD6dUlsWSCjXAn4ERWVfEMnhI\no8eeDGwH/pVCWRYLkJxg1wLrgJHAecDXEirHYgklqZD6aGAZEvC9wA0JlWOxWCwWi8VisVgslgrm\naaAnwb8vpncrFovHOXhC+CpaQFCMGjQfeyQwFpgEnARcAtwOvOTL869AnfFaWywxWIcniL+l/Mji\nEOA0FHrvAS4qMz+LpU/UAU/hCfctBvNejhqLxZIJk1Co3BXusw3mfSVSVSyWTFiCJ9j/AJoM5Tsc\nWGAorzh0AytSLC+Ki5BaZppW4N0J5Dug2YAn3FuAodlWp09UwmLjy5GdkRRfAqYkmP+AYxSwE0+4\nr8+0Nv2Tk4E1vuMZwPnAIuAuYLaBMuqATcgzZYnJNGAfnnAn2fOYpBMJ0NoM6zAceBw4yJe2B1jo\nfD8LeA0zAnkaUrssJXA5nmC/DLw52+oUpVIWG18KXBZIOw5P0OehTsNUT7uZwrbQdwyVM2CoBh7C\nE+6fk+5uU2GsAZ5H9WkPnKuExcY1wLPAYQWuuRu4wmCZHwFWFzifi5HHDaTrkm0EdgAf96V1k4yh\nHcrh5EcRr06r4AIsBf5DdBBpBfCZ9KqTRwfwYMS5KehFrsVsJLYRLbSOWmiSi5HHeuDLpioUg7HA\nVmSLuJyJWRdzUTqAA0iwDwQqkwXfRKNHFN8HZqVUlyDdwKoi13wY+DVwsMFynyDa/ZczWE6S1KDR\nLFW+gNdr7wYOTbsCPv4EXBVxLuvFxtuQB8TPu9Cod5RzPAE9x3kGy72RaPUmZ7CcpFkOvDOYmORi\n3iuAXznfnwX+mWBZhWgGjiB6+4csFxuPQBPIngqk7weeBHY5x03IePyNwbJ/z8Dwaa8HuoKJSSre\n+1DLbwDmAv9OsCw/s1D0bifyr29DgvKo75pa4GbU2rNcbNyEdP89gfTHgduQbXAAmA6cioynIPXA\nrcDpRAeYeoCZwM98aS8Ax5RY31bgQmR07wY+VuT605H//XjkumxArssepAatBn6E3kMj8AYU3LsQ\nyQ/AROCjKIB2F1Ir/byC1tWORSNz4swH/kLpD68cutAQ/ibn+C3I/xvck7sRCfoy9FCz4r14u2X1\nhSpgI/ApZNfcggI6s4H7gfc536fTe3RuRy7ZMHIhaUegwFs18FYknJMK1G0oXqBuC7JxVuJthLoK\nqYDXAuOctBokpK7/vta5pxrUiKK8MM1oblHizEDzRt6TRmEOx6NWfm4gfQ/wuRTrUQpnAc+U8fsL\ngDm+42/juVfvK/LbKWgkCyMXknYdGgFBI3AP0FIg/5ORTVCFGtCGwPkVTvlvD6T/HfiE870TNViQ\nGznYW/u5jYTn8I9HPXVnkoWEcD9aoFDrS5uIXsCc0F9kz/lI7TDBKOBe53sd8Msi1x+Nnk1tyLlc\nSNoE3/fVqLctxBhkQ7Q65ZwYOP8N4LFAWpNz7fud4yNRQ21CKlkH0bThm8Nv2ng8FPghWtr1LcN5\nF2IUcAqaB7HPl94G/I/Crr4s2Y/2DjfBfDyVawK670K4XqCoXjvI077vbRTfi/FFZJDPcj43B863\n0bsBnYJsMTfvP6L7WISCbJuKlPn6fu8mBXsY0vc2IVdfmhyNWnZQl25H/tq9mJtOa5JXkfEXJM66\n0CCL8aKnYyjuXj0E2R9heRX73duIv8loO3ov//WlHYsCebnAtWcADyAPmttbD0HG5HrUa0e9x4X4\nnACmBLsK+CrSq5caynMonhFRjFecz+d9aSOQJ8B9AZeUUZdW5B4zzW4kKEGqYvz5mYEE4QnnuB4Z\nzoWm4R5C3+bHTEcClwukt4SUV+3ULXhtOxpZ/Z6qBif9687xKtRbdyBvye1IJsLkqxmNEK/5CzbB\nVejGzqb4EBiX5ahHi8N2ZDGPc45rgZvQKLIDPZiXyqjLM8jDYJqdaGJTuerISjRSus9+FxKyQlNd\nD3PKL5U2ZJA/6UtrR6rKnYFrJyM1MRdIb0eeEv/7HYcazIPAO3z5t6B3+wJwMRLwIEuQ+9YoH0I9\n5ZhiF5bAAtSblLJgYTzwA2S9dyM34wfR8LwW9QiVyC7C3WYnoMb9aSS0weikn53IdehSj/TTuQV+\ncw3587/95Ar8bgu9Z/9NRA6D5wLpc4Hf0fs95ui9WLsGeXW+gu7Z7XTd4NoawldUuX58o5yEbug4\nA3lVoZd3L9L7ktjIsgEJy0Y0f7wL+UevR/cyH/gs3gyyahQcWEdI2LaPeQbZQG+V62DyXZSdaJgd\nW/wWY/MA0SH6XER6PTI2l0Wcz2Ii2XLUCRjDbaVxV3ZUoZZ7EBoGW1D0aRGat/AH8o2jqSYr67AI\nqSnb8Vp/HYr+TXOOJ+KFuM9AasydyOdsIs8gXcgw8tOKDKVm57gePRNTLtQhyDUapt9DvmDPw/NX\nL0DqzlHBHzikHS+oxtPJjfBGNOwktRPUNpOV9eFu1uMPvU4j3+d7ARoS3evrkX4XNUmq1DyDNCJV\nzj+9oQr1Qq6R6Eb6JkfkUSpzgO8VOO+61SY55V6JGsEOonvlE9FGSmkSOW21r3NFPol6pHKiZoW4\nMaF896Je+Ce+tNkoquVyHgrjjgb+hgyTjah3qCXfT97XPP28jOyAOXjRwh7y/b6XIR1za5H7i8tC\nChtbZzqfzwE/RurWHchJEGa8DUHPYKWh+sWljcrYWaAiuIN8nfZh9IBAgrcHCbD7kh5DVvpSvCjd\nLCetr3kGOYboFTxdKC5g6p/NNtO/pqVaYvIongenCum+rtU+AvWai/H2I7wZ9dr+zXvuBr5bRp5h\nXENvY+5UvCmZw/HcmeVwDwNjuqolIeIGj+JSixqL20BmIqE+3Pn7AJ4x2lfOpfhUU8sgpgb14qYZ\njXzu45HuHjSqw8LvcWlFtpElBkmFmuOS1bZk52DWp2ypMIYR7dNMg0rYlsxisVjSwXUhNSBjaCbw\neRQpG4ms8PuQ8dKCZtGtRj7dJShgcCveol03r0sp7J7ajxz9QZ9wXDrRaDEDeRssllCSCDUnRaVs\nS2apYNzI4z1IUOvQSmDQGsKteJP3p+JNJXwI9cjtaDOXcrmYwgsBtjh1BIWfN6PRIkvD1VLBuIJt\nMtTciGaylaKK3FRCnd1V3e3AIyX8zjJIMRFqTpMstyWz9CNMhJrTIuttySyWRJhK/no5iyWPJPfu\nM00tWskykmy3JbP0A7LelL0URqMlSbXI2E1i6ZjFYrFYLBaLxWKxWCyWwcL/AdTvRdeK61V4AAAA\nAElFTkSuQmCC\n",
+       "prompt_number": 18,
+       "text": [
+        "",
+        "   j                     ",
+        "  ____                   ",
+        "  \u2572                      ",
+        "   \u2572      j  \u239b3\u22c5\u03c0\u239e       ",
+        "    \u2572   d    \u239c\u2500\u2500\u2500\u239f\u22c5\u2758j,mi\u27e9",
+        "    \u2571    mi,m\u239d 2 \u23a0       ",
+        "   \u2571                     ",
+        "  \u2571                      ",
+        "  \u203e\u203e\u203e\u203e                   ",
+        "mi = -j                  "
+       ]
+      }
+     ],
+     "prompt_number": 18
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "## Rotation Operator",
+      "",
+      "Arbitrary rotations of spin states, written in terms of Euler angles, can be modeled using the rotation operator. These methods are utilized to go between spin bases, as seen in the section above."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Define an arbitrary rotation operator. The given angles are Euler angles in the `z-y-z` convention."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "a, b, g = symbols('alpha beta gamma')",
+      "Rotation(a, b, g)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$Rotation(\\alpha,\\beta,\\gamma)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAI0AAAAZCAYAAAAMqa3wAAAABHNCSVQICAgIfAhkiAAABq1JREFU\naIHt2nmMX1UVB/DPtJ1CIcCIbVUolKWlpQIVqiUSWzrEthANxA0Fte5iBEoR0+AatWhIS1EBBaQF\nIi51i4lFRHGNCFGrEjeIG1CRUqzaiGIBpf5x7svv9c59M7+Z+TEl4ff95807595zzr3v3LPc39BF\nF108KTBhdxvQAfQ2McaPpRVPEbwU83HH7jZklHgf/os/tzvh02LRO/EwbsHN+AF+jCtxTMfN7Bye\njj/gnWOs90R8fAz1HYxV+EjS+2VM7ZDsXtyEOcOZNEM4zSUZfbww8FEsGoExh+N+TB/B3HblHIhf\nYPEodQwH++In2GuM9C3Au7FHjXYVvthBHdOxySCpKscbhNMsKfCOTLyvjsCQFdiBPUcw94mQ0ylc\nLGwaC8zEygL9KtzZYV3X4y3DGbwDkwq8k4XTXDcCI74i0txo0Sk5ncDe+LtIi2OB1RiX0XrwO6zv\nsK55ItW3hT/huw28G7Eds0dgxFaRh0eLTsnpBE7Hz8dI12y8vEBfJorWyR3WNw7/wHEVoak1nIZD\nsS6jT8GH8QyRU+/K+LNxAf4t8uBkEbIXinT3NFGo9YvCeiM+kck4CWfh3qTvO0nGc/HKIeTMwdki\nF38GGwpra7JxS+KfhhdiLl6H/fGKxHuBKDpvymQuxm0FXbnedyS9e2E/LMeDid8jovdQeBnWpr+v\nFR3OPPHNjsO2Ieb34BycLyLj53BukkP4xJrEh8dxK5Ya4mC8Oi1gHT6Ai/A94cmlGofY7C3i41Y4\nXxRSVSg9C48opzx4k4gg09L7ISJFfjMbV5LTi6tFob4CvxyBjRPxsUT/qdisC8RGw4XYXJC7KdnU\nhNNwn3DECqvSvOrao92uqx5d1+AyUSb8S3uR9zL8BdfgBuFk9WbnTHHI61irfAB3wafwH7tWzZNE\nDVGqzo9O49+Y0ecJ53t+et8gPkQJc/EYzsjo2/DejFaSc7o4DfBtAxfZjo2LRejvwd9EC1vHu0Sk\nyLFNRMESKr3LMnrVTCwR3d77G+bXsa+IViVciQeGmL8QX8A+NdpUkTGmpPerC/PeI65aBsVd+GGB\nfrZY6IyMfrOIQnm660/jqw19QKS3Em4UxWTdUauNPTEbW5IzXZzaw0RIXZrx27HxWeJwHJNoC7Kx\nG5TT0GMFfXW9mw28SN0n6VgpHOaAhvl1vMiuUbKO1UneYLfRFypH+TPwZnGFUnL+t6mVInkFTtQr\ns5Q35+D0rBdbk8Vp+ZpWXqwwPz3vxrOT7FLH0yc6slvEB6iwSNwH1b28Sc69+J9Y/OYka7g2bhFR\n4aT0rOvtTTZuLNi/U3kvK70bk211PJSec8Vdy/2F+TmO1VxXHCXWna+vjovFunJ8Q9RDJxsYXYm1\n9dRfclT57PYCrz89H6zRDk8CNxXGL8MfRX3QLxZUOWMfDkp/zxAnMde5KM3dISJIZUOTnAmiUF4v\nok01p10b6+u8XThshVNEevi8qH2m1XjbRcGcYzC9FY7Wfhc4Q6wrxzNF8f7ZNuXk2C6i7MMGOjex\ntu3VS8lpqlRQcpqj0nNreh6kVa0/lI1dItLLcq1Qf4co2OA8rVPxz/SsF5mThNPcVhtvCDlLRY6+\nTnzYcxK9cvKhbCT2ZCG+n41dJpqBe/ASccFW4W5lp2nSS6zvcRH9dmS8WQZeWu4n0lMp/ZwrUvbq\nNuQ0YR6+1MDbX6wRZafpFxuztcCrJu4UkeFDifYtu1bch4nqfLlWezo+yYXniTBZtbm/F93OIem9\nF1eIBd8jwnzlnIPJmZXk3Ie3a10+tmsjkQL6DHSaI8QHnihOdZ1/q/JvNCW9cDwuxa9EATpOq5bo\nF/XDDdmcBaJbukgtVYjO7LV4sVo0GEROE+7UfJs8Bz/LiVNFDfBr4RCPippheTbuWFEgXy86rCMT\nvU98oPW4XPT+x2dz5+JHon1baaDDHoGv46OiLZyJ14uPc41WHTWYnAOS3ZfiNZn8dmyEU8U+TMzo\nZ4rc/0mttFdhMX5TkFXXu0589EtE1Bqf9G8SHcsJafwc/FXtZCesEofplNoarhWt+hQD0SSnhEM1\nt/wTRKR8ThtyuhgG9hAt+oEdlPnB7H1Nh+SUsAJvbeCdgN/WCaX01MXw8YhIp+cNNXAYqP963adc\nFw1XThOWKtewxOXn2gZeF6PE3qJGKRXEw8UCvKr2fqqoo0Yrp4RxokbsKfBmiX/36P6z3hOI+eLX\n99FE8AmiJqt/xFXCKUcrp4SpypFkT1HnzizwuugwluhsmtpdWKV18dlFF1100UUXT3b8HxCniSyD\npypeAAAAAElFTkSuQmCC\n",
+       "prompt_number": 19,
+       "text": [
+        "\u211b (\u03b1,\u03b2,\u03b3)"
+       ]
+      }
+     ],
+     "prompt_number": 19
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Find the Wigner-D matrix elements of the rotation operator as given by $\\langle j, m'|\\mathcal{R}(\\alpha, \\beta, \\gamma)|j,m\\rangle$:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "mp = symbols('mp')",
+      "r = Rotation.D(j, m, mp, a, b, g); r"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$D^{j}_{m,mp}\\left(\\alpha,\\beta,\\gamma\\right)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAHEAAAAgCAYAAAAlrJeCAAAABHNCSVQICAgIfAhkiAAABW1JREFU\naIHt2nmIVXUUwPHPOKNlZZqlWFZWltqmWYlJOqWJFEVClu31R5tERRsRFYWttpsk7XtJe2CQ7WG0\nQSsWFYoRLZbtZthCZX+c+5g7b+59y8ybN0XvC8N7757f75zfvb/lLHdo8J+nuQ425mF7vF4HWw26\niWFYt6cH0aDBv5qmbtQ9E+ugFSd0o53/PXmT+AhGYSf8IvzZ34msP/rhLszFXxn9x2MAnsMKDKnd\nkDvFMLGY7quDrS3Fom3G+hiKk/FNF/U242xchbWVdtolaXxphmwMluKxnL6bJp9j8VLFw+weBuB+\n9K6DrUk4T5xABW7GwzXS3yp7PnI5VUziPjnyPRP5USV0nInZ1RjtBm7GrnWwsx3OybH/UQ3tzMPE\nShs/ij+wXok2S5XeaQsxpVKD3cBIvFAnW1ehV9G1JvGM7qihnW1UcbqtVD63ewU/5MiahR/oW6nB\nbmA+jq2DnVE4OOP6Mfgcm9TY3mLh7kqyvTgqryzT7kOsyZHtjlerGlrtWY7hObJRuBXX4xY8iMEp\neTWR+/nacuE7E71vi40wtEzfJuG6PsEq3ISWlLwlGWOay3Fx4Ufx9i/Qmny+XMJ4H2yLL1PXeuN2\nEb0egXtLDr97GSaCmuUZsul4XuzUM3ASluEpbVWsuVXYWhe/Jd+/T74vEdHprDJ9b8C54thfiEMw\nJyWfiSeK+ryJCeUGtUCkDv1LtNlb7NbbUtc2FrvvNPFwepJJsgOKnfGrOOrSFE6faWL3XFihnQ1F\nAJfFTfi6RN9WPCQWfYHB+BiDkt+3ZPSbiC/KDewLvFumzTxx05PLKeshZuCNjOtP4zMd68b9xP2c\nIyZwswrt7C9cRxaFnK4lR36u7JjhcBwvNsqhGfIdpdxY1nE6XKzEUkdpPxydtOnpPDCPZm0FigKb\niJ32pI5FitXJ5xiR562o0M5YvJMj20ksmD9z5HPEqVDMIpEW7SuyhGLa6cuaxII/XJxjmEhom3Fc\niTY9zbfYqOjacBFIvFWi3864pAo72+q4WIgq1VQ8UIWuAj+Jgska2RWxgcpUgO4WR8CgHPkMUYrb\ntxODqycjdLzRrcW9ZaUDfcUDy6uIjNTxbUx/sViyjsvLxC4cUEZHHp8JP53F/ngtr2MTPhWpQzGD\ncK2I4vascCA9SRO+0tG3PSP8eZrxIgh5TwQSvbT3RZPF5D9S1O8A4UPnaJ+STBeTMLoCHXk8U0J2\ngVT0XFhBW4j8ZnMRmq9KlBQKrX2Sv4eFzyjODQeKpHovkVvuIPzmVsL/DBGr8GdckzGozvRfX6QG\nk8TpsYHwI0+JcH0tnk3kD6VsHSryrtvxo3j4S3CKCFDmiwm9J9VnJb7TMYAZL/K1qYm+Ncm4VmM3\nsUvL6chiaxGh5jFR+Ry+ao4XOeIybbXU9fC7tnxmB9k7vLP9jxYT/ToOSrVZkmozReUrvxKK68BX\n10BHFqfjxBzZIBF11/w1Yj8R0aYT/wnah/jHyH+gnenfX/iXtE+aVqSDOFHyqjbVkk7CB6g8l8zT\nkcciEWBlMRsHpi/kVWyqZbV42/Fi6tpUURUpcIQoIhRHjJ3tvwp7iIkuhNzTxDvMNLPEkdfVlTtJ\n+MwCrUoEFxXqyKKXCGg+yJCNEAtyYZV2K+Ye7YvNi0WySjz478SReVZybQrGdaE/XCTqiMQxs1T4\n0WImCP/ZWVpwnfYL4RLh/7qiI4vBIoAsphk3al/dqTmvansZ3CT8V5/kd18RoJygLWxegMe70J8I\nYK7AkaIGOaY2t9KgGrrymqi3yAPr8W+X/2pq5RM7Q7PSL5zLMQ7vy65oNKgThyn/ri2P0SII+gD7\n1WxEDRo0aNCgQYMGDXqWfwBhwxNCydgNhwAAAABJRU5ErkJggg==\n",
+       "prompt_number": 20,
+       "text": [
+        "",
+        "  j         ",
+        "D    (\u03b1,\u03b2,\u03b3)",
+        " m,mp       "
+       ]
+      }
+     ],
+     "prompt_number": 20
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Numerical matrix elements can be evaluated using the `.doit()` method:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "r = Rotation.D(1, 1, 0, pi, pi/2, 0); r"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$D^{1}_{1,0}\\left(\\pi,\\frac{1}{2} \\pi,0\\right)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAGoAAAAhCAYAAAAxvj44AAAABHNCSVQICAgIfAhkiAAABTdJREFU\naIHt2lnMHXMYx/FPqWrR1lJLUcvbUoJWrYmtSmyxJJagtHphDxIubI3YoqkIIi6IEGs0pUhExNLE\ndsGFfU8qqK3SIrTUUuvFMydnet7/zDk9Z87bSs43OZn3P8/M/3lm/tvv/8xLjx4Vcy4Gr+4gusgE\n7FdkXKuLjofjMWxTQV1XYhH+qqCuPFXG2Cnv4RTsMZBOz8K1+BfbdVjXYbi1wzpSVBljVayH+aID\nDSidvoSheAPrVxJNmjWpoeBY3N54smjOn4edsCt+wWv4J7ONFC1+H27D31VHmuMiMTUt76KPgWI8\nZuML0TlG4VIsbrjuKVyFPnzWSsW7ZxXekLBNxAI83qSOTnrr2iLQTdu8v1UGYkSNxNeYljs3Ex9g\nSOL683Bzq5VfJB7i0AL7/pl9WoGdzl7CEXi+zXtXhYFoqFlYYuUZbGP8ifMT12+Cb7Uo9h7DCrHA\nFbEAL5bYO3kJt+PyNu9dFQaioRaIKa2R9/FCwT1vycn1shY7EG/i15JrlohpsBtMEWvj/53h2AFf\nJmyLsGfBfa+Jd4DihtoZm+GVJkFsLJRZI6fjzuzvG3Fhk3oaGZbF8FGBfQTm4jcxIlK/f0RnK6LV\nGDv1tW12XJawLc/qXzdh+1huT1Wk+g7KjmUNNQTjhIpp5OHsl5p/W6EPf+D7hG0QHsTbQnmegNex\nEBfjDjFl/45XS3y0EmMVvkZkxxUJW03Nbqi/+vtajMRS5gjZPbLkmoNFb7q7WWVtcLhYTFOcgaNy\n5XlCIZJeBzqhCl/7ivd0bcI2N7NtmbBNwQ+1QtmIeg9LSwI4ITvOaRJoO4yUniqIHl5jQ/EMfwvR\nU7WUr8LXdyW22kb+54RtqdxASa1RY7GV8mlvOKZn15SpvnYZKh18I6erC46ddHfz3a6vxWLUbJSw\nrY+fpJ91mRi965BuqNr69HKJ85lZJWe2GOyq8pf0AtvI2eodZbTY7bdCkSjI/6rytVyscWMStnF4\np+C+YdmxMBF9vwi0aGifKNJKRyZsrWaj9xL7pBlijRvXYD9OWqTkOQg/qq8ZU4UyS6nQ8QXnW6VT\nX9fjGyFOaowV7/mCAp8HKEmdDRKKJiWLN8Ut+ERkJRppNRs9RDTC6Ky8t1BSefYRU0IZT+LRXHly\n5vuYhuumZOfnNamvm75Gi+eZnjt3Gz6UTiHB0fi0VqiJiTG4F1sL3b8Uz6lPAUOy36Nig5vaBN+T\nHa8pcFxjshiRNVX3htgzbY/Ps3MLxehcV8j0FBNxTq78tthUNk7ni4XM36tJXGV06utboZJnib3R\ncLEHPVJathMDY2EHMTel2Yg6W3+h8pVI7+dZhN2qC8t1DeV9cYmYBearr83d8NUOs+W+w62OT9uj\n9B+Rv+v/sexV0fver8hvXpxsgONxRVY+Gc+KDeY3Fftql0nqs1RXP8UXsdTKiyrx4hqzEM+orpcf\naGV11YfLxIJONNIw6bW3U1/tMFis0/M7D6eYZlPfIXg3Vx4sRtT4hus2EetAp6N+sJhC8p1jkJj6\naud2EXFP6oKvdjhKCJiukmqoQ4S6Ix5mkbqEnyJS+ike0H/t6gYPCUW7pjBXevtTCbVs9L+Zo3w2\neg6eyJUPxV1iH3UfdiyocwfdyXzkORM36XwUVMVYvLQ6A5jR5n2zcVKVgeQ4Rj27MtSa8U8uj0j8\ny9hAiYm1lX8pLuNqnKa+Qa6KydgcT2MLMdVU7WNVmSryiUVLQdc5VSR622UjkWqqajvRJxKhjfm9\nEWU3dZkJolP26NGjR48ePXpUz3+qbzDxAdRwIAAAAABJRU5ErkJggg==\n",
+       "prompt_number": 21,
+       "text": [
+        "",
+        " 1  \u239b  \u03c0  \u239e",
+        "D   \u239c\u03c0,\u2500,0\u239f",
+        " 1,0\u239d  2  \u23a0"
+       ]
+      }
+     ],
+     "prompt_number": 21
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "r.doit()"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} \\sqrt{2}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAACwAAAAkCAYAAADy19hsAAAABHNCSVQICAgIfAhkiAAAAjFJREFU\nWIXt2DloVFEUxvFfNBDRJEggIgYkagpBMERFQcGtSiF2phEEURBEEMFSQU0KURQURNwaNwTFQohb\nCjGlpakEK0khIgTcUHAr7sSM4+QtM5cZIvOHKd6575zzvfvuOe/eocH/wxr8ivCrGQ8xp9ogsyII\nyUI/nuNrjfJVzQO0xwhUOsNtuIfFMYIX2ICX+BAxJtiLY8LC7o4Y9y46I8b7h5iCe3EuUqxpiSn4\nuuTltRb38QhjuIauvEliCe7B1YTxVXiK+YXrVoziXd78sQRfwvKE8WHhoYrpK+S/kydRVsFtCWNd\nuJ3i/wlvsKDEPoH3GfL/IU3wXNzChYR7zmB1Sp4xfMOSEvtbfE7xBTtx0dQrOVDmnmYcwSA+Kv8x\n6BAKKY15WFhiW1TI/yyL4Dx04AsOlhk7ji0Vxj2JH1hfoX8iV/AKTUW2VqGYKqFHWNdDVeqall7h\n9fUX2Q5jewWxWvACZyPoSmTU1Iy24Im/ZzwLTUJHOZHHqdJN8w78FF7nPqFw8zKEoyW2XRXEyUQz\nxnEeI5id03+38jN7OSlhNXwXWuEg9gsVnpWtOI3HuFmiKdNRaB0OCVvMEWzMmLgTr+U//kyYfgkO\npjm3Cj1wkgGhz+beOdWKlULxLCtctwtPOlA3RSk0CUtisiWtEAT31U1RTm4IG5gZwR6ckv8DUBe2\nCYIJVd9dPynlKW70m4Tz17DQNTYLszxee1npLBX2t6X9MMqfHw0aNJjB/AanNX6i8nBFNgAAAABJ\nRU5ErkJggg==\n",
+       "prompt_number": 22,
+       "text": [
+        "",
+        "  ___",
+        "\u2572\u2571 2 ",
+        "\u2500\u2500\u2500\u2500\u2500",
+        "  2  "
+       ]
+      }
+     ],
+     "prompt_number": 22
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "The Wigner small-d matrix elements give rotations when $\\alpha=\\gamma=0$. These matrix elements can be found in the same manner as above:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "r = Rotation.d(j, m, mp, b); r"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$d^{j}_{m,mp}\\left(\\beta\\right)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAEgAAAAgCAYAAACxSj5wAAAABHNCSVQICAgIfAhkiAAABANJREFU\naIHt2VuMXVMYwPHfdAyqelGXuFcopS41qqlJOqWjKUIIRdzaeaCpB5fgoYkHQqtoXULcHkpJkLjE\nQ4mEuqSNqpCIlJB0PEgpqkNQIY1WPXx7Z/bZs8/kzDmnc4ac/8s+6/v2t/ZaK99lrXVoMiCtdern\nUZyA9XXq73/HBOzd6EE0aQAtNdpfjr0wEwtqH85/k4ewCbswKyOfjnMwAj82YFxFTMC8AfRHYjGW\n4hG8ioNELl6kBoe5AdsxMiM7JHm24/1qO64j4/A82sroO3G78PiUp/By8nsmluSNRlT48Rn4BH9l\nZD8kz1lYW2E/u5P7hLf/XaA7Fh3Cc7bndCcnz7UYI+Y6aDbjnjK6VeiqptM6MgnvDqBfpr8ztGAj\nns7IjlZFNBwj8s+cAl0rflIaeo3gcXSX0R2PSwvk8/EtDsjJ1+DUtLFHgWEXFuIbEdefYwfWFbzb\njh6lodcIzhXhVcRcPJj8fkbMZSoOx2nozb2/Dpfgs6LOrsWWxJjI+n8q3SG3YQVGJ4NaWPk8dgsT\n8PMA+sWZ38vFrn8l/sjpUi7G6qKOpogEd2VO3isSYMr+YpVvwi0DDGyo6MRXZXRjcGsZ3ZOKtycz\n8F2RwRv4RWmZnCzyz3mVjLRBzMVHZXTn4/QyumVibvk0c6KIGvRl9nEijlcrLZNnYSc+GMyIh5hW\n/FNG145Py+hOEhvgHTl5STtdoInJh/Kn8VnJB7aJEjgc2Yr9yugmKl68gzEbLxToxovKjL4F+j15\nbsq8OBJnirIHN1c23iFns8iLecaKECuq1DeK/LOsQDce36eNdIF6sAFHJe02PCG25V+L88qWQQ99\naOgRaeDQnLxTVK0lSs9YF4nz2gX4taC/dnycNtLV3YXL8DCOEOG2VHhPt0h0i8TqdgvPul8k8dFi\nYV8XrjtJeOQDBR+vxn6U2Ep04lnsK/Yvb4rd8y68nehfynxrOu4WobRCJN5RIl1MFaFZxIxkbFVx\nnfCuHlyTyPYR55uOpD0ZX9bRfp5YxPViA5e+syHzThdeyX1reSUTynGgqIhVn+pH4zAR9ykdSsvs\nfP0HW4v9WHFbuVWfx8/J9QFviWMRUZXvGGAe5bgLF2YFlZ7mU7bhbLyXkc3GO5n2VXhRcWWpxv43\nnCEWMS3Bc/Tf7V4vQqpFXF18WMmEMhwnFnjVIO368ZzSg+EasV8iJtUrwui2RNaFaTXYw50iJxJh\nsFFfQcnSIfLVYpFvKqUVjwkPr5l1+i7LWkS+2DNpjxTJdoH4l4PwhtdqsCeS8b24WtwETqnHRIYT\n5a4iKqFNbNzq9RfVoBhsDqqGVlGpqmWauHLZWZ/hDD+uEJWrGk4RCf0Lw/vA3KRJkyZNGsG/dQzH\nyXC4f9IAAAAASUVORK5CYII=\n",
+       "prompt_number": 23,
+       "text": [
+        "",
+        "  j     ",
+        "d    (\u03b2)",
+        " m,mp   "
+       ]
+      }
+     ],
+     "prompt_number": 23
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "r = Rotation.d(1, 1, 0, pi/2); r"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$d^{1}_{1,0}\\left(\\frac{1}{2} \\pi\\right)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAEMAAAAhCAYAAACC9hYiAAAABHNCSVQICAgIfAhkiAAAA/NJREFU\naIHt2VuMXVMYwPHf6JSOS6e0SmnGaBXRqFTQxq1mKOoWQlBNTJNqeKiIEOEFL1KESjyQphJBwjRK\nCEI04hLRF5EgvBChYpDUQ1ul0ro8fHvP7O6z957Tc/ZJPMw/2cnZa639rW9/a32XtQ8T/K+5Fd0d\nkLsAZ1cNOKDNCQ7DJvS1KSflPoxgbwfm+AI34PQ25RRyCx7Ev+ivQd5SrOvwHAdjszBwR6hD0Sn4\nFId0cI6UK/FkUUczbrIOWxOFBmpSKM/twhV2dUh+ljewCHNaFbAGf6GnoK/dVZuE73BkxZg6dwbc\nhsdafXgYH5f0tavoJXh3nDF1G2M6fpbzjGazyXn4sEZlslyO9zoku4zfhDEWZxubMcZcHKNzxhjA\nlg7JrmKLJmLgIDbiEawX8WKPxki/Ak+LLTycjNtfekRNMaOkv5k5piZ9fybjiq5/xO7OsgavVCm3\nCr9idnLfhz90buXmay+DdOE1PCBiz3pRm1yEN3FZ8vtcjV5wtSjECjlN7IDlufZteLgNhau4WPhu\nq9yMZZn7l0V2IlJoFQMidoySPQM8hJ0i36ecIiJvp+JFL3a08fzzmd/TxPv8LSrNqlQN25P5R0m3\nzjRcKkrVPZn+CxLhZWm1XaaIBaiDFcbc+WShdxU7xC6anDakxjgh6cjHhgF8JhRuuWKrYC8OKukr\nC4bZK8tqvJ/8nqU8KKekBeTooTA1RrpVt+YGLzHmIndk+po9SZ4hzgFD2CCMnmWXyAZFdDVxpZyP\n48TCSWT2iZ1XRq9IDqNGTWPGNyKy9if3k/GUWLVvMVNkGSJaz8a1uLtisgNF6losguTXeAlnZsb8\nIue3LXKXcPHUNUaEIdKsUkRvMn8hJ+ItPCFWcx5Wiq23AUfkxo9XIi/FV5n7LvyO4zNtM5MXKHOV\nZvleZKaUqfgBV1U8s1KNle94xliNj3JtP4ojdJYRnFoiYxHuFN80Ngt3qIu1ct9POvF5LWWG8Mks\nuzV+WPlEfH36Mtd+KK7Bvcn99XhH7NifatBvIZ7JNrT72a+K7fYNcsQLbsu1va14xefgHnE2IgzR\ng3Nq0K0bZ4ndVgvjuckgPs8psBsn5cZNF1ksv0u7hJukBp2fzLmwNXX3YRler0HOKEXGGDSWLbpF\nPEjTb1qzFPGcxliS5wU8vt9aFjMsisy2qTpJvohXM/cXisPTEJ4VGauIecYKpiJW4VGNbtcKc/FB\nDXKaYqjF59biuoL2K4QxiNqhv0X5KRuV/F1QdwCdJA5JrXA/bhKldMoSHCXqn6PF1p7V+GjTLBdH\njjJ3rZUbcWwbzx8uCrxukU12ajyPlJXv47FAGHyCCSaYYIK6+Q/y58unxR4TVgAAAABJRU5ErkJg\ngg==\n",
+       "prompt_number": 24,
+       "text": [
+        "",
+        " 1  \u239b\u03c0\u239e",
+        "d   \u239c\u2500\u239f",
+        " 1,0\u239d2\u23a0"
+       ]
+      }
+     ],
+     "prompt_number": 24
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "r.doit()"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$- \\frac{1}{2} \\sqrt{2}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAADsAAAAkCAYAAAA3pUL9AAAABHNCSVQICAgIfAhkiAAAAl5JREFU\naIHt2E+IjVEYx/HPMEXMTJoayZQGs1BiGoqi/FtNkZ3ZKCWKpKQsEWYWIoqSDDb+pchiapBZyCyt\nZFbKSrOQ1JR/URiLM5Prdu9773vvufcy7rfu4j7nPb/397zvOc95z6HO9KSh1gZSMFFrA9XkIWaX\nIzAjkpFK04Nn+FprI9VgEC3lisR8s824j0URNWE9XuJDZN2S2YsTQhHpiKx9D22RNaMQO9kuXIio\nF5XYyd6QPC3W4AEeYRTX0R7x/onETLYT1xLaV+EJ5k3+b8II3kX0kEjMZK9gWUL7kPBAMume9HA3\nkodE0iTbnNDWjjsF+n/CG8zPio/jfZEeyqKYZOfgNi4lXHMOqwvojOIbFmfF3+Jzgb5lsROX/R5C\nB/Nc14ij6MNHuT8UWoWiU4i5WJAVWzjp4WkR/atGK77gUI62k9hcou5p/MC6EvtXjKt45c+dV5NQ\neEqhU5jH/WX6qghdwpDryYgdwfYStGbhOc4nXZT5VFdgQPF73BfYX4KxTEaEubtVMDwoJJ9m79og\nFLzXOF6mn4JMFPHLxw78FIbgPqHQpaUfx7Jiu0rQqTiNGMNFDGNmyv67cSpHfCDfzWrJd2HJ6sMB\noZIWyxacxWPcyog3qvARzlocFrZ5w9iQom+bMN/SHrmMyz9t+lJqFU2TsL5N0SusoVXbfVSTlUKR\nWTr5v0V4ur01c1RBGoRhPLVkLReS7a6ZoypyU/iQn/bswRn/1uF7SWwTkiVU1o7aWclN2kU8HxuF\ns6IhoTpvEt7uWCT9v4Ylwvdt9lpX9qF2nTp16vw3/AJm7nQeoH85UwAAAABJRU5ErkJggg==\n",
+       "prompt_number": 25,
+       "text": [
+        "",
+        "   ___",
+        "-\u2572\u2571 2 ",
+        "\u2500\u2500\u2500\u2500\u2500\u2500",
+        "  2   "
+       ]
+      }
+     ],
+     "prompt_number": 25
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "You can also directly create a Wigner-D matrix element:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "WignerD(j, m, mp, a, b, g)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$D^{j}_{m,mp}\\left(\\alpha,\\beta,\\gamma\\right)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAHEAAAAgCAYAAAAlrJeCAAAABHNCSVQICAgIfAhkiAAABW1JREFU\naIHt2nmIVXUUwPHPOKNlZZqlWFZWltqmWYlJOqWJFEVClu31R5tERRsRFYWttpsk7XtJe2CQ7WG0\nQSsWFYoRLZbtZthCZX+c+5g7b+59y8ybN0XvC8N7757f75zfvb/lLHdo8J+nuQ425mF7vF4HWw26\niWFYt6cH0aDBv5qmbtQ9E+ugFSd0o53/PXmT+AhGYSf8IvzZ34msP/rhLszFXxn9x2MAnsMKDKnd\nkDvFMLGY7quDrS3Fom3G+hiKk/FNF/U242xchbWVdtolaXxphmwMluKxnL6bJp9j8VLFw+weBuB+\n9K6DrUk4T5xABW7GwzXS3yp7PnI5VUziPjnyPRP5USV0nInZ1RjtBm7GrnWwsx3OybH/UQ3tzMPE\nShs/ij+wXok2S5XeaQsxpVKD3cBIvFAnW1ehV9G1JvGM7qihnW1UcbqtVD63ewU/5MiahR/oW6nB\nbmA+jq2DnVE4OOP6Mfgcm9TY3mLh7kqyvTgqryzT7kOsyZHtjlerGlrtWY7hObJRuBXX4xY8iMEp\neTWR+/nacuE7E71vi40wtEzfJuG6PsEq3ISWlLwlGWOay3Fx4Ufx9i/Qmny+XMJ4H2yLL1PXeuN2\nEb0egXtLDr97GSaCmuUZsul4XuzUM3ASluEpbVWsuVXYWhe/Jd+/T74vEdHprDJ9b8C54thfiEMw\nJyWfiSeK+ryJCeUGtUCkDv1LtNlb7NbbUtc2FrvvNPFwepJJsgOKnfGrOOrSFE6faWL3XFihnQ1F\nAJfFTfi6RN9WPCQWfYHB+BiDkt+3ZPSbiC/KDewLvFumzTxx05PLKeshZuCNjOtP4zMd68b9xP2c\nIyZwswrt7C9cRxaFnK4lR36u7JjhcBwvNsqhGfIdpdxY1nE6XKzEUkdpPxydtOnpPDCPZm0FigKb\niJ32pI5FitXJ5xiR562o0M5YvJMj20ksmD9z5HPEqVDMIpEW7SuyhGLa6cuaxII/XJxjmEhom3Fc\niTY9zbfYqOjacBFIvFWi3864pAo72+q4WIgq1VQ8UIWuAj+Jgska2RWxgcpUgO4WR8CgHPkMUYrb\ntxODqycjdLzRrcW9ZaUDfcUDy6uIjNTxbUx/sViyjsvLxC4cUEZHHp8JP53F/ngtr2MTPhWpQzGD\ncK2I4vascCA9SRO+0tG3PSP8eZrxIgh5TwQSvbT3RZPF5D9S1O8A4UPnaJ+STBeTMLoCHXk8U0J2\ngVT0XFhBW4j8ZnMRmq9KlBQKrX2Sv4eFzyjODQeKpHovkVvuIPzmVsL/DBGr8GdckzGozvRfX6QG\nk8TpsYHwI0+JcH0tnk3kD6VsHSryrtvxo3j4S3CKCFDmiwm9J9VnJb7TMYAZL/K1qYm+Ncm4VmM3\nsUvL6chiaxGh5jFR+Ry+ao4XOeIybbXU9fC7tnxmB9k7vLP9jxYT/ToOSrVZkmozReUrvxKK68BX\n10BHFqfjxBzZIBF11/w1Yj8R0aYT/wnah/jHyH+gnenfX/iXtE+aVqSDOFHyqjbVkk7CB6g8l8zT\nkcciEWBlMRsHpi/kVWyqZbV42/Fi6tpUURUpcIQoIhRHjJ3tvwp7iIkuhNzTxDvMNLPEkdfVlTtJ\n+MwCrUoEFxXqyKKXCGg+yJCNEAtyYZV2K+Ye7YvNi0WySjz478SReVZybQrGdaE/XCTqiMQxs1T4\n0WImCP/ZWVpwnfYL4RLh/7qiI4vBIoAsphk3al/dqTmvansZ3CT8V5/kd18RoJygLWxegMe70J8I\nYK7AkaIGOaY2t9KgGrrymqi3yAPr8W+X/2pq5RM7Q7PSL5zLMQ7vy65oNKgThyn/ri2P0SII+gD7\n1WxEDRo0aNCgQYMGDXqWfwBhwxNCydgNhwAAAABJRU5ErkJggg==\n",
+       "prompt_number": 26,
+       "text": [
+        "",
+        "  j         ",
+        "D    (\u03b1,\u03b2,\u03b3)",
+        " m,mp       "
+       ]
+      }
+     ],
+     "prompt_number": 26
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "## Coupled and Uncoupled States and Operators",
+      "",
+      "States and operators can also written in terms of coupled or uncoupled angular momentum spaces."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "### Coupled States and Operators"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Define a simple coupled state of two $j=1$ spin states:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzc = JzKetCoupled(1, 0, (1, 1)); jzc"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${\\left|1,0,j_{1}=1,j_{2}=1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAI8AAAAaCAYAAACOyA9jAAAABHNCSVQICAgIfAhkiAAAA9pJREFU\naIHt2l2MHXMYx/FPdav0ZYsLlNCNVhq0TRERF96uCRIsSUmo3ggRL5GIK4oQEm1CiHjJ4WopJWlc\nCGHckV5UtBLESwiieiNkCcVx8Z9hdsyZnTlnZs9ZmW9yMmf+zzzPPL//Pjv/Z2YOLS0tLQ3xKA7P\nMxyS2X+5IMgSfNjHyddiJ7bFibyAY/qIk/B4n3nUSb9zkWUUtFCsJ8JVZYJEPcbPwm50Kya1At/g\nmtTY3diHQyvGSngWj/XpWwf9zkUew9bC7HoW4qUygaLM/il4HR28V3CCXjyAHzCWGjsKB3FjxVjD\nZtC5GDWq6NmKdbMFjApsnVlOkMen2JUzvhdvV4w1SnTM/+JJ01GsZxW2ZwezPU+dLMfJ+DrH9h3O\nbPDcLfXyldCnzmicx/KPrYVV8fanHNs0xrEYv5WItQHXYyW+x611JDgk5quWHZjE88lAk8UzHm9/\nz7FNx9sjsH+WOMdhM24X1ul9QqO5t0Iuz+GMCscT/qhRRZ/ZqEMLw9GzC1PmqHj+jLd5a+mieLuw\nRJw7cQ/+wup4LK8gi9hc8fimqEMLw9FzUOhh1wlF32jPc6DAtjTe/lwizlP4Mf5+Xhz3kwHyGibz\nXcsz2JLsNFk8+4WrzpE5tqXCJJYpno9T3y/AuwNnNjzmu5bPsSbZaXLZmsYenJBjW4MPKsZbgY3C\nbWVVnsbpFX3u0NwfdxAtDE/PanzRyxgVOHYUPwtYi8MyY1vxLRZkEujiphL+aS6K/bIPq5YLr1VO\nLPCtm47qc5EmT8vZuE3oid4UlrW5oqPcc6sHsb6XMSpwnIpPsCTHdmFs25EZXyksT9emxrbjIzNf\nT/TyT/OI0COkC3GLMNldTBT41k0/c5Emq2UZHkrZJ/ELjh8403IU6UlYhFeLgkSZ/aPxhtBdd+PP\nAbyDTanjTo3Hv8yJuVF4DL5NaLh2+u9SVuSfsBuv9LDNRfHUMRcJWS0bzLwDG4/jT9aReA/K6km4\nHNcVBYwGTOjehvzH8Qdu6WGf6ytPGapoWSAsW8mV6DRBU9W+pklelHnCXPfd1uIa/a8Qege4RJjY\nvPdko0oVLV2879++4y7h5yt7Gs6xLBPC0/Bfiw6KBjjBubi6Jv/1wkTeL9yZfKb4qjZqV55BtNyA\nh83s7YbNfQoa5YSoz+Bjwn9Kv4Kz/svwFp7Aa8K7oCJGqXgG0XKxUDyEu7WJZlKsxJjiHwn+Q9Rs\nHo0xSsXTL+cLhXNs/LkM5ww1o8ClZmmUE65sNo/a2YQnheKZws3DTadvThKetnczn/Eipzlim+Jb\n+JaWlpaWlpaW/zV/AzTy7joiuTv9AAAAAElFTkSuQmCC\n",
+       "prompt_number": 27,
+       "text": [
+        "\u27581,0,j\u2081=1,j\u2082=1\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 27
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Note that the Hilbert space of coupled states is the direct sum of the coupled spin spaces. This can be seen in the matrix representation of coupled states:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzc.hilbert_space"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\mathcal{C}^{5}\\oplus \\mathcal{C}^{3}\\oplus \\mathcal{C}^{1}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAGYAAAAZCAYAAADDq1t2AAAABHNCSVQICAgIfAhkiAAAAuNJREFU\naIHt2U+oVGUYx/GPpek1I/zbNSIvSa40rbtIEtp4ixQqlMxFlhIiim5EQQKDiYx2IRRERboxKMid\n3oR0EyhKBS5SSUI3Jl4Qysr+GdjieQfPjHPv3OMZ70zN+W7e8z685zm/mec9z3mecyj537AH/+BP\nfI3+9sppyJN4GeuxDwPtlTMi9+BzPFjUUQW9mF3U0W3kMtam41X4XfwBncZ68X9eR19RZ5WiDsaA\n+bg7Hb+AazozMFVuCsz4W3DSg024gqV4B6eKKmsx32WOV4rN9Gt7pLSeuXgLJ/ETfsbzWIO70poB\nfI872iHQ8BrhMWzHR5jcFnXBSBqrjCqVjccbGBT5uR+vp5PfVXuX9SX7wiLKb4FmGrNswLeYMpYC\n5dPYNJVNwKc4g+UZe08afxQpbAb+cCNvXyvwA/IyGo1DWIzz+Aof4BlR/XSCxoPNHNQHZjfuxM46\n+zp8I0rPSSIosATHcDqHaJiIF/GoqO6GRMAHcaLJuc00HsbTuJjsD4mNc7KDNB7KI2QAf2FOnX0G\njmBemj8rcvcOfIxZeS6Cp0QvtCTNK+I2noRX8D6mF9S4BtuwFftFoDpNI7yUfF0Xd9iWRg6P4rN8\n+nOzAm9iXMZWUZtf7xMipzU4v+s0PiKitqpVDhvQK+6weipurkjuFzspS1dprJa5y9LYLHcWYSPe\nHuXaiyKnZ9NBV2msBmZBGi8VdTgCffghx/ov1L7j6iqN1apsZhp78HdRp8MwR1Qr9SwWL/B+qbPf\ni7OZeVdq/ETkxuHews4XFU4R9g5jr2jc9T6OVzPzrtJYTWXH0/iaqL+zzMUB0a8U4ZzaUrEZy/Bl\nZt6VGifjgoj2oXTBfmwW5V8rvrnMMvqK5wG8V2oMHhYPs6v4LTnaJJqqVvEcdhm5R+gVfcDUUuPY\nslTsyifSvKK2q/5QdMntpO0axzVfcluYiNVYJBq1IfG9ZFDx50Sr+C9oLCkpKSkpyc2/Pkneg0NI\nsz0AAAAASUVORK5CYII=\n",
+       "prompt_number": 28,
+       "text": [
+        "",
+        " 5    3    1",
+        "C  \u2295 C  \u2295 C "
+       ]
+      }
+     ],
+     "prompt_number": 28
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "represent(jzc)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\left[\\begin{smallmatrix}0\\\\0\\\\1\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\end{smallmatrix}\\right]$$"
+       ],
+       "output_type": "pyout",
+       "prompt_number": 29,
+       "text": [
+        "",
+        "\u23a10\u23a4",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a21\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a30\u23a6"
+       ]
+      }
+     ],
+     "prompt_number": 29
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "We can also couple more than two spaces together. See the `JzKetCoupled` documentation for more complex coupling schemes involving more than 2 spaces."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzc = JzKetCoupled(1, 1, (S(1)/2, S(1)/2, 1)); jzc"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${\\left|1,1,j_{1}=\\frac{1}{2},j_{2}=\\frac{1}{2},j_{3}=1,j_{1,2}=1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAQMAAAAhCAYAAADdws5CAAAABHNCSVQICAgIfAhkiAAABSNJREFU\neJztnUuoHEUUhr/oFWO8uUaRaCJKjEJ8JWhQVNREowSJokGuIZBo0IggiCTqRtwoRA0+N0GRaBhQ\nLxd8LwQ1YhSCG3GjWSgI9tIXKAgufF0Xp5uZO+npruqqmq4uzgcDPdN1qs/fdbrmVFX3DCiKoozg\nC+DUtp1QFMU7dwILRu08puSz5cBkMHfSYDHwFnBW2454ICUtSjVnAtfbGGTAihCeJMI9wGPAHN0/\nTylpUepZBszYGGRoYJiQ0gWUkhalmlngtLIdZcOEOhYBXzs442oPsM9DHTGRkp4YtPiIMYhDiy11\n2g8Ad5ftsO0MLgM+B1Zb2vmyLzghrycVUtLTthZfMQbta7HFRPtBYAMlE4kThgc5H3gW+AX419JB\nH/bD7PRQR0ykpKctLb5jDLrTLjba54BPgI3AR3UVZ1SPH3t5hU1xtY+FlMbZKWmBdGKsCT3qtS9F\n5g7m0WTOQFGUbvMzkkEsG/zQdJgQA2uAuxABPwK7WvJjG3B1vr0XOIxMNNkSg56UtPgiJS1VvIoM\ng/YUH3SlM1iOzIA+iIyPjiBivrGs5wCw1tJmF/DZwPs38td9lvUM4kOPapmvxQe+4syGtrQfAh4B\nngT+G1UoI745gxeAJfn2Lbn9Kgcf2iYlPTFq6dEsRmPUYksPc+0PA5uKN12ZM3gZ+D3fXofMmn7X\nnjvOpKRHtXSXHjIkArrTGXw7sH0t3Vr7LSMlPaqlu/yK9AEnQ3fmDApOAi5GerQm7AcusbR5iH5Q\nmKRfI58KK8FFj2oJd7G6xpkNbWqfQLT+NqpAhtucwSpgYSD7m3Lbi0r2xfj0Xd25KNNzObAbeYDo\nIJKuxkATLeuAO5AHol4Hbgjm3Xx6uMWojzhrqx17mM8ZbKZmtSSjujOYzQ+2qGTfdfm+NwPZP4OM\n44a/sWJ8+s7kXAzrmUSW+Aq2AH8CZ4Rw0IImWkDS0B359u2IlsUhHBzCNUZd46zNdqzSPsw7wClV\nBTKOFroUuXXxSH6gOeRkHULWqgsuyD//wbN9wZfA2xW+x9QZ1GmBo/WsQZZ5zsnfTyGatoRw0IIm\nWkC+WU/Mt6eBvwnXGfiKMXCPs3G3o6n2QVZgMAzKcL+gHg9gPwX8AzxQYTeOzsA2/Rt1Lsr0LMjr\nL76RLkQ02Y4pTQmpZZgZ4FFL/0LioqUuzsbdjk14AriqrlCG+wW1t76Ikf00/XXe7cgtlGdX2IXu\nDJqkf4PlbfW8Bjxn76YR49KyFlnP3o9Z6jouXNrFNs5CtmMTJoCPTQpmuF1Q1wBbPdivRk76HmTG\n83vqM47QnYFt+jd4Lmz17ASexm5G34ZxagG4F/iKOH5Sz1WLTZyFbscm3Abcb1Iwo/kFNQE8T3Ph\ng/aTyKOWLwLvMXBzRAWhOwOb9G/4XNjouZn+47MLCaMptJYrgJ/of8Oel9c/7cF3F1zapcA0zsbR\njk14F+n4asmIx2lbxj2BGCL9W48E0On5azNwpedjlOFby6XAp8Dx+ftNwF/AuR6P0RZlcbYB+XGR\ngrbasY6VwCumhTO61xlsA15CGmkWwxTIkRDp30rgD/ozwsVryuMxygiVym5HbpDZjczOb/Rc/7ip\nirMZZKkO2mtHE55CMkIjMrrXGYybWNO/JqSkpW121BdpleOAD0ft7MqzCTGxHvl12Q+Q9O9Ghn4k\nokOkpKVtjiWu1ZIybgXetzHQf1QaTczpny0paYmBrbR/p2gd+9D2VRRFURRFURRFURRFURSlCf8D\nTSec3ofIo5IAAAAASUVORK5CYII=\n",
+       "prompt_number": 30,
+       "text": [
+        "\u27581,1,j\u2081=1/2,j\u2082=1/2,j\u2083=1,j\u2081,\u2082=1\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 30
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "The normal operators are assumed to be diagonal in the corresponding coupled basis:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(Jz * jzc)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\hbar {\\left|1,1,j_{1}=\\frac{1}{2},j_{2}=\\frac{1}{2},j_{3}=1,j_{1,2}=1\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAQ0AAAAhCAYAAADDC/7xAAAABHNCSVQICAgIfAhkiAAABelJREFU\neJztnXuIFVUcxz/WRrbubhmhrVLZWthLKaksqmupSC9UYhOhLSmjCCKy+iciSqiUrOwPKWJLbliL\n0MMMispoqz+kiKCHfxRIDfRH9A6iKHtsf/zOcGfHuXfmzDlnZu54PnDZef3OPd85vznzO6+74PF4\nPAWxBzim7Ex4PB7rXAdMaXfyEIOEZwF9BvYHA/3Ai8DxZWfEAnXS4unMccBSFwkHwBwXCdeEG4H7\ngQm6/z7VSYsnnUFgTMdgGnAucHLKdQHegbJQpwetTlo8ndkBzEw6EW+erATeBz7E3Dl6gc9KtAfY\naiGNKlEnPVXQYsPHoBpadEnTvg24IelEvNLYBbwH/I5UHnk5R6UzvyT7kCNUOnWhTnrK1mLLx6B8\nLbpk0b4bWEJCh2hPZPtopMnRi1QmP6njAXBGxsycCjwC/AD8m9HGpn2cdRbSqBJ10lOWFts+Bt1T\nLjraJ4C3geXAm+0uOhxYpC6+DzhJfQbbXB/QuQnTVGnlxdS+KtSpH6BOWqA+PpaHJunaZyB9G5OI\nRhp/IcOoAK8C+2zkzOPxdC3fIxHJIPBteDDep9EAfkM6SKYD25H+jWeLyaMVFgBbkBry8RLzcQ3w\npNreBNyaM50q6KmTFlvUSUsnniHW/OqJXdBAZnoOAJuBjWp7RRG5s8AspMf3DqT9thcR/blmOtuA\nhZo2twPvRvafV59bNNOJYkOP1zJZiw1s+ZkOZWkfB+4GHgL+i58cQEKRe5HKol8d/xT4ICGxgOr1\naWwBjlLbK5T9PIM8lE2d9FRRS5N8PlpFLbo0ya79LuDycCfaPLlQ7Q8Bo0gzZSYyLDNuI5cF8BTw\nq9puIL3EX5aXHWPqpMdr6V6awPXhTrTSaKi/nwBfqe1lyDjt60XkzAJfRLYvprvGzpOokx6vpXv5\nEakrpsPkPo0G8DMSZYQsQ+Zr7Ckqd5Y4EjgTqSHzMAqcpWlzJy3nyRL2tV1FmICJHq/F3UNt6mc6\nlKm9B9H6S/RgL7CfVg95yDfICApIsyVKgFmfxjxgqiP7K5Rt0qS0Kq7WTLsXSXoWAeuRhWS7aUWK\nZZNHSwO4FlkY9xzysiqCJmY+asPPyirHJtn7NFYhnaqTWKoSuCxy7AR17GZgBFkuGyWgc6WxQ9n3\nJpy7RJ17wZH9ZqSdGX8DVnG1ZpZ7EdfThwx9hqwG/gBmu8igBnm0gIS/a9X21YiWftxj6qOmflZm\nOXbSHudlZMb4JDYAfyJz6ENmIzdkFzKsFCfgwBsyA5lyuldlaEKlMY6M9Yecpo5/bdk+5CPgpTbn\noFqVRpoWOFDPAmT4a67aH0A0rXaRQQ3yaAF5U09T28PA37irNGz5GJj7WdHlmFV7lDlYbH4FmD94\nGxzYDwD/ALd1sCui0tANO9vdiyQ9U1T64RvudESTbps3Ky61xBkD7tHMn0tMtKT5WdHlmIcHgQts\nJRZg/uBtSr8kk/0wrXHyEWS+yYkd7FxXGnnCzuj1unq2A4/qZzMTRWlZiMwHGCVbyFwUJuWi62cu\nyzEPPcBbNhMMMHvwLgLWWLCfjxTOA0gP7z7SIxjXlYZu2Bm9F7p61gEPozeCoUORWgBuAj6mGj8l\naapFx89cl2MeriL/koFEAvI/eD3AY+S/QVH7PmQJ7xPAK0QmoXTAdaWhE3bG74WOnitprQuYihtN\nrrWcB3xH6419ikp/2ELeTTApl5CsflZEOeZhJ1JBWiOgOuJ0Kboj1EXYuRhxtGPVZxVwvuXvSMK2\nlrOBd5CfZgCZrrwf+VmGbifJz5YgP4ITUlY5pjEEPG070YDuqzTC1ZoTyJCT1dCrDS7CziFkmv9E\n7DNg8TuScBVCjyATkdYjoxHLLadfNJ38bAwZwoTyyjELG5EI0yoB3VdpFE1Vw8481ElL2axNv6RU\nDgPeaHfS5P+eeDqzGFnw9xoSdl5K+19Bqzp10lI2h1Kt0aEkViLzs6zj/8Nae6ocdupSJy1VYA3l\nz9xNYyu+fD0ej8fj8Xg8Ho/H4/F4PB7Pwcz/kmrHd1bpdrwAAAAASUVORK5CYII=\n",
+       "prompt_number": 31,
+       "text": [
+        "\u210f\u22c5\u27581,1,j\u2081=1/2,j\u2082=1/2,j\u2083=1,j\u2081,\u2082=1\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 31
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "### Uncoupled States and Operators"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Uncoupled states are defined as tensor products of states:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzu = TensorProduct(JzKet(1, 1), JzKet(S(1)/2, -S(1)/2)); jzu"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAHQAAAAgCAYAAADDhVzGAAAABHNCSVQICAgIfAhkiAAABCtJREFU\naIHt2lmIHEUYwPHfxtWEJYl4EI2iWRPEI0QIoiGeaFSCBqMRokRUTES8Hgz44pNRFGM8UVEUo8GL\ngBoVDHiBK6KggooK+mCw34IXokJAYV0fvll2pjPd090zmZ115w/D9FTVd1R/U1VfVTd9+vxP+ASH\nTrYTJbkaA3kNZnTJkV7kCMxuUj4Hr+Lo7rpTyPZRWNE9d6YWCYZTZddhE8aa1O1ritiej5fLKH2t\nLZemFonsGzcZAS1qezsOy6pMT7mHZLQbwtel3Cou/ygG29A93XgW67Mqi6yhp+BDLKnoQCv5EVxW\nUfd05D2cKyM5ygvoCdiJmzFawXBR+TexuoL+6coY3scFzSrzprrvcFHtehuWlTRcVH4Un+NUfFZC\n/0ysxcmik2P4G2/g05K+TjWeE0vVO+mKXlm7tuJ+xQN6PtbhGbwogkmk/euwAbfjt8662TP8LAbC\nfOyur+iVfeif+AtHFmh7KbbgLnxsIphqOp4Ss8N2HFzSjyvxZO16M24pKd8OZW1vFX/cXEYyyrdp\nvHFlKSK/CHe3aHO4mG6GRIeOb9LmRrGnGzZxg5qRmLytSScYEAlSw6DslREKu8TpzVBOm5twH/aI\nwG3E0rr62/CHmIqTWrsF+8DXXmBMrKEr6wt7KaDwPK7KqR/G97Xrf0SA1+MM3IEfNJ6k7MR5Hfey\nd9iGa+sLeiUpqifv8Pnf1O9R3IovsENkuPXsVj47r8oSPK3F4XkdX+GGNm3+KgblQfid3gvoNWLf\nmkV6RtkPj4gEYgUu0RjU+fipoO0iOUJesL7B8oK2OmV7EAeqBZPOTbnHYVabOhaJEbUnp80uLK5d\nH4AnxFHYR+Jg+1ixbRnnQpE4FGGgwKeeTvS5qu1xVuGtPMUjGeXbxb+oWcJyTq3ulRy9efLjPCAe\nD+UxT/EsdwEey9GVqJ7lFulzN9ihxdZspO56nsiivjVxEvMLPhB7pnFOrJX/mNJVVB7mivWnCBfj\nSxyT02Yj3hVrSxaJ6gHN6nM3GRZJUS4jbRi4sw3ZjcolLyvE1mS5xuloDq6v1bV6GyGxd0CX1XzZ\nJKbqs1roaKfPacravgent1I60oZDmyvKzcBLFeRmilcyHsZDte8tOK2gfKIxoLM19mGtWM/zTq+q\n9jlNWduDYgZqSdEEIs2ZuKKi7BpcXlG2HRKNAT1JbIsW1X7PFcvE2gz5dvqcpqztNQoeS86p4Myg\nGCFF919pJusBd6IxoANi2hvvx2JxU5fam3b7nKaMbXhdbFf61JHIT4pewINd8aSc7YUiR+iTIpEd\n0A1iPe7UCCxDK9v36t7p15Qi0Tygq0w8lpqV0WZf0cr2/ng7T0GvHc5PNmeLN+p2ikd1K8XxYa/Y\nXi1e2enThPSb8wvFA/Kx1GduF3wpavvxLvnTp0+fPn36TDv+AxMh2obP427zAAAAAElFTkSuQmCC\n",
+       "prompt_number": 32,
+       "text": [
+        "\u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 32
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Vector representation of tensor product states gives the vector in the direct product space:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "represent(jzu)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\left[\\begin{smallmatrix}0\\\\1\\\\0\\\\0\\\\0\\\\0\\end{smallmatrix}\\right]$$"
+       ],
+       "output_type": "pyout",
+       "prompt_number": 33,
+       "text": [
+        "",
+        "\u23a10\u23a4",
+        "\u23a2 \u23a5",
+        "\u23a21\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a20\u23a5",
+        "\u23a2 \u23a5",
+        "\u23a30\u23a6"
+       ]
+      }
+     ],
+     "prompt_number": 33
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Uncoupled operators are also defined as tensor products:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzopu = TensorProduct(Jz, 1); jzopu"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${J_z}\\otimes {1}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAADQAAAAYCAYAAAC1Ft6mAAAABHNCSVQICAgIfAhkiAAAAkRJREFU\nWIXt1k+IjVEYx/HPnZGpMRaGJkppFmIi0YTxp8mfbNCEBeXPCiOahYmyUSzGQlFqGgv/ZrKQlWaL\nQilCEYmVspOGBaKYZsbieSe3y33v7b5TE+a7ed/znud9nt855znPOfxnLMFtPMIwRvAc7eMpCrV4\nkcVBDh/xdEzkZGMpnojJ/Y1JZTpZiHpcHCNRldCEMxjAUDGjcge0JnnezaYJ1GA7msUsj+A7+kVq\nF+M1NiXvfVieRcQNDGJKFifYgF6sEmk8ylQcwAVML8NPnyIpVw45fMDDSh0kbMUzNKbYdIoiVF/C\nV58iA6oqQ8giMWtZ0m0m2sTKHMf8P9gcxBfsx6lKA5UzoLXJ816lQXAIp/FNCO8UR8IoR/EJl/A2\nsZuTIV4q/fgh2/65WtCuRjdW4wS2FPSvw94Uf30qTLkqtIq6/7WEbRrDBe0hHEZP0u4v6H+HhkoC\n5Q+oRWz+I3nfFmMa7lTivEgcYoXOoUMUncIVmoX3WQPtFpv/c963PWI2r1XiPI83WJC8T8Z5XMF9\nnMRc7Myz3yiqXSY6cCyvvVnsnY6sjkX69Io72GXFq9w+UQy6S/i7LvZQbZpRNbrE9aJH5HVrin2X\nuIasFGW5pYSINuWdQ7dEmhfSgJt46dcNY0AcJ7tKxC5JI7ahTlSjZWX+t16U5hV+vym0J30zsgjL\nlTZJZXQPFlaxNGqwQ5xDI4mGQZERDzLqyUROpCnMFkL/WprF6T9P5PbZ8ZWTjSZRperwGK9E2Z1g\nggn+AX4CKbZnF2vuuR4AAAAASUVORK5CYII=\n",
+       "prompt_number": 34,
+       "text": [
+        "",
+        "J \u2a02 1",
+        " z   "
+       ]
+      }
+     ],
+     "prompt_number": 34
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(jzopu * jzu)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\hbar {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAH4AAAAgCAYAAADUp8wPAAAABHNCSVQICAgIfAhkiAAABOJJREFU\naIHt22uMXVMUwPHfUFrVVpSUauiYEtqGaIKmHhXpEEQUHxDPaMU7oolIfGorRD0rCFEt9Yx4E/VO\nTIgmCBrEI1Hut8Y7WhokNT6sc9M7Z+6599xz79yZcv/JzZyz91p7rX32a+2zz9ChQ4eqrMXuw+1E\ng5yPrloC27XJkW2ZvTCuSvp4PIN92utOLtt7Y1773PlvUkJ3Ku0iLEF/lbyhJo/tyXii0YJ3xuHY\nv4bMs40Wug1Tkv2Ah6Ph89p+EntkZaan+vl4B+/XKXS3jPSx+LSGXj1q6d+FUU2U/X/jQSxoROEO\n/I7RNWT6qqQdhg9FTyxCPf3TcWbBspuhZNsc8V14U0aQVzniJ2IjrhIj72fRAT6v48B0rMEV2JLH\n44L6L4oZqUM++vEWjq8nOBqzE4XF2C/5Ta4i25dRxmrFR3we/UUi/miE0TgPd2K5mNFuEnXNQ8m2\nOeJhkljrB1G5Zv4lti7wEr5p1rMhYBVuxQc55Y/D2ViJx2ztVOOT9IW4Tsxu/0V+ELPoZGyozEgH\nd3OxSQRYu+JR/IGHh97HXGwU/k3JIXsabsH1eM/AmWQT7seXYkRMbNCPc3Bfcr0MVzao3wyN2l4l\nOnhNPsJrotFXYoZYW39NyfVl6K82tFM9TMMNdWT2xEMiVlmFA6vIXCb2xN22PshqlAzfdN4KykHe\ngEFeeTMBh4jRca1YT78Qlf66LS7mY71YksbWkLkcN2OzaOBFmFWRfw1+E527lMhNHQJfRwL9eB0n\nVCZWNvxRyX0PHhDT4R44CG+3x8fcPCICtiy68VVy/bfoCAtEHReL+KXyzdYa9Lbcy5HDalxYmVAZ\n3M1N/q7Dt8l1r5gqXhlqzwpQ6xDin9T9FlyNj/EcXkjlb5A/ym+Wg7BCnUOUCtbh0iZt/iQG9a6S\nZTvd8L+I0V6mV0S8a5s03GouEPv+LNJB6/ZiO3elOLw41cDGn4zvc9rOE8PUatTPMCenrVbZHoVd\nVMRq5Qc0FofiKbHelenFq2LE9BTxNMUBGNNkGdPECN1cQ2Y9ZibXO+Je8QrzXXHAsb/YzpU5SQRA\neejK8aukFXUuarvMyXi5WsY80ZtOrEibmqRdgnPFUV+ZvgwDTyY61QKvY5O8pzN06+mXuS3lSzUm\nyR/VT8XdNcoqKR7V56lzO3hOxpZ1Kf7EThVpU/Cj2M5NT8n3VVxPElHj56KS/Yne22LPWWZGkv5d\nqqy8+sTOY0X1ug3iFHyCfWvILMIbYu3LoqR4w2fVuZ10i+CuJfQ1obu0Cd1FGgvC5okt2xwDp8Hx\nuDjJq/d1Tcnghp+d+LJELBFz1aaZOqdp1PaNOLJVxvua0F1WUG87PF5Ab7T4FKn8nn65eKN3RE79\nkoENP87AOpwh4o1abxOL1jlNo7ZHiRmtZeQNhNIcjbMK6o6UY9mDxXZxWnI/QSxPZ2ToN1PnNI3a\nPl2LXyePL6AzSoy4vPvXNMP1IUbJwIbvEtNtuR4zxcOfZTDN1jlNI7bhebGN61CAktrB3aO4vS2e\nNGa7R8QwHQpSkt3wC0W80KoR3Qj1bDfyzUGHKpRUb/iTbT3uHJMhM1TUs72DOGXNpPNdfTGOEQdY\na8QR8Amqf6k0XLbni/cvHZog/Z80PeLksj/1m9AGX/LavqdN/nTo0KFDhw4dRhj/AllqCrlzA7Px\nAAAAAElFTkSuQmCC\n",
+       "prompt_number": 35,
+       "text": [
+        "\u210f\u22c5\u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 35
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Coupled operators which are diagonalized by uncoupled states (e.g. $J_z$ and uncoupled $J_z$ eigenstates) can also be applied:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "qapply(Jz * jzu)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} \\hbar {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAIcAAAAgCAYAAAA4/mtcAAAABHNCSVQICAgIfAhkiAAABRlJREFU\neJzt22msXVMUwPFfq7RoK0pKCX1eCdUQEkNqqEhLSsT0ATGGijmiiUh8okLMKggxlFJEzETNiRei\nCWIIYkgM95uYYwwSng/rXH3vuPfcfc69792+9v6Tm3fO2Xvttfc6e6+99t7n0aNHjxFlFTbvdiUq\ncDLGNUscn7ufgkex7UjWaC1kK0xuktYtm6bo3QbzUwo7HZdiEH1tVmxdo6axzbpl01S9M/BgmYJT\nGrIx9sIOBXkeK6N0jFNTbLNuDbgUvQ9hi0YJ+WklhSPwKt5ooXizgrSN8H4F3SnyN2FCG2Wva9yN\n01Izp/S2G/ArJhbkGWjyfE+8lempQiv5o3FsxbKrUjN2Pcc4vKRBYFrWc0zDzzhfjN7vRSf5MEF2\nNlbiXPxdUm8Z+aeEd+uRxiBexsGpmfuapE3E3lmeS7B99pvRIO9AgY7lqnuOFPnFIiZKZSJOwo1Y\nKjzjlaKtKdSMXc8B00XsMYyyc/OfYtkGT+OzkvKjxTJcizcT8h6E43EX7re6003Jni/CxcJLrq18\nI7zxDHxVfzh0WjkBt2XXV+G8JgXNwy8iINwUK/Ab7u1sfdviZ1HHrVvkOwrX4DK8brg3+gW342Mx\nqqZVqEeqTTtNFb3LxEBoi7fxvOgYd2FnMc//mMs3UFDGciM7rcAsXF6QviXuEbHTMuzUIM/ZYs+g\nz2pjN6Jm7O8N1QPT/xxG2YB0KnYTo+wiMbd/JAzzaUeq2Dk+F1PgRk3Sz8HV+F10gsXYfUj6hfhJ\nDIBalm/mCNV1TWAQL2Bh/UHZzrFfJtOPO4Xr3QK74JXO1LGj3CcCzUb04ZPs+i/RWU4TbbxExFND\ndw9XYsGI1HLNYTlOrd+UDUjnZX/fwxfZ9QLhkp5tt2YjRLODpX9y93/jAryDx/FkLv0r6auXTrAL\n7lBwMJbjPZzVps7vxODfFD/WO0er+btewXn4QXiNOgtEJL+qzYqNBKeIfZFG5L3memIpe544jDrS\n8A4yA1+X0J0SUxW9+A8wt4S+TuidgE1k8eP4IZmLfsTcvQceFvNvnQV4Toy8/tQWtGBHTGqzjFli\ntP/eJP1zzMmuN8CtYiv5NXFotYNYytY5VARsqbSy6dAX1In2VtGb5zA8U0XpfNErDxnybGb27Eyc\nKI6A6wwUlPVQJtcoWDwwS3ukonyd63L1yTNd+mplJm4uKKum+molpb2jxeOqLdktwR/YcMizrfGt\nWMrOzuUfyN1PF9Hwh8IYg5nsK2JdXmfn7PmXFeWJVdUdCW06HO9iu4I8i/GimIebUVO9czRr72jT\nJwLShuwtDHGpcJ/zmmVMZKBN+SVtyC6WHjzOF8vVuYa73Ck4I0tr9ZVXTePOUcam7bS3Hb11rsC+\njRImi520OseIubrVDmMRA23IMrw+ZRiPB0rKTBSfzNXPVZaKndN9EuVr/t85ytq0anvzVHmXE4R3\nbMiuYmk3K7ufKtz2MW1Uskzwlmd/HFdRdk05si9j03bam6fKuzxawRb7OOGK6m51Tlbg7s0EEphS\nUW6CGL2p6/s83fjYp+b/nSPVpu22N0+Vd/mEWMImsQLXV63dOkhN64C0WzZtpbdfxFVJLBLzbad6\n8rpATXHn6JZNU/Qmf7dymNXHtpOM/ZPG0aKmua26ZdMUveuLE/aGDN1CPkAcoq0Ux9kLNf7Cq0c6\n3bJpqt4jxB5VIf3ihHUw95vaocqu7TT6j7du2bSM3ltGoT49evTo0aNHjx6F/AvANSXYBnfGVAAA\nAABJRU5ErkJggg==\n",
+       "prompt_number": 36,
+       "text": [
+        "",
+        "\u210f\u22c5\u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "         2         "
+       ]
+      }
+     ],
+     "prompt_number": 36
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Rewriting states works as before:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzu.rewrite(\"Jx\")"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$- \\frac{1}{4} \\sqrt{2} {{\\left|1,-1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }} - \\frac{1}{4} \\sqrt{2} {{\\left|1,-1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,0\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,0\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} - \\frac{1}{4} \\sqrt{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }} - \\frac{1}{4} \\sqrt{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAA8EAAAAkCAYAAACpKTisAAAABHNCSVQICAgIfAhkiAAADd9JREFU\neJztnWusJEUZhp+FhSULu8SVOwJHlovKTRRFEEVYEQWCioJGIgQwCngF0Wg0ClkJaLiJqJEojKC4\nBkSMouB1jAkRjVc08kNixx+iYEAlEEQRf9ScnJk+fa+qrqrp90lOzpnpqa7vdD9TX3d1dTUIIYQQ\nQgghhBBCCCGEEEIIIYQQoXjKwY8QKXAI8l0IIcQwUM4TKSFXRe98G9gqdBBC9IBcF0IIMRSU80RK\nyNc5YbPQATTklcCPgcdDBzIg7gK2Cx1EB04DVoQOwgK53j+hXE/d1XlC7Z2wRe1IN5TzuqE2Kwzy\ntRtRto+pnASfC3w2dBADYxdgm9BBdGA3YEPoICyQ6/0TyvXUXZ0n1N4JW9SOdEM5rxtqs8IgX7sR\nZfvo8iR4DXALsLvDdQK8GPgt8C/H6xXd8LWfXdV9HXBmBHF0Qa7Hh82+rivbh6tlhPwep0bMbV4o\nh+RPc2y3VQwOKOelQ8ztFchXMYvPYyzoKUe+BbgQc7P3guN13wxs73idop6M5fvS536uo03dm4Ad\nI4ijLXI9DBnF+9JmXzct69PVMkJ+j2Mlw70DtsTqkPwpJsN9zozBAeW8OMnQMZptHG2Rr93JcOtr\nLL7N4Fq6g4BPOlzf1xyua97JKN+XIQ9+mtT9CuCDEcTRBteug3xvSkb1vrTZ13Vl+3C1jLrYhuRP\nhj8HbInVoSbbRA4ZbP2JwQHlvLjI0DGabRxt0PmIHRl+fLXyLfZ7gt8LXF6x/IXArcB3gHuALwC7\nVnz+6RXLVmOGOYSiqv6rgZU9xpI63wOOJq3JF1y7DvH6LteXiNlVH/7si/H4SuAK4AaW99AOzQFb\n5JAcitmBMlLLecpb7pCvcrVPSn2L+SR4L+AJ4M8ly58HfAwz1vtVwGHA3sCvaN+j8ALMbG8HdAnU\nAXX1j4HX9RZN+jwFfB/T+5MCfboOYX2X67Ok5ip092db4AeYA4XzgPOBeyfvbTn1uTHDcsAWOSSH\nUnMgtZynvOUW+VqOXHVPb765HH7wOeBZFctvx4g5zcGTGDaVlBnnXj97sp4R8FP6f4B10/o3B27q\nKaZFMtIdagOwA+Ue9BlHE3y4DnH5nqrr4H+ojgtXD6R9725dbOPca1t/LgYeYDbOdcB/gHOm3ps3\nB2zpwyEf/oAcWsT3cGhQzgP3vqWat2Jvr0C+jnOv59lVCDscGkp8C3lJfA3wSMmyXSfL760ofyTw\nQ+AQTFIE0+vyD+DlDWP4A3D85O8RcGjDcq5oWv+TwM8xwy1+1nDdq4BTgOdjJHkK+DdwG3B3t3CT\n4gHMdtsZuD9wLDG4DmF99+k6pO27C1fPx0wSkbkJqRBbf07G7Iv/Tr33EMb9k1l67MQQHbDF1qE+\n/IG4HUrdH+W85dj6pmM0f8jXWWJ2FdL3tRffmpyRrwa+DHy64jOXYzZ0FfdgdsAzc+//FXi0pMy4\nYn0j+r8S3Kb+tZjeqCYcA1yPmc59egz8GuBtwLVU348A6fcygrkH4MMB4wjpOsTre13dbVwHe98z\nwl4JBntXRw3rmabtleB8fW38WTP5fNF34U7gn7n35skBW/pwaNSwjmm6XAnO1xmLQ7HnzL7aEdsY\n5jnn1ZWfJ99s0DHaEqHOR+rK951fIfyVYPDo26mYHtjFS//vKPncykkAGzG9LmsLPrMOc79PHVsD\nO+Xe22USw49Kyowr1jci7pNggMuonxjitZgeqPyXcZrzMDeKr6v4TMZysZruZx90qXsF5v90ee97\nKq5DvL43qbuJ6+DG94ziRtTG97ZlbV0d0TwRNI1tXFNfG3/2n3z+koJlt06Wrcq9n7oDtvTp0Aj3\n/kAaDsWcM/tuR2ximPec16R86r7ZoGO0WUKejzQp32d+Bfe+xuJbJ9YBjwHvLlh2EXBUx/Veirnc\nfXjJ8nFF2RHxnwSvx9x8X8ZOmN6a1ZiZ6YruYTgH83ytBZaGjhWRMR/PgLwAOC5g/aFch3h9b1J3\nnevgzveMOFy3cXWE+/9hXFNfG38On3z+ooJlN06W5Wf4HaIDtnR1aISf/39cU2doh+YxZyrnFTPC\n/4nFEH2zZai+jivKjgjvKsynrzO+hTobfggzBOFcZi+tb4MZU1/V01fGXpiegEuAu2wDjJT7ML1L\nq0uWnwt8HPOFPgfTO3Pw1PILMEPGPo8R8jFgD0+xxsIIOCNg/XK9G3Wuw/z5PiKsqz55cvK7KDFv\nMfm9ee79ITpgywg5NM0Qc+YI5bxQDNE3W0bI1xAMNb+OmPIt5CXha4B9gGOn3jubduPUF1mFme3s\nWvzdXxALNwBvLlm2wNLN+09gBD4TOAL4KPBHZmeFu512k0ykyN8xnj8tYAxyvRtVrsP8+R6Dq754\nsGLZ1pPfRROTDM0BW+TQcoaWM2NwYMg5b2i+2SJfwzHE/Drj2/Ts0AdgdtqKgkJF/BojSVd+A/wE\neCdwB0acY6h+GHURKzCX6+8APmIRTxf63maLlNX3v9zrJ4H3AL/E3NdwW275/fQ7Q3CI7bUS82zJ\nhwPGIde7U1Vf7L63pcjVPF8EDip4f3fMbI9PFCw7C/iFdXR2/A1zBa/oQGdrzCyaZbNzpupALO3d\nNKn6A34citmfrijnhSdV32Jos0LEMGRfU82vXZnxbfok+B7MA57b0mTcetlG/hTwVczQgQ2YXom2\n4+A3YqYG3zj13mmTdfmm6zaz4XTg7SXL8lf2NweuwgzL2AC8hllpd8YcWDTBZj8vEsKxE4BvRRCH\nXG9PlesQr+9dyxa5muf0kvdHNHvEjYvvcRcexUyusVvBsr0wBzJFpOoA2H1nfDmUqj/gx6GY/XHp\ngHJef6TqG8RxjBai3YRh+ppqfnXmm4vh0Csa/JTxdeAvwLuA19P+wdlnYHoqNubeP6LlepqwL7CV\nh/W2YT2mp+WxkuX3AftN/t4S+AxwHaaH60Jgb+BNU58/DjNTWhPa7meX28vGMZcN0FBch/C+17kO\n8fie31ZdPekjWdo43IYif27H9BJP17Eec1JzS8E6UnbAllgd6ssf6MehWPyBONsR5bx2pOybDTpG\nS+98JOX8GotvTvgQRpy2wxmOxozt/lLuZxPwlZIy44r1bcL0LhTdJH7UZNnNLWNsQ1X9i1xGcS/4\nIjvQfCa3PTA9X2VkwELF8ir62F5NWMBc4YiFPl2HeH134Tq48z0jvOsL2Lk6ovv/UMa4YlkXf3bG\nDFmdvgfpKuD3mASbZ2gO2LJAd4dGuPcH4ndo3nLmAsp5ZdjmPB2juWeB4fo6rlhfDK5CHL66dHWB\nHny7nHY9H9tjbq5u26vxMGbDFP3ke2IWGede7wDcCfxuquyDmNngTp363HMm7/+pZYx1NK0fzDPM\nrm2wzhNp9kyv71I9EUHGcmEPnZS9ENPb89KSsj62V9O6p7kY83BvX8TsOsTluw/XwY3vGcWNcxPn\nyrZVW19tXR3RPME0jW2ce+3Cn+diruZdiZlR8laKE/E8OGBLnw6NcO8PpOFQzDmz73akjqHlPB2j\nNUfHaGHPR2I+xoLuvrpqG8G/bxyJGQ/+Mp+VWDC2LH+RiyA6ch7NbzjfgDk4OIzZYQFrgLdOlm1X\ns46MWWG3wTz3bJFTMMMoqh627Wp7dal7JeZL6YvYXYd0fW/jOtj7nrG8cW7r3PS2alvWhasjmp3E\ntIltbBmTjT+pO2BL3w6NcO8PpONQjDkzRDtShXJeNan7ZoOO0doztiyfUn4Fe19t2kbw7xvbYsbS\nj5lf6S6t/4gXNsM8x6wNqzBj368Erpj8/gTVD5qfJmNW2AMxw0TWT16vxfQ0nVKxDlfbq0vdJ2Fu\n3vdBCq5Dmr53cR3sfM9YfgLQ1rnpbdW2rAtXr8Y82L6ONrGNLWPq6s88OGBL3w758AfScii2nBmi\nHSlDOa+aefDNBh2jtWdsWT6l/Ar2vtq0jeDXNwDeh9lIY+KVrukN20W8BHijq0BachLwhp7rzJgV\ndgWzE5Lsh5HuYIpxub3a1g1mkoNtHdWfJwXXIU3fY3Ad2jmX31ZtffXpap42sYXyZx4csCVWh9rG\nNWSHbHNmTA4o51UzD77ZoGO09gzJVbDz1bZtBM858kRg/8nfY+KVbk3HcisxPR9VM4755GpmH2fV\nBxnVw+NupPwZar63V1XdAHtihmf4IBXXIU3fY3Qdyp1rsq2qfPXpahOqYgvlzzw6YEusDtW1xXJo\nCducGcoB5bx65tE3G3SMVs+QXIXuvtq2jeA5R+6CuUS+yJh4pRPNySgX9izMMIgQJ0lN6r4EPw/s\nluvzSUZ142zje11ZX642IeT3ODYy/DlgS6wOyZ9ZMvzlzFAOKOfFS4aO0fLI13jJ8OOrlW8unhN8\nLOZm5A9MfvbBPDfqeAfrFvFxwuT3+zHDTRYiq3sLzJCIuz3UL9eHh43vdWV9ulpHyO9xasTc5oVy\nSP40x3ZbhXRAOS89Ym6vQL6KWXweY0GNby4uiV+fe302cBP2N32L+DgS2BHzeIqdgBdhZt/LIqr7\n1cA3PMUg14eFje9Nyvp0tYqQ3+PUiL3NC+GQ/GmO7bYK7YByXlrE3l6BfBVL+D7Ggh5z5DMwl6Qf\nB77J0hm6SJO7mJ3yfE/gEZY/A21tD7G0qfuaHmKS6/NF3nWw871p2T5czRPyexwzrh2wJVaH5E85\nrnNmTA4o58WHjtHKka/x4dLX2HwTQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBC\nCCGEEEIIIYQQwo7/A1+H0IgzacuTAAAAAElFTkSuQmCC\n",
+       "prompt_number": 37,
+       "text": [
+        "",
+        "    ___                        ___                                            ",
+        "  \u2572\u2571 2 \u22c5\u27581,-1\u27e9\u2a02 \u27581/2,-1/2\u27e9   \u2572\u2571 2 \u22c5\u27581,-1\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,0\u27e9\u2a02 \u27581/2,-1/2\u27e9   \u27581,",
+        "- \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500",
+        "             4                          4                      2              ",
+        "",
+        "                  ___                       ___                 ",
+        "0\u27e9\u2a02 \u27581/2,1/2\u27e9   \u2572\u2571 2 \u22c5\u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9   \u2572\u2571 2 \u22c5\u27581,1\u27e9\u2a02 \u27581/2,1/2\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "    2                      4                        4           "
+       ]
+      }
+     ],
+     "prompt_number": 37
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "### Coulping and Uncoupling States"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "The `couple` method will couple an uncoupled state:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzu = TensorProduct(JzKet(1, 1), JzKet(S(1)/2, -S(1)/2))",
+      "couple(jzu)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{3} \\sqrt{6} {\\left|\\frac{1}{2},\\frac{1}{2},j_{1}=1,j_{2}=\\frac{1}{2}\\right\\rangle } + \\frac{1}{3} \\sqrt{3} {\\left|\\frac{3}{2},\\frac{1}{2},j_{1}=1,j_{2}=\\frac{1}{2}\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAAkCAYAAABi4faKAAAABHNCSVQICAgIfAhkiAAACSZJREFU\neJztnWusHVUVx3+33Kal1iKkPGuxVBRUKFoxVhvLRY1poKl8wKJRXhYIMT6hMVH8IJGo8QUigWCF\nDqBY5OELDIJfKAmWBKLBB0/N+IgGMI2BWFEe1w9rxjvnnJk9e8/eM7PvOeuX3PR2zqx91jpr/8/M\n3nvNvqAoiqIoiqIoihITxwOzAX4UZVJQzSgTwc+AxX07oSjzCNWM0hsLOnqfjcA9wHOB2rsPWB6o\nLWU8OAOY6tuJgKhmlLYxaqari8NHgKsCtncYsDRge8r8ZyXwrr6dCIhqRmkbo2aGLw4vB24BDg/o\nwHrgIeCZgG1W4eN/G7ErYbDJzbXAh7txZ4D5rJkNwOnAOcB3gXc3aEN1Ey91ubHWzDnA55EFrFUB\nHMu5GTgwYHsAKaM++vjfVuyKPy652Qkc3LI/Rea7Zv4BnJn9/j5gL/KFYovqJl5sc+OkmZCJPg74\nZqC2iqRU++jjv3byeLHJzXuAz7TvygjzVTPHAC/Lfj8VeB63i0OO6iZe6nLjpJmQib6e+uHma4Eb\ngWuAK4GvU99BU+K/OFyBTA30zRL8/YghFpvcTAF30/3CdNeaWQfsQPSyA7gJuaiYSDH7eCNwkZWH\no4SKP4Z+BmE0A3HEU5ebSs1Mt+QQwJHAf4E/G855PXAn8H6kmuIQ4JfAs8iQaD6zL1Jt0idvQb5A\njvVsJ4ZYbJgFfoHcDf28Z1+aYKOZNwGfQ+7080qmq4B7kTWEXzu+51rgncC/gEsdbUMTQz8LpRmI\nI546nDQT6i7gauBow+vTwKPAJwvHVgJPA5+oaTsl/pFDn7wOuANIgN2Mx4NQtrk5CJlHbcoa3G+a\nutIMyBf4LHBa4dim7NjlBrsUs4/nAQ/SrKJpHHQzjpoBu9yUasanlNU09bMie/0RwzlnAEcgycj5\nC7IQ18ac6yTxMHAycBbmHIwjTwEvAoc2tL8AeGU4dwbw1QzAr5Aqpj2FY/kX+l4HX9YBTyIaBNiF\njCI2OrQxTqhmhjTT5OKwBPge8GXDORcgawcmPgA8AfyzgQ+KYuIaYGvfThQIpRmQNYn9kHninLWI\nuL/v4NMLwO+Av2X/X40sSLtOSynjgVEzH0TmLmeRIcZHS86ZRuY7v4CsCywrOecA4LYaR6aAfyPz\ncRuAS4DLgB8hc6p1pIwOlWz8r8LHtsgaZNi/E4knBhKaDZFjiaVJbvJFtiY3Pwn2UyRdaqaKI5AR\nwHk156WMxvUh4ELgU8CtyLyzCyF0E0s/K5LQfFoplnhcc+OjmQEOQIawZWsDFwMn1tgvR5x+GDi/\ncHwGEdAbauxT4pvjPAzpDAsQ/2dptqh1LXL35vIzY2gvwb2jxxqLC9uAkxrYJbTTt3w1M8wm5ILz\nEPBZ6kWdopppUzMQbzy2NNXMCNuRBeViCdRSZFGnjoORD+45ZEW/yF+B22vsU+Lr6JcCr8h+34zE\nd1R/7vyfBPeOHmssLixHHiZzJaG9vuWjmSqmkTu+3Zj3TkpRzdiS0OziEGs8tjTVzAjHIcEXF7C2\nIR9KHQsz29+WvLYb+A+wyGCfEl9HL1aZfA1Z5ImBBPeOHmssrtwK7O9ok9Be3/LRjIkNWbu3GM5J\nUc3YktDs4hBrPC400Uwpu5i761mE1MnaPoD0FFKbPcw9SGJM1SYp8XX0Ig8Q6AocgAS/sryYYnFh\nGqnfruI6yofne4DfV7z25gB++WgG5AtozdCxZUiOX6K6FDVFNWNLgn8pa0zx2DKgmbyeu+6DqOq8\n30KezjwS2d3veou2cnYDryk5vggZOTxt2Q6W71kVg49tGfsBb2SwRBekTHEHUpVieshpO3aL8kUu\npJ2HbapieSvw9uz19cjc964Se99YfHKzCfP05JkVxxPkAcy05n2b+uajmWVIKetCZLriD9nxFwvv\nt49lW779PqRuxkkzUB6PrWagP93UacaJaWSN4HJk3tO2Y4KUsu5lcM1hCilt/UGNbYrfXdBRNP8j\nKnW2JyPJOaZwrM8NyhLMncUUT1ksSxksydyC5HFFcxdb4TZkEdiVhHZz5KOZxUi56eMMxpb/xbj7\nDbYpqhlbEpprBkbjGXfNVHIRMpw9v+7EIRYgW2VsKxzbgowYVtXYphbnVHEikrgmQz4b268iMZRd\nmfvo6Duz911S8lpdPGWxrEHy/ers//mUxpYQzgZiFaN3obYktJ+jppoB+CLwMQZzcgNS5bfWYJei\nmrHFRzMwGs+81Exxm4ANwKuQaZ2Z7ETTnG3Ot4Gzhxu24CXkCvsN5IN+Hvkw11E/pC/Ddtj2JLJV\n8fGBbIeZyWz7fPz+IOQLYwVzZcF/QgoAvoM8kAX18cwwGstvgLcBf8z+vzL79/EAfpfhMhzPORcZ\nmrdN15oBKVs9C9ko7wVkP7I9yHrIY45t+fZ7G/tJ0wyMxtO1ZsBdN0bN+O7t3iUpg3cTTYZtFwew\nHWYZItiPV7we6x40ZfHUxZJzA3ZP9jahSW6mgbs83jPBPkeTqpkm9pOgGbDTTZuaAffclGqm+ODM\nDHOlcLPIotd8YTXwaeaGbXciaxnrDTZ5qayPLcjumHkt82Zk9PNTW8cjIY/HNZatwN8ZnBoMSZPc\nbAZ+4vGez2D/d5tnmEzNNLEfV82AWzxtawbcc+OkGZ+93bsgZfBuYgoZRuVzfPnTiVUr/u9Atgn3\ntT02O/cSZPj2BNV3FBDnXVAej2ssm5jbi2Ux7cTlmhuAHyL+d80kacbVflw1A27xdKEZcM+tlWbW\nIle07ZQvxsRCivmDNQ3bppF1jqoyOxfbpcgc85XIvlBnG3yC+Dp6MR6XWE5AOvkh2c8pyJxq29QN\nx1cj88Ndopox24+zZsA+nr40A+bcOmvGZ2/3Lkip7jBbga/Q7K+B+diaCLWxXwysRipjZod+yjaU\nC4lNbr6E3DH1waRqJoR9GaqZMNTlplYzw3u7H404f2ogB0OTUt7RfYZtXQ35FHdscrMQmVvtCtVM\nGHulPepyY9RMviA9Dnu7n4Bs6HcHMmzbiP0ffPGxVdrFNjfvBX7coV+TrpkQ9kp72OTGWjO+e7t3\nyX0M7kDpM2zrc8inmHHJzRUVx9tkUjUTwl5pD9vc9KEZRVEURVEURVEURVEURVEURVEURVEUZdL5\nH3bROXO1FYCoAAAAAElFTkSuQmCC\n",
+       "prompt_number": 38,
+       "text": [
+        "",
+        "  ___                           ___                      ",
+        "\u2572\u2571 6 \u22c5\u27581/2,1/2,j\u2081=1,j\u2082=1/2\u27e9   \u2572\u2571 3 \u22c5\u27583/2,1/2,j\u2081=1,j\u2082=1/2\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "             3                             3             "
+       ]
+      }
+     ],
+     "prompt_number": 38
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Similarly, the uncouple method will uncouple a coupled state"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzc = JzKetCoupled(2, 1, (1, S(1)/2, S(1)/2))",
+      "uncouple(jzc)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} \\sqrt{2} {{\\left|1,0\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAkCAYAAAAjI/bEAAAABHNCSVQICAgIfAhkiAAACyFJREFU\neJztnWvMHUUZx38thZK2b42VSwsBjrSKiqB4IwWU0IoiElGUaiRCoEalXgtoYjTa5tUUTaFQ8Ua8\nHMFLjVggsYr3Y0xI1CgqGvkgceMHUTCgURptrPXDs8d3d89eZnZ2z87ZeX7Jm/bs7Mw+z+z/mTNn\ndmYWFEVRFEVRFEVRFEVRFEXphucBhxr4UxRFURRFURz5JnBk10YoiqIoiqL4yuIpXecC4EfAv6Z0\nvb5wL3BUB9e9HFjUwXUhTJ+VNF1pwBWNG6VLQtRAL9uKaXXMtgCfnNK1+sRxwIoOrnsCsLGD60KY\nPitputKAKxo3SpeEqIEg2oo54A7gxAYNOBv4UIPlhUQEDHKOu96nqvxrgC/XLNuViHyfwc1vn31u\nI+5mmYh2NOCKzxqKCKut0JiZJCIsDUBP24rkiNkbgWuBV9PsSNq7gJsbLC90XO+TSf6H4rRj6xjY\nEi5+++xzW3HXR7qsK581VERf2wqNGXP6qoEqetdWHKK4B2rLs2i+U/b1hsvzmYjie+F6n6ryvwR4\nr0P5dYkot8vFb199hmrbVPcLNNlG2eKrhiLCaytM/NK4EfqqgYgethVt9ySvBW4oSX8BsBf4FnA/\n8Fng+Ioyn1SStgz4tY2BMafEduwCbgRuY7InuxtYUqPsWeW7wAbCmtjrs89t6N4kf2i6d8VnDbWF\nzz5r3EwHnzXgK4V11mbHbB1wAPhjQfpzkLlnVwEvA9YDTwHuo14P9/nIys/TLPM9Afg+0jHbClwD\nPBAfOyJx3ggZmgyFQ8D3kF59KMyiz3V1b5p/RFi6d2UWNeTKLPqscdMss6iBrimsszY7Zu8Gdpak\nzyOrNf8Wf/4n8E7gaOB6i+s8HdgHvBU4aG8m70E6YHsSxz6FjKJtThy7G7i4RvmzzOeBK7s2Yso0\n4fPptP9r2VX3pvlD1L0rGjf10LiZbULUvSu5deYSBHPAPwrSjo/THyjJfy7wA+SNAA/Hx+5DOmov\ntrDjd8DL4/8PgTMt8gJcCvwE+E/i2KOI7ZeysM3HQeBnyOPXnxqWvRTYBDyXhTcX/Bu4K76m7zyM\n+L0Gmaxoyiz7XdfnJNcA25D5D23hqnvT/HV0D7OtAVfqaGjW60vjJo1+X5gz6367YFxnVRPWlgFf\nAj5ecs4NSCWXcT9S+U/OHP8z8HhJvlFJ2hC71zbNxefn+fJt4O+ZYyuBTxuWfT7SGz6b9DPkOeDN\nwK2Uz3+AbidzjtkAvN+iXFe/owq72pz8P8bW5yxDw+skqbJtVHE9l9eVVeW30T34rQFX2tBQqG1F\nlqHhdcaY2DWquJ4vcROqBrStqKizy5DRoUPIY7235ZyzJC5gHhktW5lzzipkvlYVy4HVmWPHxdf/\nYUm+UUnaELtAe2Z8/o6ctL1x2tLM8Z1UL1B4FTL6l+10JtmKTP5bVXJOxOSNNblPZdjmXxTbafLY\nuwm/I/LF7OJ3mz7nMcS8MTC1bVRxvTa/YMBM9+CvBlxpS0OhthV5DDGLGxu7RhXX8yFuQtWAthWC\na9z8n1XAfmROWJbtwHk1y70eGdY7q+ScUUnaELtAOys+f3tO2u1xWnZ15lrKN8xdjfwCWIasMn1a\nzjlXI3udDCh/I0JEd739JNcBF1ac05TfEbPjcxFDmvdhVHG9tr9gqnQP/dOAK1UaCrWtKGJIeHET\nqga0rUiTqrO6PbRHkceZW0gPP65A5oyVjXgVsQ7pWe5A3n81DcaTN/OC6/D438Myxx9ERvaWFZS5\nBfgI0nG9Gunxn5FIvw55RPoZRFT7gZMs7Z42Q6ondfbN7yE6kTVJle6hfxpwZUi5hvpYX0M0bpLo\n90U+ffTbhSGJOnMZOrsFeCrw0sSxt2A3F2XMUuT1BLfiNkfBlkdK0pbH/+YtcLgNeENBvgELix4O\nIAK8CjgH+CDwe9KvYtiH3WKHLvgropUnlpwzoF9+m/gcGmW6h/5pwJUqDQ3oX31p3Eyi3xeTDOif\n3y6k6sxlVeavgB8DbwfuQTpX51O+oWwei5AhzXuADzjYU4e/IKNleQJajqwQLVp5WrSR3n8znw8i\nr6X6BTJv7a5M+kPYrwyaNkuQ/d4eKzmnb36b+PwF5O0WWU5EVmMdyEnbDPzc2bruKNtA0mcNnIb8\n8DPdAPOXyA9NF6o05HN91UXjJh/9vkjjs9+dtxXjjlnVc/IiAz8GfBV5DLkR+WVg+8x+HlmCPJ84\ndnlcVts8jkw+PCEnbR1S4Xlcgexjk0d2FPIw4CbkMe1G4JWkRbcG6SCaYFK3ZWKqm/8i4BsV+Xz1\nu02fryg4PsRs2b/r/Zw2ZboHfzUAsgp8veG1mrp2lYZ8ri9f42bWYgb0+yIPn/3uvK1YnDix7K+I\nO4E/Ae8AXkN6k1YTrkR6zvOZ4+dYlmPKKcCRmWP7kJ540s+1SGftjpwy1iK99/0F13gQODX+/xHA\nJ4DPIaOL25C3G7w+cf6FyIoME6ruU/ZeZf21zT/GpKPsi9/T9NmVurbZkqd7W6p0D/5qwJW2NORL\nfcHsxM20YgamEzehasAXv2elrbDmfUjnynYobwPyXPWLmb89wFdK8o1K0vYgPda8iZbnxWlfyxxf\ngzyyTM4BuAn4LelXMo3ZSf4I25hjMF9tchIy6lhEBAxK0sso8teWAfJLtoqm/I6YHZ+LGFLfhyJG\nJWl1dG+af0yV7qFfGnBlQLWGQm0rihgSXtyEqgFtKxYYUFJnZyIrI7YhPdMXGRZ6NDJRz7bX+RgL\nu/xm/7IjaElGmc/HIJvB/iaR/xFkZehlifOeER//Q06Zz0ZGznYhq0D2kh9MK5Fnz1W8ArP9Wb5D\n+QTJiEnRmd6nIn9t7/OHkc3/TGjC74j8QDOxuwuf8xhi3liY2jbKfHbVvWl+MNc9+KsBV9rSUKht\nRR5DzOLGxq5R5rOPcROqBrStEArrbAXp91NuQoZeTTaUnDYjx/zbHfJuxXwC4kakk7ee9PDlHPCm\nOO2oijIi0qKrc5+S/trmX4IEhQ2ufkdMBpqt3dP2OcsQsy8YG9tGjjZNS/fgnwZcaVtDobYVWYZU\nx42tXSNHm/T7wjx/H74vXGm0zk5HHkeujT+vRH4JbHI2s3lGjvltXpCeZDGyd5sNS5Fnx7uAG+N/\nP0r5BrpJItKiq3Ofkv7a5r+Eejsmu/gdMRlotnZ34XOS3Uy+1SIPG9tGjjZNU/fglwZcmYaGQm0r\nkpjEja1dI0eb9PsirO8LVxqts0WkJ8CfGhd2RlGGDjGdAJjHC4HX1cx7CfBah2vXISItOtv7lPXX\nNv+dyBLeaRIxGWg2ds+Szza2hax7cNOAKz5raExEGG2FrV0hx01fNZAkIqC24nbs9yObFnM18y1B\neuNFqyKq2I3bvm91iCgf2i+7Tyb+luU/GRlGnjYR1Y8ziuyeVZ/HlNmmuk/jogFXfNRQRHhtBVR/\nV2ncLNBHDUQE0lZsRoYR2zRWMSOiWHSu96kq/w662cgwojzQXPz21WfQuEsS0Z4GXPFVQxHhtRUa\nM2kiwtNARABtxUVxYSCrLAeulilOROTfA9f7VJX/cORNDF0QUeyPi98++6xxlyaiHQ244rOGIsJq\nKzRmJokISwPQ07YiufvuucCxyLYRq4ELkD2+FL9wvU8m+S8G7na2tFlc/PbZZ407c7qsK581VERf\n2wqNGXP6qoEqetFWnIy8EzK7n9jKBo1V7LmX9FJh1/tkmv8WizKbJuszuPnts88ad/k0rQFXfNbQ\nmFDaCo2ZYkLRQBJtKxRFURRFURRFURRFURRFURRFURRFURRFURRFURRFURRFURRFmT7/A1TuLADP\nlUklAAAAAElFTkSuQmCC\n",
+       "prompt_number": 39,
+       "text": [
+        "",
+        "  ___                                                                         ",
+        "\u2572\u2571 2 \u22c5\u27581,0\u27e9\u2a02 \u27581/2,1/2\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,1\u27e9\u2a02 \u27581/2",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "                2                                2                            ",
+        "",
+        "                 ",
+        ",1/2\u27e9\u2a02 \u27581/2,-1/2\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "  2              "
+       ]
+      }
+     ],
+     "prompt_number": 39
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Uncoupling can also be done with the `.rewrite` method:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jzc.rewrite(\"Jz\", coupled=False)"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} \\sqrt{2} {{\\left|1,0\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAkCAYAAAAjI/bEAAAABHNCSVQICAgIfAhkiAAACyFJREFU\neJztnWvMHUUZx38thZK2b42VSwsBjrSKiqB4IwWU0IoiElGUaiRCoEalXgtoYjTa5tUUTaFQ8Ua8\nHMFLjVggsYr3Y0xI1CgqGvkgceMHUTCgURptrPXDs8d3d89eZnZ2z87ZeX7Jm/bs7Mw+z+z/mTNn\ndmYWFEVRFEVRFEVRFEVRFEXphucBhxr4UxRFURRFURz5JnBk10YoiqIoiqL4yuIpXecC4EfAv6Z0\nvb5wL3BUB9e9HFjUwXUhTJ+VNF1pwBWNG6VLQtRAL9uKaXXMtgCfnNK1+sRxwIoOrnsCsLGD60KY\nPitputKAKxo3SpeEqIEg2oo54A7gxAYNOBv4UIPlhUQEDHKOu96nqvxrgC/XLNuViHyfwc1vn31u\nI+5mmYh2NOCKzxqKCKut0JiZJCIsDUBP24rkiNkbgWuBV9PsSNq7gJsbLC90XO+TSf6H4rRj6xjY\nEi5+++xzW3HXR7qsK581VERf2wqNGXP6qoEqetdWHKK4B2rLs2i+U/b1hsvzmYjie+F6n6ryvwR4\nr0P5dYkot8vFb199hmrbVPcLNNlG2eKrhiLCaytM/NK4EfqqgYgethVt9ySvBW4oSX8BsBf4FnA/\n8Fng+Ioyn1SStgz4tY2BMafEduwCbgRuY7InuxtYUqPsWeW7wAbCmtjrs89t6N4kf2i6d8VnDbWF\nzz5r3EwHnzXgK4V11mbHbB1wAPhjQfpzkLlnVwEvA9YDTwHuo14P9/nIys/TLPM9Afg+0jHbClwD\nPBAfOyJx3ggZmgyFQ8D3kF59KMyiz3V1b5p/RFi6d2UWNeTKLPqscdMss6iBrimsszY7Zu8Gdpak\nzyOrNf8Wf/4n8E7gaOB6i+s8HdgHvBU4aG8m70E6YHsSxz6FjKJtThy7G7i4RvmzzOeBK7s2Yso0\n4fPptP9r2VX3pvlD1L0rGjf10LiZbULUvSu5deYSBHPAPwrSjo/THyjJfy7wA+SNAA/Hx+5DOmov\ntrDjd8DL4/8PgTMt8gJcCvwE+E/i2KOI7ZeysM3HQeBnyOPXnxqWvRTYBDyXhTcX/Bu4K76m7zyM\n+L0Gmaxoyiz7XdfnJNcA25D5D23hqnvT/HV0D7OtAVfqaGjW60vjJo1+X5gz6367YFxnVRPWlgFf\nAj5ecs4NSCWXcT9S+U/OHP8z8HhJvlFJ2hC71zbNxefn+fJt4O+ZYyuBTxuWfT7SGz6b9DPkOeDN\nwK2Uz3+AbidzjtkAvN+iXFe/owq72pz8P8bW5yxDw+skqbJtVHE9l9eVVeW30T34rQFX2tBQqG1F\nlqHhdcaY2DWquJ4vcROqBrStqKizy5DRoUPIY7235ZyzJC5gHhktW5lzzipkvlYVy4HVmWPHxdf/\nYUm+UUnaELtAe2Z8/o6ctL1x2tLM8Z1UL1B4FTL6l+10JtmKTP5bVXJOxOSNNblPZdjmXxTbafLY\nuwm/I/LF7OJ3mz7nMcS8MTC1bVRxvTa/YMBM9+CvBlxpS0OhthV5DDGLGxu7RhXX8yFuQtWAthWC\na9z8n1XAfmROWJbtwHk1y70eGdY7q+ScUUnaELtAOys+f3tO2u1xWnZ15lrKN8xdjfwCWIasMn1a\nzjlXI3udDCh/I0JEd739JNcBF1ac05TfEbPjcxFDmvdhVHG9tr9gqnQP/dOAK1UaCrWtKGJIeHET\nqga0rUiTqrO6PbRHkceZW0gPP65A5oyVjXgVsQ7pWe5A3n81DcaTN/OC6/D438Myxx9ERvaWFZS5\nBfgI0nG9Gunxn5FIvw55RPoZRFT7gZMs7Z42Q6ondfbN7yE6kTVJle6hfxpwZUi5hvpYX0M0bpLo\n90U+ffTbhSGJOnMZOrsFeCrw0sSxt2A3F2XMUuT1BLfiNkfBlkdK0pbH/+YtcLgNeENBvgELix4O\nIAK8CjgH+CDwe9KvYtiH3WKHLvgropUnlpwzoF9+m/gcGmW6h/5pwJUqDQ3oX31p3Eyi3xeTDOif\n3y6k6sxlVeavgB8DbwfuQTpX51O+oWwei5AhzXuADzjYU4e/IKNleQJajqwQLVp5WrSR3n8znw8i\nr6X6BTJv7a5M+kPYrwyaNkuQ/d4eKzmnb36b+PwF5O0WWU5EVmMdyEnbDPzc2bruKNtA0mcNnIb8\n8DPdAPOXyA9NF6o05HN91UXjJh/9vkjjs9+dtxXjjlnVc/IiAz8GfBV5DLkR+WVg+8x+HlmCPJ84\ndnlcVts8jkw+PCEnbR1S4Xlcgexjk0d2FPIw4CbkMe1G4JWkRbcG6SCaYFK3ZWKqm/8i4BsV+Xz1\nu02fryg4PsRs2b/r/Zw2ZboHfzUAsgp8veG1mrp2lYZ8ri9f42bWYgb0+yIPn/3uvK1YnDix7K+I\nO4E/Ae8AXkN6k1YTrkR6zvOZ4+dYlmPKKcCRmWP7kJ540s+1SGftjpwy1iK99/0F13gQODX+/xHA\nJ4DPIaOL25C3G7w+cf6FyIoME6ruU/ZeZf21zT/GpKPsi9/T9NmVurbZkqd7W6p0D/5qwJW2NORL\nfcHsxM20YgamEzehasAXv2elrbDmfUjnynYobwPyXPWLmb89wFdK8o1K0vYgPda8iZbnxWlfyxxf\ngzyyTM4BuAn4LelXMo3ZSf4I25hjMF9tchIy6lhEBAxK0sso8teWAfJLtoqm/I6YHZ+LGFLfhyJG\nJWl1dG+af0yV7qFfGnBlQLWGQm0rihgSXtyEqgFtKxYYUFJnZyIrI7YhPdMXGRZ6NDJRz7bX+RgL\nu/xm/7IjaElGmc/HIJvB/iaR/xFkZehlifOeER//Q06Zz0ZGznYhq0D2kh9MK5Fnz1W8ArP9Wb5D\n+QTJiEnRmd6nIn9t7/OHkc3/TGjC74j8QDOxuwuf8xhi3liY2jbKfHbVvWl+MNc9+KsBV9rSUKht\nRR5DzOLGxq5R5rOPcROqBrStEArrbAXp91NuQoZeTTaUnDYjx/zbHfJuxXwC4kakk7ee9PDlHPCm\nOO2oijIi0qKrc5+S/trmX4IEhQ2ufkdMBpqt3dP2OcsQsy8YG9tGjjZNS/fgnwZcaVtDobYVWYZU\nx42tXSNHm/T7wjx/H74vXGm0zk5HHkeujT+vRH4JbHI2s3lGjvltXpCeZDGyd5sNS5Fnx7uAG+N/\nP0r5BrpJItKiq3Ofkv7a5r+Eejsmu/gdMRlotnZ34XOS3Uy+1SIPG9tGjjZNU/fglwZcmYaGQm0r\nkpjEja1dI0eb9PsirO8LVxqts0WkJ8CfGhd2RlGGDjGdAJjHC4HX1cx7CfBah2vXISItOtv7lPXX\nNv+dyBLeaRIxGWg2ds+Szza2hax7cNOAKz5raExEGG2FrV0hx01fNZAkIqC24nbs9yObFnM18y1B\neuNFqyKq2I3bvm91iCgf2i+7Tyb+luU/GRlGnjYR1Y8ziuyeVZ/HlNmmuk/jogFXfNRQRHhtBVR/\nV2ncLNBHDUQE0lZsRoYR2zRWMSOiWHSu96kq/w662cgwojzQXPz21WfQuEsS0Z4GXPFVQxHhtRUa\nM2kiwtNARABtxUVxYSCrLAeulilOROTfA9f7VJX/cORNDF0QUeyPi98++6xxlyaiHQ244rOGIsJq\nKzRmJokISwPQ07YiufvuucCxyLYRq4ELkD2+FL9wvU8m+S8G7na2tFlc/PbZZ407c7qsK581VERf\n2wqNGXP6qoEqetFWnIy8EzK7n9jKBo1V7LmX9FJh1/tkmv8WizKbJuszuPnts88ad/k0rQFXfNbQ\nmFDaCo2ZYkLRQBJtKxRFURRFURRFURRFURRFURRFURRFURRFURRFURRFURRFURRFmT7/A1TuLADP\nlUklAAAAAElFTkSuQmCC\n",
+       "prompt_number": 40,
+       "text": [
+        "",
+        "  ___                                                                         ",
+        "\u2572\u2571 2 \u22c5\u27581,0\u27e9\u2a02 \u27581/2,1/2\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,1\u27e9\u2a02 \u27581/2",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "                2                                2                            ",
+        "",
+        "                 ",
+        ",1/2\u27e9\u2a02 \u27581/2,-1/2\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "  2              "
+       ]
+      }
+     ],
+     "prompt_number": 40
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "The `uncouple` method can also uncouple normal states if given a set of spin bases to consider:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "jz = JzKet(2, 1)",
+      "uncouple(jz, (1, S(1)/2, S(1)/2))"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\frac{1}{2} \\sqrt{2} {{\\left|1,0\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }} + \\frac{1}{2} {{\\left|1,1\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},\\frac{1}{2}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},- \\frac{1}{2}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAmYAAAAkCAYAAAAjI/bEAAAABHNCSVQICAgIfAhkiAAACyFJREFU\neJztnWvMHUUZx38thZK2b42VSwsBjrSKiqB4IwWU0IoiElGUaiRCoEalXgtoYjTa5tUUTaFQ8Ua8\nHMFLjVggsYr3Y0xI1CgqGvkgceMHUTCgURptrPXDs8d3d89eZnZ2z87ZeX7Jm/bs7Mw+z+z/mTNn\ndmYWFEVRFEVRFEVRFEVRFEXphucBhxr4UxRFURRFURz5JnBk10YoiqIoiqL4yuIpXecC4EfAv6Z0\nvb5wL3BUB9e9HFjUwXUhTJ+VNF1pwBWNG6VLQtRAL9uKaXXMtgCfnNK1+sRxwIoOrnsCsLGD60KY\nPitputKAKxo3SpeEqIEg2oo54A7gxAYNOBv4UIPlhUQEDHKOu96nqvxrgC/XLNuViHyfwc1vn31u\nI+5mmYh2NOCKzxqKCKut0JiZJCIsDUBP24rkiNkbgWuBV9PsSNq7gJsbLC90XO+TSf6H4rRj6xjY\nEi5+++xzW3HXR7qsK581VERf2wqNGXP6qoEqetdWHKK4B2rLs2i+U/b1hsvzmYjie+F6n6ryvwR4\nr0P5dYkot8vFb199hmrbVPcLNNlG2eKrhiLCaytM/NK4EfqqgYgethVt9ySvBW4oSX8BsBf4FnA/\n8Fng+Ioyn1SStgz4tY2BMafEduwCbgRuY7InuxtYUqPsWeW7wAbCmtjrs89t6N4kf2i6d8VnDbWF\nzz5r3EwHnzXgK4V11mbHbB1wAPhjQfpzkLlnVwEvA9YDTwHuo14P9/nIys/TLPM9Afg+0jHbClwD\nPBAfOyJx3ggZmgyFQ8D3kF59KMyiz3V1b5p/RFi6d2UWNeTKLPqscdMss6iBrimsszY7Zu8Gdpak\nzyOrNf8Wf/4n8E7gaOB6i+s8HdgHvBU4aG8m70E6YHsSxz6FjKJtThy7G7i4RvmzzOeBK7s2Yso0\n4fPptP9r2VX3pvlD1L0rGjf10LiZbULUvSu5deYSBHPAPwrSjo/THyjJfy7wA+SNAA/Hx+5DOmov\ntrDjd8DL4/8PgTMt8gJcCvwE+E/i2KOI7ZeysM3HQeBnyOPXnxqWvRTYBDyXhTcX/Bu4K76m7zyM\n+L0Gmaxoyiz7XdfnJNcA25D5D23hqnvT/HV0D7OtAVfqaGjW60vjJo1+X5gz6367YFxnVRPWlgFf\nAj5ecs4NSCWXcT9S+U/OHP8z8HhJvlFJ2hC71zbNxefn+fJt4O+ZYyuBTxuWfT7SGz6b9DPkOeDN\nwK2Uz3+AbidzjtkAvN+iXFe/owq72pz8P8bW5yxDw+skqbJtVHE9l9eVVeW30T34rQFX2tBQqG1F\nlqHhdcaY2DWquJ4vcROqBrStqKizy5DRoUPIY7235ZyzJC5gHhktW5lzzipkvlYVy4HVmWPHxdf/\nYUm+UUnaELtAe2Z8/o6ctL1x2tLM8Z1UL1B4FTL6l+10JtmKTP5bVXJOxOSNNblPZdjmXxTbafLY\nuwm/I/LF7OJ3mz7nMcS8MTC1bVRxvTa/YMBM9+CvBlxpS0OhthV5DDGLGxu7RhXX8yFuQtWAthWC\na9z8n1XAfmROWJbtwHk1y70eGdY7q+ScUUnaELtAOys+f3tO2u1xWnZ15lrKN8xdjfwCWIasMn1a\nzjlXI3udDCh/I0JEd739JNcBF1ac05TfEbPjcxFDmvdhVHG9tr9gqnQP/dOAK1UaCrWtKGJIeHET\nqga0rUiTqrO6PbRHkceZW0gPP65A5oyVjXgVsQ7pWe5A3n81DcaTN/OC6/D438Myxx9ERvaWFZS5\nBfgI0nG9Gunxn5FIvw55RPoZRFT7gZMs7Z42Q6ondfbN7yE6kTVJle6hfxpwZUi5hvpYX0M0bpLo\n90U+ffTbhSGJOnMZOrsFeCrw0sSxt2A3F2XMUuT1BLfiNkfBlkdK0pbH/+YtcLgNeENBvgELix4O\nIAK8CjgH+CDwe9KvYtiH3WKHLvgropUnlpwzoF9+m/gcGmW6h/5pwJUqDQ3oX31p3Eyi3xeTDOif\n3y6k6sxlVeavgB8DbwfuQTpX51O+oWwei5AhzXuADzjYU4e/IKNleQJajqwQLVp5WrSR3n8znw8i\nr6X6BTJv7a5M+kPYrwyaNkuQ/d4eKzmnb36b+PwF5O0WWU5EVmMdyEnbDPzc2bruKNtA0mcNnIb8\n8DPdAPOXyA9NF6o05HN91UXjJh/9vkjjs9+dtxXjjlnVc/IiAz8GfBV5DLkR+WVg+8x+HlmCPJ84\ndnlcVts8jkw+PCEnbR1S4Xlcgexjk0d2FPIw4CbkMe1G4JWkRbcG6SCaYFK3ZWKqm/8i4BsV+Xz1\nu02fryg4PsRs2b/r/Zw2ZboHfzUAsgp8veG1mrp2lYZ8ri9f42bWYgb0+yIPn/3uvK1YnDix7K+I\nO4E/Ae8AXkN6k1YTrkR6zvOZ4+dYlmPKKcCRmWP7kJ540s+1SGftjpwy1iK99/0F13gQODX+/xHA\nJ4DPIaOL25C3G7w+cf6FyIoME6ruU/ZeZf21zT/GpKPsi9/T9NmVurbZkqd7W6p0D/5qwJW2NORL\nfcHsxM20YgamEzehasAXv2elrbDmfUjnynYobwPyXPWLmb89wFdK8o1K0vYgPda8iZbnxWlfyxxf\ngzyyTM4BuAn4LelXMo3ZSf4I25hjMF9tchIy6lhEBAxK0sso8teWAfJLtoqm/I6YHZ+LGFLfhyJG\nJWl1dG+af0yV7qFfGnBlQLWGQm0rihgSXtyEqgFtKxYYUFJnZyIrI7YhPdMXGRZ6NDJRz7bX+RgL\nu/xm/7IjaElGmc/HIJvB/iaR/xFkZehlifOeER//Q06Zz0ZGznYhq0D2kh9MK5Fnz1W8ArP9Wb5D\n+QTJiEnRmd6nIn9t7/OHkc3/TGjC74j8QDOxuwuf8xhi3liY2jbKfHbVvWl+MNc9+KsBV9rSUKht\nRR5DzOLGxq5R5rOPcROqBrStEArrbAXp91NuQoZeTTaUnDYjx/zbHfJuxXwC4kakk7ee9PDlHPCm\nOO2oijIi0qKrc5+S/trmX4IEhQ2ufkdMBpqt3dP2OcsQsy8YG9tGjjZNS/fgnwZcaVtDobYVWYZU\nx42tXSNHm/T7wjx/H74vXGm0zk5HHkeujT+vRH4JbHI2s3lGjvltXpCeZDGyd5sNS5Fnx7uAG+N/\nP0r5BrpJItKiq3Ofkv7a5r+Eejsmu/gdMRlotnZ34XOS3Uy+1SIPG9tGjjZNU/fglwZcmYaGQm0r\nkpjEja1dI0eb9PsirO8LVxqts0WkJ8CfGhd2RlGGDjGdAJjHC4HX1cx7CfBah2vXISItOtv7lPXX\nNv+dyBLeaRIxGWg2ds+Szza2hax7cNOAKz5raExEGG2FrV0hx01fNZAkIqC24nbs9yObFnM18y1B\neuNFqyKq2I3bvm91iCgf2i+7Tyb+luU/GRlGnjYR1Y8ziuyeVZ/HlNmmuk/jogFXfNRQRHhtBVR/\nV2ncLNBHDUQE0lZsRoYR2zRWMSOiWHSu96kq/w662cgwojzQXPz21WfQuEsS0Z4GXPFVQxHhtRUa\nM2kiwtNARABtxUVxYSCrLAeulilOROTfA9f7VJX/cORNDF0QUeyPi98++6xxlyaiHQ244rOGIsJq\nKzRmJokISwPQ07YiufvuucCxyLYRq4ELkD2+FL9wvU8m+S8G7na2tFlc/PbZZ407c7qsK581VERf\n2wqNGXP6qoEqetFWnIy8EzK7n9jKBo1V7LmX9FJh1/tkmv8WizKbJuszuPnts88ad/k0rQFXfNbQ\nmFDaCo2ZYkLRQBJtKxRFURRFURRFURRFURRFURRFURRFURRFURRFURRFURRFURRFmT7/A1TuLADP\nlUklAAAAAElFTkSuQmCC\n",
+       "prompt_number": 41,
+       "text": [
+        "",
+        "  ___                                                                         ",
+        "\u2572\u2571 2 \u22c5\u27581,0\u27e9\u2a02 \u27581/2,1/2\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,1\u27e9\u2a02 \u27581/2,-1/2\u27e9\u2a02 \u27581/2,1/2\u27e9   \u27581,1\u27e9\u2a02 \u27581/2",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 + \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "                2                                2                            ",
+        "",
+        "                 ",
+        ",1/2\u27e9\u2a02 \u27581/2,-1/2\u27e9",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "  2              "
+       ]
+      }
+     ],
+     "prompt_number": 41
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "## Example: Spin-orbit Coupling",
+      "",
+      "If we start with a hydrogen atom, i.e. a nucleus of charge $Ze$ orbited by a single electron of charge $e$ with reduced mass $\\mu$, ignoring energy from center-of-mass motion, we can write the Hamiltonian in terms of the relative momentum, $p$, and position, $r$, as:",
+      "",
+      "$$H=\\frac{p^2}{2\\mu} - \\frac{Ze^2}{r}$$",
+      "",
+      "The resulting eigenfunctions have a seperate radial and angular compents, $\\psi=R_{n,l}(r)Y_{l,m}(\\phi,\\theta)$. While the radial component is a complicated function involving Laguere polynomials, the radial part is the familiar spherical harmonics with orbital angular momentum $\\vec{L}$, where $l$ and $m$ give the orbital angular momentum quantum numbers. We represent this as a angular momentum state:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "l, ml = symbols('l m_l')",
+      "orbit = JzKet(l, ml); orbit"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${\\left|l,m_{l}\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAC8AAAAaCAYAAAAnkAWyAAAABHNCSVQICAgIfAhkiAAAAppJREFU\nWIXt102MjVcYB/DfGJQQbTTxsTJFohqfESRidEYmTRtNRRRLhETCykdiJWFlg7AgFixESrS1E1qL\nZto0bYVFg4aIz1j4WpAgxBAW50zmde57e8/lioX5Jzfve/7Pc57zP885zzn3pRfvFDswsMzQJ2n/\nXOLzA+7iJT5rrK4sdGJJrmMZtuNmg8TUi2b8WGZIM18Nc/B7w+TUhxe4iAmpIUf8EEz1/sTDfqxM\nyRzxrcLSvU/xNzBcUrh9Mzq24xYuZfjORwcmYymGYpFQ7LOwDSewFp9iGPpjObpqxP4Ji3GgmkNn\nCXcGhzOE98fO+H4af2I9miK3UTi1tqMlcs14KEy0FvrhaJGotW0+xhR5W+bLKLgJo3E7Cn0Z7V3C\nShzC9ci9iL/hGfG7hNWvKNxudCbtb+Pg4zOCjxT25KTYpzWxH8ZfCTc6+s7LiA9j9Kxuzcy34w4u\nZAS+hSeYG5+nEnubyuR8jafyD4MrGNvdqCW+DX/E95zsEyb8N54VuPEYoVL8AvyCRxgl1MD/YQyu\nVjMWgw8W9uOa2N6b+I7DgITrg/vYlPCrhckMKnBD8Rzfx/ae+PwK/wr1kmIrJhYHq4Zu22XMxD8F\nW7tw6x1M+kzFJyoz3C6cQI8LXIuQ6ZOYjv8ifxIP8GsSox8+x7lqgtNBN+A4dnl9ol/gHq4l/t/h\nvHBspnFXJVyzcHbvxeZC/EFRfLqqC7GsmvAy8bWwpU7/HHwjXGQpjkhu2Nw/ZtXw0Vv2L0OHyi3T\nItwbT4rk24hvFQqr0egQTqAiVmBfrY6dmQP0Fb5wmmo51olheupocGGsso+kN878c6zTc/U3CrPx\nG6ZhRuTm4ViZcyp+d4PF1IuzQqbn6tkFbap8SfWiFx8aXgFjVHm5OC1AbAAAAABJRU5ErkJggg==\n",
+       "prompt_number": 42,
+       "text": [
+        "\u2758l,m_l\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 42
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Now, the spin orbit interaction arises from the electron experiencing a magnetic field as it orbits the electrically charged nucleus. This magnetic field is:",
+      "",
+      "$$\\vec{B} = \\frac{1}{c}\\frac{Ze\\vec{v}\\times\\vec{r}}{r^3} = \\frac{Ze\\vec{p}\\times\\vec{r}}{mcr^3}=\\frac{Ze\\vec{L}}{mc\\hbar r^3}$$",
+      "",
+      "Then the spin-orbit Hamiltonian can be written, using the electron's magnetic dipole moment $\\mu$, as:",
+      "",
+      "$$H_{SO} = -\\vec{\\mu}\\cdot\\vec{B} = -\\left(-\\frac{g\\mu_B \\vec{S}}{\\hbar}\\right)\\cdot\\left(\\frac{Ze\\vec{L}}{mc\\hbar r^3}\\right)$$",
+      "",
+      "Ignoring the radial term:",
+      "",
+      "$$\\propto \\vec{L}\\cdot\\vec{S} = J^2 - L^2 - S^2$$",
+      "",
+      "for $\\vec{J}$, the coupled angular momentum.",
+      "",
+      "The electron spin angular momentum is given as $\\vec{S}$, where the spin wavefunction is:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "ms = symbols('m_s')",
+      "spin = JzKet(S(1)/2, ms); spin"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${\\left|\\frac{1}{2},m_{s}\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAADgAAAAgCAYAAABHA7voAAAABHNCSVQICAgIfAhkiAAAAwpJREFU\nWIXt2F2IVVUUB/DftUnyayTzs6iG6SEiMEpF8HtKYiDDD1CCqCjtpXqRHuZVRUH8wgff/AiSLJhQ\nhKJPoiAL6anE9/NWiSloaCR6fVjn6p1zz9w558610Wn+cOCctfbae/332mvvtQ//Q/yE6SPtRAm8\njspgynE5socxOUc+BZ/isfb41TY8ihfKGCToysg2YQuqObqRxhwcK2OQGJzE3UgQPsGsPEXeEr0X\ncQRv5SlGC8Fv8LyczWa0EKziW7yYVYwWgvAB3swKRxPBc7gudtVb6Cho/CqWpO878SMOFLRdjZV4\nBm9gGtaLZbUIe/AFNuMhzMR4EY1rBceo4TA2YnuzRon2HQXjsT99/0VMzPtubwZ9Yub31o15Hy6L\nySiLithwbq3MO71ElwtSFXTjD0GmmuqviYgeExNLLLPrBjnXhkAVX6G3WaNE+yI4BxMwNx18aUb/\nsah969Gdtn2pxTGno7/2cacj+DuuijPqKk5n9CvwfUbWi3/wQ4tjnhe8HqQYwWqBZyj04Gf8Wyd7\nCrM1ElyLL/E3Hhc5WQYdmIqLFCNYKfDU8CQeyNiPwzKNRHpEDp6qk01L5R+l330iH8tgFT5r1iDR\nWg72iGj2Z+Tz5Odfv4Hk4Lm0bScW4N0W/DguJgrFz8Ei+FOs//kZ+SM4qzH/ZuDDjOxXcefcJXbc\nbSV96MIlXGjWKNEYwYXiIN4izpllTey3lnSqDF7GO3hN/u1hBxYP1UliIMHJonqpYQOuiMjkYecg\n8uFiCn5L32eI6qceHfi6SEeJgQTn4gaeSL87RZ5syLFdileKDNICJqS+nRHlXbYQWIf3inSUGEiw\nIpZobbd8WhB8NmPXgX2a/AAaJiqC5Bp8p3GlnBDHw5BINN9Fj4py679EF/4StS1RrNdHqxuH8gzL\n7qIbRXXSV9JuuDiP3SItJmKS20U8vI2DRTtL5EdwlSBIHOZ5bUYC94vKJxdFa9HlIqk/F+VVr8zF\ncgSxGifLGGT/bHeL+1m2/uxsk4PDxQF3jy9jGMMYMrgJOdmQt/74E/MAAAAASUVORK5CYII=\n",
+       "prompt_number": 43,
+       "text": [
+        "\u27581/2,m_s\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 43
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "From this we build our uncoupled state:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "state = TensorProduct(orbit, spin); state"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$${{\\left|l,m_{l}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},m_{s}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAHsAAAAgCAYAAAAyjgdLAAAABHNCSVQICAgIfAhkiAAABYdJREFU\naIHt22usXUUVwPFfubdApb0GxEoJyKUFFdFGaAwhvEpRqOFdpBgNQuQVCh9oLNEECBBCgAhGXgo+\nquENBYEPoPjKgaiEYIKCiYQEPIkRlEfASKhS6vXD2od775y9z5lzex69yfknNz0zs/bM2jOzZtas\nPWXIkCF+j50HrUSHfBVzqgq36aMis41dMb8kfwHux0f7q04Wu+OIQSsxG6ljPMk7E5dhoqRsa2AR\n7hq0ElvCtzFvAO3WVQ/o1jrYcA8+UlaQLuP3l8jciVfFC+7ZXb2yqOGUAbQ7W1mPr+UI1iryr8Pf\nuqVNh4zgvgG0Wzc7LXsOfqnEUct10A7F493UqAM243l8akDtzzYm8CscmRaMZjw8hv3w/S4r1Qk/\nwlpc0MEz22E1lokOmMB/8RCe6raCWxk/xg14rJVQrSTvaNFRH+u+Th1xt3xH7fPihQ8yfTlbgHPE\nxP1QmzrqZucy3uBO4Z1XUivJuxYvZzZwPG7EE8KZW4arcZXYBo4Vq8mFRf563IG5GXWvwmkZcifi\nGa2dybViX9uphUxd84B+Bd8Tg30Pzs/QZyq97J+UFbi4lUCtJO8PwqrasS2+U/x+Gr/F101a1jeE\nV3+dyU4cwb/lDeJcPNBGZhdh0R8QS/8nSmTOFeflcTFwVdR113p73T8pDUftfb+snYP2QXxGnnN2\nmHiBOViMfwjFJ4ryTcKS7hIdSThfm1WcCxM24QWtHbU1uAbviEFdK/yNBuvwL/yw0OEd7JHRdjfo\ndf+kTIg9e2WVQC1JH1M8tE9G5YvEnrq0eOaQpPxuEW+eyuJC9uiM+mGJSeso47YkPSKWzYNxKU5I\nylfgjIq66rpr2f3on5SdsaGRaGfZh+Of+EtGxa9go+jAjZo93uWaJ9NK/Ef+se5F7NWi/H9JerPw\n4G8u0g8l5a9gYWbbW0o/+ifldTHGO9J+sJcLZ4I86yYmyJN4d0rePmI/rSWyJ+LneFsspyNt6l6C\nl1qUp+8zIlaC88XymVr2IjGZc5jI+Muhl/2TMiq24jfLCqc2Nl9YxnlF+pZE9uPYPsnbpqj4kiR/\njXi5Habk7YT38MUi/d3i3yPxR7GfpVyFT5cpXnAp9i1+b4tbTd+zL8SXp6SvFV+KyqjbsmW8V/3T\nCSdoEZuoTfk9Jgb7KByA06eUHS5m8gbTaQQw0v1oA36X5O1fyI7hsyYnVUOPNAI0Fw9WKV6wUL43\nvofYz6uom/lg97p/cvmpFsfLWpJeh0dxvelL5CfxGv6ayB+HPwurSus9J8kbES95i/hs2Kh/B7yl\n2SpOMn3CVXGcvHP2LxR7WQV1Mx/sXvZPLuP4SSuBWocVXt6hfA5fwM9K8u+VH0E7QhyvDtQcQTu7\nKGt3C6WuebAPEBPlMnGGPbRNHb3oHyL4sganqv7CdaWIIL5PTmy8Fdtt4fNlfE5zTHdcnEs3Ztbx\na3GmPUXExyfEoG8SHvlM4vzzhcP0zSK9WjhPe+PvFc/0on8WiIFcig+L4+b6RGZULP0Xtaqo1kGj\nh+BLHcjn8ifNe+0VWjtmvaBuumUvFUe7JUV6TEyi1RXP96p/5hW6PScczLKAyyoZodxaZoOj4gZJ\n5eW2GbLQ5D7XuP81qvxSRa+pmz7Yc8Qy3njnfcVg76eZXvVPQ495wtP+jYihpzwojlwtqXVVrc5Z\nJbzoZSL4QHw8OH0AutS1dtBuV3487CXjeMOkg3eyZgteLHySJlIP7+YyoT7yrLCKFSYn3nKDuanS\nijNERGxdn9t9Hd8SW8fZ2E3zmJ2FH/RZr1lPXbllH2Mynr59hcygmCucxlKG98Y74zDhED0iwpsr\ntbkg0GeOx8ODVmI2kv6PkMXi23IaDx/rv2qV3GTr0mfIkCFDhgwZMgP+D8enOQ4jSfDWAAAAAElF\nTkSuQmCC\n",
+       "prompt_number": 44,
+       "text": [
+        "\u2758l,m_l\u27e9\u2a02 \u27581/2,m_s\u27e9"
+       ]
+      }
+     ],
+     "prompt_number": 44
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "For clarity we will define $L^2$ and $S^2$ operators. These behave the same as `J2`, they only display differently."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "L2 = J2Op('L')",
+      "S2 = J2Op('S')"
+     ],
+     "language": "python",
+     "outputs": [],
+     "prompt_number": 45
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "We also have the spin-orbit Hamiltonian:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "hso = J2 - TensorProduct(L2, 1) - TensorProduct(1, S2); hso"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$J^2 - {1}\\otimes {S^2} - {L^2}\\otimes {1}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAKoAAAAZCAYAAAChKLVZAAAABHNCSVQICAgIfAhkiAAABIhJREFU\neJzt2luoVFUcx/HP8ViWmpaZWhGWvSilKVFp5YWkKJSoIIOiJ9OSfCjoIlRIdrNSCiqk+5AvPpWE\nlZcu2EMXArML+GBlT0VYgZhBmZ4e/jM6Z5g5e8+ePTNndL5w2Gfvdfuv33/tvf5rraFLlw6gJ2O5\ny3A5RuMKPIZP8zKqw+kkbTrJ1roZidVl94vwN85ujzmDik7SppNszcQ0HMb5xftR6BMdPd7pJG06\nydZM9IgpoxQ2XCA6OKNtFg0eOkmbTrI1kRnYhi/F29eHb7C0LM96rG2xXcPxbYvbLHESHsImbMA7\nWCGm0k0VeVutzRC8i13CV//hC+HDWQll2+HHajTk2x78gR0VzxfjGdkXZVm4BF8JR7SasdiJZfr3\neQn2iIFboh3alJgn9FmdkK9EO20tp6Zvh6Ss4EKMwdayZwuL1wcwDOdmty8VU/Ae7sahJrdVi/X4\nCOv0F/NV/IMPi/et1qaS2cXrthR5220rKXw7NGVF84rXT4rXuRhfrHwCZuI3/JzNzlTswoLi/wUR\nX9XDMLFQuFgMsj4xuDaK0CaJqbgWq2qk/ygGcTu0qWQuDuLzFPnytDWrxo369ghvi46PwCTsLzOk\n9Dcqa+UZKKhv6r8ab4q9wvLp7RTciVdwekIdi4pt3l4j/WGDQ5sTcEDyIM3b1jw0pn7fHqEHv0vu\neCspSN+ZG/E1zhsgz71imhwzQJ5pxTb34wlcKQbFYGOWsPPpFraZl8Y0MFAvKhZ8MkvhJlGQrjMT\nxFs+HK9jcpU8y3CHiM3WJdS3Rv+vz18ibk0Sv5U8KGxbkJQxJ/LWuCDjQL2nWPCaLIWbREG6zqxy\nVLgT8bL++4T34day+7WYmFDnDDwqjhr/LdrxQQpbWsX7YkEyukXt5a1xQcaBulE4ZESWwk2iIF1n\n3qq478ULYtpeiRsq0q8SWzVpOQs/iD3mU+so1yx6sU9Mw7WYmnObeWtcUMW3Sav+IZgj9rYOJORN\nYqoIqNPu1e3EXQ22ebji/pCYIXaIBeLGivRfVV9xrlB9T/IXvCFi1rRbfbXIQ5/pYjFU64clJ4uF\nzfIsBtYgL40HpHygzhQnK085ekIxHafh43orrsJ3kk9H8qZy8PTieeGo+eJtLxfyTLE9U85IA9s9\nGt/jz4YszUefOcXr9hrpi7G5wTYqyUPjunhRfHKXlD17ThzDTWmk4iZQkG7qXynOsKkeP92vf/y0\nBudU1HGdOHWq9sUch724KYUtrWCj0OWMKmnjxfF32r3ztOShcTkFCb5dLlaMJRaK2DTPaSIvNojO\nDE/IN076FelEEVtV8ix+Eg4oX6BMEiHRI/UY3kSGimPuXVXSZmO3+BjlTR4al5Po2148Lkb8S+Lt\nnFMrcxsYhy1imi1tD+0Vp2W3DVDueun2+LaKMKeS0vbTzeKIdHvRji3ipKrdTBZ27Raa7BO2bRba\n7HFUr0ubZEOjGmf17THHfLwmYsDKU5OlxbSxbbDrWKKpGrf71zKtZBhuEfFTn+j7QTFzfNZGu44l\nuhp36dKlS5cuXbp0OW74H3nWOWF+Ncp/AAAAAElFTkSuQmCC\n",
+       "prompt_number": 46,
+       "text": [
+        "",
+        " 2       2    2   ",
+        "J  - 1\u2a02 J  - J \u2a02 1"
+       ]
+      }
+     ],
+     "prompt_number": 46
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Now we apply this to our state:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "apply1 = qapply(hso * state); apply1"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$- \\hbar^{2} l^{2} {{\\left|l,m_{l}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},m_{s}\\right\\rangle }} - \\hbar^{2} l {{\\left|l,m_{l}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},m_{s}\\right\\rangle }} + J^2 {{\\left|l,m_{l}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},m_{s}\\right\\rangle }} - \\frac{3}{4} \\hbar^{2} {{\\left|l,m_{l}\\right\\rangle }}\\otimes {{\\left|\\frac{1}{2},m_{s}\\right\\rangle }}$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAqIAAAAhCAYAAAACusmsAAAABHNCSVQICAgIfAhkiAAADGxJREFU\neJztnXmwHEUdgL+XlxCSvCQaEYNB8gh4ABINqCQlOQ2IJCRgcVgaEEwMl38YSSQUWgSvRCSJligi\naB4q4TCJQcEDChwojVgR7wOrVMbCAkHU4lIgJs8/fjO1s7MzszM73XPs/r6qV2+np7ent/ebnu2e\n7h5QFEVRFEVRlB7gOGAVsA64G5hTam56j13AAWVnIgPnAH1lZ8JD3TWP+qhUFXXTLlqfdk7d3IQK\n+TkAbAhsnwn8B5iSIQ2VNx8uMFhyHrJwObCw7Exgxl2lFRf10TRaR5rBRd20hdan+XCpl5tQIT+n\nA/uAw7ztCcAwImEaVN78uEQLPB7YBhxSZGZScBCwtexMkN9dJRoX9dEkWkeaw0XdDDMHOBtYAXyD\nzn9YaH2aD5d6uQkVqjv7kNa63z17FCLfjJTv7yZ5NwFjSjiuS6vAK5Dek+GIfVXgFuAVJechr7tV\nR31MTxV8jKOb6kgfdTM9tt18Eniv9/oMpJEzvoN0uqU+VTezUVjdOQ54C/DqFHG/DmzMkHYn8m7L\nkH6RLAHOLeG4LvGSVlXgE4HLCjiOTXd91MdmXNRHk+S5wKubzbiom2Fej9STAKcDe4j/IWq6Pq2i\nn+pmNgqpO5cCDyIFcUKbuMuBq0gevHoT8ISX3qER+9PI63SQbhH0A7eVcFyX+gnch4x1sznQuSh3\nnQxxi0R9TE8RPrZjhpeHnyI9oMPAr4CVoXhZGkxORJi6GY26KbdZL4/ZZ7o+hWr6qW5mozA/NwHP\nAqMT4ixG5APYn+RC2wg8EhGeR96kdIvkY0gLs0hc6inwpcDbLR+jCHedDHGLRn1MTxE+pqEP+Cfw\n84h9aetIHycmXN1spZfdPAZYDVwPjE2IZ7o+dWLCy/ZT3cyGVT8nAU8D/0Na6M96f78NxZuLiDfZ\n+zsVmJWQ7m5kUHQQE/JGpVs0U4HPFnxMl3oKfCAyvsQGRbrrZIhbNOpjekz4OB0YmTONo5Fy2hAK\nz1JH+jgx4epmK93uZhpWIr2eA6FwW/WpExNetp/qZjYi/cxbEfo8h3TBP4AMmL0pEO4zDbiDVnEn\nxqQ5AbkF9eVA2FxksOudiLwzgceRLyYtUemWwV+RzzIG+G/K94xGJh4ciwg3DLwA7ERu03UrTwB7\nkZl3jxlOuyh341Af64cJHz+E+ObmyMc87/8PA2Em6kgfdbN+2KorZwK3e/8fBu4HrgNOonn8po36\nNI4q+KluZsPmtRyA0zA7822Rl95rvO1pwDM0vjj/b0JCGk6KdMvknTRmIbbjBGAL8Faab7eNB85H\nTsaXtUnDpb4tqQXARyylbdtdHydD3DJQH9OT18ch8n++HciEEX8CSSd1pI8TEaZuRtPtbkbxJuBe\nGrfaTwZeBA6PiGu6PoVq+6luZsPmtZzNSJd8P/BSZKD8c8CNHaZ3NfBozjw5OdNdCnweaf0dirRg\nNgDrgfuAU5Be5TVe+FeR2wSjUqY/CtieIt5pwC9IHpC9ChkIPCkhjkurpO8BrkUEvgX4QIr8+Ngu\nnyD+QOcRHby3HUW562SIG4X6mEydfBwi3wWjD1lO5yc50gjiRISpm830iptxLAMuQcpvOzILOgrT\n9SlU28+6uwnd4Scg40W+j4h3A3Ak0pX/7w7T+xlwc848OTnS3Y/G2I/dwI+Qk9BvxVyKdDNvpCFF\nP9IjkbZ1BPJFJw12noy0oMYCXwFeFxHnQmQdsUFExjhczLWWiiqfIKuRlrhpinLXyRA3jPqYTN18\nHCLfZ38DctH5VI40gjgRYeqmGermZl5M16dQfT/r6iZUwE9Tv0gnAG8Efgx8GPlV/3sk03/sIL2J\nXnr3GcpfJ+nORb6QPuSW19+RL2LY278HabVspTH+aq/3l2XR1hsQ+eK4CPg0snjwhUjZBm95rAae\n8tJxvXhTMxy/U4oqnyBDwHkdvjeOMt1VH83RLT6mZb7337GUvrppjl5y03R9GkfV/Kyrm9BFfp6M\nZHoL8kFAMrgPaSlkZbGX3hE58+XkSPcgZADydO89s0P7bwZ2hcKmeXEXZcznHQn7vhba7ke60I8H\nrkBmGwZZQGPGbBgXcy2pIssnyHakpW2KIt11MsQNoz4mUzcfh8j32XciY/TGtYuYEie0rW72rpt5\nMF2f+jih7Sr6WUc3oQJ+BmfNH40MlE277twvgQu813MCYX/xXi/00vpuBxmcj8z0/EMH7zWVrj+j\nawEyGy48m20ecrIFOQl4nmw9uYfRKLMo9oW29wIfRNYO3IFckII8hjxdxTZFlU+QkUhLOHiLJ4+3\nUK676qM5quJjmBuR2+hhDkGePPNixL7lyO3NOEYg3u6meTaySdRNc1TFzbx1ZRpM16dxVM3Purrp\nHwvK9zM3u5CFlYML3G5BBtP3d5DegzSeWJCnV9QxkO7twD2hsCOQ1kB4sPbdwLe811ORz34iclLG\nPeFkPVJBxBHXkpqNLI8R1ZJ6X0xaLs0tqfDs2qi/duQtnyycipy8JinSXSdD3DhMlHeSk+pjevL4\nOES6Xo2ZiIuXBMKOQT7Pxzs8dhROaFvd7F03o0j7+U3Xpz5OaLtq1/K6uwn19pOxSKs+PLj2EWS2\nHDS66NMwgLQWLva2v5Qjb06GdF+LLP4cZATyi/2jofCLaL0tNglZxPd0b/uLoXxEzTAcRePLjOMK\n5JnRIIOKr6N5bMka4N2B7auBV8Wk5dJ5l77N8knLDpJnE2alaHedDHFtl7dDq5PqYzby+DhEus9+\nDXIheH8gbDOS97xDl4I4gdfqZm+72Smm69MgTuB11a7ldXITKuiniclKs5Av4tuBsKnAwcgA2GXI\nYNe0+Hn6E9I1/YCBPLZLdz7wEI2TxWcG8BJaW2Pzab0tNoi0Cu4C3gz8zgsfhwyqvj8iT0uQVkgS\n1yIDmcd6rzcjS0D4fAbp4l6BlPtozD/yzGb5pGUQWRLkXxnfl0SZ7pblI8Q7qT6mZxDzPkbxELAW\neaQiyNi4i5HeBNNDl3zUzc7pJTfDmK5P46jatbwubkIX+3klMlZgTCBsCvAP5MvppNW+GhlP8jny\n/Vh2UqZ7JJLfh0PxlyCPJtsvIt3zQ2H9wDeR1tm6QPrvAL4Xk79baS63OJaQbv2xu0genO7S2pI6\nznvvOqS7fQ6t2Cwfn1OQ1tfZRN+S+CSyCLBJinbXSRnXdnnHOak+NrDt4xDpejX6gU8gPSRfQMaS\nRZVJXpzQtrrZu26mYSMy0SaIjfrUxwltV+laXhc3wb6f7dyEYvysFE7G+FdayMNGosdCDCInUVre\nhiztMIvWJzKs9PYd0CYNl2aBB2h+TvWZyLIRU2Leb6N8QD7Dr73XL6f1ZB+JnJx1x8kY31Z5Rzk5\niProU4SPQ1TrCShOxvjqZve62Y65yESheZaPE8TJGL+oa/kg9XMT7JRPOzchxk9Tz5rvFka3j5KZ\nhcBZEeHLEenScg9ye+MsRLRhROQ9SC9JJ8/bnYas9XY98GdkEeIxSGvltoj4NsoHZLzJBOA3wA+A\nc0P7l9B8u6dXsFXeUU6qjw2K8PFppPeorqib3etmEhORVSBsDQsxRVHX8jq6CXbKp52b0KPXcidD\n3NnAuwwf/0AaXeADgfCRwDbDx0qDS3NLqg/p0vdbZkcR/4xgG+UTzMcYZCbdvTS37kAGgk+0dOwi\ncTLEtVXeUU6qj830io9BnAxx1c3edXMN8iPGobo9okVdy+voJtjzs52bEOOnlWd91pCRyHNgbzWc\n7vHIF3IssmagzyKSF78timFkzTB/eYe1wCaaB1GDvfIBOaGeRGZB7kQGcv8tsH8ashzIUxaOXVVs\nlneUk+pjg0HUxyTUTaEX3VyC3G59wVL6JijyWl43N8Fe+QyS7Cb0cN15RsnHPxxZ0HoNzT/6N9O8\nzlpRuMSPS1sOXEX6xY5NMYCcOMuQMTKrQnlYT3EL+9qmbB8h2kn1sUEv+RhE3WzGRd0M8krgnMC2\nQ7E9omX7qW4m085N6N66U8mIS7TAi2k8Tmz/mDhlMAoZ76J0Jy7qo1JNXNTNIOcBlyE/NtYCjyLj\nGfM84lHpDJd6uQlt/NTJSspc5FnAdwKTkSe5PI7IXjZLab8+m9JdqI9KVellN8OPeLwA2Er22eyK\nHarsJmjdqQTYRfPSENOAZ2h9HNiE4rMWyTVUJy+KedRHpaqom9EcjNz6fR74DtILpxRL3dwErTsV\nRVEURVEURVEURVEURVEURVEURVEURVEURVEURVEURVEURVEURSmC/wOumnJ1lMu6vAAAAABJRU5E\nrkJggg==\n",
+       "prompt_number": 47,
+       "text": [
+        "",
+        "                                                                              ",
+        "   2  2                       2                         2                     ",
+        "- \u210f \u22c5l \u22c5\u2758l,m_l\u27e9\u2a02 \u27581/2,m_s\u27e9 - \u210f \u22c5l\u22c5\u2758l,m_l\u27e9\u2a02 \u27581/2,m_s\u27e9 + J \u22c5\u2758l,m_l\u27e9\u2a02 \u27581/2,m_s\u27e9 -",
+        "                                                                              ",
+        "",
+        "    2                   ",
+        " 3\u22c5\u210f \u22c5\u2758l,m_l\u27e9\u2a02 \u27581/2,m_s\u27e9",
+        " \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "            4           "
+       ]
+      }
+     ],
+     "prompt_number": 47
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "Note this has not applied the coupled $J^2$ operator to the states, so we couple the states and apply again:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "apply2 = qapply(couple(apply1)); apply2"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$- \\hbar^{2} l^{2} \\sum_{j=m_{l} + m_{s}}^{l + \\frac{1}{2}} C^{j,m_{l} + m_{s}}_{l,m_{l},\\frac{1}{2},m_{s}} {\\left|j,m_{l} + m_{s},j_{1}=l,j_{2}=\\frac{1}{2}\\right\\rangle } - \\hbar^{2} l \\sum_{j=m_{l} + m_{s}}^{l + \\frac{1}{2}} C^{j,m_{l} + m_{s}}_{l,m_{l},\\frac{1}{2},m_{s}} {\\left|j,m_{l} + m_{s},j_{1}=l,j_{2}=\\frac{1}{2}\\right\\rangle } - \\frac{3}{4} \\hbar^{2} \\sum_{j=m_{l} + m_{s}}^{l + \\frac{1}{2}} C^{j,m_{l} + m_{s}}_{l,m_{l},\\frac{1}{2},m_{s}} {\\left|j,m_{l} + m_{s},j_{1}=l,j_{2}=\\frac{1}{2}\\right\\rangle } + \\sum_{j=m_{l} + m_{s}}^{l + \\frac{1}{2}} \\left(\\hbar^{2} j^{2} C^{j,m_{l} + m_{s}}_{l,m_{l},\\frac{1}{2},m_{s}} {\\left|j,m_{l} + m_{s},j_{1}=l,j_{2}=\\frac{1}{2}\\right\\rangle } + \\hbar^{2} j C^{j,m_{l} + m_{s}}_{l,m_{l},\\frac{1}{2},m_{s}} {\\left|j,m_{l} + m_{s},j_{1}=l,j_{2}=\\frac{1}{2}\\right\\rangle }\\right)$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAB24AAABKCAYAAABzXXRYAAAABHNCSVQICAgIfAhkiAAAIABJREFU\neJzt3Xu0LGV55/HvuQCCBxhQ8ShREE0QFBwVgyjiEVAEFYFBdJCAFxwTQUdFYxg1s01AEMU4Bh3v\nbqOjUYy3ZCJeoltE0WU0Rh0l3tJjYhSD0YATUSNn/ni67d69+1Jd17eqv5+19jp9qV3vs+t0/56u\n7uq3QJIkSZIkSZIkSZKkJbQZeHnTRUiSamPuS9LysgdIUprMZ0mSJCVna9MFLKG9gScDOxquQ5JU\nD3NfkpaXPUCS0mQ+S5IkSVpnrekCJEm1Wmu6AElSY9aaLkCSNNFa0wVIkiRJozY3XYAkSZIkSZIk\nSZIkLTs/uF3Mw4AvApc3XYgkqXJmviQtL3uAJKXJfJYkSVKn+cHtYj4M/Bj40Jzlzq+hFklStbJm\nPpj7ktQ19gBJSpP5LEmSpE7zg9vF3Br4j8DVc5a7bQ21SJKqlTXzwdyXpK6xB0hSmsxnSZIkdZof\n3C7mGOBa4OYC69gdeCZwCPDs/nVJUnrKyHww9yWpjewBkpQm81mSJEnSr1xOvLCfZ6XiOiRJ1cua\n+WDuS1LX2AMkKU3msyRJkjpta9MFtMzxwGPHbrs9sdOwaeS2o4FbjVy/Cbi42tIkSSWblPlg7kvS\nMrAHSFKazGdJkiRJAOwH/H3/8rY5y67MuG/njB9JUhoWyXww9yWpS+wBkpQm81mSJEmd5zduszsa\n+BhwX2Dv/uU8tgDnMTx/ymXFS5MklayszAdzX5Laxh4gSWkynyVJktR5m5suoEW+RHzQfSywVmA9\njwDeR+wUHEnscEiS0lJW5oO5L0ltYw+QpDSZz5IkSeo8P7jN7pvAOcBLgVvmLPvTGffdFfjP/cvf\nAu5UvDRJUskWyXww9yWpS+wBkpQm81mSJElS6XYD9uxf/hBwxwZrkSRVz9yXpOVlD5CkNJnPkiRJ\nStKWpgtYQr8Efg48iDhC9IPNliNJqpi5L0nLyx4gSWkynyVJkiT9yt7A7zddhCSpNua+JC0ve4Ak\npcl8liRJkgTAecAu/Z/jG65FklQ9c1+Slpc9QJLSZD5LkiRJ4kzgRuAG4EfAPZstR5JUMXNfkpaX\nPUCS0mQ+S5IkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIkSZIk/cpm4E3AYU0XIkmSpMocArwN\n2NJ0IV1xHbCzwp+X1venSJLmMPMlaXnZAyQpTV3O59cApzU4viRJkupxGvBmYFPThXTB4xi+mP9/\nxCfj82wBbgXsCexPHDl5HPBfif+Y60fW+S/AHqVXLUnKw8yXpOVlD5CkNHU1n58OXNzAuJIkSWrG\nJcBzmy6iK97A8AX9l4DdC65vK/Ao4BP9dT614Prq9Erg2U0XIUkVMvOHzHxJy8YeMGQPkJSSruXz\nIcAXgN1qHjc19hpJy84clJbLrYCvAIc3XUgX7AF8leFOwmtLXPeziJ2OtjiAeHDV5fwax5IkMPNH\n1Z35YO5LapY9YMgeICklXcvna4EH1zxmiuw1kpadOSgtn4cCf4NTJpfiMOCnDHcSHlviui8ipuzR\nRitNFyBpKZn5zVlpugBJS88e0JyVpguQlLSu5PNpwMdrGksbrTRdgCQ1bKXpAiRxDXDm+I1bGyik\n7b5MTFvw6v711wGfA75dwrovAk4vYT1VOoOYwucY4CkT7t8XOIc4YvQlwKHEuWQOBP4c2A4cDNwI\nvKykmpoYU9JyMPPTy/wmx5W0XOwB6fUA818SdCOfN/XHemYNY6UsxV7T5LiSlo85KC23i4E/Bt4F\n/HtTRRxJTD2zAnyECKS2ejfDozs/B+zabDm1OBI4AdgMfH/KMucCuwDfAM7q37YH8DPgqP71Q4mp\njRaxMuO+qsYE+DRw2xy/J7XF2aQxHUPq/cHMn6zK/F2ZcZ+5L+WTSuZnlUpvsAdM1kQPqHJMsAeo\n29rWA7Jocz4/FPhmCetJpVfmkWqvqXpce426LOVek2JemoNS9+TJwW8DJ4/eUOc3brcBpwK/179+\nBnAV8OvAdzOu40jgAcDewAOBPwSuLrfMzM4FjiDmnz8CuIzuHyn5HeCzwL2Br01Z5p3AfkSQv61/\n272Iubqv7V8/Avg/M8a5PbEtRx/gR7N+nv+biKMRyhpzmjsSj90bcvyu1AZ3IqYC+2iDNZTRH6pm\n5k9WVv6a+1I9Usj8rFLqDfaAyZroAVXmP9gD1G1t6gFZtTmfzwXeUXAdZfbKJt5vS7XXlDnuJPYa\ndVmqvSalfYtR5qDUPXly8B3Ea8MPVFLRHIcDtwB37V/fizgq8oyMv78NuHTk+hnAvwH7l1VgDkcB\nv2B4hOejGqylTs8GXjTj/rOBt45cfyExBdDAVUSz3GeBMVfm3F/FmAA9YgoIqY32JI5Cv/OMZe4A\nvL2ecqYq2h/qYuZPVlX+rsy539yXNpqX+1Vn/jHAbxE7HG8Dji+wrtR6gz1gsiZ6QFVjgj1A7dWW\n1/1VaGM+bwNuBu5ZcD1l9cqm329LsddUOW4Pe43aq+n9jbxS27cYZw5K7VFFDh5GTJN8mwJ15baJ\nOIJvcFTHPYiAvHfG3081YC9kuIPwQ+IT9a77AHBs//KxwP3G7n8LMQf+wCeAHf3L+xBH0+wCXNC/\n7SLgBXPGXJlz/6JjZtXDRqJ2Opd43uxk/mP4T4kj75pStD/UadkzHzbmfhWZD+a+tKisuV9l5t/A\n8Hn5GOJN3z1zrivF3mAPSKMHVJX/YA9QO7XpdX9V2pbPJzN9SsxFlNUrm36/LcVek2fcrHrYa9RO\nKexv5JXivsUoc1Bqhypz8AfAY3NVlcGtgd8kphmY563A5QusO9WA3Ux87Xmwk3ANsKXRiqq1hXgQ\n7d6//nbgPWPLfIo4sgDi/+urDM81sztxAvOnAIf0b7uImFphlpU59y86ZlY9bCRqtyxv4DyMeLOj\nSlX2hzote+bDxtyvIvPB3Jfympf7VWb+PYm8Bzid+AbUrA9u29Yb7AFp9ICq8h/sAWq3VF73N6Ft\n+fwqYgrKLOrolU2+35Zqr8kzblY97DVqtyb3N2Zp277FgDkotU8VOXgl8Ma8Bc3yaODzRNEPnbPs\nk4lzj8w6Se//IkJrJ3CXCfenFLDbgesZ7iS8uNly5roHsf0/SezcXAm8ntjOm4ijabZP+d0jiNAe\ndc6kBRfwQeafsPl5BccYd1z/50LiyKBpemRvJFcAXypUlSZpcrvOy6F5UnhMZHkDZxPwERY/cXpW\ndfeHqrUt8yF/7k/KfCiW+1kyH9LP/RSe313U9HZdhtyvOvMH3g48f8b9ZfeGutgD7AGQxnO9i5re\nrm3vASm87m9Sm/L5i8S0mPNU3SunPWbzvN9mr7HXtEXT27XtvQbS2d8YVce+xbxtbw6ag23R9HY1\nBye7gOnnui7s5cBPgN1mLPNIIiAhTn594IxlLwf+YcLtKb15M3ACMbXMzv6/85pEE/YiGsZ3gLNY\n//90O+JInjcD14393i7AG4hvTLwceOrIfVuA3ylQ03aicdXtMuAS5h8R1CP7B7dvBP44f0maount\nOi2Hsmi6dsj2Bg7Ei7UTKqyjrv5QlzZkPuTL/VmZD8Vyv6nMh/JzP4XndxelsF2XIferzPz7AM8h\nsmePOcuW3RvqYg/Ixx6geVLYrm3uAam87m9SG/J5V+DnwMMzLl9lr5z0mF30/TZ7zZC9ph1S2K5t\n7jXQ/P7GNFXvW0zb9ubgkDnYDilsV3Nwo5OI89zeKmdNE+0L3Nhf8S1ESP4E+MrYcg8mwnF7/+cU\n4KgZ6/0c8Lax21J882bgMoZHd34fuG2z5axzF2I6g08z/STHdydqv2Ls9tsQR/48A3jW2H2PA/Yv\nUNcTgDOBAwqsY1GnEk+aBxJHP83SI63HWBGHA1ubLqKFJuVQm2R9A2c/Yv79stXZH+qWcuZD/tyf\nlflQLPefQP2ZD8uZ+2Z+finkSxFZcr+qzB/1X4ij3rdNuK+q3lAne8DinoA9oC72gPza3APqet2f\n+uMr9Xy+F1HbvCxsolcu+n6bvWbIXqNFtLnXQD37G4s8vprctzAHh8xBLcIc3Ogu/fXeJ2dNE+1G\nnA9jJ/Dfgbv1f+4wssxBwE0MX0APfvaass69iMB9yshtKb95A3G0zGeJv+vTlPzpeAH7An8HfIM4\ncfgs1xFBW5eziaOKDqxxzAcQDfAk4MQ5y/boRiMBWKU7f0tdJuVQ22R9Awdiqoo7zF1qMXX1hyak\nmvmQbu43kfmwnLm/Sjf+jrqlki9FZM39sjP//sQUlYOpjgZvUJw+YdkqekPd7AGLswfUZ5Vu/B11\na3sPqOt1/+oC4zQh5XyGeB/rFua/0Vt3r1z0/TZ7zXr2GmXV9l4D9exvrGYcA5rbtzAH1zMHlZU5\nONmu/fWWnhWn9ld875LW94j++n6jfz31N28GXkIEdkpHdb6D2FbHZVj2k8B/qLacVunRnQBepTt/\nS13Gc6iNFnkD51jgBRXUUHV/aFKKmQ/mfhE9upGVq3Tj76hbSvmSV9bcLzvzjwA+xnBqsJOIqSDv\nNmX5sntDE+wB3dOjG9m5Sjf+jrq1vQfU9bp/dYFxmpJqPgM8DfhhxmXr6pV53m+z1+TXI/3nUBar\ndOPvqFvbew3Us7+xmnGMgSb2LczB/Hp0Iz9W6cbfUTdzcLp/Ac6Dcr/KfQzxQu9LxFEmrwROA95N\nvpNpPwT4HvD1/vVvE/O+p+zxwJOII0xuaLiWgSOJo10+CfxVhuWvAH5caUXdcjjwROLIie8Dz5yz\n/KOB44npkc4hjs56DPFkfwDwMuIE8s8ips3Yjzja4onAL8ovP9k6F92uVRnPoSxSqf3xwNH9y5cC\n17BxGvRxHwcuBF5MHAVelqr7Q1NSzHww96tk5nc782G5cr/szP9r4E3A+f31HU1MufjNKcuX3Rvq\nZg9YPvYAe8AkKdSf0uv+FKSazwPbgX/OuGwVvXLSY3bR99vsNdWx19hrJkml/qb3N2apat9i2rY3\nB6tjDpqDk6RSf9U5+APitWKpPg9cRYTjG4BDgfcDP8q5vr8mjlxpi2OAfyXmcU/Ja4kAaMMbYCnq\nMf3oiTsCrwA2A/cgtvNhM9a1a395iHncrwEuADb1b3se8eS8fGTMLcQLjzL+/1bJdiRI03Uuul0n\neRPwxQV/dkxYz6I5VEbtZdafx3OIb0mVqYv9IdXMB3O/qB6Ts9LMTzfzwdzPq4rMz6rs3lAne0B3\n9bAH2APqrb+Nr/tXSffbJSnn88AfET0wi7J7ZVnPOXtNMT3sNfaa9ta/qLp6TRX7FrO2vTlYTA9z\n0Bxsb/2LWiQH/4Z4rViavYBfAi8ELmF4pN7fAp/Jsb69iXmuf7uU6qr3G8QRk2c0XcgE3yAezL/W\ndCEt1WN6AP8Rw2kuTia288Ez1vVQ4jxvm4ipkd49dv+zicf9fcdu/zHwu1kLnmGVbM2k6ToX3a5V\nyZNDqdRexG2BK0tcXxf7Q8qZD+Z+UT0mZ6WZv17XMh+WM/fLzvysyu4NdbIHdFsPe8Aoe8BsKdWf\nR94esEqaH9ymns8D/5M49+48VfTKsh6z9ppiethrRtlrZkup/jzq6DVV7VvM2vbmYDE9zMFR5uBs\nKdWfxyI5eC3xWrE0JxEb7M3EuTEAbk98/feSHOt7ZH99h5RSXbVuS0wBV8aTqAo/BX6Scdlfr7KQ\nluoxPYDvPnL5ZcSRMbPcAdid+Gr/TuBBY/e/g407cAf1l33E/FLnWiVbM2m6zkW3a1Xy5FAqtRf1\nZ8RRimXoWn9IPfPB3C+qx+SsNPOHupj5sLy5X2bmZ1V2b6iLPaD7etgDRtkDZkup/rzy9IBV0vvg\ntg35PPAm4BMZlquiV5b1mLXXFNPDXjPKXjNbSvXnVXWvqWrfYta2NweL6WEOjjIHZ0up/ryy5uDV\nwBth/TluDwNex/Ar2vN8keEn48eM3Pbt/uXj++v6y4zrG/UQ4Hrgazl+t067Ae8DPgJc1nAt09xI\nHHU0z67A04FnVFtOp1w3cnkH83e+vtf/91iiwX927P4dxIuMUQ8Hbs6w7lFvIebLH3dn4DeBn0+4\n78kMp2uqq85pFt2uVcmTQ6nUXsRW4uinwXQyRXoDdKs/tCHzwdyviplfrM5pUsrNZcz98cyH4rmf\nRdm9oQ72gOVmDyhW5zQpZag9YKOij6+6tCWfB34O7JJhuSp6ZVmPWXtNNew1xeqcJqWsttdsVEav\nqWrfYta2NwerYQ4Wq3OalHLEHJxtFyY/nnL7NPE17z1GbnszcAMxH/eiPg+8q3851W/dbiKOhvjf\n5PsbJ9mV8ufGfz9xAus95iz3XOA+JY+9iM3Ayxscf5oe84+cGXzF//yM63w/G09cfwhxtMnDxm7/\nCPDe/uUDiMfaw4gXI5dnHG9glcWOjC5aZ1HTtuuexJQSd57xu68n5stf5OfBY+sokkPTaj+SOMn8\nCrHNjmGyovXvzPAzzSmUe4L3rvSHtmQ+mPtF9ZidlXVnPuTL/VWWJ/MhzdzPmvll1J8398vM/EVq\nKLs3VM0eUD57gD1g1DL3gDa+7l8lnW/ctimfB7Ke47bKXrlolo2z1xTTw16Tt84ilrnXlFF/3fsb\nq2R/fFW9bzFp25uDxfQwB/PWWYQ5mH4OlnqO2z2IT4HH517+B+Ct/csHkd024oiV8/rXX1Oouuq8\nGPgCUW9ZnkfMd16mHcTUEE+bscyjiQd4U/Ym5nL/QoM1TNNjfgA/gnhi3nPs9oOBW43dtpk4uuKF\nY7c/jXge3Xrktn2JMBo8Jl49ct8aGwN9nlWyN5Oy6pxl0vYZNWm7nksE8U6qfbNgXg7lqX0bcOnI\n9TOAfwP2L1Rp+d5D/J+WoUv9oS2ZD+Z+UT1m50sTmQ+L5/4qZv4iys79Zcz8rMruDXWwB5TLHmAP\nGGcPaEbeHrBKOh/ctimfB/6A9d8cmaTqXjkty7Lagb2miB72mgF7zZC9Zr1Vsv2f1LFvMemxswNz\nsIge5uCAOThkDsLfAX9Y1sDHERvsxJHbDujf9lTgLOBOC6xvcELxE4hPzJ9QSpXlehLwHWJ+8rKc\nBXyfOLqzbM8BbuqPsXnk9tsRD4SnVzBmHmtNFzBBj/mh9VLgn1k/peBDiOfA+Imn78vkueyvBD41\ndtt9+svuBdyPYajdmjg5+awgm2SV7AFcRp2zTNs+oyZt14Gqm8msHMpb++HEi7q7joyxk2gqqTiQ\neJyUpSv9oW2ZD+Z+ET1m50vdmQ/5cn8VM38RZef+MmZ+VmX3hqrZA6qz1nQBE/SwB+Stcxp7QPd6\nwCppfHDbxnyGeIP2h3OWqbpXznrOZWWvya+HvSZvndPYa5a319SxbzHtsWMO5tfDHMxb5zTmYDdy\n8Edk+//O5EXEfNu7j9y2P7ER30++qSyfQ8xB/z9YH3wpOI742/IemThqE/H17fcSD6orSljnNEcT\nX3n/PPAh4klwOWmdIH2t6QIm6DE/tD5HnGB61KHE4+Tvx24/GfgKG3cE14gXFKO2EP9PryGOfBk8\nF04EPjinpklWyR7AZdQJ8Chix/S3iB3rgWnbZ9Sk7TpQRzOZlkN5a99ENKVBc7kH8Xfcu4xiJ1hk\nqoiBi4EHllhDF/pDWzMfzP28eszOl7ozH/Ll/ir1Zz5Mzv02ZD6Um/t1Zz4snvtlZ/64y4kcGldF\nb6iKPaBaa00XMEEPe8DAGvYAaEcPqPt1/yrNf3Db5nw+hXiTceuMZarulbOec4uw1+TTw14zsIa9\nBtrRa6De/Y1Vsv2f1LFvMeuxYw7m08McHFjDHARzEOKxsRM4NW9xy2zwADo+4/KbiA1+a+Jom4OB\nBxBfQX8V8C3Wz4F9RMn1ts1a0wVM0GN2aO1FTF0w7STzLyq5HogXAG04F9GewJf6l2/H5OY3bfvM\n2651NZNZ8tY+8FYWP09xVnmmitgKfLiietrKzK/eWtMFTNBjer40kfmQL/dXqT8n5+V+mzMfiuV+\nlZkPi+d+1Zn/YOB6YgqxtrIHVG+t6QIm6GEPyMseMF3XXvev0uz/Sdvz+V40+7jOur/aFWtNFzBB\nD3tNXvaa6bq2v7FKGv8nXcjMtaYLmKCHOZiXOThd23PwIOL/ocnzYrfS7YlP/HdW9PPl+v6UzPKc\nlLuItZrGWUSPjaF1OrGzBzEdxi+Bu0z5/Uun3F7E3wJ3z/F7rwS2l1zLLLsT2+/LwMuI59C40e2z\nyHZNoZnkrR3gycBlFJuaapY8U0WcxsaT0y8zM78eazWOlVWP9fnSdOZDvtyvO/Nhfu63OfMhf/1V\nZz4snvtVZv7exM7UGu394NYeUI+1GsfKqoc9IC97wGRdfN3fxONroAv5vCtxLruTahhrYNH91arY\na0IPe01e9prJuri/0WSvqTIzzcHQwxzMyxycrAs5+Ajiw+lFT4+59F4FXFfhz2/X96csZI3FTspd\ndKzU9FgfWocRT8iLiDcmv8n0I0EeBDyu5Hr2YzhlwLaS1122TUQzOQX4GBsb6+j2WWS7QvPNpEjt\njySaCUQQH1hBfXmmingvUb+CmV/feKnpMXxeNp350J3cb3PmQ/7668h8WDz3q8z85wK70e4Pbu0B\n9Y2Xmh72gLzsARv5ur98XcnnLxJTBdZh0edc1daw1/Sw1+Rlr9loGfc3qlRHZq5hDvYwB/MyBzfq\nSg5eAHwtd3VaKnlOyp3H7sRUBNcDz2b9eQma1mP9k30b8FHg1cD7gCdO+b2twMsp/yiP04A3Eic0\nP7bkdZfpQOCHDOftfwzrjzAZ3z5Zt+tAk82kSO0PJhrJ9v7PKcBRlVU6NG+qiIOAN9RQh9JWV+ZD\ne3K/6cyHbuR+mzMf8tffVObD7NyvMvNPZni+wTXa+8HtMrIHhB72gDwOxB4wztf9muVVxDkR67Do\nc65K9prQw16Tx4HYa8Yt4/5G1arOTHMw9DAH8zgQc3Bcl3LwXcTjEKj2q8NqvxOJqe5OnHDfvsA5\nxJPjJcR5ZvYknuB/TjxRDgZuJL62X5a6x+0Rbzr2SlhXGe4GvJA4mfnlxNfzU7SNaBz/COxBvDB5\nBdEEing8cDRxJPQ7gWuAKwqusy4HEdNujB+5tTfxeK3Kk4nnxPOYvv0vIZrgZyusQ+kz80MPcz+P\nKnLfzM9nXu5Xlfl3JM43+Cf962vACmke4a2N7AGhhz0gD3vAer7u1zwnE2/m7dd0ITWz14Qe9po8\n7DXrLeP+RheYg6GHOZiHObhe13LweiIf3lm4OnXerJNynwvsAnyDmGMcIjB+xvCohkOBr5ZcU93j\n9mh+mgApryxTRewCXFVXQUqamR96mPtqr3m5X2XmPxG4EPi9/s8/Aa8jztOi9NkDQg97gNrJ1/3t\nsg24mThX2jKx14Qe9hq1V5P7G11gDoYe5qDaq4ocvCdxftvbFKpMS2PWSbn3BPYHvjty21HAZ0au\nnw1cmWGcnTN+qhw3ix42ErVT1qkiTgd+p8a6lK66Mh+y537dmQ/mvtorS+7Xmfk9nCq5TewBoYc9\nQO3j6/52+lPg4qaLqJm9JvSw16idUtvfaCNzMPQwB9VOVeXgRcAHRm/YmrNAdd9+wF7AdcTRoD8Z\nu/8m4FTiJNgDxxNzjw+cCbwW2Af4EfEAvLn/76gtwHkM59q/bEZdecYt4p/Y+LdLqTsI+AsmTxUx\nbgfw36ouSMmrIvOheO7Xnflg7qudsub+DqrP/F8jpvfZDlzQr+kvKh5TxdgDhuwBahtf97fX64mZ\nKZ7fdCE1sdcM2WvURintb7SVOThkDqqNqszBM4Fn5Sur3V5JnIRb2U06KfexwP1GlnkLMQf+wCcY\nfrNiH+AG4qvhF/Rvuwg4YsK6HgXcqX/5z/pjjio6rqTlYuYvrorMh2Huj69rVu6b+ZKKsAcszh4g\nqQ7m83qbiHPpPbzpQmpSda8ZX5+9RlJqzEFJkzwc+BZL+iXbA4j5plN0ftMFTHE3IrSfC2zu3/Z2\n4D0jy3wKuEP/8iZirvtd+9d3J05g/hTgkP5tH+wvN76uZwK/2798GfEV81FFxz2u/3Mh0WQkdZuZ\nv7gqMh+GuT++rlm5X8a45r60vOwBi7MHSKqD+bzRKcDVDY1dt6p7zfj67DWSUmMOSprkk8Djmy5C\nG600XcCCzpm/yETbieY0aV27EfPpA3wIuGOJ40I0p0tY31wkqQkrTRewoCLZO577o+ual/tFxgVz\nX1KaVpouYEH2AEnLYqXBsa8l3vheVmX2mtH12WsktYU5KC2v44hzX28ev6PrX789gwipY4ijQgb2\nJY5u2TTpl/r+HXgR8Iv+8ucQJx9+CXAoEXwHEkecbAcOBm4EXlZS7U2MOc8WYI+cv/twokkcAPzf\nsXX9rP/zIGCNmOe+rHFPBf6KmDf/D4DH5FyPpPS1OfMHdaaU+0WyF9bn/j+OrWtW7hcd19yXlpM9\noFz2AEllMZ9nexLwDuD+xDkKl0mZvWaR95nsNZJSYQ5Ky2s34BXA2cAtDddSqyOBE4hPq79fcF3n\nEl/5/wZwVv+2PYjwO6p//VBiGoFFrTQwZl6PA/bP+btnA08ldm4mrWtv4PcrGPcB/d8/CTgx5zok\npa/tmV/1uHkUyV5Yn/uT1jUt94uOa+5Ly8ceUD57gKQymM/ZnA9cWuD326rMXjNpffYaSakzB6Xl\ndTHwvKaLaMJgXvZ7Ax8vuK49iTD77shtRwGfGbl+NnDlnPXcnphC4NKRn2vGrj+/5DHb4jxiZ2gX\n4PiGa5HUPm3P/DLHbQtzX1JZ7AHtYw+QloP5nN1rgP9UcB1az14jadmZg1KaTgVWmTHzTJenSv5e\n/9+HAFeP3Xcb4Dlkn5LnJmJjfmzk/uOBj45cPxN4LbAP8KMp67yeOGH3qBUmH91Z1phtcCax4/Qi\nYqqGBzVbjqQWanvmU+K4bWDuSyqTPaBd7AHS8jCfs3sa8Abg68CXc65DQ/YaScvOHJTSdAhwOnEq\njp0N19KoDwDHlrCet7D+pN2fAHb0L+8D3EAcvXJB/7aLgBdkWO9KiWNBlOvwAAABg0lEQVRK0rJr\nKvMhW+6vVDCuJCnYAyQpTeazJEmSlNHmpguo2Bbg/sC1JazrbsCH+5c3AbcDPt2/fnN/jCcAfzny\nO1c1MKYkLaumMx/MfUlqij1AktJkPkuSJEn6lSOATzU09geZPeXPQNknID6u/3MhccSnJC2LJjMf\nsuW+mS9J1bAHSFKazGdJkiRpAV38xu0uxHlB9iTmcv+TBmrYDvyAbHNUv6TksU8gzrfyPuI8MJLU\nZSlkPmTPfTNfkspjD7AHSEqT+Ww+S5IkKactTRdQgX2AZxA7CjcBVzRQw+nA14EbgX+tcdxT++N+\nhTiy88oax5akJqSQ+dBM7pv5kpadPcAeIClN5rP5LEmSpJy2Nl1ABX4IPLDhGm4hjizNMlVyma4H\n7kx8IP+mmseWpCakkPnQTO6b+ZKWnT3AHiApTeaz+SxJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJ\nkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJkiRJ7fL/AWERTP06yLvtAAAAAElFTkSuQmCC\n",
+       "prompt_number": 48,
+       "text": [
+        "",
+        "                                                                              ",
+        "                                                                              ",
+        "                                                                              ",
+        "                                                                              ",
+        "                                                                              ",
+        "           l + 1/2                                                       l + 1",
+        "             ____                                                          ___",
+        "             \u2572                                                             \u2572  ",
+        "              \u2572        j,m_l + m_s                                          \u2572 ",
+        "   2  2        \u2572      C             \u22c5\u2758j,m_l + m_s,j\u2081=l,j\u2082=1/2\u27e9    2          \u2572",
+        "- \u210f \u22c5l \u22c5       \u2571       l,m_l,1/2,m_s                           - \u210f \u22c5l\u22c5       \u2571",
+        "              \u2571                                                             \u2571 ",
+        "             \u2571                                                             \u2571  ",
+        "             \u203e\u203e\u203e\u203e                                                          \u203e\u203e\u203e",
+        "        j = m_l + m_s                                                 j = m_l ",
+        "",
+        "                                                         l + 1/2              ",
+        "                                                           ____               ",
+        "                                                           \u2572                  ",
+        "                                                            \u2572        j,m_l + m",
+        "                                                    2        \u2572      C         ",
+        "/2                                               3\u22c5\u210f \u22c5       \u2571       l,m_l,1/2",
+        "_                                                           \u2571                 ",
+        "                                                           \u2571                  ",
+        "       j,m_l + m_s                                         \u203e\u203e\u203e\u203e               ",
+        "      C             \u22c5\u2758j,m_l + m_s,j\u2081=l,j\u2082=1/2\u27e9        j = m_l + m_s           ",
+        "       l,m_l,1/2,m_s                           - \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "                                                                              ",
+        "                                                                              ",
+        "\u203e                                                                             ",
+        "+ m_s                                                                         ",
+        "",
+        "                                                                              ",
+        "                                                                              ",
+        "                                                                              ",
+        "_s                                                                            ",
+        "    \u22c5\u2758j,m_l + m_s,j\u2081=l,j\u2082=1/2\u27e9                                                ",
+        ",m_s                                l + 1/2                                   ",
+        "                                      ____                                    ",
+        "                                      \u2572                                       ",
+        "                                       \u2572       \u239b 2  2  j,m_l + m_s            ",
+        "                                        \u2572      \u239c\u210f \u22c5j \u22c5C             \u22c5\u2758j,m_l + ",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 +        \u2571      \u239d       l,m_l,1/2,m_s          ",
+        "4                                      \u2571                                      ",
+        "                                      \u2571                                       ",
+        "                                      \u203e\u203e\u203e\u203e                                    ",
+        "                                 j = m_l + m_s                                ",
+        "",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                    2    j,m_l + m_s                            \u239e",
+        "m_s,j\u2081=l,j\u2082=1/2\u27e9 + \u210f \u22c5j\u22c5C             \u22c5\u2758j,m_l + m_s,j\u2081=l,j\u2082=1/2\u27e9\u239f",
+        "                         l,m_l,1/2,m_s                          \u23a0",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 ",
+        "                                                                 "
+       ]
+      }
+     ],
+     "prompt_number": 48
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "We now collect the terms of the sum, since they share the same limits, and factor the result:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "input": [
+      "subs = []",
+      "for sum_term in apply2.atoms(Sum):",
+      "    subs.append((sum_term, sum_term.function))",
+      "    limits = sum_term.limits",
+      "final = Sum(factor(apply2.subs(subs)), limits)",
+      "final"
+     ],
+     "language": "python",
+     "outputs": [
+      {
+       "latex": [
+        "$$\\sum_{j=m_{l} + m_{s}}^{l + \\frac{1}{2}} \\frac{1}{4} \\hbar^{2} \\left(4 j^{2} + 4 j - 4 l^{2} - 4 l -3\\right) C^{j,m_{l} + m_{s}}_{l,m_{l},\\frac{1}{2},m_{s}} {\\left|j,m_{l} + m_{s},j_{1}=l,j_{2}=\\frac{1}{2}\\right\\rangle }$$"
+       ],
+       "output_type": "pyout",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAioAAABKCAYAAACVW3/AAAAABHNCSVQICAgIfAhkiAAAE+VJREFU\neJztnXmUJWV5h5+enhkcZssMywzrDCORMDoIETOCMBvIEnYOIkGCIHBUIEoQMkHU0yQjwpDROEEM\nitCEiBpQFkUWBZtF0BAMWxQFpROVLSKbKJuQP351c6tvV93aq25P/55z6nRX3br1vVXd31fv937v\nAsYYY4wxphATgE81LYQxxhhj6mVi0wKkYCZwDLCsYTmMMcYYY2IZaloAY4wxxtTLhKYFMMYYY4yJ\no2pFZQ/gbmBNxe0YY4wxZh2kakXlBuBp4PqE806sWA5jjDHGjEGqVlSmAtsDtySct2HFchhjjDFm\nDFK1orIEuAN4ocA1pgAnAdsCJwf7xhhjjDGFWYOUjCQGKpbDGGOMMWOQqvOo7A68q+PYHKS89IWO\n7QK8LrT/HPCJakUzxhhjzHhmY+Dh4PdpCecOdPnstS6bMcYYY9ZhqrSo7ALcBLwFZZe9Ked1+oET\naPumrC4umjHGGGPGAlU6096LFKEVFMsquw9wJVJQFiPFxxhjjDHjgCoVlYeA9wDnAK8mnPv7Lp+9\nHviL4PefAVsUF80YY4wxphzWA6YHv18PbNqgLMYYY4ypkf6mBUjBH4CXgF2RZebaZsUxxhhjjBnJ\nTODjTQthjDHGGBPFCcCkYNu9YVmMMcYYY/6fw4FngV8DTwFvalYcY4wxxhhjjDHGGGOMMcYYY4wx\nxhjTQzxA9zo9Rbdz6rsVY4wxxqxrHEZbqXge2DbFd/pRFeXpwGbAImA34EPARcDjoWv+Bli/dKmN\nMcYYM264gLZicS/twoJ5mQjsB9wcXPN9Ba9njBm7rAVObloIY8zYZn3gR7SVlfNLvPZfI+XHGDM+\nmYcssHVyYs3tGWNqYBEqOthSVt5V4rVXoaUhY4ypg4GmBTBmvDGxhjbuQ+bZ84L9zwN3Aj8v4dqr\ngENKuE6vsgg4AljZtCDGxLARsBo4DnilpjYPRcVKlwTtdjIbVW5fCpwNLER+b/OBbwBzgW1QIsl/\nKEmmJto0xpTM5bStKncCk5sVpzYWo2WqAeDbaHBNwxzgu9hh2PQ+R6AJSB0sBvYEJgCPxZxzLCq3\n8SCSDdSPXgR2CvYXomXprAw00CbA7cCGOb9rTK9zJNDXtBAAfwQM01ZW/rFRaephGnBWaP9Q4Hco\noimJb6EBuQryKk9G+PmN5uvAwTW0s0nwcwekyEfRihr8VejYTsD3Q/tHApcltDUH+CTqw63tto79\n00tuM45hZJ0xZl3kdHqojt9OwMu0lZX9mhUnlunIArRlwetsB7wKvD7Yn4Hu+9CE7+0N/HvBtuMo\nojwZP784dkbLuXVZSk8Gzujy+ZHAJaH9j6Gl4hbXAQcBszK2O9BAm2BFxYxd0rxPNwEurUecdJxG\nW1F5EtiiWXFGcSwajF6j+MDQh2bfLZPWG4Pr7pDwvRuB9xZsO468ypMRfn7x/BDlT6qDq4EVof0V\nwFtD+xcjn5EWNwPLgt9noSKnk4APB8dWAR9N0e5Al8+ytpmFYayomLFHlvfpV5AVsyeYAHyHtrJy\nG0r01mukVVSmAn8G/HGKcy8B1iScMw85Jc5Ocb085FWejPDzi+cUZDWomn7gCUbmZboULT+1+B7t\nZaI+5BvSsvZMQQ6ux9FORLkK2DFF2wNdPsvaZhaGsaJixi5p3qd7IENGzzCXkVlmz2xWnEjSPNgD\ngLuCc9+RcO4xKDoiyWHoeFR+IC2nkO6Pey7ReWfSKE9VU/QeqpbjS+jF+BqwVcdndT+/PDIW4W0o\nK/R5wc+vAm+OOXcJ8AJaHkvDG1GfuBVNXi4DvoDk70MWirkR39sRKQWdvCfiWFquJZ0zX9kReLsF\n22nI2hLHMOkUlar7yHil6edatH83LX+a92kf8vnrCafaFnsiE/prwc+kF33dpLWofAr4LQqXjGNf\npKiAElR1u+6XkQksDfNQeYKBFOd+EfinjmNplacqKXoPdcmxBvhFx7G6n18eGYuwA/BNRiZV+xwK\nsd0+4vypyBq4IuKzMDOQQvI/KEIm3Hc2QpaRixipsE9Cma6noz7XmZW6H/hAQrtxzEVKUROsRg67\nSVaWYdKNR1X2kfFMLzzXIv27afnTvk9XUl0QSW5W07aqPEZvhd8lPdjZaMB+BSlavw22+zvOW4pe\naHOD7UDa4YpR/Jj05q/PB3IOpDw/TBblKYntyJ+Tp8g9lEmSHHcC/xraL/P5pSWrjEX5NKOTNO4b\nHFsb852fAKd2ueZWaEnkdmCDmHP+JGjj3NCxDZAV5YMo4qqTw8jv0HwUcDhSBOvkIDQov53kaKBh\n1o2lnyJjxXin7P5dJ2kVlY2JmKhPKFuajJxOO7rl5+hFP1Z4HlmB+lH0wfbBFrYMLUAz0guAR4Pt\nCuC/Yq7Zh/6YcfkhwhwM3JRDbpDyNAe4BilPe9FeW8/DycDmOb5X5B7KJEmOGci6cHOwX/bzS0NW\nGcvgP5Ey/pvQsdayzu9ivvMU+r+PYjbyYZkE7IOc6aN4ACk8N4aOPYle6GuRAtXJVxgZGpyFV5Gl\npm7L4uPIyXYmcGHNbTdF3rFivFNF/+5FngD+QPXjaWbORkmSesmaAuk0wIMo15FyVnC9pGy705Dy\nA9mtEQuA52hbslrbjCyCdjBI9tlekXsokzRy7BN89gaqeX5ly1glq5EVMc5P5TqkjEfxZSRjmrIX\nt6LcS0YMs25YVAZZN+6jburq31WRJYp2BR0ReE2b4N6NwnB3RqF7vcC7gV2C31sJns6NOXcJemnd\ni5SMtWjmezn5HPtaWWifTTjvNLSuncR2wNFIO30MOAlZrqbnkK1sitxD3XIsR9awnwb7dT+/PDJW\nwVbo//p44J6Yc54ieklnMVqeuZWRlpI4zgWeziHjeCRrHzkAJdd6M/p7zgbeiV4mO6MU/9eiJbYN\nkDl+ctDGy+WL37NyVj32ZCFP/+4F+bO8T1t8F415ZyJrZ6MsAZ5B5tyxyl1oBjkLzXgXAlehwToP\nm6FO2M2ZaHtG+rDEzbA3Rdl/J9AOoV2UU64kBsk2S+qVe0grx38ga0AT9IKM+wJ/jxTyj9B9yfhL\nwA0Rx89HsheJzBnPDBPdx7L2kcm0s4LfiV4cH6a97LUSmd/XhNrrRxOyMv52g6QbK5qWs6yx50Lg\n7ozbsojrZO3fZchflux5OAX485KulZs3AP/L2E6SNQOtpX0MzXZbs+x7GJk2OwutpZ+45zIBRSeE\ns3/Gvbg+Tdt0vn9w3jY55UpikPSKSq/cQ1o5ZqKljveX1G4Wek3GiSh88PvEL9VeQfTSz4NIdvsn\n5GOY6D6WtY+8Ay0t9yG/n8s7Pj8Z/S+9peP408DfZBE4hkHSjRVNy1nn+JlEnv7dS/LnYUNCDuZN\nONNuiOrYnAP8WwPtl8Uu6PktQKGWzyEHy0XE1yBJ4mlUxCxubf59qKO/lOJa59M2nS9BiuFPcspV\nJr1yD2nl2BXN1JpwYus1GV9BlpXFwD/HnDMTOYl2sjlyQP9linbSJE80ImsfuR85gS9CSymf6fj8\nrSjA4a7QsQXo7xoXBFAFTcvZS+Nnnv7dS/Ln4dfo/ToL6vdRWQ+4Es3KVtfcdtm0CtHdjfw+QOup\nfUgRy8NrwMNEZ6Wdi5aWPpfyWuEcFMso5yV2MdFOlFui7LxRL9RjaA8mZd7DIhSumzZS427aM5Is\ncixHL94fp2ynk7xyliFjkWcEChOezMhEUXcHPw9GTr6dkXpbAtdHXPtZZIFMYjLwVygM2SSTtZ8/\nGvxcAfwe+EHH58tQDpswe6FEflnGkKJjRV1yxlHF+JmXPGNQL8mfh4lI6czrRpGbPrTGdg3lpcyf\nTLlr3p2RHFFbi9uRSXL90LGLkCZY5P4uJbo40xFIwbsytF0TyPRAsB9VvbZlNjyxgExJDJLOnNsr\n95BFjrtoW/7ypD4fqzLOQC+IV2jXNQIldWv1hZkd35mELIJRVVCvQg6O60d8FuZU4E9zyFsGE1Ay\nuV5kmO59LGsfuYrRTs3bor/rHh3Hv017OW8eGt/2QEpr1qzMg2TzZysqZ1HinmvawrVfQP4lWbal\nHdco0r+j5E9b/b2o7Fnep50cSEPOy2eiomVp02unYSXJobxVsD6aEXTOdn9Bu3pqXC6JJD4APJTy\n3Pkkh/a2wtrelFOeNAySP+RwPr1xD1FyTENWgBOC/bjljrqYT30yvg4pFg8y0sK3YyBD5wy39dlL\nREdFLUMe/Md3afMAopO51cFM5Pfww4baT2KY7n0sro9sw8jMwiCF7CnkXxfmePT3mxo6Nhu96Frj\n7Hmhz4YYrSwkMUg2f7Yy5OxG1PMJE/Vcyyxcm0RS/84q/1ip/v51QuNOXT4q70UzxH0oL6nbEWhQ\nu7qk62VhJzR7DLc9D63D34Zkyxsedw1ScuKydoaZ1PEzimXIylPn+nIWeuUeouRo9Y+H0Cwkr5N0\nWdQp4wvIj2wtI82vH0J9OCpd/RLgFuSv1ckQcnI8G/WP8NizEfJ92ZLoZG518AyypiSlBuhVljG6\njyxH1rdLOs7dAfnBDXUcX44ibJ4PHZuPLBM3IL+Q1vWnooi0W4oK3oUy5OxG3PMJs4zRz/UC6sv7\n1K1/55F/AeqHLSvpdahgZi9F385ndKLJytkNOfKUMRvuQ4PhFYxOsV0Fa2jHgIc5Aw3k4eqtm6H7\nvIri5vfv0N2EOwM57D6CnsMLwB3IXNbJncDXCsqTxCDZZxa9cg9JcpyCfI4+Q3OZnJuU8Si0ZHsJ\nMhN/lfikUz9AeRO6sQsymd+FfFkuQ/2sVxxoh5oWIIZhuvexqD6yEI1JD3cc3x85q07uOD5EdA2l\ny9BMfoD2/9feKIdJVgZJP1aUIWeL/ZAl5i/RxBnin0+YbmNPHRYViO/feeSvu/p72mWmMJ+gZsWp\n9SCj1qyj6EP/lFPRLGsblNjnWOCzwM8Yub6Vpix7XpYiB6ZlFbYRx56UYz2YgcyhVTsmDlJdh63r\nHkwxFqEBs/OlMtYYalqAGIaJ72NJfeSMCuRZQz4fgkHqz0w7nbZD+EaMVrDink/Sc61LUUkir/xQ\nbfX3PMtME4nOw1QZc9DAlcahJs92X4Wyz0R/3CGaUVQAvkG+hDeH0I6XPwKtb+YpC56FtShKpSya\nuAdTjCuoxl8sr9NmXoZqaicrw4x8KWbpI2fFHC/CPSgqLCtljxVpmIKe330om+2cjs/DzyfLc+0V\nRSWv/FVXf98O+aW1lplm0D1PGChAoMrAj1F8Fq2fVbVVmdzqVBRKPURzisrGyJQeFaocxyL0j7AK\nKVsPUc1sqkrWhXsYb+yPwqCrYojsTptF2upFhmm/FLP0kV1R6YIy2Zj2ckOZwRFV0YeUlQNRYc/w\niz38fLKOPb2gqOSVv47q73mWma5gdDShiWB/2v40QzSnqICWzrLMJKch/5bzUPjq0VUIVTHrwj2M\nJzZCzoVV5WSaihJXdYtsKIMpaCnjcRT9M6X76bUzTPtlkraPTEQOwmXPmA8Gvoiywq4o+dplMx+l\nkWgtSb6T9oy98/lkHXuaVlTyyr8UKSlzg+1AFCBSNUnLTAtoF18dQd1lzXudTZE/zb8E+0PICWio\nGXGMGffsjZZh9474bDbKo7QURRMtRP4I89HS6VxkBn8WmfzLool2h9Gkabik6xVhaxQyfD968TRe\nOK4L05Bi8kuUVmIqqoHTLYdHEq1Ce+9HzuVpCu31CgvQsl2nJWwm1Ua8HYP6xErin/0nkYIVlfrA\nhDgaFYD722B7BJm092lSKGPGMd2cNo9FodoPovV40MvoRdozxIXAj0qWqYl2h2l+mcGYPKRZZpqE\nQqVNDoZpdunHmPFON6fN6SiC4FehYzsxMtfEkYSKm3UhS/bMMttNyzBWVMzYI+0y0yFE52YC6q/1\nM1bYHJmb56LS4tOAbzYqkTHjj41RpMADRNcVeg44CDlIttgdrdO3OBwVaJuFEtetQnloVnVcqx9l\n/2z5pnSrRZan3aI8QnnJMo2pgwXovRm1zNTJMuAjWRtYixzKjDGmKaKcNlegzKMtLmZkva+baVtB\nZ6GsnJPQhAOkoLTyL4WvtR+wRfD714I2wxRt1xhTMvOo3ss+D7XGVxtjGmVrpBCcSjsj56WoDkiL\n7wGbBL/3Ib+QVoTHFOTcehztbNHX0g4iCF/rJJRaHGRN6cyQXLRdUJbu3ZAfXLeSEcaYMcxA0wIY\nYxonb8X0uUjxibrWerSLKV6PIgDLarfFahTZUGcVbmPGPJ0+KoeiDrsEzQZazEazmm7hzK+g5DIv\n00z4XlOhisaY+uhHETZ52AspIfOA/+641ovBtitKR/BIie2CfFpuRH4mf4fyeRhjMrIY1ZiZADxW\n8FpVhe8NNNCmMaZ3OIz8JemPRMXs5sdcaybw8QraBdUsOwyVxYjKCWOMSUFrvXUHVKm1CGWE781B\nZtKzQtttHfunl9ymMWb8cgKa7EwifSFVY0zFhJd+Hg1+Lgdu6ThvA1RqOu3STxnhe48jp7MwA8Rb\nVZoIGTTGrBscjiZGZ6Blnl2bFccY042rKad+Q56wwY8mXHOg5DaNMcYY08NM6NjvB94G3FHCtbcG\nbgh+70PFy24P9l8I2jgK+FboO0VT6OZp0xhjjDFjhB1RfoAmCOc3iGNlBe06t4ExxhjTo0xAL+cL\nkDPq4bQrB9fJXOAJkitanl1B23siX5YrkX+NMcYYY3qEfuS78UGksDxHM+WqDwF+inKcPFNjuwcF\n7d6PLCqOCDLGGGN6iInAk8DbG5bjVWTRSVr6KZvHgS2RwnZhzW0bY4wxxhhjjDHGGGOMMcYYY4wx\nxhhjjDHGGGOMMcYYE83/AYh0fTKA9a30AAAAAElFTkSuQmCC\n",
+       "prompt_number": 49,
+       "text": [
+        "",
+        "   l + 1/2                                                                    ",
+        "    _____                                                                     ",
+        "    \u2572                                                                         ",
+        "     \u2572         2 \u239b   2            2          \u239e  j,m_l + m_s                   ",
+        "      \u2572       \u210f \u22c5\u239d4\u22c5j  + 4\u22c5j - 4\u22c5l  - 4\u22c5l - 3\u23a0\u22c5C             \u22c5\u2758j,m_l + m_s,j\u2081=",
+        "       \u2572                                        l,m_l,1/2,m_s                 ",
+        "       \u2571      \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "      \u2571                                           4                           ",
+        "     \u2571                                                                        ",
+        "    \u2571                                                                         ",
+        "    \u203e\u203e\u203e\u203e\u203e                                                                     ",
+        "j = m_l + m_s                                                                 ",
+        "",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "l,j\u2082=1/2\u27e9",
+        "         ",
+        "\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "         "
+       ]
+      }
+     ],
+     "prompt_number": 49
+    },
+    {
+     "cell_type": "markdown",
+     "source": [
+      "This gives us the modification of the angular part of the spin-orbit Hamiltonian. We see there is now the new $j$ quantum number in the coupled states, which we see from looking at the equation will have values $l\\pm \\frac{1}{2}$, and $m_j=m_l + m_s$. We still have the $l$ and $s$ quantum numbers."
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/examples/notebooks/spin.ipynb
+++ b/examples/notebooks/spin.ipynb
@@ -2,7 +2,7 @@
  "metadata": {
   "name": "spin"
  },
- "nbformat": 3,
+ "nbformat": 2,
  "worksheets": [
   {
    "cells": [
@@ -530,10 +530,10 @@
      "outputs": [
       {
        "latex": [
-        "$$Rotation(\\alpha,\\beta,\\gamma)$$"
+        "$$\\mathcal{R}\\left(\\alpha,\\beta,\\gamma\\right)$$"
        ],
        "output_type": "pyout",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAI0AAAAZCAYAAAAMqa3wAAAABHNCSVQICAgIfAhkiAAABq1JREFU\naIHt2nmMX1UVB/DPtJ1CIcCIbVUolKWlpQIVqiUSWzrEthANxA0Fte5iBEoR0+AatWhIS1EBBaQF\nIi51i4lFRHGNCFGrEjeIG1CRUqzaiGIBpf5x7svv9c59M7+Z+TEl4ff95807595zzr3v3LPc39BF\nF108KTBhdxvQAfQ2McaPpRVPEbwU83HH7jZklHgf/os/tzvh02LRO/EwbsHN+AF+jCtxTMfN7Bye\njj/gnWOs90R8fAz1HYxV+EjS+2VM7ZDsXtyEOcOZNEM4zSUZfbww8FEsGoExh+N+TB/B3HblHIhf\nYPEodQwH++In2GuM9C3Au7FHjXYVvthBHdOxySCpKscbhNMsKfCOTLyvjsCQFdiBPUcw94mQ0ylc\nLGwaC8zEygL9KtzZYV3X4y3DGbwDkwq8k4XTXDcCI74i0txo0Sk5ncDe+LtIi2OB1RiX0XrwO6zv\nsK55ItW3hT/huw28G7Eds0dgxFaRh0eLTsnpBE7Hz8dI12y8vEBfJorWyR3WNw7/wHEVoak1nIZD\nsS6jT8GH8QyRU+/K+LNxAf4t8uBkEbIXinT3NFGo9YvCeiM+kck4CWfh3qTvO0nGc/HKIeTMwdki\nF38GGwpra7JxS+KfhhdiLl6H/fGKxHuBKDpvymQuxm0FXbnedyS9e2E/LMeDid8jovdQeBnWpr+v\nFR3OPPHNjsO2Ieb34BycLyLj53BukkP4xJrEh8dxK5Ya4mC8Oi1gHT6Ai/A94cmlGofY7C3i41Y4\nXxRSVSg9C48opzx4k4gg09L7ISJFfjMbV5LTi6tFob4CvxyBjRPxsUT/qdisC8RGw4XYXJC7KdnU\nhNNwn3DECqvSvOrao92uqx5d1+AyUSb8S3uR9zL8BdfgBuFk9WbnTHHI61irfAB3wafwH7tWzZNE\nDVGqzo9O49+Y0ecJ53t+et8gPkQJc/EYzsjo2/DejFaSc7o4DfBtAxfZjo2LRejvwd9EC1vHu0Sk\nyLFNRMESKr3LMnrVTCwR3d77G+bXsa+IViVciQeGmL8QX8A+NdpUkTGmpPerC/PeI65aBsVd+GGB\nfrZY6IyMfrOIQnm660/jqw19QKS3Em4UxWTdUauNPTEbW5IzXZzaw0RIXZrx27HxWeJwHJNoC7Kx\nG5TT0GMFfXW9mw28SN0n6VgpHOaAhvl1vMiuUbKO1UneYLfRFypH+TPwZnGFUnL+t6mVInkFTtQr\ns5Q35+D0rBdbk8Vp+ZpWXqwwPz3vxrOT7FLH0yc6slvEB6iwSNwH1b28Sc69+J9Y/OYka7g2bhFR\n4aT0rOvtTTZuLNi/U3kvK70bk211PJSec8Vdy/2F+TmO1VxXHCXWna+vjovFunJ8Q9RDJxsYXYm1\n9dRfclT57PYCrz89H6zRDk8CNxXGL8MfRX3QLxZUOWMfDkp/zxAnMde5KM3dISJIZUOTnAmiUF4v\nok01p10b6+u8XThshVNEevi8qH2m1XjbRcGcYzC9FY7Wfhc4Q6wrxzNF8f7ZNuXk2C6i7MMGOjex\ntu3VS8lpqlRQcpqj0nNreh6kVa0/lI1dItLLcq1Qf4co2OA8rVPxz/SsF5mThNPcVhtvCDlLRY6+\nTnzYcxK9cvKhbCT2ZCG+n41dJpqBe/ASccFW4W5lp2nSS6zvcRH9dmS8WQZeWu4n0lMp/ZwrUvbq\nNuQ0YR6+1MDbX6wRZafpFxuztcCrJu4UkeFDifYtu1bch4nqfLlWezo+yYXniTBZtbm/F93OIem9\nF1eIBd8jwnzlnIPJmZXk3Ie3a10+tmsjkQL6DHSaI8QHnihOdZ1/q/JvNCW9cDwuxa9EATpOq5bo\nF/XDDdmcBaJbukgtVYjO7LV4sVo0GEROE+7UfJs8Bz/LiVNFDfBr4RCPippheTbuWFEgXy86rCMT\nvU98oPW4XPT+x2dz5+JHon1baaDDHoGv46OiLZyJ14uPc41WHTWYnAOS3ZfiNZn8dmyEU8U+TMzo\nZ4rc/0mttFdhMX5TkFXXu0589EtE1Bqf9G8SHcsJafwc/FXtZCesEofplNoarhWt+hQD0SSnhEM1\nt/wTRKR8ThtyuhgG9hAt+oEdlPnB7H1Nh+SUsAJvbeCdgN/WCaX01MXw8YhIp+cNNXAYqP963adc\nFw1XThOWKtewxOXn2gZeF6PE3qJGKRXEw8UCvKr2fqqoo0Yrp4RxokbsKfBmiX/36P6z3hOI+eLX\n99FE8AmiJqt/xFXCKUcrp4SpypFkT1HnzizwuugwluhsmtpdWKV18dlFF1100UUXT3b8HxCniSyD\npypeAAAAAElFTkSuQmCC\n",
+       "png": "iVBORw0KGgoAAAANSUhEUgAAAE0AAAAWCAYAAACFQBGEAAAABHNCSVQICAgIfAhkiAAAA+1JREFU\nWIXt2HmIV1UUwPGPjqVS6hQqLaSY5ZhhtkEYOpSELUq2WhIVRFZUQkWIlRhmhmmLtqlhlrQXERSY\n0kYRLWQQ/WNUtljQItG+ok5/nPdr3jzvez+n34z0x3z/eu+ce88979x7z7n30UOn6dVNdoejFQ93\nk/0iwzATTdgD++NyfNeAzSZci8Voq2rYGydhNTbi16xDG7bhN3yB53FaiY1mPILdGnC4M0zE9eib\nk63AU11guxU3VzUYg5cxH5PwgAjWVByZGZiRyf/OdOcl7KzI2u8KDsbsEh82dtEYd2FCSnEAtuCM\nnOxxsbr6JtqfL4J2T0HeIgK/q1gsdkeeXvhITG5XcCBeTSmm4+KC7B18UmJonAjahQX5vQlZdzEa\nZyXkF+BLDO7CsV7D4fUaNeEXPFaiv1EEtU9BvgkjK+yOxv24EyvxBIbm9J0pTDegX/a8OrP7Hr4V\nhaCKXpiFT/ETluv4LX0yH2vcgptqL8WlXWMc9sTricEuxVE4BVtzuuGiCGwqsTkNL4nVeHVm52Os\nFZMES0v6puiHP7Pn77PnD0T1vKxO32WYI1LJczgbi3L66Xg29/4uxtdzaJbYfqNFMK4TM/kCLirp\nM1F58h2LP8TWyXNINs5ksTrm1XMsYyCuKdEtxzcVfVvxJAbkZEPxIYZk7ysLfSbgq3pOrc2MwBrx\nYVtFEMs4E2+X6NZhs/YVVWNAZnu2CNh+9RzLmIKjS3S1c1UxddSYg/4J+QyR14/DOQXdofi9yqFB\n+EvH88nSzJFnKvpNx5sJ+WBsF9syRRsexcIqpwrMVZ5a1oqzZGdpxn1imxYnt0UuaKmBp2B3kaRr\nzMMPOB1HlAy6BXsl5CNFLtxQ4fBYLKjQFzlITESRfXCCmITO8iP2FcHZVtDtrc7t4kW8kZDPE6ui\neA6biSswqsTwiKxf6njQP3Ow7NTdor1C1hgkJii1/RaKNNBcx0YZm0WeLTJFehchPny72N9FBopy\n3iZK8DDcKma1n1hNX0vnpfXiZJ3nGJG03xeJt7eOueT4bKynC/2mihy4SMcjyjTx0YfthI0y1pfI\n56qo7PPxkPJ742QRuJ+zAVoL+jV2TKLEzD+IVViC20QlbRLB2yACd2yuzxixoj4r2FqQ+XeyOPXf\nLc5py7RXv3o2UozIbKRYJyagW5hk52d1Z5lfeF/SBTZSXIVLEvIh4lTw76ouq0D/lVfENq66FXSW\n/N23WdxUGrFRxol4KyG/UqSjyt9DjTJC5Lmu+Fc3Eefm3k8V1bERGyl643M7+jxK/ObaJYwX16RG\n6IM7dPyQBeKa1IiNFENxe0HWJP7iDNixeQ899PA/5R/opcWRrIlFmgAAAABJRU5ErkJggg==\n",
        "prompt_number": 19,
        "text": [
         "\u211b (\u03b1,\u03b2,\u03b3)"
@@ -1374,7 +1374,7 @@
        "text": [
         "",
         " 2       2    2   ",
-        "J  - 1\u2a02 J  - J \u2a02 1"
+        "J  - 1\u2a02 S  - L \u2a02 1"
        ]
       }
      ],

--- a/sympy/physics/quantum/cg.py
+++ b/sympy/physics/quantum/cg.py
@@ -60,6 +60,9 @@ class Wigner3j(Expr):
 
     .. [1] Varshalovich, D A, Quantum Theory of Angular Momentum. 1988.
     """
+
+    is_commutative = True
+
     def __new__(cls, j1, m1, j2, m2, j3, m3):
         args = map(sympify, (j1,m1,j2,m2,j3,m3))
         return Expr.__new__(cls, *args)


### PR DESCRIPTION
Here is an ipython example notebook highlighting the use of the quantum angular momentum module. There was also a small issue of CG/Wigner symbols not being commutative. @ellisonbg

A couple points:
- I realized a couple latex characters are no longer rendered correctly, namely `\mathcal{R}` (for Rotation operator) and `\mathcal{C}` (for ComlexSpace). They worked fine when I made my initial quantum printing notebook, but that was 5 months ago. Now they output some Asian language character.
- The one example notebook currently in the tree is version 2, while the latest IPython master runs the notebook version 3. Since I didn't think to roll back IPython, the version I submitted is version 3. Do we want to stick to one or the other? It might come down to if IPython 0.13 or SymPy 0.7.2 is released first.
