### PR TITLE
Mod handles more simplification

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -45,8 +45,11 @@ class Mod(Function):
 
             # by ratio
             r = p/q
-            if r.is_number:
+            try:
                 d = int(r)
+            except TypeError:
+                pass
+            else:
                 if type(d) is int:
                     rv = p - d*q
                     if rv*q < 0:

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -1,6 +1,4 @@
 from function import Function
-from sympy.core.numbers import Float
-from sympy.core.function import expand_mul
 
 
 class Mod(Function):
@@ -25,16 +23,107 @@ class Mod(Function):
 
     @classmethod
     def eval(cls, p, q):
-        from sympy.simplify.simplify import nsimplify
-        if q.is_Number:
-            float = not q.is_Rational
-            pnew = expand_mul(p)
-            if pnew.is_Number:
-                float = float or not pnew.is_Rational
-                if not float:
-                    return pnew % q
-                return Float(nsimplify(pnew) % nsimplify(q))
-            elif pnew.is_Add and pnew.args[0].is_Number:
-                r, p = pnew.as_two_terms()
-                p += Mod(r, q)
-        return Mod(p, q, evaluate=False)
+        from sympy.core.add import Add
+        from sympy.core.mul import Mul
+        from sympy.core.numbers import Integer
+        from sympy.core.singleton import S
+        from sympy.core.exprtools import gcd_terms
+        from sympy.functions.elementary.complexes import sign
+        from sympy.polys.polytools import gcd
+        from sympy.utilities.iterables import sift
+
+        def doit(p, q):
+            """Try to return p % q if both are numbers or +/-p is known
+            to be less than q.
+            """
+
+            if p == q or p == -q:
+                return S.Zero
+
+            if p.is_Number and q.is_Number:
+                return (p % q)
+
+            # by ratio
+            r = p/q
+            if r.is_number:
+                d = int(r)
+                if type(d) is int:
+                    rv = p - d*q
+                    if rv*q < 0:
+                        rv += q
+                    return rv
+
+            # by differencec
+            d = p - q
+            if (d < 0) is True:
+                if (q < 0) is True:
+                    return d
+                elif (q > 0) is True:
+                    return p
+
+        rv = doit(p, q)
+        if rv is not None:
+            return rv
+
+        # denest
+        if p.func is cls:
+            # easy
+            qinner = p.args[1]
+            if qinner == q:
+                return p
+            # XXX other possibilities?
+
+        # extract gcd; any further simplification should be done by the user
+        G = gcd(p, q)
+        if G is not S.One:
+            p, q = [
+                gcd_terms(i/G, clear=False, fraction=False) for i in (p, q)]
+        pwas, qwas = p, q
+
+        # simplify terms
+        # (x + y + 2) % x -> Mod(y + 2, x)
+        if p.is_Add:
+            args = []
+            for i in p.args:
+                a = cls(i, q)
+                if a.func is cls or (-a).func is cls:
+                    args.append(i)
+                else:
+                    args.append(a)
+            if args != list(p.args):
+                p = Add(*args)
+
+        else:
+            # handle coefficients if they are not Rational
+            # since those are not handled by factor_terms
+            # e.g. Mod(.6*x, .3*y) -> 0.3*Mod(2*x, y)
+            cp, p = p.as_coeff_Mul()
+            cq, q = q.as_coeff_Mul()
+            ok = False
+            if not cp.is_Rational or not cq.is_Rational:
+                r = cp % cq
+                if r == 0:
+                    G *= cq
+                    p *= int(cp/cq)
+                    ok = True
+            if not ok:
+                p = cp*p
+                q = cq*q
+
+        # simple -1 extraction
+        if p.could_extract_minus_sign() and q.could_extract_minus_sign():
+            G, p, q = [-i for i in (G, p, q)]
+
+        # check again to see if p and q can now be handled as numbers
+        rv = doit(p, q)
+        if rv is not None:
+            return rv*G
+
+        # put 1.0 from G on inside
+        if G.is_Float and G == 1:
+            p *= G
+            return cls(p, q, evaluate=False)
+        elif G.is_Mul and G.args[0].is_Float and G.args[0] == 1:
+            p = G.args[0]*p
+            G = Mul._from_args(G.args[1:])
+        return G*cls(p, q, evaluate=(p, q) != (pwas, qwas))

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -89,7 +89,7 @@ class Mod(Function):
             args = []
             for i in p.args:
                 a = cls(i, q)
-                if a.func is cls or (-a).func is cls:
+                if a.count(cls) > i.count(cls):
                     args.append(i)
                 else:
                     args.append(a)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -4,6 +4,8 @@ from sympy import (Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo, Integer,
 )
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.utilities.randtest import test_numerically
+
 
 x = Symbol('x')
 y = Symbol('y')
