### PR TITLE
in latex: don't use operatorname for single letter functions;

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -850,6 +850,13 @@ class Chi(TrigonometricIntegral):
         from sympy import exp_polar
         return -I*pi/2 - (E1(z) + E1(exp_polar(I*pi)*z))/2
 
+    def _latex(self, printer, exp=None):
+        assert len(self.args) == 1
+        if exp:
+            return r'\operatorname{Chi}^{%s}{\left (%s \right )}' % (exp, self.args[0])
+        else:
+            return r'\operatorname{Chi}{\left (%s \right )}' % self.args[0]
+
 
 ###############################################################################
 #################### FRESNEL INTEGRALS ########################################

--- a/sympy/physics/quantum/tests/test_printing.py
+++ b/sympy/physics/quantum/tests/test_printing.py
@@ -540,7 +540,7 @@ DifferentialOperator⎜──(f(x)),f(x)⎟\n\
     assert pretty(d) == ascii_str
     assert upretty(d) == ucode_str
     assert latex(d) == \
-        r'DifferentialOperator\left(\frac{d}{d x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )}\right)'
+        r'DifferentialOperator\left(\frac{d}{d x} f{\left (x \right )},f{\left (x \right )}\right)'
     sT(d, "DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))")
     assert str(b) == 'Operator(B,t,1/2)'
     assert pretty(b) == 'Operator(B,t,1/2)'
