### PR TITLE
log(Product(...)) -> Sum(log(...))

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -480,7 +480,6 @@ class log(Function):
     @classmethod
     def eval(cls, arg, base=None):
         from sympy import unpolarify
-        from sympy.concrete import Sum, Product
         arg = sympify(arg)
 
         if base is not None:
@@ -530,8 +529,6 @@ class log(Function):
             return arg.args[0]
         elif arg.func is exp_polar:
             return unpolarify(arg.exp)
-        elif isinstance(arg, Product):
-            return Sum(log(arg.function), *arg.limits)
         #don't autoexpand Pow or Mul (see the issue 252):
         elif not arg.is_Add:
             coeff = arg.as_coefficient(S.ImaginaryUnit)
@@ -573,6 +570,7 @@ class log(Function):
 
     def _eval_expand_log(self, deep=True, **hints):
         from sympy import unpolarify
+        from sympy.concrete import Sum, Product
         force = hints.get('force', False)
         arg = self.args[0]
         if arg.is_Mul:
@@ -598,6 +596,8 @@ class log(Function):
                     return unpolarify(e) * a._eval_expand_log(**hints)
                 else:
                     return unpolarify(e) * a
+        elif isinstance(arg, Product):
+            return Sum(log(arg.function), *arg.limits)
 
         return self.func(arg)
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -597,7 +597,8 @@ class log(Function):
                 else:
                     return unpolarify(e) * a
         elif isinstance(arg, Product):
-            return Sum(log(arg.function), *arg.limits)
+            if arg.function.is_positive:
+                return Sum(log(arg.function), *arg.limits)
 
         return self.func(arg)
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -480,6 +480,7 @@ class log(Function):
     @classmethod
     def eval(cls, arg, base=None):
         from sympy import unpolarify
+        from sympy.concrete import Sum, Product
         arg = sympify(arg)
 
         if base is not None:
@@ -529,6 +530,8 @@ class log(Function):
             return arg.args[0]
         elif arg.func is exp_polar:
             return unpolarify(arg.exp)
+        elif isinstance(arg, Product):
+            return Sum(log(arg.function), *arg.limits)
         #don't autoexpand Pow or Mul (see the issue 252):
         elif not arg.is_Add:
             coeff = arg.as_coefficient(S.ImaginaryUnit)

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, log, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
         LambertW, sqrt, Rational, expand_log, S, sign, nextprime, conjugate,
-        sin, cos, sinh, cosh, exp_polar, re, Function)
+        sin, cos, sinh, cosh, exp_polar, re, Function, simplify)
 
 
 def test_exp_values():
@@ -357,6 +357,6 @@ def test_log_product():
     from sympy.abc import i, j, n, m
     from sympy.concrete import Product, Sum
     f, g = Function('f'), Function('g')
-    assert log(Product(f(i), (i, 1, n))) == Sum(log(f(i)), (i, 1, n))
-    assert log(Product(f(i)*g(j), (i, 1, n), (j, 1, m))) == \
+    assert simplify(log(Product(f(i), (i, 1, n)))) == Sum(log(f(i)), (i, 1, n))
+    assert simplify(log(Product(f(i)*g(j), (i, 1, n), (j, 1, m)))) == \
             Sum(log(f(i)*g(j)), (i, 1, n), (j, 1, m))

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, log, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
         LambertW, sqrt, Rational, expand_log, S, sign, nextprime, conjugate,
-        sin, cos, sinh, cosh, exp_polar, re)
+        sin, cos, sinh, cosh, exp_polar, re, Function)
 
 
 def test_exp_values():
@@ -352,3 +352,11 @@ def test_polar():
 
     # Compare exp(1.0*pi*I).
     assert (exp_polar(1.0*pi*I).n(n=5)).as_real_imag()[1] >= 0
+
+def test_log_product():
+    from sympy.abc import i, j, n, m
+    from sympy.concrete import Product, Sum
+    f, g = Function('f'), Function('g')
+    assert log(Product(f(i), (i, 1, n))) == Sum(log(f(i)), (i, 1, n))
+    assert log(Product(f(i)*g(j), (i, 1, n), (j, 1, m))) == \
+            Sum(log(f(i)*g(j)), (i, 1, n), (j, 1, m))

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -1,6 +1,6 @@
 from sympy import (symbols, log, Float, nan, oo, zoo, I, pi, E, exp, Symbol,
         LambertW, sqrt, Rational, expand_log, S, sign, nextprime, conjugate,
-        sin, cos, sinh, cosh, exp_polar, re, Function, simplify)
+        sin, cos, sinh, cosh, exp_polar, re, Function, simplify, Eq)
 
 
 def test_exp_values():
@@ -355,8 +355,13 @@ def test_polar():
 
 def test_log_product():
     from sympy.abc import i, j, n, m
+    i, j = symbols('i,j', positive=True, integer=True)
+    x, y = symbols('x,y', positive=True)
     from sympy.concrete import Product, Sum
     f, g = Function('f'), Function('g')
-    assert simplify(log(Product(f(i), (i, 1, n)))) == Sum(log(f(i)), (i, 1, n))
-    assert simplify(log(Product(f(i)*g(j), (i, 1, n), (j, 1, m)))) == \
-            Sum(log(f(i)*g(j)), (i, 1, n), (j, 1, m))
+    assert simplify(log(Product(x**i, (i, 1, n)))) == Sum(i*log(x), (i, 1, n))
+    assert simplify(log(Product(x**i*y**j, (i, 1, n), (j, 1, m)))) == \
+            Sum(log(x**i*y**j), (i, 1, n), (j, 1, m))
+
+    expr = log(Product(-2, (n, 0, 4)))
+    assert Eq(simplify(expr), expr)


### PR DESCRIPTION
https://code.google.com/p/sympy/issues/detail?id=3661&thanks=3661&ts=1361550326

```
In [19]: simplify(log(Product(f(i), (i, 1, n))))
Out[19]: 
   ⎛  n       ⎞
   ⎜┬───┬     ⎟
log⎜│   │ f(i)⎟
   ⎜│   │     ⎟
   ⎝i = 1     ⎠
```

I would like to see this simplified to 

```
In [21]: Sum(log(f(i)), (i, 1, n))
Out[21]: 
  n            
 ___           
 ╲             
  ╲   log(f(i))
  ╱            
 ╱             
 ‾‾‾           
i = 1          
```
