### PR TITLE
Simplify with noncommutative parts and match issues.

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -773,8 +773,26 @@ class Mul(AssocOp):
         expr = sympify(expr)
         if self.is_commutative and expr.is_commutative:
             return AssocOp._matches_commutative(self, expr, repl_dict)
-        # todo for commutative parts, until then use the default matches method for non-commutative products
-        return self._matches(expr, repl_dict)
+        elif self.is_commutative is not expr.is_commutative:
+            return None
+        c1, nc1 = self.args_cnc()
+        c2, nc2 = expr.args_cnc()
+        repl_dict = repl_dict.copy()
+        if c1:
+            if not c2:
+                c2 = [1]
+            a = Mul(*c1)
+            if isinstance(a, AssocOp):
+                repl_dict = a._matches_commutative(Mul(*c2), repl_dict)
+            else:
+                repl_dict = a.matches(Mul(*c2), repl_dict)
+        if repl_dict:
+            a = Mul(*nc1)
+            if isinstance(a, Mul):
+                repl_dict = a._matches(Mul(*nc2), repl_dict)
+            else:
+                repl_dict = a.matches(Mul(*nc2), repl_dict)
+        return repl_dict or None
 
     def _matches(self, expr, repl_dict={}):
         # weed out negative one prefixes

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -190,11 +190,7 @@ class AssocOp(Expr):
             return newpattern.matches(newexpr, repl_dict)
 
         # now to real work ;)
-        if expr.is_Add:
-            i, d = expr.as_independent(C.Symbol)
-            expr_list = (i,) + self.make_args(expr)
-        else:
-            expr_list = self.make_args(expr)
+        expr_list = (self.identity,) + self.make_args(expr)
         for last_op in reversed(expr_list):
             for w in reversed(wild_part):
                 d1 = w.matches(last_op, repl_dict)

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,5 +1,7 @@
-from sympy import abc, Function, Symbol, Wild, Derivative, sin, cos, Float, \
-        Rational, exp, I, Integer, diff, Mul, var, oo, S, Add, Poly, sqrt, symbols
+from sympy import (abc, Add, cos, Derivative, diff, exp, Float, Function,
+    I, Integer, log, Mul, oo, Poly, Rational, S, sin, sqrt, Symbol, symbols,
+    var, Wild
+)
 from sympy.utilities.pytest import XFAIL
 
 
@@ -383,3 +385,84 @@ def test_combine_inverse():
     assert Mul._combine_inverse(oo*I*y, oo*I) == y
     assert Add._combine_inverse(oo, oo) == S(0)
     assert Add._combine_inverse(oo*I, oo*I) == S(0)
