### PR TITLE
Dict: Add iteritems.

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -204,3 +204,7 @@ class Dict(Basic):
 
     def __lt__(self, other):
         return self.args < other.args
+
+    def iteritems(self):
+        '''D.iteritems() -> generator of D's (key, value) pairs, as 2-tuples'''
+        return self._dict.iteritems()

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -112,6 +112,8 @@ def test_Dict():
     assert str(d) == '{x: 1, y: 2, z: 3}'
     assert d.__repr__() == '{x: 1, y: 2, z: 3}'
 
+    assert set(d.items()) == set(d.iteritems())
+
 def issue_2689():
     args = [(1,2),(2,1)]
     for o in [Dict, Tuple, FiniteSet]:


### PR DESCRIPTION
This method just invokes iteritems on the underlying dictionary.  Having `iteritems` is useful for efficiency reasons.
