### PR TITLE
iterables fixes, edits and coverage

### DIFF
--- a/doc/src/modules/simplify/simplify.rst
+++ b/doc/src/modules/simplify/simplify.rst
@@ -91,10 +91,6 @@ sqrtdenest
 ^^^^^^^^^^
 .. autofunction:: sqrtdenest
 
-subsets
-^^^^^^^
-.. autofunction:: subsets
-
 Common Subexpresion Elimination
 -------------------------------
 .. module:: sympy.simplify.cse_main

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -408,5 +408,5 @@ def graycode_subsets(gray_code_set):
     ========
     get_subset_from_bitstring
     """
-    return [get_subset_from_bitstring(gray_code_set, bitstring) for
-            bitstring in list(GrayCode(len(gray_code_set)).generate_gray())]
+    for bitstring in list(GrayCode(len(gray_code_set)).generate_gray()):
+        yield get_subset_from_bitstring(gray_code_set, bitstring)

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1023,7 +1023,7 @@ class Permutation(Basic):
                     unchecked[j] = False
                 if len(cycle) > 1:
                     cyclic_form.append(cycle)
-                    assert cycle == list(minlex(cycle))
+                    assert cycle == list(minlex(cycle, is_set=True))
         cyclic_form.sort()
         self._cyclic_form = cyclic_form[:]
         return cyclic_form

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -373,7 +373,7 @@ class Polyhedron(Basic):
         [1] www.ocf.berkeley.edu/~wwu/articles/platonicsolids.pdf
 
         """
-        faces = [minlex(f, directed=False) for f in faces]
+        faces = [minlex(f, directed=False, is_set=True) for f in faces]
         corners, faces, pgroup = args = \
             [Tuple(*a) for a in (corners, faces, pgroup)]
         obj = Basic.__new__(cls, *args)
@@ -677,8 +677,9 @@ def _pgroup_calcs():
             # enumerating the faces
             reorder = unflatten([c[j] for j in flat_faces], n)
             # make them canonical
-            reorder = [tuple(map(as_int, minlex(f, directed=False)))
-                for f in reorder]
+            reorder = [tuple(map(as_int,
+                       minlex(f, directed=False, is_set=True)))
+                       for f in reorder]
             # map face to vertex: the resulting list of vertices are the
             # permutation that we seek for the double
             new_pgroup.append(Perm([fmap[f] for f in reorder]))

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -81,12 +81,9 @@ class Subset(Basic):
         next_binary, prev_binary
         """
         bin_list = Subset.bitlist_from_subset(self.subset, self.superset)
-        next_bin_list = list(bin((int(reduce(lambda x, y:
-                                             x + y, bin_list), 2) + k)
-                                 % 2**self.superset_size))[2:]
-        next_bin_list = [0] * (self.superset_size - len(next_bin_list)) + \
-            next_bin_list
-        return Subset.subset_from_bitlist(self.superset, next_bin_list)
+        n = (int(''.join(bin_list), 2) + k) % 2**self.superset_size
+        bits = bin(n)[2:].rjust(self.superset_size, '0')
+        return Subset.subset_from_bitlist(self.superset, bits)
 
     def next_binary(self):
         """
@@ -443,9 +440,8 @@ class Subset(Basic):
         ========
         iterate_binary, rank_binary
         """
-        bin_list = list(bin(rank))[2:]
-        bin_list = [0] * (len(superset) - len(bin_list)) + bin_list
-        return Subset.subset_from_bitlist(superset, bin_list)
+        bits = bin(rank)[2:].rjust(len(superset), '0')
+        return Subset.subset_from_bitlist(superset, bits)
 
     @classmethod
     def unrank_gray(self, rank, superset):

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -456,8 +456,11 @@ def as_int(n):
     ValueError: ... is not an integer
 
     """
-    result = int(n)
-    if result != n:
+    try:
+        result = int(n)
+        if result != n:
+            raise TypeError
+    except TypeError:
         raise ValueError('%s is not an integer' % n)
     return result
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -3,13 +3,15 @@ from math import log as _log
 from sympify import _sympify
 from cache import cacheit
 from core import C
-from sympy.core.function import (_coeff_isneg, expand_complex,
-    expand_multinomial, expand_mul)
-from sympy.core.logic import fuzzy_bool
 from singleton import S
 from expr import Expr
 