+
+def test_issue_674():
+    z, phi, r = symbols('z phi r')
+    c, A, B, N = symbols('c A B N', cls=Wild)
+    l = Wild('l', exclude=(0,))
+
+    eq = z * sin(2*phi) * r**7
+    matcher = c * sin(phi*N)**l * r**A * log(r)**B
+
+    assert eq.match(matcher) == {c: z, l: 1, N: 2, A: 7, B: 0}
+    assert (-eq).match(matcher) == {c: -z, l: 1, N: 2, A: 7, B: 0}
+    assert (x*eq).match(matcher) == {c: x*z, l: 1, N: 2, A: 7, B: 0}
+    assert (-7*x*eq).match(matcher) == {c: -7*x*z, l: 1, N: 2, A: 7, B: 0}
+
+    matcher = c*sin(phi*N)**l * r**A
+
+    assert eq.match(matcher) == {c: z, l: 1, N: 2, A: 7}
+    assert (-eq).match(matcher) == {c: -z, l: 1, N: 2, A: 7}
+    assert (x*eq).match(matcher) == {c: x*z, l: 1, N: 2, A: 7}
+    assert (-7*x*eq).match(matcher) == {c: -7*x*z, l: 1, N: 2, A: 7}
+
+def test_issue_784():
+    from sympy.abc import gamma, mu, pi, x
+    f = (-gamma * (x - mu)**2 - log(gamma) + log(2*pi))/2
+    a, b, c = symbols('a b c', cls=Wild, exclude=(gamma,))
+
+    assert f.match(a * log(gamma) + b * gamma + c) == \
+        {a: -S(1)/2, b: -(x - mu)**2/2, c: log(2*pi)/2}
+    assert f.expand().collect(gamma).match(a * log(gamma) + b * gamma + c) == \
+        {a: -S(1)/2, b: (-(x - mu)**2/2).expand(), c: (log(2*pi)/2).expand()}
+
+def test_issue_1319():
+    x = symbols('x')
+    a, b, c = symbols('a b c', cls=Wild, exclude=(x,))
+    f, g = symbols('f g', cls=Function)
+
+    eq = diff(g(x)*f(x).diff(x), x)
+
+    assert eq.match(g(x).diff(x)*f(x).diff(x) + g(x)*f(x).diff(x, x) + c) == {c: 0}
+    assert eq.match(a*g(x).diff(x)*f(x).diff(x) + b*g(x)*f(x).diff(x, x) + c) == {a: 1, b: 1, c: 0}
+
+def test_issue_1601():
+    f = Function('f')
+    x = symbols('x')
+    a, b = symbols('a b', cls=Wild, exclude=(f(x),))
+
+    p = a*f(x) + b
+    eq1 = sin(x)
+    eq2 = f(x) + sin(x)
+    eq3 = f(x) + x + sin(x)
+    eq4 = x + sin(x)
+
+    assert eq1.match(p) == {a: 0, b: sin(x)}
+    assert eq2.match(p) == {a: 1, b: sin(x)}
+    assert eq3.match(p) == {a: 1, b: x + sin(x)}
+    assert eq4.match(p) == {a: 0, b: x + sin(x)}
+
+def test_issue_2069():
+    a, b, c = symbols('a b c', cls=Wild)
+    x = symbols('x')
+    f = Function('f')
+
+    assert x.match(a) == {a: x}
+    assert x.match(a*f(x)**c) == {a: x, c: 0}
+    assert x.match(a*b) == {a: 1, b: x}
+    assert x.match(a*b*f(x)**c) == {a: 1, b: x, c: 0}
+
+    assert (-x).match(a) == {a: -x}
+    assert (-x).match(a*f(x)**c) == {a: -x, c: 0}
+    assert (-x).match(a*b) == {a: -1, b: x}
+    assert (-x).match(a*b*f(x)**c) == {a: -1, b: x, c: 0}
+
+    assert (2*x).match(a) == {a: 2*x}
+    assert (2*x).match(a*f(x)**c) == {a: 2*x, c: 0}
+    assert (2*x).match(a*b) == {a: 2, b: x}
+    assert (2*x).match(a*b*f(x)**c) == {a: 2, b: x, c: 0}
+
+    assert (-2*x).match(a) == {a: -2*x}
+    assert (-2*x).match(a*f(x)**c) == {a: -2*x, c: 0}
+    assert (-2*x).match(a*b) == {a: -2, b: x}
+    assert (-2*x).match(a*b*f(x)**c) == {a: -2, b: x, c: 0}

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,5 +1,5 @@
 from sympy import abc, Function, Symbol, Wild, Derivative, sin, cos, Float, \
-        Rational, exp, I, Integer, diff, Mul, var, oo, S, Add, Poly, sqrt
+        Rational, exp, I, Integer, diff, Mul, var, oo, S, Add, Poly, sqrt, symbols
 from sympy.utilities.pytest import XFAIL
 
 
@@ -113,6 +113,39 @@ def test_mul():
 
     e = I*Poly(x, x)
     assert e.match(I*p) == {p: Poly(x, x)}
