### PR TITLE
Extended the named groups module to include information about nilpotency and solvability

### DIFF
--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -215,7 +215,7 @@ def DihedralGroup(n):
     else:
         G._is_nilpotent = False
     G._is_abelian = False
-    G._is_soluble = True
+    G._is_solvable = True
     G._degree = n
     G._is_transitive = True
     G._order = 2*n

--- a/sympy/combinatorics/named_groups.py
+++ b/sympy/combinatorics/named_groups.py
@@ -103,8 +103,14 @@ def AlternatingGroup(n):
 
     if n < 4:
         G._is_abelian = True
+        G._is_nilpotent = True
     else:
         G._is_abelian = False
+        G._is_nilpotent = False
+    if n < 5:
+        G._is_solvable = True
+    else:
+        G._is_solvable = False
     G._degree = n
     G._is_transitive = True
     G._is_alt = True
@@ -144,6 +150,8 @@ def CyclicGroup(n):
     G = PermutationGroup([gen])
 
     G._is_abelian = True
+    G._is_nilpotent = True
+    G._is_solvable = True
     G._degree = n
     G._is_transitive = True
     G._order = n
@@ -201,8 +209,13 @@ def DihedralGroup(n):
     a.reverse()
     gen2 = _af_new(a)
     G = PermutationGroup([gen1, gen2])
-
+    # if n is a power of 2, group is nilpotent
+    if n & (n-1) == 0:
+        G._is_nilpotent = True
+    else:
+        G._is_nilpotent = False
     G._is_abelian = False
+    G._is_soluble = True
     G._degree = n
     G._is_transitive = True
     G._order = 2*n
@@ -257,11 +270,16 @@ def SymmetricGroup(n):
         a[0], a[1] = a[1], a[0]
         gen2 = _af_new(a)
         G = PermutationGroup([gen1, gen2])
-
     if n < 3:
         G._is_abelian = True
+        G._is_nilpotent = True
     else:
         G._is_abelian = False
+        G._is_nilpotent = False
+    if n < 5:
+        G._is_solvable = True
+    else:
+        G._is_solvable = False
     G._degree = n
     G._is_transitive = True
     G._is_sym = True

--- a/sympy/combinatorics/tests/test_named_groups.py
+++ b/sympy/combinatorics/tests/test_named_groups.py
@@ -9,6 +9,7 @@ def test_SymmetricGroup():
     assert len(elements) == 120
     assert G.is_solvable is False
     assert G.is_abelian is False
+    assert G.is_nilpotent is False
     assert G.is_transitive() is True
     H = SymmetricGroup(1)
     assert H.order() == 1
@@ -22,6 +23,8 @@ def test_CyclicGroup():
     assert len(elements) == 10
     assert (G.derived_subgroup()).order() == 1
     assert G.is_abelian is True
+    assert G.is_solvable is True
+    assert G.is_nilpotent is True
     H = CyclicGroup(1)
     assert H.order() == 1
     L = CyclicGroup(2)
@@ -34,11 +37,14 @@ def test_DihedralGroup():
     assert len(elements) == 12
     assert G.is_transitive() is True
     assert G.is_abelian is False
+    assert G.is_solvable is True
+    assert G.is_nilpotent is False
     H = DihedralGroup(1)
     assert H.order() == 2
     L = DihedralGroup(2)
     assert L.order() == 4
     assert L.is_abelian is True
+    assert L.is_nilpotent is True
 
 
 def test_AlternatingGroup():


### PR DESCRIPTION
I added to the named_groups module, so that the named groups include information about their solvability and nilpotency.
