### PR TITLE
Fix issue 3330

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2546,6 +2546,16 @@ class Expr(Basic, EvalfMixin):
 
             return yield_lseries(self.removeO()._eval_lseries(x))
 
+    def taylor_term(self, n, x, *previous_terms):
+        """General method for the taylor term.
+
+        This method is slow, because it differentiates n-times. Subclasses can
+        redefine it to make it faster by using the "previous_terms".
+        """
+        x = sympify(x)
+        _x = C.Dummy('x')
+        return self.subs(x, _x).diff(_x, n).subs(_x, x).subs(x, 0) * x**n / C.factorial(n)
+
     def lseries(self, x=None, x0=0, dir='+'):
         """
         Wrapper for series yielding an iterator of the terms of the series.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -600,17 +600,6 @@ class Function(Application, Expr):
         else:
             return self.func(*args)
 
-    @classmethod
-    def taylor_term(cls, n, x, *previous_terms):
-        """General method for the taylor term.
-
-        This method is slow, because it differentiates n-times. Subclasses can
-        redefine it to make it faster by using the "previous_terms".
-        """
-        x = sympify(x)
-        _x = Dummy('x')
-        return cls(_x).diff(_x, n).subs(_x, x).subs(x, 0) * x**n / C.factorial(n)
-
 
 class AppliedUndef(Function):
     """

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1016,7 +1016,7 @@ class Pow(Expr):
             l = []
             g = None
             for i in xrange(n + 2):
-                g = self.taylor_term(i, z, g)
+                g = self._taylor_term(i, z, g)
                 g = g.nseries(x, n=n, logx=logx)
                 l.append(g)
             r = Add(*l)
@@ -1028,10 +1028,7 @@ class Pow(Expr):
         return C.exp(self.exp * C.log(self.base)).as_leading_term(x)
 
     @cacheit
-    def taylor_term(self, n, x, *previous_terms):  # of (1+x)**e
-        if n < 0:
-            return S.Zero
-        x = _sympify(x)
+    def _taylor_term(self, n, x, *previous_terms): # of (1+x)**e
         return C.binomial(self.exp, n) * self.func(x, n)
 
     def _sage_(self):

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -302,3 +302,13 @@ def test_issue_3554s():
     assert (1 / sqrt(1 + cos(x) * sin(x**2))).series(x, 0, 15) == \
         1 - x**2/2 + 5*x**4/8 - 5*x**6/8 + 4039*x**8/5760 - 5393*x**10/6720 + \
         13607537*x**12/14515200 - 532056047*x**14/479001600 + O(x**15)
+
+
+def test_issue_3330():
+    x = Symbol('x')
+    c = Symbol('c')
+    f = (c**2 + x)**(0.5)
+    assert f.series(x, x0=0, n=1) == (c**2)**0.5 + O(x)
+    assert f.taylor_term(0, x) == (c**2)**0.5
+    assert f.taylor_term(1, x) == 0.5*x*(c**2)**(-0.5)
+    assert f.taylor_term(2, x) == -0.125*x**2*(c**2)**(-1.5)


### PR DESCRIPTION
- Generic taylor_term method was moved to Expr
- Old Pow.taylor_term now is a helper method (case `(1+x)**e`) 
