### PR TITLE
Set boundaries / limit points

### DIFF
--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -245,7 +245,7 @@ class Set(Basic):
 
     @property
     def _boundary(self):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def _eval_imageset(self, f):
         from sympy.sets.fancysets import ImageSet
@@ -896,6 +896,11 @@ class Union(Set, EvalfMixin):
             # Flip Parity - next time subtract/add if we added/subtracted here
             parity *= -1
         return measure
+
+    @property
+    def _boundary(self):
+        all_possible = Union(arg.boundary for arg in self.args)
+        return all_possible
 
     def _eval_imageset(self, f):
         return Union(imageset(f, arg) for arg in self.args)

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -260,6 +260,13 @@ class Set(Basic):
         return self._boundary
 
     @property
+    def is_open(self):
+        if not Intersection(self, self.boundary):
+            return True
+        # We can't confidently claim that an intersection exists
+        return None
+
+    @property
     def is_closed(self):
         return self.subset(self.boundary)
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -244,6 +244,10 @@ class Set(Basic):
         return self._boundary
 
     @property
+    def is_closed(self):
+        return self.subset(self.boundary)
+
+    @property
     def _boundary(self):
         raise NotImplementedError()
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -232,6 +232,21 @@ class Set(Basic):
         """
         return self._measure
 
+    @property
+    def boundary(self):
+        """
+        Boundary of the set.  Limit points.
+
+        >>> from sympy import Interval
+        >>> Interval(0, 1).boundary
+        {0, 1}
+        """
+        return self._boundary
+
+    @property
+    def _boundary(self):
+        raise NotImplemented()
+
     def _eval_imageset(self, f):
         from sympy.sets.fancysets import ImageSet
         return ImageSet(f, self)
@@ -626,6 +641,10 @@ class Interval(Set, EvalfMixin):
         a = Interval(S.NegativeInfinity, self.start, True, not self.left_open)
         b = Interval(self.end, S.Infinity, not self.right_open, True)
         return Union(a, b)
+
+    @property
+    def _boundary(self):
+        return FiniteSet(self.start, self.end)
 
     def _contains(self, other):
         if self.left_open:
@@ -1274,6 +1293,10 @@ class FiniteSet(Set, EvalfMixin):
             intervals.append(Interval(a, b, True, True))  # open intervals
         intervals.append(Interval(args[-1], S.Infinity, True, True))
         return Union(intervals, evaluate=False)
+
+    @property
+    def _boundary(self):
+        return self
 
     @property
     def _inf(self):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1143,6 +1143,10 @@ class EmptySet(with_metaclass(Singleton, Set)):
     def _eval_imageset(self, f):
         return self
 
+    @property
+    def _boundary(self):
+        return self
+
 class UniversalSet(with_metaclass(Singleton, Set)):
     """
     Represents the set of all things.

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -235,10 +235,26 @@ class Set(Basic):
     @property
     def boundary(self):
         """
-        Boundary of the set.  Limit points.
+        The boundary or frontier of a set
+
+        A point x is on the boundary of a set S if
+        1.  x is in the closure of S
+            - i.e. Every neighborhood of x contains a point in S
+        2.  x is not in the interior of S
+            - i.e. There does not exist an open set centered on x contained
+              entirely within S
+
+        There are the points on the outer rim of S.  If S is open then these
+        points need not actually be contained within S.
+
+        For example, the boundary of an interval is its start and end points.
+        This is true regardless of whether or not the interval is open
 
         >>> from sympy import Interval
         >>> Interval(0, 1).boundary
+        {0, 1}
+
+        >>> Interval(0, 1, True, False).boundary
         {0, 1}
         """
         return self._boundary

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -400,6 +400,13 @@ class ProductSet(Set):
         return Union(p for p in product_sets if p != self)
 
     @property
+    def _boundary(self):
+        return Union(ProductSet(b + b.boundary if i != j else b.boundary
+                                for j, b in enumerate(self.sets))
+                                for i, a in enumerate(self.sets))
+
+
+    @property
     def is_real(self):
         return all(set.is_real for set in self.sets)
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -348,6 +348,9 @@ class ProductSet(Set):
         if EmptySet() in sets or len(sets) == 0:
             return EmptySet()
 
+        if len(sets) == 1:
+            return sets[0]
+
         return Basic.__new__(cls, *sets, **assumptions)
 
     def _contains(self, element):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -264,6 +264,14 @@ class Set(Basic):
         return self.subset(self.boundary)
 
     @property
