### PR TITLE
Issue 3943: document integral_steps, which Gamma uses

### DIFF
--- a/doc/src/modules/integrals/integrals.rst
+++ b/doc/src/modules/integrals/integrals.rst
@@ -107,6 +107,8 @@ API reference
 
 .. automethod:: sympy.integrals.manualintegrate
 
+.. automethod:: sympy.integrals.manualintegrate.integral_steps
+
 The class `Integral` represents an unevaluated integral and has some methods that help in the integration of an expression.
 
 .. autoclass:: sympy.integrals.Integral

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -658,6 +658,28 @@ def integral_steps(integrand, symbol, **options):
     found at
     https://github.com/sympy/sympy_gamma/blob/master/app/logic/intsteps.py.
 
+    Examples
+    =======
+
+    >>> from sympy import exp, sin, cos
+    >>> from sympy.integrals.manualintegrate import integral_steps
+    >>> from sympy.abc import x
+    >>> integral_steps(exp(x) / (1 + exp(2 * x)), x) #doctest: +SKIP
+    URule(u_var=_Dummy_14, u_func=exp(x), constant=1,
+        substep=ArctanRule(context=1/(_Dummy_14**2 + 1), symbol=_Dummy_14),
+        context=exp(x)/(exp(2*x) + 1), symbol=x)
+    >>> integral_steps(sin(x), x) #doctest: +SKIP
+        TrigRule(func='sin', arg=x, context=sin(x), symbol=x)
+    >>> integral_steps((x**2 + 3)**2 , x) #doctest: +SKIP
+    RewriteRule(rewritten=x**4 + 6*x**2 + 9,
+    substep=AddRule(substeps=[PowerRule(base=x, exp=4, context=x**4, symbol=x),
+        ConstantTimesRule(constant=6, other=x**2,
+            substep=PowerRule(base=x, exp=2, context=x**2, symbol=x),
+                context=6*x**2, symbol=x),
+        ConstantRule(constant=9, context=9, symbol=x)],
+    context=x**4 + 6*x**2 + 9, symbol=x), context=(x**2 + 3)**2, symbol=x)
+
+
     Returns
     =======
     rule : namedtuple

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -653,12 +653,18 @@ def integral_steps(integrand, symbol, **options):
     This function attempts to mirror what a student would do by hand as
     closely as possible.
 
+    SymPy Gamma uses this to provide a step-by-step explanation of an
+    integral. The code it uses to format the results of this function can be
+    found at
+    https://github.com/sympy/sympy_gamma/blob/master/app/logic/intsteps.py.
+
     Returns
     =======
     rule : namedtuple
         The first step; most rules have substeps that must also be
-        considered. These substeps can be evaluated using `manualintegrate`
+        considered. These substeps can be evaluated using ``manualintegrate``
         to obtain a result.
