### PR TITLE
Travis: install gmp before installing gmpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: TEST_GMPY="true"
 before_install:
   - if [[ "${TEST_GMPY}" == "true" ]]; then
+      sudo apt-get update -qq;
+      sudo apt-get install -qq libgmp-dev;
       pip install "gmpy==1.16";
     fi
 install:


### PR DESCRIPTION
This should fix the failures in gmpy tests at Travis.
