### PR TITLE
Move all statistics related tests into the statistics module

### DIFF
--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -9,7 +9,6 @@ from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
 from sympy.core import Expr
 from sympy.physics.units import second, joule
 from sympy.polys import Poly, RootOf, RootSum, groebner, ring, field, ZZ, QQ, lex, grlex
-from sympy.statistics.distributions import Normal, Sample, Uniform
 from sympy.geometry import Point, Circle
 
 from sympy.utilities.pytest import raises
@@ -217,11 +216,6 @@ def test_NaN():
 
 def test_NegativeInfinity():
     assert str(-oo) == "-oo"
-
-
-def test_Normal():
-    assert str(Normal(x + y, z)) == "Normal(x + y, z)"
-
 
 def test_Order():
     assert str(O(x)) == "O(x)"
@@ -494,18 +488,6 @@ def test_GroebnerBasis():
     assert str(groebner(F, order='lex')) == \
         "GroebnerBasis([2*x - y**2 - y + 1, y**4 + 2*y**3 - 3*y**2 - 16*y + 7], x, y, domain='ZZ', order='lex')"
 
-
-def test_Sample():
-    assert str(Sample([x, y, 1])) in [
-        "Sample([x, y, 1])",
-        "Sample([y, 1, x])",
-        "Sample([1, x, y])",
-        "Sample([y, x, 1])",
-        "Sample([x, 1, y])",
-        "Sample([1, y, x])",
-    ]
-
-
 def test_set():
     assert sstr(set()) == 'set()'
     assert sstr(frozenset()) == 'frozenset()'
@@ -538,12 +520,6 @@ def test_tuple():
     assert str((x + y, 1 + x)) == sstr((x + y, 1 + x)) == "(x + y, x + 1)"
     assert str((x + y, (
         1 + x, x**2))) == sstr((x + y, (1 + x, x**2))) == "(x + y, (x + 1, x**2))"
-
-
-def test_Uniform():
-    assert str(Uniform(x, y)) == "Uniform(x, y)"
-    assert str(Uniform(x + y, y)) == "Uniform(x + y, y)"
-
 
 def test_Unit():
     assert str(second) == "s"

--- a/sympy/statistics/tests/test_statistics.py
+++ b/sympy/statistics/tests/test_statistics.py
@@ -1,9 +1,11 @@
-from sympy import sqrt, Rational, oo, Symbol, exp, pi
+from sympy import sqrt, Rational, oo, Symbol, exp, pi, symbols
 from sympy.functions import erf
 
 from operator import abs
 
 from sympy.mpmath import mp
+
+from sympy.utilities.tests.test_pickling import check
 
 # Disable sympy.statistics deprecation warning for the tests
 # The warning is in __init__.py, so we only need to disable it for imports
@@ -12,11 +14,12 @@ import warnings
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
 
-from sympy.statistics.distributions import Normal, Uniform
-from sympy.statistics.distributions import PDF
+from sympy.statistics.distributions import (Normal, Uniform, Sample, PDF,
+    ContinuousProbability)
 
 warnings.filterwarnings("default")
 
+x, y, z = symbols('x y z')
 
 def test_normal():
     dps, mp.dps = mp.dps, 20
@@ -111,3 +114,26 @@ def test_PDF():
     exponential = exponential.transform(x, x)
     assert exponential.pdf(x) == 1
     assert exponential.cdf(x) == x - 1
+
+# These last two tests are here instead of test_str.py and test_pickling.py
+# because this module is deprecated.
+
+def test_printing():
+    assert str(Normal(x + y, z)) == "Normal(x + y, z)"
+    assert str(Sample([x, y, 1])) in [
+        "Sample([x, y, 1])",
+        "Sample([y, 1, x])",
+        "Sample([1, x, y])",
+        "Sample([y, x, 1])",
+        "Sample([x, 1, y])",
+        "Sample([1, y, x])",
+    ]
+    assert str(Uniform(x, y)) == "Uniform(x, y)"
+    assert str(Uniform(x + y, y)) == "Uniform(x + y, y)"
+
+def test_pickling():
+    x = Symbol("x")
+    y = Symbol("y")
+    for c in (ContinuousProbability, ContinuousProbability(), Normal,
+              Normal(x, y), Sample, Sample([1, 3, 4]), Uniform, Uniform(x, y)):
+        check(c)

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -409,17 +409,6 @@ def test_series():
     for c in (Limit, Limit(e, x, 1), Order, Order(e)):
         check(c)
 
-#================== statistics ==================
-from sympy.statistics.distributions import ContinuousProbability, Normal, Sample, Uniform
-
-
-def test_statistics():
-    x = Symbol("x")
-    y = Symbol("y")
-    for c in (ContinuousProbability, ContinuousProbability(), Normal,
-              Normal(x, y), Sample, Sample([1, 3, 4]), Uniform, Uniform(x, y)):
-        check(c)
-
 #================== concrete ==================
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum


### PR DESCRIPTION
This module is deprecated, so keeping the tests together makes it easier to 
ignore the deprecation warning during the tests (which otherwise raises an 
error).
