### PR TITLE
Expansions for harmonic numbers at general rational arguments n + p/q

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -554,6 +554,8 @@ class harmonic(Function):
 
     @classmethod
     def eval(cls, n, m=None):
+        if m is S.One:
+            return cls(n)
         if m is None:
             m = S.One
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -15,6 +15,7 @@ from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
 from sympy.core.evaluate import global_evaluate
 from sympy.core.cache import cacheit
 from sympy.core.numbers import pi
+from sympy.core.relational import LessThan, StrictGreaterThan
 from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.trigonometric import sin, cos, cot
@@ -532,8 +533,12 @@ class harmonic(Function):
     >>> limit(harmonic(n, 3), n, oo)
     -polygamma(2, 1)/2
 
-    >>> limit(harmonic(m, n), m, oo)
-    zeta(n)
+    However we can not compute the general relation yet:
+
+    >>> limit(harmonic(n, m), n, oo)
+    harmonic(oo, m)
+
+    which equals ``zeta(m)`` for ``m > 1``.
 
     References
     ==========
@@ -562,13 +567,16 @@ class harmonic(Function):
         if m.is_zero:
             return n
 
-        if n is S.Infinity:
+        if n is S.Infinity and m.is_Number:
+            # TODO: Fix for symbolic values of m
             if m.is_negative:
                 return S.NaN
-            elif m <= S.One:
+            elif LessThan(m, S.One):
                 return S.Infinity
-            else:
+            elif StrictGreaterThan(m, S.One):
                 return C.zeta(m)
+            else:
+                return cls
 
         if n.is_Integer and n.is_nonnegative and m.is_Integer:
             if n == 0:

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -464,6 +464,34 @@ class harmonic(Function):
     >>> harmonic(n).rewrite(Sum)
     Sum(1/_k, (_k, 1, n))
 
+    We can evaluate harmonic numbers for all integral and positive
+    rational arguments:
+
+    >>> from sympy import S, expand_func, simplify
+    >>> harmonic(8)
+    761/280
+    >>> harmonic(11)
+    83711/27720
+
+    >>> H = harmonic(1/S(3))
+    >>> H
+    harmonic(1/3)
+    >>> He = expand_func(H)
+    >>> He
+    -log(6) - sqrt(3)*pi/6 + 2*Sum(log(sin(_k*pi/3))*cos(2*_k*pi/3), (_k, 1, 1))
+                           + 3*Sum(1/(3*_k + 1), (_k, 0, 0))
+    >>> He.doit()
+    -log(6) - sqrt(3)*pi/6 - log(sqrt(3)/2) + 3
+    >>> H = harmonic(25/S(7))
+    >>> He = simplify(expand_func(H).doit())
+    >>> He
+    log(sin(pi/7)**(-2*cos(pi/7))*sin(2*pi/7)**(2*cos(16*pi/7))*cos(pi/14)**(-2*sin(pi/14))/14)
+    + pi*tan(pi/14)/2 + 30247/9900
+    >>> He.n(40)
+    1.983697455232980674869851942390639915940
+    >>> harmonic(25/S(7)).n(40)
+    1.983697455232980674869851942390639915940
+
     We can rewrite harmonic numbers in terms of polygamma functions:
 
     >>> from sympy import digamma, polygamma

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -14,6 +14,10 @@ from sympy.core import S, Symbol, Rational, oo, Integer, C, Add, Dummy
 from sympy.core.compatibility import as_int, SYMPY_INTS, xrange
 from sympy.core.evaluate import global_evaluate
 from sympy.core.cache import cacheit
+from sympy.core.numbers import pi
+from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.trigonometric import sin, cos, cot
 from sympy.functions.combinatorial.factorials import factorial
 
 from sympy.mpmath import bernfrac
@@ -571,6 +575,21 @@ class harmonic(Function):
                 elif off.is_Integer and off.is_negative:
                     result = [-S.One/(nnew + i) for i in xrange(0, off, -1)] + [harmonic(nnew)]
                     return Add(*result)
+
+            if n.is_Rational:
+                # Expansions for harmonic numbers at general rational arguments (u + p/q)
+                # Split n as u + p/q with p < q
+                p, q = n.as_numer_denom()
+                u = p // q
+                p = p - u * q
+                if u.is_nonnegative and p.is_positive and q.is_positive and p < q:
+                    k = Dummy("k")
+                    t1 = q * C.Sum(1 / (q * k + p), (k, 0, u))
+                    t2 = 2 * C.Sum(cos((2 * pi * p * k) / S(q)) *
+                                   log(sin((pi * k) / S(q))),
+                                   (k, 1, floor((q - 1) / S(2))))
+                    t3 = (pi / 2) * cot((pi * p) / q) + log(2 * q)
+                    return t1 + t2 - t3
 
         return self
 

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -556,11 +556,18 @@ class harmonic(Function):
     def eval(cls, n, m=None):
         if m is None:
             m = S.One
