### PR TITLE
Kahane's algorithm for reducing contracted products of gamma matrices

### DIFF
--- a/doc/src/modules/physics/hep/gamma_matrices.rst
+++ b/doc/src/modules/physics/hep/gamma_matrices.rst
@@ -1,0 +1,6 @@
+High energy physics
+===================
+
+.. module:: sympy.physics.hep.gamma_matrices
+
+.. autofunction:: sympy.physics.hep.gamma_matrices.kahane_simplify

--- a/doc/src/modules/physics/hep/index.rst
+++ b/doc/src/modules/physics/hep/index.rst
@@ -1,0 +1,15 @@
+===================
+High energy physics
+===================
+
+.. topic:: Abstract
+
+   Contains docstrings for methods in high energy physics.
+
+Gamma matrices
+==============
+
+.. toctree::
+    :maxdepth: 3
+
+    gamma_matrices.rst

--- a/doc/src/modules/physics/index.rst
+++ b/doc/src/modules/physics/index.rst
@@ -21,5 +21,6 @@ Contents
     secondquant.rst
     wigner.rst
     units.rst
+    hep/index.rst
     mechanics/index.rst
     quantum/index.rst

--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -214,16 +214,21 @@ def kahane_simplify(expression):
     pointer = first_dum_pos
     previous_pointer = 0
     while True:
-        try: next_ones = links.pop(pointer)
-        except KeyError: break
+        if pointer in links:
+            next_ones = links.pop(pointer)
+        else:
+            break
 
-        try: next_ones.remove(previous_pointer)
-        except ValueError: pass
+        if previous_pointer in next_ones:
+            if len(next_ones) > 1:
+                next_ones.remove(previous_pointer)
 
         previous_pointer = pointer
 
-        try: pointer = next_ones[0]
-        except IndexError: break
+        if next_ones:
+            pointer = next_ones[0]
+        else:
+            break
 
         if pointer == previous_pointer:
             break
@@ -254,18 +259,21 @@ def kahane_simplify(expression):
         # ignored.
         prepend_indices = []
         while True:
-            try: next_ones = links.pop(pointer)
-            except KeyError: break
+            if pointer in links:
+                next_ones = links.pop(pointer)
+            else:
+                break
 
-            try:
+            if previous_pointer in next_ones:
                 if len(next_ones) > 1:
                     next_ones.remove(previous_pointer)
-            except ValueError: pass
 
             previous_pointer = pointer
 
-            try: pointer = next_ones[0]
-            except IndexError: pass
+            if next_ones:
+                pointer = next_ones[0]
+            else:
+                break
 
             if pointer >= first_dum_pos and free_pos[pointer] is not None:
                 prepend_indices.insert(0, free_pos[pointer])

--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -220,8 +220,7 @@ def kahane_simplify(expression):
             break
 
         if previous_pointer in next_ones:
-            if len(next_ones) > 1:
-                next_ones.remove(previous_pointer)
+            next_ones.remove(previous_pointer)
 
         previous_pointer = pointer
 
@@ -272,8 +271,6 @@ def kahane_simplify(expression):
 
             if next_ones:
                 pointer = next_ones[0]
-            else:
-                break
 
             if pointer >= first_dum_pos and free_pos[pointer] is not None:
                 prepend_indices.insert(0, free_pos[pointer])

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -1,6 +1,6 @@
 from sympy.tensor.tensor import tensor_indices, TensorIndexType, tensorhead, TensorManager
-from sympy.tensor.gamma_matrices import GammaMatrix4D as G
-from sympy.tensor.gamma_matrices import kahane_simplify, Lorentz
+from sympy.physics.hep.gamma_matrices import GammaMatrix4D as G
+from sympy.physics.hep.gamma_matrices import kahane_simplify, Lorentz
 
 
 def test_kahane_algorithm():
@@ -143,5 +143,3 @@ def test_kahane_algorithm():
     t = 224*G(m0)*G(m1)*G(-m2)*G(m3)
     st = kahane_simplify(t)
     assert st == t
-
-test_kahane_algorithm()

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -16,66 +16,70 @@ def test_kahane_algorithm():
     # kahane_simplify only works in four dimensions:
     D = 4
 
