### PR TITLE
3401: fix matrix slicing error

### DIFF
--- a/doc/src/modules/matrices.rst
+++ b/doc/src/modules/matrices.rst
@@ -120,38 +120,51 @@ careful - to access the entries as if they were a 1-d list.
 
 Now, the more standard entry access is a pair of indices:
 
-    >>> M[1,2]
+    >>> M[1, 2]
     6
-    >>> M[0,0]
+    >>> M[0, 0]
     1
-    >>> M[1,1]
+    >>> M[1, 1]
     5
 
 Since this is Python we're also able to slice submatrices::
 
-    >>> M[0:2,0:2]
+    >>> M[0:2, 0:2]
     [1  2]
     [    ]
     [4  5]
-    >>> M[1:2,2]
-    [6]
-    >>> M[:,2]
+    >>> M[2:2, 2]
+    []
+    >>> M[:, 2]
     [3]
     [ ]
     [6]
 
 Remember in the 2nd example above that slicing 2:2 gives an empty range and
-that, as in python, a 4 column list is indexed from 0 to 3. In particular, this
-mean a quick way to create a copy of the matrix is:
+that, as in python, a 4 column list is indexed from 0 to 3. You cannot access
+rows or columns that are not present unless they are in a slice:
 
-    >>> M2 = M[:,:]
-    >>> M2[0,0] = 100
+    >>> M[:, 10] # the 10-th column (not there)
+    Traceback (most recent call last):
+    ...
+    IndexError: Index out of range: a[[0, 10]]
+    >>> M[:, 10: 11] # the 10-th column, if there
+    []
+    >>> M[:, :10] # all columns up to the 10-th
+    [1  2  3]
+    [       ]
+    [4  5  6]
+
+Slicing allows a quick way to create a copy of the matrix:
+
+    >>> M2 = M[:, :]
+    >>> M2[0, 0] = 100
     >>> M
     [1  2  3]
     [       ]
     [4  5  6]
 
-See? Changing M2 didn't change M. Since we can slice, we can also assign
+Notice that changing M2 didn't change M. Since we can slice, we can also assign
 entries:
 
     >>> M = Matrix(([1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16]))

--- a/doc/src/modules/matrices.rst
+++ b/doc/src/modules/matrices.rst
@@ -12,17 +12,11 @@ import and declare our first Matrix object:
     >>> from sympy.interactive.printing import init_printing
     >>> init_printing(use_unicode=False, wrap_line=False, no_global=True)
     >>> from sympy.matrices import *
-    >>> Matrix([[1,0], [0,1]])
-    [1  0]
-    [    ]
-    [0  1]
-    >>> Matrix((
-    ...   Matrix((
-    ...     (1, 0, 0),
-    ...     (0, 0, 0)
-    ...   )),
-    ...   (0, 0, -1)
-    ... ))
+    >>> M = Matrix([[1,0,0], [0,0,0]]); M
+    [1  0  0]
+    [       ]
+    [0  0  0]
+    >>> Matrix([M, (0, 0, -1)])
     [1  0  0 ]
     [        ]
     [0  0  0 ]
@@ -118,7 +112,8 @@ careful - to access the entries as if they were a 1-d list.
     >>> M[4]
     5
 
-Now, the more standard entry access is a pair of indices:
+Now, the more standard entry access is a pair of indices which will always
+return the value at the corresponding row and column of the matrix:
 
     >>> M[1, 2]
     6
@@ -127,7 +122,8 @@ Now, the more standard entry access is a pair of indices:
     >>> M[1, 1]
     5
 
-Since this is Python we're also able to slice submatrices::
+Since this is Python we're also able to slice submatrices; slices always
+give a matrix in return, even if the dimension is 1 x 1::
 
     >>> M[0:2, 0:2]
     [1  2]
@@ -139,30 +135,39 @@ Since this is Python we're also able to slice submatrices::
     [3]
     [ ]
     [6]
+    >>> M[:1, 2]
+    [3]
 
