### PR TITLE
Fixing squareroot display issue (#3640)

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1178,7 +1178,7 @@ class PrettyPrinter(Printer):
             if n is S.One and d.is_Atom and not e.is_Integer:
                 return self._print_nth_root(b, e)
             if e.is_Rational and e < 0:
-                return prettyForm("1")/self._print(b)**self._print(-e)
+                return prettyForm("1")/self._print(C.Pow(b, -e, evaluate=0))
 
         # None of the above special forms, do a standard power
         return self._print(b)**self._print(e)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3804,6 +3804,25 @@ def test_issue_3186():
     assert pretty(Pow(x, (1/pi))) == 'pi___\n\\/ x '
 
 
+def test_issue_3640():
+    ascii_str = \
+"""\
+  1  \n\
+-----\n\
+  ___\n\
+\/ x \
+"""
+    ucode_str = \
+u"""\
+  1  \n\
+─────\n\
+  ___\n\
+╲╱ x \
+"""
+    assert pretty(1/sqrt(x)) == ascii_str
+    assert upretty(1/sqrt(x)) == ucode_str
+
+
 def test_complicated_symbol_unchanged():
     for symb_name in ["dexpr2_d1tau", "dexpr2^d1tau"]:
         assert pretty(Symbol(symb_name)) == symb_name


### PR DESCRIPTION
Done as a project for an "Open Source Comes to Campus @ Harvard" -- http://harvard.openhatch.org/

Fixing the "bite-size bug" listed here: https://etherpad.mozilla.org/harvard as a link to this issue: http://code.google.com/p/sympy/issues/detail?id=3640