-from sympy import mpmath
+from sympy.core.function import (_coeff_isneg, expand_complex,
+    expand_multinomial, expand_mul)
+from sympy.core.logic import fuzzy_bool
+from sympy.core.compatibility import as_int
+
+from sympy.mpmath.libmp import sqrtrem as mpmath_sqrtrem
 from sympy.utilities.iterables import sift
 
 
@@ -36,7 +38,7 @@ def integer_nthroot(y, n):
     if n == 1:
         return y, True
     if n == 2:
-        x, rem = mpmath.libmp.sqrtrem(y)
+        x, rem = mpmath_sqrtrem(y)
         return int(x), not rem
     if n > y:
         return 1, False
@@ -252,18 +254,25 @@ class Pow(Expr):
 
     def _eval_subs(self, old, new):
         if old.func is self.func and self.base == old.base:
-            coeff1, terms1 = self.exp.as_coeff_Mul()
-            coeff2, terms2 = old.exp.as_coeff_Mul()
+            coeff1, terms1 = self.exp.as_independent(C.Symbol, as_Add=False)
+            coeff2, terms2 = old.exp.as_independent(C.Symbol, as_Add=False)
             if terms1 == terms2:
                 pow = coeff1/coeff2
-                if pow == int(pow) or self.base.is_positive:
+                ok = False  # True if int(pow) == pow OR self.base.is_positive
+                try:
+                    pow = as_int(pow)
+                    ok = True
+                except ValueError:
+                    ok = self.base.is_positive
+                if ok:
                     # issue 2081
                     return Pow(new, pow)  # (x**(6*y)).subs(x**(3*y),z)->z**2
         if old.func is C.exp and self.exp.is_real and self.base.is_positive:
-            coeff1, terms1 = old.args[0].as_coeff_Mul()
+            coeff1, terms1 = old.args[0].as_independent(C.Symbol, as_Add=False)
             # we can only do this when the base is positive AND the exponent
             # is real
-            coeff2, terms2 = (self.exp*C.log(self.base)).as_coeff_Mul()
+            coeff2, terms2 = (self.exp*C.log(self.base)).as_independent(
+                C.Symbol, as_Add=False)
             if terms1 == terms2:
                 pow = coeff1/coeff2
                 if pow == int(pow) or self.base.is_positive:

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, as_int
 from sympy.core.singleton import S
 from sympy.utilities.pytest import raises
 
@@ -8,3 +8,8 @@ from sympy.abc import x
 def test_default_sort_key():
     func = lambda x: x
     assert sorted([func, x, func], key=default_sort_key) == [func, func, x]
+
+
+def test_as_int():
+    raises(ValueError, lambda : as_int(1.1))
+    raises(ValueError, lambda : as_int([]))

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -554,3 +554,10 @@ def test_issue_3460():
     e = -log(-12*sqrt(2) + 17)/24 - log(-2*sqrt(2) + 3)/12 + sqrt(2)/3
     assert cse(e) == (
         [(x0, -sqrt(2))], [-x0/3 - log(2*x0 + 3)/12 - log(12*x0 + 17)/24])
+
+def test_issue_2162():
+    e = I*x
+    assert exp(e).subs(exp(x), y) == y**I
+    assert (2**e).subs(2**x, y) == y**I
+    eq = (-2)**e
+    assert eq.subs((-2)**x, y) == eq

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -342,8 +342,10 @@ class exp(ExpBase):
             o = exp(o.exp*log(o.base))
         if o.func is exp:
             # exp(a*expr) .subs( exp(b*expr), y )  ->  y ** (a/b)
-            a, expr_terms = self.args[0].as_coeff_mul()
-            b, expr_terms_ = o.args[0].as_coeff_mul()
+            a, expr_terms = self.args[0].as_independent(
+                C.Symbol, as_Add=False)
+            b, expr_terms_ = o.args[0].as_independent(
+                C.Symbol, as_Add=False)
 
             if expr_terms == expr_terms_:
                 return new**(a/b)
@@ -367,8 +369,8 @@ class exp(ExpBase):
                     return r
         if o is S.Exp1:
             # treat this however Pow is being treated
