### PR TITLE
Fix for issue 3987 with deltaproduct.

### DIFF
--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -1,10 +1,12 @@
 from __future__ import print_function, division
 
 from sympy.core import Add, Interval, Mul, S, Dummy, symbols
+from sympy.core.cache import cacheit
 from sympy.core.compatibility import default_sort_key
 from sympy.functions import KroneckerDelta, Piecewise, piecewise_fold
 
 
+@cacheit
 def _expand_delta(expr, index):
     """
     Expand the first Add containing a simple KroneckerDelta.
@@ -24,6 +26,7 @@ def _expand_delta(expr, index):
     return func(*terms)
 
 
+@cacheit
 def _extract_delta(expr, index):
     """
     Extract a simple KroneckerDelta from the expression.
@@ -71,6 +74,7 @@ def _extract_delta(expr, index):
     return (delta, expr.func(*terms))
 
 
+@cacheit
 def _has_simple_delta(expr, index):
     """
     Returns True if ``expr`` is an expression that contains a KroneckerDelta
@@ -87,6 +91,7 @@ def _has_simple_delta(expr, index):
     return False
 
 
+@cacheit
 def _is_simple_delta(delta, index):
     """
     Returns True if ``delta`` is a KroneckerDelta and is nonzero for a single
@@ -99,6 +104,7 @@ def _is_simple_delta(delta, index):
     return False
 
 
+@cacheit
 def _remove_multiple_delta(expr):
     """
     Evaluate products of KroneckerDelta's.
@@ -129,6 +135,7 @@ def _remove_multiple_delta(expr):
     return expr
 
 
+@cacheit
 def _simplify_delta(expr):
     """
     Rewrite a KroneckerDelta's indices in its simplest form.
@@ -145,6 +152,7 @@ def _simplify_delta(expr):
     return expr
 
 
+@cacheit
 def deltaproduct(f, limit):
     """
     Handle products containing a KroneckerDelta.
@@ -207,6 +215,7 @@ def deltaproduct(f, limit):
         S.One*_simplify_delta(KroneckerDelta(limit[2], limit[1] - 1))
 
 
+@cacheit
 def deltasummation(f, limit, no_piecewise=False):
     """
     Handle summations containing a KroneckerDelta.

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -193,7 +193,9 @@ def deltaproduct(f, limit):
             result = deltaproduct(newexpr, limit) + deltasummation(
                 deltaproduct(newexpr, (limit[0], limit[1], k - 1)) *
                 delta.subs(limit[0], k) *
-                deltaproduct(newexpr, (limit[0], k + 1, limit[2])), (k, limit[1], limit[2]), no_piecewise=True
+                deltaproduct(newexpr, (limit[0], k + 1, limit[2])),
+                (k, limit[1], limit[2]),
+                no_piecewise=_has_simple_delta(newexpr, limit[0])
             )
         return _remove_multiple_delta(result)
 

--- a/sympy/concrete/tests/test_delta.py
+++ b/sympy/concrete/tests/test_delta.py
@@ -7,11 +7,12 @@ from sympy.logic import And
 i, j, k, l, m = symbols("i j k l m", integer=True)
 x, y = symbols("x y", commutative=False)
 
+dp = deltaproduct
+ds = deltasummation
 KD = KroneckerDelta
 
 
-def test_deltaproduct():
-    dp = deltaproduct
+def test_deltaproduct_trivial():
     assert dp(x, (j, 1, 0)) == 1
     assert dp(x, (j, 1, 3)) == x**3
     assert dp(x + y, (j, 1, 3)) == (x + y)**3
@@ -20,6 +21,7 @@ def test_deltaproduct():
     assert dp(x*KD(i, j), (k, 1, 3)) == x**3*KD(i, j)
     assert dp(x*y*KD(i, j), (k, 1, 3)) == (x*y)**3*KD(i, j)
 
