### PR TITLE
[WIP] Fix the DiagramGrid import failure in categories.rst.

### DIFF
--- a/doc/src/modules/categories.rst
+++ b/doc/src/modules/categories.rst
@@ -53,6 +53,8 @@ diagrams.
 Diagram Drawing
 ---------------
 
+.. module:: sympy.categories.diagram_drawing
+
 This section lists the classes which allow automatic drawing of
 diagrams.
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/sympy/sympy/pull/1429#issuecomment-7570113 .

I can't reproduce it on my computer, so this pull request does not contain the actual solution as of yet.
