### PR TITLE
Fixed positive assumption for arc trigonometric functions

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -310,3 +310,25 @@ class AskPositiveHandler(CommonHandler):
         if (expr.i == expr.j
                 and ask(Q.positive_definite(expr.parent), assumptions)):
             return True
+
+    @staticmethod
+    def atan(expr, assumptions):
+        return ask(Q.positive(expr.args[0]), assumptions)
+
+    @staticmethod
+    def asin(expr, assumptions):
+        x = expr.args[0]
+        if ask(Q.positive(x) & Q.nonpositive(x - 1), assumptions):
+            return True
+        if ask(Q.negative(x) & Q.nonnegative(x + 1), assumptions):
+            return False
+
+    @staticmethod
+    def acos(expr, assumptions):
+        x = expr.args[0]
+        if ask(Q.nonpositive(x - 1) & Q.nonnegative(x + 1), assumptions):
+            return True
+
+    @staticmethod
+    def acot(expr, assumptions):
+        return ask(Q.real(expr.args[0]), assumptions)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2087,12 +2087,12 @@ def test_issue_7246():
 
     assert ask(Q.positive(asin(p)), Q.positive(p)) is None
     assert ask(Q.positive(asin(p)), Q.zero(p)) is None
-    assert ask(Q.positive(asin(Rational(1, 2)))) is True
+    assert ask(Q.positive(asin(Rational(1, 7)))) is True
     assert ask(Q.positive(asin(x)), Q.positive(x) & Q.nonpositive(x - 1)) is True
     assert ask(Q.positive(asin(x)), Q.negative(x) & Q.nonnegative(x + 1)) is False
 
     assert ask(Q.positive(acos(p)), Q.positive(p)) is None
-    assert ask(Q.positive(acos(Rational(1, 2)))) is True
+    assert ask(Q.positive(acos(Rational(1, 7)))) is True
     assert ask(Q.positive(acos(x)), Q.nonnegative(x + 1) & Q.nonpositive(x - 1)) is True
     assert ask(Q.positive(acos(x)), Q.nonnegative(x - 1)) is None
 

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2077,3 +2077,33 @@ def test_issue_5833():
 def test_issue_6732():
     raises(ValueError, lambda: ask(Q.positive(x), Q.positive(x) & Q.negative(x)))
     raises(ValueError, lambda: ask(Q.negative(x), Q.positive(x) & Q.negative(x)))
+
+
+def test_issue_7246():
+    assert ask(Q.positive(atan(p)), Q.positive(p)) is True
+    assert ask(Q.positive(atan(p)), Q.negative(p)) is False
+    assert ask(Q.positive(atan(p)), Q.zero(p)) is False
+    assert ask(Q.positive(atan(x))) is None
+
+    assert ask(Q.positive(asin(p)), Q.positive(p)) is None
+    assert ask(Q.positive(asin(p)), Q.zero(p)) is None
+    assert ask(Q.positive(asin(Rational(1, 2)))) is True
+    assert ask(Q.positive(asin(x)), Q.positive(x) & Q.nonpositive(x - 1)) is True
+    assert ask(Q.positive(asin(x)), Q.negative(x) & Q.nonnegative(x + 1)) is False
+
+    assert ask(Q.positive(acos(p)), Q.positive(p)) is None
+    assert ask(Q.positive(acos(Rational(1, 2)))) is True
+    assert ask(Q.positive(acos(x)), Q.nonnegative(x + 1) & Q.nonpositive(x - 1)) is True
+    assert ask(Q.positive(acos(x)), Q.nonnegative(x - 1)) is None
+
+    assert ask(Q.positive(acot(x)), Q.positive(x)) is True
+    assert ask(Q.positive(acot(x)), Q.real(x)) is True
+    assert ask(Q.positive(acot(x)), Q.imaginary(x)) is False
+    assert ask(Q.positive(acot(x))) is None
+
+
+@XFAIL
+def test_issue_7246_failing():
+    #Move this test to test_issue_7246 once
+    #the new assumptions module is improved.
+    assert ask(Q.positive(acos(x)), Q.zero(x)) is True

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -10,7 +10,8 @@ from sympy.core.compatibility import xrange
 x, y, z = symbols('x y z')
 r = Symbol('r', real=True)
 k = Symbol('k', integer=True)
