### PR TITLE
Issue 4107: Equality with matrices

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -138,7 +138,9 @@ def Ge(a, b):
 
 
 class Relational(Boolean, Expr, EvalfMixin):
+    """Superclass for all types of symbolic comparisons between objects.
 
+    """
     __slots__ = []
 
     is_Relational = True
@@ -168,6 +170,14 @@ class Relational(Boolean, Expr, EvalfMixin):
             elif know is False:
                 diff = diff.n()
         if rop_cls is Equality:
+            if hasattr(lhs, '_eval_Eq'):
+                res = lhs._eval_Eq(rhs)
+                if res is not None:
+                    return res
+            if hasattr(rhs, '_eval_Eq'):
+                res = rhs._eval_Eq(lhs)
+                if res is not None:
+                    return res
             if (lhs == rhs) is True or (diff == S.Zero) is True:
                 return True
             elif diff is S.NaN:
@@ -229,6 +239,13 @@ class Relational(Boolean, Expr, EvalfMixin):
 
 
 class Equality(Relational):
+    """Equality check between two symbolic expressions.
+
+    If at least one of the two objects defines the method _eval_Eq, that
+    will be called to evaluate the expression.  If the method does not
+    exist or returns None, the standard algorithm will be used.
+
+    """
 
     rel_op = '=='
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -4,9 +4,11 @@ from functools import wraps
 
 from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic, Expr
 from sympy.core.decorators import call_highest_priority
+from sympy.core.relational import Equality
 from sympy.core.sympify import SympifyError, sympify
 from sympy.functions import conjugate, adjoint
-from sympy.matrices import ShapeError
+from sympy.logic.boolalg import And
+from sympy.matrices import ShapeError, MatrixBase
 from sympy.simplify import simplify
 
 
@@ -293,6 +295,11 @@ class MatrixExpr(Basic):
 
     def as_coeff_mmul(self):
         return 1, MatMul(self)
+
+    def _eval_Eq(self, other):
+        if not hasattr(other, 'shape') or self.shape != other.shape:
+            return False
+        return And(*(Equality(i, j) for i, j in zip(self, other)))
 
 
 class MatrixElement(Expr):

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -139,3 +139,5 @@ class ImmutableSparseMatrix(Basic, SparseMatrix):
 
     def __hash__(self):
         return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
+
+    _eval_Eq = MatrixExpr._eval_Eq

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,4 +1,4 @@
-from sympy import ImmutableMatrix, Matrix, eye, zeros
+from sympy import ImmutableMatrix, Matrix, eye, zeros, Equality, And
 from sympy.abc import x, y
 from sympy.utilities.pytest import raises
 
@@ -86,3 +86,14 @@ def test_immutable_evaluation():
     assert isinstance(X * 2, ImmutableMatrix)
     assert isinstance(2 * X, ImmutableMatrix)
     assert isinstance(A**2, ImmutableMatrix)
+
+
+def test_Equality():
+    assert Equality(IM, IM) == True
+    assert Equality(IM, IM.subs(1, 2)) == False
+    assert Equality(IM, 2) == False
+    M = ImmutableMatrix([x, y])
+    assert Equality(M, IM) == False
+    assert Equality(M, M.subs(x, 2)) == Equality(x, 2)
+    N = ImmutableMatrix([3, 4])
+    assert Equality(M, N) == And(Equality(x, 3), Equality(y, 4))


### PR DESCRIPTION
http://code.google.com/p/sympy/issues/detail?id=4107

This allows matrices to be properly used within Equality objects.  Two features were added to do this:
1. Relational was changed to support objects with an _eval_Eq method, as suggested by @mrocklin.  If creating an Equality, Relational will check for the presence of _eval_Eq in either argument, and fall back on the existing algorithm if the method does not exist, or returns None.
2. MatrixExpr had an _eval_Eq method added to it.  It checks if the other argument has a shape matching its own, then creates an Equality for every element of the matrix, and wraps them all in an And.
