### PR TITLE
Fix ipython tests when readline isn't available.

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+from sympy.external import import_module
 from sympy.interactive.printing import init_printing
 
 preexec_source = """\
@@ -288,7 +289,9 @@ def init_ipython_session(argv=[], auto_symbols=False, auto_int_to_Integer=False)
         app.initialize(argv)
 
         if auto_symbols:
-            enable_automatic_symbols(app)
+            readline = import_module("readline")
+            if readline:
+                enable_automatic_symbols(app)
         if auto_int_to_Integer:
             enable_automatic_int_sympification(app)
 
@@ -468,8 +471,9 @@ def init_session(ipython=None, pretty_print=True, order=None,
         if not in_ipython:
             mainloop = ip.mainloop
 
-    if auto_symbols and (not ipython or IPython.__version__ < '0.11'):
-        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above")
+    readline = import_module("readline")
+    if auto_symbols and (not ipython or IPython.__version__ < '0.11' or not readline):
+        raise RuntimeError("automatic construction of symbols is possible only in IPython 0.11 or above with readline support")
     if auto_int_to_Integer and (not ipython or IPython.__version__ < '0.11'):
         raise RuntimeError("automatic int to Integer transformation is possible only in IPython 0.11 or above")
 

--- a/sympy/interactive/tests/test_ipython.py
+++ b/sympy/interactive/tests/test_ipython.py
@@ -14,6 +14,7 @@ from sympy.utilities.pytest import raises
 
 # run_cell was added in IPython 0.11
 ipython = import_module("IPython", min_module_version="0.11")
+readline = import_module("readline")
 
 if not ipython:
     #bin/test will not execute any tests now
@@ -21,6 +22,9 @@ if not ipython:
 
 
 def test_automatic_symbols():
+    # this implicitly requires readline
+    if not readline:
+        return None
     # NOTE: Because of the way the hook works, you have to use run_cell(code,
     # True).  This means that the code must have no Out, or it will be printed
     # during the tests.
@@ -52,6 +56,7 @@ def test_automatic_symbols():
 def test_int_to_Integer():
     # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
     app = init_ipython_session()
+    app.run_cell("from sympy import Integer")
     app.run_cell("a = 1")
     assert isinstance(app.user_ns['a'], int)
 


### PR DESCRIPTION
The automatic symbols feature depends implicitly on readline being available.
