### PR TITLE
Added Semantic Tableaux. Improved pl_true

### DIFF
--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -67,9 +67,16 @@ def satisfiable(expr, return_model=True, algorithm="dpll2"):
     """
     Check satisfiability of a propositional sentence.
 
-    return_model:   Return a model when if expression is satisfiable.
-                    Faster when set to False.
-    algorithm:      Select algorithm to use for SAT solving - dpll/dpll2
+
+    Parameters
+    ==========
+
+    return_model: boolean, optional, default: True
+        Returns a model if expression is satisfiable. If only (UN)SAT
+        is required, then set to False
+
+    algorithm: string {'dpll', 'dpll2'}, optional, default: 'dpll2'
+        Select algorithm to use for SAT solving
 
 
     Examples
@@ -85,7 +92,6 @@ def satisfiable(expr, return_model=True, algorithm="dpll2"):
     True
     >>> satisfiable(A & ~A, return_model=False)
     False
-    >>> 
     """
 
     if expr is True:
@@ -112,14 +118,21 @@ def satisfiable(expr, return_model=True, algorithm="dpll2"):
 
 def pl_true(expr, model={}, deep=False):
     """
-    Returns the value of the expression under the given model.
+    Returns whether the given assignment is a model or not.
 
-    If the model does not specify the value for every proposition,
+    If the assignment does not specify the value for every proposition,
     this may return None to indicate 'not obvious'.
 
-    model:  dict containing the symbol, boolean value pair.
-    deep:   gives the value of the expression under partial
-            interpretations correctly. May still return None.
+
+    Parameters
+    ==========
+
+    model: dict, optional, default: {}
+        Mapping of symbols to boolean values to indicate assignment.
+
+    deep: boolean, optional, default: False
+        Gives the value of the expression under partial assignments
+        correctly. May still return None to indicate 'not obvious'.
 
 
     Examples

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -66,7 +66,11 @@ def literal_symbol(literal):
 def satisfiable(expr, return_model=True, algorithm="dpll2"):
     """
     Check satisfiability of a propositional sentence.
-    Returns a model when it succeeds
+
+    return_model:   Return a model when if expression is satisfiable.
+                    Faster when set to False.
+    algorithm:      Select algorithm to use for SAT solving - dpll/dpll2
+
 
     Examples
     ========
@@ -77,6 +81,11 @@ def satisfiable(expr, return_model=True, algorithm="dpll2"):
     {A: True, B: False}
     >>> satisfiable(A & ~A)
     False
+    >>> satisfiable(A & ~B, return_model=False)
+    True
+    >>> satisfiable(A & ~A, return_model=False)
+    False
+    >>> 
     """
 
     if expr is True:
@@ -92,22 +101,26 @@ def satisfiable(expr, return_model=True, algorithm="dpll2"):
         elif algorithm == "dpll2":
             from sympy.logic.algorithms.dpll2 import dpll_satisfiable
             return dpll_satisfiable(expr)
-        raise NotImplementedError
+        raise ValueError("'algorithm' must be one of 'dpll', 'dpll2'")
 
     elif return_model is False:
         return semantic_tableaux(expr)
 
     else:
-        raise ValueError("return_model must contain a boolean value")
+        raise ValueError("'return_model' must contain a boolean value")
 
 
 def pl_true(expr, model={}, deep=False):
     """
-    Return True if the propositional logic expression is true in the model,
-    and False if it is false. If the model does not specify the value for
-    every proposition, this may return None to indicate 'not obvious'
+    Returns the value of the expression under the given model.
 
-    The model is implemented as a dict containing the pair symbol, boolean value.
+    If the model does not specify the value for every proposition,
+    this may return None to indicate 'not obvious'.
+
+    model:  dict containing the symbol, boolean value pair.
+    deep:   gives the value of the expression under partial
+            interpretations correctly. May still return None.
+
 
     Examples
     ========
