### PR TITLE
Linearize class

### DIFF
--- a/doc/src/modules/physics/mechanics/kane.rst
+++ b/doc/src/modules/physics/mechanics/kane.rst
@@ -166,7 +166,7 @@ allowed to be in the forcing vector and their derivatives are not allowed to be
 present. If dynamic symbols appear in the mass matrix or kinematic differential
 equations, an error with be raised. ::
 
-  >>> KM.linearize(A_and_B=True)[0]
+  >>> KM.linearize(A_and_B=True, new_method=True)[0]
   Matrix([
   [0, 1],
   [0, 0]])

--- a/doc/src/modules/physics/mechanics/kane.rst
+++ b/doc/src/modules/physics/mechanics/kane.rst
@@ -166,7 +166,7 @@ allowed to be in the forcing vector and their derivatives are not allowed to be
 present. If dynamic symbols appear in the mass matrix or kinematic differential
 equations, an error with be raised. ::
 
-  >>> KM.linearize()[0]
+  >>> KM.linearize(A_and_B=True)[0]
   Matrix([
   [0, 1],
   [0, 0]])

--- a/sympy/physics/mechanics/__init__.py
+++ b/sympy/physics/mechanics/__init__.py
@@ -34,3 +34,7 @@ __all__.extend(lagrange.__all__)
 from sympy.physics import vector
 from sympy.physics.vector import *
 __all__.extend(vector.__all__)
+
+from . import linearize
+from .linearize import *
+__all__.extend(linearize.__all__)

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -437,12 +437,15 @@ def _mat_inv_mul(A, B):
     temp3 = Matrix([i.T for i in temp3]).T
     return temp3.subs(dict(list(zip(temp1, A)))).subs(dict(list(zip(temp2, B))))
 
-def _subs_keep_derivs(expr, *args, **kwargs):
+def _subs_keep_derivs(expr, sub_dict):
     """ Performs subs exactly as subs normally would be,
     but doesn't sub in expressions inside Derivatives. """
 
     ds = expr.atoms(Derivative)
     gs = [Dummy() for d in ds]
+    items = sub_dict.items()
+    deriv_dict = dict((i, j) for (i, j) in items if i.is_Derivative)
+    sub_dict = dict((i, j) for (i, j) in items if not i.is_Derivative)
     dict_to = dict(zip(ds, gs))
     dict_from = dict(zip(gs, ds))
-    return expr.subs(dict_to).subs(*args, **kwargs).subs(dict_from)
+    return expr.subs(deriv_dict).subs(dict_to).subs(sub_dict).subs(dict_from)

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -437,6 +437,7 @@ def _mat_inv_mul(A, B):
     temp3 = Matrix([i.T for i in temp3]).T
     return temp3.subs(dict(list(zip(temp1, A)))).subs(dict(list(zip(temp2, B))))
 
+
 def _subs_keep_derivs(expr, sub_dict):
     """ Performs subs exactly as subs normally would be,
     but doesn't sub in expressions inside Derivatives. """

