### PR TITLE
Fixes #7010

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -54,7 +54,7 @@ from sympy import mpmath
 import sympy.mpmath.libmp as mlib
 
 import inspect
-from sympy import *
+from sympy import Or,And,Not,Xor,Nand,Nor,Implies,Equivalent
 
 def _coeff_isneg(a):
     """Return True if the leading Number is negative.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -54,7 +54,7 @@ from sympy import mpmath
 import sympy.mpmath.libmp as mlib
 
 import inspect
-
+from sympy import *
 
 def _coeff_isneg(a):
     """Return True if the leading Number is negative.
@@ -2328,10 +2328,18 @@ def count_ops(expr, visual=False):
             raise TypeError("Invalid type of expr")
         ops = [count_ops(a, visual=visual) for a in expr.args]
 
+    bool_ops = ['Or','And','Not','Xor','Nand','Nor','Implies','Equivalent']
+    for bool_func in bool_ops:
+        if bool_func in str(expr):
+            operations = 0
+            for bool_functions in bool_ops:
+                operations += str(expr).count(bool_functions)
+            return operations
+                
     if not ops:
         if visual:
             return S.Zero
-        return 0
+        return 0    
 
     ops = Add(*ops)
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2335,11 +2335,11 @@ def count_ops(expr, visual=False):
             for bool_functions in bool_ops:
                 operations += str(expr).count(bool_functions)
             return operations
-                
+
     if not ops:
         if visual:
             return S.Zero
-        return 0    
+        return 0
 
     ops = Add(*ops)
 


### PR DESCRIPTION
<code>count_ops()</code> returns 0 for logic expressions because ( I think) the cases for the <code>expr</code> being a logic expression are not dealt with. statements calling <code>count_ops()</code> are already converted into legal SymPy functions.It is not the best way but <strong>I am learning so please  enlighten me</strong> on this issue so that i can come up with a proper fix.
 fixes the issue #7010.