+def test_deltaproduct_basic():
     assert dp(KD(i, j), (j, 1, 3)) == 0
     assert dp(KD(i, j), (j, 1, 1)) == KD(i, 1)
     assert dp(KD(i, j), (j, 2, 2)) == KD(i, 2)
@@ -28,6 +30,7 @@ def test_deltaproduct():
     assert dp(KD(i, j), (j, k, 3)) == KD(i, 3)*KD(k, 3) + KD(k, 4)
     assert dp(KD(i, j), (j, k, l)) == KD(i, l)*KD(k, l) + KD(k, l + 1)
 
+def test_deltaproduct_mul_x_kd():
     assert dp(x*KD(i, j), (j, 1, 3)) == 0
     assert dp(x*KD(i, j), (j, 1, 1)) == x*KD(i, 1)
     assert dp(x*KD(i, j), (j, 2, 2)) == x*KD(i, 2)
@@ -36,6 +39,7 @@ def test_deltaproduct():
     assert dp(x*KD(i, j), (j, k, 3)) == x*KD(i, 3)*KD(k, 3) + KD(k, 4)
     assert dp(x*KD(i, j), (j, k, l)) == x*KD(i, l)*KD(k, l) + KD(k, l + 1)
 
+def test_deltaproduct_mul_add_x_y_kd():
     assert dp((x + y)*KD(i, j), (j, 1, 3)) == 0
     assert dp((x + y)*KD(i, j), (j, 1, 1)) == (x + y)*KD(i, 1)
     assert dp((x + y)*KD(i, j), (j, 2, 2)) == (x + y)*KD(i, 2)
@@ -47,6 +51,7 @@ def test_deltaproduct():
     assert dp((x + y)*KD(i, j), (j, k, l)) == \
         (x + y)*KD(i, l)*KD(k, l) + KD(k, l + 1)
 
+def test_deltaproduct_add_kd_kd():
     assert dp(KD(i, k) + KD(j, k), (k, 1, 3)) == 0
     assert dp(KD(i, k) + KD(j, k), (k, 1, 1)) == KD(i, 1) + KD(j, 1)
     assert dp(KD(i, k) + KD(j, k), (k, 2, 2)) == KD(i, 2) + KD(j, 2)
@@ -61,6 +66,7 @@ def test_deltaproduct():
         KD(i, m)*KD(l, m) + KD(j, m)*KD(l, m) + \
         KD(i, m)*KD(j, m - 1)*KD(l, m - 1) + KD(i, m - 1)*KD(j, m)*KD(l, m - 1)
 
+def test_deltaproduct_mul_x_add_kd_kd():
     assert dp(x*(KD(i, k) + KD(j, k)), (k, 1, 3)) == 0
     assert dp(x*(KD(i, k) + KD(j, k)), (k, 1, 1)) == x*(KD(i, 1) + KD(j, 1))
     assert dp(x*(KD(i, k) + KD(j, k)), (k, 2, 2)) == x*(KD(i, 2) + KD(j, 2))
@@ -76,6 +82,7 @@ def test_deltaproduct():
         x**2*KD(i, m - 1)*KD(j, m)*KD(l, m - 1) + \
         x**2*KD(i, m)*KD(j, m - 1)*KD(l, m - 1)
 
+def test_deltaproduct_mul_add_x_y_add_kd_kd():
     assert dp((x + y)*(KD(i, k) + KD(j, k)), (k, 1, 3)) == 0
     assert dp((x + y)*(KD(i, k) + KD(j, k)), (k, 1, 1)) == \
         (x + y)*(KD(i, 1) + KD(j, 1))
@@ -96,6 +103,7 @@ def test_deltaproduct():
         (x + y)**2*KD(i, m - 1)*KD(j, m)*KD(l, m - 1) + \
         (x + y)**2*KD(i, m)*KD(j, m - 1)*KD(l, m - 1)
 
