### PR TITLE
3717: Factors cleanup and non-integer exponent handling

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -12,7 +12,7 @@ from sympy.core.singleton import S
 
 class Basic(object):
     """
-    Base class for all objects in sympy.
+    Base class for all objects in SymPy.
 
     Conventions:
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1027,7 +1027,7 @@ class Expr(Basic, EvalfMixin):
         if c and split_1 and (
             c[0].is_Number and
             c[0].is_negative and
-                c[0] != S.NegativeOne):
+                c[0] is not S.NegativeOne):
             c[:1] = [S.NegativeOne, -c[0]]
 
         if cset:

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -109,8 +109,9 @@ class Factors(object):
         performed: powers of -1 and I are made canonical.
 
         """
-        if isinstance(factors, (int, float, long)):
+        if isinstance(factors, (SYMPY_INTS, float)):
             factors = S(factors)
+
         if isinstance(factors, Factors):
             factors = factors.factors.copy()
         elif factors is None or factors is S.One:
@@ -154,12 +155,12 @@ class Factors(object):
 
             handle = []
             for k in factors:
-                if k is S.NegativeOne or k is I or k == 1:
+                if k is I or k in (-1, 1):
                     handle.append(k)
             if handle:
                 i1 = S.One
                 for k in handle:
-                    if not isinstance(factors[k], (Rational, int, float, long)):
+                    if not _isnumber(factors[k]):
                         continue
                     i1 *= k**factors.pop(k)
                 if i1 is not S.One:

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -324,7 +324,24 @@ class Factors(object):
                         del self_factors[factor]
                         del other_factors[factor]
                 else:
-                    other_factors[factor] = other_exp
+                    sc, sa = self_exp.as_coeff_Add()
+                    if sc:
+                        oc, oa = other_exp.as_coeff_Add()
+                        diff = sc - oc
+                        if diff > 0:
+                            self_factors[factor] -= oc
+                            other_exp = oa
+                        elif diff < 0:
+                            self_factors[factor] -= sc
+                            other_factors[factor] -= sc
+                            other_exp = oa - diff
+                        else:
+                            self_factors[factor] = sa
+                            other_exp = oa
+                    if other_exp:
+                        other_factors[factor] = other_exp
+                    else:
+                        del other_factors[factor]
 
         return Factors(self_factors), Factors(other_factors)
 
@@ -406,7 +423,24 @@ class Factors(object):
                         else:  # should be handled already
                             del quo[factor]
                     else:
-                        rem[factor] = exp
+                        other_exp = exp
+                        sc, sa = quo[factor].as_coeff_Add()
+                        if sc:
+                            oc, oa = other_exp.as_coeff_Add()
+                            diff = sc - oc
+                            if diff > 0:
+                                quo[factor] -= oc
+                                other_exp = oa
+                            elif diff < 0:
+                                quo[factor] -= sc
+                                other_exp = oa - diff
+                            else:
+                                quo[factor] = sa
+                                other_exp = oa
+                        if other_exp:
+                            rem[factor] = other_exp
+                        else:
+                            assert factor not in rem
                     continue
 
             rem[factor] = exp

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1154,6 +1154,8 @@ def test_args_cnc():
     raises(ValueError, lambda: Mul(x, x, evaluate=False).args_cnc(cset=True))
     assert Mul(x, y, x, evaluate=False).args_cnc() == \
         [[x, y, x], []]
+    # always split -1 from leading number
+    assert (-1.*x).args_cnc() == [[-1, 1.0, x], []]
 
 
 def test_new_rawargs():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -20,13 +20,13 @@ def test_decompose_power():
 
 
 def test_Factors():
-    assert Factors() == Factors({}) == Factors(1)
-
+    assert Factors() == Factors({}) == Factors(S(1))
+    raises(ValueError, lambda: Factors(S.Infinity))
     assert Factors().as_expr() == S.One
     assert Factors({x: 2, y: 3, sin(x): 4}).as_expr() == x**2*y**3*sin(x)**4
 
     a = Factors({x: 5, y: 3, z: 7})
-    b = Factors({y: 4, z: 3, t: 10})
+    b = Factors({      y: 4, z: 3, t: 10})
 
     assert a.mul(b) == a*b == Factors({x: 5, y: 7, z: 10, t: 10})
 
@@ -55,12 +55,16 @@ def test_Factors():
     assert Factors(S(2)**x).div(S(3)**x) == \
         (Factors({S(2): x}), Factors({S(3): x}))
     assert Factors(2**(2*x + 2)).div(S(8)) == \
