### PR TITLE
Tensor expressions with canonicalization

### DIFF
--- a/doc/src/modules/tensor/index.rst
+++ b/doc/src/modules/tensor/index.rst
@@ -14,3 +14,5 @@ Contents
 
     indexed.rst
     index_methods.rst
+    tensor.rst
+    dgamma_matr.rst

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1,9 +1,9 @@
 from sympy.combinatorics.permutations import Permutation, _af_rmul, _af_rmuln,\
-  _af_invert, _af_new
+    _af_invert, _af_new
 from sympy.combinatorics.perm_groups import PermutationGroup, _orbit, \
-  _orbit_transversal
+    _orbit_transversal
 from sympy.combinatorics.util import _distribute_gens_by_base, \
-  _orbits_transversals_from_bsgs
+    _orbits_transversals_from_bsgs
 
 """
     References for tensor canonicalization:
@@ -42,25 +42,28 @@ def dummy_sgs(dummies, sym, n):
     ========
     >>> from sympy.combinatorics.tensor_can import dummy_sgs
     >>> dummy_sgs([2,3,4,5,6,7], 0, 8)
-    [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9], [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]
+    [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9],
+     [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9],
+     [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]
     """
     assert len(dummies) <= n
     res = []
     # exchange of contravariant and covariant indices
-    if sym != None:
+    if sym is not None:
         for j in dummies[::2]:
-            a = range(n+2)
+            a = range(n + 2)
             if sym == 1:
-                a[n] = n+1
-                a[n+1] = n
-            a[j], a[j+1] = a[j+1], a[j]
+                a[n] = n + 1
+                a[n + 1] = n
+            a[j], a[j + 1] = a[j + 1], a[j]
             res.append(a)
     # rename dummy indices
     for j in dummies[:-3:2]:
-        a = range(n+2)
-        a[j:j+4] = a[j+2],a[j+3],a[j],a[j+1]
+        a = range(n + 2)
+        a[j:j + 4] = a[j + 2], a[j + 3], a[j], a[j + 1]
         res.append(a)
     return res
+
 
 def _min_dummies(dummies, sym, indices):
     """
@@ -102,6 +105,7 @@ def _trace_S(s, j, b, S_cosets):
             return h
     return None
 
+
 def _trace_D(gj, p_i, Dxtrav):
     """
     Return the representative h satisfying h[gj] == p_i
@@ -112,6 +116,7 @@ def _trace_D(gj, p_i, Dxtrav):
         if h[gj] == p_i:
             return h
     return None
+
 
 def _dumx_remove(dumx, dumx_flat, p0):
     """
@@ -124,14 +129,15 @@ def _dumx_remove(dumx, dumx_flat, p0):
             continue
         k = dx.index(p0)
         if k % 2 == 0:
-            p0_paired = dx[k+1]
+            p0_paired = dx[k + 1]
         else:
-            p0_paired = dx[k-1]
+            p0_paired = dx[k - 1]
         dx.remove(p0)
         dx.remove(p0_paired)
         dumx_flat.remove(p0)
         dumx_flat.remove(p0_paired)
         res.append(dx)
+
 
 def transversal2coset(size, base, transversal):
     a = []
@@ -142,10 +148,10 @@ def transversal2coset(size, base, transversal):
             j += 1
         else:
             a.append([range(size)])
-    j = len(a)-1
+    j = len(a) - 1
     while a[j] == [range(size)]:
         j -= 1
-    return a[:j+1]
+    return a[:j + 1]
 
 
 def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
@@ -156,7 +162,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         list of lists of dummy indices,
         one list for each type of index;
         the dummy indices are put in order contravariant, covariant
-        [d0, -d0, d1,-d1,...].
+        [d0, -d0, d1, -d1, ...].
 
       sym
         list of the symmetries of the index metric for each type.
@@ -379,7 +385,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
     g = g.array_form
     num_dummies = size - 2
     indices = range(num_dummies)
-    all_metrics_with_sym = all([_ != None for _ in sym])
+    all_metrics_with_sym = all([_ is not None for _ in sym])
     num_types = len(sym)
     dumx = dummies[:]
     dumx_flat = []
@@ -392,7 +398,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
     # strong generating set for D
     dsgsx = []
     for i in range(num_types):
-       dsgsx.extend(dummy_sgs(dumx[i], sym[i], num_dummies))
+        dsgsx.extend(dummy_sgs(dumx[i], sym[i], num_dummies))
     ginv = _af_invert(g)
     idn = range(size)
     # TAB = list of entries (s, d, h) where h = _af_rmuln(d,g,s)
@@ -410,24 +416,25 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         if all_metrics_with_sym:
             md = _min_dummies(dumx, sym, indices)
         else:
-            md = [min(_orbit(size, [_af_new(ddx) for ddx in dsgsx], ii)) for ii in range(size-2)]
+            md = [min(_orbit(size, [_af_new(
+                ddx) for ddx in dsgsx], ii)) for ii in range(size - 2)]
 
-        p_i = min([min([md[h[x]] for x in deltab]) for s,d,h in TAB])
+        p_i = min([min([md[h[x]] for x in deltab]) for s, d, h in TAB])
         dsgsx1 = [_af_new(_) for _ in dsgsx]
         Dxtrav = _orbit_transversal(size, dsgsx1, p_i, False, af=True) \
-                if dsgsx else None
+            if dsgsx else None
         if Dxtrav:
             Dxtrav = [_af_invert(x) for x in Dxtrav]
         # compute the orbit of p_i
         for ii in range(num_types):
             if p_i in dumx[ii]:
                 # the orbit is made by all the indices in dum[ii]
-                if sym[ii] != None:
+                if sym[ii] is not None:
                     deltap = dumx[ii]
                 else:
                     # the orbit is made by all the even indices if p_i
                     # is even, by all the odd indices if p_i is odd
-                    p_i_index = dumx[ii].index(p_i)%2
+                    p_i_index = dumx[ii].index(p_i) % 2
                     deltap = dumx[ii][p_i_index::2]
                 break
         else:
@@ -492,7 +499,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         # if TAB contains equal permutations up to the sign, return 0
         TAB1.sort(key=lambda x: x[-1])
         nTAB1 = len(TAB1)
-        prev = [0]*size
+        prev = [0] * size
         while TAB1:
             s, d, h = TAB1.pop()
             if h[:-2] == prev[:-2]:
@@ -586,17 +593,18 @@ def _get_map_slots(size, fixed_slots):
     res = range(size)
     pos = 0
     for i in range(size):
-      if i in fixed_slots:
-          continue
-      res[i] = pos
-      pos += 1
+        if i in fixed_slots:
+            continue
+        res[i] = pos
+        pos += 1
     return res
+
 
 def _lift_sgens(size, fixed_slots, free, s):
     a = []
     j = k = 0
     fd = zip(fixed_slots, free)
-    fd = [y for x,y in sorted(fd)]
+    fd = [y for x, y in sorted(fd)]
     num_free = len(free)
     for i in range(size):
         if i in fixed_slots:
@@ -606,6 +614,7 @@ def _lift_sgens(size, fixed_slots, free, s):
             a.append(s[j] + num_free)
             j += 1
     return a
+
 
 def canonicalize(g, dummies, msym, *v):
     """
@@ -733,10 +742,11 @@ def canonicalize(g, dummies, msym, *v):
         num_types = 1
     else:
         num_types = len(msym)
-        if not all(msymx in [0,1,None] for msymx in msym):
+        if not all(msymx in [0, 1, None] for msymx in msym):
             raise ValueError('msym entries must be 0, 1 or None')
         if len(dummies) != num_types:
-            raise ValueError('dummies and msym must have the same number of elements')
+            raise ValueError(
+                'dummies and msym must have the same number of elements')
     size = g.size
     num_tensors = 0
     v1 = []
@@ -751,7 +761,7 @@ def canonicalize(g, dummies, msym, *v):
                 can = canonicalize_naive(g, dummies, msym, *v)
                 return can
             base_i, gens_i = mbsgs
-        v1.append((base_i, gens_i, [[]]*n_i, sym_i))
+        v1.append((base_i, gens_i, [[]] * n_i, sym_i))
         num_tensors += n_i
 
     if num_types == 1:
@@ -767,8 +777,9 @@ def canonicalize(g, dummies, msym, *v):
     # slot symmetry of the tensor
     size1, sbase, sgens = gens_products(*v1)
     if size != size1:
-        raise ValueError('g has size %d, generators have size %d' %(size, size1))
-    free = [i for i in range(size-2) if i not in flat_dummies]
+        raise ValueError(
+            'g has size %d, generators have size %d' % (size, size1))
+    free = [i for i in range(size - 2) if i not in flat_dummies]
     num_free = len(free)
 
     # g1 minimal tensor under slot symmetry
@@ -776,7 +787,7 @@ def canonicalize(g, dummies, msym, *v):
     if not flat_dummies:
         return g1
     # save the sign of g1
-    sign = 0 if g1[-1] == size-1 else 1
+    sign = 0 if g1[-1] == size - 1 else 1
 
     # the free indices are kept fixed.
     # Determine free_i, the list of slots of tensors which are fixed
@@ -817,7 +828,8 @@ def canonicalize(g, dummies, msym, *v):
     dummies_red = [[x - num_free for x in y] for y in dummies]
     transv_red = get_transversals(sbase_red, sgens_red)
     g1_red = _af_new(g1_red)
-    g2 = double_coset_can_rep(dummies_red, msym, sbase_red, sgens_red, transv_red, g1_red)
+    g2 = double_coset_can_rep(
+        dummies_red, msym, sbase_red, sgens_red, transv_red, g1_red)
     if g2 == 0:
         return 0
     # lift to the case with the free indices
@@ -849,7 +861,8 @@ def perm_af_direct_product(gens1, gens2, signed=True):
     start = list(range(n1))
     end = list(range(n1, n1 + n2))
     if signed:
-        gens1 = [gen[:-2] + end + [gen[-2]+n2, gen[-1]+n2] for gen in gens1]
+        gens1 = [gen[:-2] + end + [gen[-2] + n2, gen[-1] + n2]
+                 for gen in gens1]
         gens2 = [start + [x + n1 for x in gen] for gen in gens2]
     else:
         gens1 = [gen + end for gen in gens1]
@@ -858,6 +871,7 @@ def perm_af_direct_product(gens1, gens2, signed=True):
     res = gens1 + gens2
 
     return res
+
 
 def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
     """
@@ -895,6 +909,7 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
         gens = [id_af]
     return base, [_af_new(h) for h in gens]
 
+
 def get_symmetric_group_sgs(n, sym=0):
     """
     Return base, gens of the minimal BSGS for (anti)symmetric group
@@ -910,16 +925,17 @@ def get_symmetric_group_sgs(n, sym=0):
     """
     if n == 1:
         return [], [_af_new(range(3))]
-    gens = [Permutation(n-1)(i, i+1)._array_form for i in range(n-1)]
+    gens = [Permutation(n - 1)(i, i + 1)._array_form for i in range(n - 1)]
     if sym == 0:
-        gens = [x + [n, n+1] for x in gens]
+        gens = [x + [n, n + 1] for x in gens]
     else:
-        gens = [x + [n+1, n] for x in gens]
-    base = range(n-1)
+        gens = [x + [n + 1, n] for x in gens]
+    base = range(n - 1)
     return base, [_af_new(h) for h in gens]
 
-riemann_bsgs = [0, 2], [Permutation(0,1)(4,5), Permutation(2,3)(4,5), \
-               Permutation(5)(0,2)(1,3)]
+riemann_bsgs = [0, 2], [Permutation(0, 1)(4, 5), Permutation(2, 3)(4, 5),
+                        Permutation(5)(0, 2)(1, 3)]
+
 
 def get_transversals(base, gens):
     """
@@ -927,10 +943,10 @@ def get_transversals(base, gens):
     """
     if not base:
         return []
-    stabs =  _distribute_gens_by_base(base, gens)
+    stabs = _distribute_gens_by_base(base, gens)
     orbits, transversals = _orbits_transversals_from_bsgs(base, stabs)
-    transversals = [dict((x, h._array_form) for x, h in y.items()) for y in \
-            transversals]
+    transversals = [dict((x, h._array_form) for x, h in y.items()) for y in
+                    transversals]
     return transversals
 
 
@@ -959,6 +975,7 @@ def _is_minimal_bsgs(base, gens):
             sgs1 = [h for h in sgs1 if h._array_form[i] == i]
     return base1 == base
 
+
 def get_minimal_bsgs(base, gens):
     """
     Compute a minimal GSGS
@@ -986,6 +1003,7 @@ def get_minimal_bsgs(base, gens):
     if not _is_minimal_bsgs(base, gens):
         return None
     return base, gens
+
 
 def tensor_gens(base, gens, list_free_indices, sym=0):
     """
@@ -1036,7 +1054,7 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     if not base and list_free_indices.count([]) < 2:
         n = len(list_free_indices)
         size = gens[0].size
-        size = n*(gens[0].size - 2) + 2
+        size = n * (gens[0].size - 2) + 2
         return size, [], [_af_new(range(size))]
 
     # if any(list_free_indices) one needs to compute the pointwise
@@ -1058,14 +1076,14 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     for i in range(1, len(list_free_indices)):
         base1, gens1 = _get_bsgs(G, base, gens, list_free_indices[i])
         res_base, res_gens = bsgs_direct_product(res_base, res_gens,
-            base1, gens1, 1)
+                                                 base1, gens1, 1)
         if not list_free_indices[i]:
-            no_free.append(range(size-2, size - 2 + num_indices))
+            no_free.append(range(size - 2, size - 2 + num_indices))
         size += num_indices
     nr = size - 2
     res_gens = [h for h in res_gens if h._array_form != id_af]
     # if sym there are no commuting tensors stop here
-    if sym == None or not no_free:
+    if sym is None or not no_free:
         if not res_gens:
             res_gens = [_af_new(id_af)]
         return size, res_base, res_gens
@@ -1085,7 +1103,7 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
         a.extend(ind2)
         a.extend(ind1)
         base_comm.append(ind1[0])
-        a.extend(range(ind2[-1]+1, nr))
+        a.extend(range(ind2[-1] + 1, nr))
         if sym == 0:
             a.extend([nr, nr + 1])
         else:
@@ -1130,7 +1148,7 @@ def gens_products(*v):
     for i in range(1, len(v)):
         size, base, gens = tensor_gens(*v[i])
         res_base, res_gens = bsgs_direct_product(res_base, res_gens, base,
-                                               gens, 1)
+                                                 gens, 1)
     res_size = res_gens[0].size
     id_af = range(res_size)
     res_gens = [h for h in res_gens if h != id_af]

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -635,7 +635,7 @@ def canonicalize(g, dummies, msym, *v):
             in case of failure,
             canonicalize_naive is used, which is much slower.
 
-            n_i     number ot tensors of type `i`.
+            n_i     number of tensors of type `i`.
 
             sym_i   symmetry under exchange of component tensors of type `i`.
 

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -775,7 +775,7 @@ def canonicalize(g, dummies, msym, *v):
         v1.append((base_i, gens_i, [[]] * n_i, sym_i))
         num_tensors += n_i
 
-    if num_types == 1:
+    if num_types == 1 and not isinstance(msym, list):
         dummies = [dummies]
         msym = [msym]
     flat_dummies = []

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -28,20 +28,25 @@ def dummy_sgs(dummies, sym, n):
     """
     Return the strong generators for dummy indices
 
-    dummies   list of dummy indices,
-              `dummies[2k], dummies[2k+1]` are paired indices
-    sym       symmetry under interchange of contracted dummies
-    sym =     None  no symmetry
-              0 symmetric
-              1 antisymmetric
-    n         number of indices
+    Parameters
+    ==========
+
+    dummies : list of dummy indices
+        `dummies[2k], dummies[2k+1]` are paired indices
+    sym : symmetry under interchange of contracted dummies::
+        * None  no symmetry
+        * 0     commuting
+        * 1     anticommuting
+
+    n : number of indices
 
     in base form the dummy indices are always in consecutive positions
 
     Examples
     ========
+
     >>> from sympy.combinatorics.tensor_can import dummy_sgs
-    >>> dummy_sgs([2,3,4,5,6,7], 0, 8)
+    >>> dummy_sgs(range(2, 8), 0, 8)
     [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9],
      [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9],
      [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]
@@ -73,8 +78,9 @@ def _min_dummies(dummies, sym, indices):
 
     Examples
     ========
+
     >>> from sympy.combinatorics.tensor_can import _min_dummies
-    >>> _min_dummies([[2,3,4,5,6,7]], [0], range(10))
+    >>> _min_dummies([range(2, 8)], [0], range(10))
     [0, 1, 2, 2, 2, 2, 2, 2, 8, 9]
     """
     num_types = len(sym)
@@ -535,6 +541,7 @@ def canonical_free(base, gens, g, num_free):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import canonical_free
     >>> gens = [[1,0,2,3,5,4], [2,3,0,1,4,5],[0,1,3,2,5,4]]
@@ -620,40 +627,44 @@ def canonicalize(g, dummies, msym, *v):
     """
     canonicalize tensor formed by tensors
 
-      g     permutation representing the tensor
+    Parameters
+    ==========
 
-      dummies list representing the dummy indices
-              it can be a list of dummy indices of the same type
-              or a list of lists of dummy indices, one list for each
-              type of index;
-              the dummy indices must come after the free indices,
-              and put in order contravariant, covariant
-              [d0, -d0, d1,-d1,...]
+    g : permutation representing the tensor
 
-      msym  symmetry of the metric(s)
-            it can be an integer or a list;
-            in the first case it is the symmetry of the dummy index metric;
-            in the second case it is the list of the symmetries of the
-            index metric for each type
+    dummies : list representing the dummy indices
+      it can be a list of dummy indices of the same type
+      or a list of lists of dummy indices, one list for each
+      type of index;
+      the dummy indices must come after the free indices,
+      and put in order contravariant, covariant
+      [d0, -d0, d1,-d1,...]
+    msym :  symmetry of the metric(s)
+        it can be an integer or a list;
+        in the first case it is the symmetry of the dummy index metric;
+        in the second case it is the list of the symmetries of the
+        index metric for each type
+    v : list, (base_i, gens_i, n_i, sym_i) for tensors of type `i`
 
-      v     is a list of (base_i, gens_i, n_i, sym_i) for tensors of type `i`
-            base_i, gens_i BSGS for tensors of this type.
+    base_i, gens_i : BSGS for tensors of this type.
+        The BSGS should have minimal base under lexicographic ordering;
+        if not, an attempt is made do get the minimal BSGS;
+        in case of failure,
+        canonicalize_naive is used, which is much slower.
 
-            The BSGS should have minimal base under lexicographic ordering;
-            if not, an attempt is made do get the minimal BSGS;
-            in case of failure,
-            canonicalize_naive is used, which is much slower.
+    n_i :    number of tensors of type `i`.
 
-            n_i     number of tensors of type `i`.
+    sym_i :  symmetry under exchange of component tensors of type `i`.
 
-            sym_i   symmetry under exchange of component tensors of type `i`.
-
-      Both for msym and sym_i the cases are
+        Both for msym and sym_i the cases are
             * None  no symmetry
             * 0     commuting
             * 1     anticommuting
 
-    Return 0 if the tensor is zero, else return the array form of
+    Returns
+    =======
+
+    0 if the tensor is zero, else return the array form of
     the permutation representing the canonical form of the tensor.
 
     Algorithm
@@ -686,7 +697,7 @@ def canonicalize(g, dummies, msym, *v):
 
     g = [1,3,0,5,4,2,6,7]
 
-    T_c = 0
+    `T_c = 0`
 
     >>> from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, canonicalize, bsgs_direct_product
     >>> from sympy.combinatorics import Permutation
@@ -701,7 +712,7 @@ def canonicalize(g, dummies, msym, *v):
 
     `T_c = -A^{d0 d1} * B_{d0}{}^{d2} * B_{d1 d2}`
 
-    `can = [0,2,1,4,3,5,7,6]`
+    can = [0,2,1,4,3,5,7,6]
 
     >>> t1 = (base2a, gens2a, 2, 1)
     >>> canonicalize(g, range(6), 0, t0, t1)
@@ -843,6 +854,7 @@ def perm_af_direct_product(gens1, gens2, signed=True):
 
     Examples
     ========
+
     >>> from sympy.combinatorics.tensor_can import perm_af_direct_product
     >>> gens1 = [[1,0,2,3], [0,1,3,2]]
     >>> gens2 = [[1,0]]
@@ -887,6 +899,7 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import (get_symmetric_group_sgs, bsgs_direct_product)
     >>> Permutation.print_cyclic = True
@@ -917,6 +930,7 @@ def get_symmetric_group_sgs(n, sym=0):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import get_symmetric_group_sgs
     >>> Permutation.print_cyclic = True
@@ -958,6 +972,7 @@ def _is_minimal_bsgs(base, gens):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import riemann_bsgs, _is_minimal_bsgs
     >>> _is_minimal_bsgs(*riemann_bsgs)

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -333,7 +333,7 @@ def test_canonicalize1():
     can = canonicalize(g, range(8), 1, (base3, gens3,2,1), (base2a,gens2a,1,0))
     assert can == [0,2,4, 1,3,6, 5,7, 9,8]
 
-    # A anticommuting symmetric, B anticommuting anticommuting, 
+    # A anticommuting symmetric, B anticommuting anticommuting,
     # no metric symmetry
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -305,12 +305,11 @@ def test_canonicalize1():
     # g = [10,4,8, 0,7,9, 6,11,1, 2,3,5, 12,13]
     # T_c = A^{a0 d0 d1}*A^a1_d0^d2*A^{a2 a3 d3}*A_{d1 d2 d3}
     # can = [0,4,6, 1,5,8, 2,3,10, 7,9,11, 12,13]
-    base3, gens3 = get_symmetric_group_sgs(3)
     g = Permutation([10,4,8, 0,7,9, 6,11,1, 2,3,5, 12,13])
     can = canonicalize(g, range(4,12), 0, (base3, gens3, 4, 0))
     assert can == [0,4,6, 1,5,8, 2,3,10, 7,9,11, 12,13]
 
-    # A commuting symmetric, B anticommuting
+    # A commuting symmetric, B antisymmetric
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # ord = [d0,-d0,d1,-d1,d2,-d2,d3,-d3]
     # g = [0,2,4,5,7,3,1,6,8,9]
@@ -327,14 +326,15 @@ def test_canonicalize1():
     # can = [0,2,4, 1,3,6, 5,7, 8,9]
     can = canonicalize(g, range(8), 0, (base3, gens3,2,1), (base2a,gens2a,1,0))
     assert can == [0,2,4, 1,3,6, 5,7, 8,9]
-    # A anticommuting symmetric, B anticommuting, antisymmetric metric
+    # A anticommuting symmetric, B antisymmetric commuting, antisymmetric metric
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = -A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
     # can = [0,2,4, 1,3,6, 5,7, 9,8]
     can = canonicalize(g, range(8), 1, (base3, gens3,2,1), (base2a,gens2a,1,0))
     assert can == [0,2,4, 1,3,6, 5,7, 9,8]
 
-    # A anticommuting symmetric, B anticommuting, no metric symmetry
+    # A anticommuting symmetric, B anticommuting anticommuting, 
+    # no metric symmetry
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
     # can = [0,2,4, 1,3,7, 5,6, 8,9]
@@ -403,6 +403,8 @@ def test_riemann_invariants():
     # R_d11^d1_d0^d5 * R^{d6 d4 d0}_d5 * R_{d7 d2 d8 d9} *
     # R_{d10 d3 d6 d4} * R^{d2 d7 d11}_d1 * R^{d8 d9 d3 d10}
     # ord: contravariant d_k ->2*k, covariant d_k -> 2*k+1
+    # T_c = R^{d0 d1 d2 d3} * R_{d0 d1}^{d4 d5} * R_{d2 d3}^{d6 d7} *
+    # R_{d4 d5}^{d8 d9} * R_{d6 d7}^{d10 d11} * R_{d8 d9 d10 d11}
     g = Permutation([23,2,1,10,12,8,0,11,15,5,17,19,21,7,13,9,4,14,22,3,16,18,6,20,24,25])
     can = canonicalize(g, range(24), 0, (baser, gensr, 6, 0))
     assert can == [0,2,4,6,1,3,8,10,5,7,12,14,9,11,16,18,13,15,20,22,17,19,21,23,24,25]
@@ -411,8 +413,6 @@ def test_riemann_invariants():
     can = canonicalize(g, range(24), 0, ([2, 0], [Permutation([1,0,2,3,5,4]), Permutation([2,3,0,1,4,5])], 6, 0))
     assert can == [0,2,4,6,1,3,8,10,5,7,12,14,9,11,16,18,13,15,20,22,17,19,21,23,24,25]
 
-    #R^{d0 d1 d2 d3} * R_{d0 d1}^{d4 d5} * R_{d2 d3}^{d6 d7} *
-    # R_{d4 d5}^{d8 d9} * R_{d6 d7}^{d10 d11} * R_{d8 d9 d10 d11}
     g = Permutation([0,2,5,7,4,6,9,11,8,10,13,15,12,14,17,19,16,18,21,23,20,22,25,27,24,26,29,31,28,30,33,35,32,34,37,39,36,38,1,3,40,41])
     can = canonicalize(g, range(40), 0, (baser, gensr, 10, 0))
     assert can == [0,2,4,6,1,3,8,10,5,7,12,14,9,11,16,18,13,15,20,22,17,19,24,26,21,23,28,30,25,27,32,34,29,31,36,38,33,35,37,39,40,41]
@@ -470,6 +470,8 @@ def test_riemann_products():
     # R^{d2 a0 a2 d0} * R^d1_d2^{a1 a3} * R^{a4 a5}_{d0 d1}
     # ord = [a0,a1,a2,a3,a4,a5,d0,-d0,d1,-d1,d2,-d2]
     #         0  1  2  3 4  5  6   7  8   9  10  11
+    # can = [0, 6, 2, 8, 1, 3, 7, 10, 4, 5, 9, 11, 12, 13]
+    # T_c = R^{a0 d0 a2 d1}*R^{a1 a3}_d0^d2*R^{a4 a5}_{d1 d2}
     g = Permutation([10,0,2,6,8,11,1,3,4,5,7,9,12,13])
     can = canonicalize(g, range(6,12), 0, (baser, gensr, 3, 0))
     assert can == [0, 6, 2, 8, 1, 3, 7, 10, 4, 5, 9, 11, 12, 13]

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -241,6 +241,18 @@ def test_no_metric_symmetry():
     can = canonicalize(g, range(16), None, [[], [Permutation(range(4))], 8, 0])
     assert can == [0,3,2,5,4,7,6,1,8,11,10,13,12,15,14,9,16,17]
 
+def test_canonical_free():
+    # t = A^{d0 a1}*A_d0^a0
+    # ord = [a0,a1,d0,-d0];  g = [2,1,3,0,4,5]; dummies = [[2,3]]
+    # t_c = A_d0^a0*A^{d0 a1}
+    # can = [3,0, 2,1, 4,5]
+    base = [0]
+    gens = [Permutation(5)(0,2)(1,3)]
+    g = Permutation([2,1,3,0,4,5])
+    num_free = 2
+    dummies = [[2,3]]
+    can = canonicalize(g, dummies, [None], ([], [Permutation(3)], 2, 0))
+    assert can == [3,0, 2,1, 4,5]
 
 def test_canonicalize1():
     base1, gens1 = get_symmetric_group_sgs(1)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -70,6 +70,7 @@ class Basic(object):
     is_Boolean = False
     is_Not = False
     is_Matrix = False
+    is_Tensor = False
 
     @property
     @deprecated(useinstead="is_Float", issue=1721, deprecated_since_version="0.7.0")

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -70,7 +70,6 @@ class Basic(object):
     is_Boolean = False
     is_Not = False
     is_Matrix = False
-    is_Tensor = False
 
     @property
     @deprecated(useinstead="is_Float", issue=1721, deprecated_since_version="0.7.0")

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,18 +2447,37 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
+def test_sympy__tensor__tensor__TensorIndexType():
+    from sympy.tensor.tensor import TensorIndexType
+    from sympy import Symbol
+    assert _test_args(TensorIndexType(Symbol('Lorentz'), metric_antisym=S.Zero))
+
+@XFAIL
+def test_sympy__tensor__tensor__TensorSymmetry():
+    from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    assert _test_args(TensorSymmetry(get_symmetric_group_sgs(2)))
+
+
+@XFAIL
 def test_sympy__tensor__tensor__TensorType():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, TensorType
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     assert _test_args(TensorType([Lorentz], sym))
 
+@XFAIL
 def test_sympy__tensor__tensor__TensorHead():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, TensorHead
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     assert _test_args(TensorHead('p', S1, 0))
+
+@XFAIL
+def test_sympy__tensor__tensor__TensorIndex():
+    from sympy.tensor.tensor import TensorIndexType, TensorIndex, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    assert _test_args(TensorIndex('i', Lorentz))
 
 @SKIP("abstract class")
 def test_sympy__tensor__tensor__TensExpr():
@@ -2476,16 +2495,16 @@ def test_sympy__tensor__tensor__TensAdd():
     assert _test_args(TensAdd(t1, t2))
 
 
-def test_sympy__tensor__tensor__Tensor():
+def test_sympy__tensor__tensor__TensMul():
     from sympy.core import S
-    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, Tensor
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensMul
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     p = S1('p')
-    free, dum =  Tensor.from_indices(a)
-    assert _test_args(Tensor(S.One, [p], free, dum))
+    free, dum =  TensMul.from_indices(a)
+    assert _test_args(TensMul(S.One, [p], free, dum))
 
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,6 +2447,47 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
+def test_sympy__tensor__tensor__TensorType():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, TensorType
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    assert _test_args(TensorType([Lorentz], sym))
+
+def test_sympy__tensor__tensor__TensorHead():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, TensorHead
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym)
+    assert _test_args(TensorHead('p', S1, 0))
+
+@SKIP("abstract class")
+def test_sympy__tensor__tensor__TensExpr():
+    pass
+
+def test_sympy__tensor__tensor__TensAdd():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensAdd
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b = tensor_indices('a,b', Lorentz)
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym)
+    p, q = S1('p,q')
+    t1 = p(a)
+    t2 = q(a)
+    assert _test_args(TensAdd(t1, t2))
+
+
+def test_sympy__tensor__tensor__Tensor():
+    from sympy.core import S
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, Tensor
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b = tensor_indices('a,b', Lorentz)
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym)
+    p = S1('p')
+    free, dum =  Tensor.from_indices(a)
+    assert _test_args(Tensor(S.One, [p], free, dum))
+
+
 
 @XFAIL
 def test_as_coeff_add():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,10 +2447,11 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
