### PR TITLE
Passing printer parameters

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -201,7 +201,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   use_latex=None, wrap_line=None, num_columns=None,
                   no_global=False, ip=None, euler=False, forecolor='Black',
                   backcolor='Transparent', fontsize='10pt',
-                  latex_mode='equation*'):
+                  latex_mode='equation*', **printer_settings):
     """
     Initializes pretty-printer depending on the environment.
 
@@ -252,6 +252,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         IPython only: Default is '10pt'.
     latex_mode: string
         IPython only: Default is 'equation*'.
+
+    Remaining keyword arguments are passed as global settings to the Printer.
 
     Examples
     ========
@@ -329,7 +331,8 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
 
     if not no_global:
         Printer.set_global_settings(order=order, use_unicode=use_unicode,
-                                    wrap_line=wrap_line, num_columns=num_columns)
+                                    wrap_line=wrap_line, num_columns=num_columns,
+                                    **printer_settings)
     else:
         _stringify_func = stringify_func
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -242,6 +242,16 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     ip: An interactive console
         This can either be an instance of IPython,
         or a class that derives from code.InteractiveConsole.
+    euler: boolean
+        IPython only: If true, use the 'euler' package
+    forecolor: string
+        IPython only: Foreground color of font; default is 'Black'
+    backcolor: string
+        IPython only: Background color of font; default is 'Transparent'.
+    fontsize: string
+        IPython only: Default is '10pt'.
+    latex_mode: string
+        IPython only: Default is 'equation*'.
 
     Examples
     ========

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -336,7 +336,7 @@ def init_python_session():
 
 def init_session(ipython=None, pretty_print=True, order=None,
         use_unicode=None, use_latex=None, quiet=False, auto_symbols=False,
-        auto_int_to_Integer=False, argv=[]):
+        auto_int_to_Integer=False, argv=[], **printer_settings):
     """
     Initialize an embedded IPython or Python session. The IPython session is
     initiated with the --pylab option, without the numpy imports, so that
