### PR TITLE
Changed Kane class interface in physics.mechanics

### DIFF
--- a/doc/src/modules/physics/mechanics/api/essential.rst
+++ b/doc/src/modules/physics/mechanics/api/essential.rst
@@ -6,15 +6,18 @@ ReferenceFrame
 ==============
 
 .. autoclass:: sympy.physics.mechanics.essential.ReferenceFrame
+   :members:
 
 
 Vector
 ======
 
 .. autoclass:: sympy.physics.mechanics.essential.Vector
+   :members:
 
 
 Dyadic
 ======
 
 .. autoclass:: sympy.physics.mechanics.essential.Dyadic
+   :members:

--- a/doc/src/modules/physics/mechanics/api/kane.rst
+++ b/doc/src/modules/physics/mechanics/api/kane.rst
@@ -2,8 +2,8 @@
 Kane's Method & Associated Functions (Docstrings)
 =================================================
 
-Kane
-====
+KanesMethod
+===========
 
 .. automodule:: sympy.physics.mechanics.kane
    :members:

--- a/doc/src/modules/physics/mechanics/api/kane.rst
+++ b/doc/src/modules/physics/mechanics/api/kane.rst
@@ -5,9 +5,8 @@ Kane's Method & Associated Functions (Docstrings)
 KanesMethod
 ===========
 
-.. automodule:: sympy.physics.mechanics.kane
+.. autoclass:: sympy.physics.mechanics.KanesMethod
    :members:
-
 
 partial_velocity
 ================

--- a/doc/src/modules/physics/mechanics/examples.rst
+++ b/doc/src/modules/physics/mechanics/examples.rst
@@ -80,15 +80,12 @@ we form the body list. ::
   >>> BodyList = [BodyD]
 
 Finally we form the equations of motion, using the same steps we did before.
-Specify inertial frame, supply generalized speeds, supply kinematic
-differential equation dictionary, compute Fr from the force list and Fr* from
-the body list, compute the mass matrix and forcing terms, then solve for the u
-dots (time derivatives of the generalized speeds). ::
+Specify inertial frame, supply generalized coordinates and speeds, supply
+kinematic differential equation dictionary, compute Fr from the force list and
+Fr* from the body list, compute the mass matrix and forcing terms, then solve
+for the u dots (time derivatives of the generalized speeds). ::
 
