### PR TITLE
Addition of hypertangent and exponential cases to Partial Differntial Equations 

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -131,7 +131,6 @@ class im(Function):
 
     is_real = True
     unbranched = True  # implicitely works on the projection to C
-
     @classmethod
     def eval(cls, arg):
         if arg is S.NaN:

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -131,6 +131,7 @@ class im(Function):
 
     is_real = True
     unbranched = True  # implicitely works on the projection to C
+
     @classmethod
     def eval(cls, arg):
         if arg is S.NaN:

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -19,13 +19,14 @@ from sympy.core import Dummy, ilcm, Add, Mul, Pow, S
 
 from sympy.matrices import Matrix, zeros, eye
 
+from sympy import im, sqrt, re
 from sympy.solvers import solve
 
 from sympy.polys import Poly, lcm, cancel, sqf_list
 
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, derivation,
     NonElementaryIntegralException, residue_reduce, splitfactor,
-    residue_reduce_derivation, DecrementLevel)
+    residue_reduce_derivation, DecrementLevel, recognize_log_derivative)
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     bound_degree, spde, solve_poly_rde)
 
@@ -96,21 +97,37 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
 
     n = min(0, nc - min(0, nb))
     if not nb:
-        # Possible cancellation
-        #
-        # if case == 'exp':
-        #     alpha = (-b/a).rem(p) == -b(0)/a(0)
-        #     if alpha == m*Dt/t + Dz/z # parametric logarithmic derivative problem
-        #         n = min(n, m)
-        # elif case == 'tan':
-        #     alpha*sqrt(-1) + beta = (-b/a)/rem(p) == -b(sqrt(-1))/a(sqrt(-1))
-        #     eta = derivation(t, DE).quo(Poly(t**2 + 1, t)) # eta in k
-        #     if 2*beta == Db/b for some v in k* (see pg. 176) and \
-        #     alpha*sqrt(-1) + beta == 2*b*eta*sqrt(-1) + Dz/z:
-        #     # parametric logarithmic derivative problem
-        #         n = min(n, m)
-        raise NotImplementedError("The ability to solve the parametric "
-            "logarithmic derivative problem is required to solve this PRDE.")
+        # Possible cancellation.
+        if case == 'exp':
+            dcoeff = DE.d.quo(Poly(DE.t, DE.t))
+            with DecrementLevel(DE):  # We are guaranteed to not have problems,
+                                      # because case != 'base'.
+                alphaa, alphad = frac_in(-ba.eval(0)/bd.eval(0)/a.eval(0), DE.t)
+                etaa, etad = frac_in(dcoeff, DE.t)
+                A = parametric_log_deriv(alphaa, alphad, etaa, etad, DE)
+                if A is not None:
+                    a, m, z = A
+                    if a == 1:
+                        n = min(n, m)
+
+        elif case == 'tan':
+            dcoeff = DE.d.quo(Poly(DE.t**2+1, DE.t))
+            with DecrementLevel(DE):  # We are guaranteed to not have problems,
+                                      # because case != 'base'.
+                alphaa, alphad = frac_in(im(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
+                betaa, betad = frac_in(re(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
+                etaa, etad = frac_in(dcoeff, DE.t)
+
+                if recognize_log_derivative(2*betaa, betad, DE):
+                    A = None
+                    try:
+                        A = parametric_log_deriv(alphaa*sqrt(-1)*betad+alphad*betaa, alphad*betad, etaa, etad, DE)
+                    except NotImplementedError:
+                        pass
+                    if A is not None:
+                       a, m, z = A
+                       if a == 1:
+                           n = min(n, m)
 
     N = max(0, -nb)
     pN = p**N

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -118,7 +118,6 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
 
     nb = order_at(ba, p, DE.t) - order_at(bd, p, DE.t)
     nc = min([order_at(Ga, p, DE.t) - order_at(Gd, p, DE.t) for Ga, Gd in G])
-
     n = min(0, nc - min(0, nb))
     if not nb:
         # Possible cancellation.
@@ -135,7 +134,7 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
                         n = min(n, m)
 
         elif case == 'tan':
-            dcoeff = DE.d.quo(Poly(DE.t**2+1, DE.t))
+            dcoeff = DE.d.quo(Poly(DE.t**2 + 1, DE.t))
             with DecrementLevel(DE):  # We are guaranteed to not have problems,
                                       # because case != 'base'.
                 betaa, alphaa, alphad =  real_imag(ba, bd*a, DE.t)
@@ -143,7 +142,7 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
                 etaa, etad = frac_in(dcoeff, DE.t)
                 if recognize_log_derivative(2*betaa, betad, DE):
                     A = parametric_log_deriv(alphaa, alphad, etaa, etad, DE)
-                    B = parametric_log_deriv(betaa, betaad, etaa, etad, DE)
+                    B = parametric_log_deriv(betaa, betad, etaa, etad, DE)
                     if A is not None and B is not None:
                         a, s, z = A
                         if a == 1:

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -60,19 +60,27 @@ def prde_normal_denom(fa, fd, G, DE):
     return (a, (ba, bd), G, h)
 
 def real_imag(ba, bd, gen):
+    """
+    Helper function, to get the real and imaginary part of a rational function
+    evaluated at sqrt(-1) without actually evaluating it at sqrt(-1)
 
+    Seperates the even and odd power terms by checking the degree of terms wrt
+    mod 4. Returns a tuple (ba[0], ba[1], bd) where ba[0] is real part
+    of the numerator ba[1] is the imaginary part and bd is the denominator
+    of the rational function.
+    """
     bd = bd.as_poly(gen).as_dict()
     ba = ba.as_poly(gen).as_dict()
-    denom_real = [value if key[0]%4==0 else -value if key[0]%4==2 else 0 for key, value in bd.items()]
-    denom_imag = [value if key[0]%4==1 else -value if key[0]%4==3 else 0 for key, value in bd.items()]
-    bd_real = reduce(lambda x, y: x + y, denom_real, 0)
-    bd_imag = reduce(lambda x, y: x + y, denom_imag, 0)
-    num_real = [value if key[0]%4==0 else -value if key[0]%4==2 else 0 for key, value in ba.items()]
-    num_imag = [value if key[0]%4==1 else -value if key[0]%4==3 else 0 for key, value in ba.items()]
-    ba_real = reduce(lambda x, y: x + y, num_real, 0)
-    ba_imag = reduce(lambda x, y: x + y, num_imag, 0)
-    ba = ((ba_real*bd_real + ba_imag*bd_imag).as_poly(), (ba_imag*bd_real - ba_real*bd_imag).as_poly())
-    bd = (bd_real*bd_real + bd_imag*bd_imag).as_poly()
+    denom_real = [value if key[0] % 4 == 0 else -value if key[0] % 4 == 2 else 0 for key, value in bd.items()]
+    denom_imag = [value if key[0] % 4 == 1 else -value if key[0] % 4 == 3 else 0 for key, value in bd.items()]
+    bd_real = sum(r for r in denom_real)
+    bd_imag = sum(r for r in denom_imag)
+    num_real = [value if key[0] % 4 == 0 else -value if key[0] % 4 == 2 else 0 for key, value in ba.items()]
+    num_imag = [value if key[0] % 4 == 1 else -value if key[0] % 4 == 3 else 0 for key, value in ba.items()]
+    ba_real = sum(r for r in num_real)
+    ba_imag = sum(r for r in num_imag)
+    ba = ((ba_real*bd_real + ba_imag*bd_imag).as_poly(gen), (ba_imag*bd_real - ba_real*bd_imag).as_poly(gen))
+    bd = (bd_real*bd_real + bd_imag*bd_imag).as_poly(gen)
     return (ba[0], ba[1], bd)
 
 
@@ -134,15 +142,12 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
                 betad = alphad
                 etaa, etad = frac_in(dcoeff, DE.t)
                 if recognize_log_derivative(2*betaa, betad, DE):
-                    A = None
-                    try:
-                        A = parametric_log_deriv(alphaa*sqrt(-1)*betad+alphad*betaa, alphad*betad, etaa, etad, DE)
-                    except NotImplementedError:
-                        pass
-                    if A is not None:
-                       a, m, z = A
-                       if a == 1:
-                           n = min(n, m)
+                    A = parametric_log_deriv(alphaa, alphad, etaa, etad, DE)
+                    B = parametric_log_deriv(betaa, betaad, etaa, etad, DE)
+                    if A is not None and B is not None:
+                        a, s, z = A
+                        if a == 1:
+                             n = min(n, s/2)
 
     N = max(0, -nb)
     pN = p**N

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -114,10 +114,11 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
             dcoeff = DE.d.quo(Poly(DE.t**2+1, DE.t))
             with DecrementLevel(DE):  # We are guaranteed to not have problems,
                                       # because case != 'base'.
-                alphaa, alphad = frac_in(im(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
-                betaa, betad = frac_in(re(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
+                b_a = (-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))).as_expr()
+                b_a = b_a.radsimp().as_real_imag()
+                alphaa, alphad = frac_in(b_a[1], DE.t)
+                betaa, betad = frac_in(b_a[0], DE.t)
                 etaa, etad = frac_in(dcoeff, DE.t)
-
                 if recognize_log_derivative(2*betaa, betad, DE):
                     A = None
                     try:

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -59,6 +59,22 @@ def prde_normal_denom(fa, fd, G, DE):
 
     return (a, (ba, bd), G, h)
 
+def real_imag(ba, bd, gen):
+
+    bd = bd.as_poly(gen).as_dict()
+    ba = ba.as_poly(gen).as_dict()
+    denom_real = [value if key[0]%4==0 else -value if key[0]%4==2 else 0 for key, value in bd.items()]
+    denom_imag = [value if key[0]%4==1 else -value if key[0]%4==3 else 0 for key, value in bd.items()]
+    bd_real = reduce(lambda x, y: x + y, denom_real, 0)
+    bd_imag = reduce(lambda x, y: x + y, denom_imag, 0)
+    num_real = [value if key[0]%4==0 else -value if key[0]%4==2 else 0 for key, value in ba.items()]
+    num_imag = [value if key[0]%4==1 else -value if key[0]%4==3 else 0 for key, value in ba.items()]
+    ba_real = reduce(lambda x, y: x + y, num_real, 0)
+    ba_imag = reduce(lambda x, y: x + y, num_imag, 0)
+    ba = ((ba_real*bd_real + ba_imag*bd_imag).as_poly(), (ba_imag*bd_real - ba_real*bd_imag).as_poly())
+    bd = (bd_real*bd_real + bd_imag*bd_imag).as_poly()
+    return (ba[0], ba[1], bd)
+
 
 def prde_special_denom(a, ba, bd, G, DE, case='auto'):
     """
@@ -114,10 +130,8 @@ def prde_special_denom(a, ba, bd, G, DE, case='auto'):
             dcoeff = DE.d.quo(Poly(DE.t**2+1, DE.t))
             with DecrementLevel(DE):  # We are guaranteed to not have problems,
                                       # because case != 'base'.
-                b_a = (-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))).as_expr()
-                b_a = b_a.radsimp().as_real_imag()
-                alphaa, alphad = frac_in(b_a[1], DE.t)
-                betaa, betad = frac_in(b_a[0], DE.t)
+                betaa, alphaa, alphad =  real_imag(ba, bd*a, DE.t)
+                betad = alphad
                 etaa, etad = frac_in(dcoeff, DE.t)
                 if recognize_log_derivative(2*betaa, betad, DE):
                     A = None

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -213,19 +213,22 @@ def special_denom(a, ba, bd, ca, cd, DE, case='auto'):
                     a, m, z = A
                     if a == 1:
                         n = min(n, m)
-        else:
-            raise NotImplementedError("Tangent case not implemented yet for "
-                "RDE special_denom().")
-        #     if alpha == m*Dt/t + Dz/z # parametric logarithmic derivative problem
-        #         n = min(n, m)
-        # elif case == 'tan':
-        #     alpha*sqrt(-1) + beta = (-b/a).rem(p) == -b(sqrt(-1))/a(sqrt(-1))
-        #     eta = derivation(t, DE).quo(Poly(t**2 + 1, t)) # eta in k
-        #     if 2*beta == Dv/v for some v in k* (see pg. 176) and \
-        #     alpha*sqrt(-1) + beta == 2*m*eta*sqrt(-1) + Dz/z:
-        #     # parametric logarithmic derivative problem
-        #         n = min(n, m)
 
+        elif case == 'tan':
+        # test cases coming soon
+            dcoeff = DE.d.quo(Poly(DE.t**2+1, DE.t))
+            with DecrementLevel(DE):  # We are guaranteed to not have problems,
+                                      # because case != 'base'.
+                alphaa, alphad = frac_in(im(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
+                betaa, betad = frac_in(re(-ba.eval(sqrt(-1))/bd.eval(sqrt(-1))/a.eval(sqrt(-1))), DE.t)
+                etaa, etad = frac_in(dcoeff, DE.t)
+
+                if recognize_log_derivative(2*betaa, betad, DE):
+                    A = parametric_log_deriv(alphaa*sqrt(-1)*betad+alphad*betaa, alphad*betad, etaa, etad, DE)
+                    if A is not None:
+                       a, m, z = A
+                       if a == 1:
+                           n = min(n, m)
     N = max(0, -nb, n - nc)
     pN = p**N
     pn = p**-n

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -215,7 +215,6 @@ def special_denom(a, ba, bd, ca, cd, DE, case='auto'):
                         n = min(n, m)
 
         elif case == 'tan':
-        # test cases coming soon
             dcoeff = DE.d.quo(Poly(DE.t**2+1, DE.t))
             with DecrementLevel(DE):  # We are guaranteed to not have problems,
                                       # because case != 'base'.

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -24,7 +24,8 @@ will return the fraction (fa, fd). Other variable names probably come
 from the names used in Bronstein's book.
 """
 from __future__ import with_statement
-
+from sympy import real_roots
+from sympy.abc import z
 from sympy.core.function import Lambda
 from sympy.core.numbers import ilcm
 from sympy.core.mul import Mul
@@ -32,6 +33,7 @@ from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
 from sympy.core.compatibility import reduce, ordered
+from sympy.integrals.heurisch import _symbols
 
 from sympy.functions import log, exp, sin, cos, tan, asin, acos, atan
 
@@ -880,7 +882,7 @@ def splitfactor(p, DE, coefficientD=False, z=None):
         return (p, One)
 
 
-def splitfactor_sqf(p, DE, coefficientD=False, z=None):
+def splitfactor_sqf(p, DE, coefficientD=False, z=None, basic=False):
     """
     Splitting Square-free Factorization
 
@@ -903,7 +905,7 @@ def splitfactor_sqf(p, DE, coefficientD=False, z=None):
 
     for pi, i in p_sqf:
         Si = pi.as_poly(*kkinv).gcd(derivation(pi, DE,
-            coefficientD=coefficientD).as_poly(*kkinv)).as_poly(DE.t)
+            coefficientD=coefficientD,basic=basic).as_poly(*kkinv)).as_poly(DE.t)
         pi = Poly(pi, DE.t)
         Si = Poly(Si, DE.t)
         Ni = pi.exquo(Si)
@@ -1008,6 +1010,143 @@ def polynomial_reduce(p, DE):
 
     return (q, p)
 
+
+def laurent_series(a, d, F, n, DE):
+    """
+    (* Contribution of F to the full partial fraction decomposition of A/D *)
+    (* Given a field K of characteristic 0 and A,D,F in K[x] with D monic,
+    nonzero, coprime with A, and F the factor of multiplicity n in the square-
+    free factorization of D, return the principal parts of the Laurent series of
+    A/D at all the zeros of F. *)
+    """
+    if F.degree()==0:
+        return 0
+    Z = _symbols('z', n)
+    Z.insert(0, z)
+    delta = 0
+
+    E = d.quo((F**n).as_poly())
+    h_denom = E.as_expr()*z**n
+    h = a.as_expr()/h_denom
+    h = h.as_poly()
+
+    dF = derivation(F,DE)
+    B, G = gcdex_diophantine(E, F, Poly(1,DE.t))
+    C, G = gcdex_diophantine(dF, F, Poly(1,DE.t))
+
+    # initialization
+    F_store = F
+    V, DE_D_list, H_list= [], [], []
+
+    for j in range(0,n):
+    # jth derivative of z would be substituted with dfnth/(j+1) where dfnth =(d^n)f/(dx)^n
+        F_store = derivation(F_store, DE)
+        v = (F_store.as_expr())/(j + 1)
+        V.append(v)
+        DE_D_list.append(Poly(Z[j + 1],Z[j]))
+
+    DE_new = DifferentialExtension(extension = {'D': DE_D_list}) #a differential indeterminate
+    for j in range(0, n):
+        zEh = pow(z.as_poly(),n + j) * pow(E,j + 1) * h
+        P = cancel(zEh.as_expr())
+        Q = P
+
+        for i in range(0, j + 1):
+            Q = Q.subs(Z[i], V[i])
+        h = (derivation(h, DE, basic = True) + derivation(h, DE_new, basic = True)).as_expr()/(j + 1)
+        h = h.as_poly()
+
+        F_star = F.as_expr()/gcd(F,Q).as_expr()
+        F_star = cancel(F_star)
+        F_star = F_star.as_poly()
+        if F_star.degree() > 0:
+            QBC = Q.as_expr() * (B**(1 + j)).as_expr() * (C**(n + j)).as_expr()
+
+            H = QBC.as_poly(DE.t)
+            H_list.append(H)
+            H = QBC.as_poly(DE.t).rem(F_star)
+            alphas = real_roots(F_star)
+            for alpha in alphas:
+                delta = delta + H.eval(alpha)/((DE.t - alpha)**(n - j)).as_expr()
+    delta = delta.as_poly()
+    return (delta, H_list)
+
+def full_partial_fraction(a, d, DE):
+
+    q, r = a.div(d)
+    Np, Sp = splitfactor_sqf(d, DE, coefficientD=True, z=z)
+
+    i = 1
+    for (s, k) in Sp:
+        delta, H = laurent_series(r, d, s, i, DE)
+        q  = q + delta
+        i = i + 1
+    return q
+
+
+def recognize_derivative(a, d, DE, z=None):
+    """
+    Compute the squarefree factorization of the denominator of f
+    and for each Di the polynomial H in K[x] (see Theorem 2.7.1), using the
+    LaurentSeries algorithm. Write Di = GiEi where Gj = gcd(Hn, Di) and
+    gcd(Ei,Hn) = 1. Since the residues of f at the roots of Gj are all 0, and
+    the residue of f at a root alpha of Ei is Hi(a) != 0, f is the derivative of a
+    rational function if and only if Ei = 1 for each i, which is equivalent to
+    Di | H[-1] for each i.
+    """
+    flag =True
+    a, d = a.cancel(d, include=True)
+    q, r = a.div(d)
+    Np, Sp = splitfactor_sqf(d, DE, coefficientD=True, z=z)
+
+    j = 1
+    for (s, i) in Sp:
+       delta, H = laurent_series(r, d, s, j, DE)
+       g = gcd(d, H[-1]).as_poly()
+       if g is not d:
+             flag = False
+             break
+       j = j + 1
+    return flag
+
+def recognize_log_derivative(a, d, DE, z=None):
+    """
+    There exists a v in K(x)* such that f = dv/v
+    where f a rational function if and only if f can be written as f = A/D
+    where D is squarefree,deg(A) < deg(D), gcd(A, D) = 1,
+    and all the roots of the Rothstein-Trager resultant are integers. In that case,
+    any of the Rothstein-Trager, Lazard-Rioboo-Trager or Czichowski algorithm
+    produces u in K(x) such that du/dx = uf.
+    """
+    flag = True
+
+    z = z or Dummy('z')
+    a, d = a.cancel(d, include=True)
+    if a.is_zero:
+        return ([], True)
+    p, a = a.div(d)
+    pz = Poly(z, DE.t)
+    Dd = derivation(d, DE, basic = True)
+    try:
+       q = (a.as_expr() - pz.as_expr()*Dd.as_expr()).as_poly()
+    except:
+       q = (a.as_expr() - pz.as_expr()*Dd.as_expr()).as_poly(DE.t)
+    r, R = d.resultant(q, includePRS=True)
+    try:
+       Np, Sp = splitfactor_sqf(r, DE, coefficientD=True, z=z,basic=True)
+    except:
+       Np, Sp = splitfactor_sqf(r.as_poly(DE.t), DE, coefficientD=True, z=z,basic=True)
+
+    for s, i in Sp:
+        # TODO also consider the complex roots
+        # incase we have complex roots it should turn the flag false
+        a = real_roots(s.as_poly(z))
+
+        for j in a:
+            if not j.is_integer:
+                flag = False
+
+    return flag
 
 def residue_reduce(a, d, DE, z=None, invert=True):
     """

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1047,8 +1047,8 @@ def laurent_series(a, d, F, n, DE):
 
     DE_new = DifferentialExtension(extension = {'D': DE_D_list}) #a differential indeterminate
     for j in range(0, n):
-        zEh = pow(z.as_poly(),n + j) * pow(E,j + 1) * h
-        P = cancel(zEh.as_expr())
+        zEh = z**(n + j)*E.as_expr()**(j + 1)*h.as_expr()
+        P = cancel(zEh)
         Q = P
 
         for i in range(0, j + 1):
@@ -1118,24 +1118,15 @@ def recognize_log_derivative(a, d, DE, z=None):
     any of the Rothstein-Trager, Lazard-Rioboo-Trager or Czichowski algorithm
     produces u in K(x) such that du/dx = uf.
     """
-    flag = True
 
     z = z or Dummy('z')
     a, d = a.cancel(d, include=True)
     if a.is_zero:
         return ([], True)
-    p, a = a.div(d)
-    pz = Poly(z, DE.t)
     Dd = derivation(d, DE, basic = True)
-    try:
-       q = (a.as_expr() - pz.as_expr()*Dd.as_expr()).as_poly()
-    except:
-       q = (a.as_expr() - pz.as_expr()*Dd.as_expr()).as_poly(DE.t)
+    q = (a - z*Dd).as_poly()
     r, R = d.resultant(q, includePRS=True)
-    try:
-       Np, Sp = splitfactor_sqf(r, DE, coefficientD=True, z=z,basic=True)
-    except:
-       Np, Sp = splitfactor_sqf(r.as_poly(DE.t), DE, coefficientD=True, z=z,basic=True)
+    Np, Sp = splitfactor_sqf(r.as_poly(), DE, coefficientD=True, z=z,basic=True)
 
     for s, i in Sp:
         # TODO also consider the complex roots
@@ -1144,9 +1135,9 @@ def recognize_log_derivative(a, d, DE, z=None):
 
         for j in a:
             if not j.is_integer:
-                flag = False
+                return False
 
-    return flag
+    return True
 
 def residue_reduce(a, d, DE, z=None, invert=True):
     """

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1013,11 +1013,12 @@ def polynomial_reduce(p, DE):
 
 def laurent_series(a, d, F, n, DE):
     """
-    (* Contribution of F to the full partial fraction decomposition of A/D *)
-    (* Given a field K of characteristic 0 and A,D,F in K[x] with D monic,
+    Contribution of F to the full partial fraction decomposition of A/D
+
+    Given a field K of characteristic 0 and A,D,F in K[x] with D monic,
     nonzero, coprime with A, and F the factor of multiplicity n in the square-
     free factorization of D, return the principal parts of the Laurent series of
-    A/D at all the zeros of F. *)
+    A/D at all the zeros of F.
     """
     if F.degree()==0:
         return 0
@@ -1027,8 +1028,7 @@ def laurent_series(a, d, F, n, DE):
 
     E = d.quo((F**n).as_poly())
     h_denom = E.as_expr()*z**n
-    h = a.as_expr()/h_denom
-    h = h.as_poly()
+    h = (a.as_expr()/h_denom).as_poly()
 
     dF = derivation(F,DE)
     B, G = gcdex_diophantine(E, F, Poly(1,DE.t))
@@ -1135,9 +1135,8 @@ def recognize_log_derivative(a, d, DE, z=None):
         # incase we have complex roots it should turn the flag false
         a = real_roots(s.as_poly(z))
 
-        for j in a:
-            if not j.is_integer:
-                return False
+        if any(not j.is_Integer for j in a):
+            return False
     return True
 
 def residue_reduce(a, d, DE, z=None, invert=True):

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1123,10 +1123,12 @@ def recognize_log_derivative(a, d, DE, z=None):
     a, d = a.cancel(d, include=True)
     if a.is_zero:
         return ([], True)
-    Dd = derivation(d, DE, basic = True)
-    q = (a - z*Dd).as_poly()
+    p, a = a.div(d)
+
+    Dd = derivation(d, DE, basic=True)
+    q = (a.as_expr() - z*Dd.as_expr()).as_poly()
     r, R = d.resultant(q, includePRS=True)
-    Np, Sp = splitfactor_sqf(r.as_poly(), DE, coefficientD=True, z=z,basic=True)
+    Np, Sp = splitfactor_sqf(r, DE, coefficientD=True, z=z, basic=True)
 
     for s, i in Sp:
         # TODO also consider the complex roots
@@ -1136,7 +1138,6 @@ def recognize_log_derivative(a, d, DE, z=None):
         for j in a:
             if not j.is_integer:
                 return False
-
     return True
 
 def residue_reduce(a, d, DE, z=None, invert=True):

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -43,6 +43,11 @@ def test_prde_special_denom():
     assert prde_special_denom(Poly(1, t), Poly(t**2, t), Poly(1, t), G, DE) == \
         (Poly(1, t), Poly(t**2 - 1, t), [(Poly(t**2, t), Poly(1, t)),
         (Poly(1, t), Poly(1, t))], Poly(t, t))
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
+    assert prde_special_denom(Poly(5*t + 1, t), Poly(t**2, t), Poly(1, t), G, DE) == \
+    (Poly(5*t + 1, t), Poly(t**2, t),[(Poly(t, t), Poly(1, t)),(Poly(1, t), Poly(t, t))],
+     Poly(1, t))
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
 
 
 def test_prde_linear_constraints():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -43,11 +43,11 @@ def test_prde_special_denom():
     assert prde_special_denom(Poly(1, t), Poly(t**2, t), Poly(1, t), G, DE) == \
         (Poly(1, t), Poly(t**2 - 1, t), [(Poly(t**2, t), Poly(1, t)),
         (Poly(1, t), Poly(1, t))], Poly(t, t))
+    G = [(Poly(t, t), Poly(t**2, t)), (Poly(2*t, t), Poly(t, t))]
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
-    assert prde_special_denom(Poly(5*t + 1, t), Poly(t**2, t), Poly(1, t), G, DE) == \
-    (Poly(5*t + 1, t), Poly(t**2, t),[(Poly(t, t), Poly(1, t)),(Poly(1, t), Poly(t, t))],
-     Poly(1, t))
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    # asmeurer could you please have a look at these two test cases
+    prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3, t), G, DE)
+    prde_special_denom(Poly(t + 1, t), Poly(t**2, t), Poly(t**3, t), G, DE)
 
 
 def test_prde_linear_constraints():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -50,12 +50,13 @@ def test_prde_special_denom():
         (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t, t), Poly(t**2, t)),
         (Poly(2*t, t), Poly(t, t))], Poly(1, x))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly((t**2 + 1)*2*x, t)]})
