### PR TITLE
WIP - Rewrite rule simplification for sympy.stats

### DIFF
--- a/sympy/rules/branch/strat_pure.py
+++ b/sympy/rules/branch/strat_pure.py
@@ -1,5 +1,6 @@
 """ Generic SymPy-Independent Strategies """
-import itertools
+import itertools as it
+from sympy.rules.branch.util import unique, interleave, fnmap
 
 def exhaust(brule):
     """ Apply a branching rule repeatedly until it has no effect """
@@ -36,14 +37,7 @@ def debug(brule, file=None):
 
 def multiplex(*brules):
     """ Multiplex many branching rules into one """
-    def multiplex_brl(expr):
-        seen = set([])
-        for brl in brules:
-            for nexpr in brl(expr):
-                if nexpr not in seen:
-                    seen.add(nexpr)
-                    yield nexpr
-    return multiplex_brl
+    return lambda expr: unique(interleave(fnmap(brules, expr)))
 
 def condition(cond, brule):
     """ Only apply branching rule if condition is true """
@@ -57,7 +51,7 @@ def condition(cond, brule):
 def sfilter(pred, brule):
     """ Yield only those results which satisfy the predicate """
     def filtered_brl(expr):
-        for x in itertools.ifilter(pred, brule(expr)):
+        for x in it.ifilter(pred, brule(expr)):
             yield x
     return filtered_brl
 

--- a/sympy/rules/branch/tests/test_util.py
+++ b/sympy/rules/branch/tests/test_util.py
@@ -1,0 +1,14 @@
+from sympy.rules.branch.util import unique, interleave, fnmap
+
+def test_unique():
+    assert tuple(unique((1,2,3))) == (1,2,3)
+    assert tuple(unique((1,2,1,3))) == (1,2,3)
+
+def test_interleave():
+    assert ''.join(interleave(('ABC', '123'))) == 'A1B2C3'
+    assert ''.join(interleave(('ABC', '1'))) == 'A1BC'
+
+def test_fnmap():
+    inc = lambda x: x + 1
+    dec = lambda x: x - 1
+    assert tuple(fnmap((inc, dec), 2)) == (3, 1)

--- a/sympy/rules/branch/traverse.py
+++ b/sympy/rules/branch/traverse.py
@@ -1,10 +1,10 @@
 """ Branching Strategies to Traverse a Tree """
 
-from sympy.rules.util import new, is_leaf
+from sympy.rules.util import new, is_leaf, children
 from strat_pure import notempty
 from sympy.core.compatibility import product
 
-def top_down(brule):
+def top_down(brule, new=new, is_leaf=is_leaf, children=children, op=type):
     """ Apply a rule down a tree running it on the top nodes first """
     def top_down_rl(expr):
         brl = notempty(brule)
@@ -12,6 +12,6 @@ def top_down(brule):
             if is_leaf(newexpr):
                 yield newexpr
             else:
-                for args in product(*map(top_down_rl, newexpr.args)):
-                    yield new(type(newexpr), *args)
+                for args in product(*map(top_down_rl, children(newexpr))):
+                    yield new(op(newexpr), *args)
     return top_down_rl

--- a/sympy/rules/branch/util.py
+++ b/sympy/rules/branch/util.py
@@ -1,0 +1,24 @@
+import itertools as it
+
+def interleave(seqs, pass_exceptions=()):
+    iters = it.imap(iter, seqs)
+    while iters:
+        newiters = []
+        for itr in iters:
+            try:
+                yield next(itr)
+                newiters.append(itr)
+            except (StopIteration,) + tuple(pass_exceptions):
+                pass
+        iters = newiters
+
+def unique(seq):
+    seen = set()
+    for item in seq:
+        if item not in seen:
+            seen.add(item)
+            yield item
+
+def fnmap(fns, val):
+    return (fn(val) for fn in fns)
+

