### PR TITLE
Fixed dead links in documents

### DIFF
--- a/doc/src/guide.rst
+++ b/doc/src/guide.rst
@@ -516,9 +516,10 @@ Go to issues_ that are sorted by priority and simply find something that you
 would like to get fixed and fix it. If you find something odd, please report it
 into issues_ first before fixing it. Feel free to consult with us on the
 mailinglist_.  Then send your patch either to the issues_ or the mailinglist_.
-See the SymPyDevelopment_ wiki, but don't worry about it too much if you find
-it too formal - simply get in touch with us on the mailinglist_ and we'll help
-you get your patch accepted.
+See the `SymPy Development 
+<https://github.com/sympy/sympy/wiki/old-wiki-Sympy-Development>` wiki page,
+but don't worry about it too much if you find it too formal - simply get in touch
+with us on the mailinglist_ and we'll help you get your patch accepted.
 
 .. _issues:             http://code.google.com/p/sympy/issues/list
 .. _mailinglist:        http://groups.google.com/group/sympy

--- a/doc/src/modules/mpmath/references.rst
+++ b/doc/src/modules/mpmath/references.rst
@@ -16,7 +16,7 @@ References not listed here can be found in the source code.
 
 .. [BorweinBorwein] J Borwein & P B Borwein. *Pi and the AGM: A Study in Analytic Number Theory and Computational Complexity*, Wiley 1987
 
-.. [BorweinZeta] P Borwein. "An Efficient Algorithm for the Riemann Zeta Function", http://www.cecm.sfu.ca/personal/pborwein/PAPERS/P117.ps
+.. [BorweinZeta] P Borwein. "An Efficient Algorithm for the Riemann Zeta Function", http://www.cecm.sfu.ca/personal/pborwein/PAPERS/P115.pdf
 
 .. [CabralRosetti] L G Cabral-Rosetti & M A Sanchis-Lozano. "Appell Functions and the Scalar One-Loop Three-point Integrals in Feynman Diagrams". http://arxiv.org/abs/hep-ph/0206081
 

--- a/doc/src/modules/mpmath/references.rst
+++ b/doc/src/modules/mpmath/references.rst
@@ -5,7 +5,7 @@ The following is a non-comprehensive list of works used in the development of mp
 or cited for examples or mathematical definitions used in this documentation.
 References not listed here can be found in the source code.
 
