### PR TITLE
Added slices to the prime sieve.

### DIFF
--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -181,9 +181,13 @@ class Sieve:
 
     def __getitem__(self, n):
         """Return the nth prime number"""
-        n = as_int(n)
-        self.extend_to_no(n)
-        return self._list[n - 1]
+        if isinstance(n, slice):
+            self.extend_to_no(n.stop)
+            return self._list[n.start - 1:n.stop - 1:n.step]
+        else:
+            n = as_int(n)
+            self.extend_to_no(n)
+            return self._list[n - 1]
 
 # Generate a global object for repeated use in trial division etc
 sieve = Sieve()

--- a/sympy/ntheory/tests/test_ntheory.py
+++ b/sympy/ntheory/tests/test_ntheory.py
@@ -727,3 +727,9 @@ def test_search():
     assert 1 not in sieve
     assert 2**1000 not in sieve
     raises(ValueError, lambda: sieve.search(1))
+
+
+def test_sieve_slice():
+    assert sieve[5] == 11
+    assert list(sieve[5:10]) == [sieve[x] for x in range(5, 10)]
+    assert list(sieve[5:10:2]) == [sieve[x] for x in range(5, 10, 2)]


### PR DESCRIPTION
The following syntax is now possible when using the prime sieve:

``` python
from sympy import sieve

assert sieve[5] == 11
assert list(sieve[5:10]) == [sieve[x] for x in range(5, 10)]
assert list(sieve[5:10:2]) == [sieve[x] for x in range(5, 10, 2)]
```
