### PR TITLE
sympy_parser: don't apply function exponentation on Symbols

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -12,6 +12,7 @@ import ast
 import re
 import unicodedata
 
+import sympy
 from sympy.core.compatibility import exec_, StringIO
 from sympy.core.basic import Basic, C
 
@@ -47,7 +48,7 @@ def _token_callable(token, local_dict, global_dict, nextToken=None):
     func = local_dict.get(token[1])
     if not func:
         func = global_dict.get(token[1])
-    return callable(func)
+    return callable(func) and not isinstance(func, sympy.Symbol)
 
 
 def _add_factorial_tokens(name, result):

--- a/sympy/parsing/tests/test_implicit_multiplication_application.py
+++ b/sympy/parsing/tests/test_implicit_multiplication_application.py
@@ -91,6 +91,9 @@ def test_function_exponentiation():
         raises(SyntaxError,
                lambda: parse_expr(case, transformations=transformations2))
 
+    assert parse_expr('x**2', local_dict={ 'x': sympy.Symbol('x') },
+                      transformations=transformations2) == parse_expr('x**2')
+
 
 def test_symbol_splitting():
     # By default Greek letter names should not be split (lambda is a keyword


### PR DESCRIPTION
Fixes a bug where defining a symbol and then attempting to exponentiate it caused the implicit transformations to fail.

This used to cause an error, as the parser believed that `x` was now a function:

```
transformations = standard_transformations + (convert_xor, function_exponentiation)
parse_expr('x**2', local_dict={ 'x': sympy.Symbol('x') },
                  transformations=transformations)
```
