### PR TITLE
Make count_ops() work with logic operations by creating a binary tree.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2338,7 +2338,6 @@ def count_ops(expr, visual=False):
                 for i in range(args_len):
                     if not aargs[i].is_Symbol:
                         args.append(aargs[i])
-        
 
     if not ops:
         if visual:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2331,12 +2331,12 @@ def count_ops(expr, visual=False):
             args = [expr]
             while args:
                 a = args.pop()
-                if (not a.args == () and
-                    not a.__class__.__name__ == 'Basic' and
-                    not a.__class__.__name__ == 'Tuple'):
+                if a.args:
                     o = C.Symbol(a.func.__name__.upper())
-                    ops.append(o*(len(a.args)-1))
-                if not a.args == ():
+                    if a.is_Boolean:
+                        ops.append(o*(len(a.args)-1))
+                    else:
+                        ops.append(o)
                     args.extend(a.args)
 
     if not ops:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2323,21 +2323,21 @@ def count_ops(expr, visual=False):
         ops = [count_ops(i, visual=visual) for i in expr]
     elif not isinstance(expr, Basic):
         ops = []
+    elif expr.is_Boolean:
+        ops = []
+        args = [expr]
+        while args:
+            a = args.pop()
+            o = C.Symbol(a.func.__name__.upper())
+            ops.append(o*(len(a.args)-1))
+            args_len = len(a.args)
+            aargs = list(a.args)
+            for i in range(args_len):
+                if aargs[i].is_Boolean:
+                    args.append(aargs[i])
     else:  # it's Basic not isinstance(expr, Expr):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")
-        elif expr.is_Boolean:
-            ops = []
-            args = [expr]
-            while args:
-                a = args.pop()
-                o = C.Symbol(a.func.__name__.upper())
-                ops.append(o*(len(a.args)-1))
-                args_len = len(a.args)
-                aargs = list(a.args)
-                for i in range(args_len):
-                    if aargs[i].is_Boolean:
-                        args.append(aargs[i])
         ops = [count_ops(a, visual=visual) for a in expr.args]
 
     if not ops:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2339,9 +2339,9 @@ def count_ops(expr, visual=False):
                     args_len = len(a.args)
                     aargs = list(a.args)
                     for i in range(args_len):
-                        if (not aargs[i].is_Symbol or
-                            (not aargs[i] is true and 
-                            not aargs[i] is false)) :
+                        if (not aargs[i].is_Symbol and
+                            not  aargs[i] is true and
+                            not  aargs[i] is false):
                             args.append(aargs[i])
 
     if not ops:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2327,20 +2327,16 @@ def count_ops(expr, visual=False):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")
         else:
-            true = sympify(True)
-            false = sympify(False)
             ops = []
             args = [expr]
             while args:
                 a = args.pop()
