### PR TITLE
tree traversals take functional inputs

### DIFF
--- a/sympy/strategies/branch/traverse.py
+++ b/sympy/strategies/branch/traverse.py
@@ -1,21 +1,23 @@
 """ Branching Strategies to Traverse a Tree """
 
-from sympy.strategies.util import new, is_leaf
+from sympy.strategies.util import basic_fns
 from core import chain, identity, do_one
 from sympy.core.compatibility import product
 
-def top_down(brule):
+def top_down(brule, fns=basic_fns):
     """ Apply a rule down a tree running it on the top nodes first """
-    return chain(do_one(brule, identity), lambda expr: sall(top_down(brule))(expr))
+    return chain(do_one(brule, identity),
+                 lambda expr: sall(top_down(brule, fns), fns)(expr))
 
-def sall(brule):
+def sall(brule, fns=basic_fns):
     """ Strategic all - apply rule to args """
+    op, new, children, leaf = map(fns.get, ('op', 'new', 'children', 'leaf'))
     def all_rl(expr):
-        if is_leaf(expr):
+        if leaf(expr):
             yield expr
         else:
-            op = type(expr)
-            argss = product(*map(brule, expr.args))
+            myop = op(expr)
+            argss = product(*map(brule, children(expr)))
             for args in argss:
-                yield new(op, *args)
+                yield new(myop, *args)
     return all_rl

--- a/sympy/strategies/rl.py
+++ b/sympy/strategies/rl.py
@@ -2,13 +2,12 @@
 
 This file assumes knowledge of Basic and little else.
 """
-from sympy import Basic
 from sympy.utilities.iterables import sift
 from util import new
 
 # Functions that create rules
 
-def rm_id(isid):
+def rm_id(isid, new=new):
     """ Create a rule to remove identities
 
     isid - fn :: x -> Bool  --- whether or not this element is an identity
@@ -72,7 +71,7 @@ def glom(key, count, combine):
 
     return conglomerate
 
-def sort(key):
+def sort(key, new=new):
     """ Create a rule to sort by a key function
 
     >>> from sympy.strategies import sort
@@ -134,7 +133,7 @@ def unpack(expr):
     else:
         return expr
 
-def flatten(expr):
+def flatten(expr, new=new):
     """ Flatten T(a, b, T(c, d), T2(e)) to T(a, b, c, d, T2(e)) """
     cls = expr.__class__
     args = []

--- a/sympy/strategies/tests/test_traverse.py
+++ b/sympy/strategies/tests/test_traverse.py
@@ -1,5 +1,5 @@
 from sympy.strategies.traverse import (top_down, bottom_up, sall, top_down_once,
-        bottom_up_once)
+        bottom_up_once, expr_fns, basic_fns)
 from sympy import Basic, symbols, Symbol, S
 
 zero_symbols = lambda x: S.Zero if isinstance(x, Symbol) else x
@@ -52,3 +52,13 @@ def test_bottom_up_once():
 
     assert bottom_rl(Basic(1, 2, Basic(3, 4))) == \
                      Basic(1, 2, Basic2(3, 4))
+
+def test_expr_fns():
+    from sympy.strategies.rl import rebuild
+    x, y = map(Symbol, 'xy')
+    expr = x + y**3
+    e = bottom_up(lambda x: x+1, expr_fns)(expr)
+    b = bottom_up(lambda x: x+1, basic_fns)(expr)
+
+    assert b!=e
+    assert rebuild(b) == e

--- a/sympy/strategies/tools.py
+++ b/sympy/strategies/tools.py
@@ -2,7 +2,7 @@ import rl
 from core import do_one, exhaust, switch
 from traverse import top_down
 
-def subs(d):
+def subs(d, **kwargs):
     """ Full simultaneous exact substitution
 
     Example
@@ -16,18 +16,18 @@ def subs(d):
     Basic(4, Basic(2, 3), Basic(1, Basic(6, 7)))
     """
     if d:
-        return top_down(do_one(*map(rl.subs, *zip(*d.items()))))
+        return top_down(do_one(*map(rl.subs, *zip(*d.items()))), **kwargs)
     else:
         return lambda x: x
 
-def canon(*rules):
+def canon(*rules, **kwargs):
     """ Strategy for canonicalization
 
     Apply each rule in a bottom_up fashion through the tree.
     Do each one in turn.
     Keep doing this until there is no change.
     """
-    return exhaust(top_down(exhaust(do_one(*rules))))
+    return exhaust(top_down(exhaust(do_one(*rules)), **kwargs))
 
 def typed(ruletypes):
     """ Apply rules based on the expression type

