### PR TITLE
Matrices: partial implementation of the Moore-Penrose pseudoinverse.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -6,7 +6,7 @@ from sympy.core.basic import Basic, C, Atom
 from sympy.core.expr import Expr
 from sympy.core.function import count_ops
 from sympy.core.power import Pow
-from sympy.core.symbol import Symbol, Dummy
+from sympy.core.symbol import Symbol, Dummy, symbols
 from sympy.core.numbers import Integer, ilcm, Rational, Float
 from sympy.core.singleton import S
 from sympy.core.sympify import sympify
@@ -783,6 +783,7 @@ class MatrixBase(object):
         LDLsolve
         LUsolve
         QRsolve
+        pinv_solve
         """
 
         if not self.is_square:
@@ -805,6 +806,7 @@ class MatrixBase(object):
         LDLsolve
         LUsolve
         QRsolve
+        pinv_solve
         """
         if not self.is_square:
             raise NonSquareMatrixError("Matrix must be square.")
@@ -829,6 +831,7 @@ class MatrixBase(object):
         LDLsolve
         LUsolve
         QRsolve
+        pinv_solve
         """
         if self.is_symmetric():
             L = self._cholesky()
@@ -862,6 +865,7 @@ class MatrixBase(object):
         LDLsolve
         LUsolve
         QRsolve
+        pinv_solve
         """
         if not self.is_diagonal:
             raise TypeError("Matrix should be diagonal")
@@ -895,6 +899,7 @@ class MatrixBase(object):
         diagonal_solve
         LUsolve
         QRsolve
+        pinv_solve
         """
         if self.is_symmetric():
             L, D = self.LDLdecomposition()
@@ -1262,6 +1267,7 @@ class MatrixBase(object):
         diagonal_solve
         LDLsolve
         QRsolve
+        pinv_solve
         LUdecomposition
         """
         if rhs.rows != self.rows:
@@ -1638,6 +1644,7 @@ class MatrixBase(object):
         diagonal_solve
         LDLsolve
         LUsolve
+        pinv_solve
         QRdecomposition
         """
 
@@ -3974,6 +3981,108 @@ class MatrixBase(object):
         M = self[:, :]
 
         return M.applyfunc(lambda x: x.replace(F, G, map))
+
+    def pinv(self):
+        """Calculate the Moore-Penrose pseudoinverse of the matrix.
+
+        The Moore-Penrose pseudoinverse exists and is unique for any matrix.
+        If the matrix is invertible, the pseudoinverse is the same as the
+        inverse.
+
+        See Also
+        ========
+
+        inv
+        pinv_solve
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Moore-Penrose_pseudoinverse
+
+        """
+        A = self
+        AH = self.H
+        # Trivial case: pseudoinverse of all-zero matrix is its transpose.
+        if A.is_zero:
+            return AH
+        try:
+            if self.rows >= self.cols:
+                return (AH * A).inv() * AH
+            else:
+                return AH * (A * AH).inv()
+        except ValueError:
+            # Matrix is not full rank, so A*AH cannot be inverted.
+            raise NotImplementedError('Rank-deficient matrices are not yet '
+                                      'supported.')
+
+    def pinv_solve(self, B, arbitrary_matrix=None):
+        """Solve Ax = B using the Moore-Penrose pseudoinverse.
+
+        There may be zero, one, or infinite solutions.  If one solution
+        exists, it will be returned.  If infinite solutions exist, one will
+        be returned based on the value of arbitrary_matrix.  If no solutions
+        exist, the least-squares solution is returned.
+
+        Parameters
+        ==========
+
+        B : Matrix
+            The right hand side of the equation to be solved for.  Must have
+            the same number of rows as matrix A.
+        arbitrary_matrix : Matrix
+            If the system is underdetermined (e.g. A has more columns than
+            rows), infinite solutions are possible, in terms of an arbitrary
+            matrix.  This parameter may be set to a specific matrix to use
+            for that purpose; if so, it must be the same shape as x, with as
+            many rows as matrix A has columns, and as many columns as matrix
+            B.  If left as None, an appropriate matrix containing symbols in
+            the form of ``wn_m`` will be used, with n and m being row and
+            column of each symbol.
+
+        Returns
+        =======
+
+        x : Matrix
+            The matrix that will satisfy Ax = B.  Will have as many rows as
+            matrix A has columns, and as many columns as matrix B.
+
+        See Also
+        ========
+
+        lower_triangular_solve
+        upper_triangular_solve
+        cholesky_solve
+        diagonal_solve
+        LDLsolve
+        LUsolve
+        QRsolve
+        pinv
+
+        Notes
+        =====
+
+        This may return either exact solutions or least squares solutions.
+        To determine which, check ``A * A.pinv() * B == B``.  It will be
+        True if exact solutions exist, and False if only a least-squares
+        solution exists.  Be aware that the left hand side of that equation
+        may need to be simplified to correctly compare to the right hand
+        side.
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Moore-Penrose_pseudoinverse#Obtaining_all_solutions_of_a_linear_system
+
+        """
+        from sympy.matrices import eye
+        A = self
+        A_pinv = self.pinv()
+        if arbitrary_matrix is None:
+            rows, cols = A.cols, B.cols
+            w = symbols('w:{0}_:{1}'.format(rows, cols))
+            arbitrary_matrix = self.__class__(cols, rows, w).T
+        return A_pinv * B + (eye(A.cols) - A_pinv*A) * arbitrary_matrix
 
 def classof(A, B):
     """

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -3989,6 +3989,16 @@ class MatrixBase(object):
         If the matrix is invertible, the pseudoinverse is the same as the
         inverse.
 
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> Matrix([[1, 2, 3], [4, 5, 6]]).pinv()
+        Matrix([
+        [-17/18,  4/9],
+        [  -1/9,  1/9],
+        [ 13/18, -2/9]])
+
         See Also
         ========
 
