### PR TITLE
Fortran code printing of logical and relational operators.

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -15,7 +15,6 @@ from sympy.core import S, C
 from sympy.core.compatibility import string_types
 from sympy.printing.codeprinter import CodePrinter
 from sympy.printing.precedence import precedence
-from sympy.core.compatibility import default_sort_key
 
 # dictionary mapping sympy function to (argument_conditions, C_function).
 # Used in CCodePrinter._print_Function(self)
@@ -176,20 +175,6 @@ class CCodePrinter(CodePrinter):
                             self._print(expr.args[-1].expr)))
         code = "%s" + last_line
         return code % ": ".join(ecpairs) + " )"
-
-    def _print_And(self, expr):
-        PREC = precedence(expr)
-        return ' && '.join(self.parenthesize(a, PREC)
-                for a in sorted(expr.args, key=default_sort_key))
-
-    def _print_Or(self, expr):
-        PREC = precedence(expr)
-        return ' || '.join(self.parenthesize(a, PREC)
-                for a in sorted(expr.args, key=default_sort_key))
-
-    def _print_Not(self, expr):
-        PREC = precedence(expr)
-        return '!' + self.parenthesize(expr.args[0], PREC)
 
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from sympy.core import C, Add, Mul, Pow, S
+from sympy.core.compatibility import default_sort_key
 from sympy.core.mul import _keep_coeff
 from sympy.printing.str import StrPrinter
 from sympy.printing.precedence import precedence
@@ -17,6 +18,12 @@ class CodePrinter(StrPrinter):
     """
     The base class for code-printing subclasses.
     """
+
+    _operators = {
+        'and': ' && ',
+        'or': ' || ',
+        'not': '!',
+    }
 
     def _doprint_a_piece(self, expr, assign_to=None):
         # Here we print an expression that may contain Indexed objects, they
@@ -143,6 +150,20 @@ class CodePrinter(StrPrinter):
     _print_Catalan = _print_NumberSymbol
     _print_EulerGamma = _print_NumberSymbol
     _print_GoldenRatio = _print_NumberSymbol
