### PR TITLE
Transform set

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -234,6 +234,9 @@ class Set(Basic):
         .. math::
             { f(x) | x \in self }
 
+        Examples
+        ========
+
         >>> from sympy import Interval, Symbol
         >>> x = Symbol('x')
 
@@ -242,6 +245,9 @@ class Set(Basic):
 
         >>> Interval(0, 2).transform(lambda x: 2*x)
         [0, 4]
+
+        See Also:
+            TransformationSet
         """
         if len(args) == 2:
             from sympy import Lambda

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -229,7 +229,10 @@ class Set(Basic):
         return self._measure
 
     def transform(self, *args):
-        """ Scalar tranformation of a set
+        """ Image of set under transformation ``f``
+
+        .. math::
+            { f(x) | x \in self }
 
         >>> from sympy import Interval, Symbol
         >>> x = Symbol('x')

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -228,6 +228,29 @@ class Set(Basic):
         """
         return self._measure
 
+    def transform(self, *args):
+        """ Scalar tranformation of a set
+
+        >>> from sympy import Interval, Symbol
+        >>> x = Symbol('x')
+
+        >>> Interval(0, 2).transform(x, 2*x)
+        [0, 4]
+
+        >>> Interval(0, 2).transform(lambda x: 2*x)
+        [0, 4]
+        """
+        if len(args) == 2:
+            from sympy import Lambda
+            f = Lambda(*args)
+        else:
+            f, = args
+        return self._transform(f)
+
+    def _transform(self, f):
+        from sympy.sets.fancysets import TransformationSet
+        return TransformationSet(f, self)
+
     @property
     def _measure(self):
         raise NotImplementedError("(%s)._measure" % self)
@@ -631,6 +654,17 @@ class Interval(Set, EvalfMixin):
 
         return expr
 
+    def _transform(self, f):
+        # TODO: manage left_open and right_open better
+        from sympy.functions.elementary.miscellaneous import Min, Max
+        _left, _right = f(self.left), f(self.right)
+        left, right = Min(_left, _right), Max(_left, _right)
+        if _right == left: # switch happened
+            left_open, right_open = self.right_open, self.left_open
+        else:
+            left_open, right_open = self.left_open, self.right_open
+        return Interval(left, right, left_open, right_open)
+
     @property
     def _measure(self):
         return self.end - self.start
@@ -853,6 +887,9 @@ class Union(Set, EvalfMixin):
             parity *= -1
         return measure
 
+    def _transform(self, f):
+        return Union(arg.transform(f) for arg in self.args)
+
     def as_relational(self, symbol):
         """Rewrite a Union in terms of equalities and logic operators. """
         return Or(*[set.as_relational(symbol) for set in self.args])
@@ -950,6 +987,9 @@ class Intersection(Set):
     @property
     def _complement(self):
         raise NotImplementedError()
+
+    def _transform(self, f):
+        return Intersection(arg.transform(f) for arg in self.args)
 
     def _contains(self, other):
         from sympy.logic.boolalg import And
@@ -1078,6 +1118,8 @@ class EmptySet(with_metaclass(Singleton, Set)):
     def __iter__(self):
         return iter([])
 
+    def _transform(self, f):
+        return self
 
 class UniversalSet(with_metaclass(Singleton, Set)):
     """
@@ -1211,6 +1253,9 @@ class FiniteSet(Set, EvalfMixin):
 
         """
         return other in self._elements
+
+    def _transform(self, f):
+        return FiniteSet(*map(f, self))
 
     @property
     def _complement(self):

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -501,3 +501,33 @@ def test_universalset():
 def test_Interval_free_symbols():
     x = Symbol('x', real=True)
     assert set(Interval(0, x).free_symbols) == set((x,))
+
+def test_transform_interval():
+    x = Symbol('x', real=True)
+    assert Interval(-2, 1).transform(x, 2*x) == Interval(-4, 2)
+    assert Interval(-2, 1, True, False).transform(x, 2*x) == \
+            Interval(-4, 2, True, False)
+    assert Interval(-2, 1, True, False).transform(x, x**2) == \
+            Interval(1, 4, False, True)
+    assert Interval(-2, 1).transform(x, x**2) == Interval(1, 4)
+    assert Interval(-2, 1, True, False).transform(x, x**2) == \
+            Interval(1, 4, False, True)
+
+def test_transform_FiniteSet():
+    x = Symbol('x', real=True)
+    assert FiniteSet(1, 2, 3).transform(x, 2*x) == FiniteSet(2, 4, 6)
+
+def test_transform_Union():
+    x = Symbol('x', real=True)
+    assert (Interval(-2, 0) + FiniteSet(1, 2, 3)).transform(x, x**2) == \
+            (Interval(0, 4) + FiniteSet(9))
+
+def test_transform_Intersection():
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
+    assert Interval(-2, 0).intersect(Interval(x, y)).transform(x, x**2) == \
+           Interval(0, 4).intersect(Interval(Min(x**2, y**2), Max(x**2, y**2)))
+
+def test_transform_EmptySet():
+    x = Symbol('x', real=True)
+    assert S.EmptySet.transform(x, 2*x) == S.EmptySet

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -11,6 +11,7 @@ from sympy.core.expr import Expr
 from sympy.core.singleton import Singleton
 from sympy.core.rules import Transform
 from sympy.core.compatibility import as_int, with_metaclass, xrange
+from sympy.core.logic import fuzzy_and
 
 
 class IdentityFunction(with_metaclass(Singleton, Lambda)):
@@ -368,6 +369,10 @@ class MinMaxBase(Expr, LatticeOp):
                 df = Function.fdiff(self, i)
             l.append(df * da)
         return Add(*l)
+
+    @property
+    def is_real(self):
+        return fuzzy_and(*[arg.is_real for arg in self.args])
 
 class Max(MinMaxBase, Application):
     """

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -98,6 +98,10 @@ def test_Min():
     assert Min(0,-x,1-2*x).diff(x) == -Heaviside(x + Min(0, -2*x + 1)) \
         - 2*Heaviside(2*x + Min(0, -x) - 1)
 
+    a, b = Symbol('a', real=True), Symbol('b', real=True)
+    # a and b are both real, Min(a, b) should be real
+    assert Min(a, b).is_real
+
 
 def test_Max():
     from sympy.abc import x, y, z
@@ -144,6 +148,9 @@ def test_Max():
     assert Max(x**2, 1+x, 1).diff(x) == 2*x*Heaviside(x**2 - Max(1,x+1)) \
         + Heaviside(x - Max(1,x**2) + 1)
 
+    a, b = Symbol('a', real=True), Symbol('b', real=True)
+    # a and b are both real, Max(a, b) should be real
+    assert Max(a, b).is_real
 
 def test_root():
     from sympy.abc import x, y, z

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -65,6 +65,9 @@ def test_TransformationSet():
 
     assert harmonics.is_iterable
 
+def test_transform_is_TransformationSet():
+    assert isinstance(Range(5).transform(x, sqrt(sin(x))), TransformationSet)
+
 
 @XFAIL
 def test_halfcircle():


### PR DESCRIPTION
Adds `transform` method to sets in the style of `union`, and `complement`.  

Adds methods for Union, Intersection, Interval, FiniteSet and defaults to the construction of a TransformationSet if these fail.
