### PR TITLE
Use kinematic DEs in calculations of kanes_equations.

### DIFF
--- a/doc/src/modules/physics/mechanics/rollingdisc_example_kane_constraints.rst
+++ b/doc/src/modules/physics/mechanics/rollingdisc_example_kane_constraints.rst
@@ -70,7 +70,7 @@ represent the constraint forces in those directions. ::
   ...     return signsimp(trigsimp(collect(collect(factor_terms(w), f2), m*r)))
   >>> mprint(KM.auxiliary_eqs.applyfunc(simplify_auxiliary_eqs))
   Matrix([
-  [                                                   m*r*(u1*u3 + u2') - f1],
-  [      m*r*((u1**2 + u2**2)*sin(q2) + (u2*u3 + u3*q3' - u1')*cos(q2)) - f2],
-  [g*m - m*r*((u1**2 + u2**2)*cos(q2) - (u2*u3 + u3*q3' - u1')*sin(q2)) - f3]])
+  [                                                             -m*r*(u1*u3 + u2') + f1],
+  [      -m*r*((u1**2 + u2**2)*sin(q2) - (-2*u2*u3 + u3**2*tan(q2) + u1')*cos(q2)) + f2],
+  [-g*m + m*r*((u1**2 + u2**2)*cos(q2) + (-2*u2*u3 + u3**2*tan(q2) + u1')*sin(q2)) + f3]])
 

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -102,6 +102,9 @@ class KanesMethod(object):
     """
 
     simp = True
+    ___KDEqError = AttributeError('Create an instance of KanesMethod with' +
+                                  'kinematic differential equations to use' +
+                                  'this method.')
 
     def __init__(self, frame, q_ind, u_ind, kd_eqs=None, q_dependent=[],
             configuration_constraints=[], u_dependent=[],
@@ -309,14 +312,14 @@ class KanesMethod(object):
         velocity list if necessary.
         """
         if self._qdot_u_map is None:
-            raise ValueError('Kin. diff. eqs need to be supplied first.')
+            raise ___KDEqError
         v = [vel.subs(self._qdot_u_map) for vel in vlist]
         return partial_velocity(v, ulist, frame)
 
     def kindiffdict(self):
         """Returns the qdot's in a dictionary. """
         if self._qdot_u_map is None:
-            raise ValueError('Kin. diff. eqs need to be supplied first.')
+            raise ___KDEqError
         return self._qdot_u_map
 
     def _kindiffeq(self, kdeqs):
@@ -558,8 +561,8 @@ class KanesMethod(object):
         if (self._q is None) or (self._u is None):
             raise ValueError('Speeds and coordinates must be supplied first.')
         if (self._k_kqdot is None):
-            raise ValueError(
-                'Supply kinematic differential equations, please.')
+            raise __KDEqError
+
 
         fr = self._form_fr(FL)
         frstar = self._form_frstar(BL)

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -185,20 +185,9 @@ def test_aux_dep():
     kdd = kane.kindiffdict()
 
 
-    # Test
-    # First try Fr_c == fr;
-    # Second try Fr_star_c == frstar;
-    # Third try Fr_star_steady == frstar_steady.
-    # Both signs are checked in case the equations were found with an inverse
-    # sign.
-    assert ((Matrix(Fr_c).expand() == fr.expand()) or
-             (Matrix(Fr_c).expand() == (-fr).expand()))
-
-    assert ((Matrix(Fr_star_c).expand() == frstar.expand()) or
-             (Matrix(Fr_star_c).expand() == (-frstar).expand()))
-
-    assert ((Matrix(Fr_star_steady).expand() == frstar_steady.expand()) or
-             (Matrix(Fr_star_steady).expand() == (-frstar_steady).expand()))
+    assert Matrix(Fr_c).expand() == fr.expand()
+    assert Matrix(Fr_star_c).expand() == frstar.expand()
+    assert Matrix(Fr_star_steady).expand() == frstar_steady.expand()
 
 
 def test_mat_inv_mul():

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,5 +1,5 @@
-from sympy import cos, expand, Matrix, Poly, sin, solve, symbols
-from sympy import tan, trigsimp, zeros
+from sympy import cos, expand, Matrix, Poly, simplify, sin, solve, sqrt
+from sympy import symbols, tan, trigsimp, zeros
 from sympy.physics.mechanics import (cross, dot, dynamicsymbols, KanesMethod,
                                      inertia, inertia_of_point_mass, Particle,
                                      Point, ReferenceFrame, RigidBody)
@@ -184,10 +184,10 @@ def test_aux_dep():
                     .subs({q[3]: -r*cos(q[1])}).expand()
     kdd = kane.kindiffdict()
 
-
     assert Matrix(Fr_c).expand() == fr.expand()
-    assert Matrix(Fr_star_c).expand() == frstar.expand()
-    assert Matrix(Fr_star_steady).expand() == frstar_steady.expand()
+    assert Matrix(Fr_star_c.subs(kdd)).expand() == frstar.expand()
+    assert (simplify(Matrix(Fr_star_steady).expand()) ==
+            simplify(frstar_steady.expand()))
 
 
 def test_mat_inv_mul():
@@ -296,7 +296,7 @@ def test_non_central_inertia():
             -(IA + 2*J*b**2/R**2 + 2*K +
               mA*a**2 + 2*mB*b**2) * u1.diff(t) - mA*a*u1*u2,
             -(mA + 2*mB +2*J/R**2) * u2.diff(t) + mA*a*u1**2,
-            0]) * -1
+            0])
     assert (trigsimp(fr_star.subs(vc_map).subs(u3, 0)).doit().expand() ==
             fr_star_expected.expand())
 
@@ -312,3 +312,91 @@ def test_non_central_inertia():
     fr2, fr_star2 = km.kanes_equations(forces, bodies2)
     assert (trigsimp(fr_star2.subs(vc_map).subs(u3, 0)).doit().expand() ==
             fr_star_expected.expand())
+
+def test_sub_qdot():
+    # This test solves exercises 8.12, 8.17 from Kane 1985 and defines
+    # some velocities in terms of q, qdot.
+
+    ## --- Declare symbols ---
+    q1, q2, q3 = dynamicsymbols('q1:4')
+    q1d, q2d, q3d = dynamicsymbols('q1:4', level=1)
+    u1, u2, u3 = dynamicsymbols('u1:4')
+    u_prime, R, M, g, e, f, theta = symbols('u\' R, M, g, e, f, theta')
+    a, b, mA, mB, IA, J, K, t = symbols('a b mA mB IA J K t')
+    IA22, IA23, IA33 = symbols('IA22 IA23 IA33')
+    Q1, Q2, Q3 = symbols('Q1 Q2 Q3')
+
+    # --- Reference Frames ---
+    F = ReferenceFrame('F')
+    P = F.orientnew('P', 'axis', [-theta, F.y])
+    A = P.orientnew('A', 'axis', [q1, P.x])
+    A.set_ang_vel(F, u1*A.x + u3*A.z)
+    # define frames for wheels
+    B = A.orientnew('B', 'axis', [q2, A.z])
+    C = A.orientnew('C', 'axis', [q3, A.z])
+
+    ## --- define points D, S*, Q on frame A and their velocities ---
+    pD = Point('D')
+    pD.set_vel(A, 0)
+    # u3 will not change v_D_F since wheels are still assumed to roll w/o slip
+    pD.set_vel(F, u2 * A.y)
+
+    pS_star = pD.locatenew('S*', e*A.y)
+    pQ = pD.locatenew('Q', f*A.y - R*A.x)
+    # masscenters of bodies A, B, C
+    pA_star = pD.locatenew('A*', a*A.y)
+    pB_star = pD.locatenew('B*', b*A.z)
+    pC_star = pD.locatenew('C*', -b*A.z)
+    for p in [pS_star, pQ, pA_star, pB_star, pC_star]:
+        p.v2pt_theory(pD, F, A)
+
+    # points of B, C touching the plane P
+    pB_hat = pB_star.locatenew('B^', -R*A.x)
+    pC_hat = pC_star.locatenew('C^', -R*A.x)
+    pB_hat.v2pt_theory(pB_star, F, B)
+    pC_hat.v2pt_theory(pC_star, F, C)
+
+    # --- relate qdot, u ---
+    # the velocities of B^, C^ are zero since B, C are assumed to roll w/o slip
+    kde = [dot(p.vel(F), A.y) for p in [pB_hat, pC_hat]]
+    kde += [u1 - q1d]
+    kde_map = solve(kde, [q1d, q2d, q3d])
+    for k, v in kde_map.items():
+        kde_map[k.diff(t)] = v.diff(t)
+
+    # inertias of bodies A, B, C
+    # IA22, IA23, IA33 are not specified in the problem statement, but are
+    # necessary to define an inertia object. Although the values of
+    # IA22, IA23, IA33 are not known in terms of the variables given in the
+    # problem statement, they do not appear in the general inertia terms.
+    inertia_A = inertia(A, IA, IA22, IA33, 0, IA23, 0)
+    inertia_B = inertia(B, K, K, J)
+    inertia_C = inertia(C, K, K, J)
+
+    # define the rigid bodies A, B, C
+    rbA = RigidBody('rbA', pA_star, A, mA, (inertia_A, pA_star))
+    rbB = RigidBody('rbB', pB_star, B, mB, (inertia_B, pB_star))
+    rbC = RigidBody('rbC', pC_star, C, mB, (inertia_C, pC_star))
+
+    ## --- use kanes method ---
+    km = KanesMethod(F, [q1, q2, q3], [u1, u2], kd_eqs=kde, u_auxiliary=[u3])
+
+    forces = [(pS_star, -M*g*F.x), (pQ, Q1*A.x + Q2*A.y + Q3*A.z)]
+    bodies = [rbA, rbB, rbC]
+
+    # Q2 = -u_prime * u2 * Q1 / sqrt(u2**2 + f**2 * u1**2)
+    # -u_prime * R * u2 / sqrt(u2**2 + f**2 * u1**2) = R / Q1 * Q2
+    fr_expected = Matrix([
+            f*Q3 + M*g*e*sin(theta)*cos(q1),
+            Q2 + M*g*sin(theta)*sin(q1),
+            e*M*g*cos(theta) - Q1*f - Q2*R])
+             #Q1 * (f - u_prime * R * u2 / sqrt(u2**2 + f**2 * u1**2)))])
+    fr_star_expected = Matrix([
+            -(IA + 2*J*b**2/R**2 + 2*K +
+              mA*a**2 + 2*mB*b**2) * u1.diff(t) - mA*a*u1*u2,
+            -(mA + 2*mB +2*J/R**2) * u2.diff(t) + mA*a*u1**2,
+            0])
+
+    fr, fr_star = km.kanes_equations(forces, bodies)
+    assert (fr.expand() == fr_expected.expand())
+    assert (trigsimp(fr_star).expand() == fr_star_expected.expand())


### PR DESCRIPTION
Substitute expressions for qdot's when calculating generalized active
forces/inertias. This allows the system formulation to be explicitly
independent of generalized speeds.
