### PR TITLE
A little bug in ask (part 2).

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -56,8 +56,11 @@ def _extract_facts(expr, symbol):
             return expr.func
         else:
             return
-    return expr.func(*filter(lambda x: x is not None,
-                [_extract_facts(arg, symbol) for arg in expr.args]))
+    args = [_extract_facts(arg, symbol) for arg in expr.args]
+    if isinstance(expr, And):
+        return expr.func(*filter(lambda x: x is not None, args))
+    if all(arg != None for arg in args):
+        return expr.func(*args)
 
 
 def ask(proposition, assumptions=True, context=global_assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1689,13 +1689,8 @@ def test_composite_proposition():
     assert ask(Q.real(x) | Q.integer(x), Q.real(x) | Q.integer(x)) is True
 
 
-@XFAIL
-def test_Or_assomption():
+def test_composite_assomption():
     assert ask(Q.positive(x), Q.positive(x) | Q.positive(y)) is None
-
-
-@XFAIL
-def test_Imply_assomption():
     assert ask(Q.positive(x), Q.real(x) >> Q.positive(y)) is None
 
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -7,7 +7,7 @@ from sympy.assumptions.ask import (compute_known_facts, known_facts_cnf,
 from sympy.assumptions.handlers import AskHandler
 from sympy.core import I, Integer, oo, pi, Rational, S, symbols, Add
 from sympy.functions import Abs, cos, exp, im, log, re, sign, sin, sqrt
-from sympy.logic import Equivalent, Implies, Xor, And, to_cnf
+from sympy.logic import Equivalent, Implies, Xor, And, to_cnf, Not
 from sympy.utilities.pytest import raises, XFAIL, slow
 from sympy.assumptions.assume import assuming
 
@@ -1686,6 +1686,17 @@ def test_composite_proposition():
     assert ask(Equivalent(Q.integer(x), Q.even(x)), Q.even(x)) is True
     assert ask(Equivalent(Q.integer(x), Q.even(x))) is None
     assert ask(Equivalent(Q.positive(x), Q.integer(x)), Q.integer(x)) is None
+    assert ask(Q.real(x) | Q.integer(x), Q.real(x) | Q.integer(x)) is True
+
+
+@XFAIL
+def test_Or_assomption():
+    assert ask(Q.positive(x), Q.positive(x) | Q.positive(y)) is None
+
+
+@XFAIL
+def test_Imply_assomption():
+    assert ask(Q.positive(x), Q.real(x) >> Q.positive(y)) is None
 
 
 def test_incompatible_resolutors():


### PR DESCRIPTION
This pull request just correct this wrong result
ask(Q.positive(x), Q.positive(x) | Q.positive(y))