-            u = C.Dummy('u')
-            return (u**self.args[0]).subs(u, new)
+            u = C.Dummy('u', positive=True)
+            return (u**self.args[0]).xreplace({u: new})
 
         return Function._eval_subs(self, o, new)
 

--- a/sympy/physics/quantum/shor.py
+++ b/sympy/physics/quantum/shor.py
@@ -13,7 +13,7 @@ import random
 from sympy import Mul, S
 from sympy import log, sqrt
 from sympy.core.numbers import igcd
-from sympy.core.compatibility import bin
+from sympy.utilities.iterables import variations
 
 from sympy.physics.quantum.gate import Gate
 from sympy.physics.quantum.qubit import Qubit, measure_partial_oneshot
@@ -107,25 +107,6 @@ def shor(N):
     return answer
 
 
-def arr(num, t):
-    """Return a list of ``t`` binary digits of ``num``; low digits rightmost.
-
-    Examples
-    ========
-    >>> from sympy.physics.quantum.shor import arr
-    >>> arr(5, 6)
-    [0, 0, 0, 1, 0, 1]
-    >>> arr(5, 2)
-    [0, 1]
-    """
-    binary_array = [0]*t
-    b = list(bin(abs(num))[2:])  # strip 0b
-    b = b[-t:]
-    for i in range(-1, -min(len(b), t) - 1, -1):
-        binary_array[i] = int(b[i])
-    return binary_array
-
-
 def getr(x, y, N):
     fraction = continued_fraction(x, y)
     # Now convert into r
@@ -177,8 +158,8 @@ def period_find(a, N):
     #Put second half into superposition of states so we have |1>x|0> + |2>x|0> + ... |k>x>|0> + ... + |2**n-1>x|0>
     factor = 1/sqrt(2**t)
     qubits = 0
-    for i in range(2**t):
-        qbitArray = arr(i, t) + start
+    for arr in variations(range(2), t, repetition=True):
+        qbitArray = arr + start
         qubits = qubits + Qubit(*qbitArray)
     circuit = (factor*qubits).expand()
     #Controlled second half of register so that we have:

--- a/sympy/physics/quantum/tests/test_shor.py
+++ b/sympy/physics/quantum/tests/test_shor.py
@@ -3,7 +3,7 @@ from sympy.utilities.pytest import XFAIL
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.qubit import Qubit
 from sympy.physics.quantum.shor import (
-    CMod, continued_fraction, getr, arr
+    CMod, continued_fraction, getr
 )
 
 
@@ -24,6 +24,3 @@ def test_continued_frac():
     assert getr(513, 1024, 10) == 2
     assert getr(169, 1024, 11) == 6
     assert getr(314, 4096, 16) == 13
-    assert arr(5, 3) == [1, 0, 1]
-    assert arr(4, 3) == [1, 0, 0]
-    assert arr(8, 5) == [0, 1, 0, 0, 0]

--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -58,10 +58,7 @@ def together(expr, deep=False):
     """
     def _together(expr):
         if isinstance(expr, Basic):
-            if expr.is_commutative is False:
-                numer, denom = expr.as_numer_denom()
-                return numer/denom
-            elif expr.is_Atom or (expr.is_Function and not deep):
+            if expr.is_Atom or (expr.is_Function and not deep):
                 return expr
             elif expr.is_Add:
                 return gcd_terms(map(_together, Add.make_args(expr)))

--- a/sympy/simplify/sqrtdenest.py
+++ b/sympy/simplify/sqrtdenest.py
@@ -73,7 +73,7 @@ def is_algebraic(p):
         return False
 
 
-def subsets(n):
+def _subsets(n):
     """
     Returns all possible subsets of the set (0, 1, ..., n-1) except the
     empty set, listed in reversed lexicographical order according to binary
@@ -82,8 +82,8 @@ def subsets(n):
     Examples
     ========
 
