### PR TITLE
Added _repr_latex_() methods to Vector and Dyadic for display in IPython...

### DIFF
--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -165,6 +165,10 @@ class Dyadic(object):
     def __neg__(self):
         return self * -1
 
+    def _repr_latex_(self):
+        """Returns a representation for rich display with IPython."""
+        return r'${}$'.format(self._latex())
+
     def _latex(self, printer=None):
         ar = self.args  # just to shorten things
         if len(ar) == 0:
@@ -1524,6 +1528,10 @@ class Vector(object):
                 ol += Dyadic([(v[0][2] * v2[0][1], v[1].z, v2[1].y)])
                 ol += Dyadic([(v[0][2] * v2[0][2], v[1].z, v2[1].z)])
         return ol
+
+    def _repr_latex_(self):
+        """Returns a representation for rich display with IPython."""
+        return r'${}$'.format(self._latex())
 
     def _latex(self, printer=None):
         """Latex Printing method. """


### PR DESCRIPTION
This addresses issue #2584. It adds the basic method needed to display our Vector and Dyadic objects in IPython notebooks as LaTeX renderings. But it isn't operating within SymPy's printing mechanism, `init_printing()`. This will display the LaTeX form regardless if the user calls `init_printing()`, so this may not be an appropriate solution.
![screenshot from 2013-11-17 12 06 01](https://f.cloud.github.com/assets/276007/1558777/9c1a69b0-4faa-11e3-9a79-43eaecd0b50f.png)
