### PR TITLE
Issue 2865: Remove XFAIL from test for fixed issue.

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2061,7 +2061,6 @@ def test_issue_860():
     assert e.subs(x, Matrix([3, 5, 3])) == Matrix([3, 5, 3])*y
 
 
-@XFAIL
 def test_issue_2865():
     assert str(Matrix([[1, 2], [3, 4]])) == 'Matrix([[1, 2], [3, 4]])'
 


### PR DESCRIPTION
This issue was closed in June with pull request #2088.  The corresponding test
no longer fails and therefore should not have an XFAIL.
