### PR TITLE
Escape symbol names that are python keywords during printing

### DIFF
--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -61,7 +61,7 @@ def python(expr, **settings):
                     newsymbolname not in printer.functions):
                     renamings[sympy.Symbol(symbolname)] = sympy.Symbol(newsymbolname)
                     break
-        result += newsymbolname + ' = Symbol(\'' + newsymbolname + '\')\n'
+        result += newsymbolname + ' = Symbol(\'' + symbolname + '\')\n'
 
     for functionname in printer.functions:
         newfunctionname = functionname
@@ -75,7 +75,7 @@ def python(expr, **settings):
         #             newfunctionname not in printer.functions):
         #             renamings[sympy.Function(functionname)] = sympy.Function(newfunctionname)
         #             break
-        result += newfunctionname + ' = Function(\'' + newfunctionname + '\')\n'
+        result += newfunctionname + ' = Function(\'' + functionname + '\')\n'
 
     if not len(renamings) == 0:
         exprp = expr.xreplace(renamings)

--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -71,8 +71,8 @@ def python(expr, **settings):
         # if kw.iskeyword(newfunctionname):
         #     while True:
         #         newfunctionname += "_"
-        #         if (newsymbolname not in printer.symbols and
-        #             newsymbolname not in printer.functions):
+        #         if (newfunctionname not in printer.symbols and
+        #             newfunctionname not in printer.functions):
         #             renamings[sympy.Function(functionname)] = sympy.Function(newfunctionname)
         #             break
         result += newfunctionname + ' = Function(\'' + newfunctionname + '\')\n'

--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -54,6 +54,7 @@ def python(expr, **settings):
     renamings = {}
     for symbolname in printer.symbols:
         newsymbolname = symbolname
+        # Escape symbol names that are reserved python keywords
         if kw.iskeyword(newsymbolname):
             while True:
                 newsymbolname += "_"
@@ -65,20 +66,18 @@ def python(expr, **settings):
 
     for functionname in printer.functions:
         newfunctionname = functionname
-        # TODO
         # Escape function names that are reserved python keywords
-        # Fix does not work because we can not xreplace functions!
-        # if kw.iskeyword(newfunctionname):
-        #     while True:
-        #         newfunctionname += "_"
-        #         if (newfunctionname not in printer.symbols and
-        #             newfunctionname not in printer.functions):
-        #             renamings[sympy.Function(functionname)] = sympy.Function(newfunctionname)
-        #             break
+        if kw.iskeyword(newfunctionname):
+            while True:
+                newfunctionname += "_"
+                if (newfunctionname not in printer.symbols and
+                    newfunctionname not in printer.functions):
+                    renamings[sympy.Function(functionname)] = sympy.Function(newfunctionname)
+                    break
         result += newfunctionname + ' = Function(\'' + functionname + '\')\n'
 
     if not len(renamings) == 0:
-        exprp = expr.xreplace(renamings)
+        exprp = expr.subs(renamings)
     result += 'e = ' + printer._str(exprp)
     return result
 

--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -65,8 +65,9 @@ def python(expr, **settings):
     for function in printer.functions:
         result += function + ' = Function(\'' + function + '\')\n'
 
-    exprr = expr.xreplace(renamings)
-    result += 'e = ' + printer._str(exprr)
+    if not len(renamings) == 0:
+        exprp = expr.xreplace(renamings)
+    result += 'e = ' + printer._str(exprp)
     return result
 
 def print_python(expr, **settings):

--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -53,17 +53,27 @@ def python(expr, **settings):
     # Returning found symbols and functions
     renamings = {}
     for symbolname in printer.symbols:
-        variablename = symbolname
-        if kw.iskeyword(variablename):
+        newsymbolname = symbolname
+        if kw.iskeyword(newsymbolname):
             while True:
-                variablename += "_"
-                if variablename not in printer.symbols:
-                    renamings[sympy.Symbol(symbolname)] = sympy.Symbol(variablename)
+                newsymbolname += "_"
+                if newsymbolname not in printer.symbols:
+                    renamings[sympy.Symbol(symbolname)] = sympy.Symbol(newsymbolname)
                     break
