### PR TITLE
Interactive ipython printing.

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -310,7 +310,14 @@ def main():
     if session is not None:
         ipython = session == 'ipython'
     else:
-        ipython = None
+        try:
+            import IPython
+            ipython = True
+        except ImportError:
+            if not options.quiet:
+                from sympy.interactive.session import no_ipython
+                print no_ipython
+            ipython = False
 
     args = {
         'pretty_print': True,

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -27,8 +27,8 @@ def _init_python_printing(stringify_func):
     sys.displayhook = _displayhook
 
 
-def _init_ipython_printing(ip, stringify_func, render_latex, euler,
-                           forecolor, backcolor, fontsize, mode):
+def _init_ipython_printing(ip, stringify_func, use_latex, euler,
+                           forecolor, backcolor, fontsize, latex_mode):
     """Setup printing in IPython interactive session. """
 
     preamble = "\\documentclass[%s]{article}\n" \
@@ -141,9 +141,7 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
         )
 
         png_formatter = ip.display_formatter.formatters['image/png']
-        latex_formatter = ip.display_formatter.formatters['text/latex']
-        latex_formatter.enabled = True
-        if render_latex:
+        if use_latex in (True, 'png'):
             png_formatter.for_type_by_name(
                 'sympy.core.basic', 'Basic', _print_latex_png
             )
@@ -154,7 +152,11 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
             for cls in [int, long, float] + printable_containers:
                 png_formatter.for_type(cls, _print_latex_png)
             png_formatter.enabled = True
+        else:
+            png_formatter.enabled = False
 
+        latex_formatter = ip.display_formatter.formatters['text/latex']
+        if use_latex in (True, 'mathjax'):
             latex_formatter.for_type_by_name(
                 'sympy.core.basic', 'Basic', _print_latex_text
             )
@@ -163,8 +165,9 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
             )
             for cls in [int, long, float] + printable_containers:
                 latex_formatter.for_type(cls, _print_latex_text)
+            latex_formatter.enabled = True
         else:
-            png_formatter.enabled = False
+            latex_formatter.enabled = False
     else:
         ip.set_hook('result_display', _result_display)
 
@@ -193,9 +196,11 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     use_unicode: boolean or None
         If True, use unicode characters;
         if False, do not use unicode characters.
-    use_latex: boolean or None
+    use_latex: string, boolean or None
         If True, use latex rendering in GUI interfaces;
-        if False, do not use latex rendering
+        if False, do not use latex rendering; the string
+        'png' specifies using latex-rendered images while
+        the string 'mathjax' specifies using MathJax only.
     wrap_line: boolean
         If True, lines will wrap at the end;
         if False, they will not wrap but continue as one line.

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -60,8 +60,10 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
         return exprbuffer.getvalue()
 
     def _print_latex_png(o):
