### PR TITLE
Diagram Layout

### DIFF
--- a/doc/src/modules/categories.rst
+++ b/doc/src/modules/categories.rst
@@ -24,6 +24,11 @@ The module is still in its pre-embryonic stage.
 
 Base Class Reference
 --------------------
+
+This section lists the classes which implement some of the basic
+notions in category theory: objects, morphisms, categories, and
+diagrams.
+
 .. autoclass:: Object
    :members:
 
@@ -43,4 +48,13 @@ Base Class Reference
    :members:
 
 .. autoclass:: Diagram
+   :members:
+
+Diagram Drawing
+---------------
+
+This section lists the classes which allow automatic drawing of
+diagrams.
+
+.. autoclass:: DiagramGrid
    :members:

--- a/sympy/categories/__init__.py
+++ b/sympy/categories/__init__.py
@@ -20,3 +20,5 @@ from
 from baseclasses import (Object, Morphism, IdentityMorphism,
                          NamedMorphism, CompositeMorphism, Category,
                          Diagram)
+
+from diagram_drawing import DiagramGrid

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -596,6 +596,14 @@ class Diagram(Basic):
             # We have just added a new morphism.
 
             if isinstance(morphism, IdentityMorphism):
+                if props:
+                    # Properties for identity morphisms don't really
+                    # make sense, because very much is known about
+                    # identity morphisms already, so much that they
+                    # are trivial.  Having properties for identity
+                    # morphisms would only be confusing.
+                    raise ValueError(
+                        "Instances of IdentityMorphism cannot have properties.")
                 return
 
             if add_identities:

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -584,7 +584,8 @@ class Diagram(Basic):
             return False
 
     @staticmethod
-    def _add_morphism(morphisms, morphism, props, add_identities=True):
+    def _add_morphism(morphisms, morphism, props, add_identities=True,
+                      recurse_composites=True):
         """
         Adds a morphism and its attributes to the supplied dictionary
         ``morphisms``.  If ``add_identities`` is True, also adds the
@@ -615,12 +616,13 @@ class Diagram(Basic):
                     right = existing_morphism * morphism
                     Diagram._set_dict_union(morphisms, right, new_props)
 
-            if isinstance(morphism, CompositeMorphism):
+            if isinstance(morphism, CompositeMorphism) and recurse_composites:
                 # This is a composite morphism, add its components as
                 # well.
                 empty = EmptySet()
                 for component in morphism.components:
-                    Diagram._add_morphism(morphisms, component, empty)
+                    Diagram._add_morphism(morphisms, component, empty,
+                                          add_identities)
 
     def __new__(cls, *args):
         """
@@ -702,8 +704,11 @@ class Diagram(Basic):
                     # Check that no new objects appear in conclusions.
                     if (morphism.domain in objects) and \
                        (morphism.codomain in objects):
-                        # No need to add identities this time.
-                        Diagram._add_morphism(conclusions, morphism, empty, False)
+                        # No need to add identities and recurse
+                        # composites this time.
+                        Diagram._add_morphism(conclusions, morphism,
+                                              empty, add_identities=False,
+                                              recurse_composites=False)
             elif isinstance(conclusions_arg, dict) or \
                      isinstance(conclusions_arg, Dict):
                 # The user has supplied a dictionary of morphisms and
@@ -712,9 +717,12 @@ class Diagram(Basic):
                     # Check that no new objects appear in conclusions.
                     if (morphism.domain in objects) and \
                        (morphism.codomain in objects):
-                        # No need to add identities this time.
+                        # No need to add identities and recurse
+                        # composites this time.
                         Diagram._add_morphism(conclusions, morphism,
-                                           FiniteSet(props), False)
+                                              FiniteSet(props),
+                                              add_identities=False,
+                                              recurse_composites=False)
 
         return Basic.__new__(cls, Dict(premises), Dict(conclusions), objects)
 

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -520,6 +520,9 @@ class Diagram(Basic):
     the diagram.  For a more formal approach to this notion see
     [Pare1970].
 
+    The components of composite morphisms are also added to the
+    diagram.  No properties are assigned to such morphisms by default.
+
     A commutative diagram is often accompanied by a statement of the
     following kind: "if such morphisms with such properties exist,
     then such morphisms which such properties exist and the diagram is
@@ -611,6 +614,13 @@ class Diagram(Basic):
                 if morphism.codomain == existing_morphism.domain:
                     right = existing_morphism * morphism
                     Diagram._set_dict_union(morphisms, right, new_props)
+
+            if isinstance(morphism, CompositeMorphism):
+                # This is a composite morphism, add its components as
+                # well.
+                empty = EmptySet()
+                for component in morphism.components:
+                    Diagram._add_morphism(morphisms, component, empty)
 
     def __new__(cls, *args):
         """

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -584,8 +584,8 @@ class Diagram(Basic):
             return False
 
     @staticmethod
-    def _add_morphism(morphisms, morphism, props, add_identities=True,
-                      recurse_composites=True):
+    def _add_morphism_closure(morphisms, morphism, props, add_identities=True,
+                              recurse_composites=True):
         """
         Adds a morphism and its attributes to the supplied dictionary
         ``morphisms``.  If ``add_identities`` is True, also adds the
@@ -621,8 +621,8 @@ class Diagram(Basic):
                 # well.
                 empty = EmptySet()
                 for component in morphism.components:
-                    Diagram._add_morphism(morphisms, component, empty,
-                                          add_identities)
+                    Diagram._add_morphism_closure(morphisms, component, empty,
+                                                  add_identities)
 
     def __new__(cls, *args):
         """
@@ -683,13 +683,14 @@ class Diagram(Basic):
 
                 for morphism in premises_arg:
                     objects |= FiniteSet(morphism.domain, morphism.codomain)
-                    Diagram._add_morphism(premises, morphism, empty)
+                    Diagram._add_morphism_closure(premises, morphism, empty)
             elif isinstance(premises_arg, dict) or isinstance(premises_arg, Dict):
                 # The user has supplied a dictionary of morphisms and
                 # their properties.
                 for morphism, props in premises_arg.items():
                     objects |= FiniteSet(morphism.domain, morphism.codomain)
-                    Diagram._add_morphism(premises, morphism, FiniteSet(props))
+                    Diagram._add_morphism_closure(
+                        premises, morphism, FiniteSet(props))
 
         if len(args) >= 2:
             # We also have some conclusions.
@@ -706,9 +707,9 @@ class Diagram(Basic):
                        (morphism.codomain in objects):
                         # No need to add identities and recurse
                         # composites this time.
-                        Diagram._add_morphism(conclusions, morphism,
-                                              empty, add_identities=False,
-                                              recurse_composites=False)
+                        Diagram._add_morphism_closure(
+                            conclusions, morphism, empty, add_identities=False,
+                            recurse_composites=False)
             elif isinstance(conclusions_arg, dict) or \
                      isinstance(conclusions_arg, Dict):
                 # The user has supplied a dictionary of morphisms and
@@ -719,10 +720,9 @@ class Diagram(Basic):
                        (morphism.codomain in objects):
                         # No need to add identities and recurse
                         # composites this time.
-                        Diagram._add_morphism(conclusions, morphism,
-                                              FiniteSet(props),
-                                              add_identities=False,
-                                              recurse_composites=False)
+                        Diagram._add_morphism_closure(
+                            conclusions, morphism, FiniteSet(props),
+                            add_identities=False, recurse_composites=False)
 
         return Basic.__new__(cls, Dict(premises), Dict(conclusions), objects)
 

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -557,7 +557,7 @@ class Diagram(Basic):
     >>> pprint(d.premises, use_unicode=False)
     {g*f:A-->C: EmptySet(), id:A-->A: EmptySet(), id:B-->B: EmptySet(), id:C-->C:
     EmptySet(), f:A-->B: EmptySet(), g:B-->C: EmptySet()}
-    >>> d = Diagram([f, g], {g * f:"unique"})
+    >>> d = Diagram([f, g], {g * f: "unique"})
     >>> pprint(d.conclusions)
     {g*f:A-->C: {unique}}
 
@@ -667,7 +667,7 @@ class Diagram(Basic):
         True
         >>> g * f in d.premises.keys()
         True
-        >>> d = Diagram([f, g], {g * f:"unique"})
+        >>> d = Diagram([f, g], {g * f: "unique"})
         >>> d.conclusions[g * f]
         {unique}
 
@@ -775,7 +775,7 @@ class Diagram(Basic):
         True
         >>> g * f in d.premises.keys()
         True
-        >>> d = Diagram([f, g], {g * f:"unique"})
+        >>> d = Diagram([f, g], {g * f: "unique"})
         >>> d.conclusions[g * f] == FiniteSet("unique")
         True
 
@@ -892,9 +892,9 @@ class Diagram(Basic):
         >>> C = Object("C")
         >>> f = NamedMorphism(A, B, "f")
         >>> g = NamedMorphism(B, C, "g")
-        >>> d = Diagram([f, g], {f:"unique", g*f:"veryunique"})
+        >>> d = Diagram([f, g], {f: "unique", g*f: "veryunique"})
         >>> d1 = d.subdiagram_from_objects(FiniteSet(A, B))
-        >>> d1 == Diagram([f], {f:"unique"})
+        >>> d1 == Diagram([f], {f: "unique"})
         True
         """
         if not self.objects.subset(objects):

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -838,7 +838,7 @@ class Diagram(Basic):
         Checks whether ``diagram`` is a subdiagram of ``self``.
         Diagram `D'` is a subdiagram of `D` if all premises
         (conclusions) of `D'` are contained in the premises
-        (respectively, conclusions) of `D`.  The morphisms contained
+        (conclusions) of `D`.  The morphisms contained
         both in `D'` and `D` should have the same properties for `D'`
         to be a subdiagram of `D`.
 

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -302,7 +302,7 @@ class CompositeMorphism(Morphism):
         Examples
         ========
 
-        >>> from sympy.categories import Object, NamedMorphism, CompositeMorphism
+        >>> from sympy.categories import Object, NamedMorphism
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -326,7 +326,7 @@ class CompositeMorphism(Morphism):
         Examples
         ========
 
-        >>> from sympy.categories import Object, NamedMorphism, CompositeMorphism
+        >>> from sympy.categories import Object, NamedMorphism
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -349,7 +349,7 @@ class CompositeMorphism(Morphism):
         Examples
         ========
 
-        >>> from sympy.categories import Object, NamedMorphism, CompositeMorphism
+        >>> from sympy.categories import Object, NamedMorphism
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -374,7 +374,7 @@ class CompositeMorphism(Morphism):
         Examples
         ========
 
-        >>> from sympy.categories import Object, NamedMorphism, CompositeMorphism
+        >>> from sympy.categories import Object, NamedMorphism
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -657,7 +657,6 @@ class Diagram(Basic):
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import IdentityMorphism, Diagram
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -743,7 +742,7 @@ class Diagram(Basic):
         ========
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import IdentityMorphism, Diagram
-        >>> from sympy import EmptySet, Dict, pretty
+        >>> from sympy import pretty
         >>> A = Object("A")
         >>> B = Object("B")
         >>> f = NamedMorphism(A, B, "f")
@@ -792,7 +791,6 @@ class Diagram(Basic):
         Examples
         ========
         >>> from sympy.categories import Object, NamedMorphism, Diagram
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -815,7 +813,7 @@ class Diagram(Basic):
         ========
 
         >>> from sympy.categories import Object, NamedMorphism, Diagram
-        >>> from sympy import FiniteSet, pretty
+        >>> from sympy import pretty
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -853,7 +851,6 @@ class Diagram(Basic):
         Examples
         ========
         >>> from sympy.categories import Object, NamedMorphism, Diagram
-        >>> from sympy import FiniteSet, pretty
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -889,7 +886,7 @@ class Diagram(Basic):
         Examples
         ========
         >>> from sympy.categories import Object, NamedMorphism, Diagram
-        >>> from sympy import FiniteSet, pretty
+        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -824,3 +824,41 @@ class Diagram(Basic):
                 conclusions |= FiniteSet(morphism)
 
         return (premises, conclusions)
+
+    def is_subdiagram(self, diagram):
+        """
+        Checks whether ``diagram`` is a subdiagram of ``self``.
+        Diagram `D'` is a subdiagram of `D` if all premises
+        (conclusions) of `D'` are contained in the premises
+        (respectively, conclusions) of `D`.  The morphisms contained
+        both in `D'` and `D` should have the same properties for `D'`
+        to be a subdiagram of `D`.
+
+        Examples
+        ========
+        >>> from sympy.categories import Object, NamedMorphism, Diagram
+        >>> from sympy import FiniteSet, pretty
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> d = Diagram([f, g], {g * f: "unique"})
+        >>> d1 = Diagram([f])
+        >>> d.is_subdiagram(d1)
+        True
+        >>> d1.is_subdiagram(d)
+        False
+        """
+        premises = all([(m in self.premises) and \
+                        (diagram.premises[m] == self.premises[m]) \
+                        for m in diagram.premises])
+        if not premises:
+            return False
+
+        conclusions = all([(m in self.conclusions) and \
+                           (diagram.conclusions[m] == self.conclusions[m]) \
+                        for m in diagram.conclusions])
+
+        # Premises is surely ``True`` here.
+        return conclusions

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -870,3 +870,39 @@ class Diagram(Basic):
 
         # Premises is surely ``True`` here.
         return conclusions
+
+    def subdiagram_from_objects(self, objects):
+        """
+        If ``objects`` is a subset of the objects of ``self``, returns
+        a diagram which has as premises all those premises of ``self``
+        which have a domains and codomains in ``objects``, likewise
+        for conclusions.  Properties are preserved.
+
+        Examples
+        ========
+        >>> from sympy.categories import Object, NamedMorphism, Diagram
+        >>> from sympy import FiniteSet, pretty
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> d = Diagram([f, g], {f:"unique", g*f:"veryunique"})
+        >>> d1 = d.subdiagram_from_objects(FiniteSet(A, B))
+        >>> d1 == Diagram([f], {f:"unique"})
+        True
+        """
+        if not self.objects.subset(objects):
+            raise ValueError("Supplied objects should all belong to the diagram.")
+
+        new_premises = {}
+        for morphism, props in self.premises.items():
+            if (morphism.domain in objects) and (morphism.codomain in objects):
+                new_premises[morphism] = props
+
+        new_conclusions = {}
+        for morphism, props in self.conclusions.items():
+            if (morphism.domain in objects) and (morphism.codomain in objects):
+                new_conclusions[morphism] = props
+
+        return Diagram(new_premises, new_conclusions)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -655,8 +655,6 @@ class DiagramGrid(object):
         Returns a key for the supplied triangle.  It should be the
         same independently of the hash randomisation.
         """
-        # TODO: Remove this sorting when the problem with the
-        # sort_keys of FiniteSet has been solved.
         objects = sorted(DiagramGrid._triangle_objects(tri), key=default_sort_key)
         return (triangle_sizes[tri], default_sort_key(objects))
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -176,6 +176,7 @@ class DiagramGrid(object):
 
     >>> from sympy.categories import Object, NamedMorphism
     >>> from sympy.categories import Diagram, DiagramGrid
+    >>> from sympy import pprint
     >>> A = Object("A")
     >>> B = Object("B")
     >>> C = Object("C")
@@ -188,9 +189,10 @@ class DiagramGrid(object):
     >>> grid = DiagramGrid(diagram)
     >>> (grid.width, grid.height)
     (2, 2)
-    >>> print grid
-    [[Object("A"), Object("B")],
-    [None, Object("C")]]
+    >>> pprint(grid)
+    A  B
+    <BLANKLINE>
+       C
 
     Sometimes one sees the diagram as consisting of logical groups.
     One can advise ``DiagramGrid`` as to such groups by employing the
@@ -208,17 +210,19 @@ class DiagramGrid(object):
     Lay it out with generic layout:
 
     >>> grid = DiagramGrid(diagram)
-    >>> print grid
-    [[Object("A"), Object("B"), Object("D")],
-    [None, Object("C"), None]]
+    >>> pprint(grid)
+    A  B  D
+    <BLANKLINE>
+       C
 
     Now, we can group the objects `A` and `D` to have them near one
     another:
 
     >>> grid = DiagramGrid(diagram, groups=[[A, D], B, C])
-    >>> print grid
-    [[Object("B"), None, Object("C")],
-    [Object("A"), Object("D"), None]]
+    >>> pprint(grid)
+    B     C
+    <BLANKLINE>
+    A  D
 
     Note how the positioning of the other objects changes.
 
@@ -241,28 +245,34 @@ class DiagramGrid(object):
     linear:
 
     >>> grid = DiagramGrid(diagram)
-    >>> print grid
-    [[Object("A"), Object("B"), None],
-    [None, Object("C"), Object("D")],
-    [None, None, Object("E")]]
+    >>> pprint(grid)
+    A  B
+    <BLANKLINE>
+       C  D
+    <BLANKLINE>
+          E
 
     To get it laid out in a line, use ``layout="sequential"``:
 
     >>> grid = DiagramGrid(diagram, layout="sequential")
-    >>> print grid
-    [[Object("A"), Object("B"), Object("C"), Object("D"), Object("E")]]
+    >>> pprint(grid)
+    A  B  C  D  E
 
     One may sometimes need to transpose the resulting layout.  While
     this can always be done by hand, :class:`DiagramGrid` provides a
     hint for that purpose:
 
     >>> grid = DiagramGrid(diagram, layout="sequential", transpose=True)
-    >>> print grid
-    [[Object("A")],
-    [Object("B")],
-    [Object("C")],
-    [Object("D")],
-    [Object("E")]]
+    >>> pprint(grid)
+    A
+    <BLANKLINE>
+    B
+    <BLANKLINE>
+    C
+    <BLANKLINE>
+    D
+    <BLANKLINE>
+    E
 
     Separate hints can also be provided for each group.  For an
     example, refer to ``tests/test_drawing.py``, and see the different

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -762,38 +762,40 @@ class DiagramGrid(object):
         without any influence from ``hints``.  Otherwise, it is laid
         out with ``hints``.
         """
