### PR TITLE
remove tests of deprecated compile_rule

### DIFF
--- a/sympy/abc.py
+++ b/sympy/abc.py
@@ -9,4 +9,51 @@ _greek = 'alpha beta gamma delta epsilon zeta eta theta iota kappa lamda '\
 for _s in _latin + _greek:
     exec "%s = Symbol('%s')" % (_s, _s)
 
-del _latin, _greek, _s
+def clashing():
+    """Return the clashing-symbols dictionaries.
+
+    ``clash1`` defines all the single letter variables that clash with
+    SymPy objects; ``clash2`` defines the multi-letter clashing symbols;
+    and ``clash`` is the union of both. These can be passed for ``locals``
+    during sympification if one desires Symbols rather than the non-Symbol
+    objects for those names.
+
+    Examples
+    ========
+
+    >>> from sympy import S
+    >>> from sympy.abc import _clash1, _clash2, _clash
+    >>> S("Q & C", locals=_clash1)
+    And(C, Q)
+    >>> S('pi(x)', locals=_clash2)
+    pi(x)
+    >>> S('pi(C, Q)', locals=_clash)
+    pi(C, Q)
+
+    Note: if changes are made to the docstring examples they can only
+    be tested after removing "clashing" from the list of deleted items
+    at the bottom of this file which removes this function from the
+    namespace.
+    """
+
+    ns = {}
+    exec 'from sympy import *' in ns
+
+    clash1 = {}
+    clash2 = {}
+    while ns:
+        k, _ = ns.popitem()
+        if k in _greek:
+            clash2[k] = Symbol(k)
+            _greek.remove(k)
+        elif k in _latin:
+            clash1[k] = Symbol(k)
+            _latin.remove(k)
+    clash = {}
+    clash.update(clash1)
+    clash.update(clash2)
+    return clash1, clash2, clash
+
+_clash1, _clash2, _clash = clashing()
+
+del _latin, _greek, _s, clashing, Symbol

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -63,6 +63,45 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     ...
     SympifyError: SympifyError: "could not parse u'x***2'"
 
+    Locals
+    ------
+
+    The sympification happens with access to everything that is loaded
+    by ``from sympy import *``; if anything is used in the expression to be
+    sympified that is not defined by that import then it will be converted
+    to a symbol. In the following, the ``bitcout`` function is treated as
+    a symbol and the ``O`` is interpreted as the default Order shorthand
+    (and raises an error because it is being used improperly):
+
+    >>> s = 'bitcount(42)'
+    >>> sympify(s)
+    bitcount(42)
+    >>> sympify("O + 1")
+    Traceback (most recent call last):
+    ...
+    TypeError: unbound method...
+
+    In order to have ``bitcount`` be recognized it can be imported into a
+    namespace dictionary and passed as locals:
+
+    >>> ns = {}
+    >>> exec 'from sympy.core.evalf import bitcount' in ns
+    >>> sympify(s, locals=ns)
+    6
+
+    In order to have the ``O`` interpreted as a Symbol, identify it as such
+    in the namespace dictionary. This can be done in a variety of ways; all
+    three of the following are possibilities:
+
+    >>> from sympy import Symbol
+    >>> ns["O"] = Symbol("O")  # method 1
+    >>> exec 'from sympy.abc import O' in ns  # method 2
+    >>> ns.update(dict(O=Symbol("O")))  # method 3
+    >>> sympify("O + 1", locals=ns)
+    O + 1
+
+    Strict
+    ------
 
     If the option ``strict`` is set to ``True``, only the types for which an
     explicit conversion has been defined are converted. In the other
@@ -74,6 +113,9 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: True
+
+    Extending
+    ---------
 
     To extend ``sympify`` to convert custom objects (not derived from ``Basic``),
     just define a ``_sympy_`` method to your class. You can do that even to

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -100,6 +100,18 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     >>> sympify("O + 1", locals=ns)
     O + 1
 
