### PR TITLE
Removed unnecessary check: geometric multiplicity is always nonzero.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3397,8 +3397,6 @@ class MatrixBase(object):
             if geometrical == multiplicity:
                 Jcell = diag( *([eigenval] * multiplicity))
                 Jcells.append(Jcell)
-            elif geometrical==0:
-                raise MatrixError("Matrix has the eigen vector with geometrical multiplicity equal zero.")
             else:
                 sizes = self._jordan_split(multiplicity, geometrical)
                 cells = []


### PR DESCRIPTION
The geometric multiplicity of an eigenvalue is always positive,
hence a check for it being 0 was removed. This line of code
was not covered by any tests (not surprisingly).
