### PR TITLE
Set Expressions

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1339,6 +1339,7 @@ def imageset(*args):
     See Also:
         ImageSet
     """
+    from sympy.sets import ImageSet
     if len(args) == 3:
         from sympy import Lambda
         f = Lambda(*args[:2])
@@ -1346,4 +1347,4 @@ def imageset(*args):
         f = args[0]
     set = args[-1]
 
-    return set._eval_imageset(f)
+    return ImageSet(f, set).doit()

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -470,6 +470,11 @@ def test_sympy__core__trace__Tr():
     a, b = symbols('a b')
     assert _test_args(Tr(a + b))
 
+def test_sympy__sets__setexpr__SetExpr():
+    from sympy.sets.setexpr import SetExpr
+    from sympy.core.sets import Interval
+    assert _test_args(SetExpr(Interval(0, 1)))
+
 
 def test_sympy__sets__fancysets__Naturals():
     from sympy.sets.fancysets import Naturals

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -212,6 +212,8 @@ class exp(ExpBase):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_exp'):
+            return arg._eval_exp(cls)
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -508,6 +510,9 @@ class log(Function):
                 return cls(arg)/cls(base)
             else:
                 return cls(arg)
+
+        if hasattr(arg, '_eval_log'):
+            return arg._eval_log(cls)
 
         if arg.is_Number:
             if arg is S.Zero:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -179,6 +179,9 @@ class sin(TrigonometricFunction):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_sin'):
+            return arg._eval_sin(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -410,6 +413,9 @@ class cos(TrigonometricFunction):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_cos'):
+            return arg._eval_cos(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -913,6 +919,9 @@ class tan(TrigonometricFunction):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_tan'):
+            return arg._eval_tan(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -1124,6 +1133,9 @@ class cot(TrigonometricFunction):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_cot'):
+            return arg._eval_cot(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -1359,6 +1371,9 @@ class asin(Function):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_asin'):
+            return arg._eval_asin(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -1497,6 +1512,9 @@ class acos(Function):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_acos'):
+            return arg._eval_acos(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -1620,6 +1638,9 @@ class atan(Function):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_atan'):
+            return arg._eval_atan(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -1727,6 +1748,9 @@ class acot(Function):
 
     @classmethod
     def eval(cls, arg):
+        if hasattr(arg, '_eval_acot'):
+            return arg._eval_acot(cls)
+
         if arg.is_Number:
             if arg is S.NaN:
                 return S.NaN
@@ -1914,6 +1938,9 @@ class atan2(Function):
 
     @classmethod
     def eval(cls, y, x):
+        if hasattr(arg, '_eval_atan2'):
+            return arg._eval_atan2(cls)
+
         if x is S.NegativeInfinity:
             if y.is_zero:
                 # Special case y = 0 because we define Heaviside(0) = 1/2

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -173,8 +173,7 @@ class ImageSet(Set):
     9
     16
     """
-    def __new__(cls, lamda, base_set):
-        return Basic.__new__(cls, lamda, base_set)
+    __new__ = Basic.__new__
 
     lamda = property(lambda self: self.args[0])
     base_set = property(lambda self: self.args[1])
@@ -212,6 +211,10 @@ class ImageSet(Set):
     @property
     def is_iterable(self):
         return self.base_set.is_iterable
+
+
+    def doit(self, **kwargs):
+        return self.base_set._eval_imageset(self.lamda)
 
 
 @deprecated(useinstead="ImageSet", issue=3958, deprecated_since_version="0.7.4")

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -93,6 +93,11 @@ class SetExpr(Expr):
         return simplify(Mul(other, Pow(self, -1)))
 
 
+    def _eval_func(self, func):
+        return SetExpr(imageset(func, self.set))
+    _eval_exp = _eval_log = _eval_sin = _eval_cos = _eval_tan =_eval_func
+
+
 def simplify(inp):
     """ Collapse expression containing SetExprs to single SetExpr """
     if not inp.has(SetExpr):

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -3,6 +3,9 @@ from sympy import sift, latex, Min, Max, Set
 from sympy.core.sets import imageset, Interval, FiniteSet, Union
 from sympy.core.compatibility import u
 