-    DE.decrement_level()
     G = [(Poly(t + x, t), Poly(t*x, t)), (Poly(2*t, t), Poly(x**2, x))]
     assert prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3, t), G, DE) == \
-        (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t), Poly(x**2, x))], Poly(1, x))
+        (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)),
+        (Poly(2*t, t, x), Poly(x**2, t, x))], Poly(1, t))
     assert prde_special_denom(Poly(t + 1, t), Poly(t**2, t), Poly(t**3, t), G, DE) == \
-        (Poly(t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t), Poly(x**2, x))], Poly(1, x))
+        (Poly(t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t, x),
+        Poly(x**2, t, x))], Poly(1, t))
 
 
 def test_prde_linear_constraints():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -44,7 +44,7 @@ def test_prde_special_denom():
         (Poly(1, t), Poly(t**2 - 1, t), [(Poly(t**2, t), Poly(1, t)),
         (Poly(1, t), Poly(1, t))], Poly(t, t))
     G = [(Poly(t, t), Poly(t**2, t)), (Poly(2*t, t), Poly(t, t))]
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
+    DE = DifferentialExtension(extension={'D': [Poly(1, t), Poly(t**2 + 1, t)]})
     # asmeurer could you please have a look at these two test cases
     prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3, t), G, DE)
     prde_special_denom(Poly(t + 1, t), Poly(t**2, t), Poly(t**3, t), G, DE)

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -1,6 +1,6 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import with_statement
-from sympy import Poly, Matrix, S, symbols
+from sympy import Poly, Matrix, S, symbols, I
 from sympy.integrals.risch import DifferentialExtension
 from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_linear_constraints, constant_system, prde_spde, prde_no_cancel_b_large,
