### PR TITLE
MutableMatrix.is_Piecewise

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -9,6 +9,7 @@ from sympy.core.decorators import deprecated
 from sympy.core.singleton import S
 
 class BasicBase(object):
+    # To be overridden with True in the appropriate subclasses
     is_Atom = False
     is_Symbol = False
     is_Dummy = False
@@ -68,31 +69,6 @@ class Basic(BasicBase):
                  '_args',               # arguments
                  '_assumptions'
                 ]
-
-    # To be overridden with True in the appropriate subclasses
-    is_Atom = False
-    is_Symbol = False
-    is_Dummy = False
-    is_Wild = False
-    is_Function = False
-    is_Add = False
-    is_Mul = False
-    is_Pow = False
-    is_Number = False
-    is_Float = False
-    is_Rational = False
-    is_Integer = False
-    is_NumberSymbol = False
-    is_Order = False
-    is_Derivative = False
-    is_Piecewise = False
-    is_Poly = False
-    is_AlgebraicNumber = False
-    is_Relational = False
-    is_Equality = False
-    is_Boolean = False
-    is_Not = False
-    is_Matrix = False
 
     @property
     @deprecated(useinstead="is_Float", issue=1721, deprecated_since_version="0.7.0")

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -8,8 +8,32 @@ from sympy.core.compatibility import (callable, reduce, cmp, iterable,
 from sympy.core.decorators import deprecated
 from sympy.core.singleton import S
 
+class BasicBase(object):
+    is_Atom = False
+    is_Symbol = False
+    is_Dummy = False
+    is_Wild = False
+    is_Function = False
+    is_Add = False
+    is_Mul = False
+    is_Pow = False
+    is_Number = False
+    is_Float = False
+    is_Rational = False
+    is_Integer = False
+    is_NumberSymbol = False
+    is_Order = False
+    is_Derivative = False
+    is_Piecewise = False
+    is_Poly = False
+    is_AlgebraicNumber = False
+    is_Relational = False
+    is_Equality = False
+    is_Boolean = False
+    is_Not = False
+    is_Matrix = False
 
-class Basic(object):
+class Basic(BasicBase):
     """
     Base class for all objects in SymPy.
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -9,7 +9,11 @@ from sympy.core.decorators import deprecated
 from sympy.core.singleton import S
 
 class BasicBase(object):
-    # To be overridden with True in the appropriate subclasses
+    """
+    Basic base class for all objects in Sympy
+
+    To be overridden with True in the appropriate subclasses
+    """
     is_Atom = False
     is_Symbol = False
     is_Dummy = False

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -74,6 +74,7 @@ class MatrixBase(object):
     __array_priority__ = 11
 
     is_Matrix = True
+    is_Piecewise = False
     is_Identity = None
     _class_priority = 3
     _sympify = staticmethod(sympify)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,5 +1,5 @@
 from sympy.core.add import Add
-from sympy.core.basic import Basic, C
+from sympy.core.basic import Basic, C, BasicBase
 from sympy.core.expr import Expr
 from sympy.core.function import count_ops
 from sympy.core.power import Pow
@@ -68,13 +68,12 @@ class DeferredVector(Symbol):
         return "DeferredVector('%s')" % (self.name)
 
 
-class MatrixBase(object):
+class MatrixBase(BasicBase):
 
     # Added just for numpy compatibility
     __array_priority__ = 11
 
     is_Matrix = True
-    is_Piecewise = False
     is_Identity = None
     _class_priority = 3
     _sympify = staticmethod(sympify)

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2189,4 +2189,3 @@ def test_attributes():
     assert not Matrix.eye(1).is_Equality
     assert not Matrix.eye(1).is_Boolean
     assert not Matrix.eye(1).is_Not
-

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2167,8 +2167,26 @@ def test_replace_map():
     N = M.replace(F, G, True)
     assert N == K
 
-def test_is_Piecewise():
-    from sympy import S, Matrix
-    is_Piecewise = False
+def test_attributes():
+    from sympy import Matrix
     assert not Matrix.eye(1).is_Piecewise
-    assert not S(Matrix.eye(1)).is_Piecewise
+    assert not Matrix.eye(1).is_Symbol
+    assert not Matrix.eye(1).is_Dummy
+    assert not Matrix.eye(1).is_Wild
+    assert not Matrix.eye(1).is_Function
+    assert not Matrix.eye(1).is_Add
+    assert not Matrix.eye(1).is_Mul
+    assert not Matrix.eye(1).is_Pow
+    assert not Matrix.eye(1).is_Number
+    assert not Matrix.eye(1).is_Float
+    assert not Matrix.eye(1).is_Rational
+    assert not Matrix.eye(1).is_NumberSymbol
+    assert not Matrix.eye(1).is_Order
+    assert not Matrix.eye(1).is_Derivative
+    assert not Matrix.eye(1).is_Piecewise
+    assert not Matrix.eye(1).is_AlgebraicNumber
+    assert not Matrix.eye(1).is_Relational
+    assert not Matrix.eye(1).is_Equality
+    assert not Matrix.eye(1).is_Boolean
+    assert not Matrix.eye(1).is_Not
+

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2166,3 +2166,9 @@ def test_replace_map():
     M = Matrix(2, 2, lambda i, j: F(i+j))
     N = M.replace(F, G, True)
     assert N == K
+
+def test_is_Piecewise():
+    from sympy import S, Matrix
+    is_Piecewise = False
+    assert not Matrix.eye(1).is_Piecewise
+    assert not S(Matrix.eye(1)).is_Piecewise


### PR DESCRIPTION
<em>Porblem:</em> Matrix.eye(3).is_Piecewise fails but S(Matrix.eye(3)).is_Piecewise does not because S() turns it into an
ImmutableMatrix. So the Mutable version does not have at least this (and maybe more) attributes set.

<em>Solution:</em> After a regular expression search through the code base, I found that is_Piecewise variable is declared in 
sympy/core/basic.py as 

<pre>is_Piecewise = False </pre>

which is never updated once it is initialized. 
As "S(What_ever_matrix).is_Piecewise" always returns False value, is it fine to add this line to sympy/matrices/matrices.py: 

<pre>is_Piecewise = False</pre>

Which resolves the problem of the MutableMatrices at least for the above mentioned test case
After making the changes to the code, this the output:

<pre>>>> A=Matrix([(1, 2, 3), (2, 3, 4), (5, 6, 7)])
>>>A
Matrix([
[1, 2, 3],
[2, 3, 4],
[5, 6, 7]])
>>> A.is_Piecewise
False
>>> S(A).is_Piecewise
False
>>> </pre> 

All the tests were passed after making the changes. 