--- a/sympy/rules/rl.py
+++ b/sympy/rules/rl.py
@@ -152,7 +152,7 @@ def rebuild(expr):
     This forces canonicalization and removes ugliness introduced by the use of
     Basic.__new__
     """
-    try:
+    if isinstance(expr, Basic) and not expr.is_Atom:
         return type(expr)(*map(rebuild, expr.args))
-    except:
+    else:
         return expr

--- a/sympy/rules/tests/test_util.py
+++ b/sympy/rules/tests/test_util.py
@@ -1,0 +1,5 @@
+from sympy.rules.util import count, RuleDB
+
+def test_count():
+    assert count((1, 1, 2, 5, 5, 6)) == {1: 2, 2: 1, 5: 2, 6: 1}
+    assert count('a') == {'a': 1}

--- a/sympy/rules/tests/test_util.py
+++ b/sympy/rules/tests/test_util.py
@@ -3,3 +3,14 @@ from sympy.rules.util import count, RuleDB
 def test_count():
     assert count((1, 1, 2, 5, 5, 6)) == {1: 2, 2: 1, 5: 2, 6: 1}
     assert count('a') == {'a': 1}
+
+def test_RuleDB():
+    db = RuleDB()
+    db.insert('a', 1)
+    db.insert('b', 2)
+    db.insert('aa', 3)
+    db.insert('aab', 4)
+    db.insert('c', 4)
+    assert set(db.query('a')) == set([1])
+    assert set(db.query('ab')) == set([1, 2])
+    assert set(db.query('aab')) == set([1, 2, 3, 4])

--- a/sympy/rules/util.py
+++ b/sympy/rules/util.py
@@ -14,3 +14,16 @@ def children(x):
 
 def count(tup):
     return dict((k, len(v)) for k,v in groupby((lambda x: x), tup).items())
+
+class RuleDB(object):
+    def __init__(self):
+        self.coll = list()
+
+    def insert(self, tup, val):
+        self.coll.append((count(tup), val))
+
+    def query(self, indata):
+        inkey = count(indata)
+        for collkey, collval in self.coll:
+            if all(inkey.get(k, 0) >= v for k, v in collkey.items()):
+                yield collval

--- a/sympy/rules/util.py
+++ b/sympy/rules/util.py
@@ -12,6 +12,8 @@ def is_leaf(x):
 def children(x):
     return x.args
 
+op = type
+
 def count(tup):
     return dict((k, len(v)) for k,v in groupby((lambda x: x), tup).items())
 

--- a/sympy/rules/util.py
+++ b/sympy/rules/util.py
@@ -4,3 +4,6 @@ new = Basic.__new__
 
 def is_leaf(x):
     return not isinstance(x, Basic) or x.is_Atom
+
+def children(x):
+    return x.args

--- a/sympy/rules/util.py
+++ b/sympy/rules/util.py
@@ -1,4 +1,8 @@
 from sympy import Basic
+from sympy.utilities.iterables import sift
+
+def groupby(fn, coll):
+    return sift(coll, fn)
 
 new = Basic.__new__
 
@@ -7,3 +11,6 @@ def is_leaf(x):
 
 def children(x):
     return x.args
+
+def count(tup):
+    return dict((k, len(v)) for k,v in groupby((lambda x: x), tup).items())

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1634,7 +1634,7 @@ class NormalDistribution(SingleContinuousDistribution):
 
     @staticmethod
     def check(mean, std):
-        _value_check(std > 0, "Standard deviation must be positive")
+        _value_check(std >= 0, "Standard deviation must be positive")
 
     def pdf(self, x):
         return exp(-(x - self.mean)**2 / (2*self.std**2)) / (sqrt(2*pi)*self.std)

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -1,12 +1,13 @@
 from sympy.stats import Normal, ChiSquared, LogNormal
 from sympy.stats.crv import ContinuousDistribution
 from sympy.stats.rv import Density, RandomSymbol
-from sympy.unify import rewriterule
+from sympy.unify.rewrites import rewriterules
 from sympy.rules.branch import (multiplex, exhaust, chain, yieldify, debug,
         condition)
 from sympy.rules.branch.traverse import top_down
 from sympy.rules import rebuild, flatten
 from sympy import Symbol, Dummy, factor, log, Abs
+import functools
 
 x, y, z, n, m = map(Symbol, 'xyznm')
 r = Symbol('r', real=True)
@@ -17,17 +18,18 @@ mu, sigma = Symbol('mu', real=True), Symbol('sigma', positive=True)
 # Density(Normal(x, 0, 1)) == Density(StandardNormal(y))
 # We add the `Density` in these patterns later
 _rv_eqs = (
-    (Normal(x, 0, 1)**2, ChiSquared(x, 1), [x]),
-    (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m]),
-    (log(Normal(x, mu, sigma)), LogNormal(x, mu, sigma), [x, mu, sigma]),
-    (Normal(x, mu, sigma) + y, Normal(x, mu + y, sigma), [x, y, mu, sigma]),
-    (Normal(x, mu, sigma) * r, Normal(x, mu, sigma*Abs(r)), [x, r, mu, sigma]),
+    (Normal(x, 0, 1)**2, ChiSquared(x, 1), [x], None),
+    (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m],
+        None),
+    (log(Normal(x, mu, sigma)), LogNormal(x, mu, sigma), [x, mu, sigma], None),
+    (Normal(x, mu, sigma) + y, Normal(x, mu + y, sigma), [x, y, mu, sigma], None),
+    (Normal(x, mu, sigma) * r, Normal(x, mu, sigma*Abs(r)), [x, r, mu, sigma], None),
 )
 
 z = Dummy('z')
-def additive_eq(src, tgt, wilds):
+def additive_eq(src, tgt, wilds, cond):
     """ (X -> Y) -> (X + z -> Y + z) """
-    return (src + z, tgt + z, tuple(wilds) + (z,))
+    return (src + z, tgt + z, tuple(wilds) + (z,), cond)
 
 rv_eqs = _rv_eqs + tuple(map(additive_eq, *zip(*_rv_eqs)))
 
@@ -37,11 +39,15 @@ def unpack_Density(d):
         isinstance(d.expr.pspace.density, ContinuousDistribution)):
         yield d.expr.pspace.density
 
-expression_rrs = map(rewriterule, *zip(*rv_eqs))
+from sympy.unify.core import new, is_leaf, children, op
+top_down_unify = functools.partial(top_down, new=new, is_leaf=is_leaf,
+                                             children=children, op=op)
 
-rrs = expression_rrs + [unpack_Density]
-
-rules = [yieldify(factor)] + rrs + [yieldify(rebuild)]
+exprrule = rewriterules(*zip(*rv_eqs),
+                    strategy=lambda rules: exhaust(top_down_unify(multiplex(*rules))))
 
 statsimp = condition(lambda x: isinstance(x, Density),
-                     exhaust(top_down(multiplex(*rules))))
+                      exhaust(top_down(multiplex(yieldify(factor),
+                                                 exprrule,
+                                                 yieldify(rebuild),
+                                                 unpack_Density))))

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -2,12 +2,14 @@ from sympy.stats import Normal, ChiSquared
 from sympy.stats.crv import ContinuousDistribution
 from sympy.stats.rv import Density, RandomSymbol
 from sympy.unify import rewriterule
-from sympy.rules.branch import multiplex, exhaust, chain, yieldify
-from sympy.rules import rebuild
-from sympy import Symbol
+from sympy.rules.branch import multiplex, exhaust, chain, yieldify, debug
+from sympy.rules.branch.traverse import top_down
+from sympy.rules import rebuild, flatten
+from sympy import Symbol, Dummy
 
 x, y, z, n, m = map(Symbol, 'xyznm')
 
+z = Dummy('z')
 
 # Equivalences of random expressions under density. E.g.
 # Density(Normal(x, 0, 1)) == Density(StandardNormal(y))
@@ -15,7 +17,9 @@ x, y, z, n, m = map(Symbol, 'xyznm')
 expression_equivalences = [
     (Normal(x, 0, 1)**2, ChiSquared(x, 1), [x]),
     (Normal(x, 0, 1)**2 + z, ChiSquared(x, 1) + z, [x, z]),
-    (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m])
+    (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m]),
+    (ChiSquared(x, m) + ChiSquared(y, n) + z, ChiSquared(x, n+m) + z,
+        [x, y, n, m, z])
 ]
 
 def unpack_Density(d):
@@ -29,4 +33,4 @@ expression_rrs = [rewriterule(Density(src), Density(tgt), wilds)
 
 rrs = expression_rrs + [unpack_Density]
 
-statsimp = chain(exhaust(multiplex(*rrs)), yieldify(rebuild))
+statsimp = exhaust(multiplex(yieldify(rebuild), *rrs))

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -1,0 +1,17 @@
+from sympy.stats import Normal, ChiSquared
+from sympy.stats.rv import Density
+from sympy.unify import rewriterule
+from sympy.rules.branch import multiplex, exhaust
+from sympy import Symbol
+
+x, y, z, n, m = map(Symbol, 'xyznm')
+rr_data = [
+        (Density(Normal(x, 0, 1)**2), Density(ChiSquared(x, 1)), [x]),
+        (Density(Normal(x, 0, 1)**2 + z), Density(ChiSquared(x, 1) + z), [x,z]),
+        (Density(ChiSquared(x, m) + ChiSquared(y, n)),
+            Density(ChiSquared(x, n+m)), [x, y, n, m])
+        ]
+
+rrs = [rewriterule(src, tgt, wilds) for src, tgt, wilds in rr_data]
+
+statsimp = exhaust(multiplex(*rrs))

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -6,13 +6,13 @@ from sympy.rules.branch import (multiplex, exhaust, chain, yieldify, debug,
         condition)
 from sympy.rules.branch.traverse import top_down
 from sympy.rules import rebuild, flatten
-from sympy import Symbol, Dummy, factor, log, Abs
+from sympy import Dummy, factor, log, Abs
 import functools
 
-x, y, z, n, m = map(Symbol, 'xyznm')
-r = Symbol('r', real=True)
+x, y, z, n, m = map(Dummy, 'xyznm')
+r = Dummy('r', real=True)
 
-mu, sigma = Symbol('mu', real=True), Symbol('sigma', positive=True)
+mu, sigma = Dummy('mu', real=True), Dummy('sigma', positive=True)
 
 # Equivalences of random expressions under density. E.g.
 # Density(Normal(x, 0, 1)) == Density(StandardNormal(y))

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -31,8 +31,7 @@ def unpack_Density(d):
         isinstance(d.expr.pspace.density, ContinuousDistribution)):
         yield d.expr.pspace.density
 
-expression_rrs = [rewriterule(src, tgt, wilds)
-                    for src, tgt, wilds in rv_eqs]
+expression_rrs = map(rewriterule, *zip(*rv_eqs))
 
 rrs = expression_rrs + [unpack_Density]
 

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -5,13 +5,15 @@ from sympy.rules.branch import multiplex, exhaust
 from sympy import Symbol
 
 x, y, z, n, m = map(Symbol, 'xyznm')
-rr_data = [
-        (Density(Normal(x, 0, 1)**2), Density(ChiSquared(x, 1)), [x]),
-        (Density(Normal(x, 0, 1)**2 + z), Density(ChiSquared(x, 1) + z), [x,z]),
-        (Density(ChiSquared(x, m) + ChiSquared(y, n)),
-            Density(ChiSquared(x, n+m)), [x, y, n, m])
-        ]
+density_equivalences = [
+    (Normal(x, 0, 1)**2, ChiSquared(x, 1), [x]),
+    (Normal(x, 0, 1)**2 + z, ChiSquared(x, 1) + z, [x, z]),
+    (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m])
+]
 
-rrs = [rewriterule(src, tgt, wilds) for src, tgt, wilds in rr_data]
+density_rrs = [rewriterule(Density(src), Density(tgt), wilds)
+                    for src, tgt, wilds in density_equivalences]
+
+rrs = density_rrs + []
 
 statsimp = exhaust(multiplex(*rrs))

--- a/sympy/stats/simplify.py
+++ b/sympy/stats/simplify.py
@@ -1,4 +1,4 @@
-from sympy.stats import Normal, ChiSquared
+from sympy.stats import Normal, ChiSquared, LogNormal
 from sympy.stats.crv import ContinuousDistribution
 from sympy.stats.rv import Density, RandomSymbol
 from sympy.unify import rewriterule
@@ -6,9 +6,12 @@ from sympy.rules.branch import (multiplex, exhaust, chain, yieldify, debug,
         condition)
 from sympy.rules.branch.traverse import top_down
 from sympy.rules import rebuild, flatten
-from sympy import Symbol, Dummy, factor
+from sympy import Symbol, Dummy, factor, log, Abs
 
 x, y, z, n, m = map(Symbol, 'xyznm')
+r = Symbol('r', real=True)
+
+mu, sigma = Symbol('mu', real=True), Symbol('sigma', positive=True)
 
 # Equivalences of random expressions under density. E.g.
 # Density(Normal(x, 0, 1)) == Density(StandardNormal(y))
@@ -16,6 +19,9 @@ x, y, z, n, m = map(Symbol, 'xyznm')
 _rv_eqs = (
     (Normal(x, 0, 1)**2, ChiSquared(x, 1), [x]),
     (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m]),
+    (log(Normal(x, mu, sigma)), LogNormal(x, mu, sigma), [x, mu, sigma]),
+    (Normal(x, mu, sigma) + y, Normal(x, mu + y, sigma), [x, y, mu, sigma]),
+    (Normal(x, mu, sigma) * r, Normal(x, mu, sigma*Abs(r)), [x, r, mu, sigma]),
 )
 
 z = Dummy('z')

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -1,0 +1,38 @@
+from sympy.stats.simplify import statsimp
+from sympy.stats import Normal, ChiSquared
+from sympy.stats.crv_types import ChiSquaredDensity, NormalDensity, Normal
+from sympy.stats.rv import Density, pspace
+from sympy import Symbol, simplify
+
+from sympy.unify import unify
+
+x, y = map(Symbol, 'xy')
+
+def rebuild(x):
+    try:
+        return type(x)(*map(rebuild, x.args))
+    except:
+        return x
+
+def test_chisquared():
+    X = Normal('x', 0, 1)
+    dens = list(statsimp(Density(X**2)))[0]
+    assert isinstance(pspace(dens).density, ChiSquaredDensity)
+
+def test_chisquared_two_degrees():
+    X = Normal('X', 0, 1)
+    Y = Normal('Y', 0, 1)
+    dens = list(statsimp(Density(X**2 + Y**2)))[0].expr.pspace.density
+
+    assert isinstance(dens, ChiSquaredDensity)
+    assert rebuild(dens.k) == 2
+
+def _unifies(a, b):
+    assert tuple(unify, a, b)
+
+def test_unify():
+    assert tuple(unify(NormalDensity(0, 1), NormalDensity(0, 1)))
+    assert tuple(unify(Normal(x, 0, 1), Normal(x, 0, 1)))
+    assert tuple(unify(Normal(y, 0, 1), Normal(x, 0, 1), wilds=[x]))
+    assert list(unify(Normal(x, 0, 1), Normal(y, 0, 1),
+                      {}, wilds=[y])) == [{y: x}]

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -44,9 +44,9 @@ def test_unify():
 
 def test_lognormal():
     mu, sigma = Symbol('mu', real=True), Symbol('sigma', positive=True)
-    assert next(exprrule(log(Normal('X', mu, sigma)))) == \
+    assert rebuild(next(exprrule(log(Normal('X', mu, sigma))))) == \
             LogNormal('X', mu, sigma)
-    assert next(exprrule(log(Normal('X', mu, sigma)) + 1)) == \
+    assert rebuild(next(exprrule(log(Normal('X', mu, sigma)) + 1))) == \
             LogNormal('X', mu, sigma) + 1
 
 def test_exprrule():
@@ -57,3 +57,6 @@ def test_exprrule():
 def test_normal():
     assert rebuild(next(exprrule(Normal(y, 2, 5) + 2))) == Normal(y, 2+2, 5)
     assert rebuild(next(exprrule(Normal(y, 2, 5) * 3))) == Normal(y, 2, 5*3)
+
+    X = Normal(x, 2, 3)
+    assert next(statsimp(Density(X*2 + 1))) == NormalDistribution(3, 6)

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -1,10 +1,10 @@
 from sympy.stats.simplify import (statsimp, rrs, expression_rrs,
         unpack_Density, rv_eqs)
-from sympy.stats import Normal, ChiSquared
+from sympy.stats import Normal, ChiSquared, LogNormal
 from sympy.stats.crv_types import (ChiSquaredDistribution, NormalDistribution,
         Normal)
 from sympy.stats.rv import Density, pspace
-from sympy import Symbol, simplify
+from sympy import Symbol, simplify, log
 from sympy.rules.branch import exhaust, multiplex, chain, yieldify
 from sympy.rules import rebuild
 
@@ -45,3 +45,10 @@ def test_unify():
     assert tuple(unify(Normal(y, 0, 1), Normal(x, 0, 1), variables=[x]))
     assert list(unify(Normal(x, 0, 1), Normal(y, 0, 1),
                       {}, variables=[y])) == [{y: x}]
+
+def test_lognormal():
+    mu, sigma = Symbol('mu', real=True), Symbol('sigma', positive=True)
+    assert next(exprsimp(log(Normal('X', mu, sigma)))) == \
+            LogNormal('X', mu, sigma)
+    assert next(exprsimp(log(Normal('X', mu, sigma)) + 1)) == \
+            LogNormal('X', mu, sigma) + 1

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -1,36 +1,43 @@
 from sympy.stats.simplify import (statsimp, rrs, expression_rrs,
-        unpack_Density, rebuild, yieldify)
+        unpack_Density, expression_equivalences)
 from sympy.stats import Normal, ChiSquared
 from sympy.stats.crv_types import (ChiSquaredDistribution, NormalDistribution,
         Normal)
 from sympy.stats.rv import Density, pspace
 from sympy import Symbol, simplify
-from sympy.rules.branch import exhaust, multiplex, chain
+from sympy.rules.branch import exhaust, multiplex, chain, yieldify
+from sympy.rules import rebuild
 
-from sympy.unify import unify
+from sympy.unify import unify, rewriterule
 
-exprstatsimp = chain(exhaust(multiplex(*expression_rrs)), yieldify(rebuild))
+expr_rrs = map(rewriterule, *zip(*expression_equivalences))
+exprsimp = exhaust(multiplex(yieldify(rebuild), *expr_rrs))
 
 x, y = map(Symbol, 'xy')
 
 def test_chisquared():
     X = Normal('x', 0, 1)
-    dens = list(exprstatsimp(Density(X**2)))[0]
-    assert isinstance(pspace(dens).density, ChiSquaredDistribution)
+    assert next(exprsimp(X**2)).pspace.density == ChiSquaredDistribution(1)
+    assert next(statsimp(Density(X**2))) == ChiSquaredDistribution(1)
 
 def test_chisquared_two_degrees():
     X = Normal('X', 0, 1)
     Y = Normal('Y', 0, 1)
-    dens = list(exprstatsimp(Density(X**2 + Y**2)))[0].expr.pspace.density
-    assert dens == ChiSquaredDistribution(2)
+    assert next(exprsimp(X**2 + Y**2)).pspace.density == ChiSquaredDistribution(2)
+    assert next(statsimp(Density(X**2 + Y**2))) == ChiSquaredDistribution(2)
+
+def test_chisquared_three_degrees():
+    X = Normal('X', 0, 1)
+    Y = Normal('Y', 0, 1)
+    Z = Normal('Z', 0, 1)
+    assert next(exprsimp(X**2 + Y**2 + Z**2)).pspace.density ==\
+            ChiSquaredDistribution(3)
+    assert next(statsimp(Density(X**2 + Y**2 + Z**2))) == \
+            ChiSquaredDistribution(3)
 
 def test_unpack_Density():
     assert next(unpack_Density(Density(Normal('x', 0, 1)))) == \
             NormalDistribution(0, 1)
-
-def test_statsimp():
-    expr = Normal('X', 0, 1)**2 + Normal('Y', 0, 1)**2
-    assert set(statsimp(Density(expr))) == set([ChiSquaredDistribution(2)])
 
 def test_unify():
     assert tuple(unify(NormalDistribution(0, 1), NormalDistribution(0, 1)))

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -1,5 +1,5 @@
 from sympy.stats.simplify import (statsimp, rrs, expression_rrs,
-        unpack_Density, expression_equivalences)
+        unpack_Density, rv_eqs)
 from sympy.stats import Normal, ChiSquared
 from sympy.stats.crv_types import (ChiSquaredDistribution, NormalDistribution,
         Normal)
@@ -10,7 +10,7 @@ from sympy.rules import rebuild
 
 from sympy.unify import unify, rewriterule
 
-expr_rrs = map(rewriterule, *zip(*expression_equivalences))
+expr_rrs = map(rewriterule, *zip(*rv_eqs))
 exprsimp = exhaust(multiplex(yieldify(rebuild), *expr_rrs))
 
 x, y = map(Symbol, 'xy')

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -1,6 +1,7 @@
 from sympy.stats.simplify import statsimp
 from sympy.stats import Normal, ChiSquared
-from sympy.stats.crv_types import ChiSquaredDensity, NormalDensity, Normal
+from sympy.stats.crv_types import (ChiSquaredDistribution, NormalDistribution,
+        Normal)
 from sympy.stats.rv import Density, pspace
 from sympy import Symbol, simplify
 
@@ -17,21 +18,21 @@ def rebuild(x):
 def test_chisquared():
     X = Normal('x', 0, 1)
     dens = list(statsimp(Density(X**2)))[0]
-    assert isinstance(pspace(dens).density, ChiSquaredDensity)
+    assert isinstance(pspace(dens).density, ChiSquaredDistribution)
 
 def test_chisquared_two_degrees():
     X = Normal('X', 0, 1)
     Y = Normal('Y', 0, 1)
     dens = list(statsimp(Density(X**2 + Y**2)))[0].expr.pspace.density
 
-    assert isinstance(dens, ChiSquaredDensity)
+    assert isinstance(dens, ChiSquaredDistribution)
     assert rebuild(dens.k) == 2
 
 def _unifies(a, b):
     assert tuple(unify, a, b)
 
 def test_unify():
-    assert tuple(unify(NormalDensity(0, 1), NormalDensity(0, 1)))
+    assert tuple(unify(NormalDistribution(0, 1), NormalDistribution(0, 1)))
     assert tuple(unify(Normal(x, 0, 1), Normal(x, 0, 1)))
     assert tuple(unify(Normal(y, 0, 1), Normal(x, 0, 1), wilds=[x]))
     assert list(unify(Normal(x, 0, 1), Normal(y, 0, 1),

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -42,6 +42,6 @@ def test_unpack_Density():
 def test_unify():
     assert tuple(unify(NormalDistribution(0, 1), NormalDistribution(0, 1)))
     assert tuple(unify(Normal(x, 0, 1), Normal(x, 0, 1)))
-    assert tuple(unify(Normal(y, 0, 1), Normal(x, 0, 1), wilds=[x]))
+    assert tuple(unify(Normal(y, 0, 1), Normal(x, 0, 1), variables=[x]))
     assert list(unify(Normal(x, 0, 1), Normal(y, 0, 1),
-                      {}, wilds=[y])) == [{y: x}]
+                      {}, variables=[y])) == [{y: x}]

--- a/sympy/stats/tests/test_simplify.py
+++ b/sympy/stats/tests/test_simplify.py
@@ -3,7 +3,7 @@ from sympy.stats import Normal, ChiSquared, LogNormal
 from sympy.stats.crv_types import (ChiSquaredDistribution, NormalDistribution,
         Normal)
 from sympy.stats.rv import Density, pspace
-from sympy import Symbol, simplify, log
+from sympy import Symbol, simplify, log, Dummy
 from sympy.rules.branch import exhaust, multiplex, chain, yieldify
 from sympy.rules import rebuild
 
@@ -53,3 +53,7 @@ def test_exprrule():
     assert next(exprrule(Normal(y, 0, 1)**2)) == ChiSquared(y, 1)
     assert next(exprrule(2*Normal(y, 0, 1)**2)) == 2*ChiSquared(y, 1)
     assert next(exprrule(Density(Normal(y, 0, 1)**2))) == Density(ChiSquared(y, 1))
+
+def test_normal():
+    assert rebuild(next(exprrule(Normal(y, 2, 5) + 2))) == Normal(y, 2+2, 5)
+    assert rebuild(next(exprrule(Normal(y, 2, 5) * 3))) == Normal(y, 2, 5*3)

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -232,3 +232,13 @@ def index(it, ind):
     [20, 30, 10]
     """
     return type(it)([it[i] for i in ind])
