### PR TITLE
Fix Piecewise() ccode bugs

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -79,20 +79,8 @@ class CCodePrinter(CodePrinter):
         # We treat top level Piecewise here to get if tests outside loops
         lines = []
         expr = piecewise_fold(expr)
-        if isinstance(expr, C.Piecewise):
-            for i, (e, c) in enumerate(expr.args):
-                if i == 0:
-                    lines.append("if (%s) {" % self._print(c))
-                elif i == len(expr.args) - 1 and c is True:
-                    lines.append("else {")
-                else:
-                    lines.append("else if (%s) {" % self._print(c))
-                code0 = self._doprint_a_piece(e, assign_to)
-                lines.extend(code0)
-                lines.append("}")
-        else:
-            code0 = self._doprint_a_piece(expr, assign_to)
-            lines.extend(code0)
+        code0 = self._doprint_a_piece(expr, assign_to)
+        lines.extend(code0)
 
         # format the output
         if self._settings["human"]:

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -63,6 +63,8 @@ class CCodePrinter(CodePrinter):
         Actually format the expression as C code.
         """
 
+        from sympy.functions import piecewise_fold
+
         if isinstance(assign_to, string_types):
             assign_to = C.Symbol(assign_to)
         elif not isinstance(assign_to, (C.Basic, type(None))):
@@ -76,6 +78,7 @@ class CCodePrinter(CodePrinter):
 
         # We treat top level Piecewise here to get if tests outside loops
         lines = []
+        expr = piecewise_fold(expr)
         if isinstance(expr, C.Piecewise):
             for i, (e, c) in enumerate(expr.args):
                 if i == 0:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -37,7 +37,10 @@ class CodePrinter(StrPrinter):
 
         # terms with no summations first
         if None in d:
-            text = CodePrinter.doprint(self, Add(*d[None]))
+            if isinstance(d[None], set):
+                text = CodePrinter.doprint(self, Add(*d[None]))
+            else:
+                text = CodePrinter.doprint(self, d[None])
         else:
             # If all terms have summations we must initialize array to Zero
             text = CodePrinter.doprint(self, 0)

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,5 +1,6 @@
 from sympy.core import pi, oo, symbols, Function, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda, Dummy
-from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt
+from sympy.functions import (Piecewise, sin, cos, Abs, exp, ceiling, sqrt,
+        piecewise_fold)
 from sympy.utilities.pytest import raises
 from sympy.printing.ccode import CCodePrinter
 from sympy.utilities.lambdify import implemented_function
@@ -135,6 +136,13 @@ def test_ccode_Piecewise_deep():
    pow(x, 2)
 ) )\
 """
+    assert p == s
+
+def test_ccode_Piecewise3():
+    t = symbols("t")
+    e = t*x*y + x**2 + y**2 + Piecewise((0, x < 0.5), (1, x >= 0.5)) + cos(t) - 1
+    p = ccode(piecewise_fold(e))
+    s = "if (x < 0.5) {\n   t*x*y + pow(x, 2) + pow(y, 2) + cos(t) - 1\n}\nelse if (x >= 0.5) {\n   t*x*y + pow(x, 2) + pow(y, 2) + cos(t)\n}"
     assert p == s
 
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -129,19 +129,19 @@ def test_ccode_Piecewise_deep():
     p = ccode(2*Piecewise((x, x < 1), (x**2, True)))
     s = \
 """\
-2*((x < 1) ? (
-   x
-)
-: (
-   pow(x, 2)
-) )\
+if (x < 1) {
+   2*x
+}
+else {
+   2*pow(x, 2)
+}\
 """
     assert p == s
 
 def test_ccode_Piecewise3():
     t = symbols("t")
     e = t*x*y + x**2 + y**2 + Piecewise((0, x < 0.5), (1, x >= 0.5)) + cos(t) - 1
-    p = ccode(piecewise_fold(e))
+    p = ccode(e)
     s = "if (x < 0.5) {\n   t*x*y + pow(x, 2) + pow(y, 2) + cos(t) - 1\n}\nelse if (x >= 0.5) {\n   t*x*y + pow(x, 2) + pow(y, 2) + cos(t)\n}"
     assert p == s
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -115,12 +115,12 @@ def test_ccode_Piecewise():
     p = ccode(Piecewise((x, x < 1), (x**2, True)))
     s = \
 """\
-if (x < 1) {
+((x < 1) ? (
    x
-}
-else {
+)
+: (
    pow(x, 2)
-}\
+) )\
 """
     assert p == s
 
@@ -129,12 +129,12 @@ def test_ccode_Piecewise_deep():
     p = ccode(2*Piecewise((x, x < 1), (x**2, True)))
     s = \
 """\
-if (x < 1) {
+((x < 1) ? (
    2*x
-}
-else {
+)
+: (
    2*pow(x, 2)
-}\
+) )\
 """
     assert p == s
 
@@ -142,7 +142,14 @@ def test_ccode_Piecewise3():
     t = symbols("t")
     e = t*x*y + x**2 + y**2 + Piecewise((0, x < 0.5), (1, x >= 0.5)) + cos(t) - 1
     p = ccode(e)
-    s = "if (x < 0.5) {\n   t*x*y + pow(x, 2) + pow(y, 2) + cos(t) - 1\n}\nelse if (x >= 0.5) {\n   t*x*y + pow(x, 2) + pow(y, 2) + cos(t)\n}"
+    s = """\
+((x < 0.5) ? (
+   t*x*y + pow(x, 2) + pow(y, 2) + cos(t) - 1
+)
+: (x >= 0.5) ? (
+   t*x*y + pow(x, 2) + pow(y, 2) + cos(t)
+)\
+"""
     assert p == s
 
 

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -82,6 +82,7 @@ import os
 from sympy import __version__ as sympy_version
 from sympy.core import Symbol, S, Expr, Tuple, Equality, Function
 from sympy.core.compatibility import is_sequence, StringIO, string_types
+from sympy.functions.elementary.piecewise import ExprCondPair
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
 from sympy.printing.fcode import fcode, FCodePrinter
@@ -153,6 +154,9 @@ class Routine(object):
 
         # symbols that should be arguments
         symbols = expressions.atoms(Symbol) - local_vars
+
+        # Remove _True possibly coming from Piecewise()
+        symbols = symbols - set([ExprCondPair.true_sentinel])
 
         # Decide whether to use output argument or return value
         return_val = []


### PR DESCRIPTION
TODO:
- [ ] remove the `piecewise_fold`, so that the generated code looks as much like the input expression as possible. If you want to generate code that's folded, you can call `piecewise_fold` manually yourself. 
- [ ] raise an exception if the "otherwise" condition in `Piecewise()` is missing.
- [ ] check and test that proper output is produced for `Piecewise()` for more than 2 conditions
- [ ] check and test expressions with two ore more `Piecewise()` with the same and different conditions
