### PR TITLE
TODO: rebase Add info build target in doc/Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -25,6 +25,8 @@ help:
 	@echo "  web         to make files usable by Sphinx.web"
 	@echo "  htmlhelp    to make HTML files and a HTML help project"
 	@echo "  latex       to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  texinfo     to make Texinfo files"
+	@echo "  info        to make Texinfo files and run them through makeinfo"
 	@echo "  changes     to make an overview over all changed/added/deprecated items"
 	@echo "  linkcheck   to check all external links for integrity"
 	@echo "  cheatsheet  to make the Cheatsheet"
@@ -126,3 +128,18 @@ cheatsheet:
 	mkdir -p _build/cheatsheet
 	pdflatex -output-directory=_build/cheatsheet cheatsheet/cheatsheet.tex
 	pdflatex -output-directory=_build/cheatsheet cheatsheet/cheatsheet.tex
+
+texinfo:
+	mkdir -p _build/texinfo
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) _build/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in _build/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+info:
+	mkdir -p _build/texinfo
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) _build/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C _build/texinfo info
+	@echo "makeinfo finished; the Info files are in _build/texinfo."

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -155,3 +155,10 @@ pngmath_latex_preamble =  '\\usepackage{amsmath}\n'+\
               '\\usepackage{amsfonts}\n'+\
               '\\usepackage{amssymb}\n'+\
               '\\setlength{\\parindent}{0pt}\n'
+
+texinfo_documents = [
+  (master_doc, 'sympy', 'SymPy Documentation',
+   'SymPy Development Team',
+   'SymPy', 'Computer algebra system (CAS) in Python', 'Programming',
+   1),
+]


### PR DESCRIPTION
I added build targets to compile SymPy document into an info file.  However, it does not work as is.  I get the following error when tried to build (using `make info`).

I need to use `makeinfo --force --no-split -o sympy.info sympy.texi` to force compile.  Probably this is a bug in texinfo Sphinx writer.  I will report upstream.

Can this PR be merged once it is fixed in the upstream (Sphinx)?

```
Running Texinfo files through makeinfo...
make -C _build/texinfo info
make[1]: Entering directory `/.../sympy/doc/_build/texinfo'
makeinfo --no-split -o 'sympy.info' 'sympy.texi'
sympy.texi:136376: Node `Python Module Index' previously defined at line 136213.
/.../sympy/doc/_build/texinfo//sympy.texi:136213: Prev field of node `Python Module Index' not pointed to.
/.../sympy/doc/_build/texinfo//sympy.texi:136213: This node (Python Module Index) has the bad Next.
/.../sympy/doc/_build/texinfo//sympy.texi:135446: Next field of node `About' not pointed to (perhaps incorrect sectioning?).
/.../sympy/doc/_build/texinfo//sympy.texi:136213: This node (Python Module Index) has the bad Prev.
makeinfo: Removing output file `sympy.info' due to errors; use --force to preserve.
make[1]: *** [sympy.info] Error 1
make[1]: Leaving directory `/.../sympy/doc/_build/texinfo'
make: *** [info] Error 2
```
