### PR TITLE
Heurisch added functionality, new matrix property, issue fixes

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -754,13 +754,21 @@ class LambertW(Function):
         if x == S.Infinity:
             return S.Infinity
 
-    def fdiff(self, argindex=1):
+    def heurisch_diff(self, argindex=1):
         """
         Return the first derivative of this function.
         """
+
         if argindex == 1:
             x = self.args[0]
             return LambertW(x)/(x*(1 + LambertW(x)))
+        else:
+            raise ArgumentIndexError(self, argindex)
+
+    def fdiff(self, argindex=1):
+        if argindex == 1:
+            x = self.args[0]
+            return 1/((exp(LambertW(x)))*(1 + LambertW(x)))
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -4,7 +4,7 @@ from sympy.core.add import Add
 from sympy.core.basic import C, sympify, cacheit
 from sympy.core.singleton import S
 from sympy.core.numbers import igcdex
-from sympy.core.function import Function, ArgumentIndexError
+from sympy.core.function import Function, ArgumentIndexError, Derivative
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
@@ -912,9 +912,15 @@ class tan(TrigonometricFunction):
 
     """
 
+    def heurisch_diff(self, argindex=1):
+        if argindex == 1:
+            return (S.One + self**2)*Derivative(self.args[0],evaluate=True)
+        else:
+            raise ArgumentIndexError(self, argindex)
+
     def fdiff(self, argindex=1):
         if argindex == 1:
-            return S.One + self**2
+            return  (sec(self.args[0])**2)
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -336,11 +336,14 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
             terms |= set(hints)
 
     for g in set(terms):
-        terms |= components(cancel(g.diff(x)), x)
+        try:
+            terms |= components(cancel(g.heurisch_diff()), x)
+
+        except:
+            terms |= components(cancel(g.diff(x)), x)
 
     # TODO: caching is significant factor for why permutations work at all. Change this.
     V = _symbols('x', len(terms))
-
     mapping = dict(list(zip(terms, V)))
 
     rev_mapping = {}
@@ -366,7 +369,12 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     for mapping in mappings:
         mapping = list(mapping)
         mapping = mapping + unnecessary_permutations
-        diffs = [ _substitute(cancel(g.diff(x))) for g in terms ]
+        diffs=[]
+        for g in terms:
+            try:
+                diffs.append( _substitute(cancel(g.heurisch_diff())))
+            except:
+                diffs.append( _substitute(cancel(g.diff(x))))
         denoms = [ g.as_numer_denom()[1] for g in diffs ]
         if all(h.is_polynomial(*V) for h in denoms) and _substitute(f).is_rational_function(*V):
             denom = reduce(lambda p, q: lcm(p, q, *V), denoms)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -283,6 +283,13 @@ def test_issue_3952():
 def test_issue_4516():
     assert integrate(2**x - 2*x, x) == 2**x/log(2) - x**2
 
+def test_old_4058():
+    assert integrate(1/(5 + 3*cos(x) + 4*sin(x)), x) in \
+           [-1/(tan(x/2) + 2),tan(x/2)/(2*tan(x/2) + 4)]
+
+def test_issue_1393():
+    #This should now work, output needs to be checked
+    assert integrate(x**2 * sqrt(5 - x**2), x).has(Integral)
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))
@@ -724,6 +731,11 @@ def test_issue_4403():
     assert integrate(sqrt(x**2 - z**2), x) == \
         -z**2*acosh(x/z)/2 + x*sqrt(x**2 - z**2)/2
 
+
+def test_lambertw():
+    assert integrate(LambertW(x),x) == x*LambertW(x) - x +x/LambertW(x)
+
+def test_issue_1304_2():
     x = Symbol('x', real=True)
     y = Symbol('y', nonzero=True, real=True)
     assert integrate(1/(x**2 + y**2)**S('3/2'), x) == \

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -2383,6 +2383,19 @@ class MatrixBase(object):
                     return False
         return True
 
+    def is_probability_transition(self):
+        """
+        Checks if a matrix can represent a probability transition matrix.
+        The matrix must be square and all row entries must sum to 1.
+        """
+        if not self.is_square:
+            return False
+        for i in range(self.rows):
+            if sum(self.cols) != 1:
+                return False
+        return True
+
+
     def det(self, method="bareis"):
         """Computes the matrix determinant using the method "method".
 

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2174,6 +2174,13 @@ def test_anti_symmetric():
     m[0, 0] = 1
     assert m.is_anti_symmetric() is False
 
+def test_probability_transition():
+    assert Matrix([0.7,0.3]).is_probability_transition() is False
+    m = Matrix(3,3,[0,0.6,0.4,1,0,0,0.3,0.2,0.5])
+    n = Matrix(3,3,[1,x,-x,1,0,0,0.3,0.2,0.5])
+    assert m.is_probability_transition() is True
+    assert n.is_probability_transition() is True
+
 
 def test_normalize_sort_diogonalization():
     A = Matrix(((1, 2), (2, 1)))

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
-    Function, log, sqrt, Symbol, Subs
+    Function, log, sqrt, Symbol, Subs, LambertW
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
 from sympy.series.gruntz import calculate_series
@@ -27,6 +27,11 @@ def test_exp2():
     e1 = exp(cos(x)).series(x, 0)
     e2 = series(exp(cos(x)), x, 0)
     assert e1 == e2
+
+def test_lambertW_series():
+    #Test series around x=0
+    assert series(LambertW(x),x,6) == x - x**2 + 3*x**3/2 - 8*x**4/3 + 125*x**5/24 + O(x**6)
+
 
 
 def test_issue_5223():


### PR DESCRIPTION
integrals: Expanded heurisch() capabilities and revised tests
exponential: Added an alternate form of LambertW to fix issue# 7259
matrix: Added probability transition matrix property and added tests
trigonometric: Added an alternate form of fdiff for tan
test integrals: issue# 1304_2 has been fixed, removed xfail
test integrals: test# 1393 appears fixed, but output should be checked
test integrals: test# 4058 added, issue was pre-git

Improved scope of heurisch() by having the algorithm check for a special
form of a function's derivative. Because heurisch looks for the original
function, cases that have 0/0 forms in their fdiff such as LambertW(x)
have to be represented in a rational form that still evaluated correctly.
This special form has been added as the heurisch_diff property to tan
and LambertW. One issue to note is that without also including the chain
rule for tan (_Derivative(self.args[0],evaluate=True)), error in certain
integrals such as the following appear:
 integrate(1/(5 + 3_cos(x) + 4*sin(x)), x)
When the evaluation requests the first derivative of tan(x/2) to solve
this integral, it was not computing the chain rule and the answer was
off by a factor of 2. This behavior should be examined more closely to
find the source.

Fixed a NaN error (isssue#7259) when trying to evaluate:
series(LambertW(x),x)
This happened because of a 0/0 derivative form needed to integrate with 
Heurisch. It now evaluates the series and integral correctly. Tests
were added to series and integrals for confirmation.

The derivative of tangent will now show up as the more expected form
sec(x)**2 instead of 1 + tan(x)**2 which was previously needed to
integrate it. This was a result of the heurisch() fix.

For the matrix property addition, it can now test if the matrix could
be a representation of a probability transition. The matrix must be 
square and all rows must sum to a probability of 1.
