### PR TITLE
3788: simplification of powers

### DIFF
--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2,6 +2,7 @@ from __future__ import division
 
 from sympy import (Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo, Integer,
+        sign, im
 )
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import test_numerically
@@ -172,6 +173,23 @@ def test_pow2():
 def test_pow3():
     assert sqrt(2)**3 == 2 * sqrt(2)
     assert sqrt(2)**3 == sqrt(8)
+
+
+def test_pow_E():
+    assert 2**(y/log(2)) == S.Exp1**y
+    assert 2**(y/log(2)/3) == S.Exp1**(y/3)
+    assert 3**(1/log(-3)) != S.Exp1
+    assert (3 + 2*I)**(1/(log(-3 - 2*I) + I*pi)) == S.Exp1
+    assert (3 + 2*I)**(1/(log(-3 - 2*I, 3)/2 + I*pi/log(3)/2)) == 9
+    assert (3 + 2*I)**(1/(log(3 + 2*I, 3)/2)) == 9
+    # every time tests are run they will affirm with a different random
+    # value that this identity holds
+    while 1:
+        b = x._random()
+        r, i = b.as_real_imag()
+        if i:
+            break
+    assert test_numerically(b**(1/(log(-b) + sign(i)*I*pi).n()), S.Exp1)
 
 
 def test_pow_issue417():


### PR DESCRIPTION
https://code.google.com/p/sympy/issues/detail?id=3788

These changes will allow SymPy to recognize `b**(1/log(b))` and `b**(1/(log(-b)+sign(im(b))*pi))` as `E`.
