### PR TITLE
Shift two issue numbers (see #7579)

### DIFF
--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -312,7 +312,7 @@ def test_evalf_fast_series():
               fac(2*n + 1)**5, (n, 0, oo)), 100) == astr
 
 
-def test_evalf_fast_series_issue998():
+def test_evalf_fast_series_issue_4021():
     # Catalan's constant
     assert NS(Sum((-1)**(n - 1)*2**(8*n)*(40*n**2 - 24*n + 3)*fac(2*n)**3*
         fac(n)**2/n**3/(2*n - 1)/fac(4*n)**2, (n, 1, oo))/64, 100) == \

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -297,10 +297,9 @@ def test_matrices():
         [-cos(2*x), -cos(3*x)],
     ])
 
-# issue1012
-
 
 def test_integrate_functions():
+    # issue 4111
     assert integrate(f(x), x) == Integral(f(x), x)
     assert integrate(f(x), (x, 0, 1)) == Integral(f(x), (x, 0, 1))
     assert integrate(f(x)*diff(f(x), x), x) == f(x)**2/2


### PR DESCRIPTION
I'm still not sure about #4087.  The patch a945bc6 was introduced in #4021, issue #4087 was mentioned in this bugreport.  Maybe it's a typo (998 vs 988).

@fredrik-johansson
