### PR TITLE
First attempt at getting Travis to use py.test and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
       pip install "gmpy==1.16";
     fi
   - if [[ "${TEST_PYTEST}" == "true" ]]; then
-      pip install coverage pytest-cov coveralls --use-mirrors;
+      pip install coverage pytest-cov python-coveralls --use-mirrors;
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
       pip install pytest --use-mirrors;
     fi
   - if [[ "${TEST_COVERAGE}" == "true" ]]; then
-      pip install coverage python-coveralls --use-mirrors;
+      pip install coverage coveralls --use-mirrors;
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   - if [[ "${TEST_COVERAGE}" == "true" ]]; then
       pip install coverage coveralls --use-mirrors;
     fi
+  - git show # debug output
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then
       python bin/use2to3; cd py3k-sympy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - if [[ "${TEST_COVERAGE}" == "true" ]]; then
       pip install coverage coveralls --use-mirrors;
     fi
-  - git show # debug output
+  - git --no-pager show # debug output
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then
       python bin/use2to3; cd py3k-sympy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       pip install "gmpy==1.16";
     fi
   - if [[ "${TEST_PYTEST}" == "true" ]]; then
-      pip install coverage pytest-cov coveralls --use-mirrors
+      pip install coverage pytest-cov coveralls --use-mirrors;
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: TEST_GMPY="true"
     - python: 3.3
       env: TEST_GMPY="true"
+    - python: 2.7
+      env: TEST_PYTEST="true"
   allow_failures:
     - python: 2.7
       env: TEST_PYTEST="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: TEST_GMPY="true"
     - python: 2.7
       env: TEST_PYTEST="true"
+    - python: 2.7
+      env: TEST_COVERAGE="true"
   allow_failures:
     - python: 2.7
       env: TEST_PYTEST="true"
@@ -23,7 +25,10 @@ before_install:
       pip install "gmpy==1.16";
     fi
   - if [[ "${TEST_PYTEST}" == "true" ]]; then
-      pip install coverage pytest-cov python-coveralls --use-mirrors;
+      pip install pytest --use-mirrors
+    fi
+  - if [[ "${TEST_COVERAGE}" == "true" ]]; then
+      pip install coverage python-coveralls --use-mirrors;
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ before_install:
       pip install coverage pytest-cov coveralls --use-mirrors;
     fi
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then
+      python bin/use2to3; cd py3k-sympy;
+    fi
   - python setup.py install
 script:
   - bin/test_travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ script:
 notifications:
   email: false
 after_success:
-  - coveralls
-# Remove this section once py.test is passing
-after_failure:
-  - coveralls
+  - if [[ "${TEST_COVERAGE}" == "true" ]]; then
+      coveralls;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,17 @@ matrix:
       env: TEST_GMPY="true"
     - python: 3.3
       env: TEST_GMPY="true"
+  allow_failures:
+    - python: 2.7
+      env: TEST_PYTEST="true"
 before_install:
   - if [[ "${TEST_GMPY}" == "true" ]]; then
       sudo apt-get update -qq;
       sudo apt-get install -qq libgmp-dev;
       pip install "gmpy==1.16";
+    fi
+  - if [[ "${TEST_PYTEST}" == "true" ]]; then
+      pip install coverage pytest-cov coveralls --use-mirrors
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
@@ -24,3 +30,5 @@ script:
   - bin/test_travis.sh
 notifications:
   email: false
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
       pip install "gmpy==1.16";
     fi
   - if [[ "${TEST_PYTEST}" == "true" ]]; then
-      pip install pytest --use-mirrors
+      pip install pytest --use-mirrors;
     fi
   - if [[ "${TEST_COVERAGE}" == "true" ]]; then
       pip install coverage python-coveralls --use-mirrors;

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ notifications:
   email: false
 after_success:
   - coveralls
+# Remove this section once py.test is passing
+after_failure:
+  - coveralls

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ "${TEST_PYTEST}" == "true" ]]
+if [[ "${TEST_PYTEST}" == "true" ]]; then
     py.test sympy/
 else
 

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -5,7 +5,7 @@ set -e
 if [[ "${TEST_PYTEST}" == "true" ]]; then
     py.test sympy/ --cov=sympy
 elif [[ "${TEST_COVERAGE}" == "true" ]]; then
-    python bin/coverage_test.py
+    python bin/coverage_report.py
 else
 
     # We change directories to make sure that we test the installed version of

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -2,11 +2,15 @@
 
 set -e
 
-# We change directories to make sure that we test the installed version of
-# sympy.
-mkdir empty
-cd empty
-cat << EOF | python
+if [[ "${TEST_PYTEST}" == "true" ]]
+    py.test sympy/
+else
+
+    # We change directories to make sure that we test the installed version of
+    # sympy.
+    mkdir empty
+    cd empty
+    cat << EOF | python
 import sympy
 t1=sympy.test()
 t2=sympy.doctest()
@@ -14,5 +18,6 @@ if not (t1 and t2):
     raise Exception('Tests failed')
 EOF
 
-cd ..
-bin/doctest doc/
+    cd ..
+    bin/doctest doc/
+fi

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -4,6 +4,8 @@ set -e
 
 if [[ "${TEST_PYTEST}" == "true" ]]; then
     py.test sympy/ --cov=sympy
+elif [[ "${TEST_COVERAGE}" == "true" ]]; then
+    python bin/coverage_test.py
 else
 
     # We change directories to make sure that we test the installed version of

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ "${TEST_PYTEST}" == "true" ]]; then
-    py.test sympy/ --cov=sympy
+    py.test sympy/
 elif [[ "${TEST_COVERAGE}" == "true" ]]; then
     python bin/coverage_report.py
 else

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ "${TEST_PYTEST}" == "true" ]]; then
-    py.test sympy/
+    py.test sympy/ --cov=sympy
 else
 
     # We change directories to make sure that we test the installed version of


### PR DESCRIPTION
This adds py.test to Travis and runs coveralls after the tests are done.  See 
https://coveralls.io/.

I based this on https://github.com/kmike/DAWG-Python/blob/master/.travis.yml.
