### PR TITLE
cse_main: Check for used symbols, workaround for #5331

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -434,7 +434,7 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     # Preprocess the expressions to give us better optimization opportunities.
     reduced_exprs = [preprocess_for_cse(e, optimizations) for e in exprs]
 
-    excluded_symbols = set.union(*[expr.atoms(Symbol) 
+    excluded_symbols = set.union(*[expr.atoms(Symbol)
                                    for expr in reduced_exprs])
 
     if symbols is None:

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -426,17 +426,6 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     if isinstance(exprs, Basic):
         exprs = [exprs]
 
-    excluded_symbols = set()
-    for expr in exprs:
-        excluded_symbols.update(expr.atoms(Symbol))
-
-    if symbols is None:
-        symbols = numbered_symbols(exclude=excluded_symbols)
-    else:
-        # In case we get passed an iterable with an __iter__ method instead of
-        # an actual iterator.
-        symbols = iter(symbols)
-
     if optimizations is None:
         optimizations = list()
     elif optimizations == 'basic':
@@ -444,6 +433,16 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
 
     # Preprocess the expressions to give us better optimization opportunities.
     reduced_exprs = [preprocess_for_cse(e, optimizations) for e in exprs]
+
+    excluded_symbols = set.union(*[expr.atoms(Symbol) 
+                                   for expr in reduced_exprs])
+
+    if symbols is None:
+        symbols = numbered_symbols(exclude=excluded_symbols)
+    else:
+        # In case we get passed an iterable with an __iter__ method instead of
+        # an actual iterator.
+        symbols = iter(symbols)
 
     # Find other optimization opportunities.
     opt_subs = opt_cse(reduced_exprs, order)

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -4,7 +4,7 @@ from __future__ import print_function, division
 
 import difflib
 
-from sympy.core import Basic, Mul, Add, Pow, sympify, Tuple
+from sympy.core import Basic, Mul, Add, Pow, sympify, Tuple, Symbol
 from sympy.core.singleton import S
 from sympy.core.basic import preorder_traversal
 from sympy.core.function import _coeff_isneg
@@ -422,8 +422,16 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
     """
     from sympy.matrices import Matrix
 
+    # Handle the case if just one expression was passed.
+    if isinstance(exprs, Basic):
+        exprs = [exprs]
+
+    excluded_symbols = set()
+    for expr in exprs:
+        excluded_symbols.update(expr.atoms(Symbol))
+
     if symbols is None:
-        symbols = numbered_symbols()
+        symbols = numbered_symbols(exclude=excluded_symbols)
     else:
         # In case we get passed an iterable with an __iter__ method instead of
         # an actual iterator.
@@ -433,10 +441,6 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
         optimizations = list()
     elif optimizations == 'basic':
         optimizations = basic_optimizations
-
-    # Handle the case if just one expression was passed.
-    if isinstance(exprs, Basic):
-        exprs = [exprs]
 
     # Preprocess the expressions to give us better optimization opportunities.
     reduced_exprs = [preprocess_for_cse(e, optimizations) for e in exprs]

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -10,8 +10,8 @@ from sympy.core.basic import preorder_traversal
 from sympy.core.function import _coeff_isneg
 from sympy.core.exprtools import factor_terms
 from sympy.core.compatibility import iterable, xrange
-from sympy.utilities.iterables import numbered_symbols, \
-    sift, topological_sort, ordered
+from sympy.utilities.iterables import filter_symbols, \
+    numbered_symbols, sift, topological_sort, ordered
 
 from . import cse_opts
 
@@ -438,11 +438,13 @@ def cse(exprs, symbols=None, optimizations=None, postprocess=None,
                                    for expr in reduced_exprs])
 
     if symbols is None:
-        symbols = numbered_symbols(exclude=excluded_symbols)
+        symbols = numbered_symbols()
     else:
         # In case we get passed an iterable with an __iter__ method instead of
         # an actual iterator.
         symbols = iter(symbols)
+
+    symbols = filter_symbols(symbols, excluded_symbols)
 
     # Find other optimization opportunities.
     opt_subs = opt_cse(reduced_exprs, order)

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -301,3 +301,10 @@ def test_Piecewise():
 def test_ignore_order_terms():
     eq = exp(x).series(x,0,3) + sin(y+x**3) - 1
     assert cse(eq) == ([], [sin(x**3 + y) + x + x**2/2 + O(x**3)])
+
+def test_name_conflict():
+    x0, x2 = symbols("x0 x2")
+    l = [cos(x0 + x2 + y/x), x + 2, x0 + x2 + y/x]
+    substs, reduced = cse(l)
+    assert substs == [(x1, x0 + x2 + y/x)]
+    assert reduced == [cos(x1), x+2, x1]

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -308,3 +308,10 @@ def test_name_conflict():
     l = [cos(z1) + z1, cos(z2) + z2, x0 + x2]
     substs, reduced = cse(l)
     assert [e.subs(reversed(substs)) for e in reduced] == l
+
+def test_name_conflict_cust_symbols():
+    z1 = x0 + y
+    z2 = x2 + x3
+    l = [cos(z1) + z1, cos(z2) + z2, x0 + x2]
+    substs, reduced = cse(l, symbols("x:10"))
+    assert [e.subs(reversed(substs)) for e in reduced] == l

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -303,8 +303,8 @@ def test_ignore_order_terms():
     assert cse(eq) == ([], [sin(x**3 + y) + x + x**2/2 + O(x**3)])
 
 def test_name_conflict():
-    x0, x2 = symbols("x0 x2")
-    l = [cos(x0 + x2 + y/x), x + 2, x0 + x2 + y/x]
+    z1 = x0 + y
+    z2 = x2 + x3
+    l = [cos(z1) + z1, cos(z2) + z2, x0 + x2]
     substs, reduced = cse(l)
-    assert substs == [(x1, x0 + x2 + y/x)]
-    assert reduced == [cos(x1), x+2, x1]
+    assert [e.subs(reversed(substs)) for e in reduced] == l

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -527,6 +527,30 @@ def subsets(seq, k=None, repetition=False):
                 yield i
 
 
+def filter_symbols(iterator, exclude):
+    """
+    Only yield elements from `iterator` that do not occur in `exclude`.
+
+    Parameters
+    ==========
+
+    iterator : iterable
+    iterator to take elements from
+
+    exclude : iterable
+    elements to exclude
+
+    Returns
+    =======
+
+    iterator : iterator
+    filtered iterator
+    """
+    exclude = set(exclude)
+    for s in iterator:
+        if s not in exclude:
+            yield s
+
 def numbered_symbols(prefix='x', cls=None, start=0, exclude=[], *args, **assumptions):
     """
     Generate an infinite stream of Symbols consisting of a prefix and

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -6,7 +6,7 @@ from sympy import (
 from sympy.combinatorics import RGS_enum, RGS_unrank, Permutation
 from sympy.utilities.iterables import (
     _partition, _set_partitions, binary_partitions, bracelets, capture,
-    cartes, common_prefix, common_suffix, dict_merge,
+    cartes, common_prefix, common_suffix, dict_merge, filter_symbols,
     flatten, generate_bell, generate_derangements, generate_involutions,
     generate_oriented_forest, group, has_dups, kbins, minlex, multiset,
     multiset_combinations, multiset_partitions,
@@ -164,6 +164,10 @@ def test_cartes():
     assert list(cartes('a', repeat=2)) == [('a', 'a')]
     assert list(cartes(list(range(2)))) == [(0,), (1,)]
 
+def test_filter_symbols():
+    s = numbered_symbols()
+    filtered = filter_symbols(s, symbols("x0 x2 x3"))
+    assert take(filtered, 3) == list(symbols("x1 x4 x5"))
 
 def test_numbered_symbols():
     s = numbered_symbols(cls=Dummy)


### PR DESCRIPTION
This is a workaround to fix #5331. Alternative to PR #7455
