### PR TITLE
Pass tests -t sympy in master

### DIFF
--- a/sympy/polys/domains/sympyintegerring.py
+++ b/sympy/polys/domains/sympyintegerring.py
@@ -1,7 +1,8 @@
 """Implementaton of :class:`SymPyIntegerRing` class. """
 
 from sympy.polys.domains.integerring import IntegerRing
-from sympy.polys.domains.groundtypes import SymPyIntegerType
+from sympy.polys.domains.groundtypes import (SymPyIntegerType,
+    python_factorial, python_gcd, python_gcdex, python_lcm, python_sqrt)
 
 from sympy.polys.polyerrors import CoercionFailed
 
@@ -105,7 +106,7 @@ class SymPyIntegerRing(IntegerRing):
 
     def gcdex(self, a, b):
         """Compute extended GCD of ``a`` and ``b``. """
-        return SymPyIntegerType(python_gcdex(int(a), int(b)))
+        return map(SymPyIntegerType, python_gcdex(int(a), int(b)))
 
     def gcd(self, a, b):
         """Compute GCD of ``a`` and ``b``. """

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -735,7 +735,7 @@ def dmp_zz_collins_resultant(f, g, u, K):
 
     v = u - 1
 
-    B = K(2)*K.factorial(n+m)*A**m*B**n
+    B = K(2)*K.factorial(K(n+m))*A**m*B**n
     r, p, P = dmp_zero(v), K.one, K.one
 
     while P <= B:

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1228,7 +1228,7 @@ def dup_zz_heu_gcd(f, g, K):
     f_norm = dup_max_norm(f, K)
     g_norm = dup_max_norm(g, K)
 
