### PR TITLE
Classifying order of nested functions

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2290,19 +2290,7 @@ def homogeneous_order(eq, *symbols):
 
     # assuming order of a nested function can only be equal to zero
     if isinstance(eq, Function):
-        arg = eq.args[0]
-        if arg.is_Add:
-            for i in arg.args:
-                if homogeneous_order(i, *tuple(symset)) != S.Zero:
-                    return None
-            return S.Zero
-
-
-        else:
-            if homogeneous_order(arg, *tuple(symset)) != S.Zero:
-                return None
-            else:
-                return S.Zero
+        return None if homogeneous_order(eq.args[0], *tuple(symset)) != 0 else S.Zero
 
     # make the replacement of x with x*t and see if t can be factored out
     t = Dummy('t', positive=True)  # It is sufficient that t > 0

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -209,7 +209,7 @@ from sympy.core import Add, C, S, Mul, Pow, oo
 from sympy.core.compatibility import iterable, is_sequence, set_union
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.exprtools import factor_terms
-from sympy.core.function import Derivative, AppliedUndef, diff, expand_mul
+from sympy.core.function import Function, Derivative, AppliedUndef, diff, expand_mul
 from sympy.core.multidimensional import vectorize
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, Dummy
@@ -2287,6 +2287,21 @@ def homogeneous_order(eq, *symbols):
 
     if not eq.free_symbols & symset:
         return None
+
+    # assuming order of a nested function can only be equal to zero
+    if isinstance(eq, Function):
+        arg = eq.args[0]
+        if arg.is_Add:
+            for i in arg.args:
+                if homogeneous_order(i, *tuple(symset)) == S.Zero:
+                    return S.Zero
+                else:
+                    return None
+        else:
+            if homogeneous_order(arg , *tuple(symset)) == S.Zero:
+                return S.Zero
+            else:
+                return None
 
     # make the replacement of x with x*t and see if t can be factored out
     t = Dummy('t', positive=True)  # It is sufficient that t > 0

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2293,15 +2293,16 @@ def homogeneous_order(eq, *symbols):
         arg = eq.args[0]
         if arg.is_Add:
             for i in arg.args:
-                if homogeneous_order(i, *tuple(symset)) == S.Zero:
-                    return S.Zero
-                else:
+                if homogeneous_order(i, *tuple(symset)) != S.Zero:
                     return None
+            return S.Zero
+
+
         else:
-            if homogeneous_order(arg, *tuple(symset)) == S.Zero:
-                return S.Zero
-            else:
+            if homogeneous_order(arg, *tuple(symset)) != S.Zero:
                 return None
+            else:
+                return S.Zero
 
     # make the replacement of x with x*t and see if t can be factored out
     t = Dummy('t', positive=True)  # It is sufficient that t > 0

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2298,7 +2298,7 @@ def homogeneous_order(eq, *symbols):
                 else:
                     return None
         else:
-            if homogeneous_order(arg , *tuple(symset)) == S.Zero:
+            if homogeneous_order(arg, *tuple(symset)) == S.Zero:
                 return S.Zero
             else:
                 return None

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1495,3 +1495,21 @@ def test_exact_enhancement():
     rhs = [sol.rhs for sol in dsolve(eq, f)]
     assert rhs[0] == acos(-sqrt(C1*exp(-2*x)/x**4 + 1))
     assert rhs[1] == acos(sqrt(C1*exp(-2*x)/x**4 + 1))
+
+
+def test_homogeneous_function():
+    f = Function('f')
+    eq1 = tan(x + f(x))
+    eq2 = sin((3*x)/(4*f(x)))
+    eq3 = cos(3*x/4*f(x))
+    eq4 = log((3*x + 4*f(x))/(5*f(x) + 7*x))
+    eq5 = exp((2*x**2)/(3*f(x)**2))
+    eq6 = log((3*x + 4*f(x))/(5*f(x) + 7*x) + exp((2*x**2)/(3*f(x)**2)))
+    eq7 = sin((3*x)/(5*f(x) + x**2))
+    assert homogeneous_order(eq1, x, f(x)) == None
+    assert homogeneous_order(eq2, x, f(x)) == 0
+    assert homogeneous_order(eq3, x, f(x)) == None
+    assert homogeneous_order(eq4, x, f(x)) == 0
+    assert homogeneous_order(eq5, x, f(x)) == 0
+    assert homogeneous_order(eq6, x, f(x)) == 0
+    assert homogeneous_order(eq7, x, f(x)) == None


### PR DESCRIPTION
The homogenous_order() function in ode, doesn't presently find out the order of functions like tan((7_x + 3_y) / (2_x + 5_y)) , due to the inability of seperatevars to separate out t, when it is inside a function

Presently:

```
>>> homogenous_order(tan((7*x + 3*y) / (2*x + 5*y)) , x , y) 
```

returns None.

I think such nested functions should be classified and the order should be given as zero. Do have a look at my fix.
