### PR TITLE
Make degree(0) == -oo in the polys

### DIFF
--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -28,7 +28,7 @@ from __future__ import print_function, division
 from sympy import real_roots
 from sympy.abc import z
 from sympy.core.function import Lambda
-from sympy.core.numbers import ilcm
+from sympy.core.numbers import ilcm, oo
 from sympy.core.mul import Mul
 from sympy.core.power import Pow
 from sympy.core.relational import Eq, Ne
@@ -754,7 +754,7 @@ def as_poly_1t(p, t, z):
     # (...)*exp(-x).
     pa, pd = frac_in(p, t, cancel=True)
     if not pd.is_monomial:
-        # XXX: Is there a better Poly exception that we could raise here
+        # XXX: Is there a better Poly exception that we could raise here?
         # Either way, if you see this (from the Risch Algorithm) it indicates
         # a bug.
         raise PolynomialError("%s is not an element of K[%s, 1/%s]." % (p, t, t))
@@ -767,10 +767,10 @@ def as_poly_1t(p, t, z):
     except DomainError as e:
         # Issue 1851
         raise NotImplementedError(e)
-    # Compute the negative degree parts.  Also requires polys11.
+    # Compute the negative degree parts.
     one_t_part = Poly.from_list(reversed(one_t_part.rep.rep), *one_t_part.gens,
         domain=one_t_part.domain)
-    if r > 0:
+    if 0 < r < oo:
         one_t_part *= Poly(t**r, t)
 
     one_t_part = one_t_part.replace(t, z)  # z will be 1/t
@@ -1352,6 +1352,9 @@ def integrate_hyperexponential_polynomial(p, DE, z):
     qa = Poly(0, DE.t)
     qd = Poly(1, DE.t)
     b = True
+
+    if p.is_zero:
+        return(qa, qd, b)
 
     with DecrementLevel(DE):
         for i in xrange(-p.degree(z), p.degree(t1) + 1):

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -42,6 +42,7 @@ def test_as_poly_1t():
         Poly(2/(exp(2) + 1)*z, t, z), Poly(2/(exp(2) + 1)*z, z, t)]
     assert as_poly_1t(2/((exp(2) + 1)*t) + t, t, z) in [
         Poly(t + 2/(exp(2) + 1)*z, t, z), Poly(t + 2/(exp(2) + 1)*z, z, t)]
+    assert as_poly_1t(S(0), t, z) == Poly(0, t, z)
 
 
 def test_derivation():
@@ -319,6 +320,10 @@ def test_integrate_hyperexponential_polynomial():
     assert integrate_hyperexponential_polynomial(p, DE, z) == (
         Poly((x - t0)*t1**2 + (-2*t0 + 2*x)*t1, t1), Poly(-2*x*t0 + x**2 +
         t0**2, t1), True)
+
+    DE = DifferentialExtension(extension={'D':[Poly(1, x), Poly(t0, t0)]})
+    assert integrate_hyperexponential_polynomial(Poly(0, t0), DE, z) == (
+        Poly(0, t0), Poly(1, t0), True)
 
 
 def test_integrate_hyperexponential_returns_piecewise():

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -850,7 +850,7 @@ def dup_sqr(f, K):
     x**4 + 2*x**2 + 1
 
     """
-    df, h = dup_degree(f), []
+    df, h = len(f) - 1, []
 
     for i in xrange(0, 2*df + 1):
         c = K.zero

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import igcd
+from sympy import oo
 
 from sympy.polys.monomials import monomial_min, monomial_div
 from sympy.polys.orderings import monomial_key
@@ -137,6 +138,8 @@ def dup_degree(f):
     """
     Return the leading degree of ``f`` in ``K[x]``.
 
+    Note that the degree of 0 is negative infinity (the SymPy object -oo).
+
     Examples
     ========
 
