### PR TITLE
Fixing integral subs

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1345,7 +1345,35 @@ class Integral(Expr):
         return integrate(terms, *self.limits) + Add(*order)*x
 
     def _eval_subs(self, old, new):
-        return _eval_subs(self, old, new)
+        oldsyms = old.free_symbols
+        newsyms = new.free_symbols
+        limits = self.limits[-1]  # Take the outer most limit
+        intvar = limits[0]
+
+        # Direct substitution if old = f(intvar) and new = f(intvar)
+        # irrespective of whether the integral is definite or indefinite
+        if len(oldsyms) == 1 and len(newsyms) == 1 and \
+            intvar in oldsyms and intvar in newsyms and old != intvar:
+                return _eval_subs(self, old, new)
+
+        # Indefinite integral, see issue 2571
+        elif len(limits) == 1:
+            if old == intvar:
+                newargs = list(self.args)[:-1]
+                newargs.append((old, new))
+                return Integral(*newargs)
+
+            else:
+                raise ValueError("First argument of subs should be  " + str(intvar) +
+                    "or a function of " + str(intvar))
+
+        # Definite integral, substitute if transformation of variables is linear
+        else:
+            if old == intvar and new.is_Symbol:
+                return self.xreplace({old: new})
+            else:
+                raise NotImplementedError("Unable to substitute " + str(old) +
+                    "for " + str(new))
 
     def _eval_transpose(self):
         if all([x.is_real for x in flatten(self.limits)]):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1365,7 +1365,7 @@ class Integral(Expr):
 
             else:
                 raise ValueError("First argument of subs should be  " + str(intvar) +
-                    "or a function of " + str(intvar))
+                    " or a function of " + str(intvar))
 
         # Definite integral, substitute if transformation of variables is linear
         else:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1004,3 +1004,8 @@ def test_integral_subs():
     assert eq.subs(y, x) == Integral(f(y), (y, x))
     eq = Integral(f(x), (y, 1, 2))
     assert eq.subs(y, x) == Integral(f(x), (x, 1, 2))
+    expr = Integral(x**log(x)*exp(x))
+    assert expr.subs(x*log(x), exp(x)) == Integral(exp(2*x), x)
+    assert expr.subs(x, y) == Integral(x**log(x)*exp(x), (x, y))
+    expr = Integral(x**log(x)*exp(x), (x, 1, 2))
+    assert expr.subs(x, y) == Integral(y**log(y)*exp(y), (y, 1, 2))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -994,3 +994,13 @@ def test_issue_1704():
     x_max = Symbol("x_max")
     assert integrate(y/pi*exp(-(x_max - x)/cos(a)), x) == \
         y*exp((x - x_max)/cos(a))*cos(a)/pi
+
+
+def test_integral_subs():
+    f = Function("f")
+    g = Function("g")
+    eq = Integral(f(y), y)
+    assert eq.subs(f(y), g(y)) == Integral(g(y), y)
+    assert eq.subs(y, x) == Integral(f(y), (y, x))
+    eq = Integral(f(x), (y, 1, 2))
+    assert eq.subs(y, x) == Integral(f(x), (x, 1, 2))


### PR DESCRIPTION
First attempt at fixing integral subs.
1. If old, new in eq.subs(old, new) are both functions of the integration variables, then substitution takes place irrespective of whether eq is a definite or indefinite integral.
2. If it is a indefinite integral, then this is followed, https://code.google.com/p/sympy/issues/detail?id=3829
3. If it is definite, and there is a linear transformation, then it is xreplaced.
