### PR TITLE
Piecewise canonicalization

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -424,11 +424,15 @@ class Piecewise(Function):
                 c = bool(c) or c
             if isinstance(c, Equality):
                 from sympy import solve
-                slns = solve(c, dict=True)
-                if not slns:
-                    c = False
-                elif len(slns) == 1:
-                    c = And(*[Equality(key, value) for key, value in slns[0].iteritems()])
+                try:
+                    slns = solve(c, dict=True)
+                    if not slns:
+                        c = False
+                    elif len(slns) == 1:
+                        c = And(*[Equality(key, value)
+                                  for key, value in slns[0].iteritems()])
+                except NotImplementedError:
+                    pass
 
             args[i] = e, c
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -421,18 +421,23 @@ class Piecewise(Function):
             elif isinstance(c, Basic):
                 c = c._subs(old, new)
             if isinstance(c, Equality):
-                c = (c.lhs - c.rhs).is_zero or c
-            if isinstance(c, Equality):
-                from sympy import solve
-                try:
-                    slns = solve(c, dict=True)
-                    if not slns:
-                        c = False
-                    elif len(slns) == 1:
-                        c = And(*[Equality(key, value)
-                                  for key, value in slns[0].iteritems()])
-                except NotImplementedError:
-                    pass
+                d = Dummy()
+                from sympy import checksol
+                if checksol(d, d, c.lhs - c.rhs, minimal=True):
+                    # the equality is trivially solved
+                    c = True
+                else:
+                    # try to solve the equality
+                    from sympy import solve
+                    try:
+                        slns = solve(c, dict=True)
+                        if not slns:
+                            c = False
+                        elif len(slns) == 1:
+                            c = And(*[Equality(key, value)
+                                      for key, value in slns[0].iteritems()])
+                    except NotImplementedError:
+                        pass
 
             args[i] = e, c
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -412,6 +412,7 @@ class Piecewise(Function):
         """
         Piecewise conditions may contain bool which are not of Basic type.
         """
+        from sympy import checksol, solve
         args = list(self.args)
         for i, (e, c) in enumerate(args):
             e = e._subs(old, new)
@@ -421,14 +422,11 @@ class Piecewise(Function):
             elif isinstance(c, Basic):
                 c = c._subs(old, new)
             if isinstance(c, Equality):
-                d = Dummy()
-                from sympy import checksol
-                if checksol(d, d, c.lhs - c.rhs, minimal=True):
+                if checksol(c, {}, minimal=True):
                     # the equality is trivially solved
                     c = True
                 else:
                     # try to solve the equality
-                    from sympy import solve
                     try:
                         slns = solve(c, dict=True)
                         if not slns:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -421,7 +421,7 @@ class Piecewise(Function):
             elif isinstance(c, Basic):
                 c = c._subs(old, new)
             if isinstance(c, Equality):
-                c = bool(c) or c
+                c = (c.lhs - c.rhs).is_zero or c
             if isinstance(c, Equality):
                 from sympy import solve
                 try:

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -417,6 +417,15 @@ class Piecewise(Function):
                 pass
             elif isinstance(c, Basic):
                 c = c._subs(old, new)
+            if isinstance(c, Equality):
+                c = bool(c) or c
+            if isinstance(c, Equality):
+                from sympy import solve
+                slns = solve(c, dict=True)
+                if not slns:
+                    c = False
+                elif len(slns) == 1:
+                    c = And(*[Equality(key, value) for key, value in slns[0].iteritems()])
 
             args[i] = e, c
 

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -148,11 +148,14 @@ class Piecewise(Function):
             elif cond_eval:
                 if all_conds_evaled:
                     return expr
