### PR TITLE
 Function normal_lines to ellipse.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -300,3 +300,4 @@ James Goppert <james.goppert@gmail.com>
 Avichal Dayal <avichal.dayal@gmail.com>
 Paul Scott <paul.scott@nicta.com.au>
 Shipra Banga <bangashipra@gmail.com>
+Akshayah <akshaynukala95@gmail.com>

--- a/doc/src/aboutus.rst
+++ b/doc/src/aboutus.rst
@@ -305,6 +305,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. Avichal Dayal: removed duplicate solutions obtained from solve
 #. Paul Scott: pass along keywords for plots
 #. shiprabanga: code quality fixes
+#. Akshayah: added normal_lines to Ellipse
 
 Up-to-date list in the order of the first contribution is given in the `AUTHORS
 <https://github.com/sympy/sympy/blob/master/AUTHORS>`_ file.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -768,11 +768,11 @@ class Ellipse(GeometryEntity):
 
         rv = []
         if self.centre == p:
-            rv.append(Line(p, Point(p.x + 1, p.y)), Line(p, Point(p.x, p.y + 1)))
+            rv.append(Line(*self.intersection(Line(p, Point(p.x + 1, p.y)))), Line(*self.intersection(Line(p, Point(p.x, p.y + 1)))))
         elif p.x == self.center.x:
-            rv.append(Line(p, Point(p.x, p.y + 1)))
+            rv.append(Line(*self.intersection(Line(p, Point(p.x, p.y + 1)))))
         elif p.y == self.center.y:
-            rv.append(Line(p, Point(p.x + 1, p.y)))
+            rv.append(Line(*self.intersection(Line(p, Point(p.x + 1, p.y)))))
         if rv:
             return rv
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -767,9 +767,7 @@ class Ellipse(GeometryEntity):
         """
 
         rv = []
-        if self.centre == p:
-            rv.append(Line(*self.intersection(Line(p, Point(p.x + 1, p.y)))), Line(*self.intersection(Line(p, Point(p.x, p.y + 1)))))
-        elif p.x == self.center.x:
+        if p.x == self.center.x:
             rv.append(Line(*self.intersection(Line(p, Point(p.x, p.y + 1)))))
         elif p.y == self.center.y:
             rv.append(Line(*self.intersection(Line(p, Point(p.x + 1, p.y)))))

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -766,19 +766,22 @@ class Ellipse(GeometryEntity):
         [Line(Point(3, 2), Point(4, 2)), Line(Point(3, 2), Point(3, 3))]
         """
 
+        rv = []
         if self.centre == p:
-            return [Line(p, Point(p.x + 1, p.y)), Line(p, Point(p.x, p.y + 1))]
+            rv.append(Line(p, Point(p.x + 1, p.y)), Line(p, Point(p.x, p.y + 1)))
         elif p.x == self.center.x:
-            return [Line(p, Point(p.x, p.y + 1))]
+            rv.append(Line(p, Point(p.x, p.y + 1)))
         elif p.y == self.center.y:
-            return [Line(p, Point(p.x + 1, p.y))]
+            rv.append(Line(p, Point(p.x + 1, p.y)))
+        if rv:
+            return rv
 
         else:
             x, y = Dummy('x', real=True), Dummy('y', real=True)
             eq = self.equation(x, y)
-            dxdy = -idiff(eq, x, y)
+            dydx = idiff(eq, y, x)
             slope = Line(p, Point(x, y)).slope
-            points = solve([slope - dxdy, eq], [x, y])
+            points = solve([slope + 1 / dydx, eq], [x, y])
             return [Line(p, pt) for pt in points]
 
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -739,10 +739,8 @@ class Ellipse(GeometryEntity):
         else:
             raise NotImplementedError("Unknown argument type")
 
-    def normal_lines(self,p):
-       """Normal lines between `p` and the ellipse.
-
-
+    def normal_lines(self, p):
+        """Normal lines between `p` and the ellipse.
 
         Parameters
         ==========
