### PR TITLE
Added support for lambdification of MatrixSymbols

### DIFF
--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -104,6 +104,14 @@ class LambdaPrinter(StrPrinter):
             return '*'.join([self.parenthesize(arg, precedence(expr))
                 for arg in expr.args])
 
+    def _print_Transpose(self, T):
+        return "%s.T" % self.parenthesize(T.arg, 1000)
+
+    def _print_Inverse(self, I):
+        if self.use_numpy:
+            return "linalg.inv(%s)" % self.parenthesize(I.arg, 1000)
+        else:
+            return "%s**-1" % self.parenthesize(I.arg, 1000)
 
 def lambdarepr(expr, **settings):
     """

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 
 from .str import StrPrinter
+from sympy.printing.precedence import precedence
 from sympy.utilities import default_sort_key
 
 
@@ -16,6 +17,13 @@ class LambdaPrinter(StrPrinter):
     This printer converts expressions into strings that can be used by
     lambdify.
     """
+
+    def __init__(self, settings=None):
+        if settings:
+            self.use_numpy = settings.pop('use_numpy', False)
+        else:
+            self.use_numpy = False
+        StrPrinter.__init__(self, settings)
 
     def _print_MatrixBase(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, str(expr.tolist()))
@@ -78,6 +86,24 @@ class LambdaPrinter(StrPrinter):
 
     def _print_BooleanFalse(self, expr):
         return "False"
