### PR TITLE
Pretty printing of Integral(x, x)**2.

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -32,7 +32,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
     with SAGE.
 
     It currently accepts as arguments:
-       - any object defined in sympy (except matrices [TODO])
+       - any object defined in sympy
        - standard numeric python types: int, long, float, Decimal
        - strings (like "0.09" or "2e-19")
        - booleans, including ``None`` (will leave them unchanged)

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -97,6 +97,7 @@ class Operator(QExpr):
     @classmethod
     def default_args(self):
         return ("O",)
+
     #-------------------------------------------------------------------------
     # Printing
     #-------------------------------------------------------------------------
@@ -163,17 +164,12 @@ class Operator(QExpr):
     def matrix_element(self, *args):
         raise NotImplementedError('matrix_elements is not defined')
 
-    #-------------------------------------------------------------------------
-    # Printing
-    #-------------------------------------------------------------------------
-
     def inverse(self):
         return self._eval_inverse()
 
     inv = inverse
 
     def _eval_inverse(self):
-        # TODO: make non-commutative Exprs print powers using A**-1, not 1/A.
         return self**(-1)
 
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1169,7 +1169,8 @@ class PrettyPrinter(Printer):
         return s
 
     def _print_Pow(self, power):
-        from sympy import fraction
+        from sympy.physics.quantum import Operator
+        from sympy.simplify.simplify import fraction
         b, e = power.as_base_exp()
         if power.is_commutative:
             if e is S.NegativeOne:
@@ -1178,9 +1179,14 @@ class PrettyPrinter(Printer):
             if n is S.One and d.is_Atom and not e.is_Integer:
                 return self._print_nth_root(b, e)
             if e.is_Rational and e < 0:
+                if not (b.is_Atom or b.is_Function or isinstance(b, Operator)):
+                    return prettyForm("1") / \
+                        prettyForm(*self._print(b).parens())**self._print(-e)
                 return prettyForm("1")/self._print(b)**self._print(-e)
 
         # None of the above special forms, do a standard power
+        if not (b.is_Atom or b.is_Function or isinstance(b, Operator)):
+            return prettyForm(*self._print(b).parens())**self._print(e)
         return self._print(b)**self._print(e)
 
     def __print_numer_denom(self, p, q):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3804,6 +3804,27 @@ def test_issue_3186():
     assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '
 
 
+def test_issue_3260():
+    assert pretty(Integral(x**2, x)**2) == \
+"""\
+          2
+/  /     \ \n\
+| |      | \n\
+| |  2   | \n\
+| | x  dx| \n\
+| |      | \n\
+\/       / \
+"""
+    assert upretty(Integral(x**2, x)**2) == \
+u"""\
+         2
+⎛⌠      ⎞ \n\
+⎜⎮  2   ⎟ \n\
+⎜⎮ x  dx⎟ \n\
+⎝⌡      ⎠ \
+"""
+
+
 def test_complicated_symbol_unchanged():
     for symb_name in ["dexpr2_d1tau", "dexpr2^d1tau"]:
         assert pretty(Symbol(symb_name)) == symb_name

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2434,11 +2434,11 @@ def ode_Liouville(eq, func, order, match):
         >>> genform = Eq(diff(f(x),x,x) + g(f(x))*diff(f(x),x)**2 +
         ... h(x)*diff(f(x),x), 0)
         >>> pprint(genform)
-                        2                    2
-                d                d          d
-        g(f(x))*--(f(x))  + h(x)*--(f(x)) + ---(f(x)) = 0
-                dx               dx           2
-                                            dx
+                          2                    2
+                /d       \         d          d
+        g(f(x))*|--(f(x))|  + h(x)*--(f(x)) + ---(f(x)) = 0
+                \dx      /         dx           2
+                                              dx
         >>> pprint(dsolve(genform, f(x), hint='Liouville_Integral'))
                                           f(x)
                   /                     /


### PR DESCRIPTION
Wrap an Integral with brackets when raised to a power. Do the same for most objects, excepts if it is an atom (doesn't need brackets) or a function (which handle printing powers differently already).

Fixes issue 3260.
http://code.google.com/p/sympy/issues/detail?id=3260
