### PR TITLE
Add early exit in the limit heuristics() for "bad" results with oo

### DIFF
--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -95,7 +95,11 @@ def heuristics(e, z, z0, dir):
         r = []
         for a in e.args:
             try:
-                r.append(limit(a, z, z0, dir))
+                l = limit(a, z, z0, dir)
+                if l.has(S.Infinity) and l.is_bounded is None:
+                    break
+                else:
+                    r.append(l)
             except PoleError:
                 break
             if r[-1] in bad:

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -305,7 +305,7 @@ class Order(Expr):
         Return None if the inclusion relation cannot be determined
         (e.g. when self and expr have different symbols).
         """
-        from sympy import powsimp, limit
+        from sympy import powsimp, PoleError
         if expr is S.Zero:
             return True
         if expr is S.NaN:
@@ -346,7 +346,10 @@ class Order(Expr):
             ratio = self.expr/expr.expr
             ratio = powsimp(ratio, deep=True, combine='exp')
             for s in common_symbols:
-                l = limit(ratio, s, point) != 0
+                try:
+                    l = ratio.limit(s, point) != 0
+                except PoleError:
+                    l = None
                 if r is None:
                     r = l
                 else:

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -1,5 +1,6 @@
 from sympy import (Symbol, Rational, Order, exp, ln, log, nan, oo, O, pi, I,
-    S, Integral, sin, sqrt, conjugate, expand, transpose, symbols, Function)
+    S, Integral, sin, cos, sqrt, conjugate, expand, transpose, symbols,
+    Function)
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.abc import w, x, y, z
 
@@ -129,6 +130,11 @@ def test_contains_2():
 def test_contains_3():
     assert Order(x*y**2).contains(Order(x**2*y)) is None
     assert Order(x**2*y).contains(Order(x*y**2)) is None
+
+
+def test_contains_4():
+    assert Order(sin(1/x**2)).contains(Order(cos(1/x**2))) is None
+    assert Order(cos(1/x**2)).contains(Order(sin(1/x**2))) is None
 
 
 def test_contains():


### PR DESCRIPTION
This does limit calculations in this method more fragle, which is good.  An example:

```
>>> O(sin(1/x**2).contains(O(cos(1/x**2)))
True
```

was wrong, just because of this limit:

```
>>> limit(sin(1/x**2)/cos(1/x**2), x, 0)
sin(oo)/cos(oo)
```

PS: This problem appears in this pr #2905.
