### PR TITLE
Implement a new syntax for multivariable Order symbol (v2)

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from collections import defaultdict
 
 from sympy.core.core import C
-from sympy.core.compatibility import reduce
+from sympy.core.compatibility import reduce, is_sequence
 from sympy.core.singleton import S
 from sympy.core.operations import AssocOp
 from sympy.core.cache import cacheit
@@ -626,7 +626,7 @@ class Add(Expr, AssocOp):
             return self._new_rawargs(*args)
 
     @cacheit
-    def extract_leading_order(self, *symbols):
+    def extract_leading_order(self, symbols, point=None):
         """
         Returns the leading term and it's order.
 
@@ -643,7 +643,10 @@ class Add(Expr, AssocOp):
 
         """
         lst = []
-        seq = [(f, C.Order(f, *symbols)) for f in self.args]
+        symbols = list(symbols if is_sequence(symbols) else [symbols])
+        if not point:
+            point = [0]*len(symbols)
+        seq = [(f, C.Order(f, *zip(symbols, point))) for f in self.args]
         for ef, of in seq:
             for e, o in lst:
                 if o.contains(of) and o != of:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -882,7 +882,7 @@ class Pow(Expr):
                 # example:
                 # sin(x)**(-4) = 1/( sin(x)**4) = ...
                 # and expand the denominator:
-                nuse, denominator = n, O(1)
+                nuse, denominator = n, O(1, x)
                 while denominator.is_Order:
                     denominator = (b**(-e))._eval_nseries(x, n=nuse, logx=logx)
                     nuse += 1
@@ -981,7 +981,7 @@ class Pow(Expr):
                         arg = c*arg.expr
                     res.append(arg)
                 bs = Add(*res)
-                rv = (bs**e).series(x).subs(c, O(1))
+                rv = (bs**e).series(x).subs(c, O(1, x))
                 rv += order
                 return rv
 

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2617,14 +2617,14 @@ def test_X12():
 
 
 def test_X13():
-    assert series(sqrt(2*x**2 + 1), x, x0=oo, n=1) == sqrt(2)*x + O(1/x, x, oo)
+    assert series(sqrt(2*x**2 + 1), x, x0=oo, n=1) == sqrt(2)*x + O(1/x, (x, oo))
 
 
 @XFAIL
 def test_X14():
     # Wallis' product => 1/sqrt(pi n) + ...   [Knopp, p. 385]
     assert series(1/2**(2*n)*binomial(2*n, n),
-                  n, x==oo, n=1) == 1/(sqrt(pi)*sqrt(n)) + O(1/x, x, oo)
+                  n, x==oo, n=1) == 1/(sqrt(pi)*sqrt(n)) + O(1/x, (x, oo))
 
 
 @XFAIL
@@ -2635,7 +2635,7 @@ def test_X15():
     # https://code.google.com/p/sympy/issues/detail?id=4065
     e1 = integrate(exp(-t)/t, (t, x, oo))
     assert (series(e1, x, x0=oo, n=5) ==
-            6/x**4 + 2/x**3 - 1/x**2 + 1/x + O(x**(-5), x, oo))
+            6/x**4 + 2/x**3 - 1/x**2 + 1/x + O(x**(-5), (x, oo)))
 
 
 def test_X16():

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1099,14 +1099,18 @@ class LatexPrinter(Printer):
 
     def _print_Order(self, expr):
         s = self._print(expr.expr)
-        if expr.point != S.Zero or len(expr.variables) > 1:
+        if expr.point and any(p != S.Zero for p in expr.point) or \
+           len(expr.variables) > 1:
             s += '; '
             if len(expr.variables) > 1:
                 s += self._print(expr.variables)
             elif len(expr.variables):
                 s += self._print(expr.variables[0])
             s += r'\rightarrow'
-            s += self._print(expr.point)
+            if len(expr.point) > 1:
+                s += self._print(expr.point)
+            else:
+                s += self._print(expr.point[0])
         return r"\mathcal{O}\left(%s\right)" % s
 
     def _print_Symbol(self, expr):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1008,7 +1008,8 @@ class PrettyPrinter(Printer):
 
     def _print_Order(self, expr):
         pform = self._print(expr.expr)
-        if expr.point != S.Zero or len(expr.variables) > 1:
+        if (expr.point and any(p != S.Zero for p in expr.point)) or \
+           len(expr.variables) > 1:
             pform = prettyForm(*pform.right("; "))
             if len(expr.variables) > 1:
                 pform = prettyForm(*pform.right(self._print(expr.variables)))
