### PR TITLE
2748 mat sym print

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -337,18 +337,19 @@ class MatrixSymbol(MatrixExpr):
     @property 
     def matsym_print(self):
     	"""Returns the symbolic representation of MatrixSymbol of arbitrary size
-		Example
-		========
-		>>>from sympy import *
-		>>>m,n=symbols('m n')
-		>>>A=MatrixSymbol('A',m,n)
-		>>>A=matsym_print
-		[A11, A12, ..., A1n]
-		[A21, A22, ..., A2n]
-		[..., ..., ..., ...]								
-		[Am1, Am2, ..., Amn]
-		"""
-        return ("["+self.args[0]+"11"+", "+str(self.args[0])+"12"+", ..., "+self.args[0]+"1"+str(self.args[2])+"]"+"\n"+"["+self.args[0]+"2"+"1"+", "+str(self.args[0])+"2"+"2"+", ..., "+self.args[0]+"2"+str(self.args[2])+"]"+"\n"+"["+"..., ..., ..., ..."+"]"+"\n"+"["+self.args[0]+str(self.args[1])+"1"+", "+str(self.args[0])+str(self.args[1])+"2"+", ..., "+self.args[0]+str(self.args[1])+str(self.args[2])+"]")
+	Example
+	========
+	>>>from sympy import *
+	>>>m,n=symbols('m n')
+	>>>A=MatrixSymbol('A',m,n)
+	>>>A=matsym_print
+	[A11, A12, ..., A1n]
+	[A21, A22, ..., A2n]
+	[..., ..., ..., ...]								[Am1, Am2, ..., Amn]
+	
+	"""
+	
+	return ("["+self.args[0]+"11"+", "+str(self.args[0])+"12"+", ..., "+self.args[0]+"1"+str(self.args[2])+"]"+"\n"+"["+self.args[0]+"2"+"1"+", "+str(self.args[0])+"2"+"2"+", ..., "+self.args[0]+"2"+str(self.args[2])+"]"+"\n"+"["+"..., ..., ..., ..."+"]"+"\n"+"["+self.args[0]+str(self.args[1])+"1"+", "+str(self.args[0])+str(self.args[1])+"2"+", ..., "+self.args[0]+str(self.args[1])+str(self.args[2])+"]")
 
     def _eval_subs(self, old, new):
         # only do substitutions in shape

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -336,19 +336,18 @@ class MatrixSymbol(MatrixExpr):
 
     @property 
     def matsym_print(self):
-	"""Returns the symbolic representation of MatrixSymbol of arbitrary size
-	Example
-	========
-	>>>from sympy import *
-	>>>m,n=symbols('m n')
-	>>>A=MatrixSymbol('A',m,n)
-	>>>A=matsym_print
-	[A11, A12, ..., A1n]
-	[A21, A22, ..., A2n]
-	[..., ..., ..., ...]
-	[Am1, Am2, ..., Amn]
-	
-	"""
+    	"""Returns the symbolic representation of MatrixSymbol of arbitrary size
+		Example
+		========
+		>>>from sympy import *
+		>>>m,n=symbols('m n')
+		>>>A=MatrixSymbol('A',m,n)
+		>>>A=matsym_print
+		[A11, A12, ..., A1n]
+		[A21, A22, ..., A2n]
+		[..., ..., ..., ...]								
+		[Am1, Am2, ..., Amn]
+		"""
         return ("["+self.args[0]+"11"+", "+str(self.args[0])+"12"+", ..., "+self.args[0]+"1"+str(self.args[2])+"]"+"\n"+"["+self.args[0]+"2"+"1"+", "+str(self.args[0])+"2"+"2"+", ..., "+self.args[0]+"2"+str(self.args[2])+"]"+"\n"+"["+"..., ..., ..., ..."+"]"+"\n"+"["+self.args[0]+str(self.args[1])+"1"+", "+str(self.args[0])+str(self.args[1])+"2"+", ..., "+self.args[0]+str(self.args[1])+str(self.args[2])+"]")
 
     def _eval_subs(self, old, new):

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -334,10 +334,9 @@ class MatrixSymbol(MatrixExpr):
     def name(self):
         return self.args[0]
 
-    @property
+    @property 
     def matsym_print(self):
-        """
-	Returns the symbolic representation of MatrixSymbol of arbotrary size
+	"""Returns the symbolic representation of MatrixSymbol of arbitrary size
 	Example
 	========
 	>>>from sympy import *
@@ -350,7 +349,7 @@ class MatrixSymbol(MatrixExpr):
 	[Am1, Am2, ..., Amn]
 	
 	"""
