### PR TITLE
defining hashable content for objects with bound symbols

### DIFF
--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -66,10 +66,6 @@ class Product(Expr):
         """
         return [l[0] for l in self.limits]
 
-    def _hashable_content(self):
-        from sympy.integrals.integrals import _hashable_content
-        return _hashable_content(self)
-
     @property
     def free_symbols(self):
         """

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -67,9 +67,8 @@ class Product(Expr):
         return [l[0] for l in self.limits]
 
     def _hashable_content(self):
-        r = self.canonical_variables
-        return (self.function.xreplace(r),
-            ) + tuple([l.xreplace(r) for l in self.limits])
+        from sympy.integrals.integrals import _hashable_content
+        return _hashable_content(self)
 
     @property
     def free_symbols(self):
@@ -83,11 +82,10 @@ class Product(Expr):
         >>> Product(x, (x, y, 1)).free_symbols
         set([y])
         """
-        from sympy.concrete.summations import _free_symbols
-
+        from sympy.integrals.integrals import _free_symbols
         if self.function.is_zero or self.function == 1:
             return set()
-        return _free_symbols(self.function, self.limits)
+        return _free_symbols(self)
 
     @property
     def is_zero(self):
@@ -118,6 +116,10 @@ class Product(Expr):
         """
 
         return self.function.is_zero or self.function == 1 or not self.free_symbols
+
+    def as_dummy(self):
+        from sympy.integrals.integrals import _as_dummy
+        return _as_dummy(self)
 
     def doit(self, **hints):
         f = g = self.function
@@ -236,22 +238,8 @@ class Product(Expr):
 
 
     def _eval_subs(self, old, new):
-        func, limits = self.function, self.limits
-        old_atoms = old.free_symbols
-        limits = list(limits)
-
-        dummies = set()
-        for i in xrange(-1, -len(limits) - 1, -1):
-            xab = limits[i]
-            if len(xab) == 1:
-                continue
-            if not dummies.intersection(old_atoms):
-                limits[i] = Tuple(xab[0],
-                                  *[l._subs(old, new) for l in xab[1:]])
-            dummies.add(xab[0])
-        if not dummies.intersection(old_atoms):
-            func = func.subs(old, new)
-        return self.func(func, *limits)
+        from sympy.integrals.integrals import _eval_subs
+        return _eval_subs(self, old, new)
 
 
 def product(*args, **kwargs):

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -66,6 +66,11 @@ class Product(Expr):
         """
         return [l[0] for l in self.limits]
 
+    def _hashable_content(self):
+        r = self.canonical_variables
+        return (self.function.xreplace(r),
+            ) + tuple([l.xreplace(r) for l in self.limits])
+
     @property
     def free_symbols(self):
         """

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -13,21 +13,6 @@ from sympy.polys import apart, PolynomialError
 from sympy.solvers import solve
 
 
-def _free_symbols(function, limits):
-    """Helper function to return the symbols that appear in a sum-like object
-    once it is evaluated.
-    """
-    isyms = function.free_symbols
-    for xab in limits:
-        # take out the target symbol
-        if xab[0] in isyms:
-            isyms.remove(xab[0])
-        # add in the new symbols
-        for i in xab[1:]:
-            isyms.update(i.free_symbols)
-    return isyms
-
-
 class Sum(Expr):
     """Represents unevaluated summation.
 
@@ -107,25 +92,15 @@ class Sum(Expr):
         return [l[0] for l in self.limits]
 
     def _hashable_content(self):
-        r = self.canonical_variables
-        return (self.function.xreplace(r),
-            ) + tuple([l.xreplace(r) for l in self.limits])
+        from sympy.integrals.integrals import _hashable_content
+        return _hashable_content(self)
 
     @property
     def free_symbols(self):
-        """
-        This method returns the symbols that will exist when the
-        summation is evaluated. This is useful if one is trying to
-        determine whether a sum depends on a certain symbol or not.
-
-        >>> from sympy import Sum
-        >>> from sympy.abc import x, y
-        >>> Sum(x, (x, y, 1)).free_symbols
-        set([y])
-        """
+        from sympy.integrals.integrals import _free_symbols
         if self.function.is_zero:
             return set()
-        return _free_symbols(self.function, self.limits)
+        return _free_symbols(self)
 
     @property
     def is_zero(self):
@@ -166,6 +141,10 @@ class Sum(Expr):
         """
 
         return self.function.is_zero or not self.free_symbols
