### PR TITLE
added documentation for discrete RV types

### DIFF
--- a/doc/src/modules/stats.rst
+++ b/doc/src/modules/stats.rst
@@ -16,6 +16,11 @@ Finite Types
 .. autofunction:: Hypergeometric
 .. autofunction:: FiniteRV
 
+Discrete Types
+-----------------
+.. autofunction:: Geometric
+.. autofunction:: Poisson
+
 Continuous Types
 -------------------
 


### PR DESCRIPTION
Second try at adding documentation for the discrete RV types in the stats module (again, not sure if I'm doing this right).
