### PR TITLE
Rewrite of harmonic numbers into summation

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -536,6 +536,12 @@ class harmonic(Function):
         from sympy.functions.special.gamma_functions import polygamma
         return self.rewrite(polygamma)
 
+    def _eval_rewrite_as_Sum(self, n, m=None):
+        k = C.Dummy("k", integer=True)
+        if m is None:
+            m = S.One
+        return C.Sum(k**(-m), (k, 1, n))
+
     def _eval_expand_func(self, **hints):
         n = self.args[0]
         m = self.args[1] if len(self.args) == 2 else 1

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -65,13 +65,13 @@ class fibonacci(Function):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Fibonacci_number
-    * http://mathworld.wolfram.com/FibonacciNumber.html
+    .. [1] http://en.wikipedia.org/wiki/Fibonacci_number
+    .. [2] http://mathworld.wolfram.com/FibonacciNumber.html
 
     See Also
     ========
 
-    lucas
+    bell, bernoulli, catalan, euler, harmonic, lucas
     """
 
     @staticmethod
@@ -120,12 +120,13 @@ class lucas(Function):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Lucas_number
+    .. [1] http://en.wikipedia.org/wiki/Lucas_number
+    .. [2] http://mathworld.wolfram.com/LucasNumber.html
 
     See Also
     ========
 
-    fibonacci
+    bell, bernoulli, catalan, euler, fibonacci, harmonic
     """
 
     @classmethod
@@ -206,13 +207,15 @@ class bernoulli(Function):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Bernoulli_number
-    * http://en.wikipedia.org/wiki/Bernoulli_polynomial
+    .. [1] http://en.wikipedia.org/wiki/Bernoulli_number
+    .. [2] http://en.wikipedia.org/wiki/Bernoulli_polynomial
+    .. [3] http://mathworld.wolfram.com/BernoulliNumber.html
+    .. [4] http://mathworld.wolfram.com/BernoulliPolynomial.html
 
     See Also
     ========
 
-    euler, bell
+    bell, catalan, euler, fibonacci, harmonic, lucas
     """
 
     # Calculates B_n for positive even n
@@ -339,14 +342,14 @@ class bell(Function):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Bell_number
-    * http://mathworld.wolfram.com/BellNumber.html
-    * http://mathworld.wolfram.com/BellPolynomial.html
+    .. [1] http://en.wikipedia.org/wiki/Bell_number
+    .. [2] http://mathworld.wolfram.com/BellNumber.html
+    .. [3] http://mathworld.wolfram.com/BellPolynomial.html
 
     See Also
     ========
 
-    euler, bernoulli
+    bernoulli, catalan, euler, fibonacci, harmonic, lucas
     """
 
     @staticmethod
@@ -420,23 +423,21 @@ class harmonic(Function):
     r"""
     Harmonic numbers
 
-    The nth harmonic number is given by 1 + 1/2 + 1/3 + ... + 1/n.
+    The nth harmonic number is given by `\operatorname{H}_{n} =
+    1 + \frac{1}{2} + \frac{1}{3} + \ldots + \frac{1}{n}`.
 
-    More generally::
+    More generally:
 
-                   n
-                  ___
-                 \       -m
-          H    =  )     k   .
-           n,m   /___
-                 k = 1
+    .. math:: \operatorname{H}_{n,m} = \sum_{k=1}^{n} \frac{1}{k^m}
 
-    As n -> oo, H_{n,m} -> zeta(m) (the Riemann zeta function)
+    As `n \rightarrow \infty`, `\operatorname{H}_{n,m} \rightarrow \zeta(m)`,
+    the Riemann zeta function.
 
-    * harmonic(n) gives the nth harmonic number, H_n
+    * ``harmonic(n)`` gives the nth harmonic number, `\operatorname{H}_n`
 
-    * harmonic(n, m) gives the nth generalized harmonic number
-      of order m, H_{n,m}, where harmonic(n) == harmonic(n, 1)
+    * ``harmonic(n, m)`` gives the nth generalized harmonic number
+      of order `m`, `\operatorname{H}_{n,m}`, where
+      ``harmonic(n) == harmonic(n, 1)``
 
     Examples
     ========
@@ -450,10 +451,15 @@ class harmonic(Function):
     >>> harmonic(oo, 2)
     pi**2/6
 
+    >>> from sympy import Symbol, Sum
+    >>> n = Symbol("n")
+
+    >>> harmonic(n).rewrite(Sum)
+    Sum(1/_k, (_k, 1, n))
+
     We can rewrite harmonic numbers in terms of polygamma functions:
 
-    >>> from sympy import Symbol, digamma, polygamma
-    >>> n = Symbol("n")
+    >>> from sympy import digamma, polygamma
     >>> m = Symbol("m")
 
     >>> harmonic(n).rewrite(digamma)
@@ -500,6 +506,11 @@ class harmonic(Function):
     .. [1] http://en.wikipedia.org/wiki/Harmonic_number
     .. [2] http://functions.wolfram.com/GammaBetaErf/HarmonicNumber/
     .. [3] http://functions.wolfram.com/GammaBetaErf/HarmonicNumber2/
+
+    See Also
+    ========
+
+    bell, bernoulli, catalan, euler, fibonacci, lucas
     """
 
     # Generate one memoized Harmonic number-generating function for each
