### PR TITLE
Move latex printing methods for constants to numbers.py (issue 3754)

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2319,7 +2319,7 @@ class NaN(Number):
         return AtomicExpr.__new__(cls)
 
     def _latex(self, printer):
-        return r"\bot"
+        return r"\mathrm{NaN}"
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2587,6 +2587,9 @@ class GoldenRatio(NumberSymbol):
 
     __slots__ = []
 
+    def _latex(self, printer):
+        return r"\phi"
+
     def __int__(self):
         return 1
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1967,6 +1967,9 @@ class Infinity(Number):
     def __new__(cls):
         return AtomicExpr.__new__(cls)
 
+    def _latex(self, printer):
+        return r"\infty"
+
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
         if isinstance(other, Number):
@@ -2120,6 +2123,9 @@ class NegativeInfinity(Number):
 
     def __new__(cls):
         return AtomicExpr.__new__(cls)
+
+    def _latex(self, printer):
+        return r"-\infty"
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
@@ -2312,6 +2318,9 @@ class NaN(Number):
     def __new__(cls):
         return AtomicExpr.__new__(cls)
 
+    def _latex(self, printer):
+        return r"\bot"
+
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
         return self
@@ -2373,6 +2382,9 @@ class ComplexInfinity(AtomicExpr):
 
     def __new__(cls):
         return AtomicExpr.__new__(cls)
+
+    def _latex(self, printer):
+        return r"\tilde{\infty}"
 
     @staticmethod
     def __abs__():
@@ -2494,6 +2506,9 @@ class Exp1(NumberSymbol):
 
     __slots__ = []
 
+    def _latex(self, printer):
+        return r"e"
+
     @staticmethod
     def __abs__():
         return S.Exp1
@@ -2536,6 +2551,9 @@ class Pi(NumberSymbol):
     is_irrational = True
 
     __slots__ = []
+
+    def _latex(self, printer):
+        return r"\pi"
 
     @staticmethod
     def __abs__():
@@ -2602,6 +2620,9 @@ class EulerGamma(NumberSymbol):
 
     __slots__ = []
 
+    def _latex(self, printer):
+        return r"\gamma"
+
     def __int__(self):
         return 0
 
@@ -2662,6 +2683,9 @@ class ImaginaryUnit(AtomicExpr):
     is_number = True
 
     __slots__ = []
+
+    def _latex(self, printer):
+        return r"i"
 
     @staticmethod
     def __abs__():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1373,6 +1373,7 @@ def test_mpf_norm():
 def test_latex():
     assert latex(pi) == r"\pi"
     assert latex(E) == r"e"
+    assert latex(GoldenRatio) == r"\phi"
     assert latex(EulerGamma) == r"\gamma"
     assert latex(oo) == r"\infty"
     assert latex(-oo) == r"-\infty"

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1378,5 +1378,5 @@ def test_latex():
     assert latex(oo) == r"\infty"
     assert latex(-oo) == r"-\infty"
     assert latex(zoo) == r"\tilde{\infty}"
-    assert latex(nan) == r"\bot"
+    assert latex(nan) == r"\mathrm{NaN}"
     assert latex(I) == r"i"

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -2,7 +2,7 @@ from __future__ import with_statement
 import decimal
 from sympy import (Rational, Symbol, Float, I, sqrt, oo, nan, pi, E, Integer,
                    S, factorial, Catalan, EulerGamma, GoldenRatio, cos, exp,
-                   Number, zoo, log, Mul, Pow, Tuple)
+                   Number, zoo, log, Mul, Pow, Tuple, latex)
 from sympy.core.basic import _aresame
 from sympy.core.power import integer_nthroot
 from sympy.core.numbers import igcd, ilcm, igcdex, seterr, _intcache, mpf_norm
@@ -1369,3 +1369,13 @@ def test_3250():
 def test_mpf_norm():
     assert mpf_norm((1, 0, 1, 0), 10) == mpf('0')._mpf_
     assert Float._new((1, 0, 1, 0), 10)._mpf_ == mpf('0')._mpf_
+
+def test_latex():
+    assert latex(pi) == r"\pi"
+    assert latex(E) == r"e"
+    assert latex(EulerGamma) == r"\gamma"
+    assert latex(oo) == r"\infty"
+    assert latex(-oo) == r"-\infty"
+    assert latex(zoo) == r"\tilde{\infty}"
+    assert latex(nan) == r"\bot"
+    assert latex(I) == r"i"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1029,30 +1029,6 @@ class LatexPrinter(Printer):
         else:
             return self._print(expr.p)
 
-    def _print_Infinity(self, expr):
-        return r"\infty"
-
-    def _print_NegativeInfinity(self, expr):
-        return r"-\infty"
-
-    def _print_ComplexInfinity(self, expr):
-        return r"\tilde{\infty}"
-
-    def _print_ImaginaryUnit(self, expr):
-        return r"i"
-
-    def _print_NaN(self, expr):
-        return r"\bot"
-
-    def _print_Pi(self, expr):
-        return r"\pi"
-
-    def _print_Exp1(self, expr):
-        return r"e"
-
-    def _print_EulerGamma(self, expr):
-        return r"\gamma"
-
     def _print_Order(self, expr):
         return r"\mathcal{O}\left(%s\right)" % \
             self._print(expr.args[0])

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1074,3 +1074,7 @@ def test_builtin_without_args_mismatched_names():
     assert latex(DiracDelta) == r'\delta'
     assert latex(CosineTransform) == r'\mathcal{COS}'
     assert latex(lowergamma) == r'\gamma'
+
+def test_issue_3754():
+    p = Function('Pi')
+    assert latex(p(x)) == r"\Pi{\left (x \right )}"


### PR DESCRIPTION
Note: second commit adds latex printing method for GoldenRatio.
