### PR TITLE
Fix issue 3890: dsolve failing for an equality multiplied by -1

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1829,7 +1829,8 @@ def constant_renumber(expr, symbolname, startnumber, endnumber):
             newstartnumber += 1
             return newconst
         else:
-            if expr.is_Function or expr.is_Pow:
+            from sympy.core.containers import Tuple
+            if expr.is_Function or expr.is_Pow or isinstance(expr, Tuple):
                 return expr.func(
                     *[_constant_renumber(x, symbolname, startnumber,
                 endnumber) for x in expr.args])

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -688,6 +688,8 @@ def solve(f, *symbols, **flags):
 
         # Any embedded piecewise functions need to be brought out to the
         # top level so that the appropriate strategy gets selected.
+        # However, this is necessary only if one of the piecewise
+        # functions depends on one of the symbols we are solving for.
         def _has_piecewise(e, s):
             if e.is_Piecewise and e.has(s):
                 return True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -690,11 +690,11 @@ def solve(f, *symbols, **flags):
         # top level so that the appropriate strategy gets selected.
         # However, this is necessary only if one of the piecewise
         # functions depends on one of the symbols we are solving for.
-        def _has_piecewise(e, s):
-            if e.is_Piecewise and e.has(s):
-                return True
-            return any([_has_piecewise(a, s) for a in e.args])
-        if any([_has_piecewise(f[i], s) for s in symbols]):
+        def _has_piecewise(e):
+            if e.is_Piecewise:
+                return e.has(*symbols)
+            return any([_has_piecewise(a) for a in e.args])
+        if _has_piecewise(f[i]):
             f[i] = piecewise_fold(f[i])
 
         # if we have a Matrix, we need to iterate over its elements again

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -688,7 +688,12 @@ def solve(f, *symbols, **flags):
 
         # Any embedded piecewise functions need to be brought out to the
         # top level so that the appropriate strategy gets selected.
-        f[i] = piecewise_fold(f[i])
+        def _has_piecewise(e, s):
+            if e.is_Piecewise and e.has(s):
+                return True
+            return any([_has_piecewise(a, s) for a in e.args])
+        if any([_has_piecewise(f[i], s) for s in symbols]):
+            f[i] = piecewise_fold(f[i])
 
         # if we have a Matrix, we need to iterate over its elements again
         if f[i].is_Matrix:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1554,9 +1554,15 @@ def test_issue_3890():
     f = Function('f')
     k = Symbol('k')
     assert dsolve(f(x).diff(x) - x*exp(-k*x), f(x)) == \
-        Eq(f(x), C1 + Piecewise((x**2/2, Eq(k**3, 0)), ((-k**2*x - k)*exp(-k*x)/k**3, True)))
+        Eq(f(x), C1 + Piecewise(
+            (x**2/2, Eq(k**3, 0)),
+            ((-k**2*x - k)*exp(-k*x)/k**3, True)
+        ))
     assert dsolve(-f(x).diff(x) + x*exp(-k*x), f(x)) == \
-        Eq(f(x), C1 - Piecewise((-x**2/2, Eq(k**3, 0)), (x*exp(-k*x)/k + exp(-k*x)/k**2, True)))
+        Eq(f(x), C1 - Piecewise(
+            (-x**2/2, Eq(k**3, 0)),
+            (x*exp(-k*x)/k + exp(-k*x)/k**2, True)
+        ))
 
 
 def test_heuristic1():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1550,6 +1550,15 @@ def test_issue_3780():
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
 
+def test_issue_3890():
+    f = Function('f')
+    k = Symbol('k')
+    assert dsolve(f(x).diff(x) - x*exp(-k*x), f(x)) == \
+        Eq(f(x), C1 + Piecewise((x**2/2, Eq(k**3, 0)), ((-k**2*x - k)*exp(-k*x)/k**3, True)))
+    assert dsolve(-f(x).diff(x) + x*exp(-k*x), f(x)) == \
+        Eq(f(x), C1 - Piecewise((-x**2/2, Eq(k**3, 0)), (x*exp(-k*x)/k + exp(-k*x)/k**2, True)))
+
+
 def test_heuristic1():
     y, a, b, c, a4, a3, a2, a1, a0 = symbols("y a b c a4 a3 a2 a1 a0")
     y = Symbol('y')

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1233,6 +1233,12 @@ def test_issues_3720_3721_3722():
     assert solve(2**x + 4**x) == [I*pi/log(2)]
 
 
+def test_issue_3890():
+    f = Function('f')
+    assert solve(Eq(-f(x), Piecewise((1, x > 0), (0, True))), f(x)) == \
+        [-Piecewise((1, x > 0), (0, True))]
+
+
 def test_lambert_multivariate():
     from sympy.abc import a, x, y
     from sympy.solvers.bivariate import _filtered_gens, _lambert, _solve_lambert


### PR DESCRIPTION
http://code.google.com/p/sympy/issues/detail?id=3890

One issue was the reordering or args, which should not happen for Tuple instances (e.g. ExprCondPair), and another issue was the unneeded call to piecewise_fold.
