### PR TITLE
integrate(DiracDelta(y - x), x)

### DIFF
--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -107,8 +107,8 @@ class DiracDelta(Function):
             darg = diff(self.args[0], x)
             for r in argroots:
                 #should I care about multiplicities of roots?
-                if r.is_real and not darg.subs(x, r).is_zero:
-                    result = result + DiracDelta(x - r)/abs(darg.subs(x, r))
+                if r.is_real is not False and not darg.subs(x, r).is_zero:
+                    result += DiracDelta(x - r)/abs(darg.subs(x, r))
                 else:
                     valid = False
                     break

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -63,8 +63,6 @@ class DiracDelta(Function):
             return S.NaN
         if arg.is_positive or arg.is_negative:
             return S.Zero
-        elif arg.is_zero:
-            return S.Infinity
 
     def simplify(self, x):
         """simplify(self, x)

--- a/sympy/functions/special/tests/test_delta_functions.py
+++ b/sympy/functions/special/tests/test_delta_functions.py
@@ -17,10 +17,9 @@ def test_DiracDelta():
     assert DiracDelta(5.1) == 0
     assert DiracDelta(-pi) == 0
     assert DiracDelta(5, 7) == 0
-    assert DiracDelta(0) == oo
-    assert DiracDelta(0, 5) == oo
     assert DiracDelta(nan) == nan
-    assert DiracDelta(x).func == DiracDelta
+    assert DiracDelta(0).func is DiracDelta
+    assert DiracDelta(x).func is DiracDelta
 
     assert adjoint(DiracDelta(x)) == DiracDelta(x)
     assert adjoint(DiracDelta(x - y)) == DiracDelta(x - y)

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -1,4 +1,3 @@
-import sympy
 from sympy.functions import DiracDelta, Heaviside
 from sympy.solvers import solve
 from sympy.utilities.misc import default_sort_key
@@ -26,11 +25,11 @@ def change_mul(node, x):
        >>> from sympy import DiracDelta, cos
        >>> from sympy.integrals.deltafunctions import change_mul
        >>> from sympy.abc import x, y
-       >>> change_mul(x*y*DiracDelta(x)*cos(x),x)
+       >>> change_mul(x*y*DiracDelta(x)*cos(x), x)
        (DiracDelta(x), x*y*cos(x))
-       >>> change_mul(x*y*DiracDelta(x**2-1)*cos(x),x)
+       >>> change_mul(x*y*DiracDelta(x**2 - 1)*cos(x), x)
        (None, x*y*cos(x)*DiracDelta(x - 1)/2 + x*y*cos(x)*DiracDelta(x + 1)/2)
-       >>> change_mul(x*y*DiracDelta(cos(x))*cos(x),x)
+       >>> change_mul(x*y*DiracDelta(cos(x))*cos(x), x)
        (None, None)
 
        See Also
@@ -130,6 +129,9 @@ def deltaintegrate(f, x):
     """
     if not f.has(DiracDelta):
         return None
+
+    from sympy.integrals import Integral, integrate
+
     # g(x) = DiracDelta(h(x))
     if f.func == DiracDelta:
         h = f.simplify(x)
@@ -140,22 +142,24 @@ def deltaintegrate(f, x):
                 if (len(f.args) <= 1 or f.args[1] == 0):
                     return Heaviside(f.args[0])
                 else:
-                    return (DiracDelta(f.args[0], f.args[1] - 1)/ f.args[0].as_poly().LC())
+                    return (DiracDelta(f.args[0], f.args[1] - 1) /
+                        f.args[0].as_poly().LC())
         else:  # let's try to integrate the simplified expression
-            fh = sympy.integrals.integrate(h, x)
+            fh = integrate(h, x)
             return fh
-    elif f.is_Mul:  # g(x)=a*b*c*f(DiracDelta(h(x)))*d*e
+    elif f.is_Mul:  # g(x) = a*b*c*f(DiracDelta(h(x)))*d*e
         g = f.expand()
         if f != g:  # the expansion worked
-            fh = sympy.integrals.integrate(g, x)
-            if fh and not isinstance(fh, sympy.integrals.Integral):
+            fh = integrate(g, x)
+            if fh and not isinstance(fh, Integral):
                 return fh
