### PR TITLE
Intersection method of Ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1060,12 +1060,13 @@ class Ellipse(GeometryEntity):
 
         """
 
+        from sympy.utilities.iterables import uniq
         x = Dummy('x', real = True)
         y = Dummy('y', real = True)
         seq = self.equation(x, y)
         oeq = o.equation(x, y)
         re = solve([seq, oeq], [x, y])
-        result = list(set(re))
+        result = list(uniq(re))
         return [Point(*r) for r in result]
 
     def intersection(self, o):

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1116,7 +1116,7 @@ class Ellipse(GeometryEntity):
         >>> e.intersection(Ellipse(Point(100500, 0), 4, 3))
         []
         >>> e.intersection(Ellipse(Point(0, 0), 3, 4))
-        [Point(-363/175, -48*sqrt(111)/175),Point(-363/175, 48*sqrt(111)/175),Point(3, 0)]
+        [Point(-363/175, -48*sqrt(111)/175), Point(-363/175, 48*sqrt(111)/175), Point(3, 0)]
 
         >>> e.intersection(Ellipse(Point(-1, 0), 3, 4))
         [Point(-17/5, -12/5), Point(-17/5, 12/5), Point(7/5, -12/5), Point(7/5, 12/5)]

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1059,8 +1059,9 @@ class Ellipse(GeometryEntity):
         Private helper method for `intersection`.
 
         """
-        x = Dummy('x')
-        y = Dummy('y')
+
+        x = Dummy('x', real = True)
+        y = Dummy('y', real = True)
         seq = self.equation(x, y)
         oeq = o.equation(x, y)
         re = solve([seq, oeq], [x, y])
@@ -1108,17 +1109,16 @@ class Ellipse(GeometryEntity):
         []
         >>> e = Ellipse(Point(-1, 0), 4, 3)
         >>> e.intersection(Ellipse(Point(1, 0), 4, 3))
-        [Point(0, -3*sqrt(15)/4), Point(0, 3*sqrt(15)/4)]
+        [Point(0, 3*sqrt(15)/4), Point(0, -3*sqrt(15)/4)]
         >>> e.intersection(Ellipse(Point(5, 0), 4, 3))
         [Point(2, -3*sqrt(7)/4), Point(2, 3*sqrt(7)/4)]
         >>> e.intersection(Ellipse(Point(100500, 0), 4, 3))
         []
         >>> e.intersection(Ellipse(Point(0, 0), 3, 4))
-        [Point(-363/175, -48*sqrt(111)/175), Point(-363/175, 48*sqrt(111)/175),
-        Point(3, 0)]
+        [Point(3, 0),Point(-363/175, -48*sqrt(111)/175),Point(-363/175, 48*sqrt(111)/175)]
+
         >>> e.intersection(Ellipse(Point(-1, 0), 3, 4))
-        [Point(-17/5, -12/5), Point(-17/5, 12/5), Point(7/5, -12/5),
-        Point(7/5, 12/5)]
+        [Point(-17/5, -12/5), Point(-17/5, 12/5), Point(7/5, -12/5), Point(7/5, 12/5)]
         """
         if isinstance(o, Point):
             if o in self:

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1110,13 +1110,13 @@ class Ellipse(GeometryEntity):
         []
         >>> e = Ellipse(Point(-1, 0), 4, 3)
         >>> e.intersection(Ellipse(Point(1, 0), 4, 3))
-        [Point(0, 3*sqrt(15)/4), Point(0, -3*sqrt(15)/4)]
+        [Point(0, -3*sqrt(15)/4), Point(0, 3*sqrt(15)/4)]
         >>> e.intersection(Ellipse(Point(5, 0), 4, 3))
         [Point(2, -3*sqrt(7)/4), Point(2, 3*sqrt(7)/4)]
         >>> e.intersection(Ellipse(Point(100500, 0), 4, 3))
         []
         >>> e.intersection(Ellipse(Point(0, 0), 3, 4))
-        [Point(3, 0),Point(-363/175, -48*sqrt(111)/175),Point(-363/175, 48*sqrt(111)/175)]
+        [Point(-363/175, -48*sqrt(111)/175),Point(-363/175, 48*sqrt(111)/175),Point(3, 0)]
 
         >>> e.intersection(Ellipse(Point(-1, 0), 3, 4))
         [Point(-17/5, -12/5), Point(-17/5, 12/5), Point(7/5, -12/5), Point(7/5, 12/5)]

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -18,6 +18,7 @@ from sympy.geometry.exceptions import GeometryError
 from sympy.polys import Poly, PolynomialError
 from sympy.solvers import solve
 from sympy.utilities.lambdify import lambdify
+from sympy.utilities.iterables import uniq
 from .entity import GeometryEntity
 from .point import Point
 from .line import LinearEntity, Line
@@ -1060,14 +1061,13 @@ class Ellipse(GeometryEntity):
 
         """
 
-        from sympy.utilities.iterables import uniq
-        x = Dummy('x', real = True)
-        y = Dummy('y', real = True)
+        x = Dummy('x', real=True)
+        y = Dummy('y', real=True)
         seq = self.equation(x, y)
         oeq = o.equation(x, y)
         re = solve([seq, oeq], [x, y])
