### PR TITLE
disregard variables that have 0-order in Derivative

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -969,10 +969,11 @@ class Derivative(Expr):
                 raise ValueError(filldedent('''
                 Can\'t differentiate wrt the variable: %s, %s''' % (v, count)))
 
-            variable_count.append((v, count))
-
             if all_zero and not count == 0:
                 all_zero = False
+
+            if count:
+                variable_count.append((v, count))
 
         # We make a special case for 0th derivative, because there is no
         # good way to unambiguously print this.

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -3,12 +3,14 @@ from sympy import Symbol, Rational, cos, sin, tan, cot, exp, log, Function, \
 from sympy.utilities.pytest import raises
 
 def test_diff():
-    x = Symbol('x')
+    x, y = symbols('x, y')
     assert Rational(1, 3).diff(x) is S.Zero
     assert I.diff(x) is S.Zero
     assert pi.diff(x) is S.Zero
     assert x.diff(x, 0) == x
     assert (x**2).diff(x, 2, x) == 0
+    assert (x**2).diff(x, y, 0) == 2*x
+    assert (x**2).diff(x, y) == 0
     raises(ValueError, lambda: x.diff(1, x))
 
     a = Symbol("a")


### PR DESCRIPTION
diff(foo, x, 1, y, 0) should disregard 0.
