### PR TITLE
Improvements to IPython printing: strings, floats, and ints.

### DIFF
--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -233,11 +233,13 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         if 'mathjax', enable latex text generation, for example MathJax
         rendering in IPython notebook or text rendering in LaTeX documents
     wrap_line: boolean
-        If True, lines will wrap at the end;
-        if False, they will not wrap but continue as one line.
+        If True, lines will wrap at the end; if False, they will not wrap
+        but continue as one line. This is only relevant if `pretty_print` is
+        True.
     num_columns: int or None
-        If int, number of columns before wrapping is set to num_columns;
-        if None, number of columns before wrapping is set to terminal width.
+        If int, number of columns before wrapping is set to num_columns; if
+        None, number of columns before wrapping is set to terminal width.
+        This is only relevant if `pretty_print` is True.
     no_global: boolean
         If True, the settings become system wide;
         if False, use just for this console/session.

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -6,7 +6,7 @@ from io import BytesIO
 
 from sympy import latex
 from sympy import preview
-from sympy.core.compatibility import integer_types, string_types
+from sympy.core.compatibility import integer_types
 from sympy.utilities.misc import debug
 
 def _init_python_printing(stringify_func):
@@ -30,8 +30,8 @@ def _init_python_printing(stringify_func):
     sys.displayhook = _displayhook
 
 
-def _init_ipython_printing(ip, stringify_func, use_latex, euler,
-                           forecolor, backcolor, fontsize, latex_mode):
+def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
+                           backcolor, fontsize, latex_mode, print_builtin):
     """Setup printing in IPython interactive session. """
     try:
         from IPython.lib.latextools import latex_to_png
@@ -93,10 +93,12 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
         if isinstance(o, (list, tuple, set, frozenset)):
             return all(_can_print_latex(i) for i in o)
         elif isinstance(o, dict):
-            return all((isinstance(i, string_types) or _can_print_latex(i)) and _can_print_latex(o[i]) for i in o)
+            return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
         elif isinstance(o, bool):
             return False
-        elif isinstance(o, (sympy.Basic, sympy.matrices.MatrixBase, float, integer_types)):
+        elif isinstance(o, (sympy.Basic, sympy.matrices.MatrixBase)):
+            return True
+        elif isinstance(o, (float, integer_types)) and print_builtin:
             return True
         return False
 
@@ -155,7 +157,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler,
     if IPython.__version__ >= '0.11':
         from sympy.core.basic import Basic
         from sympy.matrices.matrices import MatrixBase
