### PR TITLE
Specify minimal version of the coverage module for coverage_report.py

### DIFF
--- a/bin/coverage_report.py
+++ b/bin/coverage_report.py
@@ -27,12 +27,16 @@ import re
 import sys
 from optparse import OptionParser
 
+minver = '3.4'
 try:
     import coverage
+    if coverage.__version__ < minver:
+        raise ImportError
 except ImportError:
-    print ("You need to install module coverage.\n"
-    "See http://nedbatchelder.com/code/coverage/ or \n"
-    "https://launchpad.net/ubuntu/+source/python-coverage/")
+    print(
+        "You need to install module coverage (version %s or newer required).\n"
+        "See http://nedbatchelder.com/code/coverage/ or \n"
+        "https://launchpad.net/ubuntu/+source/python-coverage/" % minver)
     sys.exit(-1)
 
 REPORT_DIR = "covhtml"


### PR DESCRIPTION
BTW: I can't find related changelog lines, but it seems that the issue 2708 is fixed too (for ver >= 3.4).

I'm not sure that 3.4 is the _minimal_ required version (this one is coming with Debian Wheezy).  But for some older versions this script just breaks down (e.g. for Debian Squeeze):

```
$ ./bin/coverage_report.py 
Traceback (most recent call last):
  File "./bin/coverage_report.py", line 104, in <module>
    make_report(source_dir, **options.__dict__)
  File "./bin/coverage_report.py", line 66, in make_report
    cov = coverage.coverage()
  File "/usr/lib/python2.6/dist-packages/coverage.py", line 303, in __init__
    raise CoverageException("Only one coverage object allowed.")
coverage.CoverageException: Only one coverage object allowed.
```
