### PR TITLE
Avoid superfluous CSEs from Idx and IndexedBase instances

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -12,6 +12,7 @@ from sympy.core.exprtools import factor_terms
 from sympy.core.compatibility import iterable, xrange
 from sympy.utilities.iterables import filter_symbols, \
     numbered_symbols, sift, topological_sort, ordered
+from sympy.tensor import Idx
 
 from . import cse_opts
 
@@ -294,7 +295,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
     seen_subexp = set()
 
     def _find_repeated(expr):
-        if expr.is_Atom or expr.is_Order:
+        if expr.is_Atom or expr.is_Order or isinstance(expr, Idx):
             return
 
         if iterable(expr):

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -322,12 +322,13 @@ def test_symbols_exhausted_error():
     with raises(ValueError) as excinfo:
         cse(l, symbols=sym)
 
+
 def test_cse_Idx_IndexedBase():
     # There is only one cse in below expression: i+1
-    len_y=5
+    len_y = 5
     i = Idx('i', len_y-1)
     y = IndexedBase('y', shape=(len_y,))
     x = IndexedBase('x', shape=(len_y,))
-    cses = cse((y[i+1] - y[i])/(x[i+1] - x[i]))
+    cses = cse((y[i + 1] - y[i])/(x[i + 1] - x[i]))
     assert len(cses[0]) == 1
-    assert cses[0][0][1] - (i+1) == 0
+    assert cses[0][0][1] - (i + 1) == 0

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -321,3 +321,13 @@ def test_symbols_exhausted_error():
     sym = [x, y, z]
     with raises(ValueError) as excinfo:
         cse(l, symbols=sym)
+
+def test_cse_Idx_IndexedBase():
+    # There is only one cse in below expression: i+1
+    len_y=5
+    i = Idx('i', len_y-1)
+    y = IndexedBase('y', shape=(len_y,))
+    x = IndexedBase('x', shape=(len_y,))
+    cses = cse((y[i+1] - y[i])/(x[i+1] - x[i]))
+    assert len(cses[0]) == 1
+    assert cses[0][0][1] - (i+1) == 0

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -234,10 +234,10 @@ def get_indices(expr):
         return inds, {}
     elif expr is None:
         return set(), {}
-    elif expr.is_Atom:
-        return set(), {}
     elif isinstance(expr, Idx):
         return set([expr]), {}
+    elif expr.is_Atom:
+        return set(), {}
 
     # recurse via specialized functions
     else:

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -108,7 +108,7 @@
 
 from __future__ import print_function, division
 
-from sympy.core import Expr, Tuple, Symbol, sympify, S
+from sympy.core import AtomicExpr, Expr, Tuple, Symbol, sympify, S
 from sympy.core.compatibility import is_sequence, string_types, NotIterable
 
 
@@ -134,7 +134,7 @@ class Indexed(Expr):
     """
     is_commutative = True
 
-    def __new__(cls, base, *args, **kw_args):
+    def __new__(cls, base, *args):
         from sympy.utilities.misc import filldedent
 
         if not args:
@@ -145,7 +145,7 @@ class Indexed(Expr):
             raise TypeError(filldedent("""
                 Indexed expects string, Symbol or IndexedBase as base."""))
         args = list(map(sympify, args))
-        return Expr.__new__(cls, base, *args, **kw_args)
+        return Expr.__new__(cls, base, *args)
 
     @property
     def base(self):
@@ -272,7 +272,7 @@ class Indexed(Expr):
         return "%s[%s]" % (p.doprint(self.base), ", ".join(indices))
 
 
-class IndexedBase(Expr, NotIterable):
+class IndexedBase(AtomicExpr, NotIterable):
     """Represent the base or stem of an indexed object
 
     The IndexedBase class represent an array that contains elements. The main purpose
@@ -325,7 +325,7 @@ class IndexedBase(Expr, NotIterable):
     """
     is_commutative = True
 
-    def __new__(cls, label, shape=None, **kw_args):
+    def __new__(cls, label, shape=None):
         if isinstance(label, string_types):
             label = Symbol(label)
         elif isinstance(label, Symbol):
@@ -333,44 +333,23 @@ class IndexedBase(Expr, NotIterable):
         else:
             raise TypeError("Base label should be a string or Symbol.")
 
-        obj = Expr.__new__(cls, label, **kw_args)
+        label = Symbol(label) if not isinstance(label, Symbol) else label
         if is_sequence(shape):
-            obj._shape = Tuple(*shape)
+            shape = Tuple(*shape)
         else:
-            obj._shape = sympify(shape)
-        return obj
+            shape = sympify(shape)
+        return AtomicExpr.__new__(cls, label, shape)
 
-    @property
-    def args(self):
-        """Returns the arguments used to create this IndexedBase object.
-
-        Examples
-        ========
-
-        >>> from sympy import IndexedBase
-        >>> from sympy.abc import x, y
-        >>> IndexedBase('A', shape=(x, y)).args
-        (A, (x, y))
-
-        """
-        if self._shape:
-            return self._args + (self._shape,)
-        else:
-            return self._args
-
-    def _hashable_content(self):
-        return Expr._hashable_content(self) + (self._shape,)
-
-    def __getitem__(self, indices, **kw_args):
+    def __getitem__(self, indices):
         if is_sequence(indices):
             # Special case needed because M[*my_tuple] is a syntax error.
             if self.shape and len(self.shape) != len(indices):
                 raise IndexException("Rank mismatch.")
-            return Indexed(self, *indices, **kw_args)
+            return Indexed(self, *indices)
         else:
             if self.shape and len(self.shape) != 1:
                 raise IndexException("Rank mismatch.")
-            return Indexed(self, indices, **kw_args)
+            return Indexed(self, indices)
 
     @property
     def shape(self):
@@ -397,7 +376,8 @@ class IndexedBase(Expr, NotIterable):
         (2, 1)
 
         """
