### PR TITLE
DocFix: Replaced import mpmath with import sympy.mpmath

### DIFF
--- a/sympy/mpmath/calculus/approximation.py
+++ b/sympy/mpmath/calculus/approximation.py
@@ -60,7 +60,7 @@ def chebyfit(ctx, f, interval, N, error=False):
     Here we use :func:`~mpmath.chebyfit` to generate a low-degree approximation
     of `f(x) = \cos(x)`, valid on the interval `[1, 2]`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> poly, err = chebyfit(cos, [1, 2], 5, error=True)
         >>> nprint(poly)
@@ -162,7 +162,7 @@ def fourier(ctx, f, interval, N):
     the function has odd symmetry), and the sine coefficients are
     rational numbers::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> c, s = fourier(lambda x: x, [-pi, pi], 5)
         >>> nprint(c)

--- a/sympy/mpmath/calculus/differentiation.py
+++ b/sympy/mpmath/calculus/differentiation.py
@@ -71,7 +71,7 @@ def diff(ctx, f, x, n=1, **options):
     an integer `n \ge 0`, the `n`-th derivative `f^{(n)}(x)`.
     A few basic examples are::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> diff(lambda x: x**2 + x, 1.0)
         3.0
@@ -243,7 +243,7 @@ def diffs(ctx, f, x, n=None, **options):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15
         >>> nprint(list(diffs(cos, 1, 5)))
         [0.540302, -0.841471, -0.540302, 0.841471, 0.540302, -0.841471]
@@ -320,7 +320,7 @@ def diffs_prod(ctx, factors):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> f = lambda x: exp(x)*cos(x)*sin(x)
         >>> u = diffs(f, 1)
@@ -408,7 +408,7 @@ def diffs_exp(ctx, fdiffs):
     The derivatives of the gamma function can be computed using
     logarithmic differentiation::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>>
         >>> def diffs_loggamma(x):
@@ -476,7 +476,7 @@ def differint(ctx, f, x, n=1, x0=0):
     monomial `x^p`, which may be used as a reference. For example,
     the following gives a half-derivative (order 0.5)::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> x = mpf(3); p = 2; n = 0.5
         >>> differint(lambda t: t**p, x, n)
@@ -524,7 +524,7 @@ def diffun(ctx, f, n=1, **options):
     Given a function `f`, returns a function `g(x)` that evaluates the nth
     derivative `f^{(n)}(x)`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> cos2 = diffun(sin)
         >>> sin2 = diffun(sin, 4)
@@ -549,7 +549,7 @@ def taylor(ctx, f, x, n, **options):
     Produces a degree-`n` Taylor polynomial around the point `x` of the
     given function `f`. The coefficients are returned as a list.
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> nprint(chop(taylor(sin, 0, 5)))
         [0.0, 1.0, 0.0, -0.166667, 0.0, 0.00833333]
@@ -600,7 +600,7 @@ def pade(ctx, a, L, M):
     from G.A. Baker 'Essentials of Pade Approximants' Academic Press,
     Ch.1A)::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> one = mpf(1)
         >>> def f(x):

--- a/sympy/mpmath/calculus/extrapolation.py
+++ b/sympy/mpmath/calculus/extrapolation.py
@@ -56,7 +56,7 @@ def richardson(ctx, seq):
 
     Applying Richardson extrapolation to the Leibniz series for `\pi`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 30; mp.pretty = True
         >>> S = [4*sum(mpf(-1)**n/(2*n+1) for n in range(m))
         ...     for m in range(1,30)]
@@ -175,7 +175,7 @@ def shanks(ctx, seq, table=None, randomized=False):
     We illustrate by applying Shanks transformation to the Leibniz
     series for `\pi`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 50
         >>> S = [4*sum(mpf(-1)**n/(2*n+1) for n in range(m))
         ...     for m in range(1,30)]
@@ -367,7 +367,7 @@ class levin_class:
 
     First we sum the zeta function::
 
-        >>> from mpmath import mp
+        >>> from sympy.mpmath import mp
         >>> mp.prec = 53
         >>> eps = mp.mpf(mp.eps)
         >>> with mp.extraprec(2 * mp.prec): # levin needs a high working precision
@@ -769,7 +769,7 @@ class cohen_alt_class:
 
     Here we compute the alternating zeta function using ``update_psum``::
 
-        >>> from mpmath import mp
+        >>> from sympy.mpmath import mp
         >>> AC = mp.cohen_alt()
         >>> S, s, n = [], 0, 1
         >>> while 1:
@@ -916,7 +916,7 @@ def sumap(ctx, f, interval, integral=None, error=False):
     decreases like a power of `k`; for example when the sum is a pure
     zeta function::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> sumap(lambda k: 1/k**2.5, [1,inf])
         1.34148725725091717975677
