### PR TITLE
restrict multiplicative extraction of negative sign

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1863,7 +1863,7 @@ class Expr(Basic, EvalfMixin):
             if quotient.is_Mul and len(quotient.args) == 2:
                 if quotient.args[0].is_Integer and quotient.args[0].is_positive and quotient.args[1] == self:
                     return quotient
-            elif quotient.is_Integer:
+            elif quotient.is_Integer and c.is_Number:
                 return quotient
         elif self.is_Add:
             cs, ps = self.primitive()

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -966,6 +966,7 @@ def test_extractions():
     assert (Rational(1, 2)*x).extract_multiplicatively(3) == x/6
     assert (sqrt(x)).extract_multiplicatively(x) is None
     assert (sqrt(x)).extract_multiplicatively(1/x) is None
+    assert x.extract_multiplicatively(-x) is None
 
     assert ((x*y)**3).extract_additively(1) is None
     assert (x + 1).extract_additively(x) == 1


### PR DESCRIPTION
https://code.google.com/p/sympy/issues/detail?id=3973

No tests fail when making this change and it will alleviate confusion about what is supposed to happen during extraction: the underlying form of the expr should not change: so the sign of the expression should not change unless a negative is extracted from a negative expression:

```
>>> (4*x).extract_multiplicatively(-2)  # there's no negative
>>> (-4*x).extract_multiplicatively(-2)
2*x
>>> (-4*x).extract_multiplicatively(2)  # -1*4*x so extract 2 from 4
-2*x
```
