### PR TITLE
Fix #2711

### DIFF
--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -162,6 +162,11 @@ class AssocOp(Basic):
         equivalent.
 
         """
+        # make sure expr is Expr if pattern is Expr
+        from .expr import Expr
+        if isinstance(self, Expr) and not isinstance(expr, Expr):
+            return None
+
         # handle simple patterns
         if self == expr:
             return repl_dict

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -875,6 +875,10 @@ class Pow(Expr):
             if d is not None:
                 return d
 
+        # make sure the expression to be matched is an Expr
+        if not isinstance(expr, Expr):
+            return None
+
         b, e = expr.as_base_exp()
 
         # special case number

--- a/sympy/core/tests/test_match.py
+++ b/sympy/core/tests/test_match.py
@@ -1,6 +1,6 @@
 from sympy import (abc, Add, cos, Derivative, diff, exp, Float, Function,
     I, Integer, log, Mul, oo, Poly, Rational, S, sin, sqrt, Symbol, symbols,
-    Wild, pi
+    Wild, pi, meijerg
 )
 from sympy.utilities.pytest import XFAIL
 
@@ -599,3 +599,15 @@ def test_issue_3539():
     assert (x - 2).match(a - x) is None
     assert (6/x).match(a*x) is None
     assert (6/x**2).match(a/x) == {a: 6/x}
+
+def test_gh_issue_2711():
+    x = Symbol('x')
+    f = meijerg(((), ()), ((0,), ()), x)
+    a = Wild('a')
+    b = Wild('b')
+
+    assert f.find(a) == set([(S.Zero,), ((), ()), ((S.Zero,), ()), x, S.Zero,
+                             (), meijerg(((), ()), ((S.Zero,), ()), x)])
+    assert f.find(a + b) == \
+        set([meijerg(((), ()), ((S.Zero,), ()), x), x, S.Zero])
+    assert f.find(a**2) == set([meijerg(((), ()), ((S.Zero,), ()), x), x])

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -202,8 +202,12 @@ def alternatives(*rules):
                 alts.append(result)
         if len(alts) == 1:
             return alts[0]
-        elif len(alts) > 1:
-            return AlternativeRule(alts, *integral)
+        elif alts:
+            doable = [rule for rule in alts if not contains_dont_know(rule)]
+            if doable:
+                return AlternativeRule(doable, *integral)
+            else:
+                return AlternativeRule(alts, *integral)
     return _alternatives
 
 def constant_rule(integral):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -24,7 +24,6 @@ import sympy
 
 from sympy.core.compatibility import reduce
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
-from sympy.simplify import fraction
 from sympy.strategies.core import (switch, identity, do_one, null_safe,
                                    condition, tryit)
 
@@ -115,29 +114,22 @@ def find_substitutions(integrand, symbol, u_var):
 
         substituted = substituted.subs(u, u_var).cancel()
         if symbol not in substituted.free_symbols:
-            _, denom = integrand.as_numer_denom()
-            _, denom2 = substituted.as_numer_denom()
-            denom2 = denom2.subs(u_var, u)
-            constant = denom/denom2
-            return (constant, substituted / constant)
+            constant, _ = substituted.as_coeff_mul(u_var)
+
+            if symbol not in constant.free_symbols:
+                return constant, substituted / constant
         return False
 
     def possible_subterms(term):
-        if any(isinstance(term, cls)
-               for cls in (sympy.sin, sympy.cos, sympy.tan,
-                           sympy.asin, sympy.acos, sympy.atan,
-                           sympy.exp, sympy.log, sympy.Heaviside)):
+        if isinstance(term, (sympy.sin, sympy.cos, sympy.tan,
+                             sympy.asin, sympy.acos, sympy.atan,
+                             sympy.exp, sympy.log, sympy.Heaviside)):
             return [term.args[0]]
         elif isinstance(term, sympy.Mul):
             r = []
             for u in term.args:
-                numer, denom = fraction(u)
-                if numer == 1:
-                    r.append(denom)
-                    r.extend(possible_subterms(denom))
-                else:
-                    r.append(u)
-                    r.extend(possible_subterms(u))
+                r.append(u)
+                r.extend(possible_subterms(u))
             return r
         elif isinstance(term, sympy.Pow):
             if term.args[1].is_constant(symbol):
@@ -641,7 +633,7 @@ def substitution_rule(integral):
 
             if sympy.simplify(c - 1) != 0:
                 _, denom = c.as_numer_denom()
-                subrule = ConstantTimesRule(c, substituted, subrule, substituted, symbol)
+                subrule = ConstantTimesRule(c, substituted, subrule, substituted, u_var)
 
                 if denom.free_symbols:
                     piecewise = []

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -114,10 +114,8 @@ def find_substitutions(integrand, symbol, u_var):
 
         substituted = substituted.subs(u, u_var).cancel()
         if symbol not in substituted.free_symbols:
-            constant, _ = substituted.as_coeff_mul(u_var)
+            return substituted.as_independent(u_var, as_Add=False)
 
-            if symbol not in constant.free_symbols:
-                return constant, substituted / constant
         return False
 
     def possible_subterms(term):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -121,7 +121,7 @@ def find_substitutions(integrand, symbol, u_var):
         return False
 
     def possible_subterms(term):
-        if isinstance(term, (sympy.sin, sympy.cos, sympy.tan,
+        if isinstance(term, (TrigonometricFunction,
                              sympy.asin, sympy.acos, sympy.atan,
                              sympy.exp, sympy.log, sympy.Heaviside)):
             return [term.args[0]]

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -165,3 +165,6 @@ def test_issue_2850():
         (x*acos(x) - sqrt(-x**2 + 1))*log(x) + Integral(sqrt(-x**2 + 1)/x, x)
     assert manualintegrate(atan(x)*log(x), x) == -x*atan(x) + (x*atan(x) - \
             log(x**2 + 1)/2)*log(x) + log(x**2 + 1)/2 + Integral(log(x**2 + 1)/x, x)/2
+
+def test_constant_independent_of_symbol():
+    assert manualintegrate(Integral(y, (x, 1, 2)), x) == x*Integral(y, (x, 1, 2))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -63,6 +63,9 @@ def test_manualintegrate_trigonometry():
     assert manualintegrate(-sec(x) * tan(x), x) == -sec(x)
     assert manualintegrate(csc(x) * cot(x), x) == -csc(x)
 
+    assert manualintegrate(x * sec(x**2), x) == log(tan(x**2) + sec(x**2))/2
+    assert manualintegrate(cos(x)*csc(sin(x)), x) == -log(cot(sin(x)) + csc(sin(x)))
+
 def test_manualintegrate_trigpowers():
     assert manualintegrate(sin(x)**2 * cos(x), x) == sin(x)**3 / 3
     assert manualintegrate(sin(x)**2 * cos(x) **2, x) == \

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1,7 +1,7 @@
 from sympy import (sin, cos, tan, sec, csc, cot, log, exp, atan, asin, acos,
                    Symbol, Mul, Integral, integrate, pi, Dummy,
                    Derivative, diff, I, sqrt, erf, Piecewise,
-                   Eq, Ne, Q, assuming, symbols, And, Heaviside, Max)
+                   Eq, Ne, Q, assuming, symbols, And, Heaviside, Max, S)
 from sympy.integrals.manualintegrate import manualintegrate, find_substitutions, \
     integral_steps, _parts_rule
 
@@ -12,6 +12,7 @@ def test_find_substitutions():
         [(cot(x), 1, -u**6 - 2*u**4 - u**2)]
     assert find_substitutions((sec(x)**2 + tan(x) * sec(x)) / (sec(x) + tan(x)),
                               x, u) == [(sec(x) + tan(x), 1, 1/u)]
+    assert find_substitutions(x * exp(-x**2), x, u) == [(-x**2, -S.Half, exp(u))]
 
 def test_manualintegrate_polynomials():
     assert manualintegrate(y, x) == x*y


### PR DESCRIPTION
Changes:
- Fix #2711 by making sure the expression to be matched is an `Expr` if the pattern is an `Expr`
- Fix bug in `manualintegrate` by ensuring that in u-substitution, the constant does not contain the original symbol (i.e. the constant is actually constant). 
