### PR TITLE
Travis-CI: add tests for Python 2.7/3.3 + gmpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,24 @@ python:
   - 2.7
   - 3.2
   - 3.3
+matrix:
+  include:
+    - python: 2.7
+      env: TEST_GMPY="true"
+    - python: 3.3
+      env: TEST_GMPY="true"
+  # Below we list *exact* builds that are allowed to fail. Once they are fixed,
+  # you can remove the appropriate test from below (you still need to keep it
+  # above in order to be tested at all).
+  allow_failures:
+    - python: 2.7
+      env: TEST_GMPY="true"
+    - python: 3.3
+      env: TEST_GMPY="true"
+before_install:
+  - if [ "${TEST_GMPY}" == "true" ]; then
+      pip install gmpy;
+    fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: TEST_GMPY="true"
 before_install:
   - if [ "${TEST_GMPY}" == "true" ]; then
-      pip install gmpy;
+      pip install "gmpy==1.16";
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi


### PR DESCRIPTION
This adds two new tests:

Python 2.7 + gmpy
Python 3.3 + gmpy

At the moment, there are some test failures. So the tests are marked as
"Allowed Failures". Travis-CI then tests them, but keeps the results separate
from the main build. That way it will not disturb the SymPy workflow, but we
can work on fixing the failures, as well as manually examining the results to
make sure that no more failures are being introduced.
