### PR TITLE
WIP:  Adding to C code generation

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -62,7 +62,6 @@ class CCodePrinter(CodePrinter):
         """
         Actually format the expression as C code.
         """
-
         if isinstance(assign_to, string_types):
             assign_to = C.Symbol(assign_to)
         elif not isinstance(assign_to, (C.Basic, type(None))):
@@ -134,6 +133,9 @@ class CCodePrinter(CodePrinter):
         else:
             return 'pow(%s, %s)' % (self._print(expr.base),
                                  self._print(expr.exp))
+
+    def _print_gamma(self, expr):
+        return 'tgamma(%s)' % self._print(expr.args[0])
 
     def _print_Rational(self, expr):
         p, q = int(expr.p), int(expr.q)


### PR DESCRIPTION
The `CCodePrinter` supports only a minimal set of functions (arithmetic, trig, exp, array indexing) and is missing out on lots of the power SymPy has to offer on advanced mathematical expressions.  

To add to that it doesn't fail gracefully and often gives wrong results.  For example, printing the SymPy expression `gamma(x)` yielded the C code `gamma(x)` which is, unfortunately, not the correct call.  Instead we need the C code to be `tgamma(x)`.  These changes are simple and powerful.

This work is alongside connecting the SymPy C code generator to Theano in https://github.com/Theano/Theano/pull/1486
