### PR TITLE
Sanitize assumptions on symbols.

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -72,6 +72,8 @@ class Symbol(AtomicExpr, Boolean):
             raise ValueError(
                 '''Symbol commutativity must be True or False.''')
         assumptions['commutative'] = is_commutative
+        for key in assumptions.keys():
+            assumptions[key] = bool(assumptions[key])
         return Symbol.__xnew_cached_(cls, name, **assumptions)
 
     def __new_stage2__(cls, name, **assumptions):

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -675,6 +675,13 @@ def test_issue_3176():
         assert (b*0).is_zero is None
 
 
+def test_sanitize_assumptions():
+    # issue 3567
+    x = Symbol('x', real=1, positive=0)
+    assert x.is_real is True
+    assert x.is_positive is False
+
+
 def test_special_assumptions():
     x = Symbol('x')
     z2 = z = Symbol('z', zero=True)


### PR DESCRIPTION
Convert assumptions to bool (this needs to happen before caching).

Fixes issue 3567: Sanitize FactKB
http://code.google.com/p/sympy/issues/detail?id=3567
