### PR TITLE
Staging the infra of a basic PDE Solver

### DIFF
--- a/doc/src/modules/index.rst
+++ b/doc/src/modules/index.rst
@@ -42,6 +42,7 @@ access any SymPy module, or use this contens:
    statistics.rst
    stats.rst
    solvers/ode.rst
+   solvers/pde.rst
    solvers/solvers.rst
    tensor/index.rst
    utilities/index.rst

--- a/doc/src/modules/solvers/ode.rst
+++ b/doc/src/modules/solvers/ode.rst
@@ -17,10 +17,6 @@ These are functions that are imported into the global namespace with ``from symp
 ^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.classify_ode
 
-:func:`ode_order`
-^^^^^^^^^^^^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.ode_order
-
 :func:`checkodesol`
 ^^^^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.checkodesol
@@ -32,10 +28,6 @@ These are functions that are imported into the global namespace with ``from symp
 Hint Methods
 ------------
 These functions are intended for internal use by :func:`dsolve` and others.  Nonetheless, they contain useful information in their docstrings on the various ODE solving methods.
-
-:obj:`preprocess`
-^^^^^^^^^^^^^^^^^
-.. autofunction:: sympy.solvers.ode.preprocess
 
 :obj:`odesimp`
 ^^^^^^^^^^^^^^
@@ -100,6 +92,18 @@ These functions are intended for internal use by :func:`dsolve` and others.  Non
 :obj:`separable`
 ^^^^^^^^^^^^^^^^
 .. autofunction:: sympy.solvers.ode.ode_separable
+
+:obj:`almost_linear`
+^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.ode.ode_almost_linear
+
+:obj:`linear_coefficients`
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.ode.ode_linear_coefficients
+
+:obj:`separable_reduced`
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.ode.ode_separable_reduced
 
 Information on the ode module
 -----------------------------

--- a/doc/src/modules/solvers/pde.rst
+++ b/doc/src/modules/solvers/pde.rst
@@ -1,0 +1,47 @@
+.. _pde-docs:
+
+PDE
+===
+
+.. module::sympy.solvers.pde
+
+User Functions
+--------------
+These are functions that are imported into the global namespace with ``from sympy import *``.  They are intended for user use.
+
+:func:`pde_separate`
+^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.pde_separate
+
+:func:`pde_separate_add`
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.pde_separate_add
+
+:func:`pde_separate_mul`
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.pde_separate_mul
+
+:func:`pdsolve`
+^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.pdsolve
+
+:func:`classify_pde`
+^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.classify_pde
+
+:func:`checkpdesol`
+^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.checkpdesol
+
+Hint Methods
+------------
+These funcions are meant for internal use. However they contain useful information on the various solving methods.
+
+:obj:`pde_1st_linear_constant_coeff_homogeneous`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autofunction:: sympy.solvers.pde.pde_1st_linear_constant_coeff_homogeneous
+
+Information on the pde module
+-----------------------------
+
+.. automodule:: sympy.solvers.pde

--- a/doc/src/modules/solvers/solvers.rst
+++ b/doc/src/modules/solvers/solvers.rst
@@ -46,17 +46,7 @@ See :ref:`ode-docs`.
 Partial Differential Equations (PDEs)
 -------------------------------------
 
-.. autofunction:: sympy.solvers.pde.pde_separate
-
-.. autofunction:: sympy.solvers.pde.pde_separate_add
-
-.. autofunction:: sympy.solvers.pde.pde_separate_mul
-
-.. autofunction:: sympy.solvers.pde.pde_separate_mul
-
-.. autofunction:: sympy.solvers.pde.pdsolve
-
-.. autofunction:: sympy.solvers.pde.classify_pde
+See :ref:`pde-docs`.
 
 Deutils (Utilities for solving ODE's and PDE's)
 -----------------------------------------------

--- a/doc/src/modules/solvers/solvers.rst
+++ b/doc/src/modules/solvers/solvers.rst
@@ -52,6 +52,17 @@ Partial Differential Equations (PDEs)
 
 .. autofunction:: sympy.solvers.pde.pde_separate_mul
 
+.. autofunction:: sympy.solvers.pde.pde_separate_mul
+
+.. autofunction:: sympy.solvers.pde.pdsolve
+
+.. autofunction:: sympy.solvers.pde.classify_pde
+
+Deutils (Utilities for solving ODE's and PDE's)
+-----------------------------------------------
+
+.. autofunction:: sympy.solvers.deutils.ode_order
+
 Recurrence Equtions
 -------------------
 

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -18,6 +18,6 @@ from ode import checkodesol, classify_ode, dsolve, \
 from polysys import solve_poly_system, solve_triangulated
 
 from pde import pde_separate, pde_separate_add, pde_separate_mul, \
-    pdsolve, classify_pde
+    pdsolve, classify_pde, checkpdesol
 
 from deutils import ode_order

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -20,4 +20,4 @@ from polysys import solve_poly_system, solve_triangulated
 from pde import pde_separate, pde_separate_add, pde_separate_mul, \
     pdsolve, classify_pde
 
-from util import _preprocess, de_order, _desolve
+from deutils import de_order

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -20,4 +20,4 @@ from polysys import solve_poly_system, solve_triangulated
 from pde import pde_separate, pde_separate_add, pde_separate_mul, \
     pdsolve, classify_pde
 
-from deutils import de_order
+from deutils import ode_order

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -12,9 +12,12 @@ from solvers import solve, solve_linear_system, solve_linear_system_LU, \
 
 from recurr import rsolve, rsolve_poly, rsolve_ratio, rsolve_hyper
 
-from ode import checkodesol, classify_ode, ode_order, dsolve, \
+from ode import checkodesol, classify_ode, dsolve, \
     homogeneous_order
 
 from polysys import solve_poly_system, solve_triangulated
 
-from pde import pde_separate, pde_separate_add, pde_separate_mul
+from pde import pde_separate, pde_separate_add, pde_separate_mul, \
+    pdsolve, classify_pde
+
+from util import _preprocess, de_order, _desolve

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -12,40 +12,8 @@ from sympy.core.compatibility import set_union
 from sympy.core.function import Function, Derivative, AppliedUndef
 from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Wild
-
-allhints_ode = (
-    "separable",
-    "1st_exact",
-    "1st_linear",
-    "Bernoulli",
-    "Riccati_special_minus2",
-    "1st_homogeneous_coeff_best",
-    "1st_homogeneous_coeff_subs_indep_div_dep",
-    "1st_homogeneous_coeff_subs_dep_div_indep",
-    "almost_linear",
-    "linear_coefficients",
-    "separable_reduced",
-    "nth_linear_constant_coeff_homogeneous",
-    "nth_linear_euler_eq_homogeneous",
-    "nth_linear_constant_coeff_undetermined_coefficients",
-    "nth_linear_constant_coeff_variation_of_parameters",
-    "Liouville",
-    "separable_Integral",
-    "1st_exact_Integral",
-    "1st_linear_Integral",
-    "Bernoulli_Integral",
-    "1st_homogeneous_coeff_subs_indep_div_dep_Integral",
-    "1st_homogeneous_coeff_subs_dep_div_indep_Integral",
-    "almost_linear_Integral",
-    "linear_coefficients_Integral",
-    "separable_reduced_Integral",
-    "nth_linear_constant_coeff_variation_of_parameters_Integral",
-    "Liouville_Integral",
-    )
-
-allhints_pde = (
-    "1st_linear_constant_coeff_homo",
-    )
+#from sympy.solvers.ode import allhints as allhints_ode
+#from sympy.solvers.pde import allhints as allhints_pde
 
 def _preprocess(expr, func=None, hint='_Integral'):
     """Prepare expr for solving by making sure that differentiation
@@ -198,14 +166,13 @@ def _desolve(eq, func=None, hint="default", simplify=True, **kwargs):
     # changes are made in the function.
     type = kwargs.get('type', None)
     if type == 'ode':
-        from sympy.solvers.ode import classify_ode
+        from sympy.solvers.ode import classify_ode, allhints
         classifier = classify_ode
-        allhints = allhints_ode
         string = 'ODE '
         dummy = ''
 
     elif type == 'pde':
-        from sympy.solvers.pde import classify_pde
+        from sympy.solvers.pde import classify_pde, allhints
         classifier = classify_pde
         allhints = allhints_pde
         string = 'PDE '

--- a/sympy/solvers/deutils.py
+++ b/sympy/solvers/deutils.py
@@ -151,7 +151,7 @@ def _desolve(eq, func=None, hint="default", simplify=True, **kwargs):
     is returned along with the keys which are returned when dict in
     classify_ode or classify_pde is set True
 
-    If the hint is given in ('all', 'all_Integral', 'best'), then this function
+    If the hint given is in ('all', 'all_Integral', 'best'), then this function
     returns a nested dict, with the keys, being the set of classified hints
     returned by classifier functions, and the values being the dict of form
     as mentioned above.

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -225,7 +225,7 @@ from sympy.simplify.simplify import _mexpand
 from sympy.solvers import solve
 
 from sympy.utilities import numbered_symbols, default_sort_key, sift
-from sympy.solvers.deutils import _preprocess, de_order, _desolve
+from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 
 # This is a list of hints in the order that they should be applied.  That means
 # that, in general, hints earlier in the list should produce simpler results
@@ -359,7 +359,7 @@ def dsolve(eq, func=None, hint="default", simplify=True, **kwargs):
                 hint's key will be the exception object raised.  The
                 dictionary will also include some special keys:
 
-                - order: The order of the ODE.  See also de_order() in
+                - order: The order of the ODE.  See also ode_order() in
                   deutils.py
                 - best: The simplest hint; what would be returned by
                   "best" below.
@@ -634,7 +634,7 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
         if eq.rhs != 0:
             return classify_ode(eq.lhs - eq.rhs, func, prep=False)
         eq = eq.lhs
-    order = de_order(eq, f(x))
+    order = ode_order(eq, f(x))
     # hint:matchdict or hint:(tuple of matchdicts)
     # Also will contain "default":<default hint> and "order":order items.
     matching_hints = {"order": order}
@@ -1225,7 +1225,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     s = True
     testnum = 0
     if order == 'auto':
-        order = de_order(ode, func)
+        order = ode_order(ode, func)
     if solve_for_func and not (
             sol.lhs == func and not sol.rhs.has(func)) and not (
             sol.rhs == func and not sol.lhs.has(func)):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -225,7 +225,7 @@ from sympy.simplify.simplify import _mexpand
 from sympy.solvers import solve
 
 from sympy.utilities import numbered_symbols, default_sort_key, sift
-from sympy.solvers.util import _preprocess, de_order, _desolve
+from sympy.solvers.deutils import _preprocess, de_order, _desolve
 
 # This is a list of hints in the order that they should be applied.  That means
 # that, in general, hints earlier in the list should produce simpler results
@@ -360,7 +360,7 @@ def dsolve(eq, func=None, hint="default", simplify=True, **kwargs):
                 dictionary will also include some special keys:
 
                 - order: The order of the ODE.  See also de_order() in
-                  utils.py
+                  deutils.py
                 - best: The simplest hint; what would be returned by
                   "best" below.
                 - best_hint: The hint that would produce the solution

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2858,13 +2858,13 @@ def ode_separable_reduced(eq, func, order, match):
     r"""
     Solves a differential equation that can be reduced to the separable form.
 
