### PR TITLE
Remove Singleton metaclass from NumberSymbol

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2400,7 +2400,6 @@ zoo = S.ComplexInfinity
 
 
 class NumberSymbol(AtomicExpr):
-    __metaclass__ = Singleton
 
     is_commutative = True
     is_bounded = True

--- a/sympy/physics/quantum/constants.py
+++ b/sympy/physics/quantum/constants.py
@@ -1,6 +1,7 @@
 """Constants (like hbar) related to quantum mechanics."""
 
 from sympy.core.numbers import NumberSymbol
+from sympy.core.singleton import Singleton
 from sympy.printing.pretty.stringpict import prettyForm
 import sympy.mpmath.libmp as mlib
 
@@ -34,6 +35,7 @@ class HBar(NumberSymbol):
     is_negative = False
     is_irrational = True
 
+    __metaclass__ = Singleton
     __slots__ = []
 
     def _as_mpf_val(self, prec):


### PR DESCRIPTION
Subclasses of NumberSymbol should manually set Singleton as their metaclass if 
they want to be singletonized.

See issue 3643.