@@ -1018,7 +1019,10 @@ class PrettyPrinter(Printer):
                 pform = prettyForm(*pform.right(u(" \u2192 ")))
             else:
                 pform = prettyForm(*pform.right(" -> "))
-            pform = prettyForm(*pform.right(self._print(expr.point)))
+            if len(expr.point) > 1:
+                pform = prettyForm(*pform.right(self._print(expr.point)))
+            else:
+                pform = prettyForm(*pform.right(self._print(expr.point[0])))
         pform = prettyForm(*pform.parens())
         pform = prettyForm(*pform.left("O"))
         return pform

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1927,18 +1927,18 @@ O⎜─⎟\n\
     expr = O(x**2 + y**2)
     ascii_str = \
 """\
- / 2    2             \\\n\
-O\\x  + y ; (x, y) -> 0/\
+ / 2    2                  \\\n\
+O\\x  + y ; (x, y) -> (0, 0)/\
 """
     ucode_str = \
 u("""\
- ⎛ 2    2            ⎞\n\
-O⎝x  + y ; (x, y) → 0⎠\
+ ⎛ 2    2                 ⎞\n\
+O⎝x  + y ; (x, y) → (0, 0)⎠\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = O(1, x, oo)
+    expr = O(1, (x, oo))
     ascii_str = \
 """\
 O(1; x -> oo)\
@@ -1950,7 +1950,7 @@ O(1; x → ∞)\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = O(1/x, x, oo)
+    expr = O(1/x, (x, oo))
     ascii_str = \
 """\
  /1         \\\n\
@@ -1966,16 +1966,16 @@ O⎜─; x → ∞⎟\n\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = O(x**2 + y**2, x, y, oo)
+    expr = O(x**2 + y**2, (x, oo), (y, oo))
     ascii_str = \
 """\
- / 2    2              \\\n\
-O\\x  + y ; (x, y) -> oo/\
+ / 2    2                    \\\n\
+O\\x  + y ; (x, y) -> (oo, oo)/\
 """
     ucode_str = \
 u("""\
- ⎛ 2    2            ⎞\n\
-O⎝x  + y ; (x, y) → ∞⎠\
+ ⎛ 2    2                 ⎞\n\
+O⎝x  + y ; (x, y) → (∞, ∞)⎠\
 """)
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -316,11 +316,11 @@ class StrPrinter(Printer):
         return "Normal(%s, %s)" % (expr.mu, expr.sigma)
 
     def _print_Order(self, expr):
-        if expr.point == S.Zero or not len(expr.variables):
+        if all(p is S.Zero for p in expr.point) or not len(expr.variables):
             if len(expr.variables) <= 1:
                 return 'O(%s)' % self._print(expr.expr)
             else:
-                return 'O(%s)' % self.stringify(expr.args[:-1], ', ', 0)
+                return 'O(%s)' % self.stringify((expr.expr,) + expr.variables, ', ', 0)
         else:
             return 'O(%s)' % self.stringify(expr.args, ', ', 0)
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -224,11 +224,11 @@ def test_latex_functions():
     assert latex(gamma(w)) == r"\Gamma{\left(w \right)}"
     assert latex(Order(x)) == r"\mathcal{O}\left(x\right)"
     assert latex(Order(x, x)) == r"\mathcal{O}\left(x\right)"
-    assert latex(Order(x, x, 0)) == r"\mathcal{O}\left(x\right)"
-    assert latex(Order(x, x, oo)) == r"\mathcal{O}\left(x; x\rightarrow\infty\right)"
-    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow0\right)"
-    assert latex(Order(x, x, y, 0)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow0\right)"
-    assert latex(Order(x, x, y, oo)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\infty\right)"
+    assert latex(Order(x, (x, 0))) == r"\mathcal{O}\left(x\right)"
+    assert latex(Order(x, (x, oo))) == r"\mathcal{O}\left(x; x\rightarrow\infty\right)"
+    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\begin{pmatrix}0, & 0\end{pmatrix}\right)"
+    assert latex(Order(x, x, y)) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\begin{pmatrix}0, & 0\end{pmatrix}\right)"
+    assert latex(Order(x, (x, oo), (y, oo))) == r"\mathcal{O}\left(x; \begin{pmatrix}x, & y\end{pmatrix}\rightarrow\begin{pmatrix}\infty, & \infty\end{pmatrix}\right)"
     assert latex(lowergamma(x, y)) == r'\gamma\left(x, y\right)'
     assert latex(uppergamma(x, y)) == r'\Gamma\left(x, y\right)'
 

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -227,11 +227,11 @@ def test_Order():
     assert str(O(x**2)) == "O(x**2)"
     assert str(O(x*y)) == "O(x*y, x, y)"
     assert str(O(x, x)) == "O(x)"
-    assert str(O(x, x, 0)) == "O(x)"
-    assert str(O(x, x, oo)) == "O(x, x, oo)"
+    assert str(O(x, (x, 0))) == "O(x)"
+    assert str(O(x, (x, oo))) == "O(x, (x, oo))"
     assert str(O(x, x, y)) == "O(x, x, y)"
-    assert str(O(x, x, y, 0)) == "O(x, x, y)"
-    assert str(O(x, x, y, oo)) == "O(x, x, y, oo)"
+    assert str(O(x, x, y)) == "O(x, x, y)"
+    assert str(O(x, (x, oo), (y, oo))) == "O(x, (x, oo), (y, oo))"
 
 
 def test_Permutation_Cycle():

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -56,11 +56,33 @@ class Order(Expr):
 
     >>> from sympy import O
     >>> from sympy.abc import x
-    >>> O(x)
+
+    >>> O(x + x**2)
     O(x)
+    >>> O(x + x**2, (x, 0))
+    O(x)
+    >>> O(x + x**2, (x, oo))
+    O(x**2, (x, oo))
+
+    >>> O(1 + x*y)
+    O(1, x, y)
+    >>> O(1 + x*y, (x, 0), (y, 0))
+    O(1, x, y)
+    >>> O(1 + x*y, (x, oo), (y, oo))
+    O(x*y, (x, oo), (y, oo))
+
+    >>> O(1) in O(1, x)
+    True
+    >>> O(1, x) in O(1)
+    False
+    >>> O(x) in O(1, x)
+    True
+    >>> O(x**2) in O(x)
+    True
+
     >>> O(x)*x
     O(x**2)
-    >>> O(x)-O(x)
+    >>> O(x) - O(x)
     O(x)
 
     References

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -5,6 +5,7 @@ from sympy.core import Add, Mul, expand_power_base, expand_log
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import default_sort_key, is_sequence
 from sympy.core.containers import Tuple
+from sympy.utilities.iterables import uniq
 
 
 class Order(Expr):
@@ -117,6 +118,9 @@ class Order(Expr):
 
         if not all(isinstance(v, Symbol) for v in variables):
            raise TypeError('Variables are not symbols, got %s' % variables)
+
+        if len(list(uniq(variables))) != len(variables):
+            raise ValueError('Variables are supposed to be unique symbols, got %s' % variables)
 
         if expr.is_Order:
             expr_vp = dict(expr.args[1:])

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -54,8 +54,8 @@ class Order(Expr):
     Examples
     ========
 
-    >>> from sympy import O
-    >>> from sympy.abc import x
+    >>> from sympy import O, oo
+    >>> from sympy.abc import x, y
 
     >>> O(x + x**2)
     O(x)

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -12,8 +12,8 @@ class Order(Expr):
     r""" Represents the limiting behavior of some function
 
     The order of a function characterizes the function based on the limiting
-    behavior of the function as it goes to some limit. Only taking the limit
-    point to be 0 or positive infinity is currently supported. This is
+    behavior of the function as it goes to some limit. Only taking all limit
+    points to be 0 or positive infinity is currently supported. This is
     expressed in big O notation [1]_.
 
     The formal definition for the order of a function `g(x)` about a point `a`

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -3,7 +3,8 @@ from __future__ import print_function, division
 from sympy.core import Basic, S, sympify, Expr, Rational, Symbol
 from sympy.core import Add, Mul, expand_power_base, expand_log
 from sympy.core.cache import cacheit
-from sympy.core.compatibility import default_sort_key
+from sympy.core.compatibility import default_sort_key, is_sequence
+from sympy.core.containers import Tuple
 
 
 class Order(Expr):
@@ -96,39 +97,57 @@ class Order(Expr):
     __slots__ = []
 
     @cacheit
-    def __new__(cls, expr, *symbols):
-
+    def __new__(cls, expr, *args, **kwargs):
         expr = sympify(expr)
+
+        if not args:
+            variables = list(expr.free_symbols)
+            point = [S.Zero]*len(variables)
+        else:
+            args = list(args if is_sequence(args) else [args])
+            variables, point = [], []
+            if is_sequence(args[0]):
+                for a in args:
+                    v, p = list(map(sympify, a))
+                    variables.append(v)
+                    point.append(p)
+            else:
+                variables = list(map(sympify, args))
+                point = [S.Zero]*len(variables)
+
+        if not all(isinstance(v, Symbol) for v in variables):
+           raise TypeError('Variables are not symbols, got %s' % variables)
+
+        if expr.is_Order:
+            expr_vp = dict(expr.args[1:])
+            new_vp = dict(expr_vp)
+            vp = dict(zip(variables, point))
+            for v, p in vp.items():
+                if v in new_vp.keys():
+                    if p != new_vp[v]:
+                        raise NotImplementedError(
+                            "Mixing Order at different points is not supported.")
+                else:
+                    new_vp[v] = p
+            if set(expr_vp.keys()) == set(new_vp.keys()):
+                return expr
+            else:
+                variables = list(new_vp.keys())
+                point = [new_vp[v] for v in variables]
+
         if expr is S.NaN:
             return S.NaN
 
-        point = S.Zero
-        if symbols:
-            symbols = list(map(sympify, symbols))
-            if symbols[-1] in (S.Infinity, S.Zero):
-                point = symbols[-1]
-                symbols = symbols[:-1]
-            if not all(isinstance(s, Symbol) for s in symbols):
-                raise NotImplementedError(
-                    'Order at points other than 0 or oo not supported.')
-        if not symbols:
-            symbols = list(expr.free_symbols)
+        if not all(p is S.Zero for p in point) and \
+           not all(p is S.Infinity for p in point):
+            raise NotImplementedError('Order at points other than 0 '
+                'or oo not supported, got %s as a point.' % point)
 
-        if expr.is_Order:
-            if expr.point != point:
-                raise NotImplementedError("Mixing Order at 0 and oo is not supported.")
-            v = set(expr.variables)
-            symbols = v | set(symbols)
-            if symbols == v:
-                return expr
-            symbols = list(symbols)
+        if variables:
 
-        elif symbols:
+            variables = list(set(variables))
 
-            symbols = list(set(symbols))
-            args = tuple(symbols) + (point,)
-
-            if len(symbols) > 1:
+            if len(variables) > 1:
                 # XXX: better way?  We need this expand() to
                 # workaround e.g: expr = x*(x + y).
                 # (x*(x + y)).as_leading_term(x, y) currently returns
@@ -137,24 +156,24 @@ class Order(Expr):
                 expr = expr.expand()
 
             if expr.is_Add:
-                lst = expr.extract_leading_order(*args)
+                lst = expr.extract_leading_order(variables, point)
                 expr = Add(*[f.expr for (e, f) in lst])
 
             elif expr:
-                if point == S.Zero:
-                    expr = expr.as_leading_term(*symbols)
-                expr = expr.as_independent(*symbols, as_Add=False)[1]
+                if point[0] == S.Zero:
+                    expr = expr.as_leading_term(*variables)
+                expr = expr.as_independent(*variables, as_Add=False)[1]
 
                 expr = expand_power_base(expr)
                 expr = expand_log(expr)
 
-                if len(symbols) == 1:
+                if len(variables) == 1:
                     # The definition of O(f(x)) symbol explicitly stated that
                     # the argument of f(x) is irrelevant.  That's why we can
                     # combine some power exponents (only "on top" of the
                     # expression tree for f(x)), e.g.:
                     # x**p * (-x)**q -> x**(p+q) for real p, q.
-                    x = symbols[0]
+                    x = variables[0]
                     margs = list(Mul.make_args(
                         expr.as_independent(x, as_Add=False)[1]))
 
@@ -182,12 +201,12 @@ class Order(Expr):
         if expr.is_Order:
             expr = expr.expr
 
-        if not expr.has(*symbols):
+        if not expr.has(*variables):
             expr = S.One
 
         # create Order instance:
-        symbols.sort(key=default_sort_key)
-        args = (expr,) + tuple(symbols) + (point,)
+        variables.sort(key=default_sort_key)
+        args = (expr,) + Tuple(*zip(variables, point))
         obj = Expr.__new__(cls, *args)
         return obj
 
@@ -202,15 +221,21 @@ class Order(Expr):
 
     @property
     def expr(self):
-        return self._args[0]
+        return self.args[0]
 
     @property
     def variables(self):
-        return self._args[1:-1]
+        if self.args[1:]:
+            return tuple(x[0] for x in self.args[1:])
+        else:
+            return ()
 
     @property
     def point(self):
-        return self._args[-1]
+        if self.args[1:]:
+            return tuple(x[1] for x in self.args[1:])
+        else:
+            return ()
 
     @property
     def free_symbols(self):
@@ -225,12 +250,19 @@ class Order(Expr):
         if order_symbols is None:
             order_symbols = self.args[1:]
         else:
-            if order_symbols[-1] != self.point:
-                raise NotImplementedError("Multiplying Order at 0 and oo is not supported.")
-            for s in self.variables:
-                if s not in order_symbols:
-                    order_symbols = (s,) + order_symbols
-        return self.expr, order_symbols
+            if not all(o[1] == order_symbols[0][1] for o in order_symbols) and \
+               not all(p == self.point[0] for p in self.point):
+                raise NotImplementedError('Order at points other than 0 '
+                    'or oo not supported, got %s as a point.' % point)
+            if order_symbols[0][1] != self.point[0]:
+                raise NotImplementedError(
+                        "Multiplying Order at different points is not supported.")
+            order_symbols = dict(order_symbols)
+            for s, p in dict(self.args[1:]).items():
+                if s not in order_symbols.keys():
+                    order_symbols[s] = p
+            order_symbols = sorted(order_symbols.items(), key=lambda x: default_sort_key(x[0]))
+        return self.expr, tuple(order_symbols)
 
     def removeO(self):
         return S.Zero
@@ -252,11 +284,23 @@ class Order(Expr):
         if expr is S.NaN:
             return False
         if expr.is_Order:
-            if expr.point != self.point:
-                return False
+            if not all(p == expr.point[0] for p in expr.point) and \
+               not all(p == self.point[0] for p in self.point):
+                raise NotImplementedError('Order at points other than 0 '
+                    'or oo not supported, got %s as a point.' % point)
+            else:
+                # self and/or expr is O(1):
+                if any(not p for p in [expr.point, self.point]):
+                    point = self.point + expr.point
+                    if point:
+                        point = point[0]
+                    else:
+                        point = S.Zero
+                else:
+                    point = self.point[0]
             if expr.expr == self.expr:
                 # O(1) + O(1), O(1) + O(1, x), etc.
-                return all([x in self.variables for x in expr.variables])
+                return all([x in self.args[1:] for x in expr.args[1:]])
             if expr.expr.is_Add:
                 return all([self.contains(x) for x in expr.expr.args])
             if self.expr.is_Add:
@@ -275,29 +319,30 @@ class Order(Expr):
             ratio = self.expr/expr.expr
             ratio = powsimp(ratio, deep=True, combine='exp')
             for s in common_symbols:
-                l = limit(ratio, s, self.point) != 0
+                l = limit(ratio, s, point) != 0
                 if r is None:
                     r = l
                 else:
                     if r != l:
                         return
             return r
-        newargs = self.args[1:]
-        obj = Order(expr, *newargs)
+        obj = self.func(expr, *self.args[1:])
         return self.contains(obj)
 
     def _eval_subs(self, old, new):
         if old.is_Symbol and old in self.variables:
             i = self.variables.index(old)
-            if isinstance(new, Symbol):
-                newargs = (self.expr._subs(old, new),) + self.variables[:i] + \
-                    (new,) + self.variables[i + 1:] + (self.point,)
-                return Order(*newargs)
             newexpr = self.expr._subs(old, new)
-            newargs = (newexpr,) + tuple(newexpr.free_symbols) + \
-                self.variables[:i] + self.variables[i + 1:] + \
-                (self.point**(new.as_numer_denom()[1].is_number*2 - 1),)
-            return Order(*newargs)
+            if isinstance(new, Symbol):
+                newvars = list(self.variables)
+                newvars[i] = new
+                newpt = self.point
+            else:
+                newvars = tuple(newexpr.free_symbols) + \
+                    self.variables[:i] + self.variables[i + 1:]
+                newpt = self.point[0]**(new.as_numer_denom()[1].is_number*2 - 1)
+                newpt = [newpt]*len(newvars)
+            return Order(newexpr, *zip(newvars, newpt))
         return Order(self.expr._subs(old, new), *self.args[1:])
 
     def _eval_conjugate(self):

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -102,8 +102,12 @@ class Order(Expr):
         expr = sympify(expr)
 
         if not args:
-            variables = list(expr.free_symbols)
-            point = [S.Zero]*len(variables)
+            if expr.is_Order:
+                variables = expr.variables
+                point = expr.point
+            else:
+                variables = list(expr.free_symbols)
+                point = [S.Zero]*len(variables)
         else:
             args = list(args if is_sequence(args) else [args])
             variables, point = [], []

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -247,7 +247,7 @@ class Order(Expr):
 
     @property
     def free_symbols(self):
-        return self.expr.free_symbols
+        return self.expr.free_symbols | set(self.variables)
 
     def _eval_power(b, e):
         if e.is_Number and e.is_nonnegative:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -19,8 +19,8 @@ class Order(Expr):
     The formal definition for the order of a function `g(x)` about a point `a`
     is such that `g(x) = O(f(x))` as `x \rightarrow a` if and only if for any
     `\delta > 0` there exists a `M > 0` such that `|g(x)| \leq M|f(x)|` for
-    `|x-a| < \delta`. This is equivalent to `\lim_{x \rightarrow a}
-    |g(x)/f(x)| < \infty`.
+    `|x-a| < \delta`.  This is equivalent to `\lim_{x \rightarrow a}
+    \sup |g(x)/f(x)| < \infty`.
 
     Let's illustrate it on the following example by taking the expansion of
     `\sin(x)` about 0:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -152,9 +152,6 @@ class Order(Expr):
                 'or oo not supported, got %s as a point.' % point)
 
         if variables:
-
-            variables = list(set(variables))
-
             if len(variables) > 1:
                 # XXX: better way?  We need this expand() to
                 # workaround e.g: expr = x*(x + y).

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -27,7 +27,7 @@ def test_simple_1():
     assert Order(x**(5*o/3)).expr == x**(5*o/3)
     assert Order(x**2 + x + y, x) == O(1, x)
     assert Order(x**2 + x + y, y) == O(1, y)
-    assert Order(exp(x), x, x) == Order(1, x)
+    raises(ValueError, lambda: Order(exp(x), x, x))
     raises(TypeError, lambda: Order(x, 2 - x))
 
 

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -12,6 +12,14 @@ def test_caching_bug():
     O(w**(-1/x/log(3)*log(5)), w)
 
 
+def test_free_symbols():
+    assert Order(1).free_symbols == set()
+    assert Order(x).free_symbols == set([x])
+    assert Order(1, x).free_symbols == set([x])
+    assert Order(x*y).free_symbols == set([x, y])
+    assert Order(x, x, y).free_symbols == set([x, y])
+
+
 def test_simple_1():
     o = Rational(0)
     assert Order(2*x) == Order(x)

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -28,7 +28,7 @@ def test_simple_1():
     assert Order(x**2 + x + y, x) == O(1, x)
     assert Order(x**2 + x + y, y) == O(1, y)
     assert Order(exp(x), x, x) == Order(1, x)
