### PR TITLE
Fixes #2676 : Convert Matrix to NumPy Array with NumPy dtype

### DIFF
--- a/sympy/external/tests/test_numpy.py
+++ b/sympy/external/tests/test_numpy.py
@@ -23,8 +23,8 @@ def setup_module(module):
         import pytest
         pytest.skip("numpy isn't available.")
 
-from sympy import (Rational, Symbol, list2numpy, sin, Float, Matrix, lambdify,
-        symarray, symbols, Integer)
+from sympy import (Rational, Symbol, list2numpy, matrix2numpy, sin, Float,
+        Matrix, lambdify, symarray, symbols, Integer)
 import sympy
 
 from sympy import mpmath
@@ -197,6 +197,28 @@ def test_Matrix_array():
             return array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     matarr = matarray()
     assert Matrix(matarr) == Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+
+def test_matrix2numpy():
+    a = matrix2numpy(Matrix([[1, x**2], [3*sin(x), 0]]))
+    assert isinstance(a, ndarray)
+    assert a.shape == (2, 2)
+    assert a[0, 0] == 1
+    assert a[0, 1] == x**2
+    assert a[1, 0] == 3*sin(x)
+    assert a[1, 1] == 0
+
+
+def test_matrix2numpy_conversion():
+    a = Matrix([[1, 2, sin(x)], [x**2, x, Rational(1, 2)]])
+    b = array([[1, 2, sin(x)], [x**2, x, Rational(1, 2)]])
+    assert (matrix2numpy(a) == b).all()
+    assert matrix2numpy(a).dtype == numpy.dtype('object')
+
+    c = matrix2numpy(Matrix([[1, 2], [10, 20]]), dtype='int8')
+    d = matrix2numpy(Matrix([[1, 2], [10, 20]]), dtype='float64')
+    assert c.dtype == numpy.dtype('int8')
+    assert d.dtype == numpy.dtype('float64')
 
 
 def test_issue629():

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -964,7 +964,7 @@ MutableMatrix = Matrix = MutableDenseMatrix
 ###########
 
 
-def list2numpy(l, d_type=object):  # pragma: no cover
+def list2numpy(l, dtype=object):  # pragma: no cover
     """Converts python list of SymPy expressions to a NumPy array.
 
     See Also
@@ -973,13 +973,13 @@ def list2numpy(l, d_type=object):  # pragma: no cover
     matrix2numpy
     """
     from numpy import empty
-    a = empty(len(l), dtype=d_type)
+    a = empty(len(l), dtype)
     for i, s in enumerate(l):
         a[i] = s
     return a
 
 
-def matrix2numpy(m, d_type=object):  # pragma: no cover
+def matrix2numpy(m, dtype=object):  # pragma: no cover
     """Converts SymPy's matrix to a NumPy array.
 
     See Also
@@ -988,14 +988,14 @@ def matrix2numpy(m, d_type=object):  # pragma: no cover
     list2numpy
     """
     from numpy import empty
-    a = empty(m.shape, dtype=d_type)
+    a = empty(m.shape, dtype)
     for i in range(m.rows):
         for j in range(m.cols):
             a[i, j] = m[i, j]
     return a
 
 @doctest_depends_on(modules=('numpy',))
-def symarray(prefix, shape, d_type=object):  # pragma: no cover
+def symarray(prefix, shape):  # pragma: no cover
     """Create a numpy ndarray of symbols (as an object array).
 
     The created symbols are named ``prefix_i1_i2_``...  You should thus provide a
@@ -1053,7 +1053,7 @@ def symarray(prefix, shape, d_type=object):  # pragma: no cover
 
     """
     from numpy import empty, ndindex
-    arr = empty(shape, dtype=d_type)
+    arr = empty(shape, dtype=object)
     for index in ndindex(shape):
         arr[index] = Symbol('%s_%s' % (prefix, '_'.join(map(str, index))))
     return arr

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -964,7 +964,7 @@ MutableMatrix = Matrix = MutableDenseMatrix
 ###########
 
 
-def list2numpy(l):  # pragma: no cover
+def list2numpy(l, d_type=object):  # pragma: no cover
     """Converts python list of SymPy expressions to a NumPy array.
 
     See Also
@@ -973,13 +973,13 @@ def list2numpy(l):  # pragma: no cover
     matrix2numpy
     """
     from numpy import empty
-    a = empty(len(l), dtype=object)
+    a = empty(len(l), dtype=d_type)
     for i, s in enumerate(l):
         a[i] = s
     return a
 
 
-def matrix2numpy(m):  # pragma: no cover
+def matrix2numpy(m, d_type=object):  # pragma: no cover
     """Converts SymPy's matrix to a NumPy array.
 
     See Also
@@ -988,14 +988,14 @@ def matrix2numpy(m):  # pragma: no cover
     list2numpy
     """
     from numpy import empty
-    a = empty(m.shape, dtype=object)
+    a = empty(m.shape, dtype=d_type)
     for i in range(m.rows):
         for j in range(m.cols):
             a[i, j] = m[i, j]
     return a
 
 @doctest_depends_on(modules=('numpy',))
-def symarray(prefix, shape):  # pragma: no cover
+def symarray(prefix, shape, d_type=object):  # pragma: no cover
     """Create a numpy ndarray of symbols (as an object array).
 
     The created symbols are named ``prefix_i1_i2_``...  You should thus provide a
@@ -1053,7 +1053,7 @@ def symarray(prefix, shape):  # pragma: no cover
 
     """
     from numpy import empty, ndindex
-    arr = empty(shape, dtype=object)
+    arr = empty(shape, dtype=d_type)
     for index in ndindex(shape):
         arr[index] = Symbol('%s_%s' % (prefix, '_'.join(map(str, index))))
     return arr


### PR DESCRIPTION
This is just #2678, but I merged with master and resolved conflicts.
