### PR TITLE
Unrad

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -25,12 +25,12 @@ def _unevaluated_Add(*args):
     Examples
     ========
 
-    >>> from sympy.simplify.simplify import _unevaluated_Add as uAdd
-    >>> from sympy import S, Add, ordered
+    >>> from sympy.core.add import _unevaluated_Add as uAdd
+    >>> from sympy import S, Add
     >>> from sympy.abc import x, y
-    >>> a = uAdd(*[S(1), x, S(2)])
+    >>> a = uAdd(*[S(1.0), x, S(2)])
     >>> a.args[0]
-    3
+    3.00000000000000
     >>> a.args[1]
     x
 
@@ -46,18 +46,20 @@ def _unevaluated_Add(*args):
 
     """
     args = list(args)
-    _addsort(args)
-    c = []
-    for a in args:
-        if a.is_Number:
-            c.append(a)
-    if c:
-        for ci in c:
-            args.remove(ci)
-        c = Add(*c)
-        if c:
-            args.insert(0, c)
-    return Add._from_args(args)
+    newargs = []
+    co = S.Zero
+    while args:
+        a = args.pop()
+        if a.is_Add:
+            args.extend(a.args)
+        elif a.is_Number:
+            co += a
+        else:
+            newargs.append(a)
+    _addsort(newargs)
+    if co:
+        newargs.insert(0, co)
+    return Add._from_args(newargs)
 
 
 class Add(Expr, AssocOp):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -23,6 +23,13 @@ class NC_Marker:
     is_commutative = False
 
 
+# Key for sorting commutative args in canonical order
+_args_sortkey = cmp_to_key(Basic.compare)
+def _mulsort(args):
+    # in-place sorting of args
+    args.sort(key=_args_sortkey)
+
+
 class Mul(Expr, AssocOp):
 
     __slots__ = []
@@ -31,9 +38,6 @@ class Mul(Expr, AssocOp):
 
     #identity = S.One
     # cyclic import, so defined in numbers.py
-
-    # Key for sorting commutative args in canonical order
-    _args_sortkey = cmp_to_key(Basic.compare)
 
     @classmethod
     def flatten(cls, seq):
@@ -113,6 +117,8 @@ class Mul(Expr, AssocOp):
 
               Removal of 1 from the sequence is already handled by AssocOp.__new__.
         """
+        from sympy.core.add import _addsort
+
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -134,7 +140,7 @@ class Mul(Expr, AssocOp):
                     else:
                         r, b = b.as_coeff_Add()
                         bargs = [_keep_coeff(a, bi) for bi in Add.make_args(b)]
-                        bargs.sort(key=hash)
+                        _addsort(bargs)
                         ar = a*r
                         if ar:
                             bargs.insert(0, ar)
@@ -498,7 +504,7 @@ class Mul(Expr, AssocOp):
             return [coeff], [], order_symbols
 
         # order commutative part canonically
-        c_part.sort(key=cls._args_sortkey)
+        _mulsort(c_part)
 
         # current code expects coeff to be always in slot-0
         if coeff is not S.One:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -206,8 +206,6 @@ def minimal_polynomial(ex, x=None, **args):
     else:
         x, cls = Dummy('x'), PurePoly
 
-    polys = args.get('polys', False)
-
     def update_mapping(ex, exp, base=None):
         a = generator.next()
         symbols[ex] = a
@@ -302,28 +300,6 @@ def minimal_polynomial(ex, x=None, **args):
             return ex.minpoly.replace(x)
     elif ex.is_Rational:
         result = ex.q*x - ex.p
-    elif ex.is_number:
-        from sympy.solvers.solvers import unrad
-        from sympy.polys import factor
-        try:
-            result = x - ex
-            u = unrad(result, all=True)
-            if u:
-                result, _, _ = u
-                poly = Poly(result, x)
-                if not poly.is_irreducible:
-                    mul = factor(poly)
-                    result = min([(abs(m.subs(x, ex).n(2)), m)
-                        for m in mul.args])[1]
-            if result.has(S.Infinity, S.NegativeInfinity, S.NaN) or \
-                    len(Poly(result).gens) > 1:
-                raise ValueError
-        except ValueError:
-            from sympy.simplify.simplify import nsimplify
-            simp = nsimplify(ex)
-            if simp != ex and simp.equals(ex):
-                return minimal_polynomial(simp, x, **args)
-            raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
     else:
         inverted = simpler_inverse(ex)
         if inverted:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -130,22 +130,24 @@ def minimal_polynomial(ex, x=None, **args):
     elif ex.is_number:
         from sympy.solvers.solvers import unrad
         from sympy.polys import factor
-        from sympy.simplify.simplify import nsimplify
-        simp = nsimplify(ex)
-        if simp != ex and simp.equals(ex):
-            return minimal_polynomial(simp, x, **args)
         try:
             result = x - ex
             u = unrad(result, all=True)
             if u:
                 result, _, _ = u
-                mul = factor(result)
-                if mul.is_Mul:
-                    result = min([(abs(m.subs(x, ex).n(2)), m) for m in mul.args])[1]
+                poly = Poly(result, x)
+                if not poly.is_irreducible:
+                    mul = factor(poly)
+                    result = min([(abs(m.subs(x, ex).n(2)), m)
+                        for m in mul.args])[1]
             if result.has(S.Infinity, S.NegativeInfinity, S.NaN) or \
                     len(Poly(result).gens) > 1:
                 raise ValueError
         except ValueError:
+            from sympy.simplify.simplify import nsimplify
+            simp = nsimplify(ex)
+            if simp != ex and simp.equals(ex):
+                return minimal_polynomial(simp, x, **args)
             raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
     else:
         F = [x - bottom_up_scan(ex)] + mapping.values()

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -130,6 +130,10 @@ def minimal_polynomial(ex, x=None, **args):
     elif ex.is_number:
         from sympy.solvers.solvers import unrad
         from sympy.polys import factor
+        from sympy.simplify.simplify import nsimplify
+        simp = nsimplify(ex)
+        if simp != ex and simp.equals(ex):
+            return minimal_polynomial(simp, x, **args)
         try:
             result = x - ex
             u = unrad(result, all=True)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -129,11 +129,15 @@ def minimal_polynomial(ex, x=None, **args):
         result = ex.q*x - ex.p
     elif ex.is_number:
         from sympy.solvers.solvers import unrad
+        from sympy.polys import factor
         try:
             result = x - ex
             u = unrad(result, all=True)
             if u:
                 result, _, _ = u
+                mul = factor(result)
+                if mul.is_Mul:
+                    result = min([(abs(m.subs(x, ex).n(2)), m) for m in mul.args])[1]
             if result.has(S.Infinity, S.NegativeInfinity, S.NaN) or \
                     len(Poly(result).gens) > 1:
                 raise ValueError

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -100,6 +100,13 @@ def test_minimal_polynomial():
     assert minimal_polynomial(
         a**Q(3, 2), x) == 729*x**4 - 506898*x**2 + 84604519
 
