### PR TITLE
Incorrect Exception in dsolve() : First implementation

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -529,7 +529,12 @@ def dsolve(eq, func=None, hint="default", simplify=True, prep=True, **kwargs):
 
     if not hints['default']:
         # classify_ode will set hints['default'] to None if no hints match.
-        raise NotImplementedError("dsolve: Cannot solve " + str(eq))
+        if hint not in allhints and hint != 'default':
+            raise ValueError("Hint not recognized: " + hint)
+        elif hint not in hints['ordered_hints'] and hint != 'default':
+            raise ValueError("ODE " + str(eq) + " does not match hint " + hint)
+        else:
+            raise NotImplementedError("dsolve: Cannot solve " + str(eq))
 
     if hint == 'default':
         return dsolve(eq, func, hint=hints['default'], simplify=simplify,

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1430,5 +1430,5 @@ def test_nth_order_linear_euler_eq_homogeneous():
 
 def test_issue_1996():
     f = Function('f')
-    raises(ValueError, lambda: dsolve(f(x).diff(x)**2 , f(x) , 'seperable'))
+    raises(ValueError, lambda: dsolve(f(x).diff(x)**2, f(x), 'seperable'))
     raises(ValueError, lambda: dsolve(f(x).diff(x)**2, f(x), 'fdsjf'))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1427,3 +1427,8 @@ def test_nth_order_linear_euler_eq_homogeneous():
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, y(t), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+def test_issue_1996():
+    f = Function('f')
+    raises(ValueError, lambda: dsolve(f(x).diff(x)**2 , f(x) , 'seperable'))
+    raises(ValueError, lambda: dsolve(f(x).diff(x)**2, f(x), 'fdsjf'))


### PR DESCRIPTION
This pull request is related to the issue http://code.google.com/p/sympy/issues/detail?id=1996

As mentioned in the above link , dsolve() returns wrong exceptions when it is not solvable , and the hint is either invalid or incorrect. I've changed it so that it raises the correct Exceptions.

```
from sympy import *
from sympy.abc import x
f = Function('f')
dsolve(f(x).diff(x)**2, f(x), 'separable')  #This now gives the correct ValueError
>>>  ValueError: ODE Derivative(f(x), x)**2 does not match hint separable
```

Also , as mentioned in the link , as needed

```
dsolve(f(x).diff(x)**2, f(x), 'fdsjf')  #This should give ValueError for incorrect hint
>>>  ValueError: Hint not recognized: fdsjf
```

Do look at the code for changes required.
