### PR TITLE
_keep_coeff modification

### DIFF
--- a/doc/src/modules/polys/basics.rst
+++ b/doc/src/modules/polys/basics.rst
@@ -109,10 +109,18 @@ the least common multiple.
 When the polynomials have integer coefficients, the contents' gcd is also
 considered::
 
-    >>> f = 12*(x + 1)*x
+    >>> f = (12*x + 12)*x
     >>> g = 16*x**2
     >>> gcd(f, g)
     4*x
+
+But if the polynomials have rational coefficients, then the returned polynomial is
+monic::
+
+    >>> f = 3*x**2/2
+    >>> g = 9*x/4
+    >>> gcd(f, g)
+    x
 
 It also works with multiple variables. In this case, the variables are ordered
 alphabetically, be default, which has influence on the leading coefficient::

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4730,6 +4730,8 @@ def terms_gcd(f, *gens, **args):
 
     >>> terms_gcd(x + y/2, clear=False)
     x + y/2
+    >>> terms_gcd(x*y/2 + y**2, clear=False)
+    y*(x/2 + y)
 
     The ``clear`` flag is ignored if all coefficients are fractions:
 
@@ -4773,7 +4775,12 @@ def terms_gcd(f, *gens, **args):
 
     term = Mul(*[ x**j for x, j in zip(f.gens, J) ])
 
-    return _keep_coeff(coeff, term*f.as_expr(), clear=clear)
+    if clear:
+        return _keep_coeff(coeff, term*f.as_expr())
+    # base the clearing on the form of the original expression, not
+    # the (perhaps) Mul that we have now
+    coeff, f = _keep_coeff(coeff, f.as_expr(), clear=False).as_coeff_Mul()
+    return _keep_coeff(coeff, term*f, clear=False)
 
 def trunc(f, p, *gens, **args):
     """


### PR DESCRIPTION
Modifications of `_keep_coeff` to keep it from removing fractions that appear in only one term of an expression. A docstring was also modified to show that gcd will extract content.
