### PR TITLE
Intersect range

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -558,7 +558,7 @@ class Interval(Set, EvalfMixin):
         if empty:
             return S.EmptySet
 
-        return self.__class__(start, end, left_open, right_open)
+        return Interval(start, end, left_open, right_open)
 
     def _union(self, other):
         """

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -89,8 +89,11 @@ class Integers(Set):
 
     def _intersect(self, other):
         if other.is_Interval:
-            s = Range(ceiling(other.left), floor(other.right) + 1)
-            return s.intersect(other) # take out endpoints if open interval
+            try:
+                s = Range(ceiling(other.left), floor(other.right) + 1)
+                return s.intersect(other) # take out endpoints if open interval
+            except:
+                return None
         return None
 
     def _contains(self, other):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -18,7 +18,7 @@ class Naturals(Set):
     Examples
     ========
 
-        >>> from sympy import S, Interval
+        >>> from sympy import S, Interval, pprint
         >>> 5 in S.Naturals
         True
         >>> iterable = iter(S.Naturals)
@@ -28,8 +28,8 @@ class Naturals(Set):
         2
         >>> print iterable.next()
         3
-        >>> S.Naturals.intersect(Interval(0, 10))
-        {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+        >>> pprint(S.Naturals.intersect(Interval(0, 10)))
+        {1, 2, ..., 10}
     """
 
     __metaclass__ = Singleton
@@ -67,7 +67,7 @@ class Integers(Set):
     Examples
     ========
 
-        >>> from sympy import S, Interval
+        >>> from sympy import S, Interval, pprint
         >>> 5 in S.Naturals
         True
         >>> iterable = iter(S.Integers)
@@ -80,8 +80,8 @@ class Integers(Set):
         >>> print iterable.next()
         2
 
-        >>> S.Integers.intersect(Interval(-4, 4))
-        {-4, -3, -2, -1, 0, 1, 2, 3, 4}
+        >>> pprint(S.Integers.intersect(Interval(-4, 4)))
+        {-4, -3, ..., 4}
     """
 
     __metaclass__ = Singleton

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -89,7 +89,7 @@ class Integers(Set):
 
     def _intersect(self, other):
         if other.is_Interval:
-            s = FiniteSet(range(ceiling(other.left), floor(other.right) + 1))
+            s = Range(ceiling(other.left), floor(other.right) + 1)
             return s.intersect(other) # take out endpoints if open interval
         return None
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -88,12 +88,9 @@ class Integers(Set):
     is_iterable = True
 
     def _intersect(self, other):
-        if other.is_Interval:
-            try:
-                s = Range(ceiling(other.left), floor(other.right) + 1)
-                return s.intersect(other) # take out endpoints if open interval
-            except:
-                return None
+        if other.is_Interval and other.measure < oo:
+            s = Range(ceiling(other.left), floor(other.right) + 1)
+            return s.intersect(other) # take out endpoints if open interval
         return None
 
     def _contains(self, other):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -3,6 +3,7 @@ from sympy.core.sets import FiniteSet, Interval
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
         Rational, sqrt)
 from sympy.utilities.pytest import XFAIL
+import itertools
 
 x = Symbol('x')
 
@@ -136,8 +137,15 @@ def test_reals():
 def test_reals_fail():
     assert sqrt(-1) not in S.Reals
 
+def take(n, iterable):
+    "Return first n items of the iterable as a list"
+    return list(itertools.islice(iterable, n))
 def test_intersections():
     assert 5 in S.Integers.intersect(S.Reals)
     assert 5 in S.Integers.intersect(S.Reals)
     assert -5 not in S.Naturals.intersect(S.Reals)
     assert 5.5 not in S.Integers.intersect(S.Reals)
+    assert 5 in S.Integers.intersect(Interval(3, oo))
+    assert -5 in S.Integers.intersect(Interval(-oo, 3))
+    assert all(x.is_Integer
+            for x in take(10, S.Integers.intersect(Interval(3, oo)) ))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -16,8 +16,8 @@ def test_naturals():
     assert (a,b,c,d) == (1,2,3,4)
     assert isinstance(a, Basic)
 
-    assert N.intersect(Interval(-5, 5)) == FiniteSet(1, 2, 3, 4, 5)
-    assert N.intersect(Interval(-5, 5, True, True)) == FiniteSet(1, 2, 3, 4)
+    assert N.intersect(Interval(-5, 5)) == Range(1, 6)
+    assert N.intersect(Interval(-5, 5, True, True)) == Range(1, 5)
 
     assert N.inf == 1
     assert N.sup == oo
@@ -32,8 +32,8 @@ def test_integers():
     assert (a,b,c,d) == (0, 1, -1, 2)
     assert isinstance(a, Basic)
 
-    assert Z.intersect(Interval(-5, 5)) == FiniteSet(range(-5, 6))
-    assert Z.intersect(Interval(-5, 5, True, True)) == FiniteSet(range(-4,5))
+    assert Z.intersect(Interval(-5, 5)) == Range(-5, 6)
+    assert Z.intersect(Interval(-5, 5, True, True)) == Range(-4,5)
 
     assert Z.inf == -oo
     assert Z.sup == oo

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -135,3 +135,9 @@ def test_reals():
 @XFAIL # this is because contains is now very strict
 def test_reals_fail():
     assert sqrt(-1) not in S.Reals
+
+def test_intersections():
+    assert 5 in S.Integers.intersect(S.Reals)
+    assert 5 in S.Integers.intersect(S.Reals)
+    assert -5 not in S.Naturals.intersect(S.Reals)
+    assert 5.5 not in S.Integers.intersect(S.Reals)


### PR DESCRIPTION
Integers.intersect(Interval) now produces a Range rather than a FiniteSet
Integers.intersect(Interval) produces an unevaluated Intersection when the Interval is unbounded

Fixes issue 
http://code.google.com/p/sympy/issues/detail?id=3301