+
+    def as_dummy(self):
+        from sympy.integrals.integrals import _as_dummy
+        return _as_dummy(self)
 
     def doit(self, **hints):
         if hints.get('deep', True):
@@ -320,22 +299,8 @@ class Sum(Expr):
         return s + iterm, abs(term)
 
     def _eval_subs(self, old, new):
-        func, limits = self.function, self.limits
-        old_atoms = old.free_symbols
-        limits = list(limits)
-
-        dummies = set()
-        for i in xrange(-1, -len(limits) - 1, -1):
-            xab = limits[i]
-            if len(xab) == 1:
-                continue
-            if not dummies.intersection(old_atoms):
-                limits[i] = Tuple(xab[0],
-                                  *[l._subs(old, new) for l in xab[1:]])
-            dummies.add(xab[0])
-        if not dummies.intersection(old_atoms):
-            func = func.subs(old, new)
-        return self.func(func, *limits)
+        from sympy.integrals.integrals import _eval_subs
+        return _eval_subs(self, old, new)
 
 
 def summation(f, *symbols, **kwargs):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -91,10 +91,6 @@ class Sum(Expr):
         """
         return [l[0] for l in self.limits]
 
-    def _hashable_content(self):
-        from sympy.integrals.integrals import _hashable_content
-        return _hashable_content(self)
-
     @property
     def free_symbols(self):
         from sympy.integrals.integrals import _free_symbols

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -106,6 +106,11 @@ class Sum(Expr):
         """
         return [l[0] for l in self.limits]
 
+    def _hashable_content(self):
+        r = self.canonical_variables
+        return (self.function.xreplace(r),
+            ) + tuple([l.xreplace(r) for l in self.limits])
+
     @property
     def free_symbols(self):
         """

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -294,14 +294,18 @@ def test_equality():
     r = symbols('x', real=True)
     for F in (Sum, Product, Integral):
         try:
-            assert F(x, x) == F(y, y)
+            assert F(x, x) != F(y, y)
             assert F(x, (x, 1, 2)) != F(x, x)
+            assert F(x, (x, x)) != F(x, x)  # or else they print the same
+            assert F(1, x) != F(1, y)
         except ValueError:
             pass
         assert F(a, (x, 1, 2)) == F(a, (x, 1, 2))
         assert F(a, (x, 1, 2)) != F(a, (x, 1, 3))
         assert F(a, (x, 1, 2)) != F(b, (x, 1, 2))
         assert F(x, (x, 1, 2)) != F(r, (r, 1, 2))
+        assert F(1, (x, 1, x)) == F(1, (y, 1, x))
+        assert F(1, (x, 1, x)) != F(1, (y, 1, y))
 
     # issue 2166
     assert Sum(x, (x, 1, x)).subs(x, a) == Sum(x, (x, 1, a))

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -288,8 +288,22 @@ def test_limit_subs():
         assert F(x, (x, 1, x + y)).subs(x, 1) == F(x, (x, 1, y + 1))
 
 
-@XFAIL
-def test_issue2166():
+def test_equality():
+    # if this fails remove special handling below
+    raises(ValueError, lambda: Sum(x, x))
+    r = symbols('x', real=True)
+    for F in (Sum, Product, Integral):
+        try:
+            assert F(x, x) == F(y, y)
+            assert F(x, (x, 1, 2)) != F(x, x)
+        except ValueError:
+            pass
+        assert F(a, (x, 1, 2)) == F(a, (x, 1, 2))
+        assert F(a, (x, 1, 2)) != F(a, (x, 1, 3))
+        assert F(a, (x, 1, 2)) != F(b, (x, 1, 2))
+        assert F(x, (x, 1, 2)) != F(r, (r, 1, 2))
+
+    # issue 2166
     assert Sum(x, (x, 1, x)).subs(x, a) == Sum(x, (x, 1, a))
 
 

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -300,11 +300,10 @@ def test_equality():
             assert F(1, x) != F(1, y)
         except ValueError:
             pass
-        assert F(a, (x, 1, 2)) == F(a, (x, 1, 2))
         assert F(a, (x, 1, 2)) != F(a, (x, 1, 3))
         assert F(a, (x, 1, 2)) != F(b, (x, 1, 2))
         assert F(x, (x, 1, 2)) != F(r, (r, 1, 2))
-        assert F(1, (x, 1, x)) == F(1, (y, 1, x))
+        assert F(1, (x, 1, x)) != F(1, (y, 1, x))
         assert F(1, (x, 1, x)) != F(1, (y, 1, y))
 
     # issue 2166

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -568,7 +568,7 @@ class Basic(object):
         >>> from sympy import Lambda
         >>> from sympy.abc import x
         >>> Lambda(x, 2*x).canonical_variables
-        {_x: 0_}
+        {x: 0_}
         """
         if not hasattr(self, 'variables'):
             return {}

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -554,6 +554,32 @@ class Basic(object):
         union = set.union
         return reduce(union, [arg.free_symbols for arg in self.args], set())
 
