### PR TITLE
Document the logx parameter in Expr.nseries()

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2655,11 +2655,11 @@ class Expr(Basic, EvalfMixin):
         In the following example, the expansion works, but only with logx you
         get a useful result:
 
-        >>> e = x**(1 - log(y)/(log(2) + log(y)))
+        >>> e = x**y
         >>> e.nseries(x, 0, 2)
         O(log(x)**2)
         >>> e.nseries(x, 0, 2, logx=l)
-        exp(l - l*log(y)/(log(y) + log(2)))
+        exp(l*y)
 
         """
         if x and not x in self.free_symbols:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2613,8 +2613,9 @@ class Expr(Basic, EvalfMixin):
         then builds up the final series just by "cross-multiplying" everything
         out.
 
-        The optional logx parameter will be substituted for all (new)
-        occurences of log(x).
+        The optional ``logx`` parameter can be used to replace any log(x) in the
+        returned series with a symbolic value to avoid evaluating log(x) at 0. A
+        symbol to use in place of log(x) should be provided.
 
         Advantage -- it's fast, because we don't have to determine how many
         terms we need to calculate in advance.
@@ -2632,16 +2633,16 @@ class Expr(Basic, EvalfMixin):
         Examples
         ========
 
-        >>> from sympy import sin, log
-        >>> from sympy.abc import x, y, l
+        >>> from sympy import sin, log, Symbol
+        >>> from sympy.abc import x, y
         >>> sin(x).nseries(x, 0, 6)
         x - x**3/6 + x**5/120 + O(x**6)
         >>> log(x+1).nseries(x, 0, 5)
         x - x**2/2 + x**3/3 - x**4/4 + O(x**5)
 
-        Handling of the logx parameter --- in the following example the
-        expansion fails unless you use logx, but you could in principle
-        substitute for log(x) before hand:
+        Handling of the ``logx`` parameter --- in the following example the
+        expansion fails since ``sin`` does not have an asymptotic expansion
+        at -oo (the limit of log(x) as x approaches 0):
 
         >>> e = sin(log(x))
         >>> e.nseries(x, 0, 6)
@@ -2649,17 +2650,18 @@ class Expr(Basic, EvalfMixin):
         ...
         PoleError: ...
         ...
-        >>> e.nseries(x, 0, 6, logx=l)
-        sin(l)
+        >>> logx = Symbol('logx')
+        >>> e.nseries(x, 0, 6, logx=logx)
+        sin(logx)
 
-        In the following example, the expansion works, but only with logx you
-        get a useful result:
+        In the following example, the expansion works but gives only an Order term
+        unless the ``logx`` parameter is used:
 
         >>> e = x**y
         >>> e.nseries(x, 0, 2)
         O(log(x)**2)
-        >>> e.nseries(x, 0, 2, logx=l)
-        exp(l*y)
+        >>> e.nseries(x, 0, 2, logx=logx)
+        exp(logx*y)
 
         """
         if x and not x in self.free_symbols:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2613,6 +2613,9 @@ class Expr(Basic, EvalfMixin):
         then builds up the final series just by "cross-multiplying" everything
         out.
 
+        The optional logx parameter will be substituted for all (new)
+        occurences of log(x).
+
         Advantage -- it's fast, because we don't have to determine how many
         terms we need to calculate in advance.
 
@@ -2625,6 +2628,39 @@ class Expr(Basic, EvalfMixin):
         number of terms.
 
         See also lseries().
+
+        Examples
+        ========
+
+        >>> from sympy import sin, log
+        >>> from sympy.abc import x, y, l
+        >>> sin(x).nseries(x, 0, 6)
+        x - x**3/6 + x**5/120 + O(x**6)
+        >>> log(x+1).nseries(x, 0, 5)
+        x - x**2/2 + x**3/3 - x**4/4 + O(x**5)
+
+        Handling of the logx parameter --- in the following example the
+        expansion fails unless you use logx, but you could in principle
+        substitute for log(x) before hand:
+
+        >>> e = sin(log(x))
+        >>> e.nseries(x, 0, 6)
+        Traceback (most recent call last):
+        ...
+        PoleError: ...
+        ...
+        >>> e.nseries(x, 0, 6, logx=l)
+        sin(l)
+
+        In the following example, the expansion works, but only with logx you
+        get a useful result:
+
+        >>> e = x**(1 - log(y)/(log(2) + log(y)))
+        >>> e.nseries(x, 0, 2)
+        O(log(x)**2)
+        >>> e.nseries(x, 0, 2, logx=l)
+        exp(l - l*log(y)/(log(y) + log(2)))
+
         """
         if x and not x in self.free_symbols:
             return self


### PR DESCRIPTION
Add doctests. This parameter was introduced in
9c46974da12df56818020e29f76313fc0903ecc6 but it was never documented.

Question: I still don't understand what logx is doing. For majority of cases, you can simply substitute for log(x) before you even start expanding. I put there one example that I figured out, where you cannot substitute before you start expanding. Can somebody provide even better example and more importantly --- explain what exactly the logx is doing?

/cc @ness01
