### PR TITLE
bugfix, consistency fix

### DIFF
--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -540,7 +540,7 @@ DifferentialOperator⎜──(f(x)),f(x)⎟\n\
     assert pretty(d) == ascii_str
     assert upretty(d) == ucode_str
     assert latex(d) == \
-        r'DifferentialOperator\left(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )}\right)'
+        r'DifferentialOperator\left(\frac{d}{d x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )}\right)'
     sT(d, "DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))")
     assert str(b) == 'Operator(B,t,1/2)'
     assert pretty(b) == 'Operator(B,t,1/2)'
@@ -815,7 +815,7 @@ u"""\
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
-        r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator\left(\frac{\partial}{\partial x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )}\right)^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+        r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )}\right)^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
     sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
     ascii_str = \

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -4,7 +4,6 @@ A few practical conventions common to all printers.
 
 
 import re
-import collections
 
 
 def split_super_sub(text):
@@ -69,7 +68,9 @@ def requires_partial(expr):
     get the context of the expression.
     """
 
-    if not isinstance(expr.free_symbols, collections.Iterable):
+    ## checking for the attribute '__iter__' is Python 2.5 friendly.
+    ## For 2.6+, say isinstance(expr.free_symbols, collections.Iterable)
+    if not hasattr(expr.free_symbols, '__iter__'):
         return len(set(expr.variables)) > 1
 
     return sum(not s.is_integer for s in expr.free_symbols) > 1

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -63,16 +63,8 @@ def requires_partial(expr):
     """Return whether a partial derivative symbol is required for printing
 
     This requires checking how many free variables there are and then
-    filtering out the ones that are Integer
-
-    Examples
-    ========
-    >>> from sympy.printing import requires_partial
-    >>> requires_partial(
-    >>> requires_partial(
-    >>> requires_partial(
-    >>> requires_partial(
-    """ 
+    filtering out the ones that are integers
+    """
 
     s = expr.free_symbols
     for sym in expr.free_symbols:

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -62,12 +62,7 @@ def split_super_sub(text):
 def requires_partial(expr):
     """Return whether a partial derivative symbol is required for printing
 
-    This requires checking how many free variables there are and then
+    This requires checking how many free variables there are,
     filtering out the ones that are integers
     """
-
-    s = expr.free_symbols
-    for sym in expr.free_symbols:
-        if sym.is_integer:
-            s.remove(sym)
-    return len(s) > 1
+    return sum(not s.is_integer for s in expr.free_symbols) > 1

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -4,6 +4,7 @@ A few practical conventions common to all printers.
 
 
 import re
+import collections
 
 
 def split_super_sub(text):
@@ -63,6 +64,12 @@ def requires_partial(expr):
     """Return whether a partial derivative symbol is required for printing
 
     This requires checking how many free variables there are,