+@XFAIL
 def test_sympy__tensor__tensor__TensorIndexType():
     from sympy.tensor.tensor import TensorIndexType
     from sympy import Symbol
-    assert _test_args(TensorIndexType(Symbol('Lorentz'), metric_antisym=S.Zero))
+    assert _test_args(TensorIndexType('Lorentz', metric=False))
 
 @XFAIL
 def test_sympy__tensor__tensor__TensorSymmetry():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -338,6 +338,9 @@ class StrPrinter(Printer):
     def _print_TensorIndex(self, expr):
         return expr._pretty()
 
+    def _print_TensorHead(self, expr):
+        return expr._pretty()
+
     def _print_TensMul(self, expr):
         return expr._pretty()
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -335,7 +335,10 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
-    def _print_Tensor(self, expr):
+    def _print_TensorIndex(self, expr):
+        return expr._pretty()
+
+    def _print_TensMul(self, expr):
         return expr._pretty()
 
     def _print_TensAdd(self, expr):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -335,6 +335,12 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
+    def _print_Tensor(self, expr):
+        return expr._pretty()
+
+    def _print_TensAdd(self, expr):
+        return expr._pretty()
+
     def _print_PermutationGroup(self, expr):
         p = ['    %s' % str(a) for a in expr.args]
         return 'PermutationGroup([\n%s])' % ',\n'.join(p)

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -66,7 +66,7 @@ class GammaMatrices(object):
         """
         if not isinstance(t, TensExpr):
             return t
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             a = [self.G5_to_right(x) for x in t.args]
             return TensAdd(*a)
         components = t._components
@@ -224,7 +224,7 @@ class GammaMatrices(object):
         """
         if not isinstance(t, TensExpr):
             return t
-        if t.is_TensMul:
+        if isinstance(t, TensMul):
             for n in range(nmax + 1):
                 r = self.match1_gamma(t, n)
                 if not r:
@@ -236,7 +236,7 @@ class GammaMatrices(object):
                         t1 = self.do_rule1_gamma(t1, nmax, doall)
                 return t1
             return t
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             a = [self.do_rule1_gamma(tx, nmax, doall) for tx in t.args]
             t1 = TensAdd(*a)
             return t1.contract_metric(self.g, contract_all=True)
@@ -359,10 +359,10 @@ class GammaMatrices(object):
         """
         if not isinstance(t, TensExpr):
             return t
-        if t.is_TensMul:
+        if isinstance(t, TensMul):
             for n in range(nmax + 1):
                 t = self.rule2_gamma(t, n)
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             a = [self.do_rule2_gamma(tx) for tx in t.args]
             t = TensAdd(*a)
         return t
@@ -398,7 +398,7 @@ class GammaMatrices(object):
         if not isinstance(t, TensExpr):
             return self.gctr*t
         t = self.G5_to_right(t)
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             a = [self.gamma_trace(x) for x in t.args]
             return TensAdd(*a)
         components = t._components

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -39,6 +39,8 @@ class GammaMatrices(object):
         with Lorentz signature `g5c = I`, which is the default;
         in Euclidean space `g5c = 1`
 
+        The attribute `Gsymbol` can be used to set commutation relations
+        with other tensors using ``TensorManager``.
         """
         self.g = typ.metric
         if not typ.dim:
@@ -47,10 +49,11 @@ class GammaMatrices(object):
         self.typ = typ
         sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
         S1 = TensorType([typ], sym1)
-        self.G = S1('G', 2)
+        self.Gsymbol = Symbol('Gsymbol')
+        self.G = S1('G', self.Gsymbol)
         sym0 = TensorSymmetry(([], [Permutation(1)]))
         S0 = TensorType([], sym0)
-        self.Gamma5 = S0('G5', 2)
+        self.Gamma5 = S0('G5', self.Gsymbol)
         self.G5 = TensMul(S.One, [self.Gamma5], [], [])
         self.g5c = g5c
         self.epsilon = typ.epsilon

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -47,10 +47,10 @@ class GammaMatrices(object):
         self.typ = typ
         sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
         S1 = TensorType([typ], sym1)
-        self.G = S1('G', None)
+        self.G = S1('G', 2)
         sym0 = TensorSymmetry(([], [Permutation(1)]))
         S0 = TensorType([], sym0)
-        self.Gamma5 = S0('G5', None)
+        self.Gamma5 = S0('G5', 2)
         self.G5 = TensMul(S.One, [self.Gamma5], [], [])
         self.g5c = g5c
         self.epsilon = typ.epsilon
@@ -256,7 +256,7 @@ class GammaMatrices(object):
                     p_pos2 = dx[3]
             if p_pos1 > 0 and p_pos2 > 0:
                 if components[p_pos1] == components[p_pos2] \
-                    and components[p_pos1].anticomm == 0:
+                    and components[p_pos1].comm == 0:
                     return i, p_pos1, p_pos2
         return None
 

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -1,0 +1,532 @@
+from sympy import Symbol, S, I
+from sympy.combinatorics import Permutation
+from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
+  TensorSymmetry, get_symmetric_group_sgs, TensorType, tensor_mul, Tensor,
+  TensAdd, TensorHead, tensorlist_contract_metric)
+
+
+class GammaMatrices(object):
+    """
+    Gamma matrices in dimensional regularization
+    with G5 naively anticommuting with all gamma matrices (NDR)
+
+    NDR is inconsistent but widely used.
+    Notice in particular that the cyclic property of the
+    trace in presence of G5 does not hold.
+
+    The original dimensional regularization scheme by 't Hooft and Veltman
+    has `G5` anticommuting only with `G(m)` for `m` in 0,1,2,3,
+    and commuting for `m > 3`. It is consistent, and it is used to
+    compute the chiral anomaly; however it breaks gauge invariance
+    involving G5 even when there are no anomalies, which complicates
+    a lot maintaining the Ward (or Slavnov-Taylor) identities.
+
+    TODO: introduce the option of using the 't Hooft and Veltman scheme.
+    """
+
+    def __init__(self, typ, gctr=4, g5c=I):
+        """
+        typ  TensorIndexType (Lorentz or Eulidean)
+
+        gct3  `tr(G(m)*G(n)) = gctr*g(m,n)`
+        in D dimensions, when D is an integer, the gamma
+        matrices are represented with matrices or rank `2**(D//2)`,
+        so `gctr = 2**(D//2)`;
+        in dimensional regularization one uses usually
+        `gctr = 4*g(m,n)`, so we choose `gctr=4` as default.
+
+        g5c  `tr(G(m0)*G(m1)*G(m2)*G(m3)) = gctr*g5c*epsilon(m0,m1,m2,m3)`
+        with Lorentz signature `g5c = I`, which is the default;
+        in Euclidean space `g5c = 1`
+
+        """
+        self.g = typ.metric
+        if not typ.dim:
+            raise ValueError('Dimension not assigned')
+        self.D = typ.dim
+        self.typ = typ
+        sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        S1 = TensorType([typ], sym1)
+        self.G = S1('G', None)
+        sym0 = TensorSymmetry(([], [Permutation(1)]))
+        S0 = TensorType([], sym0)
+        self.Gamma5 = S0('G5', None)
+        self.G5 = Tensor(S.One, [self.Gamma5], [], [])
+        self.g5c = g5c
+        self.epsilon = typ.epsilon
+        self.eps_dim = typ.eps_dim
+        self.gctr = gctr
+
+    def G5_to_right(self, t):
+        """
+        move G5 to the right
+        """
+        if not t.is_Tensor:
+            return t
+        if t.is_TensAdd:
+            a = [self.G5_to_right(x) for x in t.args]
+            return TensAdd(*a)
+        components = t.components
+        if not t.components:
+            return t
+        ncomps = len(components)
+        G = self.G
+        Gamma5 = self.Gamma5
+        G5 = self.G5
+        # [g5,g,g,g5,g,g]
+        numG = 0
+        vposG5 = []
+        for i in range(ncomps):
+            if components[i] == Gamma5:
+                vposG5.append(i)
+                for j in range(i + 1, ncomps):
+                    if components[j] == G:
+                        numG += 1
+        ct = t.coeff if 0 in vposG5 else S.One
+        a = t.split()
+        a1 = []
+        for i in range(ncomps):
+            if not i in vposG5:
+                a1.append(a[i])
+        for i in range(ncomps - 1, -1, -1):
+            if components[i] == G:
+                break
+        if len(vposG5) % 2:
+            a1 = a1[:i + 1] + [G5] + a1[i + 1:ncomps]
+        else:
+            a1 = a1[:i + 1] + a1[i + 1:ncomps]
+        t1 = ((-1)**numG*ct)*tensor_mul(*a1)
+        return t1
+
+    def match1_gamma(self, t, n):
+        #t = t.sorted_components()
+        components = t.components
+        ncomps = len(components)
+        G = self.G
+        for i in range(ncomps):
+            if not components[i] == G:
+                continue
+            for j in range(i + 1, ncomps):
+                if components[j] == G and abs(j - i) == n + 1 and \
+                        (0, 0, i, j) in t.dum:
+                    return i, j
+
+
+    def rule1_gamma(self, t, n, r=None):
+        """
+        simplify products of gamma matrices `G(m)*G(m_1)...*G(m_n)*G(-m)`
+
+        t   Gamma matrix monomial
+        n   apply rule for `G(m)*G(m_1)...*G(m_n)*G(-m)`
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> GM.gamma_trace(G(m0)*G(m1)*G(-m0)*G(m3))
+        (-4*D + 8)*metric(m1, m3)
+        >>> t = G(m1)*G(m0)*G(-m1)*G(-m0)
+        >>> GM.rule1_gamma(t, 1)
+        (-D + 2)*G(L_0)*G(-L_0)
+        """
+        if not r:
+            r = self.match1_gamma(t, n)
+            if not r:
+                return t
+        i, j = r
+        a = t.split()
+        za = zip(a, range(len(a)))
+        tc = t.coeff if i == 0 else S.One
+        a1 = [x for x, y in za if y not in r]
+        D = self.D
+        if n == 0:
+            # G(m)*G(-m) = d
+            t1 = tensor_mul(*a1)
+            t2 = Tensor(D*t1.coeff*tc, t1.components, t1.free, t1.dum)
+            return t2
+        if n == 1:
+            # G(m)*G(n)*G(-m) = (2 - d)*G(n)
+            t1 = tensor_mul(*a1)
+            t2 = Tensor((2-D)*t1.coeff*tc, t1.components, t1.free, t1.dum)
+            return t2
+        if n == 2:
+            # G(m)*G(n1)*G(n2)*G(-m) = (d-4)*G(n1)*G(n2) + 4*delta(n1, n2)
+            t1 = ((D-4)*tc)*tensor_mul(*a1)
+            a2 = a[:i] + a[j + 1:]
+            ind1 = a[r[0] + 1].free[0][0]
+            ind2 = a[r[1] - 1].free[0][0]
+            if a2:
+                a2 = tensorlist_contract_metric(a2, self.g(ind1, ind2))
+                t2 = (4*tc)*tensor_mul(*a2)
+            else:
+                t2 = (4*tc)*self.g(ind1, ind2)
+            return t1 + t2
+        if n == 3:
+            # G(m)*G(n1)*G(n2)*G(n3)*G(-m) = (4-d)*G(n1)*G(n2)*G(n3) - \
+            #  2*G(n3)*G(n2)*G(n1)
+            t1 = ((4-D)*tc)*tensor_mul(*a1)
+            a2a = a[i + 1:j]
+            a2a.reverse()
+            a2 = a[:i] + a2a + a[j + 1:]
+            t2 = (-2*tc)*tensor_mul(*a2[:])
+            return t1 + t2
+        if n > 3:
+            # G(m0)*G(m_1)*...*G(m_k)*G(-m0) =
+            # 2*G(m_k)*G(m_1)*...*G(m_(k-1)) -
+            # G(m0)*G(m_1)*...*G(m_(k-1))G(-m0)*G(m_k))
+            a1 = a[:i] + [a[j-1]] + a[i+1:j-1] + a[j + 1:]
+            t1 = (2*tc)*tensor_mul(*a1)
+            a2 = a[:j-1] + [a[j], a[j-1]] + a[j + 1:]
+            t2 = -tensor_mul(*a2)
+            return t1 + t2
+
+
+    def do_rule1_gamma(self, t, nmax=4, doall=False):
+        """
+        simplify products of gamma matrices `G(m)*G(m_1)...*G(m_n)*G(-m)`
+
+        `t` Gamma matrix expression
+
+        nmax  maximum number for which `rule1\_gamma(t, n)` is applied
+
+        doall  if true apply `rule1\_gamma` till the expression does not change
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> t = G(m1)*G(m0)*G(-m1)*G(-m0)
+        >>> GM.do_rule1_gamma(t, doall=True)
+        D*(-D + 2)
+        """
+        if not t.is_Tensor:
+            return t
+        if t.is_TensMul:
+            for n in range(nmax + 1):
+                #print 'DB10 t=%s n=%d' %(t, n)
+                r = self.match1_gamma(t, n)
+                if not r:
+                    continue
+                t1 = self.rule1_gamma(t, n, r)
+                t1 = t1.contract_metric(self.g, contract_all=True)
+                if doall:
+                    if t1 != t:
+                        t1 = self.do_rule1_gamma(t1, nmax, doall)
+                return t1
+            return t
+        if t.is_TensAdd:
+            a = [self.do_rule1_gamma(tx, nmax, doall) for tx in t.args]
+            t1 = TensAdd(*a)
+            return t1.contract_metric(self.g, contract_all=True)
+
+    def match2_gamma(self, t, n):
+        components = t.components
+        ncomps = len(components)
+        G = self.G
+        # G(a)*G(b)*...*p(-a)*p(-b)
+        for i in range(ncomps - 1 - n):
+            if not components[i] == G:
+                continue
+            if not components[i + n + 1] == G:
+                continue
+            p_pos1 = p_pos2 = 0
+            for dx in t.dum:
+                if dx[2] == i:
+                    p_pos1 = dx[3]
+                if dx[2] == i + n + 1:
+                    p_pos2 = dx[3]
+            if p_pos1 > 0 and p_pos2 > 0:
+                if components[p_pos1] == components[p_pos2] \
+                    and components[p_pos1].commuting == 0:
+                    return i, p_pos1, p_pos2
+        return None
+
+    def rule2_gamma(self, t, n):
+        """
+        simplify `G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)`
+
+        `t`    Gamma matrix monomial
+        `n` as in  `G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)`
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> p = S1('p')
+        >>> ps = G(m0)*p(-m0)
+        >>> t = G(m0)*ps*ps*G(-m0)
+        >>> GM.rule2_gamma(t, 0)
+        G(L_0)*G(-L_0)*p(L_1)*p(-L_1)
+        """
+        t = t.canon_bp()
+        r = self.match2_gamma(t, n)
+        if not r:
+            return t
+        i0, i1, i2 = r
+        if n == 0:
+            a = t.split()
+            ct = t.coeff if i0 == 0 else S.One
+            p = a[i1]
+            ind_p = p.free[0][0]
+            # G(m0)*G(m1)*p(-m0)*p(-m1) = p(m0)*p(-m0)
+            a1 = a[:i0] + a[i0 + 2:i1] + a[i1 + 1:i2] + a[i2 + 1:]
+            a2 = [p.substitute_indices((ind_p, -ind_p)), p]
+            a3 = a1 + a2
+            t = tensor_mul(*a3)*ct
+            return t
+        elif n == 1:
+            # G(m0)*G(ind1)*G(m1)*p(-m0)*p(-m1) =
+            # 2*G(m0)*p(-m0)*p(ind1) - G(ind1)*p(m0)*p(-m0)
+            a = t.split()
+            ind1 = a[i0 + 1].free[0][0]
+            ct = t.coeff if i0 == 0 else S.One
+            p = a[i1]
+            ind_p = p.free[0][0]
+            a1 = a[:i0] + [a[i0 + 1]] + a[i0 + 3:i1] + a[i1 + 1:i2] + a[i2 + 1:]
+            a2 = [p.substitute_indices((ind_p, -ind_p)), p]
+            a3 = a1 + a2
+            t1 = tensor_mul(*a3)*(-ct)
+            args = [t1]
+            a1 = a[:i0 + 1] + a[i0 + 3:i2] + a[i2 + 1:]
+            p = a[i2]
+            ind_p = p.free[0][0]
+            a2 = [p.substitute_indices((ind_p, ind1))]
+            a3 = a1 + a2
+            t2 = tensor_mul(*a3)*2
+            t3 = t1 + t2
+            return t3
+        else:
+            raise NotImplementedError
+
+    def do_rule2_gamma(self, t, nmax=1):
+        """
+        simplify `G(m0)*p(-m0)*G(m1)*p(-m1)` to `p(m)*p(-m)`
+
+        `t`    Gamma matrix expression
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> p = S1('p')
+        >>> ps = G(m0)*p(-m0)
+        >>> M = Symbol('M')
+        >>> t = G(m0)*(ps + M)*(ps - M)*G(-m0)
+        >>> GM.do_rule2_gamma(t)
+        (-M**2)*G(L_0)*G(-L_0) + G(L_0)*G(-L_0)*p(L_1)*p(-L_1)
+        """
+        if not t.is_Tensor:
+            return t
+        if t.is_TensMul:
+            for n in range(nmax + 1):
+                t = self.rule2_gamma(t, n)
+        if t.is_TensAdd:
+            a = [self.do_rule2_gamma(tx) for tx in t.args]
+            t = TensAdd(*a)
+        return t
+
+
+    def gamma_trace(self, t):
+        """
+        Trace of gamma matrices
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+                TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices( Lorentz)
+        >>> gamma_trace = GM.gamma_trace
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> gamma_trace(G(m0)*G(m1)*G(-m0)*G(m3))
+        (-4*D + 8)*metric(m1, m3)
+
+        >>> p, q = S1('p,q')
+        >>> t = G(m0)*G(m1)*G(m2)*G(m3)*p(-m1)*q(-m3)
+        >>> gamma_trace(t)
+        -4*metric(m0, m2)*p(L_0)*q(-L_0) + 4*p(m0)*q(m2) + 4*p(m2)*q(m0)
+        """
+        if not t.is_Tensor:
+            return self.gctr*t
+        t = self.G5_to_right(t)
+        if t.is_TensAdd:
+            a = [self.gamma_trace(x) for x in t.args]
+            return TensAdd(*a)
+        components = t.components
+        ncomps = len(components)
+        G = self.G
+        G5 = self.G5
+        Gamma5 = self.Gamma5
+        g = self.g
+        if all(x != G for x in components):
+            if any(x == Gamma5 for x in components):
+                return Tensor(S.Zero, [], [], [])
+            return self.gctr*t
+        withG5 = False
+        t = t.canon_bp()
+        components = t.components
+        for i in range(ncomps):
+            if components[i] == G:
+                break
+        for j in range(i + 1, ncomps):
+            if not components[j] == G:
+                break
+        else:
+            j = ncomps
+        numG = j - i
+        if any(x == Gamma5 for x in components):
+            withG5 = True
+        if withG5:
+            if numG < 4 or numG % 2 != self.eps_dim % 2:
+                return Tensor(S.Zero, [], [], [])
+            if numG == 4:
+                a = t.split()
+                indices = [x.free[0][0] for x in a[i:j]]
+                ct = t.coeff if i == 0 else S.One
+                t1 = (self.gctr*ct*self.g5c)*self.epsilon(*indices)
+                a2 = a[:i] + a[j + 1:]
+                t2 = tensor_mul(*a2)
+                res = t1*t2
+                res = res.canon_bp()
+                return res
+            if numG > 4:
+                prev = Tensor(S.Zero, [], [], [])
+                t2 = t
+                while True:
+                    t2 = self.do_rule1_gamma(t2)
+                    t2 = t2.contract_metric(g, contract_all=True)
+                    t2 = self.do_rule2_gamma(t2)
+                    if t2 == prev:
+                        break
+                    prev = t2
+                if t == t2:
+                    a = t.split()
+                    args = []
+                    for k1 in range(i, j):
+                        ind1 = a[k1].free[0][0]
+                        for k2 in range(k1 + 1, j):
+                            ind2 = a[k2].free[0][0]
+                            sign = 1 if (k1 - k2) % 2 == 1 else -1
+                            a1 = a[:k1] + a[k1 + 1:k2] + a[k2 + 1:]
+                            a1 = tensorlist_contract_metric(a1, g(ind1, ind2))
+                            ct = t.coeff if k1 == 0 else S.One
+                            t1 = (sign*ct)*tensor_mul(*a1)
+                            args.append(t1)
+                    t2 = TensAdd(*args)
+                    return self.gamma_trace(t2)
+                else:
+                    return self.gamma_trace(t2)
+        else:
+            # without G5
+            if numG % 2 == 1:
+                return Tensor(S.Zero, [], [], [])
+            if numG > 4:
+                prev = Tensor(S.Zero, [], [], [])
+                t2 = t
+                while True:
+                    t2 = self.do_rule1_gamma(t2)
+                    t2 = t2.contract_metric(g, contract_all=True)
+                    t2 = self.do_rule2_gamma(t2)
+                    if t2 == prev:
+                        break
+                    prev = t2
+                if t == t2:
+                    a = t.split()
+                    # G are from i to j1 included; anticommute G(j1) through
+                    ind1 = a[i].free[0][0]
+                    ind2 = a[i + 1].free[0][0]
+                    aa = a[:i] + a[i + 2:]
+                    aa = tensorlist_contract_metric(aa, g(ind1, ind2))
+                    ct = t.coeff if i == 0 else S.One
+                    t1 = ct*tensor_mul(*aa)
+                    args = [t1]
+                    sign = 1
+                    for k in range(i + 2, j):
+                        sign = -sign
+                        ind2 = a[k].free[0][0]
+                        aa = a[:i] + a[i + 1:k] + a[k + 1:]
+                        aa = tensorlist_contract_metric(aa, g(ind1, ind2))
+                        t2 = sign*tensor_mul(*aa)
+                        args.append(t2)
+                    t3 = TensAdd(*args)
+                    return self.gamma_trace(t3)
+                return self.gamma_trace(t2)
+
+            a = t.split()
+            t1 = self.gamma_trace1(*a[i:j])
+            a2 = a[:i] + a[j:]
+            t2 = tensor_mul(*a2)
+            ct = t.coeff if i == 0 else S.One
+            t3 = ct*t1*t2
+            if not t3:
+                return t3
+            t3 = t3.contract_metric(g, contract_all=True)
+            return t3
+
+
+    def gamma_trace1(self, *a):
+        if not a:
+            return self.gctr
+        n = len(a)
+        if n%2 == 1:
+            return Tensor(S.Zero, [], [], [])
+        if n == 2:
+            ind0 = a[0].free[0][0]
+            ind1 = a[1].free[0][0]
+            return self.gctr*self.g(ind0, ind1)
+        if n == 4:
+            ind0 = a[0].free[0][0]
+            ind1 = a[1].free[0][0]
+            ind2 = a[2].free[0][0]
+            ind3 = a[3].free[0][0]
+            return self.gctr*(self.g(ind0, ind1)*self.g(ind2, ind3) - \
+                self.g(ind0, ind2)*self.g(ind1, ind3) + self.g(ind0, ind3)*self.g(ind1, ind2))
+        else:
+            raise NotImplementedError

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -1,7 +1,7 @@
 from sympy import Symbol, S, I
 from sympy.combinatorics import Permutation
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
-  TensorSymmetry, get_symmetric_group_sgs, TensorType, tensor_mul, Tensor,
+  TensorSymmetry, get_symmetric_group_sgs, TensorType, tensor_mul, TensMul,
   TensAdd, TensorHead, tensorlist_contract_metric)
 
 
@@ -51,7 +51,7 @@ class GammaMatrices(object):
         sym0 = TensorSymmetry(([], [Permutation(1)]))
         S0 = TensorType([], sym0)
         self.Gamma5 = S0('G5', None)
-        self.G5 = Tensor(S.One, [self.Gamma5], [], [])
+        self.G5 = TensMul(S.One, [self.Gamma5], [], [])
         self.g5c = g5c
         self.epsilon = typ.epsilon
         self.eps_dim = typ.eps_dim
@@ -124,7 +124,7 @@ class GammaMatrices(object):
 
         >>> from sympy import Symbol, S
         >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
-            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
         >>> from sympy.tensor.dgamma_matr import GammaMatrices
         >>> D = Symbol('D')
         >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
@@ -152,12 +152,12 @@ class GammaMatrices(object):
         if n == 0:
             # G(m)*G(-m) = d
             t1 = tensor_mul(*a1)
-            t2 = Tensor(D*t1._coeff*tc, t1._components, t1._free, t1._dum)
+            t2 = TensMul(D*t1._coeff*tc, t1._components, t1._free, t1._dum)
             return t2
         if n == 1:
             # G(m)*G(n)*G(-m) = (2 - d)*G(n)
             t1 = tensor_mul(*a1)
-            t2 = Tensor((2-D)*t1._coeff*tc, t1._components, t1._free, t1._dum)
+            t2 = TensMul((2-D)*t1._coeff*tc, t1._components, t1._free, t1._dum)
             return t2
         if n == 2:
             # G(m)*G(n1)*G(n2)*G(-m) = (d-4)*G(n1)*G(n2) + 4*delta(n1, n2)
@@ -206,7 +206,7 @@ class GammaMatrices(object):
 
         >>> from sympy import Symbol, S
         >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
-            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
         >>> from sympy.tensor.dgamma_matr import GammaMatrices
         >>> D = Symbol('D')
         >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
@@ -256,7 +256,7 @@ class GammaMatrices(object):
                     p_pos2 = dx[3]
             if p_pos1 > 0 and p_pos2 > 0:
                 if components[p_pos1] == components[p_pos2] \
-                    and components[p_pos1].commuting == 0:
+                    and components[p_pos1].anticomm == 0:
                     return i, p_pos1, p_pos2
         return None
 
@@ -272,7 +272,7 @@ class GammaMatrices(object):
 
         >>> from sympy import Symbol, S
         >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
-            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
         >>> from sympy.tensor.dgamma_matr import GammaMatrices
         >>> D = Symbol('D')
         >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
@@ -338,7 +338,7 @@ class GammaMatrices(object):
 
         >>> from sympy import Symbol, S
         >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
-            TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
         >>> from sympy.tensor.dgamma_matr import GammaMatrices
         >>> D = Symbol('D')
         >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
@@ -374,7 +374,7 @@ class GammaMatrices(object):
 
         >>> from sympy import Symbol, S
         >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
-                TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+                TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
         >>> from sympy.tensor.dgamma_matr import GammaMatrices
         >>> D = Symbol('D')
         >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
@@ -406,7 +406,7 @@ class GammaMatrices(object):
         g = self.g
         if all(x != G for x in components):
             if any(x == Gamma5 for x in components):
-                return Tensor(S.Zero, [], [], [])
+                return TensMul(S.Zero, [], [], [])
             return self.gctr*t
         withG5 = False
         t = t.canon_bp()
@@ -424,7 +424,7 @@ class GammaMatrices(object):
             withG5 = True
         if withG5:
             if numG < 4 or numG % 2 != self.eps_dim % 2:
-                return Tensor(S.Zero, [], [], [])
+                return TensMul(S.Zero, [], [], [])
             if numG == 4:
                 a = t.split()
                 indices = [x._free[0][0] for x in a[i:j]]
@@ -436,7 +436,7 @@ class GammaMatrices(object):
                 res = res.canon_bp()
                 return res
             if numG > 4:
-                prev = Tensor(S.Zero, [], [], [])
+                prev = TensMul(S.Zero, [], [], [])
                 t2 = t
                 while True:
                     t2 = self.do_rule1_gamma(t2)
@@ -465,9 +465,9 @@ class GammaMatrices(object):
         else:
             # without G5
             if numG % 2 == 1:
-                return Tensor(S.Zero, [], [], [])
+                return TensMul(S.Zero, [], [], [])
             if numG > 4:
-                prev = Tensor(S.Zero, [], [], [])
+                prev = TensMul(S.Zero, [], [], [])
                 t2 = t
                 while True:
                     t2 = self.do_rule1_gamma(t2)
@@ -515,7 +515,7 @@ class GammaMatrices(object):
             return self.gctr
         n = len(a)
         if n%2 == 1:
-            return Tensor(S.Zero, [], [], [])
+            return TensMul(S.Zero, [], [], [])
         if n == 2:
             ind0 = a[0]._free[0][0]
             ind1 = a[1]._free[0][0]

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -381,7 +381,7 @@ class GammaMatrices(object):
         >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
         >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
         >>> S1 = TensorType([Lorentz], sym1)
-        >>> GM = GammaMatrices( Lorentz)
+        >>> GM = GammaMatrices(Lorentz)
         >>> gamma_trace = GM.gamma_trace
         >>> G = GM.G
         >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, S, I
 from sympy.combinatorics import Permutation
-from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
+from sympy.tensor.tensor import (is_Tensor, TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, tensor_mul, TensMul,
   TensAdd, TensorHead, tensorlist_contract_metric)
 
@@ -61,7 +61,7 @@ class GammaMatrices(object):
         """
         move G5 to the right
         """
-        if not t.is_Tensor:
+        if not is_Tensor(t):
             return t
         if t.is_TensAdd:
             a = [self.G5_to_right(x) for x in t.args]
@@ -219,7 +219,7 @@ class GammaMatrices(object):
         >>> GM.do_rule1_gamma(t, doall=True)
         D*(-D + 2)
         """
-        if not t.is_Tensor:
+        if not is_Tensor(t):
             return t
         if t.is_TensMul:
             for n in range(nmax + 1):
@@ -354,7 +354,7 @@ class GammaMatrices(object):
         >>> GM.do_rule2_gamma(t)
         (-M**2)*G(L_0)*G(-L_0) + G(L_0)*G(-L_0)*p(L_1)*p(-L_1)
         """
-        if not t.is_Tensor:
+        if not is_Tensor(t):
             return t
         if t.is_TensMul:
             for n in range(nmax + 1):