-Remember in the 2nd example above that slicing 2:2 gives an empty range and
-that, as in python, a 4 column list is indexed from 0 to 3. You cannot access
-rows or columns that are not present unless they are in a slice:
+In the 2nd example above notice that the slice 2:2 gives an empty range. Note
+also (in keeping with 0-based indexing of Python) the first row/column is 0.
+
+You cannot access rows or columns that are not present unless they
+are in a slice:
 
     >>> M[:, 10] # the 10-th column (not there)
     Traceback (most recent call last):
     ...
     IndexError: Index out of range: a[[0, 10]]
-    >>> M[:, 10: 11] # the 10-th column, if there
+    >>> M[:, 10:11] # the 10-th column (if there)
     []
     >>> M[:, :10] # all columns up to the 10-th
     [1  2  3]
     [       ]
     [4  5  6]
 
-Slicing allows a quick way to create a copy of the matrix:
+Slicing an empty matrix works as long as you use a slice for the coordinate
+that has no size:
+
+    >>> Matrix(0, 3, [])[:, 1]
+    []
+
+Slicing gives a copy of what is sliced, so modifications of one object
+do not affect the other:
 
     >>> M2 = M[:, :]
     >>> M2[0, 0] = 100
-    >>> M
-    [1  2  3]
-    [       ]
-    [4  5  6]
+    >>> M[0, 0] == 100
+    False
 
 Notice that changing M2 didn't change M. Since we can slice, we can also assign
 entries:

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -49,7 +49,7 @@ class DeferredVector(Symbol):
     >>> func( [1, 2, 3] )
     (3, 6)
     """
-    def __getitem__(self,i):
+    def __getitem__(self, i):
         if i == -0:
             i = 0
         if i < 0:
@@ -205,7 +205,7 @@ class MatrixBase(object):
             a[i*self.rows:(i+1)*self.rows] = self.mat[i::self.cols]
         return self._new(self.cols,self.rows,a)
 
-    T = property(transpose,None,None,"Matrix transposition.")
+    T = property(transpose, None, None, "Matrix transposition.")
 
     def conjugate(self):
         """By-element conjugation.
@@ -269,54 +269,28 @@ class MatrixBase(object):
         except ShapeError:
             raise AttributeError("Dirac conjugation not possible.")
 
-    def __getitem__(self,key):
+    def __getitem__(self, key):
         """
         >>> from sympy import Matrix, I
-        >>> m=Matrix(((1,2+I),(3,4)))
-        >>> m  #doctest: +NORMALIZE_WHITESPACE
-        [1, 2 + I]
-        [3,     4]
-        >>> m[1,0]
+        >>> m = Matrix([
+        ... [1, 2 + I],
+        ... [3, 4    ]])
+        >>> m[1, 0]
         3
-        >>> m.H[1,0]
-        2 - I
 
         """
         if type(key) is tuple:
             i, j = key
             if type(i) is slice or type(j) is slice:
                 return self.submatrix(key)
-
             else:
-                # a2idx inlined
-                if type(i) is not int:
-                    try:
-                        i = i.__index__()
-                    except AttributeError:
-                        raise IndexError("Invalid index a[%r]" % (key,))
-                # a2idx inlined
-                if type(j) is not int:
-                    try:
-                        j = j.__index__()
-                    except AttributeError:
-                        raise IndexError("Invalid index a[%r]" % (key,))
-
-                i, j = self.key2ij((i, j))
-                if not (i>=0 and i<self.rows and j>=0 and j < self.cols):
-                    raise IndexError("Index out of range: a[%s]" % (key,))
-                else:
-                    return self.mat[i*self.cols + j]
-
-
+                i, j = self.key2ij(key)
+                return self.mat[i*self.cols + j]
         else:
             # row-wise decomposition of matrix
             if type(key) is slice:
                 return self.mat[key]
-            else:
-                k = a2idx(key)
-                if k is not None:
-                    return self.mat[k]
-        raise IndexError("Invalid index: a[%s]" % repr(key))
+            return self.mat[a2idx(key)]
 
     def __setitem__(self, key, value):
         raise NotImplementedError()
@@ -1020,7 +994,7 @@ class MatrixBase(object):
         [1, 2, 3, 4]
         [2, 3, 4, 5]
         [3, 4, 5, 6]