-        return self._shape
+        return self._args[1]
+
 
     @property
     def label(self):
@@ -412,7 +392,7 @@ class IndexedBase(Expr, NotIterable):
         A
 
         """
-        return self.args[0]
+        return self._args[0]
 
     def _sympystr(self, p):
         return p.doprint(self.label)
@@ -487,7 +467,7 @@ class Idx(Expr):
 
     is_integer = True
 
-    def __new__(cls, label, range=None, **kw_args):
+    def __new__(cls, label, range=None):
         from sympy.utilities.misc import filldedent
 
         if isinstance(label, string_types):
@@ -516,7 +496,7 @@ class Idx(Expr):
         else:
             args = label,
 
-        obj = Expr.__new__(cls, *args, **kw_args)
+        obj = Expr.__new__(cls, *args)
         return obj
 
     @property
@@ -539,6 +519,23 @@ class Idx(Expr):
         return self.args[0]
 
     @property
+    def range(self):
+        """Returns the range of the Idx object.
+
+        Examples
+        ========
+
+        >>> from sympy import Idx
+        >>> Idx('j', 2).range
+        (0, 1)
+
+        """
+        try:
+            return self.args[1]
+        except IndexError:
+            return (None, None)
+
+    @property
     def lower(self):
         """Returns the lower bound of the Index.
 
@@ -554,10 +551,7 @@ class Idx(Expr):
         True
 
         """
-        try:
-            return self.args[1][0]
-        except IndexError:
-            return
+        return self.range[0]
 
     @property
     def upper(self):
@@ -575,10 +569,7 @@ class Idx(Expr):
         True
 
         """
-        try:
-            return self.args[1][1]
-        except IndexError:
-            return
+        return self.range[1]
 
     def _sympystr(self, p):
         return p.doprint(self.label)

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -109,7 +109,8 @@
 from __future__ import print_function, division
 
 from sympy.core import AtomicExpr, Expr, Tuple, Symbol, sympify, S
-from sympy.core.compatibility import is_sequence, string_types, NotIterable
+from sympy.core.compatibility import (is_sequence, string_types,
+    NotIterable, reduce)
 
 
 class IndexException(Exception):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -352,6 +352,14 @@ class IndexedBase(AtomicExpr, NotIterable):
             return Indexed(self, indices)
 
     @property
+    def free_symbols(self):
+        if self.shape is None:
+            return self.label.free_symbols
+        else:
+            union = set.union
+            return reduce(union, [arg.free_symbols for arg in self.args], set())
+
+    @property
     def shape(self):
         """Returns the shape of the IndexedBase object.
 

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -30,8 +30,10 @@ def test_Idx_properties():
 
 def test_Idx_bounds():
     i, a, b = symbols('i a b', integer=True)
+    assert Idx(i).range == (None, None)
     assert Idx(i).lower is None
     assert Idx(i).upper is None
+    assert Idx(i, a).range == (0, a - 1)
     assert Idx(i, a).lower == 0
     assert Idx(i, a).upper == a - 1
     assert Idx(i, 5).lower == 0

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -193,3 +193,16 @@ def test_Indexed_coeff():
     a = (1/y[i+1]*y[i]).coeff(y[i])
     b = (y[i]/y[i+1]).coeff(y[i])
     assert a == b
+
+
+def test_Indexed_free_symbols():
+    # Added in PR 7347: free_symbols method was added
+    # to make solve() work after modifications to Indexed.
+    N = Symbol('N', integer=True)
+    len_y = N
+    i = Idx('i', len_y-1)
+    y = IndexedBase('y', shape=(len_y,))
+    assert y[i].free_symbols == set([N, y, i])
+
+    z = IndexedBase('z')
+    assert z[i].free_symbols == set([z, i])

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -202,7 +202,8 @@ def test_Indexed_free_symbols():
     len_y = N
     i = Idx('i', len_y-1)
     y = IndexedBase('y', shape=(len_y,))
-    assert y[i].free_symbols == set([N, y, i])
+    assert y[i].free_symbols == set([N, y.label, i.label])
 
     z = IndexedBase('z')
-    assert z[i].free_symbols == set([z, i])
+    j = Idx('j')
+    assert z[j].free_symbols == set([z.label, j.label])


### PR DESCRIPTION
Continuing my work on codegeneration of finite differences using Sympy I've come across
a possiblity for a minor enhancement of the cse routine:

consider:

``` python
from sympy import *
len_y=5
i = Idx('i', len_y-1)
y = IndexedBase('y', shape=(len_y,))
x = IndexedBase('x', shape=(len_y,))

# Forward difference
print(cse((y[i+1]-y[i])/(x[i+1]-x[i])))
```

which outputs

```
([(x0, y), (x1, i), (x2, x1 + 1), (x3, x)], [(-x0[x1] + x0[x2])*(-x3[x1] + x3[x2])**(-1)])
```

here, the Idx and IndexedBase instances have been taken to be cses which makes e.g. code generation
much more verbose (in reality I have more indices and more IndexedBase).

This PR fixes the issue and only "i+1" is correctly identified as a true CSE.