@@ -4036,9 +4046,9 @@ class MatrixBase(object):
             matrix.  This parameter may be set to a specific matrix to use
             for that purpose; if so, it must be the same shape as x, with as
             many rows as matrix A has columns, and as many columns as matrix
-            B.  If left as None, an appropriate matrix containing symbols in
-            the form of ``wn_m`` will be used, with n and m being row and
-            column of each symbol.
+            B.  If left as None, an appropriate matrix containing dummy
+            symbols in the form of ``wn_m`` will be used, with n and m being
+            row and column position of each symbol.
 
         Returns
         =======
@@ -4046,6 +4056,23 @@ class MatrixBase(object):
         x : Matrix
             The matrix that will satisfy Ax = B.  Will have as many rows as
             matrix A has columns, and as many columns as matrix B.
+
+        Examples
+        ========
+
+        >>> from sympy import Matrix
+        >>> A = Matrix([[1, 2, 3], [4, 5, 6]])
+        >>> B = Matrix([7, 8])
+        >>> A.pinv_solve(B)
+        Matrix([
+        [ _w0_0/6 - _w1_0/3 + _w2_0/6 - 55/18],
+        [-_w0_0/3 + 2*_w1_0/3 - _w2_0/3 + 1/9],
+        [ _w0_0/6 - _w1_0/3 + _w2_0/6 + 59/18]])
+        >>> A.pinv_solve(B, arbitrary_matrix=Matrix([0, 0, 0]))
+        Matrix([
+        [-55/18],
+        [   1/9],
+        [ 59/18]])
 
         See Also
         ========
@@ -4080,7 +4107,7 @@ class MatrixBase(object):
         A_pinv = self.pinv()
         if arbitrary_matrix is None:
             rows, cols = A.cols, B.cols
-            w = symbols('w:{0}_:{1}'.format(rows, cols))
+            w = symbols('w:{0}_:{1}'.format(rows, cols), cls=Dummy)
             arbitrary_matrix = self.__class__(cols, rows, w).T
         return A_pinv * B + (eye(A.cols) - A_pinv*A) * arbitrary_matrix
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -13,7 +13,7 @@ from sympy.matrices import (
     rot_axis3, wronskian, zeros)
 from sympy.core.compatibility import long
 from sympy.utilities.iterables import flatten, capture
-from sympy.utilities.pytest import raises, XFAIL
+from sympy.utilities.pytest import raises, XFAIL, slow
 
 from sympy.abc import x, y, z
 
@@ -2229,3 +2229,55 @@ def test_atoms():
     m = Matrix([[1, 2], [x, 1 - 1/x]])
     assert m.atoms() == set([S(1),S(2),S(-1), x])
     assert m.atoms(Symbol) == set([x])
