### PR TITLE
Adding Jordan form and exponentiation for all matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1870,22 +1870,22 @@ class MatrixBase(object):
             raise NotImplementedError("Exponentiation is implemented only for matrices for which the Jordan normal form can be computed")
 
         def _jblock_exponential(b):
-            #This function computes the matrix exponential for one single Jordan block
+            # This function computes the matrix exponential for one single Jordan block
             nr = b.rows
             l = b[0, 0]
             if nr == 1:
                 res = C.exp(l)
             else:
                 from sympy import eye
-                #extract the diagonal part
+                # extract the diagonal part
                 d = b[0, 0]*eye(nr)
                 #and the nilpotent part
                 n = b-d
-                #compute its exponential
+                # compute its exponential
                 nex = eye(nr)
                 for i in range(1, nr):
                     nex = nex+n**i/factorial(i)
-                #combine the two parts
+                # combine the two parts
                 res = exp(b[0, 0])*nex
             return(res)
 
@@ -3375,7 +3375,7 @@ class MatrixBase(object):
             else:
                 # Up to now we know nothing about the sizes of the blocks of our Jordan matrix.
                 # Note that knowledge of algebraic and geometrical multiplicity
-                # will >>> NOT <<< be sufficient to determine this structure.
+                # will *NOT* be sufficient to determine this structure.
                 # The blocksize `s` could be defined as the minimal `k` where
                 # `kernel(self-lI)^k = kernel(self-lI)^(k+1)`
                 # The extreme case would be that k = (multiplicity-geometrical+1)
@@ -3491,10 +3491,10 @@ class MatrixBase(object):
 
                     ########   Implementation remark:   ########
 
-                    # Doing so for >>> ALL <<< already computed chain vectors
+                    # Doing so for *ALL* already computed chain vectors
                     # we actually exclude some vectors twice because they are already excluded
                     # by the condition (**).
-                    # This happens if there are more than one blocks attached to the same eigenvalue >>> AND <<<
+                    # This happens if there are more than one blocks attached to the same eigenvalue *AND*
                     # the current blocksize is smaller than the block whose chain vectors we exclude.
                     # If the current block has size `s_i` and the next bigger block has size `s_i-1` then
                     # the first `s_i-s_i-1` chainvectors of the bigger block are allready excluded by (**).

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -13,6 +13,7 @@ from sympy.polys import PurePoly, roots, cancel
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify
 from sympy.utilities.iterables import flatten
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
+from sympy.functions import exp, factorial
 from sympy.printing import sstr
 from sympy.core.compatibility import callable, reduce, as_int
 from sympy.utilities.exceptions import SymPyDeprecationWarning
@@ -1864,12 +1865,35 @@ class MatrixBase(object):
             raise NonSquareMatrixError(
                 "Exponentiation is valid only for square matrices")
         try:
-            U, D = self.diagonalize()
+            (J, P, cells) = self.jordan_cells()
         except MatrixError:
-            raise NotImplementedError("Exponentiation is implemented only for diagonalizable matrices")
-        for i in range(0, D.rows):
-            D[i, i] = C.exp(D[i, i])
-        return U*D*U.inv()
+            raise NotImplementedError("Exponentiation is implemented only for matrices for which the Jordan normal form can be computed")
+
+        def _jblock_exponential(b):
+            #This function computes the matrix exponential for one single Jordan block
+            nr=b.rows
+            l=b[0, 0]
+            if nr == 1:
+                res = C.exp(l)
+            else:
+                from sympy import eye
+                #extract the diagonal part
+                d = b[0, 0]*eye(nr)
+                #and the nilpotent part
+                n = b-d
+                #compute its exponential
+                nex = eye(nr)
+                for i in range(1, nr):
+                    nex = nex+n**i/factorial(i)
+                #combine the two parts
+                res = exp(b[0, 0])*nex
+            return(res)
+        blocks = map(_jblock_exponential, cells)
+        from sympy.matrices import diag
+        eJ = diag(* blocks)
+        # n = self.rows
+        ret = P*eJ*P.inv()
+        return type(self)(ret)
 
     @property
     def is_square(self):
@@ -3311,19 +3335,199 @@ class MatrixBase(object):
         del self._is_symmetric
         del self._eigenvects
 
