### PR TITLE
Handle the --no-colors option only in the write() function

### DIFF
--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -164,7 +164,7 @@ def test_entropy():
     assert entropy(d) == 0.5*log(2)
     assert d.entropy() == 0.5*log(2)
 
-    np = import_module('numpy', min_python_version=(2, 6))
+    np = import_module('numpy', min_python_version=(2, 6), min_module_version='1.4.0')
     if np:
         #do this test only if 'numpy' is available on test machine
         np_mat = represent(d, format='numpy')

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1444,8 +1444,10 @@ class PyTestReporter(Reporter):
             # the terminal control sequences would be printed verbatim, so
             # don't use any colors.
             color = ""
-        if sys.platform == "win32":
+        elif sys.platform == "win32":
             # Windows consoles don't support ANSI escape sequences
+            color = ""
+        elif not self._colors:
             color = ""
 
         if self._line_wrap:
@@ -1595,12 +1597,11 @@ class PyTestReporter(Reporter):
         self.write("[%d] " % n)
 
     def leaving_filename(self):
-        if self._colors:
-            self.write(" ")
-            if self._active_file_error:
-                self.write("[FAIL]", "Red", align="right")
-            else:
-                self.write("[OK]", "Green", align="right")
+        self.write(" ")
+        if self._active_file_error:
+            self.write("[FAIL]", "Red", align="right")
+        else:
+            self.write("[OK]", "Green", align="right")
         self.write("\n")
         if self._verbose:
             self.write("\n")
@@ -1666,9 +1667,8 @@ class PyTestReporter(Reporter):
         rel_name = filename[len(self._root_dir)+1:]
         self.write(rel_name)
         self.write("[?]   Failed to import", "Red")
-        if self._colors:
-            self.write(" ")
-            self.write("[FAIL]", "Red", align="right")
+        self.write(" ")
+        self.write("[FAIL]", "Red", align="right")
         self.write("\n")
 
 sympy_dir = get_sympy_dir()


### PR DESCRIPTION
This fixes the problem where [OK] was not being printed with --no-colors and
many colored text was (see also issue 3349).