@@ -1015,7 +1015,7 @@ def sumem(ctx, f, interval, tol=None, reject=10, integral=None,
     Summation of an infinite series, with automatic and symbolic
     integral and derivative values (the second should be much faster)::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 50; mp.pretty = True
         >>> sumem(lambda n: 1/n**2, [32, inf])
         0.03174336652030209012658168043874142714132886413417
@@ -1264,7 +1264,7 @@ def nsum(ctx, f, *intervals, **options):
     where the first converges rapidly and the second converges slowly,
     are::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> nsum(lambda n: 1/fac(n), [0, inf])
         2.71828182845905
@@ -1863,7 +1863,7 @@ def nprod(ctx, f, interval, nsum=False, **kwargs):
 
     A simple finite product::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> nprod(lambda k: k, [1, 4])
         24.0
@@ -2042,7 +2042,7 @@ def limit(ctx, f, x, direction=1, exp=False, **kwargs):
 
     A basic evaluation of a removable singularity::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 30; mp.pretty = True
         >>> limit(lambda x: (x-sin(x))/x**3, 0)
         0.166666666666666666666666666667

--- a/sympy/mpmath/calculus/odes.py
+++ b/sympy/mpmath/calculus/odes.py
@@ -122,7 +122,7 @@ def odefun(ctx, F, x0, y0, tol=None, degree=None, method='taylor', verbose=False
     We will solve the standard test problem `y'(x) = y(x), y(0) = 1`
     which has explicit solution `y(x) = \exp(x)`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> f = odefun(lambda x, y: y, 0, 1)
         >>> for x in [0, 1, 2.5]:

--- a/sympy/mpmath/calculus/optimization.py
+++ b/sympy/mpmath/calculus/optimization.py
@@ -742,7 +742,7 @@ def findroot(ctx, f, x0, solver=Secant, tol=None, verbose=False, verify=True, **
     secant method by default. A simple example use of the secant method is to
     compute `\pi` as the root of `\sin x` closest to `x_0 = 3`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 30; mp.pretty = True
         >>> findroot(sin, 3)
         3.14159265358979323846264338328
@@ -987,7 +987,7 @@ def multiplicity(ctx, f, root, tol=None, maxsteps=10, **kwargs):
     evaluating 10 derivatives by default. You can be specify the n-th derivative
     using the dnf keyword.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> multiplicity(lambda x: sin(x) - 1, pi/2)
     2
 
@@ -1029,7 +1029,7 @@ def steffensen(f):
     Let's try Steffensen's method:
 
     >>> f = lambda x: x**2
-    >>> from mpmath.optimization import steffensen
+    >>> from sympy.mpmath.optimization import steffensen
     >>> F = steffensen(f)
     >>> for x in [0.5, 0.9, 2.0]:
     ...     fx = Fx = x

--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -20,7 +20,7 @@ def polyval(ctx, coeffs, x, derivative=False):
     evaluates `P(x)` with the derivative, `P'(x)`, and returns the
     tuple `(P(x), P'(x))`.
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.pretty = True
         >>> polyval([3, 0, 2], 0.5)
         2.75
@@ -59,7 +59,7 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
 
     Finding the three real roots of `x^3 - x^2 - 14x + 24`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> nprint(polyroots([1,-1,-14,24]), 4)
         [-4.0, 2.0, 3.0]

--- a/sympy/mpmath/calculus/quadrature.py
+++ b/sympy/mpmath/calculus/quadrature.py
@@ -464,7 +464,7 @@ class QuadratureMethods(object):
         Computes a single, double or triple integral over a given
         1D interval, 2D rectangle, or 3D cuboid. A basic example::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> quad(sin, [0, pi])
             2.0
@@ -840,7 +840,7 @@ class QuadratureMethods(object):
         specify the `n`-th zero by providing the *zeros* arguments.
         Below is an example of each::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> f = lambda x: sin(3*x)/(x**2+1)
             >>> quadosc(f, [0,inf], omega=3)

--- a/sympy/mpmath/ctx_base.py
+++ b/sympy/mpmath/ctx_base.py
@@ -128,7 +128,7 @@ class StandardBaseContext(Context,
         numbers close to zero to exact zeros. The input can be a
         single number or an iterable::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> chop(5+1e-10j, tol=1e-9)
             mpf('5.0')
@@ -177,7 +177,7 @@ class StandardBaseContext(Context,
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15
             >>> almosteq(3.141592653589793, 3.141592653589790)
             True
@@ -231,7 +231,7 @@ class StandardBaseContext(Context,
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> arange(4)
             [mpf('0.0'), mpf('1.0'), mpf('2.0'), mpf('3.0')]
@@ -292,7 +292,7 @@ class StandardBaseContext(Context,
         for partitioning an interval into subintervals, since
         the endpoint is included::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> linspace(1, 4, 4)
             [mpf('1.0'), mpf('2.0'), mpf('3.0'), mpf('4.0')]
@@ -411,7 +411,7 @@ class StandardBaseContext(Context,
         r"""Converts `x` and `y` to mpmath numbers and evaluates
         `x^y = \exp(y \log(x))`::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 30; mp.pretty = True
             >>> power(2, 0.5)
             1.41421356237309504880168872421
@@ -433,7 +433,7 @@ class StandardBaseContext(Context,
         Return a wrapped copy of *f* that raises ``NoConvergence`` when *f*
         has been called more than *N* times::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15
             >>> f = maxcalls(sin, 10)
             >>> print(sum(f(n) for n in range(10)))
@@ -458,7 +458,7 @@ class StandardBaseContext(Context,
         a memoized copy of *f*. Values are only reused if the cached precision
         is equal to or higher than the working precision::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> f = memoize(maxcalls(sin, 1))
             >>> f(2)

--- a/sympy/mpmath/ctx_mp.py
+++ b/sympy/mpmath/ctx_mp.py
@@ -321,7 +321,7 @@ class MPContext(BaseMPContext, StandardBaseContext):
         number, whether either the real or complex part is NaN;
         otherwise return *False*::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> isnan(3.14)
             False
             >>> isnan(nan)
@@ -348,7 +348,7 @@ class MPContext(BaseMPContext, StandardBaseContext):
         Return *True* if *x* is a finite number, i.e. neither
         an infinity or a NaN.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> isfinite(inf)
             False
             >>> isfinite(-inf)
@@ -474,7 +474,7 @@ class MPContext(BaseMPContext, StandardBaseContext):
         to binary at a much higher precision. If the amount of required
         extra precision is unknown, :func:`~mpmath.autoprec` is convenient::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15
             >>> mp.pretty = True
             >>> besselj(5, 125 * 10**28)    # Exact input
@@ -575,7 +575,7 @@ class MPContext(BaseMPContext, StandardBaseContext):
         The companion function :func:`~mpmath.nprint` prints the result
         instead of returning it.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> nstr([+pi, ldexp(1,-500)])
             '[3.14159, 3.05494e-151]'
             >>> nprint([+pi, ldexp(1,-500)])
@@ -734,7 +734,7 @@ maxterms, or set zeroprec."""
         The argument `x` must be a real floating-point number (or
         possible to convert into one) and `n` must be a Python ``int``.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> ldexp(1, 10)
             mpf('1024.0')
@@ -751,7 +751,7 @@ maxterms, or set zeroprec."""
         `n` a Python integer, and such that `x = y 2^n`. No rounding is
         performed.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> frexp(7.5)
             (mpf('0.9375'), 3)
@@ -773,7 +773,7 @@ maxterms, or set zeroprec."""
 
         An mpmath number is returned::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fneg(2.5)
             mpf('-2.5')
@@ -835,7 +835,7 @@ maxterms, or set zeroprec."""
 
         Using :func:`~mpmath.fadd` with precision and rounding control::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fadd(2, 1e-20)
             mpf('2.0')
@@ -901,7 +901,7 @@ maxterms, or set zeroprec."""
 
         Using :func:`~mpmath.fsub` with precision and rounding control::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fsub(2, 1e-20)
             mpf('2.0')
@@ -967,7 +967,7 @@ maxterms, or set zeroprec."""
 
         The result is an mpmath number::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fmul(2, 5.0)
             mpf('10.0')
@@ -1036,7 +1036,7 @@ maxterms, or set zeroprec."""
 
         The result is an mpmath number::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fdiv(3, 2)
             mpf('1.5')
@@ -1096,7 +1096,7 @@ maxterms, or set zeroprec."""
         an estimate of `\log_2(|x-n|)`. If `d < 0`, `-d` gives the precision
         (measured in bits) lost to cancellation when computing `x-n`.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> n, d = nint_distance(5)
             >>> print(n); print(d)
             5
@@ -1194,7 +1194,7 @@ maxterms, or set zeroprec."""
         infinite products, see :func:`~mpmath.nprod`). The factors will be
         converted to mpmath numbers.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fprod([1, 2, 0.5, 7])
             mpf('7.0')
@@ -1222,7 +1222,7 @@ maxterms, or set zeroprec."""
         Given Python integers `(p, q)`, returns a lazy ``mpf`` representing
         the fraction `p/q`. The value is updated with the precision.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15
             >>> a = fraction(1,100)
             >>> b = mpf(1)/100

--- a/sympy/mpmath/ctx_mp_python.py
+++ b/sympy/mpmath/ctx_mp_python.py
@@ -628,7 +628,7 @@ class PythonMPContext(object):
         working precision. Strings representing fractions or complex
         numbers are permitted.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> mpmathify(3.5)
             mpf('3.5')
@@ -667,7 +667,7 @@ class PythonMPContext(object):
         number, whether either the real or complex part is NaN;
         otherwise return *False*::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> isnan(3.14)
             False
             >>> isnan(nan)
@@ -694,7 +694,7 @@ class PythonMPContext(object):
         Return *True* if the absolute value of *x* is infinite;
         otherwise return *False*::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> isinf(inf)
             True
             >>> isinf(-inf)
@@ -729,7 +729,7 @@ class PythonMPContext(object):
         complex number *x* is considered "normal" if its magnitude is
         normal::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> isnormal(3)
             True
             >>> isnormal(0)
@@ -766,7 +766,7 @@ class PythonMPContext(object):
         Return *True* if *x* is integer-valued; otherwise return
         *False*::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> isint(3)
             True
             >>> isint(mpf(3))
@@ -816,7 +816,7 @@ class PythonMPContext(object):
         faster and produces more accurate results than the builtin
         Python function :func:`sum`.
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> fsum([1, 2, 0.5, 7])
             mpf('10.5')
@@ -896,7 +896,7 @@ class PythonMPContext(object):
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> A = [2, 1.5, 3]
             >>> B = [1, -1, 2]
@@ -1090,7 +1090,7 @@ class PythonMPContext(object):
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.pretty = True
             >>> mag(10), mag(10.0), mag(mpf(10)), int(ceil(log(10,2)))
             (4, 4, 4, 4)

--- a/sympy/mpmath/function_docs.py
+++ b/sympy/mpmath/function_docs.py
@@ -10,7 +10,7 @@ things in mathematics.
 
 Mpmath can evaluate `\pi` to arbitrary precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +pi
     3.1415926535897932384626433832795028841971693993751
@@ -48,7 +48,7 @@ Represents one degree of angle, `1^{\circ} = \pi/180`, or
 about 0.01745329. This constant may be evaluated to arbitrary
 precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +degree
     0.017453292519943295769236907684886127134428718885417
@@ -69,7 +69,7 @@ natural logarithm (:func:`~mpmath.ln`) and of the exponential function
 
 Mpmath can be evaluate `e` to arbitrary precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +e
     2.7182818284590452353602874713526624977572470937
@@ -97,7 +97,7 @@ Represents the golden ratio `\phi = (1+\sqrt 5)/2`,
 approximately equal to 1.6180339887. To high precision,
 its value is::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +phi
     1.6180339887498948482045868343656381177203091798058
@@ -126,7 +126,7 @@ number (see :func:`~mpmath.harmonic`).
 
 Evaluation of `\gamma` is supported at arbitrary precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +euler
     0.57721566490153286060651209008240243104215933593992
@@ -180,7 +180,7 @@ series
 
 Mpmath can evaluate it to arbitrary precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +catalan
     0.91596559417721901505460351493238411077414937428167
@@ -223,7 +223,7 @@ Khinchin's constant `K` = 2.68542... is a number that
 appears in the theory of continued fractions. Mpmath can evaluate
 it to arbitrary precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +khinchin
     2.6854520010653064453097148354817956938203822939945
@@ -255,7 +255,7 @@ The constant is defined  as `A = \exp(1/12-\zeta'(-1))` where
 
 Mpmath can evaluate Glaisher's constant to arbitrary precision:
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +glaisher
     1.282427129100622636875342568869791727767688927325
@@ -296,7 +296,7 @@ approximately equal to 1.2020569 given by
 The calculation is based on an efficient hypergeometric
 series. To 50 decimal places, the value is given by::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +apery
     1.2020569031595942853997381615114499907649862923405
@@ -336,7 +336,7 @@ the prime reciprocal constant.
 
 The following gives the Mertens constant to 50 digits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +mertens
     0.2614972128476427837554268386086958590515666482612
@@ -362,7 +362,7 @@ It is given by the product over primes
 
 Computing `C_2` to 50 digits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 50; mp.pretty = True
     >>> +twinprime
     0.66016181584686957392781211001455577843262336028473
@@ -389,7 +389,7 @@ performing ``x**0.5``.
 
 Basic examples and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> sqrt(10)
     3.16227766016838
@@ -426,7 +426,7 @@ cbrt = r"""
 function is faster and more accurate than raising to a floating-point
 fraction::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> 125**(mpf(1)/3)
     mpf('4.9999999999999991')
@@ -460,7 +460,7 @@ For complex numbers, the exponential function also satisfies
 
 Some values of the exponential function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> exp(0)
     1.0
@@ -538,7 +538,7 @@ cosh = r"""
 Computes the hyperbolic cosine of `x`,
 `\cosh(x) = (e^x + e^{-x})/2`. Values and limits include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> cosh(0)
     1.0
@@ -568,7 +568,7 @@ sinh = r"""
 Computes the hyperbolic sine of `x`,
 `\sinh(x) = (e^x - e^{-x})/2`. Values and limits include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> sinh(0)
     0.0
@@ -597,7 +597,7 @@ tanh = r"""
 Computes the hyperbolic tangent of `x`,
 `\tanh(x) = \sinh(x)/\cosh(x)`. Values and limits include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> tanh(0)
     0.0
@@ -626,7 +626,7 @@ the argument; more precisely, `\tanh x = -i \tan ix`::
 cos = r"""
 Computes the cosine of `x`, `\cos(x)`.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> cos(pi/3)
     0.5
@@ -651,7 +651,7 @@ Intervals are supported via :func:`mpmath.iv.cos`::
 sin = r"""
 Computes the sine of `x`, `\sin(x)`.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> sin(pi/3)
     0.8660254037844386467637232
@@ -679,7 +679,7 @@ The tangent function is singular at `x = (n+1/2)\pi`, but
 ``tan(x)`` always returns a finite result since `(n+1/2)\pi`
 cannot be represented exactly using floating-point arithmetic.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> tan(pi/3)
     1.732050807568877293527446
@@ -707,7 +707,7 @@ The secant function is singular at `x = (n+1/2)\pi`, but
 ``sec(x)`` always returns a finite result since `(n+1/2)\pi`
 cannot be represented exactly using floating-point arithmetic.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> sec(pi/3)
     2.0
@@ -736,7 +736,7 @@ exception of the point `x = 0`, ``csc(x)`` returns a finite result
 since `n \pi` cannot be represented exactly using floating-point
 arithmetic.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> csc(pi/3)
     1.154700538379251529018298
@@ -764,7 +764,7 @@ exception of the point `x = 0`, ``cot(x)`` returns a finite result
 since `n \pi` cannot be represented exactly using floating-point
 arithmetic.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> cot(pi/3)
     0.5773502691896257645091488
@@ -793,7 +793,7 @@ function assuming values between `+\pi` and `0`.
 
 Basic values are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> acos(-1)
     3.141592653589793238462643
@@ -838,7 +838,7 @@ function assuming values between `-\pi/2` and `\pi/2`.
 
 Basic values are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> asin(-1)
     -1.570796326794896619231322
@@ -881,7 +881,7 @@ This is a real-valued function for all real `x`, with range
 
 Basic values are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> atan(-inf)
     -1.570796326794896619231322
@@ -974,7 +974,7 @@ sinpi = r"""
 Computes `\sin(\pi x)`, more accurately than the expression
 ``sin(pi*x)``::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> sinpi(10**10), sin(pi*(10**10))
     (0.0, -2.23936276195592e-6)
@@ -986,7 +986,7 @@ cospi = r"""
 Computes `\cos(\pi x)`, more accurately than the expression
 ``cos(pi*x)``::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> cospi(10**10), cos(pi*(10**10))
     (1.0, 0.999999999997493)
@@ -1008,7 +1008,7 @@ See :func:`~mpmath.sincpi` for the normalized sinc function.
 
 Simple values and limits include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> sinc(0)
     1.0
@@ -1041,7 +1041,7 @@ Equivalently, we have
 The normalization entails that the function integrates
 to unity over the entire real line::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> quadosc(sincpi, [-inf, inf], period=2.0)
     1.0
@@ -1056,7 +1056,7 @@ at its roots::
 expj = r"""
 Convenience function for computing `e^{ix}`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> expj(0)
     (1.0 + 0.0j)
@@ -1073,7 +1073,7 @@ Convenience function for computing `e^{i \pi x}`.
 Evaluation is accurate near zeros (see also :func:`~mpmath.cospi`,
 :func:`~mpmath.sinpi`)::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> expjpi(0)
     (1.0 + 0.0j)
@@ -1093,7 +1093,7 @@ floor = r"""
 Computes the floor of `x`, `\lfloor x \rfloor`, defined as
 the largest integer less than or equal to `x`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.pretty = False
     >>> floor(3.5)
     mpf('3.0')
@@ -1125,7 +1125,7 @@ ceil = r"""
 Computes the ceiling of `x`, `\lceil x \rceil`, defined as
 the smallest integer greater than or equal to `x`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.pretty = False
     >>> ceil(3.5)
     mpf('4.0')
@@ -1144,7 +1144,7 @@ Evaluates the nearest integer function, `\mathrm{nint}(x)`.
 This gives the nearest integer to `x`; on a tie, it
 gives the nearest even integer::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.pretty = False
     >>> nint(3.2)
     mpf('3.0')
@@ -1170,7 +1170,7 @@ Gives the fractional part of `x`, defined as
 In effect, this computes `x` modulo 1, or `x+n` where
 `n \in \mathbb{Z}` is such that `x+n \in [0,1)`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.pretty = False
     >>> frac(1.25)
     mpf('0.25')
@@ -1208,7 +1208,7 @@ sign = r"""
 Returns the sign of `x`, defined as `\mathrm{sign}(x) = x / |x|`
 (with the special case `\mathrm{sign}(0) = 0`)::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> sign(10)
     mpf('1.0')
@@ -1231,7 +1231,7 @@ Computes the complex argument (phase) of `x`, defined as the
 signed angle between the positive real axis and `x` in the
 complex plane::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> arg(3)
     0.0
@@ -1256,7 +1256,7 @@ Returns the absolute value of `x`, `|x|`. Unlike :func:`abs`,
 :func:`~mpmath.fabs` converts non-mpmath numbers (such as ``int``)
 into mpmath numbers::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> fabs(3)
     mpf('3.0')
@@ -1270,7 +1270,7 @@ re = r"""
 Returns the real part of `x`, `\Re(x)`. Unlike ``x.real``,
 :func:`~mpmath.re` converts `x` to a mpmath number::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> re(3)
     mpf('3.0')
@@ -1282,7 +1282,7 @@ im = r"""
 Returns the imaginary part of `x`, `\Im(x)`. Unlike ``x.imag``,
 :func:`~mpmath.im` converts `x` to a mpmath number::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> im(3)
     mpf('0.0')
@@ -1294,7 +1294,7 @@ conj = r"""
 Returns the complex conjugate of `x`, `\overline{x}`. Unlike
 ``x.conjugate()``, :func:`~mpmath.im` converts `x` to a mpmath number::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> conj(3)
     mpf('3.0')
@@ -1306,7 +1306,7 @@ polar = r"""
 Returns the polar representation of the complex number `z`
 as a pair `(r, \phi)` such that `z = r e^{i \phi}`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> polar(-2)
     (2.0, 3.14159265358979)
@@ -1318,7 +1318,7 @@ rect = r"""
 Returns the complex number represented by polar
 coordinates `(r, \phi)`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> chop(rect(2, pi))
     -2.0
@@ -1332,7 +1332,7 @@ Computes `e^x - 1`, accurately for small `x`.
 Unlike the expression ``exp(x) - 1``, ``expm1(x)`` does not suffer from
 potentially catastrophic cancellation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> exp(1e-10)-1; print(expm1(1e-10))
     1.00000008274037e-10
@@ -1361,7 +1361,7 @@ Computes `x^y - 1`, accurately when `x^y` is very close to 1.
 
 This avoids potentially catastrophic cancellation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> power(0.99999995, 1e-10) - 1
     0.0
@@ -1426,7 +1426,7 @@ expensive than the regular exponentiation, `x^n`. For very large
 :func:`~mpmath.nthroot`/:func:`~mpmath.root` is faster and more accurate than raising to a
 floating-point fraction::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = False
     >>> 16807 ** (mpf(1)/5)
     mpf('7.0000000000000009')
@@ -1504,7 +1504,7 @@ with `\zeta_0 = 1`.
 
 The roots of unity up to `n = 4`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> nprint(unitroots(1))
     [1.0]
@@ -1586,7 +1586,7 @@ used, meaning that `\Im(\ln(x)) = -\pi < \arg(x) \le \pi`.
 
 Some basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> log(1)
     0.0
@@ -1641,7 +1641,7 @@ fmod = r"""
 Converts `x` and `y` to mpmath numbers and returns `x \mod y`.
 For mpmath numbers, this is equivalent to ``x % y``.
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> fmod(100, pi)
     2.61062773871641
@@ -1656,7 +1656,7 @@ You can use :func:`~mpmath.fmod` to compute fractional parts of numbers::
 radians = r"""
 Converts the degree angle `x` to radians::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> radians(60)
     1.0471975511966
@@ -1665,7 +1665,7 @@ Converts the degree angle `x` to radians::
 degrees = r"""
 Converts the radian angle `x` to a degree angle::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> degrees(pi/3)
     60.0
@@ -1682,7 +1682,7 @@ The two-argument arctangent essentially computes
 `x` and `y` to give the angle for the correct quadrant. The
 following examples illustrate the difference::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> atan2(1,1), atan(1/1.)
     (0.785398163397448, 0.785398163397448)
@@ -1719,7 +1719,7 @@ For convenience, :func:`~mpmath.fib` is available as an alias for
 
 Some small Fibonacci numbers are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for i in range(10):
     ...     print(fibonacci(i))
@@ -1864,7 +1864,7 @@ in terms of the Hurwitz zeta function, for example using
 
 Some special values are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> altzeta(1)
     0.693147180559945
@@ -1921,7 +1921,7 @@ is defined for real or complex `x` by `x! = \Gamma(x+1)`.
 
 Basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for k in range(6):
     ...     print("%s %s" % (k, fac(k)))
@@ -1978,7 +1978,7 @@ by analytic continuation.
 
 Basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for k in range(1, 6):
     ...     print("%s %s" % (k, gamma(k)))
@@ -2051,7 +2051,7 @@ at `z = 0, -1, -2, \ldots`).
 For various rational arguments, the polygamma function reduces to
 a combination of standard mathematical constants::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> psi(0, 1), -euler
     (-0.5772156649015328606065121, -0.5772156649015328606065121)
@@ -2135,7 +2135,7 @@ approximation of the `n`-th harmonic number `H(n)`, defined as
 
 The first few harmonic numbers are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(8):
     ...     print("%s %s" % (n, harmonic(n)))
@@ -2203,7 +2203,7 @@ fraction, use :func:`~mpmath.bernfrac` instead.
 
 Numerical values of the first few Bernoulli numbers::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(15):
     ...     print("%s %s" % (n, bernoulli(n)))
@@ -2275,7 +2275,7 @@ coefficient `\gamma_n(a)` for the Hurwitz zeta function
 
 The zeroth Stieltjes constant is just Euler's constant `\gamma`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> stieltjes(0)
     0.577215664901533
@@ -2376,7 +2376,7 @@ In particular:
 
 The reciprocal gamma function `1/\Gamma(x)` evaluated at `x = 0`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15
     >>> gammaprod([], [0])
     0.0
@@ -2408,7 +2408,7 @@ For integer and half-integer arguments where all three gamma
 functions are finite, the beta function becomes either rational
 number or a rational multiple of `\pi`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> beta(5, 2)
     0.0333333333333333
@@ -2487,7 +2487,7 @@ beta distribution with parameters `a`, `b`.
 Verifying that :func:`~mpmath.betainc` computes the integral in the
 definition::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> x,y,a,b = 3, 4, 0, 6
     >>> betainc(x, y, a, b)
@@ -2544,7 +2544,7 @@ complex `n` and `k`, via the gamma function.
 
 Generate Pascal's triangle::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(5):
     ...     nprint([binomial(n,k) for k in range(n+1)])
@@ -2602,7 +2602,7 @@ where the rightmost expression is valid for nonintegral `n`.
 
 For integral `n`, the rising factorial is a polynomial::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(5):
     ...     nprint(taylor(lambda x: rf(x,n), 0, n))
@@ -2632,7 +2632,7 @@ where the rightmost expression is valid for nonintegral `n`.
 
 For integral `n`, the falling factorial is a polynomial::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(5):
     ...     nprint(taylor(lambda x: ff(x,n), 0, n))
@@ -2671,7 +2671,7 @@ and more generally by [1]
 
 The integer sequence of double factorials begins::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> nprint([fac2(n) for n in range(10)])
     [1.0, 1.0, 2.0, 3.0, 8.0, 15.0, 48.0, 105.0, 384.0, 945.0]
@@ -2764,7 +2764,7 @@ far the most common).
 Verifying that :func:`~mpmath.hyper` gives the sum in the definition, by
 comparison with :func:`~mpmath.nsum`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> a,b,c,d = 2,3,4,5
     >>> x = 0.25
@@ -2926,7 +2926,7 @@ with `a=1, z=3`. There is a zero factor, two gamma function poles, and
 the 1F1 function is singular; all singularities cancel out to give a finite
 value::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> hypercomb(lambda a: [([a-1],[1],[a-3],[a-4],[a],[a-1],3)], [1])
     -180.769832308689
@@ -2953,7 +2953,7 @@ and is related to the Bessel function of the first kind (see :func:`~mpmath.bess
 
 Evaluation for arbitrary arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hyp0f1(2, 0.25)
     1.130318207984970054415392
@@ -3010,7 +3010,7 @@ information.
 Evaluation for real and complex values of the argument `z`, with
 fixed parameters `a = 2, b = -1/3`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hyp1f1(2, (-1,3), 3.25)
     -2815.956856924817275640248
@@ -3069,7 +3069,7 @@ The call ``hyp1f2(a1,b1,b2,z)`` is equivalent to
 
 Evaluation works for complex and arbitrarily large arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> a, b, c = 1.5, (-1,3), 2.25
     >>> hyp1f2(a, b, c, 10**20)
@@ -3090,7 +3090,7 @@ The call ``hyp2f2(a1,a2,b1,b2,z)`` is equivalent to
 
 Evaluation works for complex and arbitrarily large arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> a, b, c, d = 1.5, (-1,3), 2.25, 4
     >>> hyp2f2(a, b, c, d, 10**20)
@@ -3111,7 +3111,7 @@ The call ``hyp2f3(a1,a2,b1,b2,b3,z)`` is equivalent to
 
 Evaluation works for arbitrarily large arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> a1,a2,b1,b2,b3 = 1.5, (-1,3), 2.25, 4, (1,5)
     >>> hyp2f3(a1,a2,b1,b2,b3,10**20)
@@ -3153,7 +3153,7 @@ is equivalent to ``hyper([a,b],[c],z)``.
 Evaluation with `z` inside, outside and on the unit circle, for
 fixed parameters::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hyp2f1(2, (1,2), 4, 0.75)
     1.303703703703703703703704
@@ -3228,7 +3228,7 @@ function is similar to that of `\,_2F_1`, generally with a singularity at
 Evaluation is supported inside, on, and outside
 the circle of convergence `|z| = 1`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hyp3f2(1,2,3,4,5,0.25)
     1.083533123380934241548707
@@ -3299,7 +3299,7 @@ see :func:`~mpmath.hyp1f1`).
 
 Evaluation for arbitrary complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hyperu(2,3,4)
     0.0625
@@ -3358,7 +3358,7 @@ after `-a` or `-b` terms.
 
 Evaluation is supported for arbitrary complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hyp2f0((2,3), 1.25, -100)
     0.07095851870980052763312791
@@ -3447,7 +3447,7 @@ function
 We can compare with numerical quadrature to verify that
 :func:`~mpmath.gammainc` computes the integral in the definition::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> gammainc(2+3j, 4, 10)
     (0.00977212668627705160602312 - 0.0770637306312989892451977j)
@@ -3543,7 +3543,7 @@ function is the normalized antiderivative of the Gaussian function
 
 Simple values and limits include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> erf(0)
     0.0
@@ -3609,7 +3609,7 @@ Computes the complementary error function,
 This function avoids cancellation that occurs when naively
 computing the complementary error function as ``1-erf(x)``::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> 1 - erf(10)
     0.0
@@ -3649,7 +3649,7 @@ numbers `x`.
 
 Basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> erfi(0)
     0.0
@@ -3705,7 +3705,7 @@ This function is defined only for `-1 \le x \le 1`.
 
 Special values include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> erfinv(0)
     0.0
@@ -3763,7 +3763,7 @@ and variance `\sigma^2`.
 Elementary properties of the probability distribution can
 be verified using numerical integration::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> quad(npdf, [-inf, inf])
     1.0
@@ -3785,7 +3785,7 @@ See also :func:`~mpmath.npdf`, which gives the probability density.
 
 Elementary properties include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> ncdf(pi, mu=pi)
     0.5
@@ -3823,7 +3823,7 @@ also given by :func:`~mpmath.e1`.
 
 Evaluation at real and complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> expint(1, 6.25)
     0.0002704758872637179088496194
@@ -3863,7 +3863,7 @@ This is equivalent to :func:`~mpmath.expint` with `n = 1`.
 
 Two ways to evaluate this function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> e1(6.25)
     0.0002704758872637179088496194
@@ -3905,7 +3905,7 @@ integral functions denoted by `E_n`, which are available as :func:`~mpmath.expin
 
 Some basic values and limits are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> ei(0)
     -inf
@@ -4006,7 +4006,7 @@ as :func:`~mpmath.polylog`.
 
 Some basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 30; mp.pretty = True
     >>> li(0)
     0.0
@@ -4089,7 +4089,7 @@ Computes the cosine integral,
 
 Some values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> ci(0)
     -inf
@@ -4158,7 +4158,7 @@ function (see :func:`~mpmath.sinc`).
 
 Some values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> si(0)
     0.0
@@ -4216,7 +4216,7 @@ in analogy with the cosine integral (see :func:`~mpmath.ci`) as
 
 Some values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> chi(0)
     -inf
@@ -4246,7 +4246,7 @@ in analogy with the sine integral (see :func:`~mpmath.si`) as
 
 Some values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> shi(0)
     0.0
@@ -4280,7 +4280,7 @@ without the normalization factor `\pi/2`.
 
 Some basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> fresnels(0)
     0.0
@@ -4315,7 +4315,7 @@ without the normalization factor `\pi/2`.
 
 Some basic values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> fresnelc(0)
     0.0
@@ -4395,7 +4395,7 @@ negative half of the real axis. They can be computed with
 
 Limits and values include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> airyai(0); 1/(power(3,'2/3')*gamma('2/3'))
     0.3550280538878172392600632
@@ -4588,7 +4588,7 @@ with :func:`~mpmath.airybizero`.
 
 Limits and values include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> airybi(0); 1/(power(3,'1/6')*gamma('2/3'))
     0.6149266274460007351509224
@@ -4747,7 +4747,7 @@ zero `a'_k` of the derivative function, i.e.
 
 Some values of `a_k`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> airyaizero(1)
     -2.338107410459767038489197
@@ -4796,7 +4796,7 @@ is computed.
 
 Some values of `b_k`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> airybizero(1)
     -1.17371322270912792491998
@@ -4888,7 +4888,7 @@ not the modulus `k` which is sometimes used.
 
 Values and limits include::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> ellipk(0)
     1.570796326794896619231322
@@ -4948,7 +4948,7 @@ two distinct positive numbers is less than the arithmetic
 mean. It follows that the arithmetic-geometric mean lies
 between the two means::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> a = mpf(3)
     >>> b = mpf(4)
@@ -5054,7 +5054,7 @@ reduces to a Legendre polynomial.
 
 Evaluation for arbitrary arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> gegenbauer(3, 0.5, -10)
     -2485.0
@@ -5128,7 +5128,7 @@ The Laguerre polynomials are orthogonal with respect to the weight
 
 Evaluation for arbitrary arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> laguerre(5, 0, 0.25)
     0.03726399739583333333333333
@@ -5205,7 +5205,7 @@ for `\Re{z} > 0`, or generally
 
 Evaluation for arbitrary arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hermite(0, 10)
     1.0
@@ -5288,7 +5288,7 @@ a polynomial in `x`.
 
 A special evaluation is `P_n^{(a,b)}(1) = {n+a \choose n}`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> jacobi(4, 0.5, 0.25, 1)
     2.4609375
@@ -5349,7 +5349,7 @@ equation
 We can verify that :func:`~mpmath.jacobi` approximately satisfies
 this equation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15
     >>> a = 2.5
     >>> b = 4
@@ -5406,7 +5406,7 @@ A third definition is in terms of the hypergeometric function
 The Legendre polynomials assume fixed values at the points
 `x = -1` and `x = 1`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> nprint([legendre(n, 1) for n in range(6)])
     [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
@@ -5515,7 +5515,7 @@ second kind as implemented by :func:`~mpmath.legenq`.
 
 Evaluation for arbitrary parameters and arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> legenp(2, 0, 10); legendre(2, 10)
     149.5
@@ -5587,7 +5587,7 @@ of `(z^2-1)^{m/2}`, giving slightly different branches.
 
 Evaluation for arbitrary parameters and arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> legenq(2, 0, 0.5)
     -0.8186632680417568557122028
@@ -5632,7 +5632,7 @@ evaluated for nonintegral `n`.
 The coefficients of the `n`-th polynomial can be recovered
 using using degree-`n` Taylor expansion::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(5):
     ...     nprint(chop(taylor(lambda x: chebyt(n, x), 0, n)))
@@ -5682,7 +5682,7 @@ evaluated for nonintegral `n`.
 The coefficients of the `n`-th polynomial can be recovered
 using using degree-`n` Taylor expansion::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(5):
     ...     nprint(chop(taylor(lambda x: chebyu(n, x), 0, n)))
@@ -5753,7 +5753,7 @@ is computed.
 Evaluation is supported for arbitrary arguments, and at
 arbitrary precision::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> besselj(2, 1000)
     -0.024777229528606
@@ -5872,7 +5872,7 @@ is computed.
 
 Some values of `I_n(x)`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> besseli(0,0)
     1.0
@@ -5947,7 +5947,7 @@ is computed.
 
 Some values of `Y_n(x)`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> bessely(0,0), bessely(1,0), bessely(2,0)
     (-inf, -inf, -inf)
@@ -6010,7 +6010,7 @@ limit.
 
 Evaluation is supported for arbitrary complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> besselk(0,1)
     0.4210244382407083333356274
@@ -6072,7 +6072,7 @@ which is the complex combination of Bessel functions given by
 
 The Hankel function is generally complex-valued::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hankel1(2, pi)
     (0.4854339326315091097054957 - 0.0999007139290278787734903j)
@@ -6099,7 +6099,7 @@ which is the complex combination of Bessel functions given by
 
 The Hankel function is generally complex-valued::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> hankel2(2, pi)
     (0.4854339326315091097054957 + 0.0999007139290278787734903j)
@@ -6140,7 +6140,7 @@ is based on [Corless]_.
 
 The Lambert W function is the inverse of `w \exp(w)`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> w = lambertw(1)
     >>> w
@@ -6261,7 +6261,7 @@ For positive integers `n`, we have have relation to superfactorials
 
 Some elementary values and limits of the Barnes G-function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> barnesg(1), barnesg(2), barnesg(3)
     (1.0, 1.0, 1.0)
@@ -6374,7 +6374,7 @@ in terms of the Barnes G-function (see :func:`~mpmath.barnesg`).
 
 The first few superfactorials are (OEIS A000178)::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(10):
     ...     print("%s %s" % (n, superfac(n)))
@@ -6444,7 +6444,7 @@ the integral representation
 The rapidly-growing sequence of hyperfactorials begins
 (OEIS A002109)::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(10):
     ...     print("%s %s" % (n, hyperfac(n)))
@@ -6526,7 +6526,7 @@ of the gamma function, `z = 0, -1, -2, \ldots`.
 
 Basic examples::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> rgamma(1)
     1.0
@@ -6572,7 +6572,7 @@ instead of :func:`~mpmath.gamma` for extremely large arguments.
 
 Comparing with `\ln(\Gamma(z))`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> loggamma('13.2'); log(gamma('13.2'))
     20.49400419456603678498394
@@ -6669,7 +6669,7 @@ providing the phase factor for the Z-function
 (see :func:`~mpmath.siegelz`). Evaluation is supported for real and
 complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> siegeltheta(0)
     0.0
@@ -6718,7 +6718,7 @@ is the Riemann-Siegel theta function (:func:`~mpmath.siegeltheta`).
 
 The first few Gram points are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> grampoint(0)
     17.84559954041086081682634
@@ -6770,7 +6770,7 @@ and where `\theta(t)` denotes the Riemann-Siegel theta function
 
 Evaluation is supported for real and complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> siegelz(1)
     -0.7363054628673177346778998
@@ -6866,7 +6866,7 @@ For small arguments, the Riemann R function almost exactly
 gives the prime counting function if rounded to the nearest
 integer::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> primepi(50), riemannr(50)
     (15, 14.9757023241462)
@@ -6939,7 +6939,7 @@ or :func:`~mpmath.riemannr`.
 
 Some values of the prime counting function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> [primepi(k) for k in range(20)]
     [0, 0, 1, 2, 2, 3, 3, 4, 4, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 8]
     >>> primepi(3.5)
@@ -6967,7 +6967,7 @@ the Riemann hypothesis, and can be computed very quickly.
 
 Exact values of the prime counting function for small `x`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> iv.dps = 15; iv.pretty = True
     >>> primepi2(10)
@@ -7026,7 +7026,7 @@ half-plane `\mathrm{Re}(s) > 0`.
 Arbitrary-precision evaluation for real and complex arguments is
 supported::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 30; mp.pretty = True
     >>> primezeta(2)
     0.452247420041065498506543364832
@@ -7089,7 +7089,7 @@ Evaluates the Bernoulli polynomial `B_n(z)`.
 
 The first few Bernoulli polynomials are::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(6):
     ...     nprint(chop(taylor(lambda x: bernpoly(n,x), 0, n)))
@@ -7138,7 +7138,7 @@ as :func:`~mpmath.li`.
 The polylogarithm satisfies a huge number of functional identities.
 A sample of polylogarithm evaluations is shown below::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> polylog(1,0.5), log(2)
     (0.693147180559945, 0.693147180559945)
@@ -7273,7 +7273,7 @@ differentiated, etc for arbitrary complex arguments.
 
 Simple evaluations::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> bell(0, 2.5)
     1.0
@@ -7371,7 +7371,7 @@ at `n = 0`.
 
 Evaluating a series::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> nsum(lambda k: sqrt(k)/fac(k), [1,inf])
     2.101755547733791780315904
@@ -7440,7 +7440,7 @@ written explicitly as
 The coefficients of low-order cyclotomic polynomials can be recovered
 using Taylor expansion::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 15; mp.pretty = True
     >>> for n in range(9):
     ...     p = chop(taylor(lambda x: cyclotomic(n,x), 0, 10))
@@ -7546,7 +7546,7 @@ Many standard functions are special cases of the Meijer G-function
 (possibly rescaled and/or with branch cut corrections). We define
 some test parameters::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> a = mpf(0.75)
     >>> b = mpf(1.5)
@@ -7709,7 +7709,7 @@ cosine sum.
 
 Evaluation for arbitrarily chosen `s` and `z`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> s, z = 3, 4
     >>> clsin(s, z); nsum(lambda k: sin(z*k)/k**s, [1,inf])
@@ -7829,7 +7829,7 @@ This function is complementary to the Clausen sine function
 
 Evaluation for arbitrarily chosen `s` and `z`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> s, z = 3, 4
     >>> clcos(s, z); nsum(lambda k: cos(z*k)/k**s, [1,inf])
@@ -7955,7 +7955,7 @@ They are alternate forms of the confluent hypergeometric functions
 
 Evaluation for arbitrary real and complex arguments is supported::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> whitm(1, 1, 1)
     0.7302596799460411820509668
@@ -8005,7 +8005,7 @@ solution to the Whittaker differential equation. (See :func:`~mpmath.whitm`.)
 
 Evaluation for arbitrary real and complex arguments is supported::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> whitw(1, 1, 1)
     1.19532063107581155661012
@@ -8064,7 +8064,7 @@ The imaginary part is given by :func:`~mpmath.bei`.
 
 Verifying the defining relation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> n, x = 2, 3.5
     >>> ber(n,x)
@@ -8109,7 +8109,7 @@ The imaginary part is given by :func:`~mpmath.kei`.
 
 Verifying the defining relation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> n, x = 2, 4.5
     >>> ker(n,x)
@@ -8154,7 +8154,7 @@ which is a solution to the Struve differential equation
 
 Evaluation for arbitrary real and complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> struveh(0, 3.5)
     0.3608207733778295024977797
@@ -8208,7 +8208,7 @@ which solves to the modified Struve differential equation
 
 Evaluation for arbitrary real and complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> struvel(0, 3.5)
     7.180846515103737996249972
@@ -8255,7 +8255,7 @@ with respecto to either variable, and sometimes both.
 
 Evaluation is supported for real and complex parameters::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> appellf1(1,0,0.5,1,0.5,0.25)
     1.154700538379251529018298
@@ -8382,7 +8382,7 @@ equation
 
 Evaluation for real and complex parameter and argument::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> angerj(2,3)
     0.4860912605858910769078311
@@ -8445,7 +8445,7 @@ equation
 
 Evaluation for real and complex parameter and argument::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> webere(2,3)
     -0.1057668973099018425662646
@@ -8513,7 +8513,7 @@ A second solution is given by :func:`~mpmath.lommels2`.
 
 An integral representation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> u,v,z = 0.25, 0.125, mpf(0.75)
     >>> lommels1(u,v,z)
@@ -8568,7 +8568,7 @@ which solves the same differential equation as
 
 For large `|z|`, `S_{\mu,\nu} \sim z^{\mu-1}`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> lommels2(10,2,30000)
     1.968299831601008419949804e+40
@@ -8612,7 +8612,7 @@ The series is generally absolutely convergent for `|x| + |y| < 1`.
 
 Evaluation for real and complex arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> appellf2(1,2,3,4,5,0.25,0.125)
     1.257417193533135344785602
@@ -8670,7 +8670,7 @@ The series is generally absolutely convergent for `|x| < 1, |y| < 1`.
 
 Evaluation for various parameters and variables::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> appellf3(1,2,3,4,5,0.5,0.25)
     2.221557778107438938158705
@@ -8741,7 +8741,7 @@ The series is generally absolutely convergent for
 
 Evaluation for various parameters and arguments::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> appellf4(1,1,2,2,0.25,0.125)
     1.286182069079718313546608
@@ -8823,7 +8823,7 @@ nonrational `a` or when computing derivatives.
 
 Some values of the Riemann zeta function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> zeta(2); pi**2 / 6
     1.644934066848226436472415
@@ -9005,7 +9005,7 @@ derivative) can be evaluated.
 
 The ordinary Riemann zeta function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> dirichlet(3, [1]); zeta(3)
     1.202056903159594285399738
@@ -9094,7 +9094,7 @@ to be complex in this implementation (see references).
 
 Evaluation is supported for arbitrary magnitudes of `z`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> coulombf(2, 1.5, 3.5)
     0.4080998961088761187426445
@@ -9209,7 +9209,7 @@ See :func:`~mpmath.coulombf` for additional information.
 
 Evaluation is supported for arbitrary magnitudes of `z`::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> coulombg(-2, 1.5, 3.5)
     1.380011900612186346255524
@@ -9314,7 +9314,7 @@ evaluating the chosen function for given arguments is returned.
 
 Basic evaluation::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> ellipfun('cd', 3.5, 0.5)
     -0.9891101840595543931308394
@@ -9397,7 +9397,7 @@ Considered as functions of `z`, the Jacobi theta functions may be
 viewed as generalizations of the ordinary trigonometric functions
 cos and sin. They are periodic functions::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> jtheta(1, 0.25, '0.2')
     0.2945120798627300045053104
@@ -9517,7 +9517,7 @@ Euler polynomials (see :func:`~mpmath.eulerpoly`) as `E_n = 2^n E_n(1/2)`.
 Computing the first few Euler numbers and verifying that they
 agree with the Taylor series::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> [eulernum(n) for n in range(11)]
     [1.0, 0.0, -1.0, 0.0, 5.0, 0.0, -61.0, 0.0, 1385.0, 0.0, -50521.0]
@@ -9577,7 +9577,7 @@ Special values include the Euler numbers `E_n = 2^n E_n(1/2)` (see
 
 Computing the coefficients of the first few Euler polynomials::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> for n in range(6):
     ...     chop(taylor(lambda z: eulerpoly(n,z), 0, n))
@@ -9679,7 +9679,7 @@ are permitted to be complex numbers.
 
 Some low-order spherical harmonics with reference values::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> theta = pi/4
     >>> phi = pi/3
@@ -9747,7 +9747,7 @@ particular solution is given by the Scorer Hi-function
 
 Some values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> scorergi(0); 1/(power(3,'7/6')*gamma('2/3'))
     0.2049755424820002450503075
@@ -9841,7 +9841,7 @@ differential equation `f''(z) - z f(z) = 1/\pi`. See also
 
 Some values and limits::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> scorerhi(0); 2/(power(3,'7/6')*gamma('2/3'))
     0.4099510849640004901006149
@@ -9912,7 +9912,7 @@ is not optimized for approximating large values quickly.
 
 Comparing with the generating function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> taylor(lambda x: ff(x, 5), 0, 5)
     [0.0, 24.0, -50.0, 35.0, -10.0, 1.0]
@@ -9964,7 +9964,7 @@ The implementation is not optimized for approximating large values quickly.
 
 Comparing with the generating function::
 
-    >>> from mpmath import *
+    >>> from sympy.mpmath import *
     >>> mp.dps = 25; mp.pretty = True
     >>> taylor(lambda x: sum(stirling2(5,k) * ff(x,k) for k in range(6)), 0, 5)
     [0.0, 0.0, 0.0, 0.0, 0.0, 1.0]

--- a/sympy/mpmath/functions/bessel.py
+++ b/sympy/mpmath/functions/bessel.py
@@ -930,7 +930,7 @@ def besseljzero(ctx, v, m, derivative=0):
 
     Initial zeros of the Bessel functions `J_0(z), J_1(z), J_2(z)`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> besseljzero(0,1); besseljzero(0,2); besseljzero(0,3)
         2.404825557695772768621632
@@ -1037,7 +1037,7 @@ def besselyzero(ctx, v, m, derivative=0):
 
     Initial zeros of the Bessel functions `Y_0(z), Y_1(z), Y_2(z)`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> besselyzero(0,1); besselyzero(0,2); besselyzero(0,3)
         0.8935769662791675215848871

--- a/sympy/mpmath/functions/elliptic.py
+++ b/sympy/mpmath/functions/elliptic.py
@@ -94,7 +94,7 @@ def qfrom(ctx, q=None, m=None, k=None, tau=None, qbar=None):
     r"""
     Returns the elliptic nome `q`, given any of `q, m, k, \tau, \bar{q}`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> qfrom(q=0.25)
         0.25
@@ -125,7 +125,7 @@ def qbarfrom(ctx, q=None, m=None, k=None, tau=None, qbar=None):
     Returns the number-theoretic nome `\bar q`, given any of
     `q, m, k, \tau, \bar{q}`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> qbarfrom(qbar=0.25)
         0.25
@@ -156,7 +156,7 @@ def taufrom(ctx, q=None, m=None, k=None, tau=None, qbar=None):
     Returns the elliptic half-period ratio `\tau`, given any of
     `q, m, k, \tau, \bar{q}`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> taufrom(tau=0.5j)
         (0.0 + 0.5j)
@@ -190,7 +190,7 @@ def kfrom(ctx, q=None, m=None, k=None, tau=None, qbar=None):
     Returns the elliptic modulus `k`, given any of
     `q, m, k, \tau, \bar{q}`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> kfrom(k=0.25)
         0.25
@@ -235,7 +235,7 @@ def mfrom(ctx, q=None, m=None, k=None, tau=None, qbar=None):
     Returns the elliptic parameter `m`, given any of
     `q, m, k, \tau, \bar{q}`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> mfrom(m=0.25)
         0.25
@@ -374,7 +374,7 @@ def kleinj(ctx, tau=None, **kwargs):
 
     Verifying the functional equation `J(\tau) = J(\tau+1) = J(-\tau^{-1})`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> tau = 0.625+0.75*j
         >>> tau = 0.625+0.75*j
@@ -575,7 +575,7 @@ def elliprf(ctx, x, y, z):
 
     Some basic values and limits::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> elliprf(0,1,1); pi/2
         1.570796326794896619231322
@@ -700,7 +700,7 @@ def elliprc(ctx, x, y, pv=True):
 
     Some special values and limits::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> elliprc(1,2)*4; elliprc(0,1)*2; +pi
         3.141592653589793238462643
@@ -764,7 +764,7 @@ def elliprj(ctx, x, y, z, p):
 
     Some values and limits::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> elliprj(1,1,1,1)
         1.0
@@ -834,7 +834,7 @@ def elliprd(ctx, x, y, z):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> elliprd(1,2,3)
         0.2904602810289906442326534
@@ -869,7 +869,7 @@ def elliprg(ctx, x, y, z):
 
     Evaluation for real and complex arguments::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> elliprg(0,1,1)*4; +pi
         3.141592653589793238462643
@@ -948,7 +948,7 @@ def ellipf(ctx, phi, m):
 
     Basic values and limits::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> ellipf(0,1)
         0.0
@@ -1068,7 +1068,7 @@ def ellipe(ctx, *args):
 
     Basic values and limits::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> ellipe(0)
         1.570796326794896619231322
@@ -1227,7 +1227,7 @@ def ellippi(ctx, *args):
 
     Some basic values and limits::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> ellippi(0,-5); ellipk(-5)
         0.9555039270640439337379334

--- a/sympy/mpmath/functions/functions.py
+++ b/sympy/mpmath/functions/functions.py
@@ -556,7 +556,7 @@ def mangoldt(ctx, n):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> [mangoldt(n) for n in range(-2,3)]
         [0.0, 0.0, 0.0, 0.0, 0.6931471805599453094172321]

--- a/sympy/mpmath/functions/hypergeometric.py
+++ b/sympy/mpmath/functions/hypergeometric.py
@@ -1181,7 +1181,7 @@ def hyper2d(ctx, a, b, x, y, **kwargs):
     Two separable cases: a product of two geometric series, and a
     product of two Gaussian hypergeometric functions::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> x, y = mpf(0.25), mpf(0.5)
         >>> hyper2d({'m':1,'n':1}, {}, x,y)
@@ -1202,7 +1202,7 @@ def hyper2d(ctx, a, b, x, y, **kwargs):
 
     Six of the 34 Horn functions, G1-G3 and H1-H3::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 10; mp.pretty = True
         >>> x, y = 0.0625, 0.125
         >>> a1,a2,b1,b2,c1,c2,d = 1.1,-1.2,-1.3,-1.4,1.5,-1.6,1.7
@@ -1368,7 +1368,7 @@ def bihyper(ctx, a_s, b_s, z, **kwargs):
 
     The value of `\,_2H_2` at `z = 1` is given by Dougall's formula::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> a,b,c,d = 0.5, 1.5, 2.25, 3.25
         >>> bihyper([a,b],[c,d],1)

--- a/sympy/mpmath/functions/orthogonal.py
+++ b/sympy/mpmath/functions/orthogonal.py
@@ -86,7 +86,7 @@ def pcfd(ctx, n, z, **kwargs):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> pcfd(0,0); pcfd(1,0); pcfd(2,0); pcfd(3,0)
         1.0
@@ -144,7 +144,7 @@ def pcfu(ctx, a, z, **kwargs):
 
     Connection to other functions::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> z = mpf(3)
         >>> pcfu(0.5,z)
@@ -178,7 +178,7 @@ def pcfv(ctx, a, z, **kwargs):
 
     Wronskian relation between `U` and `V`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> a, z = 2, 3
         >>> pcfu(a,z)*diff(pcfv,(a,z),(0,1))-diff(pcfu,(a,z),(0,1))*pcfv(a,z)
@@ -246,7 +246,7 @@ def pcfw(ctx, a, z, **kwargs):
 
     Value at the origin::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> a = mpf(0.25)
         >>> pcfw(a,0)

--- a/sympy/mpmath/functions/qfunctions.py
+++ b/sympy/mpmath/functions/qfunctions.py
@@ -25,7 +25,7 @@ def qp(ctx, a, q=None, n=None, **kwargs):
 
     If `n` is a positive integer, the function amounts to a finite product::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> qp(2,3,5)
         -725305.0
@@ -142,7 +142,7 @@ def qgamma(ctx, z, q, **kwargs):
 
     Evaluation for real and complex arguments::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> qgamma(4,0.75)
         4.046875
@@ -184,7 +184,7 @@ def qfac(ctx, z, q, **kwargs):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> qfac(0,0)
         1.0
@@ -224,7 +224,7 @@ def qhyper(ctx, a_s, b_s, q, z, **kwargs):
 
     Evaluation works for real and complex arguments::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> qhyper([0.5], [2.25], 0.25, 4)
         -0.1975849091263356009534385

--- a/sympy/mpmath/functions/zeta.py
+++ b/sympy/mpmath/functions/zeta.py
@@ -939,7 +939,7 @@ def secondzeta(ctx, s, a = 0.015, **kwargs):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.pretty = True; mp.dps = 15
         >>> secondzeta(2)
         0.023104993115419
@@ -1079,7 +1079,7 @@ def lerchphi(ctx, z, s, a):
 
     Several evaluations in terms of simpler functions::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> lerchphi(-1,2,0.5); 4*catalan
         3.663862376708876060218414

--- a/sympy/mpmath/functions/zetazeros.py
+++ b/sympy/mpmath/functions/zetazeros.py
@@ -349,7 +349,7 @@ def zetazero(ctx, n, info=False, round=True):
 
     The first few zeros::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 25; mp.pretty = True
         >>> zetazero(1)
         (0.5 + 14.13472514173469379045725j)
@@ -482,7 +482,7 @@ def nzeros(ctx, t):
 
     The first zero has imaginary part between 14 and 15::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> nzeros(14)
         0
@@ -554,7 +554,7 @@ def backlunds(ctx, t):
 
     **Examples**
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> backlunds(217.3)
         0.16302205431184

--- a/sympy/mpmath/identification.py
+++ b/sympy/mpmath/identification.py
@@ -32,7 +32,7 @@ def pslq(ctx, x, tol=None, maxcoeff=1000, maxsteps=100, verbose=False):
 
     Find rational approximations for `\pi`::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> pslq([-1, pi], tol=0.01)
         [22, 7]
@@ -331,7 +331,7 @@ def findpoly(ctx, x, n=1, **kwargs):
     By default (degree `n = 1`), :func:`~mpmath.findpoly` simply finds a linear
     polynomial with a rational root::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> findpoly(0.7)
         [-10, 7]
@@ -541,7 +541,7 @@ def identify(ctx, x, constants=[], tol=None, maxcoeff=1000, full=False,
     As a simple example, :func:`~mpmath.identify` will find an algebraic
     formula for the golden ratio::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15; mp.pretty = True
         >>> identify(phi)
         '((1+sqrt(5))/2)'

--- a/sympy/mpmath/libmp/gammazeta.py
+++ b/sympy/mpmath/libmp/gammazeta.py
@@ -495,7 +495,7 @@ def bernfrac(n):
 
     The first few Bernoulli numbers are exactly::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> for n in range(15):
         ...     p, q = bernfrac(n)
         ...     print("%s %s/%s" % (n, p, q))

--- a/sympy/mpmath/libmp/libmpi.py
+++ b/sympy/mpmath/libmp/libmpi.py
@@ -539,7 +539,7 @@ def mpi_to_str(x, dps, use_spaces=True, brackets='[]', mode='brackets', error_dp
 
     **Examples**
 
-        >>> from mpmath import mpi, mp
+        >>> from sympy.mpmath import mpi, mp
         >>> mp.dps = 30
         >>> x = mpi(1, 2)
         >>> mpi_to_str(x, mode='plusminus')

--- a/sympy/mpmath/matrices/calculus.py
+++ b/sympy/mpmath/matrices/calculus.py
@@ -67,7 +67,7 @@ class MatrixCalculusMethods(object):
 
         Basic examples::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> expm(zeros(3))
             [1.0  0.0  0.0]
@@ -151,7 +151,7 @@ class MatrixCalculusMethods(object):
 
         Examples::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> X = eye(3)
             >>> cosm(X)
@@ -180,7 +180,7 @@ class MatrixCalculusMethods(object):
 
         Examples::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> X = eye(3)
             >>> sinm(X)
@@ -218,7 +218,7 @@ class MatrixCalculusMethods(object):
 
         Square roots of some simple matrices::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> sqrtm([[1,0], [0,1]])
             [1.0  0.0]
@@ -357,7 +357,7 @@ class MatrixCalculusMethods(object):
 
         Logarithms of some simple matrices::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> X = eye(3)
             >>> logm(X)
@@ -470,7 +470,7 @@ class MatrixCalculusMethods(object):
 
         Powers and inverse powers of a matrix::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = True
             >>> A = matrix([[4,1,4],[7,8,9],[10,2,11]])
             >>> powm(A, 2)

--- a/sympy/mpmath/matrices/eigen.py
+++ b/sympy/mpmath/matrices/eigen.py
@@ -205,7 +205,7 @@ def hessenberg(ctx, A, overwrite_a = False):
       H : an upper right Hessenberg matrix
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[3, -1, 2], [2, 5, -5], [-2, -3, 7]])
       >>> Q, H = mp.hessenberg(A)
       >>> mp.nprint(H, 3) # doctest:+SKIP
@@ -504,7 +504,7 @@ def schur(ctx, A, overwrite_a = False):
     return value:   (Q, R)
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[3, -1, 2], [2, 5, -5], [-2, -3, 7]])
       >>> Q, R = mp.schur(A)
       >>> mp.nprint(R, 3) # doctest:+SKIP
@@ -694,7 +694,7 @@ def eig(ctx, A, left = False, right = True, overwrite_a = False):
 
 
     examples:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[3, -1, 2], [2, 5, -5], [-2, -3, 7]])
       >>> E, ER = mp.eig(A)
       >>> print(mp.chop(A * ER[:,0] - E[0] * ER[:,0]))
@@ -798,7 +798,7 @@ def eig_sort(ctx, E, EL = False, ER = False, f = "real"):
       (E, EL, ER)   if EL and ER are not false.
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[3, -1, 2], [2, 5, -5], [-2, -3, 7]])
       >>> E, EL, ER = mp.eig(A,left = True, right = True)
       >>> E, EL, ER = mp.eig_sort(E, EL, ER)

--- a/sympy/mpmath/matrices/eigen_symmetric.py
+++ b/sympy/mpmath/matrices/eigen_symmetric.py
@@ -543,7 +543,7 @@ def eigsy(ctx, A, eigvals_only = False, overwrite_a = False):
          (E, Q)      if eigvals_only is false
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[3, 2], [2, 0]])
       >>> E = mp.eigsy(A, eigvals_only = True)
       >>> print(E)
