### PR TITLE
Issue 4009: Fix predicate detection in simplify_logic.

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -866,8 +866,7 @@ def SOPform(variables, minterms, dontcares=None):
     """
     from sympy.core.symbol import Symbol
 
-    variables = [Symbol(v) if not isinstance(v, Symbol) else v
-                 for v in variables]
+    variables = [sympify(v) for v in variables]
     if minterms == []:
         return False
 
@@ -919,8 +918,7 @@ def POSform(variables, minterms, dontcares=None):
     """
     from sympy.core.symbol import Symbol
 
-    variables = [Symbol(v) if not isinstance(v, Symbol) else v
-                 for v in variables]
+    variables = [sympify(v) for v in variables]
     if minterms == []:
         return False
 
@@ -942,6 +940,18 @@ def POSform(variables, minterms, dontcares=None):
         new = _simplified_pairs(old)
     essential = _rem_redundancy(new, maxterms)
     return And(*[_convert_to_varsPOS(x, variables) for x in essential])
+
+
+def _find_predicates(expr):
+    """Helper to find logical predicates in BooleanFunctions.
+
+    A logical predicate is defined here as anything within a BooleanFunction
+    that is not a BooleanFunction itself.
+
+    """
+    if not isinstance(expr, BooleanFunction):
+        return set([expr])
+    return set.union(*(_find_predicates(i) for i in expr.args))
 
 
 def simplify_logic(expr):
@@ -970,12 +980,14 @@ def simplify_logic(expr):
     expr = sympify(expr)
     if not isinstance(expr, BooleanFunction):
         return expr
-    variables = list(expr.free_symbols)
+    variables = _find_predicates(expr)
     truthtable = []
     for t in product([0, 1], repeat=len(variables)):
         t = list(t)
         if expr.subs(list(zip(variables, t))) == True:
             truthtable.append(t)
+    from sympy.simplify.simplify import simplify
+    variables = [simplify(v) for v in variables]
     if (len(truthtable) >= (2 ** (len(variables) - 1))):
         return SOPform(variables, truthtable)
     else:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -986,7 +986,7 @@ def simplify_logic(expr, simplify=True):
     truthtable = []
     for t in product([0, 1], repeat=len(variables)):
         t = list(t)
-        if expr.subs(list(zip(variables, t))) == True:
+        if expr.xreplace(dict(zip(variables, t))) == True:
             truthtable.append(t)
     if simplify:
         from sympy.simplify.simplify import simplify

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -954,12 +954,14 @@ def _find_predicates(expr):
     return set.union(*(_find_predicates(i) for i in expr.args))
 
 
-def simplify_logic(expr):
+def simplify_logic(expr, simplify=True):
     """
     This function simplifies a boolean function to its
     simplified version in SOP or POS form. The return type is an
     Or or And object in SymPy. The input can be a string or a boolean
-    expression.
+    expression.  The optional parameter simplify indicates whether to
+    recursively simplify any non-boolean-functions contained within the
+    input.
 
     Examples
     ========
@@ -986,8 +988,9 @@ def simplify_logic(expr):
         t = list(t)
         if expr.subs(list(zip(variables, t))) == True:
             truthtable.append(t)
-    from sympy.simplify.simplify import simplify
-    variables = [simplify(v) for v in variables]
+    if simplify:
+        from sympy.simplify.simplify import simplify
+        variables = [simplify(v) for v in variables]
     if (len(truthtable) >= (2 ** (len(variables) - 1))):
         return SOPform(variables, truthtable)
     else:

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,4 +1,4 @@
-from sympy import symbols, sympify, Dummy, simplify
+from sympy import symbols, sympify, Dummy, simplify, Equality
 from sympy.logic.boolalg import (
     And, Boolean, Equivalent, ITE, Implies, Nand, Nor, Not, Or, POSform,
     SOPform, Xor, conjuncts, disjuncts, distribute_or_over_and,
@@ -172,6 +172,11 @@ def test_simplification():
     assert simplify_logic(Implies(A, B)) == Or(Not(A), B)
     assert simplify_logic(Equivalent(A, B)) == \
            Or(And(A, B), And(Not(A), Not(B)))
+    assert simplify(And(Equality(A, 2), C)) == And(Equality(A, 2), C)
+    assert simplify(And(Equality(A, B), C)) == And(Equality(A, B), C)
+    assert simplify(Or(And(Equality(A, 3), B), And(Equality(A, 3), C))) == (
+           And(Equality(A, 3), Or(B, C)))
+    assert simplify(And(A, x**2-x)) == And(A, x*(x-1))
 
     # check input
     ans = SOPform('xy', [[1, 0]])

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -173,6 +173,7 @@ def test_simplification():
     assert simplify_logic(Equivalent(A, B)) == \
            Or(And(A, B), And(Not(A), Not(B)))
     assert simplify_logic(And(Equality(A, 2), C)) == And(Equality(A, 2), C)
+    assert simplify_logic(And(Equality(A, 2), A)) == And(Equality(A, 2), A)
     assert simplify_logic(And(Equality(A, B), C)) == And(Equality(A, B), C)
     assert simplify_logic(Or(And(Equality(A, 3), B), And(Equality(A, 3), C))) \
            == And(Equality(A, 3), Or(B, C))

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -172,11 +172,12 @@ def test_simplification():
     assert simplify_logic(Implies(A, B)) == Or(Not(A), B)
     assert simplify_logic(Equivalent(A, B)) == \
            Or(And(A, B), And(Not(A), Not(B)))
-    assert simplify(And(Equality(A, 2), C)) == And(Equality(A, 2), C)
-    assert simplify(And(Equality(A, B), C)) == And(Equality(A, B), C)
-    assert simplify(Or(And(Equality(A, 3), B), And(Equality(A, 3), C))) == (
-           And(Equality(A, 3), Or(B, C)))
-    assert simplify(And(A, x**2-x)) == And(A, x*(x-1))
+    assert simplify_logic(And(Equality(A, 2), C)) == And(Equality(A, 2), C)
+    assert simplify_logic(And(Equality(A, B), C)) == And(Equality(A, B), C)
+    assert simplify_logic(Or(And(Equality(A, 3), B), And(Equality(A, 3), C))) \
+           == And(Equality(A, 3), Or(B, C))
+    assert simplify_logic(And(A, x**2-x)) == And(A, x*(x-1))
+    assert simplify_logic(And(A, x**2-x), simplify=False) == And(A, x**2-x)
 
     # check input
     ans = SOPform('xy', [[1, 0]])


### PR DESCRIPTION
Previously, simplify_logic would assume all free symbols were predicates, and
would construct a truth table based on results of substituting True/False for
each.  This would sometimes result in incorrect simplifications when Boolean
structures were made containing other expressions.  Now, it takes anything
that is not a BooleanFunction as a predicate, then simplifies the predicates
before reassembling.