--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -8,7 +8,7 @@ from sympy.physics.vector.printing import (vprint, vsprint, vpprint, vlatex,
                                            init_vprinting)
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
-from sympy import sympify, Matrix, Symbol
+from sympy import sympify, Matrix, Symbol, Derivative, Dummy
 from sympy.core.basic import S
 
 __all__ = ['inertia',
@@ -436,3 +436,13 @@ def _mat_inv_mul(A, B):
         temp3.append(temp1.LDLsolve(temp2[:, i]))
     temp3 = Matrix([i.T for i in temp3]).T
     return temp3.subs(dict(list(zip(temp1, A)))).subs(dict(list(zip(temp2, B))))
+
+def _subs_keep_derivs(expr, *args, **kwargs):
+    """ Performs subs exactly as subs normally would be,
+    but doesn't sub in expressions inside Derivatives. """
+
+    ds = expr.atoms(Derivative)
+    gs = [Dummy() for d in ds]
+    dict_to = dict(zip(ds, gs))
+    dict_from = dict(zip(gs, ds))
+    return expr.subs(dict_to).subs(*args, **kwargs).subs(dict_from)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -551,7 +551,7 @@ class KanesMethod(object):
 
         # Break the kinematic differential eqs apart into f_0 and f_1
         f_0 = self._f_k.subs(u_zero) + self._k_kqdot*Matrix(self._qdot)
-        f_1 = self._f_k.subs(qd_zero) + self._k_ku*Matrix(self._u) 
+        f_1 = self._f_k.subs(qd_zero) + self._k_ku*Matrix(self._u)
 
         # Break the dynamic differential eqs into f_2 and f_3
         f_2 = _subs_keep_derivs(self._frstar, qd_u_zero)
@@ -571,7 +571,7 @@ class KanesMethod(object):
         q_d = self._qdep
         u_i = self._u[:-len(self._udep)]
         u_d = self._udep
-        
+
         # Form dictionary of auxiliary speeds & and their derivatives,
         # setting each to 0.
         uaux = self._uaux
@@ -596,7 +596,7 @@ class KanesMethod(object):
             if diff(i, dynamicsymbols._t) in r:
                 raise ValueError('Cannot have derivatives of specified \
                                  quantities when linearizing forcing terms.')
-        return Linearizer(f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i, q_d, 
+        return Linearizer(f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i, q_d,
                 u_i, u_d, r)
 
     def kanes_equations(self, FL, BL):

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -523,13 +523,13 @@ class KanesMethod(object):
         """ Forms the general form for a system of constrained equations. The
         general form is composed of seven separate equations:
 
-        Configuration Constraint:   f_c(q, t)
-        Velocity Constraint:        f_v(q, u, t)
-        Acceleration Constraint:    f_a(q, q', u, u', t)
-        Kinematic Differential Eqs: f_0(q, q', t) + f_1(q, u, t)
-        Dynamic Differential Eqs:   f_2(q, u', t) + f_3(q, q', u, r, t)
+        Configuration constraints:        f_c(q, t)
+        Velocity constraints:             f_v(q, u, t)
+        Acceleration constraints:         f_a(q, q', u, u', t)
+        Kinematic differential equations: f_0(q, q', t) + f_1(q, u, t)
+        Dynamic differential equations:   f_2(q, u', t) + f_3(q, q', u, r, t)
 
-        This method returns a tuple of (f_c, f_v, f_a, f_0, f_1, f_2, f_3). """
+        This method returns a tuple of (f_c, f_v, f_a, f_0, f_1, f_2, f_3)."""
 
         # The Kane's method class breaks these into pieces. Need to reassemble
         f_c = self._f_h
@@ -561,7 +561,7 @@ class KanesMethod(object):
         """ Returns an instance of the Linearizer class, initiated from the
         data in the KanesMethod class. This may be more desirable than using
         the linearize class method, as the Linearizer object will allow more
-        efficient recalculation (i.e. about varying operating points """
+        efficient recalculation (i.e. about varying operating points)."""
 
         if (self._fr is None) or (self._frstar is None):
             raise ValueError('Need to compute Fr, Fr* first.')
@@ -571,14 +571,14 @@ class KanesMethod(object):
         q = self._q
         u = self._u
         if self._qdep:
-            q_i = self._q[:-len(self._qdep)]
+            q_i = q[:-len(self._qdep)]
         else:
-            q_i = self._q
+            q_i = q
         q_d = self._qdep
         if self._udep:
-            u_i = self._u[:-len(self._udep)]
+            u_i = u[:-len(self._udep)]
         else:
-            u_i = self._u
+            u_i = u
         u_d = self._udep
 
         # Form dictionary of auxiliary speeds & and their derivatives,
@@ -636,7 +636,7 @@ class KanesMethod(object):
         ud_op: operating point for d/dt u
         r_op: operating point for forcing vector
 
-        For more documentation, please see the `Linearizer` class"""
+        For more documentation, please see the `Linearizer` class."""
 
         linearizer = self.to_linearizer()
         result = linearizer.linearize(**kwargs)

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -543,10 +543,10 @@ class KanesMethod(object):
             f_a = Matrix([])
 
         # Dicts to sub to zero, for splitting up expressions
-        u_zero = {i: 0 for i in self._u}
-        ud_zero = {i: 0 for i in self._udot}
-        qd_zero = {i: 0 for i in self._qdot}
-        qd_u_zero = {i: 0 for i in self._qdot + self._u}
+        u_zero = dict((i, 0) for i in self._u)
+        ud_zero = dict((i, 0) for i in self._udot)
+        qd_zero = dict((i, 0) for i in self._qdot)
+        qd_u_zero = dict((i, 0) for i in self._qdot + self._u)
 
         # Break the kinematic differential eqs apart into f_0 and f_1
         f_0 = self._f_k.subs(u_zero) + self._k_kqdot*Matrix(self._qdot)
@@ -585,7 +585,7 @@ class KanesMethod(object):
         # setting each to 0.
         uaux = self._uaux
         uauxdot = [diff(i, dynamicsymbols._t) for i in uaux]
-        uaux_zero = {i: 0 for i in uaux + uauxdot}
+        uaux_zero = dict((i, 0) for i in uaux + uauxdot)
 
         # Checking for dynamic symbols outside the dynamic differential
         # equations; throws error if there is.

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -2,15 +2,14 @@ from __future__ import print_function, division
 
 __all__ = ['KanesMethod']
 
-from sympy import Symbol, zeros, Matrix, diff, solve_linear_system_LU, eye
+from sympy import zeros, Matrix, diff, solve_linear_system_LU, eye
 from sympy.core.compatibility import reduce
 from sympy.utilities import default_sort_key
 from sympy.physics.vector import ReferenceFrame, dynamicsymbols, \
      Point, partial_velocity
 from sympy.physics.mechanics.particle import Particle
 from sympy.physics.mechanics.rigidbody import RigidBody
-from sympy.physics.mechanics.functions import inertia_of_point_mass, \
-    _mat_inv_mul, _subs_keep_derivs
+from sympy.physics.mechanics.functions import _mat_inv_mul, _subs_keep_derivs
 from sympy.physics.mechanics.linearize import Linearizer
 
 class KanesMethod(object):
@@ -640,7 +639,7 @@ class KanesMethod(object):
         For more documentation, please see the `Linearizer` class"""
 
         linearizer = self.to_linearizer()
-        result =  linearizer.linearize(**kwargs)
+        result = linearizer.linearize(**kwargs)
         return result + (linearizer.r,)
 
     def kanes_equations(self, FL, BL):

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -603,7 +603,7 @@ class KanesMethod(object):
         linearized form, M*[q', u']^T = A*[q_ind, u_ind]^T + B*r.
 
         If kwarg A_and_B is True, returns A, B, r for the linearized form
-        dx = A*x + B*r, where x = [q_ind u_ind]^T. Note that this is
+        dx = A*x + B*r, where x = [q_ind, u_ind]^T. Note that this is
         computationally intensive if there are many symbolic parameters. For
         this reason, it may be more desirable to use the default A_and_B=False,
         returning M, A, and B. Values may then be substituted in to these
@@ -614,16 +614,10 @@ class KanesMethod(object):
         motion that are not part of q, u, q', or u'. They are sorted in
         canonical form.
 
-        The operating points may be also entered using kwargs. The more values
+        The operating points may be also entered using the `op_point` kwarg.
+        This takes a dictionary of {symbol: value}, or a an iterable of such
+        dictionaries. The values may be numberic or symbolic. The more values
         you can specify beforehand, the faster this computation will run.
-        Operating points are specified as dictionaries of {symbol: value}. The
-        value may be numeric or symbolic itself. Operating point kwargs are:
-
-        q_op: operating point for q (generalized coordinates)
-        u_op: operating point for u (generalized speeds)
-        qd_op: operating point for d/dt q
-        ud_op: operating point for d/dt u
-        r_op: operating point for forcing vector
 
         As part of the deprecation cycle, the new method will not be used unless
         the kwarg `new_method` is set to True. If the kwarg is missing, or set

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -567,9 +567,15 @@ class KanesMethod(object):
         f_c, f_v, f_a, f_0, f_1, f_2, f_3 = self._general_form()
         q = self._q
         u = self._u
-        q_i = self._q[:-len(self._qdep)]
+        if self._qdep:
+            q_i = self._q[:-len(self._qdep)]
+        else:
+            q_i = self._q
         q_d = self._qdep
-        u_i = self._u[:-len(self._udep)]
+        if self._udep:
+            u_i = self._u[:-len(self._udep)]
+        else:
+            u_i = self._u
         u_d = self._udep
 
         # Form dictionary of auxiliary speeds & and their derivatives,
@@ -599,6 +605,17 @@ class KanesMethod(object):
         return Linearizer(f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i, q_d,
                 u_i, u_d, r)
 
+    def linearize(self):
+        """ Linearize the equations of motion about a symbolic operating point.
+        
+        Returns M, A, B, r for the linearized form, M*dx = A*x + B*r,
+        where x = [q_independent u_independent]^T 
+        
+        For more fine tuned operation, please see the `Linearizer` class"""
+        linearizer = self.to_linearizer()
+        M, A, B =  linearizer.linearize()
+        return M, A, B, linearizer.r
+        
     def kanes_equations(self, FL, BL):
         """ Method to form Kane's equations, Fr + Fr* = 0.
 

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -198,7 +198,7 @@ class Linearizer(object):
         else:
             self._B_u = Matrix()
 
-    def linearize(self, op_point=None, A_and_B=False, simplify=True):
+    def linearize(self, op_point=None, A_and_B=False, simplify=False):
         """Linearize the system about the operating point. Note that
         q_op, u_op, qd_op, ud_op must satisfy the equations of motion.
         These may be either symbolic or numeric.
@@ -221,7 +221,7 @@ class Linearizer(object):
 
         simplify : bool, optional
             Determines if returned values are simplified before return.
-            Default is True.
+            For large expressions this may be time consuming. Default is False.
 
         Note that the process of solving with A_and_B=True is computationally
         intensive if there are many symbolic parameters. For this reason,

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -36,6 +36,130 @@ class Linearizer(object):
         self.qd = self.q.diff(t)
         self.ud = self.u.diff(t)
 
+        # Calculates here only need to be run once:
+        self._form_permutation_matrices()
+        self._form_block_matrices()
+        self._form_coefficient_matrices()
+
+    def _form_permutation_matrices(self):
+        """ Forms the permutation matrices for this choice of independent
+        coordinates and speeds """
+
+        # Extract dimension variables
+        n = len(self.q)
+        o = len(self.u)
+        l = len(self.f_c)
+        m = len(self.f_a)
+        # Compute permutation matrices
+        if n != 0:
+            self.Pq = permutation_matrix(self.q, Matrix([self.q_i, self.q_d]))
+            if l > 0:
+                self.Pqi = self.Pq[:, :-l]
+                self.Pqd = self.Pq[:, -l:]
+            else:
+                self.Pqi = self.Pq
+                self.Pqd = Matrix([])
+        if o != 0:
+            self.Pu = permutation_matrix(self.u, Matrix([self.u_i, self.u_d]))
+            if m > 0:
+                self.Pui = self.Pu[:, :-m]
+                self.Pud = self.Pu[:, -m:]
+            else:
+                self.Pui = self.Pu
+                self.Pud = Matrix([])
+        # Compute combination permutation matrix for computing A and B
+        P_col1 = Matrix([self.Pqi, zeros(o, n - l)])
+        P_col2 = Matrix([zeros(n, o - m), self.Pui])
+        if P_col1:
+            if P_col2:
+                self.P_prime = P_col1.row_join(P_col2)
+            else:
+                self.P_prime = P_col1
+        else:
+            self.P_prime = P_col2
+
+    def _form_coefficient_matrices(self):
+        """ Form the coefficient matrices. These only need to be solved for once"""
+
+        # Dimension terms
+        n = len(self.q)
+        o = len(self.u)
+        l = len(self.f_c)
+        m = len(self.f_a)
+        # Build up the coefficient matrices C_0, C_1, and C_2
+        # If there are configuration constraints (l > 0), form C_0 as normal.
+        # If not, C_0 is I_(nxn). Note that this works even if n=0
+        if l > 0:
+            f_c_jac_q = self.f_c.jacobian(self.q)
+            self.C_0 = (eye(n) - self.Pqd * (f_c_jac_q * self.Pqd).inv() * f_c_jac_q) * self.Pqi
+        else:
+            self.C_0 = eye(n)
+        # If there are motion constraints (m > 0), form C_1 and C_2 as normal.
+        # If not, C_1 is 0, and C_2 is I_(oxo). Note that this works even if
+        # o = 0.
+        if m > 0:
+            f_v_jac_u = self.f_v.jacobian(self.u)
+            temp = self.Pud * (f_v_jac_u * self.Pud).inv()
+            if n != 0:
+                f_v_jac_q = self.f_v.jacobian(self.q)
+                self.C_1 = -temp * f_v_jac_q
+            else:
+                self.C_1 = 0
+            self.C_2 = (eye(o) - temp * f_v_jac_u) * self.Pui
+        else:
+            self.C_1 = 0
+            self.C_2 = eye(o)
+
+    def _form_block_matrices(self):
+        """ Form the block matrices. These only need to be solved for once """
+
+        # Dimension terms
+        n = len(self.q)
+        o = len(self.u)
+        s = len(self.r)
+        l = len(self.f_c)
+        m = len(self.f_a)
+        # Block Matrix Definitions. These are only defined if under certain
+        # conditions. If undefined, an empty matrix is used instead
+        if n != 0:
+            self.M_qq = self.f_0.jacobian(self.qd)
+            self.A_qq = -(self.f_0 + self.f_1).jacobian(self.q)
+        else:
+            self.M_qq = Matrix([])
+            self.A_qq = Matrix([])
+        if o != 0 and m != 0:
+            self.M_uuc = self.f_a.jacobian(self.ud)
+            self.A_uuc = -self.f_a.jacobian(self.u)
+        else:
+            self.M_uuc = Matrix([])
+            self.A_uuc = Matrix([])
+        if o != 0 and o != m:
+            self.M_uud = self.f_2.jacobian(self.ud)
+            self.A_uud = -self.f_3.jacobian(self.u)
+        else:
+            self.M_uud = Matrix([])
+            self.A_uud = Matrix([])
+        if n != 0 and m != 0:
+            self.M_uqc = self.f_a.jacobian(self.qd)
+            self.A_uqc = -self.f_a.jacobian(self.q)
+        else:
+            self.M_uqc = Matrix([])
+            self.A_uqc = Matrix([])
+        if n != 0 and o != m:
+            self.M_uqd = self.f_2.jacobian(self.qd)
+            self.A_uqd = -(self.f_2 + self.f_3).jacobian(self.q)
+        else:
+            self.M_uqd = Matrix([])
+            self.A_uqd = Matrix([])
+        if o != 0 and n != 0:
+            self.A_qu = -self.f_1.jacobian(self.u)
+        else:
+            self.A_qu = Matrix([])
+        if s != 0 and o != m:
+            self.B_u = -self.f_3.jacobian(self.r)
+        else:
+            self.B_u = Matrix([])
+                
     def linearize(self, q_trim=None, u_trim=None, qd_trim=None, ud_trim=None, r_trim=None, A_and_B=False):
         """ Linearize the system about the trim conditions. Note that
         q_trim, u_trim, qd_trim, ud_trim must satisfy the equations of motion.
@@ -69,117 +193,105 @@ class Linearizer(object):
         dtrim = qd_trim
         dtrim.update(ud_trim)
 
-        # Rename terms to shorten expressions
-        q = self.q
-        u = self.u
-        qd = self.qd
-        ud = self.ud
-        r = self.r
-        q_i = self.q_i
-        q_d = self.q_d
-        u_i = self.u_i
-        u_d = self.u_d
-        f_0 = self.f_0
-        f_1 = self.f_1
-        f_2 = self.f_2
-        f_3 = self.f_3
-        f_a = self.f_a
-        f_v = self.f_v
-        f_c = self.f_c
-
         # Dimension terms
-        n = len(q)
-        o = len(u)
-        s = len(r)
-        l = len(f_c)
-        m = len(f_a)
+        n = len(self.q)
+        o = len(self.u)
+        s = len(self.r)
+        l = len(self.f_c)
+        m = len(self.f_a)
 
-        # Compute permutation matrices
-        Pq = permutation_matrix(q, Matrix([q_i, q_d]))
-        if l > 0:
-            Pqi = Pq[:, :-l]
-            Pqd = Pq[:, -l:]
-        else:
-            Pqi = Pq
-            Pqd = Matrix([])
-        Pu = permutation_matrix(u, Matrix([u_i, u_d]))
-        if m > 0:
-            Pui = Pu[:, :-m]
-            Pud = Pu[:, -m:]
-        else:
-            Pui = Pu
-            Pud = Matrix([])
-
-        # Block Matrix Definitions
-        M_qq = f_0.jacobian(qd)
-        M_uqd = f_2.jacobian(qd)
-        M_uud = f_2.jacobian(ud)
-        A_qq = -(f_0 + f_1).jacobian(q)
-        A_qu = -f_1.jacobian(u)
-        A_uqd = -(f_2 + f_3).jacobian(q)
-        A_uud = -f_3.jacobian(u)
-        # Only form these if there are dependent speeds (m > 0).
-        if m > 0:
-            M_uqc = f_a.jacobian(qd)
-            M_uuc = f_a.jacobian(ud)
-            A_uqc = -f_a.jacobian(q)
-            A_uuc = -f_a.jacobian(u)
+        # Rename terms to shorten expressions
+        M_qq = self.M_qq
+        A_qq = self.A_qq
+        M_uuc = self.M_uuc
+        A_uuc = self.A_uuc
+        M_uud = self.M_uud
+        A_uud = self.A_uud
+        M_uqc = self.M_uqc
+        A_uqc = self.A_uqc
+        M_uqd = self.M_uqd
+        A_uqd = self.A_uqd
+        A_qu = self.A_qu
+        B_u = self.B_u
+        C_0 = self.C_0
+        C_1 = self.C_1
+        C_2 = self.C_2
 
         # Build up Mass Matrix
         #     |M_qq    0_nxo|
         # M = |M_uqc   M_uuc|
         #     |M_uqd   M_uud|
-        row1 = M_qq.row_join(zeros(n, o))
-        # The second row only exists if there are motion constraints
-        if m > 0:
-            row2 = M_uqc.row_join(M_uuc)
+        if o != 0:
+            col2 = Matrix([zeros(n, o), M_uuc, M_uud])
+        if n != 0:
+            col1 = Matrix([M_qq, M_uqc, M_uqd])
+            if o != 0:
+                M = col1.row_join(col2)
+            else:
+                M = col1
         else:
-            row2 = Matrix([])
-        row3 = M_uqd.row_join(M_uud)
-        M = Matrix([row1, row2, row3])
+            M = col2
         M_eq = _subs_keep_derivs(M.subs(dtrim), trim)
         M_eq.simplify()
-
-        # Build up the coefficient matrices C_0, C_1, and C_2
-        # If there are configuration constraints (l > 0), form C_0 as normal.
-        # If not, C_0 is I_(nxn)
-        if l > 0:
-            f_c_jac_q = f_c.jacobian(q)
-            C_0 = (eye(n) - Pqd * (f_c_jac_q * Pqd).inv() * f_c_jac_q) * Pqi
-        else:
-            C_0 = eye(n)
-        # If there are motion constraints (m > 0), form C_1 and C_2 as normal.
-        # If not, C_1 is 0, and C_2 is I_(oxo)
-        if m > 0:
-            f_v_jac_q = f_v.jacobian(q)
-            f_v_jac_u = f_v.jacobian(u)
-            temp = Pud * (f_v_jac_u * Pud).inv()
-            C_1 = -temp * f_v_jac_q
-            C_2 = (eye(o) - temp * f_v_jac_u) * Pui
-        else:
-            C_1 = 0
-            C_2 = eye(o)
 
         # Build up state coefficient matrix A
         #     |(A_qq + A_qu*C_1)*C_0       A_qu*C_2|
         # A = |(A_uqc + A_uuc*C_1)*C_0    A_uuc*C_2|
         #     |(A_uqd + A_uud*C_1)*C_0    A_uud*C_2|
-        row1 = ((A_qq + A_qu * C_1) * C_0).row_join(A_qu * C_2)
-        # The second row only exists if there are motion constraints
-        if m > 0:
-            row2 = ((A_uqc + A_uuc * C_1) * C_0).row_join(A_uuc * C_2)
+        # Col 1 is only defined if n != 0
+        if n != 0:
+            r1c1 = A_qq
+            if o != 0:
+                r1c1 += A_qu*C_1
+            r1c1 = r1c1 * C_0
+            if m != 0:
+                r2c1 = A_uqc
+                if o != 0:
+                    r2c1 += A_uuc*C_1
+                r2c1 = r2c1 * C_0
+            else:
+                r2c1 = Matrix([])
+            if o != m:
+                r3c1 = A_uqd
+                if o != 0:
+                    r3c1 += A_uud*C_1
+                r3c1 = r3c1 * C_0
+            else:
+                r3c1 = Matrix([])
+            col1 = Matrix([r1c1, r2c1, r3c1])
         else:
-            row2 = Matrix([])
-        row3 = ((A_uqd + A_uud * C_1) * C_0).row_join(A_uud * C_2)
-        Amat = Matrix([row1, row2, row3])
+            col1 = Matrix([])
+        # Col 2 is only defined if o != 0
+        if o != 0:
+            if n != 0:
+                r1c2 = A_qu * C_2
+            else:
+                r1c2 = Matrix([])
+            if m != 0:
+                r2c2 = A_uuc * C_2
+            else:
+                r2c2 = Matrix([])
+            if o != m:
+                r3c2 = A_uud * C_2
+            else:
+                r3c2 = Matrix([])
+            col2 = Matrix([r1c2, r2c2, r3c2])
+        else:
+            col2 = Matrix([])
+        if col1:
+            if col2:
+                Amat = col1.row_join(col2)
+            else:
+                Amat = col1
+        else:
+            Amat = col2
         Amat_eq = _subs_keep_derivs(Amat.subs(dtrim), trim)
         Amat_eq.simplify()
 
         # Build up the B matrix if there are forcing variables
         #     |0_(n + m)xs|
         # B = |B_u        |
-        if s > 0:
-            B_u = -f_3.jacobian(r)
+        if s != 0 and o != m:
             Bmat = zeros(n + m, s).col_join(B_u)
             Bmat_eq = _subs_keep_derivs(Bmat.subs(dtrim), trim)
         else:
@@ -188,14 +300,11 @@ class Linearizer(object):
         # kwarg A_and_B indicates to return  A, B for forming the equation
         # dx = [A]x + [B]r, where x = [q_ind, u_ind]^T,
         if A_and_B:
-            P_row1 = Pqi.row_join(zeros(n, o - m))
-            P_row2 = zeros(o, n - l).row_join(Pui)
-            P = P_row1.col_join(P_row2)
             Minv = M_eq.inv()
-            A_cont = P.T*Minv*Amat_eq
+            A_cont = self.P_prime.T*Minv*Amat_eq
             A_cont.simplify()
             if Bmat_eq:
-                B_cont = P.T*Minv*Bmat_eq
+                B_cont = self.P_prime.T*Minv*Bmat_eq
                 B_cont.simplify()
             else:
                 B_cont = Bmat_eq

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -2,15 +2,17 @@ from __future__ import print_function, division
 
 __all__ = ['Linearizer']
 
-from sympy import symbols, Matrix, eye, zeros, solve, cos, sqrt, Poly, flatten
-from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
-        dot, cross, mprint, inertia
+from sympy import Matrix, eye, zeros
+from sympy.utilities.iterables import flatten
+from sympy.physics.vector import dynamicsymbols 
+from sympy.physics.mechanics.functions import _subs_keep_derivs
 
 class Linearizer(object):
     """ This object holds the general model form used as an intermediate
     for the linearize functions"""
 
-    def __init__(self, f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i=[], q_d=[], u_i=[], u_d=[], r=[]):
+    def __init__(self, f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, 
+            q_i=[], q_d=[], u_i=[], u_d=[], r=[]):
         # Generalized equation form
         self.f_0 = f_0
         self.f_1 = f_1
@@ -30,16 +32,44 @@ class Linearizer(object):
         self.r = Matrix(r)
 
         # Derivatives of generalized equation variables
-        t = symbols('t')
+        t = dynamicsymbols._t
         self.qd = self.q.diff(t)
         self.ud = self.u.diff(t)
-        
 
     def check_setpoint(self, q_trim, u_trim, r_trim):
         pass
 
-    def linearize(self, eq_ud, eq_u, eq_qd, qd_sym, eq_q, qd_sym_inv):
-        """ Perform the actual linearization"""
+    def linearize(self, q_trim=None, u_trim=None, qd_trim=None, ud_trim=None, A_and_B=False):
+        """ Linearize the system about the trim conditions. Note that
+        q_trim, u_trim, qd_trim, ud_trim must satisfy the equations of motion.
+        These may be either symbolic or numeric.
+
+        Parameters
+        ==========
+        q_trim : dict
+        u_trim : dict
+        qd_trim : dict
+        ud_trim : dict
+            Dictionaries of the trim conditions. These will be substituted in to
+            the linearized system before the linearization is complete. Leave blank
+            if you want a completely symbolic form. Note that any reduction in symbols
+            (whether substituted for numbers or expressions with a common parameter) will
+            result in faster runtime.
+
+        A_and_B : bool
+            If set to True, A and B for forming dx = [A]x + [B]r will returned, 
+            where x = [q_ind, u_ind]^T. If set to False, M, A, and B for forming
+            [M]x = [A]x + [B]r will be returned. Default is False. """
+
+        # Compose dicts of the trim condition for q, u, and qd, ud
+        if not q_trim: q_trim = dict()
+        if not u_trim: u_trim = dict()
+        if not qd_trim: qd_trim = dict()
+        if not ud_trim: ud_trim = dict()
+        trim = q_trim
+        trim.update(u_trim)
+        dtrim = qd_trim
+        dtrim.update(ud_trim)
 
         # Rename terms to shorten expressions
         q = self.q
@@ -47,12 +77,10 @@ class Linearizer(object):
         qd = self.qd
         ud = self.ud
         r = self.r
-
         q_i = self.q_i
         q_d = self.q_d
         u_i = self.u_i
         u_d = self.u_d
-
         f_0 = self.f_0
         f_1 = self.f_1
         f_2 = self.f_2
@@ -76,7 +104,7 @@ class Linearizer(object):
         Pui = Pu[:, :-m]
         Pud = Pu[:, -m:]
 
-        # Block Matrix Definitions (eq 57)
+        # Block Matrix Definitions
         M_qq = f_0.jacobian(qd)
         M_uqc = f_a.jacobian(qd)
         M_uuc = f_a.jacobian(ud)
@@ -97,7 +125,7 @@ class Linearizer(object):
         row2 = M_uqc.row_join(M_uuc)
         row3 = M_uqd.row_join(M_uud)
         M = row1.col_join(row2).col_join(row3)
-        M_eq = M.subs(eq_ud).subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+        M_eq = _subs_keep_derivs(M.subs(dtrim), trim)
         M_eq.simplify()
 
         # Jacobian of constraint matrices
@@ -105,7 +133,7 @@ class Linearizer(object):
         f_v_jac_q = f_v.jacobian(q)
         f_v_jac_u = f_v.jacobian(u)
 
-        # Matrices defined in equations (59) and equation (60)
+        # Coefficient Matrices
         C_0 = (eye(n) - Pqd * (f_c_jac_q * Pqd).inv() * f_c_jac_q) * Pqi
         C_1 = -Pud * (f_v_jac_u * Pud).inv() * f_v_jac_q
         C_2 = (eye(o) - Pud * (f_v_jac_u * Pud).inv() * f_v_jac_u) * Pui
@@ -118,7 +146,7 @@ class Linearizer(object):
         row2 = ((A_uqc + A_uuc * C_1) * C_0).row_join(A_uuc * C_2)
         row3 = ((A_uqd + A_uud * C_1) * C_0).row_join(A_uud * C_2)
         Amat = row1.col_join(row2).col_join(row3)
-        Amat_eq = Amat.subs(eq_ud).subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+        Amat_eq = _subs_keep_derivs(Amat.subs(dtrim), trim)
         Amat_eq.simplify()
 
         # Build up the B matrix if there are forcing variables
@@ -127,11 +155,26 @@ class Linearizer(object):
         if s > 0:
             B_u = -f_3.jacobian(r)
             Bmat = zeros(n + m, s).col_join(B_u)
-            Bmat_eq = Bmat.subs(eq_ud).subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+            Bmat_eq = _subs_keep_derivs(Bmat.subs(dtrim), trim)
         else:
             Bmat_eq = Matrix([])
 
-        return M_eq, Amat_eq, Bmat_eq
+        # kwarg A_and_B indicates to return  A, B for forming the equation
+        # dx = [A]x + [B]r, where x = [q_ind, u_ind]^T,
+        if A_and_B:
+            Minv = M_eq.inv()
+            A_cont = Minv*Amat_eq
+            A_cont.simplify()
+            if Bmat_eq:
+                B_cont = Minv*Bmat_eq
+                B_cont.simplify()
+            else:
+                B_cont = Bmat_eq
+            return A_cont, B_cont
+        # Otherwise return M, A, B for forming the equation
+        # [M]dx = [A]x + [B]r, where x = [q_ind, u_ind]^T
+        else:
+            return M_eq, Amat_eq, Bmat_eq
 
 
 def permutation_matrix(orig_vec, per_vec):
@@ -153,13 +196,4 @@ def permutation_matrix(orig_vec, per_vec):
     for i, j in enumerate(per_list):
         p_matrix[i, j] = 1
     return p_matrix
-
-
-
-
-
-
-
-
-
 

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -1,0 +1,165 @@
+from __future__ import print_function, division
+
+__all__ = ['Linearizer']
+
+from sympy import symbols, Matrix, eye, zeros, solve, cos, sqrt, Poly, flatten
+from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
+        dot, cross, mprint, inertia
+
+class Linearizer(object):
+    """ This object holds the general model form used as an intermediate
+    for the linearize functions"""
+
+    def __init__(self, f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i=[], q_d=[], u_i=[], u_d=[], r=[]):
+        # Generalized equation form
+        self.f_0 = f_0
+        self.f_1 = f_1
+        self.f_2 = f_2
+        self.f_3 = f_3
+        self.f_c = f_c
+        self.f_v = f_v
+        self.f_a = f_a
+
+        # Generalized equation variables
+        self.q = Matrix(q)
+        self.u = Matrix(u)
+        self.q_i = Matrix(q_i)
+        self.q_d = Matrix(q_d)
+        self.u_i = Matrix(u_i)
+        self.u_d = Matrix(u_d)
+        self.r = Matrix(r)
+
+        # Derivatives of generalized equation variables
+        t = symbols('t')
+        self.qd = self.q.diff(t)
+        self.ud = self.u.diff(t)
+        
+
+    def check_setpoint(self, q_trim, u_trim, r_trim):
+        pass
+
+    def linearize(self, eq_ud, eq_u, eq_qd, qd_sym, eq_q, qd_sym_inv):
+        """ Perform the actual linearization"""
+
+        # Rename terms to shorten expressions
+        q = self.q
+        u = self.u
+        qd = self.qd
+        ud = self.ud
+        r = self.r
+
+        q_i = self.q_i
+        q_d = self.q_d
+        u_i = self.u_i
+        u_d = self.u_d
+
+        f_0 = self.f_0
+        f_1 = self.f_1
+        f_2 = self.f_2
+        f_3 = self.f_3
+        f_a = self.f_a
+        f_v = self.f_v
+        f_c = self.f_c
+
+        # Dimension terms
+        n = len(q)
+        o = len(u)
+        s = len(r)
+        l = len(f_c)
+        m = len(f_a)
+
+        # Compute permutation matrices
+        Pq = permutation_matrix(q, q_i.col_join(q_d))
+        Pqi = Pq[:, :-l]
+        Pqd = Pq[:, -l:]
+        Pu = permutation_matrix(u, u_i.col_join(u_d))
+        Pui = Pu[:, :-m]
+        Pud = Pu[:, -m:]
+
+        # Block Matrix Definitions (eq 57)
+        M_qq = f_0.jacobian(qd)
+        M_uqc = f_a.jacobian(qd)
+        M_uuc = f_a.jacobian(ud)
+        M_uqd = f_2.jacobian(qd)
+        M_uud = f_2.jacobian(ud)
+        A_qq = -(f_0 + f_1).jacobian(q)
+        A_qu = -f_1.jacobian(u)
+        A_uqc = -f_a.jacobian(q)
+        A_uuc = -f_a.jacobian(u)
+        A_uqd = -(f_2 + f_3).jacobian(q)
+        A_uud = -f_3.jacobian(u)
+
+        # Build up Mass Matrix 
+        #     |M_qq    0_nxo|
+        # M = |M_uqc   M_uuc|
+        #     |M_uqd   M_uud|
+        row1 = M_qq.row_join(zeros(n, o))
+        row2 = M_uqc.row_join(M_uuc)
+        row3 = M_uqd.row_join(M_uud)
+        M = row1.col_join(row2).col_join(row3)
+        M_eq = M.subs(eq_ud).subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+        M_eq.simplify()
+
+        # Jacobian of constraint matrices
+        f_c_jac_q = f_c.jacobian(q)
+        f_v_jac_q = f_v.jacobian(q)
+        f_v_jac_u = f_v.jacobian(u)
+
+        # Matrices defined in equations (59) and equation (60)
+        C_0 = (eye(n) - Pqd * (f_c_jac_q * Pqd).inv() * f_c_jac_q) * Pqi
+        C_1 = -Pud * (f_v_jac_u * Pud).inv() * f_v_jac_q
+        C_2 = (eye(o) - Pud * (f_v_jac_u * Pud).inv() * f_v_jac_u) * Pui
+
+        # Build up state coefficient matrix A
+        #     |(A_qq + A_qu*C_1)*C_0      A_qu*C_2|
+        # A = |(A_uqc + A_uuc*C_1)*C_0    A_uuc*C_2|
+        #     |(A_uqd + A_uud*C_1)*C_0    A_uud*C_2|
+        row1 = ((A_qq + A_qu * C_1) * C_0).row_join(A_qu * C_2)
+        row2 = ((A_uqc + A_uuc * C_1) * C_0).row_join(A_uuc * C_2)
+        row3 = ((A_uqd + A_uud * C_1) * C_0).row_join(A_uud * C_2)
+        Amat = row1.col_join(row2).col_join(row3)
+        Amat_eq = Amat.subs(eq_ud).subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+        Amat_eq.simplify()
+
+        # Build up the B matrix if there are forcing variables
+        #     |0_(n + m)xs|
+        # B = |B_u        |
+        if s > 0:
+            B_u = -f_3.jacobian(r)
+            Bmat = zeros(n + m, s).col_join(B_u)
+            Bmat_eq = Bmat.subs(eq_ud).subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+        else:
+            Bmat_eq = Matrix([])
+
+        return M_eq, Amat_eq, Bmat_eq
+
+
+def permutation_matrix(orig_vec, per_vec):
+    """ Compute the permutation matrix to change order of
+    orig_vec into order of per_vec 
+    
+    Parameters
+    ==========
+    orig_vec : Vector or List
+        (n x 1) of original symbol ordering
+
+    per_vec : Vector or List
+        (n x 1) of desired symbol ordering
+    """
+    if not isinstance(orig_vec, (list, tuple)):
+        orig_list = flatten(orig_vec)
+    per_list = [orig_list.index(i) for i in per_vec]
+    p_matrix = zeros(len(orig_list))
+    for i, j in enumerate(per_list):
+        p_matrix[i, j] = 1
+    return p_matrix
+
+
+
+
+
+
+
+
+
+

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -146,7 +146,7 @@ class Linearizer(object):
             self.M_uqc = Matrix([])
             self.A_uqc = Matrix([])
         if n != 0 and o != m:
-            self.M_uqd = self.f_2.jacobian(self.qd)
+            self.M_uqd = self.f_3.jacobian(self.qd)
             self.A_uqd = -(self.f_2 + self.f_3).jacobian(self.q)
         else:
             self.M_uqd = Matrix([])

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -159,19 +159,19 @@ class Linearizer(object):
             self.B_u = -self.f_3.jacobian(self.r)
         else:
             self.B_u = Matrix([])
-                
-    def linearize(self, q_trim=None, u_trim=None, qd_trim=None, ud_trim=None, r_trim=None, A_and_B=False):
+
+    def linearize(self, q_op=None, u_op=None, qd_op=None, ud_op=None, r_op=None, A_and_B=False):
         """ Linearize the system about the trim conditions. Note that
-        q_trim, u_trim, qd_trim, ud_trim must satisfy the equations of motion.
+        q_op, u_op, qd_op, ud_op must satisfy the equations of motion.
         These may be either symbolic or numeric.
 
         Parameters
         ==========
-        q_trim : dict
-        u_trim : dict
-        qd_trim : dict
-        ud_trim : dict
-        r_trim : dict
+        q_op : dict
+        u_op : dict
+        qd_op : dict
+        ud_op : dict
+        r_op : dict
             Dictionaries of the trim conditions. These will be substituted in to
             the linearized system before the linearization is complete. Leave blank
             if you want a completely symbolic form. Note that any reduction in symbols
@@ -184,14 +184,14 @@ class Linearizer(object):
             [M]x = [A]x + [B]r will be returned. Default is False. """
 
         # Compose dicts of the trim condition for q, u, and qd, ud
-        if not q_trim: q_trim = dict()
-        if not u_trim: u_trim = dict()
-        if not qd_trim: qd_trim = dict()
-        if not ud_trim: ud_trim = dict()
-        trim = q_trim
-        trim.update(u_trim)
-        dtrim = qd_trim
-        dtrim.update(ud_trim)
+        if not q_op: q_op = dict()
+        if not u_op: u_op = dict()
+        if not qd_op: qd_op = dict()
+        if not ud_op: ud_op = dict()
+        trim = q_op
+        trim.update(u_op)
+        dtrim = qd_op
+        dtrim.update(ud_op)
 
         # Dimension terms
         n = len(self.q)

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -25,8 +25,7 @@ def test_one_dof():
     forcing = KM.forcing
     rhs = MM.inv() * forcing
     assert expand(rhs[0]) == expand(-(q * k + u * c) / m)
-    assert KM.linearize() == \
-        (Matrix([[0, 1], [-k, -c]]), Matrix([]), Matrix([]))
+    assert KM.linearize(A_and_B=True)[0] == Matrix([[0, 1], [-k/m, -c/m]])
 
 
 def test_two_dof():
@@ -153,13 +152,9 @@ def test_rolling_disc():
     # This code tests our output vs. benchmark values. When r=g=m=1, the
     # critical speed (where all eigenvalues of the linearized equations are 0)
     # is 1 / sqrt(3) for the upright case.
-    forcing_full = KM.forcing_full
-    forcing_full.simplify()
-    rhs_full = KM.mass_matrix_full.inv() * forcing_full
-    rhs_jac = rhs_full.jacobian([q1, q2, q3, u1, u2, u3])
-    rhs_jac_subbed = rhs_jac.subs({r: 1, g: 1, m: 1})
-    rhs_jac_upright = rhs_jac_subbed.subs({q1: 0, q2: 0, q3: 0, u1: 0, u3: 0})
-    assert rhs_jac_upright.subs(u2, 1 / sqrt(3)).eigenvals() == {S(0): 6}
+    A = KM.linearize(A_and_B=True)[0]
+    A_upright = A.subs({r: 1, g: 1, m: 1}).subs({q1: 0, q2: 0, q3: 0, u1: 0, u3: 0})
+    assert A_upright.subs(u2, 1 / sqrt(3)).eigenvals() == {S(0): 6}
 
 
 def test_aux():

--- a/sympy/physics/mechanics/tests/test_kane.py
+++ b/sympy/physics/mechanics/tests/test_kane.py
@@ -25,7 +25,7 @@ def test_one_dof():
     forcing = KM.forcing
     rhs = MM.inv() * forcing
     assert expand(rhs[0]) == expand(-(q * k + u * c) / m)
-    assert KM.linearize(A_and_B=True)[0] == Matrix([[0, 1], [-k/m, -c/m]])
+    assert KM.linearize(A_and_B=True, new_method=True)[0] == Matrix([[0, 1], [-k/m, -c/m]])
 
 
 def test_two_dof():
@@ -152,7 +152,7 @@ def test_rolling_disc():
     # This code tests our output vs. benchmark values. When r=g=m=1, the
     # critical speed (where all eigenvalues of the linearized equations are 0)
     # is 1 / sqrt(3) for the upright case.
-    A = KM.linearize(A_and_B=True)[0]
+    A = KM.linearize(A_and_B=True, new_method=True)[0]
     A_upright = A.subs({r: 1, g: 1, m: 1}).subs({q1: 0, q2: 0, q3: 0, u1: 0, u3: 0})
     assert A_upright.subs(u2, 1 / sqrt(3)).eigenvals() == {S(0): 6}
 

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,6 +1,6 @@
-from sympy import symbols, Matrix, eye, zeros, solve, cos, sqrt, Poly, sin
-from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
-        dot, cross, mprint, inertia)
+from sympy import symbols, Matrix, solve, simplify, cos, sin, atan
+from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
+        dot, cross, inertia, KanesMethod, Particle, RigidBody
 
 from sympy.physics.mechanics.linearize import Linearizer
 
@@ -11,25 +11,20 @@ def test_linearize_rolling_disc():
     # Configuration variables and their time derivatives
     q1, q2, q3, q4, q5, q6 = q = dynamicsymbols('q1:7')
     q1d, q2d, q3d, q4d, q5d, q6d = qd = [qi.diff(t) for qi in q]
-    q_zero = {qi : 0 for qi in q}
-    qd_zero = {qdi : 0 for qdi in qd}
-    qd_sym = dict(zip(qd, symbols('qd1:7')))
-    qd_sym_inv = {v: k for (k, v) in qd_sym.items()}
 
     # Generalized speeds and their time derivatives
     u = dynamicsymbols('u:6')
     u1, u2, u3, u4, u5, u6 = u = dynamicsymbols('u1:7')
     u1d, u2d, u3d, u4d, u5d, u6d = ud = [ui.diff(t) for ui in u]
-    u_zero = {ui : 0 for ui in u}
-    ud_zero = {udi : 0 for udi in ud}
-    ud_sym = dict(zip(ud, symbols('ud1:7')))
-    ud_sym_inv = {v: k for (k, v) in ud_sym.items()}
 
     # Reference frames
     N = ReferenceFrame('N')                   # Inertial frame
+    NO = Point('NO')                          # Inertial origin
     A = N.orientnew('A', 'Axis', [q1, N.z])   # Yaw intermediate frame
     B = A.orientnew('B', 'Axis', [q2, A.x])   # Lean intermediate frame
     C = B.orientnew('C', 'Axis', [q3, B.y])   # Disc fixed frame
+    CO = NO.locatenew('CO', q4*N.x + q5*N.y + q6*N.z)      # Disc center
+
     # Disc angular velocity in N expressed using time derivatives of coordinates
     w_c_n_qd = C.ang_vel_in(N)
     w_b_n_qd = B.ang_vel_in(N)
@@ -37,200 +32,206 @@ def test_linearize_rolling_disc():
     # Inertial angular velocity and angular acceleration of disc fixed frame
     C.set_ang_vel(N, u1*B.x + u2*B.y + u3*B.z)
 
-    # Points
-    NO = Point('NO')                                       # Inertial origin
-    CO = NO.locatenew('CO', q4*N.x + q5*N.y + q6*N.z)      # Disc center
     # Disc center velocity in N expressed using time derivatives of coordinates
     v_co_n_qd = CO.pos_from(NO).dt(N)
 
     # Disc center velocity in N expressed using generalized speeds
     CO.set_vel(N, u4*C.x + u5*C.y + u6*C.z)
 
-    P = CO.locatenew('P', r*B.z)                           # Disc-ground contact
+    # Disc Ground Contact Point
+    P = CO.locatenew('P', r*B.z)
     P.v2pt_theory(CO, N, C)
 
-    # Configuration constraint and its Jacobian w.r.t. q        (Table 1)
+    # Configuration constraint
     f_c = Matrix([q6 - dot(CO.pos_from(P), N.z)])
 
-    # Velocity level constraints                                (Table 1)
+    # Velocity level constraints
     f_v = Matrix([dot(P.vel(N), uv) for uv in C])
-    f_v_du = f_v.jacobian(u)
 
     # Kinematic differential equations
     kindiffs = Matrix([dot(w_c_n_qd - C.ang_vel_in(N), uv) for uv in B] +
-                      [dot(v_co_n_qd - CO.vel(N), uv) for uv in N])
+                        [dot(v_co_n_qd - CO.vel(N), uv) for uv in N])
     qdots = solve(kindiffs, qd)
 
+    # Set angular velocity of remaining frames
     B.set_ang_vel(N, w_b_n_qd.subs(qdots))
-    C.set_ang_acc(N, C.ang_vel_in(N).dt(B) + cross(B.ang_vel_in(N),
-                                                C.ang_vel_in(N)))
-
-    # f_0 and f_1                                               (Table 1)
-    f_0 = kindiffs.subs(u_zero)
-    f_1 = kindiffs.subs(qd_zero)
-
-    # Acceleration level constraints                            (Table 1)
-    f_a = f_v.diff(t)
-
-    # Kane's dynamic equations via elbow grease
-    # Partial angular velocities and velocities
-    partial_w_C = [C.ang_vel_in(N).diff(ui, N) for ui in u]
-    partial_v_CO = [CO.vel(N).diff(ui, N) for ui in u]
+    C.set_ang_acc(N, C.ang_vel_in(N).dt(B) + cross(B.ang_vel_in(N), C.ang_vel_in(N)))
 
     # Active forces
     F_CO = m*g*A.z
-    # Generalized active forces (unconstrained)
-    gaf = [dot(F_CO, pv) for pv in partial_v_CO]
 
     # Inertia force
     R_star_CO = -m*CO.acc(N)
 
+    # Create inertia dyadic of disc C about point CO
     I = (m * r**2) / 4
     J = (m * r**2) / 2
+    I_C_CO = inertia(C, I, J, I)
 
-    # Inertia torque
-    I_C_CO = inertia(C, I, J, I)     # Inertia of disc C about point CO
-    T_star_C = -(dot(I_C_CO, C.ang_acc_in(N))
-                + cross(C.ang_vel_in(N), dot(I_C_CO, C.ang_vel_in(N))))
+    Disc = RigidBody('Disc', CO, C, m, (I_C_CO, CO))
+    BL = [Disc]
+    FL = [(CO, F_CO)]
+    KM = KanesMethod(N, [q1, q2, q3, q4, q5], [u1, u2, u3], kd_eqs=kindiffs, 
+            q_dependent=[q6], configuration_constraints=f_c, 
+            u_dependent=[u4, u5, u6], velocity_constraints=f_v)
+    (fr, fr_star) = KM.kanes_equations(FL, BL)
 
-    # Generalized inertia forces (unconstrained)
-    gif = [dot(R_star_CO, pv) + dot(T_star_C, pav) for pv, pav in
-            zip(partial_v_CO, partial_w_C)]
+    # Test generalized form equations
+    gen_form = KM._general_form()
+    assert gen_form[0] == f_c
+    assert gen_form[1] == f_v
+    assert gen_form[2] == f_v.diff(t)
+    sol = solve(gen_form[3] + gen_form[4], qd)
+    for qi in qd:
+        assert sol[qi] == qdots[qi]
+    assert simplify(gen_form[5] + gen_form[6] - fr - fr_star) == Matrix([0, 0, 0])
 
-    # Constrained dynamic equations
-    # Coordinates to be independent: q1, q2, q3, q4, q5
-    # Coordinates to be dependent: q6
-    # Already in the correct order, so permutation matrix is simply a 6x6 identity
-    # matrix
-    Pq = eye(6)
-    Pqi = Pq[:, :-1]
-    Pqd = Pq[:, -1]
+    # Perform the linearization
+    # Precomputed trim condition:
+    eq_q = {q6: -r*cos(q2)}
+    eq_u = {u1: 0,
+            u2: sin(q2)*q1d + q3d,
+            u3: cos(q2)*q1d,
+            u4: -r*(sin(q2)*q1d + q3d)*cos(q3),
+            u5: 0,
+            u6: -r*(sin(q2)*q1d + q3d)*sin(q3)}
+    eq_qd = {q2d: 0,
+            q4d: -r*(sin(q2)*q1d + q3d)*cos(q1),
+            q5d: -r*(sin(q2)*q1d + q3d)*sin(q1),
+            q6d: 0}
+    eq_ud = {u1d: 4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5,
+            u2d: 0,
+            u3d: 0,
+            u4d: r*(sin(q2)*sin(q3)*q1d*q3d + sin(q3)*q3d**2),
+            u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
+            u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
 
-    # Speeds to be independent:  u1, u2, u3
-    # Speeds to be dependent:  u4, u5, u6
-    # Already in the correct order, so permutation matrix is simply a 6x6 identity
-    # matrix
-    Pu = eye(6)
-    Pui = Pu[:, :-3]
-    Pud = Pu[:, -3:]
-
-    # The constraints can be written as:
-    # Bi * ui + Bd * ud = 0
-    Bi = f_v_du*Pui
-    Bd = f_v_du*Pud
-    Bd_inv_Bi = -Bd.inv() * Bi
-
-    indep_indices = [0, 1, 2]   # Body fixed angular velocity measure numbers
-    dep_indices = [3, 4, 5]     # Body fixed velocity measure numbers
-
-    gif_indep = Matrix([gif[i] for i in indep_indices])
-    gif_dep = Matrix([gif[i] for i in dep_indices])
-    gaf_indep = Matrix([gaf[i] for i in indep_indices])
-    gaf_dep = Matrix([gaf[i] for i in dep_indices])
-
-    gif_con = gif_indep + Bd_inv_Bi.T * gif_dep
-    gaf_con = gaf_indep + Bd_inv_Bi.T * gaf_dep
-
-
-    # Build the part of f_2 and f_3 that come from Kane's equations, the first three
-    # rows of each
-    f_2 = gif_con.subs(ud_sym).subs(u_zero).subs(qd_zero).subs(ud_sym_inv)
-    f_3 = gif_con.subs(ud_zero) + gaf_con
-
-    # Linearization Code solving, for equilibrium conditions:
-    eq_q = solve(f_c, q6)
-    eq_qd = {q2d: 0}        # lean rate
-
-    # Dependent generalized speeds in terms of independent ones
-    eq_u = solve(f_v.subs(eq_q), [u4, u5, u6])
-
-    # Solve kinematic equations for qdots in terms of independent u's
-    kindiffs_eq = kindiffs.subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
-    soln = solve(kindiffs_eq, [u1, u2, u3, q4d, q5d, q6d])
-
-    for ui in [u1, u2, u3]:
-        eq_u[ui] = soln[ui]
-
-    for ui in [u4, u5, u6]:
-        eq_u[ui] = eq_u[ui].subs(soln)
-
-    for qdi in [q4d, q5d, q6d]:
-        eq_qd[qdi] = soln[qdi]
-
-    # Solve differentiated acceleration constraints for dependent du/dt's
-    f_a_eq = f_a.subs(eq_qd).subs(ud_sym).subs(eq_u).subs(qd_sym).subs(eq_q).subs(
-                qd_sym_inv).subs(ud_sym_inv)
-    eq_ud = solve(f_a_eq, [u4d, u5d, u6d])
-
-    # Evaluate the dynamic equations using the dependent du/dt's
-    dyndiffs_eq = (f_2 + f_3).subs(eq_ud).subs(eq_qd).subs(ud_sym).subs(
-                eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv).subs(ud_sym_inv).expand()
-
-    # Solve the dynamic equations for the remaining two independent du/dt's
-    soln = solve(dyndiffs_eq, [u1d, u2d, u3d])
-
-    # Update the equilibrium dependent du/dt's with solution for the independent du/dt's
-    for udi in [u4d, u5d, u6d]:
-        eq_ud[udi] = eq_ud[udi].subs(soln)
-
-    for udi in [u1d, u2d, u3d]:
-        eq_ud[udi] = soln[udi]
-
-    f_c_eq = f_c.subs(eq_q)
-    f_v_eq = f_v.subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
-    f_a_eq = f_a.subs(eq_ud).subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv).expand()
-    f_a_eq.simplify()
-    f_0_eq_plus_f_1_eq = (f_0 + f_1).subs(eq_qd).subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
-    f_0_eq_plus_f_1_eq.simplify()
-    f_2_eq_plus_f_3_eq = (f_2 + f_3).subs(eq_ud).subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv).expand()
-    f_2_eq_plus_f_3_eq.simplify()
-
-    # Verify equilibrium is satisfied
-    assert(f_c_eq == zeros(1,1))
-    assert(f_v_eq == zeros(3,1))
-    assert(f_a_eq == zeros(3,1))
-    assert(f_0_eq_plus_f_1_eq == zeros(6,1))
-    assert(f_2_eq_plus_f_3_eq == zeros(3,1))
-
-    # New Linearization Method
-    q_i = q[:-1]
-    q_d = q[-1:]
-    u_i = u[:-3]
-    u_d = u[-3:]
-    linearizer = Linearizer(f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i, q_d, u_i, u_d)
-    Mnew, Anew, Bnew = linearizer.linearize(eq_ud, eq_u, eq_qd, qd_sym, eq_q, qd_sym_inv)
-
-    # Precomputed solutions
-    M_sol = Matrix([[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
-                    [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, -sin(q3)*q3d, 0, 0, 0, 0, cos(q3), 0, 1, 0, 0], 
-                    [0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 1, 0], 
-                    [0, 0, cos(q3)*q3d, 0, 0, 0, 0, sin(q3), 0, 0, 0, 1], 
-                    [0, 0, 0, 0, 0, 0, -1/4, 0, 0, 0, -1, 0], 
-                    [0, 0, 0, 0, 0, 0, 0, -1/2, 0, cos(q3), 0, sin(q3)], 
-                    [0, 0, 0, 0, 0, 0, 0, 0, -1/4, 0, 0, 0]]) 
-
-    A_sol = Matrix([[0, 0, 0, 0, 0, 1, 0, 0], 
-                    [0, 0, 0, 0, 0, 0, 1, 0], 
-                    [0, 0, 0, 0, 0, 0, 0, 1], 
-                    [sin(q1)*q3d, 0, 0, 0, 0, -sin(q1), -cos(q1), 0], 
-                    [-cos(q1)*q3d, 0, 0, 0, 0, cos(q1), -sin(q1), 0], 
-                    [0, 0, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, cos(q3)*q3d**2, 0, 0, 0, sin(q3)*q3d, 0], 
-                    [0, 0, 0, 0, 0, 0, 0, 0], 
-                    [0, 0, sin(q3)*q3d**2, 0, 0, 0, -cos(q3)*q3d, 0], 
-                    [0, -1, 0, 0, 0, 0, 0, -3*q3d/2], 
-                    [0, 0, q3d**2, 0, 0, 0, 0, 0], 
-                    [0, 0, 0, 0, 0, q3d/2, 0, 0]]) 
-
-    B_sol = Matrix(0, 0, [])
+    linearizer = KM.to_linearizer()
+    A, B = linearizer.linearize(eq_q, eq_u, eq_qd, eq_ud, A_and_B=True)
 
     upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}
