### PR TITLE
added elementary arithmetic operations on algebraic numbers

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -101,6 +101,8 @@ def _separate_sq(p):
                 a.append((S.One, y**2))
             elif y.is_Atom:
                 a.append((y, S.One))
+            elif y.is_Pow and y.exp.is_integer:
+                a.append((y, S.One))
             else:
                 raise NotImplementedError
             continue
@@ -183,25 +185,6 @@ def _minimal_polynomial_sq(p, n, x):
 
     result = _choose_factor(factors, x, pn)
     return result
-
-def _minpoly_neg(ex, x, mp):
-    """
-    return the minimal polynomial of ``-ex``.
-
-    Examples
-    ========
-
-    >>> from sympy import Rational
-    >>> from sympy.polys.numberfields import minpoly, _minpoly_neg
-    >>> from sympy.abc import x
-    >>> p = 2**Rational(1, 3)
-    >>> mp = minpoly(p, x)
-    >>> _minpoly_neg(p, x, mp=mp)
-    -x**3 - 2
-    """
-    if mp is None:
-        mp = _minpoly1(ex, x)
-    return mp.subs({x: -x})
 
 def _minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, op=Add):
     """
@@ -338,10 +321,6 @@ def _minpoly_add(x, *a):
     """
     returns ``minpoly(Add(*a), x)``
     """
-    if not a:
-        return S.Zero
-    if len(a) == 1:
-        return _minpoly1(a[0], x)
     mp = _minpoly_op_algebraic_number(a[0], a[1], x, op=Add)
     p = a[0] + a[1]
     for px in a[2:]:
@@ -353,10 +332,6 @@ def _minpoly_mul(x, *a):
     """
     returns ``minpoly(Mul(*a), x)``
     """
-    if not a:
-        return S.One
-    if len(a) == 1:
-        return _minpoly1(a[0], x)
     mp = _minpoly_op_algebraic_number(a[0], a[1], x, op=Mul)
     p = a[0] * a[1]
     for px in a[2:]:
@@ -393,8 +368,7 @@ def _minpoly_sin(ex, x):
             else:
                 ex1 = (C.exp(I*ex.args[0]) - C.exp(-I*ex.args[0]))/(2*I)
                 return _minpoly1(ex1, x)
-        else:
-            raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
+
     raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
 
 def _minpoly_cos(ex, x):
@@ -423,8 +397,7 @@ def _minpoly_cos(ex, x):
             else:
                 ex1 = (C.exp(I*ex.args[0]) + C.exp(-I*ex.args[0]))/2
                 return _minpoly1(ex1, x)
-        else:
-            raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
+
     raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
 
 def _minpoly_exp(ex, x):

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -321,7 +321,7 @@ def _minpoly_mul(x, *a):
     if len(a) == 1:
         return minpoly1(a[0], x)
     mp = minpoly_op_algebraic_number(a[0], a[1], x, op=Mul)
-    p = a[0] + a[1]
+    p = a[0] * a[1]
     for px in a[2:]:
         p1 = p * px
         mp1 = minpoly_op_algebraic_number(p, px, x, mp1=mp, op=Mul)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -273,10 +273,6 @@ def minpoly_pow(ex, pw, x, mp=None, prec=200):
     pw : rational number
     x : indeterminate of the polynomial
 
-    TODO: avoid using ``groebner``, use linear algebra; this would be
-    faster; in the case of ``pw`` integer it would also not be necessary
-    to use ``factor_list``.
-
     Examples
     ========
 
@@ -300,8 +296,8 @@ def minpoly_pow(ex, pw, x, mp=None, prec=200):
     y = Dummy('y')
     mp = mp.subs({x:y})
     n, d = pw.as_numer_denom()
-    res = groebner([mp, x**d - y**n], gens=[y, x], order='lex')
-    _, factors = factor_list(res[-1])
+    res = resultant(mp, x**d - y**n, gens=[y])
+    _, factors = factor_list(res)
     res = _choose_factor(factors, x, ex**pw, prec)
     return res
 

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -201,7 +201,7 @@ def _minpoly_neg(ex, x, mp):
     return mp.subs({x: -x})
 
 def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
-        method='resultant', op=Add):
+        op=Add):
     """
     return the minimal polinomial for ``op(ex1, ex2)``
 
@@ -212,7 +212,6 @@ def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
     x : indeterminate of the polynomials
     mp1, mp2 : minimal polynomials for ``ex1`` and ``ex2`` or None
     prec : max precision used in identifying factors
-    method : use 'resultant' or 'groebner' method
     op : operation ``Add`` or ``Mul``
 
     Examples
@@ -223,7 +222,7 @@ def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
     >>> from sympy.abc import x
     >>> p1 = sqrt(sqrt(2) + 1)
     >>> p2 = sqrt(sqrt(2) - 1)
-    >>> minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Mul)
+    >>> minpoly_op_algebraic_number(p1, p2, x, op=Mul)
     x - 1
 
     References
@@ -242,24 +241,14 @@ def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
     else:
         mp2 = mp2.subs({x:y})
 
-    if method == 'resultant':
-        if op is Add:
-            mp1a = mp1.subs({x:x - y})
-        elif op is Mul:
-            mp1a = y**degree(mp1)*mp1.subs({x:x / y})
-        else:
-            raise NotImplementedError('option not available')
-        mp1a = _mexpand(mp1a)
-        r = resultant(mp1a, mp2, gens=[y])
-    elif method == 'groebner':
-        z = Dummy('z')
-        if op in [Add, Mul]:
-            g = groebner([mp1, mp2, op(x, y) - z], gens=[x, y, z], order='lex')
-        else:
-            raise NotImplementedError('option not available')
-        r = g[-1].subs({z:x})
+    if op is Add:
+        mp1a = mp1.subs({x:x - y})
+    elif op is Mul:
+        mp1a = y**degree(mp1)*mp1.subs({x:x / y})
     else:
         raise NotImplementedError('option not available')
