### PR TITLE
Fix init_session(ipython=False) for non-unicode terminals.

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -240,11 +240,12 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         try:
             import IPython
             from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
+            from code import InteractiveConsole
         except ImportError:
             pass
         else:
             # If in qtconsole or notebook
-            if not isinstance(ip, TerminalInteractiveShell) \
+            if not isinstance(ip, (InteractiveConsole, TerminalInteractiveShell)) \
                     and 'ipython-console' not in ''.join(sys.argv):
                 if use_unicode is None:
                     use_unicode = True

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -244,7 +244,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         except ImportError:
             pass
         else:
-            # If in qtconsole or notebook
+            # This will be True if we are in the qtconsole or notebook
             if not isinstance(ip, (InteractiveConsole, TerminalInteractiveShell)) \
                     and 'ipython-console' not in ''.join(sys.argv):
                 if use_unicode is None:


### PR DESCRIPTION
InteractiveConsole is another case were we should not force use_unicode=True. Instead, let's rely on the code that checks sys.stdout.encoding to automatically set this to the correct value.
