### PR TITLE
Fix bug: relying on cpython poping the smallest element from a set

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2289,18 +2289,16 @@ class PermutationGroup(Basic):
         [0]
 
         """
-        n = self._degree
-        s1 = set(range(n))
+        skip = set() # keep track of which indices have been seen and should be skipped
         orbs = []
-        while s1:
-            i = min(s1)
-            s1.remove(i)
-            si = self.orbit(i)
-            if rep:
-                orbs.append(i)
-            else:
-                orbs.append(si)
-            s1 -= si
+        for i in range(self._degree):
+            if i not in skip:
+                orb = self.orbit(i)
+                orbs.append(i if rep else orb)
+                # don't do any other indices that are in this orbit;
+                # not need to add current indices since we won't see
+                # this one again
+                skip.update(orb)
         return orbs
 
     def order(self):

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -2293,7 +2293,8 @@ class PermutationGroup(Basic):
         s1 = set(range(n))
         orbs = []
         while s1:
-            i = s1.pop()
+            i = min(s1)
+            s1.remove(i)
             si = self.orbit(i)
             if rep:
                 orbs.append(i)


### PR DESCRIPTION
A test (sympy/combinatorics/tests/test_perm_groups.py) is failing for PyPy, since the current implementation relies on how CPython pops from sets.  

The python docs (http://docs.python.org/library/stdtypes.html#set) state that the element popped from a set is arbitrary. I'm not sure if this is a bug in the current implementation, or just a bug in the tests. Maybe someone who understands the math could comment?
## Cpython - Python 2.7.3

```
>>> a = set([3, 4, 5, 0])
>>> a.pop()
0
>>> a
set([3, 4, 5])
>>> a = set([3, 4, 5, 0])
>>> a.pop()
0
>>> a
set([3, 4, 5])
>>> a = set([3, 4, 5, 0])
>>> a.pop()
0
>>> a
set([3, 4, 5])
```
## PyPy nightly - Python 2.7.3 (993a0159055a, Oct 01 2012, 04:14:42 - [PyPy 1.9.1-dev0 with GCC 4.7.0]

```
>>>> a = set([3, 4, 5, 0])
>>>> a.pop()
0
>>>> a
set([3, 4, 5])
>>>> a = set([3, 4, 5, 0])
>>>> a.pop()
3
>>>> a
set([0, 4, 5])
>>>> a = set([3, 4, 5, 0])
>>>> a.pop()
4
>>>> a
set([0, 3, 5])
```
