### PR TITLE
Issue 1756: don't do division by order term

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2496,13 +2496,14 @@ class Expr(Basic, EvalfMixin):
                         if newn != ngot:
                             ndo = n + (n - ngot)*more/(newn - ngot)
                             s1 = self._eval_nseries(x, n=ndo, logx=None)
-                            # if this assertion fails then our ndo calculation
-                            # needs modification
-                            assert s1.getn() == n
+                            while s1.getn() < n:
+                                s1 = self._eval_nseries(x, n=ndo, logx=None)
+                                ndo += 1
                             break
                     else:
                         raise ValueError('Could not calculate %s terms for %s'
                                          % (str(n), self))
+                    s1 += C.Order(x**n)
                 o = s1.getO()
                 s1 = s1.removeO()
             else:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -623,6 +623,9 @@ class AppliedUndef(Function):
         result.nargs = len(args)
         return result
 
+    def _eval_as_leading_term(self, x):
+        return self
+
 
 class UndefinedFunction(FunctionClass):
     """

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1429,7 +1429,10 @@ class Mul(Expr, AssocOp):
     def _eval_nseries(self, x, n, logx):
         from sympy import powsimp
         terms = [t.nseries(x, n=n, logx=logx) for t in self.args]
-        return powsimp(self.func(*terms).expand(), combine='exp', deep=True)
+        res = powsimp(self.func(*terms).expand(), combine='exp', deep=True)
+        if res.has(C.Order):
+            res += C.Order(x**n, x)
+        return res
 
     def _eval_as_leading_term(self, x):
         return self.func(*[t.as_leading_term(x) for t in self.args])

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -2,6 +2,8 @@ from sympy.core import (Rational, Symbol, S, Float, Integer, Number, Pow,
 Basic, I, nan)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.trigonometric import sin
+from sympy.series.order import O
 from sympy.utilities.pytest import XFAIL
 
 
@@ -256,7 +258,6 @@ def test_issue_3109():
     assert root(exp(5*I), 3).exp == Rational(1, 3)
 
 def test_issue_2969():
-    from sympy import sin, O
     x = Symbol('x')
     assert sqrt(sin(x)).series(x, 0, 7) == \
         sqrt(x) - x**(S(5)/2)/12 + x**(S(9)/2)/1440 - \
@@ -270,7 +271,8 @@ def test_issue_2969():
         sqrt(x**3) - x**6*sqrt(x**3)/12 + x**12*sqrt(x**3)/1440 - \
         x**18*sqrt(x**3)/24192 + O(x**20)
 
-@XFAIL
+
 def test_issue_3683():
+    x = Symbol('x')
     assert sqrt(sin(x**3)).series(x, 0, 7) == sqrt(x**3) + O(x**7)
-    assert sqrt(sin(x**4)).series(x, 0, 3) == sqrt(x**4) + O(x**4)
+    assert sqrt(sin(x**4)).series(x, 0, 3) == sqrt(x**4) + O(x**3)

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -2,9 +2,9 @@ from sympy.core import (Rational, Symbol, S, Float, Integer, Number, Pow,
 Basic, I, nan)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import exp
-from sympy.functions.elementary.trigonometric import sin
+from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.series.order import O
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, slow
 
 
 def test_rational():
@@ -276,3 +276,19 @@ def test_issue_3683():
     x = Symbol('x')
     assert sqrt(sin(x**3)).series(x, 0, 7) == sqrt(x**3) + O(x**7)
     assert sqrt(sin(x**4)).series(x, 0, 3) == sqrt(x**4) + O(x**3)
+
+
+def test_issue_3554():
+    x = Symbol('x')
+    assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 7) == \
+        1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + O(x**7)
+    assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 8) == \
+        1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + O(x**8)
+
+
+@slow
+def test_issue_3554s():
+    x = Symbol('x')
+    assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 15) == \
+        1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + 4039*x**8/5760 - 5393*x**10/6720 + \
+        13607537*x**12/14515200 - 532056047*x**14/479001600 + O(x**15)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -464,6 +464,11 @@ def test_cot():
 def test_cot_series():
     assert cot(x).series(x, 0, 9) == \
         1/x - x/3 - x**3/45 - 2*x**5/945 - x**7/4725 + O(x**9)
+    # issue 3111:
+    assert cot(x**20 + x**21 + x**22).series(x, 0, 4) == \
+        x**(-20) - 1/x**19 + x**(-17) - 1/x**16 + x**(-14) - 1/x**13 + \
+        x**(-11) - 1/x**10 + x**(-8) - 1/x**7 + x**(-5) - 1/x**4 + \
+        x**(-2) - 1/x + x - x**2 + O(x**4)
 
 
 def test_cot_rewrite():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1084,7 +1084,7 @@ class cot(TrigonometricFunction):
         i = self.args[0].limit(x, 0)/S.Pi
         if i and i.is_Integer:
             return self.rewrite(cos)._eval_nseries(x, n=n, logx=logx)
-        return Function._eval_nseries(self, x, n=n, logx=logx)
+        return self.rewrite(tan)._eval_nseries(x, n=n, logx=logx)
 
     def _eval_conjugate(self):
         assert len(self.args) == 1

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -283,7 +283,8 @@ def test_loggamma():
     raises(ArgumentIndexError, lambda: loggamma(x).fdiff(2))
     assert loggamma(x).diff(x) == polygamma(0, x)
     s1 = loggamma(1/(x + sin(x)) + cos(x)).nseries(x, n=4)
-    s2 = (-log(2*x) - 1)/(2*x) - log(x/pi)/2 + (4 - log(2*x))*x/24 + O(x**2)
+    s2 = (-log(2*x) - 1)/(2*x) - log(x/pi)/2 + (4 - log(2*x))*x/24 + O(x**2) + \
+        log(x)*x**2/2
     assert (s1 - s2).expand(force=True).removeO() == 0
     s1 = loggamma(1/x).series(x)
     s2 = (1/x - S(1)/2)*log(1/x) - 1/x + log(2*pi)/2 + \

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -313,7 +313,7 @@ def test_polygamma_expansion():
         -log(x) - x/2 - x**2/12 + O(x**4)
     assert polygamma(1, 1/x).series(x, n=5) == \
         x + x**2/2 + x**3/6 + O(x**5)
-    assert polygamma(3, 1/x).nseries(x, n=8) == \
+    assert polygamma(3, 1/x).nseries(x, n=11) == \
         2*x**3 + 3*x**4 + 2*x**5 - x**7 + 4*x**9/3 + O(x**11)
 
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -211,7 +211,7 @@ class Order(Expr):
         return self.expr.free_symbols
 
     def _eval_power(b, e):
-        if e.is_Number:
+        if e.is_Number and e.is_nonnegative:
             return b.func(b.expr ** e, *b.args[1:])
         return
 

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -20,10 +20,10 @@ def test_mul_0():
 
 
 def test_mul_1():
-    assert (x*ln(2 + x)).nseries(x, n=4) == x*log(2) + x**2/2 - x**3/8 + \
-        x**4/24 + O(x**5)  # x*log(2)+x**2/2-x**3/8+O(x**4)
+    assert (x*ln(2 + x)).nseries(x, n=5) == x*log(2) + x**2/2 - x**3/8 + \
+        x**4/24 + O(x**5)
     assert (x*ln(1 + x)).nseries(
-        x, n=4) == x**2 - x**3/2 + x**4/3 + O(x**5)  # x**2- x**3/2 + O(x**4)
+        x, n=5) == x**2 - x**3/2 + x**4/3 + O(x**5)
 
 
 def test_pow_0():
@@ -40,10 +40,9 @@ def test_pow_1():
 
 def test_geometric_1():
     assert (1/(1 - x)).nseries(x, n=5) == 1 + x + x**2 + x**3 + x**4 + O(x**5)
-    assert (x/(1 - x)).nseries(x, n=5) == x + x**2 + x**3 + x**4 + x**5 + \
-        O(x**6)  # x+x**2+x**3+x**4+O(x**5)
-    assert (x**3/(1 - x)).nseries(x, n=5) == x**3 + x**4 + x**5 + x**6 + \
-        x**7 + O(x**8)  # x**3+x**4+O(x**5)
+    assert (x/(1 - x)).nseries(x, n=6) == x + x**2 + x**3 + x**4 + x**5 + O(x**6)
+    assert (x**3/(1 - x)).nseries(x, n=8) == x**3 + x**4 + x**5 + x**6 + \
+        x**7 + O(x**8)
 
 
 def test_sqrt_1():
@@ -266,7 +265,7 @@ def test_sinsinbug():
 
 def test_issue159():
     a = x/(exp(x) - 1)
-    assert a.nseries(x, 0, 6) == 1 - x/2 - x**4/720 + x**2/12 + O(x**5)
+    assert a.nseries(x, 0, 5) == 1 - x/2 - x**4/720 + x**2/12 + O(x**5)
 
 
 def test_issue105():
@@ -306,17 +305,17 @@ def test_issue416():
 def test_issue406():
     e = sin(x)**(-4)*(sqrt(cos(x))*sin(x)**2 -
         cos(x)**Rational(1, 3)*sin(x)**2)
-    assert e.nseries(x, n=8) == -Rational(1)/12 - 7*x**2/288 - \
+    assert e.nseries(x, n=9) == -Rational(1)/12 - 7*x**2/288 - \
         43*x**4/10368 + O(x**5)
 
 
 def test_issue402():
     a = Symbol("a")
     e = x**(-2)*(x*sin(a + x) - x*sin(a))
-    assert e.nseries(x, n=5) == cos(a) - sin(a)*x/2 - cos(a)*x**2/6 + \
+    assert e.nseries(x, n=6) == cos(a) - sin(a)*x/2 - cos(a)*x**2/6 + \
         sin(a)*x**3/24 + O(x**4)
     e = x**(-2)*(x*cos(a + x) - x*cos(a))
-    assert e.nseries(x, n=5) == -sin(a) - cos(a)*x/2 + sin(a)*x**2/6 + \
+    assert e.nseries(x, n=6) == -sin(a) - cos(a)*x/2 + sin(a)*x**2/6 + \
         cos(a)*x**3/24 + O(x**4)
 
 
@@ -334,7 +333,7 @@ def test_issue404():
 
 def test_issue407():
     e = (x + sin(3*x))**(-2)*(x*(x + sin(3*x)) - (x + sin(3*x))*sin(2*x))
-    assert e.nseries(x, n=6) == \
+    assert e.nseries(x, n=7) == \
         -Rational(1, 4) + 5*x**2/96 + 91*x**4/768 + O(x**5)
 
 
@@ -348,7 +347,7 @@ def test_issue409():
 
 def test_issue408():
     e = x**(-4)*(x**2 - x**2*sqrt(cos(x)))
-    assert e.nseries(x, n=7) == \
+    assert e.nseries(x, n=9) == \
         Rational(1, 4) + x**2/96 + 19*x**4/5760 + O(x**5)
 
 
@@ -374,14 +373,14 @@ def test_series2():
     w = Symbol("w", real=True)
     x = Symbol("x", real=True)
     e = w**(-2)*(w*exp(1/x - w) - w*exp(1/x))
-    assert e.nseries(w, n=3) == -exp(1/x) + w * exp(1/x) / 2 + O(w**2)
+    assert e.nseries(w, n=4) == -exp(1/x) + w * exp(1/x) / 2 + O(w**2)
 
 
 def test_series3():
     w = Symbol("w", real=True)
     x = Symbol("x", real=True)
     e = w**(-6)*(w**3*tan(w) - w**3*sin(w))
-    assert e.nseries(w, n=5) == Integer(1)/2 + O(w**2)
+    assert e.nseries(w, n=8) == Integer(1)/2 + O(w**2)
 
 
 def test_bug4():
@@ -397,14 +396,14 @@ def test_bug5():
     e = (-log(w) + log(1 + w*log(x)))**(-2)*w**(-2)*((-log(w) +
         log(1 + x*w))*(-log(w) + log(1 + w*log(x)))*w - x*(-log(w) +
         log(1 + w*log(x)))*w)
-    assert e.nseries(w, n=1, logx=l) == x/w/l + 1/w + O(1, w)
-    assert e.nseries(w, n=2, logx=l) == x/w/l + 1/w - x/l + 1/l*log(x) \
+    assert e.nseries(w, n=2, logx=l) == x/w/l + 1/w + O(1, w)
+    assert e.nseries(w, n=3, logx=l) == x/w/l + 1/w - x/l + 1/l*log(x) \
         + x*log(x)/l**2 + O(w)
 
 
 def test_issue1016():
-    assert ( sin(x)/(1 - cos(x)) ).nseries(x, n=2) == O(1/x)
-    assert ( sin(x)**2/(1 - cos(x)) ).nseries(x, n=2) == O(1, x)
+    assert (sin(x)/(1 - cos(x))).nseries(x, n=1) == O(1/x)
+    assert (sin(x)**2/(1 - cos(x))).nseries(x, n=1) == O(1, x)
 
 
 def test_pole():

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -105,7 +105,6 @@ def test_log3():
 
 
 def test_series1():
-    x = Symbol("x")
     e = sin(x)
     assert e.nseries(x, 0, 0) != 0
     assert e.nseries(x, 0, 0) == O(1, x)
@@ -127,13 +126,11 @@ def test_series1_failing():
 
 
 def test_seriesbug1():
-    x = Symbol("x")
     assert (1/x).nseries(x, 0, 3) == 1/x
     assert (x + 1/x).nseries(x, 0, 3) == x + 1/x
 
 
 def test_series2x():
-    x = Symbol("x")
     assert ((x + 1)**(-2)).nseries(x, 0, 4) == 1 - 2*x + 3*x**2 - 4*x**3 + O(x**4, x)
     assert ((x + 1)**(-1)).nseries(x, 0, 4) == 1 - x + x**2 - x**3 + O(x**4, x)
     assert ((x + 1)**0).nseries(x, 0, 3) == 1
@@ -159,13 +156,11 @@ def test_bug2():  # 1/log(0) * log(0) problem
 
 
 def test_exp():
-    x = Symbol("x")
     e = (1 + x)**(1/x)
     assert e.nseries(x, n=3) == exp(1) - x*exp(1)/2 + O(x**2, x)
 
 
 def test_exp2():
-    x = Symbol("x")
     w = Symbol("w")
     e = w**(1 - log(x)/(log(2) + log(x)))
     logw = Symbol("logw")
@@ -174,13 +169,11 @@ def test_exp2():
 
 
 def test_bug3():
-    x = Symbol("x")
     e = (2/x + 3/x**2)/(1/x + 1/x**2)
     assert e.nseries(x, n=3) == 3 + O(x)
 
 
 def test_generalexponent():
-    x = Symbol("x")
     p = 2
     e = (2/x + 3/x**p)/(1/x + 1/x**p)
     assert e.nseries(x, 0, 3) == 3 + O(x)
@@ -195,7 +188,6 @@ def test_generalexponent():
 
 
 def test_genexp_x():
-    x = Symbol("x")
     e = 1/(1 + sqrt(x))
     assert e.nseries(x, 0, 2) == \
         1 + x - sqrt(x) - sqrt(x)**3 + O(x**2, x)
@@ -204,7 +196,6 @@ def test_genexp_x():
 
 
 def test_genexp_x2():
-    x = Symbol("x")
     p = Rational(3, 2)
     e = (2/x + 3/x**p)/(1/x + 1/x**p)
     assert e.nseries(x, 0, 3) == 3 - sqrt(x) + x + O(sqrt(x)**3)
@@ -257,12 +248,10 @@ def test_expbug4_failing():
 
 
 def test_logbug4():
-    x = Symbol("x")
     assert log(2 + O(x)).nseries(x, 0, 2) == log(2) + O(x, x)
 
 
 def test_expbug5():
-    x = Symbol("x")
     assert exp(log(1 + x)/x).nseries(x, n=3) == exp(1) + -exp(1)*x/2 + O(x**2)
 
 
@@ -272,12 +261,10 @@ def test_expbug5_failing():
 
 
 def test_sinsinbug():
-    x = Symbol("x")
     assert sin(sin(x)).nseries(x, 0, 8) == x - x**3/3 + x**5/10 - 8*x**7/315 + O(x**8)
 
 
 def test_issue159():
-    x = Symbol("x")
     a = x/(exp(x) - 1)
     assert a.nseries(x, 0, 6) == 1 - x/2 - x**4/720 + x**2/12 + O(x**5)
 
@@ -289,14 +276,13 @@ def test_issue105():
 
 
 def test_issue125():
-    y = Symbol("y")
     f = sqrt(1 - sqrt(y))
     assert f.nseries(y, 0, 2) == 1 - sqrt(y)/2 - y/8 - sqrt(y)**3/16 + O(y**2)
 
 
 def test_issue364():
     from sympy import summation, symbols
-    w, x, i = symbols('w,x,i')
+    w, i = symbols('w,i')
     r = log(5)/log(3)
     p = w**(-1 + r)
     e = 1/x*(-log(w**(1 + r)) + log(w + w**r))
@@ -305,8 +291,6 @@ def test_issue364():
 
 
 def test_sin():
-    x = Symbol("x")
-    y = Symbol("y")
     assert sin(8*x).nseries(x, n=4) == 8*x - 256*x**3/3 + O(x**4)
     assert sin(x + y).nseries(x, n=1) == sin(y) + O(x)
     assert sin(x + y).nseries(x, n=2) == sin(y) + cos(y)*x + O(x**2)
@@ -315,13 +299,11 @@ def test_sin():
 
 
 def test_issue416():
-    x = Symbol("x")
     e = sin(8*x)/x
     assert e.nseries(x, n=6) == 8 - 256*x**2/3 + 4096*x**4/15 + O(x**5)
 
 
 def test_issue406():
-    x = Symbol("x")
     e = sin(x)**(-4)*(sqrt(cos(x))*sin(x)**2 -
         cos(x)**Rational(1, 3)*sin(x)**2)
     assert e.nseries(x, n=8) == -Rational(1)/12 - 7*x**2/288 - \
@@ -329,7 +311,6 @@ def test_issue406():
 
 
 def test_issue402():
-    x = Symbol("x")
     a = Symbol("a")
     e = x**(-2)*(x*sin(a + x) - x*sin(a))
     assert e.nseries(x, n=5) == cos(a) - sin(a)*x/2 - cos(a)*x**2/6 + \
@@ -340,7 +321,6 @@ def test_issue402():
 
 
 def test_issue403():
-    x = Symbol("x")
     e = sin(5*x)/sin(2*x)
     assert e.nseries(x, n=2) == Rational(5, 2) + O(x)
     assert e.nseries(x, n=6) == \
@@ -348,13 +328,11 @@ def test_issue403():
 
 
 def test_issue404():
-    x = Symbol("x")
     e = sin(2 + x)/(2 + x)
     assert e.nseries(x, n=2) == sin(2)/2 + x*cos(2)/2 - x*sin(2)/4 + O(x**2)
 
 
 def test_issue407():
-    x = Symbol("x")
     e = (x + sin(3*x))**(-2)*(x*(x + sin(3*x)) - (x + sin(3*x))*sin(2*x))
     assert e.nseries(x, n=6) == \
         -Rational(1, 4) + 5*x**2/96 + 91*x**4/768 + O(x**5)
@@ -369,20 +347,17 @@ def test_issue409():
 
 
 def test_issue408():
-    x = Symbol("x")
     e = x**(-4)*(x**2 - x**2*sqrt(cos(x)))
     assert e.nseries(x, n=7) == \
         Rational(1, 4) + x**2/96 + 19*x**4/5760 + O(x**5)
 
 
 def test_issue540():
-    x = Symbol("x")
     assert sin(cos(x)).nseries(x, n=5) == \
         sin(1) - x**2*cos(1)/2 - x**4*sin(1)/8 + x**4*cos(1)/24 + O(x**5)
 
 
 def test_hyperbolic():
-    x = Symbol("x")
     assert sinh(x).nseries(x, n=6) == x + x**3/6 + x**5/120 + O(x**6)
     assert cosh(x).nseries(x, n=5) == 1 + x**2/2 + x**4/24 + O(x**5)
     assert tanh(x).nseries(x, n=6) == x - x**3/3 + 2*x**5/15 + O(x**6)
@@ -411,7 +386,6 @@ def test_series3():
 
 def test_bug4():
     w = Symbol("w")
-    x = Symbol("x")
     e = x/(w**4 + x**2*w**4 + 2*x*w**4)*w**4
     assert e.nseries(w, n=2) in [x/(1 + 2*x + x**2),
         1/(1 + x/2 + 1/x/2)/2, 1/x/(1 + 2/x + x**(-2))]
@@ -419,7 +393,6 @@ def test_bug4():
 
 def test_bug5():
     w = Symbol("w")
-    x = Symbol("x")
     l = Symbol('l')
     e = (-log(w) + log(1 + w*log(x)))**(-2)*w**(-2)*((-log(w) +
         log(1 + x*w))*(-log(w) + log(1 + w*log(x)))*w - x*(-log(w) +
@@ -430,20 +403,17 @@ def test_bug5():
 
 
 def test_issue1016():
-    x = Symbol("x")
     assert ( sin(x)/(1 - cos(x)) ).nseries(x, n=2) == O(1/x)
     assert ( sin(x)**2/(1 - cos(x)) ).nseries(x, n=2) == O(1, x)
 
 
 def test_pole():
-    x = Symbol("x")
     raises(PoleError, lambda: sin(1/x).series(x, 0, 5))
     raises(PoleError, lambda: sin(1 + 1/x).series(x, 0, 5))
     raises(PoleError, lambda: (x*sin(1/x)).series(x, 0, 5))
 
 
 def test_expsinbug():
-    x = Symbol("x")
     assert exp(sin(x)).series(x, 0, 0) == O(1, x)
     assert exp(sin(x)).series(x, 0, 1) == 1 + O(x)
     assert exp(sin(x)).series(x, 0, 2) == 1 + x + O(x**2)
@@ -473,7 +443,6 @@ def test_floor():
 
 
 def test_ceiling():
-    x = Symbol('x')
     assert ceiling(x).series(x) == 1
     assert ceiling(-x).series(x) == 0
     assert ceiling(sin(x)).series(x) == 1
@@ -485,7 +454,6 @@ def test_ceiling():
 
 
 def test_abs():
-    x = Symbol('x')
     a = Symbol('a')
     assert abs(x).nseries(x, n=4) == x
     assert abs(-x).nseries(x, n=4) == x
@@ -497,8 +465,6 @@ def test_abs():
 
 
 def test_dir():
-    x = Symbol('x')
-    y = Symbol('y')
     assert abs(x).series(x, 0, dir="+") == x
     assert abs(x).series(x, 0, dir="-") == -x
     assert floor(x + 2).series(x, 0, dir='+') == 2
@@ -516,7 +482,7 @@ def test_issue405():
 
 
 def test_issue1342():
-    x, a, b = symbols('x,a,b')
+    a, b = symbols('a,b')
     f = 1/(1 + a*x)
     assert f.series(x, 0, 5) == 1 - a*x + a**2*x**2 - a**3*x**3 + \
         a**4*x**4 + O(x**5)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -49,7 +49,6 @@ def test_simple_3():
 
 def test_simple_4():
     assert Order(x)**2 == Order(x**2)
-    assert Order(x**3)**-2 == Order(x**-6)
 
 
 def test_simple_5():
@@ -289,12 +288,15 @@ def test_issue_1180():
     assert O(1, a, b) + O(a + b, a, b) == O(1, a, b)
 
 
-@XFAIL
 def test_issue_1756():
-    x = Symbol('x')
-    f = Function('f')
     assert 1/O(1) != O(1)
     assert 1/O(x) != O(1/x)
+    assert 1/O(x, x, oo) != O(1/x, x, oo)
+
+
+@XFAIL
+def test_issue_1756_2():
+    f = Function('f')
     assert 1/O(f(x)) != O(1/x)
 
 
@@ -350,7 +352,6 @@ def test_order_at_infinity():
     assert Order(x, x, oo) + exp(1/x) == exp(1/x) + Order(x, x, oo)
 
     assert Order(x, x, oo)**2 == Order(x**2, x, oo)
-    assert Order(x**3, x, oo)**-2 == Order(x**-6, x, oo)
 
     assert Order(x, x, oo) + Order(x**2, x, oo) == Order(x**2, x, oo)
     assert Order(x, x, oo) + Order(x**-2, x, oo) == Order(x, x, oo)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -293,9 +293,6 @@ def test_issue_1756():
     assert 1/O(x) != O(1/x)
     assert 1/O(x, x, oo) != O(1/x, x, oo)
 
-
-@XFAIL
-def test_issue_1756_2():
     f = Function('f')
     assert 1/O(f(x)) != O(1/x)
 

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -183,7 +183,6 @@ def test_multivar_3():
 
 
 def test_issue369():
-    x = Symbol('x')
     y = Symbol('y', negative=True)
     z = Symbol('z', complex=True)
 
@@ -266,7 +265,6 @@ def test_leading_term():
 
 
 def test_eval():
-    y = Symbol('y')
     assert Order(x).subs(Order(x), 1) == 1
     assert Order(x).subs(x, y) == Order(y)
     assert Order(x).subs(y, x) == Order(x)
@@ -312,7 +310,6 @@ def test_order_conjugate_transpose():
 
 def test_order_noncommutative():
     A = Symbol('A', commutative=False)
-    x = Symbol('x')
     assert Order(A + A*x, x) == Order(1, x)
     assert (A + A*x)*Order(x) == Order(x)
     assert (A*x)*Order(x) == Order(x**2, x)

--- a/sympy/series/tests/test_residues.py
+++ b/sympy/series/tests/test_residues.py
@@ -1,9 +1,9 @@
 from sympy import residue, Symbol, Function, sin, S, I, pi, exp, log, pi, factorial
 from sympy.utilities.pytest import XFAIL, raises
+from sympy.abc import x, y, z, a, s
 
 
 def test_basic1():
-    x = Symbol("x")
     assert residue(1/x, x, 0) == 1
     assert residue(-2/x, x, 0) == -2
     assert residue(81/x, x, 0) == 81
@@ -15,7 +15,6 @@ def test_basic1():
 
 
 def test_basic2():
-    x = Symbol("x")
     assert residue(1/x, x, 1) == 0
     assert residue(-2/x, x, 1) == 0
     assert residue(81/x, x, -1) == 0
@@ -28,13 +27,11 @@ def test_basic2():
 
 def _test_f():
     # FIXME: we get infinite recursion here:
-    x = Symbol("x")
     f = Function("f")
     assert residue(f(x)/x**5, x, 0) == f.diff(x, 4)/24
 
 
 def test_functions():
-    x = Symbol("x")
     assert residue(1/sin(x), x, 0) == 1
     assert residue(2/sin(x), x, 0) == 2
     assert residue(1/sin(x)**2, x, 0) == 0
@@ -42,7 +39,6 @@ def test_functions():
 
 
 def test_expressions():
-    x = Symbol("x")
     assert residue(1/(x + 1), x, 0) == 0
     assert residue(1/(x + 1), x, -1) == 1
     assert residue(1/(x**2 + 1), x, -1) == 0
@@ -53,23 +49,18 @@ def test_expressions():
 
 @XFAIL
 def test_expressions_failing():
-    x = Symbol('x')
     assert residue(1/(x**4 + 1), x, exp(I*pi/4)) == -(S(1)/4 + I/4)/sqrt(2)
 
-    z = Symbol('z')
     n = Symbol('n', integer=True, positive=True)
-    a = Symbol('a')
     assert residue(exp(z)/(z - pi*I/4*a)**n, z, I*pi*a) == \
         exp(I*pi*a/4)/factorial(n - 1)
     assert residue(1/(x**2 + a**2)**2, x, a*I) == -I/4/a**3
 
 
 def test_NotImplemented():
-    z = Symbol('z')
     raises(NotImplementedError, lambda: residue(exp(1/z), z, 0))
 
 
 def test_bug():
-    from sympy.abc import s, z
     assert residue(2**(z)*(s + z)*(1 - s - z)/z**2, z, 0) == \
         1 + s*log(2) - s**2*log(2) - 2*s


### PR DESCRIPTION
Sympy produces the following (wrong) results (see [1756](http://code.google.com/p/sympy/issues/detail?id=1756)):
```In [11]: 1/O(1)
Out[11]: O(1)

In [14]: 1/O(x)
Out[14]: O(1/x)

In [15]: 1/O(f(x))
Out[15]: O(1/x)```

Lets fix this mess.

Also affected (fixed) issues:
[3683](http://code.google.com/p/sympy/issues/detail?id=3683) - AssertionError: sqrt(sin(x**3)).series(x,0,3)
[3554](http://code.google.com/p/sympy/issues/detail?id=3554) - AssertionError: (1 / sqrt(1 + cos(x) \* sin(x**2))).series(x, 0, 15)
[3111](http://code.google.com/p/sympy/issues/detail?id=3111) - series(cot(x**20 + x**21 + x**22), x, 0, 1) is wrong

TODO:
- [x] final rebase?