-        s = latex(o, mode=mode)
-        return _preview_wrapper(s)
+        if _can_print_latex(o):
+            s = latex(o, mode=latex_mode)
+            return _preview_wrapper(s)
+        return None
 
     #not used
     def _print_latex_inline_png(o):

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -51,7 +51,10 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
 
     def _print_plain(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
-        p.text(stringify_func(arg))
+        if _can_print_latex(arg):
+            p.text(stringify_func(arg))
+        else:
+            p.text(IPython.lib.pretty.pretty(arg))
 
     def _preview_wrapper(o):
         exprbuffer = StringIO()

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -269,15 +269,12 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     if ip:
         try:
             import IPython
-            if IPython.__version__ >= '1.0':
-                from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
-            else:
-                from IPython.zmq.zmqshell import ZMQInteractiveShell
+            from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
         except ImportError:
             pass
         else:
             # If in qtconsole or notebook
-            if isinstance(ip, ZMQInteractiveShell) \
+            if not isinstance(ip, TerminalInteractiveShell) \
                     and 'ipython-console' not in ''.join(sys.argv):
                 if use_unicode is None:
                     use_unicode = True

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -128,30 +128,19 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
 
     import IPython
     if IPython.__version__ >= '0.11':
-        printable_containers = [tuple, list, set, frozenset, dict]
+        from sympy.core.basic import Basic
+        from sympy.matrices.matrices import MatrixBase
+        printable_types = [Basic, MatrixBase, int, long, float,
+                          tuple, list, set, frozenset, dict]
 
         plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
-        for cls in [object, str] + printable_containers:
+        for cls in printable_types:
             plaintext_formatter.for_type(cls, _print_plain)
-
-        plaintext_formatter.for_type_by_name(
-            'sympy.core.basic', 'Basic', _print_plain
-        )
-        plaintext_formatter.for_type_by_name(
-            'sympy.matrices.mutable', 'Matrix', _print_plain
-        )
 
         png_formatter = ip.display_formatter.formatters['image/png']
         if use_latex in (True, 'png'):
-            png_formatter.for_type_by_name(
-                'sympy.core.basic', 'Basic', _print_latex_png
-            )
-            png_formatter.for_type_by_name(
-                'sympy.matrices.matrices', 'MatrixBase', _print_latex_png
-            )
-
-            for cls in [int, long, float] + printable_containers:
+            for cls in printable_types:
                 png_formatter.for_type(cls, _print_latex_png)
             png_formatter.enabled = True
         else:
@@ -159,13 +148,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
 
         latex_formatter = ip.display_formatter.formatters['text/latex']
         if use_latex in (True, 'mathjax'):
-            latex_formatter.for_type_by_name(
-                'sympy.core.basic', 'Basic', _print_latex_text
-            )
-            latex_formatter.for_type_by_name(
-                'sympy.matrices.matrices', 'MatrixBase', _print_latex_text
-            )
-            for cls in [int, long, float] + printable_containers:
+            for cls in printable_types:
                 latex_formatter.for_type(cls, _print_latex_text)
             latex_formatter.enabled = True
         else:
@@ -266,7 +249,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         except NameError:
             pass
 
-    if ip:
+    if ip and pretty_print:
         try:
             import IPython
             from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -126,11 +126,11 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
 
     import IPython
     if IPython.__version__ >= '0.11':
-        printable_containers = [tuple, list, set, frozenset]
+        printable_containers = [tuple, list, set, frozenset, dict]
 
         plaintext_formatter = ip.display_formatter.formatters['text/plain']
 
-        for cls in [object, str, dict] + printable_containers:
+        for cls in [object, str] + printable_containers:
             plaintext_formatter.for_type(cls, _print_plain)
 
         plaintext_formatter.for_type_by_name(
@@ -142,7 +142,7 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
 
         png_formatter = ip.display_formatter.formatters['image/png']
         latex_formatter = ip.display_formatter.formatters['text/latex']
-        latex_formatter.enabled = False #Disabled until IPython problems are resolved
+        latex_formatter.enabled = True
         if render_latex:
             png_formatter.for_type_by_name(
                 'sympy.core.basic', 'Basic', _print_latex_png
@@ -151,7 +151,7 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
                 'sympy.matrices.matrices', 'MatrixBase', _print_latex_png
             )
 
-            for cls in [dict, int, long, float] + printable_containers:
+            for cls in [int, long, float] + printable_containers:
                 png_formatter.for_type(cls, _print_latex_png)
             png_formatter.enabled = True
 
@@ -161,7 +161,7 @@ def _init_ipython_printing(ip, stringify_func, render_latex, euler,
             latex_formatter.for_type_by_name(
                 'sympy.matrices.matrices', 'MatrixBase', _print_latex_text
             )
-            for cls in printable_containers:
+            for cls in [int, long, float] + printable_containers:
                 latex_formatter.for_type(cls, _print_latex_text)
         else:
             png_formatter.enabled = False

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -244,6 +244,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     x + y +
     x**2 + y**2
     """
+    import sys
     from sympy.printing.printer import Printer
 
     if pretty_print:
@@ -269,7 +270,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
             pass
         else:
             # If in qtconsole or notebook
-            if isinstance(ip, ZMQInteractiveShell):
+            if isinstance(ip, ZMQInteractiveShell) \
+                    and 'ipython-console' not in ''.join(sys.argv):
                 if use_unicode is None:
                     use_unicode = True
                 if use_latex is None:

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -259,10 +259,21 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
             pass
 
     if ip:
-        if use_unicode is None:
-            use_unicode = True
-        if use_latex is None:
-            use_latex = True
+        try:
+            import IPython
+            if IPython.__version__ >= '1.0':
+                from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
+            else:
+                from IPython.zmq.zmqshell import ZMQInteractiveShell
+        except ImportError:
+            pass
+        else:
+            # If in qtconsole or notebook
+            if isinstance(ip, ZMQInteractiveShell):
+                if use_unicode is None:
+                    use_unicode = True
+                if use_latex is None:
+                    use_latex = True
 
     if not no_global:
         Printer.set_global_settings(order=order, use_unicode=use_unicode,

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -68,22 +68,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
             return _preview_wrapper(s)
         return None
 
-    #not used
-    def _print_latex_inline_png(o):
-        """
-        A function to display sympy expressions using inline style LaTeX in PNG.
-        """
-        s = latex(o, mode='inline')
-        return _preview_wrapper(s)
-
-    #not used
-    def _print_latex_display_png(o):
-        """
-        A function to display sympy expression using display style LaTeX in PNG.
-        """
-        s = latex(o, mode='plain')
-        return _preview_wrapper('$' + s + '$')
-
     def _can_print_latex(o):
         """Return True if type o can be printed with LaTeX.
 

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -12,6 +12,7 @@ from sympy.utilities.pytest import raises
 # @requires('IPython', version=">=0.11")
 # def test_automatic_symbols(ipython):
 
+# run_cell was added in IPython 0.11
 ipython = import_module("IPython", min_module_version="0.11")
 
 if not ipython:

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -19,10 +19,14 @@ def test_ipythonprinting():
 
     # Printing without printing extension
     app.run_cell("a = format(Symbol('pi'))")
+    app.run_cell("a2 = format(Symbol('pi')**2)")
     assert app.user_ns['a']['text/plain'] == "pi"
+    assert app.user_ns['a2']['text/plain'] == "pi**2"
 
     # Load printing extension
     app.run_cell("%load_ext sympy.interactive.ipythonprinting")
     # Printing with printing extension
     app.run_cell("a = format(Symbol('pi'))")
-    assert app.user_ns['a']['text/plain'] == u'\u03c0'
+    app.run_cell("a2 = format(Symbol('pi')**2)")
+    assert app.user_ns['a']['text/plain'] in (u'\u03c0', 'pi')
+    assert app.user_ns['a2']['text/plain'] in (u' 2\n\u03c0 ', '  2\npi ')

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -3,6 +3,7 @@
 from sympy.interactive.session import init_ipython_session
 from sympy.external import import_module
 
+# run_cell was added in IPython 0.11
 ipython = import_module("IPython", min_module_version="0.11")
 
 # disable tests if ipython is not present
@@ -20,13 +21,23 @@ def test_ipythonprinting():
     # Printing without printing extension
     app.run_cell("a = format(Symbol('pi'))")
     app.run_cell("a2 = format(Symbol('pi')**2)")
-    assert app.user_ns['a']['text/plain'] == "pi"
-    assert app.user_ns['a2']['text/plain'] == "pi**2"
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        assert app.user_ns['a']['text/plain'] == "pi"
+        assert app.user_ns['a2']['text/plain'] == "pi**2"
+    else:
+        assert app.user_ns['a'][0]['text/plain'] == "pi"
+        assert app.user_ns['a2'][0]['text/plain'] == "pi**2"
 
     # Load printing extension
     app.run_cell("%load_ext sympy.interactive.ipythonprinting")
     # Printing with printing extension
     app.run_cell("a = format(Symbol('pi'))")
     app.run_cell("a2 = format(Symbol('pi')**2)")
-    assert app.user_ns['a']['text/plain'] in (u'\u03c0', 'pi')
-    assert app.user_ns['a2']['text/plain'] in (u' 2\n\u03c0 ', '  2\npi ')
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        assert app.user_ns['a']['text/plain'] in (u'\u03c0', 'pi')
+        assert app.user_ns['a2']['text/plain'] in (u' 2\n\u03c0 ', '  2\npi ')
+    else:
+        assert app.user_ns['a'][0]['text/plain'] in (u'\u03c0', 'pi')
+        assert app.user_ns['a2'][0]['text/plain'] in (u' 2\n\u03c0 ', '  2\npi ')


### PR DESCRIPTION
I am collecting here some ipython printing issues and trying to resolve them. All of these issues should be resolved in this branch:

Issue 2945: Make init_printing() work with latex printing in the IPython qtconsole and notebook
http://code.google.com/p/sympy/issues/detail?id=2945

Issue 3292: init_session from within Python starts IPython
http://code.google.com/p/sympy/issues/detail?id=3292

Issue 3513: %load_ext sympy.interactive.ipythonprinting damaging output
http://code.google.com/p/sympy/issues/detail?id=3513

Issue 3537: %load_ext sympy.interactive.ipythonprinting int and float representation
http://code.google.com/p/sympy/issues/detail?id=3537

Issue 3604: init_printing() does not disable latex printing in the qtconsole
http://code.google.com/p/sympy/issues/detail?id=3604

Issue 3728: garbage from preview() in ipython console session
http://code.google.com/p/sympy/issues/detail?id=3728

Issue 3777: IPython pretty printing should default to MathJax
http://code.google.com/p/sympy/issues/detail?id=3777
