### PR TITLE
Unification - remove `patternify`

### DIFF
--- a/sympy/unify/__init__.py
+++ b/sympy/unify/__init__.py
@@ -5,5 +5,5 @@ See sympy.unify.core docstring for algorithmic details
 See http://matthewrocklin.com/blog/work/2012/11/01/Unification/ for discussion
 """
 
-from usympy import unify, patternify, rebuild
+from usympy import unify, rebuild
 from rewrite import rewriterule

--- a/sympy/unify/rewrite.py
+++ b/sympy/unify/rewrite.py
@@ -5,9 +5,9 @@ from sympy.unify.usympy import rebuild
 from sympy.rules.tools import subs
 from sympy import Expr
 
-def rewriterule(p1, p2, wilds=()):
+def rewriterule(p1, p2, variables=()):
     def rewrite_rl(expr):
-        for match in unify(p1, expr, {}, wilds=wilds):
+        for match in unify(p1, expr, {}, variables=variables):
             expr2 = subs(match)(p2)
             if isinstance(expr2, Expr):
                 expr2 = rebuild(expr2)

--- a/sympy/unify/rewrite.py
+++ b/sympy/unify/rewrite.py
@@ -5,9 +5,9 @@ from sympy.unify.usympy import rebuild
 from sympy.rules.tools import subs
 from sympy import Expr
 
-def rewriterule(p1, p2):
+def rewriterule(p1, p2, wilds=()):
     def rewrite_rl(expr):
-        for match in unify(p1, expr, {}):
+        for match in unify(p1, expr, {}, wilds=wilds):
             expr2 = subs(match)(p2)
             if isinstance(expr2, Expr):
                 expr2 = rebuild(expr2)

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -6,21 +6,21 @@ from sympy.core.compatibility import next
 p, q = Symbol('p'), Symbol('q')
 
 def test_simple():
-    rl = rewriterule(Basic(p, 1), Basic(p, 2), wilds=(p,))
+    rl = rewriterule(Basic(p, 1), Basic(p, 2), variables=(p,))
     assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
 
     p1 = p**2
     p2 = p**3
-    rl = rewriterule(p1, p2, wilds=(p,))
+    rl = rewriterule(p1, p2, variables=(p,))
 
     expr = x**2
     assert list(rl(expr)) == [x**3]
 
-def test_simple_wilds():
-    rl = rewriterule(Basic(x, 1), Basic(x, 2), wilds=(x,))
+def test_simple_variables():
+    rl = rewriterule(Basic(x, 1), Basic(x, 2), variables=(x,))
     assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
 
-    rl = rewriterule(x**2, x**3, wilds=(x,))
+    rl = rewriterule(x**2, x**3, variables=(x,))
     assert list(rl(y**2)) == [y**3]
 
 def test_moderate():

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -1,17 +1,27 @@
 from sympy.unify.rewrite import rewriterule
-from sympy import Wild, sin, cos
+from sympy import Wild, sin, cos, Basic
 from sympy.abc import x, y, z
 from sympy.core.compatibility import next
 
 p, q = Wild('p'), Wild('q')
 
 def test_simple():
+    rl = rewriterule(Basic(p, 1), Basic(p, 2))
+    assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
+
     p1 = p**2
     p2 = p**3
     rl = rewriterule(p1, p2)
 
     expr = x**2
     assert list(rl(expr)) == [x**3]
+
+def test_simple_wilds():
+    rl = rewriterule(Basic(x, 1), Basic(x, 2), wilds=(x,))
+    assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
+
+    rl = rewriterule(x**2, x**3, wilds=(x,))
+    assert list(rl(y**2)) == [y**3]
 
 def test_moderate():
     p1 = p**2 + q**3

--- a/sympy/unify/tests/test_rewrite.py
+++ b/sympy/unify/tests/test_rewrite.py
@@ -1,17 +1,17 @@
 from sympy.unify.rewrite import rewriterule
-from sympy import Wild, sin, cos, Basic
+from sympy import sin, cos, Basic, Symbol
 from sympy.abc import x, y, z
 from sympy.core.compatibility import next
 
-p, q = Wild('p'), Wild('q')
+p, q = Symbol('p'), Symbol('q')
 
 def test_simple():
-    rl = rewriterule(Basic(p, 1), Basic(p, 2))
+    rl = rewriterule(Basic(p, 1), Basic(p, 2), wilds=(p,))
     assert list(rl(Basic(3, 1))) == [Basic(3, 2)]
 
     p1 = p**2
     p2 = p**3
-    rl = rewriterule(p1, p2)
+    rl = rewriterule(p1, p2, wilds=(p,))
 
     expr = x**2
     assert list(rl(expr)) == [x**3]
@@ -26,7 +26,7 @@ def test_simple_wilds():
 def test_moderate():
     p1 = p**2 + q**3
     p2 = (p*q)**4
-    rl = rewriterule(p1, p2)
+    rl = rewriterule(p1, p2, (p, q))
 
     expr = x**2 + y**3
     assert list(rl(expr)) == [(x*y)**4]
@@ -34,12 +34,12 @@ def test_moderate():
 def test_sincos():
     p1 = sin(p)**2 + sin(p)**2
     p2 = 1
-    rl = rewriterule(p1, p2)
+    rl = rewriterule(p1, p2, (p, q))
 
     assert list(rl(sin(x)**2 + sin(x)**2)) == [1]
     assert list(rl(sin(y)**2 + sin(y)**2)) == [1]
 
 def test_Exprs_ok():
-    rl = rewriterule(p+q, q+p)
+    rl = rewriterule(p+q, q+p, (p, q))
     next(rl(x+y)).is_commutative
     str(next(rl(x+y)))

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -11,6 +11,13 @@ def test_deconstruct():
     expected = Compound(Basic, (1, 2, 3))
     assert deconstruct(expr) == expected
 
+    assert deconstruct(1) == 1
+    assert deconstruct(x) == x
+    assert deconstruct(x, wilds=(x,)) == Variable(x)
+    assert deconstruct(Add(1, x, evaluate=False)) == Compound(Add, (1, x))
+    assert deconstruct(Add(1, x, evaluate=False), wilds=(x,)) == \
+              Compound(Add, (1, Variable(x)))
+
 def test_construct():
     expr     = Compound(Basic, (1, 2, 3))
     expected = Basic(1, 2, 3)
@@ -28,6 +35,9 @@ def test_unify():
     pattern = Basic(a, b, c)
     assert list(unify(expr, pattern, {})) == [{a: 1, b: 2, c: 3}]
     assert list(unify(expr, pattern))     == [{a: 1, b: 2, c: 3}]
+
+def test_unify_wilds():
+    assert list(unify(Basic(1, 2), Basic(1, x), {}, wilds=(x,))) == [{x: 2}]
 
 def test_s_input():
     expr = Basic(1, 2)

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -134,3 +134,9 @@ def test_FiniteSet_complex():
 def test_and():
     wilds = x, y
     str(list(unify((x>0) & (z<3), pattern, wilds=wilds)))
+
+def test_Union():
+    from sympy import Interval
+    assert list(unify(Interval(0, 1) + Interval(10, 11),
+                      Interval(0, 1) + Interval(12, 13),
+                      wilds=(Interval(12, 13),)))

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -12,9 +12,9 @@ def test_deconstruct():
 
     assert deconstruct(1) == 1
     assert deconstruct(x) == x
-    assert deconstruct(x, wilds=(x,)) == Variable(x)
+    assert deconstruct(x, variables=(x,)) == Variable(x)
     assert deconstruct(Add(1, x, evaluate=False)) == Compound(Add, (1, x))
-    assert deconstruct(Add(1, x, evaluate=False), wilds=(x,)) == \
+    assert deconstruct(Add(1, x, evaluate=False), variables=(x,)) == \
               Compound(Add, (1, Variable(x)))
 
 def test_construct():
@@ -33,10 +33,11 @@ def test_unify():
     a, b, c = map(Symbol, 'abc')
     pattern = Basic(a, b, c)
     assert list(unify(expr, pattern, {}, (a, b, c))) == [{a: 1, b: 2, c: 3}]
-    assert list(unify(expr, pattern, wilds=(a, b, c))) == [{a: 1, b: 2, c: 3}]
+    assert list(unify(expr, pattern, variables=(a, b, c))) == \
+            [{a: 1, b: 2, c: 3}]
 
-def test_unify_wilds():
-    assert list(unify(Basic(1, 2), Basic(1, x), {}, wilds=(x,))) == [{x: 2}]
+def test_unify_variables():
+    assert list(unify(Basic(1, 2), Basic(1, x), {}, variables=(x,))) == [{x: 2}]
 
 def test_s_input():
     expr = Basic(1, 2)
@@ -100,8 +101,8 @@ def test_matrix():
     X = MatrixSymbol('X', n, n)
     Y = MatrixSymbol('Y', 2, 2)
     Z = MatrixSymbol('Z', 2, 3)
-    assert list(unify(X, Y, {}, wilds=[n, 'X'])) == [{'X': 'Y', n: 2}]
-    assert list(unify(X, Z, {}, wilds=[n, 'X'])) == []
+    assert list(unify(X, Y, {}, variables=[n, 'X'])) == [{'X': 'Y', n: 2}]
+    assert list(unify(X, Z, {}, variables=[n, 'X'])) == []
 
 def test_non_frankenAdds():
     # the is_commutative property used to fail because of Basic.__new__
@@ -117,26 +118,26 @@ def test_FiniteSet_commutivity():
     a, b, c, x, y = symbols('a,b,c,x,y')
     s = FiniteSet(a, b, c)
     t = FiniteSet(x, y)
-    wilds = (x, y)
-    assert {x: FiniteSet(a, c), y: b} in tuple(unify(s, t, wilds=wilds))
+    variables = (x, y)
+    assert {x: FiniteSet(a, c), y: b} in tuple(unify(s, t, variables=variables))
 
 def test_FiniteSet_complex():
     from sympy import FiniteSet
     a, b, c, x, y, z = symbols('a,b,c,x,y,z')
     expr = FiniteSet(Basic(1, x), y, Basic(x, z))
     pattern = FiniteSet(a, Basic(x, b))
-    wilds = a, b
+    variables = a, b
     expected = tuple([{b: 1, a: FiniteSet(y, Basic(x, z))},
                       {b: z, a: FiniteSet(y, Basic(1, x))}])
-    assert iterdicteq(unify(expr, pattern, wilds=wilds), expected)
+    assert iterdicteq(unify(expr, pattern, variables=variables), expected)
 
 @XFAIL
 def test_and():
-    wilds = x, y
-    str(list(unify((x>0) & (z<3), pattern, wilds=wilds)))
+    variables = x, y
+    str(list(unify((x>0) & (z<3), pattern, variables=variables)))
 
 def test_Union():
     from sympy import Interval
     assert list(unify(Interval(0, 1) + Interval(10, 11),
                       Interval(0, 1) + Interval(12, 13),
-                      wilds=(Interval(12, 13),)))
+                      variables=(Interval(12, 13),)))

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -1,5 +1,4 @@
-from sympy import Add, Basic, symbols, Mul, And
-from sympy import Wild as ExprWild
+from sympy import Add, Basic, symbols, Mul, And, Symbol
 from sympy.unify.core import Compound, Variable
 from sympy.unify.usympy import (deconstruct, construct, unify, is_associative,
         is_commutative)
@@ -31,20 +30,20 @@ def test_nested():
 
 def test_unify():
     expr = Basic(1, 2, 3)
-    a, b, c = map(ExprWild, 'abc')
+    a, b, c = map(Symbol, 'abc')
     pattern = Basic(a, b, c)
-    assert list(unify(expr, pattern, {})) == [{a: 1, b: 2, c: 3}]
-    assert list(unify(expr, pattern))     == [{a: 1, b: 2, c: 3}]
+    assert list(unify(expr, pattern, {}, (a, b, c))) == [{a: 1, b: 2, c: 3}]
+    assert list(unify(expr, pattern, wilds=(a, b, c))) == [{a: 1, b: 2, c: 3}]
 
 def test_unify_wilds():
     assert list(unify(Basic(1, 2), Basic(1, x), {}, wilds=(x,))) == [{x: 2}]
 
 def test_s_input():
     expr = Basic(1, 2)
-    a, b = map(ExprWild, 'ab')
+    a, b = map(Symbol, 'ab')
     pattern = Basic(a, b)
-    assert list(unify(expr, pattern, {})) == [{a: 1, b: 2}]
-    assert list(unify(expr, pattern, {a: 5})) == []
+    assert list(unify(expr, pattern, {}, (a, b))) == [{a: 1, b: 2}]
+    assert list(unify(expr, pattern, {a: 5}, (a, b))) == []
 
 def iterdicteq(a, b):
     a = tuple(a)
@@ -53,10 +52,10 @@ def iterdicteq(a, b):
 
 def test_unify_commutative():
     expr = Add(1, 2, 3, evaluate=False)
-    a, b, c = map(ExprWild, 'abc')
+    a, b, c = map(Symbol, 'abc')
     pattern = Add(a, b, c, evaluate=False)
 
-    result  = tuple(unify(expr, pattern, {}))
+    result  = tuple(unify(expr, pattern, {}, (a, b, c)))
     expected = ({a: 1, b: 2, c: 3},
                 {a: 1, b: 3, c: 2},
                 {a: 2, b: 1, c: 3},
@@ -68,12 +67,12 @@ def test_unify_commutative():
 
 def test_unify_iter():
     expr = Add(1, 2, 3, evaluate=False)
-    a, b, c = map(ExprWild, 'abc')
+    a, b, c = map(Symbol, 'abc')
     pattern = Add(a, c, evaluate=False)
     assert is_associative(deconstruct(pattern))
     assert is_commutative(deconstruct(pattern))
 
-    result   = list(unify(expr, pattern, {}))
+    result   = list(unify(expr, pattern, {}, (a, c)))
     expected = [{a: 1, c: Add(2, 3, evaluate=False)},
                 {a: 1, c: Add(3, 2, evaluate=False)},
                 {a: 2, c: Add(1, 3, evaluate=False)},
@@ -92,9 +91,9 @@ def test_unify_iter():
 def test_hard_match():
     from sympy import sin, cos
     expr = sin(x) + cos(x)**2
-    p, q = map(ExprWild, 'pq')
+    p, q = map(Symbol, 'pq')
     pattern = sin(p) + cos(p)**2
-    assert list(unify(expr, pattern, {})) == [{p: x}]
+    assert list(unify(expr, pattern, {}, (p, q))) == [{p: x}]
 
 def test_matrix():
     from sympy import MatrixSymbol

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -41,36 +41,6 @@ def mk_matchtype(typ):
                 isinstance(x, Compound) and issubclass(x.op, typ))
     return matchtype
 
-
-def patternify(expr, *wilds, **kwargs):
-    """ Create a matching pattern from an expression
-
-    Example
-    =======
-
-    >>> from sympy import symbols, sin, cos, Mul
-    >>> from sympy.unify.usympy import patternify
-    >>> a, b, c, x, y = symbols('a b c x y')
-
-    >>> # Search for anything of the form sin(foo)**2 + cos(foo)**2
-    >>> pattern = patternify(sin(x)**2 + cos(x)**2, x)
-
-    >>> # Search for any two things added to c. Note that here c is not a wild
-    >>> pattern = patternify(a + b + c, a, b)
-
-    >>> # Search for two things added together, one must be a Mul
-    >>> pattern = patternify(a + b, a, b, types={a: Mul})
-    """
-    from sympy.rules.tools import subs
-    types = kwargs.get('types', {})
-    vars = [CondVariable(wild, mk_matchtype(types[wild]))
-                if wild in types else Variable(wild)
-                for wild in wilds]
-    if any(expr.has(cls) for cls in illegal):
-        raise NotImplementedError("Unification not supported on type %s"%(
-            type(s)))
-    return subs(dict(zip(wilds, vars)))(expr)
-
 def deconstruct(s, wilds=()):
     """ Turn a SymPy object into a Compound """
     if isinstance(s, ExprWild) or s in wilds:
@@ -109,7 +79,7 @@ def unify(x, y, s=None, **kwargs):
     ========
 
     >>> from sympy.unify.usympy import unify
-    >>> from sympy import Wild
+    >>> from sympy import Wild, Basic
     >>> from sympy.abc import x, y, z
     >>> from sympy.core.compatibility import next
     >>> expr = 2*x + y + z
@@ -121,6 +91,11 @@ def unify(x, y, s=None, **kwargs):
     >>> pattern = Wild('p') + Wild('q')
     >>> len(list(unify(expr, pattern, {})))
     12
+
+    Wilds may be specified directly in the call to unify
+
+    >>> next(unify(Basic(1, 2), Basic(1, x), wilds=[x]))
+    {x: 2}
     """
     wilds = kwargs.get('wilds', ())
     decons = lambda x: deconstruct(x, wilds)

