### PR TITLE
Merge of fixed_qcircuit_measurement branch to allow simple measurements. 

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2021,6 +2021,14 @@ def test_sympy__physics__quantum__cg__Wigner9j():
     from sympy.physics.quantum.cg import Wigner9j
     assert _test_args(Wigner9j(2, 1, 1, S(3)/2, S(1)/2, 1, S(1)/2, S(1)/2, 0))
 
+def test_sympy__physics__quantum__circuitplot__Mz():
+    from sympy.physics.quantum.circuitplot import Mz
+    assert _test_args(Mz(0))
+
+def test_sympy__physics__quantum__circuitplot__Mx():
+    from sympy.physics.quantum.circuitplot import Mx
+    assert _test_args(Mx(0))
+
 def test_sympy__physics__quantum__commutator__Commutator():
     from sympy.physics.quantum.commutator import Commutator
     A, B = symbols('A,B', commutative=False)

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -16,12 +16,14 @@ Todo:
 
 from sympy import Mul
 from sympy.external import import_module
-from sympy.physics.quantum.gate import Gate
+from sympy.physics.quantum.gate import Gate,OneQubitGate,CGate,CGateS
 
 __all__ = [
     'CircuitPlot',
     'circuit_plot',
-    'labler',
+    'labeller',
+    'Mz',
+    'Mx',
 ]
 
 np = import_module('numpy')
@@ -113,9 +115,39 @@ else:
                         r'$|%s\rangle$' % self.labels[i],
                         size=self.fontsize,
                         color='k',ha='center',va='center')
+            self._plot_measured_wires()
 
-        def _plot_gates(self):
-            """Iterate through the gates and plot each of them."""
+        def _plot_measured_wires(self):
+            ismeasured = self._measurements()
+            xstop = self._gate_grid[-1]
+            dy = 0.04 # amount to shift wires when doubled
+            # Plot doubled wires after they are measured
+            for im in ismeasured:
+                xdata = (self._gate_grid[ismeasured[im]],xstop+self.scale)
+                ydata = (self._wire_grid[im]+dy,self._wire_grid[im]+dy)
+                line = Line2D(
+                    xdata, ydata,
+                    color='k',
+                    lw=self.linewidth
+                )
+                self._axes.add_line(line)
+            # Also double any controlled lines off these wires
+            for i,g in enumerate(self._gates()):
+                if isinstance(g,CGate) or isinstance(g,CGateS):
+                    wires = g.controls + g.targets
+                    for wire in wires:
+                        if wire in ismeasured and \
+                               self._gate_grid[i] > self._gate_grid[ismeasured[wire]]:
+                            ydata = min(wires),max(wires)
+                            xdata = self._gate_grid[i]-dy,self._gate_grid[i]-dy
+                            line = Line2D(
+                                xdata, ydata,
+                                color='k',
+                                lw=self.linewidth
+                                )
+                            self._axes.add_line(line)
+        def _gates(self):
+            """Create a list of all gates in the circuit plot."""
             gates = []
             if isinstance(self.circuit, Mul):
                 for g in reversed(self.circuit.args):
@@ -123,8 +155,27 @@ else:
                         gates.append(g)
             elif isinstance(self.circuit, Gate):
                 gates.append(self.circuit)
-            for i, gate in enumerate(gates):
+            return gates
+
+        def _plot_gates(self):
+            """Iterate through the gates and plot each of them."""
+            for i, gate in enumerate(self._gates()):
                 gate.plot_gate(self, i)
+
+        def _measurements(self):
+            """Return a dict {i:j} where i is the index of the wire that has
+            been measured, and j is the gate where the wire is measured.
+            """
+            ismeasured = {}
+            for i,g in enumerate(self._gates()):
+                if getattr(g,'measurement',False):
+                    for target in g.targets:
+                        if target in ismeasured:
+                            if ismeasured[target] > i:
+                                ismeasured[target] = i
+                        else:
+                            ismeasured[target] = i
+            return ismeasured
 
         def _finish(self):
             # Disable clipping to make panning work well for large circuits.
@@ -145,7 +196,8 @@ else:
             )
 
         def two_qubit_box(self, t, gate_idx, wire_idx):
-            """Draw a box for a single qubit gate."""
+            """Draw a box for a two qubit gate. Doesn't work yet.
+            """
             x = self._gate_grid[gate_idx]
             y = self._wire_grid[wire_idx]+0.5
             print self._gate_grid