+def test_deltaproduct_add_mul_x_y_mul_x_kd():
     assert dp(x*y + x*KD(i, j), (j, 1, 3)) == (x*y)**3 + \
         x*(x*y)**2*KD(i, 1) + (x*y)*x*(x*y)*KD(i, 2) + (x*y)**2*x*KD(i, 3)
     assert dp(x*y + x*KD(i, j), (j, 1, 1)) == x*y + x*KD(i, 1)
@@ -108,6 +116,7 @@ def test_deltaproduct():
     assert dp(x*y + x*KD(i, j), (j, k, l)) == \
         (x*y)**(-k + l + 1) + (x*y)**(i - k)*x*(x*y)**(l - i)
 
+def test_deltaproduct_mul_x_add_y_kd():
     assert dp(x*(y + KD(i, j)), (j, 1, 3)) == (x*y)**3 + \
         x*(x*y)**2*KD(i, 1) + (x*y)*x*(x*y)*KD(i, 2) + (x*y)**2*x*KD(i, 3)
     assert dp(x*(y + KD(i, j)), (j, 1, 1)) == x*(y + KD(i, 1))
@@ -120,6 +129,7 @@ def test_deltaproduct():
     assert dp(x*(y + KD(i, j)), (j, k, l)) == \
         (x*y)**(-k + l + 1) + (x*y)**(i - k)*x*(x*y)**(l - i)
 
+def test_deltaproduct_mul_x_add_y_twokd():
     assert dp(x*(y + 2*KD(i, j)), (j, 1, 3)) == (x*y)**3 + \
         2*x*(x*y)**2*KD(i, 1) + 2*x*y*x*x*y*KD(i, 2) + 2*(x*y)**2*x*KD(i, 3)
     assert dp(x*(y + 2*KD(i, j)), (j, 1, 1)) == x*(y + 2*KD(i, 1))
@@ -132,6 +142,7 @@ def test_deltaproduct():
     assert dp(x*(y + 2*KD(i, j)), (j, k, l)) == \
         (x*y)**(-k + l + 1) + 2*(x*y)**(i - k)*x*(x*y)**(l - i)
 
+def test_deltaproduct_mul_add_x_y_add_y_kd():
     assert dp((x + y)*(y + KD(i, j)), (j, 1, 3)) == ((x + y)*y)**3 + \
         (x + y)*((x + y)*y)**2*KD(i, 1) + \
         (x + y)*y*(x + y)**2*y*KD(i, 2) + \
@@ -147,6 +158,7 @@ def test_deltaproduct():
         ((x + y)*y)**(-k + l + 1) + \
         ((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(l - i)
 
+def test_deltaproduct_mul_add_x_kd_add_y_kd():
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, 1, 3)) == \
         KD(i, 1)*(KD(i, k) + x)*((KD(i, k) + x)*y)**2 + \
         KD(i, 2)*(KD(i, k) + x)*y*(KD(i, k) + x)**2*y + \