+from sympy.core.decorators import call_highest_priority, _sympifyit
+
+
 x = Dummy('x')
 
 
@@ -30,6 +33,7 @@ class SetExpr(Expr):
     >>> simplify(2*a + b).set
     [1, 20]
     """
+    _op_priority = 11.0
     set = property(lambda self: self.args[0])
 
     def _latex(self, printer):
@@ -37,6 +41,56 @@ class SetExpr(Expr):
 
     def _pretty(self, printer):
         return printer._print(self.set)
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__radd__')
+    def __add__(self, other):
+        return simplify(Add(self, other))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__add__')
+    def __radd__(self, other):
+        return simplify(Add(self, other))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rmul__')
+    def __mul__(self, other):
+        return simplify(Mul(self, other))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__mul__')
+    def __rmul__(self, other):
+        return simplify(Mul(other, self))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rsub__')
+    def __sub__(self, other):
+        return simplify(Add(self, -other))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__sub__')
+    def __rsub__(self, other):
+        return simplify(Add(other, -self))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rpow__')
+    def __pow__(self, other):
+        return simplify(Pow(self, other))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__pow__')
+    def __rpow__(self, other):
+        return simplify(Pow(other, self))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__rdiv__')
+    def __div__(self, other):
+        return simplify(Mul(self, 1/other))
+
+    @_sympifyit('other', NotImplemented)
+    @call_highest_priority('__div__')
+    def __rdiv__(self, other):
+        return simplify(Mul(other, Pow(self, -1)))
 
 
 def simplify(inp):

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -17,7 +17,19 @@ def setexpr(inp):
 
 
 class SetExpr(Expr):
-    """ An expression that can take on values of a set """
+    """ An expression that can take on values of a set
+
+    >>> from sympy import Interval, FiniteSet
+    >>> from sympy.sets.setexpr import SetExpr, simplify
+
+    >>> a = SetExpr(Interval(0, 5))
+    >>> b = SetExpr(FiniteSet(1, 10))
+    >>> simplify(a + b).set
+    [1, 6] U [10, 15]
+
+    >>> simplify(2*a + b).set
+    [1, 20]
+    """
     set = property(lambda self: self.args[0])
 
     def _latex(self, printer):

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -33,18 +33,10 @@ class SetExpr(Expr):
     set = property(lambda self: self.args[0])
 
     def _latex(self, printer):
-        return r"x \mid x \in " + printer._print(self.set)
+        return printer._print(self.set)
 
     def _pretty(self, printer):
-        if printer._use_unicode:
-            inn = u("\u220a")
-        else:
-            inn = 'in'
-        bar = printer._print('|')
-        xx = printer._print(x)
-        set = printer._print(self.set)
-
-        return printer._print_seq((x, bar, xx, inn, set), '', '', ' ')
+        return printer._print(self.set)
 
 
 def simplify(inp):

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -6,6 +6,16 @@ from sympy.core.compatibility import u
 x = Dummy('x')
 
 
+def setexpr(inp):
+    if isinstance(inp, set):
+        return SetExpr(FiniteSet(inp))
+    if isinstance(inp, tuple) and len(inp) == 2:
+        return SetExpr(Interval(inp[0], inp[1], True, True))
+    if isinstance(inp, list) and len(inp) == 2:
+        return SetExpr(Interval(inp[0], inp[1], False, False))
+    return SetExpr(inp)
+
+
 class SetExpr(Expr):
     set = property(lambda self: self.args[0])
 

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -17,6 +17,7 @@ def setexpr(inp):
 
 
 class SetExpr(Expr):
+    """ An expression that can take on values of a set """
     set = property(lambda self: self.args[0])
 
     def _latex(self, printer):
@@ -34,64 +35,64 @@ class SetExpr(Expr):
         return printer._print_seq((x, bar, xx, inn, set), '', '', ' ')
 
 
-def simplify(setexpr):
+def simplify(inp):
     """ Collapse expression containing SetExprs to single SetExpr """
-    if not setexpr.has(SetExpr):
-        return setexpr
+    if not inp.has(SetExpr):
+        return inp
 
     # Recurse downwards
     # e.g. simplify(x + y) -> simplify(simplify(x) + simplify(y))
-    setexpr = setexpr.func(*map(simplify, setexpr.args))
+    inp = inp.func(*map(simplify, inp.args))
 
     # Handle cases like exp(...) or sin(...)
-    if isinstance(setexpr, Function):
-        return SetExpr(imageset(type(setexpr), setexpr.args[0].set))
+    op, args = inp.func, inp.args
 
-    elif isinstance(setexpr, (Add, Mul)):
-        groups = sift(setexpr.args, lambda x: isinstance(x, SetExpr))
+    # If operation is commutative and we have non-SetExprs then
+    if (isinstance(inp, (Add, Mul))
+            and not all(isinstance(arg, SetExpr) for arg in inp.args)):
+        groups = sift(inp.args, lambda x: isinstance(x, SetExpr))
         setexprs, others = groups[True], groups[False]
-        op = type(setexpr)
-        se = join(op, setexprs)  # call out to many-setexpr function
+        se = simplify(op(*setexprs))  # call out to many-setexpr function
         return SetExpr(imageset(x, op(x, *others), se.set))
 
-    elif isinstance(setexpr, Pow) and isinstance(setexpr.base, SetExpr):
-        return SetExpr(imageset(x, Pow(x, setexpr.exp), setexpr.base.set))
-
-    return setexpr
-
-
-def join(op, setexprs):
-    ''' Join many setexprs into one
-
-    Relies on many functions named join_foo below
-    '''
-    assert all(isinstance(se, SetExpr) for se in setexprs)
-
+    args2 = [arg.set if isinstance(arg, SetExpr) else arg for arg in args]
     for key, func in join_list:  # Multiple Dispatch
         if (issubclass(op, key[0])
-            and len(key[1:]) == len(setexprs)
-            and all(isinstance(se.set, typ)
-                    for se, typ in zip(setexprs, key[1:]))):
-            return func(op, *setexprs)
+            and len(key[1:]) == len(args2)
+            and all(isinstance(se, typ)
+                    for se, typ in zip(args2, key[1:]))):
+            return func(op, *args)
 
-    # Two args is a common case for join_foo functions.  Lets reduce with join.
-    if len(setexprs) > 2:
-        result = setexprs[0]
-        for se in setexprs[1:]:
-            result = join(op, [result, se])
+    # Two args is a common case for _simplify_foo functions.  Lets reduce with join.
+    if len(args) > 2:
+        result = args[0]
+        for se in args[1:]:
+            result = simplify(op(result, se))
         return result
 
-    return op(*setexprs)
+    return op(*args)
 
 
-def join_Add_Intervals(_, a, b):
+def _simplify_Function(func, a):
+    """ f(SetExpr(set)) -> SetExpr(imageset(f, set)) """
+    return SetExpr(imageset(func, a.set))
+
+
+def _simplify_Pow(_, base, exp):
+    """ SetExpr(set)**expr -> SetExpr(imageset(x, x**expr, set)) """
+    return SetExpr(imageset(x, Pow(x, exp), base.set))
+
+
+def _simplify_Add_Intervals(_, a, b):
+    """ SetExpr([x, y]) + SetExpr([m, n]) -> SetExpr([x + m, y + n]) """
     return SetExpr(Interval(a.set.start + b.set.start,
                             a.set.end + b.set.end,
                             a.set.left_open or b.set.left_open,
                             a.set.right_open or b.set.right_open))
 
 
-def join_Mul_Intervals(_, a, b):
+def _simplify_Mul_Intervals(_, a, b):
+    """ SetExpr([x, y]) * SetExpr([m, n]) -> SetExpr([...]) """
     start = Min(*[x * y for x in (a.set.start, a.set.end)
                         for y in (b.set.start, b.set.end)])
     end =   Max(*[x * y for x in (a.set.start, a.set.end)
@@ -100,13 +101,15 @@ def join_Mul_Intervals(_, a, b):
     return SetExpr(Interval(start, end))
 
 
-def join_FiniteSet(op, a, b):
+def _simplify_FiniteSet(op, a, b):
     if isinstance(b.set, FiniteSet):
         a, b = b, a
     return SetExpr(Union(*[simplify(op(x, b)).set for x in a.set]))
 
 
-join_list = [[(Add, Interval, Interval),    join_Add_Intervals],
-             [(Mul, Interval, Interval),    join_Mul_Intervals],
-             [((Add, Mul), FiniteSet, Set), join_FiniteSet],
-             [((Add, Mul), Set, FiniteSet), join_FiniteSet]]
+join_list = [[(Function, Set),              _simplify_Function],
+             [(Pow, Set, Expr),             _simplify_Pow],
+             [(Add, Interval, Interval),    _simplify_Add_Intervals],
+             [(Mul, Interval, Interval),    _simplify_Mul_Intervals],
+             [((Add, Mul), FiniteSet, Set), _simplify_FiniteSet],
+             [((Add, Mul), Set, FiniteSet), _simplify_FiniteSet]]

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -60,8 +60,8 @@ def join(op, setexprs):
     for key, func in join_list:  # Multiple Dispatch
         if (issubclass(op, key[0])
             and len(key[1:]) == len(setexprs)
-            and all(isinstance(se.set, func)
-                    for se, func in zip(setexprs, key[1:]))):
+            and all(isinstance(se.set, typ)
+                    for se, typ in zip(setexprs, key[1:]))):
             return func(op, *setexprs)
 
     # Two args is a common case for join_foo functions.  Lets reduce with join.
@@ -82,7 +82,6 @@ def join_Add_Intervals(_, a, b):
 
 
 def join_Mul_Intervals(_, a, b):
-    bounds = {(a.set.start, a.set.end), (b.set.start, b.set.end)}
     start = Min(*[x * y for x in (a.set.start, a.set.end)
                         for y in (b.set.start, b.set.end)])
     end =   Max(*[x * y for x in (a.set.start, a.set.end)
@@ -91,7 +90,7 @@ def join_Mul_Intervals(_, a, b):
     return SetExpr(Interval(start, end))
 
 
-def join_Add_FiniteSet(op, a, b):
+def join_FiniteSet(op, a, b):
     if isinstance(b.set, FiniteSet):
         a, b = b, a
     return SetExpr(Union(*[simplify(op(x, b)).set for x in a.set]))
@@ -99,5 +98,5 @@ def join_Add_FiniteSet(op, a, b):
 
 join_list = [[(Add, Interval, Interval),    join_Add_Intervals],
              [(Mul, Interval, Interval),    join_Mul_Intervals],
-             [((Add, Mul), FiniteSet, Set), join_Add_FiniteSet],
-             [((Add, Mul), Set, FiniteSet), join_Add_FiniteSet]]
+             [((Add, Mul), FiniteSet, Set), join_FiniteSet],
+             [((Add, Mul), Set, FiniteSet), join_FiniteSet]]

--- a/sympy/sets/setexpr.py
+++ b/sympy/sets/setexpr.py
@@ -1,0 +1,103 @@
+from sympy.core import Expr, Function, Add, Mul, Pow, Dummy
+from sympy import sift, latex, Min, Max, Set
+from sympy.core.sets import imageset, Interval, FiniteSet, Union
+from sympy.core.compatibility import u
+
+x = Dummy('x')
+
+
+class SetExpr(Expr):
+    set = property(lambda self: self.args[0])
+
+    def _latex(self, printer):
+        return r"x \mid x \in " + printer._print(self.set)
+
+    def _pretty(self, printer):
+        if printer._use_unicode:
+            inn = u("\u220a")
+        else:
+            inn = 'in'
+        bar = printer._print('|')
+        xx = printer._print(x)
+        set = printer._print(self.set)
+
+        return printer._print_seq((x, bar, xx, inn, set), '', '', ' ')
+
+
+def simplify(setexpr):
+    """ Collapse expression containing SetExprs to single SetExpr """
+    if not setexpr.has(SetExpr):
+        return setexpr
+
+    # Recurse downwards
+    # e.g. simplify(x + y) -> simplify(simplify(x) + simplify(y))
+    setexpr = setexpr.func(*map(simplify, setexpr.args))
+
+    # Handle cases like exp(...) or sin(...)
+    if isinstance(setexpr, Function):
+        return SetExpr(imageset(type(setexpr), setexpr.args[0].set))
+
+    elif isinstance(setexpr, (Add, Mul)):
+        groups = sift(setexpr.args, lambda x: isinstance(x, SetExpr))
+        setexprs, others = groups[True], groups[False]
+        op = type(setexpr)
+        se = join(op, setexprs)  # call out to many-setexpr function
+        return SetExpr(imageset(x, op(x, *others), se.set))
+
+    elif isinstance(setexpr, Pow) and isinstance(setexpr.base, SetExpr):
+        return SetExpr(imageset(x, Pow(x, setexpr.exp), setexpr.base.set))
+
+    return setexpr
+
+
+def join(op, setexprs):
+    ''' Join many setexprs into one
+
+    Relies on many functions named join_foo below
+    '''
+    assert all(isinstance(se, SetExpr) for se in setexprs)
+
+    for key, func in join_list:  # Multiple Dispatch
+        if (issubclass(op, key[0])
+            and len(key[1:]) == len(setexprs)
+            and all(isinstance(se.set, func)
+                    for se, func in zip(setexprs, key[1:]))):
+            return func(op, *setexprs)
+
+    # Two args is a common case for join_foo functions.  Lets reduce with join.
+    if len(setexprs) > 2:
+        result = setexprs[0]
+        for se in setexprs[1:]:
+            result = join(op, [result, se])
+        return result
+
+    return op(*setexprs)
+
+
+def join_Add_Intervals(_, a, b):
+    return SetExpr(Interval(a.set.start + b.set.start,
+                            a.set.end + b.set.end,
+                            a.set.left_open or b.set.left_open,
+                            a.set.right_open or b.set.right_open))
+
+
+def join_Mul_Intervals(_, a, b):
+    bounds = {(a.set.start, a.set.end), (b.set.start, b.set.end)}
+    start = Min(*[x * y for x in (a.set.start, a.set.end)
+                        for y in (b.set.start, b.set.end)])
+    end =   Max(*[x * y for x in (a.set.start, a.set.end)
+                        for y in (b.set.start, b.set.end)])
+    # TODO: Handle left_open right_open
+    return SetExpr(Interval(start, end))
+
+
+def join_Add_FiniteSet(op, a, b):
+    if isinstance(b.set, FiniteSet):
+        a, b = b, a
+    return SetExpr(Union(*[simplify(op(x, b)).set for x in a.set]))
+
+
+join_list = [[(Add, Interval, Interval),    join_Add_Intervals],
+             [(Mul, Interval, Interval),    join_Mul_Intervals],
+             [((Add, Mul), FiniteSet, Set), join_Add_FiniteSet],
+             [((Add, Mul), Set, FiniteSet), join_Add_FiniteSet]]

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -65,6 +65,8 @@ def test_ImageSet():
 
     assert harmonics.is_iterable
 
+    assert imageset(x, -x, Interval(0, 1)) == Interval(-1, 0)
+
 def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -67,6 +67,8 @@ def test_ImageSet():
 
     assert imageset(x, -x, Interval(0, 1)) == Interval(-1, 0)
 
+    assert ImageSet(Lambda(x, x**2), Interval(0, 2)).doit() == Interval(0, 4)
+
 def test_image_is_ImageSet():
     assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)
 

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -1,0 +1,61 @@
+from sympy.sets.setexpr import SetExpr, simplify
+from sympy.core.sets import Interval, FiniteSet
+from sympy import Expr, Set, exp, log, sin, cos, Symbol, Min, Max
+
+I = Interval(0, 2)
+
+
+def test_setexpr():
+    se = SetExpr(Interval(0, 1))
+    assert isinstance(se.set, Set)
+    assert isinstance(se, Expr)
+
+
+def test_scalar_funcs():
+    assert simplify(SetExpr(Interval(0, 1))) == SetExpr(Interval(0, 1))
+    a, b = Symbol('a', real=True), Symbol('b', real=True)
+    a, b = 1, 2
+    for f in [exp, log, sin, cos]:
+        input = f(SetExpr(Interval(a, b)))
+        output = simplify(input)
+        expected = SetExpr(Interval(Min(f(a), f(b)), Max(f(a), f(b))))
+        assert output == expected
+
+
+def test_Add_Mul():
+    assert simplify(SetExpr(Interval(0, 1)) + 1) == SetExpr(Interval(1, 2))
+    assert simplify(SetExpr(Interval(0, 1)) * 2) == SetExpr(Interval(0, 2))
+
+
+def test_Pow():
+    assert simplify(SetExpr(Interval(0, 2))**2) == SetExpr(Interval(0, 4))
+
+
+def test_compound():
+    assert simplify(exp(SetExpr(Interval(0, 1)) * 2 + 1)) == \
+        SetExpr(Interval(exp(1), exp(3)))
+
+
+def test_Interval_Interval():
+    assert simplify(SetExpr(Interval(1, 2)) + SetExpr(Interval(10, 20))) == \
+        SetExpr(Interval(11, 22))
+    assert simplify(SetExpr(Interval(1, 2)) * SetExpr(Interval(10, 20))) == \
+        SetExpr(Interval(10, 40))
+
+
+def test_FiniteSet_FiniteSet():
+    assert simplify(SetExpr(FiniteSet(1, 2, 3)) + SetExpr(FiniteSet(1, 2))) ==\
+        SetExpr(FiniteSet(2, 3, 4, 5))
+    assert simplify(SetExpr(FiniteSet(1, 2, 3)) * SetExpr(FiniteSet(1, 2))) ==\
+        SetExpr(FiniteSet(1, 2, 3, 4, 6))
+
+
+def test_Interval_FiniteSet():
+    assert simplify(SetExpr(FiniteSet(1, 2)) + SetExpr(Interval(0, 10))) == \
+        SetExpr(Interval(1, 12))
+
+
+def test_Many_Sets():
+    assert simplify(SetExpr(Interval(0, 1)) +
+                    SetExpr(Interval(2, 3)) +
+                    SetExpr(FiniteSet(10, 11, 12))) == SetExpr(Interval(12, 16))

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -1,4 +1,4 @@
-from sympy.sets.setexpr import SetExpr, simplify
+from sympy.sets.setexpr import SetExpr
 from sympy.core.sets import Interval, FiniteSet
 from sympy import Expr, Set, exp, log, sin, cos, Symbol, Min, Max
 
@@ -12,50 +12,50 @@ def test_setexpr():
 
 
 def test_scalar_funcs():
-    assert simplify(SetExpr(Interval(0, 1))) == SetExpr(Interval(0, 1))
+    assert (SetExpr(Interval(0, 1))) == SetExpr(Interval(0, 1))
     a, b = Symbol('a', real=True), Symbol('b', real=True)
     a, b = 1, 2
     for f in [exp, log, sin, cos]:
         input = f(SetExpr(Interval(a, b)))
-        output = simplify(input)
+        output = (input)
         expected = SetExpr(Interval(Min(f(a), f(b)), Max(f(a), f(b))))
         assert output == expected
 
 
 def test_Add_Mul():
-    assert simplify(SetExpr(Interval(0, 1)) + 1) == SetExpr(Interval(1, 2))
-    assert simplify(SetExpr(Interval(0, 1)) * 2) == SetExpr(Interval(0, 2))
+    assert (SetExpr(Interval(0, 1)) + 1) == SetExpr(Interval(1, 2))
+    assert (SetExpr(Interval(0, 1)) * 2) == SetExpr(Interval(0, 2))
 
 
 def test_Pow():
-    assert simplify(SetExpr(Interval(0, 2))**2) == SetExpr(Interval(0, 4))
+    assert (SetExpr(Interval(0, 2))**2) == SetExpr(Interval(0, 4))
 
 
 def test_compound():
-    assert simplify(exp(SetExpr(Interval(0, 1)) * 2 + 1)) == \
+    assert (exp(SetExpr(Interval(0, 1)) * 2 + 1)) == \
         SetExpr(Interval(exp(1), exp(3)))
 
 
 def test_Interval_Interval():
-    assert simplify(SetExpr(Interval(1, 2)) + SetExpr(Interval(10, 20))) == \
+    assert (SetExpr(Interval(1, 2)) + SetExpr(Interval(10, 20))) == \
         SetExpr(Interval(11, 22))
-    assert simplify(SetExpr(Interval(1, 2)) * SetExpr(Interval(10, 20))) == \
+    assert (SetExpr(Interval(1, 2)) * SetExpr(Interval(10, 20))) == \
         SetExpr(Interval(10, 40))
 
 
 def test_FiniteSet_FiniteSet():
-    assert simplify(SetExpr(FiniteSet(1, 2, 3)) + SetExpr(FiniteSet(1, 2))) ==\
+    assert (SetExpr(FiniteSet(1, 2, 3)) + SetExpr(FiniteSet(1, 2))) ==\
         SetExpr(FiniteSet(2, 3, 4, 5))
-    assert simplify(SetExpr(FiniteSet(1, 2, 3)) * SetExpr(FiniteSet(1, 2))) ==\
+    assert (SetExpr(FiniteSet(1, 2, 3)) * SetExpr(FiniteSet(1, 2))) ==\
         SetExpr(FiniteSet(1, 2, 3, 4, 6))
 
 
 def test_Interval_FiniteSet():
-    assert simplify(SetExpr(FiniteSet(1, 2)) + SetExpr(Interval(0, 10))) == \
+    assert (SetExpr(FiniteSet(1, 2)) + SetExpr(Interval(0, 10))) == \
         SetExpr(Interval(1, 12))
 
 
 def test_Many_Sets():
-    assert simplify(SetExpr(Interval(0, 1)) +
+    assert (SetExpr(Interval(0, 1)) +
                     SetExpr(Interval(2, 3)) +
                     SetExpr(FiniteSet(10, 11, 12))) == SetExpr(Interval(12, 16))

--- a/sympy/sets/tests/test_setexpr.py
+++ b/sympy/sets/tests/test_setexpr.py
@@ -12,50 +12,59 @@ def test_setexpr():
 
 
 def test_scalar_funcs():
-    assert (SetExpr(Interval(0, 1))) == SetExpr(Interval(0, 1))
+    assert SetExpr(Interval(0, 1)).set == Interval(0, 1)
     a, b = Symbol('a', real=True), Symbol('b', real=True)
     a, b = 1, 2
     for f in [exp, log, sin, cos]:
         input = f(SetExpr(Interval(a, b)))
-        output = (input)
-        expected = SetExpr(Interval(Min(f(a), f(b)), Max(f(a), f(b))))
+        output = input.set
+        expected = Interval(Min(f(a), f(b)), Max(f(a), f(b)))
         assert output == expected
 
 
 def test_Add_Mul():
-    assert (SetExpr(Interval(0, 1)) + 1) == SetExpr(Interval(1, 2))
-    assert (SetExpr(Interval(0, 1)) * 2) == SetExpr(Interval(0, 2))
+    assert (SetExpr(Interval(0, 1)) + 1).set == Interval(1, 2)
+    assert (SetExpr(Interval(0, 1)) * 2).set == Interval(0, 2)
 
 
 def test_Pow():
-    assert (SetExpr(Interval(0, 2))**2) == SetExpr(Interval(0, 4))
+    assert (SetExpr(Interval(0, 2))**2).set == Interval(0, 4)
 
 
 def test_compound():
-    assert (exp(SetExpr(Interval(0, 1)) * 2 + 1)) == \
-        SetExpr(Interval(exp(1), exp(3)))
+    assert (exp(SetExpr(Interval(0, 1)) * 2 + 1)).set == \
+        Interval(exp(1), exp(3))
 
 
 def test_Interval_Interval():
-    assert (SetExpr(Interval(1, 2)) + SetExpr(Interval(10, 20))) == \
-        SetExpr(Interval(11, 22))
-    assert (SetExpr(Interval(1, 2)) * SetExpr(Interval(10, 20))) == \
-        SetExpr(Interval(10, 40))
+    assert (SetExpr(Interval(1, 2)) + SetExpr(Interval(10, 20))).set == \
+        Interval(11, 22)
+    assert (SetExpr(Interval(1, 2)) * SetExpr(Interval(10, 20))).set == \
+        Interval(10, 40)
 
 
 def test_FiniteSet_FiniteSet():
-    assert (SetExpr(FiniteSet(1, 2, 3)) + SetExpr(FiniteSet(1, 2))) ==\
-        SetExpr(FiniteSet(2, 3, 4, 5))
-    assert (SetExpr(FiniteSet(1, 2, 3)) * SetExpr(FiniteSet(1, 2))) ==\
-        SetExpr(FiniteSet(1, 2, 3, 4, 6))
+    assert (SetExpr(FiniteSet(1, 2, 3)) + SetExpr(FiniteSet(1, 2))).set ==\
+        FiniteSet(2, 3, 4, 5)
+    assert (SetExpr(FiniteSet(1, 2, 3)) * SetExpr(FiniteSet(1, 2))).set ==\
+        FiniteSet(1, 2, 3, 4, 6)
 
 
 def test_Interval_FiniteSet():
-    assert (SetExpr(FiniteSet(1, 2)) + SetExpr(Interval(0, 10))) == \
-        SetExpr(Interval(1, 12))
+    assert (SetExpr(FiniteSet(1, 2)) + SetExpr(Interval(0, 10))).set == \
+        Interval(1, 12)
 
 
 def test_Many_Sets():
     assert (SetExpr(Interval(0, 1)) +
                     SetExpr(Interval(2, 3)) +
-                    SetExpr(FiniteSet(10, 11, 12))) == SetExpr(Interval(12, 16))
+                    SetExpr(FiniteSet(10, 11, 12))).set == Interval(12, 16)
+
+
+def test_same_setexprs_are_not_identical():
+    a = SetExpr(FiniteSet(0, 1))
+    b = SetExpr(FiniteSet(0, 1))
+    assert (a + b).set == FiniteSet(0, 1, 2)
+
+    assert (a + a).set == FiniteSet(0, 2)
+


### PR DESCRIPTION
### History

In https://github.com/sympy/sympy/pull/2682 @hargup implemented a wonderful interval arithmetic system.

I was curious if we could do this for all of sets, not just Intervals.  My solution is `SetExpr`, a class that acts like an `Expr` but carries around a `Set` of possible values.  This supports general set arithmetic of which interval arithmetic is a special case.
### How

For scalar functions like exp(x) or x + 1 (where x in some set) we rely on `imageset`.

For set-set functions like x + y + z (where, x, y, z, all come from different sets) we rely on a number of small functions.  There is a naive dispatch system to select them.  This looks like a possible use case for https://github.com/sympy/sympy/pull/2680

I stole a bit from @hargup 's solution for Interval-Interval interaction.
### Example

``` Python

>>> from sympy.sets.setexpr import SetExpr, simplify
>>> a = SetExpr(FiniteSet(1, 10))
>>> b = SetExpr(Interval(0, 5))

>>> simplify(a + b).set
[1, 6] ∪ [10, 15]

>>> simplify(a + b*2).set
[1, 20]

>>> simplify(log(a + b*2)).set
[0, log(20)]
```
### Disclaimer

This doesn't yet have doctests.  It's not particularly reader-friendly
### Tasks
- [x] Fix printing.  It's currently pretty dumb.  I think it's probably best to just print out the set instead of something saying that "this is an expression that takes values on this set"
- [x] Automatic evaluation.  We could override the arithmetic operator methods and increase op_priority for this.  See #2682 or MatrixExpressions for an example
- [ ] Add a documentation page
- [ ] Add to release notes (are we doing this now?)