@@ -617,7 +617,7 @@ def eighe(ctx, A, eigvals_only = False, overwrite_a = False):
           (E, Q)     if eigvals_only is false
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[1, -3 - 1j], [-3 + 1j, -2]])
       >>> E = mp.eighe(A, eigvals_only = True)
       >>> print(E)
@@ -695,7 +695,7 @@ def eigh(ctx, A, eigvals_only = False, overwrite_a = False):
          (E, Q)     if eigvals_only is false
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[3, 2], [2, 0]])
       >>> E = mp.eigh(A, eigvals_only = True)
       >>> print(E)
@@ -778,7 +778,7 @@ def gauss_quadrature(ctx, n, qtype = "legendre", alpha = 0, beta = 0):
                       with alpha>-1 and beta>-1
 
     examples:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> f = lambda x: x**8 + 2 * x**6 - 3 * x**4 + 5 * x**2 - 7
       >>> X, W = mp.gauss_quadrature(5, "hermite")
       >>> A = mp.fdot([(f(x), w) for x, w in zip(X, W)])
@@ -1571,7 +1571,7 @@ def svd_r(ctx, A, full_matrices = False, compute_uv = True, overwrite_a = False)
 
     examples:
 
-       >>> from mpmath import mp
+       >>> from sympy.mpmath import mp
        >>> A = mp.matrix([[2, -2, -1], [3, 4, -2], [-2, -2, 0]])
        >>> S = mp.svd_r(A, compute_uv = False)
        >>> print(S)
