### PR TITLE
Fixed error in tests in mechanics.

### DIFF
--- a/doc/src/modules/physics/mechanics/rollingdisc_example_kane.rst
+++ b/doc/src/modules/physics/mechanics/rollingdisc_example_kane.rst
@@ -26,8 +26,8 @@ rather than using a body-three orientation. ::
   >>> Y = N.orientnew('Y', 'Axis', [q1, N.z])
   >>> L = Y.orientnew('L', 'Axis', [q2, Y.x])
   >>> R = L.orientnew('R', 'Axis', [q3, L.y])
+  >>> w_R_N_qd = R.ang_vel_in(N)
   >>> R.set_ang_vel(N, u1 * L.x + u2 * L.y + u3 * L.z)
-  >>> R.set_ang_acc(N, R.ang_vel_in(N).dt(R) + (R.ang_vel_in(N) ^ R.ang_vel_in(N)))
 
 This is the translational kinematics. We create a point with no velocity
 in N; this is the contact point between the disc and ground. Next we form
@@ -39,8 +39,6 @@ Finally we form the velocity and acceleration of the disc. ::
   >>> Dmc = C.locatenew('Dmc', r * L.z)
   >>> Dmc.v2pt_theory(C, N, R)
   r*u2*L.x - r*u1*L.y
-  >>> Dmc.a2pt_theory(C, N, R)
-  (r*u1*u3 + r*u2')*L.x + (-r*(-u3*q3' + u1') + r*u2*u3)*L.y + (-r*u1**2 - r*u2**2)*L.z
 
 This is a simple way to form the inertia dyadic. The inertia of the disc does
 not change within the lean frame as the disc rolls; this will make for simpler
@@ -51,9 +49,9 @@ equations in the end. ::
   m*r**2/4*(L.x|L.x) + m*r**2/2*(L.y|L.y) + m*r**2/4*(L.z|L.z)
 
 Kinematic differential equations; how the generalized coordinate time
-derivatives relate to generalized speeds. Here these were computed by hand. ::
+derivatives relate to generalized speeds. ::
 
-  >>> kd = [q1d - u3/cos(q2), q2d - u1, q3d - u2 + u3 * tan(q2)]
+  >>> kd = [dot(R.ang_vel_in(N) - w_R_N_qd, uv) for uv in L]
 
 Creation of the force list; it is the gravitational force at the center of mass of
 the disc. Then we create the disc by assigning a Point to the center of mass
@@ -80,8 +78,7 @@ for the u dots (time derivatives of the generalized speeds). ::
   >>> rhs.simplify()
   >>> mprint(rhs)
   Matrix([
-  [4*g*sin(q2)/(5*r) + 2*u2*u3 - u3**2*tan(q2)],
-  [                                 -2*u1*u3/3],
-  [                    (-2*u2 + u3*tan(q2))*u1]])
-
+  [(4*g*sin(q2) + 6*r*u2*u3 - r*u3**2*tan(q2))/(5*r)],
+  [                                       -2*u1*u3/3],
+  [                          (-2*u2 + u3*tan(q2))*u1]])
 

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,4 +1,4 @@
-from sympy import cos, expand, Matrix, sin, symbols, tan, sqrt
+from sympy import cos, expand, Matrix, sin, symbols, tan, sqrt, S
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                      RigidBody, KanesMethod, inertia, Particle,
                                      dot)
@@ -159,7 +159,7 @@ def test_rolling_disc():
     rhs_jac = rhs_full.jacobian([q1, q2, q3, u1, u2, u3])
     rhs_jac_subbed = rhs_jac.subs({r: 1, g: 1, m: 1})
     rhs_jac_upright = rhs_jac_subbed.subs({q1: 0, q2: 0, q3: 0, u1: 0, u3: 0})
-    assert rhs_jac_upright.subs(u2, 1 / sqrt(3)).eigenvals().keys() == [0]
+    assert rhs_jac_upright.subs(u2, 1 / sqrt(3)).eigenvals() == {S(0): 6}
 
 
 def test_aux():

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,6 +1,7 @@
 from sympy import cos, expand, Matrix, sin, symbols, tan
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
-                                     RigidBody, KanesMethod, inertia, Particle)
+                                     RigidBody, KanesMethod, inertia, Particle,
+                                     dot)
 
 
 def test_one_dof():
@@ -105,9 +106,8 @@ def test_rolling_disc():
     Y = N.orientnew('Y', 'Axis', [q1, N.z])
     L = Y.orientnew('L', 'Axis', [q2, Y.x])
     R = L.orientnew('R', 'Axis', [q3, L.y])
+    w_R_N_qd = R.ang_vel_in(N)
     R.set_ang_vel(N, u1 * L.x + u2 * L.y + u3 * L.z)
-    R.set_ang_acc(
-        N, R.ang_vel_in(N).dt(R) + (R.ang_vel_in(N) ^ R.ang_vel_in(N)))
 
     # This is the translational kinematics. We create a point with no velocity
     # in N; this is the contact point between the disc and ground. Next we form
@@ -117,14 +117,13 @@ def test_rolling_disc():
     C.set_vel(N, 0)
     Dmc = C.locatenew('Dmc', r * L.z)
     Dmc.v2pt_theory(C, N, R)
