### PR TITLE
quantum.TensorProduct now suports sympy.Identity

### DIFF
--- a/sympy/physics/quantum/tensorproduct.py
+++ b/sympy/physics/quantum/tensorproduct.py
@@ -6,6 +6,7 @@ from sympy import Expr, Add, Mul, Matrix, Pow, sympify
 from sympy.core.compatibility import u
 from sympy.core.trace import Tr
 from sympy.printing.pretty.stringpict import prettyForm
+from sympy.matrices.expressions.matexpr import Identity
 
 from sympy.physics.quantum.qexpr import QuantumError
 from sympy.physics.quantum.dagger import Dagger
@@ -98,7 +99,7 @@ class TensorProduct(Expr):
     is_commutative = False
 
     def __new__(cls, *args):
-        if isinstance(args[0], (Matrix, numpy_ndarray, scipy_sparse_matrix)):
+        if isinstance(args[0], (Matrix, Identity, numpy_ndarray, scipy_sparse_matrix)):
             return matrix_tensor_product(*args)
         c_part, new_args = cls.flatten(sympify(args))
         c_part = Mul(*c_part)

--- a/sympy/physics/quantum/tests/test_tensorproduct.py
+++ b/sympy/physics/quantum/tests/test_tensorproduct.py
@@ -1,4 +1,5 @@
 from sympy import I, symbols, Matrix
+from sympy.matrices.expressions.matexpr import Identity
 
 from sympy.physics.quantum.commutator import Commutator as Comm
 from sympy.physics.quantum.tensorproduct import TensorProduct
@@ -105,3 +106,10 @@ def test_eval_trace():
                         1.0*A*Dagger(C)*Tr(B*Dagger(D)) +
                         1.0*C*Dagger(A)*Tr(D*Dagger(B)) +
                         1.0*C*Dagger(C)*Tr(D*Dagger(D)))
+
+
+def test_tensor_product_identity():
+    assert (TensorProduct(Identity(2), mat1)) == \
+        TensorProduct(Matrix(Identity(2)), mat1)
+    assert (TensorProduct(mat1, Identity(2))) == \
+        TensorProduct(mat1, Matrix(Identity(2)))


### PR DESCRIPTION
`quantum.TensorProduct` used to throw exceptions when used with `sympy.Identity`.
The exceptions were different depending on whether or not the identity was the first element of the product or not.  This fix allows `sympy.Identity` to be used in any position of the product.

This syntax can now be used:

``` python
TensorProduct(Identity(2), Matrix([[1, 1], [1, -1]]))
```

Instead of:

``` python
TensorProduct(Matrix(Identity(2)), Matrix([[1, 1], [1, -1]]))
```
