### PR TITLE
Changed lambdastr to use dummy for all symbols if dummify=True (fixes #7249)

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -375,7 +375,8 @@ def lambdastr(args, expr, printer=None, dummify=False):
             dummies = flatten([sub_args(a, dummies_dict) for a in args])
             return ",".join(str(a) for a in dummies)
         else:
-            if isinstance(args, Function):
+            #Sub in dummy variables for functions or symbols
+            if isinstance(args, (Function, Symbol)):
                 dummies = Dummy()
                 dummies_dict.update({args : dummies})
                 return str(dummies)
@@ -401,6 +402,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
     # Transform args
     def isiter(l):
         return iterable(l, exclude=(str, DeferredVector))
+
     if isiter(args) and any(isiter(i) for i in args):
         from sympy.utilities.iterables import flatten
         import re

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -364,11 +364,18 @@ def test_dummification():
     t = symbols('t')
     F = Function('F')
     G = Function('G')
+    #"\alpha" is not a valid python variable name
+    #lambdify should sub in a dummy for it, and return
+    #without a syntax error
+    alpha = symbols(r'\alpha')
     some_expr = 2 * F(t)**2 / G(t)
     lam = lambdify((F(t), G(t)), some_expr)
     assert lam(3, 9) == 2
     lam = lambdify(sin(t), 2 * sin(t)**2)
     assert lam(F(t)) == 2 * F(t)**2
+    #Test that \alpha was properly dummified
+    lam = lambdify((alpha, t), 2*alpha + t)
+    assert lam(2, 1) == 5
     raises(SyntaxError, lambda: lambdify(F(t) * G(t), F(t) * G(t) + 5))
     raises(SyntaxError, lambda: lambdify(2 * F(t), 2 * F(t) + 5))
     raises(SyntaxError, lambda: lambdify(2 * F(t), 4 * F(t) + 5))


### PR DESCRIPTION
Previously, if the user declared alpha = symbols('\alpha'), lambdastr would try to use \alpha as a variable, resulting in a syntax error in lambdify. Now all all symbols are replaced with dummies if dummify is true, so any string is a valid variable name.

If the user wants to not use Dummy symbols, they can still set dummify=False, and get direct substitution. This allows the output to be examined, but will result in a syntax error in lambdify if a non-valid symbol name is used (such as \alpha)

This fixes issue #7249.
