### PR TITLE
import missing factor_terms

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -307,6 +307,8 @@ def TR2i(rv, half=False):
 
     """
 
+    from sympy import factor_terms
+
     def f(rv):
         if not rv.is_Mul:
             return rv


### PR DESCRIPTION
TR2i was missing factor_terms which is being used in factorize. Perhaps this isn't being covered in tests. It would be great if someone writes a test for this. @smichr please see this.