+        def lay_out_group(group, local_hints):
+            """
+            If ``group`` is a set of objects, uses a ``DiagramGrid``
+            to lay it out and returns the grid.  Otherwise returns the
+            object (i.e., ``group``).  If ``local_hints`` is not
+            empty, it is supplied to ``DiagramGrid`` as the dictionary
+            of hints.  Otherwise, the ``hints`` argument of
+            ``_handle_groups`` is used.
+            """
+            if isinstance(group, FiniteSet):
+                # Set up the corresponding object-to-group
+                # mappings.
+                for obj in group:
+                    obj_groups[obj] = group
+
+                # Lay out the current group.
+                if local_hints:
+                    groups_grids[group] = DiagramGrid(
+                        diagram.subdiagram_from_objects(group), **local_hints)
+                else:
+                    groups_grids[group] = DiagramGrid(
+                        diagram.subdiagram_from_objects(group), **hints)
+            else:
+                obj_groups[group] = group
+
         obj_groups = {}
         groups_grids = {}
+
         if isinstance(groups, dict) or isinstance(groups, Dict):
             for group, local_hints in groups.items():
-                if isinstance(group, FiniteSet):
-                    # Set up the corresponding object-to-group
-                    # mappings.
-                    for obj in group:
-                        obj_groups[obj] = group
-
-                    # Lay out the current group.
-                    if local_hints:
-                        groups_grids[group] = DiagramGrid(
-                            diagram.subdiagram_from_objects(group), **local_hints)
-                    else:
-                        groups_grids[group] = DiagramGrid(
-                            diagram.subdiagram_from_objects(group), **hints)
-                else:
-                    obj_groups[group] = group
+                lay_out_group(group, local_hints)
         else:
             for group in groups:
-                if isinstance(group, FiniteSet):
-                    # Set up the corresponding object-to-group
-                    # mappings.
-                    for obj in group:
-                        obj_groups[obj] = group
-
-                    # Lay out the current group.
-                    groups_grids[group] = DiagramGrid(
-                        diagram.subdiagram_from_objects(group))
-                else:
-                    obj_groups[group] = group
+                lay_out_group(group, None)
 
         new_morphisms = []
         for morphism in merged_morphisms:

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -176,7 +176,6 @@ class DiagramGrid(object):
 
     >>> from sympy.categories import Object, NamedMorphism
     >>> from sympy.categories import Diagram, DiagramGrid
-    >>> from sympy import FiniteSet
     >>> A = Object("A")
     >>> B = Object("B")
     >>> C = Object("C")
@@ -216,7 +215,7 @@ class DiagramGrid(object):
     Now, we can group the objects `A` and `D` to have them near one
     another:
 
-    >>> grid = DiagramGrid(diagram, groups=FiniteSet(FiniteSet(A, D), B, C))
+    >>> grid = DiagramGrid(diagram, groups=[[A, D], B, C])
     >>> print grid
     [[Object("B"), None, Object("C")],
     [Object("A"), Object("D"), None]]
@@ -1217,7 +1216,6 @@ class DiagramGrid(object):
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import Diagram, DiagramGrid
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -1241,7 +1239,6 @@ class DiagramGrid(object):
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import Diagram, DiagramGrid
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -1265,7 +1262,6 @@ class DiagramGrid(object):
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import Diagram, DiagramGrid
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -1292,7 +1288,6 @@ class DiagramGrid(object):
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import Diagram, DiagramGrid
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")
@@ -1319,7 +1314,6 @@ class DiagramGrid(object):
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import Diagram, DiagramGrid
-        >>> from sympy import FiniteSet
         >>> A = Object("A")
         >>> B = Object("B")
         >>> C = Object("C")

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -996,11 +996,25 @@ class DiagramGrid(object):
 
         return grid
 
+    @staticmethod
+    def _drop_inessential_morphisms(merged_morphisms):
+        r"""
+        Removes those morphisms which should appear in the diagram,
+        but which have no relevance to object layout.
+
+        Currently this removes "loop" morphisms: the non-identity
+        morphisms with the same domains and codomains.
+        """
+        morphisms = [m for m in merged_morphisms if m.domain != m.codomain]
+        return morphisms
+
     def __init__(self, diagram, groups=None, **hints):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)
         conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
