### PR TITLE
Refactor implicit parsing

### DIFF
--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -45,8 +45,26 @@ applied in the order given.
 
 .. autodata:: sympy.parsing.sympy_parser.standard_transformations
 
+.. autofunction:: sympy.parsing.sympy_parser.split_symbols
+
+.. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication
+
+.. autofunction:: sympy.parsing.sympy_parser.implicit_application
+
+.. autofunction:: sympy.parsing.sympy_parser.function_exponentiation
+
 .. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication_application
 
 .. autofunction:: sympy.parsing.sympy_parser.rationalize
 
 .. autofunction:: sympy.parsing.sympy_parser.convert_xor
+
+These are included in
+:data:``sympy.parsing.sympy_parser.standard_transformations`` and generally
+don't need to be manually added by the user.
+
+.. autofunction:: sympy.parsing.sympy_parser.factorial_notation
+
+.. autofunction:: sympy.parsing.sympy_parser.auto_symbol
+
+.. autofunction:: sympy.parsing.sympy_parser.auto_number

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -47,6 +47,8 @@ applied in the order given.
 
 .. autofunction:: sympy.parsing.sympy_parser.split_symbols
 
+.. autofunction:: sympy.parsing.sympy_parser.split_symbols_custom
+
 .. autofunction:: sympy.parsing.sympy_parser.implicit_multiplication
 
 .. autofunction:: sympy.parsing.sympy_parser.implicit_application

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -290,6 +290,13 @@ def _function_exponents(tokens, local_dict, global_dict):
 
 
 def split_symbols(tokens, local_dict, global_dict):
+    """
+    Splits symbol names for implicit multiplication.
+
+    Intended to let expressions like ``xyz`` be parsed as ``x*y*z``. Does
+    not split Greek character names, so ``theta`` will *not* become
+    ``t*h*e*t*a``.
+    """
     result = []
     split = False
     for tok in tokens:
@@ -315,27 +322,7 @@ def split_symbols(tokens, local_dict, global_dict):
 
 
 def implicit_multiplication(result, local_dict, global_dict):