+    def closure(self):
+        return self + self.boundary
+
+    @property
+    def interior(self):
+        return self - self.boundary
+
+    @property
     def _boundary(self):
         raise NotImplementedError()
 

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -387,6 +387,19 @@ class ProductSet(Set):
         return ProductSet(a.intersect(b)
                 for a, b in zip(self.sets, other.sets))
 
+    def _union(self, other):
+        if not other.is_ProductSet:
+            return None
+        if len(other.args) != len(self.args):
+            return None
+        if self.args[0] == other.args[0]:
+            return self.args[0] * Union(ProductSet(self.args[1:]),
+                                        ProductSet(other.args[1:]))
+        if self.args[-1] == other.args[-1]:
+            return Union(ProductSet(self.args[:-1]),
+                         ProductSet(other.args[:-1])) * self.args[-1]
+        return None
+
     @property
     def sets(self):
         return self.args

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -957,8 +957,14 @@ class Union(Set, EvalfMixin):
 
     @property
     def _boundary(self):
-        all_possible = Union(arg.boundary for arg in self.args)
-        return all_possible
+        def boundary_of_set(i):
+            """ The boundary of set i minus interior of all other sets """
+            b = self.args[i].boundary
+            for j, a in enumerate(self.args):
+                if j != i:
+                    b = b - a.interior
+            return b
+        return Union(map(boundary_of_set, range(len(self.args))))
 
     def _eval_imageset(self, f):
         return Union(imageset(f, arg) for arg in self.args)

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -238,17 +238,18 @@ class Set(Basic):
         The boundary or frontier of a set
 
         A point x is on the boundary of a set S if
-        1.  x is in the closure of S
-            - i.e. Every neighborhood of x contains a point in S
-        2.  x is not in the interior of S
-            - i.e. There does not exist an open set centered on x contained
-              entirely within S
+
+        1.  x is in the closure of S.
+            I.e. Every neighborhood of x contains a point in S.
+        2.  x is not in the interior of S.
+            I.e. There does not exist an open set centered on x contained
+            entirely within S.
 
         There are the points on the outer rim of S.  If S is open then these
         points need not actually be contained within S.
 
         For example, the boundary of an interval is its start and end points.
-        This is true regardless of whether or not the interval is open
+        This is true regardless of whether or not the interval is open.
 
         >>> from sympy import Interval
         >>> Interval(0, 1).boundary

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1194,6 +1194,10 @@ class UniversalSet(with_metaclass(Singleton, Set)):
     def _union(self, other):
         return self
 
