### PR TITLE
Fix issue 3700

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1259,9 +1259,9 @@ class Integral(Expr):
 
             if h is None:
                 try:
-                    manual = manualintegrate(g, x)
-                    if manual is not None and manual.func != Integral:
-                        if manual.has(Integral):
+                    result = manualintegrate(g, x)
+                    if result is not None and not isinstance(result, Integral):
+                        if result.has(Integral):
                             # try to have other algorithms do the integrals
                             # manualintegrate can't handle
                             manual = manual.func(*[

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1271,7 +1271,7 @@ class Integral(Expr):
                                       log=False,
                                       power_exp=False,
                                       power_base=False)
-                        if not result.has(Integral):
+                        if not result.has(Integral) and not result.has(Dummy):
                             parts.append(coeff * result)
                             continue
                 except (ValueError, PolynomialError):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1264,15 +1264,15 @@ class Integral(Expr):
                         if result.has(Integral):
                             # try to have other algorithms do the integrals
                             # manualintegrate can't handle
-                            manual = manual.func(*[
+                            result = result.func(*[
                                 arg.doit() if arg.has(Integral) else arg
-                                for arg in manual.args
+                                for arg in result.args
                             ]).expand(multinomial=False,
                                       log=False,
                                       power_exp=False,
                                       power_base=False)
-                        if not manual.has(Integral):
-                            parts.append(coeff * manual)
+                        if not result.has(Integral):
+                            parts.append(coeff * result)
                             continue
                 except (ValueError, PolynomialError):
                     # can't handle some SymPy expressions

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1271,7 +1271,7 @@ class Integral(Expr):
                                       log=False,
                                       power_exp=False,
                                       power_base=False)
-                        if not result.has(Integral) and not result.has(Dummy):
+                        if not result.has(Integral):
                             parts.append(coeff * result)
                             continue
                 except (ValueError, PolynomialError):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -55,6 +55,19 @@ def evaluates(rule):
         return func
     return _evaluates
 
+def contains_dont_know(rule):
+    if isinstance(rule, DontKnowRule):
+        return True
+    else:
+        for val in rule:
+            if isinstance(val, tuple):
+                if contains_dont_know(val):
+                    return True
+            elif isinstance(val, list):
+                if any(contains_dont_know(i) for i in val):
+                    return True
+    return False
+
 def manual_diff(f, symbol):
     """Derivative of f in form expected by find_substitutions
 
@@ -567,7 +580,7 @@ def substitution_rule(integral):
         ways = []
         for u_func, c, substituted in substitutions:
             subrule = integral_steps(substituted / c, u_var)
-            if isinstance(subrule, DontKnowRule):
+            if contains_dont_know(subrule):
                 continue
 
             if sympy.simplify(c - 1) != 0:

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,5 +1,5 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan,
-                   Symbol, Mul)
+                   Symbol, Mul, Integral, integrate, pi)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, integral_steps
 
 x = Symbol('x')
@@ -75,3 +75,12 @@ def test_manualintegrate_inversetrig():
     assert manualintegrate(1 / (16 + 16 * x**2), x) == atan(x) / 16
     assert manualintegrate(1 / (4 + x**2), x) == atan(x / 2) / 2
     assert manualintegrate(1 / (1 + 4 * x**2), x) == atan(2*x) / 2
+
+def test_issue_3700():
+    r, x, phi = map(Symbol, 'r x phi'.split())
+    n = Symbol('n', integer=True, positive=True)
+
+    assert manualintegrate(cos(n*(x-phi))*cos(n*x), x).has(Integral)
+    integrand = (cos(n*(x-phi))*cos(n*x)).expand(trig=True)
+    limits = (x, -pi, pi)
+    assert r * integrate(integrand, limits) / pi == r * cos(n * phi)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,5 +1,5 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan,
-                   Symbol, Mul, Integral, integrate, pi)
+                   Symbol, Mul, Integral, integrate, pi, Dummy)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, integral_steps
 
 x = Symbol('x')
@@ -80,7 +80,8 @@ def test_issue_3700():
     r, x, phi = map(Symbol, 'r x phi'.split())
     n = Symbol('n', integer=True, positive=True)
 
-    assert manualintegrate(cos(n*(x-phi))*cos(n*x), x).has(Integral)
-    integrand = (cos(n*(x-phi))*cos(n*x)).expand(trig=True)
+    integrand = (cos(n*(x-phi))*cos(n*x))
     limits = (x, -pi, pi)
-    assert r * integrate(integrand, limits) / pi == r * cos(n * phi)
+    assert manualintegrate(integrand, x).has(Integral)
+    assert r * integrate(integrand.expand(trig=True), limits) / pi == r * cos(n * phi)
+    assert not integrate(integrand, limits).has(Dummy)


### PR DESCRIPTION
Changes:
- Manualintegrate:
  - Rewrite rule: do not use if integrand cannot be evaluated with manualintegrate
  - Substitution rule: do not use ConstantTimesRule if constant == 1
  - Added test

Fixes [issue 3700](https://code.google.com/p/sympy/issues/detail?id=3700), but note that the integrand still needs to be `expand`ed to be evaluated.
