### PR TITLE
Documenting (new) assumptions

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -58,7 +58,7 @@ class Q:
     transcendental = Predicate('transcendental')
 
     ## Real
-    real = Predicate('real', doc="""
+    real = Predicate('real', doc=r"""
     Real number predicate
 
     ``Q.real(x)`` is true iff ``x`` is a real number, i.e., it is in the
@@ -104,7 +104,7 @@ class Q:
     """)
 
     # XXX: Add extended_negative
-    negative = Predicate('negative', doc="""
+    negative = Predicate('negative', doc=r"""
     Negative number predicate
 
     ``Q.negative(x)`` is true iff ``x`` is a real number and `x < 0`, that is,
@@ -138,7 +138,7 @@ class Q:
     True
 
     """)
-    nonzero = Predicate('nonzero', doc="""
+    nonzero = Predicate('nonzero', doc=r"""
     Nonzero real number predicate.
 
     ``Q.nonzero(x)`` is true iff ``x`` is real and ``x`` is not zero.  Note in

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -64,6 +64,7 @@ class Q:
     ``Q.real(x)`` is true iff ``x`` is a real number, i.e., it is in the
     interval `(-\infty, \infty)`.  Note in particular that the infinities are
     not real. Use ``Q.extended_real`` if you want to consider those as well.
+
     A few important facts about reals:
 
     - Every real number is positive, negative, or zero.  Furthermore, because
@@ -95,7 +96,42 @@ class Q:
     True
 
     """)
-    negative = Predicate('negative')
+
+    # XXX: Add extended_negative
+    negative = Predicate('negative', doc="""
+    Negative number predicate
+
+    ``Q.negative(x)`` is true iff ``x`` is a real number and `x < 0`, that is,
+    it is in the interval `(-oo, 0)`.  Note in particular that negative
+    infinity is not negative.
+
+    A few important facts about negative numbers:
+
+    - Note that ``Q.nonnegative`` and ``~Q.negative`` are *not* the same
+      thing. ``~Q.negative(x)`` simply means that ``x`` is not negative,
+      whereas ``Q.nonnegative(x)`` means that ``x`` is real and not
+      negative, i.e., ``Q.nonnegative(x)`` is logically equivalent to
+      ``Q.zero(x) | Q.positive(x)``.  So for example, ``~Q.negative(I)`` is
+      true, whereas ``Q.nonnegative(I)`` is false.
+
+    - See the docstring of ``Q.real`` for more information about related facts.
+
+    Example
+    =======
+
+    >>> from sympy import Q, ask, symbols, I
+    >>> x = symbols('x')
+    >>> ask(Q.negative(x), Q.real(x) & ~Q.positive(x) & ~Q.zero(x))
+    True
+    >>> ask(Q.negative(-1))
+    True
+
+    >>> ask(Q.nonnegative(I))
+    False
+    >>> ask(~Q.negative(I))
+    True
+
+    """)
     nonzero = Predicate('nonzero')
     positive = Predicate('positive')
     nonpositive = Predicate('nonpositive')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -58,7 +58,43 @@ class Q:
     transcendental = Predicate('transcendental')
 
     ## Real
-    real = Predicate('real')
+    real = Predicate('real', doc="""
+    Real number predicate
+
+    ``Q.real(x)`` is true iff ``x`` is a real number, i.e., it is in the
+    interval `(-\infty, \infty)`.  Note in particular that the infinities are
+    not real. Use ``Q.extended_real`` if you want to consider those as well.
+    A few important facts about reals:
+
+    - Every real number is positive, negative, or zero.  Furthermore, because
+      these sets are pairwise disjoint, each real number is exactly one of
+      those three.
+
+    - Every real number is also complex.
+
+    - Every real number is either rational or irrational.
+
+    - Every real number is either algebraic or transcendental.
+
+    - The facts ``Q.negative``, ``Q.zero``, ``Q.positive``, ``Q.nonnegative``,
+      ``Q.nonpositive``, ``Q.nonzero``, ``Q.integer``, and ``Q.rational`` all
+      imply ``Q.real``, as do all facts that imply those facts.
+
+    - The facts ``Q.irrational``, ``Q.algebraic``, and ``Q.transcendental`` do
+      not imply ``Q.real``; they imply ``Q.complex``. An irrational,
+      algebraic, or transcendental number may or may not be real.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, ask, symbols
+    >>> x = symbols('x')
+    >>> ask(Q.real(x), Q.positive(x))
+    True
+    >>> ask(Q.real(0))
+    True
+
+    """)
     negative = Predicate('negative')
     nonzero = Predicate('nonzero')
     positive = Predicate('positive')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -195,7 +195,7 @@ def register_handler(key, handler):
         True
 
     """
-    if type(key) is Predicate:
+    if isinstance(key, Predicate):
         key = key.name
     try:
         getattr(Q, key).add_handler(handler)
@@ -205,7 +205,7 @@ def register_handler(key, handler):
 
 def remove_handler(key, handler):
     """Removes a handler from the ask system. Same syntax as register_handler"""
-    if type(key) is Predicate:
+    if isinstance(key, Predicate):
         key = key.name
     getattr(Q, key).remove_handler(handler)
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -85,6 +85,12 @@ class Q:
       not imply ``Q.real``; they imply ``Q.complex``. An irrational,
       algebraic, or transcendental number may or may not be real.
 
+    - The "non" facts (i.e., ``Q.nonnegative``, ``Q.nonzero``, and
+    ``Q.nonpositive``)  are not equivalent to not the fact, but rather, not
+    the fact *and* ``Q.real``.  For example, ``Q.nonnegative`` means
+    ``~Q.negative & Q.real``. So for example, ``I`` is not nonnegative,
+    nonzero, or nonpositive.
+
     Examples
     ========
 
@@ -132,7 +138,41 @@ class Q:
     True
 
     """)
-    nonzero = Predicate('nonzero')
+    nonzero = Predicate('nonzero', doc="""
+    Nonzero real number predicate.
+
+    ``Q.nonzero(x)`` is true iff ``x`` is real and ``x`` is not zero.  Note in
+    particular that ``Q.nonzero(x)`` is false if ``x`` is not real.  Use
+    ``~Q.zero(x)`` if you want the negation of being zero without any real
+    assumptions.
+
+    A few important facts about nonzero numbers:
+
+    - ``Q.nonzero`` is logically equivalent to ``Q.positive | Q.negative``.
+
+    - See the docstring of ``Q.real`` for more information about related
+      facts.
+
+    Example
+    =======
+
+    >>> from sympy import Q, ask, symbols, I
+    >>> x = symbols('x')
+    >>> print(ask(Q.nonzero(x), ~Q.zero(x)))
+    None
+    >>> ask(Q.nonzero(x), Q.positive(x))
+    True
+    >>> ask(Q.nonzero(x), Q.zero(x))
+    False
+    >>> ask(Q.nonzero(0))
+    False
+
+    >>> ask(Q.nonzero(I))
+    False
+    >>> ask(~Q.zero(I))
+    True
+
+    """)
     positive = Predicate('positive')
     nonpositive = Predicate('nonpositive')
     nonnegative = Predicate('nonnegative')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -173,7 +173,41 @@ class Q:
     True
 
     """)
-    positive = Predicate('positive')
+    positive = Predicate('positive', doc=r"""
+    Positive real number predicate.
+
+    ``Q.positive(x)`` is true iff ``x`` is real and `x > 0`, that is if ``x``
+    is in the interval `(0, \infty)`.  In particular, infinity is not
+    positive.
+
+    A few important facts about negative numbers:
+
+    - Note that ``Q.nonpositive`` and ``~Q.positive`` are *not* the same
+      thing. ``~Q.positive(x)`` simply means that ``x`` is not positive,
+      whereas ``Q.nonpositive(x)`` means that ``x`` is real and not
+      positive, i.e., ``Q.positive(x)`` is logically equivalent to
+      ``Q.negative(x) | Q.zero(x)``.  So for example, ``~Q.positive(I)`` is
+      true, whereas ``Q.nonpositive(I)`` is false.
+
+    - See the docstring of ``Q.real`` for more information about related facts.
+
+    Example
+    =======
+
+    >>> from sympy import Q, ask, symbols, I
+    >>> x = symbols('x')
+    >>> ask(Q.positive(x), Q.real(x) & ~Q.negative(x) & ~Q.zero(x))
+    True
+    >>> ask(Q.positive(1))
+    True
+
+    >>> ask(Q.nonpositive(I))
+    False
+    >>> ask(~Q.positive(I))
+    True
+
+
+    """)
     nonpositive = Predicate('nonpositive')
     nonnegative = Predicate('nonnegative')
     zero = Predicate('zero')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -55,6 +55,7 @@ class Q:
     irrational = Predicate('irrational')
     rational = Predicate('rational')
     algebraic = Predicate('algebraic')
+    transcendental = Predicate('transcendental')
 
     ## Real
     real = Predicate('real')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -78,18 +78,19 @@ class Q:
     - Every real number is either algebraic or transcendental.
 
     - The facts ``Q.negative``, ``Q.zero``, ``Q.positive``, ``Q.nonnegative``,
-      ``Q.nonpositive``, ``Q.nonzero``, ``Q.integer``, and ``Q.rational`` all
-      imply ``Q.real``, as do all facts that imply those facts.
+      ``Q.nonpositive``, ``Q.nonzero``, ``Q.integer``, ``Q.rational``, and
+      ``Q.irrational`` all imply ``Q.real``, as do all facts that imply those
+      facts.
 
-    - The facts ``Q.irrational``, ``Q.algebraic``, and ``Q.transcendental`` do
-      not imply ``Q.real``; they imply ``Q.complex``. An irrational,
-      algebraic, or transcendental number may or may not be real.
+    - The facts ``Q.algebraic``, and ``Q.transcendental`` do not imply
+      ``Q.real``; they imply ``Q.complex``. An algebraic or transcendental
+      number may or may not be real.
 
     - The "non" facts (i.e., ``Q.nonnegative``, ``Q.nonzero``, and
-    ``Q.nonpositive``)  are not equivalent to not the fact, but rather, not
-    the fact *and* ``Q.real``.  For example, ``Q.nonnegative`` means
-    ``~Q.negative & Q.real``. So for example, ``I`` is not nonnegative,
-    nonzero, or nonpositive.
+      ``Q.nonpositive``) are not equivalent to not the fact, but rather, not
+      the fact *and* ``Q.real``.  For example, ``Q.nonnegative`` means
+      ``~Q.negative & Q.real``. So for example, ``I`` is not nonnegative,
+      nonzero, or nonpositive.
 
     Examples
     ========

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -47,7 +47,6 @@ class Q:
     ## Number theory
     integer = Predicate('integer')
     prime = Predicate('prime')
