### PR TITLE
WIP: Preprocess strings containing relational operators in sympify

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -106,6 +106,16 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     [1]
     [2]
 
+
+    See Also
+    ========
+
+    sympy.parsing.sympy_parser.parse_relationals: permits the parsing of <,
+        <=, ==, => and > into SymPy relational objects for use with solvers and
+        other. In future versions similar capabilities that differ too much
+        from python's ``eval`` (after which ``sympify`` is modeled) will be
+        consolidated in a complete parsing module.
+
     """
     try:
         cls = a.__class__

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -4,6 +4,7 @@ from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
 from sympy.core.decorators import _sympifyit
+from sympy.core.relational import Rel
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
@@ -403,3 +404,14 @@ def test_no_autosimplify_into_Mul():
     s = '-1 - 2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x)))'.replace('x', '_kern')
     ss = S(s)
     assert ss != 1 and ss.simplify() == -1
+
+def test_relationals():
+    from sympy.parsing.sympy_parser import parse_relationals
+    pr = parse_relationals
+    assert S(pr('sin(x)*x/5*5! <= y')) == Rel(24*sin(x)*x, y, '<=')
+    assert S(pr('sin(x)*x/5*5! != y')) == Rel(24*sin(x)*x, y, '!=')
+    assert S(pr('sin(x)*x/5*5! <> y')) == Rel(24*sin(x)*x, y, '<>')
+    assert S(pr('sin(x)*x/5*5! == y')) == Rel(24*sin(x)*x, y, '==')
+    assert S(pr('sin(x)*x/5*5! >= y')) == Rel(24*sin(x)*x, y, '>=')
+    assert S(pr('sin(x)*x/5*5! > y')) == Rel(24*sin(x)*x, y, '>')
+    assert S(pr('sin(x)*x/5*5! < y')) == Rel(24*sin(x)*x, y, '<')

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -167,3 +167,17 @@ def parse_expr(s, local_dict=None, rationalize=False, convert_xor=False):
         return expr.xreplace({C.Symbol(kern): 1})
     except (TypeError, AttributeError):
         return expr
+
+
+def parse_relationals(expr_string):
+    """Transform strings containing relational operators into strings calling Rel
+
+    >>> from sympy.parsing.sympy_parser import parse_relationals
+    >>> parse_relationals('x <= 5*sin(x)')
+    "Rel(x ,  5*sin(x), '<=')"
+    """
+    match = re.match(r'(?P<lhs>.*?)(?P<rel>==|<>|>=|<=|>|<|!=)(?P<rhs>.*)', expr_string)
+    if match:
+        return "Rel(%(lhs)s, %(rhs)s, '%(rel)s')" % match.groupdict()
+    else:
+        return expr_string


### PR DESCRIPTION
TODO: rebase with master

Now this works:

```
In [1]: sympify(parse_relationals('a<b'))
Out[1]: a < b

In [2]: sympify(parse_relationals('a==b'))
Out[2]: a = b

In [3]: sympify(parse_relationals('sin(a)==b'))
Out[3]: sin(a) = b
```

etc...

Fixes issue 1625

Due to how different this behavior is from that of python's `eval` I am not
adding it directly to `sympify`. When we implement more parsing functions we
will be able to build a better self-contained parser.
