### PR TITLE
refactoring of preview function in sympy/printing/preview.py

### DIFF
--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -25,6 +25,7 @@ from sympy.utilities import default_sort_key
 from sympy.utilities.misc import find_executable
 
 from sympy.printing.latex import accepted_latex_functions
+from sympy.printing.preview import preview
 
 
 def debug(txt):
@@ -169,7 +170,6 @@ class LatexPrinter(Printer):
                '\\newcommand{\\ddt}[1]{\\bfrac{d{#1}}{dt}}\n' \
                '\\newcommand{\\R}{\\dagger}\n' \
                '\\begin{document}\n'
-    postscript = '\\end{document}\n'
 
     @staticmethod
     def latex_bases():
@@ -1159,32 +1159,7 @@ def xdvi(filename='tmplatex.tex', debug=False):
                 line = i.next()
             except StopIteration:
                 break
-    body = LatexPrinter.preamble + body + LatexPrinter.postscript
-
-    with open(filename, 'w') as latex_file:
-        latex_file.write(body)
-
-    latex_str = None
-    xdvi_str = None
-
-    if find_executable('latex') is not None:
-        latex_str = 'latex'
-
-    if find_executable('xdvi') is not None:
-        xdvi_str = 'xdvi'
-
-    if find_executable('yap') is not None:
-        xdvi_str = 'yap'
-
-    if latex_str is not None and xdvi_str is not None:
-        if debug:  # Display latex excution output for debugging purposes
-            os.system(latex_str + ' ' + filename[:-4])
-        else:  # Works for Linux don't know about Windows
-            if sys.platform.startswith('linux'):
-                os.system(latex_str + ' ' + filename[:-4] + ' > /dev/null')
-            else:
-                os.system(latex_str + ' ' + filename[:-4] + ' > NUL')
-        os.system(xdvi_str + ' ' + filename[:-4] + ' &')
+    preview(body, output='dvi', preamble=LatexPrinter.preamble)
     LatexPrinter.LaTeX_flg = False
     return
 

--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -6,7 +6,6 @@ import sys
 #if sys.version.find('Stackless') >= 0:
 #    sys.path.append('/usr/lib/python2.5/site-packages')
 
-import os
 import types
 import StringIO
 
@@ -22,7 +21,6 @@ import numpy
 
 from sympy.core.compatibility import cmp_to_key
 from sympy.utilities import default_sort_key
-from sympy.utilities.misc import find_executable
 
 from sympy.printing.latex import accepted_latex_functions
 from sympy.printing.preview import preview
@@ -1159,7 +1157,8 @@ def xdvi(filename='tmplatex.tex', debug=False):
                 line = i.next()
             except StopIteration:
                 break
-    preview(body, output='dvi', preamble=LatexPrinter.preamble)
+    preview(body, output='dvi', ouputTexFile=filename,
+            preamble=LatexPrinter.preamble)
     LatexPrinter.LaTeX_flg = False
     return
 

--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -22,6 +22,7 @@ import numpy
 
 from sympy.core.compatibility import cmp_to_key
 from sympy.utilities import default_sort_key
+from sympy.utilities.misc import find_executable
 
 from sympy.printing.latex import accepted_latex_functions
 
@@ -29,40 +30,6 @@ from sympy.printing.latex import accepted_latex_functions
 def debug(txt):
     sys.stderr.write(txt + '\n')
     return
-
-
-def find_executable(executable, path=None):
-    """Try to find 'executable' in the directories listed in 'path' (a
-    string listing directories separated by 'os.pathsep'; defaults to
-    os.environ['PATH']).  Returns the complete filename or None if not
-    found
-    """
-    if path is None:
-        path = os.environ['PATH']
-    paths = path.split(os.pathsep)
-    extlist = ['']
-    if os.name == 'os2':
-        (base, ext) = os.path.splitext(executable)
-        # executable files on OS/2 can have an arbitrary extension, but
-        # .exe is automatically appended if no dot is present in the name
-        if not ext:
-            executable = executable + ".exe"
-    elif sys.platform == 'win32':
-        pathext = os.environ['PATHEXT'].lower().split(os.pathsep)
-        (base, ext) = os.path.splitext(executable)
-        if ext.lower() not in pathext:
-            extlist = pathext
-    for ext in extlist:
-        execname = executable + ext
-        if os.path.isfile(execname):
-            return execname
-        else:
-            for p in paths:
-                f = os.path.join(p, execname)
-                if os.path.isfile(f):
-                    return f
-    else:
-        return None
 
 
 def len_cmp(str1, str2):

