### PR TITLE
test_sets: Fixes the test failure

### DIFF
--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -184,7 +184,7 @@ def test_intersection():
     # iterable
     i = Intersection(FiniteSet(1,2,3), Interval(2, 5), evaluate=False)
     assert i.is_iterable
-    assert set(i) == set([2, 3])
+    assert set(i) == set([S(2), S(3)])
 
     # challenging intervals
     x = Symbol('x', real=True)


### PR DESCRIPTION
The left hand side is equal to set([S(2), S(3)]),
and that is not equal to set([2, 3]). So this patch fixes the right hand side.

This fixes the test failure introduced by #1394.
