### PR TITLE
 improved factorization of integer polynomials

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -254,7 +254,7 @@ def _test_pl(fc, q, pl):
     if q > pl // 2:
         q = q - pl
     if not q:
-        return False
+        return True
     return fc % q == 0
 
 @cythonized("l,s")

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -272,24 +272,29 @@ def dup_zz_zassenhaus(f, K):
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
     bound = int(2*gamma*_log(gamma))
-
-    for p in xrange(3, bound + 1):
-        if not isprime(p) or b % p == 0:
+    a = []
+    # choose a prime number `p` such that `f` be square free in Z_p
+    # if there are many factors in Z_p, choose among a few different `p`
+    # the one with fewer factors
+    for px in xrange(3, bound + 1):
+        if not isprime(px) or b % px == 0:
             continue
 
-        p = K.convert(p)
+        px = K.convert(px)
 
-        F = gf_from_int_poly(f, p)
+        F = gf_from_int_poly(f, px)
 
-        if gf_sqf_p(F, p, K):
+        if not gf_sqf_p(F, px, K):
+            continue
+        fsqfx = gf_factor_sqf(F, px, K)[1]
+        a.append((px, fsqfx))
+        if len(fsqfx) < 15 or len(a) > 4:
             break
+    p, fsqf = min(a, key=lambda x: len(x[1]))
 
     l = int(_ceil(_log(2*B + 1, p)))
 
-    modular = []
-
-    for ff in gf_factor_sqf(F, p, K)[1]:
-        modular.append(gf_to_int_poly(ff, p))
+    modular = [gf_to_int_poly(ff, p) for ff in fsqf]
 
     g = dup_zz_hensel_lift(p, f, modular, l, K)
 

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -32,6 +32,7 @@ from sympy.utilities import cythonized, subsets
 @cythonized("n,i")
 def swinnerton_dyer_poly(n, x=None, **args):
     """Generates n-th Swinnerton-Dyer polynomial in `x`.  """
+    from numberfields import minimal_polynomial
     if n <= 0:
         raise ValueError(
             "can't generate Swinnerton-Dyer polynomial of order %s" % n)
@@ -43,6 +44,14 @@ def swinnerton_dyer_poly(n, x=None, **args):
 
     p, elts = 2, [[x, -sqrt(2)],
                   [x, sqrt(2)]]
+
+    if n > 3:
+        a = [sqrt(2)]
+        for i in xrange(2, n + 1):
+            p = nextprime(p)
+            a.append(sqrt(p))
+        p = minimal_polynomial(Add(*a), x, polys=args.get('polys', False))
+        return p
 
     for i in xrange(2, n + 1):
         p, _elts = nextprime(p), []

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -29,7 +29,6 @@ from sympy.ntheory import nextprime
 from sympy.utilities import cythonized, subsets
 
 
-@cythonized("n,i")
 def swinnerton_dyer_poly(n, x=None, **args):
     """Generates n-th Swinnerton-Dyer polynomial in `x`.  """
     from numberfields import minimal_polynomial
@@ -38,43 +37,28 @@ def swinnerton_dyer_poly(n, x=None, **args):
             "can't generate Swinnerton-Dyer polynomial of order %s" % n)
 
     if x is not None:
-        x, cls = sympify(x), Poly
+        sympify(x)
     else:
-        x, cls = Dummy('x'), PurePoly
-
-    p, elts = 2, [[x, -sqrt(2)],
-                  [x, sqrt(2)]]
+        x = Dummy('x')
 
     if n > 3:
+        p = 2
         a = [sqrt(2)]
         for i in xrange(2, n + 1):
             p = nextprime(p)
             a.append(sqrt(p))
-        p = minimal_polynomial(Add(*a), x, polys=args.get('polys', False))
-        return p
+        return minimal_polynomial(Add(*a), x, polys=args.get('polys', False))
 
-    for i in xrange(2, n + 1):
-        p, _elts = nextprime(p), []
-
-        neg_sqrt = -sqrt(p)
-        pos_sqrt = +sqrt(p)
-
-        for elt in elts:
-            _elts.append(elt + [neg_sqrt])
-            _elts.append(elt + [pos_sqrt])
-
-        elts = _elts
-
-    poly = []
-
-    for elt in elts:
-        poly.append(Add(*elt))
-
+    if n == 1:
+        ex = x**2 - 2
+    elif n == 2:
+        ex = x**4 - 10*x**2 + 1
+    elif n == 3:
+        ex = x**8 - 40*x**6 + 352*x**4 - 960*x**2 + 576
     if not args.get('polys', False):
-        return Mul(*poly).expand()
+        return ex
     else:
-        return PurePoly(Mul(*poly), x)
-
+        return PurePoly(ex, x)
 
 def cyclotomic_poly(n, x=None, **args):
     """Generates cyclotomic polynomial of order `n` in `x`. """

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -23,6 +23,7 @@ from sympy.polys.polyerrors import (
 
 from sympy.polys.polyclasses import DMP
 from sympy.polys.domains import QQ
+from sympy.polys.polytools import degree
 from sympy.solvers import solve
 
 from sympy.utilities.pytest import skip
@@ -236,11 +237,6 @@ def test_minpoly_compose():
         24*sqrt(10)*sqrt(-sqrt(5) + 5))**2) + 1
     raises(ZeroDivisionError, lambda: minimal_polynomial(ex, x))
 
-def test_minpoly_compose1():
-    skip("This test hangs.")
-    # this test hangs because factor_list hangs in minpoly_op_algebraic_number
-    # on a polynomial of degree 96, which is factored by Sage very fast;
-    # one of the factors is the minimal polynomial.
     ex = sqrt(1 + 2**Rational(1,3)) + sqrt(1 + 2**Rational(1,4)) + sqrt(2)
     mp = minimal_polynomial(ex, x)
     assert degree(mp) == 48 and mp.subs({x:0}) == -16630256576


### PR DESCRIPTION
Optimized loop over subsets in `dup_zz_zassenhaus` and attempted to choose `p`
such that there are  fewer factorizations over Z_p[x].

For example

```
>>> minpoly(S('sqrt(1 + 2**(1/5)) + 2**(1/5)*sqrt(1 + 2**(1/5))'), x)
x**10 - 5*x**8 - 20*x**6 - 280*x**4 - 55*x**2 - 27
```

in this PR takes 1.7 seconds on my computer, in master much longer, 10 minutes.
