### PR TITLE
3545: try unrad sooner

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2360,7 +2360,8 @@ def _invert(eq, *symbols, **kwargs):
 
         # if it's a two-term Add with rhs = 0 and two powers we can get the
         # dependent terms together, e.g. 3*f(x) + 2*g(x) -> f(x)/g(x) = -2/3
-        if lhs.is_Add and not rhs and len(lhs.args) == 2:
+        if lhs.is_Add and not rhs and len(lhs.args) == 2 and \
+                not lhs.is_polynomial(*symbols):
             a, b = lhs.as_two_terms()
             ai, ad = a.as_independent(*symbols)
             bi, bd = b.as_independent(*symbols)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1117,151 +1117,199 @@ def _solve(f, *symbols, **flags):
         # a polynomial and tell us the different generators that it
         # contains, so we will inspect the generators identified by
         # polys to figure out what to do.
-        poly = Poly(f_num)
-        if poly is None:
-            raise ValueError('could not convert %s to Poly' % f_num)
-        gens = [g for g in poly.gens if g.has(symbol)]
 
-        if len(gens) > 1:
-            # If there is more than one generator, it could be that the
-            # generators have the same base but different powers, e.g.
-            #   >>> Poly(exp(x)+1/exp(x))
-            #   Poly(exp(-x) + exp(x), exp(-x), exp(x), domain='ZZ')
-            #   >>> Poly(sqrt(x)+sqrt(sqrt(x)))
-            #   Poly(sqrt(x) + x**(1/4), sqrt(x), x**(1/4), domain='ZZ')
-            # If the exponents are Rational then a change of variables
-            # will make this a polynomial equation in a single base.
+        # but first remove radicals as this will help Polys
+        if flags.pop('unrad', True):
+            try:
+                # try remove all...
+                u = unrad(f_num)
+            except ValueError:
+                # ...else hope for the best while letting some remain
+                try:
+                    u = unrad(eq, symbol)
+                except ValueError:
+                    pass  # hope for best with original equation
+            if u:
+                flags['unrad'] = False  # don't unrad next time
+                eq, cov, dens2 = u
+                dens.update(dens2)
+                if cov:
+                    if len(cov) > 1:
+                        raise NotImplementedError('Not sure how to handle this.')
+                    isym, ieq = cov[0]
+                    # since cov is written in terms of positive symbols, set
+                    # check to False or else 0 would be excluded; the solution
+                    # will be checked below
+                    absent = Dummy()
+                    check = flags.get('check', absent)
+                    flags['check'] = False
+                    sol = _solve(eq, isym, **flags)
+                    inv = _solve(ieq, symbol, **flags)
+                    result = []
+                    for s in sol:
+                        for i in inv:
+                            result.append(i.subs(isym, s))
+                    if check == absent:
+                        flags.pop('check')
+                    else:
+                        flags['check'] = check
+                else:
+                    result = _solve(eq, symbol, **flags)
 
-            def _as_base_q(x):
-                """Return (b**e, q) for x = b**(p*e/q) where p/q is the leading
-                Rational of the exponent of x, e.g. exp(-2*x/3) -> (exp(x), 3)
-                """
-                b, e = x.as_base_exp()
-                if e.is_Rational:
-                    return b, e.q
-                if not e.is_Mul:
+        if result is False:
+            poly = Poly(f_num)
+            if poly is None:
+                raise ValueError('could not convert %s to Poly' % f_num)
+            gens = [g for g in poly.gens if g.has(symbol)]
+
+            if len(gens) > 1:
+                # If there is more than one generator, it could be that the
+                # generators have the same base but different powers, e.g.
+                #   >>> Poly(exp(x)+1/exp(x))
+                #   Poly(exp(-x) + exp(x), exp(-x), exp(x), domain='ZZ')
+                #   >>> Poly(sqrt(x)+sqrt(sqrt(x)))
+                #   Poly(sqrt(x) + x**(1/4), sqrt(x), x**(1/4), domain='ZZ')
+                # If the exponents are Rational then a change of variables
+                # will make this a polynomial equation in a single base.
+
+                def _as_base_q(x):
+                    """Return (b**e, q) for x = b**(p*e/q) where p/q is the leading
+                    Rational of the exponent of x, e.g. exp(-2*x/3) -> (exp(x), 3)
+                    """
+                    b, e = x.as_base_exp()
+                    if e.is_Rational:
+                        return b, e.q
+                    if not e.is_Mul:
+                        return x, 1
+                    c, ee = e.as_coeff_Mul()
+                    if c.is_Rational and c is not S.One:  # c could be a Float
+                        return b**ee, c.q
                     return x, 1
-                c, ee = e.as_coeff_Mul()
-                if c.is_Rational and c is not S.One:  # c could be a Float
-                    return b**ee, c.q
-                return x, 1
 