@@ -392,7 +392,7 @@ class GammaMatrices(object):
         >>> gamma_trace(t)
         -4*metric(m0, m2)*p(L_0)*q(-L_0) + 4*p(m0)*q(m2) + 4*p(m2)*q(m0)
         """
-        if not t.is_Tensor:
+        if not is_Tensor(t):
             return self.gctr*t
         t = self.G5_to_right(t)
         if t.is_TensAdd:

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, S, I
 from sympy.combinatorics import Permutation
-from sympy.tensor.tensor import (is_Tensor, TensorIndexType, tensor_indices,
+from sympy.tensor.tensor import (TensExpr, TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, tensor_mul, TensMul,
   TensAdd, TensorHead, tensorlist_contract_metric)
 
@@ -61,7 +61,7 @@ class GammaMatrices(object):
         """
         move G5 to the right
         """
-        if not is_Tensor(t):
+        if not isinstance(t, TensExpr):
             return t
         if t.is_TensAdd:
             a = [self.G5_to_right(x) for x in t.args]
@@ -219,7 +219,7 @@ class GammaMatrices(object):
         >>> GM.do_rule1_gamma(t, doall=True)
         D*(-D + 2)
         """
-        if not is_Tensor(t):
+        if not isinstance(t, TensExpr):
             return t
         if t.is_TensMul:
             for n in range(nmax + 1):
@@ -354,7 +354,7 @@ class GammaMatrices(object):
         >>> GM.do_rule2_gamma(t)
         (-M**2)*G(L_0)*G(-L_0) + G(L_0)*G(-L_0)*p(L_1)*p(-L_1)
         """
-        if not is_Tensor(t):
+        if not isinstance(t, TensExpr):
             return t
         if t.is_TensMul:
             for n in range(nmax + 1):
@@ -392,7 +392,7 @@ class GammaMatrices(object):
         >>> gamma_trace(t)
         -4*metric(m0, m2)*p(L_0)*q(-L_0) + 4*p(m0)*q(m2) + 4*p(m2)*q(m0)
         """
-        if not is_Tensor(t):
+        if not isinstance(t, TensExpr):
             return self.gctr*t
         t = self.G5_to_right(t)
         if t.is_TensAdd:

--- a/sympy/tensor/group_factors.py
+++ b/sympy/tensor/group_factors.py
@@ -158,7 +158,7 @@ class SuNGroupFactors(object):
         """
         evaluate a triangle of C's
         """
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             args = t.args
             args = [self.rule_C_triangle(x) for x in args]
             return TensAdd(*args)
@@ -184,7 +184,7 @@ class SuNGroupFactors(object):
         """
         evaluate a square of C's
         """
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             args = t.args
             args = [self.rule_C_square(x) for x in args]
             return TensAdd(*args)
@@ -212,7 +212,7 @@ class SuNGroupFactors(object):
         theta(i_0,..,i_m)*theta(j_0,..,j_n) - 1/N*theta(i_0,..,i_m,j_0,..,j_n)
 
         """
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             args = t.args
             args = [self.rule_thetaii(x) for x in args]
             return TensAdd(*args)
@@ -249,7 +249,7 @@ class SuNGroupFactors(object):
         theta(k,i_0,..,i_m)*theta(k,j_0,...,j_n) =
         theta(i_0,...,i_m,j_0,...,j_n) - 1/N*theta(i_0,..,i_m)*theta(j_0,...,j_n)
         """
-        if t.is_TensAdd:
+        if isinstance(t, TensAdd):
             args = t.args
             args = [self.rule_thetaithetai(x) for x in args]
             return TensAdd(*args)

--- a/sympy/tensor/group_factors.py
+++ b/sympy/tensor/group_factors.py
@@ -1,0 +1,284 @@
+from sympy import I, S
+from sympy.tensor.tensor import (TensorIndexType, tensor_indices, \
+TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul, tensorlist_contract_metric, tensor_mul, TensAdd, TensExpr, tensorsymmetry)
+
+
+
+def match_CijCij(t, th):
+    """
+    match for two tensors components ``th`` with two or more indices contracted
+    """
+    components = t._components
+    rdum = [tuple(sorted([cpos1, cpos2])) for ipos1, ipos2, cpos1, cpos2 \
+            in t._dum if components[cpos1] == th and components[cpos2] == th]
+    rdum.sort()
+    vcount = [rdum.count(x) for x in rdum]
+    repeated = {}
+    for i in range(len(rdum)):
+        if vcount[i] > 1 and rdum[i] not in repeated:
+            repeated[rdum[i]] = vcount[i]
+    if not repeated:
+        return None
+    repeated = repeated.items()
+    res = max(repeated, key=lambda x: x[1])
+    return res
+
+def match_C_triangle(t, th):
+    """
+    match for three tensor components ``th`` with triangle of contractions
+    """
+    components = t._components
+    rdum = [sorted([cpos1, cpos2]) for ipos1, ipos2, cpos1, cpos2 in \
+            t._dum if components[cpos1] == th and components[cpos2] == th]
+    rdum.sort()
+    for cpos1, cpos2 in rdum:
+        for i in range(cpos1 + 1, len(rdum)):
+            if [cpos1, i] in rdum:
+                if [cpos2, i] in rdum:
+                    return cpos1, cpos2, i
+                elif [i, cpos2] in rdum:
+                    return cpos1, i, cpos2
+
+def match_C_square(t, th):
+    """
+    match for four tensor components ``th`` with square of contractions
+
+    It is assumed that there are not smaller cycles
+    """
+    components = t._components
+    rdum = [sorted([cpos1, cpos2]) for ipos1, ipos2, cpos1, cpos2 in \
+            t._dum if components[cpos1] == th and components[cpos2] == th]
+    rdum.sort()
+    for i in range(len(rdum)):
+        cpos1, cpos2 = rdum[i]
+        for j in range(i + 1, len(rdum)):
+            cpos3, cpos4 = rdum[j]
+            if cpos3 in rdum[i] or cpos4 in rdum[i]:
+                continue
+            if [cpos1, cpos3] in rdum:
+                if [cpos2, cpos4] in rdum or [cpos4, cpos2] in rdum:
+                    return cpos1, cpos2, cpos4, cpos3
+            if [cpos1, cpos4] in rdum:
+                if [cpos2, cpos3] in rdum or [cpos3, cpos2] in rdum:
+                    return cpos1, cpos2, cpos3, cpos4
+
+
+class SuNGroupFactors(object):
+    """
+    SU(N)
+    Lie algebra ``[T(i), T(j)] = I*C(i,j, -k)*T(k)``
+
+    ``tr(T(i)*T(j)) = g(i, j)``
+
+    ``g(i, j)`` is the metric in the adjoint representation space;
+    it is proportional to the identity matrix due to Shur lemma.
+
+    ``T(i, -a, b)`` is the generator in the defining representation ``N``
+    For ``N > 2`` there is no metric in the defining representation.
+
+    Define ``theta(i_1, ..., i_n) = tr(T(i_1)*...*T^(i_n))
+
+    ``C_(i j k) = -I*theta(i, j, k) + I*theta(j, i, k)``
+
+    ``T(i,-d,a)*T(-i,-b,c) =``
+    ``delta(-b,a)*delta(-d,c) - 1/N*delta(-d,a)*delta(-b,c)``
+
+    Using this relation one obtains easily relations among contracted
+    ``theta`` tensors.
+    """
+    def __init__(self, N):
+        self.N = N
+        self.DSuN = TensorIndexType('DSuN', metric=None, dim=N, dummy_fmt='D')
+        self.ASuN = TensorIndexType('ASuN', metric=0, dim = N**2-1, dummy_fmt='A')
+        self.delta = self.DSuN.delta
+        self.g = self.ASuN.metric
+        symT = tensorsymmetry(*[[1]]*3)
+        ST = TensorType([self.ASuN, self.DSuN, self.DSuN], symT)
+        self.T = ST('T')
+        symA = tensorsymmetry([3])
+        SC = TensorType([self.ASuN]*3, symA)
+        self.C = SC('C')
+        self._theta = [None]*3 + [TensorType([self.ASuN]*i, \
+            tensorsymmetry(*[[1]]*i))('theta') for i in range(3, 6)]
+        i0, i1, i2 = tensor_indices('i0,i1,i2', self.ASuN)
+        self.tC = self.C(i0,i1,i2)
+        self.tCs = -I*self.theta(i0, i1, i2) + I*self.theta(i1, i0, i2)
+
+    def theta(self, *indices):
+        n = len(indices)
+        if n == 1:
+            return S.Zero
+        if n == 2:
+            return self.g(*indices)
+        try:
+            return self._theta[n](*indices)
+        except IndexError:
+            for i in range(len(self._theta), n + 1):
+                self._theta.append(TensorType([self.ASuN]*i, tensorsymmetry(*[[1]]*i))('theta'))
+            return self._theta[n](*indices)
+
+    def match_thetaii(self, t):
+        """
+        match a ``theta`` with two indices contracted
+
+        Returns the slot position of the contracted indices and the position
+        of the ``theta``.
+        """
+        components = t._components
+        dum = t._dum
+        for ipos1, ipos2, cpos1, cpos2 in dum:
+            if cpos1 == cpos2 and \
+              components[cpos1].name == 'theta' and \
+              components[cpos1].types == [self.ASuN]:
+                return ipos1, ipos2, cpos1
+
+    def match_thetaithetai(self, t):
+        """
+        match for two component tensors ``theta`` with
+        an index contracted with each other
+
+        Return the positions of the contracted indices and the positions
+        of the two tensors.
+        """
+        components = t._components
+        dum = t._dum
+        for ipos1, ipos2, cpos1, cpos2 in dum:
+            if cpos1 != cpos2 and \
+               components[cpos1].name == 'theta' and \
+               components[cpos2].name == 'theta' and \
+               components[cpos1].types == components[cpos1].types == [self.ASuN]:
+               return ipos1, ipos2, cpos1, cpos2
+
+
+    def rule_C_triangle(self, t):
+        """
+        evaluate a triangle of C's
+        """
+        if t.is_TensAdd:
+            args = t.args
+            args = [self.rule_C_triangle(x) for x in args]
+            return TensAdd(*args)
+        r = match_C_triangle(t, self.C)
+        if not r:
+            return t
+        return t
+
+    def rule_C_square(self, t):
+        """
+        evaluate a square of C's
+        """
+        if t.is_TensAdd:
+            args = t.args
+            args = [self.rule_C_square(x) for x in args]
+            return TensAdd(*args)
+        r = match_C_square(t, self.C)
+        if not r:
+            return t
+        i0, i1, i2, i3 = sorted(r)
+        a = t.split()
+        a1 = a[:i0] + a[i0 + 1: i1] + a[1 + 1:i2] + a[i2 + 1:i3] + a[i3 + 1:]
+        t1 = tensor_mul(*a1)
+        t2 = tensor_mul(a[i0], a[i1], a[i2], a[i3])
+        t2 = self.rule_C2theta_all(t2)
+        t = t1*t2
+        prev = S.Zero
+        while t != prev:
+            prev = t
+            t = self.rule_thetaithetai(t)
+            t = t.contract_metric(self.g, True)
+            t = self.rule_thetaii(t)
+        return t
+
+    def rule_thetaii(self, t):
+        """
+        theta(k,i_0,..,i_m,-k,j_0,..,j_n) =
+        theta(i_0,..,i_m)*theta(j_0,..,j_n) - 1/N*theta(i_0,..,i_m,j_0,..,j_n)
+
+        """
+        if t.is_TensAdd:
+            args = t.args
+            args = [self.rule_thetaii(x) for x in args]
+            return TensAdd(*args)
+        r = self.match_thetaii(t)
+        if not r:
+            return t
+        ipos1, ipos2, cpos1 = r
+        a = t.split()
+        ct = t._coeff if cpos1 == 0 else S.One
+        a1 = a[:cpos1] + a[cpos1 + 1:]
+        t1 = a[cpos1]
+        indices = t1.get_indices()
+        if ipos1 < ipos2:
+            indices = indices[ipos1:] + indices[:ipos1]
+            i = ipos2 - ipos1
+        else:
+            indices = indices[ipos2:] + indices[:ipos2]
+            i = ipos1 - ipos2
+        indices1 = indices[1:i]
+        indices2 = indices[i + 1:]
+        theta = self.theta
+        N = self.N
+        if indices1 == []:
+            t2 = (N - 1/N)*theta(*indices2)
+        elif indices2 == []:
+            t2 = (N - 1/N)*theta(*indices1)
+        else:
+            t2 = theta(*indices1)*theta(*indices2) - 1/N*theta(*(indices1 + indices2))
+        t3 = tensor_mul(*a1)
+        return t2*t3*ct
+
+    def rule_thetaithetai(self, t):
+        """
+        theta(k,i_0,..,i_m)*theta(k,j_0,...,j_n) =
+        theta(i_0,...,i_m,j_0,...,j_n) - 1/N*theta(i_0,..,i_m)*theta(j_0,...,j_n)
+        """
+        if t.is_TensAdd:
+            args = t.args
+            args = [self.rule_thetaithetai(x) for x in args]
+            return TensAdd(*args)
+
+        r = self.match_thetaithetai(t)
+        if not r:
+            return t
+        ipos1, ipos2, cpos1, cpos2 = r
+        a = t.split()
+        if cpos1 < cpos2:
+            a1 = a[:cpos1] + a[cpos1 + 1:cpos2] + a[cpos2 + 1:]
+        else:
+            a1 = a[:cpos2] + a[cpos2 + 1:cpos1] + a[cpos1 + 1:]
+        if cpos1 == 0:
+            ct = t._coeff
+        elif cpos2 == 0:
+            ct = t._coeff
+        else:
+            ct = S.One
+        t1 = a[cpos1]
+        t2 = a[cpos2]
+        indices1 = t1.get_indices()
+        indices2 = t2.get_indices()
+        indices1 = indices1[ipos1 + 1:] + indices1[:ipos1]
+        indices2 = indices2[ipos2 + 1:] + indices2[:ipos2]
+        theta = self.theta
+        N = self.N
+        t3 = theta(*(indices1 + indices2))
+        t4 = theta(*indices1)*theta(*indices2)
+        t5 = theta(*(indices1 + indices2)) - 1/N*theta(*indices1)*theta(*indices2)
+        res = tensor_mul(*a1)*t5*ct
+        return res
+
+    def rule_C2theta_all(self, t):
+        """
+        convert all ``C`` to ``theta`` and apply simplifying rules.
+        """
+
+        tC = self.tC
+        tCs = self.tCs
+        t = t.substitute_tensor(tC, tCs, True)
+        prev = S.Zero
+        while t != prev:
+            prev = t
+            t = t.substitute_tensor(tC, tCs, True)
+            t = self.rule_thetaithetai(t)
+            t = t.contract_metric(self.g, True)
+            t = self.rule_thetaii(t)
+        return t

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1,37 +1,32 @@
 from collections import defaultdict
-from sympy.combinatorics.perm_groups import PermutationGroup
-from sympy.combinatorics.permutations import Permutation, _af_new, _af_invert
-from sympy.core import Basic, Symbol, sympify, Add, Mul, S, Rational
-from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, canonical_free, riemann_bsgs
-
-from functools import wraps
-
-from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic
-from sympy.core.decorators import call_highest_priority
-from sympy.core.sympify import SympifyError
-from sympy.matrices import ShapeError
-from sympy.simplify import simplify
-from sympy import cacheit
+from sympy.core import Basic, sympify, Add, Mul, S
+from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
 
 class TensorIndexType(object):
+    """
+    A TensorIndexType is characterized by its name, by metric_sym,
+    giving the symmetry of its metric.
+
+    If a dimension ``dim`` is defined, it can be a symbol or an integer.
+    """
     def __init__(self, name, metric_sym=0, dim=None, eps_dim = None,
                  dummy_fmt=None):
         """
         name   name of the tensor type
 
-        `metric\_sym`:
+        ``metric_sym``:
         0      symmetric
         1      antisymmetric
         None   no symmetry
 
         dim    dimension, it can be a symbol or a positive integer
 
-        `eps\_dim`  dimension of the epsilon tensor; it is by default
+        ``eps_dim``  dimension of the epsilon tensor; it is by default
                  equal to dim, if the latter is an integer; else
                  it can be assigned (for use in naive dimensional
                  regularization)
 
-        `dummy\_fmt` name of the head of dummy indices; by default it is
+        ``dummy_fmt`` name of the head of dummy indices; by default it is
         the name of the tensor type
 
         Examples
@@ -71,6 +66,8 @@ class TensorIndexType(object):
         epsilon = Sdim('Eps')
         return epsilon
 
+    def __lt__(self, other):
+        return self.name < other.name
 
     def __str__(self):
         return self.name
@@ -81,10 +78,13 @@ class TensorIndex(object):
     """
     Tensor indices are contructed with the Einstein summation convention.
 
-    An index can be in contravariant or in covariant form; in the latter
-    case it is represented prepending a `-` to the index name.
+    A TensorIndex is chacterized by their ``name``, ``tensortype``
+    and ``is_contravariant``.
 
-    Dummy indices have the head given by `dummy\_fmt`
+    An index can be in contravariant or in covariant form; in the latter
+    case it is represented prepending a ``-`` to the index name.
+
+    Dummy indices have a name with head given by ``tensortype.dummy_fmt``
 
 
     Examples
@@ -113,13 +113,6 @@ class TensorIndex(object):
 
     __repr__ = __str__
 
-    @cacheit
-    def covariant(self):
-        if self.is_contravariant:
-            return TensorIndex(self.name, self.tensortype, False)
-        else:
-            return self
-
     def __eq__(self, other):
         return self.name == other.name and \
                self.tensortype == other.tensortype and \
@@ -128,7 +121,9 @@ class TensorIndex(object):
     def __ne__(self, other):
         return not (self == other)
 
-    @cacheit
+    def __lt__(self, other):
+        return (self.tensortype, self.name) < (other.tensortype, other.name)
+
     def __neg__(self):
         t1 = TensorIndex(self.name, self.tensortype,
                 (not self.is_contravariant))
@@ -136,7 +131,11 @@ class TensorIndex(object):
 
 def tensor_indices(s, typ):
     """
-    Returns tensor indices given their name
+    Returns tensor indices given their names and the TensorIndexType ``typ``
+
+    ``s`` string of comma separated names of indices
+
+    ``typ`` list of TensorIndexType of the indices
 
     Examples
     ========
@@ -171,29 +170,10 @@ class TensorSymmetry(object):
         self.base, self.generators = bsgs
         self.rank = self.generators[0].size
 
-def _get_index_types(indices):
-    res = []
-    for i in indices:
-        if isinstance(i, TensorIndex):
-            res.append(i.tensortype)
-        elif isinstance(i, TensorIndexType):
-            res.append(i)
-        else:
-            raise NotImplementedError
-    return res
-
-def has_tensor(p):
-    if p.is_Tensor:
-        return True
-    if p.is_Mul or p.is_Add:
-        for x in p.args:
-            if has_tensor(x):
-                return True
-    return False
-
 
 class TensorType(Basic):
     """
+    A TensorType object is characterised by its index types and its symmetry
 
     Examples
     ========
@@ -209,14 +189,14 @@ class TensorType(Basic):
     """
     is_commutative = False
 
-    def __new__(cls, indices, symmetry, **kw_args):
+    def __new__(cls, index_types, symmetry, **kw_args):
         obj = Basic.__new__(cls, **kw_args)
         obj.index_types = []
-        obj.index_types = _get_index_types(indices)
+        obj.index_types = index_types
         obj.types = list(set(obj.index_types))
         obj.types.sort(key=lambda x: x.name)
         obj.symmetry = symmetry
-        assert symmetry.rank == len(indices) + 2
+        assert symmetry.rank == len(index_types) + 2
         return obj
 
     def __str__(self):
@@ -232,8 +212,8 @@ class TensorType(Basic):
         Examples
         ========
 
-        Define symmetric tensors `V`, `W` and `G`, respectively commuting,
-        anticommuting and with no commutation symmetry
+        Define symmetric tensors ``V``, ``W`` and ``G``, respectively
+        commuting, anticommuting and with no commutation symmetry
 
         >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs, canon_bp
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
@@ -260,6 +240,15 @@ class TensorHead(Basic):
     def __new__(cls, name, typ, commuting, **kw_args):
         """
         tensor with given name, index types, symmetry, commutation rule
+
+        ``name`` name of the tensor
+
+        ``typ`` list of TensorIndexType
+
+        ``commuting`` commutation property
+        0     commuting tensor
+        1     anticommuting tensor
+        None  no commutation rule
 
         Examples
         ========
@@ -290,10 +279,14 @@ class TensorHead(Basic):
     def __ne__(self, other):
         return not (self == other)
 
+    def __lt__(self, other):
+        return (self.name, self.index_types) < (other.name, other.index_types)
+
     def commutes_with(self, other):
         """
-        Returns 0 (1) if self and other (anti)commute
-        Returns None if self and other do not (anti)commute
+        Returns 0 (1) if self and other (anti)commute.
+
+        Returns None if self and other do not (anti)commute.
 
         TODO: it should be possible to assign rules for commutations
         between tensors, to be used here.
@@ -304,10 +297,6 @@ class TensorHead(Basic):
             return 1
         return None
 
-        #if self.commuting == None or other.commuting == None:
-        #    return None
-        #return self.commuting * other.commuting
-
 
     def __str__(self):
         return '%s(%s)' %(self.name, ','.join([str(x) for x in self.index_types]))
@@ -315,7 +304,7 @@ class TensorHead(Basic):
 
     def __call__(self, *indices):
         """
-        tensor with indices
+        Returns a tensor with indices.
 
         Examples
         ========
@@ -330,7 +319,7 @@ class TensorHead(Basic):
         """
         assert self.rank == len(indices)
         components = [self]
-        free, dum =  Tensor.from_indices(indices, self.types)
+        free, dum =  Tensor.from_indices(*indices)
         free.sort(key=lambda x: x[0].name)
         dum.sort()
         return Tensor(S.One, components, free, dum)
@@ -351,8 +340,8 @@ class TensExpr(Basic):
 
 
     In the internal representation contracted indices are represented
-    by `(ipos1, ipos2, icomp1, icomp2)`, where `icomp1` is the position
-    of the component tensor with contravariant index, `ipos1` is the
+    by ``(ipos1, ipos2, icomp1, icomp2)``, where ``icomp1`` is the position
+    of the component tensor with contravariant index, ``ipos1`` is the
     slot which the index occupies in that component tensor.
 
     Contracted indices are therefore nameless in the internal representation.
@@ -397,8 +386,8 @@ class TensExpr(Basic):
 
     def __rmul__(self, other):
         if self.is_TensMul:
-            coeff = other*self.coeff
-            return Tensor(coeff, self.components, self.free, self.dum)
+            coeff = other*self._coeff
+            return Tensor(coeff, self._components, self._free, self._dum)
         return TensAdd(*[x*other for x in self.args])
 
     def __pow__(self, other):
@@ -411,8 +400,8 @@ class TensExpr(Basic):
         other = sympify(other)
         if other.is_Tensor:
             raise ValueError('cannot divide by a tensor')
-        coeff = self.coeff/other
-        return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+        coeff = self._coeff/other
+        return Tensor(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
 
 
     def __rdiv__(self, other):
@@ -423,7 +412,7 @@ class TensExpr(Basic):
 
     def substitute_indices(self, *index_tuples):
         """
-        Return a tensor with indices substituted according to `index\_tuples`
+        Return a tensor with free indices substituted according to ``index_tuples``
 
         Examples
         ========
@@ -441,23 +430,20 @@ class TensExpr(Basic):
         A(j, L_0)*B(-L_0, -k)
         """
         if self.is_TensMul:
-            free = self.free
+            free = self._free
             free1 = []
-            for i, v in index_tuples:
-                for j, ipos, cpos in free:
+            for j, ipos, cpos in free:
+                for i, v in index_tuples:
                     if i.name == j.name and i.tensortype == j.tensortype:
                         if i.is_contravariant == j.is_contravariant:
                             free1.append((v, ipos, cpos))
                         else:
-                            # replace i with an index with the same covariance of i
-                            if j.is_contravariant:
-                                ind = TensorIndex(v.name, v.tensortype)
-                                free1.append((ind, ipos, cpos))
-                            else:
-                                ind = TensorIndex(v.name, v.tensortype)
-                                ind = -ind
-                                free1.append((ind, ipos, cpos))
-            return Tensor(self.coeff, self.components, free1, self.dum)
+                            free1.append((-v, ipos, cpos))
+                        break
+                else:
+                    free1.append((j, ipos, cpos))
+
+            return Tensor(self._coeff, self._components, free1, self._dum)
         if self.is_TensAdd:
             args = self.args
             args1 = []
@@ -469,6 +455,22 @@ class TensExpr(Basic):
 class TensAdd(TensExpr):
     """
     Sum of tensors
+
+    Sum of more than one tensor are put automatically in canonical form.
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensAdd
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b = tensor_indices('a,b', Lorentz)
+    >>> sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    >>> S1 = TensorType([Lorentz], sym)
+    >>> p, q = S1('p,q')
+    >>> t1 = p(a)
+    >>> t2 = q(a)
+    >>> t1 + t2
+    p(a) + q(a)
     """
     is_Tensor = True
     is_TensAdd = True
@@ -479,12 +481,19 @@ class TensAdd(TensExpr):
         """
         args = [sympify(x) for x in args if x]
         if not all(x.is_Tensor for x in args):
-            args1 = [x for x in args if x.is_Tensor and x.coeff]
+            args1 = []
+            for x in args:
+                if x.is_Tensor:
+                    if x.is_TensAdd:
+                        args1.extend(list(x.args))
+                    else:
+                        args1.append(x)
+            args1 = [x for x in args1 if x.is_Tensor and x._coeff]
             args2 = [x for x in args if not x.is_Tensor]
             t0 = args1[0]
             if t0.is_TensAdd:
                 t0 = t0.args[0]
-            if t0.free:
+            if t0._free:
                raise ValueError('all tensors must have the same indices')
             t1 = Tensor(Add(*args2), [], [], [])
             args = [t1] + args1
@@ -495,22 +504,22 @@ class TensAdd(TensExpr):
             else:
                 a.append(x)
         args = a
-        args = [x for x in args if x.coeff]
+        args = [x for x in args if x._coeff]
         if not args:
             return S.Zero
 
-        indices0 = sorted([x[0] for x in args[0].free], key=lambda x: x.name)
-        list_indices = [sorted([y[0] for y in x.free], key=lambda x: x.name) for x in args[1:]]
+        indices0 = sorted([x[0] for x in args[0]._free], key=lambda x: x.name)
+        list_indices = [sorted([y[0] for y in x._free], key=lambda x: x.name) for x in args[1:]]
         if not all(x == indices0 for x in list_indices):
-            print 'ERR list_indices=%s indices0=%s' %(list_indices, indices0)
             raise ValueError('all tensors must have the same indices')
 
         obj = Basic.__new__(cls, **kw_args)
-        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        # collect terms
+        args.sort(key=lambda x: (x._components, x._free, x._dum))
         a = []
         pprev = None
         prev = args[0]
-        prev_coeff = prev.coeff
+        prev_coeff = prev._coeff
         changed = False
         new = 0
         if len(args) == 1 and args[0].is_TensMul:
@@ -519,9 +528,9 @@ class TensAdd(TensExpr):
 
         for x in args[1:]:
             # if x and prev have the same tensor, update the coeff of prev
-            if x.components == prev.components \
-                    and x.free == prev.free and x.dum == prev.dum:
-                prev_coeff = prev_coeff + x.coeff
+            if x._components == prev._components \
+                    and x._free == prev._free and x._dum == prev._dum:
+                prev_coeff = prev_coeff + x._coeff
                 changed = True
                 op = 0
             else:
@@ -532,18 +541,18 @@ class TensAdd(TensExpr):
                 else:
                     # get a tensor from prev with coeff=prev_coeff and store it
                     if prev_coeff:
-                        t = Tensor(prev_coeff, prev.components,
-                            prev.free, prev.dum)
+                        t = Tensor(prev_coeff, prev._components,
+                            prev._free, prev._dum)
                         a.append(t)
                 # move x to prev
                 op = 1
                 pprev, prev = prev, x
-                pprev_coeff, prev_coeff = prev_coeff, x.coeff
+                pprev_coeff, prev_coeff = prev_coeff, x._coeff
                 changed = False
         # if the case op=0 prev was not stored; store it now
         # in the case op=1 x was not stored; store it now (as prev)
         if op == 0 and prev_coeff:
-            prev = Tensor(prev_coeff, prev.components, prev.free, prev.dum)
+            prev = Tensor(prev_coeff, prev._components, prev._free, prev._dum)
             a.append(prev)
         elif op == 1:
             a.append(prev)
@@ -560,8 +569,12 @@ class TensAdd(TensExpr):
         return obj
 
     def canon_bp(self):
+        """
+        canonicalize using the Butler-Portugal algorithm for canonicalization
+        under monoterm symmetries.
+        """
         args = [x.canon_bp() for x in self.args]
-        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        args.sort(key=lambda x: (x._components, x._free, x._dum))
         res = TensAdd(*args)
         return res
 
@@ -569,28 +582,28 @@ class TensAdd(TensExpr):
         other = sympify(other)
         if not other.is_Tensor:
             if len(self.args) == 1:
-                return self.args[0].coeff == other
-        if other.is_Tensor and other.is_TensMul and other.coeff == 0:
+                return self.args[0]._coeff == other
+        if other.is_Tensor and other.is_TensMul and other._coeff == 0:
             return self == 0
         t = self - other
         if not t.is_Tensor:
             return t == 0
         else:
             if t.is_TensMul:
-                return t.coeff == 0
+                return t._coeff == 0
             else:
-                return all(x.coeff == 0 for x in t.args)
+                return all(x._coeff == 0 for x in t.args)
 
     def __ne__(self, other):
         return not (self == other)
 
     def contract_metric(self, g, contract_all=False):
         """
-        Raise or lower indices with the metric `g`
+        Raise or lower indices with the metric ``g``
 
-        g  metric
+        ``g``  metric
 
-        `contract\_all` if True, eliminate all `g` which are contracted
+        ``contract_all`` if True, eliminate all ``g`` which are contracted
         """
 
         args = [x.contract_metric(g, contract_all) for x in self.args]
@@ -601,17 +614,18 @@ class TensAdd(TensExpr):
 
     def _pretty(self):
         a = []
-        #args = sorted(self.args)
         args = self.args
         for x in args:
             a.append(str(x))
-
         a.sort()
         s = ' + '.join(a)
         s = s.replace('+ -', '- ')
         return s
 
 class Tensor(TensExpr):
+    """
+    Product of tensors
+    """
     is_Tensor = True
     is_TensMul = True
 
@@ -620,64 +634,62 @@ class Tensor(TensExpr):
 
         coeff SymPy expression coefficient of the tensor.
 
-        args[0]   list of TensorHead of the component tensors.
+        ``args[0]``   list of TensorHead of the component tensors.
 
-        args[1]   list of (ind, ipos, icomp)
-        where `ind` is a free index, `ipos` is the slot position
-        of `ind` in the `icomp`-th component tensor.
+        ``args[1]``   list of ``(ind, ipos, icomp)``
+        where ``ind`` is a free index, ``ipos`` is the slot position
+        of ``ind`` in the ``icomp``-th component tensor.
 
