### PR TITLE
Fix and test issue 3256

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -967,13 +967,14 @@ def dmp_zz_wang(f, u, K, mod=None):
         i += 1
 
     _, cs, E, H, A = configs[s_arg]
+    orig_f = f
 
     try:
         f, H, LC = dmp_zz_wang_lead_coeffs(f, T, cs, E, H, A, u, K)
         factors = dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K)
     except ExtraneousFactors: # pragma: no cover
         if query('EEZ_RESTART_IF_NEEDED'):
-            return dmp_zz_wang(f, u, K, mod+1)
+            return dmp_zz_wang(orig_f, u, K, mod+1)
         else:
             raise ExtraneousFactors("we need to restart algorithm with better parameters")
 

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -358,6 +358,15 @@ def test_dmp_zz_wang():
 
     assert dmp_expand(factors, 2, ZZ) == w_1
 
+def test_issue_3256():
+    # This tests a bug in the Wang algorithm that occured only with a very
+    # specific set of random numbers.
+    random_sequence = [-1, -1, 0, 0, 0, 0, -1, -1, 0, -1, 3, -1, 3, 3, 3, 3, -1, 3]
+    f = [[[ZZ(2)]], [[]], [[ZZ(1), ZZ(-1)], [ZZ(-1), ZZ(1), ZZ(0)]]]
+    u = 2
+    K = ZZ
+    assert dmp_zz_wang(f, u, K, random_sequence=random_sequence) == [f]
+
 def test_dmp_zz_factor():
     assert dmp_zz_factor([], 0, ZZ) == (0, [])
     assert dmp_zz_factor([7], 0, ZZ) == (7, [])


### PR DESCRIPTION
This is a fix and test for issue 3256, which is a test failure under a specific random seed.  Thanks to @mattpap for the fix.  To test this, I've modified the function `dmp_zz_wang` to take in a sequence of random numbers, and I then test the exact sequence that is produced by the problem seed.  To verify that this fix works, I've cherry-picked just the test commit onto my 3256_no_fix branch.  There, you will see that the test fails without @mattpap's commit that fixes the bug in the algorithm.

How do people feel about this method of testing random algorithms?  It does not rely on any kind of random number generator, so there is no need to worry that a small change to a generator will invalidate an old test.  Furthermore, it would be possible with this method to give any sequence of numbers, making it easy to test all parts of a given random algorithm (doing this with a seed would be either difficult or impossible, depending on how specific the sequence must be).  The method is easy to do, and my little helper function could even be factored out if we find enough use for it. @smichr, what do you think?
