### PR TITLE
Fix for issue 3031

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -263,9 +263,8 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 # take a symbol arg.  The second arg is `store_history`,
                 # and False means don't add the line to IPython's history.
                 ip.runsource = lambda src, symbol='exec': ip.run_cell(src, False)
+            if not in_ipython:
                 mainloop = ip.mainloop
-            else:
-                mainloop = ip.interact
 
     if auto and (not ipython or IPython.__version__ < '0.11'):
         raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above")


### PR DESCRIPTION
Added an new argument isympy to init_session which is true if init_session
is called by isympy. It creates a new ipython session if isympy is True.

Fixes:
sympy session can be created in ipython and ipython qtconsole by calling init_session()
