### PR TITLE
Fixed bugs introduced by merging PR #2732.

### DIFF
--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,6 +1,8 @@
 from sympy import sympify, Add, ImmutableMatrix as Matrix
-from sympy.physics.vector.printers import VectorLatexPrinter, \
-     VectorPrettyPrinter, VectorStrPrinter
+from sympy.core.compatibility import u
+from sympy.physics.vector.printers import (VectorLatexPrinter,
+                                           VectorPrettyPrinter,
+                                           VectorStrPrinter)
 
 
 class Dyadic(object):
@@ -37,8 +39,8 @@ class Dyadic(object):
             for i, v in enumerate(self.args):
                 if ((str(inlist[0][1]) == str(self.args[i][1])) and
                         (str(inlist[0][2]) == str(self.args[i][2]))):
-                    self.args[i] = (self.args[i][0] +
-                        inlist[0][0], inlist[0][1], inlist[0][2])
+                    self.args[i] = (self.args[i][0] + inlist[0][0],
+                                    inlist[0][1], inlist[0][2])
                     inlist.remove(inlist[0])
                     added = 1
                     break
@@ -140,7 +142,7 @@ class Dyadic(object):
         newlist = [v for v in self.args]
         for i, v in enumerate(newlist):
             newlist[i] = (sympify(other) * newlist[i][0], newlist[i][1],
-                    newlist[i][2])
+                          newlist[i][2])
         return Dyadic(newlist)
 
     def __ne__(self, other):
@@ -159,7 +161,7 @@ class Dyadic(object):
             # if the coef of the dyadic is 1, we skip the 1
             if ar[i][0] == 1:
                 ol.append(' + ' + mlp.doprint(ar[i][1]) + r"\otimes " +
-                        mlp.doprint(ar[i][2]))
+                          mlp.doprint(ar[i][2]))
             # if the coef of the dyadic is -1, we skip the 1
             elif ar[i][0] == -1:
                 ol.append(' - ' +

--- a/sympy/physics/vector/printers.py
+++ b/sympy/physics/vector/printers.py
@@ -1,4 +1,6 @@
 from sympy import Derivative
+from sympy.core import C
+from sympy.core.compatibility import u
 from sympy.core.function import UndefinedFunction
 from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter
@@ -207,7 +209,7 @@ class VectorPrettyPrinter(PrettyPrinter):
             ds = prettyForm(*s.left('d'))
 
             if num > 1:
-                ds = ds**prettyForm(str(num))
+                ds = ds ** prettyForm(str(num))
 
             if x is None:
                 x = ds
@@ -216,7 +218,7 @@ class VectorPrettyPrinter(PrettyPrinter):
                 x = prettyForm(*x.right(ds))
         pform = prettyForm('d')
         if len(syms) > 1:
-            pform = pform**prettyForm(str(len(syms)))
+            pform = pform ** prettyForm(str(len(syms)))
         pform = prettyForm(*pform.below(stringPict.LINE, x))
         pform.baseline = pform.baseline + 1
         pform = prettyForm(*stringPict.next(pform, f))
@@ -236,10 +238,10 @@ class VectorPrettyPrinter(PrettyPrinter):
         # identical to the normal PrettyPrinter code
         if isinstance(func, UndefinedFunction) and (args == (t,)):
             pform = prettyForm(binding=prettyForm.FUNC,
-                       *stringPict.next(prettyFunc))
+                               *stringPict.next(prettyFunc))
         else:
             pform = prettyForm(binding=prettyForm.FUNC,
-                       *stringPict.next(prettyFunc, prettyArgs))
+                               *stringPict.next(prettyFunc, prettyArgs))
         # store pform parts so it can be reassembled e.g. when powered
         pform.prettyFunc = prettyFunc
         pform.prettyArgs = prettyArgs
@@ -249,6 +251,8 @@ class VectorPrettyPrinter(PrettyPrinter):
 class VectorTypeError(TypeError):
 
     def __init__(self, other, type_str):
-        super(VectorialTypeError, self).__init__("Expected an instance of %s, "
-                "instead received an object '%s' of type %s." % (
-                    type_str, other, type(other)))
+        super(VectorTypeError, self).__init__("Expected an instance of %s, "
+                                              "instead received an object "
+                                              "'%s' of type %s." % (
+                                                  type_str, other,
+                                                  type(other)))

--- a/sympy/physics/vector/printers.py
+++ b/sympy/physics/vector/printers.py
@@ -251,8 +251,6 @@ class VectorPrettyPrinter(PrettyPrinter):
 class VectorTypeError(TypeError):
 
     def __init__(self, other, type_str):
