### PR TITLE
Fix exception while series expansion of function with multiple args

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -501,7 +501,8 @@ class Function(Application, Expr):
             s = s.removeO()
             s = s.subs(v, zi).expand() + C.Order(o.expr.subs(v, zi), x)
             return s
-        if (self.func.nargs == 1 and args0[0]) or self.func.nargs > 1:
+        if (self.func.nargs == 1 and args0[0]) or \
+           isinstance(self.func.nargs, tuple) or self.func.nargs > 1:
             e = self
             e1 = e.expand()
             if e == e1:

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, zeta, nan, Rational, Float, pi, dirichlet_eta, log,
-                   zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I, exp_polar,
-                   polar_lift)
+                   zoo, expand_func, polylog, lerchphi, S, exp, sqrt, I,
+                   exp_polar, polar_lift, O)
 from sympy.utilities.randtest import (test_derivative_numerically as td,
                       random_complex_number as randcplx, test_numerically as tn)
 from sympy.utilities.pytest import XFAIL
@@ -60,6 +60,11 @@ def test_zeta_eval():
 
     assert zeta(
         3).evalf(20).epsilon_eq(Float("1.2020569031595942854", 20), 1e-19)
+
+
+def test_zeta_series():
+    assert zeta(x, a).series(a, 0, 2) == \
+        zeta(x, 0) - x*a*zeta(x + 1, 0) + O(a**2)
 
 
 def test_dirichlet_eta_eval():


### PR DESCRIPTION
```
>>> zeta(x, y).series(y, 0, 2)
    Traceback (most recent call last):
      File "<console>", line 1, in <module>
      File "/home/sk/sympy/py3k-sympy/sympy/core/expr.py", line 2360, in
    series
        s1 = self._eval_nseries(x, n=n, logx=None)
      File "/home/sk/sympy/py3k-sympy/sympy/core/function.py", line 502, in
    _eval_nseries
        if (self.func.nargs == 1 and args0[0]) or self.func.nargs > 1:
    TypeError: unorderable types: tuple() > int()
```

An example of this failure (python3 specific) is in PR #1977.