+    @property
+    def canonical_variables(self):
+        """Return a dictionary mapping any variable defined in
+        ``self.variables`` as underscore-suffixed numbers
+        corresponding to their position in ``self.variables``. Enough
+        underscores are added to ensure that there will be no clash with
+        existing free symbols.
+
+        Examples
+        ========
+
+        >>> from sympy import Lambda
+        >>> from sympy.abc import x
+        >>> Lambda(x, 2*x).canonical_variables
+        {_x: 0_}
+        """
+        if not hasattr(self, 'variables'):
+            return {}
+        u = "_"
+        while any(s.name.endswith(u) for s in self.free_symbols):
+            u += "_"
+        name = '%%i%s' % u
+        V = self.variables
+        return dict(list(zip(V, [C.Symbol(name % i, **v.assumptions0)
+            for i, v in enumerate(V)])))
+
     def is_hypergeometric(self, k):
         from sympy.simplify import hypersimp
         return hypersimp(self, k) is not None

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1270,7 +1270,7 @@ class Lambda(Expr):
         return super(Lambda, self).__hash__()
 
     def _hashable_content(self):
-        return (self.nargs, ) + tuple(sorted(self.free_symbols))
+        return (self.expr.xreplace(self.canonical_variables),)
 
     @property
     def is_identity(self):
@@ -1416,7 +1416,7 @@ class Subs(Expr):
         return super(Subs, self).__hash__()
 
     def _hashable_content(self):
-        return (self._expr, )
+        return (self._expr.xreplace(self.canonical_variables),)
 
     def _eval_subs(self, old, new):
         if old in self.variables:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -936,7 +936,7 @@ class Derivative(Expr):
             return expr
 
         # Pop evaluate because it is not really an assumption and we will need
-        # to track use it carefully below.
+        # to track it carefully below.
         evaluate = assumptions.pop('evaluate', False)
 
         # Look for a quick exit if there are symbols that don't appear in
@@ -1214,13 +1214,18 @@ class Lambda(Expr):
 
     def __new__(cls, variables, expr):
         try:
+            for v in variables if is_sequence(variables) else [variables]:
+                assert v.is_Symbol
+        except (AssertionError, AttributeError):
+            raise ValueError('variable is not a Symbol: %s' % v)
+        try:
             variables = Tuple(*variables)
         except TypeError:
             variables = Tuple(variables)
         if len(variables) == 1 and variables[0] == expr:
             return S.IdentityFunction
 
-        obj = Expr.__new__(cls, Tuple(*variables), expr)
+        obj = Expr.__new__(cls, Tuple(*variables), S(expr))
         return obj
 
     @property

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1220,11 +1220,7 @@ class Lambda(Expr):
         if len(variables) == 1 and variables[0] == expr:
             return S.IdentityFunction
 
-        #use dummy variables internally, just to be sure
-        new_variables = [C.Dummy(arg.name) for arg in variables]
-        expr = sympify(expr).xreplace(dict(zip(variables, new_variables)))
-
-        obj = Expr.__new__(cls, Tuple(*new_variables), expr)
+        obj = Expr.__new__(cls, Tuple(*variables), expr)
         return obj
 
     @property

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1214,7 +1214,7 @@ class Lambda(Expr):
 
     def __new__(cls, variables, expr):
         try:
-            for v in variables if is_sequence(variables) else [variables]:
+            for v in variables if iterable(variables) else [variables]:
                 assert v.is_Symbol
         except (AssertionError, AttributeError):
             raise ValueError('variable is not a Symbol: %s' % v)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -119,6 +119,8 @@ def test_Lambda():
 
     assert Lambda(x, 2*x) + Lambda(y, 2*y) == 2*Lambda(x, 2*x)
     assert Lambda(x, 2*x) not in [ Lambda(x, x) ]
+    raises(ValueError, lambda: Lambda(1, x))
+    assert Lambda(x, 1)(1) is S.One
 
 
 def test_IdentityFunction():

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -138,15 +138,16 @@ def test_Lambda_arguments():
 
 
 def test_Lambda_equality():
-    assert Lambda(x, 2*x) != Lambda((x, y), 2*x)
-    assert (Lambda(x, 2*x) == Lambda((x, y), 2*x)) is False
+    assert Lambda(x, 2*x) == Lambda(y, 2*y)
+    # although variables are casts as Dummies, the expressions
+    # should still compare equal
     assert Lambda((x, y), 2*x) == Lambda((x, y), 2*x)
-    assert (Lambda((x, y), 2*x) != Lambda((x, y), 2*x)) is False
+    assert Lambda(x, 2*x) != Lambda((x, y), 2*x)
     assert Lambda(x, 2*x) != 2*x
-    assert (Lambda(x, 2*x) == 2*x) is False
 
 
 def test_Subs():
+    assert Subs(x, x, 0) == Subs(y, y, 0)
     assert Subs(x, x, 0).subs(x, 1) == Subs(x, x, 1)
     assert Subs(y, x, 0).subs(y, 1) == Subs(1, x, 0)
     assert Subs(f(x), x, 0).doit() == f(0)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -214,6 +214,11 @@ class Integral(Expr):
         """
         return [l[0] for l in self.limits]
 
+    def _hashable_content(self):
+        r = self.canonical_variables
+        return (self.function.xreplace(r),
+            ) + tuple([l.xreplace(r) for l in self.limits])
+
     @property
     def free_symbols(self):
         """

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -152,27 +152,6 @@ def _as_dummy(expr_with_limits):
     return self.func(f, *limits)
 
 
-def _hashable_content(expr_with_limits):
-    """Return content that will allows this objext to compare with
-    another object as equal if the only difference is the bound variables.
-    """
-    # convert bound symbols to Dummy so we can replace only them
-    # in the expression and limits
-    self = expr_with_limits
-    dself = self.as_dummy()
-    r = dself.canonical_variables
-    limits = []
-    for l in dself.limits:
-        if len(l) == 1:
-            # treat special as long as printing is special for this
-            # otherwise the 1 or 2 arg forms would collapse to the
-            # same result
-            limits.append(l)
-        else:
-            limits.append(tuple(l.xreplace(r)))
-    return (dself.function.xreplace(r),) + tuple(limits)
-
-
 def _eval_subs(expr_with_limits, old, new):
         """
         Substitute old with new in the function and the limits, but don't
@@ -417,9 +396,6 @@ class Integral(Expr):
         transform : Perform mapping on the integration variable
         """
         return [l[0] for l in self.limits]