-
+p = Symbol('p', positive=True)
+n = Symbol('n', negative=True)
 
 def test_sin():
     x, y = symbols('x y')
@@ -558,6 +559,10 @@ def test_asin():
 
     assert asin(-2*I) == -I*asinh(2)
 
+    assert asin(Rational(1, 7), evaluate=False).is_positive is True
+    assert asin(Rational(-1, 7), evaluate=False).is_positive is False
+    assert asin(p).is_positive is None
+
 
 def test_asin_series():
     assert asin(x).series(x, 0, 9) == \
@@ -594,6 +599,11 @@ def test_acos():
     assert acos(0.2).is_real is True
     assert acos(-2).is_real is False
 
+    assert acos(Rational(1, 7), evaluate=False).is_positive is True
+    assert acos(Rational(-1, 7), evaluate=False).is_positive is True
+    assert acos(Rational(3, 2), evaluate=False).is_positive is False
+    assert acos(p).is_positive is None
+
 
 def test_acos_series():
     assert acos(x).series(x, 0, 8) == \
@@ -629,6 +639,9 @@ def test_atan():
     assert atan(r).is_real is True
 
     assert atan(-2*I) == -I*atanh(2)
+    assert atan(p).is_positive is True
+    assert atan(n).is_positive is False
+    assert atan(x).is_positive is None
 
 
 def test_atan_rewrite():
@@ -692,6 +705,10 @@ def test_acot():
 
     assert acot(I*pi) == -I*acoth(pi)
     assert acot(-2*I) == I*acoth(2)
+    assert acot(x).is_positive is None
+    assert acot(r).is_positive is True
+    assert acot(p).is_positive is True
+    assert acot(I).is_positive is False
 
 
 def test_acot_rewrite():

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1366,6 +1366,12 @@ class asin(Function):
         else:
             return s.is_rational
 
+    def _eval_is_positive(self):
+        if self.args[0].is_positive:
+            return (self.args[0] - 1).is_negative
+        if self.args[0].is_negative:
+            return not (self.args[0] + 1).is_positive
+
     @classmethod
     def eval(cls, arg):
         if arg.is_Number:
@@ -1506,6 +1512,11 @@ class acos(Function):
         else:
             return s.is_rational
 
+    def _eval_is_positive(self):
+        x = self.args[0]
+        if (x - 1).is_nonpositive and (x + 1).is_nonnegative:
+            return True
+
     @classmethod
     def eval(cls, arg):
         if arg.is_Number:
@@ -1631,6 +1642,9 @@ class atan(Function):
         else:
             return s.is_rational
 
+    def _eval_is_positive(self):
+        return self.args[0].is_positive
+
     @classmethod
     def eval(cls, arg):
         if arg.is_Number:
@@ -1735,6 +1749,9 @@ class acot(Function):
                 return False
         else:
             return s.is_rational
+
+    def _eval_is_positive(self):
+        return self.args[0].is_real
 
     @classmethod
     def eval(cls, arg):


### PR DESCRIPTION
TODO
- [x] add tests for acos and asin using old assumptions: 4 routines were added by only two functions are tested using the old assumptions.
- [x] use a Rational argument like 1/7 that doesn't have a known value
- [x] replace 1, 2 with 1, 7

```
>>> acos(S.Half)
pi/3
>>> asin(S.Half)
pi/6
```

Trying to fix https://github.com/sympy/sympy/issues/7246

Though I'm facing some problem.

```
>>> from sympy import *
>>> p = Symbol('p', positive=True)
>>> f = atan(p)
>>> f.is_positive
True  #Expected
>>> f.is_negative
True  #Expected
>>> u = Symbol('u')
>>> mf = atan(u)
>>> mf.is_positive
True  #Not Expected
```

But if I do only the second part it works well

```
>>> from sympy import *
>>> u = Symbol('u')
>>> mf = atan(u)
>>> mf.is_positive
>>> #Expected
```

Maybe `cls.is_positive` or `cls.is_negative` is not the correct way to do it. Should I define properties in these classes? Please help.

**Update**
It is working now