@@ -1277,6 +1279,7 @@ def test_issue_2820():
 
 
 def test_Mod():
+    assert Mod(x, 1).func is Mod
     assert Mod(5, 3) == 2
     assert Mod(-5, 3) == 1
     assert Mod(5, -3) == -1
@@ -1287,20 +1290,76 @@ def test_Mod():
     assert x % y == Mod(x, y)
     assert (x % y).subs({x: 5, y: 3}) == 2
     assert (x + 3) % 1 == Mod(x, 1)
-    assert (x + 3.0) % 1 == Mod(x, 1)
+    assert (x + 3.0) % 1 == Mod(1.*x, 1)
     assert (x - S(33)/10) % 1 == Mod(x + S(7)/10, 1)
-    assert (x - 3.3) % 1 == Mod(x + 0.7, 1)
-    assert Mod(-3.3, 1) == Mod(0.7, 1) == Float(0.7)
+    point3 = Float(3.3) % 1
+    assert (x - 3.3) % 1 == Mod(1.*x + 1 - point3, 1)
+    assert Mod(-3.3, 1) == 1 - point3
+    assert Mod(0.7, 1) == Float(0.7)
     e = Mod(1.3, 1)
-    assert e == .3 and e.is_Float
+    point3 = Float._new(Float(.3)._mpf_, 51)
+    assert e == point3 and e.is_Float
     e = Mod(1.3, .7)
-    assert e == .6 and e.is_Float
+    point6 = Float._new(Float(.6)._mpf_, 51)
+    assert e == point6 and e.is_Float
     e = Mod(1.3, Rational(7, 10))
-    assert e == .6 and e.is_Float
+    assert e == point6 and e.is_Float
     e = Mod(Rational(13, 10), 0.7)
-    assert e == .6 and e.is_Float
+    assert e == point6 and e.is_Float
     e = Mod(Rational(13, 10), Rational(7, 10))
     assert e == .6 and e.is_Rational
+    assert Mod(5*sqrt(2), sqrt(5)) == 5*sqrt(2) - 3*sqrt(5)
+    r2 = sqrt(2)
+    r3 = sqrt(3)
+    for i in [-r3, -r2, r2, r3]:
+        for j in [-r3, -r2, r2, r3]:
+            assert test_numerically(i % j, i.n() % j.n())
+    for _x in range(4):
+        for _y in range(9):
+            reps = [(x, _x), (y, _y)]
+            assert Mod(3*x + y, 9).subs(reps) == (3*_x + _y) % 9
+
+    # denesting
+    #   easy case
+    assert Mod(Mod(x, y), y) == Mod(x, y)
+    #   in case someone attempts more denesting
+    for i in [-3, -2, 2, 3]:
+        for j in [-3, -2, 2, 3]:
+            for k in range(3):
+                # print i, j, k
+                assert Mod(Mod(k, i), j) == (k % i) % j
+
+    # known difference
+    p = symbols('p', positive=True)
+    assert Mod(p + 1, p + 3) == p + 1
+    n = symbols('n', negative=True)
+    assert Mod(n - 3, n - 1) == -2
+    assert Mod(n - 2*p, n - p) == -p
+    assert Mod(p - 2*n, p - n) == -n
+
+    i = Symbol('i', integer=True)
+    assert pi%pi == S.Zero
+    assert (-3*x)%(-2*y) == -Mod(3*x, 2*y)
+    assert (3*i*x)%(2*i*y) == i*Mod(3*x, 2*y)
+    assert (.6*pi)%(.3*x*pi) == 0.3*pi*Mod(2, x)
+    assert (.6*pi)%(.31*x*pi) == pi*Mod(0.6, 0.31*x)
+    assert (6*pi)%(.3*x*pi) == pi*Mod(6, 0.3*x)
+    assert (6*pi)%(.31*x*pi) == pi*Mod(6, 0.31*x)
+    assert (6*pi)%(.42*x*pi) == pi*Mod(6, 0.42*x)
+    assert (12*x)%(2*y) == 2*Mod(6*x, y)
+    assert (12*x)%(3*5*y) == 3*Mod(4*x, 5*y)
+    assert (12*x)%(15*x*y) == 3*x*Mod(4, 5*y)
+    assert sqrt(2) % sqrt(5) == sqrt(2)
+    assert -sqrt(2) % sqrt(5) == sqrt(5) - sqrt(2)
+    assert (-2*pi)%(3*pi) == pi
+    assert (2*x + 2) % (x + 1) == 0
+    assert (x + 1) % x == 1 % x
+    assert (x + y) % x == y % x
+    assert (x + y + 2) % x == (y + 2) % x
+    assert (x*(x + 1)) % (x+1) == (x + 1)*Mod(x, 1)
+    assert (a + 3*x + 1)%(2*x) == Mod(a + x + 1, 2*x)
+    assert (12*x + 18*y)%(3*x) == 3*Mod(6*y, x)
+    assert Mod(5.0*x, 0.1*y) == 0.1*Mod(50*x, y)
 
 
 def test_issue_2902():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1280,6 +1280,7 @@ def test_issue_2820():
 
 def test_Mod():
     assert Mod(x, 1).func is Mod
