### PR TITLE
Restructuring and moving express and dt functions

### DIFF
--- a/doc/src/modules/physics/mechanics/api/essential.rst
+++ b/doc/src/modules/physics/mechanics/api/essential.rst
@@ -2,6 +2,12 @@
 Essential Components (Docstrings)
 =================================
 
+CoordinateSym
+=============
+
+.. autoclass:: sympy.physics.mechanics.essential.CoordinateSym
+
+
 ReferenceFrame
 ==============
 

--- a/doc/src/modules/physics/mechanics/api/functions.rst
+++ b/doc/src/modules/physics/mechanics/api/functions.rst
@@ -32,6 +32,12 @@ express
 .. autofunction:: sympy.physics.mechanics.functions.express
 
 
+time_derivative
+---------------
+
+.. autofunction:: sympy.physics.mechanics.functions.time_derivative
+
+
 get_motion_params
 -----------------
 

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -491,8 +491,8 @@ class CoordinateSym(Symbol):
     this class must only be accessed through the corresponding frame
     as 'frame[index]'.
 
-    However, CoordinateSyms having the same frame and index parameters
-    are equal (even though they may be instantiated separately).
+    CoordinateSyms having the same frame and index parameters are equal
+    (even though they may be instantiated separately).
 
     Parameters
     ==========

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -562,7 +562,7 @@ class ReferenceFrame(object):
 
     """
 
-    def __init__(self, name, variables=None,  indices=None, latexs=None):
+    def __init__(self, name, indices=None, latexs=None, variables=None):
         """ReferenceFrame initialization method.
 
         A ReferenceFrame has a set of orthonormal basis vectors, along with

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -1691,7 +1691,7 @@ class Vector(object):
         Parameters
         ==========
 
-        otherframe: ReferenceFrame
+        otherframe : ReferenceFrame
             The frame for this Vector to be described in
 
         variables : boolean

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -2012,6 +2012,7 @@ class MechanicsTypeError(TypeError):
                 "instead received an object '%s' of type %s." % (
                     type_str, other, type(other)))
 
+
 def _check_dyadic(other):
     if not isinstance(other, Dyadic):
         raise TypeError('A Dyadic must be supplied')

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -49,14 +49,48 @@ def dot(vec1, vec2):
 dot.__doc__ += Vector.dot.__doc__
 
 
