### PR TITLE
Make sympy_parser work with evaluate=0. Fixes #7663

### DIFF
--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -786,7 +786,7 @@ def parse_expr(s, local_dict=None, transformations=standard_transformations,
 
     code = stringify_expr(s, local_dict, global_dict, transformations)
 
-    if evaluate is False:
+    if not evaluate:
         code = compile(evaluateFalse(code), '<string>', 'eval')
 
     return eval_expr(code, local_dict, global_dict)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -84,4 +84,4 @@ def test_issue_2515():
 
 def test_issue_7663():
     x = Symbol('x')
-    parse_expr('2*(x+1)', evaluate=0) == 2*(x + 1)
+    parse_expr('2*(x+1)', evaluate=0) == Mul(2, x + 1, evaluate=False)

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -54,6 +54,7 @@ def test_factorial_fail():
         except TokenError:
             assert True
 
+
 def test_local_dict():
     local_dict = {
         'my_function': lambda x: x + 2
@@ -63,6 +64,7 @@ def test_local_dict():
     }
     for text, result in inputs.items():
         assert parse_expr(text, local_dict=local_dict) == result
+
 
 def test_global_dict():
     global_dict = {
@@ -74,6 +76,12 @@ def test_global_dict():
     for text, result in inputs.items():
         assert parse_expr(text, global_dict=global_dict) == result
 
+
 def test_issue_2515():
     raises(TokenError, lambda: parse_expr('(()'))
     raises(TokenError, lambda: parse_expr('"""'))
+
+
+def test_issue_7663():
+    x = Symbol('x')
+    parse_expr('2*(x+1)', evaluate=0) == 2*(x + 1)


### PR DESCRIPTION
@smichr please see this.
