### PR TITLE
Ipython enhancements

### DIFF
--- a/bin/isympy
+++ b/bin/isympy
@@ -366,6 +366,8 @@ def main():
         args['qtconsole'] = True
     elif options.notebook:
         args['notebook'] = True
+        #prefer chrome (pre-import webbrowser)
+        os.environ['BROWSER'] = os.pathsep.join(("google-chrome", "chrome", "chromium", "chromium-browser"))
 
     args['quiet'] = options.quiet
     args['auto_symbols'] = options.auto_symbols or options.interactive

--- a/bin/isympy
+++ b/bin/isympy
@@ -188,6 +188,42 @@ if os.path.isdir(sympy_dir):
 
 # DO NOT IMPORT SYMPY HERE!
 
+## below copied from Python Lib/webbrowser.py
+## (c) PSF
+## for details, see: http://docs.python.org/license.html
+def _iscommand(cmd):
+    """Return True if cmd is executable or can be found on the executable
+    search path."""
+
+    if sys.platform[:3] == "win":
+        def _isexecutable(cmd):
+            cmd = cmd.lower()
+            if os.path.isfile(cmd) and cmd.endswith((".exe", ".bat")):
+                return True
+            for ext in ".exe", ".bat":
+                if os.path.isfile(cmd + ext):
+                    return True
+            return False
+    else:
+        def _isexecutable(cmd):
+            import stat
+            if os.path.isfile(cmd):
+                mode = os.stat(cmd)[stat.ST_MODE]
+                if mode & stat.S_IXUSR or mode & stat.S_IXGRP or mode & stat.S_IXOTH:
+                    return True
+            return False
+
+    if _isexecutable(cmd):
+        return True
+    path = os.environ.get("PATH")
+    if not path:
+        return False
+    for d in path.split(os.pathsep):
+        exe = os.path.join(d, cmd)
+        if _isexecutable(exe):
+            return True
+    return False
+
 def main():
     from optparse import OptionParser
 
@@ -340,7 +376,6 @@ def main():
             if not os.environ.get('BROWSER'):
                 chromes = ["google-chrome", "chrome", "chromium", "chromium-browser"]
                 chromes = [c for c in chromes if _iscommand(c)]
-                print(chromes)
                 os.environ['BROWSER'] = os.pathsep.join(chromes)
     else:
         try:
@@ -374,37 +409,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-## below copied from Python Lib/webbrowser.py
-## (c) PSF
-## for details, see: http://docs.python.org/license.html
-def _iscommand(cmd):
-    """Return True if cmd is executable or can be found on the executable
-    search path."""
-    if _isexecutable(cmd):
-        return True
-    path = os.environ.get("PATH")
-    if not path:
-        return False
-    for d in path.split(os.pathsep):
-        exe = os.path.join(d, cmd)
-        if _isexecutable(exe):
-            return True
-    return False
-
-if sys.platform[:3] == "win":
-    def _isexecutable(cmd):
-        cmd = cmd.lower()
-        if os.path.isfile(cmd) and cmd.endswith((".exe", ".bat")):
-            return True
-        for ext in ".exe", ".bat":
-            if os.path.isfile(cmd + ext):
-                return True
-        return False
-else:
-    def _isexecutable(cmd):
-        if os.path.isfile(cmd):
-            mode = os.stat(cmd)[stat.ST_MODE]
-            if mode & stat.S_IXUSR or mode & stat.S_IXGRP or mode & stat.S_IXOTH:
-                return True
-        return False

--- a/bin/isympy
+++ b/bin/isympy
@@ -220,8 +220,9 @@ def main():
         dest='console',
         action='store',
         default=None,
-        choices=['ipython', 'python'],
-        help='select type of interactive session: ipython | python; defaults '
+        choices=['ipython', 'python', 'qtconsole', 'notebook'],
+        help='select type of interactive session: ipython | python | '
+        'qtconsole | notebook ; defaults '
         'to ipython if IPython is installed, otherwise python')
 
     parser.add_option(
@@ -299,22 +300,15 @@ def main():
         default=False,
         help='enable debugging output')
 
-    parser.add_option(
-        '--qt',
-        dest='qt',
-        action='store_true',
-        default=False,
-        help="enable IPython's qtconsole")
-
-    parser.add_option(
-        '--notebook',
-        dest='notebook',
-        action='store_true',
-        default=False,
-        help="enable IPython's notebook mode")
-
-
     (options, ipy_args) = parser.parse_args()
