### PR TITLE
Improve degree calculation

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4225,18 +4225,37 @@ def degree(f, *gens, **args):
     2
     >>> degree(x**2 + y*x + 1, gen=y)
     1
+    >>> degree((x**10-1)/(x-1))
+    9
     >>> degree(0, x)
     -oo
 
+    The degree of constants (including S.Pi, S.Exp1, S.Catalan
+    S.GoldenRatio, etc.) should be 0.
+
+    Examples
+    ========
+
+    >>> degree(pi)
+    0
+    >>> degree(S.Catalan)
+    0
     """
     options.allowed_flags(args, ['gen', 'polys'])
 
     try:
-        F, opt = poly_from_expr(f, *gens, **args)
+        from sympy.simplify import simplify
+        if isinstance(f, Poly):
+            F, opt = poly_from_expr(cancel(f), f.gens[0])
+        else:
+            F, opt = poly_from_expr(cancel(f), *gens, **args)
     except PolificationFailed as exc:
         raise ComputationFailed('degree', 1, exc)
 
-    return sympify(F.degree(opt.gen))
+    if F.is_number:
+        return S.Zero
+    else:
+        return sympify(F.degree(opt.gen))
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -4236,6 +4236,9 @@ def degree(f, *gens, **args):
     Examples
     ========
 
+    >>> from sympy import *
+    >>> from sympy.abc import x, y
+
     >>> degree(pi)
     0
     >>> degree(S.Catalan)
@@ -4244,7 +4247,6 @@ def degree(f, *gens, **args):
     options.allowed_flags(args, ['gen', 'polys'])
 
     try:
-        from sympy.simplify import simplify
         if isinstance(f, Poly):
             F, opt = poly_from_expr(cancel(f), f.gens[0])
         else:
@@ -4253,7 +4255,7 @@ def degree(f, *gens, **args):
         raise ComputationFailed('degree', 1, exc)
 
     if F.is_number:
-        return S.Zero
+        return S.NegativeInfinity if F == S.Zero else S.Zero
     else:
         return sympify(F.degree(opt.gen))
 


### PR DESCRIPTION
The latest edition of SymPy's degree computation gives few undesired answers.

Example:

```
>>> degree(S.Pi)
1
>>> degree(S.GoldenRatio)
1
>>> f = (x**3-1)/(x-1)
>>> f
 3    
x  - 1
──────
x - 1 
>>> degree(f)
3
>>> degree(f,x)
ends up with a Polynomial error.
```

This commit would rectify above issues.

See also #6322 (and @cheatiiit routine there) and #7236
