### PR TITLE
Move custom rf class outside the combsimp definition

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2963,8 +2963,8 @@ def combsimp(expr):
         def gamma_rat(x):
             # helper to simplify ratios of gammas
             was = x.count(gamma)
-            xx = x.replace(gamma, lambda n: rf(1, (n - 1).expand()
-                ).replace(rf, lambda a, b: gamma(a + b)/gamma(a)))
+            xx = x.replace(gamma, lambda n: _rf(1, (n - 1).expand()
+                ).replace(_rf, lambda a, b: gamma(a + b)/gamma(a)))
             if xx.count(gamma) < was:
                 x = xx
             return x

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2813,6 +2813,45 @@ def hypersimilar(f, g, k):
 
 from sympy.utilities.timeutils import timethis
 
+class _rf(Function):
+    @classmethod
+    def eval(cls, a, b):
+        if b.is_Integer:
+            if not b:
+                return S.One
+
+            n, result = int(b), S.One
+
+            if n > 0:
+                for i in xrange(n):
+                    result *= a + i
+
+                return result
+            elif n < 0:
+                for i in xrange(1, -n + 1):
+                    result *= a - i
+
+                return 1/result
+        else:
+            if b.is_Add:
+                c, _b = b.as_coeff_Add()
+
+                if c.is_Integer:
+                    if c > 0:
+                        return _rf(a, _b)*_rf(a + _b, c)
+                    elif c < 0:
+                        return _rf(a, _b)/_rf(a + _b + c, -c)
+
+            if a.is_Add:
+                c, _a = a.as_coeff_Add()
+
+                if c.is_Integer:
+                    if c > 0:
+                        return _rf(_a, b)*_rf(_a + b, c)/_rf(_a, c)
+                    elif c < 0:
+                        return _rf(_a, b)*_rf(_a + c, -c)/_rf(_a + b + c, -c)
+
+
 
 @timethis('combsimp')
 def combsimp(expr):
@@ -2874,57 +2913,20 @@ def combsimp(expr):
     # probably makes sense to retain them
     as_gamma = not expr.has(factorial, binomial)
 
-    class rf(Function):
-        @classmethod
-        def eval(cls, a, b):
-            if b.is_Integer:
-                if not b:
-                    return S.One
-
-                n, result = int(b), S.One
-
-                if n > 0:
-                    for i in xrange(n):
-                        result *= a + i
-
-                    return result
-                elif n < 0:
-                    for i in xrange(1, -n + 1):
-                        result *= a - i
-
-                    return 1/result
-            else:
-                if b.is_Add:
-                    c, _b = b.as_coeff_Add()
-
-                    if c.is_Integer:
-                        if c > 0:
-                            return rf(a, _b)*rf(a + _b, c)
-                        elif c < 0:
-                            return rf(a, _b)/rf(a + _b + c, -c)
-
-                if a.is_Add:
-                    c, _a = a.as_coeff_Add()
-
-                    if c.is_Integer:
-                        if c > 0:
-                            return rf(_a, b)*rf(_a + b, c)/rf(_a, c)
-                        elif c < 0:
-                            return rf(_a, b)*rf(_a + c, -c)/rf(_a + b + c, -c)
 
     expr = expr.replace(binomial,
-        lambda n, k: rf((n - k + 1).expand(), k.expand())/rf(1, k.expand()))
+        lambda n, k: _rf((n - k + 1).expand(), k.expand())/_rf(1, k.expand()))
     expr = expr.replace(factorial,
-        lambda n: rf(1, n.expand()))
+        lambda n: _rf(1, n.expand()))
     expr = expr.rewrite(gamma)
     expr = expr.replace(gamma,
-        lambda n: rf(1, (n - 1).expand()))
+        lambda n: _rf(1, (n - 1).expand()))
 
     if as_gamma:
-        expr = expr.replace(rf,
+        expr = expr.replace(_rf,
             lambda a, b: gamma(a + b)/gamma(a))
     else:
-        expr = expr.replace(rf,
+        expr = expr.replace(_rf,
             lambda a, b: binomial(a + b - 1, b)*factorial(b))
 
     def rule(n, k):
@@ -2933,7 +2935,7 @@ def combsimp(expr):
         cn, _n = n.as_coeff_Add()
 
         if _n and cn.is_Integer and cn:
-            coeff *= rf(_n + 1, cn)/rf(_n - k + 1, cn)
+            coeff *= _rf(_n + 1, cn)/_rf(_n - k + 1, cn)
             rewrite = True
             n = _n
 
@@ -2943,7 +2945,7 @@ def combsimp(expr):
         if k.is_Add:
             ck, _k = k.as_coeff_Add()
             if _k and ck.is_Integer and ck:
-                coeff *= rf(n - ck - _k + 1, ck)/rf(_k + 1, ck)
+                coeff *= _rf(n - ck - _k + 1, ck)/_rf(_k + 1, ck)
                 rewrite = True
                 k = _k
 


### PR DESCRIPTION
TODO
- [x] fix tests

This fixes, or rather, works around, a bizarre caching issue involving classes
defined inside functions.  See the discussion on pull request #1710.
