### PR TITLE
Issue 4107: Equality with matrices

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -138,7 +138,9 @@ def Ge(a, b):
 
 
 class Relational(Boolean, Expr, EvalfMixin):
+    """Superclass for all types of symbolic comparisons between objects.
 
+    """
     __slots__ = []
 
     is_Relational = True
@@ -168,6 +170,14 @@ class Relational(Boolean, Expr, EvalfMixin):
             elif know is False:
                 diff = diff.n()
         if rop_cls is Equality:
+            if hasattr(lhs, '_eval_Eq'):
+                res = lhs._eval_Eq(rhs)
+                if res is not None:
+                    return res
+            if hasattr(rhs, '_eval_Eq'):
+                res = rhs._eval_Eq(lhs)
+                if res is not None:
+                    return res
             if (lhs == rhs) is True or (diff == S.Zero) is True:
                 return True
             elif diff is S.NaN:
@@ -229,6 +239,13 @@ class Relational(Boolean, Expr, EvalfMixin):
 
 
 class Equality(Relational):
+    """Equality check between two symbolic expressions.
+
+    If at least one of the two objects defines the method _eval_Eq, that
+    will be called to evaluate the expression.  If the method does not
+    exist or returns None, the standard algorithm will be used.
+
+    """
 
     rel_op = '=='
 

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,7 +1,9 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic, Integer, Tuple, Dict
+from sympy.core.relational import Equality
 from sympy.core.sympify import converter as sympify_converter
+from sympy.logic.boolalg import And
 
 from sympy.matrices.matrices import MatrixBase
 from sympy.matrices.dense import DenseMatrix
@@ -62,6 +64,21 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
 
     def __setitem__(self, *args):
         raise TypeError("Cannot set values of ImmutableMatrix")
+
+    def _eval_Eq(self, other):
+        """Helper method for Equality with matrices.
+
+        Relational automatically converts matrices to ImmutableMatrix
+        instances, so this method only applies here.  Returns True if the
+        matrices are definitively the same, False if they are definitively
+        different, and None if undetermined (e.g. if they contain Symbols).
+        Returning None triggers default handling of Equalities.
+
+        """
+        if not hasattr(other, 'shape') or self.shape != other.shape:
+            return False
+        diff = self - other
+        return diff.is_zero
 
     adjoint = MatrixBase.adjoint
     conjugate = MatrixBase.conjugate
@@ -142,3 +159,5 @@ class ImmutableSparseMatrix(Basic, SparseMatrix):
 
     def __hash__(self):
         return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
+
+    _eval_Eq = ImmutableMatrix._eval_Eq

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,4 +1,4 @@
-from sympy import ImmutableMatrix, Matrix, eye, zeros
+from sympy import ImmutableMatrix, Matrix, eye, zeros, Equality
 from sympy.abc import x, y
 from sympy.utilities.pytest import raises
 
@@ -86,3 +86,13 @@ def test_immutable_evaluation():
     assert isinstance(X * 2, ImmutableMatrix)
     assert isinstance(2 * X, ImmutableMatrix)
     assert isinstance(A**2, ImmutableMatrix)
+
+
+def test_Equality():
+    assert Equality(IM, IM) == True
+    assert Equality(IM, IM.subs(1, 2)) == False
+    assert Equality(IM, 2) == False
+    M = ImmutableMatrix([x, y])
+    assert Equality(M, IM) == False
+    assert Equality(M, M.subs(x, 2)).subs(x, 2) == True
+    assert Equality(M, M.subs(x, 2)).subs(x, 3) == False


### PR DESCRIPTION
http://code.google.com/p/sympy/issues/detail?id=4107

This allows matrices to be properly used within Equality objects. Two features were added to do this:
1. Relational was changed to support objects with an `_eval_Eq` method, as suggested by @mrocklin. If creating an Equality, Relational will check for the presence of `_eval_Eq` in either argument, and fall back on the existing algorithm if the method does not exist, or returns None.
2. ImmutableMatrix had an `_eval_Eq` method added to it. It checks if the other argument has a shape matching its own, then checks if the difference between the two matrices is zero, leveraging PR #2637, to determine equality.

For my previous attempt, see PR #2625.
