### PR TITLE
3455: Not(0)->True, Not(1)->False, else Not(arg)

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -153,9 +153,7 @@ class Not(BooleanFunction):
         if len(args) > 1:
             return map(cls, args)
         arg = args[0]
-        if type(arg) is bool:
-            return not arg
-        if arg in (0, 1):
+        if arg in (0, 1):  # includes True and False, too
             return not bool(arg)
         # apply De Morgan Rules
         if arg.func is And:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -155,6 +155,8 @@ class Not(BooleanFunction):
         arg = args[0]
         if type(arg) is bool:
             return not arg
+        if arg in (0, 1):
+            return not bool(arg)
         # apply De Morgan Rules
         if arg.func is And:
             return Or(*[Not(a) for a in arg.args])

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -74,6 +74,9 @@ def test_Not():
     assert Not(True, True ) == [False, False]
     assert Not(True, False) == [False, True ]
     assert Not(False, False) == [True, True ]
+    assert Not(0) is True
+    assert Not(1) is False
+    assert Not(2).func is Not
 
 
 def test_Nand():


### PR DESCRIPTION
In keeping with Or(2, x) == Or(2) and Or(1, x) == True,
Not() now evaluates 0 and 1 to True and False, respectively.
