### PR TITLE
Fix user_functions argument bug in CCodePrinter

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -40,8 +40,8 @@ class CCodePrinter(CodePrinter):
         self.known_functions = dict(known_functions)
         userfuncs = settings.get('user_functions', {})
         for k, v in userfuncs.items():
-            if not isinstance(v, tuple):
-                userfuncs[k] = (lambda *x: True, v)
+            if not isinstance(v, list):
+                userfuncs[k] = [(lambda *x: True, v)]
         self.known_functions.update(userfuncs)
 
     def _rate_index_position(self, p):
@@ -240,7 +240,7 @@ def ccode(expr, assign_to=None, **settings):
             the precision for numbers such as pi [default=15]
         user_functions : optional
             A dictionary where keys are FunctionClass instances and values
-            are there string representations.  Alternatively, the
+            are their string representations.  Alternatively, the
             dictionary value can be a list of tuples i.e. [(argument_test,
             cfunction_string)].  See below for examples.
         human : optional
@@ -252,12 +252,19 @@ def ccode(expr, assign_to=None, **settings):
         Examples
         ========
 
-        >>> from sympy import ccode, symbols, Rational, sin
+        >>> from sympy import ccode, symbols, Rational, sin, ceiling, Abs
         >>> x, tau = symbols(["x", "tau"])
         >>> ccode((2*tau)**Rational(7,2))
         '8*sqrt(2)*pow(tau, 7.0L/2.0L)'
         >>> ccode(sin(x), assign_to="s")
         's = sin(x);'
+        >>> custom_functions = {
+        ...   "ceiling": "CEIL",
+        ...   "Abs": [(lambda x: not x.is_integer, "fabs"),
+        ...           (lambda x: x.is_integer, "ABS")]
+        ... }
+        >>> ccode(Abs(x) + ceiling(x), user_functions=custom_functions)
+        'fabs(x) + CEIL(x)'
 
 
     """

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -88,6 +88,18 @@ def test_ccode_exceptions():
     assert ccode(Abs(x)) == "fabs(x)"
 
 
+def test_ccode_user_functions():
+    x = symbols('x', integer=False)
+    n = symbols('n', integer=True)
+    custom_functions = {
+        "ceiling": "ceil",
+        "Abs": [(lambda x: not x.is_integer, "fabs"), (lambda x: x.is_integer, "abs")],
+    }
+    assert ccode(ceiling(x), user_functions=custom_functions) == "ceil(x)"
+    assert ccode(Abs(x), user_functions=custom_functions) == "fabs(x)"
+    assert ccode(Abs(n), user_functions=custom_functions) == "abs(n)"
+
+
 def test_ccode_boolean():
     assert ccode(x & y) == "x && y"
     assert ccode(x | y) == "x || y"


### PR DESCRIPTION
According to `sympy.printing.ccode.ccode` function documentation:

```
   [...]
    user_functions : optional
        A dictionary where keys are FunctionClass instances and values
        are there string representations.  Alternatively, the
        dictionary value can be a list of tuples i.e. [(argument_test,
        cfunction_string)].  See below for examples.
   [...]
```

the `user_functions` argument defined as

``` Python
user_functions = {
        "ceiling": "ceil",
        "Abs": [(lambda x: not x.is_integer, "fabs"), (lambda x: x.is_integer, "abs")],
    }
```

must work.
However, it doesn't work due to bug in `sympy.printing.ccode.CCodePrinter` class.

I fixed the bug and added the test `test_ccode_user_functions()` to this feature.
