### PR TITLE
Wipe out universal set

### DIFF
--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -40,6 +40,11 @@ ProductSet
 .. autoclass:: ProductSet
    :members:
 
+Difference
+^^^^^^^^^^
+.. autoclass:: Difference
+   :members:
+
 Singleton Sets
 --------------
 

--- a/doc/src/modules/sets.rst
+++ b/doc/src/modules/sets.rst
@@ -53,11 +53,6 @@ EmptySet
 .. autoclass:: EmptySet
    :members:
 
-UniversalSet
-^^^^^^^^^^^^
-.. autoclass:: UniversalSet
-   :members:
-
 Special Sets
 ------------
 .. automodule:: sympy.sets.fancysets

--- a/sympy/core/__init__.py
+++ b/sympy/core/__init__.py
@@ -23,7 +23,7 @@ from .function import Lambda, WildFunction, Derivative, diff, FunctionClass, \
     expand_trig, expand_complex, expand_multinomial, nfloat, \
     expand_power_base, expand_power_exp
 from .sets import (Set, Interval, Union, EmptySet, FiniteSet, ProductSet,
-        Intersection, imageset)
+        Intersection, imageset, Difference)
 from .evalf import PrecisionExhausted, N
 from .containers import Tuple, Dict
 from .exprtools import gcd_terms, factor_terms, factor_nc

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -11,7 +11,7 @@ from sympy.core.compatibility import iterable, with_metaclass
 from sympy.core.evaluate import global_evaluate
 
 from sympy.mpmath import mpi, mpf
-from sympy.logic.boolalg import And, Or, true, false
+from sympy.logic.boolalg import And, Or, Not, true, false
 from sympy.utilities import default_sort_key, subsets
 
 
@@ -1222,6 +1222,64 @@ class Intersection(Set):
     def as_relational(self, symbol):
         """Rewrite an Intersection in terms of equalities and logic operators"""
         return And(*[set.as_relational(symbol) for set in self.args])
+
+
+class Difference(Set, EvalfMixin):
+    """
+    Represents the set difference of a set with another set.
+
+    `A - B = {x | x \in A and x \\notin B} `
+
+    Examples
+    ========
+
+        >>> from sympy import Difference, FiniteSet
+        >>> Difference(FiniteSet(0, 1, 2), FiniteSet(1))
+        {0, 2}
+
+    See Also
+    =========
+    Intersection, Union
+
+    References
+    ==========
+    http://mathworld.wolfram.com/SetDifference.html
+    """
+    is_Difference = True
+
+    def __new__(cls, *args, **kwargs):
+
+        evaluate = kwargs.get('evaluate', global_evaluate[0])
+
+        args = list(args)
+
+        if len(args) != 2:
+            raise TypeError("The input must be two Sets")
+
+        if evaluate:
+            return Difference.reduce(args)
+
+        return Basic.__new__(cls, *args)
+
+    @staticmethod
+    def reduce(args):
+        """
+        Simplify a :class:`Difference` using known rules.
+
+        Rules:
+            1. If A is FiniteSet then use the definition
+
+        """
+
+        A = args[0]
+        B = args[1]
+
+        return A.__sub__(B)
+
+    def _contains(self, other):
+        A = self.args[0]
+        B = self.args[1]
+        return And(A.contains(other), Not(B.contains(other)))
 
 
 class EmptySet(with_metaclass(Singleton, Set)):

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -1236,7 +1236,8 @@ class Difference(Set, EvalfMixin):
     """
     Represents the set difference of a set with another set.
 
-    `A - B = {x | x \in A and x \\notin B} `
+    `A - B = \{x \in A| x \\notin B\}`
+
 
     Examples
     ========

--- a/sympy/core/sets.py
+++ b/sympy/core/sets.py
@@ -116,8 +116,7 @@ class Set(Basic):
         """
         return None
 
-    @property
-    def complement(self):
+    def complement(self, universal_set):
         """
         The complement of 'self'.
 
@@ -133,12 +132,9 @@ class Set(Basic):
         (-oo, 0) U (1, oo)
 
         """
-        return self._complement
+        return universal_set - self
 
-    @property
-    def _complement(self):
-        return Difference(S.UniversalSet, self, evaluate=False)
-
+    # def _complem
 
     @property
     def inf(self):
@@ -338,17 +334,7 @@ class Set(Basic):
         return ProductSet([self]*exp)
 
     def __sub__(self, other):