@@ -815,7 +815,7 @@ u"""\
     assert pretty(e1) == ascii_str
     assert upretty(e1) == ucode_str
     assert latex(e1) == \
-        r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} \operatorname{f}{\left (x \right )},\operatorname{f}{\left (x \right )}\right)^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
+        r'{\left(J_z\right)^{2}}\otimes \left({A^{\dag} + B^{\dag}}\right) \left\{\left(DifferentialOperator\left(\frac{d}{d x} f{\left (x \right )},f{\left (x \right )}\right)^{\dag}\right)^{3},A^{\dag} + B^{\dag}\right\} \left({\left\langle 1,0\right|} + {\left\langle 1,1\right|}\right) \left({\left|0,0\right\rangle } + {\left|1,-1\right\rangle }\right)'
     sT(e1, "Mul(TensorProduct(Pow(JzOp(Symbol('J')), Integer(2)), Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), AntiCommutator(Pow(Dagger(DifferentialOperator(Derivative(Function('f')(Symbol('x')), Symbol('x')),Function('f')(Symbol('x')))), Integer(3)),Add(Dagger(Operator(Symbol('A'))), Dagger(Operator(Symbol('B'))))), Add(JzBra(Integer(1),Integer(0)), JzBra(Integer(1),Integer(1))), Add(JzKet(Integer(0),Integer(0)), JzKet(Integer(1),Integer(-1))))")
     assert str(e2) == '[Jz**2,A + B]*{E**(-2),Dagger(D)*Dagger(C)}*[J2,Jz]'
     ascii_str = \

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -441,6 +441,22 @@ class LatexPrinter(Printer):
         else:
             return r"%s %s" % (tex, self._print(e))
 
+    def _hprint_Function(self, func):
+        '''
+        Logic to decide how to render a function to latex
+          - if it is a recognized latex name, use the appropriate latex command
+          - if it is a single letter, just use that letter
+          - if it is a longer name, then put \operatorname{} around it and be
+            mindful of undercores in the name
+        '''
+        if func in accepted_latex_functions:
+            name = r"\%s" % func
+        elif len(func) == 1:
+            name = func
+        else:
+            name = r"\operatorname{%s}" % func.replace("_", r"\_")
+        return name
+
     def _print_Function(self, expr, exp=None):
         '''
         Render functions to LaTeX, handling functions that LaTeX knows about
@@ -491,22 +507,9 @@ class LatexPrinter(Printer):
                 else:
                     name = r"\operatorname{%s}^{-1}" % func
             elif exp is not None:
-                if func in accepted_latex_functions:
-                    name = r"\%s^{%s}" % (func, exp)
-                elif len(func) == 1:
-                    name = r"%s^{%s}" % (func, exp)
-                else:
-                    # If the generic function name contains an underscore, handle it
-                    name = r"\operatorname{%s}^{%s}" % (
-                        func.replace("_", r"\_"), exp)
+                name = r'%s^{%s}' % (self._hprint_Function(func), exp)
             else:
-                if func in accepted_latex_functions:
-                    name = r"\%s" % func
-                elif len(func) == 1:
-                    name = func
-                else:
-                    # If the generic function name contains an underscore, handle it
-                    name = r"\operatorname{%s}" % func.replace("_", r"\_")
+                name = self._hprint_Function(func)
 
             if can_fold_brackets:
                 if func in accepted_latex_functions:
@@ -524,7 +527,7 @@ class LatexPrinter(Printer):
             return name % ",".join(args)
 
     def _print_UndefinedFunction(self, expr):
-        return r'\operatorname{%s}' % expr
+        return self._hprint_Function(str(expr))
 
     def _print_Lambda(self, expr):
         symbols, expr = expr.args

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -442,8 +442,16 @@ class LatexPrinter(Printer):
             return r"%s %s" % (tex, self._print(e))
 
     def _print_Function(self, expr, exp=None):
-        '''expr is the expression involving the function
-            exp is an exponent
+        '''
+        Render functions to LaTeX, handling functions that LaTeX knows about
+        e.g., sin, cos, ... by using the proper LaTeX command (\sin, \cos, ...).
+        For single-letter function names, render them as regular LaTeX math
+        symbols. For multi-letter function names that LaTeX does not know
+        about, (e.g., Li, sech) use \operatorname{} so that the function name
+        is rendered in Roman font and LaTeX handles spacing properly.
+
+        expr is the expression involving the function
+        exp is an exponent
         '''
         func = expr.func.__name__
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -22,9 +22,35 @@ import re
 # Complete list at http://www.mathjax.org/docs/1.1/tex.html#supported-latex-commands
 # This variable only contains those functions which sympy uses.
 accepted_latex_functions = ['arcsin', 'arccos', 'arctan', 'sin', 'cos', 'tan',
-                    'theta', 'beta', 'alpha', 'gamma', 'sinh', 'cosh', 'tanh', 'sqrt',
+                    'sinh', 'cosh', 'tanh', 'sqrt',
                     'ln', 'log', 'sec', 'csc', 'cot', 'coth', 're', 'im', 'frac', 'root',
-                    'arg', 'zeta', 'psi']
+                    'arg']
+## 'theta', 'beta', 'alpha', 'gamma', , 'zeta', 'psi']
+greeks = set(['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta',
+              'theta', 'iota', 'kappa', 'lambda', 'mu', 'nu', 'xi', 'omicron',
+              'pi', 'rho', 'sigma', 'tau', 'upsilon', 'phi', 'chi', 'psi',
+              'omega'])
+
+greek_dictionary = {'Alpha': 'A',
+                    'Beta': 'B',
+                    'Epsilon': 'E',
+                    'Zeta': 'Z',
+                    'Eta': 'H',
+                    'Iota': 'I',
+                    'Kappa': 'K',
+                    'Mu': 'M',
+                    'Nu': 'N',
+                    'omicron': 'o',
+                    'Omicron': 'O',
+                    'Rho': 'P',
+                    'Tau': 'T',
+                    'Chi': 'X',
+                    'lamda': r'\lambda',
+                    'Lamda': r'\Lambda',
+                   }
+
+other_symbols = set(['aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth', 'hbar',
+                     'hslash', 'mho', ])
 
 
 class LatexPrinter(Printer):
@@ -449,9 +475,11 @@ class LatexPrinter(Printer):
           - if it is a longer name, then put \operatorname{} around it and be
             mindful of undercores in the name
         '''
+        func = translate(func)
+
         if func in accepted_latex_functions:
             name = r"\%s" % func
-        elif len(func) == 1:
+        elif len(func) == 1 or func.startswith('\\'):
             name = func
         else:
             name = r"\operatorname{%s}" % func.replace("_", r"\_")
@@ -1035,26 +1063,6 @@ class LatexPrinter(Printer):
 
         name, supers, subs = split_super_sub(expr.name)
 
-        # translate name, supers and subs to tex keywords
-        greek = set([ 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta',
-                      'eta', 'theta', 'iota', 'kappa', 'lambda', 'mu', 'nu',
-                      'xi', 'omicron', 'pi', 'rho', 'sigma', 'tau', 'upsilon',
-                      'phi', 'chi', 'psi', 'omega' ])
-
-        greek_translated = {'lamda': 'lambda', 'Lamda': 'Lambda'}
-
-        other = set( ['aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth',
-                      'hbar', 'hslash', 'mho' ])
-
-        def translate(s):
-            tmp = s.lower()
-            if tmp in greek or tmp in other:
-                return "\\" + s
-            if s in greek_translated:
-                return "\\" + greek_translated[s]
-            else:
-                return s
-
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]
@@ -1622,6 +1630,23 @@ class LatexPrinter(Printer):
 
     def _print_totient(self, expr):
         return r'\phi\left( %s \right)' %  self._print(expr.args[0])
+
+
+def translate(s):
+    '''
+    Given a description of a Greek letter or other special character,
+    return the appropriate latex
+
+    let everything else pass as given
+    '''
+    tex = greek_dictionary.get(s)
+    if tex:
+        return tex
+    elif s.lower() in greeks or s in other_symbols:
+        return "\\" + s
+    else:
+        return s
+
 
 def latex(expr, **settings):
     r"""

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -442,6 +442,9 @@ class LatexPrinter(Printer):
             return r"%s %s" % (tex, self._print(e))
 
     def _print_Function(self, expr, exp=None):
