### PR TITLE
fix Dummy.sort_key and use it in expr.sort_key

### DIFF
--- a/sympy/core/compatibility.py
+++ b/sympy/core/compatibility.py
@@ -563,15 +563,19 @@ def _nodes(e):
 
 
 def ordered(seq, keys=None, default=True, warn=False):
-    """Return an iterator of the seq where keys are used to break ties.
-    Two default keys will be applied after and provided unless ``default``
-    is False. The two keys are _nodes and default_sort_key which will
-    place smaller expressions before larger ones (in terms of Basic nodes)
-    and where there are ties, they will be broken by the default_sort_key.
+    """Return an iterator of the seq where keys are used to break ties in
+    a conservative fashion: if, after applying a key, there are no ties
+    then no other keys will be computed.
+
+    Two default keys will be applied if 1) keys are not provided or 2) the
+    given keys don't resolve all ties (but only if `default` is True). The
+    two keys are `_nodes` (which places smaller expressions before large) and
+    `default_sort_key` which (if the `sort_key` for an object is defined
+    properly) should resolve any ties.
 
     If ``warn`` is True then an error will be raised if there were no
     keys remaining to break ties. This can be used if it was expected that
-    there should be no ties.
+    there should be no ties between items that are not identical.
 
     Examples
     ========
@@ -660,7 +664,11 @@ def ordered(seq, keys=None, default=True, warn=False):
                 d[k] = ordered(d[k], (_nodes, default_sort_key,),
                                default=False, warn=warn)
             elif warn:
-                raise ValueError('not enough keys to break ties')
+                from sympy.utilities.iterables import uniq
+                u = list(uniq(d[k]))
+                if len(u) > 1:
+                    raise ValueError(
+                        'not enough keys to break ties: %s' % u)
         for v in d[k]:
             yield v
         d.pop(k)

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -57,7 +57,9 @@ class Expr(Basic, EvalfMixin):
         else:
             expr, exp = expr, S.One
 
-        if expr.is_Atom:
+        if expr.is_Dummy:
+            args = (expr.sort_key(),)
+        elif expr.is_Atom:
             args = (str(expr),)
         else:
             if expr.is_Add:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -552,6 +552,15 @@ class Mul(Expr, AssocOp):
             # we know for sure the result will be 0
             return [coeff], [], order_symbols
 
+        # check for straggling Numbers that were produced
+        _new = []
+        for i in c_part:
+            if i.is_Number:
+                coeff *= i
+            else:
+                _new.append(i)
+        c_part = _new
+
         # order commutative part canonically
         _mulsort(c_part)
 

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -180,7 +180,7 @@ class Dummy(Symbol):
     @cacheit
     def sort_key(self, order=None):
         return self.class_key(), (
-            2, (str(self), self._count)), S.One.sort_key(), S.One
+            2, (str(self), self.dummy_index)), S.One.sort_key(), S.One
 
     def _hashable_content(self):
         return Symbol._hashable_content(self) + (self.dummy_index,)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1597,3 +1597,9 @@ def test_denest_add_mul():
     eq = Mul(-2, x - 2, evaluate=False)
     assert 2*eq == Mul(-4, x - 2, evaluate=False)
     assert -eq == Mul(2, x - 2, evaluate=False)
+
+def test_mul_coeff():
+    # It is important that all Numbers be removed from the seq;
+    # This can be tricky when powers combine to produce those numbers
+    p = exp(I*pi/3)
+    assert p**2*x*p*y*p*x*p**2 == x**2*y

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -17,5 +17,12 @@ def test_as_int():
 
 def test_ordered():
     # Issue 7210 - this had been failing with python2/3 problems
-    assert(list(ordered([{1:3, 2:4, 9:10}, {1:3}])) == \
+    assert (list(ordered([{1:3, 2:4, 9:10}, {1:3}])) == \
                [{1: 3}, {1: 3, 2: 4, 9: 10}])
+    # warnings should not be raised for identical items
+    l = [1, 1]
+    assert list(ordered(l, warn=True)) == l
+    l = [[1], [2], [1]]
+    assert list(ordered(l, warn=True)) == [[1], [1], [2]]
+    raises(ValueError, lambda: list(ordered(['a', 'ab'], keys=[lambda x: x[0]],
+        default=False, warn=True)))

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1315,7 +1315,7 @@ def test_expr_sorting():
     exprs = [set([1]), set([1, 2])]
     assert sorted(exprs, key=default_sort_key) == exprs
 
-    a, b = exprs = [Dummy(), Dummy()]
+    a, b = exprs = [Dummy('x'), Dummy('x')]
     assert sorted([b, a], key=default_sort_key) == exprs
 
 


### PR DESCRIPTION
Also, catch any new Numbers that are generated by the rebuilding
of terms in Mul.flatten. Rather than check them at each step of
the way, just handle them once when done traversing the args.