+    mp1a = _mexpand(mp1a)
+    r = resultant(mp1a, mp2, gens=[y, x])
 
     gcd_deg = gcd(degree(mp1), degree(mp2))
     if gcd_deg == 1:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -170,7 +170,7 @@ def _minimal_polynomial_sq(p, n, x, prec):
     # if n > 1 it contains the minimal polynomial as a factor.
     if n == 1:
         p1 = Poly(p)
-        if p.coeff(x**p1.degree()) < 0:
+        if p.coeff(x**p1.degree(x)) < 0:
             p = -p
         p = p.primitive()[1]
         return p
@@ -244,13 +244,13 @@ def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
     if op is Add:
         mp1a = mp1.subs({x:x - y})
     elif op is Mul:
-        mp1a = y**degree(mp1)*mp1.subs({x:x / y})
+        mp1a = y**degree(mp1, x)*mp1.subs({x:x / y})
     else:
         raise NotImplementedError('option not available')
     mp1a = _mexpand(mp1a)
     r = resultant(mp1a, mp2, gens=[y, x])
 
-    gcd_deg = gcd(degree(mp1), degree(mp2))
+    gcd_deg = gcd(degree(mp1, x), degree(mp2, y))
     if gcd_deg == 1:
         # in this case `r` is irreducible, see [2]
         return r
@@ -290,7 +290,9 @@ def _minpoly_pow(ex, pw, x, mp=None, prec=200):
     if not pw.is_rational:
         raise NotAlgebraic("%s doesn't seem to be an algebraic number" % ex)
     if pw < 0:
-        mp = expand_mul(x**degree(mp)*mp.subs(x, 1/x))
+        if mp == x:
+            raise ZeroDivisionError('%s is zero' % ex)
+        mp = expand_mul(x**degree(mp, x)*mp.subs(x, 1/x))
         pw = -pw
         ex = 1/ex
     y = Dummy(str(x))
@@ -549,7 +551,7 @@ def minimal_polynomial(ex, x=None, **args):
 
     if compose:
         result = minpoly1(ex, x)
-        c = result.coeff(x**degree(result))
+        c = result.coeff(x**degree(result, x))
         if c < 0:
             result = expand_mul(-result)
             c = -c
@@ -679,8 +681,8 @@ def minimal_polynomial(ex, x=None, **args):
             if result is None:
                 raise NotImplementedError("multiple candidates for the minimal polynomial of %s" % ex)
     if inverted:
-        result = expand_mul(x**degree(result)*result.subs(x, 1/x))
-        if result.coeff(x**degree(result)) < 0:
+        result = expand_mul(x**degree(result, x)*result.subs(x, 1/x))
+        if result.coeff(x**degree(result, x)) < 0:
             result = expand_mul(-result)
     if polys:
         return cls(result, x, field=True)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -225,7 +225,10 @@ def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
     ==========
 
     [1] http://en.wikipedia.org/wiki/Resultant
+    [2] J.V. Brawley and L. Carlitz, Discrete Math., 65(2):115 (1987)
+    "Irreducibles and the composed product over a finite field".
     """
+    from sympy import gcd
     y = Dummy('y')
     if mp1 is None:
         mp1 = minimal_polynomial(ex1, x)
@@ -251,6 +254,11 @@ def minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, prec=200,
         r = g[-1].subs({z:x})
     else:
         raise NotImplementedError('option not available')
+
+    gcd_deg = gcd(degree(mp1), degree(mp2))
+    if gcd_deg == 1:
+        # in this case `r` is irreducible, see [2]
+        return r
     _, factors = factor_list(r)
     if op in [Add, Mul]:
         ex = op(ex1, ex2)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -243,8 +243,8 @@ def _minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, op=Add):
         # Let us give an argument for which `r` is irreducible.
         # The argument is based on the conjecture that for any pair of
         # irreducible polynomials `mp1 and `mp2` there is a
-        # prime `p`, larger then the maximum of the absolute values of
-        # the coefficients of `r` and of the degree of `r`,
+        # prime `p`, larger then the maximum of the absolute value of
+        # the leading coefficient of `r` and of the degree of `r`,
         # for which `mp1` and `mp2` are irreducible on GF(p).
         # Then from [2] if follows that `r` is irreducible on GF(p),
         # which implies that it is irreducible on the integers; in fact
@@ -405,11 +405,7 @@ def _minpoly_cos(ex, x):
                 q = sympify(c.q)
                 if q.is_prime:
                     s = _minpoly_sin(ex, x)
-                    factors = [_mexpand(s.subs({x:sqrt((1 + x)/2)})),
-                            _mexpand(s.subs({x:sqrt((1 - x)/2)}))]
-
-                    s = _choose_factor(factors, x, ex)
-                    return s
+                    return _mexpand(s.subs({x:sqrt((1 - x)/2)}))
                 else:
                     raise NotImplementedError('case not covered')
                     # too slow

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -215,8 +215,8 @@ def _minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, op=Add):
     ==========
 
     [1] http://en.wikipedia.org/wiki/Resultant
-    [2] J.V. Brawley and L. Carlitz, Discrete Math., 65(2):115 (1987)
-    "Irreducibles and the composed product over a finite field".
+    [2] I.M. Isaacs, Proc. Amer. Math. Soc. 25 (1970), 638
+    "Degrees of sums in a separable field extension".
     """
     from sympy import gcd
     y = Dummy(str(x))