-    raises(NotImplementedError, lambda: Order(x, 2 - x))
+    raises(TypeError, lambda: Order(x, 2 - x))
 
 
 def test_simple_2():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -367,11 +367,11 @@ def test_order_at_infinity():
 def test_mixing_order_at_zero_and_infinity():
     assert (Order(x, (x, 0)) + Order(x, (x, oo))).is_Add
     assert Order(x, (x, 0)) + Order(x, (x, oo)) == Order(x, (x, oo)) + Order(x, (x, 0))
+    assert Order(Order(x, (x, oo))) == Order(x, (x, oo))
 
     # not supported (yet)
     raises(NotImplementedError, lambda: Order(x, (x, 0))*Order(x, (x, oo)))
     raises(NotImplementedError, lambda: Order(x, (x, oo))*Order(x, (x, 0)))
-    raises(NotImplementedError, lambda: Order(Order(x, (x, oo))))
     raises(NotImplementedError, lambda: Order(Order(x, (x, oo)), y))
     raises(NotImplementedError, lambda: Order(Order(x), (x, oo)))
 

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -289,7 +289,7 @@ def test_issue_1180():
 def test_issue_1756():
     assert 1/O(1) != O(1)
     assert 1/O(x) != O(1/x)
-    assert 1/O(x, x, oo) != O(1/x, x, oo)
+    assert 1/O(x, (x, oo)) != O(1/x, (x, oo))
 
     f = Function('f')
     assert 1/O(f(x)) != O(1/x)
