### PR TITLE
Fix issue 3551

### DIFF
--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -35,6 +35,7 @@ class RootOf(Expr):
     """Represents ``k``-th root of a univariate polynomial. """
 
     __slots__ = ['poly', 'index']
+    is_complex = True
 
     def __new__(cls, f, x, index=None, radicals=True, expand=True):
         """Construct a new ``RootOf`` object for ``k``-th root of ``f``. """
@@ -110,19 +111,9 @@ class RootOf(Expr):
     def free_symbols(self):
         return self.poly.free_symbols
 
-    @property
-    def is_commutative(self):
-        return True
-
-    @property
-    def is_real(self):
+    def _eval_is_real(self):
         """Return ``True`` if the root is real. """
         return self.index < len(_reals_cache[self.poly])
-
-    @property
-    def is_complex(self):
-        """Return ``True`` if the root is complex. """
-        return not self.is_real
 
     @classmethod
     def real_roots(cls, poly, radicals=True):

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -125,9 +125,7 @@ def test_RootOf_is_real():
 
 
 def test_RootOf_is_complex():
-    assert RootOf(x**3 + x + 3, 0).is_complex is False
-    assert RootOf(x**3 + x + 3, 1).is_complex is True
-    assert RootOf(x**3 + x + 3, 2).is_complex is True
+    assert RootOf(x**3 + x + 3, 0).is_complex is True
 
 
 def test_RootOf_subs():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -312,11 +312,6 @@ def check_assumptions(expr, **assumptions):
     for key, expected in assumptions.iteritems():
         if expected is None:
             continue
-        if expected in [0, 1]:
-            expected = bool(expected)
-        if not isinstance(expected, bool):
-            raise ValueError(_filldendent('''
-                A boolean is expected for %s but got %s.''' % (key, expected)))
         if hasattr(Q, key):
             test = ask(getattr(Q, key)(expr))
             if test is expected:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -312,14 +312,6 @@ def check_assumptions(expr, **assumptions):
     for key, expected in assumptions.iteritems():
         if expected is None:
             continue
-        if hasattr(Q, key):
-            test = ask(getattr(Q, key)(expr))
-            if test is expected:
-                continue
-            elif test is not None:
-                return False
-        # ask() can't conclude. Try using old assumption system.
-        # XXX: remove once transition to new assumption system is finished.
         test = getattr(expr, 'is_' + key, None)
         if test is expected:
             continue

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1007,7 +1007,7 @@ def test_float_handling():
 
 
 def test_check_assumptions():
-    x = symbols('x', positive=1)
+    x = symbols('x', positive=True)
     assert solve(x**2 - 1) == [1]
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1059,6 +1059,11 @@ def test_high_order_roots():
     s = x**5 + 4*x**3 + 3*x**2 + S(7)/4
     assert set(solve(s)) == set(Poly(s*4, domain='ZZ').all_roots())
 
+def test_real_roots():
+    # cf. issue 3551
+    x = Symbol('x', real=True)
+    assert len(solve(x**5 + x**3 + 1)) == 1
+
 
 def test_issue3429():
     eqs = [


### PR DESCRIPTION
- Implements (old) assumptions correctly for RootOf
- Simplifies check_assumptions()
- Fixes 3551: now, with real `x`, `solve(x**5 + x**3 + 1, x)` returns `[RootOf(x**5 + x**3 + 1, 0)]`.
