### PR TITLE
Hermite quadratic version to Mack's Linear version 

### DIFF
--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -940,49 +940,53 @@ def canonical_representation(a, d, DE):
 
 def hermite_reduce(a, d, DE):
     """
-    Hermite Reduction - Quadratic version.
+    Hermite Reduction - Mack's Linear Version.
 
     Given a derivation D on k(t) and f = a/d in k(t), returns g, h, r in
     k(t) such that f = Dg + h + r, h is simple, and r is reduced.
+
     """
-    # TODO: Rewrite this using Mack's linear version
     # Make d monic
     l = Poly(1/d.LC(), DE.t)
     a, d = a.mul(l), d.mul(l)
 
     fp, fs, fn = canonical_representation(a, d, DE)
-
     a, d = fn
     l = Poly(1/d.LC(), DE.t)
     a, d = a.mul(l), d.mul(l)
 
-    d_sqf = d.sqf_list_include()
     ga = Poly(0, DE.t)
     gd = Poly(1, DE.t)
 
-    for v, i in d_sqf:
-        if i < 2:
-            continue
+    dd = derivation(d, DE)
+    dm = gcd(d, dd).as_poly(DE.t)
+    ds, r = d.div(dm)
 
-        u = d.exquo(v**i)
-        for j in range(i - 1, 0, -1):
-            udv = u*derivation(v, DE)
-            b, c = gcdex_diophantine(udv.as_poly(DE.t), v.as_poly(DE.t),
-                a.mul(Poly(-S(1)/j, DE.t)).as_poly(DE.t))
-            b, c = b.as_poly(DE.t), c.as_poly(DE.t)
+    while dm.degree(DE.t)>0:
 
-            vj = v**j
-            ga = ga*vj + b*gd
-            gd = gd*vj
-            a = c.mul(Poly(-j, DE.t)) - u*derivation(b, DE)
+        ddm = derivation(dm, DE)
+        dm2 = gcd(dm, ddm)
+        dms, r = dm.div(dm2)
+        ds_ddm = ds.mul(ddm)
+        ds_ddm_dm, r = ds_ddm.div(dm)
 
-        d = u*v
+        b, c = gcdex_diophantine(-ds_ddm_dm.as_poly(DE.t), dms.as_poly(DE.t), a.as_poly(DE.t))
+        b, c = b.as_poly(DE.t), c.as_poly(DE.t)
 
+        db = derivation(b, DE).as_poly(DE.t)
+        ds_dms, r = ds.div(dms)
+        a = c.as_poly(DE.t) - db.mul(ds_dms).as_poly(DE.t)
+
+        ga = ga*dm + b*gd
+        gd = gd*dm
+        ga, gd = ga.cancel(gd, include=True)
+        dm = dm2
+
+    d = ds
     q, r = a.div(d)
-
     ga, gd = ga.cancel(gd, include=True)
-    r, d = r.cancel(d, include=True)
 
+    r, d = r.cancel(d, include=True)
     rra = q*fs[1] + fp*fs[1] + fs[0]
     rrd = fs[1]
     rra, rrd = rra.cancel(rrd, include=True)
@@ -1294,7 +1298,6 @@ def integrate_hyperexponential(a, d, DE, z=None):
         i = p - (qd*derivation(qa, DE) - qa*derivation(qd, DE)).as_expr()/\
             (qd**2).as_expr()
         i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
-
     return (ret, i, b)
 
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -119,13 +119,13 @@ def test_hermite_reduce():
     assert hermite_reduce(Poly(-x**2*t**6 + (-1 - 2*x**3 + x**4)*t**3 +
         (-3 - 3*x**4)*t**2 - 2*x*t - x - 3*x**2, t),
         Poly(x**4*t**6 - 2*x**2*t**3 + 1, t), DE) == \
-        ((Poly(x**5*t + x**2 + x**6, t), Poly(x**5*t**3 - x**3, t)), (Poly(0, t),
+        ((Poly(x**3*t + 1 + x**4, t), Poly(x**3*t**3 - x, t)), (Poly(0, t),
         Poly(1, t)), (Poly(-1, t), Poly(x**2, t)))
     assert hermite_reduce(Poly((-2 + 3*x)*t**3 + (-1 + x)*t**2 +
     (-4*x + 2*x**2)*t + x**2, t), Poly(x*t**6 - 4*x**2*t**5 +
     6*x**3*t**4 - 4*x**4*t**3 + x**5*t**2, t), DE) == \
-        ((Poly(t**2 + t/3 + x, t), Poly(t**4 - 3*x*t**3 + 3*x**2*t**2 -
-        x**3*t, t)), (Poly(0, t), Poly(1, t)), (Poly(0, t), Poly(1, t)))
+        ((Poly(3*t**2 + t + 3*x, t), Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 -
+        3*x**3*t, t)), (Poly(0, t), Poly(1, t)), (Poly(0, t), Poly(1, t)))
 
 
 def test_polynomial_reduce():
@@ -192,7 +192,7 @@ def test_integrate_hyperexponential():
     a = Poly(25*t**6 - 10*t**5 + 7*t**4 - 8*t**3 + 13*t**2 + 2*t - 1, t)
     d = Poly(25*t**6 + 35*t**4 + 11*t**2 + 1, t)
     assert integrate_hyperexponential(a, d, DE) == \
-        (-(55 - 50*exp(x))/(25 + 125*exp(2*x)) + log(1 + exp(2*x)), -1, True)
+        (-(11 - 10*exp(x))/(5 + 25*exp(2*x)) + log(1 + exp(2*x)), -1, True)
         # -(55 - 50*exp(x))/(25 + 125*exp(2*x)) - x + log(1 + exp(2*x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t0, t0), Poly(t0*t, t)],
         'Tfuncs': [exp, Lambda(i, exp(exp(i)))]})
@@ -229,7 +229,7 @@ def test_integrate_hyperexponential():
     18*x**4 - 3*x**3 - 3*x**2)*t1**2 + (8*x**10 + 24*x**9 - 12*x**8 -
     36*x**7 + 6*x**6 + 18*x**5 - x**4 - 3*x**3)*t1 + 8*x**10 - 12*x**8 +
     6*x**6 - x**4, t1), DE) == \
-        ((x*log(x) - log(x))/-((x + exp(x**2))*(2*x**2 - 1)),
+        (-(x*log(x) - log(x))/(2*x**3 - x + (2*x**2 - 1)*exp(x**2)),
         NonElementaryIntegral(exp(x**2)/(exp(x**2) + 1), x), False)
 
 def test_integrate_hyperexponential_polynomial():


### PR DESCRIPTION
Have reduced the time complexity involved in the hermite reduction (method) from m^2 to m-1 by using Mack's linear version instead of the quadratic function.
Also no partial fraction decomposition of f(input function )or square-free factorization of its denominator is required decreasing the time complexity further
