### PR TITLE
3341 - allow powsimp to process coefficients (last 2 commits)

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1013,7 +1013,7 @@ class Pow(Expr):
         >>> eq.as_content_primitive()
         (9, 3**(2*x))
         >>> powsimp(Mul(*_))
-        9**(x + 1)
+        3**(2*x + 2)
 
         >>> eq = (2 + 2*x)**y
         >>> s = expand_power_base(eq); s.is_Mul, s

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -274,14 +274,15 @@ def test_expint():
         expint(aneg, x)
 
     assert mellin_transform(Si(x), x, s) == \
-        (-2**s*sqrt(pi)*gamma((s + 1)/2)/(2*s*gamma(-s/2 + 1)
-            ), (-1, 0), True)
+        (-2**(s - 1)*sqrt(pi)*gamma(s/2 + S(1)/2)/(s*gamma(-s/2 + 1)), (-1, 0),
+        True)
     assert inverse_mellin_transform(-2**s*sqrt(pi)*gamma((s + 1)/2)
                                     /(2*s*gamma(-s/2 + 1)), s, x, (-1, 0)) \
         == Si(x)
 
     assert mellin_transform(Ci(sqrt(x)), x, s) == \
-        (-4**s*sqrt(pi)*gamma(s)/(2*s*gamma(-s + S(1)/2)), (0, 1), True)
+        (-2**(2*s - 1)*sqrt(pi)*gamma(s)/(s*gamma(-s + S(1)/2)
+        ), (0, 1), True)
     assert inverse_mellin_transform(
         -4**s*sqrt(pi)*gamma(s)/(2*s*gamma(-s + S(1)/2)),
         s, u, (0, 1)).expand() == Ci(sqrt(u))

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -5,7 +5,7 @@ import random
 import math
 
 from sympy.core.evalf import bitcount
-from sympy.core.numbers import igcd
+from sympy.core.numbers import igcd, oo, Rational
 from sympy.core.power import integer_nthroot, Pow
 from sympy.core.mul import Mul
 from sympy.core.compatibility import as_int, SYMPY_INTS
@@ -193,11 +193,31 @@ def multiplicity(p, n):
     ========
 
     >>> from sympy.ntheory import multiplicity
+    >>> from sympy.core.numbers import Rational as R
     >>> [multiplicity(5, n) for n in [8, 5, 25, 125, 250]]
     [0, 1, 2, 3, 3]
+    >>> multiplicity(3, R(1, 9))
+    -2
 
     """
-    p, n = as_int(p), as_int(n)
+    try:
+            p, n = as_int(p), as_int(n)
+    except ValueError:
+        if all(isinstance(i, (SYMPY_INTS, Rational)) for i in (p, n)):
+            try:
+                p = Rational(p)
+                n = Rational(n)
+                like_min = min(
+                    multiplicity(p.p, n.p) if p.p != 1 else oo,
+                    multiplicity(p.q, n.q) if p.q != 1 else oo)
+                cross_min = min(
+                    multiplicity(p.p, n.q) if p.p != 1 else oo,
+                    multiplicity(p.q, n.p) if p.q != 1 else oo)
+                return like_min - cross_min
+            except AttributeError:
+                pass
+        raise ValueError('expecting ints or fractions, got %s and %s' % (p, n))
+
     if p == 2:
         return trailing(n)
     if p < 2:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2555,6 +2555,8 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         nc_part = []
         newexpr = []
         for term in expr.args:
+            if term.is_Pow:
+                term = _denest_pow(term)
             if term.is_commutative:
                 b, e = term.as_base_exp()
                 if deep:

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -664,6 +664,10 @@ def test_issue_3268():
     assert powsimp(z) != 0
 
 
+def test_issue_3341():
+    assert powsimp(16*2**a*8**b) == 2**(a + 3*b + 4)
+
+
 def test_powsimp_polar():
     from sympy import polar_lift, exp_polar
     x, y, z = symbols('x y z')
@@ -1548,7 +1552,7 @@ def test_combsimp_gamma():
 
     assert simplify(combsimp(
         gamma(x)*gamma(x + S(1)/2)*gamma(y)/gamma(x + y))) == \
-        2*4**-x*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)
+        2**(-2*x + 1)*sqrt(pi)*gamma(2*x)*gamma(y)/gamma(x + y)
     assert combsimp(1/gamma(x)/gamma(x - S(1)/3)/gamma(x + S(1)/3)) == \
         3**(3*x - S(3)/2)/(2*pi*gamma(3*x - 1))
     assert simplify(
@@ -1556,7 +1560,7 @@ def test_combsimp_gamma():
     assert combsimp(gamma(S(-1)/4)*gamma(S(-3)/4)) == 16*sqrt(2)*pi/3
 
     assert simplify(combsimp(gamma(2*x)/gamma(x))) == \
-        4**x*gamma(x + S(1)/2)/sqrt(pi)/2
+        2**(2*x - 1)*gamma(x + S(1)/2)/sqrt(pi)
 
     # issue 3693
     e = (-gamma(k)*gamma(k + 2) + gamma(k + 1)**2)/gamma(k)**2

--- a/sympy/solvers/tests/test_recurr.py
+++ b/sympy/solvers/tests/test_recurr.py
@@ -176,7 +176,7 @@ def test_rsolve():
 
     assert expand_func(rsolve(f, y(n), \
         {y(1): binomial(2*n + 1, 3)}).rewrite(gamma)).simplify() == \
-        4**n*n*(8*n**3 - 4*n**2 - 2*n + 1)/12
+        2**(2*n - 2)*n*(8*n**3 - 4*n**2 - 2*n + 1)/3
 
     assert (rsolve(y(n) + a*(y(n + 1) + y(n - 1))/2, y(n)) -
             (C0*((sqrt(-a**2 + 1) - 1)/a)**n +


### PR DESCRIPTION
https://code.google.com/p/sympy/issues/detail?id=3341

master processes exact coefficients

```
>>> powsimp(2*2**n)
2**(n + 1)
```

in this PR factors can be removed from coefficients

```
>>> powsimp(4*2**n)
2**(n + 2)
>>> powsimp(16*2**m*8**n)
2**(m + 3*n + 4)
```

= only the last two commits need review; the others are in #2014 =
