### PR TITLE
Make `orientnew` respect parent class

### DIFF
--- a/sympy/physics/vector/frame.py
+++ b/sympy/physics/vector/frame.py
@@ -636,7 +636,7 @@ class ReferenceFrame(object):
 
         """
 
-        newframe = ReferenceFrame(newname, variables, indices, latexs)
+        newframe = self.__class__(newname, variables, indices, latexs)
         newframe.orient(self, rot_type, amounts, rot_order)
         return newframe
 

--- a/sympy/physics/vector/tests/test_frame.py
+++ b/sympy/physics/vector/tests/test_frame.py
@@ -158,3 +158,11 @@ def test_dcm():
         cos(q1)*cos(q3), sin(q1)*cos(q2)], [sin(q1)*sin(q3) +
         sin(q2)*cos(q1)*cos(q3), - sin(q1)*cos(q3) + sin(q2)*sin(q3)*cos(q1),
          cos(q1)*cos(q2)]])
+
+
+def test_orientnew_respects_parent_class():
+    class MyReferenceFrame(ReferenceFrame):
+        pass
+    B = MyReferenceFrame('B')
+    C = B.orientnew('C', 'Axis', [0, B.x])
+    assert isinstance(C, MyReferenceFrame)


### PR DESCRIPTION
With current SymPy stable:

```
In [1]: from sympy.physics.mechanics import ReferenceFrame

In [2]: class MyReferenceFrame(ReferenceFrame):
   ...:     pass
   ...: 

In [3]: A = MyReferenceFrame('A')

In [4]: B = A.orientnew('B', 'Axis', [0, A.x])

In [5]: type(B)
Out[5]: sympy.physics.vector.frame.ReferenceFrame

```

I expected `B` to be of the same class of `A`. I use this a lot because I usually overwrite the default versors to something like

```
class IJKReferenceFrame(ReferenceFrame):
    def __init__(self, name):
        super().__init__(name, latexs=['\mathbf{%s}_{%s}' % (idx, name) for idx in ("i", "j", "k")])
```

The needed change is minimal and is contained in this pull request. Probably I should write some kind of tests, I can do them if needed when I have 20 spare minutes by next week.
