### PR TITLE
Fix Sphinx doc failure in 0.7.2 branch.

### DIFF
--- a/doc/src/modules/ntheory.rst
+++ b/doc/src/modules/ntheory.rst
@@ -87,8 +87,6 @@ Ntheory Functions Reference
 
 .. module:: sympy.ntheory.residue_ntheory
 
-.. autofunction:: int_tested
-
 .. autofunction:: n_order
 
 .. autofunction:: is_primitive_root


### PR DESCRIPTION
The failure was introduced in one of the last merges.