-                if (not a is true and
-                    not a is false and
-                    not a.is_Symbol and
+                if (not a.args is () and
                     not a.__class__.__name__ is 'Basic' and
                     not a.__class__.__name__ is 'Tuple'):
                     o = C.Symbol(a.func.__name__.upper())
                     ops.append(o*(len(a.args)-1))
-                if not a.is_Symbol:
+                if not a.args is ():
                     args.extend(a.args)
 
     if not ops:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2323,6 +2323,18 @@ def count_ops(expr, visual=False):
         ops = [count_ops(i, visual=visual) for i in expr]
     elif not isinstance(expr, Basic):
         ops = []
+    elif expr.is_Boolean:
+        ops = []
+        args = [expr]
+        while args:
+            a = args.pop()
+            o = C.Symbol(a.func.__name__.upper())
+            ops.append(o*(len(a.args)-1))
+            args_len = len(a.args)
+            aargs = list(a.args)
+            for i in range(args_len):
+                if aargs[i].is_Boolean:
+                    args.append(aargs[i])
     else:  # it's Basic not isinstance(expr, Expr):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2326,7 +2326,7 @@ def count_ops(expr, visual=False):
     else:  # it's Basic not isinstance(expr, Expr):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")
-        elif expr.is_Boolean:
+        else:
             ops = []
             args = [expr]
             while args:
@@ -2336,10 +2336,9 @@ def count_ops(expr, visual=False):
                 args_len = len(a.args)
                 aargs = list(a.args)
                 for i in range(args_len):
-                    if aargs[i].is_Boolean:
+                    if not aargs[i].is_Symbol:
                         args.append(aargs[i])
-        else:
-            ops = [count_ops(a, visual=visual) for a in expr.args]
+        
 
     if not ops:
         if visual:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2323,21 +2323,21 @@ def count_ops(expr, visual=False):
         ops = [count_ops(i, visual=visual) for i in expr]
     elif not isinstance(expr, Basic):
         ops = []
-    elif expr.is_Boolean:
-        ops = []
-        args = [expr]
-        while args:
-            a = args.pop()
-            o = C.Symbol(a.func.__name__.upper())
-            ops.append(o*(len(a.args)-1))
-            args_len = len(a.args)
-            aargs = list(a.args)
-            for i in range(args_len):
-                if aargs[i].is_Boolean:
-                    args.append(aargs[i])
     else:  # it's Basic not isinstance(expr, Expr):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")
+        elif expr.is_Boolean:
+            ops = []
+            args = [expr]
+            while args:
+                a = args.pop()
+                o = C.Symbol(a.func.__name__.upper())
+                ops.append(o*(len(a.args)-1))
+                args_len = len(a.args)
+                aargs = list(a.args)
+                for i in range(args_len):
+                    if aargs[i].is_Boolean:
+                        args.append(aargs[i])
         ops = [count_ops(a, visual=visual) for a in expr.args]
 
     if not ops:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2336,7 +2336,7 @@ def count_ops(expr, visual=False):
                     not a.__class__.__name__ == 'Tuple'):
                     o = C.Symbol(a.func.__name__.upper())
                     ops.append(o*(len(a.args)-1))
-                if not a.args is ():
+                if not a.args == ():
                     args.extend(a.args)
 
     if not ops:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2331,9 +2331,9 @@ def count_ops(expr, visual=False):
             args = [expr]
             while args:
                 a = args.pop()
-                if (not a.args is () and
-                    not a.__class__.__name__ is 'Basic' and
-                    not a.__class__.__name__ is 'Tuple'):
+                if (not a.args == () and
+                    not a.__class__.__name__ == 'Basic' and
+                    not a.__class__.__name__ == 'Tuple'):
                     o = C.Symbol(a.func.__name__.upper())
                     ops.append(o*(len(a.args)-1))
                 if not a.args is ():

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1,6 +1,3 @@
-
-
-
 """
 There are three types of functions implemented in SymPy:
 

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2327,17 +2327,22 @@ def count_ops(expr, visual=False):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")
         else:
+            true = sympify(True)
+            false = sympify(False)
             ops = []
             args = [expr]
             while args:
                 a = args.pop()
                 o = C.Symbol(a.func.__name__.upper())
-                ops.append(o*(len(a.args)-1))
-                args_len = len(a.args)
-                aargs = list(a.args)
-                for i in range(args_len):
-                    if not aargs[i].is_Symbol:
-                        args.append(aargs[i])
+                if (not expr is true and not expr is false):
+                    ops.append(o*(len(a.args)-1))
+                    args_len = len(a.args)
+                    aargs = list(a.args)
+                    for i in range(args_len):
+                        if (not aargs[i].is_Symbol or
+                            (not aargs[i] is true and 
+                            not aargs[i] is false)) :
+                            args.append(aargs[i])
 
     if not ops:
         if visual:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2323,22 +2323,23 @@ def count_ops(expr, visual=False):
         ops = [count_ops(i, visual=visual) for i in expr]
     elif not isinstance(expr, Basic):
         ops = []
-    elif expr.is_Boolean:
-        ops = []
-        args = [expr]
-        while args:
-            a = args.pop()
-            o = C.Symbol(a.func.__name__.upper())
-            ops.append(o*(len(a.args)-1))
-            args_len = len(a.args)
-            aargs = list(a.args)
-            for i in range(args_len):
-                if aargs[i].is_Boolean:
-                    args.append(aargs[i])
     else:  # it's Basic not isinstance(expr, Expr):
         if not isinstance(expr, Basic):
             raise TypeError("Invalid type of expr")
-        ops = [count_ops(a, visual=visual) for a in expr.args]
+        elif expr.is_Boolean:
+            ops = []
+            args = [expr]
+            while args:
+                a = args.pop()
+                o = C.Symbol(a.func.__name__.upper())
+                ops.append(o*(len(a.args)-1))
+                args_len = len(a.args)
+                aargs = list(a.args)
+                for i in range(args_len):
+                    if aargs[i].is_Boolean:
+                        args.append(aargs[i])
+        else:
+            ops = [count_ops(a, visual=visual) for a in expr.args]
 
     if not ops:
         if visual:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1,3 +1,6 @@
+
+
+
 """
 There are three types of functions implemented in SymPy:
 