-        if n == oo:
-            if m is S.One:
+
+        if m.is_zero:
+            return n
+
+        if n is S.Infinity:
+            if m.is_negative:
+                return S.NaN
+            elif m <= S.One:
                 return S.Infinity
             else:
                 return C.zeta(m)
+
         if n.is_Integer and n.is_nonnegative and m.is_Integer:
             if n == 0:
                 return S.Zero

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -4,7 +4,7 @@ from sympy import (bernoulli, Symbol, symbols, Dummy, S, Sum, Rational,
                    oo, zoo, pi, I, simplify, expand_func, harmonic,
                    bell, fibonacci, lucas, euler, catalan, binomial, gamma,
                    sqrt, hyper, log, digamma, trigamma, polygamma, diff,
-                   EulerGamma, factorial, sin, cos, cot, cancel)
+                   EulerGamma, factorial, sin, cos, cot, cancel, zeta)
 
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -78,15 +78,35 @@ def test_bell():
 
 
 def test_harmonic():
+    n = Symbol("n")
+
+    assert harmonic(3, 1) == harmonic(3)
+
+    assert harmonic(n, 0) == n
+
+    assert harmonic(0, 1) == 0
     assert harmonic(1, 1) == 1
     assert harmonic(2, 1) == Rational(3, 2)
     assert harmonic(3, 1) == Rational(11, 6)
     assert harmonic(4, 1) == Rational(25, 12)
-    assert harmonic(3, 1) == harmonic(3)
-    assert harmonic(3, 5) == 1 + Rational(1, 2**5) + Rational(1, 3**5)
-    assert harmonic(10, 0) == 10
+    assert harmonic(0, 2) == 0
+    assert harmonic(1, 2) == 1
+    assert harmonic(2, 2) == Rational(5, 4)
+    assert harmonic(3, 2) == Rational(49, 36)
+    assert harmonic(4, 2) == Rational(205, 144)
+    assert harmonic(0, 3) == 0
+    assert harmonic(1, 3) == 1
+    assert harmonic(2, 3) == Rational(9, 8)
+    assert harmonic(3, 3) == Rational(251, 216)
+    assert harmonic(4, 3) == Rational(2035, 1728)
+
+    assert harmonic(oo, -1) == S.NaN
+    assert harmonic(oo, 0) == oo
+    assert harmonic(oo, S.Half) == oo
     assert harmonic(oo, 1) == oo
     assert harmonic(oo, 2) == (pi**2)/6
+    assert harmonic(oo, 3) == zeta(3)
+
 
 def test_harmonic_rational():
     ne = S(6)

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -80,9 +80,8 @@ def test_bell():
 def test_harmonic():
     n = Symbol("n")
 
-    assert harmonic(3, 1) == harmonic(3)
-
     assert harmonic(n, 0) == n
+    assert harmonic(n, 1) == harmonic(n)
 
     assert harmonic(0, 1) == 0
     assert harmonic(1, 1) == 1

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -88,25 +88,7 @@ def test_harmonic():
     assert harmonic(oo, 2) == (pi**2)/6
 
 
-def replace_dummy(expr, sym):
-    dum = expr.atoms(Dummy)
-    if not dum:
-        return expr
-    assert len(dum) == 1
-    return expr.xreplace({dum.pop(): sym})
-
-
-def test_harmonic_rewrite_sum():
-    n = Symbol("n")
-    m = Symbol("m")
-
-    _k = Dummy("k")
-    assert replace_dummy(harmonic(n).rewrite(Sum), _k) == Sum(1/_k, (_k, 1, n))
-    assert replace_dummy(harmonic(n, m).rewrite(Sum), _k) == Sum(_k**(-m), (_k, 1, n))
-
-
-@XFAIL
-def test_harmonic_rewrite_sum_fail():
+def test_harmonic_rewrite_polygamma():
     n = Symbol("n")
     m = Symbol("m")
 
@@ -122,9 +104,32 @@ def test_harmonic_rewrite_sum_fail():
 
     assert harmonic(n, m).rewrite("tractable") == harmonic(n, m).rewrite(polygamma)
 
