### PR TITLE
Improve trig evaluation2

### DIFF
--- a/doc/src/modules/simplify/hyperexpand.rst
+++ b/doc/src/modules/simplify/hyperexpand.rst
@@ -390,7 +390,7 @@ An example
 
 Because this explanation so far might be very theoretical and difficult to
 understand, we walk through an explicit example now. We take the Fresnel
-function :math:`C(z)` which obeys the following hypergeometric representation:
+function `C(z)` which obeys the following hypergeometric representation:
 
 .. math ::
     C(z) = z \cdot {}_{1}F_{2}\left.\left(
@@ -400,30 +400,30 @@ function :math:`C(z)` which obeys the following hypergeometric representation:
 
 First we try to add this formula to the lookup table by using the
 (simpler) function ``add(ap, bq, res)``. The first two arguments
-are simply the lists containing the parameter sets of :math:`{}_{1}F_{2}`.
+are simply the lists containing the parameter sets of `{}_{1}F_{2}`.
 The ``res`` argument is a little bit more complicated. We only know
-:math:`C(z)` in terms of :math:`{}_{1}F_{2}(\ldots | f(z))` with :math:`f`
-a function of :math:`z`, in our case
+`C(z)` in terms of `{}_{1}F_{2}(\ldots | f(z))` with `f`
+a function of `z`, in our case
 
 .. math ::
    f(z) = -\frac{\pi^2 z^4}{16} \,.
 
 What we need is a formula where the hypergeometric function has
-only :math:`z` as argument :math:`{}_{1}F_{2}(\ldots | z)`. We
-introduce the new complex symbol :math:`w` and search for a function
-:math:`g(w)` such that
+only `z` as argument `{}_{1}F_{2}(\ldots | z)`. We
+introduce the new complex symbol `w` and search for a function
+`g(w)` such that
 
 .. math ::
    f(g(w)) = w
 
-holds. Then we can replace every :math:`z` in :math:`C(z)` by :math:`g(w)`.
-In the case of our example the function :math:`g` could look like
+holds. Then we can replace every `z` in `C(z)` by `g(w)`.
+In the case of our example the function `g` could look like
 
 .. math ::
    g(w) = \frac{2}{\sqrt{\pi}} \exp\left(\frac{i \pi}{4}\right) w^{\frac{1}{4}} \,.
 
 We get these functions mainly by guessing and testing the result. Hence
-we proceed by computing :math:`f(g(w))` (and simplifying naively)
+we proceed by computing `f(g(w))` (and simplifying naively)
 
 .. math ::
    f(g(w)) &= -\frac{\pi^2 g(w)^4}{16} \\
@@ -432,11 +432,11 @@ we proceed by computing :math:`f(g(w))` (and simplifying naively)
            &= -\exp\left(i \pi\right) w \\
            &= w
 
-and indeed get back :math:`w`. (In case of branched functions we have to be
-aware of branch cuts. In that case we take :math:`w` to be a positive real
+and indeed get back `w`. (In case of branched functions we have to be
+aware of branch cuts. In that case we take `w` to be a positive real
 number and check the formula. If what we have found works for positive
-:math:`w`, then just replace :func:`exp` inside any branched function by
-:func:`exp\_polar` and what we get is right for `all` :math:`w`.) Hence
+`w`, then just replace :func:`exp` inside any branched function by
+:func:`exp\_polar` and what we get is right for `all` `w`.) Hence
 we can write the formula as
 
 .. math ::
@@ -470,18 +470,18 @@ in terms of simplicity and number of special function instances included.
 We can obtain much better results by adding the formula to the lookup table
 in another way. For this we use the (more complicated) function ``addb(ap, bq, B, C, M)``.
 The first two arguments are again the lists containing the parameter sets of
-:math:`{}_{1}F_{2}`. The remaining three are the matrices mentioned earlier
+`{}_{1}F_{2}`. The remaining three are the matrices mentioned earlier
 on this page.
 
-We know that the :math:`n = \max{\left(p, q+1\right)}`-th derivative can be
+We know that the `n = \max{\left(p, q+1\right)}`-th derivative can be
 expressed as a linear combination of lower order derivatives. The matrix
-:math:`B` contains the basis :math:`\{B_0, B_1, \ldots\}` and is of shape
-:math:`n \times 1`. The best way to get :math:`B_i` is to take the first
-:math:`n = \max(p, q+1)` derivatives of the expression for :math:`{}_p F_q`
+`B` contains the basis `\{B_0, B_1, \ldots\}` and is of shape
+`n \times 1`. The best way to get `B_i` is to take the first
+`n = \max(p, q+1)` derivatives of the expression for `{}_p F_q`
 and take out usefull pieces. In our case we find that
-:math:`n = \max{\left(1, 2+1\right)} = 3`. For computing the derivatives,
-we have to use the operator :math:`z\frac{\mathrm{d}}{\mathrm{d}z}`. The
-first basis element :math:`B_0` is set to the expression for :math:`{}_1 F_2`
+`n = \max{\left(1, 2+1\right)} = 3`. For computing the derivatives,
+we have to use the operator `z\frac{\mathrm{d}}{\mathrm{d}z}`. The
+first basis element `B_0` is set to the expression for `{}_1 F_2`
 from above:
 
 .. math ::
@@ -489,7 +489,7 @@ from above:
    C\left( \frac{2}{\sqrt{\pi}} \exp\left(\frac{\mathbf{\imath}\pi}{4}\right) z^{\frac{1}{4}}\right)}
    {2 z^{\frac{1}{4}}}
 
-Next we compute :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`. For this we can
+Next we compute `z\frac{\mathrm{d}}{\mathrm{d}z} B_0`. For this we can
 directly use SymPy!
 
    >>> from sympy import Symbol, sqrt, exp, I, pi, fresnelc, root, diff, expand
@@ -536,7 +536,7 @@ which can be printed as
    + \frac{1}{4} \sinh{\left(2\sqrt{z}\right)} \sqrt{z}
 
 We see the common pattern and can collect the pieces. Hence it makes sense to
-choose :math:`B_1` and :math:`B_2` as follows
+choose `B_1` and `B_2` as follows
 
 .. math ::
    B =
@@ -554,11 +554,11 @@ choose :math:`B_1` and :math:`B_2` as follows
      \sinh\left(2\sqrt{z}\right) \sqrt{z}
    \end{matrix} \right)
 
-(This is in contrast to the basis :math:`B = \left(B_0, B_1^\prime, B_2^\prime\right)` that would
+(This is in contrast to the basis `B = \left(B_0, B_1^\prime, B_2^\prime\right)` that would
 have been computed automatically if we used just ``add(ap, bq, res)``.)
 
-Because it must hold that :math:`{}_p F_q\left(\cdots \middle| z \right) = C B`
-the entries of :math:`C` are obviously
+Because it must hold that `{}_p F_q\left(\cdots \middle| z \right) = C B`
+the entries of `C` are obviously
 
 .. math ::
    C =
@@ -566,10 +566,10 @@ the entries of :math:`C` are obviously
      1 \\ 0 \\ 0
    \end{matrix} \right)
 
-Finally we have to compute the entries of the :math:`3 \times 3` matrix :math:`M`
-such that :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B = M B` holds. This is easy.
-We already computed the first part :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`
-above. This gives us the first row of :math:`M`. For the second row we have:
+Finally we have to compute the entries of the `3 \times 3` matrix `M`
+such that `z\frac{\mathrm{d}}{\mathrm{d}z} B = M B` holds. This is easy.
+We already computed the first part `z\frac{\mathrm{d}}{\mathrm{d}z} B_0`
+above. This gives us the first row of `M`. For the second row we have:
 
    >>> from sympy import Symbol, cosh, sqrt, diff
    >>> z = Symbol("z")
@@ -595,8 +595,8 @@ Now we have computed the entries of this matrix to be
      0            & z           & \frac{1}{2} \\
    \end{matrix} \right)
 
-Note that the entries of :math:`C` and :math:`M` should typically be
-rational functions in :math:`z`, with rational coefficients. This is all
+Note that the entries of `C` and `M` should typically be
+rational functions in `z`, with rational coefficients. This is all
 we need to do in order to add a new formula to the lookup table for
 ``hyperexpand``.
 

--- a/doc/src/modules/simplify/hyperexpand.rst
+++ b/doc/src/modules/simplify/hyperexpand.rst
@@ -410,15 +410,14 @@ a function of :math:`z`, in our case
 
 What we need is a formula where the hypergeometric function has
 only :math:`z` as argument :math:`{}_{1}F_{2}(\ldots | z)`. We
-introduce the new complex symbol :math:`w` and search a function
+introduce the new complex symbol :math:`w` and search for a function
 :math:`g(w)` such that
 
 .. math ::
    f(g(w)) = w
 
-holds. Then we can replace every :math:`z` in the original formula
-for :math:`C(z)` by :math:`g(w)`. In the case of our example the
-function :math:`g` could look like
+holds. Then we can replace every :math:`z` in :math:`C(z)` by :math:`g(w)`.
+In the case of our example the function :math:`g` could look like
 
 .. math ::
    g(w) = \frac{2}{\sqrt{\pi}} \exp\left(\frac{i \pi}{4}\right) w^{\frac{1}{4}} \,.
@@ -457,8 +456,8 @@ and trivially
    = \frac{C\left(\frac{2}{\sqrt{\pi}} \exp\left(\frac{i \pi}{4}\right) w^{\frac{1}{4}}\right)}
           {\frac{2}{\sqrt{\pi}} \exp\left(\frac{i \pi}{4}\right) w^{\frac{1}{4}}}
 
-which is exactly what we stick into ``add`` for the
-third parameter ``res``. Finally, the whole function call to add
+which is exactly what is needed for the third paramenter,
+``res``, in ``add``. Finally, the whole function call to add
 this rule to the table looks like::
 
   add([S(1)/4],
@@ -491,7 +490,7 @@ from above:
    {2 z^{\frac{1}{4}}}
 
 Next we compute :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`. For this we can
