### PR TITLE
Respect local_dict and global_dict when splitting symbols

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -383,8 +383,14 @@ def split_symbols_custom(predicate):
                 symbol = tok[1][1:-1]
                 if predicate(symbol):
                     for char in symbol:
-                        result.extend([(NAME, "'%s'" % char), (OP, ')'),
-                                       (NAME, 'Symbol'), (OP, '(')])
+                        if char in local_dict or char in global_dict:
+                            # Get rid of the call to Symbol
+                            del result[-2:]
+                            result.extend([(OP, '('), (NAME, "%s" % char), (OP, ')'),
+                                           (NAME, 'Symbol'), (OP, '(')])
+                        else:
+                            result.extend([(NAME, "'%s'" % char), (OP, ')'),
+                                           (NAME, 'Symbol'), (OP, '(')])
                     # Delete the last three tokens: get rid of the extraneous
                     # Symbol( we just added, and also get rid of the last )
                     # because the closing parenthesis of the original Symbol is

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -1,3 +1,4 @@
+import sympy
 from sympy.parsing.sympy_parser import (
     parse_expr,
     standard_transformations,
@@ -103,6 +104,19 @@ def test_symbol_splitting():
     for letter in greek_letters:
         assert(parse_expr(letter, transformations=transformations) ==
                parse_expr(letter))
+
+    # Make sure symbol splitting resolves names
+    transformations += (implicit_multiplication,)
+    local_dict = { 'e': sympy.E }
+    cases = {
+        'xe': 'E*x',
+        'Iy': 'I*y',
+        'ee': 'E*E',
+    }
+    for case, expected in cases.items():
+        assert(parse_expr(case, local_dict=local_dict,
+                          transformations=transformations) ==
+               parse_expr(expected))
 
     # Make sure custom splitting works
     def can_split(symbol):


### PR DESCRIPTION
Fixes the issue at https://groups.google.com/forum/#!topic/sympy/GMGX7rpjnNE where `split_symbols` didn't respect `local_dict` or `global_dict` and just created `Symbol`s always.
