### PR TITLE
Improve constant simplification for dsolve

### DIFF
--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -66,7 +66,7 @@ def real_imag(ba, bd, gen):
     Helper function, to get the real and imaginary part of a rational function
     evaluated at sqrt(-1) without actually evaluating it at sqrt(-1)
 
-    Seperates the even and odd power terms by checking the degree of terms wrt
+    Separates the even and odd power terms by checking the degree of terms wrt
     mod 4. Returns a tuple (ba[0], ba[1], bd) where ba[0] is real part
     of the numerator ba[1] is the imaginary part and bd is the denominator
     of the rational function.

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -683,7 +683,7 @@ class KanesMethod(object):
         # gets multiplied by the jacobian of qd wrt qi, this is extended for
         # the ud's as well. dqd_dqi is computed by taking a taylor expansion of
         # the holonomic constraint equations about q*, treating q* - q as dq,
-        # seperating into dqd (depedent q's) and dqi (independent q's) and the
+        # separating into dqd (depedent q's) and dqi (independent q's) and the
         # rearranging for dqd/dqi. This is again extended for the speeds.
 
         # First case: configuration and motion constraints

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -5145,6 +5145,8 @@ def terms_gcd(f, *gens, **args):
     sympy.core.exprtools.gcd_terms, sympy.core.exprtools.factor_terms
 
     """
+    from sympy.core.relational import Equality
+
     orig = sympify(f)
     if not isinstance(f, Expr) or f.is_Atom:
         return orig
@@ -5154,6 +5156,9 @@ def terms_gcd(f, *gens, **args):
         args.pop('deep')
         args['expand'] = False
         return terms_gcd(new, *gens, **args)
+
+    if isinstance(f, Equality):
+        return f
 
     clear = args.pop('clear', True)
     options.allowed_flags(args, ['polys'])

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -59,8 +59,7 @@ from sympy.core.compatibility import iterable
 from sympy.core.mul import _keep_coeff
 from sympy.utilities.pytest import raises, XFAIL
 
-x, y, z, p, q, r, s, t, u, v, w, a, b, c, d, e = symbols(
-    'x,y,z,p,q,r,s,t,u,v,w,a,b,c,d,e')
+from sympy.abc import a, b, c, d, e, p, q, r, s, t, u, v, w, x, y, z
 
 
 def _epsilon_eq(a, b):
@@ -1981,6 +1980,10 @@ def test_terms_gcd():
         3*x*(x + 1)*(sin(Mul(3, y + 1, evaluate=False)) + 1)
     assert terms_gcd(sin(x + x*y), deep=True) == \
         sin(x*(y + 1))
+
+    eq = Eq(2*x, 2*y + 2*z*y)
+    assert terms_gcd(eq) == eq
+    assert terms_gcd(eq, deep=True) == Eq(2*x, 2*y*(z + 1))
 
 
 def test_trunc():

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -177,7 +177,7 @@ def opt_cse(exprs, order='canonical'):
 
     def _find_opts(expr):
 
-        if expr.is_Atom:
+        if expr.is_Atom or expr.is_Order:
             return
 
         if iterable(expr):
@@ -294,7 +294,7 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
     seen_subexp = set()
 
     def _find_repeated(expr):
-        if expr.is_Atom:
+        if expr.is_Atom or expr.is_Order:
             return
 
         if iterable(expr):

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -2,7 +2,7 @@ import itertools
 
 from sympy import (Add, Pow, Symbol, exp, sqrt, symbols, sympify, cse,
                    Matrix, S, cos, sin, Eq, Function, Tuple, RootOf,
-                   IndexedBase, Idx, MatrixSymbol, Piecewise)
+                   IndexedBase, Idx, MatrixSymbol, Piecewise, O)
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
@@ -297,3 +297,7 @@ def test_Piecewise():
     ans = cse(f)
     actual_ans = ([(x0, -z), (x1, x*y)], [Piecewise((x0+x1, Eq(y, 0)), (x0 - x1, True))])
     assert ans == actual_ans
+
+def test_ignore_order_terms():
+    eq = exp(x).series(x,0,3) + sin(y+x**3) - 1
+    assert cse(eq) == ([], [sin(x**3 + y) + x + x**2/2 + O(x**3)])

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -2193,10 +2193,15 @@ def ode_1st_homogeneous_coeff_best(eq, func, order, match):
     func, order, match)
     simplify = match.get('simplify', True)
     if simplify:
+        # why is odesimp called here?  Should it be at the usual spot?
+        constants = sol1.free_symbols.difference(eq.free_symbols)
         sol1 = odesimp(
-            sol1, func, order, "1st_homogeneous_coeff_subs_indep_div_dep")
+            sol1, func, order, constants,
+            "1st_homogeneous_coeff_subs_indep_div_dep")
+        constants = sol2.free_symbols.difference(eq.free_symbols)
         sol2 = odesimp(
-            sol2, func, order, "1st_homogeneous_coeff_subs_dep_div_indep")
+            sol2, func, order, constants,
+            "1st_homogeneous_coeff_subs_dep_div_indep")
     return min([sol1, sol2], key=lambda x: ode_sol_simplicity(x, func,
         trysolving=not simplify))
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -791,7 +791,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
     c3 = Wild('c3', exclude=[f(x), df, f(x).diff(x, 2)])
     r3 = {'xi': xi, 'eta': eta}  # Used for the lie_group hint
     boundary = {}  # Used to extract initial conditions
-    C0 = Symbol("C0")
+    C1 = Symbol("C1")
     eq = expand(eq)
 
     # Preprocessing to get the initial conditions out
@@ -893,7 +893,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
             # at a given point.
             # This is currently done internally in ode_1st_power_series.
             point = boundary.get('f0', 0)
-            value = boundary.get('f0val', C0)
+            value = boundary.get('f0val', C1)
             check = cancel(r[d]/r[e])
             check1 = check.subs({x: point, y: value})
             if not check1.has(oo) and not check1.has(zoo) and \
@@ -1254,7 +1254,7 @@ def odesimp(eq, func, order, constants, hint):
     """
     x = func.args[0]
     f = func.func
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
 
     # First, integrate if the hint allows it.
     eq = _handle_Integral(eq, func, order, hint)
@@ -2135,7 +2135,7 @@ def ode_1st_exact(eq, func, order, match):
     d = r[r['d']]
     global y  # This is the only way to pass dummy y to _handle_Integral
     y = r['y']
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     # Refer Joel Moses, "Symbolic Integration - The Stormy Decade",
     # Communications of the ACM, Volume 14, Number 8, August 1971, pp. 558
     # which gives the method to solve an exact differential equation.
