### PR TITLE
WIP: encoded integer polynomials to speed up ``dup_mul`` and ``gf_mul``

### DIFF
--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -14,6 +14,7 @@ from sympy.polys.densebasic import (
 
 from sympy.polys.polyerrors import (ExactQuotientFailed, PolynomialDivisionFailed)
 from sympy.core.compatibility import xrange, HAS_GMPY
+from sympy.mpmath.libmp.libintmath import bitcount
 
 def dup_add_term(f, c, i, K):
     """
@@ -819,7 +820,7 @@ def _dup_pack_mul(f, g, K):
         g = dup_neg(g, K)
         sign = -sign
     p = max(max([abs(x) for x in f]), max([abs(x) for x in g]))
-    N = min(df + 1, dg + 1).bit_length() + 2*p.bit_length() + 1
+    N = bitcount(min(df + 1, dg + 1)) + 2*bitcount(p) + 1
     a = K.one << N
     a2 = a // 2
     mask = a - 1

--- a/sympy/polys/densearith.py
+++ b/sympy/polys/densearith.py
@@ -743,6 +743,12 @@ def _dup_eval1(f, N, K):
         result += c
     return result
 
+if HAS_GMPY == 2:
+    def dup_eval1(f, N, K):
+        from sympy.polys.domains.groundtypes import gmpy_pack
+        f.reverse()
+        r = gmpy_pack(f, N)
+        return r
 
 def dup_mul(f, g, K):
     """

--- a/sympy/polys/domains/groundtypes.py
+++ b/sympy/polys/domains/groundtypes.py
@@ -49,6 +49,7 @@ elif HAS_GMPY == 2:
         lcm as gmpy_lcm,
         isqrt as gmpy_sqrt,
         qdiv as gmpy_qdiv,
+        pack as gmpy_pack
     )
 else:
     class GMPYInteger(object):

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -421,8 +421,6 @@ def dup_zz_zassenhaus(f, K):
     f0 = f
     fc = f[-1]
     A = dup_max_norm(f, K)
-    Brt = int(1 + abs(float(A)/f[0])) + 1
-    Brt1 = 2*n*Brt
     b0 = b = dup_LC(f, K)
     B = int(abs(K.sqrt(K(n + 1))*2**n*A*b))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
@@ -475,7 +473,7 @@ def dup_zz_zassenhaus(f, K):
 
         return factors + [f]
 
-    w = (bitcount(pl) + bitcount(Brt1)) // 2
+    w = (bitcount(pl) + bitcount(2*n) + bitcount(A) - bitcount(f[0])) // 2
     tgv = [None]*r
     trs = [0]*r
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -80,6 +80,7 @@ from math import ceil as _ceil, log as _log
 
 from sympy.core.compatibility import xrange
 from collections import defaultdict
+from sympy.mpmath.libmp.libintmath import bitcount
 
 
 def dup_trial_division(f, factors, K):
@@ -443,7 +444,7 @@ def dup_zz_zassenhaus(f, K):
             continue
         fsqfx = gf_factor_sqf(F, px, K)[1]
         a.append((px, fsqfx))
-        if len(fsqfx) < 15 or len(a) > 4:
+        if len(fsqfx) < 50 or len(a) > 4:
             break
     p, fsqf = min(a, key=lambda x: len(x[1]))
 
@@ -474,7 +475,7 @@ def dup_zz_zassenhaus(f, K):
 
         return factors + [f]
 
-    w = int((_log(pl, 2) + _log(Brt1, 2))/2)
+    w = (bitcount(pl) + bitcount(Brt1)) // 2
     tgv = [None]*r
     trs = [0]*r
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -79,6 +79,7 @@ from sympy.utilities import subsets
 from math import ceil as _ceil, log as _log
 
 from sympy.core.compatibility import xrange
+from collections import defaultdict
 
 
 def dup_trial_division(f, factors, K):
@@ -258,16 +259,170 @@ def _test_pl(fc, q, pl):
         return True
     return fc % q == 0
 
+def dup_get_p(f, n):
+    """
+    compute ``Tr_i = sum root**i`` for ``i=0,..,n``
+    assume that ``f`` is monic
+    ``f = x**d + f_1*x**(d-1) + ... + f_d``
+    Newton identity
+    ``Tr_i = -i*E_i - sum_{k=1}^{i-1} Tr_k*E_{i-k}``
+    where ``E_i = f_i for i <= d, E_i = 0 for i > d``
+    """
+    d = dup_degree(f)
+    if n > d + 1:
+        f = f + [0]*(n - d - 1)
+    pv = [0]*n
+    for i in range(1, n):
+        t = -i*f[i]
+        for k in range(1, i):
+            t -= pv[k]*f[i - k]
+        pv[i] = t
+    pv[0] = 1
+    return pv
+
+def _symmetric_mod(c, m):
+    c = c % m
+    if c > m // 2:
+        c = c - m
+    return c
+
+def subset_gen(a, s, kmin):
+    """
+    generate the s-subsets (combinations) from the sorted list `a`;
+    when in a combination there is one or more elements >= kmin, subsequent
+    combinations which are generated from that by varying only elements
+    >= kmin are skipped.
+
+    Output: ``t, numk``, where ``numk`` is the number of the last ``k``
+    elements occurring in the combination ``t``.
+
+
+    Examples
+    ========
+
+    >>> from c2 import subset_gen
+    >>> for x in subset_gen([2, 3, 5, 7, 10, 12], 3, 7):
+    ...     print x
+    ...
+    ([2, 3, 5], 0)
+    ([2, 3, 7], 1)
+    ([2, 5, 7], 1)
+    ([2, 7, 10], 2)
+    ([3, 5, 7], 1)
+    ([3, 7, 10], 2)
+    ([5, 7, 10], 2)
+    ([7, 10, 12], 3)
+
+    """
+    n = len(a)
+    t = list(range(s))
+    ns = n - s
+    s1 = s - 1
+    while 1:
+        numk = 0
+        j = s - 1
+        while j >= 0:
+            if a[t[j]] < kmin:
+                break
+            else:
+                numk += 1
+            j -= 1
+        yield [a[ii] for ii in t], numk
+        if numk:
+            # `j` is the position of the last element not in `[n-k,..,n-1]`
+            i = j
+        else:
+            i = s1
+        # search from the right the first element which has not maximum value
+        while i >= 0 and t[i] == ns + i:
+            i -= 1
+        if i == -1:
+            raise StopIteration
+        # increase the i-th element by one; the remaining elements are in sequence
+        c = t[i] + 1 - i
+        for j in range(i, s):
+            t[j] = c + j
+
+def _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K):
+    # lift the constant coefficient of the product `G` of the factors
+    # in the subset `S`; if it is does not divide `fc`, `G` does
+    # not divide the input polynomial
+
+    if b == 1:
+        q = 1
+        for i in S:
+            q = q*g[i][-1]
+        q = q % pl
+        if not _test_pl(fc, q, pl):
+            return False
+    else:
+        G = [b]
+        for i in S:
+            G = dup_mul(G, g[i], K)
+        G = dup_trunc(G, pl, K)
+        G1 = dup_primitive(G, K)[1]
+        q = G1[-1]
+        if q and fc % q != 0:
+            return False
+
+    H = [b]
+    S = set(S)
+    T_S = T - S
+
+    if b == 1:
+        G = [b]
+        for i in S:
+            G = dup_mul(G, g[i], K)
+        G = dup_trunc(G, pl, K)
+
+    for i in T_S:
+        H = dup_mul(H, g[i], K)
+
+    H = dup_trunc(H, pl, K)
+
+    G_norm = dup_l1_norm(G, K)
+    H_norm = dup_l1_norm(H, K)
+
+    if G_norm*H_norm <= B:
+        T = T_S
+        sorted_T = [i for i in sorted_T if i not in S]
+
+        G = dup_primitive(G, K)[1]
+        f = dup_primitive(H, K)[1]
+
+        factors.append(G)
+        b = dup_LC(f, K)
+        used |= S
+
+        return b, f, factors, T, sorted_T
+    return False
+
+
 def dup_zz_zassenhaus(f, K):
-    """Factor primitive square-free polynomials in `Z[x]`. """
+    """
+    Factor primitive square-free polynomials in `Z[x]`.
+
+    References
+    ==========
+
+    [1] Gathen99
+    [2] J. Abbott, V. Shoup and P. Zimmermann
+    "Factorization in Z[x]: the Searching Phase",
+    ISSAC 2000 Proceedings, 1-7 (2000)
+    [3] M. van Hoeij "Factoring polynomials and the knapsack problem",
+    J. Number Theory, 95 (2002) 167
+
+    """
     n = dup_degree(f)
 
     if n == 1:
         return [f]
-
+    f0 = f
     fc = f[-1]
     A = dup_max_norm(f, K)
-    b = dup_LC(f, K)
+    Brt = int(1 + abs(float(A)/f[0])) + 1
+    Brt1 = 2*n*Brt
+    b0 = b = dup_LC(f, K)
     B = int(abs(K.sqrt(K(n + 1))*2**n*A*b))
     C = int((n + 1)**(2*n)*A**(2*n - 1))
     gamma = int(_ceil(2*_log(C, 2)))
@@ -302,64 +457,129 @@ def dup_zz_zassenhaus(f, K):
     T = set(sorted_T)
     factors, s = [], 1
     pl = p**l
-
-    while 2*s <= len(T):
-        for S in subsets(sorted_T, s):
-            # lift the constant coefficient of the product `G` of the factors
-            # in the subset `S`; if it is does not divide `fc`, `G` does
-            # not divide the input polynomial
-
-            if b == 1:
-                q = 1
-                for i in S:
-                    q = q*g[i][-1]
-                q = q % pl
-                if not _test_pl(fc, q, pl):
+    r = len(T)
+    used = set()
+    if n < 10:
+        while 2*s <= len(T):
+            for S in subsets(sorted_T, s):
+                ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K)
+                if ret is False:
                     continue
+                else:
+                    b, f, factors, T, sorted_T = ret
+                    break
+
             else:
