### PR TITLE
Bug piecewise

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -223,7 +223,7 @@ class Piecewise(Function):
                 intervals = self._sort_expr_cond(
                     sym, S.NegativeInfinity, S.Infinity, c)
                 values = []
-                for lower, upper in intervals:
+                for lower, upper, expr in intervals:
                     if (a < lower) is True:
                         mid = lower
                         rep = b
@@ -370,10 +370,10 @@ class Piecewise(Function):
             if self.__eval_cond(lower >= upper) is not True:  # Is it still an interval?
                 int_expr.append([lower, upper, expr])
             if cond is targetcond:
-                return [(lower, upper)]
+                return [(lower, upper, None)]
             elif isinstance(targetcond, Or) and cond in targetcond.args:
                 or_cond = Or(or_cond, cond)
-                or_intervals.append((lower, upper))
+                or_intervals.append((lower, upper, None))
                 if or_cond == targetcond:
                     or_intervals.sort(key=lambda x: x[0])
                     return or_intervals
@@ -414,7 +414,7 @@ class Piecewise(Function):
         if holes and default is not None:
             int_expr.extend(holes)
             if targetcond is True:
-                return [(h[0], h[1]) for h in holes]
+                return [(h[0], h[1], None) for h in holes]
         elif holes and default is None:
             raise ValueError("Called interval evaluation over piecewise "
                              "function on undefined intervals %s" %

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -466,6 +466,8 @@ def test_integrate_returns_piecewise():
         (0, Eq(n, 0)), ((n*x/2 - sin(n*x)*cos(n*x)/2)/n, True))
     assert integrate(x*sin(n*x), x) == Piecewise(
         (0, Eq(n, 0)), (-x*cos(n*x)/n + sin(n*x)/n**2, True))
+    assert integrate(exp(x*y),(x,0,z)) == Piecewise( \
+        (z, Eq(y,0)), (exp(y*z)/y - 1/y, True))
 
 
 def test_subs1():


### PR DESCRIPTION
This corrects a bug in the integration of a piecewise function.  For example, try Integral(exp(x*t),(t,0,y)).doit()

To the best of my knowledge, this does not seem to be covered by any of the current issues, but the
intention of replacing the Piecewise integration algorithm may make it obsolete at some point.
