### PR TITLE
Binomial coefficients are not expanded by default

### DIFF
--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -12,7 +12,7 @@ from sympy import (Rational, symbols, factorial, sqrt, log, exp, oo, product,
     I, trigsimp, tan, sin, cos, diff, nan, limit, EulerGamma, polygamma,
     bernoulli, assoc_legendre, Function, re, im, DiracDelta, chebyshevt, atan,
     sinh, cosh, floor, ceiling, solve, asinh, LambertW, N, apart, sqrtdenest,
-    factorial2, powdenest, Mul, S, mpmath, ZZ, Poly)
+    factorial2, powdenest, Mul, S, mpmath, ZZ, Poly, expand_func)
 
 from sympy.integrals.deltafunctions import deltaintegrate
 from sympy.utilities.pytest import XFAIL, slow
@@ -235,7 +235,7 @@ def test_F1():
 
 
 def test_F2():
-    assert binomial(n, 3) == n*(n - 1)*(n - 2)/6
+    assert expand_func(binomial(n, 3)) == n*(n - 1)*(n - 2)/6
 
 
 @XFAIL

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -435,10 +435,23 @@ class binomial(CombinatorialFunction):
        For the sake of convenience for negative 'k' this function
        will return zero no matter what valued is the other argument.
 
+       The binomial coeffient will not be expanded by default when
+       'n' is a symbol. In order to expand C(n, k), where 'n' is a
+       symbol whereas 'k' is a number, either of the following ways
+       exist:
+       1. Operate method expand on binomial with argument func=True.
+       2. Use the expand_func function and pass the binomial to it.
+
+       In the first case, the binomial coefficient will be expanded
+       and the correspoding polynomial will be obtained. In the second
+       case, the expasion will not expand the polynomial and this
+       method must be preferred unless otherwise required. See
+       the examples below for more information.
+
        Examples
        ========
 
-       >>> from sympy import Symbol, Rational, binomial
+       >>> from sympy import Symbol, Rational, binomial, expand_func
        >>> n = Symbol('n', integer=True)
 
        >>> binomial(15, 8)
@@ -462,6 +475,12 @@ class binomial(CombinatorialFunction):
        -5/128
 
        >>> binomial(n, 3)
+       binomial(n, 3)
+
+       >>> binomial(n, 3).expand(func=True)
+       n**3/6 - n**2/2 + n/3
+
+       >>> expand_func(binomial(n, 3))
        n*(n - 2)*(n - 1)/6
 
     """

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -521,14 +521,6 @@ class binomial(CombinatorialFunction):
                                 result *= prime**exp
 
                     return C.Integer(result)
-                else:
-                    result = n - k + 1
-
-                    for i in xrange(2, k + 1):
-                        result *= n - k + i
-                        result /= i
-
-                    return result
         elif k.is_negative:
             return S.Zero
         elif (n - k).simplify().is_negative:
@@ -538,6 +530,32 @@ class binomial(CombinatorialFunction):
 
             if d.is_Integer:
                 return cls.eval(n, d)
+
+    def _eval_expand_func(self, **hints):
+        """
+        Function to expand binomial(n,k) when m is positive integer 
+        Also,
+        n is self.args[0] and k is self.args[1] while using binomial(n, k)
+        """
+
+        if self.args[0].is_Number:
+            return binomial(*self.args)
+
+        k = self.args[1]
+        if k.is_Integer:
+            if k == S.Zero:
+                return S.One
+            elif k < 0:
+                return S.Zero
+            else:
+                n = self.args[0]
+                result = n - k + 1
+                for i in xrange(2, k + 1):
+                    result *= n - k + i
+                    result /= i
+                return result
+        else:
+            return binomial(*self.args)
 
     def _eval_rewrite_as_factorial(self, n, k):
         return C.factorial(n)/(C.factorial(k)*C.factorial(n - k))

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -521,6 +521,13 @@ class binomial(CombinatorialFunction):
                                 result *= prime**exp
 
                     return C.Integer(result)
+                elif n.is_Number:
+                    result = n - k + 1
+                    for i in xrange(2, k + 1):
+                        result *= n - k + i
+                        result /= i
+                    return result
+
         elif k.is_negative:
             return S.Zero
         elif (n - k).simplify().is_negative:
@@ -533,15 +540,18 @@ class binomial(CombinatorialFunction):
 
     def _eval_expand_func(self, **hints):
         """
