### PR TITLE
Codegen fix (WIP)

### DIFF
--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -738,6 +738,31 @@ class FCodeGen(CodeGen):
         args = ", ".join("%s" % self._get_symbol(arg.name)
                 for arg in routine.arguments)
 
+        # if function declaration is too long to fit on one line
+        if (len(args) + len(routine.name) + 3) > 78:
+            # first function line can only be (78 - len(routine.name)) long
+            # the + 3 are 2 whitespaces and the open parens
+            
+            line_end = 77 - (len(routine.name) + 3)
+
+            arg_lines = []
+            while len(args) > line_end:
+                line_idx = args[:line_end].rfind(" ")
+                # look for first whitespace, starting from the right
+
+                if (line_idx == -1) or (line_idx > line_end):
+                    raise IOError(
+                        "Cannot split the arguments of your function into"
+                        " 78 length lines")
+                
+                arg_lines.append("%s &" %args[:line_idx])
+                args = args[line_idx:]
+                line_end = 77
+                # subsequent lines can be up to 77 characters long
+
+            arg_lines.append("%s" %args)
+            args = args = "\n".join(arg_lines)
+
         # name of the routine + arguments
         code_list.append("%s(%s)\n" % (routine.name, args))
         code_list = [ " ".join(code_list) ]

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -751,7 +751,7 @@ class FCodeGen(CodeGen):
                 # look for first whitespace, starting from the right
 
                 if (line_idx == -1) or (line_idx > line_end):
-                    raise IOError(
+                    raise CodeGenError(
                         "Cannot split the arguments of your function into"
                         " 78 length lines")
                 

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -113,6 +113,14 @@ def test_autowrap_args():
     assert f.args == "y, x, z"
     assert f.returns == "z"
 
+    long_x, long_y = symbols('a_very_long_symbol_which_requires_wrapping',
+                             'b_another_very_long_symbol_with_a_nice_name')
+    f = autowrap(Eq(z, long_x, long_y), backend = 'dummy',
+                 args =[long_x, long_y])
+    assert f.returns == "z"
+    assert f.args == ("a_very_long_symbol_which_requires_wrapping,"
+                      " b_another_very_long_symbol_with_a_nice_name")
+
 
 def test_autowrap_store_files():
     x, y = symbols('x y')

--- a/sympy/utilities/tests/test_autowrap.py
+++ b/sympy/utilities/tests/test_autowrap.py
@@ -115,7 +115,7 @@ def test_autowrap_args():
 
     long_x, long_y = symbols('a_very_long_symbol_which_requires_wrapping',
                              'b_another_very_long_symbol_with_a_nice_name')
-    f = autowrap(Eq(z, long_x, long_y), backend = 'dummy',
+    f = autowrap(Eq(z, long_x + long_y), backend = 'dummy',
                  args =[long_x, long_y])
     assert f.returns == "z"
     assert f.args == ("a_very_long_symbol_which_requires_wrapping,"


### PR DESCRIPTION
As discussed: https://groups.google.com/forum/#!topic/sympy/7E3ISrPh28M

The codegen does not insert linebreaks in the function name declaration.  This can occur if the total length of symbol names + function header is longer than 78 characters - which is common if someone gives explicit names to parameters and variables.

I wrote a basic test case too, although I wasn't able to get it to run automatically - so that still needs to be fixed.  Pointers are very welcome.
