### PR TITLE
Fix a bug where subs() forgets noncommutativity

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -963,7 +963,7 @@ class Basic(with_metaclass(ManagedProperties)):
             reps = {}
             rv = self
             for old, new in sequence:
-                d = C.Dummy()
+                d = C.Dummy(commutative=new.is_commutative)
                 rv = rv._subs(old, d, **kwargs)
                 reps[d] = new
                 if not isinstance(rv, Basic):

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -598,3 +598,7 @@ def test_mul2():
     2) remove the special handling in Mul.flatten
     """
     assert (2*(x + 1)).is_Mul
+
+def test_noncommutative_subs():
+    x,y = symbols('x,y', commutative=False)
+    assert (x*y*x).subs([(x,x*y),(y,x)],simultaneous=True) == (x*y*x**2*y)


### PR DESCRIPTION
I was doing some work with rewrite systems using noncommuting variables and discovered a bug in subs().
This is a simple fix and a corresponding test.  The problem was that the dummy variables in simultaneous substitutes did not preseve the parent's properties.