-        else:  # no expansion performed, try to extract a simple DiracDelta term
+        else:
+            # no expansion performed, try to extract a simple DiracDelta term
             dg, rest_mult = change_mul(f, x)
 
             if not dg:
                 if rest_mult:
-                    fh = sympy.integrals.integrate(rest_mult, x)
+                    fh = integrate(rest_mult, x)
                     return fh
             else:
                 dg = dg.simplify(x)

--- a/sympy/integrals/deltafunctions.py
+++ b/sympy/integrals/deltafunctions.py
@@ -154,7 +154,7 @@ def deltaintegrate(f, x):
         g = f.expand()
         if f != g:  # the expansion worked
             fh = integrate(g, x)
-            if fh and not isinstance(fh, Integral):
+            if fh is not None and not isinstance(fh, Integral):
                 return fh
         else:
             # no expansion performed, try to extract a simple DiracDelta term

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -11,6 +11,10 @@ def test_change_mul():
     assert change_mul(x*y*DiracDelta(x), x) == (DiracDelta(x), x*y)
     assert change_mul(x*y*DiracDelta(x)*DiracDelta(y), x) == \
         (DiracDelta(x), x*y*DiracDelta(y))
+    assert change_mul(DiracDelta(x)**2, x) == \
+        (DiracDelta(x), DiracDelta(x))
+    assert change_mul(y*DiracDelta(x)**2, x) == \
+        (DiracDelta(x), y*DiracDelta(x))
 
 
 def test_deltaintegrate():
@@ -23,6 +27,12 @@ def test_deltaintegrate():
     assert deltaintegrate(DiracDelta(-x), x) == Heaviside(x)
     assert deltaintegrate(DiracDelta(x - y), x) == Heaviside(x - y)
     assert deltaintegrate(DiracDelta(y - x), x) == Heaviside(x - y)
+
+    assert deltaintegrate(DiracDelta(x)**2, x) == DiracDelta(0)*Heaviside(x)
+    assert deltaintegrate(y*DiracDelta(x)**2, x) == \
+        y*DiracDelta(0)*Heaviside(x)
+    assert deltaintegrate(DiracDelta(x, 1)**2, x) is None
+    assert deltaintegrate(y*DiracDelta(x, 1)**2, x) is None
 
     assert deltaintegrate(DiracDelta(x) * f(x), x) == f(0) * Heaviside(x)
     assert deltaintegrate(DiracDelta(-x) * f(x), x) == f(0) * Heaviside(x)

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -1,0 +1,44 @@
+from sympy import (
+    cos, DiracDelta, Heaviside, Function, Integral, integrate, oo,
+    pi, S, sin, symbols,
+)
+from sympy.integrals.deltafunctions import deltaintegrate
+
+f = Function("f")
+x_1, x_2, x, y, z = symbols("x_1 x_2 x y z")
+
+def test_deltaintegrate_DiracDelta():
+    assert deltaintegrate(DiracDelta(x), x) == Heaviside(x)
+    assert deltaintegrate(DiracDelta(-x), x) == Heaviside(x)
+
+    assert deltaintegrate(DiracDelta(x) * f(x), x) == f(0) * Heaviside(x)
+    assert deltaintegrate(DiracDelta(-x) * f(x), x) == f(0) * Heaviside(x)
+    assert deltaintegrate(DiracDelta(x - 1) * f(x), x) == f(1) * Heaviside(x - 1)
+    assert deltaintegrate(DiracDelta(1 - x) * f(x), x) == f(1) * Heaviside(x - 1)
+    assert deltaintegrate(DiracDelta(x**2 + x - 2), x) == \
+        Heaviside(x - 1)/3 + Heaviside(x + 2)/3
+
+    p = cos(x)*(DiracDelta(x) + DiracDelta(x**2 - 1))*sin(x)*(x - pi)
+    assert deltaintegrate(p, x) - (-pi*(cos(1)*Heaviside(-1 + x)*sin(1)/2 - \
+        cos(1)*Heaviside(1 + x)*sin(1)/2) + \
+        cos(1)*Heaviside(1 + x)*sin(1)/2 + \
+        cos(1)*Heaviside(-1 + x)*sin(1)/2) == 0
+
+    p = x_2*DiracDelta(x - x_2)*DiracDelta(x_2 - x_1)
+    assert integrate(p, (x_2, -oo, oo)) == x*DiracDelta(x - x_1)
+
+    p = x*y**2*z*DiracDelta(y - x)*DiracDelta(y - z)*DiracDelta(x - z)
+    assert integrate(p, (y, -oo, oo)) == x**3*z*DiracDelta(x - z)**2
+    assert deltaintegrate((x + 1)*DiracDelta(2*x), x) == S(1)/2 * Heaviside(x)
+    assert deltaintegrate((x + 1)*DiracDelta(2*x/3 + 4/S(9)), x) == \
+        S(1)/2 * Heaviside(x + S(2)/3)
+
+    a, b, c = symbols('a b c', commutative=False)
+    assert integrate(DiracDelta(x - y)*f(x - b)*f(x - a), (x, -oo, oo)) == \
+        f(y - b)*f(y - a)
+
+    p = f(x - a)*DiracDelta(x - y)*f(x - c)*f(x - b)
+    assert integrate(p, (x, -oo, oo)) == f(y - a)*f(y - c)*f(y - b)
+
+    assert integrate(DiracDelta(x - z)*f(x - b)*f(x - a)*DiracDelta(x - y),
+                     (x, -oo, oo)) == DiracDelta(y - z)*f(y - b)*f(y - a)

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -1,15 +1,31 @@
 from sympy import (
-    cos, DiracDelta, Heaviside, Function, Integral, integrate, oo,
+    cos, DiracDelta, Heaviside, Function, integrate, oo,
     pi, S, sin, symbols,
 )
