### PR TITLE
Add reference to Pyzo in the install guide

### DIFF
--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -85,6 +85,14 @@ libraries in addition to SymPy is to install `Anaconda
 from Continuum Analytics that includes SymPy, Matplotlib, IPython, NumPy, and
 many more useful packages for scientific computing.
 
+Pyzo
+====
+
+If you want to use SymPy exclusively with Python 3 (including other
+libraries such as NumPy, SciPy, Pandas and others), you may also find
+`Pyzo <http://www.pyzo.org/>`__ interesting. You may find this
+especially useful for working on Microsoft Windows.
+
 Other Methods
 =============
 


### PR DESCRIPTION
I think it's a good idea to include Pyzo (http://www.pyzo.org/index.html) in the list of ways to get started with SymPy.
