### PR TITLE
Tensor expression with canonicalization: part1

### DIFF
--- a/doc/src/modules/tensor/index.rst
+++ b/doc/src/modules/tensor/index.rst
@@ -14,3 +14,4 @@ Contents
 
     indexed.rst
     index_methods.rst
+    tensor.rst

--- a/doc/src/modules/tensor/tensor.rst
+++ b/doc/src/modules/tensor/tensor.rst
@@ -5,6 +5,9 @@ Tensor
 
 .. module:: sympy.tensor.tensor
 
+.. autoclass:: _TensorManager
+   :members:
+
 .. autoclass:: TensorIndexType
    :members:
 
@@ -28,14 +31,14 @@ Tensor
 .. autoclass:: TensAdd
    :members:
 
-.. autoclass:: Tensor
+.. autoclass:: TensMul
    :members:
 
 .. autofunction:: canon_bp
 
 .. autofunction:: tensor_mul
 
-.. autofunction:: riemann_cyclic_replaceR
+.. autofunction:: riemann_cyclic_replace
 
 .. autofunction:: riemann_cyclic
 

--- a/doc/src/modules/tensor/tensor.rst
+++ b/doc/src/modules/tensor/tensor.rst
@@ -1,0 +1,41 @@
+.. _tensor-tensor:
+
+Tensor
+======
+
+.. module:: sympy.tensor.tensor
+
+.. autoclass:: TensorIndexType
+   :members:
+
+.. autoclass:: TensorIndex
+   :members:
+
+.. autofunction:: tensor_indices
+
+.. autoclass:: TensorSymmetry
+   :members:
+
+.. autoclass:: TensorType
+   :members:
+
+.. autoclass:: TensorHead
+   :members:
+
+.. autoclass:: TensExpr
+   :members:
+
+.. autoclass:: TensAdd
+   :members:
+
+.. autoclass:: Tensor
+   :members:
+
+.. autofunction:: canon_bp
+
+.. autofunction:: tensor_mul
+
+.. autofunction:: riemann_cyclic_replaceR
+
+.. autofunction:: riemann_cyclic
+

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1,9 +1,9 @@
 from sympy.combinatorics.permutations import Permutation, _af_rmul, _af_rmuln,\
-  _af_invert, _af_new
+    _af_invert, _af_new
 from sympy.combinatorics.perm_groups import PermutationGroup, _orbit, \
-  _orbit_transversal
+    _orbit_transversal
 from sympy.combinatorics.util import _distribute_gens_by_base, \
-  _orbits_transversals_from_bsgs
+    _orbits_transversals_from_bsgs
 
 """
     References for tensor canonicalization:
@@ -42,25 +42,28 @@ def dummy_sgs(dummies, sym, n):
     ========
     >>> from sympy.combinatorics.tensor_can import dummy_sgs
     >>> dummy_sgs([2,3,4,5,6,7], 0, 8)
-    [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9], [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]
+    [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9],
+     [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9],
+     [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]
     """
     assert len(dummies) <= n
     res = []
     # exchange of contravariant and covariant indices
-    if sym != None:
+    if sym is not None:
         for j in dummies[::2]:
-            a = range(n+2)
+            a = range(n + 2)
             if sym == 1:
-                a[n] = n+1
-                a[n+1] = n
-            a[j], a[j+1] = a[j+1], a[j]
+                a[n] = n + 1
+                a[n + 1] = n
+            a[j], a[j + 1] = a[j + 1], a[j]
             res.append(a)
     # rename dummy indices
     for j in dummies[:-3:2]:
-        a = range(n+2)
-        a[j:j+4] = a[j+2],a[j+3],a[j],a[j+1]
+        a = range(n + 2)
+        a[j:j + 4] = a[j + 2], a[j + 3], a[j], a[j + 1]
         res.append(a)
     return res
+
 
 def _min_dummies(dummies, sym, indices):
     """
@@ -102,6 +105,7 @@ def _trace_S(s, j, b, S_cosets):
             return h
     return None
 
+
 def _trace_D(gj, p_i, Dxtrav):
     """
     Return the representative h satisfying h[gj] == p_i
@@ -112,6 +116,7 @@ def _trace_D(gj, p_i, Dxtrav):
         if h[gj] == p_i:
             return h
     return None
+
 
 def _dumx_remove(dumx, dumx_flat, p0):
     """
@@ -124,14 +129,15 @@ def _dumx_remove(dumx, dumx_flat, p0):
             continue
         k = dx.index(p0)
         if k % 2 == 0:
-            p0_paired = dx[k+1]
+            p0_paired = dx[k + 1]
         else:
-            p0_paired = dx[k-1]
+            p0_paired = dx[k - 1]
         dx.remove(p0)
         dx.remove(p0_paired)
         dumx_flat.remove(p0)
         dumx_flat.remove(p0_paired)
         res.append(dx)
+
 
 def transversal2coset(size, base, transversal):
     a = []
@@ -142,10 +148,10 @@ def transversal2coset(size, base, transversal):
             j += 1
         else:
             a.append([range(size)])
-    j = len(a)-1
+    j = len(a) - 1
     while a[j] == [range(size)]:
         j -= 1
-    return a[:j+1]
+    return a[:j + 1]
 
 
 def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
@@ -156,7 +162,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         list of lists of dummy indices,
         one list for each type of index;
         the dummy indices are put in order contravariant, covariant
-        [d0, -d0, d1,-d1,...].
+        [d0, -d0, d1, -d1, ...].
 
       sym
         list of the symmetries of the index metric for each type.
@@ -379,7 +385,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
     g = g.array_form
     num_dummies = size - 2
     indices = range(num_dummies)
-    all_metrics_with_sym = all([_ != None for _ in sym])
+    all_metrics_with_sym = all([_ is not None for _ in sym])
     num_types = len(sym)
     dumx = dummies[:]
     dumx_flat = []
@@ -392,7 +398,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
     # strong generating set for D
     dsgsx = []
     for i in range(num_types):
-       dsgsx.extend(dummy_sgs(dumx[i], sym[i], num_dummies))
+        dsgsx.extend(dummy_sgs(dumx[i], sym[i], num_dummies))
     ginv = _af_invert(g)
     idn = range(size)
     # TAB = list of entries (s, d, h) where h = _af_rmuln(d,g,s)
@@ -410,24 +416,25 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         if all_metrics_with_sym:
             md = _min_dummies(dumx, sym, indices)
         else:
-            md = [min(_orbit(size, [_af_new(ddx) for ddx in dsgsx], ii)) for ii in range(size-2)]
+            md = [min(_orbit(size, [_af_new(
+                ddx) for ddx in dsgsx], ii)) for ii in range(size - 2)]
 
-        p_i = min([min([md[h[x]] for x in deltab]) for s,d,h in TAB])
+        p_i = min([min([md[h[x]] for x in deltab]) for s, d, h in TAB])
         dsgsx1 = [_af_new(_) for _ in dsgsx]
         Dxtrav = _orbit_transversal(size, dsgsx1, p_i, False, af=True) \
-                if dsgsx else None
+            if dsgsx else None
         if Dxtrav:
             Dxtrav = [_af_invert(x) for x in Dxtrav]
         # compute the orbit of p_i
         for ii in range(num_types):
             if p_i in dumx[ii]:
                 # the orbit is made by all the indices in dum[ii]
-                if sym[ii] != None:
+                if sym[ii] is not None:
                     deltap = dumx[ii]
                 else:
                     # the orbit is made by all the even indices if p_i
                     # is even, by all the odd indices if p_i is odd
-                    p_i_index = dumx[ii].index(p_i)%2
+                    p_i_index = dumx[ii].index(p_i) % 2
                     deltap = dumx[ii][p_i_index::2]
                 break
         else:
@@ -492,7 +499,7 @@ def double_coset_can_rep(dummies, sym, b_S, sgens, S_transversals, g):
         # if TAB contains equal permutations up to the sign, return 0
         TAB1.sort(key=lambda x: x[-1])
         nTAB1 = len(TAB1)
-        prev = [0]*size
+        prev = [0] * size
         while TAB1:
             s, d, h = TAB1.pop()
             if h[:-2] == prev[:-2]:
@@ -586,17 +593,18 @@ def _get_map_slots(size, fixed_slots):
     res = range(size)
     pos = 0
     for i in range(size):
-      if i in fixed_slots:
-          continue
-      res[i] = pos
-      pos += 1
+        if i in fixed_slots:
+            continue
+        res[i] = pos
+        pos += 1
     return res
+
 
 def _lift_sgens(size, fixed_slots, free, s):
     a = []
     j = k = 0
     fd = zip(fixed_slots, free)
-    fd = [y for x,y in sorted(fd)]
+    fd = [y for x, y in sorted(fd)]
     num_free = len(free)
     for i in range(size):
         if i in fixed_slots:
@@ -606,6 +614,7 @@ def _lift_sgens(size, fixed_slots, free, s):
             a.append(s[j] + num_free)
             j += 1
     return a
+
 
 def canonicalize(g, dummies, msym, *v):
     """
@@ -733,10 +742,11 @@ def canonicalize(g, dummies, msym, *v):
         num_types = 1
     else:
         num_types = len(msym)
-        if not all(msymx in [0,1,None] for msymx in msym):
+        if not all(msymx in [0, 1, None] for msymx in msym):
             raise ValueError('msym entries must be 0, 1 or None')
         if len(dummies) != num_types:
-            raise ValueError('dummies and msym must have the same number of elements')
+            raise ValueError(
+                'dummies and msym must have the same number of elements')
     size = g.size
     num_tensors = 0
     v1 = []
@@ -751,7 +761,7 @@ def canonicalize(g, dummies, msym, *v):
                 can = canonicalize_naive(g, dummies, msym, *v)
                 return can
             base_i, gens_i = mbsgs
-        v1.append((base_i, gens_i, [[]]*n_i, sym_i))
+        v1.append((base_i, gens_i, [[]] * n_i, sym_i))
         num_tensors += n_i
 
     if num_types == 1:
@@ -767,8 +777,9 @@ def canonicalize(g, dummies, msym, *v):
     # slot symmetry of the tensor
     size1, sbase, sgens = gens_products(*v1)
     if size != size1:
-        raise ValueError('g has size %d, generators have size %d' %(size, size1))
-    free = [i for i in range(size-2) if i not in flat_dummies]
+        raise ValueError(
+            'g has size %d, generators have size %d' % (size, size1))
+    free = [i for i in range(size - 2) if i not in flat_dummies]
     num_free = len(free)
 
     # g1 minimal tensor under slot symmetry
@@ -776,7 +787,7 @@ def canonicalize(g, dummies, msym, *v):
     if not flat_dummies:
         return g1
     # save the sign of g1
-    sign = 0 if g1[-1] == size-1 else 1
+    sign = 0 if g1[-1] == size - 1 else 1
 
     # the free indices are kept fixed.
     # Determine free_i, the list of slots of tensors which are fixed
@@ -817,7 +828,8 @@ def canonicalize(g, dummies, msym, *v):
     dummies_red = [[x - num_free for x in y] for y in dummies]
     transv_red = get_transversals(sbase_red, sgens_red)
     g1_red = _af_new(g1_red)
-    g2 = double_coset_can_rep(dummies_red, msym, sbase_red, sgens_red, transv_red, g1_red)
+    g2 = double_coset_can_rep(
+        dummies_red, msym, sbase_red, sgens_red, transv_red, g1_red)
     if g2 == 0:
         return 0
     # lift to the case with the free indices
@@ -849,7 +861,8 @@ def perm_af_direct_product(gens1, gens2, signed=True):
     start = list(range(n1))
     end = list(range(n1, n1 + n2))
     if signed:
-        gens1 = [gen[:-2] + end + [gen[-2]+n2, gen[-1]+n2] for gen in gens1]
+        gens1 = [gen[:-2] + end + [gen[-2] + n2, gen[-1] + n2]
+                 for gen in gens1]
         gens2 = [start + [x + n1 for x in gen] for gen in gens2]
     else:
         gens1 = [gen + end for gen in gens1]
@@ -858,6 +871,7 @@ def perm_af_direct_product(gens1, gens2, signed=True):
     res = gens1 + gens2
 
     return res
+
 
 def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
     """
@@ -895,6 +909,7 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
         gens = [id_af]
     return base, [_af_new(h) for h in gens]
 
+
 def get_symmetric_group_sgs(n, sym=0):
     """
     Return base, gens of the minimal BSGS for (anti)symmetric group
@@ -910,16 +925,17 @@ def get_symmetric_group_sgs(n, sym=0):
     """
     if n == 1:
         return [], [_af_new(range(3))]
-    gens = [Permutation(n-1)(i, i+1)._array_form for i in range(n-1)]
+    gens = [Permutation(n - 1)(i, i + 1)._array_form for i in range(n - 1)]
     if sym == 0:
-        gens = [x + [n, n+1] for x in gens]
+        gens = [x + [n, n + 1] for x in gens]
     else:
-        gens = [x + [n+1, n] for x in gens]
-    base = range(n-1)
+        gens = [x + [n + 1, n] for x in gens]
+    base = range(n - 1)
     return base, [_af_new(h) for h in gens]
 
-riemann_bsgs = [0, 2], [Permutation(0,1)(4,5), Permutation(2,3)(4,5), \
-               Permutation(5)(0,2)(1,3)]
+riemann_bsgs = [0, 2], [Permutation(0, 1)(4, 5), Permutation(2, 3)(4, 5),
+                        Permutation(5)(0, 2)(1, 3)]
+
 
 def get_transversals(base, gens):
     """
@@ -927,10 +943,10 @@ def get_transversals(base, gens):
     """
     if not base:
         return []
-    stabs =  _distribute_gens_by_base(base, gens)
+    stabs = _distribute_gens_by_base(base, gens)
     orbits, transversals = _orbits_transversals_from_bsgs(base, stabs)
-    transversals = [dict((x, h._array_form) for x, h in y.items()) for y in \
-            transversals]
+    transversals = [dict((x, h._array_form) for x, h in y.items()) for y in
+                    transversals]
     return transversals
 
 
@@ -959,6 +975,7 @@ def _is_minimal_bsgs(base, gens):
             sgs1 = [h for h in sgs1 if h._array_form[i] == i]
     return base1 == base
 
+
 def get_minimal_bsgs(base, gens):
     """
     Compute a minimal GSGS
@@ -986,6 +1003,7 @@ def get_minimal_bsgs(base, gens):
     if not _is_minimal_bsgs(base, gens):
         return None
     return base, gens
+
 
 def tensor_gens(base, gens, list_free_indices, sym=0):
     """
@@ -1036,7 +1054,7 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     if not base and list_free_indices.count([]) < 2:
         n = len(list_free_indices)
         size = gens[0].size
-        size = n*(gens[0].size - 2) + 2
+        size = n * (gens[0].size - 2) + 2
         return size, [], [_af_new(range(size))]
 
     # if any(list_free_indices) one needs to compute the pointwise
@@ -1058,14 +1076,14 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     for i in range(1, len(list_free_indices)):
         base1, gens1 = _get_bsgs(G, base, gens, list_free_indices[i])
         res_base, res_gens = bsgs_direct_product(res_base, res_gens,
-            base1, gens1, 1)
+                                                 base1, gens1, 1)
         if not list_free_indices[i]:
-            no_free.append(range(size-2, size - 2 + num_indices))
+            no_free.append(range(size - 2, size - 2 + num_indices))
         size += num_indices
     nr = size - 2
     res_gens = [h for h in res_gens if h._array_form != id_af]
     # if sym there are no commuting tensors stop here
-    if sym == None or not no_free:
+    if sym is None or not no_free:
         if not res_gens:
             res_gens = [_af_new(id_af)]
         return size, res_base, res_gens
@@ -1085,7 +1103,7 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
         a.extend(ind2)
         a.extend(ind1)
         base_comm.append(ind1[0])
-        a.extend(range(ind2[-1]+1, nr))
+        a.extend(range(ind2[-1] + 1, nr))
         if sym == 0:
             a.extend([nr, nr + 1])
         else:
@@ -1130,7 +1148,7 @@ def gens_products(*v):
     for i in range(1, len(v)):
         size, base, gens = tensor_gens(*v[i])
         res_base, res_gens = bsgs_direct_product(res_base, res_gens, base,
-                                               gens, 1)
+                                                 gens, 1)
     res_size = res_gens[0].size
     id_af = range(res_size)
     res_gens = [h for h in res_gens if h != id_af]

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -530,14 +530,15 @@ def canonical_free(base, gens, g, num_free):
     """
     canonicalization of a tensor with respect to free indices
     choosing the minimum with respect to lexicographical ordering
+    in the free indices
 
-    base, gens  BSGS for slot permutation group
-    g           permutation representing the tensor
-    num_free    number of free indices
+    ``base``, ``gens``  BSGS for slot permutation group
+    ``g``               permutation representing the tensor
+    ``num_free``        number of free indices
     The indices must be ordered with first the free indices
 
     see explanation in double_coset_can_rep
-    The algorithm is given in [2]
+    The algorithm is a variation of the one given in [2].
 
     Examples
     ========
@@ -552,20 +553,23 @@ def canonical_free(base, gens, g, num_free):
     [0, 3, 1, 2, 5, 4]
 
     Consider the product of Riemann tensors
-    `T = R^{a}_{d0}^{d1,d2}*R_{d2,d1}^{d0,b}`
-    The order of the indices is [a,b,d0,-d0,d1,-d1,d2,-d2]
+    ``T = R^{a}_{d0}^{d1,d2}*R_{d2,d1}^{d0,b}``
+    The order of the indices is ``[a,b,d0,-d0,d1,-d1,d2,-d2]``
     The permutation corresponding to the tensor is
-    g = [0,3,4,6,7,5,2,1,8,9]
-    Use the slot symmetries to get `T` is the form which is the minimum
-    in lexicographic order
-    `R^{a}_{d0}^{d1,d2}*R^{b,d0}_{d1,d2}` corresponding to
-    `[0, 3, 4, 6, 1, 2, 5, 7, 8, 9]`
+    ``g = [0,3,4,6,7,5,2,1,8,9]``
+
+    In particular ``a`` is position ``0``, ``b`` is in position ``9``.
+    Use the slot symmetries to get `T` is a form which is the minimal
+    in lexicographic order in the free indices ``a`` and ``b``, e.g.
+    ``-R^{a}_{d0}^{d1,d2}*R^{b,d0}_{d2,d1}`` corresponding to
+    ``[0, 3, 4, 6, 1, 2, 7, 5, 9, 8]``
+
     >>> from sympy.combinatorics.tensor_can import riemann_bsgs, tensor_gens
     >>> base, gens = riemann_bsgs
     >>> size, sbase, sgens = tensor_gens(base, gens, [[],[]], 0)
     >>> g = Permutation([0,3,4,6,7,5,2,1,8,9])
     >>> canonical_free(sbase, [Permutation(h) for h in sgens], g, 2)
-    [0, 3, 4, 6, 1, 2, 5, 7, 8, 9]
+    [0, 3, 4, 6, 1, 2, 7, 5, 9, 8]
     """
     g = g.array_form
     size = len(g)
@@ -573,27 +577,26 @@ def canonical_free(base, gens, g, num_free):
         return g[:]
 
     transversals = get_transversals(base, gens)
-    cosets = transversal2coset(size, base, transversals)
-    K = [h._array_form for h in gens]
     m = len(base)
     for x in sorted(g[:-2]):
         if x not in base:
             base.append(x)
-    lambd = g
-    K1 = []
-    for i in range(m):
+    h = g
+    for i, transv in enumerate(transversals):
         b = base[i]
-        delta = [x[b] for x in cosets[b]]
-        delta1 = [lambd[x] for x in delta]
-        delta1min = min(delta1)
-        k = delta1.index(delta1min)
-        p = delta[k]
-        for omega in cosets[b]:
-            if omega[b] == p:
-                break
-        lambd = _af_rmul(lambd, omega)
-        K = [px for px in K if px[b] == b]
-    return lambd
+        h_i = [size]*num_free
+        # find the element s in transversals[i] such that
+        # _af_rmul(h, s) has its free elements with the lowest position in h
+        s = None
+        for sk in transv.values():
+            h1 = _af_rmul(h, sk)
+            hi = [h1.index(ix) for ix in range(num_free)]
+            if hi < h_i:
+                h_i = hi
+                s = sk
+        if s:
+            h = _af_rmul(h, s)
+    return h
 
 
 def _get_map_slots(size, fixed_slots):

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -635,7 +635,7 @@ def canonicalize(g, dummies, msym, *v):
             in case of failure,
             canonicalize_naive is used, which is much slower.
 
-            n_i     number ot tensors of type `i`.
+            n_i     number of tensors of type `i`.
 
             sym_i   symmetry under exchange of component tensors of type `i`.
 

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -775,7 +775,7 @@ def canonicalize(g, dummies, msym, *v):
         v1.append((base_i, gens_i, [[]] * n_i, sym_i))
         num_tensors += n_i
 
-    if num_types == 1:
+    if num_types == 1 and not isinstance(msym, list):
         dummies = [dummies]
         msym = [msym]
     flat_dummies = []

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -923,10 +923,14 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
     return base, [_af_new(h) for h in gens]
 
 
-def get_symmetric_group_sgs(n, sym=0):
+def get_symmetric_group_sgs(n, antisym=False):
     """
-    Return base, gens of the minimal BSGS for (anti)symmetric group
-    with n elements
+    Return base, gens of the minimal BSGS for (anti)symmetric tensor
+
+    ``n``  rank of the tensor
+
+    ``antisym = False`` symmetric tensor
+    ``antisym = True``  antisymmetric tensor
 
     Examples
     ========
@@ -940,7 +944,7 @@ def get_symmetric_group_sgs(n, sym=0):
     if n == 1:
         return [], [_af_new(range(3))]
     gens = [Permutation(n - 1)(i, i + 1)._array_form for i in range(n - 1)]
-    if sym == 0:
+    if antisym == 0:
         gens = [x + [n, n + 1] for x in gens]
     else:
         gens = [x + [n + 1, n] for x in gens]

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -28,20 +28,25 @@ def dummy_sgs(dummies, sym, n):
     """
     Return the strong generators for dummy indices
 
-    dummies   list of dummy indices,
-              `dummies[2k], dummies[2k+1]` are paired indices
-    sym       symmetry under interchange of contracted dummies
-    sym =     None  no symmetry
-              0 symmetric
-              1 antisymmetric
-    n         number of indices
+    Parameters
+    ==========
+
+    dummies : list of dummy indices
+        `dummies[2k], dummies[2k+1]` are paired indices
+    sym : symmetry under interchange of contracted dummies::
+        * None  no symmetry
+        * 0     commuting
+        * 1     anticommuting
+
+    n : number of indices
 
     in base form the dummy indices are always in consecutive positions
 
     Examples
     ========
+
     >>> from sympy.combinatorics.tensor_can import dummy_sgs
-    >>> dummy_sgs([2,3,4,5,6,7], 0, 8)
+    >>> dummy_sgs(range(2, 8), 0, 8)
     [[0, 1, 3, 2, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 5, 4, 6, 7, 8, 9],
      [0, 1, 2, 3, 4, 5, 7, 6, 8, 9], [0, 1, 4, 5, 2, 3, 6, 7, 8, 9],
      [0, 1, 2, 3, 6, 7, 4, 5, 8, 9]]
@@ -73,8 +78,9 @@ def _min_dummies(dummies, sym, indices):
 
     Examples
     ========
+
     >>> from sympy.combinatorics.tensor_can import _min_dummies
-    >>> _min_dummies([[2,3,4,5,6,7]], [0], range(10))
+    >>> _min_dummies([range(2, 8)], [0], range(10))
     [0, 1, 2, 2, 2, 2, 2, 2, 8, 9]
     """
     num_types = len(sym)
@@ -535,6 +541,7 @@ def canonical_free(base, gens, g, num_free):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import canonical_free
     >>> gens = [[1,0,2,3,5,4], [2,3,0,1,4,5],[0,1,3,2,5,4]]