-    The general form of this equation is y' + (y/x)*H(x^n*y) = 0
-    This can be solved by substituting u(y) = (x^n * y)
+    The general form of this equation is y' + (y/x)*H(x^n*y) = 0.
+    This can be solved by substituting u(y) = (x^n * y).
 
     The equation then reduces to the separable form
-    u'*(1/(u*(power - H(u)))) - (1/x) = 0.
+    ``u'*(1/(u*(power - H(u))))`` - (1/x) = 0.
 
-    The general solution is
+    The general solution is:
 
         >>> from sympy import Function, dsolve, Eq, pprint
         >>> from sympy.abc import x, n

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2674,10 +2674,6 @@ def ode_almost_linear(eq, func, order, match):
     substitution reduces it to a linear differential equation
     of the form u' + P(x)*u + Q(x) = 0.
 
-    See Also
-    ========
-    ode_1st_linear
-
     The general solution is
 
         >>> from sympy import Function, dsolve, Eq, pprint
@@ -2697,6 +2693,10 @@ def ode_almost_linear(eq, func, order, match):
                \         k(x)    /
 
 
+    See Also
+    ========
+    ode_1st_linear
+
     Examples
     ========
 
@@ -2711,7 +2711,6 @@ def ode_almost_linear(eq, func, order, match):
     >>> pprint(dsolve(eq, f(x), hint='almost_linear'))
                          -x
     f(x) = (C1 - Ei(x))*e
-
 
     References
     ==========
@@ -2863,11 +2862,7 @@ def ode_separable_reduced(eq, func, order, match):
     This can be solved by substituting u(y) = (x^n * y)
 
     The equation then reduces to the separable form
-    u'*(1/(u*(power - H(u)))) - (1/x) = 0
-
-    See Also
-    ========
-    ode_separable
+    u'*(1/(u*(power - H(u)))) - (1/x) = 0.
 
     The general solution is
 
@@ -2891,6 +2886,9 @@ def ode_separable_reduced(eq, func, order, match):
          |
          /
 
+    See Also
+    ========
+    ode_separable
 
     Examples
     ========
@@ -2909,7 +2907,6 @@ def ode_separable_reduced(eq, func, order, match):
             - \/  C1*x  + 1  + 1         \/  C1*x  + 1  + 1
     [f(x) = --------------------, f(x) = ------------------]
                      x                           x
-
 
     References
     ==========

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -16,7 +16,6 @@ specific hint.  See also the docstring on dsolve().
     - dsolve() - Solves ODEs.
     - classify_ode() - Classifies ODEs into possible hints for dsolve().
     - checkodesol() - Checks if an equation is the solution to an ODE.
-    - ode_order() - Returns the order (degree) of an ODE.
     - homogeneous_order() - Returns the homogeneous order of an
       expression.
 
@@ -30,7 +29,6 @@ specific hint.  See also the docstring on dsolve().
     - constantsimp() - Simplifies arbitrary constants.
     - constant_renumber() - Renumber arbitrary constants
     - _handle_Integral() - Evaluate unevaluated Integrals.
-    - preprocess - prepare the equation and detect function to solve for
 
     See also the docstrings of these functions.
 
@@ -227,6 +225,7 @@ from sympy.simplify.simplify import _mexpand
 from sympy.solvers import solve
 
 from sympy.utilities import numbered_symbols, default_sort_key, sift
+from sympy.solvers.util import _preprocess, de_order, _desolve
 
 # This is a list of hints in the order that they should be applied.  That means
 # that, in general, hints earlier in the list should produce simpler results
@@ -269,77 +268,6 @@ allhints = (
     "nth_linear_constant_coeff_variation_of_parameters_Integral",
     "Liouville_Integral",
     )
-
-
-def preprocess(expr, func=None, hint='_Integral'):
-    """Prepare expr for solving by making sure that differentiation
-    is done so that only func remains in unevaluated derivatives and
-    (if hint doesn't end with _Integral) that doit is applied to all
-    other derivatives. If hint is None, don't do any differentiation.
-    (Currently this may cause some simple differential equations to
-    fail.)
-
-    In case func is None, an attempt will be made to autodetect the
-    function to be solved for.
-
-    >>> from sympy.solvers.ode import preprocess
-    >>> from sympy import Derivative, Function, Integral, sin
-    >>> from sympy.abc import x, y, z
-    >>> f, g = map(Function, 'fg')
-
-    Apply doit to derivatives that contain more than the function
-    of interest:
-
-    >>> preprocess(Derivative(f(x) + x, x))
-    (Derivative(f(x), x) + 1, f(x))
-
-    Do others if the differentiation variable(s) intersect with those
-    of the function of interest or contain the function of interest:
-
-    >>> preprocess(Derivative(g(x), y, z), f(y))
-    (0, f(y))
-    >>> preprocess(Derivative(f(y), z), f(y))
-    (0, f(y))
-
-    Do others if the hint doesn't end in '_Integral' (the default
-    assumes that it does):
-
-    >>> preprocess(Derivative(g(x), y), f(x))
-    (Derivative(g(x), y), f(x))
-    >>> preprocess(Derivative(f(x), y), f(x), hint='')
-    (0, f(x))
-
-    Don't do any derivatives if hint is None:
-
-    >>> eq = Derivative(f(x) + 1, x) + Derivative(f(x), y)
-    >>> preprocess(eq, f(x), hint=None)
-    (Derivative(f(x) + 1, x) + Derivative(f(x), y), f(x))
-
-    If it's not clear what the function of interest is, it must be given:
-
-    >>> eq = Derivative(f(x) + g(x), x)
-    >>> preprocess(eq, g(x))
-    (Derivative(f(x), x) + Derivative(g(x), x), g(x))
-    >>> try: preprocess(eq)
-    ... except ValueError: print "A ValueError was raised."
-    A ValueError was raised.
-
-    """
-
-    derivs = expr.atoms(Derivative)
-    if not func:
-        funcs = set_union(*[d.atoms(AppliedUndef) for d in derivs])
-        if len(funcs) != 1:
-            raise ValueError('The function cannot be '
-                'automatically detected for %s.' % expr)
-        func = funcs.pop()
-    fvars = set(func.args)
-    if hint is None:
-        return expr, func
-    reps = [(d, d.doit()) for d in derivs if not hint.endswith('_Integral') or
-            d.has(func) or set(d.variables) & fvars]
-    eq = expr.subs(reps)
-    return eq, func
 
 
 def sub_func_doit(eq, func, new):
@@ -431,7 +359,8 @@ def dsolve(eq, func=None, hint="default", simplify=True, **kwargs):
                 hint's key will be the exception object raised.  The
                 dictionary will also include some special keys:
 
-                - order: The order of the ODE.  See also ode_order().
+                - order: The order of the ODE.  See also de_order() in
+                  utils.py
                 - best: The simplest hint; what would be returned by
                   "best" below.
                 - best_hint: The hint that would produce the solution
@@ -511,112 +440,70 @@ def dsolve(eq, func=None, hint="default", simplify=True, **kwargs):
     >>> # a simpler result in this case.
 
     """
-    prep = kwargs.pop('prep', True)
+    given_hint = hint  # hint given by the user
 
-    # TODO: Implement initial conditions
-    # See issue 1621.  We first need a way to represent things like f'(0).
-    if isinstance(eq, Equality):
-        eq = eq.lhs - eq.rhs
+    # See the docstring of _desolve for more details.
+    hints = _desolve(eq, func=func,
+        hint=hint, simplify=True, type='ode', **kwargs)
 
-    # preprocess the equation and find func if not given
-    if prep or func is None:
-        eq, func = preprocess(eq, func)
-        prep = False
-
-    # Magic that should only be used internally.  Prevents classify_ode from
-    # being called more than it needs to be by passing its results through
-    # recursive calls.
-    if kwargs.get('classify', True):
-        hints = classify_ode(eq, func, dict=True, prep=prep)
-    else:
-        # Here is what all this means:
-        #
-        # hint:    The hint method given to dsolve() by the user.
-        # hints:   The dictionary of hints that match the ODE, along with other
-        #          information (including the internal pass-through magic).
-        # default: The default hint to return, the first hint from allhints
-        #          that matches the hint; obtained from classify_ode().
-        # match:   Dictionary containing the match dictionary for each hint
-        #          (the parts of the ODE for solving).  When going through the
-        #          hints in "all", this holds the match string for the current
-        #          hint.
-        # order:   The order of the ODE, as determined by ode_order().
-        hints = kwargs.get('hint',
-                           {'default': hint,
-                            hint: kwargs['match'],
-                            'order': kwargs['order']})
-
-    if hints['order'] == 0:
-        raise ValueError(
-            str(eq) + " is not a differential equation in " + str(func))
-
-    if not hints['default']:
-        # classify_ode will set hints['default'] to None if no hints match.
-        if hint not in allhints and hint != 'default':
-            raise ValueError("Hint not recognized: " + hint)
-        elif hint not in hints['ordered_hints'] and hint != 'default':
-            raise ValueError("ODE " + str(eq) + " does not match hint " + hint)
-        else:
-            raise NotImplementedError("dsolve: Cannot solve " + str(eq))
-
-    if hint == 'default':
-        return dsolve(eq, func, hint=hints['default'], simplify=simplify,
-                      prep=prep, classify=False, order=hints['order'],
-                      match=hints[hints['default']])
-    elif hint in ('all', 'all_Integral', 'best'):
+    all_ = hints.pop('all', False)
+    if all_:
         retdict = {}
-        failedhints = {}
-        gethints = set(hints) - set(['order', 'default', 'ordered_hints'])
-        if hint == 'all_Integral':
-            for i in hints:
-                if i.endswith('_Integral'):
-                    gethints.remove(i[:-len('_Integral')])
-            # special case
-            if "1st_homogeneous_coeff_best" in gethints:
-                gethints.remove("1st_homogeneous_coeff_best")
-        for i in gethints:
+        failed_hints = {}
+        gethints = classify_ode(eq, dict=True)
+        orderedhints = gethints['ordered_hints']
+        for hint in hints:
             try:
-                sol = dsolve(eq, func, hint=i, simplify=simplify, prep=prep,
-                   classify=False, order=hints['order'], match=hints[i])
-            except NotImplementedError, detail:  # except NotImplementedError as detail:
-                failedhints[i] = detail
+                rv = _helper_simplify(eq, hint, hints[hint], simplify)
+            except NotImplementedError, detail:
+                failed_hints[hint] = detail
             else:
-                retdict[i] = sol
+                retdict[hint] = rv
+        func = hints[hint]['func']
         retdict['best'] = min(retdict.values(), key=lambda x:
             ode_sol_simplicity(x, func, trysolving=not simplify))
-        if hint == 'best':
+        if given_hint == 'best':
             return retdict['best']
-        for i in hints['ordered_hints']:
+        for i in orderedhints:
             if retdict['best'] == retdict.get(i, None):
                 retdict['best_hint'] = i
                 break
-        retdict['default'] = hints['default']
-        retdict['order'] = sympify(hints['order'])
-        retdict.update(failedhints)
+        retdict['default'] = gethints['default']
+        retdict['order'] = gethints['order']
+        retdict.update(failed_hints)
         return retdict
-    elif hint not in allhints:  # and hint not in ('default', 'ordered_hints'):
-        raise ValueError("Hint not recognized: " + hint)
-    elif hint not in hints:
-        raise ValueError("ODE " + str(eq) + " does not match hint " + hint)
-    elif hint.endswith('_Integral'):
+
+    else:
+        # The key 'hint' stores the hint needed to be solved for.
+        hint = hints['hint']
+        return _helper_simplify(eq, hint, hints, simplify)
+
+def _helper_simplify(eq, hint, match, simplify=True):
+    """Helper function of dsolve that calls the respective
+    ode functions to solve for the ordinary differential
+    equations. This minimises the computation in
+    calling _desolve multiple times.
+    """
+    r = match
+    if hint.endswith('_Integral'):
         solvefunc = globals()['ode_' + hint[:-len('_Integral')]]
     else:
-        # convert the string into a function
         solvefunc = globals()['ode_' + hint]
-    # odesimp() will attempt to integrate, if necessary, apply constantsimp(),
-    # attempt to solve for func, and apply any other hint specific
-    # simplifications
+    func = r['func']
+    order = r['order']
+    match = r[hint]
     if simplify:
-        rv = odesimp(solvefunc(eq, func, order=hints['order'],
-            match=hints[hint]), func, hints['order'], hint)
+        # odesimp() will attempt to integrate, if necessary, apply constantsimp(),
+        # attempt to solve for func, and apply any other hint specific
+        # simplifications
+        rv = odesimp(solvefunc(eq, func, order, match), func, order, hint)
+        return rv
     else:
-        # We still want to integrate (can be disabled separately with the hint)
-        r = hints[hint]
-        r['simplify'] = False  # Some hints can take advantage of this option
-        rv = _handle_Integral(solvefunc(eq, func, order=hints['order'],
-            match=hints[hint]), func, hints['order'], hint)
-    return rv
-
+        # We still want to integrate (you can disable it separately with the hint)
+        match['simplify'] = False  # Some hints can take advantage of this option
+        rv = _handle_Integral(solvefunc(eq, func, order, match),
+            func, order, hint)
+        return rv
 
 def classify_ode(eq, func=None, dict=False, **kwargs):
     """
