### PR TITLE
Fix #7282

### DIFF
--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -490,4 +490,5 @@ def init_session(ipython=None, pretty_print=True, order=None,
         sys.exit('Exiting ...')
     else:
         ip.write(message)
-        ip.set_hook('shutdown_hook', lambda ip: ip.write("Exiting ...\n"))
+        import atexit
+        atexit.register(lambda ip: ip.write("Exiting ...\n"), ip)


### PR DESCRIPTION
Hi, this is my first pull request. It is to close issue #7282.

It's a simple replacement of ip.set_hook with atexit.register. Note that the IPython session (`ip`), supplied as the second argument to `atexit.register` is the argument that is supplied to the lambda function.
