### PR TITLE
Fix test failures in master

### DIFF
--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -22,7 +22,7 @@ def deprecated(**decorator_kwargs):
         def new_func(*args, **kwargs):
             from sympy.utilities.exceptions import SymPyDeprecationWarning
             decorator_kwargs.setdefault('feature', func.__name__)
-            SymPyDeprecationWarning(**decorator_kwargs).warn()
+            SymPyDeprecationWarning(**decorator_kwargs).warn(stacklevel=3)
             return func(*args, **kwargs)
         return new_func
     return deprecated_decorator

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -26,7 +26,8 @@ def test_all_classes_are_tested():
     modules = {}
 
     # Ignore sympy.statistics import warning
-    warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+    warnings.filterwarnings("ignore", message="sympy.statistics has been deprecated since SymPy 0.7.2",
+        category=SymPyDeprecationWarning)
 
     for root, dirs, files in os.walk(sympy_path):
         module = root.replace(prefix, "").replace(os.sep, ".")
@@ -72,7 +73,8 @@ def test_all_classes_are_tested():
             if test not in ns:
                 failed.append(module + '.' + name)
 
-    warnings.filterwarnings("default", category=SymPyDeprecationWarning)
+    # reset all SymPyDeprecationWarning into errors
+    warnings.simplefilter("error", category=SymPyDeprecationWarning)
 
     assert not failed, "Missing classes: %s.  Please add tests for these to sympy/core/tests/test_args.py." % ", ".join(failed)
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -469,12 +469,6 @@ def test_sympy__sets__fancysets__Reals():
     from sympy.sets.fancysets import Reals
     assert _test_args(Reals())
 
-@XFAIL  # This fails because it raises a SymPyDeprecationWarning
-def test_sympy__sets__fancysets__TransformationSet():
-    from sympy.sets.fancysets import TransformationSet
-    from sympy import S, Lambda, Symbol
-    x = Symbol('x')
-    assert _test_args(TransformationSet(Lambda(x, x**2), S.Naturals))
 
 def test_sympy__sets__fancysets__ImageSet():
     from sympy.sets.fancysets import ImageSet

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -469,6 +469,7 @@ def test_sympy__sets__fancysets__Reals():
     from sympy.sets.fancysets import Reals
     assert _test_args(Reals())
 
+@XFAIL  # This fails because it raises a SymPyDeprecationWarning
 def test_sympy__sets__fancysets__TransformationSet():
     from sympy.sets.fancysets import TransformationSet
     from sympy import S, Lambda, Symbol

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -3,7 +3,7 @@ from sympy import (Symbol, Wild, GreaterThan, LessThan, StrictGreaterThan,
 )
 
 from sympy.core.compatibility import u
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 
@@ -200,10 +200,7 @@ def test_Wild_properties():
                 assert d is None
 
 
-@XFAIL
 def test_symbols_each_char():
-    # XXX: Because of the way the warnings filters work, this will fail if it's
-    # run more than once in the same session.  See issue 2492.
     import warnings
     # each_char is deprecated and emits a warning.
 
@@ -212,12 +209,11 @@ def test_symbols_each_char():
     y = Symbol('y')
     z = Symbol('z')
 
-    # First, test the warning
-    warnings.filterwarnings("error")
+    # First, test the warning (SymPyDeprecationWarning should already raises during tests)
     raises(SymPyDeprecationWarning, lambda: symbols('xyz', each_char=True))
     raises(SymPyDeprecationWarning, lambda: symbols('xyz', each_char=False))
     # now test the actual output
-    warnings.filterwarnings("ignore")
+    warnings.simplefilter("ignore", SymPyDeprecationWarning)
     assert symbols(['wx', 'yz'], each_char=True) == [(w, x), (y, z)]
     assert all(w.is_Function for w in flatten(
         symbols(['wx', 'yz'], each_char=True, cls=Function)))
@@ -243,11 +239,7 @@ def test_symbols_each_char():
     assert symbols('x1:3', each_char=False) == (Symbol('x1'), Symbol('x2'))
 
     # Keep testing reasonably thread safe, so reset the warning
-    warnings.filterwarnings("default", "The each_char option to symbols\(\) and var\(\) is "
-        "deprecated.  Separate symbol names by spaces or commas instead.")
-    # Note, in Python 2.6+, this can be done more nicely using the
-    # warnings.catch_warnings context manager.
-    # See http://docs.python.org/library/warnings#testing-warnings.
+    warnings.simplefilter("error", SymPyDeprecationWarning)
 
 
 def test_symbols():

