### PR TITLE
Vector print wrapper

### DIFF
--- a/doc/src/modules/physics/mechanics/bicycle_example.rst
+++ b/doc/src/modules/physics/mechanics/bicycle_example.rst
@@ -21,7 +21,7 @@ False (in case it has been set True elsewhere), since it slows down the
 computations::
 
   >>> Vector.simp = False
-  >>> mechanics_printing()
+  >>> mechanics_printing(pretty_print=False)
 
 Declaration of Coordinates & Speeds:
 A simple definition for qdots, qd = u,is used in this code.  Speeds are: yaw

--- a/doc/src/modules/physics/mechanics/kane.rst
+++ b/doc/src/modules/physics/mechanics/kane.rst
@@ -114,7 +114,7 @@ below: ::
 
 A dictionary returning the solved :math:`\dot{q}`'s can also be solved for: ::
 
-  >>> mechanics_printing()
+  >>> mechanics_printing(pretty_print=False)
   >>> KM.kindiffdict()
   {q1': u1, q2': u2, q3': u3, q4': u4}
 
@@ -234,7 +234,7 @@ initialization. ::
 
 With that the equations of motion can be formed. ::
 
-  >>> mechanics_printing()
+  >>> mechanics_printing(pretty_print=False)
   >>> LM.form_lagranges_equations()
   Matrix([
   [2*q1''],

--- a/doc/src/modules/physics/mechanics/rollingdisc_example_kane.rst
+++ b/doc/src/modules/physics/mechanics/rollingdisc_example_kane.rst
@@ -13,7 +13,7 @@ drop out). ::
   >>> q1, q2, q3, u1, u2, u3  = dynamicsymbols('q1 q2 q3 u1 u2 u3')
   >>> q1d, q2d, q3d, u1d, u2d, u3d = dynamicsymbols('q1 q2 q3 u1 u2 u3', 1)
   >>> r, m, g = symbols('r m g')
-  >>> mechanics_printing()
+  >>> mechanics_printing(pretty_print=False)
 
 The kinematics are formed by a series of simple rotations. Each simple rotation
 creates a new frame, and the next rotation is defined by the new frame's basis

--- a/doc/src/modules/physics/mechanics/rollingdisc_example_kane_constraints.rst
+++ b/doc/src/modules/physics/mechanics/rollingdisc_example_kane_constraints.rst
@@ -10,7 +10,7 @@ small problems, but can cause larger vector operations to hang. ::
 
   >>> from sympy import symbols, sin, cos, tan
   >>> from sympy.physics.mechanics import *
-  >>> mechanics_printing()
+  >>> mechanics_printing(pretty_print=False)
   >>> q1, q2, q3, u1, u2, u3  = dynamicsymbols('q1 q2 q3 u1 u2 u3')
   >>> q1d, q2d, q3d, u1d, u2d, u3d = dynamicsymbols('q1 q2 q3 u1 u2 u3', 1)
   >>> r, m, g = symbols('r m g')

--- a/doc/src/modules/physics/mechanics/rollingdisc_example_lagrange.rst
+++ b/doc/src/modules/physics/mechanics/rollingdisc_example_lagrange.rst
@@ -9,7 +9,7 @@ disc's mass and radius, and the local gravity. ::
 
   >>> from sympy import symbols, cos, sin
   >>> from sympy.physics.mechanics import *
-  >>> mechanics_printing()
+  >>> mechanics_printing(pretty_print=False)
   >>> q1, q2, q3 = dynamicsymbols('q1 q2 q3')
   >>> q1d, q2d, q3d = dynamicsymbols('q1 q2 q3', 1)
   >>> r, m, g = symbols('r m g')

--- a/doc/src/modules/physics/vector/api/printing.rst
+++ b/doc/src/modules/physics/vector/api/printing.rst
@@ -5,21 +5,21 @@ Printing (Docstrings)
 init_printing
 =============
 
-.. autofunction:: sympy.physics.vector.functions.init_printing
+.. autofunction:: sympy.physics.vector.printing.init_printing
 
 vprint
 ======
 
-.. autofunction:: sympy.physics.vector.functions.vprint
+.. autofunction:: sympy.physics.vector.printing.vprint
 
 
 vpprint
 =======
 
-.. autofunction:: sympy.physics.vector.functions.vpprint
+.. autofunction:: sympy.physics.vector.printing.vpprint
 
 
 vlatex
 ======
 
-.. autofunction:: sympy.physics.vector.functions.vlatex
+.. autofunction:: sympy.physics.vector.printing.vlatex

--- a/doc/src/modules/physics/vector/api/printing.rst
+++ b/doc/src/modules/physics/vector/api/printing.rst
@@ -2,10 +2,10 @@
 Printing (Docstrings)
 =====================
 
-time_derivative_printing
-========================
+init_printing
+=============
 
-.. autofunction:: sympy.physics.vector.functions.time_derivative_printing
+.. autofunction:: sympy.physics.vector.functions.init_printing
 
 vprint
 ======

--- a/doc/src/modules/physics/vector/kinematics.rst
+++ b/doc/src/modules/physics/vector/kinematics.rst
@@ -430,7 +430,6 @@ velocity definition. ::
 
   >>> from sympy import Symbol, sin, cos
   >>> from sympy.physics.vector import *
-  >>> time_derivative_printing()
   >>> N = ReferenceFrame('N')
   >>> q1 = dynamicsymbols('q1')
   >>> A = N.orientnew('A', 'Axis', [q1, N.x])

--- a/doc/src/modules/physics/vector/vectors.rst
+++ b/doc/src/modules/physics/vector/vectors.rst
@@ -709,11 +709,11 @@ non-interactive sessions. ::
   >>> vprint(q1d)
   q1'
 
-For interactive sessions use ``init_printing``. There also exist analogs
+For interactive sessions use ``init_vprinting``. There also exist analogs
 for SymPy's ``vprint``, ``vpprint``, and ``latex``, ``vlatex``. ::
 
-  >>> from sympy.physics.vector import init_printing
-  >>> init_printing(pretty_print=False)
+  >>> from sympy.physics.vector import init_vprinting
+  >>> init_vprinting(pretty_print=False)
   >>> q1
   q1
   >>> q1d

--- a/doc/src/modules/physics/vector/vectors.rst
+++ b/doc/src/modules/physics/vector/vectors.rst
@@ -496,7 +496,7 @@ defining vectors in the more complex forms can vastly slow down formulation of
 the equations of motion and increase their length, sometimes to a point where
 they cannot be shown on screen.
 
-Using Vectors and Reference Frames 
+Using Vectors and Reference Frames
 ==================================
 
 We have waited until after all of the relevant mathematical relationships have
@@ -709,10 +709,11 @@ non-interactive sessions. ::
   >>> vprint(q1d)
   q1'
 
-For interactive sessions use ``time_derivative_printing``. There also exist analogs
+For interactive sessions use ``init_printing``. There also exist analogs
 for SymPy's ``vprint``, ``vpprint``, and ``latex``, ``vlatex``. ::
 
-  >>> time_derivative_printing()
+  >>> from sympy.physics.vector import init_printing
+  >>> init_printing(pretty_print=False)
   >>> q1
   q1
   >>> q1d

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -273,7 +273,7 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     print_builtin: boolean, optional, default=True
         If true then floats and integers will be printed. If false the
         printer will only print SymPy types.
-    str_printer: function, optiona, default=None
+    str_printer: function, optional, default=None
         A custom string printer function. This should mimic
         sympy.printing.sstrrepr().
     pretty_printer: function, optional, default=None

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -64,8 +64,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     else:
         latex = default_latex
 
-    print("latex printer after: {}".format(latex))
-
     def _print_plain(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
         if _can_print_latex(arg):

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -8,7 +8,6 @@ from sympy import latex as default_latex
 from sympy import preview
 from sympy.core.compatibility import integer_types
 from sympy.utilities.misc import debug
-from sympy.physics.vector import Vector, Dyadic
 
 
 def _init_python_printing(stringify_func):
@@ -98,6 +97,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         o can be printed with LaTeX.
         """
         import sympy
+        from sympy.physics.vector import Vector, Dyadic
         if isinstance(o, (list, tuple, set, frozenset)):
             return all(_can_print_latex(i) for i in o)
         elif isinstance(o, dict):
@@ -168,6 +168,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     if IPython.__version__ >= '0.11':
         from sympy.core.basic import Basic
         from sympy.matrices.matrices import MatrixBase
+        from sympy.physics.vector import Vector, Dyadic
         printable_types = [Basic, MatrixBase, float, tuple, list, set,
                 frozenset, dict, Vector, Dyadic] + list(integer_types)
 

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -105,10 +105,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             return True
         elif isinstance(o, (float, integer_types)) and print_builtin:
             return True
-        # Is this the standard way of making an object that prints latex. If
-        # so, the I can remove the Vector and Dyadic imports above.
-        elif hasattr(o, '_latex'):
-            return True
         return False
 
     def _print_latex_png(o):
@@ -381,6 +377,6 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     if ip is not None and ip.__module__.startswith('IPython'):
         _init_ipython_printing(ip, stringify_func, use_latex, euler,
                                forecolor, backcolor, fontsize, latex_mode,
-                               print_builtin, latex_printer=latex_printer)
+                               print_builtin, latex_printer)
     else:
         _init_python_printing(stringify_func)

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -93,7 +93,8 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         If o is a container type, this is True if and only if every element of
         o can be printed with LaTeX.
         """
-        import sympy
+        from sympy import Basic
+        from sympy.matrices import MatrixBase
         from sympy.physics.vector import Vector, Dyadic
         if isinstance(o, (list, tuple, set, frozenset)):
             return all(_can_print_latex(i) for i in o)
@@ -101,7 +102,9 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
             return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
         elif isinstance(o, bool):
             return False
-        elif isinstance(o, (sympy.Basic, sympy.matrices.MatrixBase, Vector, Dyadic)):
+        # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
+        # to use here, than these explicit imports.
+        elif isinstance(o, (Basic, MatrixBase, Vector, Dyadic)):
             return True
         elif isinstance(o, (float, integer_types)) and print_builtin:
             return True

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 from io import BytesIO
 
-from sympy import latex
+from sympy import latex as default_latex
 from sympy import preview
 from sympy.core.compatibility import integer_types
 from sympy.utilities.misc import debug
@@ -61,6 +61,10 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
 
     if latex_printer is not None:
         latex = latex_printer
+    else:
+        latex = default_latex
+
+    print("latex printer after: {}".format(latex))
 
     def _print_plain(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""
@@ -72,12 +76,13 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     def _preview_wrapper(o):
         exprbuffer = BytesIO()
         try:
-            preview(o, output='png', viewer='BytesIO', outputbuffer=exprbuffer,
-                preamble=preamble, dvioptions=dvioptions)
+            preview(o, output='png', viewer='BytesIO',
+                    outputbuffer=exprbuffer, preamble=preamble,
+                    dvioptions=dvioptions)
         except Exception as e:
             # IPython swallows exceptions
             debug("png printing:", "_preview_wrapper exception raised:",
-                repr(e))
+                  repr(e))
             raise
         return exprbuffer.getvalue()
 
@@ -87,7 +92,6 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
         o = o.replace(r'\operatorname', '')
         o = o.replace(r'\overline', r'\bar')
         return latex_to_png(o)
-
 
     def _can_print_latex(o):
         """Return True if type o can be printed with LaTeX.
@@ -222,8 +226,9 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
     ==========
 
     pretty_print: boolean
-        If True, use pretty_print to stringify;
-        if False, use sstrrepr to stringify.
+        If True, use pretty_print to stringify or the provided pretty
+        printer; if False, use sstrrepr to stringify or the provided string
+        printer.
     order: string or None
         There are a few different settings for this parameter:
         lex (default), which is lexographic order;
@@ -274,11 +279,13 @@ def init_printing(pretty_print=True, order=None, use_unicode=None,
         If true then floats and integers will be printed. If false the
         printer will only print SymPy types.
     str_printer: function, optiona, default=None
-        A custom string printer.
+        A custom string printer function. This should mimic
+        sympy.printing.sstrrepr().
     pretty_printer: function, optional, default=None
-        A custom pretty printer.
+        A custom pretty printer. This should mimic sympy.printing.pretty().
     latex_printer: function, optional, default=None
-        A custom LaTeX printer.
+        A custom LaTeX printer. This should mimic sympy.printing.latex()
+        This should mimic sympy.printing.latex().
 
     Examples
     ========

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -58,10 +58,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     debug("init_printing: DVIOPTIONS:", dvioptions)
     debug("init_printing: PREAMBLE:", preamble)
 
-    if latex_printer is not None:
-        latex = latex_printer
-    else:
-        latex = default_latex
+    latex = latex_printer or default_latex
 
     def _print_plain(arg, p, cycle):
         """caller for pretty, for use in IPython 0.11"""

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -34,15 +34,3 @@ __all__.extend(lagrange.__all__)
 from sympy.physics import vector
 from sympy.physics.vector import *
 __all__.extend(vector.__all__)
-
-# These are functions that we've renamed in during the extraction of the
-# basic vector calculus code from the mechanics packages.
-# TODO : Add deprecation warnings for using these:
-
-mechanics_printing = init_printing
-mprint = vprint
-msprint = vsprint
-mpprint = vpprint
-mlatex = vlatex
-
-__all__.extend(['mechanics_printing', 'mprint', 'msprint', 'mpprint', 'mlatex'])

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -31,36 +31,17 @@ from . import lagrange
 from .lagrange import *
 __all__.extend(lagrange.__all__)
 
+from sympy.physics import vector
+from sympy.physics.vector import *
+__all__.extend(vector.__all__)
 
-#Import essential elements from physics.vector module
-from sympy.physics.vector.frame import ReferenceFrame, CoordinateSym
-from sympy.physics.vector.dyadic import Dyadic
-from sympy.physics.vector.vector import Vector
-from sympy.physics.vector.printing import (
-    VectorStrPrinter as MechanicsStrPrinter,
-    VectorLatexPrinter as MechanicsLatexPrinter,
-    VectorPrettyPrinter as MechanicsPrettyPrinter)
-from sympy.physics.vector.point import Point
-from sympy.physics.vector.functions import (cross, dot, express,
-                                            time_derivative, outer,
-                                            kinematic_equations,
-                                            get_motion_params,
-                                            partial_velocity,
-                                            dynamicsymbols)
-from sympy.physics.vector.functions import (
-     time_derivative_printing as mechanics_printing,
-     vprint as mprint, vsprint as msprint,
-     vpprint as mpprint, vlatex as mlatex)
+# These are functions that we've renamed in during the extraction of the
+# basic vector calculus code from the mechanics packages.
+# TODO : Add deprecation warnings for using these:
 
-#essentialnames contains all names to be imported from vector package
-essentialnames = ['ReferenceFrame', 'CoordinateSym',
-                  'Dyadic', 'Vector', 'MechanicsStrPrinter',
-                  'MechanicsLatexPrinter',
-                  'MechanicsPrettyPrinter', 'dynamicsymbols',
-                  'Point', 'cross', 'dot', 'express',
-                  'time_derivative', 'outer', 'kinematic_equations',
-                  'get_motion_params', 'partial_velocity',
-                  'mechanics_printing', 'mprint', 'msprint',
-                  'mpprint', 'mlatex']
+mechanics_printing = init_printing
+msprint = vsprint
+mpprint = vpprint
+mlatex = vlatex
 
-__all__.extend(essentialnames)
+__all__.extend(['mechanics_printing', 'msprint', 'mpprint', 'mlatex'])

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -40,8 +40,9 @@ __all__.extend(vector.__all__)
 # TODO : Add deprecation warnings for using these:
 
 mechanics_printing = init_printing
+mprint = vprint
 msprint = vsprint
 mpprint = vpprint
 mlatex = vlatex
 
-__all__.extend(['mechanics_printing', 'msprint', 'mpprint', 'mlatex'])
+__all__.extend(['mechanics_printing', 'mprint', 'msprint', 'mpprint', 'mlatex'])

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -6,13 +6,55 @@ __all__ = ['inertia',
            'angular_momentum',
            'kinetic_energy',
            'potential_energy',
-           'Lagrangian']
+           'Lagrangian',
+           'mechanics_printing',
+           'mprint',
+           'msprint',
+           'mpprint',
+           'mlatex']
 
 from sympy.physics.vector import Vector, ReferenceFrame, Point
+from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
+                                           init_vprinting)
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy import sympify
 from sympy.core.basic import S
+
+# These are functions that we've renamed in during the extraction of the
+# basic vector calculus code from the mechanics packages.
+
+mprint = vprint
+msprint = vsprint
+mpprint = vpprint
+mlatex = vlatex
+
+
+def mechanics_printing(**kwargs):
+
+    # mechanics_printing has slightly different functionality in 0.7.5 but
+    # shouldn't fundamentally need a deprecation warning so we do this
+    # little wrapper that gives the warning that things have changed.
+
+    # TODO : Remove this warning in SymPy 0.7.6 (or whatever the next
+    # release is after 0.7.5.
+
+    # The message is only printed if this function is called with no args,
+    # as was the previous only way to call it.
+
+    def dict_is_empty(D):
+        for k in D:
+            return False
+        return True
+
+    if dict_is_empty(kwargs):
+        print('See the doc string for slight changes to this function, '
+              'keyword args may be needed for the desired effect. Otherwise '
+              'use sympy.physics.vector.init_vprinting directly.')
+
+    init_vprinting(**kwargs)
+
+mechanics_printing.__doc__ = init_vprinting.__doc__
 
 
 def inertia(frame, ixx, iyy, izz, ixy=0, iyz=0, izx=0):

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -21,7 +21,7 @@ from sympy.physics.mechanics.rigidbody import RigidBody
 from sympy import sympify
 from sympy.core.basic import S
 
-# These are functions that we've renamed in during the extraction of the
+# These are functions that we've moved and renamed during extracting the
 # basic vector calculus code from the mechanics packages.
 
 mprint = vprint
@@ -37,7 +37,7 @@ def mechanics_printing(**kwargs):
     # little wrapper that gives the warning that things have changed.
 
     # TODO : Remove this warning in SymPy 0.7.6 (or whatever the next
-    # release is after 0.7.5.
+    # release is after 0.7.5
 
     # The message is only printed if this function is called with no args,
     # as was the previous only way to call it.

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -1,4 +1,15 @@
 from __future__ import print_function, division
+import warnings
+
+from sympy.utilities.exceptions import SymPyDeprecationWarning
+from sympy.utilities.misc import filldedent
+from sympy.physics.vector import Vector, ReferenceFrame, Point
+from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
+                                           init_vprinting)
+from sympy.physics.mechanics.particle import Particle
+from sympy.physics.mechanics.rigidbody import RigidBody
+from sympy import sympify
+from sympy.core.basic import S
 
 __all__ = ['inertia',
            'inertia_of_point_mass',
@@ -13,13 +24,7 @@ __all__ = ['inertia',
            'mpprint',
            'mlatex']
 
-from sympy.physics.vector import Vector, ReferenceFrame, Point
-from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
-                                           init_vprinting)
-from sympy.physics.mechanics.particle import Particle
-from sympy.physics.mechanics.rigidbody import RigidBody
-from sympy import sympify
-from sympy.core.basic import S
+warnings.simplefilter("always", SymPyDeprecationWarning)
 
 # These are functions that we've moved and renamed during extracting the
 # basic vector calculus code from the mechanics packages.
@@ -48,9 +53,10 @@ def mechanics_printing(**kwargs):
         return True
 
     if dict_is_empty(kwargs):
-        print('See the doc string for slight changes to this function,\n'
-              'keyword args may be needed for the desired effect. Otherwise \n'
-              'use sympy.physics.vector.init_vprinting directly.')
+        msg = ('See the doc string for slight changes to this function: '
+               'keyword args may be needed for the desired effect. '
+               'Otherwise use sympy.physics.vector.init_vprinting directly.')
+        SymPyDeprecationWarning(filldedent(msg)).warn()
 
     init_vprinting(**kwargs)
 

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -48,8 +48,8 @@ def mechanics_printing(**kwargs):
         return True
 
     if dict_is_empty(kwargs):
-        print('See the doc string for slight changes to this function, '
-              'keyword args may be needed for the desired effect. Otherwise '
+        print('See the doc string for slight changes to this function,\n'
+              'keyword args may be needed for the desired effect. Otherwise \n'
               'use sympy.physics.vector.init_vprinting directly.')
 
     init_vprinting(**kwargs)

--- a/sympy/physics/vector/__init__.py
+++ b/sympy/physics/vector/__init__.py
@@ -1,12 +1,36 @@
-from .frame import ReferenceFrame, CoordinateSym
-from .dyadic import Dyadic
-from .vector import Vector
-from .point import Point
-from .functions import (cross, dot, express, time_derivative, outer,
-                        time_derivative_printing, vprint, vsprint, vpprint,
-                        vlatex, kinematic_equations, get_motion_params,
-                        partial_velocity, dynamicsymbols, init_printing)
-# TODO : Is it really necessary to import these printer classes at the
-# package level?
-from .printing import (VectorStrPrinter, VectorLatexPrinter,
-                       VectorPrettyPrinter)
+__all__ = []
+
+# The following pattern is used below for importing sub-modules:
+#
+# 1. "from foo import *".  This imports all the names from foo.__all__ into
+#    this module. But, this does not put those names into the __all__ of
+#    this module. This enables "from sympy.physics.vector import ReferenceFrame" to
+#    work.
+# 2. "import foo; __all__.extend(foo.__all__)". This adds all the names in
+#    foo.__all__ to the __all__ of this module. The names in __all__
+#    determine which names are imported when
+#    "from sympy.physics.vector import *" is done.
+
+from . import frame
+from .frame import *
+__all__.extend(frame.__all__)
+
+from . import dyadic
+from .dyadic import *
+__all__.extend(dyadic.__all__)
+
+from . import vector
+from .vector import *
+__all__.extend(vector.__all__)
+
+from . import point
+from .point import *
+__all__.extend(point.__all__)
+
+from . import functions
+from .functions import *
+__all__.extend(functions.__all__)
+
+from . import printing
+from .printing import *
+__all__.extend(printing.__all__)

--- a/sympy/physics/vector/__init__.py
+++ b/sympy/physics/vector/__init__.py
@@ -1,10 +1,12 @@
 from .frame import ReferenceFrame, CoordinateSym
 from .dyadic import Dyadic
 from .vector import Vector
-from .printing import (VectorStrPrinter, VectorLatexPrinter,
-                       VectorPrettyPrinter)
 from .point import Point
 from .functions import (cross, dot, express, time_derivative, outer,
                         time_derivative_printing, vprint, vsprint, vpprint,
                         vlatex, kinematic_equations, get_motion_params,
-                        partial_velocity, dynamicsymbols)
+                        partial_velocity, dynamicsymbols, init_printing)
+# TODO : Is it really necessary to import these printer classes at the
+# package level?
+from .printing import (VectorStrPrinter, VectorLatexPrinter,
+                       VectorPrettyPrinter)

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -1,7 +1,9 @@
 from sympy import sympify, Add, ImmutableMatrix as Matrix
+from sympy.core.compatibility import u
 from .printing import (VectorLatexPrinter, VectorPrettyPrinter,
                        VectorStrPrinter)
-from sympy.core.compatibility import u
+
+__all__ = ['Dyadic']
 
 
 class Dyadic(object):

--- a/sympy/physics/vector/dyadic.py
+++ b/sympy/physics/vector/dyadic.py
@@ -207,20 +207,22 @@ class Dyadic(object):
                     if ar[i][0] == 1:
                         ol.append(u(" + ") +
                                   mpp.doprint(ar[i][1]) +
-                                  u("\u2a02 ") +
+                                  u("\u2297") +
                                   mpp.doprint(ar[i][2]))
                     # if the coef of the dyadic is -1, we skip the 1
                     elif ar[i][0] == -1:
                         ol.append(u(" - ") +
                                   mpp.doprint(ar[i][1]) +
-                                  u("\u2a02 ") +
+                                  u("\u2297") +
                                   mpp.doprint(ar[i][2]))
                     # If the coefficient of the dyadic is not 1 or -1,
                     # we might wrap it in parentheses, for readability.
                     elif ar[i][0] != 0:
-                        arg_str = mpp.doprint(ar[i][0])
                         if isinstance(ar[i][0], Add):
-                            arg_str = u("(%s)") % arg_str
+                            arg_str = VectorPrettyPrinter()._print(
+                                ar[i][0]).parens()[0]
+                        else:
+                            arg_str = mpp.doprint(ar[i][0])
                         if arg_str.startswith(u("-")):
                             arg_str = arg_str[1:]
                             str_start = u(" - ")
@@ -228,7 +230,7 @@ class Dyadic(object):
                             str_start = u(" + ")
                         ol.append(str_start + arg_str + u(" ") +
                                   mpp.doprint(ar[i][1]) +
-                                  u("\u2a02 ") +
+                                  u("\u2297") +
                                   mpp.doprint(ar[i][2]))
                 outstr = u("").join(ol)
                 if outstr.startswith(u(" + ")):

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1,7 +1,7 @@
 from sympy import (diff, trigsimp, expand, sin, cos, solve, Symbol, sympify,
                    eye, ImmutableMatrix as Matrix)
 from sympy.core.compatibility import string_types, u
-from .vector import Vector, _check_vector
+from sympy.physics.vector.vector import Vector, _check_vector
 
 __all__ = ['CoordinateSym', 'ReferenceFrame']
 

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -1,7 +1,9 @@
-from sympy import diff, trigsimp, expand, sin, cos, \
-     solve, Symbol, sympify, eye, ImmutableMatrix as Matrix
+from sympy import (diff, trigsimp, expand, sin, cos, solve, Symbol, sympify,
+                   eye, ImmutableMatrix as Matrix)
 from sympy.core.compatibility import string_types, u
-from sympy.physics.vector.vector import Vector, _check_vector
+from .vector import Vector, _check_vector
+
+__all__ = ['CoordinateSym', 'ReferenceFrame']
 
 
 class CoordinateSym(Symbol):
@@ -735,6 +737,6 @@ class ReferenceFrame(object):
 
 
 def _check_frame(other):
-    from sympy.physics.vector.printing import VectorTypeError
+    from .vector import VectorTypeError
     if not isinstance(other, ReferenceFrame):
         raise VectorTypeError(other, "ReferenceFrame")

--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -739,4 +739,4 @@ class ReferenceFrame(object):
 def _check_frame(other):
     from .vector import VectorTypeError
     if not isinstance(other, ReferenceFrame):
-        raise VectorTypeError(other, "ReferenceFrame")
+        raise VectorTypeError(other, ReferenceFrame('A'))

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -1,17 +1,16 @@
 from __future__ import print_function, division
 
-from sympy import (sympify, solve, diff, sin, cos, Matrix, Symbol,
-                   integrate, trigsimp, Function, symbols)
+from sympy import (sympify, diff, sin, cos, Matrix, Symbol, integrate,
+                   trigsimp, Function, symbols)
 from sympy.core.basic import S
 from sympy.core.compatibility import reduce
-from sympy.physics.vector.vector import Vector, _check_vector
-from sympy.physics.vector.frame import (CoordinateSym, ReferenceFrame,
-                                        _check_frame)
-from sympy.physics.vector.dyadic import Dyadic
-from sympy.physics.vector.point import Point
-from sympy.physics.vector.printing import (VectorStrPrinter,
-                                           VectorPrettyPrinter,
-                                           VectorLatexPrinter)
+from .vector import Vector, _check_vector
+from .frame import CoordinateSym, _check_frame
+from .dyadic import Dyadic
+
+__all__ = ['cross', 'dot', 'express', 'time_derivative', 'outer',
+           'kinematic_equations', 'get_motion_params', 'partial_velocity',
+           'dynamicsymbols']
 
 
 def cross(vec1, vec2):
@@ -97,7 +96,7 @@ def express(expr, frame, frame2=None, variables=False):
             if v[1] != frame:
                 temp = frame.dcm(v[1]) * v[0]
                 if Vector.simp:
-                    temp = temp.applyfunc(lambda x: \
+                    temp = temp.applyfunc(lambda x:
                                           trigsimp(x, method='fu'))
                 outvec += Vector([(temp, frame)])
             else:
@@ -111,7 +110,7 @@ def express(expr, frame, frame2=None, variables=False):
         ol = Dyadic(0)
         for i, v in enumerate(expr.args):
             ol += express(v[0], frame, variables=variables) * \
-                  (express(v[1], frame, variables=variables) | \
+                  (express(v[1], frame, variables=variables) |
                    express(v[2], frame2, variables=variables))
         return ol
 
@@ -156,7 +155,7 @@ def time_derivative(expr, frame, order=1):
     Examples
     ========
 
-    >>> from sympy.physics.vector import ReferenceFrame, Vector, dynamicsymbols
+    >>> from sympy.physics.vector import ReferenceFrame, dynamicsymbols
     >>> from sympy import Symbol
     >>> q1 = Symbol('q1')
     >>> u1 = dynamicsymbols('u1')
@@ -182,18 +181,18 @@ def time_derivative(expr, frame, order=1):
 
     if order == 0:
         return expr
-    if order%1 != 0 or order < 0:
+    if order % 1 != 0 or order < 0:
         raise ValueError("Unsupported value of order entered")
 
     if isinstance(expr, Vector):
         outvec = Vector(0)
         for i, v in enumerate(expr.args):
             if v[1] == frame:
-                outvec += Vector([(express(v[0], frame, \
+                outvec += Vector([(express(v[0], frame,
                                            variables=True).diff(t), frame)])
             else:
                 outvec += time_derivative(Vector([v]), v[1]) + \
-                          (v[1].ang_vel_in(frame) ^ Vector([v]))
+                    (v[1].ang_vel_in(frame) ^ Vector([v]))
         return time_derivative(outvec, frame, order - 1)
 
     if isinstance(expr, Dyadic):
@@ -214,210 +213,6 @@ def outer(vec1, vec2):
         raise TypeError('Outer product is between two Vectors')
     return vec1 | vec2
 outer.__doc__ += Vector.outer.__doc__
-
-
-def time_derivative_printing():
-    """Sets up interactive printing for vector derivatives.
-
-    The main benefit of this is for printing of time derivatives; instead of
-    displaying as Derivative(f(t),t), it will display f' This is only
-    actually needed for when derivatives are present and are not in a
-    physics.vector.Vector or physics.vector.Dyadic object.
-
-    Examples
-    ========
-
-    >>> # 2 lines below are for tests to function properly
-    >>> import sys
-    >>> sys.displayhook = sys.__displayhook__
-    >>> from sympy import Function, Symbol, diff
-    >>> from sympy.physics.vector import time_derivative_printing
-    >>> f = Function('f')
-    >>> t = Symbol('t')
-    >>> x = Symbol('x')
-    >>> diff(f(t), t)
-    Derivative(f(t), t)
-    >>> time_derivative_printing()
-    >>> diff(f(t), t)
-    f'
-    >>> diff(f(x), x)
-    Derivative(f(x), x)
-    >>> # 2 lines below are for tests to function properly
-    >>> import sys
-    >>> sys.displayhook = sys.__displayhook__
-
-    """
-
-    # TODO : Remove this function once init_printing works, as this
-    # displyhook stuff is in sympy.interactive.printing.
-
-    import sys
-    sys.displayhook = vprint
-
-
-def vprint(expr, **settings):
-    r"""Function for printing of expressions generated in the
-    sympy.physics vector package.
-
-    Extends SymPy's StrPrinter; vprint is equivalent to:
-    print sstr()
-    vprint takes the same options as sstr.
-
-    Parameters
-    ==========
-
-    expr : valid sympy object
-        SymPy expression to print
-    settings : args
-        Same as print for SymPy
-
-    Examples
-    ========
-
-    >>> from sympy.physics.vector import vprint, dynamicsymbols
-    >>> u1 = dynamicsymbols('u1')
-    >>> print(u1)
-    u1(t)
-    >>> vprint(u1)
-    u1
-
-    """
-
-    outstr = vsprint(expr, **settings)
-
-    from sympy.core.compatibility import builtins
-    if (outstr != 'None'):
-        builtins._ = outstr
-        print(outstr)
-
-class VectorStrReprPrinter(VectorStrPrinter):
-    def _print_str(self, s):
-        return repr(s)
-
-def vsstrtepr(exp, **settings):
-    p = VectorStrReprPrinter(settings)
-    return p.doprint(expr)
-
-
-def vsprint(expr, **settings):
-    r"""Function for displaying expressions generated in the
-    sympy.physics vector package.
-
-    Returns the output of vprint() as a string.
-
-    Parameters
-    ==========
-
-    expr : valid sympy object
-        SymPy expression to print
-    settings : args
-        Same as print for SymPy
-
-    Examples
-    ========
-
-    >>> from sympy.physics.vector import vsprint, dynamicsymbols
-    >>> u1, u2 = dynamicsymbols('u1 u2')
-    >>> u2d = dynamicsymbols('u2', level=1)
-    >>> print("%s = %s" % (u1, u2 + u2d))
-    u1(t) = u2(t) + Derivative(u2(t), t)
-    >>> print("%s = %s" % (vsprint(u1), vsprint(u2 + u2d)))
-    u1 = u2 + u2'
-
-    """
-
-    string_printer = VectorStrPrinter(settings)
-    return string_printer.doprint(expr)
-
-
-def vpprint(expr, **settings):
-    r"""Function for pretty printing of expressions generated in the
-    sympy.physics vector package.
-
-    Mainly used for expressions not inside a vector; the output of running
-    scripts and generating equations of motion. Takes the same options as
-    SymPy's pretty_print(); see that function for more information.
-
-    Parameters
-    ==========
-
-    expr : valid sympy object
-        SymPy expression to pretty print
-    settings : args
-        Same as pretty print
-
-    Examples
-    ========
-
-    Use in the same way as pprint
-
-    """
-
-    pp = VectorPrettyPrinter(settings)
-
-    # XXX: this is an ugly hack, but at least it works
-    use_unicode = pp._settings['use_unicode']
-    from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
-    uflag = pretty_use_unicode(use_unicode)
-
-    try:
-        return pp.doprint(expr)
-    finally:
-        pretty_use_unicode(uflag)
-
-
-def vlatex(expr, **settings):
-    r"""Function for printing latex representation of sympy.physics.vector
-    objects.
-
-    For latex representation of Vectors, Dyadics, and dynamicsymbols. Takes the
-    same options as SymPy's latex(); see that function for more information;
-
-    Parameters
-    ==========
-
-    expr : valid sympy object
-        SymPy expression to represent in LaTeX form
-    settings : args
-        Same as latex()
-
-    Examples
-    ========
-
-    >>> from sympy.physics.vector import vlatex, ReferenceFrame, dynamicsymbols
-    >>> N = ReferenceFrame('N')
-    >>> q1, q2 = dynamicsymbols('q1 q2')
-    >>> q1d, q2d = dynamicsymbols('q1 q2', 1)
-    >>> q1dd, q2dd = dynamicsymbols('q1 q2', 2)
-    >>> vlatex(N.x + N.y)
-    '\\mathbf{\\hat{n}_x} + \\mathbf{\\hat{n}_y}'
-    >>> vlatex(q1 + q2)
-    'q_{1} + q_{2}'
-    >>> vlatex(q1d)
-    '\\dot{q}_{1}'
-    >>> vlatex(q1 * q2d)
-    'q_{1} \\dot{q}_{2}'
-    >>> vlatex(q1dd * q1 / q1d)
-    '\\frac{q_{1} \\ddot{q}_{1}}{\\dot{q}_{1}}'
-
-    """
-    latex_printer = VectorLatexPrinter(settings)
-
-    return latex_printer.doprint(expr)
-
-
-def init_printing(**kwargs):
-    """Initializes time derivative printing for all sympy objects, i.e. any
-    functions of time will be displayed in a more compact notation. Take key
-    word arguments for `init_printing`:
-
-    """
-    from sympy.interactive.printing import init_printing as default_init_printing
-    #__doc__ = __doc__ + default_init_printing.__doc__
-    kwargs['str_printer'] = vsstrtepr
-    kwargs['pretty_printer'] = vpprint
-    kwargs['latex_printer'] = vlatex
-    default_init_printing(**kwargs)
 
 
 def kinematic_equations(speeds, coords, rot_type, rot_order=''):
@@ -803,10 +598,10 @@ def dynamicsymbols(names, level=0):
     esses = symbols(names, cls=Function)
     t = dynamicsymbols._t
     if hasattr(esses, '__iter__'):
-        esses = [reduce(diff, [t]*level, e(t)) for e in esses]
+        esses = [reduce(diff, [t] * level, e(t)) for e in esses]
         return esses
     else:
-        return reduce(diff, [t]*level, esses(t))
+        return reduce(diff, [t] * level, esses(t))
 
 
 dynamicsymbols._t = Symbol('t')

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -326,8 +326,8 @@ def vsprint(expr, **settings):
 
     """
 
-    pr = VectorStrPrinter(settings)
-    return pr.doprint(expr)
+    string_printer = VectorStrPrinter(settings)
+    return string_printer.doprint(expr)
 
 
 def vpprint(expr, **settings):
@@ -401,8 +401,9 @@ def vlatex(expr, **settings):
     '\\frac{q_{1} \\ddot{q}_{1}}{\\dot{q}_{1}}'
 
     """
+    latex_printer = VectorLatexPrinter(settings)
 
-    return VectorLatexPrinter(settings).doprint(expr)
+    return latex_printer.doprint(expr)
 
 
 def init_printing(**kwargs):

--- a/sympy/physics/vector/functions.py
+++ b/sympy/physics/vector/functions.py
@@ -7,10 +7,12 @@ from sympy.core.compatibility import reduce
 from .vector import Vector, _check_vector
 from .frame import CoordinateSym, _check_frame
 from .dyadic import Dyadic
+from .printing import vprint, vsprint, vpprint, vlatex, init_vprinting
 
 __all__ = ['cross', 'dot', 'express', 'time_derivative', 'outer',
            'kinematic_equations', 'get_motion_params', 'partial_velocity',
-           'dynamicsymbols']
+           'dynamicsymbols', 'vprint', 'vsprint', 'vpprint', 'vlatex',
+           'init_vprinting']
 
 
 def cross(vec1, vec2):

--- a/sympy/physics/vector/point.py
+++ b/sympy/physics/vector/point.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division
-from sympy.physics.vector.vector import Vector, _check_vector
-from sympy.physics.vector.frame import _check_frame
+from .vector import Vector, _check_vector
+from .frame import _check_frame
+
+__all__ = ['Point']
 
 
 class Point(object):

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -181,11 +181,11 @@ class VectorPrettyPrinter(PrettyPrinter):
         if len(pform.picture) > 1:
             return super(VectorPrettyPrinter, self)._print_Derivative(deriv)
 
-        dots = {0 : u"",
-                1 : u"\u0307",
-                2 : u"\u0308",
-                3 : u"\u20db",
-                4 : u"\u20dc"}
+        dots = {0 : u(""),
+                1 : u("\u0307"),
+                2 : u("\u0308"),
+                3 : u("\u20db"),
+                4 : u("\u20dc")}
 
         d = pform.__dict__
         pic = d['picture'][0]

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -379,7 +379,7 @@ def init_vprinting(**kwargs):
     light wrapper to `sympy.interactive.init_printing`. Any keyword
     arguments for it are valid here.
 
-    {}
+    {0}
 
     Examples
     ========

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -256,9 +256,12 @@ class VectorPrettyPrinter(PrettyPrinter):
         return pform
 
 
+# TODO : Why is this in printing??
 class VectorTypeError(TypeError):
 
     def __init__(self, other, type_str):
         msg = ("Expected an instance of %s, instead received an object "
                "'%s' of type %s.") % (type_str, other, type(other))
         super(VectorTypeError, self).__init__(msg)
+
+

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -221,17 +221,16 @@ def vprint(expr, **settings):
     r"""Function for printing of expressions generated in the
     sympy.physics vector package.
 
-    Extends SymPy's StrPrinter; vprint is equivalent to:
-    print(sstr())
-    vprint takes the same options as sstr.
+    Extends SymPy's StrPrinter, takes the same setting accepted by SymPy's
+    `sstr()`, and is equivalent to `print(sstr(foo))`.
 
     Parameters
     ==========
 
     expr : valid sympy object
-        SymPy expression to print
+        SymPy expression to print.
     settings : args
-        Same as print for SymPy
+        Same as print for SymPy's sstr().
 
     Examples
     ========
@@ -305,12 +304,8 @@ def vpprint(expr, **settings):
     expr : valid sympy object
         SymPy expression to pretty print
     settings : args
-        Same as pretty print
+        Same as those accepted by SymPy's pretty_print.
 
-    Examples
-    ========
-
-    Use in the same way as pprint
 
     """
 
@@ -375,7 +370,7 @@ def init_vprinting(**kwargs):
     benefit of this is for printing of time derivatives; instead of
     displaying as ``Derivative(f(t),t)``, it will display ``f'``. This is
     only actually needed for when derivatives are present and are not in a
-    physics.vector.Vector or physics.vector.Dyadic object.This function is a
+    physics.vector.Vector or physics.vector.Dyadic object. This function is a
     light wrapper to `sympy.interactive.init_printing`. Any keyword
     arguments for it are valid here.
 
@@ -392,7 +387,9 @@ def init_vprinting(**kwargs):
     Derivative(omega(x), x)
     >>> omega(t).diff()
     Derivative(omega(t), t)
-    >>> # Use the string printer.
+
+    Now use the string printer:
+
     >>> init_vprinting(pretty_print=False)
     >>> omega(x).diff()
     Derivative(omega(x), x)

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -230,7 +230,7 @@ def vprint(expr, **settings):
     expr : valid sympy object
         SymPy expression to print.
     settings : args
-        Same as print for SymPy's sstr().
+        Same as the settings accepted by SymPy's sstr().
 
     Examples
     ========

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -227,7 +227,7 @@ def vprint(expr, **settings):
     Parameters
     ==========
 
-    expr : valid sympy object
+    expr : valid SymPy object
         SymPy expression to print.
     settings : args
         Same as the settings accepted by SymPy's sstr().
@@ -259,7 +259,7 @@ def vsstrrepr(expr, **settings):
     Parameters
     ==========
 
-    expr : valid sympy object
+    expr : valid SymPy object
         SymPy expression to print.
     settings : args
         Same as the settings accepted by SymPy's sstrrepr().
@@ -278,7 +278,7 @@ def vsprint(expr, **settings):
     Parameters
     ==========
 
-    expr : valid sympy object
+    expr : valid SymPy object
         SymPy expression to print
     settings : args
         Same as the settings accepted by SymPy's sstr().
@@ -311,7 +311,7 @@ def vpprint(expr, **settings):
     Parameters
     ==========
 
-    expr : valid sympy object
+    expr : valid SymPy object
         SymPy expression to pretty print
     settings : args
         Same as those accepted by SymPy's pretty_print.
@@ -344,7 +344,7 @@ def vlatex(expr, **settings):
     Parameters
     ==========
 
-    expr : valid sympy object
+    expr : valid SymPy object
         SymPy expression to represent in LaTeX form
     settings : args
         Same as latex()

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -254,7 +254,17 @@ def vprint(expr, **settings):
 
 def vsstrrepr(expr, **settings):
     """Function for displaying expression representation's with vector
-    printing enabled."""
+    printing enabled.
+
+    Parameters
+    ==========
+
+    expr : valid sympy object
+        SymPy expression to print.
+    settings : args
+        Same as the settings accepted by SymPy's sstrrepr().
+
+    """
     p = VectorStrReprPrinter(settings)
     return p.doprint(expr)
 
@@ -271,7 +281,7 @@ def vsprint(expr, **settings):
     expr : valid sympy object
         SymPy expression to print
     settings : args
-        Same as print for SymPy
+        Same as the settings accepted by SymPy's sstr().
 
     Examples
     ========

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -386,22 +386,6 @@ def init_printing(**kwargs):
     Derivative(omega(x), x)
     >>> omega(t).diff()
     Derivative(omega(t), t)
-    >>> # Default uses pretty print and unicode.
-    >>> init_printing()
-    >>> omega(x).diff()
-    d
-    ──(ω(x))
-    dx
-    >>> omega(t).diff()
-    ω̇
-    >>> # Use only ASCII.
-    >>> init_printing(use_unicode=False)
-    >>> omega(x).diff()
-    d
-    --(omega(x))
-    dx
-    >>> omega(t).diff()
-    omegȧ
     >>> # Use the string printer.
     >>> init_printing(pretty_print=False)
     >>> omega(x).diff()

--- a/sympy/physics/vector/printing.py
+++ b/sympy/physics/vector/printing.py
@@ -4,14 +4,14 @@ from sympy import Derivative
 from sympy.core import C
 from sympy.core.compatibility import u
 from sympy.core.function import UndefinedFunction
+from sympy.interactive.printing import init_printing
 from sympy.printing.conventions import split_super_sub
 from sympy.printing.latex import LatexPrinter, translate
 from sympy.printing.pretty.pretty import PrettyPrinter
-from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.str import StrPrinter
-from sympy.utilities import group
 
-__all__ = ['vprint', 'vsstrrepr', 'vsprint', 'vpprint', 'vlatex', 'init_printing']
+__all__ = ['vprint', 'vsstrrepr', 'vsprint', 'vpprint', 'vlatex',
+           'init_vprinting']
 
 
 class VectorStrPrinter(StrPrinter):
@@ -38,6 +38,7 @@ class VectorStrPrinter(StrPrinter):
 
 
 class VectorStrReprPrinter(VectorStrPrinter):
+    """String repr printer for vector expressions."""
     def _print_str(self, s):
         return repr(s)
 
@@ -200,7 +201,6 @@ class VectorPrettyPrinter(PrettyPrinter):
 
         return pform
 
-
     def _print_Function(self, e):
         from sympy.physics.vector.functions import dynamicsymbols
         t = dynamicsymbols._t
@@ -222,7 +222,7 @@ def vprint(expr, **settings):
     sympy.physics vector package.
 
     Extends SymPy's StrPrinter; vprint is equivalent to:
-    print sstr()
+    print(sstr())
     vprint takes the same options as sstr.
 
     Parameters
@@ -254,6 +254,8 @@ def vprint(expr, **settings):
 
 
 def vsstrrepr(expr, **settings):
+    """Function for displaying expression representation's with vector
+    printing enabled."""
     p = VectorStrReprPrinter(settings)
     return p.doprint(expr)
 
@@ -314,6 +316,8 @@ def vpprint(expr, **settings):
 
     pp = VectorPrettyPrinter(settings)
 
+    # Note that this is copied from sympy.printing.pretty.pretty_print:
+
     # XXX: this is an ugly hack, but at least it works
     use_unicode = pp._settings['use_unicode']
     from sympy.printing.pretty.pretty_symbology import pretty_use_unicode
@@ -365,21 +369,23 @@ def vlatex(expr, **settings):
     return latex_printer.doprint(expr)
 
 
-def init_printing(**kwargs):
+def init_vprinting(**kwargs):
     """Initializes time derivative printing for all SymPy objects, i.e. any
-    functions of time will be displayed in a more compact notation. Any key
-    word arguments for `sympy.interactive.init_printing` are valid.
-
-    The main benefit of this is for printing of time derivatives; instead of
+    functions of time will be displayed in a more compact notation. The main
+    benefit of this is for printing of time derivatives; instead of
     displaying as ``Derivative(f(t),t)``, it will display ``f'``. This is
     only actually needed for when derivatives are present and are not in a
-    physics.vector.Vector or physics.vector.Dyadic object.
+    physics.vector.Vector or physics.vector.Dyadic object.This function is a
+    light wrapper to `sympy.interactive.init_printing`. Any keyword
+    arguments for it are valid here.
+
+    {}
 
     Examples
     ========
 
     >>> from sympy import Function, symbols
-    >>> from sympy.physics.vector import init_printing
+    >>> from sympy.physics.vector import init_vprinting
     >>> t, x = symbols('t, x')
     >>> omega = Function('omega')
     >>> omega(x).diff()
@@ -387,16 +393,17 @@ def init_printing(**kwargs):
     >>> omega(t).diff()
     Derivative(omega(t), t)
     >>> # Use the string printer.
-    >>> init_printing(pretty_print=False)
+    >>> init_vprinting(pretty_print=False)
     >>> omega(x).diff()
     Derivative(omega(x), x)
     >>> omega(t).diff()
     omega'
 
     """
-    from sympy.interactive.printing import (init_printing as
-                                            default_init_printing)
     kwargs['str_printer'] = vsstrrepr
     kwargs['pretty_printer'] = vpprint
     kwargs['latex_printer'] = vlatex
-    default_init_printing(**kwargs)
+    init_printing(**kwargs)
+
+params = init_printing.__doc__.split('Examples\n    ========')[0]
+init_vprinting.__doc__ = init_vprinting.__doc__.format(params)

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -1,6 +1,6 @@
 from sympy import sin, cos, pi, zeros, ImmutableMatrix as Matrix
-from sympy.physics.vector import ReferenceFrame, Vector, CoordinateSym, \
-     dynamicsymbols, time_derivative, express
+from sympy.physics.vector import (ReferenceFrame, Vector, CoordinateSym,
+                                  dynamicsymbols, time_derivative, express)
 
 
 Vector.simp = True

--- a/sympy/physics/vector/tests/test_output.py
+++ b/sympy/physics/vector/tests/test_output.py
@@ -1,8 +1,6 @@
-from sympy import S, Function
-from sympy.physics.vector import Vector, ReferenceFrame, Dyadic, \
-     VectorLatexPrinter
+from sympy import S
+from sympy.physics.vector import Vector, ReferenceFrame, Dyadic
 from sympy.utilities.pytest import raises
-
 
 Vector.simp = True
 A = ReferenceFrame('A')

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -34,16 +34,16 @@ def test_vector_pretty_print():
 
     pp = VectorPrettyPrinter()
 
-    expected = (u' 2\na *\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + '
-                u'b*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + '
-                u'c\u22c5sin(\u03b1)*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
+    expected = (u' 2\na  \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + b \x1b[94m'
+                u'\x1b[1mn_y\x1b[0;0m\x1b[0;0m + c\u22c5sin(\u03b1) \x1b[9'
+                u'4m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
 
     assert expected == pp.doprint(v)
     assert expected == v._pretty().render()
 
-    expected = (u'\u03b1*\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + '
-                u'sin(\u03c9)*\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + '
-                u'\u03b1\u22c5\u03b2*\x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
+    expected = (u'\u03b1 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + sin(\u03c9'
+                u') \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + \u03b1\u22c5'
+                u'\u03b2 \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;0m')
 
     assert expected == pp.doprint(w)
     assert expected == w._pretty().render()
@@ -127,22 +127,20 @@ def test_vector_latex_with_functions():
 
 def test_dyadic_pretty_print():
 
-    expected = (u' 2\na  \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[9'
-                u'4m\x1b[1mn_y\x1b[0;0m\x1b[0;0m + b \x1b[94m\x1b[1mn_y'
-                u'\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b'
-                u'[0;0m + c\u22c5sin(\u03b1) \x1b[94m\x1b[1mn_z\x1b[0;0m'
-                u'\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m')
-
+    expected = (u' 2\na  \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2297\x1b[94'
+                u'm\x1b[1mn_y\x1b[0;0m\x1b[0;0m + b \x1b[94m\x1b[1mn_y\x1b'
+                u'[0;0m\x1b[0;0m\u2297\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m'
+                u' + c\u22c5sin(\u03b1) \x1b[94m\x1b[1mn_z\x1b[0;0m\x1b[0;'
+                u'0m\u2297\x1b[94m\x1b[1mn_y\x1b[0;0m\x1b[0;0m')
     result = u._pretty().render()
 
     assert expected == result
 
-    expected = (u'\u03b1 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2a02 \x1b[9'
-                u'4m\x1b[1mn_x\x1b[0;0m\x1b[0;0m + sin(\u03c9) \x1b[94m'
-                u'\x1b[1mn_y\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_z'
-                u'\x1b[0;0m\x1b[0;0m + \u03b1\u22c5\u03b2 \x1b[94m\x1b[1mn'
-                u'_z\x1b[0;0m\x1b[0;0m\u2a02 \x1b[94m\x1b[1mn_x\x1b[0;0m'
-                u'\x1b[0;0m')
+    expected = (u'\u03b1 \x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m\u2297\x1b[94'
+                u'm\x1b[1mn_x\x1b[0;0m\x1b[0;0m + sin(\u03c9) \x1b[94m\x1b'
+                u'[1mn_y\x1b[0;0m\x1b[0;0m\u2297\x1b[94m\x1b[1mn_z\x1b[0;0'
+                u'm\x1b[0;0m + \u03b1\u22c5\u03b2 \x1b[94m\x1b[1mn_z\x1b[0'
+                u';0m\x1b[0;0m\u2297\x1b[94m\x1b[1mn_x\x1b[0;0m\x1b[0;0m')
 
     result = x._pretty().render()
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -273,16 +273,19 @@ class Vector(object):
                         elif ar[i][0][j] != 0:
                             # If the basis vector coeff is not 1 or -1,
                             # we might wrap it in parentheses, for readability.
-                            arg_str = (VectorPrettyPrinter().doprint(
-                                ar[i][0][j]))
                             if isinstance(ar[i][0][j], Add):
-                                arg_str = u("(%s)") % arg_str
+                                arg_str = VectorPrettyPrinter()._print(
+                                    ar[i][0][j]).parens()[0]
+                            else:
+                                arg_str = (VectorPrettyPrinter().doprint(
+                                    ar[i][0][j]))
+
                             if arg_str[0] == u("-"):
                                 arg_str = arg_str[1:]
                                 str_start = u(" - ")
                             else:
                                 str_start = u(" + ")
-                            ol.append(str_start + arg_str + '*' +
+                            ol.append(str_start + arg_str + ' ' +
                                       ar[i][1].pretty_vecs[j])
                 outstr = u("").join(ol)
                 if outstr.startswith(u(" + ")):

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -1,6 +1,7 @@
 from sympy import (S, sympify, trigsimp, expand, sqrt, Add, zeros,
                    ImmutableMatrix as Matrix)
 from sympy.core.compatibility import u
+from sympy.utilities.misc import filldedent
 
 __all__ = ['Vector']
 
@@ -632,9 +633,9 @@ class Vector(object):
 
 class VectorTypeError(TypeError):
 
-    def __init__(self, other, type_str):
-        msg = ("Expected an instance of %s, instead received an object "
-               "'%s' of type %s.") % (type_str, other, type(other))
+    def __init__(self, other, want):
+        msg = filldedent("Expected an instance of %s, but received object "
+                         "'%s' of %s." % (type(want), other, type(other)))
         super(VectorTypeError, self).__init__(msg)
 
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -2,6 +2,8 @@ from sympy import (S, sympify, trigsimp, expand, sqrt, Add, zeros,
                    ImmutableMatrix as Matrix)
 from sympy.core.compatibility import u
 
+__all__ = ['Vector']
+
 
 class Vector(object):
     """The class used to define vectors.
@@ -623,6 +625,14 @@ class Vector(object):
     def normalize(self):
         """Returns a Vector of magnitude 1, codirectional with self."""
         return Vector(self.args + []) / self.magnitude()
+
+
+class VectorTypeError(TypeError):
+
+    def __init__(self, other, type_str):
+        msg = ("Expected an instance of %s, instead received an object "
+               "'%s' of type %s.") % (type_str, other, type(other))
+        super(VectorTypeError, self).__init__(msg)
 
 
 def _check_vector(other):

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -150,6 +150,7 @@ def test_files():
         "%(sep)ssympy%(sep)s__init__.py" % sepd,
         # these __init__.py should be fixed:
         # XXX: not really, they use useful import pattern (DRY)
+        "%(sep)svector%(sep)s__init__.py" % sepd,
         "%(sep)smechanics%(sep)s__init__.py" % sepd,
         "%(sep)squantum%(sep)s__init__.py" % sepd,
         "%(sep)spolys%(sep)s__init__.py" % sepd,


### PR DESCRIPTION
See results here:

http://nbviewer.ipython.org/gist/moorepants/8889548

Also, I'm closing PR #2833 to default to this version.

Tasks:
- [x] Make init_printing be init_vprinting?
- [x] Make the printing functions available in vector/functions.
- [x] Add deprecation warnings to the mechanics functions (or just leave support?).
- [x] mechanics_printing is a little different now if you want mechanics string printing. you have to use the `pretty_print=False` flag. This is an api change of sorts. I can't imagine it breaking anything major, but maybe. Should we retain a mechanics printing function that only does string printing like before? Or make deprecations for it?