@@ -737,7 +624,7 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
         raise ValueError("dsolve() and classify_ode() only "
         "work with functions of one variable, not %s" % func)
     if prep or func is None:
-        eq, func_ = preprocess(eq, func)
+        eq, func_ = _preprocess(eq, func)
         if func is None:
             func = func_
     x = func.args[0]
@@ -747,7 +634,7 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
         if eq.rhs != 0:
             return classify_ode(eq.lhs - eq.rhs, func, prep=False)
         eq = eq.lhs
-    order = ode_order(eq, f(x))
+    order = de_order(eq, f(x))
     # hint:matchdict or hint:(tuple of matchdicts)
     # Also will contain "default":<default hint> and "order":order items.
     matching_hints = {"order": order}
@@ -1294,7 +1181,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
         ode = Eq(ode, 0)
     if func is None:
         try:
-            _, func = preprocess(ode.lhs)
+            _, func = _preprocess(ode.lhs)
         except ValueError:
             funcs = [s.atoms(AppliedUndef) for s in (
                 sol if is_sequence(sol, set) else [sol])]
@@ -1338,7 +1225,7 @@ def checkodesol(ode, sol, func=None, order='auto', solve_for_func=True):
     s = True
     testnum = 0
     if order == 'auto':
-        order = ode_order(ode, func)
+        order = de_order(ode, func)
     if solve_for_func and not (
             sol.lhs == func and not sol.rhs.has(func)) and not (
             sol.rhs == func and not sol.lhs.has(func)):
@@ -1939,46 +1826,6 @@ def _handle_Integral(expr, func, order, hint):
     else:
         sol = expr
     return sol
-
-
-def ode_order(expr, func):
-    """
-    Returns the order of a given ODE with respect to func.
-
-    This function is implemented recursively.
-
-    Examples
-    ========
-
-    >>> from sympy import Function, ode_order
-    >>> from sympy.abc import x
-    >>> f, g = map(Function, ['f', 'g'])
-    >>> ode_order(f(x).diff(x, 2) + f(x).diff(x)**2 +
-    ... f(x).diff(x), f(x))
-    2
-    >>> ode_order(f(x).diff(x, 2) + g(x).diff(x, 3), f(x))
-    2
-    >>> ode_order(f(x).diff(x, 2) + g(x).diff(x, 3), g(x))
-    3
-
-    """
-    a = Wild('a', exclude=[func])
-    if expr.match(a):
-        return 0
-
-    if isinstance(expr, Derivative):
-        if expr.args[0] == func:
-            return len(expr.variables)
-        else:
-            order = 0
-            for arg in expr.args[0].args:
-                order = max(order, ode_order(arg, func) + len(expr.variables))
-            return order
-    else:
-        order = 0
-        for arg in expr.args:
-            order = max(order, ode_order(arg, func))
-        return order
 
 
 # FIXME: replace the general solution in the docstring with

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -1,17 +1,370 @@
 """
-Analytical methods for solving Partial Differential Equations
-Currently implemented methods:
-    - separation of variables - pde_separate
+This module contains pdesolve() and different helper functions that it
+uses.It is heavily inspired by the ode module and hence the basic
+infrastructure remains the same.
+
+**Functions in this module**
+
+    These are the user functions in this module:
+
+    - pdesolve() - Solves PDEs.
+    - classify_pde() - Classifies PDEs into possible hints for dsolve().
+    - pde_separate() - Separate variables in partial differential equation either by
+                       additive or multiplicative separation approach.
+
+    These are the user functions in the ode module that are used here.
+    - ode_order() - Returns the order (degree) of an ODE. However this can
+      be used to find the order of a PDE as well.
+
+    These are the helper functions in this module
+    - pde_separate_add() - Helper function for searching additive separable solutions.
+    - pde_separate_mul() - Helper function for searching multiplicative
+                         separable solutions.
+
+    These are the helper functions in the ode module that are used here.
+    - preprocess - prepare the equation and detect function to solve for.
+
+**Currently implemented solver methods**
+
+The following methods are implemented for solving partial differential
+equations.  See the docstrings of the various pde_hint() functions for
+more information on each (run help(pde)):
+
+  - 1st order linear homogeneous partial differential equations
+    with constant coefficients.
 
 """
+from copy import deepcopy
+from itertools import combinations_with_replacement
 
 from sympy import Eq, Equality
 from sympy.simplify import simplify
+from sympy.core import Add, C, S, Mul, Pow, oo
 from sympy.core.compatibility import reduce
+from sympy.core.function import Function, Derivative, expand, diff
+from sympy.core.numbers import Rational
+from sympy.core.symbol import Symbol, Wild, Dummy, symbols
+from sympy.functions import exp
 from sympy.utilities.iterables import has_dups
 
+from sympy.solvers.ode import preprocess, ode_order
 import operator
 
