### PR TITLE
preserve shape for 0-sized Matrices

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -568,13 +568,16 @@ class MatrixBase(object):
             A = self
             B = other
             if A.shape != B.shape:
-                raise ShapeError("Matrices size mismatch.")
+                raise ShapeError("Matrix size mismatch.")
             alst = A.tolist()
             blst = B.tolist()
             ret = [S.Zero]*A.rows
             for i in range(A.shape[0]):
                 ret[i] = list(map(lambda j, k: j + k, alst[i], blst[i]))
-            return classof(A, B)._new(ret)
+            rv = classof(A, B)._new(ret)
+            if not A.rows:
+                rv = rv.reshape(*A.shape)
+            return rv
         raise TypeError('cannot add matrix and %s' % type(other))
 
     def __radd__(self, other):

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2310,3 +2310,7 @@ def test_pinv_rank_deficient():
     assert w1.name == 'w1_0'
     assert solution == Matrix([3, w1])
     assert A * A.pinv() * B != B
+
+def test_issue4102():
+    assert ones(0, 1) + ones(0, 1) == Matrix(0, 1, [])
+    assert ones(1, 0) + ones(1, 0) == Matrix(1, 0, [])


### PR DESCRIPTION
make sure that `ones(0,1)+ones(0,1)` gives `Matrix(0, 1, [])` instead of `Matrix(0, 0, [])`

from https://code.google.com/p/sympy/issues/detail?id=4102
