### PR TITLE
Add --split option to split the tests and doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 env:
   - TEST_DOCTESTS="true"
-  -
+  - SPLIT="1/2"
+  - SPLIT="2/2"
 python:
   - 2.6
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ matrix:
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
+        - SPLIT="1/2"
+    - python: 2.7
+      env:
+        - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
+        - SPLIT="2/2"
     - python: 3.3
       env:
         - TEST_GMPY="true"
@@ -29,6 +35,12 @@ matrix:
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
+        - SPLIT="1/2"
+    - python: 3.3
+      env:
+        - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
+        - SPLIT="2/2"
     - python: 2.7
       env: TEST_SPHINX="true"
     - python: 2.7

--- a/bin/doctest
+++ b/bin/doctest
@@ -16,6 +16,7 @@ blacklist = []
 import sys
 import os
 from optparse import OptionParser
+import re
 
 from get_sympy import path_hack
 path_hack()
@@ -38,6 +39,8 @@ parser.add_option('-C', '--no-cache', dest='cache', action='store_false',
 parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
                   default=True, help="Don't run the tests in a separate "
                   "subprocess.  This may prevent hash randomization from being enabled.")
+parser.add_option('--split', action="store", type='str', default=None,
+    help="Only run part of the doctests. Should be of the form a/b, e.g., 1/2")
 parser.set_usage("test [options ...] [files ...]")
 parser.epilog = """\
 "options" are any of the options above. "files" are 0 or more glob strings of \
@@ -48,6 +51,13 @@ documentation (doc/src/ directory).\
 
 options, args = parser.parse_args()
 
+# Check this again here to give a better error message
+if options.split:
+    sp = re.compile(r'([0-9]+)/([1-9][0-9]*)')
+    if not sp.match(options.split):
+        parser.error("option --split: must be of the form a/b where a and b "
+            "are integers, not %r" % options.split)
+
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
 if options.types:
@@ -56,7 +66,7 @@ if options.types:
 import sympy
 
 ok = sympy.doctest(*args, verbose=options.verbose, blacklist=blacklist,
-    normal=options.normal, subprocess=options.subprocess)
+    normal=options.normal, subprocess=options.subprocess, split=options.split)
 
 if ok:
     sys.exit(0)

--- a/bin/test
+++ b/bin/test
@@ -12,6 +12,7 @@ from __future__ import print_function
 import sys
 import os
 from optparse import OptionParser
+import re
 
 from get_sympy import path_hack
 path_hack()
@@ -50,6 +51,8 @@ parser.add_option("--no-subprocess", action="store_false", dest="subprocess",
                   "subprocess.  This may prevent hash randomization from being enabled.")
 parser.add_option("-E", "--enhance-asserts", action="store_true", dest="enhance_asserts",
                   default=False, help="Rewrite assert statements to give more useful error messages.")
+parser.add_option('--split', action="store", type='str', default=None,
+    help="Only run part of the tests. Should be of the form a/b, e.g., 1/2")
 parser.set_usage("test [options ...] [tests ...]")
 parser.epilog = """\
 "options" are any of the options above. "tests" are 0 or more glob strings of \
