### PR TITLE
Underscore escaped in latex with \operatorname

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -547,7 +547,7 @@ class LatexPrinter(Printer):
         elif len(func) == 1 or func.startswith('\\'):
             name = func
         else:
-            name = r"\operatorname{%s}" % func.replace("_", r"\_")
+            name = r"\operatorname{%s}" % func
         return name
 
     def _print_Function(self, expr, exp=None):
@@ -753,6 +753,15 @@ class LatexPrinter(Printer):
             return r"%s^{%s}" % (tex, exp)
         else:
             return tex
+
+    def _print_polar_lift(self, expr, exp=None):
+        func = r"\operatorname{polar\_lift}"
+        arg = r"{\left (%s \right )}" % self._print(expr.args[0])
+
+        if exp is not None:
+            return r"%s^{%s}%s" % (func, exp, arg)
+        else:
+            return r"%s%s" % (func, arg)
 
     def _print_ExpBase(self, expr, exp=None):
         # TODO should exp_polar be printed differently?

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -177,6 +177,11 @@ def test_latex_functions():
     assert latex(beta(x)) == r"\beta{\left (x \right )}"
     assert latex(beta) == r"\beta"
 
+    a1 = Function('a_1')
+
+    assert latex(a1) == r"\operatorname{a_1}"
+    assert latex(a1(x)) == r"\operatorname{a_1}{\left (x \right )}"
+
     assert latex(sin(x)) == r"\sin{\left (x \right )}"
     assert latex(sin(x), fold_func_brackets=True) == r"\sin {x}"
     assert latex(sin(2*x**2), fold_func_brackets=True) == \


### PR DESCRIPTION
A previous pull request https://github.com/sympy/sympy/pull/996 breaks my usage of sympy in the IPython notebook. To get nice readable math with MathJax I use Latex symbol names, which works really well everywhere except when a symbol with a subscript is used as a function name

The code

``` python
a1, x = sympy.symbols(r'\alpha_1 x')
display(a1)
display(a1(x))
```

produces

``` latex
\alpha_{1}
\operatorname{\alpha\_1}{\left (x \right )}
```

The escaped underscore breaks the user experience and makes the equations look bad. I understand that my use case is hard to combine with whatever the original pull request code's author did. Can this be made configurable? Or perhaps prefer the way that makes usage of Latex nicer? The pull request author could have put the backslash in the symbol name to avoid the problem, while it is now impossible to fix for my use case ...
