### PR TITLE
fixes factor(), separatevars(), combsimp() from Issue #6280

### DIFF
--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -100,10 +100,6 @@ class Operator(QExpr):
     def default_args(self):
         return ("O",)
 
-    @property
-    def free_symbols(self):
-        return set([self])
-
     #-------------------------------------------------------------------------
     # Printing
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/operator.py
+++ b/sympy/physics/quantum/operator.py
@@ -100,6 +100,10 @@ class Operator(QExpr):
     def default_args(self):
         return ("O",)
 
+    @property
+    def free_symbols(self):
+        return set([self])
+
     #-------------------------------------------------------------------------
     # Printing
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -96,7 +96,9 @@ class QExpr(Expr):
     # The separator used in printing the label.
     _label_separator = u('')
 
-    is_commutative = False
+    @property
+    def free_symbols(self):
+        return set([self])
 
     def __new__(cls, *args, **old_assumptions):
         """Construct a new quantum object.

--- a/sympy/physics/quantum/tests/test_qexpr.py
+++ b/sympy/physics/quantum/tests/test_qexpr.py
@@ -32,9 +32,6 @@ def test_qexpr_commutative():
     assert q.is_commutative is False
 
 def test_qexpr_commutative_free_symbols():
-    """
-    Simplifying functions rely on that behavior
-    """
     q1 = QExpr(x)
     assert q1.free_symbols.pop().is_commutative is False
 

--- a/sympy/physics/quantum/tests/test_qexpr.py
+++ b/sympy/physics/quantum/tests/test_qexpr.py
@@ -31,6 +31,15 @@ def test_qexpr_commutative():
     q = QExpr._new_rawargs(0, 1, HilbertSpace())
     assert q.is_commutative is False
 
+def test_qexpr_commutative_free_symbols():
+    """
+    Simplifying functions rely on that behavior
+    """
+    q1 = QExpr(x)
+    assert q1.free_symbols.pop().is_commutative is False
+
+    q2 = QExpr('q2')
+    assert q2.free_symbols.pop().is_commutative is False
 
 def test_qexpr_subs():
     q1 = QExpr(x, y)


### PR DESCRIPTION
- [x] delete comment string in test

This fixes 3 of 5 wrong results in Issue #6280.
Two other wrong results is due to Issue #3741.

This code prevents **free_symbols** property from falling back to **Symbol**'s **free_symbols** where this method intefere with **Symbol**'s default noncommutativity, so we had such behavior: 

``` python
>>> A = Operator('A')
>>> A.is_commutative
False
>>> A.free_symbols
set([A])
>>> A.free_symbols.pop().is_commutative
True
```

If we define **free_symbols** explicitly, then things became normal:

``` python
>>> A.free_symbols.pop().is_commutative
False
```

After that loop in **_mask_nc** that is used in errand functions works in right way, and we have normal behavior:

``` python
>>> A = Operator('A')
>>> B = Operator('B')
>>> Z = A*B-B*A
>>> combsimp(Z)
A*B - B*A
>>> factor(Z)
A*B - B*A
>>> separatevars(Z)
A*B - B*A
```

As for **collect**, it is not working right even for plain nc-symbols, so it more about Issue #3741.
