### PR TITLE
Do not implicitly sort elements in FiniteSet.

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -9,6 +9,8 @@ from sympy.mpmath import mpi, mpf
 from sympy.assumptions import ask
 from sympy.logic.boolalg import And, Or
 
+from sympy.utilities import default_sort_key
+
 class Set(Basic):
     """
     The base class for any kind of set.
@@ -1220,11 +1222,13 @@ class FiniteSet(Set, EvalfMixin):
             raise ValueError("%s: Complement not defined for symbolic inputs"
                     %self)
 
+        args = sorted(self.args, key=default_sort_key)
+
         intervals = [] # Build up a list of intervals between the elements
-        intervals += [Interval(S.NegativeInfinity, self.args[0], True, True)]
-        for a, b in zip(self.args[:-1], self.args[1:]):
+        intervals += [Interval(S.NegativeInfinity, args[0], True, True)]
+        for a, b in zip(args[:-1], args[1:]):
             intervals.append(Interval(a, b, True, True)) # open intervals
-        intervals.append(Interval(self.args[-1], S.Infinity, True, True))
+        intervals.append(Interval(args[-1], S.Infinity, True, True))
         return Union(intervals, evaluate=False)
 
     @property

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1122,38 +1122,6 @@ class UniversalSet(Set):
     def _union(self, other):
         return self
 
-def element_sort_fn(x):
-    """
-    Provides sorting keys for the elements of a :class:`FiniteSet`.
-
-    Instances of :class:`Basic` are sorted in accordance with
-    ``Basic.sort_key``.  Other kinds of objects are sorted according
-    to an ad-hoc sorting key.
-
-    No particular ordering for non-:class:`Basic` objects is
-    guaranteed.
-
-    Examples
-    ========
-
-    >>> from sympy import FiniteSet, Float, Symbol, Interval
-    >>> x = Symbol('x')
-    >>> A = FiniteSet(1, 2 ,3)
-    >>> A
-    {1, 2, 3}
-    >>> FiniteSet((1,2), Float, A, -5, x, 'eggs', x**2, Interval)
-    {-5, <class 'sympy.core.numbers.Float'>, <class 'sympy.core.sets.Interval'>,
-    eggs, x, x**2, {1, 2, 3}, (1, 2)}
-
-    See Also
-    ========
-    FiniteSet
-    """
-    try:
-        return x.sort_key()
-    except (TypeError, AttributeError):
-        return Float(1e9+abs(hash(x))).sort_key()
-
 class FiniteSet(Set, EvalfMixin):
     """
     Represents a finite set of discrete numbers
@@ -1185,7 +1153,6 @@ class FiniteSet(Set, EvalfMixin):
             return EmptySet()
 
         args = frozenset(args) # remove duplicates
-        args = sorted(args, key=element_sort_fn)
         obj = Basic.__new__(cls, *args)
         obj._elements = args
         return obj

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1261,3 +1261,6 @@ class FiniteSet(Set, EvalfMixin):
 
     def _eval_evalf(self, prec):
         return FiniteSet(elem.evalf(prec) for elem in self)
+
+    def _hashable_content(self):
+        return (self._elements,)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1007,7 +1007,8 @@ class LatexPrinter(Printer):
                 return 'Domain on ' + self._print(d.symbols)
 
     def _print_FiniteSet(self, s):
-        return self._print_set(s.args)
+        items = sorted(s.args, key=default_sort_key)
+        return self._print_set(items)
 
     def _print_set(self, s):
         items = sorted(s, key=default_sort_key)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -125,10 +125,11 @@ class StrPrinter(Printer):
         return "%s!" % self.parenthesize(expr.args[0], PRECEDENCE["Pow"])
 
     def _print_FiniteSet(self, s):
+        s = sorted(s, key=default_sort_key)
         if len(s) > 10:
-            printset = s.args[:3] + ('...',) + s.args[-3:]
+            printset = s[:3] + ['...'] + s[-3:]
         else:
-            printset = s.args
+            printset = s
         return '{' + ', '.join(self._print(el) for el in printset) + '}'
 
     def _print_Function(self, expr):


### PR DESCRIPTION
This pull request makes FiniteSet not sort its elements at construction and fixes the consequences.