+    # issue 2895
+    eq = S('''
+        -1/(800*sqrt(-1/240 + 1/(18000*(-1/17280000 +
+        sqrt(15)*I/28800000)**(1/3)) + 2*(-1/17280000 +
+        sqrt(15)*I/28800000)**(1/3)))''')
+    assert minimal_polynomial(eq, x) == 8000*x**2 - 1
+
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1874,25 +1874,8 @@ def radsimp(expr, symbolic=True, max_terms=4):
     1/(a + b*sqrt(c))
 
     """
-    from sympy.core.mul import _mulsort
+    from sympy.core.mul import _unevaluated_Mul as _umul
     from sympy.core.exprtools import Factors
-
-    def _umul(*args):
-        args = list(args)
-        margs = []
-        co = S.One
-        while args:
-            a = args.pop()
-            if a.is_Mul:
-                args.extend(a.args)
-            elif a.is_Rational:
-                co *= a
-            else:
-                margs.append(a)
-        _mulsort(margs)
-        if co is not S.One:
-            margs.insert(0, co)
-        return Mul._from_args(margs)
 
     def handle(expr):
         if expr.is_Atom or not symbolic and expr.free_symbols:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1939,33 +1939,10 @@ def radsimp(expr, symbolic=True, max_terms=4):
                 # but other considerations can guide selection of radical terms
                 # so that radicals are removed
                 if all([x.is_Integer and (y**2).is_Rational for x, y in rterms]):
-                    nd, d = rad_rationalize(S.One, Add._from_args([sqrt(x)*y for x, y in rterms]))
+                    nd, d = rad_rationalize(S.One, Add._from_args(
+                        [sqrt(x)*y for x, y in rterms]))
                     n *= nd
                     iter += 1
-                elif all(i.is_number for r in rterms for i in r):
-                    # try minpoly as a fallback
-                    # XXX should this only be done if the order of mp doesn't
-                    # exceed some value? Will minpoly succeed where other methods
-                    # have failed?
-                    from sympy.polys.numberfields import minpoly
-                    from sympy.utilities.randtest import test_numerically
-                    from sympy.solvers.solvers import solve
-                    _eq = Add(*[sqrt(i)*j for i, j in rterms])
-                    try:
-                        # the co handling is not necessary if minpoly does this
-                        _co, _eq = _eq.as_coeff_Add()
-                        _x = Dummy()
-                        _mp = minpoly(_eq, _x).subs(_x, _x - _co)
-                        candidates = [w for w in solve(_mp, _x) if
-                            test_numerically(w, _eq)]
-                        if len(candidates) == 1:
-                            equivalent = candidates[0]
-                            if equivalent.atoms(Pow) != _eq.atoms(Pow):
-                                # it was rewritten, so try to radsimp this instead
-                                d = radsimp(equivalent)
-                                iter += 1
-                    except NotAlgebraic:
-                        pass
                 break
             num = powsimp(_num(rterms))
             n *= num

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2001,7 +2001,6 @@ def radsimp(expr, symbolic=True, max_terms=4):
             if old == (n, d):
                 n, d = was
         n = expand_mul(n)
-    print n.args,d.args
     return _umul(n, 1/d)
 
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -6,7 +6,7 @@ from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     Derivative, Wild, Symbol, sympify, expand, expand_mul, expand_func,
     Function, Equality, Dummy, Atom, count_ops, Expr, factor_terms,
     expand_multinomial, FunctionClass, expand_power_base, symbols, igcd)
-
+from sympy.core.add import _unevaluated_Add
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import (
     iterable, reduce, default_sort_key, set_union, ordered)
@@ -1611,48 +1611,6 @@ def collect_const(expr, *vars, **kwargs):
                 break
 
     return expr
-
-
-def _unevaluated_Add(*args):
-    """Return a well-formed unevaluated Add: Number
-    is in slot 0 and args are sorted.
-
-    Examples
-    ========
-
-    >>> from sympy.simplify.simplify import _unevaluated_Add as uAdd
-    >>> from sympy import S, Add, ordered
-    >>> from sympy.abc import x, y
-    >>> a = uAdd(*[S(1), x, S(2)])
-    >>> a.args[0]
-    3
-    >>> a.args[1]
-    x
-
-    Beyond the Number being in slot 0, there is no other assurance of
-    order for the arguments since they are hash sorted. So, for testing
-    purposes, output produced by this in some other function can only
-    be tested against the output of this function or as one of several
-    options:
-
-    >>> opts = (Add(x, y, evaluated=False), Add(y, x, evaluated=False))
-    >>> a = uAdd(x, y)
-    >>> assert a in opts and a == uAdd(x, y)
-
-    """
-    args = list(args)
-    args.sort(key=hash)  # same as in Add.flatten
-    c = []
-    for a in args:
-        if a.is_Number:
-            c.append(a)
-    if c:
-        for ci in c:
-            args.remove(ci)
-        c = Add(*c)
-        if c:
-            args.insert(0, c)
-    return Add(*args, **dict(evaluate=False))
 
 
 def _split_gcd(*a):

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1913,6 +1913,9 @@ def radsimp(expr, symbolic=True, max_terms=4):
         elif d.is_Mul:
             return _umul(*[handle(1/d) for d in d.args])
 
+        if not symbolic and d.free_symbols:
+            return expr
+
         if d.is_Pow and d.exp.is_Rational and d.exp.q == 2:
             d2 = sqrtdenest(sqrt(d.base))**d.exp.p
             if d2 != d:
@@ -1994,9 +1997,6 @@ def radsimp(expr, symbolic=True, max_terms=4):
         if not keep:
             return expr
         return _umul(n, 1/d)
-
-    if not symbolic and expr.free_symbols:
-        return expr
 
     coeff, expr = expr.as_coeff_Add()
     expr = expr.normal()

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -536,13 +536,6 @@ def test_simplify_fail1():
     assert simplify(e) == 1 / (-2*y)
 
 
-def test_simplify_issue_3214():
-    c, p = symbols('c p', positive=True)
-    s = sqrt(c**2 - p**2)
-    b = (c + I*p - s)/(c + I*p + s)
-    assert radsimp(b) == (c*p - p*s + I*(-c**2 + c*s + p**2))/(c*p)
-
-
 def test_fraction():
     x, y, z = map(Symbol, 'xyz')
     A = Symbol('A', commutative=False)
@@ -1347,77 +1340,78 @@ def test_radsimp():
     assert radsimp(1/(r2 + r3)) == \
         -sqrt(2) + sqrt(3)
     assert fraction(radsimp(1/(1 + r2 + r3))) == \
-        (-sqrt(6) + sqrt(2) + 2, 4)
+        (-2*sqrt(6) + 2*sqrt(2) + 4, 8)
     assert fraction(radsimp(1/(r2 + r3 + r5))) == \
-        (-sqrt(30) + 2*sqrt(3) + 3*sqrt(2), 12)
-    assert fraction(radsimp(1/(1 + r2 + r3 + r5))) == \
-        (-34*sqrt(10) -
-        26*sqrt(15) -
-        55*sqrt(3) -
-        61*sqrt(2) +
-        14*sqrt(30) +
-        93 +
-        46*sqrt(6) +
-        53*sqrt(5), 71)
-    assert fraction(radsimp(1/(r2 + r3 + r5 + r7))) == \
-        (-50*sqrt(42) - 133*sqrt(5) - 34*sqrt(70) -
-        145*sqrt(3) + 22*sqrt(105) + 185*sqrt(2) +
-        62*sqrt(30) + 135*sqrt(7), 215)
+        (-2*sqrt(30) + 4*sqrt(3) + 6*sqrt(2), 24)
+    assert fraction(radsimp(1/(1 + r2 + r3 + r5))) == (
+        (-34*sqrt(10) - 26*sqrt(15) - 55*sqrt(3) - 61*sqrt(2) + 14*sqrt(30) +
+        93 + 46*sqrt(6) + 53*sqrt(5), 71))
+    assert fraction(radsimp(1/(r2 + r3 + r5 + r7))) == (
+        (-50*sqrt(42) - 133*sqrt(5) - 34*sqrt(70) - 145*sqrt(3) + 22*sqrt(105)
+        + 185*sqrt(2) + 62*sqrt(30) + 135*sqrt(7), 215))
     z = radsimp(1/(1 + r2/3 + r3/5 + r5 + r7))
     assert len((3616791619821680643598*z).args) == 16
-    assert radsimp(1/z) == signsimp(1/z)
+    assert radsimp(1/z) == 1/z
     assert radsimp(1/z, max_terms=20).expand() == 1 + r2/3 + r3/5 + r5 + r7
     assert radsimp(1/(r2*3)) == \
         sqrt(2)/6
     assert radsimp(1/(r2*a + r3 + r5 + r7)) == (
-        (2*sqrt(105)*(-12*a**4 + 60*a**2 - 59) + 2*sqrt(70)*(4*a**5 - 36*a**3
-        + 49*a) + 2*sqrt(42)*(4*a**5 - 20*a**3 + 41*a) + 2*sqrt(30)*(4*a**5 -
-        4*a**3 - 31*a) + sqrt(3)*(-8*a**6 + 84*a**4 - 462*a**2 + 531) +
-        sqrt(5)*(-8*a**6 + 100*a**4 - 254*a**2 + 295) + sqrt(7)*(-8*a**6 +
-        116*a**4 - 302*a**2 + 59) + sqrt(2)*(8*a**7 - 180*a**5 + 782*a**3 -
-        795*a))/(16*a**8 - 480*a**6 + 3128*a**4 - 6360*a**2 + 3481))
+        (8*sqrt(2)*a**7 - 8*sqrt(7)*a**6 - 8*sqrt(5)*a**6 - 8*sqrt(3)*a**6 -
+        180*sqrt(2)*a**5 + 8*sqrt(30)*a**5 + 8*sqrt(42)*a**5 + 8*sqrt(70)*a**5
+        - 24*sqrt(105)*a**4 + 84*sqrt(3)*a**4 + 100*sqrt(5)*a**4 +
+        116*sqrt(7)*a**4 - 72*sqrt(70)*a**3 - 40*sqrt(42)*a**3 -
+        8*sqrt(30)*a**3 + 782*sqrt(2)*a**3 - 462*sqrt(3)*a**2 -
+        302*sqrt(7)*a**2 - 254*sqrt(5)*a**2 + 120*sqrt(105)*a**2 -
+        795*sqrt(2)*a - 62*sqrt(30)*a + 82*sqrt(42)*a + 98*sqrt(70)*a -
+        118*sqrt(105) + 59*sqrt(7) + 295*sqrt(5) + 531*sqrt(3))/(16*a**8 -
+        480*a**6 + 3128*a**4 - 6360*a**2 + 3481))
     assert radsimp(1/(r2*a + r2*b + r3 + r7)) == (
-        (sqrt(42)*(a + b) + sqrt(3)*(-(a + b)**2 - 2) + sqrt(7)*(-(a + b)**2 +
-        2) + sqrt(2)*(a*(a + b)**2 - 5*a + b*(a + b)**2 - 5*b))/(a**4 +
-        4*a**3*b + 6*a**2*b**2 - 10*a**2 + 4*a*b**3 - 20*a*b + b**4 - 10*b**2
-        + 4)/2)
+        (2*sqrt(2)*a*(a + b)**2 - 10*sqrt(2)*a + 2*sqrt(42)*a + 2*sqrt(2)*b*(a
+        + b)**2 - 10*sqrt(2)*b + 2*sqrt(42)*b - 2*sqrt(7)*(a + b)**2 -
+        2*sqrt(3)*(a + b)**2 - 4*sqrt(3) + 4*sqrt(7))/(4*a**4 + 16*a**3*b +
+        24*a**2*b**2 - 40*a**2 + 16*a*b**3 - 80*a*b + 4*b**4 - 40*b**2 + 16))
     assert radsimp(1/(r2*a + r2*b + r2*c + r2*d)) == \
-        (sqrt(2)/(a + b + c + d))/2
+        sqrt(2)/(2*a + 2*b + 2*c + 2*d)
     assert radsimp(1/(1 + r2*a + r2*b + r2*c + r2*d)) == (
-        (sqrt(2)*(a + b + c + d) - 1)/(2*a**2 + 4*a*b + 4*a*c + 4*a*d + 2*b**2
-        + 4*b*c + 4*b*d + 2*c**2 + 4*c*d + 2*d**2 - 1))
+        (sqrt(2)*a + sqrt(2)*b + sqrt(2)*c + sqrt(2)*d - 1)/(2*a**2 + 4*a*b +
+        4*a*c + 4*a*d + 2*b**2 + 4*b*c + 4*b*d + 2*c**2 + 4*c*d + 2*d**2 - 1))
     assert radsimp((y**2 - x)/(y - sqrt(x))) == \
         sqrt(x) + y
     assert radsimp(-(y**2 - x)/(y - sqrt(x))) == \
         -(sqrt(x) + y)
     assert radsimp(1/(1 - I + a*I)) == \
-        (I*(-a + 1) + 1)/(a**2 - 2*a + 2)
+        (-I*a + 1 + I)/(a**2 - 2*a + 2)
     assert radsimp(1/((-x + y)*(x - sqrt(y)))) == \
         (-x - sqrt(y))/((x - y)*(x**2 - y))
     e = (3 + 3*sqrt(2))*x*(3*x - 3*sqrt(y))
-    assert radsimp(e) == 9*x*(1 + sqrt(2))*(x - sqrt(y))
-    assert radsimp(1/e) == (-1 + sqrt(2))*(x + sqrt(y))/(9*x*(x**2 - y))
+    assert radsimp(e) == x*(3 + 3*sqrt(2))*(3*x - 3*sqrt(y))
+    assert radsimp(1/e) == (
+        (-9*x + 9*sqrt(2)*x - 9*sqrt(y) + 9*sqrt(2)*sqrt(y))/(9*x*(9*x**2 -
+        9*y)))
     assert radsimp(1 + 1/(1 + sqrt(3))) == \
-        Mul(S(1)/2, 1 + sqrt(3), evaluate=False)
+        S.Half + sqrt(3)/2
     A = symbols("A", commutative=False)
     assert radsimp(x**2 + sqrt(2)*x**2 - sqrt(2)*x*A) == \
-        x**2 + sqrt(2)*(x**2 - x*A)
+        x**2 + sqrt(2)*x**2 - sqrt(2)*x*A
     assert radsimp(1/sqrt(5 + 2 * sqrt(6))) == -sqrt(2) + sqrt(3)
     assert radsimp(1/sqrt(5 + 2 * sqrt(6))**3) == -11*sqrt(2) + 9*sqrt(3)
 
     # issue 3433
-    assert radsimp(1/sqrt(x)) == 1/sqrt(x)
-    # this is sign-trickery to keep the expression from reverting
-    # back to having a radical in the denominator; the only way
-    # to get the previous expression to return as sqrt(x)/x would be
-    # to use an unevaluated Mul
-    assert radsimp(1/sqrt(2*x + 3)) == -sqrt(2*x + 3)/(-2*x - 3)
-    assert radsimp(1/sqrt(2*(x + 3))) == -sqrt(2)*sqrt(x + 3)/(-x - 3)/2
+    assert fraction(radsimp(1/sqrt(x))) == (sqrt(x), x)
+    assert fraction(radsimp(1/sqrt(2*x + 3))) == (sqrt(2*x + 3), 2*x + 3)
+    assert fraction(radsimp(1/sqrt(2*(x + 3)))) == (sqrt(2*x + 6), 2*x + 6)
 
     # issue 2895
     e = S('-(2 + 2*sqrt(2) + 4*2**(1/4))/'
         '(1 + 2**(3/4) + 3*2**(1/4) + 3*sqrt(2))')
     assert radsimp(e).expand() == -2*2**(S(3)/4) - 2*2**(S(1)/4) + 2 + 2*sqrt(2)
+
+
+def test_simplify_issue_3214():
+    c, p = symbols('c p', positive=True)
+    s = sqrt(c**2 - p**2)
+    b = (c + I*p - s)/(c + I*p + s)
+    assert radsimp(b) == -I*(c + I*p - sqrt(c**2 - p**2))**2/(2*c*p)
 
 
 def test_collect_const():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1365,22 +1365,27 @@ def test_radsimp():
         62*sqrt(30) + 135*sqrt(7), 215)
     z = radsimp(1/(1 + r2/3 + r3/5 + r5 + r7))
     assert len((3616791619821680643598*z).args) == 16
-    assert radsimp(1/z) == 1/z
+    assert radsimp(1/z) == signsimp(1/z)
     assert radsimp(1/z, max_terms=20).expand() == 1 + r2/3 + r3/5 + r5 + r7
     assert radsimp(1/(r2*3)) == \
         sqrt(2)/6
-    assert radsimp(1/(r2*a + r3 + r5 + r7)) == 1/(r2*a + r3 + r5 + r7)
+    assert radsimp(1/(r2*a + r3 + r5 + r7)) == (
+        (2*sqrt(105)*(-12*a**4 + 60*a**2 - 59) + 2*sqrt(70)*(4*a**5 - 36*a**3
+        + 49*a) + 2*sqrt(42)*(4*a**5 - 20*a**3 + 41*a) + 2*sqrt(30)*(4*a**5 -
+        4*a**3 - 31*a) + sqrt(3)*(-8*a**6 + 84*a**4 - 462*a**2 + 531) +
+        sqrt(5)*(-8*a**6 + 100*a**4 - 254*a**2 + 295) + sqrt(7)*(-8*a**6 +
+        116*a**4 - 302*a**2 + 59) + sqrt(2)*(8*a**7 - 180*a**5 + 782*a**3 -
+        795*a))/(16*a**8 - 480*a**6 + 3128*a**4 - 6360*a**2 + 3481))
     assert radsimp(1/(r2*a + r2*b + r3 + r7)) == (
-        sqrt(42)*(a + b) + sqrt(3)*(-a**2 - 2*a*b - b**2 - 2) +
-        sqrt(7)*(-a**2 - 2*a*b - b**2 + 2) + sqrt(2)*(a**3 + 3*a**2*b +
-        3*a*b**2 - 5*a + b**3 - 5*b))/(a**4 + 4*a**3*b + 6*a**2*b**2 -
-        10*a**2 + 4*a*b**3 - 20*a*b + b**4 - 10*b**2 + 4)/2
+        (sqrt(42)*(a + b) + sqrt(3)*(-(a + b)**2 - 2) + sqrt(7)*(-(a + b)**2 +
+        2) + sqrt(2)*(a*(a + b)**2 - 5*a + b*(a + b)**2 - 5*b))/(a**4 +
+        4*a**3*b + 6*a**2*b**2 - 10*a**2 + 4*a*b**3 - 20*a*b + b**4 - 10*b**2
+        + 4)/2)
     assert radsimp(1/(r2*a + r2*b + r2*c + r2*d)) == \
         (sqrt(2)/(a + b + c + d))/2
-    assert radsimp(1/(1 + r2*a + r2*b + r2*c + r2*d)) == \
-        ((sqrt(2)*(-a - b - c - d) + 1)/
-        (-2*a**2 - 4*a*b - 4*a*c - 4*a*d - 2*b**2 -
-        4*b*c - 4*b*d - 2*c**2 - 4*c*d - 2*d**2 + 1))
+    assert radsimp(1/(1 + r2*a + r2*b + r2*c + r2*d)) == (
+        (sqrt(2)*(a + b + c + d) - 1)/(2*a**2 + 4*a*b + 4*a*c + 4*a*d + 2*b**2
+        + 4*b*c + 4*b*d + 2*c**2 + 4*c*d + 2*d**2 - 1))
     assert radsimp((y**2 - x)/(y - sqrt(x))) == \
         sqrt(x) + y
     assert radsimp(-(y**2 - x)/(y - sqrt(x))) == \
@@ -1388,7 +1393,7 @@ def test_radsimp():
     assert radsimp(1/(1 - I + a*I)) == \
         (I*(-a + 1) + 1)/(a**2 - 2*a + 2)
     assert radsimp(1/((-x + y)*(x - sqrt(y)))) == \
-        (x + sqrt(y))/((-x + y)*(x**2 - y))
+        (-x - sqrt(y))/((x - y)*(x**2 - y))
     e = (3 + 3*sqrt(2))*x*(3*x - 3*sqrt(y))
     assert radsimp(e) == 9*x*(1 + sqrt(2))*(x - sqrt(y))
     assert radsimp(1/e) == (-1 + sqrt(2))*(x + sqrt(y))/(9*x*(x**2 - y))
@@ -1408,6 +1413,11 @@ def test_radsimp():
     # to use an unevaluated Mul
     assert radsimp(1/sqrt(2*x + 3)) == -sqrt(2*x + 3)/(-2*x - 3)
     assert radsimp(1/sqrt(2*(x + 3))) == -sqrt(2)*sqrt(x + 3)/(-x - 3)/2
+
+    # issue 2895
+    e = S('-(2 + 2*sqrt(2) + 4*2**(1/4))/'
+        '(1 + 2**(3/4) + 3*2**(1/4) + 3*sqrt(2))')
+    assert radsimp(e).expand() == -2*2**(S(3)/4) - 2*2**(S(1)/4) + 2 + 2*sqrt(2)
 
 
 def test_collect_const():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1470,8 +1470,15 @@ def test_radsimp():
     assert radsimp(1/e) == 1/cos(-sqrt(2) + 1)
     assert radsimp(2/e) == 2/cos(-sqrt(2) + 1)
 
+    # test that symbolic denominators are not processed
+    r = 1 + sqrt(2)
+    assert radsimp(x/r, symbolic=False) == -x*(-sqrt(2) + 1)
+    assert radsimp(x/(y + r), symbolic=False) == x/(y + 1 + sqrt(2))
+    assert radsimp(x/(y + r)/r, symbolic=False) == \
+        -x*(-sqrt(2) + 1)/(y + 1 + sqrt(2))
 
-def test_simplify_issue_3214():
+
+def test_radsimp_issue_3214():
     c, p = symbols('c p', positive=True)
     s = sqrt(c**2 - p**2)
     b = (c + I*p - s)/(c + I*p + s)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1358,16 +1358,15 @@ def test_radsimp():
     r3 = sqrt(3)
     r5 = sqrt(5)
     r7 = sqrt(7)
-    assert radsimp(1/r2) == \
-        sqrt(2)/2
+    assert fraction(radsimp(1/r2)) == (sqrt(2), 2)
     assert radsimp(1/(1 + r2)) == \
         -1 + sqrt(2)
     assert radsimp(1/(r2 + r3)) == \
         -sqrt(2) + sqrt(3)
     assert fraction(radsimp(1/(1 + r2 + r3))) == \
-        (-2*sqrt(6) + 2*sqrt(2) + 4, 8)
+        (-sqrt(6) + sqrt(2) + 2, 4)
     assert fraction(radsimp(1/(r2 + r3 + r5))) == \
-        (-2*sqrt(30) + 4*sqrt(3) + 6*sqrt(2), 24)
+        (-sqrt(30) + 2*sqrt(3) + 3*sqrt(2), 12)
     assert fraction(radsimp(1/(1 + r2 + r3 + r5))) == (
         (-34*sqrt(10) - 26*sqrt(15) - 55*sqrt(3) - 61*sqrt(2) + 14*sqrt(30) +
         93 + 46*sqrt(6) + 53*sqrt(5), 71))
@@ -1391,10 +1390,10 @@ def test_radsimp():
         118*sqrt(105) + 59*sqrt(7) + 295*sqrt(5) + 531*sqrt(3))/(16*a**8 -
         480*a**6 + 3128*a**4 - 6360*a**2 + 3481))
     assert radsimp(1/(r2*a + r2*b + r3 + r7)) == (
-        (2*sqrt(2)*a*(a + b)**2 - 10*sqrt(2)*a + 2*sqrt(42)*a + 2*sqrt(2)*b*(a
-        + b)**2 - 10*sqrt(2)*b + 2*sqrt(42)*b - 2*sqrt(7)*(a + b)**2 -
-        2*sqrt(3)*(a + b)**2 - 4*sqrt(3) + 4*sqrt(7))/(4*a**4 + 16*a**3*b +
-        24*a**2*b**2 - 40*a**2 + 16*a*b**3 - 80*a*b + 4*b**4 - 40*b**2 + 16))
+        (sqrt(2)*a*(a + b)**2 - 5*sqrt(2)*a + sqrt(42)*a + sqrt(2)*b*(a +
+        b)**2 - 5*sqrt(2)*b + sqrt(42)*b - sqrt(7)*(a + b)**2 - sqrt(3)*(a +
+        b)**2 - 2*sqrt(3) + 2*sqrt(7))/(2*a**4 + 8*a**3*b + 12*a**2*b**2 -
+        20*a**2 + 8*a*b**3 - 40*a*b + 2*b**4 - 20*b**2 + 8))
     assert radsimp(1/(r2*a + r2*b + r2*c + r2*d)) == \
         sqrt(2)/(2*a + 2*b + 2*c + 2*d)
     assert radsimp(1/(1 + r2*a + r2*b + r2*c + r2*d)) == (
@@ -1419,7 +1418,7 @@ def test_radsimp():
     assert radsimp(x**2 + sqrt(2)*x**2 - sqrt(2)*x*A) == \
         x**2 + sqrt(2)*x**2 - sqrt(2)*x*A
     assert radsimp(1/sqrt(5 + 2 * sqrt(6))) == -sqrt(2) + sqrt(3)
-    assert radsimp(1/sqrt(5 + 2 * sqrt(6))**3) == -11*sqrt(2) + 9*sqrt(3)
+    assert radsimp(1/sqrt(5 + 2 * sqrt(6))**3) == -(-sqrt(3) + sqrt(2))**3
 
     # issue 3433
     assert fraction(radsimp(1/sqrt(x))) == (sqrt(x), x)
@@ -1446,22 +1445,30 @@ def test_radsimp():
         120*sqrt(10)*sqrt(-8*sqrt(5) + 40)*sqrt(sqrt(5) + 5))/(-36000 -
         7200*sqrt(5) + (12*sqrt(10)*sqrt(sqrt(5) + 5) +
         24*sqrt(10)*sqrt(-sqrt(5) + 5))**2))
-    # assert radsimp(eq) == 0 XXX fix handling of Mul. This should be zero
+    assert radsimp(eq) is S.NaN  # it's 0/0
 
     # work with normal form
     e = 1/sqrt(sqrt(7)/7 + 2*sqrt(2) + 3*sqrt(3) + 5*sqrt(5)) + 3
     assert radsimp(e) == (
-        -1658283*sqrt(21)*sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
-        35*sqrt(5))/260084635 - 1507966*sqrt(14)*sqrt(sqrt(7) + 14*sqrt(2) +
-        21*sqrt(3) + 35*sqrt(5))/260084635 - 1141953*sqrt(sqrt(7) + 14*sqrt(2)
-        + 21*sqrt(3) + 35*sqrt(5))/260084635 - 327012*sqrt(6)*sqrt(sqrt(7) +
-        14*sqrt(2) + 21*sqrt(3) + 35*sqrt(5))/260084635 +
-        1346996*sqrt(10)*sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
-        35*sqrt(5))/1300423175 + 1278438*sqrt(15)*sqrt(sqrt(7) + 14*sqrt(2) +
-        21*sqrt(3) + 35*sqrt(5))/1300423175 + 1577436*sqrt(210)*sqrt(sqrt(7) +
-        14*sqrt(2) + 21*sqrt(3) + 35*sqrt(5))/1300423175 +
-        11654899*sqrt(35)*sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
-        35*sqrt(5))/1300423175 + 3)
+        -sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
+        35*sqrt(5))*(-11654899*sqrt(35) - 1577436*sqrt(210) - 1278438*sqrt(15)
+        - 1346996*sqrt(10) + 1635060*sqrt(6) + 5709765 + 7539830*sqrt(14) +
+        8291415*sqrt(21))/1300423175 + 3)
+
+    # obey power rules
+    base = sqrt(3) - sqrt(2)
+    assert radsimp(1/base**3) == (sqrt(3) + sqrt(2))**3
+    assert radsimp(1/(-base)**3) == -(sqrt(2) + sqrt(3))**3
+    assert radsimp(1/(-base)**x) == (-base)**(-x)
+    assert radsimp(1/base**x) == (sqrt(2) + sqrt(3))**x
+    assert radsimp(root(1/(-1 - sqrt(2)), -x)) == (-1)**(-1/x)*(1 + sqrt(2))**(1/x)
+
+    # recurse
+    e = cos(1/(1 + sqrt(2)))
+    assert radsimp(e) == cos(-sqrt(2) + 1)
+    assert radsimp(e/2) == cos(-sqrt(2) + 1)/2
+    assert radsimp(1/e) == 1/cos(-sqrt(2) + 1)
+    assert radsimp(2/e) == 2/cos(-sqrt(2) + 1)
 
 
 def test_simplify_issue_3214():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -399,7 +399,7 @@ def test_factorial_simplify():
     assert simplify(factorial(factorial(x))) == factorial(factorial(x))
 
 
-def test_simplify():
+def test_simplify_expr():
     x, y, z, k, n, m, w, f, s, A = symbols('x,y,z,k,n,m,w,f,s,A')
 
     assert all(simplify(tmp) == tmp for tmp in [I, E, oo, x, -x, -oo, -E, -I])

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -8,7 +8,7 @@ from sympy import (
     Rational, ratsimp, ratsimpmodprime, rcollect, RisingFactorial, root, S,
     separatevars, signsimp, simplify, sin, sinh, solve, sqrt, Subs, Symbol,
     symbols, sympify, tan, tanh, trigsimp, Wild, Basic, ordered,
-    expand_multinomial)
+    expand_multinomial, denom)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import (
     collect_sqrt, fraction_expand, _unevaluated_Add, nthroot)
@@ -1430,6 +1430,38 @@ def test_radsimp():
     e = S('-(2 + 2*sqrt(2) + 4*2**(1/4))/'
         '(1 + 2**(3/4) + 3*2**(1/4) + 3*sqrt(2))')
     assert radsimp(e).expand() == -2*2**(S(3)/4) - 2*2**(S(1)/4) + 2 + 2*sqrt(2)
+
+    # issue 2887 (modifications to radimp didn't initially recognize this so
+    # the test is included here)
+    assert radsimp(1/(-sqrt(5)/2 - S(1)/2 + (-sqrt(5)/2 - S(1)/2)**2)) == 1
+
+    # from issue 2835
+    eq = (
+        (-240*sqrt(2)*sqrt(sqrt(5) + 5)*sqrt(8*sqrt(5) + 40) -
+        360*sqrt(2)*sqrt(-8*sqrt(5) + 40)*sqrt(-sqrt(5) + 5) -
+        120*sqrt(10)*sqrt(-8*sqrt(5) + 40)*sqrt(-sqrt(5) + 5) +
+        120*sqrt(2)*sqrt(-sqrt(5) + 5)*sqrt(8*sqrt(5) + 40) +
+        120*sqrt(2)*sqrt(-8*sqrt(5) + 40)*sqrt(sqrt(5) + 5) +
+        120*sqrt(10)*sqrt(-sqrt(5) + 5)*sqrt(8*sqrt(5) + 40) +
+        120*sqrt(10)*sqrt(-8*sqrt(5) + 40)*sqrt(sqrt(5) + 5))/(-36000 -
+        7200*sqrt(5) + (12*sqrt(10)*sqrt(sqrt(5) + 5) +
+        24*sqrt(10)*sqrt(-sqrt(5) + 5))**2))
+    # assert radsimp(eq) == 0 XXX fix handling of Mul. This should be zero
+
+    # work with normal form
+    e = 1/sqrt(sqrt(7)/7 + 2*sqrt(2) + 3*sqrt(3) + 5*sqrt(5)) + 3
+    assert radsimp(e) == (
+        -1658283*sqrt(21)*sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
+        35*sqrt(5))/260084635 - 1507966*sqrt(14)*sqrt(sqrt(7) + 14*sqrt(2) +
+        21*sqrt(3) + 35*sqrt(5))/260084635 - 1141953*sqrt(sqrt(7) + 14*sqrt(2)
+        + 21*sqrt(3) + 35*sqrt(5))/260084635 - 327012*sqrt(6)*sqrt(sqrt(7) +
+        14*sqrt(2) + 21*sqrt(3) + 35*sqrt(5))/260084635 +
+        1346996*sqrt(10)*sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
+        35*sqrt(5))/1300423175 + 1278438*sqrt(15)*sqrt(sqrt(7) + 14*sqrt(2) +
+        21*sqrt(3) + 35*sqrt(5))/1300423175 + 1577436*sqrt(210)*sqrt(sqrt(7) +
+        14*sqrt(2) + 21*sqrt(3) + 35*sqrt(5))/1300423175 +
+        11654899*sqrt(35)*sqrt(sqrt(7) + 14*sqrt(2) + 21*sqrt(3) +
+        35*sqrt(5))/1300423175 + 3)
 
 
 def test_simplify_issue_3214():

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2610,21 +2610,23 @@ def unrad(eq, *syms, **flags):
     elif len(rterms) == 2 and not args:
         eq = rterms[0]**lcm - rterms[1]**lcm
 
-    elif log(lcm, 2).is_Integer and (not args and len(rterms) == 4 or len(rterms) < 4):
+    elif log(lcm, 2).is_Integer and (not args and
+            len(rterms) == 4 or len(rterms) < 4):
+        def _norm2(a, b):
+            return a**2 + b**2 + 2*a*b
+
         if len(rterms) == 4:
             # (r0+r1)**2 - (r2+r3)**2
-            r0, r1, r2, r3 = [t**2 for t in rterms]
-            eq = r0 + r1 + 2*rterms[0]*rterms[1] - \
-                (r2 + r3 + 2*rterms[2]*rterms[3])
+            r0, r1, r2, r3 = rterms
+            eq = _norm2(r0, r1) - _norm2(r2, r3)
         elif len(rterms) == 3:
-            # (r1+r2)**2 - (r0+a)**2
-            r0, r1, r2 = [t**2 for t in rterms]
-            eq = r1 + r2 + 2*rterms[1]*rterms[2] - \
-                (r0 + args**2 + 2*args*rterms[0])
+            # (r1+r2)**2 - (r0+args)**2
+            r0, r1, r2 = rterms
+            eq = _norm2(r1, r2) - _norm2(r0, args)
         elif len(rterms) == 2:
-            # r0**2 - (r1+a)**2
-            r0, r1 = [t**2 for t in rterms]
-            eq = r0 - (r1 + args**2 + 2*args*rterms[1])
+            # r0**2 - (r1+args)**2
+            r0, r1 = rterms
+            eq = r0**2 - _norm2(r1, args)
 
     elif len(bases) == 1:  # change of variables may work
         ok = False

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -17,7 +17,8 @@ from sympy.core.compatibility import (iterable, is_sequence, ordered,
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.sympify import sympify
 from sympy.core import (C, S, Add, Symbol, Wild, Equality, Dummy, Basic,
-    Expr, Mul)
+    Expr, Mul, Pow)
+from sympy.core.exprtools import factor_terms
 from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
                           Derivative, AppliedUndef, UndefinedFunction, nfloat,
                           count_ops)
@@ -28,13 +29,13 @@ from sympy.core.basic import preorder_traversal
 
 from sympy.functions import (log, exp, LambertW, cos, sin, tan, cot, cosh,
                              sinh, tanh, coth, acos, asin, atan, acot, acosh,
-                             asinh, atanh, acoth, Abs, sign)
+                             asinh, atanh, acoth, Abs, sign, sqrt)
 from sympy.functions.elementary.miscellaneous import real_root
 from sympy.simplify import (simplify, collect, powsimp, posify, powdenest,
                             nsimplify)
 from sympy.simplify.sqrtdenest import sqrt_depth, _mexpand
 from sympy.matrices import Matrix, zeros
-from sympy.polys import roots, cancel, Poly, together, factor, RootOf
+from sympy.polys import roots, cancel, Poly, together, factor, RootOf, degree
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
 from sympy.utilities.lambdify import lambdify
@@ -2448,7 +2449,7 @@ def unrad(eq, *syms, **flags):
 
     ValueError is raised if there are radicals and they cannot be removed.
 
-    Otherwise
+    Otherwise the tuple, ``(eq, cov, dens)``, is returned where::
 
         ``eq``, ``cov``
             equation without radicals, perhaps written in terms of
@@ -2469,8 +2470,15 @@ def unrad(eq, *syms, **flags):
             interest will be cleared.
 
     ``flags`` are used internally for communication during recursive calls.
+    Two options are also recognized::
 
-    Radicals can be removed from an expression if:
+        ``take``, when defined, is interpreted as a single-argument function
+        that returns True if a given Pow should be handled.
+        ``all``, when True, will signify that an attempt should be made to
+        remove all radicals. ``take``, if present, has priority over ``all``.
+
+    Radicals can be removed from an expression if::
+
         *   all bases of the radicals are the same; a change of variables is
             done in this case.
         *   if all radicals appear in one term of the expression
@@ -2483,33 +2491,70 @@ def unrad(eq, *syms, **flags):
         >>> from sympy.solvers.solvers import unrad
         >>> from sympy.abc import x
         >>> from sympy import sqrt, Rational
-        >>> unrad(sqrt(x)*x**Rational(1,3) + 2)
+        >>> unrad(sqrt(x)*x**Rational(1, 3) + 2)
         (x**5 - 64, [], [])
-        >>> unrad(sqrt(x) + (x + 1)**Rational(1,3))
+        >>> unrad(sqrt(x) + (x + 1)**Rational(1, 3))
         (x**3 - x**2 - 2*x - 1, [], [])
-        >>> unrad(sqrt(x) + x**Rational(1,3) + 2)
+        >>> unrad(sqrt(x) + x**Rational(1, 3) + 2)
         (_p**3 + _p**2 + 2, [(_p, -_p**6 + x)], [])
 
     """
