### PR TITLE
ODE: Added non homogeneoous linear euler eq fixes #7172

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1159,8 +1159,10 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
                 undetcoeff = _undetermined_coefficients_match(r[-1], x)
                 if undetcoeff['test']:
                     r['trialset'] = undetcoeff['trialset']
-                matching_hints["nth_linear_euler_eq_nonhomogeneous"] = r
-                matching_hints["nth_linear_euler_eq_nonhomogeneous_Integral"] = r
+                    matching_hints["nth_linear_euler_eq_nonhomogeneous"] = r
+                else:
+                    matching_hints["nth_linear_euler_eq_nonhomogeneous"] = r
+                    matching_hints["nth_linear_euler_eq_nonhomogeneous_Integral"] = r
 
     # Order keys based on allhints.
     retlist = [i for i in allhints if i in matching_hints]
@@ -3283,7 +3285,7 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     r = match
 
     chareq, eq, symbol = S.Zero, S.Zero, Dummy('x')
-    t = Dummy('t')
+    t = Symbol('t')
     #for i in r.keys():
     for i in r.keys():
         if not isinstance(i, str) and i >= 0:

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -291,6 +291,7 @@ allhints = (
     "lie_group",
     "nth_linear_constant_coeff_homogeneous",
     "nth_linear_euler_eq_homogeneous",
+    "nth_linear_euler_eq_nonhomogeneous",
     "nth_linear_constant_coeff_undetermined_coefficients",
     "nth_linear_constant_coeff_variation_of_parameters",
     "Liouville",
@@ -306,6 +307,7 @@ allhints = (
     "linear_coefficients_Integral",
     "separable_reduced_Integral",
     "nth_linear_constant_coeff_variation_of_parameters_Integral",
+    "nth_linear_euler_eq_nonhomogeneous_Integral",
     "Liouville_Integral",
     )
 
@@ -1120,10 +1122,11 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
             else:
                 matching_hints["nth_linear_constant_coeff_homogeneous"] = r
 
-        # Euler equation case (a_i * x**i for all i)
+        # nth order Euler equation a_n*x**n*y^(n) + ... + a_1*x*y' + a_0*y = F(x)
+        #In case of Homogeneous euler equation F(x) = 0
         def _test_term(coeff, order):
             r"""
-            Linear Euler ODEs have the form  K*x**order*diff(y(x),x,order),
+            Linear Euler ODEs have the form  K*x**order*diff(y(x),x,order) = F(x),
             where K is independent of x and y(x), order>= 0.
             So we need to check that for each term, coeff == K*x**order from
             some K.  We have a few cases, since coeff may have several
@@ -1134,9 +1137,12 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
             if coeff == 0:
                 return True
             if order == 0:
-                if x in coeff.free_symbols:
-                    return False
-                return f(x) not in coeff.atoms()
+                if f(x) in coeff.atoms(AppliedUndef):
+                    if x in coeff.free_symbols:
+                        return False
+                    return f(x) not in coeff.atoms()
+                else:
+                    return True
             if coeff.is_Mul:
                 if coeff.has(f(x)):
                     return False
@@ -1149,6 +1155,9 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
         if r and not any(not _test_term(r[i], i) for i in r if i >= 0):
             if not r[-1]:
                 matching_hints["nth_linear_euler_eq_homogeneous"] = r
+            else:
+               matching_hints["nth_linear_euler_eq_nonhomogeneous"] = r
+               matching_hints["nth_linear_euler_eq_nonhomogeneous_Integral"] = r
 
     # Order keys based on allhints.
     retlist = [i for i in allhints if i in matching_hints]
@@ -3233,6 +3242,62 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
             return {'sol': Eq(f(x), gsol), 'list': gensols}
     else:
         raise ValueError('Unknown value for key "returns".')
+
+
+def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'):
+    r"""
+    Solves an `n`\th order linear non homogeneous variable-coefficient
+    Cauchy-Euler equidimensional ordinary differential equation.
+
+    This is an equation with form `g(x) = a_0 f(x) + a_1 x f'(x) + a_2 x^2 f''(x)
+    \cdots`.
+
+    These equations can be solved in a general manner, by substituting
+    solutions of the form `x = exp(t)`, and deriving a characteristic equation
+    of form g(exp(t)) = b_0 f(t) + b_1 f'(t) + b_2 f''(t) which can be then solved
+    by nth_linear_constant_coeff_variation_of_parameters. If this method hangs, try
+    using "nth_linear_euler_eq_nonhomogeneous_Integral" hint which will then use
+    ``nth_linear_constant_coeff_variation_of_parameters_Integral`` and then
+    simplifying the integrals can be done manually.
+
+    Examples
+    ========
+
+    >>> from sympy import Function, dsolve, Eq
+    >>> from sympy.abc import x
+    >>> f = Function('f')
+    >>> dsolve(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3), f(x),
+    ... hint='nth_linear_euler_eq_nonhomogeneous')
+    f(x) = C1*x**2 + C2*x + Rational(1, 2)*x**3
+
+    References
+    ==========
+    http://www2.fiu.edu/~aladrog/CauchyEuler
+
+    """
+    x = func.args[0]
+    f = func.func
+    r = match
+
+    chareq, eq, symbol = S.Zero, S.Zero, Dummy('x')
+    t = Dummy('t')
+    #for i in r.keys():
+    for i in r.keys():
+        if not isinstance(i, str) and i >= 0:
+            chareq += (r[i]*diff(x**symbol, x, i)*x**-symbol).expand()
+
+    for i in range(1,degree(chareq)+1):
+        eq += chareq.coeff(symbol**i)*diff(f(t),t,i)
+
+    chareq = Poly(chareq)
+    eq += chareq.coeffs()[-1]*f(t)
+    eq += r[-1].replace(x, exp(t)).replace(log(exp(t)), t)
+
+    if 'nth_linear_constant_coeff_undetermined_coefficients' in classify_ode(eq):
+        return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).replace(t,log(x))
+    else:
+        return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).replace(t,log(x))
+
 
 def ode_almost_linear(eq, func, order, match):
     r"""

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3306,7 +3306,7 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     if 'nth_linear_constant_coeff_undetermined_coefficients' in classify_ode(eq):
         return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x)).expand()
     else:
-        return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x)).expand()
+        return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).subs(x, log(x)).replace(f(log(x)), f(x))
 
 
 def ode_almost_linear(eq, func, order, match):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1156,8 +1156,11 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
             if not r[-1]:
                 matching_hints["nth_linear_euler_eq_homogeneous"] = r
             else:
-               matching_hints["nth_linear_euler_eq_nonhomogeneous"] = r
-               matching_hints["nth_linear_euler_eq_nonhomogeneous_Integral"] = r
+                undetcoeff = _undetermined_coefficients_match(r[-1], x)
+                if undetcoeff['test']:
+                    r['trialset'] = undetcoeff['trialset']
+                matching_hints["nth_linear_euler_eq_nonhomogeneous"] = r
+                matching_hints["nth_linear_euler_eq_nonhomogeneous_Integral"] = r
 
     # Order keys based on allhints.
     retlist = [i for i in allhints if i in matching_hints]

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3266,7 +3266,7 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     >>> from sympy import Function, dsolve, Eq
     >>> from sympy.abc import x
     >>> f = Function('f')
-    >>> dsolve(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3), f(x),
+    >>> dsolve(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x) - x**3, f(x),
     ... hint='nth_linear_euler_eq_nonhomogeneous')
     f(x) = C1*x**2 + C2*x + Rational(1, 2)*x**3
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1137,12 +1137,9 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
             if coeff == 0:
                 return True
             if order == 0:
-                if f(x) in coeff.atoms(AppliedUndef):
-                    if x in coeff.free_symbols:
-                        return False
-                    return f(x) not in coeff.atoms()
-                else:
-                    return True
+                if x in coeff.free_symbols:
+                    return False
+                return True
             if coeff.is_Mul:
                 if coeff.has(f(x)):
                     return False
@@ -3286,12 +3283,12 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     r = match
 
     chareq, eq, symbol = S.Zero, S.Zero, Dummy('x')
-    #for i in r.keys():
+
     for i in r.keys():
         if not isinstance(i, str) and i >= 0:
             chareq += (r[i]*diff(x**symbol, x, i)*x**-symbol).expand()
 
-    for i in range(1,degree(chareq)+1):
+    for i in range(1,degree(Poly(chareq, symbol))+1):
         eq += chareq.coeff(symbol**i)*diff(f(x), x, i)
 
     chareq = Poly(chareq)
@@ -3300,10 +3297,8 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     eq += e.subs(re)
 
     match = _nth_linear_match(eq, f(x), ode_order(eq, f(x)))
-    undetcoeff = _undetermined_coefficients_match(e.subs(re), x)
-    if undetcoeff['test']:
-        match['trialset'] = undetcoeff['trialset']
-    if 'nth_linear_constant_coeff_undetermined_coefficients' in classify_ode(eq):
+    if 'trialset' in r.keys():
+        match['trialset'] = r['trialset']
         return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x)).expand()
     else:
         return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).subs(x, log(x)).replace(f(log(x)), f(x))

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3274,7 +3274,7 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     >>> f = Function('f')
     >>> dsolve(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x) - x, f(x),
     ... hint='nth_linear_euler_eq_nonhomogeneous')
-    f(x) = C1*x**2 + C2*x - x*log(x)
+    f(x) == x*(C1 + C2*x - log(x))
 
     References
     ==========