-            if len(non_false_ecpairs) != 0 and non_false_ecpairs[-1].expr == expr:
-                non_false_ecpairs[-1] = ExprCondPair(
-                    expr, Or(cond, non_false_ecpairs[-1].cond))
-            else:
-                non_false_ecpairs.append( ExprCondPair(expr, cond) )
+            if len(non_false_ecpairs) != 0:
+                if non_false_ecpairs[-1].cond == cond:
+                    continue
+                elif non_false_ecpairs[-1].expr == expr:
+                    non_false_ecpairs[-1] = ExprCondPair(
+                        expr, Or(cond, non_false_ecpairs[-1].cond))
+                    continue
+            non_false_ecpairs.append(ExprCondPair(expr, cond))
         if len(non_false_ecpairs) != len(args) or piecewise_again:
             return Piecewise(*non_false_ecpairs)
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -6,6 +6,7 @@ from sympy import (
 from sympy.utilities.pytest import XFAIL, raises
 
 x, y = symbols('x y')
+z = symbols('z', nonzero=True)
 
 
 def test_piecewise():
@@ -43,6 +44,13 @@ def test_piecewise():
     pf = Piecewise((f(x), x < -1), (f(x) + h(x) + 2, x <= 1))
     pg = Piecewise((g(x), x < -1), (g(x) + h(x) + 2, x <= 1))
     assert pg.subs(g, f) == pf
+
+    assert Piecewise((1, Eq(x, 0)), (0, True)).subs(x, 0) == 1
+    assert Piecewise((1, Eq(x, 0)), (0, True)).subs(x, 1) == 0
+    assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, y) == 1
+    assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, -y) == Piecewise((1, Eq(y, 0)), (0, True))
+    assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, z) == 1
+    assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, -z) == 0
 
     # Test evalf
     assert p.evalf() == p

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -2,6 +2,7 @@ from sympy import (
     adjoint, And, Basic, conjugate, diff, expand, Eq, Function, I, im,
     Integral, integrate, Interval, lambdify, log, Max, Min, oo, Or, pi,
     Piecewise, piecewise_fold, Rational, re, solve, symbols, transpose,
+    cos, exp,
 )
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -53,6 +54,8 @@ def test_piecewise():
     assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, -y) == Piecewise((1, Eq(y, 0)), (0, True))
     assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, z) == 1
     assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, -z) == 0
+    assert Piecewise((1, Eq(exp(x), cos(z))), (0, True)).subs(x, z) == \
+        Piecewise((1, Eq(exp(z), cos(z))), (0, True))
 
     # Test evalf
     assert p.evalf() == p

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -13,14 +13,16 @@ def test_piecewise():
 
     # Test canonization
     assert Piecewise((x, x < 1), (0, True)) == Piecewise((x, x < 1), (0, True))
-    assert Piecewise(
-        (x, x < 1), (0, True), (1, True)) == Piecewise((x, x < 1), (0, True))
-    assert Piecewise(
-        (x, x < 1), (0, False), (-1, 1 > 2)) == Piecewise((x, x < 1))
-    assert Piecewise(
-        (x, x < 1), (0, x < 2), (0, True)) == Piecewise((x, x < 1), (0, True))
-    assert Piecewise((x, x < 1), (
-        x, x < 2), (0, True)) == Piecewise((x, Or(x < 1, x < 2)), (0, True))
+    assert Piecewise((x, x < 1), (0, True), (1, True)) == \
+        Piecewise((x, x < 1), (0, True))
+    assert Piecewise((x, x < 1), (0, False), (-1, 1 > 2)) == \
+        Piecewise((x, x < 1))
+    assert Piecewise((x, x < 1), (0, x < 1), (0, True)) == \
+        Piecewise((x, x < 1), (0, True))
+    assert Piecewise((x, x < 1), (0, x < 2), (0, True)) == \
+        Piecewise((x, x < 1), (0, True))
+    assert Piecewise((x, x < 1), (x, x < 2), (0, True)) == \
+        Piecewise((x, Or(x < 1, x < 2)), (0, True))
     assert Piecewise((x, x < 1), (x, x < 2), (x, True)) == x
     assert Piecewise((x, True)) == x
     raises(TypeError, lambda: Piecewise(x))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -51,11 +51,13 @@ def test_piecewise():
     assert Piecewise((1, Eq(x, 0)), (0, True)).subs(x, 0) == 1
     assert Piecewise((1, Eq(x, 0)), (0, True)).subs(x, 1) == 0
     assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, y) == 1
