### PR TITLE
Replace Class(*args) by self.func(*args).

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -10,14 +10,16 @@ def _expand_delta(expr, index):
     if not expr.is_Mul:
         return expr
     delta = None
+    func = Add
     terms = [S(1)]
     for h in expr.args:
         if delta is None and h.is_Add and _has_simple_delta(h, index):
             delta = True
+            func = h.func
             terms = [terms[0]*t for t in h.args]
         else:
             terms = [t*h for t in terms]
-    return Add(*terms)
+    return func(*terms)
 
 
 def _extract_delta(expr, index):
@@ -280,7 +282,7 @@ def deltasummation(f, limit, no_piecewise=False):
     g = _expand_delta(f, x)
     if g.is_Add:
         return piecewise_fold(
-            Add(*[deltasummation(h, limit, no_piecewise) for h in g.args]))
+            g.func(*[deltasummation(h, limit, no_piecewise) for h in g.args]))
 
     # try to extract a simple KroneckerDelta term
     delta, expr = _extract_delta(g, x)

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -299,7 +299,7 @@ class Product(Expr):
 
             g = self._eval_product(f, (i, a, b))
             if g is None:
-                return Product(powsimp(f), *self.limits[index:])
+                return self.func(powsimp(f), *self.limits[index:])
             else:
                 f = g
 
@@ -310,11 +310,11 @@ class Product(Expr):
 
     def _eval_adjoint(self):
         if self.is_commutative:
-            return Product(self.function.adjoint(), *self.limits)
+            return self.func(self.function.adjoint(), *self.limits)
         return None
 
     def _eval_conjugate(self):
-        return Product(self.function.conjugate(), *self.limits)
+        return self.func(self.function.conjugate(), *self.limits)
 
     def _eval_product(self, term, limits):
         from sympy.concrete.delta import deltaproduct, _has_simple_delta
@@ -349,7 +349,7 @@ class Product(Expr):
 
             if len(all_roots) < poly.degree():
                 arg = quo(poly, Q.as_poly(k))
-                B = Product(arg, (k, a, n)).doit()
+                B = self.func(arg, (k, a, n)).doit()
 
             return poly.LC()**(n - a + 1) * A * B
 
@@ -377,7 +377,7 @@ class Product(Expr):
             else:
                 arg = term._new_rawargs(*include)
                 A = Mul(*exclude)
-                B = Product(arg, (k, a, n)).doit()
+                B = self.func(arg, (k, a, n)).doit()
                 return A * B
 
         elif term.is_Pow:
@@ -395,13 +395,13 @@ class Product(Expr):
             evaluated = term.doit()
             f = self._eval_product(evaluated, limits)
             if f is None:
-                return Product(evaluated, limits)
+                return self.func(evaluated, limits)
             else:
                 return f
 
     def _eval_transpose(self):
         if self.is_commutative:
-            return Product(self.function.transpose(), *self.limits)
+            return self.func(self.function.transpose(), *self.limits)
         return None
 
 

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -262,10 +262,10 @@ class Sum(Expr):
         return f
 
     def _eval_adjoint(self):
-        return Sum(self.function.adjoint(), *self.limits)
+        return self.func(self.function.adjoint(), *self.limits)
 
     def _eval_conjugate(self):
-        return Sum(self.function.conjugate(), *self.limits)
+        return self.func(self.function.conjugate(), *self.limits)
 
     def _eval_derivative(self, x):
         """
@@ -290,14 +290,14 @@ class Sum(Expr):
         limit = limits.pop(-1)
 
         if limits:  # f is the argument to a Sum
-            f = Sum(f, *limits)
+            f = self.func(f, *limits)
 
         if len(limit) == 3:
             _, a, b = limit
             if x in a.free_symbols or x in b.free_symbols:
                 return None
             df = Derivative(f, x, evaluate=True)
-            rv = Sum(df, limit)
+            rv = self.func(df, limit)
             if limit[0] not in df.free_symbols:
                 rv = rv.doit()
             return rv
@@ -308,7 +308,7 @@ class Sum(Expr):
         return None
 
     def _eval_transpose(self):
-        return Sum(self.function.transpose(), *self.limits)
+        return self.func(self.function.transpose(), *self.limits)
 
     def euler_maclaurin(self, m=0, n=0, eps=0, eval_integral=True):
         """

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -345,11 +345,11 @@ class Add(Expr, AssocOp):
     # issue 2425.
 
     def _eval_derivative(self, s):