+
+# Functions to define tree traversals over Compounds
+def is_leaf(x):
+    return not isinstance(x, Compound)
+def children(x):
+    return x.args
+def new(op, *args):
+    return Compound(op, args)
+def op(x):
+    return x.op

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -25,7 +25,7 @@ class Compound(object):
     """
     def __init__(self, op, args):
         self.op = op
-        self.args = args
+        self.args = tuple(args)
 
     def __eq__(self, other):
         return (type(self) == type(other) and self.op == other.op and
@@ -71,6 +71,13 @@ class CondVariable(object):
 
     def __str__(self):
         return "CondVariable(%s)" % str(self.arg)
+
+def reify(x, s):
+    if x in s:
+        return s[x]
+    if isinstance(x, Compound):
+        return Compound(reify(x.op, s), [reify(arg, s) for arg in x.args])
+    return x
 
 def unify(x, y, s=None, **fns):
     """ Unify two expressions

--- a/sympy/unify/core.py
+++ b/sympy/unify/core.py
@@ -36,6 +36,7 @@ class Compound(object):
 
     def __str__(self):
         return "%s[%s]" % (str(self.op), ', '.join(map(str, self.args)))
+    __repr__ = __str__
 
 class Variable(object):
     """ A Wild token """
@@ -50,6 +51,7 @@ class Variable(object):
 
     def __str__(self):
         return "Variable(%s)" % str(self.arg)