@@ -2333,16 +2336,15 @@ def count_ops(expr, visual=False):
             args = [expr]
             while args:
                 a = args.pop()
-                o = C.Symbol(a.func.__name__.upper())
-                if (not expr is true and not expr is false):
+                if (not a is true and
+                    not a is false and
+                    not a.is_Symbol and
+                    not a.__class__.__name__ is 'Basic' and
+                    not a.__class__.__name__ is 'Tuple'):
+                    o = C.Symbol(a.func.__name__.upper())
                     ops.append(o*(len(a.args)-1))
-                    args_len = len(a.args)
-                    aargs = list(a.args)
-                    for i in range(args_len):
-                        if (not aargs[i].is_Symbol and
-                            not  aargs[i] is true and
-                            not  aargs[i] is false):
-                            args.append(aargs[i])
+                if not a.is_Symbol:
+                    args.extend(a.args)
 
     if not ops:
         if visual:

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,5 +1,6 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
     count_ops, S, And, I, pi, Eq, Or, Not, Xor ,Nand ,Nor, Implies,Equivalent, ITE
+from sympy.core.containers import Tuple
 
 x, y, z = symbols('x,y,z')
 a, b, c = symbols('a,b,c')
@@ -92,7 +93,6 @@ def test_count_ops_visual():
     assert count(Basic()) == 0
     assert count(Basic(Basic(),Basic(x,x+y))) == ADD + 2*BASIC
     assert count(Basic(x, x + y)) == ADD + BASIC
-    assert count(Basic(Basic(), Basic(x,x+y))) ==  ADD + 2*BASIC
     assert count(Or(x,y)) == OR
     assert count(And(x,y)) == AND
     assert count(And(x**y,z)) == AND + POW
@@ -105,9 +105,8 @@ def test_count_ops_visual():
     assert count(ITE(x,y,z)) == 2*AND + OR
     assert count([Or(x,y), And(x,y), Basic(x+y)]) == ADD + AND + BASIC + OR
 
-    assert count(And((x,y),z)) == AND + TUPLE
-    # It doesn't make much sense but it checks that TUPLE is counted as an
-    # operation.
+    assert count(Basic(Tuple(x))) == BASIC + TUPLE
+    #It checks that TUPLE is counted as an operation.
 
     assert count(Eq(x + y, S(2))) == ADD
 

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -109,14 +109,3 @@ def test_count_ops_visual():
     #It checks that TUPLE is counted as an operation.
 
     assert count(Eq(x + y, S(2))) == ADD
-
-    # The test given below checks the results which comes when logical
-    # functions are given less number of arguments than required and
-    # don't raises an exception. They don't make much sense.
-    assert count(And((x,y+z))) == ADD
-    assert count(Equivalent(x)) == 0     # Equivalent(x) == 0
-    assert count(And(x)) == 0            # And(x) == 0
-    assert count(Nand(And(x,y))) == OR   # Nand(x) == Not(x)
-    assert count(Xor(And(x,y))) == AND   # Xor(x) == x
-    # Any logic function don't check if the argument is an empty tuple
-    assert count(And(x,())) == AND

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -23,6 +23,7 @@ def test_count_ops_non_visual():
     assert count(Implies(x,y)) == 1
     assert count(Equivalent(x,y)) == 1
     assert count(ITE(x,y,z)) == 3
