### PR TITLE
Fix Issue 3594 (factor should return unhandled expr unchanged)

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -6,6 +6,8 @@ from sympy.core import (
 
 from sympy.core.mul import _keep_coeff
 
+from sympy.core.function import FunctionClass
+
 from sympy.core.sympify import (
     sympify, SympifyError,
 )
@@ -5337,6 +5339,13 @@ def _symbolic_factor(expr, opt, method):
     """Helper function for :func:`_factor`. """
     if isinstance(expr, Expr) and not expr.is_Relational:
         coeff, factors = _symbolic_factor_list(together(expr), opt, method)
+        if len(factors) == 1 and hasattr(expr, "func") and opt.expand:
+                f, exp = factors[0]
+                is_fc = isinstance(expr.func, FunctionClass)
+                if is_fc:
+                        ep = expr.expand()
+                        if f.as_expr() == ep and exp == 1:
+                                factors[0] = (expr, exp)
         return _keep_coeff(coeff, _factors_product(factors))
     elif hasattr(expr, 'args'):
         return expr.func(*[ _symbolic_factor(arg, opt, method) for arg in expr.args ])

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2268,6 +2268,7 @@ def test_factor():
     assert factor(3*x**2) == 3*x**2
 
     assert factor((2*x**2 + 2)**7) == 128*(x**2 + 1)**7
+    assert factor(sin((2*x**2 + 2)**7)) == sin((2*x**2 + 2)**7)
 
     assert factor(f) == u*v**2*w
     assert factor(f, x) == u*v**2*w


### PR DESCRIPTION
it is reported that:

> > > factor(Piecewise((x_(x+2),x<1)))
> > > Piecewise((x__2 + 2_x, x < 1))

And here we request the result stay unchanged when factor do nothing in this situation.

http://code.google.com/p/sympy/issues/detail?id=3594
