### PR TITLE
watch for -Add exponents in factor_terms

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -104,14 +104,14 @@ class Pow(Expr):
                 # recognize base as E
                 if not e.is_Atom and b is not S.Exp1 and b.func is not exp_polar:
                     from sympy import numer, denom, log, sign, im, factor_terms
-                    c, ex = factor_terms(e).as_coeff_Mul()
+                    c, ex = factor_terms(e, sign=False).as_coeff_Mul()
                     den = denom(ex)
                     if den.func is log and den.args[0] == b:
                         return S.Exp1**(c*numer(ex))
                     elif den.is_Add:
                         s = sign(im(b))
                         if s.is_Number and s and den == \
-                                log(-b) + s*S.ImaginaryUnit*S.Pi:
+                                log(-factor_terms(b, sign=False)) + s*S.ImaginaryUnit*S.Pi:
                             return S.Exp1**(c*numer(ex))
 
                 obj = b._eval_power(e)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -180,6 +180,7 @@ def test_pow_E():
     assert 2**(y/log(2)/3) == S.Exp1**(y/3)
     assert 3**(1/log(-3)) != S.Exp1
     assert (3 + 2*I)**(1/(log(-3 - 2*I) + I*pi)) == S.Exp1
+    assert (4 + 2*I)**(1/(log(-4 - 2*I) + I*pi)) == S.Exp1
     assert (3 + 2*I)**(1/(log(-3 - 2*I, 3)/2 + I*pi/log(3)/2)) == 9
     assert (3 + 2*I)**(1/(log(3 + 2*I, 3)/2)) == 9
     # every time tests are run they will affirm with a different random

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -2,7 +2,7 @@
 
 from sympy import (S, Add, sin, Mul, Symbol, oo, Integral, sqrt, Tuple, I,
                    Interval, O, symbols, simplify, collect, Sum, Basic, Dict,
-                   root)
+                   root, exp)
 from sympy.abc import a, b, t, x, y, z
 from sympy.core.exprtools import (decompose_power, Factors, Term, _gcd_terms,
                                   gcd_terms, factor_terms, factor_nc)
@@ -257,9 +257,16 @@ def test_factor_terms():
     assert factor_terms((1/(x**3 + x**2) + 2/x**2)*y) == \
         y*(2 + 1/(x + 1))/x**2
 
-    assert factor_terms(-x - y) == Mul(-1, x + y, evaluate=False)
     # if not True, then processesing for this in factor_terms is not necessary
     assert gcd_terms(-x - y) == -x - y
+    assert factor_terms(-x - y) == Mul(-1, x + y, evaluate=False)
+
+    # if not True, then "special" processesing in factor_terms is not necessary
+    assert gcd_terms(exp(Mul(-1, x + 1))) == exp(-x - 1)
+    e = exp(-x - 2) + x
+    assert factor_terms(e) == exp(Mul(-1, x + 2, evaluate=False)) + x
+    assert factor_terms(e, sign=False) == e
+    assert factor_terms(exp(-4*x - 2) - x) == -x + exp(Mul(-2, 2*x + 1, evaluate=False))
 
 
 def test_xreplace():

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -785,14 +785,15 @@ def test_M6():
 def test_M7():
     assert set(solve(x**8 - 8*x**7 + 34*x**6 - 92*x**5 + 175*x**4 - 236*x**3 +
         226*x**2 - 140*x + 46, x)) == set([
-        1 + sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
+        1 + sqrt(2)*I*sqrt(sqrt(-3 + 4*sqrt(3)) + 3)/2,
         1 + sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
         1 - sqrt(2)*sqrt(-3 + I*sqrt(3 + 4*sqrt(3)))/2,
+        1 - sqrt(2)*I*sqrt(sqrt(-3 + 4*sqrt(3)) + 3)/2,
         1 + sqrt(2)*sqrt(-3 - I*sqrt(3 + 4*sqrt(3)))/2,
         1 + sqrt(2)*sqrt(-3 + I*sqrt(3 + 4*sqrt(3)))/2,
         1 - sqrt(2)*sqrt(-3 - I*sqrt(3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 - sqrt(-3 + 4*sqrt(3)))/2,
-        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,])
+        1 - sqrt(2)*sqrt(-3 + sqrt(-3 + 4*sqrt(3)))/2,
+        ])
 
 
 @XFAIL  # There are an infinite number of solutions.

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -674,8 +674,8 @@ def test_cosine_transform():
     assert cosine_transform(exp(-a*sqrt(t))*cos(a*sqrt(
         t)), t, w) == a*exp(-a**2/(2*w))/(2*w**(S(3)/2))
 
-    assert cosine_transform(1/(a + t), t, w) == -sqrt(2)*(
-        (2*Si(a*w) - pi)*sin(a*w)/2 + cos(a*w)*Ci(a*w))/sqrt(pi)
+    assert cosine_transform(1/(a + t), t, w) == sqrt(2)*(
+        (-2*Si(a*w) + pi)*sin(a*w)/2 - cos(a*w)*Ci(a*w))/sqrt(pi)
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S(1)/2, 0), ()), (
         (S(1)/2, 0, 0), (S(1)/2,)), a**2*w**2/4)/(2*pi), w, t) == 1/(a + t)
 


### PR DESCRIPTION
If the exponent of a power is -Add, gcd_terms will rewrite it
distributing the -1 because of how Terms and Factors works, so
watch out for that.

now `factor_terms(exp(-x-2) + x)` will become `exp(-(x+2))+x` instead of being unchanged.
