### PR TITLE
Fix hash randomization failure.

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1463,8 +1463,10 @@ def _aresame(a, b):
 
     """
     from itertools import izip
+    from sympy.utilities.misc import default_sort_key
 
-    for i, j in izip(preorder_traversal(a), preorder_traversal(b)):
+    for i, j in izip(preorder_traversal(a, key=default_sort_key),
+                     preorder_traversal(b, key=default_sort_key)):
         if i != j or type(i) != type(j):
             return False
     else:

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -370,7 +370,8 @@ class LatticeOp(AssocOp):
 
     @property
     def args(self):
-        return tuple(self._argset)
+        from sympy.utilities.misc import default_sort_key
+        return tuple(sorted(self._argset, key=default_sort_key))
 
     @staticmethod
     def _compare_pretty(a, b):


### PR DESCRIPTION
Make sure that `Min(a, b).args` is hash independent.
