### PR TITLE
modify/correct Integral.is_number

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -866,6 +866,17 @@ def as_mpmath(x, prec, options):
 def do_integral(expr, prec, options):
     func = expr.args[0]
     x, xlow, xhigh = expr.args[1]
+    if xlow == xhigh:
+        xlow = xhigh = 0
+    elif x not in func.free_symbols:
+        # only the difference in limits matters in this case
+        # so if there is a symbol in common that will cancel
+        # out when taking the difference, then use that
+        # difference
+        if xhigh.free_symbols & xlow.free_symbols:
+            diff = xhigh - xlow
+            if not diff.free_symbols:
+                xlow, xhigh = 0, diff
     orig = mp.prec
 
     oldmaxprec = options.get('maxprec', DEFAULT_MAXPREC)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -171,6 +171,18 @@ class Integral(AddWithLimits):
         >>> Integral(1, x, (x, 1, 2)).is_number
         True
 
+        Notes
+        =====
+
+        There are two non-heroic tests that are made here to recognize
+        situations where a free symbol is not actually free: when the upper
+        and lower limits are the same and when an integration variable is
+        not in the free symbols (in which case only free symbols of the
+        difference in limits are potential free symbols). The tests are of
+        the most trivial nature, however, and it should always be true that if
+        this routine returns True that evalf should be able to evaluate the
+        expression.
+
         See Also
         ========
 
@@ -178,22 +190,37 @@ class Integral(AddWithLimits):
         """
 
         integrand, limits = self.function, self.limits
-        isyms = integrand.atoms(Symbol)
+        isyms = integrand.free_symbols
         for xab in limits:
             if len(xab) == 1:
                 isyms.add(xab[0])
                 continue  # it may be removed later
-            elif len(xab) == 3 and xab[1] == xab[2]:  # XXX naive equality test
-                return True  # integral collapsed
+
+            if len(xab) == 3 and xab[1] == xab[2]:
+                # this is a non-heroic test and evalf knows about it
+                return True
+
             if xab[0] in isyms:
-                # take it out of the symbols since it will be replace
-                # with whatever the limits of the integral are
+                # take it out of the symbols since it will be replaced
+                # with the free symbols in the limits
                 isyms.remove(xab[0])
+            elif len(xab) == 3:
+                # the integration variable isn't in the free symbols so
+                # integration will introduce a linear factor and any
+                # expression in the lower and upper limit that doesn't
+                # appear in the difference of those limits will cancel
+                # and thus NOT add to the free symbols, e.g.
+                # Integral(x, (y, d, d + 1)) == Integral(x, (y, 0, 1)).
+                # This is a non-heroic test and evalf knows about it
+                isyms.update((xab[2] - xab[1]).free_symbols)
+                continue
+
             # add in the new symbols
             for i in xab[1:]:
                 isyms.update(i.free_symbols)
+
         # if there are no surviving symbols then the result is a number
-        return len(isyms) == 0
+        return not isyms
 
     def transform(self, x, u):
         r"""

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -670,6 +670,7 @@ def test_is_number():
     assert Integral(1, (x, 1)).is_number is True
     assert Integral(1, (x, 1, 2)).is_number is True
     assert Integral(1, (x, 1, y)).is_number is False
+    assert Integral(1, (x, y)).is_number is False
     assert Integral(x, y).is_number is False
     assert Integral(x, (y, 1, x)).is_number is False
     assert Integral(x, (y, 1, 2)).is_number is False

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -674,11 +674,17 @@ def test_is_number():
     assert Integral(x, (y, 1, x)).is_number is False
     assert Integral(x, (y, 1, 2)).is_number is False
     assert Integral(x, (x, 1, 2)).is_number is True
-    assert Integral(x, (y, 1, 1)).is_number is True
+    i = Integral(x, (y, 1, 1))
+    assert i.is_number is True and i.n() == 0
+    i = Integral(x, (y, z, z))
+    assert i.is_number is True and i.n() == 0
+    i = Integral(1, (y, z, z + 2))
+    assert i.is_number is True and i.n() == 2
     assert Integral(x*y, (x, 1, 2), (y, 1, 3)).is_number is True
     assert Integral(x*y, (x, 1, 2), (y, 1, z)).is_number is False
     assert Integral(x, (x, 1)).is_number is True
     assert Integral(x, (x, 1, Integral(y, (y, 1, 2)))).is_number is True
+    assert Integral(Sum(z, (z, 1, 2)), (x, 1, 2)).is_number is True
     # it is possible to get a false negative if the integrand is
     # actually an unsimplified zero, but this is true of is_number in general.
     assert Integral(sin(x)**2 + cos(x)**2 - 1, x).is_number is False


### PR DESCRIPTION
isyms should start with the free symbols of the integrand, not all
symbols.

A 2nd non-heroic test for a case where a free symbol will not
affect evaluation was added to is_number and to evalf for integrals.
If the variable of integration does not appear in the free symbols
then only the difference in the limits is of significance, e.g.

Integral(x, (y, d, d + 1)) will introduce a linear factor of y
and the value of d is not significant. This integral is the same
as Integral(x, (y, 0, 1)).
