### PR TITLE
issues 3710, 3731

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2744,14 +2744,6 @@ class Expr(Basic, EvalfMixin):
             newexpr = getattr(expr, hint)(**hints)
             if newexpr != expr:
                 return (newexpr, True)
-        else:
-            # see if an unevaluated form is changed
-            if expr.__class__ != cls:
-                u = cls(*sargs, **dict(evaluate=False))
-                if u.__class__ == cls and hasattr(u, hint):
-                    newexpr = getattr(u, hint)(**hints)
-                    if newexpr != u:
-                        return (newexpr, True)
 
         return (expr, hit)
 

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -649,18 +649,18 @@ class Mul(Expr, AssocOp):
         return Add.make_args(added)  # it may have collapsed down to one term
 
     def _eval_expand_mul(self, **hints):
-        from sympy import fraction, expand_mul
+        from sympy import fraction, expand_mul, expand_multinomial
 
         # Handle things like 1/(x*(x + 1)), which are automatically converted
         # to 1/x*1/(x + 1)
         expr = self
         n, d = fraction(expr)
         if d.is_Mul:
-            d = d._eval_expand_mul(**hints)
-            if n.is_Add:
-                args = [expand_mul(a/d, deep=False) for a in n.args]
-                return Add(*args)
-            return n/d
+            n, d = [i._eval_expand_mul(**hints) if i.is_Mul else i
+                for i in (n, d)]
+            expr = n/d
+            if not expr.is_Mul:
+                return expr
 
         plain, sums, rewrite = [], [], False
         for factor in expr.args:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -656,9 +656,11 @@ class Mul(Expr, AssocOp):
         expr = self
         n, d = fraction(expr)
         if d.is_Mul:
-            expr = n/d._eval_expand_mul(**hints)
-            if not expr.is_Mul:
-                return expand_mul(expr, deep=False)
+            d = d._eval_expand_mul(**hints)
+            if n.is_Add:
+                args = [expand_mul(a/d, deep=False) for a in n.args]
+                return Add(*args)
+            return n/d
 
         plain, sums, rewrite = [], [], False
         for factor in expr.args:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -480,17 +480,6 @@ class Pow(Expr):
     def _eval_expand_multinomial(self, **hints):
         """(a+b+..) ** n -> a**n + n*a**(n-1)*b + .., n is nonzero integer"""
 
-        def touchup(result):
-            # expand any newly created powers
-            args = list(Add.make_args(result))
-            for i, m in enumerate(args):
-                margs = list(Mul.make_args(m))
-                for j, p in enumerate(margs):
-                    if p.is_Pow:
-                        margs[j] = p._eval_expand_multinomial(**hints)
-                args[i] = Mul(*margs)
-            return Add(*args)
-
         base, exp = self.args
         result = self
 
@@ -580,12 +569,10 @@ class Pow(Expr):
                 expansion_dict = multinomial_coefficients(len(p), n)
                 # in our example: {(3, 0): 1, (1, 2): 3, (0, 3): 1, (2, 1): 3}
                 # and now construct the expression.
-                result = basic_from_dict(expansion_dict, *p)
-                return touchup(result)
+                return basic_from_dict(expansion_dict, *p)
             else:
                 if n == 2:
-                    return touchup(
-                        Add(*[f*g for f in base.args for g in base.args]))
+                    return Add(*[f*g for f in base.args for g in base.args])
                 else:
                     multi = (base**(n - 1))._eval_expand_multinomial()
                     if multi.is_Add:

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -255,7 +255,13 @@ def test_power_expand():
     assert (A**(a + b)).expand() != A**(a + b)
 
 
-def test_issue_3731():
+def test_issues_2820_3731():
+    # 2820
+    n = -1 + 1/x
+    z = n/x/(-n)**2 - 1/n/x
+    assert expand(z) == 1/(x**2 - 2*x + 1) - 1/(x - 2 + 1/x) - 1/(-x + 1)
+
+    # 3731
     p = (1 + x)**2
     assert expand_multinomial((1 + x*p)**2) == (
         x**2*(x**4 + 4*x**3 + 6*x**2 + 4*x + 1) + 2*x*(x**2 + 2*x + 1) + 1)

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -2,7 +2,7 @@ from sympy import (log, sqrt, Rational as R, Symbol, I, exp, pi, S,
     cos, sin, Mul, Pow, cse, O)
 from sympy.simplify.simplify import expand_numer, expand
 from sympy.core.function import (
-    expand_power_base, expand_flat, expand_multinomial)
+    expand_power_base, expand_multinomial)
 
 from sympy.utilities.pytest import raises
 from sympy.core.function import expand_power_base
