### PR TITLE
do not use None in factor_list

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -1,7 +1,7 @@
 from sympy import (
     Abs, And, binomial, Catalan, cos, Derivative, E, Eq, exp, EulerGamma,
     factorial, Function, harmonic, I, Integral, KroneckerDelta, log,
-    nan, oo, pi, Piecewise, Product, product, Rational, S, simplify,
+    nan, Ne, Or, oo, pi, Piecewise, Product, product, Rational, S, simplify,
     sqrt, Sum, summation, Symbol, symbols, sympify, zeta, gamma
 )
 from sympy.abc import a, b, c, d, f, k, m, x, y, z
@@ -780,3 +780,13 @@ def test_factor_expand_subs():
     assert Sum(x,(x,1,10)).subs([(x,y-2)]) == Sum(x,(x,1,10))
     assert Sum(1/x,(x,1,10)).subs([(x,(3+n)**3)]) == Sum(1/x,(x,1,10))
     assert Sum(1/x,(x,1,10)).subs([(x,3*x-2)]) == Sum(1/x,(x,1,10))
+
+def test_github_issue_2787():
+    n, k = symbols('n k', positive=True, integer=True)
+    p = symbols('p', positive=True)
+    binomial_dist = binomial(n, k)*p**k*(1 - p)**(n - k)
+    s = Sum(binomial_dist*k, (k, 0, n))
+    res = s.doit().simplify()
+    assert res == Piecewise((n*p, And(Or(-n + 1 < 0, -n + 1 >= 0),
+        Or(-n + 1 < 0, Ne(p/(p - 1), 1)), p*Abs(1/(p - 1)) <= 1)),
+        (Sum(k*p**k*(-p + 1)**(-k)*(-p + 1)**n*binomial(n, k), (k, 0, n)), True))

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5399,7 +5399,7 @@ def _symbolic_factor_list(expr, opt, method):
                 elif _coeff.is_positive:
                     factors.append((_coeff, exp))
                 else:
-                    _factors.append((_coeff, None))
+                    _factors.append((_coeff, S.One))
 
             if exp is S.One:
                 factors.extend(_factors)
@@ -5411,10 +5411,8 @@ def _symbolic_factor_list(expr, opt, method):
                 for f, k in _factors:
                     if f.as_expr().is_positive:
                         factors.append((f, k*exp))
-                    elif k is not None:
-                        other.append((f, k))
                     else:
-                        other.append((f, S.One))
+                        other.append((f, k))
 
                 if len(other) == 1:
                     f, k = other[0]


### PR DESCRIPTION
The None tracked a term that should not be extracted
if the exponent assumptions didn't allow. But this has
to be handled differently since the "k" value is needed
if the assumptions allow. A test (that caused the gh failure
and that gave the wrong answer when the solution was formulated
as just dropping the k term when k was None) was added.

fixes #2787
