### PR TITLE
Use _argset in preorder_traversal

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1785,7 +1785,12 @@ class preorder_traversal(Iterator):
             self._skip_flag = False
             return
         if isinstance(node, Basic):
-            args = node.args
+            if not keys and hasattr(node, '_argset'):
+                # LatticeOp keeps args as a set. We should use this if we
+                # don't care about the order, to prevent unnecessary sorting.
+                args = node._argset
+            else:
+                args = node.args
             if keys:
                 if keys != True:
                     args = ordered(args, keys, default=False)


### PR DESCRIPTION
This makes atoms much faster on LatticeOps (like And and Or), because it 
avoids ever computing the sorted .args, which are internally stored as a 
frozenset.  This is implemented as the default, because the docstring says 
that if keys=False then no order is guaranteed, but if this becomes an issue, 
we should perhaps make keys=True the default and set it to False in atoms (the 
order never matters in atoms because it returns a set).
