### PR TITLE
Complex values are discarded in plots

### DIFF
--- a/examples/beginner/plot_intro.ipynb
+++ b/examples/beginner/plot_intro.ipynb
@@ -2,29 +2,33 @@
  "metadata": {
   "name": "plot_intro"
  },
- "nbformat": 2,
+ "nbformat": 3,
+ "nbformat_minor": 0,
  "worksheets": [
   {
    "cells": [
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "#New Plotting Framework for SymPy"
      ]
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "",
-      "## Structure of the Module",
-      "",
-      "This module implements a new plotting framework for SymPy. The central class of the module is the `Plot` class that connects the data representations (subclasses of `BaseSeries`) with different plotting backends. It's not imported by default for backward compatibility with the old module.",
-      "",
+      "\n",
+      "## Structure of the Module\n",
+      "\n",
+      "This module implements a new plotting framework for SymPy. The central class of the module is the `Plot` class that connects the data representations (subclasses of `BaseSeries`) with different plotting backends. It's not imported by default for backward compatibility with the old module.\n",
+      "\n",
       "Then there is the `plot()` function that has a less stricter requirements for its input and is better suited for interactive work."
      ]
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "## Docstrings"
      ]
@@ -36,8 +40,8 @@
       "help(plot)"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 1
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -46,11 +50,12 @@
       "help(Plot) # This is from the old module!"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 2
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "##General examples"
      ]
@@ -62,8 +67,8 @@
       "p = plot(x)"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 3
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -72,8 +77,8 @@
       "p # the Plot object"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 4
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -82,8 +87,8 @@
       "p[0] # one of the data series objects"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 5
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -92,8 +97,8 @@
       "p[0].label # an option of the data series"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 6
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -102,78 +107,78 @@
       "p.legend # a global option of the plot"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 7
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p.legend = True",
+      "p.legend = True\n",
       "p.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 8
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p1 = plot(x*sin(x),x*cos(x), show=False)",
-      "p1.extend(p) # Plot objects are just like lists.",
+      "p1 = plot(x*sin(x),x*cos(x), show=False)\n",
+      "p1.extend(p) # Plot objects are just like lists.\n",
       "p1.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 9
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p1.legend = True",
+      "p1.legend = True\n",
       "p1.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 10
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p1[0].line_color='r'",
-      "p1[1].line_color='b' # a constant color",
+      "p1[0].line_color='r'\n",
+      "p1[1].line_color='b' # a constant color\n",
       "p1.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 11
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p1[0].line_color = lambda a : a # color dependent on the parameter",
+      "p1[0].line_color = lambda a : a # color dependent on the parameter\n",
       "p1.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 12
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p1.title = 'Big title'",
-      "p1.xlabel = 'the x axis'",
-      "p1[1].label = 'straight line'",
+      "p1.title = 'Big title'\n",
+      "p1.xlabel = 'the x axis'\n",
+      "p1[1].label = 'straight line'\n",
       "p1.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 13
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -182,23 +187,24 @@
       "p1.aspect_ratio"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 14
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p1.aspect_ratio = (1,1)",
-      "p1.xlim = (-15,20)",
+      "p1.aspect_ratio = (1,1)\n",
+      "p1.xlim = (-15,20)\n",
       "p1.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 15
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "Hm, `xlim` does not work in the notebook. Hopefully it works in IPython."
      ]
@@ -210,17 +216,19 @@
       "p1._backend.ax.get_xlim()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 16
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "Yeah, the backend got the command, but the `inline` backend does not honour it."
      ]
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "## Adding expressions to a plot"
      ]
@@ -229,52 +237,53 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p = plot(x)",
+      "p = plot(x)\n",
       "p"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 17
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p.extend(plot(x+1, show=False))",
-      "p.show()",
+      "p.extend(plot(x+1, show=False))\n",
+      "p.show()\n",
       "p"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 18
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p.append(plot((x+3,),(x**2,), show=False)[1])",
-      "p.show()",
+      "p.append(plot((x+3,),(x**2,), show=False)[1])\n",
+      "p.show()\n",
       "p"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 19
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "p[2] = x**2, (x, -2, 3)  # you must be explicit when not using plot()",
+      "p[2] = x**2, (x, -2, 3)  # you must be explicit when not using plot()\n",
       "p.show() # and call show() yourself"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 20
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "",
+      "\n",
       "Or even sending a `Plot` or a `Series` object to the `plot` function."
      ]
     },
@@ -285,8 +294,8 @@
       "a = plot((x,(0,2)), (x**2,(0,2)))"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 21
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -295,8 +304,8 @@
       "plot(a)"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 22
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -305,16 +314,17 @@
       "plot(a[0])"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 23
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "## Ambiguous input in `plot()`",
-      "",
-      "`plot()` is capable of working with more ambiguous input than `Plot()`. The later needs explicit free variables and range while the first finds the free variables and has default ranges.",
-      "",
+      "## Ambiguous input in `plot()`\n",
+      "\n",
+      "`plot()` is capable of working with more ambiguous input than `Plot()`. The later needs explicit free variables and range while the first finds the free variables and has default ranges.\n",
+      "\n",
       "The number of expression determines the type of the plot. The arguments to `plot()` can also be tuples, every tuples containing a new expression to be plotted."
      ]
     },