@@ -149,12 +152,16 @@ def dup_degree(f):
     3
 
     """
+    if not f:
+        return -oo
     return len(f) - 1
 
 
 def dmp_degree(f, u):
     """
     Return the leading degree of ``f`` in ``x_0`` in ``K[X]``.
+
+    Note that the degree of 0 is negative infinity (the SymPy object -oo).
 
     Examples
     ========
@@ -163,7 +170,7 @@ def dmp_degree(f, u):
     >>> from sympy.polys.densebasic import dmp_degree
 
     >>> dmp_degree([[[]]], 2)
-    -1
+    -oo
 
     >>> f = ZZ.map([[2], [1, 2, 3]])
 
@@ -172,7 +179,7 @@ def dmp_degree(f, u):
 
     """
     if dmp_zero_p(f, u):
-        return -1
+        return -oo
     else:
         return len(f) - 1
 
@@ -240,7 +247,7 @@ def dmp_degree_list(f, u):
     (1, 2)
 
     """
-    degs = [-1]*(u + 1)
+    degs = [-oo]*(u + 1)
     _rec_degree_list(f, u, 0, degs)
     return tuple(degs)
 
@@ -1027,9 +1034,9 @@ def dup_to_dict(f, K=None, zero=False):
     if not f and zero:
         return {(0,): K.zero}
 
-    n, result = dup_degree(f), {}
+    n, result = len(f) - 1, {}
 
-    for k in xrange(0, n + 1):
+    for k in xrange(0, n):
         if f[n - k]:
             result[(k,)] = f[n - k]
 
@@ -1052,9 +1059,9 @@ def dup_to_raw_dict(f, K=None, zero=False):
     if not f and zero:
         return {0: K.zero}
 
-    n, result = dup_degree(f), {}
+    n, result = len(f) - 1, {}
 
-    for k in xrange(0, n + 1):
+    for k in xrange(0, n):
         if f[n - k]:
             result[k] = f[n - k]
 
@@ -1083,6 +1090,9 @@ def dmp_to_dict(f, u, K=None, zero=False):
         return {(0,)*(u + 1): K.zero}
 
     n, v, result = dmp_degree(f, u), u - 1, {}
+
+    if n == -oo:
+        n = -1
 
     for k in xrange(0, n + 1):
         h = dmp_to_dict(f[n - k], v)

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -687,7 +687,10 @@ def dmp_ground_nth(f, N, u, K):
         elif n >= len(f):
             return K.zero
         else:
-            f, v = f[dmp_degree(f, v) - n], v - 1
+            d = dmp_degree(f, v)
+            if d == -oo:
+                d = -1
+            f, v = f[d - n], v - 1
 
     return f
 

--- a/sympy/polys/densebasic.py
+++ b/sympy/polys/densebasic.py
@@ -1036,7 +1036,7 @@ def dup_to_dict(f, K=None, zero=False):
 
     n, result = len(f) - 1, {}
 
-    for k in xrange(0, n):
+    for k in xrange(0, n + 1):
         if f[n - k]:
             result[(k,)] = f[n - k]
 
@@ -1061,7 +1061,7 @@ def dup_to_raw_dict(f, K=None, zero=False):
 
     n, result = len(f) - 1, {}
 
-    for k in xrange(0, n):
+    for k in xrange(0, n + 1):
         if f[n - k]:
             result[k] = f[n - k]
 

--- a/sympy/polys/densetools.py
+++ b/sympy/polys/densetools.py
@@ -842,7 +842,7 @@ def dup_mirror(f, K):
     -x**3 + 2*x**2 + 4*x + 2
 
     """
-    f, n, a = list(f), dup_degree(f), -K.one
+    f, n, a = list(f), len(f) - 1, -K.one
 
     for i in xrange(n - 1, -1, -1):
         f[i], a = a*f[i], -a
@@ -864,7 +864,7 @@ def dup_scale(f, a, K):
     4*x**2 - 4*x + 1
 
     """
