### PR TITLE
3783: sorting lists of edges in prufer.

### DIFF
--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -31,7 +31,6 @@ class Prufer(Basic):
         """Returns Prufer sequence for the Prufer object.
 
         This sequence is found by removing the highest numbered vertex,
-
         recording the node it was attached to, and continuuing until only
         two verices remain. The Prufer sequence is the list of recorded nodes.
 

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -250,12 +250,12 @@ class Prufer(Basic):
 
         >>> from sympy.combinatorics.prufer import Prufer
         >>> Prufer.edges([1, 2, 3], [2, 4, 5]) # a T
-        ([[0, 1], [3, 4], [1, 2], [1, 3]], 5)
+        ([[0, 1], [1, 2], [1, 3], [3, 4]], 5)
 
         Duplicate edges are removed:
 
         >>> Prufer.edges([0, 1, 2, 3], [1, 4, 5], [1, 4, 6]) # a K
-        ([[0, 1], [1, 2], [4, 6], [4, 5], [1, 4], [2, 3]], 7)
+        ([[0, 1], [1, 2], [1, 4], [2, 3], [4, 5], [4, 6]], 7)
 
         """
         e = set()

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -31,6 +31,7 @@ class Prufer(Basic):
         """Returns Prufer sequence for the Prufer object.
 
         This sequence is found by removing the highest numbered vertex,
+
         recording the node it was attached to, and continuuing until only
         two verices remain. The Prufer sequence is the list of recorded nodes.
 
@@ -268,8 +269,7 @@ class Prufer(Basic):
         rv = []
         got = set()
         nmin = nmax = None
-        while e:
-            ei = e.pop()
+        for ei in e:
             for i in ei:
                 got.add(i)
             nmin = min(ei[0], nmin) if nmin is not None else ei[0]
@@ -287,7 +287,7 @@ class Prufer(Basic):
             for i, ei in enumerate(rv):
                 rv[i] = [n - nmin for n in ei]
             nmax -= nmin
-        return rv, nmax + 1
+        return sorted(rv), nmax + 1
 
     def prufer_rank(self):
         """Computes the rank of a Prufer sequence.
@@ -429,4 +429,4 @@ class Prufer(Basic):
         prufer_rank, rank, next, size
 
         """
-        return Prufer.unrank(self.rank - delta, self.nodes)
+        return Prufer.unrank(self.rank -delta, self.nodes)

--- a/sympy/combinatorics/tests/test_prufer.py
+++ b/sympy/combinatorics/tests/test_prufer.py
@@ -19,7 +19,7 @@ def test_prufer():
     assert a.prufer_repr == [4, 1, 4, 0]
 
     assert Prufer.edges([0, 1, 2, 3], [1, 4, 5], [1, 4, 6]) == \
-        ([[0, 1], [1, 2], [4, 6], [4, 5], [1, 4], [2, 3]], 7)
+        ([[0, 1], [1, 2], [1, 4], [2, 3], [4, 5], [4, 6]], 7)
     assert Prufer([0]*4).size == Prufer([6]*4).size == 1296
 
     # accept iterables but convert to list of lists


### PR DESCRIPTION
Fixed some unpythonic syntax, and returning a sorted list of edges.  This deals with issue 3783.
