### PR TITLE
Changes to support gmpy >=1.13, or gmpy2 >=2.0.0b4

### DIFF
--- a/sympy/conftest.py
+++ b/sympy/conftest.py
@@ -10,8 +10,15 @@ def pytest_report_header(config):
     s = "architecture: %s\n" % ARCH
     from sympy.core.cache import USE_CACHE
     s += "cache:        %s\n" % USE_CACHE
-    from sympy.polys.domains import GROUND_TYPES
-    s += "ground types: %s\n" % GROUND_TYPES
+    from sympy.core.compatibility import GROUND_TYPES, HAS_GMPY
+    version = ''
+    if GROUND_TYPES =='gmpy':
+        if HAS_GMPY == 1:
+            import gmpy
+        elif HAS_GMPY == 2:
+            import gmpy2 as gmpy
+        version = gmpy.version()
+    s += "ground types: %s %s\n" % (GROUND_TYPES, version)
     return s
 
 

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -2,14 +2,16 @@
 Adaptive numerical evaluation of SymPy expressions, using mpmath
 for mathematical functions.
 """
+from sympy.core.compatibility import SYMPY_INTS
 import sympy.mpmath.libmp as libmp
 from sympy.mpmath import make_mpc, make_mpf, mp, mpc, mpf, nsum, quadts, quadosc
 from sympy.mpmath import inf as mpmath_inf
-from sympy.mpmath.libmp import (bitcount, from_int, from_man_exp,
-        from_rational, fhalf, fnan, fnone, fone, fzero, mpf_abs, mpf_add,
+from sympy.mpmath.libmp import (from_int, from_man_exp, from_rational, fhalf,
+        fnan, fnone, fone, fzero, mpf_abs, mpf_add,
         mpf_atan, mpf_atan2, mpf_cmp, mpf_cos, mpf_e, mpf_exp, mpf_log, mpf_lt,
         mpf_mul, mpf_neg, mpf_pi, mpf_pow, mpf_pow_int, mpf_shift, mpf_sin,
         mpf_sqrt, normalize, round_nearest, to_int, to_str)
+from sympy.mpmath.libmp import bitcount as mpmath_bitcount
 from sympy.mpmath.libmp.backend import MPZ
 from sympy.mpmath.libmp.libmpc import _infs_nan
 from sympy.mpmath.libmp.libmpf import dps_to_prec, prec_to_dps
@@ -25,6 +27,9 @@ from containers import Tuple
 
 LG10 = math.log(10, 2)
 rnd = round_nearest
+
+def bitcount(n):
+    return mpmath_bitcount(int(n))
 
 # Used in a few places as placeholder values to denote exponents and
 # precision levels, e.g. of exact numbers. Must be careful to avoid
@@ -147,7 +152,7 @@ def scaled_zero(mag, sign=1):
     """
     if type(mag) is tuple and len(mag) == 4 and iszero(mag, scaled=True):
         return (mag[0][0],) + mag[1:]
-    elif type(mag) is int:
+    elif isinstance(mag, SYMPY_INTS):
         if sign not in [-1, 1]:
             raise ValueError('sign must be +/-1')
         rv, p = mpf_shift(fone, mag), -1

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1,7 +1,7 @@
 """Tools for manipulating of large commutative expressions. """
 
 from sympy.core.add import Add
-from sympy.core.compatibility import iterable, is_sequence
+from sympy.core.compatibility import iterable, is_sequence, SYMPY_INTS
 from sympy.core.mul import Mul, _keep_coeff
 from sympy.core.power import Pow
 from sympy.core.basic import Basic, preorder_traversal
@@ -166,7 +166,7 @@ class Factors(object):
         return self.div(other)[1]
 
     def pow(self, other):  # Factors
-        if type(other) is int and other >= 0:
+        if isinstance(other, SYMPY_INTS) and other >= 0:
             factors = {}
 
             if other:
@@ -225,7 +225,7 @@ class Factors(object):
             return NotImplemented
 
     def __pow__(self, other):  # Factors
