### PR TITLE
Fix long arrows in Unicode pretty printing.

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1457,9 +1457,7 @@ class PrettyPrinter(Printer):
         return self._print(pretty_symbol(object.name))
 
     def _print_Morphism(self, morphism):
-        arrow = "-->"
-        if self._use_unicode:
-            arrow = u"\u2014\u2014\u25b6"
+        arrow = xsym("-->")
 
         domain = self._print(morphism.domain)
         codomain = self._print(morphism.codomain)
@@ -1480,9 +1478,7 @@ class PrettyPrinter(Printer):
     def _print_CompositeMorphism(self, morphism):
         from sympy.categories import NamedMorphism
 
-        circle = "*"
-        if self._use_unicode:
-            circle = u"\u2218"
+        circle = xsym(".")
 
         # All components of the morphism have names and it is thus
         # possible to build the name of the composite.
@@ -1505,9 +1501,7 @@ class PrettyPrinter(Printer):
 
         pretty_result = self._print(diagram.premises)
         if diagram.conclusions:
-            results_arrow = " ==> "
-            if self._use_unicode:
-                results_arrow = u" \u2550\u2550\u25b6 "
+            results_arrow = " %s " % xsym("==>")
 
             pretty_conclusions = self._print(diagram.conclusions)[0]
             pretty_result = pretty_result.right(results_arrow, pretty_conclusions)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1459,7 +1459,7 @@ class PrettyPrinter(Printer):
     def _print_Morphism(self, morphism):
         arrow = "-->"
         if self._use_unicode:
-            arrow = u"\u27f6  "
+            arrow = u"\u2014\u2014\u25b6"
 
         domain = self._print(morphism.domain)
         codomain = self._print(morphism.codomain)
@@ -1507,7 +1507,7 @@ class PrettyPrinter(Printer):
         if diagram.conclusions:
             results_arrow = " ==> "
             if self._use_unicode:
-                results_arrow = u" \u27f9  "
+                results_arrow = u" \u2550\u2550\u25b6 "
 
             pretty_conclusions = self._print(diagram.conclusions)[0]
             pretty_result = pretty_result.right(results_arrow, pretty_conclusions)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -378,6 +378,12 @@ _xsym = {
     '>='    : ('>=',    U('GREATER-THAN OR EQUAL TO')),
     '!='    : ('!=',    U('NOT EQUAL TO')),
     '*'     : ('*',     U('DOT OPERATOR')),
+    '-->'   : ('-->',   U('EM DASH') + U('EM DASH') +
+               U('BLACK RIGHT-POINTING TRIANGLE')),
+    '==>'   : ('==>',   U('BOX DRAWINGS DOUBLE HORIZONTAL') +
+               U('BOX DRAWINGS DOUBLE HORIZONTAL') +
+               U('BLACK RIGHT-POINTING TRIANGLE')),
+    '.'     : ('*',     U('RING OPERATOR')),
 }
 
 

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3716,12 +3716,12 @@ def test_categories():
     assert upretty(A1) == u"A₁"
 
     assert pretty(f1) == "f1:A1-->A2"
-    assert upretty(f1) == u"f₁:A₁⟶  A₂"
+    assert upretty(f1) == u"f₁:A₁——▶A₂"
     assert pretty(id_A1) == "id:A1-->A1"
-    assert upretty(id_A1) == u"id:A₁⟶  A₁"
+    assert upretty(id_A1) == u"id:A₁——▶A₁"
 
     assert pretty(f2*f1) == "f2*f1:A1-->A3"
-    assert upretty(f2*f1) == u"f₂∘f₁:A₁⟶  A₃"
+    assert upretty(f2*f1) == u"f₂∘f₁:A₁——▶A₃"
 
     assert pretty(K1) == "K1"
     assert upretty(K1) == u"K₁"
@@ -3736,17 +3736,17 @@ def test_categories():
            "EmptySet(), id:A2-->A2: EmptySet(), id:A3-->A3: " \
            "EmptySet(), f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet()}"
 
-    assert upretty(d) == u"{f₂∘f₁:A₁⟶  A₃: ∅, id:A₁⟶  A₁: ∅, " \
-           u"id:A₂⟶  A₂: ∅, id:A₃⟶  A₃: ∅, f₁:A₁⟶  A₂: {unique}, f₂:A₂⟶  A₃: ∅}"
+    assert upretty(d) == u"{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, " \
+           u"id:A₂——▶A₂: ∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}"
 
     d = Diagram({f1:"unique", f2:S.EmptySet}, {f2 * f1: "unique"})
     assert pretty(d) == "{f2*f1:A1-->A3: EmptySet(), id:A1-->A1: " \
            "EmptySet(), id:A2-->A2: EmptySet(), id:A3-->A3: " \
            "EmptySet(), f1:A1-->A2: {unique}, f2:A2-->A3: EmptySet()}" \
            " ==> {f2*f1:A1-->A3: {unique}}"
-    assert upretty(d) == u"{f₂∘f₁:A₁⟶  A₃: ∅, id:A₁⟶  A₁: ∅, id:A₂⟶  A₂: " \
-           u"∅, id:A₃⟶  A₃: ∅, f₁:A₁⟶  A₂: {unique}, f₂:A₂⟶  A₃: ∅}" \
-           u" ⟹  {f₂∘f₁:A₁⟶  A₃: {unique}}"
+    assert upretty(d) == u"{f₂∘f₁:A₁——▶A₃: ∅, id:A₁——▶A₁: ∅, id:A₂——▶A₂: " \
+           u"∅, id:A₃——▶A₃: ∅, f₁:A₁——▶A₂: {unique}, f₂:A₂——▶A₃: ∅}" \
+           u" ══▶ {f₂∘f₁:A₁——▶A₃: {unique}}"
 
 def test_PrettyModules():
     R = QQ[x, y]


### PR DESCRIPTION
Previously those classes were pretty printed using long Unicode symbols,
which worked erratically on different terminals.  This commit uses more
standard characters.

Things are now printed like this:

```
{g∘f:A₁——▶C₁: ∅, id:A₁——▶A₁: ∅, id:B——▶B: ∅, id:C₁——▶C₁: ∅, f:A₁——▶B: ∅, g:B——▶C₁: ∅} 
══▶ {g∘f:A₁——▶C₁: {unique}}

```

Thanks to @asmeurer for the suggestion!
