### PR TITLE
Don't assume that oo is real in the sets.

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -442,8 +442,7 @@ class Interval(Set, EvalfMixin):
 
         inftys = [S.Infinity, S.NegativeInfinity]
         # Only allow real intervals (use symbols with 'is_real=True').
-        if (not start.is_real or not end.is_real) and (start not in inftys or end
-            not in inftys):
+        if not (start.is_real or start in inftys) or not (end.is_real or end in inftys):
             raise ValueError("Only real intervals are supported")
 
         # Make sure that the created interval will be valid.

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -440,8 +440,10 @@ class Interval(Set, EvalfMixin):
         start = _sympify(start)
         end = _sympify(end)
 
+        inftys = [S.Infinity, S.NegativeInfinity]
         # Only allow real intervals (use symbols with 'is_real=True').
-        if not start.is_real or not end.is_real:
+        if (not start.is_real or not end.is_real) and (start not in inftys or end
+            not in inftys):
             raise ValueError("Only real intervals are supported")
 
         # Make sure that the created interval will be valid.


### PR DESCRIPTION
In the new assumptions, it won't be. Because of the singleton Reals, which is 
created at import time, this is needed to make SymPy import at all in #2210.
