### PR TITLE
SymPy Live Sphinx extension

### DIFF
--- a/doc/ext/sympylive.py
+++ b/doc/ext/sympylive.py
@@ -32,5 +32,5 @@ def builder_inited(app):
 
 
 def setup(app):
-    app.add_config_value('sympylive_url', 'http://localhost:8080', False)
+    app.add_config_value('sympylive_url', 'http://live.sympy.org', False)
     app.connect('builder-inited', builder_inited)

--- a/doc/ext/sympylive.py
+++ b/doc/ext/sympylive.py
@@ -1,0 +1,36 @@
+"""
+    sympylive
+    ~~~~~~~~~
+
+    Allow `SymPy Live <http://live.sympy.org/>`_ to be used for interactive
+    evaluation of SymPy's code examples.
+
+    :copyright: Copyright 2011 by the SymPy Development Team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+
+def builder_inited(app):
+    if not app.config.sympylive_url:
+        raise ExtensionError('sympylive_url config value must be set'
+                             ' for the sympylive extension to work')
+
+    app.add_javascript(app.config.sympylive_url + '/static/utilities.js')
+    app.add_javascript(app.config.sympylive_url + '/static/external/classy.js')
+    app.add_javascript(
+        'http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js')
+
+    app.add_stylesheet(app.config.sympylive_url + '/static/live-core.css')
+    app.add_stylesheet(app.config.sympylive_url +
+                       '/static/live-autocomplete.css')
+    app.add_stylesheet(app.config.sympylive_url + '/static/live-sphinx.css')
+
+    app.add_javascript(app.config.sympylive_url + '/static/live-core.js')
+    app.add_javascript(app.config.sympylive_url +
+                       '/static/live-autocomplete.js')
+    app.add_javascript(app.config.sympylive_url + '/static/live-sphinx.js')
+
+
+def setup(app):
+    app.add_config_value('sympylive_url', 'http://localhost:8080', False)
+    app.connect('builder-inited', builder_inited)

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -22,7 +22,7 @@ sys.path.extend(['../sympy', 'ext'])
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.addons.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.mathjax',
-              'numpydoc',]
+              'numpydoc', 'sympylive',]
 
 # Use this to use pngmath instead
 #extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.pngmath', ]


### PR DESCRIPTION
- Adds a "Show/Hide SymPy Live Shell" button to the bottom-right corner of the docs.
  - Clicking it shows a shell that takes up about 600x500px of space.
  - The "Fullscreen" button normally in SymPy Live now redirects to SymPy Live.
  - Settings are in a dropdown under the shell.
- Hovering over Python code blocks reveals a "run code in SymPy Live" link in the top-right corner.

This code requires SymPy Live to be updated first. It is based somewhat off of the implementation at https://github.com/mattpap/scipy-2011-tutorial which does not work anymore due to changes in SymPy Live.

Fixes [Google Code issue #2871](http://code.google.com/p/sympy/issues/detail?id=2871)

To test locally,
# . Set `sympylive_url` in doc/ext/sympylive.py to `http://localhost:8080` Alternatively, you can use `http://59.sympy-live-tests.appspot.com/`
# . Get the Google App Engine SDK and extract it.
# . Check out [sympy-live:59](https://github.com/sympy/sympy-live/pull/59) into a subdirectory of the SDK.
# . Run `./dev_appserver.py sympy-live/`
# . Build the docs. The extension should add all the necessary files.
