### PR TITLE
Issue 3587: Modified Rational.__mod__ by adding a extra test to determine whether self.evalf() is a Float.

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1207,7 +1207,7 @@ class Rational(Number):
         if isinstance(other, Rational):
             return Rational.__mod__(other, self)
         if isinstance(other, Float):
-            return self.evalf() % other
+            return other % self.evalf()
         return Number.__rmod__(self, other)
 
     def _eval_power(self, expt):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1204,7 +1204,12 @@ class Rational(Number):
         if isinstance(other, Rational):
             return Rational.__mod__(other, self)
         if isinstance(other, Float):
-            return other % self.evalf()
+            if isinstance(self.evalf(), Float):
+                return self.evalf() % other
+                # self.evalf() does not return a Float and returns S.Zero
+                # so, since 0 % (num) is 0, return S.Zero
+            elif self.evalf() is S.Zero:
+                return self.evalf()
         return Number.__rmod__(self, other)
 
     def _eval_power(self, expt):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1196,7 +1196,10 @@ class Rational(Number):
             n = (self.p*other.q) // (other.p*self.q)
             return Rational(self.p*other.q - n*other.p*self.q, self.q*other.q)
         if isinstance(other, Float):
-            return self.evalf() % other
+            evalf = self.evalf()
+            # In case self.evalf() does not return Float.
+            if isinstance(evalf, Float):
+                return evalf % other
         return Number.__mod__(self, other)
 
     @_sympifyit('other', NotImplemented)
@@ -1204,12 +1207,7 @@ class Rational(Number):
         if isinstance(other, Rational):
             return Rational.__mod__(other, self)
         if isinstance(other, Float):
-            if isinstance(self.evalf(), Float):
-                return self.evalf() % other
-                # self.evalf() does not return a Float and returns S.Zero
-                # so, since 0 % (num) is 0, return S.Zero
-            elif self.evalf() is S.Zero:
-                return self.evalf()
+            return self.evalf() % other
         return Number.__rmod__(self, other)
 
     def _eval_power(self, expt):

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -63,6 +63,10 @@ def test_mod():
     assert (a % 2).round(15) == 0.6
     assert (a % 0.5).round(15) == 0.1
 
+    s = S.Zero
+
+    assert s % float(1) == S.Zero
+
     # No rounding required since these numbers can be represented
     # exactly.
     assert Rational(3, 4) % Float(1.1) == 0.75


### PR DESCRIPTION
The issue was that expressions such as:
`(pi*0) % float(1)`
were resulting in errors because it `S.Zero.evalf() == S.Zero` and the above resulted in expression like `S.Zero % 1.0` 

So, I modified Rational.**mod** as suggested here:
http://code.google.com/p/sympy/issues/detail?id=3587&q=label%3AEasyToFix&sort=-id&colspec=ID%20Type%20Status%20Priority%20Milestone%20Reporter%20Summary%20Stars#makechanges

The modified code adds an extra check to determine whether `self.evalf()` is a `Float` or not.
I checked using pdb that:
`>>> self is S.Zero`
`>>> True`
So, for such a case, we are just returning self.evalf() == S.Zero since `0 % n ==  0`.
Also, the case where `n == 0` is already taken care of by `Sympy` itself.