-    f, n, b = list(f), dup_degree(f), a
+    f, n, b = list(f), len(f) - 1, a
 
     for i in xrange(n - 1, -1, -1):
         f[i], b = b*f[i], b*a
@@ -886,7 +886,7 @@ def dup_shift(f, a, K):
     x**2 + 2*x + 1
 
     """
-    f, n = list(f), dup_degree(f)
+    f, n = list(f), len(f) - 1
 
     for i in xrange(n, 0, -1):
         for j in xrange(0, i):
@@ -912,7 +912,7 @@ def dup_transform(f, p, q, K):
     if not f:
         return []
 
-    n = dup_degree(f)
+    n = len(f) - 1
     h, Q = [f[0]], [[K.one]]
 
     for i in xrange(0, n):
@@ -986,7 +986,7 @@ def dmp_compose(f, g, u, K):
 
 def _dup_right_decompose(f, s, K):
     """Helper function for :func:`_dup_decompose`."""
-    n = dup_degree(f)
+    n = len(f) - 1
     lc = dup_LC(f, K)
 
     f = dup_to_raw_dict(f)
@@ -1030,7 +1030,7 @@ def _dup_left_decompose(f, h, K):
 
 def _dup_decompose(f, K):
     """Helper function for :func:`dup_decompose`."""
-    df = dup_degree(f)
+    df = len(f) - 1
 
     for s in xrange(2, df):
         if df % s != 0:

--- a/sympy/polys/polyclasses.py
+++ b/sympy/polys/polyclasses.py
@@ -7,6 +7,8 @@ from sympy.core.sympify import CantSympify
 from sympy.polys.polyutils import PicklableWithSlots
 from sympy.polys.polyerrors import CoercionFailed, NotReversible
 
+from sympy import oo
+
 class GenericPoly(PicklableWithSlots):
     """Base class for low-level polynomial representations. """
 
@@ -528,7 +530,7 @@ class DMP(PicklableWithSlots, CantSympify):
     def homogeneous_order(f):
         """Returns the homogeneous order of ``f``. """
         if f.is_zero:
-            return -1
+            return -oo
 
         monoms = f.monoms()
         tdeg = sum(monoms[0])

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -1687,6 +1687,8 @@ class Poly(Expr):
         """
         Returns degree of ``f`` in ``x_j``.
 
+        The degree of 0 is negative infinity.
+
         Examples
         ========
 
@@ -1697,6 +1699,8 @@ class Poly(Expr):
         2
         >>> Poly(x**2 + y*x + y, x, y).degree(y)
         1
+        >>> Poly(0, x).degree()
+        -oo
 
         """
         j = f._gen_to_level(gen)
@@ -4051,6 +4055,8 @@ def degree(f, *gens, **args):
     """
     Return the degree of ``f`` in the given variable.
 
+    The degree of 0 is negative infinity.
+
     Examples
     ========
 
@@ -4061,6 +4067,8 @@ def degree(f, *gens, **args):
     2
     >>> degree(x**2 + y*x + 1, gen=y)
     1