-    real = Predicate('real')
     odd = Predicate('odd')
     composite = Predicate('composite')
     even = Predicate('even')
@@ -58,6 +57,7 @@ class Q:
     algebraic = Predicate('algebraic')
 
     ## Real
+    real = Predicate('real')
     negative = Predicate('negative')
     nonzero = Predicate('nonzero')
     positive = Predicate('positive')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -10,31 +10,47 @@ from sympy.assumptions.assume import (global_assumptions, Predicate,
 
 class Q:
     """Supported ask keys."""
+
+    # Generic
+    is_true = Predicate('is_true')
+
+    # Operators
     antihermitian = Predicate('antihermitian')
-    bounded = Predicate('bounded')
-    commutative = Predicate('commutative')
-    complex = Predicate('complex')
-    composite = Predicate('composite')
-    even = Predicate('even')
-    extended_real = Predicate('extended_real')
     hermitian = Predicate('hermitian')
+    commutative = Predicate('commutative')
+
+    # Complex numbers
+    complex = Predicate('complex')
     imaginary = Predicate('imaginary')
-    infinitesimal = Predicate('infinitesimal')
-    infinity = Predicate('infinity')
+
+    ## Number theory
     integer = Predicate('integer')
-    irrational = Predicate('irrational')
-    rational = Predicate('rational')
-    negative = Predicate('negative')
-    nonzero = Predicate('nonzero')
-    positive = Predicate('positive')
     prime = Predicate('prime')
     real = Predicate('real')
     odd = Predicate('odd')
-    is_true = Predicate('is_true')
+    composite = Predicate('composite')
+    even = Predicate('even')
+
+    ## Algebra
+    irrational = Predicate('irrational')
+    rational = Predicate('rational')
+    algebraic = Predicate('algebraic')
+
+    ## Real
+    negative = Predicate('negative')
+    nonzero = Predicate('nonzero')
+    positive = Predicate('positive')
     nonpositive = Predicate('nonpositive')
     nonnegative = Predicate('nonnegative')
     zero = Predicate('zero')
 
+    # Extended complex numbers
+    extended_real = Predicate('extended_real')
+    infinitesimal = Predicate('infinitesimal')
+    infinity = Predicate('infinity')
+    bounded = Predicate('bounded')
+
+    # Matrix
     symmetric = Predicate('symmetric')
     invertible = Predicate('invertible')
     singular = Predicate('singular')

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -12,7 +12,28 @@ class Q:
     """Supported ask keys."""
 
     # Generic
-    is_true = Predicate('is_true')
+    is_true = Predicate('is_true', doc="""
+    Generic predicate
+
+    ``Q.is_true(x)`` is true iff ``x`` is true. This only makes sense if ``x`` is a
+    predicate.
+    """
+    # TODO: we would like for this statement to be true:
+    # In general, ``Q.is_true(x)`` is not needed, as you can just use ``x``
+    # directly, e.g., instead of ``ask(Q.is_true(x))``, you can just write
+    # ``ask(x)``. ``Q.is_true`` is primarily intended for internal use, where
+    # it is useful to have all predicates as ``Predicate``s.
+    """
+    Example
+    =======
+
+    >>> from sympy import ask, Q, symbols
+    >>> x = symbols('x')
+    >>> ask(Q.is_true(True))
+    True
+
+    """
+    )
 
     # Operators
     antihermitian = Predicate('antihermitian')

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -99,6 +99,9 @@ class AppliedPredicate(Boolean):
     def _eval_ask(self, assumptions):
         return self.func.eval(self.arg, assumptions)
 
+# See Predicate.__new__
+class _sentinel:
+    pass
 
 class Predicate(Boolean):
     """A predicate is a function that returns a boolean value.
@@ -127,10 +130,21 @@ class Predicate(Boolean):
 
     is_Atom = True
 
-    def __new__(cls, name, handlers=None):
-        obj = Boolean.__new__(cls)
-        obj.name = name
-        obj.handlers = handlers or []
+    def __new__(cls, name, handlers=None, doc=''):
+        # We want to be able to document the assumptions. This requires
+        # putting docstrings on the instances of Predicate, so that things
+        # like help(Q.positive) work.  However, help() only looks at the
+        # __doc__ of classes, not instances.  To get around this, we create a
+        # custom subclass of Predicate for each instance, and put the
+        # docstring on that.  See http://stackoverflow.com/q/19392252/161801.
+        if name == _sentinel:
+            obj = Boolean.__new__(cls)
+        else:
+            obj = type(name.capitalize() + cls.__name__, (cls,),
+                {})(_sentinel)
+            obj.name = name
+            obj.handlers = handlers or []
+            obj.__class__.__doc__ = doc
         return obj
 
     def _hashable_content(self):
@@ -151,6 +165,22 @@ class Predicate(Boolean):
     @cacheit
     def sort_key(self, order=None):
         return self.class_key(), (1, (self.name,)), S.One.sort_key(), S.One
+
+    def __eq__(self, other):
+        # Needed because of the custom logic in __new__
+        if self is other:
+            return True
+
+        if type(self) is type(other):
+            return True
+
+        if self.__class__.__mro__[1:] == other.__class__.__mro__[1:]:
+            return self._hashable_content() == other._hashable_content()
+
+        return False
+
+    def __hash__(self):
+        return super(Predicate, self).__hash__()
 
     def eval(self, expr, assumptions=True):
         """

--- a/sympy/assumptions/assume.py
+++ b/sympy/assumptions/assume.py
@@ -103,6 +103,8 @@ class AppliedPredicate(Boolean):
 class _sentinel:
     pass
 
+__test__ = {}
+
 class Predicate(Boolean):
     """A predicate is a function that returns a boolean value.
 
@@ -126,6 +128,13 @@ class Predicate(Boolean):
         >>> Q.is_true(S(1) < x)
         Q.is_true(1 < x)
 
+    Documentation
+    =============
+
+    You can add documentation to Predicate instances by assigning the doc
+    parameter.
+
+
     """
 
     is_Atom = True
@@ -145,6 +154,12 @@ class Predicate(Boolean):
             obj.name = name
             obj.handlers = handlers or []
             obj.__class__.__doc__ = doc
+            # Allow these to be doctested
+            # XXX: This should be done better than this. For one thing, the
+            # doctester shows the test as coming from assume.py instead of
+            # ask.py.  Also, we don't need to register user-created predicates
+            # with the doctester.
+            __test__[obj.__class__.__name__] = obj.__class__
         return obj
 
     def _hashable_content(self):

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -116,6 +116,8 @@ class AskNonZeroHandler(CommonHandler):
 
     @staticmethod
     def Basic(expr, assumptions):
+        if ask(Q.real(expr)) is False:
+            return False
         if expr.is_number:
             # if there are no symbols just evalf
             return expr.evalf() != 0
@@ -139,7 +141,7 @@ class AskNonZeroHandler(CommonHandler):
     def Pow(expr, assumptions):
         return ask(Q.nonzero(expr.base), assumptions)
 
-    NaN = staticmethod(CommonHandler.AlwaysTrue)
+    NaN = staticmethod(CommonHandler.AlwaysFalse)
 
     @staticmethod
     def Abs(expr, assumptions):

--- a/sympy/assumptions/tests/test_assume.py
+++ b/sympy/assumptions/tests/test_assume.py
@@ -28,9 +28,15 @@ def test_Predicate():
     assert c.__class__.__name__ == 'CMyPredicate'
 
 def test_Predicate_doc():
-    doc = """
+    doc1 = """
 This is a predicate about a
 """
 
-    a = Predicate('a', doc=doc)
-    assert a.__class__.__doc__ == doc
+    doc2 = """
+This is another predicate about a
+"""
+    a = Predicate('a', doc=doc1)
+    assert a.__class__.__doc__ == doc1
+
+    a2 = Predicate('a', doc=doc2)
+    assert a2.__class__.__doc__ == doc2

--- a/sympy/assumptions/tests/test_assume.py
+++ b/sympy/assumptions/tests/test_assume.py
@@ -1,0 +1,36 @@
+from sympy import Predicate
+
+def test_Predicate():
+    # Test that nothing unusual happens with the Predicate.__new__ magic
+    a = Predicate('a')
+    a2 = Predicate('a')
+    b = Predicate('b')
+    assert a == a
+    assert a == a2
+    assert hash(a) == hash(a2)
+    assert not (a == b)
+
+    assert isinstance(a, Predicate)
+    assert type(a) != Predicate
+    assert a.__class__.__name__ == 'APredicate'
+
+    class MyPredicate(Predicate):
+        pass
+
+    c = MyPredicate('c')
+    c2 = MyPredicate('c')
+    d = MyPredicate('d')
+    assert c == c2
+    assert not (c == d)
+    assert isinstance(c, Predicate)
+    assert isinstance(c, MyPredicate)
+    assert type(c) != MyPredicate
+    assert c.__class__.__name__ == 'CMyPredicate'
+
+def test_Predicate_doc():
+    doc = """
+This is a predicate about a
+"""
+
+    a = Predicate('a', doc=doc)
+    assert a.__class__.__doc__ == doc

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -219,7 +219,7 @@ def test_nan():
     assert ask(Q.irrational(nan)) is False
     assert ask(Q.imaginary(nan)) is False
     assert ask(Q.positive(nan)) is False
-    assert ask(Q.nonzero(nan)) is True
+    assert ask(Q.nonzero(nan)) is False
     assert ask(Q.zero(nan)) is False
     assert ask(Q.even(nan)) is False
     assert ask(Q.odd(nan)) is False
@@ -467,6 +467,7 @@ def test_I():
     assert ask(Q.composite(z)) is False
     assert ask(Q.hermitian(z)) is False
     assert ask(Q.antihermitian(z)) is True
+    assert ask(Q.nonzero(z)) is False
 
     z = 1 + I
     assert ask(Q.commutative(z)) is True

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1457,7 +1457,11 @@ class SymPyDocTestFinder(DocTestFinder):
             tobj = obj if not isinstance(obj, property) else obj.fget
             lineno = self._find_lineno(tobj, source_lines)
 
-        assert lineno is not None
+        if lineno is None:
+            # We couldn't find it. We have to put *some* kind of number here,
+            # but if we put a number like 0 it will just add it to some offset
+            # and completely lie
+            lineno = float('nan')
 
         # Return a DocTest for this object.
         if module is None:


### PR DESCRIPTION
For now I have only pushed the infrastructure to document the assumptions.  I
had to do a little class hackery to make things work the way I wanted with
help().  The main disadvantage that I can think of this so far is that it
breaks picklability (I haven't tested if it works with dill yet).

I'll ping here when I have the docstrings written for the assumptions.
Ideally, I'd like to add even more infrastructure so that we can not only
write documentation in plain English, but also automatically include in the
documentation all the facts relating to each assumption, so that people can
see _exactly_ what facts are used to define each assumption.
