### PR TITLE
Different predicates should not have identical sort keys.

### DIFF
--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -1,6 +1,8 @@
 import inspect
-from sympy.utilities.source import get_class
+from sympy.core.cache import cacheit
+from sympy.core.singleton import S
 from sympy.logic.boolalg import Boolean
+from sympy.utilities.source import get_class
 
 class AssumptionsContext(set):
     """Set representing assumptions.
@@ -76,6 +78,10 @@ class AppliedPredicate(Boolean):
     def func(self):
         return self._args[0]
 
+    @cacheit
+    def sort_key(self, order=None):
+        return self.class_key(), (2, (self.func.name, self.arg.sort_key())), S.One.sort_key(), S.One
+
     def __eq__(self, other):
         if type(other) is AppliedPredicate:
             return self._args == other._args
@@ -134,6 +140,10 @@ class Predicate(Boolean):
 
     def remove_handler(self, handler):
         self.handlers.remove(handler)
+
+    @cacheit
+    def sort_key(self, order=None):
+        return self.class_key(), (1, (self.name,)), S.One.sort_key(), S.One
 
     def eval(self, expr, assumptions=True):
         """

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -14,6 +14,7 @@ def test_equal():
 
 def test_pretty():
     assert pretty(Q.positive(x)) == "Q.positive(x)"
+    assert pretty(set([Q.positive, Q.integer])) == "set([Q.integer, Q.positive])"
 
 def test_extract_facts():
     a, b = symbols('a b', cls=Predicate)


### PR DESCRIPTION
Before this commit:

```
>>> Q.bounded.sort_key()
((5, 0, 'Predicate'), (0, ()), ((1, 0, 'Number'), (0, ()), (), 1), 1)
>>> Q.bounded.sort_key() == Q.commutative.sort_key()
True
```

After this commit:

```
>>> Q.bounded.sort_key()
((5, 0, 'Predicate'), (1, ('bounded',)), ((1, 0, 'Number'), (0, ()), (), 1), 1)
>>> Q.bounded.sort_key() == Q.commutative.sort_key()
False
```
