### PR TITLE
App engine compatibility: fail on subprocess import

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -916,17 +916,21 @@ if GROUND_TYPES == 'gmpy':
 
 # check_output() is new in python 2.7
 import os
-from subprocess import CalledProcessError
 try:
-    from subprocess import check_output
+    from subprocess import CalledProcessError
+    try:
+        from subprocess import check_output
+    except ImportError:
+        from subprocess import check_call
+        def check_output(*args, **kwargs):
+            with open(os.devnull, 'w') as fh:
+                kwargs['stdout'] = fh
+                try:
+                    return check_call(*args, **kwargs)
+                except CalledProcessError, e:
+                    e.output = ("program output is not available for "
+                                "python 2.5.x and 2.6.x")
+                    raise e
 except ImportError:
-    from subprocess import check_call
-    def check_output(*args, **kwargs):
-        with open(os.devnull, 'w') as fh:
-            kwargs['stdout'] = fh
-            try:
-                return check_call(*args, **kwargs)
-            except CalledProcessError, e:
-                e.output = ("program output is not available for "
-                            "python 2.5.x and 2.6.x")
-                raise e
+    # running on platform like App Engine, no subprocess at all
+    pass

--- a/sympy/printing/preview.py
+++ b/sympy/printing/preview.py
@@ -1,12 +1,16 @@
 from __future__ import with_statement
 
 from os.path import join
-from subprocess import STDOUT, CalledProcessError
 import tempfile
 import shutil
 from cStringIO import StringIO
 
-from sympy.core.compatibility import check_output
+try:
+    from subprocess import STDOUT, CalledProcessError
+    from sympy.core.compatibility import check_output
+except ImportError:
+    pass
+
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.utilities.misc import find_executable
 from latex import latex


### PR DESCRIPTION
Subprocess is not available on App Engine, so if the import fails, ignore it.
