### PR TITLE
WIP: Added support for @XFAIL(exception, message) (#3945)

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2925,7 +2925,7 @@ def test_sympy__categories__baseclasses__Object():
     assert _test_args(Object("A"))
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_sympy__categories__baseclasses__Morphism():
     from sympy.categories import Object, Morphism
     assert _test_args(Morphism(Object("A"), Object("B")))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1125,7 +1125,7 @@ def test_Add_is_irrational():
     assert (i + 1).is_rational is False
 
 
-@XFAIL
+@XFAIL(AttributeError, "'Tuple' object has no attribute '_eval_power'")
 def test_issue432():
     class MightyNumeric(tuple):
         def __rdiv__(self, other):

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -156,7 +156,10 @@ def test_issue_2689():
         assert set(o(*args))  # doesn't fail
 
 
-@XFAIL
+# TODO:
+# *: AssertionError
+# 3.3: TypeError: unorderable types: FiniteSet() < FiniteSet()
+@XFAIL(Exception)
 def test_issue_2689b():
     args = [(1, 2), (2, 1)]
     for o in [FiniteSet]:

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -1,7 +1,8 @@
 from sympy.core import (Rational, Symbol, S, Float, Integer, Number, Pow,
-Basic, I, nan)
+    Basic, I, nan)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.trigonometric import sin
 from sympy.utilities.pytest import XFAIL
 
 
@@ -270,7 +271,8 @@ def test_issue_2969():
         sqrt(x**3) - x**6*sqrt(x**3)/12 + x**12*sqrt(x**3)/1440 - \
         x**18*sqrt(x**3)/24192 + O(x**20)
 
-@XFAIL
+@XFAIL # XXX: assert s1.getn() == n
 def test_issue_3683():
+    x = Symbol('x')
     assert sqrt(sin(x**3)).series(x, 0, 7) == sqrt(x**3) + O(x**7)
     assert sqrt(sin(x**4)).series(x, 0, 3) == sqrt(x**4) + O(x**4)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1,7 +1,7 @@
 from sympy import (Lambda, Symbol, Function, Derivative, Subs, sqrt,
         log, exp, Rational, Float, sin, cos, acos, diff, I, re, im,
         E, expand, pi, O, Sum, S, polygamma, loggamma, expint,
-        Tuple, Dummy, Eq, Expr, symbols, nfloat)
+        Tuple, Dummy, Eq, Expr, symbols, nfloat, oo)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import t, w, x, y, z
 from sympy.core.function import PoleError

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -186,7 +186,7 @@ def test_functions():
     assert notf.match(g) is None
 
 
-@XFAIL
+@XFAIL(TypeError, "'WildFunction' object is not callable")
 def test_functions_X1():
     from sympy.core.function import WildFunction
     x = Symbol('x')

--- a/sympy/core/tests/test_noncommutative.py
+++ b/sympy/core/tests/test_noncommutative.py
@@ -19,6 +19,7 @@ from sympy import (
     transpose,
     trigsimp,
     I,
+    PolynomialError,
 )
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import XFAIL
@@ -100,7 +101,7 @@ def test_radsimp():
     assert radsimp(A*B - B*A) == A*B - B*A
 
 
-@XFAIL
+@XFAIL(PolynomialError, "non-commutative expressions are not supported")
 def test_ratsimp():
     assert ratsimp(A*B - B*A) == A*B - B*A
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1315,8 +1315,10 @@ def test_issue_1073():
     assert int((Rational(1)/EulerGamma**100).round()) == \
         734833795660954410469466
 
-
-@XFAIL(TypeError, "6 arguments required")
+# TODO:
+# python: "_normalize() takes exactly 6 arguments (2 given)"
+# gmpy: "6 arguments required"
+@XFAIL(TypeError)
 def test_mpmath_issues():
     from sympy.mpmath.libmp.libmpf import _normalize
     import sympy.mpmath.libmp as mlib

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1316,7 +1316,7 @@ def test_issue_1073():
         734833795660954410469466
 
 
-@XFAIL
+@XFAIL(TypeError, "6 arguments required")
 def test_mpmath_issues():
     from sympy.mpmath.libmp.libmpf import _normalize
     import sympy.mpmath.libmp as mlib

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -13,7 +13,8 @@ from sympy import (Rational, symbols, factorial, sqrt, log, exp, oo, product,
     bernoulli, hyper, hyperexpand, besselj, asin, assoc_legendre, Function, re,
     im, DiracDelta, chebyshevt, atan, sinh, cosh, floor, ceiling, solve, asinh,
     LambertW, N, apart, sqrtdenest, factorial2, powdenest, Mul, S, mpmath, ZZ,
-    Poly, expand_func, E, Q, And, Or, Le, Lt, Ge, Gt, QQ, ask)
+    Poly, expand_func, E, Q, And, Or, Le, Lt, Ge, Gt, QQ, ask, zeta, acos,
+    conjugate, Equality)
 
 from sympy.functions.combinatorial.numbers import stirling
 from sympy.integrals.deltafunctions import deltaintegrate
@@ -158,7 +159,7 @@ def test_C23():
     assert 2 * oo - 3 == oo
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_C24():
     raise NotImplementedError("2**aleph_null == aleph_1")
 
