### PR TITLE
Travis: Add support for testing in Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.2
   - 3.3
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' -o $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
   - python setup.py install
 script:
   # We change directories to make sure that python won't find the copy

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
   - 2.6
   - 2.7
   - 3.2
+  - 3.3
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then python bin/use2to3; cd py3k-sympy; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' -o $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
   - python setup.py install
 script:
   # We change directories to make sure that python won't find the copy


### PR DESCRIPTION
Before merging, please make sure all tests pass and that the 2to3 is run for Python 3.2 and 3.3, but not for the other Pythons.
