### PR TITLE
bool, relational: added as_set method

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -227,6 +227,33 @@ class Relational(Boolean, Expr, EvalfMixin):
 
     __bool__ = __nonzero__
 
+    def as_set(self):
+        """
+        Rewrites univariate inequality in terms of real sets
+
+        Examples
+        ========
+
+        >>> from sympy import Symbol, Eq
+        >>> x = Symbol('x', real=True)
+        >>> (x>0).as_set()
+        (0, oo)
+        >>> Eq(x, 0).as_set()
+        {0}
+
+        """
+        from sympy.solvers.inequalities import solve_univariate_inequality
+        syms = self.free_symbols
+
+        if len(syms) == 1:
+            sym = syms.pop()
+        else:
+            raise NotImplementedError("Sorry, Relational.as_set procedure"
+                                      " is not yet implemented for"
+                                      " multivariate expressions")
+
+        return solve_univariate_inequality(self, sym, relational=False)
+
 
 class Equality(Relational):
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -3,6 +3,7 @@ from sympy import Symbol, symbols, oo, I, pi, Float, And, Or, Not, Implies, Xor
 from sympy.core.relational import ( Relational, Equality, Unequality,
     GreaterThan, LessThan, StrictGreaterThan, StrictLessThan, Rel, Eq, Lt, Le,
     Gt, Ge, Ne )
+from sympy.core.sets import Interval, FiniteSet
 
 x, y, z, t = symbols('x,y,z,t')
 
@@ -282,3 +283,21 @@ def test_relational_logic_symbols():
     assert isinstance((x < y) >> (z < t), Implies)
     assert isinstance((x < y) << (z < t), Implies)
     assert isinstance((x < y) ^ (z < t), (Or, Xor))
+
+
+def test_univariate_relational_as_set():
+    assert (x > 0).as_set() == Interval(0, oo, True, True)
+    assert (x >= 0).as_set() == Interval(0, oo)
+    assert (x < 0).as_set() == Interval(-oo, 0, True, True)
+    assert (x <= 0).as_set() == Interval(-oo, 0)
+    assert Eq(x, 0).as_set() == FiniteSet(0)
+    assert Ne(x, 0).as_set() == Interval(-oo, 0, True, True) + \
+        Interval(0, oo, True, True)
+
+    assert (x**2 >= 4).as_set() == Interval(-oo, -2) + Interval(2, oo)
+
+
+@XFAIL
+def test_multivariate_relational_as_set():
+    assert (x*y >= 0).as_set() == Interval(0, oo)*Interval(0, oo) + \
+        Interval(-oo, 0)*Interval(-oo, 0)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -1,11 +1,13 @@
-from sympy import symbols, sympify, Dummy, simplify, Equality, S
+from sympy import (symbols, sympify, Dummy, simplify, Equality, S, Interval,
+                   oo, EmptySet)
 from sympy.logic.boolalg import (
     And, Boolean, Equivalent, ITE, Implies, Nand, Nor, Not, Or, POSform,
     SOPform, Xor, conjuncts, disjuncts, distribute_or_over_and,
     distribute_and_over_or, eliminate_implications, is_cnf, is_dnf,
-    simplify_logic, to_cnf, to_dnf, to_int_repr, bool_map, true, false, BooleanAtom
+    simplify_logic, to_cnf, to_dnf, to_int_repr, bool_map, true, false,
+    BooleanAtom
 )
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import raises, XFAIL
 from sympy.utilities import cartes
 
 
@@ -543,3 +545,22 @@ def test_true_false():
         assert ITE(F, T, F) is false
         assert ITE(F, F, T) is true
         assert ITE(F, F, F) is false
+
+
+def test_bool_as_set():
+    x = symbols('x')
+
+    assert And(x <= 2, x >= -2).as_set() == Interval(-2, 2)
+    assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
+    assert Not(x > 2).as_set() == Interval(-oo, 2)
+    assert true.as_set() == S.UniversalSet
+    assert false.as_set() == EmptySet()
+
+
+@XFAIL
+def test_multivariate_bool_as_set():
+    x, y = symbols('x,y')
+
+    assert And(x >= 0, y >= 0).as_set() == Interval(0, oo)*Interval(0, oo)
+    assert Or(x >= 0, y >= 0).as_set() == S.UniversalSet - \
+        Interval(-oo, 0, True, True)*Interval(-oo, 0, True, True)


### PR DESCRIPTION
`as_set` is the inverse method for existing `as_relational`
method for sets. `as_set` converts a univariate boolean or
relational expression to real set.

Example:

```
In [1]: from sympy import And, Or

In [2]: from sympy.abc import x

In [3]: And(x<2, x>-2).as_set()
Out[3]: (-2, 2)

In [4]: (x**2 > 4).as_set()
Out[4]: (-oo, -2) U (2, oo)
```