-        result += variablename + ' = Symbol(\'' + variablename + '\')\n'
+        result += newsymbolname + ' = Symbol(\'' + newsymbolname + '\')\n'
 
-    for function in printer.functions:
-        result += function + ' = Function(\'' + function + '\')\n'
+    for functionname in printer.functions:
+        newfunctionname = functionname
+        # TODO
+        # Escape function names that are reserved python keywords
+        # Fix does not work because we can not xreplace functions!
+        # if kw.iskeyword(newfunctionname):
+        #     while True:
+        #         newfunctionname += "_"
+        #         if newfunctionname not in printer.functions:
+        #             renamings[sympy.Function(functionname)] = sympy.Function(newfunctionname)
+        #             break
+        result += newfunctionname + ' = Function(\'' + newfunctionname + '\')\n'
 
     if not len(renamings) == 0:
         exprp = expr.xreplace(renamings)

--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import keyword as kw
 import sympy
 from repr import ReprPrinter
 from str import StrPrinter
@@ -46,16 +47,26 @@ def python(expr, **settings):
     (can be passed to the exec() function without any modifications)"""
 
     printer = PythonPrinter(settings)
-    expr = printer.doprint(expr)
+    exprp = printer.doprint(expr)
 
     result = ''
     # Returning found symbols and functions
-    for symbol in printer.symbols:
-        result += symbol + ' = Symbol(\'' + symbol + '\')\n'
+    renamings = {}
+    for symbolname in printer.symbols:
+        variablename = symbolname
+        if kw.iskeyword(variablename):
+            while True:
+                variablename += "_"
+                if variablename not in printer.symbols:
+                    renamings[sympy.Symbol(symbolname)] = sympy.Symbol(variablename)
+                    break
+        result += variablename + ' = Symbol(\'' + variablename + '\')\n'
+
     for function in printer.functions:
         result += function + ' = Function(\'' + function + '\')\n'
 
-    result += 'e = ' + printer._str(expr)
+    exprr = expr.xreplace(renamings)
+    result += 'e = ' + printer._str(exprr)
     return result
 
 def print_python(expr, **settings):

--- a/sympy/printing/python.py
+++ b/sympy/printing/python.py
@@ -57,7 +57,8 @@ def python(expr, **settings):
         if kw.iskeyword(newsymbolname):
             while True:
                 newsymbolname += "_"
-                if newsymbolname not in printer.symbols:
+                if (newsymbolname not in printer.symbols and
+                    newsymbolname not in printer.functions):
                     renamings[sympy.Symbol(symbolname)] = sympy.Symbol(newsymbolname)
                     break
         result += newsymbolname + ' = Symbol(\'' + newsymbolname + '\')\n'
@@ -70,7 +71,8 @@ def python(expr, **settings):
         # if kw.iskeyword(newfunctionname):
         #     while True:
         #         newfunctionname += "_"
-        #         if newfunctionname not in printer.functions:
+        #         if (newsymbolname not in printer.symbols and
+        #             newsymbolname not in printer.functions):
         #             renamings[sympy.Function(functionname)] = sympy.Function(newfunctionname)
         #             break
         result += newfunctionname + ' = Function(\'' + newfunctionname + '\')\n'

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -63,14 +63,14 @@ def test_python_basic():
 def test_python_keyword_symbol_name_escaping():
     # Check for escaping of keywords
     assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda')\ne = 5*lambda_"
-    assert (python(5*Symbol("lambda")+7*Symbol("lambda_")) ==
+    assert (python(5*Symbol("lambda") + 7*Symbol("lambda_")) ==
             "lambda__ = Symbol('lambda')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
     assert (python(5*Symbol("for") + Function("for_")(8)) ==
             "for__ = Symbol('for')\nfor_ = Function('for_')\ne = 5*for__ + for_(8)")
 
-@XFAIL
 def test_python_keyword_function_name_escaping():
-    assert python(5*Function("for")(8)) == "for_ = Function('for_')\ne = 5*for_(8)"
+    assert python(5*Function("for")(8)) == "for_ = Function('for')\ne = 5*for_(8)"
+
 
 def test_python_relational():
     assert python(Eq(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x == y"

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -61,11 +61,11 @@ def test_python_basic():
             ]
 
     # Check for escaping of keywords
-    assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda_')\ne = 5*lambda_"
+    assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda')\ne = 5*lambda_"
     assert (python(5*Symbol("lambda")+7*Symbol("lambda_")) ==
-            "lambda__ = Symbol('lambda__')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
+            "lambda__ = Symbol('lambda')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
     assert (python(5*Symbol("for") + Function("for_")(8)) ==
-            "for__ = Symbol('for__')\nfor_ = Function('for_')\ne = 5*for__ + for_(8)")
+            "for__ = Symbol('for')\nfor_ = Function('for_')\ne = 5*for__ + for_(8)")
     #assert python(5*Function("for")(8)) == "for_ = Function('for_')\ne = 5*for_(8)"
 
 def test_python_relational():

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -64,6 +64,7 @@ def test_python_basic():
     assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda_')\ne = 5*lambda_"
     assert (python(5*Symbol("lambda")+7*Symbol("lambda_")) ==
             "lambda__ = Symbol('lambda__')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
+    #assert python(5*Function("for")(8)) == "for_ = Function('for_')\ne = 5*for_(8)"
 
 def test_python_relational():
     assert python(Eq(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x == y"

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -60,13 +60,17 @@ def test_python_basic():
             "x = Symbol('x')\ne = -3*x/2 + Rational(-1, 2)"
             ]
 
+def test_python_keyword_symbol_name_escaping():
     # Check for escaping of keywords
     assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda')\ne = 5*lambda_"
     assert (python(5*Symbol("lambda")+7*Symbol("lambda_")) ==
             "lambda__ = Symbol('lambda')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
     assert (python(5*Symbol("for") + Function("for_")(8)) ==
             "for__ = Symbol('for')\nfor_ = Function('for_')\ne = 5*for__ + for_(8)")
-    #assert python(5*Function("for")(8)) == "for_ = Function('for_')\ne = 5*for_(8)"
+
+@XFAIL
+def test_python_keyword_function_name_escaping():
+    assert python(5*Function("for")(8)) == "for_ = Function('for_')\ne = 5*for_(8)"
 
 def test_python_relational():
     assert python(Eq(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x == y"

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -64,6 +64,8 @@ def test_python_basic():
     assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda_')\ne = 5*lambda_"
     assert (python(5*Symbol("lambda")+7*Symbol("lambda_")) ==
             "lambda__ = Symbol('lambda__')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
+    assert (python(5*Symbol("for") + Function("for_")(8)) ==
+            "for__ = Symbol('for__')\nfor_ = Function('for_')\ne = 5*for__ + for_(8)")
     #assert python(5*Function("for")(8)) == "for_ = Function('for_')\ne = 5*for_(8)"
 
 def test_python_relational():

--- a/sympy/printing/tests/test_python.py
+++ b/sympy/printing/tests/test_python.py
@@ -60,6 +60,11 @@ def test_python_basic():
             "x = Symbol('x')\ne = -3*x/2 + Rational(-1, 2)"
             ]
 
+    # Check for escaping of keywords
+    assert python(5*Symbol("lambda")) == "lambda_ = Symbol('lambda_')\ne = 5*lambda_"
+    assert (python(5*Symbol("lambda")+7*Symbol("lambda_")) ==
+            "lambda__ = Symbol('lambda__')\nlambda_ = Symbol('lambda_')\ne = 7*lambda_ + 5*lambda__")
+
 def test_python_relational():
     assert python(Eq(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x == y"
     assert python(Ge(x, y)) == "x = Symbol('x')\ny = Symbol('y')\ne = x >= y"


### PR DESCRIPTION
Fixes issue 3394 "Symbol called lambda causes syntax error in code from python()".

NOTE: We should check if there is a similar issue with function names!
