### PR TITLE
Add new translate function to include accents and other latex macros in symbol names

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -47,7 +47,6 @@ tex_greek_dictionary = {
     'Chi': 'X',
     'lamda': r'\lambda',
     'Lamda': r'\Lambda',
-    'Lambda': r'\Lambda',
     'khi': r'\chi',
     'Khi': r'X',
     'varepsilon': r'\varepsilon',

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1632,10 +1632,10 @@ def translate(s):
     '''
     Check for an accent ending the string.  If present, convert the
     accent to latex and translate the rest recursively.
-    
+
     Given a description of a Greek letter or other special character,
     return the appropriate latex.
-    
+
     Let everything else pass as given.
     '''
     # Process accents, if any, and recurse

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1639,15 +1639,15 @@ def translate(s):
     '''
     # Process accents, if any, and recurse
     for key in accent_keys:
-        if s.endswith(key):
+        if s.lower().endswith(key):
             if(key in ['prime', 'prm']):
                 # MathJax can fail on primes without braces
-                return "{" + translate(s.rsplit(key,1)[0]) + "}'"
+                return "{" + translate(s[:-len(key)]) + "}'"
             if(key=='bm'):
                 outkey = 'boldsymbol' # MathJax doesn't know \bm
             else:
                 outkey = key
-            return "\\" + outkey + "{" + translate(s.rsplit(key,1)[0]) + "}"
+            return "\\" + outkey + "{" + translate(s[:-len(key)]) + "}"
     # Process the rest
     tex = tex_greek_dictionary.get(s)
     if tex:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1636,6 +1636,10 @@ def translate(s):
     return the appropriate latex.
 
     Let everything else pass as given.
+
+    >>> from sympy.printing.latex import translate
+    >>> translate('alphahatdotprime')
+    "{\\dot{\\hat{\\alpha}}}'"
     '''
     # Process accents, if any, and recurse
     for key in accent_keys:

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -64,8 +64,8 @@ other_symbols = set(['aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth', 'hbar',
 # Make sure to keep this list sorted by decreasing length so that,
 # e.g., "ddot" is not confused for "d" followed by "dot"
 accent_keys = ['mathring', 'check', 'breve', 'acute', 'grave',
-                'tilde', 'prime', 'ddot', 'hat', 'dot', 'bar',
-                'vec', 'abs', 'prm', 'bm']
+               'tilde', 'prime', 'ddot', 'bold', 'hat', 'dot',
+               'bar', 'vec', 'abs', 'prm', 'bm']
 
 greek_letters_set = frozenset(greeks)
 
@@ -1647,8 +1647,12 @@ def translate(s):
             if(key in ['prime', 'prm']):
                 # MathJax can fail on primes without braces
                 return "{" + translate(s[:-len(key)]) + "}'"
-            if(key=='bm'):
-                outkey = 'boldsymbol' # MathJax doesn't know \bm
+            if(key=='abs'):
+                # MathJax doesn't know \abs
+                return "\\left\\lvert{" + translate(s[:-len(key)]) + "}\\right\\rvert"
+            if(key in ['bold', 'bm']):
+                # MathJax doesn't know \bm
+                outkey = 'boldsymbol'
             else:
                 outkey = key
             return "\\" + outkey + "{" + translate(s[:-len(key)]) + "}"

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -61,10 +61,36 @@ tex_greek_dictionary = {
 other_symbols = set(['aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth', 'hbar',
                      'hslash', 'mho', 'wp', ])
 
-# Make sure to keep this list sorted by decreasing length so that,
-# e.g., "ddot" is not confused for "d" followed by "dot"
-modifier_keys = ['mathring', 'check', 'breve', 'acute', 'grave', 'tilde', 'prime', 'ddot',
-                 'bold', 'norm', 'avg', 'hat', 'dot', 'bar', 'vec', 'abs', 'mag', 'prm', 'bm']
+# Variable name modifiers
+modifier_dict = {
+    # Accents
+    'mathring': lambda s: r'\mathring{'+s+r'}',
+    'ddddot': lambda s: r'\ddddot{'+s+r'}',
+    'dddot': lambda s: r'\dddot{'+s+r'}',
+    'ddot': lambda s: r'\ddot{'+s+r'}',
+    'dot': lambda s: r'\dot{'+s+r'}',
+    'check': lambda s: r'\check{'+s+r'}',
+    'breve': lambda s: r'\breve{'+s+r'}',
+    'acute': lambda s: r'\acute{'+s+r'}',
+    'grave': lambda s: r'\grave{'+s+r'}',
+    'tilde': lambda s: r'\tilde{'+s+r'}',
+    'hat': lambda s: r'\hat{'+s+r'}',
+    'bar': lambda s: r'\bar{'+s+r'}',
+    'vec': lambda s: r'\vec{'+s+r'}',
+    'prime': lambda s: "{"+s+"}'",
+    'prm': lambda s: "{"+s+"}'",
+    # Faces
+    'bold': lambda s: r'\boldsymbol{'+s+r'}',
+    'bm': lambda s: r'\boldsymbol{'+s+r'}',
+    'cal': lambda s: r'\mathcal{'+s+r'}',
+    'scr': lambda s: r'\mathscr{'+s+r'}',
+    'frak': lambda s: r'\mathfrak{'+s+r'}',
+    # Brackets
+    'norm': lambda s: r'\left\lVert{'+s+r'}\right\rVert',
+    'avg': lambda s: r'\left\langle{'+s+r'}\right\rangle',
+    'abs': lambda s: r'\left\lvert{'+s+r'}\right\rvert',
+    'mag': lambda s: r'\left\lvert{'+s+r'}\right\rvert',
+}
 
 greek_letters_set = frozenset(greeks)
 
@@ -1648,21 +1674,9 @@ def translate(s):
         return "\\" + s
     else:
         # Process modifiers, if any, and recurse
-        for key in modifier_keys:
+        for key in sorted(modifier_dict.keys(), key=lambda k:len(k), reverse=True):
             if s.lower().endswith(key) and len(s)>len(key):
-                if(key in ['prime', 'prm']):
-                    # MathJax can fail on primes without braces
-                    return "{" + translate(s[:-len(key)]) + "}'"
-                if(key in ['abs', 'mag']):
-                    return "\\left\\lvert{" + translate(s[:-len(key)]) + "}\\right\\rvert"
-                if(key=='norm'):
-                    return "\\left\\lVert{" + translate(s[:-len(key)]) + "}\\right\\rVert"
-                if(key=='avg'):
-                    return "\\left\\langle{" + translate(s[:-len(key)]) + "}\\right\\rangle"
-                if(key in ['bm', 'bold']):
-                    # MathJax doesn't know \bm
-                    return "\\boldsymbol{" + translate(s[:-len(key)]) + "}"
-                return "\\" + key + "{" + translate(s[:-len(key)]) + "}"
+                return modifier_dict[key](translate(s[:-len(key)]))
         return s
 
 def latex(expr, **settings):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -63,9 +63,8 @@ other_symbols = set(['aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth', 'hbar',
 
 # Make sure to keep this list sorted by decreasing length so that,
 # e.g., "ddot" is not confused for "d" followed by "dot"
-accent_keys = ['mathring', 'check', 'breve', 'acute', 'grave',
-               'tilde', 'prime', 'ddot', 'bold', 'hat', 'dot',
-               'bar', 'vec', 'abs', 'prm', 'bm']
+modifier_keys = ['mathring', 'check', 'breve', 'acute', 'grave', 'tilde', 'prime', 'ddot',
+                 'bold', 'norm', 'avg', 'hat', 'dot', 'bar', 'vec', 'abs', 'mag', 'prm', 'bm']
 
 greek_letters_set = frozenset(greeks)
 
@@ -1629,8 +1628,8 @@ class LatexPrinter(Printer):
 
 def translate(s):
     r'''
-    Check for an accent ending the string.  If present, convert the
-    accent to latex and translate the rest recursively.
+    Check for a modifier ending the string.  If present, convert the
+    modifier to latex and translate the rest recursively.
 
     Given a description of a Greek letter or other special character,
     return the appropriate latex.
@@ -1641,21 +1640,6 @@ def translate(s):
     >>> translate('alphahatdotprime')
     "{\\dot{\\hat{\\alpha}}}'"
     '''
-    # Process accents, if any, and recurse
-    for key in accent_keys:
-        if s.lower().endswith(key):
-            if(key in ['prime', 'prm']):
-                # MathJax can fail on primes without braces
-                return "{" + translate(s[:-len(key)]) + "}'"
-            if(key=='abs'):
-                # MathJax doesn't know \abs
-                return "\\left\\lvert{" + translate(s[:-len(key)]) + "}\\right\\rvert"
-            if(key in ['bold', 'bm']):
-                # MathJax doesn't know \bm
-                outkey = 'boldsymbol'
-            else:
-                outkey = key
-            return "\\" + outkey + "{" + translate(s[:-len(key)]) + "}"
     # Process the rest
     tex = tex_greek_dictionary.get(s)
     if tex:
@@ -1663,6 +1647,22 @@ def translate(s):
     elif s.lower() in greek_letters_set or s in other_symbols:
         return "\\" + s
     else:
+        # Process modifiers, if any, and recurse
+        for key in modifier_keys:
+            if s.lower().endswith(key) and len(s)>len(key):
+                if(key in ['prime', 'prm']):
+                    # MathJax can fail on primes without braces
+                    return "{" + translate(s[:-len(key)]) + "}'"
+                if(key in ['abs', 'mag']):
+                    return "\\left\\lvert{" + translate(s[:-len(key)]) + "}\\right\\rvert"
+                if(key=='norm'):
+                    return "\\left\\lVert{" + translate(s[:-len(key)]) + "}\\right\\rVert"
+                if(key=='avg'):
+                    return "\\left\\langle{" + translate(s[:-len(key)]) + "}\\right\\rangle"
+                if(key in ['bm', 'bold']):
+                    # MathJax doesn't know \bm
+                    return "\\boldsymbol{" + translate(s[:-len(key)]) + "}"
+                return "\\" + key + "{" + translate(s[:-len(key)]) + "}"
         return s
 
 def latex(expr, **settings):

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1628,7 +1628,7 @@ class LatexPrinter(Printer):
 
 
 def translate(s):
-    '''
+    r'''
     Check for an accent ending the string.  If present, convert the
     accent to latex and translate the rest recursively.
 

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -181,6 +181,38 @@ for s in '+-=()':
     sub[s] = SSUB(s)
     sup[s] = SSUP(s)
 
+# Variable modifiers
+# TODO: Is it worth trying to handle faces with, e.g., 'MATHEMATICAL BOLD CAPITAL A'?
+# TODO: Make brackets adjust to height of contents
+modifier_dict = {
+    # Accents
+    'mathring': lambda s: s+u'\u030A',
+    # 'ddddot': lambda s: s,
+    # 'dddot': lambda s: s,
+    'ddot': lambda s: s+u'\u0308',
+    'dot': lambda s: s+u'\u0307',
+    'check': lambda s: s+u'\u030C',
+    'breve': lambda s: s+u'\u0306',
+    'acute': lambda s: s+u'\u0301',
+    'grave': lambda s: s+u'\u0300',
+    'tilde': lambda s: s+u'\u0303',
+    'hat': lambda s: s+u'\u0302',
+    'bar': lambda s: s+u'\u0305',
+    'vec': lambda s: s+u'\u20D7',
+    'prime': lambda s: s+u'\u030D',
+    'prm': lambda s: s+u'\u030D',
+    # Faces
+    # 'bold': lambda s:,
+    # 'bm': lambda s:,
+    # 'cal': lambda s:,
+    # 'scr': lambda s:,
+    # 'frak': lambda s:,
+    # Brackets
+    'norm': lambda s: u'\u2016'+s+u'\u2016',
+    'avg': lambda s: u'\u27E8'+s+u'\u27E9',
+    'abs': lambda s: u'\u007C'+s+u'\u007C',
+    'mag': lambda s: u'\u007C'+s+u'\u007C',
+}
 
 # VERTICAL OBJECTS
 HUP = lambda symb: U('%s UPPER HOOK' % symb_2txt[symb])
@@ -452,10 +484,16 @@ def pretty_symbol(symb_name):
 
     name, sups, subs = split_super_sub(symb_name)
 
-    # let's prettify name
-    gG = greek_unicode.get(name)
-    if gG is not None:
-        name = gG
+    def translate(s) :
+        gG = greek_unicode.get(s)
+        if gG is not None:
+            return gG
+        for key in sorted(modifier_dict.keys(), key=lambda k:len(k), reverse=True) :
+            if s.lower().endswith(key) and len(s)>len(key):
+                return modifier_dict[key](translate(s[:-len(key)]))
+        return s
+
+    name = translate(name)
 
     # Let's prettify sups/subs. If it fails at one of them, pretty sups/subs are
     # not used at all.
@@ -479,7 +517,7 @@ def pretty_symbol(symb_name):
 
     # glue the results into one string
     if pretty_subs is None:  # nice formatting of sups/subs did not work
-        return symb_name
+        return name + '_'+'_'.join([translate(s) for s in subs]) + '__'+'__'.join([translate(s) for s in sups])
     else:
         sups_result = ' '.join(pretty_sups)
         subs_result = ' '.join(pretty_subs)

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -187,8 +187,8 @@ for s in '+-=()':
 modifier_dict = {
     # Accents
     'mathring': lambda s: s+u('\u030A'),
-    # 'ddddot': lambda s: s,
-    # 'dddot': lambda s: s,
+    'ddddot': lambda s: s+u('\u0308\u0308'),
+    'dddot': lambda s: s+u('\u0308\u0307'),
     'ddot': lambda s: s+u('\u0308'),
     'dot': lambda s: s+u('\u0307'),
     'check': lambda s: s+u('\u030C'),
@@ -201,12 +201,12 @@ modifier_dict = {
     'vec': lambda s: s+u('\u20D7'),
     'prime': lambda s: s+u('\u030D'),
     'prm': lambda s: s+u('\u030D'),
-    # Faces
-    # 'bold': lambda s:,
-    # 'bm': lambda s:,
-    # 'cal': lambda s:,
-    # 'scr': lambda s:,
-    # 'frak': lambda s:,
+    # Faces -- these are here for some compatibility with latex printing
+    'bold': lambda s: s,
+    'bm': lambda s: s,
+    'cal': lambda s: s,
+    'scr': lambda s: s,
+    'frak': lambda s: s,
     # Brackets
     'norm': lambda s: u('\u2016')+s+u('\u2016'),
     'avg': lambda s: u('\u27E8')+s+u('\u27E9'),

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -186,21 +186,21 @@ for s in '+-=()':
 # TODO: Make brackets adjust to height of contents
 modifier_dict = {
     # Accents
-    'mathring': lambda s: s+u'\u030A',
+    'mathring': lambda s: s+u('\u030A'),
     # 'ddddot': lambda s: s,
     # 'dddot': lambda s: s,
-    'ddot': lambda s: s+u'\u0308',
-    'dot': lambda s: s+u'\u0307',
-    'check': lambda s: s+u'\u030C',
-    'breve': lambda s: s+u'\u0306',
-    'acute': lambda s: s+u'\u0301',
-    'grave': lambda s: s+u'\u0300',
-    'tilde': lambda s: s+u'\u0303',
-    'hat': lambda s: s+u'\u0302',
-    'bar': lambda s: s+u'\u0305',
-    'vec': lambda s: s+u'\u20D7',
-    'prime': lambda s: s+u'\u030D',
-    'prm': lambda s: s+u'\u030D',
+    'ddot': lambda s: s+u('\u0308'),
+    'dot': lambda s: s+u('\u0307'),
+    'check': lambda s: s+u('\u030C'),
+    'breve': lambda s: s+u('\u0306'),
+    'acute': lambda s: s+u('\u0301'),
+    'grave': lambda s: s+u('\u0300'),
+    'tilde': lambda s: s+u('\u0303'),
+    'hat': lambda s: s+u('\u0302'),
+    'bar': lambda s: s+u('\u0305'),
+    'vec': lambda s: s+u('\u20D7'),
+    'prime': lambda s: s+u('\u030D'),
+    'prm': lambda s: s+u('\u030D'),
     # Faces
     # 'bold': lambda s:,
     # 'bm': lambda s:,
@@ -208,10 +208,10 @@ modifier_dict = {
     # 'scr': lambda s:,
     # 'frak': lambda s:,
     # Brackets
-    'norm': lambda s: u'\u2016'+s+u'\u2016',
-    'avg': lambda s: u'\u27E8'+s+u'\u27E9',
-    'abs': lambda s: u'\u007C'+s+u'\u007C',
-    'mag': lambda s: u'\u007C'+s+u'\u007C',
+    'norm': lambda s: u('\u2016')+s+u('\u2016'),
+    'avg': lambda s: u('\u27E8')+s+u('\u27E9'),
+    'abs': lambda s: u('\u007C')+s+u('\u007C'),
+    'mag': lambda s: u('\u007C')+s+u('\u007C'),
 }
 
 # VERTICAL OBJECTS

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -199,14 +199,14 @@ modifier_dict = {
     'hat': lambda s: s+u('\u0302'),
     'bar': lambda s: s+u('\u0305'),
     'vec': lambda s: s+u('\u20D7'),
-    'prime': lambda s: s+u('\u030D'),
-    'prm': lambda s: s+u('\u030D'),
-    # Faces -- these are here for some compatibility with latex printing
-    'bold': lambda s: s,
-    'bm': lambda s: s,
-    'cal': lambda s: s,
-    'scr': lambda s: s,
-    'frak': lambda s: s,
+    'prime': lambda s: s+u(' \u030D'),
+    'prm': lambda s: s+u(' \u030D'),
+    # # Faces -- these are here for some compatibility with latex printing
+    # 'bold': lambda s: s,
+    # 'bm': lambda s: s,
+    # 'cal': lambda s: s,
+    # 'scr': lambda s: s,
+    # 'frak': lambda s: s,
     # Brackets
     'norm': lambda s: u('\u2016')+s+u('\u2016'),
     'avg': lambda s: u('\u27E8')+s+u('\u27E9'),
@@ -517,7 +517,11 @@ def pretty_symbol(symb_name):
 
     # glue the results into one string
     if pretty_subs is None:  # nice formatting of sups/subs did not work
-        return name + '_'+'_'.join([translate(s) for s in subs]) + '__'+'__'.join([translate(s) for s in sups])
+        if subs:
+            name += '_'+'_'.join([translate(s) for s in subs])
+        if sups:
+            name += '__'+'__'.join([translate(s) for s in sups])
+        return name
     else:
         sups_result = ' '.join(pretty_sups)
         subs_result = ' '.join(pretty_subs)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -301,7 +301,7 @@ def test_upretty_modifiers():
     assert upretty( Symbol('Fmag') ) == u('|F|')
     # Combinations
     assert upretty( Symbol('xvecdot') ) == u('x⃗̇')
-    assert upretty( Symbol('xDotVec') ) == u('ẋ⃗')
+    assert upretty( Symbol('xDotVec') ) == u('ẋ⃗')
     assert upretty( Symbol('xHATNorm') ) == u('‖x̂‖')
     assert upretty( Symbol('xMathring_yCheckPRM__zbreveAbs') ) == u('x̊_y̌ ̍__|z̆|')
     assert upretty( Symbol('alphadothat_nVECDOT__tTildePrime') ) == u('α̇̂_n⃗̇__t̃ ̍')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -274,6 +274,8 @@ def test_upretty_subs_missingin_24():
 def test_upretty_modifiers():
     # Accents
     assert upretty( Symbol('Fmathring') ) == u('F̊')
+    assert upretty( Symbol('Fddddot') ) == u('F̈̈')
+    assert upretty( Symbol('Fdddot') ) == u('F̈̇')
     assert upretty( Symbol('Fddot') ) == u('F̈')
     assert upretty( Symbol('Fdot') ) == u('Ḟ')
     assert upretty( Symbol('Fcheck') ) == u('F̌')
@@ -286,7 +288,12 @@ def test_upretty_modifiers():
     assert upretty( Symbol('Fvec') ) == u('F⃗')
     assert upretty( Symbol('Fprime') ) == u('F̍')
     assert upretty( Symbol('Fprm') ) == u('F̍')
-    # No faces are implemented...
+    # No faces are actually implemented, but test to make sure the modifiers are stripped
+    assert upretty( Symbol('Fbold') ) == u('F')
+    assert upretty( Symbol('Fbm') ) == u('F')
+    assert upretty( Symbol('Fcal') ) == u('F')
+    assert upretty( Symbol('Fscr') ) == u('F')
+    assert upretty( Symbol('Ffrak') ) == u('F')
     # Brackets
     assert upretty( Symbol('Fnorm') ) == u('‖F‖')
     assert upretty( Symbol('Favg') ) == u('⟨F⟩')

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -286,19 +286,27 @@ def test_upretty_modifiers():
     assert upretty( Symbol('Fhat') ) == u('F̂')
     assert upretty( Symbol('Fbar') ) == u('F̅')
     assert upretty( Symbol('Fvec') ) == u('F⃗')
-    assert upretty( Symbol('Fprime') ) == u('F̍')
-    assert upretty( Symbol('Fprm') ) == u('F̍')
+    assert upretty( Symbol('Fprime') ) == u('F ̍')
+    assert upretty( Symbol('Fprm') ) == u('F ̍')
     # No faces are actually implemented, but test to make sure the modifiers are stripped
-    assert upretty( Symbol('Fbold') ) == u('F')
-    assert upretty( Symbol('Fbm') ) == u('F')
-    assert upretty( Symbol('Fcal') ) == u('F')
-    assert upretty( Symbol('Fscr') ) == u('F')
-    assert upretty( Symbol('Ffrak') ) == u('F')
+    assert upretty( Symbol('Fbold') ) == u('Fbold')
+    assert upretty( Symbol('Fbm') ) == u('Fbm')
+    assert upretty( Symbol('Fcal') ) == u('Fcal')
+    assert upretty( Symbol('Fscr') ) == u('Fscr')
+    assert upretty( Symbol('Ffrak') ) == u('Ffrak')
     # Brackets
     assert upretty( Symbol('Fnorm') ) == u('‖F‖')
     assert upretty( Symbol('Favg') ) == u('⟨F⟩')
     assert upretty( Symbol('Fabs') ) == u('|F|')
     assert upretty( Symbol('Fmag') ) == u('|F|')
+    # Combinations
+    assert upretty( Symbol('xvecdot') ) == u('x⃗̇')
+    assert upretty( Symbol('xDotVec') ) == u('ẋ⃗')
+    assert upretty( Symbol('xHATNorm') ) == u('‖x̂‖')
+    assert upretty( Symbol('xMathring_yCheckPRM__zbreveAbs') ) == u('x̊_y̌ ̍__|z̆|')
+    assert upretty( Symbol('alphadothat_nVECDOT__tTildePrime') ) == u('α̇̂_n⃗̇__t̃ ̍')
+    assert upretty( Symbol('x_dot') ) == u('x_dot')
+    assert upretty( Symbol('x__dot') ) == u('x__dot')
 
 
 def test_pretty_basic():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -271,6 +271,28 @@ def test_upretty_subs_missingin_24():
     assert upretty( Symbol('F_v') ) == u('Fᵥ')
     assert upretty( Symbol('F_x') ) == u('Fₓ')
 
+def test_upretty_modifiers():
+    # Accents
+    assert upretty( Symbol('Fmathring') ) == u('F̊')
+    assert upretty( Symbol('Fddot') ) == u('F̈')
+    assert upretty( Symbol('Fdot') ) == u('Ḟ')
+    assert upretty( Symbol('Fcheck') ) == u('F̌')
+    assert upretty( Symbol('Fbreve') ) == u('F̆')
+    assert upretty( Symbol('Facute') ) == u('F́')
+    assert upretty( Symbol('Fgrave') ) == u('F̀')
+    assert upretty( Symbol('Ftilde') ) == u('F̃')
+    assert upretty( Symbol('Fhat') ) == u('F̂')
+    assert upretty( Symbol('Fbar') ) == u('F̅')
+    assert upretty( Symbol('Fvec') ) == u('F⃗')
+    assert upretty( Symbol('Fprime') ) == u('F̍')
+    assert upretty( Symbol('Fprm') ) == u('F̍')
+    # No faces are implemented...
+    # Brackets
+    assert upretty( Symbol('Fnorm') ) == u('‖F‖')
+    assert upretty( Symbol('Favg') ) == u('⟨F⟩')
+    assert upretty( Symbol('Fabs') ) == u('|F|')
+    assert upretty( Symbol('Fmag') ) == u('|F|')
+
 
 def test_pretty_basic():
     assert pretty( -Rational(1)/2 ) == '-1/2'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1051,8 +1051,13 @@ def test_translate():
     s = 'LamdaHatDOT'
     assert translate(s) == r'\dot{\hat{\Lambda}}'
 
-def test_accents():
-    # Test each accent individually in the simplest case (with funny cases)
+def test_other_symbols():
+    from sympy.printing.latex import other_symbols
+    for s in other_symbols:
+        assert latex(symbols(s)) == "\\"+s
+
+def test_modifiers():
+    # Test each modifier individually in the simplest case (with funny capitalizations)
     assert latex(symbols("xMathring")) == r"\mathring{x}"
     assert latex(symbols("xCheck")) == r"\check{x}"
     assert latex(symbols("xBreve")) == r"\breve{x}"
@@ -1062,17 +1067,40 @@ def test_accents():
     assert latex(symbols("xPrime")) == r"{x}'"
     assert latex(symbols("xDDot")) == r"\ddot{x}"
     assert latex(symbols("xBold")) == r"\boldsymbol{x}"
+    assert latex(symbols("xnOrM")) == r"\left\lVert{x}\right\rVert"
+    assert latex(symbols("xAVG")) == r"\left\langle{x}\right\rangle"
     assert latex(symbols("xHat")) == r"\hat{x}"
     assert latex(symbols("xDot")) == r"\dot{x}"
     assert latex(symbols("xBar")) == r"\bar{x}"
     assert latex(symbols("xVec")) == r"\vec{x}"
     assert latex(symbols("xAbs")) == r"\left\lvert{x}\right\rvert"
+    assert latex(symbols("xMag")) == r"\left\lvert{x}\right\rvert"
     assert latex(symbols("xPrM")) == r"{x}'"
     assert latex(symbols("xBM")) == r"\boldsymbol{x}"
+    # Test strings that are *only* the names of modifiers
+    assert latex(symbols("Mathring")) == r"Mathring"
+    assert latex(symbols("Check")) == r"Check"
+    assert latex(symbols("Breve")) == r"Breve"
+    assert latex(symbols("Acute")) == r"Acute"
+    assert latex(symbols("Grave")) == r"Grave"
+    assert latex(symbols("Tilde")) == r"Tilde"
+    assert latex(symbols("Prime")) == r"Prime"
+    assert latex(symbols("DDot")) == r"\dot{D}"
+    assert latex(symbols("Bold")) == r"Bold"
+    assert latex(symbols("NORm")) == r"NORm"
+    assert latex(symbols("AVG")) == r"AVG"
+    assert latex(symbols("Hat")) == r"Hat"
+    assert latex(symbols("Dot")) == r"Dot"
+    assert latex(symbols("Bar")) == r"Bar"
+    assert latex(symbols("Vec")) == r"Vec"
+    assert latex(symbols("Abs")) == r"Abs"
+    assert latex(symbols("Mag")) == r"Mag"
+    assert latex(symbols("PrM")) == r"PrM"
+    assert latex(symbols("BM")) == r"BM"
     # Check a few combinations
     assert latex(symbols("xvecdot")) == r"\dot{\vec{x}}"
     assert latex(symbols("xDotVec")) == r"\vec{\dot{x}}"
-    assert latex(symbols("xHATabs")) == r"\left\lvert{\hat{x}}\right\rvert"
+    assert latex(symbols("xHATNorm")) == r"\left\lVert{\hat{x}}\right\rVert"
     # Check a couple big, ugly combinations
     assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == r"\boldsymbol{\mathring{x}}^{\left\lvert{\breve{z}}\right\rvert}_{{\check{y}}'}"
     assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1065,6 +1065,8 @@ def test_modifiers():
     assert latex(symbols("xGrave")) == r"\grave{x}"
     assert latex(symbols("xTilde")) == r"\tilde{x}"
     assert latex(symbols("xPrime")) == r"{x}'"
+    assert latex(symbols("xddDDot")) == r"\ddddot{x}"
+    assert latex(symbols("xDdDot")) == r"\dddot{x}"
     assert latex(symbols("xDDot")) == r"\ddot{x}"
     assert latex(symbols("xBold")) == r"\boldsymbol{x}"
     assert latex(symbols("xnOrM")) == r"\left\lVert{x}\right\rVert"
@@ -1097,6 +1099,7 @@ def test_modifiers():
     assert latex(symbols("Mag")) == r"Mag"
     assert latex(symbols("PrM")) == r"PrM"
     assert latex(symbols("BM")) == r"BM"
+    assert latex(symbols("hbar")) == r"\hbar"
     # Check a few combinations
     assert latex(symbols("xvecdot")) == r"\dot{\vec{x}}"
     assert latex(symbols("xDotVec")) == r"\vec{\dot{x}}"

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1048,6 +1048,34 @@ def test_translate():
     assert translate(s) == r'\Pi'
     s = 'pi'
     assert translate(s) == r'\pi'
+    s = 'LamdaHatDOT'
+    assert translate(s) == r'\dot{\hat{\Lambda}}'
+
+def test_accents():
+    # Test each accent individually in the simplest case (with funny cases)
+    assert latex(symbols("xMathring")) == r"\mathring{x}"
+    assert latex(symbols("xCheck")) == r"\check{x}"
+    assert latex(symbols("xBreve")) == r"\breve{x}"
+    assert latex(symbols("xAcute")) == r"\acute{x}"
+    assert latex(symbols("xGrave")) == r"\grave{x}"
+    assert latex(symbols("xTilde")) == r"\tilde{x}"
+    assert latex(symbols("xPrime")) == r"{x}'"
+    assert latex(symbols("xDDot")) == r"\ddot{x}"
+    assert latex(symbols("xBold")) == r"\boldsymbol{x}"
+    assert latex(symbols("xHat")) == r"\hat{x}"
+    assert latex(symbols("xDot")) == r"\dot{x}"
+    assert latex(symbols("xBar")) == r"\bar{x}"
+    assert latex(symbols("xVec")) == r"\vec{x}"
+    assert latex(symbols("xAbs")) == r"\left\lvert{x}\right\rvert"
+    assert latex(symbols("xPrM")) == r"{x}'"
+    assert latex(symbols("xBM")) == r"\boldsymbol{x}"
+    # Check a few combinations
+    assert latex(symbols("xvecdot")) == r"\dot{\vec{x}}"
+    assert latex(symbols("xDotVec")) == r"\vec{\dot{x}}"
+    assert latex(symbols("xHATabs")) == r"\left\lvert{\hat{x}}\right\rvert"
+    # Check a couple big, ugly combinations
+    assert latex(symbols('xMathringBm_yCheckPRM__zbreveAbs')) == r"\boldsymbol{\mathring{x}}^{\left\lvert{\breve{z}}\right\rvert}_{{\check{y}}'}"
+    assert latex(symbols('alphadothat_nVECDOT__tTildePrime')) == r"\hat{\dot{\alpha}}^{{\tilde{t}}'}_{\dot{\vec{n}}}"
 
 def test_greek_symbols():
     assert latex(Symbol('alpha'))   == r'\alpha'


### PR DESCRIPTION
This commit adds the ability to create more complex symbol names with accents, bolds, etc., and still have them translated into reasonable latex on printing.  This is inspired by the old `latex_ex` function from the `galgebra` submodule, from the current release version, but not the dev version.  For example, some times I want the vector `L` and its corresponding unit vector to both be defined, and possibly even distinguished from some scalar `L`.  I can do something like the following:

``` python
L, Lvec, Lhat = symbols('L, Lvec, Lhat')
```

When these are printed to latex, they will just be strings of italic letters.  The alternative would be something like

``` python
L, Lvec, Lhat = symbols(r'L, \vec{L}, \hat{L}')
```

But when these are printed to non-latex things, this comes out looking terrible.  For example, with the `ccode` printer, this would give invalid C code.

With this patch, a symbol name like `Lhat` gets converted to `\hat{L}` when printed to latex, without interfering with other sympy functions.  So this patch gives the best of both worlds for latex and ccode printing, for example.

The list of recognized macros is stored in the new `accent_keys` list.  Multiple accents can be combined, as in the symbol name `Lhatdot`, which becomes `\dot{\hat{L}}` in latex, while `Ldothat` becomes `\hat{\dot{L}}`.  Also, because some people like CamelCase variables, names like `LDotHat` are processed appropriately.  (In fact, any form of capitalization, such as all caps, is accepted.)
