### PR TITLE
Fix #3055: implement additional simplifications for bessel-type functions

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -153,8 +153,13 @@ class besselj(BesselBase):
             return besselj(nnu, z)
 
     def _eval_expand_func(self, **hints):
-        if self.order.is_Rational and self.order.q == 2:
+        nu = self.order
+        if (nu + S.Half).is_integer:
             return self._eval_rewrite_as_jn(*self.args, **{'expand': True})
+        elif nu.is_integer and (nu - 1).is_positive:
+            z = self.argument
+            return (-besselj(nu - 2, z)._eval_expand_func() +
+                    2*(nu - 1)*besselj(nu - 1, z)._eval_expand_func()/z)
         return self
 
     def _eval_rewrite_as_besseli(self, nu, z):
@@ -211,8 +216,13 @@ class bessely(BesselBase):
                 return S(-1)**nu*bessely(-nu, z)
 
     def _eval_expand_func(self, **hints):
-        if self.order.is_Rational and self.order.q == 2:
+        nu = self.order
+        if (nu + S.Half).is_integer:
             return self._eval_rewrite_as_yn(*self.args, **{'expand': True})
+        elif nu.is_integer and (nu - 1).is_positive:
+            z = self.argument
+            return (-bessely(nu - 2, z)._eval_expand_func() +
+                    2*(nu - 1)*bessely(nu - 1, z)._eval_expand_func()/z)
         return self
 
 
@@ -276,6 +286,16 @@ class besseli(BesselBase):
         from sympy import polar_lift, exp
         return exp(-I*pi*nu/2)*besselj(nu, polar_lift(I)*z)
 
+    def _eval_expand_func(self, **hints):
+        nu = self.order
+        if (nu + S.Half).is_integer:
+            return expand_func(self._eval_rewrite_as_besselj(*self.args))
+        if nu.is_integer and (nu - 1).is_positive:
+            z = self.argument
+            return (besseli(nu - 2, z)._eval_expand_func() -
+                    2*(nu - 1)*besseli(nu - 1, z)._eval_expand_func()/z)
+        return self
+
 
 class besselk(BesselBase):
     r"""
@@ -309,6 +329,14 @@ class besselk(BesselBase):
 
     _a = S.One
     _b = -S.One
+
+    def _eval_expand_func(self, **hints):
+        nu = self.order
+        if nu.is_integer and (nu - 1).is_positive:
+            z = self.argument
+            return (besselk(nu - 2, z)._eval_expand_func() -
+                    2*(nu - 1)*besselk(nu - 1, z)._eval_expand_func()/z)
+        return self
 
 
 class hankel1(BesselBase):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -52,6 +52,10 @@ class BesselBase(Function):
         return self._b/2 * self.__class__(self.order - 1, self.argument) \
             - self._a/2 * self.__class__(self.order + 1, self.argument) \
 
+    def _eval_conjugate(self):
+        z = self.argument
+        if (z.is_real and z.is_negative) is False:
+            return self.__class__(self.order.conjugate(), z.conjugate())
 
 
 class besselj(BesselBase):
@@ -448,6 +452,11 @@ class hankel1(BesselBase):
     _a = S.One
     _b = S.One
 
+    def _eval_conjugate(self):
+        z = self.argument
+        if (z.is_real and z.is_negative) is False:
+            return hankel2(self.order.conjugate(), z.conjugate())
+
 
 class hankel2(BesselBase):
     r"""
@@ -486,6 +495,11 @@ class hankel2(BesselBase):
 
     _a = S.One
     _b = S.One
+
+    def _eval_conjugate(self):
+        z = self.argument
+        if (z.is_real and z.is_negative) is False:
+            return hankel1(self.order.conjugate(), z.conjugate())
 
 from sympy.polys.orthopolys import spherical_bessel_fn as fn
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -171,20 +171,18 @@ class besselj(BesselBase):
         if nu.is_integer is False:
             return csc(pi*nu)*bessely(-nu, z) - cot(pi*nu)*bessely(nu, z)
 
-    def _eval_rewrite_as_jn(self, nu, z, expand=False):
-        jn_part = jn(nu - S('1/2'), self.argument)
-        if expand:
-            jn_part = jn_part._eval_expand_func()
-        return sqrt(2*z/pi) * jn_part
+    def _eval_rewrite_as_jn(self, nu, z):
+        return sqrt(2*z/pi)*jn(nu - S.Half, self.argument)
 
     def _eval_expand_func(self, **hints):
-        nu = self.order
-        if (nu + S.Half).is_integer:
-            return self._eval_rewrite_as_jn(*self.args, **{'expand': True})
-        elif nu.is_integer and (nu - 1).is_positive:
-            z = self.argument
-            return (-besselj(nu - 2, z)._eval_expand_func() +
-                    2*(nu - 1)*besselj(nu - 1, z)._eval_expand_func()/z)
+        nu, z = self.order, self.argument
+        if nu.is_real:
+            if (nu - 1).is_positive:
+                return (-besselj(nu - 2, z)._eval_expand_func() +
+                        2*(nu - 1)*besselj(nu - 1, z)._eval_expand_func()/z)
+            elif (nu + 1).is_negative:
+                return (2*(nu + 1)*besselj(nu + 1, z)._eval_expand_func()/z -
+                        besselj(nu + 2, z)._eval_expand_func())
         return self
 
 
@@ -254,20 +252,18 @@ class bessely(BesselBase):
         if aj:
             return aj.rewrite(besseli)
 
