### PR TITLE
Fix broken test, test_ode.py::test_lie_group

### DIFF
--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -2140,7 +2140,7 @@ def test_lie_group():
 
     eq = Eq(f(x).diff(x), x**2*f(x))
     sol = dsolve(eq, f(x), hint='lie_group')
-    assert sol == Eq(f(x), C1*exp(x**3/S(3)))
+    assert sol == Eq(f(x), C1*exp(x**3)**(1/S(3)))
     assert checkodesol(eq, sol)[0]
 
     eq = f(x).diff(x) + a*f(x) - c*exp(b*x)


### PR DESCRIPTION
test_lie_group utilized an incorrect simplification that was fixed PR 7641.

For details see discussions @:

https://github.com/sympy/sympy/pull/7674
https://github.com/sympy/sympy/pull/7641
https://github.com/sympy/sympy/pull/7638
https://groups.google.com/forum/#!topic/sympy/p3hq7MCY34o
