### PR TITLE
relax constraint on quartic solutions

### DIFF
--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -206,8 +206,9 @@ def roots_quartic(f):
     The quasisymmetric case solution [6] looks for quartics that have the form
     `x**4 + A*x**3 + B*x**2 + C*x + D = 0` where `(C/A)**2 = D`.
 
-    Although there is a general solution, simpler results can be obtained for
-    certain values of the coefficients. In all cases, 4 roots are returned:
+    Although no general solution that is always applicable for all
+    coefficients is known to this reviewer, certain conditions are tested
+    to determine the simplest 4 expressions that can be returned:
 
       1) `f = c + a*(a**2/8 - b/2) == 0`
       2) `g = d - a*(a*(3*a**2/256 - b/16) + c/4) = 0`
@@ -285,14 +286,15 @@ def roots_quartic(f):
             TH = Rational(1, 3)
             if p.is_zero:
                 y = -5*e/6 - q**TH
-            elif p.is_number and p.is_comparable:
+            elif p.is_nonzero:
                 # with p != 0 then u below is not 0
                 root = sqrt(q**2/4 + p**3/27)
                 r = -q/2 + root  # or -q/2 - root
                 u = r**TH  # primary root of solve(x**3-r, x)
                 y = -5*e/6 + u - p/u/3
             else:
-                raise PolynomialError('cannot return general quartic solution')
+                raise PolynomialError('Cannot determine if `%s` is nonzero.' % p)
+
             w = sqrt(e + 2*y)
             arg1 = 3*e + 2*y
             arg2 = 2*f/w

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -84,6 +84,10 @@ def test_roots_quartic():
     eq = Poly(q*x + q/4 + x**4 + x**3 + 2*x**2 - Rational(1, 3), x)
     sol = roots_quartic(eq)
     assert all(test_numerically(eq.subs(x, i), 0) for i in sol)
+    z = symbols('z', negative=True)
+    eq = x**4 + 2*x**3 + 3*x**2 + x*(z + 11) + 5
+    zans = roots_quartic(Poly(eq, x))
+    assert all([test_numerically(eq.subs(((x, i), (z, -1))), 0) for i in zans])
     # but some are (see also iss 1890)
     raises(PolynomialError, lambda: roots_quartic(Poly(y*x**4 + x + z, x)))
 

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -1,7 +1,7 @@
 """Tests for algorithms for computing symbolic roots of polynomials. """
 
 from sympy import (S, symbols, Symbol, Wild, Integer, Rational, sqrt,
-    powsimp, Lambda, sin, cos, pi, I, Interval, re, im, exp, ZZ)
+    powsimp, Lambda, sin, cos, pi, I, Interval, re, im, exp, ZZ, Piecewise)
 
 from sympy.polys import (Poly, cyclotomic_poly, intervals, nroots,
     PolynomialError)
@@ -88,8 +88,18 @@ def test_roots_quartic():
     eq = x**4 + 2*x**3 + 3*x**2 + x*(z + 11) + 5
     zans = roots_quartic(Poly(eq, x))
     assert all([test_numerically(eq.subs(((x, i), (z, -1))), 0) for i in zans])
-    # but some are (see also iss 1890)
-    raises(PolynomialError, lambda: roots_quartic(Poly(y*x**4 + x + z, x)))
+    # but some are (see also issue 1890)
+    # it's ok if the solution is not Piecewise, but the tests below should pass
+    eq = Poly(y*x**4 + x**3 - x + z, x)
+    ans = roots_quartic(eq)
+    assert all(type(i) == Piecewise for i in ans)
+    reps = (
+        dict(y=-Rational(1, 3), z=-Rational(1, 4)),  # 4 real
+        dict(y=-Rational(1, 3), z=-Rational(1, 2)),  # 2 real
+        dict(y=-Rational(1, 3), z=-2))  # 0 real
+    for rep in reps:
+        sol = roots_quartic(Poly(eq.subs(rep), x))
+        assert all([test_numerically(w.subs(rep) - s, 0) for w, s in zip(ans, sol)])
 
 
 def test_roots_cyclotomic():


