### PR TITLE
add subs rule and tool

### DIFF
--- a/sympy/rules/rl.py
+++ b/sympy/rules/rl.py
@@ -108,6 +108,15 @@ def distribute(A, B):
         return expr
     return distribute_rl
 
+def subs(a, b):
+    """ Replace expressions exactly """
+    def subs_rl(expr):
+        if expr == a:
+            return b
+        else:
+            return expr
+    return subs_rl
+
 # Functions that are rules
 
 def unpack(expr):

--- a/sympy/rules/tests/test_rl.py
+++ b/sympy/rules/tests/test_rl.py
@@ -1,4 +1,4 @@
-from sympy.rules.rl import rm_id, glom, flatten, unpack, sort, distribute
+from sympy.rules.rl import rm_id, glom, flatten, unpack, sort, distribute, subs
 from sympy import Basic
 
 def test_rm_id():
@@ -46,3 +46,8 @@ def test_distribute_add_mul():
     expected = Add(Mul(2, x), Mul(2, y))
     distribute_mul = distribute(Mul, Add)
     assert distribute_mul(expr) == expected
+
+def test_subs():
+    rl = subs(1, 2)
+    assert rl(1) == 2
+    assert rl(3) == 3

--- a/sympy/rules/tests/test_tools.py
+++ b/sympy/rules/tests/test_tools.py
@@ -1,0 +1,11 @@
+from sympy.rules.tools import subs
+from sympy import Basic
+
+def test_subs():
+    from sympy import symbols
+    a,b,c,d,e,f = symbols('a,b,c,d,e,f')
+    mapping = {a: d, d: a, Basic(e): Basic(f)}
+    expr   = Basic(a, Basic(b, c), Basic(d, Basic(e)))
+    result = Basic(d, Basic(b, c), Basic(a, Basic(f)))
+    assert subs(mapping)(expr) == result
+

--- a/sympy/rules/tools.py
+++ b/sympy/rules/tools.py
@@ -1,0 +1,18 @@
+import rl
+from strat import do_one
+from traverse import top_down
+
+def subs(d):
+    """ Full simultaneous exact substitution
+
+    Example
+    =======
+
+    >>> from sympy.rules.tools import subs
+    >>> from sympy import Basic
+    >>> mapping = {1: 4, 4: 1, Basic(5): Basic(6, 7)}
+    >>> expr = Basic(1, Basic(2, 3), Basic(4, Basic(5)))
+    >>> subs(mapping)(expr)
+    Basic(4, Basic(2, 3), Basic(1, Basic(6, 7)))
+    """
+    return top_down(do_one(*map(rl.subs, *zip(*d.items()))))


### PR DESCRIPTION
Adds a new subs routine in the rules toolset. This performs an exact structural substitution.

Questions:
1. Should this be renamed?
2. How can I create unique identifiers? See the note in subs in tools.py.