@@ -1676,7 +1676,7 @@ def svd_c(ctx, A, full_matrices = False, compute_uv = True, overwrite_a = False)
         V           : min(m,n)*n             V  V' = 1
 
     example:
-      >>> from mpmath import mp
+      >>> from sympy.mpmath import mp
       >>> A = mp.matrix([[-2j, -1-3j, -2+2j], [2-2j, -1-3j, 1], [-3+1j,-2j,0]])
       >>> S = mp.svd_c(A, compute_uv = False)
       >>> print(mp.chop(S - mp.matrix([mp.sqrt(34), mp.sqrt(15), mp.sqrt(6)])))
@@ -1783,7 +1783,7 @@ def svd(ctx, A, full_matrices = False, compute_uv = True, overwrite_a = False):
 
     examples:
 
-       >>> from mpmath import mp
+       >>> from sympy.mpmath import mp
        >>> A = mp.matrix([[2, -2, -1], [3, 4, -2], [-2, -2, 0]])
        >>> S = mp.svd(A, compute_uv = False)
        >>> print(S)

--- a/sympy/mpmath/matrices/linalg.py
+++ b/sympy/mpmath/matrices/linalg.py
@@ -433,7 +433,7 @@ class LinearAlgebraMethods(object):
 
         Cholesky decomposition of a positive-definite symmetric matrix::
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 25; mp.pretty = True
             >>> A = eye(3) + hilbert(3)
             >>> nprint(A)
