### PR TITLE
Solve of Piecewise functions.

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1086,7 +1086,8 @@ def _solve(f, *symbols, **flags):
             for candidate in candidates:
                 if candidate in result:
                     continue
-                if cond is True or cond.subs(symbol, candidate):
+                cond = cond is True or cond.subs(symbol, candidate)
+                if cond is not False:
                     # Only include solutions that do not match the condition
                     # of any previous pieces.
                     matches_other_piece = False
@@ -1095,7 +1096,7 @@ def _solve(f, *symbols, **flags):
                             break
                         if other_cond is False:
                             continue
-                        if other_cond.subs(symbol, candidate):
+                        if other_cond.subs(symbol, candidate) is True:
                             matches_other_piece = True
                             break
                     if not matches_other_piece:

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1100,7 +1100,10 @@ def _solve(f, *symbols, **flags):
                             matches_other_piece = True
                             break
                     if not matches_other_piece:
-                        result.add(candidate)
+                        result.add(Piecewise(
+                            (candidate, cond is True or cond.doit()),
+                            (S.NaN, True)
+                        ))
         check = False
     else:
         # first see if it really depends on symbol and whether there

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1114,11 +1114,16 @@ def test_issue_2957():
 
 def test_issue_2961():
     x = Symbol('x')
-    y = Symbol('y', positive=True)
     absxm3 = Piecewise(
         (x - 3, S(0) <= x - 3),
         (3 - x, S(0) > x - 3)
     )
+    y = Symbol('y')
+    assert solve(absxm3 - y, x) == [
+        Piecewise((-y + 3, S(0) > -y), (S.NaN, True)),
+        Piecewise((y + 3, S(0) <= y), (S.NaN, True))
+    ]
+    y = Symbol('y', positive=True)
     assert solve(absxm3 - y, x) == [-y + 3, y + 3]
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1,9 +1,9 @@
 from sympy import (
     Abs, And, Derivative, Dummy, Eq, Float, Function, Gt, I, Integral,
-    LambertW, Lt, Matrix, Or, Poly, Q, Rational, S, Symbol, Wild, acos,
-    asin, atan, atanh, cos, cosh, diff, exp, expand, im, log, pi, re, sin,
-    sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
-    root)
+    LambertW, Lt, Matrix, Or, Piecewise, Poly, Q, Rational, S, Symbol,
+    Wild, acos, asin, atan, atanh, cos, cosh, diff, exp, expand, im,
+    log, pi, re, sin, sinh, solve, solve_linear, sqrt, sstr, symbols,
+    sympify, tan, tanh, root)
 from sympy.abc import a, b, c, d, k, h, p, x, y, z, t, q, m
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
@@ -1110,6 +1110,16 @@ def test_issue_2957():
     assert set(solve((tanh(x + 3)*tanh(x - 3) + 1)**2)) == \
         set([-log(2)/2 + log(-1 - I), -log(2)/2 + log(-1 + I),
             -log(2)/2 + log(1 - I), -log(2)/2 + log(1 + I)])
+
+
+def test_issue_2961():
+    x = Symbol('x')
+    y = Symbol('y', positive=True)
+    absxm3 = Piecewise(
+        (x - 3, S(0) <= x - 3),
+        (3 - x, S(0) > x - 3)
+    )
+    assert solve(absxm3 - y, x) == [-y + 3, y + 3]
 
 
 def test_issue_2574():


### PR DESCRIPTION
Don't rely on bool(Relational) in the Piecewise solver. Also, check that the solution is valid i.e. Piecewise conditions are satisfied.

Fixes issue 2961: `__nonzero__` method of Rel breaks solve of Piecewise functions
http://code.google.com/p/sympy/issues/detail?id=2961
