### PR TITLE
Enable an indexed summation of matrices

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -13,6 +13,7 @@ from sympy.core.containers import Tuple
 from sympy.functions.elementary.piecewise import piecewise_fold
 from sympy.utilities import flatten
 from sympy.utilities.iterables import sift
+from sympy.matrices import Matrix
 
 
 
@@ -412,6 +413,9 @@ class AddWithLimits(ExprWithLimits):
         summand = self.function.expand(**hints)
         if summand.is_Add and summand.is_commutative:
             return Add(*[ self.func(i, *self.limits) for i in summand.args ])
+        elif summand.is_Matrix:
+            return Matrix._new(summand.rows, summand.cols,
+                [self.func(i, *self.limits) for i in summand._mat])
         elif summand != self.function:
             return self.func(summand, *self.limits)
         return self

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -13,7 +13,7 @@ from sympy.solvers import solve
 from sympy.core.compatibility import range
 
 
-class Sum(AddWithLimits,ExprWithIntLimits):
+class Sum(AddWithLimits, ExprWithIntLimits):
     r"""Represents unevaluated summation.
 
     ``Sum`` represents a finite or infinite series, with the first argument
@@ -166,6 +166,9 @@ class Sum(AddWithLimits,ExprWithIntLimits):
             f = self.function.doit(**hints)
         else:
             f = self.function
+
+        if self.function.is_Matrix:
+            return self.expand().doit()
 
         for n, limit in enumerate(self.limits):
             i, a, b = limit

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -6,7 +6,9 @@ from sympy import (
 )
 from sympy.abc import a, b, c, d, f, k, m, x, y, z
 from sympy.concrete.summations import telescopic
-from sympy.utilities.pytest import raises
+from sympy.utilities.pytest import XFAIL, raises
+from sympy import simplify
+from sympy.matrices import Matrix
 from sympy.core.mod import Mod
 from sympy.core.compatibility import range
 
@@ -824,3 +826,8 @@ def test_issue_2787():
 
 def test_issue_4668():
     assert summation(1/n, (n, 2, oo)) == oo
+
+
+def test_matrix_sum():
+    A = Matrix([[0,1],[n,0]])
+    assert Sum(A,(n,0,3)).doit() == Matrix([[0, 4], [6, 0]])

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -1188,7 +1188,7 @@ class MatrixBase(object):
     _eval_simplify = simplify
 
     def doit(self, **kwargs):
-        return self
+        return self._new(self.rows, self.cols, [i.doit() for i in self._mat])
 
     def print_nonzero(self, symb="X"):
         """Shows location of non-zero entries for fast shape lookup.

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -1,7 +1,7 @@
 import collections
 
 from sympy import (
-    Abs, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
+    Abs, Add, E, Float, I, Integer, Max, Min, N, Poly, Pow, PurePoly, Rational,
     S, Symbol, cos, exp, oo, pi, signsimp, simplify, sin, sqrt, symbols,
     sympify, trigsimp, sstr)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
@@ -2418,3 +2418,8 @@ def test_hermitian():
     assert a.is_hermitian is None
     a[0, 1] = a[1, 0]*I
     assert a.is_hermitian is False
+
+def test_doit():
+    a = Matrix([[Add(x,x, evaluate=False)]])
+    assert a[0] != 2*x
+    assert a.doit() == Matrix([[2*x]])


### PR DESCRIPTION
- on AddWithLimits.expand() distribute sum to each matrix entry
- Sum.doit() recognizes matrix summands and distributes
- Matrix.doit() maps to matrix entries
- includes 1 new test