@@ -169,8 +181,7 @@ def test_deltaproduct():
         ((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*((x + KD(i, k))*y)**(-i + l)
 
 
-def test_deltasummation():
-    ds = deltasummation
+def test_deltasummation_trivial():
     assert ds(x, (j, 1, 0)) == 0
     assert ds(x, (j, 1, 3)) == 3*x
     assert ds(x + y, (j, 1, 3)) == 3*(x + y)
@@ -179,6 +190,7 @@ def test_deltasummation():
     assert ds(x*KD(i, j), (k, 1, 3)) == 3*x*KD(i, j)
     assert ds(x*y*KD(i, j), (k, 1, 3)) == 3*x*y*KD(i, j)
 
+def test_deltasummation_basic_numerical():
     n = symbols('n', integer=True, nonzero=True)
     assert ds(KD(n, 0), (n, 1, 3)) == 0
 
@@ -200,6 +212,7 @@ def test_deltasummation():
     assert ds(x, (i, 1, 3)) == 3*x
     assert ds((i + j)*KD(i, j), (j, -oo, oo)) == 2*i
 
+def test_deltasummation_basic_symbolic():
     assert ds(KD(i, j), (j, 1, 3)) == \
         Piecewise((1, And(S(1) <= i, i <= 3)), (0, True))
     assert ds(KD(i, j), (j, 1, 1)) == Piecewise((1, Eq(i, 1)), (0, True))
@@ -212,6 +225,7 @@ def test_deltasummation():
     assert ds(KD(i, j), (j, k, l)) == \
         Piecewise((1, And(k <= i, i <= l)), (0, True))
 
+def test_deltasummation_mul_x_kd():
     assert ds(x*KD(i, j), (j, 1, 3)) == \
         Piecewise((x, And(S(1) <= i, i <= 3)), (0, True))
     assert ds(x*KD(i, j), (j, 1, 1)) == Piecewise((x, Eq(i, 1)), (0, True))
@@ -224,6 +238,7 @@ def test_deltasummation():
     assert ds(x*KD(i, j), (j, k, l)) == \
         Piecewise((x, And(k <= i, i <= l)), (0, True))
 
+def test_deltasummation_mul_add_x_y_kd():
     assert ds((x + y)*KD(i, j), (j, 1, 3)) == \
         Piecewise((x + y, And(S(1) <= i, i <= 3)), (0, True))
     assert ds((x + y)*KD(i, j), (j, 1, 1)) == \
@@ -239,6 +254,7 @@ def test_deltasummation():
     assert ds((x + y)*KD(i, j), (j, k, l)) == \
         Piecewise((x + y, And(k <= i, i <= l)), (0, True))
 
+def test_deltasummation_add_kd_kd():
     assert ds(KD(i, k) + KD(j, k), (k, 1, 3)) == piecewise_fold(
         Piecewise((1, And(S(1) <= i, i <= 3)), (0, True)) +
         Piecewise((1, And(S(1) <= j, j <= 3)), (0, True)))
@@ -261,6 +277,7 @@ def test_deltasummation():
         Piecewise((1, And(l <= i, i <= m)), (0, True)) +
         Piecewise((1, And(l <= j, j <= m)), (0, True)))
 
+def test_deltasummation_add_mul_x_kd_kd():
     assert ds(x*KD(i, k) + KD(j, k), (k, 1, 3)) == piecewise_fold(
         Piecewise((x, And(S(1) <= i, i <= 3)), (0, True)) +
         Piecewise((1, And(S(1) <= j, j <= 3)), (0, True)))
@@ -283,6 +300,7 @@ def test_deltasummation():
         Piecewise((x, And(l <= i, i <= m)), (0, True)) +
         Piecewise((1, And(l <= j, j <= m)), (0, True)))
 
+def test_deltasummation_mul_x_add_kd_kd():
     assert ds(x*(KD(i, k) + KD(j, k)), (k, 1, 3)) == piecewise_fold(
         Piecewise((x, And(S(1) <= i, i <= 3)), (0, True)) +
         Piecewise((x, And(S(1) <= j, j <= 3)), (0, True)))
@@ -305,6 +323,7 @@ def test_deltasummation():
         Piecewise((x, And(l <= i, i <= m)), (0, True)) +
         Piecewise((x, And(l <= j, j <= m)), (0, True)))
 
+def test_deltasummation_mul_add_x_y_add_kd_kd():
     assert ds((x + y)*(KD(i, k) + KD(j, k)), (k, 1, 3)) == piecewise_fold(
         Piecewise((x + y, And(S(1) <= i, i <= 3)), (0, True)) +
         Piecewise((x + y, And(S(1) <= j, j <= 3)), (0, True)))
@@ -327,6 +346,7 @@ def test_deltasummation():
         Piecewise((x + y, And(l <= i, i <= m)), (0, True)) +
         Piecewise((x + y, And(l <= j, j <= m)), (0, True)))
 
+def test_deltasummation_add_mul_x_y_mul_x_kd():
     assert ds(x*y + x*KD(i, j), (j, 1, 3)) == \
         Piecewise((3*x*y + x, And(S(1) <= i, i <= 3)), (3*x*y, True))
     assert ds(x*y + x*KD(i, j), (j, 1, 1)) == \