--- a/sympy/external/tests/test_codegen.py
+++ b/sympy/external/tests/test_codegen.py
@@ -22,6 +22,8 @@
 # is somewhere in the path and that it can compile ANSI C code.
 
 
+from __future__ import print_function
+
 from sympy.abc import x, y, z
 from sympy.utilities.pytest import skip
 from sympy.utilities.codegen import(

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,3 +1,5 @@
+import warnings
+
 from sympy import (Abs, C, Dummy, Rational, Float, S, Symbol, cos, oo, pi,
                    simplify, sin, sqrt, symbols, tan)
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
@@ -7,7 +9,7 @@ from sympy.geometry.line import Undecidable
 from sympy.geometry.entity import rotate, scale, translate
 from sympy.geometry.polygon import _asa as asa, rad, deg
 from sympy.utilities.randtest import test_numerically
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises
 
 x = Symbol('x', real=True)
 y = Symbol('y', real=True)
@@ -669,8 +671,12 @@ def test_polygon():
         Polygon(Point(10, 10), Point(14, 14), Point(10, 14))) == 6 * sqrt(2)
     assert p5.distance(
         Polygon(Point(1, 8), Point(5, 8), Point(8, 12), Point(1, 12))) == 4
+    warnings.filterwarnings(
+        "error", message="Polygons may intersect producing erroneous output")
     raises(UserWarning,
            lambda: Polygon(Point(0, 0), Point(1, 0), Point(1, 1)).distance(Polygon(Point(0, 0), Point(0, 1), Point(1, 1))))
+    warnings.filterwarnings(
+        "ignore", message="Polygons may intersect producing erroneous output")
     assert hash(p5) == hash(Polygon(Point(0, 0), Point(4, 4), Point(0, 4)))
     assert p5 == Polygon(Point(4, 4), Point(0, 4), Point(0, 0))
     assert Polygon(Point(4, 4), Point(0, 4), Point(0, 0)) in p5
@@ -848,33 +854,19 @@ def test_polygon():
     assert p2.distance(pt1) == Rational(3)/4
     assert p3.distance(pt2) == sqrt(2)/2
 
-
-@XFAIL
-def test_polygon_to_polygon():
     '''Polygon to Polygon'''
-    # XXX: Because of the way the warnings filters work, this will fail if it's
-    # run more than once in the same session.  See issue 2492.
-
-    import warnings
     # p1.distance(p2) emits a warning
     # First, test the warning
-    warnings.filterwarnings(
-        "error", "Polygons may intersect producing erroneous output")
+    warnings.filterwarnings("error",
+        message="Polygons may intersect producing erroneous output")
     raises(UserWarning, lambda: p1.distance(p2))
     # now test the actual output
-    warnings.filterwarnings(
-        "ignore", "Polygons may intersect producing erroneous output")
+    warnings.filterwarnings("ignore",
+        message="Polygons may intersect producing erroneous output")
     assert p1.distance(p2) == half/2
-    # Keep testing reasonably thread safe, so reset the warning
-    warnings.filterwarnings(
-        "default", "Polygons may intersect producing erroneous output")
-    # Note, in Python 2.6+, this can be done more nicely using the
-    # warnings.catch_warnings context manager.
-    # See http://docs.python.org/library/warnings#testing-warnings.
 
     assert p1.distance(p3) == sqrt(2)/2
     assert p3.distance(p4) == (sqrt(2)/2 - sqrt(Rational(2)/25)/2)
-    assert p5.distance(p6) == Rational(7)/10
 
 
 def test_convex_hull():

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -196,13 +196,12 @@ class ImageSet(Set):
     def is_iterable(self):
         return self.base_set.is_iterable
 
