### PR TITLE
Post-merge cleanup of the Risch branch

### DIFF
--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -7,7 +7,7 @@ from sympy import (
     tan, S, log, Function, gamma, sinh,
 )
 
-from sympy.utilities.pytest import XFAIL, skip
+from sympy.utilities.pytest import XFAIL, skip, slow
 
 from sympy.abc import x, k, c, y, R, b, h, a, m, A, z, t
 
@@ -28,10 +28,10 @@ def run_with_timeout(test, time):
     return r
 
 @XFAIL
+@slow
 def test_issue_781():
-    t = 5 # Timeout time
     # integrate_hyperexponential(Poly(t*2*(1 - t0**2)*t0*(x**3 + x**2), t), Poly((1 + t0**2)**2*2*(x**2 + x + 1), t), [Poly(1, x), Poly(1 + t0**2, t0), Poly(t, t)], [x, t0, t], [exp, tan])
-    assert not run_with_timeout("integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3+x**2)/(2*(x**2+x+1)) , x)", t).has(Integral)
+    assert not integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3+x**2)/(2*(x**2+x+1)) , x).has(Integral)
 
 @XFAIL
 def test_issue_1113():
@@ -43,7 +43,7 @@ def test_issue_1135():
 
 @XFAIL
 def test_issue_1227():
-    assert not (2*integrate(((h*(x-R+b))/b)*sqrt(R**2-x**2), (x, R-b, R))).has(Integral)
+    assert integrate(((h*(x-R+b))/b)*sqrt(R**2-x**2), (x, R-b, R)).has(Integral)
 
 @XFAIL
 def test_issue_1392():
@@ -54,12 +54,12 @@ def test_issue_1393():
     assert not integrate(x**2 * sqrt(5-x**2), x).has(Integral)
 
 @XFAIL
+@slow
 def test_issue_1412():
     # This works, but gives a complicated answer.  The correct answer is x - cos(x).
     # The last one is what Maple gives.  It is also quite slow.
-    t = 5 # Timeout time, requires ~220 sec.
-    assert run_with_timeout("integrate(cos(x)**2 / (1-sin(x)))", t) in [x - cos(x),
-        1 - cos(x) + x, -2/(tan((S(1)/2)*x)**2+1)+x]
+    assert integrate(cos(x)**2 / (1-sin(x))) in [x - cos(x), 1 - cos(x) + x,
+            -2/(tan((S(1)/2)*x)**2 + 1) + x]
 
 @XFAIL
 def test_issue_1415():
@@ -72,10 +72,12 @@ def test_issue_1426():
     assert not integrate((x**m * (1 - x)**n * (a + b*x + c*x**2))/(1 + x**2), (x, 0, 1)).has(Integral)
 
 @XFAIL
+@slow
 def test_issue_1441():
     # Note, this integral is probably nonelementary
-    t = 5 # Timeout time
-    assert not run_with_timeout("integrate((sin(1/x) - x*exp(x))/((-sin(1/x) + x*exp(x))*x + x*sin(1/x)), x)", t).has(Integral)
+    assert not integrate(
+            (sin(1/x) - x*exp(x)) /
+            ((-sin(1/x) + x*exp(x))*x + x*sin(1/x)), x).has(Integral)
 
 @XFAIL
 def test_issue_1452():
@@ -91,10 +93,10 @@ def test_issue_1638b():
     assert integrate(sin(x)/x, (x, -oo, oo)) == pi/2
 
 @XFAIL
+@slow
 def test_issue_1792():
     # Requires the hypergeometric function.
-    t = 5 # Timeout
-    assert not run_with_timeout("integrate(cos(x)**y, x)", t).has(Integral)
+    assert not integrate(cos(x)**y, x).has(Integral)
 
 @XFAIL
 def test_issue_1796a():
@@ -113,22 +115,23 @@ def test_issue_1796d():
     assert not integrate(exp(2*b*x)*exp(-a*x**2), (x, 0, oo)).has(Integral)
 
 @XFAIL
+@slow
 def test_issue_1842():
-    t = 5 # Timeout time
-    assert not run_with_timeout("integrate(sqrt(1+sinh(x/20)**2),(x,-25, 25))", t).has(Integral)
+    assert not integrate(sqrt(1+sinh(x/20)**2),(x,-25, 25)).has(Integral)
 
 @XFAIL
+@slow
 def test_issue_1851():
     # Problem is with exception
     assert not integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x).has(Integral)
 
 @XFAIL
+@slow
 def test_issue_1869():
-    t = 5 # timeout
-    assert not run_with_timeout("integrate(sin(log(x**2)))", t).has(Integral)
+    assert not integrate(sin(log(x**2))).has(Integral)
 
 @XFAIL
