### PR TITLE
Factorization of polynomials over algebraic number fields

### DIFF
--- a/doc/src/modules/polys/literature.rst
+++ b/doc/src/modules/polys/literature.rst
@@ -94,4 +94,8 @@ a theoretical foundation for implementing polynomials manipulation module.
 
 .. [Hoeij02] M. van Hoeij and M. Monagan, A modular GCD algorithm over
     number fields presented with multiple extensions, Proceedings of ISSAC
-    2002, pp. 109-116, ACM, 2002
+    2002, pp. 109-116, ACM, 2002.
+
+.. [Javadi09] S. M. M. Javadi and M. Monagan, On factorization of multivariate
+    polynomials over algebraic number and function fields, Proceedings of
+    ISSAC 2009, pp. 199-206, ACM, 2009.

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division
 
 import collections
+from functools import partial
+
 from sympy.core.add import Add
 from sympy.core.basic import Basic, C, Atom
 from sympy.core.expr import Expr
@@ -2620,7 +2622,7 @@ class MatrixBase(object):
         return self.adjugate() / d
 
     def rref(self, simplified=False, iszerofunc=_iszero,
-            simplify=False, modulus=None):
+            simplify=False, scalefunc=None, elimfunc=None):
         """Return reduced row-echelon form of matrix and indices of pivot vars.
 
         To simplify elements before finding nonzero pivots set simplify=True
@@ -2648,14 +2650,7 @@ class MatrixBase(object):
             simplify = simplify or True
         simpfunc = simplify if isinstance(
             simplify, FunctionType) else _simplify
-        if modulus:
-            if iszerofunc == _iszero:
-                iszerofunc = lambda x : not x % modulus
-            scalefunc = lambda x, _: (x * ZZ.invert(scale, modulus)) % modulus
-            elimfunc = lambda x, y: (x - scale*y) % modulus
-        else:
-            scalefunc = lambda x, _: x / scale
-            elimfunc = lambda x, y: x - scale*y
+
         # pivot: index of next row to contain a pivot
         pivot, r = 0, self.as_mutable()
         # pivotlist: indices of pivot variables (non-free)
@@ -2675,12 +2670,14 @@ class MatrixBase(object):
                     continue
                 r.row_swap(pivot, k)
             scale = r[pivot, i]
-            r.row_op(pivot, scalefunc)
+            _scalefunc = partial(scalefunc, scale=scale) if scalefunc else lambda x, _: x / scale
+            r.row_op(pivot, _scalefunc)
             for j in xrange(r.rows):
                 if j == pivot:
                     continue
                 scale = r[j, i]
-                r.zip_row_op(j, pivot, elimfunc)
+                _elimfunc = partial(elimfunc, scale=scale) if elimfunc else lambda x, y: x - scale*y
+                r.zip_row_op(j, pivot, _elimfunc)
             pivotlist.append(i)
             pivot += 1
         return self._new(r), pivotlist

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -507,7 +507,7 @@ def _factor(f):
         lcfactors_.append((l_, exp)) # polyomials over QQ, allthough coeffs are in ZZ
 
     f_ = f_.mul_ground(D_)
-    b = zring.dmp_zz_mignotte_bound(f_)
+    b = zring.dmp_zz_mignotte_bound(f_)*abs(D)
     p = nextprime(b)
 
     N = 0

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -572,6 +572,7 @@ def _factor(f):
             # what about l_ ?
             pfactors = _hensel_lift(f_, fAfactors_, lcs, A, minpoly, p)
             if pfactors is None:
+                f_ = f_.primitive()[1]
                 continue
 
 #            factors = _padic_lift(f_, pfactors, l_, p, B, lcs, minpoly)

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -92,9 +92,10 @@ def _distinct_prime_divisors(A, domain):
     return divisors
 
 
-def _denominator(f):
-    domain = f.ring.domain
-    ring = domain.get_ring()
+def _denominator(f, qring):
+    f = _alpha_to_z(f, qring)
+
+    ring = qring.domain.get_ring()
     lcm = ring.lcm
     den = ring.one
 
@@ -114,10 +115,12 @@ def _monic_associate(f, ring):
 
 def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
     omega = D * gamma
-    ring = U[0][0].ring
-    qring = f.ring.drop(*f.ring.gens[1:-1])
+    ring = f.ring
+    domain = ring.domain
+    symbols = f.ring.symbols
+    qring = ring.clone(symbols=(symbols[0], symbols[-1]), domain=domain.get_field())
 
-    denominators = [_denominator(_alpha_to_z(u, qring)) for u, _ in U]
+    denominators = [_denominator(u, qring) for u, _ in U]
 
     m = len(denoms)
 
@@ -177,7 +180,7 @@ def _test_evaluation_points(f, gamma, lcfactors, D, A):
     denoms = []
     for l, _ in lcfactors:
         lA = l.evaluate(zip(l.ring.gens, A)) # in Q(alpha)
-        denoms.append(_denominator(_alpha_to_z(lA**(-1), qring)))
+        denoms.append(_denominator(lA**(-1), qring))
 
     divisors = _distinct_prime_divisors(denoms, ring.domain)
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -412,12 +412,12 @@ def _hensel_lift(f, H, LC, A, minpoly, p):
             if evalpoints:
                 lc = lc.evaluate(evalpoints)
             lc = _trunc(lc, minpoly, p).set_ring(Hring)
-            H[i] = h.set_ring(Hring) + (lc - h.LC)*x**h.degree()
+            H[i] = h.set_ring(Hring) + (lc - h.ring.dmp_LC(h).set_ring(Hring))*x**h.degree()
 
         m = Hring.gens[j] - a
         M = Hring.one
 
-        c = s - ring.mul(H)
+        c = _trunc(s - ring.mul(H), minpoly, p)
 
         dj = s.degree(j)
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -4,12 +4,11 @@ from sympy import Dummy
 import random
 
 from sympy.ntheory import nextprime
-from sympy.polys.galoistools import gf_sqf_p, gf_irreducible_p
+from sympy.polys.galoistools import gf_irreducible_p
 from sympy.polys.modulargcd import _trunc, _gf_gcdex, _minpoly_from_dense, _euclidean_algorithm
 from sympy.polys.polyclasses import ANP
 from sympy.polys.polyerrors import UnluckyLeadingCoefficient, UnluckyMinimalPolynomial
 from sympy.polys.polyutils import _sort_factors
-from sympy.polys.rings import PolyRing
 
 
 # TODO

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -581,7 +581,7 @@ def _factor(f):
 #                B *= B
 #                continue
 
-            return (f.LC, [_z_to_alpha(g, ring).monic() for g in pfactors])
+            return (f.LC, [_z_to_alpha(g.primitive()[1], ring).monic() for g in pfactors])
 
         N += 1
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -186,7 +186,7 @@ def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
     return f, lcs, U
 
 
-def _test_evaluation_points(f, gamma, lcfactors, D, A):
+def _test_evaluation_points(f, gamma, lcfactors, A, D):
     ring = f.ring
     qring = ring.clone(domain=ring.domain.get_field())
 
@@ -588,7 +588,7 @@ def _factor(f):
                 continue
 
             try:
-                result = _test_evaluation_points(f_, groundring.convert(gamma), lcfactors, D, A)
+                result = _test_evaluation_points(f_, groundring.convert(gamma), lcfactors, A, D)
             except UnluckyLeadingCoefficient:
                 # TODO: check interval
                 C = [random.randint(1, 3*(N + 1)) for _ in xrange(n - 1)]

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -67,12 +67,12 @@ def _z_to_alpha(f, ring):
     return f_
 
 
-def _distinct_prime_divisors(A, domain):
+def _distinct_prime_divisors(S, domain):
     gcd = domain.gcd
     divisors = []
 
-    for i, a in enumerate(A):
-        divisors.append(a)
+    for i, s in enumerate(S):
+        divisors.append(s)
 
         for j in xrange(i-1):
             g = gcd(divisors[i], divisors[j])
@@ -614,7 +614,7 @@ def _factor(f):
             else:
                 fA, denoms, divisors = result
 
-            omega_, fAfactors = _z_to_alpha(fA, ring.drop(*ring.gens[1:])).factor_list() # factorization in Q(alpha)[x_0]
+            _, fAfactors = _z_to_alpha(fA, ring.drop(*ring.gens[1:])).factor_list()
             if len(fAfactors) == 1:
                 g = _z_to_alpha(f_, ring)
                 return (f.LC, [g.monic()])

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -444,8 +444,11 @@ def _padic_lift(f, pfactors, lcs, B, minpoly, p):
     domain = ring.domain
     LC = ring.dmp_LC
 
+    x = ring.gens[0]
+    tails = [g - LC(g).set_ring(ring)*x**g.degree() for g in pfactors]
+
     coeffs = []
-    for i, g in enumerate(pfactors):
+    for i, g in enumerate(tails):
         coeffs += _symbols('c%i' % i, len(g))
 
     coeffring = PolyRing(coeffs, domain)
@@ -453,19 +456,19 @@ def _padic_lift(f, pfactors, lcs, B, minpoly, p):
 
     S = []
     k = 0
-    for g in pfactors:
+    for t in tails:
         s = ring_.zero
-        t = len(g)
-        for i, monom in zip(xrange(k, k+t), g.itermonoms()):
+        r = len(t)
+        for i, monom in zip(xrange(k, k+r), t.itermonoms()):
             s[monom] = coeffring.gens[i]
         S.append(s)
-        k += t
+        k += r
 
     m = minpoly.set_ring(ring_)
     f = f.set_ring(ring_)
     x = ring_.gens[0]
-    H = [g.set_ring(ring_) + (li - LC(g)).set_ring(ring_)*x**g.degree() for
-            g, li in zip(pfactors, lcs)]
+    H = [t.set_ring(ring_) + li.set_ring(ring_)*x**g.degree() for t, g, li in
+            zip(tails, pfactors, lcs)]
 
     prod = ring_.mul(H)
     e = (f - prod).rem(m)

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -37,10 +37,7 @@ def _alpha_to_z(f, ring):
             for i in xrange(n):
                 m = monom + (n-i-1,)
                 if coeff[i]:
-                    if m not in f_:
-                        f_[m] = coeff[i]
-                    else:
-                        f_[m] += coeff[i]
+                    f_[m] = coeff[i]
 
     return f_
 
@@ -48,21 +45,15 @@ def _alpha_to_z(f, ring):
 def _z_to_alpha(f, ring):
     domain = ring.domain
 
-    if f.ring.is_univariate:
-        f_ = domain.zero
-        for (monom,), coeff in f.iterterms():
-            f_ += domain([domain.domain(coeff)] + [0]*monom)
+    f_ = ring.zero
+    for monom, coeff in f.iterterms():
+        m = monom[:-1]
+        c = domain([domain.domain(coeff)] + [0]*monom[-1])
 
-    else:
-        f_ = ring.zero
-        for monom, coeff in f.iterterms():
-            m = monom[:-1]
-            c = domain([domain.domain(coeff)] + [0]*monom[-1])
-
-            if m not in f_:
-                f_[m] = c
-            else:
-                f_[m] += c
+        if m not in f_:
+            f_[m] = c
+        else:
+            f_[m] += c
 
     return f_
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -282,9 +282,18 @@ def _padic_lift(f, pfactors, lcs, B, minpoly, p):
 
         poly = _trunc(poly, m, P)
 
-        solution = solve_lin_sys(poly.coeffs(), coeffring, modulus=P)
+        iszerofunc = lambda x: not (x % p)
+        scalefunc = lambda x, _, scale: (x * domain.invert(scale, P)) % P
+        elimfunc = lambda x, y, scale: (x - scale*y) % P
+
+        solution = solve_lin_sys(poly.coeffs(), coeffring, iszerofunc=iszerofunc,
+            scalefunc=scalefunc, elimfunc=elimfunc)
+
         if solution is None:
             return None
+        else:
+            for k, v in solution.items():
+                solution[k] = v.trunc_ground(P)
 
         solution = _choose_particular_solution(solution, coeffring)
         subs = solution.items()

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -583,6 +583,7 @@ def _factor(f):
             # what about l_ ?
             pfactors = _hensel_lift(f_, fAfactors_, lcs, A, minpoly, p)
             if pfactors is None:
+                p = nextprime(p)
                 f_ = f_.primitive()[1]
                 continue
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -553,10 +553,12 @@ def _sqf_p(f, minpoly, p):
         return _euclidean_algorithm(f, _trunc(f.diff(0), minpoly, p), minpoly, p) == 1
 
 
-def _test_prime(fA, minpoly, p, domain):
+def _test_prime(fA, D, minpoly, p, domain):
     if fA.LC % p == 0 or minpoly.LC % p == 0:
         return False
     if not _sqf_p(fA, minpoly, p):
+        return False
+    if D % p == 0:
         return False
 
     return True
@@ -580,13 +582,14 @@ def _factor(f, save):
 
     minpoly = _minpoly_from_dense(ring.domain.mod, zring.drop(*zring.gens[:-1]))
     f_ = _monic_associate(f, zring)
+
     if save is True:
         D = minpoly.resultant(minpoly.diff(0))
     else:
         D = groundring.one
 
     # heuristic bound for p-adic lift
-    B = f_.max_norm()
+    B = (f_.max_norm() + 1)*D
 
     lc = zring.dmp_LC(f_)
     gamma, lcfactors = efactor(_z_to_alpha(lc, lcring)) # over QQ(alpha)[x_1, ..., x_n]
@@ -664,7 +667,7 @@ def _factor(f, save):
 
             f_ = f_.mul_ground(delta)
 
-            while not _test_prime(fA, minpoly, p, zring.domain):
+            while not _test_prime(fA, D, minpoly, p, zring.domain):
                 p = nextprime(p)
 
             pfactors = _hensel_lift(f_, fAfactors_, lcs, A, minpoly, p)
@@ -691,7 +694,7 @@ def _sort(factors, ring):
 
 
 # output of the form (lc, [(poly1, exp1), ...])
-def efactor(f, save=False):
+def efactor(f, save=True):
     ring = f.ring
 
     assert ring.domain.is_Algebraic

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -468,10 +468,6 @@ def _factor(f):
     ground = ring.domain.domain
     n = ring.ngens
 
-    if n == 1:
-        lc, factors = f.factor_list()
-        return (lc, [g for g, _ in factors])
-
     z = Dummy('z')
     qring = ring.clone(symbols=ring.symbols + (z,), domain=ground)
     lcqring = qring.drop(0)

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -182,11 +182,11 @@ def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
             omega = (omega * d) // djA
 
         if omega == 1:
-            return f_, lcs, U_
+            return f, lcs, U_
         else:
             lcs = [lc.mul_ground(omega) for lc in lcs]
             U_ = [u.mul_ground(omega) for u in U_]
-            f_ = f.mul_ground(omega**(n-1))
+            f = f.mul_ground(omega**(n - 1))
 
     return f, lcs, U_
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -535,7 +535,7 @@ def _test_prime(fA, minpoly, p, domain):
 
 
 # squarefree f with cont_x0(f) = 1
-def _factor(f):
+def _factor(f, save):
     ring = f.ring # Q(alpha)[x_0, ..., x_{n-1}]
     lcring = ring.drop(0)
     uniring = ring.drop(*ring.gens[1:])
@@ -552,7 +552,10 @@ def _factor(f):
 
     minpoly = _minpoly_from_dense(ring.domain.mod, zring.drop(*zring.gens[:-1]))
     f_ = _monic_associate(f, zring)
-    D = minpoly.resultant(minpoly.diff(0))
+    if save is True:
+        D = minpoly.resultant(minpoly.diff(0))
+    else:
+        D = groundring.one
 
     # heuristic bound for p-adic lift
     B = f_.max_norm()
@@ -600,7 +603,7 @@ def _factor(f):
                     xi = gens[i]
                     f_ = f_.compose(xi, x + xi.mul_ground(ci))
 
-                lc, factors = _factor(_z_to_alpha(f_, ring))
+                lc, factors = _factor(_z_to_alpha(f_, ring), save)
                 gens = factors[0].ring.gens
                 x = gens[0]
 
@@ -664,7 +667,7 @@ def _sort(factors, ring):
 
 
 # output of the form (lc, [(poly1, exp1), ...])
-def efactor(f):
+def efactor(f, save=False):
     ring = f.ring
 
     assert ring.domain.is_Algebraic
@@ -689,7 +692,7 @@ def efactor(f):
         factors = []
         for g, exp in sqflist:
             try:
-                lcg, gfactors = _factor(g)
+                lcg, gfactors = _factor(g, save)
             except UnluckyMinimalPolynomial:
                 return ring.dmp_ext_factor(f)
             lc *= lcg

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -545,7 +545,8 @@ def _factor(f):
     qring = ring.clone(symbols=ring.symbols + (z,), domain=ground)
     lcqring = qring.drop(0)
 
-    zring = qring.clone(domain=ground.get_ring())
+    groundring = ground.get_ring()
+    zring = qring.clone(domain=groundring)
     lczring = zring.drop(0)
 
     minpoly = _minpoly_from_dense(ring.domain.mod, zring.drop(*zring.gens[:-1]))
@@ -558,8 +559,9 @@ def _factor(f):
     lc = zring.dmp_LC(f_)
     gamma, lcfactors = efactor(_z_to_alpha(lc, lcring)) # over QQ(alpha)[x_1, ..., x_n]
 
-    D_ = ground.denom(gamma.rep[0])
-    gamma_ = ground.numer(gamma.rep[0]) # in QQ
+    gamma = ground.convert(gamma)
+    D_ = ground.denom(gamma)
+    gamma_ = ground.numer(gamma)
     lcfactors_ = []
 
     for l, exp in lcfactors:
@@ -586,7 +588,7 @@ def _factor(f):
                 continue
 
             try:
-                result = _test_evaluation_points(f_, gamma.rep[0], lcfactors, D, A)
+                result = _test_evaluation_points(f_, groundring.convert(gamma), lcfactors, D, A)
             except UnluckyLeadingCoefficient:
                 # TODO: check interval
                 C = [random.randint(1, 3*(N + 1)) for _ in xrange(n - 1)]
@@ -623,7 +625,7 @@ def _factor(f):
             else:
                 f_, lcs, fAfactors_ = result
 
-            prod = ground.one
+            prod = groundring.one
             for lc in lcs:
                 prod *= lc.LC
             delta = ground.numer(ground(prod, f_.LC))

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -65,7 +65,7 @@ def _distinct_prime_divisors(S, domain):
     for i, s in enumerate(S):
         divisors.append(s)
 
-        for j in xrange(i-1):
+        for j in xrange(i):
             g = gcd(divisors[i], divisors[j])
             divisors[i] = divisors[i] // g
             divisors[j] = divisors[j] // g
@@ -614,7 +614,7 @@ def _factor(f, save):
                 continue
 
             try:
-                result = _test_evaluation_points(f_, groundring.convert(gamma), lcfactors, A, D)
+                result = _test_evaluation_points(f_, gamma_, lcfactors, A, D)
             except UnluckyLeadingCoefficient:
                 # TODO: check interval
                 C = [random.randint(1, 3*(N + 1)) for _ in xrange(n - 1)]

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -482,6 +482,7 @@ def _factor(f):
     lcqring = qring.drop(0)
 
     zring = qring.clone(domain=ground.get_ring())
+    lczring = zring.drop(0)
 
     minpoly = _minpoly_from_dense(ring.domain.mod, zring.drop(*zring.gens[:-1]))
     f_ = _monic_associate(f, zring)
@@ -500,7 +501,7 @@ def _factor(f):
 
     for l, exp in lcfactors:
         den, l_ = _alpha_to_z(l, lcqring).clear_denoms() # l_ in QQ[x_1, ..., x_n, z], but coeffs in ZZ
-        cont, l_ = l_.primitive()
+        cont, l_ = l_.set_ring(lczring).primitive()
         D_ *= den
         gamma_ *= cont
         lcfactors_.append((l_, exp)) # polyomials over QQ, allthough coeffs are in ZZ
@@ -557,7 +558,7 @@ def _factor(f):
             else:
                 f_, lcs, fAfactors_ = result
 
-            prod = ring.domain.domain.one
+            prod = ground.one
             for lc in lcs:
                 prod *= lc.LC
             q = ground(prod, f_.LC)

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -1,0 +1,595 @@
+from __future__ import print_function
+
+from sympy import Dummy
+import random
+
+from sympy.ntheory import nextprime
+from sympy.polys.galoistools import gf_sqf_p, gf_irreducible_p
+from sympy.polys.modulargcd import _trunc, _gf_gcdex, _minpoly_from_dense, _euclidean_algorithm
+from sympy.polys.polyclasses import ANP
+from sympy.polys.polyutils import _sort_factors
+from sympy.polys.rings import PolyRing
+
+
+# TODO
+# ====
+
+# -) efficiency of _factor can be improved for irreducible polynomials if the
+#    univariate factorization is done before the LC is factored
+
+
+def _alpha_to_z(f, ring):
+    if isinstance(f, ANP):
+        ring = ring.drop(*ring.gens[:-1])
+        f_ = ring.from_dense(f.rep)
+
+    else:
+        f_ = ring.zero
+        domain = ring.domain
+
+        for monom, coeff in f.iterterms():
+            coeff = coeff.rep
+            n = len(coeff)
+
+            for i in xrange(n):
+                m = monom + (n-i-1,)
+                if coeff[i]:
+                    if m not in f_:
+                        f_[m] = coeff[i]
+                    else:
+                        f_[m] += coeff[i]
+
+    return f_
+
+
+def _z_to_alpha(f, ring):
+    domain = ring.domain
+
+    if f.ring.is_univariate:
+        f_ = domain.zero
+        for (monom,), coeff in f.iterterms():
+            f_ += domain([domain.domain(coeff)] + [0]*monom)
+
+    else:
+        f_ = ring.zero
+        for monom, coeff in f.iterterms():
+            m = monom[:-1]
+            c = domain([domain.domain(coeff)] + [0]*monom[-1])
+
+            if m not in f_:
+                f_[m] = c
+            else:
+                f_[m] += c
+
+    return f_
+
+
+def _distinct_prime_divisors(A, domain):
+    gcd = domain.gcd
+    divisors = []
+
+    for i, a in enumerate(A):
+        divisors.append(a)
+
+        for j in xrange(i-1):
+            g = gcd(divisors[i], divisors[j])
+            divisors[i] = divisors[i] // g
+            divisors[j] = divisors[j] // g
+            g1 = gcd(divisors[i], g)
+            g2 = gcd(divisors[j], g)
+
+            while g1 != 1:
+                g1 = gcd(divisors[i], g1)
+                divisors[i] = divisors[i] // g1
+
+            while g2 != 1:
+                g2 = gcd(divisors[j], g2)
+                divisors[j] = divisors[j] // g2
+
+            if divisors[i] == 1 or divisors[j] == 1:
+                return None
+
+    return divisors
+
+
+def _denominator(f):
+    domain = f.ring.domain
+    ring = domain.get_ring()
+    lcm = ring.lcm
+    den = ring.one
+
+    for coeff in f.itercoeffs():
+        den = lcm(den, coeff.denominator)
+
+    return den
+
+
+def _monic_associate(f, ring):
+    qring = ring.clone(domain=ring.domain.get_field())
+    f = _alpha_to_z(f.monic(), qring)
+    f_ = f.clear_denoms()[1].set_ring(ring)
+
+    return f_.primitive()[1]
+
+
+def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
+    omega = D * gamma
+    ring = U[0][0].ring
+    qring = f.ring.drop(*f.ring.gens[1:-1])
+
+    denominators = [_denominator(_alpha_to_z(u, qring)) for u, _ in U]
+
+    m = len(denoms)
+
+    gcd = f.ring.domain.gcd
+
+    for i in xrange(m):
+        pi = gcd(omega, divisors[i])
+        divisors[i] //= pi
+        if divisors[i] == 1:
+            return None
+
+    e = []
+
+    for dj in denominators:
+        ej = []
+
+        for i in xrange(m):
+            eji = 0
+            g1 = gcd(dj, divisors[i])
+
+            while g1 != 1:
+                eji += 1
+                dj = dj // g1
+                g1 = gcd(dj, g1)
+
+            ej.append(eji)
+
+        e.append(ej)
+
+    n = len(denominators)
+    if any(sum([e[j][i] for j in xrange(n)]) != lcfactors[i][1] for i in xrange(m)):
+        return None
+
+    lcs = []
+    for j in xrange(n):
+        lj = ring.mul([lcfactors[i]**e[j][i] for i in xrange(m)])
+        lcs.append(lj)
+
+    # TODO: distribute omega to l_{j}s and if needed update f
+
+    return f, lcs
+
+
+def _test_evaluation_points(f, gamma, lcfactors, D, A):
+    ring = f.ring
+    qring = ring.clone(domain=ring.domain.get_field())
+
+    lc = ring.dmp_LC(f)
+    if lc.evaluate(zip(lc.ring.gens, A)) == 0:
+        return None
+
+    fA = f.evaluate(zip(ring.gens[1:-1], A))
+    if not fA.is_squarefree:
+        return None
+
+    omega = gamma * D
+    denoms = []
+    for l, _ in lcfactors:
+        lA = l.evaluate(zip(l.ring.gens, A)) # in Q(alpha)
+        denoms.append(_denominator(_alpha_to_z(lA**(-1), qring)))
+
+    divisors = _distinct_prime_divisors(denoms, ring.domain)
+
+    if divisors is None:
+        return None
+    elif any(omega % d == 0 for d in divisors):
+        return None
+
+    return fA, denoms, divisors
+
+
+# TODO!
+def _padic_lift(f, pfactors, l, p, B, lcs, minpoly):
+    ring = f.ring
+    LC = ring.dmp_LC
+    x = ring.gens[0]
+
+    h = [g + (l - LC(g))*x**g.degree() for g, l in zip(pfactors, lcs)]
+
+    e = f - ring.mul(h).mul_ground(l) # mod minpoly
+
+    P = p
+
+
+def _div(f, g, minpoly, p):
+    ring = f.ring
+
+    rem = f
+    deg = g.degree(0)
+    lcinv, _, gcd = _gf_gcdex(ring.dmp_LC(g), minpoly, p)
+
+#    minpoly mod p should be irreducible at this point
+    if not gcd == 1:
+        return None
+
+    quotient = ring.zero
+
+    while True:
+        degrem = rem.degree(0)
+        if degrem < deg:
+            break
+        quo = (lcinv * ring.dmp_LC(rem)).set_ring(ring).mul_monom((degrem - deg, 0))
+        rem = _trunc(rem - g*quo, minpoly, p)
+        quotient += quo
+
+    return _trunc(quotient, minpoly, p), rem
+
+
+def _extended_euclidean_algorithm(f, g, minpoly, p):
+    ring = f.ring
+    zero = ring.zero
+    one = ring.one
+
+    f = _trunc(f, minpoly, p)
+    g = _trunc(g, minpoly, p)
+
+    s0, s1 = zero, one
+    t0, t1 = one, zero
+
+    while g:
+        quo, rem = _div(f, g, minpoly, p)
+        f, g = g, rem
+        s0, s1 = s1 - quo*s0, s0
+        t0, t1 = t1 - quo*t0, t0
+
+    lcfinv = _gf_gcdex(ring.dmp_LC(f), minpoly, p)[0].set_ring(ring)
+
+    return ( _trunc(s1 * lcfinv, minpoly, p), _trunc(t1 * lcfinv, minpoly, p),
+        _trunc(f * lcfinv, minpoly, p) )
+
+
+def _diophantine_univariate(F, m, minpoly, p):
+    if len(F) == 2:
+        f, g = F
+        s, t, _ = _extended_euclidean_algorithm(g, f, minpoly, p)
+
+        s = s.mul_monom((m, 0))
+        t = t.mul_monom((m, 0))
+
+        q, s = _div(s, f, minpoly, p)
+
+        t += q*g
+
+        s = _trunc(s, minpoly, p)
+        t = _trunc(t, minpoly, p)
+
+        result = [s, t]
+    else:
+        ring = F[0].ring
+        G = [F[-1]]
+
+        for f in reversed(F[1:-1]):
+            G.insert(0, f * G[0])
+
+        S, T = [], [ring.one]
+
+        for f, g in zip(F, G):
+            t, s = _diophantine([g, f], T[-1], [], 0, minpoly, p)
+            T.append(t)
+            S.append(s)
+
+        result, S = [], S + [T[-1]]
+
+        for s, f in zip(S, F):
+            r = _div(s.mul_monom((m, 0)), f, minpoly, p)[1]
+            s = _trunc(r, minpoly, p)
+
+            result.append(s)
+
+    return result
+
+
+def _diophantine(F, c, A, d, minpoly, p):
+    ring = c.ring
+
+    if not A:
+        S = [ring.zero for _ in F]
+        c = _trunc(c, minpoly, p)
+
+        for (exp,), coeff in c.drop_to_ground(1).iterterms():
+            T = _diophantine_univariate(F, exp, minpoly, p)
+
+            for j, (s, t) in enumerate(zip(S, T)):
+                S[j] = _trunc(s + t*coeff.set_ring(ring), minpoly, p)
+    else:
+        n = len(A)
+        e = ring.mul(F)
+
+        a, A = A[-1], A[:-1]
+        B, G = [], []
+
+        for f in F:
+            B.append(e.quo(f))
+            G.append(f.evaluate(n, a))
+
+        C = c.evaluate(n, a)
+
+        S = _diophantine(G, C, A, d, minpoly, p)
+        S = [s.set_ring(ring) for s in S]
+
+        for s, b in zip(S, B):
+            c = c - s*b
+
+        c = _trunc(c, minpoly, p)
+
+        m = ring.gens[n] - a
+        M = ring.one
+
+        for k in xrange(d):
+            if not c:
+                break
+
+            M = M * m
+            C = ring.dmp_diff_eval_in(c, k + 1, a, n)
+
+            if C:
+                C = C.quo_ground(ring.domain.factorial(k + 1))
+                T = _diophantine(G, C, A, d, minpoly, p)
+
+                for i, t in enumerate(T):
+                    T[i] = t.set_ring(ring) * M
+
+                for i, (s, t) in enumerate(zip(S, T)):
+                    S[i] = s + t
+
+                for t, b in zip(T, B):
+                    c = c - t * b
+
+                c = _trunc(c, minpoly, p)
+
+        S = [_trunc(s, minpoly, p) for s in S]
+
+    return S
+
+
+def _hensel_lift(f, H, LC, A, minpoly, p):
+    ring = f.ring
+    n = len(A)
+
+    S = [f]
+    H = list(H)
+
+    for i, a in enumerate(reversed(A[1:])):
+        s = S[0].evaluate(n - i, a)
+        S.insert(0, _trunc(s, minpoly, p))
+
+    d = max(f.degrees()[1:-1])
+
+    for j, s, a in zip(xrange(1, n + 1), S, A):
+        G = list(H)
+
+        I, J = A[:j - 1], A[j:]
+
+        Hring = f.ring
+        for _ in xrange(j, n):
+            Hring = Hring.drop(j + 1)
+
+        x = Hring.gens[0]
+        evalpoints = zip(LC[0].ring.gens[j:-1], J)
+
+        for i, (h, lc) in enumerate(zip(H, LC)):
+            if evalpoints:
+                lc = lc.evaluate(evalpoints)
+            lc = _trunc(lc, minpoly, p).set_ring(Hring)
+            H[i] = h.set_ring(Hring) + (lc - h.LC)*x**h.degree()
+
+        m = Hring.gens[j] - a
+        M = Hring.one
+
+        c = s - ring.mul(H)
+
+        dj = s.degree(j)
+
+        for k in xrange(dj):
+            if not c:
+                break
+
+            M = M * m
+            C = c.ring.dmp_diff_eval_in(c, k + 1, a, j)
+
+            if C:
+                C = C.quo_ground(ring.domain.factorial(k + 1)) # coeff of (x_{j-1} - a_{j-1})^(k + 1) in c
+                T = _diophantine(G, C, I, d, minpoly, p)
+
+                for i, (h, t) in enumerate(zip(H, T)):
+                    H[i] = _trunc(h + t.set_ring(Hring)*M, minpoly, p)
+
+                c = _trunc(s - ring.mul(H), minpoly, p)
+
+    prod = ring.mul(H)
+    if prod.rem(minpoly.set_ring(Hring)) != f:
+        return None
+    else:
+        return H
+
+
+def _sqf_p(f, minpoly, p):
+    ring = f.ring
+    lcinv, _, gcd = _gf_gcdex(ring.dmp_LC(f), minpoly, p)
+
+    f = _trunc(f * lcinv.set_ring(ring), minpoly, p)
+
+    if not f:
+        return True
+    else:
+        return _euclidean_algorithm(f, _trunc(f.diff(0), minpoly, p), minpoly, p) == 1
+
+
+def _test_prime(fA, minpoly, p, domain):
+    if fA.LC % p == 0 or minpoly.LC % p == 0:
+        return False
+    if not _sqf_p(fA, minpoly, p):
+        return False
+    if not gf_irreducible_p(minpoly.to_dense(), p, domain):
+        return False
+    return True
+
+
+# squarefree f with cont_x0(f) = 1
+def _factor(f):
+    ring = f.ring # Q(alpha)[x_0, ..., x_{n-1}]
+    lcring = ring.drop(0)
+    ground = ring.domain.domain
+    n = ring.ngens
+
+    if n == 1:
+        lc, factors = f.factor_list()
+        return (lc, [g for g, _ in factors])
+
+    z = Dummy('z')
+    qring = ring.clone(symbols=ring.symbols + (z,), domain=ground)
+    lcqring = qring.drop(0)
+
+    zring = qring.clone(domain=ground.get_ring())
+
+    minpoly = _minpoly_from_dense(ring.domain.mod, zring.drop(*zring.gens[:-1]))
+    f_ = _monic_associate(f, zring)
+    D = minpoly.resultant(minpoly.diff(0))
+
+#    # heuristic bound for p-adic lift
+#    B = f_.max_norm()
+
+    lc = zring.dmp_LC(f_)
+    gamma, lcfactors = efactor(_z_to_alpha(lc, lcring)) # over QQ(alpha)[x_1, ..., x_n]
+
+    # TODO: check if the computations of D_ and gamma_ are correct
+    D_ = zring.domain.one
+    gamma_ = gamma # in QQ(alpha)
+    lcfactors_ = []
+
+    for l, exp in lcfactors:
+        den, l_ = _alpha_to_z(l, lcqring).clear_denoms() # l_ in QQ[x_1, ..., x_n, z], but coeffs in ZZ
+        cont, l_ = l_.primitive()
+        D_ *= den
+        gamma_ *= cont
+        lcfactors_.append((l_, exp)) # polyomials over QQ, allthough coeffs are in ZZ
+
+    f_ = f_.mul_ground(D_)
+
+    N = 0
+    history = set([])
+    tries = 5 # how big should this be?
+
+    while True:
+        for _ in xrange(tries):
+            A = [random.randint(-N, N) for _ in xrange(n - 1)]
+
+            if tuple(A) not in history:
+                history.add(tuple(A))
+            else:
+                continue
+
+            result = _test_evaluation_points(f_, gamma, lcfactors, D, A)
+            if result is None:
+                continue
+            else:
+                fA, denoms, divisors = result
+
+            if any(denoms.count(denom) > 1 for denom in denoms):
+                # TODO: check interval
+                C = [random.randint(1, 3*(N + 1)) for _ in xrange(n - 1)]
+                x = zring.gens[0]
+
+                for i, ci in zip(xrange(1, n + 1), C):
+                    xi = zring.gens[i]
+                    f_ = f_.compose(xi, x + xi.mul_ground(ci))
+
+                # TODO: check if this is still squarefree
+                lc, factors = _factor(_z_to_alpha(f_, ring))
+
+                for i, ci in zip(xrange(1, n + 1), C):
+                    xi = zring.gens[i]
+                    factors = [g.compose(xi, (xi - x).quo_ground(ci)) for g in factors]
+
+                return (lc, factors)
+
+            omega_, fAfactors = _z_to_alpha(fA, ring.drop(*ring.gens[1:])).factor_list() # factorization in Q(alpha)[x_0]
+            if len(fAfactors) == 1:
+                g = _z_to_alpha(f_, ring)
+                return (f.LC, [g.monic()])
+
+            # f_ could be updated by _leading_coeffs
+            lcs = _leading_coeffs(f_, fAfactors, gamma_, lcfactors_, A, D, denoms, divisors)
+            if lcs is None:
+                continue
+            else:
+                f_, lcs = lcs
+
+            lcs_ = [_monic_associate(lc, zring.drop(0)) for lc in lcs]
+
+            prod = ring.domain.domain.one
+            for lc in lcs_:
+                prod *= lc.LC
+            q = ground(prod, f_.LC)
+            delta = ground.numer(q)
+            l_ = ground.denom(q)
+
+            f_ = f_.mul_ground(delta)
+
+            # avoid already used unlucky primes?
+            p = nextprime(200)
+            while not _test_prime(fA, minpoly, p, zring.domain):
+                p = nextprime(p)
+
+            fAfactors = [_monic_associate(g, zring.drop(*zring.gens[1:-1])) for g, _ in fAfactors]
+
+            pfactors = _hensel_lift(f_, fAfactors, lcs_, A, minpoly, p)
+            if pfactors is None:
+                continue
+
+#            factors = _padic_lift(f_, pfactors, l_, p, B, lcs, minpoly)
+#            if factors is None:
+#                B *= B
+#                continue
+
+            return (f.LC, [_z_to_alpha(g, ring).monic() for g in pfactors])
+
+        N += 1
+
+
+def _sort(factors, ring):
+    densefactors = _sort_factors([(f.to_dense(), exp) for f, exp in factors])
+    return [(ring.from_dense(f), exp) for f, exp in densefactors]
+
+
+# output of the form (lc, [(poly1, exp1), ...])
+def efactor(f):
+    ring = f.ring
+
+    assert ring.domain.is_Algebraic
+
+    if f.is_ground:
+        return (f[ring.zero_monom], [])
+
+    n = ring.ngens
+
+    if n == 1:
+        return f.factor_list()
+    else:
+        cont, f = ring.dmp_primitive(f)
+        if not cont.is_one:
+            lccont, contfactors = efactor(cont)
+            lc, factors = efactor(f)
+            contfactors = [(g.set_ring(ring), exp) for g, exp in contfactors]
+            return (lccont * lc, _sort(contfactors + factors, ring))
+
+        # this is only correct because the content in x_0 is already divided out
+        lc, sqflist = f.sqf_list()
+        factors = []
+        for g, exp in sqflist:
+            lcg, gfactors = _factor(g)
+            lc *= lcg
+            factors = factors + [(gi, exp) for gi in gfactors]
+
+        return (lc, _sort(factors, ring))

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -195,11 +195,11 @@ def _test_evaluation_points(f, gamma, lcfactors, D, A):
     ring = f.ring
     qring = ring.clone(domain=ring.domain.get_field())
 
-    lc = ring.dmp_LC(f)
-    if lc.evaluate(zip(lc.ring.gens, A)) == 0:
+    fA = f.evaluate(zip(ring.gens[1:-1], A))
+
+    if fA.degree() < f.degree():
         return None
 
-    fA = f.evaluate(zip(ring.gens[1:-1], A))
     if not fA.is_squarefree:
         return None
 
@@ -522,7 +522,7 @@ def _factor(f):
             else:
                 continue
 
-            result = _test_evaluation_points(f_, gamma, lcfactors, D, A)
+            result = _test_evaluation_points(f_, _alpha_to_z(gamma, qring), lcfactors, D, A)
             if result is None:
                 continue
             else:

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -506,6 +506,8 @@ def _factor(f):
         lcfactors_.append((l_, exp)) # polyomials over QQ, allthough coeffs are in ZZ
 
     f_ = f_.mul_ground(D_)
+    b = zring.dmp_zz_mignotte_bound(f_)
+    p = nextprime(b)
 
     N = 0
     history = set([])
@@ -564,8 +566,6 @@ def _factor(f):
 
             f_ = f_.mul_ground(delta)
 
-            # avoid already used unlucky primes?
-            p = nextprime(200)
             while not _test_prime(fA, minpoly, p, zring.domain):
                 p = nextprime(p)
 

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -538,6 +538,7 @@ def _test_prime(fA, minpoly, p, domain):
 def _factor(f):
     ring = f.ring # Q(alpha)[x_0, ..., x_{n-1}]
     lcring = ring.drop(0)
+    uniring = ring.drop(*ring.gens[1:])
     ground = ring.domain.domain
     n = ring.ngens
 
@@ -614,7 +615,7 @@ def _factor(f):
             else:
                 fA, denoms, divisors = result
 
-            _, fAfactors = _z_to_alpha(fA, ring.drop(*ring.gens[1:])).factor_list()
+            _, fAfactors = uniring.dup_ext_factor(_z_to_alpha(fA, uniring))
             if len(fAfactors) == 1:
                 g = _z_to_alpha(f_, ring)
                 return (f.LC, [g.monic()])
@@ -674,7 +675,7 @@ def efactor(f):
     n = ring.ngens
 
     if n == 1:
-        return f.factor_list()
+        return ring.dup_ext_factor(f)
     else:
         cont, f = ring.dmp_primitive(f)
         if not cont.is_one:

--- a/sympy/polys/factorization_alg_field.py
+++ b/sympy/polys/factorization_alg_field.py
@@ -4,6 +4,7 @@ from sympy import Dummy
 import random
 
 from sympy.ntheory import nextprime
+from sympy.core.compatibility import xrange
 from sympy.integrals.heurisch import _symbols
 from sympy.polys.galoistools import gf_irreducible_p
 from sympy.polys.modulargcd import _trunc, _gf_gcdex, _minpoly_from_dense, _euclidean_algorithm
@@ -278,7 +279,7 @@ def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
     for j in xrange(n):
         lj = lcs[j]
         dj = denominators[j]
-        ljA = lj.evaluate(zip(lcring.gens, A))
+        ljA = lj.evaluate(list(zip(lcring.gens, A)))
 
         lcs[j] = lj.mul_ground(dj)
         U[j] = U[j].mul_ground(dj).set_ring(zring) * ljA.set_ring(zring)
@@ -352,7 +353,7 @@ def _test_evaluation_points(f, gamma, lcfactors, A, D):
     omega = gamma * D
     denoms = []
     for l, _ in lcfactors:
-        lA = l.evaluate(zip(l.ring.gens, A)) # in Q(alpha)
+        lA = l.evaluate(list(zip(l.ring.gens, A))) # in Q(alpha)
         denoms.append(_denominator(_alpha_to_z(lA**(-1), qring)))
 
     if any(denoms.count(denom) > 1 for denom in denoms):
@@ -492,7 +493,7 @@ def _padic_lift(f, pfactors, lcs, B, minpoly, p):
                 solution[k] = v.trunc_ground(P)
 
         solution = _choose_particular_solution(solution, coeffring)
-        subs = solution.items()
+        subs = list(solution.items())
 
         H = [h + _subs_ground(s, subs).mul_ground(P) for h, s in zip(H, S)]
         P = P**2
@@ -749,7 +750,7 @@ def _hensel_lift(f, H, LC, A, minpoly, p):
             Hring = Hring.drop(j + 1)
 
         x = Hring.gens[0]
-        evalpoints = zip(LC[0].ring.gens[j:-1], J)
+        evalpoints = list(zip(LC[0].ring.gens[j:-1], J))
 
         for i, (h, lc) in enumerate(zip(H, LC)):
             if evalpoints:

--- a/sympy/polys/polyerrors.py
+++ b/sympy/polys/polyerrors.py
@@ -72,9 +72,6 @@ class HeuristicGCDFailed(BasePolynomialError):
 class ModularGCDFailed(BasePolynomialError):
     pass
 
-class UnluckyMinimalPolynomial(BasePolynomialError):
-    pass
-
 class UnluckyLeadingCoefficient(BasePolynomialError):
     pass
 

--- a/sympy/polys/polyerrors.py
+++ b/sympy/polys/polyerrors.py
@@ -72,6 +72,9 @@ class HeuristicGCDFailed(BasePolynomialError):
 class ModularGCDFailed(BasePolynomialError):
     pass
 
+class UnluckyMinimalPolynomial(BasePolynomialError):
+    pass
+
 class UnluckyLeadingCoefficient(BasePolynomialError):
     pass
 

--- a/sympy/polys/polyerrors.py
+++ b/sympy/polys/polyerrors.py
@@ -72,6 +72,9 @@ class HeuristicGCDFailed(BasePolynomialError):
 class ModularGCDFailed(BasePolynomialError):
     pass
 
+class UnluckyLeadingCoefficient(BasePolynomialError):
+    pass
+
 @public
 class HomomorphismFailed(BasePolynomialError):
     pass

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -32,9 +32,9 @@ def solve_lin_sys(eqs, ring, iszerofunc=lambda x: not x, scalefunc=None, elimfun
     For example, a linear system of integer equations can be solved over
     `\mathbb Z_p` by defining those functions as:
 
-        iszerofunc = lambda x: not (x % p)
-        scalefunc = lambda x, _, scale: (x * invert(scale, p)) % p
-        elimfunc = lambda x, y, scale: (x - scale*y) % p
+        |  iszerofunc = lambda x: not (x % p)
+        |  scalefunc = lambda x, _, scale: (x * invert(scale, p)) % p
+        |  elimfunc = lambda x, y, scale: (x - scale*y) % p
 
     Note that ``scalefunc`` and ``elimfunc`` have to take three arguments,
     where the third one has to be named ``scale``.

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -19,15 +19,18 @@ def eqs_to_matrix(eqs, ring):
 
     return M
 
-def solve_lin_sys(eqs, ring):
+def solve_lin_sys(eqs, ring, modulus=None):
     """Solve a system of linear equations. """
-    assert ring.domain.has_Field
+    assert ring.domain.has_Field or modulus
 
     # transform from equations to matrix form
     matrix = eqs_to_matrix(eqs, ring)
 
     # solve by row-reduction
-    echelon, pivots = matrix.rref(iszerofunc=lambda x: not x, simplify=lambda x: x)
+    if modulus:
+        echelon, pivots = matrix.rref(simplify=lambda x: x, modulus=modulus)
+    else:
+        echelon, pivots = matrix.rref(iszerofunc=lambda x: not x, simplify=lambda x: x)
 
     # construct the returnable form of the solutions
     xs = ring.gens
@@ -43,4 +46,7 @@ def solve_lin_sys(eqs, ring):
             vect = RawMatrix([ [-x] for x in xs[p+1:] ] + [[ring.one]])
             sols[xs[p]] = (echelon[i, p+1:]*vect)[0]
 
+        if modulus:
+            for k, v in sols.items():
+                sols[k] = v.trunc_ground(modulus)
         return sols

--- a/sympy/polys/tests/test_factorization_alg_field.py
+++ b/sympy/polys/tests/test_factorization_alg_field.py
@@ -1,0 +1,104 @@
+from sympy.polys.factorization_alg_field import efactor
+from sympy.polys.domains import AlgebraicField, QQ
+from sympy import sqrt, I, ring
+from sympy.utilities.pytest import slow
+
+def test_efactor():
+    A = AlgebraicField(QQ, sqrt(2))
+    R, x, y = ring('x, y', A)
+
+    f = (x**2 + sqrt(2)*y)
+    assert efactor(f) == (A.one, [(f, 1)])
+
+    f1 = x + y
+    f2 = x**2 + sqrt(2)*y
+    f = f1 * f2
+
+    assert efactor(f) == (A.one, [(f1, 1), (f2, 1)])
+
+    A = AlgebraicField(QQ, sqrt(3))
+    R, x, y, z = ring('x, y, z', A)
+
+    f1 = z + 1
+    f2 = A([QQ(3, 4)])*x*y**2 + sqrt(3)
+    f3 = sqrt(3)*y*x**2 + 2*y + z
+    f = f1 * f2**2 * f3
+
+    lc2 = f2.LC
+    lc3 = f3.LC
+
+    assert efactor(f) == (lc2**2*lc3, [(f1, 1), (f2.quo_ground(lc2), 2),
+        (f3.quo_ground(lc3), 1)])
+
+    A = AlgebraicField(QQ, I)
+    R, x, y = ring('x, y', A)
+
+    f1 = x*(y + 1) + 1
+    f2 = x*(y + I) + 1
+    f3 = x**2*(y - I) + 1
+    f = f1*f2*f3
+
+    assert efactor(f) == (A.one, [(f1, 1), (f2, 1), (f3, 1)])
+
+    lc = -A([2])
+    f1 = x*(y - 3*I) + lc**(-1)
+    f2 = x*(y + I) + 1
+    f3 = x*(y + 2) + 1
+    f = lc*f1*f2*f3
+
+    assert efactor(f) == (lc, [(f1, 1), (f2, 1), (f3, 1)])
+
+    A = AlgebraicField(QQ, sqrt(8))
+    R, x, y = ring('x, y', A)
+
+    f = (x - sqrt(8)/2)*(x + sqrt(8)/2)
+
+    assert efactor(f) == f.factor_list()
+
+    A = AlgebraicField(QQ, sqrt(3))
+    R, x, y, z, t = ring('x, y, z, t', A)
+
+    f1 = z*t + 1
+    f2 = x*y - sqrt(3)
+    f3 = x**2 + 1
+    f4 = x**2 + z*t
+    f = f1*f2*f3*f4
+
+    assert efactor(f) == (A.one, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])
+
+    a = QQ(1, 2)*sqrt(2)*(1 + I)
+    A = AlgebraicField(QQ, a)
+    R, x, y = ring('x, y', A)
+
+    f = x**4 + y**4
+
+    f1 = x - a*y
+    f2 = x - a**3*y
+    f3 = x + a*y
+    f4 = x + a**3*y
+
+    assert efactor(f) == (A.one, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])
+
+
+@slow
+def test_efactor_wang():
+    a = QQ(1, 4)*(-1 + sqrt(5)) - I*sqrt(QQ(1, 8)*(sqrt(5) + 5))
+    A = AlgebraicField(QQ, a)
+    R, x, y, z = ring('x, y, z', A)
+
+    f = x**8 + 2*x**7 - (y + z**2 + 8)*x**6 + 2*(-2*y + 3*z**2 - 20)*x**5 + \
+        (y**2 + 2*(z**2 - 24)*y + z**4 + 32*z**2 + 256)*x**4 + \
+        (-4*y**2 + 2*(z**2 + 16)*y - 4*z**4 + 32*z**2 + 960)*x**3 + \
+        (-y**3 + (-3*z**2 + 28)*y**2 + 2*(z**4 - 2*z**2 + 192)*y - z**6 -
+        32*z**4 + 144*z**2 - 1152)*x**2 + (2*y**3 + 4*(-z**2 + 18)*y**2 +
+        6*(z**4 + 4*z**2 - 96)*y + 2*z**6 - 48*z**4 - 576*z**2 + 3456)*x + \
+        y**4 - (z**2 + 12)*y**3 + (z**4 + 24*z**2 + 144)*y**2 - \
+        (z**6 - 24*z**4 + 432*z**2 + 1728)*y + z**8 - 12*z**6 + 144*z**4 - \
+        1728*z**2 + 20736
+
+    f1 = x**2 - 2*a*x - (a**3 + a**2 + a + 1)*z**2 + a**2*y + 12*a**3
+    f2 = x**2 - 2*a**2*x + a**3*z**2 - (a**3 + a**2 + a + 1)*y + 12*a
+    f3 = x**2 - 2*a**3*x + a**2*z**2 + a*y - 12*(a**3 + a**2 + a + 1)
+    f4 = x**2 + 2*(a**3 + a**2 + a + 1)*x + a*z**2 + a**3*y + 12*a**2
+
+    assert efactor(f) == (A.one, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])

--- a/sympy/polys/tests/test_factorization_alg_field.py
+++ b/sympy/polys/tests/test_factorization_alg_field.py
@@ -16,6 +16,12 @@ def test_efactor():
 
     assert efactor(f) == (A.one, [(f1, 1), (f2, 1)])
 
+    f1 = x + 2**10*y
+    f2 = x**2 + sqrt(2)*y
+    f = f1 * f2
+
+    assert efactor(f) == (A.one, [(f1, 1), (f2, 1)])
+
     A = AlgebraicField(QQ, sqrt(3))
     R, x, y, z = ring('x, y, z', A)
 

--- a/sympy/polys/tests/test_factorization_alg_field.py
+++ b/sympy/polys/tests/test_factorization_alg_field.py
@@ -1,6 +1,6 @@
 from sympy.polys.factorization_alg_field import efactor
 from sympy.polys.domains import AlgebraicField, QQ
-from sympy import sqrt, I, ring
+from sympy import sqrt, I, ring, S
 from sympy.utilities.pytest import slow
 
 def test_efactor():
@@ -26,7 +26,7 @@ def test_efactor():
     R, x, y, z = ring('x, y, z', A)
 
     f1 = z + 1
-    f2 = A([QQ(3, 4)])*x*y**2 + sqrt(3)
+    f2 = S(3)/4*x*y**2 + sqrt(3)
     f3 = sqrt(3)*y*x**2 + 2*y + z
     f = f1 * f2**2 * f3
 
@@ -46,7 +46,7 @@ def test_efactor():
 
     assert efactor(f) == (A.one, [(f1, 1), (f2, 1), (f3, 1)])
 
-    lc = -A([2])
+    lc = -A(2)
     f1 = x*(y - 3*I) + lc**(-1)
     f2 = x*(y + I) + 1
     f3 = x*(y + 2) + 1
@@ -72,7 +72,7 @@ def test_efactor():
 
     assert efactor(f) == (A.one, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])
 
-    a = QQ(1, 2)*sqrt(2)*(1 + I)
+    a = S(1)/2*sqrt(2)*(1 + I)
     A = AlgebraicField(QQ, a)
     R, x, y = ring('x, y', A)
 
@@ -88,7 +88,7 @@ def test_efactor():
 
 @slow
 def test_efactor_wang():
-    a = QQ(1, 4)*(-1 + sqrt(5)) - I*sqrt(QQ(1, 8)*(sqrt(5) + 5))
+    a = S(1)/4*(-1 + sqrt(5)) - I*sqrt(S(1)/8*(sqrt(5) + 5))
     A = AlgebraicField(QQ, a)
     R, x, y, z = ring('x, y, z', A)
 

--- a/sympy/polys/tests/test_factorization_alg_field.py
+++ b/sympy/polys/tests/test_factorization_alg_field.py
@@ -1,7 +1,15 @@
-from sympy.polys.factorization_alg_field import efactor
-from sympy.polys.domains import AlgebraicField, QQ
+from sympy.polys.factorization_alg_field import efactor, _distinct_prime_divisors
+from sympy.polys.domains import AlgebraicField, QQ, ZZ
 from sympy import sqrt, I, ring, S
 from sympy.utilities.pytest import slow
+
+def test_distinct_prime_divisors():
+    S = [20, 6, 7]
+    assert _distinct_prime_divisors(S, ZZ) == [5, 3, 7]
+
+    S = [15, 18, 11]
+    assert _distinct_prime_divisors(S, ZZ) == [5, 2, 11]
+
 
 def test_efactor():
     A = AlgebraicField(QQ, sqrt(2))

--- a/sympy/polys/tests/test_factorization_alg_field.py
+++ b/sympy/polys/tests/test_factorization_alg_field.py
@@ -62,13 +62,6 @@ def test_efactor():
 
     assert efactor(f) == (lc, [(f1, 1), (f2, 1), (f3, 1)])
 
-    A = AlgebraicField(QQ, sqrt(8))
-    R, x, y = ring('x, y', A)
-
-    f = (x - sqrt(8)/2)*(x + sqrt(8)/2)
-
-    assert efactor(f) == f.factor_list()
-
     A = AlgebraicField(QQ, sqrt(3))
     R, x, y, z, t = ring('x, y, z, t', A)
 


### PR DESCRIPTION
This is the third and last part of my GSoC project. It implements an improved algorithm for factorization of multivariate polynomials over algebraic number fields.

If the algebraic field is of small degree, the currently used algorithm by Trager will sometimes still be faster:

```
In [3]: A = AlgebraicField(QQ, sqrt(2))
In [4]: R, x, y = ring('x, y', A)
In [5]: f1, f2 = x + y, x**2 + sqrt(2)*y
In [6]: f = f1*f2

In [7]: %timeit efactor(f)
10 loops, best of 3: 64 ms per loop

In [8]: %timeit f.factor_list()
10 loops, best of 3: 35.6 ms per loop
```

But if the degree of the extension is higher, the new algorithm is clearly the better choice: 

```
In [12]: A = AlgebraicField(QQ, 2**(S(1)/5))
In [13]: R, x, y, z = ring('x, y, z', A)
In [14]: f1, f2 = x - y, x**2*y + 2**(S(1)/5)*y**2*z
In [15]: f = f1*f2

In [16]: %timeit efactor(f)
10 loops, best of 3: 105 ms per loop

In [17]: %timeit f.factor_list()
1 loops, best of 3: 873 ms per loop

In [18]: A = AlgebraicField(QQ, sqrt(2), 3**(S(1)/3))
In [19]: R, x, y, z = ring('x, y, z', A)
In [20]: f1, f2 = x**2 + 2*y + sqrt(2), 3**(S(1)/3)*x - z
In [21]: f = f1*f2

In [22]: %timeit efactor(f)
1 loops, best of 3: 647 ms per loop

In [23]: %timeit f.factor_list()
1 loops, best of 3: 99 s per loop
```

Most of the commits are in the polys module. The two commits b5986e84801a305fafc51827ca40ef010d322925 and f52f756b911c529c41c303924542ebf8d0f98f4c make a few modifications to the rref code in matrices.py.
