### PR TITLE
Simplify

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -3,6 +3,7 @@ from sympy.core.basic import Basic
 from sympy.core.singleton import S
 from sympy.core.decorators import _sympifyit, call_highest_priority
 from sympy.matrices import ShapeError
+from sympy.simplify import simplify
 
 class MatrixExpr(Basic):
     """ Matrix Expression Class
@@ -112,6 +113,12 @@ class MatrixExpr(Basic):
 
     def _eval_inverse(self):
         raise NotImplementedError()
+
+    def _eval_simplify(self, **kwargs):
+        if self.is_Atom:
+            return self
+        else:
+            return self.__class__(*[simplify(x, **kwargs) for x in self.args])
 
     def _entry(self, i, j):
         raise NotImplementedError(

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -120,6 +120,9 @@ class MatrixExpr(Basic):
         else:
             return self.__class__(*[simplify(x, **kwargs) for x in self.args])
 
+    def _eval_adjoint(self):
+        return self.T.conjugate()
+
     def _entry(self, i, j):
         raise NotImplementedError(
             "Indexing not implemented for %s" % self.__class__.__name__)

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,5 +1,5 @@
 from sympy.utilities.pytest import raises
-from sympy import S, symbols, Symbol, Tuple, Mul, Lambda
+from sympy import S, symbols, Symbol, Tuple, Mul, Lambda, simplify, sin, cos
 from sympy.matrices import (eye, MatrixSymbol, Transpose, Inverse, ShapeError,
         MatMul, Identity, BlockMatrix, BlockDiagMatrix, block_collapse, Matrix,
         ZeroMatrix, MatAdd, MatPow, ImmutableMatrix, Trace,
@@ -322,3 +322,14 @@ def test_free_symbols():
 
 def test_zero_matmul():
     assert isinstance(S.Zero * MatrixSymbol('X', 2, 2), MatrixExpr)
+
+x = Symbol('x')
+def test_matadd_simplify():
+    A = MatrixSymbol('A', 1, 1)
+    assert simplify(MatAdd(A, ImmutableMatrix([[sin(x)**2 + cos(x)**2]]))) ==\
+                    MatAdd(A, ImmutableMatrix([[1]]))
+
+def test_matmul_simplify():
+    A = MatrixSymbol('A', 1, 1)
+    assert simplify(MatMul(A, ImmutableMatrix([[sin(x)**2 + cos(x)**2]]))) ==\
+                    MatMul(A, ImmutableMatrix([[1]]))

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -81,8 +81,6 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     __div__ = MatrixBase.__div__
     __truediv__ = MatrixBase.__truediv__
 
-    _eval_simplify = DenseMatrix.simplify
-
 class ImmutableSparseMatrix(Basic, SparseMatrix):
     """Create an immutable version of a sparse matrix.
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -66,6 +66,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     _eval_transpose = DenseMatrix._eval_transpose
     _eval_conjugate = DenseMatrix._eval_conjugate
     _eval_inverse = DenseMatrix._eval_inverse
+    _eval_simplify = DenseMatrix._eval_simplify
 
     equals = DenseMatrix.equals
     is_Identity = DenseMatrix.is_Identity

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -82,6 +82,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     __div__ = MatrixBase.__div__
     __truediv__ = MatrixBase.__truediv__
 
+
 class ImmutableSparseMatrix(Basic, SparseMatrix):
     """Create an immutable version of a sparse matrix.
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -81,7 +81,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     __div__ = MatrixBase.__div__
     __truediv__ = MatrixBase.__truediv__
 
-    _simplify = DenseMatrix.simplify
+    _eval_simplify = DenseMatrix.simplify
 
 class ImmutableSparseMatrix(Basic, SparseMatrix):
     """Create an immutable version of a sparse matrix.

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -81,6 +81,7 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     __div__ = MatrixBase.__div__
     __truediv__ = MatrixBase.__truediv__
 
+    _simplify = DenseMatrix.simplify
 
 class ImmutableSparseMatrix(Basic, SparseMatrix):
     """Create an immutable version of a sparse matrix.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1040,6 +1040,7 @@ class MatrixBase(object):
         [x]
         """
         return self.applyfunc(lambda x: x.simplify(ratio, measure))