+@slow
 def test_issue_1893():
     # Nonelementary integral.  Requires hypergeometric/Meijer-G handling.
-    t = 5 # Timeout
-    assert not run_with_timeout("integrate(log(x) * x**(k-1) * exp(-x) / gamma(k), (x, 0, oo))", t).has(Integral)
+    assert not integrate(log(x) * x**(k-1) * exp(-x) / gamma(k), (x, 0, oo)).has(Integral)

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -28,68 +28,14 @@ def run_with_timeout(test, time):
     return r
 
 @XFAIL
-def test_issue_459():
-    # Si special function
-    assert not integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)).has(Integral)
-
-@XFAIL
 def test_issue_781():
     t = 5 # Timeout time
     # integrate_hyperexponential(Poly(t*2*(1 - t0**2)*t0*(x**3 + x**2), t), Poly((1 + t0**2)**2*2*(x**2 + x + 1), t), [Poly(1, x), Poly(1 + t0**2, t0), Poly(t, t)], [x, t0, t], [exp, tan])
     assert not run_with_timeout("integrate(exp(x)*cos(2*x)*sin(2*x) * (x**3+x**2)/(2*(x**2+x+1)) , x)", t).has(Integral)
 
 @XFAIL
-def test_issue_841a():
-    assert not integrate(exp(-x**2)*exp(I*k*x), (x, -oo, oo)).has(Integral)
-
-@XFAIL
-def test_issue_841b():
-    a = Symbol('a', positive=True)
-    assert not integrate(c*exp(-x**2/a)*exp(I*k*x), (x, -oo, oo)).has(Integral)
-
-@XFAIL
-def test_issue_1001():
-    # Note: issue has additional integral
-    assert not integrate(sqrt(y**2-x**2), x).has(Integral)
-
-@XFAIL
-def test_issue_1020():
-    assert not integrate(sqrt(y**2 - x**2)/x, x).has(Integral)
-
-@XFAIL
 def test_issue_1113():
     assert not integrate(sign(x), x).has(Integral)
-
-@XFAIL
-def test_issue_1116():
-    # (singularity detection)
-    assert integrate(1/(x**2), (x, -1, 1)) == oo
-
-@XFAIL
-def test_issue_1127a():
-    # The integral doesn't calculate, but the real problem is an exception
-    # caused the by Real (1/2 instead of S(1)/2) making it fail.
-    assert not integrate(-(1 + (-x + x**2)**(1/2))/(-x + (1 + (-x + x**2)**(1/2))*x), x).has(Integral)
-
-@XFAIL
-def test_issue_1127b():
-    assert not integrate(2*a/((4*a**2+x**2)*sqrt(4*a**2+x**2)),x).has(Integral)
-
-@XFAIL
-def test_issue_1127c():
-    # The integral doesn't calculate, but the real problem is an exception
-    # caused by the Real (3/2 instead of S(3)/2) making it fail.
-    assert not integrate(2*a/((((2*a)**2+x**2))**(3/2)),x).has(Integral)
-
-@XFAIL
-def test_issue_1127d():
-    # The same as test_issue_1127c with sympified exponent
-    assert not integrate(2*a/((4*a**2+x**2)*sqrt(4*a**2+x**2)),x).has(Integral)
-
-@XFAIL
-def test_issue_1127e():
-    # Similar to test_issue_841a above
-    assert not integrate(-(8 + 2*sin(x) + 6*exp(x))*exp(2*x), x).has(Integral)
 
 @XFAIL
 def test_issue_1135():
@@ -100,28 +46,12 @@ def test_issue_1227():
     assert not (2*integrate(((h*(x-R+b))/b)*sqrt(R**2-x**2), (x, R-b, R))).has(Integral)
 
 @XFAIL
-def test_issue_1304a():
-    assert not integrate(sqrt(x**2 + y**2), x).has(Integral)
-
-@XFAIL
-def test_issue_1304b():
-    assert not integrate(1/(x**2 + y**2)**(Rational(3,2)),y).has(Integral)
-
-@XFAIL
-def test_issue_1323():
-    assert not integrate(1/sqrt(16 + 4*x**2), x).has(Integral)
-
-@XFAIL
 def test_issue_1392():
     assert not integrate(x*sqrt(x**2+2*x+4), x).has(Integral)
 
 @XFAIL
 def test_issue_1393():
     assert not integrate(x**2 * sqrt(5-x**2), x).has(Integral)
-
-@XFAIL
-def test_issue_1394():
-    assert not integrate(x*sqrt(1+2*x), x).has(Integral)
 
 @XFAIL
 def test_issue_1412():
@@ -135,11 +65,6 @@ def test_issue_1412():
 def test_issue_1415():
     # The correct answer is 2*sin(x)
     assert not integrate(sin(2*x)/ sin(x)).has(Integral)
