### PR TITLE
3070: remove Neg from cse_opts and use different mechanism

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2525,13 +2525,10 @@ def test_sympy__series__order__Order():
     assert _test_args(Order(1, x, y))
 
 
-def test_sympy__simplify__cse_opts__Neg():
-    from sympy.simplify.cse_opts import Neg
-    assert _test_args(Neg())
-
 def test_sympy__simplify__hyperexpand__Hyper_Function():
     from sympy.simplify.hyperexpand import Hyper_Function
     assert _test_args(Hyper_Function([2], [1]))
+
 
 def test_sympy__simplify__hyperexpand__G_Function():
     from sympy.simplify.hyperexpand import G_Function

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -784,16 +784,15 @@ def test_M6():
 
 def test_M7():
     assert set(solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
-        226*x**2 - 140*x + 46, x)) == set(
-            [1 + sqrt(-6 + 2*sqrt(-3 - 4*sqrt(3)))/2,
-        1 + sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 + sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 - 2*sqrt(-3 - 4*sqrt(3)))/2,
-        1 - sqrt(-6 + 2*sqrt(-3 - 4*sqrt(3)))/2,
-        1 + sqrt(-6 - 2*sqrt(-3 - 4*sqrt(3)))/2])
-
+        226*x**2 - 140*x + 46, x)) == set([
+            1 + sqrt(-6 + 2*sqrt(-4*sqrt(3) - 3))/2,
+            1 + sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
+            1 + sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
+            1 - sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
+            1 - sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
+            1 - sqrt(-6 - 2*I*sqrt(3 + 4*sqrt(3)))/2,
+            1 - sqrt(-6 + 2*sqrt(-4*sqrt(3) - 3))/2,
+            1 + sqrt(-6 - 2*I*sqrt(3 + 4*sqrt(3)))/2,])
 
 @XFAIL  # There are an infinite number of solutions.
 def test_M8():

--- a/sympy/simplify/cse_opts.py
+++ b/sympy/simplify/cse_opts.py
@@ -4,30 +4,26 @@ opportunities.
 from sympy.core import Add, Basic, Expr, Mul
 from sympy.core.basic import preorder_traversal
 from sympy.core.exprtools import factor_terms
+from sympy.core.singleton import S
 from sympy.utilities.iterables import default_sort_key
 
 
-class Neg(Expr):
-    """ Stub to hold negated expression.
-    """
-    __slots__ = []
-
-
 def sub_pre(e):
-    """ Replace y - x with Neg(x - y) if -1 can be extracted from y - x.
+    """ Replace y - x with -(x - y) if -1 can be extracted from y - x.
     """
     reps = [a for a in e.atoms(Add) if a.could_extract_minus_sign()]
 
     # make it canonical
     reps.sort(key=default_sort_key)
 
-    e = e.subs([(a, Mul(-1, -a, evaluate=False)) for a in reps])
-    # now replace any persisting Adds, a, that can have -1 extracted with Neg(-a)
+    e = e.subs([(a, Mul._from_args([S.NegativeOne, -a])) for a in reps])
+    # repeat again for persisting Adds but mark these with a leading 1, -1
+    # e.g. y - x -> 1*-1*(x - y)
     if isinstance(e, Basic):
         negs = {}
         for a in sorted(e.atoms(Add), key=default_sort_key):
             if a in reps or a.could_extract_minus_sign():
-                negs[a] = Neg(-a)
+                negs[a] = Mul._from_args([S.One, S.NegativeOne, -a])
         e = e.xreplace(negs)
     return e
 
@@ -37,12 +33,13 @@ def sub_post(e):
     """
     replacements = []
     for node in preorder_traversal(e):
-        if isinstance(node, Neg):
-            replacements.append((node, -node.args[0]))
+        if isinstance(node, Mul) and node.args[:2] is (S.One, S.NegativeOne):
+            replacements.append((node, -node))
     for node, replacement in replacements:
         e = e.xreplace({node: replacement})
 
     return e
+
 
 default_optimizations = [
     (sub_pre, sub_post),

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -230,9 +230,15 @@ def test_issue1400():
 
     c = cse(t)
     ans = (
-        [(x0, sqrt(z)), (x1, -b + 1), (x2, B(b, x0)), (x3, 2*a + x1 - 1),
-        (x4, B(-x1, x0)), (x5, x3 + 1), (x6, B(x3, x0)), (x7, B(x5, x0)), (x8,
-        2*a), (x9, (x0/2)**(-2*a + 1)*G(b)*G(x5)), (x10, x0*x9)], [(a, a +
-        S(1)/2, x8, b, x5, x4*x6*x9, x10*x2*x6, x10*x4*x7, x2*x7*x9, 1, 0,
-        S(1)/2, z/2, x1, -x3, -x8)])
+        [(x0, sqrt(z)), (x1, -b + 1), (x2, B(b, x0)), (x3, B(-x1, x0)), (x4,
+        2*a + x1), (x5, B(x4 - 1, x0)), (x6, B(x4, x0)), (x7, (x0/2)**(-2*a +
+        1)*G(b)*G(x4))], [(a, a + S(1)/2, 2*a, b, x4, x3*x5*x7, x0*x2*x5*x7,
+        x0*x3*x6*x7, x2*x6*x7, 1, 0, S(1)/2, z/2, x1, -x4 + 1, -2*a)])
     assert ans == c
+
+
+def test_issue_3070():
+    from sympy import RootOf
+    from sympy.abc import x
+    r = RootOf(x**6 - 4*x**5 - 2, 1)
+    assert cse(r) == ([], [r])


### PR DESCRIPTION
Some objects, like RootOf, don't interact well with the Neg mechanism
that cse uses to keep track of Adds that can have a -1 extracted.

1) wrapping an expression in Neg changes the perceived degree of the
expression for Poly (Poly(x**2) is degree 2 but Poly(Neg(x**2)) is
degree 1. Issue 3070 shows why this leads to an error.

2) if Neg is used like a kern so that y - x -> -Neg()*(x - y) that
still causes problems with RootOf because this creates a new generator:

> > > class Neg(Expr):
> > > ...   @property
> > > ...   def is_commutative(self): return True
> > > ...

Poly is ok

> > > Poly(Neg()_x)
> > > Poly(x_Neg(), x, Neg(), domain='ZZ')
> > > 
> > > RootOf(Neg()*x)
> > > Traceback (most recent call last):
> > >  sympy.polys.polyerrors.PolynomialError: <univariate message>

So instead of using Neg, an unevaluated Mul is simply used. Instead
of replacing y - x with -1*(x - y) (since that will be hard to find later
because Muls can have a leading -1) a leading (1, -1) is used instead:

> > > Mul._from_args([S.One,S.NegativeOne])
> > > -1
> > > _.args
> > > (1, -1)

Muls should not start with a leading 1 and even if something does
(because someone used an unevaluated Mul) the storage of the -1
will make the replacement correct in terms of mathematical equality,
1_-1_x is eventually replaced with -x.
