### PR TITLE
Travis: remove pypy from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - 2.7
   - 3.2
   - 3.3
-  - "pypy"
 matrix:
   include:
     - python: 2.7
@@ -50,6 +49,18 @@ matrix:
       env:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
+        - SPLIT="3/3"
+    - python: "pypy"
+      env:
+        - TEST_DOCTESTS="true"
+    - python: "pypy"
+      env:
+        - SPLIT="1/3"
+    - python: "pypy"
+      env:
+        - SPLIT="2/3"
+    - python: "pypy"
+      env:
         - SPLIT="3/3"
     - python: 2.7
       env: TEST_SPHINX="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,6 @@ matrix:
     - python: 3.3 # Dummy value
       env:
         - TEST_SAGE="true"
-  allow_failures:
-    - python: "pypy"
 before_install:
   - if [[ "${TEST_GMPY}" == "true" ]]; then
       sudo apt-get update;

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2252,15 +2252,14 @@ def test_V8_V9():
 
 
 def test_V10():
-    assert integrate(1/(3 + 3*cos(x) + 4*sin(x)), x) == log(tan(x/2) + 3/4)/4
+    assert integrate(1/(3 + 3*cos(x) + 4*sin(x)), x) == log(tan(x/2) + Rational(3, 4))/4
 
 
 def test_V11():
-#    x = symbols('x', real=True)
     r1 = integrate(1/(4 + 3*cos(x) + 4*sin(x)), x)
     r2 = factor(r1)
     assert (logcombine(r2, force=True) ==
-            log(((tan(x/2) + 1)/(tan(x/2) + 7))**(1/3)))
+            log(((tan(x/2) + 1)/(tan(x/2) + 7))**Rational(1, 3)))
 
 
 @XFAIL
@@ -2404,7 +2403,7 @@ def test_W12():
     p = symbols('p', real=True, positive=True)
     q = symbols('q', real=True)
     r1 = integrate(x*exp(-p*x**2 + 2*q*x), (x, -oo, oo))
-    assert r1.simplify() == sqrt(pi)*q*exp(q**2/p)/p**(3/2)
+    assert r1.simplify() == sqrt(pi)*q*exp(q**2/p)/p**Rational(3, 2)
 
 
 @XFAIL

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -1819,6 +1819,7 @@ def test_R14():
     assert T.simplify() == sin(n*x)**2/sin(x)
 
 
+@slow
 @XFAIL
 def test_R15():
     n, k = symbols('n k', integer=True, positive=True)


### PR DESCRIPTION
I think 23175d7 fixes some travis timeouts in the test_wester.py, especially with pypy.

tests: https://travis-ci.org/skirpichev/sympy/builds/18029113