-            bases, qs = zip(*[_as_base_q(g) for g in gens])
-            bases = set(bases)
+                bases, qs = zip(*[_as_base_q(g) for g in gens])
+                bases = set(bases)
 
-            if len(bases) > 1:
-                funcs = set(b.func for b in bases if b.is_Function)
+                if len(bases) > 1:
+                    funcs = set(b.func for b in bases if b.is_Function)
 
-                trig = set([cos, sin, tan, cot])
-                other = funcs - trig
-                if not other and len(funcs.intersection(trig)) > 1:
-                    return _solve(f_num.rewrite(tan), symbol, **flags)
+                    trig = set([cos, sin, tan, cot])
+                    other = funcs - trig
+                    if not other and len(funcs.intersection(trig)) > 1:
+                        return _solve(f_num.rewrite(tan), symbol, **flags)
 
-                trigh = set([cosh, sinh, tanh, coth])
-                other = funcs - trigh
-                if not other and len(funcs.intersection(trigh)) > 1:
-                    return _solve(f_num.rewrite(tanh), symbol, **flags)
+                    trigh = set([cosh, sinh, tanh, coth])
+                    other = funcs - trigh
+                    if not other and len(funcs.intersection(trigh)) > 1:
+                        return _solve(f_num.rewrite(tanh), symbol, **flags)
 
-                # just a simple case - see if replacement of single function
-                # clears all symbol-dependent functions, e.g.
-                # log(x) - log(log(x) - 1) - 3 can be solved even though it has
-                # two generators.
+                    # just a simple case - see if replacement of single function
+                    # clears all symbol-dependent functions, e.g.
+                    # log(x) - log(log(x) - 1) - 3 can be solved even though it has
+                    # two generators.
 
-                funcs = [f for f in bases if f.is_Function]
-                if funcs:
-                    funcs.sort(key=count_ops)  # put shallowest function first
-                    f1 = funcs[0]
+                    funcs = [f for f in bases if f.is_Function]
+                    if funcs:
+                        funcs.sort(key=count_ops)  # put shallowest function first
+                        f1 = funcs[0]
+                        t = Dummy()
+                        # perform the substitution
+                        ftry = f_num.subs(f1, t)
+
+                        # if no Functions left, we can proceed with usual solve
+                        if not ftry.has(symbol):
+                            cv_sols = _solve(ftry, t)
+                            cv_inv = _solve(t - f1, symbol)[0]
+                            sols = list()
+                            for sol in cv_sols:
+                                sols.append(cv_inv.subs(t, sol))
+                            return sols
+
+                    msg = 'multiple generators %s' % gens
+
+                elif any(q != 1 for q in qs):
+                    # e.g. for x**(1/2) + x**(1/4) a change of variables
+                    # can be made using p**4 to give p**2 + p
+                    base = bases.pop()
+                    m = reduce(ilcm, qs)
+                    p = Dummy('p', positive=True)
+                    cov = p**m
+                    fnew = f_num.subs(base, cov)
+                    poly = Poly(fnew, p)  # we now have a single generator, p
+
+                    # for cubics and quartics, if the flag wasn't set, DON'T do it
+                    # by default since the results are quite long. Perhaps one
+                    # could base this decision on a certain critical length of the
+                    # roots.
+                    if poly.degree() > 2:
+                        flags['simplify'] = flags.get('simplify', False)
+
+                    soln = roots(poly, cubics=True, quartics=True).keys()
+                    if not soln:
+                        soln = poly.all_roots()
+                        check = False  # RootOf instances can not be checked
+
+                    # We now know what the values of p are equal to. Now find out
+                    # how they are related to the original x, e.g. if p**2 = cos(x)
+                    # then x = acos(p**2)
+                    #
+                    inversion = _solve(cov - base, symbol, **flags)
+                    result = [i.subs(p, s) for i in inversion for s in soln]
+
+                else:  # len(bases) == 1 and all(q == 1 for q in qs):
+                    # e.g. case where gens are exp(x), exp(-x)
+                    u = bases.pop()
                     t = Dummy('t')
-                    # perform the substitution
-                    ftry = f_num.subs(f1, t)
-
-                    # if no Functions left, we can proceed with usual solve
+                    inv = _solve(u - t, symbol)
+                    ftry = f_num.subs(u, t)
                     if not ftry.has(symbol):
-                        cv_sols = _solve(ftry, t)
-                        cv_inv = _solve(t - f1, symbol)[0]
+                        soln = _solve(ftry, t)
                         sols = list()
-                        for sol in cv_sols:
-                            sols.append(cv_inv.subs(t, sol))
+                        for sol in soln:
+                            for i in inv:
+                                sols.append(i.subs(t, sol))
                         return sols
 
-                msg = 'multiple generators %s' % gens
+            elif len(gens) == 1:
 
