### PR TITLE
Allow to specify the generators when building monomial_key.

### DIFF
--- a/sympy/polys/tests/test_monomialtools.py
+++ b/sympy/polys/tests/test_monomialtools.py
@@ -80,6 +80,9 @@ def test_grlex_order():
     assert grlex((0, 2, 3)) < grlex((1, 2, 2))
     assert grlex((1, 1, 3)) < grlex((1, 2, 2))
 
+    assert grlex((0, 1, 1)) > grlex((0, 0, 2))
+    assert grlex((0, 3, 1)) < grlex((2, 2, 1))
+
     assert grlex.is_global is True
 
 


### PR DESCRIPTION
This allows to obtain a sort key that can be directly applied to sort `Expr` instances; it casts `Expr` into `Poly` with the given generators and then applies the chosen ordering.
