### PR TITLE
gamma matrices in dimensional regularization

### DIFF
--- a/doc/src/modules/tensor/dgamma_matr.rst
+++ b/doc/src/modules/tensor/dgamma_matr.rst
@@ -1,0 +1,9 @@
+.. _tensor-dgamma_matr:
+
+Gamma matrices in dimensional regularization
+============================================
+
+.. module:: sympy.tensor.dgamma_matr
+
+.. autoclass:: GammaMatrices
+   :members:

--- a/doc/src/modules/tensor/index.rst
+++ b/doc/src/modules/tensor/index.rst
@@ -15,3 +15,4 @@ Contents
     indexed.rst
     index_methods.rst
     tensor.rst
+    dgamma_matr.rst

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -1,0 +1,536 @@
+from sympy import Symbol, S, I
+from sympy.combinatorics import Permutation
+from sympy.tensor.tensor import (TensExpr, TensorIndexType, tensor_indices,
+  TensorSymmetry, get_symmetric_group_sgs, TensorType, tensor_mul, TensMul,
+  TensAdd, TensorHead, tensorlist_contract_metric)
+
+
+class GammaMatrices(object):
+    """
+    Gamma matrices in dimensional regularization
+    with G5 naively anticommuting with all gamma matrices (NDR)
+
+    NDR is inconsistent but widely used.
+    Notice in particular that the cyclic property of the
+    trace in presence of G5 does not hold.
+
+    The original dimensional regularization scheme by 't Hooft and Veltman
+    has `G5` anticommuting only with `G(m)` for `m` in 0,1,2,3,
+    and commuting for `m > 3`. It is consistent, and it is used to
+    compute the chiral anomaly; however it breaks gauge invariance
+    involving G5 even when there are no anomalies, which complicates
+    a lot maintaining the Ward (or Slavnov-Taylor) identities.
+
+    TODO: introduce the option of using the 't Hooft and Veltman scheme.
+    """
+
+    def __init__(self, typ, gctr=4, g5c=I):
+        """
+
+        Parameters
+        ==========
+        typ : TensorIndexType (Lorentz or Euclidean)
+
+        gct3 : `tr(G(m)*G(n)) = gctr*g(m,n)`
+        in D dimensions, when D is an integer, the gamma
+        matrices are represented with matrices or rank `2**(D//2)`,
+        so `gctr = 2**(D//2)`;
+        in dimensional regularization one uses usually `gctr=4`
+
+        g5c : `tr(G(m0)*G(m1)*G(m2)*G(m3)) = gctr*g5c*epsilon(m0,m1,m2,m3)`
+        with Lorentz signature `g5c = I`, which is the default;
+        in Euclidean space `g5c = 1`
+
+        The attribute `Gsymbol` can be used to set commutation relations
+        with other tensors using ``TensorManager``.
+        """
+        self.g = typ.metric
+        if not typ.dim:
+            raise ValueError('Dimension not assigned')
+        self.D = typ.dim
+        self.typ = typ
+        sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        S1 = TensorType([typ], sym1)
+        self.Gsymbol = Symbol('Gsymbol')
+        self.G = S1('G', self.Gsymbol)
+        sym0 = TensorSymmetry(([], [Permutation(1)]))
+        S0 = TensorType([], sym0)
+        self.Gamma5 = S0('G5', self.Gsymbol)
+        self.G5 = TensMul(S.One, [self.Gamma5], [], [])
+        self.g5c = g5c
+        self.epsilon = typ.epsilon
+        self.eps_dim = typ.eps_dim
+        self.gctr = gctr
+
+    def G5_to_right(self, t):
+        """
+        move G5 to the right
+        """
+        if not isinstance(t, TensExpr):
+            return t
+        if isinstance(t, TensAdd):
+            a = [self.G5_to_right(x) for x in t.args]
+            return TensAdd(*a)
+        components = t._components
+        if not components:
+            return t
+        ncomps = len(components)
+        G = self.G
+        Gamma5 = self.Gamma5
+        G5 = self.G5
+        # [g5,g,g,g5,g,g]
+        numG = 0
+        vposG5 = []
+        for i in range(ncomps):
+            if components[i] == Gamma5:
+                vposG5.append(i)
+                for j in range(i + 1, ncomps):
+                    if components[j] == G:
+                        numG += 1
+        ct = t._coeff if 0 in vposG5 else S.One
+        a = t.split()
+        a1 = []
+        for i in range(ncomps):
+            if not i in vposG5:
+                a1.append(a[i])
+        for i in range(ncomps - 1, -1, -1):
+            if components[i] == G:
+                break
+        if len(vposG5) % 2:
+            a1 = a1[:i + 1] + [G5] + a1[i + 1:ncomps]
+        else:
+            a1 = a1[:i + 1] + a1[i + 1:ncomps]
+        t1 = ((-1)**numG*ct)*tensor_mul(*a1)
+        return t1
+
+    def match1_gamma(self, t, n):
+        #t = t.sorted_components()
+        components = t._components
+        ncomps = len(components)
+        G = self.G
+        for i in range(ncomps):
+            if not components[i] == G:
+                continue
+            for j in range(i + 1, ncomps):
+                if components[j] == G and abs(j - i) == n + 1 and \
+                        (0, 0, i, j) in t._dum:
+                    return i, j
+
+
+    def rule1_gamma(self, t, n, r=None):
+        """
+        simplify products of gamma matrices `G(m)*G(m_1)...*G(m_n)*G(-m)`
+
+        t   Gamma matrix monomial
+        n   apply rule for `G(m)*G(m_1)...*G(m_n)*G(-m)`
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> GM.gamma_trace(G(m0)*G(m1)*G(-m0)*G(m3))
+        (-4*D + 8)*metric(m1, m3)
+        >>> t = G(m1)*G(m0)*G(-m1)*G(-m0)
+        >>> GM.rule1_gamma(t, 1)
+        (-D + 2)*G(L_0)*G(-L_0)
+        """
+        if not r:
+            r = self.match1_gamma(t, n)
+            if not r:
+                return t
+        i, j = r
+        a = t.split()
+        za = zip(a, range(len(a)))
+        tc = t._coeff if i == 0 else S.One
+        a1 = [x for x, y in za if y not in r]
+        D = self.D
+        if n == 0:
+            # G(m)*G(-m) = d
+            t1 = tensor_mul(*a1)
+            t2 = TensMul(D*t1._coeff*tc, t1._components, t1._free, t1._dum)
+            return t2
+        if n == 1:
+            # G(m)*G(n)*G(-m) = (2 - d)*G(n)
+            t1 = tensor_mul(*a1)
+            t2 = TensMul((2-D)*t1._coeff*tc, t1._components, t1._free, t1._dum)
+            return t2
+        if n == 2:
+            # G(m)*G(n1)*G(n2)*G(-m) = (d-4)*G(n1)*G(n2) + 4*delta(n1, n2)
+            t1 = ((D-4)*tc)*tensor_mul(*a1)
+            a2 = a[:i] + a[j + 1:]
+            ind1 = a[r[0] + 1]._free[0][0]
+            ind2 = a[r[1] - 1]._free[0][0]
+            if a2:
+                a2 = tensorlist_contract_metric(a2, self.g(ind1, ind2))
+                t2 = (4*tc)*tensor_mul(*a2)
+            else:
+                t2 = (4*tc)*self.g(ind1, ind2)
+            return t1 + t2
+        if n == 3:
+            # G(m)*G(n1)*G(n2)*G(n3)*G(-m) = (4-d)*G(n1)*G(n2)*G(n3) - \
+            #  2*G(n3)*G(n2)*G(n1)
+            t1 = ((4-D)*tc)*tensor_mul(*a1)
+            a2a = a[i + 1:j]
+            a2a.reverse()
+            a2 = a[:i] + a2a + a[j + 1:]
+            t2 = (-2*tc)*tensor_mul(*a2[:])
+            return t1 + t2
+        if n > 3:
+            # G(m0)*G(m_1)*...*G(m_k)*G(-m0) =
+            # 2*G(m_k)*G(m_1)*...*G(m_(k-1)) -
+            # G(m0)*G(m_1)*...*G(m_(k-1))G(-m0)*G(m_k))
+            a1 = a[:i] + [a[j-1]] + a[i+1:j-1] + a[j + 1:]
+            t1 = (2*tc)*tensor_mul(*a1)
+            a2 = a[:j-1] + [a[j], a[j-1]] + a[j + 1:]
+            t2 = -tensor_mul(*a2)
+            return t1 + t2
+
+
+    def do_rule1_gamma(self, t, nmax=4, doall=False):
+        """
+        simplify products of gamma matrices `G(m)*G(m_1)...*G(m_n)*G(-m)`
+
+        `t` Gamma matrix expression
+
+        nmax  maximum number for which `rule1\_gamma(t, n)` is applied
+
+        doall  if true apply `rule1\_gamma` till the expression does not change
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> t = G(m1)*G(m0)*G(-m1)*G(-m0)
+        >>> GM.do_rule1_gamma(t, doall=True)
+        D*(-D + 2)
+        """
+        if not isinstance(t, TensExpr):
+            return t
+        if isinstance(t, TensMul):
+            for n in range(nmax + 1):
+                r = self.match1_gamma(t, n)
+                if not r:
+                    continue
+                t1 = self.rule1_gamma(t, n, r)
+                t1 = t1.contract_metric(self.g, contract_all=True)
+                if doall:
+                    if t1 != t:
+                        t1 = self.do_rule1_gamma(t1, nmax, doall)
+                return t1
+            return t
+        if isinstance(t, TensAdd):
+            a = [self.do_rule1_gamma(tx, nmax, doall) for tx in t.args]
+            t1 = TensAdd(*a)
+            return t1.contract_metric(self.g, contract_all=True)
+
+    def match2_gamma(self, t, n):
+        components = t._components
+        ncomps = len(components)
+        G = self.G
+        # G(a)*G(b)*...*p(-a)*p(-b)
+        for i in range(ncomps - 1 - n):
+            if not components[i] == G:
+                continue
+            if not components[i + n + 1] == G:
+                continue
+            p_pos1 = p_pos2 = 0
+            for dx in t._dum:
+                if dx[2] == i:
+                    p_pos1 = dx[3]
+                if dx[2] == i + n + 1:
+                    p_pos2 = dx[3]
+            if p_pos1 > 0 and p_pos2 > 0:
+                if components[p_pos1] == components[p_pos2] \
+                    and components[p_pos1].comm == 0:
+                    return i, p_pos1, p_pos2
+        return None
+
+    def rule2_gamma(self, t, n):
+        """
+        simplify `G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)`
+
+        `t`    Gamma matrix monomial
+        `n` as in  `G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)`
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> p = S1('p')
+        >>> ps = G(m0)*p(-m0)
+        >>> t = G(m0)*ps*ps*G(-m0)
+        >>> GM.rule2_gamma(t, 0)
+        G(L_0)*G(-L_0)*p(L_1)*p(-L_1)
+        """
+        t = t.canon_bp()
+        r = self.match2_gamma(t, n)
+        if not r:
+            return t
+        i0, i1, i2 = r
+        if n == 0:
+            a = t.split()
+            ct = t._coeff if i0 == 0 else S.One
+            p = a[i1]
+            ind_p = p._free[0][0]
+            # G(m0)*G(m1)*p(-m0)*p(-m1) = p(m0)*p(-m0)
+            a1 = a[:i0] + a[i0 + 2:i1] + a[i1 + 1:i2] + a[i2 + 1:]
+            a2 = [p.substitute_indices((ind_p, -ind_p)), p]
+            a3 = a1 + a2
+            t = tensor_mul(*a3)*ct
+            return t
+        elif n == 1:
+            # G(m0)*G(ind1)*G(m1)*p(-m0)*p(-m1) =
+            # 2*G(m0)*p(-m0)*p(ind1) - G(ind1)*p(m0)*p(-m0)
+            a = t.split()
+            ind1 = a[i0 + 1]._free[0][0]
+            ct = t._coeff if i0 == 0 else S.One
+            p = a[i1]
+            ind_p = p._free[0][0]
+            a1 = a[:i0] + [a[i0 + 1]] + a[i0 + 3:i1] + a[i1 + 1:i2] + a[i2 + 1:]
+            a2 = [p.substitute_indices((ind_p, -ind_p)), p]
+            a3 = a1 + a2
+            t1 = tensor_mul(*a3)*(-ct)
+            args = [t1]
+            a1 = a[:i0 + 1] + a[i0 + 3:i2] + a[i2 + 1:]
+            p = a[i2]
+            ind_p = p._free[0][0]
+            a2 = [p.substitute_indices((ind_p, ind1))]
+            a3 = a1 + a2
+            t2 = tensor_mul(*a3)*2
+            t3 = t1 + t2
+            return t3
+        else:
+            raise NotImplementedError
+
+    def do_rule2_gamma(self, t, nmax=1):
+        """
+        simplify `G(m0)*p(-m0)*G(m1)*p(-m1)` to `p(m)*p(-m)`
+
+        `t`    Gamma matrix expression
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+            TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> p = S1('p')
+        >>> ps = G(m0)*p(-m0)
+        >>> M = Symbol('M')
+        >>> t = G(m0)*(ps + M)*(ps - M)*G(-m0)
+        >>> GM.do_rule2_gamma(t)
+        (-M**2)*G(L_0)*G(-L_0) + G(L_0)*G(-L_0)*p(L_1)*p(-L_1)
+        """
+        if not isinstance(t, TensExpr):
+            return t
+        if isinstance(t, TensMul):
+            for n in range(nmax + 1):
+                t = self.rule2_gamma(t, n)
+        if isinstance(t, TensAdd):
+            a = [self.do_rule2_gamma(tx) for tx in t.args]
+            t = TensAdd(*a)
+        return t
+
+
+    def gamma_trace(self, t):
+        """
+        Trace of gamma matrices
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, S
+        >>> from sympy.tensor.tensor import (TensorIndexType, tensor_indices,\
+                TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
+        >>> from sympy.tensor.dgamma_matr import GammaMatrices
+        >>> D = Symbol('D')
+        >>> Lorentz = TensorIndexType('Lorentz', dim=D, dummy_fmt='L')
+        >>> sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+        >>> S1 = TensorType([Lorentz], sym1)
+        >>> GM = GammaMatrices(Lorentz)
+        >>> gamma_trace = GM.gamma_trace
+        >>> G = GM.G
+        >>> m0, m1, m2, m3 = tensor_indices('m0,m1,m2,m3', Lorentz)
+        >>> gamma_trace(G(m0)*G(m1)*G(-m0)*G(m3))
+        (-4*D + 8)*metric(m1, m3)
+
+        >>> p, q = S1('p,q')
+        >>> t = G(m0)*G(m1)*G(m2)*G(m3)*p(-m1)*q(-m3)
+        >>> gamma_trace(t)
+        -4*metric(m0, m2)*p(L_0)*q(-L_0) + 4*p(m0)*q(m2) + 4*p(m2)*q(m0)
+        """
+        if not isinstance(t, TensExpr):
+            return self.gctr*t
+        t = self.G5_to_right(t)
+        if isinstance(t, TensAdd):
+            a = [self.gamma_trace(x) for x in t.args]
+            return TensAdd(*a)
+        components = t._components
+        ncomps = len(components)
+        G = self.G
+        G5 = self.G5
+        Gamma5 = self.Gamma5
+        g = self.g
+        if all(x != G for x in components):
+            if any(x == Gamma5 for x in components):
+                return TensMul(S.Zero, [], [], [])
+            return self.gctr*t
+        withG5 = False
+        t = t.canon_bp()
+        components = t._components
+        for i in range(ncomps):
+            if components[i] == G:
+                break
+        for j in range(i + 1, ncomps):
+            if not components[j] == G:
+                break
+        else:
+            j = ncomps
+        numG = j - i
+        if any(x == Gamma5 for x in components):
+            withG5 = True
+        if withG5:
+            if numG < 4 or numG % 2 != self.eps_dim % 2:
+                return TensMul(S.Zero, [], [], [])
+            if numG == 4:
+                a = t.split()
+                indices = [x._free[0][0] for x in a[i:j]]
+                ct = t._coeff if i == 0 else S.One
+                t1 = (self.gctr*ct*self.g5c)*self.epsilon(*indices)
+                a2 = a[:i] + a[j + 1:]
+                t2 = tensor_mul(*a2)
+                res = t1*t2
+                res = res.canon_bp()
+                return res
+            if numG > 4:
+                prev = TensMul(S.Zero, [], [], [])
+                t2 = t
+                while True:
+                    t2 = self.do_rule1_gamma(t2, nmax=numG)
+                    t2 = t2.contract_metric(g, contract_all=True)
+                    t2 = self.do_rule2_gamma(t2)
+                    if t2 == prev:
+                        break
+                    prev = t2
+                if t == t2:
+                    a = t.split()
+                    args = []
+                    for k1 in range(i, j):
+                        ind1 = a[k1]._free[0][0]
+                        for k2 in range(k1 + 1, j):
+                            ind2 = a[k2]._free[0][0]
+                            sign = 1 if (k1 - k2) % 2 == 1 else -1
+                            a1 = a[:k1] + a[k1 + 1:k2] + a[k2 + 1:]
+                            a1 = tensorlist_contract_metric(a1, g(ind1, ind2))
+                            ct = t._coeff if k1 == 0 else S.One
+                            t1 = (sign*ct)*tensor_mul(*a1)
+                            args.append(t1)
+                    t2 = TensAdd(*args)
+                    return self.gamma_trace(t2)
+                else:
+                    return self.gamma_trace(t2)
+        else:
+            # without G5
+            if numG % 2 == 1:
+                return TensMul(S.Zero, [], [], [])
+            if numG > 4:
+                prev = TensMul(S.Zero, [], [], [])
+                t2 = t
+                while True:
+                    t2 = self.do_rule1_gamma(t2, nmax=numG)
+                    t2 = t2.contract_metric(g, contract_all=True)
+                    t2 = self.do_rule2_gamma(t2)
+                    if t2 == prev:
+                        break
+                    prev = t2
+                if t == t2:
+                    a = t.split()
+                    # G are from i to j1 included; anticommute G(j1) through
+                    ind1 = a[i]._free[0][0]
+                    ind2 = a[i + 1]._free[0][0]
+                    aa = a[:i] + a[i + 2:]
+                    aa = tensorlist_contract_metric(aa, g(ind1, ind2))
+                    ct = t._coeff if i == 0 else S.One
+                    t1 = ct*tensor_mul(*aa)
+                    args = [t1]
+                    sign = 1
+                    for k in range(i + 2, j):
+                        sign = -sign
+                        ind2 = a[k]._free[0][0]
+                        aa = a[:i] + a[i + 1:k] + a[k + 1:]
+                        aa = tensorlist_contract_metric(aa, g(ind1, ind2))
+                        t2 = sign*tensor_mul(*aa)
+                        args.append(t2)
+                    t3 = TensAdd(*args)
+                    return self.gamma_trace(t3)
+                return self.gamma_trace(t2)
+
+            a = t.split()
+            t1 = self.gamma_trace1(*a[i:j])
+            a2 = a[:i] + a[j:]
+            t2 = tensor_mul(*a2)
+            ct = t._coeff if i == 0 else S.One
+            t3 = ct*t1*t2
+            if not t3:
+                return t3
+            t3 = t3.contract_metric(g, contract_all=True)
+            return t3
+
+
+    def gamma_trace1(self, *a):
+        if not a:
+            return self.gctr
+        n = len(a)
+        if n%2 == 1:
+            return TensMul(S.Zero, [], [], [])
+        if n == 2:
+            ind0 = a[0]._free[0][0]
+            ind1 = a[1]._free[0][0]
+            return self.gctr*self.g(ind0, ind1)
+        if n == 4:
+            ind0 = a[0]._free[0][0]
+            ind1 = a[1]._free[0][0]
+            ind2 = a[2]._free[0][0]
+            ind3 = a[3]._free[0][0]
+            return self.gctr*(self.g(ind0, ind1)*self.g(ind2, ind3) - \
+                self.g(ind0, ind2)*self.g(ind1, ind3) + self.g(ind0, ind3)*self.g(ind1, ind2))
+        else:
+            raise NotImplementedError

