### PR TITLE
Some fixed tests, increased coverage.

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -552,6 +552,8 @@ class Add(AssocOp):
             if terms_self == -terms_old:                      # (2 + a).subs(-3 - a, y) -> -1 - y
                 return Add(-new, coeff_self,  coeff_old)
 
+        if coeff_self.is_Rational and coeff_old.is_Rational \
+                or coeff_self == coeff_old:
             args_old, args_self = Add.make_args(terms_old), Add.make_args(terms_self)
             if len(args_old) < len(args_self):    # (a+b+c+d).subs(b+c,x) -> a+x+d
                 self_set = set(args_self)

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -4,9 +4,6 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import exp
 from sympy.utilities.pytest import XFAIL
 
-def test_issue153():
-    assert sqrt(2*(1 + sqrt(2))) == sqrt((2 + 2*sqrt(2)))
-
 def test_rational():
     a = Rational(1, 5)
 

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -5,8 +5,7 @@ from sympy.functions.elementary.exponential import exp
 from sympy.utilities.pytest import XFAIL
 
 def test_issue153():
-    #test that is runs:
-    a = sqrt(2*(1+sqrt(2)))
+    assert sqrt(2*(1 + sqrt(2))) == sqrt((2 + 2*sqrt(2)))
 
 def test_rational():
     a = Rational(1, 5)

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -123,6 +123,7 @@ def dotest(s):
     for x in all_objs:
         for y in all_objs:
             s(x,y)
+    return True
 
 def test_basic():
     def j(a,b):
@@ -134,7 +135,7 @@ def test_basic():
         x = a*b
         x = a/b
         x = a**b
-    dotest(j)
+    assert dotest(j)
 
 def test_ibasic():
     def s(a,b):
@@ -146,7 +147,7 @@ def test_ibasic():
         x *= b
         x = a
         x /= b
-    dotest(s)
+    assert dotest(s)
 
 def test_relational():
     assert (pi < 3) == False

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -410,7 +410,7 @@ def test_diff_wrt():
     assert diff(f(g(x)),g(x)) == Subs(Derivative(f(x), x), (x,), (g(x),))
 
 def test_diff_wrt_func_subs():
-     f(g(x)).diff(x).subs(g, Lambda(x, 2*x)) == f(2*x).diff(x)
+    assert f(g(x)).diff(x).subs(g, Lambda(x, 2*x)).doit() == f(2*x).diff(x)
 
 def test_diff_wrt_not_allowed():
     raises(ValueError, lambda: diff(sin(x**2),x**2))

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -8,7 +8,7 @@ x, y, z, t = symbols('x,y,z,t')
 
 
 def test_rel_ne():
-    Relational(x, y, '!=')  # this used to raise
+    assert Relational(x, y, '!=') == Ne(x, y)
 
 
 def test_rel_subs():

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -65,7 +65,7 @@ def test_bug():
     x1 = Symbol('x1')
     x2 = Symbol('x2')
     y = x1*x2
-    y.subs(x1, Float(3.0))
+    assert y.subs(x1, Float(3.0)) == Float(3.0)*x2
 
 def test_subbug1():
     x = Symbol('x')
@@ -440,17 +440,17 @@ def test_subs_dict():
 def test_no_arith_subs_on_floats():
     a, x, y = symbols('a,x,y')
 
-    (x + 3).subs(x + 3, a) == a
-    (x + 3).subs(x + 2, a) == a + 1
+    assert (x + 3).subs(x + 3, a) == a
+    assert (x + 3).subs(x + 2, a) == a + 1
 
-    (x + y + 3).subs(x + 3, a) == a + y
-    (x + y + 3).subs(x + 2, a) == a + y + 1
+    assert (x + y + 3).subs(x + 3, a) == a + y
+    assert (x + y + 3).subs(x + 2, a) == a + y + 1
 
-    (x + 3.0).subs(x + 3.0, a) == a
-    (x + 3.0).subs(x + 2.0, a) == x + y + 3.0
+    assert (x + 3.0).subs(x + 3.0, a) == a
+    assert (x + 3.0).subs(x + 2.0, a) == x + 3.0
 