+    def jordan_cell(self, eigenval, n):
+        n = int(n)
+        from sympy.matrices import MutableMatrix
+        out = MutableMatrix.zeros(n)
+        for i in range(n-1):
+            out[i, i] = eigenval
+            out[i, i+1] = 1
+        out[n-1, n-1] = eigenval
+        return out
+
+    def _jordan_BlockStructure(self):
+        # to every eingenvalue may belong i blocks with size s(i)
+        # and a chain of generalized eigenvectors
+        # which will be determined by the following computations
+        # for every eigenvalue we will add a dictionary
+        # containing for all blocks the blockssizes and the attached chain vectors
+        # that will eventually be used to form the transformation P
+        jordan_block_structures = {}
+        _eigenvects = self.eigenvects()
+        ev = self.eigenvals()
+        if len(ev) == 0:
+            raise AttributeError("could not compute the eigenvalues")
+        for eigenval, multiplicity, vects in _eigenvects:
+            l_jordan_chains={}
+            geometrical = len(vects)
+            if geometrical == multiplicity:
+                # The Jordan chains have all length 1 and consist of only one vector
+                # which is the eigenvector of course
+                chains = []
+                for v in vects:
+                    chain=[v]
+                    chains.append(chain)
+                l_jordan_chains[1] = chains
+                jordan_block_structures[eigenval] = l_jordan_chains
+            elif geometrical == 0:
+                raise MatrixError("Matrix has the eigen vector with geometrical multiplicity equal zero.")
+            else:
+                # Up to now we know nothing about the sizes of the blocks of our Jordan matrix
+                # Note that knowledge of algebraic and geometrical multiplicity
+                # will >> n o t << be sufficient to determine this structure
+                # The blocksize s could be defined as the minimal k where
+                # kernel(self-lI)^k= kernel(self-lI)^(k+1)
+                # The extreme case would be that k= (multiplicity-geometrical+1)
+                # but the blocks could be smaller.
+                # Consider for instance the following matrix
+                # [2 1 0 0]
+                # [0 2 1 0]
+                # [0 0 2 0]
+                # [0 0 0 2]
+                # which coincides with it own Jordan canonical form.
+                # It has only one eigenvalue l=2 of (algebraic) multiplicity=4.
+                # It has two eigenvectors. one belonging to the last row (blocksize 1)
+                # and one being the last part of a jordan chain of length 3 (blocksize of the first block)
+                # Note again that it is not not possible to obtain this from the algebraic and geometrical
+                # multiplicity alone. This only gives us an upper limit for the dimension of one of
+                # the subspaces (blocksize of according jordan block) given by
+                # max=(multiplicity-geometrical+1) which is reached for our matrix
+                # but not for
+                # [2 1 0 0]
+                # [0 2 0 0]
+                # [0 0 2 1]
+                # [0 0 0 2]
+                # although multiplicity =4 and geometrical=2 are the same  for this matrix.
+                from sympy.matrices import MutableMatrix
+                I = MutableMatrix.eye(self.rows)
+                l = eigenval
+                M = (self-l*I)
+                # We will store the matrices (self-l*I)^k  for further computations
+                # for convenience only we store Ms[0]=(sefl-lI)^0=I
+                # so the index is the same as the power for all further Ms entries
+                # We also store the vectors that span these kernels (Ns[0] =[] )
+                # and also their dimensions a_s
+                # this is mainly done for debugging since the number of blocks of a given size
+                # can be computed from the a_s, in order to check our result which is obtained simpler
+                # by counting the number of jordanchains for a given s
+                # a_0 is dim(Kernel(Ms[0]) =dim (Kernel(I))=0 since I is regular
+                l_jordan_chains={}
+                chain_vectors=[]
+                Ms = [I]
+                Ns = [[]]
+                a = [0]
+                smax = 0
+                M_new = Ms[-1]*M
+                Ns_new = M_new.nullspace()
+                a_new = len(Ns_new)
+                Ms.append(M_new)
+                Ns.append(Ns_new)
+                while a_new > a[-1]:  # as long as the nullspaces increase compute further powers
+                    a.append(a_new)
+                    M_new = Ms[-1]*M
+                    Ns_new = M_new.nullspace()
+                    a_new=len(Ns_new)
+                    Ms.append(M_new)
+                    Ns.append(Ns_new)
+                    smax += 1
+                # We now have Ms[-1]=((self-l*I)**s)=Z=0
+                # We now know the size of the biggest jordan block
+                # associatet with l to be s
+                # now let us proceed with the computation of the associate part of the transformation matrix P
+                # We already know the kernel (=nullspace)  K_l of (self-lI) which consists of the
+                # eigenvectors belonging to eigenvalue l
+                # The dimension of this space is the geometric multiplicity of eigenvalue l.
+                # For every eigenvector ev out of K_l, there exists a subspace that is
+                # spanned by the jordan chain of ev. The dimension of this subspace is
+                # represented by the length s of the jordan block.
+                # The chain itself is given by {e_0,..,e_s-1} where:
+                # e_k+1 =(self-lI)e_k (*)
+                # and e_s-1=ev
+                # So it would be possible to start with the already known ev and work backwards until one
+                # reaches e_0. Unfortunately this can not be done by simply solving system (*) since its matrix
+                # is singular (by definition of the eigenspaces)
+                # This approach would force us a choose in every step the degree of freedom undetermined
+                # by (*). This is difficult to implement with computer algebra systems and also quite unefficient
+                # We therefore reformulate the problem in terms of nullspaces.
+                # To do so we start from the other end and choose e0's out of
+                # E=Kernel(self-lI)^s / Kernel(self-lI)^(s-1)
+                # Note that Kernel(self-lI)^s =Kernel(Z)=V (the whole vector space)
+                # So in the firs step s=smax this restriction turns out to actually restrict nothing at all
+                # and the only remaining condition is to chose vectors in Kernel(self-lI)^(s-1)
+                # Subsequently we compute e_1=(self-lI)e_0, e_2=(self-lI)*e_1 and so on.
+                # The subspace E can have a dimension larger than one
+                # That means that we have more than one Jordanblocks of size s for the eigenvalue l
+                # and as many jordanchains (This is the case in the second example)
+                # In this case we start as many jordan chains and have as many blocks of size s in the jcf
+                # We now have all the jordanblocks of size s but there might be others attached to the same
+                # eigenvalue that are smaller.
+                # So we will do the same procedure also for s-1 and so on until 1 the lowest possible order
+                # where the jordanchain is of lenght 1 and just represented by the eigenvector
+                for s in reversed(xrange(1, smax+1)):
+                    #we want the vectors in Kernel((self-lI)^s) (**)
+                    S = Ms[s]
+                    # but without those in Kernel(self-lI)^s-1 so we will add these as additional equations
+                    # to the sytem formed by S (S will no longer be quadratic but this does not harm
+                    # since S is rank deficiant)
+                    exclude_vectors = Ns[s-1]
+                    for k in range(0, a[s-1]):
+                        S = S.col_join((exclude_vectors[k]).transpose())
+                    # we also want to exclude the vectors in the chains for the bigger blogs
+                    # that we have already computed (if there are any)
+                    # (That is why we start wiht the biggest s)
+                    ######## implementation remark:#############
+                    # Doing so for >> a l l << already computed chain vectors
+                    # we actually exclude some vectors twice because they are already excluded
+                    # by the condition (**)
+                    # This happens if there are more than one blocks attached to the same eigenvalue >>and<<
+                    # the current blocksize is smaller than the block whose chain vectors we exclude
+                    # If the current block has size s_i and the next bigger block has size s_i-1 then
+                    # the first s_i-s_i-1 chainvectors of the bigger block are allready excluded by (**)
+                    # The unnecassary adding of these equations could be avoided if the algorithm would
+                    # take into account the lengths of the already computed chains which are already stored
+                    # and add only the last s items.
+                    # However the following loop would be a good deal more nested to do so.
+                    # Since adding a linear dependent equation does not change the result
+                    # it can harm only in terms of efficiency.
+                    # So to be sure i let it there for the moment
+                    #
+                    # A more elegant alternative approach might be to drop condition (**) altogether
+                    # because it is added implicitly by excluding the chainvectors but I am not yet sure
+                    # if this is correct in all cases
+                    l = len(chain_vectors)
+                    if l > 0:
+                        for k in range(0, l):
+                            old = chain_vectors[k].transpose()
+                            S = S.col_join(old)
+                    e0s = S.nullspace()
+                    #determine the number of chain leaders which equals the number of blocks with that size
+                    n_e0 = len(e0s)
+                    s_chains = []
+                    # s_cells=[]
+                    for i in range(0, n_e0):
+                        chain=[e0s[i]]
+                        for k in range(1, s):
+                            v=M*chain[k-1]
+                            chain.append(v)
+                        #we want the chain leader appear as the last of the block
+
+                        chain.reverse()
+                        chain_vectors += chain
+                        s_chains.append(chain)
+                    l_jordan_chains[s] = s_chains
+            jordan_block_structures[eigenval] = l_jordan_chains
+        return(jordan_block_structures)
+
     def jordan_form(self, calc_transformation=True):
         """Return Jordan form J of current matrix.
 
-        If calc_transformation is specified as False, then transformation P such that
+        Also the transformation P such that
 
               J = P^-1 * M * P
 
-        will not be calculated.
+        and the jordan blocks forming J
+        will be calculated.
 
-        Notes
-        =====
-
-        Calculation of transformation P is not implemented yet.
 
         Examples
         ========
@@ -3334,7 +3538,7 @@ class MatrixBase(object):
         ...        [-3, -1,  3,  3],
         ...        [ 2,  1, -2, -3],
         ...        [-1,  1,  5,  5]])
-        >>> (P, J) = m.jordan_form()
+        >>> J, P, Jcells = m.jordan_form()
         >>> J
         Matrix([
         [2, 1, 0, 0],
@@ -3347,11 +3551,8 @@ class MatrixBase(object):
 
         jordan_cells
         """