+    @property
+    def _boundary(self):
+        return EmptySet()
+
 
 class FiniteSet(Set, EvalfMixin):
     """

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -548,9 +548,29 @@ def test_boundary():
             for left_open in (True, False) for right_open in (True, False))
 
 
-    # Union
+def test_boundary_Union():
     assert (Interval(0, 1) + Interval(2, 3)).boundary == FiniteSet(0, 1, 2, 3)
     assert ((Interval(0, 1, False, True)
            + Interval(1, 2, True, False)).boundary == FiniteSet(0, 1, 2))
 
     assert (Interval(0, 1) + FiniteSet(2)).boundary == FiniteSet(0, 1, 2)
+
+
+def test_boundary_ProductSet():
+    open_square = Interval(0, 1, True, True) ** 2
+    assert open_square.boundary == (FiniteSet(0, 1) * Interval(0, 1)
+                                  + Interval(0, 1) * FiniteSet(0, 1))
+
+    second_square = Interval(1, 2, True, True) * Interval(0, 1, True, True)
+    assert (open_square + second_square).boundary == (
+                FiniteSet(0, 1) * Interval(0, 1)
+              + FiniteSet(1, 2) * Interval(0, 1)
+              + Interval(0, 1) * FiniteSet(0, 1)
+              + Interval(1, 2) * FiniteSet(0, 1))
+
+
+@XFAIL
+def test_boundary_ProductSet_line():
+    """ This fails just due to simplification - it provides a correct answer """
+    line_in_r2 = Interval(0, 1) * FiniteSet(0)
+    assert line_in_r2.boundary == line_in_r2

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -579,8 +579,6 @@ def test_boundary_ProductSet():
               + Interval(1, 2) * FiniteSet(0, 1))
 
 
-@XFAIL
 def test_boundary_ProductSet_line():
-    """ This fails just due to simplification - it provides a correct answer """
     line_in_r2 = Interval(0, 1) * FiniteSet(0)
     assert line_in_r2.boundary == line_in_r2

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -564,6 +564,21 @@ def test_boundary_Union():
            + Interval(1, 2, True, False)).boundary == FiniteSet(0, 1, 2))
 
     assert (Interval(0, 1) + FiniteSet(2)).boundary == FiniteSet(0, 1, 2)
+    assert Union(Interval(0, 10), Interval(5, 15), evaluate=False).boundary \
+            == FiniteSet(0, 15)
+
+    assert Union(Interval(0, 10), Interval(0, 1), evaluate=False).boundary \
+            == FiniteSet(0, 10)
+    assert Union(Interval(0, 10, True, True),
+                 Interval(10, 15, True, True), evaluate=False).boundary \
+            == FiniteSet(0, 10, 15)
+
+
+@XFAIL
+def test_union_boundary_of_joining_sets():
+    """ Testing the boundary of unions is a hard problem """
+    assert Union(Interval(0, 10), Interval(10, 15), evaluate=False).boundary \
+            == FiniteSet(0, 15)
 
 
 def test_boundary_ProductSet():

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -501,6 +501,12 @@ def test_universalset():
     assert U.union(Interval(2, 4)) == U
 
 
+def test_Union_of_ProductSets_shares():
+    line = Interval(0, 2)
+    points = FiniteSet(0, 1, 2)
+    assert Union(line * line, line * points) == line * line
+
+
 def test_Interval_free_symbols():
     x = Symbol('x', real=True)
     assert set(Interval(0, x).free_symbols) == set((x,))

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -538,3 +538,11 @@ def test_issue_2625():
     raises(TypeError, lambda: I in Interval(-oo,oo))
     raises(TypeError, lambda: Interval(-oo,oo).contains(I))
     raises(TypeError, lambda: I > 2)
+
+
+def test_boundary():
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
+    assert FiniteSet(1).boundary == FiniteSet(1)
+    assert all(Interval(0, 1, left_open, right_open).boundary == FiniteSet(0, 1)
+            for left_open in (True, False) for right_open in (True, False))

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -584,7 +584,14 @@ def test_boundary_ProductSet_line():
     assert line_in_r2.boundary == line_in_r2
 
 
-def test_closed():
+def test_is_open():
+    assert not Interval(0, 1, False, False).is_open
+    assert not Interval(0, 1, True, False).is_open
+    assert Interval(0, 1, True, True).is_open
+    assert not FiniteSet(1, 2, 3).is_open
+
+
+def test_is_closed():
     assert Interval(0, 1, False, False).is_closed
     assert not Interval(0, 1, True, False).is_closed
     assert FiniteSet(1, 2, 3).is_closed

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -582,3 +582,9 @@ def test_boundary_ProductSet():
 def test_boundary_ProductSet_line():
     line_in_r2 = Interval(0, 1) * FiniteSet(0)
     assert line_in_r2.boundary == line_in_r2
+
+
+def test_closed():
+    assert Interval(0, 1, False, False).is_closed
+    assert not Interval(0, 1, True, False).is_closed
+    assert FiniteSet(1, 2, 3).is_closed

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -588,3 +588,11 @@ def test_closed():
     assert Interval(0, 1, False, False).is_closed
     assert not Interval(0, 1, True, False).is_closed
     assert FiniteSet(1, 2, 3).is_closed
+
+
+def test_closure():
+    assert Interval(0, 1, False, True).closure == Interval(0, 1, False, False)
+
+
+def test_interior():
+    assert Interval(0, 1, False, True).interior == Interval(0, 1, True, True)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -546,3 +546,11 @@ def test_boundary():
     assert FiniteSet(1).boundary == FiniteSet(1)
     assert all(Interval(0, 1, left_open, right_open).boundary == FiniteSet(0, 1)
             for left_open in (True, False) for right_open in (True, False))
+
+
+    # Union
+    assert (Interval(0, 1) + Interval(2, 3)).boundary == FiniteSet(0, 1, 2, 3)
+    assert ((Interval(0, 1, False, True)
+           + Interval(1, 2, True, False)).boundary == FiniteSet(0, 1, 2))
+
+    assert (Interval(0, 1) + FiniteSet(2)).boundary == FiniteSet(0, 1, 2)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,6 +1,6 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
     GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
-    FiniteSet, Intersection, imageset, I, true, false
+    FiniteSet, Intersection, imageset, I, true, false, ProductSet
 )
 from sympy.mpmath import mpi
 
@@ -215,6 +215,10 @@ def test_intersection():
     assert (2, 2) not in i
     assert (2, 2, 2) not in i
     raises(ValueError, lambda: list(i))
+
+
+def test_ProductSet_of_single_arg_is_arg():
+    assert ProductSet(Interval(0, 1)) == Interval(0, 1)
 
 
 def test_interval_subs():

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -223,10 +223,6 @@ class ImageSet(Set):
     def is_iterable(self):
         return self.base_set.is_iterable
 
-    @property
-    def _boundary(self):
-        return ImageSet(self.lamda, self.base_set.boundary)
-
 
 @deprecated(useinstead="ImageSet", issue=3958, deprecated_since_version="0.7.4")
 def TransformationSet(*args, **kwargs):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -335,3 +335,7 @@ class Range(Set):
     @property
     def _sup(self):
         return self.stop - self.step
+
+    @property
+    def _boundary(self):
+        return self

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -63,6 +63,11 @@ class Naturals(with_metaclass(Singleton, Set)):
             yield i
             i = i + 1
 
+    @property
+    def _boundary(self):
+        return self
+
+
 class Naturals0(Naturals):
     """Represents the whole numbers which are all the non-negative integers,
     inclusive of zero.
