### PR TITLE
fix py3k syntax that is a syntax error in python 2

### DIFF
--- a/sympy/mpmath/libmp/exec_py3.py
+++ b/sympy/mpmath/libmp/exec_py3.py
@@ -1,1 +1,2 @@
-exec_ = exec
+import builtins
+exec_ = getattr(builtins, 'exec')


### PR DESCRIPTION
Fix issue 3605, syntax errors printed to the console when installing via pip.

https://code.google.com/p/sympy/issues/detail?id=3605
