### PR TITLE
issue 3434: warnings from matplotlib when starting isympy

### DIFF
--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -124,6 +124,11 @@ def import_module(module, min_module_version=None, min_python_version=None,
 
     try:
         mod = __import__(module, **__import__kwargs)
+
+        ## there's something funny about imports with matplotlib and py3k. doing
+        ##    from matplotlib import collections
+        ## gives python's stdlib collections module. explicitly re-importing
+        ## the module fixes this.
         from_list = __import__kwargs.get('fromlist', tuple())
         for submod in from_list:
             if submod == 'collections' and mod.__name__ == 'matplotlib':

--- a/sympy/external/importtools.py
+++ b/sympy/external/importtools.py
@@ -124,6 +124,10 @@ def import_module(module, min_module_version=None, min_python_version=None,
 
     try:
         mod = __import__(module, **__import__kwargs)
+        from_list = __import__kwargs.get('fromlist', tuple())
+        for submod in from_list:
+            if submod == 'collections' and mod.__name__ == 'matplotlib':
+                __import__(module + '.' + submod)
     except ImportError:
         if warn_not_installed:
             warnings.warn("%s module is not installed" % module, UserWarning)

--- a/sympy/external/tests/test_importtools.py
+++ b/sympy/external/tests/test_importtools.py
@@ -1,0 +1,32 @@
+from sympy.external import import_module
+
+# fixes issue that arose in addressing issue 3434
+def test_no_stdlib_collections():
+    '''
+    make sure we get the right collections when it is not part of a
+    larger list
+    '''
+    import collections
+    matplotlib = import_module('matplotlib',
+        __import__kwargs={'fromlist': ['cm', 'collections']},
+        min_module_version='1.1.0', catch=(RuntimeError,))
+    assert collections != matplotlib.collections
+
+def test_no_stdlib_collections2():
+    '''
+    make sure we get the right collections when it is not part of a
+    larger list
+    '''
+    import collections
+    matplotlib = import_module('matplotlib',
+        __import__kwargs={'fromlist': ['collections']},
+        min_module_version='1.1.0', catch=(RuntimeError,))
+    assert collections != matplotlib.collections
+
+def test_no_stdlib_collections3():
+    '''make sure we get the right collections with no catch'''
+    import collections
+    matplotlib = import_module('matplotlib',
+        __import__kwargs={'fromlist': ['cm', 'collections']},
+        min_module_version='1.1.0')
+    assert collections != matplotlib.collections

--- a/sympy/external/tests/test_importtools.py
+++ b/sympy/external/tests/test_importtools.py
@@ -10,7 +10,8 @@ def test_no_stdlib_collections():
     matplotlib = import_module('matplotlib',
         __import__kwargs={'fromlist': ['cm', 'collections']},
         min_module_version='1.1.0', catch=(RuntimeError,))
-    assert collections != matplotlib.collections
+    if matplotlib:
+        assert collections != matplotlib.collections
 
 def test_no_stdlib_collections2():
     '''
@@ -21,7 +22,8 @@ def test_no_stdlib_collections2():
     matplotlib = import_module('matplotlib',
         __import__kwargs={'fromlist': ['collections']},
         min_module_version='1.1.0', catch=(RuntimeError,))
-    assert collections != matplotlib.collections
+    if matplotlib:
+        assert collections != matplotlib.collections
 
 def test_no_stdlib_collections3():
     '''make sure we get the right collections with no catch'''
@@ -29,4 +31,5 @@ def test_no_stdlib_collections3():
     matplotlib = import_module('matplotlib',
         __import__kwargs={'fromlist': ['cm', 'collections']},
         min_module_version='1.1.0')
-    assert collections != matplotlib.collections
+    if matplotlib:
+        assert collections != matplotlib.collections

--- a/sympy/plotting/intervalmath/interval_arithmetic.py
+++ b/sympy/plotting/intervalmath/interval_arithmetic.py
@@ -399,6 +399,9 @@ class interval(object):
         else:
             return NotImplemented
 
+    def __hash__(self):
+        return hash((self.is_valid, self.start, self.end))
+
 
 def _pow_float(inter, power):
     """Evaluates an interval raised to a floating point."""

--- a/sympy/plotting/intervalmath/tests/test_intervalmath.py
+++ b/sympy/plotting/intervalmath/tests/test_intervalmath.py
@@ -192,3 +192,10 @@ def test_interval_div():
     assert a == (True, True)
     a = interval(-5, 5, is_valid=False) / 2
     assert a.is_valid is False
+
+def test_hashable():
+    assert hash(interval(1, 1)) is not None
+    assert hash(interval(1, 1, is_valid=True)) is not None
+    assert hash(interval(-4, -0.5)) is not None
+    assert hash(interval(-2, -0.5)) is not None
+    assert hash(interval(0.25, 8.0)) is not None

--- a/sympy/plotting/intervalmath/tests/test_intervalmath.py
+++ b/sympy/plotting/intervalmath/tests/test_intervalmath.py
@@ -194,8 +194,16 @@ def test_interval_div():
     assert a.is_valid is False
 
 def test_hashable():
-    assert hash(interval(1, 1)) is not None
-    assert hash(interval(1, 1, is_valid=True)) is not None
-    assert hash(interval(-4, -0.5)) is not None
-    assert hash(interval(-2, -0.5)) is not None
-    assert hash(interval(0.25, 8.0)) is not None
+    '''
+    test that interval objects are hashable.
+    this is required in order to be able to put them into the cache, which
+    appears to be necessary for plotting in py3k. For details, see:
+
+    https://github.com/sympy/sympy/pull/2101
+    https://code.google.com/p/sympy/issues/detail?id=3434
+    '''
+    hash(interval(1, 1))
+    hash(interval(1, 1, is_valid=True))
+    hash(interval(-4, -0.5))
+    hash(interval(-2, -0.5))
+    hash(interval(0.25, 8.0))

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -39,10 +39,9 @@ np = import_module('numpy')
 # When changing the minimum module version for matplotlib, please change
 # the same in the `SymPyDocTestFinder`` in `sympy/utilities/runtests.py`
 matplotlib = import_module('matplotlib',
-    __import__kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
+    __import__kwargs={'fromlist': ['cm', 'collections']},
     min_module_version='1.1.0', catch=(RuntimeError,))
 if matplotlib:
-    plt = matplotlib.pyplot
     cm = matplotlib.cm
     LineCollection = matplotlib.collections.LineCollection
     mpl_toolkits = import_module('mpl_toolkits',
@@ -813,10 +812,14 @@ class MatplotlibBackend(BaseBackend):
     def __init__(self, parent):
         super(MatplotlibBackend, self).__init__(parent)
         are_3D = [s.is_3D for s in self.parent._series]
+        matplotlib = import_module('matplotlib',
+            __import__kwargs={'fromlist': ['pyplot', 'cm', 'collections']},
+            min_module_version='1.1.0', catch=(RuntimeError,))
+        self.plt = matplotlib.pyplot
         if any(are_3D) and not all(are_3D):
             raise ValueError('The matplotlib backend can not mix 2D and 3D.')
         elif not any(are_3D):
-            self.fig = plt.figure()
+            self.fig = self.plt.figure()
             self.ax = self.fig.add_subplot(111)
             self.ax.spines['left'].set_position('zero')
             self.ax.spines['right'].set_color('none')
@@ -827,7 +830,7 @@ class MatplotlibBackend(BaseBackend):
             self.ax.xaxis.set_ticks_position('bottom')
             self.ax.yaxis.set_ticks_position('left')
         elif all(are_3D):
-            self.fig = plt.figure()
+            self.fig = self.plt.figure()
             self.ax = self.fig.add_subplot(111, projection='3d')
 
     def process_series(self):
@@ -949,14 +952,14 @@ class MatplotlibBackend(BaseBackend):
         # you can uncomment the next line and remove the pyplot.show() call
         #self.fig.show()
         if _show:
-            plt.show()
+            self.plt.show()
 
     def save(self, path):
         self.process_series()
         self.fig.savefig(path)
 
     def close(self):
-        plt.close(self.fig)
+        self.plt.close(self.fig)
 
 
 class TextBackend(BaseBackend):

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -31,8 +31,6 @@ from sympy.utilities.decorator import doctest_depends_on
 import warnings
 from experimental_lambdify import (vectorized_lambdify, lambdify)
 
-#TODO probably all of the imports after this line can be put inside function to
-# speed up the `from sympy import *` command.
 np = import_module('numpy')
 
 # Backend specific imports - matplotlib
@@ -54,8 +52,7 @@ if matplotlib:
 from sympy.plotting.textplot import textplot
 
 # Global variable
-# Set to False when running tests / doctests so that the plots don't
-# show.
+# Set to False when running tests / doctests so that the plots don't show.
 _show = True
 
 


### PR DESCRIPTION
the issue was that matplotlib.pyplot was being imported before
pylab was initialized. initializing pylab after the import of
matplotlib.pyplot caused a warning to be printed to the console.

fixes issue 3434. on my box, this also reduced the import time of sympy from 2.0s to 0.3s. If other people encounter a similar speed-up, you could consider issue 3427 fixed as well.

refs:
https://code.google.com/p/sympy/issues/detail?id=3434
https://code.google.com/p/sympy/issues/detail?id=3427
