### PR TITLE
Rename subset() to is_subset() #7460

### DIFF
--- a/sympy/categories/baseclasses.py
+++ b/sympy/categories/baseclasses.py
@@ -914,7 +914,7 @@ class Diagram(Basic):
         >>> d1 == Diagram([f], {f: "unique"})
         True
         """
-        if not self.objects.subset(objects):
+        if not objects.is_subset(self.objects):
             raise ValueError(
                 "Supplied objects should all belong to the diagram.")
 

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -98,7 +98,7 @@ def test_union():
     Y = Interval(1, 2) + FiniteSet(3)
     XandY = X.intersect(Y)
     assert 2 in X and 3 in X and 3 in XandY
-    assert X.subset(XandY) and Y.subset(XandY)
+    assert XandY.is_subset(X) and XandY.is_subset(Y)
 
     raises(TypeError, lambda: Union(1, 2, 3))
 
@@ -267,27 +267,50 @@ def test_measure():
     assert (band * FiniteSet(1, 2, 3)).measure == nan
 
 
-def test_subset():
-    assert Interval(0, 2).subset(Interval(0, 1)) is True
-    assert Interval(0, 2).subset(Interval(0, 3)) is False
+def test_is_subset():
+    assert Interval(0, 1).is_subset(Interval(0, 2)) is True
+    assert Interval(0, 3).is_subset(Interval(0, 2)) is False
 
-    assert FiniteSet(1, 2, 3, 4).subset(FiniteSet(1, 2))
-    assert FiniteSet(1, 2, 3, 4).subset(FiniteSet(4, 5)) is False
-    assert Interval(0, 2).subset(FiniteSet(1))
-    assert Interval(0, 2, True, True).subset(FiniteSet(1, 2)) is False
-    assert (Interval(0, 2, False, True) + FiniteSet(2, 3)).subset(
-        Interval(1, 2) + FiniteSet(3))
+    assert FiniteSet(1, 2).is_subset(FiniteSet(1, 2, 3, 4))
+    assert FiniteSet(4, 5).is_subset(FiniteSet(1, 2, 3, 4)) is False
+    assert FiniteSet(1).is_subset(Interval(0, 2))
+    assert FiniteSet(1, 2).is_subset(Interval(0, 2, True, True)) is False
+    assert (Interval(1, 2) + FiniteSet(3)).is_subset(
+        (Interval(0, 2, False, True) + FiniteSet(2, 3)))
 
-    assert Union(Interval(0, 1), Interval(2, 5)).subset(Interval(3, 4)) is True
-    assert Union(Interval(0, 1), Interval(2, 5)).subset(Interval(3, 6)) is False
+    assert Interval(3, 4).is_subset(Union(Interval(0, 1), Interval(2, 5))) is True
+    assert Interval(3, 6).is_subset(Union(Interval(0, 1), Interval(2, 5))) is False
 
-    assert Interval(0, 5).subset(FiniteSet(1, 2, 3, 4)) is True
-    assert FiniteSet(1, 2, 3).subset(S.EmptySet) is True
+    assert FiniteSet(1, 2, 3, 4).is_subset(Interval(0, 5)) is True
+    assert S.EmptySet.is_subset(FiniteSet(1, 2, 3)) is True
 
-    assert S.EmptySet.subset(Interval(0, 1)) is False
-    assert S.EmptySet.subset(S.EmptySet) is True
+    assert Interval(0, 1).is_subset(S.EmptySet) is False
+    assert S.EmptySet.is_subset(S.EmptySet) is True
 
-    raises(ValueError, lambda: S.EmptySet.subset(1))
+    raises(ValueError, lambda: S.EmptySet.is_subset(1))
+
+
+def test_is_superset():
+
+    assert Interval(0, 1).is_superset(Interval(0, 2)) == False
+    assert Interval(0, 3).is_superset(Interval(0, 2))
+
+    assert FiniteSet(1, 2).is_superset(FiniteSet(1, 2, 3, 4)) == False
+    assert FiniteSet(4, 5).is_superset(FiniteSet(1, 2, 3, 4)) == False
+    assert FiniteSet(1).is_superset(Interval(0, 2)) == False
+    assert FiniteSet(1, 2).is_superset(Interval(0, 2, True, True)) == False
+    assert (Interval(1, 2) + FiniteSet(3)).is_superset(
+        (Interval(0, 2, False, True) + FiniteSet(2, 3))) == False
+
+    assert Interval(3, 4).is_superset(Union(Interval(0, 1), Interval(2, 5))) == False
+
+    assert FiniteSet(1, 2, 3, 4).is_superset(Interval(0, 5)) == False
+    assert S.EmptySet.is_superset(FiniteSet(1, 2, 3)) == False
+
+    assert Interval(0, 1).is_superset(S.EmptySet) == True
+    assert S.EmptySet.is_superset(S.EmptySet) == True
+
+    raises(ValueError, lambda: S.EmptySet.is_superset(1))
 
 
 def test_contains():
@@ -414,8 +437,8 @@ def test_finite_basic():
     B = FiniteSet(3, 4, 5)
     AorB = Union(A, B)
     AandB = A.intersect(B)
-    assert AorB.subset(A) and AorB.subset(B)
-    assert A.subset(AandB)
+    assert A.is_subset(AorB) and B.is_subset(AorB)
+    assert AandB.is_subset(A)
     assert AandB == FiniteSet(3)
 
     assert A.inf == 1 and A.sup == 3
@@ -473,7 +496,7 @@ def test_product_basic():
     HH, TT = sympify(H), sympify(T)
     assert set(coin**2) == set(((HH, HH), (HH, TT), (TT, HH), (TT, TT)))
 
-    assert (d6*d6).subset(d4*d4)
+    assert (d4*d4).is_subset(d6*d6)
 
     inf, neginf = S.Infinity, S.NegativeInfinity
     assert square.complement == Union(
@@ -484,11 +507,11 @@ def test_product_basic():
         ((Interval(neginf, 0, True, True) + Interval(1, inf, True, True))
          * (Interval(neginf, 0, True, True) + Interval(1, inf, True, True))))
 
-    assert (Interval(-10, 10)**3).subset(Interval(-5, 5)**3)
-    assert not (Interval(-5, 5)**3).subset(Interval(-10, 10)**3)
-    assert not (Interval(-10, 10)**2).subset(Interval(-5, 5)**3)
+    assert (Interval(-5, 5)**3).is_subset(Interval(-10, 10)**3)
+    assert not (Interval(-10, 10)**3).is_subset(Interval(-5, 5)**3)
+    assert not (Interval(-5, 5)**2).is_subset(Interval(-10, 10)**3)
 
-    assert square.subset(Interval(.2, .5)*FiniteSet(.5))  # segment in square
+    assert (Interval(.2, .5)*FiniteSet(.5)).is_subset(square)  # segment in square
 
 
 def test_real():


### PR DESCRIPTION
The subset() method is now marked as deprecated. The is_subset() method
also has a different semantic meaning now.

Earlier, self.subset(other) checked if 'other' is a subset of
'self'. However, now with the renaming it makes more sense that the
method call self.is_subset(other) is interpreted as check if 'self' is a
subset of 'other'.

(See: https://groups.google.com/d/topic/sympy/ODHAMlExSb0/discussion for more context)
