### PR TITLE
Fix several subs issues with Float's

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -962,6 +962,7 @@ class Basic(with_metaclass(ManagedProperties)):
         if kwargs.pop('simultaneous', False):  # XXX should this be the default for dict subs?
             reps = {}
             rv = self
+            kwargs['hack2'] = True
             for old, new in sequence:
                 d = C.Dummy(commutative=new.is_commutative)
                 rv = rv._subs(old, d, **kwargs)

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1059,7 +1059,7 @@ class Basic(with_metaclass(ManagedProperties)):
                 if not hasattr(arg, '_eval_subs'):
                     continue
                 arg = arg._subs(old, new, **hints)
-                if arg != args[i]:
+                if not _aresame(arg, args[i]):
                     hit = True
                     args[i] = arg
             if hit:

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -1,6 +1,8 @@
+from __future__ import division
 from sympy import (Symbol, Wild, sin, cos, exp, sqrt, pi, Function, Derivative,
         abc, Integer, Eq, symbols, Add, I, Float, log, Rational, Lambda, atan2,
-        cse, cot, tan, S, Tuple, Basic, Dict, Piecewise, oo, Mul)
+        cse, cot, tan, S, Tuple, Basic, Dict, Piecewise, oo, Mul,
+        factor, nsimplify)
 from sympy.core.basic import _aresame
 from sympy.utilities.pytest import XFAIL
 from sympy.abc import x, y
@@ -608,3 +610,8 @@ def test_noncommutative_subs():
 def test_gh_issue_2877():
     f = Float(2.0)
     assert (x + f).subs({f: 2}) == x + 2
+
+    def r(a,b,c):
+        return factor(a*x**2 + b*x + c)
+    e = r(5/6, 10, 5)
+    assert nsimplify(e) == 5*x**2/6 + 10*x + 5

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -599,6 +599,12 @@ def test_mul2():
     """
     assert (2*(x + 1)).is_Mul
 
+
 def test_noncommutative_subs():
     x,y = symbols('x,y', commutative=False)
     assert (x*y*x).subs([(x,x*y),(y,x)],simultaneous=True) == (x*y*x**2*y)
+
+
+def test_gh_issue_2877():
+    f = Float(2.0)
+    assert (x + f).subs({f: 2}) == x + 2


### PR DESCRIPTION
- test structural equality with _aresame
- enable `hack2` for `simultaneous=True` to workaround `Mul` autoevaluation

this fixes #2877