+    assert count(ITE(True,x,y)) == 0
 
 def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
@@ -92,6 +93,7 @@ def test_count_ops_visual():
     assert count(Basic(Basic(), Basic(x,x+y))) ==  ADD
     assert count(Or(x,y)) == OR
     assert count(And(x,y)) == AND
+    assert count(And(x**y,z)) == AND + POW
     assert count(Or(x,Or(y,And(z,a)))) == AND + 2*OR
     assert count(Nor(x,y)) == AND
     assert count(Nand(x,y)) == OR
@@ -99,6 +101,20 @@ def test_count_ops_visual():
     assert count(Implies(x,y)) == IMPLIES
     assert count(Equivalent(x,y)) == EQUIVALENT
     assert count(ITE(x,y,z)) == 2*AND + OR
-    assert count(And((((x,y+z))))) == ADD
+
+    assert count(And((x,y),z)) == AND
+    # It doesn't make much sense but it checks that TUPLE is not counted as an
+    # operation.
 
     assert count(Eq(x + y, S(2))) == ADD
+
+    # The test given below checks the results which comes when logical
+    # functions are given less number of arguments than required and
+    # don't raises an exception. They don't make much sense.
+    assert count(And((x,y+z))) == ADD
+    assert count(Equivalent(x)) == 0     # Equivalent(x) == 0
+    assert count(And(x)) == 0            # And(x) == 0
+    assert count(Nand(And(x,y))) == OR   # Nand(x) == Not(x)
+    assert count(Xor(And(x,y))) == AND   # Xor(x) == x
+    # Any logic function don't check if the argument is an empty tuple
+    assert count(And(x,())) == AND

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -97,6 +97,5 @@ def test_count_ops_visual():
     assert count(Equivalent(x,y)) == EQUIVALENT
     assert count(ITE(x,y,z)) == 2*AND + OR
 
-    # XXX: These are a bit surprising, only Expr-compatible ops are counted.
     assert count(Basic(x, x + y)) == ADD
     assert count(Eq(x + y, S(2))) == ADD

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -29,8 +29,8 @@ def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
         'Add Mul Pow sin cos exp And Derivative Integral'.upper())
     DIV, SUB, NEG = symbols('DIV SUB NEG')
-    OR, AND, IMPLIES, EQUIVALENT = symbols(
-        'Or And Implies Equivalent'.upper())
+    OR, AND, IMPLIES, EQUIVALENT, BASIC, TUPLE = symbols(
+        'Or And Implies Equivalent Basic Tuple'.upper())
 
     def count(val):
         return count_ops(val, visual=True)
@@ -89,8 +89,10 @@ def test_count_ops_visual():
     assert count([x + 1, sin(x)*y, None]) == SIN + ADD + MUL
     assert count([]) is S.Zero
 
-    assert count(Basic(x, x + y)) == ADD
-    assert count(Basic(Basic(), Basic(x,x+y))) ==  ADD
+    assert count(Basic()) == 0
+    assert count(Basic(Basic(),Basic(x,x+y))) == ADD + 2*BASIC
+    assert count(Basic(x, x + y)) == ADD + BASIC
+    assert count(Basic(Basic(), Basic(x,x+y))) ==  ADD + 2*BASIC
     assert count(Or(x,y)) == OR
     assert count(And(x,y)) == AND
     assert count(And(x**y,z)) == AND + POW
@@ -101,9 +103,10 @@ def test_count_ops_visual():
     assert count(Implies(x,y)) == IMPLIES
     assert count(Equivalent(x,y)) == EQUIVALENT
     assert count(ITE(x,y,z)) == 2*AND + OR
+    assert count([Or(x,y), And(x,y), Basic(x+y)]) == ADD + AND + BASIC + OR
 
