### PR TITLE
Add tests for pretty printing of elliptic integrals (see pr #2164)

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1081,7 +1081,7 @@ class PrettyPrinter(Printer):
         return pform
 
     def _print_elliptic_pi(self, e):
-        name = u'\u03a0' if self._use_unicode else 'Pi'
+        name = greek['pi'][1] if self._use_unicode else 'Pi'
         pforma0 = self._print(e.args[0])
         pforma1 = self._print(e.args[1])
         if len(e.args) == 2:

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1061,16 +1061,7 @@ class PrettyPrinter(Printer):
             pform = pforma0
         else:
             pforma1 = self._print(e.args[1])
-            h0 = pforma0.height()
-            h1 = pforma1.height()
-            if h0 > h1:
-                bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma0.baseline)
-                pform = prettyForm(*pforma0.right(bar))
-                pform = prettyForm(*pform.right(pforma1))
-            else:
-                bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma1.baseline)
-                pform = prettyForm(*pforma1.left(bar))
-                pform = prettyForm(*pform.left(pforma0))
+            pform = self._hprint_vseparator(pforma0, pforma1)
         pform = prettyForm(*pform.parens())
         pform = prettyForm(*pform.left('E'))
         return pform
@@ -1084,16 +1075,7 @@ class PrettyPrinter(Printer):
     def _print_elliptic_f(self, e):
         pforma0 = self._print(e.args[0])
         pforma1 = self._print(e.args[1])
-        h0 = pforma0.height()
-        h1 = pforma1.height()
-        if h0 > h1:
-            bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma0.baseline)
-            pform = prettyForm(*pforma0.right(bar))
-            pform = prettyForm(*pform.right(pforma1))
-        else:
-            bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma1.baseline)
-            pform = prettyForm(*pforma1.left(bar))
-            pform = prettyForm(*pform.left(pforma0))
+        pform = self._hprint_vseparator(pforma0, pforma1)
         pform = prettyForm(*pform.parens())
         pform = prettyForm(*pform.left('F'))
         return pform
@@ -1106,16 +1088,7 @@ class PrettyPrinter(Printer):
             pforma = pforma1
         else:
             pforma2 = self._print(e.args[2])
-            h1 = pforma1.height()
-            h2 = pforma2.height()
-            if h1 > h2:
-                bar = stringPict(vobj('|', max(h1,h2)), baseline=pforma1.baseline)
-                pform = prettyForm(*pforma1.right(bar))
-                pforma = prettyForm(*pform.right(pforma2))
-            else:
-                bar = stringPict(vobj('|', max(h1,h2)), baseline=pforma2.baseline)
-                pform = prettyForm(*pforma2.left(bar))
-                pforma = prettyForm(*pform.left(pforma1))
+            pforma = self._hprint_vseparator(pforma1, pforma2)
         pform = prettyForm(*pforma.left(', '))
         pform = prettyForm(*pform.left(pforma0))
         pform = prettyForm(*pform.parens())

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1055,6 +1055,73 @@ class PrettyPrinter(Printer):
 
         return pform
 
