### PR TITLE
factor_terms can remove radical from +/- base

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -805,8 +805,8 @@ class Add(Expr, AssocOp):
                 for ai in Mul.make_args(m):
                     if ai.is_Pow:
                         b, e = ai.as_base_exp()
-                        if e.is_Rational and b.is_Integer and b > 0:
-                            term_rads[e.q].append(int(b)**e.p)
+                        if e.is_Rational and b.is_Integer:
+                            term_rads[e.q].append(abs(int(b))**e.p)
                 if not term_rads:
                     break
                 if common_q is None:

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -1,7 +1,8 @@
 """Tests for tools for manipulating of large commutative expressions. """
 
-from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple,
-                   Interval, O, symbols, simplify, collect, Sum, Basic, Dict)
+from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, I,
+                   Interval, O, symbols, simplify, collect, Sum, Basic, Dict,
+                   root)
 from sympy.abc import a, b, t, x, y, z
 from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
                                   gcd_terms, factor_terms, factor_nc)
@@ -154,9 +155,14 @@ def test_factor_terms():
         x*(a + 2*b)*(y + 1)
     i = Integral(x, (x, 0, oo))
     assert factor_terms(i) == i
+
+    # check radical extraction
     eq = sqrt(2) + sqrt(10)
     assert factor_terms(eq) == eq
     assert factor_terms(eq, radical=True) == sqrt(2)*(1 + sqrt(5))
+    eq = root(-6, 3) + root(6, 3)
+    assert factor_terms(eq, radical=True) == 6**(S(1)/3)*(1 + (-1)**(S(1)/3))
+
     eq = [x + x*y]
     ans = [x*(y + 1)]
     for c in [list, tuple, set]:
@@ -175,7 +181,7 @@ def test_factor_terms():
         y*(2 + 1/(x + 1))/x**2
 
     assert factor_terms(-x - y) == Mul(-1, x + y, evaluate=False)
-    # if not True, then processes for this in factor_terms is not necessary
+    # if not True, then processesing for this in factor_terms is not necessary
     assert gcd_terms(-x - y) == -x - y
 
 


### PR DESCRIPTION
Currently, radicals are only factored out of positive bases; now they can be factored from negative rational bases:

```
>>> root(3,5)+root(-9,5)
3**(1/5) + (-9)**(1/5)
>>> factor_terms(_,radical=1)
3**(1/5)*(1 + (-3)**(1/5))
>>> _.n()
2.50120038155859 + 0.912151942182797*I
>>> root(3,5)+root(-9,5)
3**(1/5) + (-9)**(1/5)
>>> _.n()
2.50120038155859 + 0.912151942182797*I
```
