### PR TITLE
3533

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1048,7 +1048,7 @@ class Basic(object):
             return rule[self]
         elif rule:
             args = tuple([arg.xreplace(rule) for arg in self.args])
-            if args != self.args:
+            if not _aresame(args, self.args):
                 return self.func(*args)
         return self
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1585,6 +1585,7 @@ class preorder_traversal(object):
 
     Examples
     ========
+
     >>> from sympy import symbols
     >>> from sympy import symbols, default_sort_key
     >>> from sympy.core.basic import preorder_traversal

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -270,34 +270,30 @@ class AssocOp(Basic):
             # that's why we don't call to evalf.
             x = x._evalf(prec) if x is not self.identity else self.identity
             args = []
-            hit = False
             for a in self.func.make_args(tail):
                 # here we call to _eval_evalf since we don't know what we
                 # are dealing with and all other _eval_evalf routines should
                 # be doing the same thing (i.e. taking binary prec and
                 # finding the evalf-able args)
                 newa = a._eval_evalf(prec)
-                if newa is None or _aresame(newa, a):
+                if newa is None:
                     args.append(a)
                 else:
-                    hit = True
                     args.append(newa)
-            if hit:
+            if not _aresame(tuple(args), self.func.make_args(tail)):
                 tail = self.func(*args)
             return self.func(x, tail)
 
         # this is the same as above, but there were no pure-number args to
         # deal with
         args = []
-        hit = False
         for a in self.args:
             newa = a._eval_evalf(prec)
-            if newa is None or _aresame(newa, a):
+            if newa is None:
                 args.append(a)
             else:
-                hit = True
                 args.append(newa)
-        if hit:
+        if not _aresame(tuple(args), self.args):
             return self.func(*args)
         return self
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -1,6 +1,6 @@
 from sympy.core.core import C
 from sympy.core.sympify import _sympify, sympify
-from sympy.core.basic import Basic
+from sympy.core.basic import Basic, _aresame
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import cmp, ordered
 from sympy.core.logic import fuzzy_and
@@ -251,7 +251,55 @@ class AssocOp(Basic):
         return not multi
 
     def _eval_evalf(self, prec):
-        return self.func(*[s._evalf(prec) for s in self.args])
+        """
+        Evaluate the parts of self that are numbers; if the whole thing
+        was a number with no functions it would have been evaluated, but
+        it wasn't so we must judiciously extract the numbers and reconstruct
+        the object. This is *not* simply replacing numbers with evaluated
+        numbers. Nunmbers should be handled in the largest pure-number
+        expression as possible. So the code below separates ``self`` into
+        number and non-number parts and evaluates the number parts and
+        walks the args of the non-number part recursively (doing the same
+        thing).
+        """
+        x, tail = self.as_independent(C.Symbol)
+
+        if tail is not self.identity:
+            # here, we have a number so we just call to _evalf with prec;
+            # prec is not the same as n, it is the binary precision so
+            # that's why we don't call to evalf.
+            x = x._evalf(prec) if x is not self.identity else self.identity
+            args = []
+            hit = False
+            for a in self.func.make_args(tail):
+                # here we call to _eval_evalf since we don't know what we
+                # are dealing with and all other _eval_evalf routines should
+                # be doing the same thing (i.e. taking binary prec and
+                # finding the evalf-able args)
+                newa = a._eval_evalf(prec)
+                if newa is None or _aresame(newa, a):
+                    args.append(a)
+                else:
+                    hit = True
+                    args.append(newa)
+            if hit:
+                tail = self.func(*args)
+            return self.func(x, tail)
+
+        # this is the same as above, but there were no pure-number args to
+        # deal with
+        args = []
+        hit = False
+        for a in self.args:
+            newa = a._eval_evalf(prec)
+            if newa is None or _aresame(newa, a):
+                args.append(a)
+            else:
+                hit = True
+                args.append(newa)
+        if hit:
+            return self.func(*args)
+        return self
 
     @classmethod
     def make_args(cls, expr):

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -376,3 +376,9 @@ def test_infinities():
 def test_to_mpmath():
     assert sqrt(3)._to_mpmath(20)._mpf_ == (0, 908093L, -19, 20)
     assert S(3.2)._to_mpmath(20)._mpf_ == (0, 838861L, -18, 20)
+
+
+def test_issue_3533_evalf():
+    add = (-100000*sqrt(2500000001) + 5000000001)
+    assert add.n() == 9.999999998e-11
+    assert (add*add).n() == 9.999999996e-21

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -541,11 +541,18 @@ def test_nfloat():
     eq = x**(S(4)/3) + 4*x**(x/3)/3
     assert _aresame(nfloat(eq), x**(S(4)/3) + (4.0/3)*x**(x/3))
     big = 12345678901234567890
-    Float_big = Float(big, '')
+    Float_big = Float(big)
     assert _aresame(nfloat(x**big, exponent=True),
                     x**Float_big)
     assert _aresame(nfloat(big), Float_big)
+    assert nfloat({x: sqrt(2)}) == {x: nfloat(sqrt(2))}
+    assert nfloat({sqrt(2): x}) == {sqrt(2): x}
+    assert nfloat(cos(x + sqrt(2))) == cos(x + nfloat(sqrt(2)))
 
     # issues 3243
     f = S('x*lamda + lamda**3*(x/2 + 1/2) + lamda**2 + 1/4')
     assert not any(a.free_symbols for a in solve(f.subs(x, -0.139)))
+
+    # issue 3533
+    assert nfloat(-100000*sqrt(2500000001) + 5000000001) == \
+        9.99999999800000e-11


### PR DESCRIPTION
```
A proper evaluation of an expression cannot be done by substituting
evaluated numbers into the expression as a result of precision issues.
Instead, numbers must be evaluated in groups, e.g. (sqrt(3) - sqrt(2)).n()
rather than sqrt(3).n() - sqrt(2).n(). Often this doesn't matter much,
but as the added test shows, it does matter.

evalf needs a serious overhaul to make this right, too, since if evalf
(instead of nfloat) is used on the added expression for this issue, the
same mistake occurs. This is because _matches_commutative deals with
args arg-wise (instead of in lumped args which are all numbers).

The way evalf should work, I believe, is:

1) expr.evalf()
  a) expr.is_number is False
    i) if subs given, then do the subs thing in evalf
    ii) else call to expr._eval_evalf (with n, not prec) to find the

       numbers and pass them back to evalf and replace them in the
       expr; if there is not expr._eval_evalf routine use the Mixin
       routine, changed to apply evalf to each of the args (rather
       than returning None as now).
  b) normal evalf when expr.is_number
```
