### PR TITLE
resolve issue 3843: fix quart constant value in physics.units

### DIFF
--- a/sympy/physics/tests/test_units.py
+++ b/sympy/physics/tests/test_units.py
@@ -1,7 +1,7 @@
 from sympy import integrate, Rational, sqrt, Symbol
 from sympy.physics.units import (au, amu, charge, day, find_unit,
                                  foot, km, m, meter, minute, s,
-                                 speed_of_light, grams)
+                                 speed_of_light, grams, quart, inch)
 
 
 def test_units():
@@ -21,6 +21,8 @@ def test_units():
     assert integrate(t*m/s, (t, 1*s, 5*s)) == 12*m*s
     assert (t * m/s).integrate((t, 1*s, 5*s)) == 12*m*s
 
+def test_issue_quart():
+    assert 4*quart/inch**3 == 231
 
 def test_issue_2466():
     assert (m < s).is_Relational

--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -35,7 +35,7 @@ If, for a given session, you wish to add a unit you may do so:
     []
     >>> u.gal = 4*u.quart
     >>> u.gal/u.inch**3
-    924
+    231
 
 To see a given quantity in terms of some other unit, divide by the desired
 unit:
@@ -261,7 +261,7 @@ dHg0 = 13.5951  # approx value at 0 C
 mmHg = dHg0 * 9.80665 * Pa
 amu = amus = gram / avogadro / mol
 mmu = mmus = gram / mol
-quart = quarts = 231 * inch**3
+quart = quarts = Rational(231, 4) * inch**3
 eV = 1.602176487e-19 * J
 
 # Other convenient units and magnitudes


### PR DESCRIPTION
There are 231 cubic inches in a US gallon, not in a US quart as is currently defined.    This appeared in a code example in the docstring for the physics.units module, so I've updated the docstring, as well as the module variable initializer for quart in the attached file.

Additionally, i've added a test function to test_units.py to verify example code in docstring
