### PR TITLE
Modified Mod so multiples of integers mod 1 are also 0

### DIFF
--- a/sympy/core/mod.py
+++ b/sympy/core/mod.py
@@ -35,7 +35,9 @@ class Mod(Function):
             to be less than q.
             """
 
-            if p == q or p == -q or p.is_Pow and p.exp.is_Integer and p.base == q:
+            if (p == q or p == -q or
+                    p.is_Pow and p.exp.is_Integer and p.base == q or
+                    p.is_integer and q == 1):
                 return S.Zero
 
             if p.is_Number and q.is_Number:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1422,6 +1422,7 @@ def test_Mod():
     assert Mod(5.0*x, 0.1*y) == 0.1*Mod(50*x, y)
     i = Symbol('i', integer=True)
     assert (3*i*x) % (2*i*y) == i*Mod(3*x, 2*y)
+    assert Mod(4*i, 4) == 0
 
 
 def test_issue_2902():

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -79,6 +79,17 @@ from sympy.simplify import powdenest, simplify, polarify, unpolarify
 from sympy.polys import poly, Poly
 from sympy.series import residue
 
+# function to define "buckets"
+def _mod1(x):
+    # although it would be nice to make this just Mod(x, 1)
+    # lots of tests break now because Mod(i + 1, 1) -> 0 instead
+    # of giving Mod(i, 1)
+    if x.is_Number:
+        return Mod(x, 1)
+    c, x = x.as_coeff_Add()
+    return Mod(c, 1) + x
+
+
 # leave add formulae at the top for easy reference
 def add_formulae(formulae):
     """ Create our knowledge base. """
@@ -386,10 +397,10 @@ def add_meijerg_formulae(formulae):
         x = func.an[0]
         y, z = func.bm
         swapped = False
-        if not Mod((x - y).simplify(), 1):
+        if not _mod1((x - y).simplify()):
             swapped = True
             (y, z) = (z, y)
-        if Mod((x - z).simplify(), 1) or x > z:
+        if _mod1((x - z).simplify()) or x > z:
             return None
         l = [y, x]
         if swapped:
@@ -407,22 +418,22 @@ def add_meijerg_formulae(formulae):
         """http://functions.wolfram.com/07.34.03.0984.01"""
         x = func.an[0]
         u, v, w = func.bm
-        if Mod((u - v).simplify(), 1) == 0:
-            if Mod((v - w).simplify(), 1) == 0:
+        if _mod1((u - v).simplify()) == 0:
+            if _mod1((v - w).simplify()) == 0:
                 return
             sig = (S(1)/2, S(1)/2, S(0))
             x1, x2, y = u, v, w
         else:
-            if Mod((x - u).simplify(), 1) == 0:
+            if _mod1((x - u).simplify()) == 0:
                 sig = (S(1)/2, S(0), S(1)/2)
                 x1, y, x2 = u, v, w
             else:
                 sig = (S(0), S(1)/2, S(1)/2)
                 y, x1, x2 = u, v, w
 
-        if (Mod((x - x1).simplify(), 1) != 0 or
-            Mod((x - x2).simplify(), 1) != 0 or
-            Mod((x - y).simplify(), 1) != S(1)/2 or
+        if (_mod1((x - x1).simplify()) != 0 or
+            _mod1((x - x2).simplify()) != 0 or
+            _mod1((x - y).simplify()) != S(1)/2 or
                 x > x1 or x > x2):
             return
 
@@ -459,7 +470,6 @@ def debug(*args):
             print(a, end="")
         print()
 
-_mod1 = lambda x: Mod(x, 1)
 
 class Hyper_Function(Expr):
     """ A generalized hypergeometric function. """
@@ -617,17 +627,18 @@ class G_Function(Expr):
 
         >>> from sympy.simplify.hyperexpand import G_Function
         >>> from sympy.abc import y
-        >>> from sympy import S
+        >>> from sympy import S, symbols
+
         >>> a, b = [1, 3, 2, S(3)/2], [1 + y, y, 2, y + 3]
         >>> G_Function(a, b, [2], [y]).compute_buckets()
         ({0: [3, 2, 1], 1/2: [3/2]},
-        {0: [2], Mod(y, 1): [y, y + 1, y + 3]}, {0: [2]}, {Mod(y, 1): [y]})
+        {0: [2], y: [y, y + 1, y + 3]}, {0: [2]}, {y: [y]})
 
         """
         dicts = pan, pap, pbm, pbq = [defaultdict(list) for i in range(4)]
         for dic, lis in zip(dicts, (self.an, self.ap, self.bm, self.bq)):
             for x in lis:
-                dic[Mod(x, 1)].append(x)
+                dic[_mod1(x)].append(x)
 
         for dic, flip in zip(dicts, (True, False, False, True)):
             for m, items in dic.items():


### PR DESCRIPTION
hyperexpand used Mod(foo, 1) to (apparently) reduce the constant part of an expression to the smallest value. But with Mod(int, 1) now being 0 this lead to cases where 3 and k + 2 (where k was an integer) both being grouped as being the same mod 1 rather than being grouped as 0 and Mod(k, 1). This lead to problems in sorting the mixed grouped numbers, e.g. sorted([0, k]) raises an error. I am not confident enough about modifying the sorting and handling of the numbers (e.g. by sorting with Basic.compare); instead, I modified the `_mod1` calls to give, effectively, the same thing that was being done before.
