### PR TITLE
KroneckerDelta not canonical (issue 3479 on google code) 

### DIFF
--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,7 +1,7 @@
 from sympy.core.function import Function, C
 from sympy.core import S, Integer
 from sympy.core.mul import prod
-from sympy.utilities.iterables import has_dups
+from sympy.utilities.iterables import (has_dups, minlex)
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################
@@ -428,3 +428,19 @@ class KroneckerDelta(Function):
                 return 1
         else:
             return 0
+
+    
+    def __eq__(self, other):
+        '''
+        To make KroneckerDelta canonicalize, __eq__method is overriden
+        simply swap the parameters using minlex wouldn't work because
+        KroneckerDelta.preferred_index() depends on the order of inputs
+        >>> from sympy.functions.special.tensor_functions import KroneckerDelta
+        >>> from sympy import (Dummy, symbols)
+        >>> p, q, r, s = symbols('p q r s', cls=Dummy)
+        >>> KroneckerDelta(q, p) == KroneckerDelta(p, q)
+        True
+        '''
+        if type(self) is not type(other):
+            return False
+        return minlex(self.args) == minlex(other.args)

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,7 +1,7 @@
 from sympy.core.function import Function, C
 from sympy.core import S, Integer
 from sympy.core.mul import prod
-from sympy.utilities.iterables import (has_dups, minlex)
+from sympy.utilities.iterables import (has_dups, default_sort_key)
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################
@@ -173,8 +173,7 @@ class KroneckerDelta(Function):
         # to make KroneckerDelta canonical
         # following lines will check if inputs are in order
         # if not, will return KroneckerDelta with correct order
-        sorted_args = minlex((i, j))
-        if i is not sorted_args[0]:
+        if i is not min(i, j, key=default_sort_key):
             return cls(j, i)
 
     @property

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -429,7 +429,6 @@ class KroneckerDelta(Function):
         else:
             return 0
 
