### PR TITLE
apart and cancel handle nc; apart takes pseudo-multivariate

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1050,7 +1050,13 @@ class Basic(object):
         if self in rule:
             return rule[self]
         elif rule:
-            args = tuple([arg.xreplace(rule) for arg in self.args])
+            args = []
+            for a in self.args:
+                try:
+                    args.append(a.xreplace(rule))
+                except AttributeError:
+                    args.append(a)
+            args = tuple(args)
             if not _aresame(args, self.args):
                 return self.func(*args)
         return self

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -785,14 +785,14 @@ def test_M6():
 def test_M7():
     assert set(solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
         226*x**2 - 140*x + 46, x)) == set([
-        1 + sqrt(-6 + 2*sqrt(-4*sqrt(3) - 3))/2,
-        1 + sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 + sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 - 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 + 2*sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(-6 - 2*sqrt(-4*sqrt(3) - 3))/2,
-        1 - sqrt(-6 + 2*sqrt(-4*sqrt(3) - 3))/2,
-        1 + sqrt(-6 - 2*sqrt(-4*sqrt(3) - 3))/2,
+        1 + sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 - sqrt(-4*sqrt(3) - 3))/2,
+        1 + sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 + sqrt(-4*sqrt(3) - 3))/2,
+        1 + sqrt(2)*sqrt(-3 - sqrt(-4*sqrt(3) - 3))/2,
+        1 - sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
+        1 + sqrt(2)*sqrt(-3 + sqrt(-4*sqrt(3) - 3))/2,
         ])
 
 

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -7,10 +7,10 @@ from sympy.polys.polyerrors import PolynomialError
 
 from sympy.core import S, Add, sympify, Function, Lambda, Dummy, Mul, Expr
 from sympy.core.basic import preorder_traversal
-from sympy.utilities import numbered_symbols, take, threaded
+from sympy.utilities import numbered_symbols, take, xthreaded
 
 
-@threaded
+@xthreaded
 def apart(f, x=None, full=False, **options):
     """
     Compute partial fraction decomposition of a rational function.

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -65,7 +65,9 @@ def apart(f, x=None, full=False, **options):
             nc = Mul(*[apart(i, x=x, full=full, **_options) for i in nc])
             if c:
                 c = apart(Mul._from_args(c), x=x, full=full, **_options)
-            return c*nc
+                return c*nc
+            else:
+                return nc
         elif f.is_Add:
             c = []
             nc = []

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6,6 +6,8 @@ from sympy.core import (
 
 from sympy.core.mul import _keep_coeff
 
+from sympy.core.basic import preorder_traversal
+
 from sympy.core.sympify import (
     sympify, SympifyError,
 )
@@ -5896,13 +5898,16 @@ def cancel(f, *gens, **args):
     Examples
     ========
 
-    >>> from sympy import cancel
+    >>> from sympy import cancel, sqrt, Symbol
     >>> from sympy.abc import x
+    >>> A = Symbol('A', commutative=False)
 
     >>> cancel((2*x**2 - 2)/(x**2 - 2*x + 1))
     (2*x + 2)/(x - 1)
-
+    >>> cancel((sqrt(3) + sqrt(15)*A)/(sqrt(2) + sqrt(10)*A))
+    sqrt(6)/2
     """
+    from sympy.core.exprtools import factor_terms
     options.allowed_flags(args, ['polys'])
 
     f = sympify(f)
@@ -5910,11 +5915,15 @@ def cancel(f, *gens, **args):
     if not isinstance(f, (tuple, Tuple)):
         if f.is_Number:
             return f
-        else:
-            p, q = f.as_numer_denom()
+        f = factor_terms(f, radical=True)
+        p, q = f.as_numer_denom()
 
-    else:
+    elif len(f) == 2:
         p, q = f
+    elif isinstance(f, Tuple):
+        return factor_terms(f)
+    else:
+        raise ValueError('unexpected argument: %s' % f)
 
     try:
         (F, G), opt = parallel_poly_from_expr((p, q), *gens, **args)
@@ -5923,6 +5932,34 @@ def cancel(f, *gens, **args):
             return f
         else:
             return S.One, p, q
+    except PolynomialError, msg:
+        if f.is_commutative:
+            raise PolynomialError(msg)
+        # non-commutative
+        if f.is_Mul:
+            c, nc = f.args_cnc(split_1=False)
+            nc = [cancel(i) for i in nc]
+            return cancel(Mul._from_args(c))*Mul(*nc)
+        elif f.is_Add:
+            c = []
+            nc = []
+            for i in f.args:
+                if i.is_commutative:
+                    c.append(i)
+                else:
+                    nc.append(cancel(i))
+            return cancel(Add(*c)) + Add(*nc)
+        else:
+            reps = []
+            pot = preorder_traversal(f)
+            pot.next()
+            for e in pot:
+                try:
+                    reps.append((e, cancel(e)))
+                    pot.skip()  # this was handled successfully
+                except NotImplementedError:
+                    pass
+            return f.xreplace(dict(reps))
 
     c, P, Q = F.cancel(G)
 

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -156,3 +156,9 @@ def test_noncommutative_pseudomultivariate():
     c = 1/(1 + y)
     assert apart(e + foo(e)) == c + foo(c)
     assert apart(e*foo(e)) == c*foo(c)
