### PR TITLE
Smartify CythonCodeWrapper in autowrap module

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -303,10 +303,15 @@ setup(
                                     dimension_args[args_py_names[atom]] = (arg, idx)
             args_py = filter(lambda x: x not in dimension_args.keys(), args_py)
             # now args_py does not contain any dimension_args
-            print >> f, "def %s_c(%s, %s):" % (routine.name,
+
+            if len(dimension_args) > 0:
+                kwargs_str = ", " + ", ".join(self._declare_arg(arg) + "=-1 " for arg in dimension_args.keys())
+            else:
+                kwargs_str = ''
+
+            print >> f, "def %s_c(%s%s):" % (routine.name,
                     ", ".join(self._declare_arg(arg) for arg in args_py),
-                                               ", ".join(self._declare_arg(arg) + "=-1 " for arg in dimension_args.keys())
-                                          )
+                                             kwargs_str)
             for dimarg, (arg, idx) in dimension_args.items():
                 print >> f, "   if %s == -1:" % str(dimarg.name)
                 print >> f, "       %s = %s.shape[%s]" % (str(dimarg.name),str(arg.name), str(idx))

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -339,7 +339,7 @@ setup(
             args_lst = []
             for a in routine.arguments:
                 if a.dimensions:
-                    args_lst.append('&{}[{}]'.format(
+                    args_lst.append('&%s[%s]' % (
                         str(a.name), ', '.join(
                             [str(low) for low,high in a.dimensions]
                         )

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -209,8 +209,17 @@ class CythonCodeWrapper(CodeWrapper):
     setup_template = """
 from distutils.core import setup
 from distutils.extension import Extension
-from Cython.Distutils import build_ext
 
+# The convention to import modules with minimum version requirements
+# in sympy is to use import_module
+from sympy.external import import_module
+
+# The use of Typed Memoryviews mandates Cython 0.16
+# Cython.Distutils does not carry any version information
+# Hence we import Cython first with version req. Then
+# we do the needed import
+Cython = import_module('Cython', min_module_version='0.16')
+from Cython.Distutils import build_ext
 import numpy as np
 
 setup(

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -293,7 +293,7 @@ setup(
             # wrap
             ret, args_py = self._split_retvals_inargs(routine.arguments)
             dimension_args = {}
-            args_py_names = {x.name: x for x in args_py}
+            args_py_names = dict([(x.name, x) for x in args_py])
             for arg in args_py:
                 if arg.dimensions:
                     for idx, (lower, upper) in enumerate(arg.dimensions):

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -211,9 +211,11 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 
+import numpy as np
+
 setup(
     cmdclass = {'build_ext': build_ext},
-    ext_modules = [Extension(%(args)s, extra_compile_args=['-std=c99'])]
+    ext_modules = [Extension(%(args)s, include_dirs=[np.get_include()], extra_compile_args=['-std=c99'])]
         )
 """
 

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -140,12 +140,12 @@ def test_ufuncify():
 def test_ufuncify_cython():
     import numpy as np
     x, y = symbols('x y')
-    f = ufuncify((x, y), x + y, language='C', backend='Cython', tempdir='/tmp/tmp')
+    f = ufuncify((x, y), x + y, language='C', backend='Cython')
     assert np.allclose(f(np.arange(10.0), 1.0), np.arange(10.0)+1.0)
 
 
 def test_ufuncify_f2py():
     import numpy as np
     x, y = symbols('x y')
-    f = ufuncify((x, y), x + y, language='F95', backend='f2py', tempdir='/tmp/tmp2')
+    f = ufuncify((x, y), x + y, language='F95', backend='f2py')
     assert np.allclose(f(np.arange(10.0), 1.0), np.arange(10.0)+1.0)

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -135,3 +135,17 @@ def test_ufuncify():
     x, y = symbols('x y')
     f = ufuncify((x, y), x + y, backend='dummy')
     assert f() == "f(_x[_i], y)"
+
+
+def test_ufuncify_cython():
+    import numpy as np
+    x, y = symbols('x y')
+    f = ufuncify((x, y), x + y, language='C', backend='Cython')
+    assert np.allclose(f(np.arange(10), 1.0), np.arange(10)+1.0)
+
+
+def test_ufuncify_f2py():
+    import numpy as np
+    x, y = symbols('x y')
+    f = ufuncify((x, y), x + y, language='F95', backend='f2py')
+    assert np.allclose(f(np.arange(10), 1.0), np.arange(10)+1.0)

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -140,12 +140,12 @@ def test_ufuncify():
 def test_ufuncify_cython():
     import numpy as np
     x, y = symbols('x y')
-    f = ufuncify((x, y), x + y, language='C', backend='Cython')
-    assert np.allclose(f(np.arange(10), 1.0), np.arange(10)+1.0)
+    f = ufuncify((x, y), x + y, language='C', backend='Cython', tempdir='/tmp/tmp')
+    assert np.allclose(f(np.arange(10.0), 1.0), np.arange(10.0)+1.0)
 
 
 def test_ufuncify_f2py():
     import numpy as np
     x, y = symbols('x y')
-    f = ufuncify((x, y), x + y, language='F95', backend='f2py')
-    assert np.allclose(f(np.arange(10), 1.0), np.arange(10)+1.0)
+    f = ufuncify((x, y), x + y, language='F95', backend='f2py', tempdir='/tmp/tmp2')
+    assert np.allclose(f(np.arange(10.0), 1.0), np.arange(10.0)+1.0)


### PR DESCRIPTION
Currently C/Cython behaves differently compared to F95/f2py when using e.g. ufuncify

This pull requests smartifies CythonCodeWrapper in autowrap module and give it some of
the functionality which f2py is currently providing for the Fortran counter part.

Two new tests are written, the one using fortran passes in current master while the one using C needs the other modifications provided in this pull request.

Looking forward to your comments/critisism!

Cheers
/Björn
