### PR TITLE
remove SymPy dependence from traverse

### DIFF
--- a/sympy/rules/traverse.py
+++ b/sympy/rules/traverse.py
@@ -1,21 +1,20 @@
-# Strategies to traverse a SymPy Tree
-from sympy import Basic
-from util import new
+# Strategies to traverse a Tree
+from util import new, is_leaf, children
 
 def top_down(rule):
     """ Apply a rule down an AST running it on the top nodes first """
     def top_down_rl(expr):
         newexpr = rule(expr)
-        if not isinstance(newexpr, Basic) or newexpr.is_Atom:
+        if is_leaf(newexpr):
             return newexpr
-        return new(newexpr.__class__, *map(top_down_rl, newexpr.args))
+        return new(type(newexpr), *map(top_down_rl, children(newexpr)))
     return top_down_rl
 
 def bottom_up(rule):
     """ Apply a rule down an AST running it on the bottom nodes first """
     def bottom_up_rl(expr):
-        if not isinstance(expr, Basic) or expr.is_Atom:
+        if is_leaf(expr):
             return rule(expr)
         else:
-            return rule(new(expr.__class__, *map(bottom_up_rl, expr.args)))
+            return rule(new(type(expr), *map(bottom_up_rl, children(expr))))
     return bottom_up_rl

--- a/sympy/rules/traverse.py
+++ b/sympy/rules/traverse.py
@@ -1,5 +1,5 @@
 # Strategies to traverse a Tree
-from util import new, is_leaf, children
+from util import new, is_leaf
 
 def top_down(rule):
     """ Apply a rule down an AST running it on the top nodes first """
@@ -7,7 +7,7 @@ def top_down(rule):
         newexpr = rule(expr)
         if is_leaf(newexpr):
             return newexpr
-        return new(type(newexpr), *map(top_down_rl, children(newexpr)))
+        return new(type(newexpr), *map(top_down_rl, newexpr.args))
     return top_down_rl
 
 def bottom_up(rule):
@@ -16,5 +16,5 @@ def bottom_up(rule):
         if is_leaf(expr):
             return rule(expr)
         else:
-            return rule(new(type(expr), *map(bottom_up_rl, children(expr))))
+            return rule(new(type(expr), *map(bottom_up_rl, expr.args)))
     return bottom_up_rl

--- a/sympy/rules/util.py
+++ b/sympy/rules/util.py
@@ -1,3 +1,9 @@
 from sympy import Basic
 
 new = Basic.__new__
+
+def is_leaf(x):
+    return not isinstance(x, Basic) or x.is_Atom
+
+def children(x):
+    return x.args

--- a/sympy/rules/util.py
+++ b/sympy/rules/util.py
@@ -4,6 +4,3 @@ new = Basic.__new__
 
 def is_leaf(x):
     return not isinstance(x, Basic) or x.is_Atom
-
-def children(x):
-    return x.args


### PR DESCRIPTION
Removes SymPy dependence from traverse.py

This allows rules to be used with a wider set of data structures. 