+allhints = (
+    "1st_linear_constant_coeff_homo",
+    )
+
+def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
+    """
+    Solves any (supported) kind of partial differential equation.
+
+    **Usage**
+
+        pdesolve(eq, f(x,y), hint) -> Solve partial differential equation
+        eq for function f(x,y), using method hint.
+
+    **Details**
+
+        ``eq`` can be any supported partial differential equation (see
+            the pde docstring for supported methods).  This can either
+            be an Equality, or an expression, which is assumed to be
+            equal to 0.
+
+        ``f(x,y)`` is a function of two variables whose derivatives in that
+            variable make up the partial differential equation. In many
+            cases it is not necessary to provide this; it will be autodetected
+            (and an error raised if it couldn't be detected).
+
+        ``hint`` is the solving method that you want pdesolve to use.  Use
+            classify_pde(eq, f(x,y)) to get all of the possible hints for
+            a PDE.  The default hint, 'default', will use whatever hint
+            is returned first by classify_pde().  See Hints below for
+            more options that you can use for hint.
+
+    **Hints**
+
+        Aside from the various solving methods, there are also some
+        meta-hints that you can pass to pdesolve():
+
+        "default":
+                This uses whatever hint is returned first by
+                classify_pde(). This is the default argument to
+                pdesolve().
+
+        See also the classify_pde() docstring for more info on hints,
+        and the ode docstring for a list of all supported hints.
+
+    **Tips**
+        - You can declare the derivative of an unknown function this way:
+            >>> from sympy import Function, Derivative
+            >>> from sympy.abc import x, y # x and y are the independent variables
+            >>> f = Function("f")(x, y) # f is a function of x and y
+            >>> # fx will be the partial derivative of f with respect to x
+            >>> fx = Derivative(f, x)
+            >>> # fy will be the partial derivative of f with respect to y
+            >>> fy = Derivative(f, y)
+
+        - See test_pde.py for many tests, which serves also as a set of
+          examples for how to use pdesolve().
+        - pdesolve always returns an Equality class (except for the case
+          when the hint is "all" or "all_Integral"). Note that it is not possible
+          to get an explicit solution for f(x, y) as in the case of ODE's
+        - Do help(ode.ode_hintname) to get help more information on a
+          specific hint
+
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.pde import pdesolve
+    >>> from sympy import Function, diff, Eq
+    >>> from sympy.abc import x, y
+    >>> f = Function('f')
+    >>> u = f(x, y)
+    >>> ux = u.diff(x)
+    >>> uy = u.diff(y)
+    >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)))
+    >>> pdesolve(eq)
+    f(x, y) == g(3*x - 2*y)*exp(-2*x/13 - 3*y/13)
+    """
+    prep = kwargs.get('prep', True)
+
+    if isinstance(eq, Equality):
+        eq = eq.lhs - eq.rhs
+
+    # preprocess the equation and find func if not given
+    if prep or func is None:
+        eq, func = preprocess(eq, func)
+        prep = False
+
+    # Magic that should only be used internally.  Prevents classify_ode from
+    # being called more than it needs to be by passing its results through
+    # recursive calls.
+    if kwargs.get('classify', True):
+        hints = classify_pde(eq, func = func, dict = True, prep = prep)
+    else:
+        # Here is what all this means:
+        #
+        # hint:    The hint method given to pdesolve() by the user.
+        # hints:   The dictionary of hints that match the PDE, along with other
+        #          information (including the internal pass-through magic).
+        # default: The default hint to return, the first hint from allhints
+        #          that matches the hint; obtained from classify_pde().
+        # match:   Dictionary containing the match dictionary for each hint
+        #          (the parts of the PDE for solving).  When going through the
+        #          hints in "all", this holds the match string for the current
+        #          hint.
+        # order:   The order of the PDE, as determined by ode_order().
+        hints = kwargs.get('hint',
+                           {'default': hint,
+                            hint: kwargs['match'],
+                            'order': kwargs['order']})
+    if hints['order'] == 0:
+        raise ValueError(
+            str(eq) + " is not a differential equation in " + str(func))
+
+    if not hints['default']:
+        # classify_pde will set hints['default'] to None if no hints match
+        if hint not in allhints and hint != 'default':
+            raise ValueError("Hint not recognized: " + hint)
+        elif hint not in hints['ordered_hints'] and hint != 'default':
+            raise ValueError("PDE " + str(eq) + " does not match hint " + hint)
+        else:
+            raise NotImplementedError("pdesolve: Cannot solve " + str(eq))
+
+    if hint == 'default':
+        return pdesolve(eq, func, hint=hints['default'], simplify=simplify,
+                      prep=prep, classify=False, order=hints['order'],
+                      match=hints[hints['default']])
+    elif hint not in allhints:  # and hint not in ('default', 'ordered_hints'):
+        raise ValueError("Hint not recognized: " + hint)
+    elif hint not in hints:
+        raise ValueError("PDE " + str(eq) + " does not match hint " + hint)
+
+    else:
+        # convert the string into a function
+        solvefunc = globals()['pde_' + hint]
+        return solvefunc(eq, func, order=hints['order'], match=hints[hint])
+
+def classify_pde(eq, func=None, dict=False, **kwargs):
+    """
+    Returns a tuple of possible pdesolve() classifications for a PDE.
+
+    The tuple is ordered so that first item is the classification that
+    pdesolve() uses to solve the PDE by default.  In general,
+    classifications at the near the beginning of the list will produce
+    better solutions faster than those near the end, thought there are
+    always exceptions.  To make dsolve use a different classification,
+    use pdesolve(PDE, func, hint=<classification>).  See also the pdesolve()
+    docstring for different meta-hints you can use.
+
+    If ``dict`` is true, classify_pde() will return a dictionary of
+    hint:match expression terms. This is intended for internal use by
+    pdesolve().  Note that because dictionaries are ordered arbitrarily,
+    this will most likely not be in the same order as the tuple.
+
+    You can get help on different hints by doing help(pde.pde_hintname),
+    where hintname is the name of the hint without "_Integral".
+
+    See sympy.pde.allhints or the sympy.pde docstring for a list of all
+    supported hints that can be returned from classify_pde.
+
+
+    Examples
+    ========
+    >>> from sympy.solvers.pde import classify_pde
+    >>> from sympy import Function, diff, Eq
+    >>> from sympy.abc import x, y
+    >>> f = Function('f')
+    >>> u = f(x, y)
+    >>> ux = u.diff(x)
+    >>> uy = u.diff(y)
+    >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)))
+    >>> classify_pde(eq)
+    ('1st_linear_constant_coeff_homo',)
+    """
+
+    prep = kwargs.pop('prep', True)
+
+    if func and len(func.args) != 2:
+        raise NotImplementedError("Right now only partial"
+        "differential equations of two variables are supported")
+
+    if prep or func is None:
+        prep, func_ = preprocess(eq, func)
+        if func is None:
+            func = func_
+
+    if isinstance(eq, Equality):
+        if eq.rhs != 0:
+            return classify_pde(eq.lhs - eq.rhs, func)
+        eq = eq.lhs
+
+    f = func.func
+    x = func.args[0]
+    y = func.args[1]
+    fx = f(x,y).diff(x)
+    fy = f(x,y).diff(y)
+
+    order = ode_order(eq, f(x,y))
+
+    # hint:matchdict or hint:(tuple of matchdicts)
+    # Also will contain "default":<default hint> and "order":order items.
+    matching_hints = {'order': order}
+
+    if not order:
+        if dict:
+            matching_hints["default"] = None
+            return matching_hints
+        else:
+            return ()
+
+    eq = expand(eq)
+
+    a = Wild('a', exclude = [f(x,y)])
+    b = Wild('b', exclude = [f(x,y), fx, fy])
+    c = Wild('c', exclude = [f(x,y), fx, fy])
+    d = Wild('d', exclude = [f(x,y), fx, fy])
+    n = Wild('n', exclude = [x, y])
+    # Try removing the smallest power of f(x,y)
+    # from the highest partial derivatives of f(x,y)
+    reduced_eq = None
+    if eq.is_Add:
+        var = set(combinations_with_replacement((x,y), order))
+        dummyvar = deepcopy(var)
+        power = None
+        for i in var:
+            coeff = eq.coeff(f(x,y).diff(*i))
+            if coeff != 1:
+                match = coeff.match(a*f(x,y)**n)
+                if match and match[a]:
+                    power = match[n]
+                    dummyvar.remove(i)
+                    break
+            dummyvar.remove(i)
+        for i in dummyvar:
+            coeff = eq.coeff(f(x,y).diff(*i))
+            if coeff != 1:
+                match = coeff.match(a*f(x,y)**n)
+                if match and match[a] and match[n] < power:
+                    power = match[n]
+        if power:
+            den = f(x,y)**power
+            reduced_eq = Add(*[arg/den for arg in eq.args])
+        if not reduced_eq:
+            reduced_eq = eq
+
+    if order == 1:
+        ## Linear first-order homogeneous partial-differential
+        ## equation with constant coefficients
+        r = reduced_eq.match(b*fx + c*fy + d*f(x,y))
+        if r and all(isinstance(r[var], Rational) for var in r):
+            r.update({'b': b, 'c': c, 'd': d})
+            matching_hints["1st_linear_constant_coeff_homo"] = r
+
+    # Order keys based on allhints.
+    retlist = []
+    for i in allhints:
+        if i in matching_hints:
+            retlist.append(i)
+
+    if dict:
+        # Dictionaries are ordered arbitrarily, so make note of which
+        # hint would come first for pdesolve().  Use an ordered dict in Py 3.
+        matching_hints["default"] = None
+        matching_hints["ordered_hints"] = tuple(retlist)
+        for i in allhints:
+            if i in matching_hints:
+                matching_hints["default"] = i
+                break
+        return matching_hints
+    else:
+        return tuple(retlist)
+
+def pde_1st_linear_constant_coeff_homo(eq, func, order, match):
+    r"""
+    Solves a first order linear homogeneous
+    partial differential equation with constant coefficients.
+
+    The general form of this partial differential equation is of
+    the form a*f(x,y).diff(x) + b*f(x,y).diff(y) + f(x,y) = 0
+    where a, b and c are Rationals.
+
+    The general solution of the differential equation, can be found
+    put by the method of characteristics. It is given by
+    f(x,y) = G(b*x - a*y)*exp(-c/(a**2 + b**2)*(a*x + b*y))
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.pde import (pde_1st_linear_constant_coeff_homo,
+    ... pdesolve)
+    >>> from sympy import Function, diff, pprint
+    >>> from sympy.abc import x,y
+    >>> f = Function('f')
+    >>> pdesolve(f(x,y) + f(x,y).diff(x) + f(x,y).diff(y))
+    f(x, y) == g(x - y)*exp(-x/2 - y/2)
+    >>> pprint(pdesolve(f(x,y) + f(x,y).diff(x) + f(x,y).diff(y)))
+                          x   y
+                        - - - -
+                          2   2
+    f(x, y) = g(x - y)*e
+
+    References
+    ==========
+
+    - Viktor Grigoryan, "Partial Differential Equations"
+      Math 124A - Fall 2010, pp.7
+
+    """
+    f = func.func
+    x = func.args[0]
+    y = func.args[1]
+    g = Function('g')
+    b = match[match['b']]
+    c = match[match['c']]
+    d = match[match['d']]
+    return Eq(f(x,y), exp(-S(d)/(b**2 + c**2)*(b*x + c*y))*g(c*x - b*y))
 
 def pde_separate(eq, fun, sep, strategy='mul'):
     """Separate variables in partial differential equation either by additive

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -1,28 +1,21 @@
 """
 This module contains pdesolve() and different helper functions that it
-uses.It is heavily inspired by the ode module and hence the basic
+uses. It is heavily inspired by the ode module and hence the basic
 infrastructure remains the same.
 
 **Functions in this module**
 
     These are the user functions in this module:
 
-    - pdesolve() - Solves PDEs.
+    - pdesolve()     - Solves PDE's
     - classify_pde() - Classifies PDEs into possible hints for dsolve().
     - pde_separate() - Separate variables in partial differential equation either by
                        additive or multiplicative separation approach.
 
-    These are the user functions in the ode module that are used here.
-    - ode_order() - Returns the order (degree) of an ODE. However this can
-      be used to find the order of a PDE as well.
-
     These are the helper functions in this module
     - pde_separate_add() - Helper function for searching additive separable solutions.
     - pde_separate_mul() - Helper function for searching multiplicative
-                         separable solutions.
-
-    These are the helper functions in the ode module that are used here.
-    - preprocess - prepare the equation and detect function to solve for.
+                           separable solutions.
 
 **Currently implemented solver methods**
 
@@ -36,30 +29,30 @@ more information on each (run help(pde)):
 """
 from copy import deepcopy
 
-from sympy import Eq, Equality
 from sympy.simplify import simplify
 from sympy.core import Add, C, S, Mul, Pow, oo
 from sympy.core.compatibility import reduce, combinations_with_replacement
 from sympy.core.function import Function, Derivative, expand, diff
 from sympy.core.numbers import Rational
+from sympy.core.relational import Equality, Eq
 from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.functions import exp
 from sympy.utilities.iterables import has_dups
 
-from sympy.solvers.ode import preprocess, ode_order
+from sympy.solvers.util import _preprocess, de_order, _desolve
 import operator
 
 allhints = (
     "1st_linear_constant_coeff_homo",
     )
 
-def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
+def pdsolve(eq, func=None, hint='default', dict=False, **kwargs):
     """
     Solves any (supported) kind of partial differential equation.
 
     **Usage**
 
-        pdesolve(eq, f(x,y), hint) -> Solve partial differential equation
+        pdsolve(eq, f(x,y), hint) -> Solve partial differential equation
         eq for function f(x,y), using method hint.
 
     **Details**
