### PR TITLE
Implement a new syntax for multivariable Order symbol

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 
 from sympy.core.core import C
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, is_sequence
 from sympy.core.singleton import S
 from sympy.core.operations import AssocOp
 from sympy.core.cache import cacheit
@@ -626,7 +626,7 @@ class Add(Expr, AssocOp):
             return self._new_rawargs(*args)
 
     @cacheit
-    def extract_leading_order(self, *symbols):
+    def extract_leading_order(self, symbols, point=None):
         """
         Returns the leading term and it's order.
 
@@ -643,7 +643,10 @@ class Add(Expr, AssocOp):
 
         """
         lst = []
-        seq = [(f, C.Order(f, *symbols)) for f in self.args]
+        symbols = list(symbols if is_sequence(symbols) else [symbols])
+        if not point:
+            point = [0]*len(symbols)
+        seq = [(f, C.Order(f, symbols, point)) for f in self.args]
         for ef, of in seq:
             for e, o in lst:
                 if o.contains(of) and o != of:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -882,7 +882,7 @@ class Pow(Expr):
                 # example:
                 # sin(x)**(-4) = 1/( sin(x)**4) = ...
                 # and expand the denominator:
-                nuse, denominator = n, O(1)
+                nuse, denominator = n, O(1, x)
                 while denominator.is_Order:
                     denominator = (b**(-e))._eval_nseries(x, n=nuse, logx=logx)
                     nuse += 1
@@ -981,7 +981,7 @@ class Pow(Expr):
                         arg = c*arg.expr
                     res.append(arg)
                 bs = Add(*res)
-                rv = (bs**e).series(x).subs(c, O(1))
+                rv = (bs**e).series(x).subs(c, O(1, x))
                 rv += order
                 return rv
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2774,7 +2774,7 @@ def test_sympy__series__limits__Limit():
 
 def test_sympy__series__order__Order():
     from sympy.series.order import Order
-    assert _test_args(Order(1, x, y))
+    assert _test_args(Order(1, (x, y)))
 
 
 def test_sympy__simplify__hyperexpand__Hyper_Function():

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2641,7 +2641,7 @@ def test_X15():
 def test_X16():
     # Multivariate Taylor series expansion => 1 - (x^2 + 2 x y + y^2)/2 + O(x^4)
     assert (series(cos(x + y), x + y, x0=0, n=4) == 1 - (x + y)**2/2 +
-            O(x**4 + x**3*y + x**2*y**2 + x*y**3 + y**4, x, y))
+            O(x**4 + x**3*y + x**2*y**2 + x*y**3 + y**4, (x, y)))
 
 
 @XFAIL

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1097,14 +1097,18 @@ class LatexPrinter(Printer):
 
     def _print_Order(self, expr):
         s = self._print(expr.expr)
-        if expr.point != S.Zero or len(expr.variables) > 1:
+        if expr.point and any(p != S.Zero for p in expr.point) or \
+           len(expr.variables) > 1:
             s += '; '
             if len(expr.variables) > 1:
                 s += self._print(expr.variables)
             elif len(expr.variables):
                 s += self._print(expr.variables[0])
             s += r'\rightarrow'
-            s += self._print(expr.point)
+            if len(expr.point) > 1:
+                s += self._print(expr.point)
+            else:
+                s += self._print(expr.point[0])
         return r"\mathcal{O}\left(%s\right)" % s
 
     def _print_Symbol(self, expr):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1008,7 +1008,8 @@ class PrettyPrinter(Printer):
 
     def _print_Order(self, expr):
         pform = self._print(expr.expr)
-        if expr.point != S.Zero or len(expr.variables) > 1:
+        if (expr.point and any(p != S.Zero for p in expr.point)) or \
+           len(expr.variables) > 1:
             pform = prettyForm(*pform.right("; "))
             if len(expr.variables) > 1:
                 pform = prettyForm(*pform.right(self._print(expr.variables)))
@@ -1018,7 +1019,10 @@ class PrettyPrinter(Printer):
                 pform = prettyForm(*pform.right(u(" \u2192 ")))
             else:
                 pform = prettyForm(*pform.right(" -> "))