-
-@XFAIL
-def test_issue_1418():
-    # Currently give a traceback
-    assert not integrate((x**Rational(1,2) - x**3)/x**Rational(1,3), x).has(Integral)
 
 @XFAIL
 def test_issue_1426():
@@ -157,19 +82,6 @@ def test_issue_1452():
     assert integrate(1/(x*sqrt(1-x**2)),x).has(Integral)
 
 @XFAIL
-def test_issue_1576a():
-    assert not integrate(4*pi**2*x**2*y**4*(y**2+9*x**2)/(y**2+x**2)**3, x).has(Integral)
-
-@XFAIL
-def test_issue_1576b():
-    assert not integrate((1+x)/(a+x**2), x).has(Integral)
-
-@XFAIL
-def test_issue_1604():
-    g = Function('g')
-    assert integrate(exp(x)*g(x), x).has(Integral)
-
-@XFAIL
 def test_issue_1638a():
     # Implementation of Si()
     assert integrate(sin(x)/x, x).has(Integral)
@@ -179,30 +91,10 @@ def test_issue_1638b():
     assert integrate(sin(x)/x, (x, -oo, oo)) == pi/2
 
 @XFAIL
-def test_issue_1768():
-    assert not integrate(sin(x)*tan(x), x).has(Integral)
-
-@XFAIL
-def test_issue_1791():
-    # Note: Answer contains erf()
-    assert not integrate(exp(-log(x)**2),x).has(Integral)
-
-@XFAIL
 def test_issue_1792():
     # Requires the hypergeometric function.
     t = 5 # Timeout
     assert not run_with_timeout("integrate(cos(x)**y, x)", t).has(Integral)
-
-@XFAIL
-def test_issue_1793a():
-    P1 = -A*exp(-z)
-    P2 = -A/(c*t)*(sin(x)**2 + cos(y)**2)
-    assert not integrate(c*(P2 - P1), t).has(Integral)
-
-@XFAIL
-def test_issue_1793b():
-    # (traceback)
-    assert not integrate((sin(y)*x**3 + 2*cos(y)*x**2 + 12)/(x**2 + 2), x).has(Integral)
 
 @XFAIL
 def test_issue_1796a():
@@ -240,8 +132,3 @@ def test_issue_1893():
     # Nonelementary integral.  Requires hypergeometric/Meijer-G handling.
     t = 5 # Timeout
     assert not run_with_timeout("integrate(log(x) * x**(k-1) * exp(-x) / gamma(k), (x, 0, oo))", t).has(Integral)
-
-@XFAIL
-def test_issue_1888():
-    f = Function('f')
-    assert integrate(f(x).diff(x)**2, x).has(Integral)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -817,8 +817,19 @@ def test_limit_bug():
         -((-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z) + \
         log(z**2)/(2*z) + EulerGamma/z + 2*log(pi)/z
 
+def test_issue_1604():
+    g = Function('g')
+    assert integrate(exp(x)*g(x), x).has(Integral)
+
+def test_issue_1888():
+    f = Function('f')
+    assert integrate(f(x).diff(x)**2, x).has(Integral)
+
 # The following tests work using meijerint.
 
+def test_issue459():
+    from sympy import Si
+    assert integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)) == 2*Si(pi**2/2)
 
 def test_issue841():
     from sympy import expand_mul
@@ -829,27 +840,21 @@ def test_issue841():
     assert expand_mul(integrate(exp(-a*x**2 + 2*d*x), (x, -oo, oo))) == \
         sqrt(pi)*exp(d**2/a)/sqrt(a)
 
-
 def test_issue1304():
     assert integrate(1/(x**2 + y**2)**S('3/2'), x) == \
         1/(y**2*sqrt(1 + y**2/x**2))
 
-
-def test_issue459():
-    from sympy import Si
-    assert integrate(cos(x*y), (x, -pi/2, pi/2), (y, 0, pi)) == 2*Si(pi**2/2)
-
+def test_issue_1323():
+    assert integrate(1/sqrt(16 + 4*x**2), x) == asinh(x/2) / 2
 
 def test_issue1394():
     from sympy import simplify
     assert simplify(integrate(x*sqrt(1 + 2*x), x)) == \
         sqrt(2*x + 1)*(6*x**2 + x - 1)/15
 
-
 def test_issue1638():
     assert integrate(sin(x)/x, (x, -oo, oo)) == pi
     assert integrate(sin(x)/x, (x, 0, oo)) == pi/2
-
 
 def test_issue1893():
     from sympy import simplify, expand_func, polygamma, gamma


### PR DESCRIPTION
Here, I'm trying to merge test_failing_integrals with test_integrals. For now, I've almost only dealt with the xpassing tests.

This adds tests for issues 1604 and 1888.