@@ -3299,8 +3299,12 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     e, re = posify(r[-1].subs(x, exp(x)))
     eq += e.subs(re)
 
+    match = _nth_linear_match(eq, f(x), ode_order(eq, f(x)))
+    undetcoeff = _undetermined_coefficients_match(e.subs(re), x)
+    if undetcoeff['test']:
+        match['trialset'] = undetcoeff['trialset']
     if 'nth_linear_constant_coeff_undetermined_coefficients' in classify_ode(eq):
-        return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x))
+        return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x))
     else:
         return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).subs(x, log(x))
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3263,10 +3263,10 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     Examples
     ========
 
-    >>> from sympy import Function, dsolve, Eq
+    >>> from sympy import Function, dsolve, Eq, Derivative
     >>> from sympy.abc import x
     >>> f = Function('f')
-    >>> dsolve(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x) - x**3, f(x),
+    >>> dsolve(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x) - x**3, f(x),
     ... hint='nth_linear_euler_eq_nonhomogeneous')
     f(x) = C1*x**2 + C2*x + Rational(1, 2)*x**3
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3304,9 +3304,9 @@ def ode_nth_linear_euler_eq_nonhomogeneous(eq, func, order, match, returns='sol'
     if undetcoeff['test']:
         match['trialset'] = undetcoeff['trialset']
     if 'nth_linear_constant_coeff_undetermined_coefficients' in classify_ode(eq):
-        return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x))
+        return ode_nth_linear_constant_coeff_undetermined_coefficients(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x)).expand()
     else:
-        return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).subs(x, log(x))
+        return ode_nth_linear_constant_coeff_variation_of_parameters(eq, func, order, match).subs(x, log(x)).subs(f(log(x)), f(x)).expand()
 
 
 def ode_almost_linear(eq, func, order, match):

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1390,16 +1390,23 @@ def test_nth_order_linear_euler_eq_homogeneous():
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
 
-def test_nth_order_linear_euler_eq_nonhomogeneous():
+def test_nth_order_linear_euler_eq_nonhomogeneous_undetermined_coefficients():
     x, t = symbols('x t')
     a, b, c, d = symbols('a b c d', integer=True)
-    our_hint = "nth_linear_euler_eq_nonhomogeneous"
+    our_hint = "nth_linear_euler_eq_nonhomogeneous_undetermined_coefficients"
 
     eq = x**4*diff(f(x), x, 4) - 13*x**2*diff(f(x), x, 2) + 36*f(x)	+ x
     assert our_hint in classify_ode(eq, f(x))
 
     eq = a*x**2*diff(f(x), x, 2) + b*x*diff(f(x), x) + c*f(x) + d*log(x)
     assert our_hint in classify_ode(eq, f(x))
+
+    eq = Eq(x**2*diff(f(x), x, x) + x*diff(f(x), x), 1)
+    sol =  C1 + C2*log(x) + log(x)**2/2
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq, f(x))
+    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3)
     sol = x*(C1 + C2*x + Rational(1, 2)*x**2)
@@ -1412,19 +1419,59 @@ def test_nth_order_linear_euler_eq_nonhomogeneous():
     sol =  C1/x + C2*x**3 - Rational(1, 16)*log(x)/x - Rational(1, 8)*log(x)**2/x
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq, f(x))
-    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) + 3*x*diff(f(x), x) - 8*f(x), log(x)**3 - log(x))
     sol = C1/x**4 + C2*x**2 - Rational(1,8)*log(x)**3 - Rational(3,32)*log(x)**2 - Rational(1,64)*log(x) - Rational(7, 256)
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq)
-    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**3*diff(f(x), x, x, x) - 3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), log(x))
     sol = C1*x + C2*x**2 + C3*x**3 - Rational(1, 6)*log(x) - Rational(11, 36)
     sols = constant_renumber(sol, 'C', 1, 3)
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+
+def test_nth_order_linear_euler_eq_nonhomogeneous_variation_of_parameters():
+    x, t = symbols('x, t')
+    a, b, c, d = symbols('a, b, c, d', integer=True)
+    our_hint = "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters"
+
+    eq = Eq(x**2*diff(f(x),x,2) - 8*x*diff(f(x),x) + 12*f(x), x**2)
+    assert our_hint in classify_ode(eq, f(x))
+
+    eq = Eq(a*x**3*diff(f(x),x,3) + b*x**2*diff(f(x),x,2) + c*x*diff(f(x),x) + d*f(x), x*log(x))
+    assert our_hint in classify_ode(eq, f(x))
+
+    eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4)
+    sol = C1*x + C2*x**2 + x**4/6
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+    eq = Eq(3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), x**3*exp(x))
+    sol = C1/x**2 + C2*x + x*exp(x)/3 - 4*exp(x)/3 + 8*exp(x)/(3*x) - 8*exp(x)/(3*x**2)
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+    eq = Eq(x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x), x**4*exp(x))
+    sol = C1*x + C2*x**2 + x**2*exp(x) - 2*x*exp(x)
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint).rhs.expand() in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+    eq = x**2*Derivative(f(x), x, x) - 2*x*Derivative(f(x), x) + 2*f(x) - log(x)
+    sol = C1*x + C2*x**2 + log(x)/2 + 3/4
+    sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1390,6 +1390,46 @@ def test_nth_order_linear_euler_eq_homogeneous():
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
 