@@ -74,7 +67,7 @@ def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
             cases it is not necessary to provide this; it will be autodetected
             (and an error raised if it couldn't be detected).
 
-        ``hint`` is the solving method that you want pdesolve to use.  Use
+        ``hint`` is the solving method that you want pdsolve to use.  Use
             classify_pde(eq, f(x,y)) to get all of the possible hints for
             a PDE.  The default hint, 'default', will use whatever hint
             is returned first by classify_pde().  See Hints below for
@@ -83,12 +76,12 @@ def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
     **Hints**
 
         Aside from the various solving methods, there are also some
-        meta-hints that you can pass to pdesolve():
+        meta-hints that you can pass to pdsolve():
 
         "default":
                 This uses whatever hint is returned first by
                 classify_pde(). This is the default argument to
-                pdesolve().
+                pdsolve().
 
         See also the classify_pde() docstring for more info on hints,
         and the ode docstring for a list of all supported hints.
@@ -104,8 +97,8 @@ def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
             >>> fy = Derivative(f, y)
 
         - See test_pde.py for many tests, which serves also as a set of
-          examples for how to use pdesolve().
-        - pdesolve always returns an Equality class (except for the case
+          examples for how to use pdsolve().
+        - pdsolve always returns an Equality class (except for the case
           when the hint is "all" or "all_Integral"). Note that it is not possible
           to get an explicit solution for f(x, y) as in the case of ODE's
         - Do help(ode.ode_hintname) to get help more information on a
@@ -115,7 +108,7 @@ def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
     Examples
     ========
 
-    >>> from sympy.solvers.pde import pdesolve
+    >>> from sympy.solvers.pde import pdsolve
     >>> from sympy import Function, diff, Eq
     >>> from sympy.abc import x, y
     >>> f = Function('f')
@@ -123,83 +116,38 @@ def pdesolve(eq, func=None, hint='default', dict=False, **kwargs):
     >>> ux = u.diff(x)
     >>> uy = u.diff(y)
     >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)))
-    >>> pdesolve(eq)
+    >>> pdsolve(eq)
     f(x, y) == g(3*x - 2*y)*exp(-2*x/13 - 3*y/13)
     """
-    prep = kwargs.get('prep', True)
 
-    if isinstance(eq, Equality):
-        eq = eq.lhs - eq.rhs
+    given_hint = hint  # hint given by the user.
 
-    # preprocess the equation and find func if not given
-    if prep or func is None:
-        eq, func = preprocess(eq, func)
-        prep = False
+    # See the docstring of _desolve for more details.
+    hints = _desolve(eq, func=func,
+        hint=hint, simplify=True, type='pde', **kwargs)
+    all_ = hints.pop('all', False)
 
-    # Magic that should only be used internally.  Prevents classify_ode from
-    # being called more than it needs to be by passing its results through
-    # recursive calls.
-    if kwargs.get('classify', True):
-        hints = classify_pde(eq, func = func, dict = True, prep = prep)
+    if all_:
+        raise NotImplementedError("Only one hint has been added till now")
     else:
-        # Here is what all this means:
-        #
-        # hint:    The hint method given to pdesolve() by the user.
-        # hints:   The dictionary of hints that match the PDE, along with other
-        #          information (including the internal pass-through magic).
-        # default: The default hint to return, the first hint from allhints
-        #          that matches the hint; obtained from classify_pde().
-        # match:   Dictionary containing the match dictionary for each hint
-        #          (the parts of the PDE for solving).  When going through the
-        #          hints in "all", this holds the match string for the current
-        #          hint.
-        # order:   The order of the PDE, as determined by ode_order().
-        hints = kwargs.get('hint',
-                           {'default': hint,
-                            hint: kwargs['match'],
-                            'order': kwargs['order']})
-    if hints['order'] == 0:
-        raise ValueError(
-            str(eq) + " is not a differential equation in " + str(func))
-
-    if not hints['default']:
-        # classify_pde will set hints['default'] to None if no hints match
-        if hint not in allhints and hint != 'default':
-            raise ValueError("Hint not recognized: " + hint)
-        elif hint not in hints['ordered_hints'] and hint != 'default':
-            raise ValueError("PDE " + str(eq) + " does not match hint " + hint)
-        else:
-            raise NotImplementedError("pdesolve: Cannot solve " + str(eq))
-
-    if hint == 'default':
-        return pdesolve(eq, func, hint=hints['default'], simplify=simplify,
-                      prep=prep, classify=False, order=hints['order'],
-                      match=hints[hints['default']])
-    elif hint not in allhints:  # and hint not in ('default', 'ordered_hints'):
-        raise ValueError("Hint not recognized: " + hint)
-    elif hint not in hints:
-        raise ValueError("PDE " + str(eq) + " does not match hint " + hint)
-
-    else:
-        # convert the string into a function
-        solvefunc = globals()['pde_' + hint]
-        return solvefunc(eq, func, order=hints['order'], match=hints[hint])
+        solvefunc = globals()['pde_' + hints[hint]]
+        return solvefunc(eq, hints['func'], hints['order'], hints[hints['hint']])
 
 def classify_pde(eq, func=None, dict=False, **kwargs):
     """
-    Returns a tuple of possible pdesolve() classifications for a PDE.
+    Returns a tuple of possible pdsolve() classifications for a PDE.
 
     The tuple is ordered so that first item is the classification that
-    pdesolve() uses to solve the PDE by default.  In general,
+    pdsolve() uses to solve the PDE by default.  In general,
     classifications at the near the beginning of the list will produce
     better solutions faster than those near the end, thought there are
     always exceptions.  To make dsolve use a different classification,
-    use pdesolve(PDE, func, hint=<classification>).  See also the pdesolve()
+    use pdsolve(PDE, func, hint=<classification>).  See also the pdsolve()
     docstring for different meta-hints you can use.
 
     If ``dict`` is true, classify_pde() will return a dictionary of
     hint:match expression terms. This is intended for internal use by
-    pdesolve().  Note that because dictionaries are ordered arbitrarily,
+    pdsolve().  Note that because dictionaries are ordered arbitrarily,
     this will most likely not be in the same order as the tuple.
 
     You can get help on different hints by doing help(pde.pde_hintname),
@@ -230,7 +178,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
         "differential equations of two variables are supported")
 
     if prep or func is None:
-        prep, func_ = preprocess(eq, func)
+        prep, func_ = _preprocess(eq, func)
         if func is None:
             func = func_
 
@@ -245,7 +193,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     fx = f(x,y).diff(x)
     fy = f(x,y).diff(y)
 
-    order = ode_order(eq, f(x,y))
+    order = de_order(eq, f(x,y))
 
     # hint:matchdict or hint:(tuple of matchdicts)
     # Also will contain "default":<default hint> and "order":order items.
@@ -309,7 +257,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
 
     if dict:
         # Dictionaries are ordered arbitrarily, so make note of which
-        # hint would come first for pdesolve().  Use an ordered dict in Py 3.
+        # hint would come first for pdsolve().  Use an ordered dict in Py 3.
         matching_hints["default"] = None
         matching_hints["ordered_hints"] = tuple(retlist)
         for i in allhints:
@@ -337,13 +285,13 @@ def pde_1st_linear_constant_coeff_homo(eq, func, order, match):
     ========
 
     >>> from sympy.solvers.pde import (pde_1st_linear_constant_coeff_homo,
-    ... pdesolve)
+    ... pdsolve)
     >>> from sympy import Function, diff, pprint
     >>> from sympy.abc import x,y
     >>> f = Function('f')
-    >>> pdesolve(f(x,y) + f(x,y).diff(x) + f(x,y).diff(y))
+    >>> pdsolve(f(x,y) + f(x,y).diff(x) + f(x,y).diff(y))
     f(x, y) == g(x - y)*exp(-x/2 - y/2)
-    >>> pprint(pdesolve(f(x,y) + f(x,y).diff(x) + f(x,y).diff(y)))
+    >>> pprint(pdsolve(f(x,y) + f(x,y).diff(x) + f(x,y).diff(y)))
                           x   y
                         - - - -
                           2   2

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -35,12 +35,11 @@ more information on each (run help(pde)):
 
 """
 from copy import deepcopy
-from itertools import combinations_with_replacement
 
 from sympy import Eq, Equality
 from sympy.simplify import simplify
 from sympy.core import Add, C, S, Mul, Pow, oo
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, combinations_with_replacement
 from sympy.core.function import Function, Derivative, expand, diff
 from sympy.core.numbers import Rational
 from sympy.core.symbol import Symbol, Wild, Dummy, symbols

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -153,7 +153,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     pdsolve() uses to solve the PDE by default.  In general,
     classifications at the near the beginning of the list will produce
     better solutions faster than those near the end, thought there are
-    always exceptions.  To make dsolve use a different classification,
+    always exceptions.  To make pdsolve use a different classification,
     use pdsolve(PDE, func, hint=<classification>).  See also the pdsolve()
     docstring for different meta-hints you can use.
 

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -1,5 +1,5 @@
 """
-This module contains pdesolve() and different helper functions that it
+This module contains pdsolve() and different helper functions that it
 uses. It is heavily inspired by the ode module and hence the basic
 infrastructure remains the same.
 
@@ -7,7 +7,7 @@ infrastructure remains the same.
 
     These are the user functions in this module:
 
-    - pdesolve()     - Solves PDE's
+    - pdsolve()     - Solves PDE's
     - classify_pde() - Classifies PDEs into possible hints for dsolve().
     - pde_separate() - Separate variables in partial differential equation either by
                        additive or multiplicative separation approach.
@@ -39,11 +39,11 @@ from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.functions import exp
 from sympy.utilities.iterables import has_dups
 
-from sympy.solvers.util import _preprocess, de_order, _desolve
+from sympy.solvers.deutils import _preprocess, de_order, _desolve
 import operator
 
 allhints = (
-    "1st_linear_constant_coeff_homo",
+    "1st_linear_constant_coeff_homogeneous",
     )
 
 def pdsolve(eq, func=None, hint='default', dict=False, **kwargs):
@@ -168,7 +168,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     >>> uy = u.diff(y)
     >>> eq = Eq(1 + (2*(ux/u)) + (3*(uy/u)))
     >>> classify_pde(eq)
-    ('1st_linear_constant_coeff_homo',)
+    ('1st_linear_constant_coeff_homogeneous',)
     """
 
     prep = kwargs.pop('prep', True)
@@ -247,7 +247,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
         r = reduced_eq.match(b*fx + c*fy + d*f(x,y))
         if r and all(isinstance(r[var], Rational) for var in r):
             r.update({'b': b, 'c': c, 'd': d})
-            matching_hints["1st_linear_constant_coeff_homo"] = r
+            matching_hints["1st_linear_constant_coeff_homogeneous"] = r
 
     # Order keys based on allhints.
     retlist = []
@@ -268,7 +268,7 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     else:
         return tuple(retlist)
 
-def pde_1st_linear_constant_coeff_homo(eq, func, order, match):
+def pde_1st_linear_constant_coeff_homogeneous(eq, func, order, match):
     r"""
     Solves a first order linear homogeneous
     partial differential equation with constant coefficients.
@@ -284,8 +284,9 @@ def pde_1st_linear_constant_coeff_homo(eq, func, order, match):
     Examples
     ========
 
-    >>> from sympy.solvers.pde import (pde_1st_linear_constant_coeff_homo,
-    ... pdsolve)
+    >>> from sympy.solvers.pde import (
+    ... pde_1st_linear_constant_coeff_homogeneous)
+    >>> from sympy import pdsolve
     >>> from sympy import Function, diff, pprint
     >>> from sympy.abc import x,y
     >>> f = Function('f')

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -39,7 +39,7 @@ from sympy.core.symbol import Symbol, Wild, Dummy, symbols
 from sympy.functions import exp
 from sympy.utilities.iterables import has_dups
 
