### PR TITLE
Clarify the Note in the release text at github

### DIFF
--- a/release/fabfile.py
+++ b/release/fabfile.py
@@ -608,8 +608,8 @@ See https://github.com/sympy/sympy/wiki/release-notes-for-{shortversion} for the
 
 {htmltable}
 
-**Note**: Do not download the `Source Code (zip)` or the `Source Code (tar)`
-files.
+**Note**: Do not download the `Source code (zip)` or the `Source code (tar.gz)`
+files below.
 """
     out = out.format(shortversion=shortversion, htmltable=htmltable)
     print blue("Here are the release notes to copy into the GitHub release "


### PR DESCRIPTION
- Now the text of the "things not to download" agree with the text on the
  buttons provided by GitHub.
- By adding the word "below", it should be clearer which files should not be
  downloaded.
