### PR TITLE
factor gets deep flag

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5625,8 +5625,8 @@ def factor_list(f, *gens, **args):
 
 def factor(f, *gens, **args):
     """
-    Compute the factorization of ``f`` into irreducibles. (Use factorint to
-    factor an integer.)
+    Compute the factorization of expression, ``f``, into irreducibles. (To
+    factor an integer into primes, use ``factorint``.)
 
     There two modes implemented: symbolic and formal. If ``f`` is not an
     instance of :class:`Poly` and generators are not specified, then the
@@ -5665,7 +5665,33 @@ def factor(f, *gens, **args):
     >>> factor((x**2 + 4*x + 4)**10000000*(x**2 + 1))
     (x + 2)**20000000*(x**2 + 1)
 
+    By default, factor deals with an expression as a whole:
+
+    >>> eq = 2**(x**2 + 2*x + 1)
+    >>> factor(eq)
+    2**(x**2 + 2*x + 1)
+
+    If the ``deep`` flag is True then subexpressions will
+    be factored:
+
+    >>> factor(eq, deep=True)
+    2**((x + 1)**2)
+
+    See Also
+    ========
+    sympy.ntheory.factor_.factorint
+
     """
+    f = sympify(f)
+    if args.pop('deep', False):
+        partials = {}
+        muladd = f.atoms(Mul, Add)
+        for p in muladd:
+            fac = factor(p, *gens, **args)
+            if (fac.is_Mul or fac.is_Pow) and fac != p:
+                partials[p] = fac
+        return f.xreplace(partials)
+
     try:
         return _generic_factor(f, gens, args, method='factor')
     except PolynomialError, msg:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2258,8 +2258,7 @@ def test_factor():
     assert factor_list((2*x)**y, x) == (1, [(2, y), (x, y)])
     assert factor_list(sqrt(x*y), x) == (1, [(x*y, S.Half)])
 
-    assert factor(1) == 1
-    assert factor(6) == 6
+    assert factor(6) == 6 and factor(6).is_Integer
 
     assert factor_list(3*x) == (3, [(x, 1)])
     assert factor_list(3*x**2) == (3, [(x, 2)])
@@ -2331,9 +2330,7 @@ def test_factor():
     assert factor(x - 1) == x - 1
     assert factor(-x - 1) == -x - 1
 
-    # We can't use this, because Mul clears out 1, even with evaluate=False
-    # assert factor(x - 1) != Mul(1, x - 1, evaluate=False)
-    assert not factor(x - 1).is_Mul
+    assert factor(x - 1) == x - 1
 
     assert factor(6*x - 10) == Mul(2, 3*x - 5, evaluate=False)
 
@@ -2385,6 +2382,9 @@ def test_factor():
     1) - x*(x - 1) - x) - (-2*x**2*(x - 1)**2 - x*(-x + 1)*(-x*(-x + 1) +
     x*(x - 1)))*(x**2*(x - 1)**4 - x*(-x*(-x + 1)*(x - 1) - x*(x - 1)**2)))
     assert factor(e) == 0
+
+    # deep option
+    assert factor(sin(x**2 + x) + x, deep=True) == sin(x*(x + 1)) + x
 
 
 def test_factor_large():


### PR DESCRIPTION
This allows factor to work inside functions:

e.g in answering the question, "What is the angle subtended by a circle of radius r that is a distance d from the origin?":

```
>>> t=Circle((d,0),r).tangent_lines((0,0)) 
>>> a=t[0].angle_between(t[1]) 
>>> simplify(a)
acos((d**4 - 3*d**2*r**2 + 2*r**4)/(d**2*(d**2 - r**2)))
>>> factor(_)
acos(d**4/(d**4 - d**2*r**2) - 3*d**2*r**2/(d**4 - d**2*r**2) + 2*r**4/(d**4 - d **2*r**2))
>>> factor(_, deep=1)
acos(-(-d**2 + 2*r**2)/d**2)
>>> expand(_)
acos(1 - 2*r**2/d**2)
```

That last expression is a lot nicer than the default form obtained from factor.
