### PR TITLE
Simplifications for LambertW

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -224,6 +224,8 @@ class exp(ExpBase):
                 return S.Zero
         elif arg.func is log:
             return arg.args[0]
+        elif arg.func is LambertW and arg.args[0].is_nonnegative:
+            return arg.args[0]/LambertW(arg.args[0])
         elif arg.is_Mul:
             Ioo = S.ImaginaryUnit*S.Infinity
             if arg in [Ioo, -Ioo]:
@@ -528,6 +530,8 @@ class log(Function):
             return S.One
         elif arg.func is exp and arg.args[0].is_real:
             return arg.args[0]
+        elif arg.func is LambertW and arg.args[0].is_nonnegative:
+            return log(arg.args[0]) - LambertW(arg.args[0])
         elif arg.func is exp_polar:
             return unpolarify(arg.exp)
         #don't autoexpand Pow or Mul (see the issue 252):

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -307,7 +307,8 @@ def test_log_simplify():
 
 
 def test_lambertw():
-    x = Symbol('x')
+    x = Symbol('x', real=True)
+    y = Symbol('y')
     assert LambertW(x) == LambertW(x)
     assert LambertW(0) == 0
     assert LambertW(E) == 1
@@ -317,6 +318,9 @@ def test_lambertw():
     assert LambertW(x**2).diff(x) == 2*LambertW(x**2)/x/(1 + LambertW(x**2))
     assert LambertW(sqrt(2)).evalf(30).epsilon_eq(
         Float("0.701338383413663009202120278965", 30), 1e-29)
+    assert exp(LambertW(x)) == x/LambertW(x)
+    assert log(LambertW(x)) == log(x) - LambertW(x)
+    assert log(LambertW(y)) == log(LambertW(y))
 
 
 def test_exp_expand():


### PR DESCRIPTION
These simplification on LambertW functions are implemented, see (https://code.google.com/p/sympy/issues/detail?id=1981)

exp(LambertW(x)) -> x/LambertW(x)
log(LambertW(x)) -> log(x) - LambertW(x)
Lambert(-pi/2) -> I*pi/2