-    assert Mnew.subs(upright_nominal) == M_sol
-    assert Anew.subs(upright_nominal) == A_sol
-    assert Bnew.subs(upright_nominal) == B_sol
+
+    # Precomputed solution
+    A_sol = Matrix([[0, 0, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 1, 0],
+                    [sin(q1)*q3d, 0, 0, 0, 0, -sin(q1), -cos(q1), 0],
+                    [-cos(q1)*q3d, 0, 0, 0, 0, cos(q1), -sin(q1), 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 4/5, 0, 0, 0, 0, 0, 6*q3d/5],
+                    [0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, -2*q3d, 0, 0],
+                    [0, 0, cos(q3)*q3d**2, 0, 0, 0, 2*sin(q3)*q3d, 0],
+                    [0, 4/5, 0, 0, 0, 0, 0, 6*q3d/5],
+                    [0, 0, sin(q3)*q3d**2, 0, 0, 0, -2*cos(q3)*q3d, 0]])
+    B_sol = Matrix([])
+
+    # Check that linearization is correct
+    assert A.subs(upright_nominal) == A_sol
+    assert B.subs(upright_nominal) == B_sol
+
+def test_linearize_pendulum_minimal():
+    q1 = dynamicsymbols('q1')                     # angle of pendulum
+    u1 = dynamicsymbols('u1')                     # Angular velocity
+    q1d = dynamicsymbols('q1', 1)                 # Angular velocity
+    u1d = dynamicsymbols('u1', 1)                 # Angular acceleration
+    L, m, t = symbols('L, m, t')
+    g = 9.8
+
+    # Compose world frame
+    N = ReferenceFrame('N')
+    pN = Point('N*')
+    pN.set_vel(N, 0)
+
+    # A.x is along the pendulum
+    A = N.orientnew('A', 'axis', [q1, N.z])
+    A.set_ang_vel(N, u1*N.z)
+
+    # Locate point P relative to the origin N*
+    P = pN.locatenew('P', L*A.x)
+    P.v2pt_theory(pN, N, A)
+    pP = Particle('pP', P, m)
+
+    # Create Kinematic Differential Equations
+    kde = Matrix([q1d - u1])
+
+    # Input the force resultant at P
+    R = m*g*N.x
+
+    # Solve for eom with kanes method
+    KM = KanesMethod(N, q_ind=[q1], u_ind=[u1], kd_eqs=kde)
+    (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+    kdd = KM.kindiffdict()
+    eom = KM.rhs()
+    eom = eom.subs(kdd)
+    eom.simplify()
+    trim_cond = Matrix([0, 0])
+
+    # Perform simple linearization by computing the jacobian of the rhs
+    eom_lin = eom.jacobian([q1, u1]).subs(dict(zip([q1, u1], trim_cond)))
+    eom_lin
+    # TODO: add linearization with Linearizer, compare with above
+
+def test_linearize_pendulum_nonminimal():
+    # Create generalized coordinates and speeds for this non-minimal realization
+    # q1, q2 = N.x and N.y coordinates of pendulum
+    # u1, u2 = N.x and N.y velocities of pendulum
+    q1, q2 = qs = dynamicsymbols('q1:3')
+    q1d, q2d = qds = dynamicsymbols('q1:3', level=1)
+    u1, u2 = us = dynamicsymbols('u1:3')
+    u1d, u2d = uds = dynamicsymbols('u1:3', level=1)
+    L, m, t = symbols('L, m, t')
+    g = 9.8
+
+    # Compose world frame
+    N = ReferenceFrame('N')
+    pN = Point('N*')
+    pN.set_vel(N, 0)
+
+    # A.x is along the pendulum
+    theta1 = atan(q2/q1)
+    A = N.orientnew('A', 'axis', [theta1, N.z])
+
+    # Locate the pendulum mass
+    P = pN.locatenew('P1', q1*N.x + q2*N.y)
+    pP = Particle('pP', P, m)
+
+    # Calculate the kinematic differential equations
+    kde = Matrix([q1d - u1,
+                  q2d - u2])
+    dq_dict = solve(kde, [q1d, q2d])
+
+    # Set velocity of point P
+    P.set_vel(N, P.pos_from(pN).dt(N).subs(dq_dict))
+
+    # Configuration constraint is length of pendulum
+    f_c = Matrix([P.pos_from(pN).magnitude() - L])
+
+    # Velocity constraint is that the velocity in the A.x direction is 
+    # always zero (the pendulum is never getting longer).
+    f_v = Matrix([P.vel(N).express(A).dot(A.x)])
+    f_v.simplify()
+
+    # Acceleration constraints is the time derivative of the velocity constraint
+    f_a = f_v.diff(t)
+    f_a.simplify()
+
+    # Input the force resultant at P
+    R = m*g*N.x
+
+    # Derive the equations of motion using the KanesMethod class.
+    KM = KanesMethod(N, q_ind=[q1], u_ind=[u1], q_dependent=[q2], 
+            u_dependent=[u2], configuration_constraints=f_c, 
+            velocity_constraints=f_v, acceleration_constraints=f_a, kd_eqs=kde)
+    (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
+    kdd = KM.kindiffdict()
+
+    # Set the trim condition to be straight down, and non-moving
+    q_trim = {q1: L, q2: 0}
+    u_trim = {u1: 0, u2: 0}
+    
+    linearizer = KM.to_linearizer()
+    A, B = linearizer.linearize(q_trim, u_trim, A_and_B=True)
+    # TODO: This results in some nan and zoo (complex infinity) terms.
+    # I don't think it should at this trim condition, but I could be wrong
 

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,6 +1,6 @@
 from sympy import symbols, Matrix, solve, simplify, cos, sin, atan, sqrt
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
-    dot, cross, inertia, KanesMethod, Particle, RigidBody
+    dot, cross, inertia, KanesMethod, Particle, RigidBody, Linearizer
 
 def test_linearize_rolling_disc():
     # Symbols for time and constant parameters
@@ -72,14 +72,14 @@ def test_linearize_rolling_disc():
     (fr, fr_star) = KM.kanes_equations(FL, BL)
 
     # Test generalized form equations
-    gen_form = KM._general_form()
-    assert gen_form[0] == f_c
-    assert gen_form[1] == f_v
-    assert gen_form[2] == f_v.diff(t)
-    sol = solve(gen_form[3] + gen_form[4], qd)
+    linearizer = KM.to_linearizer()
+    assert linearizer.f_c == f_c
+    assert linearizer.f_v == f_v
+    assert linearizer.f_a == f_v.diff(t)
+    sol = solve(linearizer.f_0 + linearizer.f_1, qd)
     for qi in qd:
         assert sol[qi] == qdots[qi]
-    assert simplify(gen_form[5] + gen_form[6] - fr - fr_star) == Matrix([0, 0, 0])
+    assert simplify(linearizer.f_2 + linearizer.f_3 - fr - fr_star) == Matrix([0, 0, 0])
 
     # Perform the linearization
     # Precomputed trim condition:
@@ -101,7 +101,8 @@ def test_linearize_rolling_disc():
              u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
              u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
 
-    A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, qd_op=qd_op, ud_op=ud_op, A_and_B=True, new_method=True)
+    A, B = linearizer.linearize(q_op=q_op, u_op=u_op, qd_op=qd_op,
+            ud_op=ud_op, A_and_B=True)
 
     upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}
 

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -82,7 +82,7 @@ def test_linearize_rolling_disc():
     assert simplify(linearizer.f_2 + linearizer.f_3 - fr - fr_star) == Matrix([0, 0, 0])
 
     # Perform the linearization