@@ -323,61 +323,61 @@ def test_issue_3654():
 
 
 def test_order_at_infinity():
-    assert Order(1 + x, x, oo) == Order(x, x, oo)
-    assert Order(3*x, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo)*3 == Order(x, x, oo)
-    assert -28*Order(x, x, oo) == Order(x, x, oo)
-    assert Order(Order(x, x, oo), oo) == Order(x, x, oo)
-    assert Order(Order(x, x, oo), y, oo) == Order(Order(x, x, oo), x, y, oo)
-    assert Order(3, x, oo) == Order(1, x, oo)
-    assert Order(x**2 + x + y, x, oo) == O(x**2, x, oo)
-    assert Order(x**2 + x + y, y, oo) == O(y, y, oo)
+    assert Order(1 + x, (x, oo)) == Order(x, (x, oo))
+    assert Order(3*x, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo))*3 == Order(x, (x, oo))
+    assert -28*Order(x, (x, oo)) == Order(x, (x, oo))
+    assert Order(Order(x, (x, oo)), (x, oo)) == Order(x, (x, oo))
+    assert Order(Order(x, (x, oo)), (y, oo)) == Order(x, (x, oo), (y, oo))
+    assert Order(3, (x, oo)) == Order(1, (x, oo))
+    assert Order(x**2 + x + y, (x, oo)) == O(x**2, (x, oo))
+    assert Order(x**2 + x + y, (y, oo)) == O(y, (y, oo))
 
