### PR TITLE
fix for setup.py not installing sympy.plotting.pygletplot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ modules = [
     'sympy.physics.mechanics',
     'sympy.physics.quantum',
     'sympy.plotting',
+    'sympy.plotting.pygletplot',
     'sympy.polys',
     'sympy.polys.domains',
     'sympy.printing',


### PR DESCRIPTION
proxy_pyglet has been created and sympy.plotting.pygletplot has been split off as a subdirectory but it is not being installed by setup.py

this means that sympy works fine when run from a git clone but will fail after install due to an inability to import sympy.plotting.pygletplot

adding sympy.plotting.pygletplot to modules in setup.py solves this problem