-    t = (G(a1)*G(mu11)*G(a2)*G(mu21)*G(-a1)*G(mu31)*G(-a2))
-    assert kahane_simplify(t) == -4*G(mu11)*G(mu31)*G(mu21) - 4*G(mu31)*G(mu11)*G(mu21)
+    # Some examples taken from Kahane's paper, 4 dim only:
+    if D == 4:
+        t = (G(a1)*G(mu11)*G(a2)*G(mu21)*G(-a1)*G(mu31)*G(-a2))
+        assert kahane_simplify(t) == -4*G(mu11)*G(mu31)*G(mu21) - 4*G(mu31)*G(mu11)*G(mu21)
+
+        t = (G(a1)*G(mu11)*G(mu12)*\
+                              G(a2)*G(mu21)*\
+                              G(a3)*G(mu31)*G(mu32)*\
+                              G(a4)*G(mu41)*\
+                              G(-a2)*G(mu51)*G(mu52)*\
+                              G(-a1)*G(mu61)*\
+                              G(-a3)*G(mu71)*G(mu72)*\
+                              G(-a4))
+        assert kahane_simplify(t) == \
+            16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41)
+
+    # Fully Lorentz-contracted expressions, these return scalars:
 
     t = (G(mu)*G(-mu))
-    assert kahane_simplify(t) == 4
+    assert kahane_simplify(t) == D
 
     t = (G(mu)*G(nu)*G(-mu)*G(-nu))
-    assert kahane_simplify(t) == -8
+    assert kahane_simplify(t) == 2*D - D**2  # -8
 
     t = (G(mu)*G(nu)*G(-nu)*G(-mu))
-    assert kahane_simplify(t) == 16
+    assert kahane_simplify(t) == D**2  # 16
 
     t = (G(mu)*G(nu)*G(-rho)*G(-nu)*G(-mu)*G(rho))
-    assert kahane_simplify(t) == 16
+    assert kahane_simplify(t) == 4*D - 4*D**2 + D**3  # 16
 
     t = (G(mu)*G(nu)*G(rho)*G(-rho)*G(-nu)*G(-mu))
-    assert kahane_simplify(t) == 64
-
-    t = (G(a1)*G(mu11)*G(mu12)*\
-                          G(a2)*G(mu21)*\
-                          G(a3)*G(mu31)*G(mu32)*\
-                          G(a4)*G(mu41)*\
-                          G(-a2)*G(mu51)*G(mu52)*\
-                          G(-a1)*G(mu61)*\
-                          G(-a3)*G(mu71)*G(mu72)*\
-                          G(-a4))
-    assert kahane_simplify(t) == \
-        16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41)
-
-    t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
-    assert kahane_simplify(t) == -2*G(sigma)*G(rho)*G(nu)
-
-    t = (G(mu)*G(nu)*G(-mu))
-    assert kahane_simplify (t) == -2*G(nu)
-
-    t = (G(mu)*G(nu)*G(rho)*G(-mu))
-    assert kahane_simplify(t) == 2*G(nu)*G(rho) + 2*G(rho)*G(nu)
+    assert kahane_simplify(t) == D**3  # 64
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(-a3)*G(-a1)*G(-a2)*G(-a4))
-    assert kahane_simplify(t) == -32
+    assert kahane_simplify(t) == -8*D + 16*D**2 - 8*D**3 + D**4  # -32
 
     t = (G(-mu)*G(-nu)*G(-rho)*G(-sigma)*G(nu)*G(mu)*G(sigma)*G(rho))
-    assert kahane_simplify(t) == 64
+    assert kahane_simplify(t) == -16*D + 24*D**2 - 8*D**3 + D**4  # 64
 
     t = (G(-mu)*G(nu)*G(-rho)*G(sigma)*G(rho)*G(-nu)*G(mu)*G(-sigma))
-    assert kahane_simplify(t) == -32
+    assert kahane_simplify(t) == 8*D - 12*D**2 + 6*D**3 - D**4  # -32
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(-a3)*G(-a2)*G(-a1)*G(-a5)*G(-a4))
-    assert kahane_simplify(t) == 256
+    assert kahane_simplify(t) == 64*D - 112*D**2 + 60*D**3 - 12*D**4 + D**5  # 256
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(-a3)*G(-a1)*G(-a2)*G(-a4)*G(-a5))
-    assert kahane_simplify(t) == -128
+    assert kahane_simplify(t) == 64*D - 120*D**2 + 72*D**3 - 16*D**4 + D**5  # -128
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(a6)*G(-a3)*G(-a2)*G(-a1)*G(-a6)*G(-a5)*G(-a4))
-    assert kahane_simplify(t) == -128
+    assert kahane_simplify(t) == 416*D - 816*D**2 + 528*D**3 - 144*D**4 + 18*D**5 - D**6  # -128
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(a6)*G(-a2)*G(-a3)*G(-a1)*G(-a6)*G(-a4)*G(-a5))
-    assert kahane_simplify(t) == -128
+    assert kahane_simplify(t) == 416*D - 848*D**2 + 584*D**3 - 172*D**4 + 22*D**5 - D**6  # -128
 
