### PR TITLE
A minor fix to the tests of jscode.

### DIFF
--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -105,7 +105,7 @@ else {
     assert p == s
 
 def test_jscode_settings():
-    raises(TypeError, 'jscode(sin(x),method="garbage")')
+    raises(TypeError, lambda : jscode(sin(x),method="garbage"))
 
 def test_jscode_Indexed():
     from sympy.tensor import IndexedBase, Idx


### PR DESCRIPTION
`raises(Error, string)` -> `raises(Error, lambda)`
