### PR TITLE
Fix regressions, related to xrange -> range conversion in PR #2318

### DIFF
--- a/examples/intermediate/vandermonde.py
+++ b/examples/intermediate/vandermonde.py
@@ -7,6 +7,7 @@ Demonstrates matrix computations using the Vandermonde matrix.
 """
 
 from sympy import Matrix, pprint, Rational, sqrt, symbols, Symbol, zeros
+from sympy.core.compatibility import xrange
 
 
 def symbol_gen(sym_str):

--- a/examples/intermediate/vandermonde.py
+++ b/examples/intermediate/vandermonde.py
@@ -99,7 +99,7 @@ def gen_poly(points, order, syms):
     V_pts = V.subs(subs_dict)
     V_inv = V_pts.inv()
 
-    coeffs = V_inv.multiply(Matrix([points[i][-1] for i in range(num_pts)]))
+    coeffs = V_inv.multiply(Matrix([points[i][-1] for i in xrange(num_pts)]))
 
     f = 0
     for j, term in enumerate(terms):

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function, division
+from sympy.core.compatibility import xrange
 
 from random import random
 from sympy import factor, I, Integer, pi, simplify, sin, sqrt, Symbol, sympify

--- a/sympy/benchmarks/bench_symbench.py
+++ b/sympy/benchmarks/bench_symbench.py
@@ -58,13 +58,13 @@ def bench_R5():
 
 def bench_R6():
     "sum(simplify((x+sin(i))/x+(x-sin(i))/x) for i in xrange(100))"
-    s = sum(simplify((x + sin(i))/x + (x - sin(i))/x) for i in range(100))
+    s = sum(simplify((x + sin(i))/x + (x - sin(i))/x) for i in xrange(100))
 
 
 def bench_R7():
     "[f.subs(x, random()) for _ in xrange(10**4)]"
     f = x**24 + 34*x**12 + 45*x**3 + 9*x**18 + 34*x**10 + 32*x**21
-    a = [f.subs(x, random()) for _ in range(10**4)]
+    a = [f.subs(x, random()) for _ in xrange(10**4)]
 
 
 def bench_R8():

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core import (Set, Basic, FiniteSet, EmptySet, Dict, Symbol,
                         Tuple)
+from sympy.core.compatibility import xrange
 
 
 class Class(Set):

--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -272,7 +272,7 @@ class CompositeMorphism(Morphism):
         normalised_components = Tuple()
 
         # TODO: Fix the unpythonicity.
-        for i in range(len(components) - 1):
+        for i in xrange(len(components) - 1):
             current = components[i]
             following = components[i + 1]
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -109,7 +109,7 @@ class _GrowableGrid(object):
         self._width = width
         self._height = height
 
-        self._array = [[None for j in range(width)] for i in range(height)]
+        self._array = [[None for j in xrange(width)] for i in xrange(height)]
 
     @property
     def width(self):
@@ -140,14 +140,14 @@ class _GrowableGrid(object):
         Appends an empty row to the grid.
         """
         self._height += 1
-        self._array.append([None for j in range(self._width)])
+        self._array.append([None for j in xrange(self._width)])
 
     def append_column(self):
         """
         Appends an empty column to the grid.
         """
         self._width += 1
-        for i in range(self._height):
+        for i in xrange(self._height):
             self._array[i].append(None)
 
     def prepend_row(self):
@@ -155,14 +155,14 @@ class _GrowableGrid(object):
         Prepends the grid with an empty row.
         """
         self._height += 1
-        self._array.insert(0, [None for j in range(self._width)])
+        self._array.insert(0, [None for j in xrange(self._width)])
 
     def prepend_column(self):
         """
         Prepends the grid with an empty column.
         """
         self._width += 1
-        for i in range(self._height):
+        for i in xrange(self._height):
             self._array[i].insert(0, None)
 
 
@@ -502,7 +502,7 @@ class DiagramGrid(object):
             grid.prepend_row()
             i = 0
             offset = (1, 0)
-            for k in range(len(fringe)):
+            for k in xrange(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
                 fringe[k] = ((i1 + 1, j1), (i2 + 1, j2))
         elif i == grid.height:
@@ -512,7 +512,7 @@ class DiagramGrid(object):
             j = 0
             offset = (offset[0], 1)
             grid.prepend_column()
-            for k in range(len(fringe)):
+            for k in xrange(len(fringe)):
                 ((i1, j1), (i2, j2)) = fringe[k]
                 fringe[k] = ((i1, j1 + 1), (i2, j2 + 1))
         elif j == grid.width:
@@ -709,8 +709,8 @@ class DiagramGrid(object):
         This method should be applied when ``_weld_triangle`` cannot
         find weldings any more.
         """
-        for i in range(grid.height):
-            for j in range(grid.width):
+        for i in xrange(grid.height):
+            for j in xrange(grid.width):
                 obj = grid[i, j]
                 if not obj:
                     continue
@@ -883,27 +883,27 @@ class DiagramGrid(object):
                 return (1, 1)
 
         row_heights = [max(group_size(top_grid[i, j])[0]
-                           for j in range(top_grid.width))
-                       for i in range(top_grid.height)]
+                           for j in xrange(top_grid.width))
+                       for i in xrange(top_grid.height)]
 
         column_widths = [max(group_size(top_grid[i, j])[1]
-                             for i in range(top_grid.height))
-                         for j in range(top_grid.width)]
+                             for i in xrange(top_grid.height))
+                         for j in xrange(top_grid.width)]
 
         grid = _GrowableGrid(sum(column_widths), sum(row_heights))
 
         real_row = 0
         real_column = 0
-        for logical_row in range(top_grid.height):
-            for logical_column in range(top_grid.width):
+        for logical_row in xrange(top_grid.height):
+            for logical_column in xrange(top_grid.width):
                 obj = top_grid[logical_row, logical_column]
 
                 if obj in groups_grids:
                     # This is a group.  Copy the corresponding grid in
                     # place.
                     local_grid = groups_grids[obj]
-                    for i in range(local_grid.height):
-                        for j in range(local_grid.width):
+                    for i in xrange(local_grid.height):
+                        for j in xrange(local_grid.width):
                             grid[real_row + i,
                                 real_column + j] = local_grid[i, j]
                 else:
@@ -995,13 +995,13 @@ class DiagramGrid(object):
                     final_height = max(grid.height, remaining_grid.height)
                     final_grid = _GrowableGrid(final_width, final_height)
 
-                    for i in range(grid.width):
-                        for j in range(grid.height):
+                    for i in xrange(grid.width):
+                        for j in xrange(grid.height):
                             final_grid[i, j] = grid[i, j]
 
                     start_j = grid.width
-                    for i in range(remaining_grid.height):
-                        for j in range(remaining_grid.width):
+                    for i in xrange(remaining_grid.height):
+                        for j in xrange(remaining_grid.width):
                             final_grid[i, start_j + j] = remaining_grid[i, j]
 
                     return final_grid
@@ -1135,7 +1135,7 @@ class DiagramGrid(object):
                 current_index += 1
 
         # List the objects of the components.
-        component_objects = [[] for i in range(current_index)]
+        component_objects = [[] for i in xrange(current_index)]
         for o, idx in component_index.items():
             component_objects[idx].append(o)
 
@@ -1206,8 +1206,8 @@ class DiagramGrid(object):
             grid = _GrowableGrid(total_width, total_height)
             start_j = 0
             for g in grids:
-                for i in range(g.height):
-                    for j in range(g.width):
+                for i in xrange(g.height):
+                    for j in xrange(g.width):
                         grid[i, start_j + j] = g[i, j]
 
                 start_j += g.width
@@ -1223,8 +1223,8 @@ class DiagramGrid(object):
         if hints.get("transpose"):
             # Transpose the resulting grid.
             grid = _GrowableGrid(self._grid.height, self._grid.width)
-            for i in range(self._grid.height):
-                for j in range(self._grid.width):
+            for i in xrange(self._grid.height):
+                for j in xrange(self._grid.width):
                     grid[j, i] = self._grid[i, j]
             self._grid = grid
 
@@ -1757,7 +1757,7 @@ class XypicDiagramDrawer(object):
 
         # Pick the freest quadrant to curve our morphism into.
         freest_quadrant = 0
-        for i in range(4):
+        for i in xrange(4):
             if quadrant[i] < quadrant[freest_quadrant]:
                 freest_quadrant = i
 
@@ -1817,7 +1817,7 @@ class XypicDiagramDrawer(object):
         up = []
         down = []
         straight_horizontal = []
-        for k in range(start + 1, end):
+        for k in xrange(start + 1, end):
             obj = grid[i, k]
             if not obj:
                 continue
@@ -1924,7 +1924,7 @@ class XypicDiagramDrawer(object):
         left = []
         right = []
         straight_vertical = []
-        for k in range(start + 1, end):
+        for k in xrange(start + 1, end):
             obj = grid[k, j]
             if not obj:
                 continue
@@ -2117,14 +2117,14 @@ class XypicDiagramDrawer(object):
             free_up = True
         else:
             free_up = all([grid[dom_i - 1, j] for j in
-                           range(start, end + 1)])
+                           xrange(start, end + 1)])
 
         # Check for free space below.
         if dom_i == grid.height - 1:
             free_down = True
         else:
             free_down = all([not grid[dom_i + 1, j] for j in
-                             range(start, end + 1)])
+                             xrange(start, end + 1)])
 
         return (free_up, free_down, backwards)
 
@@ -2147,13 +2147,13 @@ class XypicDiagramDrawer(object):
             free_left = True
         else:
             free_left = all([not grid[i, dom_j - 1] for i in
-                             range(start, end + 1)])
+                             xrange(start, end + 1)])
 
         if dom_j == grid.width - 1:
             free_right = True
         else:
             free_right = all([not grid[i, dom_j + 1] for i in
-                              range(start, end + 1)])
+                              xrange(start, end + 1)])
 
         return (free_left, free_right, backwards)
 
@@ -2164,11 +2164,11 @@ class XypicDiagramDrawer(object):
         (i.e., space not occupied by any objects) above the morphism
         or below it.
         """
-        def abs_range(start, end):
+        def abs_xrange(start, end):
             if start < end:
-                return range(start, end + 1)
+                return xrange(start, end + 1)
             else:
-                return range(end, start + 1)
+                return xrange(end, start + 1)
 
         if dom_i < cod_i and dom_j < cod_j:
             # This morphism goes from top-left to
@@ -2223,11 +2223,11 @@ class XypicDiagramDrawer(object):
         alpha = float(end_i - start_i)/(end_j - start_j)
         free_up = True
         free_down = True
-        for i in abs_range(start_i, end_i):
+        for i in abs_xrange(start_i, end_i):
             if not free_up and not free_down:
                 break
 
-            for j in abs_range(start_j, end_j):
+            for j in abs_xrange(start_j, end_j):
                 if not free_up and not free_down:
                     break
 
@@ -2358,8 +2358,8 @@ class XypicDiagramDrawer(object):
 
         result = "\\xymatrix%s{\n" % diagram_format
 
-        for i in range(grid.height):
-            for j in range(grid.width):
+        for i in xrange(grid.height):
+            for j in xrange(grid.width):
                 obj = grid[i, j]
                 if obj:
                     result += latex(obj) + " "
@@ -2473,8 +2473,8 @@ class XypicDiagramDrawer(object):
         # Build the mapping between objects and their position in the
         # grid.
         object_coords = {}
-        for i in range(grid.height):
-            for j in range(grid.width):
+        for i in xrange(grid.height):
+            for j in xrange(grid.width):
                 if grid[i, j]:
                     object_coords[grid[i, j]] = (i, j)
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1757,7 +1757,7 @@ class XypicDiagramDrawer(object):
 
         # Pick the freest quadrant to curve our morphism into.
         freest_quadrant = 0
-        for i in xrange(4):
+        for i in range(4):
             if quadrant[i] < quadrant[freest_quadrant]:
                 freest_quadrant = i
 

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -88,7 +88,7 @@ from sympy.categories import (CompositeMorphism, IdentityMorphism,
                               NamedMorphism, Diagram)
 from sympy.utilities import default_sort_key
 from itertools import chain
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, xrange
 from sympy.printing import latex
 from sympy.utilities.decorator import doctest_depends_on
 

--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -43,7 +43,7 @@ def cyclic(n):
     dihedral
     """
     gen = list(range(n))
-    for i in range(n):
+    for i in xrange(n):
         yield Permutation(gen)
         gen = rotate_left(gen, 1)
 
@@ -99,7 +99,7 @@ def dihedral(n):
         yield Permutation([3, 2, 1, 0])
     else:
         gen = list(range(n))
-        for i in range(n):
+        for i in xrange(n):
             yield Permutation(gen)
             yield Permutation(gen[::-1])
             gen = rotate_left(gen, 1)

--- a/sympy/combinatorics/generators.py
+++ b/sympy/combinatorics/generators.py
@@ -4,6 +4,7 @@ from sympy.combinatorics.permutations import Permutation
 from sympy.utilities.iterables import variations, rotate_left
 from sympy.core.symbol import symbols
 from sympy.matrices import Matrix
+from sympy.core.compatibility import xrange
 
 
 def symmetric(n):

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic
+from sympy.core.compatibility import xrange
 
 import random
 

--- a/sympy/combinatorics/graycode.py
+++ b/sympy/combinatorics/graycode.py
@@ -183,7 +183,7 @@ class GrayCode(Basic):
             'not be greater than %i' % (len(graycode_bin), bits))
         self._current = int(current, 2)
         graycode_int = int(''.join(graycode_bin), 2)
-        for i in range(graycode_int, 1 << bits):
+        for i in xrange(graycode_int, 1 << bits):
             if self._skip:
                 self._skip = False
             else:
@@ -316,7 +316,7 @@ def random_bitstring(n):
     >>> random_bitstring(3) # doctest: +SKIP
     100
     """
-    return ''.join([random.choice('01') for i in range(n)])
+    return ''.join([random.choice('01') for i in xrange(n)])
 
 
 def gray_to_bin(bin_list):
@@ -337,7 +337,7 @@ def gray_to_bin(bin_list):
     bin_to_gray
     """
     b = [bin_list[0]]
-    for i in range(1, len(bin_list)):
+    for i in xrange(1, len(bin_list)):
         b += str(int(b[i - 1] != bin_list[i]))
     return ''.join(b)
 
@@ -360,7 +360,7 @@ def bin_to_gray(bin_list):
     gray_to_bin
     """
     b = [bin_list[0]]
-    for i in range(0, len(bin_list) - 1):
+    for i in xrange(0, len(bin_list) - 1):
         b += str(int(bin_list[i]) ^ int(b[i - 1]))
     return ''.join(b)
 

--- a/sympy/combinatorics/group_constructs.py
+++ b/sympy/combinatorics/group_constructs.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from sympy.combinatorics.perm_groups import PermutationGroup
 from sympy.combinatorics.permutations import Permutation
 from sympy.utilities.iterables import uniq
+from sympy.core.compatibility import xrange
 
 _af_new = Permutation._af_new
 

--- a/sympy/combinatorics/group_constructs.py
+++ b/sympy/combinatorics/group_constructs.py
@@ -48,8 +48,8 @@ def DirectProduct(*groups):
         array_gens.append(list(range(total_degree)))
     current_gen = 0
     current_deg = 0
-    for i in range(len(gens_count)):
-        for j in range(current_gen, current_gen + gens_count[i]):
+    for i in xrange(len(gens_count)):
+        for j in xrange(current_gen, current_gen + gens_count[i]):
             gen = ((groups[i].generators)[j - current_gen]).array_form
             array_gens[j][current_deg:current_deg + degrees[i]] = \
                 [ x + current_deg for x in gen]

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -258,7 +258,7 @@ class Partition(C.FiniteSet):
         if len(rgs) != len(elements):
             raise ValueError('mismatch in rgs and element lengths')
         max_elem = max(rgs) + 1
-        partition = [[] for i in range(max_elem)]
+        partition = [[] for i in xrange(max_elem)]
         j = 0
         for i in rgs:
             partition[i].append(elements[j])
@@ -591,11 +591,11 @@ def RGS_generalized(m):
     [203,   0,   0,  0,  0, 0, 0]])
     """
     d = zeros(m + 1)
-    for i in range(0, m + 1):
+    for i in xrange(0, m + 1):
         d[0, i] = 1
 
-    for i in range(1, m + 1):
-        for j in range(m):
+    for i in xrange(1, m + 1):
+        for j in xrange(m):
             if j <= m - i:
                 d[i, j] = j * d[i - 1, j] + d[i - 1, j + 1]
             else:
@@ -662,7 +662,7 @@ def RGS_unrank(rank, m):
     L = [1] * (m + 1)
     j = 1
     D = RGS_generalized(m)
-    for i in range(2, m + 1):
+    for i in xrange(2, m + 1):
         v = D[m - i, j]
         cr = j*v
         if cr <= rank:
@@ -691,7 +691,7 @@ def RGS_rank(rgs):
     rgs_size = len(rgs)
     rank = 0
     D = RGS_generalized(rgs_size)
-    for i in range(1, rgs_size):
+    for i in xrange(1, rgs_size):
         n = len(rgs[(i + 1):])
         m = max(rgs[0:i])
         rank += D[n, m + 1] * rgs[i]

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic, C, Dict, sympify
-from sympy.core.compatibility import as_int, default_sort_key
+from sympy.core.compatibility import as_int, default_sort_key, xrange
 from sympy.functions.combinatorial.numbers import bell
 from sympy.matrices import zeros
 from sympy.utilities.iterables import has_dups, flatten, group

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -4,7 +4,7 @@ import random
 from collections import defaultdict
 
 from sympy.core import Basic
-from sympy.core.compatibility import is_sequence, reduce
+from sympy.core.compatibility import is_sequence, reduce, xrange
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
     has_dups, runs)
 from sympy.polys.polytools import lcm

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1873,7 +1873,7 @@ class Permutation(Basic):
         order
         """
         af = self.array_form
-        return not af or all(i == af[i] for i in range(self.size))
+        return not af or all(i == af[i] for i in xrange(self.size))
 
     def ascents(self):
         """

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -167,9 +167,9 @@ class Prufer(Basic):
             # edge involving it.
             d[edge[0]] += 1
             d[edge[1]] += 1
-        for i in range(n - 2):
+        for i in xrange(n - 2):
             # find the smallest leaf
-            for x in range(n):
+            for x in xrange(n):
                 if d[x] == 1:
                     break
             # find the node it was connected to
@@ -221,7 +221,7 @@ class Prufer(Basic):
         for p in prufer:
             d[p] += 1
         for i in prufer:
-            for j in range(n):
+            for j in xrange(n):
             # find the smallest leaf (degree = 1)
                 if d[j] == 1:
                     break
@@ -230,7 +230,7 @@ class Prufer(Basic):
             d[i] -= 1
             d[j] -= 1
             tree.append(sorted([i, j]))
-        last = [i for i in range(n) if d[i] == 1] or [0, 1]
+        last = [i for i in xrange(n) if d[i] == 1] or [0, 1]
         tree.append(last)
 
         return tree
@@ -309,7 +309,7 @@ class Prufer(Basic):
         """
         r = 0
         p = 1
-        for i in range(self.nodes - 3, -1, -1):
+        for i in xrange(self.nodes - 3, -1, -1):
             r += p*self.prufer_repr[i]
             p *= self.nodes
         return r
@@ -328,10 +328,10 @@ class Prufer(Basic):
         """
         n, rank = as_int(n), as_int(rank)
         L = defaultdict(int)
-        for i in range(n - 3, -1, -1):
+        for i in xrange(n - 3, -1, -1):
             L[i] = rank % n
             rank = (rank - L[i])//n
-        return Prufer([L[i] for i in range(len(L))])
+        return Prufer([L[i] for i in xrange(len(L))])
 
     def __new__(cls, *args, **kw_args):
         """The constructor for the Prufer object.

--- a/sympy/combinatorics/prufer.py
+++ b/sympy/combinatorics/prufer.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic
-from sympy.core.compatibility import iterable, as_int
+from sympy.core.compatibility import iterable, as_int, xrange
 from sympy.utilities.iterables import flatten
 
 from collections import defaultdict

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -465,7 +465,7 @@ class Subset(Basic):
         if len(super_set) != len(bitlist):
             raise ValueError("The sizes of the lists are not equal")
         ret_set = []
-        for i in range(len(bitlist)):
+        for i in xrange(len(bitlist)):
             if bitlist[i] == '1':
                 ret_set.append(super_set[i])
         return Subset(ret_set, super_set)

--- a/sympy/combinatorics/subsets.py
+++ b/sympy/combinatorics/subsets.py
@@ -4,6 +4,7 @@ from itertools import combinations
 
 from sympy.core import Basic
 from sympy.combinatorics.graycode import GrayCode
+from sympy.core.compatibility import xrange
 
 
 class Subset(Basic):

--- a/sympy/combinatorics/tests/test_polyhedron.py
+++ b/sympy/combinatorics/tests/test_polyhedron.py
@@ -34,7 +34,7 @@ def test_polyhedron():
         (0, 1), (6, 7), (1, 2), (5, 6), (0, 3), (2, 3),
         (4, 7), (4, 5), (3, 7), (1, 5), (0, 4), (2, 6)))
 
-    for i in range(3):  # add 180 degree face rotations
+    for i in xrange(3):  # add 180 degree face rotations
         cube.rotate(cube.pgroup[i]**2)
 
     assert cube.corners == corners

--- a/sympy/combinatorics/tests/test_polyhedron.py
+++ b/sympy/combinatorics/tests/test_polyhedron.py
@@ -34,7 +34,7 @@ def test_polyhedron():
         (0, 1), (6, 7), (1, 2), (5, 6), (0, 3), (2, 3),
         (4, 7), (4, 5), (3, 7), (1, 5), (0, 4), (2, 6)))
 
-    for i in xrange(3):  # add 180 degree face rotations
+    for i in range(3):  # add 180 degree face rotations
         cube.rotate(cube.pgroup[i]**2)
 
     assert cube.corners == corners

--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy.ntheory import isprime
 from sympy.combinatorics.permutations import Permutation, _af_invert, _af_rmul
+from sympy.core.compatibility import xrange
 
 rmul = Permutation.rmul
 _af_new = Permutation._af_new

--- a/sympy/combinatorics/util.py
+++ b/sympy/combinatorics/util.py
@@ -58,10 +58,10 @@ def _base_ordering(base, degree):
     """
     base_len = len(base)
     ordering = [0]*degree
