### PR TITLE
fix indeterminacy in FiniteSet

### DIFF
--- a/sympy/physics/quantum/tests/test_matrixutils.py
+++ b/sympy/physics/quantum/tests/test_matrixutils.py
@@ -1,3 +1,5 @@
+from random import randint
+
 from sympy import Matrix, zeros, ones, Integer
 
 from sympy.physics.quantum.matrixutils import (
@@ -80,8 +82,8 @@ def test_matrix_tensor_product():
     assert numpy_product.tolist() == sympy_product.tolist()
 
     #test for random matrix with random values that are floats
-    random_matrix1 = np.random.rand(np.random.rand()*5 + 1, np.random.rand()*5 + 1)
-    random_matrix2 = np.random.rand(np.random.rand()*5 + 1, np.random.rand()*5 + 1)
+    random_matrix1 = np.random.rand(randint(1, 5), randint(1, 5))
+    random_matrix2 = np.random.rand(randint(1, 5), randint(1, 5))
     numpy_product = np.kron(random_matrix1, random_matrix2)
     args = [Matrix(random_matrix1.tolist()), Matrix(random_matrix2.tolist())]
     sympy_product = matrix_tensor_product(*args)

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -7,7 +7,7 @@ from sympy.core.basic import Basic
 from sympy.core.singleton import Singleton, S
 from sympy.core.evalf import EvalfMixin
 from sympy.core.numbers import Float
-from sympy.core.compatibility import iterable, with_metaclass
+from sympy.core.compatibility import iterable, with_metaclass, ordered
 from sympy.core.evaluate import global_evaluate
 from sympy.core.decorators import deprecated
 
@@ -1371,12 +1371,12 @@ class FiniteSet(Set, EvalfMixin):
     Examples
     ========
 
-        >>> from sympy import FiniteSet
+    >>> from sympy import FiniteSet
 
-        >>> FiniteSet(1, 2, 3, 4)
-        {1, 2, 3, 4}
-        >>> 3 in FiniteSet(1, 2, 3, 4)
-        True
+    >>> FiniteSet(1, 2, 3, 4)
+    {1, 2, 3, 4}
+    >>> 3 in FiniteSet(1, 2, 3, 4)
+    True
 
     References
     ==========
@@ -1395,13 +1395,12 @@ class FiniteSet(Set, EvalfMixin):
 
             if len(args) == 0:
                 return EmptySet()
+        else:
+            args = list(map(sympify, args))
 
-
-        args = frozenset(args)  # remove duplicates
-        args = map(sympify, args)
-        args = frozenset(args)
+        args = list(ordered(frozenset(args)))
         obj = Basic.__new__(cls, *args)
-        obj._elements = args
+        obj._elements = frozenset(args)
         return obj
 
     def __iter__(self):

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division
 
 from sympy import (Basic, S, Expr, Symbol, Tuple, And, Add, Eq, lambdify,
         sympify, Equality, solve, Lambda, DiracDelta)
-from sympy.core.compatibility import reduce, ordered
+from sympy.core.compatibility import reduce
 from sympy.sets.sets import FiniteSet, ProductSet
 from sympy.abc import x
 
@@ -394,10 +394,10 @@ class ProductDomain(RandomDomain):
 
 def random_symbols(expr):
     """
-    Returns a sorted list of all RandomSymbols within a SymPy Expression.
+    Returns all RandomSymbols within a SymPy Expression.
     """
     try:
-        return list(ordered(expr.atoms(RandomSymbol), warn=True))
+        return list(expr.atoms(RandomSymbol))
     except AttributeError:
         return []
 


### PR DESCRIPTION
This fixes #7456. I downloaded 3.4 and found a failing pythonhashseed for test_rv. After applying these mods the test no longer occurs so I think it's taken care of now. I reverted the sorting of random_symbols as it was not needed to fix this issue.

In addition, I noticed that a deprecation warning from numpy is emitted during testing because non-integer dimensions were being used to create a matrix, so I used randint instead.
