### PR TITLE
watch for negated base pairs

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2599,6 +2599,9 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             else:
                 c_powers[coeff] = S.One
 
+        # convert to plain dictionary
+        c_powers = dict(c_powers)
+
         # check for base and inverted base pairs
         be = c_powers.items()
         skip = set()  # skip if we already saw them
@@ -2616,6 +2619,18 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                         skip.add(binv)
                         e = c_powers.pop(binv)
                         c_powers[b] -= e
+
+        # check for base and negated base pairs
+        be = c_powers.items()
+        _n = S.NegativeOne
+        for i, (b, e) in enumerate(be):
+            if ((-b).is_Symbol or b.is_Add) and -b in c_powers:
+                if (b.is_positive in (0, 1) or e.is_integer):
+                    c_powers[-b] += c_powers.pop(b)
+                    if _n in c_powers:
+                        c_powers[_n] += e
+                    else:
+                        c_powers[_n] = e
 
         # filter c_powers and convert to a list
         c_powers = [(b, e) for b, e in c_powers.iteritems() if e]

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -666,6 +666,17 @@ def test_issue_3268():
     assert powsimp(z) != 0
 
 
+def test_powsimp_negated_base():
+    assert powsimp((-x + y)/sqrt(x - y)) == -sqrt(x - y)
+    assert powsimp((-x + y)*(-z + y)/sqrt(x - y)/sqrt(z - y)) == sqrt(x - y)*sqrt(z - y)
+    p = symbols('p', positive=True)
+    assert powsimp((-p)**a/p**a) == (-1)**a
+    n = symbols('n', negative=True)
+    assert powsimp((-n)**a/n**a) == (-1)**a
+    # if x is 0 then the lhs is 0**a*oo**a which is not (-1)**a
+    assert powsimp((-x)**a/x**a) != (-1)**a
+
+
 def test_issue_3341():
     assert powsimp(16*2**a*8**b) == 2**(a + 3*b + 4)
 


### PR DESCRIPTION
This addresses the current inability of SymPy to reduce `(x - y)/sqrt(y - x)` to `-sqrt(y - x)`, an expression that arose from the following manipulations (which now work):

```
(-x + y)*sqrt(1/(x - y))
>>> refine(_,Q.positive(x-y))
(-x + y)/sqrt(x - y)
>>> simplify(_)
-sqrt(x - y)
>>> refine((x - y)*sqrt(1/(y - x)), Q.positive(y-x))
(x - y)/sqrt(-x + y)
>>> simplify(_)
-sqrt(-x + y)
```

In theory this problem should be handled by signsimp but
sqrt(-(x - z)) signsimp only looks for things that can have a negative
sign exptracted so (x - z)/sqrt(z - x) becomes (x - z)/sqrt(-(x - z))
and that doesn't simplify unless we look for the negated base in powsimp. (If signsimp worked by replacing `x - z` with `-(z - x)` then it would work.)

Only a minimal attempt is made to find a base and its negated pair. If one desires
other things like x + y_(z - x) to be recognized as the negated expression
of -x + y_(x - z) then sign simplification should be done first.

> > > (x + y_(z - x))==(-(-x + y_(x - z)))
> > > False
> > > signsimp((x + y_(z - x)))==signsimp((-(-x + y_(x - z))))
> > > True

Number that are negated are handled elsewhere so these are specifically
excluded from consideration by the added code.