-class TransformationSet(ImageSet):
-    @deprecated(useinstead="ImageSet",
-                deprecated_since_version="0.7.4",
-                issue=3958,
-                feature="TransformationSet")
-    def __init__(self, *args):
-        pass
+
+@deprecated(useinstead="ImageSet", issue=3958, deprecated_since_version="0.7.4")
+def TransformationSet(*args, **kwargs):
+    """Deprecated alias for the ImageSet constructor."""
+    return ImageSet(*args, **kwargs)
+
 
 class Range(Set):
     """

--- a/sympy/statistics/tests/test_statistics.py
+++ b/sympy/statistics/tests/test_statistics.py
@@ -12,12 +12,13 @@ from sympy.utilities.tests.test_pickling import check
 
 import warnings
 from sympy.utilities.exceptions import SymPyDeprecationWarning
-warnings.filterwarnings("ignore", category=SymPyDeprecationWarning)
+warnings.filterwarnings("ignore", message="sympy.statistics has been deprecated since SymPy 0.7.2",
+    category=SymPyDeprecationWarning)
 
 from sympy.statistics.distributions import (Normal, Uniform, Sample, PDF,
     ContinuousProbability)
 
-warnings.filterwarnings("default")
+warnings.simplefilter("error", category=SymPyDeprecationWarning)
 
 x, y, z = symbols('x y z')
 
@@ -79,7 +80,6 @@ def test_fit():
 
 
 def test_sample():
-    from sympy.statistics.distributions import Sample
     s = Sample([0, 1])
     assert str(s) == "Sample([0, 1])"
     assert repr(s) == "Sample([0, 1])"
@@ -132,8 +132,6 @@ def test_printing():
     assert str(Uniform(x + y, y)) == "Uniform(x + y, y)"
 
 def test_pickling():
-    x = Symbol("x")
-    y = Symbol("y")
     for c in (ContinuousProbability, ContinuousProbability(), Normal,
               Normal(x, y), Sample, Sample([1, 3, 4]), Uniform, Uniform(x, y)):
         check(c)

--- a/sympy/stats/frv.py
+++ b/sympy/stats/frv.py
@@ -193,6 +193,9 @@ class SingleFiniteDistribution(Basic, NamedArgsMixin):
 
     __call__ = pdf
 
+    def __contains__(self, other):
+        return other in self.set
+
 
 #=============================================
 #=========  Probability Space  ===============

--- a/sympy/utilities/exceptions.py
+++ b/sympy/utilities/exceptions.py
@@ -4,8 +4,9 @@ General SymPy exceptions and warnings.
 
 from __future__ import print_function, division
 
+import warnings
+
 from sympy.utilities.misc import filldedent
-from warnings import warn as warning
 
 
 class SymPyDeprecationWarning(DeprecationWarning):
@@ -145,7 +146,9 @@ class SymPyDeprecationWarning(DeprecationWarning):
     def __str__(self):
         return '\n%s\n' % filldedent(self.fullMessage)
 
-    def warn(self):
-        see_above = self
-        # the next line is what the user will see after the error is printed
-        warning(see_above, SymPyDeprecationWarning)
+    def warn(self, stacklevel=2):
+        see_above = self.fullMessage
+        # the next line is what the user would see after the error is printed
+        # if stacklevel was set to 1. If you are writting a wrapper around this,
+        # increase the stacklevel accordingly.
+        warnings.warn(see_above, SymPyDeprecationWarning, stacklevel=stacklevel)

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -909,7 +909,7 @@ class SymPyTests(object):
                     value = Tuple(values, Load())
                     assign = Assign([target], value)
                     new_compare = Compare(names_load[0], compare.ops, names_load[1:])
-                    msg_format = "%s " + " %s ".join([ ops[op.__class__.__name__] for op in compare.ops ]) + " %s"
+                    msg_format = "\n%s " + "\n%s ".join([ ops[op.__class__.__name__] for op in compare.ops ]) + "\n%s"
                     msg = BinOp(Str(msg_format), Mod(), Tuple(names_load, Load()))
                     test = Assert(new_compare, msg, lineno=stmt.lineno, col_offset=stmt.col_offset)
                     return [assign, test]

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -76,7 +76,9 @@ def check(a, exclude=[], check_attr=True):
         c(a, b, d1)
         c(b, a, d2)
 
-    warnings.filterwarnings("default", category=SymPyDeprecationWarning)
+    # reset filters
+    warnings.simplefilter("default", category=DeprecationWarning)
+    warnings.simplefilter("error", category=SymPyDeprecationWarning)
 
 #================== core =========================
 


### PR DESCRIPTION
Issue 2492: Better way to test warnings
https://code.google.com/p/sympy/issues/detail?id=2492

Issue 3964: Test failure in master: **contains** deprecated in test_finite_rv.py
https://code.google.com/p/sympy/issues/detail?id=3964
