### PR TITLE
fixed bug to make sure empty sums return zero.

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -141,7 +141,7 @@ class Sum(Expr):
             i, a, b = limit
             dif = b - a
             if dif.is_Integer and dif < 0:
-                a, b = b, a
+                return S.zero
 
             f = eval_sum(f, (i, a, b))
             if f is None:

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -295,6 +295,7 @@ def test_Sum_interface():
     assert Sum(0, (n, 0, 2)).doit() == 0
     assert isinstance(Sum(0, (n, 0, oo)), Sum)
     assert Sum(0, (n, 0, oo)).doit() == 0
+    assert Sum(x, (x, 2, 0)).doit() == 0
     raises(ValueError, lambda: Sum(1))
     raises(ValueError, lambda: summation(1))
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -295,7 +295,7 @@ def test_Sum_interface():
     assert Sum(0, (n, 0, 2)).doit() == 0
     assert isinstance(Sum(0, (n, 0, oo)), Sum)
     assert Sum(0, (n, 0, oo)).doit() == 0
-    assert Sum(x, (x, 2, 0)).doit() == 0
+    assert Sum(x, (x, 3, 0)).doit() == 0
     raises(ValueError, lambda: Sum(1))
     raises(ValueError, lambda: summation(1))
 


### PR DESCRIPTION
TODO respond to feedback

fixed bug to make sure empty sums return zero.

http://code.google.com/p/sympy/issues/detail?id=3175
