### PR TITLE
consolidate exp._eval_power and Pow._eval_power

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -225,22 +225,27 @@ class Pow(Expr):
             if (b.is_nonnegative or (abs(e) < 1) == True):
                 return Pow(b, e*other)
         elif e.is_imaginary:
-            # with radius of different origins (starting with 0) the
-            # expoents can be joined
+            # within a distance of radius (from periodic "origins") the
+            # exponents can be joined
             radius = abs(S.Pi/C.log(abs(b)))
             p = abs(e)
-            ok = smallarg = (p - radius).is_nonpositive
+            ok = (p - radius).is_nonpositive
             if not ok and other.is_Rational:
                 origin = 2*other.q*radius
                 ok = (p % origin - radius).is_nonpositive
             if ok:
                 return Pow(b, e*other)
-            # outside that radius if other is 1/2 then this is how they join
+            # outside that radius if other is 1/2 then the exponents join
+            # but the expression has the opposite sign
             if ok is False and getattr(other, 'q', None) == 2:
                 return -Pow(b, e*other)
         elif getattr(other, 'q', None) == 2 and \
-                e.is_real is False and e.is_imaginary is False:  # XXX e.is_complex gives None for 1 + I :-(
-            # for exponents that have real and imaginary parts the combining of 1/2
+                e.is_real is False and e.is_imaginary is False:
+                #            -----                       -----
+                #               \____________________________\__
+                #                                               |
+                # XXX e.is_complex gives None for 1 + I :-( so use 2 Falses
+            # for exponents with real and imaginary parts the combining of 1/2
             # is like this
             if b.is_positive:
                 return Pow(b, e*other)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -216,77 +216,74 @@ class Pow(Expr):
             s = 1
         elif b.is_polar:  # e.g. exp_polar, besselj, var('p', polar=True)...
             s = 1
-        elif e.is_real:
+        elif e.is_real is not None:
             # helper functions ===========================
             def _half(e):
+                """Return True if the exponent has a literal 2 as the
+                denominator, else None."""
                 if getattr(e, 'q', None) == 2:
                     return True
                 n, d = e.as_numer_denom()
                 if n.is_integer and d == 2:
                     return True
             def _n2(e):
+                """Return ``e`` evaluated to a Number with 2 significant
+                digits, else None."""
                 try:
                     rv = e.evalf(2, strict=True)
                     if rv.is_Number:
                         return rv
                 except PrecisionExhausted:
                     pass
-            def _si(l, h=None, eps=None):
-                if eps:
-                    from sympy.series.limits import limit
-                    l += eps
-                    h -= eps
-                l = C.exp(2*S.Pi*S.ImaginaryUnit*other*C.floor(S.Half - e*l/(2*S.Pi)))
-                h = l if h is None else C.exp(2*S.Pi*S.ImaginaryUnit*other*C.floor(S.Half - e*h/(2*S.Pi)))
-                if eps:
-                    l = limit(l, eps, 0)
-                    h = limit(h, eps, 0)
-                if h == l:
-                    s = l
-                    if s.is_real and _n2(C.sign(s) - s) == 0:
-                        return C.sign(s)
             # ===================================================
-            # we need _half(other) with constant floor or
-            # floor(S.Half - e*arg(b)/2/pi) == 0
+            if e.is_real:
+                # we need _half(other) with constant floor or
+                # floor(S.Half - e*arg(b)/2/pi) == 0
 
-            # handle -1 as special case
-            if (e == -1) == True:
-                # floor arg. is 1/2 + arg(b)/2/pi
-                if _half(other):
-                    if b.is_negative is True:
-                        return S.NegativeOne**other*Pow(-b, e*other)
-                    if b.is_real is False:
-                        return Pow(b.conjugate()/C.Abs(b)**2, other)
-            elif e.is_even:
-                if b.is_real:
-                    b = abs(b)
-                if b.is_imaginary:
-                    b = abs(C.im(b))*S.ImaginaryUnit
+                # handle -1 as special case
+                if (e == -1) == True:
+                    # floor arg. is 1/2 + arg(b)/2/pi
+                    if _half(other):
+                        if b.is_negative is True:
+                            return S.NegativeOne**other*Pow(-b, e*other)
+                        if b.is_real is False:
+                            return Pow(b.conjugate()/C.Abs(b)**2, other)
+                elif e.is_even:
+                    if b.is_real:
+                        b = abs(b)
+                    if b.is_imaginary:
+                        b = abs(C.im(b))*S.ImaginaryUnit
 
