### PR TITLE
The Translation of "Chinese" Need to Be Changed

### DIFF
--- a/doc/src/tutorial/tutorial.en.rst
+++ b/doc/src/tutorial/tutorial.en.rst
@@ -1060,4 +1060,4 @@ users contributed, and feel free to edit it.
         - `Polski <tutorial.pl.html>`_
         - `Русский <tutorial.ru.html>`_
         - `Српски <tutorial.sr.html>`_
-        - `中文 <tutorial.zh.html>`_
+        - `简体中文 <tutorial.zh.html>`_


### PR DESCRIPTION
I made a little mistake when I translated the SymPy tutorial in Chinese. Actually, I translated in Simplified Chinese, so the word "中文", which means "Chinese" at the bottom of tutorial.en.rst should be changed to "简体中文", indicating "Simplified Chinese".

Sorry about my imprecise translation.