@@ -10,7 +10,7 @@ from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
 
 from sympy.abc import x, t, n
 
-t0, t1, t2, t3 = symbols('t:4')
+t0, t1, t2, t3, k = symbols('t:4 k')
 
 
 def test_prde_normal_denom():
@@ -43,11 +43,19 @@ def test_prde_special_denom():
     assert prde_special_denom(Poly(1, t), Poly(t**2, t), Poly(1, t), G, DE) == \
         (Poly(1, t), Poly(t**2 - 1, t), [(Poly(t**2, t), Poly(1, t)),
         (Poly(1, t), Poly(1, t))], Poly(t, t))
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-2*x*t0, t0)]})
+    DE.decrement_level()
     G = [(Poly(t, t), Poly(t**2, t)), (Poly(2*t, t), Poly(t, t))]
-    DE = DifferentialExtension(extension={'D': [Poly(1, t), Poly(t**2 + 1, t)]})
-    # asmeurer could you please have a look at these two test cases
-    prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3, t), G, DE)
-    prde_special_denom(Poly(t + 1, t), Poly(t**2, t), Poly(t**3, t), G, DE)
+    assert prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3 + 2, t), G, DE) == \
+        (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t, t), Poly(t**2, t)),
+        (Poly(2*t, t), Poly(t, t))], Poly(1, x))
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly((t**2 + 1)*2*x, t)]})
+    DE.decrement_level()
+    G = [(Poly(t + x, t), Poly(t*x, t)), (Poly(2*t, t), Poly(x**2, x))]
+    assert prde_special_denom(Poly(5*x*t + 1, t), Poly(t**2 + 2*x**3*t, t), Poly(t**3, t), G, DE) == \
+        (Poly(5*x*t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t), Poly(x**2, x))], Poly(1, x))
+    assert prde_special_denom(Poly(t + 1, t), Poly(t**2, t), Poly(t**3, t), G, DE) == \
+        (Poly(t + 1, t), Poly(0, t), [(Poly(t + x, t), Poly(x*t, t)), (Poly(2*t, t), Poly(x**2, x))], Poly(1, x))
 
 
 def test_prde_linear_constraints():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -8,7 +8,8 @@ from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     integrate_primitive, integrate_hyperexponential_polynomial,
     integrate_hyperexponential, integrate_hypertangent_polynomial,
     integrate_nonlinear_no_specials, integer_powers, DifferentialExtension,
