### PR TITLE
Add _eval_derivative_wrt interface and fix diff wrt MatrixElement

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -27,25 +27,61 @@ class Expr(Basic, EvalfMixin):
         temporarily converts the non-Symbol vars in Symbols when performing
         the differentiation.
 
-        Note, see the docstring of Derivative for how this should work
-        mathematically.  In particular, note that expr.subs(yourclass, Symbol)
-        should be well-defined on a structural level, or this will lead to
-        inconsistent results.
+        Non-symbol _diff_wrt=True variables must also implement a
+        _eval_derivative_wrt method. See Expr._eval_derivative_wrt
+        for details.
 
         Examples
         ========
 
-        >>> from sympy import Expr
+        >>> from sympy import Expr, Dummy
         >>> e = Expr()
         >>> e._diff_wrt
         False
         >>> class MyClass(Expr):
         ...     _diff_wrt = True
         ...
+        ...     def _eval_derivative_wrt(self, expr, new_name):
+        ...         new_self = Dummy(new_name)
+        ...         new_expr = expr.subs(self, new_self)
+        ...         return (new_expr, new_self)
+        ...
         >>> (2*MyClass()).diff(MyClass())
         2
         """
         return False
+
+    def _eval_derivative_wrt(self, expr, new_name):
+        """Transform derivative wrt a non-symbol variable to one wrt a symbol.
+
+        When taking the derivative of an expression with respect to (wrt) a
+        non-symbol variable with _diff_wrt=True, then this method is used to
+        create a new expression and a corresponding symbol variable.
+
+        Returns a tuple of new expr and symbol, or None if the transformation
+        could not be performed. The default implementation returns None.
+
+        Examples
+        ========
+
+        >>> from sympy import Expr, Dummy
+        >>> from sympy.abc import x, y
+        >>> class MyClass(Expr):
+        ...     _diff_wrt = True
+        ...
+        ...     def _eval_derivative_wrt(self, expr, new_name):
+        ...         if expr.has(y):
+        ...             return None
+        ...         new_self = Dummy(new_name)
+        ...         new_expr = expr.subs(self, new_self)
+        ...         return (new_expr, new_self)
+        ...
+        >>> (x*MyClass()).diff(MyClass())
+        x
+        >>> (y*MyClass()).diff(MyClass())
+        Derivative(y*MyClass(), MyClass())
+        """
+        return None
 
     @cacheit
     def sort_key(self, order=None):

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -503,6 +503,11 @@ class Function(Application, Expr):
             l.append(df * da)
         return Add(*l)
 
+    def _eval_derivative_wrt(self, expr, new_name):
+        new_self = Dummy(new_name)
+        new_expr = expr.subs(self, new_self)
+        return (new_expr, new_self)
+
     def _eval_is_commutative(self):
         return fuzzy_and(a.is_commutative for a in self.args)
 
@@ -1094,18 +1099,14 @@ class Derivative(Expr):
             if unhandled_non_symbol:
                 obj = None
             else:
-                if not is_symbol:
-                    new_v = C.Dummy('xi_%i' % i)
-                    new_v.dummy_index = hash(v)
-                    expr = expr.subs(v, new_v)
-                    old_v = v
-                    v = new_v
-                obj = expr._eval_derivative(v)
-                nderivs += 1
-                if not is_symbol:
+                if is_symbol:
+                    obj = expr._eval_derivative(v)
+                else:
+                    tmp_expr, tmp_v = v._eval_derivative_wrt(expr, 'xi_%i' % i) or (None, None)
+                    obj = tmp_expr._eval_derivative(tmp_v) if tmp_expr is not None else None
                     if obj is not None:
-                        obj = obj.subs(v, old_v)
-                    v = old_v
+                        obj = obj.subs(tmp_v, v)
+                nderivs += 1
 
             if obj is None:
                 unhandled_variables.append(v)
@@ -1219,6 +1220,11 @@ class Derivative(Expr):
         # already been attempted and was not computed, either because it
         # couldn't be or evaluate=False originally.
         return self.func(self.expr, *(self.variables + (v, )), evaluate=False)
+
+    def _eval_derivative_wrt(self, expr, new_name):
+        new_self = Dummy(new_name)
+        new_expr = expr.subs(self, new_self)
+        return (new_expr, new_self)
 
     def doit(self, **hints):
         expr = self.expr

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -6,7 +6,7 @@ from sympy import (Add, Basic, S, Symbol, Wild, Float, Integer, Rational, I,
     Piecewise, Mul, Pow, nsimplify, ratsimp, trigsimp, radsimp, powsimp,
     simplify, together, collect, factorial, apart, combsimp, factor, refine,
     cancel, Tuple, default_sort_key, DiracDelta, gamma, Dummy, Sum, E,
-    exp_polar, Lambda, expand, diff, O)
+    exp_polar, Lambda, expand, diff, O, Expr)
 from sympy.core.function import AppliedUndef
 from sympy.physics.secondquant import FockState
 from sympy.physics.units import meter
@@ -1622,3 +1622,18 @@ def test_issue_6325():
     assert diff(e, t, 2) == ans
     e.diff(t, 2) == ans
     assert diff(e, t, 2, simplify=False) != ans
+
+
+def test_eval_derivative_wrt():
+    class MyClass(Expr):
+        _diff_wrt = True
+
+        def _eval_derivative_wrt(self, expr, new_name):
+            if expr.has(y):
+                return None
+            new_self = Dummy(new_name)
+            new_expr = expr.subs(self, new_self)
+            return (new_expr, new_self)
+
+    assert (x*MyClass()).diff(MyClass()) == x
+    assert (y*MyClass()).diff(MyClass()) == Derivative(y*MyClass(), MyClass())

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -306,13 +306,17 @@ class MatrixElement(Expr):
     _diff_wrt = True
 
     def _eval_derivative_wrt(self, expr, new_name):
+        """Transform derivatives wrt a MatrixElement to derivatives wrt a symbol.
+
+        See Expr._eval_derivative_wrt for more information.
+        """
         new_self = C.Dummy(new_name)
 
-        class ReplaceAmbiguousError(Exception):
-            def __init__(self, value):
-                self.value = value
+        class FoundAmbigousExpression(Exception):
+            """Signal that we have found an Expression that may or may not be equal to self"""
 
         def check_equal_index(a, b):
+            """Check if two MatrixElement indices are equal. Return None if result is ambigous."""
             if a.equals(b):
                 return True
             if (a-b).is_constant():
@@ -320,27 +324,36 @@ class MatrixElement(Expr):
             return None
 
         def replace_and_check(subexpr):
+            """Recursively search for self in subexpr and replace all instances of self with new_self.
+
+            When a subexpression is found that may or may not be equal to self (for example a
+            MatrixElement with a free variable in its index), or the self.parent is found outside
+            of a MatrixElement, raise FoundAmbigousExpression to signal that we can not evaluate
+            the Derivative.
+            """
             if isinstance(subexpr, MatrixElement):
                 found_ambiguous_arg = False
-                for is_equal in [ subexpr.parent == self.parent, check_equal_index(subexpr.i, self.i), check_equal_index(subexpr.j, self.j) ]:
+                for is_equal in [subexpr.parent == self.parent, check_equal_index(subexpr.i, self.i), check_equal_index(subexpr.j, self.j)]:
                     if is_equal is None:
                         found_ambiguous_arg = True
                     elif not is_equal:
                         return subexpr.func(subexpr.parent, replace_and_check(subexpr.i), replace_and_check(subexpr.j))
                 if found_ambiguous_arg:
-                    raise ReplaceAmbiguousError(subexpr)
+                    raise FoundAmbigousExpression()
                 return new_self
             if isinstance(subexpr, MatrixSymbol):
                 if subexpr == self.parent:
-                    raise ReplaceAmbiguousError(subexpr)
+                    raise FoundAmbigousExpression()
                 return subexpr
             if len(subexpr.args) == 0:
                 return subexpr
-            return subexpr.func(*[ replace_and_check(e) for e in subexpr.args ])
+            return subexpr.func(*[replace_and_check(e) for e in subexpr.args])
 
+        # Return new expression and new symbol, or return None if we don't know how to create
+        # a new expression and new symbol for this Derivative.
         try:
             return (replace_and_check(expr), new_self)
-        except ReplaceAmbiguousError:
+        except FoundAmbigousExpression:
             return None
 
 

--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -2,7 +2,7 @@ from __future__ import print_function, division
 
 from functools import wraps
 
-from sympy.core import S, Symbol, sympify, Tuple, Integer, Basic, Expr
+from sympy.core import C, S, Symbol, sympify, Tuple, Integer, Basic, Expr
 from sympy.core.decorators import call_highest_priority
 from sympy.core.sympify import SympifyError, sympify
 from sympy.functions import conjugate, adjoint
@@ -304,6 +304,11 @@ class MatrixElement(Expr):
     i = property(lambda self: self.args[1])
     j = property(lambda self: self.args[2])
     _diff_wrt = True
+
+    def _eval_derivative_wrt(self, expr, new_name):
+        new_self = C.Dummy(new_name)
+        new_expr = expr.subs(self, new_self)
+        return (new_expr, new_self)
 
 
 class MatrixSymbol(MatrixExpr):

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,4 +1,4 @@
-from sympy.core import S, symbols, diff, Add, Mul
+from sympy.core import S, symbols, diff, Add, Mul, Derivative
 from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
@@ -13,6 +13,7 @@ B = MatrixSymbol('B', m, l)
 C = MatrixSymbol('C', n, n)
 D = MatrixSymbol('D', n, n)
 E = MatrixSymbol('E', m, n)
+w = MatrixSymbol('w', n, 1)
 
 
 def test_shape():
@@ -197,7 +198,5 @@ def test_MatrixElement_diff():
     assert (A[3, 0]*A[0, 0]).diff(A[0, 0]) == A[3, 0]
 
 def test_issue_7421():
-    i, j, m, n = symbols('i,j,m,n')
-    w = MatrixSymbol('w', n, 1)
-    X = MatrixSymbol('X', m, n)
-    assert type(diff((X*w)[i,0], w[j,0])).__name__ == 'Derivative'
+    assert isinstance(diff((D*w)[k,0], w[p,0]), Derivative)
+    assert isinstance(diff(w.T*D*w, w[0,0]), Derivative)

--- a/sympy/matrices/expressions/tests/test_matrix_exprs.py
+++ b/sympy/matrices/expressions/tests/test_matrix_exprs.py
@@ -1,4 +1,4 @@
-from sympy.core import S, symbols, Add, Mul
+from sympy.core import S, symbols, diff, Add, Mul
 from sympy.functions import transpose, sin, cos, sqrt
 from sympy.simplify import simplify
 from sympy.matrices import (Identity, ImmutableMatrix, Inverse, MatAdd, MatMul,
@@ -195,3 +195,9 @@ def test_indexing():
 
 def test_MatrixElement_diff():
     assert (A[3, 0]*A[0, 0]).diff(A[0, 0]) == A[3, 0]
+
+def test_issue_7421():
+    i, j, m, n = symbols('i,j,m,n')
+    w = MatrixSymbol('w', n, 1)
+    X = MatrixSymbol('X', m, n)
+    assert type(diff((X*w)[i,0], w[j,0])).__name__ == 'Derivative'


### PR DESCRIPTION
This patch introduces the Expr._eval_derivative_wrt interface (see docstring in the patch for description) and fixes issue #7421.
