### PR TITLE
Enhancement in solving exact diff equations

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -814,43 +814,36 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
             try:
                 if r[d] != 0:
                     numerator = simplify(r[d].diff(y) - r[e].diff(x))
-                    if numerator == 0:
-                        matching_hints["1st_exact"] = r
-                        matching_hints["1st_exact_Integral"] = r
                     # The following few conditions try to convert a non-exact
                     # differential equation into an exact one.
                     # References : Differential equations with applications
                     # and historical notes - George E. Simmons
-                    # If (dP/dy - dQ/dx) / Q = f(x)
-                    # then exp(integral(f(x))*equation becomes exact
-                    elif numerator:
+
+                    if numerator:
+                        # If (dP/dy - dQ/dx) / Q = f(x)
+                        # then exp(integral(f(x))*equation becomes exact
                         factor = simplify(numerator/r[e])
                         variables = factor.free_symbols
-                        if len(variables) == 1:
-                            variable = variables.pop()
-                            if x == variable:
-                                factor = exp(C.Integral(factor).doit())
-                                r[d] = factor * r[d]
-                                r[e] = factor * r[e]
-                                matching_hints["1st_exact"] = r
-                                matching_hints["1st_exact_Integral"] = r
-                            else:
-                                factor = None
+                        if len(variables) == 1 and x == variables.pop():
+                            factor = exp(C.Integral(factor).doit())
+                            r[d] *= factor
+                            r[e] *= factor
+                            matching_hints["1st_exact"] = r
+                            matching_hints["1st_exact_Integral"] = r
                         else:
-                            factor = None
-                    # If (dP/dy - dQ/dx) / -P = f(y)
-                    # then exp(integral(f(y))*equation becomes exact
-                        if factor is None:
+                            # If (dP/dy - dQ/dx) / -P = f(y)
+                            # then exp(integral(f(y))*equation becomes exact
                             factor = simplify(-numerator/r[d])
                             variables = factor.free_symbols
-                            if len(variables) == 1:
-                                variable = variables.pop()
-                                if y == variable:
-                                    factor = exp(C.Integral(factor).doit())
-                                    r[d] = factor * r[d]
-                                    r[e] = factor * r[e]
-                                    matching_hints["1st_exact"] = r
-                                    matching_hints["1st_exact_Integral"] = r
+                            if len(variables) == 1 and y == variables.pop():
+                                factor = exp(C.Integral(factor).doit())
+                                r[d] *= factor
+                                r[e] *= factor
+                                matching_hints["1st_exact"] = r
+                                matching_hints["1st_exact_Integral"] = r
+                    else:
+                        matching_hints["1st_exact"] = r
+                        matching_hints["1st_exact_Integral"] = r
 
             except NotImplementedError:
                 # Differentiating the coefficients might fail because of things

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -812,36 +812,40 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
             r[d] = r[d].subs(f(x), y)
             r[e] = r[e].subs(f(x), y)
             try:
-                numerator = simplify(r[d].diff(y)) - simplify(r[e].diff(x))
-                if r[d] != 0 and numerator == 0:
-                    matching_hints["1st_exact"] = r
-                    matching_hints["1st_exact_Integral"] = r
-                # The following few conditions try to convert a non-exact
-                # differential equation into an exact one.
-                # References : Differential equations with applications
-                # and historical notes - George E. Simmons
-                # If (dP/dy - dQ/dx) / Q = f(x)
-                # then exp(integral(f(x))*equation becomes exact
-                if r[d] != 0 and numerator/r[e]:
-                    factor = simplify(numerator/r[e])
-                    variable = factor.atoms(Symbol)
-                    if x in variable and len(variable) == 1:
-                        factor = exp(C.Integral(factor).doit())
-                        r[d] = factor * r[d]
-                        r[e] = factor * r[e]
+                if r[d] != 0:
+                    numerator = simplify(r[d].diff(y) - r[e].diff(x))
+                    if numerator == 0:
                         matching_hints["1st_exact"] = r
                         matching_hints["1st_exact_Integral"] = r
