### PR TITLE
More robust factor_nc().

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -736,7 +736,8 @@ def factor_nc(expr):
     from sympy.simplify.simplify import powsimp
     from sympy.polys import gcd, factor
 
-    def _mexpand(expr):
+    def _pemexpand(expr):
+        "Expand with the minimal set of hints necessary to check the result."
         return expr.expand(deep=True, mul=True, power_exp=True,
             power_base=False, basic=False, multinomial=True, log=False)
 
@@ -881,10 +882,10 @@ def factor_nc(expr):
                     else:
                         ncfac.append(f)
             pre_mid = g*Mul(*cfac)*l
-            target = _mexpand(expr/c)
+            target = _pemexpand(expr/c)
             for s in variations(ncfac, len(ncfac)):
                 ok = pre_mid*Mul(*s)*r
-                if _mexpand(ok) == target:
+                if _pemexpand(ok) == target:
                     return _keep_coeff(c, ok)
 
         # mid was an Add that didn't factor successfully

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -733,8 +733,12 @@ def factor_nc(expr):
     >>> factor_nc(((x + A)*(x + B)).expand())
     (x + A)*(x + B)
     """
-    from sympy.simplify.simplify import _mexpand
+    from sympy.simplify.simplify import powsimp
     from sympy.polys import gcd, factor
+
+    def _mexpand(expr):
+        return expr.expand(deep=True, mul=True, power_exp=True,
+            power_base=False, basic=False, multinomial=True, log=False)
 
     expr = sympify(expr)
     if not isinstance(expr, Expr) or not expr.args:
@@ -854,7 +858,7 @@ def factor_nc(expr):
         unrep1 = [(v, k) for k, v in rep1]
         unrep1.reverse()
         new_mid, r2, _ = _mask_nc(mid.subs(rep1))
-        new_mid = factor(new_mid)
+        new_mid = powsimp(factor(new_mid))
 
         new_mid = new_mid.subs(r2).subs(unrep1)
 
@@ -872,8 +876,10 @@ def factor_nc(expr):
                     cfac.append(f)
                 else:
                     b, e = f.as_base_exp()
-                    assert e.is_Integer
-                    ncfac.extend([b]*e)
+                    if e.is_Integer:
+                        ncfac.extend([b]*e)
+                    else:
+                        ncfac.append(f)
             pre_mid = g*Mul(*cfac)*l
             target = _mexpand(expr/c)
             for s in variations(ncfac, len(ncfac)):

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -182,6 +182,7 @@ def test_xreplace():
 
 def test_factor_nc():
     x, y = symbols('x,y')
+    k = symbols('k', integer=True)
     n, m, o = symbols('n,m,o', commutative=False)
 
     # mul and multinomial expansion is needed
@@ -235,6 +236,9 @@ def test_factor_nc():
     # issue 3435
     assert (2*n + 2*m).factor() == 2*(n + m)
 
+    # issue 3602
+    assert factor_nc(n**k + n**(k + 1)) == n**k*(1 + n)
+    assert factor_nc((m*n)**k + (m*n)**(k + 1)) == (1 + m*n)*(m*n)**k
 
 def test_issue_3261():
     a, b = symbols("a b")


### PR DESCRIPTION
If factor_nc() can't factor an expression, it should just return it unchanged, not throw AssertionError.

In order to get a factorized result that matches the unfactorized input expression in some cases involving powers of a Mul, we now call powsimp() in addition to factor(). Thus it becomes necessary to call expand(power_exp=True) when checking the result.

Fixes issue 3602: AssertionError while factoring noncommutative symbols.
http://code.google.com/p/sympy/issues/detail?id=3602
