### PR TITLE
cross output matches input

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1657,7 +1657,11 @@ class MatrixBase(object):
         return self._new([row._mat for row in reversed(x)])
 
     def cross(self, b):
-        """Calculate the cross product of ``self`` and ``b``.
+        """Return the cross product of `self` and `b` relaxing the condition
+        of compatible dimensions: if each has 3 elements, a matrix of the
+        same type and shape as `self` will be returned. If `b` has the same
+        shape as `self` then common identities for the cross product (like
+        `a x b = - b x a`) will hold.
 
         See Also
         ========
@@ -1669,15 +1673,13 @@ class MatrixBase(object):
         if not is_sequence(b):
             raise TypeError("`b` must be an ordered iterable or Matrix, not %s." %
                 type(b))
-        if not ((self.rows == 1 and self.cols == 3 or
-                self.rows == 3 and self.cols == 1) and \
-                (b.rows == 1 and b.cols == 3 or
-                b.rows == 3 and b.cols == 1)):
+        if not (self.rows * self.cols == b.rows * b.cols == 3):
             raise ShapeError("Dimensions incorrect for cross product.")
         else:
-            return self._new(1, 3, ((self[1]*b[2] - self[2]*b[1]),
-                               (self[2]*b[0] - self[0]*b[2]),
-                               (self[0]*b[1] - self[1]*b[0])))
+            return self._new(self.rows, self.cols, (
+                (self[1]*b[2] - self[2]*b[1]),
+                (self[2]*b[0] - self[0]*b[2]),
+                (self[0]*b[1] - self[1]*b[0])))
 
     def dot(self, b):
         """Return the dot product of Matrix self and b relaxing the condition

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -586,7 +586,6 @@ def test_util():
 
     v1 = Matrix(1, 3, [1, 2, 3])
     v2 = Matrix(1, 3, [3, 4, 5])
-    assert v1.cross(v2) == Matrix(1, 3, [-2, 4, -2])
     assert v1.norm() == sqrt(14)
     assert v1.project(v2) == Matrix(1, 3, [R(39)/25, R(52)/25, R(13)/5])
     assert Matrix.zeros(1, 2) == Matrix(1, 2, [0, 0])
@@ -600,7 +599,6 @@ def test_util():
     test = Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert test.cofactorMatrix() == \
         Matrix([[-3, 6, -3], [6, -12, 6], [-3, 6, -3]])
-    raises(ShapeError, lambda: Matrix(1, 2, [1, 1]).cross(Matrix(1, 2, [1, 1])))
 
 
 def test_jacobian_hessian():
@@ -2155,18 +2153,21 @@ def test_issue2221():
 def test_cross():
     a = [1, 2, 3]
     b = [3, 4, 5]
-    ans = Matrix([-2, 4, -2]).T
+    col = Matrix([-2, 4, -2])
+    row = col.T
 
-    def test(M):
+    def test(M, ans):
         assert ans == M
         assert type(M) == cls
     for cls in classes:
         A = cls(a)
         B = cls(b)
-        test(A.cross(B))
-        test(A.T.cross(B))
-        test(A.T.cross(B.T))
-        test(A.cross(B.T))
+        test(A.cross(B), col)
+        test(A.cross(B.T), col)
+        test(A.T.cross(B.T), row)
+        test(A.T.cross(B), row)
+    raises(ShapeError, lambda:
+        Matrix(1, 2, [1, 1]).cross(Matrix(1, 2, [1, 1])))
 
 
 def test_hash():


### PR DESCRIPTION
This is just an update of #715 with an added docstring and a requirement that the dimensions in crossed matrices be the same.