--- a/sympy/tensor/dgamma_matr.py
+++ b/sympy/tensor/dgamma_matr.py
@@ -8,15 +8,15 @@ from sympy.tensor.tensor import (TensExpr, TensorIndexType, tensor_indices,
 class GammaMatrices(object):
     """
     Gamma matrices in dimensional regularization
-    with G5 naively anticommuting with all gamma matrices (NDR)
+    with ``G5`` naively anticommuting with all gamma matrices (NDR)
 
     NDR is inconsistent but widely used.
     Notice in particular that the cyclic property of the
     trace in presence of G5 does not hold.
 
     The original dimensional regularization scheme by 't Hooft and Veltman
-    has `G5` anticommuting only with `G(m)` for `m` in 0,1,2,3,
-    and commuting for `m > 3`. It is consistent, and it is used to
+    has ``G5`` anticommuting only with ``G(m)`` for ``m`` in ``0,1,2,3``,
+    and commuting for ``m > 3``. It is consistent, and it is used to
     compute the chiral anomaly; however it breaks gauge invariance
     involving G5 even when there are no anomalies, which complicates
     a lot maintaining the Ward (or Slavnov-Taylor) identities.
@@ -78,7 +78,6 @@ class GammaMatrices(object):
         G = self.G
         Gamma5 = self.Gamma5
         G5 = self.G5
-        # [g5,g,g,g5,g,g]
         numG = 0
         vposG5 = []
         for i in range(ncomps):
@@ -104,6 +103,9 @@ class GammaMatrices(object):
         return t1
 
     def match1_gamma(self, t, n):
+        """
+        match for ``G(m)*G(m_1)...*G(m_n)*G(-m)``
+        """
         #t = t.sorted_components()
         components = t._components
         ncomps = len(components)
@@ -119,10 +121,10 @@ class GammaMatrices(object):
 
     def rule1_gamma(self, t, n, r=None):
         """
-        simplify products of gamma matrices `G(m)*G(m_1)...*G(m_n)*G(-m)`
+        simplify products of gamma matrices ``G(m)*G(m_1)...*G(m_n)*G(-m)``
 
         t   Gamma matrix monomial
-        n   apply rule for `G(m)*G(m_1)...*G(m_n)*G(-m)`
+        n   apply rule for ``G(m)*G(m_1)...*G(m_n)*G(-m)``
 
         Examples
         ========
@@ -198,13 +200,16 @@ class GammaMatrices(object):
 
     def do_rule1_gamma(self, t, nmax=4, doall=False):
         """
-        simplify products of gamma matrices `G(m)*G(m_1)...*G(m_n)*G(-m)`
+        simplify products of gamma matrices ``G(m)*G(m_1)...*G(m_n)*G(-m)``
 
-        `t` Gamma matrix expression
+        Parameters
+        ==========
 
-        nmax  maximum number for which `rule1\_gamma(t, n)` is applied
+        t : Gamma matrix expression
 
-        doall  if true apply `rule1\_gamma` till the expression does not change
+        nmax :  maximum number for which ``rule1\_gamma(t, n)`` is applied
+
+        doall : if true apply ``rule1_gamma`` till the expression does not change
 
         Examples
         ========
@@ -244,10 +249,12 @@ class GammaMatrices(object):
             return t1.contract_metric(self.g, contract_all=True)
 
     def match2_gamma(self, t, n):
+        """
+        match ``G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)``
+        """
         components = t._components
         ncomps = len(components)
         G = self.G
-        # G(a)*G(b)*...*p(-a)*p(-b)
         for i in range(ncomps - 1 - n):
             if not components[i] == G:
                 continue
@@ -267,10 +274,13 @@ class GammaMatrices(object):
 
     def rule2_gamma(self, t, n):
         """