+
+def test_mul_noncommutative():
+    x, y = symbols('x y')
+    A, B = symbols('A B', commutative=False)
+    u, v = symbols('u v', cls=Wild)
+    w = Wild('w', commutative=False)
+
+    assert (u*v).matches(x) in ({v: x, u: 1}, {u: x, v: 1})
+    assert (u*v).matches(x*y) in ({v: y, u: x}, {u: y, v: x})
+    assert (u*v).matches(A) == None
+    assert (u*v).matches(A*B) == None
+    assert (u*v).matches(x*A) == None
+    assert (u*v).matches(x*y*A) == None
+    assert (u*v).matches(x*A*B) == None
+    assert (u*v).matches(x*y*A*B) == None
+
+    assert (v*w).matches(x) == None
+    assert (v*w).matches(x*y) == None
+    assert (v*w).matches(A) == {w: A, v: 1}
+    assert (v*w).matches(A*B) == {w: A*B, v: 1}
+    assert (v*w).matches(x*A) == {w: A, v: x}
+    assert (v*w).matches(x*y*A) == {w: A, v: x*y}
+    assert (v*w).matches(x*A*B) == {w: A*B, v: x}
+    assert (v*w).matches(x*y*A*B) == {w: A*B, v: x*y}
+
+    assert (v*w).matches(-x) == None
+    assert (v*w).matches(-x*y) == None
+    assert (v*w).matches(-A) == {w: A, v: -1}
+    assert (v*w).matches(-A*B) == {w: A*B, v: -1}
+    assert (v*w).matches(-x*A) == {w: A, v: -x}
+    assert (v*w).matches(-x*y*A) == {w: A, v: -x*y}
+    assert (v*w).matches(-x*A*B) == {w: A*B, v: -x}
+    assert (v*w).matches(-x*y*A*B) == {w: A*B, v: -x*y}
 
 def test_complex():
     a,b,c = map(Symbol, 'abc')

--- a/sympy/core/tests/test_noncommutative.py
+++ b/sympy/core/tests/test_noncommutative.py
@@ -1,18 +1,22 @@
 """Tests for noncommutative symbols and expressions."""
 
 from sympy import (
+    adjoint,
     cancel,
     collect,
     combsimp,
     conjugate,
+    cos,
     expand,
     factor,
     posify,
     radsimp,
     ratsimp,
     rcollect,
+    sin,
     simplify,
     symbols,
+    transpose,
     trigsimp,
     I,
 )
@@ -20,6 +24,26 @@ from sympy.abc import x, y, z
 from sympy.utilities.pytest import XFAIL
 
 A, B, C = symbols("A B C", commutative=False)
+X = symbols("X", commutative=False, hermitian=True)
+Y = symbols("Y", commutative=False, antihermitian=True)
+
+def test_adjoint():
+    assert adjoint(A).is_commutative == False
+    assert adjoint(A*A) == adjoint(A)**2
+    assert adjoint(A*B) == adjoint(B)*adjoint(A)
+    assert adjoint(A*B**2) == adjoint(B)**2*adjoint(A)
+    assert adjoint(A*B - B*A) == adjoint(B)*adjoint(A) - adjoint(A)*adjoint(B)
+    assert adjoint(A + I*B) == adjoint(A) - I*adjoint(B)
+
+    assert adjoint(X) == X
+    assert adjoint(-I*X) == I*X
+    assert adjoint(Y) == -Y
+    assert adjoint(-I*Y) == -I*Y
+
+    assert adjoint(X) == conjugate(transpose(X))
+    assert adjoint(Y) == conjugate(transpose(Y))
+    assert adjoint(X) == transpose(conjugate(X))
+    assert adjoint(Y) == transpose(conjugate(Y))
 
 @XFAIL
 def test_cancel():
@@ -83,6 +107,18 @@ def test_subs():
     assert (A**2*B**2).subs(A*B**2, C) == A*C
     assert (A*A*A + A*B*A).subs(A*A*A, C) == C + A*B*A
 
