### PR TITLE
Added is_literal, modified literal_symbol

### DIFF
--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -5,11 +5,39 @@ from sympy.core.basic import C
 from sympy.core.sympify import sympify
 
 
+def is_literal(expr):
+    """
+    Returns true if expr is a literal.
+    Else, returns false.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, Or
+    >>> from sympy.abc import A, B
+    >>> from sympy.logic.inference import is_literal
+    >>> is_literal(A)
+    True
+    >>> is_literal(~A)
+    True
+    >>> is_literal(Or(A, B))
+    False
+
+    """
+
+    if expr.is_Symbol:
+        return True
+    elif expr.is_Not:
+        return is_literal(expr.args[0])
+    else:
+        return False
+
 def literal_symbol(literal):
     """
     The symbol in this literal (without the negation).
 
-    Examples:
+    Examples
+    ========
 
     >>> from sympy import Symbol
     >>> from sympy.abc import A
@@ -22,9 +50,12 @@ def literal_symbol(literal):
     """
 
     if literal.func is Not:
-        return literal.args[0]
+        return literal_symbol(literal.args[0])
     else:
-        return literal
+        if len(literal.args) > 0:
+            raise ValueError("Argument must be a literal")
+        else:
+            return literal
 
 
 def satisfiable(expr, algorithm="dpll2"):

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -25,7 +25,9 @@ def is_literal(expr):
 
     """
 
-    if expr.is_Symbol:
+    if expr == True or expr == False:
+        return True
+    elif expr.is_Symbol:
         return True
     elif expr.is_Not:
         return is_literal(expr.args[0])
@@ -49,13 +51,14 @@ def literal_symbol(literal):
 
     """
 
-    if literal.func is Not:
+    if literal == True or literal == False:
+        return literal
+    elif literal.is_Symbol:
+        return literal
+    elif literal.is_Not:
         return literal_symbol(literal.args[0])
     else:
-        if len(literal.args) > 0:
-            raise ValueError("Argument must be a literal")
-        else:
-            return literal
+        raise ValueError("Argument must be literal.")
 
 
 def satisfiable(expr, algorithm="dpll2"):

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -7,8 +7,7 @@ from sympy.core.sympify import sympify
 
 def is_literal(expr):
     """
-    Returns true if expr is a literal.
-    Else, returns false.
+    Returns True if expr is a literal, else False.
 
     Examples
     ========
@@ -25,14 +24,12 @@ def is_literal(expr):
 
     """
 
-    if expr == True or expr == False:
+    try:
+        literal_symbol(expr)
         return True
-    elif expr.is_Symbol:
-        return True
-    elif expr.is_Not:
-        return is_literal(expr.args[0])
-    else:
+    except (ValueError):
         return False
+
 
 def literal_symbol(literal):
     """
@@ -51,14 +48,17 @@ def literal_symbol(literal):
 
     """
 
-    if literal == True or literal == False:
+    if literal is True or literal is False:
         return literal
-    elif literal.is_Symbol:
-        return literal
-    elif literal.is_Not:
-        return literal_symbol(literal.args[0])
-    else:
-        raise ValueError("Argument must be literal.")
+    try:
+        if literal.is_Symbol:
+            return literal
+        if literal.is_Not:
+            return literal_symbol(literal.args[0])
+        else:
+            raise ValueError
+    except (AttributeError, ValueError):
+        raise ValueError("Argument must be a boolean literal.")
 
 
 def satisfiable(expr, algorithm="dpll2"):

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,13 +1,27 @@
 """For more tests on satisfiability, see test_dimacs"""
 
 from sympy import symbols
-from sympy.logic.boolalg import Equivalent, Implies
-from sympy.logic.inference import pl_true, satisfiable, PropKB
+from sympy.logic.boolalg import Or, Equivalent, Implies
+from sympy.logic.inference import is_literal, literal_symbol, \
+     pl_true, satisfiable, PropKB
 from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
     find_pure_symbol, find_unit_clause, unit_propagate, \
     find_pure_symbol_int_repr, find_unit_clause_int_repr, \
     unit_propagate_int_repr
 from sympy.utilities.pytest import raises
+
+
+def test_literal():
+    A, B = symbols('A,B')
+    assert is_literal(True) == True
+    assert is_literal(False) == True
+    assert is_literal(A) == True
+    assert is_literal(~A) == True
+    assert is_literal(Or(A, B)) == False
+    assert literal_symbol(True) == True
+    assert literal_symbol(False) == False
+    assert literal_symbol(A) == A
+    assert literal_symbol(~A) == A
 
 
 def test_find_pure_symbol():

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -13,15 +13,15 @@ from sympy.utilities.pytest import raises
 
 def test_literal():
     A, B = symbols('A,B')
-    assert is_literal(True) == True
-    assert is_literal(False) == True
-    assert is_literal(A) == True
-    assert is_literal(~A) == True
-    assert is_literal(Or(A, B)) == False
-    assert literal_symbol(True) == True
-    assert literal_symbol(False) == False
-    assert literal_symbol(A) == A
-    assert literal_symbol(~A) == A
+    assert is_literal(True) is True
+    assert is_literal(False) is True
+    assert is_literal(A) is True
+    assert is_literal(~A) is True
+    assert is_literal(Or(A, B)) is False
+    assert literal_symbol(True) is True
+    assert literal_symbol(False) is False
+    assert literal_symbol(A) is A
+    assert literal_symbol(~A) is A
 
 
 def test_find_pure_symbol():


### PR DESCRIPTION
literal_symbol now raises ValueError is arg is not a literal.
is_literal has been added to check if an expression is a literal or not.