-    # Precomputed trim condition:
+    # Precomputed operating point
     q_op = {q6: -r*cos(q2)}
     u_op = {u1: 0,
             u2: sin(q2)*q1d + q3d,
@@ -213,7 +213,7 @@ def test_linearize_pendulum_nonminimal():
             velocity_constraints=f_v, acceleration_constraints=f_a, kd_eqs=kde)
     (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
 
-    # Set the trim condition to be straight down, and non-moving
+    # Set the operating point to be straight down, and non-moving
     q_op = {q1: L, q2: 0}
     u_op = {u1: 0, u2: 0}
     ud_op = {u1d: 0, u2d: 0}

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -101,7 +101,7 @@ def test_linearize_rolling_disc():
              u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
              u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
 
-    A, B = linearizer.linearize(op_point=[q_op, u_op, qd_op, ud_op], A_and_B=True)
+    A, B = linearizer.linearize(op_point=[q_op, u_op, qd_op, ud_op], A_and_B=True, simplify=True)
 
     upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}
 
@@ -155,7 +155,7 @@ def test_linearize_pendulum_minimal():
     (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
 
     # Linearize
-    A, B, inp_vec = KM.linearize(A_and_B=True, new_method=True)
+    A, B, inp_vec = KM.linearize(A_and_B=True, new_method=True, simplify=True)
 
     assert A == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
     assert B == Matrix([])
@@ -218,7 +218,8 @@ def test_linearize_pendulum_nonminimal():
     u_op = {u1: 0, u2: 0}
     ud_op = {u1d: 0, u2d: 0}
 
-    A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op], A_and_B=True, new_method=True)
+    A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op], A_and_B=True,
+            new_method=True, simplify=True)
 
     assert A == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,0 +1,236 @@