-            if (abs(e) < 1) == True or (e == 1) == True:
-                s = 1  # floor = 0
-            elif b.is_nonnegative:
-                s = 1  # floor = 0
-            elif C.re(b).is_nonnegative and abs(e) < 2:
-                s = 1  # floor = 0
-            elif C.im(b).is_nonzero and (abs(e) == 2) == True:
-                s = 1  # floor = 0
-            elif _half(other):
-                s = _si(C.arg(b))
-        elif e.is_real is False:
-            # _half(other) with constant floor or
-            # floor(S.Half - im(e*log(b))/2/pi) == 0
-            try:
-                s = C.exp(2*S.ImaginaryUnit*S.Pi*other*
-                    C.floor(S.Half - C.im(e*C.log(b))/2/S.Pi))
-                # be careful when testing that s is -1 or 1 b/csign(I) == I:
-                # so check that s is real
-                if s.is_real and (C.sign(s) - s).evalf(2, strict=True) == 0:
-                    s = C.sign(s)
-                else:
+                if (abs(e) < 1) == True or (e == 1) == True:
+                    s = 1  # floor = 0
+                elif b.is_nonnegative:
+                    s = 1  # floor = 0
+                elif C.re(b).is_nonnegative and (abs(e) < 2) == True:
+                    s = 1  # floor = 0
+                elif C.im(b).is_nonzero and (abs(e) == 2) == True:
+                    s = 1  # floor = 0
+                elif _half(other):
+                    s = C.exp(2*S.Pi*S.ImaginaryUnit*other*C.floor(
+                        S.Half - e*C.arg(b)/(2*S.Pi)))
+                    if s.is_real and _n2(C.sign(s) - s) == 0:
+                        s = C.sign(s)
+                    else:
+                        s = None
+            else:
+                # e.is_real is False requires:
+                #     _half(other) with constant floor or
+                #     floor(S.Half - im(e*log(b))/2/pi) == 0
+                try:
+                    s = C.exp(2*S.ImaginaryUnit*S.Pi*other*
+                        C.floor(S.Half - C.im(e*C.log(b))/2/S.Pi))
+                    # be careful to test that s is -1 or 1 b/c sign(I) == I:
+                    # so check that s is real
+                    if s.is_real and _n2(C.sign(s) - s) == 0:
+                        s = C.sign(s)
+                    else:
+                        s = None
+                except PrecisionExhausted:
                     s = None
-            except PrecisionExhausted:
-                s = None
 
         if s is not None:
             return s*Pow(b, e*other)

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -252,13 +252,15 @@ class Pow(Expr):
                 return -Pow(b, e*other)
         elif e.is_real is False:
             try:
-                n = C.floor((C.im(e)*C.log(b)/2/S.Pi).evalf(2, strict=True))
-                if n not in [-S.Half, S.Zero, S.Half, S.One]:
+                n = (C.im(e)*C.log(b)/2/S.Pi).evalf(2, strict=True)
+                if not all(i.is_Number for i in n.as_real_imag()):
                     assert None
             except (AssertionError, PrecisionExhausted):
                 n = None
             if n is not None:
-                return Pow(b, e*other)*C.exp(S.ImaginaryUnit*S.Pi*n)
+                s = C.exp(S.ImaginaryUnit*S.Pi*C.floor(C.im(e)*C.log(b)/2/S.Pi))
+                if (C.sign(s) - s).evalf(2, strict=True) == 0:
+                    return C.sign(s)*Pow(b, e*other)
 
     def _eval_is_even(self):
         if self.exp.is_integer and self.exp.is_positive:

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -213,7 +213,7 @@ class Pow(Expr):
         if other.is_integer:
             return Pow(b, e*other)
 
-        if any(i.is_polar for i in (b, e, other)):
+        if b.is_polar:  # e.g. exp_polar, besselj, var('p', polar=True)...
             return Pow(b, e*other)
 
         if e.is_real:

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -519,22 +519,25 @@ def var(names, **args):
     into the *global* namespace. It's recommended not to use :func:`var` in
     library code, where :func:`symbols` has to be used::
 
-        >>> from sympy import var
+    Examples
+    ========
 
-        >>> var('x')
-        x
-        >>> x
-        x
+    >>> from sympy import var
 