-                # If (dP/dy - dQ/dx) / -P = f(y)
-                # then exp(integral(f(y))*equation becomes exact
-                if r[d] != 0 and -(numerator/r[d]):
-                    factor = simplify(-numerator/r[d])
-                    variable = factor.atoms(Symbol)
-                    if y in variable and len(variable) == 1:
-                        factor = exp(C.Integral(factor).doit())
-                        r[d] = factor * r[d]
-                        r[e] = factor * r[e]
-                        matching_hints["1st_exact"] = r
-                        matching_hints["1st_exact_Integral"] = r
+                    # The following few conditions try to convert a non-exact
+                    # differential equation into an exact one.
+                    # References : Differential equations with applications
+                    # and historical notes - George E. Simmons
+                    # If (dP/dy - dQ/dx) / Q = f(x)
+                    # then exp(integral(f(x))*equation becomes exact
+                    if numerator:
+                        factor = simplify(numerator/r[e])
+                        variables = factor.free_symbols
+                        if len(variables) == 1:
+                            variable = variables.pop()
+                            if x == variable:
+                                factor = exp(C.Integral(factor).doit())
+                                r[d] = factor * r[d]
+                                r[e] = factor * r[e]
+                                matching_hints["1st_exact"] = r
+                                matching_hints["1st_exact_Integral"] = r
+                    # If (dP/dy - dQ/dx) / -P = f(y)
+                    # then exp(integral(f(y))*equation becomes exact
+                        factor = simplify(-numerator/r[d])
+                        variables = factor.free_symbols
+                        if len(variables) == 1:
+                            variable = variables.pop()
+                            if y == variable:
+                                factor = exp(C.Integral(factor).doit())
+                                r[d] = factor * r[d]
+                                r[e] = factor * r[e]
+                                matching_hints["1st_exact"] = r
+                                matching_hints["1st_exact_Integral"] = r
 
             except NotImplementedError:
                 # Differentiating the coefficients might fail because of things

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -823,7 +823,7 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                     # and historical notes - George E. Simmons
                     # If (dP/dy - dQ/dx) / Q = f(x)
                     # then exp(integral(f(x))*equation becomes exact
-                    if numerator:
+                    elif numerator:
                         factor = simplify(numerator/r[e])
                         variables = factor.free_symbols
                         if len(variables) == 1:
@@ -834,18 +834,23 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                                 r[e] = factor * r[e]
                                 matching_hints["1st_exact"] = r
                                 matching_hints["1st_exact_Integral"] = r
+                            else:
+                                factor = None
+                        else:
+                            factor = None
                     # If (dP/dy - dQ/dx) / -P = f(y)
                     # then exp(integral(f(y))*equation becomes exact
-                        factor = simplify(-numerator/r[d])
-                        variables = factor.free_symbols
-                        if len(variables) == 1:
-                            variable = variables.pop()
-                            if y == variable:
-                                factor = exp(C.Integral(factor).doit())
-                                r[d] = factor * r[d]
-                                r[e] = factor * r[e]
-                                matching_hints["1st_exact"] = r
-                                matching_hints["1st_exact_Integral"] = r
+                        if factor is None:
+                            factor = simplify(-numerator/r[d])
+                            variables = factor.free_symbols
+                            if len(variables) == 1:
+                                variable = variables.pop()
+                                if y == variable:
+                                    factor = exp(C.Integral(factor).doit())
+                                    r[d] = factor * r[d]
+                                    r[e] = factor * r[e]
+                                    matching_hints["1st_exact"] = r
+                                    matching_hints["1st_exact_Integral"] = r
 
             except NotImplementedError:
                 # Differentiating the coefficients might fail because of things

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -812,7 +812,8 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
             r[d] = r[d].subs(f(x), y)
             r[e] = r[e].subs(f(x), y)
             try:
-                if r[d] != 0 and simplify(r[d].diff(y)) == simplify(r[e].diff(x)):
+                numerator = simplify(r[d].diff(y)) - simplify(r[e].diff(x))
+                if r[d] != 0 and numerator == 0:
                     matching_hints["1st_exact"] = r
                     matching_hints["1st_exact_Integral"] = r
                 # The following few conditions try to convert a non-exact
@@ -821,7 +822,6 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                 # and historical notes - George E. Simmons
                 # If (dP/dy - dQ/dx) / Q = f(x)
                 # then exp(integral(f(x))*equation becomes exact
-                numerator = simplify(r[d].diff(y)) - simplify(r[e].diff(x))
                 if r[d] != 0 and numerator/r[e]:
                     factor = simplify(numerator/r[e])
                     variable = factor.atoms(Symbol)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -827,8 +827,8 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                     variable = factor.atoms(Symbol)
                     if x in variable and len(variable) == 1:
                         factor = exp(C.Integral(factor).doit())
-                        r[d] = simplify(factor * r[d])
-                        r[e] = simplify(factor * r[e])
+                        r[d] = factor * r[d]
+                        r[e] = factor * r[e]
                         matching_hints["1st_exact"] = r
                         matching_hints["1st_exact_Integral"] = r
                 # If (dP/dy - dQ/dx) / -P = f(y)
@@ -838,8 +838,8 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                     variable = factor.atoms(Symbol)
                     if y in variable and len(variable) == 1:
                         factor = exp(C.Integral(factor).doit())
-                        r[d] = simplify(factor * r[d])
-                        r[e] = simplify(factor * r[e])
+                        r[d] = factor * r[d]
+                        r[e] = factor * r[e]
                         matching_hints["1st_exact"] = r
                         matching_hints["1st_exact_Integral"] = r
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1437,7 +1437,16 @@ def test_exact_enhancement():
     f = Function('f')(x)
     d = Derivative(f, x)
     eq = f/x**2 + ((f*x - 1)/x)*d
-    rhs = dsolve(eq, f)
-    assert rhs == [f(x) == (-sqrt(C1*x**2 + 1) + 1)/x, f(x) == (sqrt(C1*x**2 + 1) + 1)/x]
-    eq = (3*x**2 - f**2)*d - (2*x*f)
-    assert dsolve(eq, f)[0] == (C1*x**2)**(1/3)
+    sol = dsolve(eq, f)
+    rhs = [eq.rhs for eq in sol]
+    assert rhs == [(-sqrt(C1*x**2 + 1) + 1)/x, (sqrt(C1*x**2 + 1) + 1)/x)
+
+    eq = (x*f - 1) + d*(x**2 - x*f)
+    rhs = [sol.rhs for sol in dsolve(eq, f)]
+    assert rhs[0] == x - sqrt(C1 + x**2 - 2*log(x)) 
+    assert rhs[1] == x + sqrt(C1 + x**2 - 2*log(x))
+
+    eq = (x + 2)*sin(f) + d*x*cos(f)
+    rhs = [sol.rhs for sol in dsolve(eq, f)] 
+    assert rhs[0] == acos(-sqrt(C1*exp(-2*x)/x**4 + 1))
+    assert rhs[1] == acos(sqrt(C1*exp(-2*x)/x**4 + 1))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1432,3 +1432,12 @@ def test_issue_1996():
     f = Function('f')
     raises(ValueError, lambda: dsolve(f(x).diff(x)**2, f(x), 'separable'))
     raises(ValueError, lambda: dsolve(f(x).diff(x)**2, f(x), 'fdsjf'))