-    risch_integrate, DecrementLevel, NonElementaryIntegral)
+    risch_integrate, DecrementLevel, NonElementaryIntegral, recognize_log_derivative,
+    recognize_derivative, laurent_series, full_partial_fraction)
 from sympy.utilities.pytest import raises
 
 from sympy.abc import x, t, nu, z, a, y
@@ -134,6 +135,71 @@ def test_polynomial_reduce():
         (Poly(t, t), Poly(x*t, t))
     assert polynomial_reduce(Poly(0, t), DE) == \
         (Poly(0, t), Poly(0, t))
+
+
+def test_laurent_series():
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
+    a = Poly(36, t)
+    d = Poly((t - 2)*(t**2 - 1)**2, t)
+    F = Poly(t**2 - 1, t)
+    n = 2
+    assert laurent_series(a, d, F, n, DE) == \
+        (Poly(-4*1/(t + 1) - 3*1/(t**2 + 2*t + 1) - 9*1/(t**2 - 2*t + 1)
+           ,1/(t + 1), 1/(t**2 + 2*t + 1), 1/(t**2 - 2*t + 1), domain='ZZ'),
+        [Poly(-3*t**3 - 6*t**2, t, domain='ZZ'), Poly(-2*t**6 - 6*t**5 + 8*t**3, t, domain='ZZ')])
+
+def test_full_partial_fraction():
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
+    a = Poly(36, t)
+    d = Poly((t - 2)*(t**2 - 1)**2, t)
+    assert full_partial_fraction(a, d, DE) == \
+        Poly(4*1/(t - 2) - 4*1/(t + 1) - 3*1/(t**2 + 2*t + 1) - 9*1/(t**2 - 2*t + 1), t,
+        1/(t - 2), 1/(t + 1), 1/(t**2 + 2*t + 1), 1/(t**2 - 2*t + 1), domain='ZZ')
+
+
+def test_recognize_derivative():
+    # needs better test cases for now
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
+    a = Poly(36, t)
+    d = Poly((t - 2)*(t**2 - 1)**2, t)
+    assert recognize_derivative(a, d, DE) == \
+        False
+
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    a = Poly(2, t)
+    d = Poly(t**2 - 1, t)
+    assert recognize_derivative(a, d, DE) == \
+        False
+
+def test_recognize_log_derivative():
+
+    a = Poly(2*x**2 + 4*x*t - 2*t - x**2*t)
+    d = Poly((2*x + t)*(t + x**2))
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    assert recognize_log_derivative(a, d, DE) == \
+         True
+    a = Poly(1, t)
+    d = Poly(t*1/(t + 1) - 1/(t + 1), t, 1/(t + 1))
+
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    assert recognize_log_derivative(a, d, DE) == \
+         True
+
+    a = Poly(1, t)
+    d = Poly(t**2 - 2, t)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
+    assert recognize_log_derivative(a, d, DE) == \
+         False
+
+    d = Poly(t**3 + t)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
+    assert recognize_log_derivative(a, d, DE) == \
+         False
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    a = Poly(2, t)
+    d = Poly(t**2 - 1, t)
+    assert recognize_log_derivative(a, d, DE) == \
+        True
 
 
 def test_residue_reduce():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -144,9 +144,9 @@ def test_laurent_series():
     F = Poly(t**2 - 1, t)
     n = 2
     assert laurent_series(a, d, F, n, DE) == \
