### PR TITLE
Fix methods using inertia in RigidBody

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -58,7 +58,7 @@ express.__doc__ += Vector.express.__doc__
 
 
 def outer(vec1, vec2):
-    """Outer prodcut convenience wrapper for Vector.outer():\n"""
+    """Outer product convenience wrapper for Vector.outer():\n"""
     if not isinstance(vec1, Vector):
         raise TypeError('Outer product is between two Vectors')
     return vec1 | vec2

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -462,15 +462,7 @@ class KanesMethod(object):
         for i, v in enumerate(bl):
             if isinstance(v, RigidBody):
                 M = v.mass.subs(uaz).doit()
-                I, P = v.inertia
-                if P != v.masscenter:
-                    # redefine I about the center of mass
-                    # have I S/O, want I S/S*
-                    # I S/O = I S/S* + I S*/O; I S/S* = I S/O - I S*/O
-                    f = v.frame
-                    d = v.masscenter.pos_from(P)
-                    I -= inertia_of_point_mass(M, d, f)
-                I = I.subs(uaz).doit()
+                I = v.central_inertia.subs(uaz).doit()
                 for j in range(o):
                     for k in range(o):
                         # translational

--- a/sympy/physics/mechanics/rigidbody.py
+++ b/sympy/physics/mechanics/rigidbody.py
@@ -99,8 +99,21 @@ class RigidBody(object):
             raise TypeError("RigidBody inertia must be about a Point.")
         self._inertia = I[0]
         self._inertia_point = I[1]
+        # have I S/O, want I S/S*
+        # I S/O = I S/S* + I S*/O; I S/S* = I S/O - I S*/O
+        # I_S/S* = I_S/O - I_S*/O
+        from sympy.physics.mechanics.functions import inertia_of_point_mass
+        I_Ss_O = inertia_of_point_mass(self.mass,
+                                       self.masscenter.pos_from(I[1]),
+                                       self.frame)
+        self._central_inertia = I[0] - I_Ss_O
 
     inertia = property(get_inertia, set_inertia)
+
+    @property
+    def central_inertia(self):
+        """The body's central inertia dyadic."""
+        return self._central_inertia
 
     def linear_momentum(self, frame):
         """ Linear momentum of the rigid body.
@@ -179,7 +192,7 @@ class RigidBody(object):
 
         """
 
