### PR TITLE
3393: _random returns None when eval fails

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -328,7 +328,15 @@ class Expr(Basic, EvalfMixin):
             a, c, b, d = re_min, re_max, im_min, im_max
             reps = dict(zip(free, [random_complex_number(a, b, c, d, rational=True)
                            for zi in free]))
-            nmag = abs(self.evalf(2, subs=reps))
+            try:
+                nmag = abs(self.evalf(2, subs=reps))
+            except TypeError:
+                # if an out of range value resulted in evalf problems
+                # then return None -- XXX is there a way to know how to
+                # select a good random number for a given expression?
+                # e.g. when calculating n! negative values for n should not
+                # be used
+                return None
         else:
             reps = {}
             nmag = abs(self.evalf(2))

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1303,6 +1303,7 @@ def test_equals():
 def test_random():
     from sympy import posify
     assert posify(x)[0]._random() is not None
+    assert S('-pi*Abs(1/log(n!)) + 1')._random(2, -2, 0, -1, 0) is None
 
 def test_round():
     from sympy.abc import x


### PR DESCRIPTION
equals tries randomly evaluating the expression. Without a good way to know the domain in which to guess, sometimes it guesses in an invalid domain for which evalf fails. In this case, when a negative value for n is chosen, evalf fails. A hack is to watch for this in _random and just bail when this happens. 

http://code.google.com/p/sympy/issues/detail?id=3393
