### PR TITLE
Fix WrongResult for risch_integrate(x*exp(-k*x), x)

### DIFF
--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1311,7 +1311,7 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
     if conds == 'piecewise' and DE.x not in qds.free_symbols:
         # We have to be careful if the exponent is S.Zero!
         ret += Piecewise(
-                (DE.x, Eq(qd.as_expr().subs(s), 0)),
+                (integrate(p/DE.t, DE.x), Eq(qds, 0)),
                 (qa.as_expr().subs(s) / qds, True)
             )
     else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1307,14 +1307,15 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
     ret = ((g1[0].as_expr()/g1[1].as_expr()).subs(s) \
         + residue_reduce_to_basic(g2, DE, z))
 
-    if conds == 'piecewise' and DE.x not in qd.as_expr().subs(s).free_symbols:
+    qds = qd.as_expr().subs(s)
+    if conds == 'piecewise' and DE.x not in qds.free_symbols:
         # We have to be careful if the exponent is S.Zero!
         ret += Piecewise(
                 (DE.x, Eq(qd.as_expr().subs(s), 0)),
-                ((qa.as_expr()/qd.as_expr()).subs(s), True)
+                (qa.as_expr().subs(s) / qds, True)
             )
     else:
-        ret += (qa.as_expr()/qd.as_expr()).subs(s)
+        ret += qa.as_expr().subs(s) / qds
 
     if not b:
         i = p - (qd*derivation(qa, DE) - qa*derivation(qd, DE)).as_expr()/\

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -447,6 +447,8 @@ def test_integrate_returns_piecewise():
         (y, Eq(log(x), 0)), (x**y/log(x), True))
     assert integrate(exp(n*x), x) == Piecewise(
         (x, Eq(n, 0)), (exp(n*x)/n, True))
+    assert integrate(x*exp(n*x), x) == Piecewise(
+        (x**2/2, Eq(n**3, 0)), ((x*n**2 - n)*exp(n*x)/n**3, True))
     assert integrate(x**(n*y), x) == Piecewise(
         (log(x), Eq(n*y, -1)), (x**(n*y + 1)/(n*y + 1), True))
     assert integrate(x**(n*y), y) == Piecewise(

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -270,6 +270,13 @@ def test_integrate_hyperexponential_returns_piecewise():
     DE = DifferentialExtension(exp(a*x), x)
     assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
         (x, Eq(a, 0)), (exp(a*x)/a, True)), 0, True)
+    DE = DifferentialExtension(x*exp(a*x), x)
+    assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
+        (x**2/2, Eq(a**3, 0)), ((x*a**2 - a)*exp(a*x)/a**3, True)), 0, True)
+    DE = DifferentialExtension(x**2*exp(a*x), x)
+    assert integrate_hyperexponential(DE.fa, DE.fd, DE) == (Piecewise(
+        (x**3/3, Eq(a**6, 0)),
+        ((x**2*a**5 - 2*x*a**4 + 2*a**3)*exp(a*x)/a**6, True)), 0, True)
 
 
 def test_integrate_primitive():

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2755,11 +2755,13 @@ def ode_almost_linear(eq, func, order, match):
         f(x)*--(l(y)) + g(x) + k(x)*l(y) = 0
              dy
         >>> pprint(dsolve(genform, hint = 'almost_linear'))
-               /     //      y        for k(x) = 0\\
-               |     ||                           ||  -y*k(x)
-               |     ||       y*k(x)              ||  -------
-               |     ||       ------              ||    f(x)
-        l(y) = |C1 + |<        f(x)               ||*e
+               /     //   -y*g(x)                 \\
+               |     ||   -------     for k(x) = 0||
+               |     ||     f(x)                  ||  -y*k(x)
+               |     ||                           ||  -------
+               |     ||       y*k(x)              ||    f(x)
+        l(y) = |C1 + |<       ------              ||*e
+               |     ||        f(x)               ||
                |     ||-g(x)*e                    ||
                |     ||-------------   otherwise  ||
                |     ||     k(x)                  ||


### PR DESCRIPTION
Fix issue 3886: Incorrect Piecewise result from risch_integrate
http://code.google.com/p/sympy/issues/detail?id=3886
