### PR TITLE
Implies and Equivalent now map numbers to (True, False)

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1666,7 +1666,7 @@ def test_sympy__logic__boolalg__ITE():
 
 def test_sympy__logic__boolalg__Implies():
     from sympy.logic.boolalg import Implies
-    assert _test_args(Implies(x, 2))
+    assert _test_args(Implies(x, y))
 
 
 def test_sympy__logic__boolalg__Nand():

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -953,7 +953,7 @@ def simplify_logic(expr):
     And(Not(x), Not(y))
 
     """
-    expr = sympify(expr)
+    expr = to_cnf(sympify(expr))
     if not isinstance(expr, BooleanFunction):
         return expr
     variables = list(expr.free_symbols)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -307,7 +307,13 @@ class Implies(BooleanFunction):
         True
         """
         try:
-            A, B = args
+            newargs = []
+            for x in args:
+                if isinstance(x, Number) or x in (0, 1):
+                    newargs.append(True if x else False)
+                else:
+                    newargs.append(x)
+            A, B = newargs
         except ValueError:
             raise ValueError(
                 "%d operand(s) used for an Implies "
@@ -346,6 +352,12 @@ class Equivalent(BooleanFunction):
 
         """
 
+        newargs = []
+        for x in args:
+            if isinstance(x, Number) or x in (0, 1):
+                newargs.append(True if x else False)
+            else:
+                newargs.append(x)
         argset = set(args)
         if len(argset) <= 1:
             return True
@@ -953,7 +965,7 @@ def simplify_logic(expr):
     And(Not(x), Not(y))
 
     """
-    expr = to_cnf(sympify(expr))
+    expr = sympify(expr)
     if not isinstance(expr, BooleanFunction):
         return expr
     variables = list(expr.free_symbols)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -358,7 +358,7 @@ class Equivalent(BooleanFunction):
                 newargs.append(True if x else False)
             else:
                 newargs.append(x)
-        argset = set(args)
+        argset = set(newargs)
         if len(argset) <= 1:
             return True
         if True in argset:

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -123,6 +123,9 @@ def test_Implies():
     assert Implies(True, False) is False
     assert Implies(False, True) is True
     assert Implies(False, False) is True
+    assert Implies(0, A) is True
+    assert Implies(1, 1) is True
+    assert Implies(1, 0) is False
     assert A >> B == B << A
 
 
@@ -137,6 +140,8 @@ def test_Equivalent():
     assert Equivalent(A, False) == Not(A)
     assert Equivalent(A, B, True) == A & B
     assert Equivalent(A, B, False) == ~A & ~B
+    assert Equivalent(1, A) == A
+    assert Equivalent(0, A) == Not(A)
 
 
 def test_simplification():

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -164,6 +164,9 @@ def test_simplification():
     ans = And(A, Or(B, C))
     assert simplify_logic('A & (B | C)') == ans
     assert simplify_logic('(A & B) | (A & C)') == ans
+    assert simplify_logic(Implies(A, B)) == Or(Not(A), B)
+    assert simplify_logic(Equivalent(A, B)) == \
+           Or(And(A, B), And(Not(A), Not(B)))
 
     # check input
     ans = SOPform('xy', [[1, 0]])


### PR DESCRIPTION
Currently, Implies(0,0) returns Implies(0,0) instead of True.
Classes like And, Not and Or convert integers to True/False, but classes like Implies and Equivalent do not. simplify_logic depends on 0, 1 being treated as False, True on substituion
Hence, the said classes have been modified to map numbers to (True, false)
