### PR TITLE
Cubic

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -877,8 +877,12 @@ def roots(f, *gens, **flags):
         f1 = f.monic()
         coeffs = f1.all_coeffs()[1:]
         c = simplify(coeffs[0])
-        if c and not c.is_rational and c.is_Add:
-            sifted = sift(c.args, lambda z: z.is_rational)
+        if c and not c.is_rational:
+            if c.is_Add:
+                args = c.args
+            else:
+                args = [c]
+            sifted = sift(args, lambda z: z.is_rational)
             c1, c2 = sifted[True], sifted[False]
             alpha = -Add(*c2)/n
             f2 = f1.shift(alpha)
@@ -926,9 +930,9 @@ def roots(f, *gens, **flags):
                         translate_x, f = _try_translate(f)
                         if translate_x:
                             result = roots(f)
-                            if not result:
-                                for root in _try_decompose(f):
-                                    _update_dict(result, root, 1)
+                        if not result:
+                            for root in _try_decompose(f):
+                                _update_dict(result, root, 1)
                 else:
                     for root in _try_decompose(f):
                         _update_dict(result, root, 1)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -926,6 +926,9 @@ def roots(f, *gens, **flags):
                         translate_x, f = _try_translate(f)
                         if translate_x:
                             result = roots(f)
+                            if not result:
+                                for root in _try_decompose(f):
+                                    _update_dict(result, root, 1)
                 else:
                     for root in _try_decompose(f):
                         _update_dict(result, root, 1)

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -895,8 +895,11 @@ def roots(f, *gens, **flags):
             if len(factors) == 1 and factors[0][1] == 1:
                 if f.get_domain().is_EX:
                     rescale_x, f = _try_rescale(f)
-                for root in _try_decompose(f):
-                    _update_dict(result, root, 1)
+                    if rescale_x:
+                       result = roots(f)
+                else:
+                    for root in _try_decompose(f):
+                        _update_dict(result, root, 1)
             else:
                 for factor, k in factors:
                     for r in _try_heuristics(Poly(factor, f.gen, field=True)):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -101,7 +101,13 @@ def roots_cubic(f):
         if q is S.Zero:
             return [-aon3]*3
         else:
-            u1 = q**Rational(1, 3)
+            if q.is_real:
+                if q > 0:
+                    u1 = -q**Rational(1, 3)
+                else:
+                    u1 = (-q)**Rational(1, 3)
+            else:
+                u1 = (-q)**Rational(1, 3)
     elif q is S.Zero:
         y1, y2 = roots([1, 0, p], multiple=True)
         return [tmp - aon3 for tmp in [y1, S.Zero, y2]]
@@ -112,6 +118,9 @@ def roots_cubic(f):
 
     u2 = u1*(-S.Half + coeff)
     u3 = u1*(-S.Half - coeff)
+
+    if p is S.Zero:
+        return [u1 - aon3, u2 - aon3, u3 - aon3]
 
     soln = [
         -u1 + pon3/u1 - aon3,

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5409,6 +5409,10 @@ def to_rational_coeffs(f):
     ``(lc, alpha, None, g)`` in case of rescaling
     ``(None, None, beta, g)`` in case of translation
 
+    Notes
+    =====
+
+    Currently it transforms only polynomials without roots larger than 2.
 
     Examples
     ========
@@ -5490,7 +5494,26 @@ def to_rational_coeffs(f):
             return alpha, f2
         return None
 
-    if f.get_domain().is_EX:
+    def _has_square_roots(p):
+        """
+        Return True if ``f`` is a sum with square roots but no other root
+        """
+        from sympy.core.exprtools import Factors
+        coeffs = p.coeffs()
+        has_sq = False
+        for y in coeffs:
+            for x in Add.make_args(y):
+                f = Factors(x).factors
+                r = [wx.q for wx in f.values() if wx.is_Rational and wx.q >= 2]
+                if not r:
+                    continue
+                if min(r) == 2:
+                    has_sq = True
+                if max(r) > 2:
+                    return False
+        return has_sq
+
+    if f.get_domain().is_EX and _has_square_roots(f):
         rescale_x = None
         translate_x = None
         r = _try_rescale(f)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5416,6 +5416,7 @@ def to_rational_coeffs(f):
 
     Examples
     ========
+
     >>> from sympy import sqrt, Poly, simplify, expand
     >>> from sympy.polys.polytools import to_rational_coeffs
     >>> from sympy.abc import x

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -369,6 +369,10 @@ def test_roots():
     assert roots(eq) == {-sqrt(2) + 1: 1, -2 + 2*sqrt(2): 1, -1 + sqrt(2): 1,
                          -4 + 4*sqrt(2): 1, -3 + 3*sqrt(2): 1}
 
+    eq = Poly(x**3 - 2*x**2 + 6*sqrt(2)*x**2 - 8*sqrt(2)*x + 23*x - 14 +
+            14*sqrt(2), x, domain='EX')
+    assert roots(eq) == {-2*sqrt(2) + 2: 1, -2*sqrt(2) + 1: 1, -2*sqrt(2) - 1: 1}
+
 def test_roots_slow():
     """Just test that calculating these roots does not hang. """
     a, b, c, d, x = symbols("a,b,c,d,x")

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -373,6 +373,11 @@ def test_roots():
             14*sqrt(2), x, domain='EX')
     assert roots(eq) == {-2*sqrt(2) + 2: 1, -2*sqrt(2) + 1: 1, -2*sqrt(2) - 1: 1}
 
