### PR TITLE
Implemented risch_integrate for trigonometric, inverse trigonometric and hyperbolic functions

### DIFF
--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,7 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import with_statement
-from sympy import (Poly, S, Function, log, symbols, exp, tan, sqrt,
-    Symbol, Lambda, sin)
+from sympy import (Poly, I, S, Function, log, symbols, exp, tan, sqrt,
+    Symbol, Lambda, sin, cos)
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
     hermite_reduce, polynomial_reduce, residue_reduce, residue_reduce_to_basic,
@@ -539,11 +539,13 @@ def test_DecrementLevel():
 
 def test_risch_integrate():
     assert risch_integrate(t0*exp(x), x) == t0*exp(x)
+    assert risch_integrate(sin(x), x, rewrite_complex=True) == -exp(I*x)/2 - exp(-I*x)/2
 
     # From my GSoC writeup
     assert risch_integrate((1 + 2*x**2 + x**4 + 2*x**3*exp(2*x**2))/
     (x**4*exp(x**2) + 2*x**2*exp(x**2) + exp(x**2)), x) == \
         NonElementaryIntegral(exp(-x**2), x) + exp(x**2)/(1 + x**2)
+
 
     assert risch_integrate(0, x) == 0
 


### PR DESCRIPTION
Earlier:

> > risch_integrate(sin(x),x)
> > NotImplementedError

Now:

> > risch_integrate(sin(x),x)
> > -cos(x)
> > integrate(sin(x),x,risch=True)
> > -cos(x)

Added flag "rewrite_complex" to prevent calculation of every integral in terms of complex numbers (as we can get better results from other algorithms).
Conversions of trigonometric , inverse trigno , hyperbolic is implemented a s a fall back measure(if no algorithm gives anti-derivative then all the above functions would be converted into exponential or logarithmic components)   
