### PR TITLE
Replace "except:" with "except Exception:"

### DIFF
--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1518,7 +1518,7 @@ class Permutation(Basic):
                 try:
                     # P([a, b, c])
                     return [i[j] for j in self._array_form]
-                except:
+                except Exception:
                     raise TypeError('unrecognized argument')
         else:
             # P(1, 2, 3)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -4098,7 +4098,7 @@ def classof(A, B):
             return A.__class__
         else:
             return B.__class__
-    except:
+    except Exception:
         pass
     try:
         import numpy
@@ -4106,7 +4106,7 @@ def classof(A, B):
             return B.__class__
         if isinstance(B, numpy.ndarray):
             return A.__class__
-    except:
+    except Exception:
         pass
     raise TypeError("Incompatible classes %s, %s" % (A.__class__, B.__class__))
 

--- a/sympy/physics/units.py
+++ b/sympy/physics/units.py
@@ -301,7 +301,7 @@ def find_unit(quantity):
             try:
                 if units == eval('u.' + i).as_coeff_Mul()[1]:
                     rv.append(str(i))
-            except:
+            except Exception:
                 pass
     return sorted(rv, key=len)
 

--- a/sympy/plotting/pygletplot/color_scheme.py
+++ b/sympy/plotting/pygletplot/color_scheme.py
@@ -117,7 +117,7 @@ class ColorScheme(object):
         elif len(lists) == 3:
             try:
                 (r1, r2), (g1, g2), (b1, b2) = lists
-            except:
+            except Exception:
                 raise ValueError("If three color arguments are given, "
                                  "they must be given in the format "
                                  "(r1, r2), (g1, g2), (b1, b2). To create "

--- a/sympy/plotting/pygletplot/plot_mode_base.py
+++ b/sympy/plotting/pygletplot/plot_mode_base.py
@@ -113,7 +113,7 @@ class PlotModeBase(PlotMode):
             try:
                 e = self._get_lambda_evaluator()
                 return e
-            except:
+            except Exception:
                 warnings.warn("\nWarning: creating lambda evaluator failed. "
                        "Falling back on sympy subs evaluator.")
         return self._get_sympy_evaluator()

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1393,7 +1393,7 @@ class LatexPrinter(Printer):
     def _print_RandomDomain(self, d):
         try:
             return 'Domain: ' + self._print(d.as_boolean())
-        except:
+        except Exception:
             try:
                 return ('Domain: ' + self._print(d.symbols) + ' in ' +
                         self._print(d.set))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1641,7 +1641,7 @@ class PrettyPrinter(Printer):
             pform = prettyForm(*pform.right(self._print(d.as_boolean())))
             return pform
 
-        except:
+        except Exception:
             try:
                 pform = self._print('Domain: ')
                 pform = prettyForm(*pform.right(self._print(d.symbols)))

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -121,7 +121,7 @@ class StrPrinter(Printer):
     def _print_RandomDomain(self, d):
         try:
             return 'Domain: ' + self._print(d.as_boolean())
-        except:
+        except Exception:
             try:
                 return ('Domain: ' + self._print(d.symbols) + ' in ' +
                         self._print(d.set))

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1155,7 +1155,7 @@ class Union(Set, EvalfMixin):
     def _eval_evalf(self, prec):
         try:
             return Union(set.evalf() for set in self.args)
-        except:
+        except Exception:
             raise TypeError("Not all sets are evalf-able")
 
     def __iter__(self):

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1618,7 +1618,7 @@ def odesimp(eq, func, order, constants, hint):
             try:
                 collectterms.sort(key=default_sort_key)
                 collectterms.reverse()
-            except:
+            except Exception:
                 pass
             assert len(eq) == 1 and eq[0].lhs == f(x)
             sol = eq[0].rhs
@@ -2198,7 +2198,7 @@ def constantsimp(expr, constants):
             else:
                 rexpr = rexpr.subs(*s)
         expr = rexpr
-    except:
+    except Exception:
         pass
     expr = __remove_linear_redundancies(expr, Cs)
 

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -370,7 +370,7 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         x = self.value.symbol
         try:
             return self.distribution.expectation(expr, x, evaluate=False, **kwargs)
-        except:
+        except Exception:
             return Integral(expr * self.pdf, (x, self.set), **kwargs)
 
     def compute_cdf(self, expr, **kwargs):

--- a/sympy/stats/drv.py
+++ b/sympy/stats/drv.py
@@ -116,7 +116,7 @@ class SingleDiscretePSpace(SinglePSpace):
         try:
             return self.distribution.expectation(expr, x, evaluate=False,
                     **kwargs)
-        except:
+        except Exception:
             return Sum(expr * self.pdf, (x, self.set.inf, self.set.sup),
                     **kwargs)
 

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -837,7 +837,7 @@ def sample_iter_lambdify(expr, condition=None, numsamples=S.Infinity, **kwargs):
         fn(*args)
         if condition:
             given_fn(*args)
-    except:
+    except Exception:
         raise TypeError("Expr/condition too complex for lambdify")
 
     def return_generator():

--- a/sympy/strategies/core.py
+++ b/sympy/strategies/core.py
@@ -75,7 +75,7 @@ def tryit(rule):
     def try_rl(expr):
         try:
             return rule(expr)
-        except:
+        except Exception:
             return expr
     return try_rl
 

--- a/sympy/strategies/rl.py
+++ b/sympy/strategies/rl.py
@@ -155,5 +155,5 @@ def rebuild(expr):
     """
     try:
         return type(expr)(*list(map(rebuild, expr.args)))
-    except:
+    except Exception:
         return expr

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -407,7 +407,7 @@ def lambdastr(args, expr, printer=None, dummify=False):
     def sub_expr(expr, dummies_dict):
         try:
             expr = sympify(expr).xreplace(dummies_dict)
-        except:
+        except Exception:
             if isinstance(expr, DeferredVector):
                 pass
             elif isinstance(expr, dict):


### PR DESCRIPTION
Fixes #5669

Purely mechanical replace, nothing more clever.

I don't know if this qualifies as helpful or useful; this was just a search/replace.  But that may be better than bare except:'s.