-        args[2] list of tuples representing dummy indices.
+        ``args[2]`` list of tuples representing dummy indices.
         (ipos1, ipos2, icomp1, icomp2) indicates that the contravariant
-        dummy index is the `ipos1` slot position in the `icomp1`-th
+        dummy index is the ``ipos1``-th slot position in the ``icomp1``-th
         component tensor; the corresponding covariant index is
-        in the `ipos2` slot position in the `icomp2`-th component tensor.
+        in the ``ipos2`` slot position in the ``icomp2``-th component tensor.
         """
         obj = Basic.__new__(cls)
-        obj.components = args[0]
+        obj._components = args[0]
         obj.types = []
-        for t in obj.components:
+        for t in obj._components:
             obj.types.extend(t.types)
-        obj.free = args[1]
-        obj.dum = args[2]
-        obj.rank = len(obj.free) + 2*len(obj.dum)
-        obj.coeff = coeff
+        obj._free = args[1]
+        obj._dum = args[2]
+        obj.rank = len(obj._free) + 2*len(obj._dum)
+        obj._coeff = coeff
         obj._is_canon_bp = kw_args.get('is_canon_bp', False)
 
         return obj
 
     def __eq__(self, other):
         if other == 0:
-            return self.coeff == 0
+            return self._coeff == 0
         other = sympify(other)
         if not other.is_Tensor :
             return False
         res = self - other
         return res == 0
 
-        res = self.components == other.components and \
-            sorted(self.free) == sorted(other.free) and \
-            sorted(self.dum) == sorted(other.dum) and self.coeff == other.coeff
-        return res
-
     def __ne__(self, other):
         return not self == other
 
-    @property
-    def set_free_indices(self):
-        return set([x[0] for x in self.free])
-
     @staticmethod
-    def from_indices(indices, types):
+    def from_indices(*indices):
         """
-        Returns free, dum for single component tensor
+        Convert ``indices`` into ``free``, ``dum`` for single component tensor
 
-        free         list of tuples (index, pos, 0),
-                     where `pos` is the position of index in
+        ``free``     list of tuples ``(index, pos, 0)``,
+                     where ``pos`` is the position of index in
                      the list of indices formed by the component tensors
 
-        dum          list of tuples (pos_contr, pos_cov, 0, 0)
+        ``dum``      list of tuples ``(pos_contr, pos_cov, 0, 0)``
 
+        Examples
+        ========
 
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, Tensor, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> Tensor.from_indices(m0, m1, -m1, m3)
+        ([(m0, 0, 0), (m3, 3, 0)], [(1, 2, 0, 0)])
         """
         n = len(indices)
         if n == 1:
@@ -725,20 +737,34 @@ class Tensor(TensExpr):
 
         The indices are listed in the order in which they appear in the
         component tensors.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> g = Lorentz.metric
+        >>> p, q = S1('p,q')
+        >>> t = p(m1)*g(m0,m2)
+        >>> t.get_indices()
+        [m1, m0, m2]
         """
         indices = [None]*self.rank
         start = 0
         pos = 0
         vpos = []
-        components = self.components
-        for t in self.components:
+        components = self._components
+        for t in self._components:
             vpos.append(pos)
             pos += t.rank
         cdt = defaultdict(int)
-        for indx, ipos, cpos in self.free:
+        for indx, ipos, cpos in self._free:
             start = vpos[cpos]
             indices[start + ipos] = indx
-        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+        for ipos1, ipos2, cpos1, cpos2 in self._dum:
             start1 = vpos[cpos1]
             start2 = vpos[cpos2]
             typ1 = components[cpos1].index_types[ipos1]
@@ -752,7 +778,7 @@ class Tensor(TensExpr):
 
     def split(self):
         """
-        Returns a list of tensors, whose product is `self`
+        Returns a list of tensors, whose product is ``self``
 
         Dummy indices contracted among different tensor components
         become free indices with the same name as the one used to
@@ -775,20 +801,20 @@ class Tensor(TensExpr):
         """
         indices = self.get_indices()
         pos = 0
-        components = self.components
+        components = self._components
         res = []
-        for t in self.components:
+        for t in self._components:
             t1 = t(*indices[pos:pos + t.rank])
             pos += t.rank
             res.append(t1)
-        res[0] = Tensor(self.coeff, res[0].components, res[0].free, res[0].dum, is_canon_bp=res[0]._is_canon_bp)
+        res[0] = Tensor(self._coeff, res[0]._components, res[0]._free, res[0]._dum, is_canon_bp=res[0]._is_canon_bp)
         return res
 
     def canon_args(self):
         """
-        Returns (g, dummies, msym, v), the entries of `canonicalize`
+        Returns ``(g, dummies, msym, v)``, the entries of ``canonicalize``
 
-        see `canonicalize` in `tensor\_can.py`
+        see ``canonicalize`` in ``tensor_can.py``
         """
         # to be called after sorted_components
         from sympy.combinatorics.permutations import _af_new
@@ -798,21 +824,21 @@ class Tensor(TensExpr):
         g = [None]*n + [n, n+1]
         pos = 0
         vpos = []
-        components = self.components
-        for t in self.components:
+        components = self._components
+        for t in self._components:
             vpos.append(pos)
             pos += t.rank
-        for i, (indx, ipos, cpos) in enumerate(self.free):
+        for i, (indx, ipos, cpos) in enumerate(self._free):
             pos = vpos[cpos] + ipos
             g[pos] = i
 
-        pos = len(self.free)
-        j = len(self.free)
+        pos = len(self._free)
+        j = len(self._free)
         dummies = []
         prev = None
         a = []
         msym = []
-        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+        for ipos1, ipos2, cpos1, cpos2 in self._dum:
             pos1 = vpos[cpos1] + ipos1
             pos2 = vpos[cpos2] + ipos2
             g[pos1] = j
@@ -844,26 +870,47 @@ class Tensor(TensExpr):
         return _af_new(g), dummies, msym, v
 
     def __mul__(self, other):
+        """
+        Multiply two tensors using Einstein summation convention.
+
+        If the two tensors have an index in common, one contravariant
+        and the other covariant, in their product the indices are summed
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> g = Lorentz.metric
+        >>> p, q = S1('p,q')
+        >>> t1 = p(m0)
+        >>> t2 = q(-m0)
+        >>> t1*t2
+        p(L_0)*q(-L_0)
+        """
         other = sympify(other)
         if not other.is_Tensor:
-            coeff = self.coeff*other
-            return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+            coeff = self._coeff*other
+            return Tensor(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
         if other.is_TensAdd:
             return TensAdd(*[self*x for x in other.args])
 
-        components = self.components + other.components
+        components = self._components + other._components
         # find out which free indices of self and other are contracted
-        free_dict1 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in self.free])
-        free_dict2 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in other.free])
+        free_dict1 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in self._free])
+        free_dict2 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in other._free])
 
         free_names = set(free_dict1.keys()) & set(free_dict2.keys())
         # find the new `free` and `dum`
-        nc1 = len(self.components)
-        dum2 = [(i1, i2, c1 + nc1, c2 + nc1) for i1, i2, c1, c2 in other.dum]
-        free1 = [(ind, i, c) for ind, i, c in self.free if ind.name not in free_names]
-        free2 = [(ind, i, c + nc1) for ind, i, c in other.free if ind.name not in free_names]
+        nc1 = len(self._components)
+        dum2 = [(i1, i2, c1 + nc1, c2 + nc1) for i1, i2, c1, c2 in other._dum]
+        free1 = [(ind, i, c) for ind, i, c in self._free if ind.name not in free_names]
+        free2 = [(ind, i, c + nc1) for ind, i, c in other._free if ind.name not in free_names]
         free = free1 + free2
-        dum = self.dum + dum2
+        dum = self._dum + dum2
         for name in free_names:
             ipos1, cpos1, ind1 = free_dict1[name]
             ipos2, cpos2, ind2 = free_dict2[name]
@@ -875,7 +922,7 @@ class Tensor(TensExpr):
             else:
                 new_dummy = (ipos2, ipos1, cpos2, cpos1)
             dum.append(new_dummy)
-        coeff = self.coeff*other.coeff
+        coeff = self._coeff*other._coeff
         return Tensor(coeff, components, free, dum)
 
 
@@ -883,7 +930,8 @@ class Tensor(TensExpr):
         """
         Returns a tensor with sorted components
         """
-        cv = zip(self.components, range(len(self.components)))
+        from sympy.combinatorics.permutations import _af_invert
+        cv = zip(self._components, range(len(self._components)))
         sign = 1
         n = len(cv) - 1
         for i in range(n):
@@ -900,35 +948,35 @@ class Tensor(TensExpr):
         components = [x[0] for x in cv]
         perm_inv = [x[1] for x in cv]
         perm = _af_invert(perm_inv)
-        free = [(ind, i, perm[c]) for ind, i, c in self.free]
-        dum = [(i1, i2, perm[c1], perm[c2]) for i1, i2, c1, c2 in self.dum]
+        free = [(ind, i, perm[c]) for ind, i, c in self._free]
+        dum = [(i1, i2, perm[c1], perm[c2]) for i1, i2, c1, c2 in self._dum]
         free.sort(key = lambda x: (x[0].tensortype, x[0].name))
         dum.sort(key = lambda x: components[x[2]].index_types[x[0]])
         if sign == -1:
-            coeff = -self.coeff
+            coeff = -self._coeff
         else:
-            coeff = self.coeff
+            coeff = self._coeff
         t = Tensor(coeff, components, free, dum)
         return t
 
     def perm2tensor(self, g, canon_bp=False):
         """
-        Returns the tensor corresponding to the permutation `g`
+        Returns the tensor corresponding to the permutation ``g``
 
-        g  permutation corrisponding to the tensor in the representation
+        ``g``  permutation corrisponding to the tensor in the representation
         used in canonicalization
 
-        `canon\_bp`   if True, then `g` is the permutation
+        ``canon_bp``   if True, then ``g`` is the permutation
         corresponding to the canonical form of the tensor
         """
         from bisect import bisect_right
         vpos = []
-        components = self.components
+        components = self._components
         pos = 0
-        for t in self.components:
+        for t in self._components:
             vpos.append(pos)
             pos += t.rank
-        free_indices = [x[0] for x in self.free]
+        free_indices = [x[0] for x in self._free]
         sorted_free = sorted(free_indices, key=lambda x:(x.tensortype, x.name))
         nfree = len(sorted_free)
         rank = self.rank
@@ -955,7 +1003,7 @@ class Tensor(TensExpr):
                     dum[idum][0] = ipos
                     dum[idum][2] = icomp
         dum = [tuple(x) for x in dum]
-        coeff = self.coeff
+        coeff = self._coeff
         if g[-1] != len(g) - 1:
             coeff = -coeff
         res = Tensor(coeff, components, free, dum, is_canon_bp=canon_bp)
@@ -975,6 +1023,9 @@ class Tensor(TensExpr):
         >>> sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
         >>> S2 = TensorType([Lorentz]*2, sym2a)
         >>> A = S2('A')
+        >>> t = A(m0,-m1)*A(m1,-m0)
+        >>> t.canon_bp()
+        -A(L_0, L_1)*A(-L_0, -L_1)
         >>> t = A(m0,-m1)*A(m1,-m2)*A(m2,-m0)
         >>> t.canon_bp()
         0
@@ -982,7 +1033,7 @@ class Tensor(TensExpr):
         from sympy.combinatorics.tensor_can import canonicalize
         if self._is_canon_bp:
             return self
-        if not self.components:
+        if not self._components:
             return self
         t = self.sorted_components()
         g, dummies, msym, v = t.canon_args()
@@ -994,11 +1045,11 @@ class Tensor(TensExpr):
 
     def contract_metric(self, g, contract_all=False):
         """
-        Raise or lower indices with the metric `g`
+        Raise or lower indices with the metric ``g``
 
-        `g`  metric
+        ``g``  metric
 
-        `contract\_all` if True, eliminate all `g` which are contracted
+        ``contract_all`` if True, eliminate all ``g`` which are contracted
 
         Examples
         ========
@@ -1019,26 +1070,26 @@ class Tensor(TensExpr):
         if g.index_types[0].metric_sym != 0:
             # TODO case of antisymmetric metric
             raise NotImplementedError
-        if not self.components:
+        if not self._components:
             return self
-        free_indices = [x[0] for x in self.free]
+        free_indices = [x[0] for x in self._free]
         a = self.split()
         typ = g.index_types[0]
         # if a component tensor of a has 2 dummy indices, it is g(d,-d) = dim
         for i, tx in enumerate(a):
-            if tx.components[0] == g:
-                free_indices_g = [x[0] for x in a[i].free]
+            if tx._components[0] == g:
+                free_indices_g = [x[0] for x in a[i]._free]
                 if len(free_indices_g) == 0:
                     a1 = a[:i] + a[i + 1:]
-                    t = tensor_mul(*a1)*(typ.dim*a[i].coeff)
-                    if contract_all == True and g in t.components:
+                    t = tensor_mul(*a1)*(typ.dim*a[i]._coeff)
+                    if contract_all == True and g in t._components:
                         return t.contract_metric(g, True)
                     return t
 
         # if all metric tensors have only free indices, there is no contraction
         for i, tg in enumerate(a):
-            if tg.components[0] == g:
-                tg_free_indices = [x[0] for x in tg.free]
+            if tg._components[0] == g:
+                tg_free_indices = [x[0] for x in tg._free]
                 if all(indx in free_indices for indx in tg_free_indices):
                     continue
                 break
@@ -1048,7 +1099,7 @@ class Tensor(TensExpr):
         # tg has one or two indices contracted with other tensors
         # i position of tg in a
         coeff = S.One
-        tg_free = tg.free
+        tg_free = tg._free
         if tg_free[0][0] in free_indices or tg_free[1][0] in free_indices:
             if tg_free[0][0] in free_indices:
                 ind_free = tg_free[0][0]
@@ -1058,20 +1109,20 @@ class Tensor(TensExpr):
                 ind, ipos1, _ = tg_free[0]
 
             ind1 = -ind
-            # search ind1 in self.dum
+            # search ind1 in self._dum
             for j, tx in enumerate(a):
-                if ind1 in [x[0] for x in tx.free]:
+                if ind1 in [x[0] for x in tx._free]:
                     break
             free1 = []
-            for indx, iposx, _ in tx.free:
+            for indx, iposx, _ in tx._free:
                 if indx == ind1:
                     free1.append((ind_free, iposx, 0))
                 else:
                     free1.append((indx, iposx, 0))
-            t1 = Tensor(tx.coeff, tx.components, free1, tx.dum)
+            t1 = Tensor(tx._coeff, tx._components, free1, tx._dum)
             a[j] = t1
             a = a[:i] + a[i + 1:]
-            coeff = coeff*tg.coeff
+            coeff = coeff*tg._coeff
             res = tensor_mul(*a)
         else:
             # tg has two indices contracted with other tensors
@@ -1080,10 +1131,10 @@ class Tensor(TensExpr):
             ind1m = -ind1
             ind2m = -ind2
             for k, ty in enumerate(a):
-                if ind2m in [x[0] for x in ty.free]:
+                if ind2m in [x[0] for x in ty._free]:
                     break
-            if ty.components == [g]:
-                ty_indices = [x[0] for  x in ty.free]
+            if ty._components == [g]:
+                ty_indices = [x[0] for  x in ty._free]
                 if all(x in [ind1m, ind2m] for x in ty_indices):
                     if i < k:
                         a = a[:i] + a[i+1:k] + a[k+1:]
@@ -1091,52 +1142,52 @@ class Tensor(TensExpr):
                         a = a[:k] + a[k+1:i] + a[k+1:]
                     if a:
                         res = tensor_mul(*a)
-                        res = (coeff*typ.dim*tg.coeff*ty.coeff)*res
+                        res = (coeff*typ.dim*tg._coeff*ty._coeff)*res
                     else:
-                        res = coeff*typ.dim*tg.coeff*ty.coeff
+                        res = coeff*typ.dim*tg._coeff*ty._coeff
                         res = Tensor(res, [],[],[], is_canon_bp=True)
-                    if contract_all == True and g in res.components:
+                    if contract_all == True and g in res._components:
                         return res.contract_metric(g, True)
                     return res
 
             free2 = []
-            for indx, iposx, _ in ty.free:
+            for indx, iposx, _ in ty._free:
                 if indx == ind2m:
                     free2.append((ind1, iposx, 0))
                 else:
                     free2.append((indx, iposx, 0))
-            t2 = Tensor(ty.coeff, ty.components, free2, ty.dum)
+            t2 = Tensor(ty._coeff, ty._components, free2, ty._dum)
             a[k] = t2
             a = a[:i] + a[i + 1:]
-            coeff = coeff*tg.coeff
+            coeff = coeff*tg._coeff
             res = tensor_mul(*a)
         res = coeff*res
-        if contract_all == True and g in res.components:
+        if contract_all == True and g in res._components:
             return res.contract_metric(g, True)
         return res
 
 
     def _pretty(self):
-        if self.components == []:
-            return str(self.coeff)
+        if self._components == []:
+            return str(self._coeff)
         indices = [str(ind) for ind in self.get_indices()]
         pos = 0
         a = []
-        for t in self.components:
+        for t in self._components:
             if t.rank > 0:
                 a.append('%s(%s)' % (t.name, ', '.join(indices[pos:pos + t.rank])))
             else:
                 a.append('%s' % t.name)
             pos += t.rank
         res = '*'. join(a)
-        if self.coeff == S.One:
+        if self._coeff == S.One:
             return res
-        elif self.coeff == -S.One:
+        elif self._coeff == -S.One:
             return '-%s' % res
-        if self.coeff.is_Atom:
-            return '%s*%s' % (self.coeff, res)
+        if self._coeff.is_Atom:
+            return '%s*%s' % (self._coeff, res)
         else:
-            return '(%s)*%s' %(self.coeff, res)
+            return '(%s)*%s' %(self._coeff, res)
 
 
 
@@ -1146,10 +1197,6 @@ def canon_bp(p):
     """
     if p.is_Tensor:
         return p.canon_bp()
-    if p.is_Add:
-        return Add(*[canon_bp(x) for x in p.args])
-    if p.is_Mul:
-        return Mul(*[canon_bp(x) for x in p.args])
     return p
 
 def tensor_mul(*a):
@@ -1167,32 +1214,32 @@ def tensorlist_contract_metric(a, tg):
     """
     contract `tg` with a tensor in the list `a = t.split()`
     """
-    ind1, ind2 = [x[0] for x in tg.free]
+    ind1, ind2 = [x[0] for x in tg._free]
     mind1 = -ind1
     mind2 = -ind2
     for i in range(len(a)):
         t1 = a[i]
-        for j in range(len(t1.free)):
-            indx, ipos, _ = t1.free[j]
+        for j in range(len(t1._free)):
+            indx, ipos, _ = t1._free[j]
             if indx == mind1 or indx == mind2:
                 ind3 = ind2 if indx == mind1 else ind1
-                free1 = t1.free[:]
+                free1 = t1._free[:]
                 free1[j] = (ind3, ipos, 0)
-                t2 = Tensor(t1.coeff, t1.components, free1, t1.dum)
+                t2 = Tensor(t1._coeff, t1._components, free1, t1._dum)
                 a[i] = t2
                 return a
     a.append(tg)
     return a
 
 
-def riemann_cyclic_replaceR(t_r):
+def riemann_cyclic_replace(t_r):
     """
     replace Riemann tensor with an equivalent expression
 
-    `R(m,n,p,q) -> 2/3*R(m,n,p,q) - 1/3*R(m,q,n,p) + 1/3*R(m,p,n,q)`
+    ``R(m,n,p,q) -> 2/3*R(m,n,p,q) - 1/3*R(m,q,n,p) + 1/3*R(m,p,n,q)``
 
     """
-    free = sorted(t_r.free, key=lambda x: x[1])
+    free = sorted(t_r._free, key=lambda x: x[1])
     m, n, p, q = [x[0] for x in free]
     t0 = S(2)/3*t_r
     t1 = - S(1)/3*t_r.substitute_indices((m,m),(n,q),(p,n),(q,p))
@@ -1222,7 +1269,7 @@ def riemann_cyclic(t2):
     """
     a = t2.args
     a1 = [x.split() for x in a]
-    a2 = [[riemann_cyclic_replaceR(tx) for tx in y] for y in a1]
+    a2 = [[riemann_cyclic_replace(tx) for tx in y] for y in a1]
     a3 = [tensor_mul(*v) for v in a2]
     t3 = TensAdd(*a3)
     if not t3:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -43,8 +43,11 @@ class _TensorManager(object):
 
     Tensors belong to tensor commutation groups; each group has a label
     ``comm``; there are predefined labels:
+
     ``0``   tensors commuting with any other tensor
+
     ``1``   tensors anticommuting among themselves
+
     ``2``   tensors not commuting, apart with those with ``comm=0``
 
     Other groups can be defined using ``set_comm``; tensors in those
@@ -101,9 +104,9 @@ class _TensorManager(object):
         Parameters
         ==========
 
-        ``i, j`` : symbols representing commutation groups
+        i, j : symbols representing commutation groups
 
-        ``c``  :  group commutation number
+        c  :  group commutation number
 
         Notes
         =====
@@ -117,8 +120,11 @@ class _TensorManager(object):
 
         The group commutation number ``c`` is assigned in corrispondence
         to the group commutation symbols; it can be
+
         0        commuting
+
         1        anticommuting
+
         None     no commutation property
 
         Examples
@@ -131,9 +137,9 @@ class _TensorManager(object):
         >>> Lorentz = TensorIndexType('Lorentz')
         >>> i0,i1,i2,i3,i4 = tensor_indices('i0:5', Lorentz)
         >>> A = tensorhead('A', [Lorentz], [[1]])
-        >>> G = tensorhead('G', [Lorentz], [[1]], 3)
-        >>> GH = tensorhead('GH', [Lorentz], [[1]], 4)
-        >>> TensorManager.set_comm(3, 4, 0)
+        >>> G = tensorhead('G', [Lorentz], [[1]], 'Gcomm')
+        >>> GH = tensorhead('GH', [Lorentz], [[1]], 'GHcomm')
+        >>> TensorManager.set_comm('Gcomm', 'GHcomm', 0)
         >>> (GH(i1)*G(i0)).canon_bp()
         G(i0)*GH(i1)
         >>> (G(i1)*G(i0)).canon_bp()
@@ -170,7 +176,7 @@ class _TensorManager(object):
         Parameters
         ==========
 
-        ``args`` : sequence of ``(i, j, c``
+        args : sequence of ``(i, j, c)``
         """
         for i, j, c in args:
             self.set_comm(i, j, c)
@@ -199,16 +205,16 @@ class TensorIndexType(Basic):
     Parameters
     ==========
 
-    ``name`` : name of the tensor type
+    name : name of the tensor type
 
-    ``metric`` : metric symmetry or metric object or ``None``
+    metric : metric symmetry or metric object or ``None``
 
 
-    ``dim`` : dimension, it can be a symbol or an integer or ``None``
+    dim : dimension, it can be a symbol or an integer or ``None``
 
-    ``eps_dim`` : dimension of the epsilon tensor
+    eps_dim : dimension of the epsilon tensor
 
-    ``dummy_fmt`` : name of the head of dummy indices
+    dummy_fmt : name of the head of dummy indices
 
     Attributes
     ==========
@@ -347,9 +353,9 @@ class TensorIndex(Basic):
     Parameters
     ==========
 
-    ``name`` : name of the index
-    ``tensortype`` : ``TensorIndexType`` of the index
-    ``is_up`` :  flag for contravariant index
+    name : name of the index
+    tensortype : ``TensorIndexType`` of the index
+    is_up :  flag for contravariant index
 
     Attributes
     ==========
@@ -423,9 +429,9 @@ def tensor_indices(s, typ):
     Parameters
     ==========
 
-    ``s`` : string of comma separated names of indices
+    s : string of comma separated names of indices
 
-    ``typ`` : list of ``TensorIndexType`` of the indices
+    typ : list of ``TensorIndexType`` of the indices
 
     Examples
     ========
@@ -449,7 +455,7 @@ class TensorSymmetry(Basic):
     Parameters
     ==========
 
-    ``bsgs`` : tuple ``(base, sgs)`` BSGS of the symmetry of the tensor
+    bsgs : tuple ``(base, sgs)`` BSGS of the symmetry of the tensor
 
     Attributes
     ==========
@@ -572,8 +578,8 @@ class TensorType(Basic):
     Parameters
     ==========
 
-    ``index_types`` : list of ``TensorIndexType`` of the tensor indices
-    ``symmetry`` : ``TensorSymmetry`` of the tensor
+    index_types : list of ``TensorIndexType`` of the tensor indices
+    symmetry : ``TensorSymmetry`` of the tensor
 
     Attributes
     ==========
