### PR TITLE
ask(Q.foo_elements(MatMul(...))) handles scalar args

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -5,7 +5,10 @@ infinitesimal, bounded, etc.
 from sympy.logic.boolalg import conjuncts
 from sympy.assumptions import Q, ask
 from sympy.assumptions.handlers import CommonHandler, test_closed_group
-from sympy.matrices.expressions import MatMul
+from sympy.matrices.expressions import MatMul, MatrixExpr
+from sympy.core.logic import fuzzy_and
+from sympy.utilities.iterables import sift
+from sympy.core import Basic
 from functools import partial
 
 class AskSquareHandler(CommonHandler):
@@ -388,15 +391,24 @@ def MS_elements(predicate, expr, assumptions):
     """ Matrix Slice elements """
     return ask(predicate(expr.parent), assumptions)
 
+def MatMul_elements(matrix_predicate, scalar_predicate, expr, assumptions):
+    d = sift(expr.args, lambda x: isinstance(x, MatrixExpr))
+    factors, matrices = d[False], d[True]
+    return fuzzy_and(
+        test_closed_group(Basic(*factors), assumptions, scalar_predicate),
+        test_closed_group(Basic(*matrices), assumptions, matrix_predicate))
+
 class AskIntegerElementsHandler(CommonHandler):
     @staticmethod
     def MatAdd(expr, assumptions):
         return test_closed_group(expr, assumptions, Q.integer_elements)
 
-    HadamardProduct = MatMul = Determinant = Trace = Transpose = MatAdd
+    HadamardProduct = Determinant = Trace = Transpose = MatAdd
 
     ZeroMatrix = Identity = staticmethod(CommonHandler.AlwaysTrue)
 
+    MatMul = staticmethod(partial(MatMul_elements, Q.integer_elements,
+                                                   Q.integer))
     MatrixSlice = staticmethod(partial(MS_elements, Q.integer_elements))
     BlockMatrix = staticmethod(partial(BM_elements, Q.integer_elements))
 
@@ -405,9 +417,9 @@ class AskRealElementsHandler(CommonHandler):
     def MatAdd(expr, assumptions):
         return test_closed_group(expr, assumptions, Q.real_elements)
 
-    HadamardProduct = MatMul = Determinant = Trace = Transpose = Inverse =\
-            MatAdd
+    HadamardProduct = Determinant = Trace = Transpose = Inverse = MatAdd
 
+    MatMul = staticmethod(partial(MatMul_elements, Q.real_elements, Q.real))
     MatrixSlice = staticmethod(partial(MS_elements, Q.real_elements))
     BlockMatrix = staticmethod(partial(BM_elements, Q.real_elements))
 
@@ -417,9 +429,10 @@ class AskComplexElementsHandler(CommonHandler):
     def MatAdd(expr, assumptions):
         return test_closed_group(expr, assumptions, Q.complex_elements)
 
-    HadamardProduct = MatMul = Determinant = Trace = Transpose = Inverse =\
-             MatAdd
+    HadamardProduct = Determinant = Trace = Transpose = Inverse = MatAdd
 
+    MatMul = staticmethod(partial(MatMul_elements, Q.complex_elements,
+                                                   Q.complex))
     MatrixSlice = staticmethod(partial(MS_elements, Q.complex_elements))
     BlockMatrix = staticmethod(partial(BM_elements, Q.complex_elements))
 

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -1,4 +1,4 @@
-from sympy import Q, ask
+from sympy import Q, ask, Symbol
 from sympy.matrices.expressions import (MatrixSymbol, Identity, ZeroMatrix,
         Trace, MatrixSlice, Determinant)
 from sympy.utilities.pytest import XFAIL
@@ -169,6 +169,8 @@ def test_field_assumptions():
     assert ask(Q.real_elements(Trace(X)), Q.real_elements(X))
     assert ask(Q.integer_elements(Determinant(X)), Q.integer_elements(X))
     assert not ask(Q.integer_elements(X.I), Q.integer_elements(X))
+    alpha = Symbol('alpha')
+    assert ask(Q.real_elements(alpha*X), Q.real_elements(X) & Q.real(alpha))
 
 def test_matrix_element_sets():
     X = MatrixSymbol('X', 4, 4)

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -431,6 +431,9 @@ class ZeroMatrix(MatrixExpr):
     def _entry(self, i, j):
         return S.Zero
 
+    def __nonzero__(self):
+        return False
+
 
 def matrix_symbols(expr):
     return [sym for sym in expr.free_symbols if sym.is_Matrix]

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -51,6 +51,8 @@ def test_ZeroMatrix():
     assert Z*A.T == ZeroMatrix(n, n)
     assert A - A == ZeroMatrix(*A.shape)
 
+    assert not Z
+
     assert transpose(Z) == ZeroMatrix(m, n)
     assert Z.conjugate() == Z
 


### PR DESCRIPTION
Previously 

``` Python
>>> print ask(Q.real_elements(alpha*X), Q.real(alpha) & Q.real_elements(X))
None
```

Now

``` Python
>>> print ask(Q.real_elements(alpha*X), Q.real(alpha) & Q.real_elements(X))
True
```
