### PR TITLE
Fixes issue #2889

### DIFF
--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -320,7 +320,8 @@ class F2PyCodeWrapper(CodeWrapper):
     @property
     def command(self):
         filename = self.filename + '.' + self.generator.code_extension
-        command = ["f2py", "-m", self.module_name, "-c", filename]
+        args = ['-c', '-m', self.module_name, filename]
+        command = [sys.executable, "-c", "import numpy.f2py as f2py2e;f2py2e.main()"]+args
         return command
 
     def _prepare_files(self, routine):


### PR DESCRIPTION
Modified the call to f2py to go through `sys.executable` such that the correct version of f2py is always chosen on systems with both python2 and python3 installed.
