### PR TITLE
add is_associative flag to Basic

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -69,6 +69,7 @@ class Basic(object):
     is_Boolean = False
     is_Not = False
     is_Matrix = False
+    is_associative = None
 
     @property
     @deprecated(useinstead="is_Float", issue=1721, deprecated_since_version="0.7.0")

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -22,6 +22,7 @@ class AssocOp(Expr):
     This is an abstract base class, concrete derived classes must define
     the attribute `identity`.
     """
+    is_associative = True
 
     # for performance reason, we don't let is_commutative go to assumptions,
     # and keep it right here

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -146,3 +146,8 @@ def test_sorted_args():
     x = symbols('x')
     assert b21._sorted_args == b21.args
     raises(AttributeError, lambda: x._sorted_args)
+
+def test_associative_commutative():
+    b = Basic(1,2)
+    assert b.is_commutative is None
+    assert b.is_associative is None


### PR DESCRIPTION
I would like to be able to test if any Basic is associative. Previously this could have been done by checking 

```
isinstance(x, AssocOp)
```

Unfortunately `AssocOp` inherits form `Expr` so this wouldn't make sense for matrices and sets.

This PR adds an `is_associative = None` flag to `Basic`