+
+    args = {
+        'pretty_print': True,
+        'use_unicode':  None,
+        'use_latex':    None,
+        'order':        None,
+        'argv':         ipy_args,
+    }
 
     if not options.cache:
         os.environ['SYMPY_USE_CACHE'] = 'no'
@@ -332,7 +326,22 @@ def main():
     session = options.console
 
     if session is not None:
-        ipython = session == 'ipython'
+        ipython = session in ('ipython', 'qtconsole', 'notebook')
+
+        if session == 'qtconsole':
+            args['qtconsole'] = True
+        elif session == 'notebook':
+            args['notebook'] = True
+            # unless user has already specified otherwise, prefer chrome
+            # it should happen before the first import of the 'webbrowser'
+            # module which happens in IPython.html.notebookapp as of the time
+            # this was written, but let's do it before any external imports
+            # just to be safe
+            if not os.environ.get('BROWSER'):
+                chromes = ["google-chrome", "chrome", "chromium", "chromium-browser"]
+                chromes = [c for c in chromes if _iscommand(c)]
+                print(chromes)
+                os.environ['BROWSER'] = os.pathsep.join(chromes)
     else:
         try:
             import IPython
@@ -343,14 +352,6 @@ def main():
                 print(no_ipython)
             ipython = False
 
-    args = {
-        'pretty_print': True,
-        'use_unicode':  None,
-        'use_latex':    None,
-        'order':        None,
-        'argv':         ipy_args,
-    }
-
     if options.pretty == 'unicode':
         args['use_unicode'] = True
     elif options.pretty == 'ascii':
@@ -360,14 +361,6 @@ def main():
 
     if options.order is not None:
         args['order'] = options.order
-
-    # these are mutually exclusive
-    if options.qt:
-        args['qtconsole'] = True
-    elif options.notebook:
-        args['notebook'] = True
-        #prefer chrome (pre-import webbrowser)
-        os.environ['BROWSER'] = os.pathsep.join(("google-chrome", "chrome", "chromium", "chromium-browser"))
 
     args['quiet'] = options.quiet
     args['auto_symbols'] = options.auto_symbols or options.interactive
@@ -381,3 +374,38 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+## below copied from Python Lib/webbrowser.py
+## (c) PSF
+## for details, see: http://docs.python.org/license.html
+def _iscommand(cmd):
+    """Return True if cmd is executable or can be found on the executable
+    search path."""
+    if _isexecutable(cmd):
+        return True
+    path = os.environ.get("PATH")
+    if not path:
+        return False
+    for d in path.split(os.pathsep):
+        exe = os.path.join(d, cmd)
+        if _isexecutable(exe):
+            return True
+    return False
+
+if sys.platform[:3] == "win":
+    def _isexecutable(cmd):
+        cmd = cmd.lower()
+        if os.path.isfile(cmd) and cmd.endswith((".exe", ".bat")):
+            return True
+        for ext in ".exe", ".bat":
+            if os.path.isfile(cmd + ext):
+                return True
+        return False
+else:
+    def _isexecutable(cmd):
+        if os.path.isfile(cmd):
+            mode = os.stat(cmd)[stat.ST_MODE]
+            if mode & stat.S_IXUSR or mode & stat.S_IXGRP or mode & stat.S_IXOTH:
+                return True
+        return False
+

--- a/bin/isympy
+++ b/bin/isympy
@@ -408,4 +408,3 @@ else:
             if mode & stat.S_IXUSR or mode & stat.S_IXGRP or mode & stat.S_IXOTH:
                 return True
         return False
-

--- a/bin/isympy
+++ b/bin/isympy
@@ -299,6 +299,14 @@ def main():
         default=False,
         help='enable debugging output')
 
+    parser.add_option(
+        '--qt',
+        dest='qt',
+        action='store_true',
+        default=False,
+        help="enable IPython's qtconsole")
+
+
     (options, ipy_args) = parser.parse_args()
 
     if not options.cache:
@@ -345,6 +353,8 @@ def main():
 
     if options.order is not None:
         args['order'] = options.order