-        merged_morphisms = DiagramGrid._merge_premises_conclusions(
+        all_merged_morphisms = DiagramGrid._merge_premises_conclusions(
             premises, conclusions)
+        merged_morphisms = DiagramGrid._drop_inessential_morphisms(
+            all_merged_morphisms)
 
         if groups and (groups != diagram.objects):
             # Lay out the diagram according to the groups.
@@ -1023,7 +1037,7 @@ class DiagramGrid(object):
                 self._grid = grid
 
         # Store the merged morphisms for later use.
-        self._morphisms = merged_morphisms
+        self._morphisms = all_merged_morphisms
 
     @property
     def width(self):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -423,12 +423,22 @@ class DiagramGrid(object):
 
     @staticmethod
     def _compute_triangle_min_sizes(triangles, edges):
-        """
+        r"""
         Returns a dictionary mapping triangles to their minimal sizes.
         The minimal size of a triangle is the sum of maximal lengths
         of morphisms associated to the sides of the triangle.  The
         length of a morphism is the number of components it consists
         of.  A non-composite morphism is of length 1.
+
+        Sorting triangles by this metric attempts to address two
+        aspects of layout.  For triangles with only simple morphisms
+        in the edge, this assures that triangles with all three edges
+        visible will get typeset after triangles with less visible
+        edges, which sometimes minimises the necessity in diagonal
+        arrows.  For triangles with composite morphisms in the edges,
+        this assures that objects connected with shorter morphisms
+        will be laid out first, resulting the visual proximity of
+        those objects which are connected by shorter morphisms.
         """
         triangle_sizes = {}
         for triangle in triangles:

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -487,6 +487,15 @@ class DiagramGrid:
         sorted_candidates = sorted(candidates, key=default_sort_key)
         return sorted_candidates[0]
 
+    @staticmethod
+    def _drop_irrelevant_triangles(triangles, placed_objects):
+        """
+        Returns only those triangles whose set of objects is not
+        completely included in ``placed_objects``.
+        """
+        return [tri for tri in triangles if not placed_objects.subset(
+            DiagramGrid._triangle_objects(tri))]
+
     def __init__(self, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)
         conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
@@ -517,8 +526,12 @@ class DiagramGrid:
         while placed_objects != all_objects:
             triangle = DiagramGrid._weld_triangle(
                 triangles, fringe, grid, skeleton)
+
             placed_objects = placed_objects | \
                              DiagramGrid._triangle_objects(triangle)
+
+            triangles = DiagramGrid._drop_irrelevant_triangles(
+                triangles, placed_objects)
 
         self._grid = grid
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -720,10 +720,12 @@ class DiagramGrid(object):
                 candidates = sorted([e for e in tri if skeleton[e]],
                                     key=default_sort_key)
                 edges = [e for e in candidates if obj in e]
-                if not edges:
-                    # No meaningful edge could be drawn from this
-                    # object, so we are not interested.
-                    continue
+
+                # Note that a meaningful edge (i.e., and edge that is
+                # associated with a morphism) containing ``obj``
+                # always exists.  That's because all triangles are
+                # guaranteed to have at least two meaningful edges.
+                # See _drop_redundant_triangles.
 
                 # Get the object at the other end of the edge.
                 edge = edges[0]

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -189,10 +189,9 @@ class DiagramGrid(object):
     >>> grid = DiagramGrid(diagram)
     >>> (grid.width, grid.height)
     (2, 2)
-    >>> [grid[0, j] for j in xrange(grid.width)]
-    [Object("A"), Object("B")]
-    >>> [grid[1, j] for j in xrange(grid.width)]
-    [None, Object("C")]
+    >>> print grid
+    [[Object("A"), Object("B")],
+    [None, Object("C")]]
 
     Sometimes one sees the diagram as consisting of logical groups.
     One can advise ``DiagramGrid`` as to such groups by employing the
@@ -210,19 +209,17 @@ class DiagramGrid(object):
     Lay it out with generic layout:
 
     >>> grid = DiagramGrid(diagram)
-    >>> [grid[0, j] for j in xrange(grid.width)]
-    [Object("A"), Object("B"), Object("D")]
-    >>> [grid[1, j] for j in xrange(grid.width)]
-    [None, Object("C"), None]
+    >>> print grid
+    [[Object("A"), Object("B"), Object("D")],
+    [None, Object("C"), None]]
 
     Now, we can group the objects `A` and `D` to have them near one
     another:
 
     >>> grid = DiagramGrid(diagram, groups=FiniteSet(FiniteSet(A, D), B, C))
-    >>> [grid[0, j] for j in xrange(grid.width)]
-    [Object("B"), None, Object("C")]
-    >>> [grid[1, j] for j in xrange(grid.width)]
-    [Object("A"), Object("D"), None]
+    >>> print grid
+    [[Object("B"), None, Object("C")],
+    [Object("A"), Object("D"), None]]
 
     Note how the positioning of the other objects changes.
 
@@ -245,26 +242,28 @@ class DiagramGrid(object):
     linear:
 
     >>> grid = DiagramGrid(diagram)
-    >>> [grid[0, j] for j in xrange(grid.width)]
-    [Object("A"), Object("B"), None]
-    >>> [grid[1, j] for j in xrange(grid.width)]
-    [None, Object("C"), Object("D")]
-    >>> [grid[2, j] for j in xrange(grid.width)]
-    [None, None, Object("E")]
+    >>> print grid
+    [[Object("A"), Object("B"), None],
+    [None, Object("C"), Object("D")],
+    [None, None, Object("E")]]
 
     To get it laid out in a line, use ``layout="sequential"``:
 
     >>> grid = DiagramGrid(diagram, layout="sequential")
-    >>> [grid[0, j] for j in xrange(grid.width)]
-    [Object("A"), Object("B"), Object("C"), Object("D"), Object("E")]
+    >>> print grid
+    [[Object("A"), Object("B"), Object("C"), Object("D"), Object("E")]]
 
     One may sometimes need to transpose the resulting layout.  While
     this can always be done by hand, :class:`DiagramGrid` provides a
     hint for that purpose:
 
     >>> grid = DiagramGrid(diagram, layout="sequential", transpose=True)
-    >>> [grid[i, 0] for i in xrange(grid.height)]
-    [Object("A"), Object("B"), Object("C"), Object("D"), Object("E")]
+    >>> print grid
+    [[Object("A")],
+    [Object("B")],
+    [Object("C")],
+    [Object("D")],
+    [Object("E")]]
 
     Separate hints can also be provided for each group.  For an
     example, refer to ``tests/test_drawing.py``, and see the different
@@ -1302,8 +1301,11 @@ class DiagramGrid(object):
         """
         Produces a string representation of this class.
 
-        This returns a string representation of the underlying list of
-        lists of objects:
+        This method returns a string representation of the underlying
+        list of lists of objects.
+
+        Examples
+        ========
 
         >>> from sympy.categories import Object, NamedMorphism
         >>> from sympy.categories import Diagram, DiagramGrid
@@ -1316,7 +1318,8 @@ class DiagramGrid(object):
         >>> diagram = Diagram([f, g])
         >>> grid = DiagramGrid(diagram)
         >>> print grid
-        [[Object("A"), Object("B")], [None, Object("C")]]
+        [[Object("A"), Object("B")],
+        [None, Object("C")]]
 
         """
         return repr(self._grid._array)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -580,6 +580,20 @@ class DiagramGrid:
 
         skeleton = DiagramGrid._build_skeleton(merged_morphisms)
 
+        all_objects = diagram.objects
+        grid = _GrowableGrid(2, 1)
+
+        if len(skeleton) == 1:
+            # This diagram contains only one morphism.  Draw it
+            # horizontally.
+            objects = sorted(all_objects, key=default_sort_key)
+            grid[0, 0] = objects[0]
+            grid[0, 1] = objects[1]
+
+            self._grid = grid
+
+            return
+
         triangles = DiagramGrid._list_triangles(skeleton)
         triangles = DiagramGrid._drop_redundant_triangles(triangles, skeleton)
         triangle_sizes = DiagramGrid._compute_triangle_min_sizes(
@@ -587,9 +601,6 @@ class DiagramGrid:
 
         triangles = sorted(triangles, key=lambda tri:
                            DiagramGrid._triangle_key(tri, triangle_sizes))
-        all_objects = diagram.objects
-
-        grid = _GrowableGrid(2, 1)
 
         # Place the first edge on the grid.
         root_edge = DiagramGrid._pick_root_edge(triangles[0], skeleton)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -363,15 +363,29 @@ class DiagramGrid(Basic):
         grid[i, j] = obj
 
     @staticmethod
-    def _choose_target_cell(pt1, pt2, grid):
+    def _choose_target_cell(pt1, pt2, edge, obj, skeleton, grid):
         """
-        Given two points, ``pt1`` and ``pt2``, chooses one of the two
-        points to place the opposing vertex of the triangle.  If
-        neither of this points fits, returns ``None``.
+        Given two points, ``pt1`` and ``pt2``, and the welding edge
+        ``edge``, chooses one of the two points to place the opposing
+        vertex ``obj`` of the triangle.  If neither of this points
+        fits, returns ``None``.
         """
         pt1_empty = DiagramGrid._empty_point(pt1, grid)
         pt2_empty = DiagramGrid._empty_point(pt2, grid)
 
+        if pt1_empty and pt2_empty:
+            # Both cells are empty.  Of them two, choose that cell
+            # which will assure that a visible edge of the triangle
+            # will be drawn perpendicularly to the current welding
+            # edge.
+
+            A = grid[edge[0]]
+            B = grid[edge[1]]
+
+            if skeleton.get((A, obj)) or skeleton.get((obj, A)):
+                return pt1
+            else:
+                return pt2
         if pt1_empty:
             return pt1
         elif pt2_empty:
@@ -427,7 +441,7 @@ class DiagramGrid(Basic):
                     break
 
                 target_cell = DiagramGrid._choose_target_cell(
-                    up_left, up_right, grid)
+                    up_left, up_right, (a, b), obj, skeleton, grid)
 
                 if not target_cell:
                     # No room above this edge.  Check below.
@@ -441,7 +455,7 @@ class DiagramGrid(Basic):
                         break
 
                     target_cell = DiagramGrid._choose_target_cell(
-                        down_left, down_right, grid)
+                        down_left, down_right, (a, b), obj, skeleton, grid)
 
                     if not target_cell:
                         # This edge is not in the fringe, remove it
@@ -461,7 +475,7 @@ class DiagramGrid(Basic):
                     break
 
                 target_cell = DiagramGrid._choose_target_cell(
-                    left_up, left_down, grid)
+                    left_down, left_up, (a, b), obj, skeleton, grid)
 
                 if not target_cell:
                     # No room to the left.  See what's to the right.
@@ -469,12 +483,12 @@ class DiagramGrid(Basic):
                     right_down = b[0], a[1] + 1
 
                     if DiagramGrid._fix_degerate(
-                        (a, b), right_up, right_down, fringe, grid):
+                        (a, b), right_up, right_down, fringe, skeleton, grid):
                         # The fringe has just been corrected.  Restart.
                         break
 
                     target_cell = DiagramGrid._choose_target_cell(
-                        right_up, right_down, grid)
+                        right_down, right_up, (a, b), obj, skeleton, grid)
 
                     if not target_cell:
                         # This edge is not in the fringe, remove it

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -682,6 +682,7 @@ class DiagramGrid(object):
                     grid[real_row, real_column] = obj
 
                 real_column += column_widths[logical_column]
+            real_column = 0
             real_row += row_heights[logical_row]
 
         return grid

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -340,11 +340,16 @@ class DiagramGrid(Basic):
         """
         Places an object at the coordinate ``cords`` in ``grid``,
         growing the grid and updating ``fringe``, if necessary.
+        Returns (0, 0) if no row or column has been prepended, (1, 0)
+        if a row was prepended, (0, 1) if a column was prepended and
+        (1, 1) if both a column and a row were prepended.
         """
         (i, j) = coords
+        offset = (0, 0)
         if i == -1:
             grid.prepend_row()
             i = 0
+            offset = (1, offset[1])
             for k in xrange(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
                 fringe[k] = ((i1 + 1, j1), (i2 + 1, j2))
@@ -353,6 +358,7 @@ class DiagramGrid(Basic):
 
         if j == -1:
             j = 0
+            offset = (offset[0], 1)
             grid.prepend_column()
             for k in xrange(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
@@ -361,6 +367,7 @@ class DiagramGrid(Basic):
             grid.append_column()
 
         grid[i, j] = obj
+        return offset
 
     @staticmethod
     def _choose_target_cell(pt1, pt2, edge, obj, skeleton, grid):
@@ -498,7 +505,14 @@ class DiagramGrid(Basic):
 
             # We now know where to place the other vertex of the
             # triangle.
-            DiagramGrid._put_object(target_cell, obj, grid, fringe)
+            offset = DiagramGrid._put_object(target_cell, obj, grid, fringe)
+
+            # Take care of the displacement of coordinates if a row or
+            # a column was prepended.
+            target_cell = (target_cell[0] + offset[0],
+                           target_cell[1] + offset[1])
+            a = (a[0] + offset[0], a[1] + offset[1])
+            b = (b[0] + offset[0], b[1] + offset[1])
 
             fringe.extend([(a, target_cell), (b, target_cell)])
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -952,7 +952,20 @@ class DiagramGrid(object):
 
         Examples
         ========
-        TODO: Add examples.
+
+        >>> from sympy.categories import Object, NamedMorphism
+        >>> from sympy.categories import Diagram, DiagramGrid
+        >>> from sympy import FiniteSet
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> diagram = Diagram([f, g])
+        >>> grid = DiagramGrid(diagram)
+        >>> grid.width
+        2
+
         """
         return self._grid.width
 
@@ -963,7 +976,20 @@ class DiagramGrid(object):
 
         Examples
         ========
-        TODO: Add examples.
+
+        >>> from sympy.categories import Object, NamedMorphism
+        >>> from sympy.categories import Diagram, DiagramGrid
+        >>> from sympy import FiniteSet
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> diagram = Diagram([f, g])
+        >>> grid = DiagramGrid(diagram)
+        >>> grid.height
+        2
+
         """
         return self._grid.height
 
@@ -971,5 +997,24 @@ class DiagramGrid(object):
         """
         Returns the object placed in the row ``i`` and column ``j``.
         The indices are 0-based.
+
+        Examples
+        ========
+
+        >>> from sympy.categories import Object, NamedMorphism
+        >>> from sympy.categories import Diagram, DiagramGrid
+        >>> from sympy import FiniteSet
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> diagram = Diagram([f, g])
+        >>> grid = DiagramGrid(diagram)
+        >>> (grid[0, 0], grid[0, 1])
+        (Object("A"), Object("B"))
+        >>> (grid[1, 0], grid[1, 1])
+        (None, Object("C"))
+
         """
         return self._grid[i, j]

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -369,8 +369,8 @@ class DiagramGrid(Basic):
     @staticmethod
     def _weld_triangle(triangles, fringe, grid, skeleton):
         """
-        Welds a triangle to the fringe and returns ``True``, if
-        possible.  Otherwise returns ``False``.
+        If possible, welds a triangle to the fringe and returns the
+        welded triangle.  Otherwise returns None.
         """
         for tri in triangles:
             welding_edge = DiagramGrid._find_triangle_welding(
@@ -463,9 +463,9 @@ class DiagramGrid(Basic):
 
             triangles.remove(tri)
 
-            return True
+            return tri
 
-        return False
+        return None
 
     def __new__(cls, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)
@@ -481,6 +481,7 @@ class DiagramGrid(Basic):
             triangles, skeleton)
 
         triangles = sorted(triangles, key=lambda triangle: triangle_sizes[triangle])
+        all_objects = diagram.objects
 
         grid = _GrowableGrid(2, 1)
 
@@ -489,5 +490,11 @@ class DiagramGrid(Basic):
         grid[0, 0], grid[0, 1] = root_edge
         fringe = [((0,0), (0, 1))]
 
-        while DiagramGrid._weld_triangle(triangles, fringe, grid, skeleton):
-            pass
+        # Record which objects we now have on the grid.
+        placed_objects = FiniteSet(root_edge)
+
+        while placed_objects != all_objects:
+            triangle = DiagramGrid._weld_triangle(
+                triangles, fringe, grid, skeleton)
+            placed_objects = placed_objects | \
+                             DiagramGrid._triangle_objects(triangle)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1,9 +1,83 @@
-"""
+r"""
 This module contains the functionality to arrange the nodes of a
 diagram on an abstract grid, and then to produce a graphical
 representation of the grid.
 
-The currently supported back-ends are Xy-pic [Xypic]
+The currently supported back-ends are Xy-pic [Xypic].
+
+Layout Algorithm
+================
+
+This section overviews the algorithms implemented in
+:class:`DiagramGrid` to lay out diagrams.
+
+The first step of the algorithm is the removal composite and identity
+morphisms which do not have properties in the supplied diagram.  The
+premises and conclusions of the diagram are then merged.
+
+The generic layout algorithm begins with the construction of the
+"skeleton" of the diagram.  The skeleton is an undirected graph which
+has the objects of the diagram as vertices and has an (undirected)
+edge between each pair of objects between which there exist morphisms.
+The direction of the morphisms does not matter at this stage.  The
+skeleton also includes an edge between each pair of vertices `A` and
+`C` such that there exists an object `B` which is connected with
+a morphism with `A`, and with a morphism with `C`.
+
+The skeleton constructed in this way has the property that every
+object is a vertex of a triangle formed by three edges of the
+skeleton.  This property lies at the base of the generic layout
+algorithm.
+
+After the skeleton has been constructed, the algorithm lists all
+triangles which can be formed.  Note that some triangles will not have
+all edges corresponding to morphisms which will actually be drawn.
+Triangles which have only one edge or less which will actually be
+drawn are immediately discarded.
+
+The list of triangles is sorted according to the number of edges which
+correspond to morphisms, then the triangle with the least number of such
+edges is selected.  One of such edges is picked and the corresponding
+objects are placed horizontally, on a grid.  This edge is recorded to
+be in the fringe.  The algorithm then finds a "welding" of a triangle
+to the fringe.  A welding is an edge in the fringe where a triangle
+could be attached.  If the algorithm succeeds in finding such a
+welding, it adds to the grid that vertex of the triangle which was not
+yet included in any edge in the fringe and records the two new edges in
+the fringe.  This process continues iteratively until all objects of
+the diagram has been placed or until no more weldings can be found.
+
+An edge is only removed from the fringe when a welding to this edge
+has been found, however, there is no room around this edge to place
+another vertex.
+
+When no more weldings can be found, but there are still triangles
+left, the algorithm searches for a possibility of attaching one of the
+remaining triangles to the existing structure by a vertex.  If such a
+possibility is found, the corresponding edge of the found triangle is
+placed in the found space and the iterative process of welding
+triangles restarts.
+
+When logical groups are supplied, each of this groups is laid out
+independently.  Then a diagram is constructed in which groups are
+objects and any two logical groups between which there exist morphisms
+are connected with a morphism.  This diagram is laid out.  Finally,
+the grid which includes all objects of the initial diagram is
+constructed by replacing the cells which contain logical groups with
+the corresponding laid out grids, and by correspondingly expanding the
+rows and columns.
+
+The sequential layout algorithm begins with constructing the
+underlying undirected graph defined by the morphisms obtained after
+simplifying premises and conclusions and merging them (see above).
+The vertex with the minimal degree is then picked up and depth-first
+search is started from it.  All objects which are located at distance
+`n` from the root in the depth-first search tree, are positioned in
+the `n`-th column of the resulting grid.  The sequential layout will
+therefore attempt to lay the objects out along a line.
+
+References
+==========
 
 [Xypic] http://www.tug.org/applications/Xy-pic/
 """

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -447,6 +447,12 @@ class DiagramGrid(object):
         """
         Given a triangle, returns the objects included in it.
         """
+        # A triangle is an iterable containing 3 edges, each of which
+        # is a two-element tuple.  Adding up all these three tuples
+        # will result in a 6-element tuple including each vertex of
+        # the triangle twice.  Setting () as the initial value allows
+        # using ``sum`` to do the summation.  Finally, applying
+        # FiniteSet removes the duplicates.
         return FiniteSet(sum(triangle, () ))
 
     @staticmethod
@@ -455,6 +461,9 @@ class DiagramGrid(object):
         Given a triangle and an edge of it, returns the vertex which
         opposes the edge.
         """
+        # This gets the set of objects of the triangle and then
+        # subtracts the set of objects employed in ``edge`` to get the
+        # vertex opposite to ``edge``.
         return (DiagramGrid._triangle_objects(triangle) - FiniteSet(edge)).args[0]
 
     @staticmethod

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -484,8 +484,10 @@ class DiagramGrid(object):
         Returns a key for the supplied triangle.  It should be the
         same independently of the hash randomisation.
         """
-        objects = sorted([x.name for x in DiagramGrid._triangle_objects(tri)])
-        return (triangle_sizes[tri], objects)
+        # TODO: Remove this sorting when the problem with the
+        # sort_keys of FiniteSet has been solved.
+        objects = sorted(DiagramGrid._triangle_objects(tri), key=default_sort_key)
+        return (triangle_sizes[tri], default_sort_key(objects))
 
     @staticmethod
     def _pick_root_edge(tri, skeleton):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1164,15 +1164,13 @@ class DiagramGrid(object):
         else:
             self._grid = DiagramGrid._generic_layout(diagram, merged_morphisms)
 
-        if "transpose" in hints:
-            if hints["transpose"]:
-                # Transpose the resulting grid.
-                grid = _GrowableGrid(self._grid.height, self._grid.width)
-                for i in xrange(self._grid.height):
-                    for j in xrange(self._grid.width):
-                        grid[j, i] = self._grid[i, j]
-                self._grid = grid
-
+        if hints.get("transpose"):
+            # Transpose the resulting grid.
+            grid = _GrowableGrid(self._grid.height, self._grid.width)
+            for i in xrange(self._grid.height):
+                for j in xrange(self._grid.width):
+                    grid[j, i] = self._grid[i, j]
+            self._grid = grid
 
     @property
     def width(self):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -924,18 +924,12 @@ class DiagramGrid(object):
         return grid
 
     @staticmethod
-    def _sequential_layout(diagram, merged_morphisms):
-        r"""
-        Lays out the diagram in "sequential" layout.  This method
-        will attempt to produce a result as close to a line as
-        possible.  For linear diagrams, the result will actually be a
-        line.
+    def _get_undirected_graph(objects, merged_morphisms):
         """
-        objects = diagram.objects
-        sorted_objects = sorted(objects, key=default_sort_key)
-
-        # Set up the adjacency lists of the underlying undirected
-        # graph of ``merged_morphisms``.
+        Given the objects and the relevant morphisms of a diagram,
+        returns the adjacency lists of the underlying undirected
+        graph.
+        """
         adjlists = {}
         for obj in objects:
             adjlists[obj] = []
@@ -948,6 +942,23 @@ class DiagramGrid(object):
         # the same order.
         for obj in adjlists.keys():
             adjlists[obj].sort(key=default_sort_key)
+
+        return adjlists
+
+    @staticmethod
+    def _sequential_layout(diagram, merged_morphisms):
+        r"""
+        Lays out the diagram in "sequential" layout.  This method
+        will attempt to produce a result as close to a line as
+        possible.  For linear diagrams, the result will actually be a
+        line.
+        """
+        objects = diagram.objects
+        sorted_objects = sorted(objects, key=default_sort_key)
+
+        # Set up the adjacency lists of the underlying undirected
+        # graph of ``merged_morphisms``.
+        adjlists = DiagramGrid._get_undirected_graph(objects, merged_morphisms)
 
         # Find an object with the minimal degree.  This is going to be
         # the root.

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -674,9 +674,12 @@ class DiagramGrid(object):
         For a given triangle always picks the same root edge.  The
         root edge is the edge that will be placed first on the grid.
         """
-        candidates = [e for e in tri if skeleton[e]]
+        candidates = [sorted(e, key=default_sort_key) \
+                      for e in tri if skeleton[e]]
         sorted_candidates = sorted(candidates, key=default_sort_key)
-        return sorted_candidates[0]
+        # Don't forget to assure the proper ordering of the vertices
+        # in this edge.
+        return tuple(sorted(sorted_candidates[0], key=default_sort_key))
 
     @staticmethod
     def _drop_irrelevant_triangles(triangles, placed_objects):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -363,6 +363,23 @@ class DiagramGrid(Basic):
         grid[i, j] = obj
 
     @staticmethod
+    def _choose_target_cell(pt1, pt2, grid):
+        """
+        Given two points, ``pt1`` and ``pt2``, chooses one of the two
+        points to place the opposing vertex of the triangle.  If
+        neither of this points fits, returns ``None``.
+        """
+        pt1_empty = DiagramGrid._empty_point(pt1, grid)
+        pt2_empty = DiagramGrid._empty_point(pt2, grid)
+
+        if pt1_empty:
+            return pt1
+        elif pt2_empty:
+            return pt2
+        else:
+            return None
+
+    @staticmethod
     def _weld_triangle(triangles, fringe, grid, skeleton):
         """
         Welds a triangle to the fringe and returns ``True``, if
@@ -409,11 +426,10 @@ class DiagramGrid(Basic):
                     # The fringe has just been corrected.  Restart.
                     break
 
-                if DiagramGrid._empty_point(up_left, grid):
-                    target_cell = up_left
-                elif DiagramGrid._empty_point(up_right, grid):
-                    target_cell = up_right
-                else:
+                target_cell = DiagramGrid._choose_target_cell(
+                    up_left, up_right, grid)
+
+                if not target_cell:
                     # No room above this edge.  Check below.
                     down_left = a[0] + 1, a[1]
                     down_right = a[0] + 1, b[1]
@@ -424,11 +440,10 @@ class DiagramGrid(Basic):
                         # Restart.
                         break
 
-                    if DiagramGrid._empty_point(up_left, grid):
-                        target_cell = down_left
-                    elif DiagramGrid._empty_point(up_right, grid):
-                        target_cell = down_right
-                    else:
+                    target_cell = DiagramGrid._choose_target_cell(
+                        down_left, down_right, grid)
+
+                    if not target_cell:
                         # This edge is not in the fringe, remove it
                         # and restart.
                         fringe.remove((a, b))
@@ -445,11 +460,10 @@ class DiagramGrid(Basic):
                     # The fringe has just been corrected.  Restart.
                     break
 
-                if DiagramGrid._empty_point(left_up, grid):
-                    target_cell = left_up
-                elif DiagramGrid._empty_point(left_down, grid):
-                    target_cell = left_down
-                else:
+                target_cell = DiagramGrid._choose_target_cell(
+                    left_up, left_down, grid)
+
+                if not target_cell:
                     # No room to the left.  See what's to the right.
                     right_up = a[0], a[1] + 1
                     right_down = b[0], a[1] + 1
@@ -459,11 +473,10 @@ class DiagramGrid(Basic):
                         # The fringe has just been corrected.  Restart.
                         break
 
-                    if DiagramGrid._empty_point(right_up, grid):
-                        target_cell = right_up
-                    elif DiagramGrid._empty_point(right_down, grid):
-                        target_cell = right_down
-                    else:
+                    target_cell = DiagramGrid._choose_target_cell(
+                        right_up, right_down, grid)
+
+                    if not target_cell:
                         # This edge is not in the fringe, remove it
                         # and restart.
                         fringe.remove((a, b))

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -259,6 +259,21 @@ class DiagramGrid(Basic):
             triangle_sizes[triangle] = size
         return triangle_sizes
 
+    @staticmethod
+    def _triangle_objects(triangle):
+        """
+        Given a triangle, returns the objects included in it.
+        """
+        return FiniteSet(sum(triangle, () ))
+
+    @staticmethod
+    def _other_vertex(triangle, edge):
+        """
+        Given a triangle and an edge of it, returns the vertex which
+        opposes the edge.
+        """
+        return (DiagramGrid._triangle_objects(triangle) - FiniteSet(edge)).args[0]
+
     def __new__(cls, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)
         conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1019,6 +1019,9 @@ class DiagramGrid(object):
                         grid[j, i] = self._grid[i, j]
                 self._grid = grid
 
+        # Store the merged morphisms for later use.
+        self._morphisms = merged_morphisms
+
     @property
     def width(self):
         """
@@ -1092,3 +1095,29 @@ class DiagramGrid(object):
 
         """
         return self._grid[i, j]
+
+    @property
+    def morphisms(self):
+        """
+        Returns those morphisms (and their properties) which are
+        sufficiently meaningful to be drawn.
+
+        Examples
+        ========
+
+        >>> from sympy.categories import Object, NamedMorphism
+        >>> from sympy.categories import Diagram, DiagramGrid
+        >>> from sympy import FiniteSet
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> diagram = Diagram([f, g])
+        >>> grid = DiagramGrid(diagram)
+        >>> grid.morphisms
+        {NamedMorphism(Object("A"), Object("B"), "f"): EmptySet(),
+        NamedMorphism(Object("B"), Object("C"), "g"): EmptySet()}
+
+        """
+        return self._morphisms

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -519,3 +519,34 @@ class DiagramGrid:
                 triangles, fringe, grid, skeleton)
             placed_objects = placed_objects | \
                              DiagramGrid._triangle_objects(triangle)
+
+        self._grid = grid
+
+    @property
+    def width(self):
+        """
+        Returns the number of columns in this diagram layout.
+
+        Examples
+        ========
+        TODO: Add examples.
+        """
+        return self._grid.width
+
+    @property
+    def height(self):
+        """
+        Returns the number of rows in this diagram layout.
+
+        Examples
+        ========
+        TODO: Add examples.
+        """
+        return self._grid.height
+
+    def __getitem__(self, (i, j)):
+        """
+        Returns the object placed in the row ``i`` and column ``j``.
+        The indices are 0-based.
+        """
+        return self._grid[i, j]

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -796,15 +796,14 @@ class DiagramGrid(object):
 
         if groups and (groups != diagram.objects):
             # Lay out the diagram according to the groups.
-            self._grid = DiagramGrid._handle_groups(diagram, groups, merged_morphisms)
-            return
-
-        if "shape" in hints:
+            self._grid = DiagramGrid._handle_groups(
+                diagram, groups, merged_morphisms)
+        elif "shape" in hints:
             if hints["shape"] == "sequential":
-                self._grid = DiagramGrid._sequential_layout(diagram, merged_morphisms)
-                return
-
-        self._grid = DiagramGrid._generic_layout(diagram, merged_morphisms)
+                self._grid = DiagramGrid._sequential_layout(
+                    diagram, merged_morphisms)
+        else:
+            self._grid = DiagramGrid._generic_layout(diagram, merged_morphisms)
 
     @property
     def width(self):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -336,6 +336,33 @@ class DiagramGrid(Basic):
         return grid[pt] is None
 
     @staticmethod
+    def _put_object(coords, obj, grid, fringe):
+        """
+        Places an object at the coordinate ``cords`` in ``grid``,
+        growing the grid and updating ``fringe``, if necessary.
+        """
+        (i, j) = coords
+        if i == -1:
+            grid.prepend_row()
+            i = 0
+            for k in xrange(len(fringe)):
+                ((i1, j1), (i2, j2)) = fringe[k]
+                fringe[k] = ((i1 + 1, j1), (i2 + 1, j2))
+        elif i == grid.height:
+            grid.append_row()
+
+        if j == -1:
+            j = 0
+            grid.prepend_column()
+            for k in xrange(len(fringe)):
+                ((i1, j1), (i2, j2)) = fringe[k]
+                fringe[k] = ((i1, j1 + 1), (i2, j2 + 1))
+        elif j == grid.width:
+            grid.append_column()
+
+        grid[i, j] = obj
+
+    @staticmethod
     def _weld_triangle(triangles, fringe, grid, skeleton):
         """
         Welds a triangle to the fringe and returns ``True``, if
@@ -441,6 +468,18 @@ class DiagramGrid(Basic):
                         # and restart.
                         fringe.remove((a, b))
                         break
+
+            # We now know where to place the other vertex of the
+            # triangle.
+            DiagramGrid._put_object(target_cell, obj, grid, fringe)
+
+            fringe.extend([(a, target_cell), (b, target_cell)])
+
+            triangles.remove(tri)
+
+            return True
+
+        return False
 
     def __new__(cls, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -432,7 +432,7 @@ class DiagramGrid(Basic):
                 right_down = b[0], a[1] + 1
 
                 target_cell = DiagramGrid._choose_target_cell(
-                    right_down, right_up, (a, b), obj, skeleton, grid)
+                    right_up, right_down, (a, b), obj, skeleton, grid)
 
                 if not target_cell:
                     # No room to the left.  See what's to the right.
@@ -440,7 +440,7 @@ class DiagramGrid(Basic):
                     left_down = b[0], a[1] - 1
 
                     target_cell = DiagramGrid._choose_target_cell(
-                        left_down, left_up, (a, b), obj, skeleton, grid)
+                        left_up, left_down, (a, b), obj, skeleton, grid)
 
                     if not target_cell:
                         # This edge is not in the fringe, remove it

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -406,8 +406,8 @@ class DiagramGrid(object):
         Returns a list which contains only those triangles who have
         morphisms associated with at least two edges.
         """
-        return [tri for tri in triangles if \
-                len([e for e in tri if skeleton[e]]) >= 2]
+        return [tri for tri in triangles
+                if len([e for e in tri if skeleton[e]]) >= 2]
 
     @staticmethod
     def _morphism_length(morphism):
@@ -436,7 +436,7 @@ class DiagramGrid(object):
             for e in triangle:
                 morphisms = edges[e]
                 if morphisms:
-                    size += max([DiagramGrid._morphism_length(m) \
+                    size += max([DiagramGrid._morphism_length(m)
                                  for m in morphisms])
             triangle_sizes[triangle] = size
         return triangle_sizes
@@ -682,7 +682,7 @@ class DiagramGrid(object):
         For a given triangle always picks the same root edge.  The
         root edge is the edge that will be placed first on the grid.
         """