+    def _print_elliptic_e(self, e):
+        pforma0 = self._print(e.args[0])
+        if len(e.args) == 1:
+            pform = pforma0
+        else:
+            pforma1 = self._print(e.args[1])
+            h0 = pforma0.height()
+            h1 = pforma1.height()
+            if h0 > h1:
+                bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma0.baseline)
+                pform = prettyForm(*pforma0.right(bar))
+                pform = prettyForm(*pform.right(pforma1))
+            else:
+                bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma1.baseline)
+                pform = prettyForm(*pforma1.left(bar))
+                pform = prettyForm(*pform.left(pforma0))
+        pform = prettyForm(*pform.parens())
+        pform = prettyForm(*pform.left('E'))
+        return pform
+
+    def _print_elliptic_k(self, e):
+        pform = self._print(e.args[0])
+        pform = prettyForm(*pform.parens())
+        pform = prettyForm(*pform.left('K'))
+        return pform
+
+    def _print_elliptic_f(self, e):
+        pforma0 = self._print(e.args[0])
+        pforma1 = self._print(e.args[1])
+        h0 = pforma0.height()
+        h1 = pforma1.height()
+        if h0 > h1:
+            bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma0.baseline)
+            pform = prettyForm(*pforma0.right(bar))
+            pform = prettyForm(*pform.right(pforma1))
+        else:
+            bar = stringPict(vobj('|', max(h0,h1)), baseline=pforma1.baseline)
+            pform = prettyForm(*pforma1.left(bar))
+            pform = prettyForm(*pform.left(pforma0))
+        pform = prettyForm(*pform.parens())
+        pform = prettyForm(*pform.left('F'))
+        return pform
+
+    def _print_elliptic_pi(self, e):
+        name = u'\u03a0' if self._use_unicode else 'Pi'
+        pforma0 = self._print(e.args[0])
+        pforma1 = self._print(e.args[1])
+        if len(e.args) == 2:
+            pforma = pforma1
+        else:
+            pforma2 = self._print(e.args[2])
+            h1 = pforma1.height()
+            h2 = pforma2.height()
+            if h1 > h2:
+                bar = stringPict(vobj('|', max(h1,h2)), baseline=pforma1.baseline)
+                pform = prettyForm(*pforma1.right(bar))
+                pforma = prettyForm(*pform.right(pforma2))
+            else:
+                bar = stringPict(vobj('|', max(h1,h2)), baseline=pforma2.baseline)
+                pform = prettyForm(*pforma2.left(bar))
+                pforma = prettyForm(*pform.left(pforma1))
+        pform = prettyForm(*pforma.left(', '))
+        pform = prettyForm(*pform.left(pforma0))
+        pform = prettyForm(*pform.parens())
+        pform = prettyForm(*pform.left(name))
+        return pform
+
     def _print_Add(self, expr, order=None):
         if self.order == 'none':
             terms = list(expr.args)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -9,7 +9,7 @@ from sympy import (
     catalan, ceiling, conjugate, cos, euler, exp, expint, factorial,
     factorial2, floor, gamma, groebner, homomorphism, hyper, log,
     lowergamma, meijerg, oo, pi, sin, sqrt, subfactorial, symbols, tan,
-    uppergamma)
+    uppergamma, elliptic_k, elliptic_f, elliptic_e, elliptic_pi)
 
 from sympy.printing.pretty import pretty as xpretty
 from sympy.printing.pretty import pprint
@@ -3999,6 +3999,104 @@ def test_expint():
     assert upretty(Si(x)) == 'Si(x)'
     assert upretty(Ci(x)) == 'Ci(x)'
     assert upretty(Chi(x)) == 'Chi(x)'
+
+
+def test_elliptic_functions():
+    ascii_str = \
+"""\
+ /  1  \\\n\
+K|-----|\n\
+ \z + 1/\
+"""
+    ucode_str = \
+u"""\
+ ⎛  1  ⎞\n\
+K⎜─────⎟\n\
+ ⎝z + 1⎠\
+"""
+    expr = elliptic_k(1/(z + 1))
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    ascii_str = \
+"""\
+ / |  1  \\\n\
+F|1|-----|\n\
+ \ |z + 1/\
+"""
+    ucode_str = \
+u"""\
+ ⎛ │  1  ⎞\n\
+F⎜1│─────⎟\n\
+ ⎝ │z + 1⎠\
+"""
+    expr = elliptic_f(1, 1/(1 + z))
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    ascii_str = \
+"""\
+ /  1  \\\n\
+E|-----|\n\
+ \z + 1/\
+"""
+    ucode_str = \
+u"""\
+ ⎛  1  ⎞\n\
+E⎜─────⎟\n\
+ ⎝z + 1⎠\
+"""
+    expr = elliptic_e(1/(z + 1))
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    ascii_str = \
+"""\
+ / |  1  \\\n\
+E|1|-----|\n\
+ \ |z + 1/\
+"""
+    ucode_str = \
+u"""\
+ ⎛ │  1  ⎞\n\
+E⎜1│─────⎟\n\
+ ⎝ │z + 1⎠\
+"""
+    expr = elliptic_e(1, 1/(1 + z))
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    ascii_str = \
+"""\
+  /   4\\\n\
+Pi|3, -|\n\
+  \   x/\
+"""
+    ucode_str = \
+u"""\
+ ⎛   4⎞\n\
+Π⎜3, ─⎟\n\
+ ⎝   x⎠\
+"""
+    expr = elliptic_pi(3, 4/x)
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
+
+    ascii_str = \
+"""\
+  /   4| \\\n\
+Pi|3, -|6|\n\
+  \   x| /\
+"""
+    ucode_str = \
+u"""\
+ ⎛   4│ ⎞\n\
+Π⎜3, ─│6⎟\n\
+ ⎝   x│ ⎠\
+"""
+    expr = elliptic_pi(3, 4/x, 6)
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
 
 
 def test_RandomDomain():


### PR DESCRIPTION
This pull request includes PR #2164, for some reason I can't choose raoulb/sympy as a base fork to send PR.