@@ -752,40 +750,42 @@ class Ellipse(GeometryEntity):
         Returns
         =======
 
-        normal_lines : list with 1 or 2 or 4 Lines
+        normal_lines : list with 1 , 2 or 4 Lines
+
+        Examples
+        ========
 
         >>> from sympy import*
         >>> e1= Ellipse(Point(0,0),2,3)
         >>> e1.normal_lines(Point(1,0))
-        Out[5]: [Line(Point(1, 0), Point(2, 0))]
+        [Line(Point(1, 0), Point(2, 0))]
 
         >>> from sympy import*
         >>> e1=Ellipse(Point(3,2),2,3)
         >>> e1.normal_lines(Point(3,2))
-        Out[6]:  [Line(Point(3, 2), Point(4, 2)), Line(Point(3, 2), Point(3, 3))]"""
+        [Line(Point(3, 2), Point(4, 2)), Line(Point(3, 2), Point(3, 3))]"""
 
-
-        if( self.centre==p):
-            return [Line(p,Point(((p.x)+1),p.y)),Line(p,Point(p.x,((p.y)+1)))]
-        elif(int(p.x) == int(self.center.x) & int(p.y) != int(self.center.y)):
-            return [Line(p,Point(p.x,((p.y)+1)))]
-        elif(int(p.y) == int(self.center.y)):
-            return [Line(p,Point(((p.x)+1),p.y))]
-
+        if self.centre == p:
+            return [Line(p, Point(p.x + 1, p.y)), Line(p, Point(p.x, p.y + 1))]
+        elif p.x == self.center.x & p.y != self.center.y:
+            return [Line(p, Point(p.x, p.y + 1))]
+        elif p.y == self.center.y:
+            return [Line(p, Point(p.x + 1, p.y))]
 
         else:
-            x, y = Dummy('x'), Dummy('y')
+            x, y = Dummy('x', real= True), Dummy('y', real= True)
             eq = self.equation(x, y)
             dxdy = -idiff(eq, x, y)
             slope = Line(p, Point(x, y)).slope
             points = solve([slope - dxdy, eq], [x, y])
 
-            normal_points=[Point(point).evalf() for point in points if Point.is_real(Point(point))]
+            normal_points = [Point(point).evalf() for point in points]
 
-            if(len(normal_points)==2):
-                return [Line(p, normal_points[0]),Line(p, normal_points[1])]
-            if(len(normal_points)==4):
-                return [Line(p, normal_points[0]),Line(p, normal_points[1]),Line(p, normal_points[2]),Line(p, normal_points[3])]
+            if len(normal_points) == 2:
+                return [Line(p, normal_points[0]), Line(p, normal_points[1])]
+            if len(normal_points) == 4:
+                return [Line(p, normal_points[0]), Line(p, normal_points[1]), Line(p, normal_points[2]), Line(p,
+                        normal_points[3])]
 
     def arbitrary_point(self, parameter='t'):
         """A parameterized point on the ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -741,17 +741,22 @@ class Ellipse(GeometryEntity):
 
     def normal_lines(self,p):
         """Normal lines between `p` and the ellipse.
+        Parameters : p (Point from which the normals are drawn to the ellipse)
+        Returns    : A list of normal lines
+        Example
+        >>> from sympy import*
+        >>> e1= Ellipse(Point(0,0),2,3)
+        >>> e1.normal_lines(Point(1,0))
+        Out[5]: [Line(Point(1, 0), Point(2, 0))] """
 
-        If `p` is on the ellipse, returns the normal line through point `p`.
-        Otherwise, returns the normal lines from `p` to the ellipse"""
-        if( (p==Point(self.hradius,0)) or (p== Point(0,self.vradius)) ):
-            return [(Point(0,0),p)]
-        elif( (int(p.x)==0) & (int(p.y)==0)):
+
+
+        if( (int(p.x)==0) & (int(p.y)==0)):
             return [Line(p,Point(self.hradius,0)),Line(p,Point(0,self.vradius))]
