### PR TITLE
Fix #7564: Matrices created from 1D ndarrays are in column form.

### DIFF
--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -161,7 +161,7 @@ class MatrixBase(object):
             flat_list = [cls._sympify(i) for i in flat_list]
 
         # Matrix(numpy.ones((2, 2)))
-        elif len(args) == 1 and hasattr(args[0], "__array__"):  # pragma: no cover
+        elif len(args) == 1 and hasattr(args[0], "__array__"):
             # NumPy array or matrix or some other object that implements
             # __array__. So let's first use this method to get a
             # numpy.array() and then make a python list out of it.
@@ -171,8 +171,8 @@ class MatrixBase(object):
                 flat_list = [cls._sympify(i) for i in arr.ravel()]
                 return rows, cols, flat_list
             elif len(arr.shape) == 1:
-                rows, cols = 1, arr.shape[0]
-                flat_list = [S.Zero]*cols
+                rows, cols = arr.shape[0], 1
+                flat_list = [S.Zero]*rows
                 for i in range(len(arr)):
                     flat_list[i] = cls._sympify(arr[i])
                 return rows, cols, flat_list

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -13,7 +13,7 @@ from sympy.matrices import (
     rot_axis3, wronskian, zeros)
 from sympy.core.compatibility import long, iterable
 from sympy.utilities.iterables import flatten, capture
-from sympy.utilities.pytest import raises, XFAIL, slow
+from sympy.utilities.pytest import raises, XFAIL, slow, skip
 
 from sympy.abc import x, y, z
 
@@ -2375,3 +2375,18 @@ def test_issue_7201():
 def test_free_symbols():
     for M in ImmutableMatrix, ImmutableSparseMatrix, Matrix, SparseMatrix:
         assert M([[x], [0]]).free_symbols == set([x])
+
+def test_from_ndarray():
+    """See issue 7465."""
+    try:
+        from numpy import array
+    except ImportError:
+        skip('NumPy must be available to test creating matrices from ndarrays')
+
+    assert Matrix(array([1, 2, 3])) == Matrix([1, 2, 3])
+    assert Matrix(array([[1, 2, 3]])) == Matrix([[1, 2, 3]])
+    assert Matrix(array([[1, 2, 3], [4, 5, 6]])) == \
+        Matrix([[1, 2, 3], [4, 5, 6]])
+    assert Matrix(array([x, y, z])) == Matrix([x, y, z])
+    raises(NotImplementedError, lambda: Matrix(array([[
+        [1, 2], [3, 4]], [[5, 6], [7, 8]]])))


### PR DESCRIPTION
This now matches the behaviour of matrices created from 1D lists.  Fixes #7564.
