### PR TITLE
Fixing some issues w/ cacheless testing.

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -9,6 +9,10 @@ from sympy.core.compatibility import (reduce, iterable, Iterator, ordered,
     string_types, with_metaclass)
 from sympy.core.decorators import deprecated
 from sympy.core.singleton import S
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 
 
 class Basic(with_metaclass(ManagedProperties)):
@@ -358,6 +362,9 @@ class Basic(with_metaclass(ManagedProperties)):
 
         from http://docs.python.org/dev/reference/datamodel.html#object.__hash__
         """
+
+        if self is other:
+            return True
 
         from .function import AppliedUndef, UndefinedFunction as UndefFunc
 
@@ -1681,9 +1688,7 @@ def _aresame(a, b):
 
     """
     from .function import AppliedUndef, UndefinedFunction as UndefFunc
-    if len(list(preorder_traversal(a))) != len(list(preorder_traversal(b))):
-        return False
-    for i, j in zip(preorder_traversal(a), preorder_traversal(b)):
+    for i, j in zip_longest(preorder_traversal(a), preorder_traversal(b)):
         if i != j or type(i) != type(j):
             if ((isinstance(i, UndefFunc) and isinstance(j, UndefFunc)) or
                 (isinstance(i, AppliedUndef) and isinstance(j, AppliedUndef))):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -6,13 +6,9 @@ from sympy.core.cache import cacheit
 from sympy.core.core import BasicType, C
 from sympy.core.sympify import _sympify, sympify, SympifyError
 from sympy.core.compatibility import (reduce, iterable, Iterator, ordered,
-    string_types, with_metaclass)
+    string_types, with_metaclass, zip_longest)
 from sympy.core.decorators import deprecated
 from sympy.core.singleton import S
-try:
-    from itertools import zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest
 
 
 class Basic(with_metaclass(ManagedProperties)):

--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -263,7 +263,10 @@ def cmp_to_key(mycmp):
             return mycmp(self.obj, other.obj) != 0
     return K
 
-
+try:
+    from itertools import zip_longest
+except ImportError: # <= Python 2.7
+    from itertools import izip_longest as zip_longest
 try:
     from itertools import combinations_with_replacement
 except ImportError:  # <= Python 2.6

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -253,6 +253,9 @@ class Function(Application, Expr):
     def __new__(cls, *args, **options):
         # Handle calls like Function('f')
         if cls is Function:
+            #newfunc = UndefinedFunction(*args)
+            #newfunc.__eq__ = Basic.__eq__
+            #return newfunc
             return UndefinedFunction(*args)
 
         if cls.nargs is not None:
@@ -625,6 +628,8 @@ class UndefinedFunction(FunctionClass):
         ret.__module__ = None
         return ret
 
+UndefinedFunction.__eq__ = lambda s, o: (isinstance(o, s.__class__) and
+                                         (s.class_key() == o.class_key()))
 
 class WildFunction(Function, AtomicExpr):
     """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -571,6 +571,7 @@ class Function(Application, Expr):
         if not self.args[argindex - 1].is_Symbol:
             # See issue 1525 and issue 1620 and issue 2501
             arg_dummy = C.Dummy('xi_%i' % argindex)
+            arg_dummy.dummy_index = hash(self.args[argindex - 1])
             return Subs(Derivative(
                 self.subs(self.args[argindex - 1], arg_dummy),
                 arg_dummy), arg_dummy, self.args[argindex - 1])
@@ -988,6 +989,7 @@ class Derivative(Expr):
             else:
                 if not is_symbol:
                     new_v = C.Dummy('xi_%i' % i)
+                    new_v.dummy_index = hash(v)
                     expr = expr.subs(v, new_v)
                     old_v = v
                     v = new_v

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -253,9 +253,6 @@ class Function(Application, Expr):
     def __new__(cls, *args, **options):
         # Handle calls like Function('f')
         if cls is Function:
-            #newfunc = UndefinedFunction(*args)
-            #newfunc.__eq__ = Basic.__eq__
-            #return newfunc
             return UndefinedFunction(*args)
 
         if cls.nargs is not None:

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -535,7 +535,6 @@ def test_unhandled():
     assert diff(expr, f(x), x) == Derivative(expr, f(x), x)
 
 
-@XFAIL
 def test_issue_1612():
     x = Symbol("x")
     assert Symbol('f')(x) == f(x)

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -274,11 +274,11 @@ def test_symarray():
     s1 = symarray("", 3)
     s2 = symarray("", 3)
     npt.assert_array_equal(s1, np.array(syms, dtype=object))
-    assert s1[0] is s2[0]
+    assert s1[0] == s2[0]
 
     a = symarray('a', 3)
     b = symarray('b', 3)
-    assert not(a[0] is b[0])
+    assert not(a[0] == b[0])
 
     asyms = symbols('a_0,a_1,a_2')
     npt.assert_array_equal(a, np.array(asyms, dtype=object))
@@ -287,15 +287,15 @@ def test_symarray():
     a2d = symarray('a', (2, 3))
     assert a2d.shape == (2, 3)
     a00, a12 = symbols('a_0_0,a_1_2')
-    assert a2d[0, 0] is a00
-    assert a2d[1, 2] is a12
+    assert a2d[0, 0] == a00
+    assert a2d[1, 2] == a12
 
     a3d = symarray('a', (2, 3, 2))
     assert a3d.shape == (2, 3, 2)
     a000, a120, a121 = symbols('a_0_0_0,a_1_2_0,a_1_2_1')
-    assert a3d[0, 0, 0] is a000
-    assert a3d[1, 2, 0] is a120
-    assert a3d[1, 2, 1] is a121
+    assert a3d[0, 0, 0] == a000
+    assert a3d[1, 2, 0] == a120
+    assert a3d[1, 2, 1] == a121
 
 
 def test_vectorize():

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -1013,11 +1013,11 @@ def symarray(prefix, shape):  # pragma: no cover
 
     >>> a = symarray('', 3)
     >>> b = symarray('', 3)
-    >>> a[0] is b[0]
+    >>> a[0] == b[0]
     True
     >>> a = symarray('a', 3)
     >>> b = symarray('b', 3)
-    >>> a[0] is b[0]
+    >>> a[0] == b[0]
     False
 
     Creating symarrays with a prefix:

--- a/sympy/strategies/tests/test_traverse.py
+++ b/sympy/strategies/tests/test_traverse.py
@@ -55,10 +55,10 @@ def test_bottom_up_once():
 
 def test_expr_fns():
     from sympy.strategies.rl import rebuild
+    from sympy import Add
     x, y = map(Symbol, 'xy')
     expr = x + y**3
     e = bottom_up(lambda x: x + 1, expr_fns)(expr)
-    b = bottom_up(lambda x: x + 1, basic_fns)(expr)
+    b = bottom_up(lambda x: Basic.__new__(Add, x, 1), basic_fns)(expr)
 
-    assert b == e
     assert rebuild(b) == e


### PR DESCRIPTION
A number of tests were failing when the cache was turned off. Main fixes
included changing some "is" statements to "==" statements, and implementing
equality/sameness tests for UndefinedFunction and AppliedUndef.

Still have 2 errors present, in test_diffgeom and test_traverse. Checkout the pastebin containing tracebacks:
http://pastebin.com/jeYcntTv
The test_traverse error seems to be happening because Basic.**new** is being called to create a Pow object.This doesn't seem to work.
The test_diffgeom error seems to be a point-of-substitution problem.
