### PR TITLE
watch out for E in exptrigsimp

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -4197,7 +4197,7 @@ def exptrigsimp(expr, simplify=True):
     for ei in ex:
         e2 = ei**-2
         if e2 in ex:
-            a = e2.args[0]/2
+            a = e2.args[0]/2 if not e2 is S.Exp1 else S.Half
             newexpr = newexpr.subs((e2 + 1)*ei, 2*cosh(a))
             newexpr = newexpr.subs((e2 - 1)*ei, 2*sinh(a))
     ## exp ratios to tan and tanh

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1853,3 +1853,6 @@ def test_trigsimp_methods_gh2827():
     M = Matrix.eye(1)
     assert all(trigsimp(M, method=m) == M for m in
         'fu matching groebner old'.split())
+    # watch for E in exptrigsimp, not only exp()
+    eq = 1/sqrt(E) + E
+    assert exptrigsimp(eq) == eq


### PR DESCRIPTION
Since E and exp are being collected, an error can happen when e2 is E because then it has no args (but the arg of E should be 1 (if it were exp() instead of E).
