### PR TITLE
Reorganized sphinx docs in physics.mechanics

### DIFF
--- a/doc/src/modules/physics/mechanics/api/essential.txt
+++ b/doc/src/modules/physics/mechanics/api/essential.txt
@@ -1,0 +1,23 @@
+=================================
+Essential Components (Docstrings)
+=================================
+
+ReferenceFrame
+==============
+
+.. automodule:: sympy.physics.mechanics.essential
+   :members: ReferenceFrame
+
+
+Vector
+======
+
+.. automodule:: sympy.physics.mechanics.essential
+   :members: Vector
+
+
+Dyadic
+======
+
+.. automodule:: sympy.physics.mechanics.essential
+   :members: Dyadic

--- a/doc/src/modules/physics/mechanics/api/functions.txt
+++ b/doc/src/modules/physics/mechanics/api/functions.txt
@@ -1,0 +1,37 @@
+========================================
+Related Essential Functions (Docstrings)
+========================================
+
+dynamicsymbols
+==============
+
+.. automodule:: sympy.physics.mechanics.essential
+   :members: dynamicsymbols
+
+
+dot
+===
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: dot
+
+
+cross
+=====
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: cross
+
+
+outer
+=====
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: outer
+
+
+express
+=======
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: express

--- a/doc/src/modules/physics/mechanics/api/kane.txt
+++ b/doc/src/modules/physics/mechanics/api/kane.txt
@@ -1,0 +1,16 @@
+=================================================
+Kane's Method & Associated Functions (Docstrings)
+=================================================
+
+Kane
+====
+
+.. automodule:: sympy.physics.mechanics.kane
+   :members:
+
+
+partial_velocity
+================
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: partial_velocity

--- a/doc/src/modules/physics/mechanics/api/kinematics.txt
+++ b/doc/src/modules/physics/mechanics/api/kinematics.txt
@@ -1,0 +1,16 @@
+=======================
+Kinematics (Docstrings)
+=======================
+
+Point
+=====
+
+.. automodule:: sympy.physics.mechanics.point
+   :members:
+
+
+kinematic_equations
+===================
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: kinematic_equations

--- a/doc/src/modules/physics/mechanics/api/part_bod.txt
+++ b/doc/src/modules/physics/mechanics/api/part_bod.txt
@@ -1,0 +1,44 @@
+=====================================================
+Masses, Inertias & Particles, RigidBodys (Docstrings)
+=====================================================
+
+Particle
+========
+
+.. automodule:: sympy.physics.mechanics.particle
+   :members:
+
+
+RigidBody
+=========
+
+.. automodule:: sympy.physics.mechanics.rigidbody
+   :members:
+
+
+inertia
+=======
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: inertias
+
+
+inertia_of_point_mass
+=====================
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: inertia_of_point_mass
+
+
+linearmomentum
+==============
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: linearmomentum
+
+
+angularmomentum
+===============
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: angularmomentum

--- a/doc/src/modules/physics/mechanics/api/printing.txt
+++ b/doc/src/modules/physics/mechanics/api/printing.txt
@@ -1,0 +1,30 @@
+=====================
+Printing (Docstrings)
+=====================
+
+mechanics_printing
+==================
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: mechanics_printing
+
+
+mprint
+======
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: mprint
+
+
+mpprint
+=======
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: mpprint
+
+
+mlatex
+======
+
+.. automodule:: sympy.physics.mechanics.functions
+   :members: mlatex

--- a/doc/src/modules/physics/mechanics/essential.txt
+++ b/doc/src/modules/physics/mechanics/essential.txt
@@ -1,6 +1,0 @@
-======================
-Essential(Docstrings)
-======================
-
-.. automodule:: sympy.physics.mechanics.essential
-   :members:

--- a/doc/src/modules/physics/mechanics/examples.txt
+++ b/doc/src/modules/physics/mechanics/examples.txt
@@ -96,7 +96,7 @@ dots (time derivatives of the generalized speeds). ::
   >>> kdd = KM.kindiffdict()
   >>> rhs = rhs.subs(kdd)
   >>> rhs.simplify()
