### PR TITLE
Refactor the testing for "def test_" in test files.

### DIFF
--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -527,7 +527,7 @@ def test_issue_1460():
 
     # Note that solve will give
     # multiple roots but match only gives one:
-    # 
+    #
     # >>> solve(x**r-y**2,y)
     # [-x**(r/2), x**(r/2)]
 

--- a/sympy/matrices/expressions/tests/test_adjoint.py
+++ b/sympy/matrices/expressions/tests/test_adjoint.py
@@ -24,4 +24,3 @@ def test_adjoint():
     assert Trace(Adjoint(Sq)) == conjugate(Trace(Sq))
 
     assert Adjoint(Sq)[0, 1] == conjugate(Sq[1, 0])
-

--- a/sympy/rules/tests/test_tools.py
+++ b/sympy/rules/tests/test_tools.py
@@ -8,4 +8,3 @@ def test_subs():
     expr   = Basic(a, Basic(b, c), Basic(d, Basic(e)))
     result = Basic(d, Basic(b, c), Basic(a, Basic(f)))
     assert subs(mapping)(expr) == result
-


### PR DESCRIPTION
Currently, for files matching `test_*.py`, each lines are first tested for the proper `def test_`, and then the file isn't rewinded before each lines are tested again for all the remaining code quality issues. Here I refactor the test so that the `def test_` test and all the other code quality tests are done in one go through the file.
