### PR TITLE
Issue 2187:IntQubit to work with inner products

### DIFF
--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -375,6 +375,8 @@ class IntQubit(IntQubitState, Qubit):
     def dual_class(self):
         return IntQubitBra
 
+    def _eval_innerproduct_IntQubitBra(self, bra, **hints):
+        return Qubit._eval_innerproduct_QubitBra(self, bra)
 
 class IntQubitBra(IntQubitState, QubitBra):
     """A qubit bra that store integers as binary numbers in qubit values."""

--- a/sympy/physics/quantum/tests/test_qubit.py
+++ b/sympy/physics/quantum/tests/test_qubit.py
@@ -53,6 +53,8 @@ def test_IntQubit():
     assert IntQubit(3).dual_class() == IntQubitBra
     assert IntQubitBra(3).dual_class() == IntQubit
 
+    assert IntQubit(5)._eval_innerproduct_IntQubitBra(IntQubitBra(5)) == Integer(1)
+    assert IntQubit(4)._eval_innerproduct_IntQubitBra(IntQubitBra(5)) == Integer(0)
     raises(ValueError, lambda: IntQubit(4, 1))
 
 


### PR DESCRIPTION
I have tried to fix the above issue.But as it says "we will have to add the appropriate methods to the IntQubit class that call the methods of Qubit" but the above does not currently use the methods of Qubit. Is this fine or does it necessarily have to use the methods of Qubit. I hope this was what was to be done. Thanks. Tests work fine.