@@ -620,40 +627,44 @@ def canonicalize(g, dummies, msym, *v):
     """
     canonicalize tensor formed by tensors
 
-      g     permutation representing the tensor
+    Parameters
+    ==========
 
-      dummies list representing the dummy indices
-              it can be a list of dummy indices of the same type
-              or a list of lists of dummy indices, one list for each
-              type of index;
-              the dummy indices must come after the free indices,
-              and put in order contravariant, covariant
-              [d0, -d0, d1,-d1,...]
+    g : permutation representing the tensor
 
-      msym  symmetry of the metric(s)
-            it can be an integer or a list;
-            in the first case it is the symmetry of the dummy index metric;
-            in the second case it is the list of the symmetries of the
-            index metric for each type
+    dummies : list representing the dummy indices
+      it can be a list of dummy indices of the same type
+      or a list of lists of dummy indices, one list for each
+      type of index;
+      the dummy indices must come after the free indices,
+      and put in order contravariant, covariant
+      [d0, -d0, d1,-d1,...]
+    msym :  symmetry of the metric(s)
+        it can be an integer or a list;
+        in the first case it is the symmetry of the dummy index metric;
+        in the second case it is the list of the symmetries of the
+        index metric for each type
+    v : list, (base_i, gens_i, n_i, sym_i) for tensors of type `i`
 
-      v     is a list of (base_i, gens_i, n_i, sym_i) for tensors of type `i`
-            base_i, gens_i BSGS for tensors of this type.
+    base_i, gens_i : BSGS for tensors of this type.
+        The BSGS should have minimal base under lexicographic ordering;
+        if not, an attempt is made do get the minimal BSGS;
+        in case of failure,
+        canonicalize_naive is used, which is much slower.
 
-            The BSGS should have minimal base under lexicographic ordering;
-            if not, an attempt is made do get the minimal BSGS;
-            in case of failure,
-            canonicalize_naive is used, which is much slower.
+    n_i :    number of tensors of type `i`.
 
-            n_i     number of tensors of type `i`.
+    sym_i :  symmetry under exchange of component tensors of type `i`.
 
-            sym_i   symmetry under exchange of component tensors of type `i`.
-
-      Both for msym and sym_i the cases are
+        Both for msym and sym_i the cases are
             * None  no symmetry
             * 0     commuting
             * 1     anticommuting
 
-    Return 0 if the tensor is zero, else return the array form of
+    Returns
+    =======
+
+    0 if the tensor is zero, else return the array form of
     the permutation representing the canonical form of the tensor.
 
     Algorithm
@@ -686,7 +697,7 @@ def canonicalize(g, dummies, msym, *v):
 
     g = [1,3,0,5,4,2,6,7]
 
-    T_c = 0
+    `T_c = 0`
 
     >>> from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, canonicalize, bsgs_direct_product
     >>> from sympy.combinatorics import Permutation
@@ -701,7 +712,7 @@ def canonicalize(g, dummies, msym, *v):
 
     `T_c = -A^{d0 d1} * B_{d0}{}^{d2} * B_{d1 d2}`
 
-    `can = [0,2,1,4,3,5,7,6]`
+    can = [0,2,1,4,3,5,7,6]
 
     >>> t1 = (base2a, gens2a, 2, 1)
     >>> canonicalize(g, range(6), 0, t0, t1)
@@ -843,6 +854,7 @@ def perm_af_direct_product(gens1, gens2, signed=True):
 
     Examples
     ========
+
     >>> from sympy.combinatorics.tensor_can import perm_af_direct_product
     >>> gens1 = [[1,0,2,3], [0,1,3,2]]
     >>> gens2 = [[1,0]]
@@ -887,6 +899,7 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import (get_symmetric_group_sgs, bsgs_direct_product)
     >>> Permutation.print_cyclic = True
@@ -917,6 +930,7 @@ def get_symmetric_group_sgs(n, sym=0):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import get_symmetric_group_sgs
     >>> Permutation.print_cyclic = True
@@ -958,6 +972,7 @@ def _is_minimal_bsgs(base, gens):
 
     Examples
     ========
+
     >>> from sympy.combinatorics import Permutation
     >>> from sympy.combinatorics.tensor_can import riemann_bsgs, _is_minimal_bsgs
     >>> _is_minimal_bsgs(*riemann_bsgs)

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -333,7 +333,7 @@ def test_canonicalize1():
     can = canonicalize(g, range(8), 1, (base3, gens3,2,1), (base2a,gens2a,1,0))
     assert can == [0,2,4, 1,3,6, 5,7, 9,8]
 
-    # A anticommuting symmetric, B anticommuting anticommuting, 
+    # A anticommuting symmetric, B anticommuting anticommuting,
     # no metric symmetry
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -305,12 +305,11 @@ def test_canonicalize1():
     # g = [10,4,8, 0,7,9, 6,11,1, 2,3,5, 12,13]
     # T_c = A^{a0 d0 d1}*A^a1_d0^d2*A^{a2 a3 d3}*A_{d1 d2 d3}
     # can = [0,4,6, 1,5,8, 2,3,10, 7,9,11, 12,13]
-    base3, gens3 = get_symmetric_group_sgs(3)
     g = Permutation([10,4,8, 0,7,9, 6,11,1, 2,3,5, 12,13])
     can = canonicalize(g, range(4,12), 0, (base3, gens3, 4, 0))
     assert can == [0,4,6, 1,5,8, 2,3,10, 7,9,11, 12,13]
 
-    # A commuting symmetric, B anticommuting
+    # A commuting symmetric, B antisymmetric
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # ord = [d0,-d0,d1,-d1,d2,-d2,d3,-d3]
     # g = [0,2,4,5,7,3,1,6,8,9]
@@ -327,14 +326,15 @@ def test_canonicalize1():
     # can = [0,2,4, 1,3,6, 5,7, 8,9]
     can = canonicalize(g, range(8), 0, (base3, gens3,2,1), (base2a,gens2a,1,0))
     assert can == [0,2,4, 1,3,6, 5,7, 8,9]
-    # A anticommuting symmetric, B anticommuting, antisymmetric metric
+    # A anticommuting symmetric, B antisymmetric commuting, antisymmetric metric
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = -A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
     # can = [0,2,4, 1,3,6, 5,7, 9,8]
     can = canonicalize(g, range(8), 1, (base3, gens3,2,1), (base2a,gens2a,1,0))
     assert can == [0,2,4, 1,3,6, 5,7, 9,8]
 
-    # A anticommuting symmetric, B anticommuting, no metric symmetry
+    # A anticommuting symmetric, B anticommuting anticommuting, 
+    # no metric symmetry
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
     # can = [0,2,4, 1,3,7, 5,6, 8,9]
@@ -403,6 +403,8 @@ def test_riemann_invariants():
     # R_d11^d1_d0^d5 * R^{d6 d4 d0}_d5 * R_{d7 d2 d8 d9} *
     # R_{d10 d3 d6 d4} * R^{d2 d7 d11}_d1 * R^{d8 d9 d3 d10}
     # ord: contravariant d_k ->2*k, covariant d_k -> 2*k+1
+    # T_c = R^{d0 d1 d2 d3} * R_{d0 d1}^{d4 d5} * R_{d2 d3}^{d6 d7} *
+    # R_{d4 d5}^{d8 d9} * R_{d6 d7}^{d10 d11} * R_{d8 d9 d10 d11}
     g = Permutation([23,2,1,10,12,8,0,11,15,5,17,19,21,7,13,9,4,14,22,3,16,18,6,20,24,25])
     can = canonicalize(g, range(24), 0, (baser, gensr, 6, 0))
     assert can == [0,2,4,6,1,3,8,10,5,7,12,14,9,11,16,18,13,15,20,22,17,19,21,23,24,25]
@@ -411,8 +413,6 @@ def test_riemann_invariants():
     can = canonicalize(g, range(24), 0, ([2, 0], [Permutation([1,0,2,3,5,4]), Permutation([2,3,0,1,4,5])], 6, 0))
     assert can == [0,2,4,6,1,3,8,10,5,7,12,14,9,11,16,18,13,15,20,22,17,19,21,23,24,25]
 
-    #R^{d0 d1 d2 d3} * R_{d0 d1}^{d4 d5} * R_{d2 d3}^{d6 d7} *
-    # R_{d4 d5}^{d8 d9} * R_{d6 d7}^{d10 d11} * R_{d8 d9 d10 d11}
     g = Permutation([0,2,5,7,4,6,9,11,8,10,13,15,12,14,17,19,16,18,21,23,20,22,25,27,24,26,29,31,28,30,33,35,32,34,37,39,36,38,1,3,40,41])
     can = canonicalize(g, range(40), 0, (baser, gensr, 10, 0))
     assert can == [0,2,4,6,1,3,8,10,5,7,12,14,9,11,16,18,13,15,20,22,17,19,24,26,21,23,28,30,25,27,32,34,29,31,36,38,33,35,37,39,40,41]
@@ -470,6 +470,8 @@ def test_riemann_products():
     # R^{d2 a0 a2 d0} * R^d1_d2^{a1 a3} * R^{a4 a5}_{d0 d1}
     # ord = [a0,a1,a2,a3,a4,a5,d0,-d0,d1,-d1,d2,-d2]
     #         0  1  2  3 4  5  6   7  8   9  10  11
+    # can = [0, 6, 2, 8, 1, 3, 7, 10, 4, 5, 9, 11, 12, 13]
+    # T_c = R^{a0 d0 a2 d1}*R^{a1 a3}_d0^d2*R^{a4 a5}_{d1 d2}
     g = Permutation([10,0,2,6,8,11,1,3,4,5,7,9,12,13])
     can = canonicalize(g, range(6,12), 0, (baser, gensr, 3, 0))
     assert can == [0, 6, 2, 8, 1, 3, 7, 10, 4, 5, 9, 11, 12, 13]

--- a/sympy/combinatorics/tests/test_tensor_can.py
+++ b/sympy/combinatorics/tests/test_tensor_can.py
@@ -241,6 +241,18 @@ def test_no_metric_symmetry():
     can = canonicalize(g, range(16), None, [[], [Permutation(range(4))], 8, 0])
     assert can == [0,3,2,5,4,7,6,1,8,11,10,13,12,15,14,9,16,17]
 
+def test_canonical_free():
+    # t = A^{d0 a1}*A_d0^a0
+    # ord = [a0,a1,d0,-d0];  g = [2,1,3,0,4,5]; dummies = [[2,3]]
+    # t_c = A_d0^a0*A^{d0 a1}
+    # can = [3,0, 2,1, 4,5]
+    base = [0]
+    gens = [Permutation(5)(0,2)(1,3)]
+    g = Permutation([2,1,3,0,4,5])
+    num_free = 2
+    dummies = [[2,3]]
+    can = canonicalize(g, dummies, [None], ([], [Permutation(3)], 2, 0))
+    assert can == [3,0, 2,1, 4,5]
 
 def test_canonicalize1():
     base1, gens1 = get_symmetric_group_sgs(1)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -70,6 +70,7 @@ class Basic(object):
     is_Boolean = False
     is_Not = False
     is_Matrix = False
+    is_Tensor = False
 
     @property
     @deprecated(useinstead="is_Float", issue=1721, deprecated_since_version="0.7.0")

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -70,7 +70,6 @@ class Basic(object):
     is_Boolean = False
     is_Not = False
     is_Matrix = False
-    is_Tensor = False
 
     @property
     @deprecated(useinstead="is_Float", issue=1721, deprecated_since_version="0.7.0")

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,6 +2447,47 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
+def test_sympy__tensor__tensor__TensorType():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, TensorType
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    assert _test_args(TensorType([Lorentz], sym))
+
+def test_sympy__tensor__tensor__TensorHead():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, TensorHead
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym)
+    assert _test_args(TensorHead('p', S1, 0))
+
+@SKIP("abstract class")
+def test_sympy__tensor__tensor__TensExpr():
+    pass
+
+def test_sympy__tensor__tensor__TensAdd():
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensAdd
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b = tensor_indices('a,b', Lorentz)
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym)
+    p, q = S1('p,q')
+    t1 = p(a)
+    t2 = q(a)
+    assert _test_args(TensAdd(t1, t2))
+
+
+def test_sympy__tensor__tensor__Tensor():
+    from sympy.core import S
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, Tensor
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b = tensor_indices('a,b', Lorentz)
+    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym)
+    p = S1('p')
+    free, dum =  Tensor.from_indices(a)
+    assert _test_args(Tensor(S.One, [p], free, dum))
+
+
 
 @XFAIL
 def test_as_coeff_add():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2450,7 +2450,7 @@ def test_sympy__tensor__indexed__IndexedBase():
 def test_sympy__tensor__tensor__TensorIndexType():
     from sympy.tensor.tensor import TensorIndexType
     from sympy import Symbol
-    assert _test_args(TensorIndexType(Symbol('Lorentz'), metric_sym=S.Zero))
+    assert _test_args(TensorIndexType(Symbol('Lorentz'), metric_antisym=S.Zero))
 
 @XFAIL
 def test_sympy__tensor__tensor__TensorSymmetry():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,18 +2447,37 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
+@XFAIL
+def test_sympy__tensor__tensor__TensorIndexType():
+    from sympy.tensor.tensor import TensorIndexType
+    assert _test_args(TensorIndexType('Lorentz', dummy_fmt='L'))
+
+@XFAIL
+def test_sympy__tensor__tensor__TensorSymmetry():
+    from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    assert _test_args(TensorSymmetry(get_symmetric_group_sgs(2)))
+
+
+@XFAIL
 def test_sympy__tensor__tensor__TensorType():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, TensorType
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     assert _test_args(TensorType([Lorentz], sym))
 
+@XFAIL
 def test_sympy__tensor__tensor__TensorHead():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, TensorHead
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     assert _test_args(TensorHead('p', S1, 0))
+
+@XFAIL
+def test_sympy__tensor__tensor__TensorIndex():
+    from sympy.tensor.tensor import TensorIndexType, TensorIndex, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    assert _test_args(TensorIndex('i', Lorentz))
 
 @SKIP("abstract class")
 def test_sympy__tensor__tensor__TensExpr():
@@ -2476,16 +2495,16 @@ def test_sympy__tensor__tensor__TensAdd():
     assert _test_args(TensAdd(t1, t2))
 
 
-def test_sympy__tensor__tensor__Tensor():
+def test_sympy__tensor__tensor__TensMul():
     from sympy.core import S
-    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, Tensor
+    from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensMul
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)
     sym = TensorSymmetry(get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     p = S1('p')
-    free, dum =  Tensor.from_indices(a)
-    assert _test_args(Tensor(S.One, [p], free, dum))
+    free, dum =  TensMul.from_indices(a)
+    assert _test_args(TensMul(S.One, [p], free, dum))
 
 
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,10 +2447,10 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
-@XFAIL
 def test_sympy__tensor__tensor__TensorIndexType():
     from sympy.tensor.tensor import TensorIndexType
-    assert _test_args(TensorIndexType('Lorentz', dummy_fmt='L'))
+    from sympy import Symbol
+    assert _test_args(TensorIndexType(Symbol('Lorentz'), metric_sym=S.Zero))
 
 @XFAIL
 def test_sympy__tensor__tensor__TensorSymmetry():

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2447,10 +2447,11 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
+@XFAIL
 def test_sympy__tensor__tensor__TensorIndexType():
     from sympy.tensor.tensor import TensorIndexType
     from sympy import Symbol
-    assert _test_args(TensorIndexType(Symbol('Lorentz'), metric_antisym=S.Zero))
+    assert _test_args(TensorIndexType('Lorentz', metric=False))
 
 @XFAIL
 def test_sympy__tensor__tensor__TensorSymmetry():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -338,6 +338,9 @@ class StrPrinter(Printer):
     def _print_TensorIndex(self, expr):
         return expr._pretty()
 
+    def _print_TensorHead(self, expr):
+        return expr._pretty()
+
     def _print_TensMul(self, expr):
         return expr._pretty()
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -335,7 +335,10 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
-    def _print_Tensor(self, expr):
+    def _print_TensorIndex(self, expr):
+        return expr._pretty()
+
+    def _print_TensMul(self, expr):
         return expr._pretty()
 
     def _print_TensAdd(self, expr):

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -335,6 +335,12 @@ class StrPrinter(Printer):
                 use = trim
             return 'Permutation(%s)' % use
 
+    def _print_Tensor(self, expr):
+        return expr._pretty()
+
+    def _print_TensAdd(self, expr):
+        return expr._pretty()
+
     def _print_PermutationGroup(self, expr):
         p = ['    %s' % str(a) for a in expr.args]
         return 'PermutationGroup([\n%s])' % ',\n'.join(p)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -22,7 +22,8 @@ The contracted indices are dummy indices, internally they have no name,
 the indices being represented by a graph-like structure.
 
 Tensors are put in canonical form using ``canon_bp``, which uses
-the Butler-Portugal algorithm for canonicalization.
+the Butler-Portugal algorithm for canonicalization using the monoterm
+symmetries of the tensors.
 
 If there is a (anti)symmetric metric, the indices can be raised and
 lowered when the tensor is put in canonical form.
@@ -450,7 +451,7 @@ def tensor_indices(s, typ):
 
 class TensorSymmetry(Basic):
     """
-    Symmetry of a tensor
+    Monoterm symmetry of a tensor
 
     Parameters
     ==========
@@ -467,7 +468,9 @@ class TensorSymmetry(Basic):
     Notes
     =====
 
-    A tensor can have an arbitrary symmetry provided by its BSGS.
+    A tensor can have an arbitrary monoterm symmetry provided by its BSGS.
+    Multiterm symmetries, like the cyclic symmetry of the Riemann tensor,
+    are not covered.
 
     See Also
     ========
@@ -511,20 +514,33 @@ def tensorsymmetry(*args):
     """
     Return a ``TensorSymmetry`` object.
 
-    One can represent a tensor with any slot symmetry group using a BSGS
+    One can represent a tensor with any monoterm slot symmetry group
+    using a BSGS.
+
     ``args`` can be a BSGS
     ``args[0]``    base
     ``args[1]``    sgs
 
-    Usually tensors are in (direct products of) irreducible representations
+    Usually tensors are in (direct products of) representations
     of the symmetric group;
-    ``args`` can be a list of lists representing Young tableaux
+    ``args`` can be a list of lists representing the shapes of Young tableaux
+
+    Notes
+    =====
+
+    For instance:
     ``[[1]]``       vector
     ``[[1]*n]``     symmetric tensor of rank ``n``
-    ``[[n]``        antisymmetric tensor of rank ``n``
-    ``[[2, 2]]``    slot symmetry of the Riemann tensor
+    ``[[n]]``       antisymmetric tensor of rank ``n``
+    ``[[2, 2]]``    monoterm slot symmetry of the Riemann tensor
     ``[[1],[1]]``   vector*vector
+    ``[[2],[1],[1]`` (antisymmetric tensor)*vector*vector
 
+    Notice that with the shape ``[2, 2]`` we associate only the monoterm
+    symmetries of the Riemann tensor; this is an abuse of notation,
+    since the shape ``[2, 2]`` corresponds usually to the irreducible
+    representation characterized by the monoterm symmetries and by the
+    cyclic symmetry.
 
     Examples
     ========

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -701,14 +701,17 @@ class TensAdd(TensExpr):
         if len(args) == 1 and args[0].is_TensMul:
             obj._args = tuple(args)
             return obj
-        args.sort(key=lambda x: (x._components, x._free, x._dum))
         args = [x.canon_bp() for x in args if x]
         args = [x for x in args if x]
         if not args:
             return S.Zero
+
+        # collect canonicalized terms
+        args.sort(key=lambda x: (x._components, x._free, x._dum))
         a = _tensAdd_collect_terms(args)
         if not a:
             return S.Zero
+        # it there is only a component tensor return it
         if len(a) == 1:
             return a[0]
         obj._args = tuple(a)
@@ -799,7 +802,7 @@ class TensAdd(TensExpr):
         if len(args) == 1:
             return args[0]
         t = TensAdd(*args)
-        return t.canon_bp()
+        return canon_bp(t)
 
 
     def fun_eval(self, *index_tuples, **kwargs):
@@ -1266,7 +1269,7 @@ class TensMul(TensExpr):
             return S.Zero
         return t.perm2tensor(can, True)
 
-    def _contract(self, g, antisym, contract_all=False, onlydelta=False):
+    def _contract(self, g, antisym, contract_all=False):
         """
         helper method for ``contract_metric`` and ``contract_delta``
 
@@ -1285,30 +1288,19 @@ class TensMul(TensExpr):
         # if a component tensor of a has 2 dummy indices, it is g(d,-d) = dim
         for i, tg in enumerate(a):
             if tg._components[0] == g:
-                tg_free_indices = [x[0] for x in tg._free]
-                if onlydelta and tg_free_indices[0].is_up == tg_free_indices[1].is_up:
-                    continue
-                if len(tg_free_indices) == 0:
-                    # g is contracted with itself
-                    a1 = a[:i] + a[i + 1:]
-                    t11 = tensor_mul(*a1)
-                    if typ.dim is None:
-                        raise ValueError('dimension not assigned')
-                    coeff = typ.dim*a[i]._coeff
-                    if antisym and tg._dum[0][0] == 0:
-                        # g(i, -i) = -D
-                        coeff = -coeff
-                    t = tensor_mul(*a1)*coeff
+                tg_free = [x[0] for x in tg._free]
+                if len(tg_free) == 0:
+                    t = _contract_g_with_itself(a, i, tg, tg_free, g, antisym)
                     if contract_all == True and g in t._components:
                         return t._contract(g, antisym, True)
                     return t
 
-                if all(indx in free_indices for indx in tg_free_indices):
+                if all(indx in free_indices for indx in tg_free):
                     continue
                 else:
                     break
         else:
-        # if all metric tensors have only free indices, there is no contraction
+            # all metric tensors have only free indices, there is no contraction
             return self
 
         # tg has one or two indices contracted with other tensors
@@ -1331,12 +1323,7 @@ class TensMul(TensExpr):
 
     def contract_delta(self, delta):
         typ = delta.types[0]
-        g = typ.metric
-        if g:
-            antisym = typ.metric_antisym
-            t = self._contract(g, antisym, contract_all=True, onlydelta=True)
-        else:
-            t = self._contract(delta, None, True)
+        t = self._contract(delta, None, True)
         return t
 
     def contract_metric(self, g, contract_all=False):
@@ -1534,6 +1521,22 @@ def riemann_cyclic(t2):
         return t3
     else:
         return canon_bp(t3)
+
+def _contract_g_with_itself(a, i, tg, tg_free, g, antisym):
+    """
+    helper function for _contract
+    """
+    typ = g.index_types[0]
+    a1 = a[:i] + a[i + 1:]
+    t11 = tensor_mul(*a1)
+    if typ.dim is None:
+        raise ValueError('dimension not assigned')
+    coeff = typ.dim*a[i]._coeff
+    if antisym and tg._dum[0][0] == 0:
+        # g(i, -i) = -D
+        coeff = -coeff
+    t = tensor_mul(*a1)*coeff
+    return t
 
 
 def _contract_g_with_free_index(a, free_indices, i, tg, tg_free, g, antisym):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -469,6 +469,20 @@ class TensExpr(Basic):
 class TensAdd(TensExpr):
     """
     Sum of tensors
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensAdd
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b = tensor_indices('a,b', Lorentz)
+    >>> sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    >>> S1 = TensorType([Lorentz], sym)
+    >>> p, q = S1('p,q')
+    >>> t1 = p(a)
+    >>> t2 = q(a)
+    >>> t1 + t2
+    p(a) + q(a)
     """
     is_Tensor = True
     is_TensAdd = True

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -380,7 +380,7 @@ class TensorIndex(Basic):
 
 def tensor_indices(s, typ):
     """
-    Returns list of tensor indices given their names and the types
+    Returns list of tensor indices given their names and their types
 
     Parameters
     ==========
@@ -461,9 +461,6 @@ class TensorSymmetry(Basic):
     def _hashable_content(self):
         r = (tuple(self.base), tuple(self.generators))
         return r
-
-    def __hash__(self):
-        return Basic.__hash__(self)
 
 def tensorsymmetry(*args):
     """
@@ -715,6 +712,10 @@ class TensorHead(Basic):
         return self.symmetry
 
     @property
+    def typ(self):
+        return self.args[1]
+
+    @property
     def comm(self):
         return self._comm
 
@@ -728,9 +729,6 @@ class TensorHead(Basic):
     def _hashable_content(self):
         r = (self.name, tuple(self._types), self._symmetry, self._comm)
         return r
-
-    def __hash__(self):
-        return Basic.__hash__(self)
 
     def commutes_with(self, other):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -66,6 +66,8 @@ class TensorIndexType(object):
         epsilon = Sdim('Eps')
         return epsilon
 
+    def __lt__(self, other):
+        return self.name < other.name
 
     def __str__(self):
         return self.name
@@ -118,6 +120,9 @@ class TensorIndex(object):
 
     def __ne__(self, other):
         return not (self == other)