+    >>> degree(0, x)
+    -oo
 
     """
     options.allowed_flags(args, ['gen', 'polys'])
@@ -4070,7 +4078,7 @@ def degree(f, *gens, **args):
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
 
-    return Integer(F.degree(opt.gen))
+    return sympify(F.degree(opt.gen))
 
 
 @public

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -7,7 +7,7 @@ from types import GeneratorType
 
 from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol, symbols as _symbols
-from sympy.core.numbers import igcd
+from sympy.core.numbers import igcd, oo
 from sympy.core.sympify import CantSympify, sympify
 from sympy.core.compatibility import is_sequence, reduce, string_types, xrange
 from sympy.ntheory.multinomial import multinomial_coefficients
@@ -1527,34 +1527,54 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         return p1
 
     def degree(f, x=None):
-        """The leading degree in ``x`` or the main variable. """
+        """
+        The leading degree in ``x`` or the main variable.
+
+        Note that the degree of 0 is negative infinity (the SymPy object -oo).
+
+        """
         i = f.ring.index(x)
 
         if not f:
-            return -1
+            return -oo
         else:
             return max([ monom[i] for monom in f.itermonoms() ])
 
     def degrees(f):
-        """A tuple containing leading degrees in all variables. """
+        """
+        A tuple containing leading degrees in all variables.
+
+        Note that the degree of 0 is negative infinity (the SymPy object -oo)
+
+        """
         if not f:
-            return (-1,)*f.ring.ngens
+            return (-oo,)*f.ring.ngens
         else:
             return tuple(map(max, list(zip(*f.itermonoms()))))
 
     def tail_degree(f, x=None):
-        """The tail degree in ``x`` or the main variable. """
+        """
+        The tail degree in ``x`` or the main variable.
+
+        Note that the degree of 0 is negative infinity (the SymPy object -oo)
+
+        """
         i = f.ring.index(x)
 
         if not f:
-            return -1
+            return -oo
         else:
             return min([ monom[i] for monom in f.itermonoms() ])
 
     def tail_degrees(f):
-        """A tuple containing tail degrees in all variables. """
+        """
+        A tuple containing tail degrees in all variables.
+
+        Note that the degree of 0 is negative infinity (the SymPy object -oo)
+
+        """
         if not f:
-            return (-1,)*f.ring.ngens
+            return (-oo,)*f.ring.ngens
         else:
             return tuple(map(min, list(zip(*f.itermonoms()))))
 

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -44,6 +44,8 @@ from sympy.polys.rings import ring
 from sympy.core.singleton import S
 from sympy.utilities.pytest import raises
 
+from sympy import oo
+
 f_0, f_1, f_2, f_3, f_4, f_5, f_6 = [ f.to_dense() for f in f_polys() ]
 
 def test_dup_LC():
@@ -94,24 +96,24 @@ def test_dmp_true_LT():
 
 
 def test_dup_degree():
-    assert dup_degree([]) == -1
+    assert dup_degree([]) == -oo
     assert dup_degree([1]) == 0
     assert dup_degree([1, 0]) == 1
     assert dup_degree([1, 0, 0, 0, 1]) == 4
 
 
 def test_dmp_degree():
-    assert dmp_degree([[]], 1) == -1
-    assert dmp_degree([[[]]], 2) == -1
+    assert dmp_degree([[]], 1) == -oo
+    assert dmp_degree([[[]]], 2) == -oo
 
     assert dmp_degree([[1]], 1) == 0
     assert dmp_degree([[2], [1]], 1) == 1
 
 
 def test_dmp_degree_in():
-    assert dmp_degree_in([[[]]], 0, 2) == -1
-    assert dmp_degree_in([[[]]], 1, 2) == -1
-    assert dmp_degree_in([[[]]], 2, 2) == -1
+    assert dmp_degree_in([[[]]], 0, 2) == -oo
+    assert dmp_degree_in([[[]]], 1, 2) == -oo
+    assert dmp_degree_in([[[]]], 2, 2) == -oo
 
     assert dmp_degree_in([[[1]]], 0, 2) == 0
     assert dmp_degree_in([[[1]]], 1, 2) == 0
@@ -130,7 +132,7 @@ def test_dmp_degree_in():
 
 
 def test_dmp_degree_list():
-    assert dmp_degree_list([[[[ ]]]], 3) == (-1, -1, -1, -1)
+    assert dmp_degree_list([[[[ ]]]], 3) == (-oo, -oo, -oo, -oo)
     assert dmp_degree_list([[[[1]]]], 3) == ( 0, 0, 0, 0)
 
     assert dmp_degree_list(f_0, 2) == (2, 2, 2)

--- a/sympy/polys/tests/test_densebasic.py
+++ b/sympy/polys/tests/test_densebasic.py
@@ -270,6 +270,7 @@ def test_dmp_nth():
 
 
 def test_dmp_ground_nth():
+    assert dmp_ground_nth([[]], (0, 0), 1, ZZ) == 0
     assert dmp_ground_nth([[1], [2], [3]], (0, 0), 1, ZZ) == 3
     assert dmp_ground_nth([[1], [2], [3]], (1, 0), 1, ZZ) == 2
     assert dmp_ground_nth([[1], [2], [3]], (2, 0), 1, ZZ) == 1

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1122,19 +1122,19 @@ def test_Poly__gen_to_level():
 
 
 def test_Poly_degree():
-    assert Poly(0, x).degree() == -1
+    assert Poly(0, x).degree() == -oo
     assert Poly(1, x).degree() == 0
     assert Poly(x, x).degree() == 1
 
-    assert Poly(0, x).degree(gen=0) == -1
+    assert Poly(0, x).degree(gen=0) == -oo
     assert Poly(1, x).degree(gen=0) == 0
     assert Poly(x, x).degree(gen=0) == 1
 
-    assert Poly(0, x).degree(gen=x) == -1
+    assert Poly(0, x).degree(gen=x) == -oo
     assert Poly(1, x).degree(gen=x) == 0
     assert Poly(x, x).degree(gen=x) == 1
 
-    assert Poly(0, x).degree(gen='x') == -1
+    assert Poly(0, x).degree(gen='x') == -oo
     assert Poly(1, x).degree(gen='x') == 0
     assert Poly(x, x).degree(gen='x') == 1
 
@@ -1167,9 +1167,9 @@ def test_Poly_degree():
 
 
 def test_Poly_degree_list():
-    assert Poly(0, x).degree_list() == (-1,)
-    assert Poly(0, x, y).degree_list() == (-1, -1)
-    assert Poly(0, x, y, z).degree_list() == (-1, -1, -1)
+    assert Poly(0, x).degree_list() == (-oo,)
+    assert Poly(0, x, y).degree_list() == (-oo, -oo)
+    assert Poly(0, x, y, z).degree_list() == (-oo, -oo, -oo)
 
     assert Poly(1, x).degree_list() == (0,)
     assert Poly(1, x, y).degree_list() == (0, 0)
@@ -1199,7 +1199,7 @@ def test_Poly_homogenize():
 
 
 def test_Poly_homogeneous_order():
-    assert Poly(0, x, y).homogeneous_order() == -1
+    assert Poly(0, x, y).homogeneous_order() == -oo
     assert Poly(1, x, y).homogeneous_order() == 0
     assert Poly(x, x, y).homogeneous_order() == 1
     assert Poly(x*y, x, y).homogeneous_order() == 2

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -12,7 +12,7 @@ from sympy.polys.polyerrors import GeneratorsError, GeneratorsNeeded, \
 from sympy.utilities.pytest import raises
 from sympy.core import Symbol, symbols
 from sympy.core.compatibility import reduce
-from sympy import sqrt, pi
+from sympy import sqrt, pi, oo
 
 def test_PolyRing___init__():
     x, y, z, t = map(Symbol, "xyzt")
@@ -253,28 +253,28 @@ def test_PolyElement_from_expr():
 def test_PolyElement_degree():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).degree() == -1
+    assert R(0).degree() == -oo
     assert R(1).degree() == 0
     assert (x + 1).degree() == 1
     assert (2*y**3 + z).degree() == 0
     assert (x*y**3 + z).degree() == 1
     assert (x**5*y**3 + z).degree() == 5
 
-    assert R(0).degree(x) == -1
+    assert R(0).degree(x) == -oo
     assert R(1).degree(x) == 0
     assert (x + 1).degree(x) == 1
     assert (2*y**3 + z).degree(x) == 0
     assert (x*y**3 + z).degree(x) == 1
     assert (7*x**5*y**3 + z).degree(x) == 5
 
-    assert R(0).degree(y) == -1
+    assert R(0).degree(y) == -oo
     assert R(1).degree(y) == 0
     assert (x + 1).degree(y) == 0
     assert (2*y**3 + z).degree(y) == 3
     assert (x*y**3 + z).degree(y) == 3
     assert (7*x**5*y**3 + z).degree(y) == 3
 
-    assert R(0).degree(z) == -1
+    assert R(0).degree(z) == -oo
     assert R(1).degree(z) == 0
     assert (x + 1).degree(z) == 0
     assert (2*y**3 + z).degree(z) == 1
@@ -284,28 +284,28 @@ def test_PolyElement_degree():
 def test_PolyElement_tail_degree():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).tail_degree() == -1
+    assert R(0).tail_degree() == -oo
     assert R(1).tail_degree() == 0
     assert (x + 1).tail_degree() == 0
     assert (2*y**3 + x**3*z).tail_degree() == 0
     assert (x*y**3 + x**3*z).tail_degree() == 1
     assert (x**5*y**3 + x**3*z).tail_degree() == 3
 
-    assert R(0).tail_degree(x) == -1
+    assert R(0).tail_degree(x) == -oo
     assert R(1).tail_degree(x) == 0
     assert (x + 1).tail_degree(x) == 0
     assert (2*y**3 + x**3*z).tail_degree(x) == 0
     assert (x*y**3 + x**3*z).tail_degree(x) == 1
     assert (7*x**5*y**3 + x**3*z).tail_degree(x) == 3
 
-    assert R(0).tail_degree(y) == -1
+    assert R(0).tail_degree(y) == -oo
     assert R(1).tail_degree(y) == 0
     assert (x + 1).tail_degree(y) == 0
     assert (2*y**3 + x**3*z).tail_degree(y) == 0
     assert (x*y**3 + x**3*z).tail_degree(y) == 0
     assert (7*x**5*y**3 + x**3*z).tail_degree(y) == 0
 
-    assert R(0).tail_degree(z) == -1
+    assert R(0).tail_degree(z) == -oo
     assert R(1).tail_degree(z) == 0
     assert (x + 1).tail_degree(z) == 0
     assert (2*y**3 + x**3*z).tail_degree(z) == 0
@@ -315,14 +315,14 @@ def test_PolyElement_tail_degree():
 def test_PolyElement_degrees():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).degrees() == (-1, -1, -1)
+    assert R(0).degrees() == (-oo, -oo, -oo)
     assert R(1).degrees() == (0, 0, 0)
     assert (x**2*y + x**3*z**2).degrees() == (3, 1, 2)
 
 def test_PolyElement_tail_degrees():
     R, x,y,z = ring("x,y,z", ZZ)
 
-    assert R(0).tail_degrees() == (-1, -1, -1)
+    assert R(0).tail_degrees() == (-oo, -oo, -oo)
     assert R(1).tail_degrees() == (0, 0, 0)
     assert (x**2*y + x**3*z**2).tail_degrees() == (2, 0, 0)
 


### PR DESCRIPTION
Previously, degree(0) was -1. This makes sense for the dense representation,
because then one can use degree in place of len(f) - 1, but outside of that,
it makes little sense. In particular, the very important formula regarding
degree, deg(f*g) == deg(f) + deg(g), does not hold unless deg(0) == -oo.
Therefore, any code that does arithmetic on a degree and then makes a
comparison against it (like "if degree(f) - 1 > 0"), such as some code in the
Risch algorithm) was previously for 0 but generally correct now.

Fixing this just means being more careful about when you mean degree(f) and
when you mean len(f) - 1 in the dense representation algorithms.  Another
argument for this is that the change in the sparse code required no additional
changes anywhere; apparently the degree does not correspond to any natural
quantity in the sparse representation.

@mattpap

@cheatiiit, you might try merging this with your branch and see if it fixes
anything. I know that a few of your bugs were caused by the fact that
degree(0) == -1 instead of -oo.