-    for i in range(base_len):
+    for i in xrange(base_len):
         ordering[base[i]] = i
     current = base_len
-    for i in range(degree):
+    for i in xrange(degree):
         if i not in base:
             ordering[i] = current
             current += 1
@@ -98,7 +98,7 @@ def _check_cycles_alt_sym(perm):
     current_len = 0
     total_len = 0
     used = set()
-    for i in range(n//2):
+    for i in xrange(n//2):
         if not i in used and i < n//2 - total_len:
             current_len = 1
             used.add(i)
@@ -163,7 +163,7 @@ def _distribute_gens_by_base(base, gens):
     """
     base_len = len(base)
     degree = gens[0].size
-    stabs = [[] for _ in range(base_len)]
+    stabs = [[] for _ in xrange(base_len)]
     max_stab_index = 0
     for gen in gens:
         j = 0
@@ -171,7 +171,7 @@ def _distribute_gens_by_base(base, gens):
             j += 1
         if j > max_stab_index:
             max_stab_index = j
-        for k in range(j + 1):
+        for k in xrange(j + 1):
             stabs[k].append(gen)
     for i in range(max_stab_index + 1, base_len):
         stabs[i].append(_af_new(list(range(degree))))
@@ -294,7 +294,7 @@ def _orbits_transversals_from_bsgs(base, strong_gens_distr,
     transversals = [None]*base_len
     if transversals_only is False:
         basic_orbits = [None]*base_len
-    for i in range(base_len):
+    for i in xrange(base_len):
         transversals[i] = dict(_orbit_transversal(degree, strong_gens_distr[i],
                                  base[i], pairs=True))
         if transversals_only is False:

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division
 
 from sympy.core import S, Dummy, symbols
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, xrange
 from sympy.polys import Poly, parallel_poly_from_expr, factor
 from sympy.solvers import solve
 from sympy.simplify import hypersimp

--- a/sympy/concrete/gosper.py
+++ b/sympy/concrete/gosper.py
@@ -67,7 +67,7 @@ def gosper_normal(f, g, n, polys=True):
         A = A.quo(d)
         B = B.quo(d.shift(-i))
 
-        for j in range(1, i + 1):
+        for j in xrange(1, i + 1):
             C *= d.shift(-j)
 
     A = A.mul_ground(Z)

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -9,6 +9,7 @@ from sympy.core.sympify import sympify
 from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.polys import quo, roots
 from sympy.simplify import powsimp
+from sympy.core.compatibility import xrange
 
 
 class Product(Expr):

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -336,7 +336,7 @@ class Product(Expr):
 
         dif = n - a
         if dif.is_Integer:
-            return Mul(*[term.subs(k, a + i) for i in range(dif + 1)])
+            return Mul(*[term.subs(k, a + i) for i in xrange(dif + 1)])
 
         elif term.is_polynomial(k):
             poly = term.as_poly(k)

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -384,7 +384,7 @@ class Sum(Expr):
         fa, fb = fpoint(f)
         iterm = (fa + fb)/2
         g = f.diff(i)
-        for k in range(1, n + 2):
+        for k in xrange(1, n + 2):
             ga, gb = fpoint(g)
             term = C.bernoulli(2*k)/C.factorial(2*k)*(gb - ga)
             if (eps and term and abs(term.evalf(3)) < eps) or (k > n):
@@ -462,7 +462,7 @@ def telescopic_direct(L, R, n, limits):
     """
     (i, a, b) = limits
     s = 0
-    for m in range(n):
+    for m in xrange(n):
         s += L.subs(i, a + m) + R.subs(i, b - m)
     return s
 
@@ -558,7 +558,7 @@ def eval_sum_direct(expr, limits):
     (i, a, b) = limits
 
     dif = b - a
-    return Add(*[expr.subs(i, a + j) for j in range(dif + 1)])
+    return Add(*[expr.subs(i, a + j) for j in xrange(dif + 1)])
 
 
 def eval_sum_symbolic(f, limits):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -13,6 +13,7 @@ from sympy.concrete.gosper import gosper_sum
 from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 from sympy.polys import apart, PolynomialError
 from sympy.solvers import solve
+from sympy.core.compatibility import xrange
 
 
 class Sum(Expr):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -295,7 +295,7 @@ class Basic(with_metaclass(ManagedProperties)):
         ========
 
         >>> from sympy import Tuple
-        >>> Tuple.fromiter(i for i in xrange(5))
+        >>> Tuple.fromiter(i for i in range(5))
         (0, 1, 2, 3, 4)
 
         """

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -295,7 +295,7 @@ class Basic(with_metaclass(ManagedProperties)):
         ========
 
         >>> from sympy import Tuple
-        >>> Tuple.fromiter(i for i in range(5))
+        >>> Tuple.fromiter(i for i in xrange(5))
         (0, 1, 2, 3, 4)
 
         """

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -86,6 +86,8 @@ if PY3:
     cStringIO = StringIO
 
     exec_ = getattr(builtins, "exec")
+
+    xrange = range
 else:
     import codecs
     import types
@@ -127,6 +129,8 @@ else:
         elif _locs_ is None:
             _locs_ = _globs_
         exec("exec _code_ in _globs_, _locs_")
+
+    xrange = xrange
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1182,7 +1182,7 @@ class Expr(Basic, EvalfMixin):
             if not l1 or not l2:
                 return []
             n = min(len(l1), len(l2))
-            for i in range(n):
+            for i in xrange(n):
                 if l1[i] != l2[i]:
                     return l1[:i]
             return l1[:]
@@ -1207,7 +1207,7 @@ class Expr(Basic, EvalfMixin):
             if not first:
                 l.reverse()
                 sub.reverse()
-            for i in range(0, len(l) - n + 1):
+            for i in xrange(0, len(l) - n + 1):
                 if all(l[i + j] == sub[j] for j in range(n)):
                     break
             else:
@@ -1278,7 +1278,7 @@ class Expr(Basic, EvalfMixin):
                 if ii is not None:
                     if not right:
                         gcdc = co[0][0]
-                        for i in range(1, len(co)):
+                        for i in xrange(1, len(co)):
                             gcdc = gcdc.intersection(co[i][0])
                             if not gcdc:
                                 break

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -7,7 +7,7 @@ from .singleton import S
 from .evalf import EvalfMixin, pure_complex
 from .decorators import _sympifyit, call_highest_priority
 from .cache import cacheit
-from .compatibility import reduce, as_int, default_sort_key
+from .compatibility import reduce, as_int, default_sort_key, xrange
 from sympy.mpmath.libmp import mpf_log, prec_to_dps
 
 from collections import defaultdict

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -47,7 +47,7 @@ from .sympify import sympify
 
 from sympy.core.containers import Tuple, Dict
 from sympy.core.logic import fuzzy_and
-from sympy.core.compatibility import string_types, with_metaclass
+from sympy.core.compatibility import string_types, with_metaclass, xrange
 from sympy.utilities import default_sort_key
 from sympy.utilities.iterables import uniq
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -533,7 +533,7 @@ class Function(Application, Expr):
         cf = C.Order(arg.as_leading_term(x), x).getn()
         if cf != 0:
             nterms = int(nterms / cf)
-        for i in range(nterms):
+        for i in xrange(nterms):
             g = self.taylor_term(i, arg, g)
             g = g.nseries(x, n=n, logx=logx)
             l.append(g)
@@ -951,7 +951,7 @@ class Derivative(Expr):
         # We make a generator so as to only generate a variable when necessary.
         # If a high order of derivative is requested and the expr becomes 0
         # after a few differentiations, then we won't need the other variables.
-        variablegen = (v for v, count in variable_count for i in range(count))
+        variablegen = (v for v, count in variable_count for i in xrange(count))
 
         # If we can't compute the derivative of expr (but we wanted to) and
         # expr is itself not a Derivative, finish building an unevaluated

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -9,7 +9,7 @@ from sympy.core.singleton import S
 from sympy.core.operations import AssocOp
 from sympy.core.cache import cacheit
 from sympy.core.logic import fuzzy_not
-from sympy.core.compatibility import cmp_to_key, reduce
+from sympy.core.compatibility import cmp_to_key, reduce, xrange
 from sympy.core.expr import Expr
 
 # internal marker to indicate:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -751,7 +751,7 @@ class Mul(Expr, AssocOp):
     def _eval_derivative(self, s):
         terms = list(self.args)
         factors = []
-        for i in range(len(terms)):
+        for i in xrange(len(terms)):
             t = terms[i].diff(s)
             if t is S.Zero:
                 continue

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -4,7 +4,7 @@ from sympy.core.core import C
 from sympy.core.sympify import _sympify, sympify
 from sympy.core.basic import Basic, _aresame
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import ordered
+from sympy.core.compatibility import ordered, xrange
 from sympy.core.logic import fuzzy_and
 
 

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -279,7 +279,7 @@ class AssocOp(Basic):
                     if not nc:
                         return True
                     elif len(nc) <= len(_nc):
-                        for i in range(len(_nc) - len(nc)):
+                        for i in xrange(len(_nc) - len(nc)):
                             if _nc[i:i + len(nc)] == nc:
                                 return True
             return False

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -11,7 +11,7 @@ from .expr import Expr
 from sympy.core.function import (_coeff_isneg, expand_complex,
     expand_multinomial, expand_mul)
 from sympy.core.logic import fuzzy_bool
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, xrange
 
 from sympy.mpmath.libmp import sqrtrem as mpmath_sqrtrem
 from sympy.utilities.iterables import sift

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -844,7 +844,7 @@ class Pow(Expr):
                     raise NotImplementedError()
 
                 terms = [1/prefactor]
-                for m in range(1, ceiling(n/l)):
+                for m in xrange(1, ceiling(n/l)):
                     new_term = terms[-1]*(-rest)
                     if new_term.is_Pow:
                         new_term = new_term._eval_expand_multinomial(
@@ -988,7 +988,7 @@ class Pow(Expr):
         else:
             l = []
             g = None
-            for i in range(n + 2):
+            for i in xrange(n + 2):
                 g = self.taylor_term(i, z, g)
                 g = g.nseries(x, n=n, logx=logx)
                 l.append(g)

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -25,7 +25,7 @@ def test_Tuple():
 
     assert Tuple(t2) == Tuple(Tuple(*t2))
     assert Tuple.fromiter(t2) == Tuple(*t2)
-    assert Tuple.fromiter(x for x in range(4)) == Tuple(0, 1, 2, 3)
+    assert Tuple.fromiter(x for x in xrange(4)) == Tuple(0, 1, 2, 3)
     assert st2.fromiter(st2.args) == st2
 
 

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -25,7 +25,7 @@ def test_Tuple():
 
     assert Tuple(t2) == Tuple(Tuple(*t2))
     assert Tuple.fromiter(t2) == Tuple(*t2)
-    assert Tuple.fromiter(x for x in xrange(4)) == Tuple(0, 1, 2, 3)
+    assert Tuple.fromiter(x for x in range(4)) == Tuple(0, 1, 2, 3)
     assert st2.fromiter(st2.args) == st2
 
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -532,7 +532,7 @@ def test_as_numer_denom():
     assert (a/x + b/2/x + c/.5/x).as_numer_denom() == \
         (2*a + b + 4.0*c, 2*x)
     # this should take no more than a few seconds
-    assert int(log(Add(*[Dummy()/i/x for i in range(1, 705)]
+    assert int(log(Add(*[Dummy()/i/x for i in xrange(1, 705)]
                        ).as_numer_denom()[1]/x).n(4)) == 705
     for i in [S.Infinity, S.NegativeInfinity, S.ComplexInfinity]:
         assert (i + x/3).as_numer_denom() == \

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -10,6 +10,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
 from sympy.core.function import AppliedUndef
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
+from sympy.core.compatibility import xrange
 
 from sympy.utilities.pytest import raises, XFAIL
 

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy import Expr, Add, Mul, Matrix, Pow, sympify, Matrix, Tuple
+from sympy.core.compatibility import xrange
 
 
 def _is_scalar(e):

--- a/sympy/core/trace.py
+++ b/sympy/core/trace.py
@@ -44,7 +44,7 @@ def _cycle_permute(l):
     # in each of the sublist is item just before the next occurence of
     # minitem in the cycle formed.
     sublist = [[le[indices[i]:indices[i + 1]]] for i in
-               range(len(indices) - 1)]
+               xrange(len(indices) - 1)]
 
     # we do comparison of strings by comparing elements
     # in each sublist

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -325,14 +325,14 @@ class RisingFactorial(CombinatorialFunction):
                         else:
                             return S.Infinity
                     else:
-                        return reduce(lambda r, i: r*(x + i), range(0, int(k)), 1)
+                        return reduce(lambda r, i: r*(x + i), xrange(0, int(k)), 1)
                 else:
                     if x is S.Infinity:
                         return S.Infinity
                     elif x is S.NegativeInfinity:
                         return S.Infinity
                     else:
-                        return 1/reduce(lambda r, i: r*(x - i), range(1, abs(int(k)) + 1), 1)
+                        return 1/reduce(lambda r, i: r*(x - i), xrange(1, abs(int(k)) + 1), 1)
 
     def _eval_rewrite_as_gamma(self, x, k):
         return C.gamma(x + k) / C.gamma(x)
@@ -391,14 +391,14 @@ class FallingFactorial(CombinatorialFunction):
                         else:
                             return S.Infinity
                     else:
-                        return reduce(lambda r, i: r*(x - i), range(0, int(k)), 1)
+                        return reduce(lambda r, i: r*(x - i), xrange(0, int(k)), 1)
                 else:
                     if x is S.Infinity:
                         return S.Infinity
                     elif x is S.NegativeInfinity:
                         return S.Infinity
                     else:
-                        return 1/reduce(lambda r, i: r*(x + i), range(1, abs(int(k)) + 1), 1)
+                        return 1/reduce(lambda r, i: r*(x + i), xrange(1, abs(int(k)) + 1), 1)
 
     def _eval_rewrite_as_gamma(self, x, k):
         return (-1)**k * C.gamma(-x + k) / C.gamma(-x)
@@ -529,7 +529,7 @@ class binomial(CombinatorialFunction):
                     return C.Integer(result)
                 elif n.is_Number:
                     result = n - k + 1
-                    for i in range(2, k + 1):
+                    for i in xrange(2, k + 1):
                         result *= n - k + i
                         result /= i
                     return result
@@ -566,7 +566,7 @@ class binomial(CombinatorialFunction):
             else:
                 n = self.args[0]
                 result = n - k + 1
-                for i in range(2, k + 1):
+                for i in xrange(2, k + 1):
                     result *= n - k + i
                     result /= i
                 return result

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -5,7 +5,7 @@ from sympy.core.function import Function, ArgumentIndexError
 from sympy.ntheory import sieve
 from math import sqrt as _sqrt
 
-from sympy.core.compatibility import reduce, as_int
+from sympy.core.compatibility import reduce, as_int, xrange
 from sympy.core.cache import cacheit
 
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -11,7 +11,7 @@ from __future__ import print_function, division
 
 from sympy.core.function import Function, expand_mul
 from sympy.core import S, Symbol, Rational, oo, Integer, C, Add, Dummy
-from sympy.core.compatibility import as_int, SYMPY_INTS
+from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
 from sympy.core.cache import cacheit
 from sympy.functions.combinatorial.factorials import factorial
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -21,7 +21,7 @@ from sympy.mpmath.libmp import ifib as _ifib
 
 def _product(a, b):
     p = 1
-    for k in range(a, b + 1):
+    for k in xrange(a, b + 1):
         p *= k
     return p
 
@@ -225,7 +225,7 @@ class bernoulli(Function):
     def _calc_bernoulli(n):
         s = 0
         a = int(C.binomial(n + 3, n - 6))
-        for j in range(1, n//6 + 1):
+        for j in xrange(1, n//6 + 1):
             s += a * bernoulli(n - 6*j)
             # Avoid computing each binomial coefficient from scratch
             a *= _product(n - 6 - 6*j + 1, n - 6*j)
@@ -268,7 +268,7 @@ class bernoulli(Function):
                     # To avoid excessive recursion when, say, bernoulli(1000) is
                     # requested, calculate and cache the entire sequence ... B_988,
                     # B_994, B_1000 in increasing order
-                    for i in range(highest_cached + 6, n + 6, 6):
+                    for i in xrange(highest_cached + 6, n + 6, 6):
                         b = cls._calc_bernoulli(i)
                         cls._cache[i] = b
                         cls._highest[case] = i
@@ -276,7 +276,7 @@ class bernoulli(Function):
                 # Bernoulli polynomials
                 else:
                     n, result = int(n), []
-                    for k in range(n + 1):
+                    for k in xrange(n + 1):
                         result.append(C.binomial(n, k)*cls(k)*sym**(n - k))
                     return Add(*result)
             else:
@@ -359,7 +359,7 @@ class bell(Function):
     def _bell(n, prev):
         s = 1
         a = 1
-        for k in range(1, n):
+        for k in xrange(1, n):
             a = a * (n - k) // k
             s += a * prev[k]
         return s
@@ -369,7 +369,7 @@ class bell(Function):
     def _bell_poly(n, prev):
         s = 1
         a = 1
-        for k in range(2, n + 1):
+        for k in xrange(2, n + 1):
             a = a * (n - k + 1) // (k - 1)
             s += a * prev[k - 1]
         return expand_mul(_sym * s)
@@ -397,7 +397,7 @@ class bell(Function):
             return S.Zero
         s = S.Zero
         a = S.One
-        for m in range(1, n - k + 2):
+        for m in xrange(1, n - k + 2):
             s += a * bell._bell_incomplete_poly(
                 n - m, k - 1, symbols) * symbols[m - 1]
             a = a * (n - m) / m
@@ -564,10 +564,10 @@ class harmonic(Function):
                 off = n.args[0]
                 nnew = n - off
                 if off.is_Integer and off.is_positive:
-                    result = [S.One/(nnew + i) for i in range(off, 0, -1)] + [harmonic(nnew)]
+                    result = [S.One/(nnew + i) for i in xrange(off, 0, -1)] + [harmonic(nnew)]
                     return Add(*result)
                 elif off.is_Integer and off.is_negative:
-                    result = [-S.One/(nnew + i) for i in range(0, off, -1)] + [harmonic(nnew)]
+                    result = [-S.One/(nnew + i) for i in xrange(0, off, -1)] + [harmonic(nnew)]
                     return Add(*result)
 
         return self

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -10,6 +10,7 @@ from sympy.core.mul import Mul
 
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.ntheory import multiplicity, perfect_power
+from sympy.core.compatibility import xrange
 
 # NOTE IMPORTANT
 # The series expansion code in this file is an important part of the gruntz

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -426,7 +426,7 @@ class exp(ExpBase):
     def _taylor(self, x, n):
         l = []
         g = None
-        for i in range(n):
+        for i in xrange(n):
             g = self.taylor_term(i, self.args[0], g)
             g = g.nseries(x, n=n)
             l.append(g)
@@ -716,7 +716,7 @@ class log(Function):
         p = cancel(s/(a*x**b) - 1)
         g = None
         l = []
-        for i in range(n + 2):
+        for i in xrange(n + 2):
             g = log.taylor_term(i, p, g)
             g = g.nseries(x, n=n, logx=logx)
             l.append(g)

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -10,7 +10,7 @@ from sympy.core.function import Application, Lambda, ArgumentIndexError
 from sympy.core.expr import Expr
 from sympy.core.singleton import Singleton
 from sympy.core.rules import Transform
-from sympy.core.compatibility import as_int, with_metaclass
+from sympy.core.compatibility import as_int, with_metaclass, xrange
 
 
 class IdentityFunction(with_metaclass(Singleton, Lambda)):

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -481,7 +481,7 @@ class Max(MinMaxBase, Application):
             argindex -= 1
             if n == 2:
                 return Heaviside( self.args[argindex] - self.args[1-argindex] )
-            newargs = tuple([self.args[i] for i in range(n) if i != argindex])
+            newargs = tuple([self.args[i] for i in xrange(n) if i != argindex])
             return Heaviside( self.args[argindex] - Max(*newargs) )
         else:
             raise ArgumentIndexError(self, argindex)
@@ -543,7 +543,7 @@ class Min(MinMaxBase, Application):
             argindex -= 1
             if n == 2:
                 return Heaviside( self.args[1-argindex] - self.args[argindex] )
-            newargs = tuple([ self.args[i] for i in range(n) if i != argindex])
+            newargs = tuple([ self.args[i] for i in xrange(n) if i != argindex])
             return Heaviside( Min(*newargs) - self.args[argindex] )
         else:
             raise ArgumentIndexError(self, argindex)

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -5,7 +5,7 @@ from sympy.core.relational import Equality, Relational
 from sympy.core.symbol import Dummy
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.logic.boolalg import And, Boolean, distribute_and_over_or, Not, Or
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, xrange
 
 
 class ExprCondPair(Tuple):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -343,7 +343,7 @@ class Piecewise(Function):
             # part 1b: Reduce (-)infinity to what was passed in.
             lower, upper = Max(a, lower), Min(b, upper)
 
-            for n in range(len(int_expr)):
+            for n in xrange(len(int_expr)):
                 # Part 2: remove any interval overlap.  For any conflicts, the
                 # iterval already there wins, and the incoming interval updates
                 # its bounds accordingly.
@@ -382,7 +382,7 @@ class Piecewise(Function):
         int_expr.sort(key=lambda x: x[0].sort_key(
         ) if x[0].is_number else S.Infinity.sort_key())
         from sympy.functions.elementary.miscellaneous import MinMaxBase
-        for n in range(len(int_expr)):
+        for n in xrange(len(int_expr)):
             if len(int_expr[n][0].free_symbols) or len(int_expr[n][1].free_symbols):
                 if isinstance(int_expr[n][1], Min) or int_expr[n][1] == b:
                     newval = Min(*int_expr[n][:-1])

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -4,6 +4,7 @@ from sympy import (symbols, Symbol, nan, oo, zoo, I, sinh, sin, acot, pi, atan,
         Float, Pow, gcd, sec, csc, cot, diff, simplify, Heaviside, arg, conjugate)
 
 from sympy.utilities.pytest import XFAIL, slow, raises
+from sympy.core.compatibility import xrange
 
 x, y, z = symbols('x y z')
 r = Symbol('r', real=True)

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -86,7 +86,7 @@ def test_sin():
     assert isinstance(sin(-re(x) + im(y)), sin) is False
 
     for d in list(range(1, 22)) + [60, 85]:
-        for n in range(0, d*2 + 1):
+        for n in xrange(0, d*2 + 1):
             x = n*pi/d
             e = abs( float(sin(x)) - sin(float(x)) )
             assert e < 1e-12
@@ -94,7 +94,7 @@ def test_sin():
 
 def test_sin_cos():
     for d in [1, 2, 3, 4, 5, 6, 10, 12]:  # list is not exhaustive...
-        for n in range(-2*d, d*2):
+        for n in xrange(-2*d, d*2):
             x = n*pi/d
             assert sin(x + pi/2) == cos(x), "fails for %d*pi/%d" % (n, d)
             assert sin(x - pi/2) == -cos(x), "fails for %d*pi/%d" % (n, d)
@@ -252,7 +252,7 @@ def test_cos():
     assert cos(2*k*pi) == 1
 
     for d in list(range(1, 22)) + [60, 85]:
-        for n in range(0, 2*d + 1):
+        for n in xrange(0, 2*d + 1):
             x = n*pi/d
             e = abs( float(cos(x)) - cos(float(x)) )
             assert e < 1e-12
@@ -927,7 +927,7 @@ def test_sincos_rewrite_sqrt():
     for p in [1, 3, 5, 17, 3*5*17]:
         for t in [1, 8]:
             n = t*p
-            for i in range(1, (n + 1)//2 + 1):
+            for i in xrange(1, (n + 1)//2 + 1):
                 if 1 == gcd(i, n):
                     x = i*pi/n
                     s1 = sin(x).rewrite(sqrt)
@@ -944,7 +944,7 @@ def test_tancot_rewrite_sqrt():
     for p in [1, 3, 5, 17, 3*5*17]:
         for t in [1, 8]:
             n = t*p
-            for i in range(1, (n + 1)//2 + 1):
+            for i in xrange(1, (n + 1)//2 + 1):
                 if 1 == gcd(i, n):
                     x = i*pi/n
                     if  2*i != n and 3*i != 2*n:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.utilities.iterables import numbered_symbols
+from sympy.core.compatibility import xrange
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -905,10 +905,10 @@ class tan(TrigonometricFunction):
                 TX.append(tx)
 
             Yg = numbered_symbols('Y')
-            Y = [ next(Yg) for i in range(n) ]
+            Y = [ next(Yg) for i in xrange(n) ]
 
             p = [0, 0]
-            for i in range(n + 1):
+            for i in xrange(n + 1):
                 p[1 - i % 2] += symmetric_poly(i, Y)*(-1)**((i % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, TX)))
 
@@ -1163,10 +1163,10 @@ class cot(TrigonometricFunction):
                 CX.append(cx)
 
             Yg = numbered_symbols('Y')
-            Y = [ next(Yg) for i in range(n) ]
+            Y = [ next(Yg) for i in xrange(n) ]
 
             p = [0, 0]
-            for i in range(n, -1, -1):
+            for i in xrange(n, -1, -1):
                 p[(n - i) % 2] += symmetric_poly(i, Y)*(-1)**(((n - i) % 4)//2)
             return (p[0]/p[1]).subs(list(zip(Y, CX)))
         else:

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -690,7 +690,7 @@ def jn_zeros(n, k, method="sympy", dps=15):
         prec = dps_to_prec(dps)
         return [Expr._from_mpmath(besseljzero(S(n + 0.5)._to_mpmath(prec),
                                               int(k)), prec)
-                for k in range(1, k + 1)]
+                for k in xrange(1, k + 1)]
     elif method == "scipy":
         from scipy.special import sph_jn
         from scipy.optimize import newton

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -7,6 +7,7 @@ from sympy.core.function import Function, ArgumentIndexError, expand_func
 from sympy.functions.elementary.trigonometric import sin, cos, csc, cot
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.complexes import re, im
+from sympy.core.compatibility import xrange
 
 # TODO
 # o Airy Ai and Bi functions

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2229,7 +2229,7 @@ class _erfs(Function):
         if point is S.Infinity:
             z = self.args[0]
             l = [ 1/sqrt(S.Pi) * C.factorial(2*k)*(-S(
-                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in range(0, n) ]
+                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in xrange(0, n) ]
             o = C.Order(1/z**(2*n + 1), x)
             # It is very inefficient to first add the order and then do the nseries
             return (Add(*l))._eval_nseries(x, n, logx) + o
@@ -2240,7 +2240,7 @@ class _erfs(Function):
             z = self.args[0]
             # TODO: is the series really correct?
             l = [ 1/sqrt(S.Pi) * C.factorial(2*k)*(-S(
-                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in range(0, n) ]
+                4))**(-k)/C.factorial(k) * (1/z)**(2*k + 1) for k in xrange(0, n) ]
             o = C.Order(1/z**(2*n + 1), x)
             # It is very inefficient to first add the order and then do the nseries
             return (Add(*l))._eval_nseries(x, n, logx) + o
@@ -2272,7 +2272,7 @@ class _eis(Function):
             return super(_erfs, self)._eval_aseries(n, args0, x, logx)
 
         z = self.args[0]
-        l = [ C.factorial(k) * (1/z)**(k + 1) for k in range(0, n) ]
+        l = [ C.factorial(k) * (1/z)**(k + 1) for k in xrange(0, n) ]
         o = C.Order(1/z**(n + 1), x)
         # It is very inefficient to first add the order and then do the nseries
         return (Add(*l))._eval_nseries(x, n, logx) + o

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -9,6 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, root
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.complexes import polar_lift
 from sympy.functions.special.hyper import hyper, meijerg
+from sympy.core.compatibility import xrange
 
 # TODO series expansions
 # TODO see the "Note:" in Ei

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -539,17 +539,17 @@ class polygamma(Function):
                     e = -(n + 1)
                     if coeff > 0:
                         tail = Add(*[C.Pow(
-                            z - i, e) for i in range(1, int(coeff) + 1)])
+                            z - i, e) for i in xrange(1, int(coeff) + 1)])
                     else:
                         tail = -Add(*[C.Pow(
-                            z + i, e) for i in range(0, int(-coeff))])
+                            z + i, e) for i in xrange(0, int(-coeff))])
                     return polygamma(n, z - coeff) + (-1)**n*C.factorial(n)*tail
 
             elif z.is_Mul:
                 coeff, z = z.as_two_terms()
                 if coeff.is_Integer and coeff.is_positive:
                     tail = [ polygamma(n, z + C.Rational(
-                        i, coeff)) for i in range(0, int(coeff)) ]
+                        i, coeff)) for i in xrange(0, int(coeff)) ]
                     if n == 0:
                         return Add(*tail)/coeff + log(coeff)
                     else:

--- a/sympy/functions/special/gamma_functions.py
+++ b/sympy/functions/special/gamma_functions.py
@@ -11,6 +11,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.combinatorial.numbers import bernoulli
 from sympy.functions.combinatorial.factorials import rf
 from sympy.functions.combinatorial.numbers import harmonic
+from sympy.core.compatibility import xrange
 
 ###############################################################################
 ############################ COMPLETE GAMMA FUNCTION ##########################

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -4,6 +4,7 @@ from sympy.core.function import Function, C
 from sympy.core import S, Integer
 from sympy.core.mul import prod
 from sympy.utilities.iterables import (has_dups, default_sort_key)
+from sympy.core.compatibility import xrange
 
 ###############################################################################
 ###################### Kronecker Delta, Levi-Civita etc. ######################

--- a/sympy/functions/special/tensor_functions.py
+++ b/sympy/functions/special/tensor_functions.py
@@ -30,8 +30,8 @@ def eval_levicivita(*args):
     from sympy import factorial
     n = len(args)
     return prod(
-        prod(args[j] - args[i] for j in range(i + 1, n))
-        / factorial(i) for i in range(n))
+        prod(args[j] - args[i] for j in xrange(i + 1, n))
+        / factorial(i) for i in xrange(n))
     # converting factorial(i) to int is slightly faster
 
 

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -143,19 +143,19 @@ class lerchphi(Function):
                     n -= 1
                 a -= n
                 mul = z**(-n)
