### PR TITLE
Fix for issue 3591 and 3705

### DIFF
--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -114,7 +114,8 @@ class vectorized_lambdify(object):
             temp_args = (np.array(a, dtype=np.complex) for a in args)
             results = self.vector_func(*temp_args)
             results = np.ma.masked_where(
-                np.abs(results.imag) != 0, results.real, copy=False)
+                                np.abs(results.imag) > 1e-7 * np.abs(results),
+                                results.real, copy=False)
         except Exception, e:
             #DEBUG: print 'Error', type(e), e
             if ((isinstance(e, TypeError)
@@ -138,7 +139,8 @@ class vectorized_lambdify(object):
                     self.lambda_func, otypes=[np.complex])
                 results = self.vector_func(*args)
                 results = np.ma.masked_where(
-                    np.abs(results.imag) != 0, results.real, copy=False)
+                                np.abs(results.imag) > 1e-7 * np.abs(results),
+                                results.real, copy=False)
             else:
                 # Complete failure. One last try with no translations, only
                 # wrapping in complex((...).evalf()) and returning the real
@@ -154,7 +156,8 @@ class vectorized_lambdify(object):
                         self.lambda_func, otypes=[np.complex])
                     results = self.vector_func(*args)
                     results = np.ma.masked_where(
-                        np.abs(results.imag) != 0, results.real, copy=False)
+                            np.abs(results.imag) > 1e-7 * np.abs(results),
+                            results.real, copy=False)
                     warnings.warn('The evaluation of the expression is'
                             ' problematic. We are trying a failback method'
                             ' that may still work. Please report this as a bug.')

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -189,20 +189,21 @@ class lambdify(object):
             #The result can be sympy.Float. Hence wrap it with complex type.
             result = complex(self.lambda_func(args))
             if abs(result.imag) > 1e-7 * abs(result):
-                result = None
+                return None
             else:
-                result = result.real
+                return result.real
         except Exception, e:
             # The exceptions raised by sympy, cmath are not consistent and
             # hence it is not possible to specify all the exceptions that
             # are to be caught. Presently there are no cases for which the code
-            # reaches this block other than ZeroDivisionError. Also the
-            # exception is caught only once. If the exception repeats itself,
+            # reaches this block other than ZeroDivisionError and complex
+            # comparision. Also the exception is caught only once. If the
+            # exception repeats itself,
             # then it is not caught and the corresponding error is raised.
             # XXX: Remove catching all exceptions once the plotting module
             # is heavily tested.
             if isinstance(e, ZeroDivisionError):
-                result = None
+                return None
             elif isinstance(e, TypeError) and ('no ordering relation is'
                                                ' defined for complex numbers'
                                                in str(e)):
@@ -210,6 +211,7 @@ class lambdify(object):
                                                          use_evalf=True,
                                                          use_python_math=True)
                 result = self.lambda_func(args.real)
+                return result
             else:
                 if self.failure:
                     raise e
@@ -224,10 +226,9 @@ class lambdify(object):
                         ' problematic. We are trying a failback method'
                         ' that may still work. Please report this as a bug.')
                 if abs(result.imag) > 1e-7 * abs(result):
-                    result = None
+                    return None
                 else:
-                    result = result.real
-        return result
+                    return result.real
 
 
 def experimental_lambdify(*args, **kwargs):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -36,6 +36,8 @@ from experimental_lambdify import (vectorized_lambdify, lambdify)
 np = import_module('numpy')
 
 # Backend specific imports - matplotlib
+# When changing the minimum module version for matplotlib, please change
+# the same in the `SymPyDocTestFinder`` in `sympy/utilities/runtests.py`
 matplotlib = import_module('matplotlib',
     __import__kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
     min_module_version='1.1.0', catch=(RuntimeError,))

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -38,7 +38,7 @@ np = import_module('numpy')
 # Backend specific imports - matplotlib
 matplotlib = import_module('matplotlib',
     __import__kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
-    min_module_version='1.0.0', catch=(RuntimeError,))
+    min_module_version='1.1.0', catch=(RuntimeError,))
 if matplotlib:
     plt = matplotlib.pyplot
     cm = matplotlib.cm

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -4,6 +4,7 @@ from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
 from sympy.plotting.plot import matplotlib, unset_show
 from sympy.utilities.pytest import skip
+from sympy.plotting.experimental_lambdify import lambdify
 from tempfile import NamedTemporaryFile
 import warnings
 
@@ -192,12 +193,17 @@ def plot_and_save(name):
             + meijerg(((1/2,), ()), ((5, 0, 1/2), ()),
                 5*x**2 * exp_polar(I*pi)/2)) / (48 * pi), (x, 1e-6, 1e-2)).save(tmp_file())
 
-    #Plots which use Max
-    plot(Max(x, 5)).save(tmp_file())
-
 
 def test_matplotlib():
     if matplotlib:
         plot_and_save('test')
     else:
         skip("Matplotlib not the default backend")
+
+
+# Tests for exceptiion handling in experimental_lambdify
+def test_experimental_lambify():
+    x = Symbol('x')
+    lambdify([x], Max(x, 5))
+    assert Max(2, 5) == 5
+    assert Max(7, 5) == 7

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -1,5 +1,5 @@
 from sympy import (pi, sin, cos, Symbol, Integral, summation, sqrt, log,
-                   oo, LambertW, I, meijerg, exp_polar)
+                   oo, LambertW, I, meijerg, exp_polar, Max)
 from sympy.plotting import (plot, plot_parametric, plot3d_parametric_line,
                             plot3d, plot3d_parametric_surface)
 from sympy.plotting.plot import matplotlib, unset_show
@@ -190,7 +190,10 @@ def plot_and_save(name):
     #Characteristic function of a StudentT distribution with nu=10
     plot((meijerg(((1 / 2,), ()), ((5, 0, 1 / 2), ()), 5 * x**2 * exp_polar(-I*pi)/2)
             + meijerg(((1/2,), ()), ((5, 0, 1/2), ()),
-                5*x**2 * exp_polar(I*pi)/2)) / (48 * pi), (x, 1e-6, 1e-2))
+                5*x**2 * exp_polar(I*pi)/2)) / (48 * pi), (x, 1e-6, 1e-2)).save(tmp_file())
+
+    #Plots which use Max
+    plot(Max(x, 5)).save(tmp_file())
 
 
 def test_matplotlib():

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1308,7 +1308,7 @@ class SymPyDocTestFinder(DocTestFinder):
                             'matplotlib',
                             __import__kwargs={'fromlist':
                                               ['pyplot', 'cm', 'collections']},
-                            min_module_version='1.0.0', catch=(RuntimeError,))
+                            min_module_version='1.1.0', catch=(RuntimeError,))
                         if matplotlib is not None:
                             pass
                             # print "EXTMODULE matplotlib version %s found" % \


### PR DESCRIPTION
This pull request handles value error due to comparison of complex numbers in experimental_lambdify.

Increases the minimum matplotlib version to 1.1.0 to handle issue 3705.
