### PR TITLE
Add feature to notify about travis builds on Gitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/d892156668f91e7802fa
-    on_success: always
+    on_success: never
     on_failure: always
     on_start: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,3 +128,9 @@ script:
   - bin/test_travis.sh
 notifications:
   email: false
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/d892156668f91e7802fa
+    on_success: never
+    on_failure: always
+    on_start: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,6 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/d892156668f91e7802fa
-    on_success: never
+    on_success: always
     on_failure: always
     on_start: false


### PR DESCRIPTION
We should enable notifications of Travis CI on Gitter. This will enable people having push access to restart build errors(which are very frequent). It will also encourage more people to review PRs.
