### PR TITLE
Make nroots() robust

### DIFF
--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -144,7 +144,7 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
     orig = ctx.prec
     weps = +ctx.eps
     try:
-        ctx.prec += 10
+        ctx.prec += extraprec
         tol = ctx.eps * 128
         deg = len(coeffs) - 1
         # Must be monic

--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -173,7 +173,8 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
                 roots[i] = p - x
                 err[i] = abs(x)
         if abs(max(err)) >= tol:
-            raise Exception("Didn't converge in maxsteps=%d steps." % maxsteps)
+            raise ctx.NoConvergence("Didn't converge in maxsteps=%d steps." \
+                    % maxsteps)
         # Remove small imaginary parts
         if cleanup:
             for i in xrange(deg):

--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -161,17 +161,16 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
             if abs(max(err)) < tol:
                 break
             for i in xrange(deg):
-                if not abs(err[i]) < tol:
-                    p = roots[i]
-                    x = f(p)
-                    for j in range(deg):
-                        if i != j:
-                            try:
-                                x /= (p-roots[j])
-                            except ZeroDivisionError:
-                                continue
-                    roots[i] = p - x
-                    err[i] = abs(x)
+                p = roots[i]
+                x = f(p)
+                for j in range(deg):
+                    if i != j:
+                        try:
+                            x /= (p-roots[j])
+                        except ZeroDivisionError:
+                            continue
+                roots[i] = p - x
+                err[i] = abs(x)
         # Remove small imaginary parts
         if cleanup:
             for i in xrange(deg):

--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -171,6 +171,8 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
                             continue
                 roots[i] = p - x
                 err[i] = abs(x)
+        if abs(max(err)) >= tol:
+            raise Exception("Didn't converge in maxsteps=%d steps." % maxsteps)
         # Remove small imaginary parts
         if cleanup:
             for i in xrange(deg):

--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -176,7 +176,9 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
         # Remove small imaginary parts
         if cleanup:
             for i in xrange(deg):
-                if abs(ctx._im(roots[i])) < weps:
+                if abs(roots[i]) < weps:
+                    roots[i] = 0
+                elif abs(ctx._im(roots[i])) < weps:
                     roots[i] = roots[i].real
                 elif abs(ctx._re(roots[i])) < weps:
                     roots[i] = roots[i].imag * 1j

--- a/sympy/mpmath/calculus/polynomials.py
+++ b/sympy/mpmath/calculus/polynomials.py
@@ -142,10 +142,11 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
         return []
 
     orig = ctx.prec
-    weps = +ctx.eps
+    # Important: we need to multiply by 1, otherwise the 'tol' will change as
+    # we assign to `ctx.prec` below.
+    tol = ctx.eps*1
     try:
         ctx.prec += extraprec
-        tol = ctx.eps * 128
         deg = len(coeffs) - 1
         # Must be monic
         lead = ctx.convert(coeffs[0])
@@ -176,11 +177,11 @@ def polyroots(ctx, coeffs, maxsteps=50, cleanup=True, extraprec=10, error=False)
         # Remove small imaginary parts
         if cleanup:
             for i in xrange(deg):
-                if abs(roots[i]) < weps:
+                if abs(roots[i]) < tol:
                     roots[i] = 0
-                elif abs(ctx._im(roots[i])) < weps:
+                elif abs(ctx._im(roots[i])) < tol:
                     roots[i] = roots[i].real
-                elif abs(ctx._re(roots[i])) < weps:
+                elif abs(ctx._re(roots[i])) < tol:
                     roots[i] = roots[i].imag * 1j
         roots.sort(key=lambda x: (abs(ctx._im(x)), ctx._re(x)))
     finally:

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -3396,7 +3396,12 @@ class Poly(Expr):
             roots = sympy.mpmath.polyroots(coeffs, maxsteps=maxsteps,
                     cleanup=cleanup, error=False, extraprec=f.degree()*10)
 
-            roots = list(map(sympify, roots))
+            # Mpmath puts real roots first, then complex ones. SymPy polynomial
+            # module orders roots by their real components (if they are equal,
+            # then by their imaginary components). So we reorder the roots here
+            # to conform to the SymPy ordering.
+            roots = list(map(sympify,
+                sorted(roots, key=lambda r: (r.real, r.imag))))
         finally:
             sympy.mpmath.mp.dps = dps
 

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -49,7 +49,7 @@ from sympy.utilities import group, sift, public
 import sympy.polys
 import sympy.mpmath
 
