### PR TITLE
Don't evaluate derivatives for O expressions

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -790,13 +790,8 @@ class Integral(AddWithLimits):
                 h = self._eval_integral(g.removeO(), x)
 
                 if h is not None:
-                    h_order_expr = self._eval_integral(order_term.expr, x)
-
-                    if h_order_expr is not None:
-                        h_order_term = order_term.func(
-                            h_order_expr, *order_term.variables)
-                        parts.append(coeff*(h + h_order_term))
-                        continue
+                    parts.append(coeff*(h + self.func(order_term, *self.limits)))
+                    continue
 
                 # NOTE: if there is O(x**n) and we fail to integrate then there is
                 # no point in trying other methods because they will fail anyway.

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -790,8 +790,13 @@ class Integral(AddWithLimits):
                 h = self._eval_integral(g.removeO(), x)
 
                 if h is not None:
-                    parts.append(coeff*(h + self.func(order_term, *self.limits)))
-                    continue
+                    h_order_expr = self._eval_integral(order_term.expr, x)
+
+                    if h_order_expr is not None:
+                        h_order_term = order_term.func(
+                            h_order_expr, *order_term.variables)
+                        parts.append(coeff*(h + h_order_term))
+                        continue
 
                 # NOTE: if there is O(x**n) and we fail to integrate then there is
                 # no point in trying other methods because they will fail anyway.

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -898,12 +898,13 @@ def test_issue_5178():
 
 def test_integrate_series():
     f = sin(x).series(x, 0, 10)
-    g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + x**10/3628800 + O(x**11)
+    g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + \
+        x**10/3628800 + Integral(O(x**10), x)
 
     assert integrate(f, x) == g
     assert diff(integrate(f, x), x) == f
 
-    assert integrate(O(x**5), x) == O(x**6)
+    assert integrate(O(x**5), x) == Integral(O(x**5), x)
 
 
 def test_atom_bug():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -901,7 +901,6 @@ def test_integrate_series():
     g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + x**10/3628800 + O(x**11)
 
     assert integrate(f, x) == g
-    assert diff(integrate(f, x), x) == f
 
     assert integrate(O(x**5), x) == O(x**6)
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -898,13 +898,12 @@ def test_issue_5178():
 
 def test_integrate_series():
     f = sin(x).series(x, 0, 10)
-    g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + \
-        x**10/3628800 + Integral(O(x**10), x)
+    g = x**2/2 - x**4/24 + x**6/720 - x**8/40320 + x**10/3628800 + O(x**11)
 
     assert integrate(f, x) == g
     assert diff(integrate(f, x), x) == f
 
-    assert integrate(O(x**5), x) == Integral(O(x**5), x)
+    assert integrate(O(x**5), x) == O(x**6)
 
 
 def test_atom_bug():

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -428,9 +428,6 @@ class Order(Expr):
         if expr is not None:
             return self.func(expr, *self.args[1:])
 
-    def _eval_derivative(self, x):
-        return self.func(self.expr.diff(x), *self.args[1:]) or self
-
     def _eval_transpose(self):
         expr = self.expr._eval_transpose()
         if expr is not None:

--- a/sympy/series/tests/test_nseries.py
+++ b/sympy/series/tests/test_nseries.py
@@ -497,7 +497,7 @@ def test_issue_5183():
     assert ((1 + x)**2).series(x, n=6) == 1 + 2*x + x**2
     assert (1 + 1/x).series() == 1 + 1/x
     assert Derivative(exp(x).series(), x).doit() == \
-        1 + x + x**2/2 + x**3/6 + x**4/24 + O(x**5)
+        1 + x + x**2/2 + x**3/6 + x**4/24 + Derivative(O(x**6), x)
 
 
 def test_issue_5654():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Rational, Order, exp, ln, log, nan, oo, O, pi, I,
     S, Integral, sin, cos, sqrt, conjugate, expand, transpose, symbols,
-    Function)
+    Function, Derivative)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import w, x, y, z
 
@@ -262,7 +262,9 @@ def test_getn():
 
 
 def test_diff():
-    assert O(x**2).diff(x) == O(x)
+    assert O(1).diff(x) == 0
+    assert O(1, x).diff(x) == Derivative(O(1, x), x)
+    assert O(x**2).diff(x) == Derivative(O(x**2), x)
 
 
 def test_getO():


### PR DESCRIPTION
Quote from [issue 4855](https://github.com/sympy/sympy/issues/4855#issuecomment-36995154):

> Strictly speaking, even a O(1) function could have a derivative that is as large as you like, so long as the function itself is bounded by a constant.  Consider for example sin(x**2).

Lets keep derivatives unevaluated:

```
In [1]: O(1, x).diff(x)
Out[1]: 
d       
──(O(1))
dx      
```