@@ -182,22 +183,22 @@ def test_D4():
     assert ceiling(R(-5, 3)) == -1
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D5():
     raise NotImplementedError("cubic_spline([1, 2, 4, 5], [1, 4, 2, 3], x)(3) == 27/8")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D6():
     raise NotImplementedError("translate sum(a[i]*x**i, (i,1,n)) to FORTRAN")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D7():
     raise NotImplementedError("translate sum(a[i]*x**i, (i,1,n)) to C")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D8():
     # One way is to cheat by converting the sum to a string,
     # and replacing the '[' and ']' with ''.
@@ -205,28 +206,28 @@ def test_D8():
     raise NotImplementedError("apply Horner's rule to sum(a[i]*x**i, (i,1,5))")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D9():
     raise NotImplementedError("translate D8 to FORTRAN")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D10():
     raise NotImplementedError("translate D8 to C")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D11():
     #Is there a way to use count_ops?
     raise NotImplementedError("flops(sum(product(f[i][k], (i,1,k)), (k,1,n)))")
 
 
-@XFAIL
+@XFAIL(TypeError, "'NoneType' object is not iterable")
 def test_D12():
     assert (mpi(-4, 2) * x + mpi(1, 3)) ** 2 == mpi(-8, 16)*x**2 + mpi(-24, 12)*x + mpi(1, 9)
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_D13():
     raise NotImplementedError("discretize a PDE: diff(f(x,t),t) == diff(diff(f(x,t),x),x)")
 
@@ -283,12 +284,12 @@ def test_G1():
     assert list(primerange(999983, 1000004)) == [999983, 1000003]
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_G2():
     raise NotImplementedError("find the primitive root of 191 == 19")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_G3():
     raise NotImplementedError("(a+b)**p mod p == a**p + b**p mod p; p prime")
 
@@ -403,11 +404,9 @@ def test_H17():
     assert simplify(factor(expand(p1 * p2)) - p1*p2) == 0
 
 
-@XFAIL
 def test_H18():
-    # Factor over complex rationals.
-    test = factor(4*x**4 + 8*x**3 + 77*x**2 + 18*x + 53)
-    good = (2*x + 3*I)*(2*x - 3*I)*(x + 1 - 4*I)(x + 1 + 4*I)
+    test = factor(4*x**4 + 8*x**3 + 77*x**2 + 18*x + 153, extension=I)
+    good = 4*((x - 3*I/2)*(x + 3*I/2)*(x + 1 - 4*I)*(x + 1 + 4*I))
     assert test == good
 
 
@@ -417,13 +416,13 @@ def test_H19():
     assert Poly(a - 1).invert(Poly(a**2 - 2)) == a + 1
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_H20():
     raise NotImplementedError("let a**2==2; (x**3 + (a-2)*x**2 - "
         + "(2*a+3)*x - 3*a) / (x**2-2) = (x**2 - 2*x - 3) / (x-a)")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_H21():
     raise NotImplementedError("evaluate (b+c)**4 assuming b**3==2, c**2==3. \
                               Answer is 2*b + 8*c + 18*b**2 + 12*b*c + 9")
@@ -439,7 +438,7 @@ def test_H23():
     assert factor(f, modulus=65537) == g
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_H24():
     raise NotImplementedError("factor x**4 - 3*x**2 + 1, GoldenRatio")
 
@@ -466,13 +465,13 @@ def test_H27():
     assert factor(expand(f*g)) == h
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_H28():
     raise NotImplementedError("expand ((1 - c**2)**5 * (1 - s**2)**5 * "
         + "(c**2 + s**2)**10) with c**2 + s**2 = 1. Answer is c**10*s**10.")
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "multivariate polynomials over finite fields")
 def test_H29():
     assert factor(4*x**2 - 21*x*y + 20*y**2, modulus=3) == (x + y)*(x - y)
 
@@ -489,7 +488,7 @@ def test_H31():
     assert apart(f) == g
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_H32():  # issue 3459
     raise NotImplementedError("[A*B*C - (A*B*C)**(-1)]*A*C*B (product \
                               of a non-commuting product and its inverse)")
@@ -529,7 +528,7 @@ def test_I5():
     assert sin((n**5/5 + n**4/2 + n**3/3 - n/30) * pi) == 0
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_I6():
     raise NotImplementedError("assuming -3*pi<x<-5*pi/2, abs(cos(x)) == -cos(x), abs(sin(x)) == -sin(x)")
 
@@ -575,12 +574,12 @@ def test_J1():
     assert bernoulli(16) == R(-3617, 510)
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_J2():
     raise NotImplementedError("diff(E(phi,k), k) == (E(phi,k) - F(phi,k)) / k; F() and E() are elliptic integrals of the 1st and 2nd kind, respectively")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_J3():
     raise NotImplementedError("Jacobi elliptic functions: diff(dn(u,k), u) == -k**2*sn(u,k)*cn(u,k)")
 
@@ -635,12 +634,12 @@ def test_J14():
     assert hyperexpand(p) == asin(z)/z
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_J15():
     raise NotImplementedError("F((n+2)/2,-(n-2)/2,R(3,2),sin(z)**2) == sin(n*z)/(n*sin(z)*cos(z)); F(.) is hypergeometric function")
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_J16():
     raise NotImplementedError("diff(zeta(x), x) @ x=0 == -log(2*pi)/2")
 
