### PR TITLE
Refactor Relational to avoid long hanging evaluations.

### DIFF
--- a/examples/advanced/hydrogen.py
+++ b/examples/advanced/hydrogen.py
@@ -4,13 +4,13 @@
 This example shows how to work with the Hydrogen radial wavefunctions.
 """
 
-from sympy import var, pretty, pprint, Integral, oo, Eq
+from sympy import Eq, Integral, oo, pprint, symbols
 from sympy.physics.hydrogen import R_nl
 
 
 def main():
     print "Hydrogen radial wavefunctions:"
-    var("r a")
+    a, r = symbols("a r")
     print "R_{21}:"
     pprint(R_nl(2, 1, a, r))
     print "R_{60}:"
@@ -18,11 +18,11 @@ def main():
 
     print "Normalization:"
     i = Integral(R_nl(1, 0, 1, r)**2 * r**2, (r, 0, oo))
-    print pretty(i), " = ", i.doit()
+    pprint(Eq(i, i.doit()))
     i = Integral(R_nl(2, 0, 1, r)**2 * r**2, (r, 0, oo))
-    print pretty(i), " = ", i.doit()
+    pprint(Eq(i, i.doit()))
     i = Integral(R_nl(2, 1, 1, r)**2 * r**2, (r, 0, oo))
-    print pretty(i), " = ", i.doit()
+    pprint(Eq(i, i.doit()))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This fixes the underlying issue from the slow hydrogen.py example file: Relational should try not to do more evaluation than it needs to.
http://code.google.com/p/sympy/issues/detail?id=3658
