### PR TITLE
Integration of Sympyprt extension from IPyXt into SymPy

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -31,14 +31,14 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
                            forecolor, backcolor, fontsize, mode):
     """Setup printing in IPython interactive session. """
 
-    preamble = "\\documentclass[12pt]{article}\n" \
+    preamble = "\\documentclass[%s]{article}\n" \
                "\\pagestyle{empty}\n" \
                "\\usepackage{amsmath,amsfonts}%s\\begin{document}"
     if euler:
         addpackages = '\\usepackage{euler}'
     else:
         addpackages = ''
-    preamble = preamble % (addpackages)
+    preamble = preamble % (fontsize, addpackages)
 
     imagesize = 'tight'
     offset = "0cm,0cm"

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -1,6 +1,9 @@
 """Tools for setting up printing in interactive sessions. """
 
+from cStringIO import StringIO
+
 from sympy import latex
+from sympy import preview
 
 
 def _init_python_printing(stringify_func):
@@ -24,40 +27,65 @@ def _init_python_printing(stringify_func):
     sys.displayhook = _displayhook
 
 
-def _init_ipython_printing(ip, stringify_func, render_latex):
+def _init_ipython_printing(ip, stringify_func, render_latex, euler,
+                           forecolor, backcolor, fontsize, mode):
     """Setup printing in IPython interactive session. """