+
+    def _print_MatMul(self,expr):
+        if self.use_numpy:
+            from sympy.matrices.expressions import MatrixExpr
+            from sympy.matrices.matrices import MatrixBase
+            mats = '.dot'.join([self.parenthesize(arg, 1000) for arg
+                in expr.args if isinstance(arg, (MatrixBase, MatrixExpr))])
+            others = '*'.join([self.parenthesize(arg, precedence(expr))
+                for arg in expr.args if not
+                isinstance(arg, (MatrixBase, MatrixExpr))])
+            if others:
+                return others + "*" + mats
+            else:
+                return mats
+        else:
+            return '*'.join([self.parenthesize(arg, precedence(expr))
+                for arg in expr.args])
+
 
 def lambdarepr(expr, **settings):
     """

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -1,4 +1,4 @@
-from sympy import symbols, sin, Matrix, Interval, Piecewise
+from sympy import symbols, sin, Matrix, MatrixSymbol, Interval, Piecewise
 from sympy.utilities.pytest import raises
 
 from sympy.printing.lambdarepr import lambdarepr
@@ -16,6 +16,15 @@ def test_matrix():
     A = Matrix([[x, y], [y*x, z**2]])
     assert lambdarepr(A) == "MutableDenseMatrix([[x, y], [x*y, z**2]])"
 
+def test_matrix_symbol():
+    A = MatrixSymbol('A', 2, 2)
+    B = MatrixSymbol('B', 2, 2)
+    assert lambdarepr(5*A*B) == "5*A*B"
+
+def test_matrix_symbol_numpy():
+    A = MatrixSymbol('A', 2, 2)
+    B = MatrixSymbol('B', 2, 2)
+    assert lambdarepr(5*A*B, use_numpy=True) == "5*(A).dot(B)"
 
 def test_piecewise():
     # In each case, test eval() the lambdarepr() to make sure there are a

--- a/sympy/printing/tests/test_lambdarepr.py
+++ b/sympy/printing/tests/test_lambdarepr.py
@@ -20,11 +20,15 @@ def test_matrix_symbol():
     A = MatrixSymbol('A', 2, 2)
     B = MatrixSymbol('B', 2, 2)
     assert lambdarepr(5*A*B) == "5*A*B"
+    assert lambdarepr(A*B.T) == "A*(B).T"
+    assert lambdarepr(A*B.I) == "A*(B)**-1"
 
 def test_matrix_symbol_numpy():
     A = MatrixSymbol('A', 2, 2)
     B = MatrixSymbol('B', 2, 2)
     assert lambdarepr(5*A*B, use_numpy=True) == "5*(A).dot(B)"
+    assert lambdarepr(A*B.T, use_numpy=True) == "(A).dot((B).T)"
+    assert lambdarepr(A*B.I, use_numpy=True) == "(A).dot(linalg.inv((B)))"
 
 def test_piecewise():
     # In each case, test eval() the lambdarepr() to make sure there are a

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1,7 +1,8 @@
 from sympy.utilities.pytest import XFAIL, raises
 from sympy import (
     symbols, lambdify, sqrt, sin, cos, pi, atan, Rational, Float,
-    Matrix, Lambda, exp, Integral, oo, I, Abs, Function, true, false)
+    Matrix, MatrixSymbol, Lambda, exp, Integral, oo, I, Abs, Function,
+    true, false)
 from sympy.printing.lambdarepr import LambdaPrinter
 from sympy import mpmath
 from sympy.utilities.lambdify import implemented_function
@@ -259,20 +260,27 @@ def test_matrix():
     assert lambdify(v, J, modules='sympy')(1, 2) == sol
     assert lambdify(v.T, J, modules='sympy')(1, 2) == sol
 
-def test_numpy_matrix():
+def test_matrix_symbol():
+    #Test matrix symbol lambdification with sympy
+    A = MatrixSymbol('A', 2, 2)
+    B = MatrixSymbol('B', 2, 2)
+    f = lambdify((A, B), 5*(A-B) + A, modules="sympy")
+    a = Matrix([[1, 2], [3, 4]])
+    b = Matrix([[1, 0], [0, 1]])
+    sol = Matrix([[1, 12], [18, 19]])
+    assert f(a, b) == sol
+
+def test_matrix_symbol_numpy():
+    #Test matrix symbol lambdification with numpy
     if not numpy:
-        skip("numpy not installed.")
-    A = Matrix([[x, x*y], [sin(z) + 4, x**z]])
-    sol_mat = numpy.matrix([[1, 2], [numpy.sin(3) + 4, 1]])
-    sol_arr = numpy.array([[1, 2], [numpy.sin(3) + 4, 1]])
-    #Lambdify array first, to ensure return to matrix as default
-    f_arr = lambdify((x, y, z), A, use_array=True)(1, 2, 3)
-    f_mat = lambdify((x, y, z), A)(1, 2, 3)
-    numpy.testing.assert_allclose(f_mat, sol_mat)
-    numpy.testing.assert_allclose(f_arr, sol_arr)
-    #Check that the types are arrays and matrices
-    assert isinstance(f_mat, numpy.matrix)
-    assert isinstance(f_arr, numpy.ndarray)
+        skip("numpy not installed")
+    A = MatrixSymbol('A', 2, 2)
+    B = MatrixSymbol('B', 2, 2)
+    f = lambdify((A, B), 5*(A-B) + A)
+    a = numpy.array([[1, 2], [3, 4]])
+    b = numpy.array([[1, 0], [0, 1]])
+    sol = numpy.array([[1, 12], [18, 19]])
+    numpy.testing.assert_allclose(f(a, b), sol)
 
 def test_integral():
     f = Lambda(x, exp(-x**2))

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -264,11 +264,15 @@ def test_matrix_symbol():
     #Test matrix symbol lambdification with sympy
     A = MatrixSymbol('A', 2, 2)
     B = MatrixSymbol('B', 2, 2)
-    f = lambdify((A, B), 5*(A-B) + A, modules="sympy")
+    C = Matrix([[x, 2*x],
+                [y, 2*y]])
+    f = lambdify((A, B, x, y), A.T*B*A + A.I*C*A*5, modules="sympy")
     a = Matrix([[1, 2], [3, 4]])
     b = Matrix([[1, 0], [0, 1]])
-    sol = Matrix([[1, 12], [18, 19]])
-    assert f(a, b) == sol
+    a = Matrix([[1, 2], [3, 4]])
+    b = Matrix([[1, 0], [0, 1]])
+    sol = Matrix([[ 10. ,  14. ], [ 31.5,  45. ]])
+    assert f(a, b, 1, 2) == sol
 
 def test_matrix_symbol_numpy():
     #Test matrix symbol lambdification with numpy
@@ -276,11 +280,13 @@ def test_matrix_symbol_numpy():
         skip("numpy not installed")
     A = MatrixSymbol('A', 2, 2)
     B = MatrixSymbol('B', 2, 2)
-    f = lambdify((A, B), 5*(A-B) + A)
+    C = Matrix([[x, 2*x],
+                [y, 2*y]])
+    f = lambdify((A, B, x, y), A.T*B*A + A.I*C*A*5)
     a = numpy.array([[1, 2], [3, 4]])
     b = numpy.array([[1, 0], [0, 1]])
-    sol = numpy.array([[1, 12], [18, 19]])
-    numpy.testing.assert_allclose(f(a, b), sol)
+    sol = numpy.array([[ 10. ,  14. ], [ 31.5,  45. ]])
+    numpy.testing.assert_allclose(f(a, b, 1, 2), sol)
 
 def test_integral():
     f = Lambda(x, exp(-x**2))


### PR DESCRIPTION
Now `lambdify((A, B), A*B)` where A and B are of type `MatrixSymbol` results in `A.dot(B)`.

Also, removed the kwarg `use_array` from lambdify. Default behavior is now to always return np.array.

Fixes #7284