-    >>> from sympy.simplify.sqrtdenest import subsets
-    >>> subsets(2)
+    >>> from sympy.simplify.sqrtdenest import _subsets
+    >>> _subsets(2)
     [[1, 0], [0, 1], [1, 1]]
 
     """
@@ -95,7 +95,7 @@ def subsets(n):
         a = [[1, 0, 0], [0, 1, 0], [1, 1, 0],
              [0, 0, 1], [1, 0, 1], [0, 1, 1], [1, 1, 1]]
     else:
-        b = subsets(n - 1)
+        b = _subsets(n - 1)
         a0 = [x + [0] for x in b]
         a1 = [x + [1] for x in b]
         a = a0 + [[0]*(n - 1) + [1]] + a1
@@ -537,7 +537,7 @@ def _denester(nested, av0, h, max_depth_level):
         return None, None
     if (av0[0] is None and
             all(n.is_Number for n in nested)):  # no arguments are nested
-        for f in subsets(len(nested)):  # test subset 'f' of nested
+        for f in _subsets(len(nested)):  # test subset 'f' of nested
             p = _mexpand(Mul(*[nested[i] for i in range(len(f)) if f[i]]))
             if f.count(1) > 1 and f[-1]:
                 p = -p

--- a/sympy/simplify/tests/test_sqrtdenest.py
+++ b/sympy/simplify/tests/test_sqrtdenest.py
@@ -1,5 +1,5 @@
 from sympy import sqrt, root, S, Symbol, sqrtdenest, Integral, cos
-from sympy.simplify.sqrtdenest import subsets
+from sympy.simplify.sqrtdenest import _subsets as subsets
 
 r2, r3, r5, r6, r7, r10, r15, r29 = [sqrt(x) for x in [2, 3, 5, 6, 7, 10,
                                           15, 29]]

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -10,7 +10,7 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.compatibility import (
     as_int, combinations, combinations_with_replacement,
     default_sort_key, is_sequence, iterable, permutations,
-    product as cartes, ordered, next
+    product as cartes, ordered, next, bin
 )
 
 
@@ -360,6 +360,66 @@ def interactive_traversal(expr):
         return result
 
     return _interactive_traversal(expr, 0)
+
+
+def ibin(n, bits=0, str=False):
+    """Return a list of length ``bits`` corresponding to the binary value
+    of ``n`` with small bits to the right (last). If bits is omitted, the
+    length will be the number required to represent ``n``. If the bits are
+    desired in reversed order, use the [::-1] slice of the returned list.
+
+    If a sequence of all bits-length lists starting from [0, 0,..., 0]
+    through [1, 1, ..., 1] are desired, pass a non-integer for bits, e.g.
+    'all'.
+
+    If the bit *string* is desired pass ``str=True``.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import ibin, variations
+    >>> ibin(2)
+    [1, 0]
+    >>> ibin(2, 4)
+    [0, 0, 1, 0]
+    >>> ibin(2, 4)[::-1]
+    [0, 1, 0, 0]
+
+    If all lists corresponding to 0 to 2**n - 1, pass a non-integer
+    for bits:
+
+    >>> bits = 2
+    >>> for i in ibin(2, 'all'):
+    ...     print i
+    (0, 0)
+    (0, 1)
+    (1, 0)
+    (1, 1)
+
+    If a bit string is desired of a given length, use str=True:
+
+    >>> n = 123
+    >>> bits = 10
+    >>> ibin(n, bits, str=True)
+    '0001111011'
+    >>> ibin(n, bits, str=True)[::-1]  # small bits left
+    '1101111000'
+    >>> list(ibin(3, 'all', str=True))
+    ['000', '001', '010', '011', '100', '101', '110', '111']
+
+    """
+    if not str:
+        try:
+            bits = as_int(bits)
+            return [1 if i == "1" else 0 for i in bin(n)[2:].rjust(bits, "0")]
+        except ValueError:
+            return variations(range(2), n, repetition=True)
+    else:
+        try:
+            bits = as_int(bits)
+            return bin(n)[2:].rjust(bits, "0")
+        except ValueError:
+            return (bin(i)[2:].rjust(n, "0") for i in range(2**n))
 
 
 def variations(seq, n, repetition=False):

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -146,25 +146,32 @@ def reshape(seq, how):
     return type(seq)(rv)
 
 
-def group(container, multiple=True):
+def group(seq, multiple=True):
     """
-    Splits a container into a list of lists of equal, adjacent elements.
+    Splits a sequence into a list of lists of equal, adjacent elements.
+
+    Examples
+    ========
 
     >>> from sympy.utilities.iterables import group
 
     >>> group([1, 1, 1, 2, 2, 3])
     [[1, 1, 1], [2, 2], [3]]
