### PR TITLE
Use iterable(expr) rather than hasattr(expr, '__iter__') in together()

### DIFF
--- a/sympy/polys/rationaltools.py
+++ b/sympy/polys/rationaltools.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, division
 
 from sympy.core import Basic, Add, sympify
+from sympy.core.compatibility import iterable
 from sympy.core.exprtools import gcd_terms
 from sympy.utilities import public
 
@@ -76,7 +77,7 @@ def together(expr, deep=False):
                 return expr.__class__(base, exp)
             else:
                 return expr.__class__(*[ _together(arg) for arg in expr.args ])
-        elif hasattr(expr, '__iter__'):
+        elif iterable(expr):
             return expr.__class__([ _together(ex) for ex in expr ])
 
         return expr


### PR DESCRIPTION
The difference is that the former excludes strings and dictionaries.

Related to #2750.

Unfortunately, I don't have a good test for this. The expression from #2750 
breaks in a new way. They are both related to the matrix expressions objects 
containing strings in their .args. And even if that worked, they would not 
test this fix if that behavior ever changes.