-        (Poly(-4*1/(t + 1) - 3*1/(t**2 + 2*t + 1) - 9*1/(t**2 - 2*t + 1)
-           ,1/(t + 1), 1/(t**2 + 2*t + 1), 1/(t**2 - 2*t + 1), domain='ZZ'),
-        [Poly(-3*t**3 - 6*t**2, t, domain='ZZ'), Poly(-2*t**6 - 6*t**5 + 8*t**3, t, domain='ZZ')])
+        (Poly(-4*1/(t + 1) - 3*1/(t**2 + 2*t + 1) - 9*1/(t**2 - 2*t + 1),
+        1/(t + 1), 1/(t**2 + 2*t + 1), 1/(t**2 - 2*t + 1)),[Poly(-3*t**3 - 6*t**2, t),
+        Poly(-2*t**6 - 6*t**5 + 8*t**3, t)])
 
 def test_full_partial_fraction():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
@@ -176,30 +176,21 @@ def test_recognize_log_derivative():
     a = Poly(2*x**2 + 4*x*t - 2*t - x**2*t)
     d = Poly((2*x + t)*(t + x**2))
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
-    assert recognize_log_derivative(a, d, DE) == \
-         True
+    assert recognize_log_derivative(a, d, DE) == True
     a = Poly(1, t)
     d = Poly(t*1/(t + 1) - 1/(t + 1), t, 1/(t + 1))
