### PR TITLE
4873: fix link to geometry plotting

### DIFF
--- a/doc/src/modules/geometry.rst
+++ b/doc/src/modules/geometry.rst
@@ -196,7 +196,7 @@ Geometry Visualization
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The plotting module is capable of plotting geometric entities. See
-`Plotting Geometric Entities <https://github.com/sympy/sympy/wiki>`_ in
+:ref:`Plotting Geometric Entities <plot_geom>` in
 the plotting module entry.
 
 API Reference

--- a/doc/src/modules/plotting.rst
+++ b/doc/src/modules/plotting.rst
@@ -258,6 +258,8 @@ the following alternative syntax:
 
 You can still use multi-step gradients with three-function color schemes.
 
+.. _plot_geom:
+
 Plotting Geometric Entities
 ---------------------------
 


### PR DESCRIPTION
fixes #4873 , adding a link to the relevant page about plotting geometric objects
