### PR TITLE
Matrix: a special technique for finding the determinant of 3x3 matrix

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2261,6 +2261,9 @@ class MatrixBase(object):
             det = M[0, 0]
         elif n == 2:
             det = M[0, 0]*M[1, 1] - M[0, 1]*M[1, 0]
+        elif n == 3:
+            det = (M[0, 0]*M[1, 1]*M[2, 2] + M[0, 1]*M[1, 2]*M[2, 0] + M[0, 2]*M[1, 0]*M[2, 1]) - \
+                  (M[0, 2]*M[1, 1]*M[2, 0] + M[0, 0]*M[1, 2]*M[2, 1] + M[0, 1]*M[1, 0]*M[2, 2])
         else:
             sign = 1  # track current sign in case of column swap
 


### PR DESCRIPTION
Duplicate column method for 3x3 matrix:
For ONLY a 3x3 matrix write down the first two columns after the third column
|00 01 02|......|00 01 02| 00 01
|10 11 12| => |10 11 12| 10 11
|20 21 22| .....|20 21 22| 20 21

det = sum of the products of the diagonal elements from left to right - sum of the products of the diagonal elements from right to left

det = 00_11_22 + 01_12_20 + 02_10_21 - 02_11_20 - 00_12_21 - 01_10_22

PS: This technique works only for 3x3 matrices

I felt this method is simple and efficient for 3x3 for a bareis' fraction free algorithm. Please correct me if I am wrong.