-                add = Add(*[-z**(k - n)/(a + k)**s for k in range(n)])
+                add = Add(*[-z**(k - n)/(a + k)**s for k in xrange(n)])
             elif a <= 0:
                 n = floor(-a) + 1
                 a += n
                 mul = z**n
-                add = Add(*[z**(n - 1 - k)/(a - k - 1)**s for k in range(n)])
+                add = Add(*[z**(n - 1 - k)/(a - k - 1)**s for k in xrange(n)])
 
             m, n = S([a.p, a.q])
             zet = exp_polar(2*pi*I/n)
             root = z**(1/n)
             return add + mul*n**(s - 1)*Add(
                 *[polylog(s, zet**k*root)._eval_expand_func(**hints)
-                  / (unpolarify(zet)**k*root)**m for k in range(n)])
+                  / (unpolarify(zet)**k*root)**m for k in xrange(n)])
 
         # TODO use minpoly instead of ad-hoc methods when issue 2789 is fixed
         if z.func is exp and (z.args[0]/(pi*I)).is_Rational or z in [-1, I, -I]:
@@ -170,7 +170,7 @@ class lerchphi(Function):
                 arg = z.args[0]/(2*pi*I)
                 p, q = S([arg.p, arg.q])
             return Add(*[exp(2*pi*I*k*p/q)/q**s*zeta(s, (k + a)/q)
-                         for k in range(q)])
+                         for k in xrange(q)])
 
         return lerchphi(z, s, a)
 

--- a/sympy/functions/special/zeta_functions.py
+++ b/sympy/functions/special/zeta_functions.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 
 from sympy.core import Function, S, C, sympify, pi
 from sympy.core.function import ArgumentIndexError
+from sympy.core.compatibility import xrange
 
 ###############################################################################
 ###################### LERCH TRANSCENDENT #####################################

--- a/sympy/galgebra/GA.py
+++ b/sympy/galgebra/GA.py
@@ -18,6 +18,7 @@ import sympy
 import re as regrep
 import sympy.galgebra.latex_ex
 from sympy.core.decorators import deprecated
+from sympy.core.compatibility import xrange
 
 NUMPAT = regrep.compile( '([\-0-9])|([\-0-9]/[0-9])')
 """Re pattern for rational number"""

--- a/sympy/galgebra/GA.py
+++ b/sympy/galgebra/GA.py
@@ -163,9 +163,9 @@ def diagpq(p, q=0):
     """
     n = p + q
     D = []
-    for i in range(p):
+    for i in xrange(p):
         D.append((i*'0 ' +'1 '+ (n-i-1)*'0 ')[:-1])
-    for i in range(p,n):
+    for i in xrange(p,n):
         D.append((i*'0 ' +'-1 '+ (n-i-1)*'0 ')[:-1])
     return ','.join(D)
 

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Expr, S, sympify, oo, pi, Symbol, zoo
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, xrange
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.complexes import sign
 from sympy.functions.elementary.trigonometric import cos, sin, tan, sqrt, atan

--- a/sympy/geometry/polygon.py
+++ b/sympy/geometry/polygon.py
@@ -174,7 +174,7 @@ class Polygon(GeometryEntity):
             for i, si in enumerate(sides):
                 pts = si[0], si[1]
                 ai = si.arbitrary_point(hit)
-                for j in range(i):
+                for j in xrange(i):
                     sj = sides[j]
                     if sj[0] not in pts and sj[1] not in pts:
                         aj = si.arbitrary_point(hit)
@@ -215,7 +215,7 @@ class Polygon(GeometryEntity):
         """
         area = 0
         args = self.args
-        for i in range(len(args)):
+        for i in xrange(len(args)):
             x1, y1 = args[i - 1].args
             x2, y2 = args[i].args
             area += x1*y2 - x2*y1
@@ -262,7 +262,7 @@ class Polygon(GeometryEntity):
         cw = _isright(args[-1], args[0], args[1])
 
         ret = {}
-        for i in range(len(args)):
+        for i in xrange(len(args)):
             a, b, c = args[i - 2], args[i - 1], args[i]
             ang = Line.angle_between(Line(b, a), Line(b, c))
             if cw ^ _isright(a, b, c):
@@ -296,7 +296,7 @@ class Polygon(GeometryEntity):
         """
         p = 0
         args = self.vertices
-        for i in range(len(args)):
+        for i in xrange(len(args)):
             p += args[i - 1].distance(args[i])
         return simplify(p)
 
@@ -363,7 +363,7 @@ class Polygon(GeometryEntity):
         A = 1/(6*self.area)
         cx, cy = 0, 0
         args = self.args
-        for i in range(len(args)):
+        for i in xrange(len(args)):
             x1, y1 = args[i - 1].args
             x2, y2 = args[i].args
             v = x1*y2 - x2*y1
@@ -407,7 +407,7 @@ class Polygon(GeometryEntity):
         """
         res = []
         args = self.vertices
-        for i in range(-len(args), 0):
+        for i in xrange(-len(args), 0):
             res.append(Segment(args[i], args[i + 1]))
         return res
 
@@ -448,7 +448,7 @@ class Polygon(GeometryEntity):
         # Determine orientation of points
         args = self.vertices
         cw = _isright(args[-2], args[-1], args[0])
-        for i in range(1, len(args)):
+        for i in xrange(1, len(args)):
             if cw ^ _isright(args[i - 2], args[i - 1], args[i]):
                 return False
 
@@ -906,11 +906,11 @@ class Polygon(GeometryEntity):
         oargs = o.args
         n = len(args)
         o0 = oargs[0]
-        for i0 in range(n):
+        for i0 in xrange(n):
             if args[i0] == o0:
-                if all(args[(i0 + i) % n] == oargs[i] for i in range(1, n)):
+                if all(args[(i0 + i) % n] == oargs[i] for i in xrange(1, n)):
                     return True
-                if all(args[(i0 - i) % n] == oargs[i] for i in range(1, n)):
+                if all(args[(i0 - i) % n] == oargs[i] for i in xrange(1, n)):
                     return True
         return False
 
@@ -1565,7 +1565,7 @@ class RegularPolygon(Polygon):
         v = 2*S.Pi/self._n
 
         return [Point(c.x + r*cos(k*v + rot), c.y + r*sin(k*v + rot))
-                for k in range(self._n)]
+                for k in xrange(self._n)]
 
     def __eq__(self, o):
         if not isinstance(o, Polygon):

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -196,7 +196,7 @@ def test_line():
     assert Line(p1, p2).scale(2, 1) == Line(p1, p9)
 
     assert l2.arbitrary_point() in l2
-    for ind in xrange(0, 5):
+    for ind in range(0, 5):
         assert l3.random_point() in l3
 
     # Orthogonality
@@ -615,7 +615,7 @@ def test_ellipse():
 def test_ellipse_random_point():
     e3 = Ellipse(Point(0, 0), y1, y1)
     rx, ry = Symbol('rx'), Symbol('ry')
-    for ind in xrange(0, 5):
+    for ind in range(0, 5):
         r = e3.random_point()
         # substitution should give zero*y1**2
         assert e3.equation(rx, ry).subs(zip((rx, ry), r.args)).equals(0)

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -196,7 +196,7 @@ def test_line():
     assert Line(p1, p2).scale(2, 1) == Line(p1, p9)
 
     assert l2.arbitrary_point() in l2
-    for ind in range(0, 5):
+    for ind in xrange(0, 5):
         assert l3.random_point() in l3
 
     # Orthogonality
@@ -615,7 +615,7 @@ def test_ellipse():
 def test_ellipse_random_point():
     e3 = Ellipse(Point(0, 0), y1, y1)
     rx, ry = Symbol('rx'), Symbol('ry')
-    for ind in range(0, 5):
+    for ind in xrange(0, 5):
         r = e3.random_point()
         # substitution should give zero*y1**2
         assert e3.equation(rx, ry).subs(zip((rx, ry), r.args)).equals(0)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from sympy.core.add import Add
 from sympy.core.basic import Basic, C
-from sympy.core.compatibility import is_sequence
+from sympy.core.compatibility import is_sequence, xrange
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import diff

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -141,7 +141,7 @@ def _as_dummy(expr_with_limits):
     reps = {}
     f = self.function
     limits = list(self.limits)
-    for i in range(-1, -len(limits) - 1, -1):
+    for i in xrange(-1, -len(limits) - 1, -1):
         xab = list(limits[i])
         if len(xab) == 1:
             continue
@@ -241,7 +241,7 @@ def _eval_subs(expr_with_limits, old, new):
         limits = list(limits)
 
         dummies = set()
-        for i in range(-1, -len(limits) - 1, -1):
+        for i in xrange(-1, -len(limits) - 1, -1):
             xab = limits[i]
             if len(xab) == 1:
                 continue

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -301,7 +301,7 @@ def prde_no_cancel_b_large(b, Q, n, DE):
     m = len(Q)
     H = [Poly(0, DE.t)]*m
 
-    for N in range(n, -1, -1):  # [n, ..., 0]
+    for N in xrange(n, -1, -1):  # [n, ..., 0]
         for i in range(m):
             si = Q[i].nth(N + db)/b.LC()
             sitn = Poly(si*DE.t**N, DE.t)
@@ -335,7 +335,7 @@ def prde_no_cancel_b_small(b, Q, n, DE):
     m = len(Q)
     H = [Poly(0, DE.t)]*m
 
-    for N in range(n, 0, -1):  # [n, ..., 1]
+    for N in xrange(n, 0, -1):  # [n, ..., 1]
         for i in range(m):
             si = Q[i].nth(N + DE.d.degree(DE.t) - 1)/(N*DE.d.LC())
             sitn = Poly(si*DE.t**N, DE.t)
@@ -826,7 +826,7 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
     respolys, residues = list(zip(*roots)) or [[], []]
     # Note: this might be empty, but everything below should work find in that
     # case (it should be the same as if it were [[1, 1]])
