### PR TITLE
Add sorted_args and fix the sort keys for some unordered collections.

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -320,7 +320,7 @@ class Basic(object):
         # XXX: remove this when issue #2070 is fixed
         def inner_key(arg):
             if isinstance(arg, Basic):
-                return arg.sort_key()
+                return arg.sort_key(order)
             else:
                 return arg
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -324,7 +324,8 @@ class Basic(object):
             else:
                 return arg
 
-        args = len(self.args), tuple([ inner_key(arg) for arg in self.args ])
+        args = self._sorted_args
+        args = len(args), tuple([ inner_key(arg) for arg in args ])
         return self.class_key(), args, S.One.sort_key(), S.One
 
     def __eq__(self, other):
@@ -630,6 +631,15 @@ class Basic(object):
         change the interface in the future if needed).
         """
         return self._args
+
+    @property
+    def _sorted_args(self):
+        """
+        The same as ``args``.  Derived classes which don't fix an
+        order on their arguments should override this method to
+        produce the sorted representation.
+        """
+        return self.args
 
     def iter_basic_args(self):
         """

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -204,3 +204,8 @@ class Dict(Basic):
 
     def __lt__(self, other):
         return self.args < other.args
+
+    @property
+    def _sorted_args(self):
+        from sympy.utilities import default_sort_key
+        return sorted(self.args, key=default_sort_key)

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1265,3 +1265,8 @@ class FiniteSet(Set, EvalfMixin):
 
     def _hashable_content(self):
         return (self._elements,)
+
+    @property
+    def _sorted_args(self):
+        from sympy.utilities import default_sort_key
+        return sorted(self.args, key=default_sort_key)

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -667,9 +667,8 @@ class Interval(Set, EvalfMixin):
 
 def set_sort_fn(s):
     """
-    Sort by infimum if possible
-
-    Otherwise sort by hash. Try to put these at the end.
+    Sort by infimum if possible.  Otherwise sort by
+    ``default_sort_key``.
     """
     try:
         val = s.inf

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1219,7 +1219,7 @@ class FiniteSet(Set, EvalfMixin):
             raise ValueError("%s: Complement not defined for symbolic inputs"
                     %self)
 
-        args = sorted(self.args, key=default_sort_key)
+        args = sorted(self.args)
 
         intervals = [] # Build up a list of intervals between the elements
         intervals += [Interval(S.NegativeInfinity, args[0], True, True)]

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -124,3 +124,6 @@ def test_preorder_traversal():
     expr = z + w*(x+y)
     assert list(preorder_traversal([expr], key=default_sort_key)) == \
         [[w*(x + y) + z], w*(x + y) + z, z, w*(x + y), w, x + y, x, y]
+
+def test_sorted_args():
+    assert b21._sorted_args == b21.args


### PR DESCRIPTION
This pull request adds `sorted_args` to `Basic`, attempts to make all the code which needs sorted `args` use this new property.  Furthermore, this pull request makes `FiniteSet` and `Dict` produce hash-independent sort keys.