@@ -602,15 +613,15 @@ class euler(Function):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Euler_numbers
-    * http://mathworld.wolfram.com/EulerNumber.html
-    * http://en.wikipedia.org/wiki/Alternating_permutation
-    * http://mathworld.wolfram.com/AlternatingPermutation.html
+    .. [1] http://en.wikipedia.org/wiki/Euler_numbers
+    .. [2] http://mathworld.wolfram.com/EulerNumber.html
+    .. [3] http://en.wikipedia.org/wiki/Alternating_permutation
+    .. [4] http://mathworld.wolfram.com/AlternatingPermutation.html
 
     See Also
     ========
 
-    bernoulli, bell
+    bell, bernoulli, catalan, fibonacci, harmonic, lucas
     """
 
     nargs = 1
@@ -726,13 +737,15 @@ class catalan(Function):
     References
     ==========
 
-    * http://en.wikipedia.org/wiki/Catalan_number
-    * http://mathworld.wolfram.com/CatalanNumber.html
-    * http://geometer.org/mathcircles/catalan.pdf
+    .. [1] http://en.wikipedia.org/wiki/Catalan_number
+    .. [2] http://mathworld.wolfram.com/CatalanNumber.html
+    .. [3] http://functions.wolfram.com/GammaBetaErf/CatalanNumber/
+    .. [4] http://geometer.org/mathcircles/catalan.pdf
 
     See Also
     ========
 
+    bell, bernoulli, euler, fibonacci, harmonic, lucas
     sympy.functions.combinatorial.factorials.binomial
     """
 

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -1,7 +1,7 @@
-from sympy import (bernoulli, Symbol, symbols, Sum, harmonic, Rational, oo,
-    zoo, pi, I, bell, fibonacci, lucas, euler, catalan,
-    binomial, gamma, sqrt, hyper, log, digamma, trigamma, polygamma, diff,
-    Expr, sympify, expand_func, EulerGamma, factorial)
+from sympy import (bernoulli, Symbol, symbols, Dummy, Sum, harmonic, Rational, oo,
+    zoo, pi, I, bell, fibonacci, lucas, euler, catalan, binomial, gamma, sqrt,
+    hyper, log, digamma, trigamma, polygamma, diff, Expr, sympify, expand_func,
+    EulerGamma, factorial)
 
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -99,6 +99,10 @@ def test_harmonic():
     assert expand_func(harmonic(n-4)) == harmonic(n) - 1/(n - 1) - 1/(n - 2) - 1/(n - 3) - 1/n
 
     assert harmonic(n, m).rewrite("tractable") == harmonic(n, m).rewrite(polygamma)
+
+    _k = Dummy("k")
+    assert harmonic(n).rewrite(Sum) == Sum(1/_k, (_k, 1, n))
+    assert harmonic(n, m).rewrite(Sum) == Sum(_k**(-m), (_k, 1, n))
 
 
 def test_euler():

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -85,6 +85,9 @@ def test_harmonic():
     assert harmonic(oo, 1) == zoo
     assert harmonic(oo, 2) == (pi**2)/6
 
+
+@XFAIL
+def test_harmonic_rewrite_sum():
     n = Symbol("n")
     m = Symbol("m")
 

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -86,14 +86,21 @@ def test_harmonic():
     assert harmonic(oo, 2) == (pi**2)/6
 
 
-@XFAIL
+def replace_dummy(expr, sym):
+    dum = expr.atoms(Dummy)
+    if not dum:
+        return expr
+    assert len(dum) == 1
+    return expr.xreplace({dum.pop(): sym})
+
+
 def test_harmonic_rewrite_sum():
     n = Symbol("n")
     m = Symbol("m")
 
     _k = Dummy("k")
-    assert harmonic(n).rewrite(Sum) == Sum(1/_k, (_k, 1, n))
-    assert harmonic(n, m).rewrite(Sum) == Sum(_k**(-m), (_k, 1, n))
+    assert replace_dummy(harmonic(n).rewrite(Sum), _k) == Sum(1/_k, (_k, 1, n))
+    assert replace_dummy(harmonic(n, m).rewrite(Sum), _k) == Sum(_k**(-m), (_k, 1, n))
 
 
 @XFAIL

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -85,6 +85,13 @@ def test_harmonic():
     assert harmonic(oo, 1) == zoo
     assert harmonic(oo, 2) == (pi**2)/6
 
+    n = Symbol("n")
+    m = Symbol("m")
+
+    _k = Dummy("k")
+    assert harmonic(n).rewrite(Sum) == Sum(1/_k, (_k, 1, n))
+    assert harmonic(n, m).rewrite(Sum) == Sum(_k**(-m), (_k, 1, n))
+
 
 @XFAIL
 def test_harmonic_rewrite_sum():


### PR DESCRIPTION
Rewrite of harmonic numbers into symbolic sums:

```
In [4]: harmonic(n)
Out[4]: harmonic(n)

In [5]: _.rewrite(Sum)
Out[5]: Sum(1/_k, (_k, 1, n))

In [6]: pprint(_)
  n    
 ____  
 ╲     
  ╲   1
   ╲  ─
   ╱  k
  ╱    
 ╱     
 ‾‾‾‾  
k = 1  

In [7]: _.subs(n, 10)
Out[7]: Sum(1/_k, (_k, 1, 10))

In [8]: _.doit()
Out[8]: 7381/2520
```
