### PR TITLE
add quick solution for linear systems of equations

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2638,10 +2638,10 @@ class MatrixBase(object):
                     if simplify and k > pivot:
                         r[k, i] = simpfunc(r[k, i])
                     if not iszerofunc(r[k, i]):
+                        r.row_swap(pivot, k)
                         break
-                if k == r.rows - 1 and iszerofunc(r[k, i]):
+                else:
                     continue
-                r.row_swap(pivot, k)
             scale = r[pivot, i]
             r.row_op(pivot, lambda x, _: x / scale)
             for j in xrange(r.rows):

--- a/sympy/solvers/__init__.py
+++ b/sympy/solvers/__init__.py
@@ -8,7 +8,8 @@
     [-1]
 """
 from .solvers import solve, solve_linear_system, solve_linear_system_LU, \
-    solve_undetermined_coeffs, tsolve, nsolve, solve_linear, checksol
+    solve_undetermined_coeffs, tsolve, nsolve, solve_linear, checksol, \
+    det_quick, inv_quick
 
 from .recurr import rsolve, rsolve_poly, rsolve_ratio, rsolve_hyper
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -45,7 +45,7 @@ from sympy.functions.elementary.piecewise import piecewise_fold, Piecewise
 
 from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent
-from sympy.utilities.iterables import uniq
+from sympy.utilities.iterables import uniq, generate_bell, flatten
 
 from sympy.mpmath import findroot
 
@@ -2122,39 +2122,38 @@ def solve_linear_system_LU(matrix, syms):
     return solutions
 
 
-def det_perm(self):
-    """Return the determinant by using permutations to select term factors.
-    For `n` larger than 8 the number of permutations becomes prohibitively
+def det_perm(M):
+    """Return the det(``M``) by using permutations to select factors.
+    For size larger than 8 the number of permutations becomes prohibitively
     large, or if there are no symbols in the matrix, it is better to use the
-    standard determinant routines, e.g. `bareis`.
+    standard determinant routines, e.g. `M.det()`.
 
     See Also
     ========
     det_minor
     det_quick
     """
-    from sympy.combinatorics import Permutation
-
-    n = self.rows
     args = []
-    perm = Permutation(range(n))
-    k = 0
-    while k < perm.cardinality:
+    s = True
+    n = M.rows
+    try:
+        list = M._mat
+    except AttributeError:
+        list = flatten(M.tolist())
+    for perm in generate_bell(n):
         fac = []
         idx = 0
-        for i, j in enumerate(perm.array_form):
-            fac.append(self._mat[idx + j])
+        for j in perm:
+            fac.append(list[idx + j])
             idx += n
-        args.append(Mul(*fac))
-        if perm.signature() < 0:
-            args[-1] = -args[-1]
-        perm += 1
-        k += 1
+        term = Mul(*fac) # disaster with unevaluated Mul -- takes forever for n=7
+        args.append(term if s else -term)
+        s = not s
     return Add(*args)
 
 
-def det_minor(self):
-    """Return the determinant of self computed from minors without
+def det_minor(M):
+    """Return the ``det(M)`` computed from minors without
     introducing new nesting in products.
 
     See Also
@@ -2162,55 +2161,57 @@ def det_minor(self):
     det_perm
     det_quick
     """
-    n = self.rows
+    n = M.rows
     if n == 2:
-        return self[0,0]*self[1,1] - self[1,0]*self[0,1]
+        return M[0, 0]*M[1, 1] - M[1, 0]*M[0, 1]
     else:
-        return sum([(1, -1)[i%2]*Add(*[self[0, i]*d for d in
-                Add.make_args(det_minor(self.minorMatrix(0, i)))])
-            if self[0, i] else S.Zero for i in range(n)])
+        return sum([(1, -1)[i % 2]*Add(*[M[0, i]*d for d in
+            Add.make_args(det_minor(M.minorMatrix(0, i)))])
+            if M[0, i] else S.Zero for i in range(n)])
 
 
-def det_quick(self, method=None):
-    """Return the inverse of self, assuming that either
+def det_quick(M, method=None):
+    """Return ``det(M)`` assuming that either
     there are lots of zeros or the size of the matrix
-    is small.
+    is small. If this assumption is not met, then the normal
+    Matrix.det function will be used with method = ``method``.
 
     See Also
     ========
     det_minor
     det_perm
     """
