### PR TITLE
Shift issue numbers in strings like issue([0-9]+), closes #7235

### DIFF
--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -194,7 +194,7 @@ def test_pow_E():
     assert test_numerically(b**(1/(log(-b) + sign(i)*I*pi).n()), S.Exp1)
 
 
-def test_pow_issue417():
+def test_pow_issue_3516():
     assert 4**Rational(1, 4) == sqrt(2)
 
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -506,7 +506,7 @@ def test_iter_basic_args():
     assert list((x**y).iter_basic_args()) == [x, y]
 
 
-def test_noncommutative_expand_issue658():
+def test_noncommutative_expand_issue_3757():
     A, B, C = symbols('A,B,C', commutative=False)
     assert A*B - B*A != 0
     assert (A*(A + B)*B).expand() == A**2*B + A*B**2

--- a/sympy/core/tests/test_subs.py
+++ b/sympy/core/tests/test_subs.py
@@ -386,7 +386,7 @@ def test_add():
     assert e.subs(-y + 1, x) == ans
 
 
-def test_subs_issue910():
+def test_subs_issue_4009():
     assert (I*Symbol('a')).subs(1, 2) == I*Symbol('a')
 
 

--- a/sympy/external/tests/test_sage.py
+++ b/sympy/external/tests/test_sage.py
@@ -187,6 +187,6 @@ TESTS::
     sage: test_Catalan()
     sage: test_GoldenRation()
     sage: test_functions()
-    sage: test_issue924()
+    sage: test_issue_4023()
 
 """

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -518,7 +518,7 @@ def test_issue_4754_derivative_conjugate():
     assert (f(y).conjugate()).diff(y) == -(f(y).diff(y)).conjugate()
 
 
-def test_derivatives_issue1658():
+def test_derivatives_issue_4757():
     x = Symbol('x', real=True)
     y = Symbol('y', imaginary=True)
     f = Function('f')

--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -774,7 +774,7 @@ def test_issue_4547():
     assert cot(x).fdiff() == -1 - cot(x)**2
 
 
-def test_as_leading_term_issue2173():
+def test_as_leading_term_issue_5272():
     assert sin(x).as_leading_term(x) == x
     assert cos(x).as_leading_term(x) == 1
     assert tan(x).as_leading_term(x) == x

--- a/sympy/polys/tests/test_numberfields.py
+++ b/sympy/polys/tests/test_numberfields.py
@@ -241,13 +241,15 @@ def test_minpoly_compose():
     mp = minimal_polynomial(ex, x)
     assert degree(mp) == 48 and mp.subs({x:0}) == -16630256576
 
-def test_minpoly_issue4014():
+
+def test_minpoly_issue_7113():
     # see discussion in https://github.com/sympy/sympy/pull/2234
     from sympy.simplify.simplify import nsimplify
     r = nsimplify(pi, tolerance=0.000000001)
     mp = minimal_polynomial(r, x)
     assert mp == 1768292677839237920489538677417507171630859375*x**109 - \
     2734577732179183863586489182929671773182898498218854181690460140337930774573792597743853652058046464
+
 
 def test_primitive_element():
     assert primitive_element([sqrt(2)], x) == (x**2 - 2, [1])

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -684,13 +684,13 @@ def test_latex_mul_symbol():
     assert latex(4*x, mul_symbol='ldot') == "4 \,.\, x"
 
 
-def test_latex_issue1282():
+def test_latex_issue_4381():
     y = 4*4**log(2)
     assert latex(y) == r'4 \cdot 4^{\log{\left (2 \right )}}'
     assert latex(1/y) == r'\frac{1}{4 \cdot 4^{\log{\left (2 \right )}}}'
 
 
-def test_latex_issue1477():
+def test_latex_issue_4576():
     assert latex(Symbol("beta_13_2")) == r"\beta_{13 2}"
     assert latex(Symbol("beta_132_20")) == r"\beta_{132 20}"
     assert latex(Symbol("beta_13")) == r"\beta_{13}"

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1514,7 +1514,7 @@ def test_issue_4825():
         {'default': None, 'order': 0}
 
 
-def test_constant_renumber_order_issue2209():
+def test_constant_renumber_order_issue_5308():
     from sympy.utilities.iterables import variations
 
     assert constant_renumber(C1*x + C2*y, "C", 1, 2) == \


### PR DESCRIPTION
n -> n + 3099, see #7235

Remaining stuff:
$ grep -R 'issue[0-9]' [^.]*|grep -v '^sympy/mpmath/'|grep -v 'bugs.python.org/issue'
sympy/concrete/tests/test_sums_products.py:def test_evalf_fast_series_issue998():
sympy/integrals/tests/test_integrals.py:# issue1012

First was introduced in a945bc6
Second - in 98b4fc9
