### PR TITLE
3814: Store name of MatrixSymbol as Symbol, not string.

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -303,7 +303,7 @@ class MatrixSymbol(MatrixExpr):
     is_commutative = False
 
     def __new__(cls, name, n, m):
-        n, m = sympify(n), sympify(m)
+        name, n, m = sympify(name), sympify(n), sympify(m)
         obj = Basic.__new__(cls, name, n, m)
         return obj
 

--- a/sympy/matrices/expressions/tests/test_indexing.py
+++ b/sympy/matrices/expressions/tests/test_indexing.py
@@ -18,7 +18,7 @@ y = MatrixSymbol('x', 2, 1)
 
 def test_symbolic_indexing():
     x12 = X[1, 2]
-    assert all(s in str(x12) for s in ['1', '2', X.name])
+    assert all(s in str(x12) for s in ['1', '2', str(X.name)])
     # We don't care about the exact form of this.  We do want to make sure
     # that all of these features are present
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -648,8 +648,10 @@ class StrPrinter(Printer):
 
     def _print_Symbol(self, expr):
         return expr.name
-    _print_MatrixSymbol = _print_Symbol
     _print_RandomSymbol = _print_Symbol
+
+    def _print_MatrixSymbol(self, expr):
+        return self._print(expr.name)
 
     def _print_Identity(self, expr):
         return "I"


### PR DESCRIPTION
MatrixSymbol was storing its name as a string, which violates the rule that all args be Basic. Store it as a Symbol instead.
