### PR TITLE
Issue 3275

### DIFF
--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -2,7 +2,7 @@
 
 from sympy import (Add, binomial, cos, exp, Expr, factorial, I, Integer, Mul,
                    pi, Rational, S, sin, simplify, sqrt, Sum, symbols, sympify,
-                   Tuple)
+                   Tuple, Dummy)
 from sympy.matrices import zeros
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import pretty_symbol
@@ -618,6 +618,70 @@ class Rotation(UnitaryOperator):
     def _represent_JzOp(self, basis, **options):
         return self._represent_base(basis, **options)
 
+    def _apply_operator_uncoupled(self, state, ket, **options):
+        a = self.alpha
+        b = self.beta
+        g = self.gamma
+        j = ket.j
+        m = ket.m
+        if j.is_number:
+            s = []
+            size = m_values(j)
+            sz = size[1]
+            for mp in sz:
+                r = Rotation.D(j, m, mp, a, b, g)
+                z = r.doit()
+                s.append(z * state(j, mp))
+            return Add(*s)
+        else:
+            if options.pop('dummy', True):
+                mp = Dummy('mp')
+            else:
+                mp = symbols('mp')
+            return Sum(Rotation.D(j, m, mp, a, b, g) * state(j, mp), (mp, -j, j))
+
+    def _apply_operator_JxKet(self, ket, **options):
+        return self._apply_operator_uncoupled(JxKet, ket, **options)
+
+    def _apply_operator_JyKet(self, ket, **options):
+        return self._apply_operator_uncoupled(JyKet, ket, **options)
+
+    def _apply_operator_JzKet(self, ket, **options):
+        return self._apply_operator_uncoupled(JzKet, ket, **options)
+
+    def _apply_operator_coupled(self, state, ket, **options):
+        a = self.alpha
+        b = self.beta
+        g = self.gamma
+        j = ket.j
+        m = ket.m
+        jn = ket.jn
+        coupling = ket.coupling
+        if j.is_number:
+            s = []
+            size = m_values(j)
+            sz = size[1]
+            for mp in sz:
+                r = Rotation.D(j, m, mp, a, b, g)
+                z = r.doit()
+                s.append(z * state(j, mp, jn, coupling))
+            return Add(*s)
+        else:
+            if options.pop('dummy', True):
+                mp = Dummy('mp')
+            else:
+                mp = symbols('mp')
+            return Sum(Rotation.D(j, m, mp, a, b, g) * state(
+                j, mp, jn, coupling), (mp, -j, j))
+
+    def _apply_operator_JxKetCoupled(self, ket, **options):
+        return self._apply_operator_coupled(JxKetCoupled, ket, **options)
+
+    def _apply_operator_JyKetCoupled(self, ket, **options):
+        return self._apply_operator_coupled(JyKetCoupled, ket, **options)
+
+    def _apply_operator_JzKetCoupled(self, ket, **options):
+        return self._apply_operator_coupled(JzKetCoupled, ket, **options)
 
 class WignerD(Expr):
     """Wigner-D function
@@ -792,7 +856,7 @@ class WignerD(Expr):
         gamma = sympify(self.gamma)
         if not j.is_number:
             raise ValueError(
-                "j parameter must be numerical to evaluate, got %s", j)
+                'j parameter must be numerical to evaluate, got %s' % j)
         r = 0
         if beta == pi/2:
             # Varshalovich Equation (5), Section 4.16, page 113, setting

--- a/sympy/physics/quantum/tests/test_spin.py
+++ b/sympy/physics/quantum/tests/test_spin.py
@@ -1,7 +1,6 @@
 from __future__ import division
 from sympy import cos, exp, expand, I, Matrix, pi, S, sin, sqrt, Sum, symbols
 from sympy.abc import alpha, beta, gamma, j, m
-
 from sympy.physics.quantum import hbar, represent, Commutator, InnerProduct
 from sympy.physics.quantum.qapply import qapply
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -4180,6 +4179,51 @@ def test_jz():
         hbar*m1*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))
     assert qapply(TensorProduct(1, Jz)*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))) == \
         hbar*m2*TensorProduct(JzKet(j1, m1), JzKet(j2, m2))
+
+
+def test_rotation():
+    a, b, g = symbols('a b g')
+    j, m = symbols('j m')
+    #Uncoupled
+    answ = [JxKet(1,-1)/2 - sqrt(2)*JxKet(1,0)/2 + JxKet(1,1)/2 ,
+       JyKet(1,-1)/2 - sqrt(2)*JyKet(1,0)/2 + JyKet(1,1)/2 ,
+       JzKet(1,-1)/2 - sqrt(2)*JzKet(1,0)/2 + JzKet(1,1)/2]
+    fun = [state(1, 1) for state in JxKet, JyKet, JzKet]
+    for state in fun:
+        got = qapply(Rotation(0, pi/2, 0)*state)
+        assert got in answ
+        answ.remove(got)
+    assert not answ
+    arg = Rotation(a, b, g)*fun[0]
+    assert qapply(arg) == (-exp(-I*a)*exp(I*g)*cos(b)*JxKet(1,-1)/2 +
+        exp(-I*a)*exp(I*g)*JxKet(1,-1)/2 - sqrt(2)*exp(-I*a)*sin(b)*JxKet(1,0)/2 +
+        exp(-I*a)*exp(-I*g)*cos(b)*JxKet(1,1)/2 + exp(-I*a)*exp(-I*g)*JxKet(1,1)/2)
+    #dummy effective
+    assert str(qapply(Rotation(a, b, g)*JzKet(j, m), dummy=False)) == str(
+        qapply(Rotation(a, b, g)*JzKet(j, m), dummy=True)).replace('_','')
+    #Coupled
+    ans = [JxKetCoupled(1,-1,(1,1))/2 - sqrt(2)*JxKetCoupled(1,0,(1,1))/2 +
+       JxKetCoupled(1,1,(1,1))/2 ,
+       JyKetCoupled(1,-1,(1,1))/2 - sqrt(2)*JyKetCoupled(1,0,(1,1))/2 +
+       JyKetCoupled(1,1,(1,1))/2 ,
+       JzKetCoupled(1,-1,(1,1))/2 - sqrt(2)*JzKetCoupled(1,0,(1,1))/2 +
+       JzKetCoupled(1,1,(1,1))/2]
+    fun = [state(1, 1, (1,1)) for state in JxKetCoupled, JyKetCoupled, JzKetCoupled]
+    for state in fun:
+        got = qapply(Rotation(0, pi/2, 0)*state)
+        assert got in ans
+        ans.remove(got)
+    assert not ans
+    arg = Rotation(a, b, g)*fun[0]
+    assert qapply(arg) == (
+        -exp(-I*a)*exp(I*g)*cos(b)*JxKetCoupled(1,-1,(1,1))/2 +
+        exp(-I*a)*exp(I*g)*JxKetCoupled(1,-1,(1,1))/2 -
+        sqrt(2)*exp(-I*a)*sin(b)*JxKetCoupled(1,0,(1,1))/2 +
+        exp(-I*a)*exp(-I*g)*cos(b)*JxKetCoupled(1,1,(1,1))/2 +
+        exp(-I*a)*exp(-I*g)*JxKetCoupled(1,1,(1,1))/2)
+    #dummy effective
+    assert str(qapply(Rotation(a,b,g)*JzKetCoupled(j,m,(j1,j2)), dummy=False)) == str(
+        qapply(Rotation(a,b,g)*JzKetCoupled(j,m,(j1,j2)), dummy=True)).replace('_','')
 
 
 def test_jzket():


### PR DESCRIPTION
Application of qapply(Rotation(alpha,beta,gamma)*JzKet(1,1)) [define the symbols alpha beta and gamma](And these are dummy) would ask for the inputs of alpha,beta,gamma.The parameters used in calling the function must be used to in the method and this is not happening so I had to ask for the input.Is there anyway that I could get it working without the use of asking for input.The issue is not completely solved because the same method has to be written for every spin state.
