### PR TITLE
Added XFAIL test for dsolve

### DIFF
--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1715,3 +1715,8 @@ def test_kamke():
     eq = x**2*(a*f(x)**2+(f(x).diff(x))) + b*x**alpha + c
     i = infinitesimals(eq, hint='sum_function')
     assert checkinfsol(eq, i)[0]
+
+
+def test_constantsimp():
+    eq = x*(f(x).diff(x)) + 1 - f(x)**2
+    assert dsolve(eq) == Eq(f(x), S(-1))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1716,7 +1716,7 @@ def test_kamke():
     i = infinitesimals(eq, hint='sum_function')
     assert checkinfsol(eq, i)[0]
 
-
-def test_constantsimp():
+@XFAIL
+def test_issue_3982():
     eq = x*(f(x).diff(x)) + 1 - f(x)**2
-    assert dsolve(eq) == Eq(f(x), S(-1))
+    assert dsolve(eq) == Eq(f(x), (C2 + x**2)/(C1 - x**2))


### PR DESCRIPTION
This is a dummy PR just to check if there is a bug in dsolve or not. In my master branch doing this.

```
eq = x*(f(x).diff(x)) + 1 - f(x)**2
dsolve(eq)
f(x) == -1
```

I just wanted to know if there is something wrong with my master, or there actually is a bug.