@@ -342,6 +362,7 @@ def test_deltasummation():
     assert ds(x*y + x*KD(i, j), (j, k, l)) == Piecewise(
         ((l - k + 1)*x*y + x, And(k <= i, i <= l)), ((l - k + 1)*x*y, True))
 
+def test_deltasummation_mul_x_add_y_kd():
     assert ds(x*(y + KD(i, j)), (j, 1, 3)) == \
         Piecewise((3*x*y + x, And(S(1) <= i, i <= 3)), (3*x*y, True))
     assert ds(x*(y + KD(i, j)), (j, 1, 1)) == \
@@ -357,6 +378,7 @@ def test_deltasummation():
     assert ds(x*(y + KD(i, j)), (j, k, l)) == Piecewise(
         ((l - k + 1)*x*y + x, And(k <= i, i <= l)), ((l - k + 1)*x*y, True))
 
+def test_deltasummation_mul_x_add_y_twokd():
     assert ds(x*(y + 2*KD(i, j)), (j, 1, 3)) == \
         Piecewise((3*x*y + 2*x, And(S(1) <= i, i <= 3)), (3*x*y, True))
     assert ds(x*(y + 2*KD(i, j)), (j, 1, 1)) == \
@@ -372,6 +394,7 @@ def test_deltasummation():
     assert ds(x*(y + 2*KD(i, j)), (j, k, l)) == Piecewise(
         ((l - k + 1)*x*y + 2*x, And(k <= i, i <= l)), ((l - k + 1)*x*y, True))
 
+def test_deltasummation_mul_add_x_y_add_y_kd():
     assert ds((x + y)*(y + KD(i, j)), (j, 1, 3)) == Piecewise(
         (3*(x + y)*y + x + y, And(S(1) <= i, i <= 3)), (3*(x + y)*y, True))
     assert ds((x + y)*(y + KD(i, j)), (j, 1, 1)) == \
@@ -389,6 +412,7 @@ def test_deltasummation():
         ((l - k + 1)*(x + y)*y + x + y, And(k <= i, i <= l)),
         ((l - k + 1)*(x + y)*y, True))
 
+def test_deltasummation_mul_add_x_kd_add_y_kd():
     assert ds((x + KD(i, k))*(y + KD(i, j)), (j, 1, 3)) == piecewise_fold(
         Piecewise((KD(i, k) + x, And(S(1) <= i, i <= 3)), (0, True)) +
         3*(KD(i, k) + x)*y)

--- a/sympy/concrete/tests/test_delta.py
+++ b/sympy/concrete/tests/test_delta.py
@@ -110,11 +110,20 @@ def test_deltaproduct_add_mul_x_y_mul_x_kd():
     assert dp(x*y + x*KD(i, j), (j, 2, 2)) == x*y + x*KD(i, 2)
     assert dp(x*y + x*KD(i, j), (j, 3, 3)) == x*y + x*KD(i, 3)
     assert dp(x*y + x*KD(i, j), (j, 1, k)) == \
-        (x*y)**k + (x*y)**(i - 1)*x*(x*y)**(k - i)
+        (x*y)**k + Piecewise(
+            ((x*y)**(i - 1)*x*(x*y)**(k - i), And(S(1) <= i, i <= k)),
+            (0, True)
+        )
     assert dp(x*y + x*KD(i, j), (j, k, 3)) == \
-        (x*y)**(-k + 4) + (x*y)**(i - k)*x*(x*y)**(3 - i)
+        (x*y)**(-k + 4) + Piecewise(
+            ((x*y)**(i - k)*x*(x*y)**(3 - i), And(k <= i, i <= 3)),
+            (0, True)
+        )
     assert dp(x*y + x*KD(i, j), (j, k, l)) == \