+    If you want *all* single-letter and Greek-letter variables to be symbols
+    then you can use the clashing-symbols dictionaries that have been defined
+    there as private variables: _clash1 (single-letter variables), _clash2
+    (the multi-letter Greek names) or _clash (both single and multi-letter
+    names that are defined in abc).
+
+    >>> from sympy.abc import _clash1
+    >>> _clash1
+    {'C': C, 'E': E, 'I': I, 'N': N, 'O': O, 'Q': Q, 'S': S}
+    >>> sympify('C & Q', _clash1)
+    And(C, Q)
+
     Strict
     ------
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -67,15 +67,17 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     ------
 
     The sympification happens with access to everything that is loaded
-    by ``from sympy import *``; if anything is used in the expression to be
-    sympified that is not defined by that import then it will be converted
-    to a symbol. In the following, the ``bitcout`` function is treated as
-    a symbol and the ``O`` is interpreted as the default Order shorthand
-    (and raises an error because it is being used improperly):
+    by ``from sympy import *``; anything used in a string that is not
+    defined by that import will be converted to a symbol. In the following,
+    the ``bitcout`` function is treated as a symbol and the ``O`` is
+    interpreted as the Order object (used with series) and it raises
+    an error when used improperly:
 
     >>> s = 'bitcount(42)'
     >>> sympify(s)
     bitcount(42)
+    >>> sympify("O(x)")
+    O(x)
     >>> sympify("O + 1")
     Traceback (most recent call last):
     ...

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -457,7 +457,7 @@ def test_issue_3441_3453():
 def test_issue_2497():
     assert str(S("Q & C", locals=_clash1)) == 'And(C, Q)'
     assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'
-    assert str(S('gamma(C, Q)', locals=_clash)) == 'gamma(C, Q)'
+    assert str(S('pi(C, Q)', locals=_clash)) == 'pi(C, Q)'
     locals = {}
     exec "from sympy.abc import Q, C" in locals
     assert str(S('C&Q', locals)) == 'And(C, Q)'

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -452,3 +452,8 @@ def test_issue_3441_3453():
     assert S('[[2/6,2], (2/4,)]') == [[Rational(1, 3), 2], (Rational(1, 2),)]
     assert S('[[[2*(1)]]]') == [[[2]]]
     assert S('Matrix([2*(1)])') == Matrix([2])
+
+def test_issue_2497():
+    locals = {}
+    exec "from sympy.abc import Q, C" in locals
+    assert str(S('C&Q', locals)) == 'And(C, Q)'

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -8,6 +8,7 @@ from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.decorator import conserve_mpmath_dps
 from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
+from sympy.abc import _clash, _clash1, _clash2
 
 from sympy import mpmath
 
@@ -454,6 +455,9 @@ def test_issue_3441_3453():
     assert S('Matrix([2*(1)])') == Matrix([2])
 
 def test_issue_2497():
+    assert str(S("Q & C", locals=_clash1)) == 'And(C, Q)'
+    assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'
+    assert str(S('gamma(C, Q)', locals=_clash)) == 'gamma(C, Q)'
     locals = {}
     exec "from sympy.abc import Q, C" in locals
     assert str(S('C&Q', locals)) == 'And(C, Q)'

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,14 +1,14 @@
 from sympy import symbols, sympify, Dummy
 from sympy.logic.boolalg import (
     And, Boolean, Equivalent, ITE, Implies, Nand, Nor, Not, Or, POSform,
-    SOPform, Xor, compile_rule, conjuncts, disjuncts,
+    SOPform, Xor, conjuncts, disjuncts,
     distribute_and_over_or, eliminate_implications, is_cnf,
     simplify_logic, to_cnf, to_int_repr
 )
 from sympy.utilities.pytest import raises
 
 
-A, B, C, Q = symbols('A,B,C,Q')
+A, B, C = symbols('A,B,C')
 
 
 def test_overloading():
@@ -282,11 +282,6 @@ def test_to_cnf():
     assert to_cnf(Equivalent(A, B & C)) == (~A | B) & (~A | C) & (~B | ~C | A)
     assert to_cnf(Equivalent(A, B | C)) == \
         And(Or(Not(B), A), Or(Not(C), A), Or(B, C, Not(A)))
-
-
-def test_compile_rule():
-    assert compile_rule("A & B") == sympify("A & B")
-    assert compile_rule("C & Q") == And(C, Q)  # this would fail with sympify
 
 
 def test_to_int_repr():


### PR DESCRIPTION
The testing of the deprecated function emits warnings during testing, so tests for it were removed.