--- a/sympy/strategies/traverse.py
+++ b/sympy/strategies/traverse.py
@@ -1,29 +1,30 @@
 """ Strategies to Traverse a Tree """
-from util import new, is_leaf
+from util import basic_fns, expr_fns
 from sympy.strategies.core import chain, do_one
 
-def top_down(rule):
+def top_down(rule, fns=basic_fns):
     """ Apply a rule down a tree running it on the top nodes first """
-    return chain(rule, lambda expr: sall(top_down(rule))(expr))
+    return chain(rule, lambda expr: sall(top_down(rule, fns), fns)(expr))
 
-def bottom_up(rule):
+def bottom_up(rule, fns=basic_fns):
     """ Apply a rule down a tree running it on the bottom nodes first """
-    return chain(lambda expr: sall(bottom_up(rule))(expr), rule)
+    return chain(lambda expr: sall(bottom_up(rule, fns), fns)(expr), rule)
 
-def top_down_once(rule):
+def top_down_once(rule, fns=basic_fns):
     """ Apply a rule down a tree - stop on success """
-    return do_one(rule, lambda expr: sall(top_down(rule))(expr))
+    return do_one(rule, lambda expr: sall(top_down(rule, fns), fns)(expr))
 
-def bottom_up_once(rule):
+def bottom_up_once(rule, fns=basic_fns):
     """ Apply a rule up a tree - stop on success """
-    return do_one(lambda expr: sall(bottom_up(rule))(expr), rule)
+    return do_one(lambda expr: sall(bottom_up(rule, fns), fns)(expr), rule)
 
-def sall(rule):
+def sall(rule, fns=basic_fns):
     """ Strategic all - apply rule to args """
+    op, new, children, leaf = map(fns.get, ('op', 'new', 'children', 'leaf'))
     def all_rl(expr):
-        if is_leaf(expr):
+        if leaf(expr):
             return expr
         else:
-            args = map(rule, expr.args)
-            return new(type(expr), *args)
+            args = map(rule, children(expr))
+            return new(op(expr), *args)
     return all_rl

--- a/sympy/strategies/util.py
+++ b/sympy/strategies/util.py
@@ -2,5 +2,14 @@ from sympy import Basic
 
 new = Basic.__new__
 
-def is_leaf(x):
-    return not isinstance(x, Basic) or x.is_Atom
+def assoc(d, k, v):
+    d = d.copy()
+    d[k] = v
+    return d
+
+basic_fns = {'op': type,
+             'new': Basic.__new__,
+             'leaf': lambda x: not isinstance(x, Basic) or x.is_Atom,
+             'children': lambda x: x.args}
+
+expr_fns = assoc(basic_fns, 'new', lambda op, *args: op(*args))


### PR DESCRIPTION
The traversal functions in sympy.strategies.traverse use `Basic.__new__` to recreate nodes in a SymPy tree.  This has two issues: 
1. It skips canonicalization required by some classes at construction time
2. It is specific to SymPy

This pull request adds a keyword parameter to these functions that completely parametrizes the inspection and creation of trees.  This makes it very easy to use traversals in an Expr friendly way.  It also more cleanly separates this module from SymPy and makes it generally applicable to other projects.  

I'm mostly interested in the latter point (I'm about to split this off into its own repository) but the fact that this solves the former point about Exprs is also relevant.  

``` Python
In [2]: from sympy.strategies.traverse import bottom_up, expr_fns, basic_fns
In [4]: add_one = lambda x: x+1

In [5]: add_one_everywhere = bottom_up(add_one, expr_fns)
In [6]: expr = x**2 + y*3
In [7]: add_one_everywhere(expr)
Out[7]: 
             3    
4⋅y + (x + 1)  + 7
```

Note that this is well formed and canonicalized on output (and indeed during execution),

`basic_fns` and `expr_fns` look like the following

``` Python
basic_fns = {'op': type,
             'new': Basic.__new__,
             'leaf': lambda x: not isinstance(x, Basic) or x.is_Atom,
             'children': lambda x: x.args}

expr_fns = assoc(basic_fns, 'new', lambda op, *args: op(*args))
```

I welcome better names for `expr/basic_fns`

These functions define how to manipulate terms

new(op, *args) -> make a new term
children(term) -> list of args
op(term) -> type of term (e.g. Add, Mul)
leaf(term) -> boolean if the term is a leaf