-        elif(int(p.x)==0):
-            return [Line(p,Point(0,self.vradius))]
-        elif(int(p.y)==0):
-            return [Line(p,Point(self.hradius,0))]
+        elif((int(p.x)==0) & (int(p.y)!=0)):
+            return [Line(p,Point(0,((p.y)+1)))]
+        elif((int(p.y)==0) & (int(p.x)!=0)):
+            return [Line(p,Point(((p.x)+1),0))]
 
 
         else:
@@ -763,12 +768,6 @@ class Ellipse(GeometryEntity):
 
             normal_points=[Point(point).evalf() for point in points if Point.is_real(Point(point))]
 
-
-
-        #return normal_points
-        #return normal_points
-            """if len(normal_points==0):
-            return """
             if(len(normal_points)==2):
                 return [Line(p, (normal_points[0].evalf())),Line(p, (normal_points[1]))]
             if len(normal_points)==4:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -755,37 +755,32 @@ class Ellipse(GeometryEntity):
         Examples
         ========
 
-        >>> from sympy import*
-        >>> e1= Ellipse(Point(0,0),2,3)
-        >>> e1.normal_lines(Point(1,0))
+        >>> from sympy import Line, Point, Ellipse
+        >>> e1= Ellipse(Point(0, 0), 2, 3)
+        >>> e1.normal_lines(Point(1, 0))
         [Line(Point(1, 0), Point(2, 0))]
 
-        >>> from sympy import*
-        >>> e1=Ellipse(Point(3,2),2,3)
-        >>> e1.normal_lines(Point(3,2))
-        [Line(Point(3, 2), Point(4, 2)), Line(Point(3, 2), Point(3, 3))]"""
+        >>> from sympy import Line, Point, Ellipse
+        >>> e1= Ellipse(Point(3, 2), 2, 3)
+        >>> e1.normal_lines(Point(3, 2))
+        [Line(Point(3, 2), Point(4, 2)), Line(Point(3, 2), Point(3, 3))]
+        """
 
         if self.centre == p:
             return [Line(p, Point(p.x + 1, p.y)), Line(p, Point(p.x, p.y + 1))]
-        elif p.x == self.center.x & p.y != self.center.y:
+        elif p.x == self.center.x:
             return [Line(p, Point(p.x, p.y + 1))]
         elif p.y == self.center.y:
             return [Line(p, Point(p.x + 1, p.y))]
 
         else:
-            x, y = Dummy('x', real= True), Dummy('y', real= True)
+            x, y = Dummy('x', real=True), Dummy('y', real=True)
             eq = self.equation(x, y)
             dxdy = -idiff(eq, x, y)
             slope = Line(p, Point(x, y)).slope
             points = solve([slope - dxdy, eq], [x, y])
+            return [Line(p, pt) for pt in points]
 