+        '''expr is the expression involving the function
+            exp is an exponent
+        '''
         func = expr.func.__name__
 
         if hasattr(self, '_print_' + func):
@@ -482,6 +485,8 @@ class LatexPrinter(Printer):
             elif exp is not None:
                 if func in accepted_latex_functions:
                     name = r"\%s^{%s}" % (func, exp)
+                elif len(func) == 1:
+                    name = r"%s^{%s}" % (func, exp)
                 else:
                     # If the generic function name contains an underscore, handle it
                     name = r"\operatorname{%s}^{%s}" % (
@@ -489,6 +494,8 @@ class LatexPrinter(Printer):
             else:
                 if func in accepted_latex_functions:
                     name = r"\%s" % func
+                elif len(func) == 1:
+                    name = func
                 else:
                     # If the generic function name contains an underscore, handle it
                     name = r"\operatorname{%s}" % func.replace("_", r"\_")
@@ -507,6 +514,9 @@ class LatexPrinter(Printer):
                 name += r"^{%s}" % exp
 
             return name % ",".join(args)
+
+    def _print_UndefinedFunction(self, expr):
+        return r'\operatorname{%s}' % expr
 
     def _print_Lambda(self, expr):
         symbols, expr = expr.args

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -529,6 +529,9 @@ class LatexPrinter(Printer):
     def _print_UndefinedFunction(self, expr):
         return self._hprint_Function(str(expr))
 
+    def _print_FunctionClass(self, expr):
+        return self._hprint_Function(str(expr))
+
     def _print_Lambda(self, expr):
         symbols, expr = expr.args
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -16,7 +16,7 @@ from sympy import (
     elliptic_e, elliptic_pi, cos, tan)
 
 from sympy.abc import mu, tau
-from sympy.printing.latex import latex
+from sympy.printing.latex import latex, translate
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.functions import DiracDelta, Heaviside, KroneckerDelta, LeviCivita
 from sympy.logic import Implies
@@ -112,6 +112,9 @@ def test_latex_symbols():
     assert latex(Symbol('91')) == r"91"
     assert latex(Symbol('alpha_new')) == r"\alpha_{new}"
     assert latex(Symbol('C^orig')) == r"C^{orig}"
+    assert latex(Symbol('x^alpha')) == r"x^{\alpha}"
+    assert latex(Symbol('beta^alpha')) == r"\beta^{\alpha}"
+    assert latex(Symbol('e^Alpha')) == r"e^{A}"
 
 
 @XFAIL
@@ -236,7 +239,7 @@ def test_latex_functions():
     assert latex(Shi(x)**2) == r'\operatorname{Shi}^{2}{\left (x \right )}'
     assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left (x \right )}'
     assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left (x \right )}'
-    assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}{\left (x \right )}'
+    assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}{\left (x \right )}', latex(Chi(x)**2)
 
     assert latex(
         jacobi(n, a, b, x)) == r'P_{n}^{\left(a,b\right)}\left(x\right)'
