### PR TITLE
KanesMethod optimisation

### DIFF
--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -489,38 +489,33 @@ class KanesMethod(object):
                 M = v.mass.subs(uaz).doit()
                 vel = v.masscenter.vel(N).subs(uaz).doit()
                 acc = v.masscenter.acc(N).subs(udotzero).subs(uaz).doit()
+                inertial_force = (M.diff(t) * vel + M * acc)
                 omega = v.frame.ang_vel_in(N).subs(uaz).doit()
                 I = v.central_inertia.subs(uaz).doit()
-                ang_vel = (I.dt(v.frame) & omega).subs(uaz).doit()
-                ang_acc = (I & v.frame.ang_acc_in(N)).subs(udotzero).subs(uaz).doit()
-                ang_acc2 = (omega ^ (I & omega)).subs(uaz).doit()
+                inertial_torque = ((I.dt(v.frame) & omega).subs(uaz).doit() +
+                    (I & v.frame.ang_acc_in(N)).subs(udotzero).subs(uaz).doit() +
+                    (omega ^ (I & omega)).subs(uaz).doit())
                 for j in range(o):
+                    tmp_vel = partials[i][0][j].subs(uaz).doit()
+                    tmp_ang = (I & partials[i][1][j].subs(uaz).doit())
                     for k in range(o):
                         # translational
-                        MM[j, k] += M * (partials[i][0][j].subs(uaz).doit() &
-                                         partials[i][0][k])
+                        MM[j, k] += M * (tmp_vel & partials[i][0][k])
                         # rotational
-                        temp = (I & partials[i][1][j].subs(uaz).doit())
-                        MM[j, k] += (temp &
-                                     partials[i][1][k])
-                    # translational components
-                    nonMM[j] += M.diff(t) * (vel & partials[i][0][j])
-                    nonMM[j] += M * (acc & partials[i][0][j])
-                    # rotational components
-                    nonMM[j] += ang_vel & partials[i][1][j]
-                    nonMM[j] += ang_acc & partials[i][1][j]
-                    nonMM[j] += ang_acc2 & partials[i][1][j]
+                        MM[j, k] += (tmp_ang & partials[i][1][k])
+                    nonMM[j] += inertial_force & partials[i][0][j]
+                    nonMM[j] += inertial_torque & partials[i][1][j]
 
             if isinstance(v, Particle):
                 M = v.mass.subs(uaz).doit()
                 vel = v.point.vel(N).subs(uaz).doit()
                 acc = v.point.acc(N).subs(udotzero).subs(uaz).doit()
+                inertial_force = (M.diff(t) * vel + M * acc)
                 for j in range(o):
+                    temp = partials[i][0][j].subs(uaz).doit()
                     for k in range(o):
-                        MM[j, k] += M * (partials[i][0][j].subs(uaz).doit() &
-                                         partials[i][0][k])
-                    nonMM[j] += M.diff(t) * (vel & partials[i][0][j])
-                    nonMM[j] += M * (acc & partials[i][0][j])
+                        MM[j, k] += M * (temp & partials[i][0][k])
+                    nonMM[j] += inertial_force & partials[i][0][j]
         # Negate FRSTAR since Kane defines the inertia forces/torques
         # to be negative and we didn't do so above.
         MM = MM.subs(qdots).subs(uaz).doit()


### PR DESCRIPTION
This simply hoists some constants out of loops.

It cuts down the run-time by ~40% when running [the pydy-code-gen benchmark](https://github.com/PythonDynamics/pydy-code-gen/blob/master/pydy_code_gen/tests/models.py#L97).