### PR DESCRIPTION
https://code.google.com/p/sympy/issues/detail?id=4003

The "general solution" given at

https://en.wikipedia.org/wiki/File:Quartic_Formula.svg for
x**4 + a*x**3 + b_x__2 + c_x + d == 0

can be computed from the following:

```
def roots4(eq, x):
    '''
    Return the 4 roots of eq in x assuming they are all distinct.

    >>> [w.n(2) for w in roots4((x-3)*(x-2)*(x-1)*(x-4),x)]
    [1.0 + 2.0e-16*I, 2.0 + 1.8e-16*I, 3.0 - 1.8e-16*I, 4.0 - 2.0e-16*I]
    >>> [w.n(2) for w in roots4((x-3)**2*(x-1)*(x-4),x)]
    [1.0 - 2.4e-15*I, 3.0 - 2.4e-15*I, 2.5 + 2.4e-15*I, 4.5 + 2.4e-15*I]
    >>> [w.n(2) for w in roots4((x-3)**3*(x-4),x)]
    [nan, nan, nan, nan]
    '''
    # https://en.wikipedia.org/wiki/File:Quartic_Formula.svg
    eq = eq.expand()
    eq = (eq/eq.coeff(x, 4)).expand()
    a, b, c, d = [eq.coeff(x, i) for i in range(3, -1, -1)]
    TH = Rational(1, 3)
    g = b**2 - 3*a*c + 12*d
    al = 2*b**3 - 9*a*b*c + 27*c**2 + 27*a**2*d - 72*b*d
    be = sqrt(-4*g**3 + al**2)
    a4 = 2**TH*g/(3*(al + be)**TH)
    a5 = ((al + be)/54)**TH
    a3 = a**2/4 - 2*b/3
    a1 = a3 + a4 + a5
    a2 = 2*a3 - a4 - a5 - (-a**3 + 4*a*b - 8*c)/(4*sqrt(a1))
    r1 = -a/4 - (sqrt(a1) + sqrt(a2))/2
    r2 = -a/4 + (-sqrt(a1) + sqrt(a2))/2
    r3 = -a/4 + (sqrt(a1) - sqrt(a2))/2
    r4 = -a/4 + (sqrt(a1) + sqrt(a2))/2
    return r1, r2, r3, r4
```

but it is not generally valid (provided I have not made a mistake).

Consider this equation

```
>>> eq=(x**4+a*x**3+b*x**2+c*x+d)
>>> eq.subs(dict(a=2,b=3,c=z + 11,d=5))
x**4 + 2*x**3 + 3*x**2 + x*(z + 11) + 5
```

There is no real value of z that will give this more than
2 real roots and yet all 4 roots given by the above formula
for z=0, for example, are real:

```
>>> zans=solve(_,x)
>>> [w.subs(z,0).n(2) for w in zans]
[-2.3, -0.51, -0.49, 1.3]
```

Again, consider

```
>>> eq = x**4 - 8*x**3 + 24*x**2 - x*(z + 32) + 16
>>> zans=solve(eq, x, check=0)
>>> [w.subs(z,0).n(2) for w in zans]
[nan, nan, nan, nan]
```

versus

```
>>> [w.n(2) for w in solve(eq.subs(z,0))]
[2.0]
```

and

```
>>> [w.subs(z,1).n(2) for w in zans] # 4 imaginary
[1.8 - 1.2*I, 1.8 + 1.2*I, 2.2 - 1.2*I, 2.2 + 1.2*I]
```

versus

```
>>> [w.n(2) for w in solve(eq.subs(z,1))]  # two imaginary
[1.0, 1.8 - 1.2*I, 1.8 + 1.2*I, 3.4]
```