-        (Factors({S(2): 2*x}), Factors({S(2): S(1)}))
+        (Factors({S(2): 2*x + 2}), Factors({S(8): S(1)}))
 
     # coverage
     # /!\ things break if this is not True
     assert Factors({S(-1): S(3)/2}) == Factors({I: S.One, S(-1): S.One})
+    assert Factors({I: S(1), S(-1): S(1)/3}).as_expr() == I*(-1)**(S(1)/3)
 
+    assert Factors(-1.) == Factors({S(-1): S(1), S(1.): 1})
+    assert Factors(-2.) == Factors({S(-1): S(1), S(2.): 1})
+    assert Factors((-2.)**x) == Factors({S(-2.): x})
     assert Factors(S(-2)) == Factors({S(-1): S(1), S(2): 1})
     assert Factors(S.Half) == Factors({S(2): -S.One})
     assert Factors(S(3)/2) == Factors({S(3): S.One, S(2): S(-1)})
@@ -71,6 +75,7 @@ def test_Factors():
     assert Factors(I) == Factors({I: S.One})
     assert Factors(x).normal(S(2)) == (Factors(x), Factors(S(2)))
     assert Factors(x).normal(S(0)) == (Factors(), Factors(S(0)))
+    raises(ZeroDivisionError, lambda: Factors(x).div(S(0)))
     assert Factors(x).mul(S(2)) == Factors(2*x)
     assert Factors(x).mul(S(0)).is_zero
     assert Factors(x).mul(1/x).is_one
@@ -78,13 +83,22 @@ def test_Factors():
     assert Factors(x)**Factors(S(2)) == Factors(x**2)
     assert Factors(x).gcd(S(0)) == Factors(x)
     assert Factors(x).lcm(S(0)).is_zero
-    assert Factors(S(0)).div(x) == (Factors(S(0)), Factors(S(0)))
-    assert Factors(x).div(x) == (Factors(), Factors(S(0)))
+    assert Factors(S(0)).div(x) == (Factors(S(0)), Factors())
+    assert Factors(x).div(x) == (Factors(), Factors())
     assert Factors({x: .2})/Factors({x: .2}) == Factors()
     assert Factors(x) != Factors()
-    assert Factors(x**(2 + y)).div(x**2) == (Factors(x**y), Factors(S(0)))
-    assert Factors(x**(2 + y)).div(x**y) == (Factors(x**2), Factors(S(0)))
-    raises(ZeroDivisionError, lambda: Factors(x).div(S(0)))
+    assert Factors(S(0)).normal(x) == (Factors(S(0)), Factors())
+    n, d = x**(2 + y), x**2
+    f = Factors(n)
+    assert f.div(d) == f.normal(d) == (Factors(x**y), Factors())
+    d = x**y
+    assert f.div(d) == f.normal(d) == (Factors(x**2), Factors())
+    n = d = 2**x
+    f = Factors(n)
+    assert f.div(d) == f.normal(d) == (Factors(), Factors())
+    n, d = 2**x, 2**y
+    f = Factors(n)
+    assert f.div(d) == f.normal(d) == (Factors({S(2): x}), Factors({S(2): y}))
 
 
 def test_Term():

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -100,6 +100,26 @@ def test_Factors():
     f = Factors(n)
     assert f.div(d) == f.normal(d) == (Factors({S(2): x}), Factors({S(2): y}))
 
+    # extraction of constant only
+    n = x**(x + 3)
+    assert Factors(n).normal(x**-3) == (Factors({x: x + 6}), Factors({}))
+    assert Factors(n).normal(x**3) == (Factors({x: x}), Factors({}))
+    assert Factors(n).normal(x**4) == (Factors({x: x}), Factors({x: 1}))
+    assert Factors(n).normal(x**(y - 3)) == \
+        (Factors({x: x + 6}), Factors({x: y}))
+    assert Factors(n).normal(x**(y + 3)) == (Factors({x: x}), Factors({x: y}))
+    assert Factors(n).normal(x**(y + 4)) == \
+        (Factors({x: x}), Factors({x: y + 1}))
+
+    assert Factors(n).div(x**-3) == (Factors({x: x + 6}), Factors({}))
+    assert Factors(n).div(x**3) == (Factors({x: x}), Factors({}))
+    assert Factors(n).div(x**4) == (Factors({x: x}), Factors({x: 1}))
+    assert Factors(n).div(x**(y - 3)) == \
+        (Factors({x: x + 6}), Factors({x: y}))
+    assert Factors(n).div(x**(y + 3)) == (Factors({x: x}), Factors({x: y}))
+    assert Factors(n).div(x**(y + 4)) == \
+        (Factors({x: x}), Factors({x: y + 1}))
+
 
 def test_Term():
     a = Term(4*x*y**2/z/t**3)

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -69,6 +69,7 @@ def test_Factors():
     assert Factors(S.Half) == Factors({S(2): -S.One})
     assert Factors(S(3)/2) == Factors({S(3): S.One, S(2): S(-1)})
     assert Factors({I: S(1)}) == Factors(I)
