### PR TITLE
Optimized number of permutations of mappings in heurisch()

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2344,7 +2344,7 @@ class Expr(Basic, EvalfMixin):
             >>> e.series(x, n=2)
             cos(exp(y)) - x*sin(exp(y)) + O(x**2)
 
-            If ``n=None`` then an iterator of the series terms will be returned.
+            If ``n=None`` then a generator of the series terms will be returned.
 
             >>> term=cos(x).series(n=None)
             >>> [term.next() for i in range(2)]

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -258,10 +258,10 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3, degree_o
         # Pre-sort mapping in order of largest to smallest expressions (last is always x).
         def _sort_key(arg):
             return default_sort_key(arg[0].as_independent(x)[1])
-        mapping = sorted(mapping.items(), key=_sort_key, reverse=True)
         #optimizing the number of permutations of mappping
-        unnecessary_permutations = [(expr, v) for expr, v in mapping if expr == x]
-        mapping = [necessary for necessary in mapping if necessary not in unnecessary_permutations]
+        unnecessary_permutations = [(x, mapping[x])]
+        del mapping[x]
+        mapping = sorted(mapping.items(), key=_sort_key, reverse=True)
         mappings = permutations(mapping)
 
     def _substitute(expr):

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -250,7 +250,7 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3, degree_o
     rev_mapping = {}
 
     if unnecessary_permutations is None:
-        unnecessary_permutations = [] #static initialization of the variable
+        unnecessary_permutations = []
     for k, v in mapping.iteritems():
         rev_mapping[v] = k
 
@@ -260,20 +260,16 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3, degree_o
             return default_sort_key(arg[0].as_independent(x)[1])
         mapping = sorted(mapping.items(), key=_sort_key, reverse=True)
         #optimizing the number of permutations of mappping
-        unnecessary_permutations = filter(lambda i: i[0] == x, mapping)
+        unnecessary_permutations = [(expr, v) for expr, v in mapping if expr == x]
         mapping = [necessary for necessary in mapping if necessary not in unnecessary_permutations]
-
         mappings = permutations(mapping)
 
     def _substitute(expr):
         return expr.subs(mapping)
+
     for mapping in mappings:
-
         mapping = list(mapping)
-
-        if unnecessary_permutations is not []:
-              mapping = mapping + unnecessary_permutations
-
+        mapping = mapping + unnecessary_permutations
         diffs = [ _substitute(cancel(g.diff(x))) for g in terms ]
         denoms = [ g.as_numer_denom()[1] for g in diffs ]
         if all(h.is_polynomial(*V) for h in denoms) and _substitute(f).is_rational_function(*V):


### PR DESCRIPTION
Reduced the number of permutations of mapping by not generating cases where mapping[-1] != x
While earlier the number of terms or components of a function being permuted were (say) n after these changes they have reduced to n-1, thus improving the time complexity
