### PR TITLE
Better docs for Wild, improved tests for excluded

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -107,7 +107,7 @@ class Pow(Expr):
     | 0**oo        | 0       | Because for all complex numbers z near        |
     |              |         | 0, z**oo -> 0.                                |
     +--------------+---------+-----------------------------------------------+
-    | 0**-oo       | oo      | This is strictly true, as 0**oo may be        |
+    | 0**-oo       | oo      | This is not strictly true, as 0**oo may be    |
     |              |         | oscillating between positive and negative     |
     |              |         | values or rotating in the complex plane.      |
     |              |         | It is convenient, however, when the base      |

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -528,8 +528,8 @@ class GreaterThan(_Greater):
 
            In Python, there is no way to override the ``and`` operator, or to
            control how it short circuits, so it is impossible to make something
-           like ``x > y > z`` work.  There is an open PEP to change this,
-           :pep:`335`, but until that is implemented, this cannot be made to work.
+           like ``x > y > z`` work.  There was a PEP to change this,
+           :pep:`335`, but it was officially closed in March, 2012.
 
     .. [2] For more information, see these two bug reports:
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -187,6 +187,28 @@ class Wild(Symbol):
     A Wild symbol matches anything, or anything
     without whatever is explicitly excluded.
 
+    **Tips**
+
+		When using Wild, be sure to use the exclude
+		keyword to make the pattern deterministic.
+		Without the exclude pattern, you may get matches
+		that are technically correct, but not what you
+		wanted. This is especially likely if the
+		expression you are matching doesn't actually match
+		your pattern. For example, using the above without
+		exclude:
+
+		>>> (2 + 3*y).match(a*x + b*y)
+		{a: 2/x, b: 3}
+
+		This is technically correct, because
+		(2/x)*x + 3*y == 2 + 3*y, but you probably
+		wanted it to not match at all. The issue is that
+		you really didn't want a and b to include x and y,
+		and the exclude parameter lets you specify exactly
+		this.  With the exclude parameter, the above match
+		gives None, meaning it did not match.
+
     Examples
     ========
 
@@ -208,6 +230,12 @@ class Wild(Symbol):
     >>> A = WildFunction('A')
     >>> A.match(a)
     {a_: A_}
+
+    References
+    ==========
+
+    https://github.com/sympy/sympy/wiki/Idioms-and-Antipatterns#antipatterns
+
     """
 
     __slots__ = ['exclude', 'properties']

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -187,33 +187,11 @@ class Wild(Symbol):
     A Wild symbol matches anything, or anything
     without whatever is explicitly excluded.
 
-    **Tips**
-
-		When using Wild, be sure to use the exclude
-		keyword to make the pattern deterministic.
-		Without the exclude pattern, you may get matches
-		that are technically correct, but not what you
-		wanted. This is especially likely if the
-		expression you are matching doesn't actually match
-		your pattern. For example, using the above without
-		exclude:
-
-		>>> (2 + 3*y).match(a*x + b*y)
-		{a: 2/x, b: 3}
-
-		This is technically correct, because
-		(2/x)*x + 3*y == 2 + 3*y, but you probably
-		wanted it to not match at all. The issue is that
-		you really didn't want a and b to include x and y,
-		and the exclude parameter lets you specify exactly
-		this.  With the exclude parameter, the above match
-		gives None, meaning it did not match.
-
     Examples
     ========
 
     >>> from sympy import Wild, WildFunction, cos, pi
-    >>> from sympy.abc import x
+    >>> from sympy.abc import x, y, z
     >>> a = Wild('a')
     >>> x.match(a)
     {a_: x}
@@ -223,13 +201,55 @@ class Wild(Symbol):
     {a_: 3*x}
     >>> cos(x).match(a)
     {a_: cos(x)}
-    >>> b = Wild('b',exclude=[x])
+    >>> b = Wild('b', exclude=[x])
     >>> (3*x**2).match(b*x)
     >>> b.match(a)
     {a_: b_}
     >>> A = WildFunction('A')
     >>> A.match(a)
     {a_: A_}
+
+    Tips
+    ====
+
+    When using Wild, be sure to use the exclude
+    keyword to make the pattern more precise.
+    Without the exclude pattern, you may get matches
+    that are technically correct, but not what you
+    wanted. For example, using the above without
+    exclude:
+
+    >>> from sympy import Wild, symbols
+    >>> from sympy.abc import x, y, z
+    >>> a, b = symbols('a b',cls=Wild)
+    >>> (2 + 3*y).match(a*x + b*y)
+    {a_: 2/x, b_: 3}
+
+    This is technically correct, because
+    (2/x)*x + 3*y == 2 + 3*y, but you probably
+    wanted it to not match at all. The issue is that
+    you really didn't want a and b to include x and y,
+    and the exclude parameter lets you specify exactly
+    this.  With the exclude parameter, the pattern will
+    not match.
+
+    >>> a = Wild('a',exclude=[x,y])
+    >>> b = Wild('b',exclude=[x,y])
+    >>> (2 + 3*y).match(a*x + b*y)
+
+    Exclude also helps remove ambiguity from matches.
+
+    >>> E = 2*x**3*y*z
+    >>> a, b = symbols('a b', cls=Wild)
+    >>> E.match(a*b)
+    {a_: 2*y*z, b_: x**3}
+    >>> a = Wild('a', exclude=[x, y])
+    >>> E.match(a*b)
+    {a_: z, b_: 2*x**3*y}
+    >>> a = Wild('a', exclude=[x, y, z])
+    >>> E.match(a*b)
+    {a_: 2, b_: x**3*y*z}
+
 
     References
     ==========

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -184,7 +184,8 @@ class Dummy(Symbol):
 
 class Wild(Symbol):
     """
