### PR TITLE
A bug in simplify fixed

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -574,7 +574,8 @@ def test_simplify():
         Sum(y, (t, a, b))) == Sum(x + y, (t, a, b)) + Sum(x, (t, b+1, c))
     assert simplify(Sum(x, (t, a, b)) + 2 * Sum(x, (t, b+1, c))) == \
         simplify(Sum(x, (t, a, b)) + Sum(x, (t, b+1, c)) + Sum(x, (t, b+1, c)))
-
+    assert simplify(Sum(x, (x, a, b))*Sum(x**2, (x, a, b))) == \
+        Sum(x, (x, a, b)) * Sum(x**2, (x, a, b))
 
 def test_change_index():
     b, v = symbols('b, v', integer = True)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4357,17 +4357,19 @@ def sum_simplify(s):
             constant = 1
             other = 1
             s = 0
+            n_sum_terms = 0
             for j in range(len(term.args)):
                 if isinstance(term.args[j], Sum):
                     s = term.args[j]
+                    n_sum_terms = n_sum_terms + 1
                 elif term.args[j].is_number == True:
                     constant = constant * term.args[j]
                 else:
                     other = other * term.args[j]
-            if other == 1 and s != 0:
+            if other == 1 and n_sum_terms == 1:
                 # Insert the constant inside the Sum
                 s_t.append(Sum(constant * s.function, *s.limits))
-            elif other != 1 and s != 0:
+            elif other != 1 and n_sum_terms == 1:
                 o_t.append(other * Sum(constant * s.function, *s.limits))
             else:
                 o_t.append(term)


### PR DESCRIPTION
Previously `simplify(Sum(i, (i, a, b))*Sum(i**2, (i, a, b)))` returned `Sum(i**2, (i, a, b))`.
A fix for the scenarios like above.