-  >>> mprint(rhs, order=None)
+  >>> mprint(rhs)
   [(4*g*sin(q2)/5 + 2*r*u2*u3 - r*u3**2*tan(q2))/r]
   [                                     -2*u1*u3/3]
   [                        (-2*u2 + u3*tan(q2))*u1]
@@ -166,11 +166,11 @@ represent the constraint forces in those directions. ::
   >>> kdd = KM.kindiffdict()
   >>> rhs = rhs.subs(kdd)
   >>> rhs.simplify()
-  >>> mprint(rhs, order=None)
+  >>> mprint(rhs)
   [(4*g*sin(q2)/5 + 2*r*u2*u3 - r*u3**2*tan(q2))/r]
   [                                     -2*u1*u3/3]
   [                        (-2*u2 + u3*tan(q2))*u1]
-  >>> mprint(KM.auxiliary_eqs, order=None)
+  >>> mprint(KM.auxiliary_eqs)
   [                                                  -m*(r*u1*u3 + r*u2') + f1]
   [       -m*r*((u1**2 + u2**2)*sin(q2) + (u2*u3 + u3*q3' - u1')*cos(q2)) + f2]
   [-g*m - m*r*((-u1**2 - u2**2)*cos(q2) + (u2*u3 + u3*q3' - u1')*sin(q2)) + f3]

--- a/doc/src/modules/physics/mechanics/functions.txt
+++ b/doc/src/modules/physics/mechanics/functions.txt
@@ -1,9 +1,0 @@
-=========
-Functions
-=========
-
-Docstrings
-==========
-
-.. automodule:: sympy.physics.mechanics.functions
-   :members:

--- a/doc/src/modules/physics/mechanics/index.txt
+++ b/doc/src/modules/physics/mechanics/index.txt
@@ -2,7 +2,7 @@
 Classical Mechanics
 ===================
 
-:Authors: Gilbert Gede, Luke Peterson
+:Authors: Gilbert Gede, Luke Peterson, Angadh Nanjangud
 
 .. topic:: Abstract
 
@@ -22,22 +22,30 @@ to create equations of motion, for dynamics. It is also limited to rigid bodies
 and particles.
 
 
-Contents
-========
+Guide to Mechanics
+==================
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
 
     vectors.txt
     kinematics.txt
     masses.txt
     kane.txt
-    particle.txt
-    point.txt
-    rigidbody.txt
-    essential.txt
     examples.txt
     advanced.txt
-    functions.txt
     reference.txt
+
+Mechanics API
+=============
+
+.. toctree::
+    :maxdepth: 2
+
+    api/essential.txt
+    api/functions.txt
+    api/kinematics.txt
+    api/part_bod.txt
+    api/kane.txt
+    api/printing.txt
 

--- a/doc/src/modules/physics/mechanics/kane.txt
+++ b/doc/src/modules/physics/mechanics/kane.txt
@@ -172,9 +172,3 @@ equations, an error with be raised. ::
 
 Exploration of the provided examples is encouraged in order to gain more
 understanding of the ``Kane`` object.
-
-Docstrings
-==========
-
-.. automodule:: sympy.physics.mechanics.kane
-   :members:

--- a/doc/src/modules/physics/mechanics/particle.txt
+++ b/doc/src/modules/physics/mechanics/particle.txt
@@ -1,9 +1,0 @@
-========
-Particle
-========
-
-Docstrings
-==========
-
-.. automodule:: sympy.physics.mechanics.particle
-   :members:

--- a/doc/src/modules/physics/mechanics/point.txt
+++ b/doc/src/modules/physics/mechanics/point.txt
@@ -1,9 +1,0 @@
-=====
-Point
-=====
-
-Docstrings
-==========
-
-.. automodule:: sympy.physics.mechanics.point
-   :members:

--- a/doc/src/modules/physics/mechanics/rigidbody.txt
+++ b/doc/src/modules/physics/mechanics/rigidbody.txt
@@ -1,9 +1,0 @@
-==========
-Rigid Body
-==========
-
-Docstrings
-==========
-
-.. automodule:: sympy.physics.mechanics.rigidbody
-   :members:


### PR DESCRIPTION
The layout of the documentation was a little mixed up, so now it is separated into a tutorial section and an API section.