--- a/sympy/unify/usympy.py
+++ b/sympy/unify/usympy.py
@@ -40,16 +40,16 @@ def mk_matchtype(typ):
                 isinstance(x, Compound) and issubclass(x.op, typ))
     return matchtype
 
-def deconstruct(s, wilds=()):
+def deconstruct(s, variables=()):
     """ Turn a SymPy object into a Compound """
-    if s in wilds:
+    if s in variables:
         return Variable(s)
     if isinstance(s, (Variable, CondVariable)):
         return s
     if not isinstance(s, Basic) or s.is_Atom:
         return s
     return Compound(s.__class__,
-                    tuple(deconstruct(arg, wilds) for arg in s.args))
+                    tuple(deconstruct(arg, variables) for arg in s.args))
 
 def construct(t):
     """ Turn a Compound into a SymPy object """
@@ -71,7 +71,7 @@ def rebuild(s):
     """
     return construct(deconstruct(s))
 
-def unify(x, y, s=None, wilds=(), **kwargs):
+def unify(x, y, s=None, variables=(), **kwargs):
     """ Structural unification of two expressions/patterns
 
     Examples
@@ -82,25 +82,25 @@ def unify(x, y, s=None, wilds=(), **kwargs):
     >>> from sympy.abc import x, y, z, p, q
     >>> from sympy.core.compatibility import next
 
