### PR TITLE
heurisch_wrapper: Leave the original poles alone.

### DIFF
--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -134,6 +134,16 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     if not slns:
         return res
     slns = list(uniq(slns))
+    # Remove the solutions corresponding to poles in the original expression.
+    slns0 = []
+    for d in denoms(f):
+        try:
+            slns0 += solve(d, dict=True, exclude=(x,))
+        except NotImplementedError:
+            pass
+    slns = [s for s in slns if s not in slns0]
+    if not slns:
+        return res
     if len(slns) > 1:
         eqs = []
         for sub_dict in slns:

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -179,6 +179,20 @@ def test_heurisch_function():
     assert heurisch(df / f(x), x) == log(f(x))
 
 
+def test_heurisch_wrapper():
+    f = 1/(y + x)
+    assert heurisch_wrapper(f, x) == log(x + y)
+    f = 1/(y - x)
+    assert heurisch_wrapper(f, x) == -log(x - y)
+    f = 1/((y - x)*(y + x))
+    assert heurisch_wrapper(f, x) == \
+        Piecewise((1/x, Eq(y, 0)), (log(x + y)/2/y - log(x - y)/2/y, True))
+    # issue 3827
+    f = sqrt(x**2/((y - x)*(y + x)))
+    assert heurisch_wrapper(f, x) == x*sqrt(x**2)*sqrt(1/(-x**2 + y**2)) \
+        - y**2*sqrt(x**2)*sqrt(1/(-x**2 + y**2))/x
+
+
 def test_issue510():
     assert heurisch(1/(x * (1 + log(x)**2)), x) == I*log(log(x) + I)/2 - \
         I*log(log(x) - I)/2


### PR DESCRIPTION
When integrating with heurisch_wrapper, we identify poles in the denominator and reevaluate the integral at those poles. This is pointless if the same poles where already in the integrand to start with, so we now leave these poles alone.

Fixes issue 3827: `integrate(sqrt(x**2/((y - x)*(y + x))), x)` showing some infinities
https://code.google.com/p/sympy/issues/detail?id=3827