-from sympy.solvers.deutils import _preprocess, de_order, _desolve
+from sympy.solvers.deutils import _preprocess, ode_order, _desolve
 import operator
 
 allhints = (
@@ -193,7 +193,11 @@ def classify_pde(eq, func=None, dict=False, **kwargs):
     fx = f(x,y).diff(x)
     fy = f(x,y).diff(y)
 
-    order = de_order(eq, f(x,y))
+    # TODO : For now pde.py uses support offered by the ode_order function
+    # to find the order with respect to a multi-variable function. An
+    # improvement could be to classify the order of the PDE on the basis of
+    # individual variables.
+    order = ode_order(eq, f(x,y))
 
     # hint:matchdict or hint:(tuple of matchdicts)
     # Also will contain "default":<default hint> and "order":order items.

--- a/sympy/solvers/pde.py
+++ b/sympy/solvers/pde.py
@@ -12,7 +12,8 @@ infrastructure remains the same.
     - pde_separate() - Separate variables in partial differential equation either by
                        additive or multiplicative separation approach.
 
-    These are the helper functions in this module
+    These are the helper functions in this module:
+
     - pde_separate_add() - Helper function for searching additive separable solutions.
     - pde_separate_mul() - Helper function for searching multiplicative
                            separable solutions.
@@ -91,7 +92,7 @@ def pdsolve(eq, func=None, hint='default', dict=False, solvefun=None, **kwargs):
                 pdsolve().
 
         See also the classify_pde() docstring for more info on hints,
-        and the ode docstring for a list of all supported hints.
+        and the pde docstring for a list of all supported hints.
 
     **Tips**
         - You can declare the derivative of an unknown function this way:
@@ -108,7 +109,7 @@ def pdsolve(eq, func=None, hint='default', dict=False, solvefun=None, **kwargs):
         - pdsolve always returns an Equality class (except for the case
           when the hint is "all" or "all_Integral"). Note that it is not possible
           to get an explicit solution for f(x, y) as in the case of ODE's
-        - Do help(ode.ode_hintname) to get help more information on a
+        - Do help(pde.pde_hintname) to get help more information on a
           specific hint
 
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -8,7 +8,8 @@ from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve, Eq,
 x, y, z = symbols('x:z', real=True)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
                                classify_ode, constant_renumber, constantsimp,
-                               homogeneous_order, ode_order)
+                               homogeneous_order)
+from sympy.solvers.util import _preprocess, de_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow
 
 C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C1:11')
@@ -86,7 +87,7 @@ def test_dsolve_options():
         'nth_linear_euler_eq_homogeneous',
         'order', 'separable_Integral']
     assert sorted(a.keys()) == keys
-    assert a['order'] == ode_order(eq, f(x))
+    assert a['order'] == de_order(eq, f(x))
     assert a['best'] == Eq(f(x), C1/x)
     assert dsolve(eq, hint='best') == Eq(f(x), C1/x)
     assert a['default'] == 'separable'
@@ -103,7 +104,7 @@ def test_dsolve_options():
     assert a['1st_homogeneous_coeff_subs_indep_div_dep_Integral'].has(Integral)
     assert a['separable_Integral'].has(Integral)
     assert sorted(b.keys()) == keys
-    assert b['order'] == ode_order(eq, f(x))
+    assert b['order'] == de_order(eq, f(x))
     assert b['best'] == Eq(f(x), C1/x)
     assert dsolve(eq, hint='best', simplify=False) == Eq(f(x), C1/x)
     assert b['default'] == 'separable'
@@ -198,34 +199,34 @@ def test_classify_ode():
                         prep=True) == ans
 
 
-def test_ode_order():
+def test_de_order():
     f = Function('f')
     g = Function('g')
     x = Symbol('x')
-    assert ode_order(3*x*exp(f(x)), f(x)) == 0
-    assert ode_order(x*diff(f(x), x) + 3*x*f(x) - sin(x)/x, f(x)) == 1
-    assert ode_order(x**2*f(x).diff(x, x) + x*diff(f(x), x) - f(x), f(x)) == 2
-    assert ode_order(diff(x*exp(f(x)), x, x), f(x)) == 2
-    assert ode_order(diff(x*diff(x*exp(f(x)), x, x), x), f(x)) == 3
-    assert ode_order(diff(f(x), x, x), g(x)) == 0
-    assert ode_order(diff(f(x), x, x)*diff(g(x), x), f(x)) == 2
-    assert ode_order(diff(f(x), x, x)*diff(g(x), x), g(x)) == 1
-    assert ode_order(diff(x*diff(x*exp(f(x)), x, x), x), g(x)) == 0
-    # issue 2736: ode_order has to also work for unevaluated derivatives
+    assert de_order(3*x*exp(f(x)), f(x)) == 0
+    assert de_order(x*diff(f(x), x) + 3*x*f(x) - sin(x)/x, f(x)) == 1
+    assert de_order(x**2*f(x).diff(x, x) + x*diff(f(x), x) - f(x), f(x)) == 2
+    assert de_order(diff(x*exp(f(x)), x, x), f(x)) == 2
+    assert de_order(diff(x*diff(x*exp(f(x)), x, x), x), f(x)) == 3
+    assert de_order(diff(f(x), x, x), g(x)) == 0
+    assert de_order(diff(f(x), x, x)*diff(g(x), x), f(x)) == 2
+    assert de_order(diff(f(x), x, x)*diff(g(x), x), g(x)) == 1
+    assert de_order(diff(x*diff(x*exp(f(x)), x, x), x), g(x)) == 0
+    # issue 2736: de_order has to also work for unevaluated derivatives
     # (ie, without using doit()).
-    assert ode_order(Derivative(x*f(x), x), f(x)) == 1
-    assert ode_order(x*sin(Derivative(x*f(x)**2, x, x)), f(x)) == 2
-    assert ode_order(Derivative(x*Derivative(x*exp(f(x)), x, x), x), g(x)) == 0
-    assert ode_order(Derivative(f(x), x, x), g(x)) == 0
-    assert ode_order(Derivative(x*exp(f(x)), x, x), f(x)) == 2
-    assert ode_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
-    assert ode_order(Derivative(x*Derivative(f(x), x, x), x), f(x)) == 3
-    assert ode_order(
+    assert de_order(Derivative(x*f(x), x), f(x)) == 1
+    assert de_order(x*sin(Derivative(x*f(x)**2, x, x)), f(x)) == 2
+    assert de_order(Derivative(x*Derivative(x*exp(f(x)), x, x), x), g(x)) == 0
+    assert de_order(Derivative(f(x), x, x), g(x)) == 0
+    assert de_order(Derivative(x*exp(f(x)), x, x), f(x)) == 2
+    assert de_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
+    assert de_order(Derivative(x*Derivative(f(x), x, x), x), f(x)) == 3
+    assert de_order(
         x*sin(Derivative(x*Derivative(f(x), x)**2, x, x)), f(x)) == 3
 
 
 # In all tests below, checkodesol has the order option set to prevent
-# superfluous calls to ode_order(), and the solve_for_func flag set to False
+# superfluous calls to de_order(), and the solve_for_func flag set to False
 # because dsolve() already tries to solve for the function, unless the
 # simplify=False option is set.
 def test_old_ode_tests():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -9,7 +9,7 @@ x, y, z = symbols('x:z', real=True)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
                                classify_ode, constant_renumber, constantsimp,
                                homogeneous_order)
-from sympy.solvers.util import _preprocess, de_order
+from sympy.solvers.deutils import ode_order
 from sympy.utilities.pytest import XFAIL, skip, raises, slow
 
 C1, C2, C3, C4, C5, C6, C7, C8, C9, C10 = symbols('C1:11')
@@ -87,7 +87,7 @@ def test_dsolve_options():
         'nth_linear_euler_eq_homogeneous',
         'order', 'separable_Integral']
     assert sorted(a.keys()) == keys
-    assert a['order'] == de_order(eq, f(x))
+    assert a['order'] == ode_order(eq, f(x))
     assert a['best'] == Eq(f(x), C1/x)
     assert dsolve(eq, hint='best') == Eq(f(x), C1/x)
     assert a['default'] == 'separable'
@@ -104,7 +104,7 @@ def test_dsolve_options():
     assert a['1st_homogeneous_coeff_subs_indep_div_dep_Integral'].has(Integral)
     assert a['separable_Integral'].has(Integral)
     assert sorted(b.keys()) == keys
-    assert b['order'] == de_order(eq, f(x))
+    assert b['order'] == ode_order(eq, f(x))
     assert b['best'] == Eq(f(x), C1/x)
     assert dsolve(eq, hint='best', simplify=False) == Eq(f(x), C1/x)
     assert b['default'] == 'separable'
@@ -199,34 +199,34 @@ def test_classify_ode():
                         prep=True) == ans
 
 
-def test_de_order():
+def test_ode_order():
     f = Function('f')
     g = Function('g')
     x = Symbol('x')
-    assert de_order(3*x*exp(f(x)), f(x)) == 0
-    assert de_order(x*diff(f(x), x) + 3*x*f(x) - sin(x)/x, f(x)) == 1
-    assert de_order(x**2*f(x).diff(x, x) + x*diff(f(x), x) - f(x), f(x)) == 2
-    assert de_order(diff(x*exp(f(x)), x, x), f(x)) == 2
-    assert de_order(diff(x*diff(x*exp(f(x)), x, x), x), f(x)) == 3
-    assert de_order(diff(f(x), x, x), g(x)) == 0
-    assert de_order(diff(f(x), x, x)*diff(g(x), x), f(x)) == 2
-    assert de_order(diff(f(x), x, x)*diff(g(x), x), g(x)) == 1
-    assert de_order(diff(x*diff(x*exp(f(x)), x, x), x), g(x)) == 0
-    # issue 2736: de_order has to also work for unevaluated derivatives
+    assert ode_order(3*x*exp(f(x)), f(x)) == 0
+    assert ode_order(x*diff(f(x), x) + 3*x*f(x) - sin(x)/x, f(x)) == 1
+    assert ode_order(x**2*f(x).diff(x, x) + x*diff(f(x), x) - f(x), f(x)) == 2
+    assert ode_order(diff(x*exp(f(x)), x, x), f(x)) == 2
+    assert ode_order(diff(x*diff(x*exp(f(x)), x, x), x), f(x)) == 3
+    assert ode_order(diff(f(x), x, x), g(x)) == 0
+    assert ode_order(diff(f(x), x, x)*diff(g(x), x), f(x)) == 2
+    assert ode_order(diff(f(x), x, x)*diff(g(x), x), g(x)) == 1
+    assert ode_order(diff(x*diff(x*exp(f(x)), x, x), x), g(x)) == 0
+    # issue 2736: ode_order has to also work for unevaluated derivatives
     # (ie, without using doit()).
