### PR TITLE
bug fix on the BaseMatrix Class

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2470,7 +2470,7 @@ class MatrixBase(object):
 
             det = sign * M[n-1, n-1]
 
-        return det.expand()
+        return expand(det)
 
     def det_LU_decomposition(self):
         """Compute matrix determinant using LU decomposition
@@ -2502,7 +2502,7 @@ class MatrixBase(object):
         for k in range(n):
             prod = prod*u[k,k]*l[k,k]
 
-        return prod.expand()
+        return expand(prod)
 
     def adjugate(self, method="berkowitz"):
         """
@@ -4326,7 +4326,7 @@ class SparseMatrix(MatrixBase):
             for i in range(self.rows):
                 for j in range(self.cols):
                     value = sympify(op(i,j))
-                    if value != 0:
+                    if value != 0 and value != None:
                         self.mat[(i,j)] = value
         elif len(args)==3 and isinstance(args[0],int) and \
                 isinstance(args[1],int) and is_sequence(args[2]):
@@ -4378,7 +4378,7 @@ class SparseMatrix(MatrixBase):
                 if (m,n) in self.mat:
                     L.append(self.mat[(m,n)])
                 else:
-                    L.append(0)
+                    L.append(S.Zero)
             if len(L) == 1:
                 return L[0]
             else:
@@ -4391,7 +4391,7 @@ class SparseMatrix(MatrixBase):
             if (i, j) in self.mat:
                 return self.mat[(i,j)]
             else:
-                return 0
+                return S.Zero
         elif isinstance(key[0], slice) or isinstance(key[1], slice):
             return self.submatrix(key)
         else:
@@ -4509,7 +4509,7 @@ class SparseMatrix(MatrixBase):
                 if (i, j) in self.mat:
                     c.append(self[i, j])
                 else:
-                    c.append(0)
+                    c.append(S.Zero)
         return Matrix(l)
 
     def row_list(self):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2470,7 +2470,7 @@ class MatrixBase(object):
 
             det = sign * M[n-1, n-1]
 
-        return det.expand()
+        return expand(det)
 
     def det_LU_decomposition(self):
         """Compute matrix determinant using LU decomposition
@@ -2502,7 +2502,7 @@ class MatrixBase(object):
         for k in range(n):
             prod = prod*u[k,k]*l[k,k]
 
-        return prod.expand()
+        return expand(prod)
 
     def adjugate(self, method="berkowitz"):
         """


### PR DESCRIPTION
Hi!
Yesterday i found a small bug in the BaseMatrix class, that led to an exception when a SparseMatrix has zero determinant because it try to use the method expand on an object that doesn't have it (the number 0).
It is simply fixed by using the standard expand instead of the object method.

This is my first patch ever, so please forgive me if i missed some step in the process.
Thank you very much for the grat job on sympy.
Enrico.

A small code to replicate the error:

```
N=3
def f(i,j):
    if i==j: return -x-y
    elif i==j+1: return y
    elif i==j-1: return x
    elif i==0 and j==N-1: return y
    elif i==N-1 and j==0: return x
    else: return Rational(0)
R=SparseMatrix(N,N,f)
print R.det()
```
