### PR TITLE
3861: Change the default latex matrix type

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1138,8 +1138,10 @@ class LatexPrinter(Printer):
         for line in range(expr.rows):  # horrible, should be 'rows'
             lines.append(" & ".join([ self._print(i) for i in expr[line, :] ]))
 
-        out_str = r'\begin{%MATSTR%}{}%s\end{%MATSTR%}'
+        out_str = r'\begin{%MATSTR%}%s\end{%MATSTR%}'
         out_str = out_str.replace('%MATSTR%', self._settings['mat_str'])
+        if self._settings['mat_str'] == "array":
+            out_str = out_str.replace('%s', '{' + 'c'*expr.cols + '}%s')
         if self._settings['mat_delim']:
             left_delim = self._settings['mat_delim']
             right_delim = self._delim_dict[left_delim]
@@ -1763,13 +1765,13 @@ def latex(expr, **settings):
     etc. Defaults to "smallmatrix".
 
     >>> print latex(Matrix(2, 1, [x, y]), mat_str = "array")
-    \left[\begin{array}{}x\\y\end{array}\right]
+    \left[\begin{array}{c}x\\y\end{array}\right]
 
     mat_delim: The delimiter to wrap around matrices. Can be one of "[", "(",
     or the empty string. Defaults to "[".
 
     >>> print latex(Matrix(2, 1, [x, y]), mat_delim="(")
-    \left(\begin{smallmatrix}{}x\\y\end{smallmatrix}\right)
+    \left(\begin{smallmatrix}x\\y\end{smallmatrix}\right)
 
     symbol_names: Dictionary of symbols and the custom strings they should be
     emitted as.

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -66,16 +66,12 @@ class LatexPrinter(Printer):
         "long_frac_ratio": 2,
         "mul_symbol": None,
         "inv_trig_style": "abbreviated",
-        "mat_str": "smallmatrix",
+        "mat_str": None,
         "mat_delim": "[",
         "symbol_names": {},
     }
 
     def __init__(self, settings=None):
-        if settings is not None and 'inline' in settings and not settings['inline']:
-            # Change to "good" defaults for inline=False
-            settings['mat_str'] = 'bmatrix'
-            settings['mat_delim'] = None
         Printer.__init__(self, settings)
 
         if 'mode' in self._settings:
@@ -84,6 +80,12 @@ class LatexPrinter(Printer):
             if self._settings['mode'] not in valid_modes:
                 raise ValueError("'mode' must be one of 'inline', 'plain', "
                     "'equation' or 'equation*'")
+
+        if self._settings['mat_str'] is None:
+            if self._settings['mode'] == 'inline':
+                self._settings['mat_str'] = 'smallmatrix'
+            else:
+                self._settings['mat_str'] = 'array'
 
         if self._settings['fold_short_frac'] is None and \
                 self._settings['mode'] == 'inline':
@@ -1761,17 +1763,17 @@ def latex(expr, **settings):
     >>> print latex(asin(Rational(7,2)), inv_trig_style="power")
     \sin^{-1}{\left (\frac{7}{2} \right )}
 
-    mat_str: Which matrix environment string to emit. "smallmatrix", "bmatrix",
-    etc. Defaults to "smallmatrix".
+    mat_str: Which matrix environment string to emit. "smallmatrix", "matrix",
+    "array", etc. Defaults to "smallmatrix" for inline mode, "array" otherwise.
 
-    >>> print latex(Matrix(2, 1, [x, y]), mat_str = "array")
-    \left[\begin{array}{c}x\\y\end{array}\right]
+    >>> print latex(Matrix(2, 1, [x, y]), mat_str = "matrix")
+    \left[\begin{matrix}x\\y\end{matrix}\right]
 
     mat_delim: The delimiter to wrap around matrices. Can be one of "[", "(",
     or the empty string. Defaults to "[".
 
     >>> print latex(Matrix(2, 1, [x, y]), mat_delim="(")
-    \left(\begin{smallmatrix}x\\y\end{smallmatrix}\right)
+    \left(\begin{array}{c}x\\y\end{array}\right)
 
     symbol_names: Dictionary of symbols and the custom strings they should be
     emitted as.

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -596,19 +596,17 @@ def test_latex_Piecewise():
 
 def test_latex_Matrix():
     M = Matrix([[1 + x, y], [y, x - 1]])
-    assert latex(M) == '\\left[\\begin{smallmatrix}x + 1 & y\\\\y & x - 1' \
-                       '\\end{smallmatrix}\\right]'
-    settings = {'mat_str': 'array'}
-    assert latex(M, **settings) == r'\left[\begin{array}{cc}x + 1 & y\\y &' \
-        r' x - 1\end{array}\right]'
-    settings = {'mat_str': 'bmatrix'}
-    assert latex(M, **settings) == '\\left[\\begin{bmatrix}x + 1 & y\\\\y &' \
-        ' x - 1\\end{bmatrix}\\right]'
-    settings['mat_delim'] = None
-    assert latex(M, **settings) == '\\begin{bmatrix}x + 1 & y\\\\y & x - 1' \
-        '\\end{bmatrix}'
-    assert latex(M) == '\\left[\\begin{smallmatrix}x + 1 & y\\\\y & x - 1' \
-                       '\\end{smallmatrix}\\right]'
+    assert latex(M) == \
+        r'\left[\begin{array}{cc}x + 1 & y\\y & x - 1\end{array}\right]'
+    assert latex(M, mode='inline') == \
+        r'$\left[\begin{smallmatrix}x + 1 & y\\' \
+        r'y & x - 1\end{smallmatrix}\right]$'
+    assert latex(M, mat_str='matrix') == \
+        r'\left[\begin{matrix}x + 1 & y\\y & x - 1\end{matrix}\right]'
+    assert latex(M, mat_str='bmatrix') == \
+        r'\left[\begin{bmatrix}x + 1 & y\\y & x - 1\end{bmatrix}\right]'
+    assert latex(M, mat_delim=None, mat_str='bmatrix') == \
+        r'\begin{bmatrix}x + 1 & y\\y & x - 1\end{bmatrix}'
 
 
 def test_latex_mul_symbol():
