### PR TITLE
Piecewise improvements

### DIFF
--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -495,8 +495,8 @@ def test_issue_3059():
 def test_Function_subs():
     from sympy.abc import x, y
     f, g, h, i = symbols('f,g,h,i', cls=Function)
-    p = Piecewise((g, x < -1), (g(x), x <= 1))
-    assert p.subs(g, h) == Piecewise((h, x < -1), (h(x), x <= 1))
+    p = Piecewise((g(f(x,y)), x < -1), (g(x), x <= 1))
+    assert p.subs(g, h) == Piecewise((h(f(x,y)), x < -1), (h(x), x <= 1))
     assert (f(y) + g(x)).subs({f:h,g:i}) == i(x) + h(y)
 
 def test_simultaneous_subs():

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -167,6 +167,11 @@ class Piecewise(Function):
             newargs.append((e, c))
         return Piecewise(*newargs)
 
+    def _eval_as_leading_term(self, x):
+        for e, c in self.args:
+            if c is True or c.subs(x, 0) is True:
+                return e.as_leading_term(x)
+
     def _eval_integral(self,x):
         from sympy.integrals import integrate
         return Piecewise(*[(integrate(e, x), c) for e, c in self.args])
@@ -353,10 +358,6 @@ class Piecewise(Function):
         args = map(lambda ec: (ec.expr._eval_nseries(x, n, logx), ec.cond), \
                    self.args)
         return self.func(*args)
-
-    def _eval_as_leading_term(self, x):
-        # This is completely wrong, cf. issue 3110
-        return self.args[0][0].as_leading_term(x)
 
     def _eval_template_is_attr(self, is_attr, when_multiple=None):
         b = None

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -336,12 +336,7 @@ class Piecewise(Function):
         """
         args = list(self.args)
         for i, (e, c) in enumerate(args):
-            try:
-                e = e._subs(old, new)
-            except TypeError:
-                if e != old:
-                    continue
-                e = new
+            e = e._subs(old, new)
 
             if isinstance(c, bool):
                 pass

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,7 +1,6 @@
 from sympy.core import Basic, S, Function, diff, Tuple
 from sympy.core.relational import Equality, Relational
 from sympy.logic.boolalg import And, Boolean
-from sympy.core.sets import Set
 from sympy.core.symbol import Dummy
 
 class ExprCondPair(Tuple):
@@ -94,10 +93,10 @@ class Piecewise(Function):
             cond = pair.cond
             if cond is False:
                 continue
-            if not isinstance(cond, (bool, Relational, Set, Boolean)):
+            if not isinstance(cond, (bool, Relational, Boolean)):
                 raise TypeError(
-                    "Cond %s is of type %s, but must be a bool," \
-                    " Relational, Number or Set" % (cond, type(cond)))
+                    "Cond %s is of type %s, but must be a Relational," \
+                    " Boolean, or a built-in bool." % (cond, type(cond)))
             newargs.append(pair)
             if cond is True:
                 break
@@ -343,9 +342,7 @@ class Piecewise(Function):
 
     def _eval_subs(self, old, new):
         """
