### PR TITLE
considered the case when Xor has same symbol returned false

### DIFF
--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -15,8 +15,7 @@ from sympy.core.function import Application
 from sympy.core.compatibility import ordered, xrange, with_metaclass
 from sympy.core.sympify import converter, _sympify, sympify
 from sympy.core.singleton import Singleton, S
-
-
+from sympy.utilities.iterables import multiset
 class Boolean(Basic):
     """A boolean object is an object for which logic operations make sense."""
 
@@ -477,8 +476,19 @@ class Xor(BooleanFunction):
     """
     def __new__(cls, *args, **options):
         args = [_sympify(arg) for arg in args]
-        argset = set(args)
-        
+        argset = multiset(args) #dictionary
+        args_final=[]
+        # xor is commutative and is false if count of x is even
+        #and  x if count of x is odd. Here x can be True, False, Symbols
+        for x,freq in argset.items():
+			if freq%2==0:
+				argset[x]=false
+			else:
+				argset[x]=x;
+				
+        for _,z in argset.items():
+        		 args_final.append(z)   
+        argset = set(args_final)
         truecount = 0
         for x in args:
             if isinstance(x, Number) or x in [True, False]: # Includes 0, 1
@@ -487,8 +497,6 @@ class Xor(BooleanFunction):
                     truecount += 1
         if len(argset) < 1:
             return true if truecount % 2 != 0 else false
-	if len(argset) == 1:
-            return false
         if truecount % 2 != 0:
             return Not(Xor(*argset))
         _args = frozenset(argset)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -476,18 +476,17 @@ class Xor(BooleanFunction):
     """
     def __new__(cls, *args, **options):
         args = [_sympify(arg) for arg in args]
-        argset = multiset(args) #dictionary
+        argset = multiset(args)  # dictionary
         args_final=[]
-        # xor is commutative and is false if count of x is even
-        #and  x if count of x is odd. Here x can be True, False, Symbols
-        for x,freq in argset.items():
-			if freq%2==0:
-				argset[x]=false
-			else:
-				argset[x]=x;
-				
-        for _,z in argset.items():
-        		 args_final.append(z)   
+        # xor is commutative and is false if count of x is even and  x 
+        # if count of x is odd. Here x can be True, False or any Symbols
+        for x, freq in argset.items():
+            if freq % 2 == 0:
+                argset[x] = false
+            else:
+                argset[x] = x
+        for _, z in argset.items():
+                args_final.append(z)   
         argset = set(args_final)
         truecount = 0
         for x in args:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -478,7 +478,7 @@ class Xor(BooleanFunction):
         args = [_sympify(arg) for arg in args]
         argset = multiset(args)  # dictionary
         args_final=[]
-        # xor is commutative and is false if count of x is even and  x 
+        # xor is commutative and is false if count of x is even and x
         # if count of x is odd. Here x can be True, False or any Symbols
         for x, freq in argset.items():
             if freq % 2 == 0:
@@ -486,7 +486,7 @@ class Xor(BooleanFunction):
             else:
                 argset[x] = x
         for _, z in argset.items():
-                args_final.append(z)   
+            args_final.append(z)
         argset = set(args_final)
         truecount = 0
         for x in args:

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -477,8 +477,8 @@ class Xor(BooleanFunction):
     """
     def __new__(cls, *args, **options):
         args = [_sympify(arg) for arg in args]
-
         argset = set(args)
+        
         truecount = 0
         for x in args:
             if isinstance(x, Number) or x in [True, False]: # Includes 0, 1
@@ -487,6 +487,8 @@ class Xor(BooleanFunction):
                     truecount += 1
         if len(argset) < 1:
             return true if truecount % 2 != 0 else false
+	if len(argset) == 1:
+            return false
         if truecount % 2 != 0:
             return Not(Xor(*argset))
         _args = frozenset(argset)

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -65,6 +65,10 @@ def test_Xor():
 
     assert Xor() is false
     assert Xor(A) == A
+    assert Xor(A, A) is false
+    assert Xor(True, A, A) is true
+    assert Xor(A, A, A, A, A) == A
+    assert Xor(True, False, False, A, B) == And(Or(A, Not(B)), Or(B, Not(A)))
     assert Xor(True) is true
     assert Xor(False) is false
     assert Xor(True, True ) is false


### PR DESCRIPTION
considered the case when Xor(x,x) is called whatever x is.
inserted two lines in sympy/logic/boolalg.py