-    def _eval_rewrite_as_yn(self, nu, z, expand=False):
-        yn_part = yn(nu - S('1/2'), self.argument)
-        if expand:
-            yn_part = yn_part._eval_expand_func()
-        return sqrt(2*z/pi) * yn_part
+    def _eval_rewrite_as_yn(self, nu, z):
+        return sqrt(2*z/pi) * yn(nu - S.Half, self.argument)
 
     def _eval_expand_func(self, **hints):
-        nu = self.order
-        if (nu + S.Half).is_integer:
-            return self._eval_rewrite_as_yn(*self.args, **{'expand': True})
-        elif nu.is_integer and (nu - 1).is_positive:
-            z = self.argument
-            return (-bessely(nu - 2, z)._eval_expand_func() +
-                    2*(nu - 1)*bessely(nu - 1, z)._eval_expand_func()/z)
+        nu, z = self.order, self.argument
+        if nu.is_real:
+            if (nu - 1).is_positive:
+                return (-bessely(nu - 2, z)._eval_expand_func() +
+                        2*(nu - 1)*bessely(nu - 1, z)._eval_expand_func()/z)
+            elif (nu + 1).is_negative:
+                return (2*(nu + 1)*bessely(nu + 1, z)._eval_expand_func()/z -
+                        bessely(nu + 2, z)._eval_expand_func())
         return self
 
 
@@ -358,14 +354,18 @@ class besseli(BesselBase):
         if aj:
             return aj.rewrite(bessely)
 
+    def _eval_rewrite_as_jn(self, nu, z):
+        return self._eval_rewrite_as_besselj(*self.args).rewrite(jn)
+
     def _eval_expand_func(self, **hints):
-        nu = self.order
-        if (nu + S.Half).is_integer:
-            return expand_func(self._eval_rewrite_as_besselj(*self.args))
-        if nu.is_integer and (nu - 1).is_positive:
-            z = self.argument
-            return (besseli(nu - 2, z)._eval_expand_func() -
-                    2*(nu - 1)*besseli(nu - 1, z)._eval_expand_func()/z)
+        nu, z = self.order, self.argument
+        if nu.is_real:
+            if (nu - 1).is_positive:
+                return (besseli(nu - 2, z)._eval_expand_func() -
+                        2*(nu - 1)*besseli(nu - 1, z)._eval_expand_func()/z)
+            elif (nu + 1).is_negative:
+                return (2*(nu + 1)*besseli(nu + 1, z)._eval_expand_func()/z +
+                        besseli(nu + 2, z)._eval_expand_func())
         return self
 
 
@@ -438,12 +438,20 @@ class besselk(BesselBase):
         if aj:
             return aj.rewrite(bessely)
 
+    def _eval_rewrite_as_yn(self, nu, z):
+        ay = self._eval_rewrite_as_bessely(*self.args)
+        if ay:
+            return ay.rewrite(yn)
+
     def _eval_expand_func(self, **hints):
-        nu = self.order
-        if nu.is_integer and (nu - 1).is_positive:
-            z = self.argument
-            return (besselk(nu - 2, z)._eval_expand_func() -
-                    2*(nu - 1)*besselk(nu - 1, z)._eval_expand_func()/z)
+        nu, z = self.order, self.argument
+        if nu.is_real:
+            if (nu - 1).is_positive:
+                return (besselk(nu - 2, z)._eval_expand_func() -
+                        2*(nu - 1)*besselk(nu - 1, z)._eval_expand_func()/z)
+            elif (nu + 1).is_negative:
+                return (2*(nu + 1)*besselk(nu + 1, z)._eval_expand_func()/z +
+                        besselk(nu + 2, z)._eval_expand_func())
         return self
 
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -107,7 +107,6 @@ class besselj(BesselBase):
 
     bessely, besseli, besselk
 
-
     References
     ==========
 
@@ -117,6 +116,7 @@ class besselj(BesselBase):
     - Luke, Y. L. (1969), The Special Functions and Their Approximations,
       Volume 1
     - http://en.wikipedia.org/wiki/Bessel_function
+    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselJ/
     """
 
     _a = S.One
@@ -211,6 +211,11 @@ class bessely(BesselBase):
 
     besselj, besseli, besselk
 
+    References
+    ==========
+
+    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselY/
+
     """
 
     _a = S.One
@@ -278,6 +283,11 @@ class besseli(BesselBase):
     ========
 
     besselj, bessely, besselk
+
+    References
+    ==========
+
+    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselI/
 
     """
 
@@ -365,6 +375,11 @@ class besselk(BesselBase):
 
     besselj, besseli, bessely
 
+    References
+    ==========
+
+    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselK/
+
     """
 
     _a = S.One
@@ -423,6 +438,11 @@ class hankel1(BesselBase):
 
     hankel2, besselj, bessely
 
+    References
+    ==========
+
+    - http://functions.wolfram.com/Bessel-TypeFunctions/HankelH1/
+
     """
 
     _a = S.One
@@ -456,6 +476,11 @@ class hankel2(BesselBase):
     ========
 
     hankel1, besselj, bessely
+
+    References
+    ==========
+
+    - http://functions.wolfram.com/Bessel-TypeFunctions/HankelH2/
 
     """
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -114,13 +114,13 @@ class besselj(BesselBase):
     References
     ==========
 
-    - Abramowitz, Milton; Stegun, Irene A., eds. (1965), "Chapter 9",
-      Handbook of Mathematical Functions with Formulas, Graphs, and Mathematical
-      Tables
-    - Luke, Y. L. (1969), The Special Functions and Their Approximations,
-      Volume 1
-    - http://en.wikipedia.org/wiki/Bessel_function
-    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselJ/
+    .. [1] Abramowitz, Milton; Stegun, Irene A., eds. (1965), "Chapter 9",
+           Handbook of Mathematical Functions with Formulas, Graphs, and
+           Mathematical Tables
+    .. [2] Luke, Y. L. (1969), The Special Functions and Their
+           Approximations, Volume 1
+    .. [3] http://en.wikipedia.org/wiki/Bessel_function
+    .. [4] http://functions.wolfram.com/Bessel-TypeFunctions/BesselJ/
     """
 
     _a = S.One
@@ -222,7 +222,7 @@ class bessely(BesselBase):
     References
     ==========
 
-    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselY/
+    .. [1] http://functions.wolfram.com/Bessel-TypeFunctions/BesselY/
 
     """
 
