### PR TITLE
Passing a dictionary to .n() now works on cos and sin. Issue 3538

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1273,6 +1273,9 @@ class EvalfMixin(object):
         try:
             result = evalf(self, prec + 4, options)
         except NotImplementedError:
+            # Make sure subs has occured
+            if subs is not None:
+                self = self.subs(subs)
             # Fall back to the ordinary evalf
             v = self._eval_evalf(prec)
             if v is None:

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -698,9 +698,9 @@ def evalf_pow(v, prec, options):
 #----------------------------------------------------------------------------#
 def evalf_trig(v, prec, options):
     """
-    This function handles sin and cos of real arguments.
+    This function handles sin and cos of complex arguments.
 
-    TODO: should also handle tan and complex arguments.
+    TODO: should also handle tan of complex arguments.
     """
     if v.func is C.cos:
         func = mpf_cos
@@ -714,7 +714,9 @@ def evalf_trig(v, prec, options):
     xprec = prec + 20
     re, im, re_acc, im_acc = evalf(arg, xprec, options)
     if im:
-        raise NotImplementedError
+        if 'subs' in options:
+            v = v.subs(options['subs'])
+        return evalf(v._eval_evalf(prec), prec, options)
     if not re:
         if v.func is C.cos:
             return fone, None, prec, None
@@ -1273,9 +1275,6 @@ class EvalfMixin(object):
         try:
             result = evalf(self, prec + 4, options)
         except NotImplementedError:
-            # Make sure subs has occured
-            if subs is not None:
-                self = self.subs(subs)
             # Fall back to the ordinary evalf
             v = self._eval_evalf(prec)
             if v is None:

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -194,6 +194,7 @@ def test_evalf_bugs():
     assert NS((-x).n()) == '-x'
     assert NS((-2*x).n()) == '-2.00000000000000*x'
     assert NS((-2*x*y).n()) == '-2.00000000000000*x*y'
+    assert cos(x).n(subs={x: 1+I}) == cos(x).subs(x, 1+I).n()
     #3561. Also NaN != mpmath.nan
     # In this order:
     # 0*nan, 0/nan, 0*inf, 0/inf


### PR DESCRIPTION
Issue 3538.
Before,

```
>>> cos(x).n(subs={x:1+I})
cos(x)
```

Now,

```
>>> cos(x).n(subs={x:1+I})
0.833730025131149 - 0.988897705762865*I
```

The problem was that evalf_trig didn't work for complex arguments and was raising NotImplementedError.  But, `cos(1+I).n()` does evaluate.
The fix here was to make sure that substitution for x is occurring.