-        simplify `G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)`
+        simplify ``G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)``
 
-        `t`    Gamma matrix monomial
-        `n` as in  `G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)`
+        Parameters
+        ==========
+
+        t :    Gamma matrix monomial
+        n : as in  ``G(m0)*p(-m0)*G(i_1)...*G(i_n)*G(m1)*p(-m1)``
 
         Examples
         ========
@@ -334,9 +344,12 @@ class GammaMatrices(object):
 
     def do_rule2_gamma(self, t, nmax=1):
         """
-        simplify `G(m0)*p(-m0)*G(m1)*p(-m1)` to `p(m)*p(-m)`
+        simplify ``G(m0)*p(-m0)*G(m1)*p(-m1)` to `p(m)*p(-m)``
 
-        `t`    Gamma matrix expression
+        Parameters
+        ==========
+
+        t :    Gamma matrix expression
 
         Examples
         ========

--- a/sympy/tensor/tests/test_dgamma_matr.py
+++ b/sympy/tensor/tests/test_dgamma_matr.py
@@ -1,0 +1,295 @@
+from sympy import Symbol, S, I
+from sympy.tensor.tensor import (TensorIndexType, tensor_indices, \
+TensorSymmetry, get_symmetric_group_sgs, TensorType, TensMul)
+from sympy.tensor.dgamma_matr import GammaMatrices
+from sympy.utilities.pytest import skip, XFAIL
+
+
+D = Symbol('D')
+Lorentz = TensorIndexType('Lorentz', dim=D, eps_dim=4, dummy_fmt='L')
+m0, m1, m2, m3, m4, m5 = tensor_indices('m0,m1,m2,m3,m4,m5', Lorentz)
+n0, n1, n2, n3, n4, n5 = tensor_indices('n0,n1,n2,n3,n4,n5', Lorentz)
+sym1 = TensorSymmetry(get_symmetric_group_sgs(1))
+S1 = TensorType([Lorentz], sym1)
+
+GM = GammaMatrices( Lorentz)
+match1_gamma = GM.match1_gamma
+G = GM.G
+g = GM.g
+epsilon = GM.epsilon
+rule1_gamma = GM.rule1_gamma
+do_rule1_gamma = GM.do_rule1_gamma
+match2_gamma = GM.match2_gamma
+rule2_gamma = GM.rule2_gamma
+do_rule2_gamma = GM.do_rule2_gamma
+gamma_trace = GM.gamma_trace
+gamma_trace1 = GM.gamma_trace1
+gctr = GM.gctr
+
+
+def test_rule1_gamma():
+    t = 2*G(m2)*G(m0)*G(m1)*G(-m0)*G(-m1)
+    r = match1_gamma(t, 1)
+    t = rule1_gamma(t, 1)
+    r = match1_gamma(t, 0)
+    t = rule1_gamma(t, 0)
+    assert t == (D*(-2*D + 4))*G(m2)
+
+    t = 3*G(m2)*G(m0)*G(m1)*G(-m0)
+    t = rule1_gamma(t, 1)
+
+    t = G(m2)*G(m0)*G(m1)*G(-m0)*G(-m2)
+    r = match1_gamma(t, 1)
+    assert r == (1, 3)
+    t = rule1_gamma(t, 1)
+    t = rule1_gamma(t, 1)
+    assert t == ((-D + 2)**2)*G(m1)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)
+    r = match1_gamma(t, 2)
+    assert r == (1, 4)
+    t = rule1_gamma(t, 2)
+    assert t == (D - 4)*G(m0)*G(m2)*G(m3) + 4*g(m2, m3)*G(m0)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)*G(-m0)
+    r = match1_gamma(t, 2)
+    t = rule1_gamma(t, 2)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)*G(-m0)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == ((D - 4)**2)*G(m2)*G(m3) + (8*D - 16)*g(m2, m3)
+
+    t = G(m2)*G(m0)*G(m1)*G(-m2)*G(-m0)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == ((-D + 2)*(D - 4) + 4)*G(m1)
+
+    t = G(m3)*G(m1)*G(m0)*G(m2)*G(-m3)*G(-m0)*G(-m2)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == (-4*D + (-D + 2)**2*(D - 4) + 8)*G(m1)
+
+    M = Symbol('M')
+
+    p = S1('p')
+    ps = p(m0)*G(-m0)
+    t0 = ps + M
+    t = G(m0)*(ps + M)*G(-m0)
+    t = do_rule1_gamma(t)
+    assert t == (2 - D)*ps + D*M
+
+    t = G(m0)*(ps + M)*G(-m0)*(ps + M)
+    t = do_rule1_gamma(t)
+
+    t = 2*G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)
+    t = do_rule1_gamma(t)
+    assert t == (-2*D + 8)*G(m1)*G(m2)*G(m3) - 4*G(m3)*G(m2)*G(m1)
+
+    t = G(m5)*G(m0)*G(m1)*G(m4)*G(m2)*G(-m4)*G(m3)*G(-m0)
+    t = do_rule1_gamma(t)
+    t = do_rule1_gamma(t)
+    assert t == ((-D + 2)*(-D + 4))*G(m5)*G(m1)*G(m2)*G(m3) + (2*D - 4)*G(m5)*G(m3)*G(m2)*G(m1)
+
+    t = -G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)*G(m4)
+    t = do_rule1_gamma(t)
+    assert t == (D - 4)*G(m1)*G(m2)*G(m3)*G(m4) + 2*G(m3)*G(m2)*G(m1)*G(m4)
+
+    t = G(-m5)*G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)*G(m5)
+    t = do_rule1_gamma(t, doall=True)
+    assert t == ((-D + 4)**2 + 4)*G(m1)*G(m2)*G(m3)*G(m4) + (4*D - 16)*G(m3)*G(m2)*G(m1)*G(m4) + (4*D - 16)*G(m4)*G(m1)*G(m2)*G(m3) + 4*G(m2)*G(m1)*G(m4)*G(m3) + 4*G(m3)*G(m4)*G(m1)*G(m2) + 4*G(m4)*G(m3)*G(m2)*G(m1)
+
+
+def test_rule2_gamma():
+    p = S1('p')
+    M = Symbol('M')
+    ps = p(m0)*G(-m0)
+    t = ps*ps
+    t = t.canon_bp()
+    t = rule2_gamma(t, 0)
+    assert t == p(m0)*p(-m0)
+
+    t = 2*G(m1)*ps*ps*G(m2)
+    t = rule2_gamma(t, 0)
+    assert t == 2*G(m1)*G(m2)*p(m0)*p(-m0)
+
+    t0 = ps + M
+    t = G(m0)*(ps + M)*G(-m0)
+    t = do_rule1_gamma(t)
+    assert t == (2 - D)*ps + D*M
+
+    t = G(m0)*(ps + M)*G(-m0)*(ps + M)
+    t = do_rule1_gamma(t)
+    t = do_rule2_gamma(t)
+    assert t == (-D + 2)*p(m0)*p(-m0) + (D*M + M*(-D + 2))*G(m0)*p(-m0) + D*M**2
+
+
+def test_gamma_trace():
+    a = [G(m0), G(m1)]
+    t1 = gamma_trace1(*a)
+    a = [G(m0), G(m1), G(m2), G(m3)]
+    t1 = gamma_trace1(*a)
+
+    t = G(m0)*G(m1)
+    t1 = gamma_trace(t)
+    assert t1 == 4*g(m0, m1)
+    t = G(m0)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    t2 = -4*g(m0, m2)*g(m1, m3) + 4*g(m0, m1)*g(m2, m3) + 4*g(m0, m3)*g(m1, m2)
+    st2 = str(t2)
+    assert t1 == t2
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)
+    t1 = gamma_trace(t)
+    assert t1 == (-4*D)*g(m1, m3)*g(m2, m4) + (4*D)*g(m1, m2)*g(m3, m4) + \
+                 (4*D)*g(m1, m4)*g(m2, m3)
+
+    t = G(-m5)*G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)*G(m5)
+    t1 = gamma_trace(t)
+    assert t1 == (32*D + 4*(-D + 4)**2 - 64)*(g(m1, m2)*g(m3, m4) - \
+            g(m1, m3)*g(m2, m4) + g(m1, m4)*g(m2, m3))
+
+    t = G(m0)*G(m1)*G(-m0)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == (-4*D + 8)*g(m1, m3)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(m5)
+    t1 = gamma_trace(t)
+    t2 = t1*g(-m0, -m5)
+    t2 = t2.contract_metric(g)
+    assert t2 == D*gamma_trace(G(m1)*G(m2)*G(m3)*G(m4))
+
+    p, q = S1('p,q')
+    ps = p(m0)*G(-m0)
+    qs = q(m0)*G(-m0)
+    t = ps*qs*ps*qs
+    t1 = gamma_trace(t)
+    assert t1 == 8*p(m0)*q(-m0)*p(m1)*q(-m1) - 4*p(m0)*p(-m0)*q(m1)*q(-m1)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(m5)*G(-m0)*G(-m1)*G(-m2)*G(-m3)*G(-m4)*G(-m5)
+    t1 = gamma_trace(t)
+    t1 = t1.expand_coeff()
+    assert t1.coeff == -4*D**6 + 120*D**5 - 1040*D**4 + 3360*D**3 - 4480*D**2 + 2048*D
+
+
+    # In[1]:= <<Tracer.m
+    # In[2]:= Spur[l];
+    # In[3]:= GammaTrace[l, {m0},{m1},{n1},{m2},{n2},{m3},{m4},{n3},{n4},{m0},{m1},{m2},{m3},{m4}]
+    t = G(m0)*G(m1)*G(n1)*G(m2)*G(n2)*G(m3)*G(m4)*G(n3)*G(n4)*G(-m0)*G(-m1)*G(-m2)*G(-m3)*G(-m4)
+    t1 = gamma_trace(t)
+    t1 = t1.expand_coeff()
+    c1 = -4*D**5 + 120*D**4 - 1200*D**3 + 5280*D**2 - 10560*D + 7808
+    c2 = -4*D**5 + 88*D**4 - 560*D**3 + 1440*D**2 - 1600*D + 640
+    assert t1 == c1*g(n1, n4)*g(n2, n3) + c2*g(n1, n2)*g(n3, n4) + \
+            (-c1)*g(n1, n3)*g(n2, n4)
+
+def test_gamma5():
+    G5 = GM.G5
+    epsilon = GM.epsilon
+    t1 = GM.G5_to_right(2*G5)
+    assert t1 == 2*G5
+    assert gamma_trace(t1) == 0
+
+    t = G5*G(m0)
+    t1 = GM.G5_to_right(t)
+    assert t1 == - G(m0)*G5
+
+    t = G5*G(m0)*G5*G(m1)
+    t1 = GM.G5_to_right(t)
+    assert t1 == -G(m0)*G(m1)
+    t = G5*G(m0)*G5*G(m1)*G5
+    t1 = GM.G5_to_right(t)
+    assert t1 == -G(m0)*G(m1)*G5
+
+    t = (1 + G5)*(1 - G5)
+    t1 = GM.G5_to_right(t)
+    assert t1 == 0
+
+    t = G5*G(m0)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t = G(m0)*G5*G(m1)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t= G5*G(m0)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 4*I*epsilon(m0, m1, m2, m3)
+
+    t= G5*G(m0)*G(-m0)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t= G5*G(m0)*G(-m0)*G(m1)*G(m2)*G(m3)*G(m4)
+    t1 = gamma_trace(t)
+    assert t1 == 4*D*I*epsilon(m1, m2, m3, m4)
+
+    t= G5*G(m0)*G(m1)*G(-m0)*G(m2)*G(m3)*G(m4)
+    t1 = gamma_trace(t)
+    assert t1 == (I*(-4*D + 8))*epsilon(m1, m2, m3, m4)
+
+    t = G(m0)*(1 - G5)
+    t1 = gamma_trace(t)
+    assert t1 == 0
+
+    t = G(m0)*(1 - G5)*G(m1)*G(m2)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 4*I*epsilon(m0, m1, m2, m3) + 4*(g(m0,m1)*g(m2,m3) - \
+            g(m0,m2)*g(m1,m3) + g(m0,m3)*g(m1,m2))
+
+    t = G(m0)*(1 - G5)*G(m1)*(1 + G5)*G(m2)*(1 - G5)*G(m3)
+    t1 = gamma_trace(t)
+    assert t1 == 16*I*epsilon(m0, m1, m2, m3) + 16*(g(m0,m1)*g(m2,m3) - \
+            g(m0,m2)*g(m1,m3) + g(m0,m3)*g(m1,m2))
+
+    M = Symbol('M')
+    p, q = S1('p,q')
+    ps = p(m0)*G(-m0)
+    qs = q(m0)*G(-m0)
+    p2 = p(m0)*p(-m0)
+    q2 = q(m0)*q(-m0)
+    pq = p(m0)*q(-m0)
+    t = (ps + M)*G5*(qs + M)*G5
+    t1 = gamma_trace(t)
+    assert t1 == -4*p(m0)*q(-m0) + 4*M**2
+
+    t = G(m0)*(ps + M)*G(m2)*(ps + qs + M)*G5
+    t1 = gamma_trace(t)
+    assert t1 == -4*I*epsilon(m0,m2,m1,m3)*p(-m1)*q(-m3)
+
+    t = G(m0)*(ps + M)*G(m1)*(ps + qs)*G(m2)*(1 - G5)
+    t1 = gamma_trace(t)
+    assert t1 == 4*M*(-g(m1, m2)*p(m0) -g(m1, m2)*q(m0) + \
+      I*epsilon(m0, m1, m2, m3)*p(-m3) + I*epsilon(m0, m1, m2, m3)*q(-m3) + \
+        g(m0, m1)*p(m2) + g(m0, m1)*q(m2) + g(m0, m2)*p(m1) + g(m0, m2)*q(m1))
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(m5)*G5
+    t1 = gamma_trace(t)
+    t2 = t1*g(-m0, -m2)
+    t2 = t2.contract_metric(g, contract_all=True)
+    assert t2 == (-4*I*D + 8*I)*epsilon(m1, m3, m4, m5)
+
+def test_trace1():
+    M = Symbol('M')
+    p, q = S1('p,q')
+    ps = p(m0)*G(-m0)
+    qs = q(m0)*G(-m0)
+    p2 = p(m0)*p(-m0)
+    q2 = q(m0)*q(-m0)
+    pq = p(m0)*q(-m0)
+
+    t = ps*qs*ps*qs*ps*qs
+    t1 = gamma_trace(t)
+    assert t1 == -12*p2*pq*q2 + 16*pq*pq*pq
+
+    t = ps*qs*ps*qs*ps*qs*ps*qs
+    t1 = gamma_trace(t)
+    assert t1 == -32*pq*pq*p2*q2 + 32*pq*pq*pq*pq + 4*p2*p2*q2*q2
+
+def test_epsilon():
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(n0)*G(n1)*G(n2)*G(n3)*epsilon(-n0,-n1,-n2,-n3)
+
+    t1 = gamma_trace(t)
+    assert t1 == 96*epsilon(m0, m1, m2, m3)

--- a/sympy/tensor/tests/test_dgamma_matr.py
+++ b/sympy/tensor/tests/test_dgamma_matr.py
@@ -172,7 +172,7 @@ def test_gamma_trace():
     t1 = t1.expand_coeff()
     assert t1.coeff == -4*D**6 + 120*D**5 - 1040*D**4 + 3360*D**3 - 4480*D**2 + 2048*D
 
-
+    # checked with Mathematica
     # In[1]:= <<Tracer.m
     # In[2]:= Spur[l];
     # In[3]:= GammaTrace[l, {m0},{m1},{n1},{m2},{n2},{m3},{m4},{n3},{n4},{m0},{m1},{m2},{m3},{m4}]


### PR DESCRIPTION
- [ ] If the only purpose of `GammaMatrices` is to be a container for global variables it should be removed
- [ ] `S1`, `G` and `G5` are `Basic` instances (`TensorType`). Does this make sense? More generally, does it make sense to use classes for all these "factory" functions?
- [ ] `p` and `q` are `Basic` instances (`TensorHead`). Does this make sence?
- [ ] Considering `TensorType` and `TensorHead`: Their semantics clash with the rest of SymPy - throughout this module `type(obj)(*obj.args)==obj` does not hold.
- [ ] `p(-m0)==p(-m1)` raises an error.
- [ ] How much is the use of the strings "Lorentz" and "Euclidean" hardcoded?
- [ ] `factor` and `simplify` raise errors when called on `TensorExpr`