-    # For IPython >= 0.11, will use latex_to_png to render LaTeX
-    try:
-        from IPython.lib.latextools import latex_to_png
-    except ImportError:
-        pass
+
+    preamble = "\\documentclass[12pt]{article}\n" \
+               "\\pagestyle{empty}\n" \
+               "\\usepackage{amsmath,amsfonts}%s\\begin{document}"
+    if euler:
+        addpackages = '\\usepackage{euler}'
+    else:
+        addpackages = ''
+    preamble = preamble % (addpackages)
+
+    imagesize = 'tight'
+    offset = "0cm,0cm"
+    resolution = 150
+    dvi = r"-T {0} -D {1:d} -bg {2} -fg {3} -O {4}"
+    dvi = dvi.format(imagesize, resolution, backcolor,
+                     forecolor, offset)
+    dvioptions = dvi.split()
+    # print "DVIOPTIONS", dvioptions
+    # print "PREAMBLE", preamble
 
     def _print_pretty(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
         p.text(stringify_func(arg))
+
+    def _preview_wrapper(o):
+        buffer = StringIO()
+        preview(o, output='png', viewer='StringIO', outputbuffer=buffer, outputTexFile='tmp.tex',
+                preamble=preamble, dvioptions=dvioptions)
+        # with open('tmp.tex', 'r') as fh:
+        #     for line in fh.readlines():
+        #         print line,
+        bin_data = buffer.getvalue()
+        # from base64 import encodestring
+        # print
+        # print "bin_data", encodestring(bin_data)
+        return bin_data
 
     def _print_png(o):
         """
         A function to display sympy expressions using inline style LaTeX in PNG.
         """
         s = latex(o, mode='inline')
-        # mathtext does not understand centain latex flags, so we try to
-        # replace them with suitable subs
-        s = s.replace(r'\operatorname', '')
-        s = s.replace(r'\overline', r'\bar')
-        png = latex_to_png(s)
-        return png
+        print "png", s
+        return _preview_wrapper(s)
+
+    def _print_custom_png(o):
+        s = latex(o, mode=mode)
+        print "custompng", s
+        return _preview_wrapper(s)
 
     def _print_display_png(o):
         """
         A function to display sympy expression using display style LaTeX in PNG.
         """
         s = latex(o, mode='plain')
-        s = s.strip('$')
-        # As matplotlib does not support display style, dvipng backend is used
-        # here
-        png = latex_to_png(s, backend='dvipng', wrap=True)
-        return png
+        return _preview_wrapper('$' + s + '$')
 
     def _can_print_latex(o):
         """Return True if type o can be printed with LaTeX.
@@ -122,31 +150,36 @@ def _init_ipython_printing(ip, stringify_func, render_latex):
 
         if render_latex:
             png_formatter = ip.display_formatter.formatters['image/png']
-
+            png_formatter.for_type(str, _print_png)
             png_formatter.for_type_by_name(
-                'sympy.core.basic', 'Basic', _print_png
+                'sympy.core.basic', 'Basic', _print_custom_png
             )
             png_formatter.for_type_by_name(
-                'sympy.matrices.matrices', 'MatrixBase', _print_display_png
+                'sympy.matrices.matrices', 'MatrixBase', _print_custom_png
             )
 
             for cls in [dict, int, long, float] + printable_containers:
-                png_formatter.for_type(cls, _print_png)
+                png_formatter.for_type(cls, _print_custom_png)
 
-            latex_formatter = ip.display_formatter.formatters['text/latex']
-            latex_formatter.for_type_by_name(
-                'sympy.core.basic', 'Basic', _print_latex
-            )
-            latex_formatter.for_type_by_name(
-                'sympy.matrices.matrices', 'MatrixBase', _print_latex
-            )
-            for cls in printable_containers:
-                latex_formatter.for_type(cls, _print_latex)
+            # WHO USES/NEEDS THE LATEX FORMATTER ?
+            # latex_formatter = ip.display_formatter.formatters['text/latex']
+            # latex_formatter.for_type_by_name(
+            #     'sympy.core.basic', 'Basic', _print_latex
+            # )
+            # latex_formatter.for_type_by_name(
+            #     'sympy.matrices.matrices', 'MatrixBase', _print_latex
+            # )
+            # for cls in printable_containers:
+            #     latex_formatter.for_type(cls, _print_latex)
     else:
         ip.set_hook('result_display', _result_display)
 
 
-def init_printing(pretty_print=True, order=None, use_unicode=None, use_latex=None, wrap_line=None, num_columns=None, no_global=False, ip=None):
+def init_printing(pretty_print=True, order=None, use_unicode=None,
+                  use_latex=None, wrap_line=None, num_columns=None,
+                  no_global=False, ip=None, euler=False, forecolor='Blue',
+                  backcolor='Transparent', fontsize='10pt',
+                  latex_mode='equation*'):
     """
     Initializes pretty-printer depending on the environment.
 
@@ -245,16 +278,22 @@ def init_printing(pretty_print=True, order=None, use_unicode=None, use_latex=Non
                     use_latex = True
 
     if not no_global:
-        Printer.set_global_settings(order=order, use_unicode=use_unicode, wrap_line=wrap_line, num_columns=num_columns)
+        Printer.set_global_settings(order=order, use_unicode=use_unicode,
+                                    wrap_line=wrap_line, num_columns=num_columns)
     else:
         _stringify_func = stringify_func
 
         if pretty_print:
-            stringify_func = lambda expr: _stringify_func(expr, order=order, use_unicode=use_unicode, wrap_line=wrap_line, num_columns=num_columns)
+            stringify_func = lambda expr: \
+                             _stringify_func(expr, order=order,
+                                             use_unicode=use_unicode,
+                                             wrap_line=wrap_line,
+                                             num_columns=num_columns)
         else:
             stringify_func = lambda expr: _stringify_func(expr, order=order)
 
     if ip is not None and ip.__module__.startswith('IPython'):
-        _init_ipython_printing(ip, stringify_func, use_latex)
+        _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
+                               backcolor, fontsize, latex_mode)
     else:
         _init_python_printing(stringify_func)


### PR DESCRIPTION
This PR integrates the sympyprt extension for prettyprinting sympy expressions in IPython (notebook/qtconsole) into SymPy. 

to be done
- [ ] output possible dvipng and latex errors in the notebook or qtconsole
- [ ] switch between dvipng and mathjax 'backend'
- [ ] doc
