### PR TITLE
Change latex output of Lambda to use \mapsto

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -600,7 +600,7 @@ class LatexPrinter(Printer):
             symbols = self._print(tuple(symbols))
 
         args = (symbols, self._print(expr))
-        tex = r"%s \mapsto %s" % (symbols, self._print(expr))
+        tex = r"\left( %s \mapsto %s \right)" % (symbols, self._print(expr))
 
         return tex
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -600,7 +600,7 @@ class LatexPrinter(Printer):
             symbols = self._print(tuple(symbols))
 
         args = (symbols, self._print(expr))
-        tex = r"\Lambda {\left (%s \right )}" % ", ".join(args)
+        tex = r"%s \mapsto %s" % (symbols, self._print(expr))
 
         return tex
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -807,7 +807,7 @@ def test_latex_RootOf():
 
 def test_latex_RootSum():
     assert latex(RootSum(x**5 + x + 3, sin)) == \
-        r"\operatorname{RootSum} {\left(x^{5} + x + 3, x \mapsto \sin{\left (x \right )}\right)}"
+        r"\operatorname{RootSum} {\left(x^{5} + x + 3, \left( x \mapsto \sin{\left (x \right )} \right)\right)}"
 
 
 def test_settings():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -691,9 +691,9 @@ def test_latex_order():
 
 def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
-        r"\Lambda {\left (x, x + 1 \right )}"
+        r"x \mapsto x + 1"
     assert latex(Lambda((x, y), x + 1)) == \
-        r"\Lambda {\left (\begin{pmatrix}x, & y\end{pmatrix}, x + 1 \right )}"
+        r"\begin{pmatrix}x, & y\end{pmatrix} \mapsto x + 1"
 
 
 def test_latex_PolyElement():
@@ -753,8 +753,9 @@ def test_latex_RootOf():
 
 
 def test_latex_RootSum():
+    print latex(RootSum(x**5 + x + 3, sin))
     assert latex(RootSum(x**5 + x + 3, sin)) == \
-        r"\operatorname{RootSum} {\left(x^{5} + x + 3, \Lambda {\left (x, \sin{\left (x \right )} \right )}\right)}"
+        r"\operatorname{RootSum} {\left(x^{5} + x + 3, x \mapsto \sin{\left (x \right )}\right)}"
 
 
 def test_settings():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -753,7 +753,6 @@ def test_latex_RootOf():
 
 
 def test_latex_RootSum():
-    print latex(RootSum(x**5 + x + 3, sin))
     assert latex(RootSum(x**5 + x + 3, sin)) == \
         r"\operatorname{RootSum} {\left(x^{5} + x + 3, x \mapsto \sin{\left (x \right )}\right)}"
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -691,9 +691,9 @@ def test_latex_order():
 
 def test_latex_Lambda():
     assert latex(Lambda(x, x + 1)) == \
-        r"x \mapsto x + 1"
+        r"\left( x \mapsto x + 1 \right)"
     assert latex(Lambda((x, y), x + 1)) == \
-        r"\begin{pmatrix}x, & y\end{pmatrix} \mapsto x + 1"
+        r"\left( \begin{pmatrix}x, & y\end{pmatrix} \mapsto x + 1 \right)"
 
 
 def test_latex_PolyElement():


### PR DESCRIPTION
A takeover of https://github.com/sympy/sympy/pull/2377.

@smichr Tests were failing because of parenthesis.

![first](https://cloud.githubusercontent.com/assets/2821646/3420758/95f980c8-fec0-11e3-9237-81f86e020e10.png)
is being produced as 
![second](https://cloud.githubusercontent.com/assets/2821646/3420757/5ef93e24-fec0-11e3-8dbb-52d57408e372.png)
