### PR TITLE
Implement integral of Piecewise with symbolic conditions.

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -143,11 +143,13 @@ class Piecewise(Function):
             cond_eval = cls.__eval_cond(cond)
             if cond_eval is None:
                 all_conds_evaled = False
-                non_false_ecpairs.append( (expr, cond) )
             elif cond_eval:
                 if all_conds_evaled:
                     return expr
-                non_false_ecpairs.append( (expr, cond) )
+            if len(non_false_ecpairs) != 0 and non_false_ecpairs[-1].expr == expr:
+                non_false_ecpairs[-1] = ExprCondPair(expr, Or(cond, non_false_ecpairs[-1].cond))
+            else:
+                non_false_ecpairs.append( ExprCondPair(expr, cond) )
         if len(non_false_ecpairs) != len(args) or piecewise_again:
             return Piecewise(*non_false_ecpairs)
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -1,6 +1,7 @@
 from sympy.core import Basic, S, Function, diff, Tuple
 from sympy.core.relational import Equality, Relational
 from sympy.core.symbol import Dummy
+from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import And, Boolean, Or
 from sympy.utilities.misc import default_sort_key
 
@@ -253,7 +254,7 @@ class Piecewise(Function):
         # Finally run through the intervals and sum the evaluation.
         ret_fun = 0
         for int_a, int_b, expr in int_expr:
-            ret_fun += expr._eval_interval(sym,  max(a, int_a), min(b, int_b))
+            ret_fun += expr._eval_interval(sym, Max(a, int_a), Min(b, int_b))
         return mul * ret_fun
 
     def _sort_expr_cond(self, sym, a, b, targetcond = None):
@@ -294,9 +295,9 @@ class Piecewise(Function):
                 upper = S.Infinity
                 for cond2 in cond.args:
                     if cond2.lts.has(sym):
-                        upper = min(cond2.gts, upper)
+                        upper = Min(cond2.gts, upper)
                     elif cond2.gts.has(sym):
-                        lower = max(cond2.lts, lower)
+                        lower = Max(cond2.lts, lower)
             else:
                 lower, upper = cond.lts, cond.gts # part 1: initialize with givens
                 if cond.lts.has(sym):     # part 1a: expand the side ...
@@ -308,7 +309,7 @@ class Piecewise(Function):
                         "Unable to handle interval evaluation of expression.")
 
             # part 1b: Reduce (-)infinity to what was passed in.
-            lower, upper = max(a, lower), min(b, upper)
+            lower, upper = Max(a, lower), Min(b, upper)
 
             for n in xrange(len(int_expr)):
                 # Part 2: remove any interval overlap.  For any conflicts, the
@@ -317,11 +318,24 @@ class Piecewise(Function):
                 if self.__eval_cond(lower < int_expr[n][1]) and \
                         self.__eval_cond(lower >= int_expr[n][0]):
                     lower = int_expr[n][1]
-                if self.__eval_cond(upper > int_expr[n][0]) and \
+                elif len(int_expr[n][1].free_symbols) and \
+                        self.__eval_cond(lower >= int_expr[n][0]):
+                    if self.__eval_cond(lower == int_expr[n][0]):
+                        lower = int_expr[n][1]
+                    else:
+                        int_expr[n][1] = Min(lower, int_expr[n][1])
+                elif len(int_expr[n][1].free_symbols) and \
+                        lower < int_expr[n][0] is not True:
+                    upper = Min(upper, int_expr[n][0])
+                elif self.__eval_cond(upper > int_expr[n][0]) and \
                         self.__eval_cond(upper <= int_expr[n][1]):
                     upper = int_expr[n][0]
-            if self.__eval_cond(lower < upper):  # Is it still an interval?
-                int_expr.append((lower, upper, expr))
+                elif len(int_expr[n][0].free_symbols) and \
+                        self.__eval_cond(upper < int_expr[n][1]):
+                    int_expr[n][0] = Max(upper, int_expr[n][0])
+
+            if self.__eval_cond(lower >= upper) is not True:  # Is it still an interval?
+                int_expr.append([lower, upper, expr])
             if cond is targetcond:
                 return [(lower, upper)]
             elif isinstance(targetcond, Or) and cond in targetcond.args:
@@ -331,18 +345,36 @@ class Piecewise(Function):
                     or_intervals.sort(key=lambda x:x[0])
                     return or_intervals
 
-        int_expr.sort(key=lambda x:x[0])
+        int_expr.sort(key=lambda x: x[1].sort_key() if x[1].is_number else S.NegativeInfinity.sort_key())
+        int_expr.sort(key=lambda x: x[0].sort_key() if x[0].is_number else S.Infinity.sort_key())
+        from sympy.functions.elementary.miscellaneous import MinMaxBase
+        for n in xrange(len(int_expr)):
+            if len(int_expr[n][0].free_symbols) or len(int_expr[n][1].free_symbols):
+                if isinstance(int_expr[n][1], Min) or int_expr[n][1] == b:
+                    newval = Min(*int_expr[n][:-1])
+                    if n > 0 and int_expr[n][0] == int_expr[n-1][1]:
+                        int_expr[n-1][1] = newval
+                    int_expr[n][0] = newval
+                else:
+                    newval = Max(*int_expr[n][:-1])
+                    if n < len(int_expr) - 1 and int_expr[n][1] == int_expr[n+1][0]:
+                        int_expr[n+1][0] = newval
+                    int_expr[n][1] = newval
 
         # Add holes to list of intervals if there is a default value,
         # otherwise raise a ValueError.
         holes = []
         curr_low = a
         for int_a, int_b, expr in int_expr:
-            if curr_low < int_a:
-                holes.append([curr_low, min(b, int_a), default])
-            curr_low = int_b
-        if curr_low < b:
-            holes.append([curr_low, b, default])
+            if (curr_low < int_a) is True:
+                holes.append([curr_low, Min(b, int_a), default])
+            elif (curr_low >= int_a) is not True:
+                holes.append([curr_low, Min(b, int_a), default])
+            curr_low = Min(b, int_b)
+        if (curr_low < b) is True:
+            holes.append([Min(b, curr_low), b, default])
+        elif (curr_low >= b) is not True:
+            holes.append([Min(b, curr_low), b, default])
 
         if holes and default is not None:
             int_expr.extend(holes)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -11,7 +11,10 @@ def test_piecewise():
     # Test canonization
     assert Piecewise((x, x < 1), (0, True)) == Piecewise((x, x < 1), (0, True))
     assert Piecewise((x, x < 1), (0, True), (1, True)) == Piecewise((x, x < 1), (0, True))
-    assert Piecewise((x, x < 1), (0, False), (-1, 1>2)) == Piecewise((x, x < 1))
+    assert Piecewise((x, x < 1), (0, False), (-1, 1 > 2)) == Piecewise((x, x < 1))
+    assert Piecewise((x, x < 1), (0, x < 2), (0, True)) == Piecewise((x, x < 1), (0, True))
+    assert Piecewise((x, x < 1), (x, x < 2), (0, True)) == Piecewise((x, Or(x < 1, x < 2)), (0, True))
+    assert Piecewise((x, x < 1), (x, x < 2), (x, True)) == x
     assert Piecewise((x, True)) == x
     raises(TypeError, lambda: Piecewise(x))
     raises(TypeError, lambda: Piecewise((x,x**2)))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -309,14 +309,22 @@ def test_piecewise_series():
     assert p1.nseries(x,n=2) == p2
 
 def test_piecewise_as_leading_term():
-    p1 = Piecewise((1/x, x > 1), (x, True))
-    p2 = Piecewise((1/x, x < 1), (x, True))
-    p3 = Piecewise((x, x < 1), (1/x, True))
+    p1 = Piecewise((1/x, x > 1), (0, True))
+    p2 = Piecewise((x, x > 1), (0, True))
+    p3 = Piecewise((1/x, x > 1), (x, True))
     p4 = Piecewise((x, x > 1), (1/x, True))
-    assert p1.as_leading_term(x) == x
-    assert p2.as_leading_term(x) == 1/x
+    p5 = Piecewise((1/x, x > 1), (x, True))
+    p6 = Piecewise((1/x, x < 1), (x, True))
+    p7 = Piecewise((x, x < 1), (1/x, True))
+    p8 = Piecewise((x, x > 1), (1/x, True))
+    assert p1.as_leading_term(x) == 0
+    assert p2.as_leading_term(x) == 0
     assert p3.as_leading_term(x) == x
     assert p4.as_leading_term(x) == 1/x
