### PR TITLE
Pull request to integrate qasm parser

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2232,11 +2232,6 @@ def test_sympy__physics__quantum__piab__PIABKet():
     from sympy.physics.quantum.piab import PIABKet
     assert _test_args(PIABKet('K'))
 
-def test_sympy__pysics__quantum__qasm__Qasm():
-    from sympy.physics.quantum.qasm import Qasm
-    assert _test_args(Qasm('qubit qo'))
-
-
 def test_sympy__physics__quantum__qexpr__QExpr():
     from sympy.physics.quantum.qexpr import QExpr
     assert _test_args(QExpr(0))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2262,11 +2262,6 @@ def test_sympy__physics__quantum__piab__PIABKet():
     from sympy.physics.quantum.piab import PIABKet
     assert _test_args(PIABKet('K'))
 
-def test_sympy__pysics__quantum__qasm__Qasm():
-    from sympy.physics.quantum.qasm import Qasm
-    assert _test_args(Qasm('qubit qo'))
-
-
 def test_sympy__physics__quantum__qexpr__QExpr():
     from sympy.physics.quantum.qexpr import QExpr
     assert _test_args(QExpr(0))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2262,6 +2262,11 @@ def test_sympy__physics__quantum__piab__PIABKet():
     from sympy.physics.quantum.piab import PIABKet
     assert _test_args(PIABKet('K'))
 
+def test_sympy__pysics__quantum__qasm__Qasm():
+    from sympy.physics.quantum.qasm import Qasm
+    assert _test_args(Qasm('qubit qo'))
+
+
 def test_sympy__physics__quantum__qexpr__QExpr():
     from sympy.physics.quantum.qexpr import QExpr
     assert _test_args(QExpr(0))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2232,6 +2232,10 @@ def test_sympy__physics__quantum__piab__PIABKet():
     from sympy.physics.quantum.piab import PIABKet
     assert _test_args(PIABKet('K'))
 
+def test_sympy__pysics__quantum__qasm__Qasm():
+    from sympy.physics.quantum.qasm import Qasm
+    assert _test_args(Qasm('qubit qo'))
+
 
 def test_sympy__physics__quantum__qexpr__QExpr():
     from sympy.physics.quantum.qexpr import QExpr

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2262,6 +2262,10 @@ def test_sympy__physics__quantum__piab__PIABKet():
     from sympy.physics.quantum.piab import PIABKet
     assert _test_args(PIABKet('K'))
 
+def test_sympy__pysics__quantum__qasm__Qasm():
+    from sympy.physics.quantum.qasm import Qasm
+    assert _test_args(Qasm('qubit qo'))
+
 
 def test_sympy__physics__quantum__qexpr__QExpr():
     from sympy.physics.quantum.qexpr import QExpr

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -44,6 +44,9 @@ else:
     Line2D = matplotlib.lines.Line2D
     Circle = matplotlib.patches.Circle
 
+    #from matplotlib import rc
+    #rc('text',usetex=True)
+
     class CircuitPlot(object):
         """A class for managing a circuit plot."""
 
@@ -340,4 +343,3 @@ class CreateOneQubitGate(ManagedProperties):
 
 def CreateCGate(ctrls,onequbitgate):
     return CGate(tuple(ctrls),onequbitgate)
-    

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -24,6 +24,7 @@ __all__ = [
     'labeller',
     'Mz',
     'Mx',
+    'CreateOneQubitGate',
 ]
 
 np = import_module('numpy')
@@ -325,3 +326,18 @@ class Mx(OneQubitGate):
     measurement = True
     gate_name='Mx'
     gate_name_latex=u'M_x'
+
+# Testing defined gates
+from sympy.core.core import BasicMeta 
+from sympy.core.assumptions import ManagedProperties 
+
+class CreateOneQubitGate(ManagedProperties): 
+    def __new__(mcl, name, latexname=None):
+        if not latexname:
+            latexname = name
+        return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
+                                 {'gate_name': name, 'gate_name_latex': latexname})
+
+def CreateCGate(ctrls,onequbitgate):
+    return CGate(tuple(ctrls),onequbitgate)
+    

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -344,5 +344,12 @@ class CreateOneQubitGate(ManagedProperties):
         return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
                                  {'gate_name': name, 'gate_name_latex': latexname})
 
-def CreateCGate(ctrls,onequbitgate):
-    return CGate(tuple(ctrls),onequbitgate)
+def CreateCGate(name,latexname=None):
+    """Use a lexical closure to make a controlled gate.
+    """
+    if not latexname:
+        latexname = name
+    onequbitgate = CreateOneQubitGate(name,latexname)
+    def ControlledGate(ctrls,target):
+        return CGate(tuple(ctrls),onequbitgate(target))
+    return ControlledGate

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -119,7 +119,7 @@ else:
                 if self.labels:
                     self._axes.text(
                         xdata[0]-self.label_buffer,ydata[0],
-                        r'$|%s\rangle$' % self.labels[i],
+                        render_label(self.labels[i]),
                         size=self.fontsize,
                         color='k',ha='center',va='center')
             self._plot_measured_wires()
