### PR TITLE
Simplify Not when applied to a Relational.

### DIFF
--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -282,7 +282,7 @@ def test_relational_logic_symbols():
 
     assert isinstance((x < y) & (z < t), And)
     assert isinstance((x < y) | (z < t), Or)
-    assert isinstance(~(x < y), Not)
+    assert isinstance(~(x < y), GreaterThan)
     assert isinstance((x < y) >> (z < t), Implies)
     assert isinstance((x < y) << (z < t), Implies)
     assert isinstance((x < y) ^ (z < t), (Or, Xor))
@@ -304,3 +304,12 @@ def test_univariate_relational_as_set():
 def test_multivariate_relational_as_set():
     assert (x*y >= 0).as_set() == Interval(0, oo)*Interval(0, oo) + \
         Interval(-oo, 0)*Interval(-oo, 0)
+
+
+def test_Not():
+    assert Not(Equality(x, y)) == Unequality(x, y)
+    assert Not(Unequality(x, y)) == Equality(x, y)
+    assert Not(StrictGreaterThan(x, y)) == LessThan(x, y)
+    assert Not(StrictLessThan(x, y)) == GreaterThan(x, y)
+    assert Not(GreaterThan(x, y)) == StrictLessThan(x, y)
+    assert Not(LessThan(x, y)) == StrictGreaterThan(x, y)

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -8,6 +8,7 @@ from itertools import product, islice
 
 from sympy.core.basic import Basic
 from sympy.core.cache import cacheit
+from sympy.core.core import C
 from sympy.core.numbers import Number
 from sympy.core.decorators import deprecated
 from sympy.core.operations import LatticeOp, AssocOp
@@ -411,6 +412,19 @@ class Not(BooleanFunction):
             return And(*[Not(a) for a in arg.args])
         if arg.func is Not:
             return arg.args[0]
+        # Simplify Relational objects.
+        if isinstance(arg, C.Equality):
+            return C.Unequality(*arg.args)
+        if isinstance(arg, C.Unequality):
+            return C.Equality(*arg.args)
+        if isinstance(arg, C.StrictLessThan):
+            return C.GreaterThan(*arg.args)
+        if isinstance(arg, C.StrictGreaterThan):
+            return C.LessThan(*arg.args)
+        if isinstance(arg, C.LessThan):
+            return C.StrictGreaterThan(*arg.args)
+        if isinstance(arg, C.GreaterThan):
+            return C.StrictLessThan(*arg.args)
 
     def as_set(self):
         """


### PR DESCRIPTION
Replaces the Not object with a corresponding Relational object with equivalent meaning.

Note that I included the logic entirely within the Not class.  It may be preferable to instead to create something like an `_eval_Not` method for each relational object, and have Not call that method on any object where it's available.  But Relationals may be the only objects that need such special treatment, so the extra layer of indirection would be unneccessary and confusing.  In conclusion, feedback is appreciated!
