### PR TITLE
Fix issue 3900

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2540,7 +2540,7 @@ class Expr(Basic, EvalfMixin):
                             ndid += 1
                         yield do
                         if ndid == ndo:
-                            raise StopIteration
+                            break
                         yielded += do
 
             return yield_lseries(self.removeO()._eval_lseries(x))

--- a/sympy/series/tests/test_lseries.py
+++ b/sympy/series/tests/test_lseries.py
@@ -1,4 +1,4 @@
-from sympy import sin, cos, exp, E, S, Order
+from sympy import sin, cos, exp, tanh, E, S, Order
 from sympy.abc import x, y
 
 
@@ -49,3 +49,12 @@ def test_issue_2084():
     # to be known since, for example, every term has a constant in it.
     s = ((1 + x)**7).series(x, 1, n=None)
     assert [next(s) for i in range(2)] == [128, -448 + 448*x]
+
+
+def test_issue_3900():
+    s = tanh(x).lseries(x, 1)
+    assert next(s) == tanh(1)
+    assert next(s) == x - (x - 1)*tanh(1)**2 - 1
+    assert next(s) == -(x - 1)**2*tanh(1) + (x - 1)**2*tanh(1)**3
+    assert next(s) == -(x - 1)**3*tanh(1)**4 - (x - 1)**3/3 + \
+        4*(x - 1)**3*tanh(1)**2/3


### PR DESCRIPTION
Before:

```
In [2]: for i in tanh(1 + x).lseries(x):
   ...:     print(i)
   ...:     if O(i).getn() > 4:
   ...:         break
   ...:         
tanh(1)
-x*tanh(1)**2 + x
```

After:

```
In [1]: for i in tanh(1 + x).lseries(x):
   ...:     print(i)
   ...:     if O(i).getn() > 4:
   ...:         break
   ...:         
tanh(1)
-x*tanh(1)**2 + x
-x**2*tanh(1) + x**2*tanh(1)**3
-x**3*tanh(1)**4 - x**3/3 + 4*x**3*tanh(1)**2/3
-5*x**4*tanh(1)**3/3 + x**4*tanh(1)**5 + 2*x**4*tanh(1)/3
-17*x**5*tanh(1)**2/15 - x**5*tanh(1)**6 + 2*x**5/15 + 2*x**5*tanh(1)**4
```

The reason for this bug seems to be not related with the form of terms (e.g. not `a*(x-b)**e`).  It is much simpler: we should break inner loop and not raise an exception instead.