-            elif any(q != 1 for q in qs):
-                # e.g. for x**(1/2) + x**(1/4) a change of variables
-                # can be made using p**4 to give p**2 + p
-                base = bases.pop()
-                m = reduce(ilcm, qs)
-                p = Dummy('p', positive=True)
-                cov = p**m
-                fnew = f_num.subs(base, cov)
-                poly = Poly(fnew, p)  # we now have a single generator, p
+                # There is only one generator that we are interested in, but there
+                # may have been more than one generator identified by polys (e.g.
+                # for symbols other than the one we are interested in) so recast
+                # the poly in terms of our generator of interest.
 
-                # for cubics and quartics, if the flag wasn't set, DON'T do it
-                # by default since the results are quite long. Perhaps one
-                # could base this decision on a certain critical length of the
-                # roots.
-                if poly.degree() > 2:
-                    flags['simplify'] = flags.get('simplify', False)
+                if len(poly.gens) > 1:
+                    poly = Poly(poly, gens[0])
 
-                soln = roots(poly, cubics=True, quartics=True).keys()
-                if not soln:
-                    soln = poly.all_roots()
-                    check = False  # RootOf instances can not be checked
-
-                # We now know what the values of p are equal to. Now find out
-                # how they are related to the original x, e.g. if p**2 = cos(x)
-                # then x = acos(p**2)
-                #
-                inversion = _solve(cov - base, symbol, **flags)
-                result = [i.subs(p, s) for i in inversion for s in soln]
-
-            else:  # len(bases) == 1 and all(q == 1 for q in qs):
-                # e.g. case where gens are exp(x), exp(-x)
-                u = bases.pop()
-                t = Dummy('t')
-                inv = _solve(u - t, symbol)
-                ftry = f_num.subs(u, t)
-                if not ftry.has(symbol):
-                    soln = _solve(ftry, t)
-                    sols = list()
-                    for sol in soln:
-                        for i in inv:
-                            sols.append(i.subs(t, sol))
-                    return sols
-
-        elif len(gens) == 1:
-
-            # There is only one generator that we are interested in, but there
-            # may have been more than one generator identified by polys (e.g.
-            # for symbols other than the one we are interested in) so recast
-            # the poly in terms of our generator of interest.
-
-            if len(poly.gens) > 1:
-                poly = Poly(poly, gens[0])
-
-            # if we haven't tried tsolve yet, do so now
-            if not flags.pop('tsolve', False):
-                # for cubics and quartics, if the flag wasn't set, DON'T do it
-                # by default since the results are quite long. Perhaps one
-                # could base this decision on a certain critical length of the
-                # roots.
-                if poly.degree() > 2:
-                    flags['simplify'] = flags.get('simplify', False)
-                soln = roots(poly, cubics=True, quartics=True).keys()
-                if not soln:
-                    soln = poly.all_roots()
-                    check = False  # RootOf instances can not be checked
-                gen = poly.gen
-                if gen != symbol:
-                    u = Dummy()
+                # if we haven't tried tsolve yet, do so now
+                if not flags.pop('tsolve', False):
                     flags['tsolve'] = True
-                    inversion = _solve(gen - u, symbol, **flags)
-                    soln = list(set([i.subs(u, s) for i in
-                                inversion for s in soln]))
-                result = soln
+                    if poly.degree() == 1 and (
+                            poly.gen.is_Pow and
+                            poly.gen.exp.is_Rational and
+                            not poly.gen.exp.is_Integer):
+                        pass
+                    else:
+                        # for cubics and quartics, if the flag wasn't set, DON'T do it
+                        # by default since the results are quite long. Perhaps one
+                        # could base this decision on a certain critical length of the
+                        # roots.
+                        if poly.degree() > 2:
+                            flags['simplify'] = flags.get('simplify', False)
+                        soln = roots(poly, cubics=True, quartics=True).keys()
+                        if not soln:
+                            soln = poly.all_roots()
+                            check = False  # RootOf instances can not be checked
+                        gen = poly.gen
+                        if gen != symbol:
+                            u = Dummy()
+                            inversion = _solve(gen - u, symbol, **flags)
+                            soln = list(set([i.subs(u, s) for i in
+                                        inversion for s in soln]))
+                        result = soln
 
     # fallback if above fails
     if result is False:
+        # allow tsolve to be used on next pass if needed
+        flags.pop('tsolve', None)
         result = _tsolve(f_num, symbol, **flags)
         if result is None:
             result = False
@@ -2054,30 +2102,6 @@ def _tsolve(eq, sym, **flags):
             if sym not in soln.free_symbols:
                 return [soln]
 