-        >>> m[:1, 1]   #doctest: +NORMALIZE_WHITESPACE
+        >>> m[:1, 1] #doctest: +NORMALIZE_WHITESPACE
         [1]
         >>> m[:2, :1] #doctest: +NORMALIZE_WHITESPACE
         [0]
@@ -1035,11 +1009,12 @@ class MatrixBase(object):
         extract
         """
         rlo, rhi, clo, chi = self.key2bounds(keys)
-        outLines, outCols = rhi-rlo, chi-clo
-        outMat = [0]*outLines*outCols
-        for i in xrange(outLines):
-            outMat[i*outCols:(i+1)*outCols] = self.mat[(i+rlo)*self.cols+clo:(i+rlo)*self.cols+chi]
-        return self._new(outLines,outCols,outMat)
+        outRows, outCols = rhi - rlo, chi - clo
+        outMat = [0]*outRows*outCols
+        for i in xrange(outRows):
+            outMat[i*outCols:(i+1)*outCols] = \
+            self.mat[(i + rlo)*self.cols + clo:(i + rlo)*self.cols + chi]
+        return self._new(outRows, outCols, outMat)
 
     def extract(self, rowsList, colsList):
         """
@@ -1082,8 +1057,8 @@ class MatrixBase(object):
         """
         cols = self.cols
         mat = self.mat
-        rowsList = [self.key2ij((k,0))[0] for k in rowsList]
-        colsList = [self.key2ij((0,k))[1] for k in colsList]
+        rowsList = [a2idx(k, self.rows) for k in rowsList]
+        colsList = [a2idx(k, self.cols) for k in colsList]
         return self._new(len(rowsList), len(colsList),
                 lambda i,j: mat[rowsList[i]*cols + colsList[j]])
 
@@ -1096,63 +1071,42 @@ class MatrixBase(object):
         ========
 
         key2ij
-        slice2bounds
         """
 
         islice, jslice = [isinstance(k, slice) for k in keys]
         if islice:
-            rlo, rhi = self.slice2bounds(keys[0], self.rows)
+            if not self.rows:
+                rlo = rhi = 0
+            else:
+                rlo, rhi = keys[0].indices(self.rows)[:2]
         else:
-            # assuming we don't have a
-            rlo, _ = self.slice2bounds((keys[0], 0), self.rows)
+            rlo = a2idx(keys[0], self.rows)
             rhi  = rlo + 1
         if jslice:
-            clo, chi = self.slice2bounds(keys[1], self.cols)
+            if not self.cols:
+                clo = chi = 0
+            else:
+                clo, chi = keys[1].indices(self.cols)[:2]
         else:
-            _, clo = self.slice2bounds((0, keys[1]), self.cols)
+            clo = a2idx(keys[1], self.cols)
             chi = clo + 1
-        if not ( 0<=rlo<=rhi and 0<=clo<=chi ):
-            raise IndexError("Slice indices out of range: a[%s]"%repr(keys))
         return rlo, rhi, clo, chi
 
+
     def key2ij(self, key):
-        """Converts key=(4,6) to 4,6 and ensures the key is correct. Negative
-        indices are also supported and are remapped to positives provided they
-        are valid indices.
+        """Converts key with two integers to canonical form, checking to see that
+        they are valid for the given shape.
 
         See Also
         ========
 
         key2bounds
-        slice2bounds
         """
 
         if not (is_sequence(key) and len(key) == 2):
             raise TypeError("wrong syntax: a[%s]. Use a[i,j] or a[(i,j)]"
-                    %repr(key))
-        i, j = [(k + n) if k < 0 else k for k, n in zip(key, (self.rows, self.cols))]
-        if not (i>=0 and i<self.rows and j>=0 and j < self.cols):
-            raise IndexError("Index out of range: a[%s]"%repr(key))
-        return i,j
-
-    def slice2bounds(self, key, defmax):
-        """
-        Takes slice or number and returns (min,max) for iteration
-        Takes a default maxval to deal with the slice ':' which is (none, none)
-
-        See Also
-        ========
-
-        key2bounds
-        key2ij
-        """
-        if isinstance(key, slice):
-            return key.indices(defmax)[:2]
-        elif isinstance(key, tuple):
-            key = [defmax - 1 if i == -1 else i for i in key]
-            return self.key2ij(key)
-        else:
-            raise IndexError("Improper index type")
+                    % repr(key))
+        return [a2idx(i, n) for i, n in zip(key, self.shape)]
 
     def applyfunc(self, f):
         """
