### PR TITLE
Fixed 'maximum recursion depth reached' issue for addition of Order term to another expression containing an order term.

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -938,15 +938,15 @@ class Pow(Expr):
             if bs.is_Add:
                 from sympy import O
                 # So, bs + O() == terms
-                _c = Symbol('_c')
+                c = Dummy('c')
                 res = []
                 for arg in bs.args:
                     if arg.is_Order:
                         arg = arg.expr()
-                        arg = _c*arg
+                        arg = c*arg
                     res.append(arg)
                 bs = Add(*res)
-                rv = (bs**e).series(x).subs(_c, O(1))
+                rv = (bs**e).series(x).subs(c, O(1))
                 rv += order
                 return rv
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -935,6 +935,21 @@ class Pow(Expr):
                 return ((Pow(lt, e) * Pow((bs/lt).expand(), e).nseries(
                     x, n=nuse, logx=logx)).expand() + order)
 
+            if bs.is_Add:
+                from sympy import O
+                # So, bs + O() == terms
+                _c = Symbol('_c')
+                res = []
+                for arg in bs.args:
+                    if arg.is_Order:
+                        arg = arg.expr()
+                        arg = _c*arg
+                    res.append(arg)
+                bs = Add(*res)
+                rv = (bs**e).series(x).subs(_c, O(1)).getO()
+                rv += order
+                return rv
+
             rv = bs**e
             if terms != bs:
                 rv += order

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -946,7 +946,7 @@ class Pow(Expr):
                         arg = _c*arg
                     res.append(arg)
                 bs = Add(*res)
-                rv = (bs**e).series(x).subs(_c, O(1)).getO()
+                rv = (bs**e).series(x).subs(_c, O(1))
                 rv += order
                 return rv
 

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -517,7 +517,7 @@ def calculate_series(e, x, skip_abs=False, logx=None):
 
     This is a place that fails most often, so it is in its own function.
     """
-    n = 6
+    n = 1
     while 1:
         series = e.nseries(x, n=n, logx=logx)
         if not series.has(O):

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -517,7 +517,7 @@ def calculate_series(e, x, skip_abs=False, logx=None):
 
     This is a place that fails most often, so it is in its own function.
     """
-    n = 1
+    n = 6
     while 1:
         series = e.nseries(x, n=n, logx=logx)
         if not series.has(O):

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -2,7 +2,7 @@ from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
     Function, log, sqrt, Symbol
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
-from sympy.series.gruntz import calcluate_series
+from sympy.series.gruntz import calculate_series
 
 
 def test_sin():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -2,6 +2,7 @@ from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
     Function, log, sqrt, Symbol
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
+from sympy.series.gruntz import calcluate_series
 
 
 def test_sin():
@@ -106,3 +107,7 @@ def test_issue_3219():
 def test_x_is_base_detection():
     eq = (x**2)**(S(2)/3)
     assert eq.series() == eq
+
+def test_sin_power():
+    e = sin(x)**1.2
+    assert e.series(x, n=6).removeO() = calculate_series(e, x)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -110,4 +110,4 @@ def test_x_is_base_detection():
 
 def test_sin_power():
     e = sin(x)**1.2
-    assert e.series(x, n=8).removeO() == calculate_series(e, x)
+    assert calculate_series(e, x) == x**1.2

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -110,4 +110,4 @@ def test_x_is_base_detection():
 
 def test_sin_power():
     e = sin(x)**1.2
-    assert e.series(x, n=6).removeO() = calculate_series(e, x)
+    assert e.series(x, n=8).removeO() == calculate_series(e, x)


### PR DESCRIPTION
See [issue 3627](http://code.google.com/p/sympy/issues/detail?id=3627) for details. I have mentioned the problem completely there in a comment.

Before,

```
>>> O(x**6) + sin(x)**1.2
RuntimeError

```

Now, 

```
>>> O(x**6) + sin(x)**1.2
sin(x)**1.2 + O(x**6)
```

I have also added a test that specifically tests the reason of the problem (see the comment on the issue page please). If someone has _any_ problems understanding the fix, or the test, feel free to ask.