+    assert roots(Poly((x + sqrt(2))**3 - 7, x, domain='EX')) == \
+        {-sqrt(2) - 7**(S(1)/3)/2 - sqrt(3)*7**(S(1)/3)*I/2: 1,
+         -sqrt(2) - 7**(S(1)/3)/2 + sqrt(3)*7**(S(1)/3)*I/2: 1,
+         -sqrt(2) + 7**(S(1)/3): 1}
+
 def test_roots_slow():
     """Just test that calculating these roots does not hang. """
     a, b, c, d, x = symbols("a,b,c,d,x")

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -360,6 +360,9 @@ def test_roots():
     cr = 4 + 2*sqrt(1074)/9
     assert real_root == -2*cr**(S(1)/3) + 20/(3*cr**(S(1)/3))
 
+    eq = Poly((7 + 5*sqrt(2))*x**3 + (-6 - 4*sqrt(2))*x**2 + (-sqrt(2) - 1)*x + 2, x, domain='EX')
+    assert roots(eq) == {-1 + sqrt(2): 1, -2 + 2*sqrt(2): 1, -sqrt(2) + 1: 1}
+
 def test_roots_slow():
     """Just test that calculating these roots does not hang. """
     a, b, c, d, x = symbols("a,b,c,d,x")

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -363,6 +363,12 @@ def test_roots():
     eq = Poly((7 + 5*sqrt(2))*x**3 + (-6 - 4*sqrt(2))*x**2 + (-sqrt(2) - 1)*x + 2, x, domain='EX')
     assert roots(eq) == {-1 + sqrt(2): 1, -2 + 2*sqrt(2): 1, -sqrt(2) + 1: 1}
 
+    eq = Poly(41*x**5 + 29*sqrt(2)*x**5 - 153*x**4 - 108*sqrt(2)*x**4 +
+    175*x**3 + 125*sqrt(2)*x**3 - 45*x**2 - 30*sqrt(2)*x**2 - 26*sqrt(2)*x -
+    26*x + 24, x, domain='EX')
+    assert roots(eq) == {-sqrt(2) + 1: 1, -2 + 2*sqrt(2): 1, -1 + sqrt(2): 1,
+                         -4 + 4*sqrt(2): 1, -3 + 3*sqrt(2): 1}
+
 def test_roots_slow():
     """Just test that calculating these roots does not hang. """
     a, b, c, d, x = symbols("a,b,c,d,x")

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -24,7 +24,8 @@ from sympy.polys.polytools import (
     real_roots, nroots, ground_roots,
     nth_power_roots_poly,
     cancel, reduced, groebner,
-    GroebnerBasis, is_zero_dimensional)
+    GroebnerBasis, is_zero_dimensional,
+    _torational_factor_list)
 
 from sympy.polys.polyerrors import (
     MultivariatePolynomialError,
@@ -2745,6 +2746,14 @@ def test_nth_power_roots_poly():
     raises(MultivariatePolynomialError, lambda: nth_power_roots_poly(
         x + y, 2, x, y))
 
+def test_torational_factor_list():
+    p = expand(((x**2-1)*(x-2)).subs({x:x*(1 + sqrt(2))}))
+    assert _torational_factor_list(p, x) == (-2,
+        [(-sqrt(2)*x/2 - x/2 + 1, 1), (-sqrt(2)*x - x - 1, 1),
+         (-sqrt(2)*x - x + 1, 1)])
+
+    p = expand(((x**2-1)*(x-2)).subs({x:x*(1 + 2**Rational(1, 4))}))
+    assert _torational_factor_list(p, x) is None
 
 def test_cancel():
     assert cancel(0) == 0


### PR DESCRIPTION
added `_try_rescale`  and `_try_translate` in `roots` to attempt transforming an algebraic equation
not on rationals to one on rationals

Example:

```
>>> from sympy import *
>>> from sympy.abc import x
>>> eq = expand(((x**2-1)*(x-2)).subs({x:x*(1+sqrt(2))}))
>>> solve(eq, x)
[-2 + 2*sqrt(2), -1 + sqrt(2), -sqrt(2) + 1]
>>> count_ops(_)
10
```

while in master `count_ops` gives 732
