### PR TITLE
Added support for kwarg "use_array" in lambdify (fixes  #2931)

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -145,7 +145,8 @@ def _import(module, reload="False"):
 
 
 @doctest_depends_on(modules=('numpy'))
-def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True, use_array=False):
+def lambdify(args, expr, modules=None, printer=None, use_imps=True,
+        dummify=True, use_array=False):
     """
     Returns a lambda function for fast calculation of numerical values.
 
@@ -168,7 +169,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True
     should probably set dummify=False.
 
     If numpy is installed, the default behavior is to substitute Sympy Matrices
-    for numpy.matrix. If you would rather have a numpy.array returned,
+    with numpy.matrix. If you would rather have a numpy.array returned,
     set use_array=True.
 
     Usage

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -168,7 +168,7 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True
     should probably set dummify=False.
 
     If numpy is installed, the default behavior is to substitute Sympy Matrices
-    for numpy.matrix. If you would rather have a numpy.array returned, 
+    for numpy.matrix. If you would rather have a numpy.array returned,
     set use_array=True.
 
     Usage

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -145,7 +145,7 @@ def _import(module, reload="False"):
 
 
 @doctest_depends_on(modules=('numpy'))
-def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True):
+def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True, use_array=False):
     """
     Returns a lambda function for fast calculation of numerical values.
 
@@ -166,6 +166,10 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True
     dummy substitution is unwanted (and `args` is not a string). If you want
     to view the lambdified function or provide "sympy" as the module, you
     should probably set dummify=False.
+
+    If numpy is installed, the default behavior is to substitute Sympy Matrices
+    for numpy.matrix. If you would rather have a numpy.array returned, 
+    set use_array=True.
 
     Usage
     =====
@@ -230,6 +234,10 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True
     >>> row = lambdify((x, y), Matrix((x, x + y)).T, modules='sympy')
     >>> row(1, 2)
     Matrix([[1, 3]])
+    >>> col = lambdify((x, y), Matrix((x, x + y)), use_array=True)
+    >>> col(1, 2)
+    array([[1],
+           [3]])
 
     Tuple arguments are handled and the lambdified function should
     be called with the same type of arguments as were used to create
@@ -274,6 +282,18 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True, dummify=True
         #      might be the reason for irreproducible errors.
         modules = ["math", "mpmath", "sympy"]
 
+        #If numpy.array should be used instead of numpy.matrix
+        if use_array:
+            NUMPY_TRANSLATIONS.update({"Matrix": "array",
+                "MutableDenseMatrix": "array",
+                "ImmutableMatrix": "array"})
+        else:
+            #Ensures that the translation dict is set back
+            #to matrix if lambdify was already called
+            NUMPY_TRANSLATIONS.update({"Matrix": "matrix",
+                "MutableDenseMatrix": "matrix",
+                "ImmutableMatrix": "matrix"})
+        #Attempt to import numpy
         try:
             _import("numpy")
         except ImportError:

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -266,10 +266,10 @@ def test_numpy_matrix():
     sol_mat = numpy.matrix([[1, 2], [numpy.sin(3) + 4, 1]])
     sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
     #Lambdify array first, to ensure return to matrix as default
-    f_arr = lambdify((x, y, z), A, use_array=True)
-    f_mat = lambdify((x, y, z), A)
-    numpy.testing.assert_allclose(f_mat(1, 2, 3), sol_mat)
-    numpy.testing.assert_allclose(f_arr(1, 2, 3), sol_arr)
+    f_arr = lambdify((x, y, z), A, use_array=True)(1, 2, 3)
+    f_mat = lambdify((x, y, z), A)(1, 2, 3)
+    numpy.testing.assert_allclose(f_mat, sol_mat)
+    numpy.testing.assert_allclose(f_arr, sol_arr)
     #Check that the types are arrays and matrices
     assert isinstance(f_mat, numpy.matrix)
     assert isinstance(f_arr, numpy.ndarray)

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -268,8 +268,8 @@ def test_numpy_matrix():
     #Lambdify array first, to ensure return to matrix as default
     f_arr = lambdify((x, y, z), A, use_array=True)
     f_mat = lambdify((x, y, z), A)
-    assert numpy.all(f_mat(1, 2, 3) == sol_mat)
-    assert numpy.all(f_arr(1, 2, 3) == sol_arr)
+    numpy.testing.assert_allclose(f_mat(1, 2, 3), sol_mat)
+    numpy.testing.assert_allclose(f_arr(1, 2, 3), sol_arr)
 
 def test_integral():
     f = Lambda(x, exp(-x**2))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -270,6 +270,9 @@ def test_numpy_matrix():
     f_mat = lambdify((x, y, z), A)
     numpy.testing.assert_allclose(f_mat(1, 2, 3), sol_mat)
     numpy.testing.assert_allclose(f_arr(1, 2, 3), sol_arr)
+    #Check that the types are arrays and matrices
+    assert isinstance(f_mat, numpy.matrix)
+    assert isinstance(f_arr, numpy.ndarray)
 
 def test_integral():
     f = Lambda(x, exp(-x**2))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -259,6 +259,17 @@ def test_matrix():
     assert lambdify(v, J, modules='sympy')(1, 2) == sol
     assert lambdify(v.T, J, modules='sympy')(1, 2) == sol
 
+def test_numpy_matrix():
+    if not numpy:
+        skip("numpy not installed.")
+    A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
+    sol_mat = numpy.matrix([[1, 2], [numpy.sin(3) + 4, 1]])
+    sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
+    #Lambdify array first, to ensure return to matrix as default
+    f_arr = lambdify((x, y, z), A, use_array=True)
+    f_mat = lambdify((x, y, z), A)
+    assert numpy.all(f_mat(1, 2, 3) == sol_mat)
+    assert numpy.all(f_arr(1, 2, 3) == sol_arr)
 
 def test_integral():
     f = Lambda(x, exp(-x**2))


### PR DESCRIPTION
Added kwarg in lambdify to support return of numpy array instead of matrix in a more user friendly way. Fixes  #2931.