-                G = [b]
+                s += 1
+
+        return factors + [f]
+
+    w = int((_log(pl, 2) + _log(Brt1, 2))/2)
+    tgv = [None]*r
+    trs = [0]*r
+
+    for ii in range(r):
+        tgv[ii] = dup_get_p(g[ii], 4)
+        trs[ii] = tgv[ii][1] + tgv[ii][2] + tgv[ii][3]
+        #trs[ii] = tgv[ii][1]
+        #trg = dup_get_p(g[ii], 2)
+
+    # ``dynk`` is the number of elements the combinations of which are
+    # stored in dictionaries.
+    # We compute a combination of the sum of the roots and the sum of the
+    # square of the roots (computed with ``dup_get_p``); let ``tr1b`` be
+    # the contribution due to ``dynk`` elements, ``tr1a`` the contributions
+    # of all the other elements. One has
+    # ``-tr1b - B < tr1a < -tr1b + B`` where ``B`` is a bound.
+    # There are ``2**dynk`` such combinations.
+    # Dividing by ``2**w > B`` one gets
+    # ``int(-tr1b/2**w) - 1 <= int(tr1a/2**w) <= int(-tr1b/2**w) + 1``
+    # Therefore one enumerates on th first ``r <= kmax`` elements,
+    # computes ``tr1a = int(tr1a/2**w)``, then one looks if ``tr1a``,
+    # ``tr1a - 1`` or ``tr1a + 1`` are in the dictionary.
+    # This is a variant of pruning test described in [2]; the idea of
+    # taking a combination of the sum of the roots and the sum of the
+    # square of the roots is taken from [3]. The algorithm in [3]
+    # avoids enumerating combinations of modular factors using the LLL
+    # algorithm. It would be nice to implement it.
+
+    dynk = min((len(T))//2 + 1, 23)
+    kmax = max(r - dynk, 0)
+    dyndv = [defaultdict(list) for _ in range(dynk)]
+    # start the searching phase
+    while 2*s <= len(T):
+        if s < dynk and not dyndv[s]:
+            for S in subsets([i for i in sorted_T if i >= kmax], s):
+                tr1b = 0
                 for i in S:
-                    G = dup_mul(G, g[i], K)
-                G = dup_trunc(G, pl, K)
-                G1 = dup_primitive(G, K)[1]
-                q = G1[-1]
-                if q and fc % q != 0:
+                    tr1b += trs[i]
+                tr1b *= b0
+                tr1b = _symmetric_mod(-tr1b, pl)
+                tr1b = int(tr1b >> w)
+                dyndv[s][tr1b].append(list(S))
+            hit = None
+            for kt in dyndv[s]:
+                if abs(kt) <= 1:
+                    a1 = dyndv[s][kt]
+                    for S1b in a1:
+                        ret = _testS1(b, g, pl, fc, S1b, T, sorted_T, B, Brt1, factors, used, K)
+                        if ret is False:
+                            continue
+                        else:
+                            hit = True
+                            break
+                    if hit:
+                        b, f, factors, T, sorted_T = ret
+                        break
+        for S, numk in subset_gen(sorted_T, s, kmax):
+            tr1a = 0
+            for i in S:
+                if i < kmax:
+                    tr1a += trs[i]
+
+            tr1a *= b0
+            tr1a = int(_symmetric_mod(tr1a, pl) >> w)
+            if numk:
+                hit = None
+                for trx in [tr1a, tr1a - 1, tr1a + 1]:
+                    if trx in dyndv[numk]:
+                        S1a = S[:-numk]
+                        a1 = dyndv[numk][trx]
+                        for S1b in a1:
+                            if any(ii in used for ii in S1b):
+                                continue
+                            S = S1a + S1b
+                            ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K)
+                            if ret is False:
+                                continue
+                            else:
+                                hit = True
+                                break
+                        if hit:
+                            break
+                    if hit:
+                        break
+                if hit:
+                    b, f, factors, T, sorted_T = ret
+                    break
+
+
+            else:
+
+                ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K)
+                if ret is False:
                     continue
+                else:
+                    b, f, factors, T, sorted_T = ret
+                    break
 
-            H = [b]
-            S = set(S)
-            T_S = T - S
-
-            if b == 1:
-                G = [b]
-                for i in S:
-                    G = dup_mul(G, g[i], K)
-                G = dup_trunc(G, pl, K)
-
-            for i in T_S:
-                H = dup_mul(H, g[i], K)
-
-            H = dup_trunc(H, pl, K)
-
-            G_norm = dup_l1_norm(G, K)
-            H_norm = dup_l1_norm(H, K)
-
-            if G_norm*H_norm <= B:
-                T = T_S
-                sorted_T = [i for i in sorted_T if i not in S]
-
-                G = dup_primitive(G, K)[1]
-                f = dup_primitive(H, K)[1]
-
-                factors.append(G)
-                b = dup_LC(f, K)
-
-                break
         else:
             s += 1
 
-    return factors + [f]
-
+    if len(f) == 1:
+        return factors
+    else:
+        return factors + [f]
 
 def dup_zz_irreducible_p(f, K):
     """Test irreducibility using Eisenstein's criterion. """

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -44,7 +44,8 @@ from sympy.polys.densearith import (
     dup_max_norm, dmp_max_norm,
     dup_l1_norm,
     dup_mul_ground, dmp_mul_ground,
-    dup_quo_ground, dmp_quo_ground)
+    dup_quo_ground, dmp_quo_ground,
+    dup_pack_mul)
 
 from sympy.polys.densetools import (
     dup_clear_denoms, dmp_clear_denoms,
@@ -171,22 +172,22 @@ def dup_zz_hensel_step(m, f, g, h, s, t, K):
     e = dup_sub_mul(f, g, h, K)
     e = dup_trunc(e, M, K)
 
-    q, r = gf_pack_div(dup_mul(s, e, K), h, M, K)
+    q, r = gf_pack_div(dup_pack_mul(s, e, K), h, M, K)
     q = dup_trunc(q, M, K)
     r = dup_trunc(r, M, K)
 
-    u = dup_add(dup_mul(t, e, K), dup_mul(q, g, K), K)
+    u = dup_add(dup_pack_mul(t, e, K), dup_pack_mul(q, g, K), K)
     G = dup_trunc(dup_add(g, u, K), M, K)
     H = dup_trunc(dup_add(h, r, K), M, K)
 
-    u = dup_add(dup_mul(s, G, K), dup_mul(t, H, K), K)
+    u = dup_add(dup_pack_mul(s, G, K), dup_pack_mul(t, H, K), K)
     b = dup_trunc(dup_sub(u, [K.one], K), M, K)
-    c, d = gf_pack_div(dup_mul(s, b, K), H, M, K)
+    c, d = gf_pack_div(dup_pack_mul(s, b, K), H, M, K)
 
     c = dup_trunc(c, M, K)
     d = dup_trunc(d, M, K)
 
-    u = dup_add(dup_mul(t, b, K), dup_mul(c, G, K), K)
+    u = dup_add(dup_pack_mul(t, b, K), dup_pack_mul(c, G, K), K)
     S = dup_trunc(dup_sub(s, d, K), M, K)
     T = dup_trunc(dup_sub(t, u, K), M, K)
 

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -301,7 +301,7 @@ def subset_gen(a, s, kmin):
     Examples
     ========
 
-    >>> from c2 import subset_gen
+    >>> from sympy.polys.factortools import subset_gen
     >>> for x in subset_gen([2, 3, 5, 7, 10, 12], 3, 7):
     ...     print x
     ...

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -141,7 +141,7 @@ def dmp_zz_mignotte_bound(f, u, K):
     return K.sqrt(K(n + 1))*2**n*a*b
 
 
-def dup_zz_hensel_step(m, f, g, h, s, t, K):
+def dup_zz_hensel_step(M, f, g, h, s, t, K, full=True):
     """
     One step in Hensel lifting in `Z[x]`.
 
@@ -169,9 +169,7 @@ def dup_zz_hensel_step(m, f, g, h, s, t, K):
     1. [Gathen99]_
 
     """
-    M = m**2
-
-    e = dup_sub_mul(f, g, h, K)
+    e = dup_sub(f, dup_pack_mul(g, h, K), K)
     e = dup_trunc(e, M, K)
 
     q, r = gf_pack_div(dup_pack_mul(s, e, K), h, M, K)
@@ -181,6 +179,9 @@ def dup_zz_hensel_step(m, f, g, h, s, t, K):
     u = dup_add(dup_pack_mul(t, e, K), dup_pack_mul(q, g, K), K)
     G = dup_trunc(dup_add(g, u, K), M, K)
     H = dup_trunc(dup_add(h, r, K), M, K)
+
+    if not full:
+        return G, H, None, None
 
     u = dup_add(dup_pack_mul(s, G, K), dup_pack_mul(t, H, K), K)
     b = dup_trunc(dup_sub(u, [K.one], K), M, K)
@@ -247,8 +248,9 @@ def dup_zz_hensel_lift(p, f, f_list, l, K):
     s = gf_to_int_poly(s, p)
     t = gf_to_int_poly(t, p)
 
-    for _ in range(1, d + 1):
-        (g, h, s, t), m = dup_zz_hensel_step(m, f, g, h, s, t, K), m**2
+    for _ in range(1, d):
+        (g, h, s, t), m = dup_zz_hensel_step(m**2, f, g, h, s, t, K), m**2
+    (g, h, s, t) = dup_zz_hensel_step(p**l, f, g, h, s, t, K, False)
 
     return dup_zz_hensel_lift(p, g, f_list[:k], l, K) \
         + dup_zz_hensel_lift(p, h, f_list[k:], l, K)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -303,7 +303,7 @@ def subset_gen(a, s, kmin):
 
     >>> from sympy.polys.factortools import subset_gen
     >>> for x in subset_gen([2, 3, 5, 7, 10, 12], 3, 7):
-    ...     print x
+    ...     print(x)
     ...
     ([2, 3, 5], 0)
     ([2, 3, 7], 1)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -8,7 +8,8 @@ from sympy.polys.galoistools import (
     gf_div, gf_rem,
     gf_gcdex,
     gf_sqf_p,
-    gf_factor_sqf, gf_factor)
+    gf_factor_sqf, gf_factor,
+    gf_pack_div)
 
 from sympy.polys.densebasic import (
     dup_LC, dmp_LC, dmp_ground_LC,
@@ -170,8 +171,7 @@ def dup_zz_hensel_step(m, f, g, h, s, t, K):
     e = dup_sub_mul(f, g, h, K)
     e = dup_trunc(e, M, K)
 
-    q, r = dup_div(dup_mul(s, e, K), h, K)
-
+    q, r = gf_pack_div(dup_mul(s, e, K), h, M, K)
     q = dup_trunc(q, M, K)
     r = dup_trunc(r, M, K)
 
@@ -181,8 +181,7 @@ def dup_zz_hensel_step(m, f, g, h, s, t, K):
 
     u = dup_add(dup_mul(s, G, K), dup_mul(t, H, K), K)
     b = dup_trunc(dup_sub(u, [K.one], K), M, K)
-
-    c, d = dup_div(dup_mul(s, b, K), H, K)
+    c, d = gf_pack_div(dup_mul(s, b, K), H, M, K)
 
     c = dup_trunc(c, M, K)
     d = dup_trunc(d, M, K)

--- a/sympy/polys/factortools.py
+++ b/sympy/polys/factortools.py
@@ -343,7 +343,7 @@ def subset_gen(a, s, kmin):
         for j in range(i, s):
             t[j] = c + j
 
-def _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K):
+def _testS1(b, g, pl, fc, S, T, sorted_T, B, factors, used, K):
     # lift the constant coefficient of the product `G` of the factors
     # in the subset `S`; if it is does not divide `fc`, `G` does
     # not divide the input polynomial
