### PR TITLE
Don't set TEST_DOCTESTS when it's false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 env:
   - TEST_DOCTESTS="true"
-  - TEST_DOCTESTS="false"
 python:
   - 2.6
   - 2.7
@@ -19,7 +18,6 @@ matrix:
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
-        - TEST_DOCTESTS="false"
     - python: 3.3
       env:
         - TEST_GMPY="true"
@@ -29,7 +27,6 @@ matrix:
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
-        - TEST_DOCTESTS="false"
     - python: 2.7
       env: TEST_SPHINX="true"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 env:
   - TEST_DOCTESTS="true"
+  -
 python:
   - 2.6
   - 2.7


### PR DESCRIPTION
This makes the Travis build matrix much easier to read.
- [x] Don't merge this until I've verified that it actually works.
