### PR TITLE
Fix typo in return from dup_zz_heu_gcd

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1276,7 +1276,7 @@ def dup_zz_heu_gcd(f, g, K):
 
                 if not r:
                     h = dup_mul_ground(h, gcd, K)
-                    return h, cff, cfg
+                    return h, cff_, cfg
 
         x = 73794*x * K.sqrt(K.sqrt(x)) // 27011
 

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -391,6 +391,15 @@ def test_dup_gcd():
     assert dup_qq_heu_gcd(f, g, QQ) == (h, g, [QQ(1,2)])
     assert dup_ff_prs_gcd(f, g, QQ) == (h, g, [QQ(1,2)])
 
+    f = ZZ.map([1317378933230047068160, 2945748836994210856960])
+    g = ZZ.map([120352542776360960, 269116466014453760])
+
+    h = ZZ.map([120352542776360960, 269116466014453760])
+    cff = ZZ.map([10946])
+    cfg = ZZ.map([1])
+
+    assert dup_zz_heu_gcd(f, g, ZZ) == (h, cff, cfg)
+
 def test_dmp_gcd():
     assert dmp_zz_heu_gcd([[]], [[]], 1, ZZ) == ([[]], [[]], [[]])
     assert dmp_rr_prs_gcd([[]], [[]], 1, ZZ) == ([[]], [[]], [[]])


### PR DESCRIPTION
This typo can lead to errors when cancelling polynomials. See the added tests for an example that fails.

I found this following the discussion here:
https://groups.google.com/d/msg/sympy/oC8FuQ_yWmo/Dqg3s1h2oXQJ
