### PR TITLE
trigsimp and simplify

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1533,6 +1533,8 @@ class Basic(object):
 
     def _eval_rewrite(self, pattern, rule, **hints):
         if self.is_Atom:
+            if hasattr(self, rule):
+                return getattr(self, rule)()
             return self
         sargs = self.args
         terms = [ t._eval_rewrite(pattern, rule, **hints)
@@ -1558,6 +1560,9 @@ class Basic(object):
         defined called 'deep'. When 'deep' is set to False it will
         forbid functions to rewrite their contents.
 
+        Examples
+        ========
+
         >>> from sympy import sin, exp
         >>> from sympy.abc import x
 
@@ -1574,7 +1579,7 @@ class Basic(object):
         -I*(exp(I*x) - exp(-I*x))/2
 
         """
-        if self.is_Atom or not args:
+        if not args:
             return self
         else:
             pattern = args[:-1]

--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -34,7 +34,7 @@ class Mod(Function):
             to be less than q.
             """
 
-            if p == q or p == -q:
+            if p == q or p == -q or p.is_Pow and p.exp.is_Integer and p.base == q:
                 return S.Zero
 
             if p.is_Number and q.is_Number:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2513,6 +2513,14 @@ class Exp1(NumberSymbol):
     def _eval_power(self, expt):
         return C.exp(expt)
 
+    def _eval_rewrite_as_sin(self):
+        I = S.ImaginaryUnit
+        return C.sin(I + S.Pi/2) - I*C.sin(I)
+
+    def _eval_rewrite_as_cos(self):
+        I = S.ImaginaryUnit
+        return C.cos(I) + I*C.cos(I + S.Pi/2)
+
     def _sage_(self):
         import sage.all as sage
         return sage.e

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -113,6 +113,8 @@ def test_exp_rewrite():
     x = symbols('x')
     assert exp(x).rewrite(sin) == sinh(x) + cosh(x)
     assert exp(x*I).rewrite(cos) == cos(x) + I*sin(x)
+    assert exp(1).rewrite(cos) == sinh(1) + cosh(1)
+    assert exp(1).rewrite(sin) == sinh(1) + cosh(1)
 
 
 def test_exp_leading_term():

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,5 +1,5 @@
 from sympy import (Abs, C, Dummy, Rational, Float, S, Symbol, cos, oo, pi,
-                   simplify, sqrt, symbols, tan)
+                   simplify, sin, sqrt, symbols, tan)
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment, Triangle,
                             are_similar, convex_hull, intersection, centroid)
@@ -999,9 +999,9 @@ def test_line_intersection():
     assert asa(120, 8, 52) == \
         Triangle(
             Point(0, 0),
-            Point(8, 0), Point(
-            (8 + 8*sqrt(3)*tan(19*pi/90))/(-3*tan(19*pi/90)**2 + 1),
-           -(8*sqrt(3) + 24*tan(19*pi/90))/(-3*tan(19*pi/90)**2 + 1)))
+            Point(8, 0),
+            Point(-4*cos(19*pi/90)/sin(2*pi/45),
+            4*sqrt(3)*cos(19*pi/90)/sin(2*pi/45)))
     assert Line((0, 0), (1, 1)).intersection(Ray((1, 0), (1, 2))) == \
         [Point(1, 1)]
     assert Line((0, 0), (1, 1)).intersection(Segment((1, 0), (1, 2))) == \

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -631,7 +631,7 @@ def test_sine_transform():
     assert sine_transform(
         exp(-a*t), t, w) == sqrt(2)*w/(sqrt(pi)*(a**2 + w**2))
     assert inverse_sine_transform(
-        sqrt(2)*w/(sqrt(pi)*(a**2 + w**2)), w, t) == -sinh(a*t) + cosh(a*t)
+        sqrt(2)*w/(sqrt(pi)*(a**2 + w**2)), w, t) == exp(-a*t)
 
     assert sine_transform(
         log(t)/t, t, w) == -sqrt(2)*sqrt(pi)*(log(w**2) + 2*EulerGamma)/4