-@XFAIL
+def test_transpose():
+    assert transpose(A).is_commutative == False
+    assert transpose(A*A) == transpose(A)**2
+    assert transpose(A*B) == transpose(B)*transpose(A)
+    assert transpose(A*B**2) == transpose(B)**2*transpose(A)
+    assert transpose(A*B - B*A) == transpose(B)*transpose(A) - transpose(A)*transpose(B)
+    assert transpose(A + I*B) == transpose(A) + I*transpose(B)
+
+    assert transpose(X) == conjugate(X)
+    assert transpose(-I*X) == -I*conjugate(X)
+    assert transpose(Y) == -conjugate(Y)
+    assert transpose(-I*Y) == I*conjugate(Y)
+
 def test_trigsimp():
     assert trigsimp(A*sin(x)**2 + A*cos(x)**2) == A

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -73,6 +73,7 @@ class Poly(Expr):
 
     __slots__ = ['rep', 'gens']
 
+    is_commutative = True
     is_Poly = True
 
     def __new__(cls, rep, *gens, **args):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2939,15 +2939,13 @@ def simplify(expr, ratio=1.7, measure=count_ops):
             return choices[0]
         return min(choices, key=measure)
 
-    if expr.is_commutative is False:
-        expr1 = factor_terms(together(powsimp(expr)))
-        if ratio is S.Infinity:
-            return expr1
-        return shorter(expr1, expr)
-
     expr0 = powsimp(expr)
-    expr1 = cancel(expr0)
-    expr2 = together(expr1.expand(), deep=True)
+    if expr.is_commutative is False:
+        expr1 = together(expr0)
+        expr2 = factor_terms(expr1)
+    else:
+        expr1 = cancel(expr0)
+        expr2 = together(expr1.expand(), deep=True)
 
     # sometimes factors in the denominators need to be allowed to join
     # factors in numerators (see issue 3270)
@@ -3009,9 +3007,6 @@ def simplify(expr, ratio=1.7, measure=count_ops):
 
     if measure(expr) > ratio*measure(original_expr):
         return original_expr
-
-    if original_expr.is_Matrix:
-        expr = matrixify(expr)
 
     return expr
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -6,7 +6,7 @@ from sympy import SYMPY_DEBUG
 from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     Derivative, Wild, Symbol, sympify, expand, expand_mul, expand_func,
     Function, Equality, Dummy, Atom, count_ops, Expr, factor_terms,
-    expand_multinomial, expand_power_base)
+    expand_multinomial, expand_power_base, symbols)
 
 from sympy.core.compatibility import iterable, reduce
 from sympy.core.numbers import igcd, Float
@@ -900,7 +900,8 @@ def trigsimp(expr, deep=False, recursive=False):
 
 def _trigsimp(expr, deep=False):
     """recursive helper for trigsimp"""
-    a, b, c = map(Wild, 'abc')
+    a, b, c = symbols('a b c', cls=Wild)
+    d = Wild('d', commutative=False)
     sin, cos, tan, cot = C.sin, C.cos, C.tan, C.cot
     sinh, cosh, tanh, coth = C.sinh, C.cosh, C.tanh, C.coth
     # for the simplifications like sinh/cosh -> tanh:
@@ -917,7 +918,22 @@ def _trigsimp(expr, deep=False):
         (a*coth(b)**c*sinh(b)**c, a*cosh(b)**c),
         (a*tanh(b)**c/sinh(b)**c, a/cosh(b)**c),
         (a*coth(b)**c/cosh(b)**c, a/sinh(b)**c),
