### PR TITLE
Bugfix in sympy.stats - add support for random parameters

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -560,11 +560,9 @@ def test_sympy__stats__rv__PSpace():
     assert _test_args(PSpace(D, die))
 
 
+@SKIP("abstract Class")
 def test_sympy__stats__rv__SinglePSpace():
-    from sympy.stats.rv import SinglePSpace, RandomDomain
-    from sympy import Dict, FiniteSet
-    D = RandomDomain(FiniteSet(x), FiniteSet(1, 2, 3, 4, 5, 6))
-    assert _test_args(SinglePSpace(D, die))
+    pass
 
 
 def test_sympy__stats__rv__RandomSymbol():

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2244,7 +2244,8 @@ def _polarify(eq, lift, pause=False):
             limits.append((var,) + rest)
         return Integral(*((func,) + tuple(limits)))
     else:
-        return eq.func(*[_polarify(arg, lift, pause=pause) for arg in eq.args])
+        return eq.func(*[_polarify(arg, lift, pause=pause)
+                         if isinstance(arg, Expr) else arg for arg in eq.args])
 
 
 def polarify(eq, subs=True, lift=False):

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -52,7 +52,7 @@ from collections import defaultdict
 
 def _ispow(e):
     """Return True if e is a Pow or is exp."""
-    return e.is_Pow or e.func is exp
+    return isinstance(e, Expr) and (e.is_Pow or e.func is exp)
 
 
 def denoms(eq, symbols=None):

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -7,7 +7,7 @@ from sympy.abc import a, b, c, d, k, h, p, x, y, z, t
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs
-from sympy.solvers.solvers import _invert, unrad, checksol, posify
+from sympy.solvers.solvers import _invert, unrad, checksol, posify, _ispow
 
 from sympy.utilities.pytest import XFAIL, raises, skip
 
@@ -1093,3 +1093,8 @@ def test_issue_3506():
     assert solve(5**(x/2) - 2**(x/3)) == [0]
     b = sqrt(6)*sqrt(log(2))/sqrt(log(5))
     assert solve(5**(x/2) - 2**(3/x)) == [-b, b]
+
+def test__ispow():
+    assert _ispow(x**2)
+    assert not _ispow(x)
+    assert not _ispow(True)

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -14,7 +14,7 @@ from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain,
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy import (S, Interval, symbols, sympify, Dummy, FiniteSet, Mul, Tuple,
         Integral, And, Or, Piecewise, solve, cacheit, integrate, oo, Lambda,
-        Basic)
+        Basic, Symbol)
 from sympy.solvers.inequalities import reduce_poly_inequalities
 from sympy.polys.polyerrors import PolynomialError
 import random
@@ -267,8 +267,10 @@ class ContinuousPSpace(PSpace):
         # Common case Density(X) where X in self.values
         if expr in self.values:
             # Marginalize all other random symbols out of the density
-            pdf = self.domain.integrate(self.pdf , set(rs.symbol
-                for rs in self.values - frozenset((expr,))), **kwargs)
+            randomsymbols = tuple(set(self.values) - frozenset([expr]))
+            symbols = tuple(rs.symbol for rs in randomsymbols)
+            pdf = self.pdf.subs(dict(zip(randomsymbols, symbols)))
+            pdf = self.domain.integrate(pdf, symbols, **kwargs)
             return Lambda(expr.symbol, pdf)
 
         z = Dummy('z', real=True, bounded=True)

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -389,7 +389,11 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         try:
             return self.distribution.expectation(expr, x, **kwargs)
         except:
-            return integrate(expr * self.pdf, (x, self.set), **kwargs)
+            evaluate = kwargs.pop('evaluate', True)
+            if evaluate:
+                return integrate(expr * self.pdf, (x, self.set), **kwargs)
+            else:
+                return Integral(expr * self.pdf, (x, self.set), **kwargs)
 
     def compute_cdf(self, expr, **kwargs):
         if expr == self.value:

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -407,7 +407,7 @@ class ProductContinuousPSpace(ProductPSpace, ContinuousPSpace):
     @property
     def pdf(self):
         p = Mul(*[space.pdf for space in self.spaces])
-        return p.subs({rv: rv.symbol for rv in self.values})
+        return p.subs(dict((rv, rv.symbol) for rv in self.values))
 
 def _reduce_inequalities(conditions, var, **kwargs):
     try:

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -269,8 +269,7 @@ class ContinuousPSpace(PSpace):
             # Marginalize all other random symbols out of the density
             randomsymbols = tuple(set(self.values) - frozenset([expr]))
             symbols = tuple(rs.symbol for rs in randomsymbols)
