### PR TITLE
Set: Fix the sort_key.

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -34,7 +34,7 @@ class Set(Basic):
     is_EmptySet = None
     is_UniversalSet = None
 
-    def sort_key(self, order):
+    def sort_key(self, order=None):
         """
         Give sort_key of infimum (if possible) else sort_key of the set.
         """
@@ -44,7 +44,7 @@ class Set(Basic):
                 return default_sort_key(infimum)
         except (NotImplementedError, ValueError):
             pass
-        args = tuple([default_sort_key(a) for a in self.args])
+        args = tuple([default_sort_key(a) for a in self._sorted_args])
         return self.class_key(), (len(args), args), S.One.class_key(), S.One
 
     def union(self, other):


### PR DESCRIPTION
Unfortunately, I haven't been sufficiently diligent to thoroughly check the recent `sort_key`-related modification, so two slight issues with `Set.sort_key` have slipped into `master`, sorry.

I hope the changes here are pretty straightforward and we will be able to merge them soon.
