### PR TITLE
#3378: Remove deprecated Symbol(dummy=True) syntax

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -62,14 +62,6 @@ class Symbol(AtomicExpr, Boolean):
 
         """
 
-        if 'dummy' in assumptions:
-            SymPyDeprecationWarning(
-                feature="Symbol('x', dummy=True)",
-                useinstead="Dummy() or symbols(..., cls=Dummy)",
-                issue=3378, deprecated_since_version="0.7.0",
-            ).warn()
-            if assumptions.pop('dummy'):
-                return Dummy(name, **assumptions)
         if assumptions.get('zero', False):
             return S.Zero
         is_commutative = fuzzy_bool(assumptions.get('commutative', True))

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -503,7 +503,7 @@ class DifferentialExtension(object):
                 if dummy:
                     i = Dummy("i")
                 else:
-                    i = Symbol('i', dummy=True)
+                    i = Symbol('i')
                 self.Tfuncs = self.Tfuncs + [Lambda(i, exp(arg.subs(self.x, i)))]
                 self.newf = self.newf.xreplace(
                         dict((exp(exparg), self.t**p) for exparg, p in others))
@@ -554,10 +554,10 @@ class DifferentialExtension(object):
                 self.L_K.append(len(self.T) - 1)
                 self.D.append(cancel(darg.as_expr()/arg).as_poly(self.t,
                     expand=False))
-                if dummy:  # XXX aren't these both the same thing?
+                if dummy:
                     i = Dummy("i")
                 else:
-                    i = Symbol('i', dummy=True)
+                    i = Symbol('i')
                 self.Tfuncs = self.Tfuncs + [Lambda(i, log(arg.subs(self.x, i)))]
                 self.newf = self.newf.xreplace({log(arg): self.t})
                 new_extension = True

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -549,14 +549,6 @@ def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
     sym : Symbol
         The subscripted symbols.
     """
-    if 'dummy' in assumptions:
-        SymPyDeprecationWarning(
-            feature="'dummy=True' to create numbered Dummy symbols",
-            useinstead="cls=Dummy",
-            issue=3378, deprecated_since_version="0.7.0",
-        ).warn()
-        if assumptions.pop('dummy'):
-            cls = C.Dummy
 
     if cls is None:
         # We can't just make the default cls=C.Symbol because it isn't


### PR DESCRIPTION
and some cleanup for risch.py
