### PR TITLE
Deep processing of cancel() for Piecewise() instances.

### DIFF
--- a/sympy/core/tests/test_noncommutative.py
+++ b/sympy/core/tests/test_noncommutative.py
@@ -47,9 +47,11 @@ def test_adjoint():
     assert adjoint(Y) == transpose(conjugate(Y))
 
 
-@XFAIL
 def test_cancel():
     assert cancel(A*B - B*A) == A*B - B*A
+    assert cancel(A*B*(x - 1)) == A*B*(x - 1)
+    assert cancel(A*B*(x**2 - 1)/(x + 1)) == A*B*(x - 1)
+    assert cancel(A*B*(x**2 - 1)/(x + 1) - B*A*(x - 1)) == A*B*(x - 1) + (1 - x)*B*A
 
 
 @XFAIL

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -8,6 +8,8 @@ from sympy.core.mul import _keep_coeff
 
 from sympy.core.basic import preorder_traversal
 
+from sympy.core.relational import Relational
+
 from sympy.core.sympify import (
     sympify, SympifyError,
 )
@@ -53,7 +55,7 @@ from sympy.polys.polyerrors import (
     GeneratorsError,
 )
 
-from sympy.utilities import group
+from sympy.utilities import group, sift
 
 import sympy.polys
 import sympy.mpmath
@@ -3965,6 +3967,10 @@ def _parallel_poly_from_expr(exprs, opt):
     except GeneratorsNeeded:
         raise PolificationFailed(opt, origs, exprs, True)
 
+    for k in opt.gens:
+        if isinstance(k, Piecewise):
+            raise PolynomialError("Piecewise generators do not make sense")
+
     coeffs_list, lengths = [], []
 
     all_monoms = []
@@ -5478,7 +5484,6 @@ def to_rational_coeffs(f):
         polynomial; else ``alpha`` is ``None``.
         """
         from sympy.core.add import Add
-        from sympy.utilities.iterables import sift
         if not len(f.gens) == 1 or not (f.gens[0]).is_Atom:
             return None, f
         n = f.degree()
@@ -5939,7 +5944,7 @@ def cancel(f, *gens, **args):
     f = sympify(f)
 
     if not isinstance(f, (tuple, Tuple)):
-        if f.is_Number:
+        if f.is_Number or isinstance(f, Relational):
             return f
         f = factor_terms(f, radical=True)
         p, q = f.as_numer_denom()
@@ -5959,22 +5964,14 @@ def cancel(f, *gens, **args):
         else:
             return S.One, p, q
     except PolynomialError, msg:
-        if f.is_commutative:
+        if f.is_commutative and not f.has(Piecewise):
             raise PolynomialError(msg)
-        # non-commutative
-        if f.is_Mul:
-            c, nc = f.args_cnc(split_1=False)
+        # Handling of noncommutative and/or piecewise expressions
+        if f.is_Add or f.is_Mul:
+            sifted = sift(f.args, lambda x: x.is_commutative and not x.has(Piecewise))
+            c, nc = sifted[True], sifted[False]
             nc = [cancel(i) for i in nc]
-            return cancel(Mul._from_args(c))*Mul(*nc)
-        elif f.is_Add:
-            c = []
-            nc = []
-            for i in f.args:
-                if i.is_commutative:
-                    c.append(i)
-                else:
-                    nc.append(cancel(i))
-            return cancel(Add(*c)) + Add(*nc)
+            return f.func(cancel(f.func._from_args(c)), *nc)
         else:
             reps = []
             pot = preorder_traversal(f)
@@ -6493,3 +6490,5 @@ def poly(expr, *gens, **args):
     opt = options.build_options(gens, args)
 
     return _poly(expr, opt)
+
+from sympy.functions import Piecewise

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2840,13 +2840,17 @@ def test_cancel():
     p1 = Piecewise((A*(x**2 - 1)/(x + 1), x > 1), (0, True))
     p2 = Piecewise((A*(x - 1), x > 1), (0, True))
     assert cancel(p1) == p2
-
-
-@XFAIL
-def test_cancel_xfail():
+    assert cancel(2*p1) == 2*p2
+    assert cancel(1 + p1) == 1 + p2
+    assert cancel((x**2 - 1)/(x + 1)*p1) == (x - 1)*p2
+    assert cancel((x**2 - 1)/(x + 1) + p1) == (x - 1) + p2
     p3 = Piecewise(((x**2 - 1)/(x + 1), x > 1), (0, True))
     p4 = Piecewise(((x - 1), x > 1), (0, True))
     assert cancel(p3) == p4
+    assert cancel(2*p3) == 2*p4
+    assert cancel(1 + p3) == 1 + p4
+    assert cancel((x**2 - 1)/(x + 1)*p3) == (x - 1)*p4
+    assert cancel((x**2 - 1)/(x + 1) + p3) == (x - 1) + p4
 
 
 def test_reduced():

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2837,15 +2837,15 @@ def test_cancel():
 
     # issue 3923
     A = Symbol('A', commutative=False)
-    p1 = Piecewise((A*(x**2 - 1)/(x + 1), x > 1), (0, True))
-    p2 = Piecewise((A*(x - 1), x > 1), (0, True))
+    p1 = Piecewise((A*(x**2 - 1)/(x + 1), x > 1), ((x + 2)/(x**2 + 2*x), True))
+    p2 = Piecewise((A*(x - 1), x > 1), (1/x, True))
     assert cancel(p1) == p2
     assert cancel(2*p1) == 2*p2
     assert cancel(1 + p1) == 1 + p2
     assert cancel((x**2 - 1)/(x + 1)*p1) == (x - 1)*p2
     assert cancel((x**2 - 1)/(x + 1) + p1) == (x - 1) + p2
-    p3 = Piecewise(((x**2 - 1)/(x + 1), x > 1), (0, True))
-    p4 = Piecewise(((x - 1), x > 1), (0, True))
+    p3 = Piecewise(((x**2 - 1)/(x + 1), x > 1), ((x + 2)/(x**2 + 2*x), True))
+    p4 = Piecewise(((x - 1), x > 1), (1/x, True))
     assert cancel(p3) == p4
     assert cancel(2*p3) == 2*p4
     assert cancel(1 + p3) == 1 + p4


### PR DESCRIPTION
Now cancel(Piecewise((e1, c1), ...) returns Piecewise((cancel(e1), c1), ...)

Fixes issue 3923: Calling cancel() on a Piecewise() instance.
http://code.google.com/p/sympy/issues/detail?id=3923
