### PR TITLE
Fix fold_frac_powers=True latex printing.

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -275,6 +275,10 @@ class LatexPrinter(Printer):
             and expr.exp.is_Rational \
                 and expr.exp.q != 1:
             base, p, q = self._print(expr.base), expr.exp.p, expr.exp.q
+            if expr.base.is_Function:
+                return self._print(expr.base, "%s/%s" % (p, q))
+            if self._needs_brackets(expr.base):
+                return r"\left(%s\right)^{%s/%s}" % (base, p, q)
             return r"%s^{%s/%s}" % (base, p, q)
         elif expr.exp.is_Rational and expr.exp.is_negative and expr.base.is_Function:
             # Things like 1/x

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -55,12 +55,20 @@ def test_latex_basic():
     assert latex(sqrt(x)**3, itex=True) == r"x^{\frac{3}{2}}"
     assert latex(x**Rational(3, 4)) == r"x^{\frac{3}{4}}"
     assert latex(x**Rational(3, 4), fold_frac_powers=True) == "x^{3/4}"
+    assert latex((x + 1)**Rational(3, 4)) == \
+        r"\left(x + 1\right)^{\frac{3}{4}}"
+    assert latex((x + 1)**Rational(3, 4), fold_frac_powers=True) == \
+        r"\left(x + 1\right)^{3/4}"
 
     assert latex(1.5e20*x) == r"1.5 \times 10^{20} x"
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
 
     assert latex(1/sin(x)) == r"\frac{1}{\sin{\left (x \right )}}"
     assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left (x \right )}}"
+    assert latex(sin(x)**Rational(3, 2)) == \
+        r"\sin^{\frac{3}{2}}{\left (x \right )}"
+    assert latex(sin(x)**Rational(3, 2), fold_frac_powers=True) == \
+        r"\sin^{3/2}{\left (x \right )}"
 
     assert latex(~x) == r"\neg x"
     assert latex(x & y) == r"x \wedge y"


### PR DESCRIPTION
TODO merge with master and get Travis report

The latex printing of (x + 1)**Rational(3, 2) with fold_frac_powers=True was missing the opening and closing brackets. The latex printing of functions raised to rational powers is made consistent with the fold_frac_powers=False option.

Fixes issue 3670.
http://code.google.com/p/sympy/issues/detail?id=3670
