### PR TITLE
Update sympy/polys/polytools.py

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3953,6 +3953,27 @@ def degree(f, *gens, **args):
     1
 
     """
+    if len(gens) is 0:
+        gens_present = False
+    else:
+        gens_present = True
+
+    polynomial=False
+
+    try:
+        polynomial = f.is_polynomial()
+    except:
+        pass
+
+    if f is polynomial:
+        if len(f.free_symbols) is 1: 
+            sym = f.free_symbols.pop()
+            if gens_present:
+                if sym is gens[0]:
+                    return -f.subs(sym, 1/sym).leadterm(sym)[1]
+            else:
+                return -f.subs(sym, 1/sym).leadterm(sym)[1]
+
     options.allowed_flags(args, ['gen', 'polys'])
 
     try:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3958,12 +3958,7 @@ def degree(f, *gens, **args):
     else:
         gens_present = True
 
-    polynomial=False
-
-    try:
-        polynomial = f.is_polynomial()
-    except:
-        pass
+    polynomial = isinstance(f, Expr) and f.is_polynomial()
 
     if f is polynomial:
         if len(f.free_symbols) is 1: 


### PR DESCRIPTION
TODO fix whitespace error

 It was giving an error when an integer was passed as an argument to the function, I didn't check for that and also didn't run the test code. I manually checked for some cases and it was working. From this time I'll make sure to run all test codes locally before committing.  

https://code.google.com/p/sympy/issues/detail?id=3223

sympy.polys.polytools.degree(f, _gens, *_args) rewritten in the way described in the thread.