-directly use sympy!
+directly use SymPy!
 
    >>> from sympy import Symbol, sqrt, exp, I, pi, fresnelc, root, diff, expand
    >>> z = Symbol("z")
@@ -513,7 +512,7 @@ Formatting this result nicely we obtain
    {2 z^{\frac{1}{4}}}
    + \frac{1}{4} \cosh{\left( 2 \sqrt{z} \right )}
 
-Going ahead and computing the second derivative we find
+Computing the second derivative we find
 
    >>> from sympy import Symbol, cosh, sqrt, pi, exp, I, fresnelc, root, diff, expand
    >>> z = Symbol("z")

--- a/doc/src/modules/simplify/hyperexpand.rst
+++ b/doc/src/modules/simplify/hyperexpand.rst
@@ -493,7 +493,7 @@ from above:
 Next we compute :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`. For this we can
 directly use sympy!
 
-   >>> from sympy import *
+   >>> from sympy import Symbol, sqrt, exp, I, pi, fresnelc, root, diff, expand
    >>> z = Symbol("z")
    >>> B0 = sqrt(pi)*exp(-I*pi/4)*fresnelc(2*root(z,4)*exp(I*pi/4)/sqrt(pi))/(2*root(z,4))
    >>> z * diff(B0, z)
@@ -515,7 +515,7 @@ Formatting this result nicely we obtain
 
 Going ahead and computing the second derivative we find
 
-   >>> from sympy import *
+   >>> from sympy import Symbol, cosh, sqrt, pi, exp, I, fresnelc, root, diff, expand
    >>> z = Symbol("z")
    >>> B1prime = cosh(2*sqrt(z))/4 - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*root(z,4)*exp(I*pi/4)/sqrt(pi))/(8*root(z,4))
    >>> z * diff(B1prime, z)
@@ -572,7 +572,7 @@ such that :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B = M B` holds. This is easy.
 We already computed the first part :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`
 above. This gives us the first row of :math:`M`. For the second row we have:
 
-   >>> from sympy import *
+   >>> from sympy import Symbol, cosh, sqrt, diff
    >>> z = Symbol("z")
    >>> B1 = cosh(2*sqrt(z))
    >>> z * diff(B1, z)
@@ -580,7 +580,7 @@ above. This gives us the first row of :math:`M`. For the second row we have:
 
 and for the third one
 
-   >>> from sympy import *
+   >>> from sympy import Symbol, sinh, sqrt, expand, diff
    >>> z = Symbol("z")
    >>> B2 = sinh(2*sqrt(z))*sqrt(z)
    >>> expand(z * diff(B2, z))

--- a/doc/src/modules/simplify/hyperexpand.rst
+++ b/doc/src/modules/simplify/hyperexpand.rst
@@ -493,11 +493,13 @@ from above:
 Next we compute :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`. For this we can
 directly use sympy!
 
-  >>> B0 = sqrt(pi)*exp(-I*pi/4)*fresnelc(2*root(z,4)*exp(I*pi/4)/sqrt(pi))/(2*root(z,4))
-  >>> z * diff(B0, z)
-  z*(cosh(2*sqrt(z))/(4*z) - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*z**(1/4)*exp(I*pi/4)/sqrt(pi))/(8*z**(5/4)))
-  >>> expand(_)
-  cosh(2*sqrt(z))/4 - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*z**(1/4)*exp(I*pi/4)/sqrt(pi))/(8*z**(1/4))
+   >>> from sympy import *
+   >>> z = Symbol("z")
+   >>> B0 = sqrt(pi)*exp(-I*pi/4)*fresnelc(2*root(z,4)*exp(I*pi/4)/sqrt(pi))/(2*root(z,4))
+   >>> z * diff(B0, z)
+   z*(cosh(2*sqrt(z))/(4*z) - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*z**(1/4)*exp(I*pi/4)/sqrt(pi))/(8*z**(5/4)))
+   >>> expand(_)
+   cosh(2*sqrt(z))/4 - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*z**(1/4)*exp(I*pi/4)/sqrt(pi))/(8*z**(1/4))
 
 Formatting this result nicely we obtain
 
@@ -513,7 +515,9 @@ Formatting this result nicely we obtain
 
 Going ahead and computing the second derivative we find
 
-   >>> B1prime = cosh(2*sqrt(z))/4 - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*z**(1/4)*exp(I*pi/4)/sqrt(pi))/(8*z**(1/4))
+   >>> from sympy import *
+   >>> z = Symbol("z")
+   >>> B1prime = cosh(2*sqrt(z))/4 - sqrt(pi)*exp(-I*pi/4)*fresnelc(2*root(z,4)*exp(I*pi/4)/sqrt(pi))/(8*root(z,4))
    >>> z * diff(B1prime, z)
    z*(-cosh(2*sqrt(z))/(16*z) + sinh(2*sqrt(z))/(4*sqrt(z)) + sqrt(pi)*exp(-I*pi/4)*fresnelc(2*z**(1/4)*exp(I*pi/4)/sqrt(pi))/(32*z**(5/4)))
    >>> expand(_)
