### PR TITLE
ODE: Incorporate imaginary constants in classify_ode of undetermined_coeff fixes #5787

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,4 @@
-# Prevent git from showing duplicate names with commands like "git shortlog"
+﻿# Prevent git from showing duplicate names with commands like "git shortlog"
 # See the manpage of git-shortlog for details.
 # The syntax is:
 # Name that should be used <email that should be used> Bad name <bad email>

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3976,7 +3976,7 @@ def _undetermined_coefficients_match(expr, x):
                 return True
             else:
                 return False
-        elif expr.is_Symbol or expr.is_Number:
+        elif expr.is_Symbol or expr.is_number:
             return True
         else:
             return False

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1120,6 +1120,14 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     assert checkodesol(eq28, sol28, order=1, solve_for_func=False)[0]
 
 
+def test_issue_5787():
+    # This test case is to show the classification of imaginary constants under
+    # nth_linear_constant_coeff_undetermined_coefficients
+    eq = Eq(diff(f(x), x), I*f(x) + S(1)/2 - I)
+    out_hint = 'nth_linear_constant_coeff_undetermined_coefficients'
+    assert out_hint in classify_ode(eq)
+
+
 @XFAIL
 def test_nth_linear_constant_coeff_undetermined_coefficients_imaginary_exp():
     # Equivalent to eq26 in


### PR DESCRIPTION
In issue https://github.com/sympy/sympy/issues/5787, there was no
condition to classify imaginary constants which caused the issue to
fail in case of undetermined coefficients. This patch have a condition
added to classify it.

fixes #5787