@@ -325,8 +335,8 @@
       "plot(sin(x),(x,-2*pi,4*pi)) # explicit 2D line"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 24
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -335,8 +345,8 @@
       "plot(sin(x),(-2*pi,4*pi)) # implicit free variable"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 25
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -345,11 +355,12 @@
       "plot(sin(x)) # and default range"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 26
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
       "## Different types of plots"
      ]
@@ -361,8 +372,8 @@
       "plot((x,), (x*sin(x), x*cos(x))) # cartesian line and a parametric line"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 27
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -371,8 +382,8 @@
       "plot(sin(x),cos(x),x) # 3D parametric line"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 28
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -381,8 +392,8 @@
       "plot(x*y) # a surface"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 29
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -391,14 +402,15 @@
       "plot(x*sin(z),x*cos(z),z) # parametric surface"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 30
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "## List of expressions as an argument",
-      "",
+      "## List of expressions as an argument\n",
+      "\n",
       "Especially useful when plotting the output of `solve`."
      ]
     },
@@ -409,8 +421,8 @@
       "plot([x,x**2])"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 31
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -419,8 +431,8 @@
       "plot([x,x**2], (0,2))"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 32
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -429,8 +441,8 @@
       "plot([-abs(x*y)-10, abs(x*y)+10], (-5,5), (-5,5))"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 33
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -439,8 +451,8 @@
       "solutions = solve(x**2+x-y,x)"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 34
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -449,8 +461,8 @@
       "solutions"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 35
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -459,14 +471,15 @@
       "plot(solutions, (-0.25,5))"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 36
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "## Complex values",
-      "If complex values are encountered a warning is raised and only the real parts are plotted."
+      "## Complex values\n",
+      "If complex values are encountered, they are discarded while plotting."
      ]
     },
     {
@@ -476,15 +489,16 @@
       "plot(solutions)"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 37
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
      "source": [
-      "",
-      "## Textplot",
-      "",
+      "\n",
+      "## Textplot\n",
+      "\n",
       "There is also the textplot backend that permits plotting in the terminal."
      ]
     },
@@ -495,8 +509,8 @@
       "pt = plot(sin(x),show=False)"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 38
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -505,8 +519,8 @@
       "pt.backend = plot_backends['text']"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 39
+     "metadata": {},
+     "outputs": []
     },
     {
      "cell_type": "code",
@@ -515,10 +529,11 @@
       "pt.show()"
      ],
      "language": "python",
-     "outputs": [],
-     "prompt_number": 40
+     "metadata": {},
+     "outputs": []
     }
-   ]
+   ],
+   "metadata": {}
   }
  ]
 }

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -116,6 +116,11 @@ class vectorized_lambdify(object):
         np_old_err = np.seterr(invalid='raise')
         try:
             results = self.vector_func(*args)
+            #Discard complex values if results has complex values
+            if results.dtype == 'complex':
+                results = np.ma.masked_where(np.abs(results.imag) != 0, results.real, copy=False)
+                warnings.warn('Complex values as arguments to numpy functions encountered. '
+                                'Discarding the complex values.')
         except Exception, e:
             np.seterr(**np_old_err)
             #DEBUG: print 'Error', type(e), e
@@ -125,8 +130,10 @@ class vectorized_lambdify(object):
                 # complex number were produced and returned as nan.
                 # Solution: demand the use of np.complex128.
                 args = (np.array(a, dtype=np.complex) for a in args)
-                results = np.real(self.vector_func(*args))
-                warnings.warn('Complex values as arguments to numpy functions encountered.')
+                results = self.vector_func(*args)
+                results = np.ma.masked_where(np.abs(results.imag) != 0, results.real, copy=False)
+                warnings.warn('Complex values as arguments to numpy functions encountered. '
+                                'Discarding the complex values.')
             elif ((isinstance(e, TypeError)
                    and 'unhashable type: \'numpy.ndarray\'' in str(e))
                   or
@@ -155,8 +162,10 @@ class vectorized_lambdify(object):
                 # Solution: use cmath and vectorize the final lambda.
                 self.lambda_func = experimental_lambdify(self.args, self.expr, use_python_cmath=True)
                 self.vector_func = np.vectorize(self.lambda_func, otypes=[np.complex])
-                results = np.real(self.__call__(*args))
-                warnings.warn('Complex values as arguments to python math functions encountered.')
+                results = self.vector_func(*args)
+                results = np.ma.masked_where(np.abs(results.imag) != 0, results.real, copy=False)
+                warnings.warn('Complex values as arguments to python math functions encountered. '
+                                'Discarding the complex values.')
             else:
                 # Complete failure. One last try with no translations, only
                 # wrapping in complex((...).evalf()) and returning the real
@@ -169,7 +178,8 @@ class vectorized_lambdify(object):
                                                         use_evalf=True,
                                                         complex_wrap_evalf=True)
                     self.vector_func = np.vectorize(self.lambda_func, otypes=[np.complex])
