### PR TITLE
Fixing tiny syntax errors occurring during compilation.

### DIFF
--- a/sympy/mpmath/tests/extratest_gamma.py
+++ b/sympy/mpmath/tests/extratest_gamma.py
@@ -47,7 +47,7 @@ def check(name, func, z, y):
         if raise_:
             raise SystemExit
     if not err:
-        print("%s ok;" % name, end=' ')
+        print("%s ok;" % name)
 
 def testcase(case):
     z, result = case

--- a/sympy/mpmath/tests/torture.py
+++ b/sympy/mpmath/tests/torture.py
@@ -77,7 +77,7 @@ def test_asymp(f, maxdps=150, verbose=False, huge_range=False):
         exponents += [-1000, -100, -50, 50, 100, 1000]
     for n in exponents:
         if verbose:
-            print(".", end=' ')
+            print(".")
         mp.dps = 25
         xpos = mpf(10)**n / 1.1287
         xneg = -xpos


### PR DESCRIPTION
There are three tiny syntax errors in total. I am not sure what to do for the third one.

byte-compiling /usr/local/lib/python2.7/dist-packages/sympy/mpmath/tests/extratest_gamma.py to extratest_gamma.pyc
SyntaxError: ('invalid syntax', ('/usr/local/lib/python2.7/dist-packages/sympy/mpmath/tests/extratest_gamma.py', 50, 35, '        print("%s ok;" % name, end=\' \')\n'))

byte-compiling /usr/local/lib/python2.7/dist-packages/sympy/mpmath/tests/torture.py to torture.pyc
SyntaxError: ('invalid syntax', ('/usr/local/lib/python2.7/dist-packages/sympy/mpmath/tests/torture.py', 80, 27, '            print(".", end=\' \')\n'))

byte-compiling /usr/local/lib/python2.7/dist-packages/sympy/mpmath/libmp/exec_py3.py to exec_py3.pyc
SyntaxError: ('invalid syntax', ('/usr/local/lib/python2.7/dist-packages/sympy/mpmath/libmp/exec_py3.py', 1, 12, 'exec_ = exec\n'))