+    assert Factors({-1.0: 2, I: 1}) == Factors({S(1.0): 1, I: 1})
     assert Factors({S.NegativeOne: -S(3)/2}).as_expr() == I
     A = symbols('A', commutative=False)
     assert Factors(2*A**2) == Factors({S(2): 1, A**2: 1})

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -9,6 +9,8 @@ from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
 from sympy.core.mul import _keep_coeff as _keep_coeff
 from sympy.simplify.cse_opts import sub_pre
 
+from sympy.utilities.pytest import raises
+
 
 def test_decompose_power():
     assert decompose_power(x) == (x, 1)
@@ -45,6 +47,45 @@ def test_Factors():
     assert a.normal(b) == (Factors({x: 4, y: 7, t: 4}), Factors({z: 1}))
 
     assert Factors(sqrt(2)*x).as_expr() == sqrt(2)*x
+
+    assert Factors(-I)*I == Factors()
+    assert Factors({S(-1): S(3)})*Factors({S(-1): S(1), I: S(5)}) == \
+        Factors(I)
+
+    assert Factors(S(2)**x).div(S(3)**x) == \
+        (Factors({S(2): x}), Factors({S(3): x}))
+    assert Factors(2**(2*x + 2)).div(S(8)) == \
+        (Factors({S(2): 2*x}), Factors({S(2): S(1)}))
+
+    # coverage
+    # /!\ things break if this is not True
+    assert Factors({S(-1): S(3)/2}) == Factors({I: S.One, S(-1): S.One})
+
+    assert Factors(S(-2)) == Factors({S(-1): S(1), S(2): 1})
+    assert Factors(S.Half) == Factors({S(2): -S.One})
+    assert Factors(S(3)/2) == Factors({S(3): S.One, S(2): S(-1)})
+    assert Factors({I: S(1)}) == Factors(I)
+    assert Factors({S.NegativeOne: -S(3)/2}).as_expr() == I
+    A = symbols('A', commutative=False)
+    assert Factors(2*A**2) == Factors({S(2): 1, A**2: 1})
+    assert Factors(I) == Factors({I: S.One})
+    assert Factors(x).normal(S(2)) == (Factors(x), Factors(S(2)))
+    assert Factors(x).normal(S(0)) == (Factors(), Factors(S(0)))
+    assert Factors(x).mul(S(2)) == Factors(2*x)
+    assert Factors(x).mul(S(0)).is_zero
+    assert Factors(x).mul(1/x).is_one
+    assert Factors(x**sqrt(2)**3).as_expr() == x**(2*sqrt(2))
+    assert Factors(x)**Factors(S(2)) == Factors(x**2)
+    assert Factors(x).gcd(S(0)) == Factors(x)
+    assert Factors(x).lcm(S(0)).is_zero
+    assert Factors(S(0)).div(x) == (Factors(S(0)), Factors(S(0)))
+    assert Factors(x).div(x) == (Factors(), Factors(S(0)))
+    assert Factors({x: .2})/Factors({x: .2}) == Factors()
+    assert Factors(x) != Factors()
+    assert Factors(x**(2 + y)).div(x**2) == (Factors(x**y), Factors(S(0)))
+    assert Factors(x**(2 + y)).div(x**y) == (Factors(x**2), Factors(S(0)))
+    raises(ZeroDivisionError, lambda: Factors(x).div(S(0)))
+
 
 def test_Term():
     a = Term(4*x*y**2/z/t**3)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1563,7 +1563,7 @@ def collect_const(expr, *vars, **kwargs):
         for m in Add.make_args(expr):
             f = Factors(m)
             q, r = f.div(Fv)
-            if r.is_zero:
+            if r.is_one:
                 # only accept this as a true factor if
                 # it didn't change an exponent from an Integer
                 # to a non-Integer, e.g. 2/sqrt(2) -> sqrt(2)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1567,10 +1567,10 @@ def collect_const(expr, *vars, **kwargs):
                 # only accept this as a true factor if
                 # it didn't change an exponent from an Integer
                 # to a non-Integer, e.g. 2/sqrt(2) -> sqrt(2)
