### PR TITLE
sympy.printing.preview: Support additional LaTeX packages.

### DIFF
--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -6,7 +6,7 @@ import tempfile
 
 from latex import latex
 
-def preview(expr, output='png', viewer=None, euler=True, packages=[], **latex_settings):
+def preview(expr, output='png', viewer=None, euler=True, packages=(), **latex_settings):
     r"""
     View expression or LaTeX markup in PNG, DVI, PostScript or PDF form.
 
@@ -93,10 +93,10 @@ def preview(expr, output='png', viewer=None, euler=True, packages=[], **latex_se
         if viewer not in special and not pexpect.which(viewer):
             raise SystemError("Unrecognized viewer: %s" % viewer)
 
-    actual_packages = packages + ["amsmath", "amsfonts"]
+    actual_packages = packages + ("amsmath", "amsfonts")
     if euler:
-        actual_packages += ["euler"]
-    package_includes = "\n".join(["\\usepackage{%s}" % p \
+        actual_packages += ("euler",)
+    package_includes = "\n".join(["\\usepackage{%s}" % p
                                   for p in actual_packages])
 
     format = r"""\documentclass[12pt]{article}

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -6,7 +6,7 @@ import tempfile
 
 from latex import latex
 
-def preview(expr, output='png', viewer=None, euler=True, **latex_settings):
+def preview(expr, output='png', viewer=None, euler=True, packages=[], **latex_settings):
     r"""
     View expression or LaTeX markup in PNG, DVI, PostScript or PDF form.
 
@@ -93,27 +93,20 @@ def preview(expr, output='png', viewer=None, euler=True, **latex_settings):
         if viewer not in special and not pexpect.which(viewer):
             raise SystemError("Unrecognized viewer: %s" % viewer)
 
-    if not euler:
-        format = r"""\documentclass[12pt]{article}
-                     \usepackage{amsmath}
-                     \usepackage{amsfonts}
-                     \begin{document}
-                     \pagestyle{empty}
-                     %s
-                     \vfill
-                     \end{document}
-                 """
-    else:
-        format = r"""\documentclass[12pt]{article}
-                     \usepackage{amsmath}
-                     \usepackage{amsfonts}
-                     \usepackage{eulervm}
-                     \begin{document}
-                     \pagestyle{empty}
-                     %s
-                     \vfill
-                     \end{document}
-                 """
+    actual_packages = packages + ["amsmath", "amsfonts"]
+    if euler:
+        actual_packages += ["euler"]
+    package_includes = "\n".join(["\\usepackage{%s}" % p \
+                                  for p in actual_packages])
+
+    format = r"""\documentclass[12pt]{article}
+                 %s
+                 \begin{document}
+                 \pagestyle{empty}
+                 %s
+                 \vfill
+                 \end{document}
+              """ % (package_includes, "%s")
 
     if isinstance(expr, str):
         latex_string = expr


### PR DESCRIPTION
This commit adds the keyword argument `packages` to `preview` which should be a list of LaTeX package names to be added to the preamble of the document.

I need this modification to be able to use `preview` with diagram drawing functionality, which requires the inclusion of `xypic` package in the preamble of the LaTeX document.