-
-    def _hashable_content(self):
-        return _hashable_content(self)
 
     @property
     def free_symbols(self):

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -78,7 +78,7 @@ def test_ccode_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert ccode(g(A[i]), assign_to=A[i]) == (
         "for (int i=0; i<n; i++){\n"
-        "   A[i] = (1 + A[i])*(2 + A[i])*A[i];\n"
+        "   A[i] = A[i]*(1 + A[i])*(2 + A[i]);\n"
         "}"
     )
 

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -144,7 +144,7 @@ def test_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert fcode(g(A[i]), assign_to=A[i]) == (
         "      do i = 1, n\n"
-        "         A(i) = (1 + A(i))*(2 + A(i))*A(i)\n"
+        "         A(i) = A(i)*(1 + A(i))*(2 + A(i))\n"
         "      end do"
     )
 

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -72,7 +72,7 @@ def test_jscode_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert jscode(g(A[i]), assign_to=A[i]) == (
         "for (var i=0; i<n; i++){\n"
-        "   A[i] = (1 + A[i])*(2 + A[i])*A[i];\n"
+        "   A[i] = A[i]*(1 + A[i])*(2 + A[i]);\n"
         "}"
     )
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -480,7 +480,7 @@ def test_RootSum():
     assert str(
         RootSum(f, Lambda(z, z), auto=False)) == "RootSum(x**5 + 2*x - 1)"
     assert str(RootSum(f, Lambda(
-        z, z**2), auto=False)) == "RootSum(x**5 + 2*x - 1, Lambda(_z, _z**2))"
+        z, z**2), auto=False)) == "RootSum(x**5 + 2*x - 1, Lambda(z, z**2))"
 
 
 def test_GroebnerBasis():

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -957,20 +957,13 @@ def classify_ode(eq, func=None, dict=False, **kwargs):
                 matching_hints["nth_linear_euler_eq_homogeneous"] = r
 
     # Order keys based on allhints.
-    retlist = []
-    for i in allhints:
-        if i in matching_hints:
-            retlist.append(i)
+    retlist = [i for i in allhints if i in matching_hints]
 
     if dict:
         # Dictionaries are ordered arbitrarily, so make note of which
         # hint would come first for dsolve().  Use an ordered dict in Py 3.
-        matching_hints["default"] = None
+        matching_hints["default"] = retlist[0] if retlist else None
         matching_hints["ordered_hints"] = tuple(retlist)
-        for i in allhints:
-            if i in matching_hints:
-                matching_hints["default"] = i
-                break
         return matching_hints
     else:
         return tuple(retlist)
@@ -1806,19 +1799,13 @@ def _handle_Integral(expr, func, order, hint):
     For most hints, this simply runs expr.doit()
 
     """
+    global y
     x = func.args[0]
     f = func.func
     if hint == "1st_exact":
-        global y
         sol = (expr.doit()).subs(y, f(x))
         del y
     elif hint == "1st_exact_Integral":
-        # FIXME: We still need to back substitute y
-        # sol = expr.subs(y, f(x))
-        # For now, we are going to have to return an expression with f(x)
-        # replaced with y when Integrals are done with respect to f(x).
-        # For example, Integral(cos(f(x)), _y).  If there were a way
-        # to do inert substitution, that could maybe be used here instead.
         sol = expr.subs(y, f(x))
         del y
     elif hint == "nth_linear_constant_coeff_homogeneous":

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -618,7 +618,7 @@ def density(expr, condition=None, **kwargs):
     >>> density(2*D)
     {2: 1/6, 4: 1/6, 6: 1/6, 8: 1/6, 10: 1/6, 12: 1/6}
     >>> density(X)
-    Lambda(_x, sqrt(2)*exp(-_x**2/2)/(2*sqrt(pi)))
+    Lambda(x, sqrt(2)*exp(-x**2/2)/(2*sqrt(pi)))
     """
     return Density(expr, condition).doit(**kwargs)
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -1099,7 +1099,7 @@ def test_inline_function():
         'REAL*8, intent(out), dimension(1:m) :: y\n'
         'INTEGER*4 :: i\n'
         'do i = 1, m\n'
-        '   y(i) = (1 + x(i))*x(i)\n'
+        '   y(i) = x(i)*(1 + x(i))\n'
         'end do\n'
         'end subroutine\n'
     )


### PR DESCRIPTION
define hashable content for Subs, Lambda, Integral, Sum and Product

The new definition allows expressions that would give identical
results (indepenedent of bound variables) to compare the same.

Issues [2440](https://code.google.com/p/sympy/issues/detail?can=2&q=2440) and  [3775](https://code.google.com/p/sympy/issues/detail?can=2&q=3775)

Lambda also now works with Symbol, not Dummy  [issue 2442](https://code.google.com/p/sympy/issues/detail?can=2&q=2442)
