### PR TITLE
Added method for intersection for ImageSet

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -330,10 +330,6 @@ class Range(Set):
         return (other >= self.inf and other <= self.sup and
                 ask(Q.integer((self.start - other)/self.step)))
 
-    def _eval_imageset(self, f):
-        from sympy.core.sets import FiniteSet
-        return FiniteSet(f(i) for i in self)
-
     def __iter__(self):
         i = self.start
         while(i < self.stop):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -312,6 +312,10 @@ class Range(Set):
         return (other >= self.inf and other <= self.sup and
                 ask(Q.integer((self.start - other)/self.step)))
 
+    def _eval_imageset(self, f):
+        from sympy.core.sets import FiniteSet
+        return FiniteSet(*[f(i) for i in self])
+
     def __iter__(self):
         i = self.start
         while(i < self.stop):

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -219,6 +219,24 @@ class ImageSet(Set):
                     return True
         return False
 
+    def _intersect(self, other):
+        from sympy import solve, Dummy, imageset, Union
+
+        if isinstance(other, ImageSet):
+            return
+
+        f = self.lamda
+        if len(f.variables) > 1:
+            return
+        var = f.variables[0]
+        expr = f.expr
+        if not expr.is_polynomial(var):
+            return
+        d = Dummy()
+        solns = solve(expr - d, var)
+        return Union(imageset(f, self.base_set.intersect(
+            imageset(d, f_inv, other))) for f_inv in solns)
+
     @property
     def is_iterable(self):
         return self.base_set.is_iterable
@@ -314,7 +332,7 @@ class Range(Set):
 
     def _eval_imageset(self, f):
         from sympy.core.sets import FiniteSet
-        return FiniteSet(*[f(i) for i in self])
+        return FiniteSet(f(i) for i in self)
 
     def __iter__(self):
         i = self.start

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -65,9 +65,6 @@ def test_ImageSet():
 
     assert harmonics.is_iterable
 
-def test_image_is_ImageSet():
-    assert isinstance(imageset(x, sqrt(sin(x)), Range(5)), ImageSet)
-
 
 @XFAIL
 def test_halfcircle():
@@ -115,6 +112,10 @@ def test_Range():
     assert len(Range(10, 38, 10)) == 3
 
     assert Range(0, 0, 5) == S.EmptySet
+
+    # Testing _eval_imageset
+    assert imageset(x, x*pi, Range(3)) == \
+        FiniteSet(0, pi, 2*pi)
 
 
 def test_range_interval_intersection():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -72,7 +72,6 @@ def test_ImageSet_intersection():
     assert n_pi.intersect(Range(10)) == FiniteSet(0)
     assert n_pi.intersect(Interval(0, 10)) == \
         FiniteSet(0, pi, 2*pi, 3*pi)
-    #TODO: add test for functions which are not injection
 
 
 @XFAIL
@@ -121,10 +120,6 @@ def test_Range():
     assert len(Range(10, 38, 10)) == 3
 
     assert Range(0, 0, 5) == S.EmptySet
-
-    # Testing _eval_imageset
-    assert imageset(x, x*pi, Range(3)) == \
-        FiniteSet(0, pi, 2*pi)
 
 
 def test_range_interval_intersection():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -66,6 +66,15 @@ def test_ImageSet():
     assert harmonics.is_iterable
 
 
+def test_ImageSet_intersection():
+    n_pi = imageset(x, x*pi, S.Integers)
+
+    assert n_pi.intersect(Range(10)) == FiniteSet(0)
+    assert n_pi.intersect(Interval(0, 10)) == \
+        FiniteSet(0, pi, 2*pi, 3*pi)
+    #TODO: add test for functions which are not injection
+
+
 @XFAIL
 def test_halfcircle():
     # This test sometimes works and sometimes doesn't.


### PR DESCRIPTION
```
In[10]: s = imageset(k, pi*k, S.Integers)

In [11]: pprint(s)
{π⋅k | k ∊ ℤ}

In [12]: pprint(s.intersect(Interval(0, 10)))
{0, π, 2⋅π, 3⋅π}
```

References

http://www.cs.berkeley.edu/~fateman/papers/sets.pdf