-
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
-    assert recognize_log_derivative(a, d, DE) == \
-         True
-
+    assert recognize_log_derivative(a, d, DE) == True
     a = Poly(1, t)
     d = Poly(t**2 - 2, t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
-    assert recognize_log_derivative(a, d, DE) == \
-         False
-
+    assert recognize_log_derivative(a, d, DE) == False
     d = Poly(t**3 + t)
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
-    assert recognize_log_derivative(a, d, DE) == \
-         False
+    assert recognize_log_derivative(a, d, DE) == False
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     a = Poly(2, t)
     d = Poly(t**2 - 1, t)
-    assert recognize_log_derivative(a, d, DE) == \
-        True
+    assert recognize_log_derivative(a, d, DE) == True
 
 
 def test_residue_reduce():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -9,7 +9,7 @@ from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     integrate_hyperexponential, integrate_hypertangent_polynomial,
     integrate_nonlinear_no_specials, integer_powers, DifferentialExtension,
     risch_integrate, DecrementLevel, NonElementaryIntegral, recognize_log_derivative,
-    recognize_derivative, laurent_series, full_partial_fraction)
+    recognize_derivative, laurent_series)
 from sympy.utilities.pytest import raises
 
 from sympy.abc import x, t, nu, z, a, y
@@ -144,53 +144,36 @@ def test_laurent_series():
     F = Poly(t**2 - 1, t)
     n = 2
     assert laurent_series(a, d, F, n, DE) == \