@@ -969,7 +972,7 @@ def test_builtins_without_args():
     assert latex(zeta) == r'\zeta'
 
 @XFAIL
-def test_latex_greeks():
+def test_latex_greek_functions():
     # bug because capital greeks that have roman equivalents should not use
     # \Alpha, \Beta, \Eta, etc.
     s = Function('Alpha')
@@ -998,6 +1001,72 @@ def test_latex_greeks():
 
     # bug because the name is 'gamma' but the representation should be \Gamma
     assert latex(gamma) == r'\Gamma'
+
+def test_translate():
+    s = 'Alpha'
+    assert translate(s) == 'A'
+    s = 'Beta'
+    assert translate(s) == 'B'
+    s = 'Eta'
+    assert translate(s) == 'H'
+    s = 'omicron'
+    assert translate(s) == 'o'
+    s = 'Pi'
+    assert translate(s) == r'\Pi'
+    s = 'pi'
+    assert translate(s) == r'\pi'
+
+def test_greek_symbols():
+    assert latex(Symbol('alpha'))   == r'\alpha'
+    assert latex(Symbol('beta'))    == r'\beta'
+    assert latex(Symbol('gamma'))   == r'\gamma'
+    assert latex(Symbol('delta'))   == r'\delta'
+    assert latex(Symbol('epsilon')) == r'\epsilon'
+    assert latex(Symbol('zeta'))    == r'\zeta'
+    assert latex(Symbol('eta'))     == r'\eta'
+    assert latex(Symbol('theta'))   == r'\theta'
+    assert latex(Symbol('iota'))    == r'\iota'
+    assert latex(Symbol('kappa'))   == r'\kappa'
+    assert latex(Symbol('lambda'))  == r'\lambda'
+    assert latex(Symbol('mu'))      == r'\mu'
+    assert latex(Symbol('nu'))      == r'\nu'
+    assert latex(Symbol('xi'))      == r'\xi'
+    assert latex(Symbol('omicron')) == r'o'
+    assert latex(Symbol('pi'))      == r'\pi'
+    assert latex(Symbol('rho'))     == r'\rho'
+    assert latex(Symbol('sigma'))   == r'\sigma'
+    assert latex(Symbol('tau'))     == r'\tau'
+    assert latex(Symbol('upsilon')) == r'\upsilon'
+    assert latex(Symbol('phi'))     == r'\phi'
+    assert latex(Symbol('chi'))     == r'\chi'
+    assert latex(Symbol('psi'))     == r'\psi'
+    assert latex(Symbol('omega'))   == r'\omega'
+
+    assert latex(Symbol('Alpha'))   == r'A'
+    assert latex(Symbol('Beta'))    == r'B'
+    assert latex(Symbol('Gamma'))   == r'\Gamma'
+    assert latex(Symbol('Delta'))   == r'\Delta'
+    assert latex(Symbol('Epsilon')) == r'E'
+    assert latex(Symbol('Zeta'))    == r'Z'
+    assert latex(Symbol('Eta'))     == r'H'
+    assert latex(Symbol('Theta'))   == r'\Theta'
+    assert latex(Symbol('Iota'))    == r'I'
+    assert latex(Symbol('Kappa'))   == r'K'
+    assert latex(Symbol('Lambda'))  == r'\Lambda'
+    assert latex(Symbol('Mu'))      == r'M'
+    assert latex(Symbol('Nu'))      == r'N'
+    assert latex(Symbol('Xi'))      == r'\Xi'
+    assert latex(Symbol('Omicron')) == r'O'
+    assert latex(Symbol('Pi'))      == r'\Pi'
+    assert latex(Symbol('Rho'))     == r'P'
+    assert latex(Symbol('Sigma'))   == r'\Sigma'
+    assert latex(Symbol('Tau'))     == r'T'
+    assert latex(Symbol('Upsilon')) == r'\Upsilon'
+    assert latex(Symbol('Phi'))     == r'\Phi'
+    assert latex(Symbol('Chi'))     == r'X'
+    assert latex(Symbol('Psi'))     == r'\Psi'
+    assert latex(Symbol('Omega'))   == r'\Omega'
+
 
 @XFAIL
 def test_builtin_without_args_mismatched_names():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -129,11 +129,26 @@ def test_latex_functions():
 
     f = Function('f')
     assert latex(f(x)) == r'f{\left (x \right )}'
