### PR TITLE
give Dummy a sort key

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -178,6 +178,11 @@ class Dummy(Symbol):
     def __getstate__(self):
         return {'_assumptions': self._assumptions, 'dummy_index': self.dummy_index}
 
+    @cacheit
+    def sort_key(self, order=None):
+        return self.class_key(), (
+            2, (str(self), self._count)), S.One.sort_key(), S.One
+
     def _hashable_content(self):
         return Symbol._hashable_content(self) + (self.dummy_index,)
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1315,6 +1315,9 @@ def test_expr_sorting():
     exprs = [set([1]), set([1, 2])]
     assert sorted(exprs, key=default_sort_key) == exprs
 
+    a, b = exprs = [Dummy(), Dummy()]
+    assert sorted([b, a], key=default_sort_key) == exprs
+
 
 def test_as_ordered_factors():
     f, g = symbols('f,g', cls=Function)


### PR DESCRIPTION
In order to sort dummies canonically, the index has to be added to the sort key, otherwise dummies with the same name are not ordered uniquely.
