### PR TITLE
3512: watch for Rational in Mul.flatten

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -408,8 +408,8 @@ class Mul(Expr, AssocOp):
             grow = []
             for j in range(i + 1, len(num_rat)):
                 bj, ej = num_rat[j]
-                g = igcd(bi, bj)
-                if g != 1:
+                g = _rgcd(bi, bj)
+                if g is not S.One:
                     # 4**r1*6**r2 -> 2**(r1+r2)  *  2**r1 *  3**r2
                     # this might have a gcd with something else
                     e = ei + ej
@@ -422,9 +422,9 @@ class Mul(Expr, AssocOp):
                             e = Rational(ep, e.q)
                         grow.append((g, e))
                     # update the jth item
-                    num_rat[j] = (bj//g, ej)
+                    num_rat[j] = (bj/g, ej)
                     # update bi that we are checking with
-                    bi = bi//g
+                    bi = bi/g
                     if bi is S.One:
                         break
             if bi is not S.One:
@@ -1493,6 +1493,9 @@ def _keep_coeff(coeff, factors, clear=True):
     else:
         return coeff*factors
 
-from numbers import Rational, igcd
+from numbers import Rational, igcd, ilcm, Integer
+def _rgcd(a, b):
+    return Rational(Integer(igcd(a.p, b.p)), Integer(ilcm(a.q, b.q)))
+
 from power import Pow
 from add import Add

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1398,3 +1398,8 @@ def test_float_int():
 
     assert int(12345678901234567890 + cos(1)**2 + sin(1)**2) == \
         12345678901234567891
+
+def test_issue_3512a():
+    assert Mul.flatten([3**Rational(1, 3),
+        Pow(-Rational(1, 9), Rational(2, 3), evaluate=False)]) == \
+        ([Rational(1, 3), (-1)**Rational(2, 3)], [], None)

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1077,10 +1077,3 @@ def test_issue_3506():
     assert solve(5**(x/2) - 2**(x/3)) == [0]
     b = sqrt(6)*sqrt(log(2))/sqrt(log(5))
     assert solve(5**(x/2) - 2**(3/x)) == [-b, b]
-
-def test_issue_3512():
-    ans = solve([x**2 + y**2 -4, y - x**3], x, y, manual=True)
-    assert [NS(ai, 3) for a in ans for ai in a] == [
-        '1.2', '1.6', '-0.71 - 1.1*I', '2.2 - 0.35*I',
-        '-0.71 + 1.1*I', '2.2 + 0.35*I', '0.71 + 1.1*I',
-        '-2.2 + 0.35*I', '0.71 - 1.1*I', '-2.2 - 0.35*I']

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1077,3 +1077,10 @@ def test_issue_3506():
     assert solve(5**(x/2) - 2**(x/3)) == [0]
     b = sqrt(6)*sqrt(log(2))/sqrt(log(5))
     assert solve(5**(x/2) - 2**(3/x)) == [-b, b]
+
+def test_issue_3512():
+    ans = solve([x**2 + y**2 -4, y - x**3], x, y, manual=True)
+    assert [NS(ai, 3) for a in ans for ai in a] == [
+        '1.2', '1.6', '-0.71 - 1.1*I', '2.2 - 0.35*I',
+        '-0.71 + 1.1*I', '2.2 + 0.35*I', '0.71 + 1.1*I',
+        '-2.2 + 0.35*I', '0.71 - 1.1*I', '-2.2 - 0.35*I']


### PR DESCRIPTION
I'm not sure why the code was expecting an Integer...the inlines show that it can be a Rational so I just changed the calculation of g. Using gcd is extremely slow; it should be much faster:

```

>>> timeit('gcd(S.Half,S.Half/2)','from sympy import S,gcd',number=1000)0.52889084815979
>>> timeit('S.Half.gcd(S.Half/2)','from sympy import S',number=1000)0.4783451557159424
>>> timeit('Rational(igcd(a.p,b.p),ilcm(a.q,b.q)),S.Half,S.Half/2','from sympy import S,igcd,ilcm,Rational\na=S.Half;b=a/2',number=1000)
0.05117201805114746
```
