### PR TITLE
Revert "Make boolean expressions callable."

### DIFF
--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -7,6 +7,8 @@ from sympy.assumptions.ask import _extract_facts, Q
 from sympy.core import symbols
 from sympy.logic.boolalg import Or
 from sympy.printing import pretty
+from sympy.assumptions.ask import Q
+from sympy.utilities.pytest import XFAIL
 
 
 def test_equal():
@@ -45,9 +47,3 @@ def test_global():
     global_assumptions.clear()
     assert not Q.is_true(x > 0) in global_assumptions
     assert not Q.is_true(y > 0) in global_assumptions
-
-
-def test_composite_predicates():
-    pred = Q.integer | ~Q.positive
-    assert type(pred(x)) is Or
-    assert pred(x) == Q.integer(x) | ~Q.positive(x)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -47,9 +47,6 @@ class BooleanFunction(Application, Boolean):
     """
     is_Boolean = True
 
-    def __call__(self, *args):
-        return self.func(*[arg(*args) for arg in self.args])
-
     def _eval_simplify(self, ratio, measure):
         return simplify_logic(self)
 


### PR DESCRIPTION
This reverts commit 59443fd7f917a2f7dcdd046360d2c89ceef514bd.

This is consistent with the behavior of the rest of Basic and Expr, which no
longer define **call**, but rather use .rcall().

Ping @rlamy.

Conflicts:
sympy/assumptions/tests/test_assumptions_2.py
sympy/logic/boolalg.py