+    def _canonical(eq):
+        # remove constants since these don't change the location of the root
+        # and expand the expression
+        eq = factor_terms(eq)
+        if eq.is_Mul:
+            eq = Mul(*[f for f in eq.args if not f.is_number])
+        eq = _mexpand(eq)
+
+        # make sign canonical
+        free = eq.free_symbols
+        if len(free) == 1:
+            if eq.coeff(free.pop()**degree(eq)) < 0:
+                eq = -eq
+        elif eq.could_extract_minus_sign():
+            eq = -eq
+
+        return eq
+
     if eq.is_Atom:
         return
-    cov, dens, nwas = [flags.get(k, v) for k, v in
-                       sorted(dict(dens=None, cov=None, n=None).items())]
+    cov, dens, nwas, rpt = [flags.get(k, v) for k, v in
+        sorted(dict(dens=None, cov=None, n=None, rpt=0).items())]
 
-    def _take(d):
-        # see if this is a term that has symbols of interest
-        # and merits further processing
-        free = d.free_symbols
-        if not free:
-            return False
-        return not syms or free.intersection(syms)
+    if flags.get('take', None):
+        _take = flags.pop('take')
+    elif flags.pop('all', None):
+        _rad = lambda w: w.is_Pow and w.exp.is_Rational and w.exp.q != 1
+        def _take(d):
+            return _rad(d) or any(_rad(i) for i in d.atoms(Pow))
+        if eq.has(S.ImaginaryUnit):
+            i = Dummy()
+            flags['take'] = _take
+            try:
+                rv = unrad(eq.xreplace({S.ImaginaryUnit: sqrt(i)}), *syms, **flags)
+                rep = {i: S.NegativeOne}
+                rv = (_canonical(rv[0].xreplace(rep)),
+                      [tuple([j.xreplace(rep) for j in i]) for i in rv[1]],
+                      [i.xreplace(rep) for i in rv[2]])
+                return rv
+            except ValueError, msg:
+                raise msg
+    else:
+        def _take(d):
+            # see if this is a term that has symbols of interest
+            # and merits further processing
+            free = d.free_symbols
+            if not free:
+                return False
+            return not syms or free.intersection(syms)
 
     if dens is None:
         dens = set()
     if cov is None:
         cov = []
 
