### PR TITLE
Raise NotImplementedError for .evalf() on indefinite integrals.

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -947,6 +947,10 @@ def do_integral(expr, prec, options):
 
 
 def evalf_integral(expr, prec, options):
+    limits = expr.limits
+    if len(limits) != 1 or not isinstance(limits[0], Tuple) or \
+            len(limits[0]) != 3:
+        raise NotImplementedError
     workprec = prec
     i = 0
     maxprec = options.get('maxprec', INF)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -948,8 +948,7 @@ def do_integral(expr, prec, options):
 
 def evalf_integral(expr, prec, options):
     limits = expr.limits
-    if len(limits) != 1 or not isinstance(limits[0], Tuple) or \
-            len(limits[0]) != 3:
+    if len(limits) != 1 or len(limits[0]) != 3:
         raise NotImplementedError
     workprec = prec
     i = 0
@@ -1070,8 +1069,7 @@ def hypsum(expr, n, start, prec):
 def evalf_sum(expr, prec, options):
     func = expr.function
     limits = expr.limits
-    if len(limits) != 1 or not isinstance(limits[0], Tuple) or \
-            len(limits[0]) != 3:
+    if len(limits) != 1 or len(limits[0]) != 3:
         raise NotImplementedError
     prec2 = prec + 10
     try:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -385,6 +385,9 @@ def test_evalf_integrals():
         Integral(sin(x)/x**2, (x, 1, oo)), quad='osc') == '0.504067061906928'
     assert NS(Integral(
         cos(pi*x + 1)/x, (x, -oo, -1)), quad='osc') == '0.276374705640365'
+    # indefinite integrals aren't evaluated
+    assert NS(Integral(x, x)) == 'Integral(x, x)'
+    assert NS(Integral(x, (x, y))) == 'Integral(x, (x, y))'
 
 
 @XFAIL


### PR DESCRIPTION
Fixes issue 3808: Calling .evalf() on indefinite integral throws an exception
http://code.google.com/p/sympy/issues/detail?id=3808
