### PR TITLE
Fix test failures in Python 3.3b2

### DIFF
--- a/sympy/utilities/source.py
+++ b/sympy/utilities/source.py
@@ -23,7 +23,7 @@ def get_class(lookup_view):
         lookup_view = lookup_view
         mod_name, func_name = get_mod_func(lookup_view)
         if func_name != '':
-            lookup_view = getattr(__import__(mod_name, {}, {}, ['']), func_name)
+            lookup_view = getattr(__import__(mod_name, {}, {}, ['*']), func_name)
             if not callable(lookup_view):
                 raise AttributeError("'%s.%s' is not a callable." % (mod_name, func_name))
     return lookup_view


### PR DESCRIPTION
The fromlist argument of `__import__` was being called as `['']`, which is
meaningless.  Because we need fromlist to be non-empty to get the submodule
returned, this was changed to `['*']`.
