### PR TITLE
Fix for series expansions in products of symbols with assumptions

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2439,9 +2439,7 @@ class Expr(Basic, EvalfMixin):
                 return rv.subs(xpos, x)
 
         if n is not None:  # nseries handling
-            _x = C.Dummy('x')
-            s0 = self.subs(x, _x)
-            s1 = s0._eval_nseries(_x, n=n, logx=logx)
+            s1 = self._eval_nseries(x, n=n, logx=logx)
             o = s1.getO() or S.Zero
             if o:
                 # make sure the requested order is returned
@@ -2450,39 +2448,39 @@ class Expr(Basic, EvalfMixin):
                     # leave o in its current form (e.g. with x*log(x)) so
                     # it eats terms properly, then replace it below
                     if n != 0:
-                        s1 += o.subs(_x, _x**C.Rational(n, ngot))
+                        s1 += o.subs(x, x**C.Rational(n, ngot))
                     else:
-                        s1 += C.Order(1, _x)
+                        s1 += C.Order(1, x)
                 elif ngot < n:
                     # increase the requested number of terms to get the desired
                     # number keep increasing (up to 9) until the received order
                     # is different than the original order and then predict how
                     # many additional terms are needed
                     for more in range(1, 9):
-                        s1 = s0._eval_nseries(_x, n=n + more, logx=logx)
+                        s1 = self._eval_nseries(x, n=n + more, logx=logx)
                         newn = s1.getn()
                         if newn != ngot:
                             ndo = n + (n - ngot)*more/(newn - ngot)
-                            s1 = s0._eval_nseries(_x, n=ndo, logx=logx)
+                            s1 = self._eval_nseries(x, n=ndo, logx=logx)
                             while s1.getn() < n:
-                                s1 = s0._eval_nseries(_x, n=ndo, logx=logx)
+                                s1 = self._eval_nseries(x, n=ndo, logx=logx)
                                 ndo += 1
                             break
                     else:
                         raise ValueError('Could not calculate %s terms for %s'
                                          % (str(n), self))
-                    s1 += C.Order(_x**n, _x)
+                    s1 += C.Order(x**n, x)
                 o = s1.getO()
                 s1 = s1.removeO()
             else:
-                o = C.Order(_x**n, _x)
+                o = C.Order(x**n, x)
                 if (s1 + o).removeO() == s1:
                     o = S.Zero
 
             try:
-                return (collect(s1, _x) + o).subs(_x, x)
+                return collect(s1, x) + o
             except NotImplementedError:
-                return (s1 + o).subs(_x, x)
+                return s1 + o
 
         else:  # lseries handling
             def yield_lseries(s):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2429,7 +2429,7 @@ class Expr(Basic, EvalfMixin):
 
         # from here on it's x0=0 and dir='+' handling
 
-        if x.is_positive is x.is_negative is None:
+        if x.is_positive is x.is_negative is None or x.is_Symbol is not True:
             # replace x with an x that has a positive assumption
             xpos = C.Dummy('x', positive=True, bounded=True)
             rv = self.subs(x, xpos).series(xpos, x0, n, dir, logx=logx)

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2766,6 +2766,14 @@ def test_X22():
     raise NotImplementedError("Fourier series not supported")
 
 
+def test_X23():
+    a, b = symbols('a b', positive=True)
+    x = a * b
+    s1 = series(exp(a), a, n=8)
+    s2 = series(exp(x), x, n=8)
+    assert s1.subs(a, x) == s2
+
+
 def test_Y1():
     t = symbols('t', real=True, positive=True)
     w = symbols('w', real=True)

--- a/sympy/core/tests/test_wester.py
+++ b/sympy/core/tests/test_wester.py
@@ -2766,14 +2766,6 @@ def test_X22():
     raise NotImplementedError("Fourier series not supported")
 
 
-def test_X23():
-    a, b = symbols('a b', positive=True)
-    x = a * b
-    s1 = series(exp(a), a, n=8)
-    s2 = series(exp(x), x, n=8)
-    assert s1.subs(a, x) == s2
-
-
 def test_Y1():
     t = symbols('t', real=True, positive=True)
     w = symbols('w', real=True)

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -1,5 +1,5 @@
 from sympy import sin, cos, exp, E, series, oo, S, Derivative, O, Integral, \
-    Function, log, sqrt, Symbol, Subs
+    Function, log, sqrt, Symbol, Subs, symbols
 from sympy.abc import x, y, n, k
 from sympy.utilities.pytest import raises
 from sympy.series.gruntz import calculate_series

--- a/sympy/series/tests/test_series.py
+++ b/sympy/series/tests/test_series.py
@@ -131,6 +131,15 @@ def test_x_is_base_detection():
     eq = (x**2)**(S(2)/3)
     assert eq.series() == x**(S(4)/3)
 
+
 def test_sin_power():
     e = sin(x)**1.2
     assert calculate_series(e, x) == x**1.2
+
+
+def test_exp_product_positive_factors():
+    a, b = symbols('a, b', positive=True)
+    x = a * b
+    s1 = series(exp(a), a, n=8)
+    s2 = series(exp(x), x, n=8)
+    assert s1.subs(a, x) == s2


### PR DESCRIPTION
I've been running into problems using series expansion of functions when doing the expansion in terms of a sympy expression that is a product of symbols with assumptions (of positivity). If no assumptions are specified the expansion works as expected, but when assumptions are added the series expansion fails with a traceback error message. This notebook demonstrates the issue:

http://nbviewer.ipython.org/gist/jrjohansson/bf7862198171b16d0ff9

This PR is an attempt to fix this issue by introducing a dummy variable in which the expansion is calculated, and then substitutes back the original expression before returning the result.