-        candidates = [sorted(e, key=default_sort_key) \
+        candidates = [sorted(e, key=default_sort_key)
                       for e in tri if skeleton[e]]
         sorted_candidates = sorted(candidates, key=default_sort_key)
         # Don't forget to assure the proper ordering of the vertices
@@ -750,8 +750,8 @@ class DiagramGrid(object):
                 # Now check for free directions.  When checking for
                 # free directions, prefer the horizontal and vertical
                 # directions.
-                neighbours = [(i-1, j), (i, j+1), (i+1, j), (i, j-1)] + \
-                             [(i-1,j-1), (i-1, j+1), (i+1,j-1), (i+1, j+1)]
+                neighbours = [(i-1, j), (i, j+1), (i+1, j), (i, j-1),
+                              (i-1,j-1), (i-1, j+1), (i+1,j-1), (i+1, j+1)]
 
                 for pt in neighbours:
                     if DiagramGrid._empty_point(pt, grid):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1297,3 +1297,26 @@ class DiagramGrid(object):
 
         """
         return self._morphisms
+
+    def __str__(self):
+        """
+        Produces a string representation of this class.
+
+        This returns a string representation of the underlying list of
+        lists of objects:
+
+        >>> from sympy.categories import Object, NamedMorphism
+        >>> from sympy.categories import Diagram, DiagramGrid
+        >>> from sympy import FiniteSet
+        >>> A = Object("A")
+        >>> B = Object("B")
+        >>> C = Object("C")
+        >>> f = NamedMorphism(A, B, "f")
+        >>> g = NamedMorphism(B, C, "g")
+        >>> diagram = Diagram([f, g])
+        >>> grid = DiagramGrid(diagram)
+        >>> print grid
+        [[Object("A"), Object("B")], [None, Object("C")]]
+
+        """
+        return repr(self._grid._array)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -798,8 +798,8 @@ class DiagramGrid(object):
             # Lay out the diagram according to the groups.
             self._grid = DiagramGrid._handle_groups(
                 diagram, groups, merged_morphisms)
-        elif "shape" in hints:
-            if hints["shape"] == "sequential":
+        elif "layout" in hints:
+            if hints["layout"] == "sequential":
                 self._grid = DiagramGrid._sequential_layout(
                     diagram, merged_morphisms)
         else:

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -13,7 +13,7 @@ from sympy.categories import (CompositeMorphism, IdentityMorphism,
                               NamedMorphism, Diagram)
 from sympy.utilities import default_sort_key
 
-class _GrowableGrid:
+class _GrowableGrid(object):
     """
     Holds a growable grid of objects.
 
@@ -84,7 +84,7 @@ class _GrowableGrid:
         for i in xrange(self._height):
             self._array[i].insert(0, None)
 
-class DiagramGrid:
+class DiagramGrid(object):
     """
     Constructs and holds the fitting of the diagram into a grid.
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -86,6 +86,7 @@ from sympy.core import Basic, FiniteSet, Dict
 from sympy.categories import (CompositeMorphism, IdentityMorphism,
                               NamedMorphism, Diagram)
 from sympy.utilities import default_sort_key
+from itertools import chain
 
 class _GrowableGrid(object):
     """
@@ -304,10 +305,7 @@ class DiagramGrid(object):
         and also in conclusions, the properties in conclusions take
         priority.
         """
-        merged = premises
-        for morphism, props in conclusions.items():
-            merged[morphism] = props
-        return merged
+        return dict(chain(premises.items(), conclusions.items()))
 
     @staticmethod
     def _juxtapose_edges(edge1, edge2):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -291,40 +291,6 @@ class DiagramGrid(Basic):
         return None
 
     @staticmethod
-    def _fix_degerate(edge, pt1, pt2, fringe, grid):
-        """
-        Checks if either of the points ``pt1`` or ``pt2`` forms a
-        perpendicular edge on ``edge``, which is in the fringe.  If
-        this is indeed so, replaces the two edges with the
-        corresponding diagonal and returns ``True``.  Otherwise
-        returns ``False``.
-        """
-        (a, b) = edge
-
-        if (a, pt1) in fringe:
-            fringe.remove((a, b))
-            fringe.remove((a, pt1))
-            fringe.append((pt1, b))
-            return True
-        elif (pt1, a) in fringe:
-            fringe.remove((a, b))
-            fringe.remove((pt1, a))
-            fringe.append((pt1, b))
-            return True
-        elif (b, pt2) in fringe:
-            fringe.remove((a, b))
-            fringe.remove((b, pt2))
-            fringe.append((a, pt2))
-            return True
-        elif (pt2, b) in fringe:
-            fringe.remove((a, b))
-            fringe.remove((pt2, b))
-            fringe.append((a, pt2))
-            return True
-
-        return False
-
-    @staticmethod
     def _empty_point(pt, grid):
         """
         Checks if the cell at coordinates ``pt`` is either empty or
@@ -442,11 +408,6 @@ class DiagramGrid(Basic):
                 up_left = a[0] - 1, a[1]
                 up_right = a[0] - 1, b[1]
 
-                if DiagramGrid._fix_degerate(
-                    (a, b), up_left, up_right, fringe, grid):
-                    # The fringe has just been corrected.  Restart.
-                    break
-
                 target_cell = DiagramGrid._choose_target_cell(
                     up_left, up_right, (a, b), obj, skeleton, grid)
 
@@ -454,12 +415,6 @@ class DiagramGrid(Basic):
                     # No room above this edge.  Check below.
                     down_left = a[0] + 1, a[1]
                     down_right = a[0] + 1, b[1]
-
-                    if DiagramGrid._fix_degerate(
-                        (a, b), up_left, up_right, fringe, grid):
-                        # The fringe has just been corrected.
-                        # Restart.
-                        break
 
                     target_cell = DiagramGrid._choose_target_cell(
                         down_left, down_right, (a, b), obj, skeleton, grid)
@@ -476,11 +431,6 @@ class DiagramGrid(Basic):
                 left_up = a[0], a[1] - 1
                 left_down = b[0], a[1] - 1
 
-                if DiagramGrid._fix_degerate(
-                    (a, b), left_up, left_down, fringe, grid):
-                    # The fringe has just been corrected.  Restart.
-                    break
-
                 target_cell = DiagramGrid._choose_target_cell(
                     left_down, left_up, (a, b), obj, skeleton, grid)
 
@@ -488,11 +438,6 @@ class DiagramGrid(Basic):
                     # No room to the left.  See what's to the right.
                     right_up = a[0], a[1] + 1
                     right_down = b[0], a[1] + 1
-
-                    if DiagramGrid._fix_degerate(
-                        (a, b), right_up, right_down, fringe, skeleton, grid):
-                        # The fringe has just been corrected.  Restart.
-                        break
 
                     target_cell = DiagramGrid._choose_target_cell(
                         right_down, right_up, (a, b), obj, skeleton, grid)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -403,21 +403,21 @@ class DiagramGrid(Basic):
                         break
             elif a[0] == b[0]:
                 # A horizontal edge.  Suppose a triangle can be
-                # built in the upward direction.
+                # built in the downward direction.
 
-                up_left = a[0] - 1, a[1]
-                up_right = a[0] - 1, b[1]
+                down_left = a[0] + 1, a[1]
+                down_right = a[0] + 1, b[1]
 
                 target_cell = DiagramGrid._choose_target_cell(
-                    up_left, up_right, (a, b), obj, skeleton, grid)
+                    down_left, down_right, (a, b), obj, skeleton, grid)
 
                 if not target_cell:
-                    # No room above this edge.  Check below.
-                    down_left = a[0] + 1, a[1]
-                    down_right = a[0] + 1, b[1]
+                    # No room below this edge.  Check above.
+                    up_left = a[0] - 1, a[1]
+                    up_right = a[0] - 1, b[1]
 
                     target_cell = DiagramGrid._choose_target_cell(
-                        down_left, down_right, (a, b), obj, skeleton, grid)
+                        up_left, up_right, (a, b), obj, skeleton, grid)
 
                     if not target_cell:
                         # This edge is not in the fringe, remove it
@@ -427,20 +427,20 @@ class DiagramGrid(Basic):
 
             elif a[1] == b[1]:
                 # A vertical edge.  Suppose a triangle can be built to
-                # the left.
-                left_up = a[0], a[1] - 1
-                left_down = b[0], a[1] - 1
+                # the right.
+                right_up = a[0], a[1] + 1
+                right_down = b[0], a[1] + 1
 
                 target_cell = DiagramGrid._choose_target_cell(
-                    left_down, left_up, (a, b), obj, skeleton, grid)
+                    right_down, right_up, (a, b), obj, skeleton, grid)
 
                 if not target_cell:
                     # No room to the left.  See what's to the right.
-                    right_up = a[0], a[1] + 1
-                    right_down = b[0], a[1] + 1
+                    left_up = a[0], a[1] - 1
+                    left_down = b[0], a[1] - 1
 
                     target_cell = DiagramGrid._choose_target_cell(
-                        right_down, right_up, (a, b), obj, skeleton, grid)
+                        left_down, left_up, (a, b), obj, skeleton, grid)
 
                     if not target_cell:
                         # This edge is not in the fringe, remove it

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -864,10 +864,16 @@ class DiagramGrid(object):
         """
         Produces the generic layout for the supplied diagram.
         """
+        all_objects = set(diagram.objects)
+        if len(all_objects) == 1:
+            # There only one object in the diagram, just put in on 1x1
+            # grid.
+            grid = _GrowableGrid(1, 1)
+            grid[0, 0] = tuple(all_objects)[0]
+            return grid
 
         skeleton = DiagramGrid._build_skeleton(merged_morphisms)
 
