### PR TITLE
compare frozensets as Basic objects (re-addresses #958)

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -182,10 +182,10 @@ class Basic(with_metaclass(ManagedProperties)):
         if c:
             return c
         for l, r in zip(st, ot):
+            l = Basic(*l) if isinstance(l, frozenset) else l
+            r = Basic(*r) if isinstance(r, frozenset) else r
             if isinstance(l, Basic):
                 c = l.compare(r)
-            elif isinstance(l, frozenset):
-                c = 0
             else:
                 c = (l > r) - (l < r)
             if c:

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from sympy import (Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
+from sympy import (Basic, Symbol, sin, cos, exp, sqrt, Rational, Float, re, pi,
         sympify, Add, Mul, Pow, Mod, I, log, S, Max, Or, symbols, oo, Integer,
         sign, im, nan
 )
@@ -1492,7 +1492,10 @@ def test_issue_6040():
 
 
 def test_issue_6082():
-    assert Max(x, 1) * Max(x, 2) == Max(x, 1) * Max(x, 2)
+    assert Basic.compare(Max(x, 1), Max(x, 2)) == -1
+    assert Basic.compare(Max(x, 2), Max(x, 1)) == 1
+    assert Basic.compare(Max(x, 1), Max(x, 1)) == 0
+    assert Basic.compare(Max(1, x), frozenset((1, x))) == -1
 
 
 def test_issue_6077():


### PR DESCRIPTION
There is instability of argument ordering when frozensets are involved, so Min(1,x)*Min(2,x) 
will have args sorted in an arbitrary order (which is something that we try to avoid).

It was wrongly being assumed (with #958) that if a frozenset was encountered that
it was equal to the other frozen set. This caused arbitrary sorting
of args like Min(1,x) and Min(2,x) since they are both the same function
with a single frozenset argument...but the (1,x) should be less than the
(2,x). So rather than returning 0, the args of the frozenset(s) are
compared.
