### PR TITLE
In ``_minpoly1`` used a faster algorithm for some products.

### DIFF
--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -9,7 +9,7 @@ from sympy import (
 
 from sympy.polys.polytools import (
     Poly, PurePoly, sqf_norm, invert, factor_list, groebner, resultant,
-    degree, poly_from_expr, parallel_poly_from_expr
+    degree, poly_from_expr, parallel_poly_from_expr, lcm
 )
 
 from sympy.polys.polyclasses import (
@@ -36,9 +36,10 @@ from sympy.polys.orthopolys import dup_chebyshevt
 from sympy.printing.lambdarepr import LambdaPrinter
 
 from sympy.utilities import (
-    numbered_symbols, variations, lambdify, public,
+    numbered_symbols, variations, lambdify, public, sift
 )
 
+from sympy.core.exprtools import Factors
 from sympy.simplify.simplify import _mexpand, _is_sum_surds
 from sympy.ntheory import sieve
 from sympy.ntheory.factor_ import divisors
@@ -210,7 +211,7 @@ def _minimal_polynomial_sq(p, n, x):
 
 def _minpoly_op_algebraic_element(op, ex1, ex2, x, dom, mp1=None, mp2=None):
     """
-    return the minimal polinomial for ``op(ex1, ex2)``
+    return the minimal polynomial for ``op(ex1, ex2)``
 
     Parameters
     ==========
@@ -534,7 +535,25 @@ def _minpoly_compose(ex, x, dom):
     if ex.is_Add:
         res = _minpoly_add(x, dom, *ex.args)
     elif ex.is_Mul:
-        res = _minpoly_mul(x, dom, *ex.args)
+        f = Factors(ex).factors
+        r = sift(f.items(), lambda itx: itx[0].is_rational and itx[1].is_rational)
+        if r[True] and dom == QQ:
+            ex1 = Mul(*[bx**ex for bx, ex in r[False] + r[None]])
+            r1 = r[True]
+            dens = [y.q for _, y in r1]
+            lcmdens = reduce(lcm, dens, 1)
+            nums = [base**(y.p*lcmdens // y.q) for base, y in r1]
+            ex2 = Mul(*nums)
+            mp1 = minimal_polynomial(ex1, x)
+            # use the fact that in SymPy canonicalization products of integers
+            # raised to rational powers are organized in relatively prime
+            # bases, and that in ``base**(n/d)`` a perfect power is
+            # simplified with the root
+            mp2 = ex2.q*x**lcmdens - ex2.p
+            ex2 = ex2**Rational(1, lcmdens)
+            res = _minpoly_op_algebraic_element(Mul, ex1, ex2, x, dom, mp1=mp1, mp2=mp2)
+        else:
+            res = _minpoly_mul(x, dom, *ex.args)
     elif ex.is_Pow:
         res = _minpoly_pow(ex.base, ex.exp, x, dom)
     elif ex.__class__ is C.sin:

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -45,6 +45,7 @@ from sympy.ntheory import sieve
 from sympy.ntheory.factor_ import divisors
 from sympy.mpmath import pslq, mp
 
+from sympy.core.compatibility import reduce
 from sympy.core.compatibility import xrange
 
 

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -241,6 +241,13 @@ def test_minpoly_compose():
     mp = minimal_polynomial(ex, x)
     assert degree(mp) == 48 and mp.subs({x:0}) == -16630256576
 
+def test_minpoly_issue4014():
+    # see discussion in https://github.com/sympy/sympy/pull/2234
+    from sympy.simplify.simplify import nsimplify
+    r = nsimplify(pi, tolerance=0.000000001)
+    mp = minimal_polynomial(r, x)
+    assert mp == 1768292677839237920489538677417507171630859375*x**109 - \
+    2734577732179183863586489182929671773182898498218854181690460140337930774573792597743853652058046464
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])


### PR DESCRIPTION
The minimal polynomial of products of rational powers of integers are computed much faster in some cases.

In master
`minimal_polynomial(nsimplify(pi, tolerance=0.000000001))`
hangs (see https://github.com/sympy/sympy/pull/2234 and issue 4014)

Now it takes a fraction of a second.