-from sympy.integrals.deltafunctions import deltaintegrate
+from sympy.integrals.deltafunctions import change_mul, deltaintegrate
 
 f = Function("f")
 x_1, x_2, x, y, z = symbols("x_1 x_2 x y z")
 
+
+def test_change_mul():
+    assert change_mul(x, x) == x
+    assert change_mul(x*y, x) == (None, None)
+    assert change_mul(x*y*DiracDelta(x), x) == (DiracDelta(x), x*y)
+    assert change_mul(x*y*DiracDelta(x)*DiracDelta(y), x) == \
+        (DiracDelta(x), x*y*DiracDelta(y))
+
+
 def test_deltaintegrate_DiracDelta():
+    assert deltaintegrate(x, x) is None
+    assert deltaintegrate(x + DiracDelta(x), x) is None
+    assert deltaintegrate(DiracDelta(x, 0), x) == Heaviside(x)
+    for n in range(10):
+        assert deltaintegrate(DiracDelta(x, n + 1), x) == DiracDelta(x, n)
     assert deltaintegrate(DiracDelta(x), x) == Heaviside(x)
     assert deltaintegrate(DiracDelta(-x), x) == Heaviside(x)
+    assert deltaintegrate(DiracDelta(x - y), x) == Heaviside(x - y)
+    assert deltaintegrate(DiracDelta(y - x), x) == Heaviside(x - y)
 
     assert deltaintegrate(DiracDelta(x) * f(x), x) == f(0) * Heaviside(x)
     assert deltaintegrate(DiracDelta(-x) * f(x), x) == f(0) * Heaviside(x)

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -28,6 +28,9 @@ def test_deltaintegrate():
     assert deltaintegrate(DiracDelta(x - y), x) == Heaviside(x - y)
     assert deltaintegrate(DiracDelta(y - x), x) == Heaviside(x - y)
 
+    assert deltaintegrate(x*DiracDelta(x), x) == 0
+    assert deltaintegrate((x - y)*DiracDelta(x - y), x) == 0
+
     assert deltaintegrate(DiracDelta(x)**2, x) == DiracDelta(0)*Heaviside(x)
     assert deltaintegrate(y*DiracDelta(x)**2, x) == \
         y*DiracDelta(0)*Heaviside(x)