-        (a*coth(b)**c*tanh(b)**c, a)
+        (a*coth(b)**c*tanh(b)**c, a),
+
+        # same as above but with noncommutative prefactor
+        (a*d*sin(b)**c/cos(b)**c, a*d*tan(b)**c),
+        (a*d*tan(b)**c*cos(b)**c, a*d*sin(b)**c),
+        (a*d*cot(b)**c*sin(b)**c, a*d*cos(b)**c),
+        (a*d*tan(b)**c/sin(b)**c, a*d/cos(b)**c),
+        (a*d*cot(b)**c/cos(b)**c, a*d/sin(b)**c),
+        (a*d*cot(b)**c*tan(b)**c, a*d),
+
+        (a*d*sinh(b)**c/cosh(b)**c, a*d*tanh(b)**c),
+        (a*d*tanh(b)**c*cosh(b)**c, a*d*sinh(b)**c),
+        (a*d*coth(b)**c*sinh(b)**c, a*d*cosh(b)**c),
+        (a*d*tanh(b)**c/sinh(b)**c, a*d/cosh(b)**c),
+        (a*d*coth(b)**c/cosh(b)**c, a*d/sinh(b)**c),
+        (a*d*coth(b)**c*tanh(b)**c, a*d),
         )
     # for cos(x)**2 + sin(x)**2 -> 1
     matchers_identity = (
@@ -933,7 +949,22 @@ def _trigsimp(expr, deep=False):
         (a*coth(b)**2, a + a*(1/sinh(b))**2),
         (a*sinh(b + c),  a*(sinh(b)*cosh(c) + sinh(c)*cosh(b))),
         (a*cosh(b + c),  a*(cosh(b)*cosh(c) + sinh(b)*sinh(c))),
-        (a*tanh(b + c),  a*((tanh(b) + tanh(c))/(1 + tanh(b)*tanh(c))))
+        (a*tanh(b + c),  a*((tanh(b) + tanh(c))/(1 + tanh(b)*tanh(c)))),
+
+        # same as above but with noncommutative prefactor
+        (a*d*sin(b)**2,  a*d - a*d*cos(b)**2),
+        (a*d*tan(b)**2,  a*d*(1/cos(b))**2 - a*d),
+        (a*d*cot(b)**2,  a*d*(1/sin(b))**2 - a*d),
+        (a*d*sin(b + c),  a*d*(sin(b)*cos(c) + sin(c)*cos(b))),
+        (a*d*cos(b + c),  a*d*(cos(b)*cos(c) - sin(b)*sin(c))),
+        (a*d*tan(b + c),  a*d*((tan(b) + tan(c))/(1 - tan(b)*tan(c)))),
+
+        (a*d*sinh(b)**2, a*d*cosh(b)**2 - a*d),
+        (a*d*tanh(b)**2, a*d - a*d*(1/cosh(b))**2),
+        (a*d*coth(b)**2, a*d + a*d*(1/sinh(b))**2),
+        (a*d*sinh(b + c),  a*d*(sinh(b)*cosh(c) + sinh(c)*cosh(b))),
+        (a*d*cosh(b + c),  a*d*(cosh(b)*cosh(c) + sinh(b)*sinh(c))),
+        (a*d*tanh(b + c),  a*d*((tanh(b) + tanh(c))/(1 + tanh(b)*tanh(c)))),
         )
 
     # Reduce any lingering artefacts, such as sin(x)**2 changing
@@ -945,7 +976,16 @@ def _trigsimp(expr, deep=False):
 
         (a - a*cosh(b)**2 + c,      -a*sinh(b)**2 + c, cosh),
         (a - a*(1/cosh(b))**2 + c,   a*tanh(b)**2 + c, cosh),
-        (a + a*(1/sinh(b))**2 + c,   a*coth(b)**2 + c, sinh)
+        (a + a*(1/sinh(b))**2 + c,   a*coth(b)**2 + c, sinh),
+
+        # same as above but with noncommutative prefactor
+        (a*d - a*d*cos(b)**2 + c,        a*d*sin(b)**2 + c, cos),
+        (a*d - a*d*(1/cos(b))**2 + c,   -a*d*tan(b)**2 + c, cos),
+        (a*d - a*d*(1/sin(b))**2 + c,   -a*d*cot(b)**2 + c, sin),
+
+        (a*d - a*d*cosh(b)**2 + c,      -a*d*sinh(b)**2 + c, cosh),
+        (a*d - a*d*(1/cosh(b))**2 + c,   a*d*tanh(b)**2 + c, cosh),
+        (a*d + a*d*(1/sinh(b))**2 + c,   a*d*coth(b)**2 + c, sinh),
         )
 
     if expr.is_Mul:
@@ -993,6 +1033,8 @@ def _trigsimp(expr, deep=False):
             m = expr.match(pattern)
             while m is not None:
                 if m[a_t] == 0 or -m[a_t] in m[c].args or m[a_t] + m[c] == 0:
+                    break
+                if d in m.keys() and m[a_t]*m[d] + m[c] == 0:
                     break
                 expr = result.subs(m)
                 m = expr.match(pattern)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -976,6 +976,7 @@ def _trigsimp(expr, deep=False):
             args.append(term)
         if args != expr.args:
             expr = Add(*args)
+            expr = min(expr, expand(expr), key=count_ops)
 
         # Reduce any lingering artifacts, such as sin(x)**2 changing
         # to 1 - cos(x)**2 when sin(x)**2 was "simpler"

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -149,6 +149,40 @@ def test_trigsimp_issue_2515():
     assert trigsimp(x*cos(x)*tan(x)) == x*sin(x)
     assert trigsimp(-sin(x)+cos(x)*tan(x)) == 0
 
+def test_trigsimp_noncommutative():
+    x, y = symbols('x,y')
+    A, B = symbols('A,B', commutative=False)
+
+    assert trigsimp(A - A*sin(x)**2) == A*cos(x)**2
+    assert trigsimp(A - A*cos(x)**2) == A*sin(x)**2
+    assert trigsimp(A*sin(x)**2 + A*cos(x)**2) == A
+    assert trigsimp(A + A*tan(x)**2) == A/cos(x)**2
+    assert trigsimp(A/cos(x)**2 - A) == A*tan(x)**2
+    assert trigsimp(A/cos(x)**2 - A*tan(x)**2) == A
+    assert trigsimp(A + A*cot(x)**2) == A/sin(x)**2
+    assert trigsimp(A/sin(x)**2 - A) == A*cot(x)**2
+    assert trigsimp(A/sin(x)**2 - A*cot(x)**2) == A
+
+    assert trigsimp(y*A*cos(x)**2 + y*A*sin(x)**2) == y*A
+
+    assert trigsimp(A*sin(x)/cos(x)) == A*tan(x)
+    assert trigsimp(A*tan(x)*cos(x)) == A*sin(x)
+    assert trigsimp(A*cot(x)**3*sin(x)**3) == A*cos(x)**3
+    assert trigsimp(y*A*tan(x)**2/sin(x)**2) == y*A/cos(x)**2
+    assert trigsimp(A*cot(x)/cos(x)) == A/sin(x)
+
+    assert trigsimp(A*sin(x + y) + A*sin(x - y)) == 2*A*sin(x)*cos(y)
+    assert trigsimp(A*sin(x + y) - A*sin(x - y)) == 2*A*sin(y)*cos(x)
+    assert trigsimp(A*cos(x + y) + A*cos(x - y)) == 2*A*cos(x)*cos(y)
+    assert trigsimp(A*cos(x + y) - A*cos(x - y)) == -2*A*sin(x)*sin(y)
+
+    assert trigsimp(A*sinh(x + y) + A*sinh(x - y)) == 2*A*sinh(x)*cosh(y)
+    assert trigsimp(A*sinh(x + y) - A*sinh(x - y)) == 2*A*sinh(y)*cosh(x)
+    assert trigsimp(A*cosh(x + y) + A*cosh(x - y)) == 2*A*cosh(x)*cosh(y)
+    assert trigsimp(A*cosh(x + y) - A*cosh(x - y)) == 2*A*sinh(x)*sinh(y)
+
+    assert trigsimp(A*cos(0.12345)**2 + A*sin(0.12345)**2) == 1.0*A
+
 def test_hyperbolic_simp():
     x, y = symbols('x,y')
 


### PR DESCRIPTION
Fixes issues 674, 2069 and 3369 and add tests for other match issues 784, 1319 and 1601.

Issue 674: ( x_z_sin(2_phi)_r**7 ).match(matcher) is wrong
http://code.google.com/p/sympy/issues/detail?id=674

Issue 2069: (-x).match(a_f(x)_*b) fails to give a, b = -x, 0
http://code.google.com/p/sympy/issues/detail?id=2069

Issue 3369: Simple trigonometric simplification and noncommutative symbol
http://code.google.com/p/sympy/issues/detail?id=3369