+    _eval_simplify = simplify
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -85,4 +85,9 @@ def test_immutable_evaluation():
     assert isinstance(X * A, ImmutableMatrix)
     assert isinstance(X * 2, ImmutableMatrix)
     assert isinstance(2 * X, ImmutableMatrix)
-    assert isinstance(A**2, ImmutableMatrix)
+    assert isinstance(A**2,  ImmutableMatrix)
+
+def test_simplify():
+    from sympy import simplify, sin, cos
+    assert simplify(ImmutableMatrix([[sin(x)**2 + cos(x)**2]])) == \
+                    ImmutableMatrix([[1]])

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -86,8 +86,3 @@ def test_immutable_evaluation():
     assert isinstance(X * 2, ImmutableMatrix)
     assert isinstance(2 * X, ImmutableMatrix)
     assert isinstance(A**2,  ImmutableMatrix)
-
-def test_simplify():
-    from sympy import simplify, sin, cos
-    assert simplify(ImmutableMatrix([[sin(x)**2 + cos(x)**2]])) == \
-                    ImmutableMatrix([[1]])

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -85,4 +85,4 @@ def test_immutable_evaluation():
     assert isinstance(X * A, ImmutableMatrix)
     assert isinstance(X * 2, ImmutableMatrix)
     assert isinstance(2 * X, ImmutableMatrix)
-    assert isinstance(A**2,  ImmutableMatrix)
+    assert isinstance(A**2, ImmutableMatrix)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2112,3 +2112,8 @@ def test_adjoint():
     ans = Matrix([[0, 1], [-I, 0]])
     for cls in classes:
         assert ans == cls(dat).adjoint()
+
+def test_simplify():
+    from sympy import simplify, sin, cos
+    assert simplify(ImmutableMatrix([[sin(x)**2 + cos(x)**2]])) == \
+                    ImmutableMatrix([[1]])

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2972,7 +2972,7 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     """
 
     try:
-        return expr._simplify(ratio=ratio, measure=measure)
+        return expr._eval_simplify(ratio=ratio, measure=measure)
     except AttributeError:
         pass
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2970,6 +2970,12 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     function, we get a completely different result that is still different
     from the input expression by doing this.
     """
+
+    try:
+        return expr._simplify(ratio=ratio, measure=measure)
+    except AttributeError:
+        pass
+
     from sympy.simplify.hyperexpand import hyperexpand
     from sympy.functions.special.bessel import BesselBase
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1419,7 +1419,7 @@ def test_Piecewise():
 
 def test_polymorphism():
     class A(Basic):
-        def _simplify(x, **kwargs):
+        def _eval_simplify(x, **kwargs):
             return 1
 
     a = A(5, 2)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -7,7 +7,7 @@ from sympy import (
     Piecewise, polar_lift, polarify, posify, powdenest, powsimp, radsimp,
     Rational, ratsimp, ratsimpmodprime, rcollect, RisingFactorial, S,
     separatevars, signsimp, simplify, sin, sinh, solve, sqrt, Subs, Symbol,
-    symbols, sympify, tan, tanh, trigsimp, Wild)
+    symbols, sympify, tan, tanh, trigsimp, Wild, Basic)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import fraction_expand
 from sympy.utilities.pytest import XFAIL
@@ -1416,3 +1416,11 @@ def test_Piecewise():
     s3 = simplify(e3)
     assert simplify(Piecewise((e1, x < e2), (e3, True))) == \
         Piecewise((s1, x < s2), (s3, True))
+
+def test_polymorphism():
+    class A(Basic):
+        def _simplify(x, **kwargs):
+            return 1
+
+    a = A(5, 2)
+    assert simplify(a) == 1


### PR DESCRIPTION
This PR adds the following lines to the simplify function to make classes determine how they are simplified. This moves the meaning of simplify away from just Exprs to potentially work on any Basic.

```
    try:
        return expr._eval_simplify(ratio=ratio, measure=measure)
    except AttributeError:
        pass
```

This PR also gives such an `_eval_simplify` method to matrices.

This is on top of PR #1560
