### PR TITLE
7450: add evalf method for atan2

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -804,6 +804,21 @@ def evalf_atan(v, prec, options):
     return mpf_atan(xre, prec, rnd), None, prec, None
 
 
+def evalf_atan2(v, prec, options):
+    x, y = v.args
+    xre, xim, reacc, imacc = evalf(x, prec + 5, options)
+    if xre is xim is None:
+        return (None,)*4
+    if xim:
+        raise NotImplementedError
+    yre, yim, reacc, imacc = evalf(y, prec + 5, options)
+    if yre is yim is None:
+        return (None,)*4
+    if yim:
+        raise NotImplementedError
+    return mpf_atan(xre, yre, prec, rnd), None, prec, None
+
+
 def evalf_subs(prec, subs):
     """ Change all Float entries in `subs` to have precision prec. """
     newsubs = {}
@@ -1163,6 +1178,7 @@ def _create_evalf_table():
 
         C.log: evalf_log,
         C.atan: evalf_atan,
+        C.atan2: evalf_atan2,
         C.Abs: evalf_abs,
 
         C.re: evalf_re,

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -1,6 +1,7 @@
 from sympy import (Add, ceiling, cos, E, Eq, exp, factorial, fibonacci, floor,
                    Function, GoldenRatio, I, log, Mul, oo, pi, Pow, Rational,
-                   sin, sqrt, sstr, Sum, sympify, S, integrate, atan, product)
+                   sin, sqrt, sstr, Sum, sympify, S, integrate, atan, product,
+                   Abs, polar_lift, atan2)
 from sympy.core.evalf import complex_accuracy, PrecisionExhausted, scaled_zero
 from sympy.core.compatibility import long
 from sympy.mpmath import inf, ninf, nan
@@ -416,3 +417,7 @@ def test_issue_6632_evalf():
     add = (-100000*sqrt(2500000001) + 5000000001)
     assert add.n() == 9.999999998e-11
     assert (add*add).n() == 9.999999996e-21
+
+
+def test_issue_7450():
+    assert atan2(0, Abs(polar_lift(-(1 + I)))).n() == 0


### PR DESCRIPTION
fixes #7450

```
>>> integrate(exp(-(1+I)*x), (x, 0, oo))
sqrt(2)*exp(-I*pi/4)/2
>>> nsimplify(_)
1/2 - I/2
```

That matches wolframalpha output.
