### PR TITLE
Implement reductions for the product of a complex conjugate pairs (issue 2296)

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -617,6 +617,15 @@ class Mul(Expr, AssocOp):
         for a in self.args:
             if a.is_real:
                 coeff *= a
+            elif a.is_commutative:
+                # search for complex conjugate pairs:
+                for i, x in enumerate(other):
+                    if x == a.conjugate():
+                        coeff *= C.Abs(x)**2
+                        del other[i]
+                        break
+                else:
+                    other.append(a)
             else:
                 other.append(a)
         m = Mul(*other)

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -1,5 +1,5 @@
-from sympy import (S, Symbol, sqrt, I, Integer, Rational, cos, sin, im, re,
-        exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi,
+from sympy import (S, Symbol, sqrt, I, Integer, Rational, cos, sin, im, re, Abs,
+        exp, sinh, cosh, tan, tanh, conjugate, sign, cot, coth, pi, symbols,
         expand_complex)
 from sympy.utilities.pytest import XFAIL
 
@@ -165,9 +165,20 @@ def test_issue_2137():
 
 
 def test_real_imag():
-    x = Symbol('x')
+    x, y, z = symbols('x, y, z')
+    X, Y, Z = symbols('X, Y, Z', commutative=False)
     a = Symbol('a', real=True)
     assert (2*a*x).as_real_imag() == (2*a*re(x), 2*a*im(x))
+
+    # issue 2296:
+    assert (x*x.conjugate()).as_real_imag() == (Abs(x)**2, 0)
+    assert im(x*x.conjugate()) == 0
+    assert im(x*y.conjugate()*z*y) == im(x*z)*Abs(y)**2
+    assert im(x*y.conjugate()*x*y) == im(x**2)*Abs(y)**2
+    assert im(Z*y.conjugate()*X*y) == im(Z*X)*Abs(y)**2
+    assert im(X*X.conjugate()) == im(X*X.conjugate(), evaluate=False)
+    assert (sin(x)*sin(x).conjugate()).as_real_imag() == \
+        (Abs(sin(x))**2, 0)
 
 
 def test_pow_issue_1724():


### PR DESCRIPTION
This is done for Mul.as_real_imag,  e.g. im(x*x.conjugate()) -> 0

Can we do something else?  E.g. alter assumptions code to recognize x*x.conjugate() as a real.  This seems to be too costly, as was noted in the issue thread.
