### PR TITLE
modify do-nothing tests

### DIFF
--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -11,9 +11,9 @@ from sympy.printing import pretty
 
 def test_equal():
     """Test for equality"""
-    assert Q.positive(x) == Q.positive(x)
+    assert Q.positive(x)  # doesn't fail
     assert Q.positive(x) != ~Q.positive(x)
-    assert ~Q.positive(x) == ~Q.positive(x)
+    assert ~Q.positive(x)  # doesn't fail
 
 
 def test_pretty():

--- a/sympy/assumptions/tests/test_assumptions_2.py
+++ b/sympy/assumptions/tests/test_assumptions_2.py
@@ -9,11 +9,8 @@ from sympy.logic.boolalg import Or
 from sympy.printing import pretty
 
 
-def test_equal():
-    """Test for equality"""
-    assert Q.positive(x)  # doesn't fail
+def test_inequality():
     assert Q.positive(x) != ~Q.positive(x)
-    assert ~Q.positive(x)  # doesn't fail
 
 
 def test_pretty():

--- a/sympy/combinatorics/tests/test_permutations.py
+++ b/sympy/combinatorics/tests/test_permutations.py
@@ -184,8 +184,8 @@ def test_Permutation():
     assert r.index() == 3
 
     assert p.get_precedence_distance(q) == q.get_precedence_distance(p)
-    assert p.get_adjacency_distance(q) == p.get_adjacency_distance(q)
-    assert p.get_positional_distance(q) == p.get_positional_distance(q)
+    assert p.get_adjacency_distance(q)  # doesn't fail
+    assert p.get_positional_distance(q)  # doesn't fail
     p = Permutation([0, 1, 2, 3])
     q = Permutation([3, 2, 1, 0])
     assert p.get_precedence_distance(q) == 6

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1854,6 +1854,7 @@ class RationalConstant(Rational):
         return AtomicExpr.__new__(cls)
 
 
+
 class IntegerConstant(Integer):
     __slots__ = []
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -80,7 +80,11 @@ def test_all_classes_are_tested():
 
 
 def _test_args(obj):
-    return all(isinstance(arg, Basic) for arg in obj.args)
+    if not all(isinstance(arg, Basic) for arg in obj.args):
+        return False
+    if not hasattr(obj, '__eq__') or not obj == obj:
+        return False
+    return True
 
 
 def test_sympy__assumptions__assume__AppliedPredicate():
@@ -361,9 +365,9 @@ def test_sympy__core__numbers__Rational():
     assert _test_args(Rational(1, 7))
 
 
+@SKIP("abstract class")
 def test_sympy__core__numbers__RationalConstant():
-    from sympy.core.numbers import RationalConstant
-    assert _test_args(RationalConstant())
+    pass
 
 
 def test_sympy__core__numbers__Zero():
@@ -2925,9 +2929,9 @@ def test_sympy__geometry__ellipse__Circle():
     assert _test_args(Circle((0, 1), 2))
 
 
+@SKIP("abstract class")
 def test_sympy__geometry__line__LinearEntity():
-    from sympy.geometry.line import LinearEntity
-    assert _test_args(LinearEntity((0, 1), (2, 3)))
+    pass
 
 
 def test_sympy__geometry__line__Line():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -155,8 +155,8 @@ def test_pow():
     n = Symbol('k', even=False)
     k = Symbol('k', even=True)
 
-    assert (-1)**x == (-1)**x
-    assert (-1)**n == (-1)**n
+    assert (-1)**x  # doesn't fail
+    assert (-1)**n  # doesn't fail
     assert (-2)**k == 2**k
     assert (-2*x)**k == (-2*x)**k  # we choose not to auto expand this
     assert (-1)**k == 1
@@ -274,7 +274,7 @@ def test_ncmul():
     assert A/A == 1
     assert A/(A**2) == 1/A
 
-    assert A/(1 + A) == A/(1 + A)
+    assert A/(1 + A)  # doesn't fail
 
     assert set((A + B + 2*(A + B)).args) == \
         set([A, B, 2*(A + B)])
@@ -323,8 +323,8 @@ def test_powerbug():
 def test_Mul_doesnt_expand_exp():
     x = Symbol('x')
     y = Symbol('y')
-    assert exp(x)*exp(y) == exp(x)*exp(y)
-    assert 2**x*2**y == 2**x*2**y
+    assert exp(x)*exp(y)  # doesn't fail
+    assert 2**x*2**y  # doesn't fail
     assert x**2*x**3 == x**5
     assert 2**x*3**x == 6**x
     assert x**(y)*x**(2*y) == x**(3*y)
@@ -1471,7 +1471,7 @@ def test_issue_2941():
 
 
 def test_issue_2983():
-    assert Max(x, 1) * Max(x, 2) == Max(x, 1) * Max(x, 2)
+    assert Max(x, 1) * Max(x, 2)  # doesn't fail
 
 
 def test_issue_2978():

--- a/sympy/core/tests/test_complex.py
+++ b/sympy/core/tests/test_complex.py
@@ -39,7 +39,7 @@ def test_conjugate():
 def test_abs1():
     a = Symbol("a", real=True)
     b = Symbol("b", real=True)
-    assert abs(a) == abs(a)
+    assert abs(a)  # doesn't fail
     assert abs(-a) == abs(a)
     assert abs(a + I*b) == sqrt(a**2 + b**2)
 

