### PR TITLE
Modify latex output of tuple and list to use \left and \right instead of matrices

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1228,15 +1228,15 @@ class LatexPrinter(Printer):
         return r"\mathbb{I}"
 
     def _print_tuple(self, expr):
-        return r"\begin{pmatrix}%s\end{pmatrix}" % \
-            r", & ".join([ self._print(i) for i in expr ])
+        return r"\left( %s \right)" % \
+            r", ".join([ self._print(i) for i in expr ])
 
     def _print_Tuple(self, expr):
         return self._print_tuple(expr)
 
     def _print_list(self, expr):
-        return r"\begin{bmatrix}%s\end{bmatrix}" % \
-            r", & ".join([ self._print(i) for i in expr ])
+        return r"\left[ %s \right]" % \
+            r", ".join([ self._print(i) for i in expr ])
 
     def _print_dict(self, d):
         keys = sorted(d.keys(), key=default_sort_key)


### PR DESCRIPTION
This modifies latex printing of tuples and lists to use $\left( ... \right)$  and $\left[ ... \right]$, respectively.
Currently they are implemented using matrices (\bmatrix etc.), which leaves unnecessary large spaces in the output.

Currently, this breaks _many_ tests. Is there an easy way to automate changing these tests?
