### PR TITLE
DONE: Remove the default "recursive __call__".

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -82,7 +82,12 @@ class Expr(Basic, EvalfMixin):
 
         ``(x+Lambda(y, 2*y))(z) == x+2*z``,
 
-        however you can use ``(x+Lambda(y, 2*y)).rcall(z) == x+2*z``.
+        however you can use
+
+        >>> from sympy import Lambda
+        >>> from sympy.abc import x,y,z
+        >>> (x + Lambda(y, 2*y)).rcall(z)
+        x + 2*z
         """
         return Expr._recursive_call(self, args)
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -74,8 +74,16 @@ class Expr(Basic, EvalfMixin):
 
         return expr.class_key(), args, exp, coeff
 
-    def __call__(self, *args):
-        # (x+Lambda(y, 2*y))(z) -> x+2*z
+    def rcall(self, *args):
+        """Apply on the argument recursively through the expression tree.
+
+        This method is used to simulate a common abuse of notation for
+        operators. For instance in SymPy the the following will not work:
+
+        ``(x+Lambda(y, 2*y))(z) == x+2*z``,
+
+        however you can use ``(x+Lambda(y, 2*y)).rcall(z) == x+2*z``.
+        """
         return Expr._recursive_call(self, args)
 
     @staticmethod

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -942,8 +942,7 @@ class Pow(Expr):
                 res = []
                 for arg in bs.args:
                     if arg.is_Order:
-                        arg = arg.expr()
-                        arg = c*arg
+                        arg = c*arg.expr
                     res.append(arg)
                 bs = Add(*res)
                 rv = (bs**e).series(x).subs(c, O(1))

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -579,14 +579,17 @@ def test_as_independent():
 def test_call():
     # See the long history of this in issues 1927 and 2006.
 
+    raises(TypeError, lambda: sin(x)({ x : 1, sin(x) : 2}))
+    raises(TypeError, lambda: sin(x)(1))
+
     # No effect as there are no callables
-    assert sin(x)(1) == sin(x)
-    assert (1 + sin(x))(1) == 1 + sin(x)
+    assert sin(x).rcall(1) == sin(x)
+    assert (1 + sin(x)).rcall(1) == 1 + sin(x)
 
     # Effect in the pressence of callables
     l = Lambda(x, 2*x)
-    assert (l + x)(y) == 2*y + x
-    assert (x**l)(2) == x**4
+    assert (l + x).rcall(y) == 2*y + x
+    assert (x**l).rcall(2) == x**4
     # TODO UndefinedFunction does not subclass Expr
     #f = Function('f')
     #assert (2*f)(x) == 2*f(x)

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -134,15 +134,15 @@ class CoordSystem(Basic):
 
     >>> v_x = rect.base_vector(0)
     >>> x = rect.coord_function(0)
-    >>> v_x(x)(p)
+    >>> v_x(x)
     1
-    >>> v_x(v_x(x))(p)
+    >>> v_x(v_x(x))
     0
 
     Define a basis oneform field:
 
     >>> dx = rect.base_oneform(0)
-    >>> dx(v_x)(p)
+    >>> dx(v_x)
     1
 
     If you provide a list of names the fields will print nicely:
@@ -427,13 +427,13 @@ class BaseScalarField(Expr):
 
     >>> fx = BaseScalarField(rect, 0)
     >>> fy = BaseScalarField(rect, 1)
-    >>> (fx**2+fy**2)(point)
+    >>> (fx**2+fy**2).rcall(point)
     r0**2
 
     >>> g = Function('g')
     >>> ftheta = BaseScalarField(polar, 1)
     >>> fg = g(ftheta-pi)
-    >>> fg(point)
+    >>> fg.rcall(point)
     g(-pi)
 
     """
@@ -503,9 +503,9 @@ class BaseVectorField(Expr):
 
     >>> g = Function('g')
     >>> s_field = g(R2.x, R2.y)
-    >>> s_field(point_r)
+    >>> s_field.rcall(point_r)
     g(x0, y0)
