### PR TITLE
fixing args in tensor module

### DIFF
--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1097,8 +1097,8 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     res_base, res_gens = _get_bsgs(G, base, gens, list_free_indices[0])
     for i in range(1, len(list_free_indices)):
         base1, gens1 = _get_bsgs(G, base, gens, list_free_indices[i])
-        res_base, res_gens = bsgs_direct_product(res_base, res_gens,
-                                                 base1, gens1, 1)
+        res_base, res_gens = bsgs_direct_product(list(res_base), res_gens,
+                                                 list(base1), gens1, 1)
         if not list_free_indices[i]:
             no_free.append(range(size - 2, size - 2 + num_indices))
         size += num_indices
@@ -1131,6 +1131,7 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
         else:
             a.extend([nr + 1, nr])
         res_gens.append(_af_new(a))
+    res_base = list(res_base)
     # each base is ordered; order the union of the two bases
     for i in base_comm:
         if i not in res_base:
@@ -1169,7 +1170,7 @@ def gens_products(*v):
     res_size, res_base, res_gens = tensor_gens(*v[0])
     for i in range(1, len(v)):
         size, base, gens = tensor_gens(*v[i])
-        res_base, res_gens = bsgs_direct_product(res_base, res_gens, base,
+        res_base, res_gens = bsgs_direct_product(list(res_base), res_gens, base,
                                                  gens, 1)
     res_size = res_gens[0].size
     id_af = range(res_size)

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -913,7 +913,7 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
     """
     s = 2 if signed else 0
     n1 = gens1[0].size - s
-    base = list(base1[:])
+    base = list(base1)
     base += [x + n1 for x in base2]
     gens1 = [h._array_form for h in gens1]
     gens2 = [h._array_form for h in gens2]

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -913,7 +913,7 @@ def bsgs_direct_product(base1, gens1, base2, gens2, signed=True):
     """
     s = 2 if signed else 0
     n1 = gens1[0].size - s
-    base = base1[:]
+    base = list(base1[:])
     base += [x + n1 for x in base2]
     gens1 = [h._array_form for h in gens1]
     gens2 = [h._array_form for h in gens2]
@@ -1097,8 +1097,8 @@ def tensor_gens(base, gens, list_free_indices, sym=0):
     res_base, res_gens = _get_bsgs(G, base, gens, list_free_indices[0])
     for i in range(1, len(list_free_indices)):
         base1, gens1 = _get_bsgs(G, base, gens, list_free_indices[i])
-        res_base, res_gens = bsgs_direct_product(list(res_base), res_gens,
-                                                 list(base1), gens1, 1)
+        res_base, res_gens = bsgs_direct_product(res_base, res_gens,
+                                                 base1, gens1, 1)
         if not list_free_indices[i]:
             no_free.append(range(size - 2, size - 2 + num_indices))
         size += num_indices

--- a/sympy/combinatorics/tensor_can.py
+++ b/sympy/combinatorics/tensor_can.py
@@ -1170,7 +1170,7 @@ def gens_products(*v):
     res_size, res_base, res_gens = tensor_gens(*v[0])
     for i in range(1, len(v)):
         size, base, gens = tensor_gens(*v[i])
-        res_base, res_gens = bsgs_direct_product(list(res_base), res_gens, base,
+        res_base, res_gens = bsgs_direct_product(res_base, res_gens, base,
                                                  gens, 1)
     res_size = res_gens[0].size
     id_af = range(res_size)

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2682,34 +2682,33 @@ def test_sympy__tensor__indexed__IndexedBase():
     assert _test_args(IndexedBase('A', 1))
     assert _test_args(IndexedBase('A')[0, 1])
 
-@XFAIL
+
 def test_sympy__tensor__tensor__TensorIndexType():
     from sympy.tensor.tensor import TensorIndexType
     from sympy import Symbol
     assert _test_args(TensorIndexType('Lorentz', metric=False))
 
-@XFAIL
+
 def test_sympy__tensor__tensor__TensorSymmetry():
     from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, TensorType, get_symmetric_group_sgs
-    assert _test_args(TensorSymmetry(get_symmetric_group_sgs(2)))
+    assert _test_args(TensorSymmetry(*get_symmetric_group_sgs(2)))
 
 
-@XFAIL
 def test_sympy__tensor__tensor__TensorType():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, get_symmetric_group_sgs, TensorType
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym = TensorSymmetry(*get_symmetric_group_sgs(1))
     assert _test_args(TensorType([Lorentz], sym))
 
-@XFAIL
+
 def test_sympy__tensor__tensor__TensorHead():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, TensorHead
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
-    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym = TensorSymmetry(*get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     assert _test_args(TensorHead('p', S1, 0))
 
-@XFAIL
+
 def test_sympy__tensor__tensor__TensorIndex():
     from sympy.tensor.tensor import TensorIndexType, TensorIndex, TensorSymmetry, TensorType, get_symmetric_group_sgs
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
@@ -2723,7 +2722,7 @@ def test_sympy__tensor__tensor__TensAdd():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensAdd
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)
-    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym = TensorSymmetry(*get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     p, q = S1('p,q')
     t1 = p(a)
@@ -2736,12 +2735,11 @@ def test_sympy__tensor__tensor__TensMul():
     from sympy.tensor.tensor import TensorIndexType, TensorSymmetry, TensorType, get_symmetric_group_sgs, tensor_indices, TensMul
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)
-    sym = TensorSymmetry(get_symmetric_group_sgs(1))
+    sym = TensorSymmetry(*get_symmetric_group_sgs(1))
     S1 = TensorType([Lorentz], sym)
     p = S1('p')
-    free, dum =  TensMul.from_indices(a)
+    free, dum = TensMul.from_indices(a)
     assert _test_args(TensMul(S.One, [p], free, dum))
-
 
 
 @XFAIL

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1143,13 +1143,13 @@ class TensAdd(TensExpr):
         return TensAdd(other, -self)
 
     def __mul__(self, other):
-        return TensAdd(*[x*other for x in self.args])
+        return TensAdd(*(x*other for x in self.args))
 
     def __div__(self, other):
         other = sympify(other)
         if isinstance(other, TensExpr):
             raise ValueError('cannot divide by a tensor')
-        return TensAdd(*[x/other for x in self.args])
+        return TensAdd(*(x/other for x in self.args))
 
     def __rdiv__(self, other):
         raise ValueError('cannot divide by a tensor')
@@ -1615,7 +1615,7 @@ class TensMul(TensExpr):
             coeff = self._coeff*other
             return TensMul(coeff, self._components, self._free, self._dum, is_canon_bp=self._is_canon_bp)
         if isinstance(other, TensAdd):
-            return TensAdd(*[self*x for x in other.args])
+            return TensAdd(*(self*x for x in other.args))
 
         components = self._components + other._components
         # find out which free indices of self and other are contracted

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -34,6 +34,7 @@ from collections import defaultdict
 from sympy.core import Basic, sympify, Add, Mul, S
 from sympy.core.symbol import Symbol, symbols
 from sympy.combinatorics.tensor_can import get_symmetric_group_sgs, bsgs_direct_product, canonicalize, riemann_bsgs
+from sympy.core.containers import Tuple
 
 class _TensorManager(object):
     """
@@ -749,15 +750,16 @@ class TensorHead(Basic):
     """
     is_commutative = False
 
-    def __new__(cls, name, typ, comm, **kw_args):
+    def __new__(cls, name, typ, comm=0, **kw_args):
         assert isinstance(name, basestring)
+        comm2i = TensorManager.comm_symbols2i(comm)
 
         obj = Basic.__new__(cls, name, typ, **kw_args)
         obj._name = obj.args[0]
         obj._rank = len(obj.index_types)
         obj._types = typ.types
         obj._symmetry = typ.symmetry
-        obj._comm = TensorManager.comm_symbols2i(comm)
+        obj._comm = comm2i
         return obj
 
     @property
@@ -1240,7 +1242,9 @@ class TensMul(TensExpr):
     ==========
 
     coeff : SymPy coefficient of the tensor
-    args
+    components : list of ``TensorHead`` of the component tensors
+    free : free indices
+    dum : dummy indices
 
     Attributes
     ==========
@@ -1272,14 +1276,18 @@ class TensMul(TensExpr):
 
     """
 
-    def __new__(cls, coeff, *args, **kw_args):
-        obj = Basic.__new__(cls)
-        obj._components = args[0]
+    def __new__(cls, coeff, components, free, dum, **kw_args):
+#         components = Tuple(components)
+#         free = Tuple(free)
+#         dum = Tuple(dum)
+
+        obj = Basic.__new__(cls, coeff, components, free, dum)
+        obj._components = components
         obj._types = []
         for t in obj._components:
             obj._types.extend(t._types)
-        obj._free = args[1]
-        obj._dum = args[2]
+        obj._free = free
+        obj._dum = dum
         obj._ext_rank = len(obj._free) + 2*len(obj._dum)
         obj._coeff = coeff
         obj._is_canon_bp = kw_args.get('is_canon_bp', False)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1277,11 +1277,11 @@ class TensMul(TensExpr):
     """
 
     def __new__(cls, coeff, components, free, dum, **kw_args):
-#         components = Tuple(components)
-#         free = Tuple(free)
-#         dum = Tuple(dum)
+        t_components = Tuple(*components)
+        t_free = Tuple(*free)
+        t_dum = Tuple(*dum)
 
-        obj = Basic.__new__(cls, coeff, components, free, dum)
+        obj = Basic.__new__(cls, coeff, t_components, t_free, t_dum)
         obj._components = components
         obj._types = []
         for t in obj._components:
@@ -1604,7 +1604,7 @@ class TensMul(TensExpr):
         free1 = [(ind, i, c) for ind, i, c in self._free if ind.name not in free_names]
         free2 = [(ind, i, c + nc1) for ind, i, c in other._free if ind.name not in free_names]
         free = free1 + free2
-        dum = self._dum + dum2
+        dum = list(self._dum) + dum2
         for name in free_names:
             ipos1, cpos1, ind1 = free_dict1[name]
             ipos2, cpos2, ind2 = free_dict2[name]
@@ -1930,7 +1930,7 @@ class TensMul(TensExpr):
 
 
     def _pretty(self):
-        if self._components == []:
+        if len(self._components) == 0:
             return str(self._coeff)
         indices = [str(ind) for ind in self.get_indices()]
         pos = 0

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -462,13 +462,13 @@ def test_indices():
 def test_tensorsymmetry():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     sym = tensorsymmetry([1]*2)
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(2))
+    sym1 = TensorSymmetry(*get_symmetric_group_sgs(2))
     assert sym == sym1
     sym = tensorsymmetry([2])
-    sym1 = TensorSymmetry(get_symmetric_group_sgs(2, 1))
+    sym1 = TensorSymmetry(*get_symmetric_group_sgs(2, 1))
     assert sym == sym1
     sym2 = tensorsymmetry()
-    assert sym2.base == [] and sym2.generators == [Permutation(1)]
+    assert sym2.base == Tuple() and sym2.generators == Tuple(Permutation(1))
     raises(NotImplementedError, lambda: tensorsymmetry([2, 1]))
 
 def test_TensorType():
@@ -477,7 +477,7 @@ def test_TensorType():
     A = tensorhead('A', [Lorentz]*2, [[1]*2])
     assert A.typ == TensorType([Lorentz]*2, sym)
     assert A.types == [Lorentz]
-    typ =  TensorType([Lorentz]*2, sym)
+    typ = TensorType([Lorentz]*2, sym)
     assert str(typ) == "TensorType(['Lorentz', 'Lorentz'])"
     raises(ValueError, lambda: typ(2))
 
@@ -1073,6 +1073,7 @@ def test_hash():
     g = Lorentz.metric
 
     p, q = tensorhead('p q', [Lorentz], [[1]])
+    p_type = p.args[1]
     t1 = p(a)*q(b)
     t2 = p(a)*p(b)
     assert hash(t1) != hash(t2)
@@ -1080,16 +1081,44 @@ def test_hash():
     t4 = p(a)*p(b) - g(a,b)
     assert hash(t3) != hash(t4)
 
-    assert type(a)(*a.args) == a
-    assert type(Lorentz)(*Lorentz.args) == Lorentz
-    assert type(p)(*p.args) == p
-    assert type(p(a))(*(p(a)).args) == p(a)
-    assert type(t1)(*t1.args) == t1
-    assert type(t3)(*t3.args) == t3
+    assert a.func(*a.args) == a
+    assert Lorentz.func(*Lorentz.args) == Lorentz
+    assert g.func(*g.args) == g
+    assert p.func(*p.args) == p
+    assert p_type.func(*p_type.args) == p_type
+    assert p(a).func(*(p(a)).args) == p(a)
+    assert t1.func(*t1.args) == t1
+    assert t2.func(*t2.args) == t2
+    assert t3.func(*t3.args) == t3
+    assert t4.func(*t4.args) == t4
 
-    assert hash(type(a)(*a.args)) == hash(a)
-    assert hash(type(Lorentz)(*Lorentz.args)) == hash(Lorentz)
-    assert hash(type(p)(*p.args)) == hash(p)
-    assert hash(type(p(a))(*(p(a)).args)) == hash(p(a))
-    assert hash(type(t1)(*t1.args)) == hash(t1)
-    assert hash(type(t3)(*t3.args)) == hash(t3)
+    assert hash(a.func(*a.args)) == hash(a)
+    assert hash(Lorentz.func(*Lorentz.args)) == hash(Lorentz)
+    assert hash(g.func(*g.args)) == hash(g)
+    assert hash(p.func(*p.args)) == hash(p)
+    assert hash(p_type.func(*p_type.args)) == hash(p_type)
+    assert hash(p(a).func(*(p(a)).args)) == hash(p(a))
+    assert hash(t1.func(*t1.args)) == hash(t1)
+    assert hash(t2.func(*t2.args)) == hash(t2)
+    assert hash(t3.func(*t3.args)) == hash(t3)
+    assert hash(t4.func(*t4.args)) == hash(t4)
+
+    def check_all(obj):
+        return all([isinstance(_, Basic) for _ in obj.args])
+
+    assert check_all(a)
+    assert check_all(Lorentz)
+    assert check_all(g)
+    assert check_all(p)
+    assert check_all(p_type)
+    assert check_all(p(a))
+    assert check_all(t1)
+    assert check_all(t2)
+    assert check_all(t3)
+    assert check_all(t4)
+
+    tsymmetry = tensorsymmetry([2], [1], [1, 1, 1])
+
+    assert tsymmetry.func(*tsymmetry.args) == tsymmetry
+    assert hash(tsymmetry.func(*tsymmetry.args)) == hash(tsymmetry)
+    assert check_all(tsymmetry)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -7,6 +7,7 @@ from sympy.tensor.tensor import (TensorIndexType, tensor_indices,
   tensorlist_contract_metric, TensMul, tensorsymmetry, tensorhead,
   TensorManager, TensExpr)
 from sympy.utilities.pytest import raises
+from sympy.core.containers import Tuple
 
 #################### Tests from tensor_can.py #######################
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1078,3 +1078,17 @@ def test_hash():
     t3 = p(a)*p(b) + g(a,b)
     t4 = p(a)*p(b) - g(a,b)
     assert hash(t3) != hash(t4)
+
+    assert type(a)(*a.args) == a
+    assert type(Lorentz)(*Lorentz.args) == Lorentz
+    assert type(p)(*p.args) == p
+    assert type(p(a))(*(p(a)).args) == p(a)
+    assert type(t1)(*t1.args) == t1
+    assert type(t3)(*t3.args) == t3
+
+    assert hash(type(a)(*a.args)) == hash(a)
+    assert hash(type(Lorentz)(*Lorentz.args)) == hash(Lorentz)
+    assert hash(type(p)(*p.args)) == hash(p)
+    assert hash(type(p(a))(*(p(a)).args)) == hash(p(a))
+    assert hash(type(t1)(*t1.args)) == hash(t1)
+    assert hash(type(t3)(*t3.args)) == hash(t3)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -597,14 +597,14 @@ def test_mul():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b, c, d = tensor_indices('a,b,c,d', Lorentz)
     sym = tensorsymmetry([1]*2)
-    t = TensMul(S.One, [],[],[])
+    t = TensMul(S.One, [], [], [])
     assert str(t) == '1'
     A, B = tensorhead('A B', [Lorentz]*2, [[1]*2])
     t = (1 + x)*A(a, b)
     assert str(t) == '(x + 1)*A(a, b)'
     assert t.types == [Lorentz]
     assert t.rank == 2
-    assert t.dum == []
+    assert t.dum == Tuple()
     assert t.coeff == 1 + x
     assert sorted(t.free) == [(a, 0, 0), (b, 1, 0)]
     assert t.components == [A]
@@ -613,11 +613,11 @@ def test_mul():
     t1 = tensor_mul(*t.split())
     assert t == t(-b, d)
     assert t == t1
-    assert tensor_mul(*[]) == TensMul(S.One, [],[],[])
+    assert tensor_mul(*[]) == TensMul(S.One, [], [], [])
 
     t = TensMul(1, [], [], [])
     zsym = tensorsymmetry()
-    typ =  TensorType([], zsym)
+    typ = TensorType([], zsym)
     C = typ('C')
     assert str(C()) == 'C'
     assert str(t) == '1'


### PR DESCRIPTION
TODO: merge

Added these tests and fixed an issue in `TensorHead`'s `args`.

```
    assert type(a)(*a.args) == a
    assert type(Lorentz)(*Lorentz.args) == Lorentz
    assert type(p)(*p.args) == p
    assert type(p(a))(*(p(a)).args) == p(a)
    assert type(t1)(*t1.args) == t1
    assert type(t3)(*t3.args) == t3

    assert hash(type(a)(*a.args)) == hash(a)
    assert hash(type(Lorentz)(*Lorentz.args)) == hash(Lorentz)
    assert hash(type(p)(*p.args)) == hash(p)
    assert hash(type(p(a))(*(p(a)).args)) == hash(p(a))
    assert hash(type(t1)(*t1.args)) == hash(t1)
    assert hash(type(t3)(*t3.args)) == hash(t3)
```
- [ ] examine all `args` trees and detect ways to simplify the expressions.
