### PR TITLE
Sort output of dotprint according to args ordering

### DIFF
--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -117,7 +117,7 @@ template = \
 %(edges)s
 }"""
 
-graphstyle = {'rankdir': 'TD'}
+graphstyle = {'rankdir': 'TD', 'ordering': 'out'}
 
 def dotprint(expr, styles=default_styles, atom=lambda x: not isinstance(x,
     Basic), maxdepth=None, repeat=True, labelfunc=str, **kwargs):
@@ -161,22 +161,23 @@ def dotprint(expr, styles=default_styles, atom=lambda x: not isinstance(x,
     digraph{
     <BLANKLINE>
     # Graph style
+    "ordering"="out"
     "rankdir"="TD"
     <BLANKLINE>
     #########
     # Nodes #
     #########
     <BLANKLINE>
-    "Symbol(x)_(1,)" ["color"="black", "label"="x", "shape"="ellipse"];
-    "Integer(2)_(0,)" ["color"="black", "label"="2", "shape"="ellipse"];
     "Add(Integer(2), Symbol(x))_()" ["color"="black", "label"="Add", "shape"="ellipse"];
+    "Integer(2)_(0,)" ["color"="black", "label"="2", "shape"="ellipse"];
+    "Symbol(x)_(1,)" ["color"="black", "label"="x", "shape"="ellipse"];
     <BLANKLINE>
     #########
     # Edges #
     #########
     <BLANKLINE>
-    "Add(Integer(2), Symbol(x))_()" -> "Symbol(x)_(1,)";
     "Add(Integer(2), Symbol(x))_()" -> "Integer(2)_(0,)";
+    "Add(Integer(2), Symbol(x))_()" -> "Symbol(x)_(1,)";
     }
 
     """
@@ -196,5 +197,5 @@ def dotprint(expr, styles=default_styles, atom=lambda x: not isinstance(x,
     traverse(expr, 0)
 
     return template%{'graphstyle': attrprint(graphstyle, delimiter='\n'),
-                     'nodes': '\n'.join(sorted(set(nodes), key=len)),
-                     'edges': '\n'.join(sorted(set(edges), key=len))}
+                     'nodes': '\n'.join(nodes),
+                     'edges': '\n'.join(edges)}


### PR DESCRIPTION
This makes the output to the dotfile use this ordering (previously it used
len), and also adds the ordering="out" flag to the file (see
http://stackoverflow.com/a/9216782/161801).

I didn't add a way to change the ordering.  The previous one, len, would
roughly order the nodes from biggest to smallest, but not exactly, since it
was a len on the string rather than a len on the nodes.

@mrocklin
