### PR TITLE
Zero division error

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -767,7 +767,7 @@ class Float(Number):
 
     @_sympifyit('other', NotImplemented)
     def __div__(self, other):
-        if isinstance(other, Number):
+        if isinstance(other, Number) and other != 0:
             rhs, prec = other._as_mpf_op(self._prec)
             return Float._new(mlib.mpf_div(self._mpf_, rhs, prec, rnd), prec)
         return Number.__div__(self, other)
@@ -795,6 +795,11 @@ class Float(Number):
         (-p)**r -> exp(r*log(-p)) -> exp(r*(log(p) + I*Pi)) ->
                   -> p**r*(sin(Pi*r) + cos(Pi*r)*I)
         """
+        if self == 0:
+            if expt.is_positive:
+                return S.Zero
+            if expt.is_negative:
+                return Float('inf')
         if isinstance(expt, Number):
             if isinstance(expt, Integer):
                 prec = self._prec

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1835,15 +1835,6 @@ class Zero(IntegerConstant):
     def __neg__():
         return S.Zero
 
-    @_sympifyit('other', NotImplemented)
-    @call_highest_priority('__rmul__')
-    def __mul__(self, other):
-        if other is S.NaN or \
-            other is S.NegativeInfinity or \
-            other is S.Infinity or \
-                other is S.ComplexInfinity:
-            return S.NaN
-        return S.Zero
 
     def _eval_power(self, expt):
         if expt.is_positive:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -639,7 +639,6 @@ def test_Mul_Infinity_Zero():
     assert Float('-inf')*Float(0) == nan
 
 
-@XFAIL
 def test_Div_By_Zero():
     assert 1/S(0) == oo
     assert 1/Float(0) == Float('inf')

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -620,6 +620,38 @@ def test_Infinity_2():
     assert abs(S.ComplexInfinity) == oo
 
 
+@XFAIL
+def test_Mul_Infinity_Zero():
+    assert 0*Float('inf') == nan
+    assert 0*Float('-inf') == nan
+    assert 0*Float('inf') == nan
+    assert 0*Float('-inf') == nan
+    assert Float('inf')*0 == nan
+    assert Float('-inf')*0 == nan
+    assert Float('inf')*0 == nan
+    assert Float('-inf')*0 == nan
+    assert Float(0)*Float('inf') == nan
+    assert Float(0)*Float('-inf') == nan
+    assert Float(0)*Float('inf') == nan
+    assert Float(0)*Float('-inf') == nan
+    assert Float('inf')*Float(0) == nan
+    assert Float('-inf')*Float(0) == nan
+    assert Float('inf')*Float(0) == nan
+    assert Float('-inf')*Float(0) == nan
+
+
+@XFAIL
+def test_Div_By_Zero():
+    assert 1/S(0) == oo
+    assert 1/Float(0) == Float('inf')
+    assert 0/S(0) == nan
+    assert 0/Float(0) == nan
+    assert S(0)/0 == nan
+    assert Float(0)/0 == nan
+    assert -1/S(0) == -oo
+    assert -1/Float(0) == Float('-inf')
+
+
 def test_Infinity_inequations():
     assert oo > pi
     assert not (oo < pi)

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -620,7 +620,6 @@ def test_Infinity_2():
     assert abs(S.ComplexInfinity) == oo
 
 
-@XFAIL
 def test_Mul_Infinity_Zero():
     assert 0*Float('inf') == nan
     assert 0*Float('-inf') == nan


### PR DESCRIPTION
This pull request has two part.
First, 0 \* Float('inf') was 0 while Float('inf') \* 0 was nan.
Now they are both nan.
Second, 1/S(0) was oo while 1/Float(0) was a ZeroDivisionError.
Now 1/Float(0) gives Float('inf').

This allow
Or(Eq(x,0), 1/x  >1 ).subs(x,0)

See also
http://code.google.com/p/sympy/issues/detail?id=3595
and 
https://github.com/sympy/sympy/pull/1868