+
+@XFAIL
+def test_harmonic_rewrite_sum_fail():
+    n = Symbol("n")
+    m = Symbol("m")
+
     _k = Dummy("k")
     assert harmonic(n).rewrite(Sum) == Sum(1/_k, (_k, 1, n))
     assert harmonic(n, m).rewrite(Sum) == Sum(_k**(-m), (_k, 1, n))
+
+
+def replace_dummy(expr, sym):
+    dum = expr.atoms(Dummy)
+    if not dum:
+        return expr
+    assert len(dum) == 1
+    return expr.xreplace({dum.pop(): sym})
+
+
+def test_harmonic_rewrite_sum():
+    n = Symbol("n")
+    m = Symbol("m")
+
+    _k = Dummy("k")
+    assert replace_dummy(harmonic(n).rewrite(Sum), _k) == Sum(1/_k, (_k, 1, n))
+    assert replace_dummy(harmonic(n, m).rewrite(Sum), _k) == Sum(_k**(-m), (_k, 1, n))
 
 
 def test_euler():

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -1,9 +1,10 @@
 import string
 
-from sympy import (bernoulli, Symbol, symbols, Dummy, Sum, harmonic, Rational, oo,
-    zoo, pi, I, bell, fibonacci, lucas, euler, catalan, binomial, gamma, sqrt,
-    hyper, log, digamma, trigamma, polygamma, diff, Expr, sympify, expand_func,
-    EulerGamma, factorial)
+from sympy import (bernoulli, Symbol, symbols, Dummy, S, Sum, Rational,
+                   oo, zoo, pi, I, simplify, expand_func, harmonic,
+                   bell, fibonacci, lucas, euler, catalan, binomial, gamma,
+                   sqrt, hyper, log, digamma, trigamma, polygamma, diff,
+                   EulerGamma, factorial, sin, cos, cot, cancel)
 
 from sympy.utilities.pytest import XFAIL, raises
 
@@ -86,6 +87,73 @@ def test_harmonic():
     assert harmonic(10, 0) == 10
     assert harmonic(oo, 1) == oo
     assert harmonic(oo, 2) == (pi**2)/6
