### PR TITLE
Fix printing Manifold and Differential in diffgeom module

### DIFF
--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -30,7 +30,7 @@ class Manifold(Basic):
         # other Patch instance on the same manifold.
 
     def _latex(self, printer, *args):
-        return r'\mathbb{%s}' % self.name
+        return r'\mathrm{%s}' % self.name
 
 
 class Patch(Basic):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1523,11 +1523,11 @@ class LatexPrinter(Printer):
         field = diff._form_field
         if hasattr(field, '_coord_sys'):
             string = field._coord_sys._names[field._index]
-            return r'\mathbb{d}%s' % self._print(Symbol(string))
+            return r'\mathrm{d}%s' % self._print(Symbol(string))
         else:
             return 'd(%s)' % self._print(field)
             string = self._print(field)
-            return r'\mathbb{d}\left(%s\right)' % string
+            return r'\mathrm{d}\left(%s\right)' % string
 
     def _print_Tr(self, p):
         #Todo: Handle indices


### PR DESCRIPTION
The blackboard bold font in the AMSFonts package only has capital letters.  So, if we want to print small leters (e.g. "d" for the differential operator symbol), we shouldn't use \mathbb{d} (or "d" just disappear).

Also, print dimension of the manifold.