-    A Wild symbol matches anything.
+    A Wild symbol matches anything, or anything
+    without whatever is explicitly excluded.
 
     Examples
     ========
@@ -192,17 +193,18 @@ class Wild(Symbol):
     >>> from sympy import Wild, WildFunction, cos, pi
     >>> from sympy.abc import x
     >>> a = Wild('a')
-    >>> b = Wild('b')
-    >>> b.match(a)
-    {a_: b_}
     >>> x.match(a)
     {a_: x}
     >>> pi.match(a)
     {a_: pi}
-    >>> (x**2).match(a)
-    {a_: x**2}
+    >>> (3*x**2).match(a*x)
+    {a_: 3*x}
     >>> cos(x).match(a)
     {a_: cos(x)}
+    >>> b = Wild('b',exclude=[x])
+    >>> (3*x**2).match(b*x)
+    >>> b.match(a)
+    {a_: b_}
     >>> A = WildFunction('A')
     >>> A.match(a)
     {a_: A_}

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -219,9 +219,8 @@ class Wild(Symbol):
     wanted. For example, using the above without
     exclude:
 
-    >>> from sympy import Wild, symbols
-    >>> from sympy.abc import x, y, z
-    >>> a, b = symbols('a b',cls=Wild)
+    >>> from sympy import symbols
+    >>> a, b = symbols('a b', cls=Wild)
     >>> (2 + 3*y).match(a*x + b*y)
     {a_: 2/x, b_: 3}
 
@@ -233,8 +232,8 @@ class Wild(Symbol):
     this.  With the exclude parameter, the pattern will
     not match.
 
-    >>> a = Wild('a',exclude=[x,y])
-    >>> b = Wild('b',exclude=[x,y])
+    >>> a = Wild('a', exclude=[x, y])
+    >>> b = Wild('b', exclude=[x, y])
     >>> (2 + 3*y).match(a*x + b*y)
 
     Exclude also helps remove ambiguity from matches.

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -249,12 +249,6 @@ class Wild(Symbol):
     >>> E.match(a*b)
     {a_: 2, b_: x**3*y*z}
 
