### PR TITLE
3451: robustify kern handling in parse_expr

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,6 +1,6 @@
 from __future__ import with_statement
 from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
-    Function, I, S, sqrt, srepr, Rational, Tuple
+    Function, I, S, sqrt, srepr, Rational, Tuple, Matrix
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError
 from sympy.core.decorators import _sympifyit
@@ -447,6 +447,8 @@ def test_no_autosimplify_into_Mul():
     assert ss != 1 and ss.simplify() == -1
 
 
-def test_issue_3441():
+def test_issue_3441_3453():
     assert S('[[1/3,2], (2/5,)]') == [[Rational(1, 3), 2], (Rational(2, 5),)]
     assert S('[[2/6,2], (2/4,)]') == [[Rational(1, 3), 2], (Rational(1, 2),)]
+    assert S('[[[2*(1)]]]') == [[[2]]]
+    assert S('Matrix([2*(1)])') == Matrix([2])

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -176,9 +176,12 @@ def parse_expr(s, local_dict=None, rationalize=False, convert_xor=False):
     if not hit:
         return expr
     rep = {C.Symbol(kern): 1}
-    try:
-        return expr.xreplace(rep)
-    except (TypeError, AttributeError):
-        if isinstance(expr, (list, tuple, set)):
-            return type(expr)([e.xreplace(rep) for e in expr])
+    def _clear(expr):
+        if hasattr(expr, 'xreplace'):
+            return expr.xreplace(rep)
+        elif isinstance(expr, (list, tuple, set)):
+            return type(expr)([_clear(e) for e in expr])
+        if hasattr(expr, 'subs'):
+            return expr.subs(rep)
         return expr
+    return _clear(expr)


### PR DESCRIPTION
Hopefully this totally eliminates the appearance of the kern introduced while parsing expression that have a number mutliplying something in parentheses.