-        (Poly(-4*1/(t + 1) - 3*1/(t**2 + 2*t + 1) - 9*1/(t**2 - 2*t + 1),
-        1/(t + 1), 1/(t**2 + 2*t + 1), 1/(t**2 - 2*t + 1)),[Poly(-3*t**3 - 6*t**2, t),
-        Poly(-2*t**6 - 6*t**5 + 8*t**3, t)])
-
-def test_full_partial_fraction():
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
-    a = Poly(36, t)
-    d = Poly((t - 2)*(t**2 - 1)**2, t)
-    assert full_partial_fraction(a, d, DE) == \
-        Poly(4*1/(t - 2) - 4*1/(t + 1) - 3*1/(t**2 + 2*t + 1) - 9*1/(t**2 - 2*t + 1), t,
-        1/(t - 2), 1/(t + 1), 1/(t**2 + 2*t + 1), 1/(t**2 - 2*t + 1), domain='ZZ')
+        (Poly(-3*t**3 + 3*t**2 - 6*t - 8, t), Poly(t**5 + t**4 - 2*t**3 - 2*t**2 + t + 1, t),
+        [Poly(-3*t**3 - 6*t**2, t), Poly(2*t**6 + 6*t**5 - 8*t**3, t)])
 
 
 def test_recognize_derivative():
