### PR TITLE
fix generate_bell

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -2373,7 +2373,9 @@ class Permutation(Basic):
         """
         Returns the next permutation in Trotter-Johnson order.
         If self is the last permutation it returns None.
-        See [4] section 2.4.
+        See [4] section 2.4. If it is desired to generate all such
+        permutations, they can be generated in order more quickly
+        with the ``generate_bell`` function.
 
         Examples
         ========
@@ -2391,7 +2393,7 @@ class Permutation(Basic):
         See Also
         ========
 
-        rank_trotterjohnson, unrank_trotterjohnson
+        rank_trotterjohnson, unrank_trotterjohnson, sympy.utilities.iterables.generate_bell
         """
         pi = self.array_form[:]
         n = len(pi)

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -408,10 +408,10 @@ def test_binary_partitions():
 
 
 def test_bell_perm():
-    assert [len(list(generate_bell(i))) for i in range(1, 7)] == [
+    assert [len(set(generate_bell(i))) for i in range(1, 7)] == [
         factorial(i) for i in range(1, 7)]
     assert list(generate_bell(3)) == [
-        (0, 1, 2), (1, 0, 2), (1, 2, 0), (2, 1, 0), (2, 0, 1), (0, 2, 1)]
+        (0, 1, 2), (0, 2, 1), (2, 0, 1), (2, 1, 0), (1, 2, 0), (1, 0, 2)]
 
 
 def test_involutions():

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -412,6 +412,16 @@ def test_bell_perm():
         factorial(i) for i in range(1, 7)]
     assert list(generate_bell(3)) == [
         (0, 1, 2), (0, 2, 1), (2, 0, 1), (2, 1, 0), (1, 2, 0), (1, 0, 2)]
+    # generate_bell and trotterjohnson are advertised to return the same
+    # permutations; this is not technically necessary so this test could
+    # be removed
+    for n in range(1, 5):
+        p = Permutation(range(n))
+        b = generate_bell(n)
+        for bi in b:
+            assert bi == tuple(p.array_form)
+            p = p.next_trotterjohnson()
+    raises(ValueError, lambda: list(generate_bell(0)))  # XXX is this consistent with other permutation algorithms?
 
 
 def test_involutions():


### PR DESCRIPTION
This fixes the generate_bell routine. The tests did not catch the fact that for n > 4 the correct number of permutations were returned, but many were duplicates.

This fixes #2693.
