### PR TITLE
Complex Numbers: Rectified the output of expand_complex(I*oo)

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -684,17 +684,25 @@ class Mul(Expr, AssocOp):
                         other.append(a)
             else:
                 other.append(a)
-        addre, addim = expand_mul(addterms, deep=False).as_real_imag()
-        m = self.func(*other)
+        m = self.func(*other)        
         if hints.get('ignore') == m:
             return None
-        else:
+        #import ipdb; ipdb.set_trace()
+        if addterms == 1:
+            if m == 1:
+                return (C.re(coeff), C.im(coeff))
+            rem, imm = (C.re(m), C.im(m))
             if coeff.is_real:
-                return (coeff*(C.re(m)*addre - C.im(m)*addim), coeff*(C.im(m)*addre + C.re(m)*addim))
-            else:
-                re = - C.im(coeff)*C.im(m)
-                im = C.im(coeff)*C.re(m)
-                return (re*addre - im*addim, re*addim + im*addre)
+                return (coeff*rem, coeff*imm)
+            imco = C.im(coeff)
+            return (-imco*imm, imco*rem)
+        addre, addim = expand_mul(addterms, deep=False).as_real_imag()
+        if coeff.is_real:
+            return (coeff*(C.re(m)*addre - C.im(m)*addim), coeff*(C.im(m)*addre + C.re(m)*addim))
+        else:
+            re = - C.im(coeff)*C.im(m)
+            im = C.im(coeff)*C.re(m)
+            return (re*addre - im*addim, re*addim + im*addre)
 
     @staticmethod
     def _expandsums(sums):

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -684,10 +684,9 @@ class Mul(Expr, AssocOp):
                         other.append(a)
             else:
                 other.append(a)
-        m = self.func(*other)        
+        m = self.func(*other)
         if hints.get('ignore') == m:
             return None
-        #import ipdb; ipdb.set_trace()
         if addterms == 1:
             if m == 1:
                 return (C.re(coeff), C.im(coeff))

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -690,11 +690,83 @@ class Mul(Expr, AssocOp):
             return None
         else:
             if coeff.is_real:
-                return (coeff*(C.re(m)*addre - C.im(m)*addim), coeff*(C.im(m)*addre + C.re(m)*addim))
+                re = coeff*(C.re(m))
+                im = coeff*(C.im(m))
+                # (re + I*im) is multiplied with (addre + I*addim)
+                if re == 0 and im != 0:
+                    if addre == 0 and addim != 0:
+                        outre = -im*addim
+                        outim = addre    #Zero
+                    elif addim == 0 and addre != 0:
+                        outre = addim    #Zero
+                        outim = im*addre
+                    else:
+                        outre = -im*addim
+                        outim = im*addre
+                elif im == 0 and re != 0:
+                    if addre == 0 and addim != 0:
+                        outre = addre    #Zero
+                        outim = re*addim
+                    elif addim == 0 and addre != 0:
+                        outre = re*addre
+                        outim = addim    #Zero
+                    else:
+                        outre = re*addre
+                        outim = re*addim
+                else:
+                    if addre == 0 and addim != 0:
+                        outre = -im*addim
+                        outim = im*addre
+                    elif addim == 0 and addre != 0:
+                        outre = re*addre
+                        outim = im*addre
+                    else:
+                        outre = re*addre - im*addim
+                        outim = re*addim + im*addre
+                return (outre, outim)
             else:
-                re = - C.im(coeff)*C.im(m)
-                im = C.im(coeff)*C.re(m)
-                return (re*addre - im*addim, re*addim + im*addre)
+                # C.im(coeff) is multiplied with m
+                if C.im(m) == 0 and C.re(m) != 0: # If m is a real number
+                    re = 0
+                    im = C.im(coeff)*C.re(m)
+                elif C.re(m) == 0 and C.im(m) != 0: # If m is purely imaginary
+                    re = -C.im(coeff)*C.im(m)
+                    im = 0
+                else: # If m is a complex number
+                    re = -C.im(coeff)*C.im(m)
+                    im = C.im(coeff)*C.re(m)
+                # (re + I*im) is multiplied with (addre + I*addim)
+                if re == 0 and im != 0:
+                    if addre == 0 and addim != 0:
+                        outre = -im*addim
+                        outim = addre    #Zero
+                    elif addim == 0 and addre != 0:
+                        outre = addim    #Zero
+                        outim = im*addre
+                    else:
+                        outre = -im*addim
+                        outim = im*addre
+                elif im == 0 and re != 0:
+                    if addre == 0 and addim != 0:
+                        outre = addre    #Zero
+                        outim = re*addim
+                    elif addim == 0 and addre != 0:
+                        outre = re*addre
+                        outim = addim    #Zero
+                    else:
+                        outre = re*addre
+                        outim = re*addim
+                else:
+                    if addre == 0 and addim != 0:
+                        outre = -im*addim
+                        outim = im*addre
+                    elif addim == 0 and addre != 0:
+                        outre = re*addre
+                        outim = im*addre
+                    else:
+                        outre = re*addre - im*addim
+                        outim = re*addim + im*addre
+                return (outre, outim)
 
     @staticmethod
     def _expandsums(sums):

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -204,3 +204,7 @@ def test_pow_issue_1724():
 
 def test_issue_2330():
     assert sqrt(I).conjugate() != sqrt(I)
+
+def test_issue_4124():
+    from sympy import oo
+    assert expand_complex(I*oo) == oo*I


### PR DESCRIPTION
  This bug is reported in the issue 4124.

https://code.google.com/p/sympy/issues/detail?id=4124

-> The output of expand_complex(I_oo) earlier was nan (wrong) and is now corrected to oo_I.
-> Modified the way two complex numbers are multiplied in the function as_real_imag() in core/mul.py.
-> This results in the function as_real_imag() returning the correct output.
-> Corner cases like (having 0 and oo are real and imaginary parts) are handled in an effective and different manner which result in correct output.

fixes #4124