-        other_comp = other.complement
-        if isinstance(other_comp, Difference):
-            return Difference(self, other, evaluate=False)
-        else:
-            return Intersection(self, other_comp)
-
-    def __neg__(self):
-        return self.complement
-
-    def __invert__(self):
-        return self.complement
+        return Difference(self, other, evaluate=False)
 
     def __contains__(self, other):
         from sympy.assumptions import ask
@@ -474,13 +460,13 @@ class ProductSet(Set):
     def sets(self):
         return self.args
 
-    @property
-    def _complement(self):
+    def __sub__(self, other):
         # For each set consider it or it's complement
         # We need at least one of the sets to be complemented
         # Consider all 2^n combinations.
         # We can conveniently represent these options easily using a ProductSet
-        switch_sets = ProductSet(FiniteSet(s, s.complement) for s in self.sets)
+        switch_sets = ProductSet(FiniteSet(s, s - o) for s, o in
+                                 zip(self.sets, other.sets))
         product_sets = (ProductSet(*set) for set in switch_sets)
         # Union of all combinations but this one
         return Union(p for p in product_sets if p != self)
@@ -736,11 +722,8 @@ class Interval(Set, EvalfMixin):
 
         return None
 
-    @property
-    def _complement(self):
-        a = Interval(S.NegativeInfinity, self.start, True, not self.left_open)
-        b = Interval(self.end, S.Infinity, not self.right_open, True)
-        return Union(a, b)
+    def __sub__(self, other):
+        return Intersection(self, other.complement(S.Reals))
 
     @property
     def _boundary(self):
@@ -983,14 +966,6 @@ class Union(Set, EvalfMixin):
         # end points.
         from sympy.functions.elementary.miscellaneous import Max
         return Max(*[set.sup for set in self.args])
-
-    @property
-    def _complement(self):
-        # De Morgan's formula.
-        complement = self.args[0].complement
-        for set in self.args[1:]:
-            complement = complement.intersect(set.complement)
-        return complement
 
     def _contains(self, other):
         or_args = [the_set.contains(other) for the_set in self.args]
@@ -1288,7 +1263,7 @@ class Difference(Set, EvalfMixin):
         A = args[0]
         B = args[1]
 
-        return A.__sub__(B)
+        return A - B
 
     def _contains(self, other):
         A = self.args[0]
@@ -1326,9 +1301,8 @@ class EmptySet(with_metaclass(Singleton, Set)):
     def _intersect(self, other):
         return S.EmptySet
 
-    @property
-    def _complement(self):
-        return S.UniversalSet
+    def __sub__(self, other):
+        return S.EmptySet
 
     @property
     def _measure(self):
@@ -1358,57 +1332,6 @@ class EmptySet(with_metaclass(Singleton, Set)):
     @property
     def _boundary(self):
         return self
-
-class UniversalSet(with_metaclass(Singleton, Set)):
-    """
-    Represents the set of all things.
-    The universal set is available as a singleton as S.UniversalSet
-
-    Examples
-    ========
-
-        >>> from sympy import S, Interval
-
-        >>> S.UniversalSet
-        UniversalSet()
-
-        >>> Interval(1, 2).intersect(S.UniversalSet)
-        [1, 2]
-
-    See Also
-    ========
-    EmptySet
-
-    References
-    ==========
-    http://en.wikipedia.org/wiki/Universal_set
-    """
-
-    is_UniversalSet = True
-
-    def _intersect(self, other):
-        return other
-
-    @property
-    def _complement(self):
-        return S.EmptySet
-
-    @property
-    def _measure(self):
-        return S.Infinity
-
-    def _contains(self, other):
-        return True
-
-    def as_relational(self, symbol):
-        return True
-
-    def _union(self, other):
-        return self
-
-    @property
-    def _boundary(self):
-        return EmptySet()
 
 
 class FiniteSet(Set, EvalfMixin):
@@ -1500,33 +1423,6 @@ class FiniteSet(Set, EvalfMixin):
 
     def _eval_imageset(self, f):
         return FiniteSet(*map(f, self))
