### PR TITLE
Test subprocess

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -33,6 +33,9 @@ parser.add_option('-t', '--types', dest='types', action='store',
         help='setup ground types: gmpy | python | sympy')
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
+parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
+                  default=True, help="Don't run the tests in a separate "
+                  "subprocess.  This may prevent hash randomization from being enabled.")
 parser.set_usage("test [options ...] [files ...]")
 parser.epilog = """\
 "options" are any of the options above. "files" are 0 or more glob strings of \
@@ -51,7 +54,7 @@ if options.types:
 import sympy
 
 ok = sympy.doctest(*args, **{"verbose": options.verbose,
-    "blacklist": blacklist, "normal": options.normal})
+    "blacklist": blacklist, "normal": options.normal, "subprocess": options.subprocess})
 
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -40,9 +40,12 @@ parser.add_option('-t', '--types', dest='types', action='store',
 parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
         default=True, help='disable caching mechanism')
 parser.add_option("--timeout", action="store", dest="timeout",
-        default=False, help="Set a timeout for the all functions. By default there is no timeout.",type='int')
+        default=False, help="Set a timeout for the all functions, in seconds. By default there is no timeout.",type='int')
 parser.add_option("--slow", action="store_true", dest="slow",
         default=False, help="Run only the slow functions.")
+parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
+                  default=True, help="Don't run the tests in a separate "
+                  "subprocess.  This may prevent hash randomization from being enabled.")
 parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = """\
 "options" are any of the options above. "tests" are 0 or more glob strings of \
@@ -61,7 +64,8 @@ import sympy
 ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
     "force_colors": options.force_colors, "sort": options.sort, "seed":
-    options.seed, "slow": options.slow, "timeout": options.timeout})
+    options.seed, "slow": options.slow, "timeout": options.timeout,
+    'subprocess': options.subprocess})
 
 if ok:
     sys.exit(0)

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -171,6 +171,12 @@ if size > 2**32:
 else:
     ARCH = "32-bit"
 
+# Python 2.5 does not have sys.flags (it doesn't have hash randomization either)
+HASH_RANDOMIZATION = hasattr(sys, 'flags') and getattr(sys.flags,
+                                                       'hash_randomization',
+                                                       False)
+
+
 def debug(*args):
     """
     Print ``*args`` if SYMPY_DEBUG is True, else do nothing.

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -637,7 +637,7 @@ def _doctest(*paths, **kwargs):
         print
         print("DO *NOT* COMMIT!")
 
-    return not failed
+    return int(failed)
 
 # The Python 2.5 doctest runner uses a tuple, but in 2.6+, it uses a namedtuple
 # (which doesn't exist in 2.5-)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -404,6 +404,10 @@ def test(*paths, **kwargs):
     $ PYTHONHASHSEED=42 ./bin/test
 
     If the seed is not set, a random seed will be chosen.
+
+    Note that to reproduce the same hash values, you must use both the same as
+    well as the same architecture (32-bit vs. 64-bit).
+
     """
     subprocess = kwargs.pop("subprocess", True)
     if subprocess:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -221,7 +221,15 @@ def run_in_subprocess_with_hash_randomization(function, function_args=(),
     commandstring = ("import sys; from %s import %s;sys.exit(%s(*%s, **%s))" %
                      (module, function, function, repr(function_args), repr(function_kwargs)))
 
-    return subprocess.call([command, "-R", "-c", commandstring])
+    try:
+        return subprocess.call([command, "-R", "-c", commandstring])
+    finally:
+        # Put the environment variable back, so that it reads correctly for
+        # the current Python process.
+        if hash_seed is None:
+            del os.environ["PYTHONHASHSEED"]
+        else:
+            os.environ["PYTHONHASHSEED"] = hash_seed
 
 def run_all_tests(test_args=(), test_kwargs={}, doctest_args=(),
     doctest_kwargs={}, examples_args=(), examples_kwargs={'quiet':True}):
@@ -255,6 +263,7 @@ def run_all_tests(test_args=(), test_kwargs={}, doctest_args=(),
             tests_successful = False
 
         # Doctests
+        print
         if not doctest(*doctest_args, **doctest_kwargs):
             tests_successful = False
 


### PR DESCRIPTION
This enables testing with hash randomization.  Hash randomization is a new feature of Python where hash values are randomized, so as to prevent against a hash collision security issue.  It causes many test failures (see [issue 3272](http://code.google.com/p/sympy/issues/detail?id=3272)) because so many operations in SymPy are hash dependent (in particular, the ordering of .args in Add and Mul).

Hash randomization will be enabled by default in Python 3.3, so this is important.  Because the only way to get the hash seed is to set it first, and the only way to set it is to set an environment variable before starting Python, we have to start a new subprocess to test this.  A new subprocess is started only when necessary, and can be disabled (see the commit messages and the added docstrings for more information).  If anyone knows of a better way, please let me know, but this seems to work quite well to me.

An important note:  the bot tests for this pull request are going to have failures.  That's a good thing.  It means that it's working.  The test failures are related to hash randomization (all of them are, since tests are currently all passing in master).  My hope is that by getting this in, I can start to draw attention to these failures and get them fixed.  Of course, if you think any of the failures are actually caused by the changes in this request, please let me know.
