### PR TITLE
Deprecated IPython extension. Use init_printing() instead.

### DIFF
--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -27,6 +27,7 @@ notebook.
 #-----------------------------------------------------------------------------
 
 from sympy.interactive.printing import init_printing
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 #-----------------------------------------------------------------------------
 # Definitions of special display functions for use with IPython
@@ -34,4 +35,9 @@ from sympy.interactive.printing import init_printing
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
+    SymPyDeprecationWarning(
+        feature="using %load_ext sympy.interactive.ipythonprinting",
+        useinstead="from sympy import init_printing ; init_printing()",
+        deprecated_since_version="0.7.3",
+    ).warn()
     init_printing(ip=ip)

--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -26,6 +26,8 @@ notebook.
 # Imports
 #-----------------------------------------------------------------------------
 
+import warnings
+
 from sympy.interactive.printing import init_printing
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
@@ -35,6 +37,9 @@ from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
+    # Since Python filters deprecation warnings by default,
+    # we add a filter to make sure this message will be shown.
+    warnings.simplefilter("once", SymPyDeprecationWarning)
     SymPyDeprecationWarning(
         feature="using %load_ext sympy.interactive.ipythonprinting",
         useinstead="from sympy import init_printing ; init_printing()",

--- a/sympy/interactive/ipythonprinting.py
+++ b/sympy/interactive/ipythonprinting.py
@@ -39,5 +39,6 @@ def load_ipython_extension(ip):
         feature="using %load_ext sympy.interactive.ipythonprinting",
         useinstead="from sympy import init_printing ; init_printing()",
         deprecated_since_version="0.7.3",
+        issue=3914
     ).warn()
     init_printing(ip=ip)


### PR DESCRIPTION
Added a deprecation warning for the IPython extension.

Issue: https://code.google.com/p/sympy/issues/detail?id=3914