+
+@slow
+def test_pinv():
+    from sympy.abc import a, b, c, d, e, f
+    # Pseudoinverse of an invertible matrix is the inverse.
+    A1 = Matrix([[a, b], [c, d]])
+    assert simplify(A1.pinv()) == simplify(A1.inv())
+    # Test the four properties of the pseudoinverse for various matrices.
+    As = [Matrix([[13, 104], [2212, 3], [-3, 5]]),
+          Matrix([[1, 7, 9], [11, 17, 19]]),
+          Matrix([a, b])]
+    for A in As:
+        A_pinv = A.pinv()
+        AAp = A * A_pinv
+        ApA = A_pinv * A
+        assert simplify(AAp * A) == A
+        assert simplify(ApA * A_pinv) == A_pinv
+        assert AAp.H == AAp
+        assert ApA.H == ApA
+
+def test_pinv_solve():
+    # Fully determined system (unique result, identical to other solvers).
+    A = Matrix([[1, 5], [7, 9]])
+    B = Matrix([12, 13])
+    assert A.pinv_solve(B) == A.cholesky_solve(B)
+    assert A.pinv_solve(B) == A.LDLsolve(B)
+    assert A.pinv_solve(B) == Matrix([sympify('-43/26'), sympify('71/26')])
+    # Fully determined, with two-dimensional B matrix.
+    B = Matrix([[12, 13, 14], [15, 16, 17]])
+    assert A.pinv_solve(B) == A.cholesky_solve(B)
+    assert A.pinv_solve(B) == A.LDLsolve(B)
+    assert A.pinv_solve(B) == Matrix([[-33, -37, -41], [69, 75, 81]]) / 26
+    # Underdetermined system (infinite results).
+    A = Matrix([[1, 0, 1], [0, 1, 1]])
+    B = Matrix([5, 7])
+    w0, w1, w2 = symbols('w:3_0')
+    assert A.pinv_solve(B) == Matrix([[w0/3 + w1/3 - w2/3 + 1],
+                                      [w0/3 + w1/3 - w2/3 + 3],
+                                      [-w0/3 - w1/3 + w2/3 + 4]])
+    # Overdetermined system (least squares results).
+    A = Matrix([[1, 0], [0, 0], [0, 1]])
+    B = Matrix([3, 2, 1])
+    assert A.pinv_solve(B) == Matrix([3, 1])
+    # Proof the solution is not exact.
+    assert A * A.pinv() * B != B
+
+@XFAIL
+def test_pinv_solve_rank_deficient():
+    A = Matrix([[1, 0], [0, 0]])
+    B = Matrix([3, 0])
+    w1 = symbols('w1')
+    assert A.pinv_solve(B) == Matrix([3, w1])

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2264,10 +2264,14 @@ def test_pinv_solve():
     # Underdetermined system (infinite results).
     A = Matrix([[1, 0, 1], [0, 1, 1]])
     B = Matrix([5, 7])
-    w0, w1, w2 = symbols('w:3_0')
-    assert A.pinv_solve(B) == Matrix([[w0/3 + w1/3 - w2/3 + 1],
-                                      [w0/3 + w1/3 - w2/3 + 3],
-                                      [-w0/3 - w1/3 + w2/3 + 4]])
+    solution = A.pinv_solve(B)
+    w = {}
+    for s in solution.atoms(Symbol):
+        # Extract dummy symbols used in the solution.
+        w[s.name] = s
+    assert solution == Matrix([[w['w0_0']/3 + w['w1_0']/3 - w['w2_0']/3 + 1],
+                               [w['w0_0']/3 + w['w1_0']/3 - w['w2_0']/3 + 3],
+                               [-w['w0_0']/3 - w['w1_0']/3 + w['w2_0']/3 + 4]])
     # Overdetermined system (least squares results).
     A = Matrix([[1, 0], [0, 0], [0, 1]])
     B = Matrix([3, 2, 1])


### PR DESCRIPTION
Added two methods: one to calculate the pseudoinverse, and another to apply it
in the solution of Ax = B.  The pseudoinverse calculation works only for full-
rank matrices and zero matrices; rank-deficient matrices will be more
complicated, possibly requiring a complete symbolic implementation of singular
value decomposition.  Until then, this should work well enough (at least for
me!).

See https://en.wikipedia.org/wiki/Moore-Penrose_pseudoinverse