+def test_nth_order_linear_euler_eq_nonhomogeneous():
+    x, t = symbols('x t')
+    a, b, c, d = symbols('a b c d', integer=True)
+    our_hint = "nth_linear_euler_eq_nonhomogeneous"
+
+    eq = x**4*diff(f(x), x, 4) - 13*x**2*diff(f(x), x, 2) + 36*f(x)	+ x
+    assert our_hint in classify_ode(eq, f(x))
+
+    eq = a*x**2*diff(f(x), x, 2) + b*x*diff(f(x), x) + c*f(x) + d*log(x)
+    assert our_hint in classify_ode(eq, f(x))
+
+    eq = Eq(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3)
+    sol = C1*x**2 + C2*x + Rational(1, 2)*x**3
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq, f(x))
+    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+    eq = Eq(x**2*diff(f(x), x, x) - x*diff(f(x), x) - 3*f(x), log(x)/x)
+    sol = C1*x**3 + C2/x - Rational(1, 16)*log(x)*(2*log(x) + 1)/x
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq, f(x))
+    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+    eq = Eq(x**2*diff(f(x), x, x) + 3*x*diff(f(x), x) - 8*f(x), log(x)**3 - log(x))
+    sol = C1*x**2 + C2*x**-4 - Rational(1,8)*log(x)**3 - Rational(3,32)*log(x)**2 - Rational(1,64)*log(x) - Rational(7, 256)
+    sols = constant_renumber(sol, 'C', 1, 2)
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+    eq = Eq(x**3*diff(f(x), x, x, x) - 3*x**2*diff(f(x), x, x) + 6*x*diff(f(x), x) - 6*f(x), log(x))
+    sol = C1*x + C2*x**2 + C3*x**3 - Rational(1, 6)*log(x) - Rational(11, 36)
+    sols = constant_renumber(sol, 'C', 1, 3)
+    assert our_hint in classify_ode(eq)
+    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
+
+
 def test_issue_5095():
     f = Function('f')
     raises(ValueError, lambda: dsolve(f(x).diff(x)**2, f(x), 'separable'))

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1402,21 +1402,21 @@ def test_nth_order_linear_euler_eq_nonhomogeneous():
     assert our_hint in classify_ode(eq, f(x))
 
     eq = Eq(x**2*diff(f(x), x, x) - 2*x*diff(f(x), x) + 2*f(x), x**3)
-    sol = C1*x**2 + C2*x + Rational(1, 2)*x**3
+    sol = x*(C1 + C2*x + Rational(1, 2)*x**2)
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) - x*diff(f(x), x) - 3*f(x), log(x)/x)
-    sol = C1*x**3 + C2/x - Rational(1, 16)*log(x)*(2*log(x) + 1)/x
+    sol =  C1/x + C2*x**3 - Rational(1, 16)*log(x)/x - Rational(1, 8)*log(x)**2/x
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq, f(x))
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = Eq(x**2*diff(f(x), x, x) + 3*x*diff(f(x), x) - 8*f(x), log(x)**3 - log(x))
-    sol = C1*x**2 + C2*x**-4 - Rational(1,8)*log(x)**3 - Rational(3,32)*log(x)**2 - Rational(1,64)*log(x) - Rational(7, 256)
+    sol = C1/x**4 + C2*x**2 - Rational(1,8)*log(x)**3 - Rational(3,32)*log(x)**2 - Rational(1,64)*log(x) - Rational(7, 256)
     sols = constant_renumber(sol, 'C', 1, 2)
     assert our_hint in classify_ode(eq)
     assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)


### PR DESCRIPTION
The issue https://github.com/sympy/sympy/issues/7172, which is about implementing non homogeneous euler differential equations like `{a_n}*x**n*diff(f(x), x, n) + ... + {a_1}*x*diff(f(x), x) + {a_0}*f(x) = g(x)`. 
This PR contain two methods to implement it,
One is undetermined coefficients which is used after converting this non homogeneous equation into homogeneous one by putting `x = exp(t)`.
Second is variation of parameters which can be used directly after dividing the coefficients of nth term. This involves first solving the homogeneous part by homogeneous_euler_eq and for non-homogeneous part using variation of parameters solves the equation. 