-        all_objects = set(diagram.objects)
         grid = _GrowableGrid(2, 1)
 
         if len(skeleton) == 1:

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -661,17 +661,11 @@ class DiagramGrid(object):
 
         return grid
 
-    def __init__(self, diagram, groups=None):
-        premises = DiagramGrid._simplify_morphisms(diagram.premises)
-        conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
-        merged_morphisms = DiagramGrid._merge_premises_conclusions(
-            premises, conclusions)
-
-        if groups and (groups != diagram.objects):
-            # Lay out the diagram according to the groups.
-            self._grid = DiagramGrid._handle_groups(diagram, groups, merged_morphisms)
-            return
-
+    @staticmethod
+    def _generic_layout(diagram, merged_morphisms):
+        """
+        Produces the generic layout for the supplied diagram.
+        """
         skeleton = DiagramGrid._build_skeleton(merged_morphisms)
 
         all_objects = diagram.objects
@@ -684,9 +678,7 @@ class DiagramGrid(object):
             grid[0, 0] = objects[0]
             grid[0, 1] = objects[1]
 
-            self._grid = grid
-
-            return
+            return grid
 
         triangles = DiagramGrid._list_triangles(skeleton)
         triangles = DiagramGrid._drop_redundant_triangles(triangles, skeleton)
@@ -729,7 +721,20 @@ class DiagramGrid(object):
             triangles = DiagramGrid._drop_irrelevant_triangles(
                 triangles, placed_objects)
 
-        self._grid = grid
+        return grid
+
+    def __init__(self, diagram, groups=None):
+        premises = DiagramGrid._simplify_morphisms(diagram.premises)
+        conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
+        merged_morphisms = DiagramGrid._merge_premises_conclusions(
+            premises, conclusions)
+
+        if groups and (groups != diagram.objects):
+            # Lay out the diagram according to the groups.
+            self._grid = DiagramGrid._handle_groups(diagram, groups, merged_morphisms)
+            return
+
+        self._grid = DiagramGrid._generic_layout(diagram, merged_morphisms)
 
     @property
     def width(self):

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1,0 +1,23 @@
+"""
+This module contains the functionality to arrange the nodes of a
+diagram on an abstract grid, and then to produce a graphical
+representation of the grid.
+
+The currently supported back-ends are Xy-pic [Xypic]
+
+[Xypic] http://www.tug.org/applications/Xy-pic/
+"""
+
+class DiagramGrid(Basic):
+    """
+    Constructs and holds the fitting of the diagram into a grid.
+
+    The constructor of this class takes a :class:`Diagram` as an
+    argument and fits it into a grid.  It is then possible to find the
+    with and height of the grid using the properties ``width`` and
+    ``height``, as well as accessing the objects located at certain
+    coordinates and finding out which moprhisms connect the object
+    with other objects in the grid.  TODO: Explain how to do that.
+    """
+    def __new__(cls, diagram):
+        pass

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -716,7 +716,7 @@ class DiagramGrid(object):
                 # the existing structure by a vertex.
 
                 candidates = sorted([e for e in tri if skeleton[e]],
-                                    key=default_sort_key)
+                                    key=lambda e: FiniteSet(e).sort_key())
                 edges = [e for e in candidates if obj in e]
 
                 # Note that a meaningful edge (i.e., and edge that is

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -83,7 +83,7 @@ class _GrowableGrid:
         for i in xrange(self._height):
             self._array[i].insert(0, None)
 
-class DiagramGrid(Basic):
+class DiagramGrid:
     """
     Constructs and holds the fitting of the diagram into a grid.
 
@@ -487,7 +487,7 @@ class DiagramGrid(Basic):
         sorted_candidates = sorted(candidates, key=default_sort_key)
         return sorted_candidates[0]
 
-    def __new__(cls, diagram):
+    def __init__(self, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)
         conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
         merged_morphisms = DiagramGrid._merge_premises_conclusions(

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -8,6 +8,79 @@ The currently supported back-ends are Xy-pic [Xypic]
 [Xypic] http://www.tug.org/applications/Xy-pic/
 """
 
+from sympy.core import Basic
+
+class _GrowableGrid:
+    """
+    Holds a growable grid of objects.
+
+    It is possible to append or prepend a row or a column to the grid
+    using the corresponding methods.  Prepending rows or columns has
+    the effect of changing the coordinates of the already existing
+    elements.
+
+    This class currently represents a naive implementation of the
+    functionality with little attempt at optimisation.
+    """
+    def __init__(self, width, height):
+        self._width = width
+        self._height = height
+
+        self._array = [[None for j in xrange(width)] for i in xrange(height)]
+
+    @property
+    def width(self):
+        return self._width
+
+    @property
+    def height(self):
+        return self._height
+
+
+    def __getitem__(self, (i, j)):
+        """
+        Returns the element located at in the i-th line and j-th
+        column.
+        """
+        return self._array[i][j]
+
+    def __setitem__(self, (i, j), newvalue):
+        """
+        Sets the element located at in the i-th line and j-th
+        column.
+        """
+        self._array[i][j] = newvalue
+
+    def append_row(self):
+        """
+        Appends an empty row to the grid.
+        """
+        self._height += 1
+        self._array.append([None for j in xrange(self._width)])
+
+    def append_column(self):
+        """
+        Appends an empty column to the grid.
+        """
+        self._width += 1
+        for i in xrange(self._height):
+            self._array[i].append(None)
+
+    def prepend_row(self):
+        """
+        Prepends the grid with an empty row.
+        """
+        self._height += 1
+        self._array.insert(0, [None for j in xrange(self._width)])
+
+    def prepend_column(self):
+        """
+        Prepends the grid with an empty column.
+        """
+        self._width += 1
+        for i in xrange(self._height):
+            self._array[i].insert(0, None)
+
 class DiagramGrid(Basic):
     """
     Constructs and holds the fitting of the diagram into a grid.

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -291,6 +291,40 @@ class DiagramGrid(Basic):
         return None
 
     @staticmethod
+    def _fix_degerate(edge, pt1, pt2, fringe, grid):
+        """
+        Checks if either of the points ``pt1`` or ``pt2`` forms a
+        perpendicular edge on ``edge``, which is in the fringe.  If
+        this is indeed so, replaces the two edges with the
+        corresponding diagonal and returns ``True``.  Otherwise
+        returns ``False``.
+        """
+        (a, b) = edge
+
+        if (a, pt1) in fringe:
+            fringe.remove((a, b))
+            fringe.remove((a, pt1))
+            fringe.append((pt1, b))
+            return True
+        elif (pt1, a) in fringe:
+            fringe.remove((a, b))
+            fringe.remove((pt1, a))
+            fringe.append((pt1, b))
+            return True
+        elif (b, pt2) in fringe:
+            fringe.remove((a, b))
+            fringe.remove((b, pt2))
+            fringe.append((a, pt2))
+            return True
+        elif (pt2, b) in fringe:
+            fringe.remove((a, b))
+            fringe.remove((pt2, b))
+            fringe.append((a, pt2))
+            return True
+
+        return False
+
+    @staticmethod
     def _weld_triangle(triangles, fringe, grid, skeleton):
         """
         Welds a triangle to the fringe and returns ``True``, if

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -9,6 +9,7 @@ The currently supported back-ends are Xy-pic [Xypic]
 """
 
 from sympy.core import Basic
+from sympy.categories import CompositeMorphism, IdentityMorphism
 
 class _GrowableGrid:
     """
@@ -92,5 +93,41 @@ class DiagramGrid(Basic):
     coordinates and finding out which moprhisms connect the object
     with other objects in the grid.  TODO: Explain how to do that.
     """
+    @staticmethod
+    def _simplify_morphisms(morphisms):
+        """
+        Given a dictionary mapping morphisms to their properties,
+        returns a new dictionary in which there are no morphisms which
+        do not have properties, and which are compositions of other
+        morphisms included in the dictionary.  Identities are dropped
+        as well.
+        """
+        newmorphisms = {}
+        for morphism, props in morphisms.items():
+            if isinstance(morphism, CompositeMorphism) and not props:
+                continue
+            elif isinstance(morphism, IdentityMorphism):
+                continue
+            else:
+                newmorphisms[morphism] = props
+        return newmorphisms
+
+    @staticmethod
+    def _merge_premises_conclusions(premises, conclusions):
+        """
+        Given two dictionaries of morphisms and their properties,
+        produces a single dictionary which includes elements from both
+        dictionaries.  If a morphism has some properties in premises
+        and also in conclusions, the properties in conclusions take
+        priority.
+        """
+        merged = premises
+        for morphism, props in conclusions.items():
+            merged[morphism] = props
+        return merged
+
     def __new__(cls, diagram):
-        pass
+        premises = DiagramGrid._simplify_morphisms(diagram.premises)
+        conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
+        merged_morphisms = DiagramGrid._merge_premises_conclusions(
+            premises, conclusions)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -275,12 +275,42 @@ class DiagramGrid(Basic):
         return (DiagramGrid._triangle_objects(triangle) - FiniteSet(edge)).args[0]
 
     @staticmethod
+    def _find_triangle_welding(triangle, fringe, grid):
+        """
+        Finds if possible an edge in the fringe to which the supplied
+        triangle could be attached and returns the index of the
+        corresponding edge in the fringe.
+
+        This function relies on the fact that objects are unique in
+        the diagram.
+        """
+        for (a, b) in fringe:
+            if ((grid[a], grid[b]) in triangle) or \
+               ((grid[b], grid[a]) in triangle):
+                return (a, b)
+        return None
+
+    @staticmethod
     def _weld_triangle(triangles, fringe, grid, skeleton):
         """
         Welds a triangle to the fringe and returns ``True``, if
         possible.  Otherwise returns ``False``.
         """
-        pass
+        for tri in triangles:
+            welding_edge = DiagramGrid._find_triangle_welding(
+                tri, fringe, grid)
+            if not welding_edge:
+                continue
+
+            a, b = welding_edge
+            target_cell = None
+
+            obj = DiagramGrid._other_vertex(tri, (grid[a], grid[b]))
+
+            # We now have a triangle and an wedge where it can be
+            # welded to the fringe.  Decide where to place the
+            # other vertex of the triangle and check for
+            # degenerate situations en route.
 
     def __new__(cls, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -274,6 +274,14 @@ class DiagramGrid(Basic):
         """
         return (DiagramGrid._triangle_objects(triangle) - FiniteSet(edge)).args[0]
 
+    @staticmethod
+    def _weld_triangle(triangles, fringe, grid, skeleton):
+        """
+        Welds a triangle to the fringe and returns ``True``, if
+        possible.  Otherwise returns ``False``.
+        """
+        pass
+
     def __new__(cls, diagram):
         premises = DiagramGrid._simplify_morphisms(diagram.premises)
         conclusions = DiagramGrid._simplify_morphisms(diagram.conclusions)
@@ -286,3 +294,15 @@ class DiagramGrid(Basic):
         triangles = DiagramGrid._drop_redundant_triangles(triangles, skeleton)
         triangle_sizes = DiagramGrid._compute_triangle_min_sizes(
             triangles, skeleton)
+
+        triangles = sorted(triangles, key=lambda triangle: triangle_sizes[triangle])
+
+        grid = _GrowableGrid(2, 1)
+
+        # Place the first edge on the grid.
+        root_edge = [e for e in triangles[0] if skeleton[e]][0]
+        grid[0, 0], grid[0, 1] = root_edge
+        fringe = [((0,0), (0, 1))]
+
+        while DiagramGrid._weld_triangle(triangles, fringe, grid, skeleton):
+            pass

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -8,7 +8,7 @@ The currently supported back-ends are Xy-pic [Xypic].
 Layout Algorithm
 ================
 
-This section overviews the algorithms implemented in
+This section provides an overview of the algorithms implemented in
 :class:`DiagramGrid` to lay out diagrams.
 
 The first step of the algorithm is the removal composite and identity
@@ -21,8 +21,8 @@ has the objects of the diagram as vertices and has an (undirected)
 edge between each pair of objects between which there exist morphisms.
 The direction of the morphisms does not matter at this stage.  The
 skeleton also includes an edge between each pair of vertices `A` and
-`C` such that there exists an object `B` which is connected with
-a morphism with `A`, and with a morphism with `C`.
+`C` such that there exists an object `B` which is connected via
+a morphism to `A`, and via a morphism to `C`.
 
 The skeleton constructed in this way has the property that every
 object is a vertex of a triangle formed by three edges of the
@@ -48,7 +48,7 @@ the fringe.  This process continues iteratively until all objects of
 the diagram has been placed or until no more weldings can be found.
 
 An edge is only removed from the fringe when a welding to this edge
-has been found, however, there is no room around this edge to place
+has been found, and there is no room around this edge to place
 another vertex.
 
 When no more weldings can be found, but there are still triangles
@@ -58,16 +58,16 @@ possibility is found, the corresponding edge of the found triangle is
 placed in the found space and the iterative process of welding
 triangles restarts.
 
-When logical groups are supplied, each of this groups is laid out
+When logical groups are supplied, each of these groups is laid out
 independently.  Then a diagram is constructed in which groups are
 objects and any two logical groups between which there exist morphisms
-are connected with a morphism.  This diagram is laid out.  Finally,
+are connected via a morphism.  This diagram is laid out.  Finally,
 the grid which includes all objects of the initial diagram is
 constructed by replacing the cells which contain logical groups with
 the corresponding laid out grids, and by correspondingly expanding the
 rows and columns.
 
-The sequential layout algorithm begins with constructing the
+The sequential layout algorithm begins by constructing the
 underlying undirected graph defined by the morphisms obtained after
 simplifying premises and conclusions and merging them (see above).
 The vertex with the minimal degree is then picked up and depth-first
@@ -310,10 +310,11 @@ class DiagramGrid(object):
     @staticmethod
     def _juxtapose_edges(edge1, edge2):
         """
-        If ``edge1`` and ``edge2`` have a common extremity, returns an
-        edge which would form a triangle with ``edge1`` and ``edge2``.
+        If ``edge1`` and ``edge2`` have precisely one common endpoint,
+        returns an edge which would form a triangle with ``edge1`` and
+        ``edge2``.
 
-        If ``edge1`` and ``edge2`` don't have a common extremity,
+        If ``edge1`` and ``edge2`` don't have a common endpoint,
         returns ``None``.
 
         If ``edge1`` and ``edge`` are the same edge, returns ``None``.
@@ -324,16 +325,16 @@ class DiagramGrid(object):
         for i in [0, 1]:
             for j in [0, 1]:
                 if edge1[i] == edge2[j]:
-                    # Some extremities match, return the other two.
+                    # Some endpoints match, return the other two.
                     return (edge1[i ^ 1], edge2[j ^ 1])
 
-        # No extremities match, return None.
+        # No endpoints match, return None.
         return None
 
     @staticmethod
     def _add_edge_append(dictionary, edge, elem):
         """
-        If ``edge`` is not ``dictionary``, adds ``edge`` to the
+        If ``edge`` is not in ``dictionary``, adds ``edge`` to the
         dictionary and sets its value to ``[elem]``.  Otherwise
         appends ``elem`` to the value of existing entry.
 
@@ -381,7 +382,7 @@ class DiagramGrid(object):
         """
         Builds the set of triangles formed by the supplied edges.  The
         triangles are arbitrary and need not be commutative.  A
-        triangle is a set contains all three sides.
+        triangle is a set that contains all three of its sides.
         """
         triangles = []
 