-    assert de_order(Derivative(x*f(x), x), f(x)) == 1
-    assert de_order(x*sin(Derivative(x*f(x)**2, x, x)), f(x)) == 2
-    assert de_order(Derivative(x*Derivative(x*exp(f(x)), x, x), x), g(x)) == 0
-    assert de_order(Derivative(f(x), x, x), g(x)) == 0
-    assert de_order(Derivative(x*exp(f(x)), x, x), f(x)) == 2
-    assert de_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
-    assert de_order(Derivative(x*Derivative(f(x), x, x), x), f(x)) == 3
-    assert de_order(
+    assert ode_order(Derivative(x*f(x), x), f(x)) == 1
+    assert ode_order(x*sin(Derivative(x*f(x)**2, x, x)), f(x)) == 2
+    assert ode_order(Derivative(x*Derivative(x*exp(f(x)), x, x), x), g(x)) == 0
+    assert ode_order(Derivative(f(x), x, x), g(x)) == 0
+    assert ode_order(Derivative(x*exp(f(x)), x, x), f(x)) == 2
+    assert ode_order(Derivative(f(x), x, x)*Derivative(g(x), x), g(x)) == 1
+    assert ode_order(Derivative(x*Derivative(f(x), x, x), x), f(x)) == 3
+    assert ode_order(
         x*sin(Derivative(x*Derivative(f(x), x)**2, x, x)), f(x)) == 3
 
 
 # In all tests below, checkodesol has the order option set to prevent
-# superfluous calls to de_order(), and the solve_for_func flag set to False
+# superfluous calls to ode_order(), and the solve_for_func flag set to False
 # because dsolve() already tries to solve for the function, unless the
 # simplify=False option is set.
 def test_old_ode_tests():

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -1,5 +1,7 @@
 from sympy import Derivative as D, Eq, exp, Function, Symbol, symbols
-from sympy.solvers.pde import pde_separate_add, pde_separate_mul
+from sympy.core import S
+from sympy.solvers.pde import (pde_separate_add, pde_separate_mul,
+    pdesolve, classify_pde)
 from sympy.utilities.pytest import raises
 
 
@@ -60,3 +62,22 @@ def test_pde_separate_mul():
     res = pde_separate_mul(eq, u(theta, r), [R(r), T(theta)])
     assert res == [r*D(R(r), r)/R(r) + r**2*D(R(r), r, r)/R(r) + c*r**2,
             -D(T(theta), theta, theta)/T(theta)]
+
+def test_pde_1st_linear_constant_coeff_homo():
+    x, y = symbols("x,y")
+    f, g = map(Function, ['f', 'g'])
+    u = f(x, y)
+    eq = 2*u + u.diff(x) + u.diff(y)
+    assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
+    sol = pdesolve(eq)
+    assert sol.rhs == g(x - y)*exp(-x - y)
+
+    eq = 4 + (3*u.diff(x)/u) + (2*u.diff(y)/u)
+    assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
+    sol = pdesolve(eq)
+    assert sol.rhs == g(2*x - 3*y)*exp(-S(12)*x/13 - S(8)*y/13)
+
+    eq = u + (6*u.diff(x)) + (7*u.diff(y))
+    assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
+    sol = pdesolve(eq)
+    assert sol.rhs == g(7*x - 6*y)*exp(-6*x/S(85) - 7*y/S(85))

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -1,7 +1,7 @@
 from sympy import Derivative as D, Eq, exp, Function, Symbol, symbols
 from sympy.core import S
 from sympy.solvers.pde import (pde_separate_add, pde_separate_mul,
-    pdesolve, classify_pde)
+    pdsolve, classify_pde)
 from sympy.utilities.pytest import raises
 
 
@@ -69,15 +69,15 @@ def test_pde_1st_linear_constant_coeff_homo():
     u = f(x, y)
     eq = 2*u + u.diff(x) + u.diff(y)
     assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
-    sol = pdesolve(eq)
+    sol = pdsolve(eq)
     assert sol.rhs == g(x - y)*exp(-x - y)
 
     eq = 4 + (3*u.diff(x)/u) + (2*u.diff(y)/u)
     assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
-    sol = pdesolve(eq)
+    sol = pdsolve(eq)
     assert sol.rhs == g(2*x - 3*y)*exp(-S(12)*x/13 - S(8)*y/13)
 
     eq = u + (6*u.diff(x)) + (7*u.diff(y))
     assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
-    sol = pdesolve(eq)
+    sol = pdsolve(eq)
     assert sol.rhs == g(7*x - 6*y)*exp(-6*x/S(85) - 7*y/S(85))

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -1,10 +1,10 @@
 from sympy import Derivative as D, Eq, exp, Function, Symbol, symbols
 from sympy.core import S
 from sympy.solvers.pde import (pde_separate_add, pde_separate_mul,
-    pdsolve, classify_pde)
+    pdsolve, classify_pde, checkpdesol)
 from sympy.utilities.pytest import raises
 
-
+a, b, c, x, y = symbols('a b c x y')
 def test_pde_separate_add():
     x, y, z, t = symbols("x,y,z,t")
     F, T, X, Y, Z, u = map(Function, 'FTXYZu')
@@ -63,21 +63,65 @@ def test_pde_separate_mul():
     assert res == [r*D(R(r), r)/R(r) + r**2*D(R(r), r, r)/R(r) + c*r**2,
             -D(T(theta), theta, theta)/T(theta)]
 
+def test_pde_classify():
+    # When more number of hints are added, add tests for classifying here.
+    f = Function('f')
+    eq1 = a*f(x,y) + b*f(x,y).diff(x) + c*f(x,y).diff(y)
+    eq2 = 3*f(x,y) + 2*f(x,y).diff(x) + f(x,y).diff(y)
+    eq3 = a*f(x,y) + b*f(x,y).diff(x) + 2*f(x,y).diff(y)
+    eq4 = x*f(x,y) + f(x,y).diff(x) + 3*f(x,y).diff(y)
+    eq5 = x**2*f(x,y) + x*f(x,y).diff(x) + x*y*f(x,y).diff(y)
+    eq6 = y*x**2*f(x,y) + y*f(x,y).diff(x) + f(x,y).diff(y)
+    for eq in [eq1, eq2, eq3]:
+        assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
+    for eq in [eq4, eq5, eq6]:
+        assert classify_pde(eq) == ()
+
+
+def test_checkpdesol():
+    f, F = map(Function, ['f', 'F'])
+    eq1 = a*f(x,y) + b*f(x,y).diff(x) + c*f(x,y).diff(y)
+    eq2 = 3*f(x,y) + 2*f(x,y).diff(x) + f(x,y).diff(y)
+    eq3 = a*f(x,y) + b*f(x,y).diff(x) + 2*f(x,y).diff(y)
+    for eq in [eq1, eq2, eq3]:
+        assert checkpdesol(eq, pdsolve(eq))[0]
+    eq4 = x*f(x,y) + f(x,y).diff(x) + 3*f(x,y).diff(y)
+    eq5 = 2*f(x,y) + 1*f(x,y).diff(x) + 3*f(x,y).diff(y)
+    eq6 = f(x,y) + 1*f(x,y).diff(x) + 3*f(x,y).diff(y)
+    assert checkpdesol(eq4, [pdsolve(eq5), pdsolve(eq6)]) == [
+        (False, (x - 2)*F(3*x - y)*exp(-x/S(5) - 3*y/S(5))),
+         (False, (x - 1)*F(3*x - y)*exp(-x/S(10) - 3*y/S(10)))]
+
+
+def test_solvefun():
+    f, F, G, H = map(Function, ['f', 'F', 'G', 'H'])
+    eq1 = f(x,y) + f(x,y).diff(x) + f(x,y).diff(y)
+    assert pdsolve(eq1) == Eq(f(x, y), F(x - y)*exp(-x/2 - y/2))
+    assert pdsolve(eq1, solvefun=G) == Eq(f(x, y), G(x - y)*exp(-x/2 - y/2))
+    assert pdsolve(eq1, solvefun=H) == Eq(f(x, y), H(x - y)*exp(-x/2 - y/2))
+
+
 def test_pde_1st_linear_constant_coeff_homogeneous():
-    x, y = symbols("x,y")
-    f, g = map(Function, ['f', 'g'])
+    f, F = map(Function, ['f', 'F'])
     u = f(x, y)
     eq = 2*u + u.diff(x) + u.diff(y)
     assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
     sol = pdsolve(eq)
-    assert sol.rhs == g(x - y)*exp(-x - y)
+    assert sol == Eq(u, F(x - y)*exp(-x - y))
+    assert checkpdesol(eq, sol)[0]
 
     eq = 4 + (3*u.diff(x)/u) + (2*u.diff(y)/u)
     assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
     sol = pdsolve(eq)
-    assert sol.rhs == g(2*x - 3*y)*exp(-S(12)*x/13 - S(8)*y/13)
+    assert sol == Eq(u, F(2*x - 3*y)*exp(-S(12)*x/13 - S(8)*y/13))
+    assert checkpdesol(eq, sol)[0]
 
     eq = u + (6*u.diff(x)) + (7*u.diff(y))
     assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
     sol = pdsolve(eq)
-    assert sol.rhs == g(7*x - 6*y)*exp(-6*x/S(85) - 7*y/S(85))
+    assert sol == Eq(u, F(7*x - 6*y)*exp(-6*x/S(85) - 7*y/S(85)))
+    assert checkpdesol(eq, sol)[0]
+
+    eq = a*u + b*u.diff(x) + c*u.diff(y)
+    sol = pdsolve(eq)
+    assert checkpdesol(eq, sol)[0]

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -63,21 +63,21 @@ def test_pde_separate_mul():
     assert res == [r*D(R(r), r)/R(r) + r**2*D(R(r), r, r)/R(r) + c*r**2,
             -D(T(theta), theta, theta)/T(theta)]
 
-def test_pde_1st_linear_constant_coeff_homo():
+def test_pde_1st_linear_constant_coeff_homogeneous():
     x, y = symbols("x,y")
     f, g = map(Function, ['f', 'g'])
     u = f(x, y)
     eq = 2*u + u.diff(x) + u.diff(y)
-    assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
+    assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
     sol = pdsolve(eq)
     assert sol.rhs == g(x - y)*exp(-x - y)
 
     eq = 4 + (3*u.diff(x)/u) + (2*u.diff(y)/u)
-    assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
+    assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
     sol = pdsolve(eq)
     assert sol.rhs == g(2*x - 3*y)*exp(-S(12)*x/13 - S(8)*y/13)
 
     eq = u + (6*u.diff(x)) + (7*u.diff(y))
-    assert classify_pde(eq) == ('1st_linear_constant_coeff_homo',)
+    assert classify_pde(eq) == ('1st_linear_constant_coeff_homogeneous',)
     sol = pdsolve(eq)
     assert sol.rhs == g(7*x - 6*y)*exp(-6*x/S(85) - 7*y/S(85))

