### PR TITLE
Speed up for matplotlib tests on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 env:
   - TEST_DOCTESTS="true"
+  - IN_PYTHON_33="false"
 python:
   - 2.6
   - 2.7
@@ -14,14 +15,12 @@ matrix:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="true"
-        - IN_PYTHON_33="false"
       virtualenv:
         system_site_packages: true
     - python: 2.7
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
-        - IN_PYTHON_33="false"
       virtualenv:
         system_site_packages: true
     - python: 3.3
@@ -49,10 +48,10 @@ before_install:
       sudo apt-get install --no-install-recommends graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra lmodern;
       pip install --use-mirrors "sphinx==1.1.3";
     fi
-  - if [[ "${TEST_MATPLOTLIB}" == "true" && "${IN_PYTHON_33}" == "true"]]; then
+  - if [[ "${TEST_MATPLOTLIB}" == "true"]] && [["${IN_PYTHON_33}" == "true"]]; then
       pip install --use-mirrors "matplotlib==1.2.1";
-    else
-      sudo apt-get install python-matplotlib python3-matplotlib;
+    elif [[ "${TEST_MATPLOTLIB}" == "true"]]; then
+      sudo apt-get -qq install python-matplotlib;
     fi
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 env:
   - TEST_DOCTESTS="true"
-  -
 python:
   - 2.6
   - 2.7
@@ -15,19 +14,27 @@ matrix:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="true"
+        - IN_PYTHON_33="false"
+      virtualenv:
+        system_site_packages: true
     - python: 2.7
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
+        - IN_PYTHON_33="false"
+      virtualenv:
+        system_site_packages: true
     - python: 3.3
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
         - TEST_DOCTESTS="true"
+        - IN_PYTHON_33="true"
     - python: 3.3
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
+        - IN_PYTHON_33="true"
     - python: 2.7
       env: TEST_SPHINX="true"
   allow_failures:
@@ -36,15 +43,16 @@ before_install:
   - if [[ "${TEST_GMPY}" == "true" ]]; then
       sudo apt-get update;
       sudo apt-get install libgmp-dev;
-      pip install "gmpy==1.16";
+      pip install --use-mirrors "gmpy==1.16";
     fi
   - if [[ "${TEST_SPHINX}" == "true" ]]; then
       sudo apt-get install --no-install-recommends graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra lmodern;
-      pip install "sphinx==1.1.3";
+      pip install --use-mirrors "sphinx==1.1.3";
     fi
-  - if [[ "${TEST_MATPLOTLIB}" == "true" ]]; then
-      pip install "numpy==1.7.1";
-      pip install "matplotlib==1.2.1";
+  - if [[ "${TEST_MATPLOTLIB}" == "true" && "${IN_PYTHON_33}" == "true"]]; then
+      pip install --use-mirrors "matplotlib==1.2.1";
+    else
+      sudo apt-get install python-matplotlib python3-matplotlib;
     fi
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
       sudo apt-get install --no-install-recommends graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra lmodern;
       pip install --use-mirrors "sphinx==1.1.3";
     fi
-  - if [[ "${TEST_MATPLOTLIB}" == "true"]] && [["${IN_PYTHON_33}" == "true"]]; then
+  - if [[ "${TEST_MATPLOTLIB}" == "true" -a "${IN_PYTHON_33}" == "true"]]; then
       pip install --use-mirrors "matplotlib==1.2.1";
     elif [[ "${TEST_MATPLOTLIB}" == "true"]]; then
       sudo apt-get -qq install python-matplotlib;


### PR DESCRIPTION
It is possible to use the system site packages option in the Traivs virtualenv for Python 2.7 apt-get installs. This is an attempt to see if it works.
