### PR TITLE
A simpler, more limited fix to issue 4111.

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -548,7 +548,7 @@ def _nodes(e):
     elif iterable(e):
         return 1 + sum(_nodes(ei) for ei in e)
     elif isinstance(e, dict):
-        return 1 + sum(_nodes(k) + _nodes(v) for k, v in e.iteritems())
+        return 1 + sum(_nodes(k) + _nodes(v) for k, v in e.items())
     else:
         return 1
 

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,4 +1,4 @@
-from sympy.core.compatibility import default_sort_key, as_int
+from sympy.core.compatibility import default_sort_key, as_int, ordered
 from sympy.core.singleton import S
 from sympy.utilities.pytest import raises
 
@@ -13,3 +13,9 @@ def test_default_sort_key():
 def test_as_int():
     raises(ValueError, lambda : as_int(1.1))
     raises(ValueError, lambda : as_int([]))
+
+
+def test_ordered():
+    "Issue 4111 - this was failing with python2/3 problems"
+    assert(list(ordered([{1:3, 2:4, 9:10}, {1:3}])) == \
+               [{1: 3}, {1: 3, 2: 4, 9: 10}])

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -16,6 +16,6 @@ def test_as_int():
 
 
 def test_ordered():
-    "Issue 4111 - this was failing with python2/3 problems"
+    # Issue 4111 - this had been failing with python2/3 problems
     assert(list(ordered([{1:3, 2:4, 9:10}, {1:3}])) == \
                [{1: 3}, {1: 3, 2: 4, 9: 10}])

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -582,7 +582,7 @@ class cos(TrigonometricFunction):
                 return r.q
 
             if None == factors:
-                a = [n//x**y for x, y in factorint(r.q).iteritems()]
+                a = [n//x**y for x, y in factorint(r.q).items()]
             else:
                 a = [n//x for x in factors]
             if len(a) == 1:

--- a/sympy/polys/polycontext.py
+++ b/sympy/polys/polycontext.py
@@ -40,7 +40,7 @@ class Context(PicklableWithSlots):
 
     def __str__(self):
         return 'Context(%s)' % ', '.join(
-            [ '%s=%r' % (key, value) for key, value in self.__options__.iteritems() ])
+            [ '%s=%r' % (key, value) for key, value in self.__options__.items() ])
 
     def __and__(self, other):
         if isinstance(other, Context):


### PR DESCRIPTION
Just change a few stray invocations of iteritems() to items(), in
order to be compatible with Python3 and consistent with previous
changes for supporting a Python2/3 unified source.

```
modified:   sympy/core/compatibility.py
modified:   sympy/core/tests/test_compatibility.py
modified:   sympy/functions/elementary/trigonometric.py
modified:   sympy/polys/polycontext.py
```
