### PR TITLE
Fix coeff for indexed

### DIFF
--- a/doc/src/modules/utilities/autowrap.rst
+++ b/doc/src/modules/utilities/autowrap.rst
@@ -13,7 +13,7 @@ routine that calculates a matrix-vector product.
 >>> i = Idx('i', m)
 >>> j = Idx('j', n)
 >>> instruction = Eq(y[i], A[i, j]*x[j]); instruction
-y[i] == A[i, j]*x[j]
+y[i] == x[j]*A[i, j]
 
 Because the code printers treat Indexed objects with repeated indices as a
 summation, the above equality instance will be translated to low-level code for

--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -273,7 +273,7 @@ def ccode(expr, assign_to=None, **settings):
         >>> i = Idx('i', len_y-1)
         >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
         >>> ccode(e.rhs, assign_to=e.lhs, contract=False)
-        'Dy[i] = (y[i + 1] - y[i])*1.0/(t[i + 1] - t[i]);'
+        'Dy[i] = (y[i + 1] - y[i])/(t[i + 1] - t[i]);'
 
     """
     return CCodePrinter(settings).doprint(expr, assign_to)

--- a/sympy/printing/fcode.py
+++ b/sympy/printing/fcode.py
@@ -456,7 +456,7 @@ def fcode(expr, **settings):
        >>> i = Idx('i', len_y-1)
        >>> e=Eq(Dy[i], (y[i+1]-y[i])/(t[i+1]-t[i]))
        >>> fcode(e.rhs, assign_to=e.lhs, contract=False)
-       '      Dy(i) = (y(i + 1) - y(i))*1.0/(t(i + 1) - t(i))'
+       '      Dy(i) = (y(i + 1) - y(i))/(t(i + 1) - t(i))'
 
     """
     # run the printer

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -78,7 +78,7 @@ def test_ccode_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert ccode(g(A[i]), assign_to=A[i]) == (
         "for (int i=0; i<n; i++){\n"
-        "   A[i] = A[i]*(1 + A[i])*(2 + A[i]);\n"
+        "   A[i] = (A[i] + 1)*(A[i] + 2)*A[i];\n"
         "}"
     )
 
@@ -168,7 +168,7 @@ def test_ccode_Indexed_without_looking_for_contraction():
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
     code0 = ccode(e.rhs, assign_to=e.lhs, contract=False)
-    assert code0 == 'Dy[i] = (y[%s] - y[i])*1.0/(x[%s] - x[i]);' % (i + 1, i + 1)
+    assert code0 == 'Dy[i] = (y[%s] - y[i])/(x[%s] - x[i]);' % (i + 1, i + 1)
 
 
 def test_ccode_loops_matrix_vector():
@@ -185,7 +185,7 @@ def test_ccode_loops_matrix_vector():
         '}\n'
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = y[i] + A[%s]*x[j];\n' % (i*n + j) +\
+        '      y[i] = x[j]*A[%s] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}'
     )
@@ -228,7 +228,7 @@ def test_ccode_loops_add():
         '}\n'
         'for (int i=0; i<m; i++){\n'
         '   for (int j=0; j<n; j++){\n'
-        '      y[i] = y[i] + A[%s]*x[j];\n' % (i*n + j) +\
+        '      y[i] = x[j]*A[%s] + y[i];\n' % (i*n + j) +\
         '   }\n'
         '}'
     )

--- a/sympy/printing/tests/test_fcode.py
+++ b/sympy/printing/tests/test_fcode.py
@@ -158,7 +158,7 @@ def test_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert fcode(g(A[i]), assign_to=A[i]) == (
         "      do i = 1, n\n"
-        "         A(i) = A(i)*(1 + A(i))*(2 + A(i))\n"
+        "         A(i) = (A(i) + 1)*(A(i) + 2)*A(i)\n"
         "      end do"
     )
 
@@ -546,7 +546,9 @@ def test_loops():
 
     code = fcode(A[i, j]*x[j], assign_to=y[i], source_format='free')
     assert (code == expected % {'rhs': 'y(i) + A(i, j)*x(j)'} or
-            code == expected % {'rhs': 'y(i) + x(j)*A(i, j)'})
+            code == expected % {'rhs': 'y(i) + x(j)*A(i, j)'} or
+            code == expected % {'rhs': 'x(j)*A(i, j) + y(i)'} or
+            code == expected % {'rhs': 'A(i, j)*x(j) + y(i)'})
 
 
 def test_dummy_loops():
@@ -574,7 +576,7 @@ def test_fcode_Indexed_without_looking_for_contraction():
     i = Idx('i', len_y-1)
     e=Eq(Dy[i], (y[i+1]-y[i])/(x[i+1]-x[i]))
     code0 = fcode(e.rhs, assign_to=e.lhs, contract=False)
