### PR TITLE
3383: Remove deprecated separate() function

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -9,7 +9,7 @@ from .decorators import _sympifyit, call_highest_priority
 from .cache import cacheit
 from .compatibility import reduce, as_int, default_sort_key, xrange
 from sympy.mpmath.libmp import mpf_log, prec_to_dps
-
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 from collections import defaultdict
 
 
@@ -2926,6 +2926,12 @@ class Expr(Basic, EvalfMixin):
         return nsimplify(self, constants, tolerance, full)
 
     def separate(self, deep=False, force=False):
+	SymPyDeprecationWarning(
+	    feature="separate()",
+	    useinstead="expand_power_base()",
+	    issue=3383,
+	    deprecated_since_version="0.7.2",
+	).warn()
         """See the separate function in sympy.simplify"""
         from sympy.simplify import separate
         return separate(self, deep)

--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -33,6 +33,7 @@ from sympy import sympify, Expr, Tuple, Dummy
 from sympy.external import import_module
 from sympy.utilities.decorator import doctest_depends_on
 from .experimental_lambdify import (vectorized_lambdify, lambdify)
+from sympy.utilities.exceptions import SymPyDeprecationWarning
 
 # N.B.
 # When changing the minimum module version for matplotlib, please change
@@ -140,9 +141,17 @@ class Plot(object):
 
     - surface_color : function which returns a float.
     """
-
+   
     def __init__(self, *args, **kwargs):
+	
+
         super(Plot, self).__init__()
+	SymPyDeprecationWarning(
+		    feature="Plot()",
+		    useinstead="",
+		    issue=2987,
+		    deprecated_since_version="",
+	).warn()
 
         #  Options for the graph as a whole.
         #  The possible values for each option are described in the docstring of


### PR DESCRIPTION
Added SymPyDeprecationWarning() to the separate function