@@ -467,7 +468,7 @@ class DiagramGrid(object):
     @staticmethod
     def _find_triangle_welding(triangle, fringe, grid):
         """
-        Finds if possible an edge in the fringe to which the supplied
+        Finds, if possible, an edge in the fringe to which the supplied
         triangle could be attached and returns the index of the
         corresponding edge in the fringe.
 
@@ -537,7 +538,7 @@ class DiagramGrid(object):
         pt2_empty = DiagramGrid._empty_point(pt2, grid)
 
         if pt1_empty and pt2_empty:
-            # Both cells are empty.  Of them two, choose that cell
+            # Both cells are empty.  Of these two, choose that cell
             # which will assure that a visible edge of the triangle
             # will be drawn perpendicularly to the current welding
             # edge.
@@ -580,7 +581,7 @@ class DiagramGrid(object):
 
             obj = DiagramGrid._other_vertex(tri, (grid[a], grid[b]))
 
-            # We now have a triangle and an wedge where it can be
+            # We now have a triangle and an edge where it can be
             # welded to the fringe.  Decide where to place the
             # other vertex of the triangle and check for
             # degenerate situations en route.
@@ -599,8 +600,8 @@ class DiagramGrid(object):
                         fringe.remove((a, b))
                         return DiagramGrid._RESTART
             elif a[0] == b[0]:
-                # A horizontal edge.  Suppose a triangle can be
-                # built in the downward direction.
+                # A horizontal edge.  We first attempt to build the
+                # triangle in the downward direction.
 
                 down_left = a[0] + 1, a[1]
                 down_right = a[0] + 1, b[1]
@@ -623,8 +624,8 @@ class DiagramGrid(object):
                         return DiagramGrid._RESTART
 
             elif a[1] == b[1]:
-                # A vertical edge.  Suppose a triangle can be built to
-                # the right.
+                # A vertical edge.  We will attempt to place the other
+                # vertex of the triangle to the right of this edge.
                 right_up = a[0], a[1] + 1
                 right_down = b[0], a[1] + 1
 
@@ -906,7 +907,7 @@ class DiagramGrid(object):
         # Place the first edge on the grid.
         root_edge = DiagramGrid._pick_root_edge(triangles[0], skeleton)
         grid[0, 0], grid[0, 1] = root_edge
-        fringe = [((0,0), (0, 1))]
+        fringe = [((0, 0), (0, 1))]
 
         # Record which objects we now have on the grid.
         placed_objects = FiniteSet(root_edge)

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -432,8 +432,8 @@ class DiagramGrid(object):
             for e in triangle:
                 morphisms = edges[e]
                 if morphisms:
-                    size += max([DiagramGrid._morphism_length(m)
-                                 for m in morphisms])
+                    size += max(DiagramGrid._morphism_length(m)
+                                for m in morphisms)
             triangle_sizes[triangle] = size
         return triangle_sizes
 
@@ -829,12 +829,12 @@ class DiagramGrid(object):
             else:
                 return (1, 1)
 
-        row_heights = [max([group_size(top_grid[i, j])[0]
-                            for j in xrange(top_grid.width)])
+        row_heights = [max(group_size(top_grid[i, j])[0]
+                           for j in xrange(top_grid.width))
                        for i in xrange(top_grid.height)]
 
-        column_widths = [max([group_size(top_grid[i, j])[1]
-                              for i in xrange(top_grid.height)])
+        column_widths = [max(group_size(top_grid[i, j])[1]
+                             for i in xrange(top_grid.height))
                          for j in xrange(top_grid.width)]
 
         grid = _GrowableGrid(sum(column_widths), sum(row_heights))
@@ -1144,8 +1144,8 @@ class DiagramGrid(object):
                 grids.append(grid)
 
             # Throw the grids together, in a line.
-            total_width = sum([g.width for g in grids])
-            total_height = max([g.height for g in grids])
+            total_width = sum(g.width for g in grids)
+            total_height = max(g.height for g in grids)
 
             grid = _GrowableGrid(total_width, total_height)
             start_j = 0

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -516,7 +516,7 @@ class DiagramGrid(object):
         if i == -1:
             grid.prepend_row()
             i = 0
-            offset = (1, offset[1])
+            offset = (1, 0)
             for k in xrange(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
                 fringe[k] = ((i1 + 1, j1), (i2 + 1, j2))

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -712,6 +712,16 @@ class DiagramGrid(object):
                     # This object is not interesting.
                     continue
 
+                # Pick the "simplest" of the triangles which could be
+                # attached.  Remember that the list of triangles is
+                # sorted according to their "simplicity" (see
+                # _compute_triangle_min_sizes for the metric).
+                #
+                # Note that ``tris`` are sequentially built from
+                # ``triangles``, so we don't have to worry about hash
+                # randomisation.
+                tri = tris[0]
+
                 # We have found a triangle which could be attached to
                 # the existing structure by a vertex.
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -805,6 +805,15 @@ class DiagramGrid(object):
         else:
             self._grid = DiagramGrid._generic_layout(diagram, merged_morphisms)
 
+        if "transpose" in hints:
+            if hints["transpose"]:
+                # Transpose the resulting grid.
+                grid = _GrowableGrid(self._grid.height, self._grid.width)
+                for i in xrange(self._grid.height):
+                    for j in xrange(self._grid.width):
+                        grid[j, i] = self._grid[i, j]
+                self._grid = grid
+
     @property
     def width(self):
         """

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -154,6 +154,26 @@ def test_diagram():
     assert f in d.premises
     assert g in d.premises
 
+    # Check subdiagrams.
+    d = Diagram([f, g], {g * f:"unique"})
+
+    d1 = Diagram([f])
+    assert d.is_subdiagram(d1)
+    assert not d1.is_subdiagram(d)
+
+    d = Diagram([NamedMorphism(B, A, "f'")])
+    assert not d.is_subdiagram(d1)
+    assert not d1.is_subdiagram(d)
+
+    d1 = Diagram([f, g], {g * f:["unique", "something"]})
+    assert not d.is_subdiagram(d1)
+    assert not d1.is_subdiagram(d)
+
+    d = Diagram({f:"blooh"})
+    d1 = Diagram({f:"bleeh"})
+    assert not d.is_subdiagram(d1)
+    assert not d1.is_subdiagram(d)
+
 def test_category():
     A = Object("A")
     B = Object("B")

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -124,7 +124,7 @@ def test_diagram():
     # Make sure that (re-)adding composites (with new properties)
     # works as expected.
     d = Diagram([f, g], {g * f:"unique"})
-    assert d.conclusions[g * f] == FiniteSet("unique")
+    assert d.conclusions == Dict({g*f:FiniteSet("unique")})
 
     # Check the hom-sets when there are premises and conclusions.
     assert d.hom(A, C) == (FiniteSet(g * f), FiniteSet(g * f))

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -118,12 +118,12 @@ def test_diagram():
     assert d1 != d2
     assert hash(d1) == hash(d11)
 
-    d11 = Diagram({f:"unique"})
+    d11 = Diagram({f: "unique"})
     assert d1 != d11
 
     # Make sure that (re-)adding composites (with new properties)
     # works as expected.
-    d = Diagram([f, g], {g * f:"unique"})
+    d = Diagram([f, g], {g * f: "unique"})
     assert d.conclusions == Dict({g*f:FiniteSet("unique")})
 
     # Check the hom-sets when there are premises and conclusions.
@@ -132,7 +132,7 @@ def test_diagram():
     assert d.hom(A, C) == (FiniteSet(g * f), FiniteSet(g * f))
 
     # Check how the properties of composite morphisms are computed.
-    d = Diagram({f:["unique", "isomorphism"], g:"unique"})
+    d = Diagram({f: ["unique", "isomorphism"], g:"unique"})
     assert d.premises[g * f] == FiniteSet("unique")
 
     # Check that conclusion morphisms with new objects are not allowed.
@@ -146,7 +146,7 @@ def test_diagram():
     assert d.objects == empty
 
     # Check a SymPy Dict object.
-    d = Diagram(Dict({f:FiniteSet("unique", "isomorphism"), g:"unique"}))
+    d = Diagram(Dict({f: FiniteSet("unique", "isomorphism"), g:"unique"}))
     assert d.premises[g * f] == FiniteSet("unique")
 
     # Check the addition of components of composite morphisms.
@@ -155,7 +155,7 @@ def test_diagram():
     assert g in d.premises
 
     # Check subdiagrams.
-    d = Diagram([f, g], {g * f:"unique"})
+    d = Diagram([f, g], {g * f: "unique"})
 
     d1 = Diagram([f])
     assert d.is_subdiagram(d1)
@@ -165,21 +165,21 @@ def test_diagram():
     assert not d.is_subdiagram(d1)
     assert not d1.is_subdiagram(d)
 
-    d1 = Diagram([f, g], {g * f:["unique", "something"]})
+    d1 = Diagram([f, g], {g * f: ["unique", "something"]})
     assert not d.is_subdiagram(d1)
     assert not d1.is_subdiagram(d)
 
-    d = Diagram({f:"blooh"})
-    d1 = Diagram({f:"bleeh"})
+    d = Diagram({f: "blooh"})
+    d1 = Diagram({f: "bleeh"})
     assert not d.is_subdiagram(d1)
     assert not d1.is_subdiagram(d)
 
-    d = Diagram([f, g], {f:"unique", g*f:"veryunique"})
+    d = Diagram([f, g], {f: "unique", g * f: "veryunique"})
     d1 = d.subdiagram_from_objects(FiniteSet(A, B))
-    assert d1 == Diagram([f], {f:"unique"})
+    assert d1 == Diagram([f], {f: "unique"})
     raises(ValueError, lambda: d.subdiagram_from_objects(FiniteSet(A, Object("D"))))
 
-    raises(ValueError, lambda: Diagram({IdentityMorphism(A):"unique"}))
+    raises(ValueError, lambda: Diagram({IdentityMorphism(A): "unique"}))
 
 def test_category():
     A = Object("A")

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -149,6 +149,11 @@ def test_diagram():
     d = Diagram(Dict({f:FiniteSet("unique", "isomorphism"), g:"unique"}))
     assert d.premises[g * f] == FiniteSet("unique")
 
+    # Check the addition of components of composite morphisms.
+    d = Diagram([g * f])
+    assert f in d.premises
+    assert g in d.premises
+
 def test_category():
     A = Object("A")
     B = Object("B")

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -179,6 +179,8 @@ def test_diagram():
     assert d1 == Diagram([f], {f:"unique"})
     raises(ValueError, lambda: d.subdiagram_from_objects(FiniteSet(A, Object("D"))))
 
+    raises(ValueError, lambda: Diagram({IdentityMorphism(A):"unique"}))
+
 def test_category():
     A = Object("A")
     B = Object("B")

--- a/sympy/categories/tests/test_baseclasses.py
+++ b/sympy/categories/tests/test_baseclasses.py
@@ -174,6 +174,11 @@ def test_diagram():
     assert not d.is_subdiagram(d1)
     assert not d1.is_subdiagram(d)
 
+    d = Diagram([f, g], {f:"unique", g*f:"veryunique"})
+    d1 = d.subdiagram_from_objects(FiniteSet(A, B))
+    assert d1 == Diagram([f], {f:"unique"})
+    raises(ValueError, lambda: d.subdiagram_from_objects(FiniteSet(A, Object("D"))))
+
 def test_category():
     A = Object("A")
     B = Object("B")

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -259,7 +259,7 @@ def test_DiagramGrid():
 
     # Test the pullback with sequential layout, just for stress
     # testing.
-    grid = DiagramGrid(d, shape="sequential")
+    grid = DiagramGrid(d, layout="sequential")
 
     assert grid.width == 5
     assert grid.height == 1
@@ -367,7 +367,7 @@ def test_DiagramGrid():
     h = NamedMorphism(C, D, "h")
     i = NamedMorphism(D, E, "i")
     d = Diagram([f, g, h, i])
-    grid = DiagramGrid(d, shape="sequential")
+    grid = DiagramGrid(d, layout="sequential")
 
     assert grid.width == 5
     assert grid.height == 1
@@ -378,7 +378,7 @@ def test_DiagramGrid():
     assert grid[0, 4] == E
 
     # Test the transposed version.
-    grid = DiagramGrid(d, shape="sequential", transpose=True)
+    grid = DiagramGrid(d, layout="sequential", transpose=True)
 
     assert grid.width == 1
     assert grid.height == 5

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -317,3 +317,28 @@ def test_DiagramGrid():
     assert grid[2, 2] is None
     assert grid[2, 3] == D_
     assert grid[2, 4] == E_
+
+    # Test the five lemma with object grouping.
+    grid = DiagramGrid(d, FiniteSet(
+        FiniteSet(A, B, C, D, E), FiniteSet(A_, B_, C_, D_, E_)))
+
+    assert grid.width == 6
+    assert grid.height == 3
+    assert grid[0, 0] == A_
+    assert grid[0, 1] == B_
+    assert grid[0, 2] is None
+    assert grid[0, 3] == A
+    assert grid[0, 4] == B
+    assert grid[0, 5] is None
+    assert grid[1, 0] is None
+    assert grid[1, 1] == C_
+    assert grid[1, 2] == D_
+    assert grid[1, 3] is None
+    assert grid[1, 4] == C
+    assert grid[1, 5] == D
+    assert grid[2, 0] is None
+    assert grid[2, 1] is None
+    assert grid[2, 2] == E_
+    assert grid[2, 3] is None
+    assert grid[2, 4] is None
+    assert grid[2, 5] == E

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -446,6 +446,32 @@ def test_DiagramGrid():
     assert grid[2, 5] == E
     assert grid.morphisms == morphisms
 
+    # Test the five lemma with object grouping, but mixing containers
+    # to represent groups.
+    grid = DiagramGrid(d, [(A, B, C, D, E), set([A_, B_, C_, D_, E_])])
+
+    assert grid.width == 6
+    assert grid.height == 3
+    assert grid[0, 0] == A_
+    assert grid[0, 1] == B_
+    assert grid[0, 2] is None
+    assert grid[0, 3] == A
+    assert grid[0, 4] == B
+    assert grid[0, 5] is None
+    assert grid[1, 0] is None
+    assert grid[1, 1] == C_
+    assert grid[1, 2] == D_
+    assert grid[1, 3] is None
+    assert grid[1, 4] == C
+    assert grid[1, 5] == D
+    assert grid[2, 0] is None
+    assert grid[2, 1] is None
+    assert grid[2, 2] == E_
+    assert grid[2, 3] is None
+    assert grid[2, 4] is None
+    assert grid[2, 5] == E
+    assert grid.morphisms == morphisms
+
     # Test the five lemma with object grouping and hints.
     grid = DiagramGrid(d, {
         FiniteSet(A, B, C, D, E): {"layout": "sequential",

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -1,0 +1,68 @@
+from sympy.categories.diagram_drawing import _GrowableGrid
+
+def test_GrowableGrid():
+    grid = _GrowableGrid(1, 2)
+
+    # Check dimensions.
+    assert grid.width == 1
+    assert grid.height == 2
+
+    # Check initialisation of elements.
+    assert grid[0, 0] == None
+    assert grid[1, 0] == None
+
+    # Check assignment to elements.
+    grid[0, 0] = 1
+    grid[1, 0] = "two"
+
+    assert grid[0, 0] == 1
+    assert grid[1, 0] == "two"
+
+    # Check appending a row.
+    grid.append_row()
+
+    assert grid.width == 1
+    assert grid.height == 3
+
+    assert grid[0, 0] == 1
+    assert grid[1, 0] == "two"
+    assert grid[2, 0] == None
+
+    # Check appending a column.
+    grid.append_column()
+    assert grid.width == 2
+    assert grid.height == 3
+
+    assert grid[0, 0] == 1
+    assert grid[1, 0] == "two"
+    assert grid[2, 0] == None
+
+    assert grid[0, 1] == None
+    assert grid[1, 1] == None
+    assert grid[2, 1] == None
+
+    grid = _GrowableGrid(1, 2)
+    grid[0, 0] = 1
+    grid[1, 0] = "two"
+
+    # Check prepending a row.
+    grid.prepend_row()
+    assert grid.width == 1
+    assert grid.height == 3
+
+    assert grid[0, 0] == None
+    assert grid[1, 0] == 1
+    assert grid[2, 0] == "two"
+
+    # Check prepending a column.
+    grid.prepend_column()
+    assert grid.width == 2
+    assert grid.height == 3
+
+    assert grid[0, 0] == None
+    assert grid[1, 0] == None
+    assert grid[2, 0] == None
+
+    assert grid[0, 1] == None
+    assert grid[1, 1] == 1
+    assert grid[2, 1] == "two"

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -219,9 +219,9 @@ def test_DiagramGrid():
     assert grid[1, 2] == B_
     assert grid[2, 0] == C_
     assert grid[2, 1] == D
-    assert grid[2, 2] == E
+    assert grid[2, 2] == D_
     assert grid[3, 0] is None
-    assert grid[3, 1] == D_
+    assert grid[3, 1] == E
     assert grid[3, 2] == E_
 
     morphisms = {}

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -257,6 +257,18 @@ def test_DiagramGrid():
     d = Diagram([m1, m2, s1, s2, f1, f2], {g: "unique"})
     grid = DiagramGrid(d)
 
+    # Test the pullback with sequential layout, just for stress
+    # testing.
+    grid = DiagramGrid(d, shape="sequential")
+
+    assert grid.width == 5
+    assert grid.height == 1
+    assert grid[0, 0] == D
+    assert grid[0, 1] == B
+    assert grid[0, 2] == A
+    assert grid[0, 3] == C
+    assert grid[0, 4] == E
+
     # Test a pullback with object grouping.
     grid = DiagramGrid(d, groups=FiniteSet(E, FiniteSet(A, B, C, D)))
 

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -245,6 +245,39 @@ def test_DiagramGrid():
     assert grid[2, 2] == A4
     assert grid[2, 3] == A8
 
+    # A line diagram.
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    D = Object("D")
+    E = Object("E")
+
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    h = NamedMorphism(C, D, "h")
+    i = NamedMorphism(D, E, "i")
+    d = Diagram([f, g, h, i])
+    grid = DiagramGrid(d, layout="sequential")
+
+    assert grid.width == 5
+    assert grid.height == 1
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == C
+    assert grid[0, 3] == D
+    assert grid[0, 4] == E
+
+    # Test the transposed version.
+    grid = DiagramGrid(d, layout="sequential", transpose=True)
+
+    assert grid.width == 1
+    assert grid.height == 5
+    assert grid[0, 0] == A
+    assert grid[1, 0] == B
+    assert grid[2, 0] == C
+    assert grid[3, 0] == D
+    assert grid[4, 0] == E
+
     # A pullback.
     m1 = NamedMorphism(A, B, "m1")
     m2 = NamedMorphism(A, C, "m2")
@@ -355,35 +388,3 @@ def test_DiagramGrid():
     assert grid[2, 4] is None
     assert grid[2, 5] == E
 
-    # A line diagram.
-    A = Object("A")
-    B = Object("B")
-    C = Object("C")
-    D = Object("D")
-    E = Object("E")
-
-    f = NamedMorphism(A, B, "f")
-    g = NamedMorphism(B, C, "g")
-    h = NamedMorphism(C, D, "h")
-    i = NamedMorphism(D, E, "i")
-    d = Diagram([f, g, h, i])
-    grid = DiagramGrid(d, layout="sequential")
-
-    assert grid.width == 5
-    assert grid.height == 1
-    assert grid[0, 0] == A
-    assert grid[0, 1] == B
-    assert grid[0, 2] == C
-    assert grid[0, 3] == D
-    assert grid[0, 4] == E
-
-    # Test the transposed version.
-    grid = DiagramGrid(d, layout="sequential", transpose=True)
-
-    assert grid.width == 1
-    assert grid.height == 5
-    assert grid[0, 0] == A
-    assert grid[1, 0] == B
-    assert grid[2, 0] == C
-    assert grid[3, 0] == D
-    assert grid[4, 0] == E

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -90,6 +90,7 @@ def test_DiagramGrid():
     assert grid.height == 1
     assert grid[0, 0] == A
     assert grid[0, 1] == B
+    assert grid.morphisms == {f:FiniteSet()}
 
     # A triangle.
     d = Diagram([f, g], {g * f:"unique"})
@@ -101,6 +102,8 @@ def test_DiagramGrid():
     assert grid[0, 1] == B
     assert grid[1, 0] == C
     assert grid[1, 1] is None
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(),
+                              g * f:FiniteSet("unique")}
 
     # A simple diagram.
     d = Diagram([f, g, h, k])
@@ -114,6 +117,8 @@ def test_DiagramGrid():
     assert grid[1, 0] is None
     assert grid[1, 1] == C
     assert grid[1, 2] is None
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), h:FiniteSet(),
+                              k:FiniteSet()}
 
     # A chain of morphisms.
     f = NamedMorphism(A, B, "f")