@@ -656,13 +662,16 @@ def tensorhead(name, typ, sym, comm=0):
     """
     Function generating tensorhead(s).
 
-    ``name`` name or sequence of names (as in ``symbol``)
+    Parameters
+    ==========
 
-    ``typ``  index types
+    name : name or sequence of names (as in ``symbol``)
 
-    ``sym``  same as ``*args`` in ``tensorsymmetry``
+    typ : index types
 
-    ``comm``: commutation group number
+    sym : same as ``*args`` in ``tensorsymmetry``
+
+    comm : commutation group number
     see ``_TensorManager.set_comm``
 
 
@@ -689,11 +698,11 @@ class TensorHead(Basic):
     Parameters
     ==========
 
-    ``name`` : name of the tensor
+    name : name of the tensor
 
-    ``typ`` : list of TensorIndexType
+    typ : list of TensorIndexType
 
-    ``comm`` : commutation group number
+    comm : commutation group number
 
     Attributes
     ==========
@@ -1016,7 +1025,7 @@ class TensAdd(TensExpr):
     Parameters
     ==========
 
-    ``free_args`` : list of the free indices
+    free_args : list of the free indices
 
     Attributes
     ==========
@@ -1084,7 +1093,7 @@ class TensAdd(TensExpr):
         Parameters
         ==========
 
-        ``indices``
+        indices
 
         Examples
         ========
@@ -1184,9 +1193,9 @@ class TensAdd(TensExpr):
         Parameters
         ==========
 
-        ``g`` :  metric
+        g :  metric
 
-        ``contract_all`` : if True, eliminate all ``g`` which are contracted
+        contract_all : if True, eliminate all ``g`` which are contracted
 
         Notes
         =====
@@ -1213,7 +1222,7 @@ class TensAdd(TensExpr):
         Parameters
         ==========
 
-        ``index_types`` : list of tuples ``(old_index, new_index)``
+        index_types : list of tuples ``(old_index, new_index)``
 
         Examples
         ========
@@ -1251,7 +1260,7 @@ class TensAdd(TensExpr):
         Parameters
         ==========
 
-        ``index_types`` : list of tuples ``(old_index, new_index)``
+        index_types : list of tuples ``(old_index, new_index)``
 
         Examples
         ========
@@ -1289,8 +1298,8 @@ class TensMul(TensExpr):
     Parameters
     ==========
 
-    ``coeff`` : SymPy coefficient of the tensor
-    ``args``
+    coeff : SymPy coefficient of the tensor
+    args
 
     Attributes
     ==========
@@ -1302,7 +1311,7 @@ class TensMul(TensExpr):
     ``ext_rank`` : rank of the tensor counting the dummy indices
     ``rank`` : rank of the tensor
     ``coeff`` : SymPy coefficient of the tensor
-    ``free_args``: list of the free indices in sorted order
+    ``free_args`` : list of the free indices in sorted order
     ``is_canon_bp`` : ``True`` if the tensor in in canonical form
 
     Notes

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1,0 +1,967 @@
+from collections import defaultdict
+from sympy.combinatorics.perm_groups import PermutationGroup
+from sympy.combinatorics.permutations import Permutation, _af_new, _af_invert
+from sympy.core import Basic, Symbol, sympify, Add, Mul, S, Rational
+from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, canonical_free, riemann_bsgs
+
+from functools import wraps
+
+from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic
+from sympy.core.decorators import call_highest_priority
+from sympy.core.sympify import SympifyError
+from sympy.matrices import ShapeError
+from sympy.simplify import simplify
+from sympy import cacheit
+
+class TensorIndexType(object):
+    def __init__(self, name, metric_sym=0, dummy_fmt=None):
+        """
+        name   name of the tensor type
+
+        metric_sym:
+        0      symmetric
+        1      antisymmetric
+        None   no symmetry
+
+        dummy_fmt name of the head of dummy indices; by default it is
+        the name of the tensor type
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        """
+        self.name = name
+        self.metric_sym = metric_sym
+        if not dummy_fmt:
+            self.dummy_fmt = '%s_%%d' % self.name
+        else:
+            self.dummy_fmt = '%s_%%d' % dummy_fmt
+
+    def __str__(self):
+        return self.name
+
+    __repr__ = __str__
+
+class TensorIndex(object):
+    """
+    Tensor indices are contructed with the Einstein summation convention.
+
+    An index can be in contravariant or in covariant form; in the latter
+    case it is represented prepending a `-` to the index name.
+
+    Dummy indices have the head given by `dummy_fmt`
+
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, TensorIndex, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> i = TensorIndex('i', Lorentz); i
+    i
+    >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    >>> S1 = TensorType([Lorentz], sym1)
+    >>> A, B = S1('A,B')
+    >>> A(i)*B(-i)
+    A(L_0)*B(-L_0)
+    """
+    def __init__(self, name, tensortype, is_contravariant=True):
+        self.name = name
+        self.tensortype = tensortype
+        self.is_contravariant = is_contravariant
+
+    def __str__(self):
+        s = self.name
+        if not self.is_contravariant:
+            s = '-%s' % s
+        return s
+
+    __repr__ = __str__
+
+    @cacheit
+    def covariant(self):
+        if self.is_contravariant:
+            return TensorIndex(self.name, self.tensortype, False)
+        else:
+            return self
+
+    def __eq__(self, other):
+        return self.name == other.name and \
+               self.tensortype == other.tensortype and \
+               self.is_contravariant == other.is_contravariant
+
+    __neg__ = covariant
+
+def tensor_indices(s, typ):
+    """
+    Returns tensor indices given their name
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    """
+    a = s.split(',')
+    return [TensorIndex(i, typ) for i in a]
+
+
+class TensorSymmetry(object):
+    """
+    Symmetry of a tensor
+
+    bsgs tuple (base, sgs) BSBS of the symmetry of the tensor
+
+    Examples
+    ========
+
+    Examples
+    ========
+
+    Define a symmetric tensor
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    >>> S2 = TensorType([Lorentz]*2, sym2)
+    >>> V = S2('V')
+    """
+    def __init__(self, bsgs):
+        self.base, self.generators = bsgs
+        self.rank = self.generators[0].size
+
+def _get_index_types(indices):
+    res = []
+    for i in indices:
+        if isinstance(i, TensorIndex):
+            res.append(i.tensortype)
+        elif isinstance(i, TensorIndexType):
+            res.append(i)
+        else:
+            raise NotImplementedError
+    return res
+
+def has_tensor(p):
+    if p.is_Tensor:
+        return True
+    if p.is_Mul or p.is_Add:
+        for x in p.args:
+            if has_tensor(x):
+                return True
+    return False
+
+
+class TensorType(Basic):
+    """
+
+    Examples
+    ========
+
+    Define a symmetric tensor
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    >>> S2 = TensorType([Lorentz]*2, sym2)
+    >>> V = S2('V')
+    """
+    is_commutative = False
+
+    def __new__(cls, indices, symmetry, **kw_args):
+        obj = Basic.__new__(cls, **kw_args)
+        obj.index_types = []
+        obj.index_types = _get_index_types(indices)
+        obj.types = list(set(obj.index_types))
+        obj.types.sort(key=lambda x: x.name)
+        obj.symmetry = symmetry
+        assert symmetry.rank == len(indices) + 2
+        return obj
+
+    def __str__(self):
+        return 'TensorType(%s)' %([str(x) for x in self.index_types])
+
+    def __call__(self, s, commuting=0):
+        """
+        commuting:
+        None no commutation rule
+        0    commutes
+        1    anticommutes
+
+        Examples
+        ========
+
+        Define symmetric tensors `V`, `W` and `G`, respectively commuting,
+        anticommuting and with no commutation symmetry
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs, canon_bp
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b = tensor_indices('a,b', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> V = S2('V')
+        >>> W = S2('W', 1)
+        >>> G = S2('G', None)
+        >>> canon_bp(V(a, b)*V(-b, -a))
+        V(L_0, L_1)*V(-L_0, -L_1)
+        >>> canon_bp(W(a, b)*W(-b, -a))
+        0
+        """
+        names = s.split(',')
+        if len(names) == 1:
+            return TensorHead(names[0], self, commuting)
+        else:
+            return [TensorHead(name, self, commuting) for name in names]
+
+class TensorHead(Basic):
+    is_commutative = False
+
+    def __new__(cls, name, typ, commuting, **kw_args):
+        """
+        tensor with given name, index types, symmetry, commutation rule
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b = tensor_indices('a,b', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A = S2('A')
+        """
+        assert isinstance(name, basestring)
+
+        obj = Basic.__new__(cls, **kw_args)
+        obj.name = name
+        obj.index_types = typ.index_types
+        obj.rank = len(obj.index_types)
+        obj.types = typ.types
+        obj.symmetry = typ.symmetry
+        obj.commuting = commuting
+        return obj
+
+    def __eq__(self, other):
+        if not isinstance(other, TensorHead):
+            return False
+        return self.name == other.name and self.index_types == other.index_types
+
+    def __neq__(self, other):
+        return not self == other
+
+    def commutes_with(self, other):
+        """
+        Returns 0 (1) if self and other (anti)commute
+        Returns None if self and other do not (anti)commute
+        """
+        if self.commuting == None or other.commuting == None:
+            return None
+        return self.commuting * other.commuting
+
+
+    def __str__(self):
+        return '%s(%s)' %(self.name, ','.join([str(x) for x in self.index_types]))
+    __repr__ = __str__
+
+    def __call__(self, *indices):
+        """
+        tensor with indices
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b = tensor_indices('a,b', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A = S2('A')
+        >>> t = A(a, -b)
+        """
+        assert self.rank == len(indices)
+        components = [self]
+        free, dum =  Tensor.from_indices(indices, self.types)
+        free.sort(key=lambda x: x[0].name)
+        dum.sort()
+        return Tensor(S.One, components, free, dum)
+
+
+class TensExpr(Basic):
+    """
+    A tensor expression is an expression formed by tensors;
+    currently the sums of tensors are distributed.
+
+    A TensExpr can be a TensAdd or a Tensor.
+
+    TensAdd objects are put in canonic form using the Butler-Portugal
+    algorithm for canonicalization under monoterm symmetries.
+
+    Tensor objects are formed by products of component tensors,
+    and include a coefficient, which is a SymPy expression.
+    """
+
+    _op_priority = 11.0
+    is_Tensor = True
+    is_TensExpr = True
+    is_TensMul = False
+    is_TensAdd = False
+    is_commutative = False
+
+    def __neg__(self):
+        return (-1)*self
+
+    def __abs__(self):
+        raise NotImplementedError
+
+    #@call_highest_priority('__radd__')
+    def __add__(self, other):
+        if self.is_TensAdd:
+            args = self.args + (other,)
+            return TensAdd(*args)
+        if other.is_TensAdd:
+            args = (self,) + other.args
+        return TensAdd(self, other)
+
+    #@call_highest_priority('__add__')
+    def __radd__(self, other):
+        return TensAdd(other, self)
+
+    #@call_highest_priority('__rsub__')
+    def __sub__(self, other):
+        return TensAdd(self, -other)
+
+    #@call_highest_priority('__sub__')
+    def __rsub__(self, other):
+        return TensAdd(other, -self)
+
+    #@call_highest_priority('__rmul__')
+    def __mul__(self, other):
+        #return TensMul(self, other)
+        if self.is_TensAdd:
+            return TensAdd(*[x*other for x in self.args])
+        if other.is_TensAdd:
+            return TensAdd(*[self*x for x in other.args])
+        return Tensor.__mul__(self, other)
+
+    #@call_highest_priority('__mul__')
+    def __rmul__(self, other):
+        if self.is_TensMul:
+            coeff = other*self.coeff
+            return Tensor(coeff, self.components, self.free, self.dum)
+        return TensAdd(*[x*other for x in self.args])
+
+    #@call_highest_priority('__rpow__')
+    def __pow__(self, other):
+        raise NotImplementedError
+
+    #@call_highest_priority('__pow__')
+    def __rpow__(self, other):
+        raise NotImplementedError
+
+    #@call_highest_priority('__rdiv__')
+    def __div__(self, other):
+        other = sympify(other)
+        if other.is_Tensor:
+            raise ValueError('cannot divide by a tensor')
+        coeff = self.coeff/other
+        return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+
+
+    #@call_highest_priority('__div__')
+    def __rdiv__(self, other):
+        raise NotImplementedError()
+
+    __truediv__ = __div__
+    __rtruediv__ = __rdiv__
+
+    def substitute_indices(self, *index_tuples):
+        """
+        Return a tensor with indices substituted according to `index_tuples`
+
+        Examples
+        ========
+
+        from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A, B = S2('A,B')
+        >>> t = A(i, k)*B(-k, -j); t
+        A(i, L_0)*B(-L_0, -j)
+        >>> t.substitute_indices((i,j), (j, k))
+        A(j, L_0)*B(-L_0, -k)
+        """
+        if self.is_TensMul:
+            free = self.free
+            free1 = []
+            for i, v in index_tuples:
+                for j, ipos, cpos in free:
+                    if i.name == j.name and i.tensortype == j.tensortype:
+                        if i.is_contravariant == j.is_contravariant:
+                            free1.append((v, ipos, cpos))
+                        else:
+                            # replace i with an index with the same covariance of i
+                            if j.is_contravariant:
+                                ind = TensorIndex(v.name, v.tensortype)
+                                free1.append((ind, ipos, cpos))
+                            else:
+                                ind = TensorIndex(v.name, v.tensortype)
+                                ind = -ind
+                                free1.append((ind, ipos, cpos))
+            return Tensor(self.coeff, self.components, free1, self.dum)
+        if self.is_TensAdd:
+            args = self.args
+            args1 = []
+            for x in args:
+                y = x.substitute_indices(*indices)
+                args1.append(y)
+            return TensAdd(args1)
+
+class TensAdd(TensExpr):
+    is_Tensor = True
+    is_TensAdd = True
+
+    def __new__(cls, *args, **kw_args):
+        """
+        args  tuple of addends
+        """
+        args = [sympify(x) for x in args if x]
+        if not all(x.is_Tensor for x in args):
+            raise ValueError('all arguments should be tensors')
+        a = []
+        for x in args:
+            if x.is_TensAdd:
+                a.extend(list(x.args))
+            else:
+                a.append(x)
+        args = a
+        indices = set([x[0] for x in args[0].free])
+        if not all(set([y[0] for y in x.free]) == indices for x in args[1:]):
+            raise ValueError('all tensors must have the same indices')
+        obj = Basic.__new__(cls, **kw_args)
+        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        a = []
+        pprev = None
+        prev = args[0]
+        prev_coeff = prev.coeff
+        changed = False
+        new = 0
+        for x in args[1:]:
+            # if x and prev have the same tensor, update the coeff of prev
+            if x.components == prev.components \
+                    and x.free == prev.free and x.dum == prev.dum:
+                prev_coeff = prev_coeff + x.coeff
+                changed = True
+                op = 0
+            else:
+                # x and prev are different; if not changed, prev has not
+                # been updated; store it
+                if not changed:
+                    a.append(prev)
+                else:
+                    # get a tensor from prev with coeff=prev_coeff and store it
+                    if prev_coeff:
+                        t = Tensor(prev_coeff, prev.components,
+                            prev.free, prev.dum)
+                        a.append(t)
+                # move x to prev
+                op = 1
+                pprev, prev = prev, x
+                pprev_coeff, prev_coeff = prev_coeff, x.coeff
+                changed = False
+        # if the case op=0 prev was not stored; store it now
+        # in the case op=1 x was not stored; store it now (as prev)
+        if op == 0 and prev_coeff:
+            prev = Tensor(prev_coeff, prev.components, prev.free, prev.dum)
+            a.append(prev)
+        elif op == 1:
+            a.append(prev)
+        if not a:
+            return S.Zero
+
+        # TODO introduce option not to use canon_bp automatically in TensAdd
+        if all(x.is_TensMul for x in a):
+            a = [x.canon_bp() for x in a]
+        obj._args = tuple(a)
+        obj.set_indices = indices
+        return obj
+
+    def canon_bp(self):
+        args = [x.canon_bp() for x in self.args]
+        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        return TensAdd(*args)
+
+    def __eq__(self, other):
+        return self - other == 0
+
+    def _pretty(self):
+        a = []
+        #args = sorted(self.args)
+        args = self.args
+        for x in args:
+            a.append(str(x))
+
+        a.sort()
+        s = ' + '.join(a)
+        s = s.replace('+ -', '- ')
+        return s
+
+class Tensor(TensExpr):
+    is_Tensor = True
+    is_TensMul = True
+
+    def __new__(cls, coeff, *args, **kw_args):
+        """
+
+        coeff SymPy expression coefficient of the tensor.
+
+        args[0]   list of TensorHead of the component tensors.
+
+        args[1]   list of (ind, ipos, icomp)
+        where `ind` is a free index, `ipos` is the slot position
+        of `ind` in the `icomp`-th component tensor.
+
+        args[2] list of tuples representing dummy indices.
+        (ipos1, ipos2, icomp1, icomp2) indicates that the contravariant
+        dummy index is the `ipos1` slot position in the `icomp1`-th
+        component tensor; the corresponding covariant index is
+        in the `ipos2` slot position in the `icomp2`-th component tensor.
+        """
+        # composite tensor
+        # p_i*p_i
+        # t = Tensor(None, t1, t2)
+        obj = Basic.__new__(cls)
+        obj.components = args[0]
+        obj.types = []
+        for t in obj.components:
+            obj.types.extend(t.types)
+        obj.free = args[1]
+        obj.dum = args[2]
+        obj.rank = len(obj.free) + 2*len(obj.dum)
+        obj.coeff = coeff
+        obj._is_canon_bp = kw_args.get('is_canon_bp', False)
+
+        return obj
+
+    def __eq__(self, other):
+        if not other.is_Tensor :
+            return False
+        res = self.components == other.components and \
+            self.free == other.free and \
+            self.dum == other.dum and self.coeff == other.coeff
+        return res
+
+    def __neq__(self, other):
+        return not self == other
+
+    @staticmethod
+    def from_indices(indices, types):
+        """
+        Returns free, dum for single component tensor
+
+        free         list of tuples (index, pos, 0),
+                     where `pos` is the position of index in
+                     the list of indices formed by the component tensors
+
+        dum          list of tuples (pos_contr, pos_cov, 0, 0)
+
+
+        """
+        n = len(indices)
+        if n == 1:
+            return [(indices[0], 0, 0)], []
+
+        # find the positions of the free indices and of the dummy indices
+        free = [True]*len(indices)
+        index_dict = {}
+        dum = []
+        for i, index in enumerate(indices):
+            name = index.name
+            typ = index.tensortype
+            contr = index.is_contravariant
+            if (name, typ) in index_dict:
+                # found a pair of dummy indices
+                is_contr, pos = index_dict[(name, typ)]
+                # check consistency and update free
+                if is_contr:
+                    if contr:
+                        raise ValueError('two equal contravariant indices in slots %d and %d' %(pos, i))
+                    else:
+                        free[pos] = False
+                        free[i] = False
+                else:
+                    if contr:
+                        free[pos] = False
+                        free[i] = False
+                    else:
+                        raise ValueError('two equal covariant indices in slots %d and %d' %(pos, i))
+                if contr:
+                    dum.append((i, pos, 0, 0))
+                else:
+                    dum.append((pos, i, 0, 0))
+            else:
+                index_dict[(name, typ)] = index.is_contravariant, i
+
+        free_indices = [(index, i, 0) for i, index in enumerate(indices) if free[i]]
+        free = sorted(free_indices, key=lambda x: (x[0].tensortype, x[0].name))
+
+        return free, dum
+
+    def get_indices(self):
+        """
+        Returns the list of indices of the tensor
+
+        The indices are listed in the order in which they appear in the
+        component tensors.
+        """
+        indices = [None]*self.rank
+        start = 0
+        pos = 0
+        vpos = []
+        components = self.components
+        for t in self.components:
+            vpos.append(pos)
+            pos += t.rank
+        cdt = defaultdict(int)
+        for indx, ipos, cpos in self.free:
+            start = vpos[cpos]
+            indices[start + ipos] = indx
+        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+            start1 = vpos[cpos1]
+            start2 = vpos[cpos2]
+            typ1 = components[cpos1].index_types[ipos1]
+            assert typ1 == components[cpos2].index_types[ipos2]
+            fmt = typ1.dummy_fmt
+            nd = cdt[typ1]
+            indices[start1 + ipos1] = TensorIndex(fmt % nd, typ1)
+            indices[start2 + ipos2] = TensorIndex(fmt % nd, typ1, False)
+            cdt[typ1] += 1
+        return indices
+
+    def split(self):
+        """
+        Returns a list of tensors, whose proouct is `self`
+
+        Dummy indices contracted among different tensor components
+        become free indices with the same name as the one used to
+        represent the dummy indices.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A, B = S2('A,B')
+        >>> t = A(a,b)*B(-b,c)
+        >>> t
+        A(a, L_0)*B(-L_0, c)
+        >>> t.split()
+        [A(a, L_0), B(-L_0, c)]
+
+
+        """
+        indices = self.get_indices()
+        pos = 0
+        components = self.components
+        res = []
+        for t in self.components:
+            t1 = t(*indices[pos:pos + t.rank])
+            pos += t.rank
+            res.append(t1)
+        res[0] = Tensor(self.coeff, res[0].components, res[0].free, res[0].dum, is_canon_bp=res[0]._is_canon_bp)
+        return res
+
+    def canon_args(self):
+        """
+        Returns (g, dummies, msym, v), the entries of `canonicalize`
+
+        see `canonicalize` in tensor_can.py
+        """
+        # to be called after sorted_components
+        from sympy.combinatorics.permutations import _af_new
+        types = list(set(self.types))
+        types.sort(key = lambda x: x.name)
+        n = self.rank
+        g = [None]*n + [n, n+1]
+        pos = 0
+        vpos = []
+        components = self.components
+        for t in self.components:
+            vpos.append(pos)
+            pos += t.rank
+        for i, (indx, ipos, cpos) in enumerate(self.free):
+            pos = vpos[cpos] + ipos
+            g[pos] = i
+
+        pos = len(self.free)
+        j = len(self.free)
+        dummies = []
+        prev = None
+        a = []
+        msym = []
+        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+            pos1 = vpos[cpos1] + ipos1
+            pos2 = vpos[cpos2] + ipos2
+            g[pos1] = j
+            g[pos2] = j + 1
+            j += 2
+            typ = components[cpos1].index_types[ipos1]
+            if typ != prev:
+                if a:
+                    dummies.append(a)
+                a = [pos, pos + 1]
+                prev = typ
+                msym.append(typ.metric_sym)
+            else:
+                a.extend([pos, pos + 1])
+            pos += 2
+        if a:
+            dummies.append(a)
+        numtyp = []
+        prev = None
+        for t in components:
+            if t == prev:
+                numtyp[-1][1] += 1
+            else:
+                prev = t
+                numtyp.append([prev, 1])
+        v = []
+        for h, n in numtyp:
+            v.append((h.symmetry.base, h.symmetry.generators, n, h.commuting))
+        return _af_new(g), dummies, msym, v
+
+    def __mul__(self, other):
+        #if not isinstance(other, Tensor):
+        other = sympify(other)
+        if not other.is_Tensor:
+            coeff = self.coeff*other
+            return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+        if other.is_TensAdd:
+            return TensAdd(*[self*x for x in other.args])
+
+        components = self.components + other.components
+        # find out which free indices of self and other are contracted
+        free_dict1 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in self.free])
+        free_dict2 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in other.free])
+
+        free_names = set(free_dict1.keys()) & set(free_dict2.keys())
+        # find the new `free` and `dum`
+        nc1 = len(self.components)
+        dum2 = [(i1, i2, c1 + nc1, c2 + nc1) for i1, i2, c1, c2 in other.dum]
+        free1 = [(ind, i, c) for ind, i, c in self.free if ind.name not in free_names]
+        free2 = [(ind, i, c + nc1) for ind, i, c in other.free if ind.name not in free_names]
+        free = free1 + free2
+        dum = self.dum + dum2
+        for name in free_names:
+            ipos1, cpos1, ind1 = free_dict1[name]
+            ipos2, cpos2, ind2 = free_dict2[name]
+            cpos2 += nc1
+            if ind1.is_contravariant == ind2.is_contravariant:
+                raise ValueError('wrong index contruction %s' % ind1)
+            if ind1.is_contravariant:
+                new_dummy = (ipos1, ipos2, cpos1, cpos2)
+            else:
+                new_dummy = (ipos2, ipos1, cpos2, cpos1)
+            dum.append(new_dummy)
+        coeff = self.coeff*other.coeff
+        return Tensor(coeff, components, free, dum)
+
+
+    def sorted_components(self):
+        """
+        Returns a tensor with sorted components
+        """
+        cv = zip(self.components, range(len(self.components)))
+        sign = 1
+        n = len(cv) - 1
+        for i in range(n):
+            for j in range(n, i, -1):
+                c = cv[j-1][0].commutes_with(cv[j][0])
+                if c == None:
+                    continue
+                if (cv[j-1][0].types, cv[j-1][0].name) > \
+                        (cv[j][0].types, cv[j][0].name):
+                    cv[j-1], cv[j] = cv[j], cv[j-1]
+                    if c:
+                        sign = -sign
+        # perm_inv[new_pos] = old_pos
+        components = [x[0] for x in cv]
+        perm_inv = [x[1] for x in cv]
+        perm = _af_invert(perm_inv)
+        free = [(ind, i, perm[c]) for ind, i, c in self.free]
+        dum = [(i1, i2, perm[c1], perm[c2]) for i1, i2, c1, c2 in self.dum]
+        free.sort(key = lambda x: (x[0].tensortype, x[0].name))
+        dum.sort(key = lambda x: components[x[2]].index_types[x[0]])
+        if sign == -1:
+            coeff = -self.coeff
+        else:
+            coeff = self.coeff
+        t = Tensor(coeff, components, free, dum)
+        return t
+
+    def perm2tensor(self, g, canon_bp=False):
+        """
+        Returns the tensor corresponding to the permutation `g`
+
+        g  permutation corrisponding to the tensor in the representation
+        used in canonicalization
+
+        canon_bp   if canon_bp is True, then `g` is the permutation
+        corresponding to the canonical form of the tensor
+        """
+        from bisect import bisect_right
+        vpos = []
+        components = self.components
+        pos = 0
+        for t in self.components:
+            vpos.append(pos)
+            pos += t.rank
+        free_indices = [x[0] for x in self.free]
+        sorted_free = sorted(free_indices, key=lambda x:(x.tensortype, x.name))
+        nfree = len(sorted_free)
+        rank = self.rank
+        indices = [None]*rank
+        dum = [[None]*4 for i in range((rank - nfree)//2)]
+        free = []
+        icomp = -1
+        for i in range(rank):
+            if i in vpos:
+                icomp += 1
+                pos0 = i
+            ipos = i - pos0
+            gi = g[i]
+            if gi < nfree:
+                ind = sorted_free[gi]
+                free.append((ind, ipos, icomp))
+            else:
+                j = gi - nfree
+                idum, cov = divmod(j, 2)
+                if cov:
+                    dum[idum][1] = ipos
+                    dum[idum][3] = icomp
+                else:
+                    dum[idum][0] = ipos
+                    dum[idum][2] = icomp
+        dum = [tuple(x) for x in dum]
+        coeff = self.coeff
+        if g[-1] != len(g) - 1:
+            coeff = -coeff
+        res = Tensor(coeff, components, free, dum, is_canon_bp=canon_bp)
+        #if canon_bp:
+        #    res._canon_bp = True
+        return res
+
+    def canon_bp(self):
+        """
+        canonicalize using the Butler-Portugal algorithm for canonicalization
+        under monoterm symmetries.
+
+        Examples
+        ========
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+        >>> S2 = TensorType([Lorentz]*2, sym2a)
+        >>> A = S2('A')
+        >>> t = A(m0,-m1)*A(m1,-m2)*A(m2,-m0)
+        >>> t.canon_bp()
+        0
+        """
+        from sympy.combinatorics.tensor_can import canonicalize
+        if self._is_canon_bp:
+            return self
+        t = self.sorted_components()
+        g, dummies, msym, v = t.canon_args()
+        can = canonicalize(g, dummies, msym, *v)
+        if can == 0:
+            return S.Zero
+        return t.perm2tensor(can, True)
+
+
+    def _pretty(self):
+        indices = [str(ind) for ind in self.get_indices()]
+        pos = 0
+        a = []
+        for t in self.components:
+            a.append('%s(%s)' % (t.name, ', '.join(indices[pos:pos + t.rank])))
+            pos += t.rank
+        res = '*'. join(a)
+        if self.coeff == S.One:
+            return res
+        elif self.coeff == -S.One:
+            return '-%s' % res
+        if self.coeff.is_Atom:
+            return '%s*%s' % (self.coeff, res)
+        else:
+            return '(%s)*%s' %(self.coeff, res)
+
+
+
+def canon_bp(p):
+    """
+    Butler-Portugal canonicalization
+    """
+    if p.is_Tensor:
+        return p.canon_bp()
+    if p.is_Add:
+        return Add(*[canon_bp(x) for x in p.args])
+    if p.is_Mul:
+        return Mul(*[canon_bp(x) for x in p.args])
+    return p
+
+def tensor_mul(*a):
+    """
+    product of tensors
+    """
+    t = a[0]
+    for tx in a[1:]:
+        t = t*tx
+    return t
+
+def riemann_cyclic_replaceR(t_r):
+    """
+    R(m,n,p,q) -> 2/3*R(m,n,p,q) - 1/3*R(m,q,n,p) + 1/3*R(m,p,n,q)
+
+    """
+    free = sorted(t_r.free, key=lambda x: x[1])
+    m, n, p, q = [x[0] for x in free]
+    t0 = S(2)/3*t_r
+    t1 = - S(1)/3*t_r.substitute_indices((m,m),(n,q),(p,n),(q,p))
+    t2 = S(1)/3*t_r.substitute_indices((m,m),(n,p),(p,n),(q,q))
+    t3 = t0 + t1 + t2
+    return t3
+
+def riemann_cyclic(t2):
+    """
+    replace each Riemann tensor with an equivalent expression
+    satisfying the cyclic identity
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, riemann_cyclic, riemann_bsgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
+    >>> symr = TensorSymmetry(riemann_bsgs)
+    >>> R4 = TensorType([Lorentz]*4, symr)
+    >>> R = R4('R')
+    >>> t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
+    >>> riemann_cyclic(t)
+    0
+    """
+    a = t2.args
+    a1 = [x.split() for x in a]
+    a2 = [[riemann_cyclic_replaceR(tx) for tx in y] for y in a1]
+    a3 = [tensor_mul(*v) for v in a2]
+    t3 = TensAdd(*a3)
+    if not t3:
+        return t3
+    else:
+        return canon_bp(t3)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1010,10 +1010,11 @@ class Tensor(TensExpr):
         >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
         >>> p, q = S1('p,q')
-        >>> t = p(m0)*q(m1)*g(-m0, -m1); t
-        p(L_1)*q(L_0)*metric(-L_1, -L_0)
-        >>> t.contract_metric(g)
-        p(-L_0)*q(L_0)
+        >>> t = p(m0)*q(m1)*g(-m0, -m1)
+        >>> t.canon_bp()
+        metric(L_0, L_1)*p(-L_0)*q(-L_1)
+        >>> t.contract_metric(g).canon_bp()
+        p(L_0)*q(-L_0)
         """
         if g.index_types[0].metric_sym != 0:
             # TODO case of antisymmetric metric

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -340,6 +340,36 @@ class TensorType(Basic):
         else:
             return [TensorHead(name, self, anticommuting) for name in names]
 
+def tensorhead(name, typ, sym, anticommuting=False):
+    """
+    Function generating tensorhead(s).
+
+    ``name`` name or sequence of names (as in ``symbol``)
+
+    ``typ``  index types
+
+    ``sym``  same as ``*args`` in ``tensorsymmetry``
+
+    ``anticommuting``:
+        None     no commutation rule
+        False    commutes
+        True     anticommutes
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b = tensor_indices('a,b', Lorentz)
+    >>> A = tensorhead('A', [Lorentz]*2, [[1]*2])
+    >>> A(a, -b)
+    A(a, -b)
+
+    """
+    sym = tensorsymmetry(*sym)
+    S = TensorType(typ, sym)
+    return S(name, anticommuting)
+
+
 class TensorHead(Basic):
     is_commutative = False
 
@@ -407,12 +437,10 @@ class TensorHead(Basic):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> a, b = tensor_indices('a,b', Lorentz)
-        >>> sym2 = tensorsymmetry([1]*2)
-        >>> S2 = TensorType([Lorentz]*2, sym2)
-        >>> A = S2('A')
+        >>> A = tensorhead('A', [Lorentz]*2, [[1]*2])
         >>> t = A(a, -b)
         """
         assert [indices[i].tensortype for i in range(len(indices))] == self.index_types
@@ -513,13 +541,10 @@ class TensExpr(Basic):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
-        >>> sym2 = tensorsymmetry([1]*2)
-        >>> S2 = TensorType([Lorentz]*2, sym2)
-        >>> A, B = S2('A,B')
+        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
         >>> t = A(i, k)*B(-k, -j); t
         A(i, L_0)*B(-L_0, -j)
         >>> t.substitute_indices((i,j), (j, k))
@@ -641,12 +666,10 @@ class TensAdd(TensExpr):
     Examples
     ========
 
-    >>> from sympy.tensor.tensor import TensorIndexType, tensorsymmetry, TensorType, tensor_indices, TensAdd
+    >>> from sympy.tensor.tensor import TensorIndexType, tensorhead, tensor_indices
     >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     >>> a, b = tensor_indices('a,b', Lorentz)
-    >>> sym = tensorsymmetry([1])
-    >>> S1 = TensorType([Lorentz], sym)
-    >>> p, q = S1('p,q')
+    >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
     >>> t1 = p(a)
     >>> t2 = q(a)
     >>> t1 + t2
@@ -875,13 +898,11 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = tensorsymmetry([1])
-        >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
+        >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t = p(m1)*g(m0,m2)
         >>> t.get_indices()
         [m1, m0, m2]
@@ -926,12 +947,10 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
-        >>> sym2 = tensorsymmetry([1]*2)
-        >>> S2 = TensorType([Lorentz]*2, sym2)
-        >>> A, B = S2('A,B')
+        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
         >>> t = A(a,b)*B(-b,c)
         >>> t
         A(a, L_0)*B(-L_0, c)
@@ -1023,13 +1042,11 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = tensorsymmetry([1])
-        >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
+        >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t1 = p(m0)
         >>> t2 = q(-m0)
         >>> t1*t2
@@ -1161,12 +1178,10 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym2a = tensorsymmetry([2])
-        >>> S2 = TensorType([Lorentz]*2, sym2a)
-        >>> A = S2('A')
+        >>> A = tensorhead('A', [Lorentz]*2, [[2]])
         >>> t = A(m0,-m1)*A(m1,-m0)
         >>> t.canon_bp()
         -A(L_0, L_1)*A(-L_0, -L_1)
@@ -1319,13 +1334,11 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = tensorsymmetry([1])
-        >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
+        >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t = p(m0)*q(m1)*g(-m0, -m1)
         >>> t.canon_bp()
         metric(L_0, L_1)*p(-L_0)*q(-L_1)
@@ -1495,12 +1508,10 @@ def riemann_cyclic(t2):
     Examples
     ========
 
-    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType, riemann_cyclic
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead, riemann_cyclic
     >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
-    >>> symr = tensorsymmetry([2, 2])
-    >>> R4 = TensorType([Lorentz]*4, symr)
-    >>> R = R4('R')
+    >>> R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     >>> t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
     >>> riemann_cyclic(t)
     0

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1071,7 +1071,7 @@ class Tensor(TensExpr):
                     a1 = a[:i] + a[i + 1:]
                     t = tensor_mul(*a1)*(typ.dim*a[i]._coeff)
                     if delta in t._components:
-                        return t.contract_delta(delta, True)
+                        return t.contract_delta(delta)
                     return t
 
         # if all metric tensors have only free indices, there is no contraction

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -674,8 +674,6 @@ class TensAdd(TensExpr):
         if not args:
             return S.Zero
         a = _tensAdd_collect_terms(args)
-        a = [canon_bp(x) for x in a]
-        a = [x for x in a if x]
         if not a:
             return S.Zero
         if len(a) == 1:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4,6 +4,9 @@ from sympy.core.symbol import Symbol, symbols
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
 
 
+def is_Tensor(x):
+    return isinstance(x, TensExpr)
+
 class TensorIndexType(Basic):
     """
     A TensorIndexType is characterized by its name, by metric_antisym,
@@ -372,8 +375,6 @@ class TensExpr(Basic):
     """
 
     _op_priority = 11.0
-    is_Tensor = True
-    is_TensExpr = True
     is_TensMul = False
     is_TensAdd = False
     is_commutative = False
@@ -422,7 +423,7 @@ class TensExpr(Basic):
 
     def __div__(self, other):
         other = sympify(other)
-        if other.is_Tensor:
+        if is_Tensor(other):
             raise ValueError('cannot divide by a tensor')
         coeff = self._coeff/other
         return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
@@ -523,16 +524,16 @@ def _tensAdd_flatten(args):
     """
     flatten TensAdd, coerce terms which are not tensors to tensors
     """
-    if not all(x.is_Tensor for x in args):
+    if not all(is_Tensor(x) for x in args):
         args1 = []
         for x in args:
-            if x.is_Tensor:
+            if is_Tensor(x):
                 if x.is_TensAdd:
                     args1.extend(list(x.args))
                 else:
                     args1.append(x)
-        args1 = [x for x in args1 if x.is_Tensor and x._coeff]
-        args2 = [x for x in args if not x.is_Tensor]
+        args1 = [x for x in args1 if is_Tensor(x) and x._coeff]
+        args2 = [x for x in args if not is_Tensor(x)]
         t0 = args1[0]
         if t0.is_TensAdd:
             t0 = t0.args[0]
@@ -579,7 +580,6 @@ class TensAdd(TensExpr):
     >>> t1 + t2
     p(a) + q(a)
     """
-    is_Tensor = True
     is_TensAdd = True
 
     def __new__(cls, *args, **kw_args):
@@ -620,13 +620,13 @@ class TensAdd(TensExpr):
 
     def __eq__(self, other):
         other = sympify(other)
-        if not other.is_Tensor:
+        if not is_Tensor(other):
             if len(self.args) == 1:
                 return self.args[0]._coeff == other
-        if other.is_Tensor and other.is_TensMul and other._coeff == 0:
+        if is_Tensor(other) and other.is_TensMul and other._coeff == 0:
             return self == 0
         t = self - other
-        if not t.is_Tensor:
+        if not is_Tensor(t):
             return t == 0
         else:
             if t.is_TensMul:
@@ -673,7 +673,6 @@ class TensMul(TensExpr):
     """
     Product of tensors
     """
-    is_Tensor = True
     is_TensMul = True
 
     def __new__(cls, coeff, *args, **kw_args):
@@ -710,7 +709,7 @@ class TensMul(TensExpr):
         if other == 0:
             return self._coeff == 0
         other = sympify(other)
-        if not other.is_Tensor :
+        if not is_Tensor(other):
             return False
         res = self - other
         return res == 0
@@ -939,7 +938,7 @@ class TensMul(TensExpr):
         p(L_0)*q(-L_0)
         """
         other = sympify(other)
-        if not other.is_Tensor:
+        if not is_Tensor(other):
             coeff = self._coeff*other
             return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
         if other.is_TensAdd:
@@ -1339,7 +1338,7 @@ def canon_bp(p):
     """
     Butler-Portugal canonicalization
     """
-    if p.is_Tensor:
+    if is_Tensor(p):
         return p.canon_bp()
     return p
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -42,12 +42,14 @@ class _TensorManager(object):
     =====
 
     Tensors belong to tensor commutation groups; each group has a label
-    ``comm`; there are predefined labels:
-    `0`   tensors commuting with any other tensor
-    `1`   tensors anticommuting among themselves
-    `2`   tensors not commuting, apart with those with ``comm=0``
+    ``comm``; there are predefined labels:
+    ``0``   tensors commuting with any other tensor
+    ``1``   tensors anticommuting among themselves
+    ``2``   tensors not commuting, apart with those with ``comm=0``
 
-    Other groups can be defined using `set_comm`.
+    Other groups can be defined using ``set_comm``; tensors in those
+    groups commute with those with ``comm=0``; by default they
+    do not commute with any other group.
     """
     def __init__(self):
         self._comm_init()
@@ -72,7 +74,10 @@ class _TensorManager(object):
         """
         get the commutation group number corresponding to ``i``
 
-        ``i`` can be a symbol or a number
+        ``i`` can be a symbol or a number or a string
+
+        If ``i`` is not already defined its commutation group number
+        is set.
         """
         if i not in self._comm_symbols2i:
             n = len(self._comm_symbols2i)
@@ -84,28 +89,37 @@ class _TensorManager(object):
         return self._comm_symbols2i[i]
 
     def comm_i2symbol(self, i):
+        """
+        Returns the symbol corresponding to the commutation group number.
+        """
         return self._comm_i2symbol[i]
 
     def set_comm(self, i, j, c):
         """
         set the commutation parameter ``c`` for commutation groups ``i, j``
 
-        ``i, j`` they can be symbols or numbers, apart from ``0, 1`` and ``2``
-        which are reserved respectively for commuting, anticommuting
-        tensors and tensors not commuting with any other group apart with
-        the commuting tensors.
+        Parameters
+        ==========
 
-        ``c``     commutation number
+        ``i, j`` : symbols representing commutation groups
+
+        ``c``  :  group commutation number
+
+        Notes
+        =====
+
+        ``i, j`` can be symbols, strings or numbers,
+        apart from ``0, 1`` and ``2`` which are reserved respectively
+        for commuting, anticommuting tensors and tensors not commuting
+        with any other group apart with the commuting tensors.
+        For the remaining cases, use this method to set the commutation rules;
+        by default ``c=None``.
+
+        The group commutation number ``c`` is assigned in corrispondence
+        to the group commutation symbols; it can be
         0        commuting
         1        anticommuting
         None     no commutation property
-
-        Tensors in the group ``i=0`` commute with any other tensor.
-        Tensors in the group ``i=1`` anticommute within that group.
-        Tensors in the group ``i=2`` commute only with the ``0`` group.
-
-        For the remaining cases, use this method to set the commutation rules;
-        by default ``c=None``.
 
         Examples
         ========
@@ -127,6 +141,9 @@ class _TensorManager(object):
         >>> (G(i1)*A(i0)).canon_bp()
         A(i0)*G(i1)
         """
+        if c not in (0, 1, None):
+            raise ValueError('`c` can assume only the values 0, 1 or None')
+
         if i not in self._comm_symbols2i:
             n = len(self._comm_symbols2i)
             self._comm[n][0] = 0
@@ -145,6 +162,14 @@ class _TensorManager(object):
         self._comm[nj][ni] = c
 
     def set_comms(self, *args):
+        """
+        set the commutation group numbers ``c`` for symbols ``i, j``
+
+        Parameters
+        ==========
+
+        ``args`` : sequence of ``(i, j, c``
+        """
         for i, j, c in range(len(args)):
             set_comm(self, i, j, c)
 
@@ -162,6 +187,9 @@ class _TensorManager(object):
             return None
 
     def clear(self):
+        """
+        Clear the TensorManager.
+        """
         self._comm_init()
 
 
@@ -1144,6 +1172,8 @@ class TensAdd(TensExpr):
             raise ValueError('cannot divide by a tensor')
         return TensAdd(*[x/other for x in self.args])
 
+    __truediv__ = __div__
+
     def _hashable_content(self):
         return tuple(self.args)
 
@@ -1673,6 +1703,8 @@ class TensMul(TensExpr):
         coeff = self._coeff/other
         return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
 
+    __truediv__ = __div__
+
     def sorted_components(self):
         """
         Returns a tensor with sorted components
@@ -2032,7 +2064,7 @@ class TensMul(TensExpr):
                     a.append('%s(%s)' % (t.name, ', '.join(sindices[pos:pos + t.rank])))
                 else:
                     a.append('%s' % t.name)
-            pos += t.rank
+            pos += t._rank
         res = '*'. join(a)
         if self._coeff == S.One:
             return res

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -742,7 +742,7 @@ class TensAdd(TensExpr):
 
     def expand_coeff(self):
         args = [_tensor_expand_coeff(x) for x in self.args]
-        return TensAdd(args)
+        return TensAdd(*args)
 
     def _pretty(self):
         a = []

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -368,6 +368,9 @@ class TensorSymmetry(Basic):
         r = (tuple(self.base), tuple(self.generators))
         return r
 
+    def __hash__(self):
+        return Basic.__hash__(self)
+
 def tensorsymmetry(*args):
     """
     return a ``TensorSymmetry`` object
@@ -573,6 +576,9 @@ class TensorHead(Basic):
     def _hashable_content(self):
         r = (self.name, tuple(self.types), self.symmetry, self.comm)
         return r
+
+    def __hash__(self):
+        return Basic.__hash__(self)
 
     def commutes_with(self, other):
         """
@@ -932,6 +938,9 @@ class TensAdd(TensExpr):
     def _hashable_content(self):
         return tuple(self.args)
 
+    def __hash__(self):
+        return Basic.__hash__(self)
+
     def __ne__(self, other):
         return not (self == other)
 
@@ -1059,6 +1068,9 @@ class TensMul(TensExpr):
         r = (t._coeff, tuple(t._components), \
                 tuple(sorted(t._free)), tuple(sorted(t._dum)))
         return r
+
+    def __hash__(self):
+        return Basic.__hash__(self)
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -363,8 +363,6 @@ class TensorSymmetry(Basic):
         r = (tuple(self.base), tuple(self.generators))
         return r
 
-    def __hash__(self):
-        return Basic.__hash__(self)
 
 def tensorsymmetry(*args):
     """
@@ -582,9 +580,6 @@ class TensorHead(Basic):
     def _hashable_content(self):
         r = (self.name, tuple(self.types), self.symmetry, self.comm)
         return r
-
-    def __hash__(self):
-        return Basic.__hash__(self)
 
     def commutes_with(self, other):
         """
@@ -955,7 +950,7 @@ class TensAdd(TensExpr):
         return tuple(self.args)
 
     def __hash__(self):
-        return Basic.__hash__(self)
+        return super(TensAdd, self).__hash__()
 
     def __ne__(self, other):
         return not (self == other)
@@ -1113,7 +1108,7 @@ class TensMul(TensExpr):
         return r
 
     def __hash__(self):
-        return Basic.__hash__(self)
+        return super(TensMul, self).__hash__()
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/tensor/tests/test_dgamma_matr.py
+++ b/sympy/tensor/tests/test_dgamma_matr.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, S, I
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices, \
-TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
 from sympy.tensor.dgamma_matr import GammaMatrices
 from sympy.utilities.pytest import skip, XFAIL
 

--- a/sympy/tensor/tests/test_dgamma_matr.py
+++ b/sympy/tensor/tests/test_dgamma_matr.py
@@ -1,0 +1,278 @@
+from sympy import Symbol, S, I
+from sympy.tensor.tensor import (TensorIndexType, tensor_indices, \
+TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
+from sympy.tensor.dgamma_matr import GammaMatrices
+from sympy.utilities.pytest import skip, XFAIL
+
+
+D = Symbol('D')
+Lorentz = TensorIndexType('Lorentz', dim=D, eps_dim=4, dummy_fmt='L')
+m0, m1, m2, m3, m4, m5 = tensor_indices('m0,m1,m2,m3,m4,m5', Lorentz)
+n0, n1, n2, n3, n4, n5 = tensor_indices('n0,n1,n2,n3,n4,n5', Lorentz)
+sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+S1 = TensorType([Lorentz], sym1)
+
+GM = GammaMatrices( Lorentz)
+match1_gamma = GM.match1_gamma
+G = GM.G
+g = GM.g
+epsilon = GM.epsilon
+rule1_gamma = GM.rule1_gamma
+do_rule1_gamma = GM.do_rule1_gamma
+match2_gamma = GM.match2_gamma
+rule2_gamma = GM.rule2_gamma
+do_rule2_gamma = GM.do_rule2_gamma
+gamma_trace = GM.gamma_trace
+gamma_trace1 = GM.gamma_trace1
+gctr = GM.gctr
+
+
+def test_rule1_gamma():
+    t = 2*G(m2)*G(m0)*G(m1)*G(-m0)*G(-m1)
+    r = match1_gamma(t, 1)
+    t = rule1_gamma(t, 1)
+    r = match1_gamma(t, 0)
+    t = rule1_gamma(t, 0)
+    assert t == (D*(-2*D + 4))*G(m2)
+
+    t = 3*G(m2)*G(m0)*G(m1)*G(-m0)
+    t = rule1_gamma(t, 1)
+
+    t = G(m2)*G(m0)*G(m1)*G(-m0)*G(-m2)
+    r = match1_gamma(t, 1)
+    assert r == (1, 3)
+    t = rule1_gamma(t, 1)
+    t = rule1_gamma(t, 1)
+    assert t == ((-D + 2)**2)*G(m1)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)
+    r = match1_gamma(t, 2)
+    assert r == (1, 4)
+    t = rule1_gamma(t, 2)
+    assert t == (D - 4)*G(m0)*G(m2)*G(m3) + 4*g(m2, m3)*G(m0)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)*G(-m0)
+    r = match1_gamma(t, 2)
+    t = rule1_gamma(t, 2)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)*G(-m0)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == ((D - 4)**2)*G(m2)*G(m3) + (8*D - 16)*g(m2, m3)
+
+    t = G(m2)*G(m0)*G(m1)*G(-m2)*G(-m0)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == ((-D + 2)*(D - 4) + 4)*G(m1)
+
+    t = G(m3)*G(m1)*G(m0)*G(m2)*G(-m3)*G(-m0)*G(-m2)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == (-4*D + (-D + 2)**2*(D - 4) + 8)*G(m1)
+
+    M = Symbol('M')
+
+    p = S1('p')
+    ps = p(m0)*G(-m0)
+    t0 = ps + M
+    t = G(m0)*(ps + M)*G(-m0)
+    t = do_rule1_gamma(t)
+    assert t == (2 - D)*ps + D*M
+
+    t = G(m0)*(ps + M)*G(-m0)*(ps + M)
+    t = do_rule1_gamma(t)
+
+    t = 2*G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)
+    t = do_rule1_gamma(t)
+    assert t == (-2*D + 8)*G(m1)*G(m2)*G(m3) - 4*G(m3)*G(m2)*G(m1)
+
+    t = G(m5)*G(m0)*G(m1)*G(m4)*G(m2)*G(-m4)*G(m3)*G(-m0)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == ((-D + 2)*(-D + 4))*G(m5)*G(m1)*G(m2)*G(m3) + (2*D - 4)*G(m5)*G(m3)*G(m2)*G(m1)
+
+    t = -G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)*G(m4)
+    t = do_rule1_gamma(t)
+    assert t == (D - 4)*G(m1)*G(m2)*G(m3)*G(m4) + 2*G(m3)*G(m2)*G(m1)*G(m4)
+
+    t = G(-m5)*G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)*G(m5)
+    t = do_rule1_gamma(t, doall=True)
+    assert t == ((-D + 4)**2 + 4)*G(m1)*G(m2)*G(m3)*G(m4) + (4*D - 16)*G(m3)*G(m2)*G(m1)*G(m4) + (4*D - 16)*G(m4)*G(m1)*G(m2)*G(m3) + 4*G(m2)*G(m1)*G(m4)*G(m3) + 4*G(m3)*G(m4)*G(m1)*G(m2) + 4*G(m4)*G(m3)*G(m2)*G(m1)
+
+
+def test_rule2_gamma():
+    p = S1('p')
+    M = Symbol('M')
+    ps = p(m0)*G(-m0)
+    t = ps*ps
+    t = t.canon_bp()
+    t = rule2_gamma(t, 0)
+    assert t == p(m0)*p(-m0)
+
+    t = 2*G(m1)*ps*ps*G(m2)
+    t = rule2_gamma(t, 0)
+    assert t == 2*G(m1)*G(m2)*p(m0)*p(-m0)
+
+    t0 = ps + M
+    t = G(m0)*(ps + M)*G(-m0)
+    t = do_rule1_gamma(t)
+    assert t == (2 - D)*ps + D*M
+
+    t = G(m0)*(ps + M)*G(-m0)*(ps + M)
+    t = do_rule1_gamma(t)
+    t = do_rule2_gamma(t)
+    assert t == (-D + 2)*p(m0)*p(-m0) + (D*M + M*(-D + 2))*G(m0)*p(-m0) + D*M**2
+
+
+def test_gamma_trace():
+    a = [G(m0), G(m1)]
+    t1 = gamma_trace1(*a)
+    a = [G(m0), G(m1), G(m2), G(m3)]
+    t1 = gamma_trace1(*a)
+
+    t = G(m0)*G(m1)
+    t1 = gamma_trace(t)
+    assert t1 == 4*g(m0, m1)
+    t = G(m0)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    t2 = -4*g(m0, m2)*g(m1, m3) + 4*g(m0, m1)*g(m2, m3) + 4*g(m0, m3)*g(m1, m2)
+    st2 = str(t2)
+    assert t1 == t2
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)
+    t1 = gamma_trace(t)
+    assert t1 == (-4*D)*g(m1, m3)*g(m2, m4) + (4*D)*g(m1, m2)*g(m3, m4) + \
+                 (4*D)*g(m1, m4)*g(m2, m3)
+
+    t = G(-m5)*G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)*G(m5)
+    t1 = gamma_trace(t)
+    assert t1 == (32*D + 4*(-D + 4)**2 - 64)*(g(m1, m2)*g(m3, m4) - \
+            g(m1, m3)*g(m2, m4) + g(m1, m4)*g(m2, m3))
+
+    t = G(m0)*G(m1)*G(-m0)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == (-4*D + 8)*g(m1, m3)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(m5)
+    t1 = gamma_trace(t)
+    t2 = t1*g(-m0, -m5)
+    t2 = t2.contract_metric(g)
+    assert t2 == D*gamma_trace(G(m1)*G(m2)*G(m3)*G(m4))
+
+    p, q = S1('p,q')
+    ps = p(m0)*G(-m0)
+    qs = q(m0)*G(-m0)
+    t = ps*qs*ps*qs
+    t1 = gamma_trace(t)
+    assert t1 == 8*p(m0)*q(-m0)*p(m1)*q(-m1) - 4*p(m0)*p(-m0)*q(m1)*q(-m1)
+
+def test_gamma5():
+    G5 = GM.G5
+    epsilon = GM.epsilon
+    t1 = GM.G5_to_right(2*G5)
+    assert t1 == 2*G5
+    assert gamma_trace(t1) == 0
+
+    t = G5*G(m0)
+    t1 = GM.G5_to_right(t)
+    assert t1 == - G(m0)*G5
+
+    t = G5*G(m0)*G5*G(m1)
+    t1 = GM.G5_to_right(t)
+    assert t1 == -G(m0)*G(m1)
+    t = G5*G(m0)*G5*G(m1)*G5
+    t1 = GM.G5_to_right(t)
+    assert t1 == -G(m0)*G(m1)*G5
+
+    t = (1 + G5)*(1 - G5)
+    t1 = GM.G5_to_right(t)
+    assert t1 == 0
+
+    t = G5*G(m0)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t = G(m0)*G5*G(m1)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t= G5*G(m0)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 4*I*epsilon(m0, m1, m2, m3)
+
+    t= G5*G(m0)*G(-m0)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t= G5*G(m0)*G(-m0)*G(m1)*G(m2)*G(m3)*G(m4)
+    t1 = gamma_trace(t)
+    assert t1 == 4*D*I*epsilon(m1, m2, m3, m4)
+
+    t= G5*G(m0)*G(m1)*G(-m0)*G(m2)*G(m3)*G(m4)
+    t1 = gamma_trace(t)
+    assert t1 == (I*(-4*D + 8))*epsilon(m1, m2, m3, m4)
+
+    t = G(m0)*(1 - G5)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t = G(m0)*(1 - G5)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 4*I*epsilon(m0, m1, m2, m3) + 4*(g(m0,m1)*g(m2,m3) - \
+            g(m0,m2)*g(m1,m3) + g(m0,m3)*g(m1,m2))
+
+    t = G(m0)*(1 - G5)*G(m1)*(1 + G5)*G(m2)*(1 - G5)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 16*I*epsilon(m0, m1, m2, m3) + 16*(g(m0,m1)*g(m2,m3) - \
+            g(m0,m2)*g(m1,m3) + g(m0,m3)*g(m1,m2))
+
+    M = Symbol('M')
+    p, q = S1('p,q')
+    ps = p(m0)*G(-m0)
+    qs = q(m0)*G(-m0)
+    p2 = p(m0)*p(-m0)
+    q2 = q(m0)*q(-m0)
+    pq = p(m0)*q(-m0)
+    t = (ps + M)*G5*(qs + M)*G5
+    t1 = gamma_trace(t)
+    assert t1 == -4*p(m0)*q(-m0) + 4*M**2
+
+    t = G(m0)*(ps + M)*G(m2)*(ps + qs + M)*G5
+    t1 = gamma_trace(t)
+    assert t1 == -4*I*epsilon(m0,m2,m1,m3)*p(-m1)*q(-m3)
+
+    t = G(m0)*(ps + M)*G(m1)*(ps + qs)*G(m2)*(1 - G5)
+    t1 = gamma_trace(t)
+    assert t1 == 4*M*(-g(m1, m2)*p(m0) -g(m1, m2)*q(m0) + \
+      I*epsilon(m0, m1, m2, m3)*p(-m3) + I*epsilon(m0, m1, m2, m3)*q(-m3) + \
+        g(m0, m1)*p(m2) + g(m0, m1)*q(m2) + g(m0, m2)*p(m1) + g(m0, m2)*q(m1))
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(m5)*G5
+    t1 = gamma_trace(t)
+    t2 = t1*g(-m0, -m2)
+    t2 = t2.contract_metric(g, contract_all=True)
+    assert t2 == (-4*I*D + 8*I)*epsilon(m1, m3, m4, m5)
+
+def test_trace1():
+    M = Symbol('M')
+    p, q = S1('p,q')
+    ps = p(m0)*G(-m0)
+    qs = q(m0)*G(-m0)
+    p2 = p(m0)*p(-m0)
+    q2 = q(m0)*q(-m0)
+    pq = p(m0)*q(-m0)
+
+    t = ps*qs*ps*qs*ps*qs
+    t1 = gamma_trace(t)
+    assert t1 == -12*p2*pq*q2 + 16*pq*pq*pq
+
+    t = ps*qs*ps*qs*ps*qs*ps*qs
+    t1 = gamma_trace(t)
+    assert t1 == -32*pq*pq*p2*q2 + 32*pq*pq*pq*pq + 4*p2*p2*q2*q2
+
+def test_epsilon():
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(n0)*G(n1)*G(n2)*G(n3)*epsilon(-n0,-n1,-n2,-n3)
+
+    t1 = gamma_trace(t)
+    assert t1 == 96*epsilon(m0, m1, m2, m3)

--- a/sympy/tensor/tests/test_group_factors.py
+++ b/sympy/tensor/tests/test_group_factors.py
@@ -1,0 +1,53 @@
+from time import time
+from sympy import Symbol, S
+from sympy.tensor.tensor import (tensor_indices)
+from sympy.tensor.group_factors import SuNGroupFactors, match_CijCij
+
+"""
+References
+
+[1] P. Cvitanovic "Group Theory" version 9.0.1
+"""
+
+def test_SuN():
+    N = Symbol('N')
+    SN = SuNGroupFactors(N)
+    C = SN.C
+    g = SN.ASuN.metric
+    i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14 = \
+        tensor_indices('i0:15', SN.ASuN)
+    theta = SN.theta
+
+    t = C(i0,i1,i2)*C(-i0,-i2,i3)
+    t = SN.rule_C2theta_all(t)
+    assert t == -2*N*g(i1, i3)
+
+    t = C(i0,i1,i2)*C(-i1,i3,i4)*C(i5,-i0,-i2)*C(-i5,-i4,-i3)
+    t = SN.rule_C2theta_all(t)
+    t = t.expand_coeff()
+    assert t == 4*N**4 - 4*N**2
+
+    # see eq.(1.1) and page 11 in Ref.[1] see also page 72
+    # We apply rule_C_square to two parts of the tensor;
+    # applying rule_C_square once to the whole tensor it is 2x slower.
+    # Without applying rule_C_square it is roughly 50x slower.
+    t1 = C(i0,i1,i2)*C(-i1,i5,i3)*C(-i2,i4,i7)*C(-i3,-i4,i6)
+    t2 = C(-i6,i10,i11)*C(-i5,-i11,i8)*C(-i7,-i10,i9)*C(-i8,-i9,i12)
+    t1 = SN.rule_C_square(t1)
+    t2 = SN.rule_C_square(t2)
+    t = t1*t2
+    t = SN.rule_C2theta_all(t)
+    t = t.expand_coeff()
+    assert t == (2*N**4 + 24*N**2)*g(i0, i12)
+
+    # Identically vanishing tensors
+    # contracted according to the Kuratowski graph  eq.(6.59) in Ref. [1]
+    t = C(i0,i1,i2)*C(-i1,i3,i4)*C(-i3,i7,i5)*C(-i2,-i5,i6)*C(-i4,-i6,i8)
+    t1 = t.canon_bp()
+    assert t1 == 0
+
+    #  contracted according to the Peterson graph eq.(6.60) in Ref. [1]
+    t = C(i0,i1,i2)*C(-i1,i3,i4)*C(-i2,i5,i6)*C(-i3,i7,i8)*C(-i6,-i7,i9)*\
+        C(-i8,i10,i13)*C(-i5,-i10,i11)*C(-i4,-i11,i12)*C(-i9,-i12,i14)
+    t1 = t.canon_bp()
+    assert t1 == 0

--- a/sympy/tensor/tests/test_group_factors.py
+++ b/sympy/tensor/tests/test_group_factors.py
@@ -40,6 +40,20 @@ def test_SuN():
     t = t.expand_coeff()
     assert t == (2*N**4 + 24*N**2)*g(i0, i12)
 
+    # without using rule_C_triangle it is 2.5x slower
+    t = C(i0,i1,i2)*C(-i2,i3,i5)*C(-i1,-i3,i4)*C(-i4,-i5,i6)
+    t = SN.rule_C_triangle(t)
+    t = SN.rule_C2theta_all(t)
+    t = t.expand_coeff()
+    assert t == 2*N**2*g(i0, i6)
+
+    # first graph in page 72 in Ref. [1]
+    t = theta(i0,i1,i2,i3)*theta(-i3,-i2,-i1,-i0)
+    t = SN.rule_C2theta_all(t)
+    t = t.expand_coeff()
+    assert (t._coeff - (N**4 - 3*N**2 + 3)*(N**2 - 1)/N**2).expand() == 0
+
+
     # Identically vanishing tensors
     # contracted according to the Kuratowski graph  eq.(6.59) in Ref. [1]
     t = C(i0,i1,i2)*C(-i1,i3,i4)*C(-i3,i7,i5)*C(-i2,-i5,i6)*C(-i4,-i6,i8)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -887,3 +887,16 @@ def test_TensorManager():
     qsh = GH(ih)*qh(-ih)
     assert ps*qsh == qsh*ps
     assert ps*qs != qs*ps
+
+def test_hash():
+    D = Symbol('D')
+    Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+    a,b,c,d,e = tensor_indices('a,b,c,d,e', Lorentz)
+    g = Lorentz.metric
+
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    t1 = p(a)*q(b)
+    t2 = p(a)*p(b)
+    t3 = p(a)*p(b) + g(a,b)
+    d = {t1:1, t2:2, t3:3}
+    assert d[t1] == 1 and d[t2] == 2 and d[t3] == 3

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -831,7 +831,7 @@ def test_fun():
     # check that g_{a b; c} = 0
     # example taken from  L. Brewin
     # "A brief introduction to Cadabra" arxiv:0903.2085
-    # dg_{a b c} = \partial_{a} g_{a b}
+    # dg_{a b c} = \partial_{a} g_{b c} is symmetric in b, c
     dg = tensorhead('dg', [Lorentz]*3, [[1], [1]*2])
     # gamma^a_{b c} is the Christoffel symbol
     gamma = S.Half*g(a,d)*(dg(-b,-d,-c) + dg(-c,-b,-d) - dg(-d,-b,-c))

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -571,7 +571,7 @@ def test_div():
     t1 = t1/4
     assert t1._is_canon_bp
 
-def test_metric_contract1():
+def test_contract_metric1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
@@ -608,7 +608,7 @@ def test_metric_contract1():
     assert t2 == A(a, -a)
     assert not t2._free
 
-def test_metric_contract1():
+def test_contract_metric2():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e, L_0 = tensor_indices('a,b,c,d,e,L_0', Lorentz)
@@ -695,6 +695,54 @@ def test_metric_contract1():
     t = A(a, b)*p(L_0)*g(-a, -b)
     t1 = t.contract_metric(g)
     assert str(t1) == 'A(L_1, -L_1)*p(L_0)' or str(t1) == 'A(-L_1, L_1)*p(L_0)'
+
+def test_metric_contract3():
+    D = Symbol('D')
+    Spinor = TensorIndexType('Spinor', dim=D, metric=True, dummy_fmt='S')
+    a0,a1,a2,a3,a4 = tensor_indices('a0:5', Spinor)
+    C = Spinor.metric
+    chi, psi = tensorhead('chi,psi', [Spinor], [[1]], 1)
+    B = tensorhead('B', [Spinor]*2, [[1],[1]])
+
+    t = C(a0,a1)*B(-a1,-a0)
+    t1 = t.contract_metric(C)
+    assert t1 == B(a0, -a0)
+
+    t = C(a0,-a1)*B(a1,-a0)
+    t1 = t.contract_metric(C)
+    assert t1 == -B(a0, -a0)
+
+    t = C(-a0,a1)*B(-a1,a0)
+    t1 = t.contract_metric(C)
+    assert t1 == -B(a0, -a0)
+
+    t = C(-a0,-a1)*B(a1,a0)
+    t1 = t.contract_metric(C)
+    assert t1 == B(a0, -a0)
+
+    t = C(a0,a1)*chi(-a0)*psi(-a1)
+    t1 = t.contract_metric(C)
+    assert t1 == -chi(a1)*psi(-a1)
+
+    t = C(a1,a0)*chi(-a0)*psi(-a1)
+    t1 = t.contract_metric(C)
+    assert t1 == chi(a1)*psi(-a1)
+
+    t = C(-a1,a0)*chi(-a0)*psi(a1)
+    t1 = t.contract_metric(C)
+    assert t1 == chi(-a1)*psi(a1)
+
+    t = C(a0, -a1)*chi(-a0)*psi(a1)
+    t1 = t.contract_metric(C)
+    assert t1 == -chi(-a1)*psi(a1)
+
+    t = C(-a0,-a1)*chi(a0)*psi(a1)
+    t1 = t.contract_metric(C)
+    assert t1 == chi(-a1)*psi(a1)
+
+    t = C(-a1,-a0)*chi(a0)*psi(a1)
+    t1 = t.contract_metric(C)
+    assert t1 == -chi(-a1)*psi(a1)
 
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
-  tensorlist_contract_metric, TensMul, tensorsymmetry, tensorhead)
+  tensorlist_contract_metric, TensMul, tensorsymmetry, tensorhead, TensorManager)
 from sympy.utilities.pytest import raises
 
 #################### Tests from tensor_can.py #######################
@@ -288,9 +288,9 @@ def test_canonicalize1():
     S3a = TensorType([Lorentz]*3, sym3a)
     alpha, beta, gamma, mu, nu, rho = \
       tensor_indices('alpha,beta,gamma,mu,nu,rho', Lorentz)
-    Gamma = S1('Gamma', None)
-    Gamma2 = S2a('Gamma', None)
-    Gamma3 = S3a('Gamma', None)
+    Gamma = S1('Gamma', 2)
+    Gamma2 = S2a('Gamma', 2)
+    Gamma3 = S3a('Gamma', 2)
     t = Gamma2(-mu,-nu)*Gamma(rho)*Gamma3(nu, mu, alpha)
     tc = t.canon_bp()
     assert str(tc) == '-Gamma(L_0, L_1)*Gamma(rho)*Gamma(alpha, -L_0, -L_1)'
@@ -845,3 +845,24 @@ def test_fun():
     t = dg(-c,-a,-b) - g(-a,-d)*gamma(d,-b,-c) - g(-b,-d)*gamma(d,-a,-c)
     t = t.contract_metric(g, True)
     assert t == 0
+
+def test_TensorManager():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    LorentzH = TensorIndexType('LorentzH', dummy_fmt='LH')
+    i, j = tensor_indices('i,j', Lorentz)
+    ih, jh = tensor_indices('ih,jh', LorentzH)
+    TensorManager.set_comm(2, 3, 0)
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
+    G = tensorhead('G', [Lorentz], [[1]], 2)
+    GH = tensorhead('GH', [LorentzH], [[1]], 3)
+    TensorManager.set_comm(2, 3, 0)
+    ps = G(i)*p(-i)
+    psh = GH(ih)*ph(-ih)
+    t = ps + psh
+    t1 = t*t
+    assert t1 == ps*ps + 2*ps*psh + psh*psh
+    qs = G(i)*q(-i)
+    qsh = GH(ih)*qh(-ih)
+    assert ps*qsh == qsh*ps
+    assert ps*qs != qs*ps

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -791,13 +791,13 @@ def test_contract_delta1():
     delta = Color.delta
 
     def idn(a, b, d, c):
-        assert a.is_contravariant and d.is_contravariant
-        assert not (b.is_contravariant or c.is_contravariant)
+        assert a.is_up and d.is_up
+        assert not (b.is_up or c.is_up)
         return delta(a, c)*delta(d, b)
 
     def T(a, b, d, c):
-        assert a.is_contravariant and d.is_contravariant
-        assert not (b.is_contravariant or c.is_contravariant)
+        assert a.is_up and d.is_up
+        assert not (b.is_up or c.is_up)
         return delta(a, b)*delta(d, c)
 
     def P1(a, b, c, d):
@@ -821,3 +821,22 @@ def test_contract_delta1():
     t = P1(a, -b, b, -a)
     t1 = t.contract_delta(delta)
     assert t1 == n**2 - 1
+
+def test_fun():
+    D = Symbol('D')
+    Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+    a,b,c,d = tensor_indices('a,b,c,d', Lorentz)
+    g = Lorentz.metric
+
+    # check that g_{a b; c} = 0
+    # example taken from  L. Brewin
+    # "A brief introduction to Cadabra" arxiv:0903.2085
+    # dg_{a b c} = \partial_{a} g_{a b}
+    dg = tensorhead('dg', [Lorentz]*3, [[1], [1]*2])
+    # gamma^a_{b c} is the Christoffel symbol
+    gamma = S.Half*g(a,d)*(dg(-b,-d,-c) + dg(-c,-b,-d) - dg(-d,-b,-c))
+    gamma.set_free_args([a, -b, -c])
+    # t = g_{a b; c}
+    t = dg(-c,-a,-b) - g(-a,-d)*gamma(d,-b,-c) - g(-b,-d)*gamma(d,-a,-c)
+    t = t.contract_metric(g, True)
+    assert t == 0

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -866,3 +866,22 @@ def test_TensorManager():
     qsh = GH(ih)*qh(-ih)
     assert ps*qsh == qsh*ps
     assert ps*qs != qs*ps
+
+    TensorManager.clear()
+    # same as before, but using symbols in TensorManager
+    Gsymbol = Symbol('Gsymbol')
+    GHsymbol = Symbol('GHsymbol')
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
+    G = tensorhead('G', [Lorentz], [[1]], Gsymbol)
+    GH = tensorhead('GH', [LorentzH], [[1]], GHsymbol)
+    TensorManager.set_comm(Gsymbol, GHsymbol, 0)
+    ps = G(i)*p(-i)
+    psh = GH(ih)*ph(-ih)
+    t = ps + psh
+    t1 = t*t
+    assert t1 == ps*ps + 2*ps*psh + psh*psh
+    qs = G(i)*q(-i)
+    qsh = GH(ih)*qh(-ih)
+    assert ps*qsh == qsh*ps
+    assert ps*qs != qs*ps

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -856,9 +856,10 @@ def test_TensorManager():
     LorentzH = TensorIndexType('LorentzH', dummy_fmt='LH')
     i, j = tensor_indices('i,j', Lorentz)
     ih, jh = tensor_indices('ih,jh', LorentzH)
-    TensorManager.set_comm(3, 4, 0)
     p, q = tensorhead('p q', [Lorentz], [[1]])
     ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
+
+    TensorManager.set_comm(3, 4, 0)
     G = tensorhead('G', [Lorentz], [[1]], 3)
     GH = tensorhead('GH', [LorentzH], [[1]], 4)
     ps = G(i)*p(-i)
@@ -871,16 +872,27 @@ def test_TensorManager():
     assert ps*qsh == qsh*ps
     assert ps*qs != qs*ps
 
-    TensorManager.clear()
     # same as before, but using symbols in TensorManager
     Gsymbol = Symbol('Gsymbol')
     GHsymbol = Symbol('GHsymbol')
     TensorManager.set_comm(Gsymbol, GHsymbol, 0)
-    p, q = tensorhead('p q', [Lorentz], [[1]])
-    ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
     G = tensorhead('G', [Lorentz], [[1]], Gsymbol)
     assert TensorManager._comm_i2symbol[G.comm] == Gsymbol
     GH = tensorhead('GH', [LorentzH], [[1]], GHsymbol)
+    ps = G(i)*p(-i)
+    psh = GH(ih)*ph(-ih)
+    t = ps + psh
+    t1 = t*t
+    assert t1 == ps*ps + 2*ps*psh + psh*psh
+    qs = G(i)*q(-i)
+    qsh = GH(ih)*qh(-ih)
+    assert ps*qsh == qsh*ps
+    assert ps*qs != qs*ps
+
+    # do it again the other way
+    TensorManager.set_comm(3, 4, 0)
+    G = tensorhead('G', [Lorentz], [[1]], 3)
+    GH = tensorhead('GH', [LorentzH], [[1]], 4)
     ps = G(i)*p(-i)
     psh = GH(ih)*ph(-ih)
     t = ps + psh

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -291,7 +291,6 @@ def test_canonicalize1():
     Gamma = S1('Gamma', 2)
     Gamma2 = S2a('Gamma', 2)
     Gamma3 = S3a('Gamma', 2)
-    TensorManager.set_comm(2,2,None)
     t = Gamma2(-mu,-nu)*Gamma(rho)*Gamma3(nu, mu, alpha)
     tc = t.canon_bp()
     assert str(tc) == '-Gamma(L_0, L_1)*Gamma(rho)*Gamma(alpha, -L_0, -L_1)'
@@ -897,6 +896,7 @@ def test_hash():
     p, q = tensorhead('p q', [Lorentz], [[1]])
     t1 = p(a)*q(b)
     t2 = p(a)*p(b)
+    assert hash(t1) != hash(t2)
     t3 = p(a)*p(b) + g(a,b)
-    d = {t1:1, t2:2, t3:3}
-    assert d[t1] == 1 and d[t2] == 2 and d[t3] == 3
+    t4 = p(a)*p(b) - g(a,b)
+    assert hash(t3) != hash(t4)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
-  tensorlist_contract_metric, TensMul)
+  tensorlist_contract_metric, TensMul, tensorsymmetry)
 from sympy.utilities.pytest import raises
 
 #################### Tests from tensor_can.py #######################
@@ -13,7 +13,7 @@ def test_canonicalize_no_slot_sym():
     # A_d0 * B^d0; T_c = A^d0*B_d0
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, d0, d1 = tensor_indices('a,b,d0,d1', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     A, B = S1('A,B')
     t = A(-d0)*B(d0)
@@ -31,7 +31,7 @@ def test_canonicalize_no_slot_sym():
 
     # A symmetric
     # A^{b}_{d0}*A^{d0, a}; T_c = A^{a d0}*A{b}_{d0}
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A = S2('A')
     t = A(b, -d0)*A(d0, a)
@@ -48,7 +48,7 @@ def test_canonicalize_no_slot_sym():
     # A without symmetry
     # A^{d1}_{d0}*B^d0*C_d1 ord=[d0,-d0,d1,-d1]; g = [2,1,0,3,4,5]
     # T_c = A^{d0 d1}*B_d1*C_d0; can = [0,2,3,1,4,5]
-    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    nsym2 = tensorsymmetry([1],[1])
     NS2 = TensorType([Lorentz]*2, nsym2)
     A = NS2('A')
     B, C = S1('B, C')
@@ -96,9 +96,9 @@ def test_canonicalize_no_slot_sym():
 def test_canonicalize_no_dummies():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a, b, c, d', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
+    sym2a = tensorsymmetry([2])
 
     # A commuting
     # A^c A^b A^a
@@ -146,7 +146,7 @@ def test_no_metric_symmetry():
     # T_c = A^d0_d1 * A^d1_d0
     Lorentz = TensorIndexType('Lorentz', metric=None, dummy_fmt='L')
     d0, d1, d2, d3 = tensor_indices('d0 d1 d2 d3', Lorentz)
-    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    nsym2 = tensorsymmetry([1], [1])
     NS2 = TensorType([Lorentz]*2, nsym2)
     A = NS2('A')
     t = A(d1, -d0)*A(d0, -d1)
@@ -169,12 +169,12 @@ def test_canonicalize1():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
       tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     base3, gens3 = get_symmetric_group_sgs(3)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
-    sym3 = TensorSymmetry(get_symmetric_group_sgs(3))
-    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    sym2 = tensorsymmetry([1]*2)
+    sym2a = tensorsymmetry([2])
+    sym3 = tensorsymmetry([1]*3)
+    sym3a = tensorsymmetry([3])
 
     # A_d0*A^d0; ord = [d0,-d0]
     # T_c = A^d0*A_d0
@@ -310,10 +310,9 @@ def test_canonicalize1():
     Flavor = TensorIndexType('Flavor', dummy_fmt='F')
     a, b, c, d, e, ff = tensor_indices('a,b,c,d,e,f', Flavor)
     mu, nu = tensor_indices('mu,nu', Lorentz)
-    sym_f = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators,
-            sym2a.base, sym2a.generators))
+    sym_f = tensorsymmetry([1], [2])
     S_f = TensorType([Flavor]*3, sym_f)
-    sym_A = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators, sym1.base, sym1.generators))
+    sym_A = tensorsymmetry([1], [1])
     S_A = TensorType([Lorentz, Flavor], sym_A)
     f = S_f('f')
     A = S_A('A')
@@ -358,9 +357,9 @@ def test_riemann_products():
     symr = TensorSymmetry(riemann_bsgs)
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
+    sym2a = tensorsymmetry([2])
     # R^{a b d0}_d0 = 0
     t = R(a, b, d0, -d0)
     tc = t.canon_bp()
@@ -400,7 +399,7 @@ def test_canonicalize2():
     Eucl = TensorIndexType('Eucl', metric=0, dim=D, dummy_fmt='E')
     i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14 = \
       tensor_indices('i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14', Eucl)
-    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    sym3a = tensorsymmetry([3])
     S3a = TensorType([Eucl]*3, sym3a)
     A = S3a('A')
 
@@ -431,9 +430,9 @@ def test_TensorIndexType():
     G = Metric('g', False)
     Lorentz = TensorIndexType('Lorentz', metric=G, dim=D, dummy_fmt='L')
     m0, m1, m2, m3, m4 = tensor_indices('m0,m1,m2,m3,m4', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     g = Lorentz.metric
     p = S1('p')
@@ -447,7 +446,7 @@ def test_get_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
     assert a != -a
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A B')
     assert A != B
@@ -466,8 +465,8 @@ def test_add1():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a,b,d0,d1,i,j,k = tensor_indices('a,b,d0,d1,i,j,k', Lorentz)
     # A, B symmetric
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A,B')
     t1 = A(b,-d0)*B(d0,a)
@@ -509,8 +508,8 @@ def test_add1():
 def test_add2():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m, n, p, q = tensor_indices('m,n,p,q', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
-    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    symr = tensorsymmetry([2, 2])
+    sym3a = tensorsymmetry([3])
     R4 = TensorType([Lorentz]*4, symr)
     S3a = TensorType([Lorentz]*3, sym3a)
     R = R4('R')
@@ -526,7 +525,7 @@ def test_add2():
 def test_substitute_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A,B')
     t = A(i, k)*B(-k, -j)
@@ -534,7 +533,7 @@ def test_substitute_indices():
     t1a = A(j, l)*B(-l, -k)
     assert t1 == t1a
 
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     p = S1('p')
     t = p(i)
@@ -552,8 +551,8 @@ def test_substitute_indices():
 def test_substitute_tensor():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
     S1 = TensorType([Lorentz], sym1)
     S2 = TensorType([Lorentz]*2, sym2)
     p, q = S1('p,q')
@@ -566,11 +565,10 @@ def test_substitute_tensor():
     t4 = t.substitute_tensor(q(m1), t2)
     assert t4 == 6*p(m0)*A(m1, m2)*p(-m2)
 
-
 def test_riemann_cyclic_replace():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
+    symr = tensorsymmetry([2, 2])
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(m0,m2,m1,m3)
@@ -581,7 +579,7 @@ def test_riemann_cyclic_replace():
 def test_riemann_cyclic():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
+    symr = tensorsymmetry([2, 2])
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(i,j,k,l) + R(i,l,j,k) + R(i,k,l,j) - \
@@ -600,7 +598,7 @@ def test_riemann_cyclic():
 def test_div():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
+    symr = tensorsymmetry([2, 2])
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(m0,m1,-m1,m3)
@@ -617,7 +615,7 @@ def test_metric_contract1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     g = Lorentz.metric
     A, B = S2('A,B')
@@ -647,12 +645,17 @@ def test_metric_contract1():
     t2 = t2.contract_metric(g)
     assert t2 == A(a,b)*B(-b,-a)
 
+    t1 = A(a,b)*g(-a,-b)
+    t2 = t1.contract_metric(g)
+    assert t2 == A(a, -a)
+    assert not t2._free
+
 def test_metric_contract1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     p, q = S1('p,q')
 
@@ -737,7 +740,7 @@ def test_epsilon():
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
     epsilon = Lorentz.epsilon
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     p, q, r, s = S1('p,q,r,s')
 
@@ -778,9 +781,9 @@ def test_contract_delta1():
     n = Symbol('n')
     Color = TensorIndexType('Color', metric=None, dim=n, dummy_fmt='C')
     a, b, c, d, e, f = tensor_indices('a,b,c,d,e,f', Color)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Color], sym1)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([2])
     S2 = TensorType([Color]*2, sym2)
     delta = Color.delta
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
-  tensorlist_contract_metric, TensMul, tensorsymmetry)
+  tensorlist_contract_metric, TensMul, tensorsymmetry, tensorhead)
 from sympy.utilities.pytest import raises
 
 #################### Tests from tensor_can.py #######################
@@ -145,10 +145,8 @@ def test_no_metric_symmetry():
     # A^d1_d0 * A^d0_d1
     # T_c = A^d0_d1 * A^d1_d0
     Lorentz = TensorIndexType('Lorentz', metric=None, dummy_fmt='L')
-    d0, d1, d2, d3 = tensor_indices('d0 d1 d2 d3', Lorentz)
-    nsym2 = tensorsymmetry([1], [1])
-    NS2 = TensorType([Lorentz]*2, nsym2)
-    A = NS2('A')
+    d0, d1, d2, d3 = tensor_indices('d:4', Lorentz)
+    A = tensorhead('A', [Lorentz]*2, [[1], [1]])
     t = A(d1, -d0)*A(d0, -d1)
     tc = t.canon_bp()
     assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_0)'
@@ -324,12 +322,10 @@ def test_canonicalize1():
 def test_riemann_invariants():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11 = \
-      tensor_indices(','.join(['d%d' % i for i in range(12)]), Lorentz)
+            tensor_indices('d0:12', Lorentz)
     # R^{d0 d1}_{d1 d0}; ord = [d0,-d0,d1,-d1]
     # T_c = -R^{d0 d1}_{d0 d1}
-    symr = TensorSymmetry(riemann_bsgs)
-    R4 = TensorType([Lorentz]*4, symr)
-    R = R4('R', 0)
+    R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     t = R(d0, d1, -d1, -d0)
     tc = t.canon_bp()
     assert str(tc) == '-R(L_0, L_1, -L_0, -L_1)'
@@ -349,17 +345,10 @@ def test_riemann_invariants():
 
 def test_riemann_products():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    d0, d1, d2, d3, d4, d5, d6= \
-      tensor_indices(','.join(['d%d' % i for i in range(7)]), Lorentz)
-    a0, a1, a2, a3, a4, a5 = \
-      tensor_indices(','.join(['a%d' % i for i in range(6)]), Lorentz)
+    d0, d1, d2, d3, d4, d5, d6 = tensor_indices('d0:7', Lorentz)
+    a0, a1, a2, a3, a4, a5 = tensor_indices('a0:6', Lorentz)
     a, b = tensor_indices('a,b', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
-    R4 = TensorType([Lorentz]*4, symr)
-    R = R4('R')
-    sym1 = tensorsymmetry([1])
-    sym2 = tensorsymmetry([1]*2)
-    sym2a = tensorsymmetry([2])
+    R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     # R^{a b d0}_d0 = 0
     t = R(a, b, d0, -d0)
     tc = t.canon_bp()
@@ -381,8 +370,7 @@ def test_riemann_products():
     # R^{d6 d5}_d2^d1 * R^{d4 d0 d2 d3} * A_{d6 d0} A_{d3 d1} * A_{d4 d5}
     # g = [12,10,5,2, 8,0,4,6, 13,1, 7,3, 9,11,14,15]
     # T_c = -R^{d0 d1 d2 d3} * R_d0^{d4 d5 d6} * A_{d1 d4}*A_{d2 d5}*A_{d3 d6}
-    S2 = TensorType([Lorentz]*2, sym2)
-    V = S2('V')
+    V = tensorhead('V', [Lorentz]*2, [[1]*2])
     t = R(d6, d5, -d2, d1)*R(d4, d0, d2, d3)*V(-d6, -d0)*V(-d3, -d1)*V(-d4, -d5)
     tc = t.canon_bp()
     assert str(tc) == '-R(L_0, L_1, L_2, L_3)*R(-L_0, L_4, L_5, L_6)*V(-L_1, -L_4)*V(-L_2, -L_5)*V(-L_3, -L_6)'
@@ -398,10 +386,8 @@ def test_canonicalize2():
     D = Symbol('D')
     Eucl = TensorIndexType('Eucl', metric=0, dim=D, dummy_fmt='E')
     i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14 = \
-      tensor_indices('i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14', Eucl)
-    sym3a = tensorsymmetry([3])
-    S3a = TensorType([Eucl]*3, sym3a)
-    A = S3a('A')
+            tensor_indices('i0:15', Eucl)
+    A = tensorhead('A', [Eucl]*3, [[3]])
 
     # two examples from Cvitanovic, Group Theory page 59
     # of identities for antisymmetric tensors of rank 3
@@ -429,13 +415,10 @@ def test_TensorIndexType():
     D = Symbol('D')
     G = Metric('g', False)
     Lorentz = TensorIndexType('Lorentz', metric=G, dim=D, dummy_fmt='L')
-    m0, m1, m2, m3, m4 = tensor_indices('m0,m1,m2,m3,m4', Lorentz)
-    sym1 = tensorsymmetry([1])
-    S1 = TensorType([Lorentz], sym1)
+    m0, m1, m2, m3, m4 = tensor_indices('m0:5', Lorentz)
     sym2 = tensorsymmetry([1]*2)
-    S2 = TensorType([Lorentz]*2, sym2)
     g = Lorentz.metric
-    p = S1('p')
+    p = tensorhead('p', [Lorentz], [[1]])
     assert str(g) == 'g(Lorentz,Lorentz)'
     t = g(m0, m1)*p(-m1)
     t1 = t.contract_metric(g)
@@ -446,9 +429,7 @@ def test_get_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
     assert a != -a
-    sym2 = tensorsymmetry([1]*2)
-    S2 = TensorType([Lorentz]*2, sym2)
-    A, B = S2('A B')
+    A, B = tensorhead('A B', [Lorentz]*2, [[1]*2])
     assert A != B
     t = A(a,b)*B(-b,c)
     indices = t.get_indices()
@@ -465,18 +446,14 @@ def test_add1():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a,b,d0,d1,i,j,k = tensor_indices('a,b,d0,d1,i,j,k', Lorentz)
     # A, B symmetric
-    sym1 = tensorsymmetry([1])
-    sym2 = tensorsymmetry([1]*2)
-    S2 = TensorType([Lorentz]*2, sym2)
-    A, B = S2('A,B')
+    A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
     t1 = A(b,-d0)*B(d0,a)
     t2a = B(d0,a) + A(d0, a)
     t2 = A(b,-d0)*t2a
     assert str(t2) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0)'
     t2b = t2 + t1
     assert str(t2b) == '2*A(b, L_0)*B(a, -L_0) + A(a, L_0)*A(b, -L_0)'
-    S1 = TensorType([Lorentz], sym1)
-    p, q, r = S1('p,q,r')
+    p, q, r = tensorhead('p,q,r', [Lorentz], [[1]])
     t = q(d0)*2
     assert str(t) == '2*q(d0)'
     t = 2*q(d0)
@@ -508,12 +485,8 @@ def test_add1():
 def test_add2():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m, n, p, q = tensor_indices('m,n,p,q', Lorentz)
-    symr = tensorsymmetry([2, 2])
-    sym3a = tensorsymmetry([3])
-    R4 = TensorType([Lorentz]*4, symr)
-    S3a = TensorType([Lorentz]*3, sym3a)
-    R = R4('R')
-    A = S3a('A')
+    R = tensorhead('R', [Lorentz]*4, [[2, 2]])
+    A = tensorhead('A', [Lorentz]*3, [[3]])
     t1 = 2*R(m,n,p,q) - R(m,q,n,p) + R(m,p,n,q)
     t2 = t1*A(-n,-p,-q)
     assert t2 == 0
@@ -525,17 +498,13 @@ def test_add2():
 def test_substitute_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
-    sym2 = tensorsymmetry([1]*2)
-    S2 = TensorType([Lorentz]*2, sym2)
-    A, B = S2('A,B')
+    A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
     t = A(i, k)*B(-k, -j)
     t1 = t.substitute_indices((i,j), (j, k))
     t1a = A(j, l)*B(-l, -k)
     assert t1 == t1a
 
-    sym1 = tensorsymmetry([1])
-    S1 = TensorType([Lorentz], sym1)
-    p = S1('p')
+    p = tensorhead('p', [Lorentz], [[1]])
     t = p(i)
     t1 = t.substitute_indices((j, k))
     assert t1 == t
@@ -550,13 +519,9 @@ def test_substitute_indices():
 
 def test_substitute_tensor():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    sym1 = tensorsymmetry([1])
-    sym2 = tensorsymmetry([1]*2)
-    S1 = TensorType([Lorentz], sym1)
-    S2 = TensorType([Lorentz]*2, sym2)
-    p, q = S1('p,q')
-    A = S2('A')
+    m0, m1, m2, m3 = tensor_indices('m0:4', Lorentz)
+    p, q = tensorhead('p,q', [Lorentz], [[1]])
+    A = tensorhead('A', [Lorentz]*2, [[1]*2])
     t = 2*p(m0)*q(m1)
     t1 = p(m1)
     t2 = 3*A(m1, m2)*p(-m2)
@@ -567,10 +532,9 @@ def test_substitute_tensor():
 
 def test_riemann_cyclic_replace():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+    m0,m1,m2,m3 = tensor_indices('m:4', Lorentz)
     symr = tensorsymmetry([2, 2])
-    R4 = TensorType([Lorentz]*4, symr)
-    R = R4('R')
+    R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     t = R(m0,m2,m1,m3)
     t1 = riemann_cyclic_replace(t)
     t1a =  -S.One/3*R(m0, m3, m2, m1) + S.One/3*R(m0, m1, m2, m3) + Rational(2,3)*R(m0, m2, m1, m3)
@@ -579,9 +543,7 @@ def test_riemann_cyclic_replace():
 def test_riemann_cyclic():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
-    symr = tensorsymmetry([2, 2])
-    R4 = TensorType([Lorentz]*4, symr)
-    R = R4('R')
+    R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     t = R(i,j,k,l) + R(i,l,j,k) + R(i,k,l,j) - \
         R(i,j,l,k) - R(i,l,k,j) - R(i,k,j,l)
     t2 = t*R(-i,-j,-k,-l)
@@ -597,10 +559,8 @@ def test_riemann_cyclic():
 
 def test_div():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    symr = tensorsymmetry([2, 2])
-    R4 = TensorType([Lorentz]*4, symr)
-    R = R4('R')
+    m0,m1,m2,m3 = tensor_indices('m0:4', Lorentz)
+    R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     t = R(m0,m1,-m1,m3)
     t1 = t/S(4)
     assert str(t1) == '1/4*R(m0, L_0, -L_0, m3)'
@@ -615,10 +575,8 @@ def test_metric_contract1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
-    sym2 = tensorsymmetry([1]*2)
-    S2 = TensorType([Lorentz]*2, sym2)
     g = Lorentz.metric
-    A, B = S2('A,B')
+    A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
 
     # case with g with all free indices
     t1 = A(a,b)*B(-b,c)*g(d, e)
@@ -655,11 +613,7 @@ def test_metric_contract1():
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e, L_0 = tensor_indices('a,b,c,d,e,L_0', Lorentz)
     g = Lorentz.metric
-    sym1 = tensorsymmetry([1])
-    sym2 = tensorsymmetry([1]*2)
-    S1 = TensorType([Lorentz], sym1)
-    S2 = TensorType([Lorentz]*2, sym2)
-    p, q = S1('p,q')
+    p, q = tensorhead('p,q', [Lorentz], [[1]])
 
     t1 = g(a,b)*p(c)*p(-c)
     t2 = 3*g(-a,-b)*q(c)*q(-c)
@@ -737,7 +691,7 @@ def test_metric_contract1():
     v1 = tensorlist_contract_metric(v, g(d, e))
     assert v1 == [p(a), q(b), p(c), g(d, e)]
 
-    A = S2('A')
+    A = tensorhead('A', [Lorentz]*2, [[1]*2])
     t = A(a, b)*p(L_0)*g(-a, -b)
     t1 = t.contract_metric(g)
     assert str(t1) == 'A(L_1, -L_1)*p(L_0)' or str(t1) == 'A(-L_1, L_1)*p(L_0)'
@@ -747,9 +701,7 @@ def test_epsilon():
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
     epsilon = Lorentz.epsilon
-    sym1 = tensorsymmetry([1])
-    S1 = TensorType([Lorentz], sym1)
-    p, q, r, s = S1('p,q,r,s')
+    p, q, r, s = tensorhead('p,q,r,s', [Lorentz], [[1]])
 
     t = epsilon(b,a,c,d)
     t1 = t.canon_bp()
@@ -788,10 +740,6 @@ def test_contract_delta1():
     n = Symbol('n')
     Color = TensorIndexType('Color', metric=None, dim=n, dummy_fmt='C')
     a, b, c, d, e, f = tensor_indices('a,b,c,d,e,f', Color)
-    sym1 = tensorsymmetry([1])
-    S1 = TensorType([Color], sym1)
-    sym2 = tensorsymmetry([2])
-    S2 = TensorType([Color]*2, sym2)
     delta = Color.delta
 
     def idn(a, b, d, c):

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -482,6 +482,10 @@ def test_add1():
     t2 = (p(j) + q(j) + 2*r(j))*(p(i) - q(i))
     t = t1 + t2
     assert t == 2*p(i)*p(j) + 2*p(i)*r(j) + 2*p(j)*r(i) - 2*q(i)*q(j) - 2*q(i)*r(j) - 2*q(j)*r(i)
+    t = p(i)*q(j)/2
+    assert 2*t == p(i)*q(j)
+    t = (p(i) + q(i))/2
+    assert 2*t == p(i) + q(i)
 
 def test_add2():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -474,7 +474,7 @@ def test_add1():
     t2 = A(b,-d0)*t2a
     assert str(t2) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0)'
     t2b = t2 + t1
-    assert str(t2b) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0) + A(b, L_0)*B(a, -L_0)'
+    assert str(t2b) == '2*A(b, L_0)*B(a, -L_0) + A(a, L_0)*A(b, -L_0)'
     S1 = TensorType([Lorentz], sym1)
     p, q, r = S1('p,q,r')
     t = q(d0)*2
@@ -653,10 +653,12 @@ def test_metric_contract1():
 def test_metric_contract1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
-    a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
+    a, b, c, d, e, L_0 = tensor_indices('a,b,c,d,e,L_0', Lorentz)
     g = Lorentz.metric
     sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
     S1 = TensorType([Lorentz], sym1)
+    S2 = TensorType([Lorentz]*2, sym2)
     p, q = S1('p,q')
 
     t1 = g(a,b)*p(c)*p(-c)
@@ -734,6 +736,11 @@ def test_metric_contract1():
     v = [p(a), q(b), p(c)]
     v1 = tensorlist_contract_metric(v, g(d, e))
     assert v1 == [p(a), q(b), p(c), g(d, e)]
+
+    A = S2('A')
+    t = A(a, b)*p(L_0)*g(-a, -b)
+    t1 = t.contract_metric(g)
+    assert str(t1) == 'A(L_1, -L_1)*p(L_0)' or str(t1) == 'A(-L_1, L_1)*p(L_0)'
 
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -291,6 +291,7 @@ def test_canonicalize1():
     Gamma = S1('Gamma', 2)
     Gamma2 = S2a('Gamma', 2)
     Gamma3 = S3a('Gamma', 2)
+    TensorManager.set_comm(2,2,None)
     t = Gamma2(-mu,-nu)*Gamma(rho)*Gamma3(nu, mu, alpha)
     tc = t.canon_bp()
     assert str(tc) == '-Gamma(L_0, L_1)*Gamma(rho)*Gamma(alpha, -L_0, -L_1)'
@@ -871,11 +872,12 @@ def test_TensorManager():
     # same as before, but using symbols in TensorManager
     Gsymbol = Symbol('Gsymbol')
     GHsymbol = Symbol('GHsymbol')
+    TensorManager.set_comm(Gsymbol, GHsymbol, 0)
     p, q = tensorhead('p q', [Lorentz], [[1]])
     ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
     G = tensorhead('G', [Lorentz], [[1]], Gsymbol)
+    assert TensorManager._comm_i2symbol[G.comm] == Gsymbol
     GH = tensorhead('GH', [LorentzH], [[1]], GHsymbol)
-    TensorManager.set_comm(Gsymbol, GHsymbol, 0)
     ps = G(i)*p(-i)
     psh = GH(ih)*ph(-ih)
     t = ps + psh

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -504,6 +504,10 @@ def test_riemann_cyclic():
     t1 = riemann_cyclic(t)
     assert t1 == 0
 
+    t = R(i,j,k,l)*R(-k,-l,m,n)*(R(-m,-n,-i,-j) + 2*R(-m,-j,-n,-i))
+    t1 = riemann_cyclic(t)
+    assert t1 == 0
+
 def test_div():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
@@ -618,3 +622,44 @@ def test_metric_contract1():
     assert t3 == 3*D**2 + 6*D
     t = t.contract_metric(g, True)
     assert t == 3*D**2 + 6*D
+
+def test_epsilon():
+    Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')
+    a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
+    g = Lorentz.metric
+    epsilon = Lorentz.epsilon
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym1)
+    p, q, r, s = S1('p,q,r,s')
+
+    t = epsilon(b,a,c,d)
+    t1 = t.canon_bp()
+    assert t1 == -epsilon(a,b,c,d)
+
+    t = epsilon(c,b,d,a)
+    t1 = t.canon_bp()
+    assert t1 == epsilon(a,b,c,d)
+
+    t = epsilon(c,a,d,b)
+    t1 = t.canon_bp()
+    assert t1 == -epsilon(a,b,c,d)
+
+    t = epsilon(a,b,c,d)*p(-a)*q(-b)
+    t1 = t.canon_bp()
+    assert t1 == epsilon(c, d, a, b)*p(-a)*q(-b)
+
+    t = epsilon(c,b,d,a)*p(-a)*q(-b)
+    t1 = t.canon_bp()
+    assert t1 == epsilon(c, d, a, b)*p(-a)*q(-b)
+
+    t = epsilon(c,a,d,b)*p(-a)*q(-b)
+    t1 = t.canon_bp()
+    assert t1 == -epsilon(c, d, a, b)*p(-a)*q(-b)
+
+    t = epsilon(c,a,d,b)*p(-a)*p(-b)
+    t1 = t.canon_bp()
+    assert t1 == 0
+
+    t = epsilon(c,a,d,b)*p(-a)*q(-b) + epsilon(a,b,c,d)*p(-b)*q(-a)
+    t1 = t.canon_bp()
+    assert t1 == -2*epsilon(c, d, a, b)*p(-a)*q(-b)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1,0 +1,522 @@
+from sympy.core import S, Rational
+from sympy.combinatorics import Permutation
+from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
+from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
+  TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
+  tensor_mul, canon_bp, TensAdd, riemann_cyclic_replaceR, riemann_cyclic)
+
+
+def test_get_indices():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    t = A(a,b)*B(-b,c)
+    indices = t.get_indices()
+    L_0 = TensorIndex('L_0', Lorentz)
+    assert indices == [a, L_0, -L_0, c]
+    a = t.split()
+    t2 = tensor_mul(*a)
+    assert t == t2
+
+def test_canonicalize_no_slot_sym():
+    # A_d0 * B^d0; T_c = A^d0*B_d0
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, d0, d1 = tensor_indices('a,b,d0,d1', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym1)
+    A, B = S1('A,B')
+    t = A(-d0)*B(d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0)*B(-L_0)'
+
+    # A^a * B^b;  T_c = T
+    t = A(a)*B(b)
+    tc = t.canon_bp()
+    assert tc == t
+    # B^b * A^a
+    t1 = B(b)*A(a)
+    tc = t1.canon_bp()
+    assert str(tc) == 'A(a)*B(b)'
+
+    # A symmetric
+    # A^{b}_{d0}*A^{d0, a}; T_c = A^{a d0}*A{b}_{d0}
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A = S2('A')
+    t = A(b, -d0)*A(d0, a)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, L_0)*A(b, -L_0)'
+
+    # A^{d1}_{d0}*B^d0*C_d1
+    # T_c = A^{d0 d1}*B_d0*C_d1
+    B, C = S1('B,C')
+    t = A(d1, -d0)*B(d0)*C(-d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_0)*C(-L_1)'
+
+    # A without symmetry
+    # A^{d1}_{d0}*B^d0*C_d1 ord=[d0,-d0,d1,-d1]; g = [2,1,0,3,4,5]
+    # T_c = A^{d0 d1}*B_d1*C_d0; can = [0,2,3,1,4,5]
+    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    NS2 = TensorType([Lorentz]*2, nsym2)
+    A = NS2('A')
+    B, C = S1('B,C')
+    t = A(d1, -d0)*B(d0)*C(-d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_1)*C(-L_0)'
+
+    # A, B without symmetry
+    # A^{d1}_{d0}*B_{d1}^{d0}
+    # T_c = A^{d0 d1}*B_{d0 d1}
+    B = NS2('B')
+    t = A(d1, -d0)*B(-d1, d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_0, -L_1)'
+    # A_{d0}^{d1}*B_{d1}^{d0}
+    # T_c = A^{d0 d1}*B_{d1 d0}
+    t = A(-d0, d1)*B(-d1, d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_1, -L_0)'
+
+    # A, B, C without symmetry
+    # A^{d1 d0}*B_{a d0}*C_{d1 b}
+    # T_c=A^{d0 d1}*B_{a d1}*C_{d0 b}
+    C = NS2('C')
+    t = A(d1, d0)*B(-a, -d0)*C(-d1, -b)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-a, -L_1)*C(-L_0, -b)'
+
+    # A symmetric, B and C without symmetry
+    # A^{d1 d0}*B_{a d0}*C_{d1 b}
+    # T_c = A^{d0 d1}*B_{a d0}*C_{d1 b}
+    A = S2('A')
+    t = A(d1, d0)*B(-a, -d0)*C(-d1, -b)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-a, -L_0)*C(-L_1, -b)'
+
+    # A and C symmetric, B without symmetry
+    # A^{d1 d0}*B_{a d0}*C_{d1 b} ord=[a,b,d0,-d0,d1,-d1]
+    # T_c = A^{d0 d1}*B_{a d0}*C_{b d1}
+    C = S2('C')
+    t = A(d1, d0)*B(-a, -d0)*C(-d1, -b)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-a, -L_0)*C(-b, -L_1)'
+
+def test_canonicalize_no_dummies():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+
+    # A commuting
+    # A^c A^b A^a
+    # T_c = A^a A^b A^c
+    S1 = TensorType([Lorentz], sym1)
+    A = S1('A')
+    t = A(c)*A(b)*A(a)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a)*A(b)*A(c)'
+
+    # A anticommuting
+    # A^c A^b A^a
+    # T_c = -A^a A^b A^c
+    A = S1('A', 1)
+    t = A(c)*A(b)*A(a)
+    tc = t.canon_bp()
+    assert str(tc) == '-A(a)*A(b)*A(c)'
+
+    # A commuting and symmetric
+    # A^{b,d}*A^{c,a}
+    # T_c = A^{a c}*A^{b d}
+    S2 = TensorType([Lorentz]*2, sym2)
+    A = S2('A')
+    t = A(b, d)*A(c, a)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, c)*A(b, d)'
+
+    # A anticommuting and symmetric
+    # A^{b,d}*A^{c,a}
+    # T_c = -A^{a c}*A^{b d}
+    A = S2('A', 1)
+    t = A(b, d)*A(c, a)
+    tc = t.canon_bp()
+    assert str(tc) == '-A(a, c)*A(b, d)'
+
+    # A^{c,a}*A^{b,d}
+    # T_c = A^{a c}*A^{b d}
+    t = A(c, a)*A(b, d)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, c)*A(b, d)'
+
+def test_no_metric_symmetry():
+    # no metric symmetry; A no symmetry
+    # A^d1_d0 * A^d0_d1
+    # T_c = A^d0_d1 * A^d1_d0
+    Lorentz = TensorIndexType('Lorentz', metric_sym=None, dummy_fmt='L')
+    d0, d1, d2, d3 = tensor_indices('d0,d1,d2,d3', Lorentz)
+    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    NS2 = TensorType([Lorentz]*2, nsym2)
+    A = NS2('A')
+    t = A(d1, -d0)*A(d0, -d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_0)'
+
+    # A^d1_d2 * A^d0_d3 * A^d2_d1 * A^d3_d0
+    # T_c = A^d0_d1 * A^d1_d0 * A^d2_d3 * A^d3_d2
+    t = A(d1, -d2)*A(d0, -d3)*A(d2,-d1)*A(d3,-d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_0)*A(L_2, -L_3)*A(L_3, -L_2)'
+
+    # A^d0_d2 * A^d1_d3 * A^d3_d0 * A^d2_d1
+    # T_c = A^d0_d1 * A^d1_d2 * A^d2_d3 * A^d3_d0
+    t = A(d0, -d1)*A(d1, -d2)*A(d2, -d3)*A(d3,-d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_2)*A(L_2, -L_3)*A(L_3, -L_0)'
+
+def test_canonicalize1():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    base3, gens3 = get_symmetric_group_sgs(3)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym3 = TensorSymmetry(get_symmetric_group_sgs(3))
+    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+
+    # A_d0*A^d0; ord = [d0,-d0]
+    # T_c = A^d0*A_d0
+    S1 = TensorType([Lorentz], sym1)
+    A = S1('A')
+    t = A(-d0)*A(d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0)*A(-L_0)'
+
+    # A commuting
+    # A_d0*A_d1*A_d2*A^d2*A^d1*A^d0
+    # T_c = A^d0*A_d0*A^d1*A_d1*A^d2*A_d2
+    t = A(-d0)*A(-d1)*A(-d2)*A(d2)*A(d1)*A(d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0)*A(-L_0)*A(L_1)*A(-L_1)*A(L_2)*A(-L_2)'
+
+    # A anticommuting
+    # A_d0*A_d1*A_d2*A^d2*A^d1*A^d0
+    # T_c 0
+    A = S1('A', 1)
+    t = A(-d0)*A(-d1)*A(-d2)*A(d2)*A(d1)*A(d0)
+    tc = t.canon_bp()
+    assert tc == 0
+
+    # A commuting symmetric
+    # A^{d0 b}*A^a_d1*A^d1_d0
+    # T_c = A^{a d0}*A^{b d1}*A_{d0 d1}
+    S2 = TensorType([Lorentz]*2, sym2)
+    A = S2('A')
+    t = A(d0, b)*A(a, -d1)*A(d1, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, L_0)*A(b, L_1)*A(-L_0, -L_1)'
+
+    # A, B commuting symmetric
+    # A^{d0 b}*A^d1_d0*B^a_d1
+    # T_c = A^{b d0}*A_d0^d1*B^a_d1
+    B = S2('B')
+    t = A(d0, b)*A(d1, -d0)*B(a, -d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(b, L_0)*A(-L_0, L_1)*B(a, -L_1)'
+
+    # A commuting symmetric
+    # A^{d1 d0 b}*A^{a}_{d1 d0}; ord=[a,b, d0,-d0,d1,-d1]
+    # T_c = A^{a d0 d1}*A^{b}_{d0 d1}
+    S3 = TensorType([Lorentz]*3, sym3)
+    A = S3('A')
+    t = A(d1, d0, b)*A(a, -d1, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, L_0, L_1)*A(b, -L_0, -L_1)'
+
+    # A^{d3 d0 d2}*A^a0_{d1 d2}*A^d1_d3^a1*A^{a2 a3}_d0
+    # T_c = A^{a0 d0 d1}*A^a1_d0^d2*A^{a2 a3 d3}*A_{d1 d2 d3}
+    t = A(d3, d0, d2)*A(a0, -d1, -d2)*A(d1, -d3, a1)*A(a2, a3, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a0, L_0, L_1)*A(a1, -L_0, L_2)*A(a2, a3, L_3)*A(-L_1, -L_2, -L_3)'
+
+    # A commuting symmetric, B antisymmetric
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # in this esxample and in the next three,
+    # renaming dummy indices and using symmetry of A,
+    # T = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
+    # can = 0
+    S2a = TensorType([Lorentz]*2, sym2a)
+    A = S3('A')
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert tc == 0
+
+    # A anticommuting symmetric, B anticommuting
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # T_c = A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
+    A = S3('A', 1)
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1, L_2)*A(-L_0, -L_1, L_3)*B(-L_2, -L_3)'
+
+    # A anticommuting symmetric, B antisymmetric commuting, antisymmetric metric
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # T_c = -A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
+    Spinor = TensorIndexType('Spinor', metric_sym=1, dummy_fmt='S')
+    a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
+    S3 = TensorType([Spinor]*3, sym3)
+    S2a = TensorType([Spinor]*2, sym2a)
+    A = S3('A', 1)
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert str(tc) == '-A(S_0, S_1, S_2)*A(-S_0, -S_1, S_3)*B(-S_2, -S_3)'
+
+    # A anticommuting symmetric, B antisymmetric anticommuting,
+    # no metric symmetry
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
+    Mat = TensorIndexType('Mat', metric_sym=None, dummy_fmt='M')
+    a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
+    S3 = TensorType([Mat]*3, sym3)
+    S2a = TensorType([Mat]*2, sym2a)
+    A = S3('A', 1)
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(M_0, M_1, M_2)*A(-M_0, -M_1, -M_3)*B(-M_2, M_3)'
+
+    # Gamma anticommuting
+    # Gamma_{mu nu} * gamma^rho * Gamma^{nu mu alpha}
+    # T_c = -Gamma^{mu nu} * gamma^rho * Gamma_{alpha mu nu}
+    S1 = TensorType([Lorentz], sym1)
+    S2a = TensorType([Lorentz]*2, sym2a)
+    S3a = TensorType([Lorentz]*3, sym3a)
+    alpha, beta, gamma, mu, nu, rho = \
+      tensor_indices('alpha,beta,gamma,mu,nu,rho', Lorentz)
+    Gamma = S1('Gamma', None)
+    Gamma2 = S2a('Gamma', None)
+    Gamma3 = S3a('Gamma', None)
+    t = Gamma2(-mu,-nu)*Gamma(rho)*Gamma3(nu, mu, alpha)
+    tc = t.canon_bp()
+    assert str(tc) == '-Gamma(L_0, L_1)*Gamma(rho)*Gamma(alpha, -L_0, -L_1)'
+
+    # Gamma_{mu nu} * Gamma^{gamma beta} * gamma_rho * Gamma^{nu mu alpha}
+    # T_c = Gamma^{mu nu} * Gamma^{beta gamma} * gamma_rho * Gamma^alpha_{mu nu}
+    t = Gamma2(mu, nu)*Gamma2(beta, gamma)*Gamma(-rho)*Gamma3(alpha, -mu, -nu)
+    tc = t.canon_bp()
+    assert str(tc) == 'Gamma(L_0, L_1)*Gamma(beta, gamma)*Gamma(-rho)*Gamma(alpha, -L_0, -L_1)'
+
+    # f^a_{b,c} antisymmetric in b,c; A_mu^a no symmetry
+    # f^c_{d a} * f_{c e b} * A_mu^d * A_nu^a * A^{nu e} * A^{mu b}
+    # g = [8,11,5, 9,13,7, 1,10, 3,4, 2,12, 0,6, 14,15]
+    # T_c = -f^{a b c} * f_a^{d e} * A^mu_b * A_{mu d} * A^nu_c * A_{nu e}
+    Flavor = TensorIndexType('Flavor', dummy_fmt='F')
+    a, b, c, d, e, ff = tensor_indices('a,b,c,d,e,f', Flavor)
+    mu, nu = tensor_indices('mu,nu', Lorentz)
+    sym_f = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators,
+            sym2a.base, sym2a.generators))
+    S_f = TensorType([Flavor]*3, sym_f)
+    sym_A = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators, sym1.base, sym1.generators))
+    S_A = TensorType([Lorentz, Flavor], sym_A)
+    f = S_f('f')
+    A = S_A('A')
+    t = f(c, -d, -a)*f(-c, -e, -b)*A(-mu, d)*A(-nu, a)*A(nu, e)*A(mu, b)
+    tc = t.canon_bp()
+    assert str(tc) == '-f(F_0, F_1, F_2)*f(-F_0, F_3, F_4)*A(L_0, -F_1)*A(-L_0, -F_3)*A(L_1, -F_2)*A(-L_1, -F_4)'
+
+
+def test_riemann_invariants():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11 = \
+      tensor_indices(','.join(['d%d' % i for i in range(12)]), Lorentz)
+    # R^{d0 d1}_{d1 d0}; ord = [d0,-d0,d1,-d1]
+    # T_c = -R^{d0 d1}_{d0 d1}
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R', 0)
+    t = R(d0, d1, -d1, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(L_0, L_1, -L_0, -L_1)'
+
+    # R_d11^d1_d0^d5 * R^{d6 d4 d0}_d5 * R_{d7 d2 d8 d9} *
+    # R_{d10 d3 d6 d4} * R^{d2 d7 d11}_d1 * R^{d8 d9 d3 d10}
+    # can = [0,2,4,6, 1,3,8,10, 5,7,12,14, 9,11,16,18, 13,15,20,22,
+    #        17,19,21<F10,23, 24,25]
+    # T_c = R^{d0 d1 d2 d3} * R_{d0 d1}^{d4 d5} * R_{d2 d3}^{d6 d7} *
+    # R_{d4 d5}^{d8 d9} * R_{d6 d7}^{d10 d11} * R_{d8 d9 d10 d11}
+
+
+    t = R(-d11,d1,-d0,d5)*R(d6,d4,d0,-d5)*R(-d7,-d2,-d8,-d9)* \
+        R(-d10,-d3,-d6,-d4)*R(d2,d7,d11,-d1)*R(d8,d9,d3,d10)
+    tc = t.canon_bp()
+    assert str(tc) == 'R(L_0, L_1, L_2, L_3)*R(-L_0, -L_1, L_4, L_5)*R(-L_2, -L_3, L_6, L_7)*R(-L_4, -L_5, L_8, L_9)*R(-L_6, -L_7, L_10, L_11)*R(-L_8, -L_9, -L_10, -L_11)'
+
+def test_riemann_products():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    d0, d1, d2, d3, d4, d5, d6= \
+      tensor_indices(','.join(['d%d' % i for i in range(7)]), Lorentz)
+    a0, a1, a2, a3, a4, a5 = \
+      tensor_indices(','.join(['a%d' % i for i in range(6)]), Lorentz)
+    a, b = tensor_indices('a,b', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    # R^{a b d0}_d0 = 0
+    t = R(a, b, d0, -d0)
+    tc = t.canon_bp()
+    assert tc == 0
+
+    # R^{d0 b a}_d0
+    # T_c = -R^{a d0 b}_d0
+    t = R(d0, b, a, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(a, L_0, b, -L_0)'
+
+    # R^d1_d2^b_d0 * R^{d0 a}_d1^d2; ord=[a,b,d0,-d0,d1,-d1,d2,-d2]
+    # T_c = -R^{a d0 d1 d2}* R^b_{d0 d1 d2}
+    t = R(d1, -d2, b, -d0)*R(d0, a, -d1, d2)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(a, L_0, L_1, L_2)*R(b, -L_0, -L_1, -L_2)'
+
+    # A symmetric commuting
+    # R^{d6 d5}_d2^d1 * R^{d4 d0 d2 d3} * A_{d6 d0} A_{d3 d1} * A_{d4 d5}
+    # g = [12,10,5,2, 8,0,4,6, 13,1, 7,3, 9,11,14,15]
+    # T_c = -R^{d0 d1 d2 d3} * R_d0^{d4 d5 d6} * A_{d1 d4}*A_{d2 d5}*A_{d3 d6}
+    S2 = TensorType([Lorentz]*2, sym2)
+    V = S2('V')
+    t = R(d6, d5, -d2, d1)*R(d4, d0, d2, d3)*V(-d6, -d0)*V(-d3, -d1)*V(-d4, -d5)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(L_0, L_1, L_2, L_3)*R(-L_0, L_4, L_5, L_6)*V(-L_1, -L_4)*V(-L_2, -L_5)*V(-L_3, -L_6)'
+
+    # R^{d2 a0 a2 d0} * R^d1_d2^{a1 a3} * R^{a4 a5}_{d0 d1}
+    # T_c = R^{a0 d0 a2 d1}*R^{a1 a3}_d0^d2*R^{a4 a5}_{d1 d2}
+    t = R(d2, a0, a2, d0)*R(d1, -d2, a1, a3)*R(a4, a5, -d0, -d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'R(a0, L_0, a2, L_1)*R(a1, a3, -L_0, L_2)*R(a4, a5, -L_1, -L_2)'
+
+
+def test_add1():
+    # simple example of algebraic expression
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a,b,d0,d1,i,j,k = tensor_indices('a,b,d0,d1,i,j,k', Lorentz)
+    # A, B symmetric
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    t1 = A(b,-d0)*B(d0,a)
+    t2a = B(d0,a) + A(d0, a)
+    t2 = A(b,-d0)*t2a
+    assert str(t2) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0)'
+    t2b = t2 + t1
+    assert str(t2b) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0) + A(b, L_0)*B(a, -L_0)'
+    S1 = TensorType([Lorentz], sym1)
+    p, q, r = S1('p,q,r')
+    t = q(d0)*2
+    assert str(t) == '2*q(d0)'
+    t = 2*q(d0)
+    assert str(t) == '2*q(d0)'
+    t1 = p(d0) + 2*q(d0)
+    assert str(t1) == '2*q(d0) + p(d0)'
+    t2 = p(-d0) + 2*q(-d0)
+    assert str(t2) == '2*q(-d0) + p(-d0)'
+    t1 = p(d0)
+    t3 = t1*t2
+    assert str(t3) == '2*p(L_0)*q(-L_0) + p(L_0)*p(-L_0)'
+    t3 = t2*t1
+    assert str(t3) == '2*p(L_0)*q(-L_0) + p(L_0)*p(-L_0)'
+    t1 = p(d0) + 2*q(d0)
+    t3 = t1*t2
+    assert str(t3) == '4*p(L_0)*q(-L_0) + 4*q(L_0)*q(-L_0) + p(L_0)*p(-L_0)'
+    t1 =  p(d0) - 2*q(d0)
+    assert str(t1) == '-2*q(d0) + p(d0)'
+    t2 = p(-d0) + 2*q(-d0)
+    t3 = t1*t2
+    assert t3 == p(d0)*p(-d0) - 4*q(d0)*q(-d0)
+    t = p(i)*p(j)*(p(k) + q(k)) + p(i)*(p(j) + q(j))*(p(k) - 3*q(k))
+    assert t == 2*p(i)*p(j)*p(k) - 2*p(i)*p(j)*q(k) + p(i)*p(k)*q(j) - 3*p(i)*q(j)*q(k)
+    t1 = (p(i) + q(i) + 2*r(i))*(p(j) - q(j))
+    t2 = (p(j) + q(j) + 2*r(j))*(p(i) - q(i))
+    t = t1 + t2
+    assert t == 2*p(i)*p(j) + 2*p(i)*r(j) + 2*p(j)*r(i) - 2*q(i)*q(j) - 2*q(i)*r(j) - 2*q(j)*r(i)
+
+def test_add2():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m, n, p, q = tensor_indices('m,n,p,q', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    R4 = TensorType([Lorentz]*4, symr)
+    S3a = TensorType([Lorentz]*3, sym3a)
+    R = R4('R')
+    A = S3a('A')
+    t1 = 2*R(m,n,p,q) - R(m,q,n,p) + R(m,p,n,q)
+    t2 = t1*A(-n,-p,-q)
+    assert t2 == 0
+    t1 = S(2)/3*R(m,n,p,q) - S(1)/3*R(m,q,n,p) + S(1)/3*R(m,p,n,q)
+    t2 = t1*A(-n,-p,-q)
+    assert t2 == 0
+
+
+def test_substitute_indices():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    t = A(i, k)*B(-k, -j)
+    t1 = t.substitute_indices((i,j), (j, k))
+    t1a = A(j, l)*B(-l, -k)
+    assert t1 == t1a
+
+def test_riemann_cyclic_replaceR():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    t = R(m0,m2,m1,m3)
+    t1 = riemann_cyclic_replaceR(t)
+    t1a =  -S.One/3*R(m0, m3, m2, m1) + S.One/3*R(m0, m1, m2, m3) + Rational(2,3)*R(m0, m2, m1, m3)
+    assert t1 == t1a
+
+def test_riemann_cyclic():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    t = R(i,j,k,l) + R(i,l,j,k) + R(i,k,l,j) - \
+        R(i,j,l,k) - R(i,l,k,j) - R(i,k,j,l)
+    t2 = t*R(-i,-j,-k,-l)
+    t3 = riemann_cyclic(t2)
+    assert t3 == 0
+    t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
+    t1 = riemann_cyclic(t)
+    assert t1 == 0
+
+def test_div():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    t = R(m0,m1,-m1,m3)
+    t1 = t/S(4)
+    assert str(t1) == '1/4*R(m0, L_0, -L_0, m3)'
+    t = t.canon_bp()
+    assert not t1._is_canon_bp
+    t1 = t*4
+    assert t1._is_canon_bp
+    t1 = t1/4
+    assert t1._is_canon_bp

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -825,8 +825,14 @@ def test_contract_delta1():
 def test_fun():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
-    a,b,c,d = tensor_indices('a,b,c,d', Lorentz)
+    a,b,c,d,e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
+
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    t = q(c)*p(a)*q(b) + g(a,b)*g(c,d)*q(-d)
+    assert t(a,b,c) == t
+    assert t - t(b,a,c) == q(c)*p(a)*q(b) - q(c)*p(b)*q(a)
+    assert t(b,c,d) == q(d)*p(b)*q(c) + g(b,c)*g(d,e)*q(-e)
 
     # check that g_{a b; c} = 0
     # example taken from  L. Brewin
@@ -835,7 +841,6 @@ def test_fun():
     dg = tensorhead('dg', [Lorentz]*3, [[1], [1]*2])
     # gamma^a_{b c} is the Christoffel symbol
     gamma = S.Half*g(a,d)*(dg(-b,-d,-c) + dg(-c,-b,-d) - dg(-d,-b,-c))
-    gamma.set_free_args([a, -b, -c])
     # t = g_{a b; c}
     t = dg(-c,-a,-b) - g(-a,-d)*gamma(d,-b,-c) - g(-b,-d)*gamma(d,-a,-c)
     t = t.contract_metric(g, True)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -273,7 +273,7 @@ def test_canonicalize1():
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
     Mat = TensorIndexType('Mat', metric=None, dummy_fmt='M')
     a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
-      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Mat)
     S3 = TensorType([Mat]*3, sym3)
     S2a = TensorType([Mat]*2, sym2a)
     A = S3('A', 1)
@@ -548,6 +548,23 @@ def test_substitute_indices():
     assert t1 == p(-j)
     t1 = t.substitute_indices((-i, -j))
     assert t1 == p(j)
+
+def test_substitute_tensor():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S1 = TensorType([Lorentz], sym1)
+    S2 = TensorType([Lorentz]*2, sym2)
+    p, q = S1('p,q')
+    A = S2('A')
+    t = 2*p(m0)*q(m1)
+    t1 = p(m1)
+    t2 = 3*A(m1, m2)*p(-m2)
+    t3 = t.substitute_tensor(t1, t2)
+    assert t3 == 6*A(m0, m2)*p(-m2)*q(m1)
+    t4 = t.substitute_tensor(q(m1), t2)
+    assert t4 == 6*p(m0)*A(m1, m2)*p(-m2)
 
 
 def test_riemann_cyclic_replace():


### PR DESCRIPTION
It is implemented a tensor class with monoterm canonicalization
and algebraic operations on tensors.

There are two applications:

check of identities involving the cyclic symmetry of the Riemann tensor

```
>>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, riemann_cyclic, riemann_bsgs
>>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
>>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
>>> symr = TensorSymmetry(riemann_bsgs)
>>> R4 = TensorType([Lorentz]*4, symr)
>>> R = R4('R')
>>> t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
>>> riemann_cyclic(t)
0
```

gamma matrices in dimensional regularization

```
>>> from sympy import Symbol, S
>>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
        TensorSymmetry, get_symmetric_group_sgs, TensorType, Tensor)
>>> from sympy.tensor.dgamma_matr import GammaMatrices
>>> D = Symbol('D')
>>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
>>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
>>> S1 = TensorType([Lorentz], sym1)
>>> GM = GammaMatrices(Lorentz)
>>> gamma_trace = GM.gamma_trace
>>> G = GM.G
>>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
>>> gamma_trace(G(m0)*G(m1)*G(-m0)*G(m3))
(-4*D + 8)*metric(m1, m3)

>>> p, q = S1('p,q')
>>> t = G(m0)*G(m1)*G(m2)*G(m3)*p(-m1)*q(-m3)
>>> gamma_trace(t)
-4*metric(m0, m2)*p(L_0)*q(-L_0) + 4*p(m0)*q(m2) + 4*p(m2)*q(m0)
```