-    try:
-        u = unrad(eq, sym)
-    except ValueError:
-        raise NotImplementedError('Radicals cannot be cleared from %s' % eq)
-    if u:
-        eq, cov, dens = u
-        if cov:
-            if len(cov) > 1:
-                raise NotImplementedError('Not sure how to handle this.')
-            isym, ieq = cov[0]
-            # since cov is written in terms of positive symbols, set
-            # check to False or else 0 would be excluded; _solve will check
-            # the results
-            flags['check'] = False
-            sol = _solve(eq, isym, **flags)
-            inv = _solve(ieq, sym, **flags)
-            result = []
-            for s in sol:
-                for i in inv:
-                    result.append(i.subs(isym, s))
-            return result
-        else:
-            return _solve(eq, sym, **flags)
-
     rhs, lhs = _invert(eq, sym)
 
     if lhs.is_Add:
@@ -2128,6 +2152,7 @@ def _tsolve(eq, sym, **flags):
         except NotImplementedError:
             return
         return [s.subs(reps) for s in soln]
+
 
 # TODO: option for calculating J numerically
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1145,3 +1145,8 @@ def test_issue_3545():
     assert solve(eq, q) == [
         m**2/2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4,
         m**2/2 + sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4]
+
+
+def test_issue_3653():
+    assert solve([a**2 + a, a - b], [a, b]) == [(-1, -1), (0, 0)]
+    assert solve([a**2 + a*c, a - b], [a, b]) == [(0, 0), (-c, -c)]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -3,7 +3,7 @@ from sympy import (
     LambertW, Lt, Matrix, Or, Poly, Q, Rational, S, Symbol, Wild, acos,
     asin, atan, atanh, cos, cosh, diff, exp, expand, im, log, pi, re, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh)
-from sympy.abc import a, b, c, d, k, h, p, x, y, z, t
+from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs
@@ -1085,17 +1085,22 @@ def test_exclude():
             Vout: (V1**2 - V1*Vplus - Vplus**2)/(V1 - 2*Vplus),
             R: Vplus/(C*s*(V1 - 2*Vplus))}]
 
+
 def test_high_order_roots():
     s = x**5 + 4*x**3 + 3*x**2 + S(7)/4
     assert set(solve(s)) == set(Poly(s*4, domain='ZZ').all_roots())
 
+
 def test_minsolve_linear_system():
     def count(dic):
         return len([x for x in dic.itervalues() if x == 0])
-    assert count(solve([x + y + z, y + z + a + t], minimal=True, quick=True)) == 3
-    assert count(solve([x + y + z, y + z + a + t], minimal=True, quick=False)) == 3
+    assert count(solve([x + y + z, y + z + a + t], minimal=True, quick=True)) \
+        == 3
+    assert count(solve([x + y + z, y + z + a + t], minimal=True, quick=False)) \
+        == 3
     assert count(solve([x + y + z, y + z + a], minimal=True, quick=True)) == 1
     assert count(solve([x + y + z, y + z + a], minimal=True, quick=False)) == 2
+
 
 def test_real_roots():
     # cf. issue 3551
@@ -1116,6 +1121,7 @@ def test_overdetermined():
     assert solve(eqs, x, manual=True) == [(S.Half,)]
     assert solve(eqs, x, manual=True, check=False) == [(S.Half/2,), (S.Half,)]
 
+
 def test_issue_3506():
     x = symbols('x')
     assert solve(4**(x/2) - 2**(x/3)) == [0]
@@ -1125,7 +1131,17 @@ def test_issue_3506():
     b = sqrt(6)*sqrt(log(2))/sqrt(log(5))
     assert solve(5**(x/2) - 2**(3/x)) == [-b, b]
 
+
 def test__ispow():
     assert _ispow(x**2)
     assert not _ispow(x)
     assert not _ispow(True)
+
+
+def test_issue_3545():
+    eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
+    4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
+    4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2)
+    assert solve(eq, q) == [
+        m**2/2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4,
+        m**2/2 + sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4]


### PR DESCRIPTION
The test that was added used to hang while simplification occured;
a very long solution was also obtained. Without unrad'ing the equation
was f(q) + g(m) where f(q) was

-4_sqrt(m__2 + m__2/(4_q**2) - 2_m_q - m/(2*q) + q**2 + 1/4)

and g(m) was

sqrt(16_m__4 - 16_m**3 + 8*m**2 + 8_m_sqrt(4_m__4 - 4_m**2 + 8_m + 1) +
24_m + 4_sqrt(4_m**4 - 4_m__2 + 8_m + 1) + 4)

Trying to solve this for q gave solutions whose op count was 2920 and
unless check and simplify were off, seemed to hang the process. Otherwise it took about 2 seconds to obtain the (long) answer.

A much shorter result (op count of 16) is obtained by removing _all_ radicals but it takes about 9 seconds (with the call to check and simplify being True, otherwise the answer is returned nearly instantly).