@@ -134,6 +139,8 @@ def test_DiagramGrid():
     assert grid[2, 0] is None
     assert grid[2, 1] is None
     assert grid[2, 2] == E
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), h:FiniteSet(),
+                              k:FiniteSet()}
 
     # A square.
     f = NamedMorphism(A, B, "f")
@@ -149,6 +156,8 @@ def test_DiagramGrid():
     assert grid[0, 1] == B
     assert grid[1, 0] == C
     assert grid[1, 1] == D
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), h:FiniteSet(),
+                              k:FiniteSet()}
 
     # A strange diagram which resulted from a typo when creating a
     # test for five lemma, but which allowed to stop one extra problem
@@ -199,6 +208,11 @@ def test_DiagramGrid():
     assert grid[3, 1] == D_
     assert grid[3, 2] == E_
 
+    morphisms = {}
+    for m in [f, g, h, i, j, k, l, m, o, p, q, r, s]:
+        morphisms[m] = FiniteSet()
+    assert grid.morphisms == morphisms
+
     # A cube.
     A1 = Object("A1")
     A2 = Object("A2")
@@ -245,6 +259,11 @@ def test_DiagramGrid():
     assert grid[2, 2] == A4
     assert grid[2, 3] == A8
 
+    morphisms = {}
+    for m in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12]:
+        morphisms[m] = FiniteSet()
+    assert grid.morphisms == morphisms
+
     # A line diagram.
     A = Object("A")
     B = Object("B")
@@ -266,6 +285,8 @@ def test_DiagramGrid():
     assert grid[0, 2] == C
     assert grid[0, 3] == D
     assert grid[0, 4] == E
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), h:FiniteSet(),
+                              i:FiniteSet()}
 
     # Test the transposed version.
     grid = DiagramGrid(d, layout="sequential", transpose=True)
@@ -277,6 +298,8 @@ def test_DiagramGrid():
     assert grid[2, 0] == C
     assert grid[3, 0] == D
     assert grid[4, 0] == E
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), h:FiniteSet(),
+                              i:FiniteSet()}
 
     # A pullback.
     m1 = NamedMorphism(A, B, "m1")
@@ -299,6 +322,11 @@ def test_DiagramGrid():
     assert grid[1, 1] == D
     assert grid[1, 2] is None
 
+    morphisms = {g:FiniteSet("unique")}
+    for m in [m1, m2, s1, s2, f1, f2]:
+        morphisms[m] = FiniteSet()
+    assert grid.morphisms == morphisms
+
     # Test the pullback with sequential layout, just for stress
     # testing.
     grid = DiagramGrid(d, layout="sequential")
@@ -310,6 +338,7 @@ def test_DiagramGrid():
     assert grid[0, 2] == A
     assert grid[0, 3] == C
     assert grid[0, 4] == E
+    assert grid.morphisms == morphisms
 
     # Test a pullback with object grouping.
     grid = DiagramGrid(d, groups=FiniteSet(E, FiniteSet(A, B, C, D)))
@@ -322,6 +351,7 @@ def test_DiagramGrid():
     assert grid[1, 0] is None
     assert grid[1, 1] == C
     assert grid[1, 2] == D
+    assert grid.morphisms == morphisms
 
     # Five lemma, actually.
     A = Object("A")
@@ -372,6 +402,11 @@ def test_DiagramGrid():
     assert grid[2, 3] == D_
     assert grid[2, 4] == E_
 
+    morphisms = {}
+    for m in [f, g, h, i, j, k, l, m, o, p, q, r, s]:
+        morphisms[m] = FiniteSet()
+    assert grid.morphisms == morphisms
+
     # Test the five lemma with object grouping.
     grid = DiagramGrid(d, FiniteSet(
         FiniteSet(A, B, C, D, E), FiniteSet(A_, B_, C_, D_, E_)))
@@ -396,6 +431,7 @@ def test_DiagramGrid():
     assert grid[2, 3] is None
     assert grid[2, 4] is None
     assert grid[2, 5] == E
+    assert grid.morphisms == morphisms
 
     # Test the five lemma with object grouping and hints.
     grid = DiagramGrid(d, {
@@ -417,3 +453,4 @@ def test_DiagramGrid():
     assert grid[1, 2] == C
     assert grid[1, 3] == D
     assert grid[1, 4] == E
+    assert grid.morphisms == morphisms

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -234,3 +234,15 @@ def test_DiagramGrid():
     assert grid[2, 1] == A3
     assert grid[2, 2] == A4
     assert grid[2, 3] == A8
+
+    # A pullback.
+    m1 = NamedMorphism(A, B, "m1")
+    m2 = NamedMorphism(A, C, "m2")
+    s1 = NamedMorphism(B, D, "s1")
+    s2 = NamedMorphism(C, D, "s2")
+    f1 = NamedMorphism(E, B, "f1")
+    f2 = NamedMorphism(E, C, "f2")
+    g = NamedMorphism(E, A, "g")
+
+    d = Diagram([m1, m2, s1, s2, f1, f2], {g: "unique"})
+    grid = DiagramGrid(d)

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -105,6 +105,19 @@ def test_DiagramGrid():
     assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(),
                               g * f:FiniteSet("unique")}
 
+    # A triangle with a "loop" morphism.
+    l_A = NamedMorphism(A, A, "l_A")
+    d = Diagram([f, g, l_A])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 2
+    assert grid.height == 2
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[1, 0] is None
+    assert grid[1, 1] == C
+    assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), l_A:FiniteSet()}
+
     # A simple diagram.
     d = Diagram([f, g, h, k])
     grid = DiagramGrid(d)

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -467,3 +467,39 @@ def test_DiagramGrid():
     assert grid[1, 3] == D
     assert grid[1, 4] == E
     assert grid.morphisms == morphisms
+
+    # A two-triangle disconnected diagram.
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    f_ = NamedMorphism(A_, B_, "f")
+    g_ = NamedMorphism(B_, C_, "g")
+    d = Diagram([f, g, f_, g_], {g * f: "unique", g_ * f_: "unique"})
+    grid = DiagramGrid(d)
+
+    assert grid.width == 4
+    assert grid.height == 2
+    assert grid[0, 0] == A_
+    assert grid[0, 1] == B_
+    assert grid[0, 2] == A
+    assert grid[0, 3] == B
+    assert grid[1, 0] == C_
+    assert grid[1, 1] is None
+    assert grid[1, 2] == C
+    assert grid[1, 3] is None
+    assert grid.morphisms == {f: FiniteSet(), g: FiniteSet(), f_: FiniteSet(),
+                              g_: FiniteSet(), g * f: FiniteSet("unique"),
+                              g_ * f_: FiniteSet("unique")}
+
+    # A two-morphism disconnected diagram.
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(C, D, "g")
+    d = Diagram([f, g])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 4
+    assert grid.height == 1
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == C
+    assert grid[0, 3] == D
+    assert grid.morphisms == {f: FiniteSet(), g: FiniteSet()}

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -429,24 +429,24 @@ def test_DiagramGrid():
 
     assert grid.width == 6
     assert grid.height == 3
-    assert grid[0, 0] == A_
-    assert grid[0, 1] == B_
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
     assert grid[0, 2] is None
-    assert grid[0, 3] == A
-    assert grid[0, 4] == B
+    assert grid[0, 3] == A_
+    assert grid[0, 4] == B_
     assert grid[0, 5] is None
     assert grid[1, 0] is None
-    assert grid[1, 1] == C_
-    assert grid[1, 2] == D_
+    assert grid[1, 1] == C
+    assert grid[1, 2] == D
     assert grid[1, 3] is None
-    assert grid[1, 4] == C
-    assert grid[1, 5] == D
+    assert grid[1, 4] == C_
+    assert grid[1, 5] == D_
     assert grid[2, 0] is None
     assert grid[2, 1] is None
-    assert grid[2, 2] == E_
+    assert grid[2, 2] == E
     assert grid[2, 3] is None
     assert grid[2, 4] is None
-    assert grid[2, 5] == E
+    assert grid[2, 5] == E_
     assert grid.morphisms == morphisms
 
     # Test the five lemma with object grouping, but mixing containers
@@ -455,24 +455,24 @@ def test_DiagramGrid():
 
     assert grid.width == 6
     assert grid.height == 3
-    assert grid[0, 0] == A_
-    assert grid[0, 1] == B_
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
     assert grid[0, 2] is None
-    assert grid[0, 3] == A
-    assert grid[0, 4] == B
+    assert grid[0, 3] == A_
+    assert grid[0, 4] == B_
     assert grid[0, 5] is None
     assert grid[1, 0] is None
-    assert grid[1, 1] == C_
-    assert grid[1, 2] == D_
+    assert grid[1, 1] == C
+    assert grid[1, 2] == D
     assert grid[1, 3] is None
-    assert grid[1, 4] == C
-    assert grid[1, 5] == D
+    assert grid[1, 4] == C_
+    assert grid[1, 5] == D_
     assert grid[2, 0] is None
     assert grid[2, 1] is None
-    assert grid[2, 2] == E_
+    assert grid[2, 2] == E
     assert grid[2, 3] is None
     assert grid[2, 4] is None
-    assert grid[2, 5] == E
+    assert grid[2, 5] == E_
     assert grid.morphisms == morphisms
 
     # Test the five lemma with object grouping and hints.
@@ -485,16 +485,16 @@ def test_DiagramGrid():
 
     assert grid.width == 5
     assert grid.height == 2
-    assert grid[0, 0] == A_
-    assert grid[0, 1] == B_
-    assert grid[0, 2] == C_
-    assert grid[0, 3] == D_
-    assert grid[0, 4] == E_
-    assert grid[1, 0] == A
-    assert grid[1, 1] == B
-    assert grid[1, 2] == C
-    assert grid[1, 3] == D
-    assert grid[1, 4] == E
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == C
+    assert grid[0, 3] == D
+    assert grid[0, 4] == E
+    assert grid[1, 0] == A_
+    assert grid[1, 1] == B_
+    assert grid[1, 2] == C_
+    assert grid[1, 3] == D_
+    assert grid[1, 4] == E_
     assert grid.morphisms == morphisms
 
     # A two-triangle disconnected diagram.
@@ -507,13 +507,13 @@ def test_DiagramGrid():
 
     assert grid.width == 4
     assert grid.height == 2
-    assert grid[0, 0] == A_
-    assert grid[0, 1] == B_
-    assert grid[0, 2] == A
-    assert grid[0, 3] == B
-    assert grid[1, 0] == C_
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == A_
+    assert grid[0, 3] == B_
+    assert grid[1, 0] == C
     assert grid[1, 1] is None
