### PR TITLE
Stop premature integral expansion described in #2708

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -201,7 +201,7 @@ class ExprWithLimits(Expr):
         return isyms
 
     def _eval_interval(self, x, a, b):
-        limits = [ ( i if i[0] != x else (x,a,b) ) for i in self.limits ]
+        limits = [( i if i[0] != x else (x,a,b) ) for i in self.limits]
         integrand = self.function
         return self.func(integrand, *limits)
 

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -29,9 +29,6 @@ from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.series import limit
 
 
-# TODO get these helper functions into a super class for sum-like
-# objects: Sum, Product, Integral (issue 6761)
-
 class Integral(AddWithLimits):
     """Represents unevaluated integral."""
 
@@ -499,6 +496,10 @@ class Integral(AddWithLimits):
             if xab[0] in ulj or any(v[0] in uli for v in undone_limits):
                 undone_limits.append(xab)
                 ulj.update(uli)
+                function = self.func(*([function] + [ xab ]))
+                factored_function = function.factor()
+                if not isinstance(factored_function, Integral):
+                    function = factored_function
                 continue
 
             # There are a number of tradeoffs in using the meijer g method.
@@ -565,15 +566,22 @@ class Integral(AddWithLimits):
 
             if antideriv is None:
                 undone_limits.append(xab)
+                function = self.func(*([function] + [ xab ])).factor()
+                factored_function = function.factor()
+                if not isinstance(factored_function, Integral):
+                    function = factored_function
+                continue
             else:
                 if len(xab) == 1:
                     function = antideriv
                 else:
                     if len(xab) == 3:
                         x, a, b = xab
-                    if len(xab) == 2:
+                    elif len(xab) == 2:
                         x, b = xab
                         a = None
+                    else:
+                        raise NotImplementedError
 
                     if deep:
                         if isinstance(a, Basic):
@@ -589,6 +597,8 @@ class Integral(AddWithLimits):
 
                         function = antideriv._eval_interval(x, a, b)
                         function = Poly(function, *gens)
+                    elif isinstance(antideriv, Add):
+                        function = Add(*[ i._eval_interval(x,a,b) for i in Add.make_args(antideriv)])
                     else:
                         try:
                             function = antideriv._eval_interval(x, a, b)
@@ -596,9 +606,10 @@ class Integral(AddWithLimits):
                             # This can happen if _eval_interval depends in a
                             # complicated way on limits that cannot be computed
                             undone_limits.append(xab)
-
-        if undone_limits:
-            return self.func(*([function] + undone_limits))
+                            function = self.func(*([function] + [ xab ]))
+                            factored_function = function.factor()
+                            if not isinstance(factored_function, Integral):
+                                function = factored_function
         return function
 
     def _eval_derivative(self, sym):
@@ -968,7 +979,7 @@ class Integral(AddWithLimits):
             # a product that could have been expanded,
             # so let's try an expansion of the whole
             # thing before giving up; we don't try this
-            # out the outset because there are things
+            # at the outset because there are things
             # that cannot be solved unless they are
             # NOT expanded e.g., x**x*(1+log(x)). There
             # should probably be a checker somewhere in this

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -496,7 +496,7 @@ class Integral(AddWithLimits):
             if xab[0] in ulj or any(v[0] in uli for v in undone_limits):
                 undone_limits.append(xab)
                 ulj.update(uli)
-                function = self.func(*([function] + [ xab ]))
+                function = self.func(*([function] + [xab]))
                 factored_function = function.factor()
                 if not isinstance(factored_function, Integral):
                     function = factored_function
@@ -566,7 +566,7 @@ class Integral(AddWithLimits):
 
             if antideriv is None:
                 undone_limits.append(xab)
-                function = self.func(*([function] + [ xab ])).factor()
+                function = self.func(*([function] + [xab])).factor()
                 factored_function = function.factor()
                 if not isinstance(factored_function, Integral):
                     function = factored_function
@@ -598,7 +598,8 @@ class Integral(AddWithLimits):
                         function = antideriv._eval_interval(x, a, b)
                         function = Poly(function, *gens)
                     elif isinstance(antideriv, Add):
-                        function = Add(*[ i._eval_interval(x,a,b) for i in Add.make_args(antideriv)])
+                        function = Add(*[i._eval_interval(x,a,b) for i in
+                            Add.make_args(antideriv)])
                     else:
                         try:
                             function = antideriv._eval_interval(x, a, b)
@@ -606,7 +607,7 @@ class Integral(AddWithLimits):
                             # This can happen if _eval_interval depends in a
                             # complicated way on limits that cannot be computed
                             undone_limits.append(xab)
-                            function = self.func(*([function] + [ xab ]))
+                            function = self.func(*([function] + [xab]))
                             factored_function = function.factor()
                             if not isinstance(factored_function, Integral):
                                 function = factored_function

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -753,16 +753,16 @@ def test_issue_5167():
     assert Integral(Integral(Integral(f(x), x), y), z).args == \
         (f(x), Tuple(x), Tuple(y), Tuple(z))
     assert integrate(Integral(f(x), x), x) == Integral(f(x), x, x)
