### PR TITLE
An attempt to fix #2969

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -925,6 +925,10 @@ class Pow(Expr):
                     'expecting numerical exponent but got %s' % ei)
 
             nuse = n - ei
+
+            if e.is_real and e > 0:
+                nuse = int(n/e)
+
             bs = b._eval_nseries(x, n=nuse, logx=logx)
             terms = bs.removeO()
             if terms.is_Add:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -926,8 +926,18 @@ class Pow(Expr):
 
             nuse = n - ei
 
-            if e.is_real and e > 0:
-                nuse = int(n/e)
+            if e.is_real and e.is_positive:
+                lt = b.as_leading_term(x)
+
+                # Try to correct nuse (= m) guess from:
+                # (lt + rest + O(x**m))**e =
+                # lt**e*(1 + rest/lt + O(x**m)/lt)**e =
+                # lt**e + ... + O(x**m)*lt**(e - 1) = ... + O(x**n)
+                try:
+                    cf = C.Order(lt, x).getn()
+                    nuse = ceiling(n - cf*(e - 1))
+                except NotImplementedError:
+                    pass
 
             bs = b._eval_nseries(x, n=nuse, logx=logx)
             terms = bs.removeO()

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -254,3 +254,18 @@ def test_issue_3109():
     assert sqrt(-sqrt(3)*(1 + 2*I)) == sqrt(sqrt(3))*sqrt(-1 - 2*I)
     assert sqrt(exp(5*I)) == -exp(5*I/2)
     assert root(exp(5*I), 3).exp == Rational(1, 3)
+
+def test_issue_2969():
+    from sympy import sin, O
+    x = Symbol('x')
+    assert sqrt(sin(x)).series(x, 0, 7) == \
+        sqrt(x) - x**(S(5)/2)/12 + x**(S(9)/2)/1440 - \
+        x**(S(13)/2)/24192 + O(x**7)
+    assert sqrt(sin(x)).series(x, 0, 9) == \
+        sqrt(x) - x**(S(5)/2)/12 + x**(S(9)/2)/1440 - \
+        x**(S(13)/2)/24192 - 67*x**(S(17)/2)/29030400 + O(x**9)
+    assert sqrt(sin(x**3)).series(x, 0, 19) == \
+        sqrt(x**3) - x**6*sqrt(x**3)/12 + x**12*sqrt(x**3)/1440 + O(x**19)
+    assert sqrt(sin(x**3)).series(x, 0, 20) == \
+        sqrt(x**3) - x**6*sqrt(x**3)/12 + x**12*sqrt(x**3)/1440 - \
+        x**18*sqrt(x**3)/24192 + O(x**20)

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -269,3 +269,8 @@ def test_issue_2969():
     assert sqrt(sin(x**3)).series(x, 0, 20) == \
         sqrt(x**3) - x**6*sqrt(x**3)/12 + x**12*sqrt(x**3)/1440 - \
         x**18*sqrt(x**3)/24192 + O(x**20)
+
+@XFAIL
+def test_issue_3683():
+    assert sqrt(sin(x**3)).series(x, 0, 7) == sqrt(x**3) + O(x**7)
+    assert sqrt(sin(x**4)).series(x, 0, 3) == sqrt(x**4) + O(x**4)

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -109,20 +109,20 @@ class Order(Expr):
             symbols = list(expr.free_symbols)
 
         if expr.is_Order:
-
-            new_symbols = list(expr.variables)
-            for s in symbols:
-                if s not in new_symbols:
-                    new_symbols.append(s)
-            if len(new_symbols) == len(expr.variables):
+            v = set(expr.variables)
+            symbols = v | set(symbols)
+            if symbols == v:
                 return expr
-            symbols = new_symbols
+            symbols = list(symbols)
 
         elif symbols:
+
+            symbols = list(set(symbols))
 
             if expr.is_Add:
                 lst = expr.extract_leading_order(*symbols)
                 expr = Add(*[f.expr for (e, f) in lst])
+
             elif expr:
                 if len(symbols) > 1 or expr.is_commutative is False:
                     # TODO
@@ -132,8 +132,7 @@ class Order(Expr):
                 else:
                     expr = expr.compute_leading_term(symbols[0])
 
-                margs = [t for t in Mul.make_args(expr) \
-                                    if set(symbols) & t.free_symbols]
+                margs = list(Mul.make_args(expr.as_independent(*symbols)[1]))
 
                 if len(symbols) == 1:
                     # The definition of O(f(x)) symbol explicitly stated that
@@ -163,7 +162,8 @@ class Order(Expr):
 
         if expr is S.Zero:
             return expr
-        elif not expr.has(*symbols):
+
+        if not expr.has(*symbols):
             expr = S.One
 
         # create Order instance:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,5 +1,5 @@
-from sympy import (Symbol, Rational, Order, exp, ln, log, O, nan, pi,
-    S, Integral, sin, conjugate, expand, transpose, symbols, Function)
+from sympy import (Symbol, Rational, Order, exp, ln, log, O, nan, pi, I,
+    S, Integral, sin, sqrt, conjugate, expand, transpose, symbols, Function)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import w, x, y, z
 
@@ -72,6 +72,14 @@ def test_simple_7():
     assert 2 + O(1) == O(1)
     assert x + O(1) == O(1)
     assert 1/x + O(1) == 1/x + O(1)
+
+
+def test_simple_8():
+    assert O(sqrt(-x)) == O(sqrt(x))
+    assert O(x**2*sqrt(x)) == O(x**(S(5)/2))
+    assert O(x**3*sqrt(-(-x)**3)) == O(x**(S(9)/2))
+    assert O(x**(S(3)/2)*sqrt((-x)**3)) == O(x**3)
+    assert O(x*(-2*x)**(I/2)) == O(x*(-x)**(I/2))
 
 
 def test_as_expr_variables():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -27,6 +27,7 @@ def test_simple_1():
     assert Order(x**(5*o/3)).expr == x**(5*o/3)
     assert Order(x**2 + x + y, x) == O(1, x)
     assert Order(x**2 + x + y, y) == O(1, y)
+    assert Order(exp(x), x, x) == Order(1, x)
     raises(NotImplementedError, lambda: Order(x, 2 - x))
 
 


### PR DESCRIPTION
Actually, this fixes two things.

First, let's compute correct number of series terms for expansion of (f(x))**a in case when limit(f(x), x, 0) = 0.  An example: sqrt(sin(x)).

Second, this patch implements additional simplifications of powers in the order term:
- O(x**a \* (-x)**b) -> O(x**(a + b)) 
- O(x**a \* (-(x)**c)**b) -> O(x**(a + b*c)) 
- O(x**a \* ((-x)**c)**b) -> O(x**(a + b*c)) 
- O(x**a \* (-(-x)**c)**b) -> O(x**(a + b*c)) 

This should fix some failures, related to getn() calculation, e.g. sqrt(sin(x**3)).series(x,0,7).
