### PR TITLE
pretty-printing of Lambda (issue 2401)

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -985,26 +985,17 @@ class PrettyPrinter(Printer):
         return self.emptyPrinter(expr)
 
     def _print_Lambda(self, e):
-        symbols, expr = e.args
-
-        if len(symbols) == 1:
-            symbols = self._print(symbols[0])
+        vars, expr = e.args
+        if self._use_unicode:
+            arrow = u(" \u21a6 ")
         else:
-            symbols = self._print(tuple(symbols))
+            arrow = " -> "
+        if len(vars) == 1:
+            var_form = self._print(vars[0])
+        else:
+            var_form = self._print(tuple(vars))
 
-        args = (symbols, self._print(expr))
-
-        prettyFunc = self._print(C.Symbol("Lambda"))
-        prettyArgs = prettyForm(*self._print_seq(args).parens())
-
-        pform = prettyForm(
-            binding=prettyForm.FUNC, *stringPict.next(prettyFunc, prettyArgs))
-
-        # store pform parts so it can be reassembled e.g. when powered
-        pform.prettyFunc = prettyFunc
-        pform.prettyArgs = prettyArgs
-
-        return pform
+        return prettyForm(*stringPict.next(var_form, arrow, self._print(expr)), binding=8)
 
     def _print_Order(self, expr):
         pform = self._print(expr.expr)

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -1824,75 +1824,64 @@ __________ __________      \n\
 
 
 def test_pretty_lambda():
-    expr = Lambda(x, x)
-    ascii_str = \
-"""\
-Lambda(x, x)\
-"""
-    ucode_str = \
-u("""\
-Λ(x, x)\
-""")
+    # S.IdentityFunction is a special case
+    expr = Lambda(y, y)
+    assert pretty(expr) == "x -> x"
+    assert upretty(expr) == u("x ↦ x")
 
-    assert pretty(expr) == ascii_str
-    assert upretty(expr) == ucode_str
+    expr = Lambda(x, x+1)
+    assert pretty(expr) == "x -> x + 1"
+    assert upretty(expr) == u("x ↦ x + 1")
 
     expr = Lambda(x, x**2)
     ascii_str = \
 """\
-      /    2\\\n\
-Lambda\\x, x /\
+      2\n\
+x -> x \
 """
     ucode_str = \
 u("""\
- ⎛    2⎞\n\
-Λ⎝x, x ⎠\
+     2\n\
+x ↦ x \
 """)
-
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = Lambda(x, x**2)**2
     ascii_str = \
 """\
-      2/    2\\\n\
-Lambda \\x, x /\
+         2
+/      2\\ \n\
+\\x -> x / \
 """
     ucode_str = \
 u("""\
- 2⎛    2⎞\n\
-Λ ⎝x, x ⎠\
+        2
+⎛     2⎞ \n\
+⎝x ↦ x ⎠ \
 """)
-
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = Lambda((x, y), x)
-    ascii_str = \
-"""\
-Lambda((x, y), x)\
-"""
-    ucode_str = \
-u("""\
-Λ((x, y), x)\
-""")
-
+    ascii_str = "(x, y) -> x"
+    ucode_str = u("(x, y) ↦ x")
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
     expr = Lambda((x, y), x**2)
     ascii_str = \
 """\
-      /         2\\\n\
-Lambda\\(x, y), x /\
+           2\n\
+(x, y) -> x \
 """
     ucode_str = \
 u("""\
- ⎛         2⎞\n\
-Λ⎝(x, y), x ⎠\
+          2\n\
+(x, y) ↦ x \
 """)
-
     assert pretty(expr) == ascii_str
+    assert upretty(expr) == ucode_str
 
 
 def test_pretty_order():
@@ -3067,13 +3056,13 @@ RootSum⎝x  + 11⋅x - 2⎠\
     expr = RootSum(x**5 + 11*x - 2, Lambda(z, exp(z)))
     ascii_str = \
 """\
-       / 5                   /    z\\\\\n\
-RootSum\\x  + 11*x - 2, Lambda\\z, e //\
+       / 5                   z\\\n\
+RootSum\\x  + 11*x - 2, z -> e /\
 """
     ucode_str = \
 u("""\
-       ⎛ 5              ⎛    z⎞⎞\n\
-RootSum⎝x  + 11⋅x - 2, Λ⎝z, ℯ ⎠⎠\
+       ⎛ 5                  z⎞\n\
+RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠\
 """)
 
     assert pretty(expr) == ascii_str


### PR DESCRIPTION
http://code.google.com/p/sympy/issues/detail?id=2401

```
In [1]: Lambda((x, y), x*y)+1
Out[1]: 1 + ((x, y) ↦ x⋅y)

In [2]: Lambda(x, x**2)**2
Out[2]:
        2
⎛     2⎞
⎝x ↦ x ⎠

In [3]: RootSum(x**5 + 11*x - 2, Lambda(z, exp(z)))
Out[3]:
       ⎛ 5                  z⎞
RootSum⎝x  + 11⋅x - 2, z ↦ ℯ ⎠
```

This is a replacement for stalled pr #389.  See also #2328 and #2377.