+    assert pi % pi == S.Zero
     assert Mod(5, 3) == 2
     assert Mod(-5, 3) == 1
     assert Mod(5, -3) == -1
@@ -1289,9 +1290,8 @@ def test_Mod():
     assert x % 5 == Mod(x, 5)
     assert x % y == Mod(x, y)
     assert (x % y).subs({x: 5, y: 3}) == 2
-    assert (x + 3) % 1 == Mod(x, 1)
-    assert (x + 3.0) % 1 == Mod(1.*x, 1)
-    assert (x - S(33)/10) % 1 == Mod(x + S(7)/10, 1)
+
+    # Float handling
     point3 = Float(3.3) % 1
     assert (x - 3.3) % 1 == Mod(1.*x + 1 - point3, 1)
     assert Mod(-3.3, 1) == 1 - point3
@@ -1308,7 +1308,8 @@ def test_Mod():
     assert e == point6 and e.is_Float
     e = Mod(Rational(13, 10), Rational(7, 10))
     assert e == .6 and e.is_Rational
-    assert Mod(5*sqrt(2), sqrt(5)) == 5*sqrt(2) - 3*sqrt(5)
+
+    # check that sign is right
     r2 = sqrt(2)
     r3 = sqrt(3)
     for i in [-r3, -r2, r2, r3]:
@@ -1330,6 +1331,7 @@ def test_Mod():
                 assert Mod(Mod(k, i), j) == (k % i) % j
 
     # known difference
+    assert Mod(5*sqrt(2), sqrt(5)) == 5*sqrt(2) - 3*sqrt(5)
     p = symbols('p', positive=True)
     assert Mod(p + 1, p + 3) == p + 1
     n = symbols('n', negative=True)
@@ -1337,29 +1339,33 @@ def test_Mod():
     assert Mod(n - 2*p, n - p) == -p
     assert Mod(p - 2*n, p - n) == -n
 
-    i = Symbol('i', integer=True)
-    assert pi%pi == S.Zero
-    assert (-3*x)%(-2*y) == -Mod(3*x, 2*y)
-    assert (3*i*x)%(2*i*y) == i*Mod(3*x, 2*y)
-    assert (.6*pi)%(.3*x*pi) == 0.3*pi*Mod(2, x)
-    assert (.6*pi)%(.31*x*pi) == pi*Mod(0.6, 0.31*x)
-    assert (6*pi)%(.3*x*pi) == pi*Mod(6, 0.3*x)
-    assert (6*pi)%(.31*x*pi) == pi*Mod(6, 0.31*x)
-    assert (6*pi)%(.42*x*pi) == pi*Mod(6, 0.42*x)
-    assert (12*x)%(2*y) == 2*Mod(6*x, y)
-    assert (12*x)%(3*5*y) == 3*Mod(4*x, 5*y)
-    assert (12*x)%(15*x*y) == 3*x*Mod(4, 5*y)
-    assert sqrt(2) % sqrt(5) == sqrt(2)
-    assert -sqrt(2) % sqrt(5) == sqrt(5) - sqrt(2)
-    assert (-2*pi)%(3*pi) == pi
-    assert (2*x + 2) % (x + 1) == 0
+    # handling sums
+    assert (x + 3) % 1 == Mod(x, 1)
+    assert (x + 3.0) % 1 == Mod(1.*x, 1)
+    assert (x - S(33)/10) % 1 == Mod(x + S(7)/10, 1)
+    assert str(Mod(.6*x + y, .3*y)) == str(Mod(0.1*y + 0.6*x, 0.3*y))
     assert (x + 1) % x == 1 % x
     assert (x + y) % x == y % x
     assert (x + y + 2) % x == (y + 2) % x