@@ -659,7 +659,7 @@ def test_cosine_transform():
     assert inverse_cosine_transform(1/sqrt(w), w, t) == 1/sqrt(t)
 
     assert cosine_transform(1/(
-        a**2 + t**2), t, w) == -sqrt(2)*sqrt(pi)*(sinh(a*w) - cosh(a*w))/(2*a)
+        a**2 + t**2), t, w) == sqrt(2)*sqrt(pi)*exp(-a*w)/(2*a)
 
     assert cosine_transform(t**(
         -a), t, w) == 2**(-a + S(1)/2)*w**(a - 1)*gamma((-a + 1)/2)/gamma(a/2)
@@ -669,10 +669,10 @@ def test_cosine_transform():
     assert cosine_transform(
         exp(-a*t), t, w) == sqrt(2)*a/(sqrt(pi)*(a**2 + w**2))
     assert inverse_cosine_transform(
-        sqrt(2)*a/(sqrt(pi)*(a**2 + w**2)), w, t) == -sinh(a*t) + cosh(a*t)
+        sqrt(2)*a/(sqrt(pi)*(a**2 + w**2)), w, t) == exp(-a*t)
 
     assert cosine_transform(exp(-a*sqrt(t))*cos(a*sqrt(
-        t)), t, w) == -a*(sinh(a**2/(2*w)) - cosh(a**2/(2*w)))/(2*w**(S(3)/2))
+        t)), t, w) == a*exp(-a**2/(2*w))/(2*w**(S(3)/2))
 
     assert cosine_transform(1/(a + t), t, w) == -sqrt(2)*(
         (2*Si(a*w) - pi)*sin(a*w)/2 + cos(a*w)*Ci(a*w))/sqrt(pi)
@@ -711,4 +711,4 @@ def test_hankel_transform():
                                                      3)/2)*gamma(nu + S(3)/2)/sqrt(pi)
     assert inverse_hankel_transform(
         2**(nu + 1)*a*k**(-nu - 3)*(a**2/k**2 + 1)**(-nu - S(3)/2)*gamma(
-        nu + S(3)/2)/sqrt(pi), k, r, nu) == r**nu*(-sinh(a*r) + cosh(a*r))
+        nu + S(3)/2)/sqrt(pi), k, r, nu) == r**nu*exp(-a*r)

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -1595,7 +1595,7 @@ def cosine_transform(f, x, k, **hints):
     >>> cosine_transform(exp(-a*x), x, k)
     sqrt(2)*a/(sqrt(pi)*(a**2 + k**2))
     >>> cosine_transform(exp(-a*sqrt(x))*cos(a*sqrt(x)), x, k)
-    -a*(sinh(a**2/(2*k)) - cosh(a**2/(2*k)))/(2*k**(3/2))
+    a*exp(-a**2/(2*k))/(2*k**(3/2))
 
     See Also
     ========
@@ -1642,7 +1642,7 @@ def inverse_cosine_transform(F, k, x, **hints):
     >>> from sympy import inverse_cosine_transform, exp, sqrt, pi
     >>> from sympy.abc import x, k, a
     >>> inverse_cosine_transform(sqrt(2)*a/(sqrt(pi)*(a**2 + k**2)), k, x)
-    -sinh(a*x) + cosh(a*x)
+    exp(-a*x)
     >>> inverse_cosine_transform(1/sqrt(k), k, x)
     1/sqrt(x)
 
@@ -1756,7 +1756,7 @@ def hankel_transform(f, r, k, nu, **hints):
     a/(k**3*(a**2/k**2 + 1)**(3/2))
 
     >>> inverse_hankel_transform(ht, k, r, 0)
-    -sinh(a*r) + cosh(a*r)
+    exp(-a*r)
 
     See Also
     ========
@@ -1812,7 +1812,7 @@ def inverse_hankel_transform(F, k, r, nu, **hints):
     a/(k**3*(a**2/k**2 + 1)**(3/2))
 
     >>> inverse_hankel_transform(ht, k, r, 0)