@@ -240,7 +292,7 @@ else:
         """
         return CircuitPlot(c, nqubits, **kwargs)
 
-def labler(n,symbol='q'):
+def labeller(n,symbol='q'):
     """Autogenerate labels for wires of quantum circuits.
 
     Parameters
@@ -250,10 +302,26 @@ def labler(n,symbol='q'):
     symbol : string
       A character string to precede all gate labels. E.g. 'q_0', 'q_1', etc.
 
-    >>> from sympy.physics.quantum.circuitplot import labler
-    >>> labler(2)
+    >>> from sympy.physics.quantum.circuitplot import labeller
+    >>> labeller(2)
     ['q_1', 'q_0']
-    >>> labler(3,'j')
+    >>> labeller(3,'j')
     ['j_2', 'j_1', 'j_0']
     """
     return ['%s_%d' % (symbol,n-i-1) for i in range(n)]
+
+class Mz(OneQubitGate):
+    """Mock-up of a z measurement gate. This is in circuitplot rather than
+    gate.py because it's not a real gate, it just draws one.
+    """
+    measurement = True
+    gate_name='Mz'
+    gate_name_latex=u'M_z'
+
+class Mx(OneQubitGate):
+    """Mock-up of an x measurement gate. This is in circuitplot rather than
+    gate.py because it's not a real gate, it just draws one.
+    """
+    measurement = True
+    gate_name='Mx'
+    gate_name_latex=u'M_x'

--- a/sympy/physics/quantum/tests/test_circuitplot.py
+++ b/sympy/physics/quantum/tests/test_circuitplot.py
@@ -1,14 +1,14 @@
-from sympy.physics.quantum.circuitplot import labler
+from sympy.physics.quantum.circuitplot import labeller
 from sympy.physics.quantum.gate import CNOT, H, X, Z, SWAP, CGate, S, T
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
 
 mpl = import_module('matplotlib')
 
-def test_labler():
-    """Test the labler utility"""
-    assert labler(2) == ['q_1', 'q_0']
-    assert labler(3,'j') == ['j_2', 'j_1', 'j_0']
+def test_labeller():
+    """Test the labeller utility"""
+    assert labeller(2) == ['q_1', 'q_0']
+    assert labeller(3,'j') == ['j_2', 'j_1', 'j_0']
 
 def test_cnot():
     """Test a simple cnot circuit. Right now this only makes sure the code doesn't
@@ -19,7 +19,7 @@ def test_cnot():
     else:
         from sympy.physics.quantum.circuitplot import CircuitPlot
 
-    c = CircuitPlot(CNOT(1,0),2,labels=labler(2))
+    c = CircuitPlot(CNOT(1,0),2,labels=labeller(2))
     assert c.ngates == 2
     assert c.nqubits == 2
     assert c.labels == ['q_1', 'q_0']
@@ -35,7 +35,7 @@ def test_ex1():
     else:
         from sympy.physics.quantum.circuitplot import CircuitPlot
 
-    c = CircuitPlot(CNOT(1,0)*H(1),2,labels=labler(2))
+    c = CircuitPlot(CNOT(1,0)*H(1),2,labels=labeller(2))
     assert c.ngates == 2
     assert c.nqubits == 2
     assert c.labels == ['q_1', 'q_0']
@@ -47,7 +47,7 @@ def test_ex4():
         from sympy.physics.quantum.circuitplot import CircuitPlot
 
     c = CircuitPlot(SWAP(0,2)*H(0)* CGate((0,),S(1)) *H(1)*CGate((0,),T(2))\
-                    *CGate((1,),S(2))*H(2),3,labels=labler(3,'j'))
+                    *CGate((1,),S(2))*H(2),3,labels=labeller(3,'j'))
     assert c.ngates == 7
     assert c.nqubits == 3
     assert c.labels == ['j_2', 'j_1', 'j_0']


### PR DESCRIPTION
The changes in this PR make a "fake" measurement operators Mx and
Mz. These does not implement real quantum measurement, is specially
flagged with a "measurement" property so that the circuitplot routines
can identify the qubits after this operation as having been
measured. The circuitplot utilities then double the qubit wires after
this gate, as well as the controlled lines hanging off the qubit
wires.

This is a fixed version of an earlier PR attempt that was closed after
it started looking grotty after I mistakenly rebased.
