### PR TITLE
Fix installation instructions for setupegg.py

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -59,7 +59,7 @@ To update to the latest version, go into your repository and execute::
 If you want to install SymPy, but still want to use the git version, you can run
 from your repository::
 
-    $ setup.py develop
+    $ setupegg.py develop
 
 This will cause the installed version to always point to the version in the git
 directory.


### PR DESCRIPTION
Docs say to run `python setup.py develop`, but you need to use `setupegg.py`. We should probably change setup.py so this functionality works, but for now, this just fixes the docs.
