### PR TITLE
Issue 4064: add **hints to sign.doit()

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -221,7 +221,7 @@ class sign(Function):
     is_bounded = True
     is_complex = True
 
-    def doit(self):
+    def doit(self, **hints):
         if self.args[0].is_nonzero:
             return self.args[0] / Abs(self.args[0])
         return self

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -160,3 +160,10 @@ def test_issue_1869():
 def test_issue_1893():
     # Nonelementary integral.  Requires hypergeometric/Meijer-G handling.
     assert not integrate(log(x) * x**(k - 1) * exp(-x) / gamma(k), (x, 0, oo)).has(Integral)
+
+
+@XFAIL
+def test_issue_4064():
+    # integral should be evaluated to (-1 + Sign[2 - x]) (Sin[1] - Sin[2]) +
+    # ((-1 + Sign[1 - x]) (1 + Sign[2 - x]) (Sin[1] - Sin[x]))/2
+    assert not integrate((sign(x - 1) - sign(x - 2)) * cos(x), x).has(Integral)


### PR DESCRIPTION
sign.doit() was missing **hints parameter, causing an exception at integrate.
I added test_issue_4064() in test_failing_integrals.py.
I @XFAIL it because even if the exception is no longer raised, the
integral is still not evaluated.