-from sympy.polys.domains import FF, QQ
+from sympy.polys.domains import FF, QQ, ZZ
 from sympy.polys.constructor import construct_domain
 
 from sympy.polys import polyoptions as options
@@ -3344,9 +3344,18 @@ class Poly(Expr):
         else:
             return group(roots, multiple=False)
 
-    def nroots(f, n=15, maxsteps=50, cleanup=True, error=False):
+    def nroots(f, n=15, maxsteps=50, cleanup=True):
         """
         Compute numerical approximations of roots of ``f``.
+
+        Parameters
+        ==========
+
+        n ... the number of digits to calculate
+        maxsteps ... the maximum number of iterations to do
+
+        If the accuracy `n` cannot be reached in `maxsteps`, it will raise an
+        exception. You need to rerun with higher maxsteps.
 
         Examples
         ========
@@ -3367,35 +3376,31 @@ class Poly(Expr):
         if f.degree() <= 0:
             return []
 
-        coeffs = [coeff.evalf(n=n).as_real_imag()
-                  for coeff in f.all_coeffs()]
+        # Convert coefficients to integers only (for accuracy)
+        if f.rep.dom is ZZ:
+            coeffs = [int(coeff) for coeff in f.all_coeffs()]
+        elif f.rep.dom is QQ:
+            denoms = [coeff.q for coeff in f.all_coeffs()]
+            from sympy.core.numbers import ilcm
+            fac = ilcm(*denoms)
+            coeffs = [int(coeff*fac) for coeff in f.all_coeffs()]
+        else:
+            raise DomainError("Numerical domain expected, got %s" % f.rep.dom)
 
         dps = sympy.mpmath.mp.dps
         sympy.mpmath.mp.dps = n
 
         try:
-            try:
-                coeffs = [sympy.mpmath.mpc(*coeff) for coeff in coeffs]
-            except TypeError:
-                raise DomainError(
-                    "numerical domain expected, got %s" % f.rep.dom)
+            # We need to add extra precision to guard against losing accuracy.
+            # 10 times the degree of the polynomial seems to work well.
+            roots = sympy.mpmath.polyroots(coeffs, maxsteps=maxsteps,
+                    cleanup=cleanup, error=False, extraprec=f.degree()*10)
 
-            result = sympy.mpmath.polyroots(
-                coeffs, maxsteps=maxsteps, cleanup=cleanup, error=error)
-
-            if error:
-                roots, error = result
-            else:
-                roots, error = result, None
-
-            roots = list(map(sympify, sorted(roots, key=lambda r: (r.real, r.imag))))
+            roots = list(map(sympify, roots))
         finally:
             sympy.mpmath.mp.dps = dps
 
-        if error is not None:
-            return roots, sympify(error)
-        else:
-            return roots
+        return roots
 
     def ground_roots(f):
         """
@@ -6080,7 +6085,7 @@ def real_roots(f, multiple=True):
 
 
 @public