+from sympy import symbols, Matrix, eye, zeros, solve, cos, sqrt, Poly, sin
+from sympy.physics.mechanics import (dynamicsymbols, ReferenceFrame, Point,
+        dot, cross, mprint, inertia)
+
+from sympy.physics.mechanics.linearize import Linearizer
+
+def test_linearize_rolling_disc():
+    # Symbols for time and constant parameters
+    t, r, m, g, v = symbols('t r m g v')
+
+    # Configuration variables and their time derivatives
+    q1, q2, q3, q4, q5, q6 = q = dynamicsymbols('q1:7')
+    q1d, q2d, q3d, q4d, q5d, q6d = qd = [qi.diff(t) for qi in q]
+    q_zero = {qi : 0 for qi in q}
+    qd_zero = {qdi : 0 for qdi in qd}
+    qd_sym = dict(zip(qd, symbols('qd1:7')))
+    qd_sym_inv = {v: k for (k, v) in qd_sym.items()}
+
+    # Generalized speeds and their time derivatives
+    u = dynamicsymbols('u:6')
+    u1, u2, u3, u4, u5, u6 = u = dynamicsymbols('u1:7')
+    u1d, u2d, u3d, u4d, u5d, u6d = ud = [ui.diff(t) for ui in u]
+    u_zero = {ui : 0 for ui in u}
+    ud_zero = {udi : 0 for udi in ud}
+    ud_sym = dict(zip(ud, symbols('ud1:7')))
+    ud_sym_inv = {v: k for (k, v) in ud_sym.items()}
+
+    # Reference frames
+    N = ReferenceFrame('N')                   # Inertial frame
+    A = N.orientnew('A', 'Axis', [q1, N.z])   # Yaw intermediate frame
+    B = A.orientnew('B', 'Axis', [q2, A.x])   # Lean intermediate frame
+    C = B.orientnew('C', 'Axis', [q3, B.y])   # Disc fixed frame
+    # Disc angular velocity in N expressed using time derivatives of coordinates
+    w_c_n_qd = C.ang_vel_in(N)
+    w_b_n_qd = B.ang_vel_in(N)
+
+    # Inertial angular velocity and angular acceleration of disc fixed frame
+    C.set_ang_vel(N, u1*B.x + u2*B.y + u3*B.z)
+
+    # Points
+    NO = Point('NO')                                       # Inertial origin
+    CO = NO.locatenew('CO', q4*N.x + q5*N.y + q6*N.z)      # Disc center
+    # Disc center velocity in N expressed using time derivatives of coordinates
+    v_co_n_qd = CO.pos_from(NO).dt(N)
+
+    # Disc center velocity in N expressed using generalized speeds
+    CO.set_vel(N, u4*C.x + u5*C.y + u6*C.z)
+
+    P = CO.locatenew('P', r*B.z)                           # Disc-ground contact
+    P.v2pt_theory(CO, N, C)
+
+    # Configuration constraint and its Jacobian w.r.t. q        (Table 1)
+    f_c = Matrix([q6 - dot(CO.pos_from(P), N.z)])
+
+    # Velocity level constraints                                (Table 1)
+    f_v = Matrix([dot(P.vel(N), uv) for uv in C])
+    f_v_du = f_v.jacobian(u)
+
+    # Kinematic differential equations
+    kindiffs = Matrix([dot(w_c_n_qd - C.ang_vel_in(N), uv) for uv in B] +
+                      [dot(v_co_n_qd - CO.vel(N), uv) for uv in N])
+    qdots = solve(kindiffs, qd)
+
+    B.set_ang_vel(N, w_b_n_qd.subs(qdots))
+    C.set_ang_acc(N, C.ang_vel_in(N).dt(B) + cross(B.ang_vel_in(N),
+                                                C.ang_vel_in(N)))
+
+    # f_0 and f_1                                               (Table 1)
+    f_0 = kindiffs.subs(u_zero)
+    f_1 = kindiffs.subs(qd_zero)
+
+    # Acceleration level constraints                            (Table 1)
+    f_a = f_v.diff(t)
+
+    # Kane's dynamic equations via elbow grease
+    # Partial angular velocities and velocities
+    partial_w_C = [C.ang_vel_in(N).diff(ui, N) for ui in u]
+    partial_v_CO = [CO.vel(N).diff(ui, N) for ui in u]
+
+    # Active forces
+    F_CO = m*g*A.z
+    # Generalized active forces (unconstrained)
+    gaf = [dot(F_CO, pv) for pv in partial_v_CO]
+
+    # Inertia force
+    R_star_CO = -m*CO.acc(N)
+
+    I = (m * r**2) / 4
+    J = (m * r**2) / 2
+
+    # Inertia torque
+    I_C_CO = inertia(C, I, J, I)     # Inertia of disc C about point CO
+    T_star_C = -(dot(I_C_CO, C.ang_acc_in(N))
+                + cross(C.ang_vel_in(N), dot(I_C_CO, C.ang_vel_in(N))))
+
+    # Generalized inertia forces (unconstrained)
+    gif = [dot(R_star_CO, pv) + dot(T_star_C, pav) for pv, pav in
+            zip(partial_v_CO, partial_w_C)]
+
+    # Constrained dynamic equations
+    # Coordinates to be independent: q1, q2, q3, q4, q5
+    # Coordinates to be dependent: q6
+    # Already in the correct order, so permutation matrix is simply a 6x6 identity
+    # matrix
+    Pq = eye(6)
+    Pqi = Pq[:, :-1]
+    Pqd = Pq[:, -1]
+
+    # Speeds to be independent:  u1, u2, u3
+    # Speeds to be dependent:  u4, u5, u6
+    # Already in the correct order, so permutation matrix is simply a 6x6 identity
+    # matrix
+    Pu = eye(6)
+    Pui = Pu[:, :-3]
+    Pud = Pu[:, -3:]
+
+    # The constraints can be written as:
+    # Bi * ui + Bd * ud = 0
+    Bi = f_v_du*Pui
+    Bd = f_v_du*Pud
+    Bd_inv_Bi = -Bd.inv() * Bi
+
+    indep_indices = [0, 1, 2]   # Body fixed angular velocity measure numbers
+    dep_indices = [3, 4, 5]     # Body fixed velocity measure numbers
+
+    gif_indep = Matrix([gif[i] for i in indep_indices])
+    gif_dep = Matrix([gif[i] for i in dep_indices])
+    gaf_indep = Matrix([gaf[i] for i in indep_indices])
+    gaf_dep = Matrix([gaf[i] for i in dep_indices])
+
+    gif_con = gif_indep + Bd_inv_Bi.T * gif_dep
+    gaf_con = gaf_indep + Bd_inv_Bi.T * gaf_dep
+
+
+    # Build the part of f_2 and f_3 that come from Kane's equations, the first three
+    # rows of each
+    f_2 = gif_con.subs(ud_sym).subs(u_zero).subs(qd_zero).subs(ud_sym_inv)
+    f_3 = gif_con.subs(ud_zero) + gaf_con
+
+    # Linearization Code solving, for equilibrium conditions:
+    eq_q = solve(f_c, q6)
+    eq_qd = {q2d: 0}        # lean rate
+
+    # Dependent generalized speeds in terms of independent ones
+    eq_u = solve(f_v.subs(eq_q), [u4, u5, u6])
+
+    # Solve kinematic equations for qdots in terms of independent u's
+    kindiffs_eq = kindiffs.subs(eq_u).subs(eq_qd).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+    soln = solve(kindiffs_eq, [u1, u2, u3, q4d, q5d, q6d])
+
+    for ui in [u1, u2, u3]:
+        eq_u[ui] = soln[ui]
+
+    for ui in [u4, u5, u6]:
+        eq_u[ui] = eq_u[ui].subs(soln)
+
+    for qdi in [q4d, q5d, q6d]:
+        eq_qd[qdi] = soln[qdi]
+
+    # Solve differentiated acceleration constraints for dependent du/dt's
+    f_a_eq = f_a.subs(eq_qd).subs(ud_sym).subs(eq_u).subs(qd_sym).subs(eq_q).subs(
+                qd_sym_inv).subs(ud_sym_inv)
+    eq_ud = solve(f_a_eq, [u4d, u5d, u6d])
+
+    # Evaluate the dynamic equations using the dependent du/dt's
+    dyndiffs_eq = (f_2 + f_3).subs(eq_ud).subs(eq_qd).subs(ud_sym).subs(
+                eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv).subs(ud_sym_inv).expand()
+
+    # Solve the dynamic equations for the remaining two independent du/dt's
+    soln = solve(dyndiffs_eq, [u1d, u2d, u3d])
+
+    # Update the equilibrium dependent du/dt's with solution for the independent du/dt's
+    for udi in [u4d, u5d, u6d]:
+        eq_ud[udi] = eq_ud[udi].subs(soln)
+
+    for udi in [u1d, u2d, u3d]:
+        eq_ud[udi] = soln[udi]
+
+    f_c_eq = f_c.subs(eq_q)
+    f_v_eq = f_v.subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+    f_a_eq = f_a.subs(eq_ud).subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv).expand()
+    f_a_eq.simplify()
+    f_0_eq_plus_f_1_eq = (f_0 + f_1).subs(eq_qd).subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv)
+    f_0_eq_plus_f_1_eq.simplify()
+    f_2_eq_plus_f_3_eq = (f_2 + f_3).subs(eq_ud).subs(eq_u).subs(qd_sym).subs(eq_q).subs(qd_sym_inv).expand()
+    f_2_eq_plus_f_3_eq.simplify()
+
+    # Verify equilibrium is satisfied
+    assert(f_c_eq == zeros(1,1))
+    assert(f_v_eq == zeros(3,1))
+    assert(f_a_eq == zeros(3,1))
+    assert(f_0_eq_plus_f_1_eq == zeros(6,1))
+    assert(f_2_eq_plus_f_3_eq == zeros(3,1))
+
+    # New Linearization Method
+    q_i = q[:-1]
+    q_d = q[-1:]
+    u_i = u[:-3]
+    u_d = u[-3:]
+    linearizer = Linearizer(f_0, f_1, f_2, f_3, f_c, f_v, f_a, q, u, q_i, q_d, u_i, u_d)
+    Mnew, Anew, Bnew = linearizer.linearize(eq_ud, eq_u, eq_qd, qd_sym, eq_q, qd_sym_inv)
+
+    # Precomputed solutions
+    M_sol = Matrix([[0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
+                    [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, -sin(q3)*q3d, 0, 0, 0, 0, cos(q3), 0, 1, 0, 0], 
+                    [0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 1, 0], 
+                    [0, 0, cos(q3)*q3d, 0, 0, 0, 0, sin(q3), 0, 0, 0, 1], 
+                    [0, 0, 0, 0, 0, 0, -1/4, 0, 0, 0, -1, 0], 
+                    [0, 0, 0, 0, 0, 0, 0, -1/2, 0, cos(q3), 0, sin(q3)], 
+                    [0, 0, 0, 0, 0, 0, 0, 0, -1/4, 0, 0, 0]]) 
+
+    A_sol = Matrix([[0, 0, 0, 0, 0, 1, 0, 0], 
+                    [0, 0, 0, 0, 0, 0, 1, 0], 
+                    [0, 0, 0, 0, 0, 0, 0, 1], 
+                    [sin(q1)*q3d, 0, 0, 0, 0, -sin(q1), -cos(q1), 0], 
+                    [-cos(q1)*q3d, 0, 0, 0, 0, cos(q1), -sin(q1), 0], 
+                    [0, 0, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, cos(q3)*q3d**2, 0, 0, 0, sin(q3)*q3d, 0], 
+                    [0, 0, 0, 0, 0, 0, 0, 0], 
+                    [0, 0, sin(q3)*q3d**2, 0, 0, 0, -cos(q3)*q3d, 0], 
+                    [0, -1, 0, 0, 0, 0, 0, -3*q3d/2], 
+                    [0, 0, q3d**2, 0, 0, 0, 0, 0], 
+                    [0, 0, 0, 0, 0, q3d/2, 0, 0]]) 
+
+    B_sol = Matrix(0, 0, [])
+
+    upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}
+    assert Mnew.subs(upright_nominal) == M_sol
+    assert Anew.subs(upright_nominal) == A_sol
+    assert Bnew.subs(upright_nominal) == B_sol
+

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -101,7 +101,7 @@ def test_linearize_rolling_disc():
              u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
              u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
 