-    -sinh(a*r) + cosh(a*r)
+    exp(-a*r)
 
     See Also
     ========

--- a/sympy/simplify/__init__.py
+++ b/sympy/simplify/__init__.py
@@ -7,7 +7,8 @@ the expression (x+x)**2 will be converted into 4*x**2
 from simplify import (collect, rcollect, separate, radsimp, ratsimp, fraction,
     simplify, trigsimp, powsimp, combsimp, hypersimp, hypersimilar, nsimplify,
     logcombine, separatevars, numer, denom, powdenest, posify, polarify,
-    unpolarify, collect_const, signsimp, besselsimp, ratsimpmodprime)
+    unpolarify, collect_const, signsimp, besselsimp, ratsimpmodprime,
+    exptrigsimp)
 
 from fu import FU, fu
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3703,6 +3703,8 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False):
 
     short = shorter(powsimp(expr, combine='exp', deep=True), powsimp(expr), expr)
     short = shorter(short, factor_terms(short), expand_power_exp(expand_mul(short)))
+    if short.has(C.TrigonometricFunction, C.HyperbolicFunction, C.ExpBase):
+        short = exptrigsimp(short, simplify=False)
 
     # get rid of hollow 2-arg Mul factorization
     from sympy.core.rules import Transform
@@ -3726,9 +3728,6 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False):
         n, d = fraction(expr)
         if d != 0:
             expr = signsimp(-n/(-d))
-
-    if expr.has(C.TrigonometricFunction, C.HyperbolicFunction, C.ExpBase):
-        expr = exptrigsimp(expr, simplify=False)
 
     if measure(expr) > ratio*measure(original_expr):
         expr = original_expr
@@ -4140,9 +4139,9 @@ def besselsimp(expr):
 def exptrigsimp(expr, simplify=True):
     """
     Simplifies exponential / trigonometric / hyperbolic functions.
-    When ``simplify`` is True (default) some simplification will be done
-    that would otherwise be done in ``simplify`` to get precondition the
-    expression so the transformations will be applied.
+    When ``simplify`` is True (default) the expression obtained after the
+    simplification step will be then be passed through simplify to
+    precondition it so the final transformations will be applied.
 
     Examples
     ========
@@ -4152,7 +4151,6 @@ def exptrigsimp(expr, simplify=True):
 
     >>> exptrigsimp(exp(z) + exp(-z))
     2*cosh(z)
-
     >>> exptrigsimp(cosh(z) - sinh(z))
     exp(-z)
     """
@@ -4167,43 +4165,47 @@ def exptrigsimp(expr, simplify=True):
         choices.append(e.rewrite(cos))
         return min(*choices, **dict(key=count_ops))
     newexpr = bottom_up(expr, exp_trig)
-    if cancel:
-        newexpr = powsimp(factor_terms(
-            expand_power_exp(newexpr).cancel()), deep=True)
+
+    if simplify:
+        newexpr = newexpr.simplify()
+
     # conversion from exp to hyperbolic
     ex = newexpr.atoms(exp, S.Exp1)
     ex = [ei for ei in ex if 1/ei not in ex]
-    # sinh and cosh
+    ## sinh and cosh
     for ei in ex:
         e2 = ei**-2
         if e2 in ex:
             a = e2.args[0]/2
             newexpr = newexpr.subs((e2 + 1)*ei, 2*cosh(a))
             newexpr = newexpr.subs((e2 - 1)*ei, 2*sinh(a))
-    # exp ratios to tan and tanh
+    ## exp ratios to tan and tanh
     for ei in ex:
+        n, d = ei - 1, ei + 1
+        et = n/d
+        etinv = d/n  # not 1/et or else recursion errors arise
         a = ei.args[0] if ei.func is exp else S.One
         if a.is_Mul or a is S.ImaginaryUnit:
             c = a.as_coefficient(I)
             if c:
                 t = S.ImaginaryUnit*tan(c/2)