-    assert count(And((x,y),z)) == AND
-    # It doesn't make much sense but it checks that TUPLE is not counted as an
+    assert count(And((x,y),z)) == AND + TUPLE
+    # It doesn't make much sense but it checks that TUPLE is counted as an
     # operation.
 
     assert count(Eq(x + y, S(2))) == ADD

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -28,8 +28,8 @@ def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
         'Add Mul Pow sin cos exp And Derivative Integral'.upper())
     DIV, SUB, NEG = symbols('DIV SUB NEG')
-    OR, AND, XOR, NAND, NOR, IMPLIES, NOT, EQUIVALENT = symbols(
-        'Or And Xor Nand Nor Implies Not Equivalent'.upper())
+    OR, AND, NAND, NOR, IMPLIES, EQUIVALENT = symbols(
+        'Or And Nand Nor Implies Equivalent'.upper())
 
     def count(val):
         return count_ops(val, visual=True)
@@ -92,7 +92,7 @@ def test_count_ops_visual():
     assert count(And(x,y)) == AND
     assert count(Nor(x,y)) == NOR
     assert count(Nand(x,y)) == NAND
-    assert count(Xor(x,y)) == XOR
+    assert count(Xor(x,y)) == 2*AND + OR
     assert count(Implies(x,y)) == IMPLIES
     assert count(Equivalent(x,y)) == EQUIVALENT
     assert count(ITE(x,y,z)) == 2*AND + OR

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -1,5 +1,5 @@
 from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
-    count_ops, S, And, I, pi, Eq
+    count_ops, S, And, I, pi, Eq, Or, Not, Xor ,Nand ,Nor, Implies,Equivalent, ITE
 
 x, y, z = symbols('x,y,z')
 
@@ -14,12 +14,22 @@ def test_count_ops_non_visual():
     assert count(x + y*x + 2*y) == 4
     assert count({x + y: x}) == 1
     assert count({x + y: S(2) + x}) is not S.One
-
+    assert count(Or(x,y)) == 1
+    assert count(And(x,y)) == 1
+    assert count(Not(x)) == 0
+    assert count(Nor(x,y)) == 1
+    assert count(Nand(x,y)) == 1
+    assert count(Xor(x,y)) == 3
+    assert count(Implies(x,y)) == 1
+    assert count(Equivalent(x,y)) == 1
+    assert count(ITE(x,y,z)) == 3
 
 def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
         'Add Mul Pow sin cos exp And Derivative Integral'.upper())
     DIV, SUB, NEG = symbols('DIV SUB NEG')
+    OR, AND, XOR, NAND, NOR, IMPLIES, NOT, EQUIVALENT = symbols(
+        'Or And Xor Nand Nor Implies Not Equivalent'.upper())
 
     def count(val):
         return count_ops(val, visual=True)
@@ -77,6 +87,15 @@ def test_count_ops_visual():
     assert count({}) is S.Zero
     assert count([x + 1, sin(x)*y, None]) == SIN + ADD + MUL
     assert count([]) is S.Zero
+
+    assert count(Or(x,y)) == OR
+    assert count(And(x,y)) == AND
+    assert count(Nor(x,y)) == NOR
+    assert count(Nand(x,y)) == NAND
+    assert count(Xor(x,y)) == XOR
+    assert count(Implies(x,y)) == IMPLIES
+    assert count(Equivalent(x,y)) == EQUIVALENT
+    assert count(ITE(x,y,z)) == 2*AND + OR
 
     # XXX: These are a bit surprising, only Expr-compatible ops are counted.
     assert count(And(x, y, z)) == 0

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -2,7 +2,7 @@ from sympy import symbols, sin, exp, cos, Derivative, Integral, Basic, \
     count_ops, S, And, I, pi, Eq, Or, Not, Xor ,Nand ,Nor, Implies,Equivalent, ITE
 
 x, y, z = symbols('x,y,z')
-
+a, b, c = symbols('a,b,c')
 
 def test_count_ops_non_visual():
     def count(val):
