### PR TITLE
Piecewise._eval_interval for cond. indep. of integration var.

### DIFF
--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -235,6 +235,12 @@ def test_piecewise_integrate_symbolic_conditions():
     assert integrate(p5, (x, -oo, y)) == 0.5*y + 0.5*Min(b, y) - Min(a, b, y)
 
 
+def test_piecewise_integrate_independent_conditions():
+    p = Piecewise((0, Eq(y, 0)), (x*y, True))
+    assert integrate(p, (x, 1, 3)) == \
+        Piecewise((0, Eq(y, 0)), (4*y, True))
+
+
 def test_piecewise_solve():
     abs2 = Piecewise((-x, x <= 0), (x, x > 0))
     f = abs2.subs(x, x - 2)


### PR DESCRIPTION
This fixes the definite Integral of a Piecewise when the conditions are independent of the integration variable.

Before:

> > > integrate(Piecewise((0, Eq(y, 0)), (x_y/sqrt(y__2), True)), (x, 1, 3))
> > > 4_y/sqrt(y**2)

After:

> > > integrate(Piecewise((0, Eq(y, 0)), (x_y/sqrt(y__2), True)), (x, 1, 3))
> > > Piecewise((0, y == 0), (4_y/sqrt(y**2), True))

Fixes issue 3648
http://code.google.com/p/sympy/issues/detail?id=3648
