### PR TITLE
Rectified bug in solve_linear

### DIFF
--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1729,11 +1729,17 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
             if type(derivs[xi]) is list:
                 derivs[xi] = dict([(der, der.doit()) for der in derivs[xi]])
             nn = n.subs(derivs[xi])
-            dn = nn.diff(xi)
+            dn = nn.diff(xi)  # Check if it is dependent on xi
             if dn:
                 all_zero = False
-                if not xi in dn.free_symbols:
-                    vi = -(nn.subs(xi, 0))/dn
+                if not xi in dn.free_symbols:  # Linear in xi
+                    if nn.is_Add:
+                        ntry = -nn.as_independent(xi)[0]
+                    elif not d.has(xi) or not (d/xi).has(xi):
+                        return xi, S.Zero
+                    else:
+                        return S.Zero, S.Zero
+                    vi = ntry/dn
                     if dens is None:
                         dens = denoms(eq, symbols)
                     if not any(checksol(di, {xi: vi}, minimal=True) is True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -21,7 +21,7 @@ from sympy.core.sympify import sympify
 from sympy.core import (C, S, Add, Symbol, Wild, Equality, Dummy, Basic,
     Expr, Mul, Pow)
 from sympy.core.exprtools import factor_terms
-from sympy.core.function import (expand_mul, expand_multinomial, expand_log,
+from sympy.core.function import (expand, expand_mul, expand_multinomial, expand_log,
                           Derivative, AppliedUndef, UndefinedFunction, nfloat,
                           count_ops, Function, expand_power_exp)
 from sympy.core.numbers import ilcm, Float
@@ -1733,13 +1733,11 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
             if dn:
                 all_zero = False
                 if not xi in dn.free_symbols:  # Linear in xi
+                    print(nn)
                     if nn.is_Add:
-                        ntry = -nn.as_independent(xi)[0]
-                    elif not d.has(xi) or not (d/xi).has(xi):
-                        return xi, S.Zero
+                        vi = -(expand(nn).as_independent(xi)[0])/dn
                     else:
-                        return S.Zero, S.Zero
-                    vi = ntry/dn
+                        vi = S.Zero
                     if dens is None:
                         dens = denoms(eq, symbols)
                     if not any(checksol(di, {xi: vi}, minimal=True) is True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -1733,7 +1733,6 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
             if dn:
                 all_zero = False
                 if not xi in dn.free_symbols:  # Linear in xi
-                    print(nn)
                     if nn.is_Add:
                         vi = -(expand(nn).as_independent(xi)[0])/dn
                     else:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1523,7 +1523,7 @@ def test_linear_coeff_match():
 def test_linear_coefficients():
     f = Function('f')
     df = f(x).diff(x)
-    sol = Eq(f(x), C1/(x**2 + 6*x + 9) - S(3)/2)
+    sol = Eq(f(x), (C1 - 3*x**2/2 - 9*x)/(x**2 + 6*x + 9))
     # XXX if force is not used in solve, the following is returned which,
     # for C1 = -81/2, will satisfy the original equation. Should there be
     # another free symbol so a family of solutions can be obtained, e.g.
@@ -1695,6 +1695,7 @@ def test_heuristic_abaco2_unique_unknown():
     assert i == [{eta(x, f(x)): x, xi(x, f(x)): -f(x)}]
     assert checkinfsol(eq, i)[0]
 
+    a = Symbol("a", positive=True)
     eq = (x*f(x).diff(x) + f(x) + 2*x)**2 -4*x*f(x) -4*x**2 -4*a
     i = infinitesimals(eq, hint='abaco2_unique_unknown')
     assert checkinfsol(eq, i)[0]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1371,3 +1371,10 @@ def test_misc():
 
     # watch out for recursive loop in tsolve
     raises(NotImplementedError, lambda: solve((x+2)**y*x-3,x))
+
+
+def test_integral():
+    eq = y - Integral(f(x), y)
+    assert solve_linear(eq) == (y, 0)
+    eq = x + y - Integral(f(x), y)
+    assert solve_linear(eq) == (y, -x/(-f(x) + 1))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1292,8 +1292,9 @@ def test_lambert_multivariate():
         log((3*LambertW(S(1)/3)/p**5)**(1/(3*log(p)))),]  # checked numerically
     # check collection
     assert solve(3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5), x) == [
-        -((log(a**5) + LambertW(1/(b + 3)))/(3*log(a)))]
-
+        (-5*log(a)/S(3) + log(((b + 3)*LambertW(1/(b + 3)))**(1/S(3))))/log(a),
+        (-log(a**5)/S(3) + log(((b + 3)*LambertW(1/(b + 3)))**(1/S(3))*(-1 - sqrt(3)*I)/S(2)))/log(a),
+        (-log(8*a**5)/S(3) + log(((b + 3)*LambertW(1/(b + 3)))**(1/S(3))*(-1 + sqrt(3)*I)))/log(a)]
     eq = 4*2**(2*p + 3) - 2*p - 3
     assert _solve_lambert(eq, p, _filtered_gens(Poly(eq), p)) == [
         -S(3)/2 - LambertW(-4*log(2))/(2*log(2))]

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -1268,7 +1268,8 @@ def test_issue_3890():
 
 
 def test_lambert_multivariate():
-    from sympy.abc import a, x, y
+    from sympy.abc import x, y
+    a = Symbol("a", positive=True)
     from sympy.solvers.bivariate import _filtered_gens, _lambert, _solve_lambert
 
     assert _filtered_gens(Poly(x + 1/x + exp(x) + y), x) == set([x, exp(x)])
@@ -1284,9 +1285,6 @@ def test_lambert_multivariate():
     # coverage test
     raises(NotImplementedError, lambda: solve(x - sin(x)*log(y - x), x))
 
-    # if sign is unknown then only this one solution is obtained
-    assert solve(3*log(a**(3*x + 5)) + a**(3*x + 5), x) == [
-        -((log(a**5) + LambertW(S(1)/3))/(3*log(a)))]  # tested numerically
     p = symbols('p', positive=True)
     assert solve(3*log(p**(3*x + 5)) + p**(3*x + 5), x) == [
         log((-3**(S(1)/3) - 3**(S(5)/6)*I)*LambertW(S(1)/3)**(S(1)/3)/(2*p**(S(5)/3)))/log(p),
@@ -1374,6 +1372,7 @@ def test_misc():
 
 
 def test_integral():
+    f = Function("f")
     eq = y - Integral(f(x), y)
     assert solve_linear(eq) == (y, 0)
     eq = x + y - Integral(f(x), y)


### PR DESCRIPTION
Hi, solve_linear gives me the following results in master, which I think is wrong,

```
eq = y - Integral(f(x), y)
solve_linear(eq)
(y, Integral(f(x), y)/(-f(x) + 1))
eq = x + y - Integral(f(x), y)
solve_linear(eq)
(y, -x/(-f(x) + 1) + Integral(f(x), y)/(-f(x) + 1))
```

I tried to rectify it but there are a couple of test failures. It would be really nice if someone could help me out and merge this, since the source code of `solvers.py` is relatively new to me.