@@ -3396,12 +3350,11 @@ class MatrixBase(object):
         ========
 
         >>> from sympy import Matrix
-        >>> m = Matrix(4, 4, [6, 5, -2, -3, -3, -1, 3, 3, 2, 1, -2, -3, -1, 1, 5, 5])
-        >>> m
-        [ 6,  5, -2, -3]
-        [-3, -1,  3,  3]
-        [ 2,  1, -2, -3]
-        [-1,  1,  5,  5]
+        >>> m = Matrix(4, 4, [
+        ...  6,  5, -2, -3,
+        ... -3, -1,  3,  3,
+        ...  2,  1, -2, -3,
+        ... -1,  1,  5,  5])
 
         >>> (P, Jcells) = m.jordan_cells()
         >>> Jcells[0]
@@ -3554,39 +3507,20 @@ class MutableMatrix(MatrixBase):
                 if is_sequence(value):
                     self.copyin_list(key, value)
                     return
+                raise ValueError('unexpected value: %s' % value)
             else:
-                # a2idx inlined
-                if type(i) is not int:
-                    try:
-                        i = i.__index__()
-                    except AttributeError:
-                        raise IndexError("Invalid index a[%r]" % (key,))
-
-                # a2idx inlined
-                if type(j) is not int:
-                    try:
-                        j = j.__index__()
-                    except AttributeError:
-                        raise IndexError("Invalid index a[%r]" % (key,))
-
-
-                i, j = self.key2ij((i,j))
-                if not (i>=0 and i<self.rows and j>=0 and j < self.cols):
-                    raise IndexError("Index out of range: a[%s]" % (key,))
-                else:
-                    self.mat[i*self.cols + j] = sympify(value)
-                    return
-
+                i, j = self.key2ij(key)
+                self.mat[i*self.cols + j] = sympify(value)
+                return
         else:
             # row-wise decomposition of matrix
             if type(key) is slice:
                 raise IndexError("Vector slices not implemented yet.")
             else:
                 k = a2idx(key)
-                if k is not None:
-                    self.mat[k] = sympify(value)
-                    return
-        raise IndexError("Invalid index: a[%s]"%repr(key))
+                self.mat[k] = sympify(value)
+                return
+        raise IndexError("Invalid index: a[%s]" % repr(key))
 
     def copyin_matrix(self, key, value):
         """
@@ -3891,7 +3825,7 @@ def force_mutable(x):
         return x.as_mutable()
     return x
 
-def classof(A,B):
+def classof(A, B):
     """
     Determines strategy for combining Immutable and Mutable matrices
 
@@ -4349,27 +4283,28 @@ class SparseMatrix(MatrixBase):
         self.mat = {}
         if len(args) == 3 and callable(args[2]):
             op = args[2]
-            if not isinstance(args[0], (int, Integer)) or not isinstance(args[1], (int, Integer)):
+            if not isinstance(args[0], (int, Integer)) or \
+               not isinstance(args[1], (int, Integer)):
                 raise TypeError("`args[0]` and `args[1]` must both be integers.")
             self.rows = args[0]
             self.cols = args[1]
             for i in range(self.rows):
                 for j in range(self.cols):
-                    value = sympify(op(i,j))
+                    value = sympify(op(i, j))
                     if value:
-                        self.mat[(i,j)] = value
-        elif len(args)==3 and isinstance(args[0],int) and \
+                        self.mat[(i, j)] = value
+        elif len(args) == 3 and isinstance(args[0], int) and \
                 isinstance(args[1],int) and is_sequence(args[2]):
             self.rows = args[0]
             self.cols = args[1]
             mat = args[2]
             for i in range(self.rows):
                 for j in range(self.cols):
-                    value = sympify(mat[i*self.cols+j])
+                    value = sympify(mat[i*self.cols + j])
                     if value:
-                        self.mat[(i,j)] = value
-        elif len(args)==3 and isinstance(args[0],int) and \
-                isinstance(args[1],int) and isinstance(args[2], dict):
+                        self.mat[(i, j)] = value
+        elif len(args) == 3 and isinstance(args[0], int) and \
+                isinstance(args[1], int) and isinstance(args[2], dict):
             self.rows = args[0]
             self.cols = args[1]
             # manual copy, copy.deepcopy() doesn't work
@@ -4385,52 +4320,39 @@ class SparseMatrix(MatrixBase):
             self.cols = c
             for i in range(self.rows):
                 for j in range(self.cols):
-                    value = mat[self.cols*i+j]
+                    value = mat[self.cols*i + j]
                     if value:
-                        self.mat[(i,j)] = value
+                        self.mat[(i, j)] = value
 
     def __getitem__(self, key):
-        if isinstance(key, slice) or isinstance(key, int):
-            lo, hi = self.slice2bounds(key, len(self))
+
+        if type(key) is tuple:
+            i, j = key
+            if isinstance(i, int) and isinstance(i, int):
+                i, j = self.key2ij(key)
+                return self.mat.get((i, j), S.Zero)
+            elif isinstance(i, slice) or isinstance(i, slice):
+                return self.submatrix(key)
+
+        # check for single arg, like M[:] or M[3]
+        if isinstance(key, slice):
+            lo, hi = self.key2bounds(key)
             L = []
             for i in range(lo, hi):
                 m, n = self.rowdecomp(i)
-                if (m, n) in self.mat:
-                    L.append(self.mat[(m, n)])
-                else:
-                    L.append(S.Zero)
-            if len(L) == 1:
-                return L[0]
-            else:
-                return L
-        if len(key) != 2:
-            raise ValueError("`key` must be of length 2.")
+                L.append(self.mat.get((m, n), S.Zero))
+            return L
 
-        if isinstance(key[0], int) and isinstance(key[1], int):
-            i, j=self.key2ij(key)
-            if (i, j) in self.mat:
-                return self.mat[(i, j)]
-            else:
-                return S.Zero
-        elif isinstance(key[0], slice) or isinstance(key[1], slice):
-            return self.submatrix(key)
-        else:
-            raise IndexError("Index out of range: a[%s]"%repr(key))
+        lo = a2idx(key)
+        i, j = self.rowdecomp(lo)
+        return self.mat.get((i, j), S.Zero)
 
     def rowdecomp(self, num):
         """
         Perform a row decomposition on the matrix.
         """
-        nmax = len(self)
-        if not (0 <= num < nmax) or not (0 <= -num < nmax):
-            raise ValueError("`num` must satisfy 0 <= `num` < `self.rows*" +
-                "*self.cols` (%d) and 0 <= -num < " % nmax +
-                "`self.rows*self.cols` (%d) to apply redecomp()." % nmax)
-        i, j = 0, num
-        while j >= self.cols:
-            j -= self.cols
-            i += 1
-        return i,j
+        num = a2idx(num, len(self))
+        return divmod(num, self.cols)
 
     def __setitem__(self, key, value):
         # almost identical, need to test for 0
@@ -4443,7 +4365,7 @@ class SparseMatrix(MatrixBase):
             if is_sequence(value):
                 self.copyin_list(key, value)
         else:
-            i, j=self.key2ij(key)
+            i, j = self.key2ij(key)
             testval = sympify(value)
             if testval:
                 self.mat[(i, j)] = testval
@@ -4472,7 +4394,7 @@ class SparseMatrix(MatrixBase):
         col_del
         """
         newD = {}
-        k = self.key2ij((k, 0))[0]
+        k = a2idx(k, self.rows)
         for (i, j) in self.mat.keys():
             if i == k:
                 pass
@@ -4506,7 +4428,7 @@ class SparseMatrix(MatrixBase):
         row_del
         """
         newD = {}
-        k = self.key2ij((0, k))[1]
+        k = a2idx(k, self.cols)
         for (i, j) in self.mat.keys():
             if j == k:
                 pass
@@ -4789,18 +4711,6 @@ def matrix2numpy(m): # pragma: no cover
             a[i, j] = m[i, j]
     return a
 
