### PR TITLE
DE in test_risch.py (test_recognize_log_derivative)

### DIFF
--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -187,10 +187,13 @@ def test_recognize_log_derivative():
     assert recognize_log_derivative(a, d, DE, z) == True
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
     assert recognize_log_derivative(Poly(t + 1, t), Poly(t + x, t), DE) == True
-    assert recognize_log_derivative(Poly(2, t), Poly(t**2 - 1), DE) == True
-    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]})
-    assert recognize_log_derivative(Poly(1, t), Poly(t**2 - 2), DE) == False
-    assert recognize_log_derivative(Poly(1, t), Poly(t**2 + t), DE) == True
+    assert recognize_log_derivative(Poly(2, t), Poly(t**2 - 1, t), DE) == True
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
+    assert recognize_log_derivative(Poly(1, x), Poly(x**2 - 2, x), DE) == False
+    assert recognize_log_derivative(Poly(1, x), Poly(x**2 + x, x), DE) == True
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
+    assert recognize_log_derivative(Poly(1, t), Poly(t**2 - 2, t), DE) == False
+    assert recognize_log_derivative(Poly(1, t), Poly(t**2 + t, t), DE) == False
 
 
 def test_residue_reduce():


### PR DESCRIPTION
The following PR corrects the differential extension of the test case in test_risch.py under test_recognize_log_derivative. It changes DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1, t)]}) to DE = DifferentialExtension(extension={'D': [Poly(1, x)]}). Also adds the case where DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t]})
