### PR TITLE
modify replace to truly act from the bottom up

### DIFF
--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -603,10 +603,16 @@ def test_replace():
         sin, lambda a: sin(2*a)) == log(sin(2*x)) + tan(sin(2*x**2))
 
     a = Wild('a')
+    b = Wild('b')
 
     assert f.replace(sin(a), cos(a)) == log(cos(x)) + tan(cos(x**2))
     assert f.replace(
         sin(a), lambda a: sin(2*a)) == log(sin(2*x)) + tan(sin(2*x**2))
+    # test exact
+    assert (2*x).replace(a*x + b, b - a, exact=True) == 2*x
+    assert (2*x).replace(a*x + b, b - a) == 2/x
+    assert (2*x).replace(a*x + b, lambda a, b: b - a, exact=True) == 2*x
+    assert (2*x).replace(a*x + b, lambda a, b: b - a) == 2/x
 
     g = 2*sin(x**3)
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -616,7 +616,19 @@ def test_replace():
     assert cos(x).replace(cos, sin, map=True) == (sin(x), {cos(x): sin(x)})
     assert sin(x).replace(cos, sin) == sin(x)
 
-    assert (y*sin(x)).replace(sin, lambda expr: sin(expr)/y) == sin(x)
+    args = lambda x:x.is_Mul, lambda x:2*x
+    assert (x*y).replace(*args, map=True) == (2*x*y, {x*y: 2*x*y})
+    assert (x*(1 + x*y)).replace(*args, map=True) == \
+        (2*x*(2*x*y + 1), {x*(2*x*y + 1): 2*x*(2*x*y + 1), x*y: 2*x*y})
+    assert (y*sin(x)).replace(sin, lambda expr: sin(expr)/y, map=True) == \
+        (sin(x), {sin(x): sin(x)/y})
+    assert (x*(x*y + 3)).replace(lambda x: x.is_Mul, lambda x: 2 + x) == \
+        x*(x*y + 5) + 2
+    e = (x*y + 1)*(2*x*y + 1) + 1
+    assert e.replace(*args, map=True) == (
+        2*((2*x*y + 1)*(4*x*y + 1)) + 1,
+        {2*x*y: 4*x*y, x*y: 2*x*y, (2*x*y + 1)*(4*x*y + 1):
+        2*((2*x*y + 1)*(4*x*y + 1))})
 
 
 def test_find():

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -521,7 +521,7 @@ class TrigonometricIntegral(Function):
         baseseries = self._trigfunc(x)._eval_nseries(x, n, logx)
         if self._trigfunc(0) != 0:
             baseseries -= 1
-        baseseries = baseseries.replace(Pow, lambda t, n: t**n/n)
+        baseseries = baseseries.replace(Pow, lambda t, n: t**n/n, simultaneous=False)
         if self._trigfunc(0) != 0:
             baseseries += EulerGamma + log(x)
         return baseseries.subs(x, self.args[0])._eval_nseries(x, n, logx)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -214,7 +214,6 @@ def test_si():
     assert tn_arg(Si)
     assert tn_arg(Shi)
 
-    from sympy import O
     assert Si(x).nseries(x, n=8) == \
         x - x**3/18 + x**5/600 - x**7/35280 + O(x**9)
     assert Shi(x).nseries(x, n=8) == \


### PR DESCRIPTION
Previously, replace would not target any subexpression in which
subexpressions were changed, so x_(x_y + 1) would become x_(2_x_y + 1)
if all Muls were being multiplied by 2. Now 2_x_(2_x*y + 1) is
obtained.

Add more explanations to replace's docstring in response to [issue 2511](https://code.google.com/p/sympy/issues/detail?id=2511).
