### PR TITLE
Raise correct error for issue 1015

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2062,6 +2062,12 @@ class Infinity(with_metaclass(Singleton, Number)):
         ``oo ** -p``     ``0``   ``p`` is number, ``oo``
         ================ ======= ==============================
 
+        See Also
+        ========
+        Pow
+        NaN
+        NegativeInfinity
+
         """
         if expt.is_positive:
             return S.Infinity
@@ -2221,6 +2227,13 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
         ``(-oo) ** o``   ``-oo`` ``o`` is positive odd integer
         ================ ======= ==============================
 
+        See Also
+        ========
+
+        Infinity
+        Pow
+        NaN
+
         """
         if isinstance(expt, Number):
             if expt is S.NaN or \
@@ -2273,11 +2286,11 @@ class NaN(with_metaclass(Singleton, Number)):
     is defined in the IEEE 754 floating point standard, and corresponds to the
     Python ``float('nan')``.
 
-    NaN serves as a place holder for numeric values that are indeterminate,
-    but not infinite.  Most operations on nan, produce another nan.  Most
-    indeterminate forms, such as ``0/0`` or ``oo - oo` produce nan.  Three
-    exceptions are ``0**0``, ``1**oo``, and ``oo**0``, which all produce ``1``
-    (this is consistent with Python's float).
+    NaN serves as a place holder for numeric values that are indeterminate.
+    Most operations on nan, produce another nan.  Most indeterminate forms,
+    such as ``0/0`` or ``oo - oo` produce nan.  Two exceptions are ``0**0``
+    and ``oo**0``, which all produce ``1`` (this is consistent with Python's
+    float).
 
     NaN is a singleton, and can be accessed by ``S.NaN``, or can be imported
     as ``nan``.

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -83,43 +83,62 @@ class Pow(Expr):
     """
     Defines the expression x**y as "x raised to a power y"
 
+    Singleton definitions involving (0, 1, -1, oo, -oo):
 
-    Singleton definitions involving (nan,0,1,-1,oo,-oo):
-        z**nan      = nan
-        z**0        = 1  although arguments over 0**0 exist
-        z**1        = z
-        (-oo)**(-1) = 0
-        (-1)**-1    = -1
-        S.Zero**-1  = oo  -- this is not strictly true,
-                        as 0**-1 may be undefined, but is convenient
-                        is some contexts where the base is assumed
-                        to be positive.
-        1**-1       = 1
-        oo**-1      = 0
-        nan**-1     = nan
-        nan**oo     = nan
-        nan**-oo    = nan
-        0**oo       = 0 because for all complex numbers z near 0, z**oo -> 0
-        0**-oo      = oo  -- this is strictly true, as
-                        as 0**oo may be oscillating between positive and
-                        negative values or rotating in the complex plane.
-                        It is convenient, however, when the base
-                        is positive.
-        1**oo       = nan because there are various cases where
-                        lim(x(t),t)=1, lim(y(t),t)=oo, but
-                        lim( x(t)**y(t), t) != 1
-        1**-oo      = nan for the same reason
-        (-1)**oo    = nan because of oscillations in the limit
-        (-1)**(-oo) = nan because of oscillations in the limit
-        oo**oo      = oo
-        oo**-oo     = 0
-        (-oo)**oo   = nan
-        (-oo)**-oo  = nan
+    +--------------+---------+-----------------------------------------------+
+    | expr         | value   | reason                                        |
+    +==============+=========+===============================================+
+    | z**0         | 1       | Although arguments over 0**0 exist, see [2].  |
+    +--------------+---------+-----------------------------------------------+
+    | z**1         | z       |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | (-oo)**(-1)  | 0       |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | (-1)**-1     | -1      |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | S.Zero**-1   | oo      | This is not strictly true, as 0**-1 may be    |
+    |              |         | undefined, but is convenient is some contexts |
+    |              |         | where the base is assumed to be positive.     |
+    +--------------+---------+-----------------------------------------------+
+    | 1**-1        | 1       |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | oo**-1       | 0       |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | 0**oo        | 0       | Because for all complex numbers z near        |
+    |              |         | 0, z**oo -> 0.                                |
+    +--------------+---------+-----------------------------------------------+
+    | 0**-oo       | oo      | This is strictly true, as 0**oo may be        |
+    |              |         | oscillating between positive and negative     |
+    |              |         | values or rotating in the complex plane.      |
+    |              |         | It is convenient, however, when the base      |
+    |              |         | is positive.                                  |
+    +--------------+---------+-----------------------------------------------+
+    | 1**oo        | nan     | Because there are various cases where         |
+    | 1**-oo       |         | lim(x(t),t)=1, lim(y(t),t)=oo (or -oo),       |
+    |              |         | but lim( x(t)**y(t), t) != 1.  See [3].       |
+    +--------------+---------+-----------------------------------------------+
+    | (-1)**oo     | nan     | Because of oscillations in the limit.         |
+    | (-1)**(-oo)  |         |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | oo**oo       | oo      |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | oo**-oo      | 0       |                                               |
+    +--------------+---------+-----------------------------------------------+
+    | (-oo)**oo    | nan     |                                               |
+    | (-oo)**-oo   |         |                                               |
+    +--------------+---------+-----------------------------------------------+
 
     Because symbolic computations are more flexible that floating point
     calculations and we prefer to never return an incorrect answer,
     we choose not to conform to all IEEE 754 conventions.  This helps
     us avoid extra test-case code in the calculation of limits.
+
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Exponentiation
+    .. [2] http://en.wikipedia.org/wiki/Exponentiation#Zero_to_the_power_of_zero
+    .. [3] http://en.wikipedia.org/wiki/Indeterminate_forms
 
     """
     is_Pow = True

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -80,7 +80,48 @@ def integer_nthroot(y, n):
 
 
 class Pow(Expr):