--- a/sympy/core/tests/test_eval.py
+++ b/sympy/core/tests/test_eval.py
@@ -48,7 +48,7 @@ def test_pow_eval():
     assert 24/sqrt(64) == 3
     assert (-27)**Rational(1, 3) == 3*(-1)**Rational(1, 3)
 
-    assert (cos(2) / tan(2))**2 == (cos(2) / tan(2))**2
+    assert (cos(2) / tan(2))**2  # doesn't fail
 
 
 @XFAIL

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -130,7 +130,6 @@ def test_Lambda():
     assert e(x) == x**2
     assert e(y) == y**2
 
-    assert Lambda(x, x**2)  # doesn't fail
     assert Lambda(x, x**2) == Lambda(y, y**2)
     assert Lambda(x, x**2) != Lambda(y, y**2 + 1)
     assert Lambda((x, y), x**y) == Lambda((y, x), y**x)
@@ -172,10 +171,9 @@ def test_Lambda_arguments():
 
 
 def test_Lambda_equality():
-    assert Lambda(x, 2*x) == Lambda(y, 2*y)
     # although variables are casts as Dummies, the expressions
     # should still compare equal
-    assert Lambda((x, y), 2*x)  # doesn't fail
+    assert Lambda((x, y), 2*x) == Lambda((y, x), 2*y)
     assert Lambda(x, 2*x) != Lambda((x, y), 2*x)
     assert Lambda(x, 2*x) != 2*x
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -130,7 +130,7 @@ def test_Lambda():
     assert e(x) == x**2
     assert e(y) == y**2
 
-    assert Lambda(x, x**2) == Lambda(x, x**2)
+    assert Lambda(x, x**2)  # doesn't fail
     assert Lambda(x, x**2) == Lambda(y, y**2)
     assert Lambda(x, x**2) != Lambda(y, y**2 + 1)
     assert Lambda((x, y), x**y) == Lambda((y, x), y**x)
@@ -175,7 +175,7 @@ def test_Lambda_equality():
     assert Lambda(x, 2*x) == Lambda(y, 2*y)
     # although variables are casts as Dummies, the expressions
     # should still compare equal
-    assert Lambda((x, y), 2*x) == Lambda((x, y), 2*x)
+    assert Lambda((x, y), 2*x)  # doesn't fail
     assert Lambda(x, 2*x) != Lambda((x, y), 2*x)
     assert Lambda(x, 2*x) != 2*x
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -703,7 +703,7 @@ def test_Infinity_inequations():
 
 
 def test_NaN():
-    assert nan == nan
+    assert nan  # doesn't fail
     assert nan != 1
     assert 1*nan == nan
     assert 1 != nan
@@ -1007,7 +1007,7 @@ def test_no_len():
 
 
 def test_issue222():
-    assert sqrt(Rational(1, 5)) == sqrt(Rational(1, 5))
+    assert sqrt(Rational(1, 5))  # doesn't fail
     assert 5 * sqrt(Rational(1, 5)) == sqrt(5)
 
 

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -20,7 +20,7 @@ def test_Symbol():
     assert x1 != xdummy1
     assert xdummy1 != xdummy2
 
-    assert Symbol("x") == Symbol("x")
+    assert Symbol("x")  # doesn't fail
     assert Dummy("x") != Dummy("x")
     d = symbols('d', cls=Dummy)
     assert isinstance(d, Dummy)

--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -76,8 +76,8 @@ def test_basics():
     one = Rational(1)
     zero = Rational(0)
     assert array(1) == array(one)
-    assert array([one]) == array([one])
-    assert array([x]) == array([x])
+    assert array([one])  # doesn't fail
+    assert array([x])  # doesn't fail
     assert array(x) == array(Symbol("x"))
     assert array(one + x) == array(1 + x)
 

--- a/sympy/functions/combinatorial/tests/test_comb_factorials.py
+++ b/sympy/functions/combinatorial/tests/test_comb_factorials.py
@@ -10,7 +10,7 @@ def test_rf_eval_apply():
 
     assert rf(nan, y) == nan
 
-    assert rf(x, y) == rf(x, y)
+    assert rf(x, y)  # doesn't fail
 
     assert rf(oo, 0) == 1
     assert rf(-oo, 0) == 1
@@ -39,7 +39,7 @@ def test_ff_eval_apply():
 
     assert ff(nan, y) == nan
 
-    assert ff(x, y) == ff(x, y)
+    assert ff(x, y)  # doesn't fail
 
     assert ff(oo, 0) == 1
     assert ff(-oo, 0) == 1

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -162,7 +162,7 @@ def test_catalan():
     assert catalan(3) == 5
     assert catalan(4) == 14
 
