### PR TITLE
Fix #7206: Equality with matrices.

### DIFF
--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -169,6 +169,12 @@ class Equality(Relational):
     for exact structural equality between two expressions; this class
     compares expressions mathematically.
 
+    If either object defines an `_eval_Eq` method, it can be used in place of
+    the default algorithm.  If `lhs._eval_Eq(rhs)` or `rhs._eval_Eq(lhs)`
+    returns anything other than None, that return value will be substituted for
+    the Equality.  If None is returned by `_eval_Eq`, an Equality object will
+    be created as usual.
+
     """
     rel_op = '=='
 
@@ -179,6 +185,15 @@ class Equality(Relational):
     def __new__(cls, lhs, rhs=0, **assumptions):
         lhs = _sympify(lhs)
         rhs = _sympify(rhs)
+        # If one expression has an _eval_Eq, return its results.
+        if hasattr(lhs, '_eval_Eq'):
+            r = lhs._eval_Eq(rhs)
+            if r is not None:
+                return r
+        if hasattr(rhs, '_eval_Eq'):
+            r = rhs._eval_Eq(lhs)
+            if r is not None:
+                return r
         # If expressions have the same structure, they must be equal.
         if lhs == rhs:
             return S.true
@@ -215,11 +230,18 @@ class Unequality(Relational):
     >>> Ne(y, x+x**2)
     y != x**2 + x
 
+    See Also
+    ========
+    Equality
+
     Notes
     =====
     This class is not the same as the != operator.  The != operator tests
     for exact structural equality between two expressions; this class
     compares expressions mathematically.
+
+    This class is effectively the inverse of Equality.  As such, it uses the
+    same algorithms, including any available `_eval_Eq` methods.
 
     """
     rel_op = '!='

--- a/sympy/matrices/immutable.py
+++ b/sympy/matrices/immutable.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division
 
-from sympy.core import Basic, Integer, Tuple, Dict
+from sympy.core import Basic, Integer, Tuple, Dict, S, sympify
 from sympy.core.sympify import converter as sympify_converter
 
 from sympy.matrices.matrices import MatrixBase
@@ -62,6 +62,21 @@ class ImmutableMatrix(MatrixExpr, DenseMatrix):
 
     def __setitem__(self, *args):
         raise TypeError("Cannot set values of ImmutableMatrix")
+
+    def _eval_Eq(self, other):
+        """Helper method for Equality with matrices.
+
+        Relational automatically converts matrices to ImmutableMatrix
+        instances, so this method only applies here.  Returns True if the
+        matrices are definitively the same, False if they are definitively
+        different, and None if undetermined (e.g. if they contain Symbols).
+        Returning None triggers default handling of Equalities.
+
+        """
+        if not hasattr(other, 'shape') or self.shape != other.shape:
+            return S.false
+        diff = self - other
+        return sympify(diff.is_zero)
 
     adjoint = MatrixBase.adjoint
     conjugate = MatrixBase.conjugate
@@ -142,3 +157,5 @@ class ImmutableSparseMatrix(Basic, SparseMatrix):
 
     def __hash__(self):
         return hash((type(self).__name__,) + (self.shape, tuple(self._smat)))
+
+    _eval_Eq = ImmutableMatrix._eval_Eq

--- a/sympy/matrices/tests/test_immutable.py
+++ b/sympy/matrices/tests/test_immutable.py
@@ -1,4 +1,4 @@
-from sympy import ImmutableMatrix, Matrix, eye, zeros
+from sympy import ImmutableMatrix, Matrix, eye, zeros, S, Equality, Unequality
 from sympy.abc import x, y
 from sympy.utilities.pytest import raises
 
@@ -90,3 +90,19 @@ def test_immutable_evaluation():
 
 def test_deterimant():
     assert ImmutableMatrix(4, 4, lambda i, j: i + j).det() == 0
+
+
+def test_Equality():
+    assert Equality(IM, IM) is S.true
+    assert Unequality(IM, IM) is S.false
+    assert Equality(IM, IM.subs(1, 2)) is S.false
+    assert Unequality(IM, IM.subs(1, 2)) is S.true
+    assert Equality(IM, 2) is S.false
+    assert Unequality(IM, 2) is S.true
+    M = ImmutableMatrix([x, y])
+    assert Equality(M, IM) is S.false
+    assert Unequality(M, IM) is S.true
+    assert Equality(M, M.subs(x, 2)).subs(x, 2) is S.true
+    assert Unequality(M, M.subs(x, 2)).subs(x, 2) is S.false
+    assert Equality(M, M.subs(x, 2)).subs(x, 3) is S.false
+    assert Unequality(M, M.subs(x, 2)).subs(x, 3) is S.true


### PR DESCRIPTION
Equality was changed to support objects with an `_eval_Eq` method.  This allows
objects to define alternative algorithms for determining equality.  Such a
method was implemented in ImmutableMatrix.

For my previous attempts at fixing this issue, see pull requests #2685 and #2625.
