### PR TITLE
7629: TR2i coverage and corrections

### DIFF
--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -1072,7 +1072,7 @@ def TR12i(rv):
     >>> TR12i(eq.expand())
     -3*tan(a + b)*tan(a + c)/(2*(tan(a) + tan(b) - 1))
     """
-    from sympy import factor, fraction, factor_terms
+    from sympy import factor, fraction
 
     def f(rv):
         if not (rv.is_Add or rv.is_Mul or rv.is_Pow):

--- a/sympy/simplify/fu.py
+++ b/sympy/simplify/fu.py
@@ -201,7 +201,7 @@ from sympy.core.power import Pow
 from sympy.core.function import expand_mul, count_ops
 from sympy.core.add import Add
 from sympy.core.symbol import Dummy
-from sympy.core.exprtools import Factors, gcd_terms
+from sympy.core.exprtools import Factors, gcd_terms, factor_terms
 from sympy.core.rules import Transform
 from sympy.core.basic import S
 from sympy.core.numbers import Integer, pi, I
@@ -340,7 +340,7 @@ def TR2i(rv, half=False):
         def factorize(d, ddone):
             newk = []
             for k in d:
-                if k.is_Add and len(k.args) > 2:
+                if k.is_Add and len(k.args) > 1:
                     knew = factor(k) if half else factor_terms(k)
                     if knew != k:
                         newk.append((k, knew))
@@ -350,10 +350,11 @@ def TR2i(rv, half=False):
                     newk[i] = knew
                 newk = Mul(*newk).as_powers_dict()
                 for k in newk:
-                    if ok(k, d[k]):
-                        d[k] += newk[k]
+                    v = d[k] + newk[k]
+                    if ok(k, v):
+                        d[k] = v
                     else:
-                        ddone.append((k, d[k]))
+                        ddone.append((k, v))
                 del newk
         factorize(n, ndone)
         factorize(d, ddone)

--- a/sympy/simplify/tests/test_fu.py
+++ b/sympy/simplify/tests/test_fu.py
@@ -31,7 +31,9 @@ def test_TR2i():
     assert TR2i(sin(x)*sin(y)/cos(x)) == tan(x)*sin(y)
     assert TR2i(1/(sin(x)/cos(x))) == 1/tan(x)
     assert TR2i(1/(sin(x)*sin(y)/cos(x))) == 1/tan(x)/sin(y)
+    assert TR2i(sin(x)/2/(cos(x) + 1)) == sin(x)/(cos(x) + 1)/2
 
+    assert TR2i(sin(x)/2/(cos(x) + 1), half=True) == tan(x/2)/2
     assert TR2i(sin(1)/(cos(1) + 1), half=True) == tan(S.Half)
     assert TR2i(sin(2)/(cos(2) + 1), half=True) == tan(1)
     assert TR2i(sin(4)/(cos(4) + 1), half=True) == tan(2)


### PR DESCRIPTION
@debugger22 pointed out the missing import. While writing tests
some corrections were made: the factoring should be done if there is
more than one term; the new value for the key must be put in ddone just
as it is put in d. Also, if k was deleted from d then the value is int 0
(because of as_powers_dict's default int value) so before checking in ok,
one has to be sure that what is sent is a SymPy object or else
e.is_integer will fail.