-    assert (x*(x + 1)) % (x+1) == (x + 1)*Mod(x, 1)
-    assert (a + 3*x + 1)%(2*x) == Mod(a + x + 1, 2*x)
-    assert (12*x + 18*y)%(3*x) == 3*Mod(6*y, x)
+    assert (a + 3*x + 1) % (2*x) == Mod(a + x + 1, 2*x)
+    assert (12*x + 18*y) % (3*x) == 3*Mod(6*y, x)
+
+    # gcd extraction
+    assert (-3*x) % (-2*y) == -Mod(3*x, 2*y)
+    assert (.6*pi) % (.3*x*pi) == 0.3*pi*Mod(2, x)
+    assert (.6*pi) % (.31*x*pi) == pi*Mod(0.6, 0.31*x)
+    assert (6*pi) % (.3*x*pi) == pi*Mod(6, 0.3*x)
+    assert (6*pi) % (.31*x*pi) == pi*Mod(6, 0.31*x)
+    assert (6*pi) % (.42*x*pi) == pi*Mod(6, 0.42*x)
+    assert (12*x) % (2*y) == 2*Mod(6*x, y)
+    assert (12*x) % (3*5*y) == 3*Mod(4*x, 5*y)
+    assert (12*x) % (15*x*y) == 3*x*Mod(4, 5*y)
+    assert (-2*pi) % (3*pi) == pi
+    assert (2*x + 2) % (x + 1) == 0
+    assert (x*(x + 1)) % (x + 1) == (x + 1)*Mod(x, 1)
     assert Mod(5.0*x, 0.1*y) == 0.1*Mod(50*x, y)
+    i = Symbol('i', integer=True)
+    assert (3*i*x) % (2*i*y) == i*Mod(3*x, 2*y)
 
 
 def test_issue_2902():

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -11,9 +11,9 @@ from sympy import (
     gamma, exp, oo, Heaviside, symbols, Symbol, re, factorial, pi,
     cos, S, And, sin, sqrt, I, log, tan, hyperexpand, meijerg,
     EulerGamma, erf, besselj, bessely, besseli, besselk,
-    exp_polar, polar_lift, unpolarify, Function, expint)
+    exp_polar, polar_lift, unpolarify, Function, expint, expand_mul)
 from sympy.utilities.pytest import XFAIL, slow, skip
-from sympy.abc import x, s, a, b
+from sympy.abc import x, s, a, b, c, d
 nu, beta, rho = symbols('nu beta rho')
 
 
@@ -326,12 +326,9 @@ def test_inverse_mellin_transform():
         == sin(r)*Heaviside(1 - exp(-r))
 
     # test multiplicative substitution
-    a, b = symbols('a b', positive=True)
-    c, d = symbols('c d')
-    assert IMT(b**(-s/a)*factorial(s/a)/s, s, x, (0, oo)) == exp(-b*x**a)
-    assert IMT(factorial(a/b + s/b)/(a + s), s, x, (-a, oo)) == x**a*exp(-x**b)
-
-    from sympy import expand_mul
+    _a, _b = symbols('a b', positive=True)
+    assert IMT(_b**(-s/_a)*factorial(s/_a)/s, s, x, (0, oo)) == exp(-_b*x**_a)
+    assert IMT(factorial(_a/_b + s/_b)/(_a + s), s, x, (-_a, oo)) == x**_a*exp(-x**_b)
 
     def simp_pows(expr):
         return simplify(powsimp(expand_mul(expr, deep=False), force=True)).replace(exp_polar, exp)
@@ -359,11 +356,11 @@ def test_inverse_mellin_transform():
         (1 + sqrt(x + 1))**c
     assert simplify(IMT(2**(a + 2*s)*b**(a + 2*s - 1)*gamma(s)*gamma(1 - a - 2*s)
                         /gamma(1 - a - s), s, x, (0, (-re(a) + 1)/2))) == \
-        (b + sqrt(
-         b**2 + x))**(a - 1)*(b**2 + b*sqrt(b**2 + x) + x)/(b**2 + x)
+         b**(a - 1)*(sqrt(1 + x/b**2) + 1)**(a - 1)*(b**2*sqrt(1 + x/b**2) +
+        b**2 + x)/(b**2 + x)
     assert simplify(IMT(-2**(c + 2*s)*c*b**(c + 2*s)*gamma(s)*gamma(-c - 2*s)
                         / gamma(-c - s + 1), s, x, (0, -re(c)/2))) == \
-        (b + sqrt(b**2 + x))**c
+        b**c*(sqrt(1 + x/b**2) + 1)**c
 
     # Section 8.4.5
     assert IMT(24/s**5, s, x, (0, oo)) == log(x)**4*Heaviside(1 - x)


### PR DESCRIPTION
While still trying to keep evaluation fast, Mod will now
handle more now in removing a gcd from the terms and
removing known terms from a sum:

**master**

```
>>> Mod(x*y,x*(y+1))
Mod(x*y, x*(y + 1))
>>> Mod(x+y,y)
Mod(x + y, y)
>>> Mod(4*x, 2*x)
Mod(4*x, 2*x)
```

**this PR**

```
>>> (x*y) % (x*(y+1))
x*Mod(y, y + 1)
>>> Mod(x + y, y)
Mod(x, y)
>>> Mod(4*x, 2*x)
0
```