-        Piecewise conditions may contain Sets whose modifications
-        requires the use of contains rather than substitution. They
-        may also contain bool which are not of Basic type.
+        Piecewise conditions may contain bool which are not of Basic type.
         """
         args = list(self.args)
         for i, (e, c) in enumerate(args):
@@ -353,10 +350,6 @@ class Piecewise(Function):
 
             if isinstance(c, bool):
                 pass
-            elif isinstance(c, Set):
-                # What do we do if there are more than one symbolic
-                # variable. Which do we put pass to Set.contains?
-                c = c.contains(new)
             elif isinstance(c, Basic):
                 c = c._subs(old, new)
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -309,8 +309,6 @@ class Piecewise(Function):
             if curr_low < int_a:
                 holes.append([curr_low, min(b, int_a), default])
             curr_low = int_b
-            if curr_low > b:
-                break
         if curr_low < b:
             holes.append([curr_low, b, default])
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -95,7 +95,7 @@ class Piecewise(Function):
                     "Cond %s is of type %s, but must be a bool," \
                     " Relational, Number or Set" % (cond, type(cond)))
             newargs.append(pair)
-            if cond is ExprCondPair.true_sentinel:
+            if cond is True:
                 break
 
         if options.pop('evaluate', True):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -41,6 +41,10 @@ class ExprCondPair(Tuple):
             result |= self.cond.free_symbols
         return result
 
+    @property
+    def is_commutative(self):
+        return self.expr.is_commutative
+
     def __iter__(self):
         yield self.expr
         yield self.cond
@@ -162,10 +166,6 @@ class Piecewise(Function):
                     c = c.doit(**hints)
             newargs.append((e, c))
         return Piecewise(*newargs)
-
-    @property
-    def is_commutative(self):
-        return all(expr.is_commutative for expr, _ in self.args)
 
     def _eval_integral(self,x):
         from sympy.integrals import integrate

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -172,7 +172,17 @@ class Piecewise(Function):
             if c is True or c.subs(x, 0) is True:
                 return e.as_leading_term(x)
 
-    def _eval_integral(self,x):
+    def _eval_conjugate(self):
+        from sympy.functions.elementary.complexes import conjugate
+        return Piecewise(*[(conjugate(e), c) for e, c in self.args])
+
+    def _eval_derivative(self, x):
+        return Piecewise(*[(diff(e, x), c) for e, c in self.args])
+
+    def _eval_evalf(self, prec):
+        return Piecewise(*[(e.evalf(prec), c) for e, c in self.args])
+
+    def _eval_integral(self, x):
         from sympy.integrals import integrate
         return Piecewise(*[(integrate(e, x), c) for e, c in self.args])
 
@@ -328,8 +338,8 @@ class Piecewise(Function):
 
         return int_expr
 
-    def _eval_derivative(self, s):
-        return Piecewise(*[(diff(e, s), c) for e, c in self.args])
+    def _eval_power(self, s):
+        return Piecewise(*[(e**s, c) for e, c in self.args])
 
     def _eval_subs(self, old, new):
         """

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -358,6 +358,34 @@ class Piecewise(Function):
         # This is completely wrong, cf. issue 3110
         return self.args[0][0].as_leading_term(x)
 
+    def _eval_template_is_attr(self, is_attr, when_multiple=None):
+        b = None
+        for expr, _ in self.args:
+            a = getattr(expr, is_attr)
+            if a is None:
+                return None
+            if b is None:
+                b = a
+            elif b is not a:
+                return when_multiple
+        return b
+
+    _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded', when_multiple=False)
+    _eval_is_complex = lambda self: self._eval_template_is_attr('is_complex')
+    _eval_is_even = lambda self: self._eval_template_is_attr('is_even')
+    _eval_is_imaginary = lambda self: self._eval_template_is_attr('is_imaginary')
+    _eval_is_integer = lambda self: self._eval_template_is_attr('is_integer')
+    _eval_is_irrational = lambda self: self._eval_template_is_attr('is_irrational')
+    _eval_is_negative = lambda self: self._eval_template_is_attr('is_negative')
+    _eval_is_nonnegative = lambda self: self._eval_template_is_attr('is_nonnegative')
+    _eval_is_nonpositive = lambda self: self._eval_template_is_attr('is_nonpositive')
+    _eval_is_nonzero = lambda self: self._eval_template_is_attr('is_nonzero', when_multiple=True)
+    _eval_is_odd = lambda self: self._eval_template_is_attr('is_odd')
+    _eval_is_polar = lambda self: self._eval_template_is_attr('is_polar')
+    _eval_is_positive = lambda self: self._eval_template_is_attr('is_positive')
+    _eval_is_real = lambda self: self._eval_template_is_attr('is_real')
+    _eval_is_zero = lambda self: self._eval_template_is_attr('is_zero', when_multiple=False)
+
     @classmethod
     def __eval_cond(cls, cond):
         """Return the truth value of the condition."""

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1,6 +1,6 @@
 from sympy import (diff, expand, Eq, Integral, integrate, Interval, lambdify,
                    log, oo, Piecewise, piecewise_fold, symbols, pi, solve,
-                   Rational, Basic)
+                   Rational, Basic, Function)
 from sympy.utilities.pytest import XFAIL, raises
 
 x,y = symbols('x,y')
@@ -27,6 +27,11 @@ def test_piecewise():
     assert p2.subs(x, 2) == 1
     assert p2.subs(x,4) == -1
     assert p2.subs(x,10) == 0
+
+    f, g, h = symbols('f,g,h', cls=Function)
+    pf = Piecewise((f(x), x < -1), (f(x) + h(x) + 2, x <= 1))
+    pg = Piecewise((g(x), x < -1), (g(x) + h(x) + 2, x <= 1))
+    assert pg.subs(g, f) == pf
 
     # Test evalf
     assert p.evalf() == p

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -193,14 +193,14 @@ def test_piecewise_fold():
     assert integrate(piecewise_fold(p),(x,-oo,oo)) == integrate(2*x + 2, (x, 0, 1))
 
 def test_piecewise_fold_expand():
