### PR TITLE
Added support for Equivalent with multiple arguments in functions

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -4,7 +4,7 @@ Boolean algebra module for SymPy
 from __future__ import print_function, division
 
 from collections import defaultdict
-from itertools import product, islice, izip
+from itertools import product, islice
 
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
@@ -995,7 +995,7 @@ def eliminate_implications(expr):
 
     elif expr.func is Equivalent:
         clauses = []
-        for a, b in izip(islice(args, None), islice(args, 1, None)):
+        for a, b in zip(islice(args, None), islice(args, 1, None)):
             clauses.append(Or(Not(a), b))
         a, b = args[-1], args[0]
         clauses.append(Or(Not(a), b))

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -4,7 +4,7 @@ Boolean algebra module for SymPy
 from __future__ import print_function, division
 
 from collections import defaultdict
-from itertools import product
+from itertools import product, islice, izip
 
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
@@ -981,17 +981,26 @@ def eliminate_implications(expr):
     Or(B, Not(A))
     >>> eliminate_implications(Equivalent(A, B))
     And(Or(A, Not(B)), Or(B, Not(A)))
+    >>> eliminate_implications(Equivalent(A, B, C))
+    And(Or(A, Not(C)), Or(B, Not(A)), Or(C, Not(B)))
     """
     expr = sympify(expr)
     if expr.is_Atom:
         return expr  # (Atoms are unchanged.)
     args = list(map(eliminate_implications, expr.args))
+
     if expr.func is Implies:
         a, b = args[0], args[-1]
         return (~a) | b
+
     elif expr.func is Equivalent:
-        a, b = args[0], args[-1]
-        return (a | Not(b)) & (b | Not(a))
+        clauses = []
+        for a, b in izip(islice(args, None), islice(args, 1, None)):
+            clauses.append(Or(Not(a), b))
+        a, b = args[-1], args[0]
+        clauses.append(Or(Not(a), b))
+        return And(*clauses)
+
     else:
         return expr.func(*args)
 

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -290,10 +290,12 @@ def test_De_Morgan():
 
 
 def test_eliminate_implications():
-
+    from sympy.abc import A, B, C, D
     assert eliminate_implications(Implies(A, B, evaluate=False)) == (~A) | B
     assert eliminate_implications(
         A >> (C >> Not(B))) == Or(Or(Not(B), Not(C)), Not(A))
+    assert eliminate_implications(Equivalent(A, B, C, D)) == \
+        (~A | B) & (~B | C) & (~C | D) & (~D | A)
 
 
 def test_conjuncts():


### PR DESCRIPTION
While Equivalent class allows multiple (more than 2) arguments, the supporting functions don't.
1. eliminate_implications gives a wrong answer
   <code>pl_true(eliminate_implications(Equivalent(a, b, c)), {a: True, b: False, c: True})</code> gives <code>True</code>
2. pl_true throws an exception
   <code>pl_true(Equivalent(a, b, c), {a: True, b: False, c: True})</code> gives <code>ValueError: too many values to unpack</code>