-    (x + y + 3.0).subs(x + 3.0, a) == a + y
-    (x + y + 3.0).subs(x + 2.0, a) == x + y + 3.0
+    assert (x + y + 3.0).subs(x + 3.0, a) == a + y
+    assert (x + y + 3.0).subs(x + 2.0, a) == x + y + 3.0
 
 @XFAIL
 def test_issue_2261() :

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -197,8 +197,8 @@ def test_sage():
     assert hasattr(log(x), "_sage_")
 
 def test_bug496():
-    a_ = sympify("a_")
-    _a = sympify("_a")
+    assert sympify("a_") == Symbol("a_")
+    assert sympify("_a") == Symbol("_a")
 
 @XFAIL
 def test_lambda():

--- a/sympy/core/tests/test_truediv.py
+++ b/sympy/core/tests/test_truediv.py
@@ -23,6 +23,7 @@ def dotest(s):
     for x in l:
         for y in l:
             s(x,y)
+    return True
 
 def test_basic():
     def s(a,b):
@@ -34,7 +35,7 @@ def test_basic():
         x = a*b
         x = a/b
         x = a**b
-    dotest(s)
+    assert dotest(s)
 
 def test_ibasic():
     def s(a,b):
@@ -46,4 +47,4 @@ def test_ibasic():
         x *= b
         x = a
         x /= b
-    dotest(s)
+    assert dotest(s)

--- a/sympy/diffgeom/__init__.py
+++ b/sympy/diffgeom/__init__.py
@@ -1,1 +1,9 @@
-from diffgeom import *
+from diffgeom import (
+    BaseCovarDerivativeOp, BaseScalarField, BaseVectorField, Commutator,
+    contravariant_order, CoordSystem, CovarDerivativeOp, covariant_order,
+    Differential, intcurve_diffequ, intcurve_series, LieDerivative,
+    Manifold, metric_to_Christoffel_1st, metric_to_Christoffel_2nd,
+    metric_to_Ricci_components, metric_to_Riemann_components, Patch,
+    Point, TensorProduct, twoform_to_matrix, vectors_in_basis,
+    WedgeProduct,
+)

--- a/sympy/geometry/__init__.py
+++ b/sympy/geometry/__init__.py
@@ -20,6 +20,7 @@ from sympy.geometry.point import Point
 from sympy.geometry.line import Line, Ray, Segment
 from sympy.geometry.ellipse import Ellipse, Circle
 from sympy.geometry.polygon import Polygon, RegularPolygon, Triangle, rad, deg
-from sympy.geometry.util import *
-from sympy.geometry.exceptions import *
+from sympy.geometry.util import are_similar, centroid, convex_hull, idiff, \
+    intersection
+from sympy.geometry.exceptions import GeometryError
 from sympy.geometry.curve import Curve

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -935,9 +935,9 @@ def test_repr():
 
 def test_transform():
     p = Point(1, 1)
-    p.transform(rotate(pi/2)) == Point(-1, 1)
-    p.transform(scale(3, 2)) == Point(3, 2)
-    p.transform(translate(1, 2)) == Point(2, 3)
+    assert p.transform(rotate(pi/2)) == Point(-1, 1)
+    assert p.transform(scale(3, 2)) == Point(3, 2)
+    assert p.transform(translate(1, 2)) == Point(2, 3)
 
 def test_line_intersection():
     assert asa(120, 8, 52) == \

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -701,7 +701,7 @@ def test_issue1304():
 
 def test_issue459():
     from sympy import Si
-    integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)) == 2*Si(pi**2/2)
+    assert integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)) == 2*Si(pi**2/2)
 
 def test_issue1394():
     from sympy import simplify

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -15,8 +15,8 @@ def test_immutability():
         IM[2,2] = 5
 
 def test_slicing():
-    IM[1,:] == ImmutableMatrix([[4,5,6]])
-    IM[:2, :2] == ImmutableMatrix([[1,2],[4,5]])
+    assert IM[1, :] == ImmutableMatrix([[4, 5, 6]])
+    assert IM[:2, :2] == ImmutableMatrix([[1, 2], [4, 5]])
 
 def test_subs():
     A = ImmutableMatrix([[1,2],[3,4]])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -389,10 +389,11 @@ def test_expand():
         Matrix([cos(a) + I*sin(a)])
 
 def test_random():
