### PR TITLE
Fix simplify issue 3476

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3025,8 +3025,12 @@ def simplify(expr, ratio=1.7, measure=count_ops):
     if (n, d) != fraction(expr):
         expr0b = powsimp(n)/powsimp(d)
         if expr0b != expr0:
-            expr1b = cancel(expr0b)
-            expr2b = together(expr1b.expand(), deep=True)
+            if expr.is_commutative is False:
+                expr1b = together(expr0b)
+                expr2b = factor_terms(expr1b)
+            else:
+                expr1b = cancel(expr0b)
+                expr2b = together(expr1b.expand(), deep=True)
             if shorter(expr2b, expr) == expr2b:
                 expr1, expr2 = expr1b, expr2b
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -323,6 +323,8 @@ def test_simplify():
     A, B = symbols('A,B', commutative=False)
 
     assert simplify(A*B - B*A) == A*B - B*A
+    assert simplify(A/(1 + y/x)) == x*A/(x + y)
+    assert simplify(A*(1/x + 1/y)) == (x + y)*A/(x*y)
 
     assert simplify(log(2) + log(3)) == log(6)
     assert simplify(log(2*x) - log(2)) == log(x)


### PR DESCRIPTION
Don't call cancel on noncommutative expr.

Fixes issue 3476: simplify and noncommutative symbol error
http://code.google.com/p/sympy/issues/detail?id=3476

> > > from sympy import Symbol, symbols, simplify
> > > A = Symbol("A", commutative=False)
> > > x, y = symbols("x y")
> > > simplify(A/(1 + y/x))
> > > x*A/(x + y)