-    assert integrate(Integral(f(x), y), x) == Integral(y*f(x), x)
-    assert integrate(Integral(f(x), x), y) == Integral(y*f(x), x)
+    assert integrate(Integral(f(x), y), x) == y*Integral(f(x), x)
+    assert integrate(Integral(f(x), x), y) in [ Integral(y*f(x), x), y*Integral(f(x), x)]
     assert integrate(Integral(2, x), x) == x**2
     assert integrate(Integral(2, x), y) == 2*x*y
     # don't re-order given limits
     assert Integral(1, x, y).args != Integral(1, y, x).args
     # do as many as possibble
-    assert Integral(f(x), y, x, y, x).doit() == Integral(y**2*f(x)/2, x, x)
+    assert Integral(f(x), y, x, y, x).doit() == y**2*Integral(f(x), x, x)/2
     assert Integral(f(x), (x, 1, 2), (w, 1, x), (z, 1, y)).doit() == \
-        Integral(-f(x) + y*f(x), (x, 1, 2), (w, 1, x))
+        y*(x - 1)*Integral(f(x), (x, 1, 2)) - (x - 1)*Integral(f(x), (x, 1, 2))
 
 
 def test_issue_4890():
@@ -867,7 +867,7 @@ def test_issue_4892b():
 
 def test_issue_5178():
     assert integrate(sin(x)*f(y, z), (x, 0, pi), (y, 0, pi), (z, 0, pi)) == \
-        Integral(2*f(y, z), (y, 0, pi), (z, 0, pi))
+        2*Integral(f(y, z), (y, 0, pi), (z, 0, pi))
 
 
 def test_integrate_series():
@@ -1004,7 +1004,6 @@ def test_issue_4803():
     assert integrate(y/pi*exp(-(x_max - x)/cos(a)), x) == \
         y*exp((x - x_max)/cos(a))*cos(a)/pi
 
-
 def test_issue_4234():
     assert integrate(1/sqrt(1 + tan(x)**2)) == tan(x) / sqrt(1 + tan(x)**2)
 
@@ -1015,3 +1014,9 @@ def test_issue_4492():
             (8*sqrt(x**2 - 5)), Abs(x**2)/5 > 1),
         ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
             (8*sqrt(-x**2 + 5)), True))
+
+def test_issue_2708():
+    assert Integral(1/log(x), (x, 2, 3)).doit() == \
+        NonElementaryIntegral(1/log(x), (x,2,3))
+    assert integrate(exp(z)+1/log(z), (z, 2, 3)) == \
+        NonElementaryIntegral(1/log(z), (z, 2, 3)) - exp(2) + exp(3)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -754,7 +754,7 @@ def test_issue_5167():
         (f(x), Tuple(x), Tuple(y), Tuple(z))
     assert integrate(Integral(f(x), x), x) == Integral(f(x), x, x)
     assert integrate(Integral(f(x), y), x) == y*Integral(f(x), x)
-    assert integrate(Integral(f(x), x), y) in [ Integral(y*f(x), x), y*Integral(f(x), x)]
+    assert integrate(Integral(f(x), x), y) in [Integral(y*f(x), x), y*Integral(f(x), x)]
     assert integrate(Integral(2, x), x) == x**2
     assert integrate(Integral(2, x), y) == 2*x*y
     # don't re-order given limits
@@ -1004,6 +1004,7 @@ def test_issue_4803():
     assert integrate(y/pi*exp(-(x_max - x)/cos(a)), x) == \
         y*exp((x - x_max)/cos(a))*cos(a)/pi
 
+
 def test_issue_4234():
     assert integrate(1/sqrt(1 + tan(x)**2)) == tan(x) / sqrt(1 + tan(x)**2)
 
@@ -1015,8 +1016,11 @@ def test_issue_4492():
         ((-2*x**5 + 15*x**3 - 25*x + 25*sqrt(-x**2 + 5)*asin(sqrt(5)*x/5)) /
             (8*sqrt(-x**2 + 5)), True))
 
+
 def test_issue_2708():
-    assert Integral(1/log(x), (x, 2, 3)).doit() == \
-        NonElementaryIntegral(1/log(x), (x,2,3))
-    assert integrate(exp(z)+1/log(z), (z, 2, 3)) == \
-        NonElementaryIntegral(1/log(z), (z, 2, 3)) - exp(2) + exp(3)
+    # This test needs to use an integration function that can
+    # not be evaluated in closed form.  Update as needed.
+    f = 1/(a + z + log(z))
+    integral_f = NonElementaryIntegral(f, (z, 2, 3))
+    assert Integral(f, (z, 2, 3)).doit() == integral_f
+    assert integrate(f + exp(z), (z, 2, 3)) == integral_f - exp(2) + exp(3)


### PR DESCRIPTION
Add a test for this issue, and tweak the Integral class to properly handle situations where risch returns an Integral.
