### PR TITLE
Fix inconsistent caching/matching behavior

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1427,7 +1427,7 @@ class Basic(with_metaclass(ManagedProperties)):
         {x_: b + c}
         """
         expr = sympify(expr)
-        if not isinstance(expr, self.__class__):
+        if expr.__class__ != self.__class__:
             return None
 
         if self == expr:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1427,7 +1427,7 @@ class Basic(with_metaclass(ManagedProperties)):
         {x_: b + c}
         """
         expr = sympify(expr)
-        if expr.__class__ != self.__class__:
+        if not isinstance(expr, self.__class__):
             return None
 
         if self == expr:

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -699,7 +699,7 @@ class UndefinedFunction(FunctionClass):
         return ret
 
     def __instancecheck__(cls, instance):
-        return type(instance) == cls
+        return cls in type(instance).__mro__
 
 UndefinedFunction.__eq__ = lambda s, o: (isinstance(o, s.__class__) and
                                          (s.class_key() == o.class_key()))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -698,6 +698,9 @@ class UndefinedFunction(FunctionClass):
         ret.__module__ = None
         return ret
 
+    def __instancecheck__(cls, instance):
+        return type(instance) == cls
+
 UndefinedFunction.__eq__ = lambda s, o: (isinstance(o, s.__class__) and
                                          (s.class_key() == o.class_key()))
 

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -8,6 +8,7 @@ from sympy.core.function import PoleError
 from sympy.sets.sets import FiniteSet
 from sympy.solvers import solve
 from sympy.utilities.iterables import subsets, variations
+from sympy.core.cache import clear_cache
 
 f, g, h = symbols('f g h', cls=Function)
 
@@ -649,3 +650,26 @@ def test_issue_7231():
     assert res == ans1
     ans2 = f(x).series(x, a)
     assert res == ans2
+
+def test_issue_7687():
+    from sympy.core.function import Function
+    from sympy.abc import x
+    f = Function('f')(x)
+    ff = Function('f')(x)
+    match_with_cache = ff.matches(f)
+    assert isinstance(f, type(ff))
+    clear_cache()
+    ff = Function('f')(x)
+    assert isinstance(f, type(ff))
+    assert match_with_cache == ff.matches(f)
+
+def test_issue_7688():
+    from sympy.core.function import Function, UndefinedFunction
+    from sympy.abc import x
+
+    f = Function('f')  # actually an UndefinedFunction
+    clear_cache()
+    class A(UndefinedFunction):
+        pass
+    a = A('f')
+    assert isinstance(a, type(f))


### PR DESCRIPTION
Old behavior is documented in #7687 and repeated here:

``` python
[ptb@cyrus sympy]$ ipython 
Python 3.4.1 |Continuum Analytics, Inc.| (default, May 19 2014, 13:02:41) 
Type "copyright", "credits" or "license" for more information.

IPython 2.1.0 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: from sympy import Function

In [2]: from sympy.abc import x

In [3]: f = Function('f')(x)

In [4]: ff = Function('f')(x)

In [5]: ff.match(f)
Out[5]: {}

In [6]: from sympy.core.cache import clear_cache

In [7]: clear_cache()

In [8]: ff = Function('f')(x)

In [9]: ff.match(f)

In [10]: f.__class__ is ff.__class__
Out[10]: False

In [11]: f.__class == ff.__class__
Out[11]: True
```

Note that 10 and 11 are there to highlight the change needed in `matches` to make the behavior consistent between `cache_clears` or when using a bounded cache as in #7464

New behavior

``` python
In [1]: from sympy import Function

In [2]: from sympy.abc import x

In [3]: f = Function('f')(x)

In [4]: ff = Function('f')(x)

In [5]: ff.match(f)
Out[5]: {}

In [6]: from sympy.core.cache import clear_cache

In [7]: clear_cache()

In [8]: ff = Function('f')(x)

In [9]: ff.match(f)
Out[9]: {}

In [10]: 
```