@@ -304,7 +304,7 @@ class besseli(BesselBase):
     References
     ==========
 
-    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselI/
+    .. [1] http://functions.wolfram.com/Bessel-TypeFunctions/BesselI/
 
     """
 
@@ -400,7 +400,7 @@ class besselk(BesselBase):
     References
     ==========
 
-    - http://functions.wolfram.com/Bessel-TypeFunctions/BesselK/
+    .. [1] http://functions.wolfram.com/Bessel-TypeFunctions/BesselK/
 
     """
 
@@ -477,7 +477,7 @@ class hankel1(BesselBase):
     References
     ==========
 
-    - http://functions.wolfram.com/Bessel-TypeFunctions/HankelH1/
+    .. [1] http://functions.wolfram.com/Bessel-TypeFunctions/HankelH1/
 
     """
 
@@ -521,7 +521,7 @@ class hankel2(BesselBase):
     References
     ==========
 
-    - http://functions.wolfram.com/Bessel-TypeFunctions/HankelH2/
+    .. [1] http://functions.wolfram.com/Bessel-TypeFunctions/HankelH2/
 
     """
 

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -4,6 +4,7 @@ from sympy import S, pi, I
 from sympy.core.function import Function, ArgumentIndexError
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.complexes import re, im
 
 # TODO
 # o Airy Ai and Bi functions
