### PR TITLE
TODO: rebase And(), Or(), etc. should be hash independent.

### DIFF
--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -25,9 +25,10 @@ def test_lattice_shortcircuit():
     assert join(0, object) == 0
 
 def test_lattice_print():
-    assert str(join(5, 4, 3, 2)) == 'join(2, 3, 4, 5)'
+    assert str(join(5, 4, 3, 2)) == 'join(5, 4, 3, 2)'
+    assert str(join(2, 3, 4, 5)) == 'join(2, 3, 4, 5)'
 
 def test_lattice_make_args():
-    assert join.make_args(0) == set([0])
-    assert join.make_args(1) == set([1])
-    assert join.make_args(join(2, 3, 4)) == set([S(2), S(3), S(4)])
+    assert join.make_args(0) == tuple([0])
+    assert join.make_args(1) == tuple([1])
+    assert join.make_args(join(2, 3, 4)) == tuple([S(2), S(3), S(4)])

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -255,7 +255,7 @@ class MinMaxBase(LatticeOp):
             return set(_args).pop()
         else:
             # base creation
-            obj = Expr.__new__(cls, _args, **assumptions)
+            obj = Expr.__new__(cls, *_args, **assumptions)
             obj._argset = _args
             return obj
 

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -256,6 +256,8 @@ class Equivalent(BooleanFunction, LatticeOp):
 
     Equivalent(A, B) is True if and only if A and B are both True or both False
     """
+    identity = None
+    zero = None
     @classmethod
     def eval(cls, *args):
         """

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -250,7 +250,7 @@ class Implies(BooleanFunction):
         else:
             return Basic.__new__(cls, *args)
 
-class Equivalent(BooleanFunction):
+class Equivalent(BooleanFunction, LatticeOp):
     """
     Equivalence relation.
 
@@ -278,16 +278,17 @@ class Equivalent(BooleanFunction):
 
         """
 
-        argset = set(args)
+        from sympy.utilities.iterables import uniq
+        argset = uniq(args)
         if len(argset) <= 1:
             return True
         if True in argset:
-            argset.discard(True)
+            argset = [x for x in argset if x is not True]
             return And(*argset)
         if False in argset:
-            argset.discard(False)
+            argset = [x for x in argset if x is not False]
             return Nor(*argset)
-        return Basic.__new__(cls, *set(args))
+        return Basic.__new__(cls, *args)
 
 class ITE(BooleanFunction):
     """
@@ -355,7 +356,7 @@ def conjuncts(expr):
     frozenset([Or(A, B)])
 
     """
-    return And.make_args(expr)
+    return frozenset(And.make_args(expr))
 
 def disjuncts(expr):
     """Return a list of the disjuncts in the sentence s.
@@ -370,7 +371,7 @@ def disjuncts(expr):
     frozenset([And(A, B)])
 
     """
-    return Or.make_args(expr)
+    return frozenset(Or.make_args(expr))
 
 def distribute_and_over_or(expr):
     """
@@ -394,7 +395,7 @@ def distribute_and_over_or(expr):
             return expr
         rest = Or(*[a for a in expr.args if a is not conj])
         return And(*map(distribute_and_over_or,
-                   [Or(c, rest) for c in conj.args]))
+                   [Or(rest, c) for c in conj.args]))
     elif expr.func is And:
         return And(*map(distribute_and_over_or, expr.args))
     else:
@@ -500,10 +501,10 @@ def eliminate_implications(expr):
     args = map(eliminate_implications, expr.args)
     if expr.func is Implies:
         a, b = args[0], args[-1]
-        return (~a) | b
+        return b | (~a)
     elif expr.func is Equivalent:
         a, b = args[0], args[-1]
-        return (a | Not(b)) & (b | Not(a))
+        return (b | Not(a)) & (a | Not(b))
     else:
         return expr.func(*args)
 
@@ -522,7 +523,7 @@ def compile_rule(s):
     >>> compile_rule('A & B')
     And(A, B)
     >>> compile_rule('(~B & ~C)|A')
-    Or(A, And(Not(B), Not(C)))
+    Or(And(Not(B), Not(C)), A)
     """
     import re
     from sympy.core import Symbol

--- a/sympy/logic/utilities/dimacs.py
+++ b/sympy/logic/utilities/dimacs.py
@@ -23,7 +23,7 @@ def load(s):
     >>> load('1 \\n 2')
     And(cnf_1, cnf_2)
     >>> load('1 2 \\n 3')
-    And(cnf_3, Or(cnf_1, cnf_2))
+    And(Or(cnf_1, cnf_2), cnf_3)
     """
     clauses = []
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -183,7 +183,7 @@ class StrPrinter(Printer):
             return "Lambda((%s), %s" % (arg_string, expr)
 
     def _print_LatticeOp(self, expr):
-        args = sorted(expr.args, key=default_sort_key)
+        args = expr.args
         return expr.func.__name__ + "(%s)"%", ".join(self._print(arg) for arg in args)
 
     def _print_Limit(self, expr):

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -55,8 +55,8 @@ def test_piecewise():
     )
     l = lambdarepr(p)
     eval(h + l)
-    assert l == "((x) if (x < 1) else (((x**2) if (((x <= 4) "\
-        "and (x > 3))) else (((0) if (True) else None)))))"
+    assert l == "((x) if (x < 1) else (((x**2) if (((x > 3) "\
+        "and (x <= 4))) else (((0) if (True) else None)))))"
 
     p = Piecewise(
         (x**2, x < 0),

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -308,7 +308,7 @@ def reduce_abs_inequalities(exprs, gen, assume=True):
 
     >>> reduce_abs_inequalities([(Abs(3*x - 5) - 7, '<'),
     ... (Abs(x + 25) - 13, '>')], x, assume=Q.real(x))
-    And(Or(-12 < x, x < -38), -2/3 < x, x < 4)
+    And(-2/3 < x, x < 4, Or(x < -38, -12 < x))
 
     >>> reduce_abs_inequalities([(Abs(x - 4) + Abs(3*x - 5) - 7, '<')], x,
     ... assume=Q.real(x))

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -410,7 +410,7 @@ def solve(f, *symbols, **flags):
     * boolean or univariate Relational
 
         >>> solve(x < 3)
-        And(im(x) == 0, re(x) < 3)
+        And(re(x) < 3, im(x) == 0)
 
     * to always get a list of solution mappings, use flag dict=True
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1375,7 +1375,7 @@ def Triangular(name, a, b, c):
                          And(a <= _x, _x < c)),
                          (2/(-a + b), _x == c),
                          ((-2*_x + 2*b)/((-a + b)*(b - c)),
-                         And(_x <= b, c < _x)), (0, True)))
+                         And(c < _x, _x <= b)), (0, True)))
 
     References
     ==========

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -44,7 +44,8 @@ class FiniteDomain(RandomDomain):
         return self.elements.__iter__()
 
     def as_boolean(self):
-        return Or(*[And(*[Eq(sym, val) for sym, val in item]) for item in self])
+        sorted_self = sorted([[(sym, val) for sym, val in sorted(item)] for item in self])
+        return Or(*[And(*[Eq(sym, val) for sym, val in item]) for item in sorted_self])
 
 class SingleFiniteDomain(FiniteDomain):
     """


### PR DESCRIPTION
Don't use a set() for LatticeOp()'s args as the order comes
out hash dependent. Instead, use a tuple, don't sort the args,
but still remove duplicates.

We need to override **eq** so that And(x, y) == And(y, x)
remains satisfied.
