### PR TITLE
Fixed Particle docstring to reflect correct order of __init__() args.

### DIFF
--- a/sympy/physics/mechanics/particle.py
+++ b/sympy/physics/mechanics/particle.py
@@ -16,11 +16,11 @@ class Particle(object):
     ==========
     name : str
         Name of particle
-    mass : sympifyable
-        A SymPy expression representing the Particle's mass
     point : Point
         A physics/mechanics Point which represents the position, velocity, and
         acceleration of this Particle
+    mass : sympifyable
+        A SymPy expression representing the Particle's mass
 
     Examples
     ========


### PR DESCRIPTION
The particle docstring had the order of the last two **init** arguments switched.  This simple patch fixes the docstring to match the API.