-    assert code0.endswith('Dy(i) = (y(i + 1) - y(i))*1.0/(x(i + 1) - x(i))')
+    assert code0.endswith('Dy(i) = (y(i + 1) - y(i))/(x(i + 1) - x(i))')
 
 
 def test_derived_classes():

--- a/sympy/printing/tests/test_jscode.py
+++ b/sympy/printing/tests/test_jscode.py
@@ -72,7 +72,7 @@ def test_jscode_inline_function():
     g = implemented_function('g', Lambda(x, x*(1 + x)*(2 + x)))
     assert jscode(g(A[i]), assign_to=A[i]) == (
         "for (var i=0; i<n; i++){\n"
-        "   A[i] = A[i]*(1 + A[i])*(2 + A[i]);\n"
+        "   A[i] = (A[i] + 1)*(A[i] + 2)*A[i];\n"
         "}"
     )
 
@@ -156,7 +156,7 @@ def test_jscode_loops_matrix_vector():
         '}\n'
         'for (var i=0; i<m; i++){\n'
         '   for (var j=0; j<n; j++){\n'
-        '      y[i] = y[i] + A[i*n + j]*x[j];\n'
+        '      y[i] = x[j]*A[i*n + j] + y[i];\n'
         '   }\n'
         '}'
     )
@@ -199,7 +199,7 @@ def test_jscode_loops_add():
         '}\n'
         'for (var i=0; i<m; i++){\n'
         '   for (var j=0; j<n; j++){\n'
-        '      y[i] = y[i] + A[i*n + j]*x[j];\n'
+        '      y[i] = x[j]*A[i*n + j] + y[i];\n'
         '   }\n'
         '}'
     )

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -383,7 +383,11 @@ def test_latex_brackets():
 def test_latex_indexed():
     Psi_symbol = Symbol('Psi_0', complex=True, real=False)
     Psi_indexed = IndexedBase(Symbol('Psi', complex=True, real=False))
-    assert latex(Psi_symbol * conjugate(Psi_symbol)) == latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
+    symbol_latex = latex(Psi_symbol * conjugate(Psi_symbol))
+    indexed_latex = latex(Psi_indexed[0] * conjugate(Psi_indexed[0]))
+    # \\overline{\\Psi_{0}} \\Psi_{0}   vs.   \\Psi_{0} \\overline{\\Psi_{0}}
+    assert symbol_latex.split() == indexed_latex.split() \
+        or symbol_latex.split() == indexed_latex.split()[::-1]
 
 def test_latex_derivatives():
     # regular "d" for ordinary derivatives

--- a/sympy/tensor/index_methods.py
+++ b/sympy/tensor/index_methods.py
@@ -334,11 +334,11 @@ def get_contraction_structure(expr):
 
     >>> d = get_contraction_structure(x[i]*(y[i] + A[i, j]*x[j]))
     >>> sorted(d.keys(), key=default_sort_key)
-    [x[i]*(y[i] + A[i, j]*x[j]), (i,)]
+    [(x[j]*A[i, j] + y[i])*x[i], (i,)]
     >>> d[(i,)]
-    set([x[i]*(y[i] + A[i, j]*x[j])])
+    set([(x[j]*A[i, j] + y[i])*x[i]])
     >>> d[x[i]*(A[i, j]*x[j] + y[i])]
-    [{None: set([y[i]]), (j,): set([A[i, j]*x[j]])}]
+    [{None: set([y[i]]), (j,): set([x[j]*A[i, j]])}]
 
     Powers with contractions in either base or exponent will also be found as
     keys in the dictionary, mapping to a list of results from recursive calls:

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -132,7 +132,7 @@ class Indexed(Expr):
     True
 
     """
-    is_commutative = False
+    is_commutative = True
 
     def __new__(cls, base, *args, **kw_args):
         from sympy.utilities.misc import filldedent
@@ -323,7 +323,7 @@ class IndexedBase(Expr, NotIterable):
     (o, p)
 
     """
-    is_commutative = False
+    is_commutative = True
 
     def __new__(cls, label, shape=None, **kw_args):
         if not isinstance(label, (string_types, Symbol)):

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -43,7 +43,7 @@
 
     >>> x = IndexedBase('x')
     >>> M[i, j]*x[j]
-    M[i, j]*x[j]
+    x[j]*M[i, j]
 
     If the indexed objects will be converted to component based arrays, e.g.
     with the code printers or the autowrap framework, you also need to provide

--- a/sympy/tensor/tests/test_indexed.py
+++ b/sympy/tensor/tests/test_indexed.py
@@ -181,3 +181,13 @@ def test_not_interable():
     i, j = symbols('i j', integer=True)
     A = Indexed('A', i, i + j)
     assert not iterable(A)
