### PR TITLE
Remove manual enable/disable of IPython formatters.

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -155,25 +155,20 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
             debug("init_printing: using png formatter")
             for cls in printable_types:
                 png_formatter.for_type(cls, _print_latex_png)
-            png_formatter.enabled = True
         elif use_latex == 'matplotlib':
             debug("init_printing: using matplotlib formatter")
             for cls in printable_types:
                 png_formatter.for_type(cls, _print_latex_matplotlib)
-            png_formatter.enabled = True
         else:
             debug("init_printing: not using any png formatter")
-            png_formatter.enabled = False
 
         latex_formatter = ip.display_formatter.formatters['text/latex']
         if use_latex in (True, 'mathjax'):
             debug("init_printing: using mathjax formatter")
             for cls in printable_types:
                 latex_formatter.for_type(cls, _print_latex_text)
-            latex_formatter.enabled = True
         else:
             debug("init_printing: not using mathjax formatter")
-            latex_formatter.enabled = False
     else:
         ip.set_hook('result_display', _result_display)
 


### PR DESCRIPTION
The `use_latex` argument to `init_printing` was manually enabling/disabling IPython's display formatters. This was breaking 1) matplotlib and 2) any image display in the notebook. No third party library should touch these settings in IPython.

Other questions to answer:
- [ ] I am not sure I like how the different options for `use_latex` work = True, False, png, mathjax.
- [ ] The mathjax option is horribly named. It is not mathjax, it is just plain latex, that is rendered by different engines in different contexts. When the underlying latex code in this mode gets run through nbconvert's LaTeX output, it is just dropped into the output verbatim.
