### PR TITLE
SYMPY_USE_CACHE=debug results in errors

### DIFF
--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -13,11 +13,15 @@ from sympy.functions import binomial, sin, cos, tan, sec, csc, cot, Piecewise
 #
 # so we cache the pattern
 
+# need to use a function instead of lamda since hash of lambda changes on
+# each call to _pat_sincos
+def _integer_instance(n):
+    return isinstance(n , Integer)
 
 @cacheit
 def _pat_sincos(x):
     a = Wild('a', exclude=[x])
-    n, m = [Wild(s, exclude=[x], properties=[lambda n: isinstance(n, Integer)])
+    n, m = [Wild(s, exclude=[x], properties=[_integer_instance])
                 for s in 'nm']
     pat = sin(a*x)**n * cos(a*x)**m
     return pat, a, n, m


### PR DESCRIPTION
Rewrite lambda as a function.  This avoids a runtime error (i.e. return value of cached and not cached function differ)  with

SYMPY_USE_CACHE=debug py.test -x sympy/integrals/tests/test_trigonometry.py

In order for #7464 to move forward, errors resulting from comparing cached/not cached functions need to be fixed.