+
+    def __lt__(self, other):
+        return (self.tensortype, self.name) < (other.tensortype, other.name)
 
     def __neg__(self):
         t1 = TensorIndex(self.name, self.tensortype,
@@ -273,6 +278,9 @@ class TensorHead(Basic):
 
     def __ne__(self, other):
         return not (self == other)
+
+    def __lt__(self, other):
+        return (self.name, self.index_types) < (other.name, other.index_types)
 
     def commutes_with(self, other):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -668,11 +668,11 @@ class TensAdd(TensExpr):
             obj._args = tuple(args)
             return obj
         args.sort(key=lambda x: (x._components, x._free, x._dum))
-        a = _tensAdd_collect_terms(args)
-        if not a:
+        args = [x.canon_bp() for x in args if x]
+        args = [x for x in args if x]
+        if not args:
             return S.Zero
-        a = [canon_bp(x) for x in a]
-        a = [x for x in a if x]
+        a = _tensAdd_collect_terms(args)
         if not a:
             return S.Zero
         if len(a) == 1:
@@ -714,7 +714,7 @@ class TensAdd(TensExpr):
         if len(args) == 1:
             return args[0]
         t = TensAdd(*args)
-        return t.canon_bp()
+        return canon_bp(t)
 
     def contract_metric(self, g, contract_all=False):
         """
@@ -926,6 +926,8 @@ class TensMul(TensExpr):
         indices = self.get_indices()
         pos = 0
         components = self._components
+        if not components:
+            return [TensMul(self._coeff, [], [], [])]
         res = []
         for t in self._components:
             t1 = t(*indices[pos:pos + t.rank])

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -191,7 +191,7 @@ class TensorIndexType(Basic):
     def __new__(cls, name, metric=False, dim=None, eps_dim = None,
                  dummy_fmt=None):
         """
-        name   name of the tensor type
+        ``name``   name of the tensor type
 
         ``metric``: it can be True, False, None or another object
         If it is True, False, None it gives its antisymmetry:
@@ -387,8 +387,6 @@ def tensorsymmetry(*args):
     Examples
     ========
 
-    Symmetric tensor using a BSBS
-
     Symmetric tensor using a Young tableau
 
     >>> from sympy.tensor.tensor import TensorIndexType, TensorType, tensorsymmetry
@@ -419,7 +417,6 @@ def tensorsymmetry(*args):
             else:
                 raise NotImplementedError
         return bsgs
-
 
     if not args:
         return TensorSymmetry([[], [Permutation(2)]])

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4,35 +4,42 @@ from sympy.core.symbol import Symbol, symbols
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
 
 
+def is_Tensor(x):
+    return isinstance(x, TensExpr)
+
+
 class TensorIndexType(Basic):
     """
-    A TensorIndexType is characterized by its name, by metric_antisym,
-    giving the symmetry of its metric.
+    A TensorIndexType is characterized by its name and its metric.
 
-    ``metric_antisym = False`` symmetric metric (in Riemannian geometry)
+    ``metric = False`` symmetric metric (in Riemannian geometry)
 
-    ``metric_antisym = True`` antisymmetric metric (for spinor calculus)
+    ``metric = True`` antisymmetric metric (for spinor calculus)
 
     In these two cases the metric is used to raise and lower indices.
 
-    ``metric_antisym = None``  there is no metric;
+    ``metric = None``  there is no metric;
     it is not possible to raise or lower indices;
     e.g. the index of the defining representation of ``SU(N)``
     is 'covariant' and the conjugate representation is
     'contravariant'; for ``N > 2`` they are linearly independent.
 
+    ``metric`` can be an object having ``name`` and ``antisym`` attributes.
 
     If a dimension ``dim`` is defined, it can be a symbol or an integer.
     """
-    def __new__(cls, name, metric_antisym=False, dim=None, eps_dim = None,
+    def __new__(cls, name, metric=False, dim=None, eps_dim = None,
                  dummy_fmt=None):
         """
         name   name of the tensor type
 
-        ``metric_antisym``:
-        False      symmetric
+        ``metric``: it can be True, False, None or another object
+        If it is True, False, None it gives its antisymmetry:
+        False      symmetric metric
         True       antisymmetric
-        None       no symmetry
+        None       no metric
+
+        Otherwise, ``metric`` must have attributes ``name`` and ``antisym``
 
         ``dim``    dimension, it can be a symbol or a positive integer
 
@@ -50,27 +57,38 @@ class TensorIndexType(Basic):
         >>> from sympy.tensor.tensor import TensorIndexType
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         """
-        obj = Basic.__new__(cls, name, metric_antisym)
+        obj = Basic.__new__(cls, name, metric)
         if not dummy_fmt:
             obj.dummy_fmt = '%s_%%d' % obj.name
         else:
             obj.dummy_fmt = '%s_%%d' % dummy_fmt
-        obj.metric = obj.get_metric()
+        if metric is None:
+            obj.metric_antisym = None
+        else:
+            if metric in (True, False, 0, 1):
+                metric_name = 'metric'
+                obj.metric_antisym = metric
+            else:
+                metric_name = metric.name
+                obj.metric_antisym = metric.antisym
+            sym2 = TensorSymmetry(get_symmetric_group_sgs(2, obj.metric_antisym))
+            S2 = TensorType([obj]*2, sym2)
+            obj.metric = S2(metric_name)
+
         obj.dim = dim
+        obj.delta = obj.get_kronecker_delta()
         obj.eps_dim = eps_dim if eps_dim else dim
         obj.epsilon = obj.get_epsilon()
         return obj
 
     name = property(lambda self: self.args[0])
-    metric_antisym = property(lambda self: self.args[1])
 
-    def get_metric(self):
-        if self.metric_antisym is None:
-            return None
-        sym2 = TensorSymmetry(get_symmetric_group_sgs(2, self.metric_antisym))
+
+    def get_kronecker_delta(self):
+        sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
         S2 = TensorType([self]*2, sym2)
-        metric = S2('metric')
-        return metric
+        delta = S2('KD')
+        return delta
 
     def get_epsilon(self):
         if not isinstance(self.eps_dim, int):
@@ -365,8 +383,6 @@ class TensExpr(Basic):
     """
 
     _op_priority = 11.0
-    is_Tensor = True
-    is_TensExpr = True
     is_TensMul = False
     is_TensAdd = False
     is_commutative = False
@@ -415,7 +431,7 @@ class TensExpr(Basic):
 
     def __div__(self, other):
         other = sympify(other)
-        if other.is_Tensor:
+        if is_Tensor(other):
             raise ValueError('cannot divide by a tensor')
         coeff = self._coeff/other
         return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
@@ -516,16 +532,16 @@ def _tensAdd_flatten(args):
     """
     flatten TensAdd, coerce terms which are not tensors to tensors
     """
-    if not all(x.is_Tensor for x in args):
+    if not all(is_Tensor(x) for x in args):
         args1 = []
         for x in args:
-            if x.is_Tensor:
+            if is_Tensor(x):
                 if x.is_TensAdd:
                     args1.extend(list(x.args))
                 else:
                     args1.append(x)
-        args1 = [x for x in args1 if x.is_Tensor and x._coeff]
-        args2 = [x for x in args if not x.is_Tensor]
+        args1 = [x for x in args1 if is_Tensor(x) and x._coeff]
+        args2 = [x for x in args if not is_Tensor(x)]
         t0 = args1[0]
         if t0.is_TensAdd:
             t0 = t0.args[0]
@@ -572,7 +588,6 @@ class TensAdd(TensExpr):
     >>> t1 + t2
     p(a) + q(a)
     """
-    is_Tensor = True
     is_TensAdd = True
 
     def __new__(cls, *args, **kw_args):
@@ -613,13 +628,13 @@ class TensAdd(TensExpr):
 
     def __eq__(self, other):
         other = sympify(other)
-        if not other.is_Tensor:
+        if not is_Tensor(other):
             if len(self.args) == 1:
                 return self.args[0]._coeff == other
-        if other.is_Tensor and other.is_TensMul and other._coeff == 0:
+        if is_Tensor(other) and other.is_TensMul and other._coeff == 0:
             return self == 0
         t = self - other
-        if not t.is_Tensor:
+        if not is_Tensor(t):
             return t == 0
         else:
             if t.is_TensMul:
@@ -629,6 +644,13 @@ class TensAdd(TensExpr):
 
     def __ne__(self, other):
         return not (self == other)
+
+    def contract_delta(self, delta):
+        args = [x.contract_delta(delta) for x in self.args]
+        if len(args) == 1:
+            return args[0]
+        t = TensAdd(*args)
+        return t.canon_bp()
 
     def contract_metric(self, g, contract_all=False):
         """
@@ -659,7 +681,6 @@ class TensMul(TensExpr):
     """
     Product of tensors
     """
-    is_Tensor = True
     is_TensMul = True
 
     def __new__(cls, coeff, *args, **kw_args):
@@ -696,7 +717,7 @@ class TensMul(TensExpr):
         if other == 0:
             return self._coeff == 0
         other = sympify(other)
-        if not other.is_Tensor :
+        if not is_Tensor(other):
             return False
         res = self - other
         return res == 0
@@ -925,7 +946,7 @@ class TensMul(TensExpr):
         p(L_0)*q(-L_0)
         """
         other = sympify(other)
-        if not other.is_Tensor:
+        if not is_Tensor(other):
             coeff = self._coeff*other
             return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
         if other.is_TensAdd:
@@ -1075,34 +1096,7 @@ class TensMul(TensExpr):
             return S.Zero
         return t.perm2tensor(can, True)
 
-
-    def contract_metric(self, g, contract_all=False):
-        """
-        Raise or lower indices with the metric ``g``
-
-        ``g``  metric
-
-        ``contract_all`` if True, eliminate all ``g`` which are contracted
-
-        Examples
-        ========
-
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
-        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-        >>> S1 = TensorType([Lorentz], sym1)
-        >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
-        >>> t = p(m0)*q(m1)*g(-m0, -m1)
-        >>> t.canon_bp()
-        metric(L_0, L_1)*p(-L_0)*q(-L_1)
-        >>> t.contract_metric(g).canon_bp()
-        p(L_0)*q(-L_0)
-        """
-        if g.index_types[0].metric_antisym != 0:
-            # TODO case of antisymmetric metric
-            raise NotImplementedError
+    def contract(self, g, is_metric, contract_all=False):
         if not self._components:
             return self
         free_indices = [x[0] for x in self._free]
@@ -1116,19 +1110,21 @@ class TensMul(TensExpr):
                     a1 = a[:i] + a[i + 1:]
                     t = tensor_mul(*a1)*(typ.dim*a[i]._coeff)
                     if contract_all == True and g in t._components:
-                        return t.contract_metric(g, True)
+                        return t.contract(g, is_metric, True)
                     return t
 
         # if all metric tensors have only free indices, there is no contraction
         for i, tg in enumerate(a):
             if tg._components[0] == g:
                 tg_free_indices = [x[0] for x in tg._free]
+                if not is_metric:
+                    if tg_free_indices[0].is_contravariant == tg_free_indices[1].is_contravariant:
+                        raise ValueError('both indices are (contra)variant')
                 if all(indx in free_indices for indx in tg_free_indices):
                     continue
                 break
         else:
             return self
-
         # tg has one or two indices contracted with other tensors
         # i position of tg in a
         coeff = S.One
@@ -1180,7 +1176,7 @@ class TensMul(TensExpr):
                         res = coeff*typ.dim*tg._coeff*ty._coeff
                         res = TensMul(res, [],[],[], is_canon_bp=True)
                     if contract_all == True and g in res._components:
-                        return res.contract_metric(g, True)
+                        return res.contract(g, is_metric, True)
                     return res
 
             free2 = []
@@ -1196,8 +1192,40 @@ class TensMul(TensExpr):
             res = tensor_mul(*a)
         res = coeff*res
         if contract_all == True and g in res._components:
-            return res.contract_metric(g, True)
+            return res.contract(g, is_metric, True)
         return res
+
+    def contract_delta(self, delta):
+        return self.contract(delta, False, True)
+
+    def contract_metric(self, g, contract_all=False):
+        """
+        Raise or lower indices with the metric ``g``
+
+        ``g``  metric
+
+        ``contract_all`` if True, eliminate all ``g`` which are contracted
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> g = Lorentz.metric
+        >>> p, q = S1('p,q')
+        >>> t = p(m0)*q(m1)*g(-m0, -m1)
+        >>> t.canon_bp()
+        metric(L_0, L_1)*p(-L_0)*q(-L_1)
+        >>> t.contract_metric(g).canon_bp()
+        p(L_0)*q(-L_0)
+        """
+        if g.index_types[0].metric_antisym != 0:
+            # TODO case of antisymmetric metric
+            raise NotImplementedError
+        return self.contract(g, True, contract_all)
 
 
     def _pretty(self):
@@ -1228,7 +1256,7 @@ def canon_bp(p):
     """
     Butler-Portugal canonicalization
     """
-    if p.is_Tensor:
+    if is_Tensor(p):
         return p.canon_bp()
     return p
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -368,6 +368,9 @@ class TensorSymmetry(Basic):
         r = (tuple(self.base), tuple(self.generators))
         return r
 
+    def __hash__(self):
+        return Basic.__hash__(self)
+
 def tensorsymmetry(*args):
     """
     return a ``TensorSymmetry`` object
@@ -573,6 +576,9 @@ class TensorHead(Basic):
     def _hashable_content(self):
         r = (self.name, tuple(self.types), self.symmetry, self.comm)
         return r
+
+    def __hash__(self):
+        return Basic.__hash__(self)
 
     def commutes_with(self, other):
         """
@@ -932,6 +938,9 @@ class TensAdd(TensExpr):
     def _hashable_content(self):
         return tuple(self.args)
 
+    def __hash__(self):
+        return Basic.__hash__(self)
+
     def __ne__(self, other):
         return not (self == other)
 
@@ -1048,6 +1057,9 @@ class TensMul(TensExpr):
         r = (t._coeff, tuple(t._components), \
                 tuple(sorted(t._free)), tuple(sorted(t._dum)))
         return r
+
+    def __hash__(self):
+        return Basic.__hash__(self)
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -340,6 +340,37 @@ class TensorType(Basic):
         else:
             return [TensorHead(name, self, anticommuting) for name in names]
 
+
+def tensorhead(name, typ, sym, anticommuting=False):
+    """
+    Function generating tensorhead(s).
+
+    ``name`` name or sequence of names (as in ``symbol``)
+
+    ``typ``  index types
+
+    ``sym``  same as ``*args`` in ``tensorsymmetry``
+
+    ``anticommuting``:
+        None     no commutation rule
+        False    commutes
+        True     anticommutes
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b = tensor_indices('a,b', Lorentz)
+    >>> A = tensorhead('A', [Lorentz]*2, [[1]*2])
+    >>> A(a, -b)
+    A(a, -b)
+
+    """
+    sym = tensorsymmetry(*sym)
+    S = TensorType(typ, sym)
+    return S(name, anticommuting)
+
+
 class TensorHead(Basic):
     is_commutative = False
 
@@ -407,12 +438,10 @@ class TensorHead(Basic):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> a, b = tensor_indices('a,b', Lorentz)
-        >>> sym2 = tensorsymmetry([1]*2)
-        >>> S2 = TensorType([Lorentz]*2, sym2)
-        >>> A = S2('A')
+        >>> A = tensorhead('A', [Lorentz]*2, [[1]*2])
         >>> t = A(a, -b)
         """
         assert [indices[i].tensortype for i in range(len(indices))] == self.index_types
@@ -513,13 +542,10 @@ class TensExpr(Basic):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
-        >>> sym2 = tensorsymmetry([1]*2)
-        >>> S2 = TensorType([Lorentz]*2, sym2)
-        >>> A, B = S2('A,B')
+        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
         >>> t = A(i, k)*B(-k, -j); t
         A(i, L_0)*B(-L_0, -j)
         >>> t.substitute_indices((i,j), (j, k))
@@ -640,12 +666,10 @@ class TensAdd(TensExpr):
     Examples
     ========
 
-    >>> from sympy.tensor.tensor import TensorIndexType, tensorsymmetry, TensorType, tensor_indices, TensAdd
+    >>> from sympy.tensor.tensor import TensorIndexType, tensorhead, tensor_indices
     >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     >>> a, b = tensor_indices('a,b', Lorentz)
-    >>> sym = tensorsymmetry([1])
-    >>> S1 = TensorType([Lorentz], sym)
-    >>> p, q = S1('p,q')
+    >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
     >>> t1 = p(a)
     >>> t2 = q(a)
     >>> t1 + t2
@@ -860,13 +884,11 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = tensorsymmetry([1])
-        >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
+        >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t = p(m1)*g(m0,m2)
         >>> t.get_indices()
         [m1, m0, m2]
@@ -911,12 +933,10 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
-        >>> sym2 = tensorsymmetry([1]*2)
-        >>> S2 = TensorType([Lorentz]*2, sym2)
-        >>> A, B = S2('A,B')
+        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
         >>> t = A(a,b)*B(-b,c)
         >>> t
         A(a, L_0)*B(-L_0, c)
@@ -1008,13 +1028,11 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = tensorsymmetry([1])
-        >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
+        >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t1 = p(m0)
         >>> t2 = q(-m0)
         >>> t1*t2
@@ -1146,12 +1164,10 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym2a = tensorsymmetry([2])
-        >>> S2 = TensorType([Lorentz]*2, sym2a)
-        >>> A = S2('A')
+        >>> A = tensorhead('A', [Lorentz]*2, [[2]])
         >>> t = A(m0,-m1)*A(m1,-m0)
         >>> t.canon_bp()
         -A(L_0, L_1)*A(-L_0, -L_1)
@@ -1304,13 +1320,11 @@ class TensMul(TensExpr):
         Examples
         ========
 
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
         >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
         >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
-        >>> sym1 = tensorsymmetry([1])
-        >>> S1 = TensorType([Lorentz], sym1)
         >>> g = Lorentz.metric
-        >>> p, q = S1('p,q')
+        >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t = p(m0)*q(m1)*g(-m0, -m1)
         >>> t.canon_bp()
         metric(L_0, L_1)*p(-L_0)*q(-L_1)
@@ -1413,12 +1427,10 @@ def riemann_cyclic(t2):
     Examples
     ========
 
-    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorsymmetry, TensorType, riemann_cyclic
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead, riemann_cyclic
     >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
-    >>> symr = tensorsymmetry([2, 2])
-    >>> R4 = TensorType([Lorentz]*4, symr)
-    >>> R = R4('R')
+    >>> R = tensorhead('R', [Lorentz]*4, [[2, 2]])
     >>> t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
     >>> riemann_cyclic(t)
     0

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -50,6 +50,9 @@ class _TensorManager(object):
     Other groups can be defined using `set_comm`.
     """
     def __init__(self):
+        self._comm_init()
+
+    def _comm_init(self):
         self._comm = defaultdict(dict)
         self._comm[0][0] = 0
         self._comm[0][1] = 0
@@ -60,6 +63,10 @@ class _TensorManager(object):
         self._comm[1][2] = None
         self._comm_symbols2i = {0:0, 1:1, 2:2}
         self._comm_i2symbol = {0:0, 1:1, 2:2}
+
+    @property
+    def comm(self):
+        return self._comm
 
     def comm_symbols2i(self, i):
         """
@@ -72,6 +79,7 @@ class _TensorManager(object):
             self._comm[n][0] = 0
             self._comm[0][n] = 0
             self._comm_symbols2i[i] = n
+            self._comm_i2symbol[n] = i
             return n
         return self._comm_symbols2i[i]
 
@@ -125,7 +133,7 @@ class _TensorManager(object):
             self._comm[0][n] = 0
             self._comm_symbols2i[i] = n
             self._comm_i2symbol[n] = i
-        if j not in self._comm.keys():
+        if j not in self._comm_symbols2i:
             n = len(self._comm_symbols2i)
             self._comm[0][n] = 0
             self._comm[n][0] = 0
@@ -154,8 +162,8 @@ class _TensorManager(object):
             return None
 
     def clear(self):
-        for i in range(3, len(self._comm)):
-            self._comm[i].clear()
+        self._comm_init()
+
 
 TensorManager = _TensorManager()
 
@@ -466,6 +474,7 @@ class TensorSymmetry(Basic):
     def _hashable_content(self):
         r = (tuple(self.base), tuple(self.generators))
         return r
+
 
 def tensorsymmetry(*args):
     """
@@ -802,28 +811,28 @@ class TensExpr(Basic):
     is_commutative = False
 
     def __neg__(self):
-        return (-1)*self
+        return self*S.NegativeOne
 
     def __abs__(self):
         raise NotImplementedError
 
     def __add__(self, other):
-        return TensAdd(self, other)
+        raise NotImplementedError
 
     def __radd__(self, other):
-        return TensAdd(other, self)
+        raise NotImplementedError
 
     def __sub__(self, other):
-        return TensAdd(self, -other)
+        raise NotImplementedError
 
     def __rsub__(self, other):
-        return TensAdd(other, -self)
+        raise NotImplementedError
 
     def __mul__(self, other):
         raise NotImplementedError
 
     def __rmul__(self, other):
-        return TensAdd(*[x*other for x in self.args])
+        return self*other
 
     def __pow__(self, other):
         raise NotImplementedError
@@ -993,7 +1002,6 @@ class TensAdd(TensExpr):
     def rank(self):
         return self.args[0]._rank
 
-
     def __call__(self, *indices):
         """Returns tensor with ordered free indices replaced by ``indices``
 
@@ -1060,6 +1068,15 @@ class TensAdd(TensExpr):
         other = sympify(other)
         args = self.args + (other,)
         return TensAdd(*args)
+
+    def __radd__(self, other):
+        return TensAdd(other, self)
+
+    def __sub__(self, other):
+        return TensAdd(self, -other)
+
+    def __rsub__(self, other):
+        return TensAdd(other, -self)
 
     def __mul__(self, other):
         return TensAdd(*[x*other for x in self.args])
@@ -1479,6 +1496,18 @@ class TensMul(TensExpr):
                 comm = TensorManager.get_comm(h._comm, h._comm)
             v.append((h._symmetry.base, h._symmetry.generators, n, comm))
         return _af_new(g), dummies, msym, v
+
+    def __add__(self, other):
+        return TensAdd(self, other)
+
+    def __radd__(self, other):
+        return TensAdd(other, self)
+
+    def __sub__(self, other):
+        return TensAdd(self, -other)
+
+    def __rsub__(self, other):
+        return TensAdd(other, -self)
 
     def __mul__(self, other):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1,37 +1,32 @@
 from collections import defaultdict
-from sympy.combinatorics.perm_groups import PermutationGroup
-from sympy.combinatorics.permutations import Permutation, _af_new, _af_invert
-from sympy.core import Basic, Symbol, sympify, Add, Mul, S, Rational
-from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, canonical_free, riemann_bsgs
-
-from functools import wraps
-
-from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic
-from sympy.core.decorators import call_highest_priority
-from sympy.core.sympify import SympifyError
-from sympy.matrices import ShapeError
-from sympy.simplify import simplify
-from sympy import cacheit
+from sympy.core import Basic, sympify, Add, Mul, S
+from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
 
 class TensorIndexType(object):
+    """
+    A TensorIndexType is characterized by its name, by metric_sym,
+    giving the symmetry of its metric.
+
+    If a dimension ``dim`` is defined, it can be a symbol or an integer.
+    """
     def __init__(self, name, metric_sym=0, dim=None, eps_dim = None,
                  dummy_fmt=None):
         """
         name   name of the tensor type
 
-        ``metric\_sym``:
+        ``metric_sym``:
         0      symmetric
         1      antisymmetric
         None   no symmetry
 
         dim    dimension, it can be a symbol or a positive integer
 
-        ``eps\_dim``  dimension of the epsilon tensor; it is by default
+        ``eps_dim``  dimension of the epsilon tensor; it is by default
                  equal to dim, if the latter is an integer; else
                  it can be assigned (for use in naive dimensional
                  regularization)
 
-        ``dummy\_fmt`` name of the head of dummy indices; by default it is
+        ``dummy_fmt`` name of the head of dummy indices; by default it is
         the name of the tensor type
 
         Examples
@@ -81,10 +76,13 @@ class TensorIndex(object):
     """
     Tensor indices are contructed with the Einstein summation convention.
 
-    An index can be in contravariant or in covariant form; in the latter
-    case it is represented prepending a `-` to the index name.
+    A TensorIndex is chacterized by their ``name``, ``tensortype``
+    and ``is_contravariant``.
 
-    Dummy indices have the head given by `dummy\_fmt`
+    An index can be in contravariant or in covariant form; in the latter
+    case it is represented prepending a ``-`` to the index name.
+
+    Dummy indices have a name with head given by ``tensortype.dummy_fmt``
 
 
     Examples
@@ -113,13 +111,6 @@ class TensorIndex(object):
 
     __repr__ = __str__
 
-    @cacheit
-    def covariant(self):
-        if self.is_contravariant:
-            return TensorIndex(self.name, self.tensortype, False)
-        else:
-            return self
-
     def __eq__(self, other):
         return self.name == other.name and \
                self.tensortype == other.tensortype and \
@@ -128,7 +119,6 @@ class TensorIndex(object):
     def __ne__(self, other):
         return not (self == other)
 
-    @cacheit
     def __neg__(self):
         t1 = TensorIndex(self.name, self.tensortype,
                 (not self.is_contravariant))
@@ -136,7 +126,11 @@ class TensorIndex(object):
 
 def tensor_indices(s, typ):
     """
-    Returns tensor indices given their name
+    Returns tensor indices given their names and the TensorIndexType ``typ``
+
+    ``s`` string of comma separated names of indices
+
+    ``typ`` list of TensorIndexType of the indices
 
     Examples
     ========
@@ -171,29 +165,10 @@ class TensorSymmetry(object):
         self.base, self.generators = bsgs
         self.rank = self.generators[0].size
 
-def _get_index_types(indices):
-    res = []
-    for i in indices:
-        if isinstance(i, TensorIndex):
-            res.append(i.tensortype)
-        elif isinstance(i, TensorIndexType):
-            res.append(i)
-        else:
-            raise NotImplementedError
-    return res
-
-def has_tensor(p):
-    if p.is_Tensor:
-        return True
-    if p.is_Mul or p.is_Add:
-        for x in p.args:
-            if has_tensor(x):
-                return True
-    return False
-
 
 class TensorType(Basic):
     """
+    A TensorType object is characterised by its index types and its symmetry
 
     Examples
     ========
@@ -209,14 +184,14 @@ class TensorType(Basic):
     """
     is_commutative = False
 
-    def __new__(cls, indices, symmetry, **kw_args):
+    def __new__(cls, index_types, symmetry, **kw_args):
         obj = Basic.__new__(cls, **kw_args)
         obj.index_types = []
-        obj.index_types = _get_index_types(indices)
+        obj.index_types = index_types
         obj.types = list(set(obj.index_types))
         obj.types.sort(key=lambda x: x.name)
         obj.symmetry = symmetry
-        assert symmetry.rank == len(indices) + 2
+        assert symmetry.rank == len(index_types) + 2
         return obj
 
     def __str__(self):
@@ -261,6 +236,15 @@ class TensorHead(Basic):
         """
         tensor with given name, index types, symmetry, commutation rule
 
+        ``name`` name of the tensor
+
+        ``typ`` list of TensorIndexType
+
+        ``commuting`` commutation property
+        0     commuting tensor
+        1     anticommuting tensor
+        None  no commutation rule
+
         Examples
         ========
 
@@ -292,8 +276,9 @@ class TensorHead(Basic):
 
     def commutes_with(self, other):
         """
-        Returns 0 (1) if self and other (anti)commute
-        Returns None if self and other do not (anti)commute
+        Returns 0 (1) if self and other (anti)commute.
+
+        Returns None if self and other do not (anti)commute.
 
         TODO: it should be possible to assign rules for commutations
         between tensors, to be used here.
@@ -304,10 +289,6 @@ class TensorHead(Basic):
             return 1
         return None
 
-        #if self.commuting == None or other.commuting == None:
-        #    return None
-        #return self.commuting * other.commuting
-
 
     def __str__(self):
         return '%s(%s)' %(self.name, ','.join([str(x) for x in self.index_types]))
@@ -315,7 +296,7 @@ class TensorHead(Basic):
 
     def __call__(self, *indices):
         """
-        tensor with indices
+        Returns a tensor with indices.
 
         Examples
         ========
@@ -397,8 +378,8 @@ class TensExpr(Basic):
 
     def __rmul__(self, other):
         if self.is_TensMul:
-            coeff = other*self.coeff
-            return Tensor(coeff, self.components, self.free, self.dum)
+            coeff = other*self._coeff
+            return Tensor(coeff, self._components, self._free, self._dum)
         return TensAdd(*[x*other for x in self.args])
 
     def __pow__(self, other):
@@ -411,8 +392,8 @@ class TensExpr(Basic):
         other = sympify(other)
         if other.is_Tensor:
             raise ValueError('cannot divide by a tensor')
-        coeff = self.coeff/other
-        return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+        coeff = self._coeff/other
+        return Tensor(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
 
 
     def __rdiv__(self, other):
@@ -423,7 +404,7 @@ class TensExpr(Basic):
 
     def substitute_indices(self, *index_tuples):
         """
-        Return a tensor with indices substituted according to `index\_tuples`
+        Return a tensor with free indices substituted according to ``index_tuples``
 
         Examples
         ========
@@ -441,23 +422,20 @@ class TensExpr(Basic):
         A(j, L_0)*B(-L_0, -k)
         """
         if self.is_TensMul:
-            free = self.free
+            free = self._free
             free1 = []
-            for i, v in index_tuples:
-                for j, ipos, cpos in free:
+            for j, ipos, cpos in free:
+                for i, v in index_tuples:
                     if i.name == j.name and i.tensortype == j.tensortype:
                         if i.is_contravariant == j.is_contravariant:
                             free1.append((v, ipos, cpos))
                         else:
-                            # replace i with an index with the same covariance of i
-                            if j.is_contravariant:
-                                ind = TensorIndex(v.name, v.tensortype)
-                                free1.append((ind, ipos, cpos))
-                            else:
-                                ind = TensorIndex(v.name, v.tensortype)
-                                ind = -ind
-                                free1.append((ind, ipos, cpos))
-            return Tensor(self.coeff, self.components, free1, self.dum)
+                            free1.append((-v, ipos, cpos))
+                        break
+                else:
+                    free1.append((j, ipos, cpos))
+
+            return Tensor(self._coeff, self._components, free1, self._dum)
         if self.is_TensAdd:
             args = self.args
             args1 = []
@@ -469,6 +447,8 @@ class TensExpr(Basic):
 class TensAdd(TensExpr):
     """
     Sum of tensors
+
+    Sum of more than one tensor are put automatically in canonical form.
 
     Examples
     ========
@@ -493,12 +473,19 @@ class TensAdd(TensExpr):
         """
         args = [sympify(x) for x in args if x]
         if not all(x.is_Tensor for x in args):
-            args1 = [x for x in args if x.is_Tensor and x.coeff]
+            args1 = []
+            for x in args:
+                if x.is_Tensor:
+                    if x.is_TensAdd:
+                        args1.extend(list(x.args))
+                    else:
+                        args1.append(x)
+            args1 = [x for x in args1 if x.is_Tensor and x._coeff]
             args2 = [x for x in args if not x.is_Tensor]
             t0 = args1[0]
             if t0.is_TensAdd:
                 t0 = t0.args[0]
-            if t0.free:
+            if t0._free:
                raise ValueError('all tensors must have the same indices')
             t1 = Tensor(Add(*args2), [], [], [])
             args = [t1] + args1
@@ -509,22 +496,21 @@ class TensAdd(TensExpr):
             else:
                 a.append(x)
         args = a
-        args = [x for x in args if x.coeff]
+        args = [x for x in args if x._coeff]
         if not args:
             return S.Zero
 
-        indices0 = sorted([x[0] for x in args[0].free], key=lambda x: x.name)
-        list_indices = [sorted([y[0] for y in x.free], key=lambda x: x.name) for x in args[1:]]
+        indices0 = sorted([x[0] for x in args[0]._free], key=lambda x: x.name)
+        list_indices = [sorted([y[0] for y in x._free], key=lambda x: x.name) for x in args[1:]]
         if not all(x == indices0 for x in list_indices):
-            print 'ERR list_indices=%s indices0=%s' %(list_indices, indices0)
             raise ValueError('all tensors must have the same indices')
 
         obj = Basic.__new__(cls, **kw_args)
-        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        args.sort(key=lambda x: (x._components, x._free, x._dum))
         a = []
         pprev = None
         prev = args[0]
-        prev_coeff = prev.coeff
+        prev_coeff = prev._coeff
         changed = False
         new = 0
         if len(args) == 1 and args[0].is_TensMul:
@@ -533,9 +519,9 @@ class TensAdd(TensExpr):
 
         for x in args[1:]:
             # if x and prev have the same tensor, update the coeff of prev
-            if x.components == prev.components \
-                    and x.free == prev.free and x.dum == prev.dum:
-                prev_coeff = prev_coeff + x.coeff
+            if x._components == prev._components \
+                    and x._free == prev._free and x._dum == prev._dum:
+                prev_coeff = prev_coeff + x._coeff
                 changed = True
                 op = 0
             else:
@@ -546,18 +532,18 @@ class TensAdd(TensExpr):
                 else:
                     # get a tensor from prev with coeff=prev_coeff and store it
                     if prev_coeff:
-                        t = Tensor(prev_coeff, prev.components,
-                            prev.free, prev.dum)
+                        t = Tensor(prev_coeff, prev._components,
+                            prev._free, prev._dum)
                         a.append(t)
                 # move x to prev
                 op = 1
                 pprev, prev = prev, x
-                pprev_coeff, prev_coeff = prev_coeff, x.coeff
+                pprev_coeff, prev_coeff = prev_coeff, x._coeff
                 changed = False
         # if the case op=0 prev was not stored; store it now
         # in the case op=1 x was not stored; store it now (as prev)
         if op == 0 and prev_coeff:
-            prev = Tensor(prev_coeff, prev.components, prev.free, prev.dum)
+            prev = Tensor(prev_coeff, prev._components, prev._free, prev._dum)
             a.append(prev)
         elif op == 1:
             a.append(prev)
@@ -574,8 +560,12 @@ class TensAdd(TensExpr):
         return obj
 
     def canon_bp(self):
+        """
+        canonicalize using the Butler-Portugal algorithm for canonicalization
+        under monoterm symmetries.
+        """
         args = [x.canon_bp() for x in self.args]
-        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        args.sort(key=lambda x: (x._components, x._free, x._dum))
         res = TensAdd(*args)
         return res
 
@@ -583,17 +573,17 @@ class TensAdd(TensExpr):
         other = sympify(other)
         if not other.is_Tensor:
             if len(self.args) == 1:
-                return self.args[0].coeff == other
-        if other.is_Tensor and other.is_TensMul and other.coeff == 0:
+                return self.args[0]._coeff == other
+        if other.is_Tensor and other.is_TensMul and other._coeff == 0:
             return self == 0
         t = self - other
         if not t.is_Tensor:
             return t == 0
         else:
             if t.is_TensMul:
-                return t.coeff == 0
+                return t._coeff == 0
             else:
-                return all(x.coeff == 0 for x in t.args)
+                return all(x._coeff == 0 for x in t.args)
 
     def __ne__(self, other):
         return not (self == other)
@@ -604,7 +594,7 @@ class TensAdd(TensExpr):
 
         ``g``  metric
 
-        ``contract\_all`` if True, eliminate all ``g`` which are contracted
+        ``contract_all`` if True, eliminate all ``g`` which are contracted
         """
 
         args = [x.contract_metric(g, contract_all) for x in self.args]
@@ -615,17 +605,18 @@ class TensAdd(TensExpr):
 
     def _pretty(self):
         a = []
-        #args = sorted(self.args)
         args = self.args
         for x in args:
             a.append(str(x))
-
         a.sort()
         s = ' + '.join(a)
         s = s.replace('+ -', '- ')
         return s
 
 class Tensor(TensExpr):
+    """
+    Product of tensors
+    """
     is_Tensor = True
     is_TensMul = True
 
@@ -634,63 +625,53 @@ class Tensor(TensExpr):
 
         coeff SymPy expression coefficient of the tensor.
 
-        args[0]   list of TensorHead of the component tensors.
+        ``args[0]``   list of TensorHead of the component tensors.
 
-        args[1]   list of ``(ind, ipos, icomp)``
+        ``args[1]``   list of ``(ind, ipos, icomp)``
         where ``ind`` is a free index, ``ipos`` is the slot position
         of ``ind`` in the ``icomp``-th component tensor.
 
-        args[2] list of tuples representing dummy indices.
+        ``args[2]`` list of tuples representing dummy indices.
         (ipos1, ipos2, icomp1, icomp2) indicates that the contravariant
-        dummy index is the `ipos1` slot position in the `icomp1`-th
+        dummy index is the ``ipos1``-th slot position in the ``icomp1``-th
         component tensor; the corresponding covariant index is
         in the ``ipos2`` slot position in the ``icomp2``-th component tensor.
         """
         obj = Basic.__new__(cls)
-        obj.components = args[0]
+        obj._components = args[0]
         obj.types = []
-        for t in obj.components:
+        for t in obj._components:
             obj.types.extend(t.types)
-        obj.free = args[1]
-        obj.dum = args[2]
-        obj.rank = len(obj.free) + 2*len(obj.dum)
-        obj.coeff = coeff
+        obj._free = args[1]
+        obj._dum = args[2]
+        obj.rank = len(obj._free) + 2*len(obj._dum)
+        obj._coeff = coeff
         obj._is_canon_bp = kw_args.get('is_canon_bp', False)
 
         return obj
 
     def __eq__(self, other):
         if other == 0:
-            return self.coeff == 0
+            return self._coeff == 0
         other = sympify(other)
         if not other.is_Tensor :
             return False
         res = self - other
         return res == 0
 
-        res = self.components == other.components and \
-            sorted(self.free) == sorted(other.free) and \
-            sorted(self.dum) == sorted(other.dum) and self.coeff == other.coeff
-        return res
-
     def __ne__(self, other):
         return not self == other
-
-    @property
-    def set_free_indices(self):
-        return set([x[0] for x in self.free])
 
     @staticmethod
     def from_indices(*indices):
         """
-
         Convert ``indices`` into ``free``, ``dum`` for single component tensor
 
-        free         list of tuples ``(index, pos, 0)``,
+        ``free``     list of tuples ``(index, pos, 0)``,
                      where ``pos`` is the position of index in
                      the list of indices formed by the component tensors
 
-        dum          list of tuples ``(pos_contr, pos_cov, 0, 0)``
+        ``dum``      list of tuples ``(pos_contr, pos_cov, 0, 0)``
 
         Examples
         ========
@@ -747,20 +728,34 @@ class Tensor(TensExpr):
 
         The indices are listed in the order in which they appear in the
         component tensors.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> g = Lorentz.metric
+        >>> p, q = S1('p,q')
+        >>> t = p(m1)*g(m0,m2)
+        >>> t.get_indices()
+        [m1, m0, m2]
         """
         indices = [None]*self.rank
         start = 0
         pos = 0
         vpos = []
-        components = self.components
-        for t in self.components:
+        components = self._components
+        for t in self._components:
             vpos.append(pos)
             pos += t.rank
         cdt = defaultdict(int)
-        for indx, ipos, cpos in self.free:
+        for indx, ipos, cpos in self._free:
             start = vpos[cpos]
             indices[start + ipos] = indx
-        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+        for ipos1, ipos2, cpos1, cpos2 in self._dum:
             start1 = vpos[cpos1]
             start2 = vpos[cpos2]
             typ1 = components[cpos1].index_types[ipos1]
@@ -797,20 +792,20 @@ class Tensor(TensExpr):
         """
         indices = self.get_indices()
         pos = 0
-        components = self.components
+        components = self._components
         res = []
-        for t in self.components:
+        for t in self._components:
             t1 = t(*indices[pos:pos + t.rank])
             pos += t.rank
             res.append(t1)
-        res[0] = Tensor(self.coeff, res[0].components, res[0].free, res[0].dum, is_canon_bp=res[0]._is_canon_bp)
+        res[0] = Tensor(self._coeff, res[0]._components, res[0]._free, res[0]._dum, is_canon_bp=res[0]._is_canon_bp)
         return res
 
     def canon_args(self):
         """
         Returns ``(g, dummies, msym, v)``, the entries of ``canonicalize``
 
-        see ``canonicalize`` in ``tensor\_can.py``
+        see ``canonicalize`` in ``tensor_can.py``
         """
         # to be called after sorted_components
         from sympy.combinatorics.permutations import _af_new
@@ -820,21 +815,21 @@ class Tensor(TensExpr):
         g = [None]*n + [n, n+1]
         pos = 0
         vpos = []
-        components = self.components
-        for t in self.components:
+        components = self._components
+        for t in self._components:
             vpos.append(pos)
             pos += t.rank
-        for i, (indx, ipos, cpos) in enumerate(self.free):
+        for i, (indx, ipos, cpos) in enumerate(self._free):
             pos = vpos[cpos] + ipos
             g[pos] = i
 
-        pos = len(self.free)
-        j = len(self.free)
+        pos = len(self._free)
+        j = len(self._free)
         dummies = []
         prev = None
         a = []
         msym = []
-        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+        for ipos1, ipos2, cpos1, cpos2 in self._dum:
             pos1 = vpos[cpos1] + ipos1
             pos2 = vpos[cpos2] + ipos2
             g[pos1] = j
@@ -869,7 +864,7 @@ class Tensor(TensExpr):
         """
         Multiply two tensors using Einstein summation convention.
 
-        If the two tensors have have an index in common, one contravariant
+        If the two tensors have an index in common, one contravariant
         and the other covariant, in their product the indices are summed
 
         Examples
@@ -889,24 +884,24 @@ class Tensor(TensExpr):
         """
         other = sympify(other)
         if not other.is_Tensor:
-            coeff = self.coeff*other
-            return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+            coeff = self._coeff*other
+            return Tensor(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
         if other.is_TensAdd:
             return TensAdd(*[self*x for x in other.args])
 
-        components = self.components + other.components
+        components = self._components + other._components
         # find out which free indices of self and other are contracted
-        free_dict1 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in self.free])
-        free_dict2 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in other.free])
+        free_dict1 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in self._free])
+        free_dict2 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in other._free])
 
         free_names = set(free_dict1.keys()) & set(free_dict2.keys())
         # find the new `free` and `dum`
