### PR TITLE
Correct Pow.as_real_imag() for im=0 (see issue 3474)

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -633,7 +633,7 @@ class Pow(Expr):
         if self.exp.is_Integer:
             exp = self.exp
             re, im = self.base.as_real_imag(deep=deep)
-            if re.func == C.re or im.func == C.im or not im:
+            if not im:
                 return self, S.Zero
             a, b = symbols('a b', cls=Dummy)
             if exp >= 0:

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -180,6 +180,9 @@ def test_real_imag():
     assert (sin(x)*sin(x).conjugate()).as_real_imag() == \
         (Abs(sin(x))**2, 0)
 
+    # issue 3474:
+    assert (x**2).as_real_imag() == (re(x)**2 - im(x)**2, 2*re(x)*im(x))
+
 
 def test_pow_issue_1724():
     e = ((-1)**(S(1)/3))


### PR DESCRIPTION
This was fixed before for issue 3162, see PR #1161
