### PR TITLE
PR1599: fix error in powersimp

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3310,7 +3310,8 @@ def _logcombine(expr, force=False):
                     argslist *= _logcombine(i.args[0], force)
                 else:
                     notlogs += i
-            elif i.is_Mul and any(map(lambda t: getattr(t, 'func', False) == log,
+            elif i.is_Mul and any(
+                map(lambda t: getattr(t, 'func', False) == log,
             i.args)):
                 largs = _getlogargs(i)
                 assert len(largs) != 0

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2248,6 +2248,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             bases = c_exp[e]
 
             # calculate the new base for e
+
             if len(bases) == 1:
                 new_base = bases[0]
             elif e.is_integer or force:
@@ -2272,10 +2273,14 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                     nonneg.extend(unk + neg)
                     unk = neg = []
                 elif neg:
-                    # their negative signs cancel in pairs
-                    neg = [-w for w in neg]
-                    if len(neg) % 2:
-                        unk.append(S.NegativeOne)
+                    # their negative signs cancel in groups of 2*q if we know
+                    # that e = p/q else we have to treat them as unknown
+                    if e.is_Rational:
+                        neg = [-w for w in neg]
+                        unk.extend([S.NegativeOne]*(len(neg) % (2*e.q)))
+                    else:
+                        unk.extend(neg)
+                        neg = []
 
                 # these shouldn't be joined
                 for b in unk:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -316,7 +316,7 @@ def test_simplify():
 
     assert simplify(solutions[y]) == \
         (a*i + c*d + f*g - a*f - c*g - d*i)/ \
-        (a*e*i + b*f*g + c*d*h - a*f*h - b*d*i - c*e*g))
+        (a*e*i + b*f*g + c*d*h - a*f*h - b*d*i - c*e*g)
 
     f = -x + y/(z + t) + z*x/(z + t) + z*a/(z + t) + t*x/(z + t)
 
@@ -442,6 +442,7 @@ def test_powsimp():
     x, y, z, n = symbols('x,y,z,n')
     f = Function('f')
     assert powsimp( 4**x * 2**(-x) * 2**(-x) ) == 1
+    assert powsimp( (-4)**x * (-2)**(-x) * 2**(-x) ) == 1
 
     assert powsimp(
         f(4**x * 2**(-x) * 2**(-x)) ) == f(4**x * 2**(-x) * 2**(-x))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -5,7 +5,7 @@ from sympy import (
     Function, gamma, GoldenRatio, hyper, hyper, hypersimp, I, Integer,
     Integral, integrate, log, logcombine, Matrix, Mul, nsimplify, O, oo, pi,
     Piecewise, polar_lift, polarify, posify, powdenest, powsimp, radsimp,
-    Rational, ratsimp, ratsimpmodprime, rcollect, RisingFactorial, S,
+    Rational, ratsimp, ratsimpmodprime, rcollect, RisingFactorial, root, S,
     separatevars, signsimp, simplify, sin, sinh, solve, sqrt, Subs, Symbol,
     symbols, sympify, tan, tanh, trigsimp, Wild, Basic)
 from sympy.core.mul import _keep_coeff
@@ -439,7 +439,6 @@ def test_powsimp():
     x, y, z, n = symbols('x,y,z,n')
     f = Function('f')
     assert powsimp( 4**x * 2**(-x) * 2**(-x) ) == 1
-    assert powsimp( (-4)**x * (-2)**(-x) * 2**(-x) ) == 1
 
     assert powsimp(
         f(4**x * 2**(-x) * 2**(-x)) ) == f(4**x * 2**(-x) * 2**(-x))
@@ -1422,6 +1421,7 @@ def test_Piecewise():
     assert simplify(Piecewise((e1, x < e2), (e3, True))) == \
         Piecewise((s1, x < s2), (s3, True))
 
+
 def test_polymorphism():
     class A(Basic):
         def _eval_simplify(x, **kwargs):
@@ -1429,3 +1429,13 @@ def test_polymorphism():
 
     a = A(5, 2)
     assert simplify(a) == 1
+
+
+def test_issue_from_PR1599():
+    n1, n2, n3, n4 = symbols('n1 n2 n3 n4', negative=True)
+    assert simplify(I*sqrt(n1)) == I*sqrt(n1)
+    assert (powsimp(sqrt(n1)*sqrt(n2)*sqrt(n3)) ==
+        -I*sqrt(-n1)*sqrt(-n2)*sqrt(-n3))
+    assert (powsimp(root(n1, 3)*root(n2, 3)*root(n3, 3)*root(n4, 3)) ==
+        -(-1)**(S(1)/3)*
+        (-n1)**(S(1)/3)*(-n2)**(S(1)/3)*(-n3)**(S(1)/3)*(-n4)**(S(1)/3))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -350,11 +350,13 @@ def test_simplify_other():
     # issue 3271
     assert simplify(2**(2 + x)/4) == 2**x
 
+
 def test_simplify_complex():
     cosAsExp = cos(x)._eval_rewrite_as_exp(x)
     tanAsExp = tan(x)._eval_rewrite_as_exp(x)
     assert simplify(cosAsExp*tanAsExp).expand() == (
         sin(x))._eval_rewrite_as_exp(x).expand()  # issue 1242
+
 
 def test_simplify_ratio():
     # roots of x**3-3*x+5

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -315,7 +315,8 @@ def test_simplify():
     solutions = solve([f_1, f_2, f_3], x, y, z, simplify=False)
 
     assert simplify(solutions[y]) == \
-        (a*i + c*d + f*g - a*f - c*g - d*i)/(a*e*i + b*f*g + c*d*h - a*f*h - b*d*i - c*e*g)
+        (a*i + c*d + f*g - a*f - c*g - d*i)/(a*e*i + b*f*g + c*d*
+         h - a*f*h - b*d*i - c*e*g)
 
     f = -x + y/(z + t) + z*x/(z + t) + z*a/(z + t) + t*x/(z + t)
 
@@ -448,7 +449,8 @@ def test_powsimp():
     assert exp(x)*exp(y) == exp(x)*exp(y)
     assert powsimp(exp(x)*exp(y)) == exp(x + y)
     assert powsimp(exp(x)*exp(y)*2**x*2**y) == (2*E)**(x + y)
-    assert powsimp(exp(x)*exp(y)*2**x*2**y, combine='exp') == exp(x + y)*2**(x + y)
+    assert powsimp(
+        exp(x)*exp(y)*2**x*2**y, combine='exp') == exp(x + y)*2**(x + y)
     assert powsimp(exp(x)*exp(y)*exp(2)*sin(x) + sin(y) + 2**x*2**y) == \
         exp(2 + x + y)*sin(x) + sin(y) + 2**(x + y)
     assert powsimp(sin(exp(x)*exp(y))) == sin(exp(x)*exp(y))
@@ -942,7 +944,8 @@ def test_logcombine_complex_coeff():
     # these hold.
     assert logcombine(Integral((sin(x**2) + cos(x**3))/x, x), force=True) == \
         Integral((sin(x**2) + cos(x**3))/x, x)
-    assert logcombine(Integral((sin(x**2) + cos(x**3))/x, x) + (2 + 3*I)*log(x),
+    assert logcombine(
+        Integral((sin(x**2) + cos(x**3))/x, x) + (2 + 3*I)*log(x),
         force=True) == log(x**2) + 3*I*log(x) + \
         Integral((sin(x**2) + cos(x**3))/x, x)
 
@@ -1285,14 +1288,16 @@ def test_combsimp_gamma():
     assert combsimp(gamma(x + y)*(x + y)) == gamma(x + y + 1)
     assert combsimp(x/gamma(x + 1)) == 1/gamma(x)
     assert combsimp((x + 1)**2/gamma(x + 2)) == (x + 1)/gamma(x + 1)
-    assert combsimp(x*gamma(x) + gamma(x + 3)/(x + 2)) == gamma(x + 1) + gamma(x + 2)
+    assert combsimp(
+        x*gamma(x) + gamma(x + 3)/(x + 2)) == gamma(x + 1) + gamma(x + 2)
 
     assert combsimp(gamma(2*x)*x) == gamma(2*x + 1)/2
     assert combsimp(gamma(2*x)/(x - S(1)/2)) == 2*gamma(2*x - 1)
 
     assert combsimp(gamma(x)*gamma(1 - x)) == pi/sin(pi*x)
     assert combsimp(gamma(x)*gamma(-x)) == -pi/(x*sin(pi*x))
-    assert combsimp(1/gamma(x + 3)/gamma(1 - x)) == sin(pi*x)/(pi*x*(x + 1)*(x + 2))
+    assert combsimp(
+        1/gamma(x + 3)/gamma(1 - x)) == sin(pi*x)/(pi*x*(x + 1)*(x + 2))
 
     assert simplify(combsimp(
         gamma(x)*gamma(x + S(1)/2)*gamma(y)/gamma(x + y))) == \

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -315,8 +315,8 @@ def test_simplify():
     solutions = solve([f_1, f_2, f_3], x, y, z, simplify=False)
 
     assert simplify(solutions[y]) == \
-        (a*i + c*d + f*g - a*f - c*g - d*i)/(a*e*i + b*f*g + c*d*
-         h - a*f*h - b*d*i - c*e*g)
+        (a*i + c*d + f*g - a*f - c*g - d*i)/ \
+        (a*e*i + b*f*g + c*d*h - a*f*h - b*d*i - c*e*g))
 
     f = -x + y/(z + t) + z*x/(z + t) + z*a/(z + t) + t*x/(z + t)
 
@@ -449,8 +449,8 @@ def test_powsimp():
     assert exp(x)*exp(y) == exp(x)*exp(y)
     assert powsimp(exp(x)*exp(y)) == exp(x + y)
     assert powsimp(exp(x)*exp(y)*2**x*2**y) == (2*E)**(x + y)
-    assert powsimp(
-        exp(x)*exp(y)*2**x*2**y, combine='exp') == exp(x + y)*2**(x + y)
+    assert powsimp(exp(x)*exp(y)*2**x*2**y, combine='exp') == \
+        exp(x + y)*2**(x + y)
     assert powsimp(exp(x)*exp(y)*exp(2)*sin(x) + sin(y) + 2**x*2**y) == \
         exp(2 + x + y)*sin(x) + sin(y) + 2**(x + y)
     assert powsimp(sin(exp(x)*exp(y))) == sin(exp(x)*exp(y))
@@ -1288,16 +1288,16 @@ def test_combsimp_gamma():
     assert combsimp(gamma(x + y)*(x + y)) == gamma(x + y + 1)
     assert combsimp(x/gamma(x + 1)) == 1/gamma(x)
     assert combsimp((x + 1)**2/gamma(x + 2)) == (x + 1)/gamma(x + 1)
-    assert combsimp(
-        x*gamma(x) + gamma(x + 3)/(x + 2)) == gamma(x + 1) + gamma(x + 2)
+    assert combsimp(x*gamma(x) + gamma(x + 3)/(x + 2)) == \
+        gamma(x + 1) + gamma(x + 2)
 
     assert combsimp(gamma(2*x)*x) == gamma(2*x + 1)/2
     assert combsimp(gamma(2*x)/(x - S(1)/2)) == 2*gamma(2*x - 1)
 
     assert combsimp(gamma(x)*gamma(1 - x)) == pi/sin(pi*x)
     assert combsimp(gamma(x)*gamma(-x)) == -pi/(x*sin(pi*x))
-    assert combsimp(
-        1/gamma(x + 3)/gamma(1 - x)) == sin(pi*x)/(pi*x*(x + 1)*(x + 2))
+    assert combsimp(1/gamma(x + 3)/gamma(1 - x)) == \
+        sin(pi*x)/(pi*x*(x + 1)*(x + 2))
 
     assert simplify(combsimp(
         gamma(x)*gamma(x + S(1)/2)*gamma(y)/gamma(x + y))) == \

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -354,7 +354,7 @@ def test_simplify_complex():
     cosAsExp = cos(x)._eval_rewrite_as_exp(x)
     tanAsExp = tan(x)._eval_rewrite_as_exp(x)
     assert simplify(cosAsExp*tanAsExp).expand() == (
-        sin(x))._eval_rewrite_as_exp(x).expand() # issue 1242
+        sin(x))._eval_rewrite_as_exp(x).expand()  # issue 1242
 
 def test_simplify_ratio():
     # roots of x**3-3*x+5


### PR DESCRIPTION
An error in powersimp was identified by the work happening in #1599. Basically, negative bases were being combined improperly so that `powersimp(I*sqrt(neg)) -> sqrt(-neg)` instead of `-sqrt(-neg)`. I thought all the power-rule errors were solved before...I can humbly say for sure that there is only one less now once this is committed.

I consider this a high priority issue but have not opened a new issue since it would (quickly) just be reclosed when this is committed.