-        >>> var('a,ab,abc')
-        (a, ab, abc)
-        >>> abc
-        abc
+    >>> var('x')
+    x
+    >>> x
+    x
 
-        >>> var('x,y', real=True)
-        (x, y)
-        >>> x.is_real and y.is_real
-        True
+    >>> var('a,ab,abc')
+    (a, ab, abc)
+    >>> abc
+    abc
+
+    >>> var('x,y', real=True)
+    (x, y)
+    >>> x.is_real and y.is_real
+    True
 
     See :func:`symbol` documentation for more details on what kinds of
     arguments can be passed to :func:`var`.

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -235,7 +235,11 @@ def test_pow2():
     # one large arg test -- see Pow._eval_power
     assert ((1 + I)**(-12*I*pi/log(sqrt(2))))**(1/S(3)) == (1 + I)**(-12*I*pi/3/log(sqrt(2)))
     # other
-    assert sqrt(Pow(2*I, 5*S.Half)) != (2*I)**(1+S.Half/2)
+    assert sqrt(Pow(2*I, 5*S.Half)) != (2*I)**(5/S(4))
+    assert cbrt(p**2) == p**(2/S(3))
+    z = symbols('z', real=False)
+    assert cbrt(p**z).as_base_exp() == (p**z, 1/S(3))
+
 
 def test_pow3():
     assert sqrt(2)**3 == 2 * sqrt(2)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -206,8 +206,6 @@ def test_pow2():
     assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
     e = sqrt(2**(-2 + I))
     assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = sqrt((-3)**(-2*sqrt(2) + I))
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
     e = sqrt((1 + I)**(-2*sqrt(2) + I))
     assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
     e = sqrt((1 + 11*I)**(-2*sqrt(2) + I))

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -169,6 +169,49 @@ def test_pow2():
     assert ((-x)**2)**Rational(1, 3) != ((-x)**Rational(1, 3))**2
     assert (-x)**Rational(2, 3) != x**Rational(2, 3)
     assert (-x)**Rational(5, 7) != -x**Rational(5, 7)
+    # there are also conditions that will make (x**y)**z == +/-x**(y*z);
+    # all checked against wolframalpha
+    f = pi/log(sqrt(2))
+    assert ((1 + I)**(I*f/2))**0.3 == (1 + I)**(0.15*I*f)
+    assert ((1 + I)**(I*f/2))**(S(1)/3) == (1 + I)**(I*f/6)
+    assert (1 + I)**(2*I*f) == ((1 + I)**(6*I*f))**(S(1)/3)
+    assert (1 + I)**(4*I*f) == ((1 + I)**(12*I*f))**(S(1)/3)
+    assert (((1 + I)**(I*(1 + 7*f)))**(S(1)/3)).exp == S(1)/3
+    assert sqrt((1 + I)**(I*f/2)) == (1 + I)**(I*f/4)
+    assert (1 + I)**(2*I*f) == sqrt((1 + I)**(4*I*f))
+    assert (1 + I)**(4*I*f) == sqrt((1 + I)**(8*I*f))
+    assert (1 + I)**(-0.15*I*f) == ((1 + I)**(-I*f/2))**0.3
+    assert (1 + I)**(-I*f/6) == ((1 + I)**(-I*f/2))**(S(1)/3)
+    assert ((1 + I)**(-6*I*f))**(S(1)/3) == (1 + I)**(-2*I*f)
+    assert ((1 + I)**(-12*I*f))**(S(1)/3) == (1 + I)**(-4*I*f)
+    assert (((1 + I)**(I*(-7*f - 1)))**(S(1)/3)).exp == S(1)/3
+    assert (1 + I)**(-I*f/4) == sqrt((1 + I)**(-I*f/2))
+    assert sqrt((1 + I)**(-4*I*f)) == (1 + I)**(-2*I*f)
+    assert sqrt((1 + I)**(-8*I*f)) == (1 + I)**(-4*I*f)
+    # check that power of 1/2 is joined and sign is correct;
+    # all checked against wolframalpha
+    e = (-2)**(-I)
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = (-2 + I)**(-I)
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = (2*I)**(-I)
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = 2**(-I)
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = -(1 + I)**(I*(1 + 5*pi/log(2))/2)
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = -(1 + I)**(I*(-5*pi/log(2) - 1)/2)
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = sqrt(2**(-2*sqrt(2) + I))
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = sqrt(2**(-2 + I))
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = sqrt((-3)**(-2*sqrt(2) + I))
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = sqrt((1 + I)**(-2*sqrt(2) + I))
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    e = sqrt((1 + 11*I)**(-2*sqrt(2) + I))
+    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
 
 
 def test_pow3():

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -5,6 +5,7 @@ from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sign, im, nan, cbrt
 )
 from sympy.core.evalf import PrecisionExhausted