@@ -79,6 +79,7 @@ def test_count_ops_visual():
 
     assert count(Derivative(x, x)) == D
     assert count(Integral(x, x) + 2*x/(1 + x)) == G + DIV + MUL + 2*ADD
+    assert count(Basic()) is S.Zero
 
     assert count({x + 1: sin(x)}) == ADD + SIN
     assert count([x + 1, sin(x) + y, None]) == ADD + SIN + ADD
@@ -87,13 +88,17 @@ def test_count_ops_visual():
     assert count([x + 1, sin(x)*y, None]) == SIN + ADD + MUL
     assert count([]) is S.Zero
 
+    assert count(Basic(x, x + y)) == ADD
+    assert count(Basic(Basic(), Basic(x,x+y))) ==  ADD
     assert count(Or(x,y)) == OR
     assert count(And(x,y)) == AND
+    assert count(Or(x,Or(y,And(z,a)))) == AND + 2*OR
     assert count(Nor(x,y)) == AND
     assert count(Nand(x,y)) == OR
     assert count(Xor(x,y)) == 2*AND + OR
     assert count(Implies(x,y)) == IMPLIES
     assert count(Equivalent(x,y)) == EQUIVALENT
     assert count(ITE(x,y,z)) == 2*AND + OR
+    assert count(And((((x,y+z))))) == ADD
 
     assert count(Eq(x + y, S(2))) == ADD

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -28,8 +28,8 @@ def test_count_ops_visual():
     ADD, MUL, POW, SIN, COS, EXP, AND, D, G = symbols(
         'Add Mul Pow sin cos exp And Derivative Integral'.upper())
     DIV, SUB, NEG = symbols('DIV SUB NEG')
-    OR, AND, NAND, NOR, IMPLIES, EQUIVALENT = symbols(
-        'Or And Nand Nor Implies Equivalent'.upper())
+    OR, AND, IMPLIES, EQUIVALENT = symbols(
+        'Or And Implies Equivalent'.upper())
 
     def count(val):
         return count_ops(val, visual=True)
@@ -90,8 +90,8 @@ def test_count_ops_visual():
 
     assert count(Or(x,y)) == OR
     assert count(And(x,y)) == AND
-    assert count(Nor(x,y)) == NOR
-    assert count(Nand(x,y)) == NAND
+    assert count(Nor(x,y)) == AND
+    assert count(Nand(x,y)) == OR
     assert count(Xor(x,y)) == 2*AND + OR
     assert count(Implies(x,y)) == IMPLIES
     assert count(Equivalent(x,y)) == EQUIVALENT

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -79,7 +79,6 @@ def test_count_ops_visual():
 
     assert count(Derivative(x, x)) == D
     assert count(Integral(x, x) + 2*x/(1 + x)) == G + DIV + MUL + 2*ADD
-    assert count(Basic()) is S.Zero
 
     assert count({x + 1: sin(x)}) == ADD + SIN
     assert count([x + 1, sin(x) + y, None]) == ADD + SIN + ADD
@@ -97,5 +96,4 @@ def test_count_ops_visual():
     assert count(Equivalent(x,y)) == EQUIVALENT
     assert count(ITE(x,y,z)) == 2*AND + OR
 
-    assert count(Basic(x, x + y)) == ADD
     assert count(Eq(x + y, S(2))) == ADD

--- a/sympy/core/tests/test_count_ops.py
+++ b/sympy/core/tests/test_count_ops.py
@@ -98,6 +98,5 @@ def test_count_ops_visual():
     assert count(ITE(x,y,z)) == 2*AND + OR
 
     # XXX: These are a bit surprising, only Expr-compatible ops are counted.
-    assert count(And(x, y, z)) == 0
     assert count(Basic(x, x + y)) == ADD
     assert count(Eq(x + y, S(2))) == ADD


### PR DESCRIPTION
Bug was that Logic functions are not the instance of sympy.core.expr.Expr due to which logic operation were actually skipping to "else" case. 

Fixes #7010
