### PR TITLE
Fix the way that Derivatives are produced when using abuse of notation.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1025,7 +1025,7 @@ class Derivative(Expr):
                 obj = None
             else:
                 if not is_symbol:
-                    new_v = C.Symbol('diff_wrt_%i' % i)
+                    new_v = C.Dummy('diff_wrt_%i' % i)
                     expr = expr.subs(v, new_v)
                     old_v = v
                     v = new_v

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1025,7 +1025,7 @@ class Derivative(Expr):
                 obj = None
             else:
                 if not is_symbol:
-                    new_v = C.Dummy('diff_wrt_%i' % i)
+                    new_v = C.Dummy('xi_%i' % i)
                     expr = expr.subs(v, new_v)
                     old_v = v
                     v = new_v

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -458,7 +458,7 @@ def test_sort_variable():
 def test_unhandled():
     class MyExpr(Expr):
         def _eval_derivative(self, s):
-            if not s.name.startswith('diff_wrt'):
+            if not s.name.startswith('xi'):
                 return self
             else:
                 return None

--- a/sympy/core/tests/test_functions.py
+++ b/sympy/core/tests/test_functions.py
@@ -175,7 +175,7 @@ def test_Subs():
     assert e1 + e2 == 2*e1
     assert e1.__hash__() == e2.__hash__()
     assert Subs(z*f(x+1), x, 1) not in [ e1, e2 ]
-    assert Derivative(f(x),x).subs(x,g(x)) == Derivative(f(g(x)),g(x))
+    assert Derivative(f(x),x).subs(x,g(x)) == Subs(Derivative(f(x),x), (x,), (g(x),))
     assert Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).n(1) == \
         Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).evalf(1) == \
         z + Rational('1/2').n(1)*f(0)
@@ -396,13 +396,16 @@ def test_diff_wrt():
 
     # Chain rule cases
     assert f(g(x)).diff(x) ==\
-        Derivative(f(g(x)),g(x))*Derivative(g(x),x)
+        Subs(Derivative(f(x),x), (x,), (g(x),))*Derivative(g(x),x)
     assert diff(f(g(x),h(x)),x) ==\
-        Derivative(f(g(x), h(x)), g(x))*Derivative(g(x), x) +\
-        Derivative(f(g(x), h(x)), h(x))*Derivative(h(x), x)
-    assert f(sin(x)).diff(x) == Derivative(f(sin(x)),sin(x))*cos(x)
+        Subs(Derivative(f(y,h(x)),y), (y,), (g(x),))*Derivative(g(x), x) +\
+        Subs(Derivative(f(g(x),y),y), (y,), (h(x),))*Derivative(h(x), x)
+    assert f(sin(x)).diff(x) == Subs(Derivative(f(x),x), (x,), (sin(x),))*cos(x)
 
-    assert diff(f(g(x)),g(x)) == Derivative(f(g(x)),g(x))
+    assert diff(f(g(x)),g(x)) == Subs(Derivative(f(x), x), (x,), (g(x),))
+
+def test_diff_wrt_func_subs():
+     f(g(x)).diff(x).subs(g, Lambda(x, 2*x)) == f(2*x).diff(x)
 
 def test_diff_wrt_not_allowed():
     raises(ValueError, lambda: diff(sin(x**2),x**2))


### PR DESCRIPTION
Pull Request #460 introduced support for a handy abuse of notation, however it
disregarded the convention for constructing `Subs(Derivative(...))` objects
causing serious inconsistencies:
- this does not work anymore:

```
In [1]: f(g(x)).diff(x).subs(g, Lambda(x, 2*x))
Error
```
- these results are inconsistent:

```
In [6]: Derivative(f(x), x).subs(x, 2*x)
Out[6]: Subs(Derivative(f(_x), _x), (_x,), (2*x,))

In [7]: Derivative(f(x), x).subs(x, sin(x))
Out[7]: Derivative(f(sin(x)), sin(x))
```

These are fixed in the present commit.

There was also a conflicting definition of "derivation wrt function" in the
docstring that was partially removed. The main source of the inconsistency was
the confusion in calling `f(x)` a function when only `f` is a function. This
does not permit a real distinction between `f(x)` and `2*x` which was claimed
in the docstring.