+
+def test_harmonic_rational():
+    ne = S(6)
+    no = S(5)
+    pe = S(8)
+    po = S(9)
+    qe = S(10)
+    qo = S(13)
+
+    Heee = harmonic(ne + pe/qe)
+    Aeee = (-log(10) + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
+             + pi*(1/S(4) + sqrt(5)/4)/(2*sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 13944145/S(4720968))
+
+    Heeo = harmonic(ne + pe/qo)
+    Aeeo = (-log(26) + 2*log(sin(3*pi/13))*cos(4*pi/13) + 2*log(sin(2*pi/13))*cos(32*pi/13)
+             + 2*log(sin(5*pi/13))*cos(80*pi/13) - 2*log(sin(6*pi/13))*cos(5*pi/13)
+             - 2*log(sin(4*pi/13))*cos(pi/13) + pi*cot(5*pi/13)/2 - 2*log(sin(pi/13))*cos(3*pi/13)
+             + 2422020029/S(702257080))
+
+    Heoe = harmonic(ne + po/qe)
+    Aeoe = (-log(20) + 2*(1/S(4) + sqrt(5)/4)*log(-1/S(4) + sqrt(5)/4)
+             + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
+             + 2*(-sqrt(5)/4 + 1/S(4))*log(1/S(4) + sqrt(5)/4)
+             + 11818877030/S(4286604231) - pi*sqrt(sqrt(5)/8 + 5/S(8))/(-sqrt(5)/2 + 1/S(2)) )
+
+
+    Heoo = harmonic(ne + po/qo)
+    Aeoo = (-log(26) + 2*log(sin(3*pi/13))*cos(54*pi/13) + 2*log(sin(4*pi/13))*cos(6*pi/13)
+             + 2*log(sin(6*pi/13))*cos(108*pi/13) - 2*log(sin(5*pi/13))*cos(pi/13)
+             - 2*log(sin(pi/13))*cos(5*pi/13) + pi*cot(4*pi/13)/2
+             - 2*log(sin(2*pi/13))*cos(3*pi/13) + 11669332571/S(3628714320))
+
+    Hoee = harmonic(no + pe/qe)
+    Aoee = (-log(10) + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
+             + pi*(1/S(4) + sqrt(5)/4)/(2*sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 779405/S(277704))
+
+    Hoeo = harmonic(no + pe/qo)
+    Aoeo = (-log(26) + 2*log(sin(3*pi/13))*cos(4*pi/13) + 2*log(sin(2*pi/13))*cos(32*pi/13)
+             + 2*log(sin(5*pi/13))*cos(80*pi/13) - 2*log(sin(6*pi/13))*cos(5*pi/13)
+             - 2*log(sin(4*pi/13))*cos(pi/13) + pi*cot(5*pi/13)/2
+             - 2*log(sin(pi/13))*cos(3*pi/13) + 53857323/S(16331560))
+
+    Hooe = harmonic(no + po/qe)
+    Aooe = (-log(20) + 2*(1/S(4) + sqrt(5)/4)*log(-1/S(4) + sqrt(5)/4)
+             + 2*(-1/S(4) + sqrt(5)/4)*log(sqrt(-sqrt(5)/8 + 5/S(8)))
+             + 2*(-sqrt(5)/4 - 1/S(4))*log(sqrt(sqrt(5)/8 + 5/S(8)))
+             + 2*(-sqrt(5)/4 + 1/S(4))*log(1/S(4) + sqrt(5)/4)
+             + 486853480/S(186374097) - pi*sqrt(sqrt(5)/8 + 5/S(8))/(2*(-sqrt(5)/4 + 1/S(4))))
+
+    Hooo = harmonic(no + po/qo)
+    Aooo = (-log(26) + 2*log(sin(3*pi/13))*cos(54*pi/13) + 2*log(sin(4*pi/13))*cos(6*pi/13)
+             + 2*log(sin(6*pi/13))*cos(108*pi/13) - 2*log(sin(5*pi/13))*cos(pi/13)
+             - 2*log(sin(pi/13))*cos(5*pi/13) + pi*cot(4*pi/13)/2
+             - 2*log(sin(2*pi/13))*cos(3*pi/13) + 383693479/S(125128080))
+
+    H = [Heee, Heeo, Heoe, Heoo, Hoee, Hoeo, Hooe, Hooo]
+    A = [Aeee, Aeeo, Aeoe, Aeoo, Aoee, Aoeo, Aooe, Aooo]
+
+    for h, a in zip(H, A):
+        e = expand_func(h).doit()
+        assert cancel(e/a) == 1
+        assert h.n() == a.n()
 
 
 def test_harmonic_rewrite_polygamma():

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -191,6 +191,12 @@ def test_harmonic_rewrite_polygamma():
 
     assert harmonic(n, m).rewrite("tractable") == harmonic(n, m).rewrite(polygamma)
 
+@XFAIL
+def test_harmonic_limit_fail():
+    n = Symbol("n")
+    m = Symbol("m")
+    # For m > 1:
+    assert limit(harmonic(n, m), n, oo) == zeta(m)
 
 @XFAIL
 def test_harmonic_rewrite_sum_fail():


### PR DESCRIPTION
``` py
In [2]: harmonic(2/S(3))
Out[2]: harmonic(2/3)

In [3]: expand_func(_)
(0, 2, 3)
Out[3]: -log(6) + 2*Sum(log(sin(_k*pi/3))*cos(4*_k*pi/3), (_k, 1, 1)) + sqrt(3)*pi/6 + 3*Sum(1/(3*_k + 2), (_k, 0, 0))

In [4]: pprint(_)
              1                                            0
             ____                                         ____
             ╲                                            ╲
              ╲      ⎛   ⎛k⋅π⎞⎞    ⎛4⋅k⋅π⎞     ___         ╲      1
               ╲  log⎜sin⎜───⎟⎟⋅cos⎜─────⎟   ╲╱ 3 ⋅π        ╲  ───────
-log(6) + 2⋅   ╱     ⎝   ⎝ 3 ⎠⎠    ⎝  3  ⎠ + ─────── + 3⋅   ╱  3⋅k + 2
              ╱                                 6          ╱
             ╱                                            ╱
             ‾‾‾‾                                         ‾‾‾‾
            k = 1                                        k = 0

In [5]: _.doit()
Out[5]: -log(6) - log(sqrt(3)/2) + sqrt(3)*pi/6 + 3/2

In [6]: simplify(_)
Out[6]: log(sqrt(3)/9) + sqrt(3)*pi/6 + 3/2

In [7]: _.n()
Out[7]: 0.758981249114944

In [8]: harmonic(2/S(3))
Out[8]: harmonic(2/3)

In [9]: _.rewrite(polygamma)
Out[9]: -3*log(3)/2 + sqrt(3)*pi/6 + 3/2

In [10]: _.n()
Out[10]: 0.758981249114944
```
