### PR TITLE
runtests: Show operands of failed tests' assert statements

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -46,6 +46,8 @@ parser.add_option("--slow", action="store_true", dest="slow",
 parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
                   default=True, help="Don't run the tests in a separate "
                   "subprocess.  This may prevent hash randomization from being enabled.")
+parser.add_option("-E", "--enhance-asserts", action="store_true", dest="enhance_asserts",
+                  default=False, help="Rewrite assert statements to give more useful error messages.")
 parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = """\
 "options" are any of the options above. "tests" are 0 or more glob strings of \
@@ -65,7 +67,7 @@ ok = sympy.test(*args, **{"verbose": options.verbose, "kw": options.kw,
     "tb": options.tb, "pdb": options.pdb, "colors": options.colors,
     "force_colors": options.force_colors, "sort": options.sort, "seed":
     options.seed, "slow": options.slow, "timeout": options.timeout,
-    'subprocess': options.subprocess})
+    'subprocess': options.subprocess, 'enhance_asserts': options.enhance_asserts})
 
 if ok:
     sys.exit(0)


### PR DESCRIPTION
This uses ast module (if available) to rewrite assert statements of the form:

```
assert expr_0 cmpop_0 expr_1 cmpop_1 ... cmpop_n expr_{n+1}
```

to:

```
(sym_0, sym_1, ..., sym_{n+1}) = (expr_0, expr_1, ..., expr_{n+1})
assert sym_0 cmpop_0 sym_1 cmpop_1 ... cmpop_n sym_{n+1},
    "%s cmpop_0 %s ... cmpop_n %s" % (sym_0, sym_1, ..., sym_{n+1})
```

Line numbers are preserved on assert statements. On short test runs there is a
small but visible speed penalty (e.g. under 10% for sympy/polys). However, full
test suit run isn't affected that much.

Plain bin/test:

```
$ bin/test sympy/polys/tests/test_rings.py
============================================================ test process starts ============================================================
executable:         /usr/bin/python  (2.7.2-final-0)
architecture:       64-bit
cache:              yes
ground types:       gmpy 1.14
random seed:        52276056
hash randomization: on (PYTHONHASHSEED=2961690477)

sympy/polys/tests/test_rings.py[12] .......F....                                                                                       [FAIL]

_____________________________________________________________________________________________________________________________________________
___________________________________________ sympy/polys/tests/test_rings.py:test_PolyElement_pow ____________________________________________
  File "/home/mateusz/repo/git/sympy/sympy/polys/tests/test_rings.py", line 78, in test_PolyElement_pow
    assert f**0 == 3
AssertionError

=========================================== tests finished: 11 passed, 1 failed, in 0.03 seconds ============================================
DO *NOT* COMMIT!
```

Enhanced bin/test:

```
$ bin/test sympy/polys/tests/test_rings.py -E
============================================================ test process starts ============================================================
executable:         /usr/bin/python  (2.7.2-final-0)
architecture:       64-bit
cache:              yes
ground types:       gmpy 1.14
random seed:        57370498
hash randomization: on (PYTHONHASHSEED=4164250690)

sympy/polys/tests/test_rings.py[12] .......F....                                                                                       [FAIL]

_____________________________________________________________________________________________________________________________________________
___________________________________________ sympy/polys/tests/test_rings.py:test_PolyElement_pow ____________________________________________
  File "/home/mateusz/repo/git/sympy/sympy/polys/tests/test_rings.py", line 78, in test_PolyElement_pow
    assert f**0 == 3
AssertionError: 1 == 3

=========================================== tests finished: 11 passed, 1 failed, in 0.06 seconds ============================================
DO *NOT* COMMIT!
```
