### PR TITLE
Fix zero vector reexpression

### DIFF
--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -78,7 +78,7 @@ def express(expr, frame, frame2=None, variables=False):
     _check_frame(frame)
 
     if expr == 0:
-        return S(0)
+        return expr
 
     if isinstance(expr, Vector):
         #Given expr is a Vector

--- a/sympy/physics/vector/tests/test_functions.py
+++ b/sympy/physics/vector/tests/test_functions.py
@@ -165,6 +165,8 @@ def test_operator_match():
 
 
 def test_express():
+    assert express(Vector(0), N) == Vector(0)
+    assert express(S(0), N) == S(0)
     assert express(A.x, C) == cos(q3)*C.x + sin(q3)*C.z
     assert express(A.y, C) == sin(q2)*sin(q3)*C.x + cos(q2)*C.y - \
         sin(q2)*cos(q3)*C.z


### PR DESCRIPTION
Fix to the issue pointed by Tarun. Re-expression of a zero vector should return a zero vector, and that of a zero scalar should return a zero scalar.
