### PR TITLE
Stats probability uneval

### DIFF
--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -191,7 +191,6 @@ class ContinuousPSpace(PSpace):
         return Lambda(z, cdf)
 
     def probability(self, condition, **kwargs):
-        evaluate = kwargs.get("evaluate", True)
         z = Dummy('z', real=True, bounded=True)
         # Univariate case can be handled by where
         try:
@@ -200,6 +199,7 @@ class ContinuousPSpace(PSpace):
             # Integrate out all other random variables
             pdf = self.compute_density(rv, **kwargs)
             # Integrate out the last variable over the special domain
+            evaluate = kwargs.pop("evaluate", True)
             if evaluate:
                 return integrate(pdf(z), (z, domain.set), **kwargs)
             else:

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -450,3 +450,7 @@ def test_unevaluated():
             Integral(sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)*
             Integral(sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)),
                 (x, -1, 1))), (x, 0, 1)))
+
+def test_probability_unevaluated():
+     T = Normal('T', 30, 3)
+     assert type(P(T>33, evaluate=False)) == Integral


### PR DESCRIPTION
Changed kwargs.get to kwargs.pop in probability method

Previously we sent the evaluate keyword downstream to Integral which caused an error. 

Now we pop it off of kwargs instead of getting it.