-    eq = powdenest(eq)
+    eq = powdenest(factor_terms(eq, radical=True))
     eq, d = eq.as_numer_denom()
     eq = _mexpand(eq)
     if _take(d):
@@ -2555,7 +2600,7 @@ def unrad(eq, *syms, **flags):
     rterms = [Add(*rterms[k]) for k in rterms.keys()]
     # the output will depend on the order terms are processed, so
     # make it canonical quickly
-    rterms.sort(key=default_sort_key)
+    rterms = list(reversed(list(ordered(rterms))))
 
     # continue handling
     ok = True
@@ -2568,18 +2613,18 @@ def unrad(eq, *syms, **flags):
     elif log(lcm, 2).is_Integer and (not args and len(rterms) == 4 or len(rterms) < 4):
         if len(rterms) == 4:
             # (r0+r1)**2 - (r2+r3)**2
-            t1, t2, t3, t4 = [t**2 for t in rterms]
-            eq = t1 + t2 + 2*rterms[0]*rterms[1] - \
-                (t3 + t4 + 2*rterms[2]*rterms[3])
+            r0, r1, r2, r3 = [t**2 for t in rterms]
+            eq = r0 + r1 + 2*rterms[0]*rterms[1] - \
+                (r2 + r3 + 2*rterms[2]*rterms[3])
         elif len(rterms) == 3:
-            # (r0+r1)**2 - (r2+a)**2
-            t1, t2, t3 = [t**2 for t in rterms]
-            eq = t1 + t2 + 2*rterms[0]*rterms[1] - \
-                (t3 + args**2 + 2*args*rterms[2])
+            # (r1+r2)**2 - (r0+a)**2
+            r0, r1, r2 = [t**2 for t in rterms]
+            eq = r1 + r2 + 2*rterms[1]*rterms[2] - \
+                (r0 + args**2 + 2*args*rterms[0])
         elif len(rterms) == 2:
-            t1, t2 = [t**2 for t in rterms[:2]]
             # r0**2 - (r1+a)**2
-            eq = t1 - (t2 + args**2 + 2*args*rterms[1])
+            r0, r1 = [t**2 for t in rterms]
+            eq = r0 - (r1 + args**2 + 2*args*rterms[1])
 
     elif len(bases) == 1:  # change of variables may work
         ok = False
@@ -2605,13 +2650,16 @@ def unrad(eq, *syms, **flags):
         ok = False
 
     new_depth = sqrt_depth(eq)
-    if not ok or (nwas is not None and len(rterms) == nwas and new_depth and new_depth == depth):
+    rpt += 1  # XXX how many repeats with others unchanging is enough?
+    if not ok or (
+                nwas is not None and len(rterms) == nwas and
+                new_depth is not None and new_depth == depth and
+                rpt > 3):
         # XXX: XFAIL tests indicate other cases that should be handled.
         raise ValueError('Cannot remove all radicals from %s' % eq)
 