-        if type(other) is int:
+        if isinstance(other, SYMPY_INTS):
             return self.pow(other)
         else:
             return NotImplemented
@@ -335,7 +335,7 @@ class Term(object):
     __truediv__ = __div__
 
     def __pow__(self, other):  # Term
-        if type(other) is int:
+        if isinstance(other, SYMPY_INTS):
             return self.pow(other)
         else:
             return NotImplemented

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -5,7 +5,7 @@ from singleton import S, Singleton
 from expr import Expr, AtomicExpr
 from decorators import _sympifyit, deprecated, call_highest_priority
 from cache import cacheit, clear_cache
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, HAS_GMPY, SYMPY_INTS
 import sympy.mpmath as mpmath
 import sympy.mpmath.libmp as mlib
 from sympy.mpmath.libmp import mpf_pow, mpf_pi, mpf_e, phi_fixed
@@ -1042,7 +1042,7 @@ class Rational(Number):
                 if isinstance(p, (float, Float)):
                     return Rational(*_as_integer_ratio(p))
 
-            if not isinstance(p, (int, long, Rational)):
+            if not isinstance(p, SYMPY_INTS + (Rational,)):
                 raise TypeError('invalid input: %s' % p)
             q = S.One
         else:
@@ -2697,13 +2697,18 @@ except ImportError:
     pass
 
 try:
-    import gmpy
+    if HAS_GMPY == 2:
+        import gmpy2 as gmpy
+    elif HAS_GMPY == 1:
+        import gmpy
+    else:
+        raise ImportError
 
     def sympify_mpz(x):
         return Integer(long(x))
 
     def sympify_mpq(x):
-        return Rational(long(x.numer()), long(x.denom()))
+        return Rational(long(x.numerator), long(x.denominator))
 
     converter[type(gmpy.mpz(1))] = sympify_mpz
     converter[type(gmpy.mpq(1, 2))] = sympify_mpq

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -9,7 +9,7 @@ the separate 'factorials' module.
 
 from sympy.core.function import Function, expand_mul
 from sympy.core import S, Symbol, Rational, oo, Integer, C, Add, Dummy
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, SYMPY_INTS
 from sympy.core.cache import cacheit
 from sympy.functions.combinatorial.factorials import factorial
 
@@ -787,7 +787,7 @@ def _nP(n, k=None, replacement=False):
 
     if k == 0:
         return 1
-    if type(n) is int:  # n different items
+    if isinstance(n, SYMPY_INTS):  # n different items
         # assert n >= 0
         if k is None:
             return sum(_nP(n, i, replacement) for i in range(n + 1))
@@ -951,7 +951,7 @@ def nC(n, k=None, replacement=False):
     from sympy.functions.combinatorial.factorials import binomial
     from sympy.core.mul import prod
 
-    if type(n) is int:
+    if isinstance(n, SYMPY_INTS):
         if k is None:
             if not replacement:
                 return 2**n
