### PR TITLE
Added 'look_for_contraction' option to CodePrinter

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -145,9 +145,12 @@ class CCodePrinter(CodePrinter):
         elem = S.Zero
         offset = S.One
         for i in reversed(range(expr.rank)):
-            elem += offset*expr.indices[i]
+            elem += expr.indices[i]*offset
             offset *= dims[i]
         return "%s[%s]" % (self._print(expr.base.label), self._print(elem))
+
+    def _print_Idx(self, expr):
+        return self._print(expr.label)
 
     def _print_Exp1(self, expr):
         return "M_E"

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -34,6 +34,7 @@ class CCodePrinter(CodePrinter):
         'precision': 15,
         'user_functions': {},
         'human': True,
+        'look_for_contraction': True,
     }
 
     def __init__(self, settings={}):
@@ -141,11 +142,10 @@ class CCodePrinter(CodePrinter):
     def _print_Indexed(self, expr):
         # calculate index for 1d array
         dims = expr.shape
-        inds = [ i.label for i in expr.indices ]
         elem = S.Zero
         offset = S.One
         for i in reversed(range(expr.rank)):
-            elem += offset*inds[i]
+            elem += offset*expr.indices[i]
             offset *= dims[i]
         return "%s[%s]" % (self._print(expr.base.label), self._print(elem))
 

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -17,6 +17,8 @@ class AssignmentError(Exception):
 class CodePrinter(StrPrinter):
     """
     The base class for code-printing subclasses.
+
+    self._settings['look_for_contraction'] assumed True if not passsed on by user
     """
 
     _operators = {
@@ -35,12 +37,18 @@ class CodePrinter(StrPrinter):
         lines = []
 
         # Setup loops over non-dummy indices  --  all terms need these
-        indices = self.get_expression_indices(expr, assign_to)
+        if self._settings.get('look_for_contraction', True):
+            indices = self.get_expression_indices(expr, assign_to)
+        else:
+            indices = []
         openloop, closeloop = self._get_loop_opening_ending(indices)
 
         # Setup loops over dummy indices  --  each term needs separate treatment
         from sympy.tensor import get_contraction_structure
-        d = get_contraction_structure(expr)
+        if self._settings.get('look_for_contraction', True):
+            d = get_contraction_structure(expr)
+        else:
+            d = {None: (expr,)}
 
         # terms with no summations first
         if None in d:
@@ -48,6 +56,7 @@ class CodePrinter(StrPrinter):
         else:
             # If all terms have summations we must initialize array to Zero
             text = CodePrinter.doprint(self, 0)
+
         # skip redundant assignments
         if text != lhs_printed:
             lines.extend(openloop)

--- a/sympy/printing/codeprinter.py
+++ b/sympy/printing/codeprinter.py
@@ -17,8 +17,6 @@ class AssignmentError(Exception):
 class CodePrinter(StrPrinter):
     """
     The base class for code-printing subclasses.
-
-    self._settings['look_for_contraction'] assumed True if not passsed on by user
     """
 
     _operators = {
@@ -37,7 +35,7 @@ class CodePrinter(StrPrinter):
         lines = []
 
         # Setup loops over non-dummy indices  --  all terms need these
-        if self._settings.get('look_for_contraction', True):
+        if self._settings.get('contract', True):
             indices = self.get_expression_indices(expr, assign_to)
         else:
             indices = []
@@ -45,7 +43,7 @@ class CodePrinter(StrPrinter):
 
         # Setup loops over dummy indices  --  each term needs separate treatment
         from sympy.tensor import get_contraction_structure
-        if self._settings.get('look_for_contraction', True):
+        if self._settings.get('contract', True):
             d = get_contraction_structure(expr)
         else:
             d = {None: (expr,)}

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -38,7 +38,7 @@ class FCodePrinter(CodePrinter):
         'user_functions': {},
         'human': True,
         'source_format': 'fixed',
-        'look_for_contraction': True,
+        'contract': True,
     }
 
     _implicit_functions = set([
@@ -429,6 +429,12 @@ def fcode(expr, **settings):
        source_format : optional
            The source format can be either 'fixed' or 'free'.
            [default='fixed']
+       contract: optional
+           If True, `Indexed` instances are assumed to obey
+           tensor contraction rules and the corresponding nested
+           loops over indices are generated. Setting contract = False
+           will not generate loops, instead the user is responsible
+           to provide values for the indices in the code. [default=True]
 
        Examples
        ========
@@ -442,6 +448,15 @@ def fcode(expr, **settings):
        >>> print(fcode(pi))
              parameter (pi = 3.14159265358979d0)
              pi
+       >>> from sympy import Eq, IndexedBase, Idx
+       >>> len_y = 5
+       >>> y = IndexedBase('y', shape=(len_y,))
+       >>> t = IndexedBase('t', shape=(len_y,))
+       >>> Dy = IndexedBase('Dy', shape=(len_y-1,))
+       >>> i = Idx('i', len_y-1)
+       >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
+       >>> fcode(e.rhs, assign_to=e.lhs, contract=False)
+       '      Dy(i) = (y(i + 1) - y(i))*1.0/(t(i + 1) - t(i))'
 
     """
     # run the printer

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -38,6 +38,7 @@ class FCodePrinter(CodePrinter):
         'user_functions': {},
         'human': True,
         'source_format': 'fixed',
+        'look_for_contraction': True,
     }
 
     _implicit_functions = set([

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -167,7 +167,7 @@ def test_ccode_Indexed_without_looking_for_contraction():
     Dy = IndexedBase('Dy', shape=(len_y-1,))
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
-    code0 = ccode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
+    code0 = ccode(e.rhs, assign_to=e.lhs, contract=False)
     assert code0 == 'Dy[i] = (y[%s] - y[i])*1.0/(x[%s] - x[i]);' % (i + 1, i + 1)
 
 

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -160,6 +160,17 @@ def test_ccode_Indexed():
     assert p._not_c == set()
 
 
+def test_ccode_Indexed_without_looking_for_contraction():
+    len_y = 5
+    y = IndexedBase('y', shape=(len_y,))
+    x = IndexedBase('x', shape=(len_y,))
+    Dy = IndexedBase('Dy', shape=(len_y-1,))
+    i = Idx('i', len_y-1)
+    e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
+    code0 = ccode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
+    assert code0.split('\n')[-1] == 'Dy[i] = (y[i + 1] - y[i])*1.0/(x[i + 1] - x[i]);'
+
+
 def test_ccode_loops_matrix_vector():
     n, m = symbols('n m', integer=True)
     A = IndexedBase('A')

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -1,4 +1,4 @@
-from sympy.core import pi, oo, symbols, Function, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda, Dummy
+from sympy.core import pi, oo, symbols, Function, Rational, Integer, GoldenRatio, EulerGamma, Catalan, Lambda, Dummy, Eq
 from sympy.functions import Piecewise, sin, cos, Abs, exp, ceiling, sqrt
 from sympy.utilities.pytest import raises
 from sympy.printing.ccode import CCodePrinter
@@ -145,7 +145,7 @@ def test_ccode_settings():
 def test_ccode_Indexed():
     from sympy.tensor import IndexedBase, Idx
     from sympy import symbols
-    i, j, k, n, m, o = symbols('i j k n m o', integer=True)
+    i, j, k, n, m, o = symbols('i j k n m o', cls=Idx)
 
     p = CCodePrinter()
     p._not_c = set()
@@ -185,7 +185,7 @@ def test_ccode_loops_matrix_vector():
         '}\n'
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = y[i] + A[i*n + j]*x[j];\n'
+        '      y[i] = y[i] + A[%s]*x[j];\n' % (i*n + j) +\
         '   }\n'
         '}'
     )
@@ -228,7 +228,7 @@ def test_ccode_loops_add():
         '}\n'
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = y[i] + A[i*n + j]*x[j];\n'
+        '      y[i] = y[i] + A[%s]*x[j];\n' % (i*n + j) +\
         '   }\n'
         '}'
     )
@@ -256,7 +256,7 @@ def test_ccode_loops_multiple_contractions():
         '   for (int j=0; j<n; j++){\n'
         '      for (int k=0; k<o; k++){\n'
         '         for (int l=0; l<p; l++){\n'
-        '            y[i] = y[i] + b[j*o*p + k*p + l]*a[i*n*o*p + j*o*p + k*p + l];\n'
+        '            y[i] = y[i] + b[%s]*a[%s];\n' % (j*o*p + k*p + l, i*n*o*p + j*o*p + k*p + l) +\
         '         }\n'
         '      }\n'
         '   }\n'
@@ -287,7 +287,7 @@ def test_ccode_loops_addfactor():
         '   for (int j=0; j<n; j++){\n'
         '      for (int k=0; k<o; k++){\n'
         '         for (int l=0; l<p; l++){\n'
-        '            y[i] = (a[i*n*o*p + j*o*p + k*p + l] + b[i*n*o*p + j*o*p + k*p + l])*c[j*o*p + k*p + l] + y[i];\n'
+        '            y[i] = (a[%s] + b[%s])*c[%s] + y[i];\n' % (i*n*o*p + j*o*p + k*p + l, i*n*o*p + j*o*p + k*p + l, j*o*p + k*p + l) +\
         '         }\n'
         '      }\n'
         '   }\n'
@@ -318,7 +318,7 @@ def test_ccode_loops_multiple_terms():
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
         '      for (int k=0; k<o; k++){\n'
-        '         y[i] = b[j]*b[k]*c[i*n*o + j*o + k] + y[i];\n'
+        '         y[i] = b[j]*b[k]*c[%s] + y[i];\n' % (i*n*o + j*o + k) +\
         '      }\n'
         '   }\n'
         '}\n'
@@ -326,14 +326,14 @@ def test_ccode_loops_multiple_terms():
     s2 = (
         'for (int i=0; i<m; i++){\n'
         '   for (int k=0; k<o; k++){\n'
-        '      y[i] = b[k]*a[i*o + k] + y[i];\n'
+        '      y[i] = b[k]*a[%s] + y[i];\n' % (i*o + k) +\
         '   }\n'
         '}\n'
     )
     s3 = (
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = b[j]*a[i*n + j] + y[i];\n'
+        '      y[i] = b[j]*a[%s] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}\n'
     )

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -168,7 +168,7 @@ def test_ccode_Indexed_without_looking_for_contraction():
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
     code0 = ccode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
-    assert code0.split('\n')[-1] == 'Dy[i] = (y[i + 1] - y[i])*1.0/(x[i + 1] - x[i]);'
+    assert code0 == 'Dy[i] = (y[%s] - y[i])*1.0/(x[%s] - x[i]);' % (i + 1, i + 1)
 
 
 def test_ccode_loops_matrix_vector():

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -145,17 +145,17 @@ def test_ccode_settings():
 def test_ccode_Indexed():
     from sympy.tensor import IndexedBase, Idx
     from sympy import symbols
-    i, j, k, n, m, o = symbols('i j k n m o', cls=Idx)
-
+    n, m, o = symbols('n m o', integer=True)
+    i, j, k = Idx('i', n), Idx('j', m), Idx('k', o)
     p = CCodePrinter()
     p._not_c = set()
 
-    x = IndexedBase('x')[Idx(j, n)]
+    x = IndexedBase('x')[j]
     assert p._print_Indexed(x) == 'x[j]'
-    A = IndexedBase('A')[Idx(i, m), Idx(j, n)]
-    assert p._print_Indexed(A) == 'A[%s]' % str(j + n*i)
-    B = IndexedBase('B')[Idx(i, m), Idx(j, n), Idx(k, o)]
-    assert p._print_Indexed(B) == 'B[%s]' % str(k + i*n*o + j*o)
+    A = IndexedBase('A')[i, j]
+    assert p._print_Indexed(A) == 'A[%s]' % (m*i+j)
+    B = IndexedBase('B')[i, j, k]
+    assert p._print_Indexed(B) == 'B[%s]' % (i*o*m+j*o+k)
 
     assert p._not_c == set()
 

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -566,6 +566,16 @@ def test_dummy_loops():
     code = fcode(x[i], assign_to=y[i], source_format='free')
     assert code == expected
 
+def test_fcode_Indexed_without_looking_for_contraction():
+    len_y = 5
+    y = IndexedBase('y', shape=(len_y,))
+    x = IndexedBase('x', shape=(len_y,))
+    Dy = IndexedBase('Dy', shape=(len_y-1,))
+    i = Idx('i', len_y-1)
+    e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
+    code0 = ccode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
+    assert code0.split('\n')[-1].endswith('Dy(i) = (y(i + 1) - y(i))*1.0/(x(i + 1) - x(i))')
+
 
 def test_derived_classes():
     class MyFancyFCodePrinter(FCodePrinter):

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, atan2, log, exp, gamma, conjugate, sqrt, \
-    factorial, Integral, Piecewise, Add, diff, symbols, S, Float, Dummy
+    factorial, Integral, Piecewise, Add, diff, symbols, S, Float, Dummy, Eq
 from sympy import Catalan, EulerGamma, E, GoldenRatio, I, pi
 from sympy import Function, Rational, Integer, Lambda
 
@@ -573,8 +573,8 @@ def test_fcode_Indexed_without_looking_for_contraction():
     Dy = IndexedBase('Dy', shape=(len_y-1,))
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
-    code0 = ccode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
-    assert code0.split('\n')[-1].endswith('Dy(i) = (y(i + 1) - y(i))*1.0/(x(i + 1) - x(i))')
+    code0 = fcode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
+    assert code0.endswith('Dy(i) = (y(i + 1) - y(i))*1.0/(x(i + 1) - x(i))')
 
 
 def test_derived_classes():

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -573,7 +573,7 @@ def test_fcode_Indexed_without_looking_for_contraction():
     Dy = IndexedBase('Dy', shape=(len_y-1,))
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
-    code0 = fcode(e.rhs, assign_to=e.lhs, look_for_contraction=False)
+    code0 = fcode(e.rhs, assign_to=e.lhs, contract=False)
     assert code0.endswith('Dy(i) = (y(i + 1) - y(i))*1.0/(x(i + 1) - x(i))')
 
 

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -351,10 +351,10 @@ def test_loops_c():
         '}\n'
     )
 
-    assert (code == expected % {'rhs': 'A[i*n + j]*x[j]'} or
-            code == expected % {'rhs': 'A[j + i*n]*x[j]'} or
-            code == expected % {'rhs': 'x[j]*A[i*n + j]'} or
-            code == expected % {'rhs': 'x[j]*A[j + i*n]'})
+    assert (code == expected % {'rhs': 'A[%s]*x[j]' % (i*n + j)} or
+            code == expected % {'rhs': 'A[%s]*x[j]' % (j + i*n)} or
+            code == expected % {'rhs': 'x[j]*A[%s]' % (i*n + j)} or
+            code == expected % {'rhs': 'x[j]*A[%s]' % (j + i*n)})
     assert f2 == 'file.h'
     assert interface == (
         '#ifndef PROJECT__FILE__H\n'
@@ -419,10 +419,10 @@ def test_partial_loops_c():
         '}\n'
     ) % {'upperi': m - 4, 'rhs': '%(rhs)s'}
 
-    assert (code == expected % {'rhs': 'A[i*p + j]*x[j]'} or
-            code == expected % {'rhs': 'A[j + i*p]*x[j]'} or
-            code == expected % {'rhs': 'x[j]*A[i*p + j]'} or
-            code == expected % {'rhs': 'x[j]*A[j + i*p]'})
+    assert (code == expected % {'rhs': 'A[%s]*x[j] % (i*p + j)'} or
+            code == expected % {'rhs': 'A[%s]*x[j] % (j + i*p)'} or
+            code == expected % {'rhs': 'x[j]*A[%s] % (i*p + j)'} or
+            code == expected % {'rhs': 'x[j]*A[%s] % (j + i*p)'})
     assert f2 == 'file.h'
     assert interface == (
         '#ifndef PROJECT__FILE__H\n'

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -419,10 +419,10 @@ def test_partial_loops_c():
         '}\n'
     ) % {'upperi': m - 4, 'rhs': '%(rhs)s'}
 
-    assert (code == expected % {'rhs': 'A[%s]*x[j] % (i*p + j)'} or
-            code == expected % {'rhs': 'A[%s]*x[j] % (j + i*p)'} or
-            code == expected % {'rhs': 'x[j]*A[%s] % (i*p + j)'} or
-            code == expected % {'rhs': 'x[j]*A[%s] % (j + i*p)'})
+    assert (code == expected % {'rhs': 'A[%s]*x[j]' % (i*p + j)} or
+            code == expected % {'rhs': 'A[%s]*x[j]' % (j + i*p)} or
+            code == expected % {'rhs': 'x[j]*A[%s]' % (i*p + j)} or
+            code == expected % {'rhs': 'x[j]*A[%s]' % (j + i*p)})
     assert f2 == 'file.h'
     assert interface == (
         '#ifndef PROJECT__FILE__H\n'


### PR DESCRIPTION
This PR allows to print Indexed instances with non-tensor compliant indices.

Example:

```
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from sympy import *

def main(len_y=5):
    y = IndexedBase('y', shape=(len_y,))
    x = IndexedBase('x', shape=(len_y,))
    Dy = IndexedBase('Dy', shape=(len_y-1,))
    i = Idx('i', len_y-1)

    a,b,c = symbols('a b c')
    print(ccode(a*b+c**2))

    # Forward difference
    e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
    print(ccode(e.rhs, assign_to=e.lhs, look_for_contraction=False))



if __name__ == '__main__':
    main()
```

Outputs:

```
 a*b + pow(c, 2)
 Dy[i] = (y[i + 1] - y[i])*1.0/(x[i + 1] - x[i]);
```

~~How to avoid "i" to end up in CodePriner._not_supported set in unclear to me.~~

Critisism is welcome. It would be great if we could allow something along these lines since it currently is a real show stopper for doing e.g. finite differences meta programming using SymPy..