@@ -650,7 +649,7 @@ def test_J17():
     assert deltaintegrate(f((x + 2)/5)*DiracDelta((x - 2)/3) - g(x)*diff(DiracDelta(x - 1), x), (x, 0, 3))
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_J18():
     raise NotImplementedError("define an antisymmetric function")
 
@@ -762,7 +761,7 @@ def test_L9():
 # M. Equations
 
 
-@XFAIL
+@XFAIL(TypeError, "unsupported operand type(s) for +: 'Mul' and 'bool'")
 def test_M1():
     assert Equality(x, 2)/2 + Equality(1, 1) == Equality(x/2 + 1, 2)
 
@@ -813,7 +812,7 @@ def test_M8():
     # where n is an arbitrary integer.  See url of detailed output above.
 
 
-@XFAIL
+@XFAIL(NotImplementedError)
 def test_M9():
     x = symbols('x', complex=True)
     raise NotImplementedError("solve(exp(2-x**2)-exp(-x),x) has complex solutions.")
@@ -853,12 +852,14 @@ def test_M16():
     assert solve(sin(x) - tan(x), x) == [0, 2*pi]
 
 
-@XFAIL
+@XFAIL(NotImplementedError, """multiple generators [asin(x), atan(x)]
+No algorithms are implemented to solve equation asin(x) - atan(x)""")
 def test_M17():
     assert solve(asin(x) - atan(x),x) == [0]
 
 
-@XFAIL
+@XFAIL(NotImplementedError, """multiple generators [acos(x), atan(x)]
+No algorithms are implemented to solve equation acos(x) - atan(x)""")
 def test_M18():
     assert solve(acos(x) - atan(x), x) == [sqrt((sqrt(5) - 1)/2)]
 
@@ -909,10 +910,11 @@ def test_M27():
     x = symbols('x', real=True)
     b = symbols('b', real=True)
     with assuming(Q.is_true(sin(cos(1/E**2) + 1) + b > 0)):
-        solve(log(acos(asin(x**R(2,3) - b) - 1)) + 2, x) == [-b - sin(1 + cos(1/e**2))**R(3/2), b + sin(1 + cos(1/e**2))**R(3/2)]
+        assert solve(log(acos(asin(x**R(2,3) - b) - 1)) + 2, x) == [-b - sin(1 + cos(1/E**2))**R(3/2), b + sin(1 + cos(1/E**2))**R(3/2)]
 
 
-@XFAIL
+@XFAIL(NotImplementedError, """multiple generators [x, exp(x/2)]
+No algorithms are implemented to solve equation -8*x**3 + 5*x + exp(x/2 - 5/2)""")
 def test_M28():
     assert solve(5*x + exp((x - 5)/2) - 8*x**3, x, assume=Q.real(x)) == [-0.784966, -0.016291, 0.802557]
 
@@ -953,7 +955,7 @@ def test_M35():
     assert solve((3*x - 2*y - I*y + 3*I).as_real_imag()) == {y: 3, x: 2}
 
 
-@XFAIL
+@XFAIL(TypeError, "unsupported operand type(s) for ** or pow(): 'UndefinedFunction' and 'int'")
 def test_M36():
     assert solve(f**2 + f - 2, x) == [Eq(f(x), 1), Eq(f(x), -2)]
 
@@ -1040,7 +1042,7 @@ def test_N2():
     assert ask(Q.is_true(x**4 - x + 1 > 1)) == False
 
 
-@XFAIL
+@XFAIL(TypeError, "proposition must be a valid logical expression")
 def test_N3():
     x = symbols('x', real=True)
     assert ask(Q.is_true(And(Lt(-1, x), Lt(x, 1))), Q.is_true(abs(x) < 1 ))

--- a/sympy/external/tests/test_autowrap.py
+++ b/sympy/external/tests/test_autowrap.py
@@ -139,25 +139,25 @@ def test_wrap_twice_c_cython():
     runtest_autowrap_twice('C', 'cython')
 
 
-@XFAIL
+@XFAIL(CodeWrapError)
 def test_autowrap_trace_C_Cython():
     has_module('Cython')
     runtest_autowrap_trace('C', 'cython')
 
 
-@XFAIL
+@XFAIL(CodeWrapError)
 def test_autowrap_matrix_vector_C_cython():
     has_module('Cython')
     runtest_autowrap_matrix_vector('C', 'cython')
 
 
-@XFAIL
+@XFAIL(CodeWrapError)
 def test_autowrap_matrix_matrix_C_cython():
     has_module('Cython')
     runtest_autowrap_matrix_matrix('C', 'cython')
 
 
-@XFAIL
+@XFAIL(CodeWrapError)
 def test_ufuncify_C_Cython():
     has_module('Cython')
     runtest_ufuncify('C', 'cython')

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -151,6 +151,9 @@ def test_euler():
 @XFAIL
 def test_euler_failing():
     # depends on dummy variables being implemented http://code.google.com/p/sympy/issues/detail?id=2566
+    n = Symbol('n', integer=True)
+    _j = Dummy('j')
+    _k = Dummy('k')
     assert euler(2*n).rewrite(Sum) == I*Sum(Sum((-1)**_j*2**(-_k)*I**(-_k)*(-2*_j + _k)**(2*n + 1)*binomial(_k, _j)/_k, (_j, 0, _k)), (_k, 1, 2*n + 1))
 
 

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -557,9 +557,10 @@ def test_periodic_argument():
     assert periodic_argument(pi*p, p) == periodic_argument(p, p)
 
 
-@XFAIL
+@XFAIL(AttributeError, "'int' object has no attribute 'n'")
 def test_principal_branch_fail():
     # TODO XXX why does abs(x)._eval_evalf() not fall back to global evalf?
+    from sympy import principal_branch
     assert N_equals(principal_branch((1 + I)**2, pi/2), 0)
 
 

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -214,6 +214,7 @@ def test_series():
 
 @XFAIL
 def test_issue_1050():
+    y = Symbol('y')
     assert floor(3 + pi*I + y*I) == 3 + floor(pi + y)*I
     assert floor(3*I + pi*I + y*I) == floor(3 + pi + y)*I
     assert floor(3 + E + pi*I + y*I) == 5 + floor(pi + y)*I

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -849,7 +849,7 @@ def test_polygon():
     assert p3.distance(pt2) == sqrt(2)/2
 
 
-@XFAIL
+@XFAIL(NameError, "global name 'p1' is not defined")
 def test_polygon_to_polygon():
     '''Polygon to Polygon'''
     # XXX: Because of the way the warnings filters work, this will fail if it's

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -9,7 +9,7 @@ from sympy import (
 
 from sympy.utilities.pytest import XFAIL, skip, slow
 
-from sympy.abc import x, k, c, y, R, b, h, a, m, A, z, t
+from sympy.abc import x, k, c, y, R, b, h, a, m, n, A, z, t
 
 import signal
 
@@ -79,6 +79,7 @@ def test_issue_1415():
 
 
 @XFAIL
+@slow
 def test_issue_1426():
     # Warning: takes a long time
     assert not integrate((x**m * (1 - x)**n * (a + b*x + c*x**2))/(1 + x**2), (x, 0, 1)).has(Integral)

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -1,6 +1,6 @@
 from sympy import Rational, sqrt, symbols, sin, exp, log, sinh, cosh, cos, pi, \
     I, S, erf, tan, asin, asinh, acos, acosh, Function, Derivative, diff, simplify, \
-    LambertW, Eq, Piecewise, Symbol, Add, ratsimp
+    LambertW, Eq, Piecewise, Symbol, Add, ratsimp, besselj
 from sympy.integrals.heurisch import components, heurisch, heurisch_wrapper
 from sympy.utilities.pytest import XFAIL, skip, slow
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -4,7 +4,7 @@ from sympy import (
     Heaviside, I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, sqrt,
     sstr, Sum, Symbol, symbols, sympify, terms_gcd, transpose, trigsimp,
-    Tuple, nan, And, Eq, Or
+    Tuple, nan, And, Eq, Or, PolynomialDivisionFailed,
 )
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.utilities.pytest import XFAIL, raises, slow
@@ -981,7 +981,11 @@ def test_issue_3729():
     h = 0.925925925925926/(1.0*x**2 - 3.98148148148148)
     assert integrate(f, x).diff(x).simplify().equals(f) is True
 
-@XFAIL
+@XFAIL(PolynomialDivisionFailed, """couldn't reduce degree in a polynomial division algorithm \
+when dividing [EX(13.2075145209219*pi)] by [EX(1.00000000000000)]. This can happen when it's \
+not possible to detect zero in the coefficient domain. The domain of computation is EX. You may \
+want to use a different simplification algorithm. Note that in general it's not possible to \
+guarantee to detect zero in this domain.""")
 def test_integrate_Piecewise_rational_over_reals():
     f = Piecewise(
         (0,                                              t - 478.515625*pi <  0),

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -75,7 +75,7 @@ def test_special_denom():
         (Poly(1, t0), Poly(I*k, t0), Poly(t0, t0), Poly(1, t0))
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "param_rischDE() is required to solve this integral.")
 def test_bound_degree_fail():
     # Primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x),

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1362,7 +1362,7 @@ def test_diagonalization():
     assert m.is_diagonalizable()
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "Can't evaluate eigenvector for eigenvalue 1/2 + I/2 - sqrt(2)*sqrt(-I)/2")
 def test_eigen_vects():
     m = Matrix(2, 2, [1, 0, 0, I])
     raises(NotImplementedError, lambda: m.is_diagonalizable(True))

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -18,7 +18,7 @@ from sympy.utilities.pytest import raises
 from sympy.utilities.pytest import XFAIL
 
 
-@XFAIL
+@XFAIL(TypeError, "__new__() takes exactly 3 arguments (1 given)")
 def test_spin():
     assert operators_to_state(set([J2Op, JxOp])) == JxKet()
     assert operators_to_state(set([J2Op, JyOp])) == JyKet()

--- a/sympy/physics/quantum/tests/test_operatorset.py
+++ b/sympy/physics/quantum/tests/test_operatorset.py
@@ -18,7 +18,10 @@ from sympy.utilities.pytest import raises
 from sympy.utilities.pytest import XFAIL
 
 
-@XFAIL(TypeError, "__new__() takes exactly 3 arguments (1 given)")
+# TODO:
+# *: "__new__() takes exactly 3 arguments (1 given)")
+# 3.3: "__new__() missing 2 required positional arguments: 'j' and 'm'"
+@XFAIL(TypeError)
 def test_spin():
     assert operators_to_state(set([J2Op, JxOp])) == JxKet()
     assert operators_to_state(set([J2Op, JyOp])) == JyKet()

--- a/sympy/physics/quantum/tests/test_shor.py
+++ b/sympy/physics/quantum/tests/test_shor.py
@@ -7,7 +7,7 @@ from sympy.physics.quantum.shor import (
 )
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "The CMod gate has not been completed.")
 def test_CMod():
     assert qapply(CMod(4, 2, 2)*Qubit(0, 0, 1, 0, 0, 0, 0, 0)) == \
         Qubit(0, 0, 1, 0, 0, 0, 0, 0)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -127,7 +127,7 @@ def test_basic_state():
     assert s.up(0) == BosonState([n + 1, m])
 
 
-@XFAIL
+@XFAIL(NameError, "global name 'move' is not defined")
 def test_move1():
     i, j = symbols('i,j')
     A, C = symbols('A,C', cls=Function)
@@ -136,7 +136,7 @@ def test_move1():
     assert move(o, 0, 1) == KroneckerDelta(i, j) + C(j)*A(i)
 
 
-@XFAIL
+@XFAIL(NameError, "global name 'move' is not defined")
 def test_move2():
     i, j = symbols('i,j')
     A, C = symbols('A,C', cls=Function)

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -268,7 +268,7 @@ def test_FracElement_diff():
 
     assert ((x**2 + y)/(z + 1)).diff(x) == 2*x/(z + 1)
 
-@XFAIL
+@XFAIL(AttributeError) # TODO: "'mpz/int' object has no attribute 'ring'"
 def test_FracElement___call__():
     F, x,y,z = field("x,y,z", ZZ)
     f = (x**2 + 3*y)/z

--- a/sympy/printing/tests/test_gtk.py
+++ b/sympy/printing/tests/test_gtk.py
@@ -1,11 +1,10 @@
 from sympy import print_gtk, sin
+from sympy.external import import_module
 from sympy.utilities.pytest import XFAIL, raises
 
-# this test fails if python-lxml isn't installed. We don't want to depend on
-# anything with SymPy
+if not import_module('lxml'):
+    disabled = True
 
-
-@XFAIL
 def test_1():
     from sympy.abc import x
     print_gtk(x**2, start_viewer=False)

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -127,7 +127,10 @@ def test_grunts_eval_special_slow_sometimes_fail():
     assert gruntz(exp(gamma(x - exp(-x))*exp(1/x)) - exp(gamma(x)), x, oo) == oo
 
 
-@XFAIL(NotImplementedError, "Don't know how to calculate the mrv of 'Subs(Derivative(zeta(_xi_1), _xi_1), (_xi_1,), (_p + _w**(-1/(log(2) + 1)),))'")
+# TODO: this fails with either of those messages:
+# "Don't know how to calculate the mrv of 'Subs(Derivative(zeta(_xi_1), _xi_1), (_xi_1,), (_p + _w**(-1/(log(2) + 1)),))'")
+# "Don't know how to calculate the mrv of 'Subs(Derivative(zeta(_xi_1), _xi_1), (_xi_1,), (_p,))'"
+@XFAIL(NotImplementedError)
 def test_gruntz_eval_special_fail():
     # TODO exponential integral Ei
     assert gruntz(

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -1,5 +1,5 @@
 from sympy import Symbol, exp, log, oo, Rational, I, sin, gamma, loggamma, S, \
-    atan, acot, pi, cancel, E, erf, sqrt, zeta, cos, digamma, Integer
+    atan, acot, pi, cancel, E, erf, sqrt, zeta, cos, digamma, Integer, Ei
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
 from sympy.utilities.pytest import XFAIL, skip
@@ -127,7 +127,7 @@ def test_grunts_eval_special_slow_sometimes_fail():
     assert gruntz(exp(gamma(x - exp(-x))*exp(1/x)) - exp(gamma(x)), x, oo) == oo
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "Don't know how to calculate the mrv of 'Subs(Derivative(zeta(_xi_1), _xi_1), (_xi_1,), (_p + _w**(-1/(log(2) + 1)),))'")
 def test_gruntz_eval_special_fail():
     # TODO exponential integral Ei
     assert gruntz(
@@ -363,7 +363,7 @@ def test_limit4():
     assert gruntz((3**(1/x) + 5**(1/x))**x, x, 0) == 5
 
 
-@XFAIL
+@XFAIL(AttributeError, "'tuple' object has no attribute 'difference'")
 def test_MrvTestCase_page47_ex3_21():
     h = exp(-x/(1 + exp(-x)))
     expr = exp(h)*exp(-x/(1 + h))*exp(exp(-x + h))/h**2 - exp(x) + x

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -203,7 +203,7 @@ def test_doit():
     assert l.doit() == oo
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "Don't know how to calculate the mrv of 'Integral(2*_p, x)'")
 def test_doit2():
     f = Integral(2 * x, x)
     l = Limit(f, x, oo)

--- a/sympy/series/tests/test_residues.py
+++ b/sympy/series/tests/test_residues.py
@@ -51,7 +51,7 @@ def test_expressions():
     assert residue(1/(x**4 + 1), x, 0) == 0
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "")
 def test_expressions_failing():
     x = Symbol('x')
     assert residue(1/(x**4 + 1), x, exp(I*pi/4)) == -(S(1)/4 + I/4)/sqrt(2)

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -66,7 +66,7 @@ def test_TransformationSet():
     assert harmonics.is_iterable
 
 
-@XFAIL
+@XFAIL(ValueError, "list.remove(x): x not in list")
 def test_halfcircle():
     # This test sometimes works and sometimes doesn't.
     # It may be an issue with solve? Maybe with using Lambdas/dummys?
@@ -146,7 +146,7 @@ def test_reals():
     assert (2, 5) not in S.Reals
 
 
-@XFAIL  # this is because contains is now very strict
+@XFAIL(TypeError, "proposition must be a valid logical expression")
 def test_reals_fail():
     assert sqrt(-1) not in S.Reals
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -401,7 +401,6 @@ def test_trigsimp_groebner():
 def test_factorial_simplify():
     # There are more tests in test_factorials.py. These are just to
     # ensure that simplify() calls factorial_simplify correctly
-    from sympy.specfun.factorials import factorial
     x = Symbol('x')
     assert simplify(factorial(x)/x) == factorial(x - 1)
     assert simplify(factorial(factorial(x))) == factorial(factorial(x))

--- a/sympy/solvers/tests/test_numeric.py
+++ b/sympy/solvers/tests/test_numeric.py
@@ -53,7 +53,7 @@ def test_issue_3309():
     assert nsolve(Piecewise((x, x < 1), (x**2, True)), x, 2) == 0.0
 
 
-@XFAIL
+@XFAIL(NameError, "global name 'Integral' is not defined")
 def test_issue_3309_fail():
     x, y = symbols('x y')
     assert nsolve(Integral(x*y, (x, 0, 5)), y, 2) == 0.0

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1116,7 +1116,9 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     assert checkodesol(eq28, sol28, order=1, solve_for_func=False)[0]
 
 
-@XFAIL
+@XFAIL(NotImplementedError, "Could not solve `-2*x - exp(I*x) + Derivative(f(x), x) \
++ 2*Derivative(f(x), x, x, x) + Derivative(f(x), x, x, x, x, x)` using the method of \
+undetermined coefficients (unable to solve for coefficients).")
 def test_nth_linear_constant_coeff_undetermined_coefficients_imaginary_exp():
     # Equivalent to eq26 in
     # test_nth_linear_constant_coeff_undetermined_coefficients above.

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1316,7 +1316,8 @@ def test_lambert_multivariate():
         acos(-3*LambertW(-log(3)/3)/log(3))]
 
 
-@XFAIL
+@XFAIL(NotImplementedError, """multiple generators [x, sin(x)]
+No algorithms are implemented to solve equation -x*sin(3) + 3*sin(x)""")
 def test_other_lambert():
     from sympy.abc import x
     assert solve(3*sin(x) - x*sin(3), x) == [3]
@@ -1341,7 +1342,7 @@ def test_rewrite_trig():
     assert solve(sinh(x) + tanh(x)) == [0, I*pi]
 
 
-@XFAIL
+@XFAIL(ImportError, "cannot import name sech")
 def test_rewrite_trigh():
     # if this import passes then the test below should also pass
     from sympy import sech

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -121,7 +121,7 @@ class ConditionalFiniteDomain(ConditionalDomain, ProductFiniteDomain):
         # where 'z' is a symbol that we don't know about
         # We will never be able to test this equality through iteration
         if not cond.free_symbols.issubset(domain.free_symbols):
-            raise ValueError('Condition "%s" contains foreign symbols \n%s.\n' % (
+            raise ValueError('Condition "%s" contains foreign symbols %s.\n' % (
                 condition, tuple(cond.free_symbols - domain.free_symbols)) +
                 "Will be unable to iterate using this condition")
 

--- a/sympy/stats/tests/test_rv.py
+++ b/sympy/stats/tests/test_rv.py
@@ -143,7 +143,8 @@ def test_dependence():
     assert dependent(XX, YY)
 
 
-@XFAIL
+@XFAIL(ValueError, """Condition "X + Y == z" contains foreign symbols (z,).
+Will be unable to iterate using this condition""")
 def test_dependent_finite():
     X, Y = Die('X'), Die('Y')
     # Dependence testing requires symbolic conditions which currently break

--- a/sympy/unify/tests/test_sympy.py
+++ b/sympy/unify/tests/test_sympy.py
@@ -132,7 +132,7 @@ def test_FiniteSet_complex():
                       {b: z, a: FiniteSet(y, Basic(1, x))}])
     assert iterdicteq(unify(expr, pattern, variables=variables), expected)
 
-@XFAIL
+@XFAIL(NameError, "global name 'pattern' is not defined")
 def test_and():
     variables = x, y
     str(list(unify((x>0) & (z<3), pattern, variables=variables)))

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1747,6 +1747,32 @@ class PyTestReporter(Reporter):
 
         return width
 
+    _can_color = None
+
+    @property
+    def can_color(self):
+        """Check if can use colored output. """
+        if self._can_color is None:
+            def check_can_color():
+                if not self._force_colors and hasattr(sys.stdout, 'isatty') and not \
+                        sys.stdout.isatty():
+                    # the stdout is not a terminal, this for example happens if the
+                    # output is piped to less, e.g. "bin/test | less". In this case,
+                    # the terminal control sequences would be printed verbatim, so
+                    # don't use any colors.
+                    return False
+                elif sys.platform == "win32":
+                    # Windows consoles don't support ANSI escape sequences
+                    return False
+                elif not self._colors:
+                    return False
+                else:
+                    return True
+
+            self._can_color = check_can_color()
+
+        return self._can_color
+
     def write(self, text, color="", align="left", width=None,
               force_colors=False):
         """
@@ -1764,29 +1790,25 @@ class PyTestReporter(Reporter):
         width : the screen width
 
         """
-        color_templates = (
-            ("Black", "0;30"),
-            ("Red", "0;31"),
-            ("Green", "0;32"),
-            ("Brown", "0;33"),
-            ("Blue", "0;34"),
-            ("Purple", "0;35"),
-            ("Cyan", "0;36"),
-            ("LightGray", "0;37"),
-            ("DarkGray", "1;30"),
-            ("LightRed", "1;31"),
-            ("LightGreen", "1;32"),
-            ("Yellow", "1;33"),
-            ("LightBlue", "1;34"),
-            ("LightPurple", "1;35"),
-            ("LightCyan", "1;36"),
-            ("White", "1;37"),
-        )
+        colors = {
+            "Black": "0;30",
+            "Red": "0;31",
+            "Green": "0;32",
+            "Brown": "0;33",
+            "Blue": "0;34",
+            "Purple": "0;35",
+            "Cyan": "0;36",
+            "LightGray": "0;37",
+            "DarkGray": "1;30",
+            "LightRed": "1;31",
+            "LightGreen": "1;32",
+            "Yellow": "1;33",
+            "LightBlue": "1;34",
+            "LightPurple": "1;35",
+            "LightCyan": "1;36",
+            "White": "1;37",
+        }
 
-        colors = {}
-
-        for name, value in color_templates:
-            colors[name] = value
         c_normal = '\033[0m'
         c_color = '\033[%sm'
 
@@ -1799,19 +1821,6 @@ class PyTestReporter(Reporter):
                 self.write("\n")
             self.write(" "*(width - self._write_pos - len(text)))
 
-        if not self._force_colors and hasattr(sys.stdout, 'isatty') and not \
-                sys.stdout.isatty():
-            # the stdout is not a terminal, this for example happens if the
-            # output is piped to less, e.g. "bin/test | less". In this case,
-            # the terminal control sequences would be printed verbatim, so
-            # don't use any colors.
-            color = ""
-        elif sys.platform == "win32":
-            # Windows consoles don't support ANSI escape sequences
-            color = ""
-        elif not self._colors:
-            color = ""
-
         if self._line_wrap:
             if text[0] != "\n":
                 sys.stdout.write("\n")
@@ -1823,11 +1832,11 @@ class PyTestReporter(Reporter):
             text = text.encode(sys.stdout.encoding, 'backslashreplace'
                               ).decode(sys.stdout.encoding)
 
-        if color == "":
-            sys.stdout.write(text)
+        if self.can_color and color:
+            sys.stdout.write("%s%s%s" % (c_color % colors[color], text, c_normal))
         else:
-            sys.stdout.write("%s%s%s" %
-                (c_color % colors[color], text, c_normal))
+            sys.stdout.write(text)
+
         sys.stdout.flush()
         l = text.rfind("\n")
         if l == -1:
@@ -1864,7 +1873,7 @@ class PyTestReporter(Reporter):
             t = traceback.format_exception_only(e, val)
             self.write("".join(t))
         else:
-            color_scheme = "Linux" if self._colors else "NoColor"
+            color_scheme = "Linux" if self.can_color else "NoColor"
             t = ListTB(color_scheme).structured_traceback(e, val, t)
             self.write("".join(t))
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1855,14 +1855,14 @@ class PyTestReporter(Reporter):
         self.write(t + "\n")
 
     def write_exception(self, e, val, tb):
-        exclude = [
+        exclude = tuple(convert_to_native_paths([
             "sympy/utilities/runtests.py",
             "sympy/utilities/pytest.py",
-        ]
+        ]))
 
         t = traceback.extract_tb(tb)
 
-        while t and t[0][0] in exclude:
+        while t and t[0][0].endswith(exclude):
             t = t[1:]
 
         try:

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -136,7 +136,7 @@ def test_core_function():
         check(f)
 
 
-@XFAIL
+@XFAIL(pickle.PicklingError, "Can't pickle f: it's not found as __main__.f")
 def test_core_dynamicfunctions():
     # This fails because f is assumed to be a class at sympy.basic.function.f
     f = Function("f")
@@ -271,7 +271,7 @@ def test_physics():
 # XXX: These tests are not complete, so XFAIL them
 
 
-@XFAIL
+@XFAIL(ImportError, "No module named color_scheme")
 def test_plotting():
     from sympy.plotting.color_scheme import ColorGradient, ColorScheme
     from sympy.plotting.managed_window import ManagedWindow
@@ -298,7 +298,7 @@ def test_plotting():
         check(c)
 
 
-@XFAIL
+@XFAIL(ImportError, "No module named color_scheme")
 def test_plotting2():
     from sympy.plotting.color_scheme import ColorGradient, ColorScheme
     from sympy.plotting.managed_window import ManagedWindow
@@ -345,7 +345,7 @@ def test_pickling_polys_polyclasses():
     for c in (ANP, ANP([QQ(1), QQ(2)], [QQ(1), QQ(2), QQ(3)], QQ)):
         check(c)
 
-@XFAIL
+@XFAIL(pickle.PicklingError, "Can't pickle <class 'sympy.polys.rings.PolyElement'>: it's not the same object as sympy.polys.rings.PolyElement")
 def test_pickling_polys_rings():
     # NOTE: can't use protocols < 2 because we have to execute __new__ to
     # make sure caching of rings works properly.
@@ -625,7 +625,7 @@ def test_printing1():
     check(MathMLPrinter())
 
 
-@XFAIL
+@XFAIL(pickle.PicklingError) # TODO: "Can't pickle <function <lambda> at 0x\w{8}>: it's not found as sympy.printing.pretty.pretty.<lambda>"
 def test_printing2():
     check(PrettyPrinter())
 

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -136,7 +136,10 @@ def test_core_function():
         check(f)
 
 
-@XFAIL(pickle.PicklingError, "Can't pickle f: it's not found as __main__.f")
+# TODO: Different messages from different Pythons:
+# 2.x: "Can't pickle f: it's not found as __main__.f"
+# 3.x: "Can't pickle f: attribute lookup __main__.f failed"
+@XFAIL(pickle.PicklingError)
 def test_core_dynamicfunctions():
     # This fails because f is assumed to be a class at sympy.basic.function.f
     f = Function("f")
@@ -271,7 +274,10 @@ def test_physics():
 # XXX: These tests are not complete, so XFAIL them
 
 
-@XFAIL(ImportError, "No module named color_scheme")
+# TODO:
+# "No module named color_scheme"
+# "No module named 'sympy.plotting.color_scheme'"
+@XFAIL(ImportError)
 def test_plotting():
     from sympy.plotting.color_scheme import ColorGradient, ColorScheme
     from sympy.plotting.managed_window import ManagedWindow
@@ -298,7 +304,10 @@ def test_plotting():
         check(c)
 
 
-@XFAIL(ImportError, "No module named color_scheme")
+# TODO:
+# "No module named color_scheme"
+# "No module named 'sympy.plotting.color_scheme'"
+@XFAIL(ImportError)
 def test_plotting2():
     from sympy.plotting.color_scheme import ColorGradient, ColorScheme
     from sympy.plotting.managed_window import ManagedWindow
@@ -620,12 +629,17 @@ def test_printing():
         check(c)
 
 
-@XFAIL
+# TODO:
+# *: AssertionError
+# 3.3: TypeError: a class that defines __slots__ without defining __getstate__ cannot be pickled
+@XFAIL(Exception)
 def test_printing1():
     check(MathMLPrinter())
 
-
-@XFAIL(pickle.PicklingError) # TODO: "Can't pickle <function <lambda> at 0x\w{8}>: it's not found as sympy.printing.pretty.pretty.<lambda>"
+# TODO:
+# 2.x: PicklingError: Can't pickle <function <lambda> at 0x\w{8}>: it's not found as sympy.printing.pretty.pretty.<lambda>
+# 3.x: TypeError: can't pickle function objects
+@XFAIL(Exception)
 def test_printing2():
     check(PrettyPrinter())
 


### PR DESCRIPTION
This fixes issue 3945. `XFAIL` decorator supports optional `exception` and `message` arguments. There are three variants: `@XFAIL`, `@XFAIL(Exception)`, `@XFAIL(Exception, "message")`. The first is equivalent to `@XFAIL(AssertionError)`. Only one exception is allowed. Currently `message` is compared exactly to `Exception`'s message. I rewrote all tests. In most cases this includes also exception message, but sometimes message depends on environment (e.g. `mpz` vs `int` or `0xdeadbeef`), so a few tests will have to be improved when matching of message is implemented. As a side effect I added coloring of tracebacks, using IPython's ultratb, because it was barely possible to read all those tracebacks (there were lots of failures). There are however a few issues with this:
- [ ]  `XFAIL` works in `py.test`, but `py.test` raises the following error every time `test_numerically` is used:

```
  def test_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
        fixture 'f' not found
        available fixtures: pytestconfig, recwarn, monkeypatch, capfd, capsys, tmpdir
        use 'py.test --fixtures [testpath]' for help on them.
```
- [x] `mpmath` fails with:

```

Traceback (most recent call last):
  File "/home/mateusz/repo/git/sympy/sympy/mpmath/tests/test_functions2.py", line 763, in test_gegenbauer_unimplemented
    assert gegenbauer(-2, -0.5, 3).ae(-12)
  File "sympy/mpmath/ctx_mp_python.py", line 1016, in f_wrapped
    retval = f(ctx, *args, **kwargs)
  File "sympy/mpmath/functions/orthogonal.py", line 316, in gegenbauer
    raise NotImplementedError("Gegenbauer function with two limits")
NotImplementedError: Gegenbauer function with two limits

Traceback (most recent call last):
  File "/home/mateusz/repo/git/sympy/sympy/mpmath/tests/test_gammazeta.py", line 196, in test_gamma_failing
    assert gamma(Rational(1,2)) == gamma(0.5)
NameError: global name 'Rational' is not defined

Traceback (most recent call last):
  File "/home/mateusz/repo/git/sympy/sympy/mpmath/tests/test_gammazeta.py", line 527, in test_gamma_huge_7_failing
    assert str(y.imag) == "2.16735365342606e-1000"
NameError: global name 'y' is not defined
```

I'm not sure how to proceed with mpmath, because of its uncertain situation in sympy. Besides this all tests pass under 2.7, but I didn't check other configurations, so there may be other issues (especially with messages).
