### PR TITLE
Fix sympy.core.sets.set_sort_fn (related to Union)

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -677,11 +677,11 @@ def set_sort_fn(s):
     try:
         val = s.inf
         if val.is_comparable:
-            return val
+            return default_sort_key(val)
         else:
-            return 1e9+abs(hash(s))
-    except NotImplementedError:
-        return 1e9+abs(hash(s))
+            return default_sort_key(s)
+    except (NotImplementedError, ValueError):
+        return default_sort_key(s)
 
 class Union(Set, EvalfMixin):
     """

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -75,6 +75,12 @@ def test_union():
     assert FiniteSet(1,2,3) & FiniteSet(2,3,4) == FiniteSet(2,3)
     assert FiniteSet(1,2,3) | FiniteSet(2,3,4) == FiniteSet(1,2,3,4)
 
+    x = Symbol("x")
+    y = Symbol("y")
+    z = Symbol("z")
+    assert S.EmptySet | FiniteSet(x, FiniteSet(y, z)) == \
+           FiniteSet(x, FiniteSet(y, z))
+
     # Test that Intervals and FiniteSets play nicely
     assert Interval(1,3) + FiniteSet(2) == Interval(1,3)
     assert Interval(1,3, True,True) + FiniteSet(3) == Interval(1,3, True,False)


### PR DESCRIPTION
Currently, the following fails in `master`

```
x = Symbol('x')
y = Symbol('y')
z = Symbol('z')

S.EmptySet | FiniteSet(x, FiniteSet(y, z))
```

I get:

```
ValueError: The argument '{y, z}' is not comparable.
```

This pull request fixes this problem and also changes `set_sort_fn` to use `default_sort_key`.
