### PR TITLE
Fixing issue of structural equality and hash in tensor module

### DIFF
--- a/sympy/physics/hep/tests/test_gamma_matrices.py
+++ b/sympy/physics/hep/tests/test_gamma_matrices.py
@@ -1,8 +1,14 @@
-from sympy.tensor.tensor import tensor_indices, TensorIndexType, tensorhead, TensorManager, TensMul, TensAdd, get_lines
+from sympy.tensor.tensor import tensor_indices, TensorIndexType, tensorhead, TensorManager, TensMul, TensAdd, get_lines, TensExpr
 from sympy import simplify, trace
 from sympy.physics.hep.gamma_matrices import GammaMatrix as G, GammaMatrixHead, DiracSpinorIndex
 from sympy.utilities.pytest import XFAIL, raises
 
+def _is_tensor_eq(arg1, arg2):
+    if isinstance(arg1, TensExpr):
+        return arg1.equals(arg2)
+    elif isinstance(arg2, TensExpr):
+        return arg2.equals(arg1)
+    return arg1 == arg2
 
 def execute_gamma_simplify_tests_for_function(tfunc, D):
     """
@@ -28,7 +34,7 @@ def execute_gamma_simplify_tests_for_function(tfunc, D):
     # Some examples taken from Kahane's paper, 4 dim only:
     if D == 4:
         t = (G(a1)*G(mu11)*G(a2)*G(mu21)*G(-a1)*G(mu31)*G(-a2))
-        assert tfunc(t) == -4*G(mu11)*G(mu31)*G(mu21) - 4*G(mu31)*G(mu11)*G(mu21)
+        assert _is_tensor_eq(tfunc(t), -4*G(mu11)*G(mu31)*G(mu21) - 4*G(mu31)*G(mu11)*G(mu21))
 
         t = (G(a1)*G(mu11)*G(mu12)*\
                               G(a2)*G(mu21)*\
@@ -38,8 +44,8 @@ def execute_gamma_simplify_tests_for_function(tfunc, D):
                               G(-a1)*G(mu61)*\
                               G(-a3)*G(mu71)*G(mu72)*\
                               G(-a4))
-        assert tfunc(t) == \
-            16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41)
+        assert _is_tensor_eq(tfunc(t), \
+            16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu31)*G(mu32)*G(mu72)*G(mu71)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu11)*G(mu52)*G(mu51)*G(mu12)*G(mu61)*G(mu21)*G(mu41) + 16*G(mu71)*G(mu72)*G(mu32)*G(mu31)*G(mu12)*G(mu51)*G(mu52)*G(mu11)*G(mu61)*G(mu21)*G(mu41))
 
     # Fully G.Lorentz-contracted expressions, these return scalars:
 
@@ -48,98 +54,98 @@ def execute_gamma_simplify_tests_for_function(tfunc, D):
 
     t = (G(mu)*G(-mu))
     ts = add_delta(D)
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(mu)*G(nu)*G(-mu)*G(-nu))
     ts = add_delta(2*D - D**2)  # -8
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(mu)*G(nu)*G(-nu)*G(-mu))
     ts = add_delta(D**2)  # 16
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(mu)*G(nu)*G(-rho)*G(-nu)*G(-mu)*G(rho))
     ts = add_delta(4*D - 4*D**2 + D**3)  # 16
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(mu)*G(nu)*G(rho)*G(-rho)*G(-nu)*G(-mu))
     ts = add_delta(D**3)  # 64
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(-a3)*G(-a1)*G(-a2)*G(-a4))
     ts = add_delta(-8*D + 16*D**2 - 8*D**3 + D**4)  # -32
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(-mu)*G(-nu)*G(-rho)*G(-sigma)*G(nu)*G(mu)*G(sigma)*G(rho))
     ts = add_delta(-16*D + 24*D**2 - 8*D**3 + D**4)  # 64
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(-mu)*G(nu)*G(-rho)*G(sigma)*G(rho)*G(-nu)*G(mu)*G(-sigma))
     ts = add_delta(8*D - 12*D**2 + 6*D**3 - D**4)  # -32
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(-a3)*G(-a2)*G(-a1)*G(-a5)*G(-a4))
     ts = add_delta(64*D - 112*D**2 + 60*D**3 - 12*D**4 + D**5)  # 256
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(-a3)*G(-a1)*G(-a2)*G(-a4)*G(-a5))
     ts = add_delta(64*D - 120*D**2 + 72*D**3 - 16*D**4 + D**5)  # -128
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(a6)*G(-a3)*G(-a2)*G(-a1)*G(-a6)*G(-a5)*G(-a4))
     ts = add_delta(416*D - 816*D**2 + 528*D**3 - 144*D**4 + 18*D**5 - D**6)  # -128
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     t = (G(a1)*G(a2)*G(a3)*G(a4)*G(a5)*G(a6)*G(-a2)*G(-a3)*G(-a1)*G(-a6)*G(-a4)*G(-a5))
     ts = add_delta(416*D - 848*D**2 + 584*D**3 - 172*D**4 + 22*D**5 - D**6)  # -128
-    assert tfunc(t) == ts
+    assert _is_tensor_eq(tfunc(t), ts)
 
     # Expressions with free indices:
 
     t = (G(mu)*G(nu)*G(rho)*G(sigma)*G(-mu))
-    assert tfunc(t) == (-2*G(sigma)*G(rho)*G(nu) + (4-D)*G(nu)*G(rho)*G(sigma))
+    assert _is_tensor_eq(tfunc(t), (-2*G(sigma)*G(rho)*G(nu) + (4-D)*G(nu)*G(rho)*G(sigma)))
 
     t = (G(mu)*G(nu)*G(-mu))
-    assert tfunc (t) == (2-D)*G(nu)
+    assert _is_tensor_eq(tfunc (t), (2-D)*G(nu))
 
     t = (G(mu)*G(nu)*G(rho)*G(-mu))
-    assert tfunc(t) == 2*G(nu)*G(rho) + 2*G(rho)*G(nu) - (4-D)*G(nu)*G(rho)
+    assert _is_tensor_eq(tfunc(t), 2*G(nu)*G(rho) + 2*G(rho)*G(nu) - (4-D)*G(nu)*G(rho))
 
     t = 2*G(m2)*G(m0)*G(m1)*G(-m0)*G(-m1)
     st = tfunc(t)
-    assert st == (D*(-2*D + 4))*G(m2)
+    assert _is_tensor_eq(st, (D*(-2*D + 4))*G(m2))
 
     t = G(m2)*G(m0)*G(m1)*G(-m0)*G(-m2)
     st = tfunc(t)
-    assert st == ((-D + 2)**2)*G(m1)
+    assert _is_tensor_eq(st, ((-D + 2)**2)*G(m1))
 
     t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)
     st = tfunc(t)
-    assert st == (D - 4)*G(m0)*G(m2)*G(m3) + 4*G(m0)*g(m2, m3)
+    assert _is_tensor_eq(st, (D - 4)*G(m0)*G(m2)*G(m3) + 4*G(m0)*g(m2, m3))
 
     t = G(m0)*G(m1)*G(m2)*G(m3)*G(-m1)*G(-m0)
     st = tfunc(t)
-    assert st == ((D - 4)**2)*G(m2)*G(m3) + (8*D - 16)*g(m2, m3)
+    assert _is_tensor_eq(st, ((D - 4)**2)*G(m2)*G(m3) + (8*D - 16)*g(m2, m3))
 
     t = G(m2)*G(m0)*G(m1)*G(-m2)*G(-m0)
     st = tfunc(t)
-    assert st == ((-D + 2)*(D - 4) + 4)*G(m1)
+    assert _is_tensor_eq(st, ((-D + 2)*(D - 4) + 4)*G(m1))
 
     t = G(m3)*G(m1)*G(m0)*G(m2)*G(-m3)*G(-m0)*G(-m2)
     st = tfunc(t)
-    assert st == (-4*D + (-D + 2)**2*(D - 4) + 8)*G(m1)
+    assert _is_tensor_eq(st, (-4*D + (-D + 2)**2*(D - 4) + 8)*G(m1))
 
     t = 2*G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)
     st = tfunc(t)
-    assert st == ((-2*D + 8)*G(m1)*G(m2)*G(m3) - 4*G(m3)*G(m2)*G(m1))
+    assert _is_tensor_eq(st, ((-2*D + 8)*G(m1)*G(m2)*G(m3) - 4*G(m3)*G(m2)*G(m1)))
 
     t = G(m5)*G(m0)*G(m1)*G(m4)*G(m2)*G(-m4)*G(m3)*G(-m0)
     st = tfunc(t)
-    assert st == (((-D + 2)*(-D + 4))*G(m5)*G(m1)*G(m2)*G(m3) + (2*D - 4)*G(m5)*G(m3)*G(m2)*G(m1))
+    assert _is_tensor_eq(st, (((-D + 2)*(-D + 4))*G(m5)*G(m1)*G(m2)*G(m3) + (2*D - 4)*G(m5)*G(m3)*G(m2)*G(m1)))
 
     t = -G(m0)*G(m1)*G(m2)*G(m3)*G(-m0)*G(m4)
     st = tfunc(t)
-    assert st == ((D - 4)*G(m1)*G(m2)*G(m3)*G(m4) + 2*G(m3)*G(m2)*G(m1)*G(m4))
+    assert _is_tensor_eq(st, ((D - 4)*G(m1)*G(m2)*G(m3)*G(m4) + 2*G(m3)*G(m2)*G(m1)*G(m4)))
 
     t = G(-m5)*G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(-m0)*G(m5)
     st = tfunc(t)
@@ -154,23 +160,23 @@ def execute_gamma_simplify_tests_for_function(tfunc, D):
     result2 = 8*G(m1)*G(m2)*G(m3)*G(m4) + 8*G(m4)*G(m3)*G(m2)*G(m1)
 
     if D == 4:
-        assert st == (result1) or st == (result2)
+        assert _is_tensor_eq(st, (result1)) or _is_tensor_eq(st, (result2))
     else:
-        assert st == (result1)
+        assert _is_tensor_eq(st, (result1))
 
     # and a few very simple cases, with no contracted indices:
 
     t = G(m0)
     st = tfunc(t)
-    assert st == t
+    assert _is_tensor_eq(st, t)
 
     t = -7*G(m0)
     st = tfunc(t)
-    assert st == t
+    assert _is_tensor_eq(st, t)
 
     t = 224*G(m0)*G(m1)*G(-m2)*G(m3)
     st = tfunc(t)
-    assert st == t
+    assert _is_tensor_eq(st, t)
 
 
 def test_kahane_algorithm():
@@ -264,11 +270,11 @@ def test_gamma_matrix_class():
 
     t = A(k)*G(i)*G(-i)
     ts = simplify(t)
-    assert ts == 4*A(k)*DiracSpinorIndex.delta(DiracSpinorIndex.auto_left, -DiracSpinorIndex.auto_right)
+    assert _is_tensor_eq(ts, 4*A(k)*DiracSpinorIndex.delta(DiracSpinorIndex.auto_left, -DiracSpinorIndex.auto_right))
 
     t = G(i)*A(k)*G(j)
     ts = simplify(t)
-    assert ts == A(k)*G(i)*G(j)
+    assert _is_tensor_eq(ts, A(k)*G(i)*G(j))
 
     execute_gamma_simplify_tests_for_function(simplify, D=4)
 
@@ -302,19 +308,19 @@ def test_gamma_matrix_trace():
     # traces without internal contractions:
     t = G(m0)*G(m1)
     t1 = gamma_trace(t)
-    assert t1 == 4*g(m0, m1)
+    assert _is_tensor_eq(t1, 4*g(m0, m1))
 
     t = G(m0)*G(m1)*G(m2)*G(m3)
     t1 = gamma_trace(t)
     t2 = -4*g(m0, m2)*g(m1, m3) + 4*g(m0, m1)*g(m2, m3) + 4*g(m0, m3)*g(m1, m2)
     st2 = str(t2)
-    assert t1 == t2
+    assert _is_tensor_eq(t1, t2)
 
     t = G(m0)*G(m1)*G(m2)*G(m3)*G(m4)*G(m5)
     t1 = gamma_trace(t)
     t2 = t1*g(-m0, -m5)
     t2 = t2.contract_metric(g)
-    assert t2 == D*gamma_trace(G(m1)*G(m2)*G(m3)*G(m4))
+    assert _is_tensor_eq(t2, D*gamma_trace(G(m1)*G(m2)*G(m3)*G(m4)))
 
     # traces of expressions with internal contractions:
     t = G(m0)*G(-m0)
@@ -366,8 +372,8 @@ def test_gamma_matrix_trace():
 #    t1 = t1.expand_coeff()
     c1 = -4*D**5 + 120*D**4 - 1200*D**3 + 5280*D**2 - 10560*D + 7808
     c2 = -4*D**5 + 88*D**4 - 560*D**3 + 1440*D**2 - 1600*D + 640
-    assert t1 == c1*g(n1, n4)*g(n2, n3) + c2*g(n1, n2)*g(n3, n4) + \
-            (-c1)*g(n1, n3)*g(n2, n4)
+    assert _is_tensor_eq(t1, c1*g(n1, n4)*g(n2, n3) + c2*g(n1, n2)*g(n3, n4) + \
+            (-c1)*g(n1, n3)*g(n2, n4))
 
     p, q = tensorhead('p,q', [G.LorentzIndex], [[1]])
     ps = p(m0)*G(-m0)
@@ -377,7 +383,7 @@ def test_gamma_matrix_trace():
     pq = p(m0)*q(-m0)
     t = ps*qs*ps*qs
     r = gamma_trace(t)
-    assert r == 8*pq*pq - 4*p2*q2
+    assert _is_tensor_eq(r, 8*pq*pq - 4*p2*q2)
     t = ps*qs*ps*qs*ps*qs
     r = gamma_trace(t)
     assert r.equals(-12*p2*pq*q2 + 16*pq*pq*pq)
@@ -386,7 +392,7 @@ def test_gamma_matrix_trace():
     assert r.equals(-32*pq*pq*p2*q2 + 32*pq*pq*pq*pq + 4*p2*p2*q2*q2)
 
     t = 4*p(m1)*p(m0)*p(-m0)*q(-m1)*q(m2)*q(-m2)
-    assert gamma_trace(t) == t
+    assert _is_tensor_eq(gamma_trace(t), t)
     t = ps*ps*ps*ps*ps*ps*ps*ps
     r = gamma_trace(t)
     assert r.equals(4*p2*p2*p2*p2)
@@ -401,12 +407,12 @@ def test_simple_trace_cases_symbolic_dim():
 
     t = G(m0)*G(m1)
     t1 = G._trace_single_line(t)
-    assert t1 == 4 * G.LorentzIndex.metric(m0, m1)
+    assert _is_tensor_eq(t1, 4 * G.LorentzIndex.metric(m0, m1))
 
     t = G(m0)*G(m1)*G(m2)*G(m3)
     t1 = G._trace_single_line(t)
     t2 = -4*g(m0, m2)*g(m1, m3) + 4*g(m0, m1)*g(m2, m3) + 4*g(m0, m3)*g(m1, m2)
-    assert t1 == t2
+    assert _is_tensor_eq(t1, t2)
 
 def test_get_lines():
     i0,i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13 = \

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -12,6 +12,13 @@ from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry,
     TensorManager, TensExpr, TIDS
 from sympy.utilities.pytest import raises, skip
 
+def _is_equal(arg1, arg2):
+    if isinstance(arg1, TensExpr):
+        return arg1.equals(arg2)
+    elif isinstance(arg2, TensExpr):
+        return arg2.equals(arg1)
+    return arg1 == arg2
+
 
 #################### Tests from tensor_can.py #######################
 def test_canonicalize_no_slot_sym():
@@ -599,8 +606,8 @@ def test_special_eq_ne():
     p, q, r = tensorhead('p,q,r', [Lorentz], [[1]])
 
     t = 0*A(a, b)
-    assert t == 0
-    assert t == S.Zero
+    assert _is_equal(t, 0)
+    assert _is_equal(t, S.Zero)
 
     assert p(i) != A(a, b)
     assert A(a, -a) != A(a, b)
@@ -615,7 +622,7 @@ def test_special_eq_ne():
     assert p(i) - p(i) == 0
     assert p(i) - p(i) == S.Zero
 
-    assert A(a, b) == A(b, a)
+    assert _is_equal(A(a, b), A(b, a))
 
 def test_add2():
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
@@ -691,20 +698,20 @@ def test_substitute_indices():
 
     A_tmul = A(m, n)
     A_c = A_tmul(m, -m)
-    assert A_c == A(n, -n)
+    assert _is_equal(A_c, A(n, -n))
     ABm = A(i, j)*B(m, n)
     ABc1 = ABm(i, j, -i, -j)
-    assert ABc1 == A(i, -j)*B(-i, j)
+    assert _is_equal(ABc1, A(i, -j)*B(-i, j))
     ABc2 = ABm(i, -i, j, -j)
-    assert ABc2 == A(m, -m)*B(-n, n)
+    assert _is_equal(ABc2, A(m, -m)*B(-n, n))
 
     asum = A(i, j) + B(i, j)
     asc1 = asum(i, -i)
-    assert asc1 == A(i, -i) + B(i, -i)
+    assert _is_equal(asc1, A(i, -i) + B(i, -i))
 
     assert A(i, -i) == A(i, -i)()
     assert A(i, -i) + B(-j, j) == ((A(i, -i) + B(i, -i)))()
-    assert A(i, j)*B(-j, k) == (A(m, -j)*B(j, n))(i, k)
+    assert _is_equal(A(i, j)*B(-j, k), (A(m, -j)*B(j, n))(i, k))
     raises(ValueError, lambda: A(i, -i)(j, k))
 
 def test_riemann_cyclic_replace():
@@ -780,15 +787,15 @@ def test_contract_metric1():
     # g with both indices contracted with another tensor
     t1 = A(a,b)*B(-b,-c)*g(c, -a)
     t2 = t1.contract_metric(g)
-    assert t2 == A(a, b)*B(-b, -a)
+    assert _is_equal(t2, A(a, b)*B(-b, -a))
 
     t1 = A(a,b)*B(-b,-c)*g(c, d)*g(-a, -d)
     t2 = t1.contract_metric(g)
-    assert t2 == A(a,b)*B(-b,-a)
+    assert _is_equal(t2, A(a,b)*B(-b,-a))
 
     t1 = A(a,b)*g(-a,-b)
     t2 = t1.contract_metric(g)
-    assert t2 == A(a, -a)
+    assert _is_equal(t2, A(a, -a))
     assert not t2.free
     Lorentz = TensorIndexType('Lorentz', dummy_fmt='L')
     a, b = tensor_indices('a,b', Lorentz)
@@ -896,67 +903,67 @@ def test_metric_contract3():
 
     t = C(a0,a1)*B(-a1,-a0)
     t1 = t.contract_metric(C)
-    assert t1 == B(a0, -a0)
+    assert _is_equal(t1, B(a0, -a0))
 
     t = C(a1,a0)*B(-a1,-a0)
     t1 = t.contract_metric(C)
-    assert t1 == -B(a0, -a0)
+    assert _is_equal(t1, -B(a0, -a0))
 
     t = C(a0,-a1)*B(a1,-a0)
     t1 = t.contract_metric(C)
-    assert t1 == -B(a0, -a0)
+    assert _is_equal(t1, -B(a0, -a0))
 
     t = C(-a0,a1)*B(-a1,a0)
     t1 = t.contract_metric(C)
-    assert t1 == -B(a0, -a0)
+    assert _is_equal(t1, -B(a0, -a0))
 
     t = C(-a0,-a1)*B(a1,a0)
     t1 = t.contract_metric(C)
-    assert t1 == B(a0, -a0)
+    assert _is_equal(t1, B(a0, -a0))
 
     t = C(-a1, a0)*B(a1,-a0)
     t1 = t.contract_metric(C)
-    assert t1 == B(a0, -a0)
+    assert _is_equal(t1, B(a0, -a0))
 
     t = C(a0,a1)*psi(-a1)
     t1 = t.contract_metric(C)
-    assert t1 == psi(a0)
+    assert _is_equal(t1, psi(a0))
 
     t = C(a1,a0)*psi(-a1)
     t1 = t.contract_metric(C)
-    assert t1 == -psi(a0)
+    assert _is_equal(t1, -psi(a0))
 
     t = C(a0,a1)*chi(-a0)*psi(-a1)
     t1 = t.contract_metric(C)
-    assert t1 == -chi(a1)*psi(-a1)
+    assert _is_equal(t1, -chi(a1)*psi(-a1))
 
     t = C(a1,a0)*chi(-a0)*psi(-a1)
     t1 = t.contract_metric(C)
-    assert t1 == chi(a1)*psi(-a1)
+    assert _is_equal(t1, chi(a1)*psi(-a1))
 
     t = C(-a1,a0)*chi(-a0)*psi(a1)
     t1 = t.contract_metric(C)
-    assert t1 == chi(-a1)*psi(a1)
+    assert _is_equal(t1, chi(-a1)*psi(a1))
 
     t = C(a0, -a1)*chi(-a0)*psi(a1)
     t1 = t.contract_metric(C)
-    assert t1 == -chi(-a1)*psi(a1)
+    assert _is_equal(t1, -chi(-a1)*psi(a1))
 
     t = C(-a0,-a1)*chi(a0)*psi(a1)
     t1 = t.contract_metric(C)
-    assert t1 == chi(-a1)*psi(a1)
+    assert _is_equal(t1, chi(-a1)*psi(a1))
 
     t = C(-a1,-a0)*chi(a0)*psi(a1)
     t1 = t.contract_metric(C)
-    assert t1 == -chi(-a1)*psi(a1)
+    assert _is_equal(t1, -chi(-a1)*psi(a1))
 
     t = C(-a1,-a0)*B(a0,a2)*psi(a1)
     t1 = t.contract_metric(C)
-    assert t1 == -B(-a1,a2)*psi(a1)
+    assert _is_equal(t1, -B(-a1,a2)*psi(a1))
 
     t = C(a1,a0)*B(-a2,-a0)*psi(-a1)
     t1 = t.contract_metric(C)
-    assert t1 == B(-a2,a1)*psi(-a1)
+    assert _is_equal(t1, B(-a2,a1)*psi(-a1))
 
 def test_epsilon():
     Lorentz = TensorIndexType('Lorentz', dim=4, dummy_fmt='L')
@@ -1085,8 +1092,8 @@ def test_TensorManager():
     assert t1 == ps*ps + 2*ps*psh + psh*psh
     qs = G(i)*q(-i)
     qsh = GH(ih)*qh(-ih)
-    assert ps*qsh == qsh*ps
-    assert ps*qs != qs*ps
+    assert _is_equal(ps*qsh, qsh*ps)
+    assert not _is_equal(ps*qs, qs*ps)
     n = TensorManager.comm_symbols2i(Gsymbol)
     assert TensorManager.comm_i2symbol(n) == Gsymbol
 
@@ -1179,36 +1186,36 @@ def test_hidden_indices_for_matrix_multiplication():
     B0 = B(-m0)
     B1 = B(m1)
 
-    assert (B1*A0*B0) == B(m1, s0)*A(m0, -s0, s1)*B(-m0, -s1)
-    assert (B0*A0) == B(-m0, s0)*A(m0, -s0, -S.auto_right)
-    assert (A0*B0) == A(m0, S.auto_left, s0)*B(-m0, -s0)
+    assert _is_equal((B1*A0*B0), B(m1, s0)*A(m0, -s0, s1)*B(-m0, -s1))
+    assert _is_equal((B0*A0), B(-m0, s0)*A(m0, -s0, -S.auto_right))
+    assert _is_equal((A0*B0), A(m0, S.auto_left, s0)*B(-m0, -s0))
 
     C = tensorhead('C', [L, L], [[1]*2])
 
-    assert (C(True, True)) == C(L.auto_left, -L.auto_right)
+    assert _is_equal((C(True, True)), C(L.auto_left, -L.auto_right))
 
-    assert (A(m0)*C(m1, -m0)) == A(m2, S.auto_left, -S.auto_right)*C(m1, -m2)
+    assert _is_equal((A(m0)*C(m1, -m0)), A(m2, S.auto_left, -S.auto_right)*C(m1, -m2))
 
-    assert (C(True, True)*C(True, True)) == C(L.auto_left, m0)*C(-m0, -L.auto_right)
+    assert _is_equal((C(True, True)*C(True, True)), C(L.auto_left, m0)*C(-m0, -L.auto_right))
 
-    assert A(m0) == A(m0)
-    assert B(-m1) == B(-m1)
+    assert _is_equal(A(m0), A(m0))
+    assert _is_equal(B(-m1), B(-m1))
 
-    assert A(m0) - A(m0) == 0
+    assert _is_equal(A(m0) - A(m0), 0)
     ts1 = A(m0)*A(m1) + A(m1)*A(m0)
     ts2 = A(m1)*A(m0) + A(m0)*A(m1)
-    assert ts1 == ts2
-    assert A(m0)*A(m1) + A(m1)*A(m0) == A(m1)*A(m0) + A(m0)*A(m1)
+    assert _is_equal(ts1, ts2)
+    assert _is_equal(A(m0)*A(m1) + A(m1)*A(m0), A(m1)*A(m0) + A(m0)*A(m1))
 
-    assert A(m0) == (2*A(m0))/2
-    assert A(m0) == -(-A(m0))
-    assert 2*A(m0) - 3*A(m0) == -A(m0)
-    assert 2*D(m0, m1) - 5*D(m1, m0) == -3*D(m0, m1)
+    assert _is_equal(A(m0), (2*A(m0))/2)
+    assert _is_equal(A(m0), -(-A(m0)))
+    assert _is_equal(2*A(m0) - 3*A(m0), -A(m0))
+    assert _is_equal(2*D(m0, m1) - 5*D(m1, m0), -3*D(m0, m1))
 
     D0 = D(True, True, True, True)
     Aa = A(True, True, True)
 
-    assert D0 * Aa == D(L.auto_left, m0, S.auto_left, s0)*A(-m0, -s0, -S.auto_right)
+    assert _is_equal(D0 * Aa, D(L.auto_left, m0, S.auto_left, s0)*A(-m0, -s0, -S.auto_right))
     assert D(m0, m1) == D(m0, m1, S.auto_left, -S.auto_right)
 
     raises(ValueError, lambda: C(True))


### PR DESCRIPTION
This PR solves the problem of structural equality comparison in the tensor module.

In the current master, `__eq__` and `__hash__` are overridden in order to provide mathematical equality of tensors. In reality `__eq__` should just test the structural equality, it should be inherited by `Basic`, the same applies to `__hash__`.

I thought initially of renaming `__eq__` to `__eval_Eq`, but `Eq` should either return `True` or return an equality, while the mathematical equality test on tensors should always return either true or false.

In the end, `__eq__` has been renamed to `equals`, and the custom `__hash__` has completely been removed.

With this PR the tensor module should allow its objects to be manipulated by `unify` and `rewriterule`.
