### PR TITLE
ImmutableMatrix defaults to MatrixBase operators

### DIFF
--- a/sympy/matrices/immutable_matrix.py
+++ b/sympy/matrices/immutable_matrix.py
@@ -39,3 +39,14 @@ class ImmutableMatrix(MatrixExpr, MatrixBase):
     equals = MatrixBase.equals
     is_Identity = MatrixBase.is_Identity
     _eval_transpose = MatrixBase._eval_transpose
+
+    __add__ = MatrixBase.__add__
+    __radd__ = MatrixBase.__radd__
+    __mul__ = MatrixBase.__mul__
+    __rmul__ = MatrixBase.__rmul__
+    __pow__ = MatrixBase.__pow__
+    __sub__ = MatrixBase.__sub__
+    __rsub__ = MatrixBase.__rsub__
+    __neg__ = MatrixBase.__neg__
+    __div__ = MatrixBase.__div__
+    __truediv__ = MatrixBase.__truediv__

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -426,7 +426,7 @@ class MatrixBase(object):
                     break
                 s *= s
                 n //= 2
-            return a
+            return self._new(a)
         elif isinstance(num, Rational):
             try:
                 P, D = self.diagonalize()
@@ -434,7 +434,7 @@ class MatrixBase(object):
                 raise NotImplementedError("Implemented only for diagonalizable matrices")
             for i in range(D.rows):
                 D[i, i] = D[i, i]**num
-            return P * D * P.inv()
+            return self._new(P * D * P.inv())
         else:
             raise NotImplementedError("Only integer and rational values are supported")
 

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -66,3 +66,15 @@ def test_function_return_types():
     assert type(X.T.upper_triangular_solve(Y)) == ImmutableMatrix
 
     assert type(X.minorMatrix(0,0)) == ImmutableMatrix
+
+# Issue 3180
+# http://code.google.com/p/sympy/issues/detail?id=3180
+# Test that Immutable _op_ Immutable => Immutable and not MatExpr
+def test_immutable_evaluation():
+    X = ImmutableMatrix(eye(3))
+    A = ImmutableMatrix(3,3, range(9))
+    assert isinstance(X + A, ImmutableMatrix)
+    assert isinstance(X * A, ImmutableMatrix)
+    assert isinstance(X * 2, ImmutableMatrix)
+    assert isinstance(2 * X, ImmutableMatrix)
+    assert isinstance(A**2,  ImmutableMatrix)


### PR DESCRIPTION
I.e.

`ImmutableMatrix.__add__ = MatrixBase.__add__`
instead of
`ImmutableMatrix.__add__ = MatExpr.__add__`

This causes `ImmutableMatrix * ImmutableMatrix => ImmutableMatrix``
instead of``ImmutableMatrix * ImmutableMatrix => MatExpr``

I.e. ImmutableMatrices evaluate by default.
