### PR TITLE
Fix Rational-Float Issue by typecasting float to str

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1076,10 +1076,8 @@ class Rational(Number):
                 except NameError:
                     pass  # error will raise below
 
-                if isinstance(p, (float, Float)):
-		    #Error Corrected by typecasting float to str
-		    return Rational(str(p))
-                    #return Rational(*_as_integer_ratio(p))
+                if isinstance(p, (float, Float)):		    
+		    return Rational(str(p))                    
 
             if not isinstance(p, SYMPY_INTS + (Rational,)):
                 raise TypeError('invalid input: %s' % p)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1076,7 +1076,7 @@ class Rational(Number):
                 except NameError:
                     pass  # error will raise below
 
-                if isinstance(p, (float, Float)):		    
+                if isinstance(p, (float, Float)):
                     return Rational(str(p))
 
             if not isinstance(p, SYMPY_INTS + (Rational,)):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1077,7 +1077,7 @@ class Rational(Number):
                     pass  # error will raise below
 
                 if isinstance(p, (float, Float)):		    
-                    return Rational(str(p))                    
+                    return Rational(str(p))
 
             if not isinstance(p, SYMPY_INTS + (Rational,)):
                 raise TypeError('invalid input: %s' % p)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -71,18 +71,6 @@ def seterr(divide=False):
         _errdict["divide"] = divide
 
 
-def _as_integer_ratio(p):
-    """compatibility implementation for python < 2.6"""
-    neg_pow, man, expt, bc = getattr(p, '_mpf_', mpmath.mpf(p)._mpf_)
-    p = [1, -1][neg_pow % 2]*man
-    if expt < 0:
-        q = 2**-expt
-    else:
-        q = 1
-        p *= 2**expt
-    return int(p), int(q)
-
-
 def _decimal_to_Rational_prec(dec):
     """Convert an ordinary decimal instance to a Rational."""
     if not dec.is_finite():  # NOTE: this is_finite is not SymPy's

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1077,7 +1077,9 @@ class Rational(Number):
                     pass  # error will raise below
 
                 if isinstance(p, (float, Float)):
-                    return Rational(*_as_integer_ratio(p))
+		    #Error Corrected by typecasting float to str
+		    return Rational(str(p))
+                    #return Rational(*_as_integer_ratio(p))
 
             if not isinstance(p, SYMPY_INTS + (Rational,)):
                 raise TypeError('invalid input: %s' % p)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1077,7 +1077,7 @@ class Rational(Number):
                     pass  # error will raise below
 
                 if isinstance(p, (float, Float)):		    
-		    return Rational(str(p))                    
+                    return Rational(str(p))                    
 
             if not isinstance(p, SYMPY_INTS + (Rational,)):
                 raise TypeError('invalid input: %s' % p)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -956,12 +956,7 @@ class Rational(Number):
     >>> Rational(.5)
     1/2
     >>> Rational(.2)
-    3602879701896397/18014398509481984
-
-    If the simpler representation of the float is desired then consider
-    limiting the denominator to the desired value or convert the float to
-    a string (which is roughly equivalent to limiting the denominator to
-    10**12):
+    1/5
 
     >>> Rational(str(.2))
     1/5


### PR DESCRIPTION
Rational(0.2) ! = Rational('0.2')
This inconsistency is not required, and leads to unnecessary use of long numbers to store the Rational number.

For example,
Rational(0.2) = 3602879701896397/18014398509481984 which is not exactly correct.
Rational('0.2') = 1/5 as you expect. 

Both these results must be same and simple. 

I've ran all the tests. No problems with it. 
Only the test corresponding to Rational(0.2) fails, which is expected. 