-        from sympy.matrices import diag
-
-        (P, Jcells) = self.jordan_cells(calc_transformation)
-        J = diag(*Jcells)
-        return (P, J)
+        (J, P, Jcells) = self.jordan_cells()
+        return (J, P, Jcells)
 
     def jordan_cells(self, calc_transformation=True):
         """Return a list of Jordan cells of current matrix.
@@ -3378,7 +3579,7 @@ class MatrixBase(object):
         ...  2,  1, -2, -3,
         ... -1,  1,  5,  5])
 
-        >>> (P, Jcells) = m.jordan_cells()
+        >>> (J, P, Jcells) = m.jordan_cells()
         >>> Jcells[0]
         Matrix([
         [2, 1],
@@ -3393,25 +3594,60 @@ class MatrixBase(object):
 
         jordan_form
         """
-        from sympy.matrices import jordan_cell, diag
-
-        if not self.is_square:
-            raise NonSquareMatrixError()
-        _eigenvects = self.eigenvects()
+        n=self.rows
         Jcells = []
-        for eigenval, multiplicity, vects in _eigenvects:
-            geometrical = len(vects)
-            if geometrical == multiplicity:
-                Jcell = diag(*([eigenval]*multiplicity))
-                Jcells.append(Jcell)
-            else:
-                sizes = self._jordan_split(multiplicity, geometrical)
-                cells = []
-                for size in sizes:
-                    cell = jordan_cell(eigenval, size)
-                    cells.append(cell)
-                Jcells += cells
-        return (None, Jcells)
+        Pcols_new = []
+        jordan_block_structures = self._jordan_BlockStructure()
+        from sympy.matrices import MutableMatrix
+        for eigenval in reversed(sorted(jordan_block_structures.keys())):  # start with the biggest eigenvalue
+            l_JordanChains=jordan_block_structures[eigenval]
+            for s in reversed(sorted((l_JordanChains).keys())):  # start with the biggest block
+                s_chains=l_JordanChains[s]
+                block = self.jordan_cell(eigenval, s)
+                number_of_s_chains=len(s_chains)
+                for i in range(0, number_of_s_chains):
+                    Jcells.append(block)
+                    chainVectors=s_chains[i]
+                    lc=len(chainVectors)
+                    assert(lc==s)
+                    for j in range(0, lc):
+                        generalizedEigenVector = chainVectors[j]
+                        Pcols_new.append(generalizedEigenVector)
+        from sympy.matrices import diag
+        J = diag(*Jcells)
+        P = MutableMatrix.zeros(n)
+        for j in range(0, n):
+            P[:, j] = Pcols_new[j]
+
+        return (J, P, Jcells)
+
+#     def Jexp(self, sym):
+#         (J, P, cells) = self.jordan_cells()
+#         f = self._jexp_fmaker(sym)
+#         blocks=map(f, cells)
+#         from sympy.matrices import diag
+#         emx = diag(*blocks)
+#         return emx
+#
+#     @classmethod
+#     def _jexp_fmaker(cls, sym):
+#         def f(c):
+#             res = cls._jexp_block(c, sym)
+#             return(res)
+#         return(f)
+#
+#     @staticmethod
+#     def _jexp_block(cell, sym):
+#         from sympy import eye
+#         n = cell.rows
+#         l = cell[0, 0]
+#         b = eye(n)
+#         for j in range(1, n):
+#             for i in range(j):
+#                 p = j-i
+#                 b[i, j] = sym**(p)/factorial(p)
+#         b = b*exp(l*sym)
+#         return b
 
     def _jordan_split(self, algebraical, geometrical):
         """Return a list of integers with sum equal to 'algebraical'
@@ -3570,10 +3806,11 @@ class MatrixBase(object):
             raise ShapeError(
                 "`self` and `bott` must have the same number of columns.")
 
-        newmat = self.zeros(self.rows + bott.rows, self.cols)
+        from sympy.matrices import MutableMatrix
+        newmat = MutableMatrix.zeros(self.rows + bott.rows, self.cols)
         newmat[:self.rows, :] = self
         newmat[self.rows:, :] = bott
-        return newmat
+        return type(self)(newmat)
 
     def row_insert(self, pos, mti):
         """Insert one or more rows at the given row position.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3346,12 +3346,12 @@ class MatrixBase(object):
         out[n-1, n-1] = eigenval
         return type(self)(out)
 