-                    results = np.real(self.__call__(*args))
+                    results = self.vector_func(*args)
+                    results = np.ma.masked_where(np.abs(results.imag) != 0, results.real, copy=False)
                     warnings.warn('The evaluation of the expression is'
                             ' problematic. We are trying a failback method'
                             ' that may still work. Please report this as a bug.')

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -932,7 +932,6 @@ class MatplotlibBackend(BaseBackend):
             self.ax.set_xlim(parent.xlim)
         if parent.ylim:
             self.ax.set_ylim(parent.ylim)
-<<<<<<< HEAD
         if not isinstance(self.ax, Axes3D) or matplotlib.__version__ >= '1.2.0': #XXX in the distant future remove this check
             self.ax.set_autoscale_on(parent.autoscale)
         if parent.axis_center:

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -490,8 +490,8 @@ class Line2DBaseSeries(BaseSeries):
             x = np.array((points[0],points[0])).T.flatten()[1:]
             y = np.array((points[1],points[1])).T.flatten()[:-1]
             points = (x, y)
-        points = np.array(points).T.reshape(-1, 1, self._dim)
-        return np.concatenate([points[:-1], points[1:]], axis=1)
+        points = np.ma.array(points).T.reshape(-1, 1, self._dim)
+        return np.ma.concatenate([points[:-1], points[1:]], axis=1)
 
     def get_color_array(self):
         c = self.line_color
@@ -932,6 +932,7 @@ class MatplotlibBackend(BaseBackend):
             self.ax.set_xlim(parent.xlim)
         if parent.ylim:
             self.ax.set_ylim(parent.ylim)
+<<<<<<< HEAD
         if not isinstance(self.ax, Axes3D) or matplotlib.__version__ >= '1.2.0': #XXX in the distant future remove this check
             self.ax.set_autoscale_on(parent.autoscale)
         if parent.axis_center:

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -132,34 +132,17 @@ def plot_and_save(name):
     ###
 
 
-<<<<<<< HEAD
-    #with warnings.catch_warnings(record=True) as w:
-    #    warnings.simplefilter("always")
-    #    plot(sqrt(sqrt(-x)), show=False).save(tmp_file())
-    #    assert len(w) == 1
-    #    assert "Complex values as arguments to numpy functions encountered." == str(w[-1].message)
-    #with warnings.catch_warnings(record=True) as w:
-    #    warnings.simplefilter("always")
-    #    plot(LambertW(x), show=False).save(tmp_file())
-    #    assert len(w) > 10 #TODO trace where do the other warnings come from
-    #    assert "Complex values as arguments to python math functions encountered." == str(w[-1].message)
-    #with warnings.catch_warnings(record=True) as w:
-    #    warnings.simplefilter("always")
-    #    plot(sqrt(LambertW(x)), show=False).save(tmp_file())
-    #    assert len(w) == 1
-    #    assert "Complex values as arguments to python math functions encountered." == str(w[-1].message)
-    #TODO these test do not work properly.
     plot(sin(x)+I*cos(x), show=False).save(tmp_file())
     plot(sqrt(sqrt(-x)), show=False).save(tmp_file())
     plot(LambertW(x), show=False).save(tmp_file())
     plot(sqrt(LambertW(x)), show=False).save(tmp_file())
+
 
     ###
     # Test all valid input args for plot()
     ###
 
     # 2D line with all possible inputs
-<<<<<<< HEAD
     plot(x              , show=False).save(tmp_file())
     plot(x, (x,        ), show=False).save(tmp_file())
     plot(x, (   -10, 10), show=False).save(tmp_file())

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -132,6 +132,7 @@ def plot_and_save(name):
     ###
 
 
+<<<<<<< HEAD
     #with warnings.catch_warnings(record=True) as w:
     #    warnings.simplefilter("always")
     #    plot(sqrt(sqrt(-x)), show=False).save(tmp_file())
@@ -153,12 +154,12 @@ def plot_and_save(name):
     plot(LambertW(x), show=False).save(tmp_file())
     plot(sqrt(LambertW(x)), show=False).save(tmp_file())
 
-
     ###
     # Test all valid input args for plot()
     ###
 
     # 2D line with all possible inputs
+<<<<<<< HEAD
     plot(x              , show=False).save(tmp_file())
     plot(x, (x,        ), show=False).save(tmp_file())
     plot(x, (   -10, 10), show=False).save(tmp_file())


### PR DESCRIPTION
If a complex value is encountered while plotting, it is masked
using a numpy masked array and the complex value is not plotted in
the plot.

The only problem with this is is plots of `sqrt(x)` appear cut, if 0 is not
an sample. I plan to fix the problem using adaptive sampling for which I
will send another pull request.

2) Fixes the tests. Does not require matplotlib version = 1.2.0 for the tests
to work.

3) Fixes some typos.