-            normal_points = [Point(point).evalf() for point in points]
-
-            if len(normal_points) == 2:
-                return [Line(p, normal_points[0]), Line(p, normal_points[1])]
-            if len(normal_points) == 4:
-                return [Line(p, normal_points[0]), Line(p, normal_points[1]), Line(p, normal_points[2]), Line(p,
-                        normal_points[3])]
 
     def arbitrary_point(self, parameter='t'):
         """A parameterized point on the ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -740,38 +740,52 @@ class Ellipse(GeometryEntity):
             raise NotImplementedError("Unknown argument type")
 
     def normal_lines(self,p):
-        """Normal lines between `p` and the ellipse.
-        Parameters : p (Point from which the normals are drawn to the ellipse)
-        Returns    : A list of normal lines
-        Example
+       """Normal lines between `p` and the ellipse.
+
+
+
+        Parameters
+        ==========
+
+        p : Point
+
+        Returns
+        =======
+
+        normal_lines : list with 1 or 2 or 4 Lines
+
         >>> from sympy import*
         >>> e1= Ellipse(Point(0,0),2,3)
         >>> e1.normal_lines(Point(1,0))
-        Out[5]: [Line(Point(1, 0), Point(2, 0))] """
+        Out[5]: [Line(Point(1, 0), Point(2, 0))]
+
+        >>> from sympy import*
+        >>> e1=Ellipse(Point(3,2),2,3)
+        >>> e1.normal_lines(Point(3,2))
+        Out[6]:  [Line(Point(3, 2), Point(4, 2)), Line(Point(3, 2), Point(3, 3))]"""
 
 
-
-        if( (int(p.x)==0) & (int(p.y)==0)):
-            return [Line(p,Point(self.hradius,0)),Line(p,Point(0,self.vradius))]
-        elif((int(p.x)==0) & (int(p.y)!=0)):
-            return [Line(p,Point(0,((p.y)+1)))]
-        elif((int(p.y)==0) & (int(p.x)!=0)):
-            return [Line(p,Point(((p.x)+1),0))]
+        if( self.centre==p):
+            return [Line(p,Point(((p.x)+1),p.y)),Line(p,Point(p.x,((p.y)+1)))]
+        elif(int(p.x) == int(self.center.x) & int(p.y) != int(self.center.y)):
+            return [Line(p,Point(p.x,((p.y)+1)))]
+        elif(int(p.y) == int(self.center.y)):
+            return [Line(p,Point(((p.x)+1),p.y))]
 
 
         else:
             x, y = Dummy('x'), Dummy('y')
             eq = self.equation(x, y)
-            dydx = -idiff(eq, x, y)
+            dxdy = -idiff(eq, x, y)
             slope = Line(p, Point(x, y)).slope
-            points = solve([slope - dydx, eq], [x, y])
+            points = solve([slope - dxdy, eq], [x, y])
 
             normal_points=[Point(point).evalf() for point in points if Point.is_real(Point(point))]
 
             if(len(normal_points)==2):
-                return [Line(p, (normal_points[0].evalf())),Line(p, (normal_points[1]))]
+                return [Line(p, normal_points[0]),Line(p, normal_points[1])]
             if len(normal_points)==4:
-                return [Line(p, (normal_points[0])),Line(p, (normal_points[1])),Line(p, (normal_points[2])),Line(p, (normal_points[3]))]
+                return [Line(p, normal_points[0]),Line(p, normal_points[1]),Line(p, normal_points[2]),Line(p, normal_points[3])]
 
     def arbitrary_point(self, parameter='t'):
         """A parameterized point on the ellipse.

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -739,6 +739,41 @@ class Ellipse(GeometryEntity):
         else:
             raise NotImplementedError("Unknown argument type")
 
