### PR TITLE
Manual integration

### DIFF
--- a/doc/src/modules/integrals/integrals.rst
+++ b/doc/src/modules/integrals/integrals.rst
@@ -103,6 +103,8 @@ API reference
 
 .. automethod:: sympy.integrals.trigintegrate
 
+.. automethod:: sympy.integrals.manualintegrate
+
 Class Integral represents an unevaluated integral and has some methods that help in the integration of an expression.
 
 .. autoclass:: sympy.integrals.Integral

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -358,6 +358,110 @@ def set_union(*sets):
         rv |= s
     return rv
 
+
+
+try:
+    from collections import namedtuple
+except ImportError:
+    # code from http://code.activestate.com/recipes/500261-named-tuples/
+    # PSF license
+    # code is Copyright 2007-2013 Raymond Hettinger
+    from operator import itemgetter as _itemgetter
+    from keyword import iskeyword as _iskeyword
+    import sys as _sys
+
+    # For some reason, doctest will test namedtuple's docstring if we simply
+    # have a def namedtuple() here
+    def _namedtuple(typename, field_names, verbose=False, rename=False):
+        if isinstance(field_names, basestring):
+            field_names = field_names.replace(',', ' ').split()
+        field_names = tuple(map(str, field_names))
+        if rename:
+            names = list(field_names)
+            seen = set()
+            for i, name in enumerate(names):
+                if (not min(c.isalnum() or c=='_' for c in name) or _iskeyword(name)
+                    or not name or name[0].isdigit() or name.startswith('_')
+                    or name in seen):
+                        names[i] = '_%d' % i
+                seen.add(name)
+            field_names = tuple(names)
+        for name in (typename,) + field_names:
+            if not min(c.isalnum() or c=='_' for c in name):
+                raise ValueError('Type names and field names can only contain'
+                                 ' alphanumeric characters and underscores: %r' % name)
+            if _iskeyword(name):
+                raise ValueError('Type names and field names cannot be a'
+                                 ' keyword: %r' % name)
+            if name[0].isdigit():
+                raise ValueError('Type names and field names cannot start'
+                                 ' with a number: %r' % name)
+        seen_names = set()
+        for name in field_names:
+            if name.startswith('_') and not rename:
+                raise ValueError('Field names cannot start with an'
+                                 ' underscore: %r' % name)
+            if name in seen_names:
+                raise ValueError('Encountered duplicate field name: %r' % name)
+            seen_names.add(name)
+
+        # Create and fill-in the class template
+        numfields = len(field_names)
+        argtxt = repr(field_names).replace("'", "")[1:-1]
+        reprtxt = ', '.join('%s=%%r' % name for name in field_names)
+        template = '''class %(typename)s(tuple):
+    '%(typename)s(%(argtxt)s)' \n
+    __slots__ = () \n
+    _fields = %(field_names)r \n
+    def __new__(_cls, %(argtxt)s):
+        return _tuple.__new__(_cls, (%(argtxt)s)) \n
+    @classmethod
+    def _make(cls, iterable, new=tuple.__new__, len=len):
+        'Make a new %(typename)s object from a sequence or iterable'
+        result = new(cls, iterable)
+        if len(result) != %(numfields)d:
+            raise TypeError('Expected %(numfields)d arguments, got %%d' %% len(result))
+        return result \n
+    def __repr__(self):
+        return '%(typename)s(%(reprtxt)s)' %% self \n
+    def _asdict(self):
+        'Return a new dict which maps field names to their values'
+        return dict(zip(self._fields, self)) \n
+    def _replace(_self, **kwds):
+        'Return a new %(typename)s object replacing specified fields with new values'
+        result = _self._make(map(kwds.pop, %(field_names)r, _self))
+        if kwds:
+            raise ValueError('Got unexpected field names: %%r' %% kwds.keys())
+        return result \n
+    def __getnewargs__(self):
+        return tuple(self) \n\n''' % locals()
+        for i, name in enumerate(field_names):
+            template += '    %s = _property(_itemgetter(%d))\n' % (name, i)
+        if verbose:
+            print template
+
+        # Execute the template string in a temporary namespace
+        namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename,
+                         _property=property, _tuple=tuple)
+        try:
+            exec template in namespace
+        except SyntaxError, e:
+            raise SyntaxError(e.message + ':\n' + template)
+        result = namespace[typename]
+
+        # For pickling to work, the __module__ variable needs to be set to the frame
+        # where the named tuple is created.  Bypass this step in enviroments where
+        # sys._getframe is not defined (Jython for example) or sys._getframe is not
+        # defined for arguments greater than 0 (IronPython).
+        try:
+            result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
+        except (AttributeError, ValueError):
+            pass
+
+        return result
+
+    namedtuple = _namedtuple
+
 try:
     bin = bin
 except NameError:  # Python 2.5

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -3,6 +3,7 @@ from sympy.core import (Basic, Expr, S, C, Symbol, Wild, Add, sympify, diff,
 
 from sympy.core.symbol import Dummy
 from sympy.core.compatibility import is_sequence
+from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.deltafunctions import deltaintegrate
 from sympy.integrals.rationaltools import ratint

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1116,7 +1116,10 @@ class Integral(Expr):
                         manual = manual.func(*[
                             arg.doit() if arg.has(Integral) else arg
                             for arg in manual.args
-                        ])
+                        ]).expand(multinomial=False,
+                                  log=False,
+                                  power_exp=False,
+                                  power_base=False)
                     if not manual.has(Integral):
                         parts.append(coeff * manual)
                         continue

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -993,6 +993,14 @@ class Integral(Expr):
                 else:
                     return result
 
+        # try manual integration
+        try:
+            manual = manualintegrate(f, x)
+            if not manual.has(Integral) and manual is not None:
+                return manual
+        except ValueError:
+            pass
+
         # since Integral(f=g1+g2+...) == Integral(g1) + Integral(g2) + ...
         # we are going to handle Add terms separately,
         # if `f` is not Add -- we only have one term

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -10,117 +10,15 @@ object and returns either a namedtuple representing a rule or
 ``None``. Then, write another function that accepts the namedtuple's fields
 and returns the antiderivative, and decorate it with
 ``@evaluates(namedtuple_type)``.
