### PR TITLE
Fix issue 4016: implicit multiplication fails for constants

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -207,7 +207,7 @@ def _implicit_multiplication(tokens, local_dict, global_dict):
     for tok, nextTok in zip(tokens, tokens[1:]):
         result.append(tok)
         if (isinstance(tok, AppliedFunction) and
-            isinstance(nextTok, AppliedFunction)):
+              isinstance(nextTok, AppliedFunction)):
             result.append((OP, '*'))
         elif (isinstance(tok, AppliedFunction) and
               nextTok[0] == OP and nextTok[1] == '('):
@@ -260,8 +260,8 @@ def _implicit_application(tokens, local_dict, global_dict):
     for tok, nextTok in zip(tokens, tokens[1:]):
         result.append(tok)
         if (tok[0] == NAME and
-            nextTok[0] != OP and
-            nextTok[0] != ENDMARKER):
+              nextTok[0] != OP and
+              nextTok[0] != ENDMARKER):
             if _token_callable(tok, local_dict, global_dict, nextTok):
                 result.append((OP, '('))
                 appendParen += 1

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -38,16 +38,14 @@ def _token_splittable(token):
 def _token_callable(token, local_dict, global_dict, nextToken=None):
     """
     Predicate for whether a token name represents a callable function.
+
+    Essentially wraps ``callable``, but looks up the token name in the
+    locals and globals.
     """
     func = local_dict.get(token[1])
     if not func:
         func = global_dict.get(token[1])
-    is_Function = getattr(func, 'is_Function', False)
-    if (is_Function or
-        (callable(func) and not hasattr(func, 'is_Function')) or
-            isinstance(nextToken, AppliedFunction)):
-        return True
-    return False
+    return callable(func)
 
 
 def _add_factorial_tokens(name, result):
@@ -178,7 +176,7 @@ def _apply_functions(tokens, local_dict, global_dict):
             symbol = tok
             result.append(tok)
         elif isinstance(tok, ParenthesisGroup):
-            if symbol:
+            if symbol and _token_callable(symbol, local_dict, global_dict):
                 result[-1] = AppliedFunction(symbol, tok)
                 symbol = None
             else:

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -232,8 +232,19 @@ def _implicit_multiplication(tokens, local_dict, global_dict):
             result.append((OP, '*'))
         elif (tok[0] == NAME and
               not _token_callable(tok, local_dict, global_dict) and
-              isinstance(nextTok, AppliedFunction)):
-            # Constant followed by function
+              nextTok[0] == OP and nextTok[1] == '('):
+            # Constant followed by parenthesis
+            result.append((OP, '*'))
+        elif (tok[0] == NAME and
+              not _token_callable(tok, local_dict, global_dict) and
+              nextTok[0] == NAME and
+              not _token_callable(nextTok, local_dict, global_dict)):
+            # Constant followed by constant
+            result.append((OP, '*'))
+        elif (tok[0] == NAME and
+              not _token_callable(tok, local_dict, global_dict) and
+              (isinstance(nextTok, AppliedFunction) or nextTok[0] == NAME)):
+            # Constant followed by (implicitly applied) function
             result.append((OP, '*'))
     if tokens:
         result.append(tokens[-1])

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -209,7 +209,7 @@ def _implicit_multiplication(tokens, local_dict, global_dict):
     for tok, nextTok in zip(tokens, tokens[1:]):
         result.append(tok)
         if (isinstance(tok, AppliedFunction) and
-                isinstance(nextTok, AppliedFunction)):
+            isinstance(nextTok, AppliedFunction)):
             result.append((OP, '*'))
         elif (isinstance(tok, AppliedFunction) and
               nextTok[0] == OP and nextTok[1] == '('):
@@ -230,7 +230,13 @@ def _implicit_multiplication(tokens, local_dict, global_dict):
         elif (isinstance(tok, AppliedFunction) and nextTok[0] == NAME):
             # Applied function followed by implicitly applied function
             result.append((OP, '*'))
-    result.append(tokens[-1])
+        elif (tok[0] == NAME and
+              not _token_callable(tok, local_dict, global_dict) and
+              isinstance(nextTok, AppliedFunction)):
+            # Constant followed by function
+            result.append((OP, '*'))
+    if tokens:
+        result.append(tokens[-1])
     return result
 
 
@@ -279,7 +285,8 @@ def _implicit_application(tokens, local_dict, global_dict):
             result.append((OP, ')'))
             appendParen -= 1
 
-    result.append(tokens[-1])
+    if tokens:
+        result.append(tokens[-1])
 
     if appendParen:
         result.extend([(OP, ')')] * appendParen)
@@ -328,7 +335,8 @@ def function_exponentiation(tokens, local_dict, global_dict):
                 exponent = []
                 continue
         result.append(tok)
-    result.append(tokens[-1])
+    if tokens:
+        result.append(tokens[-1])
     if exponent:
         result.extend(exponent)
     return result

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -24,7 +24,11 @@ def test_implicit_multiplication():
         'pi x': 'pi*x',
         'x pi': 'x*pi',
         'E x': 'E*x',
-        'EulerGamma y': 'EulerGamma*y'
+        'EulerGamma y': 'EulerGamma*y',
+        'E pi': 'E*pi',
+        'pi (x + 2)': 'pi*(x+2)',
+        '(x + 2) pi': '(x+2)*pi',
+        'pi sin(x)': 'pi*sin(x)',
     }
     transformations = standard_transformations + (convert_xor,)
     transformations2 = transformations + (split_symbols,
@@ -153,7 +157,8 @@ def test_all_implicit_steps():
         'tan 3x': 'tan(3*x)',
         'sin^2(3*E^(x))': 'sin(3*E**(x))**2',
         'sin**2(E^(3x))': 'sin(E**(3*x))**2',
-        'sin^2 (3x*E^(x))': 'sin(3*x*E^x)**2'
+        'sin^2 (3x*E^(x))': 'sin(3*x*E^x)**2',
+        'pi sin x': 'pi*sin(x)',
     }
     transformations = standard_transformations + (convert_xor,)
     transformations2 = transformations + (implicit_multiplication_application,)

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -20,7 +20,11 @@ def test_implicit_multiplication():
         '3sin(x)': '3*sin(x)',
         '(x+1)(x+2)': '(x+1)*(x+2)',
         '(5 x**2)sin(x)': '(5*x**2)*sin(x)',
-        '2 sin(x) cos(x)': '2*sin(x)*cos(x)'
+        '2 sin(x) cos(x)': '2*sin(x)*cos(x)',
+        'pi x': 'pi*x',
+        'x pi': 'x*pi',
+        'E x': 'E*x',
+        'EulerGamma y': 'EulerGamma*y'
     }
     transformations = standard_transformations + (convert_xor,)
     transformations2 = transformations + (split_symbols,


### PR DESCRIPTION
Fixes [issue 4016](http://code.google.com/p/sympy/issues/detail?id=4016).

Changes:
- Names that represent non-evaluateable symbols will be considered for implicit multiplication
- Added tests