-            pform = prettyForm(*pform.right(self._print(expr.point)))
+            if len(expr.point) > 1:
+                pform = prettyForm(*pform.right(self._print(expr.point)))
+            else:
+                pform = prettyForm(*pform.right(self._print(expr.point[0])))
         pform = prettyForm(*pform.parens())
         pform = prettyForm(*pform.left("O"))
         return pform

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1927,13 +1927,13 @@ O⎜─⎟\n\
     expr = O(x**2 + y**2)
     ascii_str = \
 """\
- / 2    2             \\\n\
-O\\x  + y ; (x, y) -> 0/\
+ / 2    2                  \\\n\
+O\\x  + y ; (x, y) -> (0, 0)/\
 """
     ucode_str = \
 u("""\
- ⎛ 2    2            ⎞\n\
-O⎝x  + y ; (x, y) → 0⎠\
+ ⎛ 2    2                 ⎞\n\
+O⎝x  + y ; (x, y) → (0, 0)⎠\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
@@ -1966,16 +1966,16 @@ O⎜─; x → ∞⎟\n\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = O(x**2 + y**2, x, y, oo)
+    expr = O(x**2 + y**2, (x, y), (oo, oo))
     ascii_str = \
 """\
- / 2    2              \\\n\
-O\\x  + y ; (x, y) -> oo/\
+ / 2    2                    \\\n\
+O\\x  + y ; (x, y) -> (oo, oo)/\
 """
     ucode_str = \
 u("""\
- ⎛ 2    2            ⎞\n\
-O⎝x  + y ; (x, y) → ∞⎠\
+ ⎛ 2    2                 ⎞\n\
+O⎝x  + y ; (x, y) → (∞, ∞)⎠\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -316,13 +316,19 @@ class StrPrinter(Printer):
         return "Normal(%s, %s)" % (expr.mu, expr.sigma)
 
     def _print_Order(self, expr):
-        if expr.point == S.Zero or not len(expr.variables):
+        if all(p is S.Zero for p in expr.point) or not len(expr.variables):
             if len(expr.variables) <= 1:
                 return 'O(%s)' % self._print(expr.expr)
             else:
                 return 'O(%s)' % self.stringify(expr.args[:-1], ', ', 0)
         else:
-            return 'O(%s)' % self.stringify(expr.args, ', ', 0)
+            if len(expr.variables) == 1:
+                args = [expr.expr, expr.variables[0]]
+                if expr.point[0] is not S.Zero:
+                    args.append(expr.point[0])
+            else:
+                args = expr.args
+            return 'O(%s)' % self.stringify(args, ', ', 0)
 
     def _print_Cycle(self, expr):
         """We want it to print as Cycle in doctests for which a repr is required.

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -226,9 +226,9 @@ def test_latex_functions():
     assert latex(Order(x, x)) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, x, 0)) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, x, oo)) == r"\mathcal{O}\left(x; x\rightarrow\infty\right)"
-    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow0\right)"
-    assert latex(Order(x, x, y, 0)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow0\right)"
-    assert latex(Order(x, x, y, oo)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\infty\right)"
+    assert latex(Order(x, (x, y))) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\begin{pmatrix}0, & 0\end{pmatrix}\right)"
+    assert latex(Order(x, (x, y), (0, 0))) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\begin{pmatrix}0, & 0\end{pmatrix}\right)"
+    assert latex(Order(x, (x, y), (oo, oo))) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\begin{pmatrix}\infty, & \infty\end{pmatrix}\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -225,13 +225,13 @@ def test_NegativeInfinity():
 def test_Order():
     assert str(O(x)) == "O(x)"
     assert str(O(x**2)) == "O(x**2)"
-    assert str(O(x*y)) == "O(x*y, x, y)"
+    assert str(O(x*y)) == "O(x*y, (x, y))"
     assert str(O(x, x)) == "O(x)"
     assert str(O(x, x, 0)) == "O(x)"
     assert str(O(x, x, oo)) == "O(x, x, oo)"
-    assert str(O(x, x, y)) == "O(x, x, y)"
-    assert str(O(x, x, y, 0)) == "O(x, x, y)"
-    assert str(O(x, x, y, oo)) == "O(x, x, y, oo)"
+    assert str(O(x, (x, y))) == "O(x, (x, y))"
+    assert str(O(x, (x, y), (0, 0))) == "O(x, (x, y))"
+    assert str(O(x, (x, y), (oo, oo))) == "O(x, (x, y), (oo, oo))"
 
 
 def test_Permutation_Cycle():

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -118,6 +118,9 @@ class Order(Expr):
             raise ValueError('Number of point values must be the same as '
                              'the number of variables.')
 
+        if any(p in variables for p in point):
+            raise ValueError('Point contains variables')
+
         if not all(p is S.Zero for p in point) and \
            not all(p is S.Infinity for p in point):
             raise NotImplementedError('Order at points other than 0 '

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -15,6 +15,16 @@ class Order(Expr):
     point to be 0 or positive infinity is currently supported. This is
     expressed in big O notation [1]_.
 
+    ``Order(expr, variables, point)`` receives at most 3 arguments:
+    an expression, a variable or list of distinct variables and a
+    point or list of limiting points corresponding to those variables.
+
+    If point is omitted, it's taken to be 0 (or list of zeros).
+
+    If both variables and points are omitted, variables are
+    taken from `expr.free_symbols` or from expr.variables property
+    if expr is an Order instance (in that case point is taken to be expr.point).
+
     The formal definition for the order of a function `g(x)` about a point `a`
     is such that `g(x) = O(f(x))` as `x \rightarrow a` if and only if for any
     `\delta > 0` there exists a `M > 0` such that `|g(x)| \leq M|f(x)|` for
@@ -87,8 +97,6 @@ class Order(Expr):
 
     In the multivariate case, it is assumed the limits w.r.t. the various
     symbols commute.
-
-    If no symbols are passed then all symbols in the expression are used.
 
     """
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -101,7 +101,11 @@ class Order(Expr):
         expr = sympify(expr)
 
         if not variables:
-            variables = list(expr.free_symbols)
+            if expr.is_Order:
+                variables = expr.variables
+                point = expr.point
+            else:
+                variables = list(expr.free_symbols)
         else:
             variables = list(variables if is_sequence(variables) else [variables])
 
@@ -130,12 +134,20 @@ class Order(Expr):
             return S.NaN
 
         if expr.is_Order:
-            v = set(expr.variables)
-            variables = v | set(variables)
-            if variables == v:
+            expr_vp = dict(zip(expr.variables, expr.point))
+            new_vp = dict(expr_vp)
+            vp = dict(zip(variables, point))
+            for v, p in vp.items():
+                if v in new_vp.keys():
+                    if p != new_vp[v]:
+                        raise ValueError('Points are different')
+                else:
+                    new_vp[v] = p
+            if set(expr_vp.keys()) == set(new_vp.keys()):
                 return expr
-            variables = list(variables)
-            point = [0]*len(variables) # FIXME
+            else:
+                variables = list(new_vp.keys())
+                point = [new_vp[v] for v in variables]
 
         elif variables:
 

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -112,7 +112,7 @@ class Order(Expr):
             point = [S.Zero]*len(variables)
         else:
             point = list(point if is_sequence(point) else [point])
-            point = map(sympify, point)
+            point = list(map(sympify, point))
 
         if len(point) != len(variables):
             raise ValueError('Number of point values must be the same as '

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -83,10 +83,10 @@ def test_simple_8():
 
 
 def test_as_expr_variables():
-    assert Order(x).as_expr_variables(None) == (x, (x, 0))
-    assert Order(x).as_expr_variables((x, 0)) == (x, (x, 0))
-    assert Order(y).as_expr_variables((x, 0)) == (y, (y, x, 0))
-    assert Order(y).as_expr_variables((x, y, 0)) == (y, (x, y, 0))
+    assert Order(x).as_expr_variables(None) == (x, ((x,), (0,)))
+    assert Order(x).as_expr_variables(((x,), (0,))) == (x, ((x,), (0,)))
+    assert Order(y).as_expr_variables(((x,), (0,))) == (y, ((y, x), (0, 0)))
+    assert Order(y).as_expr_variables(((x, y), (0, 0))) == (y, ((x, y), (0, 0)))
 
 
 def test_contains_0():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -18,7 +18,7 @@ def test_simple_1():
     assert Order(x)*3 == Order(x)
     assert -28*Order(x) == Order(x)
     assert Order(Order(x)) == Order(x)
-    assert Order(Order(x), y) == Order(Order(x), x, y)
+    assert Order(Order(x), y) == Order(Order(x), (x, y))
     assert Order(-23) == Order(1)
     assert Order(exp(x)) == Order(1, x)
     assert Order(exp(1/x)).expr == exp(1/x)
@@ -164,11 +164,11 @@ def test_multivar_1():
 
 
 def test_multivar_2():
-    assert Order(x**2*y + y**2*x, x, y).expr == x**2*y + y**2*x
+    assert Order(x**2*y + y**2*x, (x, y)).expr == x**2*y + y**2*x
 
 
 def test_multivar_mul_1():
-    assert Order(x + y)*x == Order(x**2 + y*x, x, y)
+    assert Order(x + y)*x == Order(x**2 + y*x, (x, y))
 
 
 def test_multivar_3():
@@ -222,7 +222,7 @@ def test_order_leadterm():
 
 def test_order_symbols():
     e = x*y*sin(x)*Integral(x, (x, 1, 2))
-    assert O(e) == O(x**2*y, x, y)
+    assert O(e) == O(x**2*y, (x, y))
     assert O(e, x) == O(x**2)
 
 
@@ -278,12 +278,12 @@ def test_oseries():
 
 def test_issue_1180():
     a, b = symbols('a b')
-    assert O(a, a, b) + O(1, a, b) == O(1, a, b)
-    assert O(b, a, b) + O(1, a, b) == O(1, a, b)
-    assert O(a + b, a, b) + O(1, a, b) == O(1, a, b)
-    assert O(1, a, b) + O(a, a, b) == O(1, a, b)
-    assert O(1, a, b) + O(b, a, b) == O(1, a, b)
-    assert O(1, a, b) + O(a + b, a, b) == O(1, a, b)
+    assert O(a, (a, b)) + O(1, (a, b)) == O(1, (a, b))
+    assert O(b, (a, b)) + O(1, (a, b)) == O(1, (a, b))
+    assert O(a + b, (a, b)) + O(1, (a, b)) == O(1, (a, b))
+    assert O(1, (a, b)) + O(a, (a, b)) == O(1, (a, b))
+    assert O(1, (a, b)) + O(b, (a, b)) == O(1, (a, b))
+    assert O(1, (a, b)) + O(a + b, (a, b)) == O(1, (a, b))
 
 
 def test_issue_1756():
@@ -328,7 +328,7 @@ def test_order_at_infinity():
     assert Order(x, x, oo)*3 == Order(x, x, oo)
     assert -28*Order(x, x, oo) == Order(x, x, oo)
     assert Order(Order(x, x, oo)) == Order(x, x, oo)
-    assert Order(Order(x, x, oo), y) == Order(Order(x, x, oo), x, y)
+    assert Order(Order(x, x, oo), y) == Order(Order(x, x, oo), (x, y))
     assert Order(3, x, oo) == Order(1, x, oo)
     assert Order(x**2 + x + y, x, oo) == O(x**2, x, oo)
     assert Order(x**2 + x + y, y, oo) == O(y, y, oo)
@@ -362,7 +362,7 @@ def test_order_at_infinity():
 
 def test_order_subs_limits():
     # issue 234
-    assert (1 + Order(x)).subs(x, 1/x) == 1 + Order(1/x, oo)
+    assert (1 + Order(x)).subs(x, 1/x) == 1 + Order(1/x, x, oo)
     assert (1 + Order(x)).limit(x, 0) == 1
     # issue 2670
     assert ((x + Order(x**2))/x).limit(x, 0) == 1

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -29,6 +29,7 @@ def test_simple_1():
     assert Order(x**2 + x + y, y) == O(1, y)
     raises(ValueError, lambda: Order(exp(x), x, x))
     raises(TypeError, lambda: Order(x, 2 - x))
+    raises(ValueError, lambda: Order(Order(x), x, oo))
 
 
 def test_simple_2():
@@ -322,13 +323,18 @@ def test_issue_3654():
     assert (1 + x**2)**10000*O(x) == O(x)
 
 
+@XFAIL
+def test_order_at_infinity_XFAILed():
+    assert Order(Order(x, x, oo), y) == Order(x, (x, y), (oo, 0))
+
 def test_order_at_infinity():
     assert Order(1 + x, x, oo) == Order(x, x, oo)
     assert Order(3*x, x, oo) == Order(x, x, oo)
     assert Order(x, x, oo)*3 == Order(x, x, oo)
     assert -28*Order(x, x, oo) == Order(x, x, oo)
     assert Order(Order(x, x, oo)) == Order(x, x, oo)
-    assert Order(Order(x, x, oo), y) == Order(Order(x, x, oo), (x, y))
+    #assert Order(Order(x, x, oo), y) == Order(x, (x, y), (oo, 0)) # see above
+    assert Order(Order(x, x, oo), y, oo) == Order(x, (x, y), (oo, oo))
     assert Order(3, x, oo) == Order(1, x, oo)
     assert Order(x**2 + x + y, x, oo) == O(x**2, x, oo)
     assert Order(x**2 + x + y, y, oo) == O(y, y, oo)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -27,8 +27,8 @@ def test_simple_1():
     assert Order(x**(5*o/3)).expr == x**(5*o/3)
     assert Order(x**2 + x + y, x) == O(1, x)
     assert Order(x**2 + x + y, y) == O(1, y)
-    assert Order(exp(x), x, x) == Order(1, x)
-    raises(NotImplementedError, lambda: Order(x, 2 - x))
+    raises(ValueError, lambda: Order(exp(x), x, x))
+    raises(TypeError, lambda: Order(x, 2 - x))
 
 
 def test_simple_2():


### PR DESCRIPTION
Supported input:
- `O(expr)`
- `O(expr, var)`
- `O(expr, var, pt)`
- `O(expr, (var1, var2, ..., varN))`
- `O(expr, (var1, var2, ..., varN), (pt1, pr2, ..., ptN))`

See also #2427.
