### PR TITLE
Assumptions on non-atomic args in predictates

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -100,9 +100,6 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     if assumptions is True:
         return
 
-    if not expr.is_Atom:
-        return
-
     local_facts = _extract_facts(assumptions, expr)
     if local_facts is None or local_facts is True:
         return

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -1,4 +1,4 @@
-from sympy import MatrixSymbol, Q, ask, Identity, ZeroMatrix
+from sympy import MatrixSymbol, Q, ask, Identity, ZeroMatrix, Trace
 
 X = MatrixSymbol('X', 2, 2)
 Y = MatrixSymbol('Y', 2, 3)
@@ -75,3 +75,6 @@ def test_diagonal():
                Q.diagonal(Z)) is True
     assert ask(Q.diagonal(ZeroMatrix(3, 3)))
     assert ask(Q.lower_triangular(X) & Q.upper_triangular(X), Q.diagonal(X))
+
+def test_non_atoms():
+    assert ask(Q.real(Trace(X)), Q.positive(Trace(X)))


### PR DESCRIPTION
Removed the following lines from ask.py

```
if not expr.is_Atom:
    return None
```

This stopped things like the following from working

```
ask(Q.real(Trace(X)), Q.positive(Trace(X)))
```

Because it would return None if all it had were non-atomic arguments in applied predicates. 

This fixes an error with #1633 so I'd like to get it in quickly. I put it here because I don't know much about assumptions and I felt that this was easier to review. 
