### PR TITLE
Fix issue 3174: do substitution first in evalf_sum()

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -625,11 +625,8 @@ def test_issue_1072():
     assert summation(2*k + 1, (k, 0, oo)) == oo
 
 
-@XFAIL
 def test_issue_3174():
-    # when this passes, the doctests involving Sum in
-    # is_constant can be unskipped
-    assert Sum(x, (x, 1, n)).n(2, subs={n: 0}) == 1
+    assert Sum(x, (x, 1, n)).n(2, subs={n: 1}) == 1
 
 
 def test_issue_3175():

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1069,6 +1069,8 @@ def hypsum(expr, n, start, prec):
 
 
 def evalf_sum(expr, prec, options):
+    if 'subs' in options:
+        expr = expr.subs(options['subs'])
     func = expr.function
     limits = expr.limits
     if len(limits) != 1 or len(limits[0]) != 3:
@@ -1095,11 +1097,7 @@ def evalf_sum(expr, prec, options):
             if err <= eps:
                 break
         err = fastlog(evalf(abs(err), 20, options)[0])
-        try:
-            re, im, re_acc, im_acc = evalf(s, prec2, options)
-        except TypeError:  # issue 3174
-            # when should it try subs if they are in options?
-            raise NotImplementedError
+        re, im, re_acc, im_acc = evalf(s, prec2, options)
         if re_acc is None:
             re_acc = -err
         if im_acc is None:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -451,11 +451,11 @@ class Expr(Basic, EvalfMixin):
         True
         >>> Sum(x, (x, 1, 10)).is_constant()
         True
-        >>> Sum(x, (x, 1, n)).is_constant()  # doctest: +SKIP
+        >>> Sum(x, (x, 1, n)).is_constant()
         False
         >>> Sum(x, (x, 1, n)).is_constant(y)
         True
-        >>> Sum(x, (x, 1, n)).is_constant(n) # doctest: +SKIP
+        >>> Sum(x, (x, 1, n)).is_constant(n)
         False
         >>> Sum(x, (x, 1, n)).is_constant(x)
         True


### PR DESCRIPTION
```
N.b.: XFAILed test was changed due to adoption of
the Karr convention for summation.
```