-    def _jordan_BlockStructure(self):
-        # to every eingenvalue may belong i blocks with size s(i)
+    def _jordan_block_structure(self):
+        # To every eingenvalue may belong `i` blocks with size s(i)
         # and a chain of generalized eigenvectors
-        # which will be determined by the following computations
+        # which will be determined by the following computations:
         # for every eigenvalue we will add a dictionary
-        # containing for all blocks the blockssizes and the attached chain vectors
+        # containing, for all blocks, the blockssizes and the attached chain vectors
         # that will eventually be used to form the transformation P
         jordan_block_structures = {}
         _eigenvects = self.eigenvects()
@@ -3373,45 +3373,54 @@ class MatrixBase(object):
             elif geometrical == 0:
                 raise MatrixError("Matrix has the eigen vector with geometrical multiplicity equal zero.")
             else:
-                # Up to now we know nothing about the sizes of the blocks of our Jordan matrix
+                # Up to now we know nothing about the sizes of the blocks of our Jordan matrix.
                 # Note that knowledge of algebraic and geometrical multiplicity
-                # will >> n o t << be sufficient to determine this structure
-                # The blocksize s could be defined as the minimal k where
-                # kernel(self-lI)^k= kernel(self-lI)^(k+1)
-                # The extreme case would be that k= (multiplicity-geometrical+1)
+                # will >>> NOT <<< be sufficient to determine this structure.
+                # The blocksize `s` could be defined as the minimal `k` where
+                # `kernel(self-lI)^k = kernel(self-lI)^(k+1)`
+                # The extreme case would be that k = (multiplicity-geometrical+1)
                 # but the blocks could be smaller.
+
                 # Consider for instance the following matrix
+
                 # [2 1 0 0]
                 # [0 2 1 0]
                 # [0 0 2 0]
                 # [0 0 0 2]
+
                 # which coincides with it own Jordan canonical form.
                 # It has only one eigenvalue l=2 of (algebraic) multiplicity=4.
-                # It has two eigenvectors. one belonging to the last row (blocksize 1)
-                # and one being the last part of a jordan chain of length 3 (blocksize of the first block)
+                # It has two eigenvectors, one belonging to the last row (blocksize 1)
+                # and one being the last part of a jordan chain of length 3 (blocksize of the first block).
+
                 # Note again that it is not not possible to obtain this from the algebraic and geometrical
                 # multiplicity alone. This only gives us an upper limit for the dimension of one of
                 # the subspaces (blocksize of according jordan block) given by
                 # max=(multiplicity-geometrical+1) which is reached for our matrix
                 # but not for
+
                 # [2 1 0 0]
                 # [0 2 0 0]
                 # [0 0 2 1]
                 # [0 0 0 2]
-                # although multiplicity =4 and geometrical=2 are the same  for this matrix.
+
+                # although multiplicity=4 and geometrical=2 are the same for this matrix.
+
                 from sympy.matrices import MutableMatrix
                 I = MutableMatrix.eye(self.rows)
                 l = eigenval
                 M = (self-l*I)
-                # We will store the matrices (self-l*I)^k  for further computations
-                # for convenience only we store Ms[0]=(sefl-lI)^0=I
+
+                # We will store the matrices `(self-l*I)^k` for further computations
+                # for convenience only we store `Ms[0]=(sefl-lI)^0=I`
                 # so the index is the same as the power for all further Ms entries
-                # We also store the vectors that span these kernels (Ns[0] =[] )
-                # and also their dimensions a_s
+                # We also store the vectors that span these kernels (Ns[0] = [])
+                # and also their dimensions `a_s`
                 # this is mainly done for debugging since the number of blocks of a given size
                 # can be computed from the a_s, in order to check our result which is obtained simpler
-                # by counting the number of jordanchains for a given s
-                # a_0 is dim(Kernel(Ms[0]) =dim (Kernel(I))=0 since I is regular
+                # by counting the number of jordanchains for `a` given `s`
+                # `a_0` is `dim(Kernel(Ms[0]) = dim (Kernel(I)) = 0` since `I` is regular
+
                 l_jordan_chains={}
                 chain_vectors=[]
                 Ms = [I]
@@ -3431,87 +3440,92 @@ class MatrixBase(object):
                     Ms.append(M_new)
                     Ns.append(Ns_new)
                     smax += 1
-                # We now have Ms[-1]=((self-l*I)**s)=Z=0
+
+                # We now have `Ms[-1]=((self-l*I)**s)=Z=0`
                 # We now know the size of the biggest jordan block
-                # associatet with l to be s
-                # now let us proceed with the computation of the associate part of the transformation matrix P
-                # We already know the kernel (=nullspace)  K_l of (self-lI) which consists of the
-                # eigenvectors belonging to eigenvalue l
-                # The dimension of this space is the geometric multiplicity of eigenvalue l.
-                # For every eigenvector ev out of K_l, there exists a subspace that is
+                # associatet with `l` to be `s`
+                # now let us proceed with the computation of the associate part of the transformation matrix `P`
+                # We already know the kernel (=nullspace)  `K_l` of (self-lI) which consists of the
+                # eigenvectors belonging to eigenvalue `l`
+                # The dimension of this space is the geometric multiplicity of eigenvalue `l`.
+                # For every eigenvector ev out of `K_l`, there exists a subspace that is
                 # spanned by the jordan chain of ev. The dimension of this subspace is
                 # represented by the length s of the jordan block.
-                # The chain itself is given by {e_0,..,e_s-1} where:
-                # e_k+1 =(self-lI)e_k (*)
-                # and e_s-1=ev
-                # So it would be possible to start with the already known ev and work backwards until one
-                # reaches e_0. Unfortunately this can not be done by simply solving system (*) since its matrix
-                # is singular (by definition of the eigenspaces)
+                # The chain itself is given by `{e_0,..,e_s-1}` where:
+                # `e_k+1 =(self-lI)e_k (*)`
+                # and
+                # `e_s-1=ev`
+                # So it would be possible to start with the already known `ev` and work backwards until one
+                # reaches `e_0`. Unfortunately this can not be done by simply solving system (*) since its matrix
+                # is singular (by definition of the eigenspaces).
                 # This approach would force us a choose in every step the degree of freedom undetermined
