### PR TITLE
Added DFT matrix in physics matrices

### DIFF
--- a/sympy/physics/__init__.py
+++ b/sympy/physics/__init__.py
@@ -3,4 +3,4 @@ A module that helps solving problems in physics
 """
 
 from . import units
-from .matrices import mgamma, msigma, minkowski_tensor, dft
+from .matrices import mgamma, msigma, minkowski_tensor, mdft

--- a/sympy/physics/__init__.py
+++ b/sympy/physics/__init__.py
@@ -3,4 +3,4 @@ A module that helps solving problems in physics
 """
 
 from . import units
-from .matrices import mgamma, msigma, minkowski_tensor
+from .matrices import mgamma, msigma, minkowski_tensor, dft

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -2,7 +2,8 @@
 
 from __future__ import print_function, division
 
-from sympy import Matrix, I
+from sympy import Matrix, I, pi, sqrt
+from sympy.functions import exp
 
 
 def msigma(i):
@@ -151,3 +152,32 @@ minkowski_tensor = Matrix( (
     (0, 0, -1, 0),
     (0, 0, 0, -1)
 ))
+
+def dft(n):
+    r"""Returns an expression of a discrete Fourier transform as a matrix multiplication.
+    It is an n X n matrix.
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/DFT_matrix
+
+    Examples
+    ========
+
+    >>> from sympy.physics.matrices import dft
+    >>> dft(3)
+    Matrix([
+    [sqrt(3)/3,                sqrt(3)/3,                sqrt(3)/3],
+    [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3, sqrt(3)*exp(-4*I*pi/3)/3],
+    [sqrt(3)/3, sqrt(3)*exp(-4*I*pi/3)/3, sqrt(3)*exp(-8*I*pi/3)/3]])
+    """
+    mat = [[None for x in range(n)] for y in range(n)]
+    base = exp(-2*pi*I/n)
+    mat[0] = [1]*n
+    for i in range(n):
+        mat[i][0] = 1
+    for i in range(1,n):
+        for j in range(1,n):
+            mat[i][j] = base**(i*j)
+    return (1/sqrt(n))*Matrix(mat)

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -153,7 +153,7 @@ minkowski_tensor = Matrix( (
     (0, 0, 0, -1)
 ))
 
-def dft(n):
+def mdft(n):
     r"""Returns an expression of a discrete Fourier transform as a matrix multiplication.
     It is an n X n matrix.
 
@@ -165,8 +165,8 @@ def dft(n):
     Examples
     ========
 
-    >>> from sympy.physics.matrices import dft
-    >>> dft(3)
+    >>> from sympy.physics.matrices import mdft
+    >>> mdft(3)
     Matrix([
     [sqrt(3)/3,                sqrt(3)/3,                sqrt(3)/3],
     [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3, sqrt(3)*exp(-4*I*pi/3)/3],

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -154,7 +154,8 @@ minkowski_tensor = Matrix( (
 ))
 
 def mdft(n):
-    r"""Returns an expression of a discrete Fourier transform as a matrix multiplication.
+    r"""
+    Returns an expression of a discrete Fourier transform as a matrix multiplication.
     It is an n X n matrix.
 
     References

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -4,6 +4,7 @@ from __future__ import print_function, division
 
 from sympy import Matrix, I, pi, sqrt
 from sympy.functions import exp
+from sympy.core.compatibility import xrange
 
 
 def msigma(i):

--- a/sympy/physics/matrices.py
+++ b/sympy/physics/matrices.py
@@ -173,12 +173,12 @@ def mdft(n):
     [sqrt(3)/3, sqrt(3)*exp(-2*I*pi/3)/3, sqrt(3)*exp(-4*I*pi/3)/3],
     [sqrt(3)/3, sqrt(3)*exp(-4*I*pi/3)/3, sqrt(3)*exp(-8*I*pi/3)/3]])
     """
-    mat = [[None for x in range(n)] for y in range(n)]
+    mat = [[None for x in xrange(n)] for y in xrange(n)]
     base = exp(-2*pi*I/n)
     mat[0] = [1]*n
     for i in range(n):
         mat[i][0] = 1
-    for i in range(1,n):
-        for j in range(1,n):
-            mat[i][j] = base**(i*j)
+    for i in xrange(1, n):
+        for j in xrange(i, n):
+            mat[i][j] = mat[j][i] = base**(i*j)
     return (1/sqrt(n))*Matrix(mat)

--- a/sympy/physics/tests/test_physics_matrices.py
+++ b/sympy/physics/tests/test_physics_matrices.py
@@ -1,4 +1,4 @@
-from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix, dft
+from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix, mdft
 from sympy import zeros, eye, I, Matrix, sqrt, Rational
 
 
@@ -68,10 +68,10 @@ def test_Dirac():
     assert mgamma(5, True) == \
         mgamma(0, True)*mgamma(1, True)*mgamma(2, True)*mgamma(3, True)*I
 
-def test_dft():
-    assert dft(1) == Matrix([[1]])
-    assert dft(2) == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
-    assert dft(4) == Matrix([[Rational(1,2),  Rational(1,2),  Rational(1,2),\
+def test_mdft():
+    assert mdft(1) == Matrix([[1]])
+    assert mdft(2) == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
+    assert mdft(4) == Matrix([[Rational(1,2),  Rational(1,2),  Rational(1,2),\
         Rational(1,2)],[Rational(1,2), -I/2, Rational(-1,2),  I/2\
         ],[Rational(1,2), Rational(-1,2),  Rational(1,2), Rational(-1,2)],\
         [Rational(1,2),  I/2, Rational(-1,2), -I/2]])

--- a/sympy/physics/tests/test_physics_matrices.py
+++ b/sympy/physics/tests/test_physics_matrices.py
@@ -1,5 +1,5 @@
-from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix
-from sympy import zeros, eye, I, Matrix
+from sympy.physics.matrices import msigma, mgamma, minkowski_tensor, pat_matrix, dft
+from sympy import zeros, eye, I, Matrix, sqrt, Rational
 
 
 def test_parallel_axis_theorem():
@@ -67,3 +67,11 @@ def test_Dirac():
 
     assert mgamma(5, True) == \
         mgamma(0, True)*mgamma(1, True)*mgamma(2, True)*mgamma(3, True)*I
+
+def test_dft():
+    assert dft(1) == Matrix([[1]])
+    assert dft(2) == 1/sqrt(2)*Matrix([[1,1],[1,-1]])
+    assert dft(4) == Matrix([[Rational(1,2),  Rational(1,2),  Rational(1,2),\
+        Rational(1,2)],[Rational(1,2), -I/2, Rational(-1,2),  I/2\
+        ],[Rational(1,2), Rational(-1,2),  Rational(1,2), Rational(-1,2)],\
+        [Rational(1,2),  I/2, Rational(-1,2), -I/2]])


### PR DESCRIPTION
This PR adds discrete Fourier transform matrix to `sympy.physics.matrices` and tests corresponding to it.
Reference https://en.wikipedia.org/wiki/DFT_matrix
