### PR TITLE
Rewriting the Univariate Solver

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -274,6 +274,25 @@ class ImageSet(Set):
                 # since 'a' < 'b'
                 return imageset(Lambda(t, f.subs(a, solns[0][0])), S.Integers)
 
+        if other == S.Reals:
+            from sympy.solvers.solveset import solveset_real
+            from sympy.core.function import expand_complex
+            if len(self.lamda.variables) > 1:
+                return None
+
+            f = self.lamda.expr
+            n = self.lamda.variables[0]
+
+            n_ = Dummy(n.name, real=True)
+            f_ = f.subs(n, n_)
+
+            re, im = f_.as_real_imag()
+            im = expand_complex(im)
+
+            return imageset(Lambda(n_, re),
+                            self.base_set.intersect(
+                                solveset_real(im, n_)))
+
 
 @deprecated(useinstead="ImageSet", issue=7057, deprecated_since_version="0.7.4")
 def TransformationSet(*args, **kwargs):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -926,6 +926,10 @@ class Interval(Set, EvalfMixin):
         if other.is_real is False:
             return false
 
+        if self.start is S.NegativeInfinity and self.end is S.Infinity:
+            if not other.is_real is None:
+                return other.is_real
+
         if self.left_open:
             expr = other > self.start
         else:

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -1,7 +1,7 @@
 from sympy.sets.fancysets import ImageSet, Range
 from sympy.sets.sets import FiniteSet, Interval, imageset, EmptySet
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
-        Rational, sqrt, Eq, tan)
+        Rational, sqrt, Eq, tan, log, Abs)
 from sympy.utilities.pytest import XFAIL, raises
 import itertools
 
@@ -225,6 +225,16 @@ def test_infinitely_indexed_set_2():
     assert imageset(Lambda(n, 2*n + pi), S.Integers) == ImageSet(Lambda(n, 2*n + pi), S.Integers)
     assert imageset(Lambda(n, pi*n + pi), S.Integers) == ImageSet(Lambda(n, pi*n + pi), S.Integers)
     assert imageset(Lambda(n, exp(n)), S.Integers) != imageset(Lambda(n, n), S.Integers)
+
+
+def test_imageset_intersect_real():
+    from sympy import I
+    from sympy.abc import n
+    assert imageset(Lambda(n, n + (n - 1)*(n + 1)*I), S.Integers).intersect(S.Reals) == \
+            FiniteSet(-1, 1)
+
+    s = ImageSet(Lambda(n, -I*(I*(2*pi*n - pi/4) + log(Abs(sqrt(-I))))), S.Integers)
+    assert s.intersect(S.Reals) == imageset(Lambda(n, 2*n*pi - pi/4), S.Integers)
 
 
 @XFAIL

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -431,6 +431,9 @@ def test_contains():
     assert S.EmptySet.contains(1) is S.false
     assert FiniteSet(RootOf(x**3 + x - 1, 0)).contains(S.Infinity) is S.false
 