-                # by (*). This is difficult to implement with computer algebra systems and also quite unefficient
+                # by (*). This is difficult to implement with computer algebra systems and also quite unefficient.
                 # We therefore reformulate the problem in terms of nullspaces.
-                # To do so we start from the other end and choose e0's out of
-                # E=Kernel(self-lI)^s / Kernel(self-lI)^(s-1)
-                # Note that Kernel(self-lI)^s =Kernel(Z)=V (the whole vector space)
-                # So in the firs step s=smax this restriction turns out to actually restrict nothing at all
-                # and the only remaining condition is to chose vectors in Kernel(self-lI)^(s-1)
-                # Subsequently we compute e_1=(self-lI)e_0, e_2=(self-lI)*e_1 and so on.
-                # The subspace E can have a dimension larger than one
-                # That means that we have more than one Jordanblocks of size s for the eigenvalue l
-                # and as many jordanchains (This is the case in the second example)
-                # In this case we start as many jordan chains and have as many blocks of size s in the jcf
-                # We now have all the jordanblocks of size s but there might be others attached to the same
+                # To do so we start from the other end and choose `e0`'s out of
+                # `E=Kernel(self-lI)^s / Kernel(self-lI)^(s-1)`
+                # Note that `Kernel(self-lI)^s = Kernel(Z) = V` (the whole vector space).
+                # So in the first step `s=smax` this restriction turns out to actually restrict nothing at all
+                # and the only remaining condition is to choose vectors in `Kernel(self-lI)^(s-1)`.
+                # Subsequently we compute `e_1=(self-lI)e_0`, `e_2=(self-lI)*e_1` and so on.
+                # The subspace `E` can have a dimension larger than one.
+                # That means that we have more than one Jordanblocks of size `s` for the eigenvalue `l`
+                # and as many jordanchains (This is the case in the second example).
+                # In this case we start as many jordan chains and have as many blocks of size s in the jcf.
+                # We now have all the jordanblocks of size `s` but there might be others attached to the same
                 # eigenvalue that are smaller.
-                # So we will do the same procedure also for s-1 and so on until 1 the lowest possible order
-                # where the jordanchain is of lenght 1 and just represented by the eigenvector
+                # So we will do the same procedure also for `s-1` and so on until 1 the lowest possible order
+                # where the jordanchain is of lenght 1 and just represented by the eigenvector.
+
                 for s in reversed(xrange(1, smax+1)):
-                    #we want the vectors in Kernel((self-lI)^s) (**)
                     S = Ms[s]
-                    # but without those in Kernel(self-lI)^s-1 so we will add these as additional equations
-                    # to the sytem formed by S (S will no longer be quadratic but this does not harm
-                    # since S is rank deficiant)
+                    # We want the vectors in `Kernel((self-lI)^s)` (**),
+                    # but without those in `Kernel(self-lI)^s-1` so we will add these as additional equations
+                    # to the sytem formed by `S` (`S` will no longer be quadratic but this does not harm
+                    # since S is rank deficiant).
                     exclude_vectors = Ns[s-1]
                     for k in range(0, a[s-1]):
                         S = S.col_join((exclude_vectors[k]).transpose())
-                    # we also want to exclude the vectors in the chains for the bigger blogs
-                    # that we have already computed (if there are any)
-                    # (That is why we start wiht the biggest s)
-                    ######## implementation remark:#############
-                    # Doing so for >> a l l << already computed chain vectors
+                    # We also want to exclude the vectors in the chains for the bigger blogs
+                    # that we have already computed (if there are any).
+                    # (That is why we start wiht the biggest s).
+
+                    ########   Implementation remark:   ########
+
+                    # Doing so for >>> ALL <<< already computed chain vectors
                     # we actually exclude some vectors twice because they are already excluded
-                    # by the condition (**)
-                    # This happens if there are more than one blocks attached to the same eigenvalue >>and<<
-                    # the current blocksize is smaller than the block whose chain vectors we exclude
-                    # If the current block has size s_i and the next bigger block has size s_i-1 then
-                    # the first s_i-s_i-1 chainvectors of the bigger block are allready excluded by (**)
+                    # by the condition (**).
+                    # This happens if there are more than one blocks attached to the same eigenvalue >>> AND <<<
+                    # the current blocksize is smaller than the block whose chain vectors we exclude.
+                    # If the current block has size `s_i` and the next bigger block has size `s_i-1` then
+                    # the first `s_i-s_i-1` chainvectors of the bigger block are allready excluded by (**).
                     # The unnecassary adding of these equations could be avoided if the algorithm would
                     # take into account the lengths of the already computed chains which are already stored
-                    # and add only the last s items.
+                    # and add only the last `s` items.
                     # However the following loop would be a good deal more nested to do so.
-                    # Since adding a linear dependent equation does not change the result
+                    # Since adding a linear dependent equation does not change the result,
                     # it can harm only in terms of efficiency.
                     # So to be sure i let it there for the moment
-                    #
+
                     # A more elegant alternative approach might be to drop condition (**) altogether
-                    # because it is added implicitly by excluding the chainvectors but I am not yet sure
-                    # if this is correct in all cases
+                    # because it is added implicitly by excluding the chainvectors but the original author
+                    # of this code was not sure if this is correct in all cases.
                     l = len(chain_vectors)
                     if l > 0:
                         for k in range(0, l):
                             old = chain_vectors[k].transpose()
                             S = S.col_join(old)
                     e0s = S.nullspace()
-                    #determine the number of chain leaders which equals the number of blocks with that size
+                    # Determine the number of chain leaders which equals the number of blocks with that size.
                     n_e0 = len(e0s)
                     s_chains = []
                     # s_cells=[]
                     for i in range(0, n_e0):
                         chain=[e0s[i]]
                         for k in range(1, s):
-                            v=M*chain[k-1]
+                            v = M*chain[k-1]
                             chain.append(v)
-                        #we want the chain leader appear as the last of the block
 
+                        # We want the chain leader appear as the last of the block.
                         chain.reverse()
                         chain_vectors += chain
                         s_chains.append(chain)
