### PR TITLE
Makes IndexedBase consistent with Symbol wrt to latex printing

### DIFF
--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -385,6 +385,10 @@ def test_latex_indexed():
     Psi_indexed = IndexedBase(Symbol('Psi', complex=True, real=False))
     assert latex(Psi_symbol * conjugate(Psi_symbol)) == latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
 
+    gamma = IndexedBase('gamma')
+    assert latex(gamma) == r'\gamma' # Symbol('gamma') gives r'\gamma'
+
+
 def test_latex_derivatives():
     # regular "d" for ordinary derivatives
     assert latex(diff(x**3, x, evaluate=False)) == \

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -385,8 +385,10 @@ def test_latex_indexed():
     Psi_indexed = IndexedBase(Symbol('Psi', complex=True, real=False))
     assert latex(Psi_symbol * conjugate(Psi_symbol)) == latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
 
-    gamma = IndexedBase('gamma')
-    assert latex(gamma) == r'\gamma' # Symbol('gamma') gives r'\gamma'
+    # Symbol('gamma') gives r'\gamma'
+    assert latex(IndexedBase('gamma')) == r'\gamma'
+    assert latex(IndexedBase('a b')) == 'a b'
+    assert latex(IndexedBase('a_b')) == 'a_{b}'
 
 
 def test_latex_derivatives():

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -326,10 +326,13 @@ class IndexedBase(Expr, NotIterable):
     is_commutative = False
 
     def __new__(cls, label, shape=None, **kw_args):
-        if not isinstance(label, (string_types, Symbol)):
+        if isinstance(label, string_types):
+            label = Symbol(label)
+        elif isinstance(label, Symbol):
+            pass
+        else:
             raise TypeError("Base label should be a string or Symbol.")
 
-        label = sympify(label)
         obj = Expr.__new__(cls, label, **kw_args)
         if is_sequence(shape):
             obj._shape = Tuple(*shape)


### PR DESCRIPTION
use of `sympify` on `label` in `IndexedBase.__init__` makes e.g. `type(IndexedBase('gamma').label) == sympy.functions.special.gamma_functions.gamma`

This fixes this inconsistency between IndexedBase and Symbol.
