### PR TITLE
Fix issue 3744

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -703,6 +703,8 @@ class Add(Expr, AssocOp):
             # if it simplifies to an x-free expression, return that;
             # tests don't fail if we don't but it seems nicer to do this
             if x not in rv_fraction.free_symbols:
+                if rv_fraction.is_zero and plain.is_zero is not True:
+                    return (self - plain)._eval_as_leading_term(x)
                 return rv_fraction
             return rv
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -281,6 +281,15 @@ def test_as_leading_term3():
     assert (2*x + pi*x + x**2).as_leading_term(x) == (2 + pi)*x
 
 
+def test_as_leading_term4():
+    # see issue 3744
+    n = Symbol('n', integer=True, positive=True)
+    r = -n**3/(2*n**2 + 4*n + 2) - n**2/(n**2 + 2*n + 1) + \
+        n**2/(n + 1) - n/(2*n**2 + 4*n + 2) + n/(n*x + x) + 2*n/(n + 1) - \
+        1 + 1/(n*x + x) + 1/(n + 1) - 1/x
+    assert r.as_leading_term(x).cancel() == n/2
+
+
 def test_as_leading_term_stub():
     class foo(Function):
         pass

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -863,8 +863,8 @@ def test_atom_bug():
 def test_limit_bug():
     z = Symbol('z', nonzero=True)
     assert integrate(sin(x*y*z), (x, 0, pi), (y, 0, pi)) == \
-        -((-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z) + \
-        log(z**2)/(2*z) + EulerGamma/z + 2*log(pi)/z
+        (log(z**2) + 2*EulerGamma + 2*log(pi))/(2*z) - \
+        (-log(pi*z) + log(pi**2*z**2)/2 + Ci(pi**2*z))/z + log(pi)/z
 
 
 def test_issue_1604():

--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -448,6 +448,8 @@ def calculate_series(e, x, skip_abs=False, logx=None):
 
     This is a place that fails most often, so it is in its own function.
     """
+    from sympy.core.exprtools import factor_terms
+
     n = 1
     while 1:
         series = e.nseries(x, n=n, logx=logx)
@@ -456,6 +458,7 @@ def calculate_series(e, x, skip_abs=False, logx=None):
             return series
 
         series = series.removeO()
+        series = factor_terms(series, fraction=True)
         if series and ((not skip_abs) or series.has(x)):
             return series
         n *= 2

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -173,8 +173,6 @@ def limit(e, z, z0, dir="+"):
             rval = Add(*[limit(term, z, z0, dir) for term in e.args])
             if rval != S.NaN:
                 return rval
-        if not any([a.is_unbounded for a in e.args]):
-            e = e.normal() # workaround for issue 3744
 
     if e.is_Order:
         args = e.args

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -409,8 +409,7 @@ def test_issue545():
     assert gruntz(((x**7 + x + 1)/(2**x + x**2))**(-1/x), x, oo) == 2
 
 
-@XFAIL
 def test_issue3744():
     n = Symbol('n', integer=True, positive=True)
     r = (n + 1)*x**(n + 1)/(x**(n + 1) - 1) - x/(x - 1)
-    assert gruntz(r, x, 1) == n/2
+    assert gruntz(r, x, 1).simplify() == n/2

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -363,7 +363,7 @@ def test_issue_2641():
 def test_issue_3267():
     n = Symbol('n', integer=True, positive=True)
     r = (n + 1)*x**(n + 1)/(x**(n + 1) - 1) - x/(x - 1)
-    assert limit(r, x, 1) == n/2
+    assert limit(r, x, 1).simplify() == n/2
 
 
 def test_factorial():


### PR DESCRIPTION
The calculate_series in gruntz.py should always return a non-zero        value for nontrivial expression.  Let's do some cheap         simplifications to check the result is not zero and         call nseries() with increased n if it is.

This pull also add check for zero output in the Add._eval_as_leading_term()