-        printable_types = [Basic, MatrixBase,  float, tuple, list, set,
+        printable_types = [Basic, MatrixBase, float, tuple, list, set,
                 frozenset, dict] + list(integer_types)
 
         plaintext_formatter = ip.display_formatter.formatters['text/plain']
@@ -201,7 +203,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
                   use_latex=None, wrap_line=None, num_columns=None,
                   no_global=False, ip=None, euler=False, forecolor='Black',
                   backcolor='Transparent', fontsize='10pt',
-                  latex_mode='equation*'):
+                  latex_mode='equation*', print_builtin=True):
     """
     Initializes pretty-printer depending on the environment.
 
@@ -242,6 +244,22 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     ip: An interactive console
         This can either be an instance of IPython,
         or a class that derives from code.InteractiveConsole.
+    euler: boolean, optional, default=False
+        Loads the euler package in the LaTeX preamble for handwritten style
+        fonts (http://www.ctan.org/pkg/euler).
+    forecolor: string, optional, default='Black'
+        DVI setting for foreground color.
+    backcolor: string, optional, default='Transparent'
+        DVI setting for background color.
+    fontsize: string, optional, default='10pt'
+        A font size to pass to the LaTeX documentclass function in the
+        preamble.
+    latex_mode: string, optional, default='equation*'
+        The mode used in the LaTeX printer. Can be one of:
+        {'inline'|'plain'|'equation'|'equation*'}.
+    print_builtin: boolean, optional, default=True
+        If true then floats and integers will be printed. If false the
+        printer will only print SymPy types.
 
     Examples
     ========
@@ -334,6 +352,6 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
 
     if ip is not None and ip.__module__.startswith('IPython'):
         _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
-                               backcolor, fontsize, latex_mode)
+                               backcolor, fontsize, latex_mode, print_builtin)
     else:
         _init_python_printing(stringify_func)

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -43,3 +43,40 @@ def test_ipythonprinting():
     else:
         assert app.user_ns['a'][0]['text/plain'] in (u('\u03c0'), 'pi')
         assert app.user_ns['a2'][0]['text/plain'] in (u(' 2\n\u03c0 '), '  2\npi ')
+
+def test_print_builtin_option():
+    # Initialize and setup IPython session
+    app = init_ipython_session()
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("inst = ip.instance()")
+    app.run_cell("format = inst.display_formatter.format")
+    app.run_cell("from sympy import Symbol")
+    app.run_cell("from sympy import init_printing")
+
+    app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        text = app.user_ns['a']['text/plain']
+    else:
+        text = app.user_ns['a'][0]['text/plain']
+    assert text == "{pi: 3.14, n_i: 3}"
+
+    # If we enable the default printing, then the dictionary's should render
+    # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
+    app.run_cell("init_printing()")
+    app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        text = app.user_ns['a']['text/plain']
+    else:
+        text = app.user_ns['a'][0]['text/plain']
+    assert text == u('{n\u1d62: 3, \u03c0: 3.14}')
+
+    app.run_cell("init_printing(print_builtin=False)")
+    app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")
+    # Deal with API change starting at IPython 1.0
+    if int(ipython.__version__.split(".")[0]) < 1:
+        text = app.user_ns['a']['text/plain']
+    else:
+        text = app.user_ns['a'][0]['text/plain']
+    assert text == "{pi: 3.14, n_i: 3}"

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -63,7 +63,8 @@ def test_print_builtin_option():
     else:
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
-    assert text == "{pi: 3.14, n_i: 3}"
+    # Note : In Python 3 the text is unicode, but in 2 it is a string.
+    assert text in ("{pi: 3.14, n_i: 3}", "{nᵢ: 3, π: 3.14}")
 
     # If we enable the default printing, then the dictionary's should render
     # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
@@ -90,4 +91,5 @@ def test_print_builtin_option():
     else:
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
-    assert text == "{pi: 3.14, n_i: 3}"
+    # Note : In Python 3 the text is unicode, but in 2 it is a string.
+    assert text in ("{pi: 3.14, n_i: 3}", "{nᵢ: 3, π: 3.14}")

--- a/sympy/interactive/tests/test_ipythonprinting.py
+++ b/sympy/interactive/tests/test_ipythonprinting.py
@@ -12,6 +12,7 @@ ipython = import_module("IPython", min_module_version="0.11")
 if not ipython:
     disabled = True
 
+
 def test_ipythonprinting():
     # Initialize and setup IPython session
     app = init_ipython_session()
@@ -64,7 +65,7 @@ def test_print_builtin_option():
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
     # Note : In Python 3 the text is unicode, but in 2 it is a string.
-    assert text in ("{pi: 3.14, n_i: 3}", "{nᵢ: 3, π: 3.14}")
+    assert text in ("{pi: 3.14, n_i: 3}", u('{n\u1d62: 3, \u03c0: 3.14}'))
 
     # If we enable the default printing, then the dictionary's should render
     # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
@@ -92,4 +93,7 @@ def test_print_builtin_option():
         text = app.user_ns['a'][0]['text/plain']
         raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
     # Note : In Python 3 the text is unicode, but in 2 it is a string.
-    assert text in ("{pi: 3.14, n_i: 3}", "{nᵢ: 3, π: 3.14}")
+    # Python 3.3.3 + IPython 0.13.2 gives: '{n_i: 3, pi: 3.14}'
+    # Python 3.3.3 + IPython 1.1.0 gives: '{n_i: 3, pi: 3.14}'
+    # Python 2.7.5 + IPython 1.1.0 gives: '{pi: 3.14, n_i: 3}'
+    assert text in ("{pi: 3.14, n_i: 3}", "{n_i: 3, pi: 3.14}")


### PR DESCRIPTION
Removed strings from LaTeX printing in IPython as this was causing dictionaries
that contained strings and other valid LaTeX printable types to render. This is
typically not desirable especially if you have a dictionary with only strings,
floats, and integers.

I also added an option `print_builtin` to `init_printing` that allows you to
disable the float and integer LaTeX printing. For example, if you don't want a
dictionary of integer keys and float values to render in LaTeX.

Fixes issue #2672.

Tasks
- [x] Add tests to check that the LaTeX printing is correct.
