### PR TITLE
Preprocess strings containing relational operators in sympify

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -4,6 +4,7 @@ from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
 from sympy.core.decorators import _sympifyit
+from sympy.core.relational import Rel
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
@@ -403,3 +404,13 @@ def test_no_autosimplify_into_Mul():
     s = '-1 - 2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x)))'.replace('x', '_kern')
     ss = S(s)
     assert ss != 1 and ss.simplify() == -1
+
+def test_relational():
+    assert S('sin(x)*x/5*5! <= y') == Rel(24*sin(x)*x, y, '<=')
+    assert S('sin(x)*x/5*5! != y') == Rel(24*sin(x)*x, y, '!=')
+    assert S('sin(x)*x/5*5! <> y') == Rel(24*sin(x)*x, y, '<>')
+    assert S('sin(x)*x/5*5! == y') == Rel(24*sin(x)*x, y, '==')
+    assert S('sin(x)*x/5*5! >= y') == Rel(24*sin(x)*x, y, '>=')
+    assert S('sin(x)*x/5*5! > y') == Rel(24*sin(x)*x, y, '>')
+    assert S('sin(x)*x/5*5! < y') == Rel(24*sin(x)*x, y, '<')
+

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -159,6 +159,7 @@ def parse_expr(s, local_dict=None, rationalize=False, convert_xor=False):
         hit = kern in s
 
     code = _transform(s.strip(), local_dict, global_dict, rationalize, convert_xor)
+    code = _parse_relationals(code)
     expr = eval(code, global_dict, local_dict) # take local objects in preference
 
     if not hit:
@@ -167,3 +168,12 @@ def parse_expr(s, local_dict=None, rationalize=False, convert_xor=False):
         return expr.xreplace({C.Symbol(kern): 1})
     except (TypeError, AttributeError):
         return expr
+
+
+def _parse_relationals(expr_string):
+    """Transform strings containing relational operators into strings calling Rel"""
+    match = re.match(r'(?P<lhs>.*?)(?P<rel>==|<>|>=|<=|>|<|!=)(?P<rhs>.*)', expr_string)
+    if match:
+        return "relational.Rel(%(lhs)s, %(rhs)s, '%(rel)s')" % match.groupdict()
+    else:
+        return expr_string


### PR DESCRIPTION
Now this works:

```
In [1]: sympify('a<b')
Out[1]: a < b

In [2]: sympify('a==b')
Out[2]: a = b

In [3]: sympify('sin(a)==b')
Out[3]: sin(a) = b
```

etc...

Fixes issue 1625
