### PR TITLE
Exponential map of DifferentialOperator: diff_op_exp

### DIFF
--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -10,9 +10,11 @@ TODO:
 """
 
 from sympy import Derivative, Expr
-from sympy.printing.pretty.stringpict import prettyForm
+from sympy.core.function import Function
+from sympy.core.symbol import symbols
 from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.qexpr import QExpr, dispatch_method
+from sympy.printing.pretty.stringpict import prettyForm
 
 __all__ = [
     'Operator',
@@ -514,3 +516,51 @@ class DifferentialOperator(Operator):
         )
         pform = prettyForm(*pform.right((label_pform)))
         return pform
+
+
+def diff_op_exp(diff_op):
+    """
+    Exponential map of a differential operator.
+
+    It takes a DifferentialOperator as parameter, returns a DifferentialOperator
+    representing the exponential map, or raises an exception if it failed.
+
+    Notes
+    =====
+
+    TODO
+
+    Examples
+    ========
+
+    >>> from sympy import symbols, Function
+    >>> from sympy.physics.quantum import DifferentialOperator, Wavefunction
+    >>> from sympy.physics.quantum import qapply
+    >>> from sympy.physics.quantum.operator import diff_op_exp
+    >>> f = Function('f')
+    >>> x = symbols('x')
+    >>> unit_translation_generator = DifferentialOperator(f(x).diff(x), f(x))
+    >>> unit_translation = diff_op_exp(unit_translation_generator)
+    >>> w = Wavefunction(f(x), f(x))
+    >>> qapply(unit_translation * w)
+    Wavefunction(f(x + 1), f(x))
+    >>> a = symbols('a')
+    >>> translation_generator = DifferentialOperator(a * f(x).diff(x), f(x))
+    >>> translation = diff_op_exp(translation_generator)
+    >>> qapply(translation * w)
+    Wavefunction(f(a + x), f(x))
+    """
+    from sympy import pdsolve, Eq, Function, symbols, solve
+    func = Function('func')
+    dfun = diff_op.function
+    arguments = diff_op.function.args
+    t = symbols('t')
+    psol = pdsolve(Eq(func(t, *arguments).diff(t), diff_op.expr.subs(dfun, func(t, *arguments))), func(t, *arguments))
+    Ftransform = psol.args[1]
+    sol_int_args = Ftransform.args
+    avar = symbols('avar')
+    asol = solve([avar * i.subs(t, 0) - j for i, j in zip(sol_int_args, arguments)], avar)[avar]
+    return DifferentialOperator(
+        type(dfun)(*[asol*i.subs(t, 1) for i in sol_int_args]),
+        type(dfun)(*arguments)
+    )

--- a/sympy/physics/quantum/tests/test_operator.py
+++ b/sympy/physics/quantum/tests/test_operator.py
@@ -5,7 +5,7 @@ from sympy.physics.quantum.dagger import Dagger
 from sympy.physics.quantum.hilbert import HilbertSpace
 from sympy.physics.quantum.operator import (Operator, UnitaryOperator,
                                             HermitianOperator, OuterProduct,
-                                            DifferentialOperator)
+                                            DifferentialOperator, diff_op_exp)
 from sympy.physics.quantum.state import Ket, Bra, Wavefunction
 from sympy.physics.quantum.qapply import qapply
 from sympy.core.trace import Tr
@@ -183,3 +183,16 @@ def test_differential_operator():
     assert diff(d, th) == \
         DifferentialOperator(Derivative(d.expr, th), f(r, th))
     assert qapply(d*w) == Wavefunction(3*sin(th), r, (th, 0, pi))
+
+
+def test_diff_op_exp():
+    f = Function('f')
+    x, a = symbols('x, a')
+    unit_translation_generator = DifferentialOperator(1*f(x).diff(x), f(x))
+
+    unit_translation = diff_op_exp(unit_translation_generator)
+    assert qapply(unit_translation * Wavefunction(f(x), f(x))) == Wavefunction(f(x + 1), f(x))
+
+    translation_generator = DifferentialOperator(a * f(x).diff(x), f(x))
+    translation = diff_op_exp(translation_generator)
+    assert qapply(translation * Wavefunction(f(x), f(x))) == Wavefunction(f(x + a), f(x))


### PR DESCRIPTION
A simple function `diff_op_exp()` to perform the exponential map of a DifferentialOperator. It depends on `pdsolve`, it failed in most cases, but works for a simple differential operator (thus generating the translation operator).

It provides a trick to settle the initial condition `f(0, x) == f(x)`.

In order to have better support it is necessary to improve the `pdsolve` function.
