### PR TITLE
modify is_real to not fail for non-numbers

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -556,6 +556,7 @@ def test_asin():
 
     assert asin(0.2).is_real is True
     assert asin(-2).is_real is False
+    assert asin(r).is_real is None
 
     assert asin(-2*I) == -I*asinh(2)
 
@@ -598,6 +599,7 @@ def test_acos():
 
     assert acos(0.2).is_real is True
     assert acos(-2).is_real is False
+    assert acos(r).is_real is None
 
     assert acos(Rational(1, 7), evaluate=False).is_positive is True
     assert acos(Rational(-1, 7), evaluate=False).is_positive is True

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1454,11 +1454,8 @@ class asin(Function):
         return -S.ImaginaryUnit*C.log(S.ImaginaryUnit*x + sqrt(1 - x**2))
 
     def _eval_is_real(self):
-        r = self.args[0].is_real and (self.args[0] >= -1 and
-                                      self.args[0] <= 1)
-        if r == True or r == False:
-            r = bool(r)
-        return r
+        x = self.args[0]
+        return x.is_real and (1 - abs(x)).is_nonnegative
 
     def inverse(self, argindex=1):
         """
@@ -1514,8 +1511,7 @@ class acos(Function):
 
     def _eval_is_positive(self):
         x = self.args[0]
-        if (x - 1).is_nonpositive and (x + 1).is_nonnegative:
-            return True
+        return (1 - abs(x)).is_nonnegative
 
     @classmethod
     def eval(cls, arg):
@@ -1575,14 +1571,12 @@ class acos(Function):
             return self.func(arg)
 
     def _eval_is_real(self):
-        r = self.args[0].is_real and (self.args[0] >= -1 and
-                                      self.args[0] <= 1)
-        if r == True or r == False:
-            r = bool(r)
-        return r
+        x = self.args[0]
+        return x.is_real and (1 - abs(x)).is_nonnegative
 
     def _eval_rewrite_as_log(self, x):
-        return S.Pi/2 + S.ImaginaryUnit * C.log(S.ImaginaryUnit * x + sqrt(1 - x**2))
+        return S.Pi/2 + S.ImaginaryUnit * \
+            C.log(S.ImaginaryUnit * x + sqrt(1 - x**2))
 
     def _eval_rewrite_as_asin(self, x):
         return S.Pi/2 - asin(x)


### PR DESCRIPTION
The old assumptions system cannot handle determination of a range for a non-number so the following fails:

```
>>> var('x', real=True)
x
>>>
>>> acos(x).is_positive
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sympy\core\assumptions.py", line 144, in getit
    return _ask(fact, self)
  File "sympy\core\assumptions.py", line 197, in _ask
    _ask(pk, obj)
  File "sympy\core\assumptions.py", line 187, in _ask
    a = evaluate(obj)
  File "sympy\functions\elementary\trigonometric.py", line 1567, in _eval_is_real
    r = self.args[0].is_real and (self.args[0] >= -1 and
  File "sympy\core\relational.py", line 112, in __nonzero__
    raise TypeError("symbolic boolean expression has no truth value.")
```
