### PR TITLE
Fixed imageset for Interval

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -46,6 +46,7 @@ from .utilities import *
 from .integrals import *
 from .tensor import *
 from .parsing import *
+from .calculus import *
 # Adds about .04-.05 seconds of import time
 # from combinatorics import *
 # This module is slow to import:

--- a/sympy/calculus/__init__.py
+++ b/sympy/calculus/__init__.py
@@ -1,0 +1,1 @@
+from .singularities import singularities

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -1,9 +1,7 @@
 from sympy.solvers import solve
 from sympy.simplify import simplify
-from sympy.core.cache import cacheit
 
 
-@cacheit
 def singularities(expr, sym):
     """
     Finds singularities for a function.
@@ -19,7 +17,7 @@ def singularities(expr, sym):
     >>> singularities(x**2 + x + 1, x)
     ()
     >>> singularities(1/(x + 1), x)
-    (-1)
+    (-1,)
 
     References
     ==========

--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -1,0 +1,35 @@
+from sympy.solvers import solve
+from sympy.simplify import simplify
+from sympy.core.cache import cacheit
+
+
+@cacheit
+def singularities(expr, sym):
+    """
+    Finds singularities for a function.
+    Currently supported functions are:
+        - univariate real rational functions
+
+    Examples
+    ========
+
+    >>> from sympy.calculus.singularities import singularities
+    >>> from sympy import Symbol
+    >>> x = Symbol('x', real=True)
+    >>> singularities(x**2 + x + 1, x)
+    ()
+    >>> singularities(1/(x + 1), x)
+    (-1)
+
+    References
+    ==========
+
+    .. [1] http://en.wikipedia.org/wiki/Mathematical_singularity
+
+    """
+    if not expr.is_rational_function(sym):
+        raise NotImplementedError("Sorry, Algorithms finding singularities for"
+                                  " non rational funcitons are not yet"
+                                  " implemented")
+    else:
+        return tuple(sorted(solve(simplify(1/expr), sym)))

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -1,0 +1,19 @@
+from sympy import Symbol, exp, log
+from sympy.calculus.singularities import singularities
+
+from sympy.utilities.pytest import raises, XFAIL
+
+
+def test_singularities():
+    x = Symbol('x', real=True)
+
+    assert singularities(x**2, x) == ()
+    assert singularities(x/(x**2 + 3*x + 2), x) == (-2, -1)
+
+
+@XFAIL
+def test_singularities_non_rational():
+    x = Symbol('x', real=True)
+
+    assert singularities(exp(1/x), x) == (0)
+    assert singularities(log((x - 2)**2), x) == (2)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
     GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
-    FiniteSet, Intersection, imageset, I, true, false, ProductSet
+    FiniteSet, Intersection, imageset, I, true, false, ProductSet, E
 )
 from sympy.mpmath import mpi
 
@@ -521,18 +521,39 @@ def test_Interval_free_symbols():
     x = Symbol('x', real=True)
     assert set(Interval(0, x).free_symbols) == set((x,))
 
+
 def test_image_interval():
+    from sympy.core.numbers import Rational
     x = Symbol('x', real=True)
     assert imageset(x, 2*x, Interval(-2, 1)) == Interval(-4, 2)
     assert imageset(x, 2*x, Interval(-2, 1, True, False)) == \
-            Interval(-4, 2, True, False)
+        Interval(-4, 2, True, False)
     assert imageset(x, x**2, Interval(-2, 1, True, False)) == \
-            Interval(0, 4, False, True)
+        Interval(0, 4, False, True)
     assert imageset(x, x**2, Interval(-2, 1)) == Interval(0, 4)
     assert imageset(x, x**2, Interval(-2, 1, True, False)) == \
-            Interval(0, 4, False, True)
+        Interval(0, 4, False, True)
     assert imageset(x, x**2, Interval(-2, 1, True, True)) == \
-            Interval(0, 4, False, True)
+        Interval(0, 4, False, True)
+    assert imageset(x, (x - 2)**2, Interval(1, 3)) == Interval(0, 1)
+    assert imageset(x, 3*x**4 - 26*x**3 + 78*x**2 - 90*x, Interval(0, 4)) == \
+        Interval(-35, 0)  # Multiple Maxima
+    assert imageset(x, x + 1/x, Interval(-oo, oo)) == Interval(-oo, -2) \
+        + Interval(2, oo)  # Single Infinite discontinuity
+    assert imageset(x, 1/x + 1/(x-1)**2, Interval(0, 2, True, False)) == \
+        Interval(Rational(3, 2), oo, False)  # Multiple Infinite discontinuities
+
+    # Test for Python lambda
+    assert imageset(lambda x: 2*x, Interval(-2, 1)) == Interval(-4, 2)
+
+
+@XFAIL  # See: https://github.com/sympy/sympy/pull/2723#discussion_r8659826
+def test_image_Intersection():
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
+    assert imageset(x, x**2, Interval(-2, 0).intersect(Interval(x, y))) == \
+           Interval(0, 4).intersect(Interval(Min(x**2, y**2), Max(x**2, y**2)))
+
 
 def test_image_FiniteSet():
     x = Symbol('x', real=True)
@@ -543,11 +564,6 @@ def test_image_Union():
     assert imageset(x, x**2, Interval(-2, 0) + FiniteSet(1, 2, 3)) == \
             (Interval(0, 4) + FiniteSet(9))
 
-def test_image_Intersection():
-    x = Symbol('x', real=True)
-    y = Symbol('y', real=True)
-    assert imageset(x, x**2, Interval(-2, 0).intersect(Interval(x, y))) == \
-           Interval(0, 4).intersect(Interval(Min(x**2, y**2), Max(x**2, y**2)))
 
 def test_image_EmptySet():
     x = Symbol('x', real=True)


### PR DESCRIPTION
`imageset` of sets module uses various `_eval_imageset` implemented in various set classes. But the `_eval_imageset` for Interval doesn't work well unless the given function is monotonic on both positive and negative reals. So, I have fixed it by finding the maxima and minima of the function by solving for the roots of the derivative of the function.
