### PR TITLE
add free_symbols method to MatrixBase

### DIFF
--- a/sympy/logic/tests/test_dimacs.py
+++ b/sympy/logic/tests/test_dimacs.py
@@ -74,10 +74,11 @@ p cnf 6 9
 """
 
 f4 = """c
+c file:   hole6.cnf [http://people.sc.fsu.edu/~jburkardt/data/cnf/hole6.cnf]
 c
 c SOURCE: John Hooker (jh38+@andrew.cmu.edu)
 c
-c DESCRIPTION: Pigeon hole problem of placing n (for file holen) pigeons
+c DESCRIPTION: Pigeon hole problem of placing n (for file 'holen.cnf') pigeons
 c              in n+1 holes without placing 2 pigeons in the same hole
 c
 c NOTE: Part of the collection at the Forschungsinstitut fuer

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1102,6 +1102,9 @@ class MatrixBase(object):
     def atoms(self, *types):
         """Returns the atoms that form the current object.
 
+        Examples
+        ========
+
         >>> from sympy.abc import x, y
         >>> from sympy.matrices import Matrix
         >>> Matrix([[x]])
@@ -1119,6 +1122,21 @@ class MatrixBase(object):
         for i in self:
             result.update( i.atoms(*types) )
         return result
+
+    @property
+    def free_symbols(self):
+        """Returns the free symbols within the matrix.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import x
+        >>> from sympy.matrices import Matrix
+        >>> Matrix([[x], [1]]).free_symbols
+        set([x])
+        """
+
+        return set.union(*[i.free_symbols for i in self])
 
     def subs(self, *args, **kwargs):  # should mirror core.basic.subs
         """Return a new matrix with subs applied to each entry.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2371,3 +2371,7 @@ def test_pinv_rank_deficient():
 def test_issue_7201():
     assert ones(0, 1) + ones(0, 1) == Matrix(0, 1, [])
     assert ones(1, 0) + ones(1, 0) == Matrix(1, 0, [])
+
+def test_free_symbols():
+    for M in ImmutableMatrix, ImmutableSparseMatrix, Matrix, SparseMatrix:
+        assert M([[x], [0]]).free_symbols == set([x])


### PR DESCRIPTION
This allows Matrix(...).free_symbols to work now.

fixes #7204