-    A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, qd_op=qd_op, ud_op=ud_op, A_and_B=True)
+    A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, qd_op=qd_op, ud_op=ud_op, A_and_B=True, new_method=True)
 
     upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}
 
@@ -155,7 +155,7 @@ def test_linearize_pendulum_minimal():
     (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
 
     # Linearize
-    A, B, inp_vec = KM.linearize(A_and_B=True)
+    A, B, inp_vec = KM.linearize(A_and_B=True, new_method=True)
 
     assert A == Matrix([[0, 1], [-9.8*cos(q1)/L, 0]])
     assert B == Matrix([])
@@ -218,7 +218,7 @@ def test_linearize_pendulum_nonminimal():
     u_op = {u1: 0, u2: 0}
     ud_op = {u1d: 0, u2d: 0}
 
-    A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, ud_op=ud_op, A_and_B=True)
+    A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, ud_op=ud_op, A_and_B=True, new_method=True)
 
     assert A == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -1,8 +1,6 @@
 from sympy import symbols, Matrix, solve, simplify, cos, sin, atan, sqrt
 from sympy.physics.mechanics import dynamicsymbols, ReferenceFrame, Point,\
-        dot, cross, inertia, KanesMethod, Particle, RigidBody
-
-from sympy.physics.mechanics.linearize import Linearizer
+    dot, cross, inertia, KanesMethod, Particle, RigidBody
 
 def test_linearize_rolling_disc():
     # Symbols for time and constant parameters