-    if any(i.has(Symbol) for i in self):
-        if self.rows < 8 and all(i.has(Symbol) for i in self):
-            return det_perm(self)
-        return det_minor(self)
+    if any(i.has(Symbol) for i in M):
+        if M.rows < 8 and all(i.has(Symbol) for i in M):
+            return det_perm(M)
+        return det_minor(M)
     else:
-        return self.det(method=method) if method else self.det()
+        return M.det(method=method) if method else M.det()
 
 
-def inv_quick(self):
-    """Return the inverse of self, assuming that either
+def inv_quick(M):
+    """Return the inverse of ``M``, assuming that either
     there are lots of zeros or the size of the matrix
     is small.
     """
     from sympy.matrices import zeros
-    if any(i.has(Symbol) for i in self):
-        if all(i.has(Symbol) for i in self):
-            det = lambda m: det_perm(m)
+    if any(i.has(Symbol) for i in M):
+        if all(i.has(Symbol) for i in M):
+            det = lambda _: det_perm(_)
         else:
-            det = lambda m: det_minor(m)
+            det = lambda _: det_minor(_)
     else:
-        return self.inv()
-    n = self.rows
-    d = det(self)
+        return M.inv()
+    n = M.rows
+    d = det(M)
     if d is S.Zero:
         raise ValueError("Matrix det == 0; not invertible.")
     ret = zeros(n)
+    s1 = -1
     for i in range(n):
-        s = (-1)**i
+        s = s1 = -s1
         for j in range(n):
-            di = det(self.minorMatrix(i, j))
+            di = det(M.minorMatrix(i, j))
             ret[j, i] = s*di/d
             s = -s
     return ret

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -3,12 +3,12 @@ from sympy import (
     LambertW, Lt, Matrix, Or, Piecewise, Poly, Q, Rational, S, Symbol,
     Wild, acos, asin, atan, atanh, cos, cosh, diff, exp, expand, im,
     log, pi, re, sec, sin, sinh, solve, solve_linear, sqrt, sstr, symbols,
-    sympify, tan, tanh, root, simplify, atan2, arg, Mul)
+    sympify, tan, tanh, root, simplify, atan2, arg, Mul, SparseMatrix)
 from sympy.core.function import nfloat
 from sympy.solvers import solve_linear_system, solve_linear_system_LU, \
     solve_undetermined_coeffs
 from sympy.solvers.solvers import _invert, unrad, checksol, posify, _ispow, \
-    det_quick
+    det_quick, det_perm, det_minor
 
 from sympy.polys.rootoftools import RootOf
 
@@ -1413,18 +1413,17 @@ def test_gh2725():
 def test_issue_2015_3512():
     # See that it doesn't hang; this solves in about 2 seconds.
     # Also check that the solution is relatively small.
-    # The system in issue 3512 solves in about 5 seconds and has
-    # an op-count
-    b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r = \
-        symbols('b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r')
+    # Note: the system in issue 3512 solves in about 5 seconds and has
+    # an op-count of 138336 (with simplify=False).
+    b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r = symbols('b:r')
     eqs = Matrix([
         [b - c/d + r/d], [c*(1/g + 1/e + 1/d) - f/g - r/d],
         [-c/g + f*(1/j + 1/i + 1/g) - h/i], [-f/i + h*(1/m + 1/l + 1/i) - k/m],
         [-h/m + k*(1/p + 1/o + 1/m) - n/p], [-k/p + n*(1/q + 1/p)]])
     v = Matrix([f, h, k, n, b, c])
-    ans = solve(list(eqs) , list(v))
-    # if time is taken to simplify then then 2617 below becomes
-    # 1168
+    ans = solve(list(eqs) , list(v), simplify=False)
+    # If time is taken to simplify then then 2617 below becomes
+    # 1168 and the time is about 50 seconds instead of 2.
     assert sum([s.count_ops() for s in ans.values()]) <= 2617
 
 
@@ -1435,3 +1434,6 @@ def test_det_quick():
     assert m.det() == det_quick(m)  # calls det_minor
     m = Matrix(3, 3, list(range(9)))
     assert m.det() == det_quick(m)  # defaults to .det()
+    # make sure they work with Sparse
+    s = SparseMatrix(2, 2, (1, 2, 1, 4))
+    assert det_perm(s) == det_minor(s) == s.det()


### PR DESCRIPTION
The routines were added to the solvers.py instead of matrices since
it is in the context of solving symbolic matrices that these are
most applicable.

Systems that hung or were very slow solve very quickly now:

https://code.google.com/p/sympy/issues/detail?id=3512
https://code.google.com/p/sympy/issues/detail?id=2015

If simplify=False they solve even faster.
