### PR TITLE
Don't use 'import *' in test_sympy_parser.py

### DIFF
--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -1,7 +1,9 @@
+from sympy.core import Symbol, Float, Rational, Integer, I
+from sympy.functions import exp, factorial
+
 from sympy.parsing.sympy_parser import (
     parse_expr, standard_transformations, rationalize, TokenError
 )
-from sympy import *
 
 def test_sympy_parser():
     x = Symbol('x')


### PR DESCRIPTION
Fixes a major annoyance introduced in #1546 when using py.test. 

Plus, it's better style.