@@ -2288,7 +2288,7 @@ def ode_1st_homogeneous_coeff_subs_dep_div_indep(eq, func, order, match):
     u = Dummy('u')
     u1 = Dummy('u1')  # u1 == f(x)/x
     r = match  # d+e*diff(f(x),x)
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     xarg = match.get('xarg', 0)
     yarg = match.get('yarg', 0)
     int = C.Integral(
@@ -2384,7 +2384,7 @@ def ode_1st_homogeneous_coeff_subs_indep_div_dep(eq, func, order, match):
     u = Dummy('u')
     u2 = Dummy('u2')  # u2 == x/f(x)
     r = match  # d+e*diff(f(x),x)
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     xarg = match.get('xarg', 0)  # If xarg present take xarg, else zero
     yarg = match.get('yarg', 0)  # If yarg present take yarg, else zero
     int = C.Integral(
@@ -2544,7 +2544,7 @@ def ode_1st_linear(eq, func, order, match):
     x = func.args[0]
     f = func.func
     r = match  # a*diff(f(x),x) + b*f(x) + c
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     t = exp(C.Integral(r[r['b']]/r[r['a']], x))
     tt = C.Integral(t*(-r[r['c']]/r[r['a']]), x)
     f = match.get('u', f(x))  # take almost-linear u if present, else f(x)
@@ -2630,7 +2630,7 @@ def ode_Bernoulli(eq, func, order, match):
     x = func.args[0]
     f = func.func
     r = match  # a*diff(f(x),x) + b*f(x) + c*f(x)**n, n != 1
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     t = exp((1 - r[r['n']])*C.Integral(r[r['b']]/r[r['a']], x))
     tt = (r[r['n']] - 1)*C.Integral(t*r[r['c']]/r[r['a']], x)
     return Eq(f(x), ((tt + C1)/t)**(1/(1 - r[r['n']])))
@@ -2680,7 +2680,7 @@ def ode_Riccati_special_minus2(eq, func, order, match):
     f = func.func
     r = match  # a2*diff(f(x),x) + b2*f(x) + c2*f(x)/x + d2/x**2
     a2, b2, c2, d2 = [r[r[s]] for s in 'a2 b2 c2 d2'.split()]
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     mu = sqrt(4*d2*b2 - (a2 - c2)**2)
     return Eq(f(x), (a2 - c2 - mu*tan(mu/(2*a2)*log(x) + C1))/(2*b2*x))
 
@@ -2751,8 +2751,7 @@ def ode_Liouville(eq, func, order, match):
     f = func.func
     r = match  # f(x).diff(x, 2) + g*f(x).diff(x)**2 + h*f(x).diff(x)
     y = r['y']
-    C1 = Symbol('C1')
-    C2 = Symbol('C2')
+    C1, C2 = get_new_constants(eq, num=2)
     int = C.Integral(exp(C.Integral(r['g'], y)), (y, None, f(x)))
     sol = Eq(int + C1*C.Integral(exp(-C.Integral(r['h'], x)), x) + C2, 0)
     return sol
@@ -2796,7 +2795,7 @@ def ode_2nd_power_series_ordinary(eq, func, order, match):
     """
     x = func.args[0]
     f = func.func
-    C0, C1 = symbols("C0 C1")
+    C0, C1 = get_new_constants(eq, num=2)
     n = Dummy("n")
     s = Wild("s")
     k = Wild("k", exclude=[x])
@@ -2961,7 +2960,7 @@ def ode_2nd_power_series_regular(eq, func, order, match):
     """
     x = func.args[0]
     f = func.func
-    C0, C1 = symbols("C0 C1")
+    C0, C1 = get_new_constants(eq, num=2)
     n = Dummy("n")
     m = Dummy("m")  # for solving the indicial equation
     s = Wild("s")
@@ -3203,7 +3202,7 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
     r = match
 
     # A generator of constants
-    constants = numbered_symbols(prefix='C', cls=Symbol, start=1)
+    constants = new_constants(eq)
 
     # First, set up characteristic equation.
     chareq, symbol = S.Zero, Dummy('x')
@@ -3591,7 +3590,6 @@ def ode_1st_power_series(eq, func, order, match):
     y = match['y']
     f = func.func
     h = -match[match['d']]/match[match['e']]
-    C0 = Symbol("C0")
     point = match.get('f0')
     value = match.get('f0val')
     terms = match.get('terms')
@@ -3706,7 +3704,7 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     r = match
 
     # A generator of constants
-    constants = numbered_symbols(prefix='C', cls=Symbol, start=1)
+    constants = new_constants(eq)
 
     # First, set up characteristic equation.
     chareq, symbol = S.Zero, Dummy('x')
@@ -3725,7 +3723,7 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     for root in chareqroots:
         charroots[root] += 1
     gsol = S(0)
-    # We need keep track of terms so we can run collect() at the end.
+    # We need to keep track of terms so we can run collect() at the end.
     # This is necessary for constantsimp to work properly.
     global collectterms
     collectterms = []
@@ -4275,7 +4273,7 @@ def ode_separable(eq, func, order, match):
     """
     x = func.args[0]
     f = func.func
-    C1 = Symbol('C1')
+    C1 = get_new_constants(eq, num=1)
     r = match  # {'m1':m1, 'm2':m2, 'y':y}
     u = r.get('hint', f(x))  # get u from separable_reduced else get f(x)
     return Eq(C.Integral(r['m2']['coeff']*r['m2'][r['y']]/r['m1'][r['y']],

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -357,28 +357,28 @@ def sub_func_doit(eq, func, new):
     return eq.subs(reps).subs(func, new).subs(repu)
 
 
-def new_constants(eq, start=1, prefix='C'):
-    """
-    Yield an infinite sequence constants that do not occur
-    in eq already.
-    """
-    if isinstance(eq, C.Expr):
-        atom_set = eq.atoms(Symbol)
-    elif is_iterable(eq):
-        atom_set = reduce(lambda x, y : x | y,
-            [i.atoms(Symbol) for i in eq], set() )
-    else:
-        raise ValueError("Expected Expr or iterable but got %s"%eq)
-    for Ci in numbered_symbols(prefix=prefix, start=start, cls=Symbol):
-        if Ci not in atom_set:
-            yield Ci
-
-
 def get_new_constants(eq, num=1, start=1, prefix='C'):
     """
     Returns a list of constants that do not occur
     in eq already.
     """
+
+    def new_constants(eq, start=1, prefix='C'):
+        """
+        Yield an infinite sequence constants that do not occur
+        in eq already.
+        """
+        if isinstance(eq, C.Expr):
+            atom_set = eq.atoms(Symbol)
+        elif is_iterable(eq):
+            atom_set = reduce(lambda x, y : x | y,
+                [i.atoms(Symbol) for i in eq], set() )
+        else:
+            raise ValueError("Expected Expr or iterable but got %s"%eq)
+        for Ci in numbered_symbols(prefix=prefix, start=start, cls=Symbol):
+            if Ci not in atom_set:
+                yield Ci
+
     g = new_constants(eq, start=start, prefix=prefix)
     Cs = [ next(g) for i in xrange(num) ]
     return ( Cs[0] if num == 1 else tuple(Cs) )

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -817,7 +817,7 @@ def classify_ode(eq, func=None, dict=False, ics=None, **kwargs):
              b: dep.coeff(f(x)),
              c: ind}
         # double check f[a] since the preconditioning may have failed
-        if not r[a].has(f) and (
+        if not r[a].has(f) and not r[b].has(f) and (
                 r[a]*df + r[b]*f(x) + r[c]).expand() - reduced_eq == 0:
             r['a'] = a
             r['b'] = b

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1284,7 +1284,7 @@ def odesimp(eq, func, order, constants, hint):
             # 'collectterms' gives different orders sometimes, and results
             # differ in collect based on that order.  The
             # sort-reverse trick fixes things, but may fail in the
-            # future. In addition, collect is spliting exponentials with
+            # future. In addition, collect is splitting exponentials with
             # rational powers for no reason.  We have to do a match
             # to fix this using Wilds.
             global collectterms
@@ -1809,7 +1809,7 @@ def constantsimp(expr, constants):
     This function is written specifically to work with
     :py:meth:`~sympy.solvers.ode.dsolve`, and is not intended for general use.
 
-    Simplification is done by "absorbing" the arbitrary constants in to other
+    Simplification is done by "absorbing" the arbitrary constants into other
     arbitrary constants, numbers, and symbols that they are not independent
     of.
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -3201,9 +3201,6 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
     f = func.func
     r = match
 
-    # A generator of constants
-    constants = new_constants(eq)
-
     # First, set up characteristic equation.
     chareq, symbol = S.Zero, Dummy('x')
 
@@ -3213,6 +3210,10 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
 
     chareq = Poly(chareq, symbol)
     chareqroots = [RootOf(chareq, k) for k in xrange(chareq.degree())]
+
+    # A generator of constants
+    constants = list(get_new_constants(eq, num=chareq.degree()*2))
+    constants.reverse()
 
     # Create a dict root: multiplicity or charroots
     charroots = defaultdict(int)
@@ -3225,19 +3226,19 @@ def ode_nth_linear_euler_eq_homogeneous(eq, func, order, match, returns='sol'):
     for root, multiplicity in charroots.items():
         for i in range(multiplicity):
             if isinstance(root, RootOf):
-                gsol += (x**root) * next(constants)
+                gsol += (x**root) * constants.pop()
                 if multiplicity != 1:
                     raise ValueError("Value should be 1")
                 collectterms = [(0, root, 0)] + collectterms
             elif root.is_real:
-                gsol += ln(x)**i*(x**root) * next(constants)
+                gsol += ln(x)**i*(x**root) * constants.pop()
                 collectterms = [(i, root, 0)] + collectterms
             else:
                 reroot = re(root)
                 imroot = im(root)
                 gsol += ln(x)**i * (x**reroot) * (
-                    next(constants) * sin(abs(imroot)*ln(x))
-                    + next(constants) * cos(imroot*ln(x)))
+                    constants.pop() * sin(abs(imroot)*ln(x))
+                    + constants.pop() * cos(imroot*ln(x)))
                 # Preserve ordering (multiplicity, real part, imaginary part)
                 # It will be assumed implicitly when constructing
                 # fundamental solution sets.
@@ -3703,9 +3704,6 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     f = func.func
     r = match
 
-    # A generator of constants
-    constants = new_constants(eq)
-
     # First, set up characteristic equation.
     chareq, symbol = S.Zero, Dummy('x')
 
@@ -3717,6 +3715,10 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
 
     chareq = Poly(chareq, symbol)
     chareqroots = [ RootOf(chareq, k) for k in range(chareq.degree()) ]
+
+    # A generator of constants
+    constants = list(get_new_constants(eq, num=chareq.degree()*2))
+    constants.reverse()
 
     # Create a dict root: multiplicity or charroots
     charroots = defaultdict(int)
@@ -3730,15 +3732,15 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
     for root, multiplicity in charroots.items():
         for i in range(multiplicity):
             if isinstance(root, RootOf):
-                gsol += exp(root*x) * next(constants)
+                gsol += exp(root*x) * constants.pop()
                 if multiplicity != 1:
                     raise ValueError("Value should be 1")
                 collectterms = [(0, root, 0)] + collectterms
             else:
                 reroot = re(root)
                 imroot = im(root)
-                gsol += x**i*exp(reroot*x) * (next(constants) * sin(abs(imroot) * x) + \
-                    next(constants) * cos(imroot*x))
+                gsol += x**i*exp(reroot*x) * (constants.pop() * sin(abs(imroot) * x) + \
+                    constants.pop() * cos(imroot*x))
                 # This ordering is important
                 collectterms = [(i, reroot, imroot)] + collectterms
     if returns == 'sol':

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -363,26 +363,15 @@ def get_numbered_constants(eq, num=1, start=1, prefix='C'):
     in eq already.
     """
 
-    def numbered_constants(start=1, prefix='C', exclude=[]):
-        """
-        Yield an infinite sequence constants that do not occur
-        in exclude already.
-        """
-        for Ci in numbered_symbols(prefix=prefix, start=start, cls=Symbol):
-            if Ci not in exclude:
-                yield Ci
-
     if isinstance(eq, C.Expr):
-        atom_set = eq.atoms(Symbol)
-    elif is_iterable(eq):
-        atom_set = reduce(lambda x, y : x | y,
-            [i.atoms(Symbol) for i in eq], set() )
-    else:
-        raise ValueError("Expected Expr or iterable but got %s"%eq)
+        eq = [eq]
+    elif not is_iterable(eq):
+        raise ValueError("Expected Expr or iterable but got %s" % eq)
 
-    ncs = numbered_constants(start=start, prefix=prefix, exclude=atom_set)
-    Cs = [ next(ncs) for i in xrange(num) ]
-    return ( Cs[0] if num == 1 else tuple(Cs) )
+    atom_set = set.union(*[i.free_symbols for i in eq])
+    ncs = numbered_symbols(start=start, prefix=prefix, exclude=atom_set)
+    Cs = [next(ncs) for i in xrange(num)]
+    return (Cs[0] if num == 1 else tuple(Cs))
 
 
 def dsolve(eq, func=None, hint="default", simplify=True,

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -537,7 +537,7 @@ def dsolve(eq, func=None, hint="default", simplify=True,
 
     >>> eq = sin(x)*cos(f(x)) + cos(x)*sin(f(x))*f(x).diff(x)
     >>> dsolve(eq, hint='separable_reduced')
-    f(x) == C1/(C2*x - 1)
+    f(x) == C1/(C1*x - 1)
     >>> dsolve(eq, hint='1st_exact')
     [f(x) == -acos(C1/cos(x)) + 2*pi, f(x) == acos(C1/cos(x))]
     >>> dsolve(eq, hint='almost_linear')
@@ -1242,7 +1242,7 @@ def odesimp(eq, func, order, constants, hint):
                             |
                            /
 
-    >>> pprint(odesimp(eq, f(x), 1,
+    >>> pprint(odesimp(eq, f(x), 1, set([C1]),
     ... hint='1st_homogeneous_coeff_subs_indep_div_dep'
     ... )) #doctest: +SKIP
         x
@@ -1866,12 +1866,12 @@ def constantsimp(expr, constants):
 
     >>> from sympy import symbols
     >>> from sympy.solvers.ode import constantsimp
-    >>> C1, C2, C3, x, y = symbols('C1,C2,C3,x,y')
-    >>> constantsimp(2*C1*x, x, 3)
+    >>> C1, C2, C3, x, y = symbols('C1, C2, C3, x, y')
+    >>> constantsimp(2*C1*x, set([C1, C2, C3]))
     C1*x
-    >>> constantsimp(C1 + 2 + x + y, x, 3)
+    >>> constantsimp(C1 + 2 + x, set([C1, C2, C3]))
     C1 + x
-    >>> constantsimp(C1*C2 + 2 + x + y + C3*x, x, 3)
+    >>> constantsimp(C1*C2 + 2 + C2 + C3*x, set([C1, C2, C3]))
     C1 + C3*x
 
     """
@@ -2780,10 +2780,10 @@ def ode_2nd_power_series_ordinary(eq, func, order, match):
     >>> f = Function("f")
     >>> eq = f(x).diff(x, 2) + f(x)
     >>> pprint(dsolve(eq, hint='2nd_power_series_ordinary'))
-                /   2    \      / 4    2    \
-                |  x     |      |x    x     |    / 6\
-    f(x) = C1*x*|- -- + 1| + C0*|-- - -- + 1| + O\x /
-                \  6     /      \24   2     /
+              / 4    2    \        /   2    \
+              |x    x     |        |  x     |    / 6\
+    f(x) = C2*|-- - -- + 1| + C1*x*|- -- + 1| + O\x /
+              \24   2     /        \  6     /
 
 
     References
@@ -2944,12 +2944,12 @@ def ode_2nd_power_series_regular(eq, func, order, match):
     >>> f = Function("f")
     >>> eq = x*(f(x).diff(x, 2)) + 2*(f(x).diff(x)) + x*f(x)
     >>> pprint(dsolve(eq))
-              /    6    4    2    \
-              |   x    x    x     |
-           C1*|- --- + -- - -- + 1|      /  4    2    \
-              \  720   24   2     /      | x    x     |    / 6\
-    f(x) = ------------------------ + C0*|--- - -- + 1| + O\x /
-                      x                  \120   6     /
+                                  /    6    4    2    \
+                                  |   x    x    x     |
+              /  4    2    \   C1*|- --- + -- - -- + 1|
+              | x    x     |      \  720   24   2     /    / 6\
+    f(x) = C2*|--- - -- + 1| + ------------------------ + O\x /
+              \120   6     /              x
 
 
     References
@@ -3574,8 +3574,8 @@ def ode_1st_power_series(eq, func, order, match):
     >>> eq = exp(x)*(f(x).diff(x)) - f(x)
     >>> pprint(dsolve(eq, hint='1st_power_series'))
                            3       4       5
-                       C0*x    C0*x    C0*x     / 6\
-    f(x) = C0 + C0*x - ----- + ----- + ----- + O\x /
+                       C1*x    C1*x    C1*x     / 6\
+    f(x) = C1 + C1*x - ----- + ----- + ----- + O\x /
                          6       24      60
 
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -594,12 +594,11 @@ def _helper_simplify(eq, hint, match, simplify=True, **kwargs):
         # attempt to solve for func, and apply any other hint specific
         # simplifications
         sols = solvefunc(eq, func, order, match)
+        free = eq.free_symbols
+        cons = lambda s: s.free_symbols.difference(free)
         if isinstance(sols, C.Expr):
-            constants = sols.free_symbols.difference(eq.free_symbols)
-            return odesimp(sols, func, order, constants, hint)
-        return [odesimp(sol, func, order,
-                        sol.free_symbols.difference(eq.free_symbols), hint)
-                        for sol in sols]
+            return odesimp(sols, func, order, cons(sols), hint)
+        return [odesimp(s, func, order, cons(s), hint) for s in sols]
     else:
         # We still want to integrate (you can disable it separately with the hint)
         match['simplify'] = False  # Some hints can take advantage of this option
@@ -1306,7 +1305,7 @@ def odesimp(eq, func, order, constants, hint):
             # contract over-expanded exponentials -- this is
             # a work-around for collect's bad behavior.
             w1, w2 = Wild('w1',exclude=[x]), Wild('w2')
-            sol = sol.replace( exp(w1*x)**w2, exp(w1*w2*x) )
+            sol = sol.replace(exp(w1*x)**w2, exp(w1*w2*x))
             eq[0] = Eq(f(x), sol)
 
     else:
@@ -1722,7 +1721,7 @@ def _get_constant_subexpressions(expr, Cs):
     Cs = set(Cs)
     Ces = []
     def _recursive_walk(expr):
-        expr_syms = expr.atoms(Symbol)
+        expr_syms = expr.free_symbols
         if len(expr_syms) > 0 and expr_syms.issubset(Cs):
             Ces.append(expr)
         else:
@@ -1730,13 +1729,13 @@ def _get_constant_subexpressions(expr, Cs):
                 expr = expr.expand(mul=True)
             if expr.func in (Add, Mul):
                 d = sift(expr.args, lambda i : i.free_symbols.issubset(Cs))
-                if True in d and len(d[True])>1:
+                if len(d[True]) > 1:
                     x = expr.func(*d[True])
-                    if 0 < len(x.atoms(Symbol)):
+                    if not x.is_number:
                         Ces.append(x)
-            elif expr.func in (C.Integral, ):
+            elif isinstance(expr, C.Integral):
                 if expr.free_symbols.issubset(Cs) and \
-                        all(map( lambda x : len(x) == 3, expr.limits)):
+                        all(map(lambda x: len(x) == 3, expr.limits)):
                     Ces.append(expr)
             for i in expr.args:
                 _recursive_walk(i)
@@ -1746,12 +1745,12 @@ def _get_constant_subexpressions(expr, Cs):
 
 def __remove_linear_redundancies(expr, Cs):
     cnts = dict([(i, expr.count(i)) for i in Cs])
-    Cs = [ i for i in Cs if cnts[i] > 0 ]
+    Cs = [i for i in Cs if cnts[i] > 0]
 
     def _linear(expr):
         if expr.func is Add:
-            xs = [ i for i in Cs if expr.count(i)==cnts[i] \
-                and 0 == expr.diff(i, 2) ]
+            xs = [i for i in Cs if expr.count(i)==cnts[i] \
+                and 0 == expr.diff(i, 2)]
             d = {}
             for x in xs:
                 y = expr.diff(x)
@@ -1772,18 +1771,14 @@ def __remove_linear_redundancies(expr, Cs):
         return expr
 
     if expr.func is Equality:
-        lhs = expr.lhs
-        rhs = expr.rhs
-        lhs = _recursive_walk(lhs)
-        rhs = _recursive_walk(rhs)
+        lhs, rhs = [_recursive_walk(i) for i in expr.args]
         f = lambda i: isinstance(i, C.Number) or i in Cs
-        g = lambda i: isinstance(i, C.Number) or i in Cs
         if lhs.func is Symbol and lhs in Cs:
-            (rhs, lhs) = (lhs, rhs)
+            rhs, lhs = lhs, rhs
         if lhs.func in (Add, Symbol) and rhs.func in (Add, Symbol):
             dlhs = sift([lhs] if isinstance(lhs, C.AtomicExpr) else lhs.args, f)
             drhs = sift([rhs] if isinstance(rhs, C.AtomicExpr) else rhs.args, f)
-            for i in [ True, False ]:
+            for i in [True, False]:
                 for hs in [dlhs, drhs]:
                     if i not in hs:
                         hs[i] = [0]
@@ -1879,9 +1874,9 @@ def constantsimp(expr, constants):
     constant_subexprs = _get_constant_subexpressions(expr, Cs)
     for xe in constant_subexprs:
         xes = list(xe.free_symbols)
-        if len(xes) == 0:
+        if not xes:
             continue
-        if all([ expr.count(c) == xe.count(c) for c in xes ]):
+        if all([expr.count(c) == xe.count(c) for c in xes]):
             xes.sort(key=str)
             expr = expr.subs(xe, xes[0])
 
@@ -1901,7 +1896,7 @@ def constantsimp(expr, constants):
         pass
     expr = __remove_linear_redundancies(expr, Cs)
 
-    def conditional_term_factoring(expr):
+    def _conditional_term_factoring(expr):
         new_expr = terms_gcd(expr, clear=False, deep=True, expand=False)
 
         # we do not want to factor exponentials, so handle this separately
@@ -1919,15 +1914,7 @@ def constantsimp(expr, constants):
                     break
         return new_expr
 
-    # XXX terms_gcd sometimes turns an equality into a difference.
-    # So we explicitly handle equalities seperately.  Fix terms_gcd.
-    if isinstance(expr, Eq):
-        new_lhs = conditional_term_factoring(expr.lhs)
-        new_rhs = conditional_term_factoring(expr.rhs)
-        new_expr = Eq(new_lhs, new_rhs)
-    else:
-        new_expr = conditional_term_factoring(expr)
-    expr = new_expr
+    expr = _conditional_term_factoring(expr)
 
     # call recursively if more simplification is possible
     if orig_expr != expr:
@@ -1985,7 +1972,7 @@ def constant_renumber(expr, symbolname, startnumber, endnumber):
         )
     global newstartnumber
     newstartnumber = 1
-    constants_found = [None]*(endnumber+2)
+    constants_found = [None]*(endnumber + 2)
     constantsymbols = [Symbol(
         symbolname + "%d" % t) for t in range(startnumber,
         endnumber + 1)]
@@ -2026,12 +2013,12 @@ def constant_renumber(expr, symbolname, startnumber, endnumber):
                 *[_constant_renumber(x) for x in expr.args])
         else:
             sortedargs = list(expr.args)
-            sortedargs.sort( key=sort_key )
+            sortedargs.sort(key=sort_key)
             return expr.func(*[_constant_renumber(x) for x in sortedargs])
     expr = _constant_renumber(expr)
     # Renumbering happens here
-    newconsts = symbols('C1:%d'%newstartnumber)
-    expr = expr.subs( zip(constants_found[1:], newconsts), simultaneous=True)
+    newconsts = symbols('C1:%d' % newstartnumber)
+    expr = expr.subs(zip(constants_found[1:], newconsts), simultaneous=True)
     return expr
 
 
@@ -3046,7 +3033,7 @@ def _frobenius(n, m, p0, q0, p, q, x0, x, c, check=None):
             dict_ = Poly(list(ordered(tseries.args))[: -1], x).as_dict()
         # Fill in with zeros, if coefficients are zero.
         for i in range(n + 1):
-            if (i, ) not in dict_:
+            if (i,) not in dict_:
                 dict_[(i,)] = S(0)
         serlist.append(dict_)
 
@@ -3705,7 +3692,7 @@ def ode_nth_linear_constant_coeff_homogeneous(eq, func, order, match,
             chareq += r[i]*symbol**i
 
     chareq = Poly(chareq, symbol)
-    chareqroots = [ RootOf(chareq, k) for k in range(chareq.degree()) ]
+    chareqroots = [RootOf(chareq, k) for k in range(chareq.degree())]
 
     # A generator of constants
     constants = list(get_numbered_constants(eq, num=chareq.degree()*2))

--- a/sympy/solvers/tests/test_constantsimp.py
+++ b/sympy/solvers/tests/test_constantsimp.py
@@ -20,153 +20,154 @@ f = Function('f')
 
 def test_constant_mul():
     # We want C1 (Constant) below to absorb the y's, but not the x's
-    assert constant_renumber(constantsimp(y*C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x*C1, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*y, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*x, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(2*C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*2, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(y*C1*x, x, 1), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(x*y*C1, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(y*x*C1, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*y*(y + 1), x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(y*C1*(y + 1), x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x*(y*C1), x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(x*(C1*y), x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*(x*y), x, 1), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp((x*y)*C1, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((y*x)*C1, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(y*(y + 1)*C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*x*y, x, 1), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(x*C1*y, x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((C1*x)*y, x, 1), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(y*(x*C1), x, 1), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((x*C1)*y, x, 1), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(y*C1, [C1]), 'C', 1, 1) == C1*y
+    assert constant_renumber(constantsimp(C1*y, [C1]), 'C', 1, 1) == C1*y
+    assert constant_renumber(constantsimp(x*C1, [C1]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(C1*x, [C1]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(2*C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1*2, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(y*C1*x, [C1,y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(x*y*C1, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(y*x*C1, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(C1*x*y, [C1,y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(x*C1*y, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(C1*y*(y + 1), [C1]), 'C', 1, 1) == C1*y*(y+1)
+    assert constant_renumber(constantsimp(y*C1*(y + 1), [C1]), 'C', 1, 1) == C1*y*(y+1)
+    assert constant_renumber(constantsimp(x*(y*C1), [C1]), 'C', 1, 1) == x*y*C1
+    assert constant_renumber(constantsimp(x*(C1*y), [C1]), 'C', 1, 1) == x*y*C1
+    assert constant_renumber(constantsimp(C1*(x*y), [C1,y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp((x*y)*C1, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp((y*x)*C1, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(y*(y + 1)*C1, [C1,y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp((C1*x)*y, [C1,y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(y*(x*C1), [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp((x*C1)*y, [C1,y]), 'C', 1, 1) == x*C1
     assert constant_renumber(
-        constantsimp(C1*x*y*x*y*2, x, 1), 'C', 1, 1) == C1*x**2
-    assert constant_renumber(constantsimp(C1*x*y*z, x, 1), 'C', 1, 1) == C1*x
+        constantsimp(C1*x*y*x*y*2, [C1,y]), 'C', 1, 1) == C1*x**2
+    assert constant_renumber(constantsimp(C1*x*y*z, [C1,y,z]), 'C', 1, 1) == C1*x
     assert constant_renumber(
-        constantsimp(C1*x*y**2*sin(z), x, 1), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(C1*C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*C2, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2*C2, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1*C1*C2, x, 2), 'C', 1, 2) == C1
+        constantsimp(C1*x*y**2*sin(z), [C1,y,z]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(C1*C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1*C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2*C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1*C1*C2, [C1,C2]), 'C', 1, 2) == C1
     assert constant_renumber(
-        constantsimp(C1*x*2**x, x, 1), 'C', 1, 1) == C1*x*2**x
-
+        constantsimp(C1*x*2**x, [C1]), 'C', 1, 1) == C1*x*2**x
 
 def test_constant_add():
-    assert constant_renumber(constantsimp(C1 + C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + 2, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(2 + C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + y, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + x, x, 1), 'C', 1, 1) == C1 + x
-    assert constant_renumber(constantsimp(C1 + x + y + x*y + 2, x, 1), 'C', 1, 1) == \
-        C1 + x*(y + 1)
-    assert constant_renumber(constantsimp(C1 + x + 2**x + y + 2, x, 1), 'C', 1, 1) == \
-        C1 + x + 2**x
-    assert constant_renumber(constantsimp(C1 + C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + C2, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2 + C1, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1 + C2 + C1, x, 2), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1 + C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1 + 2, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(2 + C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1 + y, [C1,y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1 + x, [C1]), 'C', 1, 1) == C1 + x
+    assert constant_renumber(constantsimp(C1 + C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1 + C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2 + C1, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1 + C2 + C1, [C1,C2]), 'C', 1, 2) == C1
 
 
 def test_constant_power_as_base():
-    assert constant_renumber(constantsimp(C1**C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(Pow(C1, C1), x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**C2, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2**C1, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2**C2, x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1**y, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**x, x, 1), 'C', 1, 1) == C1**x
-    assert constant_renumber(constantsimp(C1**2, x, 1), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1**C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(Pow(C1, C1), [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1**C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1**C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2**C1, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2**C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1**y, [C1,y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1**x, [C1]), 'C', 1, 1) == C1**x
+    assert constant_renumber(constantsimp(C1**2, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(
-        constantsimp(C1**(x*y), x, 1), 'C', 1, 1) == C1**(x*y)
+        constantsimp(C1**(x*y), [C1]), 'C', 1, 1) == C1**(x*y)
 
 
 def test_constant_power_as_exp():
-    assert constant_renumber(constantsimp(x**C1, x, 1), 'C', 1, 1) == x**C1
-    assert constant_renumber(constantsimp(y**C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x**y**C1, x, 1), 'C', 1, 1) == x**C1
+    assert constant_renumber(constantsimp(x**C1, [C1]), 'C', 1, 1) == x**C1
+    assert constant_renumber(constantsimp(y**C1, [C1,y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(x**y**C1, [C1,y]), 'C', 1, 1) == x**C1
     assert constant_renumber(
-        constantsimp((x**y)**C1, x, 1), 'C', 1, 1) == (x**y)**C1
+        constantsimp((x**y)**C1, [C1]), 'C', 1, 1) == (x**y)**C1
     assert constant_renumber(
-        constantsimp(x**(y**C1), x, 1), 'C', 1, 1) == x**C1
-    assert constant_renumber(constantsimp(x**C1**y, x, 1), 'C', 1, 1) == x**C1
+        constantsimp(x**(y**C1), [C1,y]), 'C', 1, 1) == x**C1
+    assert constant_renumber(constantsimp(x**C1**y, [C1,y]), 'C', 1, 1) == x**C1
     assert constant_renumber(
-        constantsimp(x**(C1**y), x, 1), 'C', 1, 1) == x**C1
+        constantsimp(x**(C1**y), [C1,y]), 'C', 1, 1) == x**C1
     assert constant_renumber(
-        constantsimp((x**C1)**y, x, 1), 'C', 1, 1) == (x**C1)**y
-    assert constant_renumber(constantsimp(2**C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(S(2)**C1, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(exp(C1), x, 1), 'C', 1, 1) == C1
+        constantsimp((x**C1)**y, [C1]), 'C', 1, 1) == (x**C1)**y
+    assert constant_renumber(constantsimp(2**C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(S(2)**C1, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(exp(C1), [C1]), 'C', 1, 1) == C1
     assert constant_renumber(
-        constantsimp(exp(C1 + x), x, 1), 'C', 1, 1) == C1*exp(x)
-    assert constant_renumber(constantsimp(Pow(2, C1), x, 1), 'C', 1, 1) == C1
+        constantsimp(exp(C1 + x), [C1]), 'C', 1, 1) == C1*exp(x)
+    assert constant_renumber(constantsimp(Pow(2, C1), [C1]), 'C', 1, 1) == C1
 
 
 def test_constant_function():
-    assert constant_renumber(constantsimp(sin(C1), x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1), x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1, C1), x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1, C2), x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C2, C1), x, 2), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C2, C2), x, 2), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(sin(C1), [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(f(C1), [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(f(C1, C1), [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(f(C1, C2), [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C2, C1), [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C2, C2), [C1,C2]), 'C', 1, 2) == C1
     assert constant_renumber(
-        constantsimp(f(C1, x), x, 1), 'C', 1, 2) == f(C1, x)
-    assert constant_renumber(constantsimp(f(C1, y), x, 1), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(y, C1), x, 1), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C1, y, C2), x, 2), 'C', 1, 2) == C1
+        constantsimp(f(C1, x), [C1]), 'C', 1, 2) == f(C1, x)
+    assert constant_renumber(constantsimp(f(C1, y), [C1,y]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(y, C1), [C1,y]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C1, y, C2), [C1,C2,y]), 'C', 1, 2) == C1
 
 
-@XFAIL
 def test_constant_function_multiple():
     # The rules to not renumber in this case would be too complicated, and
     # dsolve is not likely to ever encounter anything remotely like this.
     assert constant_renumber(
-        constantsimp(f(C1, C1, x), x, 1), 'C', 1, 1) == f(C1, C1, x)
+        constantsimp(f(C1, C1, x), [C1]), 'C', 1, 1) == f(C1, C1, x)
 
 
 def test_constant_multiple():
-    assert constant_renumber(constantsimp(C1*2 + 2, x, 1), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x*2/C1, x, 1), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(C1**2*2 + 2, x, 1), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1*2 + 2, [C1]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(x*2/C1, [C1]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(C1**2*2 + 2, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(
-        constantsimp(sin(2*C1) + x + sqrt(2), x, 1), 'C', 1, 1) == C1 + x
-    assert constant_renumber(constantsimp(2*C1 + C2, x, 2), 'C', 1, 2) == C1
+        constantsimp(sin(2*C1) + x + sqrt(2), [C1]), 'C', 1, 1) == C1 + x
+    assert constant_renumber(constantsimp(2*C1 + C2, [C1,C2]), 'C', 1, 2) == C1
 
+def test_constant_repeated():
+    assert C1 + C1*x == constant_renumber( C1 + C1*x, 'C', 1, 3)
 
 def test_ode_solutions():
     # only a few examples here, the rest will be tested in the actual dsolve tests
-    assert constant_renumber(constantsimp(C1*exp(2*x) + exp(x)*(C2 + C3), x, 3), 'C', 1, 3) == \
+    assert constant_renumber(constantsimp(C1*exp(2*x) + exp(x)*(C2 + C3), [C1,C2,C3]), 'C', 1, 3) == \
         constant_renumber((C1*exp(x) + C2*exp(2*x)), 'C', 1, 2)
     assert constant_renumber(
-        constantsimp(Eq(f(x), I*C1*sinh(x/3) + C2*cosh(x/3)), x, 2),
+        constantsimp(Eq(f(x), I*C1*sinh(x/3) + C2*cosh(x/3)), [C1,C2]),
         'C', 1, 2) == constant_renumber(Eq(f(x), C1*sinh(x/3) + C2*cosh(x/3)), 'C', 1, 2)
-    assert constant_renumber(constantsimp(Eq(f(x), acos((-C1)/cos(x))), x, 1), 'C', 1, 1) == \
+    assert constant_renumber(constantsimp(Eq(f(x), acos((-C1)/cos(x))), [C1]), 'C', 1, 1) == \
         Eq(f(x), acos(C1/cos(x)))
     assert constant_renumber(
-        constantsimp(Eq(log(f(x)/C1) + 2*exp(x/f(x)), 0), x, 1),
+        constantsimp(Eq(log(f(x)/C1) + 2*exp(x/f(x)), 0), [C1]),
         'C', 1, 1) == Eq(log(C1*f(x)) + 2*exp(x/f(x)), 0)
     assert constant_renumber(constantsimp(Eq(log(x*sqrt(2)*sqrt(1/x)*sqrt(f(x))
-        /C1) + x**2/(2*f(x)**2), 0), x, 1), 'C', 1, 1) == \
-        Eq(log(C1*x*sqrt(1/x)*sqrt(f(x))) + x**2/(2*f(x)**2), 0)
+        /C1) + x**2/(2*f(x)**2), 0), [C1]), 'C', 1, 1) == \
+        Eq(log(C1*sqrt(x)*sqrt(f(x))) + x**2/(2*f(x)**2), 0)
     assert constant_renumber(constantsimp(Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(x/C1) -
-        cos(f(x)/x)*exp(-f(x)/x)/2, 0), x, 1), 'C', 1, 1) == \
+        cos(f(x)/x)*exp(-f(x)/x)/2, 0), [C1]), 'C', 1, 1) == \
         Eq(-exp(-f(x)/x)*sin(f(x)/x)/2 + log(C1*x) - cos(f(x)/x)*
            exp(-f(x)/x)/2, 0)
     u2 = Symbol('u2')
     _a = Symbol('_a')
     assert constant_renumber(constantsimp(Eq(-Integral(-1/(sqrt(1 - u2**2)*u2),
-        (u2, _a, x/f(x))) + log(f(x)/C1), 0), x, 1), 'C', 1, 1) == \
+        (u2, _a, x/f(x))) + log(f(x)/C1), 0), [C1]), 'C', 1, 1) == \
         Eq(-Integral(-1/(u2*sqrt(1 - u2**2)), (u2, _a, x/f(x))) +
         log(C1*f(x)), 0)
-    assert [constant_renumber(constantsimp(i, x, 1), 'C', 1, 1) for i in
-        [Eq(f(x), sqrt(-C1*x + x**2)), Eq(f(x), -sqrt(-C1*x + x**2))]] == \
+    assert [constantsimp(i, [C1]) for i in [Eq(f(x), sqrt(-C1*x + x**2)), Eq(f(x), -sqrt(-C1*x + x**2))]] == \
         [Eq(f(x), sqrt(x*(C1 + x))), Eq(f(x), -sqrt(x*(C1 + x)))]
+
+
+@XFAIL
+def test_nonlocal_simplification():
+    assert constantsimp(C1 + C2+x*C2, [C1,C2]) == C1 + C2*x
 
 
 def test_constant_Eq():
     # C1 on the rhs is well-tested, but the lhs is only tested here
-    assert constantsimp(Eq(C1, 3 + f(x)*x), x, 1) == Eq(C1, f(x)*x)
+    assert constantsimp(Eq(C1, 3 + f(x)*x), [C1]) == Eq(x*f(x),C1)
+    assert constantsimp(Eq(C1, 3 * f(x)*x), [C1]) == Eq(f(x)*x,C1)

--- a/sympy/solvers/tests/test_constantsimp.py
+++ b/sympy/solvers/tests/test_constantsimp.py
@@ -26,31 +26,31 @@ def test_constant_mul():
     assert constant_renumber(constantsimp(C1*x, [C1]), 'C', 1, 1) == x*C1
     assert constant_renumber(constantsimp(2*C1, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(C1*2, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(y*C1*x, [C1,y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(x*y*C1, [C1,y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(y*x*C1, [C1,y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(C1*x*y, [C1,y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(x*C1*y, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(y*C1*x, [C1, y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(x*y*C1, [C1, y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(y*x*C1, [C1, y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(C1*x*y, [C1, y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(x*C1*y, [C1, y]), 'C', 1, 1) == x*C1
     assert constant_renumber(constantsimp(C1*y*(y + 1), [C1]), 'C', 1, 1) == C1*y*(y+1)
     assert constant_renumber(constantsimp(y*C1*(y + 1), [C1]), 'C', 1, 1) == C1*y*(y+1)
     assert constant_renumber(constantsimp(x*(y*C1), [C1]), 'C', 1, 1) == x*y*C1
     assert constant_renumber(constantsimp(x*(C1*y), [C1]), 'C', 1, 1) == x*y*C1
-    assert constant_renumber(constantsimp(C1*(x*y), [C1,y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp((x*y)*C1, [C1,y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((y*x)*C1, [C1,y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp(y*(y + 1)*C1, [C1,y]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp((C1*x)*y, [C1,y]), 'C', 1, 1) == C1*x
-    assert constant_renumber(constantsimp(y*(x*C1), [C1,y]), 'C', 1, 1) == x*C1
-    assert constant_renumber(constantsimp((x*C1)*y, [C1,y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(C1*(x*y), [C1, y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp((x*y)*C1, [C1, y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp((y*x)*C1, [C1, y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp(y*(y + 1)*C1, [C1, y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp((C1*x)*y, [C1, y]), 'C', 1, 1) == C1*x
+    assert constant_renumber(constantsimp(y*(x*C1), [C1, y]), 'C', 1, 1) == x*C1
+    assert constant_renumber(constantsimp((x*C1)*y, [C1, y]), 'C', 1, 1) == x*C1
     assert constant_renumber(
-        constantsimp(C1*x*y*x*y*2, [C1,y]), 'C', 1, 1) == C1*x**2
-    assert constant_renumber(constantsimp(C1*x*y*z, [C1,y,z]), 'C', 1, 1) == C1*x
+        constantsimp(C1*x*y*x*y*2, [C1, y]), 'C', 1, 1) == C1*x**2
+    assert constant_renumber(constantsimp(C1*x*y*z, [C1, y, z]), 'C', 1, 1) == C1*x
     assert constant_renumber(
-        constantsimp(C1*x*y**2*sin(z), [C1,y,z]), 'C', 1, 1) == C1*x
+        constantsimp(C1*x*y**2*sin(z), [C1, y, z]), 'C', 1, 1) == C1*x
     assert constant_renumber(constantsimp(C1*C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1*C2, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2*C2, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1*C1*C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1*C2, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2*C2, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1*C1*C2, [C1, C2]), 'C', 1, 2) == C1
     assert constant_renumber(
         constantsimp(C1*x*2**x, [C1]), 'C', 1, 1) == C1*x*2**x
 
@@ -58,22 +58,22 @@ def test_constant_add():
     assert constant_renumber(constantsimp(C1 + C1, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(C1 + 2, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(2 + C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + y, [C1,y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1 + y, [C1, y]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(C1 + x, [C1]), 'C', 1, 1) == C1 + x
     assert constant_renumber(constantsimp(C1 + C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1 + C2, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2 + C1, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1 + C2 + C1, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1 + C2, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2 + C1, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1 + C2 + C1, [C1, C2]), 'C', 1, 2) == C1
 
 
 def test_constant_power_as_base():
     assert constant_renumber(constantsimp(C1**C1, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(Pow(C1, C1), [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(C1**C1, [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(C1**C2, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2**C1, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C2**C2, [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(C1**y, [C1,y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(C1**C2, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2**C1, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C2**C2, [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(C1**y, [C1, y]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(C1**x, [C1]), 'C', 1, 1) == C1**x
     assert constant_renumber(constantsimp(C1**2, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(
@@ -82,15 +82,15 @@ def test_constant_power_as_base():
 
 def test_constant_power_as_exp():
     assert constant_renumber(constantsimp(x**C1, [C1]), 'C', 1, 1) == x**C1
-    assert constant_renumber(constantsimp(y**C1, [C1,y]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(x**y**C1, [C1,y]), 'C', 1, 1) == x**C1
+    assert constant_renumber(constantsimp(y**C1, [C1, y]), 'C', 1, 1) == C1
+    assert constant_renumber(constantsimp(x**y**C1, [C1, y]), 'C', 1, 1) == x**C1
     assert constant_renumber(
         constantsimp((x**y)**C1, [C1]), 'C', 1, 1) == (x**y)**C1
     assert constant_renumber(
-        constantsimp(x**(y**C1), [C1,y]), 'C', 1, 1) == x**C1
-    assert constant_renumber(constantsimp(x**C1**y, [C1,y]), 'C', 1, 1) == x**C1
+        constantsimp(x**(y**C1), [C1, y]), 'C', 1, 1) == x**C1
+    assert constant_renumber(constantsimp(x**C1**y, [C1, y]), 'C', 1, 1) == x**C1
     assert constant_renumber(
-        constantsimp(x**(C1**y), [C1,y]), 'C', 1, 1) == x**C1
+        constantsimp(x**(C1**y), [C1, y]), 'C', 1, 1) == x**C1
     assert constant_renumber(
         constantsimp((x**C1)**y, [C1]), 'C', 1, 1) == (x**C1)**y
     assert constant_renumber(constantsimp(2**C1, [C1]), 'C', 1, 1) == C1
@@ -105,14 +105,14 @@ def test_constant_function():
     assert constant_renumber(constantsimp(sin(C1), [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(f(C1), [C1]), 'C', 1, 1) == C1
     assert constant_renumber(constantsimp(f(C1, C1), [C1]), 'C', 1, 1) == C1
-    assert constant_renumber(constantsimp(f(C1, C2), [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C2, C1), [C1,C2]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C2, C2), [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C1, C2), [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C2, C1), [C1, C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C2, C2), [C1, C2]), 'C', 1, 2) == C1
     assert constant_renumber(
         constantsimp(f(C1, x), [C1]), 'C', 1, 2) == f(C1, x)
-    assert constant_renumber(constantsimp(f(C1, y), [C1,y]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(y, C1), [C1,y]), 'C', 1, 2) == C1
-    assert constant_renumber(constantsimp(f(C1, y, C2), [C1,C2,y]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C1, y), [C1, y]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(y, C1), [C1, y]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(f(C1, y, C2), [C1, C2, y]), 'C', 1, 2) == C1
 
 
 def test_constant_function_multiple():
@@ -128,17 +128,17 @@ def test_constant_multiple():
     assert constant_renumber(constantsimp(C1**2*2 + 2, [C1]), 'C', 1, 1) == C1
     assert constant_renumber(
         constantsimp(sin(2*C1) + x + sqrt(2), [C1]), 'C', 1, 1) == C1 + x
-    assert constant_renumber(constantsimp(2*C1 + C2, [C1,C2]), 'C', 1, 2) == C1
+    assert constant_renumber(constantsimp(2*C1 + C2, [C1, C2]), 'C', 1, 2) == C1
 
 def test_constant_repeated():
     assert C1 + C1*x == constant_renumber( C1 + C1*x, 'C', 1, 3)
 
 def test_ode_solutions():
     # only a few examples here, the rest will be tested in the actual dsolve tests
-    assert constant_renumber(constantsimp(C1*exp(2*x) + exp(x)*(C2 + C3), [C1,C2,C3]), 'C', 1, 3) == \
+    assert constant_renumber(constantsimp(C1*exp(2*x) + exp(x)*(C2 + C3), [C1, C2, C3]), 'C', 1, 3) == \
         constant_renumber((C1*exp(x) + C2*exp(2*x)), 'C', 1, 2)
     assert constant_renumber(
-        constantsimp(Eq(f(x), I*C1*sinh(x/3) + C2*cosh(x/3)), [C1,C2]),
+        constantsimp(Eq(f(x), I*C1*sinh(x/3) + C2*cosh(x/3)), [C1, C2]),
         'C', 1, 2) == constant_renumber(Eq(f(x), C1*sinh(x/3) + C2*cosh(x/3)), 'C', 1, 2)
     assert constant_renumber(constantsimp(Eq(f(x), acos((-C1)/cos(x))), [C1]), 'C', 1, 1) == \
         Eq(f(x), acos(C1/cos(x)))
@@ -164,10 +164,10 @@ def test_ode_solutions():
 
 @XFAIL
 def test_nonlocal_simplification():
-    assert constantsimp(C1 + C2+x*C2, [C1,C2]) == C1 + C2*x
+    assert constantsimp(C1 + C2+x*C2, [C1, C2]) == C1 + C2*x
 
 
 def test_constant_Eq():
     # C1 on the rhs is well-tested, but the lhs is only tested here
-    assert constantsimp(Eq(C1, 3 + f(x)*x), [C1]) == Eq(x*f(x),C1)
-    assert constantsimp(Eq(C1, 3 * f(x)*x), [C1]) == Eq(f(x)*x,C1)
+    assert constantsimp(Eq(C1, 3 + f(x)*x), [C1]) == Eq(x*f(x), C1)
+    assert constantsimp(Eq(C1, 3 * f(x)*x), [C1]) == Eq(f(x)*x, C1)

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -328,7 +328,6 @@ def test_1st_exact1():
     assert checkodesol(eq1, sol1, order=1, solve_for_func=False)[0]
     # issue 5080 needs to be addressed to test these
     # assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
-    assert checkodesol(eq2, sol2b, order=1, solve_for_func=False)[0]
     assert checkodesol(eq3, sol3, order=1, solve_for_func=False)[0]
     assert checkodesol(eq4, sol4, order=1, solve_for_func=False)[0]
     assert checkodesol(eq5, sol5, order=1, solve_for_func=False)[0]
@@ -1818,33 +1817,33 @@ def test_2nd_power_series_ordinary():
     eq = f(x).diff(x, 2) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     assert dsolve(eq) == Eq(f(x),
-        C1*(x**3/S(6) + 1) + C2*x*(x**3/S(12) + 1) + O(x**6))
+        C2*(x**3/S(6) + 1) + C1*x*(x**3/S(12) + 1) + O(x**6))
     assert dsolve(eq, x0=-2) == Eq(f(x),
-        C1*((x + 2)**4/S(6) + (x + 2)**3/S(6) - (x + 2)**2 + 1)
-        + C2*(x + (x + 2)**4/S(12) - (x + 2)**3/3 + S(2))
+        C2*((x + 2)**4/S(6) + (x + 2)**3/S(6) - (x + 2)**2 + 1)
+        + C1*(x + (x + 2)**4/S(12) - (x + 2)**3/3 + S(2))
         + O(x**6))
     assert dsolve(eq, n=2) == Eq(f(x), C2*x + C1 + O(x**2))
 
     eq = (1 + x**2)*(f(x).diff(x, 2)) + 2*x*(f(x).diff(x)) -2*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C1*(-x**4/S(3) + x**2 + 1) + C2*x
+    assert dsolve(eq) == Eq(f(x), C2*(-x**4/S(3) + x**2 + 1) + C1*x
         + O(x**6))
 
     eq = f(x).diff(x, 2) + x*(f(x).diff(x)) + f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C1*(
-        x**4/S(8) - x**2/S(2) + 1) + C2*x*(-x**2/S(3) + 1) + O(x**6))
+    assert dsolve(eq) == Eq(f(x), C2*(
+        x**4/S(8) - x**2/S(2) + 1) + C1*x*(-x**2/S(3) + 1) + O(x**6))
 
     eq = f(x).diff(x, 2) + f(x).diff(x) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C1*(
-        -x**4/S(24) + x**3/S(6) + 1) + C2*x*(x**3/S(24) + x**2/S(6) - x/S(2)
+    assert dsolve(eq) == Eq(f(x), C2*(
+        -x**4/S(24) + x**3/S(6) + 1) + C1*x*(x**3/S(24) + x**2/S(6) - x/S(2)
         + 1) + O(x**6))
 
     eq = f(x).diff(x, 2) + x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq, n=7) == Eq(f(x), C1*(
-        x**6/S(180) - x**3/S(6) + 1) + C2*x*(-x**3/S(12) + 1) + O(x**7))
+    assert dsolve(eq, n=7) == Eq(f(x), C2*(
+        x**6/S(180) - x**3/S(6) + 1) + C1*x*(-x**3/S(12) + 1) + O(x**7))
 
 
 def test_2nd_power_series_regular():

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -314,18 +314,14 @@ def test_1st_exact1():
     # Type: Exact differential equation, p(x,f) + q(x,f)*f' == 0,
     # where dp/df == dq/dx
     eq1 = sin(x)*cos(f(x)) + cos(x)*sin(f(x))*f(x).diff(x)
-    eq2 = (2*x*f(x) + 1)/f(x) + (f(x) - x)/f(x)**2*f(x).diff(x)
     eq3 = 2*x + f(x)*cos(x) + (2*f(x) + sin(x) - sin(f(x)))*f(x).diff(x)
     eq4 = cos(f(x)) - (x*sin(f(x)) - f(x)**2)*f(x).diff(x)
     eq5 = 2*x*f(x) + (x**2 + f(x)**2)*f(x).diff(x)
     sol1 = [Eq(f(x), -acos(C1/cos(x)) + 2*pi), Eq(f(x), acos(C1/cos(x)))]
-    sol2 = Eq(f(x), C1*exp(-x**2 + LambertW(C2*x*exp(x**2))))
-    sol2b = Eq(log(f(x)) + x/f(x) + x**2, C1)
     sol3 = Eq(f(x)*sin(x) + cos(f(x)) + x**2 + f(x)**2, C1)
     sol4 = Eq(x*cos(f(x)) + f(x)**3/3, C1)
     sol5 = Eq(x**2*f(x) + f(x)**3/3, C1)
     assert dsolve(eq1, f(x), hint='1st_exact') == sol1
-    assert dsolve(eq2, f(x), hint='1st_exact') == sol2
     assert dsolve(eq3, f(x), hint='1st_exact') == sol3
     assert dsolve(eq4, hint='1st_exact') == sol4
     assert dsolve(eq5, hint='1st_exact', simplify=False) == sol5
@@ -363,6 +359,18 @@ def test_1st_exact2():
         (x*(-27*f(x)/x + 27*sqrt(1 + f(x)**2/x**2))))
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
+@XFAIL
+def test_1st_exact3():
+    """
+    constantsimp() rewrites exp(C1), introducing an inconsistency
+        with the second appearance of C1.
+    """
+    eq2 = (2*x*f(x) + 1)/f(x) + (f(x) - x)/f(x)**2*f(x).diff(x)
+    sol2 = Eq(f(x), exp(C1-x**2 + LambertW(C1*x*exp(x**2))))
+    sol2b = Eq(log(f(x)) + x/f(x) + x**2, C1)
+    assert dsolve(eq2, f(x), hint='1st_exact') == sol2
+    assert checkodesol(eq2, sol2, order=1, solve_for_func=False)[0]
+    assert checkodesol(eq2, sol2b, order=1, solve_for_func=False)[0]
 
 def test_separable1():
     # test_separable1-5 are from Ordinary Differential Equations, Tenenbaum and
@@ -515,17 +523,13 @@ def test_1st_homogeneous_coeff_ode():
     # Type: First order homogeneous, y'=f(y/x)
     eq1 = f(x)/x*cos(f(x)/x) - (x/f(x)*sin(f(x)/x) + cos(f(x)/x))*f(x).diff(x)
     eq2 = x*f(x).diff(x) - f(x) - x*sin(f(x)/x)
-    eq3 = f(x) + (x*log(f(x)/x) - 2*x)*diff(f(x), x)
     eq4 = 2*f(x)*exp(x/f(x)) + f(x)*f(x).diff(x) - 2*x*exp(x/f(x))*f(x).diff(x)
-    eq5 = 2*x**2*f(x) + f(x)**3 + (x*f(x)**2 - 2*x**3)*f(x).diff(x)
     eq6 = x*exp(f(x)/x) - f(x)*sin(f(x)/x) + x*sin(f(x)/x)*f(x).diff(x)
     eq7 = (x + sqrt(f(x)**2 - x*f(x)))*f(x).diff(x) - f(x)
     eq8 = x + f(x) - (x - f(x))*f(x).diff(x)
     sol1 = Eq(log(x), C1 - log(f(x)*sin(f(x)/x)/x))
     sol2 = Eq(log(x), log(C1) + log(cos(f(x)/x) - 1)/2 - log(cos(f(x)/x) + 1)/2)
-    sol3 = Eq(f(x), C1*LambertW(C2*x))  # Eq(f(x), x*exp(-LambertW(C1*x) + 1))
     sol4 = Eq(log(f(x)), C1 - 2*exp(x/f(x)))
-    sol5 = Eq(f(x), C1*exp(LambertW(C2*x**4)/2)/x)
     sol6 = Eq(log(x),
         C1 + exp(-f(x)/x)*sin(f(x)/x)/2 + exp(-f(x)/x)*cos(f(x)/x)/2)
     sol7 = Eq(log(f(x)), C1 - 2*sqrt(-x/f(x) + 1))
@@ -536,15 +540,25 @@ def test_1st_homogeneous_coeff_ode():
     # but it runs too slow
     assert dsolve(eq2, hint='1st_homogeneous_coeff_subs_dep_div_indep',
             simplify=False) == sol2
-    assert dsolve(eq3, hint='1st_homogeneous_coeff_best') == sol3
     assert dsolve(eq4, hint='1st_homogeneous_coeff_best') == sol4
-    assert dsolve(eq5, hint='1st_homogeneous_coeff_best') == sol5
     assert dsolve(eq6, hint='1st_homogeneous_coeff_subs_dep_div_indep') == \
         sol6
     assert dsolve(eq7, hint='1st_homogeneous_coeff_best') == sol7
     assert dsolve(eq8, hint='1st_homogeneous_coeff_best') == sol8
     # checks are below
 
+@XFAIL
+def test_1st_homogeneous_coeff_ode_FAIL():
+    """
+    constantsimp() incorrectly rewrites
+    """
+    eq3 = f(x) + (x*log(f(x)/x) - 2*x)*diff(f(x), x)
+    sol3 = Eq(f(x), C1*LambertW(C2*x))  # Eq(f(x), x*exp(-LambertW(C1*x) + 1))
+    assert dsolve(eq3, hint='1st_homogeneous_coeff_best') == sol3
+
+    eq5 = 2*x**2*f(x) + f(x)**3 + (x*f(x)**2 - 2*x**3)*f(x).diff(x)
+    sol5 = Eq(f(x), C1*exp(LambertW(C2*x**4)/2)/x)
+    assert dsolve(eq5, hint='1st_homogeneous_coeff_best') == sol5
 
 @slow
 def test_1st_homogeneous_coeff_ode_check134568():
@@ -1007,7 +1021,6 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     sol2 = Eq(f(x), -1 - x + (C1 + C2*x - x**2/8)*exp(-x) + C3*exp(x/3))
     sol3 = Eq(f(x), 2 + C1*exp(-x) + C2*exp(-2*x))
     sol4 = Eq(f(x), 2*exp(x) + C1*exp(-x) + C2*exp(-2*x))
-    sol5 = Eq(f(x), C1*exp(-x) + C2*exp(-2*x) + (S(1)/10 - 3*I/10)*exp(I*x))
     sol6 = Eq(f(x), -3*cos(x)/10 + sin(x)/10 + C1*exp(-x) + C2*exp(-2*x))
     sol7 = Eq(f(x), cos(x)/10 + 3*sin(x)/10 + C1*exp(-x) + C2*exp(-2*x))
     sol8 = Eq(f(x),
@@ -1039,7 +1052,6 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     sol2s = constant_renumber(sol2, 'C', 1, 3)
     sol3s = constant_renumber(sol3, 'C', 1, 2)
     sol4s = constant_renumber(sol4, 'C', 1, 2)
-    sol5s = constant_renumber(sol5, 'C', 1, 2)
     sol6s = constant_renumber(sol6, 'C', 1, 2)
     sol7s = constant_renumber(sol7, 'C', 1, 2)
     sol8s = constant_renumber(sol8, 'C', 1, 2)
@@ -1066,7 +1078,8 @@ def test_nth_linear_constant_coeff_undetermined_coefficients():
     assert dsolve(eq2, hint=hint) in (sol2, sol2s)
     assert dsolve(eq3, hint=hint) in (sol3, sol3s)
     assert dsolve(eq4, hint=hint) in (sol4, sol4s)
-    assert dsolve(eq5, hint=hint) in (sol5, sol5s)
+    sol5 = dsolve(eq5, hint=hint)
+    assert 0 == eq5.subs(sol5.lhs, sol5.rhs).doit()
     assert dsolve(eq6, hint=hint) in (sol6, sol6s)
     assert dsolve(eq7, hint=hint) in (sol7, sol7s)
     assert dsolve(eq8, hint=hint) in (sol8, sol8s)
@@ -1319,15 +1332,15 @@ def test_issue_5770():
     w = Function('w')
     sol = dsolve(w(t).diff(t, 6) - k**6*w(t), w(t))
     assert len([s for s in sol.atoms(Symbol) if s.name.startswith('C')]) == 6
-    assert constantsimp((C1*cos(x) + C2*cos(x))*exp(x), x, 2) == \
+    assert constantsimp((C1*cos(x) + C2*cos(x))*exp(x), set([C1, C2])) == \
         C1*cos(x)*exp(x)
-    assert constantsimp(C1*cos(x) + C2*cos(x) + C3*sin(x), x, 2) == \
+    assert constantsimp(C1*cos(x) + C2*cos(x) + C3*sin(x), set([C1, C2, C3])) == \
         C1*cos(x) + C3*sin(x)
-    assert constantsimp(exp(C1 + x), x, 1) == C1*exp(x)
-    assert constantsimp(2**(C1 + x), x, 1) == C1*2**x
-    assert constantsimp(2**(C1 + x), x, 1) == C1*2**x
-    assert constantsimp(x + C1 + y, x, 1) == C1 + x
-    assert constantsimp(x + C1 + Integral(x, (x, 1, 2)), x, 1) == C1 + x
+    assert constantsimp(exp(C1 + x), set([C1])) == C1*exp(x)
+    #assert constantsimp(2**(C1 + x), x, 1) == C1*2**x
+    #assert constantsimp(2**(C1 + x), x, 1) == C1*2**x
+    assert constantsimp(x + C1 + y, set([C1, y])) == C1 + x
+    assert constantsimp(x + C1 + Integral(x, (x, 1, 2)), set([C1])) == C1 + x
 
 
 def test_issue_5112_5430():
@@ -1377,9 +1390,11 @@ def test_nth_order_linear_euler_eq_homogeneous():
 
     eq = Eq(-125*f(x) + 61*diff(f(x), x)*x - 12*x**2*diff(f(x), x, x) + x**3*diff(f(x), x, x, x), 0)
     sol = x**5*(C1 + C2*log(x) + C3*log(x)**2)
-    sols = constant_renumber(sol, 'C', 1, 4)
+    sols = [ sol ]
+    sols += [ constant_renumber(sol, 'C', 1, 4) ]
+    sols += [ sols[-1].expand() ]
     assert our_hint in classify_ode(eq)
-    assert dsolve(eq, f(x), hint=our_hint).rhs in (sol, sols)
+    assert dsolve(eq, f(x), hint=our_hint).rhs in sols
     assert checkodesol(eq, sol, order=2, solve_for_func=False)[0]
 
     eq = t**2*diff(y(t), t, 2) + t*diff(y(t), t) - 9*y(t)
@@ -1435,8 +1450,9 @@ def test_exact_enhancement():
     df = Derivative(f, x)
     eq = f/x**2 + ((f*x - 1)/x)*df
     sol = dsolve(eq, f)
-    rhs = [eq.rhs for eq in sol]
-    assert rhs == [(-sqrt(C1*x**2 + 1) + 1)/x, (sqrt(C1*x**2 + 1) + 1)/x]
+    actual_sol = [ Eq(f,(-sqrt(C1*x**2 + 1)+1)/x), Eq(f,(sqrt(C1*x**2 + 1)+1)/x)]
+    errstr = str(eq)+' : '+str(sol)+' == '+str(actual_sol)
+    assert sol == actual_sol, errstr
 
     eq = (x*f - 1) + df*(x**2 - x*f)
     rhs = [sol.rhs for sol in dsolve(eq, f)]
@@ -1454,26 +1470,28 @@ def test_exact_enhancement():
 
 def test_separable_reduced():
     f = Function('f')
+    x = Symbol('x') # BUG: if x is real, a more complex solution is returned!
     df = f(x).diff(x)
     eq = (x / f(x))*df  + tan(x**2*f(x) / (x**2*f(x) - 1))
-    assert classify_ode(eq) == ('1st_linear', 'separable_reduced', 'lie_group',
-        '1st_linear_Integral', 'separable_reduced_Integral')
+    assert classify_ode(eq) == ('separable_reduced', 'lie_group',
+        'separable_reduced_Integral')
 
     eq = x* df  + f(x)* (1 / (x**2*f(x) - 1))
-    assert classify_ode(eq) == ('1st_linear', 'separable_reduced', 'lie_group',
-        '1st_linear_Integral', 'separable_reduced_Integral')
+    assert classify_ode(eq) == ('separable_reduced', 'lie_group',
+        'separable_reduced_Integral')
     sol = dsolve(eq, hint = 'separable_reduced', simplify=False)
     assert sol.lhs ==  log(x**2*f(x))/3 + log(x**2*f(x) - S(3)/2)/6
     assert sol.rhs == C1 + log(x)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
-    eq = df + (f(x) / (x**4*f(x) - x))
-    assert classify_ode(eq) == ('1st_linear', 'separable_reduced', 'lie_group',
-        '1st_linear_Integral', 'separable_reduced_Integral')
+    # this is the equation that does not like x to be real
+    eq = f(x).diff(x) + (f(x) / (x**4*f(x) - x))
+    assert classify_ode(eq) == ('separable_reduced', 'lie_group',
+        'separable_reduced_Integral')
     # generates PolynomialError in solve attempt
     sol = dsolve(eq, hint = 'separable_reduced')
-    assert sol.lhs == log(x**3*f(x))/4 + log(x**3*f(x) - S(4)/3)/12
-    assert sol.rhs == C1 + log(x)
+    assert sol.lhs - sol.rhs == \
+        log(x**3*f(x))/4 + log(x**3*f(x) - S(4)/3)/12 - C1 - log(x)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*df + f(x)*(x**2*f(x))
@@ -1564,10 +1582,13 @@ def test_issue_6989():
             (x**2/2, Eq(k**3, 0)),
             ((-k**2*x - k)*exp(-k*x)/k**3, True)
         ))
-    assert dsolve(-f(x).diff(x) + x*exp(-k*x), f(x)) == \
-        Eq(f(x), Piecewise((C1 + x**2/2, Eq(k**3, 0)),
+    eq = -f(x).diff(x) + x*exp(-k*x)
+    sol = dsolve(eq, f(x))
+    actual_sol = Eq(f(x), Piecewise((C1 + x**2/2, Eq(k**3, 0)),
             (C1 - x*exp(-k*x)/k - exp(-k*x)/k**2, True)
         ))
+    errstr = str(eq) + ' : ' + str(sol) + ' == ' + str(actual_sol)
+    assert sol == actual_sol, errstr
 
 
 def test_heuristic1():
@@ -1723,22 +1744,22 @@ def test_kamke():
 
 
 def test_series():
-    C0 = Symbol("C0")
+    C1 = Symbol("C1")
     eq = f(x).diff(x) - f(x)
     assert dsolve(eq, hint='1st_power_series') == Eq(f(x),
-        C0 + C0*x + C0*x**2/S(2) + C0*x**3/S(6) + C0*x**4/S(24) +
-        C0*x**5/S(120) + O(x**6))
+        C1 + C1*x + C1*x**2/S(2) + C1*x**3/S(6) + C1*x**4/S(24) +
+        C1*x**5/S(120) + O(x**6))
     eq = f(x).diff(x) - x*f(x)
     assert dsolve(eq, hint='1st_power_series') == Eq(f(x),
-        C0*x**4/S(8) + C0*x**2/S(2) + C0 + O(x**6))
+        C1*x**4/S(8) + C1*x**2/S(2) + C1 + O(x**6))
     eq = f(x).diff(x) - sin(x*f(x))
-    assert dsolve(eq, hint='1st_power_series', ics={f(2): 2}, n=3) == Eq(
-        f(x), (x - 2)**2*(2*cos(4) + 2*sin(4)*cos(4))/S(2) + (x - 2)*sin(4) +
-        2 + O(x**3))
+    sol = Eq(f(x), (x - 2)**2*(1+ sin(4))*cos(4) + (x - 2)*sin(4) + 2 + O(x**3))
+    assert dsolve(eq, hint='1st_power_series', ics={f(2): 2}, n=3) == sol
 
 
 def test_lie_group():
     C1 = Symbol("C1")
+    x = Symbol("x") # assuming x is real generates an error!
     a, b, c = symbols("a b c")
     eq = f(x).diff(x)**2
     sol = dsolve(eq, f(x), hint='lie_group')
@@ -1755,7 +1776,9 @@ def test_lie_group():
 
     eq = f(x).diff(x) + 2*x*f(x) - x*exp(-x**2)
     sol = dsolve(eq, f(x), hint='lie_group')
-    assert sol == Eq(f(x), (C1 + x**2/S(2))*exp(-x**2))
+    actual_sol = Eq(f(x), (C1 + x**2/S(2))*exp(-x**2))
+    errstr = str(eq)+' : '+str(sol)+' == '+str(actual_sol)
+    assert sol == actual_sol, errstr
     assert checkodesol(eq, sol)[0]
 
     eq = (1 + 2*x)*(f(x).diff(x)) + 2 - 4*exp(-f(x))
@@ -1775,10 +1798,13 @@ def test_lie_group():
 
 def test_user_infinitesimals():
     C2 = Symbol("C2")
+    x = Symbol("x") # assuming x is real generates an error
     eq = x*(f(x).diff(x)) + 1 - f(x)**2
     sol = dsolve(eq, hint='lie_group', xi=sqrt(f(x) - 1)/sqrt(f(x) + 1),
         eta=0)
-    assert sol == Eq(f(x), (C2 + x**2)/(C1 - x**2))
+    actual_sol = Eq(f(x), (C1 + x**2)/(C1 - x**2))
+    errstr = str(eq)+' : '+str(sol)+' == '+str(actual_sol)
+    assert sol == actual_sol, errstr
     raises(ValueError, lambda: dsolve(eq, hint='lie_group', xi=0, eta=f(x)))
 
 @XFAIL
@@ -1788,65 +1814,65 @@ def test_issue_7081():
 
 
 def test_2nd_power_series_ordinary():
-    C0, C1 = symbols("C0 C1")
+    C1, C2 = symbols("C1 C2")
     eq = f(x).diff(x, 2) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
     assert dsolve(eq) == Eq(f(x),
-        C0*(x**3/S(6) + 1) + C1*x*(x**3/S(12) + 1) + O(x**6))
+        C1*(x**3/S(6) + 1) + C2*x*(x**3/S(12) + 1) + O(x**6))
     assert dsolve(eq, x0=-2) == Eq(f(x),
-        C0*((x + 2)**4/S(6) + (x + 2)**3/S(6) - (x + 2)**2 + 1)
-        + C1*(x + (x + 2)**4/S(12) - (x + 2)**3/3 + S(2))
+        C1*((x + 2)**4/S(6) + (x + 2)**3/S(6) - (x + 2)**2 + 1)
+        + C2*(x + (x + 2)**4/S(12) - (x + 2)**3/3 + S(2))
         + O(x**6))
-    assert dsolve(eq, n=2) == Eq(f(x), C1*x + C0 + O(x**2))
+    assert dsolve(eq, n=2) == Eq(f(x), C2*x + C1 + O(x**2))
 
     eq = (1 + x**2)*(f(x).diff(x, 2)) + 2*x*(f(x).diff(x)) -2*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C0*(-x**4/S(3) + x**2 + 1) + C1*x
+    assert dsolve(eq) == Eq(f(x), C1*(-x**4/S(3) + x**2 + 1) + C2*x
         + O(x**6))
 
     eq = f(x).diff(x, 2) + x*(f(x).diff(x)) + f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C0*(
-        x**4/S(8) - x**2/S(2) + 1) + C1*x*(-x**2/S(3) + 1) + O(x**6))
+    assert dsolve(eq) == Eq(f(x), C1*(
+        x**4/S(8) - x**2/S(2) + 1) + C2*x*(-x**2/S(3) + 1) + O(x**6))
 
     eq = f(x).diff(x, 2) + f(x).diff(x) - x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq) == Eq(f(x), C0*(
-        -x**4/S(24) + x**3/S(6) + 1) + C1*x*(x**3/S(24) + x**2/S(6) - x/S(2)
+    assert dsolve(eq) == Eq(f(x), C1*(
+        -x**4/S(24) + x**3/S(6) + 1) + C2*x*(x**3/S(24) + x**2/S(6) - x/S(2)
         + 1) + O(x**6))
 
     eq = f(x).diff(x, 2) + x*f(x)
     assert classify_ode(eq) == ('2nd_power_series_ordinary',)
-    assert dsolve(eq, n=7) == Eq(f(x), C0*(
-        x**6/S(180) - x**3/S(6) + 1) + C1*x*(-x**3/S(12) + 1) + O(x**7))
+    assert dsolve(eq, n=7) == Eq(f(x), C1*(
+        x**6/S(180) - x**3/S(6) + 1) + C2*x*(-x**3/S(12) + 1) + O(x**7))
 
 
 def test_2nd_power_series_regular():
-    C0, C1 = symbols("C0 C1")
+    C1, C2 = symbols("C1 C2")
     eq = x**2*(f(x).diff(x, 2)) - 3*x*(f(x).diff(x)) + (4*x + 4)*f(x)
-    assert dsolve(eq) == Eq(f(x), C0*x**2*(-16*x**3/S(9) +
+    assert dsolve(eq) == Eq(f(x), C1*x**2*(-16*x**3/S(9) +
         4*x**2 - 4*x + 1) + O(x**6))
 
     eq = 4*x**2*(f(x).diff(x, 2)) -8*x**2*(f(x).diff(x)) + (4*x**2 +
         1)*f(x)
-    assert dsolve(eq) == Eq(f(x), C0*sqrt(x)*(
+    assert dsolve(eq) == Eq(f(x), C1*sqrt(x)*(
         x**4/S(24) + x**3/S(6) + x**2/S(2) + x + 1) + O(x**6))
 
     eq = x**2*(f(x).diff(x, 2)) - x**2*(f(x).diff(x)) + (
         x**2 - 2)*f(x)
     assert dsolve(eq) == Eq(f(x), C1*(-x**6/S(720) - 3*x**5/S(80) - x**4/S(8) +
-        x**2/S(2) + x/S(2) + 1)/x + C0*x**2*(-x**3/S(60) + x**2/S(20) + x/S(2) + 1)
+        x**2/S(2) + x/S(2) + 1)/x + C2*x**2*(-x**3/S(60) + x**2/S(20) + x/S(2) + 1)
         + O(x**6))
 
     eq = x**2*(f(x).diff(x, 2)) + x*(f(x).diff(x)) + (x**2 - 1/S(4))*f(x)
     assert dsolve(eq) == Eq(f(x), C1*(x**4/S(24) - x**2/S(2) + 1)/sqrt(x) +
-        C0*sqrt(x)*(x**4/S(120) - x**2/S(6) + 1) + O(x**6))
+        C2*sqrt(x)*(x**4/S(120) - x**2/S(6) + 1) + O(x**6))
 
     eq = x*(f(x).diff(x, 2)) - f(x).diff(x) + 4*x**3*f(x)
-    assert dsolve(eq) == Eq(f(x), C1*(-x**4/S(2) + 1) + C0*x**2 + O(x**6))
-
+    assert dsolve(eq) == Eq(f(x), C2*(-x**4/S(2) + 1) + C1*x**2 + O(x**6))
 
 def test_issue_7093():
+    x = Symbol("x") # assuming x is real leads to an error
     sol = Eq(f(x), C1 - 2*x*sqrt(x**3)/5)
     eq = Derivative(f(x), x)**2 - x**3
     assert dsolve(eq) == sol and checkodesol(eq, sol) == (True, 0)

--- a/sympy/solvers/tests/test_pde.py
+++ b/sympy/solvers/tests/test_pde.py
@@ -194,7 +194,7 @@ def test_pdsolve_variable_coeff():
 
     eq = y*x**2*u + y*u.diff(x) + u.diff(y)
     sol = pdsolve(eq, hint='1st_linear_variable_coeff')
-    assert sol == Eq(u, F(-x + y**2/2)*exp(-x**3/3))
+    assert sol == Eq(u, F(-2*x + y**2)*exp(-x**3/3))
     assert checkpdesol(eq, sol)[0]
 
     eq = exp(x)**2*(u.diff(x)) + y

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -527,10 +527,10 @@ def subsets(seq, k=None, repetition=False):
                 yield i
 
 
-def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
+def numbered_symbols(prefix='x', cls=None, start=0, exclude=[], *args, **assumptions):
     """
     Generate an infinite stream of Symbols consisting of a prefix and
-    increasing subscripts.
+    increasing subscripts provided that they do not occur in `exclude`.
 
     Parameters
     ==========
@@ -551,7 +551,7 @@ def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
     sym : Symbol
         The subscripted symbols.
     """
-
+    exclude = set(exclude or [])
     if cls is None:
         # We can't just make the default cls=C.Symbol because it isn't
         # imported yet.
@@ -559,7 +559,9 @@ def numbered_symbols(prefix='x', cls=None, start=0, *args, **assumptions):
 
     while True:
         name = '%s%s' % (prefix, start)
-        yield cls(name, *args, **assumptions)
+        s = cls(name, *args, **assumptions)
+        if s not in exclude:
+            yield s
         start += 1
 
 

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -168,6 +168,8 @@ def test_cartes():
 def test_numbered_symbols():
     s = numbered_symbols(cls=Dummy)
     assert isinstance(next(s), Dummy)
+    assert next(numbered_symbols('C', start=1, exclude=[Symbol('C1')])) == \
+        Symbol('C2')
 
 
 def test_sift():


### PR DESCRIPTION
Replaces #2988 
- Fixes constant-collision errors in dsolve for good
- revise tests for ode, cse, pde, and constantsimp
- Constant numbering starts with C1, unless specified otherwise
- Specific checks for common subexpression and linear simplifications
- lie_group method errors appear because of x = Symbol('x',real=True)
  We work around with x = Symbol('x'), which raises no errors.
- Extends cse (common subexpression elimination) to Piecewise,
  and does not rewrite Order terms
-  Poorly defined behavior of collect is causing problems internally
  which extra code is added to handle.
- Stop classifying some nonlinear ODEs as linear.
- allows `numered_symbols` to exclude some symbols
- `terms_gcd` handles Eq uniformly now