-    residueterms = [(H[j][1].subs(z, i), i) for j in range(len(H)) for
+    residueterms = [(H[j][1].subs(z, i), i) for j in xrange(len(H)) for
         i in residues[j]]
 
     # TODO: finish writing this and write tests

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -30,7 +30,7 @@ from sympy.integrals.risch import (gcdex_diophantine, frac_in, derivation,
     residue_reduce_derivation, DecrementLevel, recognize_log_derivative)
 from sympy.integrals.rde import (order_at, order_at_oo, weak_normalizer,
     bound_degree, spde, solve_poly_rde)
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, xrange
 
 
 def prde_normal_denom(fa, fd, G, DE):

--- a/sympy/integrals/quadrature.py
+++ b/sympy/integrals/quadrature.py
@@ -345,7 +345,7 @@ def gauss_chebyshev_t(n, n_digits):
     x = Dummy("x")
     xi = []
     w  = []
-    for i in range(1,n+1):
+    for i in xrange(1,n+1):
         xi.append((cos((2*i-S.One)/(2*n)*S.Pi)).n(n_digits))
         w.append((S.Pi/n).n(n_digits))
     return xi, w
@@ -411,7 +411,7 @@ def gauss_chebyshev_u(n, n_digits):
     x = Dummy("x")
     xi = []
     w  = []
-    for i in range(1,n+1):
+    for i in xrange(1,n+1):
         xi.append((cos(i/(n+S.One)*S.Pi)).n(n_digits))
         w.append((S.Pi/(n+S.One)*sin(i*S.Pi/(n+S.One))**2).n(n_digits))
     return xi, w

--- a/sympy/integrals/quadrature.py
+++ b/sympy/integrals/quadrature.py
@@ -7,6 +7,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.special.gamma_functions import gamma
 from sympy.polys.orthopolys import legendre_poly, laguerre_poly, hermite_poly, jacobi_poly
 from sympy.polys.rootoftools import RootOf
+from sympy.core.compatibility import xrange
 
 def gauss_legendre(n, n_digits):
     r"""

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -144,8 +144,8 @@ def ratint_ratpart(f, g, x):
     n = u.degree()
     m = v.degree()
 
-    A_coeffs = [ Dummy('a' + str(n - i)) for i in range(0, n) ]
-    B_coeffs = [ Dummy('b' + str(m - i)) for i in range(0, m) ]
+    A_coeffs = [ Dummy('a' + str(n - i)) for i in xrange(0, n) ]
+    B_coeffs = [ Dummy('b' + str(m - i)) for i in xrange(0, m) ]
 
     C_coeffs = A_coeffs + B_coeffs
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -6,6 +6,7 @@ from sympy import S, Symbol, symbols, I, log, atan, \
     roots, collect, solve, RootSum, Lambda, cancel, Dummy
 
 from sympy.polys import Poly, subresultants, resultant, ZZ
+from sympy.core.compatibility import xrange
 
 
 def ratint(f, x, **flags):

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1354,7 +1354,7 @@ def integrate_hyperexponential_polynomial(p, DE, z):
     b = True
 
     with DecrementLevel(DE):
-        for i in range(-p.degree(z), p.degree(t1) + 1):
+        for i in xrange(-p.degree(z), p.degree(t1) + 1):
             if not i:
                 continue
             elif i < 0:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -34,7 +34,7 @@ from sympy.core.power import Pow
 from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol, Dummy
-from sympy.core.compatibility import reduce, ordered
+from sympy.core.compatibility import reduce, ordered, xrange
 from sympy.integrals.heurisch import _symbols
 
 from sympy.functions import (acos, acot, asin, atan, cos, cot, exp, log,

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -713,7 +713,7 @@ def to_int_repr(clauses, symbols):
     """
 
     # Convert the symbol list into a dict
-    symbols = dict(list(zip(symbols, list(range(1, len(symbols) + 1)))))
+    symbols = dict(list(zip(symbols, list(xrange(1, len(symbols) + 1)))))
 
     def append_symbol(arg, symbols):
         if arg.func is Not:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -9,7 +9,7 @@ from sympy.core.numbers import Number
 from sympy.core.decorators import deprecated
 from sympy.core.operations import LatticeOp
 from sympy.core.function import Application, sympify
-from sympy.core.compatibility import ordered
+from sympy.core.compatibility import ordered, xrange
 
 
 class Boolean(Basic):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -10,7 +10,7 @@ from sympy.core.symbol import Symbol, Dummy
 from sympy.core.numbers import Integer, ilcm, Rational, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
-from sympy.core.compatibility import is_sequence, default_sort_key
+from sympy.core.compatibility import is_sequence, default_sort_key, xrange
 
 from sympy.polys import PurePoly, roots, cancel
 from sympy.simplify import simplify as _simplify, signsimp, nsimplify

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1210,13 +1210,13 @@ class MatrixBase(object):
         n = self.rows
         b = rhs.permuteFwd(perm).as_mutable()
         # forward substitution, all diag entries are scaled to 1
-        for i in range(n):
-            for j in range(i):
+        for i in xrange(n):
+            for j in xrange(i):
                 scale = A[i, j]
                 b.zip_row_op(i, j, lambda x, y: x - y*scale)
         # backward substitution
-        for i in range(n - 1, -1, -1):
-            for j in range(i + 1, n):
+        for i in xrange(n - 1, -1, -1):
+            for j in xrange(i + 1, n):
                 scale = A[i, j]
                 b.zip_row_op(i, j, lambda x, y: x - y*scale)
             scale = A[i, i]
@@ -2590,13 +2590,13 @@ class MatrixBase(object):
         pivot, r = 0, self.as_mutable()
         # pivotlist: indices of pivot variables (non-free)
         pivotlist = []
-        for i in range(r.cols):
+        for i in xrange(r.cols):
             if pivot == r.rows:
                 break
             if simplify:
                 r[pivot, i] = simpfunc(r[pivot, i])
             if iszerofunc(r[pivot, i]):
-                for k in range(pivot, r.rows):
+                for k in xrange(pivot, r.rows):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
                     if not iszerofunc(r[k, i]):
@@ -2606,7 +2606,7 @@ class MatrixBase(object):
                 r.row_swap(pivot, k)
             scale = r[pivot, i]
             r.row_op(pivot, lambda x, _: x / scale)
-            for j in range(r.rows):
+            for j in xrange(r.rows):
                 if j == pivot:
                     continue
                 scale = r[j, i]
@@ -3482,7 +3482,7 @@ class MatrixBase(object):
                 # So we will do the same procedure also for `s-1` and so on until 1 the lowest possible order
                 # where the jordanchain is of lenght 1 and just represented by the eigenvector.
 
-                for s in reversed(range(1, smax+1)):
+                for s in reversed(xrange(1, smax+1)):
                     S = Ms[s]
                     # We want the vectors in `Kernel((self-lI)^s)` (**),
                     # but without those in `Kernel(self-lI)^s-1` so we will add these as additional equations

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1134,7 +1134,7 @@ def test_vec():
     m = Matrix([[1, 3], [2, 4]])
     m_vec = m.vec()
     assert m_vec.cols == 1
-    for i in range(4):
+    for i in xrange(4):
         assert m_vec[i] == i + 1
 
 
@@ -1142,7 +1142,7 @@ def test_vech():
     m = Matrix([[1, 2], [2, 3]])
     m_vech = m.vech()
     assert m_vech.cols == 1
-    for i in range(3):
+    for i in xrange(3):
         assert m_vech[i] == i + 1
     m_vech = m.vech(diagonal=False)
     assert m_vech[0] == 2

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1134,7 +1134,7 @@ def test_vec():
     m = Matrix([[1, 3], [2, 4]])
     m_vec = m.vec()
     assert m_vec.cols == 1
-    for i in xrange(4):
+    for i in range(4):
         assert m_vec[i] == i + 1
 
 
@@ -1142,7 +1142,7 @@ def test_vech():
     m = Matrix([[1, 2], [2, 3]])
     m_vech = m.vech()
     assert m_vech.cols == 1
-    for i in xrange(3):
+    for i in range(3):
         assert m_vech[i] == i + 1
     m_vech = m.vech(diagonal=False)
     assert m_vech[0] == 2

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -1220,7 +1220,7 @@ def _divisors(n):
             yield 1
         else:
             pows = [1]
-            for j in range(factordict[ps[n]]):
+            for j in xrange(factordict[ps[n]]):
                 pows.append(pows[-1] * ps[n])
             for q in rec_gen(n + 1):
                 for p in pows:

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -13,7 +13,7 @@ from sympy.core.evalf import bitcount
 from sympy.core.numbers import igcd, oo, Rational
 from sympy.core.power import integer_nthroot, Pow
 from sympy.core.mul import Mul
-from sympy.core.compatibility import as_int, SYMPY_INTS
+from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
 from sympy.core.singleton import S
 from sympy.core.function import Function
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -77,7 +77,7 @@ class Sieve:
             # Start counting at a multiple of p, offsetting
             # the index to account for the new sieve's base index
             startindex = (-begin) % p
-            for i in range(startindex, len(newsieve), p):
+            for i in xrange(startindex, len(newsieve), p):
                 newsieve[i] = 0
 
         # Merge the sieves

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -11,7 +11,7 @@ from bisect import bisect
 from array import array as _array
 
 from .primetest import isprime
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, xrange
 
 
 def _arange(a, b):

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from collections import defaultdict
+from sympy.core.compatibility import xrange
 
 
 def binomial_coefficients(n):

--- a/sympy/ntheory/multinomial.py
+++ b/sympy/ntheory/multinomial.py
@@ -21,7 +21,7 @@ def binomial_coefficients(n):
     """
     d = {(0, n): 1, (n, 0): 1}
     a = 1
-    for k in range(1, n//2 + 1):
+    for k in xrange(1, n//2 + 1):
         a = (a * (n - k + 1))//k
         d[k, n - k] = d[n - k, k] = a
     return d
@@ -45,7 +45,7 @@ def binomial_coefficients_list(n):
     """
     d = [1] * (n + 1)
     a = 1
-    for k in range(1, n//2 + 1):
+    for k in xrange(1, n//2 + 1):
         a = (a * (n - k + 1))//k
         d[k] = d[n - k] = a
     return d
@@ -91,9 +91,9 @@ def multinomial_coefficients0(m, n, _tuple=tuple, _zip=zip):
     r = {_tuple(aa*n for aa in s0): 1}
     l = [0] * (n*(m - 1) + 1)
     l[0] = r.items()
-    for k in range(1, n*(m - 1) + 1):
+    for k in xrange(1, n*(m - 1) + 1):
         d = defaultdict(int)
-        for i in range(1, min(m, k + 1)):
+        for i in xrange(1, min(m, k + 1)):
             nn = (n + 1)*i - k
             if not nn:
                 continue
@@ -167,7 +167,7 @@ def multinomial_coefficients(m, n):
             t[j] += 1
         # compute the value
         # NB: the initialization of v was done above
-        for k in range(start, m):
+        for k in xrange(start, m):
             if t[k]:
                 t[k] -= 1
                 v += r[tuple(t)]

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -6,6 +6,7 @@ from sympy.mpmath.libmp import (fzero,
     mpf_add, mpf_sqrt, mpf_pi, mpf_cosh_sinh, pi_fixed, mpf_cos)
 from sympy.core.numbers import igcd
 import math
+from sympy.core.compatibility import xrange
 
 
 def _a(n, j, prec):

--- a/sympy/ntheory/partitions_.py
+++ b/sympy/ntheory/partitions_.py
@@ -14,7 +14,7 @@ def _a(n, j, prec):
         return fone
     s = fzero
     pi = pi_fixed(prec)
-    for h in range(1, j):
+    for h in xrange(1, j):
         if igcd(h, j) != 1:
             continue
         # & with mask to compute fractional part of fixed-point number
@@ -23,7 +23,7 @@ def _a(n, j, prec):
         half = one >> 1
         g = 0
         if j >= 3:
-            for k in range(1, j):
+            for k in xrange(1, j):
                 t = h*k*one//j
                 if t > 0:
                     frac = t & onemask
@@ -82,7 +82,7 @@ def npartitions(n, verbose=False):
     M = max(6, int(0.24*n**0.5 + 4))
     sq23pi = mpf_mul(mpf_sqrt(from_rational(2, 3, p), p), mpf_pi(p), p)
     sqrt8 = mpf_sqrt(from_int(8), p)
-    for q in range(1, M):
+    for q in xrange(1, M):
         a = _a(n, q, p)
         d = _d(n, q, p, sq23pi, sqrt8)
         s = mpf_add(s, mpf_mul(a, d), prec)

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -4,6 +4,7 @@ Primality testing
 """
 
 from __future__ import print_function, division
+from sympy.core.compatibility import xrange
 
 # pseudoprimes that will pass through last mr_safe test
 _pseudos = set([

--- a/sympy/ntheory/primetest.py
+++ b/sympy/ntheory/primetest.py
@@ -51,7 +51,7 @@ def _test(n, base, s, t):
     if b == 1 or b == n - 1:
         return True
     else:
-        for j in range(1, s):
+        for j in xrange(1, s):
             b = pow(b, 2, n)
             if b == n - 1:
                 return True

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.numbers import igcd
-from sympy.core.compatibility import as_int
+from sympy.core.compatibility import as_int, xrange
 from .primetest import isprime
 from .factor_ import factorint, trailing, totient
 

--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -31,7 +31,7 @@ def n_order(a, n):
         a = a % n
     for p, e in factors.items():
         exponent = group_order
-        for f in range(e + 1):
+        for f in xrange(e + 1):
             if a**exponent % n != 1:
                 order *= p ** (e - f + 1)
                 break

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -1132,7 +1132,7 @@ def gate_simp(circuit):
         return circuit
 
     # Iterate through each element in circuit, simplify if possible.
-    for i in range(len(circuit_args)):
+    for i in xrange(len(circuit_args)):
         # H,X,Y or Z squared is 1.
         # T**2 = S, S**2 = Z
         if isinstance(circuit_args[i], Pow):
@@ -1201,7 +1201,7 @@ def gate_sort(circuit):
     while changes:
         changes = False
         circ_array = circuit.args
-        for i in range(len(circ_array) - 1):
+        for i in xrange(len(circ_array) - 1):
             # Go through each element and switch ones that are in wrong order
             if isinstance(circ_array[i], (Gate, Pow)) and \
                     isinstance(circ_array[i + 1], (Gate, Pow)):
@@ -1255,7 +1255,7 @@ def random_circuit(ngates, nqubits, gate_space=(X, Y, Z, S, T, H, CNOT, SWAP)):
     """
     qubit_space = range(nqubits)
     result = []
-    for i in range(ngates):
+    for i in xrange(ngates):
         g = random.choice(gate_space)
         if g == CNotGate or g == SwapGate:
             qubits = random.sample(qubit_space, 2)

--- a/sympy/physics/quantum/gate.py
+++ b/sympy/physics/quantum/gate.py
@@ -20,7 +20,7 @@ import random
 
 from sympy import Add, I, Integer, Matrix, Mul, Pow, sqrt, Tuple
 from sympy.core.numbers import Number
-from sympy.core.compatibility import is_sequence, u, unicode
+from sympy.core.compatibility import is_sequence, u, unicode, xrange
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 
 from sympy.physics.quantum.anticommutator import AntiCommutator

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -247,7 +247,7 @@ class Qubit(QubitState, Ket):
 
         for i in xrange(new_size):
             for j in xrange(new_size):
-                for k in xrange(2):
+                for k in range(2):
                     col = find_index_that_is_projected(j, k, qubit)
                     row = find_index_that_is_projected(i, k, qubit)
                     new_matrix[i, j] += old_matrix[row, col]

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -12,7 +12,7 @@ import math
 
 from sympy import Integer, log, Mul, Add, Pow, conjugate
 from sympy.core.basic import sympify
-from sympy.core.compatibility import string_types
+from sympy.core.compatibility import string_types, xrange
 from sympy.matrices import Matrix, zeros
 from sympy.printing.pretty.stringpict import prettyForm
 

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -220,7 +220,7 @@ class Qubit(QubitState, Ket):
 
         #trace out for each of index
         new_mat = self*bra
-        for i in range(len(sorted_idx) - 1, -1, -1):
+        for i in xrange(len(sorted_idx) - 1, -1, -1):
             # start from tracing out from leftmost qubit
             new_mat = self._reduced_density(new_mat, int(sorted_idx[i]))
 
@@ -245,9 +245,9 @@ class Qubit(QubitState, Ket):
         new_size = old_size//2
         new_matrix = Matrix().zeros(new_size)
 
-        for i in range(new_size):
-            for j in range(new_size):
-                for k in range(2):
+        for i in xrange(new_size):
+            for j in xrange(new_size):
+                for k in xrange(2):
                     col = find_index_that_is_projected(j, k, qubit)
                     row = find_index_that_is_projected(i, k, qubit)
                     new_matrix[i, j] += old_matrix[row, col]

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2040,7 +2040,7 @@ class NO(Expr):
 
         """
         ops = self.args[0].args
-        iter = range(len(ops) - 1, -1, -1)
+        iter = xrange(len(ops) - 1, -1, -1)
         for i in iter:
             if ops[i].is_q_annihilator:
                 yield i
@@ -2070,7 +2070,7 @@ class NO(Expr):
         """
 
         ops = self.args[0].args
-        iter = range(0, len(ops))
+        iter = xrange(0, len(ops))
         for i in iter:
             if ops[i].is_q_creator:
                 yield i

--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from sympy import (Add, Basic, cacheit, Dummy, Expr, Function, I,
                    KroneckerDelta, Mul, Pow, S, sqrt, Symbol, sympify, Tuple,
                    zeros)
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, xrange
 from sympy.printing.str import StrPrinter
 
 from sympy.physics.quantum.qexpr import split_commutative_parts

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -171,7 +171,7 @@ class ColorScheme(object):
         # when vars are given explicitly, any vars
         # not given are marked 'unbound' as to not
         # be accidentally used in an expression
-        vars = [Symbol('unbound%i' % (i)) for i in xrange(1, 6)]
+        vars = [Symbol('unbound%i' % (i)) for i in range(1, 6)]
         # interpret as t
         if len(args) == 1:
             vars[3] = args[0]
@@ -257,7 +257,7 @@ class ColorScheme(object):
         # scale and apply gradient
         for _u in xrange(len(u_set)):
             if cverts[_u] is not None:
-                for _c in xrange(3):
+                for _c in range(3):
                     # scale from [f_min, f_max] to [0,1]
                     cverts[_u][_c] = rinterpolate(bounds[_c][0], bounds[_c][1],
                                                   cverts[_u][_c])
@@ -300,7 +300,7 @@ class ColorScheme(object):
             for _v in xrange(len(v_set)):
                 if cverts[_u][_v] is not None:
                     # scale from [f_min, f_max] to [0,1]
-                    for _c in xrange(3):
+                    for _c in range(3):
                         cverts[_u][_v][_c] = rinterpolate(bounds[_c][0],
                                              bounds[_c][1], cverts[_u][_v][_c])
                     # apply gradient

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from sympy import Basic, Symbol, symbols, lambdify
 from util import interpolate, rinterpolate, create_bounds, update_bounds
+from sympy.core.compatibility import xrange
 
 
 class ColorGradient(object):

--- a/sympy/plotting/pygletplot/plot_curve.py
+++ b/sympy/plotting/pygletplot/plot_curve.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from pyglet.gl import *
 from plot_mode_base import PlotModeBase
 from sympy.core import S
+from sympy.core.compatibility import xrange
 
 
 class PlotCurve(PlotModeBase):

--- a/sympy/plotting/pygletplot/plot_curve.py
+++ b/sympy/plotting/pygletplot/plot_curve.py
@@ -28,13 +28,13 @@ class PlotCurve(PlotModeBase):
             except (NameError, ZeroDivisionError):
                 _e = None
             if _e is not None:      # update bounding box
-                for axis in xrange(3):
+                for axis in range(3):
                     b[axis][0] = min([b[axis][0], _e[axis]])
                     b[axis][1] = max([b[axis][1], _e[axis]])
             self.verts.append(_e)
             self._calculating_verts_pos += 1.0
 
-        for axis in xrange(3):
+        for axis in range(3):
             b[axis][2] = b[axis][1] - b[axis][0]
             if b[axis][2] == 0.0:
                 b[axis][2] = 1.0

--- a/sympy/plotting/pygletplot/plot_surface.py
+++ b/sympy/plotting/pygletplot/plot_surface.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from pyglet.gl import *
 from plot_mode_base import PlotModeBase
 from sympy.core import S
+from sympy.core.compatibility import xrange
 
 
 class PlotSurface(PlotModeBase):

--- a/sympy/plotting/pygletplot/plot_surface.py
+++ b/sympy/plotting/pygletplot/plot_surface.py
@@ -33,14 +33,14 @@ class PlotSurface(PlotModeBase):
                 except ZeroDivisionError:
                     _e = None
                 if _e is not None:  # update bounding box
-                    for axis in xrange(3):
+                    for axis in range(3):
                         b[axis][0] = min([b[axis][0], _e[axis]])
                         b[axis][1] = max([b[axis][1], _e[axis]])
                 column.append(_e)
                 self._calculating_verts_pos += 1.0
 
             verts.append(column)
-        for axis in xrange(3):
+        for axis in range(3):
             b[axis][2] = b[axis][1] - b[axis][0]
             if b[axis][2] == 0.0:
                 b[axis][2] = 1.0

--- a/sympy/plotting/pygletplot/util.py
+++ b/sympy/plotting/pygletplot/util.py
@@ -105,7 +105,7 @@ def create_bounds():
 def update_bounds(b, v):
     if v is None:
         return
-    for axis in xrange(3):
+    for axis in range(3):
         b[axis][0] = min([b[axis][0], v[axis]])
         b[axis][1] = max([b[axis][1], v[axis]])
 
@@ -122,7 +122,7 @@ def rinterpolate(a_min, a_max, a_value):
 
 
 def interpolate_color(color1, color2, ratio):
-    return tuple(interpolate(color1[i], color2[i], ratio) for i in xrange(3))
+    return tuple(interpolate(color1[i], color2[i], ratio) for i in range(3))
 
 
 def scale_value(v, v_min, v_len):
@@ -173,12 +173,12 @@ def parse_option_string(s):
 
 
 def dot_product(v1, v2):
-    return sum(v1[i]*v2[i] for i in xrange(3))
+    return sum(v1[i]*v2[i] for i in range(3))
 
 
 def vec_sub(v1, v2):
-    return tuple(v1[i] - v2[i] for i in xrange(3))
+    return tuple(v1[i] - v2[i] for i in range(3))
 
 
 def vec_mag(v):
-    return sum(v[i]**2 for i in xrange(3))**(0.5)
+    return sum(v[i]**2 for i in range(3))**(0.5)

--- a/sympy/plotting/pygletplot/util.py
+++ b/sympy/plotting/pygletplot/util.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 from pyglet.gl import *
 from sympy.core import S
+from sympy.core.compatibility import xrange
 
 
 def get_model_matrix(array_type=c_float, glGetMethod=glGetFloatv):

--- a/sympy/polys/benchmarks/bench_galoispolys.py
+++ b/sympy/polys/benchmarks/bench_galoispolys.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 from sympy.polys.galoistools import gf_from_dict, gf_factor, gf_factor_sqf
 from sympy.polys.domains import ZZ
 from sympy import pi, nextprime
+from sympy.core.compatibility import xrange
 
 
 def gathen_poly(n, p, K):

--- a/sympy/polys/benchmarks/bench_galoispolys.py
+++ b/sympy/polys/benchmarks/bench_galoispolys.py
@@ -13,7 +13,7 @@ def gathen_poly(n, p, K):
 
 def shoup_poly(n, p, K):
     f = [K.one] * (n + 1)
-    for i in range(1, n + 1):
+    for i in xrange(1, n + 1):
         f[i] = (f[i - 1]**2 + K.one) % p
     return f
 

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -759,10 +759,10 @@ def dup_mul(f, g, K):
 
     h = []
 
-    for i in range(0, df + dg + 1):
+    for i in xrange(0, df + dg + 1):
         coeff = K.zero
 
-        for j in range(max(0, i - dg), min(df, i) + 1):
+        for j in xrange(max(0, i - dg), min(df, i) + 1):
             coeff += f[j]*g[i - j]
 
         h.append(coeff)
@@ -802,10 +802,10 @@ def dmp_mul(f, g, u, K):
 
     h, v = [], u - 1
 
-    for i in range(0, df + dg + 1):
+    for i in xrange(0, df + dg + 1):
         coeff = dmp_zero(v)
 
-        for j in range(max(0, i - dg), min(df, i) + 1):
+        for j in xrange(max(0, i - dg), min(df, i) + 1):
             coeff = dmp_add(coeff, dmp_mul(f[j], g[i - j], v, K), v, K)
 
         h.append(coeff)
@@ -829,7 +829,7 @@ def dup_sqr(f, K):
     """
     df, h = dup_degree(f), []
 
-    for i in range(0, 2*df + 1):
+    for i in xrange(0, 2*df + 1):
         c = K.zero
 
         jmin = max(0, i - df)
@@ -839,7 +839,7 @@ def dup_sqr(f, K):
 
         jmax = jmin + n // 2 - 1
 
-        for j in range(jmin, jmax + 1):
+        for j in xrange(jmin, jmax + 1):
             c += f[j]*f[i - j]
 
         c += c
@@ -877,7 +877,7 @@ def dmp_sqr(f, u, K):
 
     h, v = [], u - 1
 
-    for i in range(0, 2*df + 1):
+    for i in xrange(0, 2*df + 1):
         c = dmp_zero(v)
 
         jmin = max(0, i - df)
@@ -887,7 +887,7 @@ def dmp_sqr(f, u, K):
 
         jmax = jmin + n // 2 - 1
 
-        for j in range(jmin, jmax + 1):
+        for j in xrange(jmin, jmax + 1):
             c = dmp_add(c, dmp_mul(f[j], f[i - j], v, K), v, K)
 
         c = dmp_mul_ground(c, K(2), v, K)

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -12,6 +12,7 @@ from sympy.polys.densebasic import (
     dmp_ground, dmp_zeros)
 
 from sympy.polys.polyerrors import (ExactQuotientFailed, PolynomialDivisionFailed)
+from sympy.core.compatibility import xrange
 
 def dup_add_term(f, c, i, K):
     """

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -6,6 +6,7 @@ from sympy.core import igcd
 
 from sympy.polys.monomials import monomial_min, monomial_div
 from sympy.polys.orderings import monomial_key
+from sympy.core.compatibility import xrange
 
 import random
 

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -724,7 +724,7 @@ def dmp_zero(u):
     """
     r = []
 
-    for i in range(u):
+    for i in xrange(u):
         r = [r]
 
     return r
@@ -812,7 +812,7 @@ def dmp_ground(c, u):
     if not c:
         return dmp_zero(u)
 
-    for i in range(u + 1):
+    for i in xrange(u + 1):
         c = [c]
 
     return c
@@ -840,7 +840,7 @@ def dmp_zeros(n, u, K):
     if u < 0:
         return [K.zero]*n
     else:
-        return [ dmp_zero(u) for i in range(n) ]
+        return [ dmp_zero(u) for i in xrange(n) ]
 
 
 def dmp_grounds(c, n, u):
@@ -865,7 +865,7 @@ def dmp_grounds(c, n, u):
     if u < 0:
         return [c]*n
     else:
-        return [ dmp_ground(c, u) for i in range(n) ]
+        return [ dmp_ground(c, u) for i in xrange(n) ]
 
 
 def dmp_negative_p(f, u, K):
@@ -928,12 +928,12 @@ def dup_from_dict(f, K):
     n, h = max(f.keys()), []
 
     if type(n) is int:
-        for k in range(n, -1, -1):
+        for k in xrange(n, -1, -1):
             h.append(f.get(k, K.zero))
     else:
         (n,) = n
 
-        for k in range(n, -1, -1):
+        for k in xrange(n, -1, -1):
             h.append(f.get((k,), K.zero))
 
     return dup_strip(h)
@@ -958,7 +958,7 @@ def dup_from_raw_dict(f, K):
 
     n, h = max(f.keys()), []
 
-    for k in range(n, -1, -1):
+    for k in xrange(n, -1, -1):
         h.append(f.get(k, K.zero))
 
     return dup_strip(h)
@@ -997,7 +997,7 @@ def dmp_from_dict(f, u, K):
 
     n, v, h = max(coeffs.keys()), u - 1, []
 
-    for k in range(n, -1, -1):
+    for k in xrange(n, -1, -1):
         coeff = coeffs.get(k)
 
         if coeff is not None:
@@ -1028,7 +1028,7 @@ def dup_to_dict(f, K=None, zero=False):
 
     n, result = dup_degree(f), {}
 
-    for k in range(0, n + 1):
+    for k in xrange(0, n + 1):
         if f[n - k]:
             result[(k,)] = f[n - k]
 
@@ -1053,7 +1053,7 @@ def dup_to_raw_dict(f, K=None, zero=False):
 
     n, result = dup_degree(f), {}
 
-    for k in range(0, n + 1):
+    for k in xrange(0, n + 1):
         if f[n - k]:
             result[k] = f[n - k]
 
@@ -1083,7 +1083,7 @@ def dmp_to_dict(f, u, K=None, zero=False):
 
     n, v, result = dmp_degree(f, u), u - 1, {}
 
-    for k in range(0, n + 1):
+    for k in xrange(0, n + 1):
         h = dmp_to_dict(f[n - k], v)
 
         for exp, coeff in h.items():
@@ -1175,7 +1175,7 @@ def dmp_nest(f, l, K):
     if not isinstance(f, list):
         return dmp_ground(f, l)
 
-    for i in range(l):
+    for i in xrange(l):
         f = [f]
 
     return f
@@ -1234,7 +1234,7 @@ def dup_deflate(f, K):
 
     g = 0
 
-    for i in range(len(f)):
+    for i in xrange(len(f)):
         if not f[-i - 1]:
             continue
 
@@ -1315,7 +1315,7 @@ def dup_multi_deflate(polys, K):
 
         g = 0
 
-        for i in range(len(p)):
+        for i in xrange(len(p)):
             if not p[-i - 1]:
                 continue
 
@@ -1429,7 +1429,7 @@ def _rec_inflate(g, M, v, i, K):
     result = [g[0]]
 
     for coeff in g[1:]:
-        for _ in range(1, M[i]):
+        for _ in xrange(1, M[i]):
             result.append(dmp_zero(w))
 
         result.append(coeff)
@@ -1485,7 +1485,7 @@ def dmp_exclude(f, u, K):
 
     J, F = [], dmp_to_dict(f, u)
 
-    for j in range(0, u + 1):
+    for j in xrange(0, u + 1):
         for monom in F.keys():
             if monom[j]:
                 break
@@ -1862,7 +1862,7 @@ def dup_random(n, a, b, K):
     [-2, -8, 9, -4]
 
     """
-    f = [ K.convert(random.randint(a, b)) for _ in range(0, n + 1) ]
+    f = [ K.convert(random.randint(a, b)) for _ in xrange(0, n + 1) ]
 
     while not f[0]:
         f[0] = K.convert(random.randint(a, b))

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -64,7 +64,7 @@ def dup_integrate(f, m, K):
     for i, c in enumerate(reversed(f)):
         n = i + 1
 
-        for j in range(1, m):
+        for j in xrange(1, m):
             n *= i + j + 1
 
         g.insert(0, K.exquo(c, K(n)))
@@ -99,7 +99,7 @@ def dmp_integrate(f, m, u, K):
     for i, c in enumerate(reversed(f)):
         n = i + 1
 
-        for j in range(1, m):
+        for j in xrange(1, m):
             n *= i + j + 1
 
         g.insert(0, dmp_quo_ground(c, K(n), v, K))
@@ -173,7 +173,7 @@ def dup_diff(f, m, K):
         for coeff in f[:-m]:
             k = n
 
-            for i in range(n - 1, n - m, -1):
+            for i in xrange(n - 1, n - m, -1):
                 k *= i
 
             deriv.append(K(k)*coeff)
@@ -220,7 +220,7 @@ def dmp_diff(f, m, u, K):
         for coeff in f[:-m]:
             k = n
 
-            for i in range(n - 1, n - m, -1):
+            for i in xrange(n - 1, n - m, -1):
                 k *= i
 
             deriv.append(dmp_mul_ground(coeff, K(k), v, K))
@@ -843,7 +843,7 @@ def dup_mirror(f, K):
     """
     f, n, a = list(f), dup_degree(f), -K.one
 
-    for i in range(n - 1, -1, -1):
+    for i in xrange(n - 1, -1, -1):
         f[i], a = a*f[i], -a
 
     return f
@@ -865,7 +865,7 @@ def dup_scale(f, a, K):
     """
     f, n, b = list(f), dup_degree(f), a
 
-    for i in range(n - 1, -1, -1):
+    for i in xrange(n - 1, -1, -1):
         f[i], b = b*f[i], b*a
 
     return f
@@ -887,8 +887,8 @@ def dup_shift(f, a, K):
     """
     f, n = list(f), dup_degree(f)
 
-    for i in range(n, 0, -1):
-        for j in range(0, i):
+    for i in xrange(n, 0, -1):
+        for j in xrange(0, i):
             f[j + 1] += a*f[j]
 
     return f
@@ -914,7 +914,7 @@ def dup_transform(f, p, q, K):
     n = dup_degree(f)
     h, Q = [f[0]], [[K.one]]
 
-    for i in range(0, n):
+    for i in xrange(0, n):
         Q.append(dup_mul(Q[-1], q, K))
 
     for c, q in zip(f[1:], Q[1:]):
@@ -993,10 +993,10 @@ def _dup_right_decompose(f, s, K):
 
     r = n // s
 
-    for i in range(1, s):
+    for i in xrange(1, s):
         coeff = K.zero
 
-        for j in range(0, i):
+        for j in xrange(0, i):
             if not n + j - i in f:
                 continue
 
@@ -1031,7 +1031,7 @@ def _dup_decompose(f, K):
     """Helper function for :func:`dup_decompose`."""
     df = dup_degree(f)
 
-    for s in range(2, df):
+    for s in xrange(2, df):
         if df % s != 0:
             continue
 
@@ -1282,7 +1282,7 @@ def dup_revert(f, n, K):
 
     N = int(_ceil(_log(n, 2)))
 
-    for i in range(1, N + 1):
+    for i in xrange(1, N + 1):
         a = dup_mul_ground(g, K(2), K)
         b = dup_mul(f, dup_sqr(g, K), K)
         g = dup_rem(dup_sub(a, b, K), h, K)

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -39,6 +39,7 @@ from sympy.polys.polyerrors import (
 from sympy.utilities import variations
 
 from math import ceil as _ceil, log as _log
+from sympy.core.compatibility import xrange
 
 def dup_integrate(f, m, K):
     """

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -52,6 +52,8 @@ from sympy.polys.polyconfig import query
 
 from sympy.ntheory import nextprime
 
+from sympy.core.compatibility import xrange
+
 
 def dup_half_gcdex(f, g, K):
     """

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -1242,7 +1242,7 @@ def dup_zz_heu_gcd(f, g, K):
             2*min(f_norm // abs(dup_LC(f, K)),
                   g_norm // abs(dup_LC(g, K))) + 2)
 
-    for i in range(0, HEU_GCD_MAX):
+    for i in xrange(0, HEU_GCD_MAX):
         ff = dup_eval(f, x, K)
         gg = dup_eval(g, x, K)
 
@@ -1367,7 +1367,7 @@ def dmp_zz_heu_gcd(f, g, u, K):
             2*min(f_norm // abs(dmp_ground_LC(f, u, K)),
                   g_norm // abs(dmp_ground_LC(g, u, K))) + 2)
 
-    for i in range(0, HEU_GCD_MAX):
+    for i in xrange(0, HEU_GCD_MAX):
         ff = dmp_eval(f, x, u, K)
         gg = dmp_eval(g, x, u, K)
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -274,7 +274,7 @@ def dup_zz_zassenhaus(f, K):
     # choose a prime number `p` such that `f` be square free in Z_p
     # if there are many factors in Z_p, choose among a few different `p`
     # the one with fewer factors
-    for px in range(3, bound + 1):
+    for px in xrange(3, bound + 1):
         if not isprime(px) or b % px == 0:
             continue
 
@@ -417,10 +417,10 @@ def dup_cyclotomic_p(f, K, irreducible=False):
     n = dup_degree(f)
     g, h = [], []
 
-    for i in range(n, -1, -2):
+    for i in xrange(n, -1, -2):
         g.insert(0, f[i])
 
-    for i in range(n - 1, -1, -2):
+    for i in xrange(n - 1, -1, -2):
         h.insert(0, f[i])
 
     g = dup_sqr(dup_strip(g), K)
@@ -468,7 +468,7 @@ def _dup_cyclotomic_decompose(n, K):
         Q = [ dup_quo(dup_inflate(h, p, K), h, K) for h in H ]
         H.extend(Q)
 
-        for i in range(1, k):
+        for i in xrange(1, k):
             Q = [ dup_inflate(q, p, K) for q in Q ]
             H.extend(Q)
 
@@ -674,7 +674,7 @@ def dmp_zz_wang_lead_coeffs(f, T, cs, E, H, A, u, K):
         c = dmp_one(v, K)
         d = dup_LC(h, K)*cs
 
-        for i in reversed(range(len(E))):
+        for i in reversed(xrange(len(E))):
             k, e, (t, _) = 0, E[i], T[i]
 
             while not (d % e):
@@ -809,7 +809,7 @@ def dmp_zz_diophantine(F, c, A, d, p, u, K):
         m = dmp_nest([K.one, -a], n, K)
         M = dmp_one(n, K)
 
-        for k in K.map(range(0, d)):
+        for k in K.map(xrange(0, d)):
             if dmp_zero_p(c, u):
                 break
 
@@ -848,7 +848,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
 
     d = max(dmp_degree_list(f, u)[1:])
 
-    for j, s, a in zip(range(2, n + 2), S, A):
+    for j, s, a in zip(xrange(2, n + 2), S, A):
         G, w = list(H), j - 1
 
         I, J = A[:j - 2], A[j - 1:]
@@ -864,7 +864,7 @@ def dmp_zz_wang_hensel_lifting(f, H, LC, A, p, u, K):
 
         dj = dmp_degree_in(s, w, w)
 
-        for k in K.map(range(0, dj)):
+        for k in K.map(xrange(0, dj)):
             if dmp_zero_p(c, w):
                 break
 
@@ -954,8 +954,8 @@ def dmp_zz_wang(f, u, K, mod=None, seed=None):
     eez_mod_step = query('EEZ_MODULUS_STEP')
 
     while len(configs) < eez_num_configs:
-        for _ in range(eez_num_tries):
-            A = [ K(randint(-mod, mod)) for _ in range(u) ]
+        for _ in xrange(eez_num_tries):
+            A = [ K(randint(-mod, mod)) for _ in xrange(u) ]
 
             if tuple(A) not in history:
                 history.add(tuple(A))

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -76,6 +76,8 @@ from sympy.utilities import subsets
 
 from math import ceil as _ceil, log as _log
 
+from sympy.core.compatibility import xrange
+
 
 def dup_trial_division(f, factors, K):
     """Determine multiplicities of factors using trial division. """

--- a/sympy/polys/fglmtools.py
+++ b/sympy/polys/fglmtools.py
@@ -29,7 +29,7 @@ def matrix_fglm(F, ring, O_to):
     V = [[domain.one] + [domain.zero] * (len(old_basis) - 1)]
     G = []
 
-    L = [(i, 0) for i in range(ngens)]  # (i, j) corresponds to x_i * S[j]
+    L = [(i, 0) for i in xrange(ngens)]  # (i, j) corresponds to x_i * S[j]
     L.sort(key=lambda k_l: O_to(_incr_k(S[k_l[1]], k_l[0])), reverse=True)
     t = L.pop()
 
@@ -40,10 +40,10 @@ def matrix_fglm(F, ring, O_to):
         v = _matrix_mul(M[t[0]], V[t[1]])
         _lambda = _matrix_mul(P, v)
 
-        if all(_lambda[i] == domain.zero for i in range(s, len(old_basis))):
+        if all(_lambda[i] == domain.zero for i in xrange(s, len(old_basis))):
             # there is a linear combination of v by V
             lt = ring.term_new(_incr_k(S[t[1]], t[0]), domain.one)
-            rest = ring.from_dict(dict([ (S[i], _lambda[i]) for i in range(s) ]))
+            rest = ring.from_dict(dict([ (S[i], _lambda[i]) for i in xrange(s) ]))
 
             g = (lt - rest).set_ring(ring_to)
             if g:
@@ -54,7 +54,7 @@ def matrix_fglm(F, ring, O_to):
             S.append(_incr_k(S[t[1]], t[0]))
             V.append(v)
 
-            L.extend([(i, s) for i in range(ngens)])
+            L.extend([(i, s) for i in xrange(ngens)])
             L = list(set(L))
             L.sort(key=lambda k_l: O_to(_incr_k(S[k_l[1]], k_l[0])), reverse=True)
 
@@ -72,29 +72,29 @@ def _incr_k(m, k):
 
 
 def _identity_matrix(n, domain):
-    M = [[domain.zero]*n for _ in range(n)]
+    M = [[domain.zero]*n for _ in xrange(n)]
 
-    for i in range(n):
+    for i in xrange(n):
         M[i][i] = domain.one
 
     return M
 
 
 def _matrix_mul(M, v):
-    return [sum([row[i] * v[i] for i in range(len(v))]) for row in M]
+    return [sum([row[i] * v[i] for i in xrange(len(v))]) for row in M]
 
 
 def _update(s, _lambda, P):
     """
     Update ``P`` such that for the updated `P'` `P' v = e_{s}`.
     """
-    k = min([j for j in range(s, len(_lambda)) if _lambda[j] != 0])
+    k = min([j for j in xrange(s, len(_lambda)) if _lambda[j] != 0])
 
-    for r in range(len(_lambda)):
+    for r in xrange(len(_lambda)):
         if r != k:
-            P[r] = [P[r][j] - (P[k][j] * _lambda[r]) / _lambda[k] for j in range(len(P[r]))]
+            P[r] = [P[r][j] - (P[k][j] * _lambda[r]) / _lambda[k] for j in xrange(len(P[r]))]
 
-    P[k] = [P[k][j] / _lambda[k] for j in range(len(P[k]))]
+    P[k] = [P[k][j] / _lambda[k] for j in xrange(len(P[k]))]
     P[k], P[s] = P[s], P[k]
 
     return P
@@ -112,7 +112,7 @@ def _representing_matrices(basis, G, ring):
         return tuple([0] * i + [1] + [0] * (u - i))
 
     def representing_matrix(m):
-        M = [[domain.zero] * len(basis) for _ in range(len(basis))]
+        M = [[domain.zero] * len(basis) for _ in xrange(len(basis))]
 
         for i, v in enumerate(basis):
             r = ring.term_new(monomial_mul(m, v), domain.one).rem(G)
@@ -123,7 +123,7 @@ def _representing_matrices(basis, G, ring):
 
         return M
 
-    return [representing_matrix(var(i)) for i in range(u + 1)]
+    return [representing_matrix(var(i)) for i in xrange(u + 1)]
 
 
 def _basis(G, ring):
@@ -142,7 +142,7 @@ def _basis(G, ring):
         t = candidates.pop()
         basis.append(t)
 
-        new_candidates = [_incr_k(t, k) for k in range(ring.ngens)
+        new_candidates = [_incr_k(t, k) for k in xrange(ring.ngens)
             if all(monomial_div(_incr_k(t, k), lmg) is None
             for lmg in leading_monomials)]
         candidates.extend(new_candidates)

--- a/sympy/polys/fglmtools.py
+++ b/sympy/polys/fglmtools.py
@@ -2,6 +2,7 @@
 from __future__ import print_function, division
 
 from sympy.polys.monomials import monomial_mul, monomial_div
+from sympy.core.compatibility import xrange
 
 def matrix_fglm(F, ring, O_to):
     """

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from random import uniform
 from math import ceil as _ceil, sqrt as _sqrt
 
-from sympy.core.compatibility import SYMPY_INTS
+from sympy.core.compatibility import SYMPY_INTS, xrange
 from sympy.core.mul import prod
 from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -265,12 +265,12 @@ def gf_from_dict(f, p, K):
     n, h = max(f.keys()), []
 
     if isinstance(n, SYMPY_INTS):
-        for k in range(n, -1, -1):
+        for k in xrange(n, -1, -1):
             h.append(f.get(k, K.zero) % p)
     else:
         (n,) = n
 
-        for k in range(n, -1, -1):
+        for k in xrange(n, -1, -1):
             h.append(f.get((k,), K.zero) % p)
 
     return gf_trunc(h, p)
@@ -293,7 +293,7 @@ def gf_to_dict(f, p, symmetric=True):
     """
     n, result = gf_degree(f), {}
 
-    for k in range(0, n + 1):
+    for k in xrange(0, n + 1):
         if symmetric:
             a = gf_int(f[n - k], p)
         else:
@@ -544,10 +544,10 @@ def gf_mul(f, g, p, K):
     dh = df + dg
     h = [0]*(dh + 1)
 
-    for i in range(0, dh + 1):
+    for i in xrange(0, dh + 1):
         coeff = K.zero
 
-        for j in range(max(0, i - dg), min(i, df) + 1):
+        for j in xrange(max(0, i - dg), min(i, df) + 1):
             coeff += f[j]*g[i - j]
 
         h[i] = coeff % p
@@ -574,7 +574,7 @@ def gf_sqr(f, p, K):
     dh = 2*df
     h = [0]*(dh + 1)
 
-    for i in range(0, dh + 1):
+    for i in xrange(0, dh + 1):
         coeff = K.zero
 
         jmin = max(0, i - df)
@@ -584,7 +584,7 @@ def gf_sqr(f, p, K):
 
         jmax = jmin + n // 2 - 1
 
-        for j in range(jmin, jmax + 1):
+        for j in xrange(jmin, jmax + 1):
             coeff += f[j]*f[i - j]
 
         coeff += coeff
@@ -698,10 +698,10 @@ def gf_div(f, g, p, K):
 
     h, dq, dr = list(f), df - dg, dg - 1
 
-    for i in range(0, df + 1):
+    for i in xrange(0, df + 1):
         coeff = h[i]
 
-        for j in range(max(0, dg - i), min(df - i, dr) + 1):
+        for j in xrange(max(0, dg - i), min(df - i, dr) + 1):
             coeff -= h[i + j - dg] * g[dg - j]
 
         if i <= dq:
@@ -757,10 +757,10 @@ def gf_quo(f, g, p, K):
 
     h, dq, dr = f[:], df - dg, dg - 1
 
-    for i in range(0, dq + 1):
+    for i in xrange(0, dq + 1):
         coeff = h[i]
 
-        for j in range(max(0, dg - i), min(df - i, dr) + 1):
+        for j in xrange(max(0, dg - i), min(df - i, dr) + 1):
             coeff -= h[i + j - dg] * g[dg - j]
 
         h[i] = (coeff * inv) % p
@@ -1373,7 +1373,7 @@ def gf_random(n, p, K):
     [1, 2, 3, 2, 1, 1, 1, 2, 0, 4, 2]
 
     """
-    return [K.one] + [ K(int(uniform(0, p))) for i in range(0, n) ]
+    return [K.one] + [ K(int(uniform(0, p))) for i in xrange(0, n) ]
 
 
 def gf_irreducible(n, p, K):
@@ -1420,7 +1420,7 @@ def gf_irred_p_ben_or(f, p, K):
     if n < 5:
         H = h = gf_pow_mod([K.one, K.zero], p, f, p, K)
 
-        for i in range(0, n//2):
+        for i in xrange(0, n//2):
             g = gf_sub(h, [K.one, K.zero], p, K)
 
             if gf_gcd(f, g, p, K) == [K.one]:
@@ -1430,7 +1430,7 @@ def gf_irred_p_ben_or(f, p, K):
     else:
         b = gf_frobenius_monomial_base(f, p, K)
         H = h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
-        for i in range(0, n//2):
+        for i in xrange(0, n//2):
             g = gf_sub(h, [K.one, K.zero], p, K)
             if gf_gcd(f, g, p, K) == [K.one]:
                 h = gf_frobenius_map(h, f, b, p, K)
@@ -1470,7 +1470,7 @@ def gf_irred_p_rabin(f, p, K):
     b = gf_frobenius_monomial_base(f, p, K)
     h = b[1]
 
-    for i in range(1, n):
+    for i in xrange(1, n):
         if i in indices:
             g = gf_sub(h, x, p, K)
 
@@ -1637,7 +1637,7 @@ def gf_sqf_list(f, p, K, all=False):
         if not sqf:
             d = gf_degree(f) // r
 
-            for i in range(0, d + 1):
+            for i in xrange(0, d + 1):
                 f[i] = f[i*r]
 
             f, n = f[:d + 1], n*r
@@ -1676,10 +1676,10 @@ def gf_Qmatrix(f, p, K):
     q = [K.one] + [K.zero]*(n - 1)
     Q = [list(q)] + [[]]*(n - 1)
 
-    for i in range(1, (n - 1)*r + 1):
+    for i in xrange(1, (n - 1)*r + 1):
         qq, c = [(-q[-1]*f[-1]) % p], q[-1]
 
-        for j in range(1, n):
+        for j in xrange(1, n):
             qq.append((q[j - 1] - c*f[-j - 1]) % p)
 
         if not (i % r):
@@ -1709,11 +1709,11 @@ def gf_Qbasis(Q, p, K):
     """
     Q, n = [ list(q) for q in Q ], len(Q)
 
-    for k in range(0, n):
+    for k in xrange(0, n):
         Q[k][k] = (Q[k][k] - K.one) % p
 
-    for k in range(0, n):
-        for i in range(k, n):
+    for k in xrange(0, n):
+        for i in xrange(k, n):
             if Q[k][i]:
                 break
         else:
@@ -1721,23 +1721,23 @@ def gf_Qbasis(Q, p, K):
 
         inv = K.invert(Q[k][i], p)
 
-        for j in range(0, n):
+        for j in xrange(0, n):
             Q[j][i] = (Q[j][i]*inv) % p
 
-        for j in range(0, n):
+        for j in xrange(0, n):
             t = Q[j][k]
             Q[j][k] = Q[j][i]
             Q[j][i] = t
 
-        for i in range(0, n):
+        for i in xrange(0, n):
             if i != k:
                 q = Q[k][i]
 
-                for j in range(0, n):
+                for j in xrange(0, n):
                     Q[j][i] = (Q[j][i] - Q[j][k]*q) % p
 
-    for i in range(0, n):
-        for j in range(0, n):
+    for i in xrange(0, n):
+        for j in xrange(0, n):
             if i == j:
                 Q[i][j] = (K.one - Q[i][j]) % p
             else:
@@ -1774,7 +1774,7 @@ def gf_berlekamp(f, p, K):
 
     factors = [f]
 
-    for k in range(1, len(V)):
+    for k in xrange(1, len(V)):
         for f in list(factors):
             s = K.zero
 
@@ -1893,7 +1893,7 @@ def gf_edf_zassenhaus(f, n, p, K):
         if p == 2:
             h = r
 
-            for i in range(0, 2**(n*N - 1)):
+            for i in xrange(0, 2**(n*N - 1)):
                 r = gf_pow_mod(r, 2, f, p, K)
                 h = gf_add(h, r, p, K)
 
@@ -1948,14 +1948,14 @@ def gf_ddf_shoup(f, p, K):
     # U[i] = x**(p**i)
     U = [[K.one, K.zero], h] + [K.zero]*(k - 1)
 
-    for i in range(2, k + 1):
+    for i in xrange(2, k + 1):
         U[i] = gf_frobenius_map(U[i-1], f, b, p, K)
 
     h, U = U[k], U[:k]
     # V[i] = x**(p**(k*(i+1)))
     V = [h] + [K.zero]*(k - 1)
 
-    for i in range(1, k):
+    for i in xrange(1, k):
         V[i] = gf_compose_mod(V[i - 1], h, f, p, K)
 
     factors = []

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -608,7 +608,7 @@ def _f5b(F, ring):
         F = B
         B = []
 
-        for i in range(len(F)):
+        for i in xrange(len(F)):
             p = F[i]
             r = p.rem(F[:i])
 
@@ -619,11 +619,11 @@ def _f5b(F, ring):
             break
 
     # basis
-    B = [lbp(sig(ring.zero_monom, i + 1), F[i], i + 1) for i in range(len(F))]
+    B = [lbp(sig(ring.zero_monom, i + 1), F[i], i + 1) for i in xrange(len(F))]
     B.sort(key=lambda f: order(Polyn(f).LM), reverse=True)
 
     # critical pairs
-    CP = [critical_pair(B[i], B[j], ring) for i in range(len(B)) for j in range(i + 1, len(B))]
+    CP = [critical_pair(B[i], B[j], ring) for i in xrange(len(B)) for j in xrange(i + 1, len(B))]
     CP.sort(key=lambda cp: cp_key(cp, ring), reverse=True)
 
     k = len(B)
@@ -730,8 +730,8 @@ def is_groebner(G, ring):
     """
     Check if G is a Groebner basis.
     """
-    for i in range(len(G)):
-        for j in range(i + 1, len(G)):
+    for i in xrange(len(G)):
+        for j in xrange(i + 1, len(G)):
             s = spoly(G[i], G[j])
             s = s.rem(G)
             if s:

--- a/sympy/polys/groebnertools.py
+++ b/sympy/polys/groebnertools.py
@@ -7,6 +7,7 @@ from sympy.polys.orderings import lex
 from sympy.polys.polyerrors import DomainError
 from sympy.polys.polyconfig import query
 from sympy.core.symbol import Dummy
+from sympy.core.compatibility import xrange
 
 def groebner(seq, ring, method=None):
     """

--- a/sympy/polys/heuristicgcd.py
+++ b/sympy/polys/heuristicgcd.py
@@ -69,7 +69,7 @@ def heugcd(f, g):
             2*min(f_norm // abs(f.LC),
                   g_norm // abs(g.LC)) + 2)
 
-    for i in range(0, HEU_GCD_MAX):
+    for i in xrange(0, HEU_GCD_MAX):
         ff = f.evaluate(x0, x)
         gg = g.evaluate(x0, x)
 

--- a/sympy/polys/heuristicgcd.py
+++ b/sympy/polys/heuristicgcd.py
@@ -1,6 +1,7 @@
 """Heuristic polynomial GCD algorithm (HEUGCD). """
 
 from __future__ import print_function, division
+from sympy.core.compatibility import xrange
 
 HEU_GCD_MAX = 6
 

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -286,7 +286,7 @@ class MonomialOps(object):
         return ns[name]
 
     def _vars(self, name):
-        return [ "%s%s" % (name, i) for i in range(self.ngens) ]
+        return [ "%s%s" % (name, i) for i in xrange(self.ngens) ]
 
     def mul(self):
         name = "monomial_mul"
@@ -353,7 +353,7 @@ class MonomialOps(object):
         """)
         A = self._vars("a")
         B = self._vars("b")
-        RAB = [ "r%(i)s = a%(i)s - b%(i)s\n    if r%(i)s < 0: return None" % dict(i=i) for i in range(self.ngens) ]
+        RAB = [ "r%(i)s = a%(i)s - b%(i)s\n    if r%(i)s < 0: return None" % dict(i=i) for i in xrange(self.ngens) ]
         R = self._vars("r")
         code = template % dict(name=name, A=", ".join(A), B=", ".join(B), RAB="\n    ".join(RAB), R=", ".join(R))
         return self._build(code, name)
@@ -482,7 +482,7 @@ class Monomial(PicklableWithSlots):
         elif n > 0:
             exponents = self.exponents
 
-            for i in range(1, n):
+            for i in xrange(1, n):
                 exponents = monomial_mul(exponents, self.exponents)
 
             return self.rebuild(exponents)

--- a/sympy/polys/monomials.py
+++ b/sympy/polys/monomials.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from textwrap import dedent
 
 from sympy.core import S, C, Symbol, Mul, Tuple, Expr, sympify
-from sympy.core.compatibility import exec_, iterable
+from sympy.core.compatibility import exec_, iterable, xrange
 from sympy.polys.polyutils import PicklableWithSlots, dict_from_expr
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.utilities import public

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -830,7 +830,7 @@ def field_isomorphism_pslq(a, b):
 
     n, m, prev = 100, b.minpoly.degree(), None
 
-    for i in xrange(1, 5):
+    for i in range(1, 5):
         A = a.root.evalf(n)
         B = b.root.evalf(n)
 

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -43,6 +43,8 @@ from sympy.ntheory import sieve
 from sympy.ntheory.factor_ import divisors
 from sympy.mpmath import pslq, mp
 
+from sympy.core.compatibility import xrange
+
 
 def _choose_factor(factors, x, v, prec=200):
     """

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -830,11 +830,11 @@ def field_isomorphism_pslq(a, b):
 
     n, m, prev = 100, b.minpoly.degree(), None
 
-    for i in range(1, 5):
+    for i in xrange(1, 5):
         A = a.root.evalf(n)
         B = b.root.evalf(n)
 
-        basis = [1, B] + [ B**i for i in range(2, m) ] + [A]
+        basis = [1, B] + [ B**i for i in xrange(2, m) ] + [A]
 
         dps, mp.dps = mp.dps, n
         coeffs = pslq(basis, maxcoeff=int(1e10), maxsteps=1000)

--- a/sympy/polys/orthopolys.py
+++ b/sympy/polys/orthopolys.py
@@ -16,6 +16,8 @@ from sympy.polys.densearith import (
 
 from sympy.polys.domains import ZZ, QQ
 
+from sympy.core.compatibility import xrange
+
 
 def dup_jacobi(n, a, b, K):
     """Low-level implementation of Jacobi polynomials. """

--- a/sympy/polys/orthopolys.py
+++ b/sympy/polys/orthopolys.py
@@ -21,7 +21,7 @@ def dup_jacobi(n, a, b, K):
     """Low-level implementation of Jacobi polynomials. """
     seq = [[K.one], [(a + b + K(2))/K(2), (a - b)/K(2)]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         den = K(i)*(a + b + i)*(a + b + K(2)*i - K(2))
         f0 = (a + b + K(2)*i - K.one) * (a*a - b*b) / (K(2)*den)
         f1 = (a + b + K(2)*i - K.one) * (a + b + K(2)*i - K(2)) * (a + b + K(2)*i) / (K(2)*den)
@@ -58,7 +58,7 @@ def dup_gegenbauer(n, a, K):
     """Low-level implementation of Gegenbauer polynomials. """
     seq = [[K.one], [K(2)*a, K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         f1 = K(2) * (i + a - K.one) / i
         f2 = (i + K(2)*a - K(2)) / i
         p1 = dup_mul_ground(dup_lshift(seq[-1], 1, K), f1, K)
@@ -92,7 +92,7 @@ def dup_chebyshevt(n, K):
     """Low-level implementation of Chebyshev polynomials of the 1st kind. """
     seq = [[K.one], [K.one, K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2), K)
         seq.append(dup_sub(a, seq[-2], K))
 
@@ -123,7 +123,7 @@ def dup_chebyshevu(n, K):
     """Low-level implementation of Chebyshev polynomials of the 2nd kind. """
     seq = [[K.one], [K(2), K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2), K)
         seq.append(dup_sub(a, seq[-2], K))
 
@@ -154,7 +154,7 @@ def dup_hermite(n, K):
     """Low-level implementation of Hermite polynomials. """
     seq = [[K.one], [K(2), K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         a = dup_lshift(seq[-1], 1, K)
         b = dup_mul_ground(seq[-2], K(i - 1), K)
 
@@ -188,7 +188,7 @@ def dup_legendre(n, K):
     """Low-level implementation of Legendre polynomials. """
     seq = [[K.one], [K.one, K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2*i - 1, i), K)
         b = dup_mul_ground(seq[-2], K(i - 1, i), K)
 
@@ -220,7 +220,7 @@ def dup_laguerre(n, alpha, K):
     """Low-level implementation of Laguerre polynomials. """
     seq = [[K.zero], [K.one]]
 
-    for i in range(1, n + 1):
+    for i in xrange(1, n + 1):
         a = dup_mul(seq[-1], [-K.one/i, alpha/i + K(2*i - 1)/i], K)
         b = dup_mul_ground(seq[-2], alpha/i + K(i - 1)/i, K)
 
@@ -258,7 +258,7 @@ def dup_spherical_bessel_fn(n, K):
     """ Low-level implementation of fn(n, x) """
     seq = [[K.one], [K.one, K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(2*i - 1), K)
         seq.append(dup_sub(a, seq[-2], K))
 
@@ -269,7 +269,7 @@ def dup_spherical_bessel_fn_minus(n, K):
     """ Low-level implementation of fn(-n, x) """
     seq = [[K.one, K.zero], [K.zero]]
 
-    for i in range(2, n + 1):
+    for i in xrange(2, n + 1):
         a = dup_mul_ground(dup_lshift(seq[-1], 1, K), K(3 - 2*i), K)
         seq.append(dup_sub(a, seq[-2], K))
 

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -136,7 +136,7 @@ def apart_undetermined_coeffs(P, Q):
     for f, k in factors:
         n, q = f.degree(), Q
 
-        for i in range(1, k + 1):
+        for i in xrange(1, k + 1):
             coeffs, q = take(X, n), q.quo(f)
             partial.append((coeffs, q, f, i))
             symbols.extend(coeffs)

--- a/sympy/polys/partfrac.py
+++ b/sympy/polys/partfrac.py
@@ -10,6 +10,7 @@ from sympy.polys.polyerrors import PolynomialError
 from sympy.core import S, Add, sympify, Function, Lambda, Dummy, Expr
 from sympy.core.basic import preorder_traversal
 from sympy.utilities import numbered_symbols, take, xthreaded, public
+from sympy.core.compatibility import xrange
 
 @xthreaded
 @public

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -17,6 +17,8 @@ from sympy.utilities import numbered_symbols, take, public
 
 from sympy.core import S, Basic, Add, Mul
 
+from sympy.core.compatibility import xrange
+
 
 @public
 def symmetrize(F, *gens, **args):

--- a/sympy/polys/polyfuncs.py
+++ b/sympy/polys/polyfuncs.py
@@ -84,7 +84,7 @@ def symmetrize(F, *gens, **args):
     polys, symbols = [], opt.symbols
     gens, dom = opt.gens, opt.domain
 
-    for i in range(0, len(gens)):
+    for i in xrange(0, len(gens)):
         poly = symmetric_poly(i + 1, gens, polys=True)
         polys.append((next(symbols), poly.set_domain(dom)))
 

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -22,7 +22,7 @@ from sympy.polys.rationaltools import together
 from sympy.simplify import simplify, powsimp
 from sympy.utilities import default_sort_key, public
 
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, xrange
 
 
 def roots_linear(f):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -314,7 +314,7 @@ def roots_binomial(f):
 
     roots, I = [], S.ImaginaryUnit
 
-    for k in range(n):
+    for k in xrange(n):
         zeta = exp(2*k*S.Pi*I/n).expand(complex=True)
         roots.append((alpha*zeta).expand(power_base=False))
 
@@ -370,7 +370,7 @@ def roots_cyclotomic(f, factor=False):
     """Compute roots of cyclotomic polynomials. """
     L, U = _inv_totient_estimate(f.degree())
 
-    for n in range(L, U + 1):
+    for n in xrange(L, U + 1):
         g = cyclotomic_poly(n, f.gen, polys=True)
 
         if f == g:
@@ -381,7 +381,7 @@ def roots_cyclotomic(f, factor=False):
     roots = []
 
     if not factor:
-        for k in range(1, n + 1):
+        for k in xrange(1, n + 1):
             if igcd(k, n) == 1:
                 roots.append(exp(2*k*S.Pi*I/n).expand(complex=True))
     else:

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -10,6 +10,8 @@ from sympy.core.exprtools import decompose_power
 from sympy.core import S, Add, Mul, Pow, expand_mul, expand_multinomial
 from sympy.assumptions import ask, Q
 
+from sympy.core.compatibility import xrange
+
 import re
 
 _gens_order = {

--- a/sympy/polys/polyutils.py
+++ b/sympy/polys/polyutils.py
@@ -359,7 +359,7 @@ def _dict_reorder(rep, gens, new_gens):
     monoms = rep.keys()
     coeffs = rep.values()
 
-    new_monoms = [ [] for _ in range(len(rep)) ]
+    new_monoms = [ [] for _ in xrange(len(rep)) ]
     used_indices = set()
 
     for gen in new_gens:

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -239,7 +239,7 @@ class PolyRing(DefaultPrinting, IPolys):
         """Return a list of polynomial generators. """
         one = self.domain.one
         _gens = []
-        for i in range(self.ngens):
+        for i in xrange(self.ngens):
             expv = self.monomial_basis(i)
             poly = self.zero
             poly[expv] = one
@@ -717,7 +717,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
                 else:
                     scoeff = ''
             sexpv = []
-            for i in range(ngens):
+            for i in xrange(ngens):
                 exp = expv[i]
                 if not exp:
                     continue

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -9,7 +9,7 @@ from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol, symbols as _symbols
 from sympy.core.numbers import igcd
 from sympy.core.sympify import CantSympify, sympify
-from sympy.core.compatibility import is_sequence, reduce, string_types
+from sympy.core.compatibility import is_sequence, reduce, string_types, xrange
 from sympy.ntheory.multinomial import multinomial_coefficients
 from sympy.polys.monomials import MonomialOps
 from sympy.polys.orderings import lex

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -77,13 +77,13 @@ def dup_root_upper_bound(f, K):
 
     f = list(reversed(f))
 
-    for i in range(0, n):
+    for i in xrange(0, n):
         if f[i] >= 0:
             continue
 
         a, Q = K.log(-f[i], 2), []
 
-        for j in range(i + 1, n):
+        for j in xrange(i + 1, n):
 
             if f[j] <= 0:
                 continue
@@ -192,7 +192,7 @@ def dup_inner_refine_real_root(f, M, K, eps=None, steps=None, disjoint=None, fas
             d), K, fast=fast)
 
     if eps is not None and steps is not None:
-        for i in range(0, steps):
+        for i in xrange(0, steps):
             if abs(F(a, c) - F(b, d)) >= eps:
                 f, (a, b, c, d) = dup_step_refine_real_root(f, (a, b, c, d), K, fast=fast)
             else:
@@ -203,7 +203,7 @@ def dup_inner_refine_real_root(f, M, K, eps=None, steps=None, disjoint=None, fas
                 f, (a, b, c, d) = dup_step_refine_real_root(f, (a, b, c, d), K, fast=fast)
 
         if steps is not None:
-            for i in range(0, steps):
+            for i in xrange(0, steps):
                 f, (a, b, c, d) = dup_step_refine_real_root(f, (a, b, c, d), K, fast=fast)
 
     if disjoint is not None:
@@ -1687,7 +1687,7 @@ class RealInterval(object):
 
     def refine_step(self, steps=1):
         """Perform several steps of real root refinement algorithm. """
-        for _ in range(steps):
+        for _ in xrange(steps):
             self = self._inner_refine()
 
         return self
@@ -1815,7 +1815,7 @@ class ComplexInterval(object):
 
     def refine_step(self, steps=1):
         """Perform several steps of complex root refinement algorithm. """
-        for _ in range(steps):
+        for _ in xrange(steps):
             self = self._inner_refine()
 
         return self

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -30,6 +30,8 @@ from sympy.polys.polyerrors import (
     RefinementFailed,
     DomainError)
 
+from sympy.core.compatibility import xrange
+
 def dup_sturm(f, K):
     """
     Computes the Sturm sequence of ``f`` in ``F[x]``.

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -295,7 +295,7 @@ class RootOf(Expr):
 
         roots = []
 
-        for index in range(0, reals_count):
+        for index in xrange(0, reals_count):
             roots.append(cls._reals_index(reals, index))
 
         return roots
@@ -311,14 +311,14 @@ class RootOf(Expr):
 
         roots = []
 
-        for index in range(0, reals_count):
+        for index in xrange(0, reals_count):
             roots.append(cls._reals_index(reals, index))
 
         complexes = cls._get_complexes(factors)
         complexes = cls._complexes_sorted(complexes)
         complexes_count = cls._count_roots(complexes)
 
-        for index in range(0, complexes_count):
+        for index in xrange(0, complexes_count):
             roots.append(cls._complexes_index(complexes, index))
 
         return roots

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -30,6 +30,8 @@ from sympy.mpmath.libmp.libmpf import prec_to_dps
 
 from sympy.utilities import lambdify, public
 
+from sympy.core.compatibility import xrange
+
 _reals_cache = {}
 _complexes_cache = {}
 

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -30,6 +30,8 @@ from sympy.ntheory import nextprime
 
 from sympy.utilities import subsets, public
 
+from sympy.core.compatibility import xrange
+
 
 @public
 def swinnerton_dyer_poly(n, x=None, **args):

--- a/sympy/polys/specialpolys.py
+++ b/sympy/polys/specialpolys.py
@@ -47,7 +47,7 @@ def swinnerton_dyer_poly(n, x=None, **args):
     if n > 3:
         p = 2
         a = [sqrt(2)]
-        for i in range(2, n + 1):
+        for i in xrange(2, n + 1):
             p = nextprime(p)
             a.append(sqrt(p))
         return minimal_polynomial(Add(*a), x, polys=args.get('polys', False))
@@ -123,11 +123,11 @@ def interpolating_poly(n, x, X='x', Y='y'):
 
     coeffs = []
 
-    for i in range(0, n):
+    for i in xrange(0, n):
         numer = []
         denom = []
 
-        for j in range(0, n):
+        for j in xrange(0, n):
             if i == j:
                 continue
 
@@ -144,7 +144,7 @@ def interpolating_poly(n, x, X='x', Y='y'):
 
 def fateman_poly_F_1(n):
     """Fateman's GCD benchmark: trivial GCD """
-    Y = [ Symbol('y_' + str(i)) for i in range(0, n + 1) ]
+    Y = [ Symbol('y_' + str(i)) for i in xrange(0, n + 1) ]
 
     y_0, y_1 = Y[0], Y[1]
 
@@ -163,12 +163,12 @@ def dmp_fateman_poly_F_1(n, K):
     """Fateman's GCD benchmark: trivial GCD """
     u = [K(1), K(0)]
 
-    for i in range(0, n):
+    for i in xrange(0, n):
         u = [dmp_one(i, K), u]
 
     v = [K(1), K(0), K(0)]
 
-    for i in range(0, n):
+    for i in xrange(0, n):
         v = [dmp_one(i, K), dmp_zero(i), v]
 
     m = n - 1
@@ -191,7 +191,7 @@ def dmp_fateman_poly_F_1(n, K):
 
 def fateman_poly_F_2(n):
     """Fateman's GCD benchmark: linearly dense quartic inputs """
-    Y = [ Symbol('y_' + str(i)) for i in range(0, n + 1) ]
+    Y = [ Symbol('y_' + str(i)) for i in xrange(0, n + 1) ]
 
     y_0 = Y[0]
 
@@ -209,7 +209,7 @@ def dmp_fateman_poly_F_2(n, K):
     """Fateman's GCD benchmark: linearly dense quartic inputs """
     u = [K(1), K(0)]
 
-    for i in range(0, n - 1):
+    for i in xrange(0, n - 1):
         u = [dmp_one(i, K), u]
 
     m = n - 1
@@ -228,7 +228,7 @@ def dmp_fateman_poly_F_2(n, K):
 
 def fateman_poly_F_3(n):
     """Fateman's GCD benchmark: sparse inputs (deg f ~ vars f) """
-    Y = [ Symbol('y_' + str(i)) for i in range(0, n + 1) ]
+    Y = [ Symbol('y_' + str(i)) for i in xrange(0, n + 1) ]
 
     y_0 = Y[0]
 
@@ -246,7 +246,7 @@ def dmp_fateman_poly_F_3(n, K):
     """Fateman's GCD benchmark: sparse inputs (deg f ~ vars f) """
     u = dup_from_raw_dict({n + 1: K.one}, K)
 
-    for i in range(0, n - 1):
+    for i in xrange(0, n - 1):
         u = dmp_add_term([u], dmp_one(i, K), n + 1, i + 1, K)
 
     v = dmp_add_term(u, dmp_ground(K(2), n - 2), 0, n, K)

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -611,7 +611,7 @@ def test_dmp_content():
 
     f, g, F = 3*y**2 + 2*y + 1, 1, 0
 
-    for i in xrange(0, 5):
+    for i in range(0, 5):
         g *= f
         F += x**i*g
 
@@ -634,7 +634,7 @@ def test_dmp_primitive():
 
     f, g, F = 3*y**2 + 2*y + 1, 1, 0
 
-    for i in xrange(0, 5):
+    for i in range(0, 5):
         g *= f
         F += x**i*g
 

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -611,7 +611,7 @@ def test_dmp_content():
 
     f, g, F = 3*y**2 + 2*y + 1, 1, 0
 
-    for i in range(0, 5):
+    for i in xrange(0, 5):
         g *= f
         F += x**i*g
 
@@ -634,7 +634,7 @@ def test_dmp_primitive():
 
     f, g, F = 3*y**2 + 2*y + 1, 1, 0
 
-    for i in range(0, 5):
+    for i in xrange(0, 5):
         g *= f
         F += x**i*g
 

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -157,7 +157,7 @@ def test_dup_zz_factor():
 
     f = x**4 + x + 1
 
-    for i in range(0, 20):
+    for i in xrange(0, 20):
         assert R.dup_zz_factor(f) == (1, [(f, 1)])
 
     assert R.dup_zz_factor(x**2 + 2*x + 2) == \

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -11,6 +11,8 @@ from sympy.polys.specialpolys import f_polys, w_polys
 from sympy import nextprime, sin, sqrt, I
 from sympy.utilities.pytest import raises
 
+from sympy.core.compatibility import xrange
+
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = f_polys()
 w_1, w_2 = w_polys()
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1543,8 +1543,8 @@ class LatexPrinter(Printer):
     def _print_DiagramGrid(self, grid):
         latex_result = "\\begin{array}{%s}\n" % ("c" * grid.width)
 
-        for i in range(grid.height):
-            for j in range(grid.width):
+        for i in xrange(grid.height):
+            for j in xrange(grid.width):
                 if grid[i, j]:
                     latex_result += latex(grid[i, j])
                 latex_result += " "

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -17,7 +17,7 @@ from .precedence import precedence, PRECEDENCE
 import sympy.mpmath.libmp as mlib
 from sympy.mpmath.libmp import prec_to_dps
 
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, xrange
 from sympy.utilities.iterables import has_variety
 
 import re

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -5,7 +5,7 @@ from sympy.core.function import _coeff_isneg
 from sympy.utilities import group
 from sympy.utilities.iterables import has_variety
 from sympy.core.sympify import SympifyError
-from sympy.core.compatibility import u
+from sympy.core.compatibility import u, xrange
 
 from sympy.printing.printer import Printer
 from sympy.printing.str import sstr

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -756,16 +756,16 @@ class PrettyPrinter(Printer):
         len_args = len(pexpr.args)
 
         # max widths
-        maxw = [max([P[i, j].width() for i in range(len_args)])
-                for j in range(2)]
+        maxw = [max([P[i, j].width() for i in xrange(len_args)])
+                for j in xrange(2)]
 
         # FIXME: Refactor this code and matrix into some tabular environment.
         # drawing result
         D = None
 
-        for i in range(len_args):
+        for i in xrange(len_args):
             D_row = None
-            for j in range(2):
+            for j in xrange(2):
                 p = P[i, j]
                 assert p.width() <= maxw[j]
 
@@ -1205,14 +1205,14 @@ class PrettyPrinter(Printer):
 
         # Convert to pretty forms. Add parens to Add instances if there
         # is more than one term in the numer/denom
-        for i in range(0, len(a)):
+        for i in xrange(0, len(a)):
             if (a[i].is_Add and len(a) > 1) or (i != len(a) - 1 and
                     isinstance(a[i], (Integral, Piecewise, Product, Sum))):
                 a[i] = prettyForm(*self._print(a[i]).parens())
             else:
                 a[i] = self._print(a[i])
 
-        for i in range(0, len(b)):
+        for i in xrange(0, len(b)):
             if (b[i].is_Add and len(b) > 1) or (i != len(b) - 1 and
                     isinstance(b[i], (Integral, Piecewise, Product, Sum))):
                 b[i] = prettyForm(*self._print(b[i]).parens())
@@ -1722,8 +1722,8 @@ class PrettyPrinter(Printer):
         from sympy.matrices import Matrix
         from sympy import Symbol
         matrix = Matrix([[grid[i, j] if grid[i, j] else Symbol(" ")
-                          for j in range(grid.width)]
-                         for i in range(grid.height)])
+                          for j in xrange(grid.width)]
+                         for i in xrange(grid.height)])
         return self._print_matrix_contents(matrix)
 
     def _print_FreeModuleElement(self, m):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -757,7 +757,7 @@ class PrettyPrinter(Printer):
 
         # max widths
         maxw = [max([P[i, j].width() for i in xrange(len_args)])
-                for j in xrange(2)]
+                for j in range(2)]
 
         # FIXME: Refactor this code and matrix into some tabular environment.
         # drawing result
@@ -765,7 +765,7 @@ class PrettyPrinter(Printer):
 
         for i in xrange(len_args):
             D_row = None
-            for j in xrange(2):
+            for j in range(2):
                 p = P[i, j]
                 assert p.width() <= maxw[j]
 

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -15,7 +15,7 @@ TODO:
 from __future__ import print_function, division
 
 from .pretty_symbology import hobj, vobj, xsym, xobj, pretty_use_unicode
-from sympy.core.compatibility import u, string_types
+from sympy.core.compatibility import u, string_types, xrange
 
 
 class stringPict(object):

--- a/sympy/printing/pretty/stringpict.py
+++ b/sympy/printing/pretty/stringpict.py
@@ -443,7 +443,7 @@ class prettyForm(stringPict):
                 arg = stringPict(*arg.parens())
             result.append(arg)
         len_res = len(result)
-        for i in range(len_res):
+        for i in xrange(len_res):
             if i < len_res - 1 and result[i] == '-1' and result[i + 1] == xsym('*'):
                 # substitute -1 by -, like in -1*x -> -x
                 result.pop(i)

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -7,6 +7,7 @@ from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
 from sympy.utilities.pytest import raises
+from sympy.core.compatibility import xrange
 
 
 def test_printmethod():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -199,7 +199,7 @@ def test_fcode_Piecewise():
     )
     a = cos(x)/x
     b = sin(x)/x
-    for i in range(10):
+    for i in xrange(10):
         a = diff(a, x)
         b = diff(b, x)
     expected = (

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -303,8 +303,8 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None):
     # process adds - any adds that weren't repeated might contain
     # subpatterns that are repeated, e.g. x+y+z and x+y have x+y in common
     adds = [set(a.args) for a in ordered(adds)]
-    for i in range(len(adds)):
-        for j in range(i + 1, len(adds)):
+    for i in xrange(len(adds)):
+        for j in xrange(i + 1, len(adds)):
             com = adds[i].intersection(adds[j])
             if len(com) > 1:
                 to_eliminate.add(Add(*com))
@@ -312,7 +312,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None):
                 # remove this set of symbols so it doesn't appear again
                 adds[i] = adds[i].difference(com)
                 adds[j] = adds[j].difference(com)
-                for k in range(j + 1, len(adds)):
+                for k in xrange(j + 1, len(adds)):
                     if not com.difference(adds[k]):
                         adds[k] = adds[k].difference(com)
 
@@ -324,10 +324,10 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None):
     sm = difflib.SequenceMatcher()
 
     muls = [a.args_cnc(cset=True) for a in ordered(muls)]
-    for i in range(len(muls)):
+    for i in xrange(len(muls)):
         if muls[i][1]:
             sm.set_seq1(muls[i][1])
-        for j in range(i + 1, len(muls)):
+        for j in xrange(i + 1, len(muls)):
             # the commutative part in common
             ccom = muls[i][0].intersection(muls[j][0])
 
@@ -359,7 +359,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None):
             # identified as a subexpr which would not be right.
             if not ncom:
                 muls[i][0] = muls[i][0].difference(ccom)
-                for k in range(j, len(muls)):
+                for k in xrange(j, len(muls)):
                     if not ccom.difference(muls[k][0]):
                         muls[k][0] = muls[k][0].difference(ccom)
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -7,7 +7,7 @@ import difflib
 from sympy.core import Basic, Mul, Add, sympify
 from sympy.core.basic import preorder_traversal
 from sympy.core.function import _coeff_isneg
-from sympy.core.compatibility import iterable
+from sympy.core.compatibility import iterable, xrange
 from sympy.utilities.iterables import numbered_symbols, \
     sift, topological_sort, ordered
 

--- a/sympy/simplify/epathtools.py
+++ b/sympy/simplify/epathtools.py
@@ -1,6 +1,7 @@
 """Tools for manipulation of expressions using paths. """
 
 from __future__ import print_function, division
+from sympy.core.compatibility import xrange
 
 from sympy.core import Basic
 

--- a/sympy/simplify/epathtools.py
+++ b/sympy/simplify/epathtools.py
@@ -202,7 +202,7 @@ class EPath(object):
                     else:
                         indices = [span]
                 else:
-                    indices = range(len(args))
+                    indices = xrange(len(args))
 
                 for i in indices:
                     try:

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -677,7 +677,7 @@ class Formula(object):
 
         n = poly.degree() - 1
         b = [closed_form]
-        for _ in range(n):
+        for _ in xrange(n):
             b.append(self.z*b[-1].diff(self.z))
 
         self.B = Matrix(b)
@@ -1354,7 +1354,7 @@ class ReduceOrder(Operator):
         self = Operator.__new__(cls)
 
         p = S(1)
-        for k in range(n):
+        for k in xrange(n):
             p *= (_x + bj + k)/(bj + k)
 
         self._poly = Poly(p, _x)
@@ -1376,7 +1376,7 @@ class ReduceOrder(Operator):
         self = Operator.__new__(cls)
 
         p = S(1)
-        for k in range(n):
+        for k in xrange(n):
             p *= (sign*_x + a + k)
 
         self._poly = Poly(p, _x)
@@ -1415,7 +1415,7 @@ def _reduce_order(ap, bq, gen, key):
     operators = []
     for a in ap:
         op = None
-        for i in range(len(bq)):
+        for i in xrange(len(bq)):
             op = gen(a, bq[i])
             if op is not None:
                 bq.pop(i)
@@ -1557,7 +1557,7 @@ def devise_plan(target, origin, z):
 
     def do_shifts(fro, to, inc, dec):
         ops = []
-        for i in range(len(fro)):
+        for i in xrange(len(fro)):
             if to[i] - fro[i] > 0:
                 sh = inc
                 ch = 1
@@ -1662,7 +1662,7 @@ def try_shifted_sum(func, z):
     nbq = [x - k for x in nbq]
 
     ops = []
-    for n in range(r - 1):
+    for n in xrange(r - 1):
         ops.append(ShiftA(n + 1))
     ops.reverse()
 
@@ -1675,7 +1675,7 @@ def try_shifted_sum(func, z):
     ops += [MultOperator(fac)]
 
     p = 0
-    for n in range(k):
+    for n in xrange(k):
         m = z**n/factorial(n)
         for a in nap:
             m *= rf(a, n)
@@ -1867,7 +1867,7 @@ def build_hypergeometric_formula(func):
         n = poly.degree()
         basis = []
         M = zeros(n)
-        for k in range(n):
+        for k in xrange(n):
             a = func.ap[0] + k
             basis += [hyper([a] + list(func.ap[1:]), func.bq, z)]
             if k < n - 1:
@@ -1876,7 +1876,7 @@ def build_hypergeometric_formula(func):
         B = Matrix(basis)
         C = Matrix([[1] + [0]*(n - 1)])
         derivs = [eye(n)]
-        for k in range(n):
+        for k in xrange(n):
             derivs.append(M*derivs[k])
         l = poly.all_coeffs()
         l.reverse()

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -65,7 +65,7 @@ from sympy import SYMPY_DEBUG
 from sympy.core import (S, Dummy, symbols, sympify, Tuple, expand, I, pi, Mul,
     EulerGamma, oo, zoo, expand_func, Add, nan, Expr)
 from sympy.core.mod import Mod
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, xrange
 from sympy.utilities.iterables import sift
 from sympy.functions import (exp, sqrt, root, log, lowergamma, cos,
         besseli, gamma, uppergamma, expint, erf, sin, besselj, Ei, Ci, Si, Shi,

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -817,7 +817,7 @@ def ratsimpmodprime(expr, G, *gens, **args):
         if n == 0:
             return [1]
         S = []
-        for mi in combinations_with_replacement(range(len(opt.gens)), n):
+        for mi in combinations_with_replacement(xrange(len(opt.gens)), n):
             m = [0]*len(opt.gens)
             for i in mi:
                 m[i] += 1
@@ -875,9 +875,9 @@ def ratsimpmodprime(expr, G, *gens, **args):
             ng = Cs + Ds
 
             c_hat = Poly(
-                sum([Cs[i] * M1[i] for i in range(len(M1))]), opt.gens + ng)
+                sum([Cs[i] * M1[i] for i in xrange(len(M1))]), opt.gens + ng)
             d_hat = Poly(
-                sum([Ds[i] * M2[i] for i in range(len(M2))]), opt.gens + ng)
+                sum([Ds[i] * M2[i] for i in xrange(len(M2))]), opt.gens + ng)
 
             r = reduced(a * d_hat - b * c_hat, G, opt.gens + ng,
                         order=opt.order, polys=True)[1]
@@ -2725,7 +2725,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                     # find the number of extractions possible
                     # e.g. [(1, 2), (2, 2)] -> min(2/1, 2/2) -> 1
                     min1 = ee[0][1]/ee[0][0]
-                    for i in range(len(ee)):
+                    for i in xrange(len(ee)):
                         rat = ee[i][1]/ee[i][0]
                         if rat < 1:
                             break
@@ -2734,7 +2734,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                         # update base factor counts
                         # e.g. if ee = [(2, 5), (3, 6)] then min1 = 2
                         # and the new base counts will be 5-2*2 and 6-2*3
-                        for i in range(len(bb)):
+                        for i in xrange(len(bb)):
                             common_b[bb[i]] -= min1*ee[i][0]
                             update(bb[i])
                         # update the count of the base
@@ -2811,7 +2811,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
 
         # Pull out numerical coefficients from exponent if assumptions allow
         # e.g., 2**(2*x) => 4**x
-        for i in range(len(c_powers)):
+        for i in xrange(len(c_powers)):
             b, e = c_powers[i]
             if not (b.is_nonnegative or e.is_integer or force or b.is_polar):
                 continue
@@ -3040,12 +3040,12 @@ def combsimp(expr):
                 n, result = int(b), S.One
 
                 if n > 0:
-                    for i in range(n):
+                    for i in xrange(n):
                         result *= a + i
 
                     return result
                 elif n < 0:
-                    for i in range(1, -n + 1):
+                    for i in xrange(1, -n + 1):
                         result *= a - i
 
                     return 1/result
@@ -3271,10 +3271,10 @@ def combsimp(expr):
                 ng.remove(x)
                 dg.remove(y)
                 if n > 0:
-                    for k in range(n):
+                    for k in xrange(n):
                         no.append(2*y + k)
                 elif n < 0:
-                    for k in range(-n):
+                    for k in xrange(-n):
                         do.append(2*y - 1 - k)
                 ng.append(y + S(1)/2)
                 no.append(2**(2*y - 1))

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -11,7 +11,7 @@ from sympy.core import (Basic, S, C, Add, Mul, Pow, Rational, Integer,
     expand_power_exp, expand_log)
 from sympy.core.add import _unevaluated_Add
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import iterable, reduce, default_sort_key, ordered
+from sympy.core.compatibility import iterable, reduce, default_sort_key, ordered, xrange
 from sympy.core.exprtools import Factors, gcd_terms
 from sympy.core.numbers import Float, Number, I
 from sympy.core.function import expand_log, count_ops

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -229,7 +229,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 
 from sympy.core import Add, C, S, Mul, Pow, oo
-from sympy.core.compatibility import ordered, iterable, is_sequence
+from sympy.core.compatibility import ordered, iterable, is_sequence, xrange
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.exprtools import factor_terms, gcd_terms
 from sympy.core.function import (Function, Derivative, AppliedUndef, diff,

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2703,7 +2703,7 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
             chareq += (r[i]*diff(x**symbol, x, i)*x**-symbol).expand()
 
     chareq = Poly(chareq, symbol)
-    chareqroots = [RootOf(chareq, k) for k in range(chareq.degree())]
+    chareqroots = [RootOf(chareq, k) for k in xrange(chareq.degree())]
 
     # Create a dict root: multiplicity or charroots
     charroots = defaultdict(int)

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -64,7 +64,7 @@ from sympy.polys import Poly, quo, gcd, lcm, roots, resultant
 from sympy.functions import binomial, factorial, FallingFactorial, RisingFactorial
 from sympy.matrices import Matrix, casoratian
 from sympy.concrete import product
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, xrange
 from sympy.utilities.iterables import numbered_symbols
 
 

--- a/sympy/solvers/recurr.py
+++ b/sympy/solvers/recurr.py
@@ -134,8 +134,8 @@ def rsolve_poly(coeffs, f, n, **hints):
     polys = [ Poly(0, n) ] * (r + 1)
     terms = [ (S.Zero, S.NegativeInfinity) ] *(r + 1)
 
-    for i in range(0, r + 1):
-        for j in range(i, r + 1):
+    for i in xrange(0, r + 1):
+        for j in xrange(i, r + 1):
             polys[i] += coeffs[j]*binomial(j, i)
 
         if not polys[i].is_zero:
@@ -144,7 +144,7 @@ def rsolve_poly(coeffs, f, n, **hints):
 
     d = b = terms[0][1]
 
-    for i in range(1, r + 1):
+    for i in xrange(1, r + 1):
         if terms[i][1] > d:
             d = terms[i][1]
 
@@ -157,7 +157,7 @@ def rsolve_poly(coeffs, f, n, **hints):
 
     degree_poly = S.Zero
 
-    for i in range(0, r + 1):
+    for i in xrange(0, r + 1):
         if terms[i][1] - i == b:
             degree_poly += terms[i][0]*FallingFactorial(x, i)
 
@@ -189,11 +189,11 @@ def rsolve_poly(coeffs, f, n, **hints):
         C = []
         y = E = S.Zero
 
-        for i in range(0, N + 1):
+        for i in xrange(0, N + 1):
             C.append(Symbol('C' + str(i)))
             y += C[i] * n**i
 
-        for i in range(0, r + 1):
+        for i in xrange(0, r + 1):
             E += coeffs[i].as_expr()*y.subs(n, n + i)
 
         solutions = solve_undetermined_coeffs(E - f, C, n)
@@ -225,7 +225,7 @@ def rsolve_poly(coeffs, f, n, **hints):
             B = S.One
             D = p.subs(n, a + k)
 
-            for i in range(1, k + 1):
+            for i in xrange(1, k + 1):
                 B *= -Rational(k - i + 1, i)
                 D += B * p.subs(n, a + k - i)
 
@@ -233,16 +233,16 @@ def rsolve_poly(coeffs, f, n, **hints):
 
         alpha = {}
 
-        for i in range(-A, d + 1):
+        for i in xrange(-A, d + 1):
             I = _one_vector(d + 1)
 
-            for k in range(1, d + 1):
+            for k in xrange(1, d + 1):
                 I[k] = I[k - 1] * (x + i - k + 1)/k
 
             alpha[i] = S.Zero
 
-            for j in range(0, A + 1):
-                for k in range(0, d + 1):
+            for j in xrange(0, A + 1):
+                for k in xrange(0, d + 1):
                     B = binomial(k, i + j)
                     D = _delta(polys[j].as_expr(), k)
 
@@ -251,66 +251,66 @@ def rsolve_poly(coeffs, f, n, **hints):
         V = Matrix(U, A, lambda i, j: int(i == j))
 
         if homogeneous:
-            for i in range(A, U):
+            for i in xrange(A, U):
                 v = _zero_vector(A)
 
-                for k in range(1, A + b + 1):
+                for k in xrange(1, A + b + 1):
                     if i - k < 0:
                         break
 
                     B = alpha[k - A].subs(x, i - k)
 
-                    for j in range(0, A):
+                    for j in xrange(0, A):
                         v[j] += B * V[i - k, j]
 
                 denom = alpha[-A].subs(x, i)
 
-                for j in range(0, A):
+                for j in xrange(0, A):
                     V[i, j] = -v[j] / denom
         else:
             G = _zero_vector(U)
 
-            for i in range(A, U):
+            for i in xrange(A, U):
                 v = _zero_vector(A)
                 g = S.Zero
 
-                for k in range(1, A + b + 1):
+                for k in xrange(1, A + b + 1):
                     if i - k < 0:
                         break
 
                     B = alpha[k - A].subs(x, i - k)
 
-                    for j in range(0, A):
+                    for j in xrange(0, A):
                         v[j] += B * V[i - k, j]
 
                     g += B * G[i - k]
 
                 denom = alpha[-A].subs(x, i)
 
-                for j in range(0, A):
+                for j in xrange(0, A):
                     V[i, j] = -v[j] / denom
 
                 G[i] = (_delta(f, i - A) - g) / denom
 
         P, Q = _one_vector(U), _zero_vector(A)
 
-        for i in range(1, U):
+        for i in xrange(1, U):
             P[i] = (P[i - 1] * (n - a - i + 1)/i).expand()
 
-        for i in range(0, A):
+        for i in xrange(0, A):
             Q[i] = Add(*[ (v*p).expand() for v, p in zip(V[:, i], P) ])
 
         if not homogeneous:
             h = Add(*[ (g*p).expand() for g, p in zip(G, P) ])
 
-        C = [ Symbol('C' + str(i)) for i in range(0, A) ]
+        C = [ Symbol('C' + str(i)) for i in xrange(0, A) ]
 
         g = lambda i: Add(*[ c*_delta(q, i) for c, q in zip(C, Q) ])
 
         if homogeneous:
-            E = [ g(i) for i in range(N + 1, U) ]
+            E = [ g(i) for i in xrange(N + 1, U) ]
         else:
-            E = [ g(i) + _delta(h, i) for i in range(N + 1, U) ]
+            E = [ g(i) + _delta(h, i) for i in xrange(N + 1, U) ]
 
         if E != []:
             solutions = solve(E, *C)
@@ -427,13 +427,13 @@ def rsolve_ratio(coeffs, f, n, **hints):
     else:
         C, numers = S.One, [S.Zero]*(r + 1)
 
-        for i in range(int(max(nni_roots)), -1, -1):
+        for i in xrange(int(max(nni_roots)), -1, -1):
             d = gcd(A, B.subs(n, n + i), n)
 
             A = quo(A, d, n)
             B = quo(B, d.subs(n, n - i), n)
 
-            C *= Mul(*[ d.subs(n, n - j) for j in range(0, i + 1) ])
+            C *= Mul(*[ d.subs(n, n - j) for j in xrange(0, i + 1) ])
 
         denoms = [ C.subs(n, n + i) for i in range(0, r + 1) ]
 
@@ -443,7 +443,7 @@ def rsolve_ratio(coeffs, f, n, **hints):
             numers[i] = quo(coeffs[i], g, n)
             denoms[i] = quo(denoms[i], g, n)
 
-        for i in range(0, r + 1):
+        for i in xrange(0, r + 1):
             numers[i] *= Mul(*(denoms[:i] + denoms[i + 1:]))
 
         result = rsolve_poly(numers, f * Mul(*denoms), n, **hints)
@@ -548,7 +548,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
 
             s = hypersimp(g, n)
 
-            for j in range(1, r + 1):
+            for j in xrange(1, r + 1):
                 coeff *= s.subs(n, n + j - 1)
 
                 p, q = coeff.as_numer_denom()
@@ -556,7 +556,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
                 polys[j] *= p
                 denoms[j] = q
 
-            for j in range(0, r + 1):
+            for j in xrange(0, r + 1):
                 polys[j] *= Mul(*(denoms[:j] + denoms[j + 1:]))
 
             R = rsolve_poly(polys, Mul(*denoms), n)
@@ -595,9 +595,9 @@ def rsolve_hyper(coeffs, f, n, **hints):
         polys, degrees = [], []
         D = A*B.subs(n, n + r - 1)
 
-        for i in range(0, r + 1):
-            a = Mul(*[ A.subs(n, n + j) for j in range(0, i) ])
-            b = Mul(*[ B.subs(n, n + j) for j in range(i, r) ])
+        for i in xrange(0, r + 1):
+            a = Mul(*[ A.subs(n, n + j) for j in xrange(0, i) ])
+            b = Mul(*[ B.subs(n, n + j) for j in xrange(i, r) ])
 
             poly = quo(coeffs[i]*a*b, D, n)
             polys.append(poly.as_poly(n))
@@ -607,7 +607,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
 
         d, poly = max(degrees), S.Zero
 
-        for i in range(0, r + 1):
+        for i in xrange(0, r + 1):
             coeff = polys[i].nth(d)
 
             if coeff is not S.Zero:
@@ -617,7 +617,7 @@ def rsolve_hyper(coeffs, f, n, **hints):
             if z.is_zero:
                 continue
 
-            (C, s) = rsolve_poly([ polys[i]*z**i for i in range(r + 1) ], 0, n, symbols=True)
+            (C, s) = rsolve_poly([ polys[i]*z**i for i in xrange(r + 1) ], 0, n, symbols=True)
 
             if C is not None and C is not S.Zero:
                 symbols |= set(s)
@@ -782,7 +782,7 @@ def rsolve(f, y, init=None):
         H_part = h_part
 
     K_max = max(H_part.keys())
-    coeffs = [H_part[i] for i in range(K_max + 1)]
+    coeffs = [H_part[i] for i in xrange(K_max + 1)]
 
     result = rsolve_hyper(coeffs, -i_part, n, symbols=True)
 
@@ -796,7 +796,7 @@ def rsolve(f, y, init=None):
 
     if symbols and init is not None:
         if type(init) is list:
-            init = dict([(i, init[i]) for i in range(len(init))])
+            init = dict([(i, init[i]) for i in xrange(len(init))])
 
         equations = []
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -15,7 +15,7 @@ This module contain solvers for all kinds of equations:
 from __future__ import print_function, division
 
 from sympy.core.compatibility import (iterable, is_sequence, ordered,
-    default_sort_key, reduce)
+    default_sort_key, reduce, xrange)
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.sympify import sympify
 from sympy.core import (C, S, Add, Symbol, Wild, Equality, Dummy, Basic,

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1892,7 +1892,7 @@ def solve_linear_system(system, *symbols, **flags):
         if not matrix[i, i]:
             # there is no pivot in current column
             # so try to find one in other columns
-            for k in range(i + 1, m):
+            for k in xrange(i + 1, m):
                 if matrix[i, k]:
                     break
             else:
@@ -1952,7 +1952,7 @@ def solve_linear_system(system, *symbols, **flags):
         # divide all elements in the current row by the pivot
         matrix.row_op(i, lambda x, _: x * pivot_inv)
 
-        for k in range(i + 1, matrix.rows):
+        for k in xrange(i + 1, matrix.rows):
             if matrix[k, i]:
                 coeff = matrix[k, i]
 
@@ -1977,7 +1977,7 @@ def solve_linear_system(system, *symbols, **flags):
             content = matrix[k, m]
 
             # run back-substitution for variables
-            for j in range(k + 1, m):
+            for j in xrange(k + 1, m):
                 content -= matrix[k, j]*solutions[syms[j]]
 
             if do_simplify:
@@ -1997,11 +1997,11 @@ def solve_linear_system(system, *symbols, **flags):
             content = matrix[k, m]
 
             # run back-substitution for variables
-            for j in range(k + 1, i):
+            for j in xrange(k + 1, i):
                 content -= matrix[k, j]*solutions[syms[j]]
 
             # run back-substitution for parameters
-            for j in range(i, m):
+            for j in xrange(i, m):
                 content -= matrix[k, j]*syms[j]
 
             if do_simplify:

--- a/sympy/statistics/distributions.py
+++ b/sympy/statistics/distributions.py
@@ -91,7 +91,7 @@ class ContinuousProbability(object):
         if n is None:
             return s._random()
         else:
-            return Sample([s._random() for i in range(n)])
+            return Sample([s._random() for i in xrange(n)])
 
     def __repr__(self):
         return sstr(self)

--- a/sympy/statistics/distributions.py
+++ b/sympy/statistics/distributions.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 from sympy.core import sympify, Lambda, Dummy, Integer, Rational, oo, Float, pi
 from sympy.functions import sqrt, exp, erf
 from sympy.printing import sstr
+from sympy.core.compatibility import xrange
 import random
 
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -550,7 +550,7 @@ def test_prefab_sampling():
     variables = [N, L, E, P, W, U, B, G]
     niter = 10
     for var in variables:
-        for i in range(niter):
+        for i in xrange(niter):
             assert sample(var) in var.pspace.domain.set
 
 

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -23,6 +23,8 @@ from sympy.stats.rv import ProductPSpace
 
 from sympy.utilities.pytest import raises, XFAIL, slow
 
+from sympy.core.compatibility import xrange
+
 oo = S.Infinity
 
 x, y, z = map(Symbol, 'xyz')

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -84,7 +84,7 @@ def unflatten(iter, n=2):
     """
     if n < 1 or len(iter) % n:
         raise ValueError('iter length is not a multiple of %i' % n)
-    return list(zip(*(iter[i::n] for i in range(n))))
+    return list(zip(*(iter[i::n] for i in xrange(n))))
 
 
 def reshape(seq, how):
@@ -637,7 +637,7 @@ def sift(seq, keyfunc):
 
 def take(iter, n):
     """Return ``n`` items from ``iter`` iterator. """
-    return [ value for _, value in zip(range(n), iter) ]
+    return [ value for _, value in zip(xrange(n), iter) ]
 
 
 def dict_merge(*dicts):
@@ -669,7 +669,7 @@ def common_prefix(*seqs):
         return seqs[0]
     i = 0
     for i in range(min(len(s) for s in seqs)):
-        if not all(seqs[j][i] == seqs[0][i] for j in range(len(seqs))):
+        if not all(seqs[j][i] == seqs[0][i] for j in xrange(len(seqs))):
             break
     else:
         i += 1
@@ -696,7 +696,7 @@ def common_suffix(*seqs):
         return seqs[0]
     i = 0
     for i in range(-1, -min(len(s) for s in seqs) - 1, -1):
-        if not all(seqs[j][i] == seqs[0][i] for j in range(len(seqs))):
+        if not all(seqs[j][i] == seqs[0][i] for j in xrange(len(seqs))):
             break
     else:
         i -= 1
@@ -721,7 +721,7 @@ def prefixes(seq):
     """
     n = len(seq)
 
-    for i in range(n):
+    for i in xrange(n):
         yield seq[:i + 1]
 
 
@@ -740,7 +740,7 @@ def postfixes(seq):
     """
     n = len(seq)
 
-    for i in range(n):
+    for i in xrange(n):
         yield seq[n - i - 1:]
 
 
@@ -1763,14 +1763,14 @@ def generate_oriented_forest(n):
         if P[n] > 0:
             P[n] = P[P[n]]
         else:
-            for p in range(n - 1, 0, -1):
+            for p in xrange(n - 1, 0, -1):
                 if P[p] != 0:
                     target = P[p] - 1
-                    for q in range(p - 1, 0, -1):
+                    for q in xrange(p - 1, 0, -1):
                         if P[q] == target:
                             break
                     offset = p - q
-                    for i in range(p, n + 1):
+                    for i in xrange(p, n + 1):
                         P[i] = P[i - offset]
                     break
             else:

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -11,7 +11,7 @@ from sympy.core import Basic, C
 # this is the logical location of these functions
 from sympy.core.compatibility import (
     as_int, combinations_with_replacement, default_sort_key, is_sequence,
-    iterable, ordered
+    iterable, ordered, xrange
 )
 
 

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core.decorators import wraps
+from sympy.core.compatibility import xrange
 
 
 def recurrence_memo(initial):

--- a/sympy/utilities/memoization.py
+++ b/sympy/utilities/memoization.py
@@ -17,7 +17,7 @@ def recurrence_memo(initial):
             L = len(cache)
             if n <= L - 1:
                 return cache[n]
-            for i in range(L, n + 1):
+            for i in xrange(L, n + 1):
                 cache.append(f(i, cache))
             return cache[-1]
         return g
@@ -43,7 +43,7 @@ def assoc_recurrence_memo(base_seq):
             if n < L:
                 return cache[n][m]
 
-            for i in range(L, n + 1):
+            for i in xrange(L, n + 1):
                 # get base sequence
                 F_i0 = base_seq(i)
                 F_i_cache = [F_i0]
@@ -51,7 +51,7 @@ def assoc_recurrence_memo(base_seq):
 
                 # XXX only works for m <= n cases
                 # generate assoc sequence
-                for j in range(1, i + 1):
+                for j in xrange(1, i + 1):
                     F_ij = f(i, j, cache)
                     F_i_cache.append(F_ij)
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -408,8 +408,8 @@ def test_binary_partitions():
 
 
 def test_bell_perm():
-    assert [len(list(generate_bell(i))) for i in xrange(1, 7)] == [
-        factorial(i) for i in xrange(1, 7)]
+    assert [len(list(generate_bell(i))) for i in range(1, 7)] == [
+        factorial(i) for i in range(1, 7)]
     assert list(generate_bell(3)) == [
         (0, 1, 2), (1, 0, 2), (1, 2, 0), (2, 1, 0), (2, 0, 1), (0, 2, 1)]
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -408,8 +408,8 @@ def test_binary_partitions():
 
 
 def test_bell_perm():
-    assert [len(list(generate_bell(i))) for i in range(1, 7)] == [
-        factorial(i) for i in range(1, 7)]
+    assert [len(list(generate_bell(i))) for i in xrange(1, 7)] == [
+        factorial(i) for i in xrange(1, 7)]
     assert list(generate_bell(3)) == [
         (0, 1, 2), (1, 0, 2), (1, 2, 0), (2, 1, 0), (2, 0, 1), (0, 2, 1)]
 


### PR DESCRIPTION
Quote myself [from the cited above PR](https://github.com/sympy/sympy/pull/2318#issuecomment-21708875):

> This pull changes all xrange calls to range, instead of creating wrapper (as mpmath do). But there is a big difference for py2!
> 
> I thought, that most of ours xrange's was intentional, isn't?

See also thread https://groups.google.com/forum/?fromgroups=#!topic/sympy/ZRAS1bizsAE

This pull reverts xrange's, except for cases like range(3) or range(0, 7).