--- a/sympy/integrals/tests/test_deltafunctions.py
+++ b/sympy/integrals/tests/test_deltafunctions.py
@@ -1,7 +1,4 @@
-from sympy import (
-    cos, DiracDelta, Heaviside, Function, integrate, oo,
-    pi, S, sin, symbols,
-)
+from sympy import cos, DiracDelta, Heaviside, Function, pi, S, sin, symbols
 from sympy.integrals.deltafunctions import change_mul, deltaintegrate
 
 f = Function("f")
@@ -16,7 +13,7 @@ def test_change_mul():
         (DiracDelta(x), x*y*DiracDelta(y))
 
 
-def test_deltaintegrate_DiracDelta():
+def test_deltaintegrate():
     assert deltaintegrate(x, x) is None
     assert deltaintegrate(x + DiracDelta(x), x) is None
     assert deltaintegrate(DiracDelta(x, 0), x) == Heaviside(x)
@@ -41,20 +38,21 @@ def test_deltaintegrate_DiracDelta():
         cos(1)*Heaviside(-1 + x)*sin(1)/2) == 0
 
     p = x_2*DiracDelta(x - x_2)*DiracDelta(x_2 - x_1)
-    assert integrate(p, (x_2, -oo, oo)) == x*DiracDelta(x - x_1)
+    assert deltaintegrate(p, x_2) == x*DiracDelta(x - x_1)*Heaviside(x_2 - x)
 
     p = x*y**2*z*DiracDelta(y - x)*DiracDelta(y - z)*DiracDelta(x - z)
-    assert integrate(p, (y, -oo, oo)) == x**3*z*DiracDelta(x - z)**2
+    assert deltaintegrate(p, y) == x**3*z*DiracDelta(x - z)**2*Heaviside(y - x)
     assert deltaintegrate((x + 1)*DiracDelta(2*x), x) == S(1)/2 * Heaviside(x)
     assert deltaintegrate((x + 1)*DiracDelta(2*x/3 + 4/S(9)), x) == \
         S(1)/2 * Heaviside(x + S(2)/3)
 
     a, b, c = symbols('a b c', commutative=False)
-    assert integrate(DiracDelta(x - y)*f(x - b)*f(x - a), (x, -oo, oo)) == \
-        f(y - b)*f(y - a)
+    assert deltaintegrate(DiracDelta(x - y)*f(x - b)*f(x - a), x) == \
+        f(y - b)*f(y - a)*Heaviside(x - y)
 
     p = f(x - a)*DiracDelta(x - y)*f(x - c)*f(x - b)
-    assert integrate(p, (x, -oo, oo)) == f(y - a)*f(y - c)*f(y - b)
+    assert deltaintegrate(p, x) == f(y - a)*f(y - c)*f(y - b)*Heaviside(x - y)
 
-    assert integrate(DiracDelta(x - z)*f(x - b)*f(x - a)*DiracDelta(x - y),
-                     (x, -oo, oo)) == DiracDelta(y - z)*f(y - b)*f(y - a)
+    p = DiracDelta(x - z)*f(x - b)*f(x - a)*DiracDelta(x - y)
+    assert deltaintegrate(p, x) == DiracDelta(y - z)*f(y - b)*f(y - a) * \
+        Heaviside(x - y)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -411,34 +411,10 @@ def test_failing_integrals():
 
 
 def test_integrate_DiracDelta():
-    assert integrate(DiracDelta(x), x) == Heaviside(x)
-    assert integrate(DiracDelta(x) * f(x), x) == f(0) * Heaviside(x)
+    # This is here to check that deltaintegrate is being called.
+    # More tests are in test_deltafunctions.py
     assert integrate(DiracDelta(x) * f(x), (x, -oo, oo)) == f(0)
-    assert integrate(DiracDelta(-x) * f(x), (x, -oo, oo)) == f(0)
-    assert integrate(DiracDelta(-(x - 1)) * f(x), (x, -oo, oo)) == f(1)
     assert integrate(DiracDelta(x) * f(x), (x, 0, oo)) == f(0)/2
