### PR TITLE
Revert "Compute numerical roots if domain=RR (#1868)"

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -447,10 +447,10 @@ def roots(f, *gens, **flags):
     with its roots and their multiplicities.
 
     Only roots expressible via radicals will be returned.  To get
-    a complete set of roots use RootOf class or numerical methods
-    instead. By default cubic and quartic formulas are used in
-    the algorithm. To disable them because of unreadable output
-    set ``cubics=False`` or ``quartics=False`` respectively.
+    a complete set of roots use RootOf class (or all_roots method) or
+    numerical methods instead (eg nroots). By default cubic and quartic
+    formulas are used in the algorithm. To disable them because of unreadable
+    output set ``cubics=False`` or ``quartics=False`` respectively.
 
     To get roots from a specific domain set the ``filter`` flag with
     one of the following specifiers: Z, Q, R, I, C. By default all
@@ -593,10 +593,7 @@ def roots(f, *gens, **flags):
     result = {}
 
     if not f.is_ground:
-        if not f.get_domain().is_Exact:
-            for r in f.nroots():
-                _update_dict(result, r, 1)
-        elif f.degree() == 1:
+        if f.degree() == 1:
             result[roots_linear(f)[0]] = 1
         elif f.degree() == 2:
             for r in roots_quadratic(f):

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -224,6 +224,11 @@ def test_roots():
     assert roots(x**6-4*x**4+4*x**3-x**2, x) == \
         {S.One: 2, -1 - sqrt(2): 1, S.Zero: 2, -1 + sqrt(2): 1}
 
+    R1 = sorted([ r.evalf() for r in roots(x**2 + x + 1,   x) ])
+    R2 = sorted([ r         for r in roots(x**2 + x + 1.0, x) ])
+
+    assert R1 == R2
+
     assert roots(x**8-1, x) == {
          sqrt(2)/2 + I*sqrt(2)/2: 1,
          sqrt(2)/2 - I*sqrt(2)/2: 1,
@@ -232,9 +237,9 @@ def test_roots():
         S.One: 1, -S.One: 1, I: 1, -I: 1
     }
 
-    f = -2016*x**2 - 5616*x**3 - 2056*x**4 + 3324*x**5 + 2176*x**6 - 224*x**7 - 384*x**8 - 64*x**9
-
-    assert roots(f) == {S(0): 2, -S(2): 2, S(2): 1, -S(7)/2: 1, -S(3)/2: 1, -S(1)/2: 1, S(3)/2: 1}
+    assert roots(-2016*x**2 - 5616*x**3 - 2056*x**4 + 3324*x**5 + 2176*x**6 \
+        - 224*x**7 - 384*x**8 - 64*x**9, x) == {S(0): 2, -S(2): 2, S(2): 1, -S(7)/2: 1,\
+                                            -S(3)/2: 1, -S(1)/2: 1, S(3)/2: 1}
 
     assert roots((a+b+c)*x - (a+b+c+d), x) == {(a+b+c+d)/(a+b+c): 1}
 
@@ -362,41 +367,33 @@ def test_roots_inexact():
     for r1, r2 in zip(R1, R2):
         assert abs(r1 - r2) < 1e-12
 
