### PR TITLE
Rules: Traversals stop on non-Basics

### DIFF
--- a/sympy/rules/tests/test_traverse.py
+++ b/sympy/rules/tests/test_traverse.py
@@ -3,9 +3,11 @@ from sympy import Basic, symbols, Symbol, S
 
 def test_bottom_up():
     _test_global_traversal(bottom_up)
+    _test_stop_on_non_basics(bottom_up)
 
 def test_top_down():
     _test_global_traversal(top_down)
+    _test_stop_on_non_basics(top_down)
 
 def _test_global_traversal(trav):
     zero_symbols = lambda x: S.Zero if isinstance(x, Symbol) else x
@@ -14,3 +16,14 @@ def _test_global_traversal(trav):
 
     assert zero_all_symbols(Basic(x, y, Basic(x, z))) == \
                             Basic(0, 0, Basic(0, 0))
+
+def _test_stop_on_non_basics(trav):
+    def add_one_if_can(expr):
+        try:    return expr + 1
+        except: return expr
+
+    expr     = Basic(1, 'a', Basic(2, 'b'))
+    expected = Basic(2, 'a', Basic(3, 'b'))
+    rl = trav(add_one_if_can)
+
+    assert rl(expr) == expected

--- a/sympy/rules/traverse.py
+++ b/sympy/rules/traverse.py
@@ -6,7 +6,7 @@ def top_down(rule):
     """ Apply a rule down an AST running it on the top nodes first """
     def top_down_rl(expr):
         newexpr = rule(expr)
-        if newexpr.is_Atom:
+        if not isinstance(newexpr, Basic) or newexpr.is_Atom:
             return newexpr
         return new(newexpr.__class__, *map(top_down_rl, newexpr.args))
     return top_down_rl
@@ -14,7 +14,7 @@ def top_down(rule):
 def bottom_up(rule):
     """ Apply a rule down an AST running it on the bottom nodes first """
     def bottom_up_rl(expr):
-        if expr.is_Atom:
+        if not isinstance(expr, Basic) or expr.is_Atom:
             return rule(expr)
         else:
             return rule(new(expr.__class__, *map(bottom_up_rl, expr.args)))


### PR DESCRIPTION
Traversals no longer fail when they encounter a non-basic in the tree

This allows ints, strings, and other standard python objects to be leaves in the expression tree. Notably this means that Basics can contain strings without fouling up the rules system.
