### PR TITLE
plot functions now pass on kwargs when constructing series.

### DIFF
--- a/sympy/plotting/plot.py
+++ b/sympy/plotting/plot.py
@@ -1341,7 +1341,7 @@ def plot_parametric(*args, **kwargs):
     show = kwargs.pop('show', True)
     series = []
     plot_expr = check_arguments(args, 2, 1)
-    series = [Parametric2DLineSeries(*arg) for arg in plot_expr]
+    series = [Parametric2DLineSeries(*arg, **kwargs) for arg in plot_expr]
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()
@@ -1437,7 +1437,7 @@ def plot3d_parametric_line(*args, **kwargs):
     show = kwargs.pop('show', True)
     series = []
     plot_expr = check_arguments(args, 3, 1)
-    series = [Parametric3DLineSeries(*arg) for arg in plot_expr]
+    series = [Parametric3DLineSeries(*arg, **kwargs) for arg in plot_expr]
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()
@@ -1549,7 +1549,7 @@ def plot3d(*args, **kwargs):
     show = kwargs.pop('show', True)
     series = []
     plot_expr = check_arguments(args, 1, 2)
-    series = [SurfaceOver2DRangeSeries(*arg) for arg in plot_expr]
+    series = [SurfaceOver2DRangeSeries(*arg, **kwargs) for arg in plot_expr]
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()
@@ -1644,7 +1644,7 @@ def plot3d_parametric_surface(*args, **kwargs):
     show = kwargs.pop('show', True)
     series = []
     plot_expr = check_arguments(args, 3, 2)
-    series = [ParametricSurfaceSeries(*arg) for arg in plot_expr]
+    series = [ParametricSurfaceSeries(*arg, **kwargs) for arg in plot_expr]
     plots = Plot(*series, **kwargs)
     if show:
         plots.show()


### PR DESCRIPTION
Currently functions like plot3d don't pass on kwargs when constructing the data series.  This means that it is not possible to use options like nb_of_points_x with plot3d.  This has been fixed.