-    """Allows a slightly relaxed syntax.
-
-    - Parentheses for single-argument method calls are optional.
-
-    - Multiplication is implicit.
-
-    - Symbol names can be split (i.e. spaces are not needed between
-      symbols).
-
-    - Functions can be exponentiated.
-
-    Example:
-
-    >>> from sympy.parsing.sympy_parser import (parse_expr,
-    ... standard_transformations, implicit_multiplication_application)
-    >>> parse_expr("10sin**2 x**2 + 3xyz + tan theta",
-    ... transformations=(standard_transformations +
-    ... (implicit_multiplication_application,)))
-    3*x*y*z + 10*sin(x**2)**2 + tan(theta)
-
-    """
+    """Makes the multiplication operator optional in most cases."""
     # These are interdependent steps, so we don't expose them separately
     for step in (_group_parentheses(implicit_multiplication),
                  _apply_functions,
@@ -347,6 +334,7 @@ def implicit_multiplication(result, local_dict, global_dict):
 
 
 def function_exponents(result, local_dict, global_dict):
+    """Allows functions to be exponentiated, e.g. sin**2(x)."""
     for step in (_group_parentheses(_function_exponents),
                  _apply_functions,
                  _function_exponents):
@@ -357,6 +345,7 @@ def function_exponents(result, local_dict, global_dict):
 
 
 def implicit_application(result, local_dict, global_dict):
+    """Makes parentheses optional in some cases for function calls."""
     for step in (_group_parentheses(implicit_application),
                  _apply_functions,
                  _implicit_application,):

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -340,7 +340,7 @@ def split_symbols(tokens, local_dict, global_dict):
             symbol = tok[1][1:-1]
             if _token_splittable(symbol):
                 for char in symbol:
-                    result.extend([(NAME, "'{}'".format(char)), (OP, ')'),
+                    result.extend([(NAME, "'%s'" % char), (OP, ')'),
                                    (NAME, 'Symbol'), (OP, '(')])
                 # Delete the last three tokens: get rid of the extraneous
                 # Symbol( we just added, and also get rid of the last )

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -324,10 +324,26 @@ def function_exponentiation(tokens, local_dict, global_dict):
 
 
 def split_symbols_custom(predicate):
-    """
-    Creates a transformation that splits symbol names.
+    """Creates a transformation that splits symbol names.
 
     ``predicate`` should return True if the symbol name is to be split.
+
+    For instance, to retain the default behavior but avoid splitting certain
+    symbol names, a predicate like this would work:
+
+
+    >>> from sympy.parsing.sympy_parser import (parse_expr, _token_splittable,
+    ... standard_transformations, implicit_multiplication,
+    ... split_symbols_custom)
+    >>> def can_split(symbol):
+    ...     if symbol not in ('list', 'of', 'unsplittable', 'names'):
+    ...             return _token_splittable(symbol)
+    ...     return False
+    ...
+    >>> transformation = split_symbols_custom(can_split)
+    >>> parse_expr('unsplittable', transformations=standard_transformations +
+    ... (transformation, implicit_multiplication))
+    unsplittable
     """
     def _split_symbols(tokens, local_dict, global_dict):
         result = []

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -285,6 +285,10 @@ def function_exponents(tokens, local_dict, global_dict):
             # only want to stop after hitting )
             if tok[0] == nextTok[0] == OP and tok[1] == ')' and nextTok[1] == '(':
                 consuming_exponent = False
+            # if implicit multiplication was used, we may have )*( instead
+            if tok[0] == nextTok[0] == OP and tok[1] == '*' and nextTok[1] == '(':
+                consuming_exponent = False
+                del exponent[-1]
             continue
         elif exponent and not consuming_exponent:
             if tok[0] == OP:
@@ -525,6 +529,10 @@ def rationalize(tokens, local_dict, global_dict):
 #: Inserts calls to :class:`Symbol`, :class:`Integer`, and other SymPy
 #: datatypes and allows the use of standard factorial notation (e.g. ``x!``).
 standard_transformations = (auto_symbol, auto_number, factorial_notation)
+
+
+implicit_multiplication_application = (split_symbols, implicit_multiplication,
+                                       implicit_application, function_exponents)
 
 
 def stringify_expr(s, local_dict, global_dict, transformations):

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -35,11 +35,13 @@ def test_implicit_multiplication_application():
         'x_2': 'Symbol("x_2")',
         'sin^2 x**2': 'sin(x**2)**2',  # function raised to a power
         'sin**3(x)': 'sin(x)**3',
-        '(factorial)': 'factorial'
+        '(factorial)': 'factorial',
+        'tan 3x': 'tan(3*x)'
     }
     transformations = standard_transformations + (convert_xor,)
-    transformations2 = transformations + implicit_multiplication_application
+    transformations2 = transformations + (implicit_multiplication_application,)
     for e in d:
         implicit = parse_expr(e, transformations=transformations2)
         normal = parse_expr(d[e], transformations=transformations)
+        print e, implicit, normal
         assert(implicit == normal)

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -43,5 +43,4 @@ def test_implicit_multiplication_application():
     for e in d:
         implicit = parse_expr(e, transformations=transformations2)
         normal = parse_expr(d[e], transformations=transformations)
-        print e, implicit, normal
         assert(implicit == normal)

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -2,11 +2,62 @@ from sympy.parsing.sympy_parser import (
     parse_expr,
     standard_transformations,
     convert_xor,
-    implicit_multiplication_application
+    implicit_multiplication_application,
+    implicit_multiplication,
+    implicit_application,
+    function_exponentiation,
+    split_symbols
 )
 
 
-def test_implicit_multiplication_application():
+def test_implicit_multiplication():
+    d = {
+        '5x': '5*x',
+        'abc': 'a*b*c',
+        '3sin(x)': '3*sin(x)',
+        '(x+1)(x+2)': '(x+1)*(x+2)',
+        '(5 x**2)sin(x)': '(5*x**2)*sin(x)',
+        '2 sin(x) cos(x)': '2*sin(x)*cos(x)'
+    }
+    transformations = standard_transformations + (convert_xor,)
+    transformations2 = transformations + (split_symbols,
+                                          implicit_multiplication)
+    for e in d:
+        implicit = parse_expr(e, transformations=transformations2)
+        normal = parse_expr(d[e], transformations=transformations)
+        assert(implicit == normal)
+
+
+def test_implicit_application():
+    d = {
+        'factorial': 'factorial',
+        'sin x': 'sin(x)',
+        'tan y**3': 'tan(y**3)',
+        'cos 2*x': 'cos(2*x)',
+        '(cot)': 'cot'
+    }
+    transformations = standard_transformations + (convert_xor,)
+    transformations2 = transformations + (implicit_application,)
+    for e in d:
+        implicit = parse_expr(e, transformations=transformations2)
+        normal = parse_expr(d[e], transformations=transformations)
+        assert(implicit == normal)
+
+
+def test_function_exponentiation():
+    d = {
+        'sin**2(x)': 'sin(x)**2',
+        'exp^y(z)': 'exp(z)^y'
+    }
+    transformations = standard_transformations + (convert_xor,)
+    transformations2 = transformations + (function_exponentiation,)
+    for e in d:
+        implicit = parse_expr(e, transformations=transformations2)
+        normal = parse_expr(d[e], transformations=transformations)
+        assert(implicit == normal)
+
+
+def test_all_implicit_steps():
     d = {
         '2x': '2*x',  # implicit multiplication
         'x y': 'x*y',

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -38,7 +38,7 @@ def test_implicit_multiplication_application():
         '(factorial)': 'factorial'
     }
     transformations = standard_transformations + (convert_xor,)
-    transformations2 = transformations + (implicit_multiplication_application,)
+    transformations2 = transformations + implicit_multiplication_application
     for e in d:
         implicit = parse_expr(e, transformations=transformations2)
         normal = parse_expr(d[e], transformations=transformations)


### PR DESCRIPTION
Changes:
- Function exponentiation, implicit multiplication, and implicit application are now separate transformation steps.
  - They are still somewhat order-dependent - `sin 2x` only works if implicit multiplication comes before implicit application.
- API remains the same as before.
- `sin 2x` works now. (Before it gave `x*sin(2)`, now it gives `sin(2*x)`.)
- Expanded the docs a bit

https://code.google.com/p/sympy/issues/detail?id=3678