-                et = (ei - 1)/(ei + 1)
-                newexpr = newexpr.subs(1/et, 1/t)
+                newexpr = newexpr.subs(etinv, 1/t)
                 newexpr = newexpr.subs(et, t)
                 continue
         t = tanh(a/2)
-        et = (ei - 1)/(ei + 1)
-        newexpr = newexpr.subs(1/et, 1/t)
+        newexpr = newexpr.subs(etinv, 1/t)
         newexpr = newexpr.subs(et, t)
+
     # sin/cos and sinh/cosh ratios to tan and tanh, respectively
     if newexpr.has(C.HyperbolicFunction):
         e, f = hyper_as_trig(newexpr)
         newexpr = f(TR2i(e))
     if newexpr.has(C.TrigonometricFunction):
         newexpr = TR2i(newexpr)
+
     # can we ever generate an I where there was none previously?
     if not (newexpr.has(I) and not expr.has(I)):
-        expr = factor_terms(newexpr)
+        expr = newexpr
     return expr
 
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4193,7 +4193,7 @@ def exptrigsimp(expr, simplify=True):
         newexpr = f(TR2i(e))
     if e.has(C.TrigonometricFunction):
         newexpr = TR2i(e)
-    # can we every generate an I where there was none previously?
+    # can we ever generate an I where there was none previously?
     if not (newexpr.has(I) and not expr.has(I)):
         expr = newexpr
     return expr

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3728,7 +3728,7 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False):
             expr = signsimp(-n/(-d))
 
     if expr.has(C.TrigonometricFunction, C.HyperbolicFunction, C.ExpBase):
-        expr = exptrigsimp(expr, cancel=False)
+        expr = exptrigsimp(expr, simplify=False)
 
     if measure(expr) > ratio*measure(original_expr):
         expr = original_expr
@@ -4137,9 +4137,12 @@ def besselsimp(expr):
 
     return expr
 
-def exptrigsimp(expr, cancel=True):
+def exptrigsimp(expr, simplify=True):
     """
-    Simplifies exponential / trigonometric / hyperbolic functions
+    Simplifies exponential / trigonometric / hyperbolic functions.
+    When ``simplify`` is True (default) some simplification will be done
+    that would otherwise be done in ``simplify`` to get precondition the
+    expression so the transformations will be applied.
 
     Examples
     ========

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4226,6 +4226,7 @@ def _futrig(e, **kwargs):
         TR12,  # expand tan of sum
         lambda x: _eapply(factor, x, trigs),
         TR2,  # tan-cot -> sin-cos
+        [identity, lambda x: _eapply(_mexpand, x, trigs)],
         TR2i,  # sin-cos ratio -> tan
         lambda x: _eapply(lambda i: factor(i.normal()), x, trigs),
         TR14,  # factored identities

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4185,24 +4185,11 @@ def exptrigsimp(expr, cancel=True):
         newexpr = newexpr.subs(1/et, 1/t)
         newexpr = newexpr.subs(et, t)
     # sin/cos and sinh/cosh ratios to tan and tanh, respectively
-    s = newexpr.atoms(sin)
-    if s:
-        newexpr = factor_terms(newexpr)
-        for si in s:
-            a = si.args[0]
-            trat = sin(a)/cos(a)
-            t = tan(a)
-            newexpr = newexpr.subs(trat, t)
-            newexpr = newexpr.subs(1/trat, 1/t)
-    sh = newexpr.atoms(sinh)
-    if not s and sh:
-        newexpr = factor_terms(newexpr)
-    for si in sh:
-        a = si.args[0]
-        trat = sinh(a)/cosh(a)
-        t = tanh(a)
-        newexpr = newexpr.subs(trat, t)
-        newexpr = newexpr.subs(1/trat, 1/t)
+    if newexpr.has(C.HyperbolicFunction):
+        e, f = hyper_as_trig(newexpr)
+        newexpr = f(TR2i(e))
+    if e.has(C.TrigonometricFunction):
+        newexpr = TR2i(e)
     # can we every generate an I where there was none previously?
     if not (newexpr.has(I) and not expr.has(I)):
         expr = newexpr

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4139,10 +4139,16 @@ def besselsimp(expr):
 
 def exptrigsimp(expr):
     """