-        nc1 = len(self.components)
-        dum2 = [(i1, i2, c1 + nc1, c2 + nc1) for i1, i2, c1, c2 in other.dum]
-        free1 = [(ind, i, c) for ind, i, c in self.free if ind.name not in free_names]
-        free2 = [(ind, i, c + nc1) for ind, i, c in other.free if ind.name not in free_names]
+        nc1 = len(self._components)
+        dum2 = [(i1, i2, c1 + nc1, c2 + nc1) for i1, i2, c1, c2 in other._dum]
+        free1 = [(ind, i, c) for ind, i, c in self._free if ind.name not in free_names]
+        free2 = [(ind, i, c + nc1) for ind, i, c in other._free if ind.name not in free_names]
         free = free1 + free2
-        dum = self.dum + dum2
+        dum = self._dum + dum2
         for name in free_names:
             ipos1, cpos1, ind1 = free_dict1[name]
             ipos2, cpos2, ind2 = free_dict2[name]
@@ -918,7 +913,7 @@ class Tensor(TensExpr):
             else:
                 new_dummy = (ipos2, ipos1, cpos2, cpos1)
             dum.append(new_dummy)
-        coeff = self.coeff*other.coeff
+        coeff = self._coeff*other._coeff
         return Tensor(coeff, components, free, dum)
 
 
@@ -926,7 +921,8 @@ class Tensor(TensExpr):
         """
         Returns a tensor with sorted components
         """
-        cv = zip(self.components, range(len(self.components)))
+        from sympy.combinatorics.permutations import _af_invert
+        cv = zip(self._components, range(len(self._components)))
         sign = 1
         n = len(cv) - 1
         for i in range(n):
@@ -943,35 +939,35 @@ class Tensor(TensExpr):
         components = [x[0] for x in cv]
         perm_inv = [x[1] for x in cv]
         perm = _af_invert(perm_inv)
-        free = [(ind, i, perm[c]) for ind, i, c in self.free]
-        dum = [(i1, i2, perm[c1], perm[c2]) for i1, i2, c1, c2 in self.dum]
+        free = [(ind, i, perm[c]) for ind, i, c in self._free]
+        dum = [(i1, i2, perm[c1], perm[c2]) for i1, i2, c1, c2 in self._dum]
         free.sort(key = lambda x: (x[0].tensortype, x[0].name))
         dum.sort(key = lambda x: components[x[2]].index_types[x[0]])
         if sign == -1:
-            coeff = -self.coeff
+            coeff = -self._coeff
         else:
-            coeff = self.coeff
+            coeff = self._coeff
         t = Tensor(coeff, components, free, dum)
         return t
 
     def perm2tensor(self, g, canon_bp=False):
         """
-        Returns the tensor corresponding to the permutation `g`
+        Returns the tensor corresponding to the permutation ``g``
 
-        g  permutation corrisponding to the tensor in the representation
+        ``g``  permutation corrisponding to the tensor in the representation
         used in canonicalization
 
-        `canon\_bp`   if True, then `g` is the permutation
+        ``canon_bp``   if True, then ``g`` is the permutation
         corresponding to the canonical form of the tensor
         """
         from bisect import bisect_right
         vpos = []
-        components = self.components
+        components = self._components
         pos = 0
-        for t in self.components:
+        for t in self._components:
             vpos.append(pos)
             pos += t.rank
-        free_indices = [x[0] for x in self.free]
+        free_indices = [x[0] for x in self._free]
         sorted_free = sorted(free_indices, key=lambda x:(x.tensortype, x.name))
         nfree = len(sorted_free)
         rank = self.rank
@@ -998,7 +994,7 @@ class Tensor(TensExpr):
                     dum[idum][0] = ipos
                     dum[idum][2] = icomp
         dum = [tuple(x) for x in dum]
-        coeff = self.coeff
+        coeff = self._coeff
         if g[-1] != len(g) - 1:
             coeff = -coeff
         res = Tensor(coeff, components, free, dum, is_canon_bp=canon_bp)
@@ -1018,6 +1014,9 @@ class Tensor(TensExpr):
         >>> sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
         >>> S2 = TensorType([Lorentz]*2, sym2a)
         >>> A = S2('A')
+        >>> t = A(m0,-m1)*A(m1,-m0)
+        >>> t.canon_bp()
+        -A(L_0, L_1)*A(-L_0, -L_1)
         >>> t = A(m0,-m1)*A(m1,-m2)*A(m2,-m0)
         >>> t.canon_bp()
         0
@@ -1025,7 +1024,7 @@ class Tensor(TensExpr):
         from sympy.combinatorics.tensor_can import canonicalize
         if self._is_canon_bp:
             return self
-        if not self.components:
+        if not self._components:
             return self
         t = self.sorted_components()
         g, dummies, msym, v = t.canon_args()
@@ -1041,7 +1040,7 @@ class Tensor(TensExpr):
 
         ``g``  metric
 
-        ``contract\_all`` if True, eliminate all ``g`` which are contracted
+        ``contract_all`` if True, eliminate all ``g`` which are contracted
 
         Examples
         ========
@@ -1062,26 +1061,26 @@ class Tensor(TensExpr):
         if g.index_types[0].metric_sym != 0:
             # TODO case of antisymmetric metric
             raise NotImplementedError
-        if not self.components:
+        if not self._components:
             return self
-        free_indices = [x[0] for x in self.free]
+        free_indices = [x[0] for x in self._free]
         a = self.split()
         typ = g.index_types[0]
         # if a component tensor of a has 2 dummy indices, it is g(d,-d) = dim
         for i, tx in enumerate(a):
-            if tx.components[0] == g:
-                free_indices_g = [x[0] for x in a[i].free]
+            if tx._components[0] == g:
+                free_indices_g = [x[0] for x in a[i]._free]
                 if len(free_indices_g) == 0:
                     a1 = a[:i] + a[i + 1:]
-                    t = tensor_mul(*a1)*(typ.dim*a[i].coeff)
-                    if contract_all == True and g in t.components:
+                    t = tensor_mul(*a1)*(typ.dim*a[i]._coeff)
+                    if contract_all == True and g in t._components:
                         return t.contract_metric(g, True)
                     return t
 
         # if all metric tensors have only free indices, there is no contraction
         for i, tg in enumerate(a):
-            if tg.components[0] == g:
-                tg_free_indices = [x[0] for x in tg.free]
+            if tg._components[0] == g:
+                tg_free_indices = [x[0] for x in tg._free]
                 if all(indx in free_indices for indx in tg_free_indices):
                     continue
                 break
@@ -1091,7 +1090,7 @@ class Tensor(TensExpr):
         # tg has one or two indices contracted with other tensors
         # i position of tg in a
         coeff = S.One
-        tg_free = tg.free
+        tg_free = tg._free
         if tg_free[0][0] in free_indices or tg_free[1][0] in free_indices:
             if tg_free[0][0] in free_indices:
                 ind_free = tg_free[0][0]
@@ -1101,20 +1100,20 @@ class Tensor(TensExpr):
                 ind, ipos1, _ = tg_free[0]
 
             ind1 = -ind
-            # search ind1 in self.dum
+            # search ind1 in self._dum
             for j, tx in enumerate(a):
-                if ind1 in [x[0] for x in tx.free]:
+                if ind1 in [x[0] for x in tx._free]:
                     break
             free1 = []
-            for indx, iposx, _ in tx.free:
+            for indx, iposx, _ in tx._free:
                 if indx == ind1:
                     free1.append((ind_free, iposx, 0))
                 else:
                     free1.append((indx, iposx, 0))
-            t1 = Tensor(tx.coeff, tx.components, free1, tx.dum)
+            t1 = Tensor(tx._coeff, tx._components, free1, tx._dum)
             a[j] = t1
             a = a[:i] + a[i + 1:]
-            coeff = coeff*tg.coeff
+            coeff = coeff*tg._coeff
             res = tensor_mul(*a)
         else:
             # tg has two indices contracted with other tensors
@@ -1123,10 +1122,10 @@ class Tensor(TensExpr):
             ind1m = -ind1
             ind2m = -ind2
             for k, ty in enumerate(a):
-                if ind2m in [x[0] for x in ty.free]:
+                if ind2m in [x[0] for x in ty._free]:
                     break
-            if ty.components == [g]:
-                ty_indices = [x[0] for  x in ty.free]
+            if ty._components == [g]:
+                ty_indices = [x[0] for  x in ty._free]
                 if all(x in [ind1m, ind2m] for x in ty_indices):
                     if i < k:
                         a = a[:i] + a[i+1:k] + a[k+1:]
@@ -1134,52 +1133,52 @@ class Tensor(TensExpr):
                         a = a[:k] + a[k+1:i] + a[k+1:]
                     if a:
                         res = tensor_mul(*a)
-                        res = (coeff*typ.dim*tg.coeff*ty.coeff)*res
+                        res = (coeff*typ.dim*tg._coeff*ty._coeff)*res
                     else:
-                        res = coeff*typ.dim*tg.coeff*ty.coeff
+                        res = coeff*typ.dim*tg._coeff*ty._coeff
                         res = Tensor(res, [],[],[], is_canon_bp=True)
-                    if contract_all == True and g in res.components:
+                    if contract_all == True and g in res._components:
                         return res.contract_metric(g, True)
                     return res
 
             free2 = []
-            for indx, iposx, _ in ty.free:
+            for indx, iposx, _ in ty._free:
                 if indx == ind2m:
                     free2.append((ind1, iposx, 0))
                 else:
                     free2.append((indx, iposx, 0))
-            t2 = Tensor(ty.coeff, ty.components, free2, ty.dum)
+            t2 = Tensor(ty._coeff, ty._components, free2, ty._dum)
             a[k] = t2
             a = a[:i] + a[i + 1:]
-            coeff = coeff*tg.coeff
+            coeff = coeff*tg._coeff
             res = tensor_mul(*a)
         res = coeff*res
-        if contract_all == True and g in res.components:
+        if contract_all == True and g in res._components:
             return res.contract_metric(g, True)
         return res
 
 
     def _pretty(self):
-        if self.components == []:
-            return str(self.coeff)
+        if self._components == []:
+            return str(self._coeff)
         indices = [str(ind) for ind in self.get_indices()]
         pos = 0
         a = []
-        for t in self.components:
+        for t in self._components:
             if t.rank > 0:
                 a.append('%s(%s)' % (t.name, ', '.join(indices[pos:pos + t.rank])))
             else:
                 a.append('%s' % t.name)
             pos += t.rank
         res = '*'. join(a)
-        if self.coeff == S.One:
+        if self._coeff == S.One:
             return res
-        elif self.coeff == -S.One:
+        elif self._coeff == -S.One:
             return '-%s' % res
-        if self.coeff.is_Atom:
-            return '%s*%s' % (self.coeff, res)
+        if self._coeff.is_Atom:
+            return '%s*%s' % (self._coeff, res)
         else:
-            return '(%s)*%s' %(self.coeff, res)
+            return '(%s)*%s' %(self._coeff, res)
 
 
 
@@ -1189,10 +1188,6 @@ def canon_bp(p):
     """
     if p.is_Tensor:
         return p.canon_bp()
-    if p.is_Add:
-        return Add(*[canon_bp(x) for x in p.args])
-    if p.is_Mul:
-        return Mul(*[canon_bp(x) for x in p.args])
     return p
 
 def tensor_mul(*a):
@@ -1210,32 +1205,32 @@ def tensorlist_contract_metric(a, tg):
     """
     contract `tg` with a tensor in the list `a = t.split()`
     """
-    ind1, ind2 = [x[0] for x in tg.free]
+    ind1, ind2 = [x[0] for x in tg._free]
     mind1 = -ind1
     mind2 = -ind2
     for i in range(len(a)):
         t1 = a[i]
-        for j in range(len(t1.free)):
-            indx, ipos, _ = t1.free[j]
+        for j in range(len(t1._free)):
+            indx, ipos, _ = t1._free[j]
             if indx == mind1 or indx == mind2:
                 ind3 = ind2 if indx == mind1 else ind1
-                free1 = t1.free[:]
+                free1 = t1._free[:]
                 free1[j] = (ind3, ipos, 0)
-                t2 = Tensor(t1.coeff, t1.components, free1, t1.dum)
+                t2 = Tensor(t1._coeff, t1._components, free1, t1._dum)
                 a[i] = t2
                 return a
     a.append(tg)
     return a
 
 
-def riemann_cyclic_replaceR(t_r):
+def riemann_cyclic_replace(t_r):
     """
     replace Riemann tensor with an equivalent expression
 
     ``R(m,n,p,q) -> 2/3*R(m,n,p,q) - 1/3*R(m,q,n,p) + 1/3*R(m,p,n,q)``
 
     """
-    free = sorted(t_r.free, key=lambda x: x[1])
+    free = sorted(t_r._free, key=lambda x: x[1])
     m, n, p, q = [x[0] for x in free]
     t0 = S(2)/3*t_r
     t1 = - S(1)/3*t_r.substitute_indices((m,m),(n,q),(p,n),(q,p))
@@ -1265,7 +1260,7 @@ def riemann_cyclic(t2):
     """
     a = t2.args
     a1 = [x.split() for x in a]
-    a2 = [[riemann_cyclic_replaceR(tx) for tx in y] for y in a1]
+    a2 = [[riemann_cyclic_replace(tx) for tx in y] for y in a1]
     a3 = [tensor_mul(*v) for v in a2]
     t3 = TensAdd(*a3)
     if not t3:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from sympy.core import Basic, sympify, Add, Mul, S
+from sympy.core.symbol import Symbol, symbols
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
 
 
@@ -140,7 +141,7 @@ class TensorIndex(Basic):
 
 def tensor_indices(s, typ):
     """
-    Returns tensor indices given their names and the TensorIndexType ``typ``
+    Returns list of tensor indices given their names and the type ``typ``
 
     ``s`` string of comma separated names of indices
 
@@ -153,7 +154,11 @@ def tensor_indices(s, typ):
     >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
     """
-    a = s.split(',')
+    if isinstance(s, str):
+        a = [x.name for x in symbols(s, seq=True)]
+    else:
+        raise ValueError('expecting a string')
+
     return [TensorIndex(i, typ) for i in a]
 
 
@@ -221,7 +226,10 @@ class TensorType(Basic):
 
     def __call__(self, s, commuting=0):
         """
-        commuting:
+        Return a TensorHead object or a list of TensorHead objects.
+
+        ``s``  name or string of names
+        ``commuting``:
         None no commutation rule
         0    commutes
         1    anticommutes
@@ -245,7 +253,10 @@ class TensorType(Basic):
         >>> canon_bp(W(a, b)*W(-b, -a))
         0
         """