-    assert Order(2*x, x, oo)*x == Order(x**2, x, oo)
-    assert Order(2*x, x, oo)/x == Order(1, x, oo)
-    assert Order(2*x, x, oo)*x*exp(1/x) == Order(x**2*exp(1/x), x, oo)
-    assert Order(2*x, x, oo)*x*exp(1/x)/ln(x)**3 == Order(x**2*exp(1/x)*ln(x)**-3, x, oo)
+    assert Order(2*x, (x, oo))*x == Order(x**2, (x, oo))
+    assert Order(2*x, (x, oo))/x == Order(1, (x, oo))
+    assert Order(2*x, (x, oo))*x*exp(1/x) == Order(x**2*exp(1/x), (x, oo))
+    assert Order(2*x, (x, oo))*x*exp(1/x)/ln(x)**3 == Order(x**2*exp(1/x)*ln(x)**-3, (x, oo))
 
-    assert Order(x, x, oo) + 1/x == 1/x + Order(x, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo) + 1 == 1 + Order(x, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo) + x == x + Order(x, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo) + x**2 == x**2 + Order(x, x, oo)
-    assert Order(1/x, x, oo) + 1/x**2 == 1/x**2 + Order(1/x, x, oo) == Order(1/x, x, oo)
-    assert Order(x, x, oo) + exp(1/x) == exp(1/x) + Order(x, x, oo)
+    assert Order(x, (x, oo)) + 1/x == 1/x + Order(x, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo)) + 1 == 1 + Order(x, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo)) + x == x + Order(x, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo)) + x**2 == x**2 + Order(x, (x, oo))
+    assert Order(1/x, (x, oo)) + 1/x**2 == 1/x**2 + Order(1/x, (x, oo)) == Order(1/x, (x, oo))
+    assert Order(x, (x, oo)) + exp(1/x) == exp(1/x) + Order(x, (x, oo))
 
