### PR TITLE
Fixed bug in contraction of data in tensors

### DIFF
--- a/sympy/physics/hep/gamma_matrices.py
+++ b/sympy/physics/hep/gamma_matrices.py
@@ -41,7 +41,7 @@ class GammaMatrixHead(TensorHead):
     >>> G = GammaMatrixHead()
     >>> i = tensor_indices('i', G.LorentzIndex)
     >>> G(i)
-    gamma(i, auto_left, auto_right)
+    gamma(i, auto_left, -auto_right)
 
     Note that there is already an instance of GammaMatrixHead in four dimensions:
     GammaMatrix, which is simply declare as
@@ -52,7 +52,7 @@ class GammaMatrixHead(TensorHead):
     >>> from sympy.tensor.tensor import tensor_indices
     >>> i = tensor_indices('i', GammaMatrix.LorentzIndex)
     >>> GammaMatrix(i)
-    gamma(i, auto_left, auto_right)
+    gamma(i, auto_left, -auto_right)
 
     To access the metric tensor
 
@@ -119,7 +119,7 @@ class GammaMatrixHead(TensorHead):
         >>> ps = p(i0)*G(-i0)
         >>> qs = q(i0)*G(-i0)
         >>> G.simplify_gpgp(ps*qs*qs)
-        gamma(-L_0, auto_left, auto_right)*p(L_0)*q(L_1)*q(-L_1)
+        gamma(-L_0, auto_left, -auto_right)*p(L_0)*q(L_1)*q(-L_1)
         """
         def _simplify_gpgp(ex):
             tids = ex._tids
@@ -319,8 +319,8 @@ class GammaMatrixHead(TensorHead):
             if numG == 0:
                 spinor_free = [_[0] for _ in t._tids.free if _[0].tensortype is DiracSpinorIndex]
                 tcoeff = t.coeff
-                if spinor_free == [DiracSpinorIndex.auto_left, DiracSpinorIndex.auto_right]:
-                    t = t*DiracSpinorIndex.delta(-DiracSpinorIndex.auto_left, -DiracSpinorIndex.auto_right)
+                if spinor_free == [DiracSpinorIndex.auto_left, -DiracSpinorIndex.auto_right]:
+                    t = t*DiracSpinorIndex.delta(-DiracSpinorIndex.auto_left, DiracSpinorIndex.auto_right)
                     t = t.contract_metric(sg)
                     return t/tcoeff if tcoeff else t
                 else:
@@ -328,7 +328,7 @@ class GammaMatrixHead(TensorHead):
             if numG % 2 == 1:
                 return TensMul.from_data(S.Zero, [], [], [])
             elif numG > 4:
-                t = t.substitute_indices((DiracSpinorIndex.auto_right, -DiracSpinorIndex.auto_index), (DiracSpinorIndex.auto_left, DiracSpinorIndex.auto_index))
+                t = t.substitute_indices((-DiracSpinorIndex.auto_right, -DiracSpinorIndex.auto_index), (DiracSpinorIndex.auto_left, DiracSpinorIndex.auto_index))
                 a = t.split()
                 ind1, lind1, rind1 = a[i].args[-1]
                 ind2, lind2, rind2 = a[i + 1].args[-1]
@@ -445,11 +445,11 @@ class GammaMatrixHead(TensorHead):
         >>> i0, i1, i2 = tensor_indices('i0:3', G.LorentzIndex)
         >>> s0,s1,s2,s3,s4,s5 = tensor_indices('s0:6', DS)
         >>> ta = G(i0)*G(-i0)
-        >>> G._kahane_simplify(ta.coeff, ta._tids) - 4*DS.delta(DS.auto_left, DS.auto_right)
+        >>> G._kahane_simplify(ta.coeff, ta._tids) - 4*DS.delta(DS.auto_left, -DS.auto_right)
         0
         >>> tb = G(i0)*G(i1)*G(-i0)
         >>> G._kahane_simplify(tb.coeff, tb._tids)
-        -2*gamma(i1, auto_left, auto_right)
+        -2*gamma(i1, auto_left, -auto_right)
         >>> t = G(i0, s0, -s1)*G(-i0,s1,-s2)
         >>> G._kahane_simplify(t.coeff, t._tids) - 4*DS.delta(s0, -s2)
         0
@@ -461,7 +461,7 @@ class GammaMatrixHead(TensorHead):
 
         >>> tc = 3*G(i0)*G(i1)
         >>> G._kahane_simplify(tc.coeff, tc._tids)
-        3*gamma(i0, auto_left, S_0)*gamma(i1, -S_0, auto_right)
+        3*gamma(i0, auto_left, -S_0)*gamma(i1, S_0, -auto_right)
 
         References
         ==========
@@ -755,10 +755,10 @@ class GammaMatrixHead(TensorHead):
             spinor_free1 = [_ for _ in t1._tids.free if _[1] != 0]
             if spinor_free1:
                 if spinor_free:
-                    t = t.substitute_indices((DiracSpinorIndex.auto_left, spinor_free[0][0]), (DiracSpinorIndex.auto_right, spinor_free[-1][0]))
+                    t = t.substitute_indices((DiracSpinorIndex.auto_left, spinor_free[0][0]), (-DiracSpinorIndex.auto_right, spinor_free[-1][0]))
                 else:
                     # FIXME trace
-                    t = t*DiracSpinorIndex.delta(-DiracSpinorIndex.auto_right, -DiracSpinorIndex.auto_left)
+                    t = t*DiracSpinorIndex.delta(DiracSpinorIndex.auto_right, -DiracSpinorIndex.auto_left)
                     t = GammaMatrix.simplify_lines(t)
             else:
                 if spinor_free:

--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -44,7 +44,7 @@ def execute_gamma_simplify_tests_for_function(tfunc, D):
     # Fully G.Lorentz-contracted expressions, these return scalars:
 
     def add_delta(ne):
-        return ne * DiracSpinorIndex.delta(DiracSpinorIndex.auto_left, DiracSpinorIndex.auto_right)
+        return ne * DiracSpinorIndex.delta(DiracSpinorIndex.auto_left, -DiracSpinorIndex.auto_right)
 
     t = (G(mu)*G(-mu))
     ts = add_delta(D)
@@ -210,7 +210,7 @@ def test_kahane_simplify1():
     assert r.equals(t)
     t = G(i0)*G(-i0)
     r = G._kahane_simplify(t.coeff, t._tids)
-    assert r.equals(4*KD(sl, sr))
+    assert r.equals(4*KD(sl, -sr))
     t = G(i0,s0,-s1)*G(-i0,s1,-s2)
     r = G._kahane_simplify(t.coeff, t._tids)
     assert r.equals(4*KD(s0, -s2))
@@ -222,7 +222,7 @@ def test_kahane_simplify1():
     assert r.equals(-2*G(i1))
     t = G(i0)*G(i1)*G(-i0)*G(-i1)
     r = G._kahane_simplify(t.coeff, t._tids)
-    assert r.equals((2*D - D**2)*KD(sl, sr))
+    assert r.equals((2*D - D**2)*KD(sl, -sr))
     t = G(i0,s0,-s1)*G(i1,s1,-s2)*G(-i0,s2,-s3)*G(-i1,s3,-s0)
     r = G._kahane_simplify(t.coeff, t._tids)
     assert r.equals(4*(2*D - D**2))
@@ -230,7 +230,7 @@ def test_kahane_simplify1():
     raises(ValueError, lambda: G._kahane_simplify(t.coeff, t._tids))
     t = (G(mu)*G(nu)*G(-nu)*G(-mu))
     r = G._kahane_simplify(t.coeff, t._tids)
-    assert r.equals(D**2*KD(sl, sr))
+    assert r.equals(D**2*KD(sl, -sr))
     t = (G(mu,s0,-s1)*G(nu,s1,-s2)*G(-nu,s2,-s3)*G(-mu,s3,-s4))
     r = G._kahane_simplify(t.coeff, t._tids)
     assert r.equals(D**2*KD(s0, -s4))
@@ -239,13 +239,13 @@ def test_kahane_simplify1():
     assert r.equals(4*D**2)
     t = (G(mu)*G(nu)*G(-rho)*G(-nu)*G(-mu)*G(rho))
     r = G._kahane_simplify(t.coeff, t._tids)
-    assert r.equals((4*D - 4*D**2 + D**3)*KD(sl, sr))
+    assert r.equals((4*D - 4*D**2 + D**3)*KD(sl, -sr))
     t = (G(-mu)*G(-nu)*G(-rho)*G(-sigma)*G(nu)*G(mu)*G(sigma)*G(rho))
     r = G._kahane_simplify(t.coeff, t._tids)
-    assert r.equals((-16*D + 24*D**2 - 8*D**3 + D**4)*KD(sl, sr))
+    assert r.equals((-16*D + 24*D**2 - 8*D**3 + D**4)*KD(sl, -sr))
     t = (G(-mu)*G(nu)*G(-rho)*G(sigma)*G(rho)*G(-nu)*G(mu)*G(-sigma))
     r = G._kahane_simplify(t.coeff, t._tids)
-    assert r.equals((8*D - 12*D**2 + 6*D**3 - D**4)*KD(sl, sr))
+    assert r.equals((8*D - 12*D**2 + 6*D**3 - D**4)*KD(sl, -sr))
 
     # Expressions with free indices:
     t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
@@ -264,7 +264,7 @@ def test_gamma_matrix_class():
 
     t = A(k)*G(i)*G(-i)
     ts = simplify(t)
-    assert ts == 4*A(k)*DiracSpinorIndex.delta(DiracSpinorIndex.auto_left, DiracSpinorIndex.auto_right)
+    assert ts == 4*A(k)*DiracSpinorIndex.delta(DiracSpinorIndex.auto_left, -DiracSpinorIndex.auto_right)
 
     t = G(i)*A(k)*G(j)
     ts = simplify(t)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1154,7 +1154,7 @@ def test_hidden_indices_for_matrix_multiplication():
     E = tensorhead('E', [L, L, L, L], [[1], [1], [1], [1]], matrix_behavior=True)
     F = tensorhead('F', [L], [[1]], matrix_behavior=True)
 
-    assert (A(m0)) == A(m0, S.auto_left, S.auto_right)
+    assert (A(m0)) == A(m0, S.auto_left, -S.auto_right)
     assert (B(-m1)) == B(-m1, S.auto_left)
 
     A0 = A(m0)
@@ -1162,16 +1162,16 @@ def test_hidden_indices_for_matrix_multiplication():
     B1 = B(m1)
 
     assert (B1*A0*B0) == B(m1, s0)*A(m0, -s0, s1)*B(-m0, -s1)
-    assert (B0*A0) == B(-m0, s0)*A(m0, -s0, S.auto_right)
+    assert (B0*A0) == B(-m0, s0)*A(m0, -s0, -S.auto_right)
     assert (A0*B0) == A(m0, S.auto_left, s0)*B(-m0, -s0)
 
     C = tensorhead('C', [L, L], [[1]*2])
 
-    assert (C(True, True)) == C(L.auto_left, L.auto_right)
+    assert (C(True, True)) == C(L.auto_left, -L.auto_right)
 
-    assert (A(m0)*C(m1, -m0)) == A(m2, S.auto_left, S.auto_right)*C(m1, -m2)
+    assert (A(m0)*C(m1, -m0)) == A(m2, S.auto_left, -S.auto_right)*C(m1, -m2)
 
-    assert (C(True, True)*C(True, True)) == C(L.auto_left, m0)*C(-m0, L.auto_right)
+    assert (C(True, True)*C(True, True)) == C(L.auto_left, m0)*C(-m0, -L.auto_right)
 
     assert A(m0) == A(m0)
     assert B(-m1) == B(-m1)
@@ -1190,8 +1190,8 @@ def test_hidden_indices_for_matrix_multiplication():
     D0 = D(True, True, True, True)
     Aa = A(True, True, True)
 
-    assert D0 * Aa == D(L.auto_left, m0, S.auto_left, s0)*A(-m0, -s0, S.auto_right)
-    assert D(m0, m1) == D(m0, m1, S.auto_left, S.auto_right)
+    assert D0 * Aa == D(L.auto_left, m0, S.auto_left, s0)*A(-m0, -s0, -S.auto_right)
+    assert D(m0, m1) == D(m0, m1, S.auto_left, -S.auto_right)
 
     raises(ValueError, lambda: C(True))
     raises(ValueError, lambda: C())
@@ -1200,18 +1200,18 @@ def test_hidden_indices_for_matrix_multiplication():
 
     # test that a delta is automatically added on missing auto-matrix indices in TensAdd
     assert F(m2)*F(m3)*F(m4)*A(m1) + E(m1, m2, m3, m4) == \
-        E(m1, m2, m3, m4)*S.delta(S.auto_left, S.auto_right) +\
-        F(m2)*F(m3)*F(m4)*A(m1, S.auto_left, S.auto_right)
-    assert E(m1, m2) + F(m1)*F(m2) == E(m1, m2) + F(m1)*F(m2)*L.delta(L.auto_left, L.auto_right)
+        E(m1, m2, m3, m4)*S.delta(S.auto_left, -S.auto_right) +\
+        F(m2)*F(m3)*F(m4)*A(m1, S.auto_left, -S.auto_right)
+    assert E(m1, m2) + F(m1)*F(m2) == E(m1, m2) + F(m1)*F(m2)*L.delta(L.auto_left, -L.auto_right)
     assert E(m1, m2)*A(m3) + F(m1)*F(m2)*F(m3) == \
-        E(m1, m2, L.auto_left, L.auto_right)*A(m3, S.auto_left, S.auto_right) +\
-        F(m1)*F(m2)*F(m3)*L.delta(L.auto_left, L.auto_right)*S.delta(S.auto_left, S.auto_right)
+        E(m1, m2, L.auto_left, -L.auto_right)*A(m3, S.auto_left, -S.auto_right) +\
+        F(m1)*F(m2)*F(m3)*L.delta(L.auto_left, -L.auto_right)*S.delta(S.auto_left, -S.auto_right)
 
-    assert L.delta() == L.delta(L.auto_left, L.auto_right)
-    assert S.delta() == S.delta(S.auto_left, S.auto_right)
+    assert L.delta() == L.delta(L.auto_left, -L.auto_right)
+    assert S.delta() == S.delta(S.auto_left, -S.auto_right)
 
-    assert L.metric() == L.metric(L.auto_left, L.auto_right)
-    assert S.metric() == S.metric(S.auto_left, S.auto_right)
+    assert L.metric() == L.metric(L.auto_left, -L.auto_right)
+    assert S.metric() == S.metric(S.auto_left, -S.auto_right)
 
 
 ### TEST VALUED TENSORS ###
@@ -1412,7 +1412,7 @@ def test_valued_tensor_expressions():
     assert expr4 * 2 == expr3
     expr5 = expr4 * BA(-i1, -i0)
 
-    assert expr5 == (-2*x1 * (-20*E + 44*px - 8*py - 32*pz) + 136*x2 + 3*x3).expand()
+    assert expr5 == 28*E*x1 + 12*px*x1 + 20*py*x1 + 28*pz*x1 + 136*x2 + 3*x3
 
 
 def test_noncommuting_components():
@@ -1432,7 +1432,7 @@ def test_noncommuting_components():
 
     vtp = V1(i1, i2) * V2(-i2, -i1)
 
-    assert vtp == a ** 2 + b * c + c * b + d ** 2
+    assert vtp == a**2 + b**2 + c**2 + d**2
     assert vtp != a**2 + 2*b*c + d**2
 
     Vc = b * V1(i1, -i1)
@@ -1524,3 +1524,50 @@ def test_pprint():
 
     assert pretty(A) == "A(Lorentz)"
     assert pretty(A(i0)) == "A(i0)"
+
+
+def test_contract_automatrix_and_data():
+    numpy = import_module('numpy')
+    if numpy is None:
+        return
+
+    L = TensorIndexType('L')
+    S = TensorIndexType('S')
+    G = tensorhead('G', [L, S, S], [[1] * 3], matrix_behavior=True)
+
+    def G_data():
+        G.data = [[[1]]]
+    raises(ValueError, G_data)
+    L.data = [1, -1]
+    raises(ValueError, G_data)
+    S.data = [[1, 0], [0, 2]]
+    G.data = [
+        [[1, 2],
+         [3, 4]],
+        [[5, 6],
+         [7, 8]]
+    ]
+    m0, m1, m2 = tensor_indices('m0:3', L)
+    s0, s1, s2 = tensor_indices('s0:3', S)
+
+    assert (G(-m0).data == numpy.array([
+       [[1, 4],
+        [3, 8]],
+       [[-5, -12],
+        [-7, -16]]
+    ])).all()
+
+    (G(m0) * G(-m0)).data
+    G(m0, s0, -s1).data
+
+    c1 = G(m0, s0, -s1)*G(-m0, s1, -s2)
+    c2 = G(m0) * G(-m0)
+
+    assert (c1.data == c2.data).all()
+
+    del L.data
+    del S.data
+    del G.data
+    assert L.data is None
+    assert S.data is None
+    assert G.data is None


### PR DESCRIPTION
After merging the data PR and the auto-matrix PR into the tensor module, I tried to use them and I realized that they were clashing. Furthermore, I detected a serious fault in the contraction of data in a tensor, the numpy `tensordot` could be applied on the wrong axis.

I hope this gets fixed before 0.7.4