-
     >>> group([1, 1, 1, 2, 2, 3], multiple=False)
     [(1, 3), (2, 2), (3, 1)]
+    >>> group([1, 1, 3, 2, 2, 1], multiple=False)
+    [(1, 2), (3, 1), (2, 2), (1, 1)]
 
+    See Also
+    ========
+    multiset
     """
-    if not container:
+    if not seq:
         return []
 
-    current, groups = [container[0]], []
+    current, groups = [seq[0]], []
 
-    for elem in container[1:]:
+    for elem in seq[1:]:
         if elem == current[-1]:
             current.append(elem)
         else:
@@ -180,6 +187,27 @@ def group(container, multiple=True):
         groups[i] = (current[0], len(current))
 
     return groups
+
+
+def multiset(seq):
+    """Return the hashable sequence in multiset form with values being the
+    multiplicity of the item in the sequence.
+
+    Examples
+    ========
+
+    >>> from sympy.utilities.iterables import multiset, group
+    >>> multiset('mississippi')
+    {'i': 4, 'm': 1, 'p': 2, 's': 4}
+
+    See Also
+    ========
+    group
+    """
+    rv = defaultdict(int)
+    for s in seq:
+        rv[s] += 1
+    return dict(rv)
 
 
 def postorder_traversal(node, keys=None):
@@ -790,7 +818,7 @@ def rotate_left(x, y):
     [1, 2, 0]
     """
     if len(x) == 0:
-        return x
+        return []
     y = y % len(x)
     return x[y:] + x[:y]
 
@@ -809,7 +837,7 @@ def rotate_right(x, y):
     [2, 0, 1]
     """
     if len(x) == 0:
-        return x
+        return []
     y = len(x) - y % len(x)
     return x[y:] + x[:y]
 
@@ -843,17 +871,20 @@ def multiset_combinations(m, n, g=None):
     if g is None:
         if type(m) is dict:
             if n > sum(m.values()):
-                yield []
-            g = [(k, m[k]) for k in ordered(m)]
+                return
+            g = [[k, m[k]] for k in ordered(m)]
         else:
             m = list(m)
             if n > len(m):
-                yield []
-            m = list(ordered(m))
-            g = [list(i) for i in group(m, multiple=False)]
-    def tot(g):
-        return sum(v for k, v in g)
-    if tot(g) < n or not n:
+                return
+            try:
+                m = multiset(m)
+                g = [(k, m[k]) for k in ordered(m)]
+            except TypeError:
+                m = list(ordered(m))
+                g = [list(i) for i in group(m, multiple=False)]
+        del m
+    if sum(v for k, v in g) < n or not n:
         yield []
     else:
         for i, (k, v) in enumerate(g):
@@ -867,7 +898,7 @@ def multiset_combinations(m, n, g=None):
                         yield rv
 
 
-def multiset_permutations(m, g=None):
+def multiset_permutations(m, k=None, g=None):
     """
     Return the unique permutations of multiset ``m``.
 
