### PR TITLE
Fix for rsolve bug (#2943)

### DIFF
--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -596,7 +596,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
                 poly += coeff * Z**i
 
         for z in roots(poly, Z).iterkeys():
-            if not z.is_real or z.is_zero:
+            if z.is_real == False or z.is_zero:
                 continue
 
             C = rsolve_poly([ polys[i]*z**i for i in xrange(r + 1) ], 0, n)

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -156,6 +156,18 @@ def test_rsolve():
 
     assert f.subs(y, Lambda(k, rsolve(f, y(n)).subs(n, k))).simplify() == 0
 
+    a,b,c = symbols('a,b,c')
+
+    assert rsolve(Eq(y(n + 1), a*y(n)), y(n)).simplify() == C0*a**n
+    assert rsolve(Eq(y(n + 1), a*y(n)), y(n), {y(1): a}).simplify() == a**n
+
+    f = y(n) - a*y(n-2)
+
+    assert rsolve(f,y(n)) == C0*a**(n/2) + C1*(-sqrt(a))**n
+    assert rsolve(f,y(n), \
+            {y(1): sqrt(a)*(a + b), y(2): a*(a - b)}).simplify() == \
+            a**(n/2)*((-1)**(n + 1)*b + a)
+
 
 def test_rsolve_raises():
     x = Function('x')


### PR DESCRIPTION
http://code.google.com/p/sympy/issues/detail?id=2943

Correct solutions:

```
>>> f,n,a,b = Function('f'), Symbol('n',integer=True), Symbol('a'),Symbol('b')
>>> print(rsolve(Eq(f(n + 1), a*f(n)), f(n)))
C0*a**n
>>> print(rsolve(a*f(n-1)-b**2*f(n-2)-f(n), f(n), {2:a**2-b**2, 1:a}))
(a/2 - sqrt(a**2 - 4*b**2)/2)**n*(2*a - (a + sqrt(a**2 - 4*b**2))**2/(2*sqrt(a**2 - 4*b**2)))/(a - sqrt(a**2 - 4*b**2)) + (a/2 + sqrt(a**2 - 4*b**2)/2)**n*(a + sqrt(a**2 - 4*b**2))/(2*sqrt(a**2 - 4*b**2))
```