-def express(vec, frame, frame2=None):
-    """Express convenience wrapper"""
-    if isinstance(vec, Dyadic):
-        return vec.express(frame, frame2)
-    else:
-        return frame.express(vec)
+def express(expr, frame, frame2=None):
+    """
+    Express convenience wrapper
 
-express.__doc__ += Vector.express.__doc__
+    Re-express a Vector, scalar(sympyfiable) or Dyadic in given frame.
+
+    Calls ReferenceFrame's express method for vectors and scalars, or
+    Dyadic's express method for dyadics
+
+    Parameters
+    ==========
+
+    expr : Vector/Dyadic/scalar(sympyfiable)
+        The expression to re-express in ReferenceFrame 'frame'
+
+    frame: ReferenceFrame
+        The reference frame to express expr in
+
+    frame2 : ReferenceFrame
+        The other frame required for re-expression(only for Dyadic expr)
+
+    Examples
+    ========
+
+    >>> from sympy.physics.mechanics import ReferenceFrame, outer, dynamicsymbols
+    >>> N = ReferenceFrame('N')
+    >>> q = dynamicsymbols('q')
+    >>> B = N.orientnew('B', 'Axis', [q, N.z])
+    >>> d = outer(N.x, N.x)
+    >>> from sympy.physics.mechanics import express
+    >>> express(d, B, N)
+    cos(q)*(B.x|N.x) - sin(q)*(B.y|N.x)
+    >>> express(B.x, N)
+    cos(q)*N.x + sin(q)*N.y
+    >>> express(N[0], B)
+    B_x*cos(q(t)) - B_y*sin(q(t))
+
+    """
+    if isinstance(expr, Dyadic):
+        return expr.express(frame, frame2)
+    else:
+        return frame.express(expr)
 
 
 def outer(vec1, vec2):

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -3,6 +3,7 @@ from __future__ import print_function, division
 __all__ = ['cross',
            'dot',
            'express',
+           'time_derivative',
            'outer',
            'inertia',
            'mechanics_printing',
@@ -21,6 +22,7 @@ __all__ = ['cross',
            'Lagrangian']
 
 from sympy.physics.mechanics.essential import (Vector, Dyadic, ReferenceFrame,
+                                               CoordinateSym,
                                                MechanicsStrPrinter,
                                                MechanicsPrettyPrinter,
                                                MechanicsLatexPrinter,
@@ -29,7 +31,8 @@ from sympy.physics.mechanics.essential import (Vector, Dyadic, ReferenceFrame,
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy.physics.mechanics.point import Point
-from sympy import sympify, solve, diff, sin, cos, Matrix, Symbol, integrate
+from sympy import sympify, solve, diff, sin, cos, Matrix, Symbol, integrate, \
+     trigsimp
 from sympy.core.basic import S
 
 
@@ -49,14 +52,17 @@ def dot(vec1, vec2):
 dot.__doc__ += Vector.dot.__doc__
 
 
-def express(expr, frame, frame2=None):
+def express(expr, frame, frame2=None, variables=False):
     """
-    Express convenience wrapper
+    Global function for 'express' functionality.
 
-    Re-express a Vector, scalar(sympyfiable) or Dyadic in given frame.
+    Re-expresses a Vector, scalar(sympyfiable) or Dyadic in given frame.
 
-    Calls ReferenceFrame's express method for vectors and scalars, or
-    Dyadic's express method for dyadics
+    Refer to the local methods of Vector and Dyadic for details.
+    If 'variables' is True, then the coordinate variables (CoordinateSym
+    instances) of other frames present in the vector/scalar field or
+    dyadic expression are also substituted in terms of the base scalars of
+    this frame.
 
     Parameters
     ==========
@@ -69,6 +75,10 @@ def express(expr, frame, frame2=None):
 
     frame2 : ReferenceFrame
         The other frame required for re-expression(only for Dyadic expr)
+
+    variables : boolean
+        Specifies whether to substitute the coordinate variables present
+        in expr, in terms of those of frame
 
     Examples
     ========
@@ -83,14 +93,141 @@ def express(expr, frame, frame2=None):
     cos(q)*(B.x|N.x) - sin(q)*(B.y|N.x)
     >>> express(B.x, N)
     cos(q)*N.x + sin(q)*N.y
-    >>> express(N[0], B)
+    >>> express(N[0], B, variables=True)
     B_x*cos(q(t)) - B_y*sin(q(t))
 
     """
+
+    _check_frame(frame)
+
+    if expr == 0:
+        return S(0)
+
+    if isinstance(expr, Vector):
+        #Given expr is a Vector
+        if variables:
+            #If variables attribute is True, substitute
+            #the coordinate variables in the Vector
+            frame_list = [x[-1] for x in expr.args]
+            subs_dict = {}
+            for f in frame_list:
+                subs_dict.update(f.variable_map(frame))
+            expr = expr.subs(subs_dict)
+        #Re-express in this frame
+        outvec = Vector([])
+        for i, v in enumerate(expr.args):
+            if v[1] != frame:
+                temp = frame.dcm(v[1]) * v[0]
+                if Vector.simp:
+                    temp = temp.applyfunc(lambda x: \
+                                          trigsimp(x, method='fu'))
+                outvec += Vector([(temp, frame)])
+            else:
+                outvec += Vector([v])
+        return outvec
+
     if isinstance(expr, Dyadic):
-        return expr.express(frame, frame2)
+        if frame2 is None:
+            frame2 = frame
+        _check_frame(frame2)
+        ol = Dyadic(0)
+        for i, v in enumerate(expr.args):
+            ol += express(v[0], frame, variables=variables) * \
+                  (express(v[1], frame, variables=variables) | \
+                   express(v[2], frame2, variables=variables))
+        return ol
+
     else:
-        return frame.express(expr)
+        if variables:
+            #Given expr is a scalar field
+            frame_set = set([])
+            expr = sympify(expr)
+            #Subsitute all the coordinate variables
+            for x in expr.atoms():
+                if isinstance(x, CoordinateSym)and x.frame != frame:
+                    frame_set.add(x.frame)
+            subs_dict = {}
+            for f in frame_set:
+                subs_dict.update(f.variable_map(frame))
+            return expr.subs(subs_dict)
+        return expr
+
+
+def time_derivative(expr, frame, order=1):
+    """
+    Calculate the time derivative of a vector/scalar field function
+    or dyadic expression in given frame.
+
+    References
+    ==========
+
+    http://en.wikipedia.org/wiki/Rotating_reference_frame#Time_derivatives_in_the_two_frames
+
+    Parameters
+    ==========
+
+    expr : Vector/Dyadic/sympifyable
+        The expression whose time derivative is to be calculated
+
+    frame : ReferenceFrame
+        The reference frame to calculate the time derivative in
+
+    order : integer
+        The order of the derivative to be calculated
+
+    Examples
+    ========
+
+    >>> from sympy.physics.mechanics import ReferenceFrame, Vector, dynamicsymbols
+    >>> from sympy import Symbol
+    >>> q1 = Symbol('q1')
+    >>> u1 = dynamicsymbols('u1')
+    >>> N = ReferenceFrame('N')
+    >>> A = N.orientnew('A', 'Axis', [q1, N.x])
+    >>> v = u1 * N.x
+    >>> A.set_ang_vel(N, 10*A.x)
+    >>> from sympy.physics.mechanics import time_derivative
+    >>> time_derivative(v, N)
+    u1'*N.x
+    >>> time_derivative(u1*A[0], N)
+    N_x*Derivative(u1(t), t)
+    >>> B = N.orientnew('B', 'Axis', [u1, N.z])
+    >>> from sympy.physics.mechanics import outer
+    >>> d = outer(N.x, N.x)
+    >>> time_derivative(d, B)
+    - u1'*(N.y|N.x) - u1'*(N.x|N.y)
+
+    """
+
+    t = dynamicsymbols._t
+    _check_frame(frame)
+    
+    if order == 0:
+        return expr
+    if order%1 != 0 or order < 0:
+        raise ValueError("Unsupported value of order entered")
+
+    if isinstance(expr, Vector):
+        outvec = Vector(0)
+        for i, v in enumerate(expr.args):
+            if v[1] == frame:
+                outvec += Vector([(express(v[0], frame, \
+                                           variables=True).diff(t), frame)])
+            else:
+                outvec += time_derivative(Vector([v]), v[1]) + \
+                          (v[1].ang_vel_in(frame) ^ Vector([v]))
+        return time_derivative(outvec, frame, order - 1)
+
+    if isinstance(expr, Dyadic):
+        ol = Dyadic(0)
+        for i, v in enumerate(expr.args):
+            ol += (v[0].diff(t) * (v[1] | v[2]))
+            ol += (v[0] * (time_derivative(v[1], frame) | v[2]))
+            ol += (v[0] * (v[1] | time_derivative(v[2], frame)))
+        return time_derivative(ol, frame, order - 1)
+
+    else:
+        return diff(express(expr, frame, variables=True), t, order)
 
 
 def outer(vec1, vec2):
@@ -578,14 +715,14 @@ def get_motion_params(frame, **kwargs):
 
         #Make sure boundary condition is independent of 'variable'
         if condition != 0:
-            condition = frame.express(condition)
+            condition = express(condition, frame, variables=True)
         #Special case of vectdiff == 0
         if vectdiff == Vector(0):
             return (0, 0, condition)
         #Express vectdiff completely in condition's frame to give vectdiff1
-        vectdiff1 = frame.express(vectdiff)
+        vectdiff1 = express(vectdiff, frame)
         #Find derivative of vectdiff
-        vectdiff2 = frame.dt(vectdiff)
+        vectdiff2 = time_derivative(vectdiff, frame)
         #Integrate and use boundary condition
         vectdiff0 = Vector(0)
         lims = (variable, ordinate, variable)
@@ -639,8 +776,8 @@ def get_motion_params(frame, **kwargs):
                                             dynamicsymbols._t,
                                             kwargs['timevalue1'], frame)
     else:
-        vel = frame.dt(kwargs['position'])
-        acc = frame.dt(vel)
+        vel = time_derivative(kwargs['position'], frame)
+        acc = time_derivative(vel, frame)
         return (acc, vel, kwargs['position'])
 
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -201,7 +201,7 @@ def time_derivative(expr, frame, order=1):
 
     t = dynamicsymbols._t
     _check_frame(frame)
-    
+
     if order == 0:
         return expr
     if order%1 != 0 or order < 0:
@@ -728,10 +728,10 @@ def get_motion_params(frame, **kwargs):
         lims = (variable, ordinate, variable)
         for dim in frame:
             function1 = vectdiff1.dot(dim)
-            abscissa = dim.dot(condition).subs({variable:ordinate})
+            abscissa = dim.dot(condition).subs({variable : ordinate})
             # Indefinite integral of 'function1' wrt 'variable', using
             # the given initial condition (ordinate, abscissa).
-            vectdiff0 += (integrate(function1, lims) + abscissa)*dim
+            vectdiff0 += (integrate(function1, lims) + abscissa) * dim
         #Return tuple
         return (vectdiff2, vectdiff, vectdiff0)
 

--- a/sympy/physics/mechanics/tests/test_essential.py
+++ b/sympy/physics/mechanics/tests/test_essential.py
@@ -245,10 +245,10 @@ def test_Vector_diffs():
     v4 = v2.dt(B)
     v5 = q1*A.x + q2*A.y + q3*A.z
 
-    assert v1.dt(N) == time_derivative(v1, N) == q2d * A.x + q2 * q3d * A.y + q3d * N.y
-    assert v1.dt(A) == time_derivative(v1, A) == q2d * A.x + q3 * q3d * N.x + q3d * N.y
-    assert v1.dt(B) == time_derivative(v1, B) == (q2d * A.x + q3 * q3d * N.x + q3d *
-                                    N.y - q3 * cos(q3) * q2d * N.z)
+    assert v1.dt(N) == q2d * A.x + q2 * q3d * A.y + q3d * N.y
+    assert v1.dt(A) == q2d * A.x + q3 * q3d * N.x + q3d * N.y
+    assert v1.dt(B) == (q2d * A.x + q3 * q3d * N.x + q3d *\
+                        N.y - q3 * cos(q3) * q2d * N.z)
     assert v2.dt(N) == (q2d * A.x + (q2 + q3) * q3d * A.y + q3d * B.x + q3d *
                         N.y)
     assert v2.dt(A) == q2d * A.x + q3d * B.x + q3 * q3d * N.x + q3d * N.y
@@ -276,9 +276,9 @@ def test_Vector_diffs():
                         (2 * q3d**2 + q3 * q3dd) * N.x + (q3dd - q3 * q3d**2) *
                         N.y + (2 * q3 * sin(q3) * q2d * q3d - 2 * cos(q3) *
                         q2d * q3d - q3 * cos(q3) * q2dd) * N.z)
-    assert time_derivative(v5, B) == v5.dt(B) == q1d*A.x + (q3*q2d + q2d)*A.y + (-q2*q2d + q3d)*A.z
-    assert time_derivative(v5, A) == v5.dt(A) == q1d*A.x + q2d*A.y + q3d*A.z
-    assert time_derivative(v5, N) == v5.dt(N) == (-q2*q3d + q1d)*A.x + (q1*q3d + q2d)*A.y + q3d*A.z
+    assert v5.dt(B) == q1d*A.x + (q3*q2d + q2d)*A.y + (-q2*q2d + q3d)*A.z
+    assert v5.dt(A) == q1d*A.x + q2d*A.y + q3d*A.z
+    assert v5.dt(N) == (-q2*q3d + q1d)*A.x + (q1*q3d + q2d)*A.y + q3d*A.z
     assert v3.diff(q1d, N) == 0
     assert v3.diff(q2d, N) == A.x - q3 * cos(q3) * N.z
     assert v3.diff(q3d, N) == q3 * N.x + N.y

--- a/sympy/physics/mechanics/tests/test_essential.py
+++ b/sympy/physics/mechanics/tests/test_essential.py
@@ -1,6 +1,7 @@
 from sympy import cos, Matrix, sin, symbols, pi, S, Function, zeros
 from sympy.abc import x, y, z
-from sympy.physics.mechanics import Vector, ReferenceFrame, dot, dynamicsymbols
+from sympy.physics.mechanics import Vector, ReferenceFrame, dot, dynamicsymbols, \
+     express, time_derivative
 from sympy.physics.mechanics import Dyadic, CoordinateSym, express
 from sympy.physics.mechanics.essential import MechanicsLatexPrinter
 from sympy.utilities.pytest import raises
@@ -62,29 +63,29 @@ def test_coordinate_vars():
                                  B[0]: A[0]*cos(q) + A[1]*sin(q)}
     assert A.variable_map(B) == {A[0]: B[0]*cos(q) - B[1]*sin(q),
                                  A[1]: B[0]*sin(q) + B[1]*cos(q), A[2]: B[2]}
