### PR TITLE
Create auto update mechanism for development docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 env:
+  matrix:
   - TEST_DOCTESTS="true"
   - SPLIT="1/2"
   - SPLIT="2/2"
+  global:
+    secure: <access_token>
 python:
   - 2.6
   - 2.7
@@ -149,3 +152,5 @@ script:
   - bin/test_travis.sh
 notifications:
   email: false
+after_success:
+  - bin/build_doc.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - SPLIT="1/2"
   - SPLIT="2/2"
   global:
-    secure: <access_token>
+    secure: uJycOcgT3Rg9TsU6ID2UMHc56Fh6Q70p1/mFiod8r97g8zER9kWTZ2GVDSRiw1Nfh0Wojcy04PAG3t5m9bwM08YF8qZy1PJkCb/pu7PN8Hzt+6FSBb84gGEXMiv1xuZWSQ0pUuBa1Lfcxuq6m2/eA8aNfgoqnpLgR8zeg/2xhFw=
 python:
   - 2.6
   - 2.7

--- a/bin/build_doc.sh
+++ b/bin/build_doc.sh
@@ -2,25 +2,32 @@
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
+        echo "Installing dependencies"
+        sudo apt-get install --no-install-recommends graphviz inkscape texlive texlive-xetex texlive-fonts-recommended texlive-latex-extra lmodern librsvg2-bin imagemagick docbook2x
+        pip install "sphinx==1.1.3"
+
+        echo -e "Building docs"
         cd doc
         make clean
         make html
 
         cd ../../
-
+        echo -e "Setting git attributes"
         git config --global user.email "sympy@googlegroups.com"
         git config --global user.name "SymPy (Travis CI)"
 
+        echo -e "Cloning repository"
         git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/sympy/sympy_doc.git  gh-pages > /dev/null
 
         cd gh-pages
         git remote rm origin
-        git remote add origin https://${GH_TOKEN}@github.com/sympy/sympy_doc.git
+        git remote add origin https://${GH_TOKEN}@github.com/sympy/sympy_doc.git > /dev/null
         rm -rf dev/
         cp -R ../sympy/doc/_build/html dev/
-        git add -A dev
+        git add -A dev/
         ./generate_indexes.py
 
         git commit -am "Update dev doc after building $TRAVIS_BUILD_NUMBER"
+        echo -e "Pushing commit"
         git push -fq origin gh-pages > /dev/null
 fi

--- a/bin/build_doc.sh
+++ b/bin/build_doc.sh
@@ -1,5 +1,27 @@
 #! /usr/bin/env bash
 
+# This file automatically deploys changes to http://docs.sympy.org/dev/index.html.
+# This will happen only when a PR gets merged which is basically when a new commit
+# is added to master.
+# It requires an access token which should be present in .travis.yml file.
+#
+# Following is the procedure to get the access token:
+#
+# $ curl -X POST -u <github_username> -H "Content-Type: application/json" -d\
+# "{\"scopes\":[\"public_repo\"],\"note\":\"token for pushing from travis\"}"\
+# https://api.github.com/authorizations
+#
+# It'll give you a JSON response having a key called "token".
+#
+# $ gem install travis
+# $ travis encrypt -r sympy/sympy GH_TOKEN=<token> env.global
+#
+# This will give you an access token("secure"). This helps in creating an
+# environment variable named GH_TOKEN while building.
+#
+# Add this secure code to .travis.yml as described here http://docs.travis-ci.com/user/encryption-keys/
+
+
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
         echo "Installing dependencies"

--- a/bin/build_doc.sh
+++ b/bin/build_doc.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+
+        cd doc
+        make clean
+        make html
+
+        cd ../../
+
+        git config --global user.email "sympy@googlegroups.com"
+        git config --global user.name "SymPy (Travis CI)"
+
+        git clone --quiet --branch=gh-pages https://${GH_TOKEN}@github.com/sympy/sympy_doc.git  gh-pages > /dev/null
+
+        cd gh-pages
+        git remote rm origin
+        git remote add origin https://${GH_TOKEN}@github.com/sympy/sympy_doc.git
+        rm -rf dev/
+        cp -R ../sympy/doc/_build/html dev/
+        git add -A dev
+        ./generate_indexes.py
+
+        git commit -am "Update dev doc after building $TRAVIS_BUILD_NUMBER"
+        git push -fq origin gh-pages > /dev/null
+fi


### PR DESCRIPTION
This patch intends to automatically deploy changes to http://docs.sympy.org/dev/index.html.
This will happen only when a PR gets merged which is basically when a new commit is added to `master`.

Since I do not have push access, I couldn't complete this. I've tested it on my fork though.

**Access token is required to get it working**

Procedure to get the access token:

Step 1:

```
$ curl -X POST -u <github_username> -H "Content-Type: application/json" -d "{\"scopes\":[\"public_repo\"],\"note\":\"token for pushing from travis\"}" https://api.github.com/authorizations
```

It'll give you a JSON response having a key called "token".

Step 2:

```
$ gem install travis
```

Step 3:

Put the token which you've got from step 1.

```
$ travis encrypt -r sympy/sympy GH_TOKEN=<token> env.global
```

This will give you an access token("secure"). This helps in creating an environment variable named GH_TOKEN while building.

Replace `<access_token>` in L8 in `.travis.yml` with the actual access token.