@@ -15,7 +13,7 @@ def test_linearize_rolling_disc():
     # Generalized speeds and their time derivatives
     u = dynamicsymbols('u:6')
     u1, u2, u3, u4, u5, u6 = u = dynamicsymbols('u1:7')
-    u1d, u2d, u3d, u4d, u5d, u6d = ud = [ui.diff(t) for ui in u]
+    u1d, u2d, u3d, u4d, u5d, u6d = [ui.diff(t) for ui in u]
 
     # Reference frames
     N = ReferenceFrame('N')                   # Inertial frame
@@ -60,9 +58,6 @@ def test_linearize_rolling_disc():
     # Active forces
     F_CO = m*g*A.z
 
-    # Inertia force
-    R_star_CO = -m*CO.acc(N)
-
     # Create inertia dyadic of disc C about point CO
     I = (m * r**2) / 4
     J = (m * r**2) / 2
@@ -96,15 +91,15 @@ def test_linearize_rolling_disc():
             u5: 0,
             u6: -r*(sin(q2)*q1d + q3d)*sin(q3)}
     qd_op = {q2d: 0,
-            q4d: -r*(sin(q2)*q1d + q3d)*cos(q1),
-            q5d: -r*(sin(q2)*q1d + q3d)*sin(q1),
-            q6d: 0}
+             q4d: -r*(sin(q2)*q1d + q3d)*cos(q1),
+             q5d: -r*(sin(q2)*q1d + q3d)*sin(q1),
+             q6d: 0}
     ud_op = {u1d: 4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5,
-            u2d: 0,
-            u3d: 0,
-            u4d: r*(sin(q2)*sin(q3)*q1d*q3d + sin(q3)*q3d**2),
-            u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
-            u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
+             u2d: 0,
+             u3d: 0,
+             u4d: r*(sin(q2)*sin(q3)*q1d*q3d + sin(q3)*q3d**2),
+             u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
+             u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
 
     A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, qd_op=qd_op, ud_op=ud_op, A_and_B=True)
 
