### PR TITLE
Fix bug in latex-printing Equivalent objects

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -721,8 +721,7 @@ class LatexPrinter(Printer):
         else:
             return r"\neg %s" % self._print(e.args[0])
 
-    def _print_And(self, e):
-        args = sorted(e.args, key=default_sort_key)
+    def _print_LogOp(self, args, char):
         arg = args[0]
         if arg.is_Boolean and not arg.is_Not:
             tex = r"\left(%s\right)" % self._print(arg)
@@ -731,33 +730,26 @@ class LatexPrinter(Printer):
 
         for arg in args[1:]:
             if arg.is_Boolean and not arg.is_Not:
-                tex += r" \wedge \left(%s\right)" % (self._print(arg))
+                tex += r" %s \left(%s\right)" % (char, self._print(arg))
             else:
-                tex += r" \wedge %s" % (self._print(arg))
+                tex += r" %s %s" % (char, self._print(arg))
 
         return tex
+
+    def _print_And(self, e):
+        args = sorted(e.args, key=default_sort_key)
+        return self._print_LogOp(args, r"\wedge")
 
     def _print_Or(self, e):
         args = sorted(e.args, key=default_sort_key)
-        arg = args[0]
-        if arg.is_Boolean and not arg.is_Not:
-            tex = r"\left(%s\right)" % self._print(arg)
-        else:
-            tex = r"%s" % self._print(arg)
-
-        for arg in args[1:]:
-            if arg.is_Boolean and not arg.is_Not:
-                tex += r" \vee \left(%s\right)" % (self._print(arg))
-            else:
-                tex += r" \vee %s" % (self._print(arg))
-
-        return tex
+        return self._print_LogOp(args, r"\vee")
 
     def _print_Implies(self, e, altchar=None):
         return r"%s %s %s" % (self._print(e.args[0]), altchar or r"\Rightarrow", self._print(e.args[1]))
 
     def _print_Equivalent(self, e, altchar=None):
-        return r"%s %s %s" % (self._print(e.args[0]), altchar or r"\equiv", self._print(e.args[1]))
+        args = sorted(e.args, key=default_sort_key)
+        return self._print_LogOp(args, altchar or r"\equiv")
 
     def _print_conjugate(self, expr, exp=None):
         tex = r"\overline{%s}" % self._print(expr.args[0])

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1044,6 +1044,7 @@ def test_Hadamard():
     assert latex(HadamardProduct(X, Y*Y)) == r'X \circ \left(Y Y\right)'
     assert latex(HadamardProduct(X, Y)*Y) == r'\left(X \circ Y\right) Y'
 
+
 def test_boolean_args_order():
     syms = symbols('a:f')
 
@@ -1052,6 +1053,10 @@ def test_boolean_args_order():
 
     expr = Or(*syms)
     assert latex(expr) == 'a \\vee b \\vee c \\vee d \\vee e \\vee f'
+
+    expr = Equivalent(*syms)
+    assert latex(expr) == 'a \\equiv b \\equiv c \\equiv d \\equiv e \\equiv f'
+
 
 def test_imaginary():
     i = sqrt(-1)


### PR DESCRIPTION
Latex-printing an Equivalent object would only print out two
arguments, even if there are more.

It might be argued that `a≡b≡c≡d` is not the right way to print out `Equivalent(a, b, c, d)`, since what it means is that an even number of them are true.  but that's how Unicode pretty-printing has been printing it out, so I followed that model.  (Also handled the Not(Equivalent()) case, with ≢)