-    filtering out the ones that are integers
+    filtering out the ones that are integers. Some expressions don't have
+    free variables. In that case, check its variable list explicitly to
+    get the context of the expression.
     """
+
+    if not isinstance(expr.free_symbols, collections.Iterable):
+        return len(set(expr.variables)) > 1
+
     return sum(not s.is_integer for s in expr.free_symbols) > 1

--- a/sympy/printing/conventions.py
+++ b/sympy/printing/conventions.py
@@ -58,3 +58,24 @@ def split_super_sub(text):
         subs.insert(0, sub)
 
     return name, supers, subs
+
+def requires_partial(expr):
+    """Return whether a partial derivative symbol is required for printing
+
+    This requires checking how many free variables there are and then
+    filtering out the ones that are Integer
+
+    Examples
+    ========
+    >>> from sympy.printing import requires_partial
+    >>> requires_partial(
+    >>> requires_partial(
+    >>> requires_partial(
+    >>> requires_partial(
+    """ 
+
+    s = expr.free_symbols
+    for sym in expr.free_symbols:
+        if sym.is_integer:
+            s.remove(sym)
+    return len(s) > 1

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -354,10 +354,16 @@ class LatexPrinter(Printer):
 
     def _print_Derivative(self, expr):
         dim = len(expr.variables)
+        is_partial = len(expr.free_symbols) > 1
+        if is_partial:
+            diff_symbol = r'\partial'
+        else:
+            diff_symbol = r'd'
+
 
         if dim == 1:
-            tex = r"\frac{\partial}{\partial %s}" % \
-                self._print(expr.variables[0])
+            tex = r"\frac{%s}{%s %s}" % (diff_symbol, diff_symbol,
+                self._print(expr.variables[0]))
         else:
             multiplicity, i, tex = [], 1, ""
             current = expr.variables[0]
@@ -373,11 +379,11 @@ class LatexPrinter(Printer):
 
             for x, i in multiplicity:
                 if i == 1:
-                    tex += r"\partial %s" % self._print(x)
+                    tex += diff_symbol + (r" %s" % self._print(x))
                 else:
-                    tex += r"\partial^{%s} %s" % (i, self._print(x))
+                    tex += diff_symbol + (r" %s^{%s}" % (self._print(x), i))
 
-            tex = r"\frac{\partial^{%s}}{%s} " % (dim, tex)
+            tex = r"\frac{" + diff_symbol + (r"^{%s}}{%s} " % (dim, tex))
 
         if isinstance(expr.expr, C.AssocOp):
             return r"%s\left(%s\right)" % (tex, self._print(expr.expr))

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -7,7 +7,7 @@ from sympy.core.function import _coeff_isneg
 from sympy.core.sympify import SympifyError
 
 from printer import Printer
-from conventions import split_super_sub
+from conventions import split_super_sub, requires_partial
 from precedence import precedence, PRECEDENCE
 
 import sympy.mpmath.libmp as mlib
@@ -354,8 +354,7 @@ class LatexPrinter(Printer):
 
     def _print_Derivative(self, expr):
         dim = len(expr.variables)
-        is_partial = len(expr.free_symbols) > 1
-        if is_partial:
+        if requires_partial(expr):
             diff_symbol = r'\partial'
         else:
             diff_symbol = r'd'

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -378,11 +378,11 @@ class LatexPrinter(Printer):
 
             for x, i in multiplicity:
                 if i == 1:
-                    tex += diff_symbol + (r" %s" % self._print(x))
+                    tex += r"%s %s" % (diff_symbol, self._print(x))
                 else:
-                    tex += diff_symbol + (r" %s^{%s}" % (self._print(x), i))
+                    tex += r"%s %s^{%s}" % (diff_symbol, self._print(x), i)
 
-            tex = r"\frac{" + diff_symbol + (r"^{%s}}{%s} " % (dim, tex))
+            tex = r"\frac{%s^{%s}}{%s} " % (diff_symbol, dim, tex)
 
         if isinstance(expr.expr, C.AssocOp):
             return r"%s\left(%s\right)" % (tex, self._print(expr.expr))

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -355,8 +355,6 @@ class MathMLPrinter(Printer):
         return x
 
     def _print_Derivative(self, e):
-        is_partial = len(e.free_symbols) > 1
-
         x = self.dom.createElement('apply')
         diff_symbol = self.mathml_tag(e)
         if requires_partial(e):

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -355,8 +355,13 @@ class MathMLPrinter(Printer):
         return x
 
     def _print_Derivative(self, e):
+        is_partial = len(e.free_symbols) > 1
+
         x = self.dom.createElement('apply')
-        x.appendChild(self.dom.createElement(self.mathml_tag(e)))
+        diff_symbol = self.mathml_tag(e)
+        if is_partial:
+            diff_symbol = 'partialdiff'
+        x.appendChild(self.dom.createElement(diff_symbol))
 
         x_1 = self.dom.createElement('bvar')
         for sym in e.variables:

--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -5,7 +5,7 @@ A MathML printer.
 from sympy import sympify, S, Mul
 from sympy.core.function import _coeff_isneg
 from printer import Printer
-from conventions import split_super_sub
+from conventions import split_super_sub, requires_partial
 
 
 class MathMLPrinter(Printer):
@@ -359,7 +359,7 @@ class MathMLPrinter(Printer):
 
         x = self.dom.createElement('apply')
         diff_symbol = self.mathml_tag(e)
-        if is_partial:
+        if requires_partial(e):
             diff_symbol = 'partialdiff'
         x.appendChild(self.dom.createElement(diff_symbol))
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -237,13 +237,17 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_Derivative(self, deriv):
-        # XXX use U('PARTIAL DIFFERENTIAL') here ?
+        is_partial = len(deriv.free_symbols) > 1
+        if is_partial and self._use_unicode:
+            deriv_symbol = U('PARTIAL DIFFERENTIAL')
+        else:
+            deriv_symbol = r'd'
         syms = list(reversed(deriv.variables))
         x = None
 
         for sym, num in group(syms, multiple=False):
             s = self._print(sym)
-            ds = prettyForm(*s.left('d'))
+            ds = prettyForm(*s.left(deriv_symbol))
 
             if num > 1:
                 ds = ds**prettyForm(str(num))
@@ -257,7 +261,7 @@ class PrettyPrinter(Printer):
         f = prettyForm(
             binding=prettyForm.FUNC, *self._print(deriv.expr).parens())
 
-        pform = prettyForm('d')
+        pform = prettyForm(deriv_symbol)
 
         if len(syms) > 1:
             pform = pform**prettyForm(str(len(syms)))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -6,6 +6,7 @@ from sympy.core.sympify import SympifyError
 
 from sympy.printing.printer import Printer
 from sympy.printing.str import sstr
+from sympy.printing.conventions import requires_partial
 
 from stringpict import prettyForm, stringPict
 from pretty_symbology import xstr, hobj, vobj, xobj, xsym, pretty_symbol, \
@@ -237,8 +238,7 @@ class PrettyPrinter(Printer):
             return self._print_Function(e)
 
     def _print_Derivative(self, deriv):
-        is_partial = len(deriv.free_symbols) > 1
-        if is_partial and self._use_unicode:
+        if requires_partial(deriv) and self._use_unicode:
             deriv_symbol = U('PARTIAL DIFFERENTIAL')
         else:
             deriv_symbol = r'd'

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1791,6 +1791,35 @@ dx            \
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
 
+    # basic partial derivatives
+    expr = Derivative(log(x + y) + x, x)
+    ascii_str_1 = \
+"""\
+d                 \n\
+--(log(x + y) + x)\n\
+dx                \
+"""
+    ascii_str_2 = \
+"""\
+d                 \n\
+--(x + log(x + y))\n\
+dx                \
+"""
+    ucode_str_1 = \
+u"""\
+∂                 \n\
+──(log(x + y) + x)\n\
+∂x                \
+"""
+    ucode_str_2 = \
+u"""\
+∂                 \n\
+──(x + log(x + y))\n\
+∂x                \
+"""
+    assert pretty(expr) in [ascii_str_1, ascii_str_2]
+    assert upretty(expr) in [ucode_str_1, ucode_str_2], upretty(expr)
+
     # Multiple symbols
     expr = Derivative(log(x) + x**2, x, y)
     ascii_str_1 = \
@@ -1842,16 +1871,16 @@ x  + -----(2*x*y)\n\
     ucode_str_1 = \
 u"""\
    2             \n\
-  d             2\n\
+  ∂             2\n\
 ─────(2⋅x⋅y) + x \n\
-dx dy            \
+∂x ∂y            \
 """
     ucode_str_2 = \
 u"""\
         2        \n\
- 2     d         \n\
+ 2     ∂         \n\
 x  + ─────(2⋅x⋅y)\n\
-     dx dy       \
+     ∂x ∂y       \
 """
     assert pretty(expr) in [ascii_str_1, ascii_str_2]
     assert upretty(expr) in [ucode_str_1, ucode_str_2]
@@ -1868,10 +1897,10 @@ dx        \
     ucode_str = \
 u"""\
   2       \n\
- d        \n\
+ ∂        \n\
 ───(2⋅x⋅y)\n\
   2       \n\
-dx        \
+∂x        \
 """
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1888,10 +1917,10 @@ dx         \
     ucode_str = \
 u"""\
  17        \n\
-d          \n\
+∂          \n\
 ────(2⋅x⋅y)\n\
   17       \n\
-dx         \
+∂x         \
 """
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1908,10 +1937,10 @@ dy dx        \
     ucode_str = \
 u"""\
    3         \n\
-  d          \n\
+  ∂          \n\
 ──────(2⋅x⋅y)\n\
      2       \n\
-dy dx        \
+∂y ∂x        \
 """
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -1,4 +1,4 @@
-from sympy import symbols, Derivative, Integral, exp, oo
+from sympy import symbols, Derivative, Integral, exp, cos, oo
 from sympy.functions.special.bessel import besselj
 from sympy.functions.special.polynomials import legendre
 from sympy.functions.combinatorial.numbers import bell
@@ -31,7 +31,7 @@ def test_super_sub():
     assert split_super_sub("alpha_11_11") == ("alpha", [], ["11", "11"])
 
 def test_requires_partial():
-    x, y, z, nu = symbols('x y z nu')
+    x, y, z, t, nu = symbols('x y z t nu')
     n = symbols('n', integer=True)
 
     f = x * y
@@ -66,3 +66,9 @@ def test_requires_partial():
 
     f = x ** n
     assert requires_partial(Derivative(f, x)) == False
+
+    assert requires_partial(Derivative(Integral((x*y) ** n * exp(-x * y), (x, 0, oo)), y, evaluate=False)) == False
+
+    f = (exp(t), cos(t))
+    g = sum(f)
+    assert requires_partial(Derivative(g, t)) == False

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -1,4 +1,8 @@
-from sympy.printing.conventions import split_super_sub
+from sympy import symbols, Derivative, Integral, exp, oo
+from sympy.functions.special.bessel import besselj
+from sympy.functions.special.polynomials import legendre
+from sympy.functions.combinatorial.numbers import bell
+from sympy.printing.conventions import split_super_sub, requires_partial
 
 
 def test_super_sub():
@@ -25,3 +29,40 @@ def test_super_sub():
     assert split_super_sub("x__a__b__c__d") == ("x", ["a", "b", "c", "d"], [])
     assert split_super_sub("alpha_11") == ("alpha", [], ["11"])
     assert split_super_sub("alpha_11_11") == ("alpha", [], ["11", "11"])
+
+def test_requires_partial():
+    x, y, z, nu = symbols('x y z nu')
+    n = symbols('n', integer=True)
+
+    f = x * y
+    assert requires_partial(Derivative(f, x)) == True
+    assert requires_partial(Derivative(f, y)) == True
+
+    ## integrating out one of the variables
+    assert requires_partial(Derivative(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) == False
+
+    ## bessel function with smooth parameter
+    f = besselj(nu, x)
+    assert requires_partial(Derivative(f, x)) == True
+    assert requires_partial(Derivative(f, nu)) == True
+
+    ## bessel function with integer parameter
+    f = besselj(n, x)
+    assert requires_partial(Derivative(f, x)) == False
+    ## assert requires_partial(Derivative(f, n)) == False ## what to do here?
+
+    ## bell polynomial
+    f = bell(n, x)
+    assert requires_partial(Derivative(f, x)) == False
+    ## assert requires_partial(Derivative(f, n)) == False ## what to do here?
+
+    ## legendre polynomial
+    f = legendre(0, x)
+    assert requires_partial(Derivative(f, x)) == False
+
+    f = legendre(n, x)
+    assert requires_partial(Derivative(f, x)) == False
+    ## assert requires_partial(Derivative(f, n)) == False ## what to do here?
+
+    f = x ** n
+    assert requires_partial(Derivative(f, x)) == False

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -1,4 +1,4 @@
-from sympy import symbols, Derivative, Integral, exp, cos, oo
+from sympy import symbols, Derivative, Integral, exp, cos, oo, Function
 from sympy.functions.special.bessel import besselj
 from sympy.functions.special.polynomials import legendre
 from sympy.functions.combinatorial.numbers import bell

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -49,12 +49,16 @@ def test_requires_partial():
     ## bessel function with integer parameter
     f = besselj(n, x)
     assert requires_partial(Derivative(f, x)) == False
-    ## assert requires_partial(Derivative(f, n)) == False ## what to do here?
+    # this is not really valid (differentiating with respect to an integer)
+    # but there's no reason to use the partial derivative symbol there. make
+    # sure we don't throw an exception here, though
+    assert not requires_partial(Derivative(f, n))
 
     ## bell polynomial
     f = bell(n, x)
     assert requires_partial(Derivative(f, x)) == False
-    ## assert requires_partial(Derivative(f, n)) == False ## what to do here?
+    # again, invalid
+    assert requires_partial(Derivative(f, n)) == False
 
     ## legendre polynomial
     f = legendre(0, x)
@@ -62,13 +66,15 @@ def test_requires_partial():
 
     f = legendre(n, x)
     assert requires_partial(Derivative(f, x)) == False
-    ## assert requires_partial(Derivative(f, n)) == False ## what to do here?
+    # again, invalid
+    assert requires_partial(Derivative(f, n)) == False
 
     f = x ** n
     assert requires_partial(Derivative(f, x)) == False
 
     assert requires_partial(Derivative(Integral((x*y) ** n * exp(-x * y), (x, 0, oo)), y, evaluate=False)) == False
 
+    # parametric equation
     f = (exp(t), cos(t))
     g = sum(f)
     assert requires_partial(Derivative(g, t)) == False

--- a/sympy/printing/tests/test_conventions.py
+++ b/sympy/printing/tests/test_conventions.py
@@ -35,46 +35,51 @@ def test_requires_partial():
     n = symbols('n', integer=True)
 
     f = x * y
-    assert requires_partial(Derivative(f, x)) == True
-    assert requires_partial(Derivative(f, y)) == True
+    assert requires_partial(Derivative(f, x)) is True
+    assert requires_partial(Derivative(f, y)) is True
 
     ## integrating out one of the variables
-    assert requires_partial(Derivative(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) == False
+    assert requires_partial(Derivative(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) is False
 
     ## bessel function with smooth parameter
     f = besselj(nu, x)
-    assert requires_partial(Derivative(f, x)) == True
-    assert requires_partial(Derivative(f, nu)) == True
+    assert requires_partial(Derivative(f, x)) is True
+    assert requires_partial(Derivative(f, nu)) is True
 
     ## bessel function with integer parameter
     f = besselj(n, x)
-    assert requires_partial(Derivative(f, x)) == False
+    assert requires_partial(Derivative(f, x)) is False
     # this is not really valid (differentiating with respect to an integer)
     # but there's no reason to use the partial derivative symbol there. make
     # sure we don't throw an exception here, though
-    assert not requires_partial(Derivative(f, n))
+    assert requires_partial(Derivative(f, n)) is False
 
     ## bell polynomial
     f = bell(n, x)
-    assert requires_partial(Derivative(f, x)) == False
+    assert requires_partial(Derivative(f, x)) is False
     # again, invalid
-    assert requires_partial(Derivative(f, n)) == False
+    assert requires_partial(Derivative(f, n)) is False
 
     ## legendre polynomial
     f = legendre(0, x)
-    assert requires_partial(Derivative(f, x)) == False
+    assert requires_partial(Derivative(f, x)) is False
 
     f = legendre(n, x)
-    assert requires_partial(Derivative(f, x)) == False
+    assert requires_partial(Derivative(f, x)) is False
     # again, invalid
-    assert requires_partial(Derivative(f, n)) == False
+    assert requires_partial(Derivative(f, n)) is False
 
     f = x ** n
-    assert requires_partial(Derivative(f, x)) == False
+    assert requires_partial(Derivative(f, x)) is False
 
-    assert requires_partial(Derivative(Integral((x*y) ** n * exp(-x * y), (x, 0, oo)), y, evaluate=False)) == False
+    assert requires_partial(Derivative(Integral((x*y) ** n * exp(-x * y), (x, 0, oo)), y, evaluate=False)) is False
 
     # parametric equation
     f = (exp(t), cos(t))
     g = sum(f)
-    assert requires_partial(Derivative(g, t)) == False
+    assert requires_partial(Derivative(g, t)) is False
+
+    # function of unspecified variables
+    f = symbols('f', cls=Function)
+    assert requires_partial(Derivative(f, x)) is False
+    assert requires_partial(Derivative(f, x, y)) is True

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -285,11 +285,37 @@ def test_latex_brackets():
 
 
 def test_latex_derivatives():
+    # regular "d" for ordinary derivatives
     assert latex(diff(x**3, x, evaluate=False)) == \
-        r"\frac{\partial}{\partial x} x^{3}"
+        r"\frac{d}{d x} x^{3}"
     assert latex(diff(sin(x) + x**2, x, evaluate=False)) == \
-        r"\frac{\partial}{\partial x}\left(x^{2} + \sin{\left (x \right )}\right)"
+        r"\frac{d}{d x}\left(x^{2} + \sin{\left (x \right )}\right)"
+    assert latex(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False)) == \
+        r"\frac{d^{2}}{d x^{2}} \left(x^{2} + \sin{\left (x \right )}\right)"
+    assert latex(diff(diff(diff(sin(x) + x**2, x, evaluate=False), evaluate=False), evaluate=False)) == \
+        r"\frac{d^{3}}{d x^{3}} \left(x^{2} + \sin{\left (x \right )}\right)"
 
+    # \partial for partial derivatives
+    assert latex(diff(sin(x * y), x, evaluate=False)) == \
+        r"\frac{\partial}{\partial x} \sin{\left (x y \right )}"
+    assert latex(diff(sin(x * y) + x**2, x, evaluate=False)) == \
+        r"\frac{\partial}{\partial x}\left(x^{2} + \sin{\left (x y \right )}\right)"
+    assert latex(diff(diff(sin(x*y) + x**2, x, evaluate=False), x, evaluate=False)) == \
+        r"\frac{\partial^{2}}{\partial x^{2}} \left(x^{2} + \sin{\left (x y \right )}\right)"
+    assert latex(diff(diff(diff(sin(x*y) + x**2, x, evaluate=False), x, evaluate=False), x, evaluate=False)) == \
+        r"\frac{\partial^{3}}{\partial x^{3}} \left(x^{2} + \sin{\left (x y \right )}\right)"
+
+    # mixed partial derivatives
+    f = Function("f")
+    assert latex(diff(diff(f(x,y), x, evaluate=False), y, evaluate=False)) == \
+        r"\frac{\partial^{2}}{\partial x\partial y}  " + latex(f(x,y))
+
+    assert latex(diff(diff(diff(f(x,y), x, evaluate=False), x, evaluate=False), y, evaluate=False)) == \
+        r"\frac{\partial^{3}}{\partial x^{2}\partial y}  " + latex(f(x,y))
+
+    # use ordinary d when one of the variables has been integrated out
+    assert latex(diff(Integral(exp(-x * y), (x, 0, oo)), y, evaluate=False)) == \
+        r"\frac{d}{d y} \int_{0}^{\infty} e^{- x y}\, dx"
 
 def test_latex_subs():
     assert latex(Subs(x*y, (

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -64,6 +64,13 @@ def test_mathml_functions():
     assert mml_2.childNodes[1].childNodes[
         0].nodeName == 'ci'  # below bvar there's <ci>x/ci>
 
+    mml_3 = mp._print(diff(cos(x*y), x, evaluate=False))
+    assert mml_3.nodeName == 'apply'
+    assert mml_3.childNodes[0].nodeName == 'partialdiff'
+    assert mml_3.childNodes[1].nodeName == 'bvar'
+    assert mml_3.childNodes[1].childNodes[
+        0].nodeName == 'ci'  # below bvar there's <ci>x/ci>
+
 
 def test_mathml_limits():
     # XXX No unevaluated limits


### PR DESCRIPTION
This patch makes rendering of the differential or partial differential operator in the different printing systems consistent, addressing issue 1339. the latex renderer always used the partial symbol, while the mathml and unicode renderers always used a plain d. now some attempt is made to check whether the derivative is of a multivariate function or not.

also, there was a bug in the rendering of derivatives in latex where higher order derivatives were rendered as d^n/d^n x instead of d^n/dx^n.

the method for determining whether to apply the partial or full derivative could probably be made more sophisticated and accurate, but I view this as an improvement over what exists.

Also, I have developed a set of unit tests for the diffgeom package checking the output for the hyperbolic half-plane against manual calculations. This test also serves as an example of using diffgeom (hopefully of use to others).

https://code.google.com/p/sympy/issues/detail?id=1339