@@ -238,21 +238,14 @@ def _minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, op=Add):
         raise NotImplementedError('option not available')
     r = resultant(mp1a, mp2, gens=[y, x])
 
-    gcd_deg = gcd(degree(mp1, x), degree(mp2, y))
-    if gcd_deg == 1:
-        # Let us give an argument for which `r` is irreducible.
-        # The argument is based on the conjecture that for any pair of
-        # irreducible polynomials `mp1 and `mp2` there is a
-        # prime `p`, larger then the maximum of the absolute value of
-        # the leading coefficient of `r` and of the degree of `r`,
-        # for which `mp1` and `mp2` are irreducible on GF(p).
-        # Then from [2] if follows that `r` is irreducible on GF(p),
-        # which implies that it is irreducible on the integers; in fact
-        # if `r` were reducible, `r = h1*h2` with `h1`, `h2` of degree >= 1,
-        # and with abs(leading coefficient) less than `p`, so that
-        # `h1` and `h2` are polynomials of degree >= 1 also on GF(p),
-        # which is contrary to the fact that `r` is irreducible on GF(p).
-        # TODO give a rigorous proof of irreducibility.
+    deg1 = degree(mp1, x)
+    deg2 = degree(mp2, y)
+    if op is Add and gcd(deg1, deg2) == 1:
+        # `r` is irreducible, see [2]
+        return r
+    if op is Mul and deg1 == 1 or deg2 == 1:
+        # if deg1 = 1, then mp1 = x - a; mp1a = x - y - a;
+        # r = mp2(x - a), so that `r` is irreducible
         return r
     _, factors = factor_list(r)
     if op in [Add, Mul]:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -238,7 +238,19 @@ def _minpoly_op_algebraic_number(ex1, ex2, x, mp1=None, mp2=None, op=Add):
 
     gcd_deg = gcd(degree(mp1, x), degree(mp2, y))
     if gcd_deg == 1:
-        # in this case `r` is irreducible, see [2]
+        # Let us give an argument for which `r` is irreducible.
+        # The argument is based on the conjecture that for any pair of
+        # irreducible polynomials `mp1 and `mp2` there is a
+        # prime `p`, larger then the maximum of the absolute values of
+        # the coefficients of `r` and of the degree of `r`,
+        # for which `mp1` and `mp2` are irreducible on GF(p).
+        # Then from [2] if follows that `r` is irreducible on GF(p),
+        # which implies that it is irreducible on the integers; in fact
+        # if `r` were reducible, `r = h1*h2` with `h1`, `h2` of degree >= 1,
+        # and with abs(leading coefficient) less than `p`, so that
+        # `h1` and `h2` are polynomials of degree >= 1 also on GF(p),
+        # which is contrary to the fact that `r` is irreducible on GF(p).
+        # TODO give a rigorous proof of irreducibility.
         return r
     _, factors = factor_list(r)
     if op in [Add, Mul]:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -26,6 +26,8 @@ from sympy.polys.specialpolys import cyclotomic_poly
 
 from sympy.polys.polyutils import dict_from_expr, expr_from_dict
 
