### PR TITLE
Fixing Issue 3576: symbols('aa:g') should work

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -251,6 +251,7 @@ class Wild(Symbol):
 
 _re_var_range = re.compile(r"^(.*?)(\d*):(\d+)$")
 _re_var_scope = re.compile(r"^(.):(.)$")
+_re_var_ranged_scope = re.compile(r"^([^\W\d_]*?)(.):(.)$")
 _re_var_split = re.compile(r"\s*,\s*|\s+")
 
 
@@ -360,7 +361,7 @@ def symbols(names, **args):
 
         cls = args.pop('cls', Symbol)
         seq = args.pop('seq', as_seq)
-
+        
         for name in names:
             if not name:
                 raise ValueError('missing symbol')
@@ -398,6 +399,20 @@ def symbols(names, **args):
 
                 seq = True
                 continue
+
+            match = _re_var_ranged_scope.match(name)
+
+            if match is not None:
+                name, start, end = match.groups()
+
+                for subname in xrange(ord(start), ord(end) + 1):
+                    symbol = cls(name + chr(subname), **args)
+                    result.append(symbol)
+
+                seq = True
+                continue
+
+
 
             raise ValueError(
                 "'%s' is not a valid symbol range specification" % name)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -361,7 +361,7 @@ def symbols(names, **args):
 
         cls = args.pop('cls', Symbol)
         seq = args.pop('seq', as_seq)
-        
+
         for name in names:
             if not name:
                 raise ValueError('missing symbol')

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -391,7 +391,8 @@ def symbols(names, **args):
 
             if match is not None:
                 name, start, end, suffix = match.groups()
-                letters = list(string.letters)
+                letters = list(string.ascii_lowercase + string.ascii_uppercase
+                        + string.digits)
                 start = letters.index(start)
                 end = letters.index(end)
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -10,7 +10,7 @@ from sympy.core.logic import fuzzy_bool
 from sympy.logic.boolalg import Boolean
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
-import re
+import re, string
 
 
 class Symbol(AtomicExpr, Boolean):
@@ -250,8 +250,7 @@ class Wild(Symbol):
         raise TypeError("'%s' object is not callable" % type(self).__name__)
 
 _re_var_range = re.compile(r"^(.*?)(\d*):(\d+)$")
-_re_var_scope = re.compile(r"^(.):(.)$")
-_re_var_ranged_scope = re.compile(r"^([^\W\d_]*?)(.):(.)$")
+_re_var_scope = re.compile(r"^(.*?|)(.):(.)(.*?|)$")
 _re_var_split = re.compile(r"\s*,\s*|\s+")
 
 
@@ -391,28 +390,18 @@ def symbols(names, **args):
             match = _re_var_scope.match(name)
 
             if match is not None:
-                start, end = match.groups()
+                name, start, end, suffix = match.groups()
+                letters = list(string.letters)
+ 
+                start = letters.index(start)
+                end = letters.index(end)
 
-                for name in xrange(ord(start), ord(end) + 1):
-                    symbol = cls(chr(name), **args)
+                for subname in xrange(start, end + 1):
+                    symbol = cls(name + letters[subname] + suffix, **args)
                     result.append(symbol)
 
                 seq = True
                 continue
-
-            match = _re_var_ranged_scope.match(name)
-
-            if match is not None:
-                name, start, end = match.groups()
-
-                for subname in xrange(ord(start), ord(end) + 1):
-                    symbol = cls(name + chr(subname), **args)
-                    result.append(symbol)
-
-                seq = True
-                continue
-
-
 
             raise ValueError(
                 "'%s' is not a valid symbol range specification" % name)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -392,7 +392,6 @@ def symbols(names, **args):
             if match is not None:
                 name, start, end, suffix = match.groups()
                 letters = list(string.letters)
- 
                 start = letters.index(start)
                 end = letters.index(end)
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -330,6 +330,14 @@ def test_symbols():
     assert symbols('a:d,x:z') == (a, b, c, d, x, y, z)
     assert symbols(('a:d', 'x:z')) == ((a, b, c, d), (x, y, z))
 
+    aa = Symbol('aa')
+    ab = Symbol('ab')
+    ac = Symbol('ac')
+    ad = Symbol('ad')
+
+    assert symbols('aa:d') == (aa, ab, ac, ad)
+    assert symbols('aa:d,x:z') == (aa, ab, ac, ad, x, y, z)
+    assert symbols(('aa:d','x:z')) == ((aa, ab, ac, ad), (x, y, z))
 
 def test_call():
     f = Symbol('f')


### PR DESCRIPTION
This pull request implements new behavior of symbols function, e.g.:

```
In [1]: symbols('aa:d')
Out[1]: (aa, ab, ac, ad)
```

A simple test is also provided.

The original issue: http://code.google.com/p/sympy/issues/detail?id=3576 also suggests some other features that might be worth implementing. I think that deserves new pull requests.
