### PR TITLE
faster ``gf_edf_zassenhaus`` using the Frobenius map

### DIFF
--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -943,6 +943,8 @@ def gf_frobenius_map(f, g, b, p, K):
     m = gf_degree(g)
     if gf_degree(f) >= m:
         f = gf_rem(f, g, p, K)
+    if not f:
+        return []
     n = gf_degree(f)
     sf = [f[-1]]
     for i in range(1, n + 1):
@@ -1978,13 +1980,13 @@ def gf_ddf_shoup(f, p, K):
     """
     n = gf_degree(f)
     k = int(_ceil(_sqrt(n//2)))
-
-    h = gf_pow_mod([K.one, K.zero], int(p), f, p, K)
-
+    b = gf_frobenius_monomial_base(f, p, K)
+    h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
+    # U[i] = x**(p*i)
     U = [[K.one, K.zero], h] + [K.zero]*(k - 1)
 
     for i in xrange(2, k + 1):
-        U[i] = gf_compose_mod(U[i - 1], h, f, p, K)
+        U[i] = gf_frobenius_map(U[i-1], f, b, p, K)
 
     h, U = U[k], U[:k]
     V = [h] + [K.zero]*(k - 1)
@@ -2018,7 +2020,6 @@ def gf_ddf_shoup(f, p, K):
         factors.append((f, gf_degree(f)))
 
     return factors
-
 
 @cythonized("n,N,q")
 def gf_edf_shoup(f, n, p, K):

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1433,16 +1433,25 @@ def gf_irred_p_ben_or(f, p, K, expect=False):
         return True
 
     _, f = gf_monic(f, p, K)
+    if n < 5:
+        H = h = gf_pow_mod([K.one, K.zero], p, f, p, K)
 
-    H = h = gf_pow_mod([K.one, K.zero], p, f, p, K)
+        for i in xrange(0, n//2):
+            g = gf_sub(h, [K.one, K.zero], p, K)
 
-    for i in xrange(0, n//2):
-        g = gf_sub(h, [K.one, K.zero], p, K)
-
-        if gf_gcd(f, g, p, K) == [K.one]:
-            h = gf_compose_mod(h, H, f, p, K)
-        else:
-            return False
+            if gf_gcd(f, g, p, K) == [K.one]:
+                h = gf_compose_mod(h, H, f, p, K)
+            else:
+                return False
+    else:
+        b = gf_frobenius_monomial_base(f, p, K)
+        H = h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
+        for i in xrange(0, n//2):
+            g = gf_sub(h, [K.one, K.zero], p, K)
+            if gf_gcd(f, g, p, K) == [K.one]:
+                h = gf_frobenius_map(h, f, b, p, K)
+            else:
+                return False
 
     return True
 
@@ -1484,7 +1493,7 @@ def gf_irred_p_rabin(f, p, K, expect=False):
 
     indices = set([ n//d for d in factorint(n) ])
 
-    if expect:
+    if expect or min(indices) >= 5:
         b = gf_frobenius_monomial_base(f, p, K)
         h = b[1]
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -907,7 +907,7 @@ def gf_frobenius_monomial_base(g, p, K):
         for i in range(1, n):
             mon = gf_lshift(b[i - 1], p, K)
             b[i] = gf_rem(mon, g, p, K)
-    else:
+    elif n > 1:
         b[1] = gf_pow_mod([K.one, K.zero], p, g, p, K)
         for i in range(2, n):
             b[i] = gf_mul(b[i - 1], b[1], p, K)
@@ -1404,7 +1404,6 @@ def gf_irreducible(n, p, K):
     """
     while True:
         f = gf_random(n, p, K)
-
         if gf_irreducible_p(f, p, K):
             return f
 
@@ -1472,9 +1471,9 @@ def gf_irred_p_rabin(f, p, K):
 
     x = [K.one, K.zero]
 
-    H = h = gf_pow_mod(x, p, f, p, K)
-
     indices = set([ n//d for d in factorint(n) ])
+    b = gf_frobenius_monomial_base(f, p, K)
+    h = b[1]
 
     for i in xrange(1, n):
         if i in indices:
@@ -1483,7 +1482,7 @@ def gf_irred_p_rabin(f, p, K):
             if gf_gcd(f, g, p, K) != [K.one]:
                 return False
 
-        h = gf_compose_mod(h, H, f, p, K)
+        h = gf_frobenius_map(h, f, b, p, K)
 
     return h == x
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1971,13 +1971,14 @@ def gf_ddf_shoup(f, p, K):
     k = int(_ceil(_sqrt(n//2)))
     b = gf_frobenius_monomial_base(f, p, K)
     h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
-    # U[i] = x**(p*i)
+    # U[i] = x**(p**i)
     U = [[K.one, K.zero], h] + [K.zero]*(k - 1)
 
     for i in xrange(2, k + 1):
         U[i] = gf_frobenius_map(U[i-1], f, b, p, K)
 
     h, U = U[k], U[:k]
+    # V[i] = x**(p**(k*(i+1)))
     V = [h] + [K.zero]*(k - 1)
 
     for i in xrange(1, k):

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -24,6 +24,7 @@ from sympy.polys.galoistools import (
     gf_berlekamp, gf_zassenhaus, gf_shoup,
     gf_factor_sqf, gf_factor,
     gf_value, linear_congruence, csolve_prime, gf_csolve,
+    gf_frobenius_map, gf_frobenius_monomial_base
 )
 
 from sympy.polys.polyerrors import (
@@ -515,6 +516,16 @@ def test_gf_squarefree():
         (1, [([1, 0], 1),
              ([1, 1], 3),
              ([1, 2], 6)])
+
+def test_gf_frobenius_map():
+    f = ZZ.map([2, 0, 1, 0, 2, 2, 0, 2, 2, 2])
+    g = ZZ.map([1,1,0,2,0,1,0,2,0,1])
+    p = 3
+    n = 4
+    b = gf_frobenius_monomial_base(g, p, ZZ)
+    h = gf_frobenius_map(f, g, b, p, ZZ)
+    h1 = gf_pow_mod(f, p, g, p, ZZ)
+    assert h == h1
 
 
 def test_gf_berlekamp():


### PR DESCRIPTION
For instance in this PR

`minpoly(sqrt(1 + root(2, 5)) + root(2, 5)*sqrt(1 + root(2, 10)))`

is 35% faster than in master.
