### PR TITLE
Separable reduced equations first implementation

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -936,12 +936,9 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                 matching_hints["separable_reduced_Integral"] = r3
             # Try representing factor in terms of x^n*y where n is lowest power of x in factor
             else:
-                power = S.Zero
-                for i in factor.atoms(Pow):
-                    if i.args[0] == x:
-                        if i.args[1] > power:
-                            power = i.args[1]
-                if power:
+                powerlist = [i.args[1] for i in factor.atoms(Pow) if i.args[0] == x and i.args[1] > S.Zero]
+                if powerlist:
+                    power = min(powerlist)
                     test = factor.subs(x**power, t/f(x))
                     free = test.free_symbols
                     if len(free) == 1 and free.pop() == t:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -181,14 +181,16 @@ def test_classify_ode():
         '1st_homogeneous_coeff_best',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_dep_div_indep',
+        'separable_reduced',
         'nth_linear_constant_coeff_undetermined_coefficients',
         'nth_linear_constant_coeff_variation_of_parameters',
         'separable_Integral', '1st_exact_Integral',
         '1st_linear_Integral',
         'Bernoulli_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
-       '1st_homogeneous_coeff_subs_dep_div_indep_Integral',
-       'nth_linear_constant_coeff_variation_of_parameters_Integral')
+        '1st_homogeneous_coeff_subs_dep_div_indep_Integral',
+        'separable_reduced_Integral',
+        'nth_linear_constant_coeff_variation_of_parameters_Integral')
     #     w/o f(x) given
     assert classify_ode(diff(f(x) + x, x) + diff(f(x), x)) == ans
     #     w/ f(x) and prep=True

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1495,3 +1495,33 @@ def test_exact_enhancement():
     rhs = [sol.rhs for sol in dsolve(eq, f)]
     assert rhs[0] == acos(-sqrt(C1*exp(-2*x)/x**4 + 1))
     assert rhs[1] == acos(sqrt(C1*exp(-2*x)/x**4 + 1))
+
+
+def test_separable_reduced():
+    f = Function('f')
+    df = f(x).diff(x)
+    eq = (x / f(x))*df  + tan(x**2*f(x) / (x**2*f(x) - 1))
+    assert classify_ode(eq) == ('1st_linear', 'separable_reduced',
+    '1st_linear_Integral', 'separable_reduced_Integral')
+
+    eq = x* df  + f(x)* (1 / (x**2*f(x) - 1))
+    assert classify_ode(eq) == ('1st_linear', 'separable_reduced',
+    '1st_linear_Integral', 'separable_reduced_Integral')
+    sol = dsolve(eq, hint = 'separable_reduced')
+    assert sol.lhs ==  log(x**2*f(x))/3 + log(x**2*f(x) - S(3)/2)/6
+    assert sol.rhs == C1 + log(x)
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
+
+    eq = df + (f(x) / (x**4*f(x) - x))
+    assert classify_ode(eq) == ('1st_linear', 'separable_reduced',
+    '1st_linear_Integral', 'separable_reduced_Integral')
+    sol = dsolve(eq, hint = 'separable_reduced')
+    assert sol.lhs == log(x**3*f(x))/4 + log(x**3*f(x) - S(4)/3)/12
+    assert sol.rhs == C1 + log(x)
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
+
+    eq = x*df + f(x)*(x**2*f(x))
+    sol = dsolve(eq, hint = 'separable_reduced')
+    assert sol.lhs == log(x**2*f(x))/2 - log(x**2*f(x) - 2)/2
+    assert sol.rhs == C1 + log(x)
+    assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]


### PR DESCRIPTION
Solves an equation that can be reduced to the separable form.

The general form of this equation is y' + (y/x)_H(x^n_y) = 0
This can be solved by substituting u(y) = (x^n \* y)

The equation then reduces to the separable form
 u'_(1/(u_(power - H(u)))) - (1/x) = 0 (see the docstring of ode_separable())

```
Examples
========

>>> from sympy import Function, Derivative, pprint
>>> from sympy.solvers.ode import dsolve, classify_ode
>>> from sympy.abc import x
>>> f = Function('f')
>>> d = f(x).diff(x)
>>> eq = (x - x**2*f(x))*d - f(x)
>>> dsolve(eq, hint = 'separable_reduced')
[f(x) == (-sqrt(C1*x**2 + 1) + 1)/x, f(x) == (sqrt(C1*x**2 + 1) + 1)/x]
>>> pprint(dsolve(eq, hint = 'separable_reduced'))
             ___________                ___________
            /     2                    /     2
        - \/  C1*x  + 1  + 1         \/  C1*x  + 1  + 1
[f(x) = --------------------, f(x) = ------------------]
                 x                           x
```
# References
- Joel Moses, "Symbolic Integration - The Stormy Decade",
  Communications of the ACM, Volume 14, Number 8, August 1971, pp. 558