-    Simplifies exponential / trigonometric functions
+    Simplifies exponential / trigonometric / hyperbolic functions
+
+    >>> from sympy import exptrigsimp, exp, cosh, sinh
+    >>> from sympy.abc import z
 
     >>> exptrigsimp(exp(z) + exp(-z))
     2*cosh(z)
+
+    >>> exptrigsimp(cosh(z) - sinh(z))
+    exp(-z)
     """
     def exp_trig(e):
         # select the better of e, and e rewritten in terms of exp or trig

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4141,6 +4141,9 @@ def exptrigsimp(expr):
     """
     Simplifies exponential / trigonometric / hyperbolic functions
 
+    Examples
+    ========
+
     >>> from sympy import exptrigsimp, exp, cosh, sinh
     >>> from sympy.abc import z
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -3727,17 +3727,8 @@ def simplify(expr, ratio=1.7, measure=count_ops, fu=False):
         if d != 0:
             expr = signsimp(-n/(-d))
 
-    def exp_trig(e):
-        # select the better of e, and e rewritten in terms of exp or trig
-        # functions
-        choices = [e]
-        if e.has(*_trigs):
-            choices.append(e.rewrite(exp))
-        choices.append(e.rewrite(cos))
-        return min(*choices, **dict(key=count_ops))
-    newexpr = bottom_up(expr, exp_trig)
-    if not (newexpr.has(I) and not expr.has(I)):
-        expr = newexpr
+    if expr.has(C.TrigonometricFunction, C.HyperbolicFunction, C.ExpBase):
+        expr = exptrigsimp(expr)
 
     if measure(expr) > ratio*measure(original_expr):
         expr = original_expr
@@ -4144,6 +4135,26 @@ def besselsimp(expr):
     if expr != orig_expr:
         expr = expr.factor()
 
+    return expr
+
+def exptrigsimp(expr):
+    """
+    Simplifies exponential / trigonometric functions
+
+    >>> exptrigsimp(exp(z) + exp(-z))
+    2*cosh(z)
+    """
+    def exp_trig(e):
+        # select the better of e, and e rewritten in terms of exp or trig
+        # functions
+        choices = [e]
+        if e.has(*_trigs):
+            choices.append(e.rewrite(exp))
+        choices.append(e.rewrite(cos))
+        return min(*choices, **dict(key=count_ops))
+    newexpr = bottom_up(expr, exp_trig)
+    if not (newexpr.has(I) and not expr.has(I)):
+        expr = newexpr
     return expr
 
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -110,14 +110,14 @@ def test_trigsimp1():
     assert trigsimp(cos(x + y) + cos(x - y)) == 2*cos(x)*cos(y)
     assert trigsimp(cos(x + y) - cos(x - y)) == -2*sin(x)*sin(y)
     assert ratsimp(trigsimp(tan(x + y) - tan(x)/(1 - tan(x)*tan(y)))) == \
-        -tan(y)/(tan(x)*tan(y) - 1)
+        sin(y)/(-sin(y)*tan(x) + cos(y))  # -tan(y)/(tan(x)*tan(y) - 1)
 
     assert trigsimp(sinh(x + y) + sinh(x - y)) == 2*sinh(x)*cosh(y)
     assert trigsimp(sinh(x + y) - sinh(x - y)) == 2*sinh(y)*cosh(x)
     assert trigsimp(cosh(x + y) + cosh(x - y)) == 2*cosh(x)*cosh(y)
     assert trigsimp(cosh(x + y) - cosh(x - y)) == 2*sinh(x)*sinh(y)
     assert ratsimp(trigsimp(tanh(x + y) - tanh(x)/(1 + tanh(x)*tanh(y)))) == \
