### PR TITLE
imageset() improvements

### DIFF
--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -8,6 +8,8 @@ Set
 .. autoclass:: Set
    :members:
 
+.. autofunction:: imageset
+
 Elementary Sets
 ---------------
 
@@ -74,4 +76,3 @@ ImageSet
 ^^^^^^^^
 .. autoclass:: ImageSet
    :members:
-

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -719,7 +719,6 @@ class Interval(Set, EvalfMixin):
         return expr
 
     def _eval_imageset(self, f):
-        from sympy import Dummy
         from sympy.functions.elementary.miscellaneous import Min, Max
         from sympy.solvers import solve
         from sympy.core.function import diff
@@ -729,23 +728,18 @@ class Interval(Set, EvalfMixin):
         # TODO: handle functions with infinitely many solutions (eg, sin, tan)
         # TODO: handle multivariate functions
 
-        # var and expr are being defined this way to
-        # support Python lambda and not just sympy Lambda
-        try:
-            var = Dummy()
-            expr = f(var)
-            if len(expr.free_symbols) > 1:
-                raise TypeError
-        except TypeError:
-            raise NotImplementedError("Sorry, Multivariate imagesets are"
-                                      " not yet implemented, you are welcome"
-                                      " to add this feature in Sympy")
+        expr = f.expr
+        if len(expr.free_symbols) > 1 or len(f.variables) != 1:
+            return
+        var = f.variables[0]
 
         if not self.start.is_comparable or not self.end.is_comparable:
-            raise NotImplementedError("Sets with non comparable/variable"
-                                      " arguments are not supported")
+            return
 
-        sing = [x for x in singularities(expr, var) if x.is_real and x in self]
+        try:
+            sing = [x for x in singularities(expr, var) if x.is_real and x in self]
+        except NotImplementedError:
+            return
 
         if self.left_open:
             _start = limit(expr, var, self.start, dir="+")
@@ -1485,7 +1479,11 @@ class FiniteSet(Set, EvalfMixin):
 
 
 def imageset(*args):
-    """ Image of set under transformation ``f``
+    r"""
+    Image of set under transformation ``f``.
+
+    If this function can't compute the image, it returns an
+    unevaluated ImageSet object.
 
     .. math::
         { f(x) | x \in self }
@@ -1493,7 +1491,7 @@ def imageset(*args):
     Examples
     ========
 
-    >>> from sympy import Interval, Symbol, imageset
+    >>> from sympy import Interval, Symbol, imageset, sin, Lambda
     >>> x = Symbol('x')
 
     >>> imageset(x, 2*x, Interval(0, 2))
@@ -1502,14 +1500,31 @@ def imageset(*args):
     >>> imageset(lambda x: 2*x, Interval(0, 2))
     [0, 4]
 
-    See Also:
-        ImageSet
+    >>> imageset(Lambda(x, sin(x)), Interval(-2, 1))
+    ImageSet(Lambda(x, sin(x)), [-2, 1])
+
+    See Also
+    ========
+
+    sympy.sets.fancysets.ImageSet
+
     """
+    from sympy.core import Dummy, Lambda
+    from sympy.sets.fancysets import ImageSet
     if len(args) == 3:
-        from sympy import Lambda
         f = Lambda(*args[:2])
     else:
+        # var and expr are being defined this way to
+        # support Python lambda and not just sympy Lambda
         f = args[0]
+        if not isinstance(f, Lambda):
+            var = Dummy()
+            expr = args[0](var)
+            f = Lambda(var, expr)
     set = args[-1]
 
-    return set._eval_imageset(f)
+    r = set._eval_imageset(f)
+    if r is not None:
+        return r
+
+    return ImageSet(f, set)


### PR DESCRIPTION
1) canonicalize transformation from the input to be Lambda
2) if _eval_imageset wasn't able to compute image - we return an unevaluated ImageSet object.

@mrocklin, @hargup