-        return ((self.inertia[0] & self.frame.ang_vel_in(frame)) +
+        return ((self.central_inertia & self.frame.ang_vel_in(frame)) +
                 (point.vel(frame) ^ -self.masscenter.pos_from(point)) *
                 self.mass)
 
@@ -199,8 +212,8 @@ class RigidBody(object):
 
         frame : ReferenceFrame
             The RigidBody's angular velocity and the velocity of it's mass
-            center is typically defined with respect to an inertial frame but
-            any relevant frame in which the velocity is known can be supplied.
+            center are typically defined with respect to an inertial frame but
+            any relevant frame in which the velocities are known can be supplied.
 
         Examples
         ========
@@ -222,7 +235,7 @@ class RigidBody(object):
 
         """
 
-        rotational_KE = (self.frame.ang_vel_in(frame) & (self.inertia[0] &
+        rotational_KE = (self.frame.ang_vel_in(frame) & (self.central_inertia &
                 self.frame.ang_vel_in(frame)) / sympify(2))
 
         translational_KE = (self.mass * (self.masscenter.vel(frame) &

--- a/sympy/physics/mechanics/tests/test_kane2.py
+++ b/sympy/physics/mechanics/tests/test_kane2.py
@@ -1,7 +1,9 @@
-from sympy import cos, expand, Matrix, sin, symbols, tan, Poly, zeros, solve
-from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
-                                     RigidBody, KanesMethod, inertia, Particle,
-                                     dot, cross)
+from sympy import cos, expand, Matrix, Poly, sin, solve, symbols
+from sympy import tan, trigsimp, zeros
+from sympy.physics.mechanics import (cross, dot, dynamicsymbols, KanesMethod,
+                                     inertia, inertia_of_point_mass, Particle,
+                                     Point, ReferenceFrame, RigidBody)
+
 
 def test_aux_dep():
     # This test is about rolling disc dynamics, comparing the results found
@@ -221,3 +223,103 @@ def test_mat_inv_mul():
 
     assert mat_inv_mul(m1, m2) == m1.inv() * m2
     assert mat_inv_mul(m1, m3) == m1.inv() * m3
+
+
+def test_non_central_inertia():
+    # This tests that the calculation of Fr* does not depend the point
+    # about which the inertia of a rigid body is defined. This test solves
+    # exercises 8.12, 8.17 from Kane 1985.
+
+    # Declare symbols
+    q1, q2, q3 = dynamicsymbols('q1:4')
+    q1d, q2d, q3d = dynamicsymbols('q1:4', level=1)
+    u1, u2, u3, u4, u5 = dynamicsymbols('u1:6')
+    u_prime, R, M, g, e, f, theta = symbols('u\' R, M, g, e, f, theta')
+    a, b, mA, mB, IA, J, K, t = symbols('a b mA mB IA J K t')
+    Q1, Q2, Q3 = symbols('Q1, Q2 Q3')
+    IA22, IA23, IA33 = symbols('IA22 IA23 IA33')
+
+    # Reference Frames
+    F = ReferenceFrame('F')
+    P = F.orientnew('P', 'axis', [-theta, F.y])
+    A = P.orientnew('A', 'axis', [q1, P.x])
+    A.set_ang_vel(F, u1*A.x + u3*A.z)
+    # define frames for wheels
+    B = A.orientnew('B', 'axis', [q2, A.z])
+    C = A.orientnew('C', 'axis', [q3, A.z])
+    B.set_ang_vel(A, u4 * A.z)
+    C.set_ang_vel(A, u5 * A.z)
+
+    # define points D, S*, Q on frame A and their velocities
+    pD = Point('D')
+    pD.set_vel(A, 0)
+    # u3 will not change v_D_F since wheels are still assumed to roll without slip.
+    pD.set_vel(F, u2 * A.y)
+
+    pS_star = pD.locatenew('S*', e*A.y)
+    pQ = pD.locatenew('Q', f*A.y - R*A.x)
+    for p in [pS_star, pQ]:
+        p.v2pt_theory(pD, F, A)
+
+    # masscenters of bodies A, B, C
+    pA_star = pD.locatenew('A*', a*A.y)
+    pB_star = pD.locatenew('B*', b*A.z)
+    pC_star = pD.locatenew('C*', -b*A.z)
+    for p in [pA_star, pB_star, pC_star]:
+        p.v2pt_theory(pD, F, A)
+
+    # points of B, C touching the plane P
+    pB_hat = pB_star.locatenew('B^', -R*A.x)
+    pC_hat = pC_star.locatenew('C^', -R*A.x)
+    pB_hat.v2pt_theory(pB_star, F, B)
+    pC_hat.v2pt_theory(pC_star, F, C)
+
+    # the velocities of B^, C^ are zero since B, C are assumed to roll without slip
+    #kde = [dot(p.vel(F), b) for b in A for p in [pB_hat, pC_hat]]
+    kde = [q1d - u1, q2d - u4, q3d - u5]
+    vc = [dot(p.vel(F), A.y) for p in [pB_hat, pC_hat]]
+
+    # inertias of bodies A, B, C
+    # IA22, IA23, IA33 are not specified in the problem statement, but are
+    # necessary to define an inertia object. Although the values of
+    # IA22, IA23, IA33 are not known in terms of the variables given in the
+    # problem statement, they do not appear in the general inertia terms.
+    inertia_A = inertia(A, IA, IA22, IA33, 0, IA23, 0)
+    inertia_B = inertia(B, K, K, J)
+    inertia_C = inertia(C, K, K, J)
+
+    # define the rigid bodies A, B, C
+    rbA = RigidBody('rbA', pA_star, A, mA, (inertia_A, pA_star))
+    rbB = RigidBody('rbB', pB_star, B, mB, (inertia_B, pB_star))
+    rbC = RigidBody('rbC', pC_star, C, mB, (inertia_C, pC_star))
+
+    km = KanesMethod(F, q_ind=[q1, q2, q3], u_ind=[u1, u2], kd_eqs=kde,
+                     u_dependent=[u4, u5], velocity_constraints=vc,
+                     u_auxiliary=[u3])
+
+    forces = [(pS_star, -M*g*F.x), (pQ, Q1*A.x + Q2*A.y + Q3*A.z)]
+    bodies = [rbA, rbB, rbC]
+    fr, fr_star = km.kanes_equations(forces, bodies)
+    vc_map = solve(vc, [u4, u5])
+
+    # KanesMethod returns the negative of Fr, Fr* as defined in Kane1985.
+    fr_star_expected = Matrix([
+            -(IA + 2*J*b**2/R**2 + 2*K +
+              mA*a**2 + 2*mB*b**2) * u1.diff(t) - mA*a*u1*u2,
+            -(mA + 2*mB +2*J/R**2) * u2.diff(t) + mA*a*u1**2,
+            0]) * -1
+    assert (trigsimp(fr_star.subs(vc_map).subs(u3, 0)).doit().expand() ==
+            fr_star_expected.expand())
+
+    # define inertias of rigid bodies A, B, C about point D
+    # I_S/O = I_S/S* + I_S*/O
+    bodies2 = []
+    for rb, I_star in zip([rbA, rbB, rbC], [inertia_A, inertia_B, inertia_C]):
+        I = I_star + inertia_of_point_mass(rb.mass,
+                                           rb.masscenter.pos_from(pD),
+                                           rb.frame)
+        bodies2.append(RigidBody('', rb.masscenter, rb.frame, rb.mass,
+                                 (I, pD)))
+    fr2, fr_star2 = km.kanes_equations(forces, bodies2)
+    assert (trigsimp(fr_star2.subs(vc_map).subs(u3, 0)).doit().expand() ==
+            fr_star_expected.expand())

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -71,4 +71,5 @@ def test_rigidbody3():
     rb2 = RigidBody('rb2', P, B, m,
                     (I + inertia_of_point_mass(m, P.pos_from(O), B), O))
 
+    assert rb1.central_inertia == rb2.central_inertia
     assert rb1.angular_momentum(O, A) == rb2.angular_momentum(O, A)

--- a/sympy/physics/mechanics/tests/test_rigidbody.py
+++ b/sympy/physics/mechanics/tests/test_rigidbody.py
@@ -1,6 +1,7 @@
 from sympy import symbols
 from sympy.physics.mechanics import Point, ReferenceFrame, Dyadic, RigidBody
 from sympy.physics.mechanics import dynamicsymbols, outer
+from sympy.physics.mechanics import inertia_of_point_mass
 
 
 def test_rigidbody():
@@ -52,3 +53,22 @@ def test_rigidbody2():
     B.set_potential_energy(M * g * h)
     assert B.potential_energy == M * g * h
     assert B.kinetic_energy(N) == (omega**2 + M * v**2) / 2
+
+def test_rigidbody3():
+    q1, q2, q3, q4 = dynamicsymbols('q1:5')
+    p1, p2, p3 = symbols('p1:4')
+    m = symbols('m')
+
+    A = ReferenceFrame('A')
+    B = A.orientnew('B', 'axis', [q1, A.x])
+    O = Point('O')
+    O.set_vel(A, q2*A.x + q3*A.y + q4*A.z)
+    P = O.locatenew('P', p1*B.x + p2*B.y + p3*B.z)
+    I = outer(B.x, B.x)
+
+    rb1 = RigidBody('rb1', P, B, m, (I, P))
+    # I_S/O = I_S/S* + I_S*/O
+    rb2 = RigidBody('rb2', P, B, m,
+                    (I + inertia_of_point_mass(m, P.pos_from(O), B), O))
+
+    assert rb1.angular_momentum(O, A) == rb2.angular_momentum(O, A)


### PR DESCRIPTION
Fixed a problem with the inertia of a RigidBody.
The inline import (rigidbody.py:105) is used to get around a circular import issue.
I also updated KanesMethod to use the new property and I added a short test.

@sympy/mechanics