-
-    @property
-    def _complement(self):
-        """
-        The complement of a real finite set is the Union of open Intervals
-        between the elements of the set.
-
-        >>> from sympy import FiniteSet
-        >>> FiniteSet(1, 2, 3).complement
-        (-oo, 1) U (1, 2) U (2, 3) U (3, oo)
-
-
-        """
-        if not all(elem.is_number for elem in self):
-            raise ValueError("%s: Complement not defined for symbolic inputs"
-                    % self)
-
-        # as there are only numbers involved, a straight sort is sufficient;
-        # default_sort_key is not needed
-        args = sorted(self.args)
-
-        intervals = []  # Build up a list of intervals between the elements
-        intervals += [Interval(S.NegativeInfinity, args[0], True, True)]
-        for a, b in zip(args[:-1], args[1:]):
-            intervals.append(Interval(a, b, True, True))  # open intervals
-        intervals.append(Interval(args[-1], S.Infinity, True, True))
-        return Union(intervals, evaluate=False)
 
     @property
     def _boundary(self):

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -463,6 +463,11 @@ def test_sympy__core__sets__Union():
     assert _test_args(Union(Interval(0, 1), Interval(2, 3)))
 
 
+def test_sympy__core__sets__Difference():
+    from sympy.core.sets import Difference
+    assert _test_args(Difference(Interval(0, 2), Interval(0, 1)))
+
+
 def test_sympy__core__trace__Tr():
     from sympy.core.trace import Tr
     a, b = symbols('a b')

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -426,11 +426,6 @@ def test_sympy__core__sets__EmptySet():
     assert _test_args(EmptySet())
 
 
-def test_sympy__core__sets__UniversalSet():
-    from sympy.core.sets import UniversalSet
-    assert _test_args(UniversalSet())
-
-
 def test_sympy__core__sets__FiniteSet():
     from sympy.core.sets import FiniteSet
     assert _test_args(FiniteSet(x, y, z))

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -137,47 +137,40 @@ def test_Difference():
     assert -1 in S.Reals - S.Naturals
 
 
