### PR TITLE
add new Min-replacement pattern to compute_cdf

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -307,14 +307,14 @@ class MinMaxBase(Expr, LatticeOp):
         # variant II: find local zeros
         args = cls._find_localzeros(set(_args), **assumptions)
 
-        _args = frozenset(args)
-
-        if not _args:
+        if not args:
             return cls.identity
-        elif len(_args) == 1:
-            return set(_args).pop()
+        elif len(args) == 1:
+            return args.pop()
         else:
             # base creation
+            # XXX should _args be made canonical with sorting?
+            _args = frozenset(args)
             obj = Expr.__new__(cls, _args, **assumptions)
             obj._argset = _args
             return obj

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -2155,7 +2155,8 @@ class UniformDistribution(SingleContinuousDistribution):
         z = Dummy('z', real=True, bounded=True)
         result = SingleContinuousDistribution.compute_cdf(self, **kwargs)
         result = result(z).subs({Min(z, self.right): z,
-                                 Min(z, self.left, self.right): self.left})
+                                 Min(z, self.left, self.right): self.left,
+                                 Min(z, self.left): self.left})
         return Lambda(z, result)
 
     def expectation(self, expr, var, **kwargs):


### PR DESCRIPTION
If you don't do this you might get alternate results

https://travis-ci.org/smichr/sympy/jobs/19850479 shows the failure in
a run where 3 of the 4 python versions passed but one failed.

I have not seen this very often; I don't know why it happened in the failing case; maybe because sometimes the 3-arg Min reduces to the 2-arg case?
