### PR TITLE
evaluate context manager

### DIFF
--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -27,6 +27,7 @@ from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
 from .evalf import PrecisionExhausted, N
 from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc
+from .evaluate import evaluate
 
 # expose singletons
 Catalan = S.Catalan

--- a/sympy/core/cache.py
+++ b/sympy/core/cache.py
@@ -50,6 +50,11 @@ def __cacheit_nocache(func):
     return func
 
 
+# from sympy.assumptions.assume import global_assumptions  # circular import
+from sympy.core.evaluate import global_evaluate
+_globals = (global_evaluate,)
+
+
 def __cacheit(func):
     """caching decorator.
 
@@ -84,6 +89,8 @@ def __cacheit(func):
         if kw_args:
             keys = sorted(kw_args)
             k.extend([(x, kw_args[x], type(kw_args[x])) for x in keys])
+        if _globals:
+            k.extend([tuple(g) for g in _globals])
         k = tuple(k)
 
         try:

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -6,7 +6,14 @@ global_evaluate = [True]
 
 @contextmanager
 def evaluate(x):
-    """
+    """ Control automatic evaluation
+
+    This context managers controls whether or not all SymPy functions evaluate
+    by default.
+
+    Note that much of SymPy expects evaluated expressions.  This functionality
+    is experimental and is unlikely to function as intended on large
+    expressions.
 
     >>> from sympy.abc import x
     >>> from sympy.core.operations import evaluate

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -6,7 +6,10 @@ global_evaluate = [True]
 
 @contextmanager
 def evaluate(x):
-    """
+    """ Switch automatic evaluation on or off
+
+    Examples
+    ========
 
     >>> from sympy.abc import x
     >>> from sympy.core.operations import evaluate

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -1,0 +1,24 @@
+from contextlib import contextmanager
+
+
+global_evaluate = [True]
+
+
+@contextmanager
+def evaluate(x):
+    """
+
+    >>> from sympy.abc import x
+    >>> from sympy.core.operations import evaluate
+    >>> print x + x
+    2*x
+    >>> with evaluate(False):
+    ...     print x + x
+    x + x
+    """
+
+    old = global_evaluate[0]
+
+    global_evaluate[0] = x
+    yield
+    global_evaluate[0] = old

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -49,6 +49,7 @@ from sympy.core.logic import fuzzy_and
 from sympy.core.compatibility import string_types, with_metaclass, xrange
 from sympy.utilities import default_sort_key
 from sympy.utilities.iterables import uniq
+from sympy.core.evaluate import global_evaluate
 
 from sympy import mpmath
 import sympy.mpmath.libmp as mlib
@@ -186,7 +187,7 @@ class Application(with_metaclass(FunctionClass, Basic)):
         from sympy.core.sets import FiniteSet
 
         args = list(map(sympify, args))
-        evaluate = options.pop('evaluate', True)
+        evaluate = options.pop('evaluate', global_evaluate[0])
         # WildFunction (and anything else like it) may have nargs defined
         # and we throw that value away here
         options.pop('nargs', None)
@@ -364,7 +365,7 @@ class Function(Application, Expr):
                 'plural': 's'*(min(cls.nargs) != 1),
                 'given': n})
 
-        evaluate = options.get('evaluate', True)
+        evaluate = options.get('evaluate', global_evaluate[0])
         result = super(Function, cls).__new__(cls, *args, **options)
         if not evaluate or not isinstance(result, cls):
             return result

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -165,7 +165,7 @@ class FunctionClass(with_metaclass(BasicMeta, ManagedProperties)):
         from sympy.core.sets import FiniteSet
         # XXX it would be nice to handle this in __init__ but there are import
         # problems with trying to import FiniteSet there
-        return FiniteSet(self._nargs) if self._nargs else S.Naturals0
+        return FiniteSet(*self._nargs) if self._nargs else S.Naturals0
 
     def __repr__(cls):
         return cls.__name__

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -6,29 +6,7 @@ from sympy.core.basic import Basic, _aresame
 from sympy.core.cache import cacheit
 from sympy.core.compatibility import ordered, xrange
 from sympy.core.logic import fuzzy_and
-
-global_evaluate = [True]
-
-from contextlib import contextmanager
-
-@contextmanager
-def evaluate(x):
-    """
-
-    >>> from sympy.abc import x
-    >>> from sympy.core.operations import evaluate
-    >>> print x + x
-    2*x
-    >>> with evaluate(False):
-    ...     print x + x
-    x + x
-    """
-
-    old = global_evaluate[0]
-
-    global_evaluate[0] = x
-    yield
-    global_evaluate[0] = old
+from sympy.core.evaluate import global_evaluate
 
 
 class AssocOp(Basic):

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -7,6 +7,29 @@ from sympy.core.cache import cacheit
 from sympy.core.compatibility import ordered, xrange
 from sympy.core.logic import fuzzy_and
 
+global_evaluate = [True]
+
+from contextlib import contextmanager
+
+@contextmanager
+def evaluate(x):
+    """
+
+    >>> from sympy.abc import x
+    >>> from sympy.core.operations import evaluate
+    >>> print x + x
+    2*x
+    >>> with evaluate(False):
+    ...     print x + x
+    x + x
+    """
+
+    old = global_evaluate[0]
+
+    global_evaluate[0] = x
+    yield
+    global_evaluate[0] = old
+
 
 class AssocOp(Basic):
     """ Associative operations, can separate noncommutative and