-.. [AbramowitzStegun] M Abramowitz & I Stegun. *Handbook of Mathematical Functions, 9th Ed.*, Tenth Printing, December 1972, with corrections (electronic copy: http://www.math.ucla.edu/~cbm/aands/)
+.. [AbramowitzStegun] M Abramowitz & I Stegun. *Handbook of Mathematical Functions, 9th Ed.*, Tenth Printing, December 1972, with corrections
 
 .. [Bailey] D H Bailey. "Tanh-Sinh High-Precision Quadrature", http://crd.lbl.gov/~dhbailey/dhbpapers/dhb-tanh-sinh.pdf
 

--- a/doc/src/modules/mpmath/setup.rst
+++ b/doc/src/modules/mpmath/setup.rst
@@ -46,7 +46,7 @@ OpenSUSE
 Mpmath is provided in the "Science" repository for all recent versions of `openSUSE <http://www.opensuse.org/>`_. To add this repository to the YAST software management tool, see http://en.opensuse.org/SDB:Add_package_repositories
 
 Look up http://download.opensuse.org/repositories/science/ for a list
-of supported OpenSUSE versions and use http://download.opensuse.org/repositories/science/openSUSE_11.1/
+of supported OpenSUSE versions and use http://download.opensuse.org/repositories/science/openSUSE_12.2/
 (or accordingly for your OpenSUSE version) as the repository URL for YAST.
 
 Current development version

--- a/doc/src/modules/mpmath/setup.rst
+++ b/doc/src/modules/mpmath/setup.rst
@@ -43,7 +43,7 @@ See `debian <http://packages.debian.org/python-mpmath>`_ and `ubuntu <https://la
 OpenSUSE
 ........
 
-Mpmath is provided in the "Science" repository for all recent versions of `openSUSE <http://www.opensuse.org/>`_. To add this repository to the YAST software management tool, see http://en.opensuse.org/Add_Package_Repositories_to_YaST
+Mpmath is provided in the "Science" repository for all recent versions of `openSUSE <http://www.opensuse.org/>`_. To add this repository to the YAST software management tool, see http://en.opensuse.org/SDB:Add_package_repositories
 
 Look up http://download.opensuse.org/repositories/science/ for a list
 of supported OpenSUSE versions and use http://download.opensuse.org/repositories/science/openSUSE_11.1/

--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -12,8 +12,7 @@ def AbelianGroup(*cyclic_orders):
     According to the structure theorem for finite abelian groups ([1]),
     every finite abelian group can be written as the direct product of finitely
     many cyclic groups.
-    [1] http://groupprops.subwiki.org/wiki/Structure_theorem_for_finitely
-    _generated_abelian_groups
+    [1] http://groupprops.subwiki.org/wiki/Structure_theorem_for_finitely_generated_abelian_groups
 
     Examples
     ========

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -285,7 +285,7 @@ class IntegerPartition(Basic):
     sympy.utilities.iterables.partitions,
     sympy.utilities.iterables.multiset_partitions
 
-    Reference: http://en.wikipedia.org/wiki/Partition_(number_theory)
+    Reference: http://en.wikipedia.org/wiki/Partition_%28number_theory%29
     """
 
     _dict = None

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1416,8 +1416,7 @@ def diff(f, *symbols, **kwargs):
     References
     ==========
 
-    http://documents.wolfram.com/v5/Built-inFunctions/AlgebraicComputation/
-           Calculus/D.html
+    http://reference.wolfram.com/legacy/v5_2/Built-inFunctions/AlgebraicComputation/Calculus/D.html
 
     See Also
     ========

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -352,7 +352,7 @@ class LatticeOp(AssocOp):
 
     References:
 
-    [1] - http://en.wikipedia.org/wiki/Lattice_(order)
+    [1] - http://en.wikipedia.org/wiki/Lattice_%28order%29
     """
 
     is_commutative = True

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -433,7 +433,7 @@ class Max(MinMaxBase, Application):
     ==========
 
     .. [1] http://en.wikipedia.org/wiki/Directed_complete_partial_order
-    .. [2] http://en.wikipedia.org/wiki/Lattice_(order)
+    .. [2] http://en.wikipedia.org/wiki/Lattice_%28order%29
 
     See Also
     ========

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -493,7 +493,6 @@ class Polygon(GeometryEntity):
         ==========
 
         [1] http://www.ariel.com.au/a/python-point-int-poly.html
-        [2] http://local.wasp.uwa.edu.au/~pbourke/geometry/insidepoly/
 
         """
         p = Point(p)

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -44,7 +44,7 @@ def trigintegrate(f, x):
        >>> trigintegrate(sin(x)*tan(x), x)
        -log(sin(x) - 1)/2 + log(sin(x) + 1)/2 - sin(x)
 
-       http://en.wikibooks.org/wiki/Calculus/Further_integration_techniques
+       http://en.wikibooks.org/wiki/Calculus/Integration_techniques
 
     See Also
     ========

--- a/sympy/matrices/sparse.py
+++ b/sympy/matrices/sparse.py
@@ -611,8 +611,9 @@ class SparseMatrix(MatrixBase):
         ==========
 
         Symbolic Sparse Cholesky Factorization using Elimination Trees,
-        Jeroen Van Grondelle (1999) http://citeseerx.ist.psu.edu/viewdoc/
-        summary?doi=10.1.1.39.7582, downloaded from http://tinyurl.com/9o2jsxj
+        Jeroen Van Grondelle (1999)
+        http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.39.7582,
+        downloaded from http://tinyurl.com/9o2jsxj
         """
         # Algorithm 2.4, p 17 of reference
 
@@ -655,8 +656,9 @@ class SparseMatrix(MatrixBase):
         ==========
 
         Symbolic Sparse Cholesky Factorization using Elimination Trees,
-        Jeroen Van Grondelle (1999) http://citeseerx.ist.psu.edu/viewdoc/
-        summary?doi=10.1.1.39.7582, downloaded from http://tinyurl.com/9o2jsxj
+        Jeroen Van Grondelle (1999)
+        http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.39.7582,
+        downloaded from http://tinyurl.com/9o2jsxj
         """
 
         R, parent = self.liupc()

--- a/sympy/mpmath/function_docs.py
+++ b/sympy/mpmath/function_docs.py
@@ -3333,9 +3333,6 @@ An integral representation::
     0.06674960718150520648014567
     >>> quad(lambda t: exp(-z*t)*t**(a-1)*(1+t)**(b-a-1),[0,inf]) / gamma(a)
     0.06674960718150520648014567
-
-
-[1] http://www.math.ucla.edu/~cbm/aands/page_504.htm
 """
 
 hyp2f0 = r"""
@@ -3350,7 +3347,7 @@ This series usually does not converge. For small enough `z`, it can be viewed
 as an asymptotic series that may be summed directly with an appropriate
 truncation. When this is not the case, :func:`~mpmath.hyp2f0` gives a regularized sum,
 or equivalently, it uses a representation in terms of the
-hypergeometric U function [1]. The series also converges when either `a` or `b`
+hypergeometric U function. The series also converges when either `a` or `b`
 is a nonpositive integer, as it then terminates into a polynomial
 after `-a` or `-b` terms.
 
@@ -3400,9 +3397,6 @@ The coefficients of the polynomials can be recovered using Taylor expansion::
     [1.0, -1.5, 2.25, -1.875, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     >>> nprint(taylor(lambda x: hyp2f0(-4,0.5,x), 0, 10))
     [1.0, -2.0, 4.5, -7.5, 6.5625, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-
-
-[1] http://www.math.ucla.edu/~cbm/aands/page_504.htm
 """
 
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -408,7 +408,6 @@ def pollard_rho(n, s=2, a=1, retries=5, seed=1234, max_steps=None, F=None):
 
     - Richard Crandall & Carl Pomerance (2005), "Prime Numbers:
       A Computational Perspective", Springer, 2nd edition, 229-231
-    - http://www.csh.rit.edu/~pat/math/quickies/rho/
 
     """
     n = int(n)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -568,7 +568,6 @@ def pollard_pm1(n, B=10, a=2, retries=0, seed=1234):
       A Computational Perspective", Springer, 2nd edition, 236-238
     - http://modular.math.washington.edu/edu/2007/spring/ent/ent-html/
             node81.html
-    - http://www.math.mcgill.ca/darmon/courses/05-06/usra/charest.pdf
     - http://www.cs.toronto.edu/~yuvalf/Factorization.pdf
     """
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -90,7 +90,7 @@ class Operator(QExpr):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Operator_(physics)
+    .. [1] http://en.wikipedia.org/wiki/Operator_&#40;physics&#41;
     .. [2] http://en.wikipedia.org/wiki/Observable
     """
 

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -90,7 +90,7 @@ class Operator(QExpr):
     References
     ==========
 
-    .. [1] http://en.wikipedia.org/wiki/Operator_&#40;physics&#41;
+    .. [1] http://en.wikipedia.org/wiki/Operator_%28physics%29
     .. [2] http://en.wikipedia.org/wiki/Observable
     """
 

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -841,9 +841,6 @@ def matrix_fglm(F, u, O_from, O_to, K):
     J.C. Faugere, P. Gianni, D. Lazard, T. Mora (1994). Efficient
     Computation of Zero-dimensional Groebner Bases by Change of
     Ordering
-
-    J.C. Faugere's lecture notes:
-    http://www-salsa.lip6.fr/~jcf/Papers/2010_MPRI5e.pdf
     """
     old_basis = _basis(F, u, O_from, K)
     M = _representing_matrices(old_basis, F, u, O_from, K)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5977,9 +5977,6 @@ class GroebnerBasis(Basic):
         Computation of Zero-dimensional Groebner Bases by Change of
         Ordering
 
-        J.C. Faugere's lecture notes:
-        http://www-salsa.lip6.fr/~jcf/Papers/2010_MPRI5e.pdf
-
         """
         opt = self._options
 


### PR DESCRIPTION
Dead links removed from documentation as per https://code.google.com/p/sympy/issues/detail?id=3520. I left a few links that were temporary unavailable, one that times out, and two that actually resolved just fine when opening them in a browser.
