### PR TITLE
Fix `Basic.rewrite()` behavior

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1543,11 +1543,20 @@ class Basic(with_metaclass(ManagedProperties)):
             if hasattr(self, rule):
                 return getattr(self, rule)()
             return self
-        sargs = self.args
-        terms = [ t._eval_rewrite(pattern, rule, **hints)
-                    if isinstance(t, Basic) else t
-                    for t in sargs ]
-        return self.func(*terms)
+
+        if hints.get('deep', True):
+            args = [ a._eval_rewrite(pattern, rule, **hints)
+                        if isinstance(a, Basic) else a
+                        for a in self.args ]
+        else:
+            args = self.args
+
+        if pattern is None or isinstance(self.func, pattern):
+            if hasattr(self, rule):
+                rewritten = getattr(self, rule)(*args)
+                if rewritten is not None:
+                    return rewritten
+        return self.func(*args)
 
     def rewrite(self, *args, **hints):
         """ Rewrite functions in terms of other functions.

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -631,21 +631,6 @@ class Function(Application, Expr):
             l.append(g)
         return Add(*l) + C.Order(x**n, x)
 
-    def _eval_rewrite(self, pattern, rule, **hints):
-        if hints.get('deep', False):
-            args = [a._eval_rewrite(pattern, rule, **hints) for a in self.args]
-        else:
-            args = self.args
-
-        if pattern is None or isinstance(self.func, pattern):
-            if hasattr(self, rule):
-                rewritten = getattr(self, rule)(*args)
-
-                if rewritten is not None:
-                    return rewritten
-
-        return self.func(*args)
-
     def fdiff(self, argindex=1):
         """
         Returns the first derivative of the function.

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -322,25 +322,6 @@ class QExpr(Expr):
     def doit(self, **kw_args):
         return self
 
-    def _eval_rewrite(self, pattern, rule, **hints):
-        # TODO: Make Basic.rewrite get the rule using the class name rather
-        # than str(). See L1072 of basic.py.
-        # This will call self.rule(*self.args) for rewriting.
-        if hints.get('deep', False):
-            args = [ a._eval_rewrite(pattern, rule, **hints)
-                     for a in self.args ]
-        else:
-            args = self.args
-
-        if pattern is None or isinstance(self, pattern):
-            if hasattr(self, rule):
-                rewritten = getattr(self, rule)(*args, **hints)
-
-                if rewritten is not None:
-                    return rewritten
-
-        return self
-
     #-------------------------------------------------------------------------
     # Represent
     #-------------------------------------------------------------------------

--- a/sympy/physics/quantum/qexpr.py
+++ b/sympy/physics/quantum/qexpr.py
@@ -322,6 +322,25 @@ class QExpr(Expr):
     def doit(self, **kw_args):
         return self
 
+    def _eval_rewrite(self, pattern, rule, **hints):
+        if hints.get('deep', False):
+            args = [ a._eval_rewrite(pattern, rule, **hints)
+                    for a in self.args ]
+        else:
+            args = self.args
+
+        # TODO: Make Basic.rewrite use hints in evaluating
+        # self.rule(*args, **hints), not having hints breaks spin state
+        # (un)coupling on rewrite
+        if pattern is None or isinstance(self, pattern):
+            if hasattr(self, rule):
+                rewritten = getattr(self, rule)(*args, **hints)
+
+                if rewritten is not None:
+                    return rewritten
+
+        return self
+
     #-------------------------------------------------------------------------
     # Represent
     #-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the behavior of `Basic.rewrite` to call the opropriate rule function.  Furthermore, added handling for `deep` keyword to `Basic.rewrite()`, which defaults to `True`.  This change allows the removal of `Function.rewrite()` and `physics.quantum.QExpr.rewrite()` methods, however, the default behavior is changed from `deep=False` to `deep=True`.
