### PR TITLE
Recognize integers when splitting symbols for implicit parsing

### DIFF
--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -112,6 +112,8 @@ def test_symbol_splitting():
         'xe': 'E*x',
         'Iy': 'I*y',
         'ee': 'E*E',
+        'e23': 'E*23',
+        'I23yabc1x': 'I*23*y*a*b*c*1*x',
     }
     for case, expected in cases.items():
         assert(parse_expr(case, local_dict=local_dict,


### PR DESCRIPTION
Fixes Github issue #2589. Note that a string like `x123.5y` will lead to unexpected results because of how the tokenizer works (it'll give a name `x123`, a number `.5`, and a name `y`).