+    """
+    Defines the expression x**y as "x raised to a power y"
 
+
+    Singleton definitions involving (nan,0,1,-1,oo,-oo):
+        z**nan      = nan
+        z**0        = 1  although arguments over 0**0 exist
+        z**1        = z
+        (-oo)**(-1) = 0
+        (-1)**-1    = -1
+        S.Zero**-1  = oo  -- this is not strictly true,
+                        as 0**-1 may be undefined, but is convenient
+                        is some contexts where the base is assumed
+                        to be positive.
+        1**-1       = 1
+        oo**-1      = 0
+        nan**-1     = nan
+        nan**oo     = nan
+        nan**-oo    = nan
+        0**oo       = 0 because for all complex numbers z near 0, z**oo -> 0
+        0**-oo      = oo  -- this is strictly true, as
+                        as 0**oo may be oscillating between positive and
+                        negative values or rotating in the complex plane.
+                        It is convenient, however, when the base
+                        is positive.
+        1**oo       = nan because there are various cases where
+                        lim(x(t),t)=1, lim(y(t),t)=oo, but
+                        lim( x(t)**y(t), t) != 1
+        1**-oo      = nan for the same reason
+        (-1)**oo    = nan because of oscillations in the limit
+        (-1)**(-oo) = nan because of oscillations in the limit
+        oo**oo      = oo
+        oo**-oo     = 0
+        (-oo)**oo   = nan
+        (-oo)**-oo  = nan
+
+    Because symbolic computations are more flexible that floating point
+    calculations and we prefer to never return an incorrect answer,
+    we choose not to conform to all IEEE 754 conventions.  This helps
+    us avoid extra test-case code in the calculation of limits.
+
+    """
     is_Pow = True
 
     __slots__ = ['is_commutative']
@@ -99,10 +140,9 @@ class Pow(Expr):
             elif e is S.One:
                 return b
             elif b is S.One:
-                if e not in ( S.NaN, S.Infinity, -S.Infinity):
-                    return S.One
-                else:
+                if e in ( S.NaN, S.Infinity, -S.Infinity):
                     return S.NaN
+                return S.One
             elif S.NaN in (b, e):
                 return S.NaN
             else:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -98,9 +98,12 @@ class Pow(Expr):
                 return S.One
             elif e is S.One:
                 return b
-            elif S.NaN in (b, e):
-                if b is S.One:  # already handled e == 0 above
+            elif b is S.One:
+                if e not in ( S.NaN, S.Infinity, -S.Infinity):
                     return S.One
+                else:
+                    return S.NaN
+            elif S.NaN in (b, e):
                 return S.NaN
             else:
                 # recognize base as E

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -159,7 +159,7 @@ class Pow(Expr):
             elif e is S.One:
                 return b
             elif b is S.One:
-                if e in ( S.NaN, S.Infinity, -S.Infinity):
+                if e in (S.NaN, S.Infinity, -S.Infinity):
                     return S.NaN
                 return S.One
             elif S.NaN in (b, e):

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -133,6 +133,13 @@ class Pow(Expr):
     we choose not to conform to all IEEE 754 conventions.  This helps
     us avoid extra test-case code in the calculation of limits.
 
+    See Also
+    ========
+
+    Infinity
+    NegativeInfinity
+    NaN
+
     References
     ==========
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -710,7 +710,7 @@ def test_NaN():
     assert nan + S.One == nan
     assert nan/S.One == nan
     assert nan**0 == 1  # as per IEEE 754
-    assert 1**nan == 1  # as per IEEE 754
+    assert 1**nan == nan # IEEE 754 is not the best choice for symbolic work
 
 
 def test_special_numbers():
@@ -778,7 +778,7 @@ def test_integer_nthroot_overflow():
 def test_powers_Integer():
     """Test Integer._eval_power"""
     # check infinity
-    assert S(1) ** S.Infinity == 1
+    assert S(1) ** S.Infinity == S.NaN
     assert S(-1)** S.Infinity == S.NaN
     assert S(2) ** S.Infinity == S.Infinity
     assert S(-2)** S.Infinity == S.Infinity + S.Infinity * S.ImaginaryUnit

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -785,7 +785,7 @@ def test_powers_Integer():
     assert S(0) ** S.Infinity == 0
 
     # check Nan
-    assert S(1) ** S.NaN == S.One
+    assert S(1) ** S.NaN == S.NaN
     assert S(-1) ** S.NaN == S.NaN
 
     # check for exact roots


### PR DESCRIPTION
```
When doing Limit((1+x/(n+sin(n)))**n,n,oo).doit()
we raises an error instead of returning the wrong answer.

Now, 1**oo == nan instead of 1.
```