-        return Add(*[f.diff(s) for f in self.args])
+        return self.func(*[f.diff(s) for f in self.args])
 
     def _eval_nseries(self, x, n, logx):
         terms = [t.nseries(x, n=n, logx=logx) for t in self.args]
-        return Add(*terms)
+        return self.func(*terms)
 
     def _matches_simple(self, expr, repl_dict):
         # handle (w+3).matches('x+5') -> {w: x+2}
@@ -415,7 +415,7 @@ class Add(Expr, AssocOp):
         # check for quick exit
         if len(nd) == 1:
             d, n = nd.popitem()
-            return Add(
+            return self.func(
                 *[_keep_coeff(ncon, ni) for ni in n]), _keep_coeff(dcon, d)
 
         # sum up the terms having a common denominator
@@ -423,11 +423,11 @@ class Add(Expr, AssocOp):
             if len(n) == 1:
                 nd[d] = n[0]
             else:
-                nd[d] = Add(*n)
+                nd[d] = self.func(*n)
 
         # assemble single numerator and denominator
         denoms, numers = [list(i) for i in zip(*nd.iteritems())]
-        n, d = Add(*[Mul(*(denoms[:i] + [numers[i]] + denoms[i + 1:]))
+        n, d = self.func(*[Mul(*(denoms[:i] + [numers[i]] + denoms[i + 1:]))
                    for i in xrange(len(numers))]), Mul(*denoms)
 
         return _keep_coeff(ncon, n), _keep_coeff(dcon, d)
@@ -586,29 +586,29 @@ class Add(Expr, AssocOp):
 
         if coeff_self.is_Rational and coeff_old.is_Rational:
             if terms_self == terms_old:   # (2 + a).subs( 3 + a, y) -> -1 + y
-                return Add(new, coeff_self, -coeff_old)
+                return self.func(new, coeff_self, -coeff_old)
             if terms_self == -terms_old:  # (2 + a).subs(-3 - a, y) -> -1 - y
-                return Add(-new, coeff_self, coeff_old)
+                return self.func(-new, coeff_self, coeff_old)
 
         if coeff_self.is_Rational and coeff_old.is_Rational \
                 or coeff_self == coeff_old:
-            args_old, args_self = Add.make_args(
-                terms_old), Add.make_args(terms_self)
+            args_old, args_self = self.func.make_args(
+                terms_old), self.func.make_args(terms_self)
             if len(args_old) < len(args_self):  # (a+b+c).subs(b+c,x) -> a+x
                 self_set = set(args_self)
                 old_set = set(args_old)
 
                 if old_set < self_set:
                     ret_set = self_set - old_set
-                    return Add(new, coeff_self, -coeff_old,
+                    return self.func(new, coeff_self, -coeff_old,
                                *[s._subs(old, new) for s in ret_set])
 
-                args_old = Add.make_args(
+                args_old = self.func.make_args(
                     -terms_old)     # (a+b+c+d).subs(-b-c,x) -> a-x+d
                 old_set = set(args_old)
                 if old_set < self_set:
                     ret_set = self_set - old_set
-                    return Add(-new, coeff_self, coeff_old,
+                    return self.func(-new, coeff_self, coeff_old,
                                *[s._subs(old, new) for s in ret_set])
 
     def removeO(self):
@@ -684,9 +684,9 @@ class Add(Expr, AssocOp):
 
         unbounded = [t for t in self.args if t.is_unbounded]
         if unbounded:
-            return Add._from_args(unbounded)
+            return self.func._from_args(unbounded)
 
-        self = Add(*[t.as_leading_term(x) for t in self.args]).removeO()
+        self = self.func(*[t.as_leading_term(x) for t in self.args]).removeO()
         if not self:
             # simple leading term analysis gave us 0 but we have to send
             # back a term, so compute the leading term (via series)
@@ -694,7 +694,7 @@ class Add(Expr, AssocOp):
         elif not self.is_Add:
             return self
         else:
-            plain = Add(*[s for s, _ in self.extract_leading_order(x)])
+            plain = self.func(*[s for s, _ in self.extract_leading_order(x)])
             rv = factor_terms(plain, fraction=False)
             rv_fraction = factor_terms(rv, fraction=True)
             # if it simplifies to an x-free expression, return that;
@@ -704,16 +704,16 @@ class Add(Expr, AssocOp):
             return rv
 
     def _eval_adjoint(self):
-        return Add(*[t.adjoint() for t in self.args])
+        return self.func(*[t.adjoint() for t in self.args])
 
     def _eval_conjugate(self):
-        return Add(*[t.conjugate() for t in self.args])
+        return self.func(*[t.conjugate() for t in self.args])
 
     def _eval_transpose(self):
-        return Add(*[t.transpose() for t in self.args])
+        return self.func(*[t.transpose() for t in self.args])
 
     def __neg__(self):
-        return Add(*[-t for t in self.args])
+        return self.func(*[-t for t in self.args])
 
     def _sage_(self):
         s = 0
@@ -821,7 +821,7 @@ class Add(Expr, AssocOp):
 
         See docstring of Expr.as_content_primitive for more examples.
         """
-        con, prim = Add(*[_keep_coeff(*a.as_content_primitive(
+        con, prim = self.func(*[_keep_coeff(*a.as_content_primitive(
             radical=radical)) for a in self.args]).primitive()
         if radical and prim.is_Add:
             # look for common radicals that can be removed
@@ -862,7 +862,7 @@ class Add(Expr, AssocOp):
                 if G:
                     G = Mul(*G)
                     args = [ai/G for ai in args]
-                    prim = G*Add(*args)
+                    prim = G*prim.func(*args)
 
         return con, prim
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1017,7 +1017,7 @@ class Derivative(Expr):
             # We got a Derivative at the end of it all, and we rebuild it by
             # sorting its variables.
             if isinstance(expr, Derivative):
-                expr = Derivative(
+                expr = cls(
                     expr.args[0], *cls._sort_variables(expr.args[1:])
                 )
 
@@ -1102,24 +1102,24 @@ class Derivative(Expr):
             if obj is S.Zero:
                 return S.Zero
             if isinstance(obj, Derivative):
-                return Derivative(obj.expr, *(self.variables + obj.variables))
+                return obj.func(obj.expr, *(self.variables + obj.variables))
             # The derivative wrt s could have simplified things such that the
             # derivative wrt things in self.variables can now be done. Thus,
             # we set evaluate=True to see if there are any other derivatives
             # that can be done. The most common case is when obj is a simple
             # number so that the derivative wrt anything else will vanish.
-            return Derivative(obj, *self.variables, evaluate=True)
+            return self.func(obj, *self.variables, evaluate=True)
         # In this case s was in self.variables so the derivatve wrt s has
         # already been attempted and was not computed, either because it
         # couldn't be or evaluate=False originally.
-        return Derivative(self.expr, *(self.variables + (v, )), evaluate=False)
+        return self.func(self.expr, *(self.variables + (v, )), evaluate=False)
 
     def doit(self, **hints):
         expr = self.expr
         if hints.get('deep', True):
             expr = expr.doit(**hints)
         hints['evaluate'] = True
-        return Derivative(expr, *self.variables, **hints)
+        return self.func(expr, *self.variables, **hints)
 
     @_sympifyit('z0', NotImplementedError)
     def doit_numerically(self, z0):
@@ -1159,18 +1159,18 @@ class Derivative(Expr):
         if old in self.variables and not new.is_Symbol:
             # Issue 1620
             return Subs(self, old, new)
-        return Derivative(*map(lambda x: x._subs(old, new), self.args))
+        return self.func(*map(lambda x: x._subs(old, new), self.args))
 
     def _eval_lseries(self, x):
         dx = self.args[1:]
         for term in self.args[0].lseries(x):
-            yield Derivative(term, *dx)
+            yield self.func(term, *dx)
 
     def _eval_nseries(self, x, n, logx):
         arg = self.args[0].nseries(x, n=n, logx=logx)
         o = arg.getO()
         dx = self.args[1:]
-        rv = [Derivative(a, *dx) for a in Add.make_args(arg.removeO())]
+        rv = [self.func(a, *dx) for a in Add.make_args(arg.removeO())]
         if o:
             rv.append(o/x)
         return Add(*rv)
@@ -1421,12 +1421,12 @@ class Subs(Expr):
         if old in self.variables:
             pts = list(self.point.args)
             pts[self.variables.index(old)] = new
-            return Subs(self.expr, self.variables, pts)
+            return self.func(self.expr, self.variables, pts)
 
     def _eval_derivative(self, s):
         if s not in self.free_symbols:
             return S.Zero
-        return Subs(self.expr.diff(s), self.variables, self.point).doit() \
+        return self.func(self.expr.diff(s), self.variables, self.point).doit() \
             + Add(*[ Subs(point.diff(s) * self.expr.diff(arg),
                     self.variables, self.point).doit() for arg,
                     point in zip(self.variables, self.point) ])

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -149,12 +149,12 @@ class Pow(Expr):
             smallarg = (abs(e) <= abs(S.Pi/log(b)))
         if (other.is_Rational and other.q == 2 and
                 e.is_real is False and smallarg is False):
-            return -Pow(b, e*other)
+            return -self.func(b, e*other)
         if (other.is_integer or
             e.is_real and (b_nneg or abs(e) < 1) or
             e.is_real is False and smallarg is True or
                 b.is_polar):
-            return Pow(b, e*other)
+            return self.func(b, e*other)
 
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:
@@ -209,7 +209,7 @@ class Pow(Expr):
             return False
         if b.is_Number and e.is_Number:
             # int**nonneg or rat**?
-            check = Pow(*self.args)
+            check = self.func(*self.args)
             return check.is_Integer
 
     def _eval_is_real(self):
@@ -293,7 +293,7 @@ class Pow(Expr):
                     ok = self.base.is_positive
                 if ok:
                     # issue 2081
-                    return Pow(new, pow)  # (x**(6*y)).subs(x**(3*y),z)->z**2
+                    return self.func(new, pow)  # (x**(6*y)).subs(x**(3*y),z)->z**2
         if old.func is C.exp and self.exp.is_real and self.base.is_positive:
             coeff1, terms1 = old.args[0].as_independent(C.Symbol, as_Add=False)
             # we can only do this when the base is positive AND the exponent
@@ -303,7 +303,7 @@ class Pow(Expr):
             if terms1 == terms2:
                 pow = coeff1/coeff2
                 if pow == int(pow) or self.base.is_positive:
-                    return Pow(new, pow)  # (2**x).subs(exp(x*log(2)), z) -> z
+                    return self.func(new, pow)  # (2**x).subs(exp(x*log(2)), z) -> z
 
     def as_base_exp(self):
         """Return base and exp of self.
@@ -372,9 +372,9 @@ class Pow(Expr):
         if e.is_Add and e.is_commutative:
             expr = []
             for x in e.args:
-                expr.append(Pow(self.base, x))
+                expr.append(self.func(self.base, x))
             return Mul(*expr)
-        return Pow(b, e)
+        return self.func(b, e)
 
     def _eval_expand_power_base(self, **hints):
         """(a*b)**n -> a**n * b**n"""
@@ -405,7 +405,7 @@ class Pow(Expr):
                 return rv
 
             if not cargs:
-                return Pow(Mul(*nc), e, evaluate=False)
+                return self.func(Mul(*nc), e, evaluate=False)
 
             nc = [Mul(*nc)]
 
@@ -487,9 +487,9 @@ class Pow(Expr):
 
         rv = S.One
         if cargs:
-            rv *= Mul(*[Pow(b, e, evaluate=False) for b in cargs])
+            rv *= Mul(*[self.func(b, e, evaluate=False) for b in cargs])
         if other:
-            rv *= Pow(Mul(*other), e, evaluate=False)
+            rv *= self.func(Mul(*other), e, evaluate=False)
         return rv
 
     def _eval_expand_multinomial(self, **hints):
@@ -505,9 +505,9 @@ class Pow(Expr):
                 if not n:
                     return result
                 else:
-                    radical, result = Pow(base, exp - n), []
+                    radical, result = self.func(base, exp - n), []
 
-                    expanded_base_n = Pow(base, n)
+                    expanded_base_n = self.func(base, n)
                     if expanded_base_n.is_Pow:
                         expanded_base_n = \
                             expanded_base_n._eval_expand_multinomial()
@@ -546,13 +546,13 @@ class Pow(Expr):
                     if a.is_Rational and b.is_Rational:
                         if not a.is_Integer:
                             if not b.is_Integer:
-                                k = Pow(a.q * b.q, n)
+                                k = self.func(a.q * b.q, n)
                                 a, b = a.p*b.q, a.q*b.p
                             else:
-                                k = Pow(a.q, n)
+                                k = self.func(a.q, n)
                                 a, b = a.p, a.q*b
                         elif not b.is_Integer:
-                            k = Pow(b.q, n)
+                            k = self.func(b.q, n)
                             a, b = a*b.q, b.p
                         else:
                             k = 1
@@ -598,7 +598,7 @@ class Pow(Expr):
                         return Add(*[f*multi for f in base.args])
         elif (exp.is_Rational and exp.p < 0 and base.is_Add and
                 abs(exp.p) > exp.q):
-            return 1 / Pow(base, -exp)._eval_expand_multinomial()
+            return 1 / self.func(base, -exp)._eval_expand_multinomial()
         elif exp.is_Add and base.is_Number:
             #  a + b      a  b
             # n      --> n  n  , where n, a, b are Numbers
@@ -606,11 +606,11 @@ class Pow(Expr):
             coeff, tail = S.One, S.Zero
             for term in exp.args:
                 if term.is_Number:
-                    coeff *= Pow(base, term)
+                    coeff *= self.func(base, term)
                 else:
                     tail += term
 
-            return coeff * Pow(base, tail)
+            return coeff * self.func(base, tail)
         else:
             return result
 
@@ -658,10 +658,10 @@ class Pow(Expr):
             #       x being imaginary there are actually q roots, but
             #       only a single one is returned from here.
             re, im = self.base.as_real_imag(deep=deep)
-            r = Pow(Pow(re, 2) + Pow(im, 2), S.Half)
+            r = self.func(self.func(re, 2) + self.func(im, 2), S.Half)
             t = C.atan2(im, re)
 
-            rp, tp = Pow(r, self.exp), t*self.exp
+            rp, tp = self.func(r, self.exp), t*self.exp
 
             return (rp*C.cos(tp), rp*C.sin(tp))
         else:
@@ -690,8 +690,8 @@ class Pow(Expr):
         if exp < 0 and base.is_number and base.is_real is False:
             base = base.conjugate() / (base * base.conjugate())._evalf(prec)
             exp = -exp
-            return Pow(base, exp).expand()
-        return Pow(base, exp)
+            return self.func(base, exp).expand()
+        return self.func(base, exp)
 
     def _eval_is_polynomial(self, syms):
         if self.exp.has(*syms):
@@ -764,7 +764,7 @@ class Pow(Expr):
         if neg_exp:
             n, d = d, n
             exp = -exp
-        return Pow(n, exp), Pow(d, exp)
+        return self.func(n, exp), self.func(d, exp)
 
     def matches(self, expr, repl_dict={}, old=False):
         expr = _sympify(expr)
@@ -809,7 +809,7 @@ class Pow(Expr):
             if e > 0:
                 # positive integer powers are easy to expand, e.g.:
                 # sin(x)**4 = (x-x**3/3+...)**4 = ...
-                return expand_multinomial(Pow(b._eval_nseries(x, n=n,
+                return expand_multinomial(self.func(b._eval_nseries(x, n=n,
                     logx=logx), e), deep=False)
             elif e is S.NegativeOne:
                 # this is also easy to expand using the formula:
@@ -943,7 +943,7 @@ class Pow(Expr):
                 lt = terms.as_leading_term(x)
 
                 # bs -> lt + rest -> lt*(1 + (bs/lt - 1))
-                return ((Pow(lt, e) * Pow((bs/lt).expand(), e).nseries(
+                return ((self.func(lt, e) * self.func((bs/lt).expand(), e).nseries(
                     x, n=nuse, logx=logx)).expand() + order)
 
             if bs.is_Add:
@@ -995,7 +995,7 @@ class Pow(Expr):
 
     def _eval_as_leading_term(self, x):
         if not self.exp.has(x):
-            return Pow(self.base.as_leading_term(x), self.exp)
+            return self.func(self.base.as_leading_term(x), self.exp)
         return C.exp(self.exp * C.log(self.base)).as_leading_term(x)
 
     @cacheit
@@ -1003,7 +1003,7 @@ class Pow(Expr):
         if n < 0:
             return S.Zero
         x = _sympify(x)
-        return C.binomial(self.exp, n) * Pow(x, n)
+        return C.binomial(self.exp, n) * self.func(x, n)
 
     def _sage_(self):
         return self.args[0]._sage_()**self.args[1]._sage_()
@@ -1068,17 +1068,17 @@ class Pow(Expr):
             h, t = pe.as_coeff_Add()
             if h.is_Rational:
                 ceh = ce*h
-                c = Pow(b, ceh)
+                c = self.func(b, ceh)
                 r = S.Zero
                 if not c.is_Rational:
                     iceh, r = divmod(ceh.p, ceh.q)
-                    c = Pow(b, iceh)
-                return c, Pow(b, _keep_coeff(ce, t + r/ce/ceh.q))
+                    c = self.func(b, iceh)
+                return c, self.func(b, _keep_coeff(ce, t + r/ce/ceh.q))
         e = _keep_coeff(ce, pe)
         # b**e = (h*t)**e = h**e*t**e = c*m*t**e
         if e.is_Rational and b.is_Mul:
             h, t = b.as_content_primitive(radical=radical)  # h is positive
-            c, m = Pow(h, e).as_coeff_Mul()  # so c is positive
+            c, m = self.func(h, e).as_coeff_Mul()  # so c is positive
             m, me = m.as_base_exp()
             if m is S.One or me == e:  # probably always true
                 # return the following, not return c, m*Pow(t, e)
@@ -1086,8 +1086,8 @@ class Pow(Expr):
                 # decide what to do by using the unevaluated Mul, e.g
                 # should it stay as sqrt(2 + 2*sqrt(5)) or become
                 # sqrt(2)*sqrt(1 + sqrt(5))
-                return c, Pow(_keep_coeff(m, t), e)
-        return S.One, Pow(b, e)
+                return c, self.func(_keep_coeff(m, t), e)
+        return S.One, self.func(b, e)
 
     def is_constant(self, *wrt, **flags):
         if flags.get('simplify', True):

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -151,7 +151,7 @@ class Relational(Boolean, Expr, EvalfMixin):
             rop_cls = cls
         else:
             try:
-                rop_cls = Relational.ValidRelationOperator[ rop ]
+                rop_cls = cls.ValidRelationOperator[ rop ]
             except KeyError:
                 msg = "Invalid relational operator symbol: '%r'"
                 raise ValueError(msg % repr(rop))

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -159,7 +159,7 @@ class Piecewise(Function):
                     continue
             non_false_ecpairs.append(ExprCondPair(expr, cond))
         if len(non_false_ecpairs) != len(args) or piecewise_again:
-            return Piecewise(*non_false_ecpairs)
+            return cls(*non_false_ecpairs)
 
         return None
 
@@ -175,7 +175,7 @@ class Piecewise(Function):
                 if isinstance(c, Basic):
                     c = c.doit(**hints)
             newargs.append((e, c))
-        return Piecewise(*newargs)
+        return self.func(*newargs)
 
     def _eval_as_leading_term(self, x):
         for e, c in self.args:
@@ -183,20 +183,20 @@ class Piecewise(Function):
                 return e.as_leading_term(x)
 
     def _eval_adjoint(self):
-        return Piecewise(*[(e.adjoint(), c) for e, c in self.args])
+        return self.func(*[(e.adjoint(), c) for e, c in self.args])
 
     def _eval_conjugate(self):
-        return Piecewise(*[(e.conjugate(), c) for e, c in self.args])
+        return self.func(*[(e.conjugate(), c) for e, c in self.args])
 
     def _eval_derivative(self, x):
-        return Piecewise(*[(diff(e, x), c) for e, c in self.args])
+        return self.func(*[(diff(e, x), c) for e, c in self.args])
 
     def _eval_evalf(self, prec):
-        return Piecewise(*[(e.evalf(prec), c) for e, c in self.args])
+        return self.func(*[(e.evalf(prec), c) for e, c in self.args])
 
     def _eval_integral(self, x):
         from sympy.integrals import integrate
-        return Piecewise(*[(integrate(e, x), c) for e, c in self.args])
+        return self.func(*[(integrate(e, x), c) for e, c in self.args])
 
     def _eval_interval(self, sym, a, b):
         """Evaluates the function along the sym in a given interval ab"""
@@ -264,7 +264,7 @@ class Piecewise(Function):
                     for i in range(len(values)):
                         newargs.append((values[i], (c is True and i == len(values) - 1) or
                             And(rep >= intervals[i][0], rep <= intervals[i][1])))
-            return Piecewise(*newargs)
+            return self.func(*newargs)
 
         # Determine what intervals the expr,cond pairs affect.
         int_expr = self._sort_expr_cond(sym, a, b)
@@ -313,7 +313,7 @@ class Piecewise(Function):
         for expr, cond in expr_cond:
             if cond is True:
                 independent_expr_cond.append((expr, cond))
-                default = Piecewise(*independent_expr_cond)
+                default = self.func(*independent_expr_cond)
                 break
             if sym not in cond.free_symbols:
                 independent_expr_cond.append((expr, cond))
@@ -425,7 +425,7 @@ class Piecewise(Function):
         return self.func(*args)
 
     def _eval_power(self, s):
-        return Piecewise(*[(e**s, c) for e, c in self.args])
+        return self.func(*[(e**s, c) for e, c in self.args])
 
     def _eval_subs(self, old, new):
         """
@@ -441,12 +441,12 @@ class Piecewise(Function):
                 e = e._subs(old, new)
             args[i] = e, c
             if c is True:
-                return Piecewise(*args)
+                return self.func(*args)
 
-        return Piecewise(*args)
+        return self.func(*args)
 
     def _eval_transpose(self):
-        return Piecewise(*[(e.transpose(), c) for e, c in self.args])
+        return self.func(*[(e.transpose(), c) for e, c in self.args])
 
     def _eval_template_is_attr(self, is_attr, when_multiple=None):
         b = None

--- a/sympy/functions/special/delta_functions.py
+++ b/sympy/functions/special/delta_functions.py
@@ -50,7 +50,7 @@ class DiracDelta(Function):
             k = 0
             if len(self.args) > 1:
                 k = self.args[1]
-            return DiracDelta(self.args[0], k + 1)
+            return self.func(self.args[0], k + 1)
         else:
             raise ArgumentIndexError(self, argindex)
 
@@ -108,7 +108,7 @@ class DiracDelta(Function):
             for r in argroots:
                 #should I care about multiplicities of roots?
                 if r.is_real is not False and not darg.subs(x, r).is_zero:
-                    result += DiracDelta(x - r)/abs(darg.subs(x, r))
+                    result += self.func(x - r)/abs(darg.subs(x, r))
                 else:
                     valid = False
                     break

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -162,7 +162,7 @@ class KroneckerDelta(Function):
         elif diff.is_number:
             return S.Zero
         elif i != 0 and diff.is_nonzero:
-            return KroneckerDelta(0, diff.args[0])
+            return cls(0, diff.args[0])
 
         if i.assumptions0.get("below_fermi") and \
                 j.assumptions0.get("above_fermi"):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -855,7 +855,7 @@ class Integral(Expr):
                         f, cond = res
                         if conds == 'piecewise':
                             ret = Piecewise((f, cond),
-                                          (Integral(function, (x, a, b)), True))
+                                          (self.func(function, (x, a, b)), True))
                         elif conds == 'separate':
                             if len(self.limits) != 1:
                                 raise ValueError('conds=separate not supported in '

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -5,7 +5,7 @@ from sympy.polys.polytools import parallel_poly_from_expr
 from sympy.polys.polyoptions import allowed_flags, set_defaults
 from sympy.polys.polyerrors import PolynomialError
 
-from sympy.core import S, Add, sympify, Function, Lambda, Dummy, Mul, Expr
+from sympy.core import S, Add, sympify, Function, Lambda, Dummy, Expr
 from sympy.core.basic import preorder_traversal
 from sympy.utilities import numbered_symbols, take, xthreaded, public
 
@@ -62,9 +62,9 @@ def apart(f, x=None, full=False, **options):
         # non-commutative
         if f.is_Mul:
             c, nc = f.args_cnc(split_1=False)
-            nc = Mul(*[apart(i, x=x, full=full, **_options) for i in nc])
+            nc = f.func(*[apart(i, x=x, full=full, **_options) for i in nc])
             if c:
-                c = apart(Mul._from_args(c), x=x, full=full, **_options)
+                c = apart(f.func._from_args(c), x=x, full=full, **_options)
                 return c*nc
             else:
                 return nc
@@ -79,7 +79,7 @@ def apart(f, x=None, full=False, **options):
                         nc.append(apart(i, x=x, full=full, **_options))
                     except NotImplementedError:
                         nc.append(i)
-            return apart(Add(*c), x=x, full=full, **_options) + Add(*nc)
+            return apart(f.func(*c), x=x, full=full, **_options) + f.func(*nc)
         else:
             reps = []
             pot = preorder_traversal(f)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5524,13 +5524,15 @@ def to_rational_coeffs(f):
         coeffs = f1.all_coeffs()[1:]
         c = simplify(coeffs[0])
         if c and not c.is_rational:
+            func = Add
             if c.is_Add:
                 args = c.args
+                func = c.func
             else:
                 args = [c]
             sifted = sift(args, lambda z: z.is_rational)
             c1, c2 = sifted[True], sifted[False]
-            alpha = -Add(*c2)/n
+            alpha = -func(*c2)/n
             f2 = f1.shift(alpha)
             return alpha, f2
         return None

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -457,7 +457,7 @@ def collect(expr, syms, func=None, evaluate=True, exact=False, distribute_order_
 
     if evaluate:
         if expr.is_Mul:
-            return Mul(*[
+            return expr.func(*[
                 collect(term, syms, func, True, exact, distribute_order_term)
                 for term in expr.args])
         elif expr.is_Pow:
@@ -650,7 +650,7 @@ def _separatevars(expr, force):
             args[i] = separatevars(a, force)
             changed = changed or args[i] != a
         if changed:
-            expr = Mul(*args)
+            expr = expr.func(*args)
         return expr
 
     # get a Pow ready for expansion
@@ -2019,7 +2019,7 @@ def radsimp(expr, symbolic=True, max_terms=4):
             if d2.is_Number or (d2.count_ops() <= d.count_ops()):
                 n, d = [signsimp(i) for i in (n2, d2)]
                 if n.is_Mul and n.args[0].is_Number:
-                    n = Mul(*n.args)
+                    n = n.func(*n.args)
 
     return coeff + _umul(n, 1/d)
 
@@ -2779,12 +2779,12 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         # ==============================================================
 
         # rebuild the expression
-        newexpr = Mul(
+        newexpr = expr.func(
             *(newexpr + [Pow(b, e) for b, e in c_powers.iteritems()]))
         if combine == 'exp':
-            return Mul(newexpr, Mul(*nc_part))
+            return expr.func(newexpr, expr.func(*nc_part))
         else:
-            return recurse(Mul(*nc_part), combine='base') * \
+            return recurse(expr.func(*nc_part), combine='base') * \
                 recurse(newexpr, combine='base')
 
     elif combine == 'base':
@@ -2804,7 +2804,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                     b1, e1 = nc_part[-1].as_base_exp()
                     b2, e2 = term.as_base_exp()
                     if (e1 == e2 and e2.is_commutative):
-                        nc_part[-1] = Pow(Mul(b1, b2), e1)
+                        nc_part[-1] = Pow(b1*b2, e1)
                         continue
                 nc_part.append(term)
 
@@ -2838,7 +2838,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             if len(bases) == 1:
                 new_base = bases[0]
             elif e.is_integer or force:
-                new_base = Mul(*bases)
+                new_base = expr.func(*bases)
             else:
                 # see which ones can be joined
                 unk = []
@@ -2880,7 +2880,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 for b in unk:
                     c_powers[b].append(e)
                 # here is a new joined base
-                new_base = Mul(*(nonneg + neg))
+                new_base = expr.func(*(nonneg + neg))
                 # if there are positive parts they will just get separated
                 # again unless some change is made
 
@@ -2902,7 +2902,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
         c_part = [Pow(b, ei) for b, e in c_powers.iteritems() for ei in e]
 
         # we're done
-        return Mul(*(c_part + nc_part))
+        return expr.func(*(c_part + nc_part))
 
     else:
         raise ValueError("combine must be one of ('all', 'exp', 'base').")
@@ -3513,7 +3513,7 @@ def signsimp(expr, evaluate=True):
     if not isinstance(e, Expr) or e.is_Atom:
         return e
     if e.is_Add:
-        return Add(*[signsimp(a) for a in e.args])
+        return e.func(*[signsimp(a) for a in e.args])
     if evaluate:
         e = e.xreplace(dict([(m, -(-m)) for m in e.atoms(Mul) if -(-m) != m]))
     return e


### PR DESCRIPTION
Addresses nonexhaustively the subclassing problem. For example, when you subclass Add, and then perform some operations on an instance of your subclass, you expect an instance of your subclass to be returned. Previously you often would get an instance of Add.

Part of issue 3652: Make sure classes play nice with potential subclasses
http://code.google.com/p/sympy/issues/detail?id=3652