@@ -3520,7 +3534,7 @@ class MatrixBase(object):
         return jordan_block_structures
 
     def jordan_form(self, calc_transformation=True):
-        """Return Jordan form J of current matrix.
+        r"""Return Jordan form J of current matrix.
 
         Also the transformation P such that
 
@@ -3558,7 +3572,7 @@ class MatrixBase(object):
         return P, type(self)(J)
 
     def jordan_cells(self, calc_transformation=True):
-        """Return a list of Jordan cells of current matrix.
+        r"""Return a list of Jordan cells of current matrix.
         This list shape Jordan matrix J.
 
         If calc_transformation is specified as False, then transformation P such that
@@ -3597,16 +3611,16 @@ class MatrixBase(object):
 
         jordan_form
         """
-        n=self.rows
+        n = self.rows
         Jcells = []
         Pcols_new = []
-        jordan_block_structures = self._jordan_BlockStructure()
+        jordan_block_structures = self._jordan_block_structure()
         from sympy.matrices import MutableMatrix
 
-        # order according to default_sort_key, this makes sure the order is the same as in .diagonalize():
+        # Order according to default_sort_key, this makes sure the order is the same as in .diagonalize():
         for eigenval in (sorted(jordan_block_structures.keys(), key=default_sort_key)):
             l_jordan_chains = jordan_block_structures[eigenval]
-            for s in reversed(sorted((l_jordan_chains).keys())):  # start with the biggest block
+            for s in reversed(sorted((l_jordan_chains).keys())):  # Start with the biggest block
                 s_chains = l_jordan_chains[s]
                 block = self.jordan_cell(eigenval, s)
                 number_of_s_chains=len(s_chains)
@@ -3623,34 +3637,6 @@ class MatrixBase(object):
             P[:, j] = Pcols_new[j]
 
         return type(self)(P), Jcells
-
-#     def Jexp(self, sym):
-#         (J, P, cells) = self.jordan_cells()
-#         f = self._jexp_fmaker(sym)
-#         blocks=map(f, cells)
-#         from sympy.matrices import diag
-#         emx = diag(*blocks)
-#         return emx
-#
-#     @classmethod
-#     def _jexp_fmaker(cls, sym):
-#         def f(c):
-#             res = cls._jexp_block(c, sym)
-#             return(res)
-#         return(f)
-#
-#     @staticmethod
-#     def _jexp_block(cell, sym):
-#         from sympy import eye
-#         n = cell.rows
-#         l = cell[0, 0]
-#         b = eye(n)
-#         for j in range(1, n):
-#             for i in range(j):
-#                 p = j-i
-#                 b[i, j] = sym**(p)/factorial(p)
-#         b = b*exp(l*sym)
-#         return b
 
     def _jordan_split(self, algebraical, geometrical):
         """Return a list of integers with sum equal to 'algebraical'

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3563,7 +3563,7 @@ class MatrixBase(object):
 
         If calc_transformation is specified as False, then transformation P such that
 
-              `J = P^{-1} * M * P`
+              `J = P^{-1} \cdot M \cdot P`
 
         will not be calculated.
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1385,8 +1385,8 @@ def test_jordan_form():
 
     # diagonalizable
     m = Matrix(3, 3, [7, -12, 6, 10, -19, 10, 12, -24, 13])
-    Jmust = Matrix(3, 3, [1, 0, 0, 0, 1, 0, 0, 0, -1])
-    (J, P, cells) = m.jordan_form()
+    Jmust = Matrix(3, 3, [-1, 0, 0, 0, 1, 0, 0, 0, 1])
+    P, J = m.jordan_form()
     assert Jmust == J
     assert Jmust == m.diagonalize()[1]
 
@@ -1403,9 +1403,9 @@ def test_jordan_form():
     # In my algorithm the blocks are ordered from big to small, so I had to change
     # the ordering in the test accordingly
     Jmust = Matrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
-    (J, P, cells) = m.jordan_form()
+    P, J = m.jordan_form()
     assert Jmust == J
-    (J, P, Jcells) = m.jordan_cells()
+    P, Jcells = m.jordan_cells()
     # same here see 1456ff
     assert Jcells[1] == Matrix(1, 1, [2])
     assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
@@ -1415,13 +1415,13 @@ def test_jordan_form():
     # Jmust = Matrix(3, 3, [-1, 0, 0, 0, -1, 1, 0, 0, -1])
     # same here see 1456ff
     Jmust = Matrix(3, 3, [-1, 1, 0, 0, -1, 0, 0, 0, -1])
-    (J, P, cells) = m.jordan_form()
+    P, J = m.jordan_form()
     assert Jmust == J
 
     #complexity: two of eigenvalues are zero
     m = Matrix(3, 3, [4, -5, 2, 5, -7, 3, 6, -9, 4])
-    Jmust = Matrix(3, 3, [1, 0, 0, 0, 0, 1, 0, 0, 0])
-    (J, P, cells) = m.jordan_form()
+    Jmust = Matrix(3, 3, [0, 1, 0, 0, 0, 0, 0, 0, 1])
+    P, J = m.jordan_form()
     assert Jmust == J
 
     m = Matrix(4, 4, [6, 5, -2, -3, -3, -1, 3, 3, 2, 1, -2, -3, -1, 1, 5, 5])
@@ -1430,23 +1430,23 @@ def test_jordan_form():
               0, 0, 2, 1,
               0, 0, 0, 2]
               )
-    (J, P, cells) = m.jordan_form()
+    P, J = m.jordan_form()
     assert Jmust == J
 
     m = Matrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
     #Jmust = Matrix(4, 4, [2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2, 0, 0, 0, 0, -2])
     # same here see 1456ff
-    Jmust = Matrix(4, 4, [2, 1, 0, 0,
-                          0, 2, 0, 0,
-              0, 0, 2, 0,
-              0, 0, 0, -2])
-    (J, P, cells) = m.jordan_form()
+    Jmust = Matrix(4, 4, [-2, 0, 0, 0,
+                           0, 2, 1, 0,
+                           0, 0, 2, 0,
+                           0, 0, 0, 2])
+    P, J = m.jordan_form()
     assert Jmust == J
 
     m = Matrix(4, 4, [5, 4, 2, 1, 0, 1, -1, -1, -1, -1, 3, 0, 1, 1, -1, 2])
     assert not m.is_diagonalizable()
