### PR TITLE
Allowing exp( ) function to act on a Matrix

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1,13 +1,14 @@
 from sympy.core import C, sympify
 from sympy.core.add import Add
-from sympy.core.function import Lambda, Function, ArgumentIndexError
 from sympy.core.cache import cacheit
+from sympy.core.function import Lambda, Function, ArgumentIndexError, \
+    _coeff_isneg
+from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
-from sympy.core.mul import Mul
-
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
+
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -242,7 +243,7 @@ class exp(ExpBase):
             # Warning: code in risch.py will be very sensitive to changes
             # in this (see DifferentialExtension).
 
-            # look for a single log factor
+            # look for a single log facosstor
 
             coeff, terms = arg.as_coeff_Mul()
 
@@ -278,6 +279,10 @@ class exp(ExpBase):
                     out.append(newa)
             if out:
                 return Mul(*out)*cls(Add(*add), evaluate=False)
+
+        elif arg.is_Matrix:
+            from sympy import Matrix
+            return Matrix(arg).exp()
 
     @property
     def base(self):
@@ -760,5 +765,3 @@ class LambertW(Function):
             return LambertW(x)/(x*(1 + LambertW(x)))
         else:
             raise ArgumentIndexError(self, argindex)
-
-from sympy.core.function import _coeff_isneg

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -281,7 +281,7 @@ class exp(ExpBase):
 
         elif arg.is_Matrix:
             from sympy import Matrix
-            return Matrix(arg).exp()
+            return arg.exp()
 
     @property
     def base(self):

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1,14 +1,13 @@
 from sympy.core import C, sympify
 from sympy.core.add import Add
+from sympy.core.function import Lambda, Function, ArgumentIndexError
 from sympy.core.cache import cacheit
-from sympy.core.function import Lambda, Function, ArgumentIndexError, \
-    _coeff_isneg
-from sympy.core.mul import Mul
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
+from sympy.core.mul import Mul
+
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
-
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz
@@ -243,7 +242,7 @@ class exp(ExpBase):
             # Warning: code in risch.py will be very sensitive to changes
             # in this (see DifferentialExtension).
 
-            # look for a single log facosstor
+            # look for a single log factor
 
             coeff, terms = arg.as_coeff_Mul()
 
@@ -765,3 +764,5 @@ class LambertW(Function):
             return LambertW(x)/(x*(1 + LambertW(x)))
         else:
             raise ArgumentIndexError(self, argindex)
+
+from sympy.core.function import _coeff_isneg

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3538,7 +3538,8 @@ class MatrixBase(object):
             raise ShapeError(
                 "`self` and `rhs` must have the same number of rows.")
 
-        newmat = self.zeros(self.rows, self.cols + rhs.cols)
+        from sympy.matrices import MutableMatrix
+        newmat = MutableMatrix.zeros(self.rows, self.cols + rhs.cols)
         newmat[:, :self.cols] = self
         newmat[:, self.cols:] = rhs
         return newmat

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3542,7 +3542,7 @@ class MatrixBase(object):
         newmat = MutableMatrix.zeros(self.rows, self.cols + rhs.cols)
         newmat[:, :self.cols] = self
         newmat[:, self.cols:] = rhs
-        return newmat
+        return type(self)(newmat)
 
     def col_join(self, bott):
         """Concatenates two matrices along self's last and bott's first row
@@ -3650,12 +3650,13 @@ class MatrixBase(object):
         if self.rows != mti.rows:
             raise ShapeError("self and mti must have the same number of rows.")
 
-        newmat = self.zeros(self.rows, self.cols + mti.cols)
+        from sympy.matrices import MutableMatrix
+        newmat = MutableMatrix.zeros(self.rows, self.cols + mti.cols)
         i, j = pos, pos + mti.cols
         newmat[:, :i] = self[:, :i]
         newmat[:, i:j] = mti
         newmat[:, j:] = self[:, i:]
-        return newmat
+        return type(self)(newmat)
 
     def replace(self, F, G, map=False):
         """Replaces Function F in Matrix entries with Function G.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1451,11 +1451,13 @@ def test_Matrix_berkowitz_charpoly():
 
 def test_exp():
     m = Matrix([[3, 4], [0, -2]])
-    assert m.exp() == \
-        Matrix([[exp(3), -4*exp(-2)/5 + 4*exp(3)/5], [0, exp(-2)]])
+    m_exp = Matrix([[exp(3), -4*exp(-2)/5 + 4*exp(3)/5], [0, exp(-2)]])
+    assert m.exp() == m_exp
+    assert exp(m) == m_exp
 
     m = Matrix([[1, 0], [0, 1]])
     assert m.exp() == Matrix([[E, 0], [0, E]])
+    assert exp(m) == Matrix([[E, 0], [0, E]])
 
 
 def test_has():


### PR DESCRIPTION
This is a quick fix to allow calling exp( ) function on a matrix instance, it's just a wrapper to call Matrix.exp( )
