### PR TITLE
Dict: Support creation from another Dict.

### DIFF
--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -151,7 +151,8 @@ class Dict(Basic):
     """
 
     def __new__(cls, *args):
-        if len(args)==1 and args[0].__class__ is dict:
+        if len(args)==1 and ((args[0].__class__ is dict) or
+                             (args[0].__class__ is Dict)):
             items = [Tuple(k, v) for k, v in args[0].items()]
         elif iterable(args) and all(len(arg) == 2 for arg in args):
             items = [Tuple(k, v) for k, v in args]

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -112,6 +112,10 @@ def test_Dict():
     assert str(d) == '{x: 1, y: 2, z: 3}'
     assert d.__repr__() == '{x: 1, y: 2, z: 3}'
 
+    # Test creating a Dict from a Dict.
+    d = Dict({x: 1, y: 2, z: 3})
+    assert d == Dict(d)
+
 def issue_2689():
     args = [(1,2),(2,1)]
     for o in [Dict, Tuple, FiniteSet]:


### PR DESCRIPTION
Previously `Dict` would complain whenever a `Dict` was supplied to the constructor, while it was quite OK with creating itself from a native Python dict.  This commit makes it possible to do things like Dict(Dict{1: 2}).

This is a trivial change and we can do fine without it.  Yet, the nonuniform treatment of native `dict`'s and SymPy's `Dict`'s may sometimes result in not-so-elegant code (my case right now).