-    Jmust = Matrix(4, 4, [4, 1, 0, 0, 0, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1])
-    (J, P, cells) = m.jordan_form()
+    Jmust = Matrix(4, 4, [1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 1, 0, 0, 0, 4])
+    P, J = m.jordan_form()
     assert Jmust == J
 
     # the following tests are new and include (some) test the cases were the old
@@ -1459,7 +1459,7 @@ def test_jordan_form():
                     0, 0, 2, 0,
                     0, 0, 0, 2
     ])
-    (J, P, cells) = m.jordan_form()
+    P, J = m.jordan_form()
     assert m == J
 
     m = Matrix(4, 4, [2, 1, 0, 0,
@@ -1467,7 +1467,7 @@ def test_jordan_form():
                     0, 0, 2, 1,
                     0, 0, 0, 2
     ])
-    (J, P, cells) = m.jordan_form()
+    P, J = m.jordan_form()
     assert m == J
 
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1399,9 +1399,8 @@ def test_jordan_form():
     # Jordan cells
     # complexity: one of eigenvalues is zero
     m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-    # Jmust = Matrix(3, 3, [2, 0, 0, 0, 2, 1, 0, 0, 2])
-    # In my algorithm the blocks are ordered from big to small, so I had to change
-    # the ordering in the test accordingly
+    # The blocks are ordered according to the value of their eigenvalues,
+    # in order to make the matrix compatible with .diagonalize()
     Jmust = Matrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
     P, J = m.jordan_form()
     assert Jmust == J

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -407,7 +407,7 @@ def test_reshape():
 def test_applyfunc():
     m0 = eye(3)
     assert m0.applyfunc(lambda x: 2*x) == eye(3)*2
-    assert m0.applyfunc(lambda x: 0 ) == zeros(3)
+    assert m0.applyfunc(lambda x: 0) == zeros(3)
 
 
 def test_expand():
@@ -422,6 +422,11 @@ def test_expand():
     assert Matrix([exp(I*a)]).expand(complex=True) == \
         Matrix([cos(a) + I*sin(a)])
 
+    assert Matrix([[0, 1, 2], [0, 0, -1], [0, 0, 0]]).exp() == Matrix([
+        [1, 1, Rational(3, 2)],
+        [0, 1, -1],
+        [0, 0, 1]]
+    )
 
 def test_random():
     M = randMatrix(3, 3)
@@ -1380,8 +1385,8 @@ def test_jordan_form():
 
     # diagonalizable
     m = Matrix(3, 3, [7, -12, 6, 10, -19, 10, 12, -24, 13])
-    Jmust = Matrix(3, 3, [-1, 0, 0, 0, 1, 0, 0, 0, 1])
-    (P, J) = m.jordan_form()
+    Jmust = Matrix(3, 3, [1, 0, 0, 0, 1, 0, 0, 0, -1])
+    (J, P, cells) = m.jordan_form()
     assert Jmust == J
     assert Jmust == m.diagonalize()[1]
 
@@ -1394,39 +1399,76 @@ def test_jordan_form():
     # Jordan cells
     # complexity: one of eigenvalues is zero
     m = Matrix(3, 3, [0, 1, 0, -4, 4, 0, -2, 1, 2])
-    Jmust = Matrix(3, 3, [2, 0, 0, 0, 2, 1, 0, 0, 2])
-    assert Jmust == m.jordan_form()[1]
-    (P, Jcells) = m.jordan_cells()
-    assert Jcells[0] == Matrix(1, 1, [2])
-    assert Jcells[1] == Matrix(2, 2, [2, 1, 0, 2])
+    # Jmust = Matrix(3, 3, [2, 0, 0, 0, 2, 1, 0, 0, 2])
+    # In my algorithm the blocks are ordered from big to small, so I had to change
+    # the ordering in the test accordingly
+    Jmust = Matrix(3, 3, [2, 1, 0, 0, 2, 0, 0, 0, 2])
+    (J, P, cells) = m.jordan_form()
+    assert Jmust == J
+    (J, P, Jcells) = m.jordan_cells()
+    # same here see 1456ff
+    assert Jcells[1] == Matrix(1, 1, [2])
+    assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
 
     #complexity: all of eigenvalues are equal
     m = Matrix(3, 3, [2, 6, -15, 1, 1, -5, 1, 2, -6])
-    Jmust = Matrix(3, 3, [-1, 0, 0, 0, -1, 1, 0, 0, -1])
-    (P, J) = m.jordan_form()
+    # Jmust = Matrix(3, 3, [-1, 0, 0, 0, -1, 1, 0, 0, -1])
+    # same here see 1456ff
+    Jmust = Matrix(3, 3, [-1, 1, 0, 0, -1, 0, 0, 0, -1])
+    (J, P, cells) = m.jordan_form()
     assert Jmust == J
 
     #complexity: two of eigenvalues are zero
     m = Matrix(3, 3, [4, -5, 2, 5, -7, 3, 6, -9, 4])
-    Jmust = Matrix(3, 3, [0, 1, 0, 0, 0, 0, 0, 0, 1])
-    (P, J) = m.jordan_form()
+    Jmust = Matrix(3, 3, [1, 0, 0, 0, 0, 1, 0, 0, 0])
+    (J, P, cells) = m.jordan_form()
     assert Jmust == J
 
     m = Matrix(4, 4, [6, 5, -2, -3, -3, -1, 3, 3, 2, 1, -2, -3, -1, 1, 5, 5])
-    Jmust = Matrix(4, 4, [2, 1, 0, 0, 0, 2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2])
-    (P, J) = m.jordan_form()
+    Jmust = Matrix(4, 4, [2, 1, 0, 0,
+                          0, 2, 0, 0,
+              0, 0, 2, 1,
+              0, 0, 0, 2]
+              )
+    (J, P, cells) = m.jordan_form()
     assert Jmust == J
 
     m = Matrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