@@ -1198,7 +1198,7 @@ def nT(n, k=None):
     """
     from sympy.utilities.iterables import multiset_partitions
 
-    if type(n) is int:
+    if isinstance(n, SYMPY_INTS):
         # assert n >= 0
         # all the same
         if k is None:

--- a/sympy/mpmath/libmp/backend.py
+++ b/sympy/mpmath/libmp/backend.py
@@ -61,7 +61,7 @@ if 'MPMATH_NOGMPY' not in os.environ:
                 import gmpy
             except ImportError:
                 raise ImportError
-        if gmpy.version() >= '1.03':
+        if gmpy.version() >= '1.13':
             BACKEND = 'gmpy'
             MPZ = gmpy.mpz
     except:

--- a/sympy/mpmath/libmp/libintmath.py
+++ b/sympy/mpmath/libmp/libintmath.py
@@ -298,8 +298,12 @@ def sqrt_fixed(x, prec):
 sqrt_fixed2 = sqrt_fixed
 
 if BACKEND == 'gmpy':
-    isqrt_small = isqrt_fast = isqrt = gmpy.sqrt
-    sqrtrem = gmpy.sqrtrem
+    if gmpy.version() >= "2":
+        isqrt_small = isqrt_fast = isqrt = gmpy.isqrt
+        sqrtrem = gmpy.isqrt_rem
+    else:
+        isqrt_small = isqrt_fast = isqrt = gmpy.sqrt
+        sqrtrem = gmpy.sqrtrem
 elif BACKEND == 'sage':
     isqrt_small = isqrt_fast = isqrt = \
         getattr(sage_utils, "isqrt", lambda n: MPZ(n).isqrt())

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -8,7 +8,7 @@ from sympy.core.evalf import bitcount
 from sympy.core.numbers import igcd
 from sympy.core.power import integer_nthroot, Pow
 from sympy.core.mul import Mul
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, SYMPY_INTS
 from primetest import isprime
 from generate import sieve, primerange, nextprime
 from sympy.core.singleton import S
@@ -170,7 +170,7 @@ def trailing(n):
 
     # 2**m is quick for z up through 2**30
     z = bitcount(n) - 1
-    if type(z) is int:
+    if isinstance(z, SYMPY_INTS):
         if n == 1 << z:
             return z
 

--- a/sympy/polys/domains/__init__.py
+++ b/sympy/polys/domains/__init__.py
@@ -52,25 +52,7 @@ RR_mpmath = MPmathRealDomain
 
 from pythonrationaltype import PythonRationalType
 
-from groundtypes import HAS_GMPY
-
-
-def _getenv(key, default=None):
-    from os import getenv
-    return getenv(key, default)
-
-GROUND_TYPES = _getenv('SYMPY_GROUND_TYPES', 'auto').lower()
-
-if GROUND_TYPES == 'auto':
-    if HAS_GMPY:
-        GROUND_TYPES = 'gmpy'
-    else:
-        GROUND_TYPES = 'python'
-
-if GROUND_TYPES == 'gmpy' and not HAS_GMPY:
-    from warnings import warn
-    warn("gmpy library is not installed, switching to 'python' ground types")
-    GROUND_TYPES = 'python'
+from sympy.core.compatibility import GROUND_TYPES
 
 _GROUND_TYPES_MAP = {
     'gmpy': (FF_gmpy, ZZ_gmpy(), QQ_gmpy()),

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -1,6 +1,7 @@
 """Implementation of :class:`Domain` class. """
 
 from sympy.core import Basic, sympify
+from sympy.core.compatibility import SYMPY_INTS
 
 from sympy.polys.polyerrors import (
     UnificationFailed,
@@ -88,11 +89,11 @@ class Domain(object):
                 if K1.of_type(a):
                     return a
 
-                if type(a) is int:
+                if isinstance(a, SYMPY_INTS):
                     return K1(a)
 
-                if type(a) is long:
-                    return K1(a)
+                #if type(a) is long:
+                #    return K1(a)
 
                 if K1.is_Numerical and getattr(a, 'is_ground', False):
                     return K1.convert(a.LC())

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -104,8 +104,8 @@ class FiniteField(Field, SimpleDomain):
 
     def from_QQ_gmpy(K1, a, K0=None):
         """Convert GMPY's ``mpq`` to ``dtype``. """
-        if a.denom() == 1:
-            return K1.from_ZZ_gmpy(a.numer())
+        if a.denominator == 1:
+            return K1.from_ZZ_gmpy(a.numerator)
 
     def from_RR_sympy(K1, a, K0=None):
         """Convert SymPy's ``Float`` to ``dtype``. """

--- a/sympy/polys/domains/gmpyintegerring.py
+++ b/sympy/polys/domains/gmpyintegerring.py
@@ -71,8 +71,8 @@ class GMPYIntegerRing(IntegerRing):
 
     def from_QQ_gmpy(K1, a, K0):
         """Convert GMPY ``mpq`` to GMPY's ``mpz``. """
-        if a.denom() == 1:
-            return a.numer()
+        if a.denominator == 1:
+            return a.numerator
 
     def from_RR_sympy(K1, a, K0):
         """Convert SymPy's ``Float`` to GMPY's ``mpz``. """