+    __repr__ = __str__
 
 class CondVariable(object):
     """ A wild token that matches conditionally
@@ -71,6 +73,7 @@ class CondVariable(object):
 
     def __str__(self):
         return "CondVariable(%s)" % str(self.arg)
+    __repr__ = __str__
 
 def reify(x, s):
     if x in s:

--- a/sympy/unify/rewrites.py
+++ b/sympy/unify/rewrites.py
@@ -1,0 +1,42 @@
+from sympy.unify.usympy import construct, deconstruct
+from sympy.unify.core import unify, reify, Variable
+from sympy.rules.tools import subs
+from sympy.rules.branch import exhaust, multiplex
+import functools
+import itertools as it
+
+def crl(source, target, variables, condition=None, unify=unify, reify=reify):
+    """ Conditional rewrite rule """
+    def f(expr):
+        for match in unify(source, expr, {}):
+            if not condition or condition(*map(match.get, variables, variables)):
+                yield reify(target, match)
+    return f
+
+def rewriterules(sources, targets, variabless, conditions,
+        construct=construct,
+        deconstruct=deconstruct,
+        unify=unify,
+        reify=reify,
+        strategy=lambda rules: exhaust(multiplex(*rules))):
+
+    sources2 = map(deconstruct, sources, variabless)
+    targets2 = map(deconstruct, targets, variabless)
+    variabless2 = map(lambda l: map(Variable, l), variabless)
+    conditions2 = map(functools.partial(fn_deconstruct, construct=construct),
+                      conditions)
+
+    crl2 = functools.partial(crl, reify=reify)
+
+    rules = map(crl2, sources2, targets2, variabless2, conditions2)
+
+    return lambda expr: it.imap(construct, strategy(rules)(deconstruct(expr)))
+
+def types(expr):
+    return set([type(expr)]).union(
+            reduce(set.union, map(types, expr.args), set()))
+
+def fn_deconstruct(fn, construct=construct):
+    if not fn:
+        return fn
+    return lambda *args: fn(*map(construct, args))

--- a/sympy/unify/tests/test_rewrites.py
+++ b/sympy/unify/tests/test_rewrites.py
@@ -1,0 +1,48 @@
+from sympy.unify.rewrite import crl, rewriterules
+from sympy import *
+from sympy.abc import x, y, z
+from sympy.unify.usympy import construct, deconstruct
+from sympy.unify.core import Variable
+
+def test_crl():
+
+    assert list(crl(0, 1, [])(0)) == [1]
+    assert list(crl(0, 1, [])(1)) == []
+    assert list(crl(Variable('x'), 1, [Variable('x')])(5)) == [1]
+
+def test_crl_sympy():
+    src, tgt, vs, cond = Basic(x), Basic(True), [x], lambda x: x < 10
+    pat2 = deconstruct(src, vs), deconstruct(tgt, vs), map(Variable, vs), cond
+    expr = deconstruct(Basic(3))
+
+    assert list(crl(*pat2)(expr)) == [deconstruct(Basic(True))]
+
+    expr = deconstruct(Basic(13))
+    assert not list(crl(*pat2)(expr))
+
+def test_rewriterules():
+    pat1 = x, 'foo', [x], lambda x: isinstance(x, int) and x < 10
+    pat2 = x, 'bar', [x], lambda x: isinstance(x, int) and x > 10
+    f = rewriterules(*zip(pat1, pat2))
+
+    assert list(f('a')) == ['a']
+    assert list(f(3)) == ['foo']
+    assert list(f(14)) == ['bar']
+
+def test_rewriterules_sympy():
+    pat1 = Basic(x), Basic(y), [x], lambda x: x.is_integer and x < 10
+    pat2 = Basic(x), Basic(z), [x], lambda x: x.is_integer and x > 10
+    f = rewriterules(*zip(pat1, pat2))
+
+    assert list(f('a')) == ['a']
+
+    assert list(f(Basic(S(3)))) == [Basic(y)]
+    assert list(f(Basic(S(14)))) == [Basic(z)]
+
+def test_rewriterules_sympy_nested():
+    pat1 = Basic(1, Basic(x)), Basic(2, Basic(x)), [x], None
+    pat2 = Basic(2, Basic(x)), Basic(3, Basic(x)), [x], None
+    f = rewriterules(*zip(pat1, pat2))
+
+    assert list(f('a')) == ['a']
+    assert list(f(Basic(1, Basic(4)))) == [Basic(3, Basic(4))]

--- a/sympy/unify/tests/test_rewrites.py
+++ b/sympy/unify/tests/test_rewrites.py
@@ -1,4 +1,4 @@
-from sympy.unify.rewrite import crl, rewriterules
+from sympy.unify.rewrites import crl, rewriterules
 from sympy import *
 from sympy.abc import x, y, z
 from sympy.unify.usympy import construct, deconstruct
@@ -46,3 +46,12 @@ def test_rewriterules_sympy_nested():
 
     assert list(f('a')) == ['a']
     assert list(f(Basic(1, Basic(4)))) == [Basic(3, Basic(4))]
+
+def test_strategy():
+    from sympy.rules.branch import multiplex
+    pat1 = Basic(1, Basic(x)), Basic(2, Basic(x)), [x], None
+    pat2 = Basic(2, Basic(x)), Basic(3, Basic(x)), [x], None
+    strategy = lambda rules: multiplex(*rules)
+    f = rewriterules(*zip(pat1, pat2), strategy=strategy)
+
+    assert list(f(Basic(1, Basic(4)))) == [Basic(2, Basic(4))]

--- a/sympy/unify/tests/test_rewrites.py
+++ b/sympy/unify/tests/test_rewrites.py
@@ -55,3 +55,15 @@ def test_strategy():
     f = rewriterules(*zip(pat1, pat2), strategy=strategy)
 
     assert list(f(Basic(1, Basic(4)))) == [Basic(2, Basic(4))]
+
+def test_many_sympy_rules():
+    a,b,c,d,e,f,g,h,i,j,k = map(Symbol, 'abcdefghijk')
+    x, y, z = map(Dummy, 'xyz')
+    patterns = [
+        (x +  y, x, [x, y], None),
+        (x ** y, y, [x, y], None)
+        ]
+    rl = rewriterules(*zip(*patterns))
+    expr = a + b**c + d*e + f**(g+1) + i + j + k
+
+    assert next(rl(expr)).is_Atom

--- a/sympy/unify/tests/test_rewrites.py
+++ b/sympy/unify/tests/test_rewrites.py
@@ -1,4 +1,4 @@
-from sympy.unify.rewrites import crl, rewriterules
+from sympy.unify.rewrites import crl, rewriterules, types, ops
 from sympy import *
 from sympy.abc import x, y, z
 from sympy.unify.usympy import construct, deconstruct
@@ -61,9 +61,19 @@ def test_many_sympy_rules():
     x, y, z = map(Dummy, 'xyz')
     patterns = [
         (x +  y, x, [x, y], None),
+        (x *  y, y, [x, y], None),
         (x ** y, y, [x, y], None)
         ]
     rl = rewriterules(*zip(*patterns))
     expr = a + b**c + d*e + f**(g+1) + i + j + k
 
     assert next(rl(expr)).is_Atom
+
+def test_types():
+    expr = Symbol('x') + Symbol('y') * 2
+    assert types(expr) == set([Symbol, Add, Mul, Integer])
+
+def test_ops():
+    from sympy.rules.util import is_leaf, children, op
+    expr = Symbol('x') + Symbol('y') * 2
+    assert ops(expr, op, children, is_leaf) == set([Symbol, Add, Mul, Integer])

--- a/sympy/unify/tests/test_unify.py
+++ b/sympy/unify/tests/test_unify.py
@@ -1,4 +1,5 @@
-from sympy.unify.core import Compound, Variable, CondVariable, allcombinations
+from sympy.unify.core import (Compound, Variable, CondVariable, allcombinations,
+        reify)
 from sympy.unify import core
 from sympy.core.compatibility import next
 
@@ -34,6 +35,12 @@ def test_ops():
             [{x:b, y:c}]
     assert list(unify(C('Add', (C('Mul', (1,2)), b,c)), C('Add', (x,y,c)), {})) == \
             [{x: C('Mul', (1,2)), y:b}]
+
+def test_reify():
+    assert reify(1, {2: 3}) == 1
+    assert reify(2, {2: 3}) == 3
+
+    assert reify(Compound('Add', (2, 4)), {2: 3}) == Compound('Add', (3, 4))
 
 def test_associative():
     c1 = C('Add', (1,2,3))


### PR DESCRIPTION
In [this blog post](http://matthewrocklin.com/blog/work/2012/12/11/Statistical-Simplification/) I motivate the use of rewrite rules for simplifying statistical distributions.  Statisticians know relations like if X and Y are standard normal random variables then X**2 has a ChiSquare distribution and X**2 + Y**2 has a ChiSquare distribution with two degrees of freedom.

Rewrite rules allow us to express and use this knowledge easily. 

This pull request constructs a `statsimp` function for the simplification of density calculations.  See `sympy/stats/simplify.py`.  The information for statistical transformations is separated from the algorithmic core.  Ideally someone should be able to look at `_rv_eqs` in `sympy/stats/simplify.py`, understand what is going on, and contribute more relations.  I encourage you to try this out.  Some distributions are evident here
http://www.math.wm.edu/~leemis/chart/UDR/UDR.html

This pull request builds on https://github.com/sympy/sympy/pull/1718 and https://github.com/sympy/sympy/pull/1720

This pull request is a work in progress.

In particular the information in `_rv_eqs` in https://github.com/mrocklin/sympy/blob/stats-rr/sympy/stats/simplify.py

``` python
_rv_eqs = (
    (Normal(x, 0, 1)**2, ChiSquared(x, 1), [x]),
    (ChiSquared(x, m) + ChiSquared(y, n), ChiSquared(x, n+m), [x, y, n, m]),
)
```

Makes it so that the tests in https://github.com/mrocklin/sympy/blob/stats-rr/sympy/stats/tests/test_simplify.py pass

``` python
def test_chisquared_three_degrees():
    X = Normal('X', 0, 1)
    Y = Normal('Y', 0, 1)
    Z = Normal('Z', 0, 1)
    assert next(statsimp(Density(X**2 + Y**2 + Z**2))) == \
            ChiSquaredDistribution(3)
```