@@ -24,12 +47,11 @@ class AssocOp(Basic):
     # and keep it right here
     __slots__ = ['is_commutative']
 
-    @cacheit
     def __new__(cls, *args, **options):
         args = list(map(_sympify, args))
         args = [a for a in args if a is not cls.identity]
 
-        if not options.pop('evaluate', True):
+        if not options.pop('evaluate', global_evaluate[0]):
             return cls._from_args(args)
 
         if len(args) == 0:

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -25,6 +25,7 @@ class AssocOp(Basic):
     # and keep it right here
     __slots__ = ['is_commutative']
 
+    @cacheit
     def __new__(cls, *args, **options):
         args = list(map(_sympify, args))
         args = [a for a in args if a is not cls.identity]

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -12,6 +12,7 @@ from sympy.core.function import (_coeff_isneg, expand_complex,
     expand_multinomial, expand_mul)
 from sympy.core.logic import fuzzy_bool
 from sympy.core.compatibility import as_int, xrange
+from sympy.core.evaluate import global_evaluate
 
 from sympy.mpmath.libmp import sqrtrem as mpmath_sqrtrem
 from sympy.utilities.iterables import sift
@@ -153,7 +154,9 @@ class Pow(Expr):
     __slots__ = ['is_commutative']
 
     @cacheit
-    def __new__(cls, b, e, evaluate=True):
+    def __new__(cls, b, e, evaluate=None):
+        if evaluate is None:
+            evaluate = global_evaluate[0]
         from sympy.functions.elementary.exponential import exp_polar
 
         # don't optimize "if e==0; return 1" here; it's better to handle that

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1344,6 +1344,8 @@ class FiniteSet(Set, EvalfMixin):
 
 
         args = frozenset(args)  # remove duplicates
+        args = map(sympify, args)
+        args = frozenset(args)
         obj = Basic.__new__(cls, *args)
         obj._elements = args
         return obj

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -8,6 +8,7 @@ from sympy.core.singleton import Singleton, S
 from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
 from sympy.core.compatibility import iterable, with_metaclass
+from sympy.core.evaluate import global_evaluate
 
 from sympy.mpmath import mpi, mpf
 from sympy.logic.boolalg import And, Or, true, false
@@ -866,7 +867,7 @@ class Union(Set, EvalfMixin):
     is_Union = True
 
     def __new__(cls, *args, **kwargs):
-        evaluate = kwargs.get('evaluate', True)
+        evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         # flatten inputs to merge intersections and iterables
         args = list(args)
@@ -1076,7 +1077,7 @@ class Intersection(Set):
     is_Intersection = True
 
     def __new__(cls, *args, **kwargs):
-        evaluate = kwargs.get('evaluate', True)
+        evaluate = kwargs.get('evaluate', global_evaluate[0])
 
         # flatten inputs to merge intersections and iterables
         args = list(args)
@@ -1331,7 +1332,7 @@ class FiniteSet(Set, EvalfMixin):
     is_iterable = True
 
     def __new__(cls, *args, **kwargs):
-        evaluate = kwargs.get('evaluate', True)
+        evaluate = kwargs.get('evaluate', global_evaluate[0])
         if evaluate:
             if len(args) == 1 and iterable(args[0]):
                 args = args[0]

--- a/sympy/core/sympify.py
+++ b/sympy/core/sympify.py
@@ -6,6 +6,7 @@ from inspect import getmro
 
 from .core import all_classes as sympy_classes
 from .compatibility import iterable, string_types
+from .evaluate import global_evaluate
 
 
 class SympifyError(ValueError):
@@ -49,7 +50,8 @@ class CantSympify(object):
     """
     pass
 
-def sympify(a, locals=None, convert_xor=True, strict=False, rational=False, evaluate=True):
+def sympify(a, locals=None, convert_xor=True, strict=False, rational=False,
+        evaluate=None):
     """Converts an arbitrary expression to a type that can be used inside SymPy.
 
     For example, it will convert Python ints into instance of sympy.Rational,