-def a2idx(a):
-    """
-    Tries to convert "a" to an index, returns None on failure.
-
-    The result of a2idx() (if not None) can be safely used as an index to
-    arrays/matrices.
-    """
-    if hasattr(a, "__int__"):
-        return int(a)
-    if hasattr(a, "__index__"):
-        return a.__index__()
-
 def symarray(prefix, shape):
     """Create a numpy ndarray of symbols (as an object array).
 
@@ -4987,5 +4897,19 @@ def rot_axis1(theta):
            (0,ct,st),
            (0,-st,ct))
     return MutableMatrix(mat)
+
+def a2idx(j, n=None):
+    """Return integer after making positive and validating against n."""
+    if type(j) is not int:
+        try:
+            j = j.__index__()
+        except AttributeError:
+            raise IndexError("Invalid index a[%r]" % (j,))
+    if n is not None:
+        if j < 0:
+            j += n
+        if not (j >= 0 and j < n):
+            raise IndexError("Index out of range: a[%s]" % (j,))
+    return int(j)
 
 Matrix = MutableMatrix

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -379,7 +379,20 @@ class MatrixBase(object):
 
     @property
     def shape(self):
-        """The shape (dimensions) of the matrix as the 2-tuple (rows, cols)."""
+        """The shape (dimensions) of the matrix as the 2-tuple (rows, cols).
+
+        Examples
+        ========
+
+        >>> from sympy.matrices import zeros
+        >>> M = zeros(2, 3)
+        >>> M.shape
+        (2, 3)
+        >>> M.rows
+        2
+        >>> M.cols
+        3
+        """
         return (self.rows, self.cols)
 
     def __rmul__(self,a):
@@ -3515,6 +3528,7 @@ class MutableMatrix(MatrixBase):
         self.cols = cols
         self.mat = list(mat) # create a shallow copy
         return self
+
     def __new__(cls, *args, **kwargs):
         return cls._new(*args, **kwargs)
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1719,7 +1719,6 @@ def test_errors():
     raises(IndexError, lambda: Matrix([[1, 2]])[1.2, 5])
     raises(IndexError, lambda: Matrix([[1, 2]])[1, 5.2])
     raises(ValueError, lambda: randMatrix(3, c=4, symmetric=True))
-    raises(IndexError, lambda: Matrix([1, 2]).slice2bounds('a', 4))
     raises(ValueError, lambda: Matrix([1, 2]).reshape(4, 6))
     raises(ShapeError,
         lambda: Matrix([[1, 2], [3, 4]]).copyin_matrix([1, 0], Matrix([1, 2])))
@@ -1766,7 +1765,7 @@ def test_errors():
     raises(TypeError, lambda: SparseMatrix(1.4, 2, lambda i, j: 0))
     raises(TypeError, lambda: SparseMatrix([1, 2, 3], [1, 2]))
     raises(ValueError, lambda: SparseMatrix([[1, 2], [3, 4]])[(1, 2, 3)])
-    raises(ValueError, lambda: SparseMatrix([[1, 2], [3, 4]]).rowdecomp(5))
+    raises(IndexError, lambda: SparseMatrix([[1, 2], [3, 4]]).rowdecomp(5))
     with raises(ValueError):
       SparseMatrix([[1, 2], [3, 4]])[1, 2, 3] = 4
     raises(TypeError,
@@ -2157,13 +2156,16 @@ def test_zero_dimension_multiply():
     assert zeros(0, 3)*zeros(3, 0) == Matrix()
 
 def test_slice_issue_2884():
-    m = Matrix(2,2,range(4))
+    m = Matrix(2, 2, range(4))
     assert m[1,:] == Matrix([[2, 3]])
     assert m[-1,:] == Matrix([[2, 3]])
     assert m[:,1] == Matrix([[1, 3]]).T
     assert m[:,-1] == Matrix([[1, 3]]).T
     raises(IndexError, lambda: m[2,:])
     raises(IndexError, lambda: m[2,2])
+
+def test_slice_issue_3401():
+    assert zeros(0, 3)[:, -1].shape == (0, 1)
 
 def test_invertible_check():
     x = symbols('x')


### PR DESCRIPTION
These modifications come out of the discussion about the regression in how Matrix deals with indices of slices when the matrix has zero-dimension. The discussion arose in #1530 and http://code.google.com/p/sympy/issues/detail?id=3401