-
-    References
-    ==========
-
-    https://github.com/sympy/sympy/wiki/Idioms-and-Antipatterns#antipatterns
-
     """
 
     __slots__ = ['exclude', 'properties']

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -70,7 +70,32 @@ def test_power():
 
 def test_match_exclude():
     x = Symbol('x')
-    p = Wild('p')
+    y = Symbol('y')
+    p = Wild("p")
+    q = Wild("q")
+    r = Wild("r")
+
+    e = Rational(6)
+    assert e.match(2*p) == {p: 3}
+
+    e = 3/(4*x + 5)
+    assert e.match(3/(p*x + q)) == {p: 4, q: 5}
+
+    e = 3/(4*x + 5)
+    assert e.match(p/(q*x + r)) == {p: 3, q: 4, r: 5}
+
+    e = 2/(x + 1)
+    assert e.match(p/(q*x + r)) == {p: 2, q: 1, r: 1}
+
+    e = 1/(x + 1)
+    assert e.match(p/(q*x + r)) == {p: 1, q: 1, r: 1}
+
+    e = 4*x + 5
+    assert e.match(p*x + q) == {p: 4, q: 5}
+
+    e = 4*x + 5*y + 6
+    assert e.match(p*x + q*y + r) == {p: 4, q: 5, r: 6}
+
     a = Wild('a', exclude=[x])
 
     e = 3*x
@@ -84,29 +109,6 @@ def test_match_exclude():
     e = 3*x + 3 + 6/x
     assert e.match(p*x**2 + p*x + 2*p) == {p: 3/x}
     assert e.match(a*x**2 + a*x + 2*a) is None
-
-
-def test_exclude():
-    x, y, a = map(Symbol, 'xya')
-    p = Wild('p', exclude=[1, x])
-    q = Wild('q')
-    r = Wild('r', exclude=[sin, y])
-
-    assert sin(x).match(r) is None
-    assert cos(y).match(r) is None
-
-    e = 3*x**2 + y*x + a
-    assert e.match(p*x**2 + q*x + r) == {p: 3, q: y, r: a}
-
-    e = x + 1
-    assert e.match(x + p) is None
-    assert e.match(p + 1) is None
-    assert e.match(x + 1 + p) == {p: 0}
-
-    e = cos(x) + 5*sin(y)
-    assert e.match(r) is None
-    assert e.match(cos(y) + r) is None
-    assert e.match(r + p*sin(q)) == {r: cos(x), p: 5, q: y}
 
 
 def test_mul():
@@ -315,9 +317,6 @@ def test_match_bug6():
     e = x
     assert e.match(3*p*x) == {p: Rational(1)/3}
 
-    e = Rational(6)
-    assert e.match(2*p) == {p: 3}
-
 
 def test_match_polynomial():
     x = Symbol('x')
@@ -332,6 +331,29 @@ def test_match_polynomial():
     assert (eq - 3*x**2).match(pattern) == {a: 4, b: 0, c: 2, d: 1}
     assert (x + sqrt(2) + 3).match(a + b*x + c*x**2) == \
         {b: 1, a: sqrt(2) + 3, c: 0}
+
+
+def test_exclude():
+    x, y, a = map(Symbol, 'xya')
+    p = Wild('p', exclude=[1, x])
+    q = Wild('q')
+    r = Wild('r', exclude=[sin, y])
+
+    assert sin(x).match(r) is None
+    assert cos(y).match(r) is None
+
+    e = 3*x**2 + y*x + a
+    assert e.match(p*x**2 + q*x + r) == {p: 3, q: y, r: a}
+
+    e = x + 1
+    assert e.match(x + p) is None
+    assert e.match(p + 1) is None
+    assert e.match(x + 1 + p) == {p: 0}
+
+    e = cos(x) + 5*sin(y)
+    assert e.match(r) is None
+    assert e.match(cos(y) + r) is None
+    assert e.match(r + p*sin(q)) == {r: cos(x), p: 5, q: y}
 
 
 def test_floats():


### PR DESCRIPTION
While trying to better understand the Wild symbol, I found the 'exclude' key word wasn't documented.  In the process of trying to make sense of it's behavior, I found a number of the tests using 'exclude' didn't really need it.

This patch adds some docs to Wild, removes the obsolete tests, and implements some new ones that better document the 'exclude' flag.