+
+
+def test_Indexed_coeff():
+    N = Symbol('N', integer=True)
+    len_y = N
+    i = Idx('i', len_y-1)
+    y = IndexedBase('y', shape=(len_y,))
+    a = (1/y[i+1]*y[i]).coeff(y[i])
+    b = (y[i]/y[i+1]).coeff(y[i])
+    assert a == b

--- a/sympy/utilities/tests/test_codegen.py
+++ b/sympy/utilities/tests/test_codegen.py
@@ -345,7 +345,7 @@ def test_loops_c():
         '   }\n'
         '   for (int i=0; i<m; i++){\n'
         '      for (int j=0; j<n; j++){\n'
-        '         y[i] = y[i] + %(rhs)s;\n'
+        '         y[i] = %(rhs)s + y[i];\n'
         '      }\n'
         '   }\n'
         '}\n'
@@ -413,7 +413,7 @@ def test_partial_loops_c():
         '   }\n'
         '   for (int i=o; i<%(upperi)s; i++){\n'
         '      for (int j=0; j<n; j++){\n'
-        '         y[i] = y[i] + %(rhs)s;\n'
+        '         y[i] = %(rhs)s + y[i];\n'
         '      }\n'
         '   }\n'
         '}\n'
@@ -917,13 +917,14 @@ def test_loops():
         'end do\n'
         'do i = 1, m\n'
         '   do j = 1, n\n'
-        '      y(i) = y(i) + %(rhs)s\n'
+        '      y(i) = %(rhs)s + y(i)\n'
         '   end do\n'
         'end do\n'
         'end subroutine\n'
-    ) % {'rhs': 'A(i, j)*x(j)'}
+    )
 
-    assert expected == code
+    assert code == expected % {'rhs': 'A(i, j)*x(j)'} or\
+        code == expected % {'rhs': 'x(j)*A(i, j)'}
     assert f2 == 'file.h'
     assert interface == (
         'interface\n'
@@ -992,7 +993,7 @@ def test_loops_InOut():
         'INTEGER*4 :: j\n'
         'do i = 1, m\n'
         '   do j = 1, n\n'
-        '      y(i) = y(i) + %(rhs)s\n'
+        '      y(i) = %(rhs)s + y(i)\n'
         '   end do\n'
         'end do\n'
         'end subroutine\n'
@@ -1047,18 +1048,19 @@ def test_partial_loops_f():
         'end do\n'
         'do i = %(ilow)s, %(iup)s\n'
         '   do j = 1, n\n'
-        '      y(i) = y(i) + %(rhs)s\n'
+        '      y(i) = %(rhs)s + y(i)\n'
         '   end do\n'
         'end do\n'
         'end subroutine\n'
     ) % {
-        'rhs': 'A(i, j)*x(j)',
+        'rhs': '%(rhs)s',
         'iup': str(m - 4),
         'ilow': str(1 + o),
         'iup-ilow': str(m - 4 - o)
     }
 
-    assert expected == code
+    assert code == expected % {'rhs': 'A(i, j)*x(j)'} or\
+        code == expected % {'rhs': 'x(j)*A(i, j)'}
 
 
 def test_output_arg_f():
@@ -1097,11 +1099,13 @@ def test_inline_function():
         'REAL*8, intent(out), dimension(1:m) :: y\n'
         'INTEGER*4 :: i\n'
         'do i = 1, m\n'
-        '   y(i) = x(i)*(1 + x(i))\n'
+        '   y(i) = %s*%s\n'
         'end do\n'
         'end subroutine\n'
     )
-    assert code == expected
+    args = ('x(i)', '(x(i) + 1)')
+    assert code == expected % args or\
+        code == expected % args[::-1]
 
 
 def test_check_case():


### PR DESCRIPTION
IndexedBase and Indexed are currently not commutative by default in SymPy. This is fine for tensors
but since these two classes are supposed to be lowest common denominator between different use cases I argue that we should make them commutative by default  in order not to confuse users who do not know about tensor algebra. (I was surprised when my code snippet below did not work - the example came up when doing finite differences)

``` python
N = Symbol('N', integer=True)
len_y = N
i = Idx('i', len_y-1)
y = IndexedBase('y', shape=(len_y,))
y.is_commutative = True
a = (1/y[i+1]*y[i]).coeff(y[i])
b = (y[i]/y[i+1]).coeff(y[i])
assert a == b
```

These commits changes the default of IndexedBase and Indexed to be commutative and hence the above example works (added as a test). I really think this is what we want as a default as it makes Indexed instances match Symbol instances more closely.
