### PR TITLE
Replacing fnan with symbolic NaN

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -6,10 +6,10 @@ import sympy.mpmath.libmp as libmp
 from sympy.mpmath import make_mpc, make_mpf, mp, mpc, mpf, nsum, quadts, quadosc
 from sympy.mpmath import inf as mpmath_inf
 from sympy.mpmath.libmp import (bitcount, from_int, from_man_exp,
-        from_rational, fhalf, fnone, fone, fzero, mpf_abs, mpf_add, mpf_atan,
-        mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt, mpf_mul,
-        mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin, mpf_sqrt,
-        normalize, round_nearest, to_int, to_str)
+        from_rational, fhalf, fnan, fnone, fone, fzero, mpf_abs, mpf_add,
+        mpf_atan, mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt,
+        mpf_mul, mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin,
+        mpf_sqrt, normalize, round_nearest, to_int, to_str)
 from sympy.mpmath.libmp.backend import MPZ
 from sympy.mpmath.libmp.libmpc import _infs_nan
 from sympy.mpmath.libmp.libmpf import dps_to_prec
@@ -1106,6 +1106,7 @@ def _create_evalf_table():
         C.Exp1: lambda x, prec, options: (mpf_e(prec), None, prec, None),
         C.ImaginaryUnit: lambda x, prec, options: (None, fone, None, prec),
         C.NegativeOne: lambda x, prec, options: (fnone, None, prec, None),
+        C.NaN : lambda x, prec, options: (fnan, None, prec, None),
 
         C.exp: lambda x, prec, options: evalf_pow(C.Pow(S.Exp1, x.args[0],
         evaluate=False), prec, options),

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2150,7 +2150,7 @@ class NegativeInfinity(Number):
         return other is S.NegativeInfinity
 
 
-class NaN(Float):
+class NaN(Number):
     """
     Not a Number.
 
@@ -2189,7 +2189,6 @@ class NaN(Float):
     is_commutative = True
     is_real = None
     is_rational = None
-    is_irrational = None
     is_integer = None
     is_comparable = False
     is_finite = None
@@ -2199,15 +2198,10 @@ class NaN(Float):
     is_positive = None
     is_negative = None
 
-    is_Float = False
-
-    __slots__ = ['_mpf_', '_prec']
+    __slots__ = []
 
     def __new__(cls):
-        obj = AtomicExpr.__new__(cls)
-        obj._mpf_ = fnan
-        obj._prec = 15
-        return obj
+        return AtomicExpr.__new__(cls)
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
@@ -2254,9 +2248,6 @@ class NaN(Float):
 
     def __le__(self, other):
         return False
-
-    def __nonzero__(self):
-        return True
 
 nan = S.NaN
 

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -371,4 +371,3 @@ def test_chop_value():
 def test_infinities():
     assert oo.evalf(chop=True) == inf
     assert (-oo).evalf(chop=True) == ninf
-    assert S.NaN.evalf(chop=True) == nan

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -516,15 +516,18 @@ def test_Infinity():
     assert float(1) - oo == Float('-inf')
     assert float(1) - -oo == Float('inf')
 
-    from sympy.mpmath.libmp.libmpf import fnan
-    assert (oo*Float('nan'))._mpf_ == fnan
-    assert (-oo*Float('nan'))._mpf_ == fnan
-    assert (oo/Float('nan'))._mpf_ == fnan
-    assert (-oo/Float('nan'))._mpf_ == fnan
-    assert (oo + Float('nan'))._mpf_ == fnan
-    assert (-oo + Float('nan'))._mpf_ == fnan
-    assert (oo - Float('nan'))._mpf_ == fnan
-    assert (-oo - Float('nan'))._mpf_ == fnan
+    assert Float('nan') == nan
+    assert nan*1.0 == nan
+    assert -1.0*nan == nan
+    assert nan*oo == nan
+    assert nan*-oo == nan
+    assert nan/oo == nan
+    assert nan/-oo == nan
+    assert nan + oo == nan
+    assert nan + -oo == nan
+    assert nan - oo == nan
+    assert nan - -oo == nan
+    assert -oo * S.Zero == nan
 
     assert oo*nan == nan
     assert -oo*nan == nan


### PR DESCRIPTION
See http://code.google.com/p/sympy/issues/detail?id=3536. A few comments:
1. In some cases where fnan would fail, e.g. Float('nan').floor(), the new nan also fails.
2. One assertion removed from test_infinities() in sympy/core/tests/test_evalf.py. Since symbolic NaN is used, it doesn't make sense for it to equal sympy.mpmath.nan, since sympy.mpmath.nan would fail the "is S.NaN" check.
3. Despite subclassing Float, S.NaN.is_Float is false, since NaN behaves differently from normal float values.
4. All tests/doctests/slow tests (not marked XFAIL) pass.
