### PR TITLE
Enables ccode(..., user_functions={..., 'Pow': ...})

### DIFF
--- a/sympy/printing/ccode.py
+++ b/sympy/printing/ccode.py
@@ -129,6 +129,8 @@ class CCodePrinter(CodePrinter):
         return open_lines, close_lines
 
     def _print_Pow(self, expr):
+        if "Pow" in self.known_functions:
+            return self._print_Function(expr)
         PREC = precedence(expr)
         if expr.exp == -1:
             return '1.0/%s' % (self.parenthesize(expr.base, PREC))

--- a/sympy/printing/tests/test_ccode.py
+++ b/sympy/printing/tests/test_ccode.py
@@ -32,6 +32,10 @@ def test_ccode_Pow():
         "pow(3.5*g(x), -x + pow(y, x))/(pow(x, 2) + y)"
     assert ccode(x**-1.0) == '1.0/x'
     assert ccode(x**Rational(2, 3)) == 'pow(x, 2.0L/3.0L)'
+    _cond_cfunc = [(lambda base, exp: exp.is_integer, "dpowi"),
+                   (lambda base, exp: not exp.is_integer, "pow")]
+    assert ccode(x**3, user_functions={'Pow': _cond_cfunc}) == 'dpowi(x, 3)'
+    assert ccode(x**3.2, user_functions={'Pow': _cond_cfunc}) == 'pow(x, 3.2)'
 
 
 def test_ccode_constants_mathh():


### PR DESCRIPTION
pow(double, double) in math.h is not efficient for expressions like:
pow(1.14, 2) etc. where the exponent is a small integer. For other functions
one can use `user_functions` kwarg in ccode to give own versions. This PR
enables "Pow" to be a valid key too. (Note that fortran has language level support for Pow,
and hence need no such options).