-    # needs better test cases for now
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
+    DE = DifferentialExtension(extension={'D': [Poly(1, t)]})
     a = Poly(36, t)
     d = Poly((t - 2)*(t**2 - 1)**2, t)
-    assert recognize_derivative(a, d, DE) == \
-        False
-
+    assert recognize_derivative(a, d, DE) == False
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     a = Poly(2, t)
     d = Poly(t**2 - 1, t)
-    assert recognize_derivative(a, d, DE) == \
-        False
+    assert recognize_derivative(a, d, DE) == False
+    assert recognize_derivative(Poly(x*t, t), Poly(1, t), DE) == True
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
+    assert recognize_derivative(Poly(t, t), Poly(1, t), DE) == True
+
 
 def test_recognize_log_derivative():
 
-    a = Poly(2*x**2 + 4*x*t - 2*t - x**2*t)
-    d = Poly((2*x + t)*(t + x**2))
+    a = Poly(2*x**2 + 4*x*t - 2*t - x**2*t, t)
+    d = Poly((2*x + t)*(t + x**2), t)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
-    assert recognize_log_derivative(a, d, DE) == True
-    a = Poly(1, t)
-    d = Poly(t*1/(t + 1) - 1/(t + 1), t, 1/(t + 1))
+    assert recognize_log_derivative(a, d, DE, z) == True
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
-    assert recognize_log_derivative(a, d, DE) == True
-    a = Poly(1, t)
-    d = Poly(t**2 - 2, t)
+    assert recognize_log_derivative(Poly(t + 1, t), Poly(t + x, t), DE) == True
+    assert recognize_log_derivative(Poly(2, t), Poly(t**2 - 1), DE) == True
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
-    assert recognize_log_derivative(a, d, DE) == False
-    d = Poly(t**3 + t)
-    assert recognize_log_derivative(a, d, DE) == False
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
-    a = Poly(2, t)
-    d = Poly(t**2 - 1, t)
-    assert recognize_log_derivative(a, d, DE) == True
+    assert recognize_log_derivative(Poly(1, t), Poly(t**2 - 2), DE) == False
+    assert recognize_log_derivative(Poly(1, t), Poly(t**2 + t), DE) == True
 
 
 def test_residue_reduce():


### PR DESCRIPTION
added code for exponential cases to special denom

added code for tangent cases to special denom

added code for tangent cases to special denom

added hypertangent test cases for param special
- [x] General code cleanup (spaces after commas, spaces around operators, more even line wrapping in the docstring).
- [x] Don't use `as_poly()` with no arguments. 
- [x] Don't use `as_expr()` when it is unnecessary.  There is quite often a method of Poly that will do the same thing, but more efficiently because it stays as a Poly. Converting to Expr and back is expensive.  We should only do it when it is absolutely necessary (i.e., when the result is a rational function instead of a polynomial, and even then, immediately get the numerator and denominator and go back to Poly). 
- [x] Add a least some kind of docstring to every function.
- [x] Make sure that all `Poly` objects constructed in the tests explicitly call the second argument `t`.  Subtly different things can happen when you have a polynomial in t and x instead of just in t (this is also the source of annoying unification errors). 
