### PR TITLE
Bounds checking for `_entry` function

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -347,7 +347,9 @@ class MatrixSymbol(MatrixExpr):
         raise TypeError( "%s object is not callable" % self.__class__ )
 
     def _entry(self, i, j):
-        return MatrixElement(self, i, j)
+        if(i < self.rows and j < self.cols):
+            return MatrixElement(self, i, j)
+        raise IndexError("Index out of bounds.")
 
     @property
     def free_symbols(self):
@@ -403,10 +405,12 @@ class Identity(MatrixExpr):
         return self
 
     def _entry(self, i, j):
-        if i == j:
-            return S.One
-        else:
-            return S.Zero
+        if(i < self.rows and j < self.cols):
+            if i == j:
+                return S.One
+            else:
+                return S.Zero
+        raise IndexError("Index out of bounds.")
 
     def _eval_determinant(self):
         return S.One
@@ -455,7 +459,9 @@ class ZeroMatrix(MatrixExpr):
         return self
 
     def _entry(self, i, j):
-        return S.Zero
+        if(i < self.rows and j < self.cols):
+            return S.Zero
+        raise IndexError("Index out of bounds.")
 
     def __nonzero__(self):
         return False


### PR DESCRIPTION
I was trying to implement the `_entry` function for `ElemWise` class. I realized all the `_entry` functions don't check for bounds and simply return `MatrixElement(self, i, j)`

```
In [5]: A = MatrixSymbol('A', 3, 3)

In [6]: A._entry(5, 6)
Out[6]: A[5, 6]
```

I understand this is an internal function but I felt the need for this.
