### PR TITLE
setup.py: Use parenthesis around print statements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ import sympy
 
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (2,5):
-    print "SymPy requires Python 2.5 or newer. Python %d.%d detected" % \
-          sys.version_info[:2]
+    print("SymPy requires Python 2.5 or newer. Python %d.%d detected" % \
+          sys.version_info[:2])
     sys.exit(-1)
 
 # Check that this list is uptodate against the result of the command:
@@ -113,7 +113,7 @@ class audit(Command):
         try:
             import pyflakes.scripts.pyflakes as flakes
         except ImportError:
-            print """In order to run the audit, you need to have PyFlakes installed."""
+            print("In order to run the audit, you need to have PyFlakes installed.")
             sys.exit(-1)
         # We don't want to audit external dependencies
         ext = ('mpmath',)


### PR DESCRIPTION
In Python 3, the print statement was changed to a function. As such,
running setup.py under Python 3 produces SyntaxErrors. However, for such
simple cases, it is possible to just wrap the entire string with
parenthesis and this will print as expected in all Python versions.
Making this change allows us to print the correct error message (that
use2to3 should be run) if the user tries to use setup.py under Python 3.

This addresses issue 3053.

---

Here's how it looks now:

```
vperic@vperic-laptop:~/devel/sympy> python2.4 setup.py audit
Traceback (most recent call last):
  File "setup.py", line 36, in ?
    import sympy
  File "/home/vperic/devel/sympy/sympy/__init__.py", line 31, in ?
    raise ImportError("Python Version 2.5 or above is required for SymPy.")
ImportError: Python Version 2.5 or above is required for SymPy.
vperic@vperic-laptop:~/devel/sympy> python3.2 setup.py audit
Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    import sympy
  File "/home/vperic/devel/sympy/sympy/__init__.py", line 34, in <module>
    raise ImportError("This is the Python 2 version of SymPy. To use SymPy "
ImportError: This is the Python 2 version of SymPy. To use SymPy with Python 3, please obtain a Python 3 version from http://sympy.org, or use the bin/use2to3 script if you are using the git version
```
