### PR TITLE
gh2666: terms_gcd does not remove 1.0

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1569,7 +1569,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
             factors, coeff = coeff, factors
         else:
             return coeff*factors
-    if coeff == 1:
+    if coeff is S.One:
         return factors
     elif coeff is S.NegativeOne and not sign:
         return -factors

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1569,7 +1569,7 @@ def _keep_coeff(coeff, factors, clear=True, sign=False):
             factors, coeff = coeff, factors
         else:
             return coeff*factors
-    if coeff is S.One:
+    if coeff == 1:
         return factors
     elif coeff is S.NegativeOne and not sign:
         return -factors

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4977,8 +4977,9 @@ def terms_gcd(f, *gens, **args):
     sympy.core.exprtools.gcd_terms, sympy.core.exprtools.factor_terms
 
     """
+    orig = sympify(f)
     if not isinstance(f, Expr) or f.is_Atom:
-        return sympify(f)
+        return orig
 
     if args.get('deep', False):
         new = f.func(*[terms_gcd(a, *gens, **args) for a in f.args])
@@ -5008,6 +5009,8 @@ def terms_gcd(f, *gens, **args):
         coeff = S.One
 
     term = Mul(*[x**j for x, j in zip(f.gens, J)])
+    if term*coeff == 1:
+        return orig
 
     if clear:
         return _keep_coeff(coeff, term*f.as_expr())

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5009,8 +5009,10 @@ def terms_gcd(f, *gens, **args):
         coeff = S.One
 
     term = Mul(*[x**j for x, j in zip(f.gens, J)])
-    if term*coeff == 1:
-        return orig
+    if coeff == 1:
+        coeff = S.One
+        if term == 1:
+            return orig
 
     if clear:
         return _keep_coeff(coeff, term*f.as_expr())

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3080,6 +3080,8 @@ def test_keep_coeff():
     u = Mul(2, x + 1, evaluate=False)
     assert _keep_coeff(S(1), x) == x
     assert _keep_coeff(S(-1), x) == -x
+    assert _keep_coeff(S(1.0), x) == 1.0*x
+    assert _keep_coeff(S(-1.0), x) == -1.0*x
     assert _keep_coeff(S(1), 2*x) == 2*x
     assert _keep_coeff(S(2), x/2) == x
     assert _keep_coeff(S(2), sin(x)) == 2*sin(x)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -54,6 +54,7 @@ from sympy import (
     S, Integer, Rational, Float, Mul, Symbol, symbols, sqrt, Piecewise,
     exp, sin, tanh, expand, oo, I, pi, re, im, RootOf, Eq, Tuple, Expr)
 
+from sympy.core.basic import _aresame
 from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import raises, XFAIL
@@ -1958,7 +1959,8 @@ def test_terms_gcd():
     assert terms_gcd(2*x**3*y + 4*x*y**3) == 2*x*y*(x**2 + 2*y**2)
     assert terms_gcd(2*x**3*y/3 + 4*x*y**3/5) == 2*x*y/15*(5*x**2 + 6*y**2)
 
-    assert terms_gcd(2.0*x**3*y + 4.1*x*y**3) == 1.0*x*y*(2.0*x**2 + 4.1*y**2)
+    assert terms_gcd(2.0*x**3*y + 4.1*x*y**3) == x*y*(2.0*x**2 + 4.1*y**2)
+    assert _aresame(terms_gcd(2.0*x + 3), 2.0*x + 3)
 
     assert terms_gcd((3 + 3*x)*(x + x*y), expand=False) == \
         (3*x + 3)*(x*y + x)

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -199,6 +199,8 @@ def test_Mul():
     assert str((x + 1)/(y + 2)) == "(x + 1)/(y + 2)"
     assert str(2*x/3) == '2*x/3'
     assert str(-2*x/3) == '-2*x/3'
+    assert str(-1.0*x) == '-1.0*x'
+    assert str(1.0*x) == '1.0*x'
 
     class CustomClass1(Expr):
         is_commutative = True


### PR DESCRIPTION
- [x] remove changes to docstrings that bled over from other PR

In addition, if only a 1 (or 1.0) is extracted, the original
expression is returned from terms_gcd rather than the polys-modified
form (e.g. 2.0_x + 3 instead of 2.0_x + 3.0).

fixes gh-2666
