### PR TITLE
Add IPython Notebook Checkpoints to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ doc/src/modules/physics/mechanics/*.pdf
 
 # Temp output of sympy/printing/preview.py:
 sample.tex
+
+# IPython Notebook Checkpoints
+.ipynb_checkpoints/


### PR DESCRIPTION
This stops IPython checkpoints from getting added in the git tree.