+from sympy.polys.domains import ZZ
+
 from sympy.printing.lambdarepr import LambdaPrinter
 
 from sympy.utilities import (
@@ -357,26 +359,26 @@ def _minpoly_sin(ex, x):
     see http://mathworld.wolfram.com/TrigonometryAngles.html
     """
     from sympy.functions.combinatorial.factorials import binomial
+    from sympy.polys.orthopolys import dup_chebyshevt
     c, a = ex.args[0].as_coeff_Mul()
     if a is pi:
         if c.is_rational:
+            q = sympify(c.q)
+            if q.is_prime:
+                # for ex = pi*p/q with q odd prime, using chebyshevt
+                # write sin(q*ex) = mp(sin(ex))*sin(ex);
+                # the roots of mp(x) are sin(pi*p/q) for p = 1,..., q - 1
+                n = c.q
+                a = dup_chebyshevt(n, ZZ)
+                return Add(*[x**(n - i - 1)*a[i] for i in range(n)])
             if c.p == 1:
-                q = sympify(c.q)
-                if q == 7:
-                    return 64*x**6 - 112*x**4 + 56*x**2 - 7
                 if q == 9:
                     return 64*x**6 - 96*x**4 + 36*x**2 - 3
-                if q.is_prime:
-                    s = 0
-                    q2 = q // 2
-                    for k in range(q2 + 1):
-                        s += (-1)**k*binomial(q, 2*k + 1)*(1 - x**2)**(q2 - k)*x**(2*k)
-                    return _mexpand(s)
                 else:
-                    raise NotImplementedError('case not covered')
-                    # too slow
-                    #ex1 = (C.exp(I*ex.args[0]) - C.exp(-I*ex.args[0]))/(2*I)
-                    #return _minpoly1(ex1, x)
+                   raise NotImplementedError('case not covered')
+                   # too slow
+                   #ex1 = (C.exp(I*ex.args[0]) - C.exp(-I*ex.args[0]))/(2*I)
+                   #return _minpoly1(ex1, x)
             else:
                 ex1 = (C.exp(I*ex.args[0]) - C.exp(-I*ex.args[0]))/(2*I)
                 return _minpoly1(ex1, x)
@@ -393,6 +395,13 @@ def _minpoly_cos(ex, x):
     if a is pi:
         if c.is_rational:
             if c.p == 1:
+                if c.q == 7:
+                    return 8*x**3 - 4*x**2 - 4*x + 1
+                if c.q == 9:
+                    return 8*x**3 - 6*x + 1
+                else:
+                    raise NotImplementedError('case not covered')
+            elif c.p == 2:
                 q = sympify(c.q)
                 if q.is_prime:
                     s = _minpoly_sin(ex, x)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -152,12 +152,10 @@ def test_minimal_polynomial_sq():
 def test_minpoly_op_algebraic_number():
     p1 = sqrt(1 + 2**Rational(1, 3))
     p2 = sqrt(2)
-    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Add)
-    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Add)
-    assert mp1 == mp2 == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
-    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Mul)
-    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Mul)
-    assert mp1 == mp2 == x**6 - 6*x**4 + 12*x**2 - 24
+    mp = minpoly_op_algebraic_number(p1, p2, x, op=Add)
+    assert mp == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
+    mp = minpoly_op_algebraic_number(p1, p2, x, op=Mul)
+    assert mp == x**6 - 6*x**4 + 12*x**2 - 24
     p1 = 1 + 2**Rational(1, 3)
     p2 = sqrt(1 + sqrt(3))
     mp = minpoly_op_algebraic_number(p1, p2, x, op=Add)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -25,6 +25,7 @@ from sympy.polys.polyclasses import DMP
 from sympy.polys.domains import QQ
 from sympy.solvers import solve
 
+from sympy.utilities.pytest import skip
 
 from sympy.abc import x, y
 
@@ -227,6 +228,15 @@ def test_minpoly_compose():
     ex = 1/(-36000 - 7200*sqrt(5) + (12*sqrt(10)*sqrt(sqrt(5) + 5) +
         24*sqrt(10)*sqrt(-sqrt(5) + 5))**2) + 1
     raises(ZeroDivisionError, lambda: minimal_polynomial(ex, x))
+
+def test_minpoly_compose1():
+    skip("This test hangs.")
+    # this test hangs because factor_list hangs in minpoly_op_algebraic_number
+    # on a polynomial of degree 96, which is factored by Sage very fast;
+    # one of the factors is the minimal polynomial.
+    ex = sqrt(1 + 2**Rational(1,3)) + sqrt(1 + 2**Rational(1,4)) + sqrt(2)
+    mp = minimal_polynomial(ex, x)
+    assert degree(mp) == 48 and mp.subs({x:0}) == -16630256576
 
 
 def test_primitive_element():

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -158,9 +158,6 @@ def test_minpoly_op_algebraic_number():
     mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Mul)
     mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Mul)
     assert mp1 == mp2 == x**6 - 6*x**4 + 12*x**2 - 24
-    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op='div')
-    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op='div')
-    assert mp1 == mp2 == 8*x**6 - 12*x**4 + 6*x**2 - 3
     p1 = 1 + 2**Rational(1, 3)
     p2 = sqrt(1 + sqrt(3))
     mp = minpoly_op_algebraic_number(p1, p2, x, op=Add)
@@ -200,6 +197,8 @@ def test_minpoly_compose():
 
     mp = minimal_polynomial(exp(2*I*pi/7), x)
     assert mp == x**6 + x**5 + x**4 + x**3 + x**2 + x + 1
+    mp = minimal_polynomial(exp(2*I*pi/15), x)
+    assert mp == x**8 - x**7 + x**5 - x**4 + x**3 - x + 1
     mp = minimal_polynomial(cos(2*pi/7), x)
     assert mp == 8*x**3 + 4*x**2 - 4*x - 1
     mp = minimal_polynomial(sin(2*pi/7), x)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -6,7 +6,7 @@ from sympy import (S, Rational, Symbol, Poly, sin, sqrt, I, oo, Tuple, expand,
 from sympy.utilities.pytest import raises
 
 from sympy.polys.numberfields import (
-    minimal_polynomial, minpoly_op_algebraic_number,
+    minimal_polynomial,
     primitive_element,
     is_isomorphism_possible,
     field_isomorphism_pslq,
@@ -149,19 +149,6 @@ def test_minimal_polynomial_sq():
     mp = minimal_polynomial(p, x)
     assert mp.subs({x: 0}) == -71965773323122507776
 
-def test_minpoly_op_algebraic_number():
-    p1 = sqrt(1 + 2**Rational(1, 3))
-    p2 = sqrt(2)
-    mp = minpoly_op_algebraic_number(p1, p2, x, op=Add)
-    assert mp == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
-    mp = minpoly_op_algebraic_number(p1, p2, x, op=Mul)
-    assert mp == x**6 - 6*x**4 + 12*x**2 - 24
-    p1 = 1 + 2**Rational(1, 3)
-    p2 = sqrt(1 + sqrt(3))
-    mp = minpoly_op_algebraic_number(p1, p2, x, op=Add)
-    assert mp == x**12 - 12*x**11 + 60*x**10 - 168*x**9 + 303*x**8 - \
-        408*x**7 + 544*x**6 - 1104*x**5 + 2523*x**4 - 3756*x**3 + \
-        2820*x**2 - 1032*x + 157
 
 def test_minpoly_compose():
     # issue 3769

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -6,7 +6,7 @@ from sympy import (S, Rational, Symbol, Poly, sin, sqrt, I, oo, Tuple, expand,
 from sympy.utilities.pytest import raises
 
 from sympy.polys.numberfields import (
-    minimal_polynomial, minpoly_pow, minpoly_op_algebraic_number,
+    minimal_polynomial, minpoly_op_algebraic_number,
     primitive_element,
     is_isomorphism_possible,
     field_isomorphism_pslq,
@@ -23,6 +23,7 @@ from sympy.polys.polyerrors import (
 
 from sympy.polys.polyclasses import DMP
 from sympy.polys.domains import QQ
+from sympy.solvers import solve
 
 
 from sympy.abc import x, y
@@ -206,6 +207,13 @@ def test_minpoly_compose():
     mp = minimal_polynomial(ex, x)
     assert mp == x**3 + 2*x**2 - x - 1
     assert  minimal_polynomial(-1/(2*cos(pi/7)), x) == x**3 + 2*x**2 - x - 1
+
+    eq = expand((x**5 + 3*x + 1)*(x**3 + 4*x + 1))
+    ex = solve(eq, x)[0]
+    mp = minimal_polynomial(ex, x)
+    assert mp == x**3 + 4*x + 1
+    mp = minimal_polynomial(ex + 1, x)
+    assert mp == x**3 - 3*x**2 + 7*x - 4
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -172,6 +172,14 @@ def test_minpoly_op_algebraic_number():
     mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op='div')
     mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op='div')
     assert mp1 == mp2 == 8*x**6 - 12*x**4 + 6*x**2 - 3
+    p1 = 1 + 2**Rational(1, 3)
+    p2 = sqrt(1 + sqrt(3))
+    mp = minpoly_op_algebraic_number(p1, p2, x, op=Add)
+    assert mp == x**12 - 12*x**11 + 60*x**10 - 168*x**9 + 303*x**8 - \
+        408*x**7 + 544*x**6 - 1104*x**5 + 2523*x**4 - 3756*x**3 + \
+        2820*x**2 - 1032*x + 157
+
+
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -149,6 +149,8 @@ def test_minimal_polynomial_sq():
     assert mp.subs({x: 0}) == -71965773323122507776
 
 def test_minpoly_pow():
+    p = sqrt(2)
+    assert minpoly_pow(p, 2, x) == x - 2
     p = (2*sqrt(2) + 3)
     assert minpoly_pow(p, Rational(1, 4), x) == x**4 - 2*x**2 - 1
     p = 1 + 2**Rational(1,7)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -80,6 +80,7 @@ def test_minimal_polynomial():
 
     assert minimal_polynomial(sqrt(2), polys=True) == Poly(x**2 - 2)
     assert minimal_polynomial(sqrt(2), x, polys=True) == Poly(x**2 - 2)
+    assert minimal_polynomial(sqrt(2), x, polys=True, compose=False) == Poly(x**2 - 2)
 
     a = AlgebraicNumber(sqrt(2))
     b = AlgebraicNumber(sqrt(3))

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -149,11 +149,13 @@ def test_minimal_polynomial_sq():
     assert mp.subs({x: 0}) == -71965773323122507776
 
 def test_minpoly_pow():
-    mp = minimal_polynomial(1 + 2**Rational(1,7), x)
-    assert minpoly_pow(mp, Rational(4, 3), x) == x**21 - 7*x**18 - 35*x**15 - \
+    p = (2*sqrt(2) + 3)
+    assert minpoly_pow(p, Rational(1, 4), x) == x**4 - 2*x**2 - 1
+    p = 1 + 2**Rational(1,7)
+    assert minpoly_pow(p, Rational(4, 3), x) == x**21 - 7*x**18 - 35*x**15 - \
             3339*x**12 - 14581*x**9 - 27629*x**6 + 3031*x**3 - 81
 
-    assert minpoly_pow(mp, Rational(-4, 3), x) == 81*x**21 - 3031*x**18 + \
+    assert minpoly_pow(p, Rational(-4, 3), x) == 81*x**21 - 3031*x**18 + \
             27629*x**15 + 14581*x**12 + 3339*x**9 + 35*x**6 + 7*x**3 - 1
 
 def test_minpoly_op_algebraic_number():
@@ -161,9 +163,6 @@ def test_minpoly_op_algebraic_number():
     p2 = sqrt(2)
     mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Add)
     mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Add)
-    assert mp1 == mp2 == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
-    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op='sub')
-    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op='sub')
     assert mp1 == mp2 == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
     mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Mul)
     mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Mul)

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -131,6 +131,17 @@ def test_minimal_polynomial():
     a = 1 + sqrt(2)
     assert minimal_polynomial((a*sqrt(2) + a)**3, x) == x**2 - 198*x + 1
 
+    p = 1/(1 + sqrt(2) + sqrt(3))
+    assert minimal_polynomial(p, x, compose=False) == 8*x**4 - 16*x**3 + 4*x**2 + 4*x - 1
+
+    p = 2/(1 + sqrt(2) + sqrt(3))
+    assert minimal_polynomial(p, x, compose=False) == x**4 - 4*x**3 + 2*x**2 + 4*x - 2
+
+    assert minimal_polynomial(1 + sqrt(2)*I, x, compose=False) == x**2 - 2*x + 3
+    assert minimal_polynomial(1/(1 + sqrt(2)) + 1, x, compose=False) == x**2 - 2
+    assert minimal_polynomial(sqrt(2)*I + I*(1 + sqrt(2)), x,
+            compose=False) ==  x**4 + 18*x**2 + 49
+
 def test_minimal_polynomial_hi_prec():
     p = 1/sqrt(1 - 9*sqrt(2) + 7*sqrt(3) + S(1)/10**30)
     mp = minimal_polynomial(p, x)
@@ -199,6 +210,24 @@ def test_minpoly_compose():
     assert mp == x**3 + 4*x + 1
     mp = minimal_polynomial(ex + 1, x)
     assert mp == x**3 - 3*x**2 + 7*x - 4
+    assert minimal_polynomial(exp(I*pi/3), x) == x**2 - x + 1
+    assert minimal_polynomial(exp(I*pi/4), x) == x**4 + 1
+    assert minimal_polynomial(exp(I*pi/6), x) == x**4 - x**2 + 1
+    assert minimal_polynomial(exp(I*pi/9), x) == x**6 - x**3 + 1
+    assert minimal_polynomial(exp(I*pi/10), x) == x**8 - x**6 + x**4 - x**2 + 1
+    assert minimal_polynomial(sin(pi/9), x) == 64*x**6 - 96*x**4 + 36*x**2 - 3
+    assert minimal_polynomial(sin(pi/11), x) == 1024*x**10 - 2816*x**8 + \
+            2816*x**6 - 1232*x**4 + 220*x**2 - 11
+
+    raises(NotAlgebraic, lambda: minimal_polynomial(cos(pi*sqrt(2)), x))
+    raises(NotAlgebraic, lambda: minimal_polynomial(sin(pi*sqrt(2)), x))
+    raises(NotAlgebraic, lambda: minimal_polynomial(exp(I*pi*sqrt(2)), x))
+
+    # issue 2835
+    ex = 1/(-36000 - 7200*sqrt(5) + (12*sqrt(10)*sqrt(sqrt(5) + 5) +
+        24*sqrt(10)*sqrt(-sqrt(5) + 5))**2) + 1
+    raises(ZeroDivisionError, lambda: minimal_polynomial(ex, x))
+
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -168,102 +168,44 @@ def test_minpoly_op_algebraic_number():
         2820*x**2 - 1032*x + 157
 
 def test_minpoly_compose():
-    # test_minimal_polynomial apart from tests with AlgebraicNumber,
-    # NotAlgebraic, Poly
-    assert minimal_polynomial(-7, x, compose=True) == x + 7
-    assert minimal_polynomial(-1, x, compose=True) == x + 1
-    assert minimal_polynomial( 0, x, compose=True) == x
-    assert minimal_polynomial( 1, x, compose=True) == x - 1
-    assert minimal_polynomial( 7, x, compose=True) == x - 7
-
-    assert minimal_polynomial(sqrt(2), x, compose=True) == x**2 - 2
-    assert minimal_polynomial(sqrt(5), x, compose=True) == x**2 - 5
-    assert minimal_polynomial(sqrt(6), x, compose=True) == x**2 - 6
-
-    assert minimal_polynomial(2*sqrt(2), x, compose=True) == x**2 - 8
-    assert minimal_polynomial(3*sqrt(5), x, compose=True) == x**2 - 45
-    assert minimal_polynomial(4*sqrt(6), x, compose=True) == x**2 - 96
-
-    assert minimal_polynomial(2*sqrt(2) + 3, x, compose=True) == x**2 - 6*x + 1
-    assert minimal_polynomial(3*sqrt(5) + 6, x, compose=True) == x**2 - 12*x - 9
-    assert minimal_polynomial(4*sqrt(6) + 7, x, compose=True) == x**2 - 14*x - 47
-
-    assert minimal_polynomial(2*sqrt(2) - 3, x, compose=True) == x**2 + 6*x + 1
-    assert minimal_polynomial(3*sqrt(5) - 6, x, compose=True) == x**2 + 12*x - 9
-    assert minimal_polynomial(4*sqrt(6) - 7, x, compose=True) == x**2 + 14*x - 47
-
-    assert minimal_polynomial(sqrt(1 + sqrt(6)), x, compose=True) == x**4 - 2*x**2 - 5
-    assert minimal_polynomial(sqrt(I + sqrt(6)), x, compose=True) == x**8 - 10*x**4 + 49
-
-    assert minimal_polynomial(2*I + sqrt(2 + I), x, compose=True) == x**4 + 4*x**2 + 8*x + 37
-
-    assert minimal_polynomial(sqrt(2) + sqrt(3), x, compose=True) == x**4 - 10*x**2 + 1
-    assert minimal_polynomial(
-        sqrt(2) + sqrt(3) + sqrt(6), x, compose=True) == x**4 - 22*x**2 - 48*x - 23
-
-    assert minimal_polynomial(sqrt(2)).dummy_eq(x**2 - 2)
-    assert minimal_polynomial(sqrt(2), x) == x**2 - 2
-
-    a = 1 - 9*sqrt(2) + 7*sqrt(3)
-    assert minimal_polynomial(
-        1/a, x, compose=True) == 392*x**4 - 1232*x**3 + 612*x**2 + 4*x - 1
-    assert minimal_polynomial(
-        1/sqrt(a), x, compose=True) == 392*x**8 - 1232*x**6 + 612*x**4 + 4*x**2 - 1
-    a = sqrt(2)/3 + 7
-    f = 81*x**8 - 2268*x**6 - 4536*x**5 + 22644*x**4 + 63216*x**3 - \
-        31608*x**2 - 189648*x + 141358
-    assert minimal_polynomial(sqrt(a) + sqrt(sqrt(a)), x) == f
-
-    ex = (2*sqrt(2) + 3)**Rational(1, 4)
-    assert minimal_polynomial(ex, x, compose=True) == x**4 - 2*x**2 - 1
-    ex = (1 + 2**Rational(1,7))**Rational(4, 3)
-    assert minimal_polynomial(ex, x, compose=True) == \
-            x**21 - 7*x**18 - 35*x**15 - \
-            3339*x**12 - 14581*x**9 - 27629*x**6 + 3031*x**3 - 81
-
-    assert minimal_polynomial(ex**(-1), x, compose=True) == \
-            81*x**21 - 3031*x**18 + \
-            27629*x**15 + 14581*x**12 + 3339*x**9 + 35*x**6 + 7*x**3 - 1
-
     # issue 3769
     eq = S('''
         -1/(800*sqrt(-1/240 + 1/(18000*(-1/17280000 +
         sqrt(15)*I/28800000)**(1/3)) + 2*(-1/17280000 +
         sqrt(15)*I/28800000)**(1/3)))''')
-    mp = minimal_polynomial(eq + 3, x, compose=True)
+    mp = minimal_polynomial(eq + 3, x)
     assert mp == 8000*x**2 - 48000*x + 71999
 
     # issue 2789
-    assert minimal_polynomial(exp(I*pi/8), x, compose=True) == x**8 + 1
+    assert minimal_polynomial(exp(I*pi/8), x) == x**8 + 1
 
-    mp = minimal_polynomial(sin(pi/7) + sqrt(2), x, compose=True)
+    mp = minimal_polynomial(sin(pi/7) + sqrt(2), x)
     assert mp == 4096*x**12 - 63488*x**10 + 351488*x**8 - 826496*x**6 + \
         770912*x**4 - 268432*x**2 + 28561
-    mp = minimal_polynomial(cos(pi/7) + sqrt(2), x, compose=True)
+    mp = minimal_polynomial(cos(pi/7) + sqrt(2), x)
     assert mp == 64*x**6 - 64*x**5 - 432*x**4 + 304*x**3 + 712*x**2 - \
             232*x - 239
-    mp = minimal_polynomial(exp(I*pi/7) + sqrt(2), x, compose=True)
+    mp = minimal_polynomial(exp(I*pi/7) + sqrt(2), x)
     assert mp == x**12 - 2*x**11 - 9*x**10 + 16*x**9 + 43*x**8 - 70*x**7 - 97*x**6 + 126*x**5 + 211*x**4 - 212*x**3 - 37*x**2 + 142*x + 127
 
-    mp = minimal_polynomial(sin(pi/7) + sqrt(2), x, compose=True)
+    mp = minimal_polynomial(sin(pi/7) + sqrt(2), x)
     assert mp == 4096*x**12 - 63488*x**10 + 351488*x**8 - 826496*x**6 + \
         770912*x**4 - 268432*x**2 + 28561
-    mp = minimal_polynomial(cos(pi/7) + sqrt(2), x, compose=True)
+    mp = minimal_polynomial(cos(pi/7) + sqrt(2), x)
     assert mp == 64*x**6 - 64*x**5 - 432*x**4 + 304*x**3 + 712*x**2 - \
             232*x - 239
-    mp = minimal_polynomial(exp(I*pi/7) + sqrt(2), x, compose=True)
+    mp = minimal_polynomial(exp(I*pi/7) + sqrt(2), x)
     assert mp == x**12 - 2*x**11 - 9*x**10 + 16*x**9 + 43*x**8 - 70*x**7 - 97*x**6 + 126*x**5 + 211*x**4 - 212*x**3 - 37*x**2 + 142*x + 127
 
-    mp = minimal_polynomial(exp(2*I*pi/7), x, compose=True)
+    mp = minimal_polynomial(exp(2*I*pi/7), x)
     assert mp == x**6 + x**5 + x**4 + x**3 + x**2 + x + 1
-    mp = minimal_polynomial(cos(2*pi/7), x, compose=True)
+    mp = minimal_polynomial(cos(2*pi/7), x)
     assert mp == 8*x**3 + 4*x**2 - 4*x - 1
-    mp = minimal_polynomial(sin(2*pi/7), x, compose=True)
+    mp = minimal_polynomial(sin(2*pi/7), x)
     ex = (5*cos(2*pi/7) - 7)/(9*cos(pi/7) - 5*cos(3*pi/7))
-    mp = minimal_polynomial(ex, x, compose=True)
+    mp = minimal_polynomial(ex, x)
     assert mp == x**3 + 2*x**2 - x - 1
-    assert  minimal_polynomial(-1/(2*cos(pi/7)), x, compose=True) == \
-         x**3 + 2*x**2 - x - 1
+    assert  minimal_polynomial(-1/(2*cos(pi/7)), x) == x**3 + 2*x**2 - x - 1
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -1,10 +1,12 @@
 """Tests for computational algebraic number field theory. """
 
-from sympy import S, Rational, Symbol, Poly, sin, sqrt, I, oo, Tuple, expand
+from sympy import (S, Rational, Symbol, Poly, sin, sqrt, I, oo, Tuple, expand,
+    Add, Mul)
+
 from sympy.utilities.pytest import raises
 
 from sympy.polys.numberfields import (
-    minimal_polynomial,
+    minimal_polynomial, minpoly_pow, minpoly_op_algebraic_number,
     primitive_element,
     is_isomorphism_possible,
     field_isomorphism_pslq,
@@ -146,6 +148,29 @@ def test_minimal_polynomial_sq():
     mp = minimal_polynomial(p, x)
     assert mp.subs({x: 0}) == -71965773323122507776
 
+def test_minpoly_pow():
+    mp = minimal_polynomial(1 + 2**Rational(1,7), x)
+    assert minpoly_pow(mp, Rational(4, 3), x) == x**21 - 7*x**18 - 35*x**15 - \
+            3339*x**12 - 14581*x**9 - 27629*x**6 + 3031*x**3 - 81
+
+    assert minpoly_pow(mp, Rational(-4, 3), x) == 81*x**21 - 3031*x**18 + \
+            27629*x**15 + 14581*x**12 + 3339*x**9 + 35*x**6 + 7*x**3 - 1
+
+def test_minpoly_op_algebraic_number():
+    p1 = sqrt(1 + 2**Rational(1, 3))
+    p2 = sqrt(2)
+    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Add)
+    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Add)
+    assert mp1 == mp2 == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
+    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op='sub')
+    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op='sub')
+    assert mp1 == mp2 == x**12 - 18*x**10 + 111*x**8 - 256*x**6 + 3*x**4 - 126*x**2 + 1
+    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op=Mul)
+    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op=Mul)
+    assert mp1 == mp2 == x**6 - 6*x**4 + 12*x**2 - 24
+    mp1 = minpoly_op_algebraic_number(p1, p2, x, method='resultant', op='div')
+    mp2 = minpoly_op_algebraic_number(p1, p2, x, method='groebner', op='div')
+    assert mp1 == mp2 == 8*x**6 - 12*x**4 + 6*x**2 - 3
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -203,7 +203,11 @@ def test_minpoly_compose():
     ex = (5*cos(2*pi/7) - 7)/(9*cos(pi/7) - 5*cos(3*pi/7))
     mp = minimal_polynomial(ex, x)
     assert mp == x**3 + 2*x**2 - x - 1
-    assert  minimal_polynomial(-1/(2*cos(pi/7)), x) == x**3 + 2*x**2 - x - 1
+    assert minimal_polynomial(-1/(2*cos(pi/7)), x) == x**3 + 2*x**2 - x - 1
+    assert minimal_polynomial(sin(2*pi/15), x) == \
+            256*x**8 - 448*x**6 + 224*x**4 - 32*x**2 + 1
+    assert minimal_polynomial(sin(5*pi/14), x) == 8*x**3 - 4*x**2 - 4*x + 1
+    assert minimal_polynomial(cos(pi/15), x) == 16*x**4 + 8*x**3 - 16*x**2 - 8*x + 1
 
     eq = expand((x**5 + 3*x + 1)*(x**3 + 4*x + 1))
     ex = solve(eq, x)[0]

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -220,6 +220,9 @@ def test_minpoly_compose():
     assert minimal_polynomial(sin(pi/11), x) == 1024*x**10 - 2816*x**8 + \
             2816*x**6 - 1232*x**4 + 220*x**2 - 11
 
+    ex = 2**Rational(1, 3)*exp(Rational(2, 3)*I*pi)
+    assert minimal_polynomial(ex, x) == x**3 - 2
+
     raises(NotAlgebraic, lambda: minimal_polynomial(cos(pi*sqrt(2)), x))
     raises(NotAlgebraic, lambda: minimal_polynomial(sin(pi*sqrt(2)), x))
     raises(NotAlgebraic, lambda: minimal_polynomial(exp(I*pi*sqrt(2)), x))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1659,7 +1659,7 @@ def _nthroot_solve(p, n, prec):
         return p
     pn = p**Rational(1, n)
     x = Symbol('x')
-    f = _minimal_polynomial_sq(p, n, x, prec)
+    f = _minimal_polynomial_sq(p, n, x)
     if f is None:
         return None
     sols = solve(f, x)


### PR DESCRIPTION
In master `minimal_polynomial` is slow or stalls in some simple cases, which in this PR are done fast.

Examples solved in a fraction of a second in this PR, which take a long time or stall with the old algorithm

```
>>> ex = (1 + 2**Rational(1,7))**3
>>> minpoly(ex, x)
x**7 - 7*x**6 + 21*x**5 - 203*x**4 - 1561*x**3 - 2247*x**2 - 35*x - 27
>>> ex= (1 + sqrt(2) + 2*2**Rational(1, 4))/(1 + 2**Rational(1, 4))
>>> minpoly(ex, x)
x**4 - 4*x**3 + 6*x**2 - 4*x - 1
>>> ex = solve(x**3 + x + sqrt(2))[0]
>>> minpoly(ex, x)
x**6 + 2*x**4 + x**2 - 2
>>> ex = (1 + 3*3**Rational(1, 5))/(1 + 3**Rational(1, 3) + 3*3**Rational(2, 3))
>>> degree(minpoly(ex, x))
15
```

Issues related to this PR: 

2789 : partially solved; `minpoly(exp(I*pi*r))`, with `r` rational, can be computed, but little more can be done
in trigonometric expressions.

2835 : if a subexpression is `1/0` an exception is raised. 

3769 : solved; algebraic operations on algebraic numbers are implemented

The old algorithm is accessible with the option `compose=False`;
in the examples I tried, it is sometimes faster than the new algorithm in expressions which take little time;
when the old algorithm is faster it is usually by 10%, but there are rare cases in which it is a few times faster, e.g.
 for `ex = (1 + 3*2**Rational(1, 3))*(1 + 2**Rational(1, 3))`  the old algorithm takes 0.01s, the new one 0.08s.

I think it is unlikely that there exists a case in which the new algorithm stalls and the old one does not;
in the old one the main bottleneck is `groebner`, then factorization; in the new algorithm the bottleneck
is factorization. 