-    assert grid[1, 2] == C
+    assert grid[1, 2] == C_
     assert grid[1, 3] is None
     assert grid.morphisms == {f: FiniteSet(), g: FiniteSet(), f_: FiniteSet(),
                               g_: FiniteSet(), g * f: FiniteSet("unique"),

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -268,3 +268,52 @@ def test_DiagramGrid():
     assert grid[1, 0] is None
     assert grid[1, 1] == C
     assert grid[1, 2] == D
+
+    # Five lemma, actually.
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    D = Object("D")
+    E = Object("E")
+    A_ = Object("A'")
+    B_ = Object("B'")
+    C_ = Object("C'")
+    D_ = Object("D'")
+    E_ = Object("E'")
+
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    h = NamedMorphism(C, D, "h")
+    i = NamedMorphism(D, E, "i")
+
+    j = NamedMorphism(A_, B_, "j")
+    k = NamedMorphism(B_, C_, "k")
+    l = NamedMorphism(C_, D_, "l")
+    m = NamedMorphism(D_, E_, "m")
+
+    o = NamedMorphism(A, A_, "o")
+    p = NamedMorphism(B, B_, "p")
+    q = NamedMorphism(C, C_, "q")
+    r = NamedMorphism(D, D_, "r")
+    s = NamedMorphism(E, E_, "s")
+
+    d = Diagram([f, g, h, i, j, k, l, m, o, p, q, r, s])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 5
+    assert grid.height == 3
+    assert grid[0, 0] is None
+    assert grid[0, 1] == A
+    assert grid[0, 2] == A_
+    assert grid[0, 3] is None
+    assert grid[0, 4] is None
+    assert grid[1, 0] == C
+    assert grid[1, 1] == B
+    assert grid[1, 2] == B_
+    assert grid[1, 3] == C_
+    assert grid[1, 4] is None
+    assert grid[2, 0] == D
+    assert grid[2, 1] == E
+    assert grid[2, 2] is None
+    assert grid[2, 3] == D_
+    assert grid[2, 4] == E_

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -388,3 +388,23 @@ def test_DiagramGrid():
     assert grid[2, 4] is None
     assert grid[2, 5] == E
 
+    # Test the five lemma with object grouping and hints.
+    grid = DiagramGrid(d, {
+        FiniteSet(A, B, C, D, E): {"layout": "sequential",
+                                   "transpose": True},
+        FiniteSet(A_, B_, C_, D_, E_): {"layout": "sequential",
+                                        "transpose": True}},
+                       transpose=True)
+
+    assert grid.width == 5
+    assert grid.height == 2
+    assert grid[0, 0] == A_
+    assert grid[0, 1] == B_
+    assert grid[0, 2] == C_
+    assert grid[0, 3] == D_
+    assert grid[0, 4] == E_
+    assert grid[1, 0] == A
+    assert grid[1, 1] == B
+    assert grid[1, 2] == C
+    assert grid[1, 3] == D
+    assert grid[1, 4] == E

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -139,3 +139,52 @@ def test_DiagramGrid():
     assert grid[0, 1] == B
     assert grid[1, 0] == C
     assert grid[1, 1] == D
+
+    # A strange diagram which resulted from a typo when creating a
+    # test for five lemma, but which allowed to stop one extra problem
+    # in the algorithm.
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    D = Object("D")
+    E = Object("E")
+    A_ = Object("A'")
+    B_ = Object("B'")
+    C_ = Object("C'")
+    D_ = Object("D'")
+    E_ = Object("E'")
+
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    h = NamedMorphism(C, D, "h")
+    i = NamedMorphism(D, E, "i")
+
+    # These 4 morphisms should be between primed objects.
+    j = NamedMorphism(A, B, "j")
+    k = NamedMorphism(B, C, "k")
+    l = NamedMorphism(C, D, "l")
+    m = NamedMorphism(D, E, "m")
+
+    o = NamedMorphism(A, A_, "o")
+    p = NamedMorphism(B, B_, "p")
+    q = NamedMorphism(C, C_, "q")
+    r = NamedMorphism(D, D_, "r")
+    s = NamedMorphism(E, E_, "s")
+
+    d = Diagram([f, g, h, i, j, k, l, m, o, p, q, r, s])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 3
+    assert grid.height == 4
+    assert grid[0, 0] is None
+    assert grid[0, 1] == A
+    assert grid[0, 2] == A_
+    assert grid[1, 0] == C
+    assert grid[1, 1] == B
+    assert grid[1, 2] == B_
+    assert grid[2, 0] == C_
+    assert grid[2, 1] == D
+    assert grid[2, 2] == E
+    assert grid[3, 0] is None
+    assert grid[3, 1] == D_
+    assert grid[3, 2] == E_

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -522,3 +522,42 @@ def test_DiagramGrid():
     assert grid.height == 1
     assert grid[0, 0] == A
     assert grid[0, 1] == B
+
+    # Test a diagram in which even growing a pseudopod does not
+    # eventually help.
+    F = Object("F")
+    f1 = NamedMorphism(A, B, "f1")
+    f2 = NamedMorphism(A, C, "f2")
+    f3 = NamedMorphism(A, D, "f3")
+    f4 = NamedMorphism(A, E, "f4")
+    f5 = NamedMorphism(A, A_, "f5")
+    f6 = NamedMorphism(A, B_, "f6")
+    f7 = NamedMorphism(A, C_, "f7")
+    f8 = NamedMorphism(A, D_, "f8")
+    f9 = NamedMorphism(A, E_, "f9")
+    f10 = NamedMorphism(A, F, "f10")
+    d = Diagram([f1, f2, f3, f4, f5, f6, f7, f8, f9, f10])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 5
+    assert grid.height == 3
+    assert grid[0, 0] == E
+    assert grid[0, 1] == C
+    assert grid[0, 2] == C_
+    assert grid[0, 3] == E_
+    assert grid[0, 4] == F
+    assert grid[1, 0] == D
+    assert grid[1, 1] == A
+    assert grid[1, 2] == A_
+    assert grid[1, 3] is None
+    assert grid[1, 4] is None
+    assert grid[2, 0] == D_
+    assert grid[2, 1] == B
+    assert grid[2, 2] == B_
+    assert grid[2, 3] is None
+    assert grid[2, 4] is None
+
+    morphisms = {}
+    for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10]:
+        morphisms[f] = FiniteSet()
+    assert grid.morphisms == morphisms

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -69,14 +69,73 @@ def test_GrowableGrid():
     assert grid[2, 1] == "two"
 
 def test_DiagramGrid():
+    # Set up some objects and morphisms.
     A = Object("A")
     B = Object("B")
     C = Object("C")
     D = Object("D")
+    E = Object("E")
+
     f = NamedMorphism(A, B, "f")
     g = NamedMorphism(B, C, "g")
     h = NamedMorphism(D, A, "h")
     k = NamedMorphism(D, B, "k")
-    d = Diagram([f, g, h, k])
 
+    # A triangle.
+    d = Diagram([f, g], {g * f:"unique"})
     grid = DiagramGrid(d)
+
+    assert grid.width == 2
+    assert grid.height == 2
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[1, 0] == C
+    assert grid[1, 1] is None
+
+    # A simple diagram.
+    d = Diagram([f, g, h, k])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 3
+    assert grid.height == 2
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == D
+    assert grid[1, 0] is None
+    assert grid[1, 1] == C
+    assert grid[1, 2] is None
+
+    # A chain of morphisms.
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    h = NamedMorphism(C, D, "h")
+    k = NamedMorphism(D, E, "k")
+    d = Diagram([f, g, h, k])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 3
+    assert grid.height == 3
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] is None
+    assert grid[1, 0] is None
+    assert grid[1, 1] == C
+    assert grid[1, 2] == D
+    assert grid[2, 0] is None
+    assert grid[2, 1] is None
+    assert grid[2, 2] == E
+
+    # A square.
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, D, "g")
+    h = NamedMorphism(A, C, "h")
+    k = NamedMorphism(C, D, "k")
+    d = Diagram([f, g, h, k])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 2
+    assert grid.height == 2
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[1, 0] == C
+    assert grid[1, 1] == D

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -81,6 +81,15 @@ def test_DiagramGrid():
     h = NamedMorphism(D, A, "h")
     k = NamedMorphism(D, B, "k")
 
+    # A one-morphism diagram.
+    d = Diagram([f])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 2
+    assert grid.height == 1
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+
     # A triangle.
     d = Diagram([f, g], {g * f:"unique"})
     grid = DiagramGrid(d)

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -1,4 +1,5 @@
 from sympy.categories.diagram_drawing import _GrowableGrid
+from sympy.categories import DiagramGrid, Object, NamedMorphism, Diagram
 
 def test_GrowableGrid():
     grid = _GrowableGrid(1, 2)
@@ -66,3 +67,16 @@ def test_GrowableGrid():
     assert grid[0, 1] == None
     assert grid[1, 1] == 1
     assert grid[2, 1] == "two"
+
+def test_DiagramGrid():
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    D = Object("D")
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    h = NamedMorphism(D, A, "h")
+    k = NamedMorphism(D, B, "k")
+    d = Diagram([f, g, h, k])
+
+    grid = DiagramGrid(d)

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -188,3 +188,49 @@ def test_DiagramGrid():
     assert grid[3, 0] is None
     assert grid[3, 1] == D_
     assert grid[3, 2] == E_
+
+    # A cube.
+    A1 = Object("A1")
+    A2 = Object("A2")
+    A3 = Object("A3")
+    A4 = Object("A4")
+    A5 = Object("A5")
+    A6 = Object("A6")
+    A7 = Object("A7")
+    A8 = Object("A8")
+
+    # The top face of the cube.
+    f1 = NamedMorphism(A1, A2, "f1")
+    f2 = NamedMorphism(A1, A3, "f2")
+    f3 = NamedMorphism(A2, A4, "f3")
+    f4 = NamedMorphism(A3, A4, "f3")
+
+    # The bottom face of the cube.
+    f5 = NamedMorphism(A5, A6, "f5")
+    f6 = NamedMorphism(A5, A7, "f6")
+    f7 = NamedMorphism(A6, A8, "f7")
+    f8 = NamedMorphism(A7, A8, "f8")
+
+    # The remaining morphisms.
+    f9 = NamedMorphism(A1, A5, "f9")
+    f10 = NamedMorphism(A2, A6, "f10")
+    f11 = NamedMorphism(A3, A7, "f11")
+    f12 = NamedMorphism(A4, A8, "f11")
+
+    d = Diagram([f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 4
+    assert grid.height == 3
+    assert grid[0, 0] is None
+    assert grid[0, 1] == A5
+    assert grid[0, 2] == A6
+    assert grid[0, 3] is None
+    assert grid[1, 0] is None
+    assert grid[1, 1] == A1
+    assert grid[1, 2] == A2
+    assert grid[1, 3] is None
+    assert grid[2, 0] == A7
+    assert grid[2, 1] == A3
+    assert grid[2, 2] == A4
+    assert grid[2, 3] == A8

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -342,3 +342,25 @@ def test_DiagramGrid():
     assert grid[2, 3] is None
     assert grid[2, 4] is None
     assert grid[2, 5] == E
+
+    # A line diagram.
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    D = Object("D")
+    E = Object("E")
+
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    h = NamedMorphism(C, D, "h")
+    i = NamedMorphism(D, E, "i")
+    d = Diagram([f, g, h, i])
+    grid = DiagramGrid(d, shape="sequential")
+
+    assert grid.width == 5
+    assert grid.height == 1
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == C
+    assert grid[0, 3] == D
+    assert grid[0, 4] == E

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -503,3 +503,22 @@ def test_DiagramGrid():
     assert grid[0, 2] == C
     assert grid[0, 3] == D
     assert grid.morphisms == {f: FiniteSet(), g: FiniteSet()}
+
+    # Test a one-object diagram.
+    f = NamedMorphism(A, A, "f")
+    d = Diagram([f])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 1
+    assert grid.height == 1
+    assert grid[0, 0] == A
+
+    # Test a two-object disconnected diagram.
+    g = NamedMorphism(B, B, "g")
+    d = Diagram([f, g])
+    grid = DiagramGrid(d)
+
+    assert grid.width == 2
+    assert grid.height == 1
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -290,6 +290,15 @@ def test_DiagramGrid():
     d = Diagram([m1, m2, s1, s2, f1, f2], {g: "unique"})
     grid = DiagramGrid(d)
 
+    assert grid.width == 3
+    assert grid.height == 2
+    assert grid[0, 0] == A
+    assert grid[0, 1] == B
+    assert grid[0, 2] == E
+    assert grid[1, 0] == C
+    assert grid[1, 1] == D
+    assert grid[1, 2] is None
+
     # Test the pullback with sequential layout, just for stress
     # testing.
     grid = DiagramGrid(d, layout="sequential")

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -133,6 +133,9 @@ def test_DiagramGrid():
     assert grid.morphisms == {f:FiniteSet(), g:FiniteSet(), h:FiniteSet(),
                               k:FiniteSet()}
 
+    assert str(grid) == '[[Object("A"), Object("B"), Object("D")], ' \
+           '[None, Object("C"), None]]'
+
     # A chain of morphisms.
     f = NamedMorphism(A, B, "f")
     g = NamedMorphism(B, C, "g")

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -364,3 +364,14 @@ def test_DiagramGrid():
     assert grid[0, 2] == C
     assert grid[0, 3] == D
     assert grid[0, 4] == E
+
+    # Test the transposed version.
+    grid = DiagramGrid(d, shape="sequential", transpose=True)
+
+    assert grid.width == 1
+    assert grid.height == 5
+    assert grid[0, 0] == A
+    assert grid[1, 0] == B
+    assert grid[2, 0] == C
+    assert grid[3, 0] == D
+    assert grid[4, 0] == E

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -1,5 +1,6 @@
 from sympy.categories.diagram_drawing import _GrowableGrid
 from sympy.categories import DiagramGrid, Object, NamedMorphism, Diagram
+from sympy import FiniteSet
 
 def test_GrowableGrid():
     grid = _GrowableGrid(1, 2)
@@ -255,3 +256,15 @@ def test_DiagramGrid():
 
     d = Diagram([m1, m2, s1, s2, f1, f2], {g: "unique"})
     grid = DiagramGrid(d)
+
+    # Test a pullback with object grouping.
+    grid = DiagramGrid(d, groups=FiniteSet(E, FiniteSet(A, B, C, D)))
+
+    assert grid.width == 3
+    assert grid.height == 2
+    assert grid[0, 0] == E
+    assert grid[0, 1] == A
+    assert grid[0, 2] == B
+    assert grid[1, 0] is None
+    assert grid[1, 1] == C
+    assert grid[1, 2] == D

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1238,6 +1238,24 @@ class LatexPrinter(Printer):
 
         return latex_result
 
+    def _print_DiagramGrid(self, grid):
+        latex_result = "\\begin{array}{%s}\n" % ("c" * grid.width)
+
+        for i in xrange(grid.height):
+            for j in xrange(grid.width):
+                if grid[i, j]:
+                    latex_result += latex(grid[i, j])
+                latex_result += " "
+                if j != grid.width - 1:
+                    latex_result += "& "
+
+            if i != grid.height - 1:
+                latex_result += "\\\\"
+            latex_result += "\n"
+
+        latex_result += "\\end{array}\n"
+        return latex_result
+
     def _print_FreeModule(self, M):
         return '{%s}^{%s}' % (self._print(M.ring), self._print(M.rank))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1515,6 +1515,14 @@ class PrettyPrinter(Printer):
 
         return prettyForm(pretty_result[0])
 
+    def _print_DiagramGrid(self, grid):
+        from sympy.matrices import Matrix
+        from sympy import Symbol
+        matrix = Matrix([[grid[i, j] if grid[i, j] else Symbol(" ")
+                          for j in xrange(grid.width)]
+                         for i in xrange(grid.height)])
+        return self._print_matrix_contents(matrix)
+
     def _print_FreeModuleElement(self, m):
         # Print as row vector for convenience, for now.
         return self._print_seq(m, '[', ']')

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -527,7 +527,10 @@ class PrettyPrinter(Printer):
 
         return Lim
 
-    def _print_MatrixBase(self, e):
+    def _print_matrix_contents(self, e):
+        """
+        This method factors out what is essentially grid printing.
+        """
         M = e   # matrix
         Ms = {}  # i,j -> pretty(M[i,j])
         for i in range(M.rows):
@@ -592,6 +595,10 @@ class PrettyPrinter(Printer):
         if D is None:
             D = prettyForm('') # Empty Matrix
 
+        return D
+
+    def _print_MatrixBase(self, e):
+        D = self._print_matrix_contents(e)
         D = prettyForm(*D.parens('[',']'))
         return D
     _print_ImmutableMatrix = _print_MatrixBase

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3700,7 +3700,7 @@ def test_complicated_symbol_unchanged():
 def test_categories():
     from sympy.categories import (Object, Morphism, IdentityMorphism,
                                   NamedMorphism, CompositeMorphism,
-                                  Category, Diagram)
+                                  Category, Diagram, DiagramGrid)
 
     A1 = Object("A1")
     A2 = Object("A2")
@@ -3747,6 +3747,10 @@ def test_categories():
     assert upretty(d) == u"{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
            u"∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \
            u" ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}"
+
+    grid = DiagramGrid(d)
+    assert pretty(grid) == "A1  A2\n      \nA3    "
+    assert upretty(grid) == u"A\u2081  A\u2082\n      \nA\u2083    "
 
 def test_PrettyModules():
     R = QQ[x, y]

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -577,7 +577,7 @@ def test_PolynomialRing():
 def test_categories():
     from sympy.categories import (Object, Morphism, IdentityMorphism,
                                   NamedMorphism, CompositeMorphism,
-                                  Category, Diagram)
+                                  Category, Diagram, DiagramGrid)
 
     A1 = Object("A1")
     A2 = Object("A2")
@@ -616,6 +616,21 @@ def test_categories():
            " & f_{2}:A_{2}\\rightarrow A_{3} : \\emptyset\\end{Bmatrix}" \
            "\\Longrightarrow \\begin{Bmatrix}f_{2}\\circ f_{1}:A_{1}" \
            "\\rightarrow A_{3} : \\left\\{unique\\right\\}\\end{Bmatrix}"
+
+
+    # A linear diagram.
+    A = Object("A")
+    B = Object("B")
+    C = Object("C")
+    f = NamedMorphism(A, B, "f")
+    g = NamedMorphism(B, C, "g")
+    d = Diagram([f, g])
+    grid = DiagramGrid(d)
+
+    assert latex(grid) == "\\begin{array}{cc}\n" \
+    "A & B \\\\\n"\
+    " & C \n" \
+    "\\end{array}\n"
 
 def test_Modules():
     from sympy.polys.domains import QQ


### PR DESCRIPTION
This pull request adds the code which lays out the objects of a diagram, depending how they are connected with morphisms and some other parameters.

Some tests for this pull request still fail half of the time, because of the issue with `FiniteSet` sort keys.  I do submit this pull request though so that people can start reviewing it, while I'll be fixing the `FiniteSet` issue in parallel.