@@ -228,6 +230,8 @@ def sympify(a, locals=None, convert_xor=True, strict=False, rational=False, eval
     -2*(-(-x + 1/x)/(x*(x - 1/x)**2) - 1/(x*(x - 1/x))) - 1
 
     """
+    if evaluate is None:
+        evaluate = global_evaluate[0]
     try:
         cls = a.__class__
     except AttributeError:  # a is probably an old-style class object

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -305,7 +305,7 @@ def test_implemented_function_evalf():
 
 
 def test_evaluate_false():
-    for no in [0, False, None]:
+    for no in [0, False]:
         assert Add(3, 2, evaluate=no).is_Add
         assert Mul(3, 2, evaluate=no).is_Mul
         assert Pow(3, 2, evaluate=no).is_Pow

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -7,7 +7,14 @@ def test_add():
         expr = x + x
         assert isinstance(expr, Add)
         assert expr.args == (x, x)
+
+        with evaluate(True):
+            assert (x + x).args == (2, x)
+
+        assert (x + x).args == (x, x)
+
     assert isinstance(x + x, Mul)
+
 
 
 def test_nested():

--- a/sympy/core/tests/test_evaluate.py
+++ b/sympy/core/tests/test_evaluate.py
@@ -1,0 +1,17 @@
+from sympy.abc import x, y
+from sympy.core.evaluate import evaluate
+from sympy.core import Mul, Add
+
+def test_add():
+    with evaluate(False):
+        expr = x + x
+        assert isinstance(expr, Add)
+        assert expr.args == (x, x)
+    assert isinstance(x + x, Mul)
+
+
+def test_nested():
+    with evaluate(False):
+        expr = (x + x) + (y + y)
+        assert expr.args == ((x + x), (y + y))
+        assert expr.args[0].args == (x, x)

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -12,6 +12,7 @@ from __future__ import print_function, division
 from sympy.core.function import Function, expand_mul
 from sympy.core import S, Symbol, Rational, oo, Integer, C, Add, Dummy
 from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
+from sympy.core.evaluate import global_evaluate
 from sympy.core.cache import cacheit
 from sympy.functions.combinatorial.factorials import factorial
 
@@ -625,7 +626,9 @@ class euler(Function):
     """
 
     @classmethod
-    def eval(cls, m, evaluate=True):
+    def eval(cls, m, evaluate=None):
+        if evaluate is None:
+            evaluate = global_evaluate[0]
         if not evaluate:
             return
         if m.is_odd:
@@ -748,7 +751,9 @@ class catalan(Function):
     """
 
     @classmethod
-    def eval(cls, n, evaluate=True):
+    def eval(cls, n, evaluate=None):
+        if evaluate is None:
+            evaluate = global_evaluate[0]
         if n.is_Integer and n.is_nonnegative:
             return 4**n*C.gamma(n + S.Half)/(C.gamma(S.Half)*C.gamma(n + 2))
 

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -17,6 +17,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from .entity import GeometryEntity
 from sympy.matrices import Matrix
 from sympy.core.numbers import Float
+from sympy.core.evaluate import global_evaluate
 
 
 class Point(GeometryEntity):
@@ -85,7 +86,7 @@ class Point(GeometryEntity):
         if len(coords) != 2:
             raise NotImplementedError(
                 "Only two dimensional points currently supported")
-        if kwargs.get('evaluate', True):
+        if kwargs.get('evaluate', global_evaluate[0]):
             coords = coords.xreplace(dict(
                 [(f, simplify(nsimplify(f, rational=True)))
                 for f in coords.atoms(Float)]))

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -773,7 +773,7 @@ class WignerD(Expr):
         if not len(args) == 6:
             raise ValueError('6 parameters expected, got %s' % args)
         args = sympify(args)
-        evaluate = hints.get('evaluate', global_evaluate[0])
+        evaluate = hints.get('evaluate', False)
         if evaluate:
             return Expr.__new__(cls, *args)._eval_wignerd()
         return Expr.__new__(cls, *args)

--- a/sympy/physics/quantum/spin.py
+++ b/sympy/physics/quantum/spin.py
@@ -6,6 +6,7 @@ from sympy import (Add, binomial, cos, exp, Expr, factorial, I, Integer, Mul,
                    pi, Rational, S, sin, simplify, sqrt, Sum, symbols, sympify,
                    Tuple, Dummy)
 from sympy.core.compatibility import u, unicode
+from sympy.core.evaluate import global_evaluate
 from sympy.matrices import zeros
 from sympy.printing.pretty.stringpict import prettyForm, stringPict
 from sympy.printing.pretty.pretty_symbology import pretty_symbol
@@ -772,7 +773,7 @@ class WignerD(Expr):
         if not len(args) == 6:
             raise ValueError('6 parameters expected, got %s' % args)
         args = sympify(args)
-        evaluate = hints.get('evaluate', False)
+        evaluate = hints.get('evaluate', global_evaluate[0])
         if evaluate:
             return Expr.__new__(cls, *args)._eval_wignerd()
         return Expr.__new__(cls, *args)

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1475,7 +1475,7 @@ def collect_sqrt(expr, evaluate=None):
     ========
     collect, collect_const, rcollect
     """
-    if evaluate is none:
+    if evaluate is None:
         evaluate = global_evaluate[0]
     # this step will help to standardize any complex arguments
     # of sqrts
@@ -3517,7 +3517,7 @@ def signsimp(expr, evaluate=None):
     exp(-(x - y))
 
     """
-    if global_evaluate is None:
+    if evaluate is None:
         evaluate = global_evaluate[0]
     expr = sympify(expr)
     if not isinstance(expr, Expr) or expr.is_Atom:

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -17,6 +17,7 @@ from sympy.core.numbers import Float, Number, I
 from sympy.core.function import expand_log, count_ops
 from sympy.core.mul import _keep_coeff, prod
 from sympy.core.rules import Transform
+from sympy.core.evaluate import global_evaluate
 from sympy.functions import (
     gamma, exp, sqrt, log, root, exp_polar,
     sin, cos, tan, cot, sinh, cosh, tanh, coth, piecewise_fold, Piecewise)
@@ -158,7 +159,7 @@ def separate(expr, deep=False, force=False):
     return expand_power_base(sympify(expr), deep=deep, force=force)
 
 
-def collect(expr, syms, func=None, evaluate=True, exact=False, distribute_order_term=True):
+def collect(expr, syms, func=None, evaluate=None, exact=False, distribute_order_term=True):
     """
     Collect additive terms of an expression.
 
@@ -296,6 +297,8 @@ def collect(expr, syms, func=None, evaluate=True, exact=False, distribute_order_
     ========
     collect_const, collect_sqrt, rcollect
     """
+    if evaluate is None:
+        evaluate = global_evaluate[0]
 
     def make_expression(terms):
         product = []
@@ -1432,7 +1435,7 @@ def trigsimp(expr, **opts):
     return trigsimpfunc(expr)
 
 
-def collect_sqrt(expr, evaluate=True):
+def collect_sqrt(expr, evaluate=None):
     """Return expr with terms having common square roots collected together.
     If ``evaluate`` is False a count indicating the number of sqrt-containing
     terms will be returned and, if non-zero, the terms of the Add will be
@@ -1472,6 +1475,8 @@ def collect_sqrt(expr, evaluate=True):
     ========
     collect, collect_const, rcollect
     """
+    if evaluate is none:
+        evaluate = global_evaluate[0]
     # this step will help to standardize any complex arguments
     # of sqrts
     coeff, expr = expr.as_content_primitive()
@@ -3473,7 +3478,7 @@ def combsimp(expr):
     return expr
 
 
-def signsimp(expr, evaluate=True):
+def signsimp(expr, evaluate=None):
     """Make all Add sub-expressions canonical wrt sign.
 
     If an Add subexpression, ``a``, can have a sign extracted,
@@ -3512,6 +3517,8 @@ def signsimp(expr, evaluate=True):
     exp(-(x - y))
 
     """
+    if global_evaluate is None:
+        evaluate = global_evaluate[0]
     expr = sympify(expr)
     if not isinstance(expr, Expr) or expr.is_Atom:
         return expr

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2595,7 +2595,6 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
             # allow 2**x/4 -> 2**(x - 2); don't do this when b and e are
             # Numbers since autoevaluation will undo it, e.g.
             # 2**(1/3)/4 -> 2**(1/3 - 2) -> 2**(1/3)/4
-            assert 2**(S(1)/3 - 2) == 2**(S(1)/3)/4
             if (b and b.is_Number and not all(ei.is_Number for ei in e) and \
                     coeff is not S.One and
                     b not in (S.One, S.NegativeOne)):

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -1856,3 +1856,7 @@ def test_trigsimp_methods_gh2827():
     # watch for E in exptrigsimp, not only exp()
     eq = 1/sqrt(E) + E
     assert exptrigsimp(eq) == eq
+
+
+def test_powsimp_on_numbers():
+    assert 2**(S(1)/3 - 2) == 2**(S(1)/3)/4


### PR DESCRIPTION
Sometimes we want to turn off automatic evaluation.  We usually suggest that people make the following change

``` Python
# Before
x + x

# After
Add(x, x, evaluate=False)
```

This is ugly and, more importantly, hard to do on large complex operations.

This PR sets the default value of the `evaluate` keyword to a globally accessible variable.  It then introduces an `evaluate` context manager to manage that global variable

``` Python
>>> from sympy.abc import x
>>> from sympy.core.operations import evaluate
>>> print x + x
2*x
>>> with evaluate(False):
...     print x + x
x + x
```