-    >>> next(unify(Basic(1, 2), Basic(1, x), wilds=[x]))
+    >>> next(unify(Basic(1, 2), Basic(1, x), variables=[x]))
     {x: 2}
 
     >>> expr = 2*x + y + z
     >>> pattern = 2*p +q
-    >>> next(unify(expr, pattern, {}, wilds=(p, q)))
+    >>> next(unify(expr, pattern, {}, variables=(p, q)))
     {p: x, q: y + z}
 
     Unification supports commutative and associative matching
 
     >>> expr = x + y + z
     >>> pattern = p + q
-    >>> len(list(unify(expr, pattern, {}, wilds=(p, q))))
+    >>> len(list(unify(expr, pattern, {}, variables=(p, q))))
     12
 
     Wilds may be specified directly in the call to unify
 
     """
-    decons = lambda x: deconstruct(x, wilds)
+    decons = lambda x: deconstruct(x, variables)
     s = s or {}
     s = dict((decons(k), decons(v)) for k, v in s.items())
 


### PR DESCRIPTION
Remove `patternify` function from the unification system

Previously users would create patterns ahead of time

```
pattern = patternify(sin(x)**2 + cos(x)**1, x)  # x is the wild
rl = rewriterule(pattern, 1)
```

This approach was taken because the `Wild` object only works with `Expr`s.  We had to find another way to specify wilds in generic way.  Pattern is an invalid sympy expression tree.  Now wilds are expressed separately from the pattern and the binding happens at rule construction time in a non-sympy layer

```
pattern = sin(x)**2 + cos(x)**2
wilds = [x]
rl = rewriterule(pattern, 1, wilds)
```

Instead of one bad object we have two good ones.

This PR removes the `patternify` function and introduces the `wilds` keyword to `rewriterule`, `unify`, and `deconstruct`
