### PR TITLE
Provide a docstring for `element_sort_fn` in `sympy.core.sets`.

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1123,6 +1123,32 @@ class UniversalSet(Set):
         return self
 
 def element_sort_fn(x):
+    """
+    Provides sorting keys for the elements of a :class:`FiniteSet`.
+
+    Instances of :class:`Basic` are sorted in accordance with
+    ``Basic.sort_key``.  Other kinds of objects are sorted according
+    to an ad-hoc sorting key.
+
+    No particular ordering for non-:class:`Basic` objects is
+    guaranteed.
+
+    Examples
+    ========
+
+    >>> from sympy import FiniteSet, Float, Symbol, Interval
+    >>> x = Symbol('x')
+    >>> A = FiniteSet(1, 2 ,3)
+    >>> A
+    {1, 2, 3}
+    >>> FiniteSet((1,2), Float, A, -5, x, 'eggs', x**2, Interval)
+    {-5, <class 'sympy.core.numbers.Float'>, <class 'sympy.core.sets.Interval'>,
+    eggs, x, x**2, {1, 2, 3}, (1, 2)}
+
+    See Also
+    ========
+    FiniteSet
+    """
     try:
         return x.sort_key()
     except (TypeError, AttributeError):


### PR DESCRIPTION
Another nanopullrequest for the internals of `FiniteSet`.  This one adds a verbose docstring for `element_sort_fn`, which isn't even marked as an internal function, and therefore requires one.