-            pdf = self.pdf.subs(dict(zip(randomsymbols, symbols)))
-            pdf = self.domain.integrate(pdf, symbols, **kwargs)
+            pdf = self.domain.integrate(self.pdf, symbols, **kwargs)
             return Lambda(expr.symbol, pdf)
 
         z = Dummy('z', real=True, bounded=True)
@@ -407,7 +406,8 @@ class ProductContinuousPSpace(ProductPSpace, ContinuousPSpace):
     """
     @property
     def pdf(self):
-        return Mul(*[space.pdf for space in self.spaces])
+        p = Mul(*[space.pdf for space in self.spaces])
+        return p.subs({rv: rv.symbol for rv in self.values})
 
 def _reduce_inequalities(conditions, var, **kwargs):
     try:

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -18,6 +18,9 @@ from sympy.core.compatibility import product
 from sympy.core.containers import Dict
 import random
 
+class FiniteDensity(dict):
+    def __call__(self, item):
+        return self[sympify(item)]
 
 class FiniteDomain(RandomDomain):
     """
@@ -210,7 +213,7 @@ class FinitePSpace(PSpace):
 
     def compute_density(self, expr):
         expr = expr.xreplace(dict(((rs, rs.symbol) for rs in self.values)))
-        d = {}
+        d = FiniteDensity()
         for elem in self.domain:
             val = expr.xreplace(dict(elem))
             prob = self.prob_of(elem)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -212,6 +212,7 @@ class RandomSymbol(Expr):
     is_bounded = True
     is_finite = True
     is_Symbol = True
+    is_Atom = True
 
     _diff_wrt = True
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -165,6 +165,11 @@ class SinglePSpace(PSpace):
     Represents the probabilities of a set of random events that can be
     attributed to a single variable/symbol.
     """
+    def __new__(cls, symbol, distribution):
+        symbol = sympify(symbol)
+        if not isinstance(symbol, Symbol):
+            raise ValueError()
+        return Basic.__new__(cls, symbol, distribution)
 
     @property
     def value(self):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -12,8 +12,10 @@ sympy.stats.frv
 sympy.stats.rv_interface
 """
 
-from sympy import Basic, S, Expr, Symbol, Tuple, And, Add, Eq, lambdify
+from sympy import (Basic, S, Expr, Symbol, Tuple, And, Add, Eq, lambdify,
+        sympify, Equality, solve, Lambda, DiracDelta)
 from sympy.core.sets import FiniteSet, ProductSet
+from sympy.abc import x
 
 
 class RandomDomain(Basic):
@@ -565,6 +567,8 @@ class Density(Basic):
         if condition is not None:
             # Recompute on new conditional expr
             expr = given(expr, condition, **kwargs)
+        if not random_symbols(expr):
+            return Lambda(x, DiracDelta(x-expr))
         return pspace(expr).compute_density(expr, **kwargs)
 
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -450,6 +450,13 @@ def given(expr, condition=None, **kwargs):
     if not random_symbols(condition) or pspace_independent(expr, condition):
         return expr
 