@@ -57,6 +60,13 @@ tests to run. If no test arguments are given, all tests will be run.\
 """
 
 options, args = parser.parse_args()
+
+# Check this again here to give a better error message
+if options.split:
+    sp = re.compile(r'([0-9]+)/([1-9][0-9]*)')
+    if not sp.match(options.split):
+        parser.error("option --split: must be of the form a/b where a and b "
+            "are integers, not %r" % options.split)
 
 if not options.cache:
     os.environ['SYMPY_USE_CACHE'] = 'no'
@@ -69,7 +79,8 @@ ok = sympy.test(*args, verbose=options.verbose, kw=options.kw,
     tb=options.tb, pdb=options.pdb, colors=options.colors,
     force_colors=options.force_colors, sort=options.sort,
     seed=options.seed, slow=options.slow, timeout=options.timeout,
-    subprocess=options.subprocess, enhance_asserts=options.enhance_asserts)
+    subprocess=options.subprocess, enhance_asserts=options.enhance_asserts,
+    split=options.split)
 
 if ok:
     sys.exit(0)

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -47,7 +47,7 @@ EOF
     else
         cat << EOF | python
 import sympy
-if not sympy.test():
+if not sympy.test(split='${SPLIT}'):
     raise Exception('Tests failed')
 EOF
         fi

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ modules = [
     'sympy.ntheory',
     'sympy.parsing',
     'sympy.physics',
+    'sympy.physics.hep',
     'sympy.physics.mechanics',
     'sympy.physics.quantum',
     'sympy.plotting',
@@ -87,20 +88,19 @@ modules = [
     'sympy.polys.domains',
     'sympy.printing',
     'sympy.printing.pretty',
-    'sympy.strategies',
-    'sympy.strategies.branch',
     'sympy.series',
     'sympy.sets',
     'sympy.simplify',
     'sympy.solvers',
     'sympy.statistics',
     'sympy.stats',
+    'sympy.strategies',
+    'sympy.strategies.branch',
     'sympy.tensor',
     'sympy.unify',
     'sympy.utilities',
     'sympy.utilities.mathml',
 ]
-
 
 class audit(Command):
     """Audits SymPy's source code for following issues:

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -98,7 +98,6 @@ def convert_to_native_paths(lst):
                 if rv[pos + 1] != '\\':
                     rv = rv[:pos + 1] + '\\' + rv[pos + 1:]
         newlst.append(sys_normcase(rv))
-    newlst.sort()
     return newlst
 
 
@@ -1117,7 +1116,7 @@ class SymPyTests(object):
         for path, folders, files in os.walk(dir):
             g.extend([os.path.join(path, f) for f in files if fnmatch(f, pat)])
 
-        return [sys_normcase(gi) for gi in g]
+        return sorted([sys_normcase(gi) for gi in g])
 
 
 class SymPyDocTests(object):

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -98,6 +98,7 @@ def convert_to_native_paths(lst):
                 if rv[pos + 1] != '\\':
                     rv = rv[:pos + 1] + '\\' + rv[pos + 1:]
         newlst.append(sys_normcase(rv))
+    newlst.sort()
     return newlst
 
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -464,7 +464,7 @@ def _test(*paths, **kwargs):
     enhance_asserts = kwargs.get("enhance_asserts", False)
     split = kwargs.get('split', None)
     r = PyTestReporter(verbose=verbose, tb=tb, colors=colors,
-        force_colors=force_colors)
+        force_colors=force_colors, split=split)
     t = SymPyTests(r, kw, post_mortem, seed)
 
     # Disable warnings for external modules
@@ -635,7 +635,7 @@ def _doctest(*paths, **kwargs):
     import warnings
     warnings.simplefilter("error", SymPyDeprecationWarning)
 
-    r = PyTestReporter(verbose)
+    r = PyTestReporter(verbose, split=split)
     t = SymPyDocTests(r, normal)
 
     test_files = t.get_test_files('sympy')
@@ -1721,7 +1721,7 @@ class PyTestReporter(Reporter):
     """
 
     def __init__(self, verbose=False, tb="short", colors=True,
-                 force_colors=False):
+                 force_colors=False, split=None):
         self._verbose = verbose
         self._tb_style = tb
         self._colors = colors
@@ -1735,6 +1735,7 @@ class PyTestReporter(Reporter):
         self._exceptions = []
         self._terminal_width = None
         self._default_width = 80
+        self._split = split
 
         # this tracks the x-position of the cursor (useful for positioning
         # things on the screen), without the need for any readline library:
@@ -1950,6 +1951,8 @@ class PyTestReporter(Reporter):
             self.write("on (PYTHONHASHSEED=%s)\n" % hash_seed)
         else:
             self.write("off\n")
+        if self._split:
+            self.write("split:              %s\n" % self._split)
         self.write('\n')
         self._t_start = clock()
 


### PR DESCRIPTION
The usage is

./bin/test --split 1/2

which will run the first half of the tests. Any a/b is supported.

Currently, this just splits the test files, because that was the easiest to
do, but we maybe should implement splitting the tests themselves.

Note that for the doctests, the regular doctests and the Sphinx doctests are
split independently. Furthermore, the Sphinx doctests split against every
Sphinx file, before it checks if it actually has doctests, so for some splits,
no Sphinx doctests will be run at all.

It will be easy to use this to split our Travis test runs in half to get rid
of the timeouts.