-    assert A.dt(B[0]) == -A[0]*sin(q)*qd + A[1]*cos(q)*qd
-    assert A.dt(B[1]) == -A[0]*cos(q)*qd - A[1]*sin(q)*qd
-    assert A.dt(B[2]) == 0
-    assert express(B[0], A) == A[0]*cos(q) + A[1]*sin(q)
-    assert express(B[1], A) == -A[0]*sin(q) + A[1]*cos(q)
-    assert express(B[2], A) == A[2]
-    assert B.dt(A[0]*A.x + A[1]*A.y + A[2]*A.z) == A[1]*qd*A.x - A[0]*qd*A.y
-    assert A.dt(B[0]*B.x + B[1]*B.y + B[2]*B.z) == - B[1]*qd*B.x + B[0]*qd*B.y
-    assert A.express(B[0]*B[1]*B[2]) == \
+    assert time_derivative(B[0], A) == -A[0]*sin(q)*qd + A[1]*cos(q)*qd
+    assert time_derivative(B[1], A) == -A[0]*cos(q)*qd - A[1]*sin(q)*qd
+    assert time_derivative(B[2], A) == 0
+    assert express(B[0], A, variables=True) == A[0]*cos(q) + A[1]*sin(q)
+    assert express(B[1], A, variables=True) == -A[0]*sin(q) + A[1]*cos(q)
+    assert express(B[2], A, variables=True) == A[2]
+    assert time_derivative(A[0]*A.x + A[1]*A.y + A[2]*A.z, B) == A[1]*qd*A.x - A[0]*qd*A.y
+    assert time_derivative(B[0]*B.x + B[1]*B.y + B[2]*B.z, A) == - B[1]*qd*B.x + B[0]*qd*B.y
+    assert express(B[0]*B[1]*B[2], A, variables=True) == \
            A[2]*(-A[0]*sin(q) + A[1]*cos(q))*(A[0]*cos(q) + A[1]*sin(q))