@@ -601,7 +601,7 @@ class LinearAlgebraMethods(object):
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15
             >>> mp.pretty = True
             >>> A = matrix([[1, 2], [3, 4], [1, 1]])

--- a/sympy/mpmath/matrices/matrices.py
+++ b/sympy/mpmath/matrices/matrices.py
@@ -26,7 +26,7 @@ class _matrix(object):
     The most basic way to create one is to use the ``matrix`` class directly.
     You can create an empty matrix specifying the dimensions:
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 15
         >>> matrix(2)
         matrix(
@@ -754,7 +754,7 @@ class MatrixMethods(object):
         Create square diagonal matrix using given list.
 
         Example:
-        >>> from mpmath import diag, mp
+        >>> from sympy.mpmath import diag, mp
         >>> mp.pretty = False
         >>> diag([1, 2, 3])
         matrix(
@@ -773,7 +773,7 @@ class MatrixMethods(object):
         One given dimension will create square matrix n x n.
 
         Example:
-        >>> from mpmath import zeros, mp
+        >>> from sympy.mpmath import zeros, mp
         >>> mp.pretty = False
         >>> zeros(2)
         matrix(
@@ -799,7 +799,7 @@ class MatrixMethods(object):
         One given dimension will create square matrix n x n.
 
         Example:
-        >>> from mpmath import ones, mp
+        >>> from sympy.mpmath import ones, mp
         >>> mp.pretty = False
         >>> ones(2)
         matrix(
@@ -843,7 +843,7 @@ class MatrixMethods(object):
         n defaults to m.
 
         Example:
-        >>> from mpmath import randmatrix
+        >>> from sympy.mpmath import randmatrix
         >>> randmatrix(2) # doctest:+SKIP
         matrix(
         [['0.53491598236191806', '0.57195669543302752'],
@@ -908,7 +908,7 @@ class MatrixMethods(object):
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> x = matrix([-10, 2, 100])
             >>> norm(x, 1)
@@ -964,7 +964,7 @@ class MatrixMethods(object):
 
         **Examples**
 
-            >>> from mpmath import *
+            >>> from sympy.mpmath import *
             >>> mp.dps = 15; mp.pretty = False
             >>> A = matrix([[1, -1000], [100, 50]])
             >>> mnorm(A, 1)

--- a/sympy/mpmath/tests/extratest_bessel.py
+++ b/sympy/mpmath/tests/extratest_bessel.py
@@ -2,7 +2,7 @@
 # Reference zeros generated with the aid of scipy.special
 # jn_zero, jnp_zero, yn_zero, ynp_zero
 
-from mpmath import *
+from sympy.mpmath import *
 
 V = 15
 M = 15

--- a/sympy/mpmath/tests/extratest_gamma.py
+++ b/sympy/mpmath/tests/extratest_gamma.py
@@ -1,5 +1,5 @@
-from mpmath import *
-from mpmath.libmp import ifac
+from sympy.mpmath import *
+from sympy.mpmath.libmp import ifac
 
 import sys
 if "-dps" in sys.argv:

--- a/sympy/mpmath/tests/extratest_zeta.py
+++ b/sympy/mpmath/tests/extratest_zeta.py
@@ -1,4 +1,4 @@
-from mpmath import zetazero
+from sympy.mpmath import zetazero
 from timeit import default_timer as clock
 
 def test_zetazero():

--- a/sympy/mpmath/usertools.py
+++ b/sympy/mpmath/usertools.py
@@ -8,7 +8,7 @@ def monitor(f, input='print', output='print'):
     inputs and outputs to stdout, along with the total evaluation
     count::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> mp.dps = 5; mp.pretty = False
         >>> diff(monitor(exp), 1)   # diff will eval f(x-h) and f(x+h)
         in  0 (mpf('0.99999999906867742538452148'),) {}

--- a/sympy/mpmath/visualization.py
+++ b/sympy/mpmath/visualization.py
@@ -199,7 +199,7 @@ def splot(ctx, f, u=[-5,5], v=[-5,5], points=100, keep_aspect=True, \
 
     For example, to plot a simple function::
 
-        >>> from mpmath import *
+        >>> from sympy.mpmath import *
         >>> f = lambda x, y: sin(x+y)*cos(y)
         >>> splot(f, [-pi,pi], [-pi,pi])    # doctest: +SKIP
 


### PR DESCRIPTION
This was throwing error on sympy docs. I've changed majorly in documentation though few test files have also been changed.
