### PR TITLE
Factors accepts Expr; as_powers_dict returns int-based defaultdict

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -14,7 +14,7 @@ from sympy.core.coreerrors import NonCommutativeExpression
 from sympy.core.containers import Tuple, Dict
 from sympy.utilities import default_sort_key
 from sympy.utilities.iterables import (common_prefix, common_suffix,
-        variations)
+        variations, ordered)
 
 from collections import defaultdict
 
@@ -83,9 +83,9 @@ class Factors(object):
         >>> from sympy.abc import x
         >>> e = 2*x**3
         >>> Factors(e)
-        Factors({x: 3, 2: 1})
+        Factors({2: 1, x: 3})
         >>> Factors(e.as_powers_dict())
-        Factors(defaultdict(<type 'int'>, {x: 3, 2: 1}))
+        Factors({2: 1, x: 3})
         >>> f = _
         >>> f.factors  # underlying dictionary
         {2: 1, x: 3}
@@ -109,10 +109,13 @@ class Factors(object):
             raise TypeError('expecting Expr or dictionary')
 
     def __hash__(self):  # Factors
-        return hash((tuple(self.factors), self.gens))
+        keys = tuple(ordered(self.factors.keys()))
+        values = [self.factors[k] for k in keys]
+        return hash((keys, values))
 
     def __repr__(self):  # Factors
-        return "Factors(%s)" % self.factors
+        return "Factors({%s})" % ', '.join(
+            ['%s: %s' % (k, v) for k, v in ordered(self.factors.items())])
 
     def as_expr(self):  # Factors
         """Return the underlying expression.
@@ -195,9 +198,9 @@ class Factors(object):
         >>> a = Factors((x*y**2).as_powers_dict())
         >>> b = Factors((x*y/z).as_powers_dict())
         >>> a.mul(b)
-        Factors({x: 2, z: -1, y: 3})
+        Factors({x: 2, y: 3, z: -1})
         >>> a*b
-        Factors({z: -1, y: 3, x: 2})
+        Factors({x: 2, y: 3, z: -1})
         """
         if not isinstance(other, Factors):
             other = Factors(other)
@@ -370,7 +373,7 @@ class Factors(object):
         >>> a = Factors((x*y**2).as_powers_dict())
         >>> b = Factors((x*y/z).as_powers_dict())
         >>> a.lcm(b)
-        Factors({x: 1, z: -1, y: 2})
+        Factors({x: 1, y: 2, z: -1})
         """
         if not isinstance(other, Factors):
             other = Factors(other)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -816,16 +816,10 @@ class Mul(Expr, AssocOp):
         return lhs/rhs
 
     def as_powers_dict(self):
-        d = defaultdict(list)
+        d = defaultdict(int)
         for term in self.args:
             b, e = term.as_base_exp()
-            d[b].append(e)
-        for b, e in d.iteritems():
-            if len(e) == 1:
-                e = e[0]
-            else:
-                e = Add(*e)
-            d[b] = e
+            d[b] += e
         return d
 
     def as_numer_denom(self):

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1085,6 +1085,8 @@ def test_as_powers_dict():
     assert x.as_powers_dict() == {x: 1}
     assert (x**y*z).as_powers_dict() == {x: y, z: 1}
     assert Mul(2, 2, **dict(evaluate=False)).as_powers_dict() == {S(2): S(2)}
+    assert (x*y).as_powers_dict()[z] == 0
+    assert (x + y).as_powers_dict()[z] == 0
 
 
 def test_as_coefficients_dict():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -17,7 +17,7 @@ def test_decompose_power():
 
 
 def test_Factors():
-    assert Factors() == Factors({})
+    assert Factors() == Factors({}) == Factors(1)
 
     assert Factors().as_expr() == S.One
     assert Factors({x: 2, y: 3, sin(x): 4}).as_expr() == x**2*y**3*sin(x)**4


### PR DESCRIPTION
`as_powers_dict` didn't play nicely with Factors because for Mul, a list-based defaultdict was returned. It now returns an int-based one like Add does.

Docstrings for exprtools Factors were added.
