### PR TITLE
Fix #6618.

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -129,6 +129,7 @@ html_theme_options = {
 
 # If false, no module index is generated.
 #html_use_modindex = True
+html_domain_indices = ['py-modindex']
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
 #html_copy_source = True


### PR DESCRIPTION
Add a config to our sphinx config file to remove the extra 'np-modindex' (np = numpy).

This is the particular config: http://sphinx-doc.org/config.html#confval-html_domain_indices

Of course, after this code has been changed the docs will have to be re-generated + re-uploaded.

This closes issue sympy/sympy#6618.
