### PR TITLE
Fix the docstring of Matrix.det

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2414,7 +2414,7 @@ class MatrixBase(object):
         Possible values for "method":
           bareis ... det_bareis
           berkowitz ... berkowitz_det
-          lu_decomposition ... det_LU
+          det_LU ... det_LU
 
         See Also
         ========

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2414,7 +2414,7 @@ class MatrixBase(object):
         Possible values for "method":
           bareis ... det_bareis
           berkowitz ... berkowitz_det
-          det_LU ... det_LU
+          det_LU ... det_LU_decomposition
 
         See Also
         ========


### PR DESCRIPTION
The method name for the LU method should be "det_LU", not
"lu_decomposition". We should perhaps change the code to match the docstring 
instead, but that would break compatibility.