-                # but we aren't looking for this sort of change
+                # -- we aren't looking for this sort of change
                 fwas = f.factors.copy()
                 fnow = q.factors
-                if not any(fwas[k].is_Integer and not
+                if not any(k in fwas and fwas[k].is_Integer and not
                         fnow[k].is_Integer for k in fnow):
                     terms[v].append(q.as_expr())
                     continue
@@ -3676,7 +3676,7 @@ def nsimplify(expr, constants=[], tolerance=None, full=False, rational=None):
     if rational or expr.free_symbols:
         return _real_to_rational(expr, tolerance)
 
-    # sympy's default tolarance for Rationals is 15; other numbers may have
+    # SymPy's default tolerance for Rationals is 15; other numbers may have
     # lower tolerances set, so use them to pick the largest tolerance if None
     # was given
     if tolerance is None:

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1,4 +1,7 @@
 from __future__ import with_statement
+
+from random import randrange
+
 from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
                        MeijerShiftA, MeijerShiftB, MeijerShiftC, MeijerShiftD,
                        MeijerUnShiftA, MeijerUnShiftB, MeijerUnShiftC,
@@ -13,7 +16,6 @@ from sympy.utilities.pytest import raises
 from sympy.abc import z, a, b, c
 from sympy.utilities.randtest import test_numerically as tn
 from sympy.utilities.pytest import XFAIL, skip, slow
-from random import randrange
 
 from sympy import (cos, sin, log, exp, asin, lowergamma, atanh, besseli,
                    gamma, sqrt, pi, erf, exp_polar)
@@ -45,10 +47,8 @@ def can_do(ap, bq, numerical=True, div=1, lowerplane=False):
     r = hyperexpand(hyper(ap, bq, z))
     if r.has(hyper):
         return False
-
     if not numerical:
         return True
-
     repl = {}
     for n, a in enumerate(r.free_symbols - set([z])):
         repl[a] = randcplx(n)/div
@@ -56,8 +56,9 @@ def can_do(ap, bq, numerical=True, div=1, lowerplane=False):
     if lowerplane:
         [a, b, c, d] = [2, -2, 3, -1]
     return tn(
-        hyper(ap, bq, z).subs(repl), r.replace(exp_polar, exp).subs(repl), z,
-        a=a, b=b, c=c, d=d)
+        hyper(ap, bq, z).subs(repl),
+        r.replace(exp_polar, exp).subs(repl),
+        z, a=a, b=b, c=c, d=d)
 
 
 def test_roach():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1370,13 +1370,11 @@ def test_radsimp():
     assert radsimp(1/(r2*3)) == \
         sqrt(2)/6
     assert radsimp(1/(r2*a + r3 + r5 + r7)) == 1/(r2*a + r3 + r5 + r7)
-    assert radsimp(1/(r2*a + r2*b + r3 + r7)) == \
-        ((sqrt(42)*(a + b) +
-        sqrt(3)*(-a**2 - 2*a*b - b**2 - 2) +
-        sqrt(7)*(-a**2 - 2*a*b - b**2 + 2) +
-        sqrt(2)*(a**3 + 3*a**2*b + 3*a*b**2 - 5*a + b**3 - 5*b))/
-        ((a**4 + 4*a**3*b + 6*a**2*b**2 - 10*a**2 +
-        4*a*b**3 - 20*a*b + b**4 - 10*b**2 + 4)))/2
+    assert radsimp(1/(r2*a + r2*b + r3 + r7)) == (
+        sqrt(42)*(a + b) + sqrt(3)*(-a**2 - 2*a*b - b**2 - 2) +
+        sqrt(7)*(-a**2 - 2*a*b - b**2 + 2) + sqrt(2)*(a**3 + 3*a**2*b +
+        3*a*b**2 - 5*a + b**3 - 5*b))/(a**4 + 4*a**3*b + 6*a**2*b**2 -
+        10*a**2 + 4*a*b**3 - 20*a*b + b**4 - 10*b**2 + 4)/2
     assert radsimp(1/(r2*a + r2*b + r2*c + r2*d)) == \
         (sqrt(2)/(a + b + c + d))/2
     assert radsimp(1/(1 + r2*a + r2*b + r2*c + r2*d)) == \


### PR DESCRIPTION
I tried removing I altogether from the factors, storing it as
-1**(1/2) but then there were transform tests that failed.

denominators of Rationals are given a negative exponent. This is
not done with Expr factors -- this is not suppose to be handling
rational expressions, really.

@pernici , I pulled this out of the other work since you've already given it a glance. It's simpler now than before. Can you give it a final review?
