### PR TITLE
watch for improper separation of base and exp in powsimp

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -2581,6 +2581,10 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                 b, e = term.as_base_exp()
                 if deep:
                     b, e = [recurse(i) for i in [b, e]]
+                if b.is_Pow or b.func is exp:
+                    # don't let smthg like sqrt(x**a) split into x**a, 1/2
+                    # or else it will be joined as x**(a/2) later
+                    b, e = b**e, S.One
                 c_powers[b].append(e)
             else:
                 # This is the logic that combines exponents for equal,

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -672,6 +672,8 @@ def test_powsimp():
     eq = Mul(*[sqrt(Dummy(imaginary=True)) for i in range(3)])
     assert powsimp(eq) == eq and eq.is_Mul
 
+    assert all(powsimp(e) == e for e in (sqrt(x**a), sqrt(x**2)))
+
 
 def test_issue_6367():
     z = -5*sqrt(2)/(2*sqrt(2*sqrt(29) + 29)) + sqrt(-sqrt(29)/29 + S(1)/2)

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -571,7 +571,7 @@ def solve(f, *symbols, **flags):
             >>> solve(x**2 - y**2/exp(x), x, y)
             [{x: 2*LambertW(y/2)}]
             >>> solve(x**2 - y**2/exp(x), y, x)
-            [{y: -x*exp(x/2)}, {y: x*exp(x/2)}]
+            [{y: -x*sqrt(exp(x))}, {y: x*sqrt(exp(x))}]
 
     * iterable of one or more of the above
 

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -269,7 +269,7 @@ def test_solve_rational():
 def test_solve_nonlinear():
     assert solve(x**2 - y**2, x, y) == [{x: -y}, {x: y}]
     assert solve(x**2 - y**2/exp(x), x, y) == [{x: 2*LambertW(y/2)}]
-    assert solve(x**2 - y**2/exp(x), y, x) == [{y: -x*exp(x/2)}, {y: x*exp(x/2)}]
+    assert solve(x**2 - y**2/exp(x), y, x) == [{y: -x*sqrt(exp(x))}, {y: x*sqrt(exp(x))}]
 
 
 def test_issue_7228():


### PR DESCRIPTION
e.g. sqrt(x**a) should not be split as x**a, 1/2 otherwise
it will rejoin as x**(a/2) later -- this is noted with an
inline comment.
