### PR TITLE
Replace only Symbol indices in secondquant.evaluate_deltas

### DIFF
--- a/sympy/physics/secondquant.py
+++ b/sympy/physics/secondquant.py
@@ -2325,11 +2325,12 @@ def evaluate_deltas(e):
         for d in deltas:
             # If we do something, and there are more deltas, we should recurse
             # to treat the resulting expression properly
-            if indices[d.killable_index]:
+            if d.killable_index.is_Symbol and indices[d.killable_index]:
                 e = e.subs(d.killable_index, d.preferred_index)
                 if len(deltas) > 1:
                     return evaluate_deltas(e)
-            elif indices[d.preferred_index] and d.indices_contain_equal_information:
+            elif (d.preferred_index.is_Symbol and indices[d.preferred_index]
+                  and d.indices_contain_equal_information):
                 e = e.subs(d.preferred_index, d.killable_index)
                 if len(deltas) > 1:
                     return evaluate_deltas(e)

--- a/sympy/physics/tests/test_secondquant.py
+++ b/sympy/physics/tests/test_secondquant.py
@@ -457,6 +457,29 @@ def test_contraction():
     assert restr.is_only_above_fermi
 
 
+def test_evaluate_deltas():
+    i, j, k = symbols('i,j,k')
+
+    r = KroneckerDelta(i, j) * KroneckerDelta(j, k)
+    assert evaluate_deltas(r) == KroneckerDelta(i, k)
+
+    r = KroneckerDelta(i, 0) * KroneckerDelta(j, k)
+    assert evaluate_deltas(r) == KroneckerDelta(i, 0) * KroneckerDelta(j, k)
+
+    r = KroneckerDelta(1, j) * KroneckerDelta(j, k)
+    assert evaluate_deltas(r) == KroneckerDelta(1, k)
+
+    r = KroneckerDelta(j, 2) * KroneckerDelta(k, j)
+    assert evaluate_deltas(r) == KroneckerDelta(2, k)
+
+    r = KroneckerDelta(i, 0) * KroneckerDelta(i, j) * KroneckerDelta(j, 1)
+    assert evaluate_deltas(r) == 0
+
+    r = (KroneckerDelta(0, i) * KroneckerDelta(0, j)
+         * KroneckerDelta(1, j) * KroneckerDelta(1, j))
+    assert evaluate_deltas(r) == 0
+
+
 def test_Tensors():
     i, j, k, l = symbols('i j k l', below_fermi=True, cls=Dummy)
     a, b, c, d = symbols('a b c d', above_fermi=True, cls=Dummy)


### PR DESCRIPTION
evaluate_deltas should consider only Symbol indices as candidates for summation, and not allow e.g. integer constants act as dummy summation variables.

As far as I understand the code here, in the intended use case for secondquant, the indices are always symbols.

Fixes gh-7380
