### PR TITLE
Implement __long__

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -228,6 +228,7 @@ class Expr(Basic, EvalfMixin):
             if diff_sign != isign:
                 i -= isign
         return i
+    __long__ = __int__
 
     def __float__(self):
         # Don't bother testing if it's a number; if it's not this is going

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -212,7 +212,7 @@ class Number(AtomicExpr):
 
         if isinstance(obj, Number):
             return obj
-        if isinstance(obj, (int, long)):
+        if isinstance(obj, SYMPY_INTS):
             return Integer(obj)
         if isinstance(obj, tuple) and len(obj) == 2:
             return Rational(*obj)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -814,6 +814,8 @@ class Float(Number):
             return 0
         return int(mlib.to_int(self._mpf_))  # uses round_fast = round_down
 
+    __long__ = __int__
+
     def __eq__(self, other):
         if isinstance(other, float):
             # coerce to Float at same precision
@@ -1272,6 +1274,8 @@ class Rational(Number):
             return -(-p//q)
         return p//q
 
+    __long__ = __int__
+
     def __eq__(self, other):
         try:
             other = _sympify(other)
@@ -1547,6 +1551,8 @@ class Integer(Rational):
     # Arithmetic operations are here for efficiency
     def __int__(self):
         return self.p
+
+    __long__ = __int__
 
     def __neg__(self):
         return Integer(-self.p)
@@ -2480,6 +2486,8 @@ class NumberSymbol(AtomicExpr):
         # subclass with appropriate return value
         raise NotImplementedError
 
+    __long__ = __int__
+
     def __hash__(self):
         return super(NumberSymbol, self).__hash__()
 
@@ -2500,6 +2508,8 @@ class Exp1(NumberSymbol):
 
     def __int__(self):
         return 2
+
+    __long__ = __int__
 
     def _as_mpf_val(self, prec):
         return mpf_e(prec)
@@ -2544,6 +2554,8 @@ class Pi(NumberSymbol):
     def __int__(self):
         return 3
 
+    __long__ = __int__
+
     def _as_mpf_val(self, prec):
         return mpf_pi(prec)
 
@@ -2571,6 +2583,8 @@ class GoldenRatio(NumberSymbol):
 
     def __int__(self):
         return 1
+
+    __long__ = __int__
 
     def _as_mpf_val(self, prec):
          # XXX track down why this has to be increased
@@ -2605,6 +2619,8 @@ class EulerGamma(NumberSymbol):
     def __int__(self):
         return 0
 
+    __long__ = __int__
+
     def _as_mpf_val(self, prec):
          # XXX track down why this has to be increased
         v = mlib.libhyper.euler_fixed(prec + 10)
@@ -2634,6 +2650,8 @@ class Catalan(NumberSymbol):
 
     def __int__(self):
         return 0
+
+    __long__ = __int__
 
     def _as_mpf_val(self, prec):
         # XXX track down why this has to be increased

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2553,8 +2553,6 @@ class Pi(NumberSymbol):
     def __int__(self):
         return 3
 
-
-
     def _as_mpf_val(self, prec):
         return mpf_pi(prec)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2486,7 +2486,8 @@ class NumberSymbol(AtomicExpr):
         # subclass with appropriate return value
         raise NotImplementedError
 
-    __long__ = __int__
+    def __long__(self):
+        return self.__int__()
 
     def __hash__(self):
         return super(NumberSymbol, self).__hash__()
@@ -2508,8 +2509,6 @@ class Exp1(NumberSymbol):
 
     def __int__(self):
         return 2
-
-    __long__ = __int__
 
     def _as_mpf_val(self, prec):
         return mpf_e(prec)
@@ -2554,7 +2553,7 @@ class Pi(NumberSymbol):
     def __int__(self):
         return 3
 
-    __long__ = __int__
+
 
     def _as_mpf_val(self, prec):
         return mpf_pi(prec)
@@ -2583,8 +2582,6 @@ class GoldenRatio(NumberSymbol):
 
     def __int__(self):
         return 1
-
-    __long__ = __int__
 
     def _as_mpf_val(self, prec):
          # XXX track down why this has to be increased
@@ -2619,8 +2616,6 @@ class EulerGamma(NumberSymbol):
     def __int__(self):
         return 0
 
-    __long__ = __int__
-
     def _as_mpf_val(self, prec):
          # XXX track down why this has to be increased
         v = mlib.libhyper.euler_fixed(prec + 10)
@@ -2650,8 +2645,6 @@ class Catalan(NumberSymbol):
 
     def __int__(self):
         return 0
-
-    __long__ = __int__
 
     def _as_mpf_val(self, prec):
         # XXX track down why this has to be increased

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -945,6 +945,16 @@ def test_int():
     assert int(E) == 2
     assert int(GoldenRatio) == 1
 
+def test_long():
+    a = Rational(5)
+    assert long(a) == 5
+    a = Rational(9, 10)
+    assert long(a) == long(-a) == 0
+    a = Integer(2**100)
+    assert long(a) == a
+    assert long(pi) == 3
+    assert long(E) == 2
+    assert long(GoldenRatio) == 1
 
 def test_real_bug():
     x = Symbol("x")


### PR DESCRIPTION
It is the same as **int**, because Python automatically coerces the output to 
long().  That is also why we do not even test that the output is an instance 
of long.

This fixes issue 3858.
