### PR TITLE
Fixes ipython printing extension

### DIFF
--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -43,7 +43,7 @@ def load_ipython_extension(ip):
     # Use extension manager to track loaded status if available
     # This is currently in IPython 0.14.dev
     if hasattr(ip.extension_manager, 'loaded'):
-        loaded = 'sympy.interactive.ipythonprinting' not in ip.extension_manager.loaded
+        loaded = 'sympy.interactive.ipythonprinting' in ip.extension_manager.loaded
     else:
         loaded = _loaded
 

--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -32,21 +32,6 @@ from sympy.interactive.printing import init_printing
 # Definitions of special display functions for use with IPython
 #-----------------------------------------------------------------------------
 
-_loaded = False
-
-
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    import IPython
-
-    global _loaded
-    # Use extension manager to track loaded status if available
-    # This is currently in IPython 0.14.dev
-    if hasattr(ip.extension_manager, 'loaded'):
-        loaded = 'sympy.interactive.ipythonprinting' in ip.extension_manager.loaded
-    else:
-        loaded = _loaded
-
-    if not loaded:
-        init_printing(ip=ip)
-        _loaded = True
+    init_printing(ip=ip)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -233,7 +233,11 @@ def init_printing(pretty_print=True, order=None, use_unicode=None, use_latex=Non
 
     if ip:
         try:
-            from IPython.zmq.zmqshell import ZMQInteractiveShell
+            import IPython
+            if IPython.__version__ >= '1.0':
+                from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
+            else:
+                from IPython.zmq.zmqshell import ZMQInteractiveShell
         except ImportError:
             pass
         else:

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -232,21 +232,10 @@ def init_printing(pretty_print=True, order=None, use_unicode=None, use_latex=Non
             pass
 
     if ip:
-        try:
-            import IPython
-            if IPython.__version__ >= '1.0':
-                from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
-            else:
-                from IPython.zmq.zmqshell import ZMQInteractiveShell
-        except ImportError:
-            pass
-        else:
-            # If in qtconsole or notebook
-            if isinstance(ip, ZMQInteractiveShell):
-                if use_unicode is None:
-                    use_unicode = True
-                if use_latex is None:
-                    use_latex = True
+        if use_unicode is None:
+            use_unicode = True
+        if use_latex is None:
+            use_latex = True
 
     if not no_global:
         Printer.set_global_settings(order=order, use_unicode=use_unicode, wrap_line=wrap_line, num_columns=num_columns)

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -1,0 +1,28 @@
+"""Tests that the IPython printing module is properly loaded. """
+
+from sympy.interactive.session import init_ipython_session
+from sympy.external import import_module
+
+ipython = import_module("IPython", min_module_version="0.11")
+
+# disable tests if ipython is not present
+if not ipython:
+    disabled = True
+
+def test_ipythonprinting():
+    # Initialize and setup IPython session
+    app = init_ipython_session()
+    app.run_cell("from IPython.core.interactiveshell import InteractiveShell")
+    app.run_cell("inst = InteractiveShell.instance()")
+    app.run_cell("format = inst.display_formatter.format")
+    app.run_cell("from sympy import Symbol")
+
+    # Printing without printing extension
+    app.run_cell("a = format(Symbol('pi'))")
+    assert app.user_ns['a']['text/plain'] == "pi"
+
+    # Load printing extension
+    app.run_cell("%load_ext sympy.interactive.ipythonprinting")
+    # Printing with printing extension
+    app.run_cell("a = format(Symbol('pi'))")
+    assert app.user_ns['a']['text/plain'] == u'\u03c0'

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -12,8 +12,8 @@ if not ipython:
 def test_ipythonprinting():
     # Initialize and setup IPython session
     app = init_ipython_session()
-    app.run_cell("from IPython.core.interactiveshell import InteractiveShell")
-    app.run_cell("inst = InteractiveShell.instance()")
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("inst = ip.instance()")
     app.run_cell("format = inst.display_formatter.format")
     app.run_cell("from sympy import Symbol")
 


### PR DESCRIPTION
This fixes two things.

First, the extension had to be reloaded to import the extension. Fixes issue #3619 [1].

Second, this has been broken since IPython moved IPython.zmq to IPython.kernel.zmq. This PR fixes this. Note, there are some git versions of IPython where this will still break (between moving the zmq module and changing the version to 1.0.dev), but it should work for all stable releases and will work for the current git version. The versions that won't work are between 1/29 [2] and 2/15 [3]. This was brought up in #1757.

[1] https://code.google.com/p/sympy/issues/detail?id=3619
[2] ipython/ipython@37f32253e06e216b9690c52dd6f554992d5b82b6
[3] ipython/ipython#2927
