### PR TITLE
Point.is_collinear() should check for object types

### DIFF
--- a/sympy/geometry/point.py
+++ b/sympy/geometry/point.py
@@ -218,6 +218,9 @@ class Point(GeometryEntity):
         # Coincident points are irrelevant and can confuse this algorithm.
         # Use only unique points.
         points = list(set(points))
+        if not all(isinstance(p, Point) for p in points):
+            raise TypeError('Must pass only Point objects')
+
         if len(points) == 0:
             return False
         if len(points) <= 2:

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -108,6 +108,9 @@ def test_point():
     assert Point.is_collinear(p3, p4, p1_1, p1_2)
     assert Point.is_collinear(p3, p4, p1_1, p1_3) is False
     assert Point.is_collinear(p3, p3, p4, p5) is False
+    line = Line(Point(1,0), slope = 1)
+    raises(TypeError, lambda: Point.is_collinear(line))
+    raises(TypeError, lambda: p1_1.is_collinear(line))
 
     assert p3.intersection(Point(0, 0)) == [p3]
     assert p3.intersection(p4) == []


### PR DESCRIPTION
This patch adds a minor fix to Point.is_collinear() so that if any other
geometric object is passed to it, it raises a TypeError

For more background:
https://groups.google.com/forum/#!topic/sympy/vZxvnwemC4k