--- a/sympy/polys/domains/gmpyrationalfield.py
+++ b/sympy/polys/domains/gmpyrationalfield.py
@@ -4,7 +4,7 @@ from sympy.polys.domains.rationalfield import RationalField
 
 from sympy.polys.domains.groundtypes import (
     GMPYRationalType, SymPyRationalType,
-    gmpy_numer, gmpy_denom, gmpy_factorial,
+    gmpy_numer, gmpy_denom, gmpy_factorial, gmpy_qdiv,
 )
 
 from sympy.polys.polyerrors import CoercionFailed
@@ -70,11 +70,11 @@ class GMPYRationalField(RationalField):
 
     def exquo(self, a, b):
         """Exact quotient of `a` and `b`, implies `__div__`.  """
-        return GMPYRationalType(a.qdiv(b))
+        return GMPYRationalType(gmpy_qdiv(a, b))
 
     def quo(self, a, b):
         """Quotient of `a` and `b`, implies `__div__`. """
-        return GMPYRationalType(a.qdiv(b))
+        return GMPYRationalType(gmpy_qdiv(a, b))
 
     def rem(self, a, b):
         """Remainder of `a` and `b`, implies nothing.  """
@@ -82,15 +82,15 @@ class GMPYRationalField(RationalField):
 
     def div(self, a, b):
         """Division of `a` and `b`, implies `__div__`. """
-        return GMPYRationalType(a.qdiv(b)), self.zero
+        return GMPYRationalType(gmpy_qdiv(a, b)), self.zero
 
     def numer(self, a):
         """Returns numerator of `a`. """
-        return gmpy_numer(a)
+        return a.numerator
 
     def denom(self, a):
         """Returns denominator of `a`. """
-        return gmpy_denom(a)
+        return a.denominator
 
     def factorial(self, a):
         """Returns factorial of `a`. """

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -2,16 +2,10 @@
 
 from sympy.external import import_module
 
-HAS_GMPY = True
+# The logic for detecting if a compatible version of gmpy/gmpy2 is present is
+# done in sympy.core.compatibility.
 