-    Dmc.a2pt_theory(C, N, R)
 
     # This is a simple way to form the inertia dyadic.
     I = inertia(L, m / 4 * r**2, m / 2 * r**2, m / 4 * r**2)
 
     # Kinematic differential equations; how the generalized coordinate time
     # derivatives relate to generalized speeds.
-    kd = [q1d - u3/cos(q2), q2d - u1, q3d - u2 + u3 * tan(q2)]
+    kd = [dot(R.ang_vel_in(N) - w_R_N_qd, uv) for uv in L]
 
     # Creation of the force list; it is the gravitational force at the mass
     # center of the disc. Then we create the disc by assigning a Point to the
@@ -147,7 +146,8 @@ def test_rolling_disc():
     rhs = MM.inv() * forcing
     kdd = KM.kindiffdict()
     rhs = rhs.subs(kdd)
-    assert rhs.expand() == Matrix([(10*u2*u3*r - 5*u3**2*r*tan(q2) +
+    rhs.simplify()
+    assert rhs.expand() == Matrix([(6*u2*u3*r - u3**2*r*tan(q2) +
         4*g*sin(q2))/(5*r), -2*u1*u3/3, u1*(-2*u2 + u3*tan(q2))]).expand()
 
 
@@ -167,9 +167,8 @@ def test_aux():
     Y = N.orientnew('Y', 'Axis', [q1, N.z])
     L = Y.orientnew('L', 'Axis', [q2, Y.x])
     R = L.orientnew('R', 'Axis', [q3, L.y])
+    w_R_N_qd = R.ang_vel_in(N)
     R.set_ang_vel(N, u1 * L.x + u2 * L.y + u3 * L.z)
-    R.set_ang_acc(N, R.ang_vel_in(N).dt(R) + (R.ang_vel_in(N) ^
-        R.ang_vel_in(N)))
 
     C = Point('C')
     C.set_vel(N, u4 * L.x + u5 * (Y.z ^ L.x))
@@ -179,7 +178,7 @@ def test_aux():
 
     I = inertia(L, m / 4 * r**2, m / 2 * r**2, m / 4 * r**2)
 
-    kd = [q1d - u3/cos(q2), q2d - u1, q3d - u2 + u3 * tan(q2)]
+    kd = [dot(R.ang_vel_in(N) - w_R_N_qd, uv) for uv in L]
 
     ForceList = [(Dmc, - m * g * Y.z), (C, f1 * L.x + f2 * (Y.z ^ L.x))]
     BodyD = RigidBody('BodyD', Dmc, R, m, (I, Dmc))

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -207,8 +207,11 @@ def test_aux():
     fr2 = fr2.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
     frstar2 = frstar2.subs({u4d: 0, u5d: 0}).subs({u4: 0, u5: 0})
 
-    assert fr.expand() == fr2.expand()
-    assert frstar.expand() == frstar2.expand()
+    frstar.simplify()
+    frstar2.simplify()
+
+    assert (fr - fr2).expand() == Matrix([0, 0, 0, 0, 0])
+    assert (frstar - frstar2).expand() == Matrix([0, 0, 0, 0, 0])
 
 
 def test_parallel_axis():

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -1,4 +1,4 @@
-from sympy import cos, expand, Matrix, sin, symbols, tan
+from sympy import cos, expand, Matrix, sin, symbols, tan, sqrt
 from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
                                      RigidBody, KanesMethod, inertia, Particle,
                                      dot)
@@ -149,6 +149,17 @@ def test_rolling_disc():
     rhs.simplify()
     assert rhs.expand() == Matrix([(6*u2*u3*r - u3**2*r*tan(q2) +
         4*g*sin(q2))/(5*r), -2*u1*u3/3, u1*(-2*u2 + u3*tan(q2))]).expand()
+
+    # This code tests our output vs. benchmark values. When r=g=m=1, the
+    # critical speed (where all eigenvalues of the linearized equations are 0)
+    # is 1 / sqrt(3) for the upright case.
+    forcing_full = KM.forcing_full
+    forcing_full.simplify()
+    rhs_full = KM.mass_matrix_full.inv() * forcing_full
+    rhs_jac = rhs_full.jacobian([q1, q2, q3, u1, u2, u3])
+    rhs_jac_subbed = rhs_jac.subs({r: 1, g: 1, m: 1})
+    rhs_jac_upright = rhs_jac_subbed.subs({q1: 0, q2: 0, q3: 0, u1: 0, u3: 0})
+    assert rhs_jac_upright.subs(u2, 1 / sqrt(3)).eigenvals().keys() == [0]
 
 
 def test_aux():


### PR DESCRIPTION
Some tests in mechanics (or rather, various versions of one example problem)
had an error in the definition of the _kinematics_ of the rolling disc.
However, if you did the derivation by hand and also made this error (the
improper application of the 2-point theorem for acceleration for the rolling
w/o slip case) you would also get this error. That is the reason why the
original hand-calculated values matched the SymPy output. All is fixed now.

Additionally, the kinematic differential equations are calculated, rather than
being hard-coded. This should be more robust and less likely to be a source of
confusion/error in the future.
