### PR TITLE
2284_series: Rectified the limit(( 1.0*1 + 1.0*x)**( 1.0*1/x))

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, division
 
+from sympy import Rational
 from sympy.core import C, sympify
 from sympy.core.add import Add
 from sympy.core.function import Lambda, Function, ArgumentIndexError
@@ -712,6 +713,14 @@ class log(Function):
             n += 1
             s = self.args[0].nseries(x, n=n, logx=logx)
         a, b = s.leadterm(x)
+        try:
+            a = Rational(a)
+        except TypeError:
+            pass
+        try:
+            b = Rational(b)
+        except TypeError:
+            pass
         p = cancel(s/(a*x**b) - 1)
         g = None
         l = []

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -417,3 +417,10 @@ def test_issue_3265():
     a = Symbol('a')
     e = z/(1 - sqrt(1 + z)*sin(a)**2 - sqrt(1 - z)*cos(a)**2)
     assert limit(e, z, 0).simplify() == 2/cos(2*a)
+
+def test_issue_2284():
+    from sympy import E, nsimplify
+    x = Symbol('x')
+    x0 = 0
+    func = (1.0*1 + 1.0*x)**( 1.0*1/x)
+    assert nsimplify(limit(func, x, x0)) == E


### PR DESCRIPTION
-> This is a fix to the bug reported in issue 2284.

https://code.google.com/p/sympy/issues/detail?id=2284&q=label%3ASeries&sort=summary%20-id&colspec=ID%20Type%20Status%20Priority%20Milestone%20Reporter%20Summary%20Stars

-> The output of the limit was oo(wrong) earlier which should be E but now output is 2.71828182845905 (E).
-> The error is due to the presence of terms like 1.0/3 in taylor series which evaluate to 0.33333.
-> So the fix adopted is to convert these terms to Rational Numbers and then evaluate.