-    assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, -y) == Piecewise((1, Eq(y, 0)), (0, True))
+    assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, -y) == \
+        Piecewise((1, Eq(y, 0)), (0, True))
     assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, z) == 1
     assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, -z) == 0
     assert Piecewise((1, Eq(exp(x), cos(z))), (0, True)).subs(x, z) == \
         Piecewise((1, Eq(exp(z), cos(z))), (0, True))
+    assert Piecewise((1, Eq(x, y*(y + 1))), (0, True)).subs(x, y**2 + y) == 1
 
     # Test evalf
     assert p.evalf() == p

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -492,7 +492,7 @@ def test_abs():
     assert abs(x + 1).nseries(x, n=4) == x + 1
     assert abs(sin(x)).nseries(x, n=4) == x - Rational(1, 6)*x**3 + O(x**4)
     assert abs(sin(-x)).nseries(x, n=4) == x - Rational(1, 6)*x**3 + O(x**4)
-    assert abs(x - a).nseries(x, 1) == Piecewise((x - 1, Eq(1 - a, 0)),
+    assert abs(x - a).nseries(x, 1) == Piecewise((x - 1, Eq(a, 1)),
                                                 ((x - a)*sign(1 - a), True))
 
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -106,30 +106,36 @@ def checksol(f, symbol, sol=None, **flags):
     Examples
     ========
 
-       >>> from sympy import symbols
-       >>> from sympy.solvers import checksol
-       >>> x, y = symbols('x,y')
-       >>> checksol(x**4-1, x, 1)
-       True
-       >>> checksol(x**4-1, x, 0)
-       False
-       >>> checksol(x**2 + y**2 - 5**2, {x:3, y: 4})
-       True
+    >>> from sympy import symbols
+    >>> from sympy.solvers import checksol
+    >>> x, y = symbols('x,y')
+    >>> checksol(x**4 - 1, x, 1)
+    True
+    >>> checksol(x**4 - 1, x, 0)
+    False
+    >>> checksol(x**2 + y**2 - 5**2, {x: 3, y: 4})
+    True
 
-       None is returned if checksol() could not conclude.
+    To check if an expression is zero using checksol, pass it
+    as ``f`` and send an empty dictionary for ``symbol``:
 
-       flags:
-           'numerical=True (default)'
-               do a fast numerical check if ``f`` has only one symbol.
-           'minimal=True (default is False)'
-               a very fast, minimal testing.
-           'warn=True (default is False)'
-               print a warning if checksol() could not conclude.
-           'simplify=True (default)'
-               simplify solution before substituting into function and
-               simplify the function before trying specific simplifications
-           'force=True (default is False)'
-               make positive all symbols without assumptions regarding sign.
+    >>> checksol(x**2 + x - x*(x + 1), {})
+    True
+
+    None is returned if checksol() could not conclude.
+
+    flags:
+        'numerical=True (default)'
+           do a fast numerical check if ``f`` has only one symbol.
+        'minimal=True (default is False)'
+           a very fast, minimal testing.
+        'warn=True (default is False)'
+           print a warning if checksol() could not conclude.
+        'simplify=True (default)'
+           simplify solution before substituting into function and
+           simplify the function before trying specific simplifications
+        'force=True (default is False)'
+           make positive all symbols without assumptions regarding sign.
 
     """
 
@@ -162,7 +168,7 @@ def checksol(f, symbol, sol=None, **flags):
     if not f:
         return True
 
-    if not f.has(*sol.keys()):
+    if sol and not f.has(*sol.keys()):
         # if f(y) == 0, x=3 does not set f(y) to zero...nor does it not
         return None
 


### PR DESCRIPTION
Remove consecutive identical conditions:

```
>>> Piecewise((x, x < 1), (0, x < 1), (0, True))
Piecewise((x, x < 1), (0, True))
```

Try to solve conditions upon substitution:

```
>>> Piecewise((1, Eq(x, y)), (0, True)).subs(x, y)
1
>>> Piecewise((1, Eq(x, y)), (0, True)).subs(x, -y)
Piecewise((1, Eq(y, 0)), (0, True))
```
