### PR TITLE
'Fix' issue 3998.

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -698,6 +698,10 @@ def eval_sum_hyper(f, i_a_b):
 
     i, a, b = i_a_b
 
+    if (b - a).is_Integer:
+        # We are never going to do better than doing the sum in the obvious way
+        return None
+
     old_sum = Sum(f, (i, a, b))
 
     if b != S.Infinity:

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -723,3 +723,6 @@ def test_reverse_order():
         Sum(x*y, (x, b + 1, a - 1), (y, 6, 1))
     assert reverse_order(Sum(x*y, (x, a, b), (y, 2, 5)), y, x) == \
         Sum(x*y, (x, b + 1, a - 1), (y, 6, 1))
+
+def test_issue_3998():
+    assert sum(x**n/n for n in range(1, 401)) == summation(x**n/n, (n, 1, 400))


### PR DESCRIPTION
Specifically, certain explicit summations would hang for large summation
intervals, because we tried to use hypergeometric sum evaluation tricks for
them.

Disable these tricks for explicit sums, and add a test.