@@ -883,30 +914,36 @@ def multiset_permutations(m, g=None):
     >>> len(list(multiset_permutations('banana')))
     60
     """
+    size = k
     if g is None:
         if type(m) is dict:
-            g = [(k, m[k]) for k in ordered(m)]
+            g = [[k, m[k]] for k in ordered(m)]
         else:
             m = list(ordered(m))
             g = [list(i) for i in group(m, multiple=False)]
         del m
-    do = [gi for gi in g if gi[1]]
-    if not do:
-        yield []
+    do = [gi for gi in g if gi[1] > 0]
+    SUM = sum([gi[1] for gi in do])
+    if not do or size is not None and (size > SUM or size < 1):
+        return
+    elif size == 1:
+        for k, v in do:
+            yield [k]
     elif len(do) == 1:
         k, v = do[0]
+        v = v if size is None else (size if size <= v else 0)
         yield [k for i in range(v)]
-    elif all(v == 1 for v in do):
-        for p in permutations([k for k, v in g]):
+    elif all(v == 1 for k, v in do):
+        for p in permutations([k for k, v in do], size):
             yield list(p)
     else:
-        for i, (k, v) in enumerate(g):
-            if not v:
-                continue
-            g[i][1] -= 1
-            for j in multiset_permutations(None, g):
-                yield [k] + j
-            g[i][1] += 1
+        size = size if size is not None else SUM
+        for i, (k, v) in enumerate(do):
+            do[i][1] -= 1
+            for j in multiset_permutations(None, size - 1, do):
+                if j:
+                    yield [k] + j
+            do[i][1] += 1
 
 
 def _partition(seq, vector, m=None):
@@ -1107,7 +1144,7 @@ def multiset_partitions(multiset, m=None):
     if type(multiset) is int:
         n = multiset
         if m and m > n:
-            raise ValueError('m > len(multiset)')
+            return
         multiset = range(multiset)
         if m == 1:
             yield [multiset[:]]
@@ -1126,7 +1163,7 @@ def multiset_partitions(multiset, m=None):
     if not has_variety(multiset):
         n = len(multiset)
         if m and m > n:
-            raise ValueError('m > len(multiset)')
+            return
         if m == 1:
             yield [multiset[:]]
             return
@@ -1141,7 +1178,7 @@ def multiset_partitions(multiset, m=None):
         multiset = list(ordered(multiset))
         n = len(multiset)
         if m and m > n:
-            raise ValueError('m > len(multiset)')
+            return
         if m == 1:
             yield [multiset[:]]
             return
@@ -1208,8 +1245,8 @@ def partitions(n, m=None, k=None, size=False):
     {1: 4, 2: 1}
     {1: 6}
 
-    The maximum number of parts in partion (the values of the returned dict)
-    are limited with m:
+    The maximum number of parts in the partion (the sum of the values in
+    the returned dict) are limited with m:
 
     >>> for p in partitions(6, m=2):
     ...     print p
@@ -1641,7 +1678,7 @@ def necklaces(n, k, free=False):
     http://mathworld.wolfram.com/Necklace.html
 
     """
-    return uniq(minlex(i, directed=not free, is_set=False) for i in
+    return uniq(minlex(i, directed=not free) for i in
         variations(range(k), n, repetition=True))
 
 
@@ -1692,14 +1729,14 @@ def generate_oriented_forest(n):
                 break
 
 
-def minlex(seq, directed=True, is_set=True, small=None):
+def minlex(seq, directed=True, is_set=False, small=None):
     """
     Return a tuple where the smallest element appears first; if
     ``directed`` is True (default) then the order is preserved, otherwise
     the sequence will be reversed if that gives a smaller ordering.
 
-    If every element appears only once then is_set can keep it's default
-    value of True, otherwise False should be passed.
+    If every element appears only once then is_set can be set to True
+    for more efficient processing.
 
     If the smallest element is known at the time of calling, it can be
     passed and the calculation of the smallest element will be omitted.
@@ -1715,9 +1752,9 @@ def minlex(seq, directed=True, is_set=True, small=None):
     >>> minlex((1, 0, 2), directed=False)
     (0, 1, 2)
 
-    >>> minlex('11010011000', 1, is_set=False)
+    >>> minlex('11010011000', directed=True)
     '00011010011'
-    >>> minlex('11010011000', 0, is_set=False)
+    >>> minlex('11010011000', directed=False)
     '00011001011'
 
     """
@@ -1901,7 +1938,7 @@ def kbins(l, k, ordered=None):
         for p in partition(l, k):
             yield p
     elif ordered == 11:
-        for pl in permutations(l):
+        for pl in multiset_permutations(l):
             pl = list(pl)
             for p in partition(pl, k):
                 yield p
@@ -1916,7 +1953,7 @@ def kbins(l, k, ordered=None):
         for kgot, p in partitions(len(l), k, size=True):
             if kgot != k:
                 continue
-            for li in permutations(l):
+            for li in multiset_permutations(l):
                 rv = []
                 i = j = 0
                 li = list(li)


### PR DESCRIPTION
o fixed some issues with multiset_*
  Added a size option to multiset_permutations so it behaves
  like the normal permutations (in terms of accepting the option
  size arguement)

o rotate_\* doesn't return self if self is [] (this is important
  since the rotation does not happen in place when there are elements
  to rotate

o minlex defaults to is_set=False which is safer; if someone knows
  they are working with unique elements they can set is_set to True.

o add multiset convenience function to convert unordered list to
  multiset form

o add ibin convenience function to produce list of ints or string (either in reversed
   order) and perhaps _all_ such k-bit patterns
