### PR TITLE
Make factorint take only integer arguments

### DIFF
--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -900,9 +900,6 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     smoothness, smoothness_p, divisors
 
     """
-    if (not isinstance(n, Mul) and not isinstance(n, dict)
-       and not S(n).is_integer):
-        raise ValueError('input must be an integer')
     factordict = {}
     if visual and not isinstance(n, Mul) and not isinstance(n, dict):
         factordict = factorint(n, limit=limit, use_trial=use_trial,
@@ -944,7 +941,7 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
 
     assert use_trial or use_rho or use_pm1
 
-    n = int(n)
+    n = as_int(n)
     if limit:
         limit = int(limit)
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -900,6 +900,9 @@ def factorint(n, limit=None, use_trial=True, use_rho=True, use_pm1=True,
     smoothness, smoothness_p, divisors
 
     """
+    if (not isinstance(n, Mul) and not isinstance(n, dict)
+       and not S(n).is_integer):
+        raise ValueError('input must be an integer')
     factordict = {}
     if visual and not isinstance(n, Mul) and not isinstance(n, dict):
         factordict = factorint(n, limit=limit, use_trial=use_trial,

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -326,7 +326,8 @@ def test_factorint():
     p1 = nextprime(2**17)
     p2 = nextprime(2*p1)
     assert factorint((p1*p2**2)**3) == {p1: 3, p2: 6}
-
+    # Test for non integer input
+    raises(ValueError, lambda: factorint(4.5))
 
 def test_divisors_and_divisor_count():
     assert divisors(-1) == [1]


### PR DESCRIPTION
[Issue 3672](http://code.google.com/p/sympy/issues/detail?id=3672)
Minor fix.
Before

```
>>> factorint(10.1)
>>> {2: 1, 5: 1}
```

Now, it raises a `ValueError`.
Also, a test has been added.
