### PR TITLE
Fix FiniteSet-related Python 3 test failures.

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1126,7 +1126,7 @@ def element_sort_fn(x):
     try:
         return x.sort_key()
     except:
-        return 1e9+abs(hash(x))
+        return Float(1e9+abs(hash(x))).sort_key()
 
 class FiniteSet(Set, EvalfMixin):
     """

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1125,7 +1125,9 @@ class UniversalSet(Set):
 def element_sort_fn(x):
     try:
         return x.sort_key()
-    except:
+    except TypeError:
+        return Float(1e9+abs(hash(x))).sort_key()
+    except AttributeError:
         return Float(1e9+abs(hash(x))).sort_key()
 
 class FiniteSet(Set, EvalfMixin):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1125,9 +1125,7 @@ class UniversalSet(Set):
 def element_sort_fn(x):
     try:
         return x.sort_key()
-    except TypeError:
-        return Float(1e9+abs(hash(x))).sort_key()
-    except AttributeError:
+    except (TypeError, AttributeError):
         return Float(1e9+abs(hash(x))).sort_key()
 
 class FiniteSet(Set, EvalfMixin):


### PR DESCRIPTION
This pull request makes the behaviour of `element_sort_fn` in `core/sets.py` consistent with that of `sort_key` in all SymPy classes.

This pull request also makes exception handling in `element_sort_fn` more specific.
