### PR TITLE
Added `to_matrix` method to Vector and Dyadic in mechanics.

### DIFF
--- a/doc/src/modules/physics/mechanics/masses.rst
+++ b/doc/src/modules/physics/mechanics/masses.rst
@@ -60,6 +60,18 @@ Notice that the ``inertia`` function returns a dyadic with each component
 represented as two unit vectors separated by a ``|``. Refer to the
 :ref:`Dyadic` section for more information about dyadics.
 
+Inertia is often expressed in a matrix, or tensor, form, especially for
+numerical purposes. Since the matrix form does not contain any information
+about the reference frame(s) the inertia dyadic is defined in, you must provide
+one or two reference frames to extract the measure numbers from the dyadic.
+There is a convenience function to do this::
+
+  >>> inertia(N, 1, 2, 3, 4, 5, 6).to_matrix(N)
+  Matrix([
+  [1, 4, 6],
+  [4, 2, 5],
+  [6, 5, 3]])
+
 Rigid Body
 ==========
 

--- a/doc/src/modules/physics/mechanics/vectors.rst
+++ b/doc/src/modules/physics/mechanics/vectors.rst
@@ -11,7 +11,7 @@ Vector
 ======
 
 A vector is a geometric object that has a magnitude (or length) and a
-direction.  Vectors in 3-space are often represented on paper as:
+direction. Vectors in 3-space are often represented on paper as:
 
 .. image:: vec_rep.*
    :height: 175
@@ -587,12 +587,24 @@ warnings. ::
   - N.y + N.z
 
 Two additional operations can be done with vectors: normalizing the vector to
-length 1, and getting its magnitude. These are done as follows:
+length 1, and getting its magnitude. These are done as follows::
 
   >>> (N.x + N.y).normalize()
   sqrt(2)/2*N.x + sqrt(2)/2*N.y
   >>> (N.x + N.y).magnitude()
   sqrt(2)
+
+Vectors are often expressed in a matrix form, especially for numerical
+purposes. Since the matrix form does not contain any information about the
+reference frame the vector is defined in, you must provide a reference frame to
+extract the measure numbers from the vector. There is a convenience function to
+do this::
+
+  >>> (x * N.x + 2 * x * N.y + 3 * x * N.z).to_matrix(N)
+  Matrix([
+    [  x],
+    [2*x],
+    [3*x]])
 
 Vector Calculus, in Mechanics
 -----------------------------

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -448,9 +448,9 @@ class Dyadic(object):
         >>> A = N.orientnew('A', 'Axis', (beta, N.x))
         >>> inertia_dyadic.to_matrix(A)
         Matrix([
-        [                           Ixx,                                                           Ixy*cos(beta) + Ixz*sin(beta),                                                           -Ixy*sin(beta) + Ixz*cos(beta)],
-        [ Ixy*cos(beta) + Ixz*sin(beta),   (Iyy*cos(beta) + Iyz*sin(beta))*cos(beta) + (Iyz*cos(beta) + Izz*sin(beta))*sin(beta),   -(Iyy*cos(beta) + Iyz*sin(beta))*sin(beta) + (Iyz*cos(beta) + Izz*sin(beta))*cos(beta)],
-        [-Ixy*sin(beta) + Ixz*cos(beta), (-Iyy*sin(beta) + Iyz*cos(beta))*cos(beta) + (-Iyz*sin(beta) + Izz*cos(beta))*sin(beta), -(-Iyy*sin(beta) + Iyz*cos(beta))*sin(beta) + (-Iyz*sin(beta) + Izz*cos(beta))*cos(beta)]])
+        [                           Ixx,                                           Ixy*cos(beta) + Ixz*sin(beta),                                           -Ixy*sin(beta) + Ixz*cos(beta)],
+        [ Ixy*cos(beta) + Ixz*sin(beta), Iyy*cos(2*beta)/2 + Iyy/2 + Iyz*sin(2*beta) - Izz*cos(2*beta)/2 + Izz/2,                 -Iyy*sin(2*beta)/2 + Iyz*cos(2*beta) + Izz*sin(2*beta)/2],
+        [-Ixy*sin(beta) + Ixz*cos(beta),                -Iyy*sin(2*beta)/2 + Iyz*cos(2*beta) + Izz*sin(2*beta)/2, -Iyy*cos(2*beta)/2 + Iyy/2 - Iyz*sin(2*beta) + Izz*cos(2*beta)/2 + Izz/2]])
 
         """
 

--- a/sympy/physics/mechanics/essential.py
+++ b/sympy/physics/mechanics/essential.py
@@ -454,22 +454,11 @@ class Dyadic(object):
 
         """
 
