### PR TITLE
MatrixElements and Exprs

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -864,7 +864,10 @@ def gcd_terms(terms, isprimitive=False, clear=True, fraction=True):
         if not isinstance(a, Expr):
             if isinstance(a, Basic):
                 return a.func(*[handle(i) for i in a.args])
-            return type(a)([handle(i) for i in a])
+            elif isinstance(a, (tuple, list, set, frozenset)):
+                return type(a)([handle(i) for i in a])
+            else:
+                return a
         return gcd_terms(a, isprimitive, clear, fraction)
 
     if isinstance(terms, Dict):
@@ -969,7 +972,9 @@ def factor_terms(expr, radical=False, clear=False, fraction=False, sign=True):
         p = Add._from_args(list_args)  # gcd_terms will fix up ordering
     elif p.args:
         p = p.func(
-            *[factor_terms(a, radical, clear, fraction) for a in p.args])
+            *[factor_terms(a, radical, clear, fraction)
+                if isinstance(a, Expr) else a
+                for a in p.args])
     p = gcd_terms(p,
         isprimitive=True,
         clear=clear,

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2108,6 +2108,8 @@ def count_ops(expr, visual=False):
         ADD = C.Symbol('ADD')
         while args:
             a = args.pop()
+            if not isinstance(a, Expr):  # Don't count below non-Exprs
+                continue
             if a.is_Rational:
                 #-1/3 = NEG + DIV
                 if a is not S.One:

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -303,6 +303,8 @@ class MatrixSymbol(MatrixExpr):
     is_commutative = False
 
     def __new__(cls, name, n, m):
+        if not isinstance(name, str):
+            raise TypeError("Name of MatrixSymbol must be String")
         n, m = sympify(n), sympify(m)
         obj = Basic.__new__(cls, name, n, m)
         return obj

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -285,6 +285,9 @@ class MatrixElement(Expr):
     i = property(lambda self: self.args[1])
     j = property(lambda self: self.args[2])
 
+    @property
+    def free_symbols(self):
+        return set((self.i, self.j))
 
 class MatrixSymbol(MatrixExpr):
     """Symbolic representation of a Matrix object

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -192,3 +192,6 @@ def test_indexing():
     A[1, 2]
     A[l, k]
     A[l+1, k+1]
+
+def test_3814_MatrixElement_as_Expr():
+    str(MatrixSymbol('m', 1, 1) > 0)  # make sure this doesn't raise an error

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -195,3 +195,11 @@ def test_indexing():
 
 def test_3814_MatrixElement_as_Expr():
     str(MatrixSymbol('m', 1, 1) > 0)  # make sure this doesn't raise an error
+
+def test_matrix_element():
+    from sympy import log, expand, cancel, simplify, sympify, factor
+    e = log(MatrixSymbol('m', 1, 1)[0, 0]**2 + 1) > 0
+
+    expr_fns = [expand, cancel, simplify, sympify, factor]
+    for fn in expr_fns:
+        fn(e)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2535,7 +2535,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
 
     expr = sympify(expr)
 
-    if not isinstance(expr, Basic) or expr.is_Atom or expr in (
+    if not isinstance(expr, Expr) or expr.is_Atom or expr in (
             exp_polar(0), exp_polar(1)):
         return expr
 


### PR DESCRIPTION
Alternative to https://github.com/sympy/sympy/pull/2093

Fixes https://code.google.com/p/sympy/issues/detail?id=3814

MatrixExprs make different assumptions about their trees than Exprs.  They are both more and less strict in different ways. 

MatrixElement is an Expr that contains a MatrixSymbol, injecting one type of tree inside the other.  This raises some issues which I've dealt with here.  
