### PR TITLE
Theano matrix printing and Derivative

### DIFF
--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -300,8 +300,6 @@ def block_collapse(expr):
     >>> print block_collapse(C*B)
     [X, Z + Z*Y]
     """
-    if not expr.has(BlockMatrix):
-        return expr
     hasbm = lambda expr: isinstance(expr, MatrixExpr) and expr.has(BlockMatrix)
     rule = exhaust(
         bottom_up(condition(hasbm, typed(

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -140,13 +140,14 @@ class BlockMatrix(MatrixExpr):
         # Inverse of a two by two block matrix is known
         elif expand and self.blockshape == (2, 2):
             # Cite: The Matrix Cookbook Section 9.1.3
-            A11, A12, A21, A22 = (self.blocks[0, 0], self.blocks[0, 1],
-                                  self.blocks[1, 0], self.blocks[1, 1])
+            [[A11, A12],
+             [A21, A22]] = self.blocks.tolist()
+
             C1 = A11 - A12*A22.I*A21
             C2 = A22 - A21*A11.I*A12
-            mat = Matrix([[C1.I,                    (-A11).I*A12*C2.I],
-                          [-C2.I*A21*A11.I,         C2.I             ]])
-            return BlockMatrix(mat)
+
+            return BlockMatrix([[C1.I,                (-A11).I*A12*C2.I],
+                                [-C2.I*A21*A11.I,     C2.I             ]])
         else:
             return Inverse(self)
 

--- a/sympy/matrices/expressions/blockmatrix.py
+++ b/sympy/matrices/expressions/blockmatrix.py
@@ -1,5 +1,6 @@
 from sympy.core import Tuple, Basic, Add
-from sympy.strategies import typed, canon, debug, do_one, unpack
+from sympy.strategies import typed, exhaust, condition, debug, do_one, unpack
+from sympy.strategies.traverse import bottom_up
 from sympy.functions import transpose
 from sympy.utilities import sift
 
@@ -11,6 +12,7 @@ from sympy.matrices.expressions.transpose import Transpose
 from sympy.matrices.expressions.trace import Trace
 from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions.inverse import Inverse
+from sympy.functions.elementary.complexes import transpose
 from sympy.matrices import Matrix, eye
 
 
@@ -139,11 +141,11 @@ class BlockMatrix(MatrixExpr):
         elif expand and self.blockshape == (2, 2):
             # Cite: The Matrix Cookbook Section 9.1.3
             A11, A12, A21, A22 = (self.blocks[0, 0], self.blocks[0, 1],
-                    self.blocks[1, 0], self.blocks[1, 1])
+                                  self.blocks[1, 0], self.blocks[1, 1])
             C1 = A11 - A12*A22.I*A21
             C2 = A22 - A21*A11.I*A12
-            mat = Matrix([[C1.I, (-A11).I*A12*C2.I],
-                [-C2.I*A21*A11.I, C2.I]])
+            mat = Matrix([[C1.I,                    (-A11).I*A12*C2.I],
+                          [-C2.I*A21*A11.I,         C2.I             ]])
             return BlockMatrix(mat)
         else:
             return Inverse(self)
@@ -298,9 +300,16 @@ def block_collapse(expr):
     >>> print block_collapse(C*B)
     [X, Z + Z*Y]
     """
-    rule = canon(typed({MatAdd: do_one(bc_matadd, bc_block_plus_ident),
-                        MatMul: do_one(bc_matmul, bc_dist),
-                        BlockMatrix: bc_unpack}))
+    if not expr.has(BlockMatrix):
+        return expr
+    hasbm = lambda expr: isinstance(expr, MatrixExpr) and expr.has(BlockMatrix)
+    rule = exhaust(
+        bottom_up(condition(hasbm, typed(
+            {MatAdd: do_one(bc_matadd, bc_block_plus_ident),
+             MatMul: do_one(bc_matmul, bc_dist),
+             Transpose: bc_transpose,
+             Inverse: bc_inverse,
+             BlockMatrix: bc_unpack}))))
     result = rule(expr)
     try:
         return result.doit()
@@ -350,8 +359,10 @@ def bc_dist(expr):
                                               for i in range(B.rows)])
     return expr
 
+
 def bc_matmul(expr):
     factor, matrices = expr.as_coeff_matrices()