+from sympy.core.tests.test_evalf import NS
 from sympy.core.compatibility import long
 from sympy.utilities.pytest import XFAIL, raises
 from sympy.utilities.randtest import test_numerically
@@ -167,78 +168,10 @@ def test_pow2():
     # x**(2*y) is always (x**y)**2 but is only (x**2)**y if
     #                                  x.is_positive or y.is_integer
     # let x = 1 to see why the following are not true.
-    assert ((-x)**2)**Rational(1, 3) != ((-x)**Rational(1, 3))**2
     assert (-x)**Rational(2, 3) != x**Rational(2, 3)
     assert (-x)**Rational(5, 7) != -x**Rational(5, 7)
-    # there are also conditions that will make (x**y)**z == +/-x**(y*z);
-    # all checked against wolframalpha
-    f = pi/log(sqrt(2))
-    assert ((1 + I)**(I*f/2))**0.3 == (1 + I)**(0.15*I*f)
-    assert ((1 + I)**(I*f/2))**(S(1)/3) == (1 + I)**(I*f/6)
-    assert (1 + I)**(2*I*f) == ((1 + I)**(6*I*f))**(S(1)/3)
-    assert (1 + I)**(4*I*f) == ((1 + I)**(12*I*f))**(S(1)/3)
-    assert (((1 + I)**(I*(1 + 7*f)))**(S(1)/3)).exp == S(1)/3
-    assert sqrt((1 + I)**(I*f/2)) == (1 + I)**(I*f/4)
-    assert (1 + I)**(2*I*f) == sqrt((1 + I)**(4*I*f))
-    assert (1 + I)**(4*I*f) == sqrt((1 + I)**(8*I*f))
-    assert (1 + I)**(-0.15*I*f) == ((1 + I)**(-I*f/2))**0.3
-    assert (1 + I)**(-I*f/6) == ((1 + I)**(-I*f/2))**(S(1)/3)
-    assert ((1 + I)**(-6*I*f))**(S(1)/3) == (1 + I)**(-2*I*f)
-    assert ((1 + I)**(-12*I*f))**(S(1)/3) == (1 + I)**(-4*I*f)
-    assert (((1 + I)**(I*(-7*f - 1)))**(S(1)/3)).exp == S(1)/3
-    assert (1 + I)**(-I*f/4) == sqrt((1 + I)**(-I*f/2))
-    assert sqrt((1 + I)**(-4*I*f)) == (1 + I)**(-2*I*f)
-    assert sqrt((1 + I)**(-8*I*f)) == (1 + I)**(-4*I*f)
-    # check that power of 1/2 is joined and sign is correct;
-    # all checked against wolframalpha
-    e = (-2)**(-I)
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = (-2 + I)**(-I)
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = (2*I)**(-I)
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = 2**(-I)
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = -(1 + I)**(I*(1 + 5*pi/log(2))/2)
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = -(1 + I)**(I*(-5*pi/log(2) - 1)/2)
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = sqrt(2**(-2*sqrt(2) + I))
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = sqrt(2**(-2 + I))
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = sqrt((1 + I)**(-2*sqrt(2) + I))
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
-    e = sqrt((1 + 11*I)**(-2*sqrt(2) + I))
-    assert re(e).is_positive and e.as_base_exp()[0].is_Pow is False
+    assert ((-x)**2)**Rational(1, 3) != ((-x)**Rational(1, 3))**2
     assert sqrt(x**2) != x
