### PR TITLE
fixed documentation bug as per issue #4029

### DIFF
--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -876,7 +876,7 @@ def rotate_left(x, y):
 
 def rotate_right(x, y):
     """
-    Left rotates a list x by the number of steps specified
+    Right rotates a list x by the number of steps specified
     in y.
 
     Examples


### PR DESCRIPTION
Docstring for iterables/rotate_right read "Left rotates" instead of "Right rotates". Mentioned in [issue #4029](https://code.google.com/p/sympy/issues/detail?id=4029&sort=-opened&colspec=ID%20Type%20Status%20Priority%20Milestone%20Reporter%20Summary%20Stars%20Opened) in the Google bug tracker.
