### PR TITLE
Fix libMP compile issue: exec problem

### DIFF
--- a/sympy/mpmath/libmp/exec_py3.py
+++ b/sympy/mpmath/libmp/exec_py3.py
@@ -1,1 +1,2 @@
-exec_ = exec
+#changed it according to: http://code.google.com/p/mpmath/issues/detail?id=204
+exec_ = eval('exec')


### PR DESCRIPTION
Error during sympy setup:

byte-compiling /usr/local/lib/python2.7/dist-packages/sympy/mpmath/libmp/exec_py3.py to exec_py3.pyc
  File "/usr/local/lib/python2.7/dist-packages/sympy/mpmath/libmp/exec_py3.py", line 1
    exec_ = exec
               ^
SyntaxError: invalid syntax

fixed it by looking at:
http://code.google.com/p/mpmath/issues/detail?id=204