-    M = randMatrix(3,3)
-    M = randMatrix(3,3,seed=3)
-    M = randMatrix(3,4,0,150)
+    M = randMatrix(3, 3)
+    M = randMatrix(3, 3, seed=3)
+    M = randMatrix(3, 4, 0, 150)
     M = randMatrix(3, symmetric=True)
+    assert M.is_symmetric() is True
 
 def test_LUdecomp():
     testmat = Matrix([[0,2,5,3],

--- a/sympy/physics/quantum/tests/test_qft.py
+++ b/sympy/physics/quantum/tests/test_qft.py
@@ -19,9 +19,6 @@ def test_RkGate():
     assert represent(RkGate(0,x), nqubits =1) ==\
     Matrix([[1,0],[0,exp(2*I*pi/2**x)]])
 
-def test_RkGate_controled():
-    pass
-
 def test_quantum_fourier():
     assert QFT(0,3).decompose() == SwapGate(0,2)*HadamardGate(0)*CGate((0,), PhaseGate(1))\
     *HadamardGate(1)*CGate((0,), TGate(2))*CGate((1,), PhaseGate(2))*HadamardGate(2)

--- a/sympy/plotting/intervalmath/tests/test_interval_functions.py
+++ b/sympy/plotting/intervalmath/tests/test_interval_functions.py
@@ -1,6 +1,11 @@
 from __future__ import division
-from sympy.plotting.intervalmath import *
+
 from sympy.external import import_module
+from sympy.plotting.intervalmath import (
+    Abs, acos, acosh, And, asin, asinh, atan, atanh, ceil, cos, cosh,
+    exp, floor, imax, imin, interval, log, log10, Or, sin, sinh, sqrt,
+    tan, tanh,
+)
 
 np = import_module('numpy')
 if not np:

--- a/sympy/polys/tests/test_distributedpolys.py
+++ b/sympy/polys/tests/test_distributedpolys.py
@@ -59,56 +59,8 @@ def test_sdp_monoms():
     assert sdp_monoms([((1,0), QQ(1,2))]) == [(1,0)]
     assert sdp_monoms([((1,1), QQ(1,4)), ((1,0), QQ(1,2))]) == [(1,1), (1,0)]
 
-def test_sdp_sort():
-    pass
-
 def test_sdp_strip():
     assert sdp_strip([((2,2), 0), ((1,1), 1), ((0,0), 0)]) == [((1,1), 1)]
-
-def test_sdp_normal():
-    pass
-
-def test_sdp_from_dict():
-    pass
-
-def test_sdp_indep_p():
-    pass
-
-def test_sdp_one_p():
-    pass
-
-def test_sdp_one():
-    pass
-
-def test_sdp_term_p():
-    pass
-
-def test_sdp_abs():
-    pass
-
-def test_sdp_neg():
-    pass
-
-def test_sdp_add_term():
-    pass
-
-def test_sdp_sub_term():
-    pass
-
-def test_sdp_mul_term():
-    pass
-
-def test_sdp_add():
-    pass
-
-def test_sdp_sub():
-    pass
-
-def test_sdp_mul():
-    pass
-
-def test_sdp_sqr():
-    pass
 
 def test_sdp_pow():
     f = sdp_from_dict({(1,): 2, (0,): 3}, grlex)
@@ -132,15 +84,6 @@ def test_sdp_pow():
     assert sdp_pow(f, 2, 2, grlex, ZZ) == g
 
     raises(ValueError, lambda: sdp_pow(f, -2, 2, grlex, ZZ))
-
-def test_sdp_monic():
-    pass
-
-def test_sdp_content():
-    pass
-
-def test_sdp_primitive():
-    pass
 
 def test_sdp_div():
     f = sdp_from_dict({(2,1): 4, (1,1): -2, (1,0): 4, (0,1): -2, (0,0): 8}, grlex)
@@ -247,9 +190,3 @@ def test_sdp_rem():
     r = sdp_from_dict({(1,0): 2, (0,0): 1}, grlex)
 
     assert sdp_rem(f, G, 1, grlex, ZZ) == r
-
-def test_sdp_lcm():
-    pass
-
-def test_sdp_gcd():
-    pass

--- a/sympy/polys/tests/test_groebnertools.py
+++ b/sympy/polys/tests/test_groebnertools.py
@@ -426,9 +426,6 @@ def test_f5_reduce():
     s = lbp(sig(Sign(s)[0], 100), Polyn(s), Num(s))
     assert f5_reduce(s, F, 2, lex, QQ) == s
 
-def test_matrix_fglm():
-    pass  # see test_polytools.py
-
 def test_representing_matrices():
     basis = [(0, 0), (0, 1), (1, 0), (1, 1)]
     F = [[((2, 0), QQ(1,1)), ((1, 0), QQ(-1,1)), ((0, 1), QQ(-3,1)), ((0, 0), QQ(1,1))],

--- a/sympy/polys/tests/test_polyclasses.py
+++ b/sympy/polys/tests/test_polyclasses.py
@@ -347,9 +347,6 @@ def test_DMF__init__():
     raises(ValueError, lambda: DMF(([1], [[1]]), ZZ))
     raises(ZeroDivisionError, lambda: DMF(([1], []), ZZ))
 
-def test_DMF__eq__():
-    pass
-
 def test_DMF__bool__():
     assert bool(DMF([[]], ZZ)) == False
     assert bool(DMF([[1]], ZZ)) == True

--- a/sympy/polys/tests/test_polyoptions.py
+++ b/sympy/polys/tests/test_polyoptions.py
@@ -403,9 +403,6 @@ def test_All_postprocess():
 
     assert opt == {'all': True}
 
-def test_Gen_preprocess():
-    pass
-
 def test_Gen_postprocess():
     opt = {'gen': x}
     Gen.postprocess(opt)

--- a/sympy/printing/__init__.py
+++ b/sympy/printing/__init__.py
@@ -1,13 +1,14 @@
 """Printing subsystem"""
 
-from pretty import *
+from pretty import pager_print, pretty, pretty_print, pprint, \
+    pprint_use_unicode, pprint_try_use_unicode
 from latex import latex, print_latex
 from mathml import mathml, print_mathml
 from python import python, print_python
 from ccode import ccode, print_ccode
 from fcode import fcode, print_fcode
 from jscode import jscode, print_jscode
-from gtk import *
+from gtk import print_gtk
 from preview import preview
 from repr import srepr
 from tree import print_tree

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -100,9 +100,6 @@ def test_mathml_tuples():
     assert mml_2.childNodes[1].nodeName == 'cn'
     assert len(mml_2.childNodes) == 2
 
-def test_mathml_matrices():
-    pass #TODO
-
 def test_mathml_add():
     mml = mp._print(x**5 - x**4 + x)
     assert mml.childNodes[0].nodeName == 'plus'

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1231,8 +1231,8 @@ def test_unpolarify():
     assert unpolarify(True) is True
 
 def test_issue_2998():
-    collect(a*y**(2.0*x)+b*y**(2.0*x),y**(x)) == y**(2.0*x)*(a + b)
-    collect(a*2**(2.0*x)+b*2**(2.0*x),2**(x)) == 2**(2.0*x)*(a + b)
+    assert collect(a*y**(2.0*x) + b*y**(2.0*x), y**x) == y**(2.0*x)*(a + b)
+    assert collect(a*2**(2.0*x) + b*2**(2.0*x), 2**x) == 2**(2.0*x)*(a + b)
 
 def test_signsimp():
     e = x*(-x + 1) + x*(x - 1)

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -61,11 +61,6 @@ def recurrence_term(c, f):
     """Compute RHS of recurrence in f(n) with coefficients in c."""
     return sum(c[i]*f.subs(n, n+i) for i in range(len(c)))
 
-def rsolve_bulk_checker(solver, c, q, p):
-    """Used by test_rsolve_bulk."""
-    pp = solver(c, q, n)
-    assert pp == p
-
 def test_rsolve_bulk():
     """Some bulk-generated tests."""
     funcs = [ n, n+1, n**2, n**3, n**4, n+n**2, 27*n + 52*n**2 - 3*n**3 + 12*n**4 - 52*n**5 ]
@@ -75,9 +70,9 @@ def test_rsolve_bulk():
         for c in coeffs:
             q = recurrence_term(c, p)
             if p.is_polynomial(n):
-                yield rsolve_bulk_checker, rsolve_poly, c, q, p
+                assert rsolve_poly(c, q, n) == p
             #if p.is_hypergeometric(n):
-            #    yield rsolve_bulk_checker, rsolve_hyper, c, q, p
+            #    assert rsolve_hyper(c, q, n) == p
 
 def test_rsolve():
     f = y(n+2) - y(n+1) - y(n)

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -39,13 +39,23 @@ Examples
 __all__ = []
 
 import rv_interface
-from rv_interface import *
+from rv_interface import (
+    cdf, covariance, density, dependent, E, given, independent, P, pspace,
+    random_symbols, sample, sample_iter, skewness, std, variance, where,
+)
 __all__.extend(rv_interface.__all__)
 
 import frv_types
-from frv_types import *
+from frv_types import (
+    Bernoulli, Binomial, Coin, Die, DiscreteUniform, FiniteRV, Hypergeometric,
+)
 __all__.extend(frv_types.__all__)
 
 import crv_types
-from crv_types import *
+from crv_types import (
+    Arcsin, Benini, Beta, BetaPrime, Cauchy, Chi, ContinuousRV, Dagum,
+    Exponential, Gamma, Laplace, Logistic, LogNormal, Maxwell, Nakagami,
+    Normal, Pareto, Rayleigh, StudentT, Triangular, Uniform, UniformSum,
+    Weibull, WignerSemicircle,
+)
 __all__.extend(crv_types.__all__)

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -74,9 +74,9 @@ def test_dice():
 
 def test_given():
     X = Die('X', 6)
-    density(X, X>5) == {S(6): S(1)}
-    where(X>2, X>5).as_boolean() == Eq(X.symbol, 6)
-    sample(X, X>5) == 6
+    assert density(X, X > 5) == {S(6): S(1)}
+    assert where(X > 2, X > 5).as_boolean() == Eq(X.symbol, 6)
+    assert sample(X, X > 5) == 6
 
 def test_domains():
     X, Y= Die('x', 6), Die('y', 6)

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -155,7 +155,7 @@ def test_files():
         "%(sep)splotting%(sep)stextplot.py" % sepd,
     ])
     check_files(top_level_files, test)
-    check_directory_tree(BIN_PATH, test, set([".pyc"]), "*")
+    check_directory_tree(BIN_PATH, test, set(["~", ".pyc"]), "*")
     check_directory_tree(SYMPY_PATH, test, exclude)
     check_directory_tree(EXAMPLES_PATH, test, exclude)
 

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -2,7 +2,7 @@ from __future__ import with_statement
 from sympy.core.compatibility import reduce
 
 from os import walk, sep, chdir, pardir
-from os.path import split, join, abspath, exists
+from os.path import split, join, abspath, exists, isfile
 from glob import glob
 import re
 import random
@@ -57,7 +57,7 @@ def tab_in_leading(s):
         check = s[:n] + smore[:len(smore)-len(smore.lstrip())]
     return not (check.expandtabs() == check)
 
-def check_directory_tree(base_path, file_check, exclusions=set()):
+def check_directory_tree(base_path, file_check, exclusions=set(), pattern="*.py"):
     """
     Checks all files in the directory tree (with base_path as starting point)
     with the file_check function provided, skipping files that contain
@@ -66,10 +66,21 @@ def check_directory_tree(base_path, file_check, exclusions=set()):
     if not base_path:
         return
     for root, dirs, files in walk(base_path):
-        for fname in glob(join(root, "*.py")):
-            if filter(lambda ex: ex in fname, exclusions):
-                continue
-            file_check(fname)
+        check_files(glob(join(root, pattern)), file_check, exclusions)
+
+def check_files(files, file_check, exclusions=set()):
+    """
+    Checks all files with the file_check function provided, skipping files
+    that contain any of the strings in the set provided by exclusions.
+    """
+    if not files:
+        return
+    for fname in files:
+        if not exists(fname) or not isfile(fname):
+            continue
+        if filter(lambda ex: ex in fname, exclusions):
+            continue
+        file_check(fname)
 
 def test_files():
     """

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -124,9 +124,17 @@ def test_files():
                 # eof newline check
                 assert False, message_eof % (fname, idx+1)
 
+    # Files to test at top level
+    top_level_files = [join(TOP_PATH, file) for file in [
+        "build.py",
+        "setup.py",
+        "setupegg.py",
+    ]]
+    # Files to exclude from all tests
     exclude = set([
         "%(sep)smpmath%(sep)s" % sepd,
     ])
+    # Files to exclude from the implicit import test
     import_exclude = set([
         # glob imports are allowed in top-level __init__.py:
         "%(sep)ssympy%(sep)s__init__.py" % sepd,
@@ -135,12 +143,19 @@ def test_files():
         "%(sep)squantum%(sep)s__init__.py" % sepd,
         # interactive sympy executes ``from sympy import *``:
         "%(sep)sinteractive%(sep)ssession.py" % sepd,
+        # isympy executes ``from sympy import *``:
+        "%(sep)sbin%(sep)sisympy" % sepd,
+        # these two are import timing tests:
+        "%(sep)sbin%(sep)ssympy_time.py" % sepd,
+        "%(sep)sbin%(sep)ssympy_time_cache.py" % sepd,
         # Taken from Python stdlib:
         "%(sep)sparsing%(sep)ssympy_tokenize.py" % sepd,
         # these two should be fixed:
         "%(sep)splotting%(sep)spygletplot%(sep)s" % sepd,
         "%(sep)splotting%(sep)stextplot.py" % sepd,
     ])
+    check_files(top_level_files, test)
+    check_directory_tree(BIN_PATH, test, set([".pyc"]), "*")
     check_directory_tree(SYMPY_PATH, test, exclude)
     check_directory_tree(EXAMPLES_PATH, test, exclude)
 

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -123,13 +123,18 @@ def test_files():
         "%(sep)smpmath%(sep)s" % sepd,
     ])
     import_exclude = set([
-        "%(sep)s__init__.py" % sepd,
+        # glob imports are allowed in top-level __init__.py:
+        "%(sep)ssympy%(sep)s__init__.py" % sepd,
+        # these __init__.py should be fixed:
+        "%(sep)smechanics%(sep)s__init__.py" % sepd,
+        "%(sep)squantum%(sep)s__init__.py" % sepd,
+        # interactive sympy executes ``from sympy import *``:
         "%(sep)sinteractive%(sep)ssession.py" % sepd,
         # Taken from Python stdlib:
         "%(sep)sparsing%(sep)ssympy_tokenize.py" % sepd,
         # these two should be fixed:
-        "%(sep)smpmath%(sep)s" % sepd,
-        "%(sep)splotting%(sep)s" % sepd,
+        "%(sep)splotting%(sep)spygletplot%(sep)s" % sepd,
+        "%(sep)splotting%(sep)stextplot.py" % sepd,
     ])
     check_directory_tree(SYMPY_PATH, test, exclude)
     check_directory_tree(EXAMPLES_PATH, test, exclude)

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -1,5 +1,4 @@
 from __future__ import with_statement
