### PR TITLE
Issue 3561: Initial fix for multiplication of a number with an expression that evaluates to exceptions in the ieee system

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -378,7 +378,9 @@ def add_terms(terms, prec, target_prec):
         return terms[0]
     working_prec = 2*prec
     sum_man, sum_exp, absolute_error = 0, 0, MINUS_INF
-    new_terms = [C.Float._new(t[0], prec) for t in terms]
+    # using 1 for precision since we just want to calculate
+    # nan, inf and -inf properly
+    new_terms = [C.Float._new(t[0], 1) for t in terms]
     if (S.NaN in new_terms or S.Infinity in new_terms
         or S.NegativeInfinity in new_terms):
         new_sum = S.Zero

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -430,10 +430,13 @@ def evalf_add(v, prec, options):
 
     i = 0
     target_prec = prec
+    nan_tup = evalf(S.NaN, prec + 10, options)
     while 1:
         options['maxprec'] = min(oldmaxprec, 2*prec)
 
         terms = [evalf(arg, prec + 10, options) for arg in v.args]
+        if nan_tup in terms:
+            return nan_tup[0], None, prec, prec
         re, re_acc = add_terms(
             [a[0::2] for a in terms if a[0]], prec, target_prec)
         im, im_acc = add_terms(

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -383,12 +383,10 @@ def add_terms(terms, prec, target_prec):
     new_terms = [C.Float._new(t[0], 1) for t in terms]
     if (S.NaN in new_terms or S.Infinity in new_terms
         or S.NegativeInfinity in new_terms):
-        new_sum = S.Zero
-        for t in new_terms:
-            new_sum = new_sum + t
-        result = evalf(new_sum, prec+4, {})
-        r = result[0], result[2]
-        return r
+        from sympy import Add
+        r = Add(*new_terms)
+        r = evalf(r, prec+4, {})
+        return r[0], r[2]
 
     for x, accuracy in terms:
         sign, man, exp, bc = x
@@ -503,13 +501,13 @@ def evalf_mul(v, prec, options):
     complex_factors = []
 
     terms = [evalf(arg, prec + 10, options) for arg in v.args]
+    # C already imported on top but python gived UnboundLocalError
     from core import C
     terms = [C.Float._new(t[0], prec) for t in terms if t[0] is not None]
     if (S.NaN in terms or S.Infinity in terms
         or S.NegativeInfinity in terms):
-        new_mul = S.One
-        for t in terms:
-            new_mul *=  t
+        from sympy import Mul
+        new_mul = Mul(*terms)
         return evalf(new_mul, prec+4, {})
 
     for i, arg in enumerate(args):

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -489,6 +489,8 @@ def evalf_mul(v, prec, options):
     direction = 0
     args.append(S.One)
     complex_factors = []
+    # list of exceptions -inf, inf and nan respectively
+    exptn_args = [(1, 0L, -789, -3), (0, 0L, -456, -2), (0, 0L, -123, -1)]
     for i, arg in enumerate(args):
         if i != last and pure_complex(arg):
             args[-1] = (args[-1]*arg).expand()
@@ -507,9 +509,12 @@ def evalf_mul(v, prec, options):
         else:
             return None, None, None, None
         direction += 2*s
-        man *= m
-        exp += e
-        bc += b
+        if re in exptn_args:
+            return re, None, acc, None
+        else:
+            man *= m
+            exp += e
+            bc += b
         if bc > 3*working_prec:
             man >>= working_prec
             exp += working_prec

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1344,6 +1344,8 @@ class Rational(Number):
         if other.is_real and other.is_number and not isinstance(other, Rational):
             other = other.evalf()
         if isinstance(other, Number):
+            if other is S.NaN:
+                return None
             if isinstance(other, Float):
                 return bool(mlib.mpf_le(
                     self._as_mpf_val(other._prec), other._mpf_))

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -120,13 +120,19 @@ class Pow(Expr):
 
     def _eval_power(self, other):
         from sympy.functions.elementary.exponential import log
+        from sympy.core.evalf import evalf
 
         b, e = self.as_base_exp()
         b_nneg = b.is_nonnegative
         if b.is_real and not b_nneg and e.is_even:
             b = abs(b)
             b_nneg = True
-        smallarg = (abs(e) <= abs(S.Pi/log(b)))
+
+        # Special case for when b is nan. See pull req 1714 for details
+        if b is S.NaN:
+            smallarg = (abs(e) <= S.Zero)
+        else:
+            smallarg = (abs(e) <= abs(S.Pi/log(b)))
         if (other.is_Rational and other.q == 2 and
                 e.is_real is False and smallarg is False):
             return -Pow(b, e*other)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -120,7 +120,6 @@ class Pow(Expr):
 
     def _eval_power(self, other):
         from sympy.functions.elementary.exponential import log
-        from sympy.core.evalf import evalf
 
         b, e = self.as_base_exp()
         b_nneg = b.is_nonnegative

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -194,6 +194,8 @@ def test_evalf_bugs():
     assert NS((-x).n()) == '-x'
     assert NS((-2*x).n()) == '-2.00000000000000*x'
     assert NS((-2*x*y).n()) == '-2.00000000000000*x*y'
+    #3561. Also NaN != mpmath.nan
+    assert (2*sin(oo)).n() == S.NaN
 
 
 def test_evalf_integer_parts():

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -195,7 +195,31 @@ def test_evalf_bugs():
     assert NS((-2*x).n()) == '-2.00000000000000*x'
     assert NS((-2*x*y).n()) == '-2.00000000000000*x*y'
     #3561. Also NaN != mpmath.nan
-    assert (2*sin(oo)).n() == S.NaN
+    # In this order:
+    # 0*nan, 0/nan, 0*inf, 0/inf
+    # 0+nan, 0-nan, 0+inf, 0-inf
+    # >>> n = Some Number
+    # n*nan, n/nan, n*inf, n/inf
+    # n+nan, n-nan, n+inf, n-inf
+    assert (0*sin(oo)).n() == S.Zero
+    assert (0/sin(oo)).n() == S.Zero
+    assert (0*E**(oo)).n() == S.NaN
+    assert (0/E**(oo)).n() == S.Zero
+
+    assert (0+sin(oo)).n() == S.NaN
+    assert (0-sin(oo)).n() == S.NaN
+    assert (0+E**(oo)).n() == S.Infinity
+    assert (0-E**(oo)).n() == S.NegativeInfinity
+
+    assert (5*sin(oo)).n() == S.NaN
+    assert (5/sin(oo)).n() == S.NaN
+    assert (5*E**(oo)).n() == S.Infinity
+    assert (5/E**(oo)).n() == S.Zero
+
+    assert (5+sin(oo)).n() == S.NaN
+    assert (5-sin(oo)).n() == S.NaN
+    assert (5+E**(oo)).n() == S.Infinity
+    assert (5-E**(oo)).n() == S.NegativeInfinity
 
 
 def test_evalf_integer_parts():


### PR DESCRIPTION
The issue was that:
`> (2*sin(oo)).n()`
`> 0`

It should clearly give NaN instead. The problem was due to multiplication procedure which multiplies individual mantissa values. These values are zero for nan, inf, -inf. And hence, it was returning 0.

The procedure has now been modified to check whether the number is an exception or not. The rest is self explanatory. 
