### PR TITLE
rsolve: use limit() to substitute initial values of n in the generic solution of the recurrence equation

### DIFF
--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -771,7 +771,7 @@ def rsolve(f, y, init=None):
                     raise ValueError("Integer or term expected, got '%s'" % k)
             try:
                 eq = solution.limit(n, i) - v
-            except:
+            except NotImplementedError:
                 eq = solution.subs(n, i) - v
             equations.append(eq)
 

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -756,33 +756,24 @@ def rsolve(f, y, init=None):
         init = None
 
     if symbols and init is not None:
+        if type(init) is list:
+            init = dict([(i, init[i]) for i in xrange(len(init))])
+
         equations = []
 
-        if type(init) is list:
-            for i in xrange(0, len(init)):
-                try:
-                    s = solution.limit(n, i)
-                except:
-                    s = solution.subs(n, i)
-                eq = s - init[i]
-                equations.append(eq)
-        else:
-            for k, v in init.iteritems():
-                try:
-                    i = int(k)
-                except TypeError:
-                    if k.is_Function and k.func == y.func:
-                        i = int(k.args[0])
-                    else:
-                        raise ValueError(
-                            "Integer or term expected, got '%s'" % k)
-
-                try:
-                    s = solution.limit(n, i)
-                except:
-                    s = solution.subs(n, i)
-                eq = s - v
-                equations.append(eq)
+        for k, v in init.iteritems():
+            try:
+                i = int(k)
+            except TypeError:
+                if k.is_Function and k.func == y.func:
+                    i = int(k.args[0])
+                else:
+                    raise ValueError("Integer or term expected, got '%s'" % k)
+            try:
+                eq = solution.limit(n, i) - v
+            except:
+                eq = solution.subs(n, i) - v
+            equations.append(eq)
 
         result = solve(equations, *symbols)
 

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -760,7 +760,11 @@ def rsolve(f, y, init=None):
 
         if type(init) is list:
             for i in xrange(0, len(init)):
-                eq = solution.subs(n, i) - init[i]
+                try:
+                    s = solution.limit(n, i)
+                except:
+                    s = solution.subs(n, i)
+                eq = s - init[i]
                 equations.append(eq)
         else:
             for k, v in init.iteritems():
@@ -773,7 +777,11 @@ def rsolve(f, y, init=None):
                         raise ValueError(
                             "Integer or term expected, got '%s'" % k)
 
-                eq = solution.subs(n, i) - v
+                try:
+                    s = solution.limit(n, i)
+                except:
+                    s = solution.subs(n, i)
+                eq = s - v
                 equations.append(eq)
 
         result = solve(equations, *symbols)

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -66,9 +66,9 @@ def test_rsolve_hyper():
 
     assert rsolve_hyper([-a, 1],0,n).expand() == C0*a**n
 
-    assert rsolve_hyper([-a, 0, 1],0,n).expand() == (-1)**n*C1*a**(n/2) + C0*a**(n/2)
+    assert rsolve_hyper([-a, 0, 1], 0, n).expand() == (-1)**n*C1*a**(n/2) + C0*a**(n/2)
 
-    assert rsolve_hyper([1,1,1], 0, n).expand() == \
+    assert rsolve_hyper([1, 1, 1], 0, n).expand() == \
         C0*(-S(1)/2 - sqrt(3)*I/2)**n + C1*(-S(1)/2 + sqrt(3)*I/2)**n
 
 

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -1,4 +1,4 @@
-from sympy import Eq, factorial, Function, Lambda, rf, S, sqrt, symbols
+from sympy import Eq, factorial, Function, Lambda, rf, S, sqrt, symbols, expand_func, binomial, gamma
 from sympy.solvers.recurr import rsolve, rsolve_hyper, rsolve_poly, rsolve_ratio
 from sympy.utilities.pytest import raises
 
@@ -161,12 +161,18 @@ def test_rsolve():
     assert rsolve(Eq(y(n + 1), a*y(n)), y(n)).simplify() == C0*a**n
     assert rsolve(Eq(y(n + 1), a*y(n)), y(n), {y(1): a}).simplify() == a**n
 
-    f = y(n) - a*y(n-2)
+    f = y(n) - a*y(n - 2)
 
     assert rsolve(f,y(n)) == C0*a**(n/2) + C1*(-sqrt(a))**n
     assert rsolve(f,y(n), \
             {y(1): sqrt(a)*(a + b), y(2): a*(a - b)}).simplify() == \
             a**(n/2)*((-1)**(n + 1)*b + a)
+
+    f = (-16*n**2 + 32*n - 12)*y(n - 1) + (4*n**2 - 12*n + 9)*y(n)
+
+    assert expand_func(rsolve(f, y(n), \
+        {y(1): binomial(2*n + 1, 3)}).rewrite(gamma)).simplify() == \
+        4**n*n*(8*n**3 - 4*n**2 - 2*n + 1)/12
 
 
 def test_rsolve_raises():


### PR DESCRIPTION
Using just subs() rsolve sometimes is not able to find solution with specified initial conditions.

An example in master:

```
In [1]: f = (-16*n**2 + 32*n - 12)*y(n - 1) + (4*n**2 - 12*n + 9)*y(n)

In [2]: rsolve(f, y(n), {y(1): binomial(2*n + 1, 3)})
Out[2]: 0

In [3]: g=rsolve(f, y(n))

In [4]: g.subs(n,1)
Out[4]: ∞⋅C₀
In [5]: g
Out[5]: 
 -n  n - 1              
2  ⋅8     ⋅C₀⋅(n - 1/2)!
────────────────────────
       (n - 3/2)!       
In [6]: g.limit(n,1)
Out[6]: 
C₀
──
4 
```
