### PR TITLE
Fix for #3626

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -512,7 +512,12 @@ class Function(Application, Expr):
         arg = self.args[0]
         l = []
         g = None
-        for i in xrange(n + 2):
+        # try to predict a number of terms needed
+        nterms = n + 2
+        cf = C.Order(arg.as_leading_term(x), x).getn()
+        if cf != 0:
+            nterms = int(nterms / cf)
+        for i in xrange(nterms):
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)
             l.append(g)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1,6 +1,6 @@
 from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
-        E, expand, pi, O, Sum, S, polygamma, loggamma,
+        E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
         Tuple, Dummy, Eq, Expr, symbols, nfloat)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import t, w, x, y, z
@@ -324,6 +324,12 @@ def test_function__eval_nseries():
     assert loggamma(1/x)._eval_nseries(x, 0, None) == \
         log(x)/2 - log(x)/x - 1/x + O(1, x)
     assert loggamma(log(1/x)).nseries(x, n=1, logx=y) == loggamma(-y)
+
+    # issue 3626:
+    assert expint(S(3)/2, -x)._eval_nseries(x, 5, None) == \
+        2 - 2*sqrt(pi)*sqrt(-x) - 2*x - x**2/3 - x**3/15 - x**4/84 + O(x**5)
+    assert sin(sqrt(x))._eval_nseries(x, 3, None) == \
+        sqrt(x) - x**(S(3)/2)/6 + x**(S(5)/2)/120 + O(x**3)
 
 
 def test_doit():

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -781,7 +781,7 @@ class Poly(Expr):
         See Also
         ========
         all_monoms
- 
+
         """
         return f.rep.monoms(order=order)
 


### PR DESCRIPTION
Function._eval_series() does wrong prediction for number of taylor terms if the argument of function is non-atomic.

Simple test:

```
In [1]: sin(sqrt(x))._eval_nseries(x, 3, None)
Out[1]: 
         3/2        
  ___   x       ⎛ 3⎞
╲╱ x  - ──── + O⎝x ⎠
         6          
```

Correct one:

```
In [1]: sin(sqrt(x))._eval_nseries(x, 3, None)
Out[1]: 
         3/2    5/2        
  ___   x      x       ⎛ 3⎞
╲╱ x  - ──── + ──── + O⎝x ⎠
         6     120         
```