@@ -133,12 +133,12 @@ def test_expand_frac():
 
 def test_issue_3022():
     eq = -I*exp(-3*I*pi/4)/(4*pi**(S(3)/2)*sqrt(x))
-    assert cse((eq).expand(complex=True)) == S('''(
-    [(x0, re(x)), (x1, im(x)), (x2, sin(atan2(x1, x0)/2)), (x3,
-    cos(atan2(x1, x0)/2)), (x4, x0**2 + x1**2), (x5, sin(atan2(0, x4)/4)),
-    (x6, cos(atan2(0, x4)/4)), (x7, x2*x5), (x8, x3*x5), (x9, x2*x6),
-    (x10, x3*x6)], [sqrt(2)*(-x10 + I*x10 + x7 - I*x7 + x8 + I*x8 + x9 +
-    I*x9)/(8*pi**(3/2)*x4**(1/4))])''')
+    assert cse((eq).expand(complex=True)) == S('''
+        ([(x0, re(x)), (x1, im(x)), (x2, sin(atan2(x1, x0)/2)), (x3,
+        cos(atan2(x1, x0)/2)), (x4, x0**2 + x1**2), (x5, sin(atan2(0, x4)/4)),
+        (x6, cos(atan2(0, x4)/4)), (x7, x2*x5), (x8, x3*x5), (x9, x2*x6),
+        (x10, x3*x6)], [sqrt(2)*(-x10 + I*x10 + x7 - I*x7 + x8 + I*x8 + x9 +
+        I*x9)/(8*pi**(3/2)*x4**(1/4))])''')
 
 
 def test_expand_power_base():
@@ -273,19 +273,18 @@ def test_issues_2820_3731():
     assert expand_multinomial((1 + x*p)**2) == (
         x**2*(1 + 4*A + 6*A**2 + 4*A**3 + A**4) + 2*x*(1 + 2*A + A**2) + 1)
     assert expand_multinomial((1 + (y + x)*p)**2) == (
-        (2*x + 2*y)*(1 + 2*A + A**2) + (x**2 + 2*x*y + y**2)*
+        (x + y)*(1 + 2*A + A**2)*2 + (x**2 + 2*x*y + y**2)*
         (1 + 4*A + 6*A**2 + 4*A**3 + A**4) + 1)
     assert expand_multinomial((1 + (y + x)*p)**3) == (
-        (x + y)*(2*x + 2*y)*(1 + 2*A + A**2)**2 + (x + y)*(x**2 + 2*x*y +
-        y**2)*(1 + 2*A +      A**2)*(1 + 4*A + 6*A**2 + 4*A**3 + A**4) + (x +
-        y)*(1 + 2*A + A**2) + (2*x +     2*y)*(1 + 2*A + A**2) + (x**2 + 2*x*y
-        + y**2)*(1 + 4*A + 6*A**2 + 4*A**3 + A**4) + 1)
+        (x + y)*(1 + 2*A + A**2)*3 + (3*x**2 + 6*x*y + 3*y**2)*(1 + 4*A +
+        6*A**2 + 4*A**3 + A**4) + (x**3 + 3*x**2*y + 3*x*y**2 + y**3)*(1 + 6*A
+        + 15*A**2 + 20*A**3 + 15*A**4 + 6*A**5 + A**6) + 1)
     # unevaluate powers
     eq = (Pow((x + 1)*((A + 1)**2), 2, evaluate=False))
     # - in this case the base is not an Add so no further
     #   expansion is done
     assert expand_multinomial(eq) == \
-        Pow((x + 1)*(1 + 2*A + A**2), 2, evaluate=False)
+        (x**2 + 2*x + 1)*(1 + 4*A + 6*A**2 + 4*A**3 + A**4)
     # - but here, the expanded base *is* an Add so it gets expanded
     eq = (Pow(((A + 1)**2), 2, evaluate=False))
     assert expand_multinomial(eq) == 1 + 4*A + 6*A**2 + 4*A**3 + A**4