+    def normal_lines(self,p):
+        """Normal lines between `p` and the ellipse.
+
+        If `p` is on the ellipse, returns the normal line through point `p`.
+        Otherwise, returns the normal lines from `p` to the ellipse"""
+        if( (p==Point(self.hradius,0)) or (p== Point(0,self.vradius)) ):
+            return [(Point(0,0),p)]
+        elif( (int(p.x)==0) & (int(p.y)==0)):
+            return [Line(p,Point(self.hradius,0)),Line(p,Point(0,self.vradius))]
+        elif(int(p.x)==0):
+            return [Line(p,Point(0,self.vradius))]
+        elif(int(p.y)==0):
+            return [Line(p,Point(self.hradius,0))]
+
+
+        else:
+            x, y = Dummy('x'), Dummy('y')
+            eq = self.equation(x, y)
+            dydx = -idiff(eq, x, y)
+            slope = Line(p, Point(x, y)).slope
+            points = solve([slope - dydx, eq], [x, y])
+
+            normal_points=[Point(point).evalf() for point in points if Point.is_real(Point(point))]
+
+
+
+        #return normal_points
+        #return normal_points
+            """if len(normal_points==0):
+            return """
+            if(len(normal_points)==2):
+                return [Line(p, (normal_points[0].evalf())),Line(p, (normal_points[1]))]
+            if len(normal_points)==4:
+                return [Line(p, (normal_points[0])),Line(p, (normal_points[1])),Line(p, (normal_points[2])),Line(p, (normal_points[3]))]
+
     def arbitrary_point(self, parameter='t'):
         """A parameterized point on the ellipse.
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -784,7 +784,7 @@ class Ellipse(GeometryEntity):
 
             if(len(normal_points)==2):
                 return [Line(p, normal_points[0]),Line(p, normal_points[1])]
-            if len(normal_points)==4:
+            if(len(normal_points)==4):
                 return [Line(p, normal_points[0]),Line(p, normal_points[1]),Line(p, normal_points[2]),Line(p, normal_points[3])]
 
     def arbitrary_point(self, parameter='t'):

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -60,8 +60,8 @@ class LinearEntity(GeometryEntity):
         p1 = Point(p1)
         p2 = Point(p2)
         if p1 == p2:
-            # Rolygon returns lower priority classes...should LinearEntity, too?
-            return p1  # raise ValueError("%s.__new__ requires two unique Points." % cls.__name__)
+            # if it makes sense to return a Point, handle in subclass
+            raise ValueError("%s.__new__ requires two unique Points." % cls.__name__)
 
         return GeometryEntity.__new__(cls, p1, p2, **kwargs)
 
@@ -996,8 +996,6 @@ class Line(LinearEntity):
             except NotImplementedError:
                 raise ValueError('The 2nd argument was not a valid Point. '
                 'If it was a slope, enter it with keyword "slope".')
-            if p1 == p2:
-                raise ValueError('A line requires two distinct points.')
         elif slope is not None and pt is None:
             slope = sympify(slope)
             if slope.is_bounded is False:

--- a/sympy/geometry/line.py
+++ b/sympy/geometry/line.py
@@ -1000,10 +1000,14 @@ class Line(LinearEntity):
             slope = sympify(slope)
             if slope.is_bounded is False:
                 # when unbounded slope, don't change x
-                p2 = p1 + Point(0, 1)
+                dx = 0
+                dy = 1
             else:
                 # go over 1 up slope
-                p2 = p1 + Point(1, slope)
+                dx = 1
+                dy = slope
+            # XXX avoiding simplification by adding to coords directly
+            p2 = Point(p1.x + dx, p1.y + dy)
         else:
             raise ValueError('A 2nd Point or keyword "slope" must be used.')
 
@@ -1083,6 +1087,7 @@ class Line(LinearEntity):
     def contains(self, o):
         """Return True if o is on this Line, or False otherwise."""
         if isinstance(o, Point):
+            o = o.func(*[simplify(i) for i in o.args])
             x, y = Dummy(), Dummy()
             eq = self.equation(x, y)
             if not eq.has(y):

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -322,14 +322,6 @@ class Point(GeometryEntity):
 #       return True
 #       """
 
-    def is_real(point):
-
-        x,y=point.args
-        if x.is_real and y.is_real:
-            return True
-        else:
-            return False
-
     def distance(self, p):
         """The Euclidean distance from self to point p.
 

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -322,6 +322,14 @@ class Point(GeometryEntity):
 #       return True
 #       """
 
