### PR TITLE
Add functions to continued_fraction.py, fix small problems.

### DIFF
--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -14,4 +14,5 @@ from .residue_ntheory import is_primitive_root, is_quad_residue, \
 from .multinomial import binomial_coefficients, binomial_coefficients_list, \
     multinomial_coefficients
 from .continued_fraction import continued_fraction_periodic, \
-    continued_fraction_iterator
+    continued_fraction_iterator, continued_fraction_rational, \
+    continued_fraction_convergents

--- a/sympy/ntheory/continued_fraction.py
+++ b/sympy/ntheory/continued_fraction.py
@@ -33,10 +33,13 @@ def continued_fraction_periodic(p, q, d=0):
     >>> continued_fraction_periodic(1, 2, 5)
     [[1]]
 
-    If the discriminator is zero then the number will be a rational number:
+    If the discriminator is zero or a perfect square then the number will be a
+    rational number:
 
     >>> continued_fraction_periodic(4, 3, 0)
     [1, 3]
+    >>> continued_fraction_periodic(4, 3, 49)
+    [3, 1, 2]
 
     See Also
     ========
@@ -62,9 +65,9 @@ def continued_fraction_periodic(p, q, d=0):
     if d < 0:
         raise ValueError("Delta supposed to be a non-negative "
                          "integer, got %d" % d)
-    elif d == 0:
+    elif d == 0 or sqrt(d).is_integer:
         # the number is a rational number
-        return list(continued_fraction_iterator(Rational(p, q)))
+        return list(continued_fraction_iterator(Rational(p+sqrt(d), q)))
 
     if (d - p**2)%q:
         d *= q**2
@@ -120,8 +123,69 @@ def continued_fraction_iterator(x):
 
     while True:
         i = Integer(x)
+        # Only the first element of a CF can be negative
+        if x < 0 and x != i:
+            i -= 1
         yield i
         x -= i
         if not x:
             break
         x = 1/x
+
+# Rational.__iter__=lambda self: continued_fraction_iterator(self)
+
+def continued_fraction_convergents(cf):
+    """
+    Returns an iterator over the convergents (successive Rational approximations)
+    of a continued fraction.
+
+    Examples
+    ========
+    >>> from sympy.core import Rational, pi
+    >>> from sympy.ntheory.continued_fraction import continued_fraction_convergents, \
+    ...    continued_fraction_iterator
+
+    >>> list(continued_fraction_convergents([0, 2, 1, 2]))
+    [0, 1/2, 1/3, 3/8]
+
+    >>> it=continued_fraction_convergents(continued_fraction_iterator(pi))
+    >>> for i in range(7):
+    ...  print(next(it))
+    ...
+    3
+    22/7
+    333/106
+    355/113
+    103993/33102
+    104348/33215
+    208341/66317
+    >>>
+    """
+    p_2, q_2=0, 1
+    p_1, q_1=1, 0
+    for a in cf:
+        p, q=a*p_1+p_2, a*q_1+q_2
+        p_2, q_2=p_1, q_1
+        p_1, q_1=p, q
+        yield Rational(p,q)
+
+def continued_fraction_rational(cf, maxdenom=10000000000):
+    """
+    Returns the Rational from a continued fraction iterator.
+
+    Optional parameter maxdenom (default 10000000000) specifies the maximum
+    denominator to be returned (stopping the continued fraction expansion if
+    it continues further).  Set to None for no maximum; the default is to guard
+    against accidentally giving it an infinite iterator.
+
+    >>> from sympy.ntheory.continued_fraction import continued_fraction_rational
+    >>> continued_fraction_rational([1,2,3,4,5])
+    225/157
+    """
+    it=continued_fraction_convergents(cf)
+    a=next(it)
+    for nxt in it:
+        if maxdenom is not None and maxdenom < nxt.q:
+            return a
+        a=nxt
+    return a


### PR DESCRIPTION
Happened to find sympy just when I was in the middle of doing a bunch of coding for continued fractions...

Fixed small issues with continued fractions (only the first term may be negative, and handle quadratic irrationals which are rational after all, because their discriminator is a perfect square).  Also added some new CF functions (names maybe could be better) for generating convergents of a CF from an iterator, or evaluating it as a Rational.

Hope these are useful.
