### PR TITLE
Fu tree

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1529,6 +1529,7 @@ if SYMPY_DEBUG:
     (TR0, TR1, TR2, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TR10, TR11, TR12, TR13,
     TR2i, TRmorrie, TR14, TR15, TR16, TR12i, TR111, TR22))
 
+
 _CTR1 = [(TR5, TR0), (TR6, TR0), identity]
 
 _CTR2 = (TR11, [(TR5, TR0), (TR6, TR0), TR0])
@@ -1550,7 +1551,7 @@ _RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
 _RL2 = [
     (TR4, TR3, TR10, TR4, TR3, TR11),
     (TR5, TR7, TR11, TR4),
-    (CTR3, CTR1, TR9, CTR2, TR4, TR9, TR9, CTR4),
+    (_CTR3, _CTR1, TR9, _CTR2, TR4, TR9, TR9, _CTR4),
     identity,
     ]
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1703,14 +1703,11 @@ def process_common_addends(rv, do, key2=None, key1=True):
     return rv
 
 
-FU = dict(zip('''
+fufuncs = '''
     TR0 TR1 TR2 TR3 TR4 TR5 TR6 TR7 TR8 TR9 TR10 TR10i TR11
     TR12 TR13 L TR2i TRmorrie TR12i
-    TR14 TR15 TR16 TR111 TR22'''.split(),
-    (TR0, TR1, TR2, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TR10, TR10i, TR11,
-    TR12, TR13, L, TR2i, TRmorrie, TR12i,
-    TR14, TR15, TR16, TR111, TR22)))
-
+    TR14 TR15 TR16 TR111 TR22'''.split()
+FU = dict(zip(fufuncs, map(locals().get, fufuncs)))
 
 def _roots():
     global _ROOT2, _ROOT3, _invROOT3

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1518,10 +1518,6 @@ def L(rv):
 
 # ============== end of basic Fu-like tools =====================
 
-objective = lambda x: (L(x), x.count_ops())
-strat = partial(greedy, objective=objective)
-
-
 if SYMPY_DEBUG:
     (TR0, TR1, TR2, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TR10, TR11, TR12, TR13,
     TR2i, TRmorrie, TR14, TR15, TR16, TR12i, TR111, TR22
@@ -1541,8 +1537,6 @@ _CTR3 = [(TRmorrie, TR8, TR0), (TRmorrie, TR8, TR10i, TR0), identity]
 
 _CTR4 = [(TR4, TR10i), identity]
 
-CTR1, CTR2, CTR3, CTR4 = map(strat, (_CTR1, _CTR2, _CTR3, _CTR4))
-
 _RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
 
 
@@ -1557,10 +1551,6 @@ _RL2 = [
     (_CTR3, _CTR1, TR9, _CTR2, TR4, TR9, TR9, _CTR4),
     identity,
     ]
-
-
-RL1 = strat(_RL1)
-RL2 = strat(_RL2)
 
 
 def fu(rv, objective=lambda x: (L(x), x.count_ops())):
@@ -1696,10 +1686,10 @@ def process_common_addends(rv, do, key2=None, key1=True):
 
 FU = dict(zip('''
     TR0 TR1 TR2 TR3 TR4 TR5 TR6 TR7 TR8 TR9 TR10 TR10i TR11
-    TR12 TR13 CTR1 CTR2 CTR3 CTR4 RL1 RL2 L TR2i TRmorrie TR12i
+    TR12 TR13 L TR2i TRmorrie TR12i
     TR14 TR15 TR16 TR111 TR22'''.split(),
     (TR0, TR1, TR2, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TR10, TR10i, TR11,
-    TR12, TR13, CTR1, CTR2, CTR3, CTR4, RL1, RL2, L, TR2i, TRmorrie, TR12i,
+    TR12, TR13, L, TR2i, TRmorrie, TR12i,
     TR14, TR15, TR16, TR111, TR22)))
 
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1529,15 +1529,15 @@ if SYMPY_DEBUG:
 # tuples are chains  --  (f, g) -> lambda x: g(f(x))
 # lists are choices  --  [f, g] -> lambda x: min(f(x), g(x), key=objective)
 
-_CTR1 = [(TR5, TR0), (TR6, TR0), identity]
+CTR1 = [(TR5, TR0), (TR6, TR0), identity]
 
-_CTR2 = (TR11, [(TR5, TR0), (TR6, TR0), TR0])
+CTR2 = (TR11, [(TR5, TR0), (TR6, TR0), TR0])
 
-_CTR3 = [(TRmorrie, TR8, TR0), (TRmorrie, TR8, TR10i, TR0), identity]
+CTR3 = [(TRmorrie, TR8, TR0), (TRmorrie, TR8, TR10i, TR0), identity]
 
-_CTR4 = [(TR4, TR10i), identity]
+CTR4 = [(TR4, TR10i), identity]
 
-_RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
+RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
 
 
 # XXX it's a little unclear how this one is to be implemented
@@ -1545,10 +1545,10 @@ _RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
 # The diagram shows all these as one chain of transformations, but the
 # text refers to them being applied independently. Also, a break
 # if L starts to increase has not been implemented.
-_RL2 = [
+RL2 = [
     (TR4, TR3, TR10, TR4, TR3, TR11),
     (TR5, TR7, TR11, TR4),
-    (_CTR3, _CTR1, TR9, _CTR2, TR4, TR9, TR9, _CTR4),
+    (CTR3, CTR1, TR9, CTR2, TR4, TR9, TR9, CTR4),
     identity,
     ]
 
@@ -1612,20 +1612,20 @@ def fu(rv, objective=lambda x: (L(x), x.count_ops())):
     http://rfdz.ph-noe.ac.at/fileadmin/Mathematik_Uploads/ACDCA/
     DESTIME2006/DES_contribs/Fu/simplification.pdf
     """
-    RL1 = greedy(_RL1, objective)
-    RL2 = greedy(_RL2, objective)
+    fRL1 = greedy(RL1, objective)
+    fRL2 = greedy(RL2, objective)
 
     was = rv
     rv = sympify(rv)
     rv = TR1(rv)
     if rv.has(tan, cot):
-        rv1 = RL1(rv)
+        rv1 = fRL1(rv)
         if (objective(rv1) < objective(rv)):
             rv = rv1
         if rv.has(tan, cot):
             rv = TR2(rv)
     if rv.has(sin, cos):
-        rv1 = RL2(rv)
+        rv1 = fRL2(rv)
         rv2 = TR8(TRmorrie(rv1))
         rv = min([was, rv, rv1, rv2], key=objective)
     return min(TR2i(rv), rv, key=objective)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1556,6 +1556,10 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
     """Attempt to simplify expression by using transformation rules given
     in the algorithm by Fu et al.
 
+    :func:`fu` will try to minimize the objective function ``measure``.
+    By default this first minimizes the number of trig terms and then minimizes
+    the number of total operations.
+
     Examples
     ========
 
@@ -1605,6 +1609,12 @@ def fu(rv, measure=lambda x: (L(x), x.count_ops())):
 
     >>> fu(tan(7*pi/18)+tan(5*pi/18)-sqrt(3)*tan(5*pi/18)*tan(7*pi/18))
     -sqrt(3)
+
+    Objective function example
+    >>> fu(sin(x)/cos(x))  # default objective function
+    tan(x)
+    >>> fu(sin(x)/cos(x), measure=lambda x: -x.count_ops()) # maximize op count
+    sin(x)/cos(x)
 
     References
     ==========

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -186,7 +186,6 @@ http://www.sosmath.com/trig/Trig5/trig5/pdf/pdf.html gives a formula sheet.
 """
 
 from collections import defaultdict
-from functools import partial
 
 from sympy.simplify.simplify import (simplify, powsimp, ratsimp, combsimp,
     _mexpand)

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1530,6 +1530,9 @@ if SYMPY_DEBUG:
     TR2i, TRmorrie, TR14, TR15, TR16, TR12i, TR111, TR22))
 
 
+# tuples are chains  --  (f, g) -> lambda x: g(f(x))
+# lists are choices  --  [f, g] -> lambda x: min(f(x), g(x), key=objective)
+
 _CTR1 = [(TR5, TR0), (TR6, TR0), identity]
 
 _CTR2 = (TR11, [(TR5, TR0), (TR6, TR0), TR0])

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -503,8 +503,10 @@ def _TR56(rv, f, g, h, max, pow):
         return h(g(rv.base.args[0])**2)**e
 
 
-def TR5(rv):
+def TR5(rv, max=4, pow=False):
     """Replacement of sin**2 with 1 - cos(x)**2.
+
+    See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
     Examples
     ========
@@ -519,11 +521,13 @@ def TR5(rv):
     >>> TR5(sin(x)**4)
     (-cos(x)**2 + 1)**2
     """
-    return _TR56(rv, sin, cos, lambda x: 1 - x, max=4, pow=False)
+    return _TR56(rv, sin, cos, lambda x: 1 - x, max=max, pow=pow)
 
 
-def TR6(rv):
+def TR6(rv, max=4, pow=False):
     """Replacement of cos**2 with 1 - sin(x)**2.
+
+    See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
     Examples
     ========
@@ -538,7 +542,7 @@ def TR6(rv):
     >>> TR6(cos(x)**4)
     (-sin(x)**2 + 1)**2
     """
-    return _TR56(rv, cos, sin, lambda x: 1 - x, max=4, pow=False)
+    return _TR56(rv, cos, sin, lambda x: 1 - x, max=max, pow=pow)
 
 
 def TR7(rv):
@@ -1400,8 +1404,10 @@ def TR14(rv, first=True):
     return rv
 
 
-def TR15(rv):
-    """Convert sin(x)*-2 to 1 + cot(x)**2
+def TR15(rv, max=4, pow=False):
+    """Convert sin(x)*-2 to 1 + cot(x)**2.
+
+    See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
     Examples
     ========
@@ -1418,13 +1424,15 @@ def TR15(rv):
         return rv
 
     ia = 1/rv
-    a = _TR56(ia, sin, cot, lambda x: 1 + x, max=4, pow=False)
+    a = _TR56(ia, sin, cot, lambda x: 1 + x, max=max, pow=pow)
     if a != ia:
         rv = a
     return rv
 
-def TR16(rv):
-    """Convert cos(x)*-2 to 1 + tan(x)**2
+def TR16(rv, max=4, pow=False):
+    """Convert cos(x)*-2 to 1 + tan(x)**2.
+
+    See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
     Examples
     ========
@@ -1441,7 +1449,7 @@ def TR16(rv):
         return rv
 
     ia = 1/rv
-    a = _TR56(ia, cos, tan, lambda x: 1 + x, max=4, pow=False)
+    a = _TR56(ia, cos, tan, lambda x: 1 + x, max=max, pow=pow)
     if a != ia:
         rv = a
     return rv
@@ -1476,8 +1484,10 @@ def TR111(rv):
     return rv
 
 
-def TR22(rv):
-    """Convert tan(x)**2 to sec(x)**2 - 1 and cot(x)**2 to csc(x)**2 - 1
+def TR22(rv, max=4, pow=False):
+    """Convert tan(x)**2 to sec(x)**2 - 1 and cot(x)**2 to csc(x)**2 - 1.
+
+    See _TR56 docstring for advanced use of ``max`` and ``pow``.
 
     Examples
     ========
@@ -1495,8 +1505,8 @@ def TR22(rv):
     if not (isinstance(rv, Pow) and rv.base.func in (cot, tan)):
         return rv
 
-    rv = _TR56(rv, tan, sec, lambda x: x - 1, max=4, pow=False)
-    rv = _TR56(rv, cot, csc, lambda x: x - 1, max=4, pow=False)
+    rv = _TR56(rv, tan, sec, lambda x: x - 1, max=max, pow=pow)
+    rv = _TR56(rv, cot, csc, lambda x: x - 1, max=max, pow=pow)
     return rv
 
 

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1563,7 +1563,7 @@ RL1 = strat(_RL1)
 RL2 = strat(_RL2)
 
 
-def fu(rv):
+def fu(rv, objective=lambda x: (L(x), x.count_ops())):
     """Attempt to simplify expression by using transformation rules given
     in the algorithm by Fu et al.
 
@@ -1622,23 +1622,23 @@ def fu(rv):
     http://rfdz.ph-noe.ac.at/fileadmin/Mathematik_Uploads/ACDCA/
     DESTIME2006/DES_contribs/Fu/simplification.pdf
     """
+    RL1 = greedy(_RL1, objective)
+    RL2 = greedy(_RL2, objective)
+
     was = rv
     rv = sympify(rv)
     rv = TR1(rv)
     if rv.has(tan, cot):
         rv1 = RL1(rv)
-        if (_L(rv1) < _L(rv)):
+        if (objective(rv1) < objective(rv)):
             rv = rv1
         if rv.has(tan, cot):
             rv = TR2(rv)
     if rv.has(sin, cos):
         rv1 = RL2(rv)
         rv2 = TR8(TRmorrie(rv1))
-        rv = ordered(
-            [was, rv, rv1, rv2], keys=(L, count_ops), default=False).next()
-    return min(TR2i(rv), rv, key=lambda x: (L(x), x.count_ops()))
-
-_L = lambda x: (L(x), x.count_ops())
+        rv = min([was, rv, rv1, rv2], key=objective)
+    return min(TR2i(rv), rv, key=objective)
 
 
 def bottom_up(rv, F):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1552,7 +1552,7 @@ RL2 = [
     ]
 
 
-def fu(rv, objective=lambda x: (L(x), x.count_ops())):
+def fu(rv, measure=lambda x: (L(x), x.count_ops())):
     """Attempt to simplify expression by using transformation rules given
     in the algorithm by Fu et al.
 
@@ -1611,23 +1611,23 @@ def fu(rv, objective=lambda x: (L(x), x.count_ops())):
     http://rfdz.ph-noe.ac.at/fileadmin/Mathematik_Uploads/ACDCA/
     DESTIME2006/DES_contribs/Fu/simplification.pdf
     """
-    fRL1 = greedy(RL1, objective)
-    fRL2 = greedy(RL2, objective)
+    fRL1 = greedy(RL1, measure)
+    fRL2 = greedy(RL2, measure)
 
     was = rv
     rv = sympify(rv)
     rv = TR1(rv)
     if rv.has(tan, cot):
         rv1 = fRL1(rv)
-        if (objective(rv1) < objective(rv)):
+        if (measure(rv1) < measure(rv)):
             rv = rv1
         if rv.has(tan, cot):
             rv = TR2(rv)
     if rv.has(sin, cos):
         rv1 = fRL2(rv)
         rv2 = TR8(TRmorrie(rv1))
-        rv = min([was, rv, rv1, rv2], key=objective)
-    return min(TR2i(rv), rv, key=objective)
+        rv = min([was, rv, rv1, rv2], key=measure)
+    return min(TR2i(rv), rv, key=measure)
 
 
 def bottom_up(rv, F):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -186,6 +186,7 @@ http://www.sosmath.com/trig/Trig5/trig5/pdf/pdf.html gives a formula sheet.
 """
 
 from collections import defaultdict
+from functools import partial
 
 from sympy.simplify.simplify import (simplify, powsimp, ratsimp, combsimp,
     _mexpand)
@@ -204,8 +205,8 @@ from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.rules import Transform
 from sympy.core.basic import S
 from sympy.core.numbers import Integer, pi, I
-from sympy.strategies import minimize, chain, debug
-from sympy.strategies.core import identity
+from sympy.strategies.tree import greedy
+from sympy.strategies.core import identity, debug
 from sympy.polys.polytools import factor
 from sympy.ntheory.factor_ import perfect_power
 
@@ -1517,6 +1518,10 @@ def L(rv):
 
 # ============== end of basic Fu-like tools =====================
 
+objective = lambda x: (L(x), x.count_ops())
+strat = partial(greedy, objective=objective)
+
+
 if SYMPY_DEBUG:
     (TR0, TR1, TR2, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TR10, TR11, TR12, TR13,
     TR2i, TRmorrie, TR14, TR15, TR16, TR12i, TR111, TR22
@@ -1524,22 +1529,17 @@ if SYMPY_DEBUG:
     (TR0, TR1, TR2, TR3, TR4, TR5, TR6, TR7, TR8, TR9, TR10, TR11, TR12, TR13,
     TR2i, TRmorrie, TR14, TR15, TR16, TR12i, TR111, TR22))
 
-_CTR1 = [TR5, TR0], [TR6, TR0], [identity]
+_CTR1 = [(TR5, TR0), (TR6, TR0), identity]
 
-_CTR2 = [TR11, TR5, TR0], [TR11, TR6, TR0], [TR11, TR0]
+_CTR2 = (TR11, [(TR5, TR0), (TR6, TR0), TR0])
 
-_CTR3 = [TRmorrie, TR8, TR0], [TRmorrie, TR8, TR10i, TR0], [identity]
+_CTR3 = [(TRmorrie, TR8, TR0), (TRmorrie, TR8, TR10i, TR0), identity]
 
-_CTR4 = [TR4, TR10i], [identity]
+_CTR4 = [(TR4, TR10i), identity]
 
+CTR1, CTR2, CTR3, CTR4 = map(strat, (_CTR1, _CTR2, _CTR3, _CTR4))
 
-def CTRstrat(lists):
-    return minimize(*[chain(*list) for list in lists],
-        **dict(objective=lambda x: (L(x), x.count_ops())))
-
-CTR1, CTR2, CTR3, CTR4 = map(CTRstrat, (_CTR1, _CTR2, _CTR3, _CTR4))
-
-_RL1 = [TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0]
+_RL1 = (TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0)
 
 
 # XXX it's a little unclear how this one is to be implemented
@@ -1548,18 +1548,15 @@ _RL1 = [TR4, TR3, TR4, TR12, TR4, TR13, TR4, TR0]
 # text refers to them being applied independently. Also, a break
 # if L starts to increase has not been implemented.
 _RL2 = [
-    [TR4, TR3, TR10, TR4, TR3, TR11],
-    [TR5, TR7, TR11, TR4],
-    [CTR3, CTR1, TR9, CTR2, TR4, TR9, TR9, CTR4],
-    [identity],
+    (TR4, TR3, TR10, TR4, TR3, TR11),
+    (TR5, TR7, TR11, TR4),
+    (CTR3, CTR1, TR9, CTR2, TR4, TR9, TR9, CTR4),
+    identity,
     ]
 
 
-def RLstrat(rls):
-    return chain(*rls)
-
-RL1 = RLstrat(_RL1)
-RL2 = CTRstrat(_RL2)
+RL1 = strat(_RL1)
+RL2 = strat(_RL2)
 
 
 def fu(rv):

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -271,9 +271,9 @@ def test_fu():
 
 
 def test_objective():
-    assert fu(sin(x)/cos(x), objective=lambda x: x.count_ops()) == \
+    assert fu(sin(x)/cos(x), measure=lambda x: x.count_ops()) == \
             tan(x)
-    assert fu(sin(x)/cos(x), objective=lambda x: -x.count_ops()) == \
+    assert fu(sin(x)/cos(x), measure=lambda x: -x.count_ops()) == \
             sin(x)/cos(x)
 
 

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -270,6 +270,13 @@ def test_fu():
     assert fu(expr) == sin(1024)/(1024*sin(1))
 
 
+def test_objective():
+    assert fu(sin(x)/cos(x), objective=lambda x: x.count_ops()) == \
+            tan(x)
+    assert fu(sin(x)/cos(x), objective=lambda x: -x.count_ops()) == \
+            sin(x)/cos(x)
+
+
 def test_process_common_addends():
     # this tests that the args are not evaluated as they are given to do
     # and that key2 works when key1 is False


### PR DESCRIPTION
`fu` function makes use of tree strategies.  This uses `sympy.strategies.tree.greedy` to organize transformations rather than chain and minimize.  Aside from a slightly more established syntax this also introduces a couple of efficiencies in the call trees.

This pull request also passes a keyword function `objective` from `fu(...)` into the call tree.
