### PR TITLE
fix a typo and lack of spaces in strings split across two lines

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2280,7 +2280,7 @@ class Expr(Basic, EvalfMixin):
             >>> e.series(x, n=2)
             cos(exp(y)) - x*sin(exp(y)) + O(x**2)
 
-            If ``n=None`` then a generator of the series terms will be returned.
+            If ``n=None`` then an iterator of the series terms will be returned.
 
             >>> term=cos(x).series(n=None)
             >>> [term.next() for i in range(2)]

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2280,7 +2280,7 @@ class Expr(Basic, EvalfMixin):
             >>> e.series(x, n=2)
             cos(exp(y)) - x*sin(exp(y)) + O(x**2)
 
-            If ``n=None`` then an iterator of the series terms will be returned.
+            If ``n=None`` then a generator of the series terms will be returned.
 
             >>> term=cos(x).series(n=None)
             >>> [term.next() for i in range(2)]

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -118,7 +118,7 @@ class Tr(Expr):
             indices = Tuple()
             expr = args[0]
         else:
-            raise ValueError("Arguments to Tr should be of form"
+            raise ValueError("Arguments to Tr should be of form "
                              "(expr[, [indices]])")
 
         if isinstance(expr, Matrix):

--- a/sympy/physics/quantum/density.py
+++ b/sympy/physics/quantum/density.py
@@ -308,7 +308,7 @@ def fidelity(state1, state2):
                          (type(state1), type(state2)))
 
     if ( state1.shape != state2.shape and state1.is_square):
-        raise ValueError("The dimensions of both args should be equal and the"
+        raise ValueError("The dimensions of both args should be equal and the "
                          "matrix obtained should be a square matrix")
 
     sqrt_state1 = state1**Rational(1, 2)

--- a/sympy/plotting/intervalmath/interval_arithmetic.py
+++ b/sympy/plotting/intervalmath/interval_arithmetic.py
@@ -81,7 +81,7 @@ class interval(object):
                 self.end = float(args[0])
 
         else:
-            raise ValueError("interval takes a maximum of two float values"
+            raise ValueError("interval takes a maximum of two float values "
                             "as arguments")
 
     @property

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1678,7 +1678,7 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
                                         for e in expr]))
 
         if len(free_symbols) > nb_of_free_symbols:
-            raise ValueError("The number of free_symbols in the expression"
+            raise ValueError("The number of free_symbols in the expression "
                              "is greater than %d" % nb_of_free_symbols)
         if len(args) == i + nb_of_free_symbols and isinstance(args[i], Tuple):
             ranges = Tuple(*[range_expr for range_expr in args[
@@ -1707,6 +1707,6 @@ def check_arguments(args, expr_len, nb_of_free_symbols):
                                      str(arg[i]))
             for i in range(nb_of_free_symbols):
                 if not len(arg[i + expr_len]) == 3:
-                    raise ValueError("The ranges should be a tuple of"
+                    raise ValueError("The ranges should be a tuple of "
                                      "length 3, got %s" % str(arg[i + expr_len]))
         return args

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -179,7 +179,7 @@ class ImplicitSeries(BaseSeries):
         elif isinstance(self.expr, (LessThan, StrictLessThan)):
             expr = self.expr.rhs - self.expr.lhs
         else:
-            raise NotImplementedError("The expression is not supported for"
+            raise NotImplementedError("The expression is not supported for "
                                     "plotting in uniform meshed plot.")
         xarray = np.linspace(self.start_x, self.end_x, self.nb_of_points)
         yarray = np.linspace(self.start_y, self.end_y, self.nb_of_points)

--- a/sympy/statistics/distributions.py
+++ b/sympy/statistics/distributions.py
@@ -269,7 +269,7 @@ class Uniform(ContinuousProbability):
         """
         x = sympify(x)
         if not x.is_Number:
-            raise NotImplementedError("SymPy does not yet support"
+            raise NotImplementedError("SymPy does not yet support "
                 "piecewise functions")
         if x < s.a or x > s.b:
             return Rational(0)
@@ -291,7 +291,7 @@ class Uniform(ContinuousProbability):
         """
         x = sympify(x)
         if not x.is_Number:
-            raise NotImplementedError("SymPy does not yet support"
+            raise NotImplementedError("SymPy does not yet support "
                 "piecewise functions")
         if x <= s.a:
             return Rational(0)


### PR DESCRIPTION
very simple clean-up of a few strings and one piece of documentation that i noticed is slightly inaccurate.
