### PR TITLE
Added sampling_density to sympy.stats

### DIFF
--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -532,7 +532,7 @@ def density(expr, condition=None, numsamples=None, **kwargs):
     """
 
     if numsamples:
-        return sampling_density(expr, condition, numsamples=numsamples, 
+        return sampling_density(expr, condition, numsamples=numsamples,
                 **kwargs)
 
     if condition is not None: # If there is a condition

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -503,7 +503,7 @@ def probability(condition, given_condition=None, numsamples=None,  **kwargs):
     # Otherwise pass work off to the ProbabilitySpace
     return pspace(condition).probability(condition, **kwargs)
 
-def density(expr, condition=None, **kwargs):
+def density(expr, condition=None, numsamples=None, **kwargs):
     """
     Probability density of a random expression
 
@@ -530,6 +530,11 @@ def density(expr, condition=None, **kwargs):
     >>> density(X)
     Lambda(_x, sqrt(2)*exp(-_x**2/2)/(2*sqrt(pi)))
     """
+
+    if numsamples:
+        return sampling_density(expr, condition, numsamples=numsamples, 
+                **kwargs)
+
     if condition is not None: # If there is a condition
         # Recompute on new conditional expr
         return density(given(expr, condition, **kwargs), **kwargs)
@@ -706,10 +711,8 @@ def sample_iter_subs(expr, condition=None, numsamples=S.Infinity, **kwargs):
         ps = pspace(expr)
 
     count = 0
-
     while count < numsamples:
         d = ps.sample() # a dictionary that maps RVs to values
-
 
         if condition: # Check that these values satisfy the condition
             gd = condition.subs(d)
@@ -719,8 +722,10 @@ def sample_iter_subs(expr, condition=None, numsamples=S.Infinity, **kwargs):
                 continue
 
         yield expr.subs(d)
-
         count += 1
+
+
+
 def sampling_P(condition, given_condition=None, numsamples=1,
                evalf=True, **kwargs):
     """
@@ -730,6 +735,7 @@ def sampling_P(condition, given_condition=None, numsamples=1,
     ========
     P
     sampling_E
+    sampling_density
     """
 
     count_true = 0
@@ -762,6 +768,7 @@ def sampling_E(condition, given_condition=None, numsamples=1,
     ========
     P
     sampling_P
+    sampling_density
     """
 
     samples = sample_iter(condition, given_condition,
@@ -772,6 +779,24 @@ def sampling_E(condition, given_condition=None, numsamples=1,
         return result.evalf()
     else:
         return result
+
+def sampling_density(condition, given_condition=None, numsamples=1, 
+                     **kwargs):
+    """
+    Sampling version of density
+
+    See Also
+    ========
+    density
+    sampling_P
+    sampling_E
+    """
+
+    results = {}
+    for result in sample_iter(condition, given_condition,
+                              numsamples=numsamples, **kwargs):
+        results[result] = results.get(result, 0) + 1
+    return results
 
 def dependent(a, b):
     """

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -462,7 +462,7 @@ def expectation(expr, condition=None, numsamples=None, **kwargs):
     # Otherwise case is simple, pass work off to the ProbabilitySpace
     return pspace(expr).integrate(expr, **kwargs)
 
-def probability(condition, given_condition=None, numsamples=None,  **kwargs):
+def probability(condition, given_condition=None, numsamples=None, **kwargs):
     """
     Probability that a condition is true, optionally given a second condition
 
@@ -505,14 +505,19 @@ def probability(condition, given_condition=None, numsamples=None,  **kwargs):
 
 def density(expr, condition=None, numsamples=None, **kwargs):
     """
-    Probability density of a random expression
+    Probability density of a random expression, optionally given a second condition
 
-    Optionally given a second condition
+    This density will take on different forms for different types of probability
+    spaces. Discrete variables produce Dicts. Continuous variables produce Lambdas.
 
-    This density will take on different forms for different types of
-    probability spaces.
-    Discrete variables produce Dicts.
-    Continuous variables produce Lambdas.
+    Parameters
+    ----------
+    expr : Expr containing RandomSymbols
+        The expression of which you want to compute the density value
+    condition : Relational containing RandomSymbols
+        A conditional expression. density(X>1, X>0) is density of X>1 given X>0
+    numsamples : int
+        Enables sampling and approximates the density with this many samples
 
     Examples
     ========
@@ -724,8 +729,6 @@ def sample_iter_subs(expr, condition=None, numsamples=S.Infinity, **kwargs):
         yield expr.subs(d)
         count += 1
 
-
-
 def sampling_P(condition, given_condition=None, numsamples=1,
                evalf=True, **kwargs):
     """
@@ -780,7 +783,7 @@ def sampling_E(condition, given_condition=None, numsamples=1,
     else:
         return result
 
-def sampling_density(condition, given_condition=None, numsamples=1, 
+def sampling_density(condition, given_condition=None, numsamples=1,
                      **kwargs):
     """
     Sampling version of density

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -99,6 +99,9 @@ def test_Sample():
     # Make sure this doesn't raise an error
     E(Sum(1/z**Y, (z,1,oo)), Y>2, numsamples=3)
 
+    assert sorted(density(X, numsamples=10).keys()) == [1,2,3,4,5,6]
+    assert sorted(density(X, X>3, numsamples=10).keys()) == [4,5,6]
+
 def test_given():
     X = Normal('X', 0, 1)
     Y = Normal('Y', 0, 1)


### PR DESCRIPTION
TODO: rebase with master

This PR adds `numsamples` to `density()` in `sympy.stats`.

``` python
>>> from sympy.stats import *
>>> X = Die("X")
>>> density(X)
{6: 1/6, 2: 1/6, 1: 1/6, 4: 1/6, 3: 1/6, 5: 1/6}
>>> density(X, numsamples=600)
{6: 92, 2: 98, 1: 107, 4: 87, 3: 112, 5: 104}
>>> density(X, X > 3, numsamples=600)
{4: 188, 6: 213, 5: 199}
```

--Benjamin
