### PR TITLE
Fix order handlers (positive/negative) for new assumptions

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -77,7 +77,8 @@ class AskNegativeHandler(CommonHandler):
             return AskNegativeHandler._number(expr, assumptions)
         if ask(Q.real(expr.base), assumptions):
             if ask(Q.positive(expr.base), assumptions):
-                return False
+                if ask(Q.real(expr.exp), assumptions):
+                    return False
             if ask(Q.even(expr.exp), assumptions):
                 return False
             if ask(Q.odd(expr.exp), assumptions):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -166,12 +166,16 @@ class AskPositiveHandler(CommonHandler):
     def Add(expr, assumptions):
         if expr.is_number:
             return AskPositiveHandler._number(expr, assumptions)
+        nonneg = 0
         for arg in expr.args:
             if ask(Q.positive(arg), assumptions) is not True:
-                break
+                if ask(Q.negative(arg), assumptions) is False:
+                    nonneg += 1
+                else:
+                    break
         else:
-            # if all argument's are positive
-            return True
+            if nonneg < len(expr.args):
+                return True
 
     @staticmethod
     def Pow(expr, assumptions):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -43,12 +43,16 @@ class AskNegativeHandler(CommonHandler):
         """
         if expr.is_number:
             return AskNegativeHandler._number(expr, assumptions)
+        nonpos = 0
         for arg in expr.args:
-            if not ask(Q.negative(arg), assumptions):
-                break
+            if ask(Q.negative(arg), assumptions) is not True:
+                if ask(Q.positive(arg), assumptions) is False:
+                    nonpos += 1
+                else:
+                    break
         else:
-            # if all argument's are negative
-            return True
+            if nonpos < len(expr.args):
+                return True
 
     @staticmethod
     def Mul(expr, assumptions):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -177,7 +177,8 @@ class AskPositiveHandler(CommonHandler):
         if expr.is_number:
             return expr.evalf() > 0
         if ask(Q.positive(expr.base), assumptions):
-            return True
+            if ask(Q.real(expr.exp), assumptions):
+                return True
         if ask(Q.negative(expr.base), assumptions):
             if ask(Q.even(expr.exp), assumptions):
                 return True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1482,6 +1482,8 @@ def test_negative():
     assert ask(Q.negative(x**2), Q.real(x)) is False
     assert ask(Q.negative(x**1.4), Q.real(x)) is None
 
+    assert ask(Q.negative(x**I), Q.positive(x)) is None
+
     assert ask(Q.negative(x*y)) is None
     assert ask(Q.negative(x*y), Q.positive(x) & Q.positive(y)) is False
     assert ask(Q.negative(x*y), Q.positive(x) & Q.negative(y)) is True

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1049,7 +1049,6 @@ def test_bounded_xfail():
     """We need to support relations in ask for this to work"""
     assert ask(Q.bounded(sin(x)**x)) is True
     assert ask(Q.bounded(cos(x)**x)) is True
-    assert ask(Q.bounded(sin(x) ** x)) is True
 
 @XFAIL
 def test_imaginary_xfail():

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1476,6 +1476,7 @@ def test_negative():
     assert ask(Q.negative(x + y)) is None
     assert ask(Q.negative(x + y), Q.negative(x)) is None
     assert ask(Q.negative(x + y), Q.negative(x) & Q.negative(y)) is True
+    assert ask(Q.negative(x + y), Q.negative(x) & ~Q.positive(y)) is True
 
     assert ask(Q.negative(x**2)) is None
     assert ask(Q.negative(x**2), Q.real(x)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1598,6 +1598,8 @@ def test_positive():
     assert ask(Q.positive(x*y*z), assumptions) is True
     assert ask(Q.positive(-x*y*z), assumptions) is False
 
+    assert ask(Q.positive(x**I), Q.positive(x)) is None
+
     assert ask(Q.positive(x**2), Q.positive(x)) is True
     assert ask(Q.positive(x**2), Q.negative(x)) is True
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1592,6 +1592,7 @@ def test_positive():
     assert ask(Q.positive(-x), Q.negative(x)) is True
 
     assert ask(Q.positive(x + y), Q.positive(x) & Q.positive(y)) is True
+    assert ask(Q.positive(x + y), Q.positive(x) & ~Q.negative(y)) is True
     assert ask(Q.positive(x + y), Q.positive(x) & Q.negative(y)) is None
 
     assert ask(Q.positive(2*x), Q.positive(x)) is True
@@ -1604,6 +1605,7 @@ def test_positive():
 
     assert ask(Q.positive(x**2), Q.positive(x)) is True
     assert ask(Q.positive(x**2), Q.negative(x)) is True
+    assert ask(Q.positive(1/(1 + x**2)), Q.real(x)) is True
 
     #exponential
     assert ask(Q.positive(exp(x)), Q.real(x)) is True
@@ -1617,11 +1619,6 @@ def test_positive():
     #absolute value
     assert ask(Q.positive(Abs(x))) is None  # Abs(0) = 0
     assert ask(Q.positive(Abs(x)), Q.positive(x)) is True
-
-
-@XFAIL
-def test_positive_xfail():
-    assert ask(Q.positive(1/(1 + x**2)), Q.real(x)) is True
 
 
 def test_real():


### PR DESCRIPTION
Before:

```
In [1]: ask(Q.negative(x**I), Q.positive(x))
Out[1]: False
In [2]: ask(Q.negative((E**(pi/2))**I))
Out[2]: False
In [3]: ask(Q.negative((E**pi)**I))
Out[3]: True
In [4]: ask(Q.positive(1/(1 + x**2)), Q.real(x))
```

After:

```
In [1]: ask(Q.negative(x**I), Q.positive(x))
In [2]: ask(Q.positive(1/(1 + x**2)), Q.real(x))
Out[2]: True
```
