### PR TITLE
Fix issue 3503

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -676,7 +676,7 @@ class Ci(TrigonometricIntegral):
 
     _trigfunc = C.cos
     _atzero = S.ComplexInfinity
-    _atinf = 0
+    _atinf = S.Zero
     _atneginf = I*pi
 
     @classmethod

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -474,6 +474,11 @@ class TrigonometricIntegral(Function):
     def eval(cls, z):
         if z == 0:
             return cls._atzero
+        elif z is S.Infinity:
+            return cls._atinf
+        elif z is S.NegativeInfinity:
+            return cls._atneginf
+
         nz = z.extract_multiplicatively(polar_lift(I))
         if nz is None and cls._trigfunc(0) == 0:
             nz = z.extract_multiplicatively(I)
@@ -581,6 +586,8 @@ class Si(TrigonometricIntegral):
 
     _trigfunc = C.sin
     _atzero = S(0)
+    _atinf = pi*S.Half
+    _atneginf = -pi*S.Half
 
     @classmethod
     def _minusfactor(cls, z):
@@ -669,6 +676,8 @@ class Ci(TrigonometricIntegral):
 
     _trigfunc = C.cos
     _atzero = S.ComplexInfinity
+    _atinf = 0
+    _atneginf = I*pi
 
     @classmethod
     def _minusfactor(cls, z):
@@ -740,6 +749,8 @@ class Shi(TrigonometricIntegral):
 
     _trigfunc = C.sinh
     _atzero = S(0)
+    _atinf = S.Infinity
+    _atneginf = S.NegativeInfinity
 
     @classmethod
     def _minusfactor(cls, z):
@@ -824,6 +835,8 @@ class Chi(TrigonometricIntegral):
 
     _trigfunc = C.cosh
     _atzero = S.ComplexInfinity
+    _atinf = S.Infinity
+    _atneginf = S.Infinity
 
     @classmethod
     def _minusfactor(cls, z):

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -192,6 +192,11 @@ def test_si():
     assert Shi(exp_polar(2*pi*I)*x) == Shi(x)
     assert Shi(exp_polar(-2*pi*I)*x) == Shi(x)
 
+    assert Si(oo) == pi/2
+    assert Si(-oo) == -pi/2
+    assert Shi(oo) == oo
+    assert Shi(-oo) == -oo
+
     assert mytd(Si(x), sin(x)/x, x)
     assert mytd(Shi(x), sinh(x)/x, x)
 
@@ -237,6 +242,11 @@ def test_ci():
     assert Chi(exp_polar(-2*I*pi)*x) == Chi(x) - 2*I*pi
     assert Chi(exp_polar(2*I*pi)*x) == Chi(x) + 2*I*pi
     assert Ci(exp_polar(-2*I*pi)*x) == Ci(x) - 2*I*pi
+
+    assert Ci(oo) == 0
+    assert Ci(-oo) == I*pi
+    assert Chi(oo) == oo
+    assert Chi(-oo) == oo
 
     assert mytd(Ci(x), cos(x)/x, x)
     assert mytd(Chi(x), cosh(x)/x, x)


### PR DESCRIPTION
Fix Issue 3503: Special values for Si are not implemented.

This fix adds values for Si, Ci, Shi, Chi at oo and -oo.
