### PR TITLE
Add Python 3.4 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - 2.7
   - 3.2
   - 3.3
+  - 3.4
 matrix:
   include:
     - python: 2.7
@@ -50,6 +51,26 @@ matrix:
         - TEST_GMPY="true"
         - TEST_MATPLOTLIB="true"
         - SPLIT="3/3"
+    - python: 3.4
+      env:
+        - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
+        - TEST_DOCTESTS="true"
+    - python: 3.4
+      env:
+        - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
+        - SPLIT="1/3"
+    - python: 3.4
+      env:
+        - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
+        - SPLIT="2/3"
+    - python: 3.4
+      env:
+        - TEST_GMPY="true"
+        - TEST_MATPLOTLIB="true"
+        - SPLIT="3/3"
     - python: "pypy"
       env:
         - TEST_DOCTESTS="true"
@@ -72,18 +93,18 @@ matrix:
       env:
         - TEST_SLOW="true"
         - SPLIT="2/2"
-    - python: 3.3
+    - python: 3.4
       env:
         - TEST_SLOW="true"
         - SPLIT="1/2"
-    - python: 3.3
+    - python: 3.4
       env:
         - TEST_SLOW="true"
         - SPLIT="2/2"
     - python: 2.7
       env:
         - TEST_THEANO="true"
-    - python: 3.3
+    - python: 3.4
       env:
         - TEST_THEANO="true"
   allow_failures:


### PR DESCRIPTION
I don't know if Travis actually supports it yet. I guess we'll find out.

For the slow tests, we only tested on the most recent version of Python 2 and
Python 3, so change them from 3.3 to 3.4.

This is a lot of Pythons now. We should probably think about dropping 3.2
support...
