### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.2
+install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then python bin/use2to3; cd py3k-sympy; fi
+  - python setup.py install
+script:
+  # We change directories to make sure that python won't find the copy
+  # of sympy in the source directory.
+  - mkdir empty
+  - cd empty
+  - INSTALLDIR=$(python -c "import os; import sympy; print(os.path.dirname(sympy.__file__))")
+  - "echo -e \"import sympy\\nif not sympy.test(): raise Exception('Tests failed')\" | python"
+notifications:
+  email: false

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ if sys.version_info[:2] < (2,5):
 modules = [
     'sympy.assumptions',
     'sympy.assumptions.handlers',
+    'sympy.categories',
     'sympy.combinatorics',
     'sympy.concrete',
     'sympy.core',
@@ -201,6 +202,7 @@ class run_benchmarks(Command):
 # $ python bin/generate_test_list.py
 tests = [
     'sympy.assumptions.tests',
+    'sympy.categories.tests',
     'sympy.combinatorics.tests',
     'sympy.concrete.tests',
     'sympy.core.tests',


### PR DESCRIPTION
This adds a simple `.travis.yml` script which makes SymPy repository automatically work with http://travis-ci.org/ continuous integration. You still have to enable it at travis-ci.org for _your_ repository, I enabled it for mine. Each branch with `.travis.yml` present will then be automatically tested by just pusing to github. This is _really_ awesome, because from now on, it will test your branches even before you manage to send a pull request.

Also, if we donate some money (from our funds) to travis-ci.org, they will enable testing of our pull requests. But that we can do later.

Finally, here is the current status of certik:travis-ci branch: [![Build Status](https://secure.travis-ci.org/certik/sympy.png?branch=travis-ci)](http://travis-ci.org/certik/sympy)

As you can see, it is failing -- there seem to be genuine failures in master (edit: so only in Python 3.2 now). I fixed a few in the second commit of this pull request and there will have to be a few more fixes in master. However, I suggest we merge this now and add fixes later, as this pull request doesn't break anything.

Finally, Travis CI can be configured in any way we need. I decided to test sympy _after_ `python setup.py install` is called, to reveal mistakes that we currently don't catch with sympy-bot.
