### PR TITLE
Suppress plots in the tests

### DIFF
--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -11,7 +11,22 @@ from tempfile import NamedTemporaryFile
 import warnings
 import os
 
+
+class MockPrint(object):
+
+    def write(self, s):
+        pass
+
+
+def disable_print(func, *args, **kwargs):
+    def wrapper(*args, **kwargs):
+        sys.stdout = MockPrint()
+        func(*args, **kwargs)
+        sys.stdout = sys.__stdout__
+    return wrapper
+
 unset_show()
+
 
 # XXX: We could implement this as a context manager instead
 # That would need rewriting the plot_and_save() function
@@ -229,6 +244,7 @@ def test_experimental_lambify():
     assert Max(2, 5) == 5
     assert Max(7, 5) == 7
 
+@disable_print
 def test_append_issue_7140():
     x = Symbol('x')
     p1 = plot(x)

--- a/sympy/plotting/tests/test_plot.py
+++ b/sympy/plotting/tests/test_plot.py
@@ -6,10 +6,12 @@ from sympy.plotting.plot import unset_show
 from sympy.utilities.pytest import skip, raises
 from sympy.plotting.experimental_lambdify import lambdify
 from sympy.external import import_module
+from sympy.core.decorators import wraps
 
 from tempfile import NamedTemporaryFile
 import warnings
 import os
+import sys
 
 
 class MockPrint(object):
@@ -17,8 +19,8 @@ class MockPrint(object):
     def write(self, s):
         pass
 
-
 def disable_print(func, *args, **kwargs):
+    @wraps(func)
     def wrapper(*args, **kwargs):
         sys.stdout = MockPrint()
         func(*args, **kwargs)


### PR DESCRIPTION
- [x] use wraps as indicated by Aaron
- [x] make sure that the tests are not skipped when the decoration is used

This PR suppresses the generated textplots on the terminal which was added by @smichr to test issue #7140.

See [this comment.](https://github.com/sympy/sympy/pull/7452#issuecomment-41636604)
