### PR TITLE
Use `sort_key()` to sort those elements in `FiniteSet` which have it.

### DIFF
--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -475,7 +475,7 @@ class Category(Basic):
         >>> B = Object("B")
         >>> K = Category("K", FiniteSet(A, B))
         >>> K.objects
-        Class({Object("B"), Object("A")})
+        Class({Object("A"), Object("B")})
 
         """
         return self.args[1]
@@ -773,7 +773,7 @@ class Diagram(Basic):
         >>> g = NamedMorphism(B, C, "g")
         >>> d = Diagram([f, g])
         >>> d.objects
-        {Object("C"), Object("B"), Object("A")}
+        {Object("A"), Object("B"), Object("C")}
 
         """
         return self.args[2]

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1124,11 +1124,9 @@ class UniversalSet(Set):
 
 def element_sort_fn(x):
     try:
-        if x.is_comparable is True:
-            return x
+        return x.sort_key()
     except:
-        pass
-    return 1e9+abs(hash(x))
+        return 1e9+abs(hash(x))
 
 class FiniteSet(Set, EvalfMixin):
     """
@@ -1161,7 +1159,7 @@ class FiniteSet(Set, EvalfMixin):
             return EmptySet()
 
         args = frozenset(args) # remove duplicates
-        args = sorted(args, key = element_sort_fn)
+        args = sorted(args, key=element_sort_fn)
         obj = Basic.__new__(cls, *args)
         obj._elements = args
         return obj


### PR DESCRIPTION
Using `sort_key` instead of relying on the objects being comparable considerably widens the range of objects which are sorted deterministically rather than arbitrarily.
