### PR TITLE
Fix #5072: hash(Integer) should return the int

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -2,8 +2,8 @@ from __future__ import print_function, division
 
 from collections import defaultdict
 
-from sympy.core.core import C
-from sympy.core.compatibility import reduce, is_sequence
+from sympy.core.basic import C, Basic
+from sympy.core.compatibility import cmp_to_key, reduce, is_sequence
 from sympy.core.singleton import S
 from sympy.core.operations import AssocOp
 from sympy.core.cache import cacheit
@@ -11,13 +11,11 @@ from sympy.core.numbers import ilcm, igcd
 from sympy.core.expr import Expr
 
 
+# Key for sorting commutative args in canonical order
+_args_sortkey = cmp_to_key(Basic.compare)
 def _addsort(args):
     # in-place sorting of args
-
-    # Currently we sort things using hashes, as it is quite fast. A better
-    # solution is not to sort things at all - but this needs some more
-    # fixing.
-    args.sort(key=hash)
+    args.sort(key=_args_sortkey)
 
 
 def _unevaluated_Add(*args):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1710,7 +1710,7 @@ class Integer(Rational):
         return Rational.__le__(self, other)
 
     def __hash__(self):
-        return super(Integer, self).__hash__()
+        return hash(self.p)
 
     def __index__(self):
         return self.p

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1173,7 +1173,7 @@ def test_as_powers_dict():
 def test_as_coefficients_dict():
     check = [S(1), x, y, x*y, 1]
     assert [Add(3*x, 2*x, y, 3).as_coefficients_dict()[i] for i in check] == \
-        [3, 5, 1, 0, 0]
+        [3, 5, 1, 0, 3]
     assert [(3*x*y).as_coefficients_dict()[i] for i in check] == \
         [0, 0, 0, 3, 0]
     assert (3.0*x*y).as_coefficients_dict()[3.0*x*y] == 1

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -21,19 +21,16 @@ def test_integers_cache():
 
     assert python_int in _intcache
     assert hash(python_int) not in _intcache
-    assert sympy_int not in _intcache
 
     sympy_int_int = Integer(sympy_int)
 
     assert python_int in _intcache
     assert hash(python_int) not in _intcache
-    assert sympy_int_int not in _intcache
 
     sympy_hash_int = Integer(hash(python_int))
 
     assert python_int in _intcache
     assert hash(python_int) in _intcache
-    assert sympy_hash_int not in _intcache
 
 
 def test_seterr():
@@ -1328,12 +1325,10 @@ def test_as_content_primitive():
     assert S(3.1).as_content_primitive() == (1, 3.1)
 
 
-@XFAIL
 def test_hashing_sympy_integers():
     # Test for issue 5072
-    # https://github.com/sympy/sympy/issues/5072
-    assert hash(S(4)) == 4
-    assert hash(S(4)) == hash(int(4))
+    assert set([Integer(3)]) == set([int(3)])
+    assert hash(Integer(4)) == hash(int(4))
 
 
 def test_issue_4172():


### PR DESCRIPTION
fix #5072

@smichr, please take look on changes in add.py.  _addsort and _mulsort were introduced by 8942676.  Why cmp_to_key(Basic.compare) wasn't used as a key in both places?
