### PR TITLE
Fix srepr(Function) for non-undefined Functions

### DIFF
--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -5,6 +5,7 @@ The most important function here is srepr that returns a string so that the
 relation eval(srepr(expr))=expr holds in an appropriate environment.
 """
 
+from sympy.core.function import AppliedUndef
 from printer import Printer
 import sympy.mpmath.libmp as mlib
 from sympy.mpmath.libmp import prec_to_dps, repr_dps
@@ -52,7 +53,10 @@ class ReprPrinter(Printer):
         return r
 
     def _print_FunctionClass(self, expr):
-        return 'Function(%r)' % (expr.__name__)
+        if issubclass(expr, AppliedUndef):
+            return 'Function(%r)' % (expr.__name__)
+        else:
+            return expr.__name__
 
     def _print_Half(self, expr):
         return 'Rational(1, 2)'

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -1,6 +1,6 @@
 from sympy.utilities.pytest import raises
 from sympy import symbols, Function, Integer, Matrix, Abs, \
-    Rational, Float, S, WildFunction, ImmutableMatrix
+    Rational, Float, S, WildFunction, ImmutableMatrix, sin
 from sympy.geometry import Point, Ellipse
 from sympy.printing import srepr
 from sympy.polys import ring, field, ZZ, QQ, lex, grlex
@@ -42,6 +42,8 @@ def test_Function():
     # test unapplied Function
     sT(Function('f'), "Function('f')")
 
+    sT(sin(x), "sin(Symbol('x'))")
+    sT(sin, "sin")
 
 def test_Geometry():
     sT(Point(0, 0), "Point(Integer(0), Integer(0))")


### PR DESCRIPTION
Now srepr(sin(x)) gives sin(Symbol('x')) instead of 
Function('sin')(Symbol('x')).
