### PR TITLE
Make the default color of LaTeX printing black instead of blue

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -146,7 +146,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
 
 def init_printing(pretty_print=True, order=None, use_unicode=None,
                   use_latex=None, wrap_line=None, num_columns=None,
-                  no_global=False, ip=None, euler=False, forecolor='Blue',
+                  no_global=False, ip=None, euler=False, forecolor='Black',
                   backcolor='Transparent', fontsize='10pt',
                   latex_mode='equation*'):
     """


### PR DESCRIPTION
I don't feel too strongly about this, but I do think that black looks better
than blue.