@@ -132,7 +127,6 @@ def test_linearize_pendulum_minimal():
     q1 = dynamicsymbols('q1')                     # angle of pendulum
     u1 = dynamicsymbols('u1')                     # Angular velocity
     q1d = dynamicsymbols('q1', 1)                 # Angular velocity
-    u1d = dynamicsymbols('u1', 1)                 # Angular acceleration
     L, m, t = symbols('L, m, t')
     g = 9.8
 
@@ -170,10 +164,10 @@ def test_linearize_pendulum_nonminimal():
     # Create generalized coordinates and speeds for this non-minimal realization
     # q1, q2 = N.x and N.y coordinates of pendulum
     # u1, u2 = N.x and N.y velocities of pendulum
-    q1, q2 = qs = dynamicsymbols('q1:3')
-    q1d, q2d = qds = dynamicsymbols('q1:3', level=1)
-    u1, u2 = us = dynamicsymbols('u1:3')
-    u1d, u2d = uds = dynamicsymbols('u1:3', level=1)
+    q1, q2 = dynamicsymbols('q1:3')
+    q1d, q2d = dynamicsymbols('q1:3', level=1)
+    u1, u2 = dynamicsymbols('u1:3')
+    u1d, u2d = dynamicsymbols('u1:3', level=1)
     L, m, t = symbols('L, m, t')
     g = 9.8
 
@@ -218,7 +212,6 @@ def test_linearize_pendulum_nonminimal():
             u_dependent=[u1], configuration_constraints=f_c,
             velocity_constraints=f_v, acceleration_constraints=f_a, kd_eqs=kde)
     (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
-    kdd = KM.kindiffdict()
 
     # Set the trim condition to be straight down, and non-moving
     q_op = {q1: L, q2: 0}

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -101,8 +101,7 @@ def test_linearize_rolling_disc():
              u5d: r*(4*g*sin(q2)/(5*r) + sin(2*q2)*q1d**2/2 + 6*cos(q2)*q1d*q3d/5),
              u6d: -r*(sin(q2)*cos(q3)*q1d*q3d + cos(q3)*q3d**2)}
 
-    A, B = linearizer.linearize(q_op=q_op, u_op=u_op, qd_op=qd_op,
-            ud_op=ud_op, A_and_B=True)
+    A, B = linearizer.linearize(op_point=[q_op, u_op, qd_op, ud_op], A_and_B=True)
 
     upright_nominal = {q1d: 0, q2: 0, m: 1, r: 1, g: 1}
 
@@ -219,7 +218,7 @@ def test_linearize_pendulum_nonminimal():
     u_op = {u1: 0, u2: 0}
     ud_op = {u1d: 0, u2d: 0}
 
-    A, B, inp_vec = KM.linearize(q_op=q_op, u_op=u_op, ud_op=ud_op, A_and_B=True, new_method=True)
+    A, B, inp_vec = KM.linearize(op_point=[q_op, u_op, ud_op], A_and_B=True, new_method=True)
 
     assert A == Matrix([[0, 1], [-9.8/L, 0]])
     assert B == Matrix([])

--- a/sympy/physics/mechanics/tests/test_linearize.py
+++ b/sympy/physics/mechanics/tests/test_linearize.py
@@ -160,16 +160,17 @@ def test_linearize_pendulum_minimal():
     # Solve for eom with kanes method
     KM = KanesMethod(N, q_ind=[q1], u_ind=[u1], kd_eqs=kde)
     (fr, frstar) = KM.kanes_equations([(P, R)], [pP])
-    kdd = KM.kindiffdict()
-    eom = KM.rhs()
-    eom = eom.subs(kdd)
-    eom.simplify()
-    trim_cond = Matrix([0, 0])
 
-    # Perform simple linearization by computing the jacobian of the rhs
-    eom_lin = eom.jacobian([q1, u1]).subs(dict(zip([q1, u1], trim_cond)))
-    eom_lin
-    # TODO: add linearization with Linearizer, compare with above
+    # Linearize with Linearizer Class
+    linearizer = KM.to_linearizer()
+    A, B = linearizer.linearize(A_and_B=True)
+
+    A_sol = Matrix([[0, 1], 
+                    [-9.8*cos(q1)/L, 0]])
+    B_sol = Matrix([])
+
+    assert A == A_sol
+    assert B == B_sol
 
 def test_linearize_pendulum_nonminimal():
     # Create generalized coordinates and speeds for this non-minimal realization


### PR DESCRIPTION
This is a rewrite of the linearization methods in physics/mechanics to be more general. At this point, all previous functionality is supported, with a more modular structure. This pull request includes:
- A `Linearizer` class:
  Holds the system in the generalized form, performs the actual linearization with the `linearize` class method.
- A `to_linearizer` method for the `KanesMethod` class:
  This returns an initialized instance of `Linearizer`
- A `linearize` method for the `KanesMethod` class:
  This creates a `Linearizer` instance, calls the `linearize` method, and returns the result in one step.

Tests have been created for the new functions, and the old tests have been updated to use them.
