### PR TITLE
fix Sum and Product _eval_subs

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -280,10 +280,12 @@ def test_sum_reconstruct():
     raises(ValueError, lambda: Sum(x, (x, 1)))
 
 
-def test_Sum_limit_subs():
-    assert Sum(a*exp(a), (a, -2, 2)) == Sum(a*exp(a), (a, -b, b)).subs(b, 2)
-    assert Sum(a, (a, Sum(b, (b, 1, 2)), 4)).subs(Sum(b, (b, 1, 2)), c) == \
-        Sum(a, (a, c, 4))
+def test_limit_subs():
+    for F in (Sum, Product, Integral):
+        assert F(a*exp(a), (a, -2, 2)) == F(a*exp(a), (a, -b, b)).subs(b, 2)
+        assert F(a, (a, F(b, (b, 1, 2)), 4)).subs(F(b, (b, 1, 2)), c) == \
+            F(a, (a, c, 4))
+        assert F(x, (x, 1, x + y)).subs(x, 1) == F(x, (x, 1, y + 1))
 
 
 @XFAIL

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1,8 +1,14 @@
-from sympy.core import (Basic, Expr, S, C, Symbol, Wild, Add, sympify, diff,
-                        oo, Tuple, Interval)
-
-from sympy.core.symbol import Dummy
+from sympy.core.add import Add
+from sympy.core.basic import Basic, C
 from sympy.core.compatibility import is_sequence
+from sympy.core.containers import Tuple
+from sympy.core.expr import Expr
+from sympy.core.function import diff
+from sympy.core.numbers import oo
+from sympy.core.sets import Interval
+from sympy.core.singleton import S
+from sympy.core.symbol import (Dummy, Symbol, Wild)
+from sympy.core.sympify import sympify
 from sympy.integrals.manualintegrate import manualintegrate
 from sympy.integrals.trigonometry import trigintegrate
 from sympy.integrals.deltafunctions import deltaintegrate
@@ -1234,7 +1240,7 @@ class Integral(Expr):
         >>> i.subs(x, y - c)
         Integral(a - c + y, (a, a, 3), (b, -c + y, c))
         """
-        integrand, limits = self.function, self.limits
+        func, limits = self.function, self.limits
         old_atoms = old.free_symbols
         limits = list(limits)
 
@@ -1248,8 +1254,8 @@ class Integral(Expr):
                                   *[l._subs(old, new) for l in xab[1:]])
             dummies.add(xab[0])
         if not dummies.intersection(old_atoms):
-            integrand = integrand.subs(old, new)
-        return self.func(integrand, *limits)
+            func = func.subs(old, new)
+        return self.func(func, *limits)
 
     def _eval_transpose(self):
         if all(map(lambda x: x.is_real, flatten(self.limits))):


### PR DESCRIPTION
https://code.google.com/p/sympy/issues/detail?id=3786

```
>>> Integral(x,(x,1,x+y)).subs(x,1)  # CORRECT
Integral(x, (x, 1, y + 1))

>>> Sum(x,(x,1,x+y)).subs(x,1)  # this doesn't replace the x
Sum(x, (x, 1, x + y))

>>> Product(x,(x,1,2))  # raises Traceback
Product(x, (x, 1, 2))
>>> _.subs(x,1)
Traceback (most recent call last):

...
ValueError: Invalid limits given: ((1, 1, 2),)
```

This is a pretty clean fix, making Product and Sum handling in `_eval_subs` consistent with that of Integral. Without this change they are significantly broken in terms of handling of subs.
