### PR TITLE
fixes pyglet doctest problems

### DIFF
--- a/sympy/plotting/pygletplot/plot_mode_base.py
+++ b/sympy/plotting/pygletplot/plot_mode_base.py
@@ -323,7 +323,7 @@ class PlotModeBase(PlotMode):
             for i in self.intervals:
                 if i.v_steps is None:
                     continue
-                step_max = max([step_max, i.v_steps])
+                step_max = max([step_max, int(i.v_steps)])
             v = ['both', 'solid'][step_max > 40]
         #try:
         if v not in self.styles:


### PR DESCRIPTION
fixes TypeError and KeyError exceptions in the pygletplot package

``` py
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/doctest.py", line 1289, in __run
        compileflags, 1) in test.globs
      File "<doctest sympy.plotting.pygletplot.__init__.PygletPlot[29]>", line 1, in <module>
        p[2] = -x**2-y**2
      File "sympy/plotting/pygletplot/plot.py", line 320, in __setitem__
        f = PlotMode(*args, **kwargs)
      File "sympy/plotting/pygletplot/plot_mode_base.py", line 164, in __init__
        self.style = self.options.pop('style', '')
      File "sympy/plotting/pygletplot/plot_mode_base.py", line 174, in w
        r = f(self, *args, **kwargs)
      File "sympy/plotting/pygletplot/plot_mode_base.py", line 327, in _set_style
        v = ['both', 'solid'][step_max > 40]
    TypeError: list indices must be integers, not BooleanFalse

    Traceback (most recent call last):
      File "/usr/lib64/python2.7/doctest.py", line 1289, in __run
        compileflags, 1) in test.globs
      File "<doctest sympy.plotting.pygletplot.__init__.PygletPlot[30]>", line 1, in <module>
        p[2].style = 'wireframe'
      File "sympy/plotting/pygletplot/plot.py", line 301, in __getitem__
        return self._functions[i]
    KeyError: 2
```
