### PR TITLE
capitalize reimann in docstrings

### DIFF
--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -598,7 +598,7 @@ class adjoint(Function):
 
 class polar_lift(Function):
     """
-    Lift argument to the riemann surface of the logarithm, using the
+    Lift argument to the Riemann surface of the logarithm, using the
     standard branch.
 
     >>> from sympy import Symbol, polar_lift, I
@@ -669,7 +669,7 @@ class polar_lift(Function):
 
 class periodic_argument(Function):
     """
-    Represent the argument on a quotient of the riemann surface of the
+    Represent the argument on a quotient of the Riemann surface of the
     logarithm. That is, given a period P, always return a value in
     (-P/2, P/2], by using exp(P*I) == 1.
 
@@ -690,7 +690,7 @@ class periodic_argument(Function):
     ========
 
     sympy.functions.elementary.exponential.exp_polar
-    polar_lift : Lift argument to the riemann surface of the logarithm
+    polar_lift : Lift argument to the Riemann surface of the logarithm
     principal_branch
     """
 
@@ -719,7 +719,7 @@ class periodic_argument(Function):
 
     @classmethod
     def eval(cls, ar, period):
-        # Our strategy is to evaluate the argument on the riemann surface of the
+        # Our strategy is to evaluate the argument on the Riemann surface of the
         # logarithm, and then reduce.
         # NOTE evidently this means it is a rather bad idea to use this with
         # period != 2*pi and non-polar numbers.
@@ -766,7 +766,7 @@ def unbranched_argument(arg):
 class principal_branch(Function):
     """
     Represent a polar number reduced to its principal branch on a quotient
-    of the riemann surface of the logarithm.
+    of the Riemann surface of the logarithm.
 
     This is a function of two arguments. The first argument is a polar
     number `z`, and the second one a positive real number of infinity, `p`.
@@ -785,7 +785,7 @@ class principal_branch(Function):
     ========
 
     sympy.functions.elementary.exponential.exp_polar
-    polar_lift : Lift argument to the riemann surface of the logarithm
+    polar_lift : Lift argument to the Riemann surface of the logarithm
     periodic_argument
     """
 

--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -1,3 +1,4 @@
+
 from __future__ import print_function, division
 
 from sympy.core import C, sympify

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -943,7 +943,7 @@ class Ei(Function):
     where `\gamma` is the Euler-Mascheroni constant.
 
     If `x` is a polar number, this defines an analytic function on the
-    riemann surface of the logarithm. Otherwise this defines an analytic
+    Riemann surface of the logarithm. Otherwise this defines an analytic
     function in the cut plane `\mathbb{C} \setminus (-\infty, 0]`.
 
     **Background**

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2373,7 +2373,7 @@ def powdenest(eq, force=False, polar=False):
     negative behave as though they are positive, resulting in more
     denesting.
 
-    Setting ``polar`` to True will do simplifications on the riemann surface of
+    Setting ``polar`` to True will do simplifications on the Riemann surface of
     the logarithm, also resulting in more denestings.
 
     When there are sums of logs in exp() then a product of powers may be


### PR DESCRIPTION
Only capitalization in docstrings is done so I skipped the travis tests and ran code quality locally:

```
sympy\utilities\tests\test_code_quality.py[5] .....

================== tests finished: 5 passed, in 8.67 seconds
```
