### PR TITLE
Limits: limit of order term should raise error

### DIFF
--- a/sympy/series/gruntz.py
+++ b/sympy/series/gruntz.py
@@ -408,6 +408,8 @@ def limitinf(e, x):
 
     if not e.has(x):
         return e  # e is a constant
+    if e.is_Order:
+        raise ValueError("Cannot find limit of %s" % e)
     if e.has(Order):
         e = e.expand().removeO()
     if not x.is_positive:

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -72,9 +72,6 @@ def limit(e, z, z0, dir="+"):
                 return limit(inve.as_leading_term(u), u,
                     S.Zero, "+" if z0 is S.Infinity else "-")
 
-    if e.is_Order:
-        return C.Order(limit(e.expr, z, z0), *e.args[1:])
-
     try:
         r = gruntz(e, z, z0, dir)
         if r is S.NaN:

--- a/sympy/series/tests/test_gruntz.py
+++ b/sympy/series/tests/test_gruntz.py
@@ -3,7 +3,8 @@ from sympy import Symbol, exp, log, oo, Rational, I, sin, gamma, loggamma, S, \
 from sympy.functions.elementary.hyperbolic import cosh, coth, sinh, tanh
 from sympy.series.gruntz import compare, mrv, rewrite, mrv_leadterm, gruntz, \
     sign
-from sympy.utilities.pytest import XFAIL, skip
+from sympy.series.order import Order
+from sympy.utilities.pytest import XFAIL, skip, raises
 
 """
 This test suite is testing the limit algorithm using the bottom up approach.
@@ -464,3 +465,7 @@ def test_issue_3583():
 def test_issue_3997():
     from sympy.functions import sign
     assert gruntz(x**-pi, x, 0, dir='-') == oo*sign((-1)**(-pi))
+
+
+def test_gh_issue_2865():
+    raises(ValueError, lambda: gruntz(Order(1/x, (x, oo)), x, 0))

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -2,7 +2,7 @@ from itertools import product as cartes
 
 from sympy import (limit, exp, oo, log, sqrt, Limit, sin, floor, cos, ceiling,
                    atan, gamma, Symbol, S, pi, Integral, cot, Rational, I, zoo,
-                   tan, cot, integrate, Sum, sign)
+                   tan, cot, integrate, Sum, sign, PoleError)
 
 from sympy.series.limits import heuristics
 from sympy.series.order import Order
@@ -35,10 +35,9 @@ def test_basic1():
     raises(NotImplementedError, lambda: limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo))
     assert limit(gamma(1/x + 3), x, oo) == 2
     assert limit(S.NaN, x, -oo) == S.NaN
-    assert limit(Order(2)*x, x, S.NaN) == S.NaN
+    raises(PoleError, lambda: limit(Order(2)*x, x, S.NaN))
     assert limit(gamma(1/x + 3), x, oo) == 2
     assert limit(S.NaN, x, -oo) == S.NaN
-    assert limit(Order(2)*x, x, S.NaN) == S.NaN
     assert limit(1/(x - 1), x, 1, dir="+") == oo
     assert limit(1/(x - 1), x, 1, dir="-") == -oo
     assert limit(1/(5 - x)**3, x, 5, dir="+") == -oo
@@ -417,3 +416,7 @@ def test_issue_3265():
     a = Symbol('a')
     e = z/(1 - sqrt(1 + z)*sin(a)**2 - sqrt(1 - z)*cos(a)**2)
     assert limit(e, z, 0).simplify() == 2/cos(2*a)
+
+
+def test_gh_issue_2865():
+    raises(PoleError, lambda: limit(Order(1/x, (x, oo)), x, 0))


### PR DESCRIPTION
See https://github.com/sympy/sympy/issues/2865

A few doubts:-
1) I'm not sure what type of error should be given. Now I give a ValueError. Tell me if some other error is to be given and if error message is to be changed.
2) Output for `limit(Order(2)*x, x, S.NaN)` was `S.NaN`, now it gives error. Is that correct?
