### PR TITLE
find singularities for any expression

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -1,23 +1,51 @@
-from sympy.solvers import solve
-from sympy.simplify import simplify
+from sympy.polys.polytools import together
+from sympy.solvers.solvers import solve, denoms
+from sympy.core.sympify import sympify
+from sympy.core.symbol import Dummy
+from sympy.functions.elementary.exponential import exp
 
 
-def singularities(expr, sym):
-    """
-    Finds singularities for a function.
-    Currently supported functions are:
-        - univariate real rational functions
+def singularities(expr, sym=None, strict=False, poles=True):
+    """Return the real-valued singularities of an expression that
+    would set any denominator in the expression to zero.
 
     Examples
     ========
 
     >>> from sympy.calculus.singularities import singularities
-    >>> from sympy import Symbol
-    >>> x = Symbol('x', real=True)
+    >>> from sympy import Symbol, log
+    >>> from sympy.abc import x
     >>> singularities(x**2 + x + 1, x)
     ()
-    >>> singularities(1/(x + 1), x)
-    (-1,)
+    >>> singularities(1/(1/x - 1))
+    (1,)
+    >>> singularities(1/(1/x - 1), strict=True)
+    (0, 1)
+
+    If `poles` is True then points at which functions are undefined will
+    be returned. (This is currently not implemented and an error will be
+    raised unless the expression is rational.)
+
+    >>> singularities(log(1 - x)/(x - 2), poles=False)
+    (2,)
+    >>> singularities(log(1 - x)/(x - 2))
+    Traceback (most recent call last):
+    ...
+    NotImplementedError: finding poles for non-rational functions
+
+    Parameters
+    ==========
+
+    expr : expression
+    sym : the independent symbol (automatically detected for univariate expr)
+    strict : if True (default=False) removable singularities are returned, too
+
+    Notes
+    =====
+
+    The purpose of this function is to identify any value that would create
+    a "division by zero" error. This function does not try to identify the
+    domain of the expression, e.g. no singularities for log(x) are identified.
 
     References
     ==========
@@ -25,9 +53,28 @@ def singularities(expr, sym):
     .. [1] http://en.wikipedia.org/wiki/Mathematical_singularity
 
     """
-    if not expr.is_rational_function(sym):
-        raise NotImplementedError("Sorry, Algorithms finding singularities for"
-                                  " non rational funcitons are not yet"
-                                  " implemented")
-    else:
-        return tuple(sorted(solve(simplify(1/expr), sym)))
+    expr = sympify(expr)
+    if sym is None:
+        free = expr.free_symbols
+        if free:
+            if len(free) > 1:
+                raise ValueError('must supply independent symbol')
+            sym = free.pop()
+
+    if not expr.has(sym):
+        return tuple()
+
+    if not sym.is_real:
+        d = Dummy(sym.name, real=True)
+        expr = expr.xreplace({sym: d})
+        sym = d
+
+    if not strict:
+        expr = together(expr, deep=True)
+    rv = set()
+    for d in denoms(expr, [sym]):
+        rv.update(solve(d, sym))
+    # XXX add in poles
+    if poles and not expr.is_rational_function(sym):
+        raise NotImplementedError('finding poles for non-rational functions')
+    return tuple(sorted(rv))

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -1,19 +1,30 @@
-from sympy import Symbol, exp, log
+from sympy import Symbol, exp, log, Mul, sqrt
 from sympy.calculus.singularities import singularities
+from sympy.abc import x, y
 
 from sympy.utilities.pytest import raises, XFAIL
 
 
 def test_singularities():
-    x = Symbol('x', real=True)
+
+    # results should be sorted
+    v = sqrt(3) - sqrt(7), sqrt(3)
+    assert singularities(1/Mul(*[(x - i) for i in v])) == tuple(v)
+
+    eq = 1/(x - 1) + 1/y
+    raises(ValueError, lambda: singularities(eq))
+    assert singularities(eq, y) == (0,)
+    assert singularities(eq, x) == (1,)
 
     assert singularities(x**2, x) == ()
     assert singularities(x/(x**2 + 3*x + 2), x) == (-2, -1)
-
+    assert singularities(1/(1/x - 1)) == (1,)
+    assert singularities(1/(1/x - 1), strict=True) == (0, 1,)
+    assert singularities(1/(exp(x) - exp(0)), poles=False) == (0,)
+    assert singularities(exp(1/x), x, poles=False) == (0,)
+    assert singularities(log((x - 2)**2), x, poles=False) == ()
+    assert singularities(log(1 - x)/(x - 2), poles=False) == (2,)
 
 @XFAIL
-def test_singularities_non_rational():
-    x = Symbol('x', real=True)
-
-    assert singularities(exp(1/x), x) == (0)
-    assert singularities(log((x - 2)**2), x) == (2)
+def test_singularity_poles():
+    singularities(log(x)) == (0,)


### PR DESCRIPTION
`poles` was added as a keyword; when False it allows the singularites of non-rational expressions to be returned.

together, rather than simplify, is now used and solve is applied only on extracted denominators
