### PR TITLE
3712 - simplify changes (last commit)

### DIFF
--- a/doc/src/modules/concrete.rst
+++ b/doc/src/modules/concrete.rst
@@ -75,7 +75,7 @@ minimal degree. Otherwise is will return `None` to say that sequence is not
 hypergeometric:
 
     >>> hypersimp(factorial(2*n), n)
-    4*n**2 + 6*n + 2
+    2*(n + 1)*(2*n + 1)
     >>> hypersimp(factorial(n**2), n)
 
 Concrete Class Reference

--- a/doc/src/modules/physics/mechanics/examples.rst
+++ b/doc/src/modules/physics/mechanics/examples.rst
@@ -94,9 +94,9 @@ for the u dots (time derivatives of the generalized speeds). ::
   >>> rhs = rhs.subs(kdd)
   >>> rhs.simplify()
   >>> mprint(rhs)
-  [(4*g*sin(q2)/5 + 2*r*u2*u3 - r*u3**2*tan(q2))/r]
-  [                                     -2*u1*u3/3]
-  [                        (-2*u2 + u3*tan(q2))*u1]
+  [4*g*sin(q2)/(5*r) + 2*u2*u3 - u3**2*tan(q2)]
+  [                                 -2*u1*u3/3]
+  [                    (-2*u2 + u3*tan(q2))*u1]
 
 This concludes the rolling disc example.
 
@@ -162,9 +162,9 @@ represent the constraint forces in those directions. ::
   >>> rhs = rhs.subs(kdd)
   >>> rhs.simplify()
   >>> mprint(rhs)
