### PR TITLE
issue 3654: Don't do costly expand() on top of Order.__new__() method

### DIFF
--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -543,6 +543,14 @@ class polygamma(Function):
             else:
                 return S.NegativeOne**(n+1) * C.factorial(n) * (C.zeta(n+1) - harmonic(z-1, n+1))
 
+    def _eval_as_leading_term(self, x):
+        n, z = [a.as_leading_term(x) for a in self.args]
+        o = C.Order(z, x)
+        if n == 0 and o.contains(1/x):
+            return o.getn() * log(x)
+        else:
+            return self.func(n, z)
+
 
 class loggamma(Function):
     """

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -1,5 +1,5 @@
 from sympy.core import Basic, S, sympify, Expr, Rational, Symbol
-from sympy.core import Add, Mul
+from sympy.core import Add, Mul, expand_power_base, expand_log
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import cmp_to_key
 
@@ -96,7 +96,7 @@ class Order(Expr):
     @cacheit
     def __new__(cls, expr, *symbols, **assumptions):
 
-        expr = sympify(expr).expand()
+        expr = sympify(expr)
         if expr is S.NaN:
             return S.NaN
 
@@ -119,6 +119,14 @@ class Order(Expr):
 
             symbols = list(set(symbols))
 
+            if len(symbols) > 1:
+                # XXX: better way?  We need this expand() to
+                # workaround e.g: expr = x*(x + y).
+                # (x*(x + y)).as_leading_term(x, y) currently returns
+                # x*y (wrong order term!).  That's why we want to deal with
+                # expand()'ed expr (handled in "if expr.is_Add" branch below).
+                expr = expr.expand()
+
             if expr.is_Add:
                 lst = expr.extract_leading_order(*symbols)
                 expr = Add(*[f.expr for (e, f) in lst])
@@ -130,9 +138,12 @@ class Order(Expr):
                     # works in one symbol.
                     expr = expr.as_leading_term(*symbols)
                 else:
-                    expr = expr.compute_leading_term(symbols[0])
+                    expr = expr.as_leading_term(symbols[0])
 
-                margs = list(Mul.make_args(expr.as_independent(*symbols)[1]))
+                expr = expr.as_independent(*symbols, **dict(as_Add=False))[1]
+
+                expr = expand_power_base(expr)
+                expr = expand_log(expr)
 
                 if len(symbols) == 1:
                     # The definition of O(f(x)) symbol explicitly stated that
@@ -141,6 +152,8 @@ class Order(Expr):
                     # expression tree for f(x)), e.g.:
                     # x**p * (-x)**q -> x**(p+q) for real p, q.
                     x = symbols[0]
+                    margs = list(Mul.make_args(
+                        expr.as_independent(x, **dict(as_Add=False))[1]))
 
                     for i, t in enumerate(margs):
                         if t.is_Pow:
@@ -158,7 +171,7 @@ class Order(Expr):
                                     if b in (x, -x) and r.is_real:
                                         margs[i] = x**(r*q)
 
-                expr = Mul(*margs)
+                    expr = Mul(*margs)
 
         if expr is S.Zero:
             return expr

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -132,14 +132,7 @@ class Order(Expr):
                 expr = Add(*[f.expr for (e, f) in lst])
 
             elif expr:
-                if len(symbols) > 1 or expr.is_commutative is False:
-                    # TODO
-                    # We cannot use compute_leading_term because that only
-                    # works in one symbol.
-                    expr = expr.as_leading_term(*symbols)
-                else:
-                    expr = expr.as_leading_term(symbols[0])
-
+                expr = expr.as_leading_term(*symbols)
                 expr = expr.as_independent(*symbols, **dict(as_Add=False))[1]
 
                 expr = expand_power_base(expr)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -316,3 +316,6 @@ def test_order_noncommutative():
     assert expand((1 + Order(x))*A*A*x) == A*A*x + Order(x**2, x)
     assert expand((A*A + Order(x))*x) == A*A*x + Order(x**2, x)
     assert expand((A + Order(x))*A*x) == A*A*x + Order(x**2, x)
+
+def test_issue_3654():
+    assert (1 + x**2)**10000*O(x) == O(x)


### PR DESCRIPTION
Do expand() only for multivariate O.

Also, first patch change compute_leading_term -> as_leading_term, as `compute_leading_term(x)` for `x*(1 + x**2)**10000` calls `expand()` too.

This seems to be related to Add._eval_nseries method.  Sometimes, it doesn't return order term (e.g. `(1 + x**2).nseries(x)`) - that's why `Pow._eval_nseries()` does actually `expand_multinomial()` for `x*(1 + x**2)**10000`.
