### PR TITLE
Better detection of zero-equivalence in calculate_series()

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -458,7 +458,7 @@ def calculate_series(e, x, logx=None):
     for t in e.lseries(x, logx=logx):
         t = cancel(t)
 
-        if t:
+        if t.simplify():
             break
 
     return t


### PR DESCRIPTION
This pr, most likely, fixes the problem with test_wester.py/gruntz.py timeouts, mentioned in #2846.  See also [my comment](https://github.com/sympy/sympy/pull/2846#issuecomment-33573790) in that thread.
