### PR TITLE
Silence internationalization warnings

### DIFF
--- a/doc/src/tutorial.de.rst
+++ b/doc/src/tutorial.de.rst
@@ -1,4 +1,4 @@
-.. _tutorial:
+.. _tutorial_de:
 
 ========
 Tutorial
@@ -256,7 +256,7 @@ wurde::
     >>> init_printing(use_unicode=False, wrap_line=False, no_global=True)
 
 Dies sorgt dafür, dass Ausdrücke bei der Ausgabe besser aussehen (siehe
-:ref:`printing-tutorial` weiter unten). Wenn eine Unicode-Schrift installiert
+:ref:`printing-tutorial_de` weiter unten). Wenn eine Unicode-Schrift installiert
 ist, erreichst du mit use_unicode=True eine noch hübschere Ausgabe.
 
 Algebra
@@ -753,7 +753,7 @@ ausschließen:
     >>> print (x+1).match(x+2+p) # -1 ist nicht ausgeschlossen
     {p_: -1}
 
-.. _printing-tutorial:
+.. _printing-tutorial_de:
 
 Ausgabe
 =======

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -972,4 +972,4 @@ This tutorial is also available in other languages:
 .. toctree::
    :maxdepth: 1
 
-   tutorial.ru.rst
+   tutorial.de.rst


### PR DESCRIPTION
This doesn't necessarily fix the problems with internationalization, but it does silence the warnings that come up in the normal doc building and it doesn't make the i18n docs any worse (previously, none of the translations would show up at the bottom of the page, tho it tried to reference the Russian docs).
