### PR TITLE
MatrixBase.is_zero supporting None results.

### DIFF
--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -90,6 +90,9 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
     __neg__ = MatrixBase.__neg__
     __div__ = MatrixBase.__div__
     __truediv__ = MatrixBase.__truediv__
+# This is included after the class definition as a workaround for issue 4114.
+# See http://code.google.com/p/sympy/issues/detail?id=4114
+ImmutableMatrix.is_zero = DenseMatrix.is_zero
 
 
 class ImmutableSparseMatrix(Basic, SparseMatrix):

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2005,16 +2005,19 @@ class MatrixBase(object):
 
         A matrix is zero if every element is zero.  A matrix need not be square
         to be considered zero.  The empty matrix is zero by the principle of
-        vacuous truth.
+        vacuous truth.  For a matrix that may or may not be zero (e.g.
+        contains a symbol), this will be None
 
         Examples
         ========
 
         >>> from sympy import Matrix, zeros
+        >>> from sympy.abc import x
         >>> a = Matrix([[0, 0], [0, 0]])
         >>> b = zeros(3, 4)
         >>> c = Matrix([[0, 1], [0, 0]])
         >>> d = Matrix([])
+        >>> e = Matrix([[x, 0], [0, 0]])
         >>> a.is_zero
         True
         >>> b.is_zero
@@ -2023,8 +2026,13 @@ class MatrixBase(object):
         False
         >>> d.is_zero
         True
+        >>> e.is_zero
         """
-        return not list(self.values())
+        if any(i.is_zero == False for i in self):
+            return False
+        if any(i.is_zero == None for i in self):
+            return None
+        return True
 
     def is_nilpotent(self):
         """Checks if a matrix is nilpotent.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1936,6 +1936,13 @@ def test_is_zero():
     assert Matrix([[0, 0], [0, 0]]).is_zero
     assert zeros(3, 4).is_zero
     assert not eye(3).is_zero
+    assert Matrix([[x, 0], [0, 0]]).is_zero == None
+    assert SparseMatrix([[x, 0], [0, 0]]).is_zero == None
+    assert ImmutableMatrix([[x, 0], [0, 0]]).is_zero == None
+    assert ImmutableSparseMatrix([[x, 0], [0, 0]]).is_zero == None
+    assert Matrix([[x, 1], [0, 0]]).is_zero == False
+    a = Symbol('a', nonzero=True)
+    assert Matrix([[a, 0], [0, 0]]).is_zero == False
 
 
 def test_rotation_matrices():


### PR DESCRIPTION
Extended original implementation of MatrixBase.is_zero to return None if the
matrix may or may not be a zero matrix.  Also found a workaround to issue 4114
to have this method accessible to ImmutableMatrix.

See http://code.google.com/p/sympy/issues/detail?id=4114
