### PR TITLE
Added links to missing docs in RST file for the diffgeom module

### DIFF
--- a/doc/src/modules/diffgeom.rst
+++ b/doc/src/modules/diffgeom.rst
@@ -17,13 +17,28 @@ Base Class Reference
 .. autoclass:: CoordSystem
    :members:
 
+.. autoclass:: Point
+   :members:
+
 .. autoclass:: BaseScalarField
    :members:
 
 .. autoclass:: BaseVectorField
    :members:
 
+.. autoclass:: Commutator
+   :members:
+
 .. autoclass:: Differential
+   :members:
+
+.. autoclass:: TensorProduct
+   :members:
+
+.. autoclass:: WedgeProduct
+   :members:
+
+.. autoclass:: LieDerivative
    :members:
 
 .. autoclass:: BaseCovarDerivativeOp
@@ -31,4 +46,20 @@ Base Class Reference
 
 .. autoclass:: CovarDerivativeOp
    :members:
+
+.. autofunction:: intcurve_series
+
+.. autofunction:: intcurve_diffequ
+
+.. autofunction:: vectors_in_basis
+
+.. autofunction:: twoform_to_matrix
+
+.. autofunction:: metric_to_Christoffel_1st
+
+.. autofunction:: metric_to_Christoffel_2nd
+
+.. autofunction:: metric_to_Riemann_components
+
+.. autofunction:: metric_to_Ricci_components
 

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -768,7 +768,7 @@ class TensorProduct(Expr):
     The tensor product permits the creation of multilinear functionals (i.e.
     higher order tensors) out of lower order forms (e.g. 1-forms). However, the
     higher tensors thus created lack the interesting features provided by the
-    other type of product, the wedge product, namely they are not antisymetric
+    other type of product, the wedge product, namely they are not antisymmetric
     and hence are not form fields.
 
     Examples
@@ -852,7 +852,7 @@ class TensorProduct(Expr):
 class WedgeProduct(TensorProduct):
     """Wedge product of forms.
 
-    In the context of integration only completely antisymetric forms make
+    In the context of integration only completely antisymmetric forms make
     sense. The wedge product permits the creation of such forms.
 
     Examples

--- a/sympy/diffgeom/diffgeom.py
+++ b/sympy/diffgeom/diffgeom.py
@@ -801,7 +801,7 @@ class TensorProduct(Expr):
     >>> metric.rcall(R2.e_y, None)
     3*dy
 
-    Or automatically pad the args with ``None``s.
+    Or automatically pad the args with ``None`` s.
 
     >>> metric.rcall(R2.e_y)
     3*dy


### PR DESCRIPTION
For some reasos, there were no links to python docs in diffgeom's RST file. This fixes it.