@@ -380,6 +380,8 @@ def init_session(ipython=None, pretty_print=True, order=None,
         an ipython instance or not.
     argv: list of arguments for IPython
         See sympy.bin.isympy for options that can be used to initialize IPython.
+
+    Remaining keyword arguments are passed as global settings to the Printer.
 
     See Also
     ========
@@ -481,7 +483,7 @@ def init_session(ipython=None, pretty_print=True, order=None,
 
     ip.runsource(_preexec_source, symbol='exec')
     init_printing(pretty_print=pretty_print, order=order,
-        use_unicode=use_unicode, use_latex=use_latex, ip=ip)
+        use_unicode=use_unicode, use_latex=use_latex, ip=ip, **printer_settings)
 
     message = _make_message(ipython, quiet, _preexec_source)
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -63,7 +63,7 @@ other_symbols = set(['aleph', 'beth', 'daleth', 'gimel', 'ell', 'eth', 'hbar',
                      'hslash', 'mho', 'wp', ])
 
 # Variable name modifiers
-modifier_dict = {
+default_symbol_modifiers = {
     # Accents
     'mathring': lambda s: r'\mathring{'+s+r'}',
     'ddddot': lambda s: r'\ddddot{'+s+r'}',
@@ -111,6 +111,7 @@ class LatexPrinter(Printer):
         "mat_str": None,
         "mat_delim": "[",
         "symbol_names": {},
+        "symbol_modifiers": default_symbol_modifiers
     }
 
     def __init__(self, settings=None):
@@ -540,7 +541,7 @@ class LatexPrinter(Printer):
           - if it is a longer name, then put \operatorname{} around it and be
             mindful of undercores in the name
         '''
-        func = translate(func)
+        func = translate(func, self._settings['symbol_modifiers'])
 
         if func in accepted_latex_functions:
             name = r"\%s" % func
@@ -1119,9 +1120,9 @@ class LatexPrinter(Printer):
 
         name, supers, subs = split_super_sub(expr.name)
 
-        name = translate(name)
-        supers = [translate(sup) for sup in supers]
-        subs = [translate(sub) for sub in subs]
+        name = translate(name, self._settings['symbol_modifiers'])
+        supers = [translate(sup, self._settings['symbol_modifiers']) for sup in supers]
+        subs = [translate(sub, self._settings['symbol_modifiers']) for sub in subs]
 
         # glue all items together:
         if len(supers) > 0:
@@ -1662,7 +1663,7 @@ class LatexPrinter(Printer):
         return r'\phi\left( %s \right)' %  self._print(expr.args[0])
 
 
-def translate(s):
+def translate(s, symbol_modifiers=default_symbol_modifiers):
     r'''
     Check for a modifier ending the string.  If present, convert the
     modifier to latex and translate the rest recursively.
@@ -1684,9 +1685,9 @@ def translate(s):
         return "\\" + s
     else:
         # Process modifiers, if any, and recurse
-        for key in sorted(modifier_dict.keys(), key=lambda k:len(k), reverse=True):
+        for key in sorted(symbol_modifiers.keys(), key=lambda k:len(k), reverse=True):
             if s.lower().endswith(key) and len(s)>len(key):
-                return modifier_dict[key](translate(s[:-len(key)]))
+                return symbol_modifiers[key](translate(s[:-len(key)], symbol_modifiers))
         return s
 
 def latex(expr, **settings):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -14,7 +14,7 @@ from sympy.printing.conventions import requires_partial
 from .stringpict import prettyForm, stringPict
 from .pretty_symbology import xstr, hobj, vobj, xobj, xsym, pretty_symbol, \
     pretty_atom, pretty_use_unicode, pretty_try_use_unicode, greek_unicode, U, \
-    annotated
+    annotated, default_symbol_modifiers
 
 from sympy.utilities import default_sort_key
 
@@ -33,6 +33,7 @@ class PrettyPrinter(Printer):
         "use_unicode": None,
         "wrap_line": True,
         "num_columns": None,
+        "symbol_modifiers": default_symbol_modifiers
     }
 
     def __init__(self, settings=None):
@@ -62,7 +63,7 @@ class PrettyPrinter(Printer):
         return pform
 
     def _print_Symbol(self, e):
-        symb = pretty_symbol(e.name)
+        symb = pretty_symbol(e.name, self._settings['symbol_modifiers'])
         return prettyForm(symb)
     _print_RandomSymbol = _print_Symbol
 
@@ -1496,7 +1497,7 @@ class PrettyPrinter(Printer):
         else:
             form = 'GF(%d)'
 
-        return prettyForm(pretty_symbol(form % expr.mod))
+        return prettyForm(pretty_symbol(form % expr.mod), self._settings['symbol_modifiers'])
 
     def _print_IntegerRing(self, expr):
         if self._use_unicode:
@@ -1519,7 +1520,7 @@ class PrettyPrinter(Printer):
         if domain.has_default_precision:
             return prettyForm(prefix)
         else:
-            return self._print(pretty_symbol(prefix + "_" + str(domain.precision)))
+            return self._print(pretty_symbol(prefix + "_" + str(domain.precision), self._settings['symbol_modifiers']))
 
     def _print_ComplexField(self, domain):
         if self._use_unicode:
@@ -1530,7 +1531,7 @@ class PrettyPrinter(Printer):
         if domain.has_default_precision:
             return prettyForm(prefix)
         else:
-            return self._print(pretty_symbol(prefix + "_" + str(domain.precision)))
+            return self._print(pretty_symbol(prefix + "_" + str(domain.precision), self._settings['symbol_modifiers']))
 
     def _print_PolynomialRing(self, expr):
         args = list(expr.symbols)
@@ -1622,7 +1623,7 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.right((prettyForm(','))))
         pform = prettyForm(*pform.right((self._print(e.args[1]))))
         if self._use_unicode:
-            a = stringPict(pretty_symbol('delta'))
+            a = stringPict(pretty_symbol('delta', self._settings['symbol_modifiers']))
         else:
             a = stringPict('d')
         b = pform
@@ -1659,7 +1660,7 @@ class PrettyPrinter(Printer):
         return self._print_DMP(p)
 
     def _print_Object(self, object):
-        return self._print(pretty_symbol(object.name))
+        return self._print(pretty_symbol(object.name, self._settings['symbol_modifiers']))
 
     def _print_Morphism(self, morphism):
         arrow = xsym("-->")
@@ -1671,7 +1672,7 @@ class PrettyPrinter(Printer):
         return prettyForm(tail)
 
     def _print_NamedMorphism(self, morphism):
-        pretty_name = self._print(pretty_symbol(morphism.name))
+        pretty_name = self._print(pretty_symbol(morphism.name, self._settings['symbol_modifiers']))
         pretty_morphism = self._print_Morphism(morphism)
         return prettyForm(pretty_name.right(":", pretty_morphism)[0])
 
@@ -1686,7 +1687,7 @@ class PrettyPrinter(Printer):
 
         # All components of the morphism have names and it is thus
         # possible to build the name of the composite.