@@ -129,11 +130,23 @@ class besselj(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
-        if nu.is_Integer:
-            if nu < 0:
-                return S(-1)**nu*besselj(-nu, z)
-            if z.could_extract_minus_sign():
-                return S(-1)**nu*besselj(nu, -z)
+        if z.is_zero:
+            if nu.is_zero:
+                return S.One
+            elif (nu.is_integer and nu.is_zero is False) or re(nu).is_positive:
+                return S.Zero
+            elif re(nu).is_negative and not (nu.is_integer is True):
+                return S.ComplexInfinity
+            elif nu.is_imaginary:
+                return S.NaN
+        if z is S.Infinity or (z is S.NegativeInfinity):
+            return S.Zero
+
+        if z.could_extract_minus_sign():
+            return (z)**nu*(-z)**(-nu)*besselj(nu, -z)
+        if nu.is_integer:
+            if nu.could_extract_minus_sign():
+                return S(-1)**(-nu)*besselj(-nu, z)
             newz = z.extract_multiplicatively(I)
             if newz:  # NOTE we don't want to change the function if z==0
                 return I**(nu)*besseli(nu, newz)
@@ -211,9 +224,19 @@ class bessely(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
-        if nu.is_Integer:
-            if nu < 0:
-                return S(-1)**nu*bessely(-nu, z)
+        if z.is_zero:
+            if nu.is_zero:
+                return S.NegativeInfinity
+            elif re(nu).is_zero is False:
+                return S.ComplexInfinity
+            elif re(nu).is_zero:
+                return S.NaN
+        if z is S.Infinity or z is S.NegativeInfinity:
+            return S.Zero
+
+        if nu.is_integer:
+            if nu.could_extract_minus_sign():
+                return S(-1)**(-nu)*bessely(-nu, z)
 
     def _eval_expand_func(self, **hints):
         nu = self.order
@@ -263,7 +286,24 @@ class besseli(BesselBase):
 
     @classmethod
     def eval(cls, nu, z):
-        if nu.is_Integer:
+        if z.is_zero:
+            if nu.is_zero:
+                return S.One
+            elif (nu.is_integer and nu.is_zero is False) or re(nu).is_positive:
+                return S.Zero
+            elif re(nu).is_negative and not (nu.is_integer is True):
+                return S.ComplexInfinity
+            elif nu.is_imaginary:
+                return S.NaN
+        if z.is_imaginary:
+            if im(z) is S.Infinity or im(z) is S.NegativeInfinity:
+                return S.Zero
+
+        if z.could_extract_minus_sign():
+            return (z)**nu*(-z)**(-nu)*besseli(nu, -z)
+        if nu.is_integer:
+            if nu.could_extract_minus_sign():
+                return besseli(-nu, z)
             newz = z.extract_multiplicatively(I)
             if newz:  # NOTE we don't want to change the function if z==0
                 return I**(-nu)*besselj(nu, -newz)
@@ -329,6 +369,23 @@ class besselk(BesselBase):
 
     _a = S.One
     _b = -S.One
+
+    @classmethod
+    def eval(cls, nu, z):
+        if z.is_zero:
+            if nu.is_zero:
+                return S.Infinity
+            elif re(nu).is_zero is False:
+                return S.ComplexInfinity
+            elif re(nu).is_zero:
+                return S.NaN
+        if z.is_imaginary:
+            if im(z) is S.Infinity or im(z) is S.NegativeInfinity:
+                return S.Zero
+
+        if nu.is_integer:
+            if nu.could_extract_minus_sign():
+                return besselk(-nu, z)
 
     def _eval_expand_func(self, **hints):
         nu = self.order

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -126,12 +126,6 @@ class besselj(BesselBase):
     _a = S.One
     _b = S.One
 
-    def _eval_rewrite_as_jn(self, nu, z, expand=False):
-        jn_part = jn(nu - S('1/2'), self.argument)
-        if expand:
-            jn_part = jn_part._eval_expand_func()
-        return sqrt(2*z/pi) * jn_part
-
     @classmethod
     def eval(cls, nu, z):
         if z.is_zero:
@@ -169,6 +163,16 @@ class besselj(BesselBase):
         if nu != nnu:
             return besselj(nnu, z)
 
+    def _eval_rewrite_as_besseli(self, nu, z):
+        from sympy import polar_lift, exp
+        return exp(I*pi*nu/2)*besseli(nu, polar_lift(-I)*z)
+
+    def _eval_rewrite_as_jn(self, nu, z, expand=False):
+        jn_part = jn(nu - S('1/2'), self.argument)
+        if expand:
+            jn_part = jn_part._eval_expand_func()
+        return sqrt(2*z/pi) * jn_part
+
     def _eval_expand_func(self, **hints):
         nu = self.order
         if (nu + S.Half).is_integer:
@@ -178,10 +182,6 @@ class besselj(BesselBase):
             return (-besselj(nu - 2, z)._eval_expand_func() +
                     2*(nu - 1)*besselj(nu - 1, z)._eval_expand_func()/z)
         return self
-
-    def _eval_rewrite_as_besseli(self, nu, z):
-        from sympy import polar_lift, exp
-        return exp(I*pi*nu/2)*besseli(nu, polar_lift(-I)*z)
 
 
 class bessely(BesselBase):
@@ -225,12 +225,6 @@ class bessely(BesselBase):
     _a = S.One
     _b = S.One
 
-    def _eval_rewrite_as_yn(self, nu, z, expand=False):
-        yn_part = yn(nu - S('1/2'), self.argument)
-        if expand:
-            yn_part = yn_part._eval_expand_func()
-        return sqrt(2*z/pi) * yn_part
-
     @classmethod
     def eval(cls, nu, z):
         if z.is_zero:
@@ -246,6 +240,12 @@ class bessely(BesselBase):
         if nu.is_integer:
             if nu.could_extract_minus_sign():
                 return S(-1)**(-nu)*bessely(-nu, z)
+
+    def _eval_rewrite_as_yn(self, nu, z, expand=False):
+        yn_part = yn(nu - S('1/2'), self.argument)
+        if expand:
+            yn_part = yn_part._eval_expand_func()
+        return sqrt(2*z/pi) * yn_part
 
     def _eval_expand_func(self, **hints):
         nu = self.order

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -57,6 +57,18 @@ class BesselBase(Function):
         if (z.is_real and z.is_negative) is False:
             return self.__class__(self.order.conjugate(), z.conjugate())
 
+    def _eval_expand_func(self, **hints):
+        nu, z, f = self.order, self.argument, self.__class__
+        if nu.is_real:
+            if (nu - 1).is_positive:
+                return (-self._a*self._b*f(nu - 2, z)._eval_expand_func() +
+                        2*self._a*(nu - 1)*f(nu - 1, z)._eval_expand_func()/z)
+            elif (nu + 1).is_negative:
+                return (2*self._b*(nu + 1)*f(nu + 1, z)._eval_expand_func()/z -
+                        self._a*self._b*f(nu + 2, z)._eval_expand_func())
+        return self
+
+
 
 class besselj(BesselBase):
     r"""
@@ -174,17 +186,6 @@ class besselj(BesselBase):
     def _eval_rewrite_as_jn(self, nu, z):
         return sqrt(2*z/pi)*jn(nu - S.Half, self.argument)
 
-    def _eval_expand_func(self, **hints):
-        nu, z = self.order, self.argument
-        if nu.is_real:
-            if (nu - 1).is_positive:
-                return (-besselj(nu - 2, z)._eval_expand_func() +
-                        2*(nu - 1)*besselj(nu - 1, z)._eval_expand_func()/z)
-            elif (nu + 1).is_negative:
-                return (2*(nu + 1)*besselj(nu + 1, z)._eval_expand_func()/z -
-                        besselj(nu + 2, z)._eval_expand_func())
-        return self
-
 
 class bessely(BesselBase):
     r"""
@@ -254,17 +255,6 @@ class bessely(BesselBase):
 
     def _eval_rewrite_as_yn(self, nu, z):
         return sqrt(2*z/pi) * yn(nu - S.Half, self.argument)
-
-    def _eval_expand_func(self, **hints):
-        nu, z = self.order, self.argument
-        if nu.is_real:
-            if (nu - 1).is_positive:
-                return (-bessely(nu - 2, z)._eval_expand_func() +
-                        2*(nu - 1)*bessely(nu - 1, z)._eval_expand_func()/z)
-            elif (nu + 1).is_negative:
-                return (2*(nu + 1)*bessely(nu + 1, z)._eval_expand_func()/z -
-                        bessely(nu + 2, z)._eval_expand_func())
-        return self
 
 
 class besseli(BesselBase):
@@ -357,17 +347,6 @@ class besseli(BesselBase):
     def _eval_rewrite_as_jn(self, nu, z):
         return self._eval_rewrite_as_besselj(*self.args).rewrite(jn)
 
-    def _eval_expand_func(self, **hints):
-        nu, z = self.order, self.argument
-        if nu.is_real:
-            if (nu - 1).is_positive:
-                return (besseli(nu - 2, z)._eval_expand_func() -
-                        2*(nu - 1)*besseli(nu - 1, z)._eval_expand_func()/z)
-            elif (nu + 1).is_negative:
-                return (2*(nu + 1)*besseli(nu + 1, z)._eval_expand_func()/z +
-                        besseli(nu + 2, z)._eval_expand_func())
-        return self
-
 
 class besselk(BesselBase):
     r"""
@@ -442,17 +421,6 @@ class besselk(BesselBase):
         ay = self._eval_rewrite_as_bessely(*self.args)
         if ay:
             return ay.rewrite(yn)
-
-    def _eval_expand_func(self, **hints):
-        nu, z = self.order, self.argument
-        if nu.is_real:
-            if (nu - 1).is_positive:
-                return (besselk(nu - 2, z)._eval_expand_func() -
-                        2*(nu - 1)*besselk(nu - 1, z)._eval_expand_func()/z)
-            elif (nu + 1).is_negative:
-                return (2*(nu + 1)*besselk(nu + 1, z)._eval_expand_func()/z +
-                        besselk(nu + 2, z)._eval_expand_func())
-        return self
 
 
 class hankel1(BesselBase):

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -53,9 +53,10 @@ def test_rewrite():
 def test_expand():
     from sympy import besselsimp, Symbol, exp, exp_polar, I
 
-    assert expand_func(besselj(S(1)/2, z)) == sqrt(2)*sin(z)/(sqrt(pi)*sqrt(z))
-    assert expand_func(
-        bessely(S(1)/2, z)) == -sqrt(2)*cos(z)/(sqrt(pi)*sqrt(z))
+    assert expand_func(besselj(S(1)/2, z).rewrite(jn)) == \
+        sqrt(2)*sin(z)/(sqrt(pi)*sqrt(z))
+    assert expand_func(bessely(S(1)/2, z).rewrite(yn)) == \
+        -sqrt(2)*cos(z)/(sqrt(pi)*sqrt(z))
 
     # XXX: teach sin/cos to work around arguments like
     # x*exp_polar(I*pi*n/2).  Then change besselsimp -> expand_func
@@ -66,25 +67,35 @@ def test_expand():
     assert expand_func(besselj(2, x)) == \
         -besselj(0, x) + 2*besselj(1, x)/x
     assert expand_func(besselk(2, x)) == \
-        besselk(0, x) - 2*besselk(1, x)/x
+        besselk(0, x) + 2*besselk(1, x)/x
     assert expand_func(bessely(2, x)) == \
+        -bessely(0, x) + 2*bessely(1, x)/x
+
+    assert expand_func(besseli(-2, x)) == \
+        besseli(0, x) - 2*besseli(1, x)/x
+    assert expand_func(besselj(-2, x)) == \
+        -besselj(0, x) + 2*besselj(1, x)/x
+    assert expand_func(besselk(-2, x)) == \
+        besselk(0, x) + 2*besselk(1, x)/x
+    assert expand_func(bessely(-2, x)) == \
         -bessely(0, x) + 2*bessely(1, x)/x
 
     n = Symbol('n', integer=True, positive=True)
 
     assert expand_func(besseli(n + 2, z)) == \
-        besseli(n, z) - (2*n + 2)*(-2*n*besseli(n, z)/z + besseli(n - 1, z))/z
+        besseli(n, z) + (-2*n - 2)*(-2*n*besseli(n, z)/z + besseli(n - 1, z))/z
     assert expand_func(besselj(n + 2, z)) == \
         -besselj(n, z) + (2*n + 2)*(2*n*besselj(n, z)/z - besselj(n - 1, z))/z
     assert expand_func(besselk(n + 2, z)) == \
-        besselk(n, z) - (2*n + 2)*(-2*n*besselk(n, z)/z + besselk(n - 1, z))/z
+        besselk(n, z) + (2*n + 2)*(2*n*besselk(n, z)/z + besselk(n - 1, z))/z
     assert expand_func(bessely(n + 2, z)) == \
         -bessely(n, z) + (2*n + 2)*(2*n*bessely(n, z)/z - bessely(n - 1, z))/z
 
-    assert expand_func(besseli(n + S(1)/2, z)) == \
+    assert expand_func(besseli(n + S(1)/2, z).rewrite(jn)) == \
         sqrt(2)*sqrt(z)*exp(-I*pi*(n + S(1)/2)/2)* \
         exp_polar(I*pi/4)*jn(n, z*exp_polar(I*pi/2))/sqrt(pi)
-    assert expand_func(besselj(n + S(1)/2, z)) == sqrt(2)*sqrt(z)*jn(n, z)/sqrt(pi)
+    assert expand_func(besselj(n + S(1)/2, z).rewrite(jn)) == \
+        sqrt(2)*sqrt(z)*jn(n, z)/sqrt(pi)
 
 
 def test_fn():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -192,6 +192,36 @@ def test_bessel_eval():
     assert besselj(3, I*z) == -I*besseli(3, z)
 
 
+def test_conjugate():
+    from sympy import conjugate, I, Symbol
+    n, z, x = Symbol('n'), Symbol('z', real=False), Symbol('x', real=True)
+    y, t = Symbol('y', real=True, positive=True), Symbol('t', negative=True)
+
+    for f in [besseli, besselj, besselk, bessely, jn, yn, hankel1, hankel2]:
+        assert f(n, -1).conjugate() != f(conjugate(n), -1)
+        assert f(n, x).conjugate() != f(conjugate(n), x)
+        assert f(n, t).conjugate() != f(conjugate(n), t)
+
+    for f in [besseli, besselj, besselk, bessely, jn, yn]:
+        assert f(n, 1 + I).conjugate() == f(conjugate(n), 1 - I)
+        assert f(n, 0).conjugate() == f(conjugate(n), 0)
+        assert f(n, 1).conjugate() == f(conjugate(n), 1)
+        assert f(n, z).conjugate() == f(conjugate(n), conjugate(z))
+        assert f(n, y).conjugate() == f(conjugate(n), y)
+
+    assert hankel1(n, 1 + I).conjugate() == hankel2(conjugate(n), 1 - I)
+    assert hankel1(n, 0).conjugate() == hankel2(conjugate(n), 0)
+    assert hankel1(n, 1).conjugate() == hankel2(conjugate(n), 1)
+    assert hankel1(n, y).conjugate() == hankel2(conjugate(n), y)
+    assert hankel1(n, z).conjugate() == hankel2(conjugate(n), conjugate(z))
+
+    assert hankel2(n, 1 + I).conjugate() == hankel1(conjugate(n), 1 - I)
+    assert hankel2(n, 0).conjugate() == hankel1(conjugate(n), 0)
+    assert hankel2(n, 1).conjugate() == hankel1(conjugate(n), 1)
+    assert hankel2(n, y).conjugate() == hankel1(conjugate(n), y)
+    assert hankel2(n, z).conjugate() == hankel1(conjugate(n), conjugate(z))
+
+
 def test_branching():
     from sympy import exp_polar, polar_lift, Symbol, I, exp
     assert besselj(polar_lift(k), x) == besselj(k, x)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -44,9 +44,36 @@ def test_rewrite():
 
 
 def test_expand():
+    from sympy import Symbol, exp, exp_polar, I
+
     assert expand_func(besselj(S(1)/2, z)) == sqrt(2)*sin(z)/(sqrt(pi)*sqrt(z))
     assert expand_func(
         bessely(S(1)/2, z)) == -sqrt(2)*cos(z)/(sqrt(pi)*sqrt(z))
+
+    assert expand_func(besseli(2, x)) == \
+        besseli(0, x) - 2*besseli(1, x)/x
+    assert expand_func(besselj(2, x)) == \
+        -besselj(0, x) + 2*besselj(1, x)/x
+    assert expand_func(besselk(2, x)) == \
+        besselk(0, x) - 2*besselk(1, x)/x
+    assert expand_func(bessely(2, x)) == \
+        -bessely(0, x) + 2*bessely(1, x)/x
+
+    n = Symbol('n', integer=True, positive=True)
+
+    assert expand_func(besseli(n + 2, z)) == \
+        besseli(n, z) - (2*n + 2)*(-2*n*besseli(n, z)/z + besseli(n - 1, z))/z
+    assert expand_func(besselj(n + 2, z)) == \
+        -besselj(n, z) + (2*n + 2)*(2*n*besselj(n, z)/z - besselj(n - 1, z))/z
+    assert expand_func(besselk(n + 2, z)) == \
+        besselk(n, z) - (2*n + 2)*(-2*n*besselk(n, z)/z + besselk(n - 1, z))/z
+    assert expand_func(bessely(n + 2, z)) == \
+        -bessely(n, z) + (2*n + 2)*(2*n*bessely(n, z)/z - bessely(n - 1, z))/z
+
+    assert expand_func(besseli(n + S(1)/2, z)) == \
+        sqrt(2)*sqrt(z)*exp(-I*pi*(n + S(1)/2)/2)* \
+        exp_polar(I*pi/4)*jn(n, z*exp_polar(I*pi/2))/sqrt(pi)
+    assert expand_func(besselj(n + S(1)/2, z)) == sqrt(2)*sqrt(z)*jn(n, z)/sqrt(pi)
 
 
 def test_fn():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -137,12 +137,52 @@ def test_jn_zeros():
 
 
 def test_bessel_eval():
-    from sympy import I
-    assert besselj(-4, z) == besselj(4, z)
-    assert besselj(-3, z) == -besselj(3, z)
+    from sympy import I, Symbol
+    n, m, k = Symbol('n', integer=True), Symbol('m'), Symbol('k', integer=True, zero=False)
 
-    assert bessely(-2, z) == bessely(2, z)
-    assert bessely(-1, z) == -bessely(1, z)
+    for f in [besselj, besseli]:
+        assert f(0, 0) == S.One
+        assert f(2.1, 0) == S.Zero
+        assert f(-3, 0) == S.Zero
+        assert f(-10.2, 0) == S.ComplexInfinity
+        assert f(1 + 3*I, 0) == S.Zero
+        assert f(-3 + I, 0) == S.ComplexInfinity
+        assert f(-2*I, 0) == S.NaN
+        assert f(n, 0) != S.One and f(n, 0) != S.Zero
+        assert f(m, 0) != S.One and f(m, 0) != S.Zero
+        assert f(k, 0) == S.Zero
+
+    assert bessely(0, 0) == S.NegativeInfinity
+    assert besselk(0, 0) == S.Infinity
+    for f in [bessely, besselk]:
+        assert f(1 + I, 0) == S.ComplexInfinity
+        assert f(I, 0) == S.NaN
+
+    for f in [besselj, bessely]:
+        assert f(m, S.Infinity) == S.Zero
+        assert f(m, S.NegativeInfinity) == S.Zero
+
+    for f in [besseli, besselk]:
+        assert f(m, I*S.Infinity) == S.Zero
+        assert f(m, I*S.NegativeInfinity) == S.Zero
+
+    for f in [besseli, besselk]:
+        assert f(-4, z) == f(4, z)
+        assert f(-3, z) == f(3, z)
+        assert f(-n, z) == f(n, z)
+        assert f(-m, z) != f(m, z)
+
+    for f in [besselj, bessely]:
+        assert f(-4, z) == f(4, z)
+        assert f(-3, z) == -f(3, z)
+        assert f(-n, z) == (-1)**n*f(n, z)
+        assert f(-m, z) != (-1)**m*f(m, z)
+
+    for f in [besselj, besseli]:
+        assert f(m, -z) == (-z)**m*z**(-m)*f(m, z)
+
+    assert besseli(2, -z) == besseli(2, z)
+    assert besseli(3, -z) == -besseli(3, z)
 
     assert besselj(0, -z) == besselj(0, z)
     assert besselj(1, -z) == -besselj(1, z)

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -1,6 +1,6 @@
 from sympy import jn, yn, symbols, sin, cos, pi, S, jn_zeros, besselj, \
     bessely, besseli, besselk, hankel1, hankel2, expand_func, \
-    latex, sqrt
+    latex, sqrt, sinh
 from sympy.functions.special.bessel import fn
 from sympy.utilities.pytest import raises, skip
 from sympy.utilities.randtest import \
@@ -40,15 +40,26 @@ def test_rewrite():
         exp(I*n*pi/2)*besseli(n, polar_lift(-I)*z)
     nu = randcplx()
     assert tn(besselj(nu, z), besselj(nu, z).rewrite(besseli), z)
+    assert tn(besselj(nu, z), besselj(nu, z).rewrite(bessely), z)
     assert tn(besseli(nu, z), besseli(nu, z).rewrite(besselj), z)
+    assert tn(besseli(nu, z), besseli(nu, z).rewrite(bessely), z)
+    assert tn(bessely(nu, z), bessely(nu, z).rewrite(besselj), z)
+    assert tn(bessely(nu, z), bessely(nu, z).rewrite(besseli), z)
+    assert tn(besselk(nu, z), besselk(nu, z).rewrite(besselj), z)
+    assert tn(besselk(nu, z), besselk(nu, z).rewrite(besseli), z)
+    assert tn(besselk(nu, z), besselk(nu, z).rewrite(bessely), z)
 
 
 def test_expand():
-    from sympy import Symbol, exp, exp_polar, I
+    from sympy import besselsimp, Symbol, exp, exp_polar, I
 
     assert expand_func(besselj(S(1)/2, z)) == sqrt(2)*sin(z)/(sqrt(pi)*sqrt(z))
     assert expand_func(
         bessely(S(1)/2, z)) == -sqrt(2)*cos(z)/(sqrt(pi)*sqrt(z))
+
+    # XXX: teach sin/cos to work around arguments like
+    # x*exp_polar(I*pi*n/2).  Then change besselsimp -> expand_func
+    assert besselsimp(besseli(S(1)/2, z)) == sqrt(2)*sinh(z)/(sqrt(pi)*sqrt(z))
 
     assert expand_func(besseli(2, x)) == \
         besseli(0, x) - 2*besseli(1, x)/x

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -62,35 +62,30 @@ def test_expand():
     # x*exp_polar(I*pi*n/2).  Then change besselsimp -> expand_func
     assert besselsimp(besseli(S(1)/2, z)) == sqrt(2)*sinh(z)/(sqrt(pi)*sqrt(z))
 
-    rn, rx = randcplx(a=1.01, b=0, d=0), randcplx()
+    def check(eq, ans):
+        return tn(eq, ans) and eq == ans
 
-    assert expand_func(besseli(2, x)) == besseli(0, x) - 2*besseli(1, x)/x
-    assert expand_func(besseli(-2, x)) == besseli(0, x) - 2*besseli(1, x)/x
-    assert tn(expand_func(besseli(rn, rx)), \
-        besseli(rn - 2, rx) - 2*(rn - 1)*besseli(rn - 1, rx)/rx)
-    assert tn(expand_func(besseli(-rn, rx)), \
-        besseli(-rn + 2, rx) + 2*(-rn + 1)*besseli(-rn + 1, rx)/rx)
+    rn = randcplx(a=1, b=0, d=0, c=2)
 
-    assert expand_func(besselj(2, x)) == -besselj(0, x) + 2*besselj(1, x)/x
-    assert expand_func(besselj(-2, x)) == -besselj(0, x) + 2*besselj(1, x)/x
-    assert tn(expand_func(besselj(rn, rx)), \
-        -besselj(rn - 2, rx) + 2*(rn - 1)*besselj(rn - 1, rx)/rx)
-    assert tn(expand_func(besselj(-rn, rx)), \
-        -besselj(-rn + 2, rx) + 2*(-rn + 1)*besselj(-rn + 1, rx)/rx)
+    assert check(expand_func(besseli(rn, x)), \
+        besseli(rn - 2, x) - 2*(rn - 1)*besseli(rn - 1, x)/x)
+    assert check(expand_func(besseli(-rn, x)), \
+        besseli(-rn + 2, x) + 2*(-rn + 1)*besseli(-rn + 1, x)/x)
 
-    assert expand_func(besselk(2, x)) == besselk(0, x) + 2*besselk(1, x)/x
-    assert expand_func(besselk(-2, x)) == besselk(0, x) + 2*besselk(1, x)/x
-    assert tn(expand_func(besselk(rn, rx)), \
-        besselk(rn - 2, rx) + 2*(rn - 1)*besselk(rn - 1, rx)/rx)
-    assert tn(expand_func(besselk(-rn, rx)), \
-        besselk(-rn + 2, rx) - 2*(-rn + 1)*besselk(-rn + 1, rx)/rx)
+    assert check(expand_func(besselj(rn, x)), \
+        -besselj(rn - 2, x) + 2*(rn - 1)*besselj(rn - 1, x)/x)
+    assert check(expand_func(besselj(-rn, x)), \
+        -besselj(-rn + 2, x) + 2*(-rn + 1)*besselj(-rn + 1, x)/x)
 
-    assert expand_func(bessely(2, x)) == -bessely(0, x) + 2*bessely(1, x)/x
-    assert expand_func(bessely(-2, x)) == -bessely(0, x) + 2*bessely(1, x)/x
-    assert tn(expand_func(bessely(rn, rx)), \
-        -bessely(rn - 2, rx) + 2*(rn - 1)*bessely(rn - 1, rx)/rx)
-    assert tn(expand_func(bessely(-rn, rx)), \
-        -bessely(-rn + 2, rx) + 2*(-rn + 1)*bessely(-rn + 1, rx)/rx)
+    assert check(expand_func(besselk(rn, x)), \
+        besselk(rn - 2, x) + 2*(rn - 1)*besselk(rn - 1, x)/x)
+    assert check(expand_func(besselk(-rn, x)), \
+        besselk(-rn + 2, x) - 2*(-rn + 1)*besselk(-rn + 1, x)/x)
+
+    assert check(expand_func(bessely(rn, x)), \
+        -bessely(rn - 2, x) + 2*(rn - 1)*bessely(rn - 1, x)/x)
+    assert check(expand_func(bessely(-rn, x)), \
+        -bessely(-rn + 2, x) + 2*(-rn + 1)*bessely(-rn + 1, x)/x)
 
     n = Symbol('n', integer=True, positive=True)
 
@@ -236,7 +231,7 @@ def test_conjugate():
         assert f(n, x).conjugate() != f(conjugate(n), x)
         assert f(n, t).conjugate() != f(conjugate(n), t)
 
-    rn, rz = randcplx(), randcplx(b=0.5)
+    rz = randcplx(b=0.5)
 
     for f in [besseli, besselj, besselk, bessely, jn, yn]:
         assert f(n, 1 + I).conjugate() == f(conjugate(n), 1 - I)
@@ -244,21 +239,21 @@ def test_conjugate():
         assert f(n, 1).conjugate() == f(conjugate(n), 1)
         assert f(n, z).conjugate() == f(conjugate(n), conjugate(z))
         assert f(n, y).conjugate() == f(conjugate(n), y)
-        assert tn(f(rn, rz).conjugate(), f(conjugate(rn), conjugate(rz)))
+        assert tn(f(n, rz).conjugate(), f(conjugate(n), conjugate(rz)))
 
     assert hankel1(n, 1 + I).conjugate() == hankel2(conjugate(n), 1 - I)
     assert hankel1(n, 0).conjugate() == hankel2(conjugate(n), 0)
     assert hankel1(n, 1).conjugate() == hankel2(conjugate(n), 1)
     assert hankel1(n, y).conjugate() == hankel2(conjugate(n), y)
     assert hankel1(n, z).conjugate() == hankel2(conjugate(n), conjugate(z))
-    assert tn(hankel1(rn, rz).conjugate(), hankel2(conjugate(rn), conjugate(rz)))
+    assert tn(hankel1(n, rz).conjugate(), hankel2(conjugate(n), conjugate(rz)))
 
     assert hankel2(n, 1 + I).conjugate() == hankel1(conjugate(n), 1 - I)
     assert hankel2(n, 0).conjugate() == hankel1(conjugate(n), 0)
     assert hankel2(n, 1).conjugate() == hankel1(conjugate(n), 1)
     assert hankel2(n, y).conjugate() == hankel1(conjugate(n), y)
     assert hankel2(n, z).conjugate() == hankel1(conjugate(n), conjugate(z))
-    assert tn(hankel2(rn, rz).conjugate(), hankel1(conjugate(rn), conjugate(rz)))
+    assert tn(hankel2(n, rz).conjugate(), hankel1(conjugate(n), conjugate(rz)))
 
 
 def test_branching():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1604,7 +1604,7 @@ def test_signsimp():
 
 
 def test_besselsimp():
-    from sympy import besselj, besseli, besselk, bessely, jn, yn, exp_polar, cosh
+    from sympy import besselj, besseli, besselk, bessely, jn, yn, exp_polar, cosh, cosine_transform
     assert besselsimp(exp(-I*pi*y/2)*besseli(y, z*exp_polar(I*pi/2))) == \
         besselj(y, z)
     assert besselsimp(exp(-I*pi*a/2)*besseli(a, 2*sqrt(x)*exp_polar(I*pi/2))) == \
@@ -1617,6 +1617,8 @@ def test_besselsimp():
         sqrt(2)*cosh(z)/(sqrt(pi)*sqrt(z))
     assert besselsimp(besseli(a, z*exp_polar(-I*pi/2))) == \
         exp(-I*pi*a/2)*besselj(a, z)
+    assert cosine_transform(1/t*sin(a/t), t, y) == \
+        sqrt(2)*sqrt(pi)*besselj(0, 2*sqrt(a)*sqrt(y))/2
 
 
 def test_Piecewise():


### PR DESCRIPTION
1) add some missing symmetry properties (e.g.: besseli(-1, x) -> besseli(1, x))
2) implement recursive expansion of besseli/j for integer orders (in _eval_expand_func)
3) besselsimp() uses 2) by default
4) apply factor() on the expression, modified by besselsimp()

Now example from the issue looks not so ugly:

```
In [3]: cosine_transform(1/t*sin(a/t), t, w)
Out[3]: 
  ___   ___        ⎛       ___   ___⎞
╲╱ 2 ⋅╲╱ π ⋅besselj⎝0, 2⋅╲╱ a ⋅╲╱ w ⎠
─────────────────────────────────────
                  2                  
```

Remaining part of #3055:

> There are also formulae for expanding Bessel functions of rational
> order under the conditions that for the order it holds that:
> ...
> n - 1/3 \in Z : one-third integer values
> n - 2/3 \in Z : two-third integer values
> We should implement these too.

This can't be done without Airy Ai and Bi functions (already in TODO of bessel.py).
