### PR TITLE
Fixed Minor Bug in physics.mechanics

### DIFF
--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -443,7 +443,7 @@ class Dyadic(object):
     def simplify(self):
         """Simplify the elements in the Dyadic in-place."""
         for i in self.args:
-            i[0] = i[0].simplify()
+            i[0].simplify()
 
     def subs(self, *args, **kwargs):
         """Substituion on the Dyadic.
@@ -1595,7 +1595,7 @@ class Vector(object):
     def simplify(self):
         """Simplify the elements in the Vector in place. """
         for i in self.args:
-            i[0] = i[0].simplify()
+            i[0].simplify()
 
     def subs(self, *args, **kwargs):
         """Substituion on the Vector.
@@ -1713,58 +1713,37 @@ class MechanicsLatexPrinter(LatexPrinter):
 
             return name % ",".join(args)
 
-    def _print_Derivative(self, expr):
-        expr = Derivative(expr)
+    def _print_Derivative(self, der_expr):
+        # make sure it is an the right form
+        der_expr = der_expr.doit()
+        if not isinstance(der_expr, Derivative):
+            return self.doprint(der_expr)
+
+        # check if expr is a dynamicsymbol
+        from sympy.core.function import AppliedUndef
         t = dynamicsymbols._t
-        syms = list(reversed(expr.variables))
-        dots = 0
+        expr = der_expr.expr
+        red = expr.atoms(AppliedUndef)
+        syms = der_expr.variables
+        test1 = not all([True for i in red if i.atoms() == set([t])])
+        test2 = not all([(t == i) for i in syms])
+        if test1 or test2:
+            return LatexPrinter().doprint(der_expr)
 
-        while len(syms) > 0:
-            if syms[-1] == t:
-                syms.pop()
-                dots += 1
-            else:
-                break
-        base = self._print(expr.expr)
+        # done checking
+        dots = len(syms)
+        base = self._print_Function(expr)
+        base_split = base.split('_', 1)
+        base = base_split[0]
         if dots == 1:
-            base = r"\dot{%s}" % self._print(expr.expr)
-        if dots == 2:
-            base = r"\ddot{%s}" % self._print(expr.expr)
-        if dots == 3:
-            base = r"\dddot{%s}" % self._print(expr.expr)
-
-        expr = Derivative(expr.expr, *syms)
-
-        dim = len(expr.variables)
-
-        if dim == 1:
-            tex = r"\frac{\partial}{\partial %s}" % \
-                self._print(expr.variables[0])
-        else:
-            multiplicity, i, tex = [], 1, ""
-            current = expr.variables[0]
-
-            for symbol in expr.variables[1:]:
-                if symbol == current:
-                    i = i + 1
-                else:
-                    multiplicity.append((current, i))
-                    current, i = symbol, 1
-            else:
-                multiplicity.append((current, i))
-
-            for x, i in multiplicity:
-                if i == 1:
-                    tex += r"\partial %s" % self._print(x)
-                else:
-                    tex += r"\partial^{%s} %s" % (i, self._print(x))
-
-            tex = r"\frac{\partial^{%s}}{%s} " % (dim, tex)
-
-        if isinstance(expr.expr, C.AssocOp):
-            return r"%s\left(%s\right)" % (tex, base)
-        else:
-            return r"%s %s" % (tex, base)
+            base = r"\dot{%s}" % base
+        elif dots == 2:
+            base = r"\ddot{%s}" % base
+        elif dots == 3:
+            base = r"\dddot{%s}" % base
+        if len(base_split) is not 1:
+            base += '_' + base_split[1]
+        return base
 
 
 class MechanicsPrettyPrinter(PrettyPrinter):

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -442,8 +442,8 @@ class Dyadic(object):
 
     def simplify(self):
         """Simplify the elements in the Dyadic in-place."""
