### PR TITLE
[WIP] Call 2to3 automatically from setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_install:
       pip install "sphinx==1.1.3";
     fi
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi
   - python setup.py install
 script:
   - bin/test_travis.sh

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -5,6 +5,10 @@ set -e
 # Echo each command
 set -x
 
+# We delete the 'sympy' directory to make sure that we test the installed
+# version of sympy:
+rm -rf sympy
+
 if [[ "${TEST_SPHINX}" == "true" ]]; then
     cd doc
     make html-errors
@@ -14,18 +18,12 @@ if [[ "${TEST_SPHINX}" == "true" ]]; then
     export LATEXOPTIONS="-interaction=nonstopmode"
     make all
 else
-    # We change directories to make sure that we test the installed version of
-    # sympy.
-    mkdir empty
-    cd empty
-
     if [[ "${TEST_DOCTESTS}" == "true" ]]; then
         cat << EOF | python
 import sympy
 if not sympy.doctest():
     raise Exception('Tests failed')
 EOF
-        cd ..
         bin/doctest doc/
     else
         cat << EOF | python

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -5,10 +5,6 @@ set -e
 # Echo each command
 set -x
 
-# We delete the 'sympy' directory to make sure that we test the installed
-# version of sympy:
-rm -rf sympy
-
 if [[ "${TEST_SPHINX}" == "true" ]]; then
     cd doc
     make html-errors
@@ -18,6 +14,10 @@ if [[ "${TEST_SPHINX}" == "true" ]]; then
     export LATEXOPTIONS="-interaction=nonstopmode"
     make all
 else
+    # We delete the 'sympy' directory to make sure that we test the installed
+    # version of sympy:
+    rm -rf sympy
+
     if [[ "${TEST_DOCTESTS}" == "true" ]]; then
         cat << EOF | python
 import sympy

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,10 @@ if sys.version_info[:2] < (2, 5):
           sys.version_info[:2])
     sys.exit(-1)
 
+if sys.version_info[0] >= 3:
+    os.system("bin/use2to3")
+    os.chdir("py3k-sympy")
+
 # Check that this list is uptodate against the result of the command:
 # for i in `find sympy -name __init__.py | rev | cut -f 2- -d '/' | rev | egrep -v "^sympy$" | egrep -v "tests$" `; do echo "'${i//\//.}',"; done | sort
 modules = [

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ import sys
 import subprocess
 import os
 
-import sympy
-
 # Make sure I have the right Python version.
 if sys.version_info[:2] < (2, 5):
     print("SymPy requires Python 2.5 or newer. Python %d.%d detected" %
@@ -42,8 +40,12 @@ if sys.version_info[:2] < (2, 5):
     sys.exit(-1)
 
 if sys.version_info[0] >= 3:
+    local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
     os.system("bin/use2to3")
     os.chdir("py3k-sympy")
+    sys.path.insert(0, os.path.join(local_path, 'py3k-sympy'))
+
+import sympy
 
 # Check that this list is uptodate against the result of the command:
 # for i in `find sympy -name __init__.py | rev | cut -f 2- -d '/' | rev | egrep -v "^sympy$" | egrep -v "tests$" `; do echo "'${i//\//.}',"; done | sort


### PR DESCRIPTION
Current status: as of 4a5b5dafb663bcdb1bfe3ff8b47ef0c5566657f4, all tests at Travis seem to pass. But there are still a few bugs, see below.
### Prefix Path Bug

If you do:

```
python setup.py install --prefix=xx
```

it will install into `build/py3k-sympy/xx` instead to `xx` in the current directory. By following NumPy's 1.7.0 approach in their [setup.py](https://github.com/numpy/numpy/blob/maintenance/1.7.x/setup.py), I tried to apply the following patch:

``` diff
commit c6c40f0cdbc1a4774730d4acc093ed4716cb2761
Author: Ondřej Čertík <ondrej.certik@gmail.com>
Date:   Sun Jul 7 21:50:31 2013 -0600

    Try to fix the directory change

diff --git a/setup.py b/setup.py
index 6142f7c..235c805 100755
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,12 @@

 if sys.version_info[0] >= 3:
     local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
+    src_path = os.path.join(local_path, 'build', 'py3k')
     os.system("bin/use2to3")
-    os.chdir("py3k-sympy")
-    sys.path.insert(0, os.path.join(local_path, 'py3k-sympy'))
+    os.system("mkdir -p build")
+    os.system("mv py3k-sympy %s" % src_path)
+    os.chdir(src_path)
+    sys.path.insert(0, src_path)

 import sympy


```

and even this on top of it:

``` diff
diff --git a/setup.py b/setup.py
index 235c805..580c7d4 100755
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@
     os.system("bin/use2to3")
     os.system("mkdir -p build")
     os.system("mv py3k-sympy %s" % src_path)
+    global __file__
+    __file__ = os.path.join(os.curdir, os.path.basename(__file__))
+
     os.chdir(src_path)
     sys.path.insert(0, src_path)

```

But unfortunately neither fixes the problem. The core of the problem is that we change the current directory in setup.py (following the NumPy's approach), but for some reason NumPy works, but this code doesn't yet.
### TODO
- [ ] Fix the prefix path bug (see above)
- [x] Update .travis.yml to test this
- [ ] If `use2to3` is run manually, then the setup.py should not run 2to3 again (currently it always runs it in Python 3)
- [ ] Test this in all scenarios and make sure it always does the right thing
- [ ] Update `use2to3` to also work from a release tarball (currently it needs the git repository)
- [ ] Currently the `bin/doctest doc` doesn't find any tests in Travis, which is a bug in doctest ([#3935](http://code.google.com/p/sympy/issues/detail?id=3935))
