### PR TITLE
Add a descriptive Exception if symbols iterator runs out of symbols

### DIFF
--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -360,7 +360,10 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical'):
             new_expr = expr
 
         if orig_expr in to_eliminate:
-            sym = next(symbols)
+            try:
+                sym = next(symbols)
+            except StopIteration:
+                raise ValueError("Symbols iterator ran out of symbols.")
             subs[orig_expr] = sym
             replacements.append((sym, new_expr))
             return sym

--- a/sympy/simplify/tests/test_cse.py
+++ b/sympy/simplify/tests/test_cse.py
@@ -6,7 +6,7 @@ from sympy import (Add, Pow, Symbol, exp, sqrt, symbols, sympify, cse,
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.functions.special.hyper import meijerg
 from sympy.simplify import cse_main, cse_opts
-from sympy.utilities.pytest import XFAIL
+from sympy.utilities.pytest import XFAIL, raises
 
 w, x, y, z = symbols('w,x,y,z')
 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12 = symbols('x:13')
@@ -315,3 +315,9 @@ def test_name_conflict_cust_symbols():
     l = [cos(z1) + z1, cos(z2) + z2, x0 + x2]
     substs, reduced = cse(l, symbols("x:10"))
     assert [e.subs(reversed(substs)) for e in reduced] == l
+
+def test_symbols_exhausted_error():
+    l = cos(x+y)+x+y+cos(w+y)+sin(w+y)
+    sym = [x, y, z]
+    with raises(ValueError) as excinfo:
+        cse(l, symbols=sym)


### PR DESCRIPTION
Fix for #7466
