### PR TITLE
Move sympyprinting extension from IPython to SymPy

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -313,6 +313,7 @@ def main():
     args = {
         'pretty_print' : True,
         'use_unicode'  : None,
+        'use_latex'    : None,
         'order'        : None,
         'argv'         : ipy_args,
     }

--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -21,7 +21,6 @@ pretty-printed.
 # Imports
 #-----------------------------------------------------------------------------
 
-from sympy import pretty, latex
 from sympy.interactive.printing import init_printing
 
 #-----------------------------------------------------------------------------

--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -36,7 +36,7 @@ def load_ipython_extension(ip):
     # Use extension manager to track loaded status if available
     # This is currently in IPython 0.14.dev
     if hasattr(ip.extension_manager, 'loaded'):
-        loaded = 'sympy.utilities.sympyprinting' not in ip.extension_manager.loaded
+        loaded = 'sympy.interactive.ipythonprinting' not in ip.extension_manager.loaded
     else:
         loaded = _loaded
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -45,7 +45,7 @@ def _init_ipython_printing(ip, stringify_func):
         png = latex_to_png(s)
         return png
 
-    def _print_png(o):
+    def _print_display_png(o):
         """
         A function to display sympy expression using display style LaTeX in PNG.
         """
@@ -122,7 +122,7 @@ def _init_ipython_printing(ip, stringify_func):
             'sympy.core.basic', 'Basic', _print_png
         )
         png_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'MatrixBase', _print_png
+            'sympy.matrices.matrices', 'MatrixBase', _print_display_png
         )
 
         for cls in [dict, int, long, float] + printable_containers:

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -1,5 +1,7 @@
 """Tools for setting up printing in interactive sessions. """
 
+from sympy import latex
+
 def _init_python_printing(stringify_func):
     """Setup printing in Python interactive session. """
     import __builtin__, sys
@@ -21,10 +23,64 @@ def _init_python_printing(stringify_func):
 
 def _init_ipython_printing(ip, stringify_func):
     """Setup printing in IPython interactive session. """
+    # For IPython >= 0.11, will use latex_to_png to render LaTeX
+    try:
+        from IPython.lib.latextools import latex_to_png
+    except ImportError:
+        pass
 
-    def _pretty_print(arg, p, cycle):
+    def _print_pretty(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
         p.text(stringify_func(arg))
+
+    def _print_png(o):
+        """
+        A function to display sympy expressions using inline style LaTeX in PNG.
+        """
+        s = latex(o, mode='inline')
+        # mathtext does not understand centain latex flags, so we try to
+        # replace them with suitable subs
+        s = s.replace(r'\operatorname', '')
+        s = s.replace(r'\overline', r'\bar')
+        png = latex_to_png(s)
+        return png
+
+    def _print_png(o):
+        """
+        A function to display sympy expression using display style LaTeX in PNG.
+        """
+        s = latex(o, mode='plain')
+        s = s.strip('$')
+        # As matplotlib does not support display style, dvipng backend is used
+        # here
+        png = latex_to_png(s, backend='dvipng', wrap=True)
+        return png
+
+    def _can_print_latex(o):
+        """Return True if type o can be printed with LaTeX.
+
+        If o is a container type, this is True if and only if every element of
+        o can be printed with LaTeX.
+        """
+        if isinstance(o, (list, tuple, set, frozenset)):
+            return all(can_print_latex(i) for i in o)
+        elif isinstance(o, dict):
+            return all((isinstance(i, basestring) or can_print_latex(i)) and can_print_latex(o[i]) for i in o)
+        elif isinstance(o,(sympy.Basic, sympy.matrices.MatrixBase, int, long, float)):
+            return True
+        return False
+
+    def _print_latex(o):
+        """
+        A function to generate the latex representation of sympy expressions.
+        """
+        if _can_print_latex(o):
+            s = latex(o, mode='plain')
+            s = s.replace(r'\dag', r'\dagger')
+            s = s.strip('$')
+            return '$$%s$$' % s
+        # Fallback to the string printer
+        return None
 
     def _result_display(self, arg):
         """IPython's pretty-printer display hook, for use in IPython 0.10
@@ -46,18 +102,41 @@ def _init_ipython_printing(ip, stringify_func):
 
     import IPython
     if IPython.__version__ >= '0.11':
-        formatter = ip.display_formatter.formatters['text/plain']
+        printable_containers = [tuple, list, set, frozenset]
 
-        for cls in (object, tuple, list, set, frozenset, dict, str):
-            formatter.for_type(cls, _pretty_print)
+        plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
-        # this loads pretty printing for objects that inherit from Basic or Matrix:
-        formatter.for_type_by_name(
-            'sympy.core.basic', 'Basic', _pretty_print
+        for cls in [object, str, dict] + printable_containers:
+            plaintext_formatter.for_type(cls, _print_pretty)
+
+        plaintext_formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', _print_pretty
         )
-        formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'Matrix', _pretty_print
+        plaintext_formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'MatrixBase', _print_pretty
         )
+
+        png_formatter = ip.display_formatter.formatters['image/png']
+
+        png_formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', _print_png
+        )
+        png_formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'MatrixBase', _print_png
+        )
+
+        for cls in [dict, int, long, float] + printable_containers:
+            png_formatter.for_type(cls, _print_png)
+
+        latex_formatter = ip.display_formatter.formatters['text/latex']
+        latex_formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', _print_latex
+        )
+        latex_formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'MatrixBase', _print_latex
+        )
+        for cls in printable_containers:
+            latex_formatter.for_type(cls, _print_latex)
     else:
         ip.set_hook('result_display', _result_display)
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -141,7 +141,7 @@ def _init_ipython_printing(ip, stringify_func, render_latex):
     else:
         ip.set_hook('result_display', _result_display)
 
-def init_printing(pretty_print=True, order=None, use_unicode=True, use_latex=True, wrap_line=None, num_columns=None, no_global=False, ip=None):
+def init_printing(pretty_print=True, order=None, use_unicode=None, use_latex=None, wrap_line=None, num_columns=None, no_global=False, ip=None):
     """
     Initializes pretty-printer depending on the environment.
 

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -313,7 +313,8 @@ def init_python_session():
     return SymPyConsole()
 
 def init_session(ipython=None, pretty_print=True, order=None,
-        use_unicode=None, quiet=False, auto_symbols=False, auto_int_to_Integer=False, argv=[]):
+        use_unicode=None, use_latex=None, quiet=False, auto_symbols=False,
+        auto_int_to_Integer=False, argv=[]):
     """
     Initialize an embedded IPython or Python session. The IPython session is
     initiated with the --pylab option, without the numpy imports, so that
@@ -335,6 +336,9 @@ def init_session(ipython=None, pretty_print=True, order=None,
     use_unicode: boolean or None
         If True, use unicode characters;
         if False, do not use unicode characters.
+    use_latex: boolean or None
+        If True, use latex rendering if IPython GUI's;
+        if False, do not use latex rendering.
     quiet: boolean
         If True, init_session will not print messages regarding its status;
         if False, init_session will print messages regarding its status.
@@ -456,7 +460,8 @@ def init_session(ipython=None, pretty_print=True, order=None,
     _preexec_source = preexec_source
 
     ip.runsource(_preexec_source, symbol='exec')
-    init_printing(pretty_print=pretty_print, order=order, use_unicode=use_unicode, ip=ip)
+    init_printing(pretty_print=pretty_print, order=order,
+        use_unicode=use_unicode, use_latex=use_latex, ip=ip)
 
     message = _make_message(ipython, quiet, _preexec_source)
 

--- a/sympy/utilities/sympyprinting.py
+++ b/sympy/utilities/sympyprinting.py
@@ -87,7 +87,7 @@ def can_print_latex(o):
         return all(can_print_latex(i) for i in o)
     elif isinstance(o, dict):
         return all((isinstance(i, basestring) or can_print_latex(i)) and can_print_latex(o[i]) for i in o)
-    elif isinstance(o,(sympy.Basic, sympy.matrices.MutableMatrix, int, long, float)):
+    elif isinstance(o,(sympy.Basic, sympy.matrices.Matrix, int, long, float)):
         return True
     return False
 

--- a/sympy/utilities/sympyprinting.py
+++ b/sympy/utilities/sympyprinting.py
@@ -1,0 +1,151 @@
+"""
+A print function that pretty prints sympy Basic objects.
+
+:moduleauthor: Brian Granger
+
+Usage
+=====
+
+Once the extension is loaded, Sympy Basic objects are automatically
+pretty-printed.
+
+"""
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from IPython.lib.latextools import latex_to_png
+from IPython.testing import decorators as dec
+# use @dec.skipif_not_sympy to skip tests requiring sympy
+
+try:
+    from sympy import pretty, latex
+except ImportError:
+    pass
+
+#-----------------------------------------------------------------------------
+# Definitions of special display functions for use with IPython
+#-----------------------------------------------------------------------------
+
+def print_basic_unicode(o, p, cycle):
+    """A function to pretty print sympy Basic objects."""
+    if cycle:
+        return p.text('Basic(...)')
+    out = pretty(o, use_unicode=True)
+    if '\n' in out:
+        p.text(u'\n')
+    p.text(out)
+
+
+def print_png(o):
+    """
+    A function to display sympy expression using inline style LaTeX in PNG.
+    """
+    s = latex(o, mode='inline')
+    # mathtext does not understand certain latex flags, so we try to replace
+    # them with suitable subs.
+    s = s.replace('\\operatorname','')
+    s = s.replace('\\overline', '\\bar')
+    png = latex_to_png(s)
+    return png
+
+
+def print_display_png(o):
+    """
+    A function to display sympy expression using display style LaTeX in PNG.
+    """
+    s = latex(o, mode='plain')
+    s = s.strip('$')
+    # As matplotlib does not support display style, dvipng backend is
+    # used here.
+    png = latex_to_png(s, backend='dvipng', wrap=True)
+    return png
+
+
+def can_print_latex(o):
+    """
+    Return True if type o can be printed with LaTeX.
+
+    If o is a container type, this is True if and only if every element of o
+    can be printed with LaTeX.
+    """
+    import sympy
+    if isinstance(o, (list, tuple, set, frozenset)):
+        return all(can_print_latex(i) for i in o)
+    elif isinstance(o, dict):
+        return all((isinstance(i, basestring) or can_print_latex(i)) and can_print_latex(o[i]) for i in o)
+    elif isinstance(o,(sympy.Basic, sympy.matrices.Matrix, int, long, float)):
+        return True
+    return False
+
+def print_latex(o):
+    """A function to generate the latex representation of sympy
+    expressions."""
+    if can_print_latex(o):
+        s = latex(o, mode='plain')
+        s = s.replace('\\dag','\\dagger')
+        s = s.strip('$')
+        return '$$%s$$' % s
+    # Fallback to the string printer
+    return None
+
+_loaded = False
+
+def load_ipython_extension(ip):
+    """Load the extension in IPython."""
+    import sympy
+    global _loaded
+    if not _loaded:
+        plaintext_formatter = ip.display_formatter.formatters['text/plain']
+
+        for cls in (object, str):
+            plaintext_formatter.for_type(cls, print_basic_unicode)
+
+        printable_containers = [list, tuple]
+
+        # set and frozen set were broken with SymPy's latex() function, but
+        # was fixed in the 0.7.1-git development version. See
+        # http://code.google.com/p/sympy/issues/detail?id=3062.
+        if sympy.__version__ > '0.7.1':
+            printable_containers += [set, frozenset]
+        else:
+            plaintext_formatter.for_type(cls, print_basic_unicode)
+
+        plaintext_formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', print_basic_unicode
+        )
+        plaintext_formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'Matrix', print_basic_unicode
+        )
+
+        png_formatter = ip.display_formatter.formatters['image/png']
+
+        png_formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', print_png
+        )
+        png_formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'Matrix', print_display_png
+        )
+        for cls in [dict, int, long, float] + printable_containers:
+            png_formatter.for_type(cls, print_png)
+
+        latex_formatter = ip.display_formatter.formatters['text/latex']
+        latex_formatter.for_type_by_name(
+            'sympy.core.basic', 'Basic', print_latex
+        )
+        latex_formatter.for_type_by_name(
+            'sympy.matrices.matrices', 'Matrix', print_latex
+        )
+
+        for cls in printable_containers:
+            # Use LaTeX only if every element is printable by latex
+            latex_formatter.for_type(cls, print_latex)
+
+        _loaded = True

--- a/sympy/utilities/sympyprinting.py
+++ b/sympy/utilities/sympyprinting.py
@@ -109,7 +109,14 @@ _loaded = False
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
     global _loaded
-    if not _loaded:
+    # Use extension manager to track loaded status if available
+    # This is currently in IPython 0.14.dev
+    if hasattr(ip.extension_manager, 'loaded'):
+        loaded = 'sympy.utilities.sympyprinting' not in ip.extension_manager.loaded
+    else:
+        loaded = _loaded
+
+    if not loaded:
         printable_containers = [list, tuple, set, frozenset]
 
         plaintext_formatter = ip.display_formatter.formatters['text/plain']

--- a/sympy/utilities/sympyprinting.py
+++ b/sympy/utilities/sympyprinting.py
@@ -87,7 +87,7 @@ def can_print_latex(o):
         return all(can_print_latex(i) for i in o)
     elif isinstance(o, dict):
         return all((isinstance(i, basestring) or can_print_latex(i)) and can_print_latex(o[i]) for i in o)
-    elif isinstance(o,(sympy.Basic, sympy.matrices.Matrix, int, long, float)):
+    elif isinstance(o,(sympy.Basic, sympy.matrices.MutableMatrix, int, long, float)):
         return True
     return False
 
@@ -128,7 +128,7 @@ def load_ipython_extension(ip):
             'sympy.core.basic', 'Basic', print_basic_unicode
         )
         plaintext_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'Matrix', print_basic_unicode
+            'sympy.matrices.matrices', 'MutableMatrix', print_basic_unicode
         )
 
         png_formatter = ip.display_formatter.formatters['image/png']
@@ -137,8 +137,9 @@ def load_ipython_extension(ip):
             'sympy.core.basic', 'Basic', print_png
         )
         png_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'Matrix', print_display_png
+            'sympy.matrices.matrices', 'MutableMatrix', print_display_png
         )
+
         for cls in [dict, int, long, float] + printable_containers:
             png_formatter.for_type(cls, print_png)
 
@@ -147,7 +148,7 @@ def load_ipython_extension(ip):
             'sympy.core.basic', 'Basic', print_latex
         )
         latex_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'Matrix', print_latex
+            'sympy.matrices.matrices', 'MutableMatrix', print_latex
         )
 
         for cls in printable_containers:

--- a/sympy/utilities/sympyprinting.py
+++ b/sympy/utilities/sympyprinting.py
@@ -22,87 +22,11 @@ pretty-printed.
 #-----------------------------------------------------------------------------
 
 from sympy import pretty, latex
-from sympy.external import import_module
-
-import warnings
-
-ipython = import_module("IPython", min_module_version="0.11")
+from sympy.interactive.printing import init_printing
 
 #-----------------------------------------------------------------------------
 # Definitions of special display functions for use with IPython
 #-----------------------------------------------------------------------------
-
-# If IPython cannot be imported, then not in IPython shell or insufficient version
-if ipython:
-    latex_to_png = ipython.lib.latextools.latex_to_png
-else:
-    warnings.warn("This should only be imported from within an IPython instance, "
-            "check that IPython version >= 0.11.")
-
-
-def print_basic_unicode(o, p, cycle):
-    """A function to pretty print sympy Basic objects."""
-    if cycle:
-        return p.text('Basic(...)')
-    out = pretty(o, use_unicode=True)
-    if '\n' in out:
-        p.text(u'\n')
-    p.text(out)
-
-
-def print_png(o):
-    """
-    A function to display sympy expression using inline style LaTeX in PNG.
-    """
-    s = latex(o, mode='inline')
-    # mathtext does not understand certain latex flags, so we try to replace
-    # them with suitable subs.
-    s = s.replace('\\operatorname','')
-    s = s.replace('\\overline', '\\bar')
-    png = latex_to_png(s)
-    return png
-
-
-def print_display_png(o):
-    """
-    A function to display sympy expression using display style LaTeX in PNG.
-    """
-    s = latex(o, mode='plain')
-    s = s.strip('$')
-    # As matplotlib does not support display style, dvipng backend is
-    # used here.
-    png = latex_to_png(s, backend='dvipng', wrap=True)
-    return png
-
-
-def can_print_latex(o):
-    """
-    Return True if type o can be printed with LaTeX.
-
-    If o is a container type, this is True if and only if every element of o
-    can be printed with LaTeX.
-    """
-    import sympy
-    if isinstance(o, (list, tuple, set, frozenset)):
-        return all(can_print_latex(i) for i in o)
-    elif isinstance(o, dict):
-        return all((isinstance(i, basestring) or can_print_latex(i)) and can_print_latex(o[i]) for i in o)
-    elif isinstance(o,(sympy.Basic, sympy.matrices.Matrix, int, long, float)):
-        return True
-    return False
-
-
-def print_latex(o):
-    """A function to generate the latex representation of sympy
-    expressions."""
-    if can_print_latex(o):
-        s = latex(o, mode='plain')
-        s = s.replace('\\dag','\\dagger')
-        s = s.strip('$')
-        return '$$%s$$' % s
-    # Fallback to the string printer
-    return None
-
 
 _loaded = False
 
@@ -117,42 +41,6 @@ def load_ipython_extension(ip):
         loaded = _loaded
 
     if not loaded:
-        printable_containers = [list, tuple, set, frozenset]
-
-        plaintext_formatter = ip.display_formatter.formatters['text/plain']
-
-        for cls in (object, str):
-            plaintext_formatter.for_type(cls, print_basic_unicode)
-
-        plaintext_formatter.for_type_by_name(
-            'sympy.core.basic', 'Basic', print_basic_unicode
-        )
-        plaintext_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'MutableMatrix', print_basic_unicode
-        )
-
-        png_formatter = ip.display_formatter.formatters['image/png']
-
-        png_formatter.for_type_by_name(
-            'sympy.core.basic', 'Basic', print_png
-        )
-        png_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'MutableMatrix', print_display_png
-        )
-
-        for cls in [dict, int, long, float] + printable_containers:
-            png_formatter.for_type(cls, print_png)
-
-        latex_formatter = ip.display_formatter.formatters['text/latex']
-        latex_formatter.for_type_by_name(
-            'sympy.core.basic', 'Basic', print_latex
-        )
-        latex_formatter.for_type_by_name(
-            'sympy.matrices.matrices', 'MutableMatrix', print_latex
-        )
-
-        for cls in printable_containers:
-            # Use LaTeX only if every element is printable by latex
-            latex_formatter.for_type(cls, print_latex)
+        init_printing(ip=ip)
 
         _loaded = True


### PR DESCRIPTION
This is the SymPy side of moving the sympyprinting extension from IPython to SymPy.  It was noted in ipython/ipython#2430 that the sympyprinting module might be moved here so as to keep the version of the extension in lockstep with the SymPy version, noting the change from Matrix to MutableMatrix.

I'm not sure what we should do to the IPython copyright notice, how to ask permission to move it (I figure we should, even though technically we're both BSD license), or any other such formalities. This shouldn't be merged until that is handled.

88e8e3f6a4287213254ccc1329b2141fa2d6f150 depends on ipython/ipython#2462, but should that PR be merged, this commit would have the sympyprinting extension use the newly implemented extension tracking.

We may also want to push these changes into 0.7.2, so deprecating the IPython extension makes better sense.

I have an IPython branch [1] that I'll open a PR for to start the deprecation on the IPython side if this is merged.

[1] https://github.com/flacjacket/ipython/tree/move_sympyprinting