-def test_complement():
-    assert Interval(0, 1).complement == \
-        Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
-    assert Interval(0, 1, True, False).complement == \
-        Union(Interval(-oo, 0, True, False), Interval(1, oo, True, True))
-    assert Interval(0, 1, False, True).complement == \
-        Union(Interval(-oo, 0, True, True), Interval(1, oo, False, True))
-    assert Interval(0, 1, True, True).complement == \
-        Union(Interval(-oo, 0, True, False), Interval(1, oo, False, True))
-
-    assert -S.EmptySet == S.EmptySet.complement
-    assert ~S.EmptySet == S.EmptySet.complement
-
-    assert S.EmptySet.complement == S.UniversalSet
-    assert S.UniversalSet.complement == S.EmptySet
-
-    assert Union(Interval(0, 1), Interval(2, 3)).complement == \
-        Union(Interval(-oo, 0, True, True), Interval(1, 2, True, True),
-              Interval(3, oo, True, True))
-
-    assert FiniteSet(0).complement == Union(Interval(-oo, 0, True, True),
-            Interval(0, oo, True, True))
-
-    assert (FiniteSet(5) + Interval(S.NegativeInfinity, 0)).complement == \
-        Interval(0, 5, True, True) + Interval(5, S.Infinity, True, True)
-
-    assert FiniteSet(1, 2, 3).complement == \
-        Interval(S.NegativeInfinity, 1, True, True) + Interval(1, 2, True, True) + \
-        Interval(2, 3, True, True) + Interval(3, S.Infinity, True, True)
-
-    X = Interval(1, 3) + FiniteSet(5)
-    assert X.intersect(X.complement) == S.EmptySet
-
-    square = Interval(0, 1) * Interval(0, 1)
-    notsquare = square.complement
-
-    assert all(pt in square for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
-    assert not any(
-        pt in notsquare for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
-    assert not any(pt in square for pt in [(-1, 0), (1.5, .5), (10, 10)])
-    assert all(pt in notsquare for pt in [(-1, 0), (1.5, .5), (10, 10)])
+# def test_complement():
+#     assert Interval(0, 1).complement(S.Reals) == \
+#         Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
+#     assert Interval(0, 1, True, False).complement(S.Reals) == \
+#         Union(Interval(-oo, 0, True, False), Interval(1, oo, True, True))
+#     assert Interval(0, 1, False, True).complement(S.Reals) == \
+#         Union(Interval(-oo, 0, True, True), Interval(1, oo, False, True))
+#     assert Interval(0, 1, True, True).complement(S.Reals) == \
+#         Union(Interval(-oo, 0, True, False), Interval(1, oo, False, True))
+#
+#     assert Union(Interval(0, 1), Interval(2, 3)).complement(S.Reals) == \
+#         Union(Interval(-oo, 0, True, True), Interval(1, 2, True, True),
+#               Interval(3, oo, True, True))
+#
+#     assert FiniteSet(0).complement(S.Reals) ==  \
+#         Union(Interval(-oo, 0, True, True), Interval(0, oo, True, True))
+#
+#     assert (FiniteSet(5) + Interval(S.NegativeInfinity,
+#                                     0)).complement(S.Reals) == \
+#         Interval(0, 5, True, True) + Interval(5, S.Infinity, True, True)
+#
+#     assert FiniteSet(1, 2, 3).complement(S.Reals) == \
+#         Interval(S.NegativeInfinity, 1, True, True) + \
+#         Interval(1, 2, True, True) + Interval(2, 3, True, True) +\
+#         Interval(3, S.Infinity, True, True)
+#
+#     square = Interval(0, 1) * Interval(0, 1)
+#     notsquare = square.complement(S.Reals*S.Reals)
+#
+#     assert all(pt in square for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
+#     assert not any(
+#         pt in notsquare for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
+#     assert not any(pt in square for pt in [(-1, 0), (1.5, .5), (10, 10)])
+#     assert all(pt in notsquare for pt in [(-1, 0), (1.5, .5), (10, 10)])
 
 
 def test_intersect():
@@ -490,13 +483,13 @@ def test_product_basic():
     assert (d6*d6).subset(d4*d4)
 
     inf, neginf = S.Infinity, S.NegativeInfinity
-    assert square.complement == Union(
-        Interval(0, 1) *
-        (Interval(neginf, 0, True, True) + Interval(1, inf, True, True)),
-        (Interval(neginf, 0, True, True) + Interval(1, inf, True, True)) *
-        Interval(0, 1),
-        ((Interval(neginf, 0, True, True) + Interval(1, inf, True, True))
-         * (Interval(neginf, 0, True, True) + Interval(1, inf, True, True))))
+    # assert square.complement == Union(
+    #     Interval(0, 1) *
+    #     (Interval(neginf, 0, True, True) + Interval(1, inf, True, True)),
+    #     (Interval(neginf, 0, True, True) + Interval(1, inf, True, True)) *
+    #     Interval(0, 1),
+    #     ((Interval(neginf, 0, True, True) + Interval(1, inf, True, True))
+    #      * (Interval(neginf, 0, True, True) + Interval(1, inf, True, True))))
 
     assert (Interval(-10, 10)**3).subset(Interval(-5, 5)**3)
     assert not (Interval(-5, 5)**3).subset(Interval(-10, 10)**3)

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -122,6 +122,7 @@ def test_difference():
     assert Union(Interval(0, 2), FiniteSet(2, 3, 4)) - Interval(1, 3) == \
         Union(Interval(0, 1, False, True), FiniteSet(4))
 
+    assert -1 in S.Reals - S.Naturals
 
 def test_Difference():
     assert Difference(Interval(1, 3), Interval(1, 2)) == Interval(2, 3, True)
@@ -134,43 +135,42 @@ def test_Difference():
     assert -1 in Difference(S.Reals, S.Naturals, evaluate=False)
     assert not 1 in Difference(S.Reals, S.Naturals, evaluate=False)
 
-    assert -1 in S.Reals - S.Naturals
 
 
-# def test_complement():
-#     assert Interval(0, 1).complement(S.Reals) == \
-#         Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
-#     assert Interval(0, 1, True, False).complement(S.Reals) == \
-#         Union(Interval(-oo, 0, True, False), Interval(1, oo, True, True))
-#     assert Interval(0, 1, False, True).complement(S.Reals) == \
-#         Union(Interval(-oo, 0, True, True), Interval(1, oo, False, True))
-#     assert Interval(0, 1, True, True).complement(S.Reals) == \
-#         Union(Interval(-oo, 0, True, False), Interval(1, oo, False, True))
-#
-#     assert Union(Interval(0, 1), Interval(2, 3)).complement(S.Reals) == \
-#         Union(Interval(-oo, 0, True, True), Interval(1, 2, True, True),
-#               Interval(3, oo, True, True))
-#
-#     assert FiniteSet(0).complement(S.Reals) ==  \
-#         Union(Interval(-oo, 0, True, True), Interval(0, oo, True, True))
-#
-#     assert (FiniteSet(5) + Interval(S.NegativeInfinity,
-#                                     0)).complement(S.Reals) == \
-#         Interval(0, 5, True, True) + Interval(5, S.Infinity, True, True)
-#
-#     assert FiniteSet(1, 2, 3).complement(S.Reals) == \
-#         Interval(S.NegativeInfinity, 1, True, True) + \
-#         Interval(1, 2, True, True) + Interval(2, 3, True, True) +\
-#         Interval(3, S.Infinity, True, True)
-#
-#     square = Interval(0, 1) * Interval(0, 1)
-#     notsquare = square.complement(S.Reals*S.Reals)
-#
-#     assert all(pt in square for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
-#     assert not any(
-#         pt in notsquare for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
-#     assert not any(pt in square for pt in [(-1, 0), (1.5, .5), (10, 10)])
-#     assert all(pt in notsquare for pt in [(-1, 0), (1.5, .5), (10, 10)])
+def test_complement():
+    assert Interval(0, 1).complement(S.Reals) == \
+        Union(Interval(-oo, 0, True, True), Interval(1, oo, True, True))
+    assert Interval(0, 1, True, False).complement(S.Reals) == \
+        Union(Interval(-oo, 0, True, False), Interval(1, oo, True, True))
+    assert Interval(0, 1, False, True).complement(S.Reals) == \
+        Union(Interval(-oo, 0, True, True), Interval(1, oo, False, True))
+    assert Interval(0, 1, True, True).complement(S.Reals) == \
+        Union(Interval(-oo, 0, True, False), Interval(1, oo, False, True))
+
+    assert Union(Interval(0, 1), Interval(2, 3)).complement(S.Reals) == \
+        Union(Interval(-oo, 0, True, True), Interval(1, 2, True, True),
+              Interval(3, oo, True, True))
+
+    assert FiniteSet(0).complement(S.Reals) ==  \
+        Union(Interval(-oo, 0, True, True), Interval(0, oo, True, True))
+
+    assert (FiniteSet(5) + Interval(S.NegativeInfinity,
+                                    0)).complement(S.Reals) == \
+        Interval(0, 5, True, True) + Interval(5, S.Infinity, True, True)
+
+    assert FiniteSet(1, 2, 3).complement(S.Reals) == \
+        Interval(S.NegativeInfinity, 1, True, True) + \
+        Interval(1, 2, True, True) + Interval(2, 3, True, True) +\
+        Interval(3, S.Infinity, True, True)
+
+    square = Interval(0, 1) * Interval(0, 1)
+    notsquare = square.complement(S.Reals*S.Reals)
+
+    assert all(pt in square for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
+    assert not any(
+        pt in notsquare for pt in [(0, 0), (.5, .5), (1, 0), (1, 1)])
+    assert not any(pt in square for pt in [(-1, 0), (1.5, .5), (10, 10)])
+    assert all(pt in notsquare for pt in [(-1, 0), (1.5, .5), (10, 10)])
 
 
 def test_intersect():
@@ -219,7 +219,6 @@ def test_intersection():
 
     # Singleton special cases
     assert Intersection(Interval(0, 1), S.EmptySet) == S.EmptySet
-    assert Intersection(Interval(0, 1), S.UniversalSet) == Interval(0, 1)
 
     # Products
     line = Interval(0, 5)
@@ -483,13 +482,11 @@ def test_product_basic():
     assert (d6*d6).subset(d4*d4)
 
     inf, neginf = S.Infinity, S.NegativeInfinity
-    # assert square.complement == Union(
-    #     Interval(0, 1) *
-    #     (Interval(neginf, 0, True, True) + Interval(1, inf, True, True)),
-    #     (Interval(neginf, 0, True, True) + Interval(1, inf, True, True)) *
-    #     Interval(0, 1),
-    #     ((Interval(neginf, 0, True, True) + Interval(1, inf, True, True))
-    #      * (Interval(neginf, 0, True, True) + Interval(1, inf, True, True))))
+    assert square.complement(S.Reals*S.Reals) == Union(
+        (Interval(-oo, 0, True, True) +
+         Interval(1, oo, True, True))*Interval(-oo, oo),
+        Interval(-oo, oo)*(Interval(-oo, 0, True, True) +
+                           Interval(1, oo, True, True)))
 
     assert (Interval(-10, 10)**3).subset(Interval(-5, 5)**3)
     assert not (Interval(-5, 5)**3).subset(Interval(-10, 10)**3)
@@ -533,13 +530,6 @@ def test_supinf():
     assert FiniteSet(5, 1, x, y, S.Infinity, S.NegativeInfinity).inf == \
         S.NegativeInfinity
     assert FiniteSet('Ham', 'Eggs').sup == Max('Ham', 'Eggs')
-
-
-def test_universalset():
-    U = S.UniversalSet
-    x = Symbol('x')
-    assert U.as_relational(x) is True
-    assert U.union(Interval(2, 4)) == U
 
 
 def test_Union_of_ProductSets_shares():

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -1,7 +1,7 @@
 from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
     GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
-    FiniteSet, Intersection, imageset, I, true, false, ProductSet, E
-)
+    FiniteSet, Intersection, imageset, I, true, false, ProductSet, E,
+    Difference)
 from sympy.mpmath import mpi
 
 from sympy.utilities.pytest import raises
@@ -121,6 +121,18 @@ def test_difference():
     assert FiniteSet(1, 2, 3, 4) - S.EmptySet == FiniteSet(1, 2, 3, 4)
     assert Union(Interval(0, 2), FiniteSet(2, 3, 4)) - Interval(1, 3) == \
         Union(Interval(0, 1, False, True), FiniteSet(4))
+
+
+def test_Difference():
+    assert Difference(Interval(1, 3), Interval(1, 2)) == Interval(2, 3, True)
+    assert Difference(FiniteSet(1, 3, 4), FiniteSet(3, 4)) == FiniteSet(1)
+    assert Difference(Union(Interval(0, 2),
+                            FiniteSet(2, 3, 4)), Interval(1, 3)) == \
+        Union(Interval(0, 1, False, True), FiniteSet(4))
+
+    assert not 3 in Difference(Interval(0, 5), Interval(1, 4), evaluate=False)
+    assert -1 in Difference(S.Reals, S.Naturals, evaluate=False)
+    assert not 1 in Difference(S.Reals, S.Naturals, evaluate=False)
 
 
 def test_complement():

--- a/sympy/core/tests/test_sets.py
+++ b/sympy/core/tests/test_sets.py
@@ -134,6 +134,8 @@ def test_Difference():
     assert -1 in Difference(S.Reals, S.Naturals, evaluate=False)
     assert not 1 in Difference(S.Reals, S.Naturals, evaluate=False)
 
+    assert -1 in S.Reals - S.Naturals
+
 
 def test_complement():
     assert Interval(0, 1).complement == \

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -514,7 +514,9 @@ class Piecewise(Function):
 
     def as_expr_set_pairs(self):
         exp_sets = []
-        U = S.UniversalSet
+        # Not sure if this current, I mean can/do we have
+        # Piecewise in Complex domain
+        U = S.Reals
         for expr, cond in self.args:
             cond_int = U.intersect(cond.as_set())
             U = U - cond_int

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -144,9 +144,12 @@ class BooleanTrue(with_metaclass(Singleton, BooleanAtom)):
 
         >>> from sympy import true
         >>> true.as_set()
-        UniversalSet()
+        (-oo, oo)
         """
-        return S.UniversalSet
+        #XXX: It won't work
+        # It is impossible to have true as a set without having
+        # a universal set
+        return S.Reals
 
 
 class BooleanFalse(with_metaclass(Singleton, BooleanAtom)):

--- a/sympy/logic/tests/test_boolalg.py
+++ b/sympy/logic/tests/test_boolalg.py
@@ -559,7 +559,7 @@ def test_bool_as_set():
     assert And(x <= 2, x >= -2).as_set() == Interval(-2, 2)
     assert Or(x >= 2, x <= -2).as_set() == Interval(-oo, -2) + Interval(2, oo)
     assert Not(x > 2).as_set() == Interval(-oo, 2)
-    assert true.as_set() == S.UniversalSet
+    assert true.as_set() == S.Reals
     assert false.as_set() == EmptySet()
 
 
@@ -568,5 +568,5 @@ def test_multivariate_bool_as_set():
     x, y = symbols('x,y')
 
     assert And(x >= 0, y >= 0).as_set() == Interval(0, oo)*Interval(0, oo)
-    assert Or(x >= 0, y >= 0).as_set() == S.UniversalSet - \
+    assert Or(x >= 0, y >= 0).as_set() == S.Reals*S.Reals - \
         Interval(-oo, 0, True, True)*Interval(-oo, 0, True, True)


### PR DESCRIPTION
This pull request removes the UniversalSet class by introducing a set Difference class. The removal of UniversalSet was proposed [here](https://groups.google.com/forum/#!topic/sympy/KEPsVepimHs), though most of the people in the community have not expressed their options. 
