### PR TITLE
remove redundant condtion

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -175,7 +175,7 @@ class ExprWithLimits(Expr):
         """
         This method returns the symbols that will exist when the object is
         evaluated. This is useful if one is trying to determine whether the
-        objet contains a certain symbol or not.
+        object contains a certain symbol or not.
 
         Examples
         ========
@@ -186,8 +186,6 @@ class ExprWithLimits(Expr):
         set([y])
         """
         function, limits = self.function, self.limits
-        if function.is_zero:
-            return set()
         isyms = function.free_symbols
         for xab in limits:
             if len(xab) == 1:

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -334,9 +334,9 @@ class RootOf(Expr):
         if not radicals:
             return None
 
-        if radicals and poly.degree() == 2:
+        if poly.degree() == 2:
             return roots_quadratic(poly)
-        elif radicals and poly.length() == 2 and poly.TC():
+        elif poly.length() == 2 and poly.TC():
             return roots_binomial(poly)
         else:
             return None


### PR DESCRIPTION
Really small simplification: we already know that radicals is True since the preceding line
returned if `not radicals` was True.