-def nroots(f, n=15, maxsteps=50, cleanup=True, error=False):
+def nroots(f, n=15, maxsteps=50, cleanup=True):
     """
     Compute numerical approximations of roots of ``f``.
 
@@ -6102,7 +6107,7 @@ def nroots(f, n=15, maxsteps=50, cleanup=True, error=False):
         raise PolynomialError(
             "can't compute numerical roots of %s, not a polynomial" % f)
 
-    return F.nroots(n=n, maxsteps=maxsteps, cleanup=cleanup, error=error)
+    return F.nroots(n=n, maxsteps=maxsteps, cleanup=cleanup)
 
 
 @public

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -14,6 +14,7 @@ from sympy.polys.orthopolys import legendre_poly
 
 from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import test_numerically
+import sympy
 
 
 a, b, c, d, e, q, t, x, y, z = symbols('a,b,c,d,e,q,t,x,y,z')
@@ -510,6 +511,9 @@ def test_root_factors():
 def test_nroots1():
     n = 64
     p = legendre_poly(n, x, polys=True)
+
+    raises(sympy.mpmath.mp.NoConvergence, lambda: p.nroots(n=3, maxsteps=5))
+
     roots = p.nroots(n=3)
     assert [str(r) for r in roots] == \
             ['-0.999', '-0.996', '-0.991', '-0.983', '-0.973', '-0.961',

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -515,6 +515,8 @@ def test_nroots1():
     raises(sympy.mpmath.mp.NoConvergence, lambda: p.nroots(n=3, maxsteps=5))
 
     roots = p.nroots(n=3)
+    # The order of roots matters. They are ordered from smallest to the
+    # largest.
     assert [str(r) for r in roots] == \
             ['-0.999', '-0.996', '-0.991', '-0.983', '-0.973', '-0.961',
             '-0.946', '-0.930', '-0.911', '-0.889', '-0.866', '-0.841',
@@ -531,6 +533,8 @@ def test_nroots2():
     p = Poly(x**5+3*x+1, x)
 
     roots = p.nroots(n=3)
+    # The order of roots matters. The real roots are first, then
+    # complex ones.
     assert [str(r) for r in roots] == \
             ['-0.332', '1.01 - 0.937*I', '1.01 + 0.937*I',
             '-0.839 + 0.944*I', '-0.839 - 0.944*I']

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -533,13 +533,13 @@ def test_nroots2():
     p = Poly(x**5+3*x+1, x)
 
     roots = p.nroots(n=3)
-    # The order of roots matters. The real roots are first, then
-    # complex ones.
+    # The order of roots matters. The roots are ordered by their real
+    # components (if they agree, then by their imaginary components).
     assert [str(r) for r in roots] == \
-            ['-0.332', '1.01 - 0.937*I', '1.01 + 0.937*I',
-            '-0.839 + 0.944*I', '-0.839 - 0.944*I']
+            ['-0.839 - 0.944*I', '-0.839 + 0.944*I', '-0.332',
+                '1.01 - 0.937*I', '1.01 + 0.937*I']
 
     roots = p.nroots(n=5)
     assert [str(r) for r in roots] == \
-            ['-0.33199', '1.0051 - 0.93726*I', '1.0051 + 0.93726*I',
-            '-0.83907 + 0.94385*I', '-0.83907 - 0.94385*I']
+            ['-0.83907 - 0.94385*I', '-0.83907 + 0.94385*I',
+                '-0.33199', '1.0051 - 0.93726*I', '1.0051 + 0.93726*I']

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -10,6 +10,8 @@ from sympy.polys.polyroots import (root_factors, roots_linear,
     roots_quadratic, roots_cubic, roots_quartic, roots_cyclotomic,
     roots_binomial, preprocess_roots, roots)
 
+from sympy.polys.orthopolys import legendre_poly
+
 from sympy.utilities.pytest import raises
 from sympy.utilities.randtest import test_numerically
 
@@ -504,3 +506,32 @@ def test_root_factors():
         [Poly(x - 1, x), Poly(x + 1, x), Poly(x**2 + 1, x)]
     assert root_factors(8*x**2 + 12*x**4 + 6*x**6 + x**8, x, filter='Q') == \
         [x, x, x**6 + 6*x**4 + 12*x**2 + 8]
+
+def test_nroots1():
+    n = 64
+    p = legendre_poly(n, x, polys=True)
+    roots = p.nroots(n=3)
+    assert [str(r) for r in roots] == \
+            ['-0.999', '-0.996', '-0.991', '-0.983', '-0.973', '-0.961',
+            '-0.946', '-0.930', '-0.911', '-0.889', '-0.866', '-0.841',
+            '-0.813', '-0.784', '-0.753', '-0.720', '-0.685', '-0.649',
+            '-0.611', '-0.572', '-0.531', '-0.489', '-0.446', '-0.402',
+            '-0.357', '-0.311', '-0.265', '-0.217', '-0.170', '-0.121',
+            '-0.0730', '-0.0243', '0.0243', '0.0730', '0.121', '0.170',
+            '0.217', '0.265', '0.311', '0.357', '0.402', '0.446', '0.489',
+            '0.531', '0.572', '0.611', '0.649', '0.685', '0.720', '0.753',
+            '0.784', '0.813', '0.841', '0.866', '0.889', '0.911', '0.930',
+            '0.946', '0.961', '0.973', '0.983', '0.991', '0.996', '0.999']
+
+def test_nroots2():
+    p = Poly(x**5+3*x+1, x)
+
+    roots = p.nroots(n=3)
+    assert [str(r) for r in roots] == \
+            ['-0.332', '1.01 - 0.937*I', '1.01 + 0.937*I',
+            '-0.839 + 0.944*I', '-0.839 - 0.944*I']
+
+    roots = p.nroots(n=5)
+    assert [str(r) for r in roots] == \
+            ['-0.33199', '1.0051 - 0.93726*I', '1.0051 + 0.93726*I',
+            '-0.83907 + 0.94385*I', '-0.83907 - 0.94385*I']

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2654,17 +2654,17 @@ def test_nroots():
     assert Poly(x**2 - 1, x).nroots() == [-1.0, 1.0]
     assert Poly(x**2 + 1, x).nroots() == [-1.0*I, 1.0*I]
 
-    roots, error = Poly(x**2 - 1, x).nroots(error=True)
-    assert roots == [-1.0, 1.0] and error < 1e25
+    roots = Poly(x**2 - 1, x).nroots()
+    assert roots == [-1.0, 1.0]
 
-    roots, error = Poly(x**2 + 1, x).nroots(error=True)
-    assert roots == [-1.0*I, 1.0*I] and error < 1e25
+    roots = Poly(x**2 + 1, x).nroots()
+    assert roots == [-1.0*I, 1.0*I]
 
-    roots, error = Poly(x**2/3 - S(1)/3, x).nroots(error=True)
-    assert roots == [-1.0, 1.0] and error < 1e25
+    roots = Poly(x**2/3 - S(1)/3, x).nroots()
+    assert roots == [-1.0, 1.0]
 
-    roots, error = Poly(x**2/3 + S(1)/3, x).nroots(error=True)
-    assert roots == [-1.0*I, 1.0*I] and error < 1e25
+    roots = Poly(x**2/3 + S(1)/3, x).nroots()
+    assert roots == [-1.0*I, 1.0*I]
 
     assert Poly(x**2 + 2*I, x).nroots() == [-1.0 + 1.0*I, 1.0 - 1.0*I]
     assert Poly(
@@ -2704,8 +2704,8 @@ def test_nroots():
 
     assert nroots(x**2 - 1) == [-1.0, 1.0]
 
-    roots, error = nroots(x**2 - 1, error=True)
-    assert roots == [-1.0, 1.0] and error < 1e25
+    roots = nroots(x**2 - 1)
+    assert roots == [-1.0, 1.0]
 
     assert nroots(x + I) == [-1.0*I]
     assert nroots(x + 2*I) == [-2.0*I]


### PR DESCRIPTION
Previously:

``` py
from sympy import var, legendre_poly
var("x")
n = 64
p = legendre_poly(n, x, polys=True)
print p.nroots(n=3)
```

produced:

```
[-1.77, -1.6 - 0.456*I, -1.6 + 0.456*I, -1.22 - 0.639*I, -1.22 + 0.639*I, -1.20, -0.979 - 0.56*I, -0.979 + 0.56*I, -0.823 + 0.561*I, -0.823 - 0.561*I, -0.701 - 0.466*I, -0.701 + 0.466*I, -0.579 - 0.446*I, -0.579 + 0.446*I, -0.57 + 0.172*I, -0.531 - 0.0702*I, -0.459 - 0.351*I, -0.456 + 0.354*I, -0.44 - 0.109*I, -0.404 + 0.115*I, -0.371 - 0.26*I, -0.371 + 0.26*I, -0.359 - 0.133*I, -0.308 + 0.177*I, -0.272 - 0.112*I, -0.247 + 0.0635*I, -0.209 - 0.0534*I, -0.178 + 0.0231*I, -0.119 - 0.0344*I, -0.0796 - 0.0155*I, -0.0564 + 0.144*I, -0.0366 - 0.00806*I, 0.0233 - 0.00192*I, 0.0736 - 0.000641*I, 0.12 - 0.00184*I, 0.167 + 0.0116*I, 0.18 - 0.0771*I, 0.225 + 0.0617*I, 0.268 + 0.173*I, 0.272 - 0.111*I, 0.296 - 0.0282*I, 0.311 - 0.174*I, 0.311 + 0.174*I, 0.364 - 0.246*I, 0.367 + 0.23*I, 0.401 + 0.0157*I, 0.456 - 0.354*I, 0.457 + 0.354*I, 0.57 - 0.172*I, 0.57 + 0.172*I, 0.579 - 0.446*I, 0.579 + 0.446*I, 0.7 - 0.466*I, 0.703 + 0.488*I, 0.736 + 0.539*I, 0.804 - 0.461*I, 0.979 - 0.56*I, 0.979 + 0.56*I, 1.20, 1.22 - 0.639*I, 1.22 + 0.639*I, 1.6 - 0.456*I, 1.6 + 0.456*I, 1.77]
```

Which is just **wrong** (inaccurate for some roots and getting complex roots instead of real roots).
Now it not only produces the correct answer:

```
[-0.999, -0.996, -0.991, -0.983, -0.973, -0.961, -0.946, -0.930, -0.911, -0.889, -0.866, -0.841, -0.813, -0.784, -0.753, -0.720, -0.685, -0.649, -0.611, -0.572, -0.531, -0.489, -0.446, -0.402, -0.357, -0.311, -0.265, -0.217, -0.170, -0.121, -0.0730, -0.0243, 0.0243, 0.0730, 0.121, 0.170, 0.217, 0.265, 0.311, 0.357, 0.402, 0.446, 0.489, 0.531, 0.572, 0.611, 0.649, 0.685, 0.720, 0.753, 0.784, 0.813, 0.841, 0.866, 0.889, 0.911, 0.930, 0.946, 0.961, 0.973, 0.983, 0.991, 0.996, 0.999]
```

But it also raises an exception if it can't get convergence to the given accuracy, e.g. with this change:

``` py
print p.nroots(n=3, maxsteps=10)
```

it gives:

```
Traceback (most recent call last):
  File "a.py", line 7, in <module>
    print p.nroots(n=3, maxsteps=10)
  File "/auto/nest/nest/u/ondrej/repos/sympy/sympy/polys/polytools.py", line 3397, in nroots
    cleanup=cleanup, error=False, extraprec=f.degree()*10)
  File "/auto/nest/nest/u/ondrej/repos/sympy/sympy/mpmath/calculus/polynomials.py", line 176, in polyroots
    raise Exception("Didn't converge in maxsteps=%d steps." % maxsteps)
Exception: Didn't converge in maxsteps=10 steps.
```

Tests were written that ensure the the accurate results (they previously fail, not only because of accuracy but also because of different ordering of the roots).

With this better `nroots()` we can now almost use it in [quadrature.py](https://github.com/sympy/sympy/blob/master/sympy/integrals/quadrature.py) as follows:

``` diff
--- a/sympy/integrals/quadrature.py
+++ b/sympy/integrals/quadrature.py
@@ -69,10 +69,9 @@ def gauss_legendre(n, n_digits):
     pd = p.diff(x)
     xi = []
     w  = []
-    for r in p.real_roots():
-        if isinstance(r, RootOf):
-            r = r.eval_rational(S(1)/10**(n_digits+2))
-        xi.append(r.n(n_digits))
+    roots = p.nroots(n_digits)
+    for r in roots:
+        xi.append(r)
         w.append((2/((1-r**2) * pd.subs(x, r)**2)).n(n_digits))
     return xi, w
```

This gets a lot faster. The `xi` points are as accurate as before, but the `w` points are now very inaccurate, due to evaluating the `pd`, which is a polynomial of high order. This is not a small error, i.e. in one of the tests that fail, instead of `0.5555555555555555555555555555555555555556`, we got `0.5555555555574520784163542152657447087753`. One solution is to modify `nroots()` further and allow to also optionally return accurate derivatives, but one has to figure out what the best approach is. I will work on that once this PR is in.

@mattpap, @fredrik-johansson would you mind both reviewing this? Many bugs were fixed in both polys and mpmath by this. I have tried to carefully document what exactly I did and why in the git commit logs.