-    # more complex expressions:
+    # Expressions with free indices:
+
+    t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
+    assert kahane_simplify(t).equals(-2*G(sigma)*G(rho)*G(nu) + (4-D)*G(nu)*G(rho)*G(sigma))
+
+    t = (G(mu)*G(nu)*G(-mu))
+    assert kahane_simplify (t) == (2-D)*G(nu)
+
+    t = (G(mu)*G(nu)*G(rho)*G(-mu))
+    assert kahane_simplify(t) == 2*G(nu)*G(rho) + 2*G(rho)*G(nu) - (4-D)*G(nu)*G(rho)
 
     t = 2*G(m2)*G(m0)*G(m1)*G(-m0)*G(-m1)
     st = kahane_simplify(t)
@@ -130,7 +134,7 @@ def test_kahane_algorithm():
     else:
         assert st.equals(result1)
 
-    # and a few very simple cases:
+    # and a few very simple cases, with no contracted indices:
 
     t = G(m0)
     st = kahane_simplify(t)

--- a/sympy/tensor/gamma_matrices.py
+++ b/sympy/tensor/gamma_matrices.py
@@ -1,0 +1,279 @@
+from sympy import S
+from sympy.tensor.tensor import TensorIndexType, tensorhead
+
+
+Lorentz = TensorIndexType("L", 1)
+GammaMatrix4D = tensorhead("G", [Lorentz], [[1]], 2)
+
+
+def kahane_simplify(expression):
+    """
+    This function cancels contracted elements in an expression of four
+    dimensional gamma matrices, resulting in an expression equal to the given
+    one, without the contracted gamma matrices.
+
+    Examples
+    ========
+
+    >>> from sympy.tensor.gamma_matrices import Lorentz, GammaMatrix4D as G, kahane_simplify
+    >>> from sympy.tensor.tensor import tensor_indices, tensorhead
+    >>> i0, i1, i2 = tensor_indices('i0:3', Lorentz)
+    >>> kahane_simplify(G(i0)*G(-i0))
+    4
+    >>> kahane_simplify(G(i0)*G(i1)*G(-i0))
+    -2*G(i1)
+
+    If there are no contractions, the same expression is returned
+
+    >>> kahane_simplify(3*G(i0)*G(i1))
+    3*G(i0)*G(i1)
+
+    References
+    ==========
+
+    [1] Algorithm for Reducing Contracted Products of gamma Matrices, Joseph Kahane, Journal of Mathematical Physics, Vol. 9, No. 10, October 1968.
+    """
+
+    free = expression.free[:]
+    dum = sorted(expression.dum)
+
+    if len(dum) == 0:
+        # no contractions in `expression`, just return it.
+        return expression
+
+    # find the `first_dum_pos`, i.e. the position of the first contracted
+    # gamma matrix, Kahane's algorithm as described in his paper requires the
+    # gamma matrix expression to start with a contracted gamma matrix, this is
+    # a workaround which ignores possible initial free indices, and re-adds
+    # them later.
+    dum_zip = list(zip(*dum))[2:]
+    first_dum_pos = min(min(dum_zip[0]), min(dum_zip[1]))
+
+    total_number = len(free) + len(dum)*2
+    number_of_contractions = len(dum)
+
+    free_pos = [None]*total_number
+    for i in free:
+        free_pos[i[2]] = i[0]
+
+    # `index_is_free` is a list of booleans, to identify index position
+    # and whether that index is free or dummy.
+    index_is_free = [False]*total_number
+
+    for i, indx in enumerate(free):
+        assert indx[1] == 0
+        index_is_free[indx[2]] = True
+
+    # `links` is a dictionary containing the graph described in Kahane's paper,
+    # to every key correspond one or two values, representing the linked indices.
+    # All values in `links` are integers, negative numbers are used in the case
+    # where it is necessary to insert gamma matrices between free indices, in
+    # order to make Kahane's algorithm work (see paper).
+    links = {}
+    for i in range(first_dum_pos, total_number):
+        links[i] = []
+
+    # `cum_sign` is a step variable to mark the sign of every index, see paper.
+    cum_sign = -1
+    last_cum_sign = 1
+    # `cum_sign_list` keeps storage for all `cum_sign` (every index).
+    cum_sign_list = [None]*total_number
+    block_free_count = 0
+
+    # multiply `resulting_expr` by the coefficient of `expression`, the rest
+    # of the algorithm ignores a scalar coefficient.
+    resulting_expr = expression.coeff
+
+    # start to count the `connected_components`, which together with the number
+    # of contractions, determines a -1 or +1 factor to be multiplied.
+    connected_components = 1
+
+    # First loop: here we fill `cum_sign_list`, and draw the links
+    # among consecutive indices (they are stored in `links`). Links among
+    # non-consecutive indices will be drawn later.
+    for i, is_free in enumerate(index_is_free):
+        # if `expression` starts with free indices, they are ignored here;
+        # they are later added as they are to the beginning of `resulting_expr`
+        if i < first_dum_pos:
+            continue
+
+        if is_free:
+            block_free_count += 1
+            # if previous index was free as well, draw an arch in `links`.
+            if block_free_count > 1:
+                links[i - 1].append(i)
+                links[i].append(i - 1)
+        else:
+            # Change the sign of the index (`cum_sign`) if the number of free
+            # indices preceding it is even.
+            cum_sign *= 1 if (block_free_count % 2) else -1
+            if block_free_count == 0 and i != first_dum_pos:
+                # check if there are two consecutive dummy indices:
+                # in this case create virtual indices with negative position,
+                # these "virtual" indices represent the insertion of two
+                # gamma^0 matrices to separate consecutive dummy indices, as
+                # Kahane's algorithm requires dummy indices to be separated by
+                # free indices. The product of two gamma^0 matrices is unity,
+                # so the new expression being examined is the same as the
+                # original one.
+                if cum_sign == -1:
+                    links[-1-i] = [-1-i+1]
+                    links[-1-i+1] = [-1-i]
+            if (i - cum_sign) in links:
+                if i != first_dum_pos:
+                    links[i].append(i - cum_sign)
+                if block_free_count != 0:
+                    if i - cum_sign < len(index_is_free):
+                        if index_is_free[i - cum_sign]:
+                            links[i - cum_sign].append(i)
+            block_free_count = 0
+            last_cum_sign = cum_sign
+
+        cum_sign_list[i] = cum_sign
+
+    # The previous loop has only created links between consecutive free indices,
+    # it is necessary to properly create links among dummy (contracted) indices,
+    # according to the rules described in Kahane's paper. There is only one exception
+    # to Kahane's rules: the negative indices, which handle the case of some
+    # consecutive free indices (Kahane's paper just describes dummy indices
+    # separated by free indices, hinting that free indices can be added without
+    # altering the expression result).
+    for i in dum:
+        assert i[0] == 0
+        assert i[1] == 0
+        # get the positions of the two contracted indices:
+        pos1 = i[2]
+        pos2 = i[3]
+
+        # create Kahane's upper links, i.e. the upper arcs between dummy
+        # (i.e. contracted) indices:
+        links[pos1].append(pos2)
+        links[pos2].append(pos1)
+
+        # create Kahane's lower links, this corresponds to the arcs below
+        # the line described in the paper:
+
+        # first we move `pos1` and `pos2` according to the sign of the indices:
+        linkpos1 = pos1 + cum_sign_list[pos1]
+        linkpos2 = pos2 + cum_sign_list[pos2]
+
+        # otherwise, perform some checks before creating the lower arcs:
+
+        # make sure we are not exceeding the total number of indices:
+        if linkpos1 >= total_number:
+            continue
+        if linkpos2 >= total_number:
+            continue
+
+        # make sure we are not below the first dummy index in `expression`:
+        if linkpos1 < first_dum_pos:
+            continue
+        if linkpos2 < first_dum_pos:
+            continue
+
+        # check if the previous loop created "virtual" indices between dummy
+        # indices, in such a case relink `linkpos1` and `linkpos2`:
+        if (-1-linkpos1) in links:
+            linkpos1 = -1-linkpos1
+        if (-1-linkpos2) in links:
+            linkpos2 = -1-linkpos2
+
+        # move only if not next to free index:
+        if linkpos1 >= 0 and not index_is_free[linkpos1]:
+            linkpos1 = pos1
+
+        if linkpos2 >=0 and not index_is_free[linkpos2]:
+            linkpos2 = pos2
+
+        # create the lower arcs:
+        if linkpos2 not in links[linkpos1]:
+            links[linkpos1].append(linkpos2)
+        if linkpos1 not in links[linkpos2]:
+            links[linkpos2].append(linkpos1)
+
+    # This loop starts from the `first_dum_pos` index (first dummy index)
+    # walks through the graph deleting the visited indices from `links`,
+    # it adds a gamma matrix for every free index in encounters, while it
+    # completely ignores dummy indices and virtual indices.
+    pointer = first_dum_pos
+    previous_pointer = 0
+    while True:
+        try: next_ones = links.pop(pointer)
+        except KeyError: break
+
+        try: next_ones.remove(previous_pointer)
+        except ValueError: pass
+
+        previous_pointer = pointer
+
+        try: pointer = next_ones[0]
+        except IndexError: break
+
+        if pointer == previous_pointer:
+            break
+        if pointer >=0 and free_pos[pointer] is not None:
+            resulting_expr *= GammaMatrix4D(free_pos[pointer])
+
+    # The following loop removes the remaining connected components in `links`.
+    # If there are free indices inside a connected component, it gives a
+    # contribution to the resulting expression given by the factor
+    # `gamma_a gamma_b ... gamma_z + gamma_z ... gamma_b gamma_a`, in Kahanes's
+    # paper represented as  {gamma_a, gamma_b, ... , gamma_z},
+    # virtual indices are ignored. The variable `connected_components` is
+    # increased by one for every connected component this loop encounters.
+
+    # If the connected component has virtual and dummy indices only
+    # (no free indices), it contributes to `resulting_expr` by a factor of two.
+    # The multiplication by two is a result of the
+    # factor {gamma^0, gamma^0} = 2 I, as it appears in Kahane's paper.
+    # Note: curly brackets are meant as in the paper, not as an anticommutator!
+
+    while len(links.keys()) > 0:
+        connected_components += 1
+        pointer = min(links.keys())
+        previous_pointer = pointer
+        # the inner loop erases the visited indices from `links`, and it adds
+        # all free indices to `prepend_indices` list, virtual indices are
+        # ignored.
+        prepend_indices = []
+        while True:
+            try: next_ones = links.pop(pointer)
+            except KeyError: break
+
+            try:
+                if len(next_ones) > 1:
+                    next_ones.remove(previous_pointer)
+            except ValueError: pass
+
+            previous_pointer = pointer
+
+            try: pointer = next_ones[0]
+            except IndexError: pass
+
+            if pointer >= first_dum_pos and free_pos[pointer] is not None:
+                prepend_indices.insert(0, free_pos[pointer])
+
+        # if `prepend_indices` is void, ...
+        if len(prepend_indices) == 0:
+            resulting_expr *= 2
+        # otherwise, add the free indices in `prepend_indices` to
+        # the `resulting_expr`:
+        else:
+            expr1 = S.One
+            expr2 = S.One
+            for i in prepend_indices:
+                expr1 = expr1 * GammaMatrix4D(i)
+                expr2 = GammaMatrix4D(i) * expr2
+            resulting_expr = (expr1 + expr2)*resulting_expr
+
+    # sign correction, as described in Kahane's paper:
+    resulting_expr *= -1 if (number_of_contractions - connected_components + 1) % 2 else 1
+    # power of two factor, as described in Kahane's paper:
+    resulting_expr *= 2**(number_of_contractions)
+
+    # If `first_dum_pos` is not zero, it means that there are trailing free gamma
+    # matrices in front of `expression`, so multiply by them:
+    for i in range(0, first_dum_pos):
+        resulting_expr = GammaMatrix4D(free_pos[i])*resulting_expr
+
+    return resulting_expr

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -1604,7 +1604,7 @@ class TensMul(TensExpr):
             ipos2, cpos2, ind2 = free_dict2[name]
             cpos2 += nc1
             if ind1._is_up == ind2._is_up:
-                raise ValueError('wrong index contruction %s' % ind1)
+                raise ValueError('wrong index construction %s' % ind1)
             if ind1._is_up:
                 new_dummy = (ipos1, ipos2, cpos1, cpos2)
             else:

--- a/sympy/tensor/tests/test_gamma_matrices.py
+++ b/sympy/tensor/tests/test_gamma_matrices.py
@@ -1,0 +1,147 @@
+from sympy.tensor.tensor import tensor_indices, TensorIndexType, tensorhead, TensorManager
+from sympy.tensor.gamma_matrices import GammaMatrix4D as G
+from sympy.tensor.gamma_matrices import kahane_simplify, Lorentz
+
+
+def test_kahane_algorithm():
+    mu, nu, rho, sigma = tensor_indices("mu, nu, rho, sigma", Lorentz)
+    a1, a2, a3, a4, a5, a6 = tensor_indices("a1:7", Lorentz)
+    mu11, mu12, mu21, mu31, mu32, mu41, mu51, mu52 = tensor_indices("mu11, mu12, mu21, mu31, mu32, mu41, mu51, mu52", Lorentz)
+    mu61, mu71, mu72 = tensor_indices("mu61, mu71, mu72", Lorentz)
+    m0, m1, m2, m3, m4, m5, m6 = tensor_indices("m0:7", Lorentz)
+
+    def g(xx, yy):
+        return (G(xx)*G(yy) + G(yy)*G(xx))/2
+
+    # kahane_simplify only works in four dimensions:
+    D = 4
+
+    t = (G(a1)*G(mu11)*G(a2)*G(mu21)*G(-a1)*G(mu31)*G(-a2))
+    assert kahane_simplify(t) == -4*G(mu11)*G(mu31)*G(mu21) - 4*G(mu31)*G(mu11)*G(mu21)
+
+    t = (G(mu)*G(-mu))
+    assert kahane_simplify(t) == 4
+
+    t = (G(mu)*G(nu)*G(-mu)*G(-nu))
+    assert kahane_simplify(t) == -8
+
+    t = (G(mu)*G(nu)*G(-nu)*G(-mu))
+    assert kahane_simplify(t) == 16
+
+    t = (G(mu)*G(nu)*G(-rho)*G(-nu)*G(-mu)*G(rho))
+    assert kahane_simplify(t) == 16
+
+    t = (G(mu)*G(nu)*G(rho)*G(-rho)*G(-nu)*G(-mu))
+    assert kahane_simplify(t) == 64
+
+    t = (G(a1)*G(mu11)*G(mu12)*\
+                          G(a2)*G(mu21)*\
+                          G(a3)*G(mu31)*G(mu32)*\
+                          G(a4)*G(mu41)*\
+                          G(-a2)*G(mu51)*G(mu52)*\
+                          G(-a1)*G(mu61)*\
+                          G(-a3)*G(mu71)*G(mu72)*\
+                          G(-a4))
+    assert kahane_simplify(t) == \
+        16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41)
+
+    t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
+    assert kahane_simplify(t) == -2*G(sigma)*G(rho)*G(nu)
+
+    t = (G(mu)*G(nu)*G(-mu))
+    assert kahane_simplify (t) == -2*G(nu)
+
+    t = (G(mu)*G(nu)*G(rho)*G(-mu))
+    assert kahane_simplify(t) == 2*G(nu)*G(rho) + 2*G(rho)*G(nu)
+
+    t = (G(a1)*G(a2)*G(a3)*G(a4)*G(-a3)*G(-a1)*G(-a2)*G(-a4))
+    assert kahane_simplify(t) == -32
+
+    t = (G(-mu)*G(-nu)*G(-rho)*G(-sigma)*G(nu)*G(mu)*G(sigma)*G(rho))
+    assert kahane_simplify(t) == 64
+
+    t = (G(-mu)*G(nu)*G(-rho)*G(sigma)*G(rho)*G(-nu)*G(mu)*G(-sigma))
+    assert kahane_simplify(t) == -32
+
+    t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(-a3)*G(-a2)*G(-a1)*G(-a5)*G(-a4))
+    assert kahane_simplify(t) == 256
+
+    t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(-a3)*G(-a1)*G(-a2)*G(-a4)*G(-a5))
+    assert kahane_simplify(t) == -128
+
+    t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(a6)*G(-a3)*G(-a2)*G(-a1)*G(-a6)*G(-a5)*G(-a4))
+    assert kahane_simplify(t) == -128
+
+    t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(a6)*G(-a2)*G(-a3)*G(-a1)*G(-a6)*G(-a4)*G(-a5))
+    assert kahane_simplify(t) == -128
+
+    # more complex expressions:
+
+    t = 2*G(m2)*G(m0)*G(m1)*G(-m0)*G(-m1)
+    st = kahane_simplify(t)
+    assert st == (D*(-2*D + 4))*G(m2)
+
+    t = G(m2)*G(m0)*G(m1)*G(-m0)*G(-m2)
+    st = kahane_simplify(t)
+    assert st == ((-D + 2)**2)*G(m1)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)
+    st = kahane_simplify(t)
+    assert st == (D - 4)*G(m0)*G(m2)*G(m3) + 4*G(m0)*g(m2, m3)
+
+    t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)*G(-m0)
+    st = kahane_simplify(t)
+    assert st == ((D - 4)**2)*G(m2)*G(m3) + (8*D - 16)*g(m2, m3)
+
+    t = G(m2)*G(m0)*G(m1)*G(-m2)*G(-m0)
+    st = kahane_simplify(t)
+    assert st == ((-D + 2)*(D - 4) + 4)*G(m1)
+
+    t = G(m3)*G(m1)*G(m0)*G(m2)*G(-m3)*G(-m0)*G(-m2)
+    st = kahane_simplify(t)
+    assert st == (-4*D + (-D + 2)**2*(D - 4) + 8)*G(m1)
+
+    t = 2*G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)
+    st = kahane_simplify(t)
+    assert st.equals((-2*D + 8)*G(m1)*G(m2)*G(m3) - 4*G(m3)*G(m2)*G(m1))
+
+    t = G(m5)*G(m0)*G(m1)*G(m4)*G(m2)*G(-m4)*G(m3)*G(-m0)
+    st = kahane_simplify(t)
+    assert st.equals(((-D + 2)*(-D + 4))*G(m5)*G(m1)*G(m2)*G(m3) + (2*D - 4)*G(m5)*G(m3)*G(m2)*G(m1))
+
+    t = -G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)*G(m4)
+    st = kahane_simplify(t)
+    assert st.equals((D - 4)*G(m1)*G(m2)*G(m3)*G(m4) + 2*G(m3)*G(m2)*G(m1)*G(m4))
+
+    t = G(-m5)*G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)*G(m5)
+    st = kahane_simplify(t)
+
+    result1 = ((-D + 4)**2 + 4)*G(m1)*G(m2)*G(m3)*G(m4) +\
+        (4*D - 16)*G(m3)*G(m2)*G(m1)*G(m4) + (4*D - 16)*G(m4)*G(m1)*G(m2)*G(m3)\
+        + 4*G(m2)*G(m1)*G(m4)*G(m3) + 4*G(m3)*G(m4)*G(m1)*G(m2) +\
+        4*G(m4)*G(m3)*G(m2)*G(m1)
+
+    # Kahane's algorithm yields this result, which is equivalent to `result1`
+    # in four dimensions, but is not automatically recognized as equal:
+    result2 = 8*G(m1)*G(m2)*G(m3)*G(m4) + 8*G(m4)*G(m3)*G(m2)*G(m1)
+
+    if D == 4:
+        assert st.equals(result1) or st.equals(result2)
+    else:
+        assert st.equals(result1)
+
+    # and a few very simple cases:
+
+    t = G(m0)
+    st = kahane_simplify(t)
+    assert st == t
+
+    t = -7*G(m0)
+    st = kahane_simplify(t)
+    assert st == t
+
+    t = 224*G(m0)*G(m1)*G(-m2)*G(m3)
+    st = kahane_simplify(t)
+    assert st == t
+
+test_kahane_algorithm()


### PR DESCRIPTION
This is an algorithm for reducing an expression with contracted gamma matrices in four dimensions.

Unfortunately this algorithm works in four dimensions only and is not generalizable, because it relies on the Chisholm identities.

In any case a 1989 paper claims that it is faster than other algorithms, and can handle very long and complex expressions in a very short time (I do not know if someone has devised a faster algorithm since then).

I have found a paper referring to another algorithm which operates on all dimensions: the Kennedy-Cvitanovich algorithm. Unfortunately on four dimensions it is slower than Kahane's algorithm, besides I have not yet carefully examines the details of Kennedy-Cvitanovich algorithm, so it will temporarily be ignored.

TODO list:
- [ ] decide whether the result has to contain the metric or its equivalent gamma matrix expressions.