-  [(4*g*sin(q2)/5 + 2*r*u2*u3 - r*u3**2*tan(q2))/r]
-  [                                     -2*u1*u3/3]
-  [                        (-2*u2 + u3*tan(q2))*u1]
+  [4*g*sin(q2)/(5*r) + 2*u2*u3 - u3**2*tan(q2)]
+  [                                 -2*u1*u3/3]
+  [                    (-2*u2 + u3*tan(q2))*u1]
   >>> from sympy import signsimp, collect, factor_terms
   >>> mprint(KM.auxiliary_eqs.applyfunc(lambda w: signsimp(collect(factor_terms(w), m*r))))
   [                                                   m*r*(u1*u3 + u2') - f1]
@@ -570,9 +570,9 @@ accelerations(q double dots) with the ``rhs`` method. ::
   [                     m*r*(8*g*sin(q2) - 5*r*sin(2*q2)*q1'**2 - 12*r*cos(q2)*q1'*q3' + 10*r*q2'')/8]
   [                                                3*m*r**2*(sin(q2)*q1'' + cos(q2)*q1'*q2' + q3'')/2]
   >>> lrhs = l.rhs(); lrhs.simplify(); lrhs
-  [                                                                q1']
-  [                                                                q2']
-  [                                                                q3']
-  [                     -2*(2*cos(q2)*tan(q2)*q1' + 3*q3')*q2'/cos(q2)]
-  [(-8*g*sin(q2) + 5*r*sin(2*q2)*q1'**2 + 12*r*cos(q2)*q1'*q3')/(10*r)]
-  [               (-5*cos(q2)*q1' + 6*tan(q2)*q3' + 4*q1'/cos(q2))*q2']
+  [                                                          q1']
+  [                                                          q2']
+  [                                                          q3']
+  [                     -4*(tan(q2)*q1' + 3*q3'/(2*cos(q2)))*q2']
+  [-4*g*sin(q2)/(5*r) + sin(2*q2)*q1'**2/2 + 6*cos(q2)*q1'*q3'/5]
+  [         (-5*cos(q2)*q1' + 6*tan(q2)*q3' + 4*q1'/cos(q2))*q2']

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1050,7 +1050,13 @@ class Basic(object):
         if self in rule:
             return rule[self]
         elif rule:
-            args = tuple([arg.xreplace(rule) for arg in self.args])
+            args = []
+            for a in self.args:
+                try:
+                    args.append(a.xreplace(rule))
+                except AttributeError:
+                    args.append(a)
+            args = tuple(args)
             if not _aresame(args, self.args):
                 return self.func(*args)
         return self

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -471,8 +471,8 @@ class Expr(Basic, EvalfMixin):
         >>> one = cos(x)**2 + sin(x)**2
         >>> one.is_constant()
         True
-        >>> ((one - 1)**(x + 1)).is_constant() # could be 0 or 1
-        False
+        >>> ((one - 1)**(x + 1)).is_constant() in (True, False) # could be 0 or 1
+        True
         """
 
         simplify = flags.get('simplify', True)
@@ -501,9 +501,6 @@ class Expr(Basic, EvalfMixin):
 
         # simplify unless this has already been done
         if simplify:
-            self = self.as_content_primitive()[1]
-            if self.is_commutative:
-                self = self.cancel()
             self = self.simplify()
 
         # is_zero should be a quick assumptions check; it can be wrong for
@@ -581,10 +578,7 @@ class Expr(Basic, EvalfMixin):
         # don't worry about doing simplification steps one at a time
         # because if the expression ever goes to 0 then the subsequent
         # simplification steps that are done will be very fast.
-        diff = (self - other).as_content_primitive()[1]
-        if diff.is_commutative:
-            diff = diff.cancel()
-        diff = factor_terms(diff.simplify(), radical=True)
+        diff = factor_terms((self - other).simplify(), radical=True)
 
         if not diff:
             return True

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1464,11 +1464,6 @@ def test_equals():
     S(13)/6)/2 - S(1)/4)**2 - S(1)/3)
     assert z.equals(0)
 
-    # SELF UPDATING CODE TEST
-    # If this tests fails then the cancel in line 581 of expr.py
-    # can be deleted and then below, "!= 0" -> "is S.Zero"
-    assert simplify(z) != 0
-
 
 def test_random():
     from sympy import posify, lucas

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -786,14 +786,13 @@ def test_M7():
     assert set(solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
         226*x**2 - 140*x + 46, x)) == set([
         1 + sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 - sqrt(-4*sqrt(3) - 3))/2,
         1 + sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 + sqrt(-4*sqrt(3) - 3))/2,
-        1 + sqrt(2)*sqrt(-3 - sqrt(-4*sqrt(3) - 3))/2,
+        1 - sqrt(2)*sqrt(-3 + I*sqrt(3 + 4*sqrt(3)))/2,
+        1 + sqrt(2)*sqrt(-3 - I*sqrt(3 + 4*sqrt(3)))/2,
+        1 + sqrt(2)*sqrt(-3 + I*sqrt(3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 - I*sqrt(3 + 4*sqrt(3)))/2,
         1 - sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
-        1 + sqrt(2)*sqrt(-3 + sqrt(-4*sqrt(3) - 3))/2,
-        ])
+        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,])
 
 
 @XFAIL  # There are an infinite number of solutions.

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -785,14 +785,14 @@ def test_M6():
 def test_M7():
     assert set(solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
         226*x**2 - 140*x + 46, x)) == set([
-        1 + sqrt(-6 + 2*sqrt(-4*sqrt(3) - 3))/2,
-        1 + sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 + sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 - 2*sqrt(-4*sqrt(3) - 3))/2,
-        1 - sqrt(-6 + 2*sqrt(-4*sqrt(3) - 3))/2,
-        1 + sqrt(-6 - 2*sqrt(-4*sqrt(3) - 3))/2,
+        1 + sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 - sqrt(-4*sqrt(3) - 3))/2,
+        1 + sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 + sqrt(-4*sqrt(3) - 3))/2,
+        1 + sqrt(2)*sqrt(-3 - sqrt(-4*sqrt(3) - 3))/2,
+        1 - sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
+        1 + sqrt(2)*sqrt(-3 + sqrt(-4*sqrt(3) - 3))/2,
         ])
 
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -354,12 +354,12 @@ def test_polar():
     assert (exp_polar(1.0*pi*I).n(n=5)).as_real_imag()[1] >= 0
 
 def test_log_product():
-    from sympy.abc import i, j, n, m
+    from sympy.abc import n, m
     i, j = symbols('i,j', positive=True, integer=True)
     x, y = symbols('x,y', positive=True)
     from sympy.concrete import Product, Sum
     f, g = Function('f'), Function('g')
-    assert simplify(log(Product(x**i, (i, 1, n)))) == Sum(i*log(x), (i, 1, n))
+    assert simplify(log(Product(x**i, (i, 1, n)))) == Sum(log(x**i), (i, 1, n))
     assert simplify(log(Product(x**i*y**j, (i, 1, n), (j, 1, m)))) == \
             Sum(log(x**i*y**j), (i, 1, n), (j, 1, m))
 

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -91,13 +91,14 @@ def test_inflate():
 def test_recursive():
     from sympy import symbols, exp_polar, expand
     a, b, c = symbols('a b c', positive=True)
-    assert simplify(integrate(exp(-(x - a)**2)*exp(-(x - b)**2), (x, 0, oo))) \
-        == (sqrt(2)*sqrt(pi)*(erf(sqrt(2)*(a + b)/2) + 1)*exp(
-        -a**2/2 + a*b - b**2/2))/4
-    assert simplify(integrate(
-        exp(-(x - a)**2)*exp(-(x - b)**2)*exp(c*x), (x, 0, oo))) == \
-        (sqrt(2)*sqrt(pi)*(erf(sqrt(2)*(2*a + 2*b + c)/4) + 1)*
-        exp(-a**2/2 + a*b + a*c/2 - b**2/2 + b*c/2 + c**2/8)/4)
+    e = integrate(exp(-(x - a)**2)*exp(-(x - b)**2), (x, 0, oo))
+    assert simplify(e.expand()) == (
+        sqrt(2)*sqrt(pi)*(
+        (erf(sqrt(2)*(a + b)/2) + 1)*exp(-a**2/2 + a*b - b**2/2))/4)
+    e = integrate(exp(-(x - a)**2)*exp(-(x - b)**2)*exp(c*x), (x, 0, oo))
+    assert simplify(e) == (
+        sqrt(2)*sqrt(pi)*(erf(sqrt(2)*(2*a + 2*b + c)/4) + 1)*exp(-a**2 - b**2
+        + (2*a + 2*b + c)**2/8)/4)
     assert simplify(integrate(exp(-(x - a - b - c)**2), (x, 0, oo))) == \
         sqrt(pi)/2*(1 + erf(a + b + c))
     assert simplify(integrate(exp(-(x + a + b + c)**2), (x, 0, oo))) == \
@@ -381,7 +382,7 @@ def test_probability():
     assert E(1) == 1
     assert E(x*y) == mu1/rate
     assert E(x*y**2) == mu1**2/rate + sigma1**2/rate
-    ans = (rate**2*sigma1**2 + 1)/rate**2
+    ans = sigma1**2 + 1/rate**2
     assert simplify(E((x + y + 1)**2) - E(x + y + 1)**2) == ans
     assert simplify(E((x + y - 1)**2) - E(x + y - 1)**2) == ans
     assert simplify(E((x + y)**2) - E(x + y)**2) == ans

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -94,7 +94,7 @@ def test_mellin_transform():
 
     # 8.4.2
     assert MT(x**nu*Heaviside(x - 1), x, s) == \
-        (1/(-nu - s), (-oo, -re(nu)), True)
+        (-1/(nu + s), (-oo, -re(nu)), True)
     assert MT(x**nu*Heaviside(1 - x), x, s) == \
         (1/(nu + s), (-re(nu), oo), True)
 
@@ -233,8 +233,8 @@ def test_mellin_transform_bessel():
         (gamma(
          s - a/2)*gamma(s + a/2)/2, (Max(-re(a)/2, re(a)/2), oo), True)
     assert MT(besselj(a, 2*sqrt(2*sqrt(x)))*besselk(
-        a, 2*sqrt(2*sqrt(x))), x, s) == (2**(-2*s - 1)*gamma(2*s)*
-        gamma(a/2 + s)/gamma(a/2 - s + 1), (Max(0, -re(a)/2), oo), True)
+        a, 2*sqrt(2*sqrt(x))), x, s) == (4**(-s)*gamma(2*s)*
+        gamma(a/2 + s)/(2*gamma(a/2 - s + 1)), (Max(0, -re(a)/2), oo), True)
     # TODO bessely(a, x)*besselk(a, x) is a mess
     assert MT(besseli(a, sqrt(x))*besselk(a, sqrt(x)), x, s) == \
         (gamma(s)*gamma(
@@ -274,15 +274,14 @@ def test_expint():
         expint(aneg, x)
 
     assert mellin_transform(Si(x), x, s) == \
-        (-2**(s - 1)*sqrt(pi)*gamma(s/2 + S(1)/2)/(s*gamma(-s/2 + 1)), (-1, 0),
-        True)
+        (-2**s*sqrt(pi)*gamma(s/2 + S(1)/2)/(
+        2*s*gamma(-s/2 + 1)), (-1, 0), True)
     assert inverse_mellin_transform(-2**s*sqrt(pi)*gamma((s + 1)/2)
                                     /(2*s*gamma(-s/2 + 1)), s, x, (-1, 0)) \
         == Si(x)
 
     assert mellin_transform(Ci(sqrt(x)), x, s) == \
-        (-2**(2*s - 1)*sqrt(pi)*gamma(s)/(s*gamma(-s + S(1)/2)
-        ), (0, 1), True)
+        (-2**(2*s - 1)*sqrt(pi)*gamma(s)/(s*gamma(-s + S(1)/2)), (0, 1), True)
     assert inverse_mellin_transform(
         -4**s*sqrt(pi)*gamma(s)/(2*s*gamma(-s + S(1)/2)),
         s, u, (0, 1)).expand() == Ci(sqrt(u))
@@ -360,7 +359,7 @@ def test_inverse_mellin_transform():
         (1 + sqrt(x + 1))**c
     assert simplify(IMT(2**(a + 2*s)*b**(a + 2*s - 1)*gamma(s)*gamma(1 - a - 2*s)
                         /gamma(1 - a - s), s, x, (0, (-re(a) + 1)/2))) == \
-         b**(a - 1)*(sqrt(1 + x/b**2) + 1)**(a - 1)*(b**2*sqrt(1 + x/b**2) +
+        b**(a - 1)*(sqrt(1 + x/b**2) + 1)**(a - 1)*(b**2*sqrt(1 + x/b**2) +
         b**2 + x)/(b**2 + x)
     assert simplify(IMT(-2**(c + 2*s)*c*b**(c + 2*s)*gamma(s)*gamma(-c - 2*s)
                         / gamma(-c - s + 1), s, x, (0, -re(c)/2))) == \
@@ -381,6 +380,7 @@ def test_inverse_mellin_transform():
         return expand(
             powsimp(logcombine(expr, force=True), force=True, deep=True),
             force=True).replace(exp_polar, exp)
+
     assert mysimp(mysimp(IMT(pi/(s*tan(pi*s)), s, x, (-1, 0)))) in [
         log(1 - x)*Heaviside(1 - x) + log(x - 1)*Heaviside(x - 1),
         log(x)*Heaviside(x - 1) + log(1 - 1/x)*Heaviside(x - 1) + log(-x +
@@ -428,8 +428,8 @@ def test_inverse_mellin_transform():
                       (pi*gamma(a/2 - b/2 - s + 1)*gamma(a/2 + b/2 - s + 1)),
                     s, x,
                       (Max(-re(a)/2 - re(b)/2, -re(a)/2 + re(b)/2), S(1)/2))) == \
-        (-cos(pi*b)*besselj(b, sqrt(x)) + besselj(-b, sqrt(x))) * \
-        besselj(a, sqrt(x))/sin(pi*b)*(-1)
+        (cos(pi*b)*besselj(b, sqrt(x)) - besselj(-b, sqrt(x)))*besselj(a,
+        sqrt(x))/sin(pi*b)
     # TODO more
 
     # for coverage
@@ -470,7 +470,7 @@ def test_laplace_transform():
     assert LT(exp(2*t), t, s)[:2] == (1/(s - 2), 2)
     assert LT(exp(a*t), t, s)[:2] == (1/(s - a), a)
 
-    assert LT(log(t/a), t, s) == ((log(a) + log(s) + EulerGamma)/(-s), 0, True)
+    assert LT(log(t/a), t, s) == ((log(a*s) + EulerGamma)/s/-1, 0, True)
 
     assert LT(erf(t), t, s) == ((-erf(s/2) + 1)*exp(s**2/4)/s, 0, True)
 
@@ -478,9 +478,9 @@ def test_laplace_transform():
     assert LT(cos(a*t), t, s) == (s/(a**2 + s**2), 0, True)
     # TODO would be nice to have these come out better
     assert LT(
-        exp(-a*t)*sin(b*t), t, s) == (1/b/(1 + (a + s)**2/b**2), -a, True)
+        exp(-a*t)*sin(b*t), t, s) == (b/(b**2 + (a + s)**2), -a, True)
     assert LT(exp(-a*t)*cos(b*t), t, s) == \
-        (1/(s + a)/(1 + b**2/(a + s)**2), -a, True)
+        ((a + s)/(b**2 + (a + s)**2), -a, True)
     # TODO sinh, cosh have delicate cancellation
 
     assert LT(besselj(0, t), t, s) == (1/sqrt(1 + s**2), 0, True)
@@ -499,21 +499,20 @@ def test_laplace_transform():
     assert laplace_transform(fresnels(t), t, s) == \
         ((-sin(s**2/(2*pi))*fresnels(s/pi) + sin(s**2/(2*pi))/2 -
             cos(s**2/(2*pi))*fresnelc(s/pi) + cos(s**2/(2*pi))/2)/s, 0, True)
-    assert laplace_transform(fresnelc(t), t, s) == \
-        (sqrt(2)*(sqrt(2)*sin(s**2/(2*pi))*fresnelc(s/pi) -
-        sqrt(2)*cos(s**2/(2*pi))*fresnels(s/pi) + cos(s**2/(2*pi) +
-        pi/4))/(2*s), 0, True)
+    assert laplace_transform(fresnelc(t), t, s) == (
+        (sin(s**2/(2*pi))*fresnelc(s/pi)/s - cos(s**2/(2*pi))*fresnels(s/pi)/s
+        + sqrt(2)*cos(s**2/(2*pi) + pi/4)/(2*s), 0, True))
 
 
 def test_inverse_laplace_transform():
     from sympy import (expand, sinh, cosh, besselj, besseli, exp_polar,
-                       unpolarify, simplify)
+                       unpolarify, simplify, factor_terms)
     ILT = inverse_laplace_transform
     a, b, c, = symbols('a b c', positive=True)
     t = symbols('t')
 
     def simp_hyp(expr):
-        return expand(expand(expr).rewrite(sin))
+        return factor_terms(expand_mul(expr)).rewrite(sin)
 
     # just test inverses of all of the above
     assert ILT(1/s, s, t) == Heaviside(t)
@@ -593,7 +592,7 @@ def test_fourier_transform():
     assert factor(FT(x*exp(-a*x)*Heaviside(x), x, k), extension=I) == \
         1/(a + 2*pi*I*k)**2
     assert FT(exp(-a*x)*sin(b*x)*Heaviside(x), x, k) == \
-        1/b/(1 + a**2*(1 + 2*pi*I*k/a)**2/b**2)
+        b/(b**2 + (a + 2*I*pi*k)**2)
 
     assert FT(exp(-a*x**2), x, k) == sqrt(pi)*exp(-pi**2*k**2/a)/sqrt(a)
     assert IFT(sqrt(pi/a)*exp(-(pi*k)**2/a), k, x) == exp(-a*x**2)
@@ -635,7 +634,7 @@ def test_sine_transform():
         sqrt(2)*w/(sqrt(pi)*(a**2 + w**2)), w, t) == -sinh(a*t) + cosh(a*t)
 
     assert sine_transform(
-        log(t)/t, t, w) == sqrt(2)*sqrt(pi)*(-log(w**2) - 2*EulerGamma)/4
+        log(t)/t, t, w) == -sqrt(2)*sqrt(pi)*(log(w**2) + 2*EulerGamma)/4
 
     assert sine_transform(
         t*exp(-a*t**2), t, w) == sqrt(2)*w*exp(-w**2/(4*a))/(4*a**(S(3)/2))
@@ -675,8 +674,8 @@ def test_cosine_transform():
     assert cosine_transform(exp(-a*sqrt(t))*cos(a*sqrt(
         t)), t, w) == -a*(sinh(a**2/(2*w)) - cosh(a**2/(2*w)))/(2*w**(S(3)/2))
 
-    assert cosine_transform(1/(a + t), t, w) == -sqrt(
-        2)*((2*Si(a*w) - pi)*sin(a*w) + 2*cos(a*w)*Ci(a*w))/(2*sqrt(pi))
+    assert cosine_transform(1/(a + t), t, w) == -sqrt(2)*(
+        (2*Si(a*w) - pi)*sin(a*w)/2 + cos(a*w)*Ci(a*w))/sqrt(pi)
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S(1)/2, 0), ()), (
         (S(1)/2, 0, 0), (S(1)/2,)), a**2*w**2/4)/(2*pi), w, t) == 1/(a + t)
 
@@ -702,8 +701,8 @@ def test_hankel_transform():
     assert inverse_hankel_transform(
         2**(-m + 1)*k**(m - 2)*gamma(-m/2 + 1)/gamma(m/2), k, r, 0) == r**(-m)
 
-    assert hankel_transform(1/r**m, r, k, nu) == 2**(
-        -m + 1)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
+    assert hankel_transform(1/r**m, r, k, nu) == (
+        2*2**(-m)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2))
     assert inverse_hankel_transform(2**(-m + 1)*k**(
         m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2), k, r, nu) == r**(-m)
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -837,11 +837,11 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     >>> f = 1/(s**2 - 1)
     >>> inverse_mellin_transform(f, s, x, (-oo, -1))
-    x*(1 - 1/x**2)*Heaviside(x - 1)/2
+    (x/2 - 1/(2*x))*Heaviside(x - 1)
     >>> inverse_mellin_transform(f, s, x, (-1, 1))
     -x*Heaviside(-x + 1)/2 - Heaviside(x - 1)/(2*x)
     >>> inverse_mellin_transform(f, s, x, (1, oo))
-    (-x**2/2 + 1/2)*Heaviside(-x + 1)/x
+    (-x/2 + 1/(2*x))*Heaviside(-x + 1)
 
     See Also
     ========
@@ -1101,7 +1101,7 @@ def laplace_transform(f, t, s, **hints):
     >>> from sympy.integrals import laplace_transform
     >>> from sympy.abc import t, s, a
     >>> laplace_transform(t**a, t, s)
-    (s**(-a - 1)*gamma(a + 1), 0, -re(a) < 1)
+    (s**(-a)*gamma(a + 1)/s, 0, -re(a) < 1)
 
     See Also
     ========
@@ -1746,7 +1746,7 @@ def hankel_transform(f, r, k, nu, **hints):
 
     >>> ht = hankel_transform(1/r**m, r, k, nu)
     >>> ht
-    2**(-m + 1)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
+    2*2**(-m)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
 
     >>> inverse_hankel_transform(ht, k, r, nu)
     r**(-m)
@@ -1802,7 +1802,7 @@ def inverse_hankel_transform(F, k, r, nu, **hints):
 
     >>> ht = hankel_transform(1/r**m, r, k, nu)
     >>> ht
-    2**(-m + 1)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
+    2*2**(-m)*k**(m - 2)*gamma(-m/2 + nu/2 + 1)/gamma(m/2 + nu/2)
 
     >>> inverse_hankel_transform(ht, k, r, nu)
     r**(-m)

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -190,9 +190,9 @@ def test_rolling_disc():
     t = symbols('t')
 
     assert (l.mass_matrix[3:6] == [0, 5*m*r**2/4, 0])
-    assert RHS[4].simplify() == (-8*g*sin(q2(t)) + 5*r*sin(2*q2(t)
-        )*Derivative(q1(t), t)**2 + 12*r*cos(q2(t))*Derivative(q1(t), t
-        )*Derivative(q3(t), t))/(10*r)
+    assert RHS[4].simplify() == (
+        (-8*g*sin(q2(t)) + r*(5*sin(2*q2(t))*Derivative(q1(t), t) +
+        12*cos(q2(t))*Derivative(q3(t), t))*Derivative(q1(t), t))/(10*r))
     assert RHS[5] == (-5*cos(q2(t))*Derivative(q1(t), t) + 6*tan(q2(t)
         )*Derivative(q3(t), t) + 4*Derivative(q1(t), t)/cos(q2(t))
         )*Derivative(q2(t), t)

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -7,10 +7,10 @@ from sympy.polys.polyerrors import PolynomialError
 
 from sympy.core import S, Add, sympify, Function, Lambda, Dummy, Mul, Expr
 from sympy.core.basic import preorder_traversal
-from sympy.utilities import numbered_symbols, take, threaded
+from sympy.utilities import numbered_symbols, take, xthreaded
 
 
-@threaded
+@xthreaded
 def apart(f, x=None, full=False, **options):
     """
     Compute partial fraction decomposition of a rational function.

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -65,7 +65,9 @@ def apart(f, x=None, full=False, **options):
             nc = Mul(*[apart(i, x=x, full=full, **_options) for i in nc])
             if c:
                 c = apart(Mul._from_args(c), x=x, full=full, **_options)
-            return c*nc
+                return c*nc
+            else:
+                return nc
         elif f.is_Add:
             c = []
             nc = []

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5540,7 +5540,7 @@ def _torational_factor_list(p, x):
     >>> from sympy import sqrt, expand, Mul
     >>> p = expand(((x**2-1)*(x-2)).subs({x:x*(1 + sqrt(2))}))
     >>> factors = _torational_factor_list(p, x); factors
-    (-2, [(-sqrt(2)*x/2 - x/2 + 1, 1), (-sqrt(2)*x - x - 1, 1), (-sqrt(2)*x - x + 1, 1)])
+    (-2, [(-x*(1 + sqrt(2))/2 + 1, 1), (-x*(1 + sqrt(2)) - 1, 1), (-x*(1 + sqrt(2)) + 1, 1)])
     >>> expand(factors[0]*Mul(*[z[0] for z in factors[1]])) == p
     True
     >>> p = expand(((x**2-1)*(x-2)).subs({x:x + sqrt(2)}))

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6,6 +6,8 @@ from sympy.core import (
 
 from sympy.core.mul import _keep_coeff
 
+from sympy.core.basic import preorder_traversal
+
 from sympy.core.sympify import (
     sympify, SympifyError,
 )
@@ -5896,13 +5898,16 @@ def cancel(f, *gens, **args):
     Examples
     ========
 
-    >>> from sympy import cancel
+    >>> from sympy import cancel, sqrt, Symbol
     >>> from sympy.abc import x
+    >>> A = Symbol('A', commutative=False)
 
     >>> cancel((2*x**2 - 2)/(x**2 - 2*x + 1))
     (2*x + 2)/(x - 1)
-
+    >>> cancel((sqrt(3) + sqrt(15)*A)/(sqrt(2) + sqrt(10)*A))
+    sqrt(6)/2
     """
+    from sympy.core.exprtools import factor_terms
     options.allowed_flags(args, ['polys'])
 
     f = sympify(f)
@@ -5910,11 +5915,15 @@ def cancel(f, *gens, **args):
     if not isinstance(f, (tuple, Tuple)):
         if f.is_Number:
             return f
-        else:
-            p, q = f.as_numer_denom()
+        f = factor_terms(f, radical=True)
+        p, q = f.as_numer_denom()
 
-    else:
+    elif len(f) == 2:
         p, q = f
+    elif isinstance(f, Tuple):
+        return factor_terms(f)
+    else:
+        raise ValueError('unexpected argument: %s' % f)
 
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
@@ -5923,6 +5932,34 @@ def cancel(f, *gens, **args):
             return f
         else:
             return S.One, p, q
+    except PolynomialError, msg:
+        if f.is_commutative:
+            raise PolynomialError(msg)
+        # non-commutative
+        if f.is_Mul:
+            c, nc = f.args_cnc(split_1=False)
+            nc = [cancel(i) for i in nc]
+            return cancel(Mul._from_args(c))*Mul(*nc)
+        elif f.is_Add:
+            c = []
+            nc = []
+            for i in f.args:
+                if i.is_commutative:
+                    c.append(i)
+                else:
+                    nc.append(cancel(i))
+            return cancel(Add(*c)) + Add(*nc)
+        else:
+            reps = []
+            pot = preorder_traversal(f)
+            pot.next()
+            for e in pot:
+                try:
+                    reps.append((e, cancel(e)))
+                    pot.skip()  # this was handled successfully
+                except NotImplementedError:
+                    pass
+            return f.xreplace(dict(reps))
 
     c, P, Q = F.cancel(G)
 

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -109,7 +109,7 @@ def test_apart_undetermined_coeffs():
 
     p = Poly(1, x, domain='ZZ[a,b]')
     q = Poly((x + a)*(x + b), x, domain='ZZ[a,b]')
-    r = 1/((a - b)*(b + x)) + 1/((-a + b)*(a + x))
+    r = 1/((a - b)*(b + x)) - 1/((a - b)*(a + x))
 
     assert apart_undetermined_coeffs(p, q) == r
 

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -156,3 +156,9 @@ def test_noncommutative_pseudomultivariate():
     c = 1/(1 + y)
     assert apart(e + foo(e)) == c + foo(c)
     assert apart(e*foo(e)) == c*foo(c)
+
+
+def test_issue_2699():
+    assert apart(
+        2*x/(x**2 + 1) - (x - 1)/(2*(x**2 + 1)) + 1/(2*(x + 1)) - 2/x) == \
+        (3*x + 1)/(x**2 + 1)/2 + 1/(x + 1)/2 - 2/x

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -10,7 +10,7 @@ from sympy.polys.partfrac import (
 )
 
 from sympy import (S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda,
-                   Symbol, Dummy, factor, together, sqrt)
+                   Symbol, Dummy, factor, together, sqrt, Expr)
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y, a, b, c
 
@@ -109,7 +109,7 @@ def test_apart_undetermined_coeffs():
 
     p = Poly(1, x, domain='ZZ[a,b]')
     q = Poly((x + a)*(x + b), x, domain='ZZ[a,b]')
-    r = 1/((x + b)*(a - b)) + 1/((x + a)*(b - a))
+    r = 1/((a - b)*(b + x)) + 1/((-a + b)*(a + x))
 
     assert apart_undetermined_coeffs(p, q) == r
 
@@ -147,3 +147,12 @@ def test_assemble_partfrac_list():
     a = Dummy("a")
     pfd = (1, Poly(0, x, domain='ZZ'), [([sqrt(2),-sqrt(2)], Lambda(a, a/2), Lambda(a, -a + x), 1)])
     assert assemble_partfrac_list(pfd) == -1/(sqrt(2)*(x + sqrt(2))) + 1/(sqrt(2)*(x - sqrt(2)))
+
+
+def test_noncommutative_pseudomultivariate():
+    class foo(Expr):
+        is_commutative=False
+    e = x/(x + x*y)
+    c = 1/(1 + y)
+    assert apart(e + foo(e)) == c + foo(c)
+    assert apart(e*foo(e)) == c*foo(c)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2748,9 +2748,11 @@ def test_nth_power_roots_poly():
 
 def test_torational_factor_list():
     p = expand(((x**2-1)*(x-2)).subs({x:x*(1 + sqrt(2))}))
-    assert _torational_factor_list(p, x) == (-2,
-        [(-sqrt(2)*x/2 - x/2 + 1, 1), (-sqrt(2)*x - x - 1, 1),
-         (-sqrt(2)*x - x + 1, 1)])
+    assert _torational_factor_list(p, x) == (-2, [
+        (-x*(1 + sqrt(2))/2 + 1, 1),
+        (-x*(1 + sqrt(2)) - 1, 1),
+        (-x*(1 + sqrt(2)) + 1, 1)])
+
 
     p = expand(((x**2-1)*(x-2)).subs({x:x*(1 + 2**Rational(1, 4))}))
     assert _torational_factor_list(p, x) is None

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -51,7 +51,7 @@ from sympy.polys.monomialtools import lex, grlex, grevlex
 
 from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, symbols, sqrt,
-    exp, sin, expand, oo, I, pi, re, im, RootOf, Eq, Tuple)
+    exp, sin, expand, oo, I, pi, re, im, RootOf, Eq, Tuple, Expr)
 
 from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
@@ -3093,3 +3093,13 @@ def test_poly_matching_consistency():
 def test_issue_2687():
     assert expand(factor(expand(
         (x - I*y)*(z - I*t)), extension=[I])) == -I*t*x - t*y + x*z - I*y*z
+
+
+def test_noncommutative():
+    class foo(Expr):
+        is_commutative=False
+    e = x/(x + x*y)
+    c = 1/( 1 + y)
+    assert cancel(foo(e)) == foo(c)
+    assert cancel(e + foo(e)) == c + foo(c)
+    assert cancel(e*foo(c)) == c*foo(c)

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -128,7 +128,7 @@ def test_hyperexpand_parametric():
 def test_shifted_sum():
     from sympy import simplify
     assert simplify(hyperexpand(z**4*hyper([2], [3, S('3/2')], -z**2))) \
-        == -S(1)/2 + cos(2*z)/2 + z*sin(2*z) - z**2*cos(2*z)
+        == z*sin(2*z) + (-z**2 + S.Half)*cos(2*z) - S.Half
 
 
 def _randrat():
@@ -387,7 +387,7 @@ def test_meijerg_expand():
     # Testing a bug:
     assert hyperexpand(meijerg([0, 2], [], [], [-1, 1], z)) == \
         Piecewise((0, abs(z) < 1),
-                  (z*(1 - 1/z**2)/2, abs(1/z) < 1),
+                  (z/2 - 1/(2*z), abs(1/z) < 1),
                   (meijerg([0, 2], [], [], [-1, 1], z), True))
 
     # Test that the simplest possible answer is returned:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -14,7 +14,7 @@ from sympy.simplify.simplify import (
     collect_sqrt, fraction_expand, _unevaluated_Add, nthroot)
 from sympy.utilities.pytest import XFAIL, slow
 
-from sympy.abc import x, y, z, t, a, b, c, d, e, k
+from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
 
 def test_ratsimp():
@@ -82,6 +82,7 @@ def test_ratsimpmodprime():
     assert ratsimpmodprime(x, [y - 2*x], order='lex') == \
         y/2
 
+
 def test_trigsimp1():
     x, y = symbols('x,y')
 
@@ -122,6 +123,7 @@ def test_trigsimp1():
     e = 2*sin(x)**2 + 2*cos(x)**2
     assert trigsimp(log(e)) == log(2)
 
+
 def test_trigsimp1a():
     assert trigsimp(sin(2)**2*cos(3)*exp(2)/cos(2)**2) == tan(2)**2*cos(3)*exp(2)
     assert trigsimp(tan(2)**2*cos(3)*exp(2)*cos(2)**2) == sin(2)**2*cos(3)*exp(2)
@@ -135,6 +137,7 @@ def test_trigsimp1a():
     assert trigsimp(tanh(2)*cos(3)*exp(2)/sinh(2)) == cos(3)*exp(2)/cosh(2)
     assert trigsimp(coth(2)*cos(3)*exp(2)/cosh(2)) == cos(3)*exp(2)/sinh(2)
     assert trigsimp(coth(2)*cos(3)*exp(2)*tanh(2)) == cos(3)*exp(2)
+
 
 def test_trigsimp2():
     x, y = symbols('x,y')
@@ -237,8 +240,8 @@ def test_trigsimp_issues():
     # check integer exponents
     e = sin(x)**y/cos(x)**y
     assert trigsimp(e) == e
-    assert trigsimp(e.subs(y,2)) == tan(x)**2
-    assert trigsimp(e.subs(x,1)) == tan(1)**y
+    assert trigsimp(e.subs(y, 2)) == tan(x)**2
+    assert trigsimp(e.subs(x, 1)) == tan(1)**y
 
     # check for multiple patterns
     assert (cos(x)**2/sin(x)**2*cos(y)**2/sin(y)**2).trigsimp() == \
@@ -364,20 +367,20 @@ def test_hyperbolic_simp():
 def test_trigsimp_groebner():
     from sympy.simplify.simplify import trigsimp_groebner
 
-    ex = (4*sin(x)*cos(x) + 12*sin(x) + 5*cos(x)**3
-          + 21*cos(x)**2 + 23*cos(x) + 15) \
-       / (-sin(x)*cos(x)**2 + 2*sin(x)*cos(x) + 15*sin(x)
-          + 7*cos(x)**3 + 31*cos(x)**2 + 37*cos(x) + 21)
-    resnum = (5*sin(x) - 5*cos(x) + 1)
-    resdenom = (8*sin(x) - 6*cos(x))
+    c = cos(x)
+    s = sin(x)
+    ex = (4*s*c + 12*s + 5*c**3 + 21*c**2 + 23*c + 15)/(
+        -s*c**2 + 2*s*c + 15*s + 7*c**3 + 31*c**2 + 37*c + 21)
+    resnum = (5*s - 5*c + 1)
+    resdenom = (8*s - 6*c)
     results = [resnum/resdenom, (-resnum)/(-resdenom)]
     assert trigsimp_groebner(ex) in results
-    assert trigsimp_groebner(sin(x)/cos(x), hints=[tan]) == tan(x)
+    assert trigsimp_groebner(s/c, hints=[tan]) == tan(x)
 
-    assert trigsimp((-sin(x) + 1)/cos(x) + cos(x)/(-sin(x) + 1),
-                    method='groebner') == 2/cos(x)
-    assert trigsimp((-sin(x) + 1)/cos(x) + cos(x)/(-sin(x) + 1),
-                    method='groebner', polynomial=True) == 2/cos(x)
+    assert trigsimp((-s + 1)/c + c/(-s + 1),
+                    method='groebner') == 2/c
+    assert trigsimp((-s + 1)/c + c/(-s + 1),
+                    method='groebner', polynomial=True) == 2/c
 
     # Test quick=False works
     assert trigsimp_groebner(ex, hints=[2]) in results
@@ -387,7 +390,7 @@ def test_trigsimp_groebner():
 
     # test hyperbolic / sums
     assert trigsimp_groebner((tanh(x)+tanh(y))/(1+tanh(x)*tanh(y)),
-                             hints=[(tanh,x,y)]) == tanh(x + y)
+                             hints=[(tanh, x, y)]) == tanh(x + y)
 
 
 @XFAIL
@@ -428,7 +431,7 @@ def test_simplify_expr():
     assert simplify(e) == 1 + y
 
     e = (2 * (1/n - cos(n * pi)/n))/pi
-    assert simplify(e) == 2*((-cos(pi*n) + 1)/(pi*n))
+    assert simplify(e) == (-cos(pi*n) + 1)/(pi*n)*2
 
     e = integrate(1/(x**3 + 1), x).diff(x)
     assert simplify(e) == 1/(x**3 + 1)
@@ -437,11 +440,25 @@ def test_simplify_expr():
     assert simplify(e) == x/(x**2 + 3*x + 1)
 
     A = Matrix([[2*k - m*w**2, -k], [-k, k - m*w**2]]).inv()
-
     assert simplify((A*Matrix([0, f]))[1]) == \
-        f*(2*k - m*w**2)/(k**2 - 3*k*m*w**2 + m**2*w**4)
-    a, b, c, d, e, f, g, h, i = symbols('a,b,c,d,e,f,g,h,i')
+        -f*(2*k - m*w**2)/(k**2 - (k - m*w**2)*(2*k - m*w**2))
 
+    f = -x + y/(z + t) + z*x/(z + t) + z*a/(z + t) + t*x/(z + t)
+    assert simplify(f) == (y + a*z)/(z + t)
+
+    A, B = symbols('A,B', commutative=False)
+
+    assert simplify(A*B - B*A) == A*B - B*A
+    assert simplify(A/(1 + y/x)) == x*A/(x + y)
+    assert simplify(A*(1/x + 1/y)) == A/x + A/y  #(x + y)*A/(x*y)
+
+    assert simplify(log(2) + log(3)) == log(6)
+    assert simplify(log(2*x) - log(2)) == log(x)
+
+    assert simplify(hyper([], [], x)) == exp(x)
+
+
+def test_issue_458():
     f_1 = x*a + y*b + z*c - 1
     f_2 = x*d + y*e + z*f - 1
     f_3 = x*g + y*h + z*i - 1
@@ -451,21 +468,6 @@ def test_simplify_expr():
     assert simplify(solutions[y]) == \
         (a*i + c*d + f*g - a*f - c*g - d*i)/ \
         (a*e*i + b*f*g + c*d*h - a*f*h - b*d*i - c*e*g)
-
-    f = -x + y/(z + t) + z*x/(z + t) + z*a/(z + t) + t*x/(z + t)
-
-    assert simplify(f) == (y + a*z)/(z + t)
-
-    A, B = symbols('A,B', commutative=False)
-
-    assert simplify(A*B - B*A) == A*B - B*A
-    assert simplify(A/(1 + y/x)) == x*A/(x + y)
-    assert simplify(A*(1/x + 1/y)) == (x + y)*A/(x*y)
-
-    assert simplify(log(2) + log(3)) == log(6)
-    assert simplify(log(2*x) - log(2)) == log(x)
-
-    assert simplify(hyper([], [], x)) == exp(x)
 
 
 def test_simplify_other():
@@ -991,7 +993,7 @@ def test_hypersimp():
 
     assert hypersimp(1/factorial(k), k) == 1/(k + 1)
 
-    assert hypersimp(2**k/factorial(k)**2, k) == 2/(k**2 + 2*k + 1)
+    assert hypersimp(2**k/factorial(k)**2, k) == 2/(k + 1)**2
 
     assert hypersimp(binomial(n, k), k) == (n - k)/(k + 1)
     assert hypersimp(binomial(n + 1, k), k) == (n - k + 1)/(k + 1)
@@ -1000,10 +1002,10 @@ def test_hypersimp():
     assert hypersimp(term, k) == (S(1)/2)*((4*k + 5)/(3 + 14*k + 8*k**2))
 
     term = 1/((2*k - 1)*factorial(2*k + 1))
-    assert hypersimp(term, k) == (2*k - 1)/(3 + 11*k + 12*k**2 + 4*k**3)/2
+    assert hypersimp(term, k) == (k - S(1)/2)/((k + 1)*(2*k + 1)*(2*k + 3))
 
     term = binomial(n, k)*(-1)**k/factorial(k)
-    assert hypersimp(term, k) == (k - n)/(k**2 + 2*k + 1)
+    assert hypersimp(term, k) == (k - n)/(k + 1)**2
 
 
 def test_nsimplify():
@@ -1550,7 +1552,7 @@ def test_combsimp_gamma():
     assert combsimp(1/gamma(x + 3)/gamma(1 - x)) == \
         sin(pi*x)/(pi*x*(x + 1)*(x + 2))
 
-    assert simplify(combsimp(
+    assert powsimp(combsimp(
         gamma(x)*gamma(x + S(1)/2)*gamma(y)/gamma(x + y))) == \
         2**(-2*x + 1)*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)
     assert combsimp(1/gamma(x)/gamma(x - S(1)/3)/gamma(x + S(1)/3)) == \
@@ -1559,7 +1561,7 @@ def test_combsimp_gamma():
         gamma(S(1)/2 + x/2)*gamma(1 + x/2)/gamma(1 + x)/sqrt(pi)*2**x) == 1
     assert combsimp(gamma(S(-1)/4)*gamma(S(-3)/4)) == 16*sqrt(2)*pi/3
 
-    assert simplify(combsimp(gamma(2*x)/gamma(x))) == \
+    assert powsimp(combsimp(gamma(2*x)/gamma(x))) == \
         2**(2*x - 1)*gamma(x + S(1)/2)/sqrt(pi)
 
     # issue 3693
@@ -1724,9 +1726,28 @@ def test_polymorphism():
 
 def test_issue_from_PR1599():
     n1, n2, n3, n4 = symbols('n1 n2 n3 n4', negative=True)
-    assert simplify(I*sqrt(n1)) == I*sqrt(n1)
+    assert simplify(I*sqrt(n1)) == -sqrt(-n1)
     assert (powsimp(sqrt(n1)*sqrt(n2)*sqrt(n3)) ==
         -I*sqrt(-n1)*sqrt(-n2)*sqrt(-n3))
     assert (powsimp(root(n1, 3)*root(n2, 3)*root(n3, 3)*root(n4, 3)) ==
         -(-1)**(S(1)/3)*
         (-n1)**(S(1)/3)*(-n2)**(S(1)/3)*(-n3)**(S(1)/3)*(-n4)**(S(1)/3))
+
+
+def test_3712():
+    eq = (x + 2*y)*(2*x + 2)
+    assert simplify(eq) == (x + 1)*(x + 2*y)*2
+    # reject the 2-arg Mul -- these are a headache for test writing
+    assert simplify(eq.expand()) == \
+        2*x**2 + 4*x*y + 2*x + 4*y
+
+
+@XFAIL
+def test_3712_fail():
+    # from doc/src/modules/physics/mechanics/examples.rst, the current `eq`
+    # at Line 576 (in different variables) was formerly the equivalent and
+    # shorter expression given below...it would be nice to get the short one
+    # back again
+    xp, y, x, z = symbols('xp, y, x, z')
+    eq = 4*(-19*sin(x)*y + 5*sin(3*x)*y + 15*cos(2*x)*z - 21*z)*xp/(9*cos(x) - 5*cos(3*x))
+    assert trigsimp(eq) == -2*(2*cos(x)*tan(x)*y + 3*z)*xp/cos(x)

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1009,13 +1009,14 @@ def odesimp(eq, func, order, hint):
                            f(x)
                              /
                             |
-                            |   /      /1 \    \
-                            |  -|u2*sin|--| + 1|
-                            |   \      \u2/    /
-    log(f(x)) = log(C1) +   |  ----------------- d(u2)
-                            |       2    /1 \
-                            |     u2 *sin|--|
-                            |            \u2/
+                            |   /        1   \
+                            |  -|u2 + -------|
+                            |   |        /1 \|
+                            |   |     sin|--||
+                            |   \        \u2//
+    log(f(x)) = log(C1) +   |  --------------- d(u2)
+                            |          2
+                            |        u2
                             |
                            /
 
@@ -2082,9 +2083,9 @@ def ode_1st_homogeneous_coeff_subs_indep_div_dep(eq, func, order, match):
                 f(x)
                   /
                  |
-                 |        g(u2)
-                 |  ----------------- d(u2)
-                 |  -u2*g(u2) - h(u2)
+                 |       -g(u2)
+                 |  ---------------- d(u2)
+                 |  u2*g(u2) + h(u2)
                  |
                 /
     <BLANKLINE>

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -506,7 +506,7 @@ def solve(f, *symbols, **flags):
 
             >>> eqs = (x*y + 3*y + sqrt(3), x + 4 + y)
             >>> solve(eqs, y, x + 2)
-            {y: sqrt(3)/(-x - 3), x + 2: (-2*x - 6 + sqrt(3))/(x + 3)}
+            {y: -sqrt(3)/(x + 3), x + 2: (-2*x - 6 + sqrt(3))/(x + 3)}
             >>> solve(eqs, y*x, x)
             {x: -y - 4, x*y: -3*y - sqrt(3)}
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -44,8 +44,8 @@ def test_checkodesol():
     assert checkodesol(diff(sol1.lhs, x, 3), sol1) == (True, 0)
     assert checkodesol(diff(sol1.lhs, x, 3)*exp(f(x)), sol1) == (True, 0)
     assert checkodesol(diff(sol1.lhs, x, 3), Eq(f(x), x*log(x))) == \
-        (False, -9 + 60*x**4*log(x)**2 + 240*x**4*log(x)**3 +
-        235*x**4*log(x)**4 + 60*x**4*log(x)**5)
+        (False, 60*x**4*((log(x) + 1)**2 + log(x))*(
+        log(x) + 1)*log(x)**2 - 5*x**4*log(x)**4 - 9)
     assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x)) == \
         (True, 0)
     assert checkodesol(diff(exp(f(x)) + x, x)*x, Eq(exp(f(x)) + x),
@@ -1329,20 +1329,20 @@ def test_1686():
     from sympy.abc import A
     eq = x + A*(x + diff(f(x), x) + f(x)) + diff(f(x), x) + f(x) + 2
     assert classify_ode(eq, f(x)) == ('1st_linear', 'almost_linear',
-    'nth_linear_constant_coeff_undetermined_coefficients',
-    'nth_linear_constant_coeff_variation_of_parameters',
-    '1st_linear_Integral', 'almost_linear_Integral',
-    'nth_linear_constant_coeff_variation_of_parameters_Integral')
+        'nth_linear_constant_coeff_undetermined_coefficients',
+        'nth_linear_constant_coeff_variation_of_parameters',
+        '1st_linear_Integral', 'almost_linear_Integral',
+        'nth_linear_constant_coeff_variation_of_parameters_Integral')
     # 1765
     eq = (x**2 + f(x)**2)*f(x).diff(x) - 2*x*f(x)
     assert classify_ode(eq, f(x)) == ('1st_exact',
         '1st_homogeneous_coeff_best',
         '1st_homogeneous_coeff_subs_indep_div_dep',
         '1st_homogeneous_coeff_subs_dep_div_indep',
-        '1st_exact_Integral',
+        'separable_reduced', '1st_exact_Integral',
         '1st_homogeneous_coeff_subs_indep_div_dep_Integral',
-        '1st_homogeneous_coeff_subs_dep_div_indep_Integral')
-
+        '1st_homogeneous_coeff_subs_dep_div_indep_Integral',
+        'separable_reduced_Integral')
 
 def test_1726():
     raises(ValueError, lambda: dsolve(f(x, y).diff(x) - y*f(x, y), f(x)))
@@ -1472,7 +1472,7 @@ def test_almost_linear():
 
     eq = x*exp(f(x))*d + exp(f(x)) + 3*x
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol.rhs == log(C1/x - 3*x) - log(2)
+    assert sol.rhs == log(C1/x - 3*x/2)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x + A*(x + diff(f(x), x) + f(x)) + diff(f(x), x) + f(x) + 2
@@ -1496,8 +1496,9 @@ def test_exact_enhancement():
 
     eq = (x + 2)*sin(f) + d*x*cos(f)
     rhs = [sol.rhs for sol in dsolve(eq, f)]
-    assert rhs[0] == acos(-sqrt(C1*exp(-2*x)/x**4 + 1))
-    assert rhs[1] == acos(sqrt(C1*exp(-2*x)/x**4 + 1))
+    assert rhs == [
+        acos(-sqrt(C1*exp(-2*x) + x**4)/x**2),
+        acos(sqrt(C1*exp(-2*x) + x**4)/x**2)]
 
 
 def test_separable_reduced():

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -162,7 +162,7 @@ def test_rsolve():
 
     assert rsolve(f, y(n), {y(3): 6, y(4): 24}) == n*(n - 1)*(n - 2)
     assert rsolve(
-        f, y(n), {y(3): 6, y(4): -24}) == -n*(n - 1)*(n - 2)*(-1)**(-n)
+        f, y(n), {y(3): 6, y(4): -24}) == -n*(n - 1)*(n - 2)*(-1)**(n)
 
     assert f.subs(y, Lambda(k, rsolve(f, y(n)).subs(n, k))).simplify() == 0
 
@@ -170,13 +170,13 @@ def test_rsolve():
 
     assert rsolve(y(n) - a*y(n-2),y(n), \
             {y(1): sqrt(a)*(a + b), y(2): a*(a - b)}).simplify() == \
-            a**(n/2)*((-1)**(n + 1)*b + a)
+            a**(n/2)*(-(-1)**n*b + a)
 
     f = (-16*n**2 + 32*n - 12)*y(n - 1) + (4*n**2 - 12*n + 9)*y(n)
 
     assert expand_func(rsolve(f, y(n), \
-        {y(1): binomial(2*n + 1, 3)}).rewrite(gamma)).simplify() == \
-        2**(2*n - 2)*n*(8*n**3 - 4*n**2 - 2*n + 1)/3
+            {y(1): binomial(2*n + 1, 3)}).rewrite(gamma)).simplify() == \
+        2**(2*n)*n*(2*n - 1)*(4*n**2 - 1)/12
 
     assert (rsolve(y(n) + a*(y(n + 1) + y(n - 1))/2, y(n)) -
             (C0*((sqrt(-a**2 + 1) - 1)/a)**n +

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -252,7 +252,7 @@ def test_linear_system():
                 [-1, 0, 1, 0, 0]])
 
     assert solve_linear_system(M, x, y, z, t) == \
-        {y: 0, z: t*(-n - 1)/n, x: t*(-n - 1)/n}
+        {x: -t - t/n, z: -t - t/n, y: 0}
 
     assert solve([x + y + z + t, -z - t], x, y, z, t) == {x: -y, z: -t}
 
@@ -289,7 +289,10 @@ def test_tsolve():
         log(y/2 + sqrt(y**2 - 4)/2),
     ]), set([
         log(y - sqrt(y**2 - 4)) - log(2),
-        log(y + sqrt(y**2 - 4)) - log(2)])]
+        log(y + sqrt(y**2 - 4)) - log(2)]),
+    set([
+        log(y/2 - sqrt((y - 2)*(y + 2))/2),
+        log(y/2 + sqrt((y - 2)*(y + 2))/2)])]
     assert solve(exp(x) - 3, x) == [log(3)]
     assert solve(Eq(exp(x), 3), x) == [log(3)]
     assert solve(log(x) - 3, x) == [exp(3)]
@@ -1103,13 +1106,15 @@ def test_solve_abs():
 def test_issue_2957():
     assert solve(tanh(x + 3)*tanh(x - 3) - 1) == []
     assert set(solve(tanh(x - 1)*tanh(x + 1) + 1)) == set([
-        -log(2)/2 + log(-1 - I),
-        -log(2)/2 + log(-1 + I),
         -log(2)/2 + log(1 - I),
-        -log(2)/2 + log(1 + I)])
-    assert set(solve((tanh(x + 3)*tanh(x - 3) + 1)**2)) == \
-        set([-log(2)/2 + log(-1 - I), -log(2)/2 + log(-1 + I),
-            -log(2)/2 + log(1 - I), -log(2)/2 + log(1 + I)])
+        -log(2)/2 + log(-1 - I),
+        -log(2)/2 + log(1 + I),
+        -log(2)/2 + log(-1 + I),])
+    assert set(solve((tanh(x + 3)*tanh(x - 3) + 1)**2)) == set([
+        -log(2)/2 + log(1 - I),
+        -log(2)/2 + log(-1 - I),
+        -log(2)/2 + log(1 + I),
+        -log(2)/2 + log(-1 + I),])
 
 
 def test_issue_2574():

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1602,10 +1602,10 @@ def Nakagami(name, mu, omega):
 
     >>> V = simplify(variance(X, meijerg=True))
     >>> pprint(V, use_unicode=False)
-          /                               2          \
-    omega*\gamma(mu)*gamma(mu + 1) - gamma (mu + 1/2)/
-    --------------------------------------------------
-                 gamma(mu)*gamma(mu + 1)
+                        2
+             omega*gamma (mu + 1/2)
+    omega - -----------------------
+            gamma(mu)*gamma(mu + 1)
 
     References
     ==========
@@ -1657,7 +1657,7 @@ def Normal(name, mean, std):
     ========
 
     >>> from sympy.stats import Normal, density, E, std, cdf, skewness
-    >>> from sympy import Symbol, simplify, pprint, factor, together
+    >>> from sympy import Symbol, simplify, pprint, factor, together, factor_terms
 
     >>> mu = Symbol("mu")
     >>> sigma = Symbol("sigma", positive=True)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1670,12 +1670,12 @@ def Normal(name, mean, std):
 
     >>> C = simplify(cdf(X))(z) # it needs a little more help...
     >>> pprint(C, use_unicode=False)
-            /  ___          \             /  ___          \
-            |\/ 2 *(-mu + z)|             |\/ 2 *(-mu + z)|
-    - mu*erf|---------------| - mu + z*erf|---------------| + z
-            \    2*sigma    /             \    2*sigma    /
-    -----------------------------------------------------------
-                            2*(-mu + z)
+       /  ___          \
+       |\/ 2 *(-mu + z)|
+    erf|---------------|
+       \    2*sigma    /   1
+    -------------------- + -
+             2             2
 
     >>> simplify(skewness(X))
     0

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -384,8 +384,7 @@ def test_nakagami():
     assert simplify(E(X, meijerg=True)) == (sqrt(mu)*sqrt(omega)
            *gamma(mu + S.Half)/gamma(mu + 1))
     assert simplify(variance(X, meijerg=True)) == (
-        omega*(gamma(mu)*gamma(mu + 1) - gamma(mu + S.Half)**2)/
-        (gamma(mu)*gamma(mu + 1)))
+    omega - omega*gamma(mu + S(1)/2)**2/(gamma(mu)*gamma(mu + 1)))
 
 
 def test_pareto():

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -14,7 +14,10 @@ def threaded_factory(func, use_add):
         if isinstance(expr, Matrix):
             return expr.applyfunc(lambda f: func(f, *args, **kwargs))
         elif iterable(expr):
-            return expr.__class__([ func(f, *args, **kwargs) for f in expr ])
+            try:
+                return expr.__class__([func(f, *args, **kwargs) for f in expr])
+            except TypeError:
+                return expr
         else:
             expr = sympify(expr)
 


### PR DESCRIPTION
- try return a factored expr more often from simplify
  With the changes made here, more "factored" expressions are obtained from simplify:

```
>>> simplify((x-y)*(40*z-20)/10)
2*(x - y)*(2*z - 1)
```

https://code.google.com/p/sympy/issues/detail?id=3712
- denest powers in powsimp so 4**s*2**(x-2_s) -> 2_*x
- allow factors of coeff to enter powers so powsimp(12_2__x) -> 3_2**(x + 2)
  https://code.google.com/p/sympy/issues/detail?id=3341
- keep expr as option before powsimp, e.g.

```
expr = (_t*exp_polar(-I*pi))**(a - 1)
powsimp forms:
_t**(a - 1)*exp_polar(-I*pi*(a - 1))
_t**(a - 1)*exp_polar(-I*pi*(a - 1))
```
- mark some solve tests as slow
  this removes about a minute from testing time
- Factors cleanup and non-integer exponent handling
  Factors works harder to keep Rational bases sorted out better and differentiates bewteen easy-to-handle numerical exponents and more difficult symbolic exponents
