### PR TITLE
issue 3692 (old assumptions)

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -857,10 +857,22 @@ class Mul(Expr, AssocOp):
         return all(term._eval_is_rational_function(syms) for term in self.args)
 
     _eval_is_bounded = lambda self: self._eval_template_is_attr('is_bounded')
-    _eval_is_integer = lambda self: self._eval_template_is_attr(
-        'is_integer', when_multiple=None)
     _eval_is_commutative = lambda self: self._eval_template_is_attr(
         'is_commutative')
+    _eval_is_rational = lambda self: self._eval_template_is_attr('is_rational',
+        when_multiple=None)
+
+    def _eval_is_integer(self):
+        is_rational = self.is_rational
+
+        if is_rational:
+            n, d = self.as_numer_denom()
+            if d is S.One:
+                return True
+            elif d is S(2):
+                return n.is_even
+        elif is_rational is False:
+            return False
 
     def _eval_is_polar(self):
         has_polar = any(arg.is_polar for arg in self.args)
@@ -1067,10 +1079,15 @@ class Mul(Expr, AssocOp):
         if is_integer:
             r = True
             for t in self.args:
-                if t.is_even:
-                    return False
-                if t.is_odd is None:
-                    r = None
+                if not t.is_integer:
+                    return None
+                elif t.is_even:
+                    r = False
+                elif t.is_integer:
+                    if r is False:
+                        pass
+                    elif t.is_odd is None:
+                        r = None
             return r
 
         # !integer -> !odd

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -391,6 +391,17 @@ def test_Mul_is_even_odd():
     assert (m/2).is_integer is True
 
 
+def test_Mul_is_rational():
+    x = Symbol('x')
+    n = Symbol('n', integer=True)
+    m = Symbol('m', integer=True)
+
+    assert (n/m).is_rational is True
+    assert (x/pi).is_rational is None
+    assert (x/n).is_rational is None
+    assert (n/pi).is_rational is False
+
+
 def test_Add_is_even_odd():
     x = Symbol('x', integer=True)
 

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -317,13 +317,13 @@ def test_Add_Mul_is_integer():
 
     assert (2*k).is_integer is True
     assert (-k).is_integer is True
-    assert (k/3).is_integer is False
+    assert (k/3).is_integer is None
     assert (x*k*n).is_integer is None
 
     assert (k + n).is_integer is True
     assert (k + x).is_integer is None
     assert (k + n*x).is_integer is None
-    assert (k + n/3).is_integer is False
+    assert (k + n/3).is_integer is None
 
     assert ((1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
     assert (1 + (1 + sqrt(3))*(-sqrt(3) + 1)).is_integer is not False
@@ -360,9 +360,9 @@ def test_Mul_is_even_odd():
     assert (3*x).is_even is None
     assert (3*x).is_odd is None
 
-    assert (k/3).is_integer is False
-    assert (k/3).is_even is False
-    assert (k/3).is_odd is False
+    assert (k/3).is_integer is None
+    assert (k/3).is_even is None
+    assert (k/3).is_odd is None
 
     assert (2*n).is_even is True
     assert (2*n).is_odd is False

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -385,6 +385,11 @@ def test_Mul_is_even_odd():
     assert (k*m*x).is_even is True
     assert (k*m*x).is_odd is False
 
+    # issue 3692:
+    assert (x/2).is_integer is None
+    assert (k/2).is_integer is False
+    assert (m/2).is_integer is True
+
 
 def test_Add_is_even_odd():
     x = Symbol('x', integer=True)


### PR DESCRIPTION
This patch alter following Mul methods:
is_integer
is_odd/even
and
is_rational

N.B.: some tests in test_arit.py was broken.  An example:

```
k = Symbol('k', integer=True)
assert (k/3).is_integer is False
```