@@ -78,6 +83,7 @@ class Naturals0(Naturals):
         if ask(Q.negative(other)) == False and ask(Q.integer(other)):
             return True
         return False
+
 
 class Integers(with_metaclass(Singleton, Set)):
     """
@@ -137,6 +143,10 @@ class Integers(with_metaclass(Singleton, Set)):
     @property
     def _sup(self):
         return S.Infinity
+
+    @property
+    def _boundary(self):
+        return self
 
 
 class Reals(with_metaclass(Singleton, Interval)):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -223,6 +223,10 @@ class ImageSet(Set):
     def is_iterable(self):
         return self.base_set.is_iterable
 
+    @property
+    def _boundary(self):
+        return ImageSet(self.lamda, self.base_set.boundary)
+
 
 @deprecated(useinstead="ImageSet", issue=3958, deprecated_since_version="0.7.4")
 def TransformationSet(*args, **kwargs):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -168,7 +168,3 @@ def test_intersections():
     assert -5 in S.Integers.intersect(Interval(-oo, 3))
     assert all(x.is_Integer
             for x in take(10, S.Integers.intersect(Interval(3, oo)) ))
-
-def test_ImageSet_boundary():
-    assert ImageSet(Lambda(x, x**2), Interval(0, 2)).boundary == \
-            ImageSet(Lambda(x, x**2), FiniteSet(0, 2))

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -168,3 +168,7 @@ def test_intersections():
     assert -5 in S.Integers.intersect(Interval(-oo, 3))
     assert all(x.is_Integer
             for x in take(10, S.Integers.intersect(Interval(3, oo)) ))
+
+def test_ImageSet_boundary():
+    assert ImageSet(Lambda(x, x**2), Interval(0, 2)).boundary == \
+            ImageSet(Lambda(x, x**2), FiniteSet(0, 2))


### PR DESCRIPTION
Provides new `boundary` property for sets.  I could use some theoretical help on this.  I think I'm defining the set of limit points of a set.

``` Python
Interval(0, 1).boundary == FiniteSet(0, 1)

FiniteSet(0, 1).boundary = FiniteSet(0, 1)

square = Interval(0, 1) ** 2
square.boundary == Interval(0, 1) * FiniteSet(0, 1) + FiniteSet(0, 1) * Interval(0, 1)

S.Reals.boundary == FiniteSet(-oo, oo)
```

Oh, fun examples:

``` Python

# An L shape

In [1]: line = Interval(0, 10)

In [2]: line2 = Interval(0, 20)

In [3]: L = line2**2 - line**2

In [4]: L
Out[4]: ([0, 10] × (10, 20]) ∪ ((10, 20] × [0, 20])

In [5]: L.boundary
Out[5]: 
([0, 10] × {10, 20}) ∪ ({0, 10} × [10, 20]) ∪ 
([10, 20] × {0, 20}) ∪ ({10, 20} × [0, 20])

In [6]: L + L.boundary
Out[6]: ([0, 10] × [10, 20]) ∪ ([10, 20] × [0, 20])


# Half Circle

In [9]: r, th = symbols('r, theta', real=True)

In [10]: L = Lambda((r, th), (r*cos(th), r*sin(th)))

In [11]: halfcircle = ImageSet(L, Interval(0, 1)*Interval(0, pi))

In [12]: 

In [12]: halfcircle
Out[12]: {(r⋅cos(θ), r⋅sin(θ)) | r, θ ∊ [0, 1] × [0, π]}

In [13]: halfcircle.boundary
Out[13]: {(r⋅cos(θ), r⋅sin(θ)) | r, θ ∊ ({0, 1} × [0, π]) ∪ ([0, 1] × {0, π})}

```