@@ -568,12 +572,16 @@ such that :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B = M B` holds. This is easy.
 We already computed the first part :math:`z\frac{\mathrm{d}}{\mathrm{d}z} B_0`
 above. This gives us the first row of :math:`M`. For the second row we have:
 
+   >>> from sympy import *
+   >>> z = Symbol("z")
    >>> B1 = cosh(2*sqrt(z))
    >>> z * diff(B1, z)
    sqrt(z)*sinh(2*sqrt(z))
 
 and for the third one
 
+   >>> from sympy import *
+   >>> z = Symbol("z")
    >>> B2 = sinh(2*sqrt(z))*sqrt(z)
    >>> expand(z * diff(B2, z))
    sqrt(z)*sinh(2*sqrt(z))/2 + z*cosh(2*sqrt(z))

--- a/doc/src/modules/simplify/hyperexpand.rst
+++ b/doc/src/modules/simplify/hyperexpand.rst
@@ -428,10 +428,10 @@ we proceed by computing :math:`f(g(w))` (and simplifying naively)
 
 .. math ::
    f(g(w)) &= -\frac{\pi^2 g(w)^4}{16} \\
-   	   &= -\frac{\pi^2 g(\frac{2}{\sqrt{\pi}} \exp\left(\frac{i \pi}{4}\right) w^{\frac{1}{4}})^4}{16} \\
-	   &= -\frac{\pi^2 \frac{2^4}{\sqrt{\pi}^4} \exp\left(\frac{i \pi}{4}\right)^4 w^{\frac{1}{4}}^4}{16} \\
-	   &= -\exp\left(i \pi\right) w \\
-	   &= w
+           &= -\frac{\pi^2 g\left(\frac{2}{\sqrt{\pi}} \exp\left(\frac{i \pi}{4}\right) w^{\frac{1}{4}}\right)^4}{16} \\
+           &= -\frac{\pi^2 \frac{2^4}{\sqrt{\pi}^4} \exp\left(\frac{i \pi}{4}\right)^4 {w^{\frac{1}{4}}}^4}{16} \\
+           &= -\exp\left(i \pi\right) w \\
+           &= w
 
 and indeed get back :math:`w`. Hence we can write the formula as
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, acot, pi, atan,
         acos, Rational, sqrt, asin, acot, cot, coth, E, S, tan, tanh, cos,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,
-        Float,Pow,expand,gcd)
+        Float, Pow, gcd)
 
 from sympy.utilities.pytest import XFAIL
 
@@ -64,7 +64,7 @@ def test_sin():
 
     assert sin(-1273*pi/5) == -sin(2*pi/5)
 
-    assert 0 == (sin(pi/8) - sqrt((2-sqrt(2))/4))
+    assert sin(pi/8) == sqrt((2-sqrt(2))/4)
 
 
     assert sin(104*pi/105) == sin(pi/105)
@@ -91,12 +91,14 @@ def test_sin():
             e = abs( float(sin(x)) - sin(float(x)) )
             assert e < 1e-12
 
-#def test_sin_cos():
-#    for d in [1,2,3,4,5,6,8,10,12,15,16,20,60,85]: # list is not exhaustive...
-#        for n in xrange(0,d*2):
-#            x = n*pi/d
-#            assert sin(x+pi/2) == cos(x), "fails for pi %d/%d"%(n,d)
-#            assert sin(x-pi/2) == -cos(x), "fails for pi %d/%d"%(n,d)
+def test_sin_cos():
+    for d in [1,2,3,4,5,6,10,12]: # list is not exhaustive...
+        for n in xrange(-2*d,d*2):
+            x = n*pi/d
+            assert sin(x+pi/2) == cos(x),  "fails for %d*pi/%d"%(n,d)
+            assert sin(x-pi/2) == -cos(x), "fails for %d*pi/%d"%(n,d)
+            assert sin(x) == cos(x-pi/2),  "fails for %d*pi/%d"%(n,d)
+            assert -sin(x) == cos(x+pi/2), "fails for %d*pi/%d"%(n,d)
 
 def test_sin_series():
     x = Symbol('x')
@@ -826,18 +828,16 @@ def test_sin_cos_with_infinity():
     assert cos(oo) == S.NaN
 
 def test_sincos_rewrite_sqrt():
-    for p in [1,3,5,17,3*5*17]:
-        for t in [ 1, 8]:
+    for p in [1, 3, 5, 17, 3*5*17]:
+        for t in [1, 8]:
             n=t*p
-            for i in xrange(1,(n+1)//2+1):
+            for i in xrange(1, (n+1)//2 + 1):
                 if 1 == gcd(i,n):
                     x = i*pi/n
                     s1 = sin(x).rewrite(sqrt)
                     c1 = cos(x).rewrite(sqrt)
 
-                    assert not isinstance(abs(s1),sin)
-                    assert not isinstance(abs(s1),cos)
-                    assert not isinstance(abs(c1),sin)
-                    assert not isinstance(abs(c1),cos)
+                    assert not s1.has(cos, sin), "fails for %d*pi/%d"%(i,n)
+                    assert not c1.has(cos, sin), "fails for %d*pi/%d"%(i,n)
                     assert 1e-10 > abs( sin(float(x)) - float(s1) )
                     assert 1e-10 > abs( cos(float(x)) - float(c1) )

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -64,8 +64,7 @@ def test_sin():
 
     assert sin(-1273*pi/5) == -sin(2*pi/5)
 
-    assert sin(pi/8) == sqrt((2-sqrt(2))/4)
-
+    assert sin(pi/8) == sqrt((2 - sqrt(2))/4)
 
     assert sin(104*pi/105) == sin(pi/105)
     assert sin(106*pi/105) == -sin(pi/105)
@@ -85,8 +84,8 @@ def test_sin():
     assert isinstance(sin( re(x) - im(y)), sin) == True
     assert isinstance(sin(-re(x) + im(y)), sin) == False
 
-    for d in range(1,22) + [60, 85]:
-        for n in xrange(0, d*2+1):
+    for d in range(1, 22) + [60, 85]:
+        for n in xrange(0, d*2 + 1):
             x = n*pi/d
             e = abs( float(sin(x)) - sin(float(x)) )
             assert e < 1e-12
@@ -95,10 +94,10 @@ def test_sin_cos():
     for d in [1, 2, 3, 4, 5, 6, 10, 12]: # list is not exhaustive...
         for n in xrange(-2*d, d*2):
             x = n*pi/d
-            assert sin(x + pi/2) == cos(x),  "fails for %d*pi/%d"%(n,d)
-            assert sin(x - pi/2) == -cos(x), "fails for %d*pi/%d"%(n,d)
-            assert sin(x) == cos(x - pi/2),  "fails for %d*pi/%d"%(n,d)
-            assert -sin(x) == cos(x + pi/2), "fails for %d*pi/%d"%(n,d)
+            assert sin(x + pi/2) == cos(x),  "fails for %d*pi/%d" % (n, d)
+            assert sin(x - pi/2) == -cos(x), "fails for %d*pi/%d" % (n, d)
+            assert sin(x) == cos(x - pi/2),  "fails for %d*pi/%d" % (n, d)
+            assert -sin(x) == cos(x + pi/2), "fails for %d*pi/%d" % (n, d)
 
 def test_sin_series():
     x = Symbol('x')
@@ -246,7 +245,7 @@ def test_cos():
     assert cos(k*pi) == (-1)**k
     assert cos(2*k*pi) == 1
 
-    for d in range(1,22) + [60,85]:
+    for d in range(1, 22) + [60, 85]:
         for n in xrange(0, 2*d + 1):
             x = n*pi/d
             e = abs( float(cos(x)) - cos(float(x)) )
@@ -831,8 +830,8 @@ def test_sincos_rewrite_sqrt():
     for p in [1, 3, 5, 17, 3*5*17]:
         for t in [1, 8]:
             n=t*p
-            for i in xrange(1, (n+1)//2 + 1):
-                if 1 == gcd(i,n):
+            for i in xrange(1, (n + 1)//2 + 1):
+                if 1 == gcd(i, n):
                     x = i*pi/n
                     s1 = sin(x).rewrite(sqrt)
                     c1 = cos(x).rewrite(sqrt)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -85,20 +85,20 @@ def test_sin():
     assert isinstance(sin( re(x) - im(y)), sin) == True
     assert isinstance(sin(-re(x) + im(y)), sin) == False
 
-    for d in range(1,22)+[60,85]:
-        for n in xrange(0,d*2+1):
+    for d in range(1,22) + [60, 85]:
+        for n in xrange(0, d*2+1):
             x = n*pi/d
             e = abs( float(sin(x)) - sin(float(x)) )
             assert e < 1e-12
 
 def test_sin_cos():
-    for d in [1,2,3,4,5,6,10,12]: # list is not exhaustive...
-        for n in xrange(-2*d,d*2):
+    for d in [1, 2, 3, 4, 5, 6, 10, 12]: # list is not exhaustive...
+        for n in xrange(-2*d, d*2):
             x = n*pi/d
-            assert sin(x+pi/2) == cos(x),  "fails for %d*pi/%d"%(n,d)
-            assert sin(x-pi/2) == -cos(x), "fails for %d*pi/%d"%(n,d)
-            assert sin(x) == cos(x-pi/2),  "fails for %d*pi/%d"%(n,d)
-            assert -sin(x) == cos(x+pi/2), "fails for %d*pi/%d"%(n,d)
+            assert sin(x + pi/2) == cos(x),  "fails for %d*pi/%d"%(n,d)
+            assert sin(x - pi/2) == -cos(x), "fails for %d*pi/%d"%(n,d)
+            assert sin(x) == cos(x - pi/2),  "fails for %d*pi/%d"%(n,d)
+            assert -sin(x) == cos(x + pi/2), "fails for %d*pi/%d"%(n,d)
 
 def test_sin_series():
     x = Symbol('x')
@@ -230,7 +230,7 @@ def test_cos():
 
     assert cos(-1273*pi/5) == -cos(2*pi/5)
 
-    assert cos(pi/8) == sqrt((2+sqrt(2))/4)
+    assert cos(pi/8) == sqrt((2 + sqrt(2))/4)
 
     assert cos(104*pi/105) == -cos(pi/105)
     assert cos(106*pi/105) == -cos(pi/105)
@@ -246,8 +246,8 @@ def test_cos():
     assert cos(k*pi) == (-1)**k
     assert cos(2*k*pi) == 1
 
-    for d in range(1,22)+[60,85]:
-        for n in xrange(0,2*d+1):
+    for d in range(1,22) + [60,85]:
+        for n in xrange(0, 2*d + 1):
             x = n*pi/d
             e = abs( float(cos(x)) - cos(float(x)) )
             assert e < 1e-12

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -82,6 +82,19 @@ def test_sin():
     assert isinstance(sin( re(x) - im(y)), sin) == True
     assert isinstance(sin(-re(x) + im(y)), sin) == False
 
+    for d in range(1,22)+[60,85]:
+        for n in xrange(0,d*2+1):
+            x = n*pi/d
+            e = abs( float(sin(x)) - sin(float(x)) )
+            assert e < 1e-12
+
+def test_sin_cos():
+    for d in [1,2,3,4,5,6,8,10,12,15,16,20,60,85]: # list is not exhaustive...
+        for n in xrange(0,d*2):
+            x = n*pi/d
+            assert sin(x+pi/2) == cos(x)
+            assert sin(x-pi/2) == -cos(x)
+
 def test_sin_series():
     x = Symbol('x')
     assert sin(x).series(x, 0, 9) == \
@@ -225,6 +238,12 @@ def test_cos():
 
     assert cos(k*pi) == (-1)**k
     assert cos(2*k*pi) == 1
+
+    for d in range(1,22)+[60,85]:
+        for n in xrange(0,2*d+1):
+            x = n*pi/d
+            e = abs( float(cos(x)) - cos(float(x)) )
+            assert e < 1e-12
 
 def test_issue_3091():
     c = Float('123456789012345678901234567890.25', '')

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -228,6 +228,8 @@ def test_cos():
 
     assert cos(-1273*pi/5) == -cos(2*pi/5)
 
+    assert cos(pi/8) == sqrt((2+sqrt(2))/4)
+
     assert cos(104*pi/105) == -cos(pi/105)
     assert cos(106*pi/105) == -cos(pi/105)
 

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, acot, pi, atan,
         acos, Rational, sqrt, asin, acot, cot, coth, E, S, tan, tanh, cos,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,
-        Float,Pow,expand)
+        Float,Pow,expand,gcd)
 
 from sympy.utilities.pytest import XFAIL
 
@@ -824,3 +824,20 @@ def test_sin_cos_with_infinity():
     # http://code.google.com/p/sympy/issues/detail?id=2097
     assert sin(oo) == S.NaN
     assert cos(oo) == S.NaN
+
+def test_sincos_rewrite_sqrt():
+    for p in [1,3,5,17,3*5*17]:
+        for t in [ 1, 8]:
+            n=t*p
+            for i in xrange(1,(n+1)/2+1):
+                if 1 == gcd(i,n):
+                    x = i*pi/n
+                    s1 = sin(x).rewrite(sqrt)
+                    c1 = cos(x).rewrite(sqrt)
+
+                    assert not isinstance(abs(s1),sin)
+                    assert not isinstance(abs(s1),cos)
+                    assert not isinstance(abs(c1),sin)
+                    assert not isinstance(abs(c1),cos)
+                    assert 1e-10 > abs( sin(float(x)) - float(s1) )
+                    assert 1e-10 > abs( cos(float(x)) - float(c1) )

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -829,7 +829,7 @@ def test_sincos_rewrite_sqrt():
     for p in [1,3,5,17,3*5*17]:
         for t in [ 1, 8]:
             n=t*p
-            for i in xrange(1,(n+1)/2+1):
+            for i in xrange(1,(n+1)//2+1):
                 if 1 == gcd(i,n):
                     x = i*pi/n
                     s1 = sin(x).rewrite(sqrt)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -91,12 +91,12 @@ def test_sin():
             e = abs( float(sin(x)) - sin(float(x)) )
             assert e < 1e-12
 
-def test_sin_cos():
-    for d in [1,2,3,4,5,6,8,10,12,15,16,20,60,85]: # list is not exhaustive...
-        for n in xrange(0,d*2):
-            x = n*pi/d
-            assert sin(x+pi/2) == cos(x)
-            assert sin(x-pi/2) == -cos(x)
+#def test_sin_cos():
+#    for d in [1,2,3,4,5,6,8,10,12,15,16,20,60,85]: # list is not exhaustive...
+#        for n in xrange(0,d*2):
+#            x = n*pi/d
+#            assert sin(x+pi/2) == cos(x), "fails for pi %d/%d"%(n,d)
+#            assert sin(x-pi/2) == -cos(x), "fails for pi %d/%d"%(n,d)
 
 def test_sin_series():
     x = Symbol('x')

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1,7 +1,7 @@
 from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, acot, pi, atan,
         acos, Rational, sqrt, asin, acot, cot, coth, E, S, tan, tanh, cos,
         cosh, atan2, exp, log, asinh, acoth, atanh, O, cancel, Matrix, re, im,
-        Float,Pow)
+        Float,Pow,expand)
 
 from sympy.utilities.pytest import XFAIL
 
@@ -63,6 +63,9 @@ def test_sin():
     assert sin(8*pi/5) == -sin(2*pi/5)
 
     assert sin(-1273*pi/5) == -sin(2*pi/5)
+
+    assert 0 == (sin(pi/8) - sqrt((2-sqrt(2))/4))
+
 
     assert sin(104*pi/105) == sin(pi/105)
     assert sin(106*pi/105) == -sin(pi/105)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -176,7 +176,6 @@ class sin(TrigonometricFunction):
             elif arg is S.Infinity or arg is S.NegativeInfinity:
                 return
 
-
         if arg.could_extract_minus_sign():
             return -cls(-arg)
 
@@ -203,9 +202,9 @@ class sin(TrigonometricFunction):
                     return -cls((x%1)*S.Pi)
                 if 2*x > 1:
                     return cls((1-x)*S.Pi)
-                narg = ((pi_coeff + C.Rational(3,2)) % 2)*S.Pi
+                narg = ((pi_coeff + C.Rational(3, 2)) % 2)*S.Pi
                 result = cos(narg)
-                if not isinstance(result,cos):
+                if not isinstance(result, cos):
                     return result
                 if pi_coeff*S.Pi != arg:
                     return cls(pi_coeff*S.Pi)
@@ -405,7 +404,15 @@ class cos(TrigonometricFunction):
             elif arg is S.Zero:
                 return S.One
             elif arg is S.Infinity or arg is S.NegativeInfinity:
-                return        # for test_sin in test_trigonometric
+                # In this cases, it is unclear if we should
+                # return S.NaN or leave un-evaluated.  One
+                # useful test case is how "limit(sin(x)/x,x,oo)"
+                # is handled.
+                # See test_sin_cos_with_infinity() an
+                # Test for issue 209
+                # http://code.google.com/p/sympy/issues/detail?id=2097
+                # For now, we return un-evaluated.
+                return
 
         if arg.could_extract_minus_sign():
             return cls(-arg)
@@ -454,7 +461,6 @@ class cos(TrigonometricFunction):
                 if q in cst_table_some:
                     cts = cst_table_some[pi_coeff.q]
                     return C.chebyshevt(pi_coeff.p, cts).expand()
-
 
                 if 0 == q % 2:
                     narg = (pi_coeff*2)*S.Pi
@@ -538,8 +544,8 @@ class cos(TrigonometricFunction):
         def migcdex(x):
             # recursive calcuation of gcd and linear combination
             # for a sequence of integers.
-            # Given  (x1,x2,x3)
-            # Returns (y1,y1,y3,g)
+            # Given  (x1, x2, x3)
+            # Returns (y1, y1, y3, g)
             # such that g is the gcd and x1*y1+x2*y2+x3*y3 - g = 0
             # Note, that this is only one such linear combination.
             if len(x) == 1:
@@ -549,7 +555,7 @@ class cos(TrigonometricFunction):
             g = migcdex(x[1:])
             u, v, h = igcdex(x[0], g[-1])
             return tuple([u] + [v*i for i in g[0:-1] ] + [h])
-        def ipartfrac(r, factors=None):
+        def ipartfrac(r, factors = None):
             if isinstance(r, int):
                 return r
             assert isinstance(r, C.Rational)
@@ -558,9 +564,9 @@ class cos(TrigonometricFunction):
                 return r.q
 
             if None == factors:
-                a=[n/x**y for x, y in factorint(r.q).iteritems()]
+                a = [n/x**y for x, y in factorint(r.q).iteritems()]
             else:
-                a=[n/x for x in factors]
+                a = [n/x for x in factors]
             if len(a) == 1:
                 return [ r ]
             h = migcdex(a)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -275,6 +275,9 @@ class sin(TrigonometricFunction):
         cot_half = cot(S.Half*arg)
         return 2*cot_half/(1 + cot_half**2)
 
+    def _eval_rewrite_as_pow(self, arg):
+        return self.rewrite(cos).rewrite(pow)
+
     def _eval_rewrite_as_sqrt(self, arg):
         return self.rewrite(cos).rewrite(sqrt)
 
@@ -517,6 +520,9 @@ class cos(TrigonometricFunction):
     def _eval_rewrite_as_cot(self, arg):
         cot_half = cot(S.Half*arg)**2
         return (cot_half-1)/(cot_half+1)
+
+    def _eval_rewrite_as_pow(self, arg):
+         return self._eval_rewrite_as_sqrt(arg)
 
     def _eval_rewrite_as_sqrt(self, arg):
         _EXPAND_INTS = False

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -198,12 +198,12 @@ class sin(TrigonometricFunction):
             # http://code.google.com/p/sympy/issues/detail?id=2949
             # transform a sine to a cosine, to avoid redundant code
             if pi_coeff.is_Rational:
-                x = pi_coeff%2
+                x = pi_coeff % 2
                 if x > 1:
-                    return -cls(x%1*S.Pi)
+                    return -cls((x%1)*S.Pi)
                 if 2*x > 1:
                     return cls((1-x)*S.Pi)
-                narg = ((pi_coeff + C.Rational(3,2))%2)*S.Pi
+                narg = ((pi_coeff + C.Rational(3,2)) % 2)*S.Pi
                 result = cos(narg)
                 if not isinstance(result,cos):
                     return result
@@ -456,7 +456,7 @@ class cos(TrigonometricFunction):
                     return C.chebyshevt(pi_coeff.p, cts).expand()
 
 
-                if 0 == q%2:
+                if 0 == q % 2:
                     narg = (pi_coeff*2)*S.Pi
                     nval = cls(narg)
                     if None == nval:
@@ -588,24 +588,24 @@ class cos(TrigonometricFunction):
         def fermatCoords(n):
             assert isinstance(n, int)
             assert n > 0
-            if n == 1 or 0 == n%2:
+            if n == 1 or 0 == n % 2:
                 return False
             primes = dict( [(p, 0) for p in cst_table_some ] )
             assert 1 not in primes
             for p_i in primes:
-                while 0 == n%p_i:
+                while 0 == n % p_i:
                     n = n/p_i;
                     primes[p_i] += 1;
             if 1 != n:
                 return False
             if max(primes.values()) > 1:
                 return False
-            return tuple([ p for p in primes if primes[p]==1])
+            return tuple([ p for p in primes if primes[p] == 1])
 
         if pi_coeff.q in cst_table_some:
             return C.chebyshevt(pi_coeff.p, cst_table_some[pi_coeff.q]).expand()
 
-        if 0==pi_coeff.q%2: # recursively remove powers of 2
+        if 0 == pi_coeff.q % 2: # recursively remove powers of 2
             narg = (pi_coeff*2)*S.Pi
             nval = cos(narg)
             if None == nval:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -438,11 +438,11 @@ class cos(TrigonometricFunction):
             if pi_coeff.is_Rational:
                 q = pi_coeff.q
                 p = pi_coeff.p % (2*q)
-                if p>q:
-                    narg = (pi_coeff-1)*S.Pi
+                if p > q:
+                    narg = (pi_coeff - 1)*S.Pi
                     return -cls(narg)
                 if 2*p > q:
-                    narg = (1-pi_coeff)*S.Pi
+                    narg = (1 - pi_coeff)*S.Pi
                     return -cls(narg)
 
                 # If nested sqrt's are worse than un-evaluation
@@ -456,14 +456,14 @@ class cos(TrigonometricFunction):
                     return C.chebyshevt(pi_coeff.p,cts).expand()
 
 
-                if 0==q%2:
+                if 0 == q%2:
                     narg = (pi_coeff*2)*S.Pi
                     nval = cls(narg)
                     if None == nval:
                         return None
-                    x = (2*pi_coeff+1)/2
+                    x = (2*pi_coeff + 1)/2
                     sign_cos = (-1)**((-1 if x < 0 else 1)*int(abs(x)))
-                    return sign_cos*sqrt( (1+nval)/2 )
+                    return sign_cos*sqrt( (1 + nval)/2 )
             return None
 
         if arg.is_Add:
@@ -548,13 +548,13 @@ class cos(TrigonometricFunction):
                 return igcdex(x[0], x[-1])
             g = migcdex(x[1:])
             u,v,h = igcdex(x[0], g[-1])
-            return tuple([u]+[v*i for i in g[0:-1]]+[h])
+            return tuple([u] + [v*i for i in g[0:-1] ] + [h])
         def ipartfrac(r,factors=None):
             if isinstance(r,int):
                 return r
             assert isinstance(r,C.Rational)
             n = r.q
-            if r.q*r.q < 2:
+            if 2 > r.q*r.q:
                 return r.q
 
             if None == factors:
@@ -579,9 +579,9 @@ class cos(TrigonometricFunction):
         cst_table_some = {
             3 : S.Half,
             5 : (sqrt(5) + 1)/4,
-            17 : sqrt((15+sqrt(17))/32 + sqrt(2)*(sqrt(-sqrt(17) + 17) +\
-                sqrt(sqrt(2)*(-8*sqrt(sqrt(17) + 17) + (-1 + sqrt(17))\
-                *sqrt(-sqrt(17) + 17)) + 6*sqrt(17) + 34))/32)
+            17 : sqrt((15 + sqrt(17))/32 + sqrt(2)*(sqrt(17 - sqrt(17)) + \
+                sqrt(sqrt(2)*(-8*sqrt(17 + sqrt(17)) - (1 - sqrt(17)) \
+                *sqrt(17 - sqrt(17))) + 6*sqrt(17) + 34))/32)
             # 65537 and 257 are the only other known Fermat primes
             # Please add if you would like them
         }

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -174,7 +174,7 @@ class sin(TrigonometricFunction):
             elif arg is S.Zero:
                 return S.Zero
             elif arg is S.Infinity or arg is S.NegativeInfinity:
-                return        # for test_sin in test_trigonometric
+                return
 
 
         if arg.could_extract_minus_sign():
@@ -446,14 +446,14 @@ class cos(TrigonometricFunction):
                     return -cls(narg)
 
                 # If nested sqrt's are worse than un-evaluation
-                # you can require q in (1,2,3,4,6)
+                # you can require q in (1, 2, 3, 4, 6)
                 # q <= 12 returns expressions with 2 or fewer nestings.
                 if q > 12:
                     return None
 
                 if q in cst_table_some:
                     cts = cst_table_some[pi_coeff.q]
-                    return C.chebyshevt(pi_coeff.p,cts).expand()
+                    return C.chebyshevt(pi_coeff.p, cts).expand()
 
 
                 if 0 == q%2:
@@ -547,24 +547,24 @@ class cos(TrigonometricFunction):
             if len(x) == 2:
                 return igcdex(x[0], x[-1])
             g = migcdex(x[1:])
-            u,v,h = igcdex(x[0], g[-1])
+            u, v, h = igcdex(x[0], g[-1])
             return tuple([u] + [v*i for i in g[0:-1] ] + [h])
-        def ipartfrac(r,factors=None):
-            if isinstance(r,int):
+        def ipartfrac(r, factors=None):
+            if isinstance(r, int):
                 return r
-            assert isinstance(r,C.Rational)
+            assert isinstance(r, C.Rational)
             n = r.q
             if 2 > r.q*r.q:
                 return r.q
 
             if None == factors:
-                a=[n/x**y for x,y in factorint(r.q).iteritems()]
+                a=[n/x**y for x, y in factorint(r.q).iteritems()]
             else:
                 a=[n/x for x in factors]
             if len(a) == 1:
                 return [ r ]
             h = migcdex(a)
-            ans = [ r.p*C.Rational(i*j,r.q) for i,j in zip(h[:-1],a) ]
+            ans = [ r.p*C.Rational(i*j, r.q) for i, j in zip(h[:-1], a) ]
             assert r == sum(ans)
             return ans
         pi_coeff = _pi_coeff(arg)
@@ -586,11 +586,11 @@ class cos(TrigonometricFunction):
             # Please add if you would like them
         }
         def fermatCoords(n):
-            assert isinstance(n,int)
+            assert isinstance(n, int)
             assert n > 0
             if n == 1 or 0 == n%2:
                 return False
-            primes = dict( [(p,0) for p in cst_table_some ] )
+            primes = dict( [(p, 0) for p in cst_table_some ] )
             assert 1 not in primes
             for p_i in primes:
                 while 0 == n%p_i:
@@ -603,7 +603,7 @@ class cos(TrigonometricFunction):
             return tuple([ p for p in primes if primes[p]==1])
 
         if pi_coeff.q in cst_table_some:
-            return C.chebyshevt(pi_coeff.p,cst_table_some[pi_coeff.q]).expand()
+            return C.chebyshevt(pi_coeff.p, cst_table_some[pi_coeff.q]).expand()
 
         if 0==pi_coeff.q%2: # recursively remove powers of 2
             narg = (pi_coeff*2)*S.Pi
@@ -612,7 +612,7 @@ class cos(TrigonometricFunction):
                 return None
             nval = nval.rewrite(sqrt)
             if not _EXPAND_INTS:
-                if (isinstance(nval,cos) or isinstance(-nval,cos)):
+                if (isinstance(nval, cos) or isinstance(-nval, cos)):
                     return None
             x = (2*pi_coeff+1)/2
             sign_cos = (-1)**((-1 if x < 0 else 1)*int(abs(x)))
@@ -620,13 +620,13 @@ class cos(TrigonometricFunction):
 
         FC = fermatCoords(pi_coeff.q)
         if FC:
-            decomp = ipartfrac(pi_coeff,FC)
-            X=[ (x[1],x[0]*S.Pi) for x in zip(decomp,numbered_symbols('z'))]
+            decomp = ipartfrac(pi_coeff, FC)
+            X=[(x[1], x[0]*S.Pi) for x in zip(decomp, numbered_symbols('z'))]
             pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls.rewrite(sqrt)
         if _EXPAND_INTS:
             decomp = ipartfrac(pi_coeff)
-            X=[ (x[1],x[0]*S.Pi) for x in zip(decomp,numbered_symbols('z'))]
+            X=[(x[1], x[0]*S.Pi) for x in zip(decomp, numbered_symbols('z'))]
             pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls
         return None

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -426,6 +426,11 @@ class cos(TrigonometricFunction):
 
             # cosine formula #####################
             # http://code.google.com/p/sympy/issues/detail?id=2949
+            # explicit calculations are preformed for
+            # cos(k pi / 8), cos(k pi /10), and cos(k pi / 12)
+            # Some other exact values like cos(k pi/15) can be
+            # calculated using a partial-fraction decomposition
+            # by calling cos( X ).rewrite(sqrt)
             cst_table_some = {
                 3 : S.Half,
                 5 : (sqrt(5) + 1)/4,
@@ -440,12 +445,16 @@ class cos(TrigonometricFunction):
                     narg = (1-pi_coeff)*S.Pi
                     return -cls(narg)
 
+                # If nested sqrt's are worse than un-evaluation
+                # you can require q in (1,2,3,4,6)
+                # q <= 12 returns expressions with 2 or fewer nestings.
+                if q > 12:
+                    return None
+
                 if q in cst_table_some:
                     cts = cst_table_some[pi_coeff.q]
                     return C.chebyshevt(pi_coeff.p,cts).expand()
 
-                if q > 10:
-                    return None
 
                 if 0==q%2:
                     narg = (pi_coeff*2)*S.Pi
@@ -534,11 +543,11 @@ class cos(TrigonometricFunction):
             # such that g is the gcd and x1*y1+x2*y2+x3*y3 - g = 0
             # Note, that this is only one such linear combination.
             if len(x) == 1:
-                return (1,x[0])
+                return (1, x[0])
             if len(x) == 2:
-                return igcdex(x[0],x[-1])
+                return igcdex(x[0], x[-1])
             g = migcdex(x[1:])
-            u,v,h = igcdex(x[0],g[-1])
+            u,v,h = igcdex(x[0], g[-1])
             return tuple([u]+[v*i for i in g[0:-1]]+[h])
         def ipartfrac(r,factors=None):
             if isinstance(r,int):
@@ -568,7 +577,6 @@ class cos(TrigonometricFunction):
             return None
 
         cst_table_some = {
-            #1 : -S.One,
             3 : S.Half,
             5 : (sqrt(5) + 1)/4,
             17 : sqrt((15+sqrt(17))/32 + sqrt(2)*(sqrt(-sqrt(17) + 17) +\
@@ -615,7 +623,7 @@ class cos(TrigonometricFunction):
             decomp = ipartfrac(pi_coeff,FC)
             X=[ (x[1],x[0]*S.Pi) for x in zip(decomp,numbered_symbols('z'))]
             pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
-            return pcls
+            return pcls.rewrite(sqrt)
         if _EXPAND_INTS:
             decomp = ipartfrac(pi_coeff)
             X=[ (x[1],x[0]*S.Pi) for x in zip(decomp,numbered_symbols('z'))]

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1,5 +1,4 @@
 from sympy.core.add import Add
-from sympy.core.numbers import Rational
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.function import Function, ArgumentIndexError
@@ -94,10 +93,10 @@ def _pi_coeff(arg, cycles=1):
                     cm = c*m
                     i = int(cm)
                     if i == cm:
-                        c = Rational(i, m)
+                        c = C.Rational(i, m)
                         cx = c*x
                 else:
-                    c = Rational(int(c))
+                    c = C.Rational(int(c))
                     cx = c*x
             if x.is_integer:
                 c2 = c % 2
@@ -202,7 +201,7 @@ class sin(TrigonometricFunction):
                     return -cls(x%1*S.Pi)
                 if 2*x > 1:
                     return cls((1-x)*S.Pi)
-                narg = ((pi_coeff + Rational(3,2))%2)*S.Pi
+                narg = ((pi_coeff + C.Rational(3,2))%2)*S.Pi
                 result = cos(narg)
                 if not isinstance(result,cos):
                     return result
@@ -466,16 +465,16 @@ class cos(TrigonometricFunction):
                     # Now we use partial-fraction decomposition
                     # and angle sum formulas.
                     if frozenset([3,5]) == FC:
-                        narg1 = Rational(p, 6)*S.Pi
-                        narg2 = Rational(p,10)*S.Pi
+                        narg1 = C.Rational(p, 6)*S.Pi
+                        narg2 = C.Rational(p,10)*S.Pi
                         return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
                     elif frozenset([3,17]) == FC:
-                        narg1 = Rational(p*6,17)*S.Pi
-                        narg2 = Rational(p*1, 3)*S.Pi
+                        narg1 = C.Rational(p*6,17)*S.Pi
+                        narg2 = C.Rational(p*1, 3)*S.Pi
                         return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
                     elif frozenset([5,17]) == FC:
-                        narg1 = Rational(p*7,17)*S.Pi
-                        narg2 = Rational(p*2, 5)*S.Pi
+                        narg1 = C.Rational(p*7,17)*S.Pi
+                        narg2 = C.Rational(p*2, 5)*S.Pi
                         return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
                     else :
                         return None
@@ -519,7 +518,7 @@ class cos(TrigonometricFunction):
                         result = ChebyshevMethod(fundamental,p)
                 except KeyError:
                     if (pi_coeff.p, pi_coeff.q) != (p,q):
-                        narg = Rational(p, q)*S.Pi
+                        narg = C.Rational(p, q)*S.Pi
                         result = cls(narg)
                     else:
                         return None
@@ -750,8 +749,8 @@ class tan(TrigonometricFunction):
                 if pi_coeff.p > pi_coeff.q:
                     p, q = pi_coeff.p % pi_coeff.q, pi_coeff.q
                     if 2 * p > q:
-                        return -cls(Rational(q - p, q)*S.Pi)
-                    return cls(Rational(p, q)*S.Pi)
+                        return -cls(C.Rational(q - p, q)*S.Pi)
+                    return cls(C.Rational(p, q)*S.Pi)
                 else:
                     newarg = pi_coeff*S.Pi
                     if newarg != arg:
@@ -934,8 +933,8 @@ class cot(TrigonometricFunction):
                 if pi_coeff.p > pi_coeff.q:
                     p, q = pi_coeff.p % pi_coeff.q, pi_coeff.q
                     if 2 * p > q:
-                        return -cls(Rational(q - p, q)*S.Pi)
-                    return cls(Rational(p, q)*S.Pi)
+                        return -cls(C.Rational(q - p, q)*S.Pi)
+                    return cls(C.Rational(p, q)*S.Pi)
                 else:
                     newarg = pi_coeff*S.Pi
                     if newarg != arg:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -481,9 +481,12 @@ class cos(TrigonometricFunction):
 
                 assert len(FC) == 1
 
-                ## calculate and store special values of sine and cosine
                 def _calc_cos_pi_over_17():
-                    # this calculation could be cached
+                    ## calculate and store special values of sine and cosine
+                    # Perhaps this should be stored in the singletans, like S.Half?
+                    # Then the calculation of cos and sin together would use...
+                    #
+                    #sin17 = sqrt(2*(17-sq17-sqrt(2)*(a+ec)))/8                    # this calculation could be cached
                     sq17 = sqrt(17)
                     en = sqrt(17 + sq17)
                     ec = sqrt(17 - sq17)
@@ -491,13 +494,7 @@ class cos(TrigonometricFunction):
                     a = sqrt(34+6*sq17+sqrt(2)*(d*ec-8*en))
                     c17 = sqrt(1-(2*(17-sq17-sqrt(2)*(a+ec)))/64)
                     return c17
-                    # Perhaps this should be stored in the singletans, like S.Half?
-                    # Then the calculation of cos and sin together would use...
-                    #
-                    #s17 = sqrt(2*(17-sq17-sqrt(2)*(a+ec)))/8
-                    #return c17,s17
 
-                #cos_pi_over_17, sin_pi_over_17 = _calc_cos_pi_over_17()
                 cos_pi_over_17 = _calc_cos_pi_over_17()
 
                 cst_table_some = {

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -496,26 +496,11 @@ class cos(TrigonometricFunction):
                     3 : S.Half,
                     5 : (sqrt(5) + 1)/4,
                     17 : makecos17(),
-                    # 65537 and 257 are missing becaue they are too complicated.
+                    # 65537 and 257 are missing because they are too complicated.
                 }
 
-                def chebyshevMethod(x,n):
-                    # Chebyshev polynomial method for reducing
-                    # numerators
-                    y = x*x-1
-                    z = sqrt(y.expand())
-                    E = ((x-z)**n + (x+z)**n)/2
-                    E = E.expand()
-                    return E
-
                 try:
-                    fundamental= cst_table_some[q]
-                    if 1 == p:
-                        result = fundamental
-                    elif 2 == p:
-                        result = 2*fundamental**2-1
-                    else:
-                        result = chebyshevMethod(fundamental,p)
+                    result = C.chebyshevt(p,cst_table_some[q])
                 except KeyError:
                     if (pi_coeff.p, pi_coeff.q) != (p,q):
                         narg = C.Rational(p, q)*S.Pi

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -208,7 +208,7 @@ class sin(TrigonometricFunction):
                 if not isinstance(result,cos):
                     return result
                 if pi_coeff*S.Pi != arg:
-                	return cls(pi_coeff*S.Pi)
+                    return cls(pi_coeff*S.Pi)
                 return None
 
         if arg.is_Add:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -2,7 +2,7 @@ from sympy.core.add import Add
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.numbers import igcdex
-from sympy.core.function import Function, ArgumentIndexError, expand_trig
+from sympy.core.function import Function, ArgumentIndexError
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
@@ -317,6 +317,10 @@ class sin(TrigonometricFunction):
                 else:
                     return expand_mul((-1)**(n/2 - 1)*cos(x)*C.chebyshevu(n -
                         1, sin(x)), deep=False)
+            pi_coeff = _pi_coeff(arg)
+            if pi_coeff is not None:
+                if pi_coeff.is_Rational:
+                    return self.rewrite(sqrt)
         return sin(arg)
 
     def _eval_as_leading_term(self, x):
@@ -604,12 +608,12 @@ class cos(TrigonometricFunction):
         if FC:
             decomp = ipartfrac(pi_coeff,FC)
             X=[ (x[1],x[0]*S.Pi) for x in zip(decomp,numbered_symbols('z'))]
-            pcls = expand_trig(cos(sum([x[0] for x in X]))).subs(X)
+            pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls
         if _EXPAND_INTS:
             decomp = ipartfrac(pi_coeff)
             X=[ (x[1],x[0]*S.Pi) for x in zip(decomp,numbered_symbols('z'))]
-            pcls = expand_trig(cos(sum([x[0] for x in X]))).subs(X)
+            pcls = cos(sum([x[0] for x in X]))._eval_expand_trig().subs(X)
             return pcls
         return None
 
@@ -643,6 +647,10 @@ class cos(TrigonometricFunction):
             coeff, terms = arg.as_coeff_Mul(rational=True)
             if coeff.is_Integer:
                 return C.chebyshevt(coeff, cos(terms))
+            pi_coeff = _pi_coeff(arg)
+            if pi_coeff is not None:
+                if pi_coeff.is_Rational:
+                    return self.rewrite(sqrt)
         return cos(arg)
 
     def _eval_as_leading_term(self, x):

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -499,7 +499,7 @@ class cos(TrigonometricFunction):
                     # 65537 and 257 are missing becaue they are too complicated.
                 }
 
-                def ChebyshevMethod(x,n):
+                def chebyshevMethod(x,n):
                     # Chebyshev polynomial method for reducing
                     # numerators
                     y = x*x-1
@@ -515,7 +515,7 @@ class cos(TrigonometricFunction):
                     elif 2 == p:
                         result = 2*fundamental**2-1
                     else:
-                        result = ChebyshevMethod(fundamental,p)
+                        result = chebyshevMethod(fundamental,p)
                 except KeyError:
                     if (pi_coeff.p, pi_coeff.q) != (p,q):
                         narg = C.Rational(p, q)*S.Pi

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -110,6 +110,7 @@ def _pi_coeff(arg, cycles=1):
                     return c2*x
             return cx
 
+
 class sin(TrigonometricFunction):
     """
     The sine function.
@@ -481,21 +482,30 @@ class cos(TrigonometricFunction):
 
                 assert len(FC) == 1
 
-                def makecos17():
+                ## calculate and store special values of sine and cosine
+                def _calc_cos_pi_over_17():
                     # this calculation could be cached
                     sq17 = sqrt(17)
                     en = sqrt(17 + sq17)
                     ec = sqrt(17 - sq17)
                     d = sq17-1
                     a = sqrt(34+6*sq17+sqrt(2)*(d*ec-8*en))
-                    return sqrt(1-(2*(17-sq17-sqrt(2)*(a+ec)))/64)
-                    # sin(pi/17) = sqrt(2*(17-sq17-sqrt(2)*(a+ec)))/8
+                    c17 = sqrt(1-(2*(17-sq17-sqrt(2)*(a+ec)))/64)
+                    return c17
+                    # Perhaps this should be stored in the singletans, like S.Half?
+                    # Then the calculation of cos and sin together would use...
+                    #
+                    #s17 = sqrt(2*(17-sq17-sqrt(2)*(a+ec)))/8
+                    #return c17,s17
+
+                #cos_pi_over_17, sin_pi_over_17 = _calc_cos_pi_over_17()
+                cos_pi_over_17 = _calc_cos_pi_over_17()
 
                 cst_table_some = {
                     1 : -S.One,
                     3 : S.Half,
                     5 : (sqrt(5) + 1)/4,
-                    17 : makecos17(),
+                    17 : cos_pi_over_17,
                     # 65537 and 257 are missing because they are too complicated.
                 }
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -519,8 +519,8 @@ class cos(TrigonometricFunction):
                     else:
                         result = ChebyshevMethod(fundamental,p)
                 except KeyError:
-                    if pi_coeff.p != p or pi_coeff.q != q:
-                        narg = C.Rational(p, q)*S.Pi
+                    if (pi_coeff.p, pi_coeff.q) != (p,q):
+                        narg = Rational(p, q)*S.Pi
                         result = cls(narg)
                     else:
                         return None

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -403,9 +403,9 @@ class cos(TrigonometricFunction):
 
         pi_coeff = _pi_coeff(arg)
         if pi_coeff is not None:
+            if pi_coeff.is_integer:
+                return (S.NegativeOne)**pi_coeff
             if not pi_coeff.is_Rational:
-                if pi_coeff.is_integer:
-                    return (S.NegativeOne)**pi_coeff
                 narg = pi_coeff*S.Pi
                 if narg != arg:
                     return cls(narg)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -172,8 +172,9 @@ class sin(TrigonometricFunction):
                 return S.NaN
             elif arg is S.Zero:
                 return S.Zero
-            elif arg is S.Infinity:
-                return
+            elif arg is S.Infinity or arg is S.NegativeInfinity:
+                return        # for test_sin in test_trigonometric
+
 
         if arg.could_extract_minus_sign():
             return -cls(-arg)
@@ -193,44 +194,19 @@ class sin(TrigonometricFunction):
                     return cls(narg)
                 return None
 
-            cst_table_some = {
-                2 : S.One,
-                3 : S.Half*sqrt(3),
-                4 : S.Half*sqrt(2),
-                6 : S.Half,
-            }
-
-            cst_table_more = {
-                (1, 5) : sqrt((5 - sqrt(5)) / 8),
-                (2, 5) : sqrt((5 + sqrt(5)) / 8)
-            }
-
-            p = pi_coeff.p
-            q = pi_coeff.q
-
-            Q, P = p // q, p % q
-
-            try:
-                result = cst_table_some[q]
-            except KeyError:
-                if abs(P) > q // 2:
-                    P = q - P
-
-                try:
-                    result = cst_table_more[(P, q)]
-                except KeyError:
-                    if P != p:
-                        result = cls(C.Rational(P, q)*S.Pi)
-                    else:
-                        newarg = pi_coeff*S.Pi
-                        if newarg != arg:
-                            return cls(newarg)
-                        return None
-
-            if Q % 2 == 1:
-                return -result
-            else:
-                return result
+            # http://code.google.com/p/sympy/issues/detail?id=2949
+            # transform a sine to a cosine, to avoid redundant code
+            if pi_coeff.is_Rational:
+                x = pi_coeff%2
+                if x > 1:
+                    return -cls(x%1*S.Pi)
+                if 2*x > 1:
+                    return cls((1-x)*S.Pi)
+                narg = ((pi_coeff + Rational(3,2))%2)*S.Pi
+                result = cos(narg)
+                if not isinstance(result,cos):
+                    return result
+                return None
 
         if arg.is_Add:
             x, m = _peeloff_pi(arg)
@@ -415,8 +391,8 @@ class cos(TrigonometricFunction):
                 return S.NaN
             elif arg is S.Zero:
                 return S.One
-            elif arg is S.Infinity:
-                return
+            elif arg is S.Infinity or arg is S.NegativeInfinity:
+                return        # for test_sin in test_trigonometric
 
         if arg.could_extract_minus_sign():
             return cls(-arg)
@@ -435,45 +411,122 @@ class cos(TrigonometricFunction):
                     return cls(narg)
                 return None
 
-            cst_table_some = {
-                1 : S.One,
-                2 : S.Zero,
-                3 : S.Half,
-                4 : S.Half*sqrt(2),
-                6 : S.Half*sqrt(3),
-            }
+            # cosine formula #####################
+            # http://code.google.com/p/sympy/issues/detail?id=2949
+            def fermatCoords(n):
+                assert isinstance(n,int)
+                assert n > 0
+                if n == 1 or 0 == n%2:
+                    return False
+                primes = { 65537:0,257:0,17:0,5:0,3:0 }
+                for i,p_i in enumerate(primes):
+                    while 0 == n%p_i:
+                        n = n/p_i;
+                        primes[p_i] += 1;
+                if 1 != n:
+                    return False
+                if max(primes.values()) > 1:
+                    return False
+                return frozenset([ p for p in primes if primes[p]==1])
+            if pi_coeff.is_Rational:
+                q = pi_coeff.q
+                p = pi_coeff.p % (2*q)
+                if p>q:
+                    narg = (pi_coeff-1)*S.Pi
+                    return -cls(narg)
+                if 2*p > q:
+                    narg = (1-pi_coeff)*S.Pi
+                    return -cls(narg)
 
-            cst_table_more = {
-                (1, 5) : (sqrt(5) + 1)/4,
-                (2, 5) : (sqrt(5) - 1)/4
-            }
+                ###  Good place to bail-out.
+                #if q > 15:
+                #    # arbitrary threshold set for complex denominators
+                #    # 15 is the largest denominator allowed
+                #    return None
 
-            p = pi_coeff.p
-            q = pi_coeff.q
-
-            Q, P = 2*p // q, p % q
-
-            try:
-                result = cst_table_some[q]
-            except KeyError:
-                if abs(P) > q // 2:
-                    P = q - P
-
-                try:
-                    result = cst_table_more[(P, q)]
-                except KeyError:
-                    if P != p:
-                        result = cls(C.Rational(P, q)*S.Pi)
-                    else:
-                        newarg = pi_coeff*S.Pi
-                        if newarg != arg:
-                            return cls(newarg)
+                if 0==q%2:
+                    # ?? narg = C.Rational(p%q, q/2)*S.Pi
+                    narg = (pi_coeff*2)*S.Pi
+                    nval = cls(narg)
+                    if None == nval:
+                        return None
+                    if isinstance(nval,cos):
+                        return
+                    if isinstance(-nval,cos):
+                        return
+                    x = (2*pi_coeff+1)/2
+                    sign_cos = (-1)**((-1 if x < 0 else 1)*int(abs(x)))
+                    return sign_cos*sqrt( (1+nval)/2 )
+                FC = fermatCoords(q)
+                if not FC or len(FC) > 2:
+                    return None
+                elif len(FC) == 2:
+                    # only 3, 5, and 17 are used currently
+                    # so only 3 pairs are possible.
+                    #
+                    # Now we use partial-fraction decomposition
+                    # and angle sum formulas.
+                    if frozenset([3,5]) == FC:
+                        narg1 = C.Rational(p, 6)*S.Pi
+                        narg2 = C.Rational(p,10)*S.Pi
+                        return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
+                    elif frozenset([3,17]) == FC:
+                        narg1 = C.Rational(p*6,17)*S.Pi
+                        narg2 = C.Rational(p*1, 3)*S.Pi
+                        return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
+                    elif frozenset([5,17]) == FC:
+                        narg1 = C.Rational(p*7,17)*S.Pi
+                        narg2 = C.Rational(p*2, 5)*S.Pi
+                        return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
+                    else :
                         return None
 
-            if Q % 4 in (1, 2):
-                return -result
-            else:
-                return result
+                assert len(FC) == 1
+
+                def makecos17():
+                    # this calculation could be cached
+                    sq17 = sqrt(17)
+                    en = sqrt(17 + sq17)
+                    ec = sqrt(17 - sq17)
+                    d = sq17-1
+                    a = sqrt(34+6*sq17+sqrt(2)*(d*ec-8*en))
+                    return sqrt(1-(2*(17-sq17-sqrt(2)*(a+ec)))/64)
+                    # sin(pi/17) = sqrt(2*(17-sq17-sqrt(2)*(a+ec)))/8
+
+                cst_table_some = {
+                    1 : -S.One,
+                    3 : S.Half,
+                    5 : (sqrt(5) + 1)/4,
+                    17 : makecos17(),
+                    # 65537 and 257 are missing becaue they are too complicated.
+                }
+
+                def ChebyshevMethod(x,n):
+                    # Chebyshev polynomial method for reducing
+                    # numerators
+                    y = x*x-1
+                    z = sqrt(y.expand())
+                    E = ((x-z)**n + (x+z)**n)/2
+                    E = E.expand()
+                    return E
+
+                try:
+                    fundamental= cst_table_some[q]
+                    if 1 == p:
+                        result = fundamental
+                    elif 2 == p:
+                        result = 2*fundamental**2-1
+                    else:
+                        result = ChebyshevMethod(fundamental,p)
+                except KeyError:
+                    if pi_coeff.p != p or pi_coeff.q != q:
+                        narg = C.Rational(p, q)*S.Pi
+                        result = cls(narg)
+                    else:
+                        return None
+                return result.expand()
+                # should have used sqrtdenest() ?
+            return None
 
         if arg.is_Add:
             x, m = _peeloff_pi(arg)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -561,9 +561,9 @@ class cos(TrigonometricFunction):
             #1 : -S.One,
             3 : S.Half,
             5 : (sqrt(5) + 1)/4,
-            17 : sqrt(sqrt(17)/32 + sqrt(2)*(sqrt(-sqrt(17) + 17) +\
+            17 : sqrt((15+sqrt(17))/32 + sqrt(2)*(sqrt(-sqrt(17) + 17) +\
                 sqrt(sqrt(2)*(-8*sqrt(sqrt(17) + 17) + (-1 + sqrt(17))\
-                *sqrt(-sqrt(17) + 17)) + 6*sqrt(17) + 34))/32 + 15/32)
+                *sqrt(-sqrt(17) + 17)) + 6*sqrt(17) + 34))/32)
             # 65537 and 257 are the only other known Fermat primes
             # Please add if you would like them
         }

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -445,7 +445,6 @@ class cos(TrigonometricFunction):
                 #    return None
 
                 if 0==q%2:
-                    # ?? narg = C.Rational(p%q, q/2)*S.Pi
                     narg = (pi_coeff*2)*S.Pi
                     nval = cls(narg)
                     if None == nval:
@@ -467,16 +466,16 @@ class cos(TrigonometricFunction):
                     # Now we use partial-fraction decomposition
                     # and angle sum formulas.
                     if frozenset([3,5]) == FC:
-                        narg1 = C.Rational(p, 6)*S.Pi
-                        narg2 = C.Rational(p,10)*S.Pi
+                        narg1 = Rational(p, 6)*S.Pi
+                        narg2 = Rational(p,10)*S.Pi
                         return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
                     elif frozenset([3,17]) == FC:
-                        narg1 = C.Rational(p*6,17)*S.Pi
-                        narg2 = C.Rational(p*1, 3)*S.Pi
+                        narg1 = Rational(p*6,17)*S.Pi
+                        narg2 = Rational(p*1, 3)*S.Pi
                         return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
                     elif frozenset([5,17]) == FC:
-                        narg1 = C.Rational(p*7,17)*S.Pi
-                        narg2 = C.Rational(p*2, 5)*S.Pi
+                        narg1 = Rational(p*7,17)*S.Pi
+                        narg2 = Rational(p*2, 5)*S.Pi
                         return cos(narg1)*cos(narg2)+sin(narg1)*sin(narg2)
                     else :
                         return None
@@ -525,7 +524,7 @@ class cos(TrigonometricFunction):
                     else:
                         return None
                 return result.expand()
-                # should have used sqrtdenest() ?
+                # should have used sqrtdenest() rather than expand ?
             return None
 
         if arg.is_Add:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -110,7 +110,6 @@ def _pi_coeff(arg, cycles=1):
                     return c2*x
             return cx
 
-
 class sin(TrigonometricFunction):
     """
     The sine function.

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -437,15 +437,14 @@ class cos(TrigonometricFunction):
                     cts = cst_table_some[pi_coeff.q]
                     return C.chebyshevt(pi_coeff.p,cts).expand()
 
+                if q > 10:
+                    return None
+
                 if 0==q%2:
                     narg = (pi_coeff*2)*S.Pi
                     nval = cls(narg)
                     if None == nval:
                         return None
-                    if isinstance(nval,cos):
-                        return
-                    if isinstance(-nval,cos):
-                        return
                     x = (2*pi_coeff+1)/2
                     sign_cos = (-1)**((-1 if x < 0 else 1)*int(abs(x)))
                     return sign_cos*sqrt( (1+nval)/2 )
@@ -549,7 +548,6 @@ class cos(TrigonometricFunction):
             ans = [ r.p*C.Rational(i*j,r.q) for i,j in zip(h[:-1],a) ]
             assert r == sum(ans)
             return ans
-        pi_coeff = arg
         pi_coeff = _pi_coeff(arg)
         if pi_coeff is None:
             return None
@@ -558,8 +556,6 @@ class cos(TrigonometricFunction):
 
         if not pi_coeff.is_Rational:
             return None
-
-        assert pi_coeff.is_Rational
 
         cst_table_some = {
             #1 : -S.One,
@@ -596,6 +592,7 @@ class cos(TrigonometricFunction):
             nval = cos(narg)
             if None == nval:
                 return None
+            nval = nval.rewrite(sqrt)
             if not _EXPAND_INTS:
                 if (isinstance(nval,cos) or isinstance(-nval,cos)):
                     return None

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -418,7 +418,7 @@ class cos(TrigonometricFunction):
                 if n == 1 or 0 == n%2:
                     return False
                 primes = { 65537:0,257:0,17:0,5:0,3:0 }
-                for i,p_i in enumerate(primes):
+                for p_i in primes:
                     while 0 == n%p_i:
                         n = n/p_i;
                         primes[p_i] += 1;

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1340,9 +1340,9 @@ class RegularPolygon(Polygon):
         ========
 
         >>> from sympy.geometry import RegularPolygon, Point
-        >>> rp = RegularPolygon(Point(0, 0), 4, 8)
+        >>> rp = RegularPolygon(Point(0, 0), 4, 7)
         >>> rp.incircle
-        Circle(Point(0, 0), 4*cos(pi/8))
+        Circle(Point(0, 0), 4*cos(pi/7))
 
         """
         return Circle(self.center, self.apothem)


### PR DESCRIPTION
New code for evaluating rational*pi arguments to sin and cos.  sin(pi/12),
sin(pi/15), and sin(pi/85), and others.  This version may return very large
radical expressions.  There is a comment showing where to bail if only simple
expressions are desired.

This is an updated version of the code I posted in relation to
issue 2949. http://code.google.com/p/sympy/issues/detail?id=2949

Second attempt.  Removed uneed and distracting changes, in response
to criticism.  (my branches were a mess.  Still getting the hang of this.
Did some probably ill-advised stuff to clear my head.  Will avoid committing
to master next-time.)
