### PR TITLE
Added _eval_Abs for polar_lift

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -329,3 +329,4 @@ Sahil Shekhawat <sahilshekhawat01@gmail.com>
 Kundan Kumar <kundankumar18581@gmail.com>
 sevaader <sevaader@gmail.com>
 Lennart Fricke <lennart@die-frickes.eu>
+carstimon <carstimon@gmail.com>

--- a/doc/src/aboutus.rst
+++ b/doc/src/aboutus.rst
@@ -334,6 +334,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. Kundan Kumar: fixes to ODE identification of separable_reduced
 #. sevaader: fix to assumptions
 #. Lennart Fricke: make sure that cse avoids symbol collision
+#. carstimon: make Abs(polar_lift(arg)) -> abs(arg)
 
 Up-to-date list in the order of the first contribution is given in the `AUTHORS
 <https://github.com/sympy/sympy/blob/master/AUTHORS>`_ file.

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -663,6 +663,9 @@ class polar_lift(Function):
         """ Careful! any evalf of polar numbers is flaky """
         return self.args[0]._eval_evalf(prec)
 
+    def _eval_Abs(self):
+        return Abs(self.args[0], evaluate=True)
+
 
 class periodic_argument(Function):
     """

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -560,7 +560,8 @@ def test_periodic_argument():
     assert periodic_argument(2*p, p) == periodic_argument(p, p)
     assert periodic_argument(pi*p, p) == periodic_argument(p, p)
 
-    assert Abs(polar_lift(1+I)) == Abs(1+I)
+    assert Abs(polar_lift(1 + I)) == Abs(1 + I)
+
 
 @XFAIL
 def test_principal_branch_fail():

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -560,6 +560,7 @@ def test_periodic_argument():
     assert periodic_argument(2*p, p) == periodic_argument(p, p)
     assert periodic_argument(pi*p, p) == periodic_argument(p, p)
 
+    assert Abs(polar_lift(1+I)) == Abs(1+I)
 
 @XFAIL
 def test_principal_branch_fail():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -283,6 +283,9 @@ def test_issue_3952():
 def test_issue_4516():
     assert integrate(2**x - 2*x, x) == 2**x/log(2) - x**2
 
+def test_issue_7450():
+    ans = integrate(exp(-(1+I)*x), (x, 0, oo))
+    assert re(ans)==S.Half and im(ans) == -S.Half
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -4,7 +4,7 @@ from sympy import (
     Heaviside, I, Integral, integrate, Interval, Lambda, LambertW, log,
     Matrix, O, oo, pi, Piecewise, Poly, Rational, S, simplify, sin, tan, sqrt,
     sstr, Sum, Symbol, symbols, sympify, terms_gcd, transpose, trigsimp,
-    Tuple, nan, And, Eq, Or
+    Tuple, nan, And, Eq, Or, re, im
 )
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.utilities.pytest import XFAIL, raises, slow
@@ -283,9 +283,11 @@ def test_issue_3952():
 def test_issue_4516():
     assert integrate(2**x - 2*x, x) == 2**x/log(2) - x**2
 
+
 def test_issue_7450():
-    ans = integrate(exp(-(1+I)*x), (x, 0, oo))
-    assert re(ans)==S.Half and im(ans) == -S.Half
+    ans = integrate(exp(-(1 + I)*x), (x, 0, oo))
+    assert re(ans) == S.Half and im(ans) == -S.Half
+
 
 def test_matrices():
     M = Matrix(2, 2, lambda i, j: (i + j + 1)*sin((i + j + 1)*x))


### PR DESCRIPTION
Abs is the same on every branch, so this is ok.
fixes #7450

```
>>> Abs(polar_lift(-1-I))
sqrt(2)
>>> integrate(exp(-(1+I)*x), (x, 0, oo))
sqrt(2)*exp(-I*pi/4)/2
```

Added a test for Abs(polar_lift(..))