-        names = s.split(',')
+        if isinstance(s, str):
+            names = [x.name for x in symbols(s, seq=True)]
+        else:
+            raise ValueError('expecting a string')
         if len(names) == 1:
             return TensorHead(names[0], self, commuting)
         else:

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1,0 +1,1260 @@
+from collections import defaultdict
+from sympy.combinatorics.perm_groups import PermutationGroup
+from sympy.combinatorics.permutations import Permutation, _af_new, _af_invert
+from sympy.core import Basic, Symbol, sympify, Add, Mul, S, Rational
+from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, canonical_free, riemann_bsgs
+
+from functools import wraps
+
+from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic
+from sympy.core.decorators import call_highest_priority
+from sympy.core.sympify import SympifyError
+from sympy.matrices import ShapeError
+from sympy.simplify import simplify
+from sympy import cacheit
+
+class TensorIndexType(object):
+    def __init__(self, name, metric_sym=0, dim=None, eps_dim = None,
+                 dummy_fmt=None):
+        """
+        name   name of the tensor type
+
+        ``metric\_sym``:
+        0      symmetric
+        1      antisymmetric
+        None   no symmetry
+
+        dim    dimension, it can be a symbol or a positive integer
+
+        ``eps\_dim``  dimension of the epsilon tensor; it is by default
+                 equal to dim, if the latter is an integer; else
+                 it can be assigned (for use in naive dimensional
+                 regularization)
+
+        ``dummy\_fmt`` name of the head of dummy indices; by default it is
+        the name of the tensor type
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        """
+        self.name = name
+        self.metric_sym = metric_sym
+        if not dummy_fmt:
+            self.dummy_fmt = '%s_%%d' % self.name
+        else:
+            self.dummy_fmt = '%s_%%d' % dummy_fmt
+        self.metric = self.get_metric()
+        self.dim = dim
+        if eps_dim:
+            self.eps_dim = eps_dim
+        else:
+            self.eps_dim = dim
+        if isinstance(self.eps_dim, int):
+            self.epsilon = self.get_epsilon()
+        else:
+            self.epsilon = None
+
+    def get_metric(self):
+        if self.metric_sym is None:
+            return None
+        sym2 = TensorSymmetry(get_symmetric_group_sgs(2, self.metric_sym))
+        S2 = TensorType([self]*2, sym2)
+        metric = S2('metric')
+        return metric
+
+    def get_epsilon(self):
+        sym = TensorSymmetry(get_symmetric_group_sgs(self.eps_dim, 1))
+        Sdim = TensorType([self]*self.eps_dim, sym)
+        epsilon = Sdim('Eps')
+        return epsilon
+
+
+    def __str__(self):
+        return self.name
+
+    __repr__ = __str__
+
+class TensorIndex(object):
+    """
+    Tensor indices are contructed with the Einstein summation convention.
+
+    An index can be in contravariant or in covariant form; in the latter
+    case it is represented prepending a `-` to the index name.
+
+    Dummy indices have the head given by `dummy\_fmt`
+
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, TensorIndex, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> i = TensorIndex('i', Lorentz); i
+    i
+    >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    >>> S1 = TensorType([Lorentz], sym1)
+    >>> A, B = S1('A,B')
+    >>> A(i)*B(-i)
+    A(L_0)*B(-L_0)
+    """
+    def __init__(self, name, tensortype, is_contravariant=True):
+        self.name = name
+        self.tensortype = tensortype
+        self.is_contravariant = is_contravariant
+
+    def __str__(self):
+        s = self.name
+        if not self.is_contravariant:
+            s = '-%s' % s
+        return s
+
+    __repr__ = __str__
+
+    @cacheit
+    def covariant(self):
+        if self.is_contravariant:
+            return TensorIndex(self.name, self.tensortype, False)
+        else:
+            return self
+
+    def __eq__(self, other):
+        return self.name == other.name and \
+               self.tensortype == other.tensortype and \
+               self.is_contravariant == other.is_contravariant
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    @cacheit
+    def __neg__(self):
+        t1 = TensorIndex(self.name, self.tensortype,
+                (not self.is_contravariant))
+        return t1
+
+def tensor_indices(s, typ):
+    """
+    Returns tensor indices given their name
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    """
+    a = s.split(',')
+    return [TensorIndex(i, typ) for i in a]
+
+
+class TensorSymmetry(object):
+    """
+    Symmetry of a tensor
+
+    bsgs tuple (base, sgs) BSGS of the symmetry of the tensor
+
+    Examples
+    ========
+
+    Define a symmetric tensor
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    >>> S2 = TensorType([Lorentz]*2, sym2)
+    >>> V = S2('V')
+    """
+    def __init__(self, bsgs):
+        self.base, self.generators = bsgs
+        self.rank = self.generators[0].size
+
+def _get_index_types(indices):
+    res = []
+    for i in indices:
+        if isinstance(i, TensorIndex):
+            res.append(i.tensortype)
+        elif isinstance(i, TensorIndexType):
+            res.append(i)
+        else:
+            raise NotImplementedError
+    return res
+
+def has_tensor(p):
+    if p.is_Tensor:
+        return True
+    if p.is_Mul or p.is_Add:
+        for x in p.args:
+            if has_tensor(x):
+                return True
+    return False
+
+
+class TensorType(Basic):
+    """
+
+    Examples
+    ========
+
+    Define a symmetric tensor
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    >>> S2 = TensorType([Lorentz]*2, sym2)
+    >>> V = S2('V')
+    """
+    is_commutative = False
+
+    def __new__(cls, indices, symmetry, **kw_args):
+        obj = Basic.__new__(cls, **kw_args)
+        obj.index_types = []
+        obj.index_types = _get_index_types(indices)
+        obj.types = list(set(obj.index_types))
+        obj.types.sort(key=lambda x: x.name)
+        obj.symmetry = symmetry
+        assert symmetry.rank == len(indices) + 2
+        return obj
+
+    def __str__(self):
+        return 'TensorType(%s)' %([str(x) for x in self.index_types])
+
+    def __call__(self, s, commuting=0):
+        """
+        commuting:
+        None no commutation rule
+        0    commutes
+        1    anticommutes
+
+        Examples
+        ========
+
+        Define symmetric tensors ``V``, ``W`` and ``G``, respectively
+        commuting, anticommuting and with no commutation symmetry
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs, canon_bp
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b = tensor_indices('a,b', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> V = S2('V')
+        >>> W = S2('W', 1)
+        >>> G = S2('G', None)
+        >>> canon_bp(V(a, b)*V(-b, -a))
+        V(L_0, L_1)*V(-L_0, -L_1)
+        >>> canon_bp(W(a, b)*W(-b, -a))
+        0
+        """
+        names = s.split(',')
+        if len(names) == 1:
+            return TensorHead(names[0], self, commuting)
+        else:
+            return [TensorHead(name, self, commuting) for name in names]
+
+class TensorHead(Basic):
+    is_commutative = False
+
+    def __new__(cls, name, typ, commuting, **kw_args):
+        """
+        tensor with given name, index types, symmetry, commutation rule
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b = tensor_indices('a,b', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A = S2('A')
+        """
+        assert isinstance(name, basestring)
+
+        obj = Basic.__new__(cls, **kw_args)
+        obj.name = name
+        obj.index_types = typ.index_types
+        obj.rank = len(obj.index_types)
+        obj.types = typ.types
+        obj.symmetry = typ.symmetry
+        obj.commuting = commuting
+        return obj
+
+    def __eq__(self, other):
+        if not isinstance(other, TensorHead):
+            return False
+        return self.name == other.name and self.index_types == other.index_types
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def commutes_with(self, other):
+        """
+        Returns 0 (1) if self and other (anti)commute
+        Returns None if self and other do not (anti)commute
+
+        TODO: it should be possible to assign rules for commutations
+        between tensors, to be used here.
+        """
+        if self.commuting == 0 or other.commuting == 0:
+            return 0
+        if self.commuting == 1 and other.commuting == 1:
+            return 1
+        return None
+
+        #if self.commuting == None or other.commuting == None:
+        #    return None
+        #return self.commuting * other.commuting
+
+
+    def __str__(self):
+        return '%s(%s)' %(self.name, ','.join([str(x) for x in self.index_types]))
+    __repr__ = __str__
+
+    def __call__(self, *indices):
+        """
+        tensor with indices
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b = tensor_indices('a,b', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A = S2('A')
+        >>> t = A(a, -b)
+        """
+        assert self.rank == len(indices)
+        components = [self]
+        free, dum =  Tensor.from_indices(*indices)
+        free.sort(key=lambda x: x[0].name)
+        dum.sort()
+        return Tensor(S.One, components, free, dum)
+
+
+class TensExpr(Basic):
+    """
+    A tensor expression is an expression formed by tensors;
+    currently the sums of tensors are distributed.
+
+    A TensExpr can be a TensAdd or a Tensor.
+
+    TensAdd objects are put in canonic form using the Butler-Portugal
+    algorithm for canonicalization under monoterm symmetries.
+
+    Tensor objects are formed by products of component tensors,
+    and include a coefficient, which is a SymPy expression.
+
+
+    In the internal representation contracted indices are represented
+    by ``(ipos1, ipos2, icomp1, icomp2)``, where ``icomp1`` is the position
+    of the component tensor with contravariant index, ``ipos1`` is the
+    slot which the index occupies in that component tensor.
+
+    Contracted indices are therefore nameless in the internal representation.
+    """
+
+    _op_priority = 11.0
+    is_Tensor = True
+    is_TensExpr = True
+    is_TensMul = False
+    is_TensAdd = False
+    is_commutative = False
+
+    def __neg__(self):
+        return (-1)*self
+
+    def __abs__(self):
+        raise NotImplementedError
+
+    def __add__(self, other):
+        other = sympify(other)
+        if self.is_TensAdd:
+            args = self.args + (other,)
+            return TensAdd(*args)
+        return TensAdd(self, other)
+
+    def __radd__(self, other):
+        return TensAdd(other, self)
+
+    def __sub__(self, other):
+        other = sympify(other)
+        return TensAdd(self, -other)
+
+    def __rsub__(self, other):
+        return TensAdd(other, -self)
+
+    def __mul__(self, other):
+        if self.is_TensAdd:
+            return TensAdd(*[x*other for x in self.args])
+        if other.is_TensAdd:
+            return TensAdd(*[self*x for x in other.args])
+        return Tensor.__mul__(self, other)
+
+    def __rmul__(self, other):
+        if self.is_TensMul:
+            coeff = other*self.coeff
+            return Tensor(coeff, self.components, self.free, self.dum)
+        return TensAdd(*[x*other for x in self.args])
+
+    def __pow__(self, other):
+        raise NotImplementedError
+
+    def __rpow__(self, other):
+        raise NotImplementedError
+
+    def __div__(self, other):
+        other = sympify(other)
+        if other.is_Tensor:
+            raise ValueError('cannot divide by a tensor')
+        coeff = self.coeff/other
+        return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+
+
+    def __rdiv__(self, other):
+        raise NotImplementedError()
+
+    __truediv__ = __div__
+    __rtruediv__ = __rdiv__
+
+    def substitute_indices(self, *index_tuples):
+        """
+        Return a tensor with indices substituted according to `index\_tuples`
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A, B = S2('A,B')
+        >>> t = A(i, k)*B(-k, -j); t
+        A(i, L_0)*B(-L_0, -j)
+        >>> t.substitute_indices((i,j), (j, k))
+        A(j, L_0)*B(-L_0, -k)
+        """
+        if self.is_TensMul:
+            free = self.free
+            free1 = []
+            for i, v in index_tuples:
+                for j, ipos, cpos in free:
+                    if i.name == j.name and i.tensortype == j.tensortype:
+                        if i.is_contravariant == j.is_contravariant:
+                            free1.append((v, ipos, cpos))
+                        else:
+                            # replace i with an index with the same covariance of i
+                            if j.is_contravariant:
+                                ind = TensorIndex(v.name, v.tensortype)
+                                free1.append((ind, ipos, cpos))
+                            else:
+                                ind = TensorIndex(v.name, v.tensortype)
+                                ind = -ind
+                                free1.append((ind, ipos, cpos))
+            return Tensor(self.coeff, self.components, free1, self.dum)
+        if self.is_TensAdd:
+            args = self.args
+            args1 = []
+            for x in args:
+                y = x.substitute_indices(*index_tuples)
+                args1.append(y)
+            return TensAdd(*args1)
+
+class TensAdd(TensExpr):
+    """
+    Sum of tensors
+    """
+    is_Tensor = True
+    is_TensAdd = True
+
+    def __new__(cls, *args, **kw_args):
+        """
+        args  tuple of addends
+        """
+        args = [sympify(x) for x in args if x]
+        if not all(x.is_Tensor for x in args):
+            args1 = [x for x in args if x.is_Tensor and x.coeff]
+            args2 = [x for x in args if not x.is_Tensor]
+            t0 = args1[0]
+            if t0.is_TensAdd:
+                t0 = t0.args[0]
+            if t0.free:
+               raise ValueError('all tensors must have the same indices')
+            t1 = Tensor(Add(*args2), [], [], [])
+            args = [t1] + args1
+        a = []
+        for x in args:
+            if x.is_TensAdd:
+                a.extend(list(x.args))
+            else:
+                a.append(x)
+        args = a
+        args = [x for x in args if x.coeff]
+        if not args:
+            return S.Zero
+
+        indices0 = sorted([x[0] for x in args[0].free], key=lambda x: x.name)
+        list_indices = [sorted([y[0] for y in x.free], key=lambda x: x.name) for x in args[1:]]
+        if not all(x == indices0 for x in list_indices):
+            print 'ERR list_indices=%s indices0=%s' %(list_indices, indices0)
+            raise ValueError('all tensors must have the same indices')
+
+        obj = Basic.__new__(cls, **kw_args)
+        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        a = []
+        pprev = None
+        prev = args[0]
+        prev_coeff = prev.coeff
+        changed = False
+        new = 0
+        if len(args) == 1 and args[0].is_TensMul:
+            obj._args = tuple(args)
+            return obj
+
+        for x in args[1:]:
+            # if x and prev have the same tensor, update the coeff of prev
+            if x.components == prev.components \
+                    and x.free == prev.free and x.dum == prev.dum:
+                prev_coeff = prev_coeff + x.coeff
+                changed = True
+                op = 0
+            else:
+                # x and prev are different; if not changed, prev has not
+                # been updated; store it
+                if not changed:
+                    a.append(prev)
+                else:
+                    # get a tensor from prev with coeff=prev_coeff and store it
+                    if prev_coeff:
+                        t = Tensor(prev_coeff, prev.components,
+                            prev.free, prev.dum)
+                        a.append(t)
+                # move x to prev
+                op = 1
+                pprev, prev = prev, x
+                pprev_coeff, prev_coeff = prev_coeff, x.coeff
+                changed = False
+        # if the case op=0 prev was not stored; store it now
+        # in the case op=1 x was not stored; store it now (as prev)
+        if op == 0 and prev_coeff:
+            prev = Tensor(prev_coeff, prev.components, prev.free, prev.dum)
+            a.append(prev)
+        elif op == 1:
+            a.append(prev)
+        if not a:
+            return S.Zero
+
+        # TODO introduce option not to use canon_bp automatically in TensAdd
+        if all(x.is_TensMul for x in a):
+            a = [canon_bp(x) for x in a]
+        a = [x for x in a if x]
+        if not a:
+            return S.Zero
+        obj._args = tuple(a)
+        return obj
+
+    def canon_bp(self):
+        args = [x.canon_bp() for x in self.args]
+        args.sort(key=lambda x: (x.components, x.free, x.dum))
+        res = TensAdd(*args)
+        return res
+
+    def __eq__(self, other):
+        other = sympify(other)
+        if not other.is_Tensor:
+            if len(self.args) == 1:
+                return self.args[0].coeff == other
+        if other.is_Tensor and other.is_TensMul and other.coeff == 0:
+            return self == 0
+        t = self - other
+        if not t.is_Tensor:
+            return t == 0
+        else:
+            if t.is_TensMul:
+                return t.coeff == 0
+            else:
+                return all(x.coeff == 0 for x in t.args)
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def contract_metric(self, g, contract_all=False):
+        """
+        Raise or lower indices with the metric ``g``
+
+        ``g``  metric
+
+        ``contract\_all`` if True, eliminate all ``g`` which are contracted
+        """
+
+        args = [x.contract_metric(g, contract_all) for x in self.args]
+        if len(args) == 1:
+            return args[0]
+        t = TensAdd(*args)
+        return t.canon_bp()
+
+    def _pretty(self):
+        a = []
+        #args = sorted(self.args)
+        args = self.args
+        for x in args:
+            a.append(str(x))
+
+        a.sort()
+        s = ' + '.join(a)
+        s = s.replace('+ -', '- ')
+        return s
+
+class Tensor(TensExpr):
+    is_Tensor = True
+    is_TensMul = True
+
+    def __new__(cls, coeff, *args, **kw_args):
+        """
+
+        coeff SymPy expression coefficient of the tensor.
+
+        args[0]   list of TensorHead of the component tensors.
+
+        args[1]   list of ``(ind, ipos, icomp)``
+        where ``ind`` is a free index, ``ipos`` is the slot position
+        of ``ind`` in the ``icomp``-th component tensor.
+
+        args[2] list of tuples representing dummy indices.
+        (ipos1, ipos2, icomp1, icomp2) indicates that the contravariant
+        dummy index is the `ipos1` slot position in the `icomp1`-th
+        component tensor; the corresponding covariant index is
+        in the ``ipos2`` slot position in the ``icomp2``-th component tensor.
+        """
+        obj = Basic.__new__(cls)
+        obj.components = args[0]
+        obj.types = []
+        for t in obj.components:
+            obj.types.extend(t.types)
+        obj.free = args[1]
+        obj.dum = args[2]
+        obj.rank = len(obj.free) + 2*len(obj.dum)
+        obj.coeff = coeff
+        obj._is_canon_bp = kw_args.get('is_canon_bp', False)
+
+        return obj
+
+    def __eq__(self, other):
+        if other == 0:
+            return self.coeff == 0
+        other = sympify(other)
+        if not other.is_Tensor :
+            return False
+        res = self - other
+        return res == 0
+
+        res = self.components == other.components and \
+            sorted(self.free) == sorted(other.free) and \
+            sorted(self.dum) == sorted(other.dum) and self.coeff == other.coeff
+        return res
+
+    def __ne__(self, other):
+        return not self == other
+
+    @property
+    def set_free_indices(self):
+        return set([x[0] for x in self.free])
+
+    @staticmethod
+    def from_indices(*indices):
+        """
+
+        Convert ``indices`` into ``free``, ``dum`` for single component tensor
+
+        free         list of tuples ``(index, pos, 0)``,
+                     where ``pos`` is the position of index in
+                     the list of indices formed by the component tensors
+
+        dum          list of tuples ``(pos_contr, pos_cov, 0, 0)``
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, Tensor, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> Tensor.from_indices(m0, m1, -m1, m3)
+        ([(m0, 0, 0), (m3, 3, 0)], [(1, 2, 0, 0)])
+        """
+        n = len(indices)
+        if n == 1:
+            return [(indices[0], 0, 0)], []
+
+        # find the positions of the free indices and of the dummy indices
+        free = [True]*len(indices)
+        index_dict = {}
+        dum = []
+        for i, index in enumerate(indices):
+            name = index.name
+            typ = index.tensortype
+            contr = index.is_contravariant
+            if (name, typ) in index_dict:
+                # found a pair of dummy indices
+                is_contr, pos = index_dict[(name, typ)]
+                # check consistency and update free
+                if is_contr:
+                    if contr:
+                        raise ValueError('two equal contravariant indices in slots %d and %d' %(pos, i))
+                    else:
+                        free[pos] = False
+                        free[i] = False
+                else:
+                    if contr:
+                        free[pos] = False
+                        free[i] = False
+                    else:
+                        raise ValueError('two equal covariant indices in slots %d and %d' %(pos, i))
+                if contr:
+                    dum.append((i, pos, 0, 0))
+                else:
+                    dum.append((pos, i, 0, 0))
+            else:
+                index_dict[(name, typ)] = index.is_contravariant, i
+
+        free_indices = [(index, i, 0) for i, index in enumerate(indices) if free[i]]
+        free = sorted(free_indices, key=lambda x: (x[0].tensortype, x[0].name))
+
+        return free, dum
+
+    def get_indices(self):
+        """
+        Returns the list of indices of the tensor
+
+        The indices are listed in the order in which they appear in the
+        component tensors.
+        """
+        indices = [None]*self.rank
+        start = 0
+        pos = 0
+        vpos = []
+        components = self.components
+        for t in self.components:
+            vpos.append(pos)
+            pos += t.rank
+        cdt = defaultdict(int)
+        for indx, ipos, cpos in self.free:
+            start = vpos[cpos]
+            indices[start + ipos] = indx
+        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+            start1 = vpos[cpos1]
+            start2 = vpos[cpos2]
+            typ1 = components[cpos1].index_types[ipos1]
+            assert typ1 == components[cpos2].index_types[ipos2]
+            fmt = typ1.dummy_fmt
+            nd = cdt[typ1]
+            indices[start1 + ipos1] = TensorIndex(fmt % nd, typ1)
+            indices[start2 + ipos2] = TensorIndex(fmt % nd, typ1, False)
+            cdt[typ1] += 1
+        return indices
+
+    def split(self):
+        """
+        Returns a list of tensors, whose product is ``self``
+
+        Dummy indices contracted among different tensor components
+        become free indices with the same name as the one used to
+        represent the dummy indices.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+        >>> sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+        >>> S2 = TensorType([Lorentz]*2, sym2)
+        >>> A, B = S2('A,B')
+        >>> t = A(a,b)*B(-b,c)
+        >>> t
+        A(a, L_0)*B(-L_0, c)
+        >>> t.split()
+        [A(a, L_0), B(-L_0, c)]
+        """
+        indices = self.get_indices()
+        pos = 0
+        components = self.components
+        res = []
+        for t in self.components:
+            t1 = t(*indices[pos:pos + t.rank])
+            pos += t.rank
+            res.append(t1)
+        res[0] = Tensor(self.coeff, res[0].components, res[0].free, res[0].dum, is_canon_bp=res[0]._is_canon_bp)
+        return res
+
+    def canon_args(self):
+        """
+        Returns ``(g, dummies, msym, v)``, the entries of ``canonicalize``
+
+        see ``canonicalize`` in ``tensor\_can.py``
+        """
+        # to be called after sorted_components
+        from sympy.combinatorics.permutations import _af_new
+        types = list(set(self.types))
+        types.sort(key = lambda x: x.name)
+        n = self.rank
+        g = [None]*n + [n, n+1]
+        pos = 0
+        vpos = []
+        components = self.components
+        for t in self.components:
+            vpos.append(pos)
+            pos += t.rank
+        for i, (indx, ipos, cpos) in enumerate(self.free):
+            pos = vpos[cpos] + ipos
+            g[pos] = i
+
+        pos = len(self.free)
+        j = len(self.free)
+        dummies = []
+        prev = None
+        a = []
+        msym = []
+        for ipos1, ipos2, cpos1, cpos2 in self.dum:
+            pos1 = vpos[cpos1] + ipos1
+            pos2 = vpos[cpos2] + ipos2
+            g[pos1] = j
+            g[pos2] = j + 1
+            j += 2
+            typ = components[cpos1].index_types[ipos1]
+            if typ != prev:
+                if a:
+                    dummies.append(a)
+                a = [pos, pos + 1]
+                prev = typ
+                msym.append(typ.metric_sym)
+            else:
+                a.extend([pos, pos + 1])
+            pos += 2
+        if a:
+            dummies.append(a)
+        numtyp = []
+        prev = None
+        for t in components:
+            if t == prev:
+                numtyp[-1][1] += 1
+            else:
+                prev = t
+                numtyp.append([prev, 1])
+        v = []
+        for h, n in numtyp:
+            v.append((h.symmetry.base, h.symmetry.generators, n, h.commuting))
+        return _af_new(g), dummies, msym, v
+
+    def __mul__(self, other):
+        """
+        Multiply two tensors using Einstein summation convention.
+
+        If the two tensors have have an index in common, one contravariant
+        and the other covariant, in their product the indices are summed
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> g = Lorentz.metric
+        >>> p, q = S1('p,q')
+        >>> t1 = p(m0)
+        >>> t2 = q(-m0)
+        >>> t1*t2
+        p(L_0)*q(-L_0)
+        """
+        other = sympify(other)
+        if not other.is_Tensor:
+            coeff = self.coeff*other
+            return Tensor(coeff, self.components, self.free, self.dum, is_canon_bp=self._is_canon_bp)
+        if other.is_TensAdd:
+            return TensAdd(*[self*x for x in other.args])
+
+        components = self.components + other.components
+        # find out which free indices of self and other are contracted
+        free_dict1 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in self.free])
+        free_dict2 = dict([(i.name, (pos, cpos, i)) for i, pos, cpos in other.free])
+
+        free_names = set(free_dict1.keys()) & set(free_dict2.keys())
+        # find the new `free` and `dum`
+        nc1 = len(self.components)
+        dum2 = [(i1, i2, c1 + nc1, c2 + nc1) for i1, i2, c1, c2 in other.dum]
+        free1 = [(ind, i, c) for ind, i, c in self.free if ind.name not in free_names]
+        free2 = [(ind, i, c + nc1) for ind, i, c in other.free if ind.name not in free_names]
+        free = free1 + free2
+        dum = self.dum + dum2
+        for name in free_names:
+            ipos1, cpos1, ind1 = free_dict1[name]
+            ipos2, cpos2, ind2 = free_dict2[name]
+            cpos2 += nc1
+            if ind1.is_contravariant == ind2.is_contravariant:
+                raise ValueError('wrong index contruction %s' % ind1)
+            if ind1.is_contravariant:
+                new_dummy = (ipos1, ipos2, cpos1, cpos2)
+            else:
+                new_dummy = (ipos2, ipos1, cpos2, cpos1)
+            dum.append(new_dummy)
+        coeff = self.coeff*other.coeff
+        return Tensor(coeff, components, free, dum)
+
+
+    def sorted_components(self):
+        """
+        Returns a tensor with sorted components
+        """
+        cv = zip(self.components, range(len(self.components)))
+        sign = 1
+        n = len(cv) - 1
+        for i in range(n):
+            for j in range(n, i, -1):
+                c = cv[j-1][0].commutes_with(cv[j][0])
+                if c == None:
+                    continue
+                if (cv[j-1][0].types, cv[j-1][0].name) > \
+                        (cv[j][0].types, cv[j][0].name):
+                    cv[j-1], cv[j] = cv[j], cv[j-1]
+                    if c:
+                        sign = -sign
+        # perm_inv[new_pos] = old_pos
+        components = [x[0] for x in cv]
+        perm_inv = [x[1] for x in cv]
+        perm = _af_invert(perm_inv)
+        free = [(ind, i, perm[c]) for ind, i, c in self.free]
+        dum = [(i1, i2, perm[c1], perm[c2]) for i1, i2, c1, c2 in self.dum]
+        free.sort(key = lambda x: (x[0].tensortype, x[0].name))
+        dum.sort(key = lambda x: components[x[2]].index_types[x[0]])
+        if sign == -1:
+            coeff = -self.coeff
+        else:
+            coeff = self.coeff
+        t = Tensor(coeff, components, free, dum)
+        return t
+
+    def perm2tensor(self, g, canon_bp=False):
+        """
+        Returns the tensor corresponding to the permutation `g`
+
+        g  permutation corrisponding to the tensor in the representation
+        used in canonicalization
+
+        `canon\_bp`   if True, then `g` is the permutation
+        corresponding to the canonical form of the tensor
+        """
+        from bisect import bisect_right
+        vpos = []
+        components = self.components
+        pos = 0
+        for t in self.components:
+            vpos.append(pos)
+            pos += t.rank
+        free_indices = [x[0] for x in self.free]
+        sorted_free = sorted(free_indices, key=lambda x:(x.tensortype, x.name))
+        nfree = len(sorted_free)
+        rank = self.rank
+        indices = [None]*rank
+        dum = [[None]*4 for i in range((rank - nfree)//2)]
+        free = []
+        icomp = -1
+        for i in range(rank):
+            if i in vpos:
+                icomp += vpos.count(i)
+                pos0 = i
+            ipos = i - pos0
+            gi = g[i]
+            if gi < nfree:
+                ind = sorted_free[gi]
+                free.append((ind, ipos, icomp))
+            else:
+                j = gi - nfree
+                idum, cov = divmod(j, 2)
+                if cov:
+                    dum[idum][1] = ipos
+                    dum[idum][3] = icomp
+                else:
+                    dum[idum][0] = ipos
+                    dum[idum][2] = icomp
+        dum = [tuple(x) for x in dum]
+        coeff = self.coeff
+        if g[-1] != len(g) - 1:
+            coeff = -coeff
+        res = Tensor(coeff, components, free, dum, is_canon_bp=canon_bp)
+        return res
+
+    def canon_bp(self):
+        """
+        canonicalize using the Butler-Portugal algorithm for canonicalization
+        under monoterm symmetries.
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+        >>> S2 = TensorType([Lorentz]*2, sym2a)
+        >>> A = S2('A')
+        >>> t = A(m0,-m1)*A(m1,-m2)*A(m2,-m0)
+        >>> t.canon_bp()
+        0
+        """
+        from sympy.combinatorics.tensor_can import canonicalize
+        if self._is_canon_bp:
+            return self
+        if not self.components:
+            return self
+        t = self.sorted_components()
+        g, dummies, msym, v = t.canon_args()
+        can = canonicalize(g, dummies, msym, *v)
+        if can == 0:
+            return S.Zero
+        return t.perm2tensor(can, True)
+
+
+    def contract_metric(self, g, contract_all=False):
+        """
+        Raise or lower indices with the metric ``g``
+
+        ``g``  metric
+
+        ``contract\_all`` if True, eliminate all ``g`` which are contracted
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, get_symmetric_group_sgs, TensorType
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> m0, m1, m2 = tensor_indices('m0,m1,m2', Lorentz)
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> g = Lorentz.metric
+        >>> p, q = S1('p,q')
+        >>> t = p(m0)*q(m1)*g(-m0, -m1)
+        >>> t.canon_bp()
+        metric(L_0, L_1)*p(-L_0)*q(-L_1)
+        >>> t.contract_metric(g).canon_bp()
+        p(L_0)*q(-L_0)
+        """
+        if g.index_types[0].metric_sym != 0:
+            # TODO case of antisymmetric metric
+            raise NotImplementedError
+        if not self.components:
+            return self
+        free_indices = [x[0] for x in self.free]
+        a = self.split()
+        typ = g.index_types[0]
+        # if a component tensor of a has 2 dummy indices, it is g(d,-d) = dim
+        for i, tx in enumerate(a):
+            if tx.components[0] == g:
+                free_indices_g = [x[0] for x in a[i].free]
+                if len(free_indices_g) == 0:
+                    a1 = a[:i] + a[i + 1:]
+                    t = tensor_mul(*a1)*(typ.dim*a[i].coeff)
+                    if contract_all == True and g in t.components:
+                        return t.contract_metric(g, True)
+                    return t
+
+        # if all metric tensors have only free indices, there is no contraction
+        for i, tg in enumerate(a):
+            if tg.components[0] == g:
+                tg_free_indices = [x[0] for x in tg.free]
+                if all(indx in free_indices for indx in tg_free_indices):
+                    continue
+                break
+        else:
+            return self
+
+        # tg has one or two indices contracted with other tensors
+        # i position of tg in a
+        coeff = S.One
+        tg_free = tg.free
+        if tg_free[0][0] in free_indices or tg_free[1][0] in free_indices:
+            if tg_free[0][0] in free_indices:
+                ind_free = tg_free[0][0]
+                ind, ipos1, _ = tg_free[1]
+            else:
+                ind_free = tg_free[1][0]
+                ind, ipos1, _ = tg_free[0]
+
+            ind1 = -ind
+            # search ind1 in self.dum
+            for j, tx in enumerate(a):
+                if ind1 in [x[0] for x in tx.free]:
+                    break
+            free1 = []
+            for indx, iposx, _ in tx.free:
+                if indx == ind1:
+                    free1.append((ind_free, iposx, 0))
+                else:
+                    free1.append((indx, iposx, 0))
+            t1 = Tensor(tx.coeff, tx.components, free1, tx.dum)
+            a[j] = t1
+            a = a[:i] + a[i + 1:]
+            coeff = coeff*tg.coeff
+            res = tensor_mul(*a)
+        else:
+            # tg has two indices contracted with other tensors
+            ind1 = tg_free[0][0]
+            ind2 = tg_free[1][0]
+            ind1m = -ind1
+            ind2m = -ind2
+            for k, ty in enumerate(a):
+                if ind2m in [x[0] for x in ty.free]:
+                    break
+            if ty.components == [g]:
+                ty_indices = [x[0] for  x in ty.free]
+                if all(x in [ind1m, ind2m] for x in ty_indices):
+                    if i < k:
+                        a = a[:i] + a[i+1:k] + a[k+1:]
+                    else:
+                        a = a[:k] + a[k+1:i] + a[k+1:]
+                    if a:
+                        res = tensor_mul(*a)
+                        res = (coeff*typ.dim*tg.coeff*ty.coeff)*res
+                    else:
+                        res = coeff*typ.dim*tg.coeff*ty.coeff
+                        res = Tensor(res, [],[],[], is_canon_bp=True)
+                    if contract_all == True and g in res.components:
+                        return res.contract_metric(g, True)
+                    return res
+
+            free2 = []
+            for indx, iposx, _ in ty.free:
+                if indx == ind2m:
+                    free2.append((ind1, iposx, 0))
+                else:
+                    free2.append((indx, iposx, 0))
+            t2 = Tensor(ty.coeff, ty.components, free2, ty.dum)
+            a[k] = t2
+            a = a[:i] + a[i + 1:]
+            coeff = coeff*tg.coeff
+            res = tensor_mul(*a)
+        res = coeff*res
+        if contract_all == True and g in res.components:
+            return res.contract_metric(g, True)
+        return res
+
+
+    def _pretty(self):
+        if self.components == []:
+            return str(self.coeff)
+        indices = [str(ind) for ind in self.get_indices()]
+        pos = 0
+        a = []
+        for t in self.components:
+            if t.rank > 0:
+                a.append('%s(%s)' % (t.name, ', '.join(indices[pos:pos + t.rank])))
+            else:
+                a.append('%s' % t.name)
+            pos += t.rank
+        res = '*'. join(a)
+        if self.coeff == S.One:
+            return res
+        elif self.coeff == -S.One:
+            return '-%s' % res
+        if self.coeff.is_Atom:
+            return '%s*%s' % (self.coeff, res)
+        else:
+            return '(%s)*%s' %(self.coeff, res)
+
+
+
+def canon_bp(p):
+    """
+    Butler-Portugal canonicalization
+    """
+    if p.is_Tensor:
+        return p.canon_bp()
+    if p.is_Add:
+        return Add(*[canon_bp(x) for x in p.args])
+    if p.is_Mul:
+        return Mul(*[canon_bp(x) for x in p.args])
+    return p
+
+def tensor_mul(*a):
+    """
+    product of tensors
+    """
+    if not a:
+        return Tensor(S.One, [], [], [])
+    t = a[0]
+    for tx in a[1:]:
+        t = t*tx
+    return t
+
+def tensorlist_contract_metric(a, tg):
+    """
+    contract `tg` with a tensor in the list `a = t.split()`
+    """
+    ind1, ind2 = [x[0] for x in tg.free]
+    mind1 = -ind1
+    mind2 = -ind2
+    for i in range(len(a)):
+        t1 = a[i]
+        for j in range(len(t1.free)):
+            indx, ipos, _ = t1.free[j]
+            if indx == mind1 or indx == mind2:
+                ind3 = ind2 if indx == mind1 else ind1
+                free1 = t1.free[:]
+                free1[j] = (ind3, ipos, 0)
+                t2 = Tensor(t1.coeff, t1.components, free1, t1.dum)
+                a[i] = t2
+                return a
+    a.append(tg)
+    return a
+
+
+def riemann_cyclic_replaceR(t_r):
+    """
+    replace Riemann tensor with an equivalent expression
+
+    ``R(m,n,p,q) -> 2/3*R(m,n,p,q) - 1/3*R(m,q,n,p) + 1/3*R(m,p,n,q)``
+
+    """
+    free = sorted(t_r.free, key=lambda x: x[1])
+    m, n, p, q = [x[0] for x in free]
+    t0 = S(2)/3*t_r
+    t1 = - S(1)/3*t_r.substitute_indices((m,m),(n,q),(p,n),(q,p))
+    t2 = S(1)/3*t_r.substitute_indices((m,m),(n,p),(p,n),(q,q))
+    t3 = t0 + t1 + t2
+    return t3
+
+def riemann_cyclic(t2):
+    """
+    replace each Riemann tensor with an equivalent expression
+    satisfying the cyclic identity.
+
+    This trick is discussed in the reference guide to Cadabra.
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, riemann_cyclic, riemann_bsgs
+    >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
+    >>> symr = TensorSymmetry(riemann_bsgs)
+    >>> R4 = TensorType([Lorentz]*4, symr)
+    >>> R = R4('R')
+    >>> t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
+    >>> riemann_cyclic(t)
+    0
+    """
+    a = t2.args
+    a1 = [x.split() for x in a]
+    a2 = [[riemann_cyclic_replaceR(tx) for tx in y] for y in a1]
+    a3 = [tensor_mul(*v) for v in a2]
+    t3 = TensAdd(*a3)
+    if not t3:
+        return t3
+    else:
+        return canon_bp(t3)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -172,7 +172,7 @@ class TensorIndexType(Basic):
     In the case of antisymmetric metric, the following raising and
     lowering conventions will be adopted:
 
-    ``psi(a) = g(a, b)*psi(-b); chi(-a) = chi(b)*g(-b, -a)
+    ``psi(a) = g(a, b)*psi(-b); chi(-a) = chi(b)*g(-b, -a)``
 
     ``g(-a, b) = delta(-a, b); g(b, -a) = -delta(a, -b)``
 
@@ -342,7 +342,7 @@ class TensorSymmetry(Basic):
     """
     Symmetry of a tensor
 
-    bsgs tuple (base, sgs) BSGS of the symmetry of the tensor
+    ``bsgs`` tuple (base, sgs) BSGS of the symmetry of the tensor
 
     Examples
     ========

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -546,6 +546,8 @@ class TensExpr(Basic):
         """
         Return a tensor with free indices substituted according to ``index_tuples``
 
+        ``index_types`` list of tuples ``(old_index, new_index)``
+
         Examples
         ========
 
@@ -680,7 +682,6 @@ class TensAdd(TensExpr):
     >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
     >>> t = p(a) + q(a); t
     p(a) + q(a)
-    >>> t.set_free_args([a])
     >>> t(b)
     p(b) + q(b)
     """
@@ -711,30 +712,15 @@ class TensAdd(TensExpr):
         if len(a) == 1:
             return a[0]
         obj._args = tuple(a)
-        obj.free_args = None
-        # attribute that can be assigned to make the tensor callable
         return obj
 
-    def set_free_args(self, free_args, sym=None):
-        """Set arguments to call a tensor.
-
-        ``free_args``  list of the free indices
-        It must be compatible with ``_free``
-
-        ``sym`` symmetry of the tensor (to be implemented)
-
-        """
-        t0 = self.args[0]
-        if not sorted([x[0] for x in t0._free]) == sorted(free_args):
-            raise ValueError('indices do not match')
-        self.free_args = free_args
+    @property
+    def free_args(self):
+        return self.args[0].free_args
 
 
     def __call__(self, *indices):
-        """Returns tensor with ``free_args`` indices replaced by ``indices``
-
-        If ``free_args`` is not defined or has not the same tensortypes
-        as ``indices`` an error is raised.
+        """Returns tensor with ordered free indices replaced by ``indices``
 
         Examples
         ========
@@ -747,7 +733,6 @@ class TensAdd(TensExpr):
         >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> g = Lorentz.metric
         >>> t = p(i0)*p(i1) + g(i0,i1)*q(i2)*q(-i2)
-        >>> t.set_free_args([i0,i1])
         >>> t(i0,i2)
         metric(i0, i2)*q(L_0)*q(-L_0) + p(i0)*p(i2)
         >>> t(i0,i1) - t(i1,i0)
@@ -755,14 +740,12 @@ class TensAdd(TensExpr):
         """
         free_args = self.free_args
         indices = list(indices)
-        if free_args is None:
-            raise ValueError('`free_args` has not been assigned')
-        indices = list(indices)
         if [x.tensortype for x in indices] != [x.tensortype for x in free_args]:
             raise ValueError('incompatible types')
+        if indices == free_args:
+            return self
         index_tuples = zip(free_args, indices)
         a = [x.fun_eval(*index_tuples) for x in self.args]
-        free_types = set([x.tensortype for x in free_args])
         res = TensAdd(*a)
 
         return res
@@ -889,8 +872,11 @@ class TensMul(TensExpr):
         obj._coeff = coeff
         obj._is_canon_bp = kw_args.get('is_canon_bp', False)
 
-        obj.free_args = None
         return obj
+
+    @property
+    def free_args(self):
+        return sorted([x[0] for x in self._free])
 
     def __eq__(self, other):
         if other == 0:
@@ -1412,24 +1398,9 @@ class TensMul(TensExpr):
                 free1.append((j, ipos, cpos))
         return TensMul(self._coeff, self._components, free1, self._dum)
 
-    def set_free_args(self, free_args, sym=None):
-        """Set arguments to call a tensor.
-
-        ``free_args``  list of the free indices
-        It must be compatible with ``_free``
-
-        ``sym`` symmetry of the tensor (to be implemented)
-
-        """
-        if not sorted([x[0] for x in self._free]) == sorted(free_args):
-            raise ValueError('indices do not match')
-        self.free_args = free_args
 
     def __call__(self, *indices):
-        """Returns tensor with ``free_args`` indices replaced by ``indices``
-
-        If ``free_args`` is not defined or has not the same tensortypes
-        as ``indices`` an error is raised.
+        """Returns tensor with ordered free indices replaced by ``indices``
 
         Examples
         ========
@@ -1442,16 +1413,15 @@ class TensMul(TensExpr):
         >>> g = Lorentz.metric
         >>> p, q = tensorhead('p,q', [Lorentz], [[1]])
         >>> t = p(i0)*q(i1)*q(-i1)
-        >>> t.set_free_args([i0])
         >>> t(i1)
         p(i1)*q(L_0)*q(-L_0)
         """
         free_args = self.free_args
-        if free_args is None:
-            raise ValueError('`free_args` has not been assigned')
         indices = list(indices)
         if [x.tensortype for x in indices] != [x.tensortype for x in free_args]:
             raise ValueError('incompatible types')
+        if indices == free_args:
+            return self
         t = self.fun_eval(*zip(free_args, indices))
         return t
 

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -4,9 +4,6 @@ from sympy.core.symbol import Symbol, symbols
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
 
 
-def is_Tensor(x):
-    return isinstance(x, TensExpr)
-
 
 class TensorIndexType(Basic):
     """
@@ -533,7 +530,7 @@ class TensExpr(Basic):
 
     def __div__(self, other):
         other = sympify(other)
-        if is_Tensor(other):
+        if isinstance(other, TensExpr):
             raise ValueError('cannot divide by a tensor')
         coeff = self._coeff/other
         return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
@@ -632,16 +629,16 @@ def _tensAdd_flatten(args):
     """
     flatten TensAdd, coerce terms which are not tensors to tensors
     """
-    if not all(is_Tensor(x) for x in args):
+    if not all(isinstance(x, TensExpr) for x in args):
         args1 = []
         for x in args:
-            if is_Tensor(x):
+            if isinstance(x, TensExpr):
                 if x.is_TensAdd:
                     args1.extend(list(x.args))
                 else:
                     args1.append(x)
-        args1 = [x for x in args1 if is_Tensor(x) and x._coeff]
-        args2 = [x for x in args if not is_Tensor(x)]
+        args1 = [x for x in args1 if isinstance(x, TensExpr) and x._coeff]
+        args2 = [x for x in args if not isinstance(x, TensExpr)]
         t0 = args1[0]
         if t0.is_TensAdd:
             t0 = t0.args[0]
@@ -767,8 +764,6 @@ class TensAdd(TensExpr):
         a = [x.fun_eval(*index_tuples) for x in self.args]
         free_types = set([x.tensortype for x in free_args])
         res = TensAdd(*a)
-        for typ in free_types:
-            res = res.contract_delta(typ.delta)
 
         return res
 
@@ -784,13 +779,13 @@ class TensAdd(TensExpr):
 
     def __eq__(self, other):
         other = sympify(other)
-        if not is_Tensor(other):
+        if not isinstance(other, TensExpr):
             if len(self.args) == 1:
                 return self.args[0]._coeff == other
-        if is_Tensor(other) and other.is_TensMul and other._coeff == 0:
+        if isinstance(other, TensExpr) and other.is_TensMul and other._coeff == 0:
             return self == 0
         t = self - other
-        if not is_Tensor(t):
+        if not isinstance(t, TensExpr):
             return t == 0
         else:
             if t.is_TensMul:
@@ -901,7 +896,7 @@ class TensMul(TensExpr):
         if other == 0:
             return self._coeff == 0
         other = sympify(other)
-        if not is_Tensor(other):
+        if not isinstance(other, TensExpr):
             assert not self._components
             return self._coeff == other
         res = self - other
@@ -1137,7 +1132,7 @@ class TensMul(TensExpr):
         p(L_0)*q(-L_0)
         """
         other = sympify(other)
-        if not is_Tensor(other):
+        if not isinstance(other, TensExpr):
             coeff = self._coeff*other
             return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
         if other.is_TensAdd:
@@ -1340,130 +1335,10 @@ class TensMul(TensExpr):
 
         if tg_free[0][0] in free_indices or tg_free[1][0] in free_indices:
             # tg has one free index
-            if tg_free[0][0] in free_indices:
-                ind_free = tg_free[0][0]
-                ind, ipos1, _ = tg_free[1]
-            else:
-                ind_free = tg_free[1][0]
-                ind, ipos1, _ = tg_free[0]
-
-            ind1 = -ind
-            # search ind1 in the other component tensors
-            for j, tx in enumerate(a):
-                if ind1 in [x[0] for x in tx._free]:
-                    break
-            # replace ind1 with ind_free
-            free1 = []
-            for indx, iposx, _ in tx._free:
-                if indx == ind1:
-                    free1.append((ind_free, iposx, 0))
-                else:
-                    free1.append((indx, iposx, 0))
-            coeff = tx._coeff
-            if antisym:
-                if ind.is_up and ind == tg_free[0][0] or \
-                (not ind.is_up) and ind == tg_free[1][0]:
-                    # g(i1, i0)*psi(-i1) = -psi(i0)
-                    # g(-i0, -i1)*psi(i1) = -psi(-i0)
-                    coeff = -coeff
-            t1 = TensMul(coeff, tx._components, free1, tx._dum)
-            a[j] = t1
-            a = a[:i] + a[i + 1:]
-            coeff = tg._coeff
-            res = tensor_mul(*a)
+            res = _contract_g_with_free_index(a, free_indices, i, tg, tg_free, g, antisym)
         else:
             # tg has two indices contracted with other tensors
-            ind1 = tg_free[0][0]
-            ind2 = tg_free[1][0]
-            ind1m = -ind1
-            ind2m = -ind2
-            for k, ty in enumerate(a):
-                if ind2m in [x[0] for x in ty._free]:
-                    break
-            # ty has the index ind2m
-            ty_free = ty._free[:]
-            if ty._components == [g]:
-                ty_indices = [x[0] for  x in ty._free]
-                if all(x in [ind1m, ind2m] for x in ty_indices):
-                    # the two `g` are completely contracted
-                    # i < k always
-                    a = a[:i] + a[i+1:k] + a[k+1:]
-                    coeff = coeff*typ.dim*tg._coeff*ty._coeff
-                    if antisym:
-                        ty_free = sorted(ty_free, key=lambda x: x[1])
-                        if ind1.is_up == ind2.is_up:
-                            # g(i,j)*g(-i,-j) = g(-i,-j)*g(i,j) = dim
-                            # g(i,j)*g(-j,-i) = g(-i,-j)*g(j,i) = -dim
-                            if ind1m == ty_free[1][0]:
-                                coeff = -coeff
-                        else:
-                            # g(-i,j)*g(i,-j) = g(i,-j)^g(-i,j) = -dim
-                            # g(-i,j)*g(-j,i) = g(i,-j)*g(j,i) = dim
-                            if ind1m == ty_free[0][0]:
-                                coeff = -coeff
-
-                    if a:
-                        res = tensor_mul(*a)
-                        res = coeff*res
-                    else:
-                        res = TensMul(coeff, [],[],[], is_canon_bp=True)
-                    if contract_all == True and g in res._components:
-                        return res._contract(g, antisym, True)
-                    return res
-
-            free2 = []
-            ty_freeindices = [x[0] for x in ty_free]
-            if ind1m in ty_freeindices:
-                # tg has both indices contracted with ty
-                free2 = [(indx, iposx, cposx) for indx, iposx, cposx in ty._free if indx != ind1m and indx != ind2m]
-                dum2 = ty._dum[:]
-                for indx, iposx, _ in ty._free:
-                    if indx == ind1m:
-                        iposx1 = iposx
-                    if indx == ind2m:
-                        iposx2 = iposx
-                if antisym:
-                    if ind1.is_up == ind2.is_up:
-                        if iposx1 < iposx2:
-                            coeff = -coeff
-                            dum2.append((iposx1, iposx2, 0, 0))
-                        else:
-                            dum2.append((iposx2, iposx1, 0, 0))
-                    else:
-                        if iposx1 > iposx2:
-                            coeff = -coeff
-                            dum2.append((iposx2, iposx1, 0, 0))
-                        else:
-                            dum2.append((iposx1, iposx2, 0, 0))
-                else:
-                    dum2.append((iposx1, iposx2, 0, 0))
-            else:
-                # replace ind2m with ind1 in the free indices of ty
-
-                free2 = []
-                if not antisym:
-                    for indx, iposx, _ in ty._free:
-                        if indx == ind2m:
-                            free2.append((ind1, iposx, 0))
-                        else:
-                            free2.append((indx, iposx, 0))
-                else:
-                    for indx, iposx, _ in ty._free:
-                        if indx == ind2m:
-                            free2.append((ind1, iposx, 0))
-                            if indx.is_up:
-                                coeff = -coeff
-                        else:
-                            free2.append((indx, iposx, 0))
-                            if not indx.is_up:
-                                coeff = -coeff
-                dum2 = ty._dum
-            t2 = TensMul(ty._coeff, ty._components, free2, dum2)
-            a[k] = t2
-            a = a[:i] + a[i + 1:]
-            coeff = coeff*tg._coeff
-            res = tensor_mul(*a)
-        res = coeff*res
+            res = _contract_g_without_free_index(a, free_indices, i, tg, tg_free, g, typ, antisym)
         if contract_all == True and g in res._components:
             return res._contract(g, antisym, True)
         return res
@@ -1609,7 +1484,7 @@ def canon_bp(p):
     """
     Butler-Portugal canonicalization
     """
-    if is_Tensor(p):
+    if isinstance(p, TensExpr):
         return p.canon_bp()
     return p
 
@@ -1689,3 +1564,138 @@ def riemann_cyclic(t2):
         return t3
     else:
         return canon_bp(t3)
+
+
+def _contract_g_with_free_index(a, free_indices, i, tg, tg_free, g, antisym):
+    """
+    helper function for _contract
+    """
+    if tg_free[0][0] in free_indices:
+        ind_free = tg_free[0][0]
+        ind, ipos1, _ = tg_free[1]
+    else:
+        ind_free = tg_free[1][0]
+        ind, ipos1, _ = tg_free[0]
+
+    ind1 = -ind
+    # search ind1 in the other component tensors
+    for j, tx in enumerate(a):
+        if ind1 in [x[0] for x in tx._free]:
+            break
+    # replace ind1 with ind_free
+    free1 = []
+    for indx, iposx, _ in tx._free:
+        if indx == ind1:
+            free1.append((ind_free, iposx, 0))
+        else:
+            free1.append((indx, iposx, 0))
+    coeff = tx._coeff
+    if antisym:
+        if ind.is_up and ind == tg_free[0][0] or \
+        (not ind.is_up) and ind == tg_free[1][0]:
+            # g(i1, i0)*psi(-i1) = -psi(i0)
+            # g(-i0, -i1)*psi(i1) = -psi(-i0)
+            coeff = -coeff
+    t1 = TensMul(coeff, tx._components, free1, tx._dum)
+    a[j] = t1
+    a = a[:i] + a[i + 1:]
+    coeff = tg._coeff
+    res = tensor_mul(*a)
+    return coeff*res
+
+
+def _contract_g_without_free_index(a, free_indices, i, tg, tg_free, g, typ, antisym):
+    """
+    helper function for _contract
+    """
+    coeff = S.One
+    ind1 = tg_free[0][0]
+    ind2 = tg_free[1][0]
+    ind1m = -ind1
+    ind2m = -ind2
+    for k, ty in enumerate(a):
+        if ind2m in [x[0] for x in ty._free]:
+            break
+    # ty has the index ind2m
+    ty_free = ty._free[:]
+    if ty._components == [g]:
+        ty_indices = [x[0] for  x in ty._free]
+        if all(x in [ind1m, ind2m] for x in ty_indices):
+            # the two `g` are completely contracted
+            # i < k always
+            a = a[:i] + a[i+1:k] + a[k+1:]
+            coeff = coeff*typ.dim*tg._coeff*ty._coeff
+            if antisym:
+                ty_free = sorted(ty_free, key=lambda x: x[1])
+                if ind1.is_up == ind2.is_up:
+                    # g(i,j)*g(-i,-j) = g(-i,-j)*g(i,j) = dim
+                    # g(i,j)*g(-j,-i) = g(-i,-j)*g(j,i) = -dim
+                    if ind1m == ty_free[1][0]:
+                        coeff = -coeff
+                else:
+                    # g(-i,j)*g(i,-j) = g(i,-j)^g(-i,j) = -dim
+                    # g(-i,j)*g(-j,i) = g(i,-j)*g(j,i) = dim
+                    if ind1m == ty_free[0][0]:
+                        coeff = -coeff
+
+            if a:
+                res = tensor_mul(*a)
+                res = coeff*res
+            else:
+                res = TensMul(coeff, [],[],[], is_canon_bp=True)
+            return res
+
+    free2 = []
+    ty_freeindices = [x[0] for x in ty_free]
+    if ind1m in ty_freeindices:
+        # tg has both indices contracted with ty
+        free2 = [(indx, iposx, cposx) for indx, iposx, cposx in ty._free if indx != ind1m and indx != ind2m]
+        dum2 = ty._dum[:]
+        for indx, iposx, _ in ty._free:
+            if indx == ind1m:
+                iposx1 = iposx
+            if indx == ind2m:
+                iposx2 = iposx
+        if antisym:
+            if ind1.is_up == ind2.is_up:
+                if iposx1 < iposx2:
+                    coeff = -coeff
+                    dum2.append((iposx1, iposx2, 0, 0))
+                else:
+                    dum2.append((iposx2, iposx1, 0, 0))
+            else:
+                if iposx1 > iposx2:
+                    coeff = -coeff
+                    dum2.append((iposx2, iposx1, 0, 0))
+                else:
+                    dum2.append((iposx1, iposx2, 0, 0))
+        else:
+            dum2.append((iposx1, iposx2, 0, 0))
+    else:
+        # replace ind2m with ind1 in the free indices of ty
+
+        free2 = []
+        if not antisym:
+            for indx, iposx, _ in ty._free:
+                if indx == ind2m:
+                    free2.append((ind1, iposx, 0))
+                else:
+                    free2.append((indx, iposx, 0))
+        else:
+            for indx, iposx, _ in ty._free:
+                if indx == ind2m:
+                    free2.append((ind1, iposx, 0))
+                    if indx.is_up:
+                        coeff = -coeff
+                else:
+                    free2.append((indx, iposx, 0))
+                    if not indx.is_up:
+                        coeff = -coeff
+        dum2 = ty._dum
+
+    t2 = TensMul(ty._coeff, ty._components, free2, dum2)
+    a[k] = t2
+    a = a[:i] + a[i + 1:]
+    coeff = coeff*tg._coeff
+    res = tensor_mul(*a)
+    return coeff*res

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -26,27 +26,6 @@ the Butler-Portugal algorithm for canonicalization.
 
 If there is a (anti)symmetric metric, the indices can be raised and
 lowered when the tensor is put in canonical form.
-
-
-
-TODO:
-
-* better integration in SymPy
-
-* term collection
-
-* introduce scalars:
-for example in ``p(a)*p(b)/(p**2 + m**2)`` the scalar ``p**2``
-is equivalent to the tensor ``p(c)*p(-c)``, but can appear in the denominator.
-
-* introduce tensor symmetrizers and algebraic operations on them
-
-* Rule for contraction of Levi-Civita ``epsilon`` tensors:
-one must intoduce generalized Kronecker deltas to do this properly
-
-* develop a Young tableaux model:
-one of its uses is in ``tensorsymmetry`` to provide the symmetry of the tensor
-using the Young diagrams
 """
 
 
@@ -242,8 +221,9 @@ class TensorIndexType(Basic):
         obj.epsilon = obj.get_epsilon()
         return obj
 
-    name = property(lambda self: self.args[0])
-
+    @property
+    def name(self):
+        return self.args[0]
 
     def get_kronecker_delta(self):
         sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
@@ -360,9 +340,17 @@ class TensorSymmetry(Basic):
         obj = Basic.__new__(cls, base, generators, **kw_args)
         return obj
 
-    base = property(lambda self: self.args[0])
-    generators = property(lambda self: self.args[1])
-    rank = property(lambda self: self.args[1][0].size)
+    @property
+    def base(self):
+        return self.args[0]
+
+    @property
+    def generators(self):
+        return self.args[1]
+
+    @property
+    def rank(self):
+        return self.args[1][0].size
 
     def _hashable_content(self):
         r = (tuple(self.base), tuple(self.generators))
@@ -458,11 +446,17 @@ class TensorType(Basic):
         obj = Basic.__new__(cls, index_types, symmetry, **kw_args)
         return obj
 
-    index_types = property(lambda self: self.args[0])
+    @property
+    def index_types(self):
+        return self.args[0]
 
-    symmetry = property(lambda self: self.args[1])
+    @property
+    def symmetry(self):
+        return self.args[1]
 
-    types = property(lambda self: sorted(set(self.index_types), key=lambda x: x.name))
+    @property
+    def types(self):
+        return sorted(set(self.index_types), key=lambda x: x.name)
 
     def __str__(self):
         return 'TensorType(%s)' %([str(x) for x in self.index_types])
@@ -567,8 +561,13 @@ class TensorHead(Basic):
         obj.comm = TensorManager.comm_symbols2i(comm)
         return obj
 
-    name = property(lambda self: self.args[0])
-    index_types = property(lambda self: self.args[1].index_types)
+    @property
+    def name(self):
+        return self.args[0]
+
+    @property
+    def index_types(self):
+        return self.args[1].index_types
 
     def __lt__(self, other):
         return (self.name, self.index_types) < (other.name, other.index_types)
@@ -651,9 +650,6 @@ class TensExpr(Basic):
 
     def __add__(self, other):
         other = sympify(other)
-        if self.is_TensAdd:
-            args = self.args + (other,)
-            return TensAdd(*args)
         return TensAdd(self, other)
 
     def __radd__(self, other):
@@ -698,47 +694,6 @@ class TensExpr(Basic):
 
     __truediv__ = __div__
     __rtruediv__ = __rdiv__
-
-    def substitute_indices(self, *index_tuples):
-        """
-        Return a tensor with free indices substituted according to ``index_tuples``
-
-        ``index_types`` list of tuples ``(old_index, new_index)``
-
-        Examples
-        ========
-
-        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
-        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-        >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
-        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
-        >>> t = A(i, k)*B(-k, -j); t
-        A(i, L_0)*B(-L_0, -j)
-        >>> t.substitute_indices((i,j), (j, k))
-        A(j, L_0)*B(-L_0, -k)
-        """
-        if self.is_TensMul:
-            free = self._free
-            free1 = []
-            for j, ipos, cpos in free:
-                for i, v in index_tuples:
-                    if i.name == j.name and i.tensortype == j.tensortype:
-                        if i.is_up == j.is_up:
-                            free1.append((v, ipos, cpos))
-                        else:
-                            free1.append((-v, ipos, cpos))
-                        break
-                else:
-                    free1.append((j, ipos, cpos))
-
-            return TensMul(self._coeff, self._components, free1, self._dum)
-        if self.is_TensAdd:
-            args = self.args
-            args1 = []
-            for x in args:
-                y = x.substitute_indices(*index_tuples)
-                args1.append(y)
-            return TensAdd(*args1)
 
 
 def _tensAdd_collect_terms(args):
@@ -989,6 +944,27 @@ class TensAdd(TensExpr):
         args1 = []
         for x in args:
             y = x.fun_eval(*index_tuples)
+            args1.append(y)
+        return TensAdd(*args1)
+
+    def substitute_indices(self, *index_tuples):
+        """
+        Return a tensor with free indices substituted according to ``index_tuples``
+
+        ``index_types`` list of tuples ``(old_index, new_index)``
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
+        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
+        """
+        args = self.args
+        args1 = []
+        for x in args:
+            y = x.substitute_indices(*index_tuples)
             args1.append(y)
         return TensAdd(*args1)
 
@@ -1521,6 +1497,39 @@ class TensMul(TensExpr):
             raise NotImplementedError
         return self._contract(g, g.index_types[0].metric_antisym, contract_all)
 
+
+    def substitute_indices(self, *index_tuples):
+        """
+        Return a tensor with free indices substituted according to ``index_tuples``
+
+        ``index_types`` list of tuples ``(old_index, new_index)``
+
+        Examples
+        ========
+
+        >>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, tensorhead
+        >>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+        >>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
+        >>> A, B = tensorhead('A,B', [Lorentz]*2, [[1]*2])
+        >>> t = A(i, k)*B(-k, -j); t
+        A(i, L_0)*B(-L_0, -j)
+        >>> t.substitute_indices((i,j), (j, k))
+        A(j, L_0)*B(-L_0, -k)
+        """
+        free = self._free
+        free1 = []
+        for j, ipos, cpos in free:
+            for i, v in index_tuples:
+                if i.name == j.name and i.tensortype == j.tensortype:
+                    if i.is_up == j.is_up:
+                        free1.append((v, ipos, cpos))
+                    else:
+                        free1.append((-v, ipos, cpos))
+                    break
+            else:
+                free1.append((j, ipos, cpos))
+
+        return TensMul(self._coeff, self._components, free1, self._dum)
 
     def fun_eval(self, *index_tuples):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -364,6 +364,10 @@ class TensorSymmetry(Basic):
     generators = property(lambda self: self.args[1])
     rank = property(lambda self: self.args[1][0].size)
 
+    def _hashable_content(self):
+        r = (tuple(self.base), tuple(self.generators))
+        return r
+
 def tensorsymmetry(*args):
     """
     return a ``TensorSymmetry`` object
@@ -565,6 +569,10 @@ class TensorHead(Basic):
 
     def __lt__(self, other):
         return (self.name, self.index_types) < (other.name, other.index_types)
+
+    def _hashable_content(self):
+        r = (self.name, tuple(self.types), self.symmetry, self.comm)
+        return r
 
     def commutes_with(self, other):
         """
@@ -921,6 +929,9 @@ class TensAdd(TensExpr):
             else:
                 return all(x._coeff == 0 for x in t.args)
 
+    def _hashable_content(self):
+        return tuple(self.args)
+
     def __ne__(self, other):
         return not (self == other)
 
@@ -1031,6 +1042,12 @@ class TensMul(TensExpr):
             return self._coeff == other
         res = self - other
         return res == 0
+
+    def _hashable_content(self):
+        t = self.canon_bp()
+        r = (t._coeff, tuple(t._components), \
+                tuple(sorted(t._free)), tuple(sorted(t._dum)))
+        return r
 
     def __ne__(self, other):
         return not self == other

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -61,6 +61,25 @@ class _TensorManager(object):
         self._comm[0][0] = 0
         self._comm[0][1] = 0
         self._comm[1][0] = 1
+        self._comm_symbols2i = {0:0, 1:1}
+        self._comm_i2symbol = {0:0, 1:1}
+
+    def comm_symbols2i(self, i):
+        """
+        get the commutation group number corresponding to ``i``
+
+        ``i`` can be a symbol or a number
+        """
+        if i not in self._comm_symbols2i:
+            n = len(self._comm_symbols2i)
+            self._comm[n][0] = 0
+            self._comm[0][n] = 0
+            self._comm_symbols2i[i] = n
+            return n
+        return self._comm_symbols2i[i]
+
+    def comm_i2symbol(self, i):
+        return self._comm_i2symbol[i]
 
     def set_comm(self, i, j, c):
         """
@@ -100,15 +119,22 @@ class _TensorManager(object):
         >>> (G(i1)*A(i0)).canon_bp()
         A(i0)*G(i1)
         """
-        if i not in self._comm.keys():
-            self._comm[i][0] = 0
-            self._comm[0][i] = 0
+        if i not in self._comm_symbols2i:
+            n = len(self._comm_symbols2i)
+            self._comm[n][0] = 0
+            self._comm[0][n] = 0
+            self._comm_symbols2i[i] = n
+            self._comm_i2symbol[n] = i
         if j not in self._comm.keys():
-            self._comm[0][j] = 0
-        if j not in self._comm[i]:
-            self._comm[i][j] = c
-        if i not in self._comm[j]:
-            self._comm[j][i] = c
+            n = len(self._comm_symbols2i)
+            self._comm[0][n] = 0
+            self._comm[n][0] = 0
+            self._comm_symbols2i[j] = n
+            self._comm_i2symbol[n] = j
+        ni = self._comm_symbols2i[i]
+        nj = self._comm_symbols2i[j]
+        self._comm[ni][nj] = c
+        self._comm[nj][ni] = c
 
     def set_comms(self, *args):
         for i, j, c in range(len(args)):
@@ -120,10 +146,12 @@ class _TensorManager(object):
 
         see ``_TensorManager.set_comm``
         """
-        if i == 0 or j == 0:
-            return 0
-        return self._comm[i].get(j)
-
+        try:
+            return self._comm[i].get(j, 0 if i*j == 0 else None)
+        except IndexError:
+            if j == 0:
+                return 0
+            return None
 
     def clear(self):
         for i in range(2, len(self._comm)):
@@ -532,7 +560,7 @@ class TensorHead(Basic):
         obj.rank = len(obj.index_types)
         obj.types = typ.types
         obj.symmetry = typ.symmetry
-        obj.comm = comm
+        obj.comm = TensorManager.comm_symbols2i(comm)
         return obj
 
     name = property(lambda self: self.args[0])

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -5,6 +5,7 @@ from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
   tensorlist_contract_metric, TensMul)
+from sympy.utilities.pytest import raises
 
 #################### Tests from tensor_can.py #######################
 
@@ -393,6 +394,30 @@ def test_riemann_products():
     tc = t.canon_bp()
     assert str(tc) == 'R(a0, L_0, a2, L_1)*R(a1, a3, -L_0, L_2)*R(a4, a5, -L_1, -L_2)'
 ######################################################################
+
+def test_canonicalize2():
+    D = Symbol('D')
+    Eucl = TensorIndexType('Eucl', metric_sym=0, dim=D, dummy_fmt='E')
+    i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14 = \
+      tensor_indices('i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14', Eucl)
+    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    S3a = TensorType([Eucl]*3, sym3a)
+    A = S3a('A')
+
+    # two examples from Cvitanovic, Group Theory page 59
+    # of identities for antisymmetric tensors of rank 3
+    # contracted according to the Kuratowski graph  eq.(6.59)
+    t = A(i0,i1,i2)*A(-i1,i3,i4)*A(-i3,i7,i5)*A(-i2,-i5,i6)*A(-i4,-i6,i8)
+    t1 = t.canon_bp()
+    assert t1 == 0
+
+    # eq.(6.60)
+    #t = A(i0,i1,i2)*A(-i1,i3,i4)*A(-i2,i5,i6)*A(-i3,i7,i8)*A(-i6,-i7,i9)*
+    #    A(-i8,i10,i13)*A(-i5,-i10,i11)*A(-i4,-i11,i12)*A(-i3,-i12,i14)
+    t = A(i0,i1,i2)*A(-i1,i3,i4)*A(-i2,i5,i6)*A(-i3,i7,i8)*A(-i6,-i7,i9)*\
+        A(-i8,i10,i13)*A(-i5,-i10,i11)*A(-i4,-i11,i12)*A(-i9,-i12,i14)
+    t1 = t.canon_bp()
+    assert t1 == 0
 
 
 def test_get_indices():

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1,0 +1,665 @@
+from sympy.core import S, Rational, Symbol
+from sympy.combinatorics import Permutation
+from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
+from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
+  TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
+  tensor_mul, canon_bp, TensAdd, riemann_cyclic_replaceR, riemann_cyclic)
+
+def test_get_indices():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    t = A(a,b)*B(-b,c)
+    indices = t.get_indices()
+    L_0 = TensorIndex('L_0', Lorentz)
+    assert indices == [a, L_0, -L_0, c]
+    a = t.split()
+    t2 = tensor_mul(*a)
+    assert t == t2
+
+def test_canonicalize_no_slot_sym():
+    # A_d0 * B^d0; T_c = A^d0*B_d0
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, d0, d1 = tensor_indices('a,b,d0,d1', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym1)
+    A, B = S1('A,B')
+    t = A(-d0)*B(d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0)*B(-L_0)'
+
+    # A^a * B^b;  T_c = T
+    t = A(a)*B(b)
+    tc = t.canon_bp()
+    assert tc == t
+    # B^b * A^a
+    t1 = B(b)*A(a)
+    tc = t1.canon_bp()
+    assert str(tc) == 'A(a)*B(b)'
+
+    # A symmetric
+    # A^{b}_{d0}*A^{d0, a}; T_c = A^{a d0}*A{b}_{d0}
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A = S2('A')
+    t = A(b, -d0)*A(d0, a)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, L_0)*A(b, -L_0)'
+
+    # A^{d1}_{d0}*B^d0*C_d1
+    # T_c = A^{d0 d1}*B_d0*C_d1
+    B, C = S1('B,C')
+    t = A(d1, -d0)*B(d0)*C(-d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_0)*C(-L_1)'
+
+    # A without symmetry
+    # A^{d1}_{d0}*B^d0*C_d1 ord=[d0,-d0,d1,-d1]; g = [2,1,0,3,4,5]
+    # T_c = A^{d0 d1}*B_d1*C_d0; can = [0,2,3,1,4,5]
+    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    NS2 = TensorType([Lorentz]*2, nsym2)
+    A = NS2('A')
+    B, C = S1('B,C')
+    t = A(d1, -d0)*B(d0)*C(-d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_1)*C(-L_0)'
+
+    # A, B without symmetry
+    # A^{d1}_{d0}*B_{d1}^{d0}
+    # T_c = A^{d0 d1}*B_{d0 d1}
+    B = NS2('B')
+    t = A(d1, -d0)*B(-d1, d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_0, -L_1)'
+    # A_{d0}^{d1}*B_{d1}^{d0}
+    # T_c = A^{d0 d1}*B_{d1 d0}
+    t = A(-d0, d1)*B(-d1, d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-L_1, -L_0)'
+
+    # A, B, C without symmetry
+    # A^{d1 d0}*B_{a d0}*C_{d1 b}
+    # T_c=A^{d0 d1}*B_{a d1}*C_{d0 b}
+    C = NS2('C')
+    t = A(d1, d0)*B(-a, -d0)*C(-d1, -b)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-a, -L_1)*C(-L_0, -b)'
+
+    # A symmetric, B and C without symmetry
+    # A^{d1 d0}*B_{a d0}*C_{d1 b}
+    # T_c = A^{d0 d1}*B_{a d0}*C_{d1 b}
+    A = S2('A')
+    t = A(d1, d0)*B(-a, -d0)*C(-d1, -b)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-a, -L_0)*C(-L_1, -b)'
+
+    # A and C symmetric, B without symmetry
+    # A^{d1 d0}*B_{a d0}*C_{d1 b} ord=[a,b,d0,-d0,d1,-d1]
+    # T_c = A^{d0 d1}*B_{a d0}*C_{b d1}
+    C = S2('C')
+    t = A(d1, d0)*B(-a, -d0)*C(-d1, -b)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1)*B(-a, -L_0)*C(-b, -L_1)'
+
+def test_canonicalize_no_dummies():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+
+    # A commuting
+    # A^c A^b A^a
+    # T_c = A^a A^b A^c
+    S1 = TensorType([Lorentz], sym1)
+    A = S1('A')
+    t = A(c)*A(b)*A(a)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a)*A(b)*A(c)'
+
+    # A anticommuting
+    # A^c A^b A^a
+    # T_c = -A^a A^b A^c
+    A = S1('A', 1)
+    t = A(c)*A(b)*A(a)
+    tc = t.canon_bp()
+    assert str(tc) == '-A(a)*A(b)*A(c)'
+
+    # A commuting and symmetric
+    # A^{b,d}*A^{c,a}
+    # T_c = A^{a c}*A^{b d}
+    S2 = TensorType([Lorentz]*2, sym2)
+    A = S2('A')
+    t = A(b, d)*A(c, a)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, c)*A(b, d)'
+
+    # A anticommuting and symmetric
+    # A^{b,d}*A^{c,a}
+    # T_c = -A^{a c}*A^{b d}
+    A = S2('A', 1)
+    t = A(b, d)*A(c, a)
+    tc = t.canon_bp()
+    assert str(tc) == '-A(a, c)*A(b, d)'
+
+    # A^{c,a}*A^{b,d}
+    # T_c = A^{a c}*A^{b d}
+    t = A(c, a)*A(b, d)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, c)*A(b, d)'
+
+def test_no_metric_symmetry():
+    # no metric symmetry; A no symmetry
+    # A^d1_d0 * A^d0_d1
+    # T_c = A^d0_d1 * A^d1_d0
+    Lorentz = TensorIndexType('Lorentz', metric_sym=None, dummy_fmt='L')
+    d0, d1, d2, d3 = tensor_indices('d0,d1,d2,d3', Lorentz)
+    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    NS2 = TensorType([Lorentz]*2, nsym2)
+    A = NS2('A')
+    t = A(d1, -d0)*A(d0, -d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_0)'
+
+    # A^d1_d2 * A^d0_d3 * A^d2_d1 * A^d3_d0
+    # T_c = A^d0_d1 * A^d1_d0 * A^d2_d3 * A^d3_d2
+    t = A(d1, -d2)*A(d0, -d3)*A(d2,-d1)*A(d3,-d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_0)*A(L_2, -L_3)*A(L_3, -L_2)'
+
+    # A^d0_d2 * A^d1_d3 * A^d3_d0 * A^d2_d1
+    # T_c = A^d0_d1 * A^d1_d2 * A^d2_d3 * A^d3_d0
+    t = A(d0, -d1)*A(d1, -d2)*A(d2, -d3)*A(d3,-d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, -L_1)*A(L_1, -L_2)*A(L_2, -L_3)*A(L_3, -L_0)'
+
+def test_canonicalize1():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Lorentz)
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    base3, gens3 = get_symmetric_group_sgs(3)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym3 = TensorSymmetry(get_symmetric_group_sgs(3))
+    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+
+    # A_d0*A^d0; ord = [d0,-d0]
+    # T_c = A^d0*A_d0
+    S1 = TensorType([Lorentz], sym1)
+    A = S1('A')
+    t = A(-d0)*A(d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0)*A(-L_0)'
+
+    # A commuting
+    # A_d0*A_d1*A_d2*A^d2*A^d1*A^d0
+    # T_c = A^d0*A_d0*A^d1*A_d1*A^d2*A_d2
+    t = A(-d0)*A(-d1)*A(-d2)*A(d2)*A(d1)*A(d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0)*A(-L_0)*A(L_1)*A(-L_1)*A(L_2)*A(-L_2)'
+
+    # A anticommuting
+    # A_d0*A_d1*A_d2*A^d2*A^d1*A^d0
+    # T_c 0
+    A = S1('A', 1)
+    t = A(-d0)*A(-d1)*A(-d2)*A(d2)*A(d1)*A(d0)
+    tc = t.canon_bp()
+    assert tc == 0
+
+    # A commuting symmetric
+    # A^{d0 b}*A^a_d1*A^d1_d0
+    # T_c = A^{a d0}*A^{b d1}*A_{d0 d1}
+    S2 = TensorType([Lorentz]*2, sym2)
+    A = S2('A')
+    t = A(d0, b)*A(a, -d1)*A(d1, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, L_0)*A(b, L_1)*A(-L_0, -L_1)'
+
+    # A, B commuting symmetric
+    # A^{d0 b}*A^d1_d0*B^a_d1
+    # T_c = A^{b d0}*A_d0^d1*B^a_d1
+    B = S2('B')
+    t = A(d0, b)*A(d1, -d0)*B(a, -d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(b, L_0)*A(-L_0, L_1)*B(a, -L_1)'
+
+    # A commuting symmetric
+    # A^{d1 d0 b}*A^{a}_{d1 d0}; ord=[a,b, d0,-d0,d1,-d1]
+    # T_c = A^{a d0 d1}*A^{b}_{d0 d1}
+    S3 = TensorType([Lorentz]*3, sym3)
+    A = S3('A')
+    t = A(d1, d0, b)*A(a, -d1, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a, L_0, L_1)*A(b, -L_0, -L_1)'
+
+    # A^{d3 d0 d2}*A^a0_{d1 d2}*A^d1_d3^a1*A^{a2 a3}_d0
+    # T_c = A^{a0 d0 d1}*A^a1_d0^d2*A^{a2 a3 d3}*A_{d1 d2 d3}
+    t = A(d3, d0, d2)*A(a0, -d1, -d2)*A(d1, -d3, a1)*A(a2, a3, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(a0, L_0, L_1)*A(a1, -L_0, L_2)*A(a2, a3, L_3)*A(-L_1, -L_2, -L_3)'
+
+    # A commuting symmetric, B antisymmetric
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # in this esxample and in the next three,
+    # renaming dummy indices and using symmetry of A,
+    # T = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
+    # can = 0
+    S2a = TensorType([Lorentz]*2, sym2a)
+    A = S3('A')
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert tc == 0
+
+    # A anticommuting symmetric, B anticommuting
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # T_c = A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
+    A = S3('A', 1)
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(L_0, L_1, L_2)*A(-L_0, -L_1, L_3)*B(-L_2, -L_3)'
+
+    # A anticommuting symmetric, B antisymmetric commuting, antisymmetric metric
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # T_c = -A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
+    Spinor = TensorIndexType('Spinor', metric_sym=1, dummy_fmt='S')
+    a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
+    S3 = TensorType([Spinor]*3, sym3)
+    S2a = TensorType([Spinor]*2, sym2a)
+    A = S3('A', 1)
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert str(tc) == '-A(S_0, S_1, S_2)*A(-S_0, -S_1, S_3)*B(-S_2, -S_3)'
+
+    # A anticommuting symmetric, B antisymmetric anticommuting,
+    # no metric symmetry
+    # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
+    # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
+    Mat = TensorIndexType('Mat', metric_sym=None, dummy_fmt='M')
+    a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
+    S3 = TensorType([Mat]*3, sym3)
+    S2a = TensorType([Mat]*2, sym2a)
+    A = S3('A', 1)
+    B = S2a('B')
+    t = A(d0, d1, d2)*A(-d2, -d3, -d1)*B(-d0, d3)
+    tc = t.canon_bp()
+    assert str(tc) == 'A(M_0, M_1, M_2)*A(-M_0, -M_1, -M_3)*B(-M_2, M_3)'
+
+    # Gamma anticommuting
+    # Gamma_{mu nu} * gamma^rho * Gamma^{nu mu alpha}
+    # T_c = -Gamma^{mu nu} * gamma^rho * Gamma_{alpha mu nu}
+    S1 = TensorType([Lorentz], sym1)
+    S2a = TensorType([Lorentz]*2, sym2a)
+    S3a = TensorType([Lorentz]*3, sym3a)
+    alpha, beta, gamma, mu, nu, rho = \
+      tensor_indices('alpha,beta,gamma,mu,nu,rho', Lorentz)
+    Gamma = S1('Gamma', None)
+    Gamma2 = S2a('Gamma', None)
+    Gamma3 = S3a('Gamma', None)
+    t = Gamma2(-mu,-nu)*Gamma(rho)*Gamma3(nu, mu, alpha)
+    tc = t.canon_bp()
+    assert str(tc) == '-Gamma(L_0, L_1)*Gamma(rho)*Gamma(alpha, -L_0, -L_1)'
+
+    # Gamma_{mu nu} * Gamma^{gamma beta} * gamma_rho * Gamma^{nu mu alpha}
+    # T_c = Gamma^{mu nu} * Gamma^{beta gamma} * gamma_rho * Gamma^alpha_{mu nu}
+    t = Gamma2(mu, nu)*Gamma2(beta, gamma)*Gamma(-rho)*Gamma3(alpha, -mu, -nu)
+    tc = t.canon_bp()
+    assert str(tc) == 'Gamma(L_0, L_1)*Gamma(beta, gamma)*Gamma(-rho)*Gamma(alpha, -L_0, -L_1)'
+
+    # f^a_{b,c} antisymmetric in b,c; A_mu^a no symmetry
+    # f^c_{d a} * f_{c e b} * A_mu^d * A_nu^a * A^{nu e} * A^{mu b}
+    # g = [8,11,5, 9,13,7, 1,10, 3,4, 2,12, 0,6, 14,15]
+    # T_c = -f^{a b c} * f_a^{d e} * A^mu_b * A_{mu d} * A^nu_c * A_{nu e}
+    Flavor = TensorIndexType('Flavor', dummy_fmt='F')
+    a, b, c, d, e, ff = tensor_indices('a,b,c,d,e,f', Flavor)
+    mu, nu = tensor_indices('mu,nu', Lorentz)
+    sym_f = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators,
+            sym2a.base, sym2a.generators))
+    S_f = TensorType([Flavor]*3, sym_f)
+    sym_A = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators, sym1.base, sym1.generators))
+    S_A = TensorType([Lorentz, Flavor], sym_A)
+    f = S_f('f')
+    A = S_A('A')
+    t = f(c, -d, -a)*f(-c, -e, -b)*A(-mu, d)*A(-nu, a)*A(nu, e)*A(mu, b)
+    tc = t.canon_bp()
+    assert str(tc) == '-f(F_0, F_1, F_2)*f(-F_0, F_3, F_4)*A(L_0, -F_1)*A(-L_0, -F_3)*A(L_1, -F_2)*A(-L_1, -F_4)'
+
+
+def test_riemann_invariants():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11 = \
+      tensor_indices(','.join(['d%d' % i for i in range(12)]), Lorentz)
+    # R^{d0 d1}_{d1 d0}; ord = [d0,-d0,d1,-d1]
+    # T_c = -R^{d0 d1}_{d0 d1}
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R', 0)
+    t = R(d0, d1, -d1, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(L_0, L_1, -L_0, -L_1)'
+
+    # R_d11^d1_d0^d5 * R^{d6 d4 d0}_d5 * R_{d7 d2 d8 d9} *
+    # R_{d10 d3 d6 d4} * R^{d2 d7 d11}_d1 * R^{d8 d9 d3 d10}
+    # can = [0,2,4,6, 1,3,8,10, 5,7,12,14, 9,11,16,18, 13,15,20,22,
+    #        17,19,21<F10,23, 24,25]
+    # T_c = R^{d0 d1 d2 d3} * R_{d0 d1}^{d4 d5} * R_{d2 d3}^{d6 d7} *
+    # R_{d4 d5}^{d8 d9} * R_{d6 d7}^{d10 d11} * R_{d8 d9 d10 d11}
+
+
+    t = R(-d11,d1,-d0,d5)*R(d6,d4,d0,-d5)*R(-d7,-d2,-d8,-d9)* \
+        R(-d10,-d3,-d6,-d4)*R(d2,d7,d11,-d1)*R(d8,d9,d3,d10)
+    tc = t.canon_bp()
+    assert str(tc) == 'R(L_0, L_1, L_2, L_3)*R(-L_0, -L_1, L_4, L_5)*R(-L_2, -L_3, L_6, L_7)*R(-L_4, -L_5, L_8, L_9)*R(-L_6, -L_7, L_10, L_11)*R(-L_8, -L_9, -L_10, -L_11)'
+
+def test_riemann_products():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    d0, d1, d2, d3, d4, d5, d6= \
+      tensor_indices(','.join(['d%d' % i for i in range(7)]), Lorentz)
+    a0, a1, a2, a3, a4, a5 = \
+      tensor_indices(','.join(['a%d' % i for i in range(6)]), Lorentz)
+    a, b = tensor_indices('a,b', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    # R^{a b d0}_d0 = 0
+    t = R(a, b, d0, -d0)
+    tc = t.canon_bp()
+    assert tc == 0
+
+    # R^{d0 b a}_d0
+    # T_c = -R^{a d0 b}_d0
+    t = R(d0, b, a, -d0)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(a, L_0, b, -L_0)'
+
+    # R^d1_d2^b_d0 * R^{d0 a}_d1^d2; ord=[a,b,d0,-d0,d1,-d1,d2,-d2]
+    # T_c = -R^{a d0 d1 d2}* R^b_{d0 d1 d2}
+    t = R(d1, -d2, b, -d0)*R(d0, a, -d1, d2)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(a, L_0, L_1, L_2)*R(b, -L_0, -L_1, -L_2)'
+
+    # A symmetric commuting
+    # R^{d6 d5}_d2^d1 * R^{d4 d0 d2 d3} * A_{d6 d0} A_{d3 d1} * A_{d4 d5}
+    # g = [12,10,5,2, 8,0,4,6, 13,1, 7,3, 9,11,14,15]
+    # T_c = -R^{d0 d1 d2 d3} * R_d0^{d4 d5 d6} * A_{d1 d4}*A_{d2 d5}*A_{d3 d6}
+    S2 = TensorType([Lorentz]*2, sym2)
+    V = S2('V')
+    t = R(d6, d5, -d2, d1)*R(d4, d0, d2, d3)*V(-d6, -d0)*V(-d3, -d1)*V(-d4, -d5)
+    tc = t.canon_bp()
+    assert str(tc) == '-R(L_0, L_1, L_2, L_3)*R(-L_0, L_4, L_5, L_6)*V(-L_1, -L_4)*V(-L_2, -L_5)*V(-L_3, -L_6)'
+
+    # R^{d2 a0 a2 d0} * R^d1_d2^{a1 a3} * R^{a4 a5}_{d0 d1}
+    # T_c = R^{a0 d0 a2 d1}*R^{a1 a3}_d0^d2*R^{a4 a5}_{d1 d2}
+    t = R(d2, a0, a2, d0)*R(d1, -d2, a1, a3)*R(a4, a5, -d0, -d1)
+    tc = t.canon_bp()
+    assert str(tc) == 'R(a0, L_0, a2, L_1)*R(a1, a3, -L_0, L_2)*R(a4, a5, -L_1, -L_2)'
+
+
+def test_add1():
+    # simple example of algebraic expression
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a,b,d0,d1,i,j,k = tensor_indices('a,b,d0,d1,i,j,k', Lorentz)
+    # A, B symmetric
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    t1 = A(b,-d0)*B(d0,a)
+    t2a = B(d0,a) + A(d0, a)
+    t2 = A(b,-d0)*t2a
+    assert str(t2) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0)'
+    t2b = t2 + t1
+    assert str(t2b) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0) + A(b, L_0)*B(a, -L_0)'
+    S1 = TensorType([Lorentz], sym1)
+    p, q, r = S1('p,q,r')
+    t = q(d0)*2
+    assert str(t) == '2*q(d0)'
+    t = 2*q(d0)
+    assert str(t) == '2*q(d0)'
+    t1 = p(d0) + 2*q(d0)
+    assert str(t1) == '2*q(d0) + p(d0)'
+    t2 = p(-d0) + 2*q(-d0)
+    assert str(t2) == '2*q(-d0) + p(-d0)'
+    t1 = p(d0)
+    t3 = t1*t2
+    assert str(t3) == '2*p(L_0)*q(-L_0) + p(L_0)*p(-L_0)'
+    t3 = t2*t1
+    assert str(t3) == '2*p(L_0)*q(-L_0) + p(L_0)*p(-L_0)'
+    t1 = p(d0) + 2*q(d0)
+    t3 = t1*t2
+    assert str(t3) == '4*p(L_0)*q(-L_0) + 4*q(L_0)*q(-L_0) + p(L_0)*p(-L_0)'
+    t1 =  p(d0) - 2*q(d0)
+    assert str(t1) == '-2*q(d0) + p(d0)'
+    t2 = p(-d0) + 2*q(-d0)
+    t3 = t1*t2
+    assert t3 == p(d0)*p(-d0) - 4*q(d0)*q(-d0)
+    t = p(i)*p(j)*(p(k) + q(k)) + p(i)*(p(j) + q(j))*(p(k) - 3*q(k))
+    assert t == 2*p(i)*p(j)*p(k) - 2*p(i)*p(j)*q(k) + p(i)*p(k)*q(j) - 3*p(i)*q(j)*q(k)
+    t1 = (p(i) + q(i) + 2*r(i))*(p(j) - q(j))
+    t2 = (p(j) + q(j) + 2*r(j))*(p(i) - q(i))
+    t = t1 + t2
+    assert t == 2*p(i)*p(j) + 2*p(i)*r(j) + 2*p(j)*r(i) - 2*q(i)*q(j) - 2*q(i)*r(j) - 2*q(j)*r(i)
+
+def test_add2():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m, n, p, q = tensor_indices('m,n,p,q', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    R4 = TensorType([Lorentz]*4, symr)
+    S3a = TensorType([Lorentz]*3, sym3a)
+    R = R4('R')
+    A = S3a('A')
+    t1 = 2*R(m,n,p,q) - R(m,q,n,p) + R(m,p,n,q)
+    t2 = t1*A(-n,-p,-q)
+    assert t2 == 0
+    t1 = S(2)/3*R(m,n,p,q) - S(1)/3*R(m,q,n,p) + S(1)/3*R(m,p,n,q)
+    t2 = t1*A(-n,-p,-q)
+    assert t2 == 0
+
+
+def test_substitute_indices():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    t = A(i, k)*B(-k, -j)
+    t1 = t.substitute_indices((i,j), (j, k))
+    t1a = A(j, l)*B(-l, -k)
+    assert t1 == t1a
+
+def test_riemann_cyclic_replaceR():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    t = R(m0,m2,m1,m3)
+    t1 = riemann_cyclic_replaceR(t)
+    t1a =  -S.One/3*R(m0, m3, m2, m1) + S.One/3*R(m0, m1, m2, m3) + Rational(2,3)*R(m0, m2, m1, m3)
+    assert t1 == t1a
+
+def test_riemann_cyclic():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    t = R(i,j,k,l) + R(i,l,j,k) + R(i,k,l,j) - \
+        R(i,j,l,k) - R(i,l,k,j) - R(i,k,j,l)
+    t2 = t*R(-i,-j,-k,-l)
+    t3 = riemann_cyclic(t2)
+    assert t3 == 0
+    t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
+    t1 = riemann_cyclic(t)
+    assert t1 == 0
+
+    t = R(i,j,k,l)*R(-k,-l,m,n)*(R(-m,-n,-i,-j) + 2*R(-m,-j,-n,-i))
+    t1 = riemann_cyclic(t)
+    assert t1 == 0
+
+def test_div():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+    symr = TensorSymmetry(riemann_bsgs)
+    R4 = TensorType([Lorentz]*4, symr)
+    R = R4('R')
+    t = R(m0,m1,-m1,m3)
+    t1 = t/S(4)
+    assert str(t1) == '1/4*R(m0, L_0, -L_0, m3)'
+    t = t.canon_bp()
+    assert not t1._is_canon_bp
+    t1 = t*4
+    assert t1._is_canon_bp
+    t1 = t1/4
+    assert t1._is_canon_bp
+
+def test_metric_contract1():
+    D = Symbol('D')
+    Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+    a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    g = Lorentz.metric
+    A, B = S2('A,B')
+
+    # case with g with all free indices
+    t1 = A(a,b)*B(-b,c)*g(d, e)
+    t2 = t1.contract_metric(g)
+    assert t1 == t2
+
+    # case of g(d, -d)
+    t1 = A(a,b)*B(-b,c)*g(-d, d)
+    t2 = t1.contract_metric(g)
+    assert t2 == D*A(a, d)*B(-d, c)
+
+    # g with one free index
+    t1 = A(a,b)*B(-b,-c)*g(c, d)
+    t2 = t1.contract_metric(g)
+    assert t2 == A(a, c)*B(-c, d)
+
+    # g with both indices contracted with another tensor
+    t1 = A(a,b)*B(-b,-c)*g(c, -a)
+    t2 = t1.contract_metric(g)
+    assert t2 == A(a, b)*B(-b, -a)
+
+    t1 = A(a,b)*B(-b,-c)*g(c, d)*g(-a, -d)
+    t2 = t1.contract_metric(g)
+    t2 = t2.contract_metric(g)
+    assert t2 == A(a,b)*B(-b,-a)
+
+def test_metric_contract1():
+    D = Symbol('D')
+    Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+    a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
+    g = Lorentz.metric
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym1)
+    p, q = S1('p,q')
+
+    t1 = g(a,b)*p(c)*p(-c)
+    t2 = 3*g(-a,-b)*q(c)*q(-c)
+    t = t1*t2
+    t = t.contract_metric(g)
+    t = t.contract_metric(g)
+    assert t == 3*D*p(a)*p(-a)*q(b)*q(-b)
+    t1 = g(a,b)*p(c)*p(-c)
+    t2 = 3*q(-a)*q(-b)
+    t = t1*t2
+    t = t.contract_metric(g)
+    t = t.canon_bp()
+    assert t == 3*p(a)*p(-a)*q(b)*q(-b)
+
+    t1 = 2*g(a,b)*p(c)*p(-c)
+    t2 = - 3*g(-a,-b)*q(c)*q(-c)
+    t = t1*t2
+    t = t.contract_metric(g)
+    t = t.contract_metric(g)
+    t = 6*g(a,b)*g(-a,-b)*p(c)*p(-c)*q(d)*q(-d)
+    t = t.contract_metric(g)
+    t = t.contract_metric(g)
+
+    t1 = 2*g(a,b)*p(c)*p(-c)
+    t2 = q(-a)*q(-b) + 3*g(-a,-b)*q(c)*q(-c)
+    t = t1*t2
+    t = t.contract_metric(g)
+    assert t == (2 + 6*D)*p(a)*p(-a)*q(b)*q(-b)
+
+    t1 = p(a)*p(b) + p(a)*q(b) + 2*g(a,b)*p(c)*p(-c)
+    t2 = q(-a)*q(-b) - g(-a,-b)*q(c)*q(-c)
+    t = t1*t2
+    t = t.contract_metric(g)
+    t1 = (1 - 2*D)*p(a)*p(-a)*q(b)*q(-b) + p(a)*q(-a)*p(b)*q(-b)
+    assert t == t1
+
+    t = g(a,b)*g(c,d)*g(-b,-c)
+    t1 = t.contract_metric(g)
+    t1 = t1.canon_bp()
+    assert t1 == g(a,c)*g(d,-c)
+
+    t2 = t1.contract_metric(g)
+    assert t2 == g(a, d)
+
+    t1 = t.contract_metric(g, True)
+    assert t1 == g(a, d)
+
+    t1 = g(a,b)*g(c,d) + g(a,c)*g(b,d) + g(a,d)*g(b,c)
+    t2 = t1.substitute_indices((a,-a),(b,-b),(c,-c),(d,-d))
+    t = t1*t2
+    t3 = t.contract_metric(g)
+    t3 = t3.contract_metric(g)
+    t3 = t3.contract_metric(g)
+    assert t3 == 3*D**2 + 6*D
+    t = t.contract_metric(g, True)
+    assert t == 3*D**2 + 6*D
+
+def test_epsilon():
+    Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')
+    a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
+    g = Lorentz.metric
+    epsilon = Lorentz.epsilon
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym1)
+    p, q, r, s = S1('p,q,r,s')
+
+    t = epsilon(b,a,c,d)
+    t1 = t.canon_bp()
+    assert t1 == -epsilon(a,b,c,d)
+
+    t = epsilon(c,b,d,a)
+    t1 = t.canon_bp()
+    assert t1 == epsilon(a,b,c,d)
+
+    t = epsilon(c,a,d,b)
+    t1 = t.canon_bp()
+    assert t1 == -epsilon(a,b,c,d)
+
+    t = epsilon(a,b,c,d)*p(-a)*q(-b)
+    t1 = t.canon_bp()
+    assert t1 == epsilon(c, d, a, b)*p(-a)*q(-b)
+
+    t = epsilon(c,b,d,a)*p(-a)*q(-b)
+    t1 = t.canon_bp()
+    assert t1 == epsilon(c, d, a, b)*p(-a)*q(-b)
+
+    t = epsilon(c,a,d,b)*p(-a)*q(-b)
+    t1 = t.canon_bp()
+    assert t1 == -epsilon(c, d, a, b)*p(-a)*q(-b)
+
+    t = epsilon(c,a,d,b)*p(-a)*p(-b)
+    t1 = t.canon_bp()
+    assert t1 == 0
+
+    t = epsilon(c,a,d,b)*p(-a)*q(-b) + epsilon(a,b,c,d)*p(-b)*q(-a)
+    t1 = t.canon_bp()
+    assert t1 == -2*epsilon(c, d, a, b)*p(-a)*q(-b)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -144,7 +144,7 @@ def test_no_metric_symmetry():
     # no metric symmetry; A no symmetry
     # A^d1_d0 * A^d0_d1
     # T_c = A^d0_d1 * A^d1_d0
-    Lorentz = TensorIndexType('Lorentz', metric_sym=None, dummy_fmt='L')
+    Lorentz = TensorIndexType('Lorentz', metric_antisym=None, dummy_fmt='L')
     d0, d1, d2, d3 = tensor_indices('d0 d1 d2 d3', Lorentz)
     nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
     NS2 = TensorType([Lorentz]*2, nsym2)
@@ -256,7 +256,7 @@ def test_canonicalize1():
     # A anticommuting symmetric, B antisymmetric commuting, antisymmetric metric
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = -A^{d0 d1 d2} * A_{d0 d1}^d3 * B_{d2 d3}
-    Spinor = TensorIndexType('Spinor', metric_sym=1, dummy_fmt='S')
+    Spinor = TensorIndexType('Spinor', metric_antisym=1, dummy_fmt='S')
     a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
       tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
     S3 = TensorType([Spinor]*3, sym3)
@@ -271,7 +271,7 @@ def test_canonicalize1():
     # no metric symmetry
     # A^{d0 d1 d2} * A_{d2 d3 d1} * B_d0^d3
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
-    Mat = TensorIndexType('Mat', metric_sym=None, dummy_fmt='M')
+    Mat = TensorIndexType('Mat', metric_antisym=None, dummy_fmt='M')
     a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
       tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
     S3 = TensorType([Mat]*3, sym3)
@@ -397,7 +397,7 @@ def test_riemann_products():
 
 def test_canonicalize2():
     D = Symbol('D')
-    Eucl = TensorIndexType('Eucl', metric_sym=0, dim=D, dummy_fmt='E')
+    Eucl = TensorIndexType('Eucl', metric_antisym=0, dim=D, dummy_fmt='E')
     i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14 = \
       tensor_indices('i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14', Eucl)
     sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -841,9 +841,9 @@ def test_TensorManager():
     TensorManager.set_comm(2, 3, 0)
     p, q = tensorhead('p q', [Lorentz], [[1]])
     ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
-    G = tensorhead('G', [Lorentz], [[1]], 2)
-    GH = tensorhead('GH', [LorentzH], [[1]], 3)
-    TensorManager.set_comm(2, 3, 0)
+    G = tensorhead('G', [Lorentz], [[1]], 3)
+    GH = tensorhead('GH', [LorentzH], [[1]], 4)
+    TensorManager.set_comm(3, 4, 0)
     ps = G(i)*p(-i)
     psh = GH(ih)*ph(-ih)
     t = ps + psh

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -474,7 +474,7 @@ def test_add1():
     t2 = A(b,-d0)*t2a
     assert str(t2) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0)'
     t2b = t2 + t1
-    assert str(t2b) == 'A(a, L_0)*A(b, -L_0) + A(b, L_0)*B(a, -L_0) + A(b, L_0)*B(a, -L_0)'
+    assert str(t2b) == '2*A(b, L_0)*B(a, -L_0) + A(a, L_0)*A(b, -L_0)'
     S1 = TensorType([Lorentz], sym1)
     p, q, r = S1('p,q,r')
     t = q(d0)*2

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
-  tensorlist_contract_metric, TensMul, tensorsymmetry, tensorhead)
+  tensorlist_contract_metric, TensMul, tensorsymmetry, tensorhead, TensorManager)
 from sympy.utilities.pytest import raises
 
 #################### Tests from tensor_can.py #######################
@@ -288,9 +288,9 @@ def test_canonicalize1():
     S3a = TensorType([Lorentz]*3, sym3a)
     alpha, beta, gamma, mu, nu, rho = \
       tensor_indices('alpha,beta,gamma,mu,nu,rho', Lorentz)
-    Gamma = S1('Gamma', None)
-    Gamma2 = S2a('Gamma', None)
-    Gamma3 = S3a('Gamma', None)
+    Gamma = S1('Gamma', 2)
+    Gamma2 = S2a('Gamma', 2)
+    Gamma3 = S3a('Gamma', 2)
     t = Gamma2(-mu,-nu)*Gamma(rho)*Gamma3(nu, mu, alpha)
     tc = t.canon_bp()
     assert str(tc) == '-Gamma(L_0, L_1)*Gamma(rho)*Gamma(alpha, -L_0, -L_1)'
@@ -832,3 +832,24 @@ def test_fun():
     t = dg(-c,-a,-b) - g(-a,-d)*gamma(d,-b,-c) - g(-b,-d)*gamma(d,-a,-c)
     t = t.contract_metric(g, True)
     assert t == 0
+
+def test_TensorManager():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    LorentzH = TensorIndexType('LorentzH', dummy_fmt='LH')
+    i, j = tensor_indices('i,j', Lorentz)
+    ih, jh = tensor_indices('ih,jh', LorentzH)
+    TensorManager.set_comm(2, 3, 0)
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
+    G = tensorhead('G', [Lorentz], [[1]], 2)
+    GH = tensorhead('GH', [LorentzH], [[1]], 3)
+    TensorManager.set_comm(2, 3, 0)
+    ps = G(i)*p(-i)
+    psh = GH(ih)*ph(-ih)
+    t = ps + psh
+    t1 = t*t
+    assert t1 == ps*ps + 2*ps*psh + psh*psh
+    qs = G(i)*q(-i)
+    qsh = GH(ih)*qh(-ih)
+    assert ps*qsh == qsh*ps
+    assert ps*qs != qs*ps

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -884,3 +884,6 @@ def test_hash():
     t1 = p(a)*q(b)
     t2 = p(a)*p(b)
     assert hash(t1) != hash(t2)
+    t3 = p(a)*p(b) + g(a,b)
+    t4 = p(a)*p(b) - g(a,b)
+    assert hash(t3) != hash(t4)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -812,8 +812,14 @@ def test_contract_delta1():
 def test_fun():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
-    a,b,c,d = tensor_indices('a,b,c,d', Lorentz)
+    a,b,c,d,e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
+
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    t = q(c)*p(a)*q(b) + g(a,b)*g(c,d)*q(-d)
+    assert t(a,b,c) == t
+    assert t - t(b,a,c) == q(c)*p(a)*q(b) - q(c)*p(b)*q(a)
+    assert t(b,c,d) == q(d)*p(b)*q(c) + g(b,c)*g(d,e)*q(-e)
 
     # check that g_{a b; c} = 0
     # example taken from  L. Brewin
@@ -822,7 +828,6 @@ def test_fun():
     dg = tensorhead('dg', [Lorentz]*3, [[1], [1]*2])
     # gamma^a_{b c} is the Christoffel symbol
     gamma = S.Half*g(a,d)*(dg(-b,-d,-c) + dg(-c,-b,-d) - dg(-d,-b,-c))
-    gamma.set_free_args([a, -b, -c])
     # t = g_{a b; c}
     t = dg(-c,-a,-b) - g(-a,-d)*gamma(d,-b,-c) - g(-b,-d)*gamma(d,-a,-c)
     t = t.contract_metric(g, True)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -873,3 +873,14 @@ def test_TensorManager():
     qsh = GH(ih)*qh(-ih)
     assert ps*qsh == qsh*ps
     assert ps*qs != qs*ps
+
+def test_hash():
+    D = Symbol('D')
+    Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+    a,b,c,d,e = tensor_indices('a,b,c,d,e', Lorentz)
+    g = Lorentz.metric
+
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    t1 = p(a)*q(b)
+    t2 = p(a)*p(b)
+    assert hash(t1) != hash(t2)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -51,7 +51,7 @@ def test_canonicalize_no_slot_sym():
     nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
     NS2 = TensorType([Lorentz]*2, nsym2)
     A = NS2('A')
-    B, C = S1('B,C')
+    B, C = S1('B, C')
     t = A(d1, -d0)*B(d0)*C(-d1)
     tc = t.canon_bp()
     assert str(tc) == 'A(L_0, L_1)*B(-L_1)*C(-L_0)'
@@ -95,7 +95,7 @@ def test_canonicalize_no_slot_sym():
 
 def test_canonicalize_no_dummies():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    a, b, c, d = tensor_indices('a, b, c, d', Lorentz)
     sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
     sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
     sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
@@ -145,7 +145,7 @@ def test_no_metric_symmetry():
     # A^d1_d0 * A^d0_d1
     # T_c = A^d0_d1 * A^d1_d0
     Lorentz = TensorIndexType('Lorentz', metric_sym=None, dummy_fmt='L')
-    d0, d1, d2, d3 = tensor_indices('d0,d1,d2,d3', Lorentz)
+    d0, d1, d2, d3 = tensor_indices('d0 d1 d2 d3', Lorentz)
     nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
     NS2 = TensorType([Lorentz]*2, nsym2)
     A = NS2('A')
@@ -426,7 +426,7 @@ def test_get_indices():
     assert a != -a
     sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
     S2 = TensorType([Lorentz]*2, sym2)
-    A, B = S2('A,B')
+    A, B = S2('A B')
     assert A != B
     t = A(a,b)*B(-b,c)
     indices = t.get_indices()

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -858,11 +858,12 @@ def test_TensorManager():
     # same as before, but using symbols in TensorManager
     Gsymbol = Symbol('Gsymbol')
     GHsymbol = Symbol('GHsymbol')
+    TensorManager.set_comm(Gsymbol, GHsymbol, 0)
     p, q = tensorhead('p q', [Lorentz], [[1]])
     ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
     G = tensorhead('G', [Lorentz], [[1]], Gsymbol)
+    assert TensorManager._comm_i2symbol[G.comm] == Gsymbol
     GH = tensorhead('GH', [LorentzH], [[1]], GHsymbol)
-    TensorManager.set_comm(Gsymbol, GHsymbol, 0)
     ps = G(i)*p(-i)
     psh = GH(ih)*ph(-ih)
     t = ps + psh

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -818,7 +818,7 @@ def test_fun():
     # check that g_{a b; c} = 0
     # example taken from  L. Brewin
     # "A brief introduction to Cadabra" arxiv:0903.2085
-    # dg_{a b c} = \partial_{a} g_{a b}
+    # dg_{a b c} = \partial_{a} g_{b c} is symmetric in b, c
     dg = tensorhead('dg', [Lorentz]*3, [[1], [1]*2])
     # gamma^a_{b c} is the Christoffel symbol
     gamma = S.Half*g(a,d)*(dg(-b,-d,-c) + dg(-c,-b,-d) - dg(-d,-b,-c))

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,24 +4,9 @@ from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
-  tensorlist_contract_metric, Tensor)
+  tensorlist_contract_metric, TensMul)
 
-def test_get_indices():
-    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
-    assert a != -a
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    S2 = TensorType([Lorentz]*2, sym2)
-    A, B = S2('A,B')
-    assert A != B
-    t = A(a,b)*B(-b,c)
-    indices = t.get_indices()
-    L_0 = TensorIndex('L_0', Lorentz)
-    assert indices == [a, L_0, -L_0, c]
-    a = t.split()
-    t2 = tensor_mul(*a)
-    assert t == t2
-    assert tensor_mul(*[]) == Tensor(S.One, [],[],[])
+#################### Tests from tensor_can.py #######################
 
 def test_canonicalize_no_slot_sym():
     # A_d0 * B^d0; T_c = A^d0*B_d0
@@ -407,6 +392,25 @@ def test_riemann_products():
     t = R(d2, a0, a2, d0)*R(d1, -d2, a1, a3)*R(a4, a5, -d0, -d1)
     tc = t.canon_bp()
     assert str(tc) == 'R(a0, L_0, a2, L_1)*R(a1, a3, -L_0, L_2)*R(a4, a5, -L_1, -L_2)'
+######################################################################
+
+
+def test_get_indices():
+    Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
+    a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    assert a != -a
+    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    S2 = TensorType([Lorentz]*2, sym2)
+    A, B = S2('A,B')
+    assert A != B
+    t = A(a,b)*B(-b,c)
+    indices = t.get_indices()
+    L_0 = TensorIndex('L_0', Lorentz)
+    assert indices == [a, L_0, -L_0, c]
+    a = t.split()
+    t2 = tensor_mul(*a)
+    assert t == t2
+    assert tensor_mul(*[]) == TensMul(S.One, [],[],[])
 
 
 def test_add1():
@@ -647,9 +651,7 @@ def test_metric_contract1():
     t1 = t.contract_metric(g)
     assert t1 == 2*D*p(a)
 
-    print 'DB40'
     t = 2*p(a)*g(b,-a)
-    #t = 2*p(a)*g(-a, b)
     t1 = t.contract_metric(g)
     assert t1 == 2*p(b)
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -481,6 +481,10 @@ def test_add1():
     t2 = (p(j) + q(j) + 2*r(j))*(p(i) - q(i))
     t = t1 + t2
     assert t == 2*p(i)*p(j) + 2*p(i)*r(j) + 2*p(j)*r(i) - 2*q(i)*q(j) - 2*q(i)*r(j) - 2*q(j)*r(i)
+    t = p(i)*q(j)/2
+    assert 2*t == p(i)*q(j)
+    t = (p(i) + q(i))/2
+    assert 2*t == p(i) + q(i)
 
 def test_add2():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -273,7 +273,7 @@ def test_canonicalize1():
     # T_c = A^{d0 d1 d2} * A_{d0 d1 d3} * B_d2^d3
     Mat = TensorIndexType('Mat', metric=None, dummy_fmt='M')
     a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
-      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Spinor)
+      tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Mat)
     S3 = TensorType([Mat]*3, sym3)
     S2a = TensorType([Mat]*2, sym2a)
     A = S3('A', 1)
@@ -629,6 +629,11 @@ def test_metric_contract1():
     t2 = t1.contract_metric(g)
     t2 = t2.contract_metric(g)
     assert t2 == A(a,b)*B(-b,-a)
+
+    t1 = A(a,b)*g(-a,-b)
+    t2 = t1.contract_metric(g)
+    assert t2 == A(a, -a)
+    assert not t2._free
 
 def test_metric_contract1():
     D = Symbol('D')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -4,7 +4,7 @@ from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
   tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
-  tensorlist_contract_metric, TensMul)
+  tensorlist_contract_metric, TensMul, tensorsymmetry)
 from sympy.utilities.pytest import raises
 
 #################### Tests from tensor_can.py #######################
@@ -13,7 +13,7 @@ def test_canonicalize_no_slot_sym():
     # A_d0 * B^d0; T_c = A^d0*B_d0
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, d0, d1 = tensor_indices('a,b,d0,d1', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     A, B = S1('A,B')
     t = A(-d0)*B(d0)
@@ -31,7 +31,7 @@ def test_canonicalize_no_slot_sym():
 
     # A symmetric
     # A^{b}_{d0}*A^{d0, a}; T_c = A^{a d0}*A{b}_{d0}
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A = S2('A')
     t = A(b, -d0)*A(d0, a)
@@ -48,7 +48,7 @@ def test_canonicalize_no_slot_sym():
     # A without symmetry
     # A^{d1}_{d0}*B^d0*C_d1 ord=[d0,-d0,d1,-d1]; g = [2,1,0,3,4,5]
     # T_c = A^{d0 d1}*B_d1*C_d0; can = [0,2,3,1,4,5]
-    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    nsym2 = tensorsymmetry([1],[1])
     NS2 = TensorType([Lorentz]*2, nsym2)
     A = NS2('A')
     B, C = S1('B, C')
@@ -96,9 +96,9 @@ def test_canonicalize_no_slot_sym():
 def test_canonicalize_no_dummies():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a, b, c, d', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
+    sym2a = tensorsymmetry([2])
 
     # A commuting
     # A^c A^b A^a
@@ -146,7 +146,7 @@ def test_no_metric_symmetry():
     # T_c = A^d0_d1 * A^d1_d0
     Lorentz = TensorIndexType('Lorentz', metric=None, dummy_fmt='L')
     d0, d1, d2, d3 = tensor_indices('d0 d1 d2 d3', Lorentz)
-    nsym2 = TensorSymmetry(([], [Permutation(range(4))]))
+    nsym2 = tensorsymmetry([1], [1])
     NS2 = TensorType([Lorentz]*2, nsym2)
     A = NS2('A')
     t = A(d1, -d0)*A(d0, -d1)
@@ -169,12 +169,12 @@ def test_canonicalize1():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, a0, a1, a2, a3, b, d0, d1, d2, d3 = \
       tensor_indices('a,a0,a1,a2,a3,b,d0,d1,d2,d3', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     base3, gens3 = get_symmetric_group_sgs(3)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
-    sym3 = TensorSymmetry(get_symmetric_group_sgs(3))
-    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    sym2 = tensorsymmetry([1]*2)
+    sym2a = tensorsymmetry([2])
+    sym3 = tensorsymmetry([1]*3)
+    sym3a = tensorsymmetry([3])
 
     # A_d0*A^d0; ord = [d0,-d0]
     # T_c = A^d0*A_d0
@@ -310,10 +310,9 @@ def test_canonicalize1():
     Flavor = TensorIndexType('Flavor', dummy_fmt='F')
     a, b, c, d, e, ff = tensor_indices('a,b,c,d,e,f', Flavor)
     mu, nu = tensor_indices('mu,nu', Lorentz)
-    sym_f = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators,
-            sym2a.base, sym2a.generators))
+    sym_f = tensorsymmetry([1], [2])
     S_f = TensorType([Flavor]*3, sym_f)
-    sym_A = TensorSymmetry(bsgs_direct_product(sym1.base, sym1.generators, sym1.base, sym1.generators))
+    sym_A = tensorsymmetry([1], [1])
     S_A = TensorType([Lorentz, Flavor], sym_A)
     f = S_f('f')
     A = S_A('A')
@@ -358,9 +357,9 @@ def test_riemann_products():
     symr = TensorSymmetry(riemann_bsgs)
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
-    sym2a = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
+    sym2a = tensorsymmetry([2])
     # R^{a b d0}_d0 = 0
     t = R(a, b, d0, -d0)
     tc = t.canon_bp()
@@ -400,7 +399,7 @@ def test_canonicalize2():
     Eucl = TensorIndexType('Eucl', metric=0, dim=D, dummy_fmt='E')
     i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14 = \
       tensor_indices('i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14', Eucl)
-    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    sym3a = tensorsymmetry([3])
     S3a = TensorType([Eucl]*3, sym3a)
     A = S3a('A')
 
@@ -431,9 +430,9 @@ def test_TensorIndexType():
     G = Metric('g', False)
     Lorentz = TensorIndexType('Lorentz', metric=G, dim=D, dummy_fmt='L')
     m0, m1, m2, m3, m4 = tensor_indices('m0,m1,m2,m3,m4', Lorentz)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     g = Lorentz.metric
     p = S1('p')
@@ -447,7 +446,7 @@ def test_get_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
     assert a != -a
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A B')
     assert A != B
@@ -466,8 +465,8 @@ def test_add1():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a,b,d0,d1,i,j,k = tensor_indices('a,b,d0,d1,i,j,k', Lorentz)
     # A, B symmetric
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A,B')
     t1 = A(b,-d0)*B(d0,a)
@@ -509,8 +508,8 @@ def test_add1():
 def test_add2():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m, n, p, q = tensor_indices('m,n,p,q', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
-    sym3a = TensorSymmetry(get_symmetric_group_sgs(3, 1))
+    symr = tensorsymmetry([2, 2])
+    sym3a = tensorsymmetry([3])
     R4 = TensorType([Lorentz]*4, symr)
     S3a = TensorType([Lorentz]*3, sym3a)
     R = R4('R')
@@ -526,7 +525,7 @@ def test_add2():
 def test_substitute_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A,B')
     t = A(i, k)*B(-k, -j)
@@ -534,7 +533,7 @@ def test_substitute_indices():
     t1a = A(j, l)*B(-l, -k)
     assert t1 == t1a
 
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     p = S1('p')
     t = p(i)
@@ -553,7 +552,7 @@ def test_substitute_indices():
 def test_riemann_cyclic_replace():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
+    symr = tensorsymmetry([2, 2])
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(m0,m2,m1,m3)
@@ -564,7 +563,7 @@ def test_riemann_cyclic_replace():
 def test_riemann_cyclic():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     i, j, k, l, m, n, p, q = tensor_indices('i,j,k,l,m,n,p,q', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
+    symr = tensorsymmetry([2, 2])
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(i,j,k,l) + R(i,l,j,k) + R(i,k,l,j) - \
@@ -583,7 +582,7 @@ def test_riemann_cyclic():
 def test_div():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
-    symr = TensorSymmetry(riemann_bsgs)
+    symr = tensorsymmetry([2, 2])
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(m0,m1,-m1,m3)
@@ -600,7 +599,7 @@ def test_metric_contract1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([1]*2)
     S2 = TensorType([Lorentz]*2, sym2)
     g = Lorentz.metric
     A, B = S2('A,B')
@@ -640,7 +639,7 @@ def test_metric_contract1():
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     p, q = S1('p,q')
 
@@ -725,7 +724,7 @@ def test_epsilon():
     a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
     g = Lorentz.metric
     epsilon = Lorentz.epsilon
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Lorentz], sym1)
     p, q, r, s = S1('p,q,r,s')
 
@@ -766,9 +765,9 @@ def test_contract_delta1():
     n = Symbol('n')
     Color = TensorIndexType('Color', metric=None, dim=n, dummy_fmt='C')
     a, b, c, d, e, f = tensor_indices('a,b,c,d,e,f', Color)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym1 = tensorsymmetry([1])
     S1 = TensorType([Color], sym1)
-    sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym2 = tensorsymmetry([2])
     S2 = TensorType([Color]*2, sym2)
     delta = Color.delta
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -637,10 +637,12 @@ def test_metric_contract1():
 def test_metric_contract1():
     D = Symbol('D')
     Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
-    a, b, c, d, e = tensor_indices('a,b,c,d,e', Lorentz)
+    a, b, c, d, e, L_0, L_1 = tensor_indices('a,b,c,d,e,L_0,L_1', Lorentz)
     g = Lorentz.metric
     sym1 = tensorsymmetry([1])
+    sym2 = tensorsymmetry([1]*2)
     S1 = TensorType([Lorentz], sym1)
+    S2 = TensorType([Lorentz]*2, sym2)
     p, q = S1('p,q')
 
     t1 = g(a,b)*p(c)*p(-c)
@@ -718,6 +720,11 @@ def test_metric_contract1():
     v = [p(a), q(b), p(c)]
     v1 = tensorlist_contract_metric(v, g(d, e))
     assert v1 == [p(a), q(b), p(c), g(d, e)]
+
+    A = S2('A')
+    t = A(a, b)*p(L_0)*g(-a, -b)
+    t1 = t.contract_metric(g)
+    assert str(t1) == 'A(L_1, -L_1)*p(L_0)' or str(t1) == 'A(-L_1, L_1)*p(L_0)'
 
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -3,14 +3,17 @@ from sympy.combinatorics import Permutation
 from sympy.combinatorics.tensor_can import (bsgs_direct_product, riemann_bsgs)
 from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   TensorSymmetry, get_symmetric_group_sgs, TensorType, TensorIndex,
-  tensor_mul, canon_bp, TensAdd, riemann_cyclic_replaceR, riemann_cyclic)
+  tensor_mul, canon_bp, TensAdd, riemann_cyclic_replace, riemann_cyclic,
+  tensorlist_contract_metric, Tensor)
 
 def test_get_indices():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
+    assert a != -a
     sym2 = TensorSymmetry(get_symmetric_group_sgs(2))
     S2 = TensorType([Lorentz]*2, sym2)
     A, B = S2('A,B')
+    assert A != B
     t = A(a,b)*B(-b,c)
     indices = t.get_indices()
     L_0 = TensorIndex('L_0', Lorentz)
@@ -18,6 +21,7 @@ def test_get_indices():
     a = t.split()
     t2 = tensor_mul(*a)
     assert t == t2
+    assert tensor_mul(*[]) == Tensor(S.One, [],[],[])
 
 def test_canonicalize_no_slot_sym():
     # A_d0 * B^d0; T_c = A^d0*B_d0
@@ -478,14 +482,30 @@ def test_substitute_indices():
     t1a = A(j, l)*B(-l, -k)
     assert t1 == t1a
 
-def test_riemann_cyclic_replaceR():
+    sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+    S1 = TensorType([Lorentz], sym1)
+    p = S1('p')
+    t = p(i)
+    t1 = t.substitute_indices((j, k))
+    assert t1 == t
+    t1 = t.substitute_indices((i, j))
+    assert t1 == p(j)
+    t1 = t.substitute_indices((i, -j))
+    assert t1 == p(-j)
+    t1 = t.substitute_indices((-i, j))
+    assert t1 == p(-j)
+    t1 = t.substitute_indices((-i, -j))
+    assert t1 == p(j)
+
+
+def test_riemann_cyclic_replace():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     m0,m1,m2,m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
     symr = TensorSymmetry(riemann_bsgs)
     R4 = TensorType([Lorentz]*4, symr)
     R = R4('R')
     t = R(m0,m2,m1,m3)
-    t1 = riemann_cyclic_replaceR(t)
+    t1 = riemann_cyclic_replace(t)
     t1a =  -S.One/3*R(m0, m3, m2, m1) + S.One/3*R(m0, m1, m2, m3) + Rational(2,3)*R(m0, m2, m1, m3)
     assert t1 == t1a
 
@@ -622,6 +642,28 @@ def test_metric_contract1():
     assert t3 == 3*D**2 + 6*D
     t = t.contract_metric(g, True)
     assert t == 3*D**2 + 6*D
+
+    t = 2*p(a)*g(b,-b)
+    t1 = t.contract_metric(g)
+    assert t1 == 2*D*p(a)
+
+    print 'DB40'
+    t = 2*p(a)*g(b,-a)
+    #t = 2*p(a)*g(-a, b)
+    t1 = t.contract_metric(g)
+    assert t1 == 2*p(b)
+
+    M = Symbol('M')
+    t = (p(a)*p(b) + g(a, b)*M**2)*g(-a, -b) - D*M**2
+    t1 = t.contract_metric(g)
+    assert t1 == p(a)*p(-a)
+
+    v = [p(a), q(b), p(c)]
+    v1 = tensorlist_contract_metric(v, g(-a, -b))
+    assert v1 == [p(-b), q(b), p(c)]
+    v = [p(a), q(b), p(c)]
+    v1 = tensorlist_contract_metric(v, g(d, e))
+    assert v1 == [p(a), q(b), p(c), g(d, e)]
 
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -853,3 +853,22 @@ def test_TensorManager():
     qsh = GH(ih)*qh(-ih)
     assert ps*qsh == qsh*ps
     assert ps*qs != qs*ps
+
+    TensorManager.clear()
+    # same as before, but using symbols in TensorManager
+    Gsymbol = Symbol('Gsymbol')
+    GHsymbol = Symbol('GHsymbol')
+    p, q = tensorhead('p q', [Lorentz], [[1]])
+    ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
+    G = tensorhead('G', [Lorentz], [[1]], Gsymbol)
+    GH = tensorhead('GH', [LorentzH], [[1]], GHsymbol)
+    TensorManager.set_comm(Gsymbol, GHsymbol, 0)
+    ps = G(i)*p(-i)
+    psh = GH(ih)*ph(-ih)
+    t = ps + psh
+    t1 = t*t
+    assert t1 == ps*ps + 2*ps*psh + psh*psh
+    qs = G(i)*q(-i)
+    qsh = GH(ih)*qh(-ih)
+    assert ps*qsh == qsh*ps
+    assert ps*qs != qs*ps

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -842,12 +842,12 @@ def test_TensorManager():
     LorentzH = TensorIndexType('LorentzH', dummy_fmt='LH')
     i, j = tensor_indices('i,j', Lorentz)
     ih, jh = tensor_indices('ih,jh', LorentzH)
-    TensorManager.set_comm(2, 3, 0)
     p, q = tensorhead('p q', [Lorentz], [[1]])
     ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
+
+    TensorManager.set_comm(3, 4, 0)
     G = tensorhead('G', [Lorentz], [[1]], 3)
     GH = tensorhead('GH', [LorentzH], [[1]], 4)
-    TensorManager.set_comm(3, 4, 0)
     ps = G(i)*p(-i)
     psh = GH(ih)*ph(-ih)
     t = ps + psh
@@ -858,16 +858,27 @@ def test_TensorManager():
     assert ps*qsh == qsh*ps
     assert ps*qs != qs*ps
 
-    TensorManager.clear()
     # same as before, but using symbols in TensorManager
     Gsymbol = Symbol('Gsymbol')
     GHsymbol = Symbol('GHsymbol')
     TensorManager.set_comm(Gsymbol, GHsymbol, 0)
-    p, q = tensorhead('p q', [Lorentz], [[1]])
-    ph, qh = tensorhead('ph qh', [LorentzH], [[1]])
     G = tensorhead('G', [Lorentz], [[1]], Gsymbol)
     assert TensorManager._comm_i2symbol[G.comm] == Gsymbol
     GH = tensorhead('GH', [LorentzH], [[1]], GHsymbol)
+    ps = G(i)*p(-i)
+    psh = GH(ih)*ph(-ih)
+    t = ps + psh
+    t1 = t*t
+    assert t1 == ps*ps + 2*ps*psh + psh*psh
+    qs = G(i)*q(-i)
+    qsh = GH(ih)*qh(-ih)
+    assert ps*qsh == qsh*ps
+    assert ps*qs != qs*ps
+
+    # do it again the other way
+    TensorManager.set_comm(3, 4, 0)
+    G = tensorhead('G', [Lorentz], [[1]], 3)
+    GH = tensorhead('GH', [LorentzH], [[1]], 4)
     ps = G(i)*p(-i)
     psh = GH(ih)*ph(-ih)
     t = ps + psh


### PR DESCRIPTION
``````
It is implemented a tensor class with monoterm canonicalization
and algebraic operations on tensors.

As an application,
check of identities involving the cyclic symmetry of the Riemann tensor

```
>>> from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorS
>>> Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
>>> i, j, k, l = tensor_indices('i,j,k,l', Lorentz)
>>> symr = TensorSymmetry(riemann_bsgs)
>>> R4 = TensorType([Lorentz]*4, symr)
>>> R = R4('R')
>>> t = R(i,j,k,l)*(R(-i,-j,-k,-l) - 2*R(-i,-k,-j,-l))
>>> riemann_cyclic(t)
0
```
``````