@@ -462,7 +462,7 @@ def dup_zz_zassenhaus(f, K):
     if n < 10:
         while 2*s <= len(T):
             for S in subsets(sorted_T, s):
-                ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K)
+                ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, factors, used, K)
                 if ret is False:
                     continue
                 else:
@@ -522,7 +522,7 @@ def dup_zz_zassenhaus(f, K):
                 if abs(kt) <= 1:
                     a1 = dyndv[s][kt]
                     for S1b in a1:
-                        ret = _testS1(b, g, pl, fc, S1b, T, sorted_T, B, Brt1, factors, used, K)
+                        ret = _testS1(b, g, pl, fc, S1b, T, sorted_T, B, factors, used, K)
                         if ret is False:
                             continue
                         else:
@@ -549,7 +549,7 @@ def dup_zz_zassenhaus(f, K):
                             if any(ii in used for ii in S1b):
                                 continue
                             S = S1a + S1b
-                            ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K)
+                            ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, factors, used, K)
                             if ret is False:
                                 continue
                             else:
@@ -566,7 +566,7 @@ def dup_zz_zassenhaus(f, K):
 
             else:
 
-                ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, Brt1, factors, used, K)
+                ret = _testS1(b, g, pl, fc, S, T, sorted_T, B, factors, used, K)
                 if ret is False:
                     continue
                 else:

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -10,8 +10,6 @@ from sympy.core.mul import prod
 from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
-from sympy.polys.densebasic import dup_strip
-from sympy.polys.densebasic import dup_strip
 from sympy.mpmath.libmp.libintmath import bitcount
 
 from sympy.ntheory import factorint
@@ -555,10 +553,6 @@ def gf_mul(f, g, p, K):
 
         h[i] = coeff % p
 
-    #r1 = gf_mul1(f, g, p, K)
-    #r2 = gf_strip(h)
-    #if r1 != r2:
-    #    print('ERR f=%s\ng=%s\np=%s K=%s\nr1=%s\nr2=%s' %(f, g, p, K, r1, r2))
     return gf_strip(h)
 
 def dup_eval1(f, N, p, K):
@@ -592,7 +586,7 @@ def gf_mul(f, g, p, K):
         a.append((r & mask) % p)
         r >>= N
     a.reverse()
-    return dup_strip(a)
+    return gf_strip(a)
 
 
 def gf_sqr(f, p, K):
@@ -804,7 +798,7 @@ def gf_pack_div(f, g, p, K):
         sf >>= N
     a.reverse()
     qv.reverse()
-    a = dup_strip(a)
+    a = gf_strip(a)
     return qv, a
 
 
@@ -864,7 +858,7 @@ def gf_pack_rem(f, g, p, K):
         a.append((sf & mask) % p)
         sf >>= N
     a.reverse()
-    return dup_strip(a)
+    return gf_strip(a)
 
 gf_rem = gf_pack_rem
 
@@ -1053,7 +1047,7 @@ def gf_unpack(sf, N, mask, p, K):
         a.append((sf & mask) % p)
         sf >>= N
     a.reverse()
-    return dup_strip(a)
+    return gf_strip(a)
 
 
 def gf_frobenius_map(f, g, b, Nb, p, K):