-    assert Order(x, x, oo)**2 == Order(x**2, x, oo)
+    assert Order(x, (x, oo))**2 == Order(x**2, (x, oo))
 
-    assert Order(x, x, oo) + Order(x**2, x, oo) == Order(x**2, x, oo)
-    assert Order(x, x, oo) + Order(x**-2, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo) + Order(1/x, x, oo) == Order(x, x, oo)
+    assert Order(x, (x, oo)) + Order(x**2, (x, oo)) == Order(x**2, (x, oo))
+    assert Order(x, (x, oo)) + Order(x**-2, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo)) + Order(1/x, (x, oo)) == Order(x, (x, oo))
 
-    assert Order(x, x, oo) - Order(x, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo) + Order(1, x, oo) == Order(x, x, oo)
-    assert Order(x, x, oo) + Order(x**2, x, oo) == Order(x**2, x, oo)
-    assert Order(1/x, x, oo) + Order(1, x, oo) == Order(1, x, oo)
-    assert Order(x, x, oo) + Order(exp(1/x), x, oo) == Order(x, x, oo)
-    assert Order(x**3, x, oo) + Order(exp(2/x), x, oo) == Order(x**3, x, oo)
-    assert Order(x**-3, x, oo) + Order(exp(2/x), x, oo) == Order(exp(2/x), x, oo)
+    assert Order(x, (x, oo)) - Order(x, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo)) + Order(1, (x, oo)) == Order(x, (x, oo))
+    assert Order(x, (x, oo)) + Order(x**2, (x, oo)) == Order(x**2, (x, oo))
+    assert Order(1/x, (x, oo)) + Order(1, (x, oo)) == Order(1, (x, oo))
+    assert Order(x, (x, oo)) + Order(exp(1/x), (x, oo)) == Order(x, (x, oo))
+    assert Order(x**3, (x, oo)) + Order(exp(2/x), (x, oo)) == Order(x**3, (x, oo))
+    assert Order(x**-3, (x, oo)) + Order(exp(2/x), (x, oo)) == Order(exp(2/x), (x, oo))
 
     # issue 4108