-
 """
-
 import sympy
-import collections
 
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.simplify import fraction
 from sympy.strategies.core import (switch, identity, do_one, null_safe,
                                    condition, tryit)
 
-try:
-    from collections import namedtuple
-except ImportError:
-    # for Python 2.5 compatibility
-    # code from http://code.activestate.com/recipes/500261-named-tuples/
-    # PSF license
-    # code is Copyright 2007-2013 Raymond Hettinger
-    from operator import itemgetter as _itemgetter
-    from keyword import iskeyword as _iskeyword
-    import sys as _sys
-
-    # For some reason, doctest will test namedtuple's docstring if we simply
-    # have a def namedtuple() here
-    def _namedtuple(typename, field_names, verbose=False, rename=False):
-        # Parse and validate the field names.  Validation serves two purposes,
-        # generating informative error messages and preventing template injection attacks.
-        if isinstance(field_names, basestring):
-            field_names = field_names.replace(',', ' ').split() # names separated by whitespace and/or commas
-        field_names = tuple(map(str, field_names))
-        if rename:
-            names = list(field_names)
-            seen = set()
-            for i, name in enumerate(names):
-                if (not min(c.isalnum() or c=='_' for c in name) or _iskeyword(name)
-                    or not name or name[0].isdigit() or name.startswith('_')
-                    or name in seen):
-                        names[i] = '_%d' % i
-                seen.add(name)
-            field_names = tuple(names)
-        for name in (typename,) + field_names:
-            if not min(c.isalnum() or c=='_' for c in name):
-                raise ValueError('Type names and field names can only contain alphanumeric characters and underscores: %r' % name)
-            if _iskeyword(name):
-                raise ValueError('Type names and field names cannot be a keyword: %r' % name)
-            if name[0].isdigit():
-                raise ValueError('Type names and field names cannot start with a number: %r' % name)
-        seen_names = set()
-        for name in field_names:
-            if name.startswith('_') and not rename:
-                raise ValueError('Field names cannot start with an underscore: %r' % name)
-            if name in seen_names:
-                raise ValueError('Encountered duplicate field name: %r' % name)
-            seen_names.add(name)
-
-        # Create and fill-in the class template
-        numfields = len(field_names)
-        argtxt = repr(field_names).replace("'", "")[1:-1]   # tuple repr without parens or quotes
-        reprtxt = ', '.join('%s=%%r' % name for name in field_names)
-        template = '''class %(typename)s(tuple):
-    '%(typename)s(%(argtxt)s)' \n
-    __slots__ = () \n
-    _fields = %(field_names)r \n
-    def __new__(_cls, %(argtxt)s):
-        return _tuple.__new__(_cls, (%(argtxt)s)) \n
-    @classmethod
-    def _make(cls, iterable, new=tuple.__new__, len=len):
-        'Make a new %(typename)s object from a sequence or iterable'
-        result = new(cls, iterable)
-        if len(result) != %(numfields)d:
-            raise TypeError('Expected %(numfields)d arguments, got %%d' %% len(result))
-        return result \n
-    def __repr__(self):
-        return '%(typename)s(%(reprtxt)s)' %% self \n
-    def _asdict(self):
-        'Return a new dict which maps field names to their values'
-        return dict(zip(self._fields, self)) \n
-    def _replace(_self, **kwds):
-        'Return a new %(typename)s object replacing specified fields with new values'
-        result = _self._make(map(kwds.pop, %(field_names)r, _self))
-        if kwds:
-            raise ValueError('Got unexpected field names: %%r' %% kwds.keys())
-        return result \n
-    def __getnewargs__(self):
-        return tuple(self) \n\n''' % locals()
-        for i, name in enumerate(field_names):
-            template += '    %s = _property(_itemgetter(%d))\n' % (name, i)
-        if verbose:
-            print template
-
-        # Execute the template string in a temporary namespace
-        namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename,
-                         _property=property, _tuple=tuple)
-        try:
-            exec template in namespace
-        except SyntaxError, e:
-            raise SyntaxError(e.message + ':\n' + template)
-        result = namespace[typename]
-
-        # For pickling to work, the __module__ variable needs to be set to the frame
-        # where the named tuple is created.  Bypass this step in enviroments where
-        # sys._getframe is not defined (Jython for example) or sys._getframe is not
-        # defined for arguments greater than 0 (IronPython).
-        try:
-            result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
-        except (AttributeError, ValueError):
-            pass
-
-        return result
-
-    namedtuple = _namedtuple
+from sympy.core.compatibility import namedtuple
 
 def Rule(name, props=""):
     # GOTCHA: namedtuple class name not considered!

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -596,6 +596,18 @@ def fallback_rule(integral):
 
 _integral_cache = {}
 def integral_steps(integrand, symbol, **options):
+    """Returns the steps needed to compute an integral.
+
+    This function attempts to mirror what a student would do by hand as
+    closely as possible.
+
+    Returns
+    =======
+    rule : namedtuple
+        The first step; most rules have substeps that must also be
+        considered. These substeps can be evaluated using `manualintegrate`
+        to obtain a result.
+    """
     cachekey = (integrand, symbol)
     if cachekey in _integral_cache:
         if _integral_cache[cachekey] is None:
@@ -723,5 +735,50 @@ def _manualintegrate(rule):
         raise TypeError("Cannot evaluate rule %s" % rule)
     return evaluator(*rule)
 
-def manualintegrate(f, x):
-    return _manualintegrate(integral_steps(f, x))
+def manualintegrate(f, var):
+    """manualintegrate(f, var)
+
+    Compute indefinite integral of a single variable using an algorithm that
+    resembles what a student would do by hand.
+
+    Unlike ``integrate``, var can only be a single symbol.
+
+    Examples
+    ========
+
+    >>> from sympy import sin, cos, tan, exp, log, integrate
+    >>> from sympy.integrals.manualintegrate import manualintegrate
+    >>> from sympy.abc import x
+    >>> manualintegrate(1 / x, x)
+    log(Abs(x))
+    >>> integrate(1/x)
+    log(x)
+    >>> manualintegrate(log(x), x)
+    x*log(x) - x
+    >>> integrate(log(x))
+    x*log(x) - x
+    >>> manualintegrate(exp(x) / (1 + exp(2 * x)), x)
+    atan(exp(x))
+    >>> integrate(exp(x) / (1 + exp(2 * x)))
+    RootSum(4*_z**2 + 1, Lambda(_i, _i*log(2*_i + exp(x))))
+    >>> manualintegrate(cos(x)**4 * sin(x), x)
+    -cos(x)**5/5
+    >>> integrate(cos(x)**4 * sin(x), x)
+    -cos(x)**5/5
+    >>> manualintegrate(cos(x)**4 * sin(x)**3, x)
+    cos(x)**7/7 - cos(x)**5/5
+    >>> integrate(cos(x)**4 * sin(x)**3, x)
+    cos(x)**7/7 - cos(x)**5/5
+    >>> manualintegrate(tan(x), x)
+    -log(Abs(cos(x)))
+    >>> integrate(tan(x), x)
+    -log(sin(x)**2 - 1)/2
+
+    See Also
+    ========
+
+    sympy.integrals.integrals.integrate
+    sympy.integrals.integrals.Integral.doit
+    sympy.integrals.integrals.Integral
+    """
+    return _manualintegrate(integral_steps(f, var))

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -128,7 +128,7 @@ AlternativeRule = Rule("AlternativeRule", "alternatives")
 DontKnowRule = Rule("DontKnowRule")
 RewriteRule = Rule("RewriteRule", "rewritten substep")
 
-class IntegralInfo(collections.namedtuple('IntegralInfo', 'integrand symbol')):
+class IntegralInfo(namedtuple('IntegralInfo', 'integrand symbol')):
     def __new__(cls, *args, **kwargs):
         u_var = kwargs['u_var']
         del kwargs['u_var']

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1,3 +1,18 @@
+"""Integration method that emulates by-hand techniques.
+
+This module also provides functionality to get the steps used to evaluate a
+particular integral, in the ``integral_steps`` function. This will return
+nested namedtuples representing the integration rules used.
+
+The integrator can be extended with new heuristics and evaluation
+techniques. To do so, write a function that accepts an ``IntegralInfo``
+object and returns either a namedtuple representing a rule or
+``None``. Then, write another function that accepts the namedtuple's fields
+and returns the antiderivative, and decorate it with
+``@evaluates(namedtuple_type)``.
+
+"""
+
 import sympy
 import collections
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1,0 +1,551 @@
+import sympy
+import collections
+
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
+from sympy.simplify import fraction
+from sympy.strategies.core import switch, identity, do_one, null_safe, condition
+
+def Rule(name, props=""):
+    # GOTCHA: namedtuple class name not considered!
+    def __eq__(self, other):
+        return self.__class__ == other.__class__ and tuple.__eq__(self, other)
+    __neq__ = lambda self, other: not __eq__(self, other)
+    cls = collections.namedtuple(name, props + " context symbol")
+    cls.__eq__ = __eq__
+    cls.__ne__ = __neq__
+    return cls
+
+ConstantRule = Rule("ConstantRule", "constant")
+ConstantTimesRule = Rule("ConstantTimesRule", "constant other substep")
+PowerRule = Rule("PowerRule", "base exp")
+AddRule = Rule("AddRule", "substeps")
+URule = Rule("URule", "u_var u_func constant substep")
+TrigRule = Rule("TrigRule", "func arg")
+ExpRule = Rule("ExpRule", "base exp")
+LogRule = Rule("LogRule", "func")
+ArctanRule = Rule("ArctanRule")
+AlternativeRule = Rule("AlternativeRule", "alternatives")
+DontKnowRule = Rule("DontKnowRule")
+RewriteRule = Rule("RewriteRule", "rewritten substep")
+
+class IntegralInfo(collections.namedtuple('IntegralInfo', 'integrand symbol')):
+    def __new__(cls, *args, **kwargs):
+        u_var = kwargs['u_var']
+        del kwargs['u_var']
+        self = super(IntegralInfo, cls).__new__(cls, *args, **kwargs)
+        self.u_var = u_var
+        return self
+
+    @staticmethod
+    def new_u_var(var):
+        if len(var.name) == 3:
+            num = int(var.name[2]) + 1
+            name = var.name[0] + str(num)
+        else:
+            name = 'u_1'
+        return sympy.Symbol(name)
+
+evaluators = {}
+def evaluates(rule):
+    def _evaluates(func):
+        func.rule = rule
+        evaluators[rule] = func
+        return func
+    return _evaluates
+
+# Method based on that on SIN, described in "Symbolic Integration: The
+# Stormy Decade"
+
+def find_substitutions(integrand, symbol, u_var):
+    results = []
+
+    def test_subterm(u, u_diff):
+        substituted = integrand.rewrite('sincos') / u_diff
+        if symbol not in substituted.free_symbols:
+            return False
+        substituted = sympy.trigsimp(substituted.subs(u, u_var))
+        if symbol not in substituted.free_symbols:
+            return substituted
+        return False
+
+    def possible_subterms(term):
+        if term.func in (sympy.sin, sympy.cos, sympy.tan,
+                         sympy.asin, sympy.acos, sympy.atan,
+                         sympy.exp, sympy.log):
+            return [term.args[0]]
+        elif term.func == sympy.Mul:
+            r = []
+            for u in term.args:
+                numer, denom = fraction(u)
+                if numer == 1:
+                    r.append(denom)
+                else:
+                    r.append(u)
+                r.extend(possible_subterms(u))
+            return r
+        elif term.func == sympy.Pow:
+            if term.args[1].is_constant(symbol):
+                return [term.args[0]]
+            elif term.args[0].is_constant(symbol):
+                return [term.args[1]]
+        return []
+
+    for u in possible_subterms(integrand):
+        if u == symbol:
+            continue
+        new_integrand = test_subterm(u.rewrite('sincos'),
+                                     u.rewrite('sincos').diff(symbol))
+        if new_integrand is not False:
+            constant = new_integrand.as_coeff_mul()[0]
+            results.append((u, constant, new_integrand))
+
+    return results
+
+def rewriter(condition, rewrite):
+    """Strategy that rewrites an integrand."""
+    def _rewriter(integral):
+        integrand, symbol = integral
+        if condition(*integral):
+            rewritten = rewrite(*integral)
+            if rewritten != integrand:
+                return RewriteRule(
+                    rewritten,
+                    integral_steps(rewritten, symbol),
+                    integrand, symbol)
+    return _rewriter
+
+def proxy_rewriter(condition, rewrite):
+    """Strategy that rewrites an integrand based on some other criteria."""
+    def _proxy_rewriter(criteria):
+        criteria, integral = criteria
+        integrand, symbol = integral
+        args = criteria + list(integral)
+        if condition(*args):
+            rewritten = rewrite(*args)
+            if rewritten != integrand:
+                return RewriteRule(
+                    rewritten,
+                    integral_steps(rewritten, symbol),
+                    integrand, symbol)
+    return _proxy_rewriter
+
+def multiplexer(conditions):
+    """Apply the rule that matches the condition, else None"""
+    def multiplexer_rl(expr):
+        for key, rule in conditions.items():
+            if key(expr):
+                return rule(expr)
+    return multiplexer_rl
+
+def alternatives(*rules):
+    """Strategy that makes an AlternativeRule out of multiple possible results."""
+    def _alternatives(integral):
+        alts = []
+        for rule in rules:
+            result = rule(integral)
+            if result and not isinstance(result, DontKnowRule) and result != integral:
+                alts.append(result)
+        if len(alts) == 1:
+            return alts[0]
+        elif len(alts) > 1:
+            return AlternativeRule(alts, *integral)
+    return _alternatives
+
+def constant_rule(integral):
+    integrand, symbol = integral
+    return ConstantRule(integral.integrand, *integral)
+
+def power_rule(integral):
+    integrand, symbol = integral
+    base, exp = integrand.as_base_exp()
+
+    if exp.rewrite('sincos').is_constant(symbol) and base.func == sympy.Symbol:
+        if sympy.simplify(exp + 1) == 0:
+            return LogRule(base, integrand, symbol)
+        return PowerRule(base, exp, integrand, symbol)
+    elif base.rewrite('sincos').is_constant(symbol) and exp.func == sympy.Symbol:
+        return ExpRule(base, exp, integrand, symbol)
+
+def exp_rule(integral):
+    integrand, symbol = integral
+    if integrand.args[0].func == sympy.Symbol:
+        return ExpRule(sympy.E, integrand.args[0], integrand, symbol)
+
+def arctan_rule(integral):
+    integrand, symbol = integral
+    base, exp = integrand.as_base_exp()
+
+    if sympy.simplify(exp + 1) == 0:
+        a = sympy.Wild('a', exclude=[symbol])
+        b = sympy.Wild('b', exclude=[symbol])
+        match = base.match(a + b*symbol**2)
+        if match:
+            a, b = match[a], match[b]
+
+            if a != 1 or b != 1:
+                u_var = integral.u_var
+                rewritten = sympy.Rational(1, a) * (base / a) ** (-1)
+                u_func = sympy.sqrt(sympy.Rational(b, a)) * symbol
+                constant = 1 / sympy.sqrt(sympy.Rational(b, a))
+                substituted = rewritten.subs(u_func, u_var)
+
+                if a == b:
+                    substep = ArctanRule(integrand, symbol)
+                else:
+                    substep = URule(u_var, u_func, constant,
+                                    ArctanRule(substituted, u_var),
+                                    integrand, symbol)
+
+                if a != 1:
+                    other = (base / a) ** (-1)
+                    return ConstantTimesRule(
+                        sympy.Rational(1, a), other,
+                        substep, integrand, symbol)
+                return substep
+
+            return ArctanRule(integrand, symbol)
+
+def add_rule(integral):
+    integrand, symbol = integral
+    return AddRule(
+        [integral_steps(g, symbol) for g in integrand.as_ordered_terms()],
+        integrand, symbol)
+
+def mul_rule(integral):
+    integrand, symbol = integral
+    args = integrand.args
+
+    # Constant times function case
+    if len(args) == 2:
+        integrand_t = integrand.rewrite('sincos')
+        if integrand_t.args[0].is_constant(symbol):
+            return ConstantTimesRule(args[0], args[1],
+                                     integral_steps(args[1], symbol),
+                                     integrand, symbol)
+        elif integrand_t.args[1].is_constant(symbol):
+            return ConstantTimesRule(args[1], args[0],
+                                     integral_steps(args[0], symbol),
+                                     integrand, symbol)
+
+    # TODO: integration by parts case
+
+def trig_rule(integral):
+    integrand, symbol = integral
+    func = integrand.func
+    if func in (sympy.sin, sympy.cos):
+        arg = integrand.args[0]
+
+        if type(arg) != sympy.Symbol:
+            return  # perhaps a substitution can deal with it
+
+        return TrigRule(func, arg, integrand, symbol)
+
+    if func == sympy.tan:
+        rewritten = sympy.sin(*integrand.args) / sympy.cos(*integrand.args)
+    elif func == sympy.cot:
+        rewritten = sympy.cos(*integrand.args) / sympy.sin(*integrand.args)
+    elif func == sympy.sec:
+        rewritten = sympy.Mul(
+            integrand,
+            sympy.sec(*integrand.args) + sympy.tan(*integrand.args),
+            1 / (sympy.sec(*integrand.args) + sympy.tan(*integrand.args)),
+            evaluate=False)
+    elif func == sympy.csc:
+        rewritten = sympy.Mul(
+            integrand,
+            sympy.csc(*integrand.args) + sympy.cot(*integrand.args),
+            1 / (sympy.csc(*integrand.args) + sympy.cot(*integrand.args)),
+            evaluate=False)
+    return RewriteRule(
+        rewritten,
+        integral_steps(rewritten, symbol, u_var=integral.u_var),
+        integrand, symbol
+    )
+
+@sympy.cacheit
+def make_wilds(symbol):
+    a = sympy.Wild('a', exclude=[symbol])
+    b = sympy.Wild('b', exclude=[symbol])
+    m = sympy.Wild('m', exclude=[symbol], properties=[lambda n: isinstance(n, sympy.Integer)])
+    n = sympy.Wild('n', exclude=[symbol], properties=[lambda n: isinstance(n, sympy.Integer)])
+
+    return a, b, m, n
+
+@sympy.cacheit
+def sincos_pattern(symbol):
+    a, b, m, n = make_wilds(symbol)
+    pattern = sympy.sin(a*symbol)**m * sympy.cos(b*symbol)**n
+
+    return pattern, a, b, m, n
+
+@sympy.cacheit
+def tansec_pattern(symbol):
+    a, b, m, n = make_wilds(symbol)
+    pattern = sympy.tan(a*symbol)**m * sympy.sec(b*symbol)**n
+
+    return pattern, a, b, m, n
+
+@sympy.cacheit
+def cotcsc_pattern(symbol):
+    a, b, m, n = make_wilds(symbol)
+    pattern = sympy.cot(a*symbol)**m * sympy.csc(b*symbol)**n
+
+    return pattern, a, b, m, n
+
+def uncurry(func):
+    def uncurry_rl(args):
+        return func(*args)
+    return uncurry_rl
+
+def trig_rewriter(rewrite):
+    def trig_rewriter_rl(args):
+        a, b, m, n, integrand, symbol = args
+        rewritten = rewrite(a, b, m, n, integrand, symbol)
+        if rewritten != integrand:
+            return RewriteRule(
+                rewritten,
+                integral_steps(rewritten, symbol),
+                integrand, symbol)
+    return trig_rewriter_rl
+
+sincos_botheven_condition = uncurry(lambda a, b, m, n, i, s: m.is_even and n.is_even)
+
+sincos_botheven = trig_rewriter(
+    lambda a, b, m, n, i, symbol: ( (((1 - sympy.cos(2*a*symbol)) / 2) ** (m / 2)) *
+                                    (((1 + sympy.cos(2*b*symbol)) / 2) ** (n / 2)) ))
+
+sincos_sinodd_condition = uncurry(lambda a, b, m, n, i, s: m.is_odd and m >= 3)
+
+sincos_sinodd = trig_rewriter(
+    lambda a, b, m, n, i, symbol: ( (1 - sympy.cos(a*symbol)**2)**((m - 1) / 2) *
+                                    sympy.sin(a*symbol) *
+                                    sympy.cos(b*symbol) ** n))
+
+sincos_cosodd_condition = uncurry(lambda a, b, m, n, i, s: n.is_odd and n >= 3)
+
+sincos_cosodd = trig_rewriter(
+    lambda a, b, m, n, i, symbol: ( (1 - sympy.sin(b*symbol)**2)**((n - 1) / 2) *
+                                    sympy.cos(b*symbol) *
+                                    sympy.sin(a*symbol) ** m))
+
+tansec_seceven = proxy_rewriter(
+    lambda a, b, m, n, i, s: n.is_even and n >= 4,
+    lambda a, b, m, n, i, symbol: ( (1 + sympy.tan(b*symbol)**2) ** (n/2 - 1) *
+                                    sympy.sec(b*symbol)**2 *
+                                    sympy.tan(a*symbol) ** m ))
+
+tansec_tanodd = proxy_rewriter(
+    lambda a, b, m, n, i, s: m.is_odd,
+    lambda a, b, m, n, i, symbol: ( (sympy.sec(a*symbol)**2 - 1) ** ((m - 1) / 2) *
+                                     sympy.tan(a*symbol) *
+                                     sympy.sec(b*symbol) ** n ))
+
+cotcsc_csceven = proxy_rewriter(
+    lambda a, b, m, n, i, s: n.is_even and n >= 4,
+    lambda a, b, m, n, i, symbol: ( (1 + sympy.cot(b*symbol)**2) ** (n/2 - 1) *
+                                    sympy.csc(b*symbol)**2 *
+                                    sympy.cot(a*symbol) ** m ))
+
+cotcsc_cotodd = proxy_rewriter(
+    lambda a, b, m, n, i, s: m.is_odd,
+    lambda a, b, m, n, i, symbol: ( (sympy.csc(a*symbol)**2 - 1) ** ((m - 1) / 2) *
+                                    sympy.cot(a*symbol) *
+                                    sympy.csc(b*symbol) ** n ))
+
+def trig_powers_products_rule(integral):
+    integrand, symbol = integral
+
+    if any(integrand.find(f) for f in (sympy.sin, sympy.cos)):
+        pattern, a, b, m, n = sincos_pattern(symbol)
+        match = integrand.match(pattern)
+
+        if match:
+            a, b, m, n = match.get(a, 0),match.get(b, 0), match.get(m, 0), match.get(n, 0)
+            return multiplexer({
+                sincos_botheven_condition: sincos_botheven,
+                sincos_sinodd_condition: sincos_sinodd,
+                sincos_cosodd_condition: sincos_cosodd
+            })((a, b, m, n, integrand, symbol))
+
+    integrand = integrand.subs({
+        1 / sympy.cos(symbol): sympy.sec(symbol)
+    })
+    # TODO use multiplexer below as well
+    if any(integrand.find(f) for f in (sympy.tan, sympy.sec)):
+        pattern, a, b, m, n = tansec_pattern(symbol)
+        match = integrand.match(pattern)
+
+        if match:
+            a, b, m, n = match.get(a, 0),match.get(b, 0), match.get(m, 0), match.get(n, 0)
+            return do_one(*map(null_safe, [tansec_seceven, tansec_tanodd]))(
+                ([a, b, m, n], integral))
+
+    integrand = integrand.subs({
+        1 / sympy.sin(symbol): sympy.csc(symbol),
+        1 / sympy.tan(symbol): sympy.cot(symbol),
+        sympy.cos(symbol) / sympy.tan(symbol): sympy.cot(symbol)
+    })
+
+    if any(integrand.find(f) for f in (sympy.cot, sympy.csc)):
+        pattern, a, b, m, n = tansec_pattern(symbol)
+        match = integrand.match(pattern)
+
+        if match:
+            a, b, m, n = match.get(a, 0),match.get(b, 0), match.get(m, 0), match.get(n, 0)
+            return do_one(*map(null_safe, [cotcsc_csceven, cotcsc_cotodd]))(
+                ([a, b, m, n], integral))
+
+def substitution_rule(integral):
+    integrand, symbol = integral
+
+    u_var = integral.u_var
+    substitutions = find_substitutions(integrand, symbol, u_var)
+    if substitutions:
+        ways = []
+        new_u = integral.new_u_var(u_var)
+        for u_func, c, substituted in substitutions:
+            ways.append(URule(u_var, u_func, c,
+                              integral_steps(substituted, u_var, u_var=new_u),
+                              integrand, symbol))
+
+        if len(ways) > 1:
+            return AlternativeRule(ways, integrand, symbol)
+        elif ways:
+            return ways[0]
+
+    elif integrand.has(sympy.exp):
+        u_func = sympy.exp(symbol)
+        c = 1
+        substituted = integrand / u_func.diff(symbol)
+        substituted = substituted.subs(u_func, u_var)
+        new_u = integral.new_u_var(u_var)
+        return URule(u_var, u_func, c,
+                     integral_steps(substituted, u_var, u_var=new_u),
+                     integrand, symbol)
+
+partial_fractions_rule = rewriter(
+    lambda integrand, symbol: integrand.is_rational_function(),
+    lambda integrand, symbol: integrand.apart(symbol))
+
+distribute_expand_rule = rewriter(
+    lambda integrand, symbol: (
+        all(arg.is_Pow or arg.is_polynomial(symbol) for arg in integrand.args)
+        or integrand.func in (sympy.Pow, sympy.Mul)),
+    lambda integrand, symbol: integrand.expand())
+
+def fallback_rule(integral):
+    return DontKnowRule(*integral)
+
+_integral_cache = {}
+def integral_steps(integrand, symbol, **options):
+    cachekey = (integrand, symbol)
+    if cachekey in _integral_cache:
+        if _integral_cache[cachekey] is None:
+            # cyclic integral! null_safe will eliminate that path
+            return None
+        else:
+            return _integral_cache[cachekey]
+    else:
+        _integral_cache[cachekey] = None
+
+    u_var = options.get('u_var', sympy.Symbol('u'))
+    integral = IntegralInfo(integrand, symbol, u_var=u_var)
+
+    def key(integral):
+        integrand = integral.integrand
+
+        if isinstance(integrand, TrigonometricFunction):
+            return TrigonometricFunction
+        elif symbol not in integrand.free_symbols:
+            return 'constant'
+        else:
+            return integrand.func
+
+    result = do_one(
+        null_safe(switch(key, {
+            sympy.Pow: do_one(null_safe(power_rule), null_safe(arctan_rule)),
+            sympy.Symbol: power_rule,
+            sympy.exp: exp_rule,
+            sympy.Add: add_rule,
+            sympy.Mul: mul_rule,
+            TrigonometricFunction: trig_rule,
+            'constant': constant_rule
+        })),
+        null_safe(
+            alternatives(
+                substitution_rule,
+                condition(lambda integral: key(integral) == sympy.Mul,
+                          partial_fractions_rule),
+                condition(lambda integral: key(integral) in (sympy.Mul, sympy.Pow),
+                          distribute_expand_rule),
+                trig_powers_products_rule
+            )
+        ),
+        fallback_rule)(integral)
+    _integral_cache[cachekey] = result
+    return result
+
+@evaluates(ConstantRule)
+def eval_constant(constant, integrand, symbol):
+    return constant * symbol
+
+@evaluates(ConstantTimesRule)
+def eval_constanttimes(constant, other, substep, integrand, symbol):
+    return constant * _manualintegrate(substep)
+
+@evaluates(PowerRule)
+def eval_power(base, exp, integrand, symbol):
+    return (base ** (exp + 1)) / (exp + 1)
+
+@evaluates(ExpRule)
+def eval_exp(base, exp, integrand, symbol):
+    return integrand / sympy.ln(base)
+
+@evaluates(AddRule)
+def eval_add(substeps, integrand, symbol):
+    return sum(map(_manualintegrate, substeps))
+
+@evaluates(URule)
+def eval_u(u_var, u_func, constant, substep, integrand, symbol):
+    result = _manualintegrate(substep)
+
+    if not isinstance(substep, ConstantTimesRule):
+        result *= constant
+
+    return result.subs(u_var, u_func)
+
+@evaluates(TrigRule)
+def eval_trig(func, arg, integrand, symbol):
+    if func == sympy.sin:
+        return -sympy.cos(arg)
+    elif func == sympy.cos:
+        return sympy.sin(arg)
+
+@evaluates(LogRule)
+def eval_log(func, integrand, symbol):
+    return sympy.ln(sympy.Abs(func))
+
+@evaluates(ArctanRule)
+def eval_arctan(integrand, symbol):
+    return sympy.atan(symbol)
+
+@evaluates(AlternativeRule)
+def eval_alternative(alternatives, integrand, symbol):
+    return _manualintegrate(alternatives[0])
+
+@evaluates(RewriteRule)
+def eval_rewrite(rewritten, substep, integrand, symbol):
+    return _manualintegrate(substep)
+
+@evaluates(DontKnowRule)
+def eval_dontknowrule(integrand, symbol):
+    return sympy.integrate(integrand, symbol)
+
+def _manualintegrate(rule):
+    evaluator = evaluators.get(rule.__class__)
+    if not evaluator:
+        raise TypeError("Cannot evaluate rule %s" % rule)
+    return evaluator(*rule)
+
+def manualintegrate(f, x):
+    return _manualintegrate(integral_steps(f, x))

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -860,7 +860,7 @@ def manualintegrate(f, var):
     >>> from sympy.integrals.manualintegrate import manualintegrate
     >>> from sympy.abc import x
     >>> manualintegrate(1 / x, x)
-    log(Abs(x))
+    log(x)
     >>> integrate(1/x)
     log(x)
     >>> manualintegrate(log(x), x)
@@ -880,7 +880,7 @@ def manualintegrate(f, var):
     >>> integrate(cos(x)**4 * sin(x)**3, x)
     cos(x)**7/7 - cos(x)**5/5
     >>> manualintegrate(tan(x), x)
-    -log(Abs(cos(x)))
+    -log(cos(x))
     >>> integrate(tan(x), x)
     -log(sin(x)**2 - 1)/2
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -6,12 +6,109 @@ from sympy.simplify import fraction
 from sympy.strategies.core import (switch, identity, do_one, null_safe,
                                    condition, tryit)
 
+try:
+    from collections import namedtuple
+except ImportError:
+    # for Python 2.5 compatibility
+    # code from http://code.activestate.com/recipes/500261-named-tuples/
+    # PSF license
+    # code is Copyright 2007-2013 Raymond Hettinger
+    from operator import itemgetter as _itemgetter
+    from keyword import iskeyword as _iskeyword
+    import sys as _sys
+
+    def namedtuple(typename, field_names, verbose=False, rename=False):
+        # Parse and validate the field names.  Validation serves two purposes,
+        # generating informative error messages and preventing template injection attacks.
+        if isinstance(field_names, basestring):
+            field_names = field_names.replace(',', ' ').split() # names separated by whitespace and/or commas
+        field_names = tuple(map(str, field_names))
+        if rename:
+            names = list(field_names)
+            seen = set()
+            for i, name in enumerate(names):
+                if (not min(c.isalnum() or c=='_' for c in name) or _iskeyword(name)
+                    or not name or name[0].isdigit() or name.startswith('_')
+                    or name in seen):
+                        names[i] = '_%d' % i
+                seen.add(name)
+            field_names = tuple(names)
+        for name in (typename,) + field_names:
+            if not min(c.isalnum() or c=='_' for c in name):
+                raise ValueError('Type names and field names can only contain alphanumeric characters and underscores: %r' % name)
+            if _iskeyword(name):
+                raise ValueError('Type names and field names cannot be a keyword: %r' % name)
+            if name[0].isdigit():
+                raise ValueError('Type names and field names cannot start with a number: %r' % name)
+        seen_names = set()
+        for name in field_names:
+            if name.startswith('_') and not rename:
+                raise ValueError('Field names cannot start with an underscore: %r' % name)
+            if name in seen_names:
+                raise ValueError('Encountered duplicate field name: %r' % name)
+            seen_names.add(name)
+
+        # Create and fill-in the class template
+        numfields = len(field_names)
+        argtxt = repr(field_names).replace("'", "")[1:-1]   # tuple repr without parens or quotes
+        reprtxt = ', '.join('%s=%%r' % name for name in field_names)
+        template = '''class %(typename)s(tuple):
+    '%(typename)s(%(argtxt)s)' \n
+    __slots__ = () \n
+    _fields = %(field_names)r \n
+    def __new__(_cls, %(argtxt)s):
+        return _tuple.__new__(_cls, (%(argtxt)s)) \n
+    @classmethod
+    def _make(cls, iterable, new=tuple.__new__, len=len):
+        'Make a new %(typename)s object from a sequence or iterable'
+        result = new(cls, iterable)
+        if len(result) != %(numfields)d:
+            raise TypeError('Expected %(numfields)d arguments, got %%d' %% len(result))
+        return result \n
+    def __repr__(self):
+        return '%(typename)s(%(reprtxt)s)' %% self \n
+    def _asdict(self):
+        'Return a new dict which maps field names to their values'
+        return dict(zip(self._fields, self)) \n
+    def _replace(_self, **kwds):
+        'Return a new %(typename)s object replacing specified fields with new values'
+        result = _self._make(map(kwds.pop, %(field_names)r, _self))
+        if kwds:
+            raise ValueError('Got unexpected field names: %%r' %% kwds.keys())
+        return result \n
+    def __getnewargs__(self):
+        return tuple(self) \n\n''' % locals()
+        for i, name in enumerate(field_names):
+            template += '    %s = _property(_itemgetter(%d))\n' % (name, i)
+        if verbose:
+            print template
+
+        # Execute the template string in a temporary namespace
+        namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename,
+                         _property=property, _tuple=tuple)
+        try:
+            exec template in namespace
+        except SyntaxError, e:
+            raise SyntaxError(e.message + ':\n' + template)
+        result = namespace[typename]
+
+        # For pickling to work, the __module__ variable needs to be set to the frame
+        # where the named tuple is created.  Bypass this step in enviroments where
+        # sys._getframe is not defined (Jython for example) or sys._getframe is not
+        # defined for arguments greater than 0 (IronPython).
+        try:
+            result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
+        except (AttributeError, ValueError):
+            pass
+
+        return result
+
 def Rule(name, props=""):
     # GOTCHA: namedtuple class name not considered!
     def __eq__(self, other):
         return self.__class__ == other.__class__ and tuple.__eq__(self, other)
     __neq__ = lambda self, other: not __eq__(self, other)
-    cls = collections.namedtuple(name, props + " context symbol")
+    cls = namedtuple(name, props + " context symbol")
     cls.__eq__ = __eq__
     cls.__ne__ = __neq__
     return cls
@@ -187,11 +284,11 @@ def power_rule(integral):
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
 
-    if exp.rewrite('sincos').is_constant(symbol) and base.func == sympy.Symbol:
+    if symbol not in exp.free_symbols and base.func == sympy.Symbol:
         if sympy.simplify(exp + 1) == 0:
             return LogRule(base, integrand, symbol)
         return PowerRule(base, exp, integrand, symbol)
-    elif base.rewrite('sincos').is_constant(symbol) and exp.func == sympy.Symbol:
+    elif symbol not in base.free_symbols and exp.func == sympy.Symbol:
         return ExpRule(base, exp, integrand, symbol)
 
 def exp_rule(integral):
@@ -252,14 +349,20 @@ def mul_rule(integral):
     # Constant times function case
     if len(args) == 2:
         integrand_t = integrand.rewrite('sincos')
-        if integrand_t.args[0].is_constant(symbol):
-            return ConstantTimesRule(args[0], args[1],
-                                     integral_steps(args[1], symbol),
-                                     integrand, symbol)
-        elif integrand_t.args[1].is_constant(symbol):
-            return ConstantTimesRule(args[1], args[0],
-                                     integral_steps(args[0], symbol),
-                                     integrand, symbol)
+
+        # simplification can raise TypeError based on what the expr is
+        # (e.g. DiracDelta)
+        try:
+            if integrand_t.args[0].is_constant(symbol):
+                return ConstantTimesRule(args[0], args[1],
+                                         integral_steps(args[1], symbol),
+                                         integrand, symbol)
+            elif integrand_t.args[1].is_constant(symbol):
+                return ConstantTimesRule(args[1], args[0],
+                                         integral_steps(args[0], symbol),
+                                         integrand, symbol)
+        except TypeError:
+            pass
 
 def _parts_rule(integrand, symbol):
     # LIATE rule:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -17,7 +17,9 @@ except ImportError:
     from keyword import iskeyword as _iskeyword
     import sys as _sys
 
-    def namedtuple(typename, field_names, verbose=False, rename=False):
+    # For some reason, doctest will test namedtuple's docstring if we simply
+    # have a def namedtuple() here
+    def _namedtuple(typename, field_names, verbose=False, rename=False):
         # Parse and validate the field names.  Validation serves two purposes,
         # generating informative error messages and preventing template injection attacks.
         if isinstance(field_names, basestring):
@@ -102,6 +104,8 @@ except ImportError:
             pass
 
         return result
+
+    namedtuple = _namedtuple
 
 def Rule(name, props=""):
     # GOTCHA: namedtuple class name not considered!

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -411,6 +411,7 @@ def _parts_rule(integrand, symbol):
                     du = u.diff(symbol)
                     v_step = integral_steps(dv, symbol)
                     v = _manualintegrate(v_step)
+
                     return u, dv, v, du, v_step
 
 def parts_rule(integral):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,4 +1,4 @@
-from sympy import (sin, cos, tan, sec, csc, cot, log, exp, Abs, atan,
+from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan,
                    Symbol, Mul)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, integral_steps
 
@@ -25,8 +25,8 @@ def test_manualintegrate_exponentials():
     assert manualintegrate(exp(2*x), x) == exp(2*x) / 2
     assert manualintegrate(2**x, x) == (2 ** x) / log(2)
 
-    assert manualintegrate(1 / x, x) == log(Abs(x))
-    assert manualintegrate(1 / (2*x + 3), x) == log(Abs(2*x + 3)) / 2
+    assert manualintegrate(1 / x, x) == log(x)
+    assert manualintegrate(1 / (2*x + 3), x) == log(2*x + 3) / 2
     assert manualintegrate(log(x)**2 / x, x) == log(x)**3 / 3
 
 def test_manualintegrate_parts():
@@ -37,14 +37,15 @@ def test_manualintegrate_parts():
     assert manualintegrate(log(x), x) == x * log(x) - x
     assert manualintegrate((3*x**2 + 5) * exp(x), x) == \
         -6*x*exp(x) + (3*x**2 + 5)*exp(x) + 6*exp(x)
+    assert manualintegrate(atan(x), x) == x*atan(x) - log(x**2 + 1)/2
 
 def test_manualintegrate_trigonometry():
     assert manualintegrate(sin(x), x) == -cos(x)
-    assert manualintegrate(tan(x), x) == -log(Abs(cos(x)))
+    assert manualintegrate(tan(x), x) == -log(cos(x))
 
     # TODO: benchmark these two - they're slow
-    assert manualintegrate(sec(x), x) == log(Abs(sec(x) + tan(x)))
-    assert manualintegrate(csc(x), x) == -log(Abs(csc(x) + cot(x)))
+    assert manualintegrate(sec(x), x) == log(sec(x) + tan(x))
+    assert manualintegrate(csc(x), x) == -log(csc(x) + cot(x))
 
     assert manualintegrate(sin(x) * cos(x), x) in [sin(x) ** 2 / 2, -cos(x)**2 / 2]
     assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,0 +1,52 @@
+from sympy import (sin, cos, tan, sec, csc, cot, log, exp, Abs, atan,
+                   Symbol)
+from sympy.integrals.manualintegrate import manualintegrate, integral_steps
+
+x = Symbol('x')
+y = Symbol('y')
+
+def test_manualintegrate_polynomials():
+    assert manualintegrate(y, x) == x*y
+    assert manualintegrate(exp(2), x) == x * exp(2)
+    assert manualintegrate(x**2, x) == x**3 / 3
+    assert manualintegrate(3 * x**2 + 4 * x**3, x) == x**3 + x**4
+
+    assert manualintegrate((x + 2)**3, x) == (x + 2)**4 / 4
+    assert manualintegrate((3*x + 4)**2, x) == (3*x + 4)**3 / 9
+
+def test_manualintegrate_exponentials():
+    assert manualintegrate(exp(2*x), x) == exp(2*x) / 2
+    assert manualintegrate(2**x, x) == (2 ** x) / log(2)
+
+    assert manualintegrate(1 / x, x) == log(Abs(x))
+    assert manualintegrate(1 / (2*x + 3), x) == log(Abs(2*x + 3)) / 2
+
+def test_manualintegrate_trigonometry():
+    assert manualintegrate(sin(x), x) == -cos(x)
+    assert manualintegrate(tan(x), x) == -log(Abs(cos(x)))
+
+#    assert manualintegrate(sec(x), x) == log(Abs(sec(x) + tan(x)))
+#    assert manualintegrate(csc(x), x) == -log(Abs(csc(x) + cot(x)))
+
+    assert manualintegrate(sin(x) * cos(x), x) == -cos(x) ** 2 / 2
+
+def test_manualintegrate_trigpowers():
+    assert manualintegrate(sin(x)**2 * cos(x), x) == sin(x)**3 / 3
+    assert manualintegrate(sin(x)**2 * cos(x) **2, x) == \
+        x / 8 - sin(4*x) / 32
+    assert manualintegrate(sin(x) * cos(x)**3, x) == -cos(x)**4 / 4
+    assert manualintegrate(sin(x)**3 * cos(x)**2, x) == \
+        -cos(x)**5 / 5 + cos(x)**3 / 3
+
+    assert manualintegrate(tan(x)**3 * sec(x), x) == sec(x)**3/3 - sec(x)
+    assert manualintegrate(tan(x) * sec(x) **2, x) == sec(x)**2/2
+
+    # print integral_steps(cot(x) ** 5 * csc(x), x)
+    # print integral_steps(cot(x)**2 * csc(x)**6, x)
+
+def test_manualintegrate_inversetrig():
+    assert manualintegrate(exp(x) / (1 + exp(2*x)), x) == atan(exp(x))
+    assert manualintegrate(1 / (4 + 9 * x**2), x) == atan(3 * x/2) / 6
+    assert manualintegrate(1 / (16 + 16 * x**2), x) == atan(x) / 16
+    assert manualintegrate(1 / (4 + x**2), x) == atan(x / 2) / 2
+    assert manualintegrate(1 / (1 + 4 * x**2), x) == atan(2*x) / 2

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -43,7 +43,6 @@ def test_manualintegrate_trigonometry():
     assert manualintegrate(sin(x), x) == -cos(x)
     assert manualintegrate(tan(x), x) == -log(cos(x))
 
-    # TODO: benchmark these two - they're slow
     assert manualintegrate(sec(x), x) == log(sec(x) + tan(x))
     assert manualintegrate(csc(x), x) == -log(csc(x) + cot(x))
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -21,6 +21,9 @@ def test_manualintegrate_polynomials():
     assert manualintegrate((x + 2)**3, x) == (x + 2)**4 / 4
     assert manualintegrate((3*x + 4)**2, x) == (3*x + 4)**3 / 9
 
+    assert manualintegrate((u + 2)**3, u) == (u + 2)**4 / 4
+    assert manualintegrate((3*u + 4)**2, u) == (3*u + 4)**3 / 9
+
 def test_manualintegrate_exponentials():
     assert manualintegrate(exp(2*x), x) == exp(2*x) / 2
     assert manualintegrate(2**x, x) == (2 ** x) / log(2)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,9 +1,16 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, Abs, atan,
-                   Symbol)
-from sympy.integrals.manualintegrate import manualintegrate, integral_steps
+                   Symbol, Mul)
+from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, integral_steps
 
 x = Symbol('x')
 y = Symbol('y')
+u = Symbol('u')
+
+def test_find_substitutions():
+    assert find_substitutions((cot(x)**2 + 1)**2*csc(x)**2*cot(x)**2, x, u) == \
+        [(cot(x), 1, -u**6 - 2*u**4 - u**2)]
+    assert find_substitutions((sec(x)**2 + tan(x) * sec(x)) / (sec(x) + tan(x)),
+                              x, u) == [(sec(x) + tan(x), 1, 1/u)]
 
 def test_manualintegrate_polynomials():
     assert manualintegrate(y, x) == x*y
@@ -20,15 +27,28 @@ def test_manualintegrate_exponentials():
 
     assert manualintegrate(1 / x, x) == log(Abs(x))
     assert manualintegrate(1 / (2*x + 3), x) == log(Abs(2*x + 3)) / 2
+    assert manualintegrate(log(x)**2 / x, x) == log(x)**3 / 3
+
+def test_manualintegrate_parts():
+    assert manualintegrate(exp(x) * sin(x), x) == \
+        (exp(x) * sin(x)) / 2 - (exp(x) * cos(x)) / 2
+    assert manualintegrate(2*x*cos(x), x) == 2*x*sin(x) + 2*cos(x)
+    assert manualintegrate(x * log(x), x) == x**2*log(x)/2 - x**2/4
+    assert manualintegrate(log(x), x) == x * log(x) - x
+    assert manualintegrate((3*x**2 + 5) * exp(x), x) == \
+        -6*x*exp(x) + (3*x**2 + 5)*exp(x) + 6*exp(x)
 
 def test_manualintegrate_trigonometry():
     assert manualintegrate(sin(x), x) == -cos(x)
     assert manualintegrate(tan(x), x) == -log(Abs(cos(x)))
 
-#    assert manualintegrate(sec(x), x) == log(Abs(sec(x) + tan(x)))
-#    assert manualintegrate(csc(x), x) == -log(Abs(csc(x) + cot(x)))
+    # TODO: benchmark these two - they're slow
+    assert manualintegrate(sec(x), x) == log(Abs(sec(x) + tan(x)))
+    assert manualintegrate(csc(x), x) == -log(Abs(csc(x) + cot(x)))
 
-    assert manualintegrate(sin(x) * cos(x), x) == -cos(x) ** 2 / 2
+    assert manualintegrate(sin(x) * cos(x), x) in [sin(x) ** 2 / 2, -cos(x)**2 / 2]
+    assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)
+    assert manualintegrate(csc(x) * cot(x), x) == -csc(x)
 
 def test_manualintegrate_trigpowers():
     assert manualintegrate(sin(x)**2 * cos(x), x) == sin(x)**3 / 3
@@ -36,13 +56,15 @@ def test_manualintegrate_trigpowers():
         x / 8 - sin(4*x) / 32
     assert manualintegrate(sin(x) * cos(x)**3, x) == -cos(x)**4 / 4
     assert manualintegrate(sin(x)**3 * cos(x)**2, x) == \
-        -cos(x)**5 / 5 + cos(x)**3 / 3
+        cos(x)**5 / 5 - cos(x)**3 / 3
 
     assert manualintegrate(tan(x)**3 * sec(x), x) == sec(x)**3/3 - sec(x)
     assert manualintegrate(tan(x) * sec(x) **2, x) == sec(x)**2/2
 
-    # print integral_steps(cot(x) ** 5 * csc(x), x)
-    # print integral_steps(cot(x)**2 * csc(x)**6, x)
+    assert manualintegrate(cot(x)**5 * csc(x), x) == \
+        -csc(x)**5/5 + 2*csc(x)**3/3 - csc(x)
+    assert manualintegrate(cot(x)**2 * csc(x)**6, x) == \
+        -cot(x)**7/7 - 2*cot(x)**5/5 - cot(x)**3/3
 
 def test_manualintegrate_inversetrig():
     assert manualintegrate(exp(x) / (1 + exp(2*x)), x) == atan(exp(x))

--- a/sympy/integrals/tests/test_trigonometry.py
+++ b/sympy/integrals/tests/test_trigonometry.py
@@ -41,7 +41,7 @@ def test_trigintegrate_even():
     assert trigintegrate(sin(3*x)**2, x) == x/2 - cos(3*x)*sin(3*x)/6
     assert trigintegrate(cos(3*x)**2, x) == x/2 + cos(3*x)*sin(3*x)/6
     assert trigintegrate(sin(x)**2 * cos(x)**2, x) == \
-        x/8 - sin(4*x)/32
+        x/8 - sin(2*x)*cos(2*x)/16
 
     assert trigintegrate(sin(x)**4 * cos(x)**2, x) == \
         x/16 - sin(x) *cos(x)/16 - sin(x)**3*cos(x)/24 + \

--- a/sympy/integrals/tests/test_trigonometry.py
+++ b/sympy/integrals/tests/test_trigonometry.py
@@ -41,7 +41,7 @@ def test_trigintegrate_even():
     assert trigintegrate(sin(3*x)**2, x) == x/2 - cos(3*x)*sin(3*x)/6
     assert trigintegrate(cos(3*x)**2, x) == x/2 + cos(3*x)*sin(3*x)/6
     assert trigintegrate(sin(x)**2 * cos(x)**2, x) == \
-        x/8 - cos(2*x)*sin(2*x)/16
+        x/8 - sin(4*x)/32
 
     assert trigintegrate(sin(x)**4 * cos(x)**2, x) == \
         x/16 - sin(x) *cos(x)/16 - sin(x)**3*cos(x)/24 + \


### PR DESCRIPTION
Changes:
- Add function that integrates "by hand"
- Add function that gives steps for such an integral (does not include a pretty-printer)

Do we want this as an option to `integrate`/`Integral.doit`?

Not implemented:
- [Trigonometric substitution](http://en.wikipedia.org/wiki/Trigonometric_substitution)
- Clever u-substitutions/parts integrals (e.g. `x^3 exp(x^2)` with `u = x^2`, `dv = x exp(x^2)`; `x sqrt(x-2)` changed to `(u+2)sqrt(u)`)

Examples:

```
>>> from sympy import sin, cos, tan, sec, exp, log, integrate
>>> from sympy.integrals.manualintegrate import manualintegrate
>>> from sympy.abc import x
>>> manualintegrate(1 / x, x)
log(Abs(x))
>>> integrate(1/x)
log(x)
>>> manualintegrate(log(x), x)
x*log(x) - x
>>> integrate(log(x))
x*log(x) - x
>>> manualintegrate(exp(x) / (1 + exp(2 * x)), x)
atan(exp(x))
>>> integrate(exp(x) / (1 + exp(2 * x)))
RootSum(4*_z**2 + 1, Lambda(_i, _i*log(2*_i + exp(x))))
>>> manualintegrate(cos(x)**4 * sin(x), x)
-cos(x)**5/5
>>> integrate(cos(x)**4 * sin(x), x)
-cos(x)**5/5
>>> manualintegrate(cos(x)**4 * sin(x)**3, x)
cos(x)**7/7 - cos(x)**5/5
>>> integrate(cos(x)**4 * sin(x)**3, x)
cos(x)**7/7 - cos(x)**5/5
>>> manualintegrate(tan(x), x)
-log(Abs(cos(x)))
>>> integrate(tan(x), x)
-log(sin(x)**2 - 1)/2
>>> manualintegrate(sec(x), x)
log(Abs(sec(x) + tan(x)))
>>> integrate(sec(x), x)
-log(sin(x) - 1)/2 + log(sin(x) + 1)/2
>>> manualintegrate(sec(x)**4 *tan(x)**4, x)
tan(x)**7/7 + tan(x)**5/5
>>> integrate(sec(x)**4 *tan(x)**4, x)
2*sin(x)/(35*cos(x)) + sin(x)/(35*cos(x)**3) - 8*sin(x)/(35*cos(x)**5) + sin(x)/(7*cos(x)**7)
```