--- a/sympy/galgebra/latex_ex.py
+++ b/sympy/galgebra/latex_ex.py
@@ -1157,7 +1157,7 @@ def xdvi(filename='tmplatex.tex', debug=False):
                 line = i.next()
             except StopIteration:
                 break
-    preview(body, output='dvi', ouputTexFile=filename,
+    preview(body, output='dvi', outputTexFile=filename,
             preamble=LatexPrinter.preamble)
     LatexPrinter.LaTeX_flg = False
     return

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -147,9 +147,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
                         %s
                         \vfill
                         \end{document}
-                     """ % (package_includes, "%s")
-    else:
-        formatstr = formatstr % (package_includes, "%s")
+                     """
+    formatstr = formatstr % (package_includes, "%s")
 
     if isinstance(expr, str):
         latex_string = expr

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -68,8 +68,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     to be passed to the 'outputbuffer' argument.
 
     >>> obj = StringIO() # doctest: +SKIP
-    >>> preview(x + y, output='png', viewer='StringIO', \
-                outputbuffer=obj) # doctest: +SKIP
+    >>> preview(x + y, output='png', viewer='StringIO',
+    ...         outputbuffer=obj) # doctest: +SKIP
 
     The template for the LaTeX code, which is processed by the LaTeX
     interpreter can customized with the 'formatstr' argument. This can be

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -101,10 +101,9 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     else:
         if viewer == "file":
             if filename is None:
-                SymPyDeprecationWarning("Using viewer=\"file\" without a "
-                    "specified filename will be deprecated in future versions "
-                    "of SymPy."
-                ).warn()
+                SymPyDeprecationWarning(feature="Using viewer=\"file\" without a "
+                    "specified filename ", last_supported_version="0.7.3",
+                    use_instead="viewer=\"file\" and filename=\"desiredname\"")
         elif viewer == "StringIO":
             if outputbuffer is None:
                 raise ValueError("outputbuffer has to be a StringIO "

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -9,6 +9,7 @@ import shutil
 from cStringIO import StringIO
 
 from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.misc import find_executable
 from latex import latex
 
 
@@ -104,6 +105,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         else:
             # sorted in order from most pretty to most ugly
             # very discussable, but indeed 'gv' looks awful :)
+            # TODO add candidates for windows to list
             candidates = {
                 "dvi": [ "evince", "okular", "kdvi", "xdvi" ],
                 "ps": [ "evince", "okular", "gsview", "gv" ],
@@ -112,7 +114,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
             try:
                 for candidate in candidates[output]:
-                    if pexpect.which(candidate):
+                    if find_executable(candidate):
                         viewer = candidate
                         break
                 else:
@@ -130,7 +132,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
             if outputbuffer is None:
                 raise ValueError("outputbuffer has to be a StringIO "
                                  "compatible object if viewer=\"StringIO\"")
-        elif viewer not in special and not pexpect.which(viewer):
+        elif viewer not in special and not find_executable(viewer):
             raise SystemError("Unrecognized viewer: %s" % viewer)
 
     actual_packages = packages + ("amsmath", "amsfonts")

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 
 import os
-from os.path import isabs
+from os.path import isabs, join
 import time
 from subprocess import Popen, check_call, PIPE, STDOUT
 import tempfile
@@ -196,16 +196,16 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         if viewer == "file":
             if filename is None:
                 buffer = StringIO()
-                with open(src, 'rb') as fh:
+                with open(join(workdir, src), 'rb') as fh:
                     buffer.write(fh.read())
                 return buffer
             else:
                 if not isabs(filename):
                     raise ValueError("Provided filename has to be an absolute "
                                      "path")
-                os.rename(src, filename)
+                shutil.move(join(workdir,src), filename)
         elif viewer == "StringIO":
-            with open(src, 'rb') as fh:
+            with open(join(workdir, src), 'rb') as fh:
                 outputbuffer.write(fh.read())
         elif viewer == "pyglet":
             try:
@@ -216,7 +216,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
             if output == "png":
                 from pyglet.image.codecs.png import PNGImageDecoder
-                img = image.load(src, decoder=PNGImageDecoder())
+                img = image.load(join(workdir, src), decoder=PNGImageDecoder())
             else:
                 raise SystemError("pyglet preview works only for 'png' files.")
 

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -73,15 +73,15 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
     The template for the LaTeX code, which is processed by the LaTeX
     interpreter can customized with the 'formatstr' argument. This can be
-    used, e.g., to set a differnt font size or use a diffent documentclass.
+    used, e.g., to set a differnt font size or use a differnt documentclass.
 
     >>> fmt =r"\documentclass[10pt]{extarticle}%s\begin{document}%s\end{document}"
     >>> preview(x + y, output='png', formatstr=fmt) # doctest: +SKIP
 
-    If the value of 'output' is different from 'dvi' then DVI options can be
-    set by using the 'dvioptions' argument. These options have to be in the
-    form of a list of strings (see subprocess.Popen) and they are passed to
-    the 'dvi' + output conversion tool.
+    If the value of 'output' is different from 'dvi' then command line
+    options can be set ('dvioptions' argument) for the execution of the
+    'dvi'+output conversion tool. These options have to be in the form of a
+    list of strings (see subprocess.Popen).
 
     Additional keyword args will be passed to the latex call, e.g., the
     symbol_names flag.

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -268,7 +268,6 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
         else:
             with open(os.devnull, 'wb') as devnull:
                 check_call([viewer, src], stdout=devnull, stderr=STDOUT)
-            time.sleep(2)  # wait for the viewer to read data
     finally:
         os.chdir(cwd)
         try:

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -67,8 +67,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     There is also support for writing to a StringIO like object, which needs
     to be passed to the 'outputbuffer' argument.
 
-    >>> obj = StringIO()
-    >>> preview(x + y, output='png', viewer='StringIO',
+    >>> obj = StringIO() # doctest: +SKIP
+    >>> preview(x + y, output='png', viewer='StringIO', \
                 outputbuffer=obj) # doctest: +SKIP
 
     The template for the LaTeX code, which is processed by the LaTeX

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -136,8 +136,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     actual_packages = packages + ("amsmath", "amsfonts")
     if euler:
         actual_packages += ("euler",)
-    package_includes = "\n".join(["\\usepackage{%s}" % p
-                                  for p in actual_packages])
+    package_includes = "\n" + "\n".join(["\\usepackage{%s}" % p
+                                         for p in actual_packages])
 
     if formatstr is None:
         formatstr = r"""\documentclass[12pt]{article}

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -19,7 +19,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     View expression or LaTeX markup in PNG, DVI, PostScript or PDF form.
 
     If the expr argument is an expression, it will be exported to LaTeX and
-    then compiled using available the TeX distribution.  The first argument,
+    then compiled using the available TeX distribution.  The first argument,
     'expr', may also be a LaTeX string.  The function will then run the
     appropriate viewer for the given output format or use the user defined
     one. By default png output is generated.
@@ -56,11 +56,32 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
     This will skip auto-detection and will run user specified
     'superior-dvi-viewer'. If 'view' fails to find it on your system it will
-    gracefully raise an exception. You may also enter 'file' for the viewer
-    argument. Doing so will cause this function to return a file object in
-    read-only mode.
+    gracefully raise an exception. Currently this depends on pexpect, which
+    is not available for windows.
 
-    Currently this depends on pexpect, which is not available for windows.
+    You may also enter 'file' for the viewer argument. Doing so will cause
+    this function to return a file object in read-only mode, if 'filename'
+    is unset. However, if it was set, then 'preview' writes the genereted
+    file to this filename instead.
+
+    There is also support for writing to a StringIO like object, which needs
+    to be passed to the 'outputbuffer' argument.
+
+    >>> obj = StringIO()
+    >>> preview(x + y, output='png', viewer='StringIO',
+                outputbuffer=obj) # doctest: +SKIP
+
+    The template for the LaTeX code, which is processed by the LaTeX
+    interpreter can customized with the 'formatstr' argument. This can be
+    used, e.g., to set a differnt font size or use a diffent documentclass.
+
+    >>> fmt =r"\documentclass[10pt]{extarticle}%s\begin{document}%s\end{document}"
+    >>> preview(x + y, output='png', formatstr=fmt) # doctest: +SKIP
+
+    If the value of 'output' is different from 'dvi' then DVI options can be
+    set by using the 'dvioptions' argument. These options have to be in the
+    form of a list of strings (see subprocess.Popen) and they are passed to
+    the 'dvi' + output conversion tool.
 
     Additional keyword args will be passed to the latex call, e.g., the
     symbol_names flag.

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -67,7 +67,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     There is also support for writing to a StringIO like object, which needs
     to be passed to the 'outputbuffer' argument.
 
-    >>> import StringIO
+    >>> from StringIO import StringIO
     >>> obj = StringIO()
     >>> preview(x + y, output='png', viewer='StringIO',
     ...         outputbuffer=obj) # doctest: +SKIP

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -67,7 +67,8 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     There is also support for writing to a StringIO like object, which needs
     to be passed to the 'outputbuffer' argument.
 
-    >>> obj = StringIO() # doctest: +SKIP
+    >>> import StringIO
+    >>> obj = StringIO()
     >>> preview(x + y, output='png', viewer='StringIO',
     ...         outputbuffer=obj) # doctest: +SKIP
 

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -57,8 +57,7 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
 
     This will skip auto-detection and will run user specified
     'superior-dvi-viewer'. If 'view' fails to find it on your system it will
-    gracefully raise an exception. Currently this depends on pexpect, which
-    is not available for windows.
+    gracefully raise an exception.
 
     You may also enter 'file' for the viewer argument. Doing so will cause
     this function to return a file object in read-only mode, if 'filename'
@@ -92,11 +91,6 @@ def preview(expr, output='png', viewer=None, euler=True, packages=(),
     >>> preview(phidd, symbol_names={phidd:r'\ddot{\varphi}'}) # doctest: +SKIP
 
     """
-
-    # we don't want to depend on anything not in the
-    # standard library with SymPy by default
-    import pexpect
-
     special = [ 'pyglet' ]
 
     if viewer is None:

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -1,5 +1,6 @@
 """Miscellaneous stuff that doesn't really fit anywhere else."""
 
+import os
 from textwrap import fill, dedent
 
 # if you use
@@ -113,3 +114,37 @@ def debug(*args):
         for a in args:
             print a,
         print
+
+
+def find_executable(executable, path=None):
+    """Try to find 'executable' in the directories listed in 'path' (a
+    string listing directories separated by 'os.pathsep'; defaults to
+    os.environ['PATH']).  Returns the complete filename or None if not
+    found
+    """
+    if path is None:
+        path = os.environ['PATH']
+    paths = path.split(os.pathsep)
+    extlist = ['']
+    if os.name == 'os2':
+        (base, ext) = os.path.splitext(executable)
+        # executable files on OS/2 can have an arbitrary extension, but
+        # .exe is automatically appended if no dot is present in the name
+        if not ext:
+            executable = executable + ".exe"
+    elif sys.platform == 'win32':
+        pathext = os.environ['PATHEXT'].lower().split(os.pathsep)
+        (base, ext) = os.path.splitext(executable)
+        if ext.lower() not in pathext:
+            extlist = pathext
+    for ext in extlist:
+        execname = executable + ext
+        if os.path.isfile(execname):
+            return execname
+        else:
+            for p in paths:
+                f = os.path.join(p, execname)
+                if os.path.isfile(f):
+                    return f
+    else:
+        return None


### PR DESCRIPTION
Note that this PR makes the preview function not threadsafe (generated texname is same). To make it threadsafe again do you mind if I use the `tempfile.mkdtemp()` function instead of `tempfile.gettempdir()` and use the code from this SO answer http://stackoverflow.com/a/6886556/537149

edit: 
fixed thread safety problem
