### PR TITLE
Permutation args are now subtypes of Basic

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -4,7 +4,7 @@ import random
 from collections import defaultdict
 
 from sympy.core import Basic
-from sympy import Tuple
+from sympy.core.containers import Tuple
 from sympy.core.compatibility import is_sequence, reduce, xrange
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
     has_dups, runs)

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -4,6 +4,7 @@ import random
 from collections import defaultdict
 
 from sympy.core import Basic
+from sympy import Tuple
 from sympy.core.compatibility import is_sequence, reduce, xrange
 from sympy.utilities.iterables import (flatten, has_variety, minlex,
     has_dups, runs)
@@ -894,7 +895,7 @@ class Permutation(Basic):
             # but do allow the permutation size to be increased
             aform.extend(list(range(len(aform), size)))
         size = len(aform)
-        obj = Basic.__new__(cls, aform)
+        obj = Basic.__new__(cls, Tuple(*aform))
         obj._array_form = aform
         obj._size = size
         return obj
@@ -919,7 +920,7 @@ class Permutation(Basic):
         Permutation([2, 1, 3, 0])
 
         """
-        p = Basic.__new__(Perm, perm)
+        p = Basic.__new__(Perm, Tuple(*perm))
         p._array_form = perm
         p._size = len(perm)
         return p

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -107,7 +107,6 @@ def test_sympy__combinatorics__subsets__Subset():
     assert _test_args(Subset(['c', 'd'], ['a', 'b', 'c', 'd']))
 
 
-@XFAIL
 def test_sympy__combinatorics__permutations__Permutation():
     from sympy.combinatorics.permutations import Permutation
     assert _test_args(Permutation([0, 1, 2, 3]))


### PR DESCRIPTION
Permutation has currently a `list` subtype in its args. I changed that to `Tuple`
