### PR TITLE
Travis-CI: propagate tests failures back to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ script:
   # of sympy in the source directory.
   - mkdir empty
   - cd empty
-  - "echo -e \"import sympy\\nif not sympy.test(): raise Exception('Tests failed')\" | python"
-  - "echo -e \"import sympy\\nif not sympy.doctest(): raise Exception('Doctests failed')\" | python"
+  - "echo -e \"import sympy\\nt1=sympy.test();t2=sympy.doctest()\\nif not (t1 and t2): raise Exception('Tests failed')\" | python"
 notifications:
   email: false


### PR DESCRIPTION
The problem was that somehow the nonzero exit code was not always propagated to
Travis. I have found that using just one executable statement fixes it. So now
we run both tests and doctests using one Python session.

See here for an example of results:

https://travis-ci.org/certik/sympy/builds/4605973

so it works like a charm.