-    assert cbrt(x**3) != x
-    r = symbols('r', real=True)
-    assert sqrt(r**2) == abs(r)
-    assert cbrt(r**3) != r
-    p = symbols('p', positive=True)
-    assert cbrt(p**3) == p
-    # there are also conditions that will make (x**y)**z == +/-x**(y*z);
-    # all checked against wolframalpha
-    # im(n).is_integer != True, other=1/2 -- see Pow._eval_power
-    assert sqrt((1 + I)**(-2*sqrt(2) + I)) == (1 + I)**(-sqrt(2) + I/2)
-    assert sqrt(exp(3 + I)) == exp(S(3)/2 + I/2)
-    # im(n) is not rational, other=1/3
-    assert ((1 + I)**(I*pi/(2*log(sqrt(2)))))**(S(1)/3) == (1 + I)**(I*pi/3/(2*log(sqrt(2))))
-    # im(n).is_integer == True -- see Pow._eval_power
-    assert sqrt(2**(-2 + I)) == 2**(-1 + I/2)
-    # outside radius but other is 1/2 -- see Pow._eval_power
-    assert sqrt((1 + I)**(2*I*pi/log(sqrt(2)))) == -(1 + I)**(I*pi/log(sqrt(2)))
-    # two small arg tests -- see Pow._eval_power
-    assert ((1 + I)**(-I*pi/(2*log(sqrt(2)))))**.3 == (1 + I)**(-I*pi*.3/(2*log(sqrt(2))))
-    assert ((1 + I)**(-I*pi/(2*log(sqrt(2)))))**(1/S(3)) == (1 + I)**(-I*pi/3/(2*log(sqrt(2))))
-    # one large arg test -- see Pow._eval_power
-    assert ((1 + I)**(-12*I*pi/log(sqrt(2))))**(1/S(3)) == (1 + I)**(-12*I*pi/3/log(sqrt(2)))
-    # other
-    assert sqrt(Pow(2*I, 5*S.Half)) != (2*I)**(5/S(4))
-    assert cbrt(p**2) == p**(2/S(3))
-    z = symbols('z', real=False)
-    assert cbrt(p**z).as_base_exp() == (p**z, 1/S(3))
 
 
 def test_pow3():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,9 +1,8 @@
-from sympy.core import Symbol, S, Rational, Integer
-from sympy.utilities.pytest import raises, XFAIL
 from sympy import I, sqrt, log, exp, sin, asin
-
+from sympy.core import Symbol, S, Rational, Integer
 from sympy.core.facts import InconsistentAssumptions
-from sympy.utilities.pytest import XFAIL
+
+from sympy.utilities.pytest import raises, XFAIL
 
 
 def test_symbol_unset():
@@ -717,8 +716,3 @@ def test_issue_6631():
 
 def test_issue_2730():
     assert (1/(1 + I)).is_real is False
-
-
-@XFAIL
-def test_is_complex():
-    assert (1 + I).is_complex is True

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -3,6 +3,7 @@ from sympy.utilities.pytest import raises, XFAIL
 from sympy import I, sqrt, log, exp, sin, asin
 
 from sympy.core.facts import InconsistentAssumptions
+from sympy.utilities.pytest import XFAIL
 
 
 def test_symbol_unset():
@@ -716,3 +717,8 @@ def test_issue_6631():
 
 def test_issue_2730():
     assert (1/(1 + I)).is_real is False
+
+
+@XFAIL
+def test_is_complex():
+    assert (1 + I).is_complex is True

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -5,7 +5,7 @@ from sympy.functions.elementary.miscellaneous import sqrt, cbrt
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.series.order import O
-from sympy.utilities.pytest import XFAIL, slow
+from sympy.utilities.pytest import slow
 
 
 def test_rational():

--- a/sympy/core/tests/test_eval_power.py
+++ b/sympy/core/tests/test_eval_power.py
@@ -1,7 +1,8 @@
 from sympy.core import (Rational, Symbol, S, Float, Integer, Number, Pow,
-Basic, I, nan)
-from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.exponential import exp
+Basic, I, nan, pi, symbols)
+from sympy.core.tests.test_evalf import NS
+from sympy.functions.elementary.miscellaneous import sqrt, cbrt
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.series.order import O
 from sympy.utilities.pytest import XFAIL, slow
@@ -125,7 +126,7 @@ def test_issue_4362():
     eq = eqn(npos, dpos, pow)
     assert eq.is_Pow and eq.as_numer_denom() == (npos**pow, dpos**pow)
     eq = eqn(npos, dneg, pow)
-    assert eq.is_Pow and eq.as_numer_denom() == ((-npos)**pow, (-dneg)**pow)
+    assert eq.is_Pow is False and eq.as_numer_denom() == ((-npos)**pow, (-dneg)**pow)
     eq = eqn(nneg, dpos, pow)
     assert not eq.is_Pow or eq.as_numer_denom() == (nneg**pow, dpos**pow)
     eq = eqn(nneg, dneg, pow)