@@ -217,9 +230,10 @@ def _pl_interpretation(expr, atoms, i={}):
 
 def semantic_tableaux(expr):
     """
-    Checks satisfiability of a formula using a Semantic Tableaux
-    This method is much faster than a traditional SAT solver however
-    it returns only True or False. To obtain a model use 'satisfiable'
+    Checks satisfiability of a formula using a Semantic Tableaux.
+
+    This method is much faster than a traditional SAT solver, however,
+    it returns only True or False. To obtain a model use 'satisfiable'.
 
     Examples
     ========

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -3,7 +3,7 @@
 from sympy import symbols, Q
 from sympy.logic.boolalg import Or, Equivalent, Implies, And
 from sympy.logic.inference import is_literal, literal_symbol, \
-     pl_true, satisfiable, PropKB
+     pl_true, satisfiable, semantic_tableaux, PropKB
 from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
     find_pure_symbol, find_unit_clause, unit_propagate, \
     find_pure_symbol_int_repr, find_unit_clause_int_repr, \
@@ -143,8 +143,29 @@ def test_pl_true():
 def test_pl_true_wrong_input():
     from sympy import pi
     raises(ValueError, lambda: pl_true('John Cleese'))
-    raises(ValueError, lambda: pl_true(42 + pi + pi ** 2))
-    raises(ValueError, lambda: pl_true(42))
+    raises(TypeError, lambda: pl_true(42 + pi + pi ** 2))
+    raises(TypeError, lambda: pl_true(42))
+
+
+def test_pl_true_deep():
+    from sympy.abc import A, B, C
+    assert pl_true(A | B, {A: False}, deep=True) is None
+    assert pl_true(~A & ~B, {A: False}, deep=True) is None
+    assert pl_true(A | B, {A: False, B: False}, deep=True) is False
+    assert pl_true(A & B & (~A | ~B), {A: True}, deep=True) is False
+    assert pl_true((C >> A) >> (B >> A), {C: True}, deep=True) is True
+
+
+def test_semantic_tableaux():
+    from sympy import pi
+    from sympy.abc import A, B
+    assert semantic_tableaux(A & B) is True
+    assert semantic_tableaux(A >> (B >> A)) is True
+    assert semantic_tableaux(Equivalent(A, B)) is True
+    assert semantic_tableaux(Implies(False, True)) is True
+    assert semantic_tableaux(A & ~A) is False
+    assert semantic_tableaux(Implies(True, False)) is False
+    raises(TypeError, lambda: semantic_tableaux(pi**2))
 
 
 def test_PropKB():

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -158,7 +158,7 @@ def test_pl_true_deep():
 
 def test_semantic_tableaux():
     from sympy import pi
-    from sympy.abc import A, B
+    from sympy.abc import A, B, C
     assert semantic_tableaux(A & B) is True
     assert semantic_tableaux(A >> (B >> A)) is True
     assert semantic_tableaux(Equivalent(A, B)) is True
@@ -166,6 +166,17 @@ def test_semantic_tableaux():
     assert semantic_tableaux(A & ~A) is False
     assert semantic_tableaux(Implies(True, False)) is False
     raises(TypeError, lambda: semantic_tableaux(pi**2))
+
+    formulas = {
+        A & C & (B >> A) & (B >> (A & C & (~A | ~C))): True,
+        (~A | ~B | (A & B) | (A & B & ~C) | (~A >> (~A | ~B))): True,
+        (A | C & (B >> ~A) | (C & ~(C >> A)) & (B & ~(C >> ~A))): True,
+        (B | C | ~(A >> B)) & (~A & ~C & ~B) & ~((B | A) >> B): False,
+        (C & ~B & ((A | C) >> A) & ((~C >> A) >> (B & (A | C)))): False,
+        (A & ~B & ~C & (B | C | (~A & B)) & (A >> (A & (B | C)))): False
+    }
+    for expr, sat in formulas.items():
+        assert semantic_tableaux(expr) is sat
 
 
 def test_PropKB():
@@ -218,6 +229,8 @@ def test_satisfiable_non_symbols():
     assert satisfiable(And(assumptions, facts, ~query), algorithm='dpll') in refutations
     assert not satisfiable(And(assumptions, facts, query), algorithm='dpll2')
     assert satisfiable(And(assumptions, facts, ~query), algorithm='dpll2') in refutations
+    assert not satisfiable(And(assumptions, facts, query), return_model=False)
+    assert satisfiable(And(assumptions, facts, ~query), return_model=False)
 
 def test_satisfiable_bool():
     assert satisfiable(True) == {}

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -112,6 +112,8 @@ def test_dpll_satisfiable():
 def test_satisfiable():
     A, B, C = symbols('A,B,C')
     assert satisfiable(A & (A >> B) & ~B) is False
+    raises (ValueError, lambda: satisfiable(A | B, algorithm='cdcl'))
+    raises (ValueError, lambda: satisfiable(A & B, return_model="True"))
 
 
 def test_pl_true():


### PR DESCRIPTION
1. Added satisfiability checking using a Semantic Tableaux. Semantic tableaux removes the overhead of converting a formula to CNF (or DNF) and is faster than a SAT solver. However, it can only return True or False to indicate satisfiability, and not the model.
2. Modified pl_true to give the correct result under incomplete interpretations. Previously something like <code>pl_true(a >> (b >> a))</code> would return None. This function now accurately returns whether the value is obvious (True/False) or not (None).
