### PR TITLE
block imaginary coordinates for Point

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -859,11 +859,11 @@ class Ellipse(GeometryEntity):
             except PolynomialError:
                 pass
         if not points:
-            points = [Point(*s) for s in solve((seq, eq), (x, y))]
+            points = solve((seq, eq), (x, y))
             # complicated expressions may not be decidably real so evaluate to
             # check whether they are real or not
-            points = [i.n(prec) if prec is not None else i
-                for i in points if all(j.n(2).is_real for j in i.args)]
+            points = [Point(i).n(prec) if prec is not None else Point(i)
+                      for i in points if all(j.n(2).is_real for j in i)]
         slopes = [norm.subs(zip((x, y), pt.args)) for pt in points]
         if prec is not None:
             slopes = [i.n(prec) if i not in (-oo, oo, zoo) else i

--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -14,6 +14,7 @@ from sympy.core.containers import Tuple
 from sympy.simplify import simplify, nsimplify
 from sympy.geometry.exceptions import GeometryError
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.complexes import im
 from .entity import GeometryEntity
 from sympy.matrices import Matrix
 from sympy.core.numbers import Float
@@ -76,20 +77,27 @@ class Point(GeometryEntity):
     """
 
     def __new__(cls, *args, **kwargs):
-        if iterable(args[0]):
-            args = args[0]
-        elif isinstance(args[0], Point):
+        eval = kwargs.get('evaluate', True)
+        check = True
+        if isinstance(args[0], Point):
+            if not eval:
+                return args[0]
             args = args[0].args
+            check = False
+        else:
+            if iterable(args[0]):
+                args = args[0]
+            if len(args) != 2:
+                raise NotImplementedError(
+                    "Only two dimensional points currently supported")
         coords = Tuple(*args)
-
-        if len(coords) != 2:
-            raise NotImplementedError(
-                "Only two dimensional points currently supported")
-        if kwargs.get('evaluate', True):
+        if check:
+            if any(a.is_number and im(a) for a in coords):
+                raise ValueError('Imaginary args not permitted.')
+        if eval:
             coords = coords.xreplace(dict(
                 [(f, simplify(nsimplify(f, rational=True)))
                 for f in coords.atoms(Float)]))
-
         return GeometryEntity.__new__(cls, *coords)
 
     def __hash__(self):

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -1,6 +1,6 @@
 import warnings
 
-from sympy import (Abs, C, Dummy, Rational, Float, S, Symbol, cos, oo, pi,
+from sympy import (Abs, C, I, Dummy, Rational, Float, S, Symbol, cos, oo, pi,
                    simplify, sin, sqrt, symbols, tan, Derivative)
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment, Triangle,
@@ -85,6 +85,9 @@ def test_point():
     assert (p2 - p1) == Point(y1 - x1, y2 - x2)
     assert p4*5 == Point(5, 5)
     assert -p2 == Point(-y1, -y2)
+    raises(ValueError, lambda: Point(3, I))
+    raises(ValueError, lambda: Point(2*I, I))
+    raises(ValueError, lambda: Point(3 + I, I))
 
     assert Point(34.05, sqrt(3)) == Point(Rational(681, 20), sqrt(3))
     assert Point.midpoint(p3, p4) == Point(half, half)
@@ -528,7 +531,7 @@ def test_ellipse():
         [Line(Point(0, 0), Point(0, 1))]
     assert e.normal_lines(Point(1, 1), 1) == \
         [Line(Point(-2, -1/5), Point(-1, 1/5)),
-        Line(Point(1, -9/10), Point(2, -43/11))]
+         Line(Point(1, -9/10), Point(2, -43/11))]
     # test the failure of Poly.intervals and checks a point on the boundary
     p = Point(sqrt(3), S.Half)
     assert p in e


### PR DESCRIPTION
The computations that are done in geometry assume that
the points are real. Without placing undue stress on the
computations by checking this every time, a check is done
only when the coordinates are numbers. Of course, there
is nothing to stop one from using imaginary points in
an expression obtained from geometry, but one should not
be doing that.