-        (x*y)**(-k + l + 1) + (x*y)**(i - k)*x*(x*y)**(l - i)
+        (x*y)**(-k + l + 1) + Piecewise(
+            ((x*y)**(i - k)*x*(x*y)**(l - i), And(k <= i, i <= l)),
+            (0, True)
+        )
 
 def test_deltaproduct_mul_x_add_y_kd():
     assert dp(x*(y + KD(i, j)), (j, 1, 3)) == (x*y)**3 + \
@@ -123,11 +132,20 @@ def test_deltaproduct_mul_x_add_y_kd():
     assert dp(x*(y + KD(i, j)), (j, 2, 2)) == x*(y + KD(i, 2))
     assert dp(x*(y + KD(i, j)), (j, 3, 3)) == x*(y + KD(i, 3))
     assert dp(x*(y + KD(i, j)), (j, 1, k)) == \
-        (x*y)**k + (x*y)**(i - 1)*x*(x*y)**(k - i)
+        (x*y)**k + Piecewise(
+            ((x*y)**(i - 1)*x*(x*y)**(k - i), And(S(1) <= i, i <= k)),
+            (0, True)
+        )
     assert dp(x*(y + KD(i, j)), (j, k, 3)) == \
-        (x*y)**(-k + 4) + (x*y)**(i - k)*x*(x*y)**(3 - i)
+        (x*y)**(-k + 4) + Piecewise(
+            ((x*y)**(i - k)*x*(x*y)**(3 - i), And(k <= i, i <= 3)),
+            (0, True)
+        )
     assert dp(x*(y + KD(i, j)), (j, k, l)) == \
-        (x*y)**(-k + l + 1) + (x*y)**(i - k)*x*(x*y)**(l - i)
+        (x*y)**(-k + l + 1) + Piecewise(
+            ((x*y)**(i - k)*x*(x*y)**(l - i), And(k <= i, i <= l)),
+            (0, True)
+        )
 
 def test_deltaproduct_mul_x_add_y_twokd():
     assert dp(x*(y + 2*KD(i, j)), (j, 1, 3)) == (x*y)**3 + \
@@ -136,11 +154,20 @@ def test_deltaproduct_mul_x_add_y_twokd():
     assert dp(x*(y + 2*KD(i, j)), (j, 2, 2)) == x*(y + 2*KD(i, 2))
     assert dp(x*(y + 2*KD(i, j)), (j, 3, 3)) == x*(y + 2*KD(i, 3))
     assert dp(x*(y + 2*KD(i, j)), (j, 1, k)) == \
-        (x*y)**k + 2*(x*y)**(i - 1)*x*(x*y)**(k - i)
+        (x*y)**k + Piecewise(
+            (2*(x*y)**(i - 1)*x*(x*y)**(k - i), And(S(1) <= i, i <= k)),
+            (0, True)
+        )
     assert dp(x*(y + 2*KD(i, j)), (j, k, 3)) == \
-        (x*y)**(-k + 4) + 2*(x*y)**(i - k)*x*(x*y)**(3 - i)
+        (x*y)**(-k + 4) + Piecewise(
+            (2*(x*y)**(i - k)*x*(x*y)**(3 - i), And(k <= i, i <= 3)),
+            (0, True)
+        )
     assert dp(x*(y + 2*KD(i, j)), (j, k, l)) == \
-        (x*y)**(-k + l + 1) + 2*(x*y)**(i - k)*x*(x*y)**(l - i)
+        (x*y)**(-k + l + 1) + Piecewise(
+            (2*(x*y)**(i - k)*x*(x*y)**(l - i), And(k <= i, i <= l)),
+            (0, True)
+        )
 
 def test_deltaproduct_mul_add_x_y_add_y_kd():
     assert dp((x + y)*(y + KD(i, j)), (j, 1, 3)) == ((x + y)*y)**3 + \