-	return ("["+self.args[0]+"11"+", "+str(self.args[0])+"12"+", ..., "+self.args[0]+"1"+str(self.args[2])+"]"+"\n"+"["+self.args[0]+"2"+"1"+", "+str(self.args[0])+"2"+"2"+", ..., "+self.args[0]+"2"+str(self.args[2])+"]"+"\n"+"["+"..., ..., ..., ..."+"]"+"\n"+"["+self.args[0]+str(self.args[1])+"1"+", "+str(self.args[0])+str(self.args[1])+"2"+", ..., "+self.args[0]+str(self.args[1])+str(self.args[2])+"]")
+        return ("["+self.args[0]+"11"+", "+str(self.args[0])+"12"+", ..., "+self.args[0]+"1"+str(self.args[2])+"]"+"\n"+"["+self.args[0]+"2"+"1"+", "+str(self.args[0])+"2"+"2"+", ..., "+self.args[0]+"2"+str(self.args[2])+"]"+"\n"+"["+"..., ..., ..., ..."+"]"+"\n"+"["+self.args[0]+str(self.args[1])+"1"+", "+str(self.args[0])+str(self.args[1])+"2"+", ..., "+self.args[0]+str(self.args[1])+str(self.args[2])+"]")
 
     def _eval_subs(self, old, new):
         # only do substitutions in shape

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -334,8 +334,23 @@ class MatrixSymbol(MatrixExpr):
     def name(self):
         return self.args[0]
 
+    @property
     def matsym_print(self):
-    	return ("["+self.args[0]+"1"+", "+self.args[0]+"2"+" ...,"+self.args[0]+self.args[1]+"]")
+        """
+	Returns the symbolic representation of MatrixSymbol of arbotrary size
+	Example
+	========
+	>>>from sympy import *
+	>>>m,n=symbols('m n')
+	>>>A=MatrixSymbol('A',m,n)
+	>>>A=matsym_print
+	[A11, A12, ..., A1n]
+	[A21, A22, ..., A2n]
+	[..., ..., ..., ...]
+	[Am1, Am2, ..., Amn]
+	
+	"""
+	return ("["+self.args[0]+"11"+", "+str(self.args[0])+"12"+", ..., "+self.args[0]+"1"+str(self.args[2])+"]"+"\n"+"["+self.args[0]+"2"+"1"+", "+str(self.args[0])+"2"+"2"+", ..., "+self.args[0]+"2"+str(self.args[2])+"]"+"\n"+"["+"..., ..., ..., ..."+"]"+"\n"+"["+self.args[0]+str(self.args[1])+"1"+", "+str(self.args[0])+str(self.args[1])+"2"+", ..., "+self.args[0]+str(self.args[1])+str(self.args[2])+"]")
 
     def _eval_subs(self, old, new):
         # only do substitutions in shape

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -334,6 +334,9 @@ class MatrixSymbol(MatrixExpr):
     def name(self):
         return self.args[0]
 
+    def matsym_print(self):
+    	return ("["+self.args[0]+"1"+", "+self.args[0]+"2"+" ...,"+self.args[0]+self.args[1]+"]")
+
     def _eval_subs(self, old, new):
         # only do substitutions in shape
         shape = Tuple(*self.shape)._subs(old, new)


### PR DESCRIPTION
http://stackoverflow.com/questions/20885374/sympy-dense-display-of-matrices-of-arbitrary-size

->As mentioned in issue #2748 there is no method in matexp.py to print the symbolic representation of a MatrixSymbol with arbitrary size,ex. m rows and n columns.
->Implemented a function matsym_print to print matrix symbols with symbolic number of rows or columns.