-    assert integrate(DiracDelta(x**2 + x - 2), x) - \
-        (Heaviside(-1 + x)/3 + Heaviside(2 + x)/3) == 0
-    assert integrate(cos(x)*(DiracDelta(x) + DiracDelta(x**2 - 1))*sin(x)*(x - pi), x) - \
-        (-pi*(cos(1)*Heaviside(-1 + x)*sin(1)/2 - cos(1)*Heaviside(1 + x)*sin(1)/2) +
-         cos(1)*Heaviside(1 + x)*sin(1)/2 + cos(1)*Heaviside(-1 + x)*sin(1)/2) == 0
-    assert integrate(x_2*DiracDelta(x - x_2)*DiracDelta(x_2 - x_1), (x_2, -oo, oo)) == \
-        x*DiracDelta(x - x_1)
-    assert integrate(
-        x*y**2*z*DiracDelta(y - x)*DiracDelta(y - z)*DiracDelta(x - z),
-        (y, -oo, oo)) == x**3*z*DiracDelta(x - z)**2
-    assert integrate((x + 1)*DiracDelta(2*x), (x, -oo, oo)) == S(1)/2
-    assert integrate((x + 1)*DiracDelta(2*x/3 + 4/S(9)), (x, -oo, oo)) == \
-        S(1)/2
-
-    a, b, c = symbols('a b c', commutative=False)
-    assert integrate(DiracDelta(x - y)*f(x - b)*f(x - a), (x, -oo, oo)) == \
-        f(y - b)*f(y - a)
-    assert integrate(f(x - a)*DiracDelta(x - y)*f(x - c)*f(x - b),
-                     (x, -oo, oo)) == f(y - a)*f(y - c)*f(y - b)
-
-    assert integrate(DiracDelta(x - z)*f(x - b)*f(x - a)*DiracDelta(x - y),
-                     (x, -oo, oo)) == DiracDelta(y - z)*f(y - b)*f(y - a)
 
 
 def test_subs1():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -411,11 +411,24 @@ def test_failing_integrals():
 
 
 def test_integrate_DiracDelta():
-    # This is here to check that deltaintegrate is being called.
-    # More tests are in test_deltafunctions.py
+    # This is here to check that deltaintegrate is being called, but also
+    # to test definite integrals. More tests are in test_deltafunctions.py
     assert integrate(DiracDelta(x) * f(x), (x, -oo, oo)) == f(0)
     assert integrate(DiracDelta(x) * f(x), (x, 0, oo)) == f(0)/2
     assert integrate(DiracDelta(x)**2, (x, -oo, oo)) == DiracDelta(0)
+    # issue 1423
+    assert integrate(integrate((4 - 4*x + x*y - 4*y) * \
+        DiracDelta(x)*DiracDelta(y - 1), (x, 0, 1)), (y, 0, 1)) == 0
+    # issue 2630
+    p = exp(-(x**2 + y**2))/pi
+    assert integrate(p*DiracDelta(x - 10*y), (x, -oo, oo), (y, -oo, oo)) == \
+        integrate(p*DiracDelta(x - 10*y), (y, -oo, oo), (x, -oo, oo)) == \
+        integrate(p*DiracDelta(10*x - y), (x, -oo, oo), (y, -oo, oo)) == \
+        integrate(p*DiracDelta(10*x - y), (y, -oo, oo), (x, -oo, oo)) == \
+        1/sqrt(101*pi)
+    # issue 3328
+    assert integrate(integrate(integrate(
+        DiracDelta(x - y - z), (z, 0, oo)), (y, 0, 1)), (x, 0, 1)) == 1
 
 
 def test_subs1():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -415,6 +415,7 @@ def test_integrate_DiracDelta():
     # More tests are in test_deltafunctions.py
     assert integrate(DiracDelta(x) * f(x), (x, -oo, oo)) == f(0)
     assert integrate(DiracDelta(x) * f(x), (x, 0, oo)) == f(0)/2
+    assert integrate(DiracDelta(x)**2, (x, -oo, oo)) == DiracDelta(0)
 
 
 def test_subs1():


### PR DESCRIPTION
Fix an simple DiracDelta integral, reorganize tests and add some tests.

Before:

```
>>> integrate(DiracDelta(y - x), x)
Heaviside(y - x)
>>> integrate(DiracDelta(y - x), (x, -oo, oo))
-1
```

After:

```
>>> integrate(DiracDelta(y - x), x)
Heaviside(x - y)
>>> integrate(DiracDelta(y - x), (x, -oo, oo))
1
```