--- a/sympy/core/tests/test_expand.py
+++ b/sympy/core/tests/test_expand.py
@@ -136,9 +136,9 @@ def test_issue_3022():
     assert cse((eq).expand(complex=True)) == S('''(
     [(x0, re(x)), (x1, im(x)), (x2, sin(atan2(x1, x0)/2)), (x3,
     cos(atan2(x1, x0)/2)), (x4, x0**2 + x1**2), (x5, sin(atan2(0, x4)/4)),
-    (x6, cos(atan2(0, x4)/4)), (x7, -x2*x6 - x3*x5), (x8, x2*x5), (x9,
-    x3*x6)],
-    [-sqrt(2)*(x7 - x8 + x9 + I*(x7 + x8 - x9))/(8*pi**(3/2)*x4**(1/4))])''')
+    (x6, cos(atan2(0, x4)/4)), (x7, x2*x5), (x8, x3*x5), (x9, x2*x6),
+    (x10, x3*x6)], [sqrt(2)*(-x10 + I*x10 + x7 - I*x7 + x8 + I*x8 + x9 +
+    I*x9)/(8*pi**(3/2)*x4**(1/4))])''')
 
 
 def test_expand_power_base():

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -400,11 +400,11 @@ def test_tan_subs():
 
 
 def test_tan_expansion():
-    assert 0 == tan(x + y).expand(trig=True) - ((tan(x) + tan(y))/(1 - tan(x)*tan(y)))
-    assert 0 == tan(x - y).expand(trig=True) - ((tan(x) - tan(y))/(1 + tan(x)*tan(y)))
-    assert 0 == (tan(x) + tan(y) + tan(z) - tan(x)*tan(y)*tan(z)) \
-        /(1 - tan(x)*tan(y) - tan(x)*tan(z) - tan(y)*tan(z)) \
-        - tan(x + y + z).expand(trig=True)
+    assert tan(x + y).expand(trig=True) == ((tan(x) + tan(y))/(1 - tan(x)*tan(y))).expand()
+    assert tan(x - y).expand(trig=True) == ((tan(x) - tan(y))/(1 + tan(x)*tan(y))).expand()
+    assert tan(x + y + z).expand(trig=True) == (
+        (tan(x) + tan(y) + tan(z) - tan(x)*tan(y)*tan(z))/
+        (1 - tan(x)*tan(y) - tan(x)*tan(z) - tan(y)*tan(z))).expand()
     assert 0 == tan(2*x).expand(trig=True).rewrite(tan).subs([(tan(x), Rational(1, 7))])*24 - 7
     assert 0 == tan(3*x).expand(trig=True).rewrite(tan).subs([(tan(x), Rational(1, 5))])*55 - 37
     assert 0 == tan(4*x - pi/4).expand(trig=True).rewrite(tan).subs([(tan(x), Rational(1, 5))])*239 - 1
@@ -497,12 +497,12 @@ def test_cot_subs():
 
 
 def test_cot_expansion():
-    assert 0 == cot(x + y).expand(trig=True) - (cot(x)*cot(y) - 1)/(cot(x) + cot(y))
-    assert 0 == (cot(x - y).expand(trig=True) + (cot(x)*cot(y) + 1)/(cot(x) - cot(y))).factor()
-    assert 0 == (cot(x)*cot(y)*cot(z) - cot(x) - cot(y) - cot(z))\
-        /(-1 + cot(x)*cot(y) + cot(x)*cot(z) + cot(y)*cot(z)) \
-        - cot(x + y + z).expand(trig=True)
-    assert 0 == cot(3*x).expand(trig=True) - ((cot(x)**3 - 3*cot(x))/(3*cot(x)**2 - 1))
+    assert cot(x + y).expand(trig=True) == ((cot(x)*cot(y) - 1)/(cot(x) + cot(y))).expand()
+    assert cot(x - y).expand(trig=True) == (-(cot(x)*cot(y) + 1)/(cot(x) - cot(y))).expand()
+    assert cot(x + y + z).expand(trig=True) == (
+        (cot(x)*cot(y)*cot(z) - cot(x) - cot(y) - cot(z))/
+        (-1 + cot(x)*cot(y) + cot(x)*cot(z) + cot(y)*cot(z))).expand()
+    assert cot(3*x).expand(trig=True) == ((cot(x)**3 - 3*cot(x))/(3*cot(x)**2 - 1)).expand()
     assert 0 == cot(2*x).expand(trig=True).rewrite(cot).subs([(cot(x), Rational(1, 3))])*3 + 4
     assert 0 == cot(3*x).expand(trig=True).rewrite(cot).subs([(cot(x), Rational(1, 5))])*55 - 37
     assert 0 == cot(4*x - pi/4).expand(trig=True).rewrite(cot).subs([(cot(x), Rational(1, 7))])*863 + 191

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -57,9 +57,7 @@ attempted. For example,
     >>> from time import time
 
 >>> eq = cos(x + y)/cos(x)
->>> TR10i(eq.expand(trig=True)) == eq
-True
->>> TR10i(eq.expand(trig=True).expand())
+>>> TR10i(eq.expand(trig=True))
 -sin(x)*sin(y)/cos(x) + cos(y)
 
 If the expression is put in "normal" form (with a common denominator) then


### PR DESCRIPTION
expand now recursively flattens any expression wrt mul and multinomials; this is handled at the main expand level, not within the `_eval_expand_foo` level (which is just suppose to perform the basic expansion on a given type of expression)

The coverage of `Pow._eval_expand_multinomial` is now at 100% (less one line that I am not sure that can be reached).
