### PR TITLE
Partially make undefined Functions picklable (issue 1198)

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -631,7 +631,9 @@ class UndefinedFunction(FunctionClass):
     The (meta)class of undefined functions.
     """
     def __new__(mcl, name):
-        return BasicMeta.__new__(mcl, name, (AppliedUndef,), {})
+        ret = BasicMeta.__new__(mcl, name, (AppliedUndef,), {})
+        ret.__module__ = None
+        return ret
 
 
 class WildFunction(Function, AtomicExpr):


### PR DESCRIPTION
The fix, which is described at issue 1198, now makes it possible to pickle 
functions in an interactive session.  For example

In [1]: import pickle

In [2]: pickle.dumps(f) Out[2]: 'c__main__\nf\np0\n.'

However, it does not work in other situations. For example, in a regular 
Python session, it will not work.  If you create a script with

import pickle from sympy import Function pickle.dumps(Function('f'))

it will not work.

However, this _does_ fix many issues in SymPy Live, including issue 2600, 
which prevented most examples using undefined Functions from working.

Unfortunately, the tests in test_pickle.py seem to be among the instances 
where this doesn't work.  I don't know how to set up a test situation where 
this does fix the problem.

This fix should be considered a temporary one. We really need to rewrite 
Function so that it doesn't create classes on the fly (see issue 1688).
