### PR TITLE
Fix return value for rsolve + misc fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ Fredrik Johansson has wrote mpmath and contributed a lot of patches. Since
 then, a lot more people have joined the development and some people have also
 left. You can see the full list in doc/src/aboutus.rst, or online at:
 
-http://docs.sympy.org/aboutus.html#sympy-development-team
+http://docs.sympy.org/dev/aboutus.html#sympy-development-team
 
 For people that don't want to be listed there, see the git history.
 

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -114,7 +114,7 @@ def test_aux_dep():
     #         taking u[3], u[4], u[5] as dependent,
     #         rearranging the matrix of M_v to be A_rs for u_dependent.
     # Third, u_aux ==0 for u_dep, and resulting dictionary of u_dep_dict.
-    M_v = zeros((3, 9))
+    M_v = zeros(3, 9)
     for i in range(3):
         for j, ui in enumerate(u + ua):
             M_v[i, j] = f_v[i].diff(ui)

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -621,8 +621,11 @@ def rsolve_hyper(coeffs, f, n, **hints):
     kernel.sort(key=default_sort_key)
     sk = zip(symbols, kernel)
 
-    for C, ker in sk:
-        result += C * ker
+    if sk:
+        for C, ker in sk:
+            result += C * ker
+    else:
+        return None
 
     if hints.get('symbols', False):
         return (result, [s for s, k in sk])

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -71,6 +71,8 @@ def test_rsolve_hyper():
     assert rsolve_hyper([1, 1, 1], 0, n).expand() == \
         C0*(-S(1)/2 - sqrt(3)*I/2)**n + C1*(-S(1)/2 + sqrt(3)*I/2)**n
 
+    assert rsolve_hyper([1, -2*n/a - 2/a, 1], 0, n) == None
+
 
 def recurrence_term(c, f):
     """Compute RHS of recurrence in f(n) with coefficients in c."""

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -54,9 +54,9 @@ def test_rsolve_hyper():
         [2*n*(n + 1), -n**2 - 3*n + 2, n - 1], 0, n) == C1*factorial(n) + C0*2**n
 
     assert rsolve_hyper(
-        [n + 2, -(2*n + 3)*(17*n**2 + 51*n + 39), n + 1], 0, n) == 0
+        [n + 2, -(2*n + 3)*(17*n**2 + 51*n + 39), n + 1], 0, n) == None
 
-    assert rsolve_hyper([-n - 1, -1, 1], 0, n) == 0
+    assert rsolve_hyper([-n - 1, -1, 1], 0, n) == None
 
     assert rsolve_hyper([-1, 1], n, n).expand() == C0 + n**2/2 - n/2
 


### PR DESCRIPTION
rsolve (according to docs) should return Null, not 0, if it can't find any solution

misc: broken URL in README.rst, SymPyDeprecationWarning in test_kane2.py
