### PR TITLE
Fix examples after removing deprecated Plot (see d804fd2)

### DIFF
--- a/examples/advanced/gibbs_phenomenon.py
+++ b/examples/advanced/gibbs_phenomenon.py
@@ -14,7 +14,7 @@ See:
 """
 
 from sympy import var, sqrt, integrate, conjugate, seterr, Abs, pprint, I, pi,\
-    sin, cos, sign, Plot, lambdify, Integral, S
+    sin, cos, sign, lambdify, Integral, S
 
 # seterr(True)
 
@@ -139,7 +139,6 @@ def main():
     f = series(L)
     print("Fourier series of the step function")
     pprint(f)
-    # Plot(f.diff(x), [x, -5, 5, 3000])
     x0 = msolve(f.diff(x), x)
 
     print("x-value of the maximum:", x0)

--- a/examples/beginner/plotting_nice_plot.py
+++ b/examples/beginner/plotting_nice_plot.py
@@ -5,7 +5,8 @@
 Demonstrates simple plotting.
 """
 
-from sympy import Symbol, cos, sin, Plot, log, tan
+from sympy import Symbol, cos, sin, log, tan
+from sympy.plotting import PygletPlot
 from sympy.abc import x, y
 
 
@@ -14,7 +15,7 @@ def main():
     fun2 = sin(x)*sin(y)
     fun3 = cos(y) + log(tan(y/2)) + 0.2*x
 
-    Plot(fun1, fun2, fun3, [x, -0.00, 12.4, 40], [y, 0.1, 2, 40])
+    PygletPlot(fun1, fun2, fun3, [x, -0.00, 12.4, 40], [y, 0.1, 2, 40])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
e.g.

```
$ python examples/advanced/gibbs_phenomenon.py
Traceback (most recent call last):
  File "examples/advanced/gibbs_phenomenon.py", line 16, in <module>
    from sympy import var, sqrt, integrate, conjugate, seterr, Abs,
pprint, I, pi,\
ImportError: cannot import name Plot
```

fix #7593