-        result = list(uniq(re))
-        return [Point(*r) for r in result]
+        return list(uniq(re))
+
 
     def intersection(self, o):
         """The intersection of this ellipse and another geometrical entity

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1053,33 +1053,8 @@ class Ellipse(GeometryEntity):
 
         return [r for r in result if r in o]
 
-    def _do_circle_intersection(self, o):
-        """The intersection of an Ellipse and a Circle.
-
-        Private helper method for `intersection`.
-
-        """
-        variables = self.equation().atoms(C.Symbol)
-        if len(variables) > 2:
-            return None
-        if self.center == o.center:
-            a, b, r = o.major, o.minor, self.radius
-            x = a*sqrt(simplify((r**2 - b**2)/(a**2 - b**2)))
-            y = b*sqrt(simplify((a**2 - r**2)/(a**2 - b**2)))
-            return list(set([Point(x, y), Point(x, -y), Point(-x, y),
-                             Point(-x, -y)]))
-        else:
-            x, y = variables
-            xx = solve(self.equation(), x)
-            intersect = []
-            for xi in xx:
-                yy = solve(o.equation().subs(x, xi), y)
-                for yi in yy:
-                    intersect.append(Point(xi, yi))
-            return list(set(intersect))
-
     def _do_ellipse_intersection(self, o):
-        """The intersection of two ellipses.
+        """The intersection of an ellipse with another ellipse or a circle.
 
         Private helper method for `intersection`.
 
@@ -1088,8 +1063,9 @@ class Ellipse(GeometryEntity):
         y = Dummy('y')
         seq = self.equation(x, y)
         oeq = o.equation(x, y)
-        result = solve([seq, oeq], [x, y])
-        return [Point(*r) for r in result if im(r[0]).is_zero is not False and im(r[1]).is_zero is not False]
+        re = solve([seq, oeq], [x, y])
+        result = list(set(re))
+        return [Point(*r) for r in result]
 
     def intersection(self, o):
         """The intersection of this ellipse and another geometrical entity
@@ -1156,7 +1132,7 @@ class Ellipse(GeometryEntity):
             return self._do_line_intersection(o)
 
         elif isinstance(o, Circle):
-            return self._do_circle_intersection(o)
+            return self._do_ellipse_intersection(o)
 
         elif isinstance(o, Ellipse):
             if o == self:
@@ -1165,7 +1141,6 @@ class Ellipse(GeometryEntity):
                 return self._do_ellipse_intersection(o)
 
         return o.intersection(self)
-
     def __eq__(self, o):
         """Is the other GeometryEntity the same as this ellipse?"""
         return isinstance(o, GeometryEntity) and (self.center == o.center and

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1141,6 +1141,7 @@ class Ellipse(GeometryEntity):
                 return self._do_ellipse_intersection(o)
 
         return o.intersection(self)
+
     def __eq__(self, o):
         """Is the other GeometryEntity the same as this ellipse?"""
         return isinstance(o, GeometryEntity) and (self.center == o.center and

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1065,8 +1065,8 @@ class Ellipse(GeometryEntity):
         y = Dummy('y', real=True)
         seq = self.equation(x, y)
         oeq = o.equation(x, y)
-        re = solve([seq, oeq], [x, y])
-        return list(uniq(re))
+        result = solve([seq, oeq], [x, y])
+        return [Point(*r) for r in list(uniq(result))]
 
 
     def intersection(self, o):


### PR DESCRIPTION
Even though the intersection is a method of the Ellipse it doesn't seem to work as expected.
e = Ellipse(Point(-1, 0), 4, 3)
e.intersection(Circle(Point(-1, 1), 4)) this will give the following error:
In order to solve this equation, try replacing your symbols with Dummy symbols (or other symbols without assumptions). But if applied to the circle object it works fine.
a = Circle(point(-1, 1, 4)
a.intersection(Ellipse(Point(-1, 0),4, 3)
[Point(−1,−3),Point(−1,−3),Point(−1+16∗sqrt(3)/7,3/7),Point(−16∗sqrt(3)/7−1,3/7)]
So I have made some changes to the intersection method of the ellipse which includes the deletion of    _do_circle_intersection method.I have included its functionality in  _do_ellipse_intersection.
_do_circle_intersection does the same job as _do_ellipse_intersection except for this:

if self.center == o.center:
- ```
         a, b, r = o.major, o.minor, self.radius
  ```
- ```
         x = a*sqrt(simplify((r**2 - b**2)/(a**2 - b**2)))
  ```
- ```
         y = b*sqrt(simplify((a**2 - r**2)/(a**2 - b**2)))
  ```
- ```
         return list(set([Point(x, y), Point(x, -y), Point(-x, y),
  ```
- ```
                          Point(-x, -y)]))
  ```
  
  But the above assumption will fail if even though both the centers coincide but are not at the origin.So I have removed this method and appended the functionality to _do_ellipse_intersection.
