### PR TITLE
LaTeX printing bug hunt

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1597,9 +1597,11 @@ class Chi(TrigonometricIntegral):
     def _latex(self, printer, exp=None):
         assert len(self.args) == 1
         if exp:
-            return r'\operatorname{Chi}^{%s}{\left (%s \right )}' % (exp, self.args[0])
+            return r'\operatorname{Chi}^{%s}{\left (%s \right )}' \
+                % (printer._print(exp), printer._print(self.args[0]))
         else:
-            return r'\operatorname{Chi}{\left (%s \right )}' % self.args[0]
+            return r'\operatorname{Chi}{\left (%s \right )}' \
+                % printer._print(self.args[0])
 
 
 ###############################################################################

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -79,6 +79,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
             return all(_can_print_latex(i) for i in o)
         elif isinstance(o, dict):
             return all((isinstance(i, basestring) or _can_print_latex(i)) and _can_print_latex(o[i]) for i in o)
+        elif isinstance(o, bool):
+            return False
         elif isinstance(o, (sympy.Basic, sympy.matrices.MatrixBase, int, long, float)):
             return True
         return False

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -182,6 +182,12 @@ class LatexPrinter(Printer):
         else:
             return expr
 
+    def _print_bool(self, e):
+        return r"\mathrm{%s}" % e
+
+    def _print_NoneType(self, e):
+        return r"\mathrm{%s}" % e
+
     def _print_Add(self, expr, order=None):
         if self.order == 'none':
             terms = list(expr.args)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -99,6 +99,9 @@ class LatexPrinter(Printer):
         self._settings['mul_symbol_latex'] = \
             mul_symbol_table[self._settings['mul_symbol']]
 
+        self._settings['mul_symbol_latex_numbers'] = \
+            mul_symbol_table[self._settings['mul_symbol'] or 'dot']
+
         self._delim_dict = {'(': ')', '[': ']'}
 
     def parenthesize(self, item, level):
@@ -200,10 +203,8 @@ class LatexPrinter(Printer):
         str_real = mlib.to_str(expr._mpf_, dps, strip_zeros=True)
 
         # Must always have a mul symbol (as 2.5 10^{20} just looks odd)
-        separator = r" \times "
-
-        if self._settings['mul_symbol'] is not None:
-            separator = self._settings['mul_symbol_latex']
+        # thus we use the number separator
+        separator = self._settings['mul_symbol_latex_numbers']
 
         if 'e' in str_real:
             (mant, exp) = str_real.split('e')
@@ -231,6 +232,7 @@ class LatexPrinter(Printer):
         from sympy.simplify import fraction
         numer, denom = fraction(expr, exact=True)
         separator = self._settings['mul_symbol_latex']
+        numbersep = self._settings['mul_symbol_latex_numbers']
 
         def convert(expr):
             if not expr.is_Mul:
@@ -249,12 +251,10 @@ class LatexPrinter(Printer):
                     if self._needs_mul_brackets(term, last=(i == len(args) - 1)):
                         term_tex = r"\left(%s\right)" % term_tex
 
-                    # between two digits, \times must always be used,
-                    # to avoid confusion
-                    if separator == " " and \
-                            re.search("[0-9][} ]*$", last_term_tex) and \
+                    if re.search("[0-9][} ]*$", last_term_tex) and \
                             re.match("[{ ]*[-+0-9]", term_tex):
-                        _tex += r" \times "
+                        # between two numbers
+                        _tex += numbersep
                     elif _tex:
                         _tex += separator
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1138,7 +1138,7 @@ class LatexPrinter(Printer):
         for line in range(expr.rows):  # horrible, should be 'rows'
             lines.append(" & ".join([ self._print(i) for i in expr[line, :] ]))
 
-        out_str = r'\begin{%MATSTR%}%s\end{%MATSTR%}'
+        out_str = r'\begin{%MATSTR%}{}%s\end{%MATSTR%}'
         out_str = out_str.replace('%MATSTR%', self._settings['mat_str'])
         if self._settings['mat_delim']:
             left_delim = self._settings['mat_delim']
@@ -1763,13 +1763,13 @@ def latex(expr, **settings):
     etc. Defaults to "smallmatrix".
 
     >>> latex(Matrix(2, 1, [x, y]), mat_str = "array")
-    '\\left[\\begin{array}x\\\\y\\end{array}\\right]'
+    '\\left[\\begin{array}{}x\\\\y\\end{array}\\right]'
 
     mat_delim: The delimiter to wrap around matrices. Can be one of "[", "(",
     or the empty string. Defaults to "[".
 
     >>> latex(Matrix(2, 1, [x, y]), mat_delim="(")
-    '\\left(\\begin{smallmatrix}x\\\\y\\end{smallmatrix}\\right)'
+    '\\left(\\begin{smallmatrix}{}x\\\\y\\end{smallmatrix}\\right)'
 
     symbol_names: Dictionary of symbols and the custom strings they should be
     emitted as.

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -595,15 +595,15 @@ def test_latex_Piecewise():
 
 def test_latex_Matrix():
     M = Matrix([[1 + x, y], [y, x - 1]])
-    assert latex(M) == '\\left[\\begin{smallmatrix}x + 1 & y\\\\y & x - 1' \
+    assert latex(M) == '\\left[\\begin{smallmatrix}{}x + 1 & y\\\\y & x - 1' \
                        '\\end{smallmatrix}\\right]'
     settings = {'mat_str': 'bmatrix'}
