### PR TITLE
doctests: fix problem with decorators

### DIFF
--- a/sympy/core/evaluate.py
+++ b/sympy/core/evaluate.py
@@ -19,11 +19,11 @@ def evaluate(x):
     ========
 
     >>> from sympy.abc import x
-    >>> from sympy.core.operations import evaluate
-    >>> print x + x
+    >>> from sympy.core.evaluate import evaluate
+    >>> print(x + x)
     2*x
     >>> with evaluate(False):
-    ...     print x + x
+    ...     print(x + x)
     x + x
     """
 

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1398,8 +1398,6 @@ class SymPyDocTestFinder(DocTestFinder):
                                    source_lines, globs, seen)
                     except KeyboardInterrupt:
                         raise
-                    except ValueError:
-                        raise
 
             # Look for tests in a module's __test__ dictionary.
             for valname, val in getattr(obj, '__test__', {}).items():

--- a/sympy/utilities/runtests.py
+++ b/sympy/utilities/runtests.py
@@ -1400,8 +1400,6 @@ class SymPyDocTestFinder(DocTestFinder):
                         raise
                     except ValueError:
                         raise
-                    except Exception:
-                        pass
 
             # Look for tests in a module's __test__ dictionary.
             for valname, val in getattr(obj, '__test__', {}).items():
@@ -1431,19 +1429,21 @@ class SymPyDocTestFinder(DocTestFinder):
 
                 # Recurse to methods, properties, and nested classes.
                 if (inspect.isfunction(val) or
-                    inspect.isclass(val) or
-                    isinstance(val, property)):
+                        inspect.isclass(val) or
+                        isinstance(val, property)):
                     # Make sure we don't run doctests functions or classes
                     # from different modules
                     if isinstance(val, property):
-                        if val.fget.__module__ != module.__name__:
-                            continue
+                        if hasattr(val.fget, '__module__'):
+                            if val.fget.__module__ != module.__name__:
+                                continue
                     else:
                         if val.__module__ != module.__name__:
                             continue
 
                     assert self._from_module(module, val), \
-                        "%s is not in module %s (valname %s)" % (val, module, valname)
+                        "%s is not in module %s (valname %s)" % (
+                            val, module, valname)
 
                     valname = '%s.%s' % (name, valname)
                     self._find(tests, val, valname, module, source_lines,
@@ -1500,10 +1500,16 @@ class SymPyDocTestFinder(DocTestFinder):
         if lineno is None:
             # handling of properties is not implemented in _find_lineno so do
             # it here
-            tobj = obj if not isinstance(obj, property) else obj.fget
+            if hasattr(obj, 'func_closure') and obj.func_closure is not None:
+                tobj = obj.func_closure[0].cell_contents
+            elif isinstance(obj, property):
+                tobj = obj.fget
+            else:
+                tobj = obj
             lineno = self._find_lineno(tobj, source_lines)
 
-        assert lineno is not None
+        if lineno is None:
+            return None
 
         # Return a DocTest for this object.
         if module is None:


### PR DESCRIPTION
fixes #7399

with this commit all decorated functions/methods containing doctests,
where the used decorator is != `property` are executed now and not
silently skipped.