-    >>> s_field(point_p)
+    >>> s_field.rcall(point_p)
     g(r0*cos(theta0), r0*sin(theta0))
 
     Vector field:
@@ -515,11 +515,11 @@ class BaseVectorField(Expr):
     /  d              \|
     |-----(g(x, xi_2))||
     \dxi_2            /|xi_2=y
-    >>> pprint(v(s_field)(point_r).doit())
+    >>> pprint(v(s_field).rcall(point_r).doit())
      d
     ---(g(x0, y0))
     dy0
-    >>> pprint(v(s_field)(point_p).doit())
+    >>> pprint(v(s_field).rcall(point_p).doit())
     /  d                           \|
     |-----(g(r0*cos(theta0), xi_2))||
     \dxi_2                         /|xi_2=r0*sin(theta0)
@@ -727,7 +727,7 @@ class Differential(Expr):
         k = len(vector_fields)
         if k == 1:
             if vector_fields[0]:
-                return vector_fields[0](self._form_field)
+                return vector_fields[0].rcall(self._form_field)
             return self
         else:
             # For higher form it is more complicated:
@@ -739,13 +739,13 @@ class Differential(Expr):
             v = vector_fields
             ret = 0
             for i in range(k):
-                t = v[i](f(*v[:i] + v[i + 1:]))
+                t = v[i].rcall(f.rcall(*v[:i] + v[i + 1:]))
                 ret += (-1)**i*t
                 for j in range(i + 1, k):
                     c = Commutator(v[i], v[j])
                     if c:  # TODO this is ugly - the Commutator can be Zero and
                           # this causes the next line to fail
-                        t = f(*(c,) + v[:i] + v[i + 1:j] + v[j + 1:])
+                        t = f.rcall(*(c,) + v[:i] + v[i + 1:j] + v[j + 1:])
                         ret += (-1)**(i + j)*t
             return ret
 
@@ -786,12 +786,12 @@ class TensorProduct(Expr):
 
     >>> TP = TensorProduct
     >>> metric = TP(R2.dx, R2.dx) + 3*TP(R2.dy, R2.dy)
-    >>> metric(R2.e_y, None)
+    >>> metric.rcall(R2.e_y, None)
     3*dy
 
     Or automatically pad the args with ``None``s.
 
