### PR TITLE
Fixed bug in _integer_basis

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -487,9 +487,9 @@ def _quintic_simplify(expr):
 def _integer_basis(poly):
     """Compute coefficient basis for a polynomial over integers.
 
-    Returns the integer ``div`` such that substituting ``y = div*x``
-    the algebraic equation ``p(x) = 0`` becomes an algebraic equation
-    in ``y`` with smaller integer coefficients.
+    Returns the integer ``div`` such that substituting ``x = div*y``
+    ``p(x) = m*q(y)`` where the coefficients of ``q`` are smaller
+    than those of ``p``.
 
     For example ``x**5 + 512*x + 1024 = 0``
     with ``div = 4`` becomes ``y**5 + 2*y + 1 = 0``

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -485,7 +485,27 @@ def _quintic_simplify(expr):
 
 
 def _integer_basis(poly):
-    """Compute coefficient basis for a polynomial over integers. """
+    """Compute coefficient basis for a polynomial over integers.
+
+    Returns the integer ``div`` such that substituting ``y = div*x``
+    the algebraic equation ``p(x) = 0`` becomes an algebraic equation
+    in ``y`` with smaller integer coefficients.
+
+    For example ``x**5 + 512*x + 1024 = 0``
+    with ``div = 4`` becomes ``y**5 + 2*y + 1 = 0``
+
+    Returns the integer ``div`` or ``None`` if there is no possible scaling.
+
+    Examples
+    ========
+
+    >>> from sympy.polys import Poly
+    >>> from sympy.abc import x
+    >>> from sympy.polys.polyroots import _integer_basis
+    >>> p = Poly(x**5 + 512*x + 1024, x, domain='ZZ')
+    >>> _integer_basis(p)
+    4
+    """
     monoms, coeffs = zip(*poly.terms())
 
     monoms, = zip(*monoms)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -493,6 +493,8 @@ def _integer_basis(poly):
 
     if coeffs[0] < coeffs[-1]:
         coeffs = list(reversed(coeffs))
+        n = monoms[0]
+        monoms = [n - i for i in reversed(monoms)]
     else:
         return None
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -343,6 +343,10 @@ def test_roots():
         -I: 1, I: 1,
     }
 
+    r = roots(x**3 + 40*x + 64)
+    real_root = [rx for rx in r if rx.is_real][0]
+    cr = 4 + 2*sqrt(1074)/9
+    assert real_root == -2*cr**(S(1)/3) + 20/(3*cr**(S(1)/3))
 
 def test_roots_slow():
     """Just test that calculating these roots does not hang. """


### PR DESCRIPTION
``````
``_integer_basis`` determines the scaling factor to put an algebraic
equation in simpler form; a bug in it has been fixed in this PR.

For example in the following example there is no scaling factor

```
>>> from sympy.polys import Poly
>>> from sympy.abc import x
>>> Poly(x**5 - 40*x + 64, x, domain='ZZ').all_roots()[0]
RootOf(x**5 - 40*x + 64, 0)
```

while in master one gets scaling factor 2, and wrong roots.
``````