-    B = 2*min(f_norm, g_norm) + 29
+    B = K(2*min(f_norm, g_norm) + 29)
 
     x = max(min(B, 99*K.sqrt(B)),
             2*min(f_norm // abs(dup_LC(f, K)),
@@ -1353,7 +1353,7 @@ def dmp_zz_heu_gcd(f, g, u, K):
     f_norm = dmp_max_norm(f, u, K)
     g_norm = dmp_max_norm(g, u, K)
 
-    B = 2*min(f_norm, g_norm) + 29
+    B = K(2*min(f_norm, g_norm) + 29)
 
     x = max(min(B, 99*K.sqrt(B)),
             2*min(f_norm // abs(dmp_ground_LC(f, u, K)),

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -775,7 +775,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
         m = dmp_nest([K.one, -a], n, K)
         M = dmp_one(n, K)
 
-        for k in xrange(0, d):
+        for k in K.map(xrange(0, d)):
             if dmp_zero_p(c, u):
                 break
 
@@ -830,7 +830,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
 
         dj = dmp_degree_in(s, w, w)
 
-        for k in xrange(0, dj):
+        for k in K.map(xrange(0, dj)):
             if dmp_zero_p(c, w):
                 break
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -269,7 +269,7 @@ def gf_from_dict(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_from_dict
 
-    >>> gf_from_dict({10: 4, 4: 33, 0: -1}, 5, ZZ)
+    >>> gf_from_dict({10: ZZ(4), 4: ZZ(33), 0: ZZ(-1)}, 5, ZZ)
     [4, 0, 0, 0, 0, 0, 3, 0, 0, 0, 4]
 
     """
@@ -450,7 +450,7 @@ def gf_quo_ground(f, a, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_quo_ground
 
-    >>> gf_quo_ground([3, 2, 4], 2, 5, ZZ)
+    >>> gf_quo_ground(ZZ.map([3, 2, 4]), ZZ(2), 5, ZZ)
     [4, 1, 2]
 
     """
@@ -672,12 +672,12 @@ def gf_div(f, g, p, K):
        >>> from sympy.polys.domains import ZZ
        >>> from sympy.polys.galoistools import gf_div, gf_add_mul
 
-       >>> gf_div([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
+       >>> gf_div(ZZ.map([1, 0, 1, 1]), ZZ.map([1, 1, 0]), 2, ZZ)
        ([1, 1], [1])
 
     As result we obtained quotient ``x + 1`` and remainder ``1``, thus::
 
-       >>> gf_add_mul([1], [1, 1], [1, 1, 0], 2, ZZ)
+       >>> gf_add_mul(ZZ.map([1]), ZZ.map([1, 1]), ZZ.map([1, 1, 0]), 2, ZZ)
        [1, 0, 1, 1]
 
     References
@@ -722,7 +722,7 @@ def gf_rem(f, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_rem
 
-    >>> gf_rem([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
+    >>> gf_rem(ZZ.map([1, 0, 1, 1]), ZZ.map([1, 1, 0]), 2, ZZ)
     [1]
 
     """
@@ -739,9 +739,9 @@ def gf_quo(f, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_quo
 
-    >>> gf_quo([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
+    >>> gf_quo(ZZ.map([1, 0, 1, 1]), ZZ.map([1, 1, 0]), 2, ZZ)
     [1, 1]
-    >>> gf_quo([1, 0, 3, 2, 3], [2, 2, 2], 5, ZZ)
+    >>> gf_quo(ZZ.map([1, 0, 3, 2, 3]), ZZ.map([2, 2, 2]), 5, ZZ)
     [3, 2, 4]
 
     """
@@ -777,10 +777,10 @@ def gf_exquo(f, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_exquo
 
-    >>> gf_exquo([1, 0, 3, 2, 3], [2, 2, 2], 5, ZZ)
+    >>> gf_exquo(ZZ.map([1, 0, 3, 2, 3]), ZZ.map([2, 2, 2]), 5, ZZ)
     [3, 2, 4]
 
-    >>> gf_exquo([1, 0, 1, 1], [1, 1, 0], 2, ZZ)
+    >>> gf_exquo(ZZ.map([1, 0, 1, 1]), ZZ.map([1, 1, 0]), 2, ZZ)
     Traceback (most recent call last):
     ...
     ExactQuotientFailed: [1, 1, 0] does not divide [1, 0, 1, 1]
@@ -884,7 +884,7 @@ def gf_pow_mod(f, n, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_pow_mod
 
-    >>> gf_pow_mod([3, 2, 4], 3, [1, 1], 5, ZZ)
+    >>> gf_pow_mod(ZZ.map([3, 2, 4]), 3, ZZ.map([1, 1]), 5, ZZ)
     []
 
     References
@@ -928,7 +928,7 @@ def gf_gcd(f, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_gcd
 
-    >>> gf_gcd([3, 2, 4], [2, 2, 3], 5, ZZ)
+    >>> gf_gcd(ZZ.map([3, 2, 4]), ZZ.map([2, 2, 3]), 5, ZZ)
     [1, 3]
 
     """
@@ -947,7 +947,7 @@ def gf_lcm(f, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_lcm
 
-    >>> gf_lcm([3, 2, 4], [2, 2, 3], 5, ZZ)
+    >>> gf_lcm(ZZ.map([3, 2, 4]), ZZ.map([2, 2, 3]), 5, ZZ)
     [1, 2, 0, 4]
 
     """
@@ -969,7 +969,7 @@ def gf_cofactors(f, g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_cofactors
 
-    >>> gf_cofactors([3, 2, 4], [2, 2, 3], 5, ZZ)
+    >>> gf_cofactors(ZZ.map([3, 2, 4]), ZZ.map([2, 2, 3]), 5, ZZ)
     ([1, 3], [3, 3], [2, 1])
 
     """
@@ -995,15 +995,15 @@ def gf_gcdex(f, g, p, K):
        >>> from sympy.polys.domains import ZZ
        >>> from sympy.polys.galoistools import gf_gcdex, gf_mul, gf_add
 
-       >>> s, t, g = gf_gcdex([1,8,7], [1,7,1,7], 11, ZZ)
+       >>> s, t, g = gf_gcdex(ZZ.map([1, 8, 7]), ZZ.map([1, 7, 1, 7]), 11, ZZ)
        >>> s, t, g
        ([5, 6], [6], [1, 7])
 
     As result we obtained polynomials ``s = 5*x + 6`` and ``t = 6``, and
     additionally ``gcd(f, g) = x + 7``. This is correct because::
 
-       >>> S = gf_mul(s,   [1,8,7], 11, ZZ)
-       >>> T = gf_mul(t, [1,7,1,7], 11, ZZ)
+       >>> S = gf_mul(s, ZZ.map([1, 8, 7]), 11, ZZ)
+       >>> T = gf_mul(t, ZZ.map([1, 7, 1, 7]), 11, ZZ)
 
        >>> gf_add(S, T, 11, ZZ) == [1, 7]
        True
@@ -1056,7 +1056,7 @@ def gf_monic(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_monic
 
-    >>> gf_monic([3, 2, 4], 5, ZZ)
+    >>> gf_monic(ZZ.map([3, 2, 4]), 5, ZZ)
     (3, [1, 4, 3])
 
     """
@@ -1177,7 +1177,7 @@ def gf_compose_mod(g, h, f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_compose_mod
 
-    >>> gf_compose_mod([3, 2, 4], [2, 2, 2], [4, 3], 5, ZZ)
+    >>> gf_compose_mod(ZZ.map([3, 2, 4]), ZZ.map([2, 2, 2]), ZZ.map([4, 3]), 5, ZZ)
     [4]
 
     """
@@ -1296,9 +1296,9 @@ def gf_irred_p_ben_or(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_irred_p_ben_or
 
-    >>> gf_irred_p_ben_or([1, 4, 2, 2, 3, 2, 4, 1, 4, 0, 4], 5, ZZ)
+    >>> gf_irred_p_ben_or(ZZ.map([1, 4, 2, 2, 3, 2, 4, 1, 4, 0, 4]), 5, ZZ)
     True
-    >>> gf_irred_p_ben_or([3, 2, 4], 5, ZZ)
+    >>> gf_irred_p_ben_or(ZZ.map([3, 2, 4]), 5, ZZ)
     False
 
     """
@@ -1332,9 +1332,9 @@ def gf_irred_p_rabin(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_irred_p_rabin
 
-    >>> gf_irred_p_rabin([1, 4, 2, 2, 3, 2, 4, 1, 4, 0, 4], 5, ZZ)
+    >>> gf_irred_p_rabin(ZZ.map([1, 4, 2, 2, 3, 2, 4, 1, 4, 0, 4]), 5, ZZ)
     True
-    >>> gf_irred_p_rabin([3, 2, 4], 5, ZZ)
+    >>> gf_irred_p_rabin(ZZ.map([3, 2, 4]), 5, ZZ)
     False
 
     """
@@ -1377,9 +1377,9 @@ def gf_irreducible_p(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_irreducible_p
 
-    >>> gf_irreducible_p([1, 4, 2, 2, 3, 2, 4, 1, 4, 0, 4], 5, ZZ)
+    >>> gf_irreducible_p(ZZ.map([1, 4, 2, 2, 3, 2, 4, 1, 4, 0, 4]), 5, ZZ)
     True
-    >>> gf_irreducible_p([3, 2, 4], 5, ZZ)
+    >>> gf_irreducible_p(ZZ.map([3, 2, 4]), 5, ZZ)
     False
 
     """
@@ -1402,9 +1402,9 @@ def gf_sqf_p(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_sqf_p
 
-    >>> gf_sqf_p([3, 2, 4], 5, ZZ)
+    >>> gf_sqf_p(ZZ.map([3, 2, 4]), 5, ZZ)
     True
-    >>> gf_sqf_p([2, 4, 4, 2, 2, 1, 4], 5, ZZ)
+    >>> gf_sqf_p(ZZ.map([2, 4, 4, 2, 2, 1, 4]), 5, ZZ)
     False
 
     """
@@ -1425,7 +1425,7 @@ def gf_sqf_part(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_sqf_part
 
-    >>> gf_sqf_part([1, 1, 3, 0, 1, 0, 2, 2, 1], 5, ZZ)
+    >>> gf_sqf_part(ZZ.map([1, 1, 3, 0, 1, 0, 2, 2, 1]), 5, ZZ)
     [1, 4, 3]
 
     """
@@ -1458,7 +1458,7 @@ def gf_sqf_list(f, p, K, all=False):
        ... )
        ... # doctest: +NORMALIZE_WHITESPACE
 
-       >>> f = gf_from_dict({11: 1, 0: 1}, 11, ZZ)
+       >>> f = gf_from_dict({11: ZZ(1), 0: ZZ(1)}, 11, ZZ)
 
     Note that ``f'(x) = 0``::
 
@@ -1689,7 +1689,7 @@ def gf_ddf_zassenhaus(f, p, K):
        >>> from sympy.polys.domains import ZZ
        >>> from sympy.polys.galoistools import gf_from_dict
 
-       >>> f = gf_from_dict({15: 1, 0: -1}, 11, ZZ)
+       >>> f = gf_from_dict({15: ZZ(1), 0: ZZ(-1)}, 11, ZZ)
 
     Distinct degree factorization gives::
 
@@ -1802,7 +1802,7 @@ def gf_ddf_shoup(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_ddf_shoup, gf_from_dict
 
-    >>> f = gf_from_dict({6: 1, 5: -1, 4: 1, 3: 1, 1: -1}, 3, ZZ)
+    >>> f = gf_from_dict({6: ZZ(1), 5: ZZ(-1), 4: ZZ(1), 3: ZZ(1), 1: ZZ(-1)}, 3, ZZ)
 
     >>> gf_ddf_shoup(f, 3, ZZ)
     [([1, 1, 0], 1), ([1, 1, 0, 1, 2], 2)]
@@ -1877,7 +1877,7 @@ def gf_edf_shoup(f, n, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_edf_shoup
 
-    >>> gf_edf_shoup([1, 2837, 2277], 1, 2917, ZZ)
+    >>> gf_edf_shoup(ZZ.map([1, 2837, 2277]), 1, 2917, ZZ)
     [[1, 852], [1, 1985]]
 
     References
@@ -1931,7 +1931,7 @@ def gf_zassenhaus(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_zassenhaus
 
-    >>> gf_zassenhaus([1, 4, 3], 5, ZZ)
+    >>> gf_zassenhaus(ZZ.map([1, 4, 3]), 5, ZZ)
     [[1, 1], [1, 3]]
 
     """
@@ -1953,7 +1953,7 @@ def gf_shoup(f, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_shoup
 
-    >>> gf_shoup([1, 4, 3], 5, ZZ)
+    >>> gf_shoup(ZZ.map([1, 4, 3]), 5, ZZ)
     [[1, 1], [1, 3]]
 
     """
@@ -1980,7 +1980,7 @@ def gf_factor_sqf(f, p, K, method=None):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_factor_sqf
 
-    >>> gf_factor_sqf([3, 2, 4], 5, ZZ)
+    >>> gf_factor_sqf(ZZ.map([3, 2, 4]), 5, ZZ)
     (3, [[1, 1], [1, 3]])
 
     """
@@ -2022,7 +2022,7 @@ def gf_factor(f, p, K):
        >>> from sympy.polys.domains import ZZ
        >>> from sympy.polys.galoistools import gf_factor
 
-       >>> gf_factor([5, 2, 7, 2], 11, ZZ)
+       >>> gf_factor(ZZ.map([5, 2, 7, 2]), 11, ZZ)
        (5, [([1, 2], 1), ([1, 8], 2)])
 
     We arrived with factorization ``f = 5 (x + 2) (x + 8)**2``. We didn't

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -179,11 +179,11 @@ def test_dmp_subresultants():
     assert dmp_zz_collins_resultant([[]], [[ZZ(1)]], 1, ZZ) == []
     assert dmp_qq_collins_resultant([[]], [[ZZ(1)]], 1, ZZ) == []
 
-    f = dmp_normal([[3,0],[],[-1,0,0,-4]], 1, ZZ)
-    g = dmp_normal([[1],[1,0,0,0],[-9]], 1, ZZ)
+    f = dmp_normal(ZZ.map([[3, 0], [], [-1, 0, 0, -4]]), 1, ZZ)
+    g = dmp_normal(ZZ.map([[1], [1, 0, 0, 0], [-9]]), 1, ZZ)
 
-    a = dmp_normal([[3,0,0,0,0],[1,0,-27,4]], 1, ZZ)
-    b = dmp_normal([[-3,0,0,-12,1,0,-54,8,729,-216,16]], 1, ZZ)
+    a = dmp_normal(ZZ.map([[3, 0, 0, 0, 0], [1, 0, -27, 4]]), 1, ZZ)
+    b = dmp_normal(ZZ.map([[-3, 0, 0, -12, 1, 0, -54, 8, 729, -216, 16]]), 1, ZZ)
 
     r = dmp_LC(b, ZZ)
 
@@ -194,11 +194,11 @@ def test_dmp_subresultants():
     assert dmp_zz_collins_resultant(f, g, 1, ZZ) == r
     assert dmp_qq_collins_resultant(f, g, 1, ZZ) == r
 
-    f = dmp_normal([[-1],[],[],[5]], 1, ZZ)
-    g = dmp_normal([[3,1],[],[]], 1, ZZ)
+    f = dmp_normal(ZZ.map([[-1], [], [], [5]]), 1, ZZ)
+    g = dmp_normal(ZZ.map([[3, 1], [], []]), 1, ZZ)
 
-    a = dmp_normal([[45,30,5]], 1, ZZ)
-    b = dmp_normal([[675,675,225,25]], 1, ZZ)
+    a = dmp_normal(ZZ.map([[45, 30, 5]]), 1, ZZ)
+    b = dmp_normal(ZZ.map([[675, 675, 225, 25]]), 1, ZZ)
 
     r = dmp_LC(b, ZZ)
 
@@ -301,11 +301,11 @@ def test_dup_gcd():
     assert dup_zz_heu_gcd([2], [2,4,2], ZZ) == ([2], [1], [1, 2, 1])
     assert dup_rr_prs_gcd([2], [2,4,2], ZZ) == ([2], [1], [1, 2, 1])
 
-    assert dup_zz_heu_gcd([2,4,2], [1,1], ZZ) == ([1, 1], [2, 2], [1])
-    assert dup_rr_prs_gcd([2,4,2], [1,1], ZZ) == ([1, 1], [2, 2], [1])
+    assert dup_zz_heu_gcd(ZZ.map([2, 4, 2]), [1, 1], ZZ) == ([1, 1], [2, 2], [1])
+    assert dup_rr_prs_gcd(ZZ.map([2, 4, 2]), [1, 1], ZZ) == ([1, 1], [2, 2], [1])
 
-    assert dup_zz_heu_gcd([1,1], [2,4,2], ZZ) == ([1, 1], [1], [2, 2])
-    assert dup_rr_prs_gcd([1,1], [2,4,2], ZZ) == ([1, 1], [1], [2, 2])
+    assert dup_zz_heu_gcd(ZZ.map([1, 1]), [2, 4, 2], ZZ) == ([1, 1], [1], [2, 2])
+    assert dup_rr_prs_gcd(ZZ.map([1, 1]), [2, 4, 2], ZZ) == ([1, 1], [1], [2, 2])
 
     f, g = [1, -31], [1, 0]
 
@@ -434,14 +434,14 @@ def test_dmp_gcd():
     assert dmp_zz_heu_gcd([[2]], [[2],[4],[2]], 1, ZZ) == ([[2]], [[1]], [[1], [2], [1]])
     assert dmp_rr_prs_gcd([[2]], [[2],[4],[2]], 1, ZZ) == ([[2]], [[1]], [[1], [2], [1]])
 
-    assert dmp_zz_heu_gcd([[2],[4],[2]], [[1],[1]], 1, ZZ) == ([[1], [1]], [[2], [2]], [[1]])
-    assert dmp_rr_prs_gcd([[2],[4],[2]], [[1],[1]], 1, ZZ) == ([[1], [1]], [[2], [2]], [[1]])
+    assert dmp_zz_heu_gcd(ZZ.map([[2], [4], [2]]), [[1], [1]], 1, ZZ) == ([[1], [1]], [[2], [2]], [[1]])
+    assert dmp_rr_prs_gcd(ZZ.map([[2], [4], [2]]), [[1], [1]], 1, ZZ) == ([[1], [1]], [[2], [2]], [[1]])
 
-    assert dmp_zz_heu_gcd([[1],[1]], [[2],[4],[2]], 1, ZZ) == ([[1], [1]], [[1]], [[2], [2]])
-    assert dmp_rr_prs_gcd([[1],[1]], [[2],[4],[2]], 1, ZZ) == ([[1], [1]], [[1]], [[2], [2]])
+    assert dmp_zz_heu_gcd(ZZ.map([[1], [1]]), [[2], [4], [2]], 1, ZZ) == ([[1], [1]], [[1]], [[2], [2]])
+    assert dmp_rr_prs_gcd(ZZ.map([[1], [1]]), [[2], [4], [2]], 1, ZZ) == ([[1], [1]], [[1]], [[2], [2]])
 
-    assert dmp_zz_heu_gcd([[[[1,2,1]]]], [[[[2,2]]]], 3, ZZ) == ([[[[1,1]]]], [[[[1,1]]]], [[[[2]]]])
-    assert dmp_rr_prs_gcd([[[[1,2,1]]]], [[[[2,2]]]], 3, ZZ) == ([[[[1,1]]]], [[[[1,1]]]], [[[[2]]]])
+    assert dmp_zz_heu_gcd(ZZ.map([[[[1, 2, 1]]]]), [[[[2, 2]]]], 3, ZZ) == ([[[[1, 1]]]], [[[[1, 1]]]], [[[[2]]]])
+    assert dmp_rr_prs_gcd(ZZ.map([[[[1, 2, 1]]]]), [[[[2, 2]]]], 3, ZZ) == ([[[[1, 1]]]], [[[[1, 1]]]], [[[[2]]]])
 
     f, g = [[[[1,2,1],[1,1],[]]]], [[[[1,2,1]]]]
     h, cff, cfg = [[[[1,1]]]], [[[[1,1],[1],[]]]], [[[[1,1]]]]
@@ -530,11 +530,11 @@ def test_dup_lcm():
     assert dup_lcm([2,0,0,0], [6,0], ZZ) == [6,0,0,0]
     assert dup_lcm([2,0,0,0], [3,0], ZZ) == [6,0,0,0]
 
-    assert dup_lcm([1,1,0], [1,0], ZZ) == [1,1,0]
-    assert dup_lcm([1,1,0], [2,0], ZZ) == [2,2,0]
-    assert dup_lcm([1,2,0], [1,0], ZZ) == [1,2,0]
-    assert dup_lcm([2,1,0], [1,0], ZZ) == [2,1,0]
-    assert dup_lcm([2,1,0], [2,0], ZZ) == [4,2,0]
+    assert dup_lcm(ZZ.map([1, 1, 0]), ZZ.map([1, 0]), ZZ) == [1, 1, 0]
+    assert dup_lcm(ZZ.map([1, 1, 0]), ZZ.map([2, 0]), ZZ) == [2, 2, 0]
+    assert dup_lcm(ZZ.map([1, 2, 0]), ZZ.map([1, 0]), ZZ) == [1, 2, 0]
+    assert dup_lcm(ZZ.map([2, 1, 0]), ZZ.map([1, 0]), ZZ) == [2, 1, 0]
+    assert dup_lcm(ZZ.map([2, 1, 0]), ZZ.map([2, 0]), ZZ) == [4, 2, 0]
 
 def test_dmp_lcm():
     assert dmp_lcm([[2]], [[6]], 1, ZZ) == [[6]]
@@ -543,17 +543,17 @@ def test_dmp_lcm():
     assert dmp_lcm([[2],[],[],[]], [[6,0,0],[]], 1, ZZ) == [[6,0,0],[],[],[]]
     assert dmp_lcm([[2],[],[],[]], [[3,0,0],[]], 1, ZZ) == [[6,0,0],[],[],[]]
 
-    assert dmp_lcm([[1,0],[],[]], [[1,0,0],[]], 1, ZZ) == [[1,0,0],[],[]]
+    assert dmp_lcm(ZZ.map([[1, 0], [], []]), ZZ.map([[1, 0, 0], []]), 1, ZZ) == [[1, 0, 0], [], []]
 
-    f = [[2,-3,-2,3,0,0],[]]
-    g = [[1,0,-2,0,1,0]]
-    h = [[2,-3,-4,6,2,-3,0,0],[]]
+    f = ZZ.map([[2, -3, -2, 3, 0, 0], []])
+    g = ZZ.map([[1, 0, -2, 0, 1, 0]])
+    h = [[2, -3, -4, 6, 2, -3, 0, 0], []]
 
     assert dmp_lcm(f, g, 1, ZZ) == h
 
-    f = [[1],[-3,0],[-9,0,0],[-5,0,0,0]]
-    g = [[1],[6,0],[12,0,0],[10,0,0,0],[3,0,0,0,0]]
-    h = [[1],[1,0],[-18,0,0],[-50,0,0,0],[-47,0,0,0,0],[-15,0,0,0,0,0]]
+    f = ZZ.map([[1], [-3, 0], [-9, 0, 0], [-5, 0, 0, 0]])
+    g = ZZ.map([[1], [6, 0], [12, 0, 0], [10, 0, 0, 0], [3, 0, 0, 0, 0]])
+    h = [[1], [1, 0], [-18, 0, 0], [-50, 0, 0, 0], [-47, 0, 0, 0, 0], [-15, 0, 0, 0, 0, 0]]
 
     assert dmp_lcm(f, g, 1, ZZ) == h
 

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -85,7 +85,7 @@ def test_dup_zz_hensel_lift():
     f3 = dup_from_raw_dict({1:1, 0: 2}, ZZ)
     f4 = dup_from_raw_dict({1:1, 0: 1}, ZZ)
 
-    ff_list = dup_zz_hensel_lift(5, f, [f1, f2, f3, f4], 4, ZZ)
+    ff_list = dup_zz_hensel_lift(ZZ(5), f, [f1, f2, f3, f4], 4, ZZ)
 
     assert dup_to_raw_dict(ff_list[0]) == {0: -1,   1: 1}
     assert dup_to_raw_dict(ff_list[1]) == {0: -182, 1: 1}
@@ -100,27 +100,27 @@ def test_dup_zz_irreducible_p():
     assert dup_zz_irreducible_p([3, 2, 6, 8, 14], ZZ) == True
 
 def test_dup_cyclotomic_p():
-    assert dup_cyclotomic_p([1,-1], ZZ) == True
-    assert dup_cyclotomic_p([1,1], ZZ) == True
-    assert dup_cyclotomic_p([1,1,1], ZZ) == True
-    assert dup_cyclotomic_p([1,0,1], ZZ) == True
-    assert dup_cyclotomic_p([1,1,1,1,1], ZZ) == True
-    assert dup_cyclotomic_p([1,-1,1], ZZ) == True
-    assert dup_cyclotomic_p([1,1,1,1,1,1,1], ZZ) == True
-    assert dup_cyclotomic_p([1,0,0,0,1], ZZ) == True
-    assert dup_cyclotomic_p([1,0,0,1,0,0,1], ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, -1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 1, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 0, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 1, 1, 1, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, -1, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 1, 1, 1, 1, 1, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 0, 0, 0, 1]), ZZ) == True
+    assert dup_cyclotomic_p(ZZ.map([1, 0, 0, 1, 0, 0, 1]), ZZ) == True
 
-    assert dup_cyclotomic_p([], ZZ) == False
-    assert dup_cyclotomic_p([1], ZZ) == False
-    assert dup_cyclotomic_p([1, 0], ZZ) == False
-    assert dup_cyclotomic_p([1, 2], ZZ) == False
-    assert dup_cyclotomic_p([3, 1], ZZ) == False
-    assert dup_cyclotomic_p([1, 0, -1], ZZ) == False
+    assert dup_cyclotomic_p(ZZ.map([]), ZZ) == False
+    assert dup_cyclotomic_p(ZZ.map([1]), ZZ) == False
+    assert dup_cyclotomic_p(ZZ.map([1, 0]), ZZ) == False
+    assert dup_cyclotomic_p(ZZ.map([1, 2]), ZZ) == False
+    assert dup_cyclotomic_p(ZZ.map([3, 1]), ZZ) == False
+    assert dup_cyclotomic_p(ZZ.map([1, 0, -1]), ZZ) == False
 
-    f = [1, 0, 1, 0, 0, 0,-1, 0, 1, 0,-1, 0, 0, 0, 1, 0, 1]
+    f = ZZ.map([1, 0, 1, 0, 0, 0, -1, 0, 1, 0, -1, 0, 0, 0, 1, 0, 1])
     assert dup_cyclotomic_p(f, ZZ) == False
 
-    g = [1, 0, 1, 0, 0, 0,-1, 0,-1, 0,-1, 0, 0, 0, 1, 0, 1]
+    g = ZZ.map([1, 0, 1, 0, 0, 0, -1, 0, -1, 0, -1, 0, 0, 0, 1, 0, 1])
     assert dup_cyclotomic_p(g, ZZ) == True
 
     assert dup_cyclotomic_p([QQ(1),QQ(1),QQ(1)], QQ) == True
@@ -197,56 +197,56 @@ def test_dup_zz_factor():
     assert dup_zz_factor_sqf([2,4], ZZ) == \
         (2, [([1, 2], 1)])
 
-    f = [1,0,0,1,1]
+    f = ZZ.map([1, 0, 0, 1, 1])
 
     for i in xrange(0, 20):
         assert dup_zz_factor(f, ZZ) == (1, [(f, 1)])
 
-    assert dup_zz_factor([1,2,2], ZZ) == \
+    assert dup_zz_factor(ZZ.map([1, 2, 2]), ZZ) == \
         (1, [([1,2,2], 1)])
 
-    assert dup_zz_factor([18,12,2], ZZ) == \
+    assert dup_zz_factor(ZZ.map([18, 12, 2]), ZZ) == \
         (2, [([3, 1], 2)])
 
-    assert dup_zz_factor([-9,0,1], ZZ) == \
+    assert dup_zz_factor(ZZ.map([-9, 0, 1]), ZZ) == \
         (-1, [([3,-1], 1),
               ([3, 1], 1)])
 
-    assert dup_zz_factor_sqf([-9,0,1], ZZ) == \
+    assert dup_zz_factor_sqf(ZZ.map([-9, 0, 1]), ZZ) == \
         (-1, [[3,-1],
               [3, 1]])
 
-    assert dup_zz_factor([1,-6,11,-6], ZZ) == \
+    assert dup_zz_factor(ZZ.map([1, -6, 11, -6]), ZZ) == \
         (1, [([1,-3], 1),
              ([1,-2], 1),
              ([1,-1], 1)])
 
-    assert dup_zz_factor_sqf([1,-6,11,-6], ZZ) == \
+    assert dup_zz_factor_sqf(ZZ.map([1, -6, 11, -6]), ZZ) == \
         (1, [[1,-3],
              [1,-2],
              [1,-1]])
 
-    assert dup_zz_factor([3,10,13,10], ZZ) == \
+    assert dup_zz_factor(ZZ.map([3, 10, 13, 10]), ZZ) == \
         (1, [([1,2], 1),
              ([3,4,5], 1)])
 
-    assert dup_zz_factor_sqf([3,10,13,10], ZZ) == \
+    assert dup_zz_factor_sqf(ZZ.map([3, 10, 13, 10]), ZZ) == \
         (1, [[1,2],
              [3,4,5]])
 
-    assert dup_zz_factor([-1,0,0,0,1,0,0], ZZ) == \
+    assert dup_zz_factor(ZZ.map([-1, 0, 0, 0, 1, 0, 0]), ZZ) == \
         (-1, [([1,-1], 1),
               ([1, 1], 1),
               ([1, 0], 2),
               ([1, 0, 1], 1)])
 
-    f = [1080, 5184, 2099, 744, 2736, -648, 129, 0, -324]
+    f = ZZ.map([1080, 5184, 2099, 744, 2736, -648, 129, 0, -324])
 
     assert dup_zz_factor(f, ZZ) == \
         (1, [([5, 24, 9, 0, 12], 1),
              ([216, 0, 31, 0, -27], 1)])
 
-    f = [-29802322387695312500000000000000000000,
+    f = ZZ.map([-29802322387695312500000000000000000000,
           0, 0, 0, 0,
           2980232238769531250000000000000000,
           0, 0, 0, 0,
@@ -256,7 +256,7 @@ def test_dup_zz_factor():
           0, 0, 0, 0,
           -210106372833251953125,
           0, 0, 0, 0,
-          95367431640625]
+          95367431640625])
 
     assert dup_zz_factor(f, ZZ) == \
         (-95367431640625, [([5, -1], 1),
@@ -265,7 +265,7 @@ def test_dup_zz_factor():
                            ([10000, -3000, 400, -20, 1], 2),
                            ([10000,  2000, 400,  30, 1], 2)])
 
-    f = dup_from_raw_dict({10:1, 0:-1}, ZZ)
+    f = dup_from_raw_dict({10: ZZ(1), 0: ZZ(-1)}, ZZ)
 
     config.setup('USE_CYCLOTOMIC_FACTOR', True)
     F_0 = dup_zz_factor(f, ZZ)
@@ -281,7 +281,7 @@ def test_dup_zz_factor():
 
     config.setup('USE_CYCLOTOMIC_FACTOR')
 
-    f = dup_from_raw_dict({10:1, 0:1}, ZZ)
+    f = dup_from_raw_dict({10: ZZ(1), 0: ZZ(1)}, ZZ)
 
     config.setup('USE_CYCLOTOMIC_FACTOR', True)
     F_0 = dup_zz_factor(f, ZZ)
@@ -368,46 +368,46 @@ def test_issue_3256():
     assert dmp_zz_wang(f, u, K, seed=random_sequence) == [f]
 
 def test_dmp_zz_factor():
-    assert dmp_zz_factor([], 0, ZZ) == (0, [])
-    assert dmp_zz_factor([7], 0, ZZ) == (7, [])
-    assert dmp_zz_factor([-7], 0, ZZ) == (-7, [])
+    assert dmp_zz_factor(ZZ.map([]), 0, ZZ) == (0, [])
+    assert dmp_zz_factor(ZZ.map([7]), 0, ZZ) == (7, [])
+    assert dmp_zz_factor(ZZ.map([-7]), 0, ZZ) == (-7, [])
 
-    assert dmp_zz_factor([[]], 1, ZZ) == (0, [])
-    assert dmp_zz_factor([[7]], 1, ZZ) == (7, [])
-    assert dmp_zz_factor([[-7]], 1, ZZ) == (-7, [])
+    assert dmp_zz_factor(ZZ.map([[]]), 1, ZZ) == (0, [])
+    assert dmp_zz_factor(ZZ.map([[7]]), 1, ZZ) == (7, [])
+    assert dmp_zz_factor(ZZ.map([[-7]]), 1, ZZ) == (-7, [])
 
-    assert dmp_zz_factor([[1], []], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[1], []]), 1, ZZ) == \
         (1, [([[1], []], 1)])
 
-    assert dmp_zz_factor([[4], []], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[4], []]), 1, ZZ) == \
         (4, [([[1], []], 1)])
 
-    assert dmp_zz_factor([[4], [2]], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[4], [2]]), 1, ZZ) == \
         (2, [([[2], [1]], 1)])
 
-    assert dmp_zz_factor([[1, 0], [1]], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[1, 0], [1]]), 1, ZZ) == \
         (1, [([[1, 0], [1]], 1)])
 
-    assert dmp_zz_factor([[1,0,1]], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[1, 0, 1]]), 1, ZZ) == \
         (1, [([[1, 0, 1]], 1)])
 
-    assert dmp_zz_factor([[1,0,-1]], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[1, 0, -1]]), 1, ZZ) == \
         (1, [([[1,-1]], 1),
              ([[1, 1]], 1)])
 
-    assert dmp_zz_factor([[1, 6, 9], [], [-1]], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[1, 6, 9], [], [-1]]), 1, ZZ) == \
         (1, [([[1, 3], [-1]], 1), ([[1, 3], [1]], 1)])
 
-    assert dmp_zz_factor([1, 0, -9], 0, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([1, 0, -9]), 0, ZZ) == \
         (1, [([1, -3], 1), ([1, 3], 1)])
 
-    assert dmp_zz_factor([[1, 0, 0], [], [-9]], 1, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[1, 0, 0], [], [-9]]), 1, ZZ) == \
         (1, [([[1, 0], [-3]], 1), ([[1, 0], [3]], 1)])
 
-    assert dmp_zz_factor([[[1, 0, 0], [], []], [[]], [[-9]]], 2, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[[1, 0, 0], [], []], [[]], [[-9]]]), 2, ZZ) == \
         (1, [([[[1, 0], []], [[-3]]], 1), ([[[1, 0], []], [[3]]], 1)])
 
-    assert dmp_zz_factor([[[[1, 0, 0], [], []], [[]], [[]]], [[[]]], [[[-9]]]], 3, ZZ) == \
+    assert dmp_zz_factor(ZZ.map([[[[1, 0, 0], [], []], [[]], [[]]], [[[]]], [[[-9]]]]), 3, ZZ) == \
         (1, [([[[[1, 0], []], [[]]], [[[-3]]]], 1), ([[[[1, 0], []], [[]]], [[[3]]]], 1)])
 
     assert dmp_zz_factor(f_1, 2, ZZ) == \

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -126,13 +126,13 @@ def test_gf_TC():
     assert gf_TC([1,2], ZZ) == 2
 
 def test_gf_monic():
-    assert gf_monic([], 11, ZZ) == (0, [])
+    assert gf_monic(ZZ.map([]), 11, ZZ) == (0, [])
 
-    assert gf_monic([1], 11, ZZ) == (1, [1])
-    assert gf_monic([2], 11, ZZ) == (2, [1])
+    assert gf_monic(ZZ.map([1]), 11, ZZ) == (1, [1])
+    assert gf_monic(ZZ.map([2]), 11, ZZ) == (2, [1])
 
-    assert gf_monic([1,2,3,4], 11, ZZ) == (1, [1,2,3,4])
-    assert gf_monic([2,3,4,5], 11, ZZ) == (2, [1,7,2,8])
+    assert gf_monic(ZZ.map([1, 2, 3, 4]), 11, ZZ) == (1, [1, 2, 3, 4])
+    assert gf_monic(ZZ.map([2, 3, 4, 5]), 11, ZZ) == (2, [1, 7, 2, 8])
 
 def test_gf_arith():
     assert gf_neg([], 11, ZZ) == []
@@ -216,7 +216,10 @@ def test_gf_division():
     assert gf_rem([1], [1,2,3], 7, ZZ) == [1]
     assert gf_quo([1], [1,2,3], 7, ZZ) == []
 
-    f, g, q, r = [5,4,3,2,1,0], [1,2,3], [5,1,0,6], [3,3]
+    f = ZZ.map([5, 4, 3, 2, 1, 0])
+    g = ZZ.map([1, 2, 3])
+    q = [5, 1, 0, 6]
+    r = [3, 3]
 
     assert gf_div(f, g, 7, ZZ) == (q, r)
     assert gf_rem(f, g, 7, ZZ) == r
@@ -224,7 +227,10 @@ def test_gf_division():
 
     raises(ExactQuotientFailed, lambda: gf_exquo(f, g, 7, ZZ))
 
-    f, g, q, r = [5,4,3,2,1,0], [1,2,3,0], [5,1,0], [6,1,0]
+    f = ZZ.map([5, 4, 3, 2, 1, 0])
+    g = ZZ.map([1, 2, 3, 0])
+    q = [5, 1, 0]
+    r = [6, 1, 0]
 
     assert gf_div(f, g, 7, ZZ) == (q, r)
     assert gf_rem(f, g, 7, ZZ) == r
@@ -232,7 +238,7 @@ def test_gf_division():
 
     raises(ExactQuotientFailed, lambda: gf_exquo(f, g, 7, ZZ))
 
-    assert gf_quo([1,2,1], [1,1], 11, ZZ) == [1,1]
+    assert gf_quo(ZZ.map([1, 2, 1]), ZZ.map([1, 1]), 11, ZZ) == [1, 1]
 
 def test_gf_shift():
     f = [1,2,3,4,5]
@@ -277,61 +283,61 @@ def test_gf_powering():
          10, 0, 0, 10, 3, 0, 0, 0, 0, 0, 0,  2, 0, 0,  2,  5, 0, 0, 0, 0, 0, 0,
           4, 0, 0, 4, 10]
 
-    assert gf_pow_mod([1,0,0,1,8], 0, [2,0,7], 11, ZZ) == [1]
-    assert gf_pow_mod([1,0,0,1,8], 1, [2,0,7], 11, ZZ) == [1,1]
-    assert gf_pow_mod([1,0,0,1,8], 2, [2,0,7], 11, ZZ) == [2,3]
-    assert gf_pow_mod([1,0,0,1,8], 5, [2,0,7], 11, ZZ) == [7,8]
-    assert gf_pow_mod([1,0,0,1,8], 8, [2,0,7], 11, ZZ) == [1,5]
-    assert gf_pow_mod([1,0,0,1,8], 45, [2,0,7], 11, ZZ) == [5,4]
+    assert gf_pow_mod(ZZ.map([1, 0, 0, 1, 8]), 0, ZZ.map([2, 0, 7]), 11, ZZ) == [1]
+    assert gf_pow_mod(ZZ.map([1, 0, 0, 1, 8]), 1, ZZ.map([2, 0, 7]), 11, ZZ) == [1, 1]
+    assert gf_pow_mod(ZZ.map([1, 0, 0, 1, 8]), 2, ZZ.map([2, 0, 7]), 11, ZZ) == [2, 3]
+    assert gf_pow_mod(ZZ.map([1, 0, 0, 1, 8]), 5, ZZ.map([2, 0, 7]), 11, ZZ) == [7, 8]
+    assert gf_pow_mod(ZZ.map([1, 0, 0, 1, 8]), 8, ZZ.map([2, 0, 7]), 11, ZZ) == [1, 5]
+    assert gf_pow_mod(ZZ.map([1, 0, 0, 1, 8]), 45, ZZ.map([2, 0, 7]), 11, ZZ) == [5, 4]
 
 def test_gf_gcdex():
-    assert gf_gcdex([], [], 11, ZZ) == ([1], [], [])
-    assert gf_gcdex([2], [], 11, ZZ) == ([6], [], [1])
-    assert gf_gcdex([], [2], 11, ZZ) == ([], [6], [1])
-    assert gf_gcdex([2], [2], 11, ZZ) == ([], [6], [1])
+    assert gf_gcdex(ZZ.map([]), ZZ.map([]), 11, ZZ) == ([1], [], [])
+    assert gf_gcdex(ZZ.map([2]), ZZ.map([]), 11, ZZ) == ([6], [], [1])
+    assert gf_gcdex(ZZ.map([]), ZZ.map([2]), 11, ZZ) == ([], [6], [1])
+    assert gf_gcdex(ZZ.map([2]), ZZ.map([2]), 11, ZZ) == ([], [6], [1])
 
-    assert gf_gcdex([], [3,0], 11, ZZ) == ([], [4], [1,0])
-    assert gf_gcdex([3,0], [], 11, ZZ) == ([4], [], [1,0])
+    assert gf_gcdex(ZZ.map([]), ZZ.map([3, 0]), 11, ZZ) == ([], [4], [1, 0])
+    assert gf_gcdex(ZZ.map([3, 0]), ZZ.map([]), 11, ZZ) == ([4], [], [1, 0])
 
-    assert gf_gcdex([3,0], [3,0], 11, ZZ) == ([], [4], [1,0])
+    assert gf_gcdex(ZZ.map([3, 0]), ZZ.map([3, 0]), 11, ZZ) == ([], [4], [1, 0])
 
-    assert gf_gcdex([1,8,7], [1,7,1,7], 11, ZZ) == ([5,6], [6], [1,7])
+    assert gf_gcdex(ZZ.map([1, 8, 7]), ZZ.map([1, 7, 1, 7]), 11, ZZ) == ([5, 6], [6], [1, 7])
 
 def test_gf_gcd():
-    assert gf_gcd([], [], 11, ZZ) == []
-    assert gf_gcd([2], [], 11, ZZ) == [1]
-    assert gf_gcd([], [2], 11, ZZ) == [1]
-    assert gf_gcd([2], [2], 11, ZZ) == [1]
+    assert gf_gcd(ZZ.map([]), ZZ.map([]), 11, ZZ) == []
+    assert gf_gcd(ZZ.map([2]), ZZ.map([]), 11, ZZ) == [1]
+    assert gf_gcd(ZZ.map([]), ZZ.map([2]), 11, ZZ) == [1]
+    assert gf_gcd(ZZ.map([2]), ZZ.map([2]), 11, ZZ) == [1]
 
-    assert gf_gcd([], [1,0], 11, ZZ) == [1,0]
-    assert gf_gcd([1,0], [], 11, ZZ) == [1,0]
+    assert gf_gcd(ZZ.map([]), ZZ.map([1, 0]), 11, ZZ) == [1, 0]
+    assert gf_gcd(ZZ.map([1, 0]), ZZ.map([]), 11, ZZ) == [1, 0]
 
-    assert gf_gcd([3,0], [3,0], 11, ZZ) == [1,0]
-    assert gf_gcd([1,8,7], [1,7,1,7], 11, ZZ) == [1,7]
+    assert gf_gcd(ZZ.map([3, 0]), ZZ.map([3, 0]), 11, ZZ) == [1, 0]
+    assert gf_gcd(ZZ.map([1, 8, 7]), ZZ.map([1, 7, 1, 7]), 11, ZZ) == [1, 7]
 
 def test_gf_lcm():
-    assert gf_lcm([], [], 11, ZZ) == []
-    assert gf_lcm([2], [], 11, ZZ) == []
-    assert gf_lcm([], [2], 11, ZZ) == []
-    assert gf_lcm([2], [2], 11, ZZ) == [1]
+    assert gf_lcm(ZZ.map([]), ZZ.map([]), 11, ZZ) == []
+    assert gf_lcm(ZZ.map([2]), ZZ.map([]), 11, ZZ) == []
+    assert gf_lcm(ZZ.map([]), ZZ.map([2]), 11, ZZ) == []
+    assert gf_lcm(ZZ.map([2]), ZZ.map([2]), 11, ZZ) == [1]
 
-    assert gf_lcm([], [1,0], 11, ZZ) == []
-    assert gf_lcm([1,0], [], 11, ZZ) == []
+    assert gf_lcm(ZZ.map([]), ZZ.map([1, 0]), 11, ZZ) == []
+    assert gf_lcm(ZZ.map([1, 0]), ZZ.map([]), 11, ZZ) == []
 
-    assert gf_lcm([3,0], [3,0], 11, ZZ) == [1,0]
-    assert gf_lcm([1,8,7], [1,7,1,7], 11, ZZ) == [1,8,8,8,7]
+    assert gf_lcm(ZZ.map([3, 0]), ZZ.map([3, 0]), 11, ZZ) == [1, 0]
+    assert gf_lcm(ZZ.map([1, 8, 7]), ZZ.map([1, 7, 1, 7]), 11, ZZ) == [1, 8, 8, 8, 7]
 
 def test_gf_cofactors():
-    assert gf_cofactors([], [], 11, ZZ) == ([], [], [])
-    assert gf_cofactors([2], [], 11, ZZ) == ([1], [2], [])
-    assert gf_cofactors([], [2], 11, ZZ) == ([1], [], [2])
-    assert gf_cofactors([2], [2], 11, ZZ) == ([1], [2], [2])
+    assert gf_cofactors(ZZ.map([]), ZZ.map([]), 11, ZZ) == ([], [], [])
+    assert gf_cofactors(ZZ.map([2]), ZZ.map([]), 11, ZZ) == ([1], [2], [])
+    assert gf_cofactors(ZZ.map([]), ZZ.map([2]), 11, ZZ) == ([1], [], [2])
+    assert gf_cofactors(ZZ.map([2]), ZZ.map([2]), 11, ZZ) == ([1], [2], [2])
 
-    assert gf_cofactors([], [1,0], 11, ZZ) == ([1,0], [], [1])
-    assert gf_cofactors([1,0], [], 11, ZZ) == ([1,0], [1], [])
+    assert gf_cofactors(ZZ.map([]), ZZ.map([1, 0]), 11, ZZ) == ([1, 0], [], [1])
+    assert gf_cofactors(ZZ.map([1, 0]), ZZ.map([]), 11, ZZ) == ([1, 0], [1], [])
 
-    assert gf_cofactors([3,0], [3,0], 11, ZZ) == ([1,0], [3], [3])
-    assert gf_cofactors([1,8,7], [1,7,1,7], 11, ZZ) == (([1,7], [1,1], [1,0,1]))
+    assert gf_cofactors(ZZ.map([3, 0]), ZZ.map([3, 0]), 11, ZZ) == ([1, 0], [3], [3])
+    assert gf_cofactors(ZZ.map([1, 8, 7]), ZZ.map([1, 7, 1, 7]), 11, ZZ) == (([1, 7], [1, 1], [1, 0, 1]))
 
 def test_gf_diff():
     assert gf_diff([], 11, ZZ) == []
@@ -366,13 +372,17 @@ def test_gf_compose():
     assert gf_compose([1,0], [], 11, ZZ) == []
     assert gf_compose([1,0], [1,0], 11, ZZ) == [1,0]
 
-    f, g, h = [1, 1, 4, 9, 1], [1,1,1], [1,0,0,2]
+    f = ZZ.map([1, 1, 4, 9, 1])
+    g = ZZ.map([1, 1, 1])
+    h = ZZ.map([1, 0, 0, 2])
 
     assert gf_compose(g, h, 11, ZZ) == [1,0,0,5,0,0,7]
     assert gf_compose_mod(g, h, f, 11, ZZ) == [3,9,6,10]
 
 def test_gf_trace_map():
-    f, a, c = [1, 1, 4, 9, 1], [1,1,1], [1,0]
+    f = ZZ.map([1, 1, 4, 9, 1])
+    a = [1, 1, 1]
+    c = ZZ.map([1, 0])
     b = gf_pow_mod(c, 11, f, 11, ZZ)
 
     assert gf_trace_map(a, b, c, 0, f, 11, ZZ) == \
@@ -400,32 +410,32 @@ def test_gf_irreducible():
     assert gf_irreducible_p(gf_irreducible(7, 11, ZZ), 11, ZZ) == True
 
 def test_gf_irreducible_p():
-    assert gf_irred_p_ben_or([7], 11, ZZ) == True
-    assert gf_irred_p_ben_or([7,3], 11, ZZ) == True
-    assert gf_irred_p_ben_or([7,3,1], 11, ZZ) == False
+    assert gf_irred_p_ben_or(ZZ.map([7]), 11, ZZ) == True
+    assert gf_irred_p_ben_or(ZZ.map([7, 3]), 11, ZZ) == True
+    assert gf_irred_p_ben_or(ZZ.map([7, 3, 1]), 11, ZZ) == False
 
-    assert gf_irred_p_rabin([7], 11, ZZ) == True
-    assert gf_irred_p_rabin([7,3], 11, ZZ) == True
-    assert gf_irred_p_rabin([7,3,1], 11, ZZ) == False
+    assert gf_irred_p_rabin(ZZ.map([7]), 11, ZZ) == True
+    assert gf_irred_p_rabin(ZZ.map([7, 3]), 11, ZZ) == True
+    assert gf_irred_p_rabin(ZZ.map([7, 3, 1]), 11, ZZ) == False
 
     config.setup('GF_IRRED_METHOD', 'ben-or')
 
-    assert gf_irreducible_p([7], 11, ZZ) == True
-    assert gf_irreducible_p([7,3], 11, ZZ) == True
-    assert gf_irreducible_p([7,3,1], 11, ZZ) == False
+    assert gf_irreducible_p(ZZ.map([7]), 11, ZZ) == True
+    assert gf_irreducible_p(ZZ.map([7, 3]), 11, ZZ) == True
+    assert gf_irreducible_p(ZZ.map([7, 3, 1]), 11, ZZ) == False
 
     config.setup('GF_IRRED_METHOD', 'rabin')
 
-    assert gf_irreducible_p([7], 11, ZZ) == True
-    assert gf_irreducible_p([7,3], 11, ZZ) == True
-    assert gf_irreducible_p([7,3,1], 11, ZZ) == False
+    assert gf_irreducible_p(ZZ.map([7]), 11, ZZ) == True
+    assert gf_irreducible_p(ZZ.map([7, 3]), 11, ZZ) == True
+    assert gf_irreducible_p(ZZ.map([7, 3, 1]), 11, ZZ) == False
 
     config.setup('GF_IRRED_METHOD', 'other')
     raises(KeyError, lambda: gf_irreducible_p([7], 11, ZZ))
     config.setup('GF_IRRED_METHOD')
 
-    f = [1, 9,  9, 13, 16, 15,  6,  7,  7,  7, 10]
-    g = [1, 7, 16,  7, 15, 13, 13, 11, 16, 10,  9]
+    f = ZZ.map([1, 9,  9, 13, 16, 15,  6,  7,  7,  7, 10])
+    g = ZZ.map([1, 7, 16,  7, 15, 13, 13, 11, 16, 10,  9])
 
     h = gf_mul(f, g, 17, ZZ)
 
@@ -492,16 +502,16 @@ def test_gf_berlekamp():
     assert gf_berlekamp(f, 11, ZZ) == \
         [[1, 1], [1, 5, 3], [1, 2, 3, 4]]
 
-    f = [1,0,1,0,10,10,8,2,8]
+    f = ZZ.map([1, 0, 1, 0, 10, 10, 8, 2, 8])
 
-    Q = [[1, 0, 0, 0, 0, 0, 0, 0],
+    Q = ZZ.map([[1, 0, 0, 0, 0, 0, 0, 0],
          [2, 1, 7,11,10,12, 5,11],
          [3, 6, 4, 3, 0, 4, 7, 2],
          [4, 3, 6, 5, 1, 6, 2, 3],
          [2,11, 8, 8, 3, 1, 3,11],
          [6,11, 8, 6, 2, 7,10, 9],
          [5,11, 7,10, 0,11, 7,12],
-         [3, 3,12, 5, 0,11, 9,12]]
+         [3, 3,12, 5, 0,11, 9,12]])
 
     V = [[1, 0, 0, 0, 0, 0, 0, 0],
          [0, 5, 5, 0, 9, 5, 1, 0],
@@ -514,14 +524,14 @@ def test_gf_berlekamp():
         [[1, 3], [1, 8, 4, 12], [1, 2, 3, 4, 6]]
 
 def test_gf_ddf():
-    f = gf_from_dict({15: 1, 0: -1}, 11, ZZ)
+    f = gf_from_dict({15: ZZ(1), 0: ZZ(-1)}, 11, ZZ)
     g = [([1, 0, 0, 0, 0, 10], 1),
          ([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1], 2)]
 
     assert gf_ddf_zassenhaus(f, 11, ZZ) == g
     assert gf_ddf_shoup(f, 11, ZZ) == g
 
-    f = gf_from_dict({63: 1, 0: 1}, 2, ZZ)
+    f = gf_from_dict({63: ZZ(1), 0: ZZ(1)}, 2, ZZ)
     g = [([1, 1], 1),
          ([1, 1, 1], 2),
          ([1, 1, 1, 1, 1, 1, 1], 3),
@@ -532,14 +542,14 @@ def test_gf_ddf():
     assert gf_ddf_zassenhaus(f, 2, ZZ) == g
     assert gf_ddf_shoup(f, 2, ZZ) == g
 
-    f = gf_from_dict({6: 1, 5: -1, 4: 1, 3: 1, 1: -1}, 3, ZZ)
+    f = gf_from_dict({6: ZZ(1), 5: ZZ(-1), 4: ZZ(1), 3: ZZ(1), 1: ZZ(-1)}, 3, ZZ)
     g = [([1, 1, 0], 1),
          ([1, 1, 0, 1, 2], 2)]
 
     assert gf_ddf_zassenhaus(f, 3, ZZ) == g
     assert gf_ddf_shoup(f, 3, ZZ) == g
 
-    f = [1, 2, 5, 26, 677, 436, 791, 325, 456, 24, 577]
+    f = ZZ.map([1, 2, 5, 26, 677, 436, 791, 325, 456, 24, 577])
     g = [([1, 701], 1),
          ([1, 110, 559, 532, 694, 151, 110, 70, 735, 122], 9)]
 
@@ -556,8 +566,8 @@ def test_gf_ddf():
     assert gf_ddf_shoup(f, p, ZZ) == g
 
 def test_gf_edf():
-    f = [1, 1, 0, 1, 2]
-    g = [[1, 0, 1], [1, 1, 2]]
+    f = ZZ.map([1, 1, 0, 1, 2])
+    g = ZZ.map([[1, 0, 1], [1, 1, 2]])
 
     assert gf_edf_zassenhaus(f, 2, 3, ZZ) == g
     assert gf_edf_shoup(f, 2, 3, ZZ) == g
@@ -585,11 +595,11 @@ def test_gf_factor():
 
     config.setup('GF_FACTOR_METHOD', 'shoup')
 
-    assert gf_factor_sqf([], 11, ZZ) == (0, [])
-    assert gf_factor_sqf([1], 11, ZZ) == (1, [])
-    assert gf_factor_sqf([1,1], 11, ZZ) == (1, [[1, 1]])
+    assert gf_factor_sqf(ZZ.map([]), 11, ZZ) == (0, [])
+    assert gf_factor_sqf(ZZ.map([1]), 11, ZZ) == (1, [])
+    assert gf_factor_sqf(ZZ.map([1, 1]), 11, ZZ) == (1, [[1, 1]])
 
-    f, p = [1,0,0,1,0], 2
+    f, p = ZZ.map([1,0,0,1,0]), 2
 
     g = (1, [([1, 0], 1),
              ([1, 1], 1),
@@ -672,7 +682,7 @@ def test_gf_factor():
     config.setup('GF_FACTOR_METHOD', 'shoup')
     assert gf_factor(f, p, ZZ) == g
 
-    f, p = gf_from_dict({32: 8, 0: 5}, 11, ZZ), 11
+    f, p = gf_from_dict({32: ZZ(8), 0: ZZ(5)}, 11, ZZ), 11
 
     g = (8, [([1, 3], 1),
              ([1, 8], 1),
@@ -693,7 +703,7 @@ def test_gf_factor():
     config.setup('GF_FACTOR_METHOD', 'shoup')
     assert gf_factor(f, p, ZZ) == g
 
-    f, p = gf_from_dict({63: 8, 0: 5}, 11, ZZ), 11
+    f, p = gf_from_dict({63: ZZ(8), 0: ZZ(5)}, 11, ZZ), 11
 
     g = (8, [([1, 7], 1),
              ([1, 4, 5], 1),
@@ -751,7 +761,7 @@ def test_gf_factor():
     # (mod p > 2**(n-2) * pi), where a_n = a_{n-1}**2 + 1, a_0 = 1
 
     p = ZZ(nextprime(int((2**4 * pi).evalf())))
-    f = [1, 2, 5, 26, 41, 39, 38]
+    f = ZZ.map([1, 2, 5, 26, 41, 39, 38])
 
     assert gf_sqf_p(f, p, ZZ) == True
 

--- a/sympy/polys/tests/test_quotientring.py
+++ b/sympy/polys/tests/test_quotientring.py
@@ -33,7 +33,7 @@ def test_QuotientRing():
 
     assert R.convert(1)/x == -x + I
     assert -1 + I == x**2 + I
-    assert R.convert(1, ZZ) == 1 + I
+    assert R.convert(ZZ(1), ZZ) == 1 + I
     assert R.convert(R.convert(x), R) == R.convert(x)
 
     X = R.convert(x)

--- a/sympy/polys/tests/test_rootisolation.py
+++ b/sympy/polys/tests/test_rootisolation.py
@@ -409,207 +409,207 @@ def test_dup_count_real_roots():
     assert dup_count_real_roots([], ZZ) == 0
     assert dup_count_real_roots([7], ZZ) == 0
 
-    assert dup_count_real_roots([1,-1], ZZ) == 1
-    assert dup_count_real_roots([1,-1], ZZ, inf=1) == 1
-    assert dup_count_real_roots([1,-1], ZZ, sup=0) == 0
-    assert dup_count_real_roots([1,-1], ZZ, sup=1) == 1
-    assert dup_count_real_roots([1,-1], ZZ, inf=0, sup=1) == 1
-    assert dup_count_real_roots([1,-1], ZZ, inf=0, sup=2) == 1
-    assert dup_count_real_roots([1,-1], ZZ, inf=1, sup=2) == 1
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ) == 1
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ, inf=1) == 1
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ, sup=0) == 0
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ, sup=1) == 1
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ, inf=0, sup=1) == 1
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ, inf=0, sup=2) == 1
+    assert dup_count_real_roots(ZZ.map([1, -1]), ZZ, inf=1, sup=2) == 1
 
-    assert dup_count_real_roots([1,0,-2], ZZ) == 2
-    assert dup_count_real_roots([1,0,-2], ZZ, sup=0) == 1
-    assert dup_count_real_roots([1,0,-2], ZZ, inf=-1, sup=1) == 0
+    assert dup_count_real_roots(ZZ.map([1, 0, -2]), ZZ) == 2
+    assert dup_count_real_roots(ZZ.map([1, 0, -2]), ZZ, sup=0) == 1
+    assert dup_count_real_roots(ZZ.map([1, 0, -2]), ZZ, inf=-1, sup=1) == 0
 
 a, b = (-QQ(1), -QQ(1)), (QQ(1), QQ(1))
 c, d = ( QQ(0),  QQ(0)), (QQ(1), QQ(1))
 
 def test_dup_count_complex_roots_1():
     # z-1
-    assert dup_count_complex_roots([1,-1], ZZ, a, b) == 1
-    assert dup_count_complex_roots([1,-1], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, -1]), ZZ, a, b) == 1
+    assert dup_count_complex_roots(ZZ.map([1, -1]), ZZ, c, d) == 1
 
     # z+1
-    assert dup_count_complex_roots([1,1], ZZ, a, b) == 1
-    assert dup_count_complex_roots([1,1], ZZ, c, d) == 0
+    assert dup_count_complex_roots(ZZ.map([1, 1]), ZZ, a, b) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 1]), ZZ, c, d) == 0
 
 def test_dup_count_complex_roots_2():
     # (z-1)*(z)
-    assert dup_count_complex_roots([1,-1,0], ZZ, a, b) == 2
-    assert dup_count_complex_roots([1,-1,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0]), ZZ, c, d) == 2
 
     # (z-1)*(-z)
-    assert dup_count_complex_roots([-1,1,0], ZZ, a, b) == 2
-    assert dup_count_complex_roots([-1,1,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([-1, 1, 0]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([-1, 1, 0]), ZZ, c, d) == 2
 
     # (z+1)*(z)
-    assert dup_count_complex_roots([1,1,0], ZZ, a, b) == 2
-    assert dup_count_complex_roots([1,1,0], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0]), ZZ, c, d) == 1
 
     # (z+1)*(-z)
-    assert dup_count_complex_roots([-1,-1,0], ZZ, a, b) == 2
-    assert dup_count_complex_roots([-1,-1,0], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([-1, -1, 0]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([-1, -1, 0]), ZZ, c, d) == 1
 
 def test_dup_count_complex_roots_3():
     # (z-1)*(z+1)
-    assert dup_count_complex_roots([1,0,-1], ZZ, a, b) == 2
-    assert dup_count_complex_roots([1,0,-1], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1]), ZZ, c, d) == 1
 
     # (z-1)*(z+1)*(z)
-    assert dup_count_complex_roots([1,0,-1,0], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,0,-1,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1, 0]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1, 0]), ZZ, c, d) == 2
 
     # (z-1)*(z+1)*(-z)
-    assert dup_count_complex_roots([-1,0,1,0], ZZ, a, b) == 3
-    assert dup_count_complex_roots([-1,0,1,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([-1, 0, 1, 0]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([-1, 0, 1, 0]), ZZ, c, d) == 2
 
 def test_dup_count_complex_roots_4():
     # (z-I)*(z+I)
-    assert dup_count_complex_roots([1,0,1], ZZ, a, b) == 2
-    assert dup_count_complex_roots([1,0,1], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 0, 1]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 0, 1]), ZZ, c, d) == 1
 
     # (z-I)*(z+I)*(z)
-    assert dup_count_complex_roots([1,0,1,0], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,0,1,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 0, 1, 0]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 0, 1, 0]), ZZ, c, d) == 2
 
     # (z-I)*(z+I)*(-z)
-    assert dup_count_complex_roots([-1,0,-1,0], ZZ, a, b) == 3
-    assert dup_count_complex_roots([-1,0,-1,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([-1, 0, -1, 0]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([-1, 0, -1, 0]), ZZ, c, d) == 2
 
     # (z-I)*(z+I)*(z-1)
-    assert dup_count_complex_roots([1,-1,1,-1], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,-1,1,-1], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -1, 1, -1]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -1, 1, -1]), ZZ, c, d) == 2
 
     # (z-I)*(z+I)*(z-1)*(z)
-    assert dup_count_complex_roots([1,-1,1,-1,0], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,-1,1,-1,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -1, 1, -1, 0]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, -1, 1, -1, 0]), ZZ, c, d) == 3
 
     # (z-I)*(z+I)*(z-1)*(-z)
-    assert dup_count_complex_roots([-1,1,-1,1,0], ZZ, a, b) == 4
-    assert dup_count_complex_roots([-1,1,-1,1,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([-1, 1, -1, 1, 0]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([-1, 1, -1, 1, 0]), ZZ, c, d) == 3
 
     # (z-I)*(z+I)*(z-1)*(z+1)
-    assert dup_count_complex_roots([1,0,0,0,-1], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,0,0,0,-1], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, -1]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, -1]), ZZ, c, d) == 2
 
     # (z-I)*(z+I)*(z-1)*(z+1)*(z)
-    assert dup_count_complex_roots([1,0,0,0,-1,0], ZZ, a, b) == 5
-    assert dup_count_complex_roots([1,0,0,0,-1,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, -1, 0]), ZZ, a, b) == 5
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, -1, 0]), ZZ, c, d) == 3
 
     # (z-I)*(z+I)*(z-1)*(z+1)*(-z)
-    assert dup_count_complex_roots([-1,0,0,0,1,0], ZZ, a, b) == 5
-    assert dup_count_complex_roots([-1,0,0,0,1,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([-1, 0, 0, 0, 1, 0]), ZZ, a, b) == 5
+    assert dup_count_complex_roots(ZZ.map([-1, 0, 0, 0, 1, 0]), ZZ, c, d) == 3
 
 def test_dup_count_complex_roots_5():
     # (z-I+1)*(z+I+1)
-    assert dup_count_complex_roots([1,2,2], ZZ, a, b) == 2
-    assert dup_count_complex_roots([1,2,2], ZZ, c, d) == 0
+    assert dup_count_complex_roots(ZZ.map([1, 2, 2]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 2, 2]), ZZ, c, d) == 0
 
     # (z-I+1)*(z+I+1)*(z-1)
-    assert dup_count_complex_roots([1,1,0,-2], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,1,0,-2], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, -2]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, -2]), ZZ, c, d) == 1
 
     # (z-I+1)*(z+I+1)*(z-1)*z
-    assert dup_count_complex_roots([1,1,0,-2,0], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,1,0,-2,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, -2, 0]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, -2, 0]), ZZ, c, d) == 2
 
     # (z-I+1)*(z+I+1)*(z+1)
-    assert dup_count_complex_roots([1,3,4,2], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,3,4,2], ZZ, c, d) == 0
+    assert dup_count_complex_roots(ZZ.map([1, 3, 4, 2]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 3, 4, 2]), ZZ, c, d) == 0
 
     # (z-I+1)*(z+I+1)*(z+1)*z
-    assert dup_count_complex_roots([1,3,4,2,0], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,3,4,2,0], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 3, 4, 2, 0]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 3, 4, 2, 0]), ZZ, c, d) == 1
 
     # (z-I+1)*(z+I+1)*(z-1)*(z+1)
-    assert dup_count_complex_roots([1,2,1,-2,-2], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,2,1,-2,-2], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 2, 1, -2, -2]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 2, 1, -2, -2]), ZZ, c, d) == 1
 
     # (z-I+1)*(z+I+1)*(z-1)*(z+1)*z
-    assert dup_count_complex_roots([1,2,1,-2,-2,0], ZZ, a, b) == 5
-    assert dup_count_complex_roots([1,2,1,-2,-2,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 2, 1, -2, -2, 0]), ZZ, a, b) == 5
+    assert dup_count_complex_roots(ZZ.map([1, 2, 1, -2, -2, 0]), ZZ, c, d) == 2
 
 def test_dup_count_complex_roots_6():
     # (z-I-1)*(z+I-1)
-    assert dup_count_complex_roots([1,-2,2], ZZ, a, b) == 2
-    assert dup_count_complex_roots([1,-2,2], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, -2, 2]), ZZ, a, b) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -2, 2]), ZZ, c, d) == 1
 
     # (z-I-1)*(z+I-1)*(z-1)
-    assert dup_count_complex_roots([1,-3,4,-2], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,-3,4,-2], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -3, 4, -2]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -3, 4, -2]), ZZ, c, d) == 2
 
     # (z-I-1)*(z+I-1)*(z-1)*z
-    assert dup_count_complex_roots([1,-3,4,-2,0], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,-3,4,-2,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -3, 4, -2, 0]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, -3, 4, -2, 0]), ZZ, c, d) == 3
 
     # (z-I-1)*(z+I-1)*(z+1)
-    assert dup_count_complex_roots([1,-1,0,2], ZZ, a, b) == 3
-    assert dup_count_complex_roots([1,-1,0,2], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 2]), ZZ, a, b) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 2]), ZZ, c, d) == 1
 
     # (z-I-1)*(z+I-1)*(z+1)*z
-    assert dup_count_complex_roots([1,-1,0,2,0], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,-1,0,2,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 2, 0]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 2, 0]), ZZ, c, d) == 2
 
     # (z-I-1)*(z+I-1)*(z-1)*(z+1)
-    assert dup_count_complex_roots([1,-2,1,2,-2], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,-2,1,2,-2], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -2, 1, 2, -2]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, -2, 1, 2, -2]), ZZ, c, d) == 2
 
     # (z-I-1)*(z+I-1)*(z-1)*(z+1)*z
-    assert dup_count_complex_roots([1,-2,1,2,-2,0], ZZ, a, b) == 5
-    assert dup_count_complex_roots([1,-2,1,2,-2,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -2, 1, 2, -2, 0]), ZZ, a, b) == 5
+    assert dup_count_complex_roots(ZZ.map([1, -2, 1, 2, -2, 0]), ZZ, c, d) == 3
 
 def test_dup_count_complex_roots_7():
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)
-    assert dup_count_complex_roots([1,0,0,0,4], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,0,0,0,4], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, 4]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, 4]), ZZ, c, d) == 1
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-2)
-    assert dup_count_complex_roots([1,-2,0,0,4,-8], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,-2,0,0,4,-8], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, -2, 0, 0, 4, -8]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, -2, 0, 0, 4, -8]), ZZ, c, d) == 1
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z**2-2)
-    assert dup_count_complex_roots([1,0,-2,0,4,0,-8], ZZ, a, b) == 4
-    assert dup_count_complex_roots([1,0,-2,0,4,0,-8], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 0, -2, 0, 4, 0, -8]), ZZ, a, b) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 0, -2, 0, 4, 0, -8]), ZZ, c, d) == 1
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)
-    assert dup_count_complex_roots([1,-1,0,0,4,-4], ZZ, a, b) == 5
-    assert dup_count_complex_roots([1,-1,0,0,4,-4], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 0, 4, -4]), ZZ, a, b) == 5
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 0, 4, -4]), ZZ, c, d) == 2
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)*z
-    assert dup_count_complex_roots([1,-1,0,0,4,-4,0], ZZ, a, b) == 6
-    assert dup_count_complex_roots([1,-1,0,0,4,-4,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 0, 4, -4, 0]), ZZ, a, b) == 6
+    assert dup_count_complex_roots(ZZ.map([1, -1, 0, 0, 4, -4, 0]), ZZ, c, d) == 3
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z+1)
-    assert dup_count_complex_roots([1,1,0,0,4,4], ZZ, a, b) == 5
-    assert dup_count_complex_roots([1,1,0,0,4,4], ZZ, c, d) == 1
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, 0, 4, 4]), ZZ, a, b) == 5
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, 0, 4, 4]), ZZ, c, d) == 1
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z+1)*z
-    assert dup_count_complex_roots([1,1,0,0,4,4,0], ZZ, a, b) == 6
-    assert dup_count_complex_roots([1,1,0,0,4,4,0], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, 0, 4, 4, 0]), ZZ, a, b) == 6
+    assert dup_count_complex_roots(ZZ.map([1, 1, 0, 0, 4, 4, 0]), ZZ, c, d) == 2
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)*(z+1)
-    assert dup_count_complex_roots([1,0,-1,0,4,0,-4], ZZ, a, b) == 6
-    assert dup_count_complex_roots([1,0,-1,0,4,0,-4], ZZ, c, d) == 2
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1, 0, 4, 0, -4]), ZZ, a, b) == 6
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1, 0, 4, 0, -4]), ZZ, c, d) == 2
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)*(z+1)*z
-    assert dup_count_complex_roots([1,0,-1,0,4,0,-4,0], ZZ, a, b) == 7
-    assert dup_count_complex_roots([1,0,-1,0,4,0,-4,0], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1, 0, 4, 0, -4, 0]), ZZ, a, b) == 7
+    assert dup_count_complex_roots(ZZ.map([1, 0, -1, 0, 4, 0, -4, 0]), ZZ, c, d) == 3
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)*(z+1)*(z-I)*(z+I)
-    assert dup_count_complex_roots([1,0,0,0,3,0,0,0,-4], ZZ, a, b) == 8
-    assert dup_count_complex_roots([1,0,0,0,3,0,0,0,-4], ZZ, c, d) == 3
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, 3, 0, 0, 0, -4]), ZZ, a, b) == 8
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, 3, 0, 0, 0, -4]), ZZ, c, d) == 3
 
 def test_dup_count_complex_roots_8():
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)*(z+1)*(z-I)*(z+I)*z
-    assert dup_count_complex_roots([1,0,0,0,3,0,0,0,-4,0], ZZ, a, b) == 9
-    assert dup_count_complex_roots([1,0,0,0,3,0,0,0,-4,0], ZZ, c, d) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, 3, 0, 0, 0, -4, 0]), ZZ, a, b) == 9
+    assert dup_count_complex_roots(ZZ.map([1, 0, 0, 0, 3, 0, 0, 0, -4, 0]), ZZ, c, d) == 4
 
     # (z-I-1)*(z+I-1)*(z-I+1)*(z+I+1)*(z-1)*(z+1)*(z-I)*(z+I)*(z**2-2)*z
-    assert dup_count_complex_roots([1,0,-2,0,3,0,-6,0,-4,0,8,0], ZZ, a, b) == 9
-    assert dup_count_complex_roots([1,0,-2,0,3,0,-6,0,-4,0,8,0], ZZ, c, d) == 4
+    assert dup_count_complex_roots(ZZ.map([1, 0, -2, 0, 3, 0, -6, 0, -4, 0, 8, 0]), ZZ, a, b) == 9
+    assert dup_count_complex_roots(ZZ.map([1, 0, -2, 0, 3, 0, -6, 0, -4, 0, 8, 0]), ZZ, c, d) == 4
 
 def test_dup_count_complex_roots_implicit():
-    f = [1,0,0,0,-1,0] # z*(z-1)*(z+1)*(z-I)*(z+I)
+    f = ZZ.map([1, 0, 0, 0, -1, 0])  # z*(z-1)*(z+1)*(z-I)*(z+I)
 
     assert dup_count_complex_roots(f, ZZ) == 5
 
@@ -617,7 +617,7 @@ def test_dup_count_complex_roots_implicit():
     assert dup_count_complex_roots(f, ZZ, inf=(0, 0)) == 3
 
 def test_dup_count_complex_roots_exclude():
-    f = [1,0,0,0,-1,0] # z*(z-1)*(z+1)*(z-I)*(z+I)
+    f = ZZ.map([1, 0, 0, 0, -1, 0])  # z*(z-1)*(z+1)*(z-I)*(z+I)
 
     a, b = (-QQ(1), QQ(0)), (QQ(1), QQ(1))
 
@@ -647,7 +647,7 @@ def test_dup_count_complex_roots_exclude():
     assert dup_count_complex_roots(f, ZZ, a, b, exclude=True) == 1
 
 def test_dup_isolate_complex_roots_sqf():
-    f = [1, -2, 3]
+    f = ZZ.map([1, -2, 3])
 
     assert dup_isolate_complex_roots_sqf(f, ZZ) == \
         [((0, -6), (6, 0)), ((0, 0), (6, 6))]
@@ -659,13 +659,13 @@ def test_dup_isolate_complex_roots_sqf():
     assert dup_isolate_complex_roots_sqf(f, ZZ, eps=QQ(1,100)) == \
         [((QQ(255,256), -QQ(363,256)), (QQ(513,512), -QQ(723,512))), ((QQ(255,256), QQ(723,512)), (QQ(513,512), QQ(363,256)))]
 
-    f = [7, -19, 20, 17, 20]
+    f = ZZ.map([7, -19, 20, 17, 20])
 
     assert dup_isolate_complex_roots_sqf(f, ZZ) == \
         [((-QQ(40,7), -QQ(40,7)), (0, 0)), ((-QQ(40,7), 0), (0, QQ(40,7))), ((0, -QQ(40,7)), (QQ(40,7), 0)), ((0, 0), (QQ(40,7), QQ(40,7)))]
 
 def test_dup_isolate_all_roots_sqf():
-    f = [4, -1, 2, 5, 0]
+    f = ZZ.map([4, -1, 2, 5, 0])
 
     assert dup_isolate_all_roots_sqf(f, ZZ) == \
         ([(-1, 0), (0, 0)], [((0, -QQ(5,2)), (QQ(5,2), 0)), ((0, 0), (QQ(5,2), QQ(5,2)))])


### PR DESCRIPTION
With these changes, tests pass with the sympy ground types. Although we might want to remove sympy ground types eventually, Aaron pointed out that the mapping `ZZ(int)` should be used instead of `int` inside polys. Indeed, testing with -t sympy revealed potential bugs. After the changes, all tests pass with -t sympy, and the doctest failures with -t sympy are limited to difference in printing "0" versus "0/1", "1" versus "1/1", and so on.
