### PR TITLE
Run doctests in Travis CI as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   # of sympy in the source directory.
   - mkdir empty
   - cd empty
-  - INSTALLDIR=$(python -c "import os; import sympy; print(os.path.dirname(sympy.__file__))")
   - "echo -e \"import sympy\\nif not sympy.test(): raise Exception('Tests failed')\" | python"
+  - "echo -e \"import sympy\\nif not sympy.doctest(): raise Exception('Doctests failed')\" | python"
 notifications:
   email: false


### PR DESCRIPTION
**IMPORTANT**: Only merge this _after_ the pull request #1366 is in.

Now both regular tests and doctests are run. The only missing tests are documentation tests. This pull request is a simple change and you can see the Travis CI results here: http://travis-ci.org/#!/certik/sympy/builds/1676447

You can notice, that the doctests for Python 3.2 were not run due to a test failure. That is ok and that's why the pull request #1366 needs to be merged first. Then we need to trigger a new test run for this branch to make sure that all doctests pass for Python 3.2 and thus we keep the green light.