+    if options.qt:
+        args['qtconsole'] = True
 
     args['quiet'] = options.quiet
     args['auto_symbols'] = options.auto_symbols or options.interactive

--- a/bin/isympy
+++ b/bin/isympy
@@ -306,6 +306,13 @@ def main():
         default=False,
         help="enable IPython's qtconsole")
 
+    parser.add_option(
+        '--notebook',
+        dest='notebook',
+        action='store_true',
+        default=False,
+        help="enable IPython's notebook mode")
+
 
     (options, ipy_args) = parser.parse_args()
 
@@ -353,8 +360,12 @@ def main():
 
     if options.order is not None:
         args['order'] = options.order
+
+    # these are mutually exclusive
     if options.qt:
         args['qtconsole'] = True
+    elif options.notebook:
+        args['notebook'] = True
 
     args['quiet'] = options.quiet
     args['auto_symbols'] = options.auto_symbols or options.interactive

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -38,7 +38,8 @@ def _make_message(ipython=True, quiet=False, source=None):
     python_version = "%d.%d.%d" % sys.version_info[:3]
 
     if ipython:
-        shell_name = "IPython"
+        import IPython
+        shell_name = "IPython %s" % IPython.__version__
     else:
         shell_name = "Python"
 

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -293,7 +293,11 @@ def init_ipython_session(argv=(), auto_symbols=False, auto_int_to_Integer=False,
                 time.sleep(1e6) # will be woken up when parent sends a signal
             else: # parent
                 child_pid['pid'] = pid
-                from IPython.qt.console.qtconsoleapp import IPythonQtConsoleApp as App
+                try:
+                    from IPython.qt.console.qtconsoleapp import IPythonQtConsoleApp as App
+                except ImportError as e:
+                    os.kill(pid, signal.SIGTERM)
+                    raise RuntimeError("IPython >=1.0 required for this feature")
         elif notebook:
             pid = os.fork()
             if pid == 0: # child
@@ -301,7 +305,12 @@ def init_ipython_session(argv=(), auto_symbols=False, auto_int_to_Integer=False,
                 time.sleep(1e6) # will be woken up when parent sends a signal
             else: # parent
                 child_pid['pid'] = pid
-                from IPython.html.notebookapp import NotebookApp
+                try:
+                    from IPython.html.notebookapp import NotebookApp
+                except ImportError as e:
+                    os.kill(pid, signal.SIGTERM)
+                    raise RuntimeError("IPython >=1.0 required for this feature")
+
                 App = NotebookApp.instance
         elif IPython.__version__ >= '1.0':
             from IPython.terminal.ipapp import TerminalIPythonApp as App

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -3,6 +3,8 @@
 from __future__ import print_function, division
 import sys
 import os
+import webbrowser
+import urlparse
 
 from sympy.interactive.printing import init_printing
 
@@ -269,7 +271,7 @@ def enable_automatic_symbols(app):
         app.set_custom_exc((NameError,), _handler)
 
 
-def init_ipython_session(argv=[], auto_symbols=False, auto_int_to_Integer=False,
+def init_ipython_session(argv=(), auto_symbols=False, auto_int_to_Integer=False,
                          qtconsole=False, notebook=False):
     """Construct new IPython session. """
     import IPython
@@ -339,7 +341,7 @@ def init_python_session():
 
 def init_session(ipython=None, pretty_print=True, order=None,
         use_unicode=None, use_latex=None, quiet=False, auto_symbols=False,
-        auto_int_to_Integer=False, argv=[], qtconsole=False, notebook=False):
+        auto_int_to_Integer=False, argv=(), qtconsole=False, notebook=False):
     """
     Initialize an embedded IPython or Python session. The IPython session is
     initiated with the --pylab option, without the numpy imports, so that
@@ -484,8 +486,16 @@ def init_session(ipython=None, pretty_print=True, order=None,
         notebook_id = ip_app.notebook_manager.new_notebook()
         kernel_id = ip_app.kernel_manager.start_kernel(notebook_id)
         kernel = ip_app.kernel_manager.get_kernel(kernel_id)
-        kernel.shell_channel.execute('%pylab inline')
-        kernel.shell_channel.execute(preexec_source)
+        client = kernel.client()
+        client.shell_channel.execute('%pylab inline')
+        client.shell_channel.execute(preexec_source)
+        ip = ip_app.ip or LOCALHOST
+        proto = 'https' if ip_app.certfile else 'http'
+        base_url = r"%s://%s:%i" % (proto, ip, ip_app.port, )
+        from IPython.html.utils import url_path_join
+        url = url_path_join(base_url, ip_app.base_project_url, notebook_id)
+        g = webbrowser.get()
+        g.open(url)
     else:
         try:
              ip.run_cell(preexec_source, False)

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -290,24 +290,32 @@ def init_ipython_session(argv=(), auto_symbols=False, auto_int_to_Integer=False,
             pid = os.fork()
             if pid == 0: # child
                 signal.signal(signal.SIGUSR1, send_sympy_init)
-                time.sleep(1e6) # will be woken up when parent sends a signal
+                # will be woken up when parent sends a signal, but exit on
+                # our own after 10 minutes anyway, in case something goes wrong
+                time.sleep(600)
+                sys.exit(1)
             else: # parent
                 child_pid['pid'] = pid
                 try:
                     from IPython.qt.console.qtconsoleapp import IPythonQtConsoleApp as App
                 except ImportError as e:
+                    # kill the child process if there is any error
                     os.kill(pid, signal.SIGTERM)
                     raise RuntimeError("IPython >=1.0 required for this feature")
         elif notebook:
             pid = os.fork()
             if pid == 0: # child
                 signal.signal(signal.SIGUSR1, send_sympy_init)
-                time.sleep(1e6) # will be woken up when parent sends a signal
+                time.sleep(600)
+                # will be woken up when parent sends a signal, but exit on
+                # our own after 10 minutes anyway, in case something goes wrong
+                sys.exit(1)
             else: # parent
                 child_pid['pid'] = pid
                 try:
                     from IPython.html.notebookapp import NotebookApp
                 except ImportError as e:
+                    # kill the child process if there is any error
                     os.kill(pid, signal.SIGTERM)
                     raise RuntimeError("IPython >=1.0 required for this feature")
 

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -505,12 +505,10 @@ def init_session(ipython=None, pretty_print=True, order=None,
         ip = ip_app.ip or LOCALHOST
         proto = 'https' if ip_app.certfile else 'http'
         base_url = r"%s://%s:%i" % (proto, ip, ip_app.port, )
-        import webbrowser
-        g = webbrowser.get()
-
         from IPython.html.utils import url_path_join
         url = url_path_join(base_url, ip_app.base_project_url, notebook_id)
-        g.open(url)
+        import webbrowser
+        webbrowser.open(url)
     elif not qtconsole:
         try:
             ip.run_cell(preexec_source, False)

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -24,7 +24,7 @@ def test_automatic_symbols():
     # NOTE: Because of the way the hook works, you have to use run_cell(code,
     # True).  This means that the code must have no Out, or it will be printed
     # during the tests.
-    app = init_ipython_session()
+    app = init_ipython_session().shell
     app.run_cell("from sympy import *")
 
     enable_automatic_symbols(app)
@@ -51,7 +51,7 @@ def test_automatic_symbols():
 
 def test_int_to_Integer():
     # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
-    app = init_ipython_session()
+    app = init_ipython_session().shell.shell
     app.run_cell("a = 1")
     assert isinstance(app.user_ns['a'], int)
 

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -51,7 +51,7 @@ def test_automatic_symbols():
 
 def test_int_to_Integer():
     # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
-    app = init_ipython_session().shell.shell
+    app = init_ipython_session().shell
     app.run_cell("a = 1")
     assert isinstance(app.user_ns['a'], int)
 

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -13,7 +13,7 @@ if not ipython:
 
 def test_ipythonprinting():
     # Initialize and setup IPython session
-    app = init_ipython_session()
+    app = init_ipython_session().shell
     app.run_cell("ip = get_ipython()")
     app.run_cell("inst = ip.instance()")
     app.run_cell("format = inst.display_formatter.format")


### PR DESCRIPTION
this allows one to call isympy with either the --qt or --notebook flag and have isympy open up the corresponding ipython session type, with sympy already loaded (just like in the terminal), and with printing set up properly.

This only works with the latest testing IPython (1.0.dev), since it is new functionality, it is easy not to write to old APIs. It can always be backported to other IPython versions if 1.0 takes a while to reach a wide enough audience.

no existing functionality should be affected by this patch.
