### PR TITLE
Catch all exceptions when trying to enable pylab

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -439,8 +439,11 @@ def init_session(ipython=None, pretty_print=True, order=None,
                 #Enable interactive plotting using pylab.
                 try:
                     ip.enable_pylab(import_all=False)
-                except ImportError:
-                    #Causes an import error if matplotlib is not installed.
+                except Exception:
+                    # Causes an import error if matplotlib is not installed.
+                    # Causes other errors (depending on the backend) if there
+                    # is no display, or if there is some problem in the
+                    # backend, so we have a bare "except Exception" here
                     pass
             if not in_ipython:
                 mainloop = ip.mainloop

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -37,7 +37,7 @@ np = import_module('numpy')
 # Backend specific imports - matplotlib
 matplotlib = import_module('matplotlib',
     __import__kwargs={'fromlist':['pyplot', 'cm', 'collections']},
-    min_module_version='1.0.0')
+    min_module_version='1.0.0', catch=(RuntimeError,))
 if matplotlib:
     plt = matplotlib.pyplot
     cm = matplotlib.cm


### PR DESCRIPTION
If I find any other errors that arise from not having a display, I'll push them here as well.