-    assert latex(M, **settings) == '\\left[\\begin{bmatrix}x + 1 & y\\\\y &' \
+    assert latex(M, **settings) == '\\left[\\begin{bmatrix}{}x + 1 & y\\\\y &' \
         ' x - 1\\end{bmatrix}\\right]'
     settings['mat_delim'] = None
-    assert latex(M, **settings) == '\\begin{bmatrix}x + 1 & y\\\\y & x - 1' \
+    assert latex(M, **settings) == '\\begin{bmatrix}{}x + 1 & y\\\\y & x - 1' \
         '\\end{bmatrix}'
-    assert latex(M) == '\\left[\\begin{smallmatrix}x + 1 & y\\\\y & x - 1' \
+    assert latex(M) == '\\left[\\begin{smallmatrix}{}x + 1 & y\\\\y & x - 1' \
                        '\\end{smallmatrix}\\right]'
 
 
@@ -929,7 +929,7 @@ def test_Modules():
 
     h = homomorphism(QQ[x].free_module(2), QQ[x].free_module(2), [0, 0])
 
-    assert latex(h) == r"{\left[\begin{smallmatrix}0 & 0\\0 & 0\end{smallmatrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
+    assert latex(h) == r"{\left[\begin{smallmatrix}{}0 & 0\\0 & 0\end{smallmatrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
 
 
 def test_QuotientRing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -264,6 +264,7 @@ def test_latex_functions():
     assert latex(Si(x)**2) == r'\operatorname{Si}^{2}{\left (x \right )}'
     assert latex(Ci(x)**2) == r'\operatorname{Ci}^{2}{\left (x \right )}'
     assert latex(Chi(x)**2) == r'\operatorname{Chi}^{2}{\left (x \right )}', latex(Chi(x)**2)
+    assert latex(Chi(x**2)**2) == r'\operatorname{Chi}^{2}{\left (x^{2} \right )}', latex(Chi(x**2)**2)
 
     assert latex(
         jacobi(n, a, b, x)) == r'P_{n}^{\left(a,b\right)}\left(x\right)'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -78,8 +78,9 @@ def test_latex_basic():
     assert latex((x + 1)**Rational(3, 4), fold_frac_powers=True) == \
         r"\left(x + 1\right)^{3/4}"
 
-    assert latex(1.5e20*x) == r"1.5 \times 10^{20} x"
+    assert latex(1.5e20*x) == r"1.5 \cdot 10^{20} x"
     assert latex(1.5e20*x, mul_symbol='dot') == r"1.5 \cdot 10^{20} \cdot x"
+    assert latex(1.5e20*x, mul_symbol='times') == r"1.5 \times 10^{20} \times x"
 
     assert latex(1/sin(x)) == r"\frac{1}{\sin{\left (x \right )}}"
     assert latex(sin(x)**-1) == r"\frac{1}{\sin{\left (x \right )}}"
@@ -112,9 +113,9 @@ def test_latex_basic():
 
 
 def test_latex_Float():
-    assert latex(Float(1.0e100)) == r"1.0 \times 10^{100}"
-    assert latex(Float(1.0e-100)) == r"1.0 \times 10^{-100}"
-    assert latex(Float(1.0e-100), mul_symbol="dot") == r"1.0 \cdot 10^{-100}"
+    assert latex(Float(1.0e100)) == r"1.0 \cdot 10^{100}"
+    assert latex(Float(1.0e-100)) == r"1.0 \cdot 10^{-100}"
+    assert latex(Float(1.0e-100), mul_symbol="times") == r"1.0 \times 10^{-100}"
     assert latex(1.0*oo) == r"\infty"
     assert latex(-1.0*oo) == r"- \infty"
 
@@ -612,8 +613,8 @@ def test_latex_mul_symbol():
 
 def test_latex_issue1282():
     y = 4*4**log(2)
-    assert latex(y) == '4 \\times 4^{\\log{\\left (2 \\right )}}'
-    assert latex(1/y) == '\\frac{1}{4 \\times 4^{\\log{\\left (2 \\right )}}}'
+    assert latex(y) == r'4 \cdot 4^{\log{\left (2 \right )}}'
+    assert latex(1/y) == r'\frac{1}{4 \cdot 4^{\log{\left (2 \right )}}}'
 
 
 def test_latex_issue1477():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -112,6 +112,12 @@ def test_latex_basic():
         r"x_i \Rightarrow y_i"
 
 
+def test_latex_builtins():
+    assert latex(True) == r"\mathrm{True}"
+    assert latex(False) == r"\mathrm{False}"
+    assert latex(None) == r"\mathrm{None}"
+
+
 def test_latex_Float():
     assert latex(Float(1.0e100)) == r"1.0 \cdot 10^{100}"
     assert latex(Float(1.0e-100)) == r"1.0 \cdot 10^{-100}"


### PR DESCRIPTION
Separate numbers with \cdot by default. Print True/False as latex mathrm and prevent IPython from printing True/False as latex at all. Add an empty {} argument to \begin{array} constructs.

Fixes the following issues:

Issue 3740: Don't use \times in latex
http://code.google.com/p/sympy/issues/detail?id=3740

Issue 3757: True and False in latex
http://code.google.com/p/sympy/issues/detail?id=3757

Issue 3861: latex(Matrix, mat_str='array') misses first element
http://code.google.com/p/sympy/issues/detail?id=3861
