### PR TITLE
compatibility.next import in unify/test_sympy.py

### DIFF
--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -4,6 +4,7 @@ from sympy.unify.usympy import (deconstruct, construct, unify, is_associative,
         is_commutative)
 from sympy.abc import w, x, y, z, n, m, k
 from sympy.utilities.pytest import XFAIL
+from sympy.core.compatibility import next
 
 def test_deconstruct():
     expr     = Basic(1, 2, 3)


### PR DESCRIPTION
This fixes a current bug in master.

`next` was used in a test in the unify module without importing from `sympy.core.comatibility`.  This pull request adds the appropriate import.