+    condsymbols = random_symbols(condition)
+    if (isinstance(condition, Equality) and len(condsymbols) == 1 and
+        not isinstance(pspace(expr).domain, ConditionalDomain)):
+        rv = tuple(condsymbols)[0]
+        results = solve(condition, rv)
+        return sum(expr.subs(rv, res) for res in results)
+
     # Get full probability space of both the expression and the condition
     fullspace = pspace(Tuple(expr, condition))
     # Build new space given the condition

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -202,9 +202,16 @@ class RandomSymbol(Expr):
     convenience functions Normal, Exponential, Coin, Die, FiniteRV, etc....
     """
 
+    def __new__(cls, pspace, symbol):
+        assert isinstance(symbol, Symbol)
+        assert isinstance(pspace, PSpace)
+        return Basic.__new__(cls, pspace, symbol)
+
     is_bounded = True
     is_finite = True
     is_Symbol = True
+
+    _diff_wrt = True
 
     pspace = property(lambda self: self.args[0])
     symbol = property(lambda self: self.args[1])

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -21,8 +21,7 @@ from sympy.utilities.pytest import raises, XFAIL, slow
 
 oo = S.Infinity
 
-z = Symbol("z")
-x = Symbol('x')
+x, y, z = map(Symbol, 'xyz')
 
 
 def test_single_normal():
@@ -590,3 +589,8 @@ def test_random_parameters_given():
     meas = Normal('T', mu, 1)
     assert given(meas, Eq(mu, 5)) == Normal('T', 5, 1)
 
+def test_conjugate_priors():
+    mu = Normal('mu', 2, 3)
+    x = Normal('x', mu, 1)
+    assert isinstance(simplify(density(mu, Eq(x, y), evaluate=False)(z)),
+            Integral)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -571,3 +571,10 @@ def test_NormalDistribution():
     assert nd.expectation(1, x) == 1
     assert nd.expectation(x, x) == 0
     assert nd.expectation(x**2, x) == 1
+
+def test_random_parameters():
+    mu = Normal('mu', 2, 3)
+    meas = Normal('T', mu, 1)
+    assert density(meas, evaluate=False)(z)
+    #assert density(meas, evaluate=False)(z) == Integral(mu.pspace.pdf *
+    #        meas.pspace.pdf, (mu.symbol, -oo, oo)).subs(meas.symbol, z)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -563,6 +563,12 @@ def test_probability_unevaluated():
     T = Normal('T', 30, 3)
     assert type(P(T > 33, evaluate=False)) == Integral
 
+def test_density_unevaluated():
+    X = Normal('X', 0, 1)
+    Y = Normal('Y', 0, 2)
+    assert isinstance(density(X+Y, evaluate=False)(z), Integral)
+
+
 def test_NormalDistribution():
     nd = NormalDistribution(0, 1)
     x = Symbol('x')

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -584,3 +584,9 @@ def test_random_parameters():
     assert density(meas, evaluate=False)(z)
     #assert density(meas, evaluate=False)(z) == Integral(mu.pspace.pdf *
     #        meas.pspace.pdf, (mu.symbol, -oo, oo)).subs(meas.symbol, z)
+
+def test_random_parameters_given():
+    mu = Normal('mu', 2, 3)
+    meas = Normal('T', mu, 1)
+    assert given(meas, Eq(mu, 5)) == Normal('T', 5, 1)
+

--- a/sympy/stats/tests/test_finite_rv.py
+++ b/sympy/stats/tests/test_finite_rv.py
@@ -5,6 +5,7 @@ from sympy.stats import (DiscreteUniform, Die, Bernoulli, Coin, Binomial,
         Hypergeometric, P, E, variance, covariance, skewness, sample, density,
         given, independent, dependent, where, FiniteRV, pspace, cdf)
 from sympy.utilities.pytest import raises, slow
+from sympy.abc import p
 
 oo = S.Infinity
 
@@ -216,3 +217,8 @@ def test_FiniteRV():
 
     assert pspace(F).domain.as_boolean() == Or(
         *[Eq(F.symbol, i) for i in [1, 2, 3]])
+
+def test_density_call():
+    x = Bernoulli('x', p)
+    d = density(x)
+    assert d(0) == 1 - p

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -71,7 +71,7 @@ def test_RandomSymbol():
     assert X.name == X.symbol.name
 
 
-def test_RandomSymbol_diff()
+def test_RandomSymbol_diff():
     X = Normal('x', 0, 1)
     assert (2*X).diff(X)
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -70,6 +70,11 @@ def test_RandomSymbol():
     assert X.name == X.symbol.name
 
 
+def test_RandomSymbol_diff()
+    X = Normal('x', 0, 1)
+    assert (2*X).diff(X)
+
+
 def test_overlap():
     X = Normal('x', 0, 1)
     Y = Normal('x', 0, 2)

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -1,5 +1,6 @@
 from sympy import (EmptySet, FiniteSet, S, Symbol, Interval, exp, erf, sqrt,
-        symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic)
+        symbols, simplify, Eq, cos, And, Tuple, integrate, oo, sin, Sum, Basic,
+        DiracDelta)
 from sympy.stats import (Die, Normal, Exponential, P, E, variance, covariance,
         skewness, density, given, independent, dependent, where, pspace,
         random_symbols, sample)
@@ -177,3 +178,7 @@ def test_NamedArgsMixin():
         pass
 
     raises(AttributeError, lambda: Bar(1, 2).foo)
+
+def test_density_constant():
+    assert density(3)(2) == 0
+    assert density(3)(3) == DiracDelta(0)


### PR DESCRIPTION
This PR supports random expressions with random parameters e.g.

``` Python
mu = Normal('mu', 0, 1)
x = Normal('x', mu, 3)
```

This allows for good statistical questions dealing with priors given data

```
density(mu, Eq(x, data))
```

Doing this exposed some issues with the core (or with the design of stats depending on your perspective).  

SymPy.stats.RandomSymbol is an Expr with args that are not themselves Exprs.  Much of the core assumes `all(isinstance(arg, Expr) for arg in expr)`. 