+
     """
     cachekey = (integrand, symbol)
     if cachekey in _integral_cache:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -233,7 +233,7 @@ def arctan_rule(integral):
             a, b = match[a], match[b]
 
             if a != 1 or b != 1:
-                u_var = sympy.Dummy()
+                u_var = sympy.Dummy("u")
                 rewritten = sympy.Rational(1, a) * (base / a) ** (-1)
                 u_func = sympy.sqrt(sympy.Rational(b, a)) * symbol
                 constant = 1 / sympy.sqrt(sympy.Rational(b, a))
@@ -309,7 +309,7 @@ def _parts_rule(integrand, symbol):
                    pull_out_u(sympy.exp)]
 
 
-    dummy = sympy.Dummy()
+    dummy = sympy.Dummy("temporary")
     # we can integrate log(x) and atan(x) by setting dv = 1
     if isinstance(integrand, sympy.log) or isinstance(integrand, sympy.atan):
         integrand = dummy * integrand
@@ -589,7 +589,7 @@ def trig_powers_products_rule(integral):
 def substitution_rule(integral):
     integrand, symbol = integral
 
-    u_var = sympy.Dummy()
+    u_var = sympy.Dummy("u")
     substitutions = find_substitutions(integrand, symbol, u_var)
     if substitutions:
         ways = []
@@ -659,18 +659,23 @@ def integral_steps(integrand, symbol, **options):
     https://github.com/sympy/sympy_gamma/blob/master/app/logic/intsteps.py.
 
     Examples
-    =======
+    ========
 
     >>> from sympy import exp, sin, cos
-    >>> from sympy.integrals.manualintegrate import integral_steps
+    >>> from sympy.integrals.manualintegrate import (integral_steps, URule,
+    ... TrigRule, RewriteRule)
     >>> from sympy.abc import x
-    >>> integral_steps(exp(x) / (1 + exp(2 * x)), x) #doctest: +SKIP
-    URule(u_var=_Dummy_14, u_func=exp(x), constant=1,
-        substep=ArctanRule(context=1/(_Dummy_14**2 + 1), symbol=_Dummy_14),
+    >>> # The __repr__ is only needed here for doctest to pass.
+    >>> print(URule.__repr__(integral_steps(exp(x) / (1 + exp(2 * x)), x))) \
+    # doctest: +NORMALIZE_WHITESPACE
+    URule(u_var=_u, u_func=exp(x), constant=1,
+        substep=ArctanRule(context=1/(_u**2 + 1), symbol=_u),
         context=exp(x)/(exp(2*x) + 1), symbol=x)
-    >>> integral_steps(sin(x), x) #doctest: +SKIP
-        TrigRule(func='sin', arg=x, context=sin(x), symbol=x)
-    >>> integral_steps((x**2 + 3)**2 , x) #doctest: +SKIP
+    >>> print(TrigRule.__repr__(integral_steps(sin(x), x))) \
+    # doctest: +NORMALIZE_WHITESPACE
+    TrigRule(func='sin', arg=x, context=sin(x), symbol=x)
+    >>> print(RewriteRule.__repr__(integral_steps((x**2 + 3)**2 , x))) \
+    # doctest: +NORMALIZE_WHITESPACE
     RewriteRule(rewritten=x**4 + 6*x**2 + 9,
     substep=AddRule(substeps=[PowerRule(base=x, exp=4, context=x**4, symbol=x),
         ConstantTimesRule(constant=6, other=x**2,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -662,19 +662,17 @@ def integral_steps(integrand, symbol, **options):
     ========
 
     >>> from sympy import exp, sin, cos
-    >>> from sympy.integrals.manualintegrate import (integral_steps, URule,
-    ... TrigRule, RewriteRule)
+    >>> from sympy.integrals.manualintegrate import integral_steps
     >>> from sympy.abc import x
-    >>> # The __repr__ is only needed here for doctest to pass.
-    >>> print(URule.__repr__(integral_steps(exp(x) / (1 + exp(2 * x)), x))) \
+    >>> print(repr(integral_steps(exp(x) / (1 + exp(2 * x)), x))) \
     # doctest: +NORMALIZE_WHITESPACE
     URule(u_var=_u, u_func=exp(x), constant=1,
         substep=ArctanRule(context=1/(_u**2 + 1), symbol=_u),
         context=exp(x)/(exp(2*x) + 1), symbol=x)
-    >>> print(TrigRule.__repr__(integral_steps(sin(x), x))) \
+    >>> print(repr(integral_steps(sin(x), x))) \
     # doctest: +NORMALIZE_WHITESPACE
     TrigRule(func='sin', arg=x, context=sin(x), symbol=x)
-    >>> print(RewriteRule.__repr__(integral_steps((x**2 + 3)**2 , x))) \
+    >>> print(repr(integral_steps((x**2 + 3)**2 , x))) \
     # doctest: +NORMALIZE_WHITESPACE
     RewriteRule(rewritten=x**4 + 6*x**2 + 9,
     substep=AddRule(substeps=[PowerRule(base=x, exp=4, context=x**4, symbol=x),


### PR DESCRIPTION
Changes:
- Add `sympy.integrals.manualintegrate.integral_steps` to the Sphinx docs
- Update the docstring to point to Gamma's code

Addresses [issue 3943](https://code.google.com/p/sympy/issues/detail?id=3943).
