### PR TITLE
omit lambdify test; remove doc reference to Diag

### DIFF
--- a/doc/src/modules/matrices/sparse.rst
+++ b/doc/src/modules/matrices/sparse.rst
@@ -7,8 +7,3 @@ SparseMatrix Class Reference
 ----------------------------
 .. autoclass:: SparseMatrix
    :members:
-
-Diag Class Reference
---------------------
-.. autoclass:: Diag
-   :members:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -205,9 +205,6 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True):
     >>> f = lambdify((x, y), sin(x*y)**2)
     >>> f(0, 5)
     0.0
-    >>> f = lambdify((x, y), Matrix((x, x + y)).T)
-    >>> f(1, 2)
-    [1.0  3.0]
     >>> f = lambdify((x, y), Matrix((x, x + y)).T, modules='sympy')
     >>> f(1, 2)
     [1, 3]


### PR DESCRIPTION
The lambdify test that I removed doesn't fail with 2.7.3 (32-bit).
I don't know what the issue is so I am just removing the test that
I added.
