### PR TITLE
4023: better handling of exponents in nfloat

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2244,7 +2244,8 @@ def nfloat(expr, n=15, exponent=False):
     x**4.0 + y**0.5
 
     """
-    from sympy.core import Pow
+    from sympy.core.power import Pow
+    from sympy.polys.rootoftools import RootOf
 
     if iterable(expr, exclude=string_types):
         if isinstance(expr, (dict, Dict)):
@@ -2264,11 +2265,18 @@ def nfloat(expr, n=15, exponent=False):
             pass  # pure_complex(rv) is likely True
         return rv
 
+    # watch out for RootOf instances that don't like to have
+    # their exponents replaced with Dummies and also sometimes have
+    # problems with evaluating at low precision (issue 3294)
+    rv = rv.xreplace(dict([(ro, ro.n(n)) for ro in rv.atoms(RootOf)]))
+
     if not exponent:
-        reps = [(p, Pow(p.base.n(n), p.exp)) for p in rv.atoms(Pow)]
+        reps = [(p, Pow(p.base, Dummy())) for p in rv.atoms(Pow)]
         rv = rv.xreplace(dict(reps))
+    rv = rv.n(n)
+    if not exponent:
+        rv = rv.xreplace(dict([(d.exp, p.exp) for p, d in reps]))
     else:
-        rv = rv.n(n)
         # Pow._eval_evalf special cases Integer exponents so if
         # exponent is suppose to be handled we have to do so here
         rv = rv.xreplace(Transform(

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2265,12 +2265,10 @@ def nfloat(expr, n=15, exponent=False):
         return rv
 
     if not exponent:
-        reps = [(p, Pow(p.base, Dummy())) for p in rv.atoms(Pow)]
+        reps = [(p, Pow(p.base.n(n), p.exp)) for p in rv.atoms(Pow)]
         rv = rv.xreplace(dict(reps))
-    rv = rv.n(n)
-    if not exponent:
-        rv = rv.xreplace(dict([(d.exp, p.exp) for p, d in reps]))
     else:
+        rv = rv.n(n)
         # Pow._eval_evalf special cases Integer exponents so if
         # exponent is suppose to be handled we have to do so here
         rv = rv.xreplace(Transform(

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -558,6 +558,8 @@ def test_issue_1612():
 
 def test_nfloat():
     from sympy.core.basic import _aresame
+    from sympy.polys.rootoftools import RootOf
+
     x = Symbol("x")
     eq = x**(S(4)/3) + 4*x**(S(1)/3)/3
     assert _aresame(nfloat(eq), x**(S(4)/3) + (4.0/3)*x**(S(1)/3))
@@ -573,10 +575,14 @@ def test_nfloat():
     assert nfloat({sqrt(2): x}) == {sqrt(2): x}
     assert nfloat(cos(x + sqrt(2))) == cos(x + nfloat(sqrt(2)))
 
-    # issues 3243
+    # issue 3243
     f = S('x*lamda + lamda**3*(x/2 + 1/2) + lamda**2 + 1/4')
     assert not any(a.free_symbols for a in solve(f.subs(x, -0.139)))
 
     # issue 3533
     assert nfloat(-100000*sqrt(2500000001) + 5000000001) == \
         9.99999999800000e-11
+
+    # issue 4023
+    eq = cos(3*x**4 + y)*RootOf(x**5 + 3*x**3 + 1, 0)
+    assert str(nfloat(eq, exponent=False, n=1)) == '-0.7*cos(3.0*x**4 + y)'

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -223,11 +223,12 @@ def test_quintics_1():
     # if one uses solve to get the roots of a polynomial that has a RootOf
     # solution, make sure that the use of nfloat during the solve process
     # doesn't fail. Note: if you want numerical solutions to a polynomial
-    # it is *much* faster to use nroots to get them than to evaluate
-    # RootOf solutions (e.g. Poly(x**5 + 3*x + 7).nroots() to get the
-    # numerical roots of that expression.
-    assert nfloat(solve(x**5 + 3*x**3 + 7)[0], exponent=False) = \
-        RootOf(x**5 + 3*x**3 + 7, 0)
+    # it is *much* faster to use nroots to get them than to solve the
+    # equation only to get RootOf solutions which are then numerically
+    # evaluated. So for eq = x**5 + 3*x + 7 do Poly(eq).nroots() rather
+    # than [i.n() for i in solve(eq)] to get the numerical roots of eq.
+    assert nfloat(solve(x**5 + 3*x**3 + 7)[0], exponent=False) == \
+        RootOf(x**5 + 3*x**3 + 7, 0).n()
 
 
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -220,6 +220,16 @@ def test_quintics_1():
     for root in s:
         assert root.func == RootOf
 
+    # if one uses solve to get the roots of a polynomial that has a RootOf
+    # solution, make sure that the use of nfloat during the solve process
+    # doesn't fail. Note: if you want numerical solutions to a polynomial
+    # it is *much* faster to use nroots to get them than to evaluate
+    # RootOf solutions (e.g. Poly(x**5 + 3*x + 7).nroots() to get the
+    # numerical roots of that expression.
+    assert nfloat(solve(x**5 + 3*x**3 + 7)[0], exponent=False) = \
+        RootOf(x**5 + 3*x**3 + 7, 0)
+
+
 
 def test_highorder_poly():
     # just testing that the uniq generator is unpacked


### PR DESCRIPTION
When nfloat encountered RootOf instances the method
it used to leave the exponents alone didn't work because
RootOf instances don't allow non-univariate expression.
So RootOf(x**dummy_1 + x**dummy_2, 0) fails. The handling
of exponents is now handled in a more straightforward
manner and a test expression was added to solve's suite.

https://code.google.com/p/sympy/issues/detail?id=4023