+    assert latex(f) == r'f'
+
+    g = Function('g')
+    assert latex(g(x, y)) == r'g{\left (x,y \right )}'
+    assert latex(g) == r'g'
+
+    h = Function('h')
+    assert latex(h(x, y, z)) == r'h{\left (x,y,z \right )}'
+    assert latex(h) == r'h'
+
+    Li = Function('Li')
+    assert latex(Li) == r'\operatorname{Li}'
+    assert latex(Li(x)) == r'\operatorname{Li}{\left (x \right )}'
 
     beta = Function('beta')
 
     # not to be confused with the beta function
     assert latex(beta(x)) == r"\beta{\left (x \right )}"
+    assert latex(beta) == r"\beta"
+
     assert latex(sin(x)) == r"\sin{\left (x \right )}"
     assert latex(sin(x), fold_func_brackets=True) == r"\sin {x}"
     assert latex(sin(2*x**2), fold_func_brackets=True) == \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -128,10 +128,11 @@ def test_latex_functions():
     assert latex(exp(1) + exp(2)) == "e + e^{2}"
 
     f = Function('f')
-    assert latex(f(x)) == '\\operatorname{f}{\\left (x \\right )}'
+    assert latex(f(x)) == r'f{\left (x \right )}'
 
     beta = Function('beta')
 
+    # not to be confused with the beta function
     assert latex(beta(x)) == r"\beta{\left (x \right )}"
     assert latex(sin(x)) == r"\sin{\left (x \right )}"
     assert latex(sin(x), fold_func_brackets=True) == r"\sin {x}"
@@ -262,6 +263,11 @@ def test_latex_functions():
 
     assert latex(totient(n)) == r'\phi\left( n \right)'
 
+    # some unknown function name should get rendered with \operatorname
+    fjlkd = Function('fjlkd')
+    assert latex(fjlkd(x)) == r'\operatorname{fjlkd}{\left (x \right )}'
+    # even when it is referred to without an argument
+    assert latex(fjlkd) == r'\operatorname{fjlkd}'
 
 def test_hyper_printing():
     from sympy import pi
@@ -782,20 +788,20 @@ def test_integral_transforms():
     a = Symbol("a")
     b = Symbol("b")
 
-    assert latex(MellinTransform(f(x), x, k)) == r"\mathcal{M}_{x}\left[\operatorname{f}{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == r"\mathcal{M}^{-1}_{k}\left[\operatorname{f}{\left (k \right )}\right]\left(x\right)"
+    assert latex(MellinTransform(f(x), x, k)) == r"\mathcal{M}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
+    assert latex(InverseMellinTransform(f(k), k, x, a, b)) == r"\mathcal{M}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
 
-    assert latex(LaplaceTransform(f(x), x, k)) == r"\mathcal{L}_{x}\left[\operatorname{f}{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == r"\mathcal{L}^{-1}_{k}\left[\operatorname{f}{\left (k \right )}\right]\left(x\right)"
+    assert latex(LaplaceTransform(f(x), x, k)) == r"\mathcal{L}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
+    assert latex(InverseLaplaceTransform(f(k), k, x, (a, b))) == r"\mathcal{L}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
 
-    assert latex(FourierTransform(f(x), x, k)) == r"\mathcal{F}_{x}\left[\operatorname{f}{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseFourierTransform(f(k), k, x)) == r"\mathcal{F}^{-1}_{k}\left[\operatorname{f}{\left (k \right )}\right]\left(x\right)"
+    assert latex(FourierTransform(f(x), x, k)) == r"\mathcal{F}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
+    assert latex(InverseFourierTransform(f(k), k, x)) == r"\mathcal{F}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
 
-    assert latex(CosineTransform(f(x), x, k)) == r"\mathcal{COS}_{x}\left[\operatorname{f}{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseCosineTransform(f(k), k, x)) == r"\mathcal{COS}^{-1}_{k}\left[\operatorname{f}{\left (k \right )}\right]\left(x\right)"
+    assert latex(CosineTransform(f(x), x, k)) == r"\mathcal{COS}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
+    assert latex(InverseCosineTransform(f(k), k, x)) == r"\mathcal{COS}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
 