+    assert RootOf(x**5 + x**3 + 1, 0) in S.Reals
+    assert not RootOf(x**5 + x**3 + 1, 1) in S.Reals
+
 
 def test_interval_symbolic():
     x = Symbol('x')

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1,0 +1,863 @@
+"""
+This module contains functions to solve a single equation for a single variable.
+"""
+from __future__ import print_function, division
+
+from sympy.core.sympify import sympify
+from sympy.core import S, Pow, Dummy, pi, C, Expr, Wild, Mul
+from sympy.core.numbers import I, Number, Rational
+from sympy.core.function import (Lambda, expand, expand_complex)
+from sympy.core.relational import Eq
+from sympy.core.symbol import Symbol
+from sympy.simplify.simplify import fraction, trigsimp
+from sympy.functions import (log, Abs, tan, cot, exp,
+                             arg, Piecewise, piecewise_fold)
+from sympy.sets import FiniteSet, EmptySet, imageset, Union
+from sympy.polys import (roots, Poly, degree, together, PolynomialError,
+                         RootOf)
+from sympy.solvers.solvers import checksol
+from sympy.utilities import filldedent
+
+import warnings
+
+
+def invert_real(f_x, y, x):
+    """ Inverts a real valued function
+
+    Reduces the real valued equation ``f(x) = y`` to a set of equations ``{g(x)
+    = h_1(y), g(x) = h_2(y), ..., g(x) = h_n(y) }`` where ``g(x)`` is a simpler
+    function than ``f(x)``.  The return value is a tuple ``(g(x), set_h)``,
+    where ``g(x)`` is a function of ``x`` and ``set_h`` is the set of
+    functions ``{h_1(y), h_2(y), ..., h_n(y)}``.
+    Here, ``y`` is not necessarily a symbol.
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.solveset import invert_real
+    >>> from sympy import tan, Abs, exp
+    >>> from sympy.abc import x, y, n
+    >>> invert_real(exp(Abs(x)), y, x)
+    (x, {-log(y), log(y)})
+    >>> invert_real(exp(x), 1, x)
+    (x, {0})
+    >>> invert_real(Abs(x**31 + x), y, x)
+    (x**31 + x, {-y, y})
+    >>> invert_real(tan(x), y, x)
+    (x, ImageSet(Lambda(_n, _n*pi + atan(y)), Integers()))
+
+    See Also
+    ========
+    invert_complex
+    """
+    y = sympify(y)
+    if not y.has(x):
+        return _invert_real(f_x, FiniteSet(y), x)
+    else:
+        raise ValueError(" y should be independent of x ")
+
+
+def _invert_real(f, g_ys, symbol):
+    """ Helper function for invert_real """
+
+    if not f.has(symbol):
+        raise ValueError("Inverse of constant function doesn't exist")
+
+    if f is symbol:
+        return (f, g_ys)
+
+    n = Dummy('n')
+    if hasattr(f, 'inverse') and not isinstance(f, C.TrigonometricFunction):
+        if len(f.args) > 1:
+            raise ValueError("Only functions with one argument are supported.")
+        return _invert_real(f.args[0],
+                            imageset(Lambda(n, f.inverse()(n)), g_ys), symbol)
+
+    if isinstance(f, Abs):
+        return _invert_real(f.args[0],
+                            Union(g_ys, imageset(Lambda(n, -n), g_ys)), symbol)
+
+    if f.is_Add:
+        # f = g + h
+        g, h = f.as_independent(symbol)
+        if g != S.Zero:
+            return _invert_real(h, imageset(Lambda(n, n - g), g_ys), symbol)
+
+    if f.is_Mul:
+        # f = g*h
+        g, h = f.as_independent(symbol)
+
+        if g != S.One:
+            return _invert_real(h, imageset(Lambda(n, n/g), g_ys), symbol)
+
+    if f.is_Pow:
+        base, expo = f.args
+        base_has_sym = base.has(symbol)
+        expo_has_sym = expo.has(symbol)
+
+        if not expo_has_sym:
+            res = imageset(Lambda(n, Pow(n, 1/expo)), g_ys)
+            if expo.is_rational:
+                numer, denom = expo.as_numer_denom()
+                if numer == S.One or numer == - S.One:
+                    return _invert_real(base, res, symbol)
+                else:
+                    if numer % 2 == 0:
+                        n = Dummy('n')
+                        neg_res = imageset(Lambda(n, -n), res)
+                        return _invert_real(base, res + neg_res, symbol)
+                    else:
+                        return _invert_real(base, res, symbol)
+            else:
+                if not base.is_positive:
+                    raise ValueError("x**w where w is irrational is not"
+                                     "defined for negative x")
+                return _invert_real(base, res, symbol)
+
+        if not base_has_sym:
+            return _invert_real(expo, imageset(Lambda(n, log(n)/log(base)),
+                                               g_ys), symbol)
+
+    if isinstance(f, tan) or isinstance(f, cot):
+        n = Dummy('n')
+        if isinstance(g_ys, FiniteSet):
+            tan_cot_invs = Union(*[imageset(Lambda(n, n*pi + f.inverse()(g_y)),
+                                            S.Integers) for g_y in g_ys])
+            return _invert_real(f.args[0], tan_cot_invs, symbol)
+
+    return (f, g_ys)
+
+
+def invert_complex(f_x, y, x):
+    """ Inverts a complex valued function.
+
+    Reduces the complex valued equation ``f(x) = y`` to a set of equations
+    ``{g(x) = h_1(y), g(x) = h_2(y), ..., g(x) = h_n(y) }`` where ``g(x)`` is
+    a simpler function than ``f(x)``.  The return value is a tuple ``(g(x),
+    set_h)``, where ``g(x)`` is a function of ``x`` and ``set_h`` is
+    the set of function ``{h_1(y), h_2(y), ..., h_n(y)}``.
+    Here, ``y`` is not necessarily a symbol.
+
+    Note that `invert_complex` and `invert_real` don't always produce the
+    same result even for a seemingly simple function like ``exp(x)`` because
+    the complex extension of real valued ``log`` is multivariate in the complex
+    system and has infinitely many branches. If you are working with real
+    values only or you are not sure with function to use you should use
+    `invert_real`.
+
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.solveset import invert_complex
+    >>> from sympy.abc import x, y
+    >>> from sympy import exp, log
+    >>> invert_complex(log(x), y, x)
+    (x, {exp(y)})
+    >>> invert_complex(log(x), 0, x)  # Second parameter is not a symbol
+    (x, {1})
+    >>> invert_complex(exp(x), y, x)
+    (x, ImageSet(Lambda(_n, I*(2*_n*pi + arg(y)) + log(Abs(y))), Integers()))
+
+    See Also
+    ========
+    invert_real
+    """
+    y = sympify(y)
+    if not y.has(x):
+        return _invert_complex(f_x, FiniteSet(y), x)
+    else:
+        raise ValueError(" y should be independent of x ")
+
+
+def _invert_complex(f, g_ys, symbol):
+    """ Helper function for invert_complex """
+
+    if not f.has(symbol):
+        raise ValueError("Inverse of constant function doesn't exist")
+
+    if f is symbol:
+        return (f, g_ys)
+
+    n = Dummy('n')
+    if f.is_Add:
+        # f = g + h
+        g, h = f.as_independent(symbol)
+        if g != S.Zero:
+            return _invert_complex(h, imageset(Lambda(n, n - g), g_ys), symbol)
+
+    if f.is_Mul:
+        # f = g*h
+        g, h = f.as_independent(symbol)
+
+        if g != S.One:
+            return _invert_complex(h, imageset(Lambda(n, n/g), g_ys), symbol)
+
+    if hasattr(f, 'inverse') and \
+       not isinstance(f, C.TrigonometricFunction) and \
+       not isinstance(f, exp):
+        if len(f.args) > 1:
+            raise ValueError("Only functions with one argument are supported.")
+        return _invert_complex(f.args[0],
+                               imageset(Lambda(n, f.inverse()(n)), g_ys), symbol)
+
+    if isinstance(f, exp):
+        if isinstance(g_ys, FiniteSet):
+            exp_invs = Union(*[imageset(Lambda(n, I*(2*n*pi + arg(g_y)) +
+                                               log(Abs(g_y))), S.Integers)
+                               for g_y in g_ys])
+            return _invert_complex(f.args[0], exp_invs, symbol)
+    return (f, g_ys)
+
+
+def domain_check(f, symbol, p):
+    """Returns False if point p is infinite or any subexpression of f
+    is infinite or becomes so after replacing symbol with p. If none of
+    these conditions is met then True will be returned.
+
+    Examples
+    ========
+
+    >>> from sympy import Mul, oo
+    >>> from sympy.abc import x
+    >>> from sympy.solvers.solveset import domain_check
+    >>> g = 1/(1 + (1/(x + 1))**2)
+    >>> domain_check(g, x, -1)
+    False
+    >>> domain_check(x**2, x, 0)
+    True
+    >>> domain_check(1/x, x, oo)
+    False
+
+    The function relies on the assumption that the original form
+    of the equation has not been changed by automatic simplification.
+
+    >>> domain_check(x/x, x, 0) # x/x is automatically simplified to 1
+    True
+
+    To deal with automatic evaluations use evaluate=False:
+
+    >>> domain_check(Mul(x, 1/x, evaluate=False), x, 0)
+    False
+    """
+    f, p = sympify(f), sympify(p)
+    if p.is_infinite:
+        return False
+    return _domain_check(f, symbol, p)
+
+
+def _domain_check(f, symbol, p):
+    # helper for domain check
+    if f.is_Atom and f.is_finite:
+        return True
+    elif f.subs(symbol, p).is_infinite:
+        return False
+    else:
+        return all([_domain_check(g, symbol, p)
+                    for g in f.args])
+
+
+def _is_finite_with_finite_vars(f):
+    """
+    Return True if the given expression is finite when all free symbols
+    (that are not already specified as finite) are made finite.
+    """
+    reps = dict([(s, Dummy(s.name, finite=True, **s.assumptions0))
+                for s in f.free_symbols if s.is_finite is None])
+    return f.xreplace(reps).is_finite
+
+
+def _is_function_class_equation(func_class, f, symbol):
+    """ Tests whether the equation is an equation of the given function class.
+
+    The given equation belongs to the given function class if it is
+    comprised of functions of the function class which are multiplied by
+    or added to expressions independent of the symbol. In addition, the
+    arguments of all such functions must be linear in the symbol as well.
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.solveset import _is_function_class_equation
+    >>> from sympy import C, tan, sin, tanh, sinh, exp
+    >>> from sympy.abc import x
+    >>> _is_function_class_equation(C.TrigonometricFunction, exp(x) + tan(x), x)
+    False
+    >>> _is_function_class_equation(C.TrigonometricFunction, tan(x) + sin(x), x)
+    True
+    >>> _is_function_class_equation(C.TrigonometricFunction, tan(x**2), x)
+    False
+    >>> _is_function_class_equation(C.TrigonometricFunction, tan(x + 2), x)
+    True
+    >>> _is_function_class_equation(C.HyperbolicFunction, tanh(x) + sinh(x), x)
+    True
+    """
+    if f.is_Mul or f.is_Add:
+        return all(_is_function_class_equation(func_class, arg, symbol)
+                   for arg in f.args)
+
+    if f.is_Pow:
+        if not f.exp.has(symbol):
+            return _is_function_class_equation(func_class, f.base, symbol)
+        else:
+            return False
+
+    if not f.has(symbol):
+        return True
+
+    if isinstance(f, func_class):
+        try:
+            g = Poly(f.args[0], symbol)
+            return g.degree() <= 1
+        except PolynomialError:
+            return False
+    else:
+        return False
+
+
+def solveset_real(f, symbol):
+    """ Solves a real valued equation.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The target equation
+    symbol : Symbol
+        The variable for which the equation is solved
+
+    Returns
+    =======
+
+    Set
+        A set of values for `symbol` for which `f` is equal to
+        zero. An `EmptySet` is returned if no solution is found.
+
+    `solveset_real` claims to be complete in the set of the solution it
+    returns.
+
+    Raises
+    ======
+
+    NotImplementedError
+        The algorithms for to find the solution of the given equation are
+        not yet implemented.
+    ValueError
+        The input is not valid.
+    RuntimeError
+        It is a bug, please report to the github issue tracker.
+
+
+    See Also
+    =======
+
+    solveset_complex : solver for complex domain
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, exp, sin, sqrt, I
+    >>> from sympy.solvers.solveset import solveset_real
+    >>> x = Symbol('x', real=True)
+    >>> a = Symbol('a', real=True, finite=True, positive=True)
+    >>> solveset_real(x**2 - 1, x)
+    {-1, 1}
+    >>> solveset_real(sqrt(5*x + 6) - 2 - x, x)
+    {-1, 2}
+    >>> solveset_real(x - I, x)
+    EmptySet()
+    >>> solveset_real(x - a, x)
+    {a}
+    >>> solveset_real(exp(x) - a, x)
+    {log(a)}
+
+    In case the equation has infinitely many solutions an infinitely indexed
+    `ImageSet` is returned.
+
+    >>> solveset_real(sin(x) - 1, x)
+    ImageSet(Lambda(_n, 2*_n*pi + pi/2), Integers())
+
+    If the equation is true for any arbitrary value of the symbol a `S.Reals`
+    set is returned.
+
+    >>> solveset_real(x - x, x)
+    (-oo, oo)
+
+    """
+    if not symbol.is_Symbol:
+        raise ValueError(" %s is not a symbol" % (symbol))
+
+    f = sympify(f)
+    if not isinstance(f, (Expr, Number)):
+        raise ValueError(" %s is not a valid sympy expression" % (f))
+
+    original_eq = f
+    f = together(f)
+
+    if f.has(Piecewise):
+        f = piecewise_fold(f)
+    result = EmptySet()
+
+    if f.expand().is_zero:
+        return S.Reals
+    elif not f.has(symbol):
+        return EmptySet()
+    elif f.is_Mul and all([_is_finite_with_finite_vars(m) for m in f.args]):
+        # if f(x) and g(x) are both finite we can say that the solution of
+        # f(x)*g(x) == 0 is same as Union(f(x) == 0, g(x) == 0) is not true in
+        # general. g(x) can grow to infinitely large for the values where
+        # f(x) == 0. To be sure that we not are silently allowing any
+        # wrong solutions we are using this technique only if both f and g and
+        # finite for a finite input.
+        result = Union(*[solveset_real(m, symbol) for m in f.args])
+    elif _is_function_class_equation(C.TrigonometricFunction, f, symbol) or \
+            _is_function_class_equation(C.HyperbolicFunction, f, symbol):
+        result = _solve_real_trig(f, symbol)
+    elif f.is_Piecewise:
+        result = EmptySet()
+        expr_set_pairs = f.as_expr_set_pairs()
+        for (expr, in_set) in expr_set_pairs:
+            solns = solveset_real(expr, symbol).intersect(in_set)
+            result = result + solns
+    else:
+        lhs, rhs_s = invert_real(f, 0, symbol)
+        if lhs == symbol:
+            result = rhs_s
+        elif isinstance(rhs_s, FiniteSet):
+            equations = [lhs - rhs for rhs in rhs_s]
+            for equation in equations:
+                if equation == f:
+                    if any(_has_rational_power(g, symbol)[0]
+                           for g in equation.args):
+                        result += _solve_radical(equation,
+                                                 symbol,
+                                                 solveset_real)
+                    elif equation.has(Abs):
+                        result += _solve_abs(f, symbol)
+                    else:
+                        result += _solve_as_rational(equation, symbol,
+                                                     solveset_solver=solveset_real,
+                                                     as_poly_solver=_solve_as_poly_real)
+                else:
+                    result += solveset_real(equation, symbol)
+        else:
+            raise NotImplementedError
+
+    if isinstance(result, FiniteSet):
+        result = [s for s in result
+                  if isinstance(s, RootOf)
+                  or domain_check(original_eq, symbol, s)]
+        return FiniteSet(*result).intersect(S.Reals)
+    else:
+        return result.intersect(S.Reals)
+
+
+def _solve_as_rational(f, symbol, solveset_solver, as_poly_solver):
+    """ solve rational functions"""
+    f = together(f, deep=True)
+    g, h = fraction(f)
+    if not h.has(symbol):
+        return as_poly_solver(g, symbol)
+    else:
+        valid_solns = solveset_solver(g, symbol)
+        invalid_solns = solveset_solver(h, symbol)
+        return valid_solns - invalid_solns
+
+
+def _solve_real_trig(f, symbol):
+    """ Helper to solve trigonometric equations """
+    f = trigsimp(f)
+    f = f.rewrite(exp)
+    f = together(f)
+    g, h = fraction(f)
+    y = Dummy('y')
+    g, h = g.expand(), h.expand()
+    g, h = g.subs(exp(I*symbol), y), h.subs(exp(I*symbol), y)
+    if g.has(symbol) or h.has(symbol):
+        raise NotImplementedError
+
+    solns = solveset_complex(g, y) - solveset_complex(h, y)
+
+    if isinstance(solns, FiniteSet):
+        return Union(*[invert_complex(exp(I*symbol), s, symbol)[1]
+                       for s in solns])
+    elif solns is S.EmptySet:
+        return S.EmptySet
+    else:
+        raise NotImplementedError
+
+
+def _solve_as_poly(f, symbol, solveset_solver, invert_func):
+    """
+    Solve the equation using polynomial techniques if it already is a
+    polynomial equation or, with a change of variables, can be made so.
+    """
+    result = None
+    if f.is_polynomial(symbol):
+
+        solns = roots(f, symbol, cubics=True, quartics=True,
+                      quintics=True, domain='EX')
+        num_roots = sum(solns.values())
+        if degree(f, symbol) <= num_roots:
+            result = FiniteSet(*solns.keys())
+        else:
+            poly = Poly(f, symbol)
+            solns = poly.all_roots()
+            if poly.degree() <= len(solns):
+                result = FiniteSet(*solns)
+            else:
+                raise NotImplementedError("Couldn't find all roots "
+                                          "of the equation %s" % f)
+    else:
+        poly = Poly(f)
+        if poly is None:
+            raise NotImplementedError("Could not convert %s to Poly" % f)
+        gens = [g for g in poly.gens if g.has(symbol)]
+
+        if len(gens) == 1:
+            poly = Poly(poly, gens[0])
+            gen = poly.gen
+            deg = poly.degree()
+            poly = Poly(poly.as_expr(), poly.gen, composite=True)
+            poly_solns = FiniteSet(*roots(poly, cubics=True, quartics=True,
+                                          quintics=True).keys())
+
+            if len(poly_solns) < deg:
+                raise NotImplementedError("Couldn't find all the roots of "
+                                          "the equation %s" % f)
+
+            if gen != symbol:
+                y = Dummy('y')
+                lhs, rhs_s = invert_func(gen, y, symbol)
+                result = Union(*[rhs_s.subs(y, s) for s in poly_solns])
+                if lhs is not symbol and lhs is not gen:
+                    result = Union(*[solveset_solver(lhs - rhs, symbol)
+                                     for rhs in result])
+                else:
+                    raise NotImplementedError
+        else:
+            raise NotImplementedError("multiple generators not handled"
+                                      " by solveset")
+
+    if result is not None:
+        if isinstance(result, FiniteSet):
+            # this is to simplify solutions like -sqrt(-I) to sqrt(2)/2
+            # - sqrt(2)*I/2. We are not expanding for solution with free
+            # variables because that makes the solution more complicated. For
+            # example expand_complex(a) returns re(a) + I*im(a)
+            if all([s.free_symbols == set() and not isinstance(s, RootOf)
+                    for s in result]):
+                s = Dummy('s')
+                result = imageset(Lambda(s, expand_complex(s)), result)
+        return result
+    else:
+        raise NotImplementedError
+
+
+def _solve_as_poly_real(f, symbol):
+    """
+    Solve real valued equation with methods to solve polynomial
+    equations.
+    """
+    return _solve_as_poly(f, symbol,
+                          solveset_solver=solveset_real,
+                          invert_func=invert_real)
+
+
+def _solve_as_poly_complex(f, symbol):
+    """
+    Solve complex valued equation with methods to solve polynomial
+    equations.
+    """
+    return _solve_as_poly(f, symbol,
+                          solveset_solver=solveset_complex,
+                          invert_func=invert_complex)
+
+
+def _has_rational_power(expr, symbol):
+    """
+    Returns (bool, den) where bool is True if the term has a
+    non-integer rational power and den is the denominator of the
+    expression's exponent.
+
+    Examples
+    ========
+
+    >>> from sympy.solvers.solveset import _has_rational_power
+    >>> from sympy import sqrt
+    >>> from sympy.abc import x
+    >>> _has_rational_power(sqrt(x), x)
+    (True, 2)
+    >>> _has_rational_power(x**2, x)
+    (False, 1)
+    """
+    a, p, q = Wild('a'), Wild('p'), Wild('q')
+    pattern_match = expr.match(a*p**q)
+    if pattern_match is None or pattern_match[a] is S.Zero:
+        return (False, S.One)
+    elif p not in pattern_match.keys() or a not in pattern_match.keys():
+        return (False, S.One)
+    elif isinstance(pattern_match[q], Rational) \
+            and pattern_match[p].has(symbol):
+        if not pattern_match[q].q == S.One:
+            return (True, pattern_match[q].q)
+
+    if not isinstance(pattern_match[a], Pow) \
+            or isinstance(pattern_match[a], Mul):
+        return (False, S.One)
+    else:
+        return _has_rational_power(pattern_match[a], symbol)
+
+
+def _solve_radical(f, symbol, solveset_solver):
+    """ Helper function to solve equations with radicals """
+    from sympy.solvers.solvers import unrad
+    try:
+        eq, cov, dens = unrad(f)
+        if cov == []:
+            result = solveset_solver(eq, symbol) - \
+                Union(*[solveset_solver(g, symbol) for g in dens])
+        else:
+            if len(cov) > 1:
+                raise NotImplementedError("Multivariate solver is "
+                                          "not implemented.")
+            else:
+                y = cov[0][0]
+                g_y_s = solveset_solver(cov[0][1], symbol)
+                f_y_sols = solveset_solver(eq, y)
+                result = Union(*[imageset(Lambda(y, g_y), f_y_sols)
+                                 for g_y in g_y_s])
+
+        return FiniteSet(*[s for s in result if checksol(f, symbol, s) is True])
+    except ValueError:
+        raise NotImplementedError
+
+
+def _solve_abs(f, symbol):
+    """ Helper function to solve equation involving absolute value function """
+    from sympy.solvers.inequalities import solve_univariate_inequality
+    assert f.has(Abs)
+    p, q, r = Wild('p'), Wild('q'), Wild('r')
+    pattern_match = f.match(p*Abs(q) + r)
+    if not pattern_match[p].is_zero:
+        f_p, f_q, f_r = pattern_match[p], pattern_match[q], pattern_match[r]
+        q_pos_cond = solve_univariate_inequality(f_q >= 0, symbol,
+                                                 relational=False)
+        q_neg_cond = solve_univariate_inequality(f_q < 0, symbol,
+                                                 relational=False)
+
+        sols_q_pos = solveset_real(f_p*f_q + f_r,
+                                           symbol).intersect(q_pos_cond)
+        sols_q_neg = solveset_real(f_p*(-f_q) + f_r,
+                                           symbol).intersect(q_neg_cond)
+        return Union(sols_q_pos, sols_q_neg)
+    else:
+        raise NotImplementedError
+
+
+def solveset_complex(f, symbol):
+    """ Solve a complex valued equation.
+
+    Parameters
+    ==========
+
+    f : Expr
+        The target equation
+    symbol : Symbol
+        The variable for which the equation is solved
+
+    Returns
+    =======
+
+    Set
+        A set of values for `symbol` for which `f` equal to
+        zero. An `EmptySet` is returned if no solution is found.
+
+    `solveset_complex` claims to be complete in the solution set that
+    it returns.
+
+    Raises
+    ======
+
+    NotImplementedError
+        The algorithms for to find the solution of the given equation are
+        not yet implemented.
+    ValueError
+        The input is not valid.
+    RuntimeError
+        It is a bug, please report to the github issue tracker.
+
+    See Also
+    ========
+
+    solveset_real: solver for real domain
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, exp
+    >>> from sympy.solvers.solveset import solveset_complex
+    >>> from sympy.abc import x, a, b, c
+    >>> solveset_complex(a*x**2 + b*x +c, x)
+    {-b/(2*a) - sqrt(-4*a*c + b**2)/(2*a), -b/(2*a) + sqrt(-4*a*c + b**2)/(2*a)}
+
+    Due to the fact that complex extension of my real valued functions are
+    multivariate even some simple equations can have infinitely many solution.
+
+    >>> solveset_complex(exp(x) - 1, x)
+    ImageSet(Lambda(_n, 2*_n*I*pi), Integers())
+
+    """
+    if not symbol.is_Symbol:
+        raise ValueError(" %s is not a symbol" % (symbol))
+
+    f = sympify(f)
+    original_eq = f
+    if not isinstance(f, (Expr, Number)):
+        raise ValueError(" %s is not a valid sympy expression" % (f))
+
+    f = together(f)
+    # Without this equations like a + 4*x**2 - E keep oscillating
+    # into form  a/4 + x**2 - E/4 and (a + 4*x**2 - E)/4
+    if not fraction(f)[1].has(symbol):
+        f = expand(f)
+
+    if f.is_zero:
+        raise NotImplementedError("S.Complex set is not yet implemented")
+    elif not f.has(symbol):
+        result = EmptySet()
+    elif f.is_Mul and all([_is_finite_with_finite_vars(m) for m in f.args]):
+        result = Union(*[solveset_complex(m, symbol) for m in f.args])
+    else:
+        lhs, rhs_s = invert_complex(f, 0, symbol)
+        if lhs == symbol:
+            result = rhs_s
+        elif isinstance(rhs_s, FiniteSet):
+            equations = [lhs - rhs for rhs in rhs_s]
+            result = EmptySet()
+            for equation in equations:
+                if equation == f:
+                    result += _solve_as_rational(equation, symbol,
+                                                 solveset_solver=solveset_complex,
+                                                 as_poly_solver=_solve_as_poly_complex)
+                else:
+                    result += solveset_complex(equation, symbol)
+        else:
+            raise NotImplementedError
+
+    if isinstance(result, FiniteSet):
+        result = [s for s in result
+                  if isinstance(s, RootOf)
+                  or domain_check(original_eq, symbol, s)]
+        return FiniteSet(*result)
+    else:
+        return result
+
+
+def solveset(f, symbol=None):
+    """Solves a given inequality or equation with set as output
+
+    Parameters
+    ==========
+
+    f : Expr or a relational.
+        The target equation or inequality
+    symbol : Symbol
+        The variable for which the equation is solved
+
+    Returns
+    =======
+
+    Set
+        A set of values for `symbol` for which `f` is True or is equal to
+        zero. An `EmptySet` is returned if no solution is found.
+
+    `solveset` claims to be complete in the solution set that it returns.
+
+    Raises
+    ======
+
+    NotImplementedError
+        The algorithms for to find the solution of the given equation are
+        not yet implemented.
+    ValueError
+        The input is not valid.
+    RuntimeError
+        It is a bug, please report to the github issue tracker.
+
+
+    `solveset` uses two underlying functions `solveset_real` and
+    `solveset_complex` to solve equations. They are
+    the solvers for real and complex domain respectively. The domain of
+    the solver is decided by the assumption on the variable for which the
+    equation is being solved.
+
+
+    See Also
+    ========
+
+    solveset_real: solver for real domain
+    solveset_complex: solver for complex domain
+
+    Examples
+    ========
+
+    >>> from sympy import exp, Symbol, Eq, pprint
+    >>> from sympy.solvers.solveset import solveset
+    >>> from sympy.abc import x
+
+    Symbols in Sympy are complex by default. A complex variable
+    will lead to the solving of the equation in complex domain
+    >>> pprint(solveset(exp(x) - 1, x), use_unicode=False)
+    {2*n*I*pi | n in Integers()}
+
+    If you want to solve equation in real domain by the `solveset`
+    interface, then specify the variable to real. Alternatively use
+    `solveset_real`.
+    >>> x = Symbol('x', real=True)
+    >>> solveset(exp(x) - 1, x)
+    {0}
+    >>> solveset(Eq(exp(x), 1), x)
+    {0}
+
+    Inequalities are always solved in the real domain irrespective of
+    the assumption on the variable for which the inequality is solved.
+    >>> solveset(exp(x) > 1, x)
+    (0, oo)
+
+    """
+
+    from sympy.solvers.inequalities import solve_univariate_inequality
+
+    if symbol is None:
+        free_symbols = f.free_symbols
+        if len(free_symbols) == 1:
+            symbol = free_symbols.pop()
+        else:
+            raise ValueError(filldedent('''
+                The independent variable must be specified for a
+                multivariate equation.'''))
+    elif not symbol.is_Symbol:
+        raise ValueError('A Symbol must be given, not type %s: %s' % (type(symbol), symbol))
+
+    real = (symbol.is_real is True)
+
+    f = sympify(f)
+
+    if isinstance(f, Eq):
+        f = f.lhs - f.rhs
+
+    if f.is_Relational:
+        if real is False:
+            warnings.warn(filldedent('''
+                The variable you are solving for is complex
+                but will assumed to be real since solving complex
+                inequalities is not supported.
+            '''))
+        return solve_univariate_inequality(f, symbol, relational=False)
+
+    if isinstance(f, (Expr, Number)):
+        if real is True:
+            return solveset_real(f, symbol)
+        else:
+            return solveset_complex(f, symbol)

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1,0 +1,797 @@
+from sympy import (
+    Abs, And, Derivative, Dummy, Eq, Float, Function, Gt, Integral,
+    LambertW, Lt, Matrix, Or, Piecewise, Poly, Q, Rational, S, Symbol, Wild,
+    acos, asin, atan, atanh, cos, cosh, diff, erf, erfinv, erfc, erfcinv, erf2,
+    erf2inv, exp, expand, im, log, pi, re, sec, sin, sinh, sqrt, sstr, symbols,
+    sympify, tan, tanh, simplify, atan2, arg, Mul, SparseMatrix, ask, C,
+    Lambda, imageset, cot, acot, I, EmptySet, Union, E, Interval, oo)
+
+from sympy.core.function import nfloat
+
+from sympy.polys.rootoftools import RootOf
+
+from sympy.sets import FiniteSet
+
+from sympy.utilities.pytest import slow, XFAIL, raises, skip
+from sympy.utilities.randtest import verify_numerically as tn
+from sympy.physics.units import cm
+
+
+from sympy.solvers.solveset import (
+    solveset_real, domain_check, solveset_complex,
+    _is_function_class_equation, invert_real, invert_complex, solveset)
+
+a = Symbol('a', real=True)
+b = Symbol('b', real=True)
+c = Symbol('c', real=True)
+x = Symbol('x', real=True)
+y = Symbol('y', real=True)
+z = Symbol('z', real=True)
+q = Symbol('q', real=True)
+m = Symbol('m', real=True)
+n = Symbol('n', real=True)
+
+
+def test_invert_real():
+    x = Symbol('x', real=True)
+    x = Dummy(real=True)
+    n = Symbol('n')
+    d = Dummy()
+    assert solveset(abs(x) - n, x) == solveset(abs(x) - d, x) == EmptySet()
+
+    n = Symbol('n', real=True)
+    assert invert_real(x + 3, y, x) == (x, FiniteSet(y - 3))
+    assert invert_real(x*3, y, x) == (x, FiniteSet(y / 3))
+
+    assert invert_real(exp(x), y, x) == (x, FiniteSet(log(y)))
+    assert invert_real(exp(3*x), y, x) == (x, FiniteSet(log(y) / 3))
+    assert invert_real(exp(x + 3), y, x) == (x, FiniteSet(log(y) - 3))
+
+    assert invert_real(exp(x) + 3, y, x) == (x, FiniteSet(log(y - 3)))
+    assert invert_real(exp(x)*3, y, x) == (x, FiniteSet(log(y / 3)))
+
+    assert invert_real(log(x), y, x) == (x, FiniteSet(exp(y)))
+    assert invert_real(log(3*x), y, x) == (x, FiniteSet(exp(y) / 3))
+    assert invert_real(log(x + 3), y, x) == (x, FiniteSet(exp(y) - 3))
+
+    assert invert_real(Abs(x), y, x) == (x, FiniteSet(-y, y))
+
+    assert invert_real(2**x, y, x) == (x, FiniteSet(log(y)/log(2)))
+    assert invert_real(2**exp(x), y, x) == (x, FiniteSet(log(log(y)/log(2))))
+
+    assert invert_real(x**2, y, x) == (x, FiniteSet(sqrt(y), -sqrt(y)))
+    assert invert_real(x**Rational(1, 2), y, x) == (x, FiniteSet(y**2))
+
+    raises(ValueError, lambda: invert_real(x, x, x))
+    raises(ValueError, lambda: invert_real(x**pi, y, x))
+    raises(ValueError, lambda: invert_real(S.One, y, x))
+
+    assert invert_real(x**31 + x, y, x) == (x**31 + x, FiniteSet(y))
+
+    assert invert_real(Abs(x**31 + x + 1), y, x) == (x**31 + x,
+                                                     FiniteSet(-y - 1, y - 1))
+
+    assert invert_real(tan(x), y, x) == \
+        (x, imageset(Lambda(n, n*pi + atan(y)), S.Integers))
+
+    assert invert_real(tan(exp(x)), y, x) == \
+        (x, imageset(Lambda(n, log(n*pi + atan(y))), S.Integers))
+
+    assert invert_real(cot(x), y, x) == \
+        (x, imageset(Lambda(n, n*pi + acot(y)), S.Integers))
+    assert invert_real(cot(exp(x)), y, x) == \
+        (x, imageset(Lambda(n, log(n*pi + acot(y))), S.Integers))
+
+    assert invert_real(tan(tan(x)), y, x) == \
+        (tan(x), imageset(Lambda(n, n*pi + atan(y)), S.Integers))
+
+    x = Symbol('x', positive=True)
+    assert invert_real(x**pi, y, x) == (x, FiniteSet(y**(1/pi)))
+
+
+def test_invert_complex():
+    assert invert_complex(x + 3, y, x) == (x, FiniteSet(y - 3))
+    assert invert_complex(x*3, y, x) == (x, FiniteSet(y / 3))
+
+    assert invert_complex(exp(x), y, x) == \
+        (x, imageset(Lambda(n, I*(2*pi*n + arg(y)) + log(Abs(y))), S.Integers))
+
+    assert invert_complex(log(x), y, x) == (x, FiniteSet(exp(y)))
+
+    raises(ValueError, lambda: invert_real(S.One, y, x))
+    raises(ValueError, lambda: invert_complex(x, x, x))
+
+
+def test_domain_check():
+    assert domain_check(1/(1 + (1/(x+1))**2), x, -1) is False
+    assert domain_check(x**2, x, 0) is True
+    assert domain_check(x, x, oo) is False
+    assert domain_check(0, x, oo) is False
+
+
+def test_is_function_class_equation():
+    from sympy.abc import x, a
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x), x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x) - 1, x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x) + sin(x), x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x) + sin(x) - a, x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       sin(x)*tan(x) + sin(x), x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       sin(x)*tan(x + a) + sin(x), x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       sin(x)*tan(x*a) + sin(x), x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       a*tan(x) - 1, x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x)**2 + sin(x) - 1, x) is True
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x**2), x) is False
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x**2) + sin(x), x) is False
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(x)**sin(x), x) is False
+    assert _is_function_class_equation(C.TrigonometricFunction,
+                                       tan(sin(x)) + sin(x), x) is False
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x), x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x) - 1, x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x) + sinh(x), x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x) + sinh(x) - a, x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       sinh(x)*tanh(x) + sinh(x), x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       sinh(x)*tanh(x + a) + sinh(x), x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       sinh(x)*tanh(x*a) + sinh(x), x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       a*tanh(x) - 1, x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x)**2 + sinh(x) - 1, x) is True
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x**2), x) is False
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x**2) + sinh(x), x) is False
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(x)**sinh(x), x) is False
+    assert _is_function_class_equation(C.HyperbolicFunction,
+                                       tanh(sinh(x)) + sinh(x), x) is False
+
+
+def test_garbage_input():
+    raises(ValueError, lambda: solveset_real([x], x))
+    raises(ValueError, lambda: solveset_real(x, pi))
+    raises(ValueError, lambda: solveset_real(x, x**2))
+
+    raises(ValueError, lambda: solveset_complex([x], x))
+    raises(ValueError, lambda: solveset_complex(x, pi))
+
+
+def test_solve_mul():
+    assert solveset_real((a*x + b)*(exp(x) - 3), x) == \
+        FiniteSet(-b/a, log(3))
+    assert solveset_real((2*x + 8)*(8 + exp(x)), x) == FiniteSet(S(-4))
+    assert solveset_real(x/log(x), x) == EmptySet()
+
+
+def test_solve_invert():
+    assert solveset_real(exp(x) - 3, x) == FiniteSet(log(3))
+    assert solveset_real(log(x) - 3, x) == FiniteSet(exp(3))
+
+    assert solveset_real(3**(x + 2), x) == FiniteSet()
+    assert solveset_real(3**(2 - x), x) == FiniteSet()
+
+    b = Symbol('b', positive=True)
+    y = Symbol('y', positive=True)
+    assert solveset_real(y - b*exp(a/x), x) == FiniteSet(a/log(y/b))
+    # issue 4504
+    assert solveset_real(2**x - 10, x) == FiniteSet(log(10)/log(2))
+
+
+def test_errorinverses():
+    assert solveset_real(erf(x) - S.One/2, x) == \
+        FiniteSet(erfinv(S.One/2))
+    assert solveset_real(erfinv(x) - 2, x) == \
+        FiniteSet(erf(2))
+    assert solveset_real(erfc(x) - S.One, x) == \
+        FiniteSet(erfcinv(S.One))
+    assert solveset_real(erfcinv(x) - 2, x) == FiniteSet(erfc(2))
+
+
+def test_solve_polynomial():
+    assert solveset_real(3*x - 2, x) == FiniteSet(Rational(2, 3))
+
+    assert solveset_real(x**2 - 1, x) == FiniteSet(-S(1), S(1))
+    assert solveset_real(x - y**3, x) == FiniteSet(y ** 3)
+
+    a11, a12, a21, a22, b1, b2 = symbols('a11, a12, a21, a22, b1, b2')
+
+    assert solveset_real(x**3 - 15*x - 4, x) == FiniteSet(
+        -2 + 3 ** Rational(1, 2),
+        S(4),
+        -2 - 3 ** Rational(1, 2))
+
+    assert solveset_real(sqrt(x) - 1, x) == FiniteSet(1)
+    assert solveset_real(sqrt(x) - 2, x) == FiniteSet(4)
+    assert solveset_real(x**Rational(1, 4) - 2, x) == FiniteSet(16)
+    assert solveset_real(x**Rational(1, 3) - 3, x) == FiniteSet(27)
+    assert len(solveset_real(x**5 + x**3 + 1, x)) == 1
+    assert len(solveset_real(-2*x**3 + 4*x**2 - 2*x + 6, x)) > 0
+
+
+def test_return_root_of():
+    f = x**5 - 15*x**3 - 5*x**2 + 10*x + 20
+    s = list(solveset_complex(f, x))
+    for root in s:
+        assert root.func == RootOf
+
+    # if one uses solve to get the roots of a polynomial that has a RootOf
+    # solution, make sure that the use of nfloat during the solve process
+    # doesn't fail. Note: if you want numerical solutions to a polynomial
+    # it is *much* faster to use nroots to get them than to solve the
+    # equation only to get RootOf solutions which are then numerically
+    # evaluated. So for eq = x**5 + 3*x + 7 do Poly(eq).nroots() rather
+    # than [i.n() for i in solve(eq)] to get the numerical roots of eq.
+    assert nfloat(list(solveset_complex(x**5 + 3*x**3 + 7, x))[0],
+                  exponent=False) == RootOf(x**5 + 3*x**3 + 7, 0).n()
+
+    sol = list(solveset_complex(x**6 - 2*x + 2, x))
+    assert all(isinstance(i, RootOf) for i in sol) and len(sol) == 6
+
+    f = x**5 - 15*x**3 - 5*x**2 + 10*x + 20
+    s = list(solveset_complex(f, x))
+    for root in s:
+        assert root.func == RootOf
+
+    s = x**5 + 4*x**3 + 3*x**2 + S(7)/4
+    assert solveset_complex(s, x) == \
+        FiniteSet(*Poly(s*4, domain='ZZ').all_roots())
+
+    # XXX: this comparison should work without converting the FiniteSet to list
+    # See #7876
+    eq = x*(x - 1)**2*(x + 1)*(x**6 - x + 1)
+    assert list(solveset_complex(eq, x)) == \
+        list(FiniteSet(-1, 0, 1, RootOf(x**6 - x + 1, 0),
+                       RootOf(x**6 - x + 1, 1),
+                       RootOf(x**6 - x + 1, 2),
+                       RootOf(x**6 - x + 1, 3),
+                       RootOf(x**6 - x + 1, 4),
+                       RootOf(x**6 - x + 1, 5)))
+
+
+def test__has_rational_power():
+    from sympy.solvers.solveset import _has_rational_power
+    assert _has_rational_power(sqrt(2), x)[0] is False
+    assert _has_rational_power(x*sqrt(2), x)[0] is False
+
+    assert _has_rational_power(x**2*sqrt(x), x) == (True, 2)
+    assert _has_rational_power(sqrt(2)*x**(S(1)/3), x) == (True, 3)
+    assert _has_rational_power(sqrt(x)*x**(S(1)/3), x) == (True, 6)
+
+
+def test_solveset_sqrt_1():
+    assert solveset_real(sqrt(5*x + 6) - 2 - x, x) == \
+        FiniteSet(-S(1), S(2))
+    assert solveset_real(sqrt(x - 1) - x + 7, x) == FiniteSet(10)
+    assert solveset_real(sqrt(x - 2) - 5, x) == FiniteSet(27)
+    assert solveset_real(sqrt(x) - 2 - 5, x) == FiniteSet(49)
+    assert solveset_real(sqrt(x**3), x) == FiniteSet(0)
+    assert solveset_real(sqrt(x - 1), x) == FiniteSet(1)
+
+
+def test_solveset_sqrt_2():
+    # http://tutorial.math.lamar.edu/Classes/Alg/SolveRadicalEqns.aspx#Solve_Rad_Ex2_a
+    assert solveset_real(sqrt(2*x - 1) - sqrt(x - 4) - 2, x) == \
+        FiniteSet(S(5), S(13))
+    assert solveset_real(sqrt(x + 7) + 2 - sqrt(3 - x), x) == \
+        FiniteSet(-6)
+    assert solveset_real(sqrt(17*x - sqrt(x**2 - 5)) - 7, x) == \
+        FiniteSet(3)
+
+    # http://www.purplemath.com/modules/solverad.htm
+    eq = x + 1 - (x**4 + 4*x**3 - x)**Rational(1, 4)
+    assert solveset_real(eq, x) == FiniteSet(-S(1)/2, -S(1)/3)
+
+    eq = sqrt(2*x + 9) - sqrt(x + 1) - sqrt(x + 4)
+    assert solveset_real(eq, x) == FiniteSet(0)
+
+    eq = sqrt(x + 4) + sqrt(2*x - 1) - 3*sqrt(x - 1)
+    assert solveset_real(eq, x) == FiniteSet(5)
+
+    eq = sqrt(x)*sqrt(x - 7) - 12
+    assert solveset_real(eq, x) == FiniteSet(16)
+
+    eq = sqrt(x - 3) + sqrt(x) - 3
+    assert solveset_real(eq, x) == FiniteSet(4)
+
+    eq = sqrt(9*x**2 + 4) - (3*x + 2)
+    assert solveset_real(eq, x) == FiniteSet(0)
+
+    assert solveset_real(sqrt(x - 3) - sqrt(x) - 3, x) == FiniteSet()
+
+    eq = (x**3 - 3*x**2)**Rational(1, 3) + 1 - x
+    assert solveset_real(eq, x) == FiniteSet()
+
+    eq = (2*x - 5)**Rational(1, 3) - 3
+    assert solveset_real(eq, x) == FiniteSet(16)
+
+    assert solveset_real(sqrt(x) + sqrt(sqrt(x)) - 4, x) == \
+        FiniteSet(-9*sqrt(17)/2 + 49*S.Half)
+
+    eq = sqrt(2*x**2 - 7) - (3 - x)
+    assert solveset_real(eq, x) == FiniteSet(-S(8), S(2))
+
+    eq = sqrt(x) - sqrt(x - 1) + sqrt(sqrt(x))
+    assert solveset_real(eq, x) == FiniteSet()
+
+    eq = (sqrt(x) + sqrt(x + 1) + sqrt(1 - x) - 6*sqrt(5)/5)
+    ans = solveset_real(eq, x)
+    ra = S('''-1484/375 - 4*(-1/2 + sqrt(3)*I/2)*(-12459439/52734375 +
+    114*sqrt(12657)/78125)**(1/3) - 172564/(140625*(-1/2 +
+    sqrt(3)*I/2)*(-12459439/52734375 + 114*sqrt(12657)/78125)**(1/3))''')
+    rb = S(4)/5
+    assert all(abs(eq.subs(x, i).n()) < 1e-10 for i in (ra, rb)) and \
+        len(ans) == 2 and \
+        set([i.n(chop=True) for i in ans]) == \
+        set([i.n(chop=True) for i in (ra, rb)])
+
+    assert solveset_real(sqrt(x) + x**Rational(1, 3) +
+                                 x**Rational(1, 4), x) == FiniteSet(0)
+
+    assert solveset_real(x/sqrt(x**2 + 1), x) == FiniteSet(0)
+
+    eq = (x - y**3)/((y**2)*sqrt(1 - y**2))
+    assert solveset_real(eq, x) == FiniteSet(y**3)
+
+    # issue 4497
+    assert solveset_real(1/(5 + x)**(S(1)/5) - 9, x) == \
+        FiniteSet(-295244/S(59049))
+
+
+@XFAIL
+def test_solve_sqrt_3():
+    R = Symbol('R')
+    eq = sqrt(2)*R*sqrt(1/(R + 1)) + (R + 1)*(sqrt(2)*sqrt(1/(R + 1)) - 1)
+    sol = solveset_complex(eq, R)
+
+    assert sol == FiniteSet(*[(S(5)/3 + 40/(3*(251 + 3*sqrt(111)*I)**(S(1)/3)) +
+                       (251 + 3*sqrt(111)*I)**(S(1)/3)/3,), ((-160 + (1 +
+                       sqrt(3)*I)*(10 - (1 + sqrt(3)*I)*(251 +
+                       3*sqrt(111)*I)**(S(1)/3))*(251 +
+                       3*sqrt(111)*I)**(S(1)/3))/Mul(6, (1 +
+                       sqrt(3)*I), (251 + 3*sqrt(111)*I)**(S(1)/3),
+                       evaluate=False),)])
+
+    eq = -sqrt((m - q)**2 + (-m/(2*q) + S(1)/2)**2) + sqrt((-m**2/2 - sqrt(
+        4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2 + (m**2/2 - m - sqrt(
+            4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)**2)
+    assert solveset_real(eq, q) == FiniteSet(
+        m**2/2 - sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4,
+        m**2/2 + sqrt(4*m**4 - 4*m**2 + 8*m + 1)/4 - S(1)/4)
+
+
+def test_solve_polynomial_symbolic_param():
+    assert solveset_complex((x**2 - 1)**2 - a, x) == \
+        FiniteSet(sqrt(1 + sqrt(a)), -sqrt(1 + sqrt(a)),
+                  sqrt(1 - sqrt(a)), -sqrt(1 - sqrt(a)))
+
+    # By attempt to make Set.contains behave symbolically SetDifference on
+    # FiniteSet isn't working very well.
+    # Simple operations like `FiniteSet(a) - FiniteSet(-b)` raises `TypeError`
+    # The likely course of action will making such operations return
+    # SetDifference object. That will also change the expected output of
+    # the given tests. Till the SetDifference becomes well behaving again the
+    # following tests are kept as comments.
+
+    # # issue 4508
+    # assert solveset_complex(y - b*x/(a + x), x) == \
+    #     FiniteSet(-a*y/(y - b))
+    #
+    # # issue 4507
+    # assert solveset_complex(y - b/(1 + a*x), x) == \
+    #     FiniteSet((b - y)/(a*y))
+
+
+def test_solve_rational():
+    assert solveset_real(1/x + 1, x) == FiniteSet(-S.One)
+    assert solveset_real(1/exp(x) - 1, x) == FiniteSet(0)
+    assert solveset_real(x*(1 - 5/x), x) == FiniteSet(5)
+    assert solveset_real(2*x/(x + 2) - 1, x) == FiniteSet(2)
+    assert solveset_real((x**2/(7 - x)).diff(x), x) == \
+        FiniteSet(S(0), S(14))
+
+
+def test_solveset_real_gen_is_pow():
+    assert solveset_real(sqrt(1) + 1, x) == EmptySet()
+
+
+def test_no_sol():
+    assert solveset_real(4, x) == EmptySet()
+    assert solveset_real(exp(x), x) == EmptySet()
+    assert solveset_real(x**2 + 1, x) == EmptySet()
+    assert solveset_real(-3*a/sqrt(x), x) == EmptySet()
+    assert solveset_real(1/x, x) == EmptySet()
+    assert solveset_real(-(1 + x)/(2 + x)**2 + 1/(2 + x), x) == \
+        EmptySet()
+
+
+def test_sol_zero_real():
+    assert solveset_real(0, x) == S.Reals
+    assert solveset_real(-x**2 - 2*x + (x + 1)**2 - 1, x) == S.Reals
+
+
+def test_no_sol_rational_extragenous():
+    assert solveset_real((x/(x + 1) + 3)**(-2), x) == EmptySet()
+    assert solveset_real((x - 1)/(1 + 1/(x - 1)), x) == EmptySet()
+
+
+def test_solve_polynomial_cv_1a():
+    """
+    Test for solving on equations that can be converted to
+    a polynomial equation using the change of variable y -> x**Rational(p, q)
+    """
+    assert solveset_real(sqrt(x) - 1, x) == FiniteSet(1)
+    assert solveset_real(sqrt(x) - 2, x) == FiniteSet(4)
+    assert solveset_real(x**Rational(1, 4) - 2, x) == FiniteSet(16)
+    assert solveset_real(x**Rational(1, 3) - 3, x) == FiniteSet(27)
+    assert solveset_real(x*(x**(S(1) / 3) - 3), x) == \
+        FiniteSet(S(0), S(27))
+
+
+def test_solveset_real_rational():
+    """Test solveset_real for rational functions"""
+    assert solveset_real((x - y**3) / ((y**2)*sqrt(1 - y**2)), x) \
+        == FiniteSet(y**3)
+    # issue 4486
+    assert solveset_real(2*x/(x + 2) - 1, x) == FiniteSet(2)
+
+
+def test_solveset_real_log():
+    assert solveset_real(log((x-1)*(x+1)), x) == \
+        FiniteSet(sqrt(2), -sqrt(2))
+
+
+def test_poly_gens():
+    assert solveset_real(4**(2*(x**2) + 2*x) - 8, x) == \
+        FiniteSet(-Rational(3, 2), S.Half)
+
+
+@XFAIL
+def test_uselogcombine_1():
+    assert solveset_real(log(x - 3) + log(x + 3), x) == \
+        FiniteSet(sqrt(10))
+    assert solveset_real(log(x + 1) - log(2*x - 1), x) == FiniteSet(2)
+    assert solveset_real(log(x + 3) + log(1 + 3/x) - 3) == FiniteSet(
+        -3 + sqrt(-12 + exp(3))*exp(S(3)/2)/2 + exp(3)/2,
+        -sqrt(-12 + exp(3))*exp(S(3)/2)/2 - 3 + exp(3)/2)
+
+
+@XFAIL
+def test_uselogcombine_2():
+    eq = z - log(x) + log(y/(x*(-1 + y**2/x**2)))
+    assert solveset_real(eq, x) == \
+        FiniteSet(-sqrt(y*(y - exp(z))), sqrt(y*(y - exp(z))))
+
+
+def test_solve_abs():
+    assert solveset_real(Abs(x) - 2, x) == FiniteSet(-2, 2)
+    assert solveset_real(Abs(x + 3) - 2*Abs(x - 3), x) == \
+        FiniteSet(1, 9)
+    assert solveset_real(2*Abs(x) - Abs(x - 1), x) == \
+        FiniteSet(-1, Rational(1, 3))
+
+    assert solveset_real(Abs(x - 7) - 8, x) == FiniteSet(-S(1), S(15))
+
+
+@XFAIL
+def test_rewrite_trigh():
+    # if this import passes then the test below should also pass
+    from sympy import sech
+    assert solveset_real(sinh(x) + sech(x)) == FiniteSet(
+        2*atanh(-S.Half + sqrt(5)/2 - sqrt(-2*sqrt(5) + 2)/2),
+        2*atanh(-S.Half + sqrt(5)/2 + sqrt(-2*sqrt(5) + 2)/2),
+        2*atanh(-sqrt(5)/2 - S.Half + sqrt(2 + 2*sqrt(5))/2),
+        2*atanh(-sqrt(2 + 2*sqrt(5))/2 - sqrt(5)/2 - S.Half))
+
+
+@XFAIL
+def test_real_imag_splitting1():
+    a, b = symbols('a b', real=True, finite=True)
+    s = solveset_real(sqrt(a**2 + b**2) - 3, a)
+    assert s != S.EmptySet
+    # FiniteSet(-sqrt(-b**2 + 9), sqrt(-b**2 + 9))
+    # fails now because whether it is real or not depends
+    # on the value of b, e.g. b = 4 gives an imaginary value
+
+
+def test_real_imag_splitting():
+    a, b = symbols('a b', real=True, finite=True)
+    assert solveset_real(sqrt(a**2 - b**2) - 3, a) == \
+        FiniteSet(-sqrt(b**2 + 9), sqrt(b**2 + 9))
+
+
+def test_units():
+    assert solveset_real(1/x - 1/(2*cm), x) == FiniteSet(2*cm)
+
+
+def test_solve_only_exp_1():
+    y = Symbol('y', positive=True, finite=True)
+    assert solveset_real(exp(x) - y, x) == FiniteSet(log(y))
+
+
+@XFAIL
+def test_only_exp_2():
+    assert solveset_real(exp(x) + exp(-x) - 4, x) == \
+        FiniteSet(log(-sqrt(3) + 2), log(sqrt(3) + 2))
+    assert solveset_real(exp(x) + exp(-x) - y, x) != S.EmptySet
+    # FiniteSet(log(y/2 - sqrt((y - 2)*(y + 2))/2),
+    #           log(y/2 + sqrt((y - 2)*(y + 2))/2))
+    # fails now because whether it is real or not depends
+    # on whether y >= 2
+
+
+@XFAIL
+def test_only_exp_3():
+    assert solveset_real(exp(x/y)*exp(-z/y) - 2, y) == \
+        FiniteSet((x - z)/log(2))
+    assert solveset_real(sqrt(exp(x)) + sqrt(exp(-x)) - 4, x) == \
+        FiniteSet(2*log(-sqrt(3) + 2), 2*log(sqrt(3) + 2))
+
+
+def test_atan2():
+    # The .inverse() method on atan2 works only if x.is_real is True and the
+    # second argument is a real constant
+    assert solveset_real(atan2(x, 2) - pi/3, x) == FiniteSet(2*sqrt(3))
+
+
+def test_piecewise():
+    eq = Piecewise((x - 2, Gt(x, 2)), (2 - x, True)) - 3
+    assert set(solveset_real(eq, x)) == set(FiniteSet(-1, 5))
+    absxm3 = Piecewise(
+        (x - 3, S(0) <= x - 3),
+        (3 - x, S(0) > x - 3)
+    )
+    y = Symbol('y', positive=True)
+    assert solveset_real(absxm3 - y, x) == FiniteSet(-y + 3, y + 3)
+
+
+def test_solveset_complex_polynomial():
+    from sympy.abc import x, a, b, c
+    assert solveset_complex(a*x**2 + b*x + c, x) == \
+        FiniteSet(-b/(2*a) - sqrt(-4*a*c + b**2)/(2*a),
+                  -b/(2*a) + sqrt(-4*a*c + b**2)/(2*a))
+
+    assert solveset_complex(x - y**3, y) == FiniteSet(
+        (-x**Rational(1, 3))/2 + I*sqrt(3)*x**Rational(1, 3)/2,
+        x**Rational(1, 3),
+        (-x**Rational(1, 3))/2 - I*sqrt(3)*x**Rational(1, 3)/2)
+
+    assert solveset_complex(x + 1/x - 1, x) == \
+        FiniteSet(Rational(1, 2) + I*sqrt(3)/2, Rational(1, 2) - I*sqrt(3)/2)
+
+
+def test_sol_zero_complex():
+    # This should return the complex set after it is implemented
+    raises(NotImplementedError, lambda: solveset_complex(0, x))
+
+
+def test_solveset_complex_rational():
+    assert solveset_complex((x - 1)*(x - I)/(x - 3), x) == \
+        FiniteSet(1, I)
+
+    assert solveset_complex((x - y**3)/((y**2)*sqrt(1 - y**2)), x) == \
+        FiniteSet(y**3)
+    assert solveset_complex(-x**2 - I, x) == \
+        FiniteSet(-sqrt(2)/2 + sqrt(2)*I/2, sqrt(2)/2 - sqrt(2)*I/2)
+
+
+def test_solve_quintics():
+    skip("This test is too slow")
+    f = x**5 - 110*x**3 - 55*x**2 + 2310*x + 979
+    s = solveset_complex(f, x)
+    for root in s:
+        res = f.subs(x, root.n()).n()
+        assert tn(res, 0)
+
+    f = x**5 + 15*x + 12
+    s = solveset_complex(f, x)
+    for root in s:
+        res = f.subs(x, root.n()).n()
+        assert tn(res, 0)
+
+
+def test_solveset_complex_exp():
+    from sympy.abc import x, n
+    assert solveset_complex(exp(x) - 1, x) == \
+        imageset(Lambda(n, I*2*n*pi), S.Integers)
+    assert solveset_complex(exp(x) - I, x) == \
+        imageset(Lambda(n, I*(2*n*pi + pi/2)), S.Integers)
+
+
+def test_solve_complex_log():
+    assert solveset_complex(log(x), x) == FiniteSet(1)
+    assert solveset_complex(1 - log(a + 4*x**2), x) == \
+        FiniteSet(-sqrt(-a/4 + E/4), sqrt(-a/4 + E/4))
+
+
+@XFAIL
+def test_solve_complex_sqrt():
+    assert solveset_complex(sqrt(5*x + 6) - 2 - x, x) == \
+        FiniteSet(-S(1), S(2))
+    assert solveset_complex(4*x*(1 - a * sqrt(x)), x) == \
+        FiniteSet(S(0), 1 / a ** 2)
+
+
+def test_solveset_complex_tan():
+    s = solveset_complex(tan(x).rewrite(exp), x)
+    assert s == imageset(Lambda(n, pi*n), S.Integers) - \
+        imageset(Lambda(n, pi*n + pi/2), S.Integers)
+
+
+def test_solve_trig():
+    from sympy.abc import n
+    assert solveset_real(sin(x), x) == \
+        Union(imageset(Lambda(n, 2*pi*n), S.Integers),
+              imageset(Lambda(n, 2*pi*n + pi), S.Integers))
+
+    assert solveset_real(sin(x) - 1, x) == \
+        imageset(Lambda(n, 2*pi*n + pi/2), S.Integers)
+
+    assert solveset_real(cos(x), x) == \
+        Union(imageset(Lambda(n, 2*pi*n - pi/2), S.Integers),
+              imageset(Lambda(n, 2*pi*n + pi/2), S.Integers))
+
+    assert solveset_real(sin(x) + cos(x), x) == \
+        Union(imageset(Lambda(n, 2*n*pi - pi/4), S.Integers),
+              imageset(Lambda(n, 2*n*pi + 3*pi/4), S.Integers))
+
+    assert solveset_real(sin(x)**2 + cos(x)**2, x) == S.EmptySet
+
+
+def test_solve_invalid_sol():
+    assert 0 not in solveset_real(sin(x)/x, x)
+    assert 0 not in solveset_complex((exp(x) - 1)/x, x)
+
+
+def test_solve_complex_unsolvable():
+    raises(NotImplementedError, lambda: solveset_complex(cos(x) - S.Half, x))
+
+
+@XFAIL
+def test_solve_trig_simplified():
+    from sympy.abc import n
+    assert solveset_real(sin(x), x) == \
+        imageset(Lambda(n, n*pi), S.Integers)
+
+    assert solveset_real(cos(x), x) == \
+        imageset(Lambda(n, n*pi + pi/2), S.Integers)
+
+    assert solveset_real(cos(x) + sin(x), x) == \
+        imageset(Lambda(n, n*pi - pi/4), S.Integers)
+
+
+@XFAIL
+def test_solve_lambert():
+    assert solveset_real(x*exp(x) - 1, x) == FiniteSet(LambertW(1))
+    assert solveset_real(x + 2**x, x) == \
+        FiniteSet(-LambertW(log(2))/log(2))
+
+    # issue 4739
+    assert solveset_real(exp(log(5)*x) - 2**x, x) == FiniteSet(0)
+    ans = solveset_real(3*x + 5 + 2**(-5*x + 3), x)
+    assert ans == FiniteSet(-Rational(5, 3) +
+                            LambertW(-10240*2**(S(1)/3)*log(2)/3)/(5*log(2)))
+
+    eq = 2*(3*x + 4)**5 - 6*7**(3*x + 9)
+    result = solveset_real(eq, x)
+    ans = FiniteSet((log(2401) +
+                     5*LambertW(-log(7**(7*3**Rational(1, 5)/5))))/(3*log(7))/-1)
+    assert result == ans
+    assert solveset_real(eq.expand(), x) == result
+
+    assert solveset_real(5*x - 1 + 3*exp(2 - 7*x), x) == \
+        FiniteSet(Rational(1, 5) + LambertW(-21*exp(Rational(3, 5))/5)/7)
+
+    assert solveset_real(2*x + 5 + log(3*x - 2), x) == \
+        FiniteSet(Rational(2, 3) + LambertW(2*exp(-Rational(19, 3))/3)/2)
+
+    assert solveset_real(3*x + log(4*x), x) == \
+        FiniteSet(LambertW(Rational(3, 4))/3)
+
+    assert solveset_complex(x**z*y**z - 2, z) == \
+        FiniteSet(log(2)/(log(x) + log(y)))
+
+    assert solveset_real(x**x - 2) == FiniteSet(exp(LambertW(log(2))))
+
+    a = Symbol('a')
+    assert solveset_real(-a*x + 2*x*log(x), x) == FiniteSet(exp(a/2))
+    a = Symbol('a', real=True)
+    assert solveset_real(a/x + exp(x/2), x) == \
+        FiniteSet(2*LambertW(-a/2))
+    assert solveset_real((a/x + exp(x/2)).diff(x), x) == \
+        FiniteSet(4*LambertW(sqrt(2)*sqrt(a)/4))
+
+    assert solveset_real(1/(1/x - y + exp(y)), x) == EmptySet()
+    # coverage test
+    p = Symbol('p', positive=True)
+    w = Symbol('w')
+    assert solveset_real((1/p + 1)**(p + 1), p) == EmptySet()
+    assert solveset_real(tanh(x + 3)*tanh(x - 3) - 1, x) == EmptySet()
+    assert solveset_real(2*x**w - 4*y**w, w) == \
+        solveset_real((x/y)**w - 2, w)
+
+    assert solveset_real((x**2 - 2*x + 1).subs(x, log(x) + 3*x), x) == \
+        FiniteSet(LambertW(3*S.Exp1)/3)
+    assert solveset_real((x**2 - 2*x + 1).subs(x, (log(x) + 3*x)**2 - 1), x) == \
+        FiniteSet(LambertW(3*exp(-sqrt(2)))/3, LambertW(3*exp(sqrt(2)))/3)
+    assert solveset_real((x**2 - 2*x - 2).subs(x, log(x) + 3*x), x) == \
+        FiniteSet(LambertW(3*exp(1 + sqrt(3)))/3, LambertW(3*exp(-sqrt(3) + 1))/3)
+    assert solveset_real(x*log(x) + 3*x + 1, x) == \
+        FiniteSet(exp(-3 + LambertW(-exp(3))))
+    eq = (x*exp(x) - 3).subs(x, x*exp(x))
+    assert solveset_real(eq, x) == \
+        FiniteSet(LambertW(3*exp(-LambertW(3))))
+
+    assert solveset_real(3*log(a**(3*x + 5)) + a**(3*x + 5), x) == \
+        FiniteSet(-((log(a**5) + LambertW(S(1)/3))/(3*log(a))))
+    p = symbols('p', positive=True)
+    assert solveset_real(3*log(p**(3*x + 5)) + p**(3*x + 5), x) == \
+        FiniteSet(
+        log((-3**(S(1)/3) - 3**(S(5)/6)*I)*LambertW(S(1)/3)**(S(1)/3)/(2*p**(S(5)/3)))/log(p),
+        log((-3**(S(1)/3) + 3**(S(5)/6)*I)*LambertW(S(1)/3)**(S(1)/3)/(2*p**(S(5)/3)))/log(p),
+        log((3*LambertW(S(1)/3)/p**5)**(1/(3*log(p)))),)  # checked numerically
+    # check collection
+    b = Symbol('b')
+    eq = 3*log(a**(3*x + 5)) + b*log(a**(3*x + 5)) + a**(3*x + 5)
+    assert solveset_real(eq, x) == FiniteSet(
+        -((log(a**5) + LambertW(1/(b + 3)))/(3*log(a))))
+
+    # issue 4271
+    assert solveset_real((a/x + exp(x/2)).diff(x, 2), x) == FiniteSet(
+        6*LambertW((-1)**(S(1)/3)*a**(S(1)/3)/3))
+
+    assert solveset_real(x**3 - 3**x, x) == \
+        FiniteSet(-3/log(3)*LambertW(-log(3)/3))
+    assert solveset_real(x**2 - 2**x, x) == FiniteSet(2)
+    assert solveset_real(-x**2 + 2**x, x) == FiniteSet(2)
+    assert solveset_real(3**cos(x) - cos(x)**3) == FiniteSet(
+        acos(-3*LambertW(-log(3)/3)/log(3)))
+
+    assert solveset_real(4**(x/2) - 2**(x/3), x) == FiniteSet(0)
+    assert solveset_real(5**(x/2) - 2**(x/3), x) == FiniteSet(0)
+    b = sqrt(6)*sqrt(log(2))/sqrt(log(5))
+    assert solveset_real(5**(x/2) - 2**(3/x), x) == FiniteSet(-b, b)
+
+
+def test_solveset():
+    x = Symbol('x', real=True)
+    raises(ValueError, lambda: solveset(x + y))
+
+    assert solveset(exp(x) - 1) == FiniteSet(0)
+    assert solveset(exp(x) - 1, x) == FiniteSet(0)
+    assert solveset(Eq(exp(x), 1), x) == FiniteSet(0)
+
+    assert solveset(x - 1 >= 0, x) == Interval(1, oo)
+    assert solveset(exp(x) - 1 >= 0, x) == Interval(0, oo)
+
+    x = Symbol('x')
+    assert solveset(exp(x) - 1, x) == imageset(Lambda(n, 2*I*pi*n), S.Integers)
+    assert solveset(Eq(exp(x), 1), x) == imageset(Lambda(n, 2*I*pi*n),
+                                                  S.Integers)
+
+
+def test_improve_coverage():
+    from sympy.solvers.solveset import _has_rational_power
+    x = Symbol('x', real=True)
+    y = exp(x+1/x**2)
+    raises(NotImplementedError, lambda: solveset(y**2+y, x))
+
+    assert _has_rational_power(sin(x)*exp(x) + 1, x) == (False, S.One)
+    assert _has_rational_power((sin(x)**2)*(exp(x) + 1)**3, x) == (False, S.One)


### PR DESCRIPTION
This PR aims to rewrite a cleaner and robust univariate equation solver.
- [x] polynomial
- [x] rational
- [x] real trigonometric
- [x] write 4 tests to complete coverage
- [x] correct typo
- [x] correct [this failure](https://github.com/sympy/sympy/pull/7523#issuecomment-62201765)
### Nonblocking todo
- [ ] functions solvable by LambertW
- [ ] functions that can be recast as polynomials with a change of variables [this, for example](https://github.com/sympy/sympy/pull/7523#commitcomment-8338203); this can be factored out of solve where multiple generators are handled
- [ ] use something like [this](https://github.com/sympy/sympy/pull/7523#issuecomment-62198981) to handle the XFAILed test `test_real_imag_splitting1`, this will be handled in the set module.
