### PR TITLE
remove practice of evaluating factorial as 0 for negative numbers

### DIFF
--- a/sympy/concrete/tests/test_gosper.py
+++ b/sympy/concrete/tests/test_gosper.py
@@ -1,6 +1,6 @@
 """Tests for Gosper's algorithm for hypergeometric summation. """
 
-from sympy import binomial, factorial, gamma, Poly, S, simplify, sqrt, exp, log, Symbol
+from sympy import binomial, factorial, gamma, Poly, S, simplify, sqrt, exp, log, Symbol, pi
 from sympy.abc import a, b, j, k, m, n, r, x
 from sympy.concrete.gosper import gosper_normal, gosper_sum, gosper_term
 
@@ -104,7 +104,7 @@ def test_gosper_sum_AeqB_part1():
         3*m + 2)/(40*27**m*factorial(m)*factorial(m + 1)*factorial(m + 2))
     g1f = (2*m + 1)**2*binomial(2*m, m)**2/(4**(2*m)*(m + 1))
     g1g = -binomial(2*m, m)**2/4**(2*m)
-    g1h = -(2*m + 1)**2*(3*m + 4)*factorial(m - S(1)/2)**2/factorial(m + 1)**2
+    g1h = 4*pi -(2*m + 1)**2*(3*m + 4)*factorial(m - S(1)/2)**2/factorial(m + 1)**2
 
     g = gosper_sum(f1a, (n, 0, m))
     assert g is not None and simplify(g - g1a) == 0
@@ -121,7 +121,9 @@ def test_gosper_sum_AeqB_part1():
     g = gosper_sum(f1g, (n, 0, m))
     assert g is not None and simplify(g - g1g) == 0
     g = gosper_sum(f1h, (n, 0, m))
-    assert g is not None and simplify(g - g1h) == 0
+    # need to call rewrite(gamma) here because we have terms involving
+    # factorial(1/2)
+    assert g is not None and simplify(g - g1h).rewrite(gamma) == 0
 
 
 def test_gosper_sum_AeqB_part2():

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -47,7 +47,7 @@ class factorial(CombinatorialFunction):
        Examples
        ========
 
-       >>> from sympy import Symbol, factorial
+       >>> from sympy import Symbol, factorial, S
        >>> n = Symbol('n', integer=True)
 
        >>> factorial(0)

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -28,7 +28,7 @@ class CombinatorialFunction(Function):
 class factorial(CombinatorialFunction):
     """Implementation of factorial function over nonnegative integers.
        By convention (consistent with the gamma function and the binomial
-       coefficients), factorials of negative integers are infinite.
+       coefficients), factorial of a negative integer is complex infinity.
 
        The factorial is very important in combinatorics where it gives
        the number of ways in which `n` objects can be permuted. It also
@@ -57,7 +57,7 @@ class factorial(CombinatorialFunction):
        5040
 
        >>> factorial(-2)
-       oo
+       zoo
 
        >>> factorial(n)
        factorial(n)
@@ -142,7 +142,7 @@ class factorial(CombinatorialFunction):
                 return S.Infinity
             elif n.is_Integer:
                 if n.is_negative:
-                    return S.Infinity
+                    return S.ComplexInfinity
                 else:
                     n, result = n.p, 1
 

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -27,13 +27,12 @@ class CombinatorialFunction(Function):
 
 class factorial(CombinatorialFunction):
     """Implementation of factorial function over nonnegative integers.
-       For the sake of convenience and simplicity of procedures using
-       this function it is defined for negative integers and returns
-       zero in this case.
+       By convention (consistent with the gamma function and the binomial
+       coefficients), factorials of negative integers are infinite.
 
        The factorial is very important in combinatorics where it gives
-       the number of ways in which 'n' objects can be permuted. It also
-       arises in calculus, probability, number theory etc.
+       the number of ways in which `n` objects can be permuted. It also
+       arises in calculus, probability, number theory, etc.
 
        There is strict relation of factorial with gamma function. In
        fact n! = gamma(n+1) for nonnegative integers. Rewrite of this
@@ -51,20 +50,23 @@ class factorial(CombinatorialFunction):
        >>> from sympy import Symbol, factorial
        >>> n = Symbol('n', integer=True)
 
-       >>> factorial(-2)
-       0
-
        >>> factorial(0)
        1
 
        >>> factorial(7)
        5040
 
+       >>> factorial(-2)
+       oo
+
        >>> factorial(n)
        factorial(n)
 
        >>> factorial(2*n)
        factorial(2*n)
+
+       >>> factorial(S(1)/2)
+       factorial(1/2)
 
        See Also
        ========
@@ -140,7 +142,7 @@ class factorial(CombinatorialFunction):
                 return S.Infinity
             elif n.is_Integer:
                 if n.is_negative:
-                    return S.Zero
+                    return S.Infinity
                 else:
                     n, result = n.p, 1
 
@@ -159,9 +161,6 @@ class factorial(CombinatorialFunction):
                         result = cls._recursive(n)*2**(n - bits)
 
                     return C.Integer(result)
-
-        if n.is_negative:
-            return S.Zero
 
     def _eval_rewrite_as_gamma(self, n):
         return C.gamma(n + 1)

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, symbols, factorial, factorial2, binomial,
                    rf, ff, gamma, polygamma, EulerGamma, O, pi, nan,
-                   oo, simplify, expand_func)
+                   oo, zoo, simplify, expand_func)
 from sympy.functions.combinatorial.factorials import subfactorial
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -67,7 +67,7 @@ def test_factorial():
     n = Symbol('n', integer=True)
     k = Symbol('k', integer=True, positive=True)
 
-    assert factorial(-2) == oo
+    assert factorial(-2) == zoo
     assert factorial(0) == 1
     assert factorial(7) == 5040
     assert factorial(n).func == factorial

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -67,7 +67,7 @@ def test_factorial():
     n = Symbol('n', integer=True)
     k = Symbol('k', integer=True, positive=True)
 
-    assert factorial(-2) == 0
+    assert factorial(-2) == oo
     assert factorial(0) == 1
     assert factorial(7) == 5040
     assert factorial(n).func == factorial

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -97,7 +97,7 @@ def test_Exp():
 
 def test_factorial():
     n = Symbol('n', integer=True)
-    assert str(factorial(-2)) == "oo"
+    assert str(factorial(-2)) == "zoo"
     assert str(factorial(0)) == "1"
     assert str(factorial(7)) == "5040"
     assert str(factorial(n)) == "factorial(n)"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -97,7 +97,7 @@ def test_Exp():
 
 def test_factorial():
     n = Symbol('n', integer=True)
-    assert str(factorial(-2)) == "0"
+    assert str(factorial(-2)) == "oo"
     assert str(factorial(0)) == "1"
     assert str(factorial(7)) == "5040"
     assert str(factorial(n)) == "factorial(n)"


### PR DESCRIPTION
it is infinity for negative integers and remains unevaluated for non-integers. fix gosper test, which had a missing term.
fix string representations
