### PR TITLE
Temporary Fix in limit() when expression.is_Add is True

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -185,7 +185,10 @@ def limit(e, z, z0, dir="+"):
                 else:
                     finite.append(term)
             else:
-                result = term.subs(z, z0)
+                try:
+                    result = limit(term, z, z0)
+                except:
+                    result = term.subs(z, z0)
                 bounded = result.is_bounded
                 if bounded is False or result is S.NaN:
                     unbounded.append(term)

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -187,7 +187,7 @@ def limit(e, z, z0, dir="+"):
             else:
                 try:
                     result = limit(term, z, z0)
-                except:
+                except NotImplementedError:
                     result = term.subs(z, z0)
                 bounded = result.is_bounded
                 if bounded is False or result is S.NaN:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -185,10 +185,7 @@ def limit(e, z, z0, dir="+"):
                 else:
                     finite.append(term)
             else:
-                try:
-                    result = limit(term, z, z0)
-                except NotImplementedError:
-                    result = term.subs(z, z0)
+                result = limit(term, z, z0)
                 bounded = result.is_bounded
                 if bounded is False or result is S.NaN:
                     unbounded.append(term)

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -1,6 +1,6 @@
 from sympy import (limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
                    atan, gamma, Symbol, S, pi, Integral, cot, Rational, I, zoo,
-                   tan, cot, integrate, Sum, sign)
+                   tan, cot, integrate, Sum, sign, E)
 
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
@@ -51,6 +51,7 @@ def test_basic1():
     assert limit(1/tan(x**3), x, (2*pi)**(S(1)/3), dir="-") == -oo
     assert limit(1/cot(x)**3, x, (3*pi/2), dir="+") == -oo
     assert limit(1/cot(x)**3, x, (3*pi/2), dir="-") == oo
+    assert limit(2 + (1 + 1/x)**x, x, oo) == 2 + E
 
     # approaching 0
     # from dir="+"

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -31,14 +31,12 @@ def test_basic1():
     assert limit(cos(x + y)/x, x, 0) == sign(cos(y))*oo
     raises(NotImplementedError, lambda: limit(Sum(1/x, (x, 1, y)) -
            log(y), y, oo))
-    assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))
     assert limit(gamma(1/x + 3), x, oo) == 2
     assert limit(S.NaN, x, -oo) == S.NaN
     assert limit(Order(2)*x, x, S.NaN) == S.NaN
-    assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))
-    assert limit(gamma(1/x + 3), x, oo) == 2
-    assert limit(S.NaN, x, -oo) == S.NaN
-    assert limit(Order(2)*x, x, S.NaN) == S.NaN
+    assert limit(gamma(1/x + 3), x, oo, dir="-") == 2
+    assert limit(S.NaN, x, -oo, dir="-") == S.NaN
+    assert limit(Order(2)*x, x, S.NaN, dir="-") == S.NaN
     assert limit(1/(x - 1), x, 1, dir="+") == oo
     assert limit(1/(x - 1), x, 1, dir="-") == -oo
     assert limit(1/(5 - x)**3, x, 5, dir="+") == -oo
@@ -380,3 +378,8 @@ def test_factorial():
     assert limit(f, x, -oo) == factorial(-oo)
     assert limit(f, x, x**2) == factorial(x**2)
     assert limit(f, x, -x**2) == factorial(-x**2)
+
+
+@XFAIL
+def test_PR_2000():
+    assert limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo) == Sum(1/x, (x, 1, oo))


### PR DESCRIPTION
Please refer https://groups.google.com/forum/?fromgroups=#!topic/sympy/61pRw1PINUA

Currently,

``` py
>>> from sympy import *
>>> x=Symbol('x')
>>> limit(1+(1+1/x)**x,x,oo)
2
```

Desired,

``` py
>>> from sympy import *
>>> x=Symbol('x')
>>> limit(1+(1+1/x)**x,x,oo)
1 + E
```
