### PR TITLE
Fix test_import directory dependency issue

### DIFF
--- a/bin/get_sympy.py
+++ b/bin/get_sympy.py
@@ -12,3 +12,4 @@ def path_hack():
     sympy_dir = os.path.join(os.path.dirname(this_file), "..")
     sympy_dir = os.path.normpath(sympy_dir)
     sys.path.insert(0, sympy_dir)
+    return sympy_dir

--- a/bin/test_import
+++ b/bin/test_import
@@ -13,12 +13,13 @@ n_tests = 50
 
 from pexpect import run
 from numpy import mean, std
-
+from get_sympy import path_hack
 
 def test():
-    t = run("python bin/test_import.py")
+    t = run("python bin/test_import.py", cwd=path_hack())
     t = float(t)
     return t
+
 
 tests = [test() for x in range(n_tests + 1)]
 print "Note: the first run (warm up) was not included in the average + std dev"


### PR DESCRIPTION
`test_import` could only be executed inside `sympy`.
See the discussion here https://github.com/sympy/sympy-bot/pull/164