-    
     def __eq__(self, other):
         '''
         To make KroneckerDelta canonicalize, __eq__method is overriden

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,7 +1,7 @@
 from sympy.core.function import Function, C
 from sympy.core import S, Integer
 from sympy.core.mul import prod
-from sympy.utilities.iterables import (has_dups, minlex)
+from sympy.utilities.iterables import (has_dups, minlex, default_sort_key)
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################
@@ -173,8 +173,7 @@ class KroneckerDelta(Function):
         # to make KroneckerDelta canonical
         # following lines will check if inputs are in order
         # if not, will return KroneckerDelta with correct order
-        sorted_args = minlex((i, j))
-        if i is not sorted_args[0]:
+        if i is not min(i, j, key=default_sort_key):
             return cls(j, i)
 
     @property

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -1,7 +1,7 @@
 from sympy.core.function import Function, C
 from sympy.core import S, Integer
 from sympy.core.mul import prod
-from sympy.utilities.iterables import (has_dups, minlex, default_sort_key)
+from sympy.utilities.iterables import (has_dups, default_sort_key)
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -170,6 +170,12 @@ class KroneckerDelta(Function):
         if j.assumptions0.get("below_fermi") and \
                 i.assumptions0.get("above_fermi"):
             return S.Zero
+        # to make KroneckerDelta canonical
+        # following lines will check if inputs are in order
+        # if not, will return KroneckerDelta with correct order
+        sorted_args = minlex((i, j))
+        if i is not sorted_args[0]:
+            return cls(j, i)
 
     @property
     def is_above_fermi(self):
@@ -428,18 +434,3 @@ class KroneckerDelta(Function):
                 return 1
         else:
             return 0
-
-    def __eq__(self, other):
-        '''
-        To make KroneckerDelta canonicalize, __eq__method is overriden
-        simply swap the parameters using minlex wouldn't work because
-        KroneckerDelta.preferred_index() depends on the order of inputs
-        >>> from sympy.functions.special.tensor_functions import KroneckerDelta
-        >>> from sympy import (Dummy, symbols)
-        >>> p, q, r, s = symbols('p q r s', cls=Dummy)
-        >>> KroneckerDelta(q, p) == KroneckerDelta(p, q)
-        True
-        '''
-        if type(self) is not type(other):
-            return False
-        return minlex(self.args) == minlex(other.args)

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -52,6 +52,7 @@ def test_kronecker_delta():
     assert conjugate(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
     assert transpose(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
 
+    assert (KroneckerDelta(i, j) == KroneckerDelta(j, i)) == True
 
 def test_kronecker_delta_secondquant():
     """secondquant-specific methods"""

--- a/sympy/functions/special/tests/test_tensor_functions.py
+++ b/sympy/functions/special/tests/test_tensor_functions.py
@@ -51,7 +51,7 @@ def test_kronecker_delta():
     assert adjoint(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
     assert conjugate(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
     assert transpose(KroneckerDelta(i, j)) == KroneckerDelta(i, j)
-
+    # to test if canonical
     assert (KroneckerDelta(i, j) == KroneckerDelta(j, i)) == True
 
 def test_kronecker_delta_secondquant():
@@ -105,8 +105,8 @@ def test_kronecker_delta_secondquant():
     assert D(q, i).killable_index == q
     assert D(q, v).preferred_index == v
     assert D(q, v).killable_index == q
-    assert D(q, p).preferred_index == q
-    assert D(q, p).killable_index == p
+    assert D(q, p).preferred_index == p
+    assert D(q, p).killable_index == q
 
     EV = evaluate_deltas
     assert EV(D(a, q)*F(q)) == F(a)

--- a/sympy/physics/quantum/sho1d.py
+++ b/sympy/physics/quantum/sho1d.py
@@ -399,7 +399,7 @@ class SHOKet(SHOState, Ket):
         >>> k = SHOKet('k')
         >>> b = SHOBra('b')
         >>> InnerProduct(b,k).doit()
-        KroneckerDelta(k, b)
+        KroneckerDelta(b, k)
 
     """
 

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1936,12 +1936,12 @@ class NO(Expr):
         >>> from sympy import symbols, Dummy
         >>> p,q = symbols('p,q', cls=Dummy)
         >>> print fill(str(NO(Fd(p)*F(q)).doit()))
-        KroneckerDelta(_a, _p)*KroneckerDelta(_a,
-        _q)*CreateFermion(_a)*AnnihilateFermion(_a) + KroneckerDelta(_a,
-        _p)*KroneckerDelta(_i, _q)*CreateFermion(_a)*AnnihilateFermion(_i) -
-        KroneckerDelta(_a, _q)*KroneckerDelta(_i,
-        _p)*AnnihilateFermion(_a)*CreateFermion(_i) - KroneckerDelta(_i,
-        _p)*KroneckerDelta(_i, _q)*AnnihilateFermion(_i)*CreateFermion(_i)
+        KroneckerDelta(_p, _a)*KroneckerDelta(_q,
+        _a)*CreateFermion(_a)*AnnihilateFermion(_a) + KroneckerDelta(_p,
+        _a)*KroneckerDelta(_q, _i)*CreateFermion(_a)*AnnihilateFermion(_i) -
+        KroneckerDelta(_p, _i)*KroneckerDelta(_q,
+        _a)*AnnihilateFermion(_a)*CreateFermion(_i) - KroneckerDelta(_p,
+        _i)*KroneckerDelta(_q, _i)*AnnihilateFermion(_i)*CreateFermion(_i)
         """
         if kw_args.get("remove_brackets", True):
             return self._remove_brackets()
@@ -2293,9 +2293,9 @@ def evaluate_deltas(e):
     imply a loss of information:
 
     >>> evaluate_deltas(KroneckerDelta(i,p)*f(q))
-    f(_q)*KroneckerDelta(_i, _p)
+    f(_q)*KroneckerDelta(_p, _i)
     >>> evaluate_deltas(KroneckerDelta(i,p)*f(i))
-    f(_i)*KroneckerDelta(_i, _p)
+    f(_i)*KroneckerDelta(_p, _i)
     """
 
     # We treat Deltas only in mul objects

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -1666,8 +1666,8 @@ class Commutator(Function):
     >>> comm = Commutator(Fd(p)*Fd(q),F(i)); comm
     Commutator(CreateFermion(p)*CreateFermion(q), AnnihilateFermion(i))
     >>> comm.doit(wicks=True)
-    -KroneckerDelta(p, i)*CreateFermion(q) +
-     KroneckerDelta(q, i)*CreateFermion(p)
+    -KroneckerDelta(i, p)*CreateFermion(q) +
+     KroneckerDelta(i, q)*CreateFermion(p)
 
     """
 
@@ -1936,12 +1936,12 @@ class NO(Expr):
         >>> from sympy import symbols, Dummy
         >>> p,q = symbols('p,q', cls=Dummy)
         >>> print fill(str(NO(Fd(p)*F(q)).doit()))
-        KroneckerDelta(_p, _a)*KroneckerDelta(_q,
-        _a)*CreateFermion(_a)*AnnihilateFermion(_a) + KroneckerDelta(_p,
-        _a)*KroneckerDelta(_q, _i)*CreateFermion(_a)*AnnihilateFermion(_i) -
-        KroneckerDelta(_p, _i)*KroneckerDelta(_q,
-        _a)*AnnihilateFermion(_a)*CreateFermion(_i) - KroneckerDelta(_p,
-        _i)*KroneckerDelta(_q, _i)*AnnihilateFermion(_i)*CreateFermion(_i)
+        KroneckerDelta(_a, _p)*KroneckerDelta(_a,
+        _q)*CreateFermion(_a)*AnnihilateFermion(_a) + KroneckerDelta(_a,
+        _p)*KroneckerDelta(_i, _q)*CreateFermion(_a)*AnnihilateFermion(_i) -
+        KroneckerDelta(_a, _q)*KroneckerDelta(_i,
+        _p)*AnnihilateFermion(_a)*CreateFermion(_i) - KroneckerDelta(_i,
+        _p)*KroneckerDelta(_i, _q)*AnnihilateFermion(_i)*CreateFermion(_i)
         """
         if kw_args.get("remove_brackets", True):
             return self._remove_brackets()
@@ -2129,9 +2129,9 @@ def contraction(a, b):
     the fermi surface:
 
     >>> contraction(Fd(p),F(q))
-    KroneckerDelta(p, q)*KroneckerDelta(q, _i)
+    KroneckerDelta(_i, q)*KroneckerDelta(p, q)
     >>> contraction(F(p),Fd(q))
-    KroneckerDelta(p, q)*KroneckerDelta(q, _a)
+    KroneckerDelta(_a, q)*KroneckerDelta(p, q)
 
     Two creators or two annihilators always vanishes:
 
@@ -2293,9 +2293,9 @@ def evaluate_deltas(e):
     imply a loss of information:
 
     >>> evaluate_deltas(KroneckerDelta(i,p)*f(q))
-    f(_q)*KroneckerDelta(_p, _i)
+    f(_q)*KroneckerDelta(_i, _p)
     >>> evaluate_deltas(KroneckerDelta(i,p)*f(i))
-    f(_i)*KroneckerDelta(_p, _i)
+    f(_i)*KroneckerDelta(_i, _p)
     """
 
     # We treat Deltas only in mul objects

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -450,7 +450,8 @@ def test_latex_KroneckerDelta():
     assert latex(KroneckerDelta(x, y)) == r"\delta_{x y}"
     assert latex(KroneckerDelta(x, y)**2) == r"\left(\delta_{x y}\right)^{2}"
     assert latex(KroneckerDelta(x, y + 1)) == r"\delta_{x, y + 1}"
-    assert latex(KroneckerDelta(x + 1, y)) == r"\delta_{x + 1, y}"
+    # issue 3479
+    assert latex(KroneckerDelta(x + 1, y)) == r"\delta_{y, x + 1}"
 
 
 def test_latex_LeviCivita():


### PR DESCRIPTION
Tried to use minlex to swap parameters within KroneckerDelta but preferred_index will return the first input if both parameters contain same information about fermi level. So I override a ____eq____ method(markdown keeps messing around with the underscore) .
