### PR TITLE
Issue 1966: Add evaluate=False to sympify

### DIFF
--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -49,7 +49,7 @@ class CantSympify(object):
     """
     pass
 
-def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
+def sympify(a, locals=None, convert_xor=True, strict=False, rational=False, evaluate=True):
     """
     Converts an arbitrary expression to a type that can be used inside SymPy.
 
@@ -299,7 +299,7 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False):
 
     try:
         a = a.replace('\n', '')
-        expr = parse_expr(a, local_dict=locals, transformations=transformations)
+        expr = parse_expr(a, local_dict=locals, transformations=transformations, evaluate=evaluate)
     except (TokenError, SyntaxError) as exc:
         raise SympifyError('could not parse %r' % a, exc)
 

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -50,8 +50,7 @@ class CantSympify(object):
     pass
 
 def sympify(a, locals=None, convert_xor=True, strict=False, rational=False, evaluate=True):
-    """
-    Converts an arbitrary expression to a type that can be used inside SymPy.
+    """Converts an arbitrary expression to a type that can be used inside SymPy.
 
     For example, it will convert Python ints into instance of sympy.Rational,
     floats into instances of sympy.Float, etc. It is also able to coerce symbolic
@@ -155,6 +154,21 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False, eval
     Traceback (most recent call last):
     ...
     SympifyError: SympifyError: True
+
+    Evaluation
+    ----------
+
+    If the option ``evaluate`` is set to ``False``, then arithmetic and
+    operators will be converted into their SymPy equivalents and the
+    ``evaluate=False`` option will be added. Nested ``Add`` or ``Mul`` will
+    be denested first. This is done via an AST transformation that replaces
+    operators with their SymPy equivalents, so if an operand redefines any
+    of those operations, the redefined operators will not be used.
+
+    >>> sympify('2**2 / 3 + 5')
+    19/3
+    >>> sympify('2**2 / 3 + 5', evaluate=False)
+    2**2/3 + 5
 
     Extending
     ---------

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,5 +1,6 @@
 from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
-    Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval
+    Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,\
+    Pow
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
 from sympy.core.decorators import _sympifyit
@@ -382,6 +383,18 @@ def test_int_float():
     assert abs(_sympify(f1_1) - 1.1) < 1e-5
     assert abs(_sympify(f1_1b) - 1.1) < 1e-5
     assert abs(_sympify(f1_1c) - 1.1) < 1e-5
+
+
+def test_evaluate_false():
+    cases = {
+        '2 + 3': Add(2, 3, evaluate=False),
+        '2**2 / 3': Mul(Pow(2, 2, evaluate=False), Pow(3, -1, evaluate=False), evaluate=False),
+        '2 + 3 * 5': Add(2, Mul(3, 5, evaluate=False), evaluate=False),
+        '2 - 3 * 5': Add(2, -Mul(3, 5, evaluate=False), evaluate=False),
+        '1 / 3': Mul(1, Pow(3, -1, evaluate=False), evaluate=False)
+    }
+    for case, result in cases.items():
+        assert sympify(case, evaluate=False) == result
 
 
 def test_issue1034():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -1,6 +1,6 @@
 from sympy import Symbol, exp, Integer, Float, sin, cos, log, Poly, Lambda, \
     Function, I, S, sqrt, srepr, Rational, Tuple, Matrix, Interval, Add, Mul,\
-    Pow
+    Pow, And, Or, Xor, Not
 from sympy.abc import x, y
 from sympy.core.sympify import sympify, _sympify, SympifyError, kernS
 from sympy.core.decorators import _sympifyit
@@ -391,7 +391,10 @@ def test_evaluate_false():
         '2**2 / 3': Mul(Pow(2, 2, evaluate=False), Pow(3, -1, evaluate=False), evaluate=False),
         '2 + 3 * 5': Add(2, Mul(3, 5, evaluate=False), evaluate=False),
         '2 - 3 * 5': Add(2, -Mul(3, 5, evaluate=False), evaluate=False),
-        '1 / 3': Mul(1, Pow(3, -1, evaluate=False), evaluate=False)
+        '1 / 3': Mul(1, Pow(3, -1, evaluate=False), evaluate=False),
+        'True | False': Or(True, False, evaluate=False),
+        '1 + 2 + 3 + 5*3 + integrate(x)': Add(1, 2, 3, Mul(5, 3, evaluate=False), x**2/2, evaluate=False),
+        '2 * 4 * 6 + 8': Add(Mul(2, 4, 6, evaluate=False), 8, evaluate=False),
     }
     for case, result in cases.items():
         assert sympify(case, evaluate=False) == result

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -7,6 +7,8 @@ from .sympy_tokenize import \
     NUMBER, STRING, NAME, OP, ENDMARKER
 
 from keyword import iskeyword
+
+import ast
 import re
 import unicodedata
 
@@ -685,7 +687,7 @@ def eval_expr(code, local_dict, global_dict):
 
 
 def parse_expr(s, local_dict=None, transformations=standard_transformations,
-               global_dict=None):
+               global_dict=None, evaluate=True):
     """Converts the string ``s`` to a SymPy expression, in ``local_dict``
 
     Parameters
@@ -741,4 +743,56 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
         exec_('from sympy import *', global_dict)
 
     code = stringify_expr(s, local_dict, global_dict, transformations)
+
+    if evaluate is False:
+        code = compile(evaluateFalse(code), '<string>', 'eval')
+
     return eval_expr(code, local_dict, global_dict)
+
+
+def evaluateFalse(s):
+    """
+    Replaces operators with the SymPy equivalent and sets evaluate=False.
+    """
+    node = ast.parse(s)
+    node = EvaluateFalseTransformer().visit(node)
+    # node is a Module, we want an Expression
+    node = ast.Expression(node.body[0].value)
+
+    return ast.fix_missing_locations(node)
+
+
+class EvaluateFalseTransformer(ast.NodeTransformer):
+    operators = {
+        ast.Add: 'Add',
+        ast.Mult: 'Mul',
+        ast.Pow: 'Pow',
+        ast.Sub: 'Add',
+        ast.Div: 'Mul'
+    }
+
+    def visit_BinOp(self, node):
+        if node.op.__class__ in self.operators:
+            sympy_class = self.operators[node.op.__class__]
+            right = self.visit(node.right)
+
+            if isinstance(node.op, ast.Sub):
+                right = ast.UnaryOp(op=ast.USub(), operand=right)
+            elif isinstance(node.op, ast.Div):
+                right = ast.Call(
+                    func=ast.Name(id='Pow', ctx=ast.Load()),
+                    args=[right, ast.UnaryOp(op=ast.USub(), operand=ast.Num(1))],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                    starargs=None,
+                    kwargs=None
+                )
+
+            new_node = ast.Call(
+                func=ast.Name(id=sympy_class, ctx=ast.Load()),
+                args=[self.visit(node.left), right],
+                keywords=[ast.keyword(arg='evaluate', value=ast.Name(id='False', ctx=ast.Load()))],
+                starargs=None,
+                kwargs=None
+            )
+            return new_node
+        return node


### PR DESCRIPTION
Changes:
- Add `evaluate=False` flag to `sympify` (fixes [issue 1966](https://code.google.com/p/sympy/issues/detail?id=1966))

I know that we don't want more flags, but this isn't a transformation on the tokens like implicit parsing is, so for now I've used the API as discussed in [issue 1966](https://code.google.com/p/sympy/issues/detail?id=1966).

This works by using an AST transformer to change `+`, `-`, `*`, `/`, and `**` operators into the SymPy equivalents and add `evaluate=False`.
