### PR TITLE
Lambdify uses Dummy symbols

### DIFF
--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -369,6 +369,9 @@ def test_dummification():
     assert lam(3, 9) == 2
     lam = lambdify(sin(t), 2 * sin(t)**2)
     assert lam(F(t)) == 2 * F(t)**2
+    raises(SyntaxError, lambda: lambdify(F(t) * G(t), F(t) * G(t) + 5))
+    raises(SyntaxError, lambda: lambdify(2 * F(t), 2 * F(t) + 5))
+    raises(SyntaxError, lambda: lambdify(2 * F(t), 4 * F(t) + 5))
 
 
 #================== Test special printers ==========================

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,7 +1,7 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
-    symbols, lambdify, sqrt, sin, cos, pi, Rational, Float,
-    Matrix, Lambda, exp, Integral, oo, I, Abs)
+    symbols, lambdify, sqrt, sin, cos, pi, atan, Rational, Float,
+    Matrix, Lambda, exp, Integral, oo, I, Abs, Function)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy import mpmath
 from sympy.utilities.lambdify import implemented_function
@@ -17,7 +17,7 @@ numpy = import_module('numpy', min_python_version=(2, 6))
 
 x, y, z = symbols('x,y,z')
 
-#================== Test different arguments ==============
+#================== Test different arguments =======================
 
 
 def test_no_args():
@@ -72,7 +72,7 @@ def test_atoms():
     f = lambdify(x, I + x, {"I": 1j})
     assert f(1) == 1 + 1j
 
-#================== Test different modules ================
+#================== Test different modules =========================
 
 # high precision output of sin(0.2*pi) is used to detect if precision is lost unwanted
 
@@ -120,7 +120,7 @@ def test_number_precision():
     prec = 1e-49  # mpmath precision is around 50 decimal places
     assert -prec < f(0) - sin02 < prec
 
-#================== Test Translations =====================
+#================== Test Translations ==============================
 # We can only check if all translated functions are valid. It has to be checked
 # by hand if they are complete.
 
@@ -157,7 +157,7 @@ def test_numpy_translation_abs():
     assert f(-1) == 1
     assert f(1) == 1
 
-#================== Test some functions ===================
+#================== Test some functions ============================
 
 
 def test_exponentiation():
@@ -190,7 +190,7 @@ def test_trig():
     assert -prec < d[0] + 1 < prec
     assert -prec < d[1] < prec
 
-#================== Test vectors ==========================
+#================== Test vectors ===================================
 
 
 def test_vector_simple():
@@ -265,7 +265,7 @@ def test_integral():
     l = lambdify(x, Integral(f(x), (x, -oo, oo)), modules="sympy")
     assert l(x) == Integral(exp(-x**2), (x, -oo, oo))
 
-#########Test Symbolic###########
+#================== Test symbolic ==================================
 
 
 def test_sym_single_arg():
@@ -359,6 +359,17 @@ def test_lambdify_imps():
     # Unless flag passed
     lam = lambdify(x, f(x), d, use_imps=False)
     assert lam(3) == 102
+
+def test_dummification():
+    t = symbols('t')
+    F = Function('F')
+    G = Function('G')
+    some_expr = 2 * F(t)**2 / G(t)
+    lam = lambdify((F(t), G(t)), some_expr)
+    assert lam(3, 9) == 2
+    lam = lambdify(sin(t), 2 * sin(t)**2)
+    assert lam(F(t)) == 2 * F(t)**2
+
 
 #================== Test special printers ==========================
 


### PR DESCRIPTION
Within lambdify, lambdastr specifically, all over the provided args are replaced with Dummy symbols within the expr to be evaluated. This allows for substitution of things with unfriendly names, such as AppliedUndef's (e.g., x(t)).

Before this failed:

> t = symbols('t')
> x = Function('x')
> y = x(t)
> lambdify(y, 2*y)

Now the above works.

Within lambdastr, the default behavior is not to dummify everything; it is a kwarg option. When lambdstr is called by lambdify though, dummify is set to True. The justification for this is that if lambdastr is called directly by a user, they might want to observe the output, in which case all Dummy symbols would be confusing; if lambdify calls lambdastr, they won't be able to see the output, and the lambdastr readability doesn't matter, making the increased range of input arguments worth it.

In addition, translations from ImmutableMatrix -> matrix needed to be added, as calling sympify on a Matrix results in an ImmutableMatrix.

A few tests were added to ensure that the new lambdify functionality works.
