### PR TITLE
Fix a bug in coeff for Mul

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1132,7 +1132,7 @@ class Expr(Basic, EvalfMixin):
                 if not right:
                     return self - Add(*[a*x for a in Add.make_args(c)])
                 return self - Add(*[x*a for a in Add.make_args(c)])
-            return self.as_independent(x, as_Add=not self.is_Mul)[0]
+            return self.as_independent(x, as_Add=True)[0]
 
         # continue with the full method, looking for this power of x:
         x = x**n

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1040,6 +1040,8 @@ def test_coeff():
     assert (4*x).coeff(2*x) == 0
     assert (2*x).coeff(2*x) == 1
     assert (-oo*x).coeff(x*oo) == -1
+    assert (10*x).coeff(x, 0) == 0
+    assert (10*x).coeff(10*x, 0) == 0
 
     n1, n2 = symbols('n1 n2', commutative=False)
     assert (n1*n2).coeff(n1) == 1


### PR DESCRIPTION
The coeff method for Mul was returning `2` for expression `2*x` when `n=0`. Fixes https://github.com/sympy/sympy/issues/7377