-    neq = unrad(eq, *syms, **dict(cov=cov, dens=dens, n=len(rterms)))
+    neq = unrad(eq, *syms, **dict(cov=cov, dens=dens, n=len(rterms), rpt=rpt, take=_take))
     if neq:
         eq = neq[0]
-    if eq.could_extract_minus_sign():
-        eq = -eq
-    return (_mexpand(eq), cov, list(dens))
+
+    return (_canonical(eq), cov, list(dens))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -3,7 +3,7 @@ from sympy import (
     LambertW, Lt, Matrix, Or, Poly, Q, Rational, S, Symbol, Wild, acos,
     asin, atan, atanh, cos, cosh, diff, exp, expand, im, log, pi, re, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
-    RootOf)
+    root)
 from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
@@ -743,7 +743,7 @@ def test_unrad():
     assert check(unrad(sqrt(x) + sqrt(1 - x)),
                 (2*x - 1, [], []))
     assert check(unrad(sqrt(x) + sqrt(1 - x) - 3),
-                (36*x + (2*x - 10)**2 - 36, [], []))
+                (9*x + (x - 5)**2 - 9, [], []))
     assert check(unrad(sqrt(x) + sqrt(1 - x) + sqrt(2 + x)),
                 (-5*x**2 + 2*x - 1, [], []))
     assert check(unrad(sqrt(x) + sqrt(1 - x) + sqrt(2 + x) - 3),
@@ -761,7 +761,8 @@ def test_unrad():
     assert set(solve(sqrt(x) - sqrt(x + 1) + sqrt(1 - sqrt(x)))) == \
         set([S.Zero, S(9)/16])
 
-    '''real_root changes the value of the result if the solution is
+    '''NOTE
+    real_root changes the value of the result if the solution is
     simplified; `a` in the text below is the root that is not 4/5:
     >>> eq
     sqrt(x) + sqrt(-x + 1) + sqrt(x + 1) - 6*sqrt(5)/5
@@ -794,10 +795,12 @@ def test_unrad():
         set([i.n(chop=True) for i in ans]) == \
         set([i.n(chop=True) for i in (ra, rb)])
 
-    raises(
-        ValueError, lambda: unrad(sqrt(x) + sqrt(x + 1) + sqrt(1 - sqrt(x)) + 3))
-    raises(ValueError, lambda: unrad(sqrt(x) + (x + 1)**Rational(1, 3) +
-           2*sqrt(y)))
+    raises(ValueError, lambda:
+        unrad(-root(x,3)**2 + 2**pi*root(x,3) - x + 2**pi))
+    raises(ValueError, lambda:
+        unrad(sqrt(x) + sqrt(x + 1) + sqrt(1 - sqrt(x)) + 3))
+    raises(ValueError, lambda:
+        unrad(sqrt(x) + (x + 1)**Rational(1, 3) + 2*sqrt(y)))
     # same as last but consider only y
     assert check(unrad(sqrt(x) + (x + 1)**Rational(1, 3) + 2*sqrt(y), y),
            (4*y - (sqrt(x) + (x + 1)**(S(1)/3))**2, [], []))
@@ -842,6 +845,17 @@ def test_unrad():
     assert solve(z) == []
     assert solve(z + 6*I) == [-S(1)/11]
     assert solve(p + 6*I) == []
+
+    eq = sqrt(2 + I) + 2*I
+    assert unrad(eq - x, x, all=True) == (x**4 + 4*x**2 + 8*x + 37, [], [])
+    ans = (81*x**8 - 2268*x**6 - 4536*x**5 + 22644*x**4 + 63216*x**3 -
+        31608*x**2 - 189648*x + 141358, [], [])
+    r = sqrt(sqrt(2)/3 + 7)
+    eq = sqrt(r) + r - x
+    assert unrad(eq, all=1)
+    r2 = sqrt(sqrt(2) + 21)/sqrt(3)
+    assert r != r2 and r.equals(r2)
+    assert unrad(eq - r + r2, all=True) == ans
 
 
 @slow


### PR DESCRIPTION
unrad
    - now makes the returned expression more canonical
    - recognizes two keywords, `take` and `all` as described
      in the docstring. `all`, in particular, can be used to remove
      all radicals (or attempt to) from an expression.
    - the radicals are sorted in reverse order of complexity as this
      seems to provide better results as the added test shows.

radsimp
    - radsimp no longer uses match and it also works with
      radicals that are powers of 2 (e.g. sqrt(sqrt(x))).

```
>>> radsimp(1/(sqrt(sqrt(3))+sqrt(4)+(sqrt(sqrt(5)))))  # in master
1/(3**(1/4) + 5**(1/4) + 2)
>>> _.n()
0.207838729369393

>>> S('''(-20512*15**(3/4) - 39808*3**(3/4)*5**(1/4) - 25472*3**(1/4)*5**(3/4) -
 35824*sqrt(3) - 27664*sqrt(5) - 8384*sqrt(15) - 16960*5**(1/4) - 12992*3**(1/4)
 + 6344*3**(1/4)*sqrt(5) + 10424*sqrt(3)*5**(1/4) + 14976*15**(1/4) + 16928*sqrt
(3)*5**(3/4) + 24096*3**(3/4)*sqrt(5) + 44600*5**(3/4) + 153344 + 69192*3**(3/4)
)/737264''').n()  # from this PR
0.207838729369393
```

```
- The precomputed multiplication factors (num) are used to
  clear the identified radical in the terms of a denominator.
- rather than play with the sign of numerator and denominator,
  an unevaluated Mul is returned from radsimp. The arguments
  are sorted so properties like "Number in slot 0" are observed.
```
