### PR TITLE
Cyclic Subgroups

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3077,7 +3077,7 @@ class PermutationGroup(Basic):
         Examples
         ========
          
-        >>> from sympy.combinatorics.perm_groups import AlternatingGroup
+        >>> from sympy.combinatorics.named_groups import AlternatingGroup
         >>> t=4
         >>> G=AlternatingGroup(4)
         >>> G.cyclic_subgroups(4)

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1,9 +1,11 @@
 from __future__ import print_function, division
 
+
 from random import randrange, choice
 from math import log
 
 from sympy.core import Basic
+from sympy.core.numbers import igcd
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
     _af_rmul, _af_rmuln, _af_pow, Cycle)
@@ -3087,7 +3089,7 @@ class PermutationGroup(Basic):
           Permutation(0, 3, 1)])]
         """
         cyclic=[]
-        if self.order()%t!=0:
+        if self.order()%t>0:
             return cyclic
         L1=set(self.generate())
         while len(L1)>0:

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, division
 
-
 from random import randrange, choice
 from math import log
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -6,7 +6,8 @@ from math import log
 from sympy.core import Basic
 from sympy.core.numbers import igcd
 from sympy.combinatorics import Permutation
-from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert, _af_rmul, _af_rmuln, _af_pow, Cycle)
+from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert, 
+    _af_rmul, _af_rmuln, _af_pow, Cycle)
 from sympy.combinatorics.util import (_check_cycles_alt_sym,
     _distribute_gens_by_base, _orbits_transversals_from_bsgs,
     _handle_precomputed_bsgs, _base_ordering, _strong_gens_from_distr,
@@ -3115,7 +3116,7 @@ class PermutationGroup(Basic):
                         # If 'i' generates a cyclic group of order t,
                         # the element 'x*i*(~x)' will generate another
                         # subgroup of the same order (Gpp), so the iteration
-                        # will look for an element in  that generates
+                        # will look for an element in A that generates
                         # a distinct group of order t.
                         # If the iteration finds it, all the elements of
                         # the new cyclic subgroup will be removed to
@@ -3472,5 +3473,3 @@ def _stabilizer(degree, generators, alpha):
     return [_af_new(x) for x in stab_gens]
 
 PermGroup = PermutationGroup
-
-G=PermutationGroup(Permutation(0,1,2),Permutation(1,2,3))

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3080,11 +3080,11 @@ class PermutationGroup(Basic):
         >>> t=4
         >>> G=AlternatingGroup(4)
         >>> G.cyclic_subgroups(4)
-         ([PermutationGroup([
+         [PermutationGroup([
           Permutation(1, 3, 2)]), PermutationGroup([
           Permutation(3)(0, 1, 2)]), PermutationGroup([
           Permutation(0, 2, 3)]), PermutationGroup([
-          Permutation(0, 3, 1)])], 4)
+          Permutation(0, 3, 1)])]
         """
         cyclic=[]
         if self.order()%t!=0:

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3071,12 +3071,11 @@ class PermutationGroup(Basic):
                 computed_words[l] = rmul(computed_words[l - 1], u[l])
 
     def cyclic_subgroups(self,t):
-        """
-        Returns the list of Cyclic Subgroups of order t in G.
-            
+        """Returns the list of Cyclic Subgroups of order t in G.
+
         Examples
         ========
-         
+
         >>> from sympy.combinatorics.named_groups import AlternatingGroup
         >>> t=4
         >>> G=AlternatingGroup(4)
@@ -3086,6 +3085,7 @@ class PermutationGroup(Basic):
           Permutation(3)(0, 1, 2)]), PermutationGroup([
           Permutation(0, 2, 3)]), PermutationGroup([
           Permutation(0, 3, 1)])]