@@ -1620,7 +1614,6 @@ def gf_irred_p_rabin(f, p, K):
     indices = set([ n//d for d in factorint(n) ])
 
     b, Nb = gf_frobenius_monomial_base(f, p, K)
-    #h = b[1]
     mask = (K.one << Nb) - 1
     h = gf_unpack(b[1], Nb, mask, p, K)
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1023,8 +1023,8 @@ def gf_frobenius_monomial_base(g, p, K):
     n = gf_degree(g)
     if n == 0:
         return [], bitcount(p)
-    b = [0]*n
-    b[0] = [1]
+    b = [K.zero]*n
+    b[0] = [K.one]
     if p < n:
         for i in range(1, n):
             mon = gf_lshift(b[i - 1], p, K)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -11,7 +11,7 @@ from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.densebasic import dup_strip
-from sympy.polys.densearith import _dup_eval1
+from sympy.polys.densebasic import dup_strip
 
 from sympy.ntheory import factorint
 
@@ -525,13 +525,6 @@ def gf_sub(f, g, p, K):
 
         return h + [ (a - b) % p for a, b in zip(f, g) ]
 
-def gf_eval1(f, p, N, K):
-    result = K.zero
-    for c in f:
-        result <<= N
-        result += c % p
-    return result
-
 
 def gf_mul(f, g, p, K):
     """
@@ -546,19 +539,43 @@ def gf_mul(f, g, p, K):
     >>> gf_mul([3, 2, 4], [2, 2, 2], 5, ZZ)
     [1, 0, 3, 2, 3]
 
-    See Also
-    ========
-
-    sympy.polys.densearith.dup_pack_mul
     """
+    df = gf_degree(f)
+    dg = gf_degree(g)
+
+    dh = df + dg
+    h = [0]*(dh + 1)
+
+    for i in xrange(0, dh + 1):
+        coeff = K.zero
+
+        for j in xrange(max(0, i - dg), min(i, df) + 1):
+            coeff += f[j]*g[i - j]
+
+        h[i] = coeff % p
+
+    #r1 = gf_mul1(f, g, p, K)
+    #r2 = gf_strip(h)
+    #if r1 != r2:
+    #    print('ERR f=%s\ng=%s\np=%s K=%s\nr1=%s\nr2=%s' %(f, g, p, K, r1, r2))
+    return gf_strip(h)
+
+def dup_eval1(f, N, p, K):
+    result = K.zero
+    for c in f:
+        result <<= N
+        result += c % p
+    return result
+
+def gf_mul(f, g, p, K):
     df = gf_degree(f)
     dg = gf_degree(g)
     N = min(df + 1, dg + 1).bit_length() + 2*p.bit_length()
     #N = (max(df + 1, dg + 1)*p**2).bit_length() + 1
     a = K.one << N
     mask = a - 1
-    sf = gf_eval1(f, p, N, K)
-    sg = gf_eval1(g, p, N, K)
+    sf = dup_eval1(f, N, p, K)
+    sg = dup_eval1(g, N, p, K)
     r = sf*sg
     a = []
 
@@ -567,6 +584,7 @@ def gf_mul(f, g, p, K):
         r >>= N
     a.reverse()
     return dup_strip(a)
+
 
 def gf_sqr(f, p, K):
     """
@@ -741,9 +759,9 @@ def gf_pack_div(f, g, p, K):
     inv = K.invert(lcg, p)
     q = (lcf * inv) % p
 
-    sf = _dup_eval1(f, N, K)
-    g1 = [(-x) % p for x in g]
-    sgneg = _dup_eval1(g1, N, K)
+    sf = dup_eval1(f, N, p, K)
+    g1 = [(-x) for x in g]
+    sgneg = dup_eval1(g1, N, p, K)
     qv = [K.zero]*(df - dg + 1)
     while df >= dg or df == dg and lcf >= lcg:
         q = (lcf * inv) % p
@@ -797,6 +815,49 @@ def gf_rem(f, g, p, K):
     """
     return gf_div(f, g, p, K)[1]
 
+def gf_pack_rem(f, g, p, K):
+    df = gf_degree(f)
+    dg = gf_degree(g)
+    N = min(df + 1, dg + 1).bit_length() + 2*p.bit_length()
+    if df < dg:
+        return f
+    lcf = gf_LC(f, K)
+    lcg = gf_LC(g, K)
+    inv = K.invert(lcg, p)
+    q = (lcf * inv) % p
+    sf = dup_eval1(f, N, p, K)
+    g1 = [(-x) % p for x in g]
+    sgneg = dup_eval1(g1, N, p, K)
+    while df >= dg or df == dg and lcf >= lcg:
+        q = (lcf * inv) % p
+        sf += q*sgneg << ((df - dg)*N)
+        sf = sf & ((1<<(N*df)) - 1)
+        if sf == 0:
+            return []
+        df -= 1
+        lcf = (sf >> (N*df)) % p
+        if not lcf:
+            sf = sf & ((1<<(N*df)) - 1)
+            if sf == 0:
+                return []
+            df -= 1
+            lcf = (sf >> (N*df)) % p
+            if not lcf:
+                while not lcf:
+                    sf = sf & ((1<<(N*df)) - 1)
+                    if sf == 0:
+                        return []
+                    df -= 1
+                    lcf = (sf >> (N*df)) % p
+    mask = (K.one << N) - 1
+    a = []
+    while sf:
+        a.append((sf & mask) % p)
+        sf >>= N
+    a.reverse()
+    return dup_strip(a)
+
+gf_rem = gf_pack_rem
 
 def gf_quo(f, g, p, K):
     """
@@ -944,7 +1005,7 @@ def gf_pow(f, n, p, K):
 def gf_frobenius_monomial_base(g, p, K):
     """
     return the list of ``x**(i*p) mod g in Z_p`` for ``i = 0, .., n - 1``
-    where ``n = gf_degree(g)``
+    in packed form, and the number of bits used in packing.
 
     Examples
     ========
@@ -952,13 +1013,13 @@ def gf_frobenius_monomial_base(g, p, K):
     >>> from sympy.polys.domains import ZZ
     >>> from sympy.polys.galoistools import gf_frobenius_monomial_base
     >>> g = ZZ.map([1, 0, 2, 1])
-    >>> gf_frobenius_monomial_base(g, 5, ZZ)
-    [[1], [4, 4, 2], [1, 2]]
-
+    >>> b, Nb = gf_frobenius_monomial_base(g, 5, ZZ)
+    >>> map(int, b), Nb
+    ([1, 4198402, 1026], 10)
     """
     n = gf_degree(g)
     if n == 0:
-        return []
+        return [], p.bit_length()
     b = [0]*n
     b[0] = [1]
     if p < n:
@@ -971,9 +1032,24 @@ def gf_frobenius_monomial_base(g, p, K):
             b[i] = gf_mul(b[i - 1], b[1], p, K)
             b[i] = gf_rem(b[i], g, p, K)
 
-    return b
+    # FIXME n*p**2 < Nb in a multiplication of polynomials of degree n
+    # doing n successive multiplications, one needs n**2*p**2 < Nb
+    Nb = 2*n.bit_length() + 2*p.bit_length()
+    b = [dup_eval1(bx, Nb, p, K) for bx in b]
+    return b, Nb
 
-def gf_frobenius_map(f, g, b, p, K):
+def gf_unpack(sf, N, mask, p, K):
+    #print('DB20 sf=%s N=%s p=%s' %(sf, N, p))
+    a = []
+    while sf:
+        #print('DB21', sf, mask, (sf & mask), (sf & mask) % p)
+        a.append((sf & mask) % p)
+        sf >>= N
+    a.reverse()
+    return dup_strip(a)
+
+
+def gf_frobenius_map(f, g, b, Nb, p, K):
     """
     compute gf_pow_mod(f, p, g, p, K) using the Frobenius map
 
@@ -993,25 +1069,33 @@ def gf_frobenius_map(f, g, b, p, K):
     >>> f = ZZ.map([2, 1 , 0, 1])
     >>> g = ZZ.map([1, 0, 2, 1])
     >>> p = 5
-    >>> b = gf_frobenius_monomial_base(g, p, ZZ)
-    >>> r = gf_frobenius_map(f, g, b, p, ZZ)
-    >>> gf_frobenius_map(f, g, b, p, ZZ)
+    >>> b, Nb = gf_frobenius_monomial_base(g, p, ZZ)
+    >>> map(int, gf_frobenius_map(f, g, b, Nb, p, ZZ))
     [4, 0, 3]
     """
     m = gf_degree(g)
     if gf_degree(f) >= m:
-        f = gf_pack_div(f, g, p, K)[1]
-        f = [y%p for y in f]
+        f = gf_rem(f, g, p, K)
     if not f:
         return []
     n = gf_degree(f)
-    sf = [f[-1]]
+    mask = (K.one << Nb) - 1
+    #print('DB0 f=%s g=%s b=%s p=%s' %(f,g,b,p))
+    #print ('DB2 N=', N, mask)
+    # TODO change b in pb, avoid computing it at each call
+    #sf = [f[-1]]
+    r = f[-1]
     for i in range(1, n + 1):
-        v = gf_mul_ground(b[i], f[n - i], p, K)
-        sf = gf_add(sf, v, p, K)
-    return sf
+        #v = gf_mul_ground(b[i], f[n - i], p, K)
+        #sf = gf_add(sf, v, p, K)
+        r += b[i]*f[n - i]
+    #print('DB8 r=', r)
+    sf1 = gf_unpack(r, Nb, mask, p, K)
+    #print('DB9 sf=%s sf1=%s' %(sf, sf1))
+    #assert sf == sf1
+    return sf1
 
-def _gf_pow_pnm1d2(f, n, g, b, p, K):
+def _gf_pow_pnm1d2(f, n, g, b, Nb, p, K):
     """
     utility function for ``gf_edf_zassenhaus``
     Compute ``f**((p**n - 1) // 2)`` in ``GF(p)[x]/(g)``
@@ -1021,10 +1105,9 @@ def _gf_pow_pnm1d2(f, n, g, b, p, K):
     h = f
     r = f
     for i in range(1, n):
-        h = gf_frobenius_map(h, g, b, p, K)
+        h = gf_frobenius_map(h, g, b, Nb, p, K)
         r = gf_mul(r, h, p, K)
-        r = gf_pack_div(r, g, p, K)[1]
-        r = [y % p for y in r]
+        r = gf_rem(r, g, p, K)
 
     res = gf_pow_mod(r, (p - 1)//2, g, p, K)
     return res
@@ -1417,7 +1500,7 @@ def gf_trace_map(a, b, c, n, f, p, K):
 
     return gf_compose_mod(a, V, f, p, K), U
 
-def _gf_trace_map(f, n, g, b, p, K):
+def _gf_trace_map(f, n, g, b, Nb, p, K):
     """
     utility for ``gf_edf_shoup``
     """
@@ -1425,7 +1508,7 @@ def _gf_trace_map(f, n, g, b, p, K):
     h = f
     r = f
     for i in range(1, n):
-        h = gf_frobenius_map(h, g, b, p, K)
+        h = gf_frobenius_map(h, g, b, Nb, p, K)
         r = gf_add(r, h, p, K)
         r = gf_rem(r, g, p, K)
     return r
@@ -1499,12 +1582,12 @@ def gf_irred_p_ben_or(f, p, K):
             else:
                 return False
     else:
-        b = gf_frobenius_monomial_base(f, p, K)
-        H = h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
+        b, Nb = gf_frobenius_monomial_base(f, p, K)
+        H = h = gf_frobenius_map([K.one, K.zero], f, b, Nb, p, K)
         for i in xrange(0, n//2):
             g = gf_sub(h, [K.one, K.zero], p, K)
             if gf_gcd(f, g, p, K) == [K.one]:
-                h = gf_frobenius_map(h, f, b, p, K)
+                h = gf_frobenius_map(h, f, b, Nb, p, K)
             else:
                 return False
 
@@ -1538,8 +1621,10 @@ def gf_irred_p_rabin(f, p, K):
 
     indices = set([ n//d for d in factorint(n) ])
 
-    b = gf_frobenius_monomial_base(f, p, K)
-    h = b[1]
+    b, Nb = gf_frobenius_monomial_base(f, p, K)
+    #h = b[1]
+    mask = (K.one << Nb) - 1
+    h = gf_unpack(b[1], Nb, mask, p, K)
 
     for i in xrange(1, n):
         if i in indices:
@@ -1548,7 +1633,7 @@ def gf_irred_p_rabin(f, p, K):
             if gf_gcd(f, g, p, K) != [K.one]:
                 return False
 
-        h = gf_frobenius_map(h, f, b, p, K)
+        h = gf_frobenius_map(h, f, b, Nb, p, K)
 
     return h == x
 
@@ -1904,9 +1989,9 @@ def gf_ddf_zassenhaus(f, p, K):
     """
     i, g, factors = 1, [K.one, K.zero], []
 
-    b = gf_frobenius_monomial_base(f, p, K)
+    b, Nb = gf_frobenius_monomial_base(f, p, K)
     while 2*i <= gf_degree(f):
-        g = gf_frobenius_map(g, f, b, p, K)
+        g = gf_frobenius_map(g, f, b, Nb, p, K)
         h = gf_gcd(f, gf_sub(g, [K.one, K.zero], p, K), p, K)
 
         if h != [K.one]:
@@ -1914,7 +1999,7 @@ def gf_ddf_zassenhaus(f, p, K):
 
             f = gf_quo(f, h, p, K)
             g = gf_rem(g, f, p, K)
-            b = gf_frobenius_monomial_base(f, p, K)
+            b, Nb = gf_frobenius_monomial_base(f, p, K)
 
         i += 1
 
@@ -1956,7 +2041,7 @@ def gf_edf_zassenhaus(f, n, p, K):
 
     N = gf_degree(f) // n
     if p != 2:
-        b = gf_frobenius_monomial_base(f, p, K)
+        b, Nb = gf_frobenius_monomial_base(f, p, K)
 
     while len(factors) < N:
         r = gf_random(2*n - 1, p, K)
@@ -1970,7 +2055,7 @@ def gf_edf_zassenhaus(f, n, p, K):
 
             g = gf_gcd(f, h, p, K)
         else:
-            h = _gf_pow_pnm1d2(r, n, f, b, p, K)
+            h = _gf_pow_pnm1d2(r, n, f, b, Nb, p, K)
             g = gf_gcd(f, gf_sub_ground(h, K.one, p, K), p, K)
 
         if g != [K.one] and g != f:
@@ -2014,13 +2099,13 @@ def gf_ddf_shoup(f, p, K):
     """
     n = gf_degree(f)
     k = int(_ceil(_sqrt(n//2)))
-    b = gf_frobenius_monomial_base(f, p, K)
-    h = gf_frobenius_map([K.one, K.zero], f, b, p, K)
+    b, Nb = gf_frobenius_monomial_base(f, p, K)
+    h = gf_frobenius_map([K.one, K.zero], f, b, Nb, p, K)
     # U[i] = x**(p**i)
     U = [[K.one, K.zero], h] + [K.zero]*(k - 1)
 
     for i in xrange(2, k + 1):
-        U[i] = gf_frobenius_map(U[i-1], f, b, p, K)
+        U[i] = gf_frobenius_map(U[i-1], f, b, Nb, p, K)
 
     h, U = U[k], U[:k]
     # V[i] = x**(p**(k*(i+1)))
@@ -2104,8 +2189,8 @@ def gf_edf_shoup(f, n, p, K):
         factors = gf_edf_shoup(h1, n, p, K) \
             + gf_edf_shoup(h2, n, p, K)
     else:
-        b = gf_frobenius_monomial_base(f, p, K)
-        H = _gf_trace_map(r, n, f, b, p, K)
+        b, Nb = gf_frobenius_monomial_base(f, p, K)
+        H = _gf_trace_map(r, n, f, b, Nb, p, K)
         h = gf_pow_mod(H, (q - 1)//2, f, p, K)
 
         h1 = gf_gcd(f, h, p, K)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division
 from random import uniform
 from math import ceil as _ceil, sqrt as _sqrt
 
-from sympy.core.compatibility import SYMPY_INTS, xrange
+from sympy.core.compatibility import SYMPY_INTS, xrange, HAS_GMPY
 from sympy.core.mul import prod
 from sympy.polys.polyutils import _sort_factors
 from sympy.polys.polyconfig import query
@@ -567,6 +567,15 @@ def dup_eval1(f, N, p, K):
         result <<= N
         result += c % p
     return result
+
+if HAS_GMPY == 2:
+    def dup_eval1(f, N, p, K):
+        from sympy.polys.domains.groundtypes import gmpy_pack
+        f = [x % p for x in f]
+        f.reverse()
+        r = gmpy_pack(f, N)
+        return r
+
 
 def gf_mul(f, g, p, K):
     df = gf_degree(f)

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1014,7 +1014,7 @@ def gf_frobenius_monomial_base(g, p, K):
     >>> from sympy.polys.galoistools import gf_frobenius_monomial_base
     >>> g = ZZ.map([1, 0, 2, 1])
     >>> b, Nb = gf_frobenius_monomial_base(g, 5, ZZ)
-    >>> map(int, b), Nb
+    >>> b, Nb
     ([1, 4198402, 1026], 10)
     """
     n = gf_degree(g)
@@ -1039,10 +1039,8 @@ def gf_frobenius_monomial_base(g, p, K):
     return b, Nb
 
 def gf_unpack(sf, N, mask, p, K):
-    #print('DB20 sf=%s N=%s p=%s' %(sf, N, p))
     a = []
     while sf:
-        #print('DB21', sf, mask, (sf & mask), (sf & mask) % p)
         a.append((sf & mask) % p)
         sf >>= N
     a.reverse()
@@ -1070,7 +1068,7 @@ def gf_frobenius_map(f, g, b, Nb, p, K):
     >>> g = ZZ.map([1, 0, 2, 1])
     >>> p = 5
     >>> b, Nb = gf_frobenius_monomial_base(g, p, ZZ)
-    >>> map(int, gf_frobenius_map(f, g, b, Nb, p, ZZ))
+    >>> gf_frobenius_map(f, g, b, Nb, p, ZZ)
     [4, 0, 3]
     """
     m = gf_degree(g)
@@ -1080,19 +1078,10 @@ def gf_frobenius_map(f, g, b, Nb, p, K):
         return []
     n = gf_degree(f)
     mask = (K.one << Nb) - 1
-    #print('DB0 f=%s g=%s b=%s p=%s' %(f,g,b,p))
-    #print ('DB2 N=', N, mask)
-    # TODO change b in pb, avoid computing it at each call
-    #sf = [f[-1]]
     r = f[-1]
     for i in range(1, n + 1):
-        #v = gf_mul_ground(b[i], f[n - i], p, K)
-        #sf = gf_add(sf, v, p, K)
         r += b[i]*f[n - i]
-    #print('DB8 r=', r)
     sf1 = gf_unpack(r, Nb, mask, p, K)
-    #print('DB9 sf=%s sf1=%s' %(sf, sf1))
-    #assert sf == sf1
     return sf1
 
 def _gf_pow_pnm1d2(f, n, g, b, Nb, p, K):

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -12,6 +12,7 @@ from sympy.polys.polyconfig import query
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.densebasic import dup_strip
 from sympy.polys.densebasic import dup_strip
+from sympy.mpmath.libmp.libintmath import bitcount
 
 from sympy.ntheory import factorint
 
@@ -570,8 +571,7 @@ def dup_eval1(f, N, p, K):
 def gf_mul(f, g, p, K):
     df = gf_degree(f)
     dg = gf_degree(g)
-    N = min(df + 1, dg + 1).bit_length() + 2*p.bit_length()
-    #N = (max(df + 1, dg + 1)*p**2).bit_length() + 1
+    N = bitcount(min(df + 1, dg + 1)) + 2*bitcount(p)
     a = K.one << N
     mask = a - 1
     sf = dup_eval1(f, N, p, K)
@@ -750,7 +750,7 @@ def gf_pack_div(f, g, p, K):
     """
     df = gf_degree(f)
     dg = gf_degree(g)
-    N = min(df + 1, dg + 1).bit_length() + 2*p.bit_length() + 1
+    N = bitcount(min(df + 1, dg + 1)) + 2*bitcount(p) + 1
     if df < dg:
         return [], f
     f = [x % p for x in f]
@@ -818,7 +818,7 @@ def gf_rem(f, g, p, K):
 def gf_pack_rem(f, g, p, K):
     df = gf_degree(f)
     dg = gf_degree(g)
-    N = min(df + 1, dg + 1).bit_length() + 2*p.bit_length()
+    N = bitcount(min(df + 1, dg + 1)) + 2*bitcount(p)
     if df < dg:
         return f
     lcf = gf_LC(f, K)
@@ -1019,7 +1019,7 @@ def gf_frobenius_monomial_base(g, p, K):
     """
     n = gf_degree(g)
     if n == 0:
-        return [], p.bit_length()
+        return [], bitcount(p)
     b = [0]*n
     b[0] = [1]
     if p < n:
@@ -1032,9 +1032,9 @@ def gf_frobenius_monomial_base(g, p, K):
             b[i] = gf_mul(b[i - 1], b[1], p, K)
             b[i] = gf_rem(b[i], g, p, K)
 
-    # FIXME n*p**2 < Nb in a multiplication of polynomials of degree n
+    # n*p**2 < Nb in a multiplication of polynomials of degree n
     # doing n successive multiplications, one needs n**2*p**2 < Nb
-    Nb = 2*n.bit_length() + 2*p.bit_length()
+    Nb = 2*bitcount(n) + 2*bitcount(p)
     b = [dup_eval1(bx, Nb, p, K) for bx in b]
     return b, Nb
 

--- a/sympy/polys/galoistools.py
+++ b/sympy/polys/galoistools.py
@@ -1000,7 +1000,8 @@ def gf_frobenius_map(f, g, b, p, K):
     """
     m = gf_degree(g)
     if gf_degree(f) >= m:
-        f = gf_rem(f, g, p, K)
+        f = gf_pack_div(f, g, p, K)[1]
+        f = [y%p for y in f]
     if not f:
         return []
     n = gf_degree(f)
@@ -1022,7 +1023,8 @@ def _gf_pow_pnm1d2(f, n, g, b, p, K):
     for i in range(1, n):
         h = gf_frobenius_map(h, g, b, p, K)
         r = gf_mul(r, h, p, K)
-        r = gf_rem(r, g, p, K)
+        r = gf_pack_div(r, g, p, K)[1]
+        r = [y % p for y in r]
 
     res = gf_pow_mod(r, (p - 1)//2, g, p, K)
     return res

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -35,7 +35,7 @@ from sympy.polys.orthopolys import dup_chebyshevt
 
 from sympy.polys.rings import ring
 
-from sympy.polys.ring_series import rs_compose_add
+from sympy.polys.ring_series import rs_compose_add, rs_composed_product
 
 from sympy.printing.lambdarepr import LambdaPrinter
 
@@ -270,15 +270,24 @@ def _minpoly_op_algebraic_element(op, ex1, ex2, x, dom, mp1=None, mp2=None):
             mp1a = r.as_expr()
 
     elif op is Mul:
-        mp1a = _muly(mp1, x, y)
+        if dom == QQ:
+            R, X = ring('X', QQ)
+            p1 = R(dict_from_expr(mp1)[0])
+            p2 = R(dict_from_expr(mp2)[0])
+        else:
+            mp1a = _muly(mp1, x, y)
     else:
         raise NotImplementedError('option not available')
 
-    if op is Mul or dom != QQ:
-        r = resultant(mp1a, mp2, gens=[y, x])
+    if dom == QQ:
+        if op is Mul:
+            r = rs_composed_product(p1, p2)
+            r = expr_from_dict(r.as_expr_dict(), x)
+        else:
+            r = rs_compose_add(p1, p2)
+            r = expr_from_dict(r.as_expr_dict(), x)
     else:
-        r = rs_compose_add(p1, p2)
-        r = expr_from_dict(r.as_expr_dict(), x)
+        r = resultant(mp1a, mp2, gens=[y, x])
 
     deg1 = degree(mp1, x)
     deg2 = degree(mp2, y)

--- a/sympy/polys/numberfields.py
+++ b/sympy/polys/numberfields.py
@@ -300,6 +300,20 @@ def _minpoly_op_algebraic_element(op, ex1, ex2, x, dom, mp1=None, mp2=None):
         return r
 
     r = Poly(r, x, domain=dom)
+    if dom == QQ:
+        a = r.rep.rep
+        n = len(a)
+        i = n - 1
+        while a[i] == 0:
+            i -= 1
+        num_zeros = n - i - 1
+        if num_zeros:
+            r = r.from_list(a[:i + 1], x)
+            factors = [(x, num_zeros), (r, 1)]
+            res = _choose_factor(factors, x, op(ex1, ex2), dom)
+            if res == x:
+                return x
+
     _, factors = r.factor_list()
     res = _choose_factor(factors, x, op(ex1, ex2), dom)
     return res.as_expr()
@@ -380,15 +394,26 @@ def _minpoly_pow(ex, pw, x, dom, mp=None):
     return res.as_expr()
 
 
+def _minpoly_add_rec(x, dom, *a):
+    n = len(a)
+    assert n
+    if n == 1:
+        return a[0]
+    elif n == 2:
+        ex1, mp1 = a[0]
+        ex2, mp2 = a[1]
+        mp = _minpoly_op_algebraic_element(Add, ex1, ex2, x, dom, mp1=mp1, mp2=mp2)
+        return ex1 + ex2, mp
+    else:
+        ex1, mp1 = _minpoly_add_rec(x, dom, *a[:n//2])
+        ex2, mp2 = _minpoly_add_rec(x, dom, *a[n//2:])
+        mp = _minpoly_op_algebraic_element(Add, ex1, ex2, x, dom, mp1=mp1, mp2=mp2)
+        return ex1 + ex2, mp
+
+
 def _minpoly_add(x, dom, *a):
-    """
-    returns ``minpoly(Add(*a), dom, x)``
-    """
-    mp = _minpoly_op_algebraic_element(Add, a[0], a[1], x, dom)
-    p = a[0] + a[1]
-    for px in a[2:]:
-        mp = _minpoly_op_algebraic_element(Add, p, px, x, dom, mp1=mp)
-        p = p + px
+    b = [(ex, None) for ex in a]
+    r, mp = _minpoly_add_rec(x, dom, *b)
     return mp
 
 

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1,0 +1,598 @@
+"""Power series manipulating functions acting on polys.ring.PolyElement()"""
+
+from sympy.polys.domains import QQ
+from sympy.polys.rings import ring, PolyElement
+from sympy.polys.monomials import monomial_min, monomial_mul
+from sympy.mpmath.libmp.libintmath import ifac
+from sympy.core.numbers import Rational
+from sympy.core.compatibility import as_int
+import math
+
+def _invert_monoms(p1):
+    """
+    Compute ``x**n * p1(1/x)`` for ``p1`` univariate polynomial.
+
+    Example
+    =======
+
+    >>> from sympy.polys.domains import ZZ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import _invert_monoms
+    >>> R, x = ring('x', ZZ)
+    >>> p = x**2 + 2*x + 3
+    >>> _invert_monoms(p)
+    3*x**2 + 2*x + 1
+
+    See Also
+    ========
+    sympy.polys.densebasic.dup_reverse
+
+    """
+    terms = list(p1.items())
+    terms.sort()
+    deg = p1.degree()
+    ring = p1.ring
+    p = ring.zero
+    cv = p1.listcoeffs()
+    mv = p1.listmonoms()
+    for i in range(len(mv)):
+        p[(deg - mv[i][0],)] = cv[i]
+    return p
+
+def _giant_steps(target):
+    """
+    list of precision steps for the Newton's method
+
+    code adapted from mpmath/libmp/libintmath.py
+    """
+    L = [target]
+    start = 2
+    while 1:
+        Li = L[-1]//2 + 2
+        if Li >= L[-1] or Li < start:
+            if L[-1] != start:
+                L.append(start)
+            break
+        L.append(Li)
+    return L[::-1]
+
+def rs_trunc(p1, x, prec):
+    """
+    truncate the series in the ``x`` variable with precision ``prec``,
+    that is modulo ``O(x**prec)``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_trunc
+    >>> R, x = ring('x', QQ)
+    >>> p = x**10 + x**5 + x + 1
+    >>> rs_trunc(p, x, 12)
+    x**10 + x**5 + x + 1
+    >>> rs_trunc(p, x, 10)
+    x**5 + x + 1
+    """
+
+    ring = p1.ring
+    p = ring.zero
+    i = ring.gens.index(x)
+    for exp1 in p1:
+        if exp1[i] >= prec:
+            continue
+        p[exp1] = p1[exp1]
+    return p
+
+
+def rs_mul(p1, p2, x, prec):
+    """
+    product of series modulo ``O(x**prec)``
+
+    ``x`` is the series variable or its position in the generators.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_mul
+    >>> R, x = ring('x', QQ)
+    >>> p1 = x**2 + 2*x + 1
+    >>> p2 = x + 1
+    >>> rs_mul(p1, p2, x, 3)
+    3*x**2 + 3*x + 1
+    """
+
+    ring = p1.ring
+    p = ring.zero
+    if ring.__class__ != p2.ring.__class__ or ring != p2.ring:
+        raise ValueError('p1 and p2 must have the same ring')
+    iv = ring.gens.index(x)
+    if not isinstance(p2, PolyElement):
+        raise ValueError('p1 and p2 must have the same ring')
+    if ring == p2.ring:
+        get = p.get
+        items2 = list(p2.items())
+        items2.sort(key=lambda e: e[0][iv])
+        if ring.ngens == 1:
+            for exp1, v1 in p1.items():
+                for exp2, v2 in items2:
+                    exp = exp1[0] + exp2[0]
+                    if exp < prec:
+                        exp = (exp, )
+                        p[exp] = get(exp, 0) + v1*v2
+                    else:
+                        break
+        else:
+            monomial_mul = ring.monomial_mul
+            for exp1, v1 in p1.items():
+                for exp2, v2 in items2:
+                    if exp1[iv] + exp2[iv] < prec:
+                        exp = monomial_mul(exp1, exp2)
+                        p[exp] = get(exp, 0) + v1*v2
+                    else:
+                        break
+
+    p.strip_zero()
+    return p
+
+def rs_square(p1, x, prec):
+    """
+    square modulo ``O(x**prec)``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_square
+    >>> R, x = ring('x', QQ)
+    >>> p = x**2 + 2*x + 1
+    >>> rs_square(p, x, 3)
+    6*x**2 + 4*x + 1
+    """
+    ring = p1.ring
+    p = ring.zero
+    iv = ring.gens.index(x)
+    get = p.get
+    items = list(p1.items())
+    items.sort(key=lambda e: e[0][iv])
+    monomial_mul = ring.monomial_mul
+    for i in range(len(items)):
+        exp1, v1 = items[i]
+        for j in range(i):
+            exp2, v2 = items[j]
+            if exp1[iv] + exp2[iv] < prec:
+                exp = monomial_mul(exp1, exp2)
+                p[exp] = get(exp, 0) + v1*v2
+            else:
+                break
+    p = p.imul_num(2)
+    get = p.get
+    for expv, v in p1.items():
+        if 2*expv[iv] < prec:
+            e2 = monomial_mul(expv, expv)
+            p[e2] = get(e2, 0) + v**2
+    p.strip_zero()
+    return p
+
+def rs_pow(p1, n, x, prec):
+    """
+    return ``p1**n`` modulo ``O(x**prec)``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_pow
+    >>> R, x = ring('x', QQ)
+    >>> p = x + 1
+    >>> rs_pow(p, 4, x, 3)
+    6*x**2 + 4*x + 1
+    """
+    R = p1.ring
+    p = R.zero
+    if isinstance(n, Rational):
+        raise NotImplementedError('to be implemented')
+
+    n = as_int(n)
+    if n == 0:
+        if p1:
+            return R(1)
+        else:
+            raise ValueError('0**0 is undefined')
+    if n < 0:
+        p1 = rs_pow(p1, -n, x, prec)
+        return rs_series_inversion(p1, x, prec)
+    if n == 1:
+        return rs_trunc(p1, x, prec)
+    if n == 2:
+        return rs_square(p1, x, prec)
+    if n == 3:
+        p2 = rs_square(p1, x, prec)
+        return rs_mul(p1, p2, x, prec)
+    p = R(1)
+    while 1:
+        if n&1:
+            p = rs_mul(p1, p, x, prec)
+            n -= 1
+            if not n:
+                break
+        p1 = rs_square(p1, x, prec)
+        n = n // 2
+    return p
+
+def _has_constant_term(p, x):
+    """
+    test if ``p`` has a constant term in ``x``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import _has_constant_term
+    >>> R, x = ring('x', QQ)
+    >>> p = x**2 + x + 1
+    >>> _has_constant_term(p, x)
+    True
+    """
+    ring = p.ring
+    iv = ring.gens.index(x)
+    zm = ring.zero_monom
+    a = [0]*ring.ngens
+    a[iv] = 1
+    miv = tuple(a)
+    for expv in p:
+        if monomial_min(expv, miv) == zm:
+            return True
+    return False
+
+def _series_inversion1(p, x, prec):
+    """
+    univariate series inversion ``1/p`` modulo ``O(x**prec)``
+
+    The Newton method is used.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import _series_inversion1
+    >>> R, x = ring('x', QQ)
+    >>> p = x + 1
+    >>> _series_inversion1(p, x, 4)
+    -x**3 + x**2 - x + 1
+
+    """
+    ring = p.ring
+    zm = ring.zero_monom
+    if zm not in p:
+        raise ValueError('no constant term in series')
+    if _has_constant_term(p - p[zm], x):
+        raise ValueError('p cannot contain a constant term depending on parameters')
+    if p[zm] != ring(1):
+        # TODO add check that it is a unit
+        p1 = ring(1)/p[zm]
+    else:
+        p1 = ring(1)
+    for precx in _giant_steps(prec):
+        tmp = p1.square()
+        tmp = rs_mul(tmp, p, x, precx)
+        p1 = 2*p1 - tmp
+    return p1
+
+def rs_series_inversion(p, x, prec):
+    """
+    multivariate series inversion ``1/p`` modulo ``O(x**prec)``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_series_inversion
+    >>> R, x, y = ring('x, y', QQ)
+    >>> rs_series_inversion(1 + x*y**2, x, 4)
+    -x**3*y**6 + x**2*y**4 - x*y**2 + 1
+    >>> rs_series_inversion(1 + x*y**2, y, 4)
+    -x*y**2 + 1
+    """
+    ring = p.ring
+    zm = ring.zero_monom
+    ii = ring.gens.index(x)
+    m = min(p, key=lambda k: k[ii])[ii]
+    if m:
+        raise NotImplementedError('no constant term in series')
+    if zm not in p:
+        raise NotImplementedError('no constant term in series')
+    if _has_constant_term(p - p[zm], x):
+        raise NotImplementedError('p - p[0] must not have a constant term in the series variables')
+    return _series_inversion1(p, x, prec)
+
+def rs_series_from_list(p, c, x, prec, concur=1):
+    """
+    series ``sum c[n]*p**n`` modulo ``O(x**prec)``
+
+    reduce the number of multiplication summing concurrently
+    ``ax = [1, p, p**2, .., p**(J - 1)]``
+    ``s = sum(c[i]*ax[i] for i in range(r, (r + 1)*J))*p**((K - 1)*J)``
+    with ``K >= (n + 1)/J``
+
+    Examples
+    ========
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_series_from_list, rs_trunc
+    >>> R, x = ring('x', QQ)
+    >>> p = x**2 + x + 1
+    >>> c = [1, 2, 3]
+    >>> rs_series_from_list(p, c, x, 4)
+    6*x**3 + 11*x**2 + 8*x + 6
+    >>> rs_trunc(1 + 2*p + 3*p**2, x, 4)
+    6*x**3 + 11*x**2 + 8*x + 6
+    >>> pc = R.from_list(list(reversed(c)))
+    >>> rs_trunc(pc.compose(x, p), x, 4)
+    6*x**3 + 11*x**2 + 8*x + 6
+
+    See Also
+    ========
+    sympy.polys.ring.compose
+
+    """
+
+    ring = p.ring
+    n = len(c)
+    if not concur:
+        q = ring(1)
+        s = c[0]*q
+        for i in range(1, n):
+            q = rs_mul(q, p, x, prec)
+            s += c[i]*q
+        return s
+    J = int(math.sqrt(n) + 1)
+    K, r = divmod(n, J)
+    if r:
+        K += 1
+    ax = [ring(1)]
+    b = 1
+    q = ring(1)
+    if len(p) < 20:
+        for i in range(1, J):
+            q = rs_mul(q, p, x, prec)
+            ax.append(q)
+    else:
+        for i in range(1, J):
+            if i % 2 == 0:
+                q = rs_square(ax[i//2], x, prec)
+            else:
+                q = rs_mul(q, p, x, prec)
+            ax.append(q)
+    # optimize using rs_square
+    pj = rs_mul(ax[-1], p, x, prec)
+    b = ring(1)
+    s = ring(0)
+    for k in range(K - 1):
+        r = J*k
+        s1 = c[r]
+        for j in range(1, J):
+            s1 += c[r + j]*ax[j]
+        s1 = rs_mul(s1, b, x, prec)
+        s += s1
+        b = rs_mul(b, pj, x, prec)
+        if not b:
+            break
+    k = K - 1
+    r = J*k
+    if r < n:
+        s1 = c[r]*ring(1)
+        for j in range(1, J):
+            if r + j >= n:
+                break
+            s1 += c[r + j]*ax[j]
+        s1 = rs_mul(s1, b, x, prec)
+        s += s1
+    return s
+
+def rs_integrate(self, x):
+    """
+    integrate ``p`` with respect to ``x``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_integrate
+    >>> R, x, y = ring('x, y', QQ)
+    >>> p = x + x**2*y**3
+    >>> rs_integrate(p, x)
+    1/3*x**3*y**3 + 1/2*x**2
+    """
+    ring = self.ring
+    p1 = ring.zero
+    n = ring.gens.index(x)
+    mn = [0]*ring.ngens
+    mn[n] = 1
+    mn = tuple(mn)
+
+    for expv in self:
+        e = monomial_mul(expv, mn)
+        p1[e] = self[expv]/(expv[n] + 1)
+    return p1
+
+def rs_log(p, x, prec):
+    """
+    logarithm of ``p`` modulo ``O(x**prec)``
+
+    Notes
+    =====
+
+    truncation of ``integral dx p**-1*d p/dx`` is used.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_log
+    >>> R, x = ring('x', QQ)
+    >>> rs_log(1 + x, x, 8)
+    1/7*x**7 - 1/6*x**6 + 1/5*x**5 - 1/4*x**4 + 1/3*x**3 - 1/2*x**2 + x
+    """
+    ring = p.ring
+    if p == 1:
+        return 0
+    if _has_constant_term(p - 1, x):
+        raise NotImplementedError('p - 1 must not have a constant term in the series variables')
+    dlog = p.diff(x)
+    dlog = rs_mul(dlog, _series_inversion1(p, x, prec), x, prec - 1)
+    return rs_integrate(dlog, x)
+
+def _exp1(p, x, prec):
+    """
+    helper function for ``rs_exp``
+    """
+    ring = p.ring
+    p1 = ring(1)
+    for precx in _giant_steps(prec):
+        pt = p - rs_log(p1, x, precx)
+        tmp = rs_mul(pt, p1, x, precx)
+        p1 += tmp
+    return p1
+
+def rs_exp(p, x, prec):
+    """
+    exponentiation of a series modulo ``O(x**prec)``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_exp
+    >>> R, x = ring('x', QQ)
+    >>> rs_exp(x**2, x, 7)
+    1/6*x**6 + 1/2*x**4 + x**2 + 1
+    """
+    ring = p.ring
+    if _has_constant_term(p, x):
+        raise NotImplementedError
+    if len(p) > 20:
+        return _exp1(p, x, prec)
+    one = ring(1)
+    n = 1
+    k = 1
+    c = []
+    for k in range(prec):
+        c.append(one/n)
+        k += 1
+        n *= k
+
+    r = rs_series_from_list(p, c, x, prec)
+    return r
+
+def rs_newton(p, x, prec):
+    """
+    compute the truncated Newton sum of the polynomial ``p``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_newton
+    >>> R, x = ring('x', QQ)
+    >>> p = x**2 - 2
+    >>> rs_newton(p, x, 5)
+    8*x**4 + 4*x**2 + 2
+    """
+    deg = p.degree()
+    p1 = _invert_monoms(p)
+    p2 = rs_series_inversion(p1, x, prec)
+    p3 = rs_mul(p1.diff(x), p2, x, prec)
+    res = deg - p3*x
+    return res
+
+def rs_hadamard_exp(p1, inverse=False):
+    """
+    return ``sum f_i/i!*x**i`` from ``sum f_i*x**i``,
+    where ``x`` is the first variable.
+
+    If ``invers=True`` return ``sum f_i*i!*x**i``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_hadamard_exp
+    >>> R, x = ring('x', QQ)
+    >>> p = 1 + x + x**2 + x**3
+    >>> rs_hadamard_exp(p)
+    1/6*x**3 + 1/2*x**2 + x + 1
+    """
+    R = p1.ring
+    if R.domain != QQ:
+        raise NotImplementedError
+    p = R.zero
+    if not inverse:
+        for exp1, v1 in p1.items():
+            p[exp1] = v1/int(ifac(exp1[0]))
+    else:
+        for exp1, v1 in p1.items():
+            p[exp1] = v1*int(ifac(exp1[0]))
+    return p
+
+def rs_compose_add(p1, p2):
+    """
+    compute the composed sum ``prod(p2(x - beta) for beta root of p1)``
+
+    Examples
+    ========
+
+    >>> from sympy.polys.domains import QQ
+    >>> from sympy.polys.rings import ring
+    >>> from sympy.polys.ring_series import rs_compose_add
+    >>> R, x = ring('x', QQ)
+    >>> f = x**2 - 2
+    >>> g = x**2 - 3
+    >>> rs_compose_add(f, g)
+    x**4 - 10*x**2 + 1
+
+    References
+    ==========
+
+    A. Bostan, P. Flajolet, B. Salvy and E. Schost
+    "Fast Computation with Two Algebraic Numbers",
+    (2002) Research Report 4579, Institut
+    National de Recherche en Informatique et en Automatique
+    """
+    R = p1.ring
+    x = R.gens[0]
+    prec = p1.degree() * p2.degree() + 1
+    np1 = rs_newton(p1, x, prec)
+    np1e = rs_hadamard_exp(np1)
+    np2 = rs_newton(p2, x, prec)
+    np2e = rs_hadamard_exp(np2)
+    np3e = rs_mul(np1e, np2e, x, prec)
+    np3 = rs_hadamard_exp(np3e, True)
+    np3a = (np3[(0,)] - np3)/x
+    q = rs_integrate(np3a, x)
+    q = rs_exp(q, x, prec)
+    q = _invert_monoms(q)
+    q = q.primitive()[1]
+    dp = p1.degree() * p2.degree() - q.degree()
+    # `dp` is the multiplicity of the zeroes of the resultant;
+    # these zeroes are missed in this computation so they are put here.
+    # if p1 and p2 are monic irreducible polynomials,
+    # there are zeroes in the resultant
+    # if and only if p1 = p2 ; in fact in that case p1 and p2 have a
+    # root in common, so gcd(p1, p2) != 1; being p1 and p2 irreducible
+    # this means p1 = p2
+    if dp:
+        q = q*x**dp
+    return q

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -527,7 +527,7 @@ def rs_newton(p, x, prec):
 def rs_hadamard_product(p1, p2):
     ring = p1.ring
     p = ring.zero
-    for exp1, v1 in p1.iteritems():
+    for exp1, v1 in p1.items():
         if exp1 in p2:
             v = v1*p2[exp1]
             p[exp1] = v

--- a/sympy/polys/tests/test_factortools.py
+++ b/sympy/polys/tests/test_factortools.py
@@ -45,7 +45,7 @@ def test_dup_zz_hensel_step():
     s = -2
     t = 2*x**2 - 2*x - 1
 
-    G, H, S, T = R.dup_zz_hensel_step(5, f, g, h, s, t)
+    G, H, S, T = R.dup_zz_hensel_step(25, f, g, h, s, t)
 
     assert G == x**3 + 7*x**2 - x - 7
     assert H == x - 7

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -28,7 +28,7 @@ from sympy.polys.galoistools import (
 )
 
 from sympy.polys.polyerrors import (
-    ExactQuotientFailed,
+    ExactQuotientFailed, NotInvertible,
 )
 
 from sympy.polys import polyconfig as config
@@ -227,7 +227,7 @@ def test_gf_arith():
 
 def test_gf_division():
     raises(ZeroDivisionError, lambda: gf_div([1, 2, 3], [], 11, ZZ))
-    raises(ZeroDivisionError, lambda: gf_rem([1, 2, 3], [], 11, ZZ))
+    raises((ZeroDivisionError, NotInvertible), lambda: gf_rem([1, 2, 3], [], 11, ZZ))
     raises(ZeroDivisionError, lambda: gf_quo([1, 2, 3], [], 11, ZZ))
     raises(ZeroDivisionError, lambda: gf_quo([1, 2, 3], [], 11, ZZ))
 
@@ -522,8 +522,8 @@ def test_gf_frobenius_map():
     g = ZZ.map([1,1,0,2,0,1,0,2,0,1])
     p = 3
     n = 4
-    b = gf_frobenius_monomial_base(g, p, ZZ)
-    h = gf_frobenius_map(f, g, b, p, ZZ)
+    b, Nb = gf_frobenius_monomial_base(g, p, ZZ)
+    h = gf_frobenius_map(f, g, b, Nb, p, ZZ)
     h1 = gf_pow_mod(f, p, g, p, ZZ)
     assert h == h1
 

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -1,0 +1,169 @@
+from sympy import Rational
+from sympy.polys.domains import ZZ, QQ
+from sympy.polys.rings import ring
+from sympy.polys.ring_series import (_invert_monoms, rs_integrate,
+  rs_trunc, rs_mul, rs_square, rs_pow, _has_constant_term,
+  rs_series_inversion, rs_series_from_list, rs_exp, rs_log, rs_newton,
+  rs_hadamard_exp, rs_compose_add)
+from sympy.utilities.pytest import raises
+
+def test_ring_series1():
+    R, x = ring('x', QQ)
+    p = x**4 + 2*x**3 + 3*x + 4
+    assert _invert_monoms(p) == 4*x**4 + 3*x**3 + 2*x + 1
+    assert rs_hadamard_exp(p) == x**4/24 + x**3/3 + 3*x + 4
+    R, x = ring('x', QQ)
+    p = x**4 + 2*x**3 + 3*x + 4
+    assert rs_integrate(p, x) == x**5/5 + x**4/2 + 3*x**2/2 + 4*x
+    R, x, y = ring('x, y', QQ)
+    p = x**2*y**2 + x + 1
+    assert rs_integrate(p, x) == x**3*y**2/3 + x**2/2 + x
+    assert rs_integrate(p, y) == x**2*y**3/3 + x*y + y
+
+def test_trunc():
+    R, x, y, t = ring('x, y, t', QQ)
+    p = (y + t*x)**4
+    p1 = rs_trunc(p, x, 3)
+    assert p1 == y**4 + 4*y**3*t*x + 6*y**2*t**2*x**2
+
+def test_mul_trunc():
+    R, x, y, t = ring('x, y, t', QQ)
+    p = 1 + t*x + t*y
+    for i in range(2):
+        p = rs_mul(p, p, t, 3)
+
+    assert p == 6*x**2*t**2 + 12*x*y*t**2 + 6*y**2*t**2 + 4*x*t + 4*y*t + 1
+    p = 1 + t*x + t*y + t**2*x*y
+    p1 = rs_mul(p, p, t, 2)
+    assert p1 == 1 + 2*t*x + 2*t*y
+    R1, z = ring('z', QQ)
+    def test1(p):
+        p2 = rs_mul(p, z, x, 2)
+    raises(ValueError, lambda: test1(p))
+
+    p1 = 2 + 2*x + 3*x**2
+    p2 = 3 + x**2
+    assert rs_mul(p1, p2, x, 4) == 2*x**3 + 11*x**2 + 6*x + 6
+
+def test_square_trunc():
+    R, x, y, t = ring('x, y, t', QQ)
+    p = (1 + t*x + t*y)*2
+    p1 = rs_mul(p, p, x, 3)
+    p2 = rs_square(p, x, 3)
+    assert p1 == p2
+    p = 1 + x + x**2 + x**3
+    assert rs_square(p, x, 4) == 4*x**3 + 3*x**2 + 2*x + 1
+
+def test_pow_trunc():
+    R, x, y, z = ring('x, y, z', QQ)
+    p0 = y + x*z
+    p = p0**16
+    for xx in (x, y, z):
+        p1 = rs_trunc(p, xx, 8)
+        p2 = rs_pow(p0, 16, xx, 8)
+        assert p1 == p2
+
+    p = 1 + x
+    p1 = rs_pow(p, 3, x, 2)
+    assert p1 == 1 + 3*x
+    assert rs_pow(p, 0, x, 2) == 1
+    assert rs_pow(p, -2, x, 2) == 1 - 2*x
+    p = x + y
+    assert rs_pow(p, 3, y, 3) == x**3 + 3*x**2*y + 3*x*y**2
+
+def test_has_constant_term():
+    R, x, y, z = ring('x, y, z', QQ)
+    p = y + x*z
+    assert _has_constant_term(p, x)
+    p = x + x**4
+    assert not _has_constant_term(p, x)
+    p = 1 + x + x**4
+    assert _has_constant_term(p, x)
+    p = x + y + x*z
+
+def test_inversion():
+    R, x = ring('x', QQ)
+    p = 2 + x + 2*x**2
+    n = 5
+    p1 = rs_series_inversion(p, x, n)
+    assert rs_trunc(p*p1, x, n) == 1
+    R, x, y = ring('x, y', QQ)
+    p = 2 + x + 2*x**2 + y*x + x**2*y
+    p1 = rs_series_inversion(p, x, n)
+    assert rs_trunc(p*p1, x, n) == 1
+
+    R, x, y = ring('x, y', QQ)
+    p = 1 + x + y
+    def test2(p):
+        p1 = rs_series_inversion(p, x, 4)
+    raises(NotImplementedError, lambda: test2(p))
+
+def test_series_from_list():
+    R, x = ring('x', QQ)
+    p = 1 + 2*x + x**2 + 3*x**3
+    c = [1, 2, 0, 4, 4]
+    r = rs_series_from_list(p, c, x, 5)
+    pc = R.from_list(list(reversed(c)))
+    r1 = rs_trunc(pc.compose(x, p), x, 5)
+    assert r == r1
+    R, x, y = ring('x, y', QQ)
+    c = [1, 3, 5, 7]
+    p1 = rs_series_from_list(x + y, c, x, 3, concur=0)
+    p2 = rs_trunc((1 + 3*(x+y) + 5*(x+y)**2 + 7*(x+y)**3), x, 3)
+    assert p1 == p2
+
+    R, x = ring('x', QQ)
+    h = 25
+    p = rs_exp(x, x, h) - 1
+    p1 = rs_series_from_list(p, c, x, h)
+    p2 = 0
+    for i, cx in enumerate(c):
+        p2 += cx*rs_pow(p, i, x, h)
+    assert p1 == p2
+
+def test_log():
+    R, x = ring('x', QQ)
+    p = 1 + x
+    p1 = rs_log(p, x, 4)
+    assert p1 == x - x**2/2 + x**3/3
+    p = 1 + x +2*x**2/3
+    p1 = rs_log(p, x, 9)
+    assert p1 == -17*x**8/648 + 13*x**7/189 - 11*x**6/162 - x**5/45 + \
+      7*x**4/36 - x**3/3 + x**2/6 + x
+    p2 = rs_series_inversion(p, x, 9)
+    p3 = rs_log(p2, x, 9)
+    assert p3 == -p1
+
+    R, x, y = ring('x, y', QQ)
+    p = 1 + x + 2*y*x**2
+    p1 = rs_log(p, x, 6)
+    assert p1 == 4*x**5*y**2 - 2*x**5*y - 2*x**4*y**2 + x**5/5 + 2*x**4*y - x**4/4 - 2*x**3*y + x**3/3 + 2*x**2*y - x**2/2 + x
+
+def test_exp():
+    R, x = ring('x', QQ)
+    p = x + x**4
+    for h in [10, 30]:
+        q = rs_series_inversion(1 + p, x, h) - 1
+        p1 = rs_exp(q, x, h)
+        q1 = rs_log(p1, x, h)
+        assert q1 == q
+    p1 = rs_exp(p, x, 30)
+    assert p1.coeff(x**29) == QQ(74274246775059676726972369, 353670479749588078181744640000)
+    prec = 21
+    p = rs_log(1 + x, x, prec)
+    p1 = rs_exp(p, x, prec)
+    assert p1 == x + 1
+
+
+def test_newton():
+    R, x = ring('x', QQ)
+    p = x**2 - 2
+    r = rs_newton(p, x, 4)
+    f = [1, 0, -2]
+    assert r == 8*x**4 + 4*x**2 + 2
+
+def test_compose_add():
+    R, x = ring('x', QQ)
+    p1 = x**3 - 1
+    p2 = x**2 - 2
+    assert rs_compose_add(p1, p2) == x**6 - 6*x**4 - 2*x**3 + 12*x**2 - 12*x - 7


### PR DESCRIPTION
Used encoded polynomials to speed up the modular factorization of integer polynomials.
The speed-up tends to be larger for polynomials in which the modular factorization  takes long
time.  This is typical in the computation of minimal polynomials.

For instance  `minpoly('sqrt(1 + 2**(1/5)) + 2**(1/5)*sqrt(1 + 2**(1/10))') takes`
(time in seconds; 1. python with gmpy; 2. python in python mode; 3. pypy)

```
        master     mp5      mul2
1      8.1          5.0       1.8
2      13           6.6       2.8
3      12           6.5       4.0
```

The case mp5 of https://github.com/sympy/sympy/pull/2630  is included for comparison; PR 2630 uses composed sum instead of the resultant in minpoly; it is included in this branch.

In this branch I put also some other optimizations, with the purpose of speeding up `minpoly`.