-        super(VectorTypeError, self).__init__("Expected an instance of %s, "
-                                              "instead received an object "
-                                              "'%s' of type %s." % (
-                                                  type_str, other,
-                                                  type(other)))
+        msg = ("Expected an instance of %s, instead received an object "
+               "'%s' of type %s.") % (type_str, other, type(other))
+        super(VectorTypeError, self).__init__(msg)

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -1,0 +1,31 @@
+from sympy import symbols, sin
+from sympy.physics.vector import dynamicsymbols, ReferenceFrame
+from sympy.physics.vector.printers import VectorPrettyPrinter
+
+a, b, c = symbols('a, b, c')
+alpha, omega, beta = dynamicsymbols('alpha, omega, beta')
+
+N = ReferenceFrame('N')
+
+v = a ** 2 * N.x + b * N.y + c * sin(alpha) * N.z
+w = alpha * N.x + sin(omega) * N.y + alpha * beta * N.z
+
+# TODO : The division does not print correctly here:
+# w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
+
+
+def test_vector_pretty_print():
+
+    pp = VectorPrettyPrinter()
+
+    expected = (u' 2\na *\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + ' +
+                u'b*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
+                u'c\u22c5sin(\u03b1)*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
+
+    assert expected == pp.doprint(v)
+
+    expected = (u'\u03b1*\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + ' +
+                u'sin(\u03c9)*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
+                u'\u03b1\u22c5\u03b2*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
+
+    assert expected == pp.doprint(w)

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -1,6 +1,6 @@
-from sympy import symbols, sin
+from sympy import symbols, sin, cos, sqrt
 from sympy.physics.vector import dynamicsymbols, ReferenceFrame
-from sympy.physics.vector.printers import VectorPrettyPrinter
+from sympy.physics.vector.printers import VectorPrettyPrinter, VectorLatexPrinter
 
 a, b, c = symbols('a, b, c')
 alpha, omega, beta = dynamicsymbols('alpha, omega, beta')
@@ -21,32 +21,63 @@ def test_vector_pretty_print():
 
     pp = VectorPrettyPrinter()
 
-    expected = (u' 2\na *\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + ' +
-                u'b*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
+    expected = (u' 2\na *\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + '
+                u'b*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + '
                 u'c\u22c5sin(\u03b1)*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
 
     assert expected == pp.doprint(v)
 
-    expected = (u'\u03b1*\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + ' +
-                u'sin(\u03c9)*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
+    expected = (u'\u03b1*\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + '
+                u'sin(\u03c9)*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + '
                 u'\u03b1\u22c5\u03b2*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
 
     assert expected == pp.doprint(w)
 
 
+def test_vector_latex():
+
+    N = ReferenceFrame('N')
+
+    a, b, c, d, omega = symbols('a, b, c, d, omega')
+
+    v = (a ** 2 + b / c) * N.x + sqrt(d) * N.y + cos(omega) * N.z
+
+    expected = ('(a^{2} + \\frac{b}{c})\\mathbf{\\hat{n}_x} + '
+                '\\sqrt{d}\\mathbf{\\hat{n}_y} + '
+                '\\operatorname{cos}\\left(\\omega\\right)\\mathbf{\\hat{n}_z}')
+
+    assert v._latex() == expected
+    lp = VectorLatexPrinter()
+    assert lp.doprint(v) == expected
+
+    N = ReferenceFrame('N', latexs=(r'\hat{i}', r'\hat{j}', r'\hat{k}'))
+
+    v = (a ** 2 + b / c) * N.x + sqrt(d) * N.y + cos(omega) * N.z
+
+    expected = ('(a^{2} + \\frac{b}{c})\\hat{i} + '
+                '\\sqrt{d}\\hat{j} + '
+                '\\operatorname{cos}\\left(\\omega\\right)\\hat{k}')
+    assert v._latex() == expected
+
+
 def test_dyadic_pretty_print():
 
-    expected = (u' 2\na  \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
-                u'b \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
-                u'c\u22c5sin(\u03b1) \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m')
+    expected = (u' 2\na  \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[9'
+                u'4m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + b \x1b[94m\x1b[1mn_y'
+                u'\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b'
+                u'[0;0m + c\u22c5sin(\u03b1) \x1b[94m\x1b[1mn_z\x1b[0;0m'
+                u'\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m')
 
     result = u._pretty().render()
 
     assert expected == result
 
-    expected = (u'\u03b1 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + ' +
-                u'sin(\u03c9) \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m + ' +
-                u'\u03b1\u22c5\u03b2 \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m')
+    expected = (u'\u03b1 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[9'
+                u'4m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + sin(\u03c9) \x1b[94m'
+                u'\x1b[1mn_y\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_z'
+                u'\x1b[0;0m\x1b[0;0m + \u03b1\u22c5\u03b2 \x1b[94m\x1b[1mn'
+                u'_z\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_x\x1b[0;0m'
+                u'\x1b[0;0m')
 
     result = x._pretty().render()
 

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -13,6 +13,9 @@ w = alpha * N.x + sin(omega) * N.y + alpha * beta * N.z
 # TODO : The division does not print correctly here:
 # w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
 
+u = a ** 2 * (N.x | N.y) + b * (N.y | N.y) + c * sin(alpha) * (N.z | N.y)
+x = alpha * (N.x | N.x) + sin(omega) * (N.y | N.z) + alpha * beta * (N.z | N.x)
+
 
 def test_vector_pretty_print():
 
@@ -29,3 +32,22 @@ def test_vector_pretty_print():
                 u'\u03b1\u22c5\u03b2*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
 
     assert expected == pp.doprint(w)
+
+
+def test_dyadic_pretty_print():
+
+    expected = (u' 2\na  \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
+                u'b \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + ' +
+                u'c\u22c5sin(\u03b1) \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m')
+
+    result = u._pretty().render()
+
+    assert expected == result
+
+    expected = (u'\u03b1 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + ' +
+                u'sin(\u03c9) \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m + ' +
+                u'\u03b1\u22c5\u03b2 \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m')
+
+    result = x._pretty().render()
+
+    assert expected == result

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,5 +1,6 @@
 from sympy import S, sympify, trigsimp, expand, sqrt, \
      Add, zeros, ImmutableMatrix as Matrix
+from sympy.core.compatibility import u
 
 
 class Vector(object):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,5 +1,5 @@
-from sympy import S, sympify, trigsimp, expand, sqrt, \
-     Add, zeros, ImmutableMatrix as Matrix
+from sympy import (S, sympify, trigsimp, expand, sqrt, Add, zeros,
+                   ImmutableMatrix as Matrix)
 from sympy.core.compatibility import u
 
 
@@ -38,8 +38,8 @@ class Vector(object):
             added = 0
             for i, v in enumerate(self.args):
                 if inlist[0][1] == self.args[i][1]:
-                    self.args[i] = (self.args[i][0] +
-                            inlist[0][0], inlist[0][1])
+                    self.args[i] = (self.args[i][0] + inlist[0][0],
+                                    inlist[0][1])
                     inlist.remove(inlist[0])
                     added = 1
                     break
@@ -76,7 +76,7 @@ class Vector(object):
         Examples
         ========
 
-        >>> from sympy.physics.vector import ReferenceFrame, Vector, dot
+        >>> from sympy.physics.vector import ReferenceFrame, dot
         >>> from sympy import symbols
         >>> q1 = symbols('q1')
         >>> N = ReferenceFrame('N')
@@ -149,7 +149,7 @@ class Vector(object):
         Examples
         ========
 
-        >>> from sympy.physics.vector import ReferenceFrame, Vector
+        >>> from sympy.physics.vector import ReferenceFrame
         >>> from sympy import Symbol
         >>> N = ReferenceFrame('N')
         >>> b = Symbol('b')
@@ -213,7 +213,7 @@ class Vector(object):
     def _latex(self, printer=None):
         """Latex Printing method. """
 
-        from sympy.physics.vector.printers import VectorStrPrinter
+        from sympy.physics.vector.printers import VectorLatexPrinter
         ar = self.args  # just to shorten things
         if len(ar) == 0:
             return str(0)
@@ -229,7 +229,7 @@ class Vector(object):
                 elif ar[i][0][j] != 0:
                     # If the coefficient of the basis vector is not 1 or -1;
                     # also, we might wrap it in parentheses, for readability.
-                    arg_str = VectorStrPrinter().doprint(ar[i][0][j])
+                    arg_str = VectorLatexPrinter().doprint(ar[i][0][j])
                     if isinstance(ar[i][0][j], Add):
                         arg_str = "(%s)" % arg_str
                     if arg_str[0] == '-':


### PR DESCRIPTION
Printing of vectors and dyadics was broken when PR #2732 was merged due to
some missing imports. There were no tests for this, so I've added a couple for
pretty printing. I have some tests for latex printing in PR #2772 that has not
been merged yet.

PR #2732 also reverted the changes in PR #2728 by accident. This introduces those changes back into the code base.
