### PR TITLE
degree: Improving speed of polynomial's degree()

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4278,7 +4278,11 @@ def degree(f, *gens, **args):
                 return max(order, f.args[1].coeff(func))
             return order * f.args[1]
         else:
-            return max(degree(arg, func) for arg in f.args)
+            try:
+                F, opt = poly_from_expr(f, *gens, **args)
+            except PolificationFailed as exc:
+                raise ComputationFailed('degree', 1, exc)
+            return sympify(F.degree(opt.gen))
     else:
         return S.Zero
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4251,6 +4251,7 @@ def degree(f, *gens, **args):
         return S.Zero
     elif isinstance(f, Poly):
         func = f.gens[0]
+        f = f.args[0]
     else:
         func = f.atoms(Symbol).pop()
 
@@ -4279,8 +4280,8 @@ def _degree(f, func):
         # if f is a power function
         if isinstance(f, Pow):
             order = S.One
+            temp_r = 1
             if f.args[0].has(func):
-                temp_r = 1
                 order1 = 0
                 for arg in f.args:
                     order2, r = _degree(arg, func)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4321,6 +4321,8 @@ def _degree(f, func):
                             arg = arg.args[1]
                         if isinstance(arg.args[1], Pow) and isinstance(arg.args[1].args[0], Add): # in (2*(x+1)**3-2*(x-1)**3)
                             arg = arg.args[1]
+                        elif isinstance(arg, Pow) and arg.args[1].has(func): # in (3**x-2**x) form
+                            return abs(order1), abs(r)
                         else: # in ((x+1)**3-x**3) form
                             deg1, r = _degree(temp_arg.args[0].args[0], func)
                             deg2, r = _degree(temp_arg.args[0].args[1], func)
@@ -4333,6 +4335,8 @@ def _degree(f, func):
                             arg = temp_arg.args[1]
                         if isinstance(temp_arg.args[1], Pow) and isinstance(temp_arg.args[1].args[0], Add):
                             arg = temp_arg.args[1]
+                        elif isinstance(arg, Pow) and arg.args[1].has(func):
+                            return abs(order1), abs(r)
                         else:
                             deg1, r = _degree(arg.args[0].args[0], func)
                             deg2, r = _degree(arg.args[0].args[1], func)

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4229,6 +4229,18 @@ def degree(f, *gens, **args):
     >>> degree(0, x)
     -oo
 
+    Enhancement
+    ===========
+
+    The degree is calculated by traversing through the
+    argument list recursively and hence improve the speed
+    of operation for higher exponents of functions.
+
+    >>> degree((x+1)**10000)
+    10000
+    >>> degree(((x**2+y**3+4)**11111+1)**3, y)
+    99999
+
     """
     options.allowed_flags(args, ['gen', 'polys'])
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -1164,6 +1164,39 @@ def test_Poly_degree():
     assert degree(x*y**2, x, y) == 1
     assert degree(x*y**2, y, x) == 2
 
+    assert degree((x+1)**100000) == 100000
+    assert degree((x**3+1)**33333) == 99999
+
+    assert degree(Poly(y**2 - x, y, domain='ZZ[x]')) == 2
+
+    assert degree((x+1)**3-(x-1)**3) == 2
+    assert degree((x+1)**5-(x-1)**5) == 4
+    assert degree((x+1)**5-(-x-1)**5) == 5
+
+    assert degree((x+1)**30000-(x-1)**30000) == 29999
+    assert degree((x**100+1)**30000-(x**100-1)**30000) == 2999900
+    assert degree((x**100+x**2)**5-(x**100-x**2)**5) == 402
+
+    assert degree((x**100+x**2)**5-(2*x**100-x**2)**5) == 500
+    assert degree((x**100+1)**5-(x**100-1)**5) == 400
+    assert degree((x**100+x)**5-2*(x**100-x)**5) == 500
+    assert degree(2*(x**100+x**2)**5-2*(x**100-x**2)**5) == 402
+    assert degree(2**5*(x**100+x**2)**5-(2*x**100-x**2)**5) == 402
+
+    assert degree((2*x+1)**10-(2*x-1)**10) == 9
+    assert degree((2*x+1)**10-(x-1)**10) == 10
+    assert degree((x+1)**5-(x-1)**5) == 4
+    assert degree((x+1)**5-(2*x-1)**5) == 5
+    assert degree((2*x**10+1)**5-(2*x-1)**5) == 50
+    assert degree((2*x**10+1)**5-(2*x**10-1)**5) == 40
+
+    assert degree((x+1)**5-(x)**5) == 4
+    assert degree((2*x+1)**5-(2*x)**5) == 4
+    assert degree((2*x+1)**5-(x)**5) == 5
+    assert degree((2*x**10+1)**5-(2*x**10)**5) == 40
+    assert degree((2*x**10+1)**5-(x**10)**5) == 50
+    assert degree((2*x**10+1)**5-2*(x**10)**5) == 50
+
     raises(ComputationFailed, lambda: degree(1))
 
 


### PR DESCRIPTION
When calculating degree of functions like (x+1)**10000, it takes a considerable amount of time. Its because the process should first expand the function. But this can be brought into a much faster calculation in which it uses the the iterative traversal through it's arguments. 

Example:

```
>>> degree(((x+1)**3-(x-1)**3)**10000)
20000
>>> eq = (4*(x+2)**1000+1)**1000
>>> eq
                   1000
⎛         1000    ⎞    
⎝4⋅(x + 2)     + 1⎠    
>>> degree(eq)
1000000

```

This algorithm makes the calculation to a several miliseconds whereas the older one took several minutes where I had to reboot the machine.

See also #6322 (and @cheatiiit routine there)  and #7270 
