### PR TITLE
Fix bin/coverage_report.py

### DIFF
--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -68,7 +68,7 @@ def make_report(source_dir, report_dir, use_cache=False):
         cov.erase()
         cov.start()
         import sympy
-        sympy.test(source_dir)
+        sympy.test(source_dir, subprocess=False)
         #sympy.doctest()        #coverage doesn't play well with doctests
         cov.stop()
         cov.save()


### PR DESCRIPTION
Coverage test runs must be run in the same process.
