### PR TITLE
Issue #2850 solved. Integration doesn't halt now.

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -336,14 +336,14 @@ def _parts_rule(integrand, symbol):
 
         return pull_out_u_rl
 
-    liate_rules = [pull_out_u(sympy.log), pull_out_u(sympy.atan),
+    liate_rules = [pull_out_u(sympy.log), pull_out_u(sympy.atan, sympy.asin, sympy.acos),
                    pull_out_polys, pull_out_u(sympy.sin, sympy.cos),
                    pull_out_u(sympy.exp)]
 
 
     dummy = sympy.Dummy("temporary")
     # we can integrate log(x) and atan(x) by setting dv = 1
-    if isinstance(integrand, sympy.log) or isinstance(integrand, sympy.atan):
+    if isinstance(integrand, sympy.log) or isinstance(integrand, sympy.atan) or isinstance(integrand, sympy.asin) or isinstance(integrand, sympy.acos):
         integrand = dummy * integrand
 
     for index, rule in enumerate(liate_rules):
@@ -766,7 +766,7 @@ def integral_steps(integrand, symbol, **options):
             return sympy.Number
         else:
             for cls in (sympy.Pow, sympy.Symbol, sympy.exp, sympy.log,
-                        sympy.Add, sympy.Mul, sympy.atan):
+                        sympy.Add, sympy.Mul, sympy.atan, sympy.asin, sympy.acos):
                 if isinstance(integrand, cls):
                     return cls
 
@@ -791,7 +791,7 @@ def integral_steps(integrand, symbol, **options):
             alternatives(
                 substitution_rule,
                 condition(
-                    integral_is_subclass(sympy.Mul, sympy.log, sympy.atan),
+                    integral_is_subclass(sympy.Mul, sympy.log, sympy.atan, sympy.asin, sympy.acos),
                     parts_rule),
                 condition(
                     integral_is_subclass(sympy.Mul, sympy.Pow),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -343,7 +343,7 @@ def _parts_rule(integrand, symbol):
 
     dummy = sympy.Dummy("temporary")
     # we can integrate log(x) and atan(x) by setting dv = 1
-    if isinstance(integrand, sympy.log) or isinstance(integrand, sympy.atan) or isinstance(integrand, sympy.asin) or isinstance(integrand, sympy.acos):
+    if isinstance(integrand, (sympy.log, sympy.atan, sympy.asin, sympy.acos)):
         integrand = dummy * integrand
 
     for index, rule in enumerate(liate_rules):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,4 +1,4 @@
-from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan,
+from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Mul, Integral, integrate, pi, Dummy,
                    Derivative, diff, I, sqrt, erf, Piecewise,
                    Eq, Ne, Q, assuming, symbols, And)
@@ -149,3 +149,11 @@ def test_issue_3647():
     with assuming(Q.negative(a)):
         assert manualintegrate(1 / (a + b*x**2), x) == \
             Integral(1/(a + b*x**2), x)
+
+def test_issue_2850():
+    assert manualintegrate(asin(x)*log(x), x) == -x*asin(x) - sqrt(-x**2 + 1) \
+            + (x*asin(x) + sqrt(-x**2 + 1))*log(x) - Integral(sqrt(-x**2 + 1)/x, x)
+    assert manualintegrate(acos(x)*log(x), x) == -x*acos(x) + sqrt(-x**2 + 1) + \
+        (x*acos(x) - sqrt(-x**2 + 1))*log(x) + Integral(sqrt(-x**2 + 1)/x, x)
+    assert manualintegrate(atan(x)*log(x), x) == -x*atan(x) + (x*atan(x) - \
+            log(x**2 + 1)/2)*log(x) + log(x**2 + 1)/2 + Integral(log(x**2 + 1)/x, x)/2

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -150,7 +150,7 @@ def test_issue_3647():
         assert manualintegrate(1 / (a + b*x**2), x) == \
             Integral(1/(a + b*x**2), x)
 
-def test_issue_2850():
+def test_gh_issue_2850():
     assert manualintegrate(asin(x)*log(x), x) == -x*asin(x) - sqrt(-x**2 + 1) \
             + (x*asin(x) + sqrt(-x**2 + 1))*log(x) - Integral(sqrt(-x**2 + 1)/x, x)
     assert manualintegrate(acos(x)*log(x), x) == -x*acos(x) + sqrt(-x**2 + 1) + \


### PR DESCRIPTION
In issue #2850 it was mentioned that `integrate(asin(x)*log(x), x)`  does not give any answer. It just give `Integral(log(x)*asin(x), x)` which is probably wrong. The reason was `asin and acos` was not implemented in `manualintegrate.py`. It is now done.