-        for i in self.args:
-            i[0].simplify()
+        for i, v in enumerate(self.args):
+            self.args[i] = (v[0].simplify(), v[1], v[2])
 
     def subs(self, *args, **kwargs):
         """Substituion on the Dyadic.

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -248,10 +248,21 @@ def mlatex(expr, **settings):
     Examples
     ========
 
-    >>> from sympy.physics.mechanics import mlatex, ReferenceFrame
+    >>> from sympy.physics.mechanics import mlatex, ReferenceFrame, dynamicsymbols
     >>> N = ReferenceFrame('N')
+    >>> q1, q2 = dynamicsymbols('q1 q2')
+    >>> q1d, q2d = dynamicsymbols('q1 q2', 1)
+    >>> q1dd, q2dd = dynamicsymbols('q1 q2', 2)
     >>> mlatex(N.x + N.y)
     '\\mathbf{\\hat{n}_x} + \\mathbf{\\hat{n}_y}'
+    >>> mlatex(q1 + q2)
+    'q_{1} + q_{2}'
+    >>> mlatex(q1d)
+    '\\dot{q}_{1}'
+    >>> mlatex(q1 * q2d)
+    'q_{1} \\dot{q}_{2}'
+    >>> mlatex(q1dd * q1 / q1d)
+    '\\frac{q_{1} \\ddot{q}_{1}}{\\dot{q}_{1}}'
 
     """
 

--- a/sympy/physics/mechanics/tests/test_essential.py
+++ b/sympy/physics/mechanics/tests/test_essential.py
@@ -1,4 +1,4 @@
-from sympy import cos, Matrix, sin
+from sympy import cos, Matrix, sin, symbols, pi
 from sympy.abc import x, y, z
 from sympy.physics.mechanics import Vector, ReferenceFrame, dot, dynamicsymbols
 
@@ -230,3 +230,47 @@ def test_Vector_diffs():
     assert v4.diff(q1d, B) == 0
     assert v4.diff(q2d, B) == A.x - q3 * cos(q3) * N.z
     assert v4.diff(q3d, B) == B.x + q3 * N.x + N.y
+
+def test_vector_simplify():
+    x, y, z, k, n, m, w, f, s, A = symbols('x, y, z, k, n, m, w, f, s, A')
+    N = ReferenceFrame('N')
+
+    test1 = (1 / x + 1 / y) * N.x
+    assert (test1 & N.x) != (x + y) / (x * y)
+    test1.simplify()
+    assert (test1 & N.x) == (x + y) / (x * y)
+
+    test2 = (A**2 * s**4 / (4 * pi * k * m**3)) * N.x
+    test2.simplify()
+    assert (test2 & N.x) == (A**2 * s**4 / (4 * pi * k * m**3))
+
+    test3 = ((4 + 4 * x - 2 * (2 + 2 * x)) / (2 + 2 * x)) * N.x
+    test3.simplify()
+    assert (test3 & N.x) == 0
+
+    test4 = ((-4 * x * y**2 - 2 * y**3 - 2 * x**2 * y) / (x + y)**2) * N.x
+    test4.simplify()
+    assert (test4 & N.x) == -2 * y
+
+def test_dyadic_simplify():
+    x, y, z, k, n, m, w, f, s, A = symbols('x, y, z, k, n, m, w, f, s, A')
+    N = ReferenceFrame('N')
+
+    dy = N.x | N.x
+    test1 = (1 / x + 1 / y) * dy
+    assert (N.x & test1 & N.x) != (x + y) / (x * y)
+    test1.simplify()
+    assert (N.x & test1 & N.x) == (x + y) / (x * y)
+
+    test2 = (A**2 * s**4 / (4 * pi * k * m**3)) * dy
+    test2.simplify()
+    assert (N.x & test2 & N.x) == (A**2 * s**4 / (4 * pi * k * m**3))
+
+    test3 = ((4 + 4 * x - 2 * (2 + 2 * x)) / (2 + 2 * x)) * dy
+    test3.simplify()
+    assert (N.x & test3 & N.x) == 0
+
+    test4 = ((-4 * x * y**2 - 2 * y**3 - 2 * x**2 * y) / (x + y)**2) * dy
+    test4.simplify()
+    assert (N.x & test4 & N.x) == -2 * y
+

--- a/sympy/physics/mechanics/tests/test_essential.py
+++ b/sympy/physics/mechanics/tests/test_essential.py
@@ -273,4 +273,3 @@ def test_dyadic_simplify():
     test4 = ((-4 * x * y**2 - 2 * y**3 - 2 * x**2 * y) / (x + y)**2) * dy
     test4.simplify()
     assert (N.x & test4 & N.x) == -2 * y
-


### PR DESCRIPTION
Latex printing for dynamic symbols wasn't working, now it is.
Also, the Vector and Dyadic simplify() method had an error which has been
corrected.