-        tanh(y)/(tanh(x)*tanh(y) + 1)
+        sinh(y)/(sinh(y)*tanh(x) + cosh(y))
 
     assert trigsimp(cos(0.12345)**2 + sin(0.12345)**2) == 1
     e = 2*sin(x)**2 + 2*cos(x)**2
@@ -275,6 +275,10 @@ def test_trigsimp_issue_2515():
     x = Symbol('x')
     assert trigsimp(x*cos(x)*tan(x)) == x*sin(x)
     assert trigsimp(-sin(x) + cos(x)*tan(x)) == 0
+
+
+def test_issue_3826():
+    assert trigsimp(tan(2*x).expand(trig=True)) == tan(2*x)
 
 
 def test_trigsimp_noncommutative():

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1,13 +1,13 @@
 from sympy import (
     acos, Add, atan, besselsimp, binomial, collect, collect_const, combsimp,
     cos, cosh, cot, coth, count_ops, Derivative, diff, Dummy, E, Eq, erf, exp,
-    exp_polar, expand, factor, factorial, FallingFactorial, Float, fraction,
-    Function, gamma, GoldenRatio, hyper, hyper, hypersimp, I, Integer,
-    Integral, integrate, log, logcombine, Matrix, Mul, nsimplify, O, oo, pi,
-    Piecewise, polar_lift, polarify, posify, powdenest, powsimp, radsimp,
-    Rational, ratsimp, ratsimpmodprime, rcollect, RisingFactorial, root, S,
-    separatevars, signsimp, simplify, sin, sinh, solve, sqrt, Subs, Symbol,
-    symbols, sympify, tan, tanh, trigsimp, Wild, Basic, ordered,
+    exp_polar, expand, exptrigsimp, factor, factorial, FallingFactorial, Float,
+    fraction, Function, gamma, GoldenRatio, hyper, hyper, hypersimp, I,
+    Integer, Integral, integrate, log, logcombine, Matrix, Mul, nsimplify, O,
+    oo, pi, Piecewise, polar_lift, polarify, posify, powdenest, powsimp,
+    radsimp, Rational, ratsimp, ratsimpmodprime, rcollect, RisingFactorial,
+    root, S, separatevars, signsimp, simplify, sin, sinh, solve, sqrt, Subs,
+    Symbol, symbols, sympify, tan, tanh, trigsimp, Wild, Basic, ordered,
     expand_multinomial, denom)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import (
@@ -1775,8 +1775,20 @@ def test_3821():
     # wrap in f to show that the change happens wherever ei occurs
     f = Function('f')
     assert [simplify(f(ei)).args[0] for ei in e] == ok
-    assert simplify(exp(x) + exp(-x)) == 2*cosh(x)
-    assert simplify(exp(x) - exp(-x)) == 2*sinh(x)
+
+
+def test_exptrigsimp():
+    assert exptrigsimp(exp(x) + exp(-x)) == 2*cosh(x)
+    assert exptrigsimp(exp(x) - exp(-x)) == 2*sinh(x)
+    e = [cos(x) + I*sin(x), cos(x) - I*sin(x),
+         cosh(x) - sinh(x), cosh(x) + sinh(x)]
+    ok = [exp(I*x), exp(-I*x), exp(-x), exp(x)]
+    assert [exptrigsimp(ei) for ei in e] == ok
+
+    ue = [cos(x) + sin(x), cos(x) - sin(x),
+          cosh(x) + I*sinh(x), cosh(x) - I*sinh(x)]
+    assert [exptrigsimp(ei) for ei in ue] == ue
+
     # TODO
     # w = exp(x)
     # assert simplify((w - 1/w)/(w + 1/w)) == tanh(x)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -531,7 +531,7 @@ def test_simplify_issue_1308():
 
 
 def test_issue_2553():
-    assert simplify(E + exp(-E)) == 2*cosh(x)
+    assert simplify(E + exp(-E)) == exp(-E) + E
     n = symbols('n', commutative=False)
     assert simplify(n + n**(-n)) == n + n**(-n)
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1789,8 +1789,20 @@ def test_exptrigsimp():
           cosh(x) + I*sinh(x), cosh(x) - I*sinh(x)]
     assert [exptrigsimp(ei) for ei in ue] == ue
 