-    assert (A.dt(B[0]*B[1]*B[2]) -
+    assert (time_derivative(B[0]*B[1]*B[2], A) -
             (A[2]*(-A[0]**2*cos(2*q) -
              2*A[0]*A[1]*sin(2*q) +
              A[1]**2*cos(2*q))*qd)).trigsimp() == 0
-    assert A.express(B[0]*B.x + B[1]*B.y + B[2]*B.z) == \
+    assert express(B[0]*B.x + B[1]*B.y + B[2]*B.z, A) == \
            (B[0]*cos(q) - B[1]*sin(q))*A.x + (B[0]*sin(q) + \
            B[1]*cos(q))*A.y + B[2]*A.z
-    assert A.express(B[0]*B.x + B[1]*B.y + B[2]*B.z, variables=True) == \
+    assert express(B[0]*B.x + B[1]*B.y + B[2]*B.z, A, variables=True) == \
            A[0]*A.x + A[1]*A.y + A[2]*A.z
-    assert B.express(A[0]*A.x + A[1]*A.y + A[2]*A.z) == \
+    assert express(A[0]*A.x + A[1]*A.y + A[2]*A.z, B) == \
            (A[0]*cos(q) + A[1]*sin(q))*B.x + \
            (-A[0]*sin(q) + A[1]*cos(q))*B.y + A[2]*B.z
-    assert B.express(A[0]*A.x + A[1]*A.y + A[2]*A.z, variables=True) == \
+    assert express(A[0]*A.x + A[1]*A.y + A[2]*A.z, B, variables=True) == \
            B[0]*B.x + B[1]*B.y + B[2]*B.z
     N = B.orientnew('N', 'Axis', [-q, B.z])
     assert N.variable_map(A) == {N[0]: A[0], N[2]: A[2], N[1]: A[1]}
@@ -244,9 +245,9 @@ def test_Vector_diffs():
     v4 = v2.dt(B)
     v5 = q1*A.x + q2*A.y + q3*A.z
 
-    assert v1.dt(N) == N.dt(v1) == q2d * A.x + q2 * q3d * A.y + q3d * N.y
-    assert v1.dt(A) == A.dt(v1) == q2d * A.x + q3 * q3d * N.x + q3d * N.y
-    assert v1.dt(B) == B.dt(v1) == (q2d * A.x + q3 * q3d * N.x + q3d *
+    assert v1.dt(N) == time_derivative(v1, N) == q2d * A.x + q2 * q3d * A.y + q3d * N.y
+    assert v1.dt(A) == time_derivative(v1, A) == q2d * A.x + q3 * q3d * N.x + q3d * N.y
+    assert v1.dt(B) == time_derivative(v1, B) == (q2d * A.x + q3 * q3d * N.x + q3d *
                                     N.y - q3 * cos(q3) * q2d * N.z)
     assert v2.dt(N) == (q2d * A.x + (q2 + q3) * q3d * A.y + q3d * B.x + q3d *
                         N.y)
@@ -275,9 +276,9 @@ def test_Vector_diffs():
                         (2 * q3d**2 + q3 * q3dd) * N.x + (q3dd - q3 * q3d**2) *
                         N.y + (2 * q3 * sin(q3) * q2d * q3d - 2 * cos(q3) *
                         q2d * q3d - q3 * cos(q3) * q2dd) * N.z)
-    assert B.dt(v5) == v5.dt(B) == q1d*A.x + (q3*q2d + q2d)*A.y + (-q2*q2d + q3d)*A.z
-    assert A.dt(v5) == v5.dt(A) == q1d*A.x + q2d*A.y + q3d*A.z
-    assert N.dt(v5) == v5.dt(N) == (-q2*q3d + q1d)*A.x + (q1*q3d + q2d)*A.y + q3d*A.z
+    assert time_derivative(v5, B) == v5.dt(B) == q1d*A.x + (q3*q2d + q2d)*A.y + (-q2*q2d + q3d)*A.z
+    assert time_derivative(v5, A) == v5.dt(A) == q1d*A.x + q2d*A.y + q3d*A.z
+    assert time_derivative(v5, N) == v5.dt(N) == (-q2*q3d + q1d)*A.x + (q1*q3d + q2d)*A.y + q3d*A.z
     assert v3.diff(q1d, N) == 0
     assert v3.diff(q2d, N) == A.x - q3 * cos(q3) * N.z
     assert v3.diff(q3d, N) == q3 * N.x + N.y

--- a/sympy/physics/mechanics/tests/test_functions.py
+++ b/sympy/physics/mechanics/tests/test_functions.py
@@ -2,8 +2,8 @@ from sympy import S, Integral, sin, cos, pi, sqrt, symbols
 from sympy.physics.mechanics import (Dyadic, Particle, Point, ReferenceFrame,
                                      RigidBody, Vector)
 from sympy.physics.mechanics import (angular_momentum, cross, dot,
-                                     dynamicsymbols, express, inertia,
-                                     inertia_of_point_mass,
+                                     dynamicsymbols, express, time_derivative,
+                                     inertia, inertia_of_point_mass,
                                      kinematic_equations, kinetic_energy,
                                      linear_momentum, outer, partial_velocity,
                                      potential_energy, get_motion_params)
@@ -331,6 +331,47 @@ def test_express():
             cos(q2)*cos(q3)*A.z), C)
     assert C.x == express((cos(q3)*B.x - sin(q3)*B.z), C)
     assert C.z == express((sin(q3)*B.x + cos(q3)*B.z), C)
