### PR TITLE
Fix doctest for evaluate

### DIFF
--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -19,7 +19,7 @@ def evaluate(x):
     ========
 
     >>> from sympy.abc import x
-    >>> from sympy.core.operations import evaluate
+    >>> from sympy.core.evaluate import evaluate
     >>> print(x + x)
     2*x
     >>> with evaluate(False):

--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -20,10 +20,10 @@ def evaluate(x):
 
     >>> from sympy.abc import x
     >>> from sympy.core.operations import evaluate
-    >>> print x + x
+    >>> print(x + x)
     2*x
     >>> with evaluate(False):
-    ...     print x + x
+    ...     print(x + x)
     x + x
     """
 


### PR DESCRIPTION
What's concerning here is that the doctest runner (obviously) isn't run on
this doctest.
