### PR TITLE
factor_list: fix factorization of polynomials over polynomial rings or fraction fields

### DIFF
--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -1178,6 +1178,7 @@ def dmp_gf_factor(f, u, K):
 def dup_factor_list(f, K0):
     """Factor polynomials into irreducibles in `K[x]`. """
     j, f = dup_terms_gcd(f, K0)
+    cont, f = dup_primitive(f, K0)
 
     if K0.is_FiniteField:
         coeff, factors = dup_gf_factor(f, K0)
@@ -1232,7 +1233,7 @@ def dup_factor_list(f, K0):
     if j:
         factors.insert(0, ([K0.one, K0.zero], j))
 
-    return coeff, _sort_factors(factors)
+    return coeff*cont, _sort_factors(factors)
 
 
 def dup_factor_list_include(f, K):
@@ -1252,6 +1253,7 @@ def dmp_factor_list(f, u, K0):
         return dup_factor_list(f, K0)
 
     J, f = dmp_terms_gcd(f, u, K0)
+    cont, f = dmp_ground_primitive(f, u, K0)
 
     if K0.is_FiniteField:  # pragma: no cover
         coeff, factors = dmp_gf_factor(f, u, K0)
@@ -1314,7 +1316,7 @@ def dmp_factor_list(f, u, K0):
         term = {(0,)*(u - i) + (1,) + (0,)*i: K0.one}
         factors.insert(0, (dmp_from_dict(term, u, K0), j))
 
-    return coeff, _sort_factors(factors)
+    return coeff*cont, _sort_factors(factors)
 
 
 def dmp_factor_list_include(f, u, K):

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -534,8 +534,7 @@ def test_dup_factor_list():
     f = 4*t*x**2 + 4*t**2*x
 
     assert R.dup_factor_list(f) == \
-        (4, [(t, 1),
-             (x, 1),
+        (4*t, [(x, 1),
              (x + t, 1)])
 
     Rt, t = ring("t", QQ)
@@ -544,8 +543,7 @@ def test_dup_factor_list():
     f = QQ(1, 2)*t*x**2 + QQ(1, 2)*t**2*x
 
     assert R.dup_factor_list(f) == \
-        (QQ(1, 2), [(t, 1),
-                    (x, 1),
+        (QQ(1, 2)*t, [(x, 1),
                     (x + t, 1)])
 
     R, x = ring("x", QQ.algebraic_field(I))
@@ -640,8 +638,7 @@ def test_dmp_factor_list():
     f = 4*t*x**2 + 4*t**2*x
 
     assert R.dmp_factor_list(f) == \
-        (4, [(t, 1),
-             (x, 1),
+        (4*t, [(x, 1),
              (x + t, 1)])
 
     Rt, t = ring("t", QQ)
@@ -649,8 +646,7 @@ def test_dmp_factor_list():
     f = QQ(1, 2)*t*x**2 + QQ(1, 2)*t**2*x
 
     assert R.dmp_factor_list(f) == \
-        (QQ(1, 2), [(t, 1),
-                    (x, 1),
+        (QQ(1, 2)*t, [(x, 1),
                     (x + t, 1)])
 
     R, x, y = ring("x,y", FF(2))


### PR DESCRIPTION
When factoring polynomials over a polynomial ring or a fraction field, factor_list currently does not compute the correct factorization.

With the current master, I get:

```
In [1]: D, t = ring('t', ZZ)

In [2]: R, x = ring('x', D)

In [3]: f = (t**2 - 1) * x

In [4]: f.factor_list()
Out[4]: (1, [(t - 1, 1), (t + 1, 1), (x, 1)])
```

That is incorrect, since `t**2 - 1` is an element of the ground domain. Therefore, the correct factorization would be `(t**2 - 1, [(x, 1)])`.
Computing and dividing out the content of a polynomial first solves this.
