### PR TITLE
Guard against extracting a gcd for symbolic powers.

### DIFF
--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -533,8 +533,11 @@ class Factors(object):
 
         for factor, exp in self.factors.items():
             if factor in other.factors:
-                exp = min(exp, other.factors[factor])
-                factors[factor] = exp
+                lt = (exp < other.factors[factor])
+                if lt is True:
+                    factors[factor] = exp
+                elif lt is False:
+                    factors[factor] = other.factors[factor]
 
         return Factors(factors)
 

--- a/sympy/core/tests/test_exprtools.py
+++ b/sympy/core/tests/test_exprtools.py
@@ -93,14 +93,18 @@ def test_Factors():
     n, d = x**(2 + y), x**2
     f = Factors(n)
     assert f.div(d) == f.normal(d) == (Factors(x**y), Factors())
+    assert f.gcd(d) == Factors()
     d = x**y
     assert f.div(d) == f.normal(d) == (Factors(x**2), Factors())
+    assert f.gcd(d) == Factors(d)
     n = d = 2**x
     f = Factors(n)
     assert f.div(d) == f.normal(d) == (Factors(), Factors())
+    assert f.gcd(d) == Factors(d)
     n, d = 2**x, 2**y
     f = Factors(n)
     assert f.div(d) == f.normal(d) == (Factors({S(2): x}), Factors({S(2): y}))
+    assert f.gcd(d) == Factors()
 
     # extraction of constant only
     n = x**(x + 3)

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -281,6 +281,12 @@ def test_issue_3826():
     assert trigsimp(tan(2*x).expand(trig=True)) == tan(2*x)
 
 
+def test_trigsimp_issue_4032():
+    n = Symbol('n', integer=True, positive=True)
+    assert trigsimp(2**(n/2)*cos(pi*n/4)/2 + 2**(n - 1)/2) == \
+        2**(n/2)*cos(pi*n/4)/2 + 2**n/4
+
+
 def test_trigsimp_noncommutative():
     x, y = symbols('x,y')
     A, B = symbols('A,B', commutative=False)


### PR DESCRIPTION
Fixes issue 4032: trigsimp() TypeError: symbolic boolean expression has no truth value
http://code.google.com/p/sympy/issues/detail?id=4032