-    p1 = Piecewise((1,Interval(0,1,False,True)),(0,True))
+    p1 = Piecewise((1, Interval(0, 1, False, True).contains(x)), (0, True))
 
     p2 = piecewise_fold(expand((1-x)*p1))
-    assert p2 == Piecewise((1 - x, Interval(0,1,False,True)), \
-        (Piecewise((-x, Interval(0,1,False,True)), (0, True)), True))
+    assert p2 == Piecewise((1 - x, Interval(0, 1, False, True).contains(x)), \
+        (Piecewise((-x, Interval(0, 1, False, True).contains(x)), (0, True)), True))
 
     p2 = expand(piecewise_fold((1-x)*p1))
-    assert p2 == Piecewise((1 - x, Interval(0,1,False,True)), (0, True))
+    assert p2 == Piecewise((1 - x, Interval(0, 1, False, True).contains(x)), (0, True))
 
 def test_piecewise_duplicate():
     p = Piecewise((x, x < -10),(x**2, x <= -1),(x, 1 < x))
@@ -230,7 +230,7 @@ def test_piecewise_collapse():
 def test_piecewise_lambdify():
     p = Piecewise(
         (x**2, x < 0),
-        (x, Interval(0, 1, False, True)),
+        (x, Interval(0, 1, False, True).contains(x)),
         (2 - x, x >= 1),
         (0, True)
     )

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -9,6 +9,7 @@ def test_piecewise():
 
     # Test canonization
     assert Piecewise((x, x < 1), (0, True)) == Piecewise((x, x < 1), (0, True))
+    assert Piecewise((x, x < 1), (0, True), (1, True)) == Piecewise((x, x < 1), (0, True))
     assert Piecewise((x, x < 1), (0, False), (-1, 1>2)) == Piecewise((x, x < 1))
     assert Piecewise((x, True)) == x
     raises(TypeError, lambda: Piecewise(x))

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -36,7 +36,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 0
         >>> knots = range(5)
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((1, [0, 1]), (0, True))
+        Piecewise((1, And(x <= 1, x >= 0)), (0, True))
 
     For a given (d, knots) there are len(knots)-d-1 B-splines defined, that
     are indexed by n (starting at 0).
@@ -44,7 +44,7 @@ def bspline_basis(d, knots, n, x, close=True):
     Here is an example of a cubic B-spline:
 
         >>> bspline_basis(3, range(5), 0, x)
-        Piecewise((x**3/6, [0, 1)), (-x**3/2 + 2*x**2 - 2*x + 2/3, [1, 2)), (x**3/2 - 4*x**2 + 10*x - 22/3, [2, 3)), (-x**3/6 + 2*x**2 - 8*x + 32/3, [3, 4]), (0, True))
+        Piecewise((x**3/6, And(x < 1, x >= 0)), (-x**3/2 + 2*x**2 - 2*x + 2/3, And(x < 2, x >= 1)), (x**3/2 - 4*x**2 + 10*x - 22/3, And(x < 3, x >= 2)), (-x**3/6 + 2*x**2 - 8*x + 32/3, And(x <= 4, x >= 3)), (0, True))
 
     By repeating knot points, you can introduce discontinuities in the
     B-splines and their derivatives:
@@ -52,7 +52,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 1
         >>> knots = [0,0,2,3,4]
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((-x/2 + 1, [0, 2]), (0, True))
+        Piecewise((-x/2 + 1, And(x <= 2, x >= 0)), (0, True))
 
     It is quite time consuming to construct and evaluate B-splines. If you
     need to evaluate a B-splines many times, it is best to lambdify them
@@ -85,34 +85,27 @@ def bspline_basis(d, knots, n, x, close=True):
         raise ValueError('n+d+1 must not exceed len(knots)-1')
     if d==0:
         result = Piecewise(
-            (S.One, Interval(knots[n], knots[n+1], False, True)),
+            (S.One, Interval(knots[n], knots[n+1], False, not close).contains(x)),
             (0, True)
         )
     elif d > 0:
-        denom = knots[n+d] - knots[n]
-        if denom != S.Zero:
-            A = (x - knots[n])/denom
-            b1 = bspline_basis(d-1, knots, n, x, close=False)
-        else:
-            b1 = A = S.Zero
-
         denom = knots[n+d+1] - knots[n+1]
         if denom != S.Zero:
             B = (knots[n+d+1] - x)/denom
-            b2 = bspline_basis(d-1, knots, n+1, x, close=False)
+            b2 = bspline_basis(d-1, knots, n+1, x, close)
         else:
             b2 = B = S.Zero