-    assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[\operatorname{f}{\left (x \right )}\right]\left(k\right)"
-    assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[\operatorname{f}{\left (k \right )}\right]\left(x\right)"
+    assert latex(SineTransform(f(x), x, k)) == r"\mathcal{SIN}_{x}\left[f{\left (x \right )}\right]\left(k\right)"
+    assert latex(InverseSineTransform(f(k), k, x)) == r"\mathcal{SIN}^{-1}_{k}\left[f{\left (k \right )}\right]\left(x\right)"
 
 
 def test_PolynomialRing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -967,3 +967,41 @@ def test_builtins_without_args():
     assert latex(log) == r'\log'
     assert latex(Ei) == r'\operatorname{Ei}'
     assert latex(zeta) == r'\zeta'
+
+@XFAIL
+def test_latex_greeks():
+    # bug because capital greeks that have roman equivalents should not use
+    # \Alpha, \Beta, \Eta, etc.
+    s = Function('Alpha')
+    assert latex(s) == r'A'
+    s = Function('Beta')
+    assert latex(s) == r'B'
+    s = Function('Eta')
+    assert latex(s) == r'H'
+
+    s = symbols('Alpha')
+    assert latex(s) == r'A'
+    s = symbols('Beta')
+    assert latex(s) == r'B'
+    s = symbols('Eta')
+    assert latex(s) == r'H'
+
+    # bug because sympy.core.numbers.Pi is special
+    p = Function('Pi')
+    assert latex(p(x)) == r'\Pi{\left (x \right )}'
+    assert latex(p) == r'\Pi'
+
+    # bug because not all greeks are included
+    c = Function('chi')
+    assert latex(c(x)) == r'\chi{\left (x \right )}'
+    assert latex(c) == r'\chi'
+
+    # bug because the name is 'gamma' but the representation should be \Gamma
+    assert latex(gamma) == r'\Gamma'
+
+@XFAIL
+def test_builtin_without_args_mismatched_names():
+    assert latex(KroneckerDelta) == r'\delta'
+    assert latex(DiracDelta) == r'\delta'
+    assert latex(CosineTransform) == r'\mathcal{COS}'
+    assert latex(lowergamma) == r'\gamma'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -13,7 +13,7 @@ from sympy import (
     hyper, im, im, jacobi, laguerre, legendre, lerchphi, log, lowergamma,
     meijerg, oo, polar_lift, polylog, re, re, root, sin, sqrt, symbols,
     uppergamma, zeta, subfactorial, totient, elliptic_k, elliptic_f,
-    elliptic_e, elliptic_pi)
+    elliptic_e, elliptic_pi, cos, tan)
 
 from sympy.abc import mu, tau
 from sympy.printing.latex import latex
@@ -959,3 +959,11 @@ def test_boolean_args_order():
 def test_imaginary():
     i = sqrt(-1)
     assert latex(i) == r'i'
+
+def test_builtins_without_args():
+    assert latex(sin) == r'\sin'
+    assert latex(cos) == r'\cos'
+    assert latex(tan) == r'\tan'
+    assert latex(log) == r'\log'
+    assert latex(Ei) == r'\operatorname{Ei}'
+    assert latex(zeta) == r'\zeta'


### PR DESCRIPTION
copied from the mailing list:

I noticed something about rendering of symbolic functions into latex. Currently, \operatorname is applied to all functions, even single letter ones when they are rendered with an argument, but not when they are rendered without the argument.  The following code in SymPy Live illustrates this point:

f, f(x)

I would say that the former is more correct and looks better. I have a set of patches that would change the behavior as I suggest. You can see the diff below. Even if you thing that \operatorname should be used on single character functions, I think it should at least be consistent.

ALSO (this was not in my post to the mailing list): if you render a multi-character function name without arguments, you don't get \operatorname{} around it, which looks strange:

In [3]: ijkl = Function('ijkl')

In [4]: latex(ijkl)
Out[4]: ijkl

In [5]: latex(ijkl(x))
Out[5]: \operatorname{ijkl}{\left (x \right )}

I have fixed both issues.
