### PR TITLE
Remove inconsistency in the no. of args passed to dmp_gf_sqf_part.

### DIFF
--- a/sympy/polys/sqfreetools.py
+++ b/sympy/polys/sqfreetools.py
@@ -236,7 +236,7 @@ def dmp_sqf_part(f, u, K):
         return dup_sqf_part(f, K)
 
     if K.is_FiniteField:
-        return dmp_gf_sqf_part(f, u, K)
+        return dmp_gf_sqf_part(f, K)
 
     if dmp_zero_p(f, u):
         return f


### PR DESCRIPTION
dmp_gf_sqf_part takes at most 2 arguments but in dmp_sqf_part, 3 args are being passed.
I'm not sure if I've removed correct arg. @mattpap Please review.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
