### PR TITLE
Fixed error with a slow test in mechanics.

### DIFF
--- a/sympy/physics/mechanics/tests/test_kane3.py
+++ b/sympy/physics/mechanics/tests/test_kane3.py
@@ -282,12 +282,7 @@ def test_bicycle():
 
     # Actual eigenvalue comparison
     for i in range(6):
-        # Pull out eigenvalues, put in a list
-        e_valsA = list(A.subs(v, i).eigenvals(rational=False).keys())
-        e_valsR = list(Res.subs(v, i).eigenvals(rational=False).keys())
-        # sort the list
-        e_valsA.sort()
-        e_valsR.sort()
-        # numerically compare eigenvalues
-        for i in range(4):
-            assert abs(e_valsA[i] - e_valsR[i]) < 1e-12
+        eps = 1.e-12
+        error = Res.subs(v, i) - A.subs(v, i)
+        to_test = error.applyfunc(lambda x: x < eps)
+        assert min(to_test)


### PR DESCRIPTION
The test, test_bicycle(), used to sort eigenvalues and compare the difference
(within a tolerance) to test for equality. For some reason, complex eigenvalues
stopped sorting. Now, the two matrices are directly compared, with the
difference in each element being compared (within a tolerance) and the minimum
value of the output matrix (which will be only booleans) needs to be True for
the test to pass.
