### PR TITLE
Fix for #1733: mishandling of factorials when taking limits

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -53,7 +53,7 @@ def limit(e, z, z0, dir="+"):
     # If no factorial term is present, e should remain unchanged.
     # factorial is defined to be zero for negative inputs (which
     # differs from gamma) so only rewrite for positive z0.
-    if z0 >= 0:
+    if z0.is_positive:
         e = e.rewrite(factorial, gamma)
 
     if e.func is tan:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -48,11 +48,11 @@ def limit(e, z, z0, dir="+"):
 
     if not e.has(z):
         return e
-        
+
     # gruntz fails on factorials but works with the gamma function
     # if no factorial term is present, e should remain unchanged
     e = e.rewrite(factorial, gamma)
-    
+
     if e.func is tan:
         # discontinuity at odd multiples of pi/2; 0 at even
         disc = S.Pi/2

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -50,8 +50,11 @@ def limit(e, z, z0, dir="+"):
         return e
 
     # gruntz fails on factorials but works with the gamma function
-    # if no factorial term is present, e should remain unchanged
-    e = e.rewrite(factorial, gamma)
+    # If no factorial term is present, e should remain unchanged.
+    # factorial is defined to be zero for negative inputs (which
+    # differs from gamma) so only rewrite for positive z0.
+    if z0 >= 0:
+        e = e.rewrite(factorial, gamma)
 
     if e.func is tan:
         # discontinuity at odd multiples of pi/2; 0 at even

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,5 +1,5 @@
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul, oo, C
-from sympy.functions import tan, cot
+from sympy.functions import tan, cot, gamma
 from gruntz import gruntz
 
 
@@ -48,7 +48,11 @@ def limit(e, z, z0, dir="+"):
 
     if not e.has(z):
         return e
-
+        
+    # gruntz fails on factorials but works with the gamma function
+    # if no factorial term is present, e should remain unchanged
+    e = e.rewrite(gamma)
+    
     if e.func is tan:
         # discontinuity at odd multiples of pi/2; 0 at even
         disc = S.Pi/2

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -1,5 +1,5 @@
 from sympy.core import S, Symbol, Add, sympify, Expr, PoleError, Mul, oo, C
-from sympy.functions import tan, cot, gamma
+from sympy.functions import tan, cot, factorial, gamma
 from gruntz import gruntz
 
 
@@ -51,7 +51,7 @@ def limit(e, z, z0, dir="+"):
         
     # gruntz fails on factorials but works with the gamma function
     # if no factorial term is present, e should remain unchanged
-    e = e.rewrite(gamma)
+    e = e.rewrite(factorial, gamma)
     
     if e.func is tan:
         # discontinuity at odd multiples of pi/2; 0 at even

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -366,3 +366,13 @@ def test_issue_3267():
     n = Symbol('n', integer=True, positive=True)
     r = (n + 1)*x**(n + 1)/(x**(n + 1) - 1) - x/(x - 1)
     assert limit(r, x, 1) == n/2
+
+
+def test_factorial():
+    from sympy import factorial, E
+    f = factorial(x)
+    assert limit(f, x, oo) == oo
+    assert limit(x/f, x, oo) == 0
+    # see Stirling's approximation:
+    # http://en.wikipedia.org/wiki/Stirling's_approximation
+    assert limit(f/(sqrt(2*pi*x)*(x/E)**x), x, oo) == 1

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -377,3 +377,5 @@ def test_factorial():
     # http://en.wikipedia.org/wiki/Stirling's_approximation
     assert limit(f/(sqrt(2*pi*x)*(x/E)**x), x, oo) == 1
     assert limit(f, x, -oo) == factorial(-oo)
+    assert limit(f, x, x**2) == factorial(x**2)
+    assert limit(f, x, -x**2) == factorial(-x**2)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -376,3 +376,4 @@ def test_factorial():
     # see Stirling's approximation:
     # http://en.wikipedia.org/wiki/Stirling's_approximation
     assert limit(f/(sqrt(2*pi*x)*(x/E)**x), x, oo) == 1
+    assert limit(f, x, -oo) == factorial(-oo)


### PR DESCRIPTION
I'm assuming that the line `e = e.rewrite(gamma)` is (a) not too expensive, and (b) doesn't interfere with functions that don't include factorial terms.

See #1733 for the discussion that led to this PR.
