### PR TITLE
Added support for rational inequalities (#3528, #3448)

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -7,7 +7,7 @@ from sympy.core.singleton import S
 from sympy.assumptions import ask, AppliedPredicate, Q
 from sympy.functions import re, im, Abs
 from sympy.logic import And
-from sympy.polys import Poly
+from sympy.polys import Poly, PolynomialError, parallel_poly_from_expr
 
 
 def solve_poly_inequality(poly, rel):
@@ -90,22 +90,24 @@ def solve_poly_inequality(poly, rel):
     return intervals
 
 
-def solve_poly_inequalities(polys):
-    """Solve a system of polynomial inequalities with rational coefficients.
+def solve_rational_inequalities(eqs):
+    """Solve a system of rational inequalities with rational coefficients.
 
     Examples
     ========
 
     >>> from sympy.abc import x
     >>> from sympy import Poly
-    >>> from sympy.solvers.inequalities import solve_poly_inequalities
+    >>> from sympy.solvers.inequalities import solve_rational_inequalities
 
-    >>> solve_poly_inequalities([[(Poly(-x + 1, x, domain='ZZ'), '>='),
-    ... (Poly(-x + 1, x, domain='ZZ'), '<=')]])
+    >>> solve_rational_inequalities([[
+    ... ((Poly(-x + 1), Poly(1, x)), '>='),
+    ... ((Poly(-x + 1), Poly(1, x)), '<=')]])
     {1}
 
-    >>> solve_poly_inequalities([[(Poly(x, x, domain='ZZ'), '!='),
-    ... (Poly(-x + 1, x, domain='ZZ'), '>=')]])
+    >>> solve_rational_inequalities([[
+    ... ((Poly(x), Poly(1, x)), '!='),
+    ... ((Poly(-x + 1), Poly(1, x)), '>=')]])
     (-oo, 0) U (0, 1]
 
     See Also
@@ -114,25 +116,37 @@ def solve_poly_inequalities(polys):
     """
     result = S.EmptySet
 
-    for _polys in polys:
+    for _eqs in eqs:
         global_intervals = None
 
-        for poly, rel in _polys:
-            local_intervals = solve_poly_inequality(poly, rel)
+        for (numer, denom), rel in _eqs:
+            numer_intervals = solve_poly_inequality(numer*denom, rel)
+            denom_intervals = solve_poly_inequality(denom, '==')
 
             if global_intervals is None:
-                global_intervals = local_intervals
+                global_intervals = numer_intervals
             else:
                 intervals = []
 
-                for local_interval in local_intervals:
+                for numer_interval in numer_intervals:
                     for global_interval in global_intervals:
-                        interval = local_interval.intersect(global_interval)
+                        interval = numer_interval.intersect(global_interval)
 
                         if interval is not S.EmptySet:
                             intervals.append(interval)
 
                 global_intervals = intervals
+
+            intervals = []
+
+            for global_interval in global_intervals:
+                for denom_interval in denom_intervals:
+                    global_interval -= denom_interval
+
+                if global_interval is not S.EmptySet:
+                    intervals.append(global_interval)
+
+            global_intervals = intervals
 
             if not global_intervals:
                 break
@@ -143,28 +157,28 @@ def solve_poly_inequalities(polys):
     return result
 
 
-def reduce_poly_inequalities(exprs, gen, assume=True, relational=True):
-    """Reduce a system of polynomial inequalities with rational coefficients.
+def reduce_rational_inequalities(exprs, gen, assume=True, relational=True):
+    """Reduce a system of rational inequalities with rational coefficients.
 
     Examples
     ========
 
     >>> from sympy import Poly, Symbol
-    >>> from sympy.solvers.inequalities import reduce_poly_inequalities
+    >>> from sympy.solvers.inequalities import reduce_rational_inequalities
 
     >>> x = Symbol('x', real=True)
 
-    >>> reduce_poly_inequalities([[x**2 <= 0]], x)
+    >>> reduce_rational_inequalities([[x**2 <= 0]], x)
     x == 0
 
-    >>> reduce_poly_inequalities([[x + 2 > 0]], x)
+    >>> reduce_rational_inequalities([[x + 2 > 0]], x)
     -2 < x
     """
     exact = True
-    polys = []
+    eqs = []
 
     for _exprs in exprs:
-        _polys = []
+        _eqs = []
 
         for expr in _exprs:
             if isinstance(expr, tuple):
@@ -175,22 +189,24 @@ def reduce_poly_inequalities(exprs, gen, assume=True, relational=True):
                 else:
                     expr, rel = expr, '=='
 
-            poly = Poly(expr, gen)
+            try:
+                (numer, denom), opt = parallel_poly_from_expr(expr.together().as_numer_denom(), gen)
+            except PolynomialError:
+                raise PolynomialError("only polynomials and rational functions are supported in this context")
 
-            if not poly.get_domain().is_Exact:
-                poly, exact = poly.to_exact(), False
+            if not opt.domain.is_Exact:
+                numer, denom, exact = numer.to_exact(), denom.to_exact(), False
 
-            domain = poly.get_domain()
+            domain = opt.domain.get_exact()
 
             if not (domain.is_ZZ or domain.is_QQ):
-                raise NotImplementedError(
-                    "inequality solving is not supported over %s" % domain)
+                raise NotImplementedError("inequality solving is not supported over %s" % opt.domain)
 
-            _polys.append((poly, rel))
+            _eqs.append(((numer, denom), rel))
 
-        polys.append(_polys)
+        eqs.append(_eqs)
 
-    solution = solve_poly_inequalities(polys)
+    solution = solve_rational_inequalities(eqs)
 
     if not exact:
         solution = solution.evalf()
@@ -285,7 +301,7 @@ def reduce_abs_inequality(expr, rel, gen, assume=True):
 
         inequalities.append([expr] + conds)
 
-    return reduce_poly_inequalities(inequalities, gen, assume)
+    return reduce_rational_inequalities(inequalities, gen, assume)
 
 
 def reduce_abs_inequalities(exprs, gen, assume=True):
@@ -316,11 +332,13 @@ def reduce_abs_inequalities(exprs, gen, assume=True):
 def _solve_inequality(ie, s):
     """ A hacky replacement for solve, since the latter only works for
         univariate inequalities. """
-    from sympy import Poly
     if not ie.rel_op in ('>', '>=', '<', '<='):
         raise NotImplementedError
     expr = ie.lhs - ie.rhs
-    p = Poly(expr, s)
+    try:
+        p = Poly(expr, s)
+    except PolynomialError:
+        raise NotImplementedError
     if p.degree() != 1:
         raise NotImplementedError('%s' % ie)
     a, b = p.all_coeffs()
@@ -413,7 +431,7 @@ def reduce_inequalities(inequalities, assume=True, symbols=[]):
     abs_reduced = []
 
     for gen, exprs in poly_part.iteritems():
-        poly_reduced.append(reduce_poly_inequalities([exprs], gen, assume))
+        poly_reduced.append(reduce_rational_inequalities([exprs], gen, assume))
 
     for gen, exprs in abs_part.iteritems():
         abs_reduced.append(reduce_abs_inequalities(exprs, gen, assume))

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -5,7 +5,7 @@ from sympy import (And, Eq, FiniteSet, Ge, Gt, im, Interval, Le, Lt, Ne, oo,
 from sympy.assumptions import assuming
 from sympy.abc import x, y
 from sympy.solvers.inequalities import (reduce_inequalities,
-                                        reduce_poly_inequalities)
+                                        reduce_rational_inequalities)
 from sympy.utilities.pytest import raises
 
 inf = oo.evalf()
@@ -13,121 +13,151 @@ inf = oo.evalf()
 
 def test_reduce_poly_inequalities_real_interval():
     with assuming(Q.real(x), Q.real(y)):
-
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Eq(x**2, 0)]], x, relational=False) == FiniteSet(0)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Le(x**2, 0)]], x, relational=False) == FiniteSet(0)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Lt(x**2, 0)]], x, relational=False) == S.EmptySet
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ge(x**2, 0)]], x, relational=False) == Interval(-oo, oo)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Gt(x**2, 0)]], x, relational=False) == FiniteSet(0).complement
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ne(x**2, 0)]], x, relational=False) == FiniteSet(0).complement
 
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Eq(x**2, 1)]], x, relational=False) == FiniteSet(-1, 1)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Le(x**2, 1)]], x, relational=False) == Interval(-1, 1)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Lt(x**2, 1)]], x, relational=False) == Interval(-1, 1, True, True)
-        assert reduce_poly_inequalities([[Ge(x**2, 1)]], x, relational=False) == Union(Interval(-oo, -1), Interval(1, oo))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities([[Ge(x**2, 1)]], x, relational=False) == Union(Interval(-oo, -1), Interval(1, oo))
+        assert reduce_rational_inequalities(
             [[Gt(x**2, 1)]], x, relational=False) == Interval(-1, 1).complement
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ne(x**2, 1)]], x, relational=False) == FiniteSet(-1, 1).complement
-        assert reduce_poly_inequalities([[Eq(
+        assert reduce_rational_inequalities([[Eq(
             x**2, 1.0)]], x, relational=False) == FiniteSet(-1.0, 1.0).evalf()
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Le(x**2, 1.0)]], x, relational=False) == Interval(-1.0, 1.0)
-        assert reduce_poly_inequalities([[Lt(
+        assert reduce_rational_inequalities([[Lt(
             x**2, 1.0)]], x, relational=False) == Interval(-1.0, 1.0, True, True)
-        assert reduce_poly_inequalities([[Ge(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0), Interval(1.0, inf))
-        assert reduce_poly_inequalities([[Gt(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0, right_open=True), Interval(1.0, inf, left_open=True))
-        assert reduce_poly_inequalities([[Ne(
+        assert reduce_rational_inequalities([[Ge(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0), Interval(1.0, inf))
+        assert reduce_rational_inequalities([[Gt(x**2, 1.0)]], x, relational=False) == Union(Interval(-inf, -1.0, right_open=True), Interval(1.0, inf, left_open=True))
+        assert reduce_rational_inequalities([[Ne(
             x**2, 1.0)]], x, relational=False) == FiniteSet(-1.0, 1.0).complement
 
         s = sqrt(2)
 
-        assert reduce_poly_inequalities([[Lt(
+        assert reduce_rational_inequalities([[Lt(
             x**2 - 1, 0), Gt(x**2 - 1, 0)]], x, relational=False) == S.EmptySet
-        assert reduce_poly_inequalities([[Le(x**2 - 1, 0), Ge(
+        assert reduce_rational_inequalities([[Le(x**2 - 1, 0), Ge(
             x**2 - 1, 0)]], x, relational=False) == FiniteSet(-1, 1)
-        assert reduce_poly_inequalities([[Le(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, False), Interval(1, s, False, False))
-        assert reduce_poly_inequalities([[Le(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, True), Interval(1, s, True, False))
-        assert reduce_poly_inequalities([[Lt(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, False), Interval(1, s, False, True))
-        assert reduce_poly_inequalities([[Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(1, s, True, True))
-        assert reduce_poly_inequalities([[Lt(x**2 - 2, 0), Ne(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(-1, 1, True, True), Interval(1, s, True, True))
+        assert reduce_rational_inequalities([[Le(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, False), Interval(1, s, False, False))
+        assert reduce_rational_inequalities([[Le(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, False, True), Interval(1, s, True, False))
+        assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Ge(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, False), Interval(1, s, False, True))
+        assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Gt(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(1, s, True, True))
+        assert reduce_rational_inequalities([[Lt(x**2 - 2, 0), Ne(x**2 - 1, 0)]], x, relational=False) == Union(Interval(-s, -1, True, True), Interval(-1, 1, True, True), Interval(1, s, True, True))
 
 
 
 def test_reduce_poly_inequalities_real_relational():
     with assuming(Q.real(x), Q.real(y)):
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Eq(x**2, 0)]], x, relational=True) == Eq(x, 0)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Le(x**2, 0)]], x, relational=True) == Eq(x, 0)
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Lt(x**2, 0)]], x, relational=True) is False
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ge(x**2, 0)]], x, relational=True) is True
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Gt(x**2, 0)]], x, relational=True) == Or(Lt(x, 0), Lt(0, x))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ne(x**2, 0)]], x, relational=True) == Or(Lt(x, 0), Lt(0, x))
 
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Eq(x**2, 1)]], x, relational=True) == Or(Eq(x, -1), Eq(x, 1))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Le(x**2, 1)]], x, relational=True) == And(Le(-1, x), Le(x, 1))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Lt(x**2, 1)]], x, relational=True) == And(Lt(-1, x), Lt(x, 1))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ge(x**2, 1)]], x, relational=True) == Or(Le(x, -1), Le(1, x))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Gt(x**2, 1)]], x, relational=True) == Or(Lt(x, -1), Lt(1, x))
-        assert reduce_poly_inequalities([[Ne(x**2, 1)]], x, relational=True) == Or(
+        assert reduce_rational_inequalities([[Ne(x**2, 1)]], x, relational=True) == Or(
             Lt(x, -1), And(Lt(-1, x), Lt(x, 1)), Lt(1, x))
 
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Le(x**2, 1.0)]], x, relational=True) == And(Le(-1.0, x), Le(x, 1.0))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Lt(x**2, 1.0)]], x, relational=True) == And(Lt(-1.0, x), Lt(x, 1.0))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Ge(x**2, 1.0)]], x, relational=True) == Or(Le(x, -1.0), Le(1.0, x))
-        assert reduce_poly_inequalities(
+        assert reduce_rational_inequalities(
             [[Gt(x**2, 1.0)]], x, relational=True) == Or(Lt(x, -1.0), Lt(1.0, x))
-        assert reduce_poly_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == Or(Lt(x, -1.0), And(Lt(-1.0, x), Lt(x, 1.0)), Lt(1.0, x))
+        assert reduce_rational_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == Or(Lt(x, -1.0), And(Lt(-1.0, x), Lt(x, 1.0)), Lt(1.0, x))
 
 
 def test_reduce_poly_inequalities_complex_relational():
     cond = Eq(im(x), 0)
 
-    assert reduce_poly_inequalities(
+    assert reduce_rational_inequalities(
         [[Eq(x**2, 0)]], x, relational=True) == And(Eq(re(x), 0), cond)
-    assert reduce_poly_inequalities(
+    assert reduce_rational_inequalities(
         [[Le(x**2, 0)]], x, relational=True) == And(Eq(re(x), 0), cond)
-    assert reduce_poly_inequalities(
+    assert reduce_rational_inequalities(
         [[Lt(x**2, 0)]], x, relational=True) is False
-    assert reduce_poly_inequalities(
+    assert reduce_rational_inequalities(
         [[Ge(x**2, 0)]], x, relational=True) == cond
-    assert reduce_poly_inequalities([[Gt(x**2, 0)]], x, relational=True) == And(Or(Lt(re(x), 0), Lt(0, re(x))), cond)
-    assert reduce_poly_inequalities([[Ne(x**2, 0)]], x, relational=True) == And(Or(Lt(re(x), 0), Lt(0, re(x))), cond)
+    assert reduce_rational_inequalities([[Gt(x**2, 0)]], x, relational=True) == And(Or(Lt(re(x), 0), Lt(0, re(x))), cond)
+    assert reduce_rational_inequalities([[Ne(x**2, 0)]], x, relational=True) == And(Or(Lt(re(x), 0), Lt(0, re(x))), cond)
 
-    assert reduce_poly_inequalities([[Eq(x**2, 1)]], x, relational=True) == And(Or(Eq(re(x), -1), Eq(re(x), 1)), cond)
-    assert reduce_poly_inequalities([[Le(x**2, 1)]], x, relational=True) == And(And(Le(-1, re(x)), Le(re(x), 1)), cond)
-    assert reduce_poly_inequalities([[Lt(x**2, 1)]], x, relational=True) == And(And(Lt(-1, re(x)), Lt(re(x), 1)), cond)
-    assert reduce_poly_inequalities([[Ge(x**2, 1)]], x, relational=True) == And(Or(Le(re(x), -1), Le(1, re(x))), cond)
-    assert reduce_poly_inequalities([[Gt(x**2, 1)]], x, relational=True) == And(Or(Lt(re(x), -1), Lt(1, re(x))), cond)
-    assert reduce_poly_inequalities([[Ne(x**2, 1)]], x, relational=True) == And(Or(Lt(re(x), -1), And(Lt(-1, re(x)), Lt(re(x), 1)), Lt(1, re(x))), cond)
+    assert reduce_rational_inequalities([[Eq(x**2, 1)]], x, relational=True) == And(Or(Eq(re(x), -1), Eq(re(x), 1)), cond)
+    assert reduce_rational_inequalities([[Le(x**2, 1)]], x, relational=True) == And(And(Le(-1, re(x)), Le(re(x), 1)), cond)
+    assert reduce_rational_inequalities([[Lt(x**2, 1)]], x, relational=True) == And(And(Lt(-1, re(x)), Lt(re(x), 1)), cond)
+    assert reduce_rational_inequalities([[Ge(x**2, 1)]], x, relational=True) == And(Or(Le(re(x), -1), Le(1, re(x))), cond)
+    assert reduce_rational_inequalities([[Gt(x**2, 1)]], x, relational=True) == And(Or(Lt(re(x), -1), Lt(1, re(x))), cond)
+    assert reduce_rational_inequalities([[Ne(x**2, 1)]], x, relational=True) == And(Or(Lt(re(x), -1), And(Lt(-1, re(x)), Lt(re(x), 1)), Lt(1, re(x))), cond)
 
-    assert reduce_poly_inequalities([[Le(x**2, 1.0)]], x, relational=True) == And(And(Le(-1.0, re(x)), Le(re(x), 1.0)), cond)
-    assert reduce_poly_inequalities([[Lt(x**2, 1.0)]], x, relational=True) == And(And(Lt(-1.0, re(x)), Lt(re(x), 1.0)), cond)
-    assert reduce_poly_inequalities([[Ge(x**2, 1.0)]], x, relational=True) == And(Or(Le(re(x), -1.0), Le(1.0, re(x))), cond)
-    assert reduce_poly_inequalities([[Gt(x**2, 1.0)]], x, relational=True) == And(Or(Lt(re(x), -1.0), Lt(1.0, re(x))), cond)
-    assert reduce_poly_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == And(Or(Lt(re(x), -1.0), And(Lt(-1.0, re(x)), Lt(re(x), 1.0)), Lt(1.0, re(x))), cond)
+    assert reduce_rational_inequalities([[Le(x**2, 1.0)]], x, relational=True) == And(And(Le(-1.0, re(x)), Le(re(x), 1.0)), cond)
+    assert reduce_rational_inequalities([[Lt(x**2, 1.0)]], x, relational=True) == And(And(Lt(-1.0, re(x)), Lt(re(x), 1.0)), cond)
+    assert reduce_rational_inequalities([[Ge(x**2, 1.0)]], x, relational=True) == And(Or(Le(re(x), -1.0), Le(1.0, re(x))), cond)
+    assert reduce_rational_inequalities([[Gt(x**2, 1.0)]], x, relational=True) == And(Or(Lt(re(x), -1.0), Lt(1.0, re(x))), cond)
+    assert reduce_rational_inequalities([[Ne(x**2, 1.0)]], x, relational=True) == And(Or(Lt(re(x), -1.0), And(Lt(-1.0, re(x)), Lt(re(x), 1.0)), Lt(1.0, re(x))), cond)
+
+
+def test_reduce_rational_inequalities_real_relational():
+    def OpenInterval(a, b):
+        return Interval(a, b, True, True)
+    def LeftOpenInterval(a, b):
+        return Interval(a, b, True, False)
+    def RightOpenInterval(a, b):
+        return Interval(a, b, False, True)
+
+    with assuming(Q.real(x)):
+        assert reduce_rational_inequalities([[(x**2 + 3*x + 2)/(x**2 - 16) >= 0]], x, relational=False) == \
+            Union(OpenInterval(-oo, -4), Interval(-2, -1), OpenInterval(4, oo))
+
+        assert reduce_rational_inequalities([[((-2*x - 10)*(3 - x))/((x**2 + 5)*(x - 2)**2) < 0]], x, relational=False) == \
+            Union(OpenInterval(-5, 2), OpenInterval(2, 3))
+
+        assert reduce_rational_inequalities([[(x + 1)/(x - 5) <= 0]], x, assume=Q.real(x), relational=False) == \
+            RightOpenInterval(-1, 5)
+
+        assert reduce_rational_inequalities([[(x**2 + 4*x + 3)/(x - 1) > 0]], x, assume=Q.real(x), relational=False) == \
+            Union(OpenInterval(-3, -1), OpenInterval(1, oo))
+
+        assert reduce_rational_inequalities([[(x**2 - 16)/(x - 1)**2 < 0]], x, assume=Q.real(x), relational=False) == \
+            Union(OpenInterval(-4, 1), OpenInterval(1, 4))
+
+        assert reduce_rational_inequalities([[(3*x + 1)/(x + 4) >= 1]], x, assume=Q.real(x), relational=False) == \
+            Union(OpenInterval(-oo, -4), RightOpenInterval(S(3)/2, oo))
+
+        assert reduce_rational_inequalities([[(x - 8)/x <= 3 - x]], x, assume=Q.real(x), relational=False) == \
+            Union(LeftOpenInterval(-oo, -2), LeftOpenInterval(0, 4))
 
 
 def test_reduce_abs_inequalities():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -440,6 +440,9 @@ def test_solve_inequalities():
     assert solve(system, assume=Q.real(x)) == \
         Or(And(Lt(-sqrt(2), x), Lt(x, -1)), And(Lt(1, x), Lt(x, sqrt(2))))
 
+    # issue 3528, 3448
+    assert solve((x - 3)/(x - 2) < 0, x, assume=Q.real(x)) == And(Lt(2, x), Lt(x, 3))
+    assert solve(x/(x + 1) > 1, x, assume=Q.real(x)) == Lt(x, -1)
 
 def test_issue_1694():
     assert solve(1/x) == []

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -14,8 +14,8 @@ from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain,
 from sympy.functions.special.delta_functions import DiracDelta
 from sympy import (S, Interval, symbols, sympify, Dummy, FiniteSet, Mul, Tuple,
         Integral, And, Or, Piecewise, solve, cacheit, integrate, oo, Lambda,
-        Basic, Symbol)
-from sympy.solvers.inequalities import reduce_poly_inequalities
+        Basic)
+from sympy.solvers.inequalities import reduce_rational_inequalities
 from sympy.polys.polyerrors import PolynomialError
 import random
 
@@ -112,7 +112,7 @@ class ConditionalContinuousDomain(ContinuousDomain, ConditionalDomain):
                     for i, limit in enumerate(limits):
                         if limit[0] == symbol:
                             # Make condition into an Interval like [0, oo]
-                            cintvl = reduce_poly_inequalities_wrap(
+                            cintvl = reduce_rational_inequalities_wrap(
                                 cond, symbol)
                             # Make limit into an Interval like [-oo, oo]
                             lintvl = Interval(limit[1], limit[2])
@@ -135,7 +135,7 @@ class ConditionalContinuousDomain(ContinuousDomain, ConditionalDomain):
     @property
     def set(self):
         if len(self.symbols) == 1:
-            return (self.fulldomain.set & reduce_poly_inequalities_wrap(
+            return (self.fulldomain.set & reduce_rational_inequalities_wrap(
                 self.condition, tuple(self.symbols)[0]))
         else:
             raise NotImplementedError(
@@ -324,7 +324,7 @@ class ContinuousPSpace(PSpace):
             raise NotImplementedError(
                 "Multiple continuous random variables not supported")
         rv = tuple(rvs)[0]
-        interval = reduce_poly_inequalities_wrap(condition, rv)
+        interval = reduce_rational_inequalities_wrap(condition, rv)
         interval = interval.intersect(self.domain.set)
         return SingleContinuousDomain(rv.symbol, interval)
 
@@ -400,12 +400,12 @@ class ProductContinuousPSpace(ProductPSpace, ContinuousPSpace):
 
 def _reduce_inequalities(conditions, var, **kwargs):
     try:
-        return reduce_poly_inequalities(conditions, var, **kwargs)
+        return reduce_rational_inequalities(conditions, var, **kwargs)
     except PolynomialError:
         raise ValueError("Reduction of condition failed %s\n" % conditions[0])
 
 
-def reduce_poly_inequalities_wrap(condition, var):
+def reduce_rational_inequalities_wrap(condition, var):
     if condition.is_Relational:
         return _reduce_inequalities([[condition]], var, relational=False)
     if condition.__class__ is Or:


### PR DESCRIPTION
In [1]: from sympy.solvers.inequalities import *

In [2]: reduce_rational_inequalities([[(x**2 + 3*x + 2)/(x**2 - 16) >= 0]], x, assume=Q.real(x), relational=False)
Out[2]: (-∞, -4) ∪ [-2, -1] ∪ (4, ∞)

In [3]: solve((3*x + 1)/(x + 4) >= 1, x, assume=Q.real(x))
Out[3]: 3/2 ≤ x ∨ x < -4
