### PR TITLE
Don't show pylab's welcome message when creating a new session

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -454,15 +454,21 @@ def init_session(ipython=None, pretty_print=True, order=None,
             # and False means don't add the line to IPython's history.
             ip.runsource = lambda src, symbol='exec': ip.run_cell(src, False)
 
-            #Enable interactive plotting using pylab.
+            # Enable interactive plotting using pylab.
             try:
-                ip.enable_pylab(import_all=False)
+                if IPython.__version__ >= '0.14':
+                    ip.enable_pylab(import_all=False, welcome_message=False)
+                else:
+                    ip.enable_pylab(import_all=False)
+            except TypeError:
+                raise
             except Exception:
                 # Causes an import error if matplotlib is not installed.
                 # Causes other errors (depending on the backend) if there
                 # is no display, or if there is some problem in the
                 # backend, so we have a bare "except Exception" here
                 pass
+
         if not in_ipython:
             mainloop = ip.mainloop
 


### PR DESCRIPTION
Previously:

$ bin/isympy -q

Welcome to pylab, a matplotlib-based Python environment [backend: agg].
For more information, type 'help(pylab)'.
IPython console for SymPy 0.7.3-git (Python 2.7.2-64-bit) (ground types:
gmpy)

In [1]:

Now:

$ bin/isympy -q
IPython console for SymPy 0.7.3-git (Python 2.7.2-64-bit) (ground types:
gmpy)

In [1]:
