### PR TITLE
Travis: test against matplotlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,22 @@ matrix:
     - python: 2.7
       env:
         - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="true"
     - python: 2.7
       env:
         - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="false"
     - python: 3.3
       env:
         - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="true"
     - python: 3.3
       env:
         - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="false"
     - python: 2.7
       env: TEST_SPHINX="true"
@@ -39,6 +43,9 @@ before_install:
   - if [[ "${TEST_SPHINX}" == "true" ]]; then
       sudo apt-get install -qq graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra;
       pip install "sphinx==1.1.3";
+    fi
+  - if [[ "${TEST_MATPLOTLIB}" == "true" ]]; then
+      pip install "matplotlib==1.2.1";
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ before_install:
       pip install "sphinx==1.1.3";
     fi
   - if [[ "${TEST_MATPLOTLIB}" == "true" ]]; then
-      pip install "matplotlib==1.2.1" "numpy==1.7.1";
+      pip install "numpy==1.7.1";
+      pip install "matplotlib==1.2.1";
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
       pip install "sphinx==1.1.3";
     fi
   - if [[ "${TEST_MATPLOTLIB}" == "true" ]]; then
-      pip install "matplotlib==1.2.1";
+      pip install "matplotlib==1.2.1" "numpy==1.7.1";
     fi
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' || $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python bin/use2to3; cd py3k-sympy; fi


### PR DESCRIPTION
The matplotlib test was added to the gmpy tests. That way, we either test pure
Python, or Python+"all libraries".

**PROPOSAL**: I propose to test against "pure Python" for all supported versions of Python. This pure Python should literally be pure Python (no other libs installed). Then I propose to test against all optional libraries, against Python 2.7 and the latest Python 3.x only. 

This is exactly what we do now, and this PR is consistent with it. The only small unrelated issue is that I think Travis actually installs numpy and possibly other libs into Pythons automatically. As such, we need to uninstall them from the "pure Python" tests (one way or another).