-    f = x**4 + 3.0*sqrt(2.0)*x**3 - (78.0 + 24.0*sqrt(3.0))*x**2 + 144.0*(2*sqrt(3.0) + 9.0)
-
-    R1 = sorted(roots(f, multiple=True))
-    R2 = sorted([-12.7530479110482, -3.85012393732929, 4.89897948556636, 7.46155167569183])
-
-    for r1, r2 in zip(R1, R2):
-        assert abs(r1 - r2) < 1e-10
-
-def test_roots_preprocessed():
-    E, F, J, L = symbols("E,F,J,L")
-
-    f = -21601054687500000000*E**8*J**8/L**16 + \
-         508232812500000000*F*x*E**7*J**7/L**14 - \
-         4269543750000000*E**6*F**2*J**6*x**2/L**12 + \
-         16194716250000*E**5*F**3*J**5*x**3/L**10 - \
-         27633173750*E**4*F**4*J**4*x**4/L**8 + \
-         14840215*E**3*F**5*J**3*x**5/L**6 + \
-         54794*E**2*F**6*J**2*x**6/(5*L**4) - \
-         1153*E*J*F**7*x**7/(80*L**2) + \
-         633*F**8*x**8/160000
-
-    assert roots(f, x) == {}
-
-    R1 = roots(f.evalf(), x, multiple=True)
-    R2 = [-1304.88375606366, 97.1168816800648, 186.946430171876, 245.526792947065,
-           503.441004174773, 791.549343830097, 1273.16678129348, 1850.10650616851]
-
-    w = Wild('w')
-    p = w*E*J/(F*L**2)
-
-    assert len(R1) == len(R2)
-
-    for r1, r2 in zip(R1, R2):
-        match = r1.match(p)
-        assert match is not None and abs(match[w] - r2) < 1e-10
+#def test_roots_preprocessed():
+#    E, F, J, L = symbols("E,F,J,L")
+#
+#    f = -21601054687500000000*E**8*J**8/L**16 + \
+#         508232812500000000*F*x*E**7*J**7/L**14 - \
+#         4269543750000000*E**6*F**2*J**6*x**2/L**12 + \
+#         16194716250000*E**5*F**3*J**5*x**3/L**10 - \
+#         27633173750*E**4*F**4*J**4*x**4/L**8 + \
+#         14840215*E**3*F**5*J**3*x**5/L**6 + \
+#         54794*E**2*F**6*J**2*x**6/(5*L**4) - \
+#         1153*E*J*F**7*x**7/(80*L**2) + \
+#         633*F**8*x**8/160000
+#
+#    assert roots(f, x) == {}
+#
+#    R1 = roots(f.evalf(), x, multiple=True)
+#    R2 = [-1304.88375606366, 97.1168816800648, 186.946430171876, 245.526792947065,
+#           503.441004174773, 791.549343830097, 1273.16678129348, 1850.10650616851]
+#
+#    w = Wild('w')
+#    p = w*E*J/(F*L**2)
+#
+#    assert len(R1) == len(R2)
+#
+#    for r1, r2 in zip(R1, R2):
+#        match = r1.match(p)
+#        assert match is not None and abs(match[w] - r2) < 1e-10
 
 def test_roots_mixed():
     f = -1936 - 5056*x - 7592*x**2 + 2704*x**3 - 49*x**4
@@ -435,3 +432,15 @@ def test_root_factors():
         [Poly(x - 1, x), Poly(x + 1, x), Poly(x**2 + 1, x)]
     assert root_factors(8*x**2 + 12*x**4 + 6*x**6 + x**8, x, filter='Q') == \
         [x, x, x**6 + 6*x**4 + 12*x**2 + 8]
+
+
+# TODO this test hangs
+#def test_Poly_all_roots_inexact():
+#
+#    f = x**4 + 3.0*sqrt(2.0)*x**3 - (78.0 + 24.0*sqrt(3.0))*x**2 + 144.0*(2*sqrt(3.0) + 9.0)
+#
+#    R1 = sorted(r.evalf() for r in Poly(f).all_roots())
+#    R2 = sorted([-12.7530479110482, -3.85012393732929, 4.89897948556636, 7.46155167569183])
+#
+#    for r1, r2 in zip(R1, R2):
+#        assert abs(r1 - r2) < 1e-10


### PR DESCRIPTION
This is related to duplication of code and to code inconsistent with its docstrings in the poly module. See also:
http://code.google.com/p/sympy/issues/detail?id=3294
http://code.google.com/p/sympy/issues/detail?id=3295

This is not to be merged. However I hope that someone will explain to me what is the idea behind all the functions with slightly duplicated functionality (`nroots`, `roots(domain=RR)` before this revert and `RootOf.evalf`) None of them is using what is already implemented in the others.

Please check carefully the commented out failing tests. (Those that are not commented out are just the same tests, slightly changed in formating due to the revert).

The commit message:

```
This reverts commit f638fcfb46e760c22f6a664a1485b7f33fa56247.

Conflicts:

    sympy/polys/polyroots.py
    sympy/polys/tests/test_polyroots.py

The behavior of `roots` was not consistent with what was writtend in the
docstring. `roots` is documented as returning only radicals, however it was
returning also aproximante `float` solutions. `nroots`, `RootOf` and
`Poly.all_roots` already provide the functionality that was added here.

The behavior was changed to the old one, consistent with the
docstring and the docstring itself was updated to point out the standart ways
to get non-radical roots.
```