+
+        denom = knots[n+d] - knots[n]
+        if denom != S.Zero:
+            A = (x - knots[n])/denom
+            b1 = bspline_basis(d-1, knots, n, x, close and (B == S.Zero or b2 == S.Zero))
+        else:
+            b1 = A = S.Zero
+
         result = _add_splines(A, b1, B, b2)
     else:
         raise ValueError('degree must be non-negative: %r' % n)
-    if close:
-        final_ec_pair = result.args[-2]
-        final_cond = final_ec_pair.cond
-        final_expr = final_ec_pair.expr
-        new_args = final_cond.args[:3] + (False,)
-        new_ec_pair = ExprCondPair(final_expr, Interval(*new_args))
-        new_args = result.args[:-2] + (new_ec_pair, result.args[-1])
-        result = Piecewise(*new_args)
     return result
 
 def bspline_basis_set(d, knots, x):
@@ -131,7 +124,7 @@ def bspline_basis_set(d, knots, x):
     >>> knots = range(5)
     >>> splines = bspline_basis_set(d, knots, x)
     >>> splines
-    [Piecewise((x**2/2, [0, 1)), (-x**2 + 3*x - 3/2, [1, 2)), (x**2/2 - 3*x + 9/2, [2, 3]), (0, True)), Piecewise((x**2/2 - x + 1/2, [1, 2)), (-x**2 + 5*x - 11/2, [2, 3)), (x**2/2 - 4*x + 8, [3, 4]), (0, True))]
+    [Piecewise((x**2/2, And(x < 1, x >= 0)), (-x**2 + 3*x - 3/2, And(x < 2, x >= 1)), (x**2/2 - 3*x + 9/2, And(x <= 3, x >= 2)), (0, True)), Piecewise((x**2/2 - x + 1/2, And(x < 2, x >= 1)), (-x**2 + 5*x - 11/2, And(x < 3, x >= 2)), (x**2/2 - 4*x + 8, And(x <= 4, x >= 3)), (0, True))]
 
     See Also
     ========

--- a/sympy/functions/special/tests/test_bsplines.py
+++ b/sympy/functions/special/tests/test_bsplines.py
@@ -9,22 +9,29 @@ def test_basic_degree_0():
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
     for i in range(len(splines)):
-        assert splines[i] == Piecewise((1, Interval(i, i+1)), (0, True))
+        assert splines[i] == Piecewise((1, Interval(i, i+1).contains(x)), (0, True))
 
 def test_basic_degree_1():
     d = 1
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
-    assert splines[0] == Piecewise((x,Interval(0,1,False,True)),(2-x,Interval(1,2)),(0,True))
-    assert splines[1] == Piecewise((-1+x,Interval(1,2,False,True)),(3-x,Interval(2,3)),(0,True))
-    assert splines[2] == Piecewise((-2+x,Interval(2,3,False,True)),(4-x,Interval(3,4)),(0,True))
+    assert splines[0] == Piecewise((x, Interval(0, 1, False, True).contains(x)),
+        (2 - x, Interval(1, 2).contains(x)), (0, True))
+    assert splines[1] == Piecewise((-1 + x, Interval(1, 2, False, True).contains(x)),
+        (3 - x, Interval(2, 3).contains(x)), (0, True))
+    assert splines[2] == Piecewise((-2 + x, Interval(2, 3, False, True).contains(x)),
+        (4 - x, Interval(3, 4).contains(x)), (0, True))
 
 def test_basic_degree_2():
     d = 2
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
-    b0 = Piecewise((x**2/2,Interval(0,1,False,True)),(Rational('-3/2')+3*x-x**2,Interval(1,2,False,True)),(Rational(9,2)-3*x+x**2/2,Interval(2,3)),(0,True))
-    b1 = Piecewise((Rational(1,2)-x+x**2/2,Interval(1,2,False,True)),(Rational(-11,2)+5*x-x**2,Interval(2,3,False,True)),(8-4*x+x**2/2,Interval(3,4)),(0,True))
+    b0 = Piecewise((x**2/2, Interval(0, 1, False, True).contains(x)),
+        (Rational(-3, 2) + 3*x - x**2, Interval(1, 2, False, True).contains(x)),
+        (Rational(9, 2) - 3*x + x**2/2, Interval(2, 3).contains(x)), (0, True))
+    b1 = Piecewise((Rational(1, 2) - x + x**2/2, Interval(1, 2, False, True).contains(x)),
+        (Rational(-11, 2) + 5*x - x**2, Interval(2, 3, False, True).contains(x)),
+        (8 - 4*x + x**2/2, Interval(3, 4).contains(x)), (0, True))
     assert splines[0] == b0
     assert splines[1] == b1
 
