### PR TITLE
Piecewise: added as_expr_set_pair property

### DIFF
--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -508,6 +508,15 @@ class Piecewise(Function):
                 return diff.is_zero
         return None
 
+    def as_expr_set_pairs(self):
+        exp_sets = []
+        U = S.UniversalSet
+        for expr, cond in self.args:
+            cond_int = U.intersect(cond.as_set())
+            U = U - cond_int
+            exp_sets.append((expr, cond_int))
+        return exp_sets
+
 
 def piecewise_fold(expr):
     """

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -476,3 +476,11 @@ def test_piecewise_evaluate():
     assert p != x
     assert p.is_Piecewise
     assert all(isinstance(i, Basic) for i in p.args)
+
+
+def test_as_expr_set_pairs():
+    assert Piecewise((x, x > 0), (-x, x <= 0)).as_expr_set_pairs() == \
+        [(x, Interval(0, oo, True, True)), (-x, Interval(-oo, 0))]
+
+    assert Piecewise(((x - 2)**2, x >= 0), (0, True)).as_expr_set_pairs() == \
+        [((x - 2)**2, Interval(0, oo)), (0, Interval(-oo, 0, True, True))]


### PR DESCRIPTION
This came up in the discussion at https://groups.google.com/forum/#!topic/sympy/x7IgsNoofNE.
This method will be useful in general while handling `Piecewise` functions. A few examples can be
- in evaluating imageset for Piecewise functions
- in plotting Piecewise function. Currently `plot` cannot plot even simple Piecewise functions like `Piecewise((x, x > 0), (-x, True))`
- in solving expressions like `Piecewise(((x - 2)**2, x >= 0), (0, True))`. See line 305 `sympy.functions.elementary.tests.test_piecewise`