-    # TODO
-    # w = exp(x)
-    # assert simplify((w - 1/w)/(w + 1/w)) == tanh(x)
-    # w = exp(I*x)
-    # assert simplify((w - 1/w)/(w + 1/w)) == I*tan(x)
+    res = []
+    ok = [y*tanh(1), 1/(y*tanh(1)), I*y*tan(1), -I/(y*tan(1)),
+        y*tanh(x), 1/(y*tanh(x)), I*y*tan(x), -I/(y*tan(x)),
+        y*tanh(1 + I), 1/(y*tanh(1 + I))]
+    from sympy.utilities.randtest import test_numerically
+    for a in (1, I, x, I*x, 1 + I):
+        w = exp(a)
+        eq = y*(w - 1/w)/(w + 1/w)
+        s = simplify(eq)
+        assert s == exptrigsimp(eq)
+        assert test_numerically(eq, s)
+        res.append(s)
+        sinv = simplify(1/eq)
+        assert sinv == exptrigsimp(1/eq)
+        assert test_numerically(1/eq, sinv)
+        res.append(sinv)
+    assert res == ok

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1793,16 +1793,13 @@ def test_exptrigsimp():
     ok = [y*tanh(1), 1/(y*tanh(1)), I*y*tan(1), -I/(y*tan(1)),
         y*tanh(x), 1/(y*tanh(x)), I*y*tan(x), -I/(y*tan(x)),
         y*tanh(1 + I), 1/(y*tanh(1 + I))]
-    from sympy.utilities.randtest import test_numerically
     for a in (1, I, x, I*x, 1 + I):
         w = exp(a)
         eq = y*(w - 1/w)/(w + 1/w)
         s = simplify(eq)
         assert s == exptrigsimp(eq)
-        assert test_numerically(eq, s)
         res.append(s)
         sinv = simplify(1/eq)
         assert sinv == exptrigsimp(1/eq)
-        assert test_numerically(1/eq, sinv)
         res.append(sinv)
     assert res == ok

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1766,3 +1766,19 @@ def test_3712_fail():
     xp, y, x, z = symbols('xp, y, x, z')
     eq = 4*(-19*sin(x)*y + 5*sin(3*x)*y + 15*cos(2*x)*z - 21*z)*xp/(9*cos(x) - 5*cos(3*x))
     assert trigsimp(eq) == -2*(2*cos(x)*tan(x)*y + 3*z)*xp/cos(x)
+
+
+def test_3821():
+    e = [cos(x) + I*sin(x), cos(x) - I*sin(x),
+        cosh(x) - sinh(x), cosh(x) + sinh(x)]
+    ok = [exp(I*x), exp(-I*x), exp(-x), exp(x)]
+    # wrap in f to show that the change happens wherever ei occurs
+    f = Function('f')
+    assert [simplify(f(ei)).args[0] for ei in e] == ok
+    assert simplify(exp(x) + exp(-x)) == 2*cosh(x)
+    assert simplify(exp(x) - exp(-x)) == 2*sinh(x)
+    # TODO
+    # w = exp(x)
+    # assert simplify((w - 1/w)/(w + 1/w)) == tanh(x)
+    # w = exp(I*x)
+    # assert simplify((w - 1/w)/(w + 1/w)) == I*tan(x)


### PR DESCRIPTION
- simplify sums of trigs to exponential form if that's shorter `cos(x) + I*sin(x)` -> `exp(I*x)` [issue 3821](https://code.google.com/p/sympy/issues/detail?id=3821)
- add a line to trigsimp's tree that allows it to reduce expanded `tan double-angle expressions` back to `tan` [issue 3826](https://code.google.com/p/sympy/issues/detail?id=3826)
