### PR TITLE
iterables: Fixed documentation issue mentioned in issue #4029

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -209,7 +209,8 @@ class Plot(object):
         if len(args) == 1 and isinstance(args[0], BaseSeries):
             self._series.append(*args)
         else:
-            self._series.append(Series(*args))
+            for i in args:
+				self._series.extend(i._series)
 
     def extend(self, arg):
         """Adds the series from another plot or a list of series."""

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -205,15 +205,67 @@ class Plot(object):
         del self._series[index]
 
     def append(self, *args):
-        """Adds one more graph to the figure."""
+        """Adds one more graph to the figure.
+
+        Raises a TypeError exception if the argument is not an
+        instance of BaseSeries.
+        
+        Examples:
+        =========
+
+        >>> from sympy.plotting import plot
+        >>> from sympy import symbols, sin
+        >>> x = symbols('x')
+              
+        >>> p1 = plot(x**2, (x, -5, 5))
+        >>> p1
+        Plot object containing:
+        [0]: cartesian line: x**2 for x over (-5.0, 5.0)
+
+        >>> p2 = plot(sin(x), (x, -5, 5))
+        >>> p2
+        Plot object containing:
+        [0]: cartesian line: sin(x) for x over (-5.0, 5.0)
+
+        >>> p1.append(p2[0])
+        >>> p1
+        Plot object containing: 
+        [0]: cartesian line: x**2 for x over (-5.0, 5.0)
+        [1]: cartesian line: sin(x) for x over (-5.0, 5.0)
+
+        """
         if len(args) == 1 and isinstance(args[0], BaseSeries):
             self._series.append(*args)
         else:
-            for i in args:
-				self._series.extend(i._series)
+            raise TypeError("Only BaseSeries can be appended to Plot")
 
     def extend(self, arg):
-        """Adds the series from another plot or a list of series."""
+        """Adds the series from another plot or a list of series.
+
+        Examples:
+        =========
+
+        >>> from sympy.plotting import plot
+        >>> from sympy import symbols, sin
+        >>> x = symbols('x')
+              
+        >>> p1 = plot(x**2, (x, -5, 5))
+        >>> p1
+        Plot object containing:
+        [0]: cartesian line: x**2 for x over (-5.0, 5.0)
+        
+        >>> p2 = plot(sin(x), (x, -5, 5))
+        >>> p2
+        Plot object containing:
+        [0]: cartesian line: sin(x) for x over (-5.0, 5.0)
+
+        >>> p1.extend(p2)
+        >>> p1
+        Plot object containing: 
+        [0]: cartesian line: x**2 for x over (-5.0, 5.0)
+        [1]: cartesian line: sin(x) for x over (-5.0, 5.0)
+
+        """
         if isinstance(arg, Plot):
             self._series.extend(arg._series)
         else:

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -237,12 +237,7 @@ class Plot(object):
         if len(args) == 1 and isinstance(args[0], BaseSeries):
             self._series.append(*args)
         else:
-<<<<<<< HEAD
             raise TypeError("Only BaseSeries can be appended to Plot")
-=======
-            for i in args:
-		self._series.extend(i._series)
->>>>>>> 7550f5daec94423549c090e3cda556d90a6585f0
 
     def extend(self, arg):
         """Adds the series from another plot or a list of series.

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -210,7 +210,7 @@ class Plot(object):
             self._series.append(*args)
         else:
             for i in args:
-				self._series.extend(i._series)
+		self._series.extend(i._series)
 
     def extend(self, arg):
         """Adds the series from another plot or a list of series."""

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -876,7 +876,7 @@ def rotate_left(x, y):
 
 def rotate_right(x, y):
     """
-    Left rotates a list x by the number of steps specified
+    Right rotates a list x by the number of steps specified
     in y.
 
     Examples


### PR DESCRIPTION
The docstring for iterables/rotate_right read "Left rotates" instead of "Right rotates"