-    Jmust = Matrix(4, 4, [-2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2])
-    (P, J) = m.jordan_form()
+    #Jmust = Matrix(4, 4, [2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2, 0, 0, 0, 0, -2])
+    # same here see 1456ff
+    Jmust = Matrix(4, 4, [2, 1, 0, 0,
+                          0, 2, 0, 0,
+              0, 0, 2, 0,
+              0, 0, 0, -2])
+    (J, P, cells) = m.jordan_form()
     assert Jmust == J
 
     m = Matrix(4, 4, [5, 4, 2, 1, 0, 1, -1, -1, -1, -1, 3, 0, 1, 1, -1, 2])
     assert not m.is_diagonalizable()
-    Jmust = Matrix(4, 4, [1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 1, 0, 0, 0, 4])
-    (P, J) = m.jordan_form()
+    Jmust = Matrix(4, 4, [4, 1, 0, 0, 0, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1])
+    (J, P, cells) = m.jordan_form()
     assert Jmust == J
+
+    # the following tests are new and include (some) test the cases were the old
+    # algorithm failed due to the fact that the block structure can
+    # >>n o t<< be determined  from algebraic and geometric multiplicity alone
+    # This can be seen most easily when one lets compute the J.c.f. of a matrix that
+    # is in J.c.f already.
+    m = Matrix(4, 4, [2, 1, 0, 0,
+                    0, 2, 1, 0,
+                    0, 0, 2, 0,
+                    0, 0, 0, 2
+    ])
+    (J, P, cells) = m.jordan_form()
+    assert m == J
+
+    m = Matrix(4, 4, [2, 1, 0, 0,
+                    0, 2, 0, 0,
+                    0, 0, 2, 1,
+                    0, 0, 0, 2
+    ])
+    (J, P, cells) = m.jordan_form()
+    assert m == J
 
 
 def test_Matrix_berkowitz_charpoly():
@@ -1470,7 +1512,6 @@ def test_has():
 
 
 def test_errors():
-    # Note, some errors not tested.  See 'XXX' in code.
     raises(ValueError, lambda: Matrix([[1, 2], [1]]))
     raises(IndexError, lambda: Matrix([[1, 2]])[1.2, 5])
     raises(IndexError, lambda: Matrix([[1, 2]])[1, 5.2])
@@ -1504,8 +1545,6 @@ def test_errors():
     raises(ShapeError, lambda: Matrix([1, 2, 3]).dot(Matrix([1, 2])))
     raises(ShapeError, lambda: Matrix([1, 2]).dot([]))
     raises(TypeError, lambda: Matrix([1, 2]).dot('a'))
-    raises(NotImplementedError, lambda: Matrix([[0, 1, 2], [0, 0, -1],
-           [0, 0, 0]]).exp())
     raises(NonSquareMatrixError, lambda: Matrix([1, 2, 3]).exp())
     raises(ShapeError, lambda: Matrix([[1, 2], [3, 4]]).normalized())
     raises(ValueError, lambda: Matrix([1, 2]).inv(method='not a method'))

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1390,9 +1390,9 @@ def test_jordan_form():
     assert Jmust == J
     assert Jmust == m.diagonalize()[1]
 
-    #m = Matrix(3, 3, [0, 6, 3, 1, 3, 1, -2, 2, 1])
-    #m.jordan_form() # very long
-    # m.jordan_form() #
+    # m = Matrix(3, 3, [0, 6, 3, 1, 3, 1, -2, 2, 1])
+    # m.jordan_form()  # very long
+    # m.jordan_form()  #
 
     # diagonalizable, complex only
 
@@ -1409,7 +1409,7 @@ def test_jordan_form():
     assert Jcells[1] == Matrix(1, 1, [2])
     assert Jcells[0] == Matrix(2, 2, [2, 1, 0, 2])
 
-    #complexity: all of eigenvalues are equal
+    # complexity: all of eigenvalues are equal
     m = Matrix(3, 3, [2, 6, -15, 1, 1, -5, 1, 2, -6])
     # Jmust = Matrix(3, 3, [-1, 0, 0, 0, -1, 1, 0, 0, -1])
     # same here see 1456ff
@@ -1417,7 +1417,7 @@ def test_jordan_form():
     P, J = m.jordan_form()
     assert Jmust == J
 
-    #complexity: two of eigenvalues are zero
+    # complexity: two of eigenvalues are zero
     m = Matrix(3, 3, [4, -5, 2, 5, -7, 3, 6, -9, 4])
     Jmust = Matrix(3, 3, [0, 1, 0, 0, 0, 0, 0, 0, 1])
     P, J = m.jordan_form()
@@ -1433,7 +1433,7 @@ def test_jordan_form():
     assert Jmust == J
 
     m = Matrix(4, 4, [6, 2, -8, -6, -3, 2, 9, 6, 2, -2, -8, -6, -1, 0, 3, 4])
-    #Jmust = Matrix(4, 4, [2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2, 0, 0, 0, 0, -2])
+    # Jmust = Matrix(4, 4, [2, 0, 0, 0, 0, 2, 1, 0, 0, 0, 2, 0, 0, 0, 0, -2])
     # same here see 1456ff
     Jmust = Matrix(4, 4, [-2, 0, 0, 0,
                            0, 2, 1, 0,
@@ -1448,9 +1448,9 @@ def test_jordan_form():
     P, J = m.jordan_form()
     assert Jmust == J
 
-    # the following tests are new and include (some) test the cases were the old
+    # the following tests are new and include (some) test the cases where the old
     # algorithm failed due to the fact that the block structure can
-    # >>n o t<< be determined  from algebraic and geometric multiplicity alone
+    # *NOT* be determined  from algebraic and geometric multiplicity alone
     # This can be seen most easily when one lets compute the J.c.f. of a matrix that
     # is in J.c.f already.
     m = Matrix(4, 4, [2, 1, 0, 0,


### PR DESCRIPTION
This is mamueller's PR merged with the current master branch of SymPy.

Task to do:
- [x] `Matrix.diagonalize( )` and `Matrix.jordan_form( )` should return the same diagonal matrix if matrix is diagonalizable (as of now order of eigenvectors may not be the same).
- [x] Clean up the code
- [x] Remove useless comments
- [x] Remove unused variables
- [x] `Matrix.jordan( )` form ===> what is it supposed to return? `mamueller` returns `(J, P, Jcells)`, I'd rather return `(P, J)`.