-        i_unit_vectors = [getattr(reference_frame, u)
-                          for u in ['x', 'y', 'z']]
-        if second_reference_frame is not None:
-            j_unit_vectors = [getattr(second_reference_frame, u)
-                              for u in ['x', 'y', 'z']]
-        else:
-            j_unit_vectors = i_unit_vectors
+        if second_reference_frame is None:
+            second_reference_frame = reference_frame
 
-        matrix = []
-        for i in i_unit_vectors:
-            row = []
-            for j in j_unit_vectors:
-                row.append(self.dot(j).dot(i))
-            matrix.append(row)
-
-        return Matrix(matrix)
+        return Matrix([i.dot(self).dot(j) for i in reference_frame for j in
+                      second_reference_frame]).reshape(3, 3)
 
     def doit(self, **hints):
         """Calls .doit() on each term in the Dyadic"""
@@ -1808,14 +1797,8 @@ class Vector(object):
 
         """
 
-        i_unit_vectors = [getattr(reference_frame, u)
-                          for u in ['x', 'y', 'z']]
-
-        matrix = []
-        for i in i_unit_vectors:
-            matrix.append([self.dot(i)])
-
-        return Matrix(matrix)
+        return Matrix([self.dot(unit_vec) for unit_vec in
+                       reference_frame]).reshape(3, 1)
 
     def doit(self, **hints):
         """Calls .doit() on each term in the Vector"""

--- a/sympy/physics/mechanics/tests/test_essential.py
+++ b/sympy/physics/mechanics/tests/test_essential.py
@@ -45,6 +45,24 @@ def test_dyadic():
     assert d1.express(A, B) == (cos(q)) * (A.x | B.x) + (-sin(q)) * (A.x | B.y)
     assert d1.dt(B) == (-qd) * (A.y | A.x) + (-qd) * (A.x | A.y)
 
+    assert d1.to_matrix(A) == Matrix([[1, 0, 0], [0, 0, 0], [0, 0, 0]])
+    assert d1.to_matrix(A, B) == Matrix([[cos(q), -sin(q), 0],
+                                         [0, 0, 0],
+                                         [0, 0, 0]])
+    assert d3.to_matrix(A) == Matrix([[0, 1, 0], [0, 0, 0], [0, 0, 0]])
+    a, b, c, d, e, f = symbols('a, b, c, d, e, f')
+    v1 = a * A.x + b * A.y + c * A.z
+    v2 = d * A.x + e * A.y + f * A.z
+    d4 = v1.outer(v2)
+    assert d4.to_matrix(A) == Matrix([[a * d, a * e, a * f],
+                                      [b * d, b * e, b * f],
+                                      [c * d, c * e, c * f]])
+    d5 = v1.outer(v1)
+    C = A.orientnew('C', 'Axis', [q, A.x])
+    for expected, actual in zip(C.dcm(A) * d5.to_matrix(A) * C.dcm(A).T,
+                                d5.to_matrix(C)):
+        assert (expected - actual).simplify() == 0
+
 
 def test_coordinate_vars():
     """Tests the coordinate variables functionality"""
@@ -231,6 +249,12 @@ def test_Vector():
     assert dot(v4, A.y) == y - y**2
     assert dot(v4, A.z) == z - z**2
 
+    assert v1.to_matrix(A) == Matrix([[x], [y], [z]])
+    q = symbols('q')
+    B = A.orientnew('B', 'Axis', (q, A.x))
+    assert v1.to_matrix(B) == Matrix([[x],
+                                      [ y * cos(q) + z * sin(q)],
+                                      [-y * sin(q) + z * cos(q)]])
 
 def test_Vector_diffs():
     q1, q2, q3, q4 = dynamicsymbols('q1 q2 q3 q4')


### PR DESCRIPTION
When jumping back and forth from symbolics to numerics when using the mechanics
module it would be nice to be able to output the matrix forms of vectors and
dyadics with respect to different reference frames. I've added two new methods
that provide this functionality. It is particularly useful for returning
inertia tensors in reference frames from dyadics as the tensor form is the more
widely used.
