### PR TITLE
Set RR.get_ring() to RR

### DIFF
--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -103,7 +103,7 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
 
     def get_ring(self):
         """Returns a ring associated with ``self``. """
-        raise DomainError('there is no ring associated with %s' % self)
+        return self
 
     def get_exact(self):
         """Returns an exact domain associated with ``self``. """

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -68,6 +68,7 @@ def test_Domain_unify():
     assert unify(RR, ZZ[x]) == RR[x]
     assert unify(RR, ZZ.frac_field(x)) == RR.frac_field(x)
     assert unify(RR, EX) == EX
+    assert RR[x].unify(ZZ.frac_field(y)) == RR.frac_field(x, y)
 
     assert unify(CC, F3) == CC
     assert unify(CC, ZZ) == CC
@@ -432,7 +433,8 @@ def test_Domain_get_ring():
 
     assert EX.get_ring() == EX
 
-    raises(DomainError, lambda: RR.get_ring())
+    assert RR.get_ring() == RR
+    # XXX: This should also be like RR
     raises(DomainError, lambda: ALG.get_ring())
 
 


### PR DESCRIPTION
Mathematically, it doesn't make sense to ask what "the ring" associated with a
field is, since every field is itself a ring, and most have several
non-trivial subrings, so I'm not sure what this function is trying to achieve.
This seems to work. This fixes unification of things like RR[x] and ZZ(y),
which would result in DomainError: there is no ring associated with RR.
