### PR TITLE
Test basestring instead of str in Symbol

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -72,7 +72,8 @@ class Symbol(AtomicExpr, Boolean):
         return Symbol.__xnew_cached_(cls, name, **assumptions)
 
     def __new_stage2__(cls, name, **assumptions):
-        assert isinstance(name, str), repr(type(name))
+        if not isinstance(name, basestring):
+            raise TypeError("name should be a string, not %s" % repr(type(name)))
         obj = Expr.__new__(cls)
         obj.name = name
         obj._assumptions = StdFactKB(assumptions)

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -376,3 +376,10 @@ def test_call():
     f = Symbol('f')
     assert f(2)
     raises(TypeError, lambda: Wild('x')(1))
+
+def test_unicode():
+    xu = Symbol(u'x')
+    x = Symbol('x')
+    assert x == xu
+
+    raises(TypeError, lambda: Symbol(1))


### PR DESCRIPTION
Also, raise TypeError instead of AssertionError on bad arguments.