+
     i = 0
     while (i+1 < len(matrices)):
         A, B = matrices[i:i+2]
@@ -361,6 +372,12 @@ def bc_matmul(expr):
         else:
             i+=1
     return MatMul(factor, *matrices).doit()
+
+def bc_transpose(expr):
+    return BlockMatrix(block_collapse(expr.arg).blocks.applyfunc(transpose).T)
+
+def bc_inverse(expr):
+    return expr.arg._eval_inverse(True)
 
 def bounds(sizes):
     """ Convert sequence of numbers into pairs of low-high pairs

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -1,13 +1,17 @@
 from sympy.matrices.expressions.blockmatrix import (block_collapse, bc_matmul,
         bc_block_plus_ident, BlockDiagMatrix, BlockMatrix, bc_dist, bc_matadd,
-        blockcut)
+        bc_transpose, blockcut)
 from sympy.matrices.expressions import (MatrixSymbol, Identity, MatMul,
-        Inverse, Trace)
+        Inverse, Trace, Transpose)
 from sympy.matrices import Matrix, ImmutableMatrix
 from sympy.core import Tuple, symbols
 from sympy.functions import transpose
 
 i, j, k, l, m, n, p = symbols('i:n, p', integer=True)
+A = MatrixSymbol('A', n, n)
+B = MatrixSymbol('B', n, n)
+C = MatrixSymbol('C', n, n)
+D = MatrixSymbol('D', n, n)
 G = MatrixSymbol('G', n, n)
 H = MatrixSymbol('H', n, n)
 b1 = BlockMatrix([[G, H]])
@@ -19,6 +23,10 @@ def test_bc_matmul():
 def test_bc_matadd():
     assert bc_matadd(BlockMatrix([[G, H]]) + BlockMatrix([[H, H]])) == \
             BlockMatrix([[G+H, H+H]])
+
+def test_bc_transpose():
+    assert bc_transpose(Transpose(BlockMatrix([[A, B], [C, D]]))) == \
+            BlockMatrix([[A.T, C.T], [B.T, D.T]])
 
 def test_bc_dist_diag():
     A = MatrixSymbol('A', n, n)

--- a/sympy/matrices/expressions/tests/test_blockmatrix.py
+++ b/sympy/matrices/expressions/tests/test_blockmatrix.py
@@ -107,8 +107,6 @@ def test_squareBlockMatrix():
         BlockMatrix([[A + Identity(n), B], [C, D + Identity(m)]]))
     Q = X + Identity(m + n)
 
-    assert block_collapse(Q.inverse()) == Inverse(block_collapse(Q))
-
     assert (X + MatrixSymbol('Q', n + m, n + m)).is_MatAdd
     assert (X * MatrixSymbol('Q', n + m, n + m)).is_MatMul
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -984,6 +984,7 @@ class LatexPrinter(Printer):
 
         return name
     _print_RandomSymbol = _print_Symbol
+    _print_MatrixSymbol = _print_Symbol
 
     def _print_Relational(self, expr):
         if self._settings['itex']:

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -130,3 +130,24 @@ def test_theano_function_numpy():
     xx = np.arange(3).astype('float64')
     yy = 2*np.arange(3).astype('float64')
     assert np.linalg.norm(f(xx, yy) - 3*np.arange(3)) < 1e-9
+
+def test_slice():
+    assert theano_code(slice(1, 2, 3)) == slice(1, 2, 3)
+    assert str(theano_code(slice(1, x, 3), dtypes={x: 'int32'})) ==\
+           str(slice(1, xt, 3))
+
+def test_MatrixSlice():
+    n = sympy.Symbol('n', integer=True)
+    X = sympy.MatrixSymbol('X', n, n)
+
+    Y = X[1:2:3, 4:5:6]
+    Yt = theano_code(Y)
+    assert tuple(Yt.owner.op.idx_list) == (slice(1,2,3), slice(4,5,6))
+    assert Yt.owner.inputs[0] == theano_code(X)
+
+    k = sympy.Symbol('k')
+    kt = theano_code(k, dtypes={k: 'int32'})
+    start, stop, step = 4, k, 2
+    Y = X[start:stop:step]
+    Yt = theano_code(Y, dtypes={n: 'int32', k: 'int32'})
+    # assert Yt.owner.op.idx_list[0].stop == kt

--- a/sympy/printing/tests/test_theanocode.py
+++ b/sympy/printing/tests/test_theanocode.py
@@ -167,3 +167,16 @@ def test_MatrixSlice():
     Y = X[start:stop:step]
     Yt = theano_code(Y, dtypes={n: 'int32', k: 'int32'})
     # assert Yt.owner.op.idx_list[0].stop == kt
+
+def test_BlockMatrix():
+    n = sympy.Symbol('n', integer=True)
+    A = sympy.MatrixSymbol('A', n, n)
+    B = sympy.MatrixSymbol('B', n, n)
+    C = sympy.MatrixSymbol('C', n, n)
+    D = sympy.MatrixSymbol('D', n, n)
+    At, Bt, Ct, Dt = map(theano_code, (A, B, C, D))
+    Block = sympy.BlockMatrix([[A, B], [C, D]])
+    Blockt = theano_code(Block)
+    solutions = [tt.join(0, tt.join(1, At, Bt), tt.join(1, Ct, Dt)),
+                 tt.join(1, tt.join(0, At, Ct), tt.join(0, Bt, Dt))]
+    assert any(theq(Blockt, solution) for solution in solutions)

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -49,7 +49,6 @@ if theano:
             sympy.Ge: tt.ge,
             sympy.Max: tt.maximum,  # Sympy accept >2 inputs, Theano only 2
             sympy.Min: tt.minimum,  # Sympy accept >2 inputs, Theano only 2
-            sympy.Derivative: tt.grad,
 
             # Matrices
             sympy.MatAdd: tt.Elemwise(ts.add),
@@ -114,6 +113,13 @@ class TheanoPrinter(Printer):
 
     def _print_factorial(self, expr, **kwargs):
         return self._print(sympy.gamma(expr.args[0] + 1), **kwargs)
+
+    def _print_Derivative(self, deriv, **kwargs):
+        rv = self._print(deriv.expr, **kwargs)
+        for var in deriv.variables:
+            var = self._print(var, **kwargs)
+            rv = tt.Rop(rv, var, tt.ones_like(var))
+        return rv
 
     def emptyPrinter(self, expr):
         return expr

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -101,6 +101,17 @@ class TheanoPrinter(Printer):
             result = tt.dot(result, child)
         return result
 
+    def _print_MatrixSlice(self, expr, **kwargs):
+        parent = self._print(expr.parent, **kwargs)
+        rowslice = self._print(slice(*expr.rowslice), **kwargs)
+        colslice = self._print(slice(*expr.colslice), **kwargs)
+        return parent[rowslice, colslice]
+
+    def _print_slice(self, expr, **kwargs):
+        return slice(*[self._print(i, **kwargs)
+                        if isinstance(i, sympy.Basic) else i
+                        for i in (expr.start, expr.stop, expr.step)])
+
     def _print_Pi(self, expr, **kwargs):
         return 3.141592653589793
 

--- a/sympy/printing/theanocode.py
+++ b/sympy/printing/theanocode.py
@@ -107,6 +107,14 @@ class TheanoPrinter(Printer):
         colslice = self._print(slice(*expr.colslice), **kwargs)
         return parent[rowslice, colslice]
 
+    def _print_BlockMatrix(self, expr, **kwargs):
+        nrows, ncols = expr.blocks.shape
+        blocks = [[self._print(expr.blocks[r, c], **kwargs)
+                        for c in range(ncols)]
+                        for r in range(nrows)]
+        return tt.join(0, *[tt.join(1, *row) for row in blocks])
+
+
     def _print_slice(self, expr, **kwargs):
         return slice(*[self._print(i, **kwargs)
                         if isinstance(i, sympy.Basic) else i


### PR DESCRIPTION
Two somewhat separate contributions
1.  Uses `theano.Rop` for derivatives rather than `theano.grad`.  This is more robust
2.  Adds theano translations for MatrixSlice (Subtensor) and BlockMatrix (join) 
3.  Extends `block_collapse` functionality to transposes and inverses.  
4.  Improve the application strategy for `block_collapse`. Use `bottom_up` rather than `top_down` and put in a short circuit to check for BlockMatrix elements.

As a result of 2, 3 and 4 I can execute most (all?) of Matrix expressions through Theano.  In particular I can build blocked computations (e.g. blocked cholesky) pretty smoothly.  This starts to approach the functionality in research systems for numerical linear algebra.