+
+def test_exact_enhancement():
+    f = Function('f')(x)
+    d = Derivative(f, x)
+    eq = f/x**2 + ((f*x - 1)/x)*d
+    rhs = dsolve(eq, f)
+    assert rhs = [f(x) == (-sqrt(C1*x**2 + 1) + 1)/x, f(x) == (sqrt(C1*x**2 + 1) + 1)/x]
+    eq = (3*x**2 - f**2)*d - (2*x*f)
+    assert dsolve(eq, f)[0] == (C1*x**2)**(1/3)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1438,6 +1438,6 @@ def test_exact_enhancement():
     d = Derivative(f, x)
     eq = f/x**2 + ((f*x - 1)/x)*d
     rhs = dsolve(eq, f)
-    assert rhs = [f(x) == (-sqrt(C1*x**2 + 1) + 1)/x, f(x) == (sqrt(C1*x**2 + 1) + 1)/x]
+    assert rhs == [f(x) == (-sqrt(C1*x**2 + 1) + 1)/x, f(x) == (sqrt(C1*x**2 + 1) + 1)/x]
     eq = (3*x**2 - f**2)*d - (2*x*f)
     assert dsolve(eq, f)[0] == (C1*x**2)**(1/3)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1323,10 +1323,11 @@ def test_1686():
     'nth_linear_constant_coeff_variation_of_parameters_Integral')
     # 1765
     eq = (x**2 + f(x)**2)*f(x).diff(x) - 2*x*f(x)
-    assert classify_ode(eq, f(x)) == (
+    assert classify_ode(eq, f(x)) == ('1st_exact',
         '1st_homogeneous_coeff_best',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_dep_div_indep',
+        '1st_exact_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
         '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
 
@@ -1439,14 +1440,14 @@ def test_exact_enhancement():
     eq = f/x**2 + ((f*x - 1)/x)*d
     sol = dsolve(eq, f)
     rhs = [eq.rhs for eq in sol]
-    assert rhs == [(-sqrt(C1*x**2 + 1) + 1)/x, (sqrt(C1*x**2 + 1) + 1)/x)
+    assert rhs == [(-sqrt(C1*x**2 + 1) + 1)/x, (sqrt(C1*x**2 + 1) + 1)/x]
 
     eq = (x*f - 1) + d*(x**2 - x*f)
     rhs = [sol.rhs for sol in dsolve(eq, f)]
-    assert rhs[0] == x - sqrt(C1 + x**2 - 2*log(x)) 
+    assert rhs[0] == x - sqrt(C1 + x**2 - 2*log(x))
     assert rhs[1] == x + sqrt(C1 + x**2 - 2*log(x))
 
     eq = (x + 2)*sin(f) + d*x*cos(f)
-    rhs = [sol.rhs for sol in dsolve(eq, f)] 
+    rhs = [sol.rhs for sol in dsolve(eq, f)]
     assert rhs[0] == acos(-sqrt(C1*exp(-2*x)/x**4 + 1))
     assert rhs[1] == acos(sqrt(C1*exp(-2*x)/x**4 + 1))


### PR DESCRIPTION
There are cases in which a non exact differential equation can be converted into an exact one.

The prinicipal cases are when (dM/dy - dN/dx) / N is a function of x and - (dM/dy - dN/dx)/M is a function of y respectively.

Then multiplying by exp(f(x)) and exp(f(y)) would convert the equation into an exact one.

```
from sympy import *
from sympy.abc import x
f = Function('f')(x)
d = Derivative(f,x)
eq = f / x**2 + ((f*x - 1)/x) * d
dsolve(eq, f)
[f(x) == (-sqrt(C1*x**2 + 1) + 1)/x, f(x) == (sqrt(C1*x**2 + 1) + 1)/x]
```

Note that one of the tests had failed when I had tested it on my laptop

```
eq = (x**2 + f(x)**2)*f(x).diff(x) - 2*x*f(x)
classify_ode(eq, f)
```

Because this can be converted into an exact form and my primary hint becomes 
'1st_exact' .

Do give suggestions and I shall add tests.
