### PR TITLE
lxml instead of libxml2 for c2p

### DIFF
--- a/sympy/printing/tests/test_gtk.py
+++ b/sympy/printing/tests/test_gtk.py
@@ -1,7 +1,7 @@
 from sympy import print_gtk, sin
 from sympy.utilities.pytest import XFAIL, raises
 
-# this test fails if python-libxml2 isn't installed. We don't want to depend on
+# this test fails if python-lxml isn't installed. We don't want to depend on
 # anything with SymPy
 
 

--- a/sympy/utilities/mathml/__init__.py
+++ b/sympy/utilities/mathml/__init__.py
@@ -20,7 +20,6 @@ def apply_xsl(mml, xsl):
     @param mml: a string with MathML code
     @param xsl: a string representing a path to a xsl (xml stylesheet)
         file. This file name is relative to the PYTHONPATH
-    
     >>> xsl = 'mathml/data/simple_mmlctop.xsl'
     >>> mml = '<apply> <inverse/> <sin/> </apply>'
     >>> apply_xsl(mml,xsl)

--- a/sympy/utilities/mathml/__init__.py
+++ b/sympy/utilities/mathml/__init__.py
@@ -20,9 +20,13 @@ def apply_xsl(mml, xsl):
     @param mml: a string with MathML code
     @param xsl: a string representing a path to a xsl (xml stylesheet)
         file. This file name is relative to the PYTHONPATH
+    >>> from sympy.utilities.mathml import apply_xsl
     >>> xsl = 'mathml/data/simple_mmlctop.xsl'
     >>> mml = '<apply> <inverse/> <sin/> </apply>'
-    >>> apply_xsl(mml,xsl)
+    >>> res = apply_xsl(mml,xsl)
+    >>> '-1' in res.splitlines()[6]
+    True
+    
     """
     from lxml import etree
     s = etree.XML(get_resource(xsl).read())

--- a/sympy/utilities/mathml/__init__.py
+++ b/sympy/utilities/mathml/__init__.py
@@ -5,6 +5,7 @@ To use this module, you will need lxml.
 """
 
 from sympy.utilities.pkgdata import get_resource
+from sympy.utilities.decorator import doctest_depends_on
 import xml.dom.minidom
 
 

--- a/sympy/utilities/mathml/__init__.py
+++ b/sympy/utilities/mathml/__init__.py
@@ -1,8 +1,7 @@
 """Module with some functions for MathML, like transforming MathML
 content in MathML presentation.
 
-To use this module, you will need libxml2 and libxslt, with its
-respective python bindings.
+To use this module, you will need lxml.
 """
 
 from sympy.utilities.pkgdata import get_resource
@@ -21,24 +20,17 @@ def apply_xsl(mml, xsl):
     @param mml: a string with MathML code
     @param xsl: a string representing a path to a xsl (xml stylesheet)
         file. This file name is relative to the PYTHONPATH
+    
+    >>> xsl = 'mathml/data/simple_mmlctop.xsl'
+    >>> mml = '<apply> <inverse/> <sin/> </apply>'
+    >>> apply_xsl(mml,xsl)
     """
-
-    import libxml2
-    import libxslt
-
-    s = get_resource(xsl).read()
-
-    styledoc = libxml2.parseDoc(s)
-    style = libxslt.parseStylesheetDoc(styledoc)
-
-    doc = libxml2.parseDoc(mml)
-    result = style.applyStylesheet(doc, None)
-    sourceDoc = result
-    s = style.saveResultToString(result)
-
-    style.freeStylesheet()
-    sourceDoc.freeDoc()
-
+    from lxml import etree
+    s = etree.XML(get_resource(xsl).read())
+    transform = etree.XSLT(s)
+    doc = etree.XML(mml)
+    result = transform(doc)
+    s = str(result)
     return s
 
 

--- a/sympy/utilities/mathml/__init__.py
+++ b/sympy/utilities/mathml/__init__.py
@@ -15,18 +15,20 @@ def add_mathml_headers(s):
         http://www.w3.org/Math/XMLSchema/mathml2/mathml2.xsd">""" + s + "</math>"
 
 
+@doctest_depends_on(modules=('lxml',))
 def apply_xsl(mml, xsl):
     """Apply a xsl to a MathML string
     @param mml: a string with MathML code
     @param xsl: a string representing a path to a xsl (xml stylesheet)
         file. This file name is relative to the PYTHONPATH
+
     >>> from sympy.utilities.mathml import apply_xsl
     >>> xsl = 'mathml/data/simple_mmlctop.xsl'
-    >>> mml = '<apply> <inverse/> <sin/> </apply>'
+    >>> mml = '<apply> <plus/> <ci>a</ci> <ci>b</ci> </apply>'
     >>> res = apply_xsl(mml,xsl)
-    >>> '-1' in res.splitlines()[6]
-    True
-    
+    >>> ''.join(res.splitlines())
+    '<?xml version="1.0"?><mrow xmlns="http://www.w3.org/1998/Math/MathML">  <mi>a</mi>  <mo> + </mo>  <mi>b</mi></mrow>'
+
     """
     from lxml import etree
     s = etree.XML(get_resource(xsl).read())
@@ -37,10 +39,17 @@ def apply_xsl(mml, xsl):
     return s
 
 
+@doctest_depends_on(modules=('lxml',))
 def c2p(mml, simple=False):
     """Transforms a document in MathML content (like the one that sympy produces)
     in one document in MathML presentation, more suitable for printing, and more
     widely accepted
+
+    >>> from sympy.utilities.mathml import c2p
+    >>> mml = '<apply> <exp/> <cn>2</cn> </apply>'
+    >>> c2p(mml,simple=True) != c2p(mml,simple=False)
+    True
+
     """
 
     if not mml.startswith('<math'):

--- a/sympy/utilities/pkgdata.py
+++ b/sympy/utilities/pkgdata.py
@@ -49,7 +49,7 @@ def get_resource(identifier, pkgname=__name__):
     if loader is not None:
         try:
             data = loader.get_data(path)
-        except IOError:
+        except (IOError,AttributeError):
             pass
         else:
             return StringIO(data)


### PR DESCRIPTION
google app engine supports lxml and generally better supported
- the dependency is only in c2p, i.e. convert content mathml to representation mathml
- google app engine loader does not have get_data, so I added AttributeError to except...
