### PR TITLE
Issue #3773: Error in acos(x).rewrite(atan)

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -586,6 +586,7 @@ def test_acos_series():
 
 def test_acos_rewrite():
     assert acos(x).rewrite(log) == pi/2 + I*log(I*x + sqrt(1 - x**2))
+    assert acos(x).rewrite(atan) == 2*atan(sqrt(1 - x**2)/(1 + x))
     assert acos(0).rewrite(atan) == S.Pi/2
     assert acos(0.5).rewrite(atan) == acos(0.5).rewrite(log)
     assert acos(x).rewrite(asin) == S.Pi/2 - asin(x)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -586,7 +586,8 @@ def test_acos_series():
 
 def test_acos_rewrite():
     assert acos(x).rewrite(log) == pi/2 + I*log(I*x + sqrt(1 - x**2))
-    assert acos(x).rewrite(atan) == 2*atan(sqrt(1 - x**2)/(1 + x))
+    assert acos(x).rewrite(atan) == \
+           atan(sqrt(1 - x**2)/x) + (pi/2)*(1 - x*sqrt(1/x**2))
     assert acos(0).rewrite(atan) == S.Pi/2
     assert acos(0.5).rewrite(atan) == acos(0.5).rewrite(log)
     assert acos(x).rewrite(asin) == S.Pi/2 - asin(x)

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1434,7 +1434,7 @@ class acos(Function):
         return S.Pi/2 - asin(x)
 
     def _eval_rewrite_as_atan(self, x):
-        return 2 * atan(sqrt(1 - x**2)/(1 + x))
+        return atan(sqrt(1 - x**2)/x) + (S.Pi/2)*(1 - x*sqrt(1/x**2))
 
     def _sage_(self):
         import sage.all as sage

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1434,11 +1434,7 @@ class acos(Function):
         return S.Pi/2 - asin(x)
 
     def _eval_rewrite_as_atan(self, x):
-        if x > -1 and x <= 1:
-            return 2 * atan(sqrt(1 - x**2)/(1 + x))
-        else:
-            raise ValueError(
-                "The argument must be bounded in the interval (-1,1]")
+        return 2 * atan(sqrt(1 - x**2)/(1 + x))
 
     def _sage_(self):
         import sage.all as sage


### PR DESCRIPTION
acos().rewrite(atan) returned an error whenever the argument being passed was outside (-1,1]. This prevents symbols from being rewritten to atan. The function was changed to match the rewrite_as_atan in asin.

A test was added to test_trigonometric to ensure acos(x).rewrite(atan) returns 2_atan(sqrt(1 - x_*2)/(1+x))