-        component_names_list = [pretty_symbol(component.name) for
+        component_names_list = [pretty_symbol(component.name, self._settings['symbol_modifiers']) for
                                 component in morphism.components]
         component_names_list.reverse()
         component_names = circle.join(component_names_list) + ":"
@@ -1696,7 +1697,7 @@ class PrettyPrinter(Printer):
         return prettyForm(pretty_name.right(pretty_morphism)[0])
 
     def _print_Category(self, category):
-        return self._print(pretty_symbol(category.name))
+        return self._print(pretty_symbol(category.name, self._settings['symbol_modifiers']))
 
     def _print_Diagram(self, diagram):
         if not diagram.premises:
@@ -1755,17 +1756,17 @@ class PrettyPrinter(Printer):
 
     def _print_BaseScalarField(self, field):
         string = field._coord_sys._names[field._index]
-        return self._print(pretty_symbol(string))
+        return self._print(pretty_symbol(string, self._settings['symbol_modifiers']))
 
     def _print_BaseVectorField(self, field):
         s = U('PARTIAL DIFFERENTIAL') + '_' + field._coord_sys._names[field._index]
-        return self._print(pretty_symbol(s))
+        return self._print(pretty_symbol(s, self._settings['symbol_modifiers']))
 
     def _print_Differential(self, diff):
         field = diff._form_field
         if hasattr(field, '_coord_sys'):
             string = field._coord_sys._names[field._index]
-            return self._print(u('\u2146 ') + pretty_symbol(string))
+            return self._print(u('\u2146 ') + pretty_symbol(string, self._settings['symbol_modifiers']))
         else:
             pform = self._print(field)
             pform = prettyForm(*pform.parens())

--- a/sympy/printing/pretty/pretty_symbology.py
+++ b/sympy/printing/pretty/pretty_symbology.py
@@ -184,7 +184,7 @@ for s in '+-=()':
 # Variable modifiers
 # TODO: Is it worth trying to handle faces with, e.g., 'MATHEMATICAL BOLD CAPITAL A'?
 # TODO: Make brackets adjust to height of contents
-modifier_dict = {
+default_symbol_modifiers = {
     # Accents
     'mathring': lambda s: s+u('\u030A'),
     'ddddot': lambda s: s+u('\u0308\u0308'),
@@ -201,7 +201,7 @@ modifier_dict = {
     'vec': lambda s: s+u('\u20D7'),
     'prime': lambda s: s+u(' \u030D'),
     'prm': lambda s: s+u(' \u030D'),
-    # # Faces -- these are here for some compatibility with latex printing
+    # # Faces -- these are used in latex printing...
     # 'bold': lambda s: s,
     # 'bm': lambda s: s,
     # 'cal': lambda s: s,
@@ -473,7 +473,7 @@ def pretty_atom(atom_name, default=None):
         raise KeyError('only unicode')  # send it default printer
 
 
-def pretty_symbol(symb_name):
+def pretty_symbol(symb_name, symbol_modifiers=default_symbol_modifiers):
     """return pretty representation of a symbol"""
     # let's split symb_name into symbol + index
     # UC: beta1
@@ -488,9 +488,9 @@ def pretty_symbol(symb_name):
         gG = greek_unicode.get(s)
         if gG is not None:
             return gG
-        for key in sorted(modifier_dict.keys(), key=lambda k:len(k), reverse=True) :
+        for key in sorted(symbol_modifiers.keys(), key=lambda k:len(k), reverse=True) :
             if s.lower().endswith(key) and len(s)>len(key):
-                return modifier_dict[key](translate(s[:-len(key)]))
+                return symbol_modifiers[key](translate(s[:-len(key)]))
         return s
 
     name = translate(name)


### PR DESCRIPTION
Following up on PR #2488 and ~~google issue [4054](https://code.google.com/p/sympy/issues/detail?id=4054)~~ #7153, this PR adds options to the latex and pretty printers to change the symbol modifier lists.  In particular, to disable the symbol modifiers, either printer can be given an empty dictionary as the `symbol_modifiers` argument.

This also takes a stab at passing the options through `init_printing` and `init_session`, per google issue ~~[3612](https://code.google.com/p/sympy/issues/detail?id=3612)~~ #6711.  For example, to disable symbol modifiers:

``` python
from sympy import *
init_printing(symbol_modifiers={})
```

Or, to change the unicode printer to print `Symbol('xTilde')` as `x~` instead of `x̃`, you could initialize printing like this:

``` python
from sympy import *
from sympy.printing.pretty.pretty_symbology import default_symbol_modifiers as new_symbol_modifiers
new_symbol_modifiers['tilde'] = lambda s: s+'~'
init_printing(symbol_modifiers=new_symbol_modifiers)
```

This passing through may not be done in the most future-friendly way, so I welcome any suggestions.  In particular, I have no idea how to pass a printer as an option to either of those functions; I don't really understand the voodoo well enough.  So this does not address google issue ~~[4013](https://code.google.com/p/sympy/issues/detail?id=4013)~~ #7112.  Finally, I have no idea how I would test these initializations.

<!-- BEGIN RELEASE NOTES -->
* printing
  * add support for custom `symbol_modifiers`
<!-- END RELEASE NOTES -->