-from sympy.core.compatibility import reduce
 
 from os import walk, sep, chdir, pardir
 from os.path import split, join, abspath, exists, isfile
@@ -16,17 +15,12 @@ import sys
 sepd = {"sep": sep}
 
 # path and sympy_path
-PATH = reduce(join, [split(__file__)[0], pardir, pardir]) # go to sympy/
-SYMPY_PATH = abspath(PATH)
+SYMPY_PATH = abspath(join(split(__file__)[0], pardir, pardir))  # go to sympy/
 assert exists(SYMPY_PATH)
 
-# Tests can be executed when examples are not installed
-# (e.g. after "./setup.py install") so set the examples path
-# to null so it will be skipped by the checker if it is not
-# there.
-EXAMPLES_PATH = abspath(reduce(join, [PATH, pardir, "examples"]))
-if not exists(EXAMPLES_PATH):
-    EXAMPLES_PATH = ""
+TOP_PATH = abspath(join(SYMPY_PATH, pardir))
+BIN_PATH = join(TOP_PATH, "bin")
+EXAMPLES_PATH = join(TOP_PATH, "examples")
 
 IS_PYTHON_3 = (sys.version_info[0] == 3)
 


### PR DESCRIPTION
Add `assert` where missing throughout the tests, run the implicit import tests on `__init__.py` and run the code quality tests outside of `sympy/`.

Issue 846:  test setup.py for whitespace
http://code.google.com/p/sympy/issues/detail?id=846

Issue 2216:     Module names are imported with from sympy import *
http://code.google.com/p/sympy/issues/detail?id=2216

Issue 2432:     Tests without assert
http://code.google.com/p/sympy/issues/detail?id=2432
