### PR TITLE
Residues: Try replacing x with 1/x when series fails

### DIFF
--- a/sympy/series/residues.py
+++ b/sympy/series/residues.py
@@ -52,16 +52,21 @@ def residue(expr, x, x0):
     expr = sympify(expr)
     if x0 != 0:
         expr = expr.subs(x, x + x0)
-    for n in [0, 1, 2, 4, 8, 16, 32]:
-        if n == 0:
-            s = expr.series(x, n=0)
-        else:
-            s = expr.nseries(x, n=n)
-        if s.has(Order) and s.removeO() == 0:
-            # bug in nseries
-            continue
-        if not s.has(Order) or s.getn() >= 0:
-            break
+    def get_series(e):
+        for n in [0, 2, 4, 8, 16, 32]:
+            if n == 0:
+                s = e.series(x, n=0)
+            else:
+                s = e.nseries(x, n=n)
+            if s.has(Order) and s.removeO() == 0:
+                # bug in nseries
+                continue
+            if not s.has(Order) or s.getn() >= 0:
+                break
+        return s
+    s = get_series(expr)
+    if s == expr:  # try replacing x with 1/x
+        s = get_series(expr.subs(x, 1/x)).removeO().subs(x, 1/x)
     if s.has(Order) and s.getn() < 0:
         raise NotImplementedError('Bug in nseries?')
     s = collect(s.removeO(), x)

--- a/sympy/series/tests/test_residues.py
+++ b/sympy/series/tests/test_residues.py
@@ -57,10 +57,6 @@ def test_expressions_failing():
     assert residue(1/(x**2 + a**2)**2, x, a*I) == -I/4/a**3
 
 
-def test_NotImplemented():
-    raises(NotImplementedError, lambda: residue(exp(1/z), z, 0))
-
-
 def test_bug():
     assert residue(2**(z)*(s + z)*(1 - s - z)/z**2, z, 0) == \
         1 + s*log(2) - s**2*log(2) - 2*s
@@ -68,6 +64,7 @@ def test_bug():
 
 def test_issue_2555():
     assert residue(1/(x**2 + a**2)**2, x, a*I) == -I/(4*a**3)
+    assert residue(exp(1/x), x, 0) == 1
 
 
 def test_issue_3400():


### PR DESCRIPTION
I made a function for the part where it finds the series trying various values of n because I needed to call it again.
It tries n = 0, 1, 2, 4 ...
but n = 1 didn't work as exp(x) = 1 + O(x) was not enough. It needs one more term.