@@ -298,6 +298,15 @@ else:
             as big as the largest `min_qubits`` of the gates.
         """
         return CircuitPlot(c, nqubits, **kwargs)
+
+def render_label(label):
+    """Slightly more flexible way to render labels.
+    >>> from sympy.physics.quantum.circuitplot import render_label
+    >>> render_label('q0')
+    '$|q0\\\\rangle$'
+    My attempt to include the initialization strings failed, e.g. qubit q0,0
+    """
+    return r'$|%s\rangle$' % label
 
 def labeller(n,symbol='q'):
     """Autogenerate labels for wires of quantum circuits.

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -19,7 +19,7 @@ from __future__ import print_function, division
 from sympy import Mul
 from sympy.core.compatibility import u
 from sympy.external import import_module
-from sympy.physics.quantum.gate import Gate,OneQubitGate,CGate,CGateS
+from sympy.physics.quantum.gate import Gate, OneQubitGate, CGate, CGateS
 from sympy.core.core import BasicMeta
 from sympy.core.assumptions import ManagedProperties
 
@@ -147,13 +147,13 @@ else:
                 self._axes.add_line(line)
             # Also double any controlled lines off these wires
             for i,g in enumerate(self._gates()):
-                if isinstance(g,CGate) or isinstance(g,CGateS):
+                if isinstance(g, CGate) or isinstance(g, CGateS):
                     wires = g.controls + g.targets
                     for wire in wires:
                         if wire in ismeasured and \
                                self._gate_grid[i] > self._gate_grid[ismeasured[wire]]:
-                            ydata = min(wires),max(wires)
-                            xdata = self._gate_grid[i]-dy,self._gate_grid[i]-dy
+                            ydata = min(wires), max(wires)
+                            xdata = self._gate_grid[i]-dy, self._gate_grid[i]-dy
                             line = Line2D(
                                 xdata, ydata,
                                 color='k',
@@ -306,20 +306,20 @@ else:
         """
         return CircuitPlot(c, nqubits, **kwargs)
 
-def render_label(label,inits={}):
+def render_label(label, inits={}):
     """Slightly more flexible way to render labels.
     >>> from sympy.physics.quantum.circuitplot import render_label
     >>> render_label('q0')
     '$|q0\\\\rangle$'
-    >>> render_label('q0',{'q0':'0'})
+    >>> render_label('q0', {'q0':'0'})
     '$|q0\\\\rangle=|0\\\\rangle$'
     """
     init = inits.get(label)
     if init:
-        return r'$|%s\rangle=|%s\rangle$' % (label,init)
+        return r'$|%s\rangle=|%s\rangle$' % (label, init)
     return r'$|%s\rangle$' % label
 
-def labeller(n,symbol='q'):
+def labeller(n, symbol='q'):
     """Autogenerate labels for wires of quantum circuits.
 
     Parameters
@@ -360,12 +360,12 @@ class CreateOneQubitGate(ManagedProperties):
         return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
                                  {'gate_name': name, 'gate_name_latex': latexname})
 
-def CreateCGate(name,latexname=None):
+def CreateCGate(name, latexname=None):
     """Use a lexical closure to make a controlled gate.
     """
     if not latexname:
         latexname = name
-    onequbitgate = CreateOneQubitGate(name,latexname)
+    onequbitgate = CreateOneQubitGate(name, latexname)
     def ControlledGate(ctrls,target):
         return CGate(tuple(ctrls),onequbitgate(target))
     return ControlledGate

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -341,5 +341,12 @@ class CreateOneQubitGate(ManagedProperties):
         return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
                                  {'gate_name': name, 'gate_name_latex': latexname})
 
-def CreateCGate(ctrls,onequbitgate):
-    return CGate(tuple(ctrls),onequbitgate)
+def CreateCGate(name,latexname=None):
+    """Use a lexical closure to make a controlled gate.
+    """
+    if not latexname:
+        latexname = name
+    onequbitgate = CreateOneQubitGate(name,latexname)
+    def ControlledGate(ctrls,target):
+        return CGate(tuple(ctrls),onequbitgate(target))
+    return ControlledGate

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -20,6 +20,9 @@ from sympy import Mul
 from sympy.core.compatibility import u
 from sympy.external import import_module
 from sympy.physics.quantum.gate import Gate,OneQubitGate,CGate,CGateS
+from sympy.core.core import BasicMeta
+from sympy.core.assumptions import ManagedProperties
+
 
 __all__ = [
     'CircuitPlot',
@@ -348,10 +351,6 @@ class Mx(OneQubitGate):
     measurement = True
     gate_name='Mx'
     gate_name_latex=u('M_x')
-
-# Testing defined gates
-from sympy.core.core import BasicMeta
-from sympy.core.assumptions import ManagedProperties
 
 class CreateOneQubitGate(ManagedProperties):
     def __new__(mcl, name, latexname=None):

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -31,6 +31,7 @@ __all__ = [
     'Mz',
     'Mx',
     'CreateOneQubitGate',
+    'CreateCGate',
 ]
 
 np = import_module('numpy')

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -47,6 +47,9 @@ else:
     Line2D = matplotlib.lines.Line2D
     Circle = matplotlib.patches.Circle
 
+    #from matplotlib import rc
+    #rc('text',usetex=True)
+
     class CircuitPlot(object):
         """A class for managing a circuit plot."""
 

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -328,10 +328,10 @@ class Mx(OneQubitGate):
     gate_name_latex=u'M_x'
 
 # Testing defined gates
-from sympy.core.core import BasicMeta 
-from sympy.core.assumptions import ManagedProperties 
+from sympy.core.core import BasicMeta
+from sympy.core.assumptions import ManagedProperties
 
-class CreateOneQubitGate(ManagedProperties): 
+class CreateOneQubitGate(ManagedProperties):
     def __new__(mcl, name, latexname=None):
         if not latexname:
             latexname = name

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -308,7 +308,7 @@ else:
 
 def render_label(label, inits={}):
     """Slightly more flexible way to render labels.
-    
+
     >>> from sympy.physics.quantum.circuitplot import render_label
     >>> render_label('q0')
     '$|q0\\\\rangle$'

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -331,10 +331,10 @@ class Mx(OneQubitGate):
     gate_name_latex=u('M_x')
 
 # Testing defined gates
-from sympy.core.core import BasicMeta 
-from sympy.core.assumptions import ManagedProperties 
+from sympy.core.core import BasicMeta
+from sympy.core.assumptions import ManagedProperties
 
-class CreateOneQubitGate(ManagedProperties): 
+class CreateOneQubitGate(ManagedProperties):
     def __new__(mcl, name, latexname=None):
         if not latexname:
             latexname = name

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -60,6 +60,7 @@ else:
         not_radius = 0.15
         swap_delta = 0.05
         labels = []
+        inits = {}
         label_buffer = 0.5
 
         def __init__(self, c, nqubits, **kwargs):
@@ -117,9 +118,11 @@ else:
                 )
                 self._axes.add_line(line)
                 if self.labels:
+                    init_label_buffer = 0
+                    if self.inits.get(self.labels[i]): init_label_buffer = 0.25
                     self._axes.text(
-                        xdata[0]-self.label_buffer,ydata[0],
-                        render_label(self.labels[i]),
+                        xdata[0]-self.label_buffer-init_label_buffer,ydata[0],
+                        render_label(self.labels[i],self.inits),
                         size=self.fontsize,
                         color='k',ha='center',va='center')
             self._plot_measured_wires()
@@ -299,13 +302,17 @@ else:
         """
         return CircuitPlot(c, nqubits, **kwargs)
 
-def render_label(label):
+def render_label(label,inits={}):
     """Slightly more flexible way to render labels.
     >>> from sympy.physics.quantum.circuitplot import render_label
     >>> render_label('q0')
     '$|q0\\\\rangle$'
-    My attempt to include the initialization strings failed, e.g. qubit q0,0
+    >>> render_label('q0',{'q0':'0'})
+    '$|q0\\\\rangle=|0\\\\rangle$'
     """
+    init = inits.get(label)
+    if init:
+        return r'$|%s\rangle=|%s\rangle$' % (label,init)
     return r'$|%s\rangle$' % label
 
 def labeller(n,symbol='q'):

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -27,6 +27,7 @@ __all__ = [
     'labeller',
     'Mz',
     'Mx',
+    'CreateOneQubitGate',
 ]
 
 np = import_module('numpy')
@@ -328,3 +329,17 @@ class Mx(OneQubitGate):
     measurement = True
     gate_name='Mx'
     gate_name_latex=u('M_x')
+
+# Testing defined gates
+from sympy.core.core import BasicMeta 
+from sympy.core.assumptions import ManagedProperties 
+
+class CreateOneQubitGate(ManagedProperties): 
+    def __new__(mcl, name, latexname=None):
+        if not latexname:
+            latexname = name
+        return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
+                                 {'gate_name': name, 'gate_name_latex': latexname})
+
+def CreateCGate(ctrls,onequbitgate):
+    return CGate(tuple(ctrls),onequbitgate)

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -27,6 +27,7 @@ __all__ = [
     'labeller',
     'Mz',
     'Mx',
+    'CreateOneQubitGate',
 ]
 
 np = import_module('numpy')
@@ -328,3 +329,18 @@ class Mx(OneQubitGate):
     measurement = True
     gate_name='Mx'
     gate_name_latex=u('M_x')
+
+# Testing defined gates
+from sympy.core.core import BasicMeta 
+from sympy.core.assumptions import ManagedProperties 
+
+class CreateOneQubitGate(ManagedProperties): 
+    def __new__(mcl, name, latexname=None):
+        if not latexname:
+            latexname = name
+        return BasicMeta.__new__(mcl, name + "Gate", (OneQubitGate,),
+                                 {'gate_name': name, 'gate_name_latex': latexname})
+
+def CreateCGate(ctrls,onequbitgate):
+    return CGate(tuple(ctrls),onequbitgate)
+    

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -47,6 +47,9 @@ else:
     Line2D = matplotlib.lines.Line2D
     Circle = matplotlib.patches.Circle
 
+    #from matplotlib import rc
+    #rc('text',usetex=True)
+
     class CircuitPlot(object):
         """A class for managing a circuit plot."""
 
@@ -343,4 +346,3 @@ class CreateOneQubitGate(ManagedProperties):
 
 def CreateCGate(ctrls,onequbitgate):
     return CGate(tuple(ctrls),onequbitgate)
-    

--- a/sympy/physics/quantum/circuitplot.py
+++ b/sympy/physics/quantum/circuitplot.py
@@ -308,6 +308,7 @@ else:
 
 def render_label(label, inits={}):
     """Slightly more flexible way to render labels.
+    
     >>> from sympy.physics.quantum.circuitplot import render_label
     >>> render_label('q0')
     '$|q0\\\\rangle$'
@@ -338,16 +339,20 @@ def labeller(n, symbol='q'):
     return ['%s_%d' % (symbol,n-i-1) for i in range(n)]
 
 class Mz(OneQubitGate):
-    """Mock-up of a z measurement gate. This is in circuitplot rather than
-    gate.py because it's not a real gate, it just draws one.
+    """Mock-up of a z measurement gate.
+
+    This is in circuitplot rather than gate.py because it's not a real
+    gate, it just draws one.
     """
     measurement = True
     gate_name='Mz'
     gate_name_latex=u('M_z')
 
 class Mx(OneQubitGate):
-    """Mock-up of an x measurement gate. This is in circuitplot rather than
-    gate.py because it's not a real gate, it just draws one.
+    """Mock-up of an x measurement gate.
+
+    This is in circuitplot rather than gate.py because it's not a real
+    gate, it just draws one.
     """
     measurement = True
     gate_name='Mx'

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -9,7 +9,7 @@ Todo:
 * Figure out the def boxes
 
 The code returns a circuit and an associated list of labels.
-
+from sympy.physics.quantum.qasm import qasm
 >>> qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
 (CNOT(1,0)*H(1), ['q1', 'q0'])
 
@@ -31,6 +31,7 @@ def prod(c):
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
+    from sympy.physics.quantum.qasm import flip_index
     >>> flip_index(0,2)
     1
     >>> flip_index(1,2)
@@ -40,6 +41,7 @@ def flip_index(i,n):
 
 def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
+    from sympy.physics.quantum.qasm import isblank
     >>> isblank('   ')
     True
     >>> isblank(' _ ')
@@ -49,6 +51,7 @@ def isblank(line):
 
 def trim(line):
     """Remove everything following comment # characters in line.
+    from sympy.physics.quantum.qasm import trim
     >>> trim('nothing happens here')
     'nothing happens here'
     >>> trim('something #happens here')
@@ -60,6 +63,7 @@ def trim(line):
 def get_indices(rest,labels):
     """Get qubit labels from the rest of the line,
     and return their indices, properly flipped.
+    from sympy.physics.quantum.qasm import get_indices
     >>> get_indices('q0',['q0','q1'])
     1
     >>> get_indices('q1',['q0','q1'])

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -101,9 +101,6 @@ class Qasm(object):
     >>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
     >>> q.get_circuit()
     CNOT(1,0)*H(1)
-    >>> q.get_circuit()
-    C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
-
     >>> q = Qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
     >>> q.get_circuit()
     CNOT(1,0)*CNOT(0,1)*CNOT(1,0)

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -22,7 +22,7 @@ The code returns a circuit and an associated list of labels.
 """
 import re
 
-from sympy.physics.quantum.gate import H, CNOT, X, Z
+from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -20,14 +20,12 @@ The code returns a circuit and an associated list of labels.
 >>> qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
 (CNOT(1,0)*CNOT(0,1)*CNOT(1,0), ['q1', 'q0'])
 """
-import re
-
 from sympy.physics.quantum.gate import *
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
-    import operator
-    return reduce(operator.mul,c,1)
+    def mul(a,b): return a*b
+    return reduce(mul,c,1)
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
@@ -68,6 +66,7 @@ def get_indices(rest,labels):
     nq = len(labels)
     targets = rest.split(',')
     indices = [labels.index(target) for target in targets]
+
     if len(indices) == 1: return flip_index(indices[0],nq)
     return [flip_index(i,nq) for i in indices]
 
@@ -78,6 +77,7 @@ def qasm(*args,**kwargs):
     two_qubit_commands = ['cnot','c-x','c-z']
     for line in args:
         line = trim(line)
+
         if isblank(line): continue
         words = line.split()
         command = words[0]

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -18,10 +18,6 @@ CNOT(1,0)*H(1)
 >>> q.get_circuit()
 CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
 """
-<<<<<<< HEAD
-import re
-=======
->>>>>>> a937251e90d88cf8a3fb97f865db637e15685a4e
 
 from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS,SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -36,7 +36,7 @@ def prod(c):
 
 def flip_index(i, n):
     """Reorder qubit indices from largest to smallest.
-    
+
     >>> from sympy.physics.quantum.qasm import flip_index
     >>> flip_index(0, 2)
     1
@@ -47,7 +47,7 @@ def flip_index(i, n):
 
 def trim(line):
     """Remove everything following comment # characters in line.
-    
+
     >>> from sympy.physics.quantum.qasm import trim
     >>> trim('nothing happens here')
     'nothing happens here'
@@ -60,7 +60,7 @@ def trim(line):
 
 def get_index(target, labels):
     """Get qubit labels from the rest of the line,and return indices
-    
+
     >>> from sympy.physics.quantum.qasm import get_index
     >>> get_index('q0', ['q0', 'q1'])
     1
@@ -88,7 +88,7 @@ def fullsplit(line):
 
 def fixcommand(c):
     """Fix Qasm command names.
-    
+
     Remove all of forbidden characters from command c, and
     replace 'def' with 'qdef'.
     """
@@ -102,7 +102,7 @@ def fixcommand(c):
 
 def stripquotes(s):
     """Replace explicit quotes in a string.
-    
+
     >>> from sympy.physics.quantum.qasm import stripquotes
     >>> stripquotes("'S'") == 'S'
     True
@@ -117,7 +117,7 @@ def stripquotes(s):
 
 class Qasm(object):
     """Class to form objects from Qasm lines
-    
+
     >>> from sympy.physics.quantum.qasm import Qasm
     >>> q = Qasm('qubit q0', 'qubit q1', 'h q0', 'cnot q0,q1')
     >>> q.get_circuit()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -66,7 +66,6 @@ def get_indices(rest,labels):
     nq = len(labels)
     targets = rest.split(',')
     indices = [labels.index(target) for target in targets]
-
     if len(indices) == 1: return flip_index(indices[0],nq)
     return [flip_index(i,nq) for i in indices]
 
@@ -77,7 +76,6 @@ def qasm(*args,**kwargs):
     two_qubit_commands = ['cnot','c-x','c-z']
     for line in args:
         line = trim(line)
-
         if isblank(line): continue
         words = line.split()
         command = words[0]

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -4,10 +4,6 @@ qasm.py - Functions to parse a set of qasm commands into a Sympy Circuit.
 
 Examples taken from Chuang's page: http://www.media.mit.edu/quanta/qasm2circ/
 
-Todo:
-* Put in subscripts??
-* Figure out the def boxes
-
 The code returns a circuit and an associated list of labels.
 >>> from sympy.physics.quantum.qasm import Qasm
 >>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
@@ -18,6 +14,10 @@ CNOT(1,0)*H(1)
 >>> q.get_circuit()
 CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
 """
+
+__all__ = [
+    'Qasm',
+    ]
 
 from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS,SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -20,7 +20,7 @@ The code returns a circuit and an associated list of labels.
 >>> qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
 (CNOT(1,0)*CNOT(0,1)*CNOT(1,0), ['q1', 'q0'])
 """
-from sympy.physics.quantum.gate import *
+from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
@@ -76,8 +76,8 @@ def get_indices(rest,labels):
 def qasm(*args,**kwargs):
     circuit = []
     labels = []
-    commands = ['qubit','h','cnot','c-x','c-z','nop','measure']
-    two_qubit_commands = ['cnot','c-x','c-z']
+    commands = ['qubit','h','cnot','c-x','c-z','nop','measure','s','t','swap']
+    two_qubit_commands = ['cnot','c-x','c-z','swap']
     for line in args:
         line = trim(line)
         if isblank(line): continue
@@ -88,9 +88,21 @@ def qasm(*args,**kwargs):
             print "Skipping unknown/unparsed command: ",command
         if command == 'qubit':
             labels.append(words[1])
+        elif command == 'x':
+            fi = get_indices(rest,labels)
+            circuit.append(X(fi))
+        elif command == 'z':
+            fi = get_indices(rest,labels)
+            circuit.append(Z(fi))
         elif command == 'h':
             fi = get_indices(rest,labels)
             circuit.append(H(fi))
+        elif command == 's':
+            fi = get_indices(rest,labels)
+            circuit.append(S(fi))
+        elif command == 't':
+            fi = get_indices(rest,labels)
+            circuit.append(T(fi))
         elif command == 'cnot':
             fi,fj = get_indices(rest,labels)
             circuit.append(CNOT(fi,fj))
@@ -100,6 +112,9 @@ def qasm(*args,**kwargs):
         elif command == 'c-z':
             fi,fj = get_indices(rest,labels)
             circuit.append(CGate(fi,Z(fj)))
+        elif command == 'swap':
+            fi,fj = get_indices(rest,labels)
+            circuit.append(SWAP(fi,fj))
         elif command == 'nop':
             pass
         elif command == 'measure':

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -60,7 +60,7 @@ def trim(line):
     if not '#' in line: return line
     return line.split('#')[0]
 
-def get_indices(rest,labels):
+def get_indices(targets,labels):
     """Get qubit labels from the rest of the line,
     and return their indices, properly flipped.
     >>> from sympy.physics.quantum.qasm import get_indices
@@ -70,26 +70,33 @@ def get_indices(rest,labels):
     0
     """
     nq = len(labels)
-    targets = rest.split(',')
     indices = [labels.index(target) for target in targets]
     if len(indices) == 1: return flip_index(indices[0],nq)
     return [flip_index(i,nq) for i in indices]
+
+def nonblank(args):
+    for line in args:
+        line = trim(line)
+        if isblank(line): continue
+        yield line
+    return
+
+def fullsplit(line):
+    words = line.split()
+    rest = ' '.join(words[1:])
+    return words[0],rest.split(',')
 
 def qasm(*args,**kwargs):
     circuit = []
     labels = []
     commands = ['qubit','h','cnot','c-x','c-z','nop','measure','s','t','swap']
     two_qubit_commands = ['cnot','c-x','c-z','swap']
-    for line in args:
-        line = trim(line)
-        if isblank(line): continue
-        words = line.split()
-        command = words[0]
-        rest = ' '.join(words[1:])
+    for line in nonblank(args):
+        command,rest = fullsplit(line)
         if command not in commands:
             print "Skipping unknown/unparsed command: ",command
         if command == 'qubit':
-            labels.append(words[1])
+            labels.append(rest[0])
         elif command == 'x':
             fi = get_indices(rest,labels)
             circuit.append(X(fi))

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -152,7 +152,7 @@ class Qasm(object):
 
     def get_circuit(self):
         return prod(reversed(self.circuit))
-    
+
     def get_labels(self):
         return list(reversed(self.labels))
 
@@ -170,34 +170,34 @@ class Qasm(object):
 
     def index(self, arg):
         return get_index(arg, self.labels)
-    
+
     def nop(self, *args):
         pass
-    
+
     def x(self, arg):
         self.circuit.append(X(self.index(arg)))
-        
+
     def z(self, arg):
         self.circuit.append(Z(self.index(arg)))
-        
+
     def h(self, arg):
         self.circuit.append(H(self.index(arg)))
-        
+
     def s(self, arg):
         self.circuit.append(S(self.index(arg)))
-        
+
     def t(self, arg):
         self.circuit.append(T(self.index(arg)))
-        
+
     def measure(self, arg):
         self.circuit.append(Mz(self.index(arg)))
 
     def cnot(self, a1, a2):
         self.circuit.append(CNOT(*self.indices([a1, a2])))
-        
+
     def swap(self, a1, a2):
         self.circuit.append(SWAP(*self.indices([a1, a2])))
-        
+
     def cphase(self, a1, a2):
         self.circuit.append(CPHASE(*self.indices([a1, a2])))
 
@@ -208,7 +208,7 @@ class Qasm(object):
     def cx(self, a1, a2):
         fi, fj = self.indices([a1, a2])
         self.circuit.append(CGate(fi, X(fj)))
-        
+
     def cz(self, a1, a2):
         fi, fj = self.indices([a1, a2])
         self.circuit.append(CGate(fi, Z(fj)))

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -56,7 +56,8 @@ def trim(line):
     >>> trim('something #happens here')
     'something '
     """
-    if not '#' in line: return line
+    if not '#' in line:
+        return line
     return line.split('#')[0]
 
 def get_index(target, labels):
@@ -77,7 +78,8 @@ def get_indices(targets, labels):
 def nonblank(args):
     for line in args:
         line = trim(line)
-        if isblank(line): continue
+        if isblank(line):
+            continue
         yield line
     return
 
@@ -147,8 +149,11 @@ class Qasm(object):
             else:
                 print("Function %s not defined. Skipping" % command)
 
-    def get_circuit(self): return prod(reversed(self.circuit))
-    def get_labels(self): return list(reversed(self.labels))
+    def get_circuit(self):
+        return prod(reversed(self.circuit))
+    
+    def get_labels(self):
+        return list(reversed(self.labels))
 
     def plot(self):
         from sympy.physics.quantum.circuitplot import CircuitPlot
@@ -159,19 +164,41 @@ class Qasm(object):
         self.labels.append(arg)
         if init: self.inits[arg] = init
 
-    def indices(self, args): return get_indices(args, self.labels)
-    def index(self, arg): return get_index(arg, self.labels)
-    def nop(self, *args): pass
-    def x(self, arg): self.circuit.append(X(self.index(arg)))
-    def z(self, arg): self.circuit.append(Z(self.index(arg)))
-    def h(self, arg): self.circuit.append(H(self.index(arg)))
-    def s(self, arg): self.circuit.append(S(self.index(arg)))
-    def t(self, arg): self.circuit.append(T(self.index(arg)))
-    def measure(self, arg): self.circuit.append(Mz(self.index(arg)))
+    def indices(self, args):
+        return get_indices(args, self.labels)
 
-    def cnot(self, a1, a2):self.circuit.append(CNOT(*self.indices([a1, a2])))
-    def swap(self, a1, a2):self.circuit.append(SWAP(*self.indices([a1, a2])))
-    def cphase(self, a1, a2):self.circuit.append(CPHASE(*self.indices([a1, a2])))
+    def index(self, arg):
+        return get_index(arg, self.labels)
+    
+    def nop(self, *args):
+        pass
+    
+    def x(self, arg):
+        self.circuit.append(X(self.index(arg)))
+        
+    def z(self, arg):
+        self.circuit.append(Z(self.index(arg)))
+        
+    def h(self, arg):
+        self.circuit.append(H(self.index(arg)))
+        
+    def s(self, arg):
+        self.circuit.append(S(self.index(arg)))
+        
+    def t(self, arg):
+        self.circuit.append(T(self.index(arg)))
+        
+    def measure(self, arg):
+        self.circuit.append(Mz(self.index(arg)))
+
+    def cnot(self, a1, a2):
+        self.circuit.append(CNOT(*self.indices([a1, a2])))
+        
+    def swap(self, a1, a2):
+        self.circuit.append(SWAP(*self.indices([a1, a2])))
+        
+    def cphase(self, a1, a2):
+        self.circuit.append(CPHASE(*self.indices([a1, a2])))
 
     def toffoli(self, a1, a2, a3):
         i1, i2, i3 = self.indices([a1, a2, a3])
@@ -180,6 +207,7 @@ class Qasm(object):
     def cx(self, a1, a2):
         fi, fj = self.indices([a1, a2])
         self.circuit.append(CGate(fi, X(fj)))
+        
     def cz(self, a1, a2):
         fi, fj = self.indices([a1, a2])
         self.circuit.append(CGate(fi, Z(fj)))

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -25,7 +25,9 @@ import re
 from sympy.physics.quantum.gate import *
 from sympy.physics.quantum.circuitplot import Mz
 
-def prod(c): return reduce(operator.mul, c, 1)
+def prod(c):
+    import operator
+    return reduce(operator.mul,c,1)
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
@@ -40,7 +42,7 @@ def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
     >>> isblank('   ')
     True
-    >>> isblank('_')
+    >>> isblank(' _ ')
     False
     """
     return len(line.split()) == 0

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -27,11 +27,11 @@ from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c): return reduce(operator.mul, c, 1)
 
-def flip(i,n):
+def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
-    >>> flip(0,2)
+    >>> flip_index(0,2)
     1
-    >>> flip(1,2)
+    >>> flip_index(1,2)
     0
     """
     return n-i-1
@@ -40,7 +40,7 @@ def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
     >>> isblank('   ')
     True
-    >>> isblank(' _ ')
+    >>> isblank('_')
     False
     """
     return len(line.split()) == 0

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -76,6 +76,7 @@ def get_indices(targets,labels):
 def nonblank(args):
     for line in args:
         line = trim(line)
+
         if isblank(line): continue
         yield line
     return

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -76,7 +76,6 @@ def get_indices(targets,labels):
 def nonblank(args):
     for line in args:
         line = trim(line)
-
         if isblank(line): continue
         yield line
     return

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -24,8 +24,10 @@ from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS,SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
-    def mul(a,b): return a*b # Can't import operator.mul b/c operator module in directory
-    return reduce(mul,c,1)
+    p = 1
+    for ci in c:
+        p *= ci
+    return p
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -196,6 +196,3 @@ class Qasm(object):
             self.defs[command] = CreateCGate(symbol)
         else:
             self.defs[command] = CreateOneQubitGate(symbol)
-
-if __name__ == '__main__':
-    import doctest; doctest.testmod()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -39,17 +39,6 @@ def flip_index(i, n):
     """
     return n-i-1
 
-def isblank(line):
-    """Returns True if the line is empty/blank/all whitespace.
-    
-    >>> from sympy.physics.quantum.qasm import isblank
-    >>> isblank('   ')
-    True
-    >>> isblank(' _ ')
-    False
-    """
-    return len(line.split()) == 0
-
 def trim(line):
     """Remove everything following comment # characters in line.
     
@@ -81,7 +70,7 @@ def get_indices(targets, labels):
 def nonblank(args):
     for line in args:
         line = trim(line)
-        if isblank(line):
+        if line.isspace():
             continue
         yield line
     return

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -26,13 +26,8 @@ from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
-    #import operator
-    #return reduce(operator.mul,c,1)
-    # Testing to see whether the module in this directory named 'operator' is the prob:
-    p = 1
-    for ci in c:
-        p *= ci
-    return p
+    def mul(a,b): return a*b # Can't import operator.mul b/c operator module in directory
+    return reduce(mul,c,1)
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
@@ -112,7 +107,14 @@ def qasm(*args,**kwargs):
         elif command == 'measure':
             fi = get_indices(rest,labels)
             circuit.append(Mz(fi))
-    return prod(reversed(circuit)),list(reversed(labels))
+    circuit,labels = prod(reversed(circuit)),list(reversed(labels))
+    if kwargs.get('plot'):
+        try:
+            from sympy.physics.quantum.circuitplot import CircuitPlot
+            CircuitPlot(circuit,len(labels),labels=labels)
+        except:
+            pass
+    return circuit,labels
 
 if __name__ == '__main__':
     import doctest; doctest.testmod()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -127,6 +127,7 @@ class Qasm(object):
         self.defs = {}
         self.circuit = []
         self.labels = []
+        self.inits = {}
         self.add(*args)
         self.kwargs = kwargs
 
@@ -152,9 +153,12 @@ class Qasm(object):
     def plot(self):
         from sympy.physics.quantum.circuitplot import CircuitPlot
         circuit,labels = self.get_circuit(), self.get_labels()
-        CircuitPlot(circuit,len(labels),labels=labels)
+        CircuitPlot(circuit,len(labels),labels=labels,inits=self.inits)
 
-    def qubit(self,arg,*rest): self.labels.append(arg)
+    def qubit(self,arg,init=None):
+        self.labels.append(arg)
+        if init: self.inits[arg] = init
+
     def indices(self,args): return get_indices(args,self.labels)
     def index(self,arg): return get_index(arg,self.labels)
     def nop(self,*args): pass

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -20,13 +20,14 @@ The code returns a circuit and an associated list of labels.
 >>> qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
 (CNOT(1,0)*CNOT(0,1)*CNOT(1,0), ['q1', 'q0'])
 """
-import operator
 import re
 
 from sympy.physics.quantum.gate import *
 from sympy.physics.quantum.circuitplot import Mz
 
-def prod(c): return reduce(operator.mul, c, 1)
+def prod(c):
+    import operator
+    return reduce(operator.mul,c,1)
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
@@ -41,7 +42,7 @@ def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
     >>> isblank('   ')
     True
-    >>> isblank('_')
+    >>> isblank(' _ ')
     False
     """
     return len(line.split()) == 0

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -25,15 +25,13 @@ import re
 from sympy.physics.quantum.gate import *
 from sympy.physics.quantum.circuitplot import Mz
 
-def prod(c):
-    import operator
-    return reduce(operator.mul,c,1)
+def prod(c): return reduce(operator.mul, c, 1)
 
-def flip_index(i,n):
+def flip(i,n):
     """Reorder qubit indices from largest to smallest.
-    >>> flip_index(0,2)
+    >>> flip(0,2)
     1
-    >>> flip_index(1,2)
+    >>> flip(1,2)
     0
     """
     return n-i-1

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -23,10 +23,10 @@ from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS, SWAP, S, T,
 from sympy.physics.quantum.circuitplot import Mz
 
 def read_qasm(lines):
-    return Qasm(lines.splitlines())
+    return Qasm(*lines.splitlines())
 
 def read_qasm_file(filename):
-    return Qasm(open(filename).readlines())
+    return Qasm(*open(filename).readlines())
 
 def prod(c):
     p = 1

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -110,15 +110,20 @@ class Qasm(object):
         self.labels = []
         self.add(*args)
         self.kwargs = kwargs
+        self.defs = {}
 
     def add(self,*lines):
         for line in nonblank(lines):
             command,rest = fullsplit(line)
-            function = getattr(self,command)
-            if not function:
-                print "%s not defined: skipping" % command
-            else:
+            if hasattr(self,command):
+                function = getattr(self,command)
                 function(*rest)
+            elif self.defs.get(command):
+                function = self.defs.get(command)
+                fi = self.index(rest[0])
+                self.circuit.append(function(fi))
+            else:
+                print "Function %s not defined. Skipping"
 
     def get_circuit(self): return prod(reversed(self.circuit))
     def get_labels(self): return list(reversed(self.labels))
@@ -138,7 +143,7 @@ class Qasm(object):
     def s(self,arg): self.circuit.append(S(self.index(arg)))
     def t(self,arg): self.circuit.append(T(self.index(arg)))
     def measure(self,arg): self.circuit.append(Mz(self.index(arg)))
-    
+
     def cnot(self,a1,a2):self.circuit.append(CNOT(*self.indices([a1,a2])))
     def swap(self,a1,a2):self.circuit.append(SWAP(*self.indices([a1,a2])))
     def cphase(self,a1,a2):self.circuit.append(CPhase(*self.indices([a1,a2])))
@@ -151,7 +156,13 @@ class Qasm(object):
         self.circuit.append(CGate(fi,Z(fj)))
 
     def qdef(self,name,nq,symbol):
-        print "Testing def",name,nq,symbol
+        from sympy.physics.quantum.circuitplot import CreateOneQubitGate
+        nq = int(nq)
+        command = fixcommand(name)
+        if nq > 1:
+            print "Def for nq>1 not defined ",nq
+        else:
+            self.defs[command] = CreateOneQubitGate(symbol)
 
 if __name__ == '__main__':
     import doctest; doctest.testmod()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -143,7 +143,7 @@ class Qasm(object):
                 function = getattr(self,command)
                 function(*rest)
             else:
-                print "Function %s not defined. Skipping" % command
+                print("Function %s not defined. Skipping" % command)
 
     def get_circuit(self): return prod(reversed(self.circuit))
     def get_labels(self): return list(reversed(self.labels))
@@ -180,7 +180,7 @@ class Qasm(object):
         self.circuit.append(CGate(fi,Z(fj)))
 
     def defbox(self,*args):
-        print "defbox not supported yet. Skipping: ",args
+        print("defbox not supported yet. Skipping: ",args)
 
     def qdef(self,name,ncontrols,symbol):
         from sympy.physics.quantum.circuitplot import CreateOneQubitGate,CreateCGate

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -95,6 +95,15 @@ def fixcommand(c):
         return 'qdef'
     return c
 
+def stripquotes(s):
+    """Replace explicit quotes in a string.
+    >>> stripquotes("'S'")
+    "S"
+    """
+    s = s.replace('"','') # Remove second set of quotes?
+    s = s.replace("'",'')
+    return s
+
 class Qasm(object):
     """
     >>> from sympy.physics.quantum.qasm import Qasm
@@ -106,11 +115,11 @@ class Qasm(object):
     CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
     """
     def __init__(self,*args,**kwargs):
+        self.defs = {}
         self.circuit = []
         self.labels = []
         self.add(*args)
         self.kwargs = kwargs
-        self.defs = {}
 
     def add(self,*lines):
         for line in nonblank(lines):
@@ -159,6 +168,7 @@ class Qasm(object):
         from sympy.physics.quantum.circuitplot import CreateOneQubitGate
         nq = int(nq)
         command = fixcommand(name)
+        symbol = stripquotes(symbol)
         if nq > 1:
             print "Def for nq>1 not defined ",nq
         else:

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -103,9 +103,6 @@ class Qasm(object):
     >>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
     >>> q.get_circuit()
     CNOT(1,0)*H(1)
-    >>> q.get_circuit()
-    C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
-
     >>> q = Qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
     >>> q.get_circuit()
     CNOT(1,0)*CNOT(0,1)*CNOT(1,0)

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -95,14 +95,12 @@ def fixcommand(c):
         return 'qdef'
     return c
 
-class Qasm:
+class Qasm(object):
     """
     >>> from sympy.physics.quantum.qasm import Qasm
     >>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
     >>> q.get_circuit()
     CNOT(1,0)*H(1)
-    
-    >>> q = Qasm('qubit q0','qubit q1','qubit q2','h q1','cnot q1,q2','cnot q0,q1','h q0','nop q1','measure q0','measure q1','c-x q1,q2','c-z q0,q2')
     >>> q.get_circuit()
     C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
 

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -1,0 +1,108 @@
+"""
+
+qasm.py - Functions to parse a set of qasm commands into a Sympy Circuit.
+
+Examples taken from Chuang's page: http://www.media.mit.edu/quanta/qasm2circ/
+
+Todo:
+* Put in subscripts??
+* Figure out the def boxes
+
+The code returns a circuit and an associated list of labels.
+
+>>> qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
+(CNOT(1,0)*H(1), ['q1', 'q0'])
+
+>>> qasm('qubit q0','qubit q1','qubit q2','h q1','cnot q1,q2','cnot q0,q1',\
+         'h q0','nop q1','measure q0','measure q1','c-x q1,q2','c-z q0,q2')
+(C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1), ['q2', 'q1', 'q0'])
+
+>>> qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
+(CNOT(1,0)*CNOT(0,1)*CNOT(1,0), ['q1', 'q0'])
+"""
+import operator
+import re
+
+from sympy.physics.quantum.gate import *
+from sympy.physics.quantum.circuitplot import Mz
+
+def prod(c): return reduce(operator.mul, c, 1)
+
+def flip(i,n):
+    """Reorder qubit indices from largest to smallest.
+    >>> flip(0,2)
+    1
+    >>> flip(1,2)
+    0
+    """
+    return n-i-1
+
+def blank(line):
+    """Returns True if the line is empty/blank/all whitespace.
+    >>> blank('   ')
+    True
+    >>> blank('_')
+    False
+    """
+    return len(line.split()) == 0
+
+def trim(line):
+    """Remove everything following comment # characters in line.
+    >>> trim('nothing happens here')
+    'nothing happens here'
+    >>> trim('something #happens here')
+    'something '
+    """
+    if not '#' in line: return line
+    return line.split('#')[0]
+
+def get_indices(rest,labels):
+    """Get qubit labels from the rest of the line,
+    and return their indices, properly flipped.
+    >>> get_indices('q0',['q0','q1'])
+    1
+    >>> get_indices('q1',['q0','q1'])
+    0
+    """
+    nq = len(labels)
+    targets = rest.split(',')
+    indices = [labels.index(target) for target in targets]
+    if len(indices) == 1: return flip(indices[0],nq)
+    return [flip(i,nq) for i in indices]
+
+def qasm(*args,**kwargs):
+    circuit = []
+    labels = []
+    commands = ['qubit','h','cnot','c-x','c-z','nop','measure']
+    two_qubit_commands = ['cnot','c-x','c-z']
+    for line in args:
+        line = trim(line)
+        if blank(line): continue
+        words = line.split()
+        command = words[0]
+        rest = ' '.join(words[1:])
+        if command not in commands:
+            print "Skipping unknown/unparsed command: ",command
+        if command == 'qubit':
+            labels.append(words[1])
+        elif command == 'h':
+            fi = get_indices(rest,labels)
+            circuit.append(H(fi))
+        elif command == 'cnot':
+            fi,fj = get_indices(rest,labels)
+            circuit.append(CNOT(fi,fj))
+        elif command == 'c-x':
+            fi,fj = get_indices(rest,labels)
+            circuit.append(CGate(fi,X(fj)))
+        elif command == 'c-z':
+            fi,fj = get_indices(rest,labels)
+            circuit.append(CGate(fi,Z(fj)))
+        elif command == 'nop':
+            pass
+        elif command == 'measure':
+            fi = get_indices(rest,labels)
+            circuit.append(Mz(fi))
+    return prod(reversed(circuit)),list(reversed(labels))
+
+if __name__ == '__main__':
+    import doctest; doctest.testmod()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -22,7 +22,7 @@ The code returns a circuit and an associated list of labels.
 """
 import re
 
-from sympy.physics.quantum.gate import *
+from sympy.physics.quantum.gate import H, CNOT, X, Z
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -24,7 +24,7 @@ from sympy.physics.quantum.gate import *
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
-    def mul(a,b): return a*b
+    def mul(a,b): return a*b # Can't import operator.mul b/c operator module in directory
     return reduce(mul,c,1)
 
 def flip_index(i,n):
@@ -105,7 +105,14 @@ def qasm(*args,**kwargs):
         elif command == 'measure':
             fi = get_indices(rest,labels)
             circuit.append(Mz(fi))
-    return prod(reversed(circuit)),list(reversed(labels))
+    circuit,labels = prod(reversed(circuit)),list(reversed(labels))
+    if kwargs.get('plot'):
+        try:
+            from sympy.physics.quantum.circuitplot import CircuitPlot
+            CircuitPlot(circuit,len(labels),labels=labels)
+        except:
+            pass
+    return circuit,labels
 
 if __name__ == '__main__':
     import doctest; doctest.testmod()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -142,7 +142,7 @@ class Qasm(object):
                 function = getattr(self,command)
                 function(*rest)
             else:
-                print "Function %s not defined. Skipping" % command
+                print("Function %s not defined. Skipping" % command)
 
     def get_circuit(self): return prod(reversed(self.circuit))
     def get_labels(self): return list(reversed(self.labels))
@@ -179,7 +179,7 @@ class Qasm(object):
         self.circuit.append(CGate(fi,Z(fj)))
 
     def defbox(self,*args):
-        print "defbox not supported yet. Skipping: ",args
+        print("defbox not supported yet. Skipping: ",args)
 
     def qdef(self,name,ncontrols,symbol):
         from sympy.physics.quantum.circuitplot import CreateOneQubitGate,CreateCGate

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -128,6 +128,7 @@ class Qasm(object):
         self.labels = []
         self.add(*args)
         self.kwargs = kwargs
+        self.defs = {}
 
     def add(self,*lines):
         for line in nonblank(lines):

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -97,6 +97,15 @@ def fixcommand(c):
         return 'qdef'
     return c
 
+def stripquotes(s):
+    """Replace explicit quotes in a string.
+    >>> stripquotes("'S'")
+    "S"
+    """
+    s = s.replace('"','') # Remove second set of quotes?
+    s = s.replace("'",'')
+    return s
+
 class Qasm(object):
     """
     >>> from sympy.physics.quantum.qasm import Qasm
@@ -108,11 +117,11 @@ class Qasm(object):
     CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
     """
     def __init__(self,*args,**kwargs):
+        self.defs = {}
         self.circuit = []
         self.labels = []
         self.add(*args)
         self.kwargs = kwargs
-        self.defs = {}
 
     def add(self,*lines):
         for line in nonblank(lines):
@@ -161,6 +170,7 @@ class Qasm(object):
         from sympy.physics.quantum.circuitplot import CreateOneQubitGate
         nq = int(nq)
         command = fixcommand(name)
+        symbol = stripquotes(symbol)
         if nq > 1:
             print "Def for nq>1 not defined ",nq
         else:

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -9,16 +9,14 @@ Todo:
 * Figure out the def boxes
 
 The code returns a circuit and an associated list of labels.
->>> from sympy.physics.quantum.qasm import qasm
->>> qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
-(CNOT(1,0)*H(1), ['q1', 'q0'])
+>>> from sympy.physics.quantum.qasm import Qasm
+>>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
+>>> q.get_circuit()
+CNOT(1,0)*H(1)
 
->>> qasm('qubit q0','qubit q1','qubit q2','h q1','cnot q1,q2','cnot q0,q1',\
-         'h q0','nop q1','measure q0','measure q1','c-x q1,q2','c-z q0,q2')
-(C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1), ['q2', 'q1', 'q0'])
-
->>> qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
-(CNOT(1,0)*CNOT(0,1)*CNOT(1,0), ['q1', 'q0'])
+>>> q = Qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
+>>> q.get_circuit()
+CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
 """
 from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz
@@ -58,19 +56,20 @@ def trim(line):
     if not '#' in line: return line
     return line.split('#')[0]
 
-def get_indices(targets,labels):
+def get_index(target,labels):
     """Get qubit labels from the rest of the line,
     and return their indices, properly flipped.
-    >>> from sympy.physics.quantum.qasm import get_indices
-    >>> get_indices('q0',['q0','q1'])
+    >>> from sympy.physics.quantum.qasm import get_index
+    >>> get_index('q0',['q0','q1'])
     1
-    >>> get_indices('q1',['q0','q1'])
+    >>> get_index('q1',['q0','q1'])
     0
     """
     nq = len(labels)
-    indices = [labels.index(target) for target in targets]
-    if len(indices) == 1: return flip_index(indices[0],nq)
-    return [flip_index(i,nq) for i in indices]
+    return flip_index(labels.index(target),nq)
+
+def get_indices(targets,labels):
+    return [get_index(t,labels) for t in targets]
 
 def nonblank(args):
     for line in args:
@@ -82,59 +81,82 @@ def nonblank(args):
 def fullsplit(line):
     words = line.split()
     rest = ' '.join(words[1:])
-    return words[0],rest.split(',')
+    return fixcommand(words[0]),rest.split(',')
 
-def qasm(*args,**kwargs):
-    circuit = []
-    labels = []
-    commands = ['qubit','h','cnot','c-x','c-z','nop','measure','s','t','swap']
-    two_qubit_commands = ['cnot','c-x','c-z','swap']
-    for line in nonblank(args):
-        command,rest = fullsplit(line)
-        if command not in commands:
-            print "Skipping unknown/unparsed command: ",command
-        if command == 'qubit':
-            labels.append(rest[0])
-        elif command == 'x':
-            fi = get_indices(rest,labels)
-            circuit.append(X(fi))
-        elif command == 'z':
-            fi = get_indices(rest,labels)
-            circuit.append(Z(fi))
-        elif command == 'h':
-            fi = get_indices(rest,labels)
-            circuit.append(H(fi))
-        elif command == 's':
-            fi = get_indices(rest,labels)
-            circuit.append(S(fi))
-        elif command == 't':
-            fi = get_indices(rest,labels)
-            circuit.append(T(fi))
-        elif command == 'cnot':
-            fi,fj = get_indices(rest,labels)
-            circuit.append(CNOT(fi,fj))
-        elif command == 'c-x':
-            fi,fj = get_indices(rest,labels)
-            circuit.append(CGate(fi,X(fj)))
-        elif command == 'c-z':
-            fi,fj = get_indices(rest,labels)
-            circuit.append(CGate(fi,Z(fj)))
-        elif command == 'swap':
-            fi,fj = get_indices(rest,labels)
-            circuit.append(SWAP(fi,fj))
-        elif command == 'nop':
-            pass
-        elif command == 'measure':
-            fi = get_indices(rest,labels)
-            circuit.append(Mz(fi))
-    circuit,labels = prod(reversed(circuit)),list(reversed(labels))
-    if kwargs.get('plot'):
-        try:
-            from sympy.physics.quantum.circuitplot import CircuitPlot
-            CircuitPlot(circuit,len(labels),labels=labels)
-        except:
-            pass
-    return circuit,labels
+def fixcommand(c):
+    """Fix Qasm command names.
+    Remove all of forbidden characters from command c, and
+    replace 'def' with 'qdef'.
+    """
+    forbidden_characters = ['-']
+    for char in forbidden_characters:
+        c = c.replace(char,'')
+    if c == 'def':
+        return 'qdef'
+    return c
+
+class Qasm:
+    """
+    >>> from sympy.physics.quantum.qasm import Qasm
+    >>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
+    >>> q.get_circuit()
+    CNOT(1,0)*H(1)
+    
+    >>> q = Qasm('qubit q0','qubit q1','qubit q2','h q1','cnot q1,q2','cnot q0,q1','h q0','nop q1','measure q0','measure q1','c-x q1,q2','c-z q0,q2')
+    >>> q.get_circuit()
+    C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
+
+    >>> q = Qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
+    >>> q.get_circuit()
+    CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
+    """
+    def __init__(self,*args,**kwargs):
+        self.circuit = []
+        self.labels = []
+        self.add(*args)
+        self.kwargs = kwargs
+
+    def add(self,*lines):
+        for line in nonblank(lines):
+            command,rest = fullsplit(line)
+            function = getattr(self,command)
+            if not function:
+                print "%s not defined: skipping" % command
+            else:
+                function(*rest)
+
+    def get_circuit(self): return prod(reversed(self.circuit))
+    def get_labels(self): return list(reversed(self.labels))
+
+    def plot(self):
+        from sympy.physics.quantum.circuitplot import CircuitPlot
+        circuit,labels = self.get_circuit(), self.get_labels()
+        CircuitPlot(circuit,len(labels),labels=labels)
+
+    def qubit(self,arg): self.labels.append(arg)
+    def indices(self,args): return get_indices(args,self.labels)
+    def index(self,arg): return get_index(arg,self.labels)
+    def nop(self,*args): pass
+    def x(self,arg): self.circuit.append(X(self.index(arg)))
+    def z(self,arg): self.circuit.append(Z(self.index(arg)))
+    def h(self,arg): self.circuit.append(H(self.index(arg)))
+    def s(self,arg): self.circuit.append(S(self.index(arg)))
+    def t(self,arg): self.circuit.append(T(self.index(arg)))
+    def measure(self,arg): self.circuit.append(Mz(self.index(arg)))
+    
+    def cnot(self,a1,a2):self.circuit.append(CNOT(*self.indices([a1,a2])))
+    def swap(self,a1,a2):self.circuit.append(SWAP(*self.indices([a1,a2])))
+    def cphase(self,a1,a2):self.circuit.append(CPhase(*self.indices([a1,a2])))
+
+    def cx(self,a1,a2):
+        fi,fj = self.indices([a1,a2])
+        self.circuit.append(CGate(fi,X(fj)))
+    def cz(self,a1,a2):
+        fi,fj = self.indices([a1,a2])
+        self.circuit.append(CGate(fi,Z(fj)))
+
+    def qdef(self,name,nq,symbol):
+        print "Testing def",name,nq,symbol
 
 if __name__ == '__main__':
     import doctest; doctest.testmod()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -22,6 +22,12 @@ __all__ = [
 from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS, SWAP, S, T,CPHASE
 from sympy.physics.quantum.circuitplot import Mz
 
+def read_qasm(lines):
+    return Qasm(lines.splitlines())
+
+def read_qasm_file(filename):
+    return Qasm(open(filename).readlines())
+
 def prod(c):
     p = 1
     for ci in c:

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -23,8 +23,10 @@ from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS,SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
-    def mul(a,b): return a*b # Can't import operator.mul b/c operator module in directory
-    return reduce(mul,c,1)
+    p = 1
+    for ci in c:
+        p *= ci
+    return p
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -30,6 +30,7 @@ def prod(c):
 
 def flip_index(i, n):
     """Reorder qubit indices from largest to smallest.
+    
     >>> from sympy.physics.quantum.qasm import flip_index
     >>> flip_index(0, 2)
     1
@@ -40,6 +41,7 @@ def flip_index(i, n):
 
 def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
+    
     >>> from sympy.physics.quantum.qasm import isblank
     >>> isblank('   ')
     True
@@ -50,6 +52,7 @@ def isblank(line):
 
 def trim(line):
     """Remove everything following comment # characters in line.
+    
     >>> from sympy.physics.quantum.qasm import trim
     >>> trim('nothing happens here')
     'nothing happens here'
@@ -61,8 +64,8 @@ def trim(line):
     return line.split('#')[0]
 
 def get_index(target, labels):
-    """Get qubit labels from the rest of the line,
-    and return their indices, properly flipped.
+    """Get qubit labels from the rest of the line,and return indices
+    
     >>> from sympy.physics.quantum.qasm import get_index
     >>> get_index('q0', ['q0', 'q1'])
     1
@@ -90,6 +93,7 @@ def fullsplit(line):
 
 def fixcommand(c):
     """Fix Qasm command names.
+    
     Remove all of forbidden characters from command c, and
     replace 'def' with 'qdef'.
     """
@@ -103,6 +107,7 @@ def fixcommand(c):
 
 def stripquotes(s):
     """Replace explicit quotes in a string.
+    
     >>> from sympy.physics.quantum.qasm import stripquotes
     >>> stripquotes("'S'") == 'S'
     True
@@ -116,7 +121,8 @@ def stripquotes(s):
     return s
 
 class Qasm(object):
-    """
+    """Class to form objects from Qasm lines
+    
     >>> from sympy.physics.quantum.qasm import Qasm
     >>> q = Qasm('qubit q0', 'qubit q1', 'h q0', 'cnot q0,q1')
     >>> q.get_circuit()

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -97,14 +97,12 @@ def fixcommand(c):
         return 'qdef'
     return c
 
-class Qasm:
+class Qasm(object):
     """
     >>> from sympy.physics.quantum.qasm import Qasm
     >>> q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
     >>> q.get_circuit()
     CNOT(1,0)*H(1)
-    
-    >>> q = Qasm('qubit q0','qubit q1','qubit q2','h q1','cnot q1,q2','cnot q0,q1','h q0','nop q1','measure q0','measure q1','c-x q1,q2','c-z q0,q2')
     >>> q.get_circuit()
     C((2),Z(0))*C((1),X(0))*Mz(1)*Mz(2)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
 

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -20,7 +20,7 @@ CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
 """
 import re
 
-from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, SWAP,S,T
+from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, CGateS,SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
@@ -91,6 +91,7 @@ def fixcommand(c):
     replace 'def' with 'qdef'.
     """
     forbidden_characters = ['-']
+    c = c.lower()
     for char in forbidden_characters:
         c = c.replace(char,'')
     if c == 'def':
@@ -131,15 +132,18 @@ class Qasm(object):
     def add(self,*lines):
         for line in nonblank(lines):
             command,rest = fullsplit(line)
-            if hasattr(self,command):
+            if self.defs.get(command): #defs come first, since you can override built-in
+                function = self.defs.get(command)
+                indices = self.indices(rest)
+                if len(indices) == 1:
+                    self.circuit.append(function(indices[0]))
+                else:
+                    self.circuit.append(function(indices[:-1],indices[-1]))
+            elif hasattr(self,command):
                 function = getattr(self,command)
                 function(*rest)
-            elif self.defs.get(command):
-                function = self.defs.get(command)
-                fi = self.index(rest[0])
-                self.circuit.append(function(fi))
             else:
-                print "Function %s not defined. Skipping"
+                print "Function %s not defined. Skipping" % command
 
     def get_circuit(self): return prod(reversed(self.circuit))
     def get_labels(self): return list(reversed(self.labels))
@@ -149,7 +153,7 @@ class Qasm(object):
         circuit,labels = self.get_circuit(), self.get_labels()
         CircuitPlot(circuit,len(labels),labels=labels)
 
-    def qubit(self,arg): self.labels.append(arg)
+    def qubit(self,arg,*rest): self.labels.append(arg)
     def indices(self,args): return get_indices(args,self.labels)
     def index(self,arg): return get_index(arg,self.labels)
     def nop(self,*args): pass
@@ -164,6 +168,10 @@ class Qasm(object):
     def swap(self,a1,a2):self.circuit.append(SWAP(*self.indices([a1,a2])))
     def cphase(self,a1,a2):self.circuit.append(CPhase(*self.indices([a1,a2])))
 
+    def toffoli(self,a1,a2,a3):
+        i1,i2,i3 = self.indices([a1,a2,a3])
+        self.circuit.append(CGateS((i1,i2),X(i3)))
+
     def cx(self,a1,a2):
         fi,fj = self.indices([a1,a2])
         self.circuit.append(CGate(fi,X(fj)))
@@ -171,13 +179,16 @@ class Qasm(object):
         fi,fj = self.indices([a1,a2])
         self.circuit.append(CGate(fi,Z(fj)))
 
-    def qdef(self,name,nq,symbol):
-        from sympy.physics.quantum.circuitplot import CreateOneQubitGate
-        nq = int(nq)
+    def defbox(self,*args):
+        print "defbox not supported yet. Skipping: ",args
+
+    def qdef(self,name,ncontrols,symbol):
+        from sympy.physics.quantum.circuitplot import CreateOneQubitGate,CreateCGate
+        ncontrols = int(ncontrols)
         command = fixcommand(name)
         symbol = stripquotes(symbol)
-        if nq > 1:
-            print "Def for nq>1 not defined ",nq
+        if ncontrols > 0:
+            self.defs[command] = CreateCGate(symbol)
         else:
             self.defs[command] = CreateOneQubitGate(symbol)
 

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -128,7 +128,6 @@ class Qasm(object):
         self.labels = []
         self.add(*args)
         self.kwargs = kwargs
-        self.defs = {}
 
     def add(self,*lines):
         for line in nonblank(lines):

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -9,7 +9,7 @@ Todo:
 * Figure out the def boxes
 
 The code returns a circuit and an associated list of labels.
-
+from sympy.physics.quantum.qasm import qasm
 >>> qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
 (CNOT(1,0)*H(1), ['q1', 'q0'])
 
@@ -29,6 +29,7 @@ def prod(c):
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
+    from sympy.physics.quantum.qasm import flip_index
     >>> flip_index(0,2)
     1
     >>> flip_index(1,2)
@@ -38,6 +39,7 @@ def flip_index(i,n):
 
 def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
+    from sympy.physics.quantum.qasm import isblank
     >>> isblank('   ')
     True
     >>> isblank(' _ ')
@@ -47,6 +49,7 @@ def isblank(line):
 
 def trim(line):
     """Remove everything following comment # characters in line.
+    from sympy.physics.quantum.qasm import trim
     >>> trim('nothing happens here')
     'nothing happens here'
     >>> trim('something #happens here')
@@ -58,6 +61,7 @@ def trim(line):
 def get_indices(rest,labels):
     """Get qubit labels from the rest of the line,
     and return their indices, properly flipped.
+    from sympy.physics.quantum.qasm import get_indices
     >>> get_indices('q0',['q0','q1'])
     1
     >>> get_indices('q1',['q0','q1'])

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -128,6 +128,7 @@ class Qasm(object):
         self.defs = {}
         self.circuit = []
         self.labels = []
+        self.inits = {}
         self.add(*args)
         self.kwargs = kwargs
 
@@ -153,9 +154,12 @@ class Qasm(object):
     def plot(self):
         from sympy.physics.quantum.circuitplot import CircuitPlot
         circuit,labels = self.get_circuit(), self.get_labels()
-        CircuitPlot(circuit,len(labels),labels=labels)
+        CircuitPlot(circuit,len(labels),labels=labels,inits=self.inits)
 
-    def qubit(self,arg,*rest): self.labels.append(arg)
+    def qubit(self,arg,init=None):
+        self.labels.append(arg)
+        if init: self.inits[arg] = init
+
     def indices(self,args): return get_indices(args,self.labels)
     def index(self,arg): return get_index(arg,self.labels)
     def nop(self,*args): pass

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -28,20 +28,20 @@ from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c): return reduce(operator.mul, c, 1)
 
-def flip(i,n):
+def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
-    >>> flip(0,2)
+    >>> flip_index(0,2)
     1
-    >>> flip(1,2)
+    >>> flip_index(1,2)
     0
     """
     return n-i-1
 
-def blank(line):
+def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
-    >>> blank('   ')
+    >>> isblank('   ')
     True
-    >>> blank('_')
+    >>> isblank('_')
     False
     """
     return len(line.split()) == 0
@@ -67,8 +67,8 @@ def get_indices(rest,labels):
     nq = len(labels)
     targets = rest.split(',')
     indices = [labels.index(target) for target in targets]
-    if len(indices) == 1: return flip(indices[0],nq)
-    return [flip(i,nq) for i in indices]
+    if len(indices) == 1: return flip_index(indices[0],nq)
+    return [flip_index(i,nq) for i in indices]
 
 def qasm(*args,**kwargs):
     circuit = []
@@ -77,7 +77,7 @@ def qasm(*args,**kwargs):
     two_qubit_commands = ['cnot','c-x','c-z']
     for line in args:
         line = trim(line)
-        if blank(line): continue
+        if isblank(line): continue
         words = line.split()
         command = words[0]
         rest = ' '.join(words[1:])

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -26,8 +26,13 @@ from sympy.physics.quantum.gate import *
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
-    import operator
-    return reduce(operator.mul,c,1)
+    #import operator
+    #return reduce(operator.mul,c,1)
+    # Testing to see whether the module in this directory named 'operator' is the prob:
+    p = 1
+    for ci in c:
+        p *= ci
+    return p
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -99,8 +99,13 @@ def fixcommand(c):
 
 def stripquotes(s):
     """Replace explicit quotes in a string.
-    >>> stripquotes("'S'")
-    "S"
+    >>> from sympy.physics.quantum.qasm import stripquotes
+    >>> stripquotes("'S'") == 'S'
+    True
+    >>> stripquotes('"S"') == 'S'
+    True
+    >>> stripquotes('S') == 'S'
+    True
     """
     s = s.replace('"','') # Remove second set of quotes?
     s = s.replace("'",'')

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -9,7 +9,7 @@ Todo:
 * Figure out the def boxes
 
 The code returns a circuit and an associated list of labels.
-from sympy.physics.quantum.qasm import qasm
+>>> from sympy.physics.quantum.qasm import qasm
 >>> qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
 (CNOT(1,0)*H(1), ['q1', 'q0'])
 
@@ -29,7 +29,7 @@ def prod(c):
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
-    from sympy.physics.quantum.qasm import flip_index
+    >>> from sympy.physics.quantum.qasm import flip_index
     >>> flip_index(0,2)
     1
     >>> flip_index(1,2)
@@ -39,7 +39,7 @@ def flip_index(i,n):
 
 def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
-    from sympy.physics.quantum.qasm import isblank
+    >>> from sympy.physics.quantum.qasm import isblank
     >>> isblank('   ')
     True
     >>> isblank(' _ ')
@@ -49,7 +49,7 @@ def isblank(line):
 
 def trim(line):
     """Remove everything following comment # characters in line.
-    from sympy.physics.quantum.qasm import trim
+    >>> from sympy.physics.quantum.qasm import trim
     >>> trim('nothing happens here')
     'nothing happens here'
     >>> trim('something #happens here')
@@ -61,7 +61,7 @@ def trim(line):
 def get_indices(rest,labels):
     """Get qubit labels from the rest of the line,
     and return their indices, properly flipped.
-    from sympy.physics.quantum.qasm import get_indices
+    >>> from sympy.physics.quantum.qasm import get_indices
     >>> get_indices('q0',['q0','q1'])
     1
     >>> get_indices('q1',['q0','q1'])

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -22,7 +22,7 @@ The code returns a circuit and an associated list of labels.
 """
 import re
 
-from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate
+from sympy.physics.quantum.gate import H, CNOT, X, Z, CGate, SWAP,S,T
 from sympy.physics.quantum.circuitplot import Mz
 
 def prod(c):
@@ -78,8 +78,8 @@ def get_indices(rest,labels):
 def qasm(*args,**kwargs):
     circuit = []
     labels = []
-    commands = ['qubit','h','cnot','c-x','c-z','nop','measure']
-    two_qubit_commands = ['cnot','c-x','c-z']
+    commands = ['qubit','h','cnot','c-x','c-z','nop','measure','s','t','swap']
+    two_qubit_commands = ['cnot','c-x','c-z','swap']
     for line in args:
         line = trim(line)
         if isblank(line): continue
@@ -90,9 +90,21 @@ def qasm(*args,**kwargs):
             print "Skipping unknown/unparsed command: ",command
         if command == 'qubit':
             labels.append(words[1])
+        elif command == 'x':
+            fi = get_indices(rest,labels)
+            circuit.append(X(fi))
+        elif command == 'z':
+            fi = get_indices(rest,labels)
+            circuit.append(Z(fi))
         elif command == 'h':
             fi = get_indices(rest,labels)
             circuit.append(H(fi))
+        elif command == 's':
+            fi = get_indices(rest,labels)
+            circuit.append(S(fi))
+        elif command == 't':
+            fi = get_indices(rest,labels)
+            circuit.append(T(fi))
         elif command == 'cnot':
             fi,fj = get_indices(rest,labels)
             circuit.append(CNOT(fi,fj))
@@ -102,6 +114,9 @@ def qasm(*args,**kwargs):
         elif command == 'c-z':
             fi,fj = get_indices(rest,labels)
             circuit.append(CGate(fi,Z(fj)))
+        elif command == 'swap':
+            fi,fj = get_indices(rest,labels)
+            circuit.append(SWAP(fi,fj))
         elif command == 'nop':
             pass
         elif command == 'measure':

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -97,8 +97,13 @@ def fixcommand(c):
 
 def stripquotes(s):
     """Replace explicit quotes in a string.
-    >>> stripquotes("'S'")
-    "S"
+    >>> from sympy.physics.quantum.qasm import stripquotes
+    >>> stripquotes("'S'") == 'S'
+    True
+    >>> stripquotes('"S"') == 'S'
+    True
+    >>> stripquotes('S') == 'S'
+    True
     """
     s = s.replace('"','') # Remove second set of quotes?
     s = s.replace("'",'')

--- a/sympy/physics/quantum/qasm.py
+++ b/sympy/physics/quantum/qasm.py
@@ -9,7 +9,7 @@ Todo:
 * Figure out the def boxes
 
 The code returns a circuit and an associated list of labels.
-from sympy.physics.quantum.qasm import qasm
+>>> from sympy.physics.quantum.qasm import qasm
 >>> qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
 (CNOT(1,0)*H(1), ['q1', 'q0'])
 
@@ -31,7 +31,7 @@ def prod(c):
 
 def flip_index(i,n):
     """Reorder qubit indices from largest to smallest.
-    from sympy.physics.quantum.qasm import flip_index
+    >>> from sympy.physics.quantum.qasm import flip_index
     >>> flip_index(0,2)
     1
     >>> flip_index(1,2)
@@ -41,7 +41,7 @@ def flip_index(i,n):
 
 def isblank(line):
     """Returns True if the line is empty/blank/all whitespace.
-    from sympy.physics.quantum.qasm import isblank
+    >>> from sympy.physics.quantum.qasm import isblank
     >>> isblank('   ')
     True
     >>> isblank(' _ ')
@@ -51,7 +51,7 @@ def isblank(line):
 
 def trim(line):
     """Remove everything following comment # characters in line.
-    from sympy.physics.quantum.qasm import trim
+    >>> from sympy.physics.quantum.qasm import trim
     >>> trim('nothing happens here')
     'nothing happens here'
     >>> trim('something #happens here')
@@ -63,7 +63,7 @@ def trim(line):
 def get_indices(rest,labels):
     """Get qubit labels from the rest of the line,
     and return their indices, properly flipped.
-    from sympy.physics.quantum.qasm import get_indices
+    >>> from sympy.physics.quantum.qasm import get_indices
     >>> get_indices('q0',['q0','q1'])
     1
     >>> get_indices('q1',['q0','q1'])

--- a/sympy/physics/quantum/tests/test_circuitplot.py
+++ b/sympy/physics/quantum/tests/test_circuitplot.py
@@ -1,9 +1,25 @@
-from sympy.physics.quantum.circuitplot import labeller
+from sympy.physics.quantum.circuitplot import labeller, render_label, Mz, CreateOneQubitGate,\
+     CreateCGate
 from sympy.physics.quantum.gate import CNOT, H, X, Z, SWAP, CGate, S, T
 from sympy.external import import_module
 from sympy.utilities.pytest import skip
 
 mpl = import_module('matplotlib')
+
+def test_render_label():
+    assert render_label('q0') == r'$|q0\rangle$'
+    assert render_label('q0', {'q0': '0'}) == r'$|q0\rangle=|0\rangle$'
+
+def test_Mz():
+    assert str(Mz(0)) == 'Mz(0)'
+
+def test_create1():
+    Qgate = CreateOneQubitGate('Q')
+    assert str(Qgate(0)) == 'Q(0)'
+
+def test_createc():
+    Qgate = CreateCGate('Q')
+    assert str(Qgate([1],0)) == 'C((1),Q(0))'
 
 def test_labeller():
     """Test the labeller utility"""

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -23,7 +23,7 @@ def test_qasm_ex1_methodcalls():
     q.qubit('q_0')
     q.qubit('q_1')
     q.h('q_0')
-    q.cnot('q_0', 'q_1')    
+    q.cnot('q_0', 'q_1')
     assert q.get_circuit() == CNOT(1,0)*H(1)
 
 def test_qasm_swap():

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -2,10 +2,10 @@ from sympy.physics.quantum.qasm import Qasm, prod, flip_index, isblank, trim,\
      get_index, nonblank, fullsplit, fixcommand, stripquotes
 from sympy.physics.quantum.gate import X, Z, H, S, T
 from sympy.physics.quantum.gate import CNOT, SWAP, CPHASE, CGate, CGateS
-from sympy.physics.quantum.circuitplot import Mz
+from sympy.physics.quantum.circuitplot import Mz, CreateOneQubitGate, CreateCGate
 
 def test_qasm_ex1():
-    q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
+    q = Qasm('qubit q0', 'qubit q1', 'h q0', 'cnot q0,q1')
     assert q.get_circuit() == CNOT(1,0)*H(1)
 
 def test_qasm_ex1_methodcalls():
@@ -13,42 +13,42 @@ def test_qasm_ex1_methodcalls():
     q.qubit('q_0')
     q.qubit('q_1')
     q.h('q_0')
-    q.cnot('q_0','q_1')    
+    q.cnot('q_0', 'q_1')    
     assert q.get_circuit() == CNOT(1,0)*H(1)
 
 def test_qasm_swap():
-    q = Qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
+    q = Qasm('qubit q0', 'qubit q1', 'cnot q0,q1', 'cnot q1,q0', 'cnot q0,q1')
     assert q.get_circuit() == CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
 
 
 def test_qasm_ex2():
-    q = Qasm('qubit q_0','qubit q_1','qubit q_2','h  q_1',
-             'cnot q_1,q_2','cnot q_0,q_1','h q_0',
-             'measure q_1','measure q_0',
-             'c-x q_1,q_2','c-z q_0,q_2')
+    q = Qasm('qubit q_0', 'qubit q_1', 'qubit q_2', 'h  q_1',
+             'cnot q_1,q_2', 'cnot q_0,q_1', 'h q_0',
+             'measure q_1', 'measure q_0',
+             'c-x q_1,q_2', 'c-z q_0,q_2')
     assert q.get_circuit() == CGate(2,Z(0))*CGate(1,X(0))*Mz(2)*Mz(1)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
 
 def test_qasm_1q():
-    for symbol,gate in [('x',X), ('z',Z), ('h',H), ('s',S), ('t',T), ('measure',Mz)]:
-        q = Qasm('qubit q_0','%s q_0' % symbol)
+    for symbol, gate in [('x', X), ('z', Z), ('h', H), ('s', S), ('t', T), ('measure', Mz)]:
+        q = Qasm('qubit q_0', '%s q_0' % symbol)
         assert q.get_circuit() == gate(0)
 
 def test_qasm_2q():
-    for symbol,gate in [('cnot',CNOT), ('swap',SWAP), ('cphase',CPHASE)]:
-        q = Qasm('qubit q_0','qubit q_1','%s q_0,q_1' % symbol)
+    for symbol, gate in [('cnot', CNOT), ('swap', SWAP), ('cphase', CPHASE)]:
+        q = Qasm('qubit q_0', 'qubit q_1', '%s q_0,q_1' % symbol)
         assert q.get_circuit() == gate(1,0)
 
 def test_qasm_3q():
-    q = Qasm('qubit q0','qubit q1','qubit q2','toffoli q2,q1,q0')
+    q = Qasm('qubit q0', 'qubit q1', 'qubit q2', 'toffoli q2,q1,q0')
     assert q.get_circuit() == CGateS((0,1),X(2))
 
 def test_qasm_prod():
-    assert prod([1,2,3]) == 6
-    assert prod([H(0),X(1)])== H(0)*X(1)
+    assert prod([1, 2, 3]) == 6
+    assert prod([H(0), X(1)])== H(0)*X(1)
 
 def test_qasm_flip_index():
-    assert flip_index(0,2) == 1
-    assert flip_index(1,2) == 0
+    assert flip_index(0, 2) == 1
+    assert flip_index(1, 2) == 0
 
 def test_qasm_isblank():
     assert isblank('  ')
@@ -67,7 +67,7 @@ def test_qasm_nonblank():
     assert list(nonblank('abc ')) == list('abc')
 
 def test_qasm_fullsplit():
-    assert fullsplit('g q0,q1,q2,  q3') == ('g',['q0', 'q1', 'q2', 'q3'])
+    assert fullsplit('g q0,q1,q2,  q3') == ('g', ['q0', 'q1', 'q2', 'q3'])
 
 def test_qasm_fixcommand():
     assert fixcommand('foo') == 'foo'
@@ -77,3 +77,13 @@ def test_qasm_stripquotes():
     assert stripquotes("'S'") == 'S'
     assert stripquotes('"S"') == 'S'
     assert stripquotes('S') == 'S'
+
+def test_qasm_qdef():
+    # weaker test condition (str) since we don't have access to the actual class
+    q = Qasm("def Q,0,Q",'qubit q0','Q q0')
+    Qgate = CreateOneQubitGate('Q')
+    assert str(q.get_circuit()) == 'Q(0)'
+    q = Qasm("def CQ,1,Q", 'qubit q0', 'qubit q1', 'CQ q0,q1')
+    Qgate = CreateCGate('Q')
+    print(str(q.get_circuit()))
+    assert str(q.get_circuit()) == 'C((1),Q(0))'

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -1,4 +1,4 @@
-from sympy.physics.quantum.qasm import Qasm, prod, flip_index, isblank, trim,\
+from sympy.physics.quantum.qasm import Qasm, prod, flip_index, trim,\
      get_index, nonblank, fullsplit, fixcommand, stripquotes
 from sympy.physics.quantum.gate import X, Z, H, S, T
 from sympy.physics.quantum.gate import CNOT, SWAP, CPHASE, CGate, CGateS
@@ -49,10 +49,6 @@ def test_qasm_prod():
 def test_qasm_flip_index():
     assert flip_index(0, 2) == 1
     assert flip_index(1, 2) == 0
-
-def test_qasm_isblank():
-    assert isblank('  ')
-    assert not isblank(' _ ')
 
 def test_qasm_trim():
     assert trim('nothing happens here') == 'nothing happens here'

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -85,5 +85,4 @@ def test_qasm_qdef():
     assert str(q.get_circuit()) == 'Q(0)'
     q = Qasm("def CQ,1,Q", 'qubit q0', 'qubit q1', 'CQ q0,q1')
     Qgate = CreateCGate('Q')
-    print(str(q.get_circuit()))
     assert str(q.get_circuit()) == 'C((1),Q(0))'

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -1,5 +1,7 @@
-from sympy.physics.quantum.qasm import Qasm
-from sympy.physics.quantum.gate import CNOT,H,SWAP,CGate,T,S,Z,X
+from sympy.physics.quantum.qasm import Qasm, prod, flip_index, isblank, trim,\
+     get_index, nonblank, fullsplit, fixcommand, stripquotes
+from sympy.physics.quantum.gate import X, Z, H, S, T
+from sympy.physics.quantum.gate import CNOT, SWAP, CPHASE, CGate, CGateS
 from sympy.physics.quantum.circuitplot import Mz
 
 def test_qasm_ex1():
@@ -25,3 +27,53 @@ def test_qasm_ex2():
              'measure q_1','measure q_0',
              'c-x q_1,q_2','c-z q_0,q_2')
     assert q.get_circuit() == CGate(2,Z(0))*CGate(1,X(0))*Mz(2)*Mz(1)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)
+
+def test_qasm_1q():
+    for symbol,gate in [('x',X), ('z',Z), ('h',H), ('s',S), ('t',T), ('measure',Mz)]:
+        q = Qasm('qubit q_0','%s q_0' % symbol)
+        assert q.get_circuit() == gate(0)
+
+def test_qasm_2q():
+    for symbol,gate in [('cnot',CNOT), ('swap',SWAP), ('cphase',CPHASE)]:
+        q = Qasm('qubit q_0','qubit q_1','%s q_0,q_1' % symbol)
+        assert q.get_circuit() == gate(1,0)
+
+def test_qasm_3q():
+    q = Qasm('qubit q0','qubit q1','qubit q2','toffoli q2,q1,q0')
+    assert q.get_circuit() == CGateS((0,1),X(2))
+
+def test_qasm_prod():
+    assert prod([1,2,3]) == 6
+    assert prod([H(0),X(1)])== H(0)*X(1)
+
+def test_qasm_flip_index():
+    assert flip_index(0,2) == 1
+    assert flip_index(1,2) == 0
+
+def test_qasm_isblank():
+    assert isblank('  ')
+    assert not isblank(' _ ')
+
+def test_qasm_trim():
+    assert trim('nothing happens here') == 'nothing happens here'
+    assert trim("Something #happens here") == "Something "
+
+def test_qasm_get_index():
+    assert get_index('q0', ['q0', 'q1']) == 1
+    assert get_index('q1', ['q0', 'q1']) == 0
+
+def test_qasm_nonblank():
+    assert list(nonblank('abcd')) == list('abcd')
+    assert list(nonblank('abc ')) == list('abc')
+
+def test_qasm_fullsplit():
+    assert fullsplit('g q0,q1,q2,  q3') == ('g',['q0', 'q1', 'q2', 'q3'])
+
+def test_qasm_fixcommand():
+    assert fixcommand('foo') == 'foo'
+    assert fixcommand('def') == 'qdef'
+
+def test_qasm_stripquotes():
+    assert stripquotes("'S'") == 'S'
+    assert stripquotes('"S"') == 'S'
+    assert stripquotes('S') == 'S'

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -1,8 +1,18 @@
 from sympy.physics.quantum.qasm import Qasm, prod, flip_index, trim,\
-     get_index, nonblank, fullsplit, fixcommand, stripquotes
+     get_index, nonblank, fullsplit, fixcommand, stripquotes, read_qasm
 from sympy.physics.quantum.gate import X, Z, H, S, T
 from sympy.physics.quantum.gate import CNOT, SWAP, CPHASE, CGate, CGateS
 from sympy.physics.quantum.circuitplot import Mz, CreateOneQubitGate, CreateCGate
+
+def test_qasm_readqasm():
+    qasm_lines = """\
+    qubit q_0
+    qubit q_1
+    h q_0
+    cnot q_0,q_1
+    """
+    q = read_qasm(qasm_lines)
+    assert q.get_circuit() == CNOT(1,0)*H(1)
 
 def test_qasm_ex1():
     q = Qasm('qubit q0', 'qubit q1', 'h q0', 'cnot q0,q1')

--- a/sympy/physics/quantum/tests/test_qasm.py
+++ b/sympy/physics/quantum/tests/test_qasm.py
@@ -1,0 +1,27 @@
+from sympy.physics.quantum.qasm import Qasm
+from sympy.physics.quantum.gate import CNOT,H,SWAP,CGate,T,S,Z,X
+from sympy.physics.quantum.circuitplot import Mz
+
+def test_qasm_ex1():
+    q = Qasm('qubit q0','qubit q1','h q0','cnot q0,q1')
+    assert q.get_circuit() == CNOT(1,0)*H(1)
+
+def test_qasm_ex1_methodcalls():
+    q = Qasm()
+    q.qubit('q_0')
+    q.qubit('q_1')
+    q.h('q_0')
+    q.cnot('q_0','q_1')    
+    assert q.get_circuit() == CNOT(1,0)*H(1)
+
+def test_qasm_swap():
+    q = Qasm('qubit q0','qubit q1','cnot q0,q1','cnot q1,q0','cnot q0,q1')
+    assert q.get_circuit() == CNOT(1,0)*CNOT(0,1)*CNOT(1,0)
+
+
+def test_qasm_ex2():
+    q = Qasm('qubit q_0','qubit q_1','qubit q_2','h  q_1',
+             'cnot q_1,q_2','cnot q_0,q_1','h q_0',
+             'measure q_1','measure q_0',
+             'c-x q_1,q_2','c-z q_0,q_2')
+    assert q.get_circuit() == CGate(2,Z(0))*CGate(1,X(0))*Mz(2)*Mz(1)*H(2)*CNOT(2,1)*CNOT(1,0)*H(1)


### PR DESCRIPTION
This PR makes several changes centered around creating a circuit from the
[qasm quantum circuit language](http://www.media.mit.edu/quanta/qasm2circ/).
Examples of the parser are now included on the [sympy quantum circuit parsing
notebook](http://nbviewer.ipython.org/5843312). Roughly half of the examples
from the MIT page now plot directly from the qasm text.

Most of these changes are in the qasm.py file, which defines a Qasm class
that does most of the work.

Did a rebase of these changes on 8/8/2013 to make sure they could be merged
easily. Have since learned that this complicates things unnecessarily,
at least in terms of the number of commits that show up here.
