### PR TITLE
Add elliptic integrals E and K to the Meijer-G tables

### DIFF
--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -251,6 +251,11 @@ def _create_lookup_table(table):
     add(besselk(a, t), [], [], [a/2, -a/2], [], t**2/4, S(1)/2)
     # TODO many more formulas. should all be derivable
 
+    # Complete elliptic integrals
+    from sympy import elliptic_e, elliptic_k
+    add(elliptic_e(t), [S.Half, 3*S.Half], [], [0], [0], -t, S.Half/2)
+    add(elliptic_k(t), [S.Half, S.Half], [], [0], [0], -t, S.Half)
+
 
 ####################################################################
 # First some helper functions.

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -251,10 +251,10 @@ def _create_lookup_table(table):
     add(besselk(a, t), [], [], [a/2, -a/2], [], t**2/4, S(1)/2)
     # TODO many more formulas. should all be derivable
 
-    # Complete elliptic integrals
-    from sympy import elliptic_e, elliptic_k
-    add(elliptic_e(t), [S.Half, 3*S.Half], [], [0], [0], -t, S.Half/2)
+    # Complete elliptic integrals K(z) and E(z)
+    from sympy import elliptic_k, elliptic_e
     add(elliptic_k(t), [S.Half, S.Half], [], [0], [0], -t, S.Half)
+    add(elliptic_e(t), [S.Half, 3*S.Half], [], [0], [0], -t, -S.Half/2)
 
 
 ####################################################################

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -135,8 +135,19 @@ def add_formulae(formulae):
          Matrix([HyperRep_asin2(z), 1]), Matrix([[1, 0]]),
          Matrix([[(z - S.Half)/(1 - z), 1/(1 - z)/2], [0, 0]]))
 
-    add((S.Half, S.Half), (S.One, ), 2*elliptic_k(z)/pi)
-    add((-S.Half, S.Half), (S.One, ), 2*elliptic_e(z)/pi)
+    # Complete elliptic integrals K(z) and E(z), both a 2F1 function
+    #add((S.Half, S.Half), (S.One, ), 2*elliptic_k(z)/pi)
+    #add((-S.Half, S.Half), (S.One, ), 2*elliptic_e(z)/pi)
+    addb([S.Half, S.Half], [S.One],
+         Matrix([elliptic_k(z), elliptic_e(z)]),
+         Matrix([[2/pi, 0]]),
+         Matrix([[-S.Half, -1/(2*z-2)],
+                 [-S.Half, S.Half]]))
+    addb([-S.Half, S.Half], [S.One],
+         Matrix([elliptic_k(z), elliptic_e(z)]),
+         Matrix([[0, 2/pi]]),
+         Matrix([[-S.Half, -1/(2*z-2)],
+                 [-S.Half, S.Half]]))
 
     # 3F2
     addb([-S.Half, 1, 1], [S.Half, 2],


### PR DESCRIPTION
Add elliptic integrals E and K to the Meijer-G tables

```
In [3]: elliptic_e(x)
Out[3]: elliptic_e(x)

In [4]: integrate(_, x, meijerg=True)
Out[4]: -2*x*elliptic_e(x*exp_polar(2*I*pi))/3 - 2*x*elliptic_k(x*exp_polar(2*I*pi))/3 - 2*elliptic_e(x*exp_polar(2*I*pi))/3 + 2*elliptic_k(x*exp_polar(2*I*pi))/3
```

```
In [6]: elliptic_k(x)
Out[6]: elliptic_k(x)

In [7]: integrate(_, x, meijerg=True)
Out[7]: 2*x*elliptic_k(x*exp_polar(2*I*pi)) + 2*elliptic_e(x*exp_polar(2*I*pi)) - 2*elliptic_k(x*exp_polar(2*I*pi))

```
