### PR TITLE
fix two aspects of latex printing: absolute values and imaginary unit

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -553,7 +553,7 @@ class LatexPrinter(Printer):
             return tex
 
     def _print_Abs(self, expr, exp=None):
-        tex = r"\lvert{%s}\rvert" % self._print(expr.args[0])
+        tex = r"\left\lvert{%s}\right\rvert" % self._print(expr.args[0])
 
         if exp is not None:
             return r"%s^{%s}" % (tex, exp)
@@ -928,7 +928,7 @@ class LatexPrinter(Printer):
         return r"\tilde{\infty}"
 
     def _print_ImaginaryUnit(self, expr):
-        return r"\mathbf{\imath}"
+        return r"i"
 
     def _print_NaN(self, expr):
         return r"\bot"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -169,7 +169,7 @@ def test_latex_functions():
     assert latex(Min(x, y)**2) == r"\min\left(x, y\right)^{2}"
     assert latex(Max(x, 2, x**3)) == r"\max\left(2, x, x^{3}\right)"
     assert latex(Max(x, y)**2) == r"\max\left(x, y\right)^{2}"
-    assert latex(Abs(x)) == r"\lvert{x}\rvert"
+    assert latex(Abs(x)) == r"\left\lvert{x}\right\rvert"
     assert latex(re(x)) == r"\Re{x}"
     assert latex(re(x + y)) == r"\Re{x} + \Re{y}"
     assert latex(im(x)) == r"\Im{x}"
@@ -885,3 +885,7 @@ def test_boolean_args_order():
 
     expr = Or(*syms)
     assert latex(expr) == 'a \\vee b \\vee c \\vee d \\vee e \\vee f'
+
+def test_imaginary():
+    i = sqrt(-1)
+    assert latex(i) == r'i'


### PR DESCRIPTION
\imath is almost never what you want when rendering the imaginary unit
to latex. its purpose is so that you can put things like bar, vec, hat,
dot, tilde, etc. onto the character, none of which really make sense
for i. bar (representing complex conjugation) makes some sense, but
\bar{i} equals -i by definition, so this is a rare case.

enter the following into live.sympy.org to see an illustration of both fixes:

i = sqrt(-1)
Abs(zeta(Integer(1)/2 + i \* t))