-    assert catalan(x) == catalan(x)
+    assert catalan(x)  # doesn't fail
     assert catalan(2*x).rewrite(binomial) == binomial(4*x, 2*x)/(2*x + 1)
     assert catalan(Rational(1, 2)).rewrite(gamma) == 8/(3*pi)
     assert catalan(3*x).rewrite(gamma) == 4**(

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -33,14 +33,14 @@ def test_re():
     assert re(E) == E
     assert re(-E) == -E
 
-    assert re(x) == re(x)
+    assert re(x)  # doesn't fail
     assert re(x*I) == -im(x)
     assert re(r*I) == 0
     assert re(r) == r
     assert re(i*I) == I * i
     assert re(i) == 0
 
-    assert re(x + y) == re(x + y)
+    assert re(x + y)  # doesn't fail
     assert re(x + r) == re(x) + r
 
     assert re(re(x)) == re(x)
@@ -91,14 +91,14 @@ def test_im():
     assert im(E*I) == E
     assert im(-E*I) == -E
 
-    assert im(x) == im(x)
+    assert im(x)  # doesn't fail
     assert im(x*I) == re(x)
     assert im(r*I) == r
     assert im(r) == 0
     assert im(i*I) == 0
     assert im(i) == -I * i
 
-    assert im(x + y) == im(x + y)
+    assert im(x + y)  # doesn't fail
     assert im(x + r) == im(x)
     assert im(x + r*I) == im(x) + r
 

--- a/sympy/functions/elementary/tests/test_exponential.py
+++ b/sympy/functions/elementary/tests/test_exponential.py
@@ -141,10 +141,10 @@ def test_log_values():
     assert log(E) == 1
     assert log(-E).expand() == 1 + I*pi
 
-    assert log(pi) == log(pi)
+    assert log(pi)  # doesn't fail
     assert log(-pi).expand() == log(pi) + I*pi
 
-    assert log(17) == log(17)
+    assert log(17)  # doesn't fail
     assert log(-17) == log(17) + I*pi
 
     assert log(I) == I*pi/2
@@ -309,7 +309,7 @@ def test_log_simplify():
 
 def test_lambertw():
     x = Symbol('x')
-    assert LambertW(x) == LambertW(x)
+    assert LambertW(x)  # doesn't fail
     assert LambertW(0) == 0
     assert LambertW(E) == 1
     assert LambertW(-1/E) == -1

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -18,16 +18,16 @@ def test_sinh():
 
     assert sinh(0) == 0
 
-    assert sinh(1) == sinh(1)
+    assert sinh(1)  # doesn't fail
     assert sinh(-1) == -sinh(1)
 
-    assert sinh(x) == sinh(x)
+    assert sinh(x)  # doesn't fail
     assert sinh(-x) == -sinh(x)
 
-    assert sinh(pi) == sinh(pi)
+    assert sinh(pi)  # doesn't fail
     assert sinh(-pi) == -sinh(pi)
 
-    assert sinh(2**1024 * E) == sinh(2**1024 * E)
+    assert sinh(2**1024 * E)  # doesn't fail
     assert sinh(-2**1024 * E) == -sinh(2**1024 * E)
 
     assert sinh(pi*I) == 0
@@ -58,7 +58,7 @@ def test_sinh():
     assert sinh(pi*I/105) == sin(pi/105)*I
     assert sinh(-pi*I/105) == -sin(pi/105)*I
 
-    assert sinh(2 + 3*I) == sinh(2 + 3*I)
+    assert sinh(2 + 3*I)  # doesn't fail
 
     assert sinh(x*I) == sin(x)*I
 
@@ -87,16 +87,16 @@ def test_cosh():
 
     assert cosh(0) == 1
 
-    assert cosh(1) == cosh(1)
+    assert cosh(1)  # doesn't fail
     assert cosh(-1) == cosh(1)
 
-    assert cosh(x) == cosh(x)
+    assert cosh(x)  # doesn't fail
     assert cosh(-x) == cosh(x)
 
     assert cosh(pi*I) == cos(pi)
     assert cosh(-pi*I) == cos(pi)
 
-    assert cosh(2**1024 * E) == cosh(2**1024 * E)
+    assert cosh(2**1024 * E)  # doesn't fail
     assert cosh(-2**1024 * E) == cosh(2**1024 * E)
 
     assert cosh(pi*I/2) == 0
@@ -127,14 +127,14 @@ def test_cosh():
     assert cosh(pi*I/105) == cos(pi/105)
     assert cosh(-pi*I/105) == cos(pi/105)
 
-    assert cosh(2 + 3*I) == cosh(2 + 3*I)
+    assert cosh(2 + 3*I)  # doesn't fail
 
     assert cosh(x*I) == cos(x)
 
     assert cosh(k*pi*I) == cos(k*pi)
     assert cosh(17*k*pi*I) == cos(17*k*pi)
 
-    assert cosh(k*pi) == cosh(k*pi)
+    assert cosh(k*pi)  # doesn't fail
 
 
 def test_cosh_series():
@@ -156,16 +156,16 @@ def test_tanh():
 
     assert tanh(0) == 0
 
-    assert tanh(1) == tanh(1)
+    assert tanh(1)  # doesn't fail
     assert tanh(-1) == -tanh(1)
 
-    assert tanh(x) == tanh(x)
+    assert tanh(x)  # doesn't fail
     assert tanh(-x) == -tanh(x)
 
-    assert tanh(pi) == tanh(pi)
+    assert tanh(pi)  # doesn't fail
     assert tanh(-pi) == -tanh(pi)
 
-    assert tanh(2**1024 * E) == tanh(2**1024 * E)
+    assert tanh(2**1024 * E)  # doesn't fail
     assert tanh(-2**1024 * E) == -tanh(2**1024 * E)
 
     assert tanh(pi*I) == 0
@@ -175,10 +175,10 @@ def test_tanh():
     assert tanh(-3*10**73*pi*I) == 0
     assert tanh(7*10**103*pi*I) == 0
 
-    assert tanh(pi*I/2) == tanh(pi*I/2)
+    assert tanh(pi*I/2)  # doesn't fail
     assert tanh(-pi*I/2) == -tanh(pi*I/2)
-    assert tanh(5*pi*I/2) == tanh(5*pi*I/2)
-    assert tanh(7*pi*I/2) == tanh(7*pi*I/2)
+    assert tanh(5*pi*I/2)  # doesn't fail
+    assert tanh(7*pi*I/2)  # doesn't fail
 
     assert tanh(pi*I/3) == sqrt(3)*I
     assert tanh(-2*pi*I/3) == sqrt(3)*I
@@ -196,7 +196,7 @@ def test_tanh():
     assert tanh(pi*I/105) == tan(pi/105)*I
     assert tanh(-pi*I/105) == -tan(pi/105)*I
 
-    assert tanh(2 + 3*I) == tanh(2 + 3*I)
+    assert tanh(2 + 3*I)  # doesn't fail
 
     assert tanh(x*I) == tan(x)*I
 
@@ -223,18 +223,18 @@ def test_coth():
     assert coth(oo) == 1
     assert coth(-oo) == -1
 
-    assert coth(0) == coth(0)
+    assert coth(0) == 0
 
-    assert coth(1) == coth(1)
+    assert coth(1)  # doesn't fail
     assert coth(-1) == -coth(1)
 
-    assert coth(x) == coth(x)
+    assert coth(x)  # doesn't fail
     assert coth(-x) == -coth(x)
 
     assert coth(pi*I) == -I*cot(pi)
     assert coth(-pi*I) == cot(pi)*I
 
-    assert coth(2**1024 * E) == coth(2**1024 * E)
+    assert coth(2**1024 * E)  # doesn't fail
     assert coth(-2**1024 * E) == -coth(2**1024 * E)
 
     assert coth(pi*I) == -I*cot(pi)
@@ -265,7 +265,7 @@ def test_coth():
     assert coth(pi*I/105) == -cot(pi/105)*I
     assert coth(-pi*I/105) == cot(pi/105)*I
 
-    assert coth(2 + 3*I) == coth(2 + 3*I)
+    assert coth(2 + 3*I)  # doesn't fail
 
     assert coth(x*I) == -cot(x)*I
 
@@ -283,7 +283,7 @@ def test_coth_series():
 
 def test_asinh():
     x, y = symbols('x,y')
-    assert asinh(x) == asinh(x)
+    assert asinh(x)  # doesn't fail
     assert asinh(-x) == -asinh(x)
     assert asinh(nan) == nan
     assert asinh( 0) == 0

--- a/sympy/functions/elementary/tests/test_integers.py
+++ b/sympy/functions/elementary/tests/test_integers.py
@@ -56,27 +56,27 @@ def test_floor():
     assert floor(E + 17) == 19
     assert floor(pi + 2) == 5
 
-    assert floor(E + pi) == floor(E + pi)
-    assert floor(I + pi) == floor(I + pi)
+    assert floor(E + pi)  # doesn't fail
+    assert floor(I + pi)  # doesn't fail
 
     assert floor(floor(pi)) == 3
     assert floor(floor(y)) == floor(y)
-    assert floor(floor(x)) == floor(floor(x))
+    assert floor(floor(x))  # doesn't fail
 
-    assert floor(x) == floor(x)
-    assert floor(2*x) == floor(2*x)
-    assert floor(k*x) == floor(k*x)
+    assert floor(x)  # doesn't fail
+    assert floor(2*x)  # doesn't fail
+    assert floor(k*x)  # doesn't fail
 
     assert floor(k) == k
     assert floor(2*k) == 2*k
     assert floor(k*n) == k*n
 
-    assert floor(k/2) == floor(k/2)
+    assert floor(k/2)  # doesn't fail
 
-    assert floor(x + y) == floor(x + y)
+    assert floor(x + y)  # doesn't fail
 
-    assert floor(x + 3) == floor(x + 3)
-    assert floor(x + k) == floor(x + k)
+    assert floor(x + 3)  # doesn't fail
+    assert floor(x + k)  # doesn't fail
 
     assert floor(y + 3) == floor(y) + 3
     assert floor(y + k) == floor(y) + k
@@ -85,7 +85,7 @@ def test_floor():
 
     assert floor(k + n) == k + n
 
-    assert floor(x*I) == floor(x*I)
+    assert floor(x*I)  # doesn't fail
     assert floor(k*I) == k*I
 
     assert floor(Rational(23, 10) - E*I) == 2 - 3*I
@@ -154,27 +154,27 @@ def test_ceiling():
     assert ceiling(E + 17) == 20
     assert ceiling(pi + 2) == 6
 
-    assert ceiling(E + pi) == ceiling(E + pi)
-    assert ceiling(I + pi) == ceiling(I + pi)
+    assert ceiling(E + pi)  # doesn't fail
+    assert ceiling(I + pi)  # doesn't fail
 
     assert ceiling(ceiling(pi)) == 4
     assert ceiling(ceiling(y)) == ceiling(y)
-    assert ceiling(ceiling(x)) == ceiling(ceiling(x))
+    assert ceiling(ceiling(x))  # doesn't fail
 
-    assert ceiling(x) == ceiling(x)
-    assert ceiling(2*x) == ceiling(2*x)
-    assert ceiling(k*x) == ceiling(k*x)
+    assert ceiling(x)  # doesn't fail
+    assert ceiling(2*x)  # doesn't fail
+    assert ceiling(k*x)  # doesn't fail
 
     assert ceiling(k) == k
     assert ceiling(2*k) == 2*k
     assert ceiling(k*n) == k*n
 
-    assert ceiling(k/2) == ceiling(k/2)
+    assert ceiling(k/2)  # doesn't fail
 
-    assert ceiling(x + y) == ceiling(x + y)
+    assert ceiling(x + y)  # doesn't fail
 
-    assert ceiling(x + 3) == ceiling(x + 3)
-    assert ceiling(x + k) == ceiling(x + k)
+    assert ceiling(x + 3)  # doesn't fail
+    assert ceiling(x + k)  # doesn't fail
 
     assert ceiling(y + 3) == ceiling(y) + 3
     assert ceiling(y + k) == ceiling(y) + k
@@ -183,7 +183,7 @@ def test_ceiling():
 
     assert ceiling(k + n) == k + n
 
-    assert ceiling(x*I) == ceiling(x*I)
+    assert ceiling(x*I)  # doesn't fail
     assert ceiling(k*I) == k*I
 
     assert ceiling(Rational(23, 10) - E*I) == 3 - 2*I

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -31,8 +31,8 @@ def test_Min():
     assert Min(-oo, oo) == -oo
     assert Min(oo, -oo) == -oo
     assert Min(n, n) == n
-    assert Min(n, np) == Min(n, np)
-    assert Min(np, n) == Min(np, n)
+    assert Min(n, np)  # doesn't fail
+    assert Min(np, n)  # doesn't fail
     assert Min(n, 0) == n
     assert Min(0, n) == n
     assert Min(n, nn) == n
@@ -58,8 +58,8 @@ def test_Min():
     assert Min(0, oo) == 0
     assert Min(oo, 0) == 0
     assert Min(nn, nn) == nn
-    assert Min(nn, p) == Min(nn, p)
-    assert Min(p, nn) == Min(p, nn)
+    assert Min(nn, p)  # doesn't fail
+    assert Min(p, nn)  # doesn't fail
     assert Min(nn, oo) == nn
     assert Min(oo, nn) == nn
     assert Min(p, p) == p
@@ -84,7 +84,7 @@ def test_Min():
     assert Min(2, x, p, n, oo, n_, p, 2, -2, -2) == Min(-2, x, n, n_)
     assert Min(0, x, 1, y) == Min(0, x, y)
     assert Min(1000, 100, -100, x, p, n) == Min(n, x, -100)
-    assert Min(cos(x), sin(x)) == Min(cos(x), sin(x))
+    assert Min(cos(x), sin(x))  # doesn't fail
     assert Min(cos(x), sin(x)).subs(x, 1) == cos(1)
     assert Min(cos(x), sin(x)).subs(x, S(1)/2) == sin(S(1)/2)
     raises(ValueError, lambda: Min(cos(x), sin(x)).subs(x, I))

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -13,7 +13,7 @@ z = symbols('z', nonzero=True)
 def test_piecewise():
 
     # Test canonization
-    assert Piecewise((x, x < 1), (0, True)) == Piecewise((x, x < 1), (0, True))
+    assert Piecewise((x, x < 1), (0, True))  # doesn't fail
     assert Piecewise((x, x < 1), (0, True), (1, True)) == \
         Piecewise((x, x < 1), (0, True))
     assert Piecewise((x, x < 1), (0, False), (-1, 1 > 2)) == \

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -439,8 +439,8 @@ def test_li():
 
     assert conjugate(li(z)) == li(conjugate(z))
     assert conjugate(li(-zr)) == li(-zr)
-    assert conjugate(li(-zp)) == conjugate(li(-zp))
-    assert conjugate(li(zn)) == conjugate(li(zn))
+    assert conjugate(li(-zp))  # doesn't fail
+    assert conjugate(li(zn))  # doesn't fail
 
     assert li(z).rewrite(Li) == Li(z) + li(2)
     assert li(z).rewrite(Ei) == Ei(log(z))
@@ -565,7 +565,7 @@ def test_fresnel():
     assert fresnels(oo) == S.Half
     assert fresnels(-oo) == -S.Half
 
-    assert fresnels(z) == fresnels(z)
+    assert fresnels(z)  # doesn't fail
     assert fresnels(-z) == -fresnels(z)
     assert fresnels(I*z) == -I*fresnels(z)
     assert fresnels(-I*z) == I*fresnels(z)
@@ -608,7 +608,7 @@ def test_fresnel():
     assert fresnelc(oo) == S.Half
     assert fresnelc(-oo) == -S.Half
 
-    assert fresnelc(z) == fresnelc(z)
+    assert fresnelc(z)  # doesn't fail
     assert fresnelc(-z) == -fresnelc(z)
     assert fresnelc(I*z) == I*fresnelc(z)
     assert fresnelc(-I*z) == -I*fresnelc(z)

--- a/sympy/functions/special/tests/test_gamma_functions.py
+++ b/sympy/functions/special/tests/test_gamma_functions.py
@@ -119,8 +119,8 @@ def test_lowergamma():
         lowergamma(-2, x*exp_polar(I*pi)) + 2*pi*I
 
     assert conjugate(lowergamma(x, y)) == lowergamma(conjugate(x), conjugate(y))
-    assert conjugate(lowergamma(x, 0)) == conjugate(lowergamma(x, 0))
-    assert conjugate(lowergamma(x, -oo)) == conjugate(lowergamma(x, -oo))
+    assert conjugate(lowergamma(x, 0))  # doesn't fail
+    assert conjugate(lowergamma(x, -oo))  # doesn't fail
 
     assert lowergamma(
         x, y).rewrite(expint) == -y**x*expint(-x + 1, y) + gamma(x)
@@ -164,7 +164,7 @@ def test_uppergamma():
 
     assert conjugate(uppergamma(x, y)) == uppergamma(conjugate(x), conjugate(y))
     assert conjugate(uppergamma(x, 0)) == gamma(conjugate(x))
-    assert conjugate(uppergamma(x, -oo)) == conjugate(uppergamma(x, -oo))
+    assert conjugate(uppergamma(x, -oo))  # doesn't fail
 
     assert uppergamma(x, y).rewrite(expint) == y**x*expint(-x + 1, y)
     assert uppergamma(x, y).rewrite(lowergamma) == gamma(x) - lowergamma(x, y)
@@ -312,9 +312,9 @@ def test_loggamma():
     assert s1 == loggamma(x).rewrite('intractable').series(x)
 
     assert conjugate(loggamma(x)) == loggamma(conjugate(x))
-    assert conjugate(loggamma(0)) == conjugate(loggamma(0))
+    assert conjugate(loggamma(0))  # doesn't fail
     assert conjugate(loggamma(1)) == loggamma(conjugate(1))
-    assert conjugate(loggamma(-oo)) == conjugate(loggamma(-oo))
+    assert conjugate(loggamma(-oo))  # doesn't fail
     assert loggamma(x).is_real is None
     y, z = Symbol('y', real=True), Symbol('z', imaginary=True)
     assert loggamma(y).is_real

--- a/sympy/functions/special/tests/test_spec_polynomials.py
+++ b/sympy/functions/special/tests/test_spec_polynomials.py
@@ -210,9 +210,9 @@ def test_hermite():
     assert hermite(6, x) == 64*x**6 - 480*x**4 + 720*x**2 - 120
 
     n = Symbol("n")
-    assert hermite(n, x) == hermite(n, x)
+    assert hermite(n, x)  # doesn't fail
     assert hermite(n, -x) == (-1)**n*hermite(n, x)
-    assert hermite(-n, x) == hermite(-n, x)
+    assert hermite(-n, x)  # doesn't fail
 
     assert diff(hermite(n, x), x) == 2*n*hermite(n - 1, x)
     assert diff(hermite(n, x), n) == Derivative(hermite(n, x), n)

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -10,7 +10,7 @@ sigma3 = Pauli(3)
 def test_Pauli():
     from sympy.physics.paulialgebra import evaluate_pauli_product
 
-    assert sigma1 == sigma1
+    assert sigma1  # doesn't fail
     assert sigma1 != sigma2
 
     assert sigma1*sigma2 == I*sigma3

--- a/sympy/physics/tests/test_physics_matrices.py
+++ b/sympy/physics/tests/test_physics_matrices.py
@@ -35,7 +35,7 @@ def test_Pauli():
     sigma2 = msigma(2)
     sigma3 = msigma(3)
 
-    assert sigma1 == sigma1
+    assert sigma1  # doesn't fail
     assert sigma1 != sigma2
 
     # sigma*I -> I*sigma    (see #354)

--- a/sympy/polys/agca/tests/test_homomorphisms.py
+++ b/sympy/polys/agca/tests/test_homomorphisms.py
@@ -25,7 +25,7 @@ def test_operations():
     h = homomorphism(F, F, [[1, 0], 0])
     i = homomorphism(F, G, [[1, 0, 0], [0, 1, 0]])
 
-    assert f == f
+    assert f  # doesn't fail
     assert f != g
     assert f != i
     assert (f != F.identity_hom()) is False

--- a/sympy/polys/agca/tests/test_ideals.py
+++ b/sympy/polys/agca/tests/test_ideals.py
@@ -13,7 +13,7 @@ def test_ideal_operations():
     T = R.ideal(x, y)
 
     assert not (I == J)
-    assert I == I
+    assert I  # doesn't fail
 
     assert I.union(J) == T
     assert I + J == T

--- a/sympy/polys/tests/test_densetools.py
+++ b/sympy/polys/tests/test_densetools.py
@@ -128,7 +128,7 @@ def test_dup_diff():
     f = dup_normal([17, 34, 56, -345, 23, 76, 0, 0, 12, 3, 7], ZZ)
 
     assert dup_diff(f, 0, ZZ) == f
-    assert dup_diff(f, 1, ZZ) == dup_diff(f, 1, ZZ)
+    assert dup_diff(f, 1, ZZ)  # doesn't fail
     assert dup_diff(f, 2, ZZ) == dup_diff(dup_diff(f, 1, ZZ), 1, ZZ)
     assert dup_diff(
         f, 3, ZZ) == dup_diff(dup_diff(dup_diff(f, 1, ZZ), 1, ZZ), 1, ZZ)
@@ -141,7 +141,7 @@ def test_dup_diff():
     assert dup_diff(f, 3, K) == dup_normal([], K)
 
     assert dup_diff(f, 0, K) == f
-    assert dup_diff(f, 1, K) == dup_diff(f, 1, K)
+    assert dup_diff(f, 1, K)  # doesn't fail
     assert dup_diff(f, 2, K) == dup_diff(dup_diff(f, 1, K), 1, K)
     assert dup_diff(
         f, 3, K) == dup_diff(dup_diff(dup_diff(f, 1, K), 1, K), 1, K)
@@ -161,7 +161,7 @@ def test_dmp_diff():
         dup_diff([1, -1, 0, 0, 2], 1, ZZ)
 
     assert dmp_diff(f_6, 0, 3, ZZ) == f_6
-    assert dmp_diff(f_6, 1, 3, ZZ) == dmp_diff(f_6, 1, 3, ZZ)
+    assert dmp_diff(f_6, 1, 3, ZZ)  # doesn't fail
     assert dmp_diff(
         f_6, 2, 3, ZZ) == dmp_diff(dmp_diff(f_6, 1, 3, ZZ), 1, 3, ZZ)
     assert dmp_diff(f_6, 3, 3, ZZ) == dmp_diff(
@@ -171,7 +171,7 @@ def test_dmp_diff():
     F_6 = dmp_normal(f_6, 3, K)
 
     assert dmp_diff(F_6, 0, 3, K) == F_6
-    assert dmp_diff(F_6, 1, 3, K) == dmp_diff(F_6, 1, 3, K)
+    assert dmp_diff(F_6, 1, 3, K)  # doesn't fail
     assert dmp_diff(F_6, 2, 3, K) == dmp_diff(dmp_diff(F_6, 1, 3, K), 1, 3, K)
     assert dmp_diff(F_6, 3, 3, K) == dmp_diff(
         dmp_diff(dmp_diff(F_6, 1, 3, K), 1, 3, K), 1, 3, K)

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -26,7 +26,7 @@ def test_FracField___hash__():
     assert hash(F)
 
 def test_FracField___eq__():
-    assert field("x,y,z", QQ)[0] == field("x,y,z", QQ)[0]
+    assert field("x,y,z", QQ)[0]  # doesn't fail
     assert field("x,y,z", QQ)[0] is field("x,y,z", QQ)[0]
 
     assert field("x,y,z", QQ)[0] != field("x,y,z", ZZ)[0]

--- a/sympy/polys/tests/test_orderings.py
+++ b/sympy/polys/tests/test_orderings.py
@@ -13,7 +13,7 @@ def test_lex_order():
     assert lex((1, 2, 3)) == (1, 2, 3)
     assert str(lex) == 'lex'
 
-    assert lex((1, 2, 3)) == lex((1, 2, 3))
+    assert lex((1, 2, 3))  # doesn't fail
 
     assert lex((2, 2, 3)) > lex((1, 2, 3))
     assert lex((1, 3, 3)) > lex((1, 2, 3))
@@ -31,7 +31,7 @@ def test_grlex_order():
     assert grlex((1, 2, 3)) == (6, (1, 2, 3))
     assert str(grlex) == 'grlex'
 
-    assert grlex((1, 2, 3)) == grlex((1, 2, 3))
+    assert grlex((1, 2, 3))  # doesn't fail
 
     assert grlex((2, 2, 3)) > grlex((1, 2, 3))
     assert grlex((1, 3, 3)) > grlex((1, 2, 3))
@@ -56,7 +56,7 @@ def test_grevlex_order():
     assert grevlex((1, 2, 3)) == (6, (-3, -2, -1))
     assert str(grevlex) == 'grevlex'
 
-    assert grevlex((1, 2, 3)) == grevlex((1, 2, 3))
+    assert grevlex((1, 2, 3))  # doesn't fail
 
     assert grevlex((2, 2, 3)) > grevlex((1, 2, 3))
     assert grevlex((1, 3, 3)) > grevlex((1, 2, 3))

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -52,7 +52,7 @@ def test_PolyRing___hash__():
     assert hash(R)
 
 def test_PolyRing___eq__():
-    assert ring("x,y,z", QQ)[0] == ring("x,y,z", QQ)[0]
+    assert ring("x,y,z", QQ)[0]  # doesn't fail
     assert ring("x,y,z", QQ)[0] is ring("x,y,z", QQ)[0]
 
     assert ring("x,y,z", QQ)[0] != ring("x,y,z", ZZ)[0]

--- a/sympy/series/tests/test_order.py
+++ b/sympy/series/tests/test_order.py
@@ -52,7 +52,7 @@ def test_simple_3():
     assert Order(x) + x**2 == Order(x)
     assert Order(x) + 1/x == 1/x + Order(x)
     assert Order(1/x) + 1/x**2 == 1/x**2 + Order(1/x)
-    assert Order(x) + exp(1/x) == Order(x) + exp(1/x)
+    assert Order(x) + exp(1/x)  # doesn't fail
 
 
 def test_simple_4():
@@ -79,7 +79,7 @@ def test_simple_7():
     assert 1 + O(1) == O(1)
     assert 2 + O(1) == O(1)
     assert x + O(1) == O(1)
-    assert 1/x + O(1) == 1/x + O(1)
+    assert 1/x + O(1)  # doesn't fail
 
 
 def test_simple_8():

--- a/sympy/simplify/tests/test_function.py
+++ b/sympy/simplify/tests/test_function.py
@@ -25,7 +25,7 @@ def test_has():
     assert not f.has(c)
 
 def test_eq():
-    assert Hyper_Function([1], []) == Hyper_Function([1], [])
+    assert Hyper_Function([1], [])  # doesn't fail
     assert (Hyper_Function([1], []) != Hyper_Function([1], [])) is False
     assert Hyper_Function([1], []) != Hyper_Function([2], [])
     assert Hyper_Function([1], []) != Hyper_Function([1, 2], [])

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -588,7 +588,7 @@ def test_powsimp():
     assert powsimp(
         f(4**x * 2**(-x) * 2**(-x)) ) == f(4**x * 2**(-x) * 2**(-x))
     assert powsimp( f(4**x * 2**(-x) * 2**(-x)), deep=True ) == f(1)
-    assert exp(x)*exp(y) == exp(x)*exp(y)
+    assert exp(x)*exp(y)  # doesn't fail
     assert powsimp(exp(x)*exp(y)) == exp(x + y)
     assert powsimp(exp(x)*exp(y)*2**x*2**y) == (2*E)**(x + y)
     assert powsimp(exp(x)*exp(y)*2**x*2**y, combine='exp') == \
@@ -701,7 +701,7 @@ def test_powsimp_polar():
     assert p**x * (1/p)**x == 1
     assert (1/p)**x == p**(-x)
 
-    assert exp_polar(x)*exp_polar(y) == exp_polar(x)*exp_polar(y)
+    assert exp_polar(x)*exp_polar(y)  # doesn't fail
     assert powsimp(exp_polar(x)*exp_polar(y)) == exp_polar(x + y)
     assert powsimp(exp_polar(x)*exp_polar(y)*p**x*p**y) == \
         (p*exp_polar(1))**(x + y)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1173,8 +1173,8 @@ def test_hidden_indices_for_matrix_multiplication():
 
     assert (C(True, True)*C(True, True)) == C(L.auto_left, m0)*C(-m0, -L.auto_right)
 
-    assert A(m0) == A(m0)
-    assert B(-m1) == B(-m1)
+    assert A(m0)  # doesn't fail
+    assert B(-m1)  # doesn't fail
 
     assert A(m0) - A(m0) == 0
     ts1 = A(m0)*A(m1) + A(m1)*A(m0)

--- a/sympy/utilities/tests/test_code_quality.py
+++ b/sympy/utilities/tests/test_code_quality.py
@@ -32,7 +32,7 @@ message_old_raise = "File contains old-style raise statement: %s, line %s, \"%s\
 message_eof = "File does not end with a newline: %s, line %s"
 message_multi_eof = "File ends with more than 1 newline: %s, line %s"
 message_test_suite_def = "Function should start with 'test_' or '_': %s, line %s"
-message_donothing = "Left and right side of equality are the same: %s, line %s"
+message_equality = "Test not needed since foo == foo is an automated test: %s, line %s"
 
 implicit_test_re = re.compile(r'^\s*(>>> )?(\.\.\. )?from .* import .*\*')
 str_raise_re = re.compile(
@@ -42,7 +42,7 @@ gen_raise_re = re.compile(
 old_raise_re = re.compile(r'^\s*(>>> )?(\.\.\. )?raise((\s*\(\s*)|\s+)\w+\s*,')
 test_suite_def_re = re.compile(r'^def\s+(?!(_|test))[^(]*\(\s*\)\s*:$')
 test_file_re = re.compile(r'.*test_.*\.py$')
-donothing_re = re.compile(r'^ *assert +(.*) *== *\1$')
+equality_re = re.compile(r'^ *assert +(.*) *== *\1$')
 
 
 def tab_in_leading(s):
@@ -123,8 +123,8 @@ def test_files():
             if (implicit_test_re.search(line) and
                     not filter(lambda ex: ex in fname, import_exclude)):
                 assert False, message_implicit % (fname, idx + 1)
-            if donothing_re.match(line):
-                assert False, message_donothing % (fname, idx + 1)
+            if equality_re.match(line):
+                assert False, message_equality % (fname, idx + 1)
 
             result = old_raise_re.search(line)
 
@@ -300,7 +300,7 @@ def test_test_suite_defs():
     for c in candidates_fail:
         assert test_suite_def_re.search(c) is not None, c
 
-def test_donothing():
+def test_equality():
     # XXX this will miss things like
     # assert x == \
     #        x
@@ -312,6 +312,6 @@ def test_donothing():
         "assert x   ==x",
     ]
     for c in candidates_ok:
-        assert donothing_re.match(c) is None
+        assert equality_re.match(c) is None
     for c in candidates_fail:
-        assert donothing_re.match(c) is not None
+        assert equality_re.match(c) is not None


### PR DESCRIPTION
In some cases a test was added because simply doing the
lhs caused an error. Rather than guess why a do-nothing
test was added, the rhs is simply replaced with `# doesn't fail.`