+
+
+def test_issue_2699():
+    assert apart(
+        2*x/(x**2 + 1) - (x - 1)/(2*(x**2 + 1)) + 1/(2*(x + 1)) - 2/x) == \
+        (3*x + 1)/(x**2 + 1)/2 + 1/(x + 1)/2 - 2/x

--- a/sympy/polys/tests/test_partfrac.py
+++ b/sympy/polys/tests/test_partfrac.py
@@ -10,7 +10,7 @@ from sympy.polys.partfrac import (
 )
 
 from sympy import (S, Poly, E, pi, I, Matrix, Eq, RootSum, Lambda,
-                   Symbol, Dummy, factor, together, sqrt)
+                   Symbol, Dummy, factor, together, sqrt, Expr)
 from sympy.utilities.pytest import raises
 from sympy.abc import x, y, a, b, c
 
@@ -109,7 +109,7 @@ def test_apart_undetermined_coeffs():
 
     p = Poly(1, x, domain='ZZ[a,b]')
     q = Poly((x + a)*(x + b), x, domain='ZZ[a,b]')
-    r = 1/((x + b)*(a - b)) + 1/((x + a)*(b - a))
+    r = 1/((a - b)*(b + x)) + 1/((-a + b)*(a + x))
 
     assert apart_undetermined_coeffs(p, q) == r
 
@@ -147,3 +147,12 @@ def test_assemble_partfrac_list():
     a = Dummy("a")
     pfd = (1, Poly(0, x, domain='ZZ'), [([sqrt(2),-sqrt(2)], Lambda(a, a/2), Lambda(a, -a + x), 1)])
     assert assemble_partfrac_list(pfd) == -1/(sqrt(2)*(x + sqrt(2))) + 1/(sqrt(2)*(x - sqrt(2)))
+
+
+def test_noncommutative_pseudomultivariate():
+    class foo(Expr):
+        is_commutative=False
+    e = x/(x + x*y)
+    c = 1/(1 + y)
+    assert apart(e + foo(e)) == c + foo(c)
+    assert apart(e*foo(e)) == c*foo(c)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -51,7 +51,7 @@ from sympy.polys.monomialtools import lex, grlex, grevlex
 
 from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, symbols, sqrt,
-    exp, sin, expand, oo, I, pi, re, im, RootOf, Eq, Tuple)
+    exp, sin, expand, oo, I, pi, re, im, RootOf, Eq, Tuple, Expr)
 
 from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
@@ -3093,3 +3093,13 @@ def test_poly_matching_consistency():
 def test_issue_2687():
     assert expand(factor(expand(
         (x - I*y)*(z - I*t)), extension=[I])) == -I*t*x - t*y + x*z - I*y*z
+
+
+def test_noncommutative():
+    class foo(Expr):
+        is_commutative=False
+    e = x/(x + x*y)
+    c = 1/( 1 + y)
+    assert cancel(foo(e)) == foo(c)
+    assert cancel(e + foo(e)) == c + foo(c)
+    assert cancel(e*foo(c)) == c*foo(c)

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1670,12 +1670,12 @@ def Normal(name, mean, std):
 
     >>> C = simplify(cdf(X))(z) # it needs a little more help...
     >>> pprint(C, use_unicode=False)
-            /  ___          \             /  ___          \
-            |\/ 2 *(-mu + z)|             |\/ 2 *(-mu + z)|
-    - mu*erf|---------------| - mu + z*erf|---------------| + z
-            \    2*sigma    /             \    2*sigma    /
-    -----------------------------------------------------------
-                            2*(-mu + z)
+       /  ___          \
+       |\/ 2 *(-mu + z)|
+    erf|---------------|
+       \    2*sigma    /   1
+    -------------------- + -
+             2             2
 
     >>> simplify(skewness(X))
     0

--- a/sympy/utilities/decorator.py
+++ b/sympy/utilities/decorator.py
@@ -14,7 +14,10 @@ def threaded_factory(func, use_add):
         if isinstance(expr, Matrix):
             return expr.applyfunc(lambda f: func(f, *args, **kwargs))
         elif iterable(expr):
-            return expr.__class__([ func(f, *args, **kwargs) for f in expr ])
+            try:
+                return expr.__class__([func(f, *args, **kwargs) for f in expr])
+            except TypeError:
+                return expr
         else:
             expr = sympify(expr)
 


### PR DESCRIPTION
`cancel` and `apart` now handle non-commutative expressions, and `apart` will now defer judgement about the expression being multivariate until after the cancel step is taken.

Rather than raise an error, when the non-commutative error is detected, factors or terms of Mul and Add are stripped away and handled separately from the non-commutative portion.
