### PR TITLE
Assumptions on ImageSet.lamda variable

### DIFF
--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -257,7 +257,7 @@ class ImageSet(Set):
                 # order of the variable names, since the result should not depend
                 # on the variable name, they are replaced by the dummy variables
                 # below
-                a, b = Dummy('a'), Dummy('b')
+                a, b = Dummy('a', **n.assumptions0), Dummy('b', **m.assumptions0)
                 f, g = f.subs(n, a), g.subs(m, b)
                 solns_set = diophantine(f - g)
                 if solns_set == set():

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1674,13 +1674,11 @@ def imageset(*args):
     elif set is S.Naturals0:
         n = Dummy(var.name, integer=True, nonnegative=True)
     elif set.intersect(S.Reals) == set:
-        # XXX; I'm being lazy here the other assumptions might still apply
+        # XXX; I'm being lazy here the other
+        # more specific assumptions might still apply
         n = Dummy(var.name, real=True)
     else:
         n = Dummy(var.name)
-
-    # XXX: make sure that the assumptions on the variables don't wear off
-    # while doing various set operations
 
     f = Lambda(n, expr.subs(var, n))
 

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1651,17 +1651,38 @@ def imageset(*args):
     """
     from sympy.core import Dummy, Lambda
     from sympy.sets.fancysets import ImageSet
+
+    set = args[-1]
     if len(args) == 3:
-        f = Lambda(*args[:2])
+        var, expr = args[:2]
     else:
         # var and expr are being defined this way to
         # support Python lambda and not just sympy Lambda
         f = args[0]
         if not isinstance(f, Lambda):
-            var = Dummy()
+            var = Dummy('n')
             expr = args[0](var)
-            f = Lambda(var, expr)
-    set = args[-1]
+        else:
+            # XXX: Not caring about multivariate Lambdas now,
+            var = f.variables[0]
+            expr = f.expr
+
+    if set is S.Integers:
+        n = Dummy(var.name, integer=True)
+    elif set is S.Naturals:
+        n = Dummy(var.name, integer=True, positive=True)
+    elif set is S.Naturals0:
+        n = Dummy(var.name, integer=True, nonnegative=True)
+    elif set.intersect(S.Reals) == set:
+        # XXX; I'm being lazy here the other assumptions might still apply
+        n = Dummy(var.name, real=True)
+    else:
+        n = Dummy(var.name)
+
+    # XXX: make sure that the assumptions on the variables don't wear off
+    # while doing various set operations
+
+    f = Lambda(n, expr.subs(var, n))
 
     r = set._eval_imageset(f)
     if r is not None:

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -732,25 +732,26 @@ def test_imageset_var_assumptions():
     s1 = imageset(Lambda(n, sin(n)), S.Reals)
     s2 = imageset(lambda n: sin(n), S.Reals)
     s3 = imageset(n, sin(n), S.Reals)
-
-    s4 = imageset(Lambda(n, sin(n)), S.Integers)
-
-    s5 = imageset(Lambda(n, sin(n)), S.Naturals)
-
-    s6 = imageset(Lambda(n, sin(n)), S.Naturals0)
-
-    s7 = imageset(Lambda(n, sin(n)), Interval(-10, oo))
-
     assert s1.lamda.variables[0].is_real is True
     assert s2.lamda.variables[0].is_real is True
     assert s3.lamda.variables[0].is_real is True
 
+    s4 = imageset(Lambda(n, sin(n)), S.Integers)
     assert s4.lamda.variables[0].is_integer is True
 
+    s5 = imageset(Lambda(n, sin(n)), S.Naturals)
     assert s5.lamda.variables[0].is_integer is True \
             and s5.lamda.variables[0].is_positive is True
 
+    s6 = imageset(Lambda(n, sin(n)), S.Naturals0)
     assert s6.lamda.variables[0].is_integer is True \
             and s6.lamda.variables[0].is_nonnegative is True
 
+    s7 = imageset(Lambda(n, sin(n)), Interval(-10, oo))
     assert s7.lamda.variables[0].is_real is True
+
+    s8 = imageset(Lambda(n, 2*n), S.Integers).intersect(
+        imageset(Lambda(n, 3*n), S.Integers))
+    assert s8.lamda.variables[0].is_integer is True
+
+

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -1,6 +1,6 @@
-from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
+from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan, Lambda,
     GreaterThan, LessThan, Max, Min, And, Or, Eq, Ge, Le, Gt, Lt, Float,
-    FiniteSet, Intersection, imageset, I, true, false, ProductSet, E
+    FiniteSet, Intersection, imageset, I, true, false, ProductSet, E, sin
 )
 from sympy.mpmath import mpi
 
@@ -725,3 +725,32 @@ def test_closure():
 
 def test_interior():
     assert Interval(0, 1, False, True).interior == Interval(0, 1, True, True)
+
+
+def test_imageset_var_assumptions():
+    from sympy.abc import n
+    s1 = imageset(Lambda(n, sin(n)), S.Reals)
+    s2 = imageset(lambda n: sin(n), S.Reals)
+    s3 = imageset(n, sin(n), S.Reals)
+
+    s4 = imageset(Lambda(n, sin(n)), S.Integers)
+
+    s5 = imageset(Lambda(n, sin(n)), S.Naturals)
+
+    s6 = imageset(Lambda(n, sin(n)), S.Naturals0)
+
+    s7 = imageset(Lambda(n, sin(n)), Interval(-10, oo))
+
+    assert s1.lamda.variables[0].is_real is True
+    assert s2.lamda.variables[0].is_real is True
+    assert s3.lamda.variables[0].is_real is True
+
+    assert s4.lamda.variables[0].is_integer is True
+
+    assert s5.lamda.variables[0].is_integer is True \
+            and s5.lamda.variables[0].is_positive is True
+
+    assert s6.lamda.variables[0].is_integer is True \
+            and s6.lamda.variables[0].is_nonnegative is True
+
+    assert s7.lamda.variables[0].is_real is True


### PR DESCRIPTION
This came up while working `ImageSet(...).intersect(S.Reals).
The assumption on the lambda variable in`ImageSet` is complex by default which causes inconvenience like 

```
In[]: (n + I*n).as_imag_real()
Out[]:(re(n) - im(n), re(n) + im(n))
```

It is better if the assumptions on the variable is decided by the base_set of the ImageSet.
