### PR TITLE
 Issue 4007: 	Incorrect Real & Imaginary parts of Irrational functions

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -669,7 +669,13 @@ class Add(Expr, AssocOp):
         >>> from sympy import I
         >>> (7 + 9*I).as_real_imag()
         (7, 9)
+	>>> ((1 + I)/(1 - I)).as_real_imag()
+	(0, 1)
+	>>> ((1 + 2*I)*(1 + 3*I)).as_real_imag()
+	(-5, 5)
         """
+        from sympy import expand_mul
+        self = expand_mul(self)
         sargs, terms = self.args, []
         re_part, im_part = [], []
         for term in sargs:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -674,8 +674,6 @@ class Add(Expr, AssocOp):
         >>> ((1 + 2*I)*(1 + 3*I)).as_real_imag()
         (-5, 5)
         """
-        from sympy import expand_mul
-        self = expand_mul(self)
         sargs, terms = self.args, []
         re_part, im_part = [], []
         for term in sargs:

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -669,10 +669,10 @@ class Add(Expr, AssocOp):
         >>> from sympy import I
         >>> (7 + 9*I).as_real_imag()
         (7, 9)
-	>>> ((1 + I)/(1 - I)).as_real_imag()
-	(0, 1)
-	>>> ((1 + 2*I)*(1 + 3*I)).as_real_imag()
-	(-5, 5)
+        >>> ((1 + I)/(1 - I)).as_real_imag()
+        (0, 1)
+        >>> ((1 + 2*I)*(1 + 3*I)).as_real_imag()
+        (-5, 5)
         """
         from sympy import expand_mul
         self = expand_mul(self)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -663,8 +663,12 @@ class Mul(Expr, AssocOp):
             return S.One, self
 
     def as_real_imag(self, deep=True, **hints):
+        from sympy import expand_mul
         other = []
         coeff = S.One
+        self = expand_mul(self)
+        if self.is_Add:
+            return self.as_real_imag(deep=True)
         for a in self.args:
             if a.is_real or a.is_imaginary:
                 coeff *= a
@@ -686,7 +690,7 @@ class Mul(Expr, AssocOp):
             if coeff.is_real:
                 return (coeff*C.re(m), coeff*C.im(m))
             else:
-                return (-C.im(coeff)*C.im(m), C.im(coeff)*C.re(m))
+                return (-C.im(coeff)*C.im(m), C.im(coeff)*C.re(m)) 
 
     @staticmethod
     def _expandsums(sums):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -690,7 +690,7 @@ class Mul(Expr, AssocOp):
             if coeff.is_real:
                 return (coeff*C.re(m), coeff*C.im(m))
             else:
-                return (-C.im(coeff)*C.im(m), C.im(coeff)*C.re(m)) 
+                return (-C.im(coeff)*C.im(m), C.im(coeff)*C.re(m))
 
     @staticmethod
     def _expandsums(sums):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -666,6 +666,7 @@ class Mul(Expr, AssocOp):
         from sympy import expand_mul
         other = []
         coeff = S.One
+        addterms = S.One
         for a in self.args:
             if a.is_real or a.is_imaginary:
                 coeff *= a
@@ -677,19 +678,23 @@ class Mul(Expr, AssocOp):
                         del other[i]
                         break
                 else:
-                    if any(a.is_Add for a in self.args):
-                        return expand_mul(self, deep=False).as_real_imag()
-                    other.append(a)
+                    if a.is_Add:
+                        addterms *= a
+                    else:
+                        other.append(a)
             else:
                 other.append(a)
+        addre, addim = expand_mul(addterms, deep=False).as_real_imag()
         m = self.func(*other)
         if hints.get('ignore') == m:
             return None
         else:
             if coeff.is_real:
-                return (coeff*C.re(m), coeff*C.im(m))
+                return (coeff*(C.re(m)*addre - C.im(m)*addim), coeff*(C.im(m)*addre + C.re(m)*addim))
             else:
-                return (-C.im(coeff)*C.im(m), C.im(coeff)*C.re(m))
+                re = C.re(coeff)*C.re(m) - C.im(coeff)*C.im(m)
+                im = C.im(coeff)*C.re(m) + C.re(coeff)*C.im(m)
+                return (re*addre - im*addim, re*addim + im*addre)
 
     @staticmethod
     def _expandsums(sums):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -666,9 +666,6 @@ class Mul(Expr, AssocOp):
         from sympy import expand_mul
         other = []
         coeff = S.One
-        self = expand_mul(self)
-        if self.is_Add:
-            return self.as_real_imag(deep=True)
         for a in self.args:
             if a.is_real or a.is_imaginary:
                 coeff *= a
@@ -680,6 +677,8 @@ class Mul(Expr, AssocOp):
                         del other[i]
                         break
                 else:
+                    if any(a.is_Add for a in self.args):
+                        return expand_mul(self, deep=False).as_real_imag()
                     other.append(a)
             else:
                 other.append(a)

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -692,8 +692,8 @@ class Mul(Expr, AssocOp):
             if coeff.is_real:
                 return (coeff*(C.re(m)*addre - C.im(m)*addim), coeff*(C.im(m)*addre + C.re(m)*addim))
             else:
-                re = C.re(coeff)*C.re(m) - C.im(coeff)*C.im(m)
-                im = C.im(coeff)*C.re(m) + C.re(coeff)*C.im(m)
+                re = - C.im(coeff)*C.im(m)
+                im = C.im(coeff)*C.re(m)
                 return (re*addre - im*addim, re*addim + im*addre)
 
     @staticmethod

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -188,6 +188,10 @@ def test_real_imag():
     i = Symbol('i', imaginary=True)
     assert (i*r*x).as_real_imag() == (I*i*r*im(x), -I*i*r*re(x))
 
+    # issue 4007:
+    assert ((1 + I)/(1 - I)).as_real_imag() == (0, 1)
+    assert ((1 + 2*I)*(1 + 3*I)).as_real_imag() == (-5, 5)
+
 
 def test_pow_issue_1724():
     e = ((-1)**(S(1)/3))


### PR DESCRIPTION
Functions, as_real_imag and expand_complex, failed to work for cases like (1 + i)/(1 - i) and (1 + 2_i)(1 + 3_i)

Both the functions give output in terms of re and im (that is):

```
for expand_complex:
    /       \                  /       \
re |  1 + i  |  .(1 + i), im  |  1 + i  | . (1 +i)
   | --- --- |                | --- --- |
    \ 2   2                    \ 2   2 /

for as_real_imag:

    /       \        /       \
re |  1 + i  | ,im  |  1 + i  | 
   | ------- |      | ------- |
    \ 1 - i  /       \ i - i /
```

Corrects the above case, giving following result for cases

```
>>> ((1 + I)/(1 - I)).as_real_imag()
      (0, 1)
>>> ((1 + 2*I)*(1 + 3*I)).as_real_imag()
      (-5, 5) 
```

Issue Reported: 
https://code.google.com/p/sympy/issues/detail?id=4007&q=irrational&colspec=ID%20Type%20Status%20Priority%20Milestone%20Reporter%20Summary%20Stars
