### PR TITLE
Fix for issue 3891

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -993,7 +993,7 @@ class Pow(Expr):
                 g = g.nseries(x, n=n, logx=logx)
                 l.append(g)
             r = Add(*l)
-        return r*b0**e + order
+        return expand_mul(r*b0**e) + order
 
     def _eval_as_leading_term(self, x):
         if not self.exp.has(x):

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -255,6 +255,16 @@ def test_issue_3109():
     assert sqrt(exp(5*I)) == -exp(5*I/2)
     assert root(exp(5*I), 3).exp == Rational(1, 3)
 
+
+def test_issue_3891():
+    x = Symbol('x')
+    a = Symbol('a')
+    b = Symbol('b')
+    assert (sqrt(a + b*x + x**2)).series(x, 0, 3).removeO() == \
+        b*x/(2*sqrt(a)) + x**2*(1/(2*sqrt(a)) - \
+        b**2/(8*a**(S(3)/2))) + sqrt(a)
+
+
 def test_issue_2969():
     from sympy import sin, O
     x = Symbol('x')


### PR DESCRIPTION
Pow._eval_nseries: do expand_mul for output if b0!=0.  Now:

```
In [1]: x,a,b = symbols('x,a,b')

In [2]: (sqrt(a+b*x+x**2)).series(x,0,3)
Out[2]: 
             ⎛             2  ⎞                
  b⋅x      2 ⎜   1        b   ⎟     ___    ⎛ 3⎞
─────── + x ⋅⎜─────── - ──────⎟ + ╲╱ a  + O⎝x ⎠
    ___      ⎜    ___      3/2⎟                
2⋅╲╱ a       ⎝2⋅╲╱ a    8⋅a   ⎠                


```