@@ -33,10 +40,10 @@ def test_basic_degree_3():
     knots = range(5)
     splines = bspline_basis_set(d, knots, x)
     b0 = Piecewise(
-        (x**3/6, Interval(0,1,False,True)),
-        (Rational(2,3) - 2*x + 2*x**2 - x**3/2, Interval(1,2,False,True)),
-        (Rational(-22,3) + 10*x - 4*x**2 + x**3/2, Interval(2,3,False,True)),
-        (Rational(32,3) - 8*x + 2*x**2 - x**3/6, Interval(3,4)),
+        (x**3/6, Interval(0, 1, False, True).contains(x)),
+        (Rational(2, 3) - 2*x + 2*x**2 - x**3/2, Interval(1, 2, False, True).contains(x)),
+        (Rational(-22, 3) + 10*x - 4*x**2 + x**3/2, Interval(2, 3, False, True).contains(x)),
+        (Rational(32, 3) - 8*x + 2*x**2 - x**3/6, Interval(3, 4).contains(x)),
         (0, True)
     )
     assert splines[0] == b0
@@ -45,9 +52,11 @@ def test_repeated_degree_1():
     d = 1
     knots = [0,0,1,2,2,3,4,4]
     splines = bspline_basis_set(d, knots, x)
-    assert splines[0] == Piecewise((1 - x, Interval(0,1)), (0, True))
-    assert splines[1] == Piecewise((x, Interval(0,1,False,True)), (2 - x, Interval(1,2)), (0, True))
-    assert splines[2] == Piecewise((-1 + x, Interval(1,2)), (0, True))
-    assert splines[3] == Piecewise((3 - x, Interval(2,3)), (0, True))
-    assert splines[4] == Piecewise((-2 + x, Interval(2,3,False,True)), (4 - x, Interval(3,4)), (0, True))
-    assert splines[5] == Piecewise((-3 + x, Interval(3,4)), (0, True))
+    assert splines[0] == Piecewise((1 - x, Interval(0, 1).contains(x)), (0, True))
+    assert splines[1] == Piecewise((x, Interval(0, 1, False, True).contains(x)),
+        (2 - x, Interval(1, 2).contains(x)), (0, True))
+    assert splines[2] == Piecewise((-1 + x, Interval(1, 2).contains(x)), (0, True))
+    assert splines[3] == Piecewise((3 - x, Interval(2, 3).contains(x)), (0, True))
+    assert splines[4] == Piecewise((-2 + x, Interval(2, 3, False, True).contains(x)),
+        (4 - x, Interval(3, 4).contains(x)), (0, True))
+    assert splines[5] == Piecewise((-3 + x, Interval(3, 4).contains(x)), (0, True))

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -50,7 +50,7 @@ def test_piecewise():
 
     p = Piecewise(
         (x, x < 1),
-        (x**2, Interval(3, 4, True, False)),
+        (x**2, Interval(3, 4, True, False).contains(x)),
         (0, True),
     )
     l = lambdarepr(p)
@@ -60,7 +60,7 @@ def test_piecewise():
 
     p = Piecewise(
         (x**2, x < 0),
-        (x, Interval(0, 1, False, True)),
+        (x, Interval(0, 1, False, True).contains(x)),
         (2 - x, x >= 1),
         (0, True)
     )
@@ -71,7 +71,7 @@ def test_piecewise():
 
     p = Piecewise(
         (x**2, x < 0),
-        (x, Interval(0, 1, False, True)),
+        (x, Interval(0, 1, False, True).contains(x)),
         (2 - x, x >= 1),
     )
     l = lambdarepr(p)


### PR DESCRIPTION
This brings a few improvements to Piecewise:

Implement methods such as _eval_conjugate, _eval_power, etc. to allow for simplifications. Implement the is_real, etc. assumption methods. Fix the canonalization of Piecewise with multiple otherwise conditions. Don't allow a Set() inside a condition, instead use Set().contains(x). In general, clean up the code and bring the test coverage to 100%.

Fixes:
as_real_imag for Piecewise does not give correct answer
http://code.google.com/p/sympy/issues/detail?id=1964

Piecewise((1,Interval(0,1,False,True)),(0,True)) syntax should not be allowed
http://code.google.com/p/sympy/issues/detail?id=2726

Piecewise evaluate=False does not work when conditions are boolean
http://code.google.com/p/sympy/issues/detail?id=3025

Piecewise.as_leading_term is broken
http://code.google.com/p/sympy/issues/detail?id=3110
