### PR TITLE
manualintegrate can now handle Heaviside(x)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -11,7 +11,9 @@ techniques. To do so, write a function that accepts an ``IntegralInfo``
 object and returns either a namedtuple representing a rule or
 ``None``. Then, write another function that accepts the namedtuple's fields
 and returns the antiderivative, and decorate it with
-``@evaluates(namedtuple_type)``.
+``@evaluates(namedtuple_type)``.  If the new technique requires a new
+match, add the key and call to the antiderivative function to integral_steps.
+To enable simple substitutions, add the match to find_substitutions.
 
 """
 from __future__ import print_function, division
@@ -45,13 +47,14 @@ PartsRule = Rule("PartsRule", "u dv v_step second_step")
 CyclicPartsRule = Rule("CyclicPartsRule", "parts_rules coefficient")
 TrigRule = Rule("TrigRule", "func arg")
 ExpRule = Rule("ExpRule", "base exp")
-LogRule = Rule("LogRule", "func")
+ReciprocalRule = Rule("ReciprocalRule", "func")
 ArctanRule = Rule("ArctanRule")
 AlternativeRule = Rule("AlternativeRule", "alternatives")
 DontKnowRule = Rule("DontKnowRule")
 DerivativeRule = Rule("DerivativeRule")
 RewriteRule = Rule("RewriteRule", "rewritten substep")
 PiecewiseRule = Rule("PiecewiseRule", "subfunctions")
+HeavisideRule = Rule("HeavisideRule", "func")
 
 IntegralInfo = namedtuple('IntegralInfo', 'integrand symbol')
 
@@ -123,7 +126,7 @@ def find_substitutions(integrand, symbol, u_var):
         if any(isinstance(term, cls)
                for cls in (sympy.sin, sympy.cos, sympy.tan,
                            sympy.asin, sympy.acos, sympy.atan,
-                           sympy.exp, sympy.log)):
+                           sympy.exp, sympy.log, sympy.Heaviside)):
             return [term.args[0]]
         elif isinstance(term, sympy.Mul):
             r = []
@@ -221,7 +224,7 @@ def power_rule(integral):
 
     if symbol not in exp.free_symbols and isinstance(base, sympy.Symbol):
         if sympy.simplify(exp + 1) == 0:
-            return LogRule(base, integrand, symbol)
+            return ReciprocalRule(base, integrand, symbol)
         return PowerRule(base, exp, integrand, symbol)
     elif symbol not in base.free_symbols and isinstance(exp, sympy.Symbol):
         rule = ExpRule(base, exp, integrand, symbol)
@@ -480,6 +483,12 @@ def trig_product_rule(integral):
             rule = ConstantTimesRule(q, csccot, rule, integrand, symbol)
 
         return rule
+
+def heaviside_rule(integral):
+    integrand, symbol = integral
+    if isinstance(integrand.args[0], sympy.Symbol):
+        return HeavisideRule(integrand.args[0], integrand, symbol)
+    # else perhaps substitution can handle this
 
 @sympy.cacheit
 def make_wilds(symbol):
@@ -766,7 +775,7 @@ def integral_steps(integrand, symbol, **options):
             return sympy.Number
         else:
             for cls in (sympy.Pow, sympy.Symbol, sympy.exp, sympy.log,
-                        sympy.Add, sympy.Mul, sympy.atan, sympy.asin, sympy.acos):
+                        sympy.Add, sympy.Mul, sympy.atan, sympy.asin, sympy.acos, sympy.Heaviside):
                 if isinstance(integrand, cls):
                     return cls
 
@@ -785,6 +794,7 @@ def integral_steps(integrand, symbol, **options):
             sympy.Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule)),
             sympy.Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
+            sympy.Heaviside: heaviside_rule,
             sympy.Number: constant_rule
         })),
         null_safe(
@@ -859,8 +869,8 @@ def eval_trig(func, arg, integrand, symbol):
     elif func == 'csc*cot':
         return sympy.csc(arg)
 
-@evaluates(LogRule)
-def eval_log(func, integrand, symbol):
+@evaluates(ReciprocalRule)
+def eval_reciprocal(func, integrand, symbol):
     return sympy.ln(func)
 
 @evaluates(ArctanRule)
@@ -887,6 +897,11 @@ def eval_derivativerule(integrand, symbol):
         return integrand.args[0]
     else:
         return sympy.Derivative(integrand.args[0], *integrand.args[1:-1])
+
+@evaluates(HeavisideRule)
+def eval_heaviside(arg,integrand,symbol):
+    # this result can also be represented as sympy.Max(0,arg)
+    return arg*sympy.Heaviside(arg)
 
 @evaluates(DontKnowRule)
 def eval_dontknowrule(integrand, symbol):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,7 +1,7 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Mul, Integral, integrate, pi, Dummy,
                    Derivative, diff, I, sqrt, erf, Piecewise,
-                   Eq, Ne, Q, assuming, symbols, And)
+                   Eq, Ne, Q, assuming, symbols, And, Heaviside, Max)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     integral_steps, _parts_rule
 
@@ -103,6 +103,10 @@ def test_manualintegrate_derivative():
         x * Derivative(x**2 + 2*x + 3, y)
     assert manualintegrate(Derivative(sin(x), x, x, y, x), x) == \
         Derivative(sin(x), x, x, y)
+
+def test_manualintegrate_Heaviside():
+    assert manualintegrate(Heaviside(x), x) == x*Heaviside(x)
+    assert manualintegrate(Heaviside(2*x + 1), x) == (2*x+1)*Heaviside(2*x + 1)/2
 
 def test_issue_6799():
     r, x, phi = map(Symbol, 'r x phi'.split())


### PR DESCRIPTION
- [x] use x*Heaviside(x) instead of Max(x,0)
- Integral(Heaviside(x),x) == Max(0,x)
- enable simple substitutions
- add manualintegrate tests for Heaviside
- add to docs for improving manualintegrate

Also, rename "Log" integration commands to Reciprical for
    readability in manualintegrate module
