### PR TITLE
3606: keep track of original float

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3782,6 +3782,7 @@ def _real_to_rational(expr, tolerance=None):
     if tolerance is not None and tolerance < 1:
         reduce_num = ceiling(1/tolerance)
     for float in p.atoms(C.Float):
+        key = float
         if reduce_num is not None:
             r = Rational(float).limit_denominator(reduce_num)
         elif (tolerance is not None and tolerance >= 1 and
@@ -3801,7 +3802,7 @@ def _real_to_rational(expr, tolerance=None):
                     r = Rational(str(float/d))*d
                 else:
                     r = Integer(0)
-        reps[float] = r
+        reps[key] = r
     return p.subs(reps, simultaneous=True)
 
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3851,11 +3851,12 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=None):
         return _real_to_rational(expr, tolerance)
 
     # sympy's default tolarance for Rationals is 15; other numbers may have
-    # lower tolerances set, so use them to pick the largest tolerance if none
+    # lower tolerances set, so use them to pick the largest tolerance if None
     # was given
-    tolerance = tolerance or 10**-min([15] +
-                                     [mpmath.libmp.libmpf.prec_to_dps(n._prec)
-                                     for n in expr.atoms(Float)])
+    if tolerance is None:
+        tolerance = 10**-min([15] +
+             [mpmath.libmp.libmpf.prec_to_dps(n._prec)
+             for n in expr.atoms(Float)])
 
     prec = 30
     bprec = int(prec*3.33)
@@ -3871,8 +3872,8 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=None):
     exprval = expr.evalf(prec, chop=True)
     re, im = exprval.as_real_imag()
 
-    # Must be numerical
-    if not ((re.is_Float or re.is_Integer) and (im.is_Float or im.is_Integer)):
+    # safety check to make sure that this evaluated to a number
+    if not (re.is_Number and im.is_Number):
         return expr
 
     def nsimplify_real(x):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1081,6 +1081,8 @@ def test_nsimplify():
     assert nsimplify(33, tolerance=10, rational=True) == Rational(33)
     assert nsimplify(33.33, tolerance=10, rational=True) == Rational(30)
     assert nsimplify(37.76, tolerance=10, rational=True) == Rational(40)
+    assert nsimplify(-203.1) == -S(2031)/10
+
 
 def test_extract_minus_sign():
     x = Symbol("x")

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1082,6 +1082,10 @@ def test_nsimplify():
     assert nsimplify(33.33, tolerance=10, rational=True) == Rational(30)
     assert nsimplify(37.76, tolerance=10, rational=True) == Rational(40)
     assert nsimplify(-203.1) == -S(2031)/10
+    assert nsimplify(.2, tolerance=0) == S.One/5
+    assert nsimplify(-.2, tolerance=0) == -S.One/5
+    assert nsimplify(.2222, tolerance=0) == S(1111)/5000
+    assert nsimplify(-.2222, tolerance=0) == -S(1111)/5000
 
 
 def test_extract_minus_sign():


### PR DESCRIPTION
When a negative float was encountered, its value was changed but
this, then, lost the sign of the float when it was used as the key
for the replacements. Now the key is captured before the calculation
begins.
