### PR TITLE
enable limits for certain sums of rational functions

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -163,8 +163,13 @@ def limit(e, z, z0, dir="+"):
                             return -oo*i
 
     if e.is_Add:
-        if e.is_polynomial() and not z0.is_unbounded:
-            return Add(*[limit(term, z, z0, dir) for term in e.args])
+        if e.is_polynomial():
+            if not z0.is_unbounded:
+                return Add(*[limit(term, z, z0, dir) for term in e.args])
+        elif e.is_rational_function(z):
+            rval = Add(*[limit(term, z, z0, dir) for term in e.args])
+            if rval != S.NaN:
+                return rval
 
         # this is a case like limit(x*y+x*z, z, 2) == x*y+2*x
         # but we need to make sure, that the general gruntz() algorithm is

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -357,6 +357,10 @@ def test_polynomial():
     assert limit((x + 1)**1000/((x + 1)**1000 + 1), x, oo) == 1
     assert limit((x + 1)**1000/((x + 1)**1000 + 1), x, -oo) == 1
 
+def test_rational():
+    assert limit(1/y - ( 1/(y+x) + x/(y+x)/y )/z,x,oo) ==  1/y - 1/(y*z)
+    assert limit(1/y - ( 1/(y+x) + x/(y+x)/y )/z,x,-oo) ==  1/y - 1/(y*z)
+
 
 def test_issue_2641():
     assert limit(log(x)/z - log(2*x)/z, x, 0) == -log(2)/z


### PR DESCRIPTION
I found a bug in the evaluation of limits of some complicated sums of rational functions.  This is a small change that fixes the issue, allong with a confirming test.