-  >>> KM = Kane(N)
-  >>> KM.coords([q1, q2, q3])
-  >>> KM.speeds([u1, u2, u3])
-  >>> KM.kindiffeq(kd)
+  >>> KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd)
   >>> (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
   >>> MM = KM.mass_matrix
   >>> forcing = KM.forcing
@@ -155,10 +152,8 @@ represent the constraint forces in those directions. ::
   >>> BodyD = RigidBody('BodyD', Dmc, R, m, (I, Dmc))
   >>> BodyList = [BodyD]
 
-  >>> KM = Kane(N)
-  >>> KM.coords([q1, q2, q3])
-  >>> KM.speeds([u1, u2, u3], u_auxiliary=[u4, u5, u6])
-  >>> KM.kindiffeq(kd)
+  >>> KM = KanesMethod(N, q_ind=[q1, q2, q3], u_ind=[u1, u2, u3], kd_eqs=kd,
+  ...           u_auxiliary=[u4, u5, u6])
   >>> (fr, frstar) = KM.kanes_equations(ForceList, BodyList)
   >>> MM = KM.mass_matrix
   >>> forcing = KM.forcing
@@ -172,9 +167,9 @@ represent the constraint forces in those directions. ::
   [                        (-2*u2 + u3*tan(q2))*u1]
   >>> from sympy import signsimp, factor_terms
   >>> mprint(KM.auxiliary_eqs.applyfunc(lambda w: factor_terms(signsimp(w))))
-  [                                                   -m*r*(u1*u3 + u2') + f1]
-  [      -m*r*((u1**2 + u2**2)*sin(q2) + (u2*u3 + u3*q3' - u1')*cos(q2)) + f2]
-  [-g*m + m*r*((u1**2 + u2**2)*cos(q2) - (u2*u3 + u3*q3' - u1')*sin(q2)) + f3]
+  [                                                   m*r*(u1*u3 + u2') - f1]
+  [      m*r*((u1**2 + u2**2)*sin(q2) + (u2*u3 + u3*q3' - u1')*cos(q2)) - f2]
+  [g*m - m*r*((u1**2 + u2**2)*cos(q2) - (u2*u3 + u3*q3' - u1')*sin(q2)) - f3]
 
 The Bicycle
 ===========
@@ -344,23 +339,23 @@ dynamic equations, but instead is necessary for the linearization process. ::
 The force list; each body has the appropriate gravitational force applied at
 its center of mass. ::
 
-  >>> FL = [(Frame_mc, -mframe * g * Y.z), (Fork_mc, -mfork * g * Y.z), (WF_mc, -mwf * g * Y.z), (WR_mc, -mwr * g * Y.z)]
+  >>> FL = [(Frame_mc, -mframe * g * Y.z), (Fork_mc, -mfork * g * Y.z),
+  ...       (WF_mc, -mwf * g * Y.z), (WR_mc, -mwr * g * Y.z)]
   >>> BL = [BodyFrame, BodyFork, BodyWR, BodyWF]
 
 The N frame is the inertial frame, coordinates are supplied in the order of
-independent, dependent coordinates, as are the speeds. The kinematic
-differential equation are also entered here.  Here the dependent speeds are
-specified, in the same order they were provided in earlier, along with the
-non-holonomic constraints.  The dependent coordinate is also provided, with the
-holonomic constraint.  Again, this is only provided for the linearization
-process. ::
+independent, dependent coordinates. The kinematic differential equation are
+also entered here. Here the independent speeds are specified, followed by the
+dependent speeds, along with the non-holonomic constraints. The dependent
+coordinate is also provided, with the holonomic constraint. Again, this is only
+comes into play in the linearization process, but is necessary for the
+linearization to correctly work. ::
 
-  >>> KM = Kane(N)
-  >>> KM.coords([q1, q2, q5], qdep=[q4], coneqs=conlist_coord)
-  >>> print('Before Handling of Dependent Speeds.')
-  Before Handling of Dependent Speeds.
-  >>> KM.speeds([u2, u3, u5], udep=[u1, u4, u6], coneqs=conlist_speed)
-  >>> KM.kindiffeq(kd)
+  >>> KM = KanesMethod(N, q_ind=[q1, q2, q3],
+  ...           q_dependent=[q4], configuration_constraints=conlist_coord,
+  ...           u_ind=[u2, u3, u5],
+  ...           u_dependent=[u1, u4, u6], velocity_constraints=conlist_speed,
+  ...           kd_eqs=kd)
   >>> print('Before Forming Generalized Active and Inertia Forces, Fr and Fr*')
   Before Forming Generalized Active and Inertia Forces, Fr and Fr*
   >>> (fr, frstar) = KM.kanes_equations(FL, BL)

--- a/doc/src/modules/physics/mechanics/examples.rst
+++ b/doc/src/modules/physics/mechanics/examples.rst
@@ -344,7 +344,7 @@ its center of mass. ::
   >>> BL = [BodyFrame, BodyFork, BodyWR, BodyWF]
 
 The N frame is the inertial frame, coordinates are supplied in the order of
-independent, dependent coordinates. The kinematic differential equation are
+independent, dependent coordinates. The kinematic differential equations are
 also entered here. Here the independent speeds are specified, followed by the
 dependent speeds, along with the non-holonomic constraints. The dependent
 coordinate is also provided, with the holonomic constraint. Again, this is only

--- a/doc/src/modules/physics/mechanics/kane.rst
+++ b/doc/src/modules/physics/mechanics/kane.rst
@@ -26,8 +26,8 @@ In :mod:`mechanics` holonomic constraints are only used for the linearization
 process; it is assumed that they will be too complicated to solve for the
 dependent coordinate(s).  If you are able to easily solve a holonomic
 constraint, you should consider redefining your problem in terms of a smaller
-set of coordinates. Altenatively, the time-differentiated holonomic constraints
-can be supplied.
+set of coordinates. Alternatively, the time-differentiated holonomic
+constraints can be supplied.
 
 Kane's method forms two expressions, :math:`F_r` and :math:`F_r^*`, whose sum
 is zero. In this module, these expressions are rearranged into the following

--- a/doc/src/modules/physics/mechanics/kane.rst
+++ b/doc/src/modules/physics/mechanics/kane.rst
@@ -26,7 +26,8 @@ In :mod:`mechanics` holonomic constraints are only used for the linearization
 process; it is assumed that they will be too complicated to solve for the
 dependent coordinate(s).  If you are able to easily solve a holonomic
 constraint, you should consider redefining your problem in terms of a smaller
-set of coordinates.
+set of coordinates. Altenatively, the time-differentiated holonomic constraints
+can be supplied.
 
 Kane's method forms two expressions, :math:`F_r` and :math:`F_r^*`, whose sum
 is zero. In this module, these expressions are rearranged into the following
@@ -50,76 +51,76 @@ Kane's Method in Physics/Mechanics
 ==================================
 
 Formulation of the equations of motion in :mod:`mechanics` starts with creation
-of a ``Kane`` object. Upon initialization of the ``Kane`` object, an inertial
-reference frame needs to be supplied. ::
+of a ``KanesMethod`` object. Upon initialization of the ``KanesMethod`` object,
+an inertial reference frame needs to be supplied. along with some basic system
+information, suchs as coordinates and speeds ::
 
   >>> from sympy.physics.mechanics import *
   >>> N = ReferenceFrame('N')
-  >>> KM = Kane(N)
-
-Next is the specification of coordinates and speeds for Kane's Method.
-
   >>> q1, q2, u1, u2 = dynamicsymbols('q1 q2 u1 u2')
   >>> q1d, q2d, u1d, u2d = dynamicsymbols('q1 q2 u1 u2', 1)
-  >>> KM.coords([q1, q2])
-  >>> KM.speeds([u1, u2])
+  >>> KM = KanesMethod(N, [q1, q2], [u1, u2])
 
 It is also important to supply the order of coordinates and speeds properly if
 there are dependent coordinates and speeds. They must be supplied after
 independent coordinates and speeds or as a keyword argument; this is shown
-later: ::
+later. ::
 
   >>> q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')
   >>> u1, u2, u3, u4 = dynamicsymbols('u1 u2 u3 u4')
   >>> # Here we will assume q2 is dependent, and u2 and u3 are dependent
   >>> # We need the constraint equations to enter them though
-  >>> KM.coords([q1, q3, q4])
-  >>> KM.speeds([u1, u4])
+  >>> KM = KanesMethod(N, [q1, q3, q4], [u1, u4])
 
 Additionally, if there are auxiliary speeds, they need to be identified here.
 See the examples for more information on this. In this example u4 is the
 auxiliary speed. ::
 
-  >>> u1, u2, u3, u4 = dynamicsymbols('u1 u2 u3 u4')
-  >>> KM.speeds([u1, u2, u3], u_auxiliary=[u4])
+  >>> KM = KanesMethod(N, [q1, q3, q4], [u1, u2, u3], u_auxiliary=[u4])
 
 Kinematic differential equations must also be supplied; there are to be
 provided as a list of expressions which are each equal to zero. A trivial
 example follows: ::
 
-  >>> KM.coords([q1, q2])
   >>> kd = [q1d - u1, q2d - u2]
-  >>> KM.kindiffeq(kd)
+
+Turning on ``mechanics_printing()`` makes the expressions significantly
+shorter and is recommended. Alternatively, the ``mprint`` and ``mpprint``
+commands can be used.
+
+If there are non-holonomic constraints, dependent speeds need to be specified
+(and so do dependent coordinates, but they only come into play when linearizing
+the system). The constraints need to be supplied in a list of expressions which
+are equal to zero, trivial motion and configuration constraints are shown
+below: ::
+
+  >>> N = ReferenceFrame('N')
+  >>> q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')
+  >>> q1d, q2d, q3d, q4d = dynamicsymbols('q1 q2 q3 q4', 1)
+  >>> u1, u2, u3, u4 = dynamicsymbols('u1 u2 u3 u4')
+  >>> #Here we will assume q2 is dependent, and u2 and u3 are dependent
+  >>> speed_cons = [u2 - u1, u3 - u1 - u4]
+  >>> coord_cons = [q2 - q1]
+  >>> q_ind = [q1, q3, q4]
+  >>> q_dep = [q2]
+  >>> u_ind = [u1, u4]
+  >>> u_dep = [u2, u3]
+  >>> kd = [q1d - u1, q2d - u2, q3d - u3, q4d - u4]
+  >>> KM = KanesMethod(N, q_ind, u_ind, kd,
+  ...           q_dependent=q_dep,
+  ...           configuration_constraints=coord_cons,
+  ...           u_dependent=u_dep,
+  ...           velocity_constraints=speed_cons)
 
 A dictionary returning the solved :math:`\dot{q}`'s can also be solved for: ::
 
   >>> mechanics_printing()
   >>> KM.kindiffdict()
-  {q1': u1, q2': u2}
-
-Turning on ``mechanics_printing()`` makes the expressions significantly
-shorter and is recommended.
-
-If there are non-holonomic constraints, dependent speeds need to be specified
-(and so do dependent coordinates, but they only come into play when linearizing
-the system). The dependent speeds need to be specified in the same order as
-they were earlier. The constraints need to be supplied in a list of expressions
-which are equal to zero, trivial motion and configuration constraints are shown
-below: ::
-
-  >>> N = ReferenceFrame('N')
-  >>> KM = Kane(N)
-  >>> q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')
-  >>> u1, u2, u3, u4 = dynamicsymbols('u1 u2 u3 u4')
-  >>> #Here we will assume q2 is dependent, and u2 and u3 are dependent
-  >>> speed_cons = [u2 - u1, u3 - u1 - u4]
-  >>> coord_cons = [q2 - q1]
-  >>> KM.coords([q1, q3, q4], qdep=[q2], coneqs=coord_cons)
-  >>> KM.speeds([u1, u4], udep=[u2, u3], coneqs=speed_cons)
+  {q1': u1, q2': u2, q3': u3, q4': u4}
 
 The final step in forming the equations of motion is supplying a list of
 bodies and particles, and a list of 2-tuples of the form ``(Point, Vector)``
-or ``(ReferenceFrame, Vector)`` to represent applied forces and torques.
+or ``(ReferenceFrame, Vector)`` to represent applied forces and torques. ::
 
   >>> N = ReferenceFrame('N')
   >>> q, u = dynamicsymbols('q u')
@@ -129,15 +130,12 @@ or ``(ReferenceFrame, Vector)`` to represent applied forces and torques.
   >>> Pa = Particle('Pa', P, 5)
   >>> BL = [Pa]
   >>> FL = [(P, 7 * N.x)]
-  >>> KM = Kane(N)
-  >>> KM.coords([q])
-  >>> KM.speeds([u])
-  >>> KM.kindiffeq([qd - u])
+  >>> KM = KanesMethod(N, [q], [u], [qd - u])
   >>> (fr, frstar) = KM.kanes_equations(FL, BL)
   >>> KM.mass_matrix
-  [-5]
+  [5]
   >>> KM.forcing
-  [-7]
+  [7]
 
 When there are motion constraints, the mass matrix is augmented by the
 :math:`k_{dnh}(q, t)` matrix, and the forcing vector by the :math:`f_{dnh}(q,
@@ -148,11 +146,11 @@ include the kinematic differential equations; the mass matrix is of size (n +
 o) x (n + o), or square and the size of all coordinates and speeds. ::
 
   >>> KM.mass_matrix_full
-  [1,  0]
-  [0, -5]
+  [1, 0]
+  [0, 5]
   >>> KM.forcing_full
-  [ u]
-  [-7]
+  [u]
+  [7]
 
 The forcing vector can be linearized as well; its Jacobian is taken only with
 respect to the independent coordinates and speeds. The linearized forcing
@@ -171,4 +169,4 @@ equations, an error with be raised. ::
   [0, 0]
 
 Exploration of the provided examples is encouraged in order to gain more
-understanding of the ``Kane`` object.
+understanding of the ``KanesMethod`` object.

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -95,13 +95,11 @@ class Dyadic(object):
             for i, v in enumerate(self.args):
                 for i2, v2 in enumerate(other.args):
                     ol += v[0] * v2[0] * (v[2] & v2[1]) * (v[1] | v2[2])
-        elif isinstance(other, Vector):
+        else:
             other = _check_vector(other)
             ol = Vector([])
             for i, v in enumerate(self.args):
                 ol += v[0] * v[1] * (v[2] & other)
-        else:
-            raise TypeError('Need to supply a Vector or Dyadic')
         return ol
 
     def __div__(self, other):

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -4,10 +4,9 @@ __all__ = ['ReferenceFrame', 'Vector', 'Dyadic', 'dynamicsymbols',
 
 from sympy import (Matrix, Symbol, sin, cos, eye, trigsimp, diff, sqrt, sympify,
                    expand, zeros, Derivative, Function, symbols, Add,
-                   solve)
+                   solve, S)
 from sympy.core import C
 from sympy.core.function import UndefinedFunction
-from sympy.core.numbers import Zero
 from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter
 from sympy.printing.pretty.pretty import PrettyPrinter
@@ -402,10 +401,15 @@ class Dyadic(object):
             frame2 = frame1
         _check_frame(frame1)
         _check_frame(frame2)
-        ol = 0
+        ol = S(0)
         for i, v in enumerate(self.args):
             ol += v[0] * (v[1].express(frame1) | v[2].express(frame2))
         return ol
+
+    def doit(self, **hints):
+        """Calls .doit() on each term in the Dyadic"""
+        return sum([Dyadic( [ (v[0].doit(**hints), v[1], v[2]) ]) for
+                    v in self.args])
 
     def dt(self, frame):
         """Take the time derivative of this Dyadic in a frame.
@@ -431,15 +435,20 @@ class Dyadic(object):
 
         _check_frame(frame)
         t = dynamicsymbols._t
-        ol = 0
+        ol = S(0)
         for i, v in enumerate(self.args):
             ol += (v[0].diff(t) * (v[1] | v[2]))
             ol += (v[0] * (v[1].dt(frame) | v[2]))
             ol += (v[0] * (v[1] | v[2].dt(frame)))
         return ol
 
-    def subs(self, dictin):
-        """Substituion on the Dyadic, with a dict.
+    def simplify(self):
+        """Simplify the elements in the Dyadic in-place."""
+        for i in self.args:
+            i[0] = i[0].simplify()
+
+    def subs(self, *args, **kwargs):
+        """Substituion on the Dyadic.
 
         Examples
         ========
@@ -454,8 +463,8 @@ class Dyadic(object):
 
         """
 
-        return sum([ Dyadic( [ (v[0].subs(dictin), v[1], v[2]) ]) for v in
-                   self.args])
+        return sum([Dyadic( [ (v[0].subs(*args, **kwargs), v[1], v[2]) ]) for
+                    v in self.args])
 
     dot = __and__
     cross = __xor__
@@ -1112,7 +1121,7 @@ class Vector(object):
         if isinstance(other, Dyadic):
             return NotImplemented
         other = _check_vector(other)
-        out = 0
+        out = S(0)
         for i, v1 in enumerate(self.args):
             for j, v2 in enumerate(other.args):
                 out += ((v2[0].T)
@@ -1411,7 +1420,7 @@ class Vector(object):
             return NotImplemented
         other = _check_vector(other)
         if other.args == []:
-            return self * 0
+            return self * S(0)
 
         def _det(mat):
             """This is needed as a little method for to find the determinant
@@ -1487,7 +1496,7 @@ class Vector(object):
 
         wrt = sympify(wrt)
         _check_frame(otherframe)
-        outvec = 0
+        outvec = S(0)
         for i,v in enumerate(self.args):
             if v[1] == otherframe:
                 outvec += Vector([(v[0].diff(wrt), otherframe)])
@@ -1499,6 +1508,13 @@ class Vector(object):
                     d = (Vector([v]).express(otherframe)).args[0][0].diff(wrt)
                     outvec += Vector([(d, otherframe)]).express(v[1])
         return outvec
+
+    def doit(self, **hints):
+        """Calls .doit() on each term in the Vector"""
+        ov = S(0)
+        for i, v in enumerate(self.args):
+            ov += Vector([(v[0].applyfunc(lambda x: x.doit(**hints)) , v[1])])
+        return ov
 
     def dt(self, otherframe):
         """Returns the time derivative of the Vector in a ReferenceFrame.
@@ -1530,7 +1546,7 @@ class Vector(object):
 
         """
 
-        outvec = 0
+        outvec = S(0)
         _check_frame(otherframe)
         for i, v in enumerate(self.args):
             if v[1] == otherframe:
@@ -1578,8 +1594,13 @@ class Vector(object):
                 outvec -= Vector([v])
         return outvec
 
-    def subs(self, dictin):
-        """Substituion on the Vector, with a dict.
+    def simplify(self):
+        """Simplify the elements in the Vector in place. """
+        for i in self.args:
+            i[0] = i[0].simplify()
+
+    def subs(self, *args, **kwargs):
+        """Substituion on the Vector.
 
         Examples
         ========
@@ -1594,9 +1615,9 @@ class Vector(object):
 
         """
 
-        ov = 0
+        ov = S(0)
         for i, v in enumerate(self.args):
-            ov += Vector([(v[0].subs(dictin), v[1])])
+            ov += Vector([(v[0].subs(*args, **kwargs), v[1])])
         return ov
 
     def magnitude(self):
@@ -1862,7 +1883,7 @@ class MechanicsPrettyPrinter(PrettyPrinter):
 def _check_dyadic(other):
     if not isinstance(other, Dyadic):
         other = sympify(other)
-        if other != 0:
+        if other != S(0):
             raise TypeError('A Dyadic must be supplied')
         else:
             other = Dyadic([])
@@ -1877,7 +1898,7 @@ def _check_frame(other):
 def _check_vector(other):
     if not isinstance(other, Vector):
         other = sympify(other)
-        if other != 0:
+        if other != S(0):
             raise TypeError('A Vector must be supplied')
         else:
             other = Vector([])

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -461,8 +461,8 @@ class Dyadic(object):
 
         """
 
-        return sum([Dyadic( [ (v[0].subs(*args, **kwargs), v[1], v[2]) ]) for
-                    v in self.args])
+        return sum([ Dyadic([(v[0].subs(*args, **kwargs), v[1], v[2])])
+                     for v in self.args])
 
     dot = __and__
     cross = __xor__

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -407,17 +407,27 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
     else:
         raise ValueError('Not an approved rotation type for this function')
 
-def partial_velocity(vel_list, u_list):
+def partial_velocity(vel_list, u_list, frame):
     """Returns a list of partial velocities.
+
+    For a list of velocity or angular velocity vectors the partial derivatives
+    with respect to the supplied generalized speeds are computed, in the
+    specified ReferenceFrame.
+
+    The output is a list of lists. The outer list has a number of elements
+    equal to the number of supplied velocity vectors. The inner lists are, for
+    each velocity vector, the partial derivatives of that velocity vector with
+    respect to the generalized speeds supplied.
 
     Parameters
     ==========
 
     vel_list : list
         List of velocities of Point's and angular velocities of ReferenceFrame's
-
     u_list : list
         List of independent generalized speeds.
+    frame : ReferenceFrame
+        The ReferenceFrame the partial derivatives are going to be taken in.
 
     Examples
     ========
@@ -431,7 +441,7 @@ def partial_velocity(vel_list, u_list):
     >>> P.set_vel(N, u * N.x)
     >>> vel_list = [P.vel(N)]
     >>> u_list = [u]
-    >>> partial_velocity(vel_list, u_list)
+    >>> partial_velocity(vel_list, u_list, N)
     [[N.x]]
 
     """
@@ -439,8 +449,6 @@ def partial_velocity(vel_list, u_list):
         raise TypeError('Provide velocities in an iterable')
     if not hasattr(u_list, '__iter__'):
         raise TypeError('Provide speeds in an iterable')
-    a = vel_list[0]
-    frame = a.args[0][1]
     list_of_pvlists = []
     for i in vel_list:
         pvlist = []
@@ -462,12 +470,13 @@ def linear_momentum(frame, *body):
 
     L = L1 + L2
 
+    Parameters
+    ==========
+
     frame : ReferenceFrame
         The frame in which linear momentum is desired.
-
     body1, body2, body3... : Particle and/or RigidBody
         The body (or bodies) whose kinetic energy is required.
-
 
     Examples
     ========
@@ -515,10 +524,8 @@ def angular_momentum(point, frame, *body):
 
     point : Point
         The point about which angular momentum of the system is desired.
-
     frame : ReferenceFrame
         The frame in which angular momentum is desired.
-
     body1, body2, body3... : Particle and/or RigidBody
         The body (or bodies) whose kinetic energy is required.
 
@@ -577,7 +584,6 @@ def kinetic_energy(frame, *body):
     frame : ReferenceFrame
         The frame in which the velocity or angular velocity of the body is
         defined.
-
     body1, body2, body3... : Particle and/or RigidBody
         The body (or bodies) whose kinetic energy is required.
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -407,7 +407,7 @@ def kinematic_equations(speeds, coords, rot_type, rot_order=''):
     else:
         raise ValueError('Not an approved rotation type for this function')
 
-def partial_velocity(vel_list, u_ind_list):
+def partial_velocity(vel_list, u_list):
     """Returns a list of partial velocities.
 
     Parameters
@@ -416,7 +416,7 @@ def partial_velocity(vel_list, u_ind_list):
     vel_list : list
         List of velocities of Point's and angular velocities of ReferenceFrame's
 
-    u_ind_list : list
+    u_list : list
         List of independent generalized speeds.
 
     Examples
@@ -435,22 +435,19 @@ def partial_velocity(vel_list, u_ind_list):
     [[N.x]]
 
     """
-    if not isinstance(vel_list, list):
-        raise TypeError('Provide velocities in a list')
-    if not isinstance(u_ind_list, list):
-        raise TypeError('Provide speeds in a list')
-    else:
-        a = vel_list[0]
-        frame = a.args[0][1]
-        list_of_pvlists = []
-        i = 0
-        while i < len(u_ind_list):
-            pvlist = []
-            for e in vel_list:
-                vel = e.diff(u_ind_list[i], frame)
-                pvlist = pvlist + [vel]
-            list_of_pvlists = list_of_pvlists + [pvlist]
-            i = i + 1
+    if not hasattr(vel_list, '__iter__'):
+        raise TypeError('Provide velocities in an iterable')
+    if not hasattr(u_list, '__iter__'):
+        raise TypeError('Provide speeds in an iterable')
+    a = vel_list[0]
+    frame = a.args[0][1]
+    list_of_pvlists = []
+    for i in vel_list:
+        pvlist = []
+        for j in u_list:
+            vel = i.diff(j, frame)
+            pvlist += [vel]
+        list_of_pvlists += [pvlist]
     return list_of_pvlists
 
 def linear_momentum(frame, *body):

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -382,7 +382,7 @@ class KanesMethod(object):
             else:
                 raise TypeError('First entry in pair must be point or frame.')
             f_list += [i[1]]
-        partials = partial_velocity(vel_list, u)
+        partials = partial_velocity(vel_list, u, N)
 
         # Fill Fr with dot product of partial velocities and forces
         for i in range(o):
@@ -446,9 +446,9 @@ class KanesMethod(object):
         for v in bl:
             if isinstance(v, RigidBody):
                 partials += [partial_velocity([v.masscenter.vel(N),
-                                               v.frame.ang_vel_in(N)], u)]
+                                               v.frame.ang_vel_in(N)], u, N)]
             elif isinstance(v, Particle):
-                partials += [partial_velocity([v.point.vel(N)], u)]
+                partials += [partial_velocity([v.point.vel(N)], u, N)]
             else:
                 raise TypeError('The body list needs RigidBody or '
                                 'Particle as list elements.')
@@ -778,9 +778,11 @@ class KanesMethod(object):
         """ Returns the system's equations of motion in first order form.
 
         The output of this will be the right hand side of:
-        [qdot, udot].T = rhs(q, u, t)
-        Or, the equations of motion, in first order form, as they would be
-        passed to a numerical integrator.
+
+        [qdot, udot].T = f(q, u, t)
+
+        Or, the equations of motion in first order form.  The right hand side
+        is what is needed by most numerical ODE integrators.
 
         Parameters
         ==========

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -301,9 +301,10 @@ def test_partial_velocity():
 
     vel_list = [Dmc.vel(N), C.vel(N), R.ang_vel_in(N)]
     u_list = [u1, u2, u3, u4, u5]
-    assert (partial_velocity(vel_list, u_list) == [[- r*L.y, 0, L.x],
-            [r*L.x, 0, L.y], [0, 0, L.z], [L.x, L.x, 0],
-                [cos(q2)*L.y - sin(q2)*L.z, cos(q2)*L.y - sin(q2)*L.z, 0]])
+    assert (partial_velocity(vel_list, u_list) ==
+            [[- r*L.y, r*L.x, 0, L.x, cos(q2)*L.y - sin(q2)*L.z],
+            [0, 0, 0, L.x, cos(q2)*L.y - sin(q2)*L.z],
+            [L.x, L.y, L.z, 0, 0]])
 
 def test_linear_momentum():
     N = ReferenceFrame('N')

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -301,7 +301,7 @@ def test_partial_velocity():
 
     vel_list = [Dmc.vel(N), C.vel(N), R.ang_vel_in(N)]
     u_list = [u1, u2, u3, u4, u5]
-    assert (partial_velocity(vel_list, u_list) ==
+    assert (partial_velocity(vel_list, u_list, N) ==
             [[- r*L.y, r*L.x, 0, L.x, cos(q2)*L.y - sin(q2)*L.z],
             [0, 0, 0, L.x, cos(q2)*L.y - sin(q2)*L.z],
             [L.x, L.y, L.z, 0, 0]])


### PR DESCRIPTION
The class for forming equations of motion with Kane's method has been changed slightly. Most of the changes are related to making this class's interface more in line with the interface in the new LagrangesMethod class.

The class's name has been changed to KanesMethod, and it now takes in almost all data on initialization. One major method was rewritten to make it easier to read. Some other associated changes were also made throughout mechanics for this.
