### PR TITLE
Piecewise._eval_subs should not call solve.

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -429,30 +429,12 @@ class Piecewise(Function):
         """
         Piecewise conditions may contain bool which are not of Basic type.
         """
-        from sympy import checksol, solve
         args = list(self.args)
         for i, (e, c) in enumerate(args):
-
             if isinstance(c, bool):
                 pass
             elif isinstance(c, Basic):
                 c = c._subs(old, new)
-            if isinstance(c, Equality):
-                if checksol(c, {}, minimal=True):
-                    # the equality is trivially solved
-                    c = True
-                else:
-                    # try to solve the equality
-                    try:
-                        slns = solve(c, dict=True)
-                        if not slns:
-                            c = False
-                        elif len(slns) == 1:
-                            c = And(*[Equality(key, value)
-                                      for key, value in slns[0].iteritems()])
-                    except NotImplementedError:
-                        pass
-
             if not c is False:
                 e = e._subs(old, new)
             args[i] = e, c
@@ -502,8 +484,13 @@ class Piecewise(Function):
     @classmethod
     def __eval_cond(cls, cond):
         """Return the truth value of the condition."""
+        from sympy.solvers.solvers import checksol
         if cond is True:
             return True
+        if isinstance(cond, Equality):
+            if checksol(cond, {}, minimal=True):
+                # the equality is trivially solved
+                return True
         return None
 
 

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -10,6 +10,12 @@ x, y = symbols('x y')
 z = symbols('z', nonzero=True)
 
 
+@XFAIL
+def test_bug_subs():
+    p = Piecewise( (0, Eq(sin(x)+y, 0)), (1, True))
+    assert(p.subs(y, 0) == Piecewise( (0, Eq(sin(x), 0)), (1, True)))
+
+
 def test_piecewise():
 
     # Test canonization

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -10,12 +10,6 @@ x, y = symbols('x y')
 z = symbols('z', nonzero=True)
 
 
-@XFAIL
-def test_bug_subs():
-    p = Piecewise( (0, Eq(sin(x)+y, 0)), (1, True))
-    assert(p.subs(y, 0) == Piecewise( (0, Eq(sin(x), 0)), (1, True)))
-
-
 def test_piecewise():
 
     # Test canonization
@@ -32,6 +26,7 @@ def test_piecewise():
         Piecewise((x, Or(x < 1, x < 2)), (0, True))
     assert Piecewise((x, x < 1), (x, x < 2), (x, True)) == x
     assert Piecewise((x, True)) == x
+    assert Piecewise((1, Eq(x + 1/x, (x**2 + 1)/x)), (2, True)) == 1
     raises(TypeError, lambda: Piecewise(x))
     raises(TypeError, lambda: Piecewise((x, x**2)))
 
@@ -62,13 +57,13 @@ def test_piecewise():
     assert Piecewise((1, Eq(x, 0)), (0, True)).subs(x, 0) == 1
     assert Piecewise((1, Eq(x, 0)), (0, True)).subs(x, 1) == 0
     assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, y) == 1
-    assert Piecewise((1, Eq(x, y)), (0, True)).subs(x, -y) == \
-        Piecewise((1, Eq(y, 0)), (0, True))
     assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, z) == 1
-    assert Piecewise((1, Eq(x, z)), (0, True)).subs(x, -z) == 0
     assert Piecewise((1, Eq(exp(x), cos(z))), (0, True)).subs(x, z) == \
         Piecewise((1, Eq(exp(z), cos(z))), (0, True))
     assert Piecewise((1, Eq(x, y*(y + 1))), (0, True)).subs(x, y**2 + y) == 1
+
+    p5 = Piecewise( (0, Eq(cos(x) + y, 0)), (1, True))
+    assert p5.subs(y, 0) == Piecewise( (0, Eq(cos(x), 0)), (1, True))
 
     # Test evalf
     assert p.evalf() == p

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -492,7 +492,7 @@ def test_abs():
     assert abs(x + 1).nseries(x, n=4) == x + 1
     assert abs(sin(x)).nseries(x, n=4) == x - Rational(1, 6)*x**3 + O(x**4)
     assert abs(sin(-x)).nseries(x, n=4) == x - Rational(1, 6)*x**3 + O(x**4)
-    assert abs(x - a).nseries(x, 1) == Piecewise((x - 1, Eq(a, 1)),
+    assert abs(x - a).nseries(x, 1) == Piecewise((x - 1, Eq(1 - a, 0)),
                                                 ((x - a)*sign(1 - a), True))
 
 


### PR DESCRIPTION
There is actually two problems with this call to solve.

Piecewise( (0, Eq(sin(x)+y, 0)), (1, True)).subs(y,0)
was giving Piecewise((0, x == 0), (1, True))
For some equations, solve doesn't return all solutions.
A simple exemple is solve(sin(x)) which gives [0].
It would be very usefull to implement some easy way to know if solve did give all solutions.
I suggest an option like
'findall=True (default is False)'
        solve fails (with exception) if it cannot be sure to return all solutions.

The second issue with solve is that it can be slow.
Piecewise( (0, Eq(sqrt(Abs(-5_x_(0.19_x_y + 0.05_y)/(x__2 + 25) + (1 - 25/(x__2 + 25))_(-x**2/10 - 0.01_x_y - 0.05*y))**2 + Abs(-5_x_(-x**2/10 - 0.01_x_y - 0.05*y)/(x**2 + 25) + (0.19_x_y + 0.05_y)_(-x**2/(x**2 + 25) + 1))**2), 0)), (1,True)).subs({x:s, y:0})
seems to never end.
subs should not be slow.

Maybe the call to solve could be made with the option

'minimal=True (default is False)'
        a very fast, minimal testing.

unfortunately, the doc of solve contains an other options with the same name (?)

'minimal=True (default is False)'
        instructs solve to try to find a particular solution to a linear
        system with as many zeros as possible; this is very expensive

and still we must be sure that it returns every solutions.

Maybe we could put all non trivial stuff into Piecewise._eval_simplify
so that it is possible to simplify only if needed.