-    >>> metric(R2.e_y)
+    >>> metric.rcall(R2.e_y)
     3*dy
 
     """
@@ -829,7 +829,7 @@ class TensorProduct(Expr):
         orders = [covariant_order(f) for f in self._args]
         indices = [sum(orders[:i + 1]) for i in range(len(orders) - 1)]
         v_fields = [v_fields[i:j] for i, j in zip([0] + indices, indices + [None])]
-        multipliers = [t[0](*t[1]) for t in zip(self._args, v_fields)]
+        multipliers = [t[0].rcall(*t[1]) for t in zip(self._args, v_fields)]
         return TensorProduct(*multipliers)
 
     def _latex(self, printer, *args):
@@ -904,7 +904,7 @@ class LieDerivative(Expr):
         if expr.atoms(BaseVectorField):
             return Commutator(v_field, expr)
         else:
-            return v_field(expr)
+            return v_field.rcall(expr)
 
     def __init__(self, v_field, expr):
         super(LieDerivative, self).__init__()
@@ -1023,7 +1023,7 @@ class CovarDerivativeOp(Expr):
         vectors = list(self._wrt.atoms(BaseVectorField))
         base_ops = [BaseCovarDerivativeOp(v._coord_sys, v._index, self._christoffel)
                     for v in vectors]
-        return self._wrt.subs(zip(vectors, base_ops))(field)
+        return self._wrt.subs(zip(vectors, base_ops)).rcall(field)
 
     def _latex(self, printer, *args):
         return r'\mathbb{\nabla}_{%s}' % printer._print(self._wrt)
@@ -1118,11 +1118,11 @@ def intcurve_series(vector_field, param, start_point, n=6, coord_sys=None, coeff
 
     def iter_vfield(scalar_field, i):
         """Return `vector_field` called `i` times on `scalar_field`."""
-        return reduce(lambda s, v: v(s), [vector_field, ]*i, scalar_field)
+        return reduce(lambda s, v: v.rcall(s), [vector_field, ]*i, scalar_field)
 
     def taylor_terms_per_coord(coord_function):
         """Return the series for one of the coordinates."""
-        return [param**i*iter_vfield(coord_function, i)(start_point)/factorial(i)
+        return [param**i*iter_vfield(coord_function, i).rcall(start_point)/factorial(i)
                 for i in range(n)]
     coord_sys = coord_sys if coord_sys else start_point._coord_sys
     coord_functions = coord_sys.coord_functions()
@@ -1205,9 +1205,9 @@ def intcurve_diffequ(vector_field, param, start_point, coord_sys=None):
         start_point._coord_sys.dim)]
     arbitrary_p = Point(coord_sys, gammas)
     coord_functions = coord_sys.coord_functions()
-    equations = [simplify(diff(cf(arbitrary_p), param) - vector_field(cf)(arbitrary_p))
+    equations = [simplify(diff(cf.rcall(arbitrary_p), param) - vector_field.rcall(cf).rcall(arbitrary_p))
                  for cf in coord_functions]
-    init_cond = [simplify(cf(arbitrary_p).subs(param, 0) - cf(start_point))
+    init_cond = [simplify(cf.rcall(arbitrary_p).subs(param, 0) - cf.rcall(start_point))
                  for cf in coord_functions]
     return equations, init_cond
 
@@ -1386,7 +1386,7 @@ def twoform_to_matrix(expr):
     coord_sys = coord_sys.pop()
     vectors = coord_sys.base_vectors()
     expr = expr.expand()
-    matrix_content = [[expr(v1, v2) for v1 in vectors]
+    matrix_content = [[expr.rcall(v1, v2) for v1 in vectors]
                       for v2 in vectors]
     return Matrix(matrix_content)
 

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -20,9 +20,9 @@ def test_R2():
     point_p = R2_p.point([r0, theta0])
 
     # r**2 = x**2 + y**2
-    assert (R2.r**2 - R2.x**2 - R2.y**2)(point_r) == 0
-    assert trigsimp( (R2.r**2 - R2.x**2 - R2.y**2)(point_p) ) == 0
-    assert trigsimp(R2.e_r(R2.x**2 + R2.y**2)(point_p).doit()) == 2*r0
+    assert (R2.r**2 - R2.x**2 - R2.y**2).rcall(point_r) == 0
+    assert trigsimp( (R2.r**2 - R2.x**2 - R2.y**2).rcall(point_p) ) == 0
+    assert trigsimp(R2.e_r(R2.x**2 + R2.y**2).rcall(point_p).doit()) == 2*r0
 
     # polar->rect->polar == Id
     a, b = symbols('a b', positive=True)
@@ -65,7 +65,7 @@ def test_commutator():
 def test_differential():
     xdy = R2.x*R2.dy
     dxdy = Differential(xdy)
-    assert xdy(None) == xdy
+    assert xdy.rcall(None) == xdy
     assert dxdy(R2.e_x, R2.e_y) == 1
     assert dxdy(R2.e_x, R2.x*R2.e_y) == R2.x
     assert Differential(dxdy) == 0

--- a/sympy/diffgeom/tests/test_function_diffgeom_book.py
+++ b/sympy/diffgeom/tests/test_function_diffgeom_book.py
@@ -32,8 +32,8 @@ def test_functional_diffgeom_ch2():
     field = f(R2.x, R2.y)
     p1_in_rect = R2_r.point([x0, y0])
     p1_in_polar = R2_p.point([sqrt(x0**2 + y0**2), atan2(y0, x0)])
-    assert field(p1_in_rect) == f(x0, y0)
-    assert field(p1_in_polar) == f(x0, y0)
+    assert field.rcall(p1_in_rect) == f(x0, y0)
+    assert field.rcall(p1_in_polar) == f(x0, y0)
 
     p_r = R2_r.point([x0, y0])
     p_p = R2_p.point([r0, theta0])
@@ -44,8 +44,8 @@ def test_functional_diffgeom_ch2():
     assert R2.theta(p_r) == atan2(y0, x0)
 
     h = R2.x*R2.r**2 + R2.y**3
-    assert h(p_r) == x0*(x0**2 + y0**2) + y0**3
-    assert h(p_p) == r0**3*sin(theta0)**3 + r0**3*cos(theta0)
+    assert h.rcall(p_r) == x0*(x0**2 + y0**2) + y0**3
+    assert h.rcall(p_p) == r0**3*sin(theta0)**3 + r0**3*cos(theta0)
 
 
 def test_functional_diffgeom_ch3():
@@ -58,13 +58,13 @@ def test_functional_diffgeom_ch3():
 
     s_field = f(R2.x, R2.y)
     v_field = b1(R2.x)*R2.e_x + b2(R2.y)*R2.e_y
-    assert v_field(s_field)(p_r).doit() == b1(
+    assert v_field.rcall(s_field).rcall(p_r).doit() == b1(
         x0)*Derivative(f(x0, y0), x0) + b2(y0)*Derivative(f(x0, y0), y0)
 
-    assert R2.e_x(R2.r**2)(p_r) == 2*x0
+    assert R2.e_x(R2.r**2).rcall(p_r) == 2*x0
     v = R2.e_x + 2*R2.e_y
     s = R2.r**2 + 3*R2.x
-    assert v(s)(p_r).doit() == 2*x0 + 4*y0 + 3
+    assert v.rcall(s).rcall(p_r).doit() == 2*x0 + 4*y0 + 3
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
     series = intcurve_series(circ, t, R2_r.point([1, 0]), coeffs=True)
@@ -86,31 +86,33 @@ def test_functional_diffgeom_ch4():
     p_p = R2_p.point([r0, theta0])
 
     f_field = b1(R2.x, R2.y)*R2.dx + b2(R2.x, R2.y)*R2.dy
-    assert f_field(R2.e_x)(p_r) == b1(x0, y0)
-    assert f_field(R2.e_y)(p_r) == b2(x0, y0)
+    assert f_field.rcall(R2.e_x).rcall(p_r) == b1(x0, y0)
+    assert f_field.rcall(R2.e_y).rcall(p_r) == b2(x0, y0)
 
     s_field_r = f(R2.x, R2.y)
     df = Differential(s_field_r)
-    assert df(R2.e_x)(p_r).doit() == Derivative(f(x0, y0), x0)
-    assert df(R2.e_y)(p_r).doit() == Derivative(f(x0, y0), y0)
+    assert df(R2.e_x).rcall(p_r).doit() == Derivative(f(x0, y0), x0)
+    assert df(R2.e_y).rcall(p_r).doit() == Derivative(f(x0, y0), y0)
 
     s_field_p = f(R2.r, R2.theta)
     df = Differential(s_field_p)
-    assert trigsimp(df(R2.e_x)(p_p).doit()) == cos(theta0)*Derivative(
+    assert trigsimp(df(R2.e_x).rcall(p_p).doit()) == cos(theta0)*Derivative(
         f(r0, theta0), r0) - sin(theta0)*Derivative(f(r0, theta0), theta0)/r0
-    assert trigsimp(df(R2.e_y)(p_p).doit()) == sin(theta0)*Derivative(
+    assert trigsimp(df(R2.e_y).rcall(p_p).doit()) == sin(theta0)*Derivative(
         f(r0, theta0), r0) + cos(theta0)*Derivative(f(r0, theta0), theta0)/r0
 
-    assert R2.dx(R2.e_x)(p_r) == 1
-    assert R2.dx(R2.e_y)(p_r) == 0
+    assert R2.dx(R2.e_x).rcall(p_r) == 1
+    assert R2.dx(R2.e_x) == 1
+    assert R2.dx(R2.e_y).rcall(p_r) == 0
+    assert R2.dx(R2.e_y) == 0
 
     circ = -R2.y*R2.e_x + R2.x*R2.e_y
-    assert R2.dx(circ)(p_r).doit() == -y0
-    assert R2.dy(circ)(p_r) == x0
-    assert R2.dr(circ)(p_r) == 0
-    assert simplify(R2.dtheta(circ)(p_r)) == 1
+    assert R2.dx(circ).rcall(p_r).doit() == -y0
+    assert R2.dy(circ).rcall(p_r) == x0
+    assert R2.dr(circ).rcall(p_r) == 0
+    assert simplify(R2.dtheta(circ).rcall(p_r)) == 1
 
-    assert (circ - R2.e_theta)(s_field_r)(p_r) == 0
+    assert (circ - R2.e_theta).rcall(s_field_r).rcall(p_r) == 0
 
 
 def test_functional_diffgeom_ch6():
@@ -139,4 +141,4 @@ def test_functional_diffgeom_ch6():
     dc = Differential(c_f)
     expr = dtheta - WedgeProduct(
         da, R3_r.dx) - WedgeProduct(db, R3_r.dy) - WedgeProduct(dc, R3_r.dz)
-    assert expr(R3_r.e_x, R3_r.e_y) == 0
+    assert expr.rcall(R3_r.e_x, R3_r.e_y) == 0

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -57,7 +57,7 @@ class RaisingOp(SHOOp):
         >>> from sympy.physics.quantum import Dagger
 
         >>> ad = RaisingOp('a')
-        >>> ad().rewrite('xp').doit()
+        >>> ad.rewrite('xp').doit()
         sqrt(2)*(m*omega*X - I*Px)/(2*sqrt(hbar)*sqrt(m*omega))
 
         >>> Dagger(ad)
@@ -185,7 +185,7 @@ class LoweringOp(SHOOp):
         >>> from sympy.physics.quantum import Dagger
 
         >>> a = LoweringOp('a')
-        >>> a().rewrite('xp').doit()
+        >>> a.rewrite('xp').doit()
         sqrt(2)*(m*omega*X + I*Px)/(2*sqrt(hbar)*sqrt(m*omega))
 
         >>> Dagger(a)
@@ -309,11 +309,11 @@ class NumberOp(SHOOp):
         >>> from sympy.physics.quantum.sho1d import NumberOp
 
         >>> N = NumberOp('N')
-        >>> N().rewrite('a').doit()
+        >>> N.rewrite('a').doit()
         RaisingOp(a)*a
-        >>> N().rewrite('xp').doit()
+        >>> N.rewrite('xp').doit()
         -1/2 + (m**2*omega**2*X**2 + Px**2)/(2*hbar*m*omega)
-        >>> N().rewrite('H').doit()
+        >>> N.rewrite('H').doit()
         -1/2 + H/(hbar*omega)
 
     Take the Commutator of the Number Operator with other Operators:
@@ -428,11 +428,11 @@ class Hamiltonian(SHOOp):
         >>> from sympy.physics.quantum.sho1d import Hamiltonian
 
         >>> H = Hamiltonian('H')
-        >>> H().rewrite('a').doit()
+        >>> H.rewrite('a').doit()
         hbar*omega*(1/2 + RaisingOp(a)*a)
-        >>> H().rewrite('xp').doit()
+        >>> H.rewrite('xp').doit()
         (m**2*omega**2*X**2 + Px**2)/(2*m)
-        >>> H().rewrite('N').doit()
+        >>> H.rewrite('N').doit()
         hbar*omega*(1/2 + N)
 
     Take the Commutator of the Hamiltonian and the Number Operator:

--- a/sympy/physics/quantum/tests/test_density.py
+++ b/sympy/physics/quantum/tests/test_density.py
@@ -205,8 +205,8 @@ def test_eval_trace():
     k1 = TestTimeDepKet(0, 0.5)
     k2 = TestTimeDepKet(0, 1)
     d = Density([k1, 0.5], [k2, 0.5])
-    assert d.doit() == (0.5 * OuterProduct(k1, k1.dual()) +
-                        0.5 * OuterProduct(k2, k2.dual()))
+    assert d.doit() == (0.5 * OuterProduct(k1, k1.dual) +
+                        0.5 * OuterProduct(k2, k2.dual))
 
     t = Tr(d)
     assert t.doit() == 1

--- a/sympy/physics/quantum/tests/test_sho1d.py
+++ b/sympy/physics/quantum/tests/test_sho1d.py
@@ -48,7 +48,7 @@ def test_RaisingOp():
     assert qapply(ad*k) == (sqrt(k.n + 1)*SHOKet(k.n + 1)).expand()
     assert qapply(ad*kz) == (sqrt(kz.n + 1)*SHOKet(kz.n + 1)).expand()
     assert qapply(ad*kf) == (sqrt(kf.n + 1)*SHOKet(kf.n + 1)).expand()
-    assert ad().rewrite('xp').doit() == \
+    assert ad.rewrite('xp').doit() == \
         (Integer(1)/sqrt(Integer(2)*hbar*m*omega))*(Integer(-1)*I*Px + m*omega*X)
     assert ad.hilbert_space == ComplexSpace(S.Infinity)
     for i in range(ndim - 1):
@@ -82,7 +82,7 @@ def test_LoweringOp():
     assert qapply(a*k) == (sqrt(k.n)*SHOKet(k.n-Integer(1))).expand()
     assert qapply(a*kz) == Integer(0)
     assert qapply(a*kf) == (sqrt(kf.n)*SHOKet(kf.n-Integer(1))).expand()
-    assert a().rewrite('xp').doit() == \
+    assert a.rewrite('xp').doit() == \
         (Integer(1)/sqrt(Integer(2)*hbar*m*omega))*(I*Px + m*omega*X)
     for i in range(ndim - 1):
         assert a_rep[i,i + 1] == sqrt(i + 1)
@@ -92,10 +92,10 @@ def test_NumberOp():
     assert Commutator(N, a).doit() == Integer(-1)*a
     assert Commutator(N, H).doit() == Integer(0)
     assert qapply(N*k) == (k.n*k).expand()
-    assert N().rewrite('a').doit() == ad*a
-    assert N().rewrite('xp').doit() == (Integer(1)/(Integer(2)*m*hbar*omega))*(
+    assert N.rewrite('a').doit() == ad*a
+    assert N.rewrite('xp').doit() == (Integer(1)/(Integer(2)*m*hbar*omega))*(
         Px**2 + (m*omega*X)**2) - Integer(1)/Integer(2)
-    assert N().rewrite('H').doit() == H/(hbar*omega) - Integer(1)/Integer(2)
+    assert N.rewrite('H').doit() == H/(hbar*omega) - Integer(1)/Integer(2)
     for i in range(ndim):
         assert N_rep[i,i] == i
     assert N_rep == ad_rep_sympy*a_rep
@@ -103,10 +103,10 @@ def test_NumberOp():
 def test_Hamiltonian():
     assert Commutator(H, N).doit() == Integer(0)
     assert qapply(H*k) == ((hbar*omega*(k.n + Integer(1)/Integer(2)))*k).expand()
-    assert H().rewrite('a').doit() == hbar*omega*(ad*a + Integer(1)/Integer(2))
-    assert H().rewrite('xp').doit() == \
+    assert H.rewrite('a').doit() == hbar*omega*(ad*a + Integer(1)/Integer(2))
+    assert H.rewrite('xp').doit() == \
         (Integer(1)/(Integer(2)*m))*(Px**2 + (m*omega*X)**2)
-    assert H().rewrite('N').doit() == hbar*omega*(N + Integer(1)/Integer(2))
+    assert H.rewrite('N').doit() == hbar*omega*(N + Integer(1)/Integer(2))
     for i in range(ndim):
         assert H_rep[i,i] == hbar*omega*(i + Integer(1)/Integer(2))
 


### PR DESCRIPTION
Now if one needs to use an expression as an operator, the `rcall` method should
be used. The use of the default `__call__` method was deemed too confusing for
novice users.

There are some failures in modules that I have not worked on. I can apply the change to them as well, and I will do it, I just want a quick confirmation by someone more knowledgeable.
