### PR TITLE
Don't load own jQuery

### DIFF
--- a/doc/ext/sympylive.py
+++ b/doc/ext/sympylive.py
@@ -17,8 +17,6 @@ def builder_inited(app):
 
     app.add_javascript(app.config.sympylive_url + '/static/utilities.js')
     app.add_javascript(app.config.sympylive_url + '/static/external/classy.js')
-    app.add_javascript(
-        'http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js')
 
     app.add_stylesheet(app.config.sympylive_url + '/static/live-core.css')
     app.add_stylesheet(app.config.sympylive_url +


### PR DESCRIPTION
The Sphinx extension loads its own jQuery library, which unfortunately overrides some methods that Sphinx uses for search. This removes the new jQuery library; the pull request below adds workarounds to Live so it can use the old jQuery library Sphinx has. Once Sphinx 1.2 is released, those will become unnecessary as Sphinx will include jQuery 1.7.

See https://github.com/sympy/sympy-live/pull/62.