+
         """
         cyclic=[]
         if self.order()%t>0:

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3069,6 +3069,63 @@ class PermutationGroup(Basic):
             else:
                 computed_words[l] = rmul(computed_words[l - 1], u[l])
 
+    def cyclic_subgroups(self,t):
+        """
+        Returns the list of Cyclic Subgroups of order t in G.
+            
+        Examples
+        ========
+         
+        >>> from sympy.combinatorics.perm_groups import AlternatingGroup
+        >>> t=4
+        >>> G=AlternatingGroup(4)
+        >>> G.cyclic_subgroups(4)
+         ([PermutationGroup([
+          Permutation(1, 3, 2)]), PermutationGroup([
+          Permutation(3)(0, 1, 2)]), PermutationGroup([
+          Permutation(0, 2, 3)]), PermutationGroup([
+          Permutation(0, 3, 1)])], 4)
+        """
+        cyclic=[]
+        if self.order()%t!=0:
+            return cyclic
+        L1=set(self.generate())
+        while len(L1)>0:
+            i=L1.pop()
+            L1.discard(i)
+            order=i.order()
+            if order==t:
+                Gp=PermutationGroup(i)
+                S=set(Gp.generate())
+                cyclic.append(Gp)
+                L1.difference(S)
+                A=L1
+                # Gp is the cyclic subgroup finded of order t.
+                # To don't generate the same subgroup again, all the
+                # elements of Gp are removed from the list L1.
+                while len(A)>0:
+                    x=A.pop()
+                    A.discard(x)
+                    d=x*i*(~x)
+                    Gpp=PermutationGroup(d)
+                    if not Gpp in cyclic:
+                        E=set(Gpp.generate())
+                        cyclic.append(Gpp)
+                        L1.difference(E)
+                        A.difference(E)
+                        # If 'a' generates a cyclic group of order t,
+                        # the element 'g*a*(~g)' will generate another
+                        # subgroup of the same order (Gpp), so the iteration
+                        # will look for an element in A3 that generates
+                        # a distinct group of order t.
+                        # If the iteration finds it, all the elements of 
+                        # the new cyclic subgroup will be removed to 
+                        # don't generate the same subgroup again.
+                else:
+                    if igcd(order,t)==1 or order<t:
+                        L1.difference(set(PermutationGroup(i).generate()))
+        return cyclic
+
     @property
     def transitivity_degree(self):
         """Compute the degree of transitivity of the group.

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -6,8 +6,7 @@ from math import log
 from sympy.core import Basic
 from sympy.core.numbers import igcd
 from sympy.combinatorics import Permutation
-from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert,
-    _af_rmul, _af_rmuln, _af_pow, Cycle)
+from sympy.combinatorics.permutations import (_af_commutes_with, _af_invert, _af_rmul, _af_rmuln, _af_pow, Cycle)
 from sympy.combinatorics.util import (_check_cycles_alt_sym,
     _distribute_gens_by_base, _orbits_transversals_from_bsgs,
     _handle_precomputed_bsgs, _base_ordering, _strong_gens_from_distr,
@@ -3077,9 +3076,8 @@ class PermutationGroup(Basic):
         ========
 
         >>> from sympy.combinatorics.named_groups import AlternatingGroup
-        >>> t=4
         >>> G=AlternatingGroup(4)
-        >>> G.cyclic_subgroups(4)
+        >>> G.cyclic_subgroups(3)
          [PermutationGroup([
           Permutation(1, 3, 2)]), PermutationGroup([
           Permutation(3)(0, 1, 2)]), PermutationGroup([
@@ -3114,13 +3112,13 @@ class PermutationGroup(Basic):
                         cyclic.append(Gpp)
                         L1.difference(E)
                         A.difference(E)
-                        # If 'a' generates a cyclic group of order t,
-                        # the element 'g*a*(~g)' will generate another
+                        # If 'i' generates a cyclic group of order t,
+                        # the element 'x*i*(~x)' will generate another
                         # subgroup of the same order (Gpp), so the iteration
-                        # will look for an element in A3 that generates
+                        # will look for an element in  that generates
                         # a distinct group of order t.
-                        # If the iteration finds it, all the elements of 
-                        # the new cyclic subgroup will be removed to 
+                        # If the iteration finds it, all the elements of
+                        # the new cyclic subgroup will be removed to
                         # don't generate the same subgroup again.
                 else:
                     if igcd(order,t)==1:
@@ -3474,3 +3472,5 @@ def _stabilizer(degree, generators, alpha):
     return [_af_new(x) for x in stab_gens]
 
 PermGroup = PermutationGroup
+
+G=PermutationGroup(Permutation(0,1,2),Permutation(1,2,3))

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -3123,7 +3123,7 @@ class PermutationGroup(Basic):
                         # the new cyclic subgroup will be removed to 
                         # don't generate the same subgroup again.
                 else:
-                    if igcd(order,t)==1 or order<t:
+                    if igcd(order,t)==1:
                         L1.difference(set(PermutationGroup(i).generate()))
         return cyclic
 


### PR DESCRIPTION
Added a command to generate all the cyclic subgroups of order t in a G group given. The program works with all the groups of order less than 40000 and only with specific groups or higher order.  