-    assert Order(exp(x), x, oo).expr == Order(2*exp(x), x, oo).expr == exp(x)
-    assert Order(y**x, x, oo).expr == Order(2*y**x, x, oo).expr == y**x
+    assert Order(exp(x), (x, oo)).expr == Order(2*exp(x), (x, oo)).expr == exp(x)
+    assert Order(y**x, (x, oo)).expr == Order(2*y**x, (x, oo)).expr == y**x
 
 
 def test_mixing_order_at_zero_and_infinity():
-    assert (Order(x, x, 0) + Order(x, x, oo)).is_Add
-    assert Order(x, x, 0) + Order(x, x, oo) == Order(x, x, oo) + Order(x, x, 0)
+    assert (Order(x, (x, 0)) + Order(x, (x, oo))).is_Add
+    assert Order(x, (x, 0)) + Order(x, (x, oo)) == Order(x, (x, oo)) + Order(x, (x, 0))
 
     # not supported (yet)
-    raises(NotImplementedError, lambda: Order(x, x, 0)*Order(x, x, oo))
-    raises(NotImplementedError, lambda: Order(x, x, oo)*Order(x, x, 0))
-    raises(NotImplementedError, lambda: Order(Order(x, x, oo)))
-    raises(NotImplementedError, lambda: Order(Order(x, x, oo), y))
+    raises(NotImplementedError, lambda: Order(x, (x, 0))*Order(x, (x, oo)))
+    raises(NotImplementedError, lambda: Order(x, (x, oo))*Order(x, (x, 0)))
+    raises(NotImplementedError, lambda: Order(Order(x, (x, oo))))
+    raises(NotImplementedError, lambda: Order(Order(x, (x, oo)), y))
 
 
 def test_order_subs_limits():
     # issue 234
-    assert (1 + Order(x)).subs(x, 1/x) == 1 + Order(1/x, oo)
+    assert (1 + Order(x)).subs(x, 1/x) == 1 + Order(1/x, (x, oo))
     assert (1 + Order(x)).limit(x, 0) == 1
     # issue 2670
     assert ((x + Order(x**2))/x).limit(x, 0) == 1

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -83,10 +83,10 @@ def test_simple_8():
 
 
 def test_as_expr_variables():
-    assert Order(x).as_expr_variables(None) == (x, (x, 0))
-    assert Order(x).as_expr_variables((x, 0)) == (x, (x, 0))
-    assert Order(y).as_expr_variables((x, 0)) == (y, (y, x, 0))
-    assert Order(y).as_expr_variables((x, y, 0)) == (y, (x, y, 0))
+    assert Order(x).as_expr_variables(None) == (x, ((x, 0),))
+    assert Order(x).as_expr_variables((((x, 0),))) == (x, ((x, 0),))
+    assert Order(y).as_expr_variables(((x, 0),)) == (y, ((x, 0), (y, 0)))
+    assert Order(y).as_expr_variables(((x, 0), (y, 0))) == (y, ((x, 0), (y, 0)))
 
 
 def test_contains_0():

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -373,6 +373,7 @@ def test_mixing_order_at_zero_and_infinity():
     raises(NotImplementedError, lambda: Order(x, (x, oo))*Order(x, (x, 0)))
     raises(NotImplementedError, lambda: Order(Order(x, (x, oo))))
     raises(NotImplementedError, lambda: Order(Order(x, (x, oo)), y))
+    raises(NotImplementedError, lambda: Order(Order(x), (x, oo)))
 
 
 def test_order_subs_limits():

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -63,7 +63,7 @@ def test_2124():
     assert ((sin(x))**y).nseries(x, n=1, logx=logx) == \
         exp(y*logx) + O(x*exp(y*logx), x)
 
-    assert sin(1/x).series(x, oo, n=5) == 1/x - 1/(6*x**3) + O(x**(-5), x, oo)
+    assert sin(1/x).series(x, oo, n=5) == 1/x - 1/(6*x**3) + O(x**(-5), (x, oo))
     assert abs(x).series(x, oo, n=5, dir='+') == x
     assert abs(x).series(x, -oo, n=5, dir='-') == -x
     assert abs(-x).series(x, oo, n=5, dir='+') == x


### PR DESCRIPTION
This is an alternative for #2605

Supported input:
- `O(expr)`
- `O(expr, (var1, pt1), (var2, pt2), ...)`
- `O(expr, var1, var2, ...) == O(expr, (var1, 0), (var2, 0), ...)`

PS: not sure if latex & pretty printing is ok.  May be we should change that just like the str printer.