+
+
+def test_time_derivative():
+    #The use of time_derivative for calculations pertaining to scalar
+    #fields has been tested in test_coordinate_vars in test_essential.py
+    A = ReferenceFrame('A')
+    q = dynamicsymbols('q')
+    qd = dynamicsymbols('q', 1)
+    B = A.orientnew('B', 'Axis', [q, A.z])
+    d = A.x | A.x
+    assert time_derivative(d, B) == (-qd) * (A.y | A.x) + \
+           (-qd) * (A.x | A.y)
+    d1 = A.x | B.y
+    assert time_derivative(d1, A) == - qd*(A.x|B.x)
+    assert time_derivative(d1, B) == - qd*(A.y|B.y)
+    d2 = A.x | B.x
+    assert time_derivative(d2, A) == qd*(A.x|B.y)
+    assert time_derivative(d2, B) == - qd*(A.y|B.x)
+    d3 = A.x | B.z
+    assert time_derivative(d3, A) == 0
+    assert time_derivative(d3, B) == - qd*(A.y|B.z)
+    q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')
+    q1d, q2d, q3d, q4d = dynamicsymbols('q1 q2 q3 q4', 1)
+    q1dd, q2dd, q3dd, q4dd = dynamicsymbols('q1 q2 q3 q4', 2)
+    C = B.orientnew('C', 'Axis', [q4, B.x])
+    v1 = q1 * A.z
+    v2 = q2*A.x + q3*B.y
+    v3 = q1*A.x + q2*A.y + q3*A.z
+    assert time_derivative(B.x, C) == 0
+    assert time_derivative(B.y, C) == - q4d*B.z
+    assert time_derivative(B.z, C) == q4d*B.y
+    assert time_derivative(v1, B) == q1d*A.z
+    assert time_derivative(v1, C) == - q1*sin(q)*q4d*A.x + \
+           q1*cos(q)*q4d*A.y + q1d*A.z
+    assert time_derivative(v2, A) == q2d*A.x - q3*qd*B.x + q3d*B.y
+    assert time_derivative(v2, C) == q2d*A.x - q2*qd*A.y + \
+           q2*sin(q)*q4d*A.z + q3d*B.y - q3*q4d*B.z
+    assert time_derivative(v3, B) == (q2*qd + q1d)*A.x + \
+           (-q1*qd + q2d)*A.y + q3d*A.z
+    assert time_derivative(d, C) == - qd*(A.y|A.x) + \
+           sin(q)*q4d*(A.z|A.x) - qd*(A.x|A.y) + sin(q)*q4d*(A.x|A.z)
 
 
 def test_get_motion_methods():


### PR DESCRIPTION
The said functions have been removed from ReferenceFrame and placed as global functions in functions.py
All the class-methods for these functionalities call the global functions
Also improves the documentation
