### PR TITLE
Add command to exit on error(build_doc.sh)

### DIFF
--- a/bin/build_doc.sh
+++ b/bin/build_doc.sh
@@ -21,6 +21,8 @@
 #
 # Add this secure code to .travis.yml as described here http://docs.travis-ci.com/user/encryption-keys/
 
+# Exit on error
+set -e
 
 if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 


### PR DESCRIPTION
It is important to exit on error and not delete all the doc files and push an empty dev folder.