+
+    def _print_And(self, expr):
+        PREC = precedence(expr)
+        return self._operators['and'].join(self.parenthesize(a, PREC)
+                for a in sorted(expr.args, key=default_sort_key))
+
+    def _print_Or(self, expr):
+        PREC = precedence(expr)
+        return self._operators['or'].join(self.parenthesize(a, PREC)
+                for a in sorted(expr.args, key=default_sort_key))
+
+    def _print_Not(self, expr):
+        PREC = precedence(expr)
+        return self._operators['not'] + self.parenthesize(expr.args[0], PREC)
 
     def _print_Mul(self, expr):
 

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -20,8 +20,8 @@ class CodePrinter(StrPrinter):
     """
 
     _operators = {
-        'and': ' && ',
-        'or': ' || ',
+        'and': '&&',
+        'or': '||',
         'not': '!',
     }
 
@@ -153,26 +153,26 @@ class CodePrinter(StrPrinter):
 
     def _print_And(self, expr):
         PREC = precedence(expr)
-        return self._operators['and'].join(self.parenthesize(a, PREC)
+        return (" %s " % self._operators['and']).join(self.parenthesize(a, PREC)
                 for a in sorted(expr.args, key=default_sort_key))
 
     def _print_Or(self, expr):
         PREC = precedence(expr)
-        return self._operators['or'].join(self.parenthesize(a, PREC)
+        return (" %s " % self._operators['or']).join(self.parenthesize(a, PREC)
                 for a in sorted(expr.args, key=default_sort_key))
 
     def _print_Xor(self, expr):
         if self._operators.get('xor') is None:
             return self._print_not_supported(expr)
         PREC = precedence(expr)
-        return self._operators['xor'].join(self.parenthesize(a, PREC)
+        return (" %s " % self._operators['xor']).join(self.parenthesize(a, PREC)
                 for a in sorted(expr.args, key=default_sort_key))
 
     def _print_Equivalent(self, expr):
         if self._operators.get('equivalent') is None:
             return self._print_not_supported(expr)
         PREC = precedence(expr)
-        return self._operators['equivalent'].join(self.parenthesize(a, PREC)
+        return (" %s " % self._operators['equivalent']).join(self.parenthesize(a, PREC)
                 for a in sorted(expr.args, key=default_sort_key))
 
     def _print_Not(self, expr):

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -161,6 +161,20 @@ class CodePrinter(StrPrinter):
         return self._operators['or'].join(self.parenthesize(a, PREC)
                 for a in sorted(expr.args, key=default_sort_key))
 
+    def _print_Xor(self, expr):
+        if self._operators.get('xor') is None:
+            return self._print_not_supported(expr)
+        PREC = precedence(expr)
+        return self._operators['xor'].join(self.parenthesize(a, PREC)
+                for a in sorted(expr.args, key=default_sort_key))
+
+    def _print_Equivalent(self, expr):
+        if self._operators.get('equivalent') is None:
+            return self._print_not_supported(expr)
+        PREC = precedence(expr)
+        return self._operators['equivalent'].join(self.parenthesize(a, PREC)
+                for a in sorted(expr.args, key=default_sort_key))
+
     def _print_Not(self, expr):
         PREC = precedence(expr)
         return self._operators['not'] + self.parenthesize(expr.args[0], PREC)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -45,6 +45,12 @@ class FCodePrinter(CodePrinter):
         "cosh", "tanh", "sqrt", "log", "exp", "erf", "Abs", "sign", "conjugate",
     ])
 
+    _operators = {
+        'and': ' .and. ',
+        'or': ' .or. ',
+        'not': '.not. ',
+    }
+
     def __init__(self, settings=None):
         CodePrinter.__init__(self, settings)
         self._init_leading_padding()

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -46,10 +46,10 @@ class FCodePrinter(CodePrinter):
     ])
 
     _operators = {
-        'and': ' .and. ',
-        'or': ' .or. ',
-        'xor': ' .neqv. ',
-        'equivalent': ' .eqv. ',
+        'and': '.and.',
+        'or': '.or.',
+        'xor': '.neqv.',
+        'equivalent': '.eqv.',
         'not': '.not. ',
     }
 

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -51,6 +51,10 @@ class FCodePrinter(CodePrinter):
         'not': '.not. ',
     }
 
+    _relationals = {
+        '!=': '/=',
+    }
+
     def __init__(self, settings=None):
         CodePrinter.__init__(self, settings)
         self._init_leading_padding()

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -48,6 +48,8 @@ class FCodePrinter(CodePrinter):
     _operators = {
         'and': ' .and. ',
         'or': ' .or. ',
+        'xor': ' .neqv. ',
+        'equivalent': ' .eqv. ',
         'not': '.not. ',
     }
 

--- a/sympy/printing/jscode.py
+++ b/sympy/printing/jscode.py
@@ -188,20 +188,6 @@ class JavascriptCodePrinter(CodePrinter):
         code = "if %s" + last_line
         return code % "else if ".join(ecpairs)
 
-    def _print_And(self, expr):
-        PREC = precedence(expr)
-        return ' && '.join(self.parenthesize(a, PREC)
-                for a in sorted(expr.args, key=default_sort_key))
-
-    def _print_Or(self, expr):
-        PREC = precedence(expr)
-        return ' || '.join(self.parenthesize(a, PREC)
-                for a in sorted(expr.args, key=default_sort_key))
-
-    def _print_Not(self, expr):
-        PREC = precedence(expr)
-        return '!' + self.parenthesize(expr.args[0], PREC)
-
     def _print_Function(self, expr):
         if expr.func.__name__ in self.known_functions:
             cond_cfunc = self.known_functions[expr.func.__name__]

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -7,6 +7,7 @@ from sympy.core.function import _coeff_isneg
 # Default precedence values for some basic types
 PRECEDENCE = {
     "Lambda": 1,
+    "Xor": 10,
     "Relational": 20,
     "Or": 20,
     "And": 30,
@@ -21,6 +22,8 @@ PRECEDENCE = {
 # treated like they were inherited, so not every single class has to be named
 # here.
 PRECEDENCE_VALUES = {
+    "Equivalent": PRECEDENCE["Xor"],
+    "Xor": PRECEDENCE["Xor"],
     "Or": PRECEDENCE["Or"],
     "And": PRECEDENCE["And"],
     "Add": PRECEDENCE["Add"],

--- a/sympy/printing/precedence.py
+++ b/sympy/printing/precedence.py
@@ -8,9 +8,9 @@ from sympy.core.function import _coeff_isneg
 PRECEDENCE = {
     "Lambda": 1,
     "Xor": 10,
-    "Relational": 20,
     "Or": 20,
     "And": 30,
+    "Relational": 35,
     "Add": 40,
     "Mul": 50,
     "Pow": 60,

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -23,6 +23,8 @@ class StrPrinter(Printer):
         "full_prec": "auto",
     }
 
+    _relationals = dict()
+
     def parenthesize(self, item, level):
         if precedence(item) <= level:
             return "(%s)" % self._print(item)
@@ -547,7 +549,7 @@ class StrPrinter(Printer):
 
     def _print_Relational(self, expr):
         return '%s %s %s' % (self.parenthesize(expr.lhs, precedence(expr)),
-                           expr.rel_op,
+                           self._relationals.get(expr.rel_op) or expr.rel_op,
                            self.parenthesize(expr.rhs, precedence(expr)))
 
     def _print_RootOf(self, expr):

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -182,6 +182,18 @@ def test_line_wrapping():
     )
 
 
+def test_fcode_precedence():
+    x, y = symbols("x y")
+    assert fcode(And(x < y, y < x + 1), source_format="free") == \
+        "x < y .and. y < x + 1"
+    assert fcode(Or(x < y, y < x + 1), source_format="free") == \
+        "x < y .or. y < x + 1"
+    assert fcode(Xor(x < y, y < x + 1, evaluate=False),
+        source_format="free") == "x < y .neqv. y < x + 1"
+    assert fcode(Equivalent(x < y, y < x + 1), source_format="free") == \
+        "x < y .eqv. y < x + 1"
+
+
 def test_fcode_Logical():
     x, y, z = symbols("x y z")
     # unary Not

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -3,6 +3,7 @@ from sympy import sin, cos, atan2, log, exp, gamma, conjugate, sqrt, \
 from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
+from sympy.logic.boolalg import And, Or, Not
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
@@ -178,6 +179,55 @@ def test_line_wrapping():
         "      x**10 + x**9 + x**8 + x**7 + x**6 + x**5 + x**4 + x**3 + x**2 + x\n"
         "     @ + 1"
     )
+
+
+def test_fcode_Logical():
+    x, y, z = symbols("x y z")
+    # unary Not
+    assert fcode(Not(x), source_format="free") == ".not. x"
+    # binary And
+    assert fcode(And(x, y), source_format="free") == "x .and. y"
+    assert fcode(And(x, Not(y)), source_format="free") == "x .and. .not. y"
+    assert fcode(And(Not(x), y), source_format="free") == "y .and. .not. x"
+    assert fcode(And(Not(x), Not(y)), source_format="free") == \
+        ".not. x .and. .not. y"
+    assert fcode(Not(And(x, y), evaluate=False), source_format="free") == \
+        ".not. (x .and. y)"
+    # binary Or
+    assert fcode(Or(x, y), source_format="free") == "x .or. y"
+    assert fcode(Or(x, Not(y)), source_format="free") == "x .or. .not. y"
+    assert fcode(Or(Not(x), y), source_format="free") == "y .or. .not. x"
+    assert fcode(Or(Not(x), Not(y)), source_format="free") == \
+        ".not. x .or. .not. y"
+    assert fcode(Not(Or(x, y), evaluate=False), source_format="free") == \
+        ".not. (x .or. y)"
+    # mixed And/Or
+    assert fcode(And(Or(y, z), x), source_format="free") == "x .and. (y .or. z)"
+    assert fcode(And(Or(z, x), y), source_format="free") == "y .and. (x .or. z)"
+    assert fcode(And(Or(x, y), z), source_format="free") == "z .and. (x .or. y)"
+    assert fcode(Or(And(y, z), x), source_format="free") == "x .or. y .and. z"
+    assert fcode(Or(And(z, x), y), source_format="free") == "y .or. x .and. z"
+    assert fcode(Or(And(x, y), z), source_format="free") == "z .or. x .and. y"
+    # trinary And
+    assert fcode(And(x, y, z), source_format="free") == "x .and. y .and. z"
+    assert fcode(And(x, y, Not(z)), source_format="free") == \
+        "x .and. y .and. .not. z"
+    assert fcode(And(x, Not(y), z), source_format="free") == \
+        "x .and. z .and. .not. y"
+    assert fcode(And(Not(x), y, z), source_format="free") == \
+        "y .and. z .and. .not. x"
+    assert fcode(Not(And(x, y, z), evaluate=False), source_format="free") == \
+        ".not. (x .and. y .and. z)"
+    # trinary Or
+    assert fcode(Or(x, y, z), source_format="free") == "x .or. y .or. z"
+    assert fcode(Or(x, y, Not(z)), source_format="free") == \
+        "x .or. y .or. .not. z"
+    assert fcode(Or(x, Not(y), z), source_format="free") == \
+        "x .or. z .or. .not. y"
+    assert fcode(Or(Not(x), y, z), source_format="free") == \
+        "y .or. z .or. .not. x"
+    assert fcode(Not(Or(x, y, z), evaluate=False), source_format="free") == \
+        ".not. (x .or. y .or. z)"
 
 
 def test_fcode_Piecewise():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -3,6 +3,7 @@ from sympy import sin, cos, atan2, log, exp, gamma, conjugate, sqrt, \
 from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
+from sympy.core.relational import Relational
 from sympy.logic.boolalg import And, Or, Not
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
@@ -228,6 +229,16 @@ def test_fcode_Logical():
         "y .or. z .or. .not. x"
     assert fcode(Not(Or(x, y, z), evaluate=False), source_format="free") == \
         ".not. (x .or. y .or. z)"
+
+
+def test_fcode_Relational():
+    x, y = symbols("x y")
+    assert fcode(Relational(x, y, "=="), source_format="free") == "x == y"
+    assert fcode(Relational(x, y, "!="), source_format="free") == "x /= y"
+    assert fcode(Relational(x, y, ">="), source_format="free") == "x >= y"
+    assert fcode(Relational(x, y, "<="), source_format="free") == "x <= y"
+    assert fcode(Relational(x, y, ">"), source_format="free") == "x > y"
+    assert fcode(Relational(x, y, "<"), source_format="free") == "x < y"
 
 
 def test_fcode_Piecewise():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -4,7 +4,7 @@ from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
 from sympy.core.relational import Relational
-from sympy.logic.boolalg import And, Or, Not
+from sympy.logic.boolalg import And, Or, Not, Equivalent, Xor
 from sympy.printing.fcode import fcode, FCodePrinter
 from sympy.tensor import IndexedBase, Idx
 from sympy.utilities.lambdify import implemented_function
@@ -229,6 +229,105 @@ def test_fcode_Logical():
         "y .or. z .or. .not. x"
     assert fcode(Not(Or(x, y, z), evaluate=False), source_format="free") == \
         ".not. (x .or. y .or. z)"
+
+
+def test_fcode_Xlogical():
+    x, y, z = symbols("x y z")
+    # binary Xor
+    assert fcode(Xor(x, y, evaluate=False), source_format="free") == \
+        "x .neqv. y"
+    assert fcode(Xor(x, Not(y), evaluate=False), source_format="free") == \
+        "x .neqv. .not. y"
+    assert fcode(Xor(Not(x), y, evaluate=False), source_format="free") == \
+        "y .neqv. .not. x"
+    assert fcode(Xor(Not(x), Not(y), evaluate=False),
+        source_format="free") == ".not. x .neqv. .not. y"
+    assert fcode(Not(Xor(x, y, evaluate=False), evaluate=False),
+        source_format="free") == ".not. (x .neqv. y)"
+    # binary Equivalent
+    assert fcode(Equivalent(x, y), source_format="free") == "x .eqv. y"
+    assert fcode(Equivalent(x, Not(y)), source_format="free") == \
+        "x .eqv. .not. y"
+    assert fcode(Equivalent(Not(x), y), source_format="free") == \
+        "y .eqv. .not. x"
+    assert fcode(Equivalent(Not(x), Not(y)), source_format="free") == \
+        ".not. x .eqv. .not. y"
+    assert fcode(Not(Equivalent(x, y), evaluate=False),
+        source_format="free") == ".not. (x .eqv. y)"
+    # mixed And/Equivalent
+    assert fcode(Equivalent(And(y, z), x), source_format="free") == \
+        "x .eqv. y .and. z"
+    assert fcode(Equivalent(And(z, x), y), source_format="free") == \
+        "y .eqv. x .and. z"
+    assert fcode(Equivalent(And(x, y), z), source_format="free") == \
+        "z .eqv. x .and. y"
+    assert fcode(And(Equivalent(y, z), x), source_format="free") == \
+        "x .and. (y .eqv. z)"
+    assert fcode(And(Equivalent(z, x), y), source_format="free") == \
+        "y .and. (x .eqv. z)"
+    assert fcode(And(Equivalent(x, y), z), source_format="free") == \
+        "z .and. (x .eqv. y)"
+    # mixed Or/Equivalent
+    assert fcode(Equivalent(Or(y, z), x), source_format="free") == \
+        "x .eqv. y .or. z"
+    assert fcode(Equivalent(Or(z, x), y), source_format="free") == \
+        "y .eqv. x .or. z"
+    assert fcode(Equivalent(Or(x, y), z), source_format="free") == \
+        "z .eqv. x .or. y"
+    assert fcode(Or(Equivalent(y, z), x), source_format="free") == \
+        "x .or. (y .eqv. z)"
+    assert fcode(Or(Equivalent(z, x), y), source_format="free") == \
+        "y .or. (x .eqv. z)"
+    assert fcode(Or(Equivalent(x, y), z), source_format="free") == \
+        "z .or. (x .eqv. y)"
+    # mixed Xor/Equivalent
+    assert fcode(Equivalent(Xor(y, z, evaluate=False), x),
+        source_format="free") == "x .eqv. (y .neqv. z)"
+    assert fcode(Equivalent(Xor(z, x, evaluate=False), y),
+        source_format="free") == "y .eqv. (x .neqv. z)"
+    assert fcode(Equivalent(Xor(x, y, evaluate=False), z),
+        source_format="free") == "z .eqv. (x .neqv. y)"
+    assert fcode(Xor(Equivalent(y, z), x, evaluate=False),
+        source_format="free") == "x .neqv. (y .eqv. z)"
+    assert fcode(Xor(Equivalent(z, x), y, evaluate=False),
+        source_format="free") == "y .neqv. (x .eqv. z)"
+    assert fcode(Xor(Equivalent(x, y), z, evaluate=False),
+        source_format="free") == "z .neqv. (x .eqv. y)"
+    # mixed And/Xor
+    assert fcode(Xor(And(y, z), x, evaluate=False), source_format="free") == \
+        "x .neqv. y .and. z"
+    assert fcode(Xor(And(z, x), y, evaluate=False), source_format="free") == \
+        "y .neqv. x .and. z"
+    assert fcode(Xor(And(x, y), z, evaluate=False), source_format="free") == \
+        "z .neqv. x .and. y"
+    assert fcode(And(Xor(y, z, evaluate=False), x), source_format="free") == \
+        "x .and. (y .neqv. z)"
+    assert fcode(And(Xor(z, x, evaluate=False), y), source_format="free") == \
+        "y .and. (x .neqv. z)"
+    assert fcode(And(Xor(x, y, evaluate=False), z), source_format="free") == \
+        "z .and. (x .neqv. y)"
+    # mixed Or/Xor
+    assert fcode(Xor(Or(y, z), x, evaluate=False), source_format="free") == \
+        "x .neqv. y .or. z"
+    assert fcode(Xor(Or(z, x), y, evaluate=False), source_format="free") == \
+        "y .neqv. x .or. z"
+    assert fcode(Xor(Or(x, y), z, evaluate=False), source_format="free") == \
+        "z .neqv. x .or. y"
+    assert fcode(Or(Xor(y, z, evaluate=False), x), source_format="free") == \
+        "x .or. (y .neqv. z)"
+    assert fcode(Or(Xor(z, x, evaluate=False), y), source_format="free") == \
+        "y .or. (x .neqv. z)"
+    assert fcode(Or(Xor(x, y, evaluate=False), z), source_format="free") == \
+        "z .or. (x .neqv. y)"
+    # trinary Xor
+    assert fcode(Xor(x, y, z, evaluate=False), source_format="free") == \
+        "x .neqv. y .neqv. z"
+    assert fcode(Xor(x, y, Not(z), evaluate=False), source_format="free") == \
+        "x .neqv. y .neqv. .not. z"
+    assert fcode(Xor(x, Not(y), z, evaluate=False), source_format="free") == \
+        "x .neqv. z .neqv. .not. y"
+    assert fcode(Xor(Not(x), y, z, evaluate=False), source_format="free") == \
+        "y .neqv. z .neqv. .not. x"
 
 
 def test_fcode_Relational():


### PR DESCRIPTION
Generalize the code printing of logical operators (And, Or, Not) and relational operators (==, !=, >=, etc.) to make them customizable by overriding a dict. Add the correct syntax for Fortran code printing for these and add tests. Also implement Fortran printing of Xor and Equivalent, and fix the precedence order for Relational.
