### PR TITLE
No evalf 1

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -355,7 +355,7 @@ def test_issue_1072() :
 def test_issue_3174():
     # when this passes, the doctests involving Sum in
     # is_constant can be unskipped
-    assert Sum(x, (x, 1, n)).n(1, subs={n: 0}) == 1
+    assert Sum(x, (x, 1, n)).n(2, subs={n: 0}) == 1
 
 @XFAIL
 def test_issue_3175():

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -359,4 +359,4 @@ def test_issue_3174():
 
 @XFAIL
 def test_issue_3175():
-    assert Sum(x, (x, 1, 0)).n(1) == 1
+    assert Sum(x, (x, 1, 0)).doit() == 0

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -190,7 +190,7 @@ class Expr(Basic, EvalfMixin):
         # off by one. So...if our round value is the same as the int value
         # (regardless of how much extra work we do to calculate extra decimal
         # places) we need to test whether we are off by one.
-        r = self.round(1)
+        r = self.round(2)
         if not r.is_Number:
             raise TypeError("can't convert complex to int")
         i = int(r)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -200,11 +200,11 @@ class Expr(Basic, EvalfMixin):
         if i == r and not (self - i).equals(0):
             isign = 1 if i > 0 else -1
             x = C.Dummy()
-            # in the following (self - i).evalf(1) will not always work while
-            # (self - r).evalf(1) and the use of subs does; if the test that
+            # in the following (self - i).evalf(2) will not always work while
+            # (self - r).evalf(2) and the use of subs does; if the test that
             # was added when this comment was added passes, it might be safe
             # to simply use sign to compute this rather than doing this by hand:
-            diff_sign = 1 if (self - x).evalf(1, subs={x: i}) > 0 else -1
+            diff_sign = 1 if (self - x).evalf(2, subs={x: i}) > 0 else -1
             if diff_sign != isign:
                 i -= isign
         return i
@@ -328,10 +328,10 @@ class Expr(Basic, EvalfMixin):
             a, c, b, d = re_min, re_max, im_min, im_max
             reps = dict(zip(free, [random_complex_number(a, b, c, d, rational=True)
                            for zi in free]))
-            nmag = abs(self.evalf(1, subs=reps))
+            nmag = abs(self.evalf(2, subs=reps))
         else:
             reps = {}
-            nmag = abs(self.evalf(1))
+            nmag = abs(self.evalf(2))
 
         if not hasattr(nmag, '_prec'):
             # e.g. exp_polar(2*I*pi) doesn't evaluate but is_number is True
@@ -575,7 +575,7 @@ class Expr(Basic, EvalfMixin):
                 return False
             try:
                 # check to see that we can get a value
-                n2 = self._eval_evalf(1)
+                n2 = self._eval_evalf(2)
             except AttributeError:
                 n2 = None
             if n2 is None:
@@ -597,7 +597,7 @@ class Expr(Basic, EvalfMixin):
                 return False
             try:
                 # check to see that we can get a value
-                n2 = self._eval_evalf(1)
+                n2 = self._eval_evalf(2)
             except AttributeError:
                 n2 = None
             if n2 is None:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -155,7 +155,7 @@ class Relational(Boolean, Expr, EvalfMixin):
                 Nlhs = S.Zero
             elif know is False:
                 from sympy import sign
-                Nlhs = sign(diff.n(1))
+                Nlhs = sign(diff.n(2))
             else:
                 Nlhs = None
                 lhs = know

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -181,9 +181,9 @@ def test_Subs():
     assert e1.__hash__() == e2.__hash__()
     assert Subs(z*f(x+1), x, 1) not in [ e1, e2 ]
     assert Derivative(f(x),x).subs(x,g(x)) == Subs(Derivative(f(x),x), (x,), (g(x),))
-    assert Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).n(1) == \
-        Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).evalf(1) == \
-        z + Rational('1/2').n(1)*f(0)
+    assert Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).n(2) == \
+        Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).evalf(2) == \
+        z + Rational('1/2').n(2)*f(0)
 
 @XFAIL
 def test_Subs2():

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1231,8 +1231,8 @@ def test_issue882():
 def test_evalf():
     a = Matrix([sqrt(5), 6])
     assert all(a.evalf()[i] == a[i].evalf() for i in range(2))
-    assert all(a.evalf(1)[i] == a[i].evalf(1) for i in range(2))
-    assert all(a.n(1)[i] == a[i].n(1) for i in range(2))
+    assert all(a.evalf(2)[i] == a[i].evalf(2) for i in range(2))
+    assert all(a.n(2)[i] == a[i].n(2) for i in range(2))
 
 def test_is_symbolic():
     x = Symbol('x')

--- a/sympy/physics/tests/test_units.py
+++ b/sympy/physics/tests/test_units.py
@@ -7,7 +7,7 @@ def test_units():
     assert (5*m/s * day) / km == 432
     assert foot / meter == Rational('0.3048')
     # amu is a pure mass so mass/mass gives a number, not an amount (mol)
-    assert str(grams/(amu).n(1)) == '6.e+23'
+    assert str(grams/(amu).n(2)) == '6.0e+23'
 
     # Light from the sun needs about 8.3 minutes to reach earth
     t = (1*au / speed_of_light).evalf() / minute

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -304,7 +304,7 @@ def test_Float():
     assert str(pi.evalf(1+14))  == '3.14159265358979'
     assert str(pi.evalf(1+64))  == '3.1415926535897932384626433832795028841971693993751058209749445923'
     assert str(pi.round(-1)) == '0.'
-    assert str((pi**400 - (pi**400).round(1)).n(1)) == '-0.e+91'
+    assert str((pi**400 - (pi**400).round(1)).n(2)) == '-0.e+88'
 
 def test_Relational():
     assert str(Rel(x, y, "<")) == "x < y"


### PR DESCRIPTION
Don't use `n(1)` or `evalf(1)`.  See [issue 3235](http://code.google.com/p/sympy/issues/detail?id=3235) (which this fixes) for more information.  

I'd like a verification from someone familiar with the core code I've modified that this is correct.  

Also, can someone look at the change in the printing test.  Is that right?  Is this a consistant value (i.e., something we should be testing)?
