### PR TITLE
Make Matrix sympifiable.

### DIFF
--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -67,7 +67,11 @@ def __sympifyit(func, arg, retval=None):
         @wraps(func)
         def __sympifyit_wrapper(a, b):
             try:
-                return func(a, sympify(b, strict=True))
+                # If an external class has _op_priority, it knows how to deal
+                # with sympy objects. Otherwise, it must be converted.
+                if not hasattr(b, '_op_priority'):
+                    b = sympify(b, strict=True)
+                return func(a, b)
             except SympifyError:
                 return retval
 

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -26,8 +26,8 @@ class DenseMatrix(MatrixBase):
 
     is_MatrixExpr = False
 
-    _op_priority = 12.0
-    _class_priority = 10
+    _op_priority = 10.01
+    _class_priority = 4
 
     def __getitem__(self, key):
         """Return portion of self defined by key. If the key involves a slice

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -1,9 +1,26 @@
-from sympy import Symbol, sympify, Tuple, Integer
-from sympy.core.basic import Basic
-from sympy.core.decorators import _sympifyit, call_highest_priority
-from sympy.core.singleton import S
+from functools import wraps
+
+from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic
+from sympy.core.decorators import call_highest_priority
+from sympy.core.sympify import SympifyError
 from sympy.matrices import ShapeError
 from sympy.simplify import simplify
+
+
+def _sympifyit(arg, retval=None):
+    # This version of _sympifyit sympifies MutableMatrix objects
+    def deco(func):
+        @wraps(func)
+        def __sympifyit_wrapper(a, b):
+            try:
+                b = sympify(b, strict=True)
+                return func(a, b)
+            except SympifyError:
+                return retval
+
+        return __sympifyit_wrapper
+
+    return deco
 
 
 class MatrixExpr(Basic):

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,9 +1,15 @@
-from matrices import MatrixBase
-from dense import DenseMatrix
-from sparse import SparseMatrix, MutableSparseMatrix
-from expressions import MatrixExpr
-from sympy import Basic, Integer, Tuple, Dict
+from sympy.core import Basic, Integer, Tuple, Dict
+from sympy.core.sympify import converter as sympify_converter
 
+from sympy.matrices.matrices import MatrixBase
+from sympy.matrices.dense import DenseMatrix
+from sympy.matrices.sparse import SparseMatrix, MutableSparseMatrix
+from sympy.matrices.expressions import MatrixExpr
+
+
+def sympify_matrix(arg):
+    return ImmutableMatrix(arg)
+sympify_converter[MatrixBase] = sympify_matrix
 
 class ImmutableMatrix(MatrixExpr, DenseMatrix):
     """Create an immutable version of a matrix.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -78,9 +78,6 @@ class MatrixBase(object):
     is_Identity = None
     _class_priority = 3
 
-    def _sympy_(self):
-        raise SympifyError('Matrix cannot be sympified')
-
     @classmethod
     def _handle_creation_inputs(cls, *args, **kwargs):
         """Return the number of rows, cols and flat matrix elements.
@@ -2738,7 +2735,7 @@ class MatrixBase(object):
         flags.pop('rational', None)
 
         for r, k in vlist:
-            tmp = self - eye(self.rows)*r
+            tmp = self.as_mutable() - eye(self.rows)*r
             basis = tmp.nullspace()
             # whether tmp.is_symbolic() is True or False, it is possible that
             # the basis will come back as [] in which case simplification is
@@ -3494,9 +3491,9 @@ class MatrixBase(object):
 
 def classof(A, B):
     """
-    Determines strategy for combining Immutable and Mutable matrices
+    Get the type of the result when combining matrices of different types.
 
-    Currently the strategy is that Mutability is contagious
+    Currently the strategy is that immutability is contagious.
 
     Examples
     ========
@@ -3506,7 +3503,7 @@ def classof(A, B):
     >>> M = Matrix([[1, 2], [3, 4]]) # a Mutable Matrix
     >>> IM = ImmutableMatrix([[1, 2], [3, 4]])
     >>> classof(M, IM)
-    <class 'sympy.matrices.dense.MutableDenseMatrix'>
+    <class 'sympy.matrices.immutable.ImmutableMatrix'>
     """
     try:
         if A._class_priority > B._class_priority:

--- a/sympy/matrices/tests/test_interactions.py
+++ b/sympy/matrices/tests/test_interactions.py
@@ -8,6 +8,7 @@ Here we test the extent to which they cooperate
 from sympy import symbols
 from sympy.matrices import (Matrix, MatrixSymbol, eye, Identity,
         ImmutableMatrix)
+from sympy.matrices.expressions import MatrixExpr, MatAdd
 from sympy.matrices.matrices import classof
 from sympy.utilities.pytest import raises
 
@@ -21,16 +22,16 @@ a, b, c = symbols('a,b,c')
 
 
 def test_IM_MM():
-    assert (MM + IM).__class__ is Matrix
-    assert (IM + MM).__class__ is Matrix
-    assert (2*IM + MM).__class__ is Matrix
+    assert isinstance(MM + IM, ImmutableMatrix)
+    assert isinstance(IM + MM, ImmutableMatrix)
+    assert isinstance(2*IM + MM, ImmutableMatrix)
     assert MM.equals(IM)
 
 
 def test_ME_MM():
-    assert (Identity(3) + MM).__class__ is Matrix
-    assert (SM + MM).__class__ is Matrix
-    assert (MM + SM).__class__ is Matrix
+    assert isinstance(Identity(3) + MM, MatrixExpr)
+    assert isinstance(SM + MM, MatAdd)
+    assert isinstance(MM + SM, MatAdd)
     assert (Identity(3) + MM)[1, 1] == 6
 
 
@@ -60,5 +61,6 @@ def test_classof():
     C = MatrixSymbol('C', 3, 3)
     assert classof(A, A) == Matrix
     assert classof(B, B) == ImmutableMatrix
-    assert classof(A, B) == Matrix
+    assert classof(A, B) == ImmutableMatrix
+    assert classof(B, A) == ImmutableMatrix
     raises(TypeError, lambda: classof(A, C))


### PR DESCRIPTION
- sympify(<Matrix>) now returns an ImmutableMatrix
- for consistency with general sympy conventions, this forces
  <MutableMatrix> + <ImmutableMatrix> -> ImmutableMatrix.
- Some hacking of arithmetic operator dispatch is required to
  still get scalar \* MutableMatrix -> MutableMatrix
