### PR TITLE
fixed annoying errors when installing in both python2 and python3

### DIFF
--- a/sympy/mpmath/libmp/exec_py2.py
+++ b/sympy/mpmath/libmp/exec_py2.py
@@ -1,2 +1,2 @@
 def exec_(string, globals, locals):
-    exec string in globals, locals
+    exec(string,globals, locals)

--- a/sympy/mpmath/libmp/exec_py2.py
+++ b/sympy/mpmath/libmp/exec_py2.py
@@ -1,2 +1,2 @@
 def exec_(string, globals, locals):
-    exec(string,globals, locals)
+    exec(string, globals, locals)

--- a/sympy/mpmath/libmp/exec_py3.py
+++ b/sympy/mpmath/libmp/exec_py3.py
@@ -1,1 +1,1 @@
-exec_ = exec
+exec_ = eval('exec')


### PR DESCRIPTION
The issue was half fixed in pull #2875, but got closed for some reason. This fixes both the py2 and the py3 errors relating to calling exec funny.
