### PR TITLE
Issue #7537: CPython set/frozenset compatible FiniteSet interface

### DIFF
--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -88,6 +88,12 @@ class Set(Basic):
         """
         return Intersection(self, other)
 
+    def intersection(self, other):
+        """
+        Alias for :meth:`intersect()`
+        """
+        return self.intersect(other)
+
     def _intersect(self, other):
         """
         This function should only be used internally
@@ -223,6 +229,12 @@ class Set(Basic):
         else:
             raise ValueError("Unknown argument '%s'" % other)
 
+    def issubset(self, other):
+        """
+        Alias for :meth:`is_subset()`
+        """
+        return self.is_subset(other)
+
     def is_proper_subset(self, other):
         """
         Returns True if 'self' is a proper subset of 'other'.
@@ -254,6 +266,12 @@ class Set(Basic):
             return other.is_subset(self)
         else:
             raise ValueError("Unknown argument '%s'" % other)
+
+    def issuperset(self, other):
+        """
+        Alias for :meth:`is_superset()`
+        """
+        return self.is_superset(other)
 
     def is_proper_superset(self, other):
         """

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -197,6 +197,12 @@ def test_intersect():
     assert Union(Interval(0, 5), FiniteSet(['Ham'])).intersect(FiniteSet(2, 3, 4, 5, 6)) == \
         FiniteSet(2, 3, 4, 5)
 
+    # tests for the intersection alias
+    assert Interval(0, 5).intersection(FiniteSet(1, 3)) == FiniteSet(1, 3)
+    assert Interval(0, 1, True, True).intersection(FiniteSet(1)) == S.EmptySet
+
+    assert Union(Interval(0, 1), Interval(2, 3)).intersection(Interval(1, 2)) == \
+        Union(Interval(1, 1), Interval(2, 2))
 
 def test_intersection():
     # iterable
@@ -289,6 +295,10 @@ def test_is_subset():
 
     raises(ValueError, lambda: S.EmptySet.is_subset(1))
 
+    # tests for the issubset alias
+    assert FiniteSet(1, 2, 3, 4).issubset(Interval(0, 5)) is True
+    assert S.EmptySet.issubset(FiniteSet(1, 2, 3)) is True
+
 def test_is_proper_subset():
     assert Interval(0, 1).is_proper_subset(Interval(0, 2)) is True
     assert Interval(0, 3).is_proper_subset(Interval(0, 2)) is False
@@ -315,6 +325,10 @@ def test_is_superset():
     assert S.EmptySet.is_superset(S.EmptySet) == True
 
     raises(ValueError, lambda: S.EmptySet.is_superset(1))
+
+    # tests for the issuperset alias
+    assert Interval(0, 1).issuperset(S.EmptySet) == True
+    assert S.EmptySet.issuperset(S.EmptySet) == True
 
 def test_is_proper_superset():
     assert Interval(0, 1).is_proper_superset(Interval(0, 2)) is False


### PR DESCRIPTION
Is this something which we can have? My use case right now is simple: third party libraries which are written with CPython's standard set interface in mind, will continue to work.  My current use case is using `matplotlib-venn` (https://github.com/konstantint/matplotlib-venn). Here is how I would use it:

```
from sympy.sets.sets_compat import FiniteSet
import matplotlib.pyplot as plt
from matplotlib_venn import venn2

s1 = FiniteSet(1, 2, 3)
s2 = FiniteSet(2, 4, 6)

venn2(subsets= (s1, s2))
plt.show()
```
