### PR TITLE
Fix for issue 4111.

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -48,6 +48,8 @@ Moved modules:
 Iterator/list changes:
     * `xrange` removed in Python 3, import `xrange` for Python 2/3 compatible
       iterator version of range
+    * `.iteritems()` method of dict removed in Python 3.  Import function
+      `items()` for a stable name across Python versions.
 
 exec:
     * Use `exec_()`, with parameters `exec_(code, globs=None, locs=None)`
@@ -94,6 +96,10 @@ if PY3:
     exec_ = getattr(builtins, "exec")
 
     xrange = range
+
+    def items(d):
+        """return an iterator over the items of dict `d`"""
+        return d.items()
 else:
     import codecs
     import types
@@ -138,6 +144,10 @@ else:
         exec("exec _code_ in _globs_, _locs_")
 
     xrange = xrange
+
+    def items(d):
+        """return an iterator over the items of dict `d`"""
+        return d.iteritems()
 
 def with_metaclass(meta, *bases):
     """
@@ -548,7 +558,7 @@ def _nodes(e):
     elif iterable(e):
         return 1 + sum(_nodes(ei) for ei in e)
     elif isinstance(e, dict):
-        return 1 + sum(_nodes(k) + _nodes(v) for k, v in e.iteritems())
+        return 1 + sum(_nodes(k) + _nodes(v) for k, v in items(e))
     else:
         return 1
 

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import default_sort_key, as_int
+from sympy.core.compatibility import default_sort_key, as_int, ordered
 from sympy.core.singleton import S
 from sympy.utilities.pytest import raises
 
@@ -13,3 +13,8 @@ def test_default_sort_key():
 def test_as_int():
     raises(ValueError, lambda : as_int(1.1))
     raises(ValueError, lambda : as_int([]))
+
+def test_ordered():
+    "Issue 4111 - this was failing with python2/3 problems"
+    assert(list(ordered([{1:3, 2:4, 9:10}, {1:3}])) == \
+               [{1: 3}, {1: 3, 2: 4, 9: 10}])

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
 from sympy.utilities.iterables import numbered_symbols
-from sympy.core.compatibility import xrange
+from sympy.core.compatibility import items, xrange
 
 ###############################################################################
 ########################## TRIGONOMETRIC FUNCTIONS ############################
@@ -582,7 +582,7 @@ class cos(TrigonometricFunction):
                 return r.q
 
             if None == factors:
-                a = [n//x**y for x, y in factorint(r.q).iteritems()]
+                a = [n//x**y for x, y in items(factorint(r.q))]
             else:
                 a = [n//x for x in factors]
             if len(a) == 1:

--- a/sympy/polys/polycontext.py
+++ b/sympy/polys/polycontext.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function, division
 
+from sympy.core.compatibility import items
 from sympy.utilities.iterables import dict_merge
 from sympy.polys.polyutils import PicklableWithSlots
 
@@ -40,7 +41,7 @@ class Context(PicklableWithSlots):
 
     def __str__(self):
         return 'Context(%s)' % ', '.join(
-            [ '%s=%r' % (key, value) for key, value in self.__options__.iteritems() ])
+            ['%s=%r' % (key, value) for key, value in items(self.__options__)])
 
     def __and__(self, other):
         if isinstance(other, Context):


### PR DESCRIPTION
Define an items() function which delegates to dict.items() or
dict.iteritems(), depending on Python version.

I don't (yet) have tests to exercise the change to trigonometric.py or
polycontext.py.

```
modified:   core/compatibility.py
modified:   core/tests/test_compatibility.py
modified:   functions/elementary/trigonometric.py
modified:   polys/polycontext.py
```