-# Versions of gmpy prior to 1.03 do not work correctly with int(largempz)
-# For example, int(gmpy.mpz(2**256)) would raise OverflowError.
-# See issue 1881.
-
-gmpy = import_module('gmpy', min_module_version='1.03',
-    module_version_attr='version', module_version_attr_call_args=())
-
-HAS_GMPY = bool(gmpy)
+from sympy.core.compatibility import HAS_GMPY
 
 from __builtin__ import (
     int as PythonIntegerType,
@@ -33,7 +27,7 @@ from sympy import (
     Rational as SymPyRationalType,
 )
 
-if HAS_GMPY:
+if HAS_GMPY == 1:
     from gmpy import (
         mpz as GMPYIntegerType,
         mpq as GMPYRationalType,
@@ -44,6 +38,20 @@ if HAS_GMPY:
         gcd as gmpy_gcd,
         lcm as gmpy_lcm,
         sqrt as gmpy_sqrt,
+        qdiv as gmpy_qdiv,
+    )
+elif HAS_GMPY == 2:
+    from gmpy2 import (
+        mpz as GMPYIntegerType,
+        mpq as GMPYRationalType,
+        fac as gmpy_factorial,
+        numer as gmpy_numer,
+        denom as gmpy_denom,
+        gcdext as gmpy_gcdex,
+        gcd as gmpy_gcd,
+        lcm as gmpy_lcm,
+        isqrt as gmpy_sqrt,
+        qdiv as gmpy_qdiv,
     )
 else:
     class GMPYIntegerType(object):
@@ -61,6 +69,7 @@ else:
     gmpy_gcd = None
     gmpy_lcm = None
     gmpy_sqrt = None
+    gmpy_qdiv = None
 
 from sympy.mpmath import (
     mpf as MPmathRealType,

--- a/sympy/polys/domains/mpmathrealdomain.py
+++ b/sympy/polys/domains/mpmathrealdomain.py
@@ -37,7 +37,7 @@ class MPmathRealDomain(RealDomain):
 
     def from_QQ_gmpy(K1, a, K0):
         """Convert a GMPY `mpq` object to `dtype`. """
-        return MPmathRealType(int(a.numer())) / int(a.denom())
+        return MPmathRealType(int(a.numerator)) / int(a.denominator)
 
     def from_RR_sympy(K1, a, K0):
         """Convert a SymPy `Float` object to `dtype`. """

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -3,6 +3,7 @@
 from random import uniform
 from math import ceil as _ceil, sqrt as _sqrt
 
+from sympy.core.compatibility import SYMPY_INTS
 from sympy.core.mul import prod
 from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query
@@ -285,7 +286,7 @@ def gf_from_dict(f, p, K):
     """
     n, h = max(f.iterkeys()), []
 
-    if type(n) is int:
+    if isinstance(n, SYMPY_INTS):
         for k in xrange(n, -1, -1):
             h.append(f.get(k, K.zero) % p)
     else:

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -462,7 +462,7 @@ class StrPrinter(Printer):
         return '%s/%s' % (expr.numerator, expr.denominator)
 
     def _print_mpq(self, expr):
-        return '%s/%s' % (expr.numer(), expr.denom())
+        return '%s/%s' % (expr.numerator, expr.denominator)
 
     def _print_Float(self, expr):
         prec = expr._prec

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1554,8 +1554,15 @@ class PyTestReporter(Reporter):
         self.write("architecture:       %s\n" % ARCH)
         from sympy.core.cache import USE_CACHE
         self.write("cache:              %s\n" % USE_CACHE)
-        from sympy.polys.domains import GROUND_TYPES
-        self.write("ground types:       %s\n" % GROUND_TYPES)
+        from sympy.core.compatibility import GROUND_TYPES, HAS_GMPY
+        version = ''
+        if GROUND_TYPES =='gmpy':
+            if HAS_GMPY == 1:
+                import gmpy
+            elif HAS_GMPY == 2:
+                import gmpy2 as gmpy
+            version = gmpy.version()
+        self.write("ground types:       %s %s\n" % (GROUND_TYPES, version))
         if seed is not None:
             self.write("random seed:        %d\n" % seed)
         from .misc import HASH_RANDOMIZATION

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -365,7 +365,7 @@ def test_polys():
     for c in (PythonRationalField, PythonRationalField()):
         check(c)
 
-    from sympy.polys.domains import HAS_GMPY
+    from sympy.core.compatibility import HAS_GMPY
 
     if HAS_GMPY:
         from sympy.polys.domains import GMPYIntegerRing, GMPYRationalField


### PR DESCRIPTION
From [issue 3622](http://code.google.com/p/sympy/issues/detail?id=3622). casevh wrote:

I've attached a patch file for the changes I made to support gmpy and gmpy2. (I'm still trying to figure out git....).

With these changes, gmpy 1.13 or later and gmpy2 2.0.0b4 or later should work. I discovered a bug in gmpy2 so I will be releasing b4 in a few days.

Summary of the changes;
sympy.core.compatibility tries importing both gmpy2 and gmpy and checks for the correct version. HAS_GMPY is set to 2 if a valid version of gmpy2 is found. It is set to 1 if a valid version of gmpy is found. And it is set to 0 if no valid version is found.

The check for the requested ground type is also done in sympy.core.compatibility so GROUND_TYPES should be imported from there.

I also added SYMPY_INTS to sympy.core.compatibility. It is a tuple that contains the valid integer types, taking into account the Python version and the requested ground type.

I made the following changes to account for the changes in gmpy2. They are backwards compatible to gmpy 1.13.
- changed mpq.numer() to mpq.numerator
- changed mpq.denom() to mpq.denominator
- changed the uses of qdiv() to use gmpy.qdiv(a,b) instead of a.qdiv(b)
- changed various type checks to use SYMPY_INTS