@@ -133,7 +134,7 @@ def test_issue_4362():
     eq = eqn(npos, dpos, -pow)
     assert eq.is_Pow and eq.as_numer_denom() == (dpos**pow, npos**pow)
     eq = eqn(npos, dneg, -pow)
-    assert eq.is_Pow and eq.as_numer_denom() == ((-dneg)**pow, (-npos)**pow)
+    assert eq.is_Pow is False and eq.as_numer_denom() == (-(-npos)**pow*(-dneg)**pow, npos)
     eq = eqn(nneg, dpos, -pow)
     assert not eq.is_Pow or eq.as_numer_denom() == (dpos**pow, nneg**pow)
     eq = eqn(nneg, dneg, -pow)
@@ -312,3 +313,34 @@ def test_issue_6429():
     assert f.taylor_term(0, x) == (c**2)**0.5
     assert f.taylor_term(1, x) == 0.5*x*(c**2)**(-0.5)
     assert f.taylor_term(2, x) == -0.125*x**2*(c**2)**(-1.5)
+
+
+def test_issue_7638():
+    f = pi/log(sqrt(2))
+    assert ((1 + I)**(I*f/2))**0.3 == (1 + I)**(0.15*I*f)
+    # if 1/3 -> 1.0/3 this should fail since it cannot be shown that the
+    # sign will be +/-1; for the previous "small arg" case, it didn't matter
+    # that this could not be proved
+    assert (1 + I)**(4*I*f) == ((1 + I)**(12*I*f))**(S(1)/3)
+
+    assert (((1 + I)**(I*(1 + 7*f)))**(S(1)/3)).exp == S(1)/3
+    r = symbols('r', real=True)
+    assert sqrt(r**2) == abs(r)
+    assert cbrt(r**3) != r
+    assert sqrt(Pow(2*I, 5*S.Half)) != (2*I)**(5/S(4))
+    p = symbols('p', positive=True)
+    assert cbrt(p**2) == p**(2/S(3))
+    assert NS(((0.2 + 0.7*I)**(0.7 + 1.0*I))**(0.5 - 0.1*I), 1) == '0.4 + 0.2*I'
+    assert sqrt(1/(1 + I)) == sqrt((1 - I)/2)  # or 1/sqrt(1 + I)
+    e = 1/(1 - sqrt(2))
+    assert sqrt(e) == I/sqrt(-1 + sqrt(2))
+    assert e**-S.Half == -I*sqrt(-1 + sqrt(2))
+    assert sqrt((cos(1)**2 + sin(1)**2 - 1)**(3 + I)).exp == S.Half
+    assert sqrt(r**(4/S(3))) != r**(2/S(3))
+    assert sqrt((p + I)**(4/S(3))) == (p + I)**(2/S(3))
+    assert sqrt((p - p**2*I)**2) == p - p**2*I
+    assert sqrt((p + r*I)**2) != p + r*I
+    e = (1 + I/5)
+    assert sqrt(e**5) == e**(5*S.Half)
+    assert sqrt(e**6) == e**3
+    assert sqrt((1 + I*r)**6) != (1 + I*r)**3

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -5,6 +5,7 @@ from sympy.core import C, sympify
 from sympy.core.add import Add
 from sympy.core.function import Lambda, Function, ArgumentIndexError
 from sympy.core.cache import cacheit
+from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Wild, Dummy
 from sympy.core.mul import Mul
@@ -96,28 +97,11 @@ class ExpBase(Function):
     def _eval_is_zero(self):
         return (self.args[0] is S.NegativeInfinity)
 
-    def _eval_power(b, e):
+    def _eval_power(self, other):
         """exp(arg)**e -> exp(arg*e) if assumptions allow it.
         """
-        f = b.func
-        be = b.exp
-        rv = f(be*e)
-        if e.is_integer:
-            return rv
-        if be.is_real:
-            return rv
-        # "is True" needed below; exp.is_polar returns <property object ...>
-        if f.is_polar is True:
-            return rv
-        if e.is_polar:
-            return rv
-        if be.is_polar:
-            return rv
-        besmall = abs(be) <= S.Pi
-        if besmall == True:
-            return rv
-        elif besmall == False and e.is_Rational and e.q == 2:
-            return -rv
+        b, e = self.as_base_exp()
+        return Pow._eval_power(Pow(b, e, evaluate=False), other)
 
     def _eval_expand_power_exp(self, **hints):
         arg = self.args[0]
