### PR TITLE
Fix auxiliary speeds bugs in physics.mechanics.

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -563,8 +563,8 @@ class KanesMethod(object):
                 km = KanesMethod(self._inertial, self._q, self._uaux,
                              u_auxiliary=self._uaux)
             else:
-                km = KanesMethod(self._inertial, self._q, self._uaux, 
-                u_auxiliary=self._uaux, u_dependent=self._udep, 
+                km = KanesMethod(self._inertial, self._q, self._uaux,
+                u_auxiliary=self._uaux, u_dependent=self._udep,
                 velocity_constraints=(self._k_nh * Matrix(self._u) + self._f_nh))
             self._km = km
             fraux = km._form_fr(FL)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -177,8 +177,8 @@ class KanesMethod(object):
 
         r1, c1 = A.shape
         r2, c2 = B.shape
-        temp1 = Matrix(r1, c1, lambda i, j: Symbol('x' + str(j + r1 * i)))
-        temp2 = Matrix(r2, c2, lambda i, j: Symbol('y' + str(j + r2 * i)))
+        temp1 = Matrix(r1, c1, lambda i, j: Symbol('x' + str(j) + str(r1 * i)))
+        temp2 = Matrix(r2, c2, lambda i, j: Symbol('y' + str(j) + str(r2 * i)))
         for i in range(len(temp1)):
             if A[i] == 0:
                 temp1[i] = 0
@@ -289,16 +289,16 @@ class KanesMethod(object):
             p = o - m # number of independent speeds
             # For a reminder, form of non-holonomic constraints is:
             # B u + C = 0
-            B = self._k_nh[:m, :]
-            C = self._f_nh[:m, 0]
+            B = self._k_nh[:, :]
+            C = self._f_nh[:, 0]
 
             # We partition B into indenpendent and dependent columns
             # Ars is then -Bdep.inv() * Bind, and it relates depedent speeds to
             # independent speeds as: udep = Ars uind, neglecting the C term here.
             self._depB = B
             self._depC = C
-            mr1 = B[:m, :p]
-            ml1 = B[:m, p:o]
+            mr1 = B[:, :p]
+            ml1 = B[:, p:o]
             self._Ars = - self._mat_inv_mul(ml1, mr1)
 
     def kindiffdict(self):
@@ -566,6 +566,7 @@ class KanesMethod(object):
                 km = KanesMethod(self._inertial, self._q, self._uaux, 
                 u_auxiliary=self._uaux, u_dependent=self._udep, 
                 velocity_constraints=(self._k_nh * Matrix(self._u) + self._f_nh))
+            self._km = km
             fraux = km._form_fr(FL)
             frstaraux = km._form_frstar(BL)
             self._aux_eq = fraux + frstaraux

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -559,8 +559,13 @@ class KanesMethod(object):
         fr = self._form_fr(FL)
         frstar = self._form_frstar(BL)
         if self._uaux != []:
-            km = KanesMethod(self._inertial, self._q, self._uaux,
+            if self._udep == []:
+                km = KanesMethod(self._inertial, self._q, self._uaux,
                              u_auxiliary=self._uaux)
+            else:
+                km = KanesMethod(self._inertial, self._q, self._uaux, 
+                u_auxiliary=self._uaux, u_dependent=self._udep, 
+                velocity_constraints=(self._k_nh * Matrix(self._u) + self._f_nh))
             fraux = km._form_fr(FL)
             frstaraux = km._form_frstar(BL)
             self._aux_eq = fraux + frstaraux

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,0 +1,189 @@
+from sympy import cos, expand, Matrix, sin, symbols, tan, Poly, zeros, solve
+from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
+                                     RigidBody, KanesMethod, inertia, Particle,
+                                     dot, cross)
+
+def test_aux_dep():
+    """
+    This test is to compare the results of general active forces Fr and general
+    inertia forces Fr_star as well as Fr_star_steady in steady turning condition
+    calculated from "mannual" derivation with Kane' method.
+    """
+
+    # Mannual derivation of Fr, Fr_star, Fr_star_steady.
+
+    # Symbols for time and constant parameters.
+    # Symbols for contact forces: Fx, Fy, Fz.
+    t, r, m, g, I, J = symbols('t r m g I J')
+    Fx, Fy, Fz = symbols('Fx Fy Fz')
+
+    # Configuration variables and their time derivatives:
+    # q[0] -- yaw
+    # q[1] -- lean
+    # q[2] -- spin
+    # q[3] -- dot(-r*B.z, A.z) -- distance from ground plane to disc center in 
+    #         A.z direction
+    # Generalized speeds and their time derivatives:
+    # u[0] -- disc angular velocity component, disc fixed x direction
+    # u[1] -- disc angular velocity component, disc fixed y direction
+    # u[2] -- disc angular velocity component, disc fixed z direction
+    # u[3] -- disc velocity component, A.x direction
+    # u[4] -- disc velocity component, A.y direction
+    # u[5] -- disc velocity component, A.z direction
+    # Auxiliary generalized speeds:
+    # ua[0] -- contact point auxiliary generalized speed, A.x direction
+    # ua[1] -- contact point auxiliary generalized speed, A.y direction
+    # ua[2] -- contact point auxiliary generalized speed, A.z direction
+    q = dynamicsymbols('q:4')
+    qd = [qi.diff(t) for qi in q]
+    u = dynamicsymbols('u:6')
+    ud = [ui.diff(t) for ui in u]
+    ud_zero = {udi : 0 for udi in ud}
+    ua = dynamicsymbols('ua:3')
+    ua_zero = {uai : 0 for uai in ua}
+
+    # Reference frames:
+    # Yaw intermediate frame: A.
+    # Lean intermediate frame: B.
+    # Disc fixed frame: C.
+    N = ReferenceFrame('N')
+    A = N.orientnew('A', 'Axis', [q[0], N.z])
+    B = A.orientnew('B', 'Axis', [q[1], A.x])
+    C = B.orientnew('C', 'Axis', [q[2], B.y])
+
+    # Angular velocity and angular acceleration of disc fixed frame
+    # u[0], u[1] and u[2] are generalized independent speeds.
+    C.set_ang_vel(N, u[0]*B.x + u[1]*B.y + u[2]*B.z)
+    C.set_ang_acc(N, C.ang_vel_in(N).diff(t, B)
+                   + cross(B.ang_vel_in(N), C.ang_vel_in(N)))
+
+    # Velocity and acceleration of points:
+    # Disc-ground contact point: P.
+    # Center of disc: O, defined from point P with depend coordinate: q[3]
+    # u[3], u[4] and u[5] are generalized dependent speeds.
+    P = Point('P')
+    P.set_vel(N, ua[0]*A.x + ua[1]*A.y + ua[2]*A.z)
+    O = P.locatenew('O', q[3]*A.z + r*sin(q[1])*A.y)
+    O.set_vel(N, u[3]*A.x + u[4]*A.y + u[5]*A.z)
+    O.set_acc(N, O.vel(N).diff(t, A) + cross(A.ang_vel_in(N), O.vel(N)))
+
+    # Kinematic differential equations:
+    # Two equalities: one is w_c_n_qd = C.ang_vel_in(N) in three coordinates
+    #                 directions of B, for qd0, qd1 and qd2.
+    #                 the other is v_o_n_qd = O.vel(N) in A.z direction for qd3.
+    # Then, solve for dq/dt's in terms of u's: qd_kd.
+    w_c_n_qd = qd[0]*A.z + qd[1]*B.x + qd[2]*B.y
+    v_o_n_qd = O.pos_from(P).diff(t, A) + cross(A.ang_vel_in(N), O.pos_from(P))
+    kindiffs = Matrix([dot(w_c_n_qd - C.ang_vel_in(N), uv) for uv in B] +
+                      [dot(v_o_n_qd - O.vel(N), A.z)])
+    qd_kd = solve(kindiffs, qd)
+
+    # Values of generalized speeds during a steady turn for later substitution
+    # into the Fr_star_steady.
+    steady_conditions = solve(kindiffs.subs({qd[1] : 0, qd[3] : 0}), u)
+    steady_conditions.update({qd[1] : 0, qd[3] : 0})
+
+    # Partial angular velocities and velocities.
+    partial_w_C = [C.ang_vel_in(N).diff(ui, N) for ui in u + ua]
+    partial_v_O = [O.vel(N).diff(ui, N) for ui in u + ua]
+    partial_v_P = [P.vel(N).diff(ui, N) for ui in u + ua]
+
+    # Configuration constraint: f_c, the projection of radius r in A.z direction
+    #                                is q[3].
+    # Velocity constraints: f_v, for u3, u4 and u5.
+    # Acceleration constraints: f_a.
+    f_c = Matrix([dot(-r*B.z, A.z) - q[3]])
+    f_v = Matrix([dot(O.vel(N) - (P.vel(N) + cross(C.ang_vel_in(N),
+        O.pos_from(P))), ai).expand() for ai in A])
+    v_o_n = cross(C.ang_vel_in(N), O.pos_from(P))
+    a_o_n = v_o_n.diff(t, A) + cross(A.ang_vel_in(N), v_o_n)
+    f_a = Matrix([dot(O.acc(N) - a_o_n, ai) for ai in A])
+
+    # Solve for constraint equations in the form of u_dependent = A_rs * [u_i; u_aux].
+    # First, obtain constraint coefficient matrix:  M_v * [u; ua] = 0;
+    # Second, taking u[0], u[1], u[2] as independent,
+    #         taking u[3], u[4], u[5] as dependent,
+    #         rearranging the matrix of M_v to be A_rs for u_dependent.
+    # Third, u_aux ==0 for u_dep, and resulting dictionary of u_dep_dict.
+    M_v = zeros((3, 9))
+    for i in range(3):
+        for j, ui in enumerate(u + ua):
+            M_v[i, j] = f_v[i].diff(ui)
+
+    M_v_i = M_v[:, :3]
+    M_v_d = M_v[:, 3:6]
+    M_v_aux = M_v[:, 6:]
+    M_v_i_aux = M_v_i.row_join(M_v_aux)
+    A_rs = - M_v_d.inv() * M_v_i_aux
+
+    u_dep = A_rs[:, :3] * Matrix(u[:3])
+    u_dep_dict = {udi : u_depi[0] for udi, u_depi in zip(u[3:], u_dep.tolist())}
+
+    # Active forces: F_O acting on point O; F_P acting on point P.
+    # Generalized active forces (unconstrained): Fr_u = F_point * pv_point.
+    F_O = m*g*A.z
+    F_P = Fx * A.x + Fy * A.y + Fz * A.z
+    Fr_u = Matrix([dot(F_O, pv_o) + dot(F_P, pv_p) for pv_o, pv_p in
+            zip(partial_v_O, partial_v_P)])
+
+    # Inertia force: R_star_O.
+    # Inertia of disc: I_C_O, where J is a inertia component about principal axis.
+    # Inertia torque: T_star_C.
+    # Generalized inertia forces (unconstrained): Fr_star_u.
+    R_star_O = -m*O.acc(N)
+    I_C_O = inertia(B, I, J, I)
+    T_star_C = -(dot(I_C_O, C.ang_acc_in(N)) \
+                 + cross(C.ang_vel_in(N), dot(I_C_O, C.ang_vel_in(N))))
+    Fr_star_u = Matrix([dot(R_star_O, pv) + dot(T_star_C, pav) for pv, pav in
+                        zip(partial_v_O, partial_w_C)])
+
+    # Form nonholonomic Fr: Fr_c, and nonholonomic Fr_star: Fr_star_c.
+    # Also, nonholonomic Fr_star in steady turning condition: Fr_star_steady.
+    Fr_c = Fr_u[:3, :].col_join(Fr_u[6:, :]) + A_rs.T * Fr_u[3:6, :]
+    Fr_star_c = Fr_star_u[:3, :].col_join(Fr_star_u[6:, :])\
+                + A_rs.T * Fr_star_u[3:6, :]
+    Fr_star_steady = Fr_star_c.subs(ud_zero).subs(u_dep_dict)\
+            .subs(steady_conditions).subs({q[3]: -r*cos(q[1])}).expand()
+
+
+    # Here goes with KanesMethod command directly for fr, frstar and frstar_steady.
+
+    # Rigid Bodies: disc, with inertia I_C_O.
+    iner_tuple = (I_C_O, O)
+    disc = RigidBody('disc', O, C, m, iner_tuple)
+    bodyList = [disc]
+
+    # Generalized forces: Gravity: F_o; Auxiliary forces: F_p.
+    F_o = (O, F_O)
+    F_p = (P, F_P)
+    forceList = [F_o,  F_p]
+
+    # Kanes Method.
+    kane = KanesMethod(
+        N, q_ind= q[:3], u_ind= u[:3], kd_eqs=kindiffs, 
+        q_dependent=q[3:], configuration_constraints = f_c, 
+        u_dependent=u[3:], velocity_constraints= f_v, 
+        u_auxiliary=ua
+        )
+
+    # fr, frstar, frstar_steady and kdd(kinematic differential equations).
+    (fr, frstar)= kane.kanes_equations(forceList, bodyList)
+    frstar_steady = frstar.subs(ud_zero).subs(u_dep_dict).subs(steady_conditions)\
+                    .subs({q[3]: -r*cos(q[1])}).expand()
+    kdd = kane.kindiffdict()
+
+
+    # Test
+    from sympy import trigsimp, simplify
+
+    # FIRST try Fr_c == fr;
+    # Second try Fr_star_c == frstar;
+    # Third try Fr_star_steady == frstar_steady.
+    assert ((Matrix(Fr_c).expand() == fr.expand()) or
+             (Matrix(Fr_c).expand() == (-fr).expand()))
+
+    assert ((Matrix(Fr_star_c).expand() == frstar.expand()) or
+             (Matrix(Fr_star_c).expand() == (-frstar).expand()))
+
+    assert ((Matrix(Fr_star_steady).expand() == frstar_steady.expand()) or
+             (Matrix(Fr_star_steady).expand() == (-frstar_steady).expand()))


### PR DESCRIPTION
We fixed:
1) Auxiliary forces were not being formed correctly when there were nonholonomic (velocity) constraints. This is now fixed and a more thorough test of auxiliary forces and dependent speeds in one problem has been added. This test also checks the other outputs of KanesMethod against calculations done by hand.
2) In KanesMethod, the _mat_inv_mul method had a bug in temporary symbol generation - symbols were being generated that were not unique. This issue has been fixed.