@@ -933,7 +931,7 @@ def test_Modules():
 
     h = homomorphism(QQ[x].free_module(2), QQ[x].free_module(2), [0, 0])
 
-    assert latex(h) == r"{\left[\begin{smallmatrix}0 & 0\\0 & 0\end{smallmatrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
+    assert latex(h) == r"{\left[\begin{array}{cc}0 & 0\\0 & 0\end{array}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
 
 
 def test_QuotientRing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -596,15 +596,18 @@ def test_latex_Piecewise():
 
 def test_latex_Matrix():
     M = Matrix([[1 + x, y], [y, x - 1]])
-    assert latex(M) == '\\left[\\begin{smallmatrix}{}x + 1 & y\\\\y & x - 1' \
+    assert latex(M) == '\\left[\\begin{smallmatrix}x + 1 & y\\\\y & x - 1' \
                        '\\end{smallmatrix}\\right]'
+    settings = {'mat_str': 'array'}
+    assert latex(M, **settings) == r'\left[\begin{array}{cc}x + 1 & y\\y &' \
+        r' x - 1\end{array}\right]'
     settings = {'mat_str': 'bmatrix'}
-    assert latex(M, **settings) == '\\left[\\begin{bmatrix}{}x + 1 & y\\\\y &' \
+    assert latex(M, **settings) == '\\left[\\begin{bmatrix}x + 1 & y\\\\y &' \
         ' x - 1\\end{bmatrix}\\right]'
     settings['mat_delim'] = None
-    assert latex(M, **settings) == '\\begin{bmatrix}{}x + 1 & y\\\\y & x - 1' \
+    assert latex(M, **settings) == '\\begin{bmatrix}x + 1 & y\\\\y & x - 1' \
         '\\end{bmatrix}'
-    assert latex(M) == '\\left[\\begin{smallmatrix}{}x + 1 & y\\\\y & x - 1' \
+    assert latex(M) == '\\left[\\begin{smallmatrix}x + 1 & y\\\\y & x - 1' \
                        '\\end{smallmatrix}\\right]'
 
 
@@ -930,7 +933,7 @@ def test_Modules():
 
     h = homomorphism(QQ[x].free_module(2), QQ[x].free_module(2), [0, 0])
 
-    assert latex(h) == r"{\left[\begin{smallmatrix}{}0 & 0\\0 & 0\end{smallmatrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
+    assert latex(h) == r"{\left[\begin{smallmatrix}0 & 0\\0 & 0\end{smallmatrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
 
 
 def test_QuotientRing():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -597,16 +597,20 @@ def test_latex_Piecewise():
 def test_latex_Matrix():
     M = Matrix([[1 + x, y], [y, x - 1]])
     assert latex(M) == \
-        r'\left[\begin{array}{cc}x + 1 & y\\y & x - 1\end{array}\right]'
+        r'\left[\begin{matrix}x + 1 & y\\y & x - 1\end{matrix}\right]'
     assert latex(M, mode='inline') == \
         r'$\left[\begin{smallmatrix}x + 1 & y\\' \
         r'y & x - 1\end{smallmatrix}\right]$'
-    assert latex(M, mat_str='matrix') == \
-        r'\left[\begin{matrix}x + 1 & y\\y & x - 1\end{matrix}\right]'
+    assert latex(M, mat_str='array') == \
+        r'\left[\begin{array}{cc}x + 1 & y\\y & x - 1\end{array}\right]'
     assert latex(M, mat_str='bmatrix') == \
         r'\left[\begin{bmatrix}x + 1 & y\\y & x - 1\end{bmatrix}\right]'
     assert latex(M, mat_delim=None, mat_str='bmatrix') == \
         r'\begin{bmatrix}x + 1 & y\\y & x - 1\end{bmatrix}'
+    M2 = Matrix(1, 11, range(11))
+    assert latex(M2) == \
+        r'\left[\begin{array}{ccccccccccc}' \
+        r'0 & 1 & 2 & 3 & 4 & 5 & 6 & 7 & 8 & 9 & 10\end{array}\right]'
 
 
 def test_latex_mul_symbol():
@@ -931,7 +935,7 @@ def test_Modules():
 
     h = homomorphism(QQ[x].free_module(2), QQ[x].free_module(2), [0, 0])
 
-    assert latex(h) == r"{\left[\begin{array}{cc}0 & 0\\0 & 0\end{array}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
+    assert latex(h) == r"{\left[\begin{matrix}0 & 0\\0 & 0\end{matrix}\right]} : {{\mathbb{Q}\left[x\right]}^{2}} \to {{\mathbb{Q}\left[x\right]}^{2}}"
 
 
 def test_QuotientRing():


### PR DESCRIPTION
Fix the latex printing of 'array' and change the default latex matrix type to use 'smallmatrix' for mode='inline', use 'array' otherwise.

http://code.google.com/p/sympy/issues/detail?id=3861
