### PR TITLE
Skip plotting doctest and avoid deprecation warning.

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -95,7 +95,7 @@ class Ellipse(GeometryEntity):
     >>> c1 = Circle(Point(0,0), 1)
     >>> Plot(c1)                                # doctest: +SKIP
     [0]: cos(t), sin(t), 'mode=parametric'
-    >>> p = Plot()
+    >>> p = Plot()                              # doctest: +SKIP
     >>> p[0] = c1                               # doctest: +SKIP
     >>> radius = Segment(c1.center, c1.random_point())
     >>> p[1] = radius                           # doctest: +SKIP

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -30,7 +30,8 @@ def test_ipythonprinting():
         assert app.user_ns['a2'][0]['text/plain'] == "pi**2"
 
     # Load printing extension
-    app.run_cell("%load_ext sympy.interactive.ipythonprinting")
+    app.run_cell("from sympy import init_printing")
+    app.run_cell("init_printing()")
     # Printing with printing extension
     app.run_cell("a = format(Symbol('pi'))")
     app.run_cell("a2 = format(Symbol('pi')**2)")


### PR DESCRIPTION
Skip the plotting doctest in sympy/geometry/ellipse.py This fixes issue 3925: Failing doctest in sympy/geometry/ellipse
http://code.google.com/p/sympy/issues/detail?id=3925

Also change the ipython printing test to use init_printing(). This removes the following deprecation warning while running the tests:

```
sympy/interactive/tests/test_ipythonprinting.py[1] sympy/utilities/exceptions.py:149:
SymPyDeprecationWarning:

using %load_ext sympy.interactive.ipythonprinting has been deprecated
since SymPy 0.7.3. Use from sympy import init_printing ;
init_printing() instead. See
http://code.google.com/p/sympy/issues/detail?id=3914 for more info.

  warning(see_above, SymPyDeprecationWarning)
.                                                            [OK]
```
