### PR TITLE
4094: add note about chop in docs

### DIFF
--- a/doc/src/tutorial/basic_operations.rst
+++ b/doc/src/tutorial/basic_operations.rst
@@ -143,7 +143,17 @@ takes a dictionary of ``Symbol: point`` pairs.
 
     >>> expr = cos(2*x)
     >>> expr.evalf(subs={x: 2.4})
-        0.0874989834394464
+    0.0874989834394464
+
+Sometimes there are roundoff errors smaller than the desired precision that
+remain after an expression is evaluated. Such numbers can be removed at the
+user's discretion by setting the ``chop`` flag to True.
+
+    >>> one = cos(1)**2 + sin(1)**2
+    >>> (one - 1).evalf()
+    -0.e-124
+    >>> (one - 1).evalf(chop=True)
+    0
 
 ``lambdify``
 ============


### PR DESCRIPTION
While checking this I noticed that chopping occurs for
any number in an expression, not only the final result.
This is ub-optimal. e.g. (pi/65).n(chop=.01) rounds to
zero because the 1/65 rounds to less than 0.02 and is
replaced with zero even though if the rounding was delayed
until the multiplication by pi occured, it wouldn't have
been rouned. I did not clutter the docs with this detail, however.