-        Function to expand binomial(n,k) when m is positive integer 
+        Function to expand binomial(n,k) when m is positive integer
         Also,
         n is self.args[0] and k is self.args[1] while using binomial(n, k)
         """
-
-        if self.args[0].is_Number:
+        n = self.args[0]
+        if n.is_Number:
             return binomial(*self.args)
 
         k = self.args[1]
+        if k.is_Add and n in k:
+            k = n - k
+
         if k.is_Integer:
             if k == S.Zero:
                 return S.One

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -435,18 +435,10 @@ class binomial(CombinatorialFunction):
        For the sake of convenience for negative 'k' this function
        will return zero no matter what valued is the other argument.
 
-       The binomial coeffient will not be expanded by default when
-       'n' is a symbol. In order to expand C(n, k), where 'n' is a
-       symbol whereas 'k' is a number, either of the following ways
-       exist:
-       1. Operate method expand on binomial with argument func=True.
-       2. Use the expand_func function and pass the binomial to it.
-
-       In the first case, the binomial coefficient will be expanded
-       and the correspoding polynomial will be obtained. In the second
-       case, the expasion will not expand the polynomial and this
-       method must be preferred unless otherwise required. See
-       the examples below for more information.
+       To expand the binomial when n is a symbol, use either
+       expand_func() or expand(func=True). The former will keep the
+       polynomial in factored form while the latter will expand the
+       polynomial itself. See examples for details.
 
        Examples
        ========

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,5 +1,6 @@
 from sympy import (Symbol, symbols, factorial, factorial2, binomial,
-    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan, oo, simplify)
+                   rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
+                   oo, simplify, expand_func)
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -120,10 +121,10 @@ def test_binomial():
     assert binomial(-10, 7) == -11440
     assert binomial(n, -1) == 0
     assert binomial(n, 0) == 1
-    assert binomial(n, 1) == n
-    assert binomial(n, 2) == n*(n - 1)/2
-    assert binomial(n, n - 2) == n*(n - 1)/2
-    assert binomial(n, n - 1) == n
+    assert expand_func(binomial(n, 1)) == n
+    assert expand_func(binomial(n, 2)) == n*(n - 1)/2
+    assert expand_func(binomial(n, n - 2)) == n*(n - 1)/2
+    assert expand_func(binomial(n, n - 1)) == n
     assert binomial(n, n) == 1
     assert binomial(n, n + 1) == 0
     assert binomial(n, u) == 0

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -125,6 +125,9 @@ def test_binomial():
     assert expand_func(binomial(n, 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 1)) == n
+    assert binomial(n, 3) == binomial(n, 3)
+    assert binomial(n, 3).expand(func=True) ==  n**3/6 - n**2/2 + n/3
+    assert expand_func(binomial(n, 3)) ==  n*(n - 2)*(n - 1)/6
     assert binomial(n, n) == 1
     assert binomial(n, n + 1) == 0
     assert binomial(n, u) == 0

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -125,7 +125,7 @@ def test_binomial():
     assert expand_func(binomial(n, 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 2)) == n*(n - 1)/2
     assert expand_func(binomial(n, n - 1)) == n
-    assert binomial(n, 3) == binomial(n, 3)
+    assert binomial(n, 3).func == binomial
     assert binomial(n, 3).expand(func=True) ==  n**3/6 - n**2/2 + n/3
     assert expand_func(binomial(n, 3)) ==  n*(n - 2)*(n - 1)/6
     assert binomial(n, n) == 1


### PR DESCRIPTION
Initial fix for issue 3544. Now,

```
>>> b = binomial(n, 8)

>>> print b
>>> binomial(n, 8)

>>> b.expand(func=True)
>>> n**8/40320 - n**7/1440 + 23*n**6/2880 - 7*n**5/144 + 967*n**4/5760 - 469*n**3/1440 + 363*n**2/1120 - n/8

>>> expand_func(b)
>>> n*(n - 7)*(n - 6)*(n - 5)*(n - 4)*(n - 3)*(n - 2)*(n - 1)/40320
```

Let me know if more changes are required.
I expect many tests to fail because of this change. I'll update them later.
