### PR TITLE
Fixed issue 1160 with the mathematica module

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -11,8 +11,15 @@ def mathematica(s):
 def parse(s):
     s = s.strip()
 
+
     #Begin rules
     rules = (
+        (r"\A(\d+)([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",  # Arithmetic operation between a constant and a function
+        lambda m: m.group(1) + translateFunction(m.group(2)) + parse(m.group(3)) ),
+
+        (r"\A(\w+\[[^\]]+[^\[]*\])([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",  # Arithmetic operation between two functions
+        lambda m: parse(m.group(1)) + translateFunction(m.group(2)) + parse(m.group(3)) ),
+
         (r"\A(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
         lambda m: translateFunction(
             m.group(1)) + "(" + parse(m.group(2)) + ")" ),

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -62,3 +62,4 @@ def translateOperator(s):
     if s in dictionary:
         return dictionary[s]
     return s
+    

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -14,33 +14,56 @@ def parse(s):
 
     #Begin rules
     rules = (
-        (r"\A(\d+)([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",  # Arithmetic operation between a constant and a function
-        lambda m: m.group(1) + translateFunction(m.group(2)) + parse(m.group(3)) ),
 
-        (r"\A(\w+\[[^\]]+[^\[]*\])([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",  # Arithmetic operation between two functions
-        lambda m: parse(m.group(1)) + translateFunction(m.group(2)) + parse(m.group(3)) ),
+        # Arithmetic operation between a constant and a function
 
-        (r"\A(\w+)\[([^\]]+[^\[]*)\]\Z",  # Function call
+        (r"\A(\d+)([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",
+        lambda m: m.group(1) + translateFunction(
+                m.group(2)) + parse(m.group(3)) ),
+
+        # Arithmetic operation between two functions
+
+        (r"\A(\w+\[[^\]]+[^\[]*\])([*/+-^])(\w+\[[^\]]+[^\[]*\])\Z",
+        lambda m: parse(m.group(1)) + translateFunction(
+                m.group(2)) + parse(m.group(3)) ),
+
+        # Function call
+
+        (r"\A(\w+)\[([^\]]+[^\[]*)\]\Z",
         lambda m: translateFunction(
-            m.group(1)) + "(" + parse(m.group(2)) + ")" ),
+                m.group(1)) + "(" + parse(m.group(2)) + ")" ),
 
-        (r"\((.+)\)\((.+)\)",  # Parenthesized implied multiplication
-        lambda m: "(" + parse(m.group(1)) + ")*(" + parse(m.group(2)) + ")" ),
+        # Parenthesized implied multiplication
 
-        (r"\A\((.+)\)\Z",  # Parenthesized expression
+        (r"\((.+)\)\((.+)\)",
+        lambda m: "(" + parse(m.group(1)) + ")*(" + parse(
+                m.group(2)) + ")" ),
+
+         # Parenthesized expression
+
+        (r"\A\((.+)\)\Z",
         lambda m: "(" + parse(m.group(1)) + ")" ),
 
-        (r"\A(.*[\w\.])\((.+)\)\Z",  # Implied multiplication - a(b)
+        # Implied multiplication - a(b)
+
+        (r"\A(.*[\w\.])\((.+)\)\Z",
         lambda m: parse(m.group(1)) + "*(" + parse(m.group(2)) + ")" ),
 
-        (r"\A\((.+)\)([\w\.].*)\Z",  # Implied multiplication - (a)b
+        # Implied multiplication - (a)b
+
+        (r"\A\((.+)\)([\w\.].*)\Z",
         lambda m: "(" + parse(m.group(1)) + ")*" + parse(m.group(2)) ),
 
-        (r"\A([\d\.]+)([a-zA-Z].*)\Z",  # Implied multiplicatin - 2a
+        # Implied multiplicatin - 2a
+
+        (r"\A([\d\.]+)([a-zA-Z].*)\Z",
         lambda m: parse(m.group(1)) + "*" + parse(m.group(2)) ),
 
-        (r"\A([^=]+)([\^\-\*/\+=]=?)(.+)\Z",  # Infix operator
-        lambda m: parse(m.group(1)) + translateOperator(m.group(2)) + parse(m.group(3)) ))
+        # Infix operator
+
+        (r"\A([^=]+)([\^\-\*/\+=]=?)(.+)\Z",
+        lambda m: parse(m.group(1)) + translateOperator(
+                m.group(2)) + parse(m.group(3)) ) )
     #End rules
 
     for rule, action in rules:

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -1,4 +1,4 @@
-from sympy.parsing.mathematica import mathematica
+from mathematica import mathematica
 from sympy import sympify
 
 
@@ -14,6 +14,9 @@ def test_mathematica():
         'Exp[Log[4]]': 'exp(log(4))',
         '(x+1)(x+3)': '(x+1)*(x+3)',
         'Cos[Arccos[3.6]]': 'cos(acos(3.6))',
-        'Cos[x]==Sin[y]': 'cos(x)==sin(y)'}
+        'Cos[x]==Sin[y]': 'cos(x)==sin(y)',
+        '2*Sin[x+y]': '2*sin(x+y)',
+        'Sin[x]+Cos[y]': 'sin(x)+cos(y)',
+        'Sin[Cos[x]]': 'sin(cos(x))'}
     for e in d:
         assert mathematica(e) == sympify(d[e])

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -1,4 +1,4 @@
-from mathematica import mathematica
+from sympy.parsing.mathematica import mathematica
 from sympy import sympify
 
 

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -17,6 +17,7 @@ def test_mathematica():
         'Cos[x]==Sin[y]': 'cos(x)==sin(y)',
         '2*Sin[x+y]': '2*sin(x+y)',
         'Sin[x]+Cos[y]': 'sin(x)+cos(y)',
-        'Sin[Cos[x]]': 'sin(cos(x))'}
+        'Sin[Cos[x]]': 'sin(cos(x))',
+        '2*Sqrt[x+y]': '2*sqrt(x+y)'}   # Test case from the issue 1160
     for e in d:
         assert mathematica(e) == sympify(d[e])


### PR DESCRIPTION
Fixed the issue 1160 with the sympy.parsing.mathematica module where in the expressions of the type "2_Sin[x+y]" and "Sin[x+y]_Cos[x+y]" were not parsed properly and a TypeError was raised. The issue is fixed by adding the relevant rules to parse the previously unhandled expressions.