@@ -179,6 +163,9 @@ class exp_polar(ExpBase):
             # i ~ pi, but exp(I*i) evaluated to argument slightly bigger than pi
             return re(res)
         return res
+
+    def _eval_power(self, other):
+        return self.func(self.args[0]*other)
 
     def _eval_is_real(self):
         if self.args[0].is_real:

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -259,7 +259,7 @@ def test_as_real_imag():
 
     assert sqrt(a**2).as_real_imag() == (sqrt(a**2), 0)
     i = symbols('i', imaginary=True)
-    assert sqrt(i**2).as_real_imag() == (0, -I*i)
+    assert sqrt(i**2).as_real_imag() == (0, abs(i))
 
 @XFAIL
 def test_sign_issue_3068():

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -259,7 +259,7 @@ def test_as_real_imag():
 
     assert sqrt(a**2).as_real_imag() == (sqrt(a**2), 0)
     i = symbols('i', imaginary=True)
-    assert sqrt(i**2).as_real_imag() == (0, sqrt(-i**2))
+    assert sqrt(i**2).as_real_imag() == (0, -I*i)
 
 @XFAIL
 def test_sign_issue_3068():

--- a/sympy/physics/sho.py
+++ b/sympy/physics/sho.py
@@ -36,7 +36,7 @@ def R_nl(n, l, nu, r):
     l, nu and r may be symbolic:
 
     >>> R_nl(0, 0, nu, r)
-    2*2**(3/4)*nu**(3/4)*exp(-nu*r**2)/pi**(1/4)
+    2*2**(3/4)*sqrt(nu**(3/2))*exp(-nu*r**2)/pi**(1/4)
     >>> R_nl(0, l, 1, r)
     r**l*sqrt(2**(l + 3/2)*2**(l + 2)/factorial2(2*l + 1))*exp(-r**2)/pi**(1/4)
 

--- a/sympy/physics/sho.py
+++ b/sympy/physics/sho.py
@@ -36,7 +36,7 @@ def R_nl(n, l, nu, r):
     l, nu and r may be symbolic:
 
     >>> R_nl(0, 0, nu, r)
-    2*2**(3/4)*sqrt(nu**(3/2))*exp(-nu*r**2)/pi**(1/4)
+    2*2**(3/4)*nu**(3/4)*exp(-nu*r**2)/pi**(1/4)
     >>> R_nl(0, l, 1, r)
     r**l*sqrt(2**(l + 3/2)*2**(l + 2)/factorial2(2*l + 1))*exp(-r**2)/pi**(1/4)
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2251,6 +2251,11 @@ def _denest_pow(eq):
     transformation.
     """
     b, e = eq.as_base_exp()
+    if b.is_Pow or isinstance(b.func, exp) and e != 1:
+        new = b._eval_power(e)
+        if new is not None:
+            eq = new
+            b, e = new.as_base_exp()
 
     # denest exp with log terms in exponent
     if b is S.Exp1 and e.is_Mul:

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -1847,7 +1847,7 @@ def test_almost_linear():
 
     eq = x*f(x)*d + 2*x*f(x)**2 + 1
     sol = dsolve(eq, f(x), hint = 'almost_linear')
-    assert sol[0].rhs == -sqrt((C1 - 2*Ei(4*x))*exp(-4*x))
+    assert sol[0].rhs == -sqrt(C1 - 2*Ei(4*x))*exp(-2*x)
     assert checkodesol(eq, sol, order=1, solve_for_func=False)[0]
 
     eq = x*d + x*f(x) + 1


### PR DESCRIPTION
Consolidate exp._eval_power into Pow._eval_power as much as possible.

Details are given in the commit's log.

In master, the lhs is incorrectly reported with a negative of the rhs

```
    assert sqrt(exp(3 + I)) == exp(S(3)/2 + I/2)
```

these are not recognized of being able to combine exponents

```
    ((1 + I)**(I*pi/(2*log(sqrt(2)))))**(S(1)/3)
    ((1 + I)**(-I*pi/(2*log(sqrt(2)))))**.3
    ((1 + I)**(-I*pi/(2*log(sqrt(2)))))**(1/S(3))
    ((1 + I)**(-12*I*pi/log(sqrt(2))))**(1/S(3))
```