+    assert p5.as_leading_term(x) == x
+    assert p6.as_leading_term(x) == 1/x
+    assert p7.as_leading_term(x) == x
+    assert p8.as_leading_term(x) == 1/x
 
 def test_piecewise_complex():
     p1 = Piecewise((2, x < 0), (1, 0 <= x))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -7,7 +7,7 @@ from sympy import (
     nsimplify, oo, pi, posify, powdenest, powsimp, radsimp, ratsimp,
     ratsimpmodprime, rcollect, separatevars, signsimp, simplify,
     sin, sinh, solve, sqrt, symbols, sympify, tan, tanh, trigsimp, Dummy,
-    Subs, polarify, exp_polar, polar_lift)
+    Subs, polarify, exp_polar, polar_lift, Piecewise)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
@@ -1206,3 +1206,13 @@ def test_besselsimp():
            besselj(a, sqrt(x)) * cos(sqrt(x))
     assert besselsimp(besseli(S(-1)/2, z)) == sqrt(2)*cosh(z)/(sqrt(pi)*sqrt(z))
     assert besselsimp(besseli(a, z*exp_polar(-I*pi/2))) == exp(-I*pi*a/2)*besselj(a, z)
+
+def test_Piecewise():
+    e1 = x*(x + y) - y*(x + y)
+    e2 = sin(x)**2 + cos(x)**2
+    e3 = expand((x + y)*y/x)
+    s1 = simplify(e1)
+    s2 = simplify(e2)
+    s3 = simplify(e3)
+    assert simplify(Piecewise((e1, x < e2), (e3, True))) \
+        == Piecewise((s1, x < s2), (s3, True))

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -187,7 +187,7 @@ class ContinuousPSpace(PSpace):
         # CDF is integral of PDF from left bound to z
         cdf = integrate(d(x), (x, left_bound, z), **kwargs)
         # CDF Ensure that CDF left of left_bound is zero
-        cdf = Piecewise((0, z<left_bound), (cdf, True))
+        cdf = Piecewise((cdf, z >= left_bound), (0, True))
         return Lambda(z, cdf)
 
     def probability(self, condition, **kwargs):

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -106,7 +106,7 @@ def test_cdf():
     Z = Exponential('z', 1)
     f = cdf(Z)
     z = Symbol('z')
-    assert f(z) == Piecewise((0, z < 0), (1 - exp(-z), True))
+    assert f(z) == Piecewise((1 - exp(-z), z >= 0), (0, True))
 
 def test_sample():
     z = Symbol('z')
@@ -222,8 +222,8 @@ def test_gamma():
     X = Gamma('x', k, theta)
     assert density(X) == Lambda(_x,
                                 _x**(k - 1)*theta**(-k)*exp(-_x/theta)/gamma(k))
-    assert cdf(X, meijerg=True) == Lambda(_z, Piecewise((0, _z < 0),
-    (-k*lowergamma(k, 0)/gamma(k + 1) + k*lowergamma(k, _z/theta)/gamma(k + 1), True)))
+    assert cdf(X, meijerg=True) == Lambda(_z, Piecewise(
+    (-k*lowergamma(k, 0)/gamma(k + 1) + k*lowergamma(k, _z/theta)/gamma(k + 1), _z >= 0), (0, True)))
     assert variance(X) == (-theta**2*gamma(k + 1)**2/gamma(k)**2 +
            theta*theta**(-k)*theta**(k + 1)*gamma(k + 2)/gamma(k))
 


### PR DESCRIPTION
In this pull request:
- Handle symbolic delimiters in conditions to Piecewise. For example,

```
>>> L = Symbol('L', positive=True)
>>> p = Piecewise((1, And(-L <= x, x <= L)), (0, True))
>>> integrate(p, (x, -oo, oo))
2*L
```
- Handle Or() conditions, e.g. Or(x < -1, x > 1)
- If two subsequent ExprCondPairs in Piecewise have the same expression, reduce them to one ExprCondPair with corresponding Or condition. e.g., automatically canonalize

```
Piecewise((e, c1), (e, c2))
```

to

```
Piecewise((e, Or(c1, c2)))
```
- Tests
