### PR TITLE
Implement __ne__() by calling __eq__()

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -334,17 +334,7 @@ class Basic(with_metaclass(ManagedProperties)):
 
            but faster
         """
-
-        if type(self) is not type(other):
-            try:
-                other = _sympify(other)
-            except SympifyError:
-                return True     # sympy != other
-
-            if type(self) is not type(other):
-                return True
-
-        return self._hashable_content() != other._hashable_content()
+        return not self.__eq__(other)
 
     def dummy_eq(self, other, symbol=None):
         """


### PR DESCRIPTION
The `__ne__()` operator should return `not __eq__()`. Alternatively, one can copy & paste the algorithm from `__eq__()` and negate the answer right before each return. But anything else means there is a potential bug.