--- a/sympy/solvers/util.py
+++ b/sympy/solvers/util.py
@@ -1,0 +1,278 @@
+"""Utility functions for classifying and solving
+ordinary and partial differential equations.
+
+Contains
+========
+_preprocess
+de_order
+_desolve
+
+"""
+from sympy.core.compatibility import set_union
+from sympy.core.function import Function, Derivative, AppliedUndef
+from sympy.core.relational import Equality, Eq
+from sympy.core.symbol import Wild
+
+allhints_ode = (
+    "separable",
+    "1st_exact",
+    "1st_linear",
+    "Bernoulli",
+    "Riccati_special_minus2",
+    "1st_homogeneous_coeff_best",
+    "1st_homogeneous_coeff_subs_indep_div_dep",
+    "1st_homogeneous_coeff_subs_dep_div_indep",
+    "almost_linear",
+    "linear_coefficients",
+    "separable_reduced",
+    "nth_linear_constant_coeff_homogeneous",
+    "nth_linear_euler_eq_homogeneous",
+    "nth_linear_constant_coeff_undetermined_coefficients",
+    "nth_linear_constant_coeff_variation_of_parameters",
+    "Liouville",
+    "separable_Integral",
+    "1st_exact_Integral",
+    "1st_linear_Integral",
+    "Bernoulli_Integral",
+    "1st_homogeneous_coeff_subs_indep_div_dep_Integral",
+    "1st_homogeneous_coeff_subs_dep_div_indep_Integral",
+    "almost_linear_Integral",
+    "linear_coefficients_Integral",
+    "separable_reduced_Integral",
+    "nth_linear_constant_coeff_variation_of_parameters_Integral",
+    "Liouville_Integral",
+    )
+
+allhints_pde = (
+    "1st_linear_constant_coeff_homo",
+    )
+
+def _preprocess(expr, func=None, hint='_Integral'):
+    """Prepare expr for solving by making sure that differentiation
+    is done so that only func remains in unevaluated derivatives and
+    (if hint doesn't end with _Integral) that doit is applied to all
+    other derivatives. If hint is None, don't do any differentiation.
+    (Currently this may cause some simple differential equations to
+    fail.)
+
+    In case func is None, an attempt will be made to autodetect the
+    function to be solved for.
+
+    >>> from sympy.solvers.util import _preprocess
+    >>> from sympy import Derivative, Function, Integral, sin
+    >>> from sympy.abc import x, y, z
+    >>> f, g = map(Function, 'fg')
+
+    Apply doit to derivatives that contain more than the function
+    of interest:
+
+    >>> _preprocess(Derivative(f(x) + x, x))
+    (Derivative(f(x), x) + 1, f(x))
+
+    Do others if the differentiation variable(s) intersect with those
+    of the function of interest or contain the function of interest:
+
+    >>> _preprocess(Derivative(g(x), y, z), f(y))
+    (0, f(y))
+    >>> _preprocess(Derivative(f(y), z), f(y))
+    (0, f(y))
+
+    Do others if the hint doesn't end in '_Integral' (the default
+    assumes that it does):
+
+    >>> _preprocess(Derivative(g(x), y), f(x))
+    (Derivative(g(x), y), f(x))
+    >>> _preprocess(Derivative(f(x), y), f(x), hint='')
+    (0, f(x))
+
+    Don't do any derivatives if hint is None:
+
+    >>> eq = Derivative(f(x) + 1, x) + Derivative(f(x), y)
+    >>> _preprocess(eq, f(x), hint=None)
+    (Derivative(f(x) + 1, x) + Derivative(f(x), y), f(x))
+
+    If it's not clear what the function of interest is, it must be given:
+
+    >>> eq = Derivative(f(x) + g(x), x)
+    >>> _preprocess(eq, g(x))
+    (Derivative(f(x), x) + Derivative(g(x), x), g(x))
+    >>> try: _preprocess(eq)
+    ... except ValueError: print "A ValueError was raised."
+    A ValueError was raised.
+
+    """
+
+    derivs = expr.atoms(Derivative)
+    if not func:
+        funcs = set_union(*[d.atoms(AppliedUndef) for d in derivs])
+        if len(funcs) != 1:
+            raise ValueError('The function cannot be '
+                'automatically detected for %s.' % expr)
+        func = funcs.pop()
+    fvars = set(func.args)
+    if hint is None:
+        return expr, func
+    reps = [(d, d.doit()) for d in derivs if not hint.endswith('_Integral') or
+            d.has(func) or set(d.variables) & fvars]
+    eq = expr.subs(reps)
+    return eq, func
+
+def de_order(expr, func):
+    """
+    Returns the order of a given differential
+    equation with respect to func.
+
+    This function is implemented recursively.
+
+    Examples
+    ========
+
+    >>> from sympy import Function
+    >>> from sympy.solvers.util import de_order
+    >>> from sympy.abc import x
+    >>> f, g = map(Function, ['f', 'g'])
+    >>> de_order(f(x).diff(x, 2) + f(x).diff(x)**2 +
+    ... f(x).diff(x), f(x))
+    2
+    >>> de_order(f(x).diff(x, 2) + g(x).diff(x, 3), f(x))
+    2
+    >>> de_order(f(x).diff(x, 2) + g(x).diff(x, 3), g(x))
+    3
+
+    """
+    a = Wild('a', exclude=[func])
+    if expr.match(a):
+        return 0
+
+    if isinstance(expr, Derivative):
+        if expr.args[0] == func:
+            return len(expr.variables)
+        else:
+            order = 0
+            for arg in expr.args[0].args:
+                order = max(order, de_order(arg, func) + len(expr.variables))
+            return order
+    else:
+        order = 0
+        for arg in expr.args:
+            order = max(order, de_order(arg, func))
+        return order
+
+def _desolve(eq, func=None, hint="default", simplify=True, **kwargs):
+    """This is a helper function to dsolve and pdsolve in the ode
+    and pde modules.
+
+    If the hint is given in ('all', 'all_Integral', 'best'), then this function
+    returns a nested dict, with the keys, being the
+    set of identified hints in classify_ode(). The value of each key is a dict
+    consisting of a 'default' key, a 'hint' key which helps in
+    identifying the hint needed to be passed to the solver functions
+    in ode and pde.py, an 'order' key that identifies the order of the
+    differential equation given by 'de_order', a 'func' key that
+    tells what function, the differential equation is to be solved for,
+    an 'all' key that tells if the hint given is in all or not,
+    and the match for the corresponding hint as returned by classify_ode
+
+    If the hint given is not present in ('all', 'all_Integral', 'best')
+    then a single dict corresponding to the key value mentioned
+    above that has a 'default', 'order', 'func' and 'match' key is
+    returned.
+
+    See Also
+    ========
+    classify_ode(ode.py)
+    classify_pde(pde.py)
+    """
+    prep = kwargs.pop('prep', True)
+    if isinstance(eq, Equality):
+        eq = eq.lhs - eq.rhs
+
+    # preprocess the equation and find func if not given
+    if prep or func is None:
+        eq, func = _preprocess(eq, func)
+        prep = False
+
+    # type is an argument passed by the solve functions in ode and pde.py
+    # that identifies whether the function caller is an ordinary
+    # or partial differential equation. Accordingly corresponding
+    # changes are made in the function.
+    type = kwargs.get('type', None)
+    if type == 'ode':
+        from sympy.solvers.ode import classify_ode
+        classifier = classify_ode
+        allhints = allhints_ode
+        string = 'ODE '
+        dummy = ''
+
+    elif type == 'pde':
+        from sympy.solvers.pde import classify_pde
+        classifier = classify_pde
+        allhints = allhints_pde
+        string = 'PDE '
+        dummy = 'p'
+
+    # Magic that should only be used internally.  Prevents classify_ode from
+    # being called more than it needs to be by passing its results through
+    # recursive calls.
+    if kwargs.get('classify', True):
+        hints = classifier(eq, func, dict=True, prep=prep)
+
+    else:
+        # Here is what all this means:
+        #
+        # hint:    The hint method given to _desolve() by the user.
+        # hints:   The dictionary of hints that match the DE, along with other
+        #          information (including the internal pass-through magic).
+        # default: The default hint to return, the first hint from allhints
+        #          that matches the hint; obtained from classify_ode().
+        # match:   Dictionary containing the match dictionary for each hint
+        #          (the parts of the DE for solving).  When going through the
+        #          hints in "all", this holds the match string for the current
+        #          hint.
+        # order:   The order of the DE, as determined by de_order().
+        hints = kwargs.get('hint',
+                           {'default': hint,
+                            hint: kwargs['match'],
+                            'order': kwargs['order']})
+    if hints['order'] == 0:
+        raise ValueError(
+            str(eq) + " is not a differential equation in " + str(func))
+
+    if not hints['default']:
+        # classify_ode will set hints['default'] to None if no hints match.
+        if hint not in allhints and hint != 'default':
+            raise ValueError("Hint not recognized: " + hint)
+        elif hint not in hints['ordered_hints'] and hint != 'default':
+            raise ValueError(string + str(eq) + " does not match hint " + hint)
+        else:
+            raise NotImplementedError(dummy + "solve" + ": Cannot solve " + str(eq))
+    if hint == 'default':
+        return _desolve(eq, func, hint=hints['default'], simplify=simplify,
+                      prep=prep, classify=False, order=hints['order'],
+                      match=hints[hints['default']], type=type)
+    elif hint in ('all', 'all_Integral', 'best'):
+        retdict = {}
+        failedhints = {}
+        gethints = set(hints) - set(['order', 'default', 'ordered_hints'])
+        if hint == 'all_Integral':
+            for i in hints:
+                if i.endswith('_Integral'):
+                    gethints.remove(i[:-len('_Integral')])
+            # special case
+            if "1st_homogeneous_coeff_best" in gethints:
+                gethints.remove("1st_homogeneous_coeff_best")
+        for i in gethints:
+            sol = _desolve(eq, func, hint=i, simplify=simplify, prep=prep,
+                classify=False, order=hints['order'], match=hints[i], type=type)
+            retdict[i] = sol
+        retdict['all'] = True
+        return retdict
+    elif hint not in allhints:  # and hint not in ('default', 'ordered_hints'):
+        raise ValueError("Hint not recognized: " + hint)
+    elif hint not in hints:
+        raise ValueError(string + str(eq) + " does not match hint " + hint)
+    else:
+        # Key added to identify the hint needed to solve the equation
+        hints['hint'] = hint
+    hints['func'] = func
+    return hints


### PR DESCRIPTION
See the discussion at https://groups.google.com/forum/?fromgroups=#!topic/sympy/bBenTf1lG70 . 

And also point 2 under theory at https://github.com/sympy/sympy/wiki/GSoC-2013-Application:-Manoj-Kumar-:-Improved-ODE-Solver . I thought this could be implemented in ode.py itself, but then according to the discussion, extending the pde solver to these type of simple equations, could be beneficial.

So I decided to give this a shot myself. The code borrows its architecture, heavily from the ode.py code and for now I've added a hint that solves simple linear homogeneous partial first order PDE's.

However I've not added an ' integral' , 'best' or 'all' hint since, I've implemented only a 
single hint till now that doesn't need actual integration. Also I've yet to add a checkodesol equivalent yet. 