+    def is_real(point):
+
+        x,y=point.args
+        if x.is_real and y.is_real:
+            return True
+        else:
+            return False
+
     def distance(self, p):
         """The Euclidean distance from self to point p.
 

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -299,29 +299,6 @@ class Point(GeometryEntity):
             # three points passed in, hence they are not concyclic.
             return False
 
-#       """
-#       # This code is from Maple
-#       def f(u):
-#           dd = u[0]**2 + u[1]**2 + 1
-#           u1 = 2*u[0] / dd
-#           u2 = 2*u[1] / dd
-#           u3 = (dd - 2) / dd
-#           return u1,u2,u3
-
-#       u1,u2,u3 = f(points[0])
-#       v1,v2,v3 = f(points[1])
-#       w1,w2,w3 = f(points[2])
-#       p = [v1 - u1, v2 - u2, v3 - u3]
-#       q = [w1 - u1, w2 - u2, w3 - u3]
-#       r = [p[1]*q[2] - p[2]*q[1], p[2]*q[0] - p[0]*q[2], p[0]*q[1] - p[1]*q[0]]
-#       for ind in xrange(3, len(points)):
-#           s1,s2,s3 = f(points[ind])
-#           test = simplify(r[0]*(s1-u1) + r[1]*(s2-u2) + r[2]*(s3-u3))
-#           if test != 0:
-#               return False
-#       return True
-#       """
-
     def distance(self, p):
         """The Euclidean distance from self to point p.
 

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -87,7 +87,8 @@ class Point(GeometryEntity):
             raise NotImplementedError(
                 "Only two dimensional points currently supported")
         if kwargs.get('evaluate', True):
-            coords = [simplify(nsimplify(c, rational=True)) for c in coords]
+            coords = [simplify(nsimplify(c, rational=True))
+                if isinstance(c, Float) else c for c in coords]
 
         return GeometryEntity.__new__(cls, *coords)
 

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -497,19 +497,19 @@ def test_ellipse():
         [Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 - sqrt(2))),
      Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 + sqrt(2))), ]
 
-    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(0, 0)) == \
-        [Line(Point(0, 0), Point(1, 0)), Line(Point(0, 0), Point(0, 1))]
-    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(1, 0)) == \
-        [Line(Point(1, 0), Point(2, 0))]
-    assert Ellipse(Point(0, 0), 2, 1).normal_lines((0, 1)) == \
-        [Line(Point(0, 1), Point(0, 2))]
-    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(1, 1)) == \
-        [Line(Point(1, 1), Point(Rational(-19602460564453 / 10000000000000, -7935625953651 / 40000000000000))),
-       Line(Point(1, 1), Point(Rational(482864362534199 / 500000000000000, 875695156658093 / 1000000000000000)))]
-    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(sqrt(3), 0.5)) == \
-        [Line(Point(sqrt(3), 1 / 2), Point(Rational(21650635094611 / 12500000000000, 1 / 2))),
-       Line(Point(sqrt(3), 1 / 2), Point(Rational(-7976108716653 / 4000000000000, -772263050363531 / 10000000000000000)))]
-
+    e = Ellipse(Point(0, 0), 2, 1)
+    assert e.normal_lines(Point(0, 0)) == \
+        [Line(Point(0, 0), Point(0, 1)), Line(Point(0, 0), Point(1, 0))]
+    assert e.normal_lines(Point(1, 0)) == \
+        [Line(Point(0, 0), Point(1, 0))]
+    assert e.normal_lines((0, 1)) == \
+        [Line(Point(0, 0), Point(0, 1))]
+    assert e.normal_lines(Point(1, 1), 1) == \
+        [Line(Point(-2, -1/5), Point(-1, 1/5)), Line(Point(1, -9/10), Point(1, 1/10))]
+    p = Point(sqrt(3), S.Half)
+    assert p in e
+    assert e.normal_lines(p, 1) == \
+        [Line(Point(7/4, 1/2), Point(11/4, 1/2)), Line(Point(-2, -26/337), Point(-1, 26/337))]
 
     # Properties
     major = 3

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -373,7 +373,8 @@ def test_line():
     p10 = Point(2000, 2000)
     s1 = Segment(p1, p10)
     p_s1 = s1.random_point()
-    assert p1.x <= p_s1.x and p_s1.x <= p10.x and p1.y <= p_s1.y and p_s1.y <= p10.y
+    assert p1.x <= p_s1.x and p_s1.x <= p10.x and \
+        p1.y <= p_s1.y and p_s1.y <= p10.y
     s2 = Segment(p10, p1)
 
     assert hash(s1) == hash(s2)
@@ -505,16 +506,19 @@ def test_ellipse():
     assert e.normal_lines((0, 1)) == \
         [Line(Point(0, 0), Point(0, 1))]
     assert e.normal_lines(Point(1, 1), 1) == \
-        [Line(Point(-2, -1/5), Point(-1, 1/5)), Line(Point(1, -9/10), Point(2, -43/11))]
-    # this tests the failure of Poly.intervals and checks a point on the boundary
+        [Line(Point(-2, -1/5), Point(-1, 1/5)),
+        Line(Point(1, -9/10), Point(2, -43/11))]
+    # test the failure of Poly.intervals and checks a point on the boundary
     p = Point(sqrt(3), S.Half)
     assert p in e
     assert e.normal_lines(p, 1) == \
-        [Line(Point(7/4, 1/2), Point(11/4, 3/2)), Line(Point(-2, -26/337), Point(-1, 1/8))]
+        [Line(Point(7/4, 1/2), Point(11/4, 3/2)),
+        Line(Point(-2, -26/337), Point(-1, 1/8))]
     # be sure to use the slope that isn't undefined on boundary
     e = Ellipse((0, 0), 2, 2*sqrt(3)/3)
     assert e.normal_lines((1, 1), 1) == \
-        [Line(Point(-2, -1/3), Point(-1, 1/6)), Line(Point(1, -1), Point(2, -4))]
+        [Line(Point(-2, -1/3), Point(-1, 1/6)),
+        Line(Point(1, -1), Point(2, -4))]
 
     # Properties
     major = 3
@@ -695,7 +699,9 @@ def test_polygon():
     warnings.filterwarnings(
         "error", message="Polygons may intersect producing erroneous output")
     raises(UserWarning,
-           lambda: Polygon(Point(0, 0), Point(1, 0), Point(1, 1)).distance(Polygon(Point(0, 0), Point(0, 1), Point(1, 1))))
+           lambda: Polygon(Point(0, 0), Point(1, 0),
+           Point(1, 1)).distance(
+           Polygon(Point(0, 0), Point(0, 1), Point(1, 1))))
     warnings.filterwarnings(
         "ignore", message="Polygons may intersect producing erroneous output")
     assert hash(p5) == hash(Polygon(Point(0, 0), Point(4, 4), Point(0, 4)))
@@ -953,7 +959,7 @@ def test_encloses():
     # square with a dimpled left side
     s = Polygon(Point(0, 0), Point(1, 0), Point(1, 1), Point(0, 1),
         Point(S.Half, S.Half))
-    # the following will be True if the polygon isn't treated as closing on itself
+    # the following is True if the polygon isn't treated as closing on itself
     assert s.encloses(Point(0, S.Half)) is False
     assert s.encloses(Point(S.Half, S.Half)) is False  # it's a vertex
     assert s.encloses(Point(Rational(3, 4), S.Half)) is True

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -504,8 +504,12 @@ def test_ellipse():
     assert Ellipse(Point(0, 0), 2, 1).normal_lines((0, 1)) == \
         [Line(Point(0, 1), Point(0, 2))]
     assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(1, 1)) == \
-        [Line(Point(1, 1), Point(-19602460564453 / 10000000000000, -7935625953651 / 40000000000000)),
-       Line(Point(1, 1), Point(482864362534199 / 500000000000000, 875695156658093 / 1000000000000000))]
+        [Line(Point(1, 1), Point(Rational(-19602460564453 / 10000000000000, -7935625953651 / 40000000000000))),
+       Line(Point(1, 1), Point(Rational(482864362534199 / 500000000000000, 875695156658093 / 1000000000000000)))]
+    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(sqrt(3), 0.5)) == \
+        [Line(Point(sqrt(3), 1 / 2), Point(Rational(21650635094611 / 12500000000000, 1 / 2))),
+       Line(Point(sqrt(3), 1 / 2), Point(Rational(-7976108716653 / 4000000000000, -772263050363531 / 10000000000000000)))]
+
 
     # Properties
     major = 3

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -497,6 +497,16 @@ def test_ellipse():
         [Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 - sqrt(2))),
      Line(Point(5 - 2*sqrt(2), 5), Point(5 - sqrt(2), 5 + sqrt(2))), ]
 
+    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(0, 0)) == \
+        [Line(Point(0, 0), Point(1, 0)), Line(Point(0, 0), Point(0, 1))]
+    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(1, 0)) == \
+        [Line(Point(1, 0), Point(2, 0))]
+    assert Ellipse(Point(0, 0), 2, 1).normal_lines((0, 1)) == \
+        [Line(Point(0, 1), Point(0, 2))]
+    assert Ellipse(Point(0, 0), 2, 1).normal_lines(Point(1, 1)) == \
+        [Line(Point(1, 1), Point(-19602460564453 / 10000000000000, -7935625953651 / 40000000000000)),
+       Line(Point(1, 1), Point(482864362534199 / 500000000000000, 875695156658093 / 1000000000000000))]
+
     # Properties
     major = 3
     minor = 1

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -505,11 +505,16 @@ def test_ellipse():
     assert e.normal_lines((0, 1)) == \
         [Line(Point(0, 0), Point(0, 1))]
     assert e.normal_lines(Point(1, 1), 1) == \
-        [Line(Point(-2, -1/5), Point(-1, 1/5)), Line(Point(1, -9/10), Point(1, 1/10))]
+        [Line(Point(-2, -1/5), Point(-1, 1/5)), Line(Point(1, -9/10), Point(2, -43/11))]
+    # this tests the failure of Poly.intervals and checks a point on the boundary
     p = Point(sqrt(3), S.Half)
     assert p in e
     assert e.normal_lines(p, 1) == \
-        [Line(Point(7/4, 1/2), Point(11/4, 1/2)), Line(Point(-2, -26/337), Point(-1, 26/337))]
+        [Line(Point(7/4, 1/2), Point(11/4, 3/2)), Line(Point(-2, -26/337), Point(-1, 1/8))]
+    # be sure to use the slope that isn't undefined on boundary
+    e = Ellipse((0, 0), 2, 2*sqrt(3)/3)
+    assert e.normal_lines((1, 1), 1) == \
+        [Line(Point(-2, -1/3), Point(-1, 1/6)), Line(Point(1, -1), Point(2, -4))]
 
     # Properties
     major = 3

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -987,7 +987,7 @@ def test_util_centroid():
     assert centroid(p, q) == Point(20, 40)/3
     p = Segment((0, 0), (2, 0))
     q = Segment((0, 0), (2, 2))
-    assert centroid(p, q) == Point(1, 2*sqrt(2)/(2 + 2*sqrt(2)))
+    assert centroid(p, q) == Point(1, -sqrt(2) + 2)
     assert centroid(Point(0, 0), Point(2, 0)) == Point(2, 0)/2
     assert centroid(Point(0, 0), Point(0, 0), Point(2, 0)) == Point(2, 0)/3
 

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -406,7 +406,7 @@ def centroid(*args):
             c = Point(0, 0)
             for g in args:
                 c += g
-            return c/len(args)
+            den = len(args)
         elif all(isinstance(g, Segment) for g in args):
             c = Point(0, 0)
             L = 0
@@ -414,7 +414,7 @@ def centroid(*args):
                 l = g.length
                 c += g.midpoint*l
                 L += l
-            return c/L
+            den = L
         elif all(isinstance(g, Polygon) for g in args):
             c = Point(0, 0)
             A = 0
@@ -422,4 +422,6 @@ def centroid(*args):
                 a = g.area
                 c += g.centroid*a
                 A += a
-            return c/A
+            den = A
+        c /= den
+        return c.func(*[i.simplify() for i in c.args])


### PR DESCRIPTION
I browsed through the ellipse class and found out that there was no method for returning normal lines.So I wrote a simple function which returns normal lines to the ellipse.
- [x] add test case for 3 roots (Fig 2.3 in paper on ellipse normals from http://www.internationalmathematicasymposium.org/IMS99/ims99papers/ims99papers.html)
- [x] add test case for point on ellipse