@@ -150,13 +177,24 @@ def test_deltaproduct_mul_add_x_y_add_y_kd():
     assert dp((x + y)*(y + KD(i, j)), (j, 1, 1)) == (x + y)*(y + KD(i, 1))
     assert dp((x + y)*(y + KD(i, j)), (j, 2, 2)) == (x + y)*(y + KD(i, 2))
     assert dp((x + y)*(y + KD(i, j)), (j, 3, 3)) == (x + y)*(y + KD(i, 3))
-    assert dp((x + y)*(y + KD(i, j)), (j, 1, k)) == ((x + y)*y)**k + \
-        ((x + y)*y)**(i - 1)*(x + y)*((x + y)*y)**(k - i)
-    assert dp((x + y)*(y + KD(i, j)), (j, k, 3)) == ((x + y)*y)**(-k + 4) + \
-        ((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(3 - i)
+    assert dp((x + y)*(y + KD(i, j)), (j, 1, k)) == \
+        ((x + y)*y)**k + Piecewise(
+            (((x + y)*y)**(i - 1)*(x + y)*((x + y)*y)**(k - i),
+             And(S(1) <= i, i <= k)),
+            (0, True)
+        )
+    assert dp((x + y)*(y + KD(i, j)), (j, k, 3)) == \
+        ((x + y)*y)**(-k + 4) + Piecewise(
+            (((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(3 - i),
+             And(k <= i, i <= 3)),
+            (0, True)
+        )
     assert dp((x + y)*(y + KD(i, j)), (j, k, l)) == \
-        ((x + y)*y)**(-k + l + 1) + \
-        ((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(l - i)
+        ((x + y)*y)**(-k + l + 1) + Piecewise(
+            (((x + y)*y)**(i - k)*(x + y)*((x + y)*y)**(l - i),
+             And(k <= i, i <= l)),
+            (0, True)
+        )
 
 def test_deltaproduct_mul_add_x_kd_add_y_kd():
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, 1, 3)) == \
@@ -171,14 +209,23 @@ def test_deltaproduct_mul_add_x_kd_add_y_kd():
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, 3, 3)) == \
         (x + KD(i, k))*(y + KD(i, 3))
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, 1, k)) == \
-        ((x + KD(i, k))*y)**k + \
-        ((x + KD(i, k))*y)**(i - 1)*(x + KD(i, k))*((x + KD(i, k))*y)**(-i + k)
+        ((x + KD(i, k))*y)**k + Piecewise(
+            (((x + KD(i, k))*y)**(i - 1)*(x + KD(i, k))*
+             ((x + KD(i, k))*y)**(-i + k), And(S(1) <= i, i <= k)),
+            (0, True)
+        )
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, k, 3)) == \
-        ((x + KD(i, k))*y)**(4 - k) + \
-        ((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*((x + KD(i, k))*y)**(-i + 3)
+        ((x + KD(i, k))*y)**(4 - k) + Piecewise(
+            (((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*
+             ((x + KD(i, k))*y)**(-i + 3), And(k <= i, i <= 3)),
+            (0, True)
+        )
     assert dp((x + KD(i, k))*(y + KD(i, j)), (j, k, l)) == \
-        ((x + KD(i, k))*y)**(-k + l + 1) + \
-        ((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*((x + KD(i, k))*y)**(-i + l)
+        ((x + KD(i, k))*y)**(-k + l + 1) + Piecewise(
+            (((x + KD(i, k))*y)**(i - k)*(x + KD(i, k))*
+             ((x + KD(i, k))*y)**(-i + l), And(k <= i, i <= l)),
+            (0, True)
+        )
 
 
 def test_deltasummation_trivial():


### PR DESCRIPTION
Fix the no_piecewise logic for recursive deltaproduct calls. This fixes the first two tests reported in issue 3987, where a Piecewise was missing to really make the result valid for all input. Note that this does not address the Karr convention; limits have been assumed and are still assumed to be in increasing order.

c.f. issue 3987: wrong tests in test_deltaproduct
http://code.google.com/p/sympy/issues/detail?id=3987

I've also partly cherry-picked the added caching from #2448.
